### PR TITLE
Add imports for base64 and BytesIO in vision_utils.py

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -49,6 +49,8 @@ IMAGE_TOKENS = [
 
 import torch
 from PIL import Image
+import base64
+from io import BytesIO
 import math
 import requests
 from typing import Union, Tuple


### PR DESCRIPTION
at function `fetch_image` you guys code support read image from bytes, base64 but not import lib to load images.
```python
    elif image.startswith("data:image"):
        if "base64," in image:
            _, base64_data = image.split("base64,", 1)
            data = base64.b64decode(base64_data)
            image_obj = Image.open(BytesIO(data))
```