### PR TITLE
Fix/dpo

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -356,7 +356,7 @@ _cross_entropy_code = """
 from torch.nn import CrossEntropyLoss
 
 @torch.compile(fullgraph = True, dynamic = True, options = torch_compile_options)
-def uncompiled_cross_entropy_loss(self, hidden_states,):
+def uncompiled_cross_entropy_loss(self, hidden_states, labels):
     logits = self.lm_head(hidden_states)
     logits = logits.float()
     # Shift so that tokens < n predict n
@@ -417,7 +417,7 @@ loss = loss_fct(shift_logits, shift_labels)
 """
 
 cross_entropy_replacement_1 = """
-if not self.training and labels is None:
+if labels is None: 
     logits = self.lm_head(hidden_states)
 elif NOT_RETURN_LOGITS and labels is not None:
     n_items = loss_kwargs.get("num_items_in_batch", None) or loss_kwargs.get("n_items", None)
@@ -429,7 +429,7 @@ elif NOT_RETURN_LOGITS and labels is not None:
         logit_softcapping  = getattr(self.config, "final_logit_softcapping", 0),
     )
 else:
-    loss, logits = uncompiled_cross_entropy_loss(self, hidden_states)
+    loss, logits = uncompiled_cross_entropy_loss(self, hidden_states, labels)
 """
 
 cross_entropy_find_2 = """

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -439,7 +439,7 @@ if labels is not None:$loss = self.loss_function(logits=logits, labels=labels, v
 """
 
 cross_entropy_replacement_2 = """
-if not self.training and labels is None:
+if self.training and labels is None:
     logits = self.lm_head(hidden_states)
 elif NOT_RETURN_LOGITS and self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None:
     n_items = loss_kwargs.get("num_items_in_batch", None) or loss_kwargs.get("n_items", None)
@@ -462,7 +462,7 @@ if labels is not None:$loss = self.loss_function(logits, labels, self.vocab_size
 """
 
 cross_entropy_replacement_3 = """
-if not self.training and labels is None:
+if labels is None:
     logits = self.lm_head(hidden_states)
 elif NOT_RETURN_LOGITS and self.training and self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None:
     n_items = loss_kwargs.get("num_items_in_batch", None) or loss_kwargs.get("n_items", None)


### PR DESCRIPTION
This enabling DPO training for VLM models.

`uncompiled_cross_entropy_loss` function actually missing `labels` arguments. 

on `DPO`, I think what's happening is that the status is actually `training` but there's no labels. So I removed that `self.training` part.

