### PR TITLE
Add error handling for forward method in patch_gradient_accumulation

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -788,8 +788,11 @@ def patch_gradient_accumulation(modeling_file, module):
 
     functions = dir(modeling_file)
     module = eval(f"modeling_file.{module}")
-    forward = module.forward
-    source = inspect.getsource(forward)
+    try: 
+        forward = module.forward
+        source = inspect.getsource(forward)
+    except: 
+        return None
     has_kwargs = tuple(inspect.signature(forward).parameters.values())[-1].kind == inspect._VAR_KEYWORD
     if has_kwargs: return None
 


### PR DESCRIPTION
User reported an error of :

```
  File "/mnt/c/code/vllm/pyenv/lib/python3.10/site-packages/unsloth_zoo/compiler.py", line 791, in patch_gradient_accumulation
    forward = module.forward
AttributeError: type object 'Qwen2VLCausalLMOutputWithPast' has no attribute 'forward'
```

`other_classes` in `patch_gradient_accumulation` (for Qwen) somehow includes `Qwen2VLCausalLMOutputWithPast` which is not supposed to be there since it doesn't have `forward` method

```
other_classes = ['Qwen2VLCausalLMOutputWithPast', 'Qwen2VLPreTrainedModel', 'Qwen2VisionTransformerPretrainedModel', 'Qwen2VLModel', 'Qwen2VLForConditionalGeneration']
```

by skipping class that has no `forward` method. This run smoothly again on `Qwen2VL`