### PR TITLE
Loosen transformers version dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "triton>=3.0.0",
     "packaging",
     "tyro",
-    "transformers<4.45.0",
+    "transformers>=4.44.2",
     "datasets>=2.16.0",
     "sentencepiece>=0.2.0",
     "tqdm",


### PR DESCRIPTION
Hi thanks for Unsloth (and unsloth-zoo)!

It would be great if the latest transformers package could be allowed (e.g. vllm only supports that, and I hope my code able to use both vllm + unsloth).

It seems that unsloth uses `"transformers>=4.44.2"` as dependency, thus I sync the zoo to be also like this. Hope this do not break anything!