### PR TITLE
Fix CUDA_VISIBLE_DEVICES with vllm

### DIFF
--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -947,10 +947,7 @@ def load_vllm(
     )
 
     # Get device as well
-    device = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
-    if not "," in device: device = device + ","
-    device = device.split(",")[0]
-    device = f"cuda:{device}"
+    device = "cuda:0"
 
     engine_args = dict(
         model                  = model_name,


### PR DESCRIPTION
Before (with CUDA_VISIBLE_DEVICES set to 1, with this notebook: https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Llama3.1_(8B)-GRPO.ipynb):
```
INFO 02-18 10:38:23 model_runner.py:1110] Starting to load model unsloth/meta-llama-3.1-8b-instruct-unsloth-bnb-4bit...
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/unsloth_zoo/vllm_utils.py", line 993, in load_vllm
[rank0]:     llm = LLM(**engine_args)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/utils.py", line 1051, in inner
[rank0]:     return fn(*args, **kwargs)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/entrypoints/llm.py", line 242, in __init__
[rank0]:     self.llm_engine = self.engine_class.from_engine_args(
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 484, in from_engine_args
[rank0]:     engine = cls(
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 273, in __init__
[rank0]:     self.model_executor = executor_class(vllm_config=vllm_config, )
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/executor/executor_base.py", line 51, in __init__
[rank0]:     self._init_executor()
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/executor/uniproc_executor.py", line 42, in _init_executor
[rank0]:     self.collective_rpc("load_model")
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/executor/uniproc_executor.py", line 51, in collective_rpc
[rank0]:     answer = run_method(self.driver_worker, method, args, kwargs)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/utils.py", line 2220, in run_method
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/worker/worker.py", line 183, in load_model
[rank0]:     self.model_runner.load_model()
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 1112, in load_model
[rank0]:     self.model = get_model(vllm_config=self.vllm_config)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/model_executor/model_loader/__init__.py", line 14, in get_model
[rank0]:     return loader.load_model(vllm_config=vllm_config)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/model_executor/model_loader/loader.py", line 1223, in load_model
[rank0]:     model = _initialize_model(vllm_config=vllm_config)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/model_executor/model_loader/loader.py", line 125, in _initialize_model
[rank0]:     return model_class(vllm_config=vllm_config, prefix=prefix)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 490, in __init__
[rank0]:     self.model = self._init_model(vllm_config=vllm_config,
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 527, in _init_model
[rank0]:     return LlamaModel(vllm_config=vllm_config, prefix=prefix)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/compilation/decorators.py", line 151, in __init__
[rank0]:     old_init(self, vllm_config=vllm_config, prefix=prefix, **kwargs)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 315, in __init__
[rank0]:     self.embed_tokens = VocabParallelEmbedding(
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/model_executor/layers/vocab_parallel_embedding.py", line 263, in __init__
[rank0]:     self.linear_method.create_weights(self,
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/vllm/model_executor/layers/vocab_parallel_embedding.py", line 31, in create_weights
[rank0]:     weight = Parameter(torch.empty(sum(output_partition_sizes),
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/torch/utils/_device.py", line 106, in __torch_function__
[rank0]:     return func(*args, **kwargs)
[rank0]: RuntimeError: CUDA error: invalid device ordinal
[rank0]: CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
[rank0]: For debugging consider passing CUDA_LAUNCH_BLOCKING=1
[rank0]: Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.


[rank0]: During handling of the above exception, another exception occurred:

[rank0]: Traceback (most recent call last):
[rank0]:   File "/home_dir/unsloth/Llama3_1_(8B)_GRPO.py", line 54, in <module>
[rank0]:     model, tokenizer = FastLanguageModel.from_pretrained(
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/unsloth/models/loader.py", line 292, in from_pretrained
[rank0]:     model, tokenizer = dispatch_model.from_pretrained(
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/unsloth/models/llama.py", line 1810, in from_pretrained
[rank0]:     llm = load_vllm(**load_vllm_kwargs)
[rank0]:   File "/home_dir/miniconda3/envs/unsloth/lib/python3.10/site-packages/unsloth_zoo/vllm_utils.py", line 1015, in load_vllm
[rank0]:     raise RuntimeError(error)
[rank0]: RuntimeError: CUDA error: invalid device ordinal
[rank0]: CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
[rank0]: For debugging consider passing CUDA_LAUNCH_BLOCKING=1
[rank0]: Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.

[rank0]:[W218 10:38:25.903233945 ProcessGroupNCCL.cpp:1250] Warning: WARNING: process group has NOT been destroyed before we destruct ProcessGroupNCCL. On normal program exit, the application should call destroy_process_group to ensure that any pending NCCL operations have finished in this process. In rare cases this process can exit before this point and block the progress of another member of the process group. This constraint has always been present,  but this warning has only been added since PyTorch 2.4 (function operator())
```

After: working correctly on GPU 1.

Fixes #46 