### PR TITLE
Add vlm support in `train_on_responses_only`

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -179,8 +179,8 @@ def train_on_responses_only(
     """
     Trains only on responses and not on the instruction by masking out
     the labels with -100 for the instruction part for Language models
-    and by removing the "text" key from message if "role" is "user" for
-    Vision models.
+    and by removing content entries from messages with "role": "user" 
+    and "type": "text" for Vision models.
     """
     # All Unsloth Zoo code licensed under LGPLv3
     

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -188,8 +188,10 @@ def train_on_responses_only(
     # "vision_tower": Llava/Pixtral (Mistral AI) models
     # "vision_model": Llama models
     IS_VISION_MODEL = False
-    for vision_layer_name in ["visual", "vision_tower", "vision_model"]:
-        if hasattr(trainer.model.base_model.model, vision_layer_name):
+    # This approach should support all kind of models irrespecitve 
+    # of depth of vision layer in the parent module.
+    for module_name, _ in trainer.model.named_modules():
+        if any(name in module_name for name in ["visual", "vision_tower", "vision_model"]):
             IS_VISION_MODEL = True
             break
     


### PR DESCRIPTION
Edited `train_on_responses_only` function to support VLMs.

Test Colab: https://colab.research.google.com/drive/18PkC1dYETTdbGzBj6GwUW5cv3T3NmGYf?usp=sharing

Main changes:
- Vision model detection by checking the following VLM-specific keywards in names of `trainer.model.named_modules()`
    - `visual`: Qwen2-VL models
    - `vision_tower`: Llava/Pixtral (Mistral AI) models
    - `vision_model`: Llama models
- `trainer.train_dataset` is a list of messages. Remove a content entry if "role" is "user" and "type" is "text".

Input Example:
```py
{'messages': [{'role': 'user',
   'content': [{'type': 'text',
     'text': 'Write the LaTeX representation for this image.'},
    {'type': 'image',
     'image': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=160x40>}]},
  {'role': 'assistant',
   'content': [{'type': 'text',
     'text': '{ \\frac { N } { M } } \\in { \\bf Z } , { \\frac { M } { P } } \\in { \\bf Z } , { \\frac { P } { Q } } \\in { \\bf Z }'}]}]}
```

Output Example:
```py
{'messages': [{'role': 'user',
   'content': [{'type': 'image',
     'image': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=160x40>}]},
  {'role': 'assistant',
   'content': [{'type': 'text',
     'text': '{ \\frac { N } { M } } \\in { \\bf Z } , { \\frac { M } { P } } \\in { \\bf Z } , { \\frac { P } { Q } } \\in { \\bf Z }'}]}]}
```