### PR TITLE
Fix: Using IterableDataset crashes training

### DIFF
--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -19,6 +19,7 @@ from transformers.models.llama.modeling_llama import logger
 import gc
 import numpy as np
 import itertools
+import datasets
 
 __all__ = [
 	"mean_of_trained_tokens",
@@ -233,6 +234,11 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
     if chat_template is not None:
         if_bad_first = any(x in chat_template for x in actual_bad_tokens)
     pass
+
+    if isinstance(train_dataset, datasets.IterableDataset):
+        # Skip the check, since the code below assumes
+        # an indexable dataset
+        return
 
     # Check the first 250, last 250 input_ids
     size_dataset = len(train_dataset)

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -16,6 +16,7 @@
 
 import torch
 import math
+import datasets
 from transformers import set_seed as transformers_set_seed
 from transformers import get_scheduler as transformers_get_scheduler
 from transformers import Trainer
@@ -37,6 +38,11 @@ def fix_zero_training_loss(model, tokenizer, train_dataset):
     Sometimes the labels get masked by all -100s, causing the loss
     to be 0. We check for this!
     """
+    if isinstance(train_dataset, datasets.IterableDataset):
+        # Skip the check since the code below assumes
+        # an indexable dataset
+        return
+    
     if len(train_dataset) == 0: return
 
     row = train_dataset[0]


### PR DESCRIPTION
When using a dataset that inherits from IterableDataset, it causes training runs to crash with the following error:
```
│ /opt/conda/lib/python3.10/site-packages/unsloth_zoo/tokenizer_utils.py:238 in                    │
│ fix_untrained_tokens                                                                             │
│                                                                                                  │
│   235 │   pass                                                                                   │
│   236 │                                                                                          │
│   237 │   # Check the first 250, last 250 input_ids                                              │
│ ❱ 238 │   size_dataset = len(train_dataset)                                                      │
│   239 │   size = min(size_dataset, 250)                                                          │
│   240 │   for j in range(size):                                                                  │
│   241 │   │   input_ids = train_dataset[j]
TypeError: object of type 'IterableDataset' has no len()
```

The code in `tokenizer_utils` assumes that users will always use an indexable dataset causing the error. I've added simple checks for instances of IterableDataset. Although it is a half measure, since those checks kinda disable parts of `tokenizer_utils` functionality (when encountering an IterableDatset). 

Ideally, functions in `tokenizer_utils` should not assume anything about the datasets and do everything in the most generic way possible offering maximum compatibility with existing `transformers`/`datasets` tools.