### PR TITLE
Support `image_url` with the `url` field

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -114,11 +114,15 @@ def smart_resize(
 pass
 
 
-def fetch_image(ele: dict[Union[Tuple[str, str], Image.Image]], size_factor: int = IMAGE_FACTOR) -> Image.Image:
+def fetch_image(
+    ele: Dict[str, Union[str, Dict[str, str], Image.Image, int]], size_factor: int = IMAGE_FACTOR
+) -> Image.Image:
     if "image" in ele:
         image = ele["image"]
     else:
         image = ele["image_url"]
+        if isinstance(image, dict) and "url" in image:
+            image = image["url"]
     image_obj = None
     if isinstance(image, Image.Image):
         image_obj = image


### PR DESCRIPTION
First of all, thank you very much for `unsloth` and the utilities in `unsloth-zoo` as they help a lot.

Increasingly, JSONL or otherwise datasets have a `url` field rather than simply providing an `image_url` directly as a URL (probably due to tutorials related to OpenAI API) for vision. This PR minimally changes the type annotation and the code to support when `image_url` is a dictionary rather than a URL string.

I tested this with various data, including WebP images encoded as base64.

Reference tutorial with many such examples: https://platform.openai.com/docs/guides/vision

Thank you for your consideration! If there are any changes that would benefit from adjustment, please let me know, and I can update the PR. Kind regards. - Oguz