### PR TITLE
Fix longest common substring implementation

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -29,14 +29,11 @@ def _longest_common_sublist(lists):
     List[int]: The longest common sublist. If multiple sublists have the same maximum length,
                one of them is returned. If there's no common sublist, an empty list is returned.
     """
-
-    if not lists:
-        return []
+    if not lists: return []
 
     # Find the minimum length among all lists
     min_len = min(len(lst) for lst in lists)
-    if min_len == 0:
-        return []
+    if min_len == 0: return []
 
     def has_common_sublist(length):
         """
@@ -51,6 +48,7 @@ def _longest_common_sublist(lists):
         for i in range(len(first) - length + 1):
             sub = tuple(first[i:i + length])
             common.add(sub)
+        pass
 
         # Iterate over the remaining lists and retain only the common sublists
         for lst in lists[1:]:
@@ -62,9 +60,11 @@ def _longest_common_sublist(lists):
             common = current
             if not common:
                 return False, []
+        pass
         
         # If common is not empty, return one of the common sublists
         return True, list(common.pop())
+    pass
 
     left, right = 1, min_len
     result = []
@@ -77,8 +77,11 @@ def _longest_common_sublist(lists):
             left = mid + 1    # Try to find a longer sublist
         else:
             right = mid - 1   # Try with a shorter length
+    pass
 
     return result
+pass
+
 
 def _find_common_token_ids(component, tokenizer):
     """
@@ -95,7 +98,7 @@ def _find_common_token_ids(component, tokenizer):
     if   component.startswith (" "): left_text = " "
     elif component.startswith("\n"): left_text = "\n"
     stripped = component.strip()
-
+    
     # Add current pieces and also newlines
     all_input_ids = []
     for left in range(3):
@@ -244,13 +247,3 @@ def train_on_responses_only(
         trainer.eval_dataset  = trainer.eval_dataset .map(_train_on_responses_only, batched = True)
     return trainer
 pass
-
-if __name__ == '__main__':
-    # test least common sublist implementation
-    lists_of_ints = [
-        [1, 2, 3, 4, 5, 6],
-        [0, 1, 2, 3, 4, 7],
-        [11, 12, 1, 2, 3, 4, 8, 9]
-    ]
-    assert _longest_common_sublist(lists_of_ints) == [1, 2, 3, 4]
-    print("test passed")

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1,4 +1,6 @@
 # Unsloth Zoo
+# Copyright (C) 2024-present the Unsloth AI team. All rights reserved.
+
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
 # by the Free Software Foundation, either version 3 of the License, or

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -18,6 +18,26 @@ __all__ = [
     "train_on_responses_only",
 ]
 
+# From https://www.geeksforgeeks.org/longest-common-substring-array-strings/
+# Longest Common Substring in an Array of Strings
+def _old_longest_common_substring(arr):
+    n = len(arr)
+    s = arr[0]
+    l = len(s)
+    res = ""
+    for i in range(l):
+        for j in range(i + 1, l + 1):
+            stem = s[i:j]
+            k = 1
+            for k in range(1, n):
+                if stem not in arr[k]:
+                    break
+            if (k + 1 == n and len(res) < len(stem)):
+                res = stem
+    return res
+pass
+
+
 def _longest_common_sublist(lists):
     """
     Finds the longest common sublist among multiple lists.
@@ -112,8 +132,13 @@ def _find_common_token_ids(component, tokenizer):
             all_input_ids.append(x)
         pass
     pass
-    substring = _longest_common_sublist([x + [0] for x in all_input_ids])
 
+    # Old longest common substring is replaced with actual longest common list of numbers
+    # substring = _old_longest_common_substring([str(x + [0]) for x in all_input_ids])
+    # substring = substring.split(", ")[:-1]
+    # substring = [int(x) for x in substring if x.isdigit()]
+    substring = _longest_common_sublist([x + [0] for x in all_input_ids])
+    
     # Also get rest of tokenized string
     original = tokenizer(component, add_special_tokens = False).input_ids
     # Get optional left and right


### PR DESCRIPTION
This should fix https://github.com/unslothai/unsloth/issues/1015

The issue was that the existing LCS implementation would find a leading comma, leading it to call `int('')`.
Since I was performing this fix anyways, I took the liberty of implementing it a bit cleaner. Instead of finding the LCS of a string repr of a list of tokens, we just find the least common sublist of tokens directly. The string/int conversions are not necessary anymore.

I also added a very simple sanity test at the bottom of the file.