### PR TITLE
quick fix when output requires grad

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -188,7 +188,15 @@ def requires_grad_for_gradient_checkpointing(model):
 
     # Add post forward hook
     def requires_grad_post_hook(module, input, output):
-        output.requires_grad_(True)
+        type_output = type(output)
+        if type_output is torch.Tensor:
+            output.requires_grad_(True)
+        else:
+            try:
+                # Output in huggingface generally a dataclass with loss, try to add to that
+                output.loss.requires_grad_(True)
+            except Exception as _:
+                raise RuntimeError("Unsloth: Failed to make output require gradients!")
     pass
 
     def requires_grad_pre_hook(module, input):
@@ -198,6 +206,8 @@ def requires_grad_for_gradient_checkpointing(model):
         elif type_input is tuple or type_input is list:
             if len(input) == 0:
                 raise RuntimeError("Unsloth: Failed to make input require gradients!")
+                # print(f"  WARNING: Empty list input to {module.__class__.__name__}!") # 
+                # return
             input[0].requires_grad_(True)
         else:
             raise RuntimeError("Unsloth: Failed to make input require gradients!")
@@ -206,7 +216,8 @@ def requires_grad_for_gradient_checkpointing(model):
     # Find 1st ever item which requires grad
     param = None
     for name, param in model.named_parameters():
-        if param.requires_grad: break
+        if param.requires_grad: 
+            break
     if param is None: return
 
     name = re.sub("\.([\d]{1,})\.", r"[\1].", name)

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -216,8 +216,7 @@ def requires_grad_for_gradient_checkpointing(model):
     # Find 1st ever item which requires grad
     param = None
     for name, param in model.named_parameters():
-        if param.requires_grad: 
-            break
+        if param.requires_grad: break
     if param is None: return
 
     name = re.sub("\.([\d]{1,})\.", r"[\1].", name)


### PR DESCRIPTION
When doing finetuning on Qwen2.5 VL (not Qwen2 VL, Qwen2 VL is fine), we got an error that says `Qwen2_5_VLCausalLMOutputWithPast` has no "requires_grad_" attribute` on the 

This is because the output is the dataclass. What we might want to have grad flowing is the `loss` and the `logits` instead. 

Again I am not sure this `requires_grad_for_gradient_checkpointing` do. It's still hard to understand of why we go from end layer and try to find the parent class until we finally found the module that calls itself (by `self.{name_itself}`)? I assume it's because probably this is the layer that's wrapping all of the transformers block? Therefore by putting `requires_grad` on the inputs (or the outputs), this means all of the inputs and outputs of following layers will have gradients, which makes calculation more correct? The choice of which layer you put the `requires_grad=True` stills very vague to me therefore I am worried this might harmful the training. Because when I checked, the `loss` tensor here already has `requires_grad=True` anyway which I assume you actually want something else to be the first checkpointer.

Here's the result of small training:

![image](https://github.com/user-attachments/assets/c6b96c86-3236-4ef8-aa7e-671709b5a4f2)

By the way, there's a little comment on the post hook because there's an error for Llava which I'll make an issue real quick (I haven't found the solution yet)