### PR TITLE
Add `formatting_func` Support to Enable Lazy Data Loading in `UnslothVisionDataCollator`

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -241,7 +241,7 @@ pass
 class UnslothVisionDataCollator:
     __slots__ = "padding_token_ids", "dtype", "ignore_index", "processor", "formatting_func"
 
-    def __init__(self, model, processor, formatting_func=None, ignore_index = -100):
+    def __init__(self, model, processor, formatting_func = None, ignore_index = -100):
         self.padding_token_ids = get_padding_tokens_ids(processor)
         self.dtype = _get_dtype(
             model.config.torch_dtype \

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -239,9 +239,9 @@ pass
 
 
 class UnslothVisionDataCollator:
-    __slots__ = "padding_token_ids", "dtype", "ignore_index", "processor"
+    __slots__ = "padding_token_ids", "dtype", "ignore_index", "processor", "formatting_func"
 
-    def __init__(self, model, processor, ignore_index = -100):
+    def __init__(self, model, processor, formatting_func=None, ignore_index = -100):
         self.padding_token_ids = get_padding_tokens_ids(processor)
         self.dtype = _get_dtype(
             model.config.torch_dtype \
@@ -250,6 +250,7 @@ class UnslothVisionDataCollator:
         )
         self.ignore_index = ignore_index
         self.processor = processor
+        self.formatting_func = formatting_func
         return
     pass
 
@@ -258,7 +259,11 @@ class UnslothVisionDataCollator:
         # The issue is batch = self.processor( forces tensors to be returned and not None.
         texts  = []
         images = []
-        for example in examples:
+        
+        if self.formatting_func is not None:
+            examples = [self.formatting_func(example) for example in examples]
+        
+        for example in examples:    
             messages = example["messages"]
             message = self.processor.apply_chat_template(
                 messages,


### PR DESCRIPTION
### **Overview**

This PR introduces a new `formatting_func` parameter to the `UnslothVisionDataCollator`, allowing for dynamic formatting of examples during data collation. This enhancement addresses a critical memory issue caused by preloading and pre-formatting large datasets (e.g., image-heavy datasets) into memory before training. 

By adopting lazy formatting, **this change ensures examples are processed only when needed, significantly reducing peak memory usage during training**. Furthermore, it eliminates **the time previously required for preprocessing the entire dataset into a formatted list before training**.



---

### **Motivation**

Previously, preprocessing large datasets required iterating through the entire dataset and saving formatted examples into memory or files, which often led to memory exhaustion when handling datasets with high-resolution images. 

For instance:

```python
formatted_data = [convert_to_conversation(sample, ...) for sample in dataset]
```

<img width="517" alt="image" src="https://github.com/user-attachments/assets/80585355-e2ee-400f-bb43-d93e982ac0d8">


would load and hold all images and their associated metadata in memory at once. This was problematic, especially when working with constrained environments or large-scale datasets.

### **Solution**

By introducing a `formatting_func` in the `UnslothVisionDataCollator`, the examples are now lazily formatted as part of the `__call__` method during collation, minimizing memory overhead. This approach seamlessly integrates into the training pipeline without requiring significant changes to dataset loading or preprocessing workflows.

Here is an example of how the new functionality is used:

```python
def convert_to_conversation(sample, instruction, min_pixels, max_pixels):
    ground_truth_dict = json.loads(sample["ground_truth"])
    ground_truth = ground_truth_dict["gt_parse"]["text_sequence"]
    conversation = [
        {"role": "user",
         "content": [
             {"type": "text", "text": instruction},
             {"type": "image", "image": sample["image"],
              "min_pixels": min_pixels,
              "max_pixels": max_pixels,
              }]
         },
        {"role": "assistant",
         "content": [
             {"type": "text", "text": '{"text_sequence": "' + ground_truth + '"}'}]
         },
    ]
    return {"messages": conversation}

formatting_func = partial(
    convert_to_conversation,
    instruction="Extract text from the image and return as JSON.",
    min_pixels=MIN_PIXELS,
    max_pixels=MAX_PIXELS
)

data_collator = UnslothVisionDataCollator(
    model=model,
    processor=processor,
    formatting_func=formatting_func
)
```

With this setup, `convert_to_conversation` is applied lazily during data collation, significantly improving memory efficiency.

---

### **Key Changes**
1. **New `formatting_func` Parameter**: Optional parameter added to `UnslothVisionDataCollator`, enabling dynamic formatting of examples.
2. **Lazy Loading**: Instead of preloading processed data into memory, examples are formatted on-the-fly during collation.
3. **Backward Compatibility**: Existing workflows remain unaffected as `formatting_func` is optional. Without it, the collation process proceeds as before.

---

### **Performance Benefits**
- **Reduced Memory Overhead**: Lazy formatting eliminates the need to preload the dataset into memory, preventing out-of-memory errors in memory-constrained environments.
- **Improved Scalability**: Allows efficient handling of large-scale datasets with high-resolution images.
- **Enhanced Flexibility**: Users can define custom formatting logic without altering the dataset itself.

---

### **Testing and Validation**
- Verified lazy formatting correctness by comparing the output of pre-formatted and lazily formatted batches.
- Tested with the `naver-clova-ix/synthdog-ko` dataset for both training and validation splits.
- No regressions observed in training speed or output quality.


```python
import os
os.environ["HF_HOME"] = "/workspace/"

from unsloth import FastVisionModel
from qwen_vl_utils import process_vision_info

from transformers import TextStreamer
from datasets import load_dataset
import json
from tqdm.auto import tqdm
from multiprocessing import Pool

from functools import partial


# Load datasets
train_dataset = load_dataset("naver-clova-ix/synthdog-ko", split="train")
NUM_TRAIN_SAMPLES = 50000
train_dataset = train_dataset.shuffle(seed=42).select(range(NUM_TRAIN_SAMPLES))

validation_dataset = load_dataset("naver-clova-ix/synthdog-ko", split="validation")

# Constants
MIN_PIXELS = 4 * 28 * 28
MAX_PIXELS = 960 * 28 * 28
INSTRUCTION = """
이미지에 포함된 문자를 추출하세요. 출력은 JSON 형식으로 제공하며, 키는 "text_sequence"이고 값은 추출된 문자입니다.\n
예시: {"text_sequence": 인식한 문자}
"""

def convert_to_conversation(sample, instruction, min_pixels, max_pixels):
    ground_truth_dict = json.loads(sample["ground_truth"])
    ground_truth = ground_truth_dict["gt_parse"]["text_sequence"]
    conversation = [
        {"role": "user",
         "content": [
             {"type": "text", "text": instruction},
             {"type": "image", "image": sample["image"],
              "min_pixels": min_pixels,
              "max_pixels": max_pixels,
              }]
         },
        {"role": "assistant",
         "content": [
             {"type": "text", "text": '{"text_sequence": "' + ground_truth + '"}'}]
         },
    ]
    return {"messages": conversation}

formatting_func = partial(convert_to_conversation, instruction=INSTRUCTION, min_pixels=MIN_PIXELS, max_pixels=MAX_PIXELS)

# Model setup
model, tokenizer = FastVisionModel.from_pretrained(
    "unsloth/Qwen2-VL-7B-Instruct",
    load_in_4bit=False,
    use_gradient_checkpointing="unsloth",
)

model = FastVisionModel.get_peft_model(
    model,
    finetune_vision_layers=True,
    finetune_language_layers=True,
    finetune_attention_modules=True,
    finetune_mlp_modules=True,
    r=64,
    lora_alpha=64,
    lora_dropout=0,
    bias="none",
    random_state=3407,
    use_rslora=False,
    loftq_config=None,
)

FastVisionModel.for_inference(model)

def run_inference(dataset, formatting_func, num_samples, filename, filemode, mode):
    with open(filename, filemode, encoding="utf-8") as f:
        f.write(f"{mode} training\n")
        for i in range(min(num_samples, len(dataset))):
            data = dataset[i]
            formatted_data = formatting_func(data)
            messages = formatted_data["messages"]
            prompt_without_ground_truth = [messages[0]]
            ground_truth = messages[1]['content'][0]['text']

            text = tokenizer.apply_chat_template(prompt_without_ground_truth, tokenize=False, add_generation_prompt=True)
            image_inputs, video_inputs = process_vision_info(prompt_without_ground_truth)

            inputs = tokenizer(
                text=[text],
                images=image_inputs,
                videos=video_inputs,
                padding=True,
                return_tensors="pt",
            )

            inputs = inputs.to("cuda")

            text_streamer = TextStreamer(tokenizer, skip_prompt=True)
            generated_ids = model.generate(**inputs, streamer=text_streamer, max_new_tokens=1024, use_cache=True)
            generated_ids_trimmed = [
                out_ids[len(in_ids):] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
            ]
            output_text = tokenizer.batch_decode(
                generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
            )

            f.write(f'label: {ground_truth}\noutput: {output_text}\n')
            f.write('-----------------------------------\n')
            f.flush()

run_inference(validation_dataset, formatting_func, num_samples=10, filename="results_train.txt", filemode="w", mode="before")

from unsloth import is_bf16_supported
from unsloth.trainer import UnslothVisionDataCollator
from trl import SFTTrainer, SFTConfig

FastVisionModel.for_training(model)

trainer = SFTTrainer(
    model=model,
    tokenizer=tokenizer,
    data_collator=UnslothVisionDataCollator(model, tokenizer, formatting_func),
    train_dataset=train_dataset,
    args=SFTConfig(
        per_device_train_batch_size=1,
        gradient_accumulation_steps=16,
        warmup_steps=5,
        num_train_epochs=3,
        learning_rate=2e-4,
        fp16=not is_bf16_supported(),
        bf16=is_bf16_supported(),
        logging_steps=1,
        optim="adamw_8bit",
        weight_decay=0.01,
        lr_scheduler_type="linear",
        seed=3407,
        output_dir="outputs",
        report_to="none",
        remove_unused_columns=False,
        dataset_text_field="",
        dataset_kwargs={"skip_prepare_dataset": True},
        dataset_num_proc=4,
        max_seq_length=1024,
    ),
)

trainer_stats = trainer.train()

model.save_pretrained("synthdog-koqwen2-vl-7b-instruct-lora-model")
tokenizer.save_pretrained("synthdog-koqwen2-vl-7b-instruct-lora-model")

FastVisionModel.for_inference(model)

run_inference(validation_dataset, formatting_func, num_samples=10, filename="results_train.txt", filemode="a", mode="after")

```

---

### **Conclusion**

This PR introduces a simple yet powerful enhancement to `UnslothVisionDataCollator`, enabling efficient and flexible training pipelines. By leveraging lazy formatting, users can now process large datasets with minimal memory overhead, paving the way for smoother training workflows.

---

Would love to hear your feedback! 🎉