### PR TITLE
Fix VLM train_on_response_only

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -331,7 +331,7 @@ def train_on_responses_only(
                 batch = self.collator(examples)
                 batch["labels"] = self.modifier_fn(batch)["labels"]
                 return batch
-        if hasattr(trainer, "data_collator") and hasattr(trainer.data_collator, "collator"):
+        if hasattr(trainer, "data_collator") and not hasattr(trainer.data_collator, "collator"):
             trainer.data_collator = UnslothResponseOnlyCollator(trainer.data_collator, _train_on_responses_only)
         else:
             pass

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -317,7 +317,7 @@ def train_on_responses_only(
             old_collator = trainer.data_collator
             def __call__(self, examples):
                 batch = self.old_collator(examples)
-                batch["labels"] = _train_on_responses_only(batch)
+                batch["labels"] = _train_on_responses_only(batch)["labels"]
                 return batch
         trainer.data_collator = data_collator()
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -301,16 +301,6 @@ def train_on_responses_only(
     from multiprocessing import cpu_count
     num_proc = cpu_count()
 
-    # Edit data collator if not DataCollatorForSeq2Seq or UnslothVisionDataCollator, then apply _train_on_responses_only
-    from transformers import DataCollatorForSeq2Seq
-    from unsloth_zoo.vision_utils import UnslothVisionDataCollator
-    if hasattr(trainer, "data_collator"):
-        if not isinstance(trainer.data_collator, DataCollatorForSeq2Seq) and not hasattr(trainer.data_collator, "tokenizer"):
-            trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer)
-        elif not isinstance(trainer.data_collator, UnslothVisionDataCollator) and hasattr(trainer.data_collator, "tokenizer"):
-            trainer.data_collator = UnslothVisionDataCollator(model = trainer.model, tokenizer = tokenizer)
-        else:
-            pass
 
     if has_tokenized:
         if hasattr(trainer, "train_dataset") and trainer.train_dataset is not None:
@@ -326,8 +316,14 @@ def train_on_responses_only(
                 trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True, num_proc = num_proc)
             pass
         pass
+
+        # Edit data collator as well if not DataCollatorForSeq2Seq
+        from transformers import DataCollatorForSeq2Seq
+        if hasattr(trainer, "data_collator") and \
+            not isinstance(trainer.data_collator, DataCollatorForSeq2Seq):
+            trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer)
     else:
-        class CustomDataCollator:
+        class UnslothResponseOnlyCollator:
             def __init__(self, collator, modifier_fn):
                 self.collator = collator
                 self.modifier_fn = modifier_fn
@@ -335,8 +331,8 @@ def train_on_responses_only(
                 batch = self.collator(examples)
                 batch["labels"] = self.modifier_fn(batch)["labels"]
                 return batch
-        if hasattr(trainer, "data_collator") and not isinstance(trainer.data_collator, CustomDataCollator):
-            trainer.data_collator = CustomDataCollator(trainer.data_collator, _train_on_responses_only)
+        if hasattr(trainer, "data_collator") and not isinstance(trainer.data_collator, UnslothResponseOnlyCollator):
+            trainer.data_collator = UnslothResponseOnlyCollator(trainer.data_collator, _train_on_responses_only)
         else:
             pass
     # Check if all labels randomnly got masked to nothing - maybe wrong chat template?

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -182,6 +182,7 @@ def train_on_responses_only(
     """
     # All Unsloth Zoo code licensed under LGPLv3
     tokenizer = trainer.processing_class if hasattr(trainer, "processing_class") else trainer.tokenizer
+    has_tokenized = not trainer.args.dataset_kwargs["skip_prepare_dataset"]
     
     if  not hasattr(tokenizer, "_unsloth_input_part") or \
         not hasattr(tokenizer, "_unsloth_output_part"):
@@ -218,6 +219,8 @@ def train_on_responses_only(
         all_labels = []
 
         for input_ids in input_ids_:
+            if not has_tokenized:
+                input_ids = input_ids.tolist()
             n = len(input_ids)
             labels = [-100] * n
             n_minus_1 = n - 1
@@ -285,26 +288,39 @@ def train_on_responses_only(
             pass
             all_labels.append(labels)
         pass
+        if not has_tokenized:
+            import torch
+            all_labels = torch.tensor(all_labels)
         return { "labels" : all_labels }
     pass
 
-    if hasattr(trainer, "train_dataset") and trainer.train_dataset is not None:
-        trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True)
-    pass
-    
-    if hasattr(trainer, "eval_dataset")  and trainer.eval_dataset  is not None:
-        # Eval datasets could be a dict!
-        if type(trainer.eval_dataset) is dict:
-            for key, value in trainer.eval_dataset.items():
-                trainer.eval_dataset[key] = value.map(_train_on_responses_only, batched = True)
-        else:
-            trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True)
+    if has_tokenized:
+        if hasattr(trainer, "train_dataset") and trainer.train_dataset is not None:
+            trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True)
         pass
-    pass
+        
+        if hasattr(trainer, "eval_dataset")  and trainer.eval_dataset  is not None:
+            # Eval datasets could be a dict!
+            if type(trainer.eval_dataset) is dict:
+                for key, value in trainer.eval_dataset.items():
+                    trainer.eval_dataset[key] = value.map(_train_on_responses_only, batched = True)
+            else:
+                trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True)
+            pass
+        pass
 
-    # Check if all labels randomnly got masked to nothing - maybe wrong chat template?
-    from .training_utils import fix_zero_training_loss
-    fix_zero_training_loss(None, tokenizer, trainer.train_dataset)
+        # Check if all labels randomnly got masked to nothing - maybe wrong chat template?
+        from .training_utils import fix_zero_training_loss
+        fix_zero_training_loss(None, tokenizer, trainer.train_dataset)
+    else:
+        class data_collator:
+            old_collator = trainer.data_collator
+            def __call__(self, examples):
+                batch = self.old_collator(examples)
+                batch["labels"] = _train_on_responses_only(batch)
+                return batch
+        trainer.data_collator = data_collator()
+
     return trainer
 pass
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -182,7 +182,10 @@ def train_on_responses_only(
     """
     # All Unsloth Zoo code licensed under LGPLv3
     tokenizer = trainer.processing_class if hasattr(trainer, "processing_class") else trainer.tokenizer
+    # if input haven't been tokenized by the trainer
     has_tokenized = not trainer.args.dataset_kwargs["skip_prepare_dataset"]
+    # for vlms, get the text tokenizer
+    tokenizer = tokenizer.tokenizer if hasattr(tokenizer, "tokenizer") else tokenizer
     
     if  not hasattr(tokenizer, "_unsloth_input_part") or \
         not hasattr(tokenizer, "_unsloth_output_part"):

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -184,8 +184,6 @@ def train_on_responses_only(
     tokenizer = trainer.processing_class if hasattr(trainer, "processing_class") else trainer.tokenizer
     # if input haven't been tokenized by the trainer
     has_tokenized = not trainer.args.dataset_kwargs["skip_prepare_dataset"]
-    # for vlms, get the text tokenizer
-    tokenizer = tokenizer.tokenizer if hasattr(tokenizer, "tokenizer") else tokenizer
     
     if  not hasattr(tokenizer, "_unsloth_input_part") or \
         not hasattr(tokenizer, "_unsloth_output_part"):
@@ -202,9 +200,12 @@ def train_on_responses_only(
         response_part    = tokenizer._unsloth_output_part
     pass
 
+    # for vlms, get the text tokenizer
+    text_tokenizer = tokenizer.tokenizer if hasattr(tokenizer, "tokenizer") else tokenizer
+
     # Get most common tokens since tokenizers can tokenize stuff differently!
-    Q_must, Q_left, Q_right = _find_common_token_ids(instruction_part, tokenizer)
-    A_must, A_left, A_right = _find_common_token_ids(response_part,    tokenizer)
+    Q_must, Q_left, Q_right = _find_common_token_ids(instruction_part, text_tokenizer)
+    A_must, A_left, A_right = _find_common_token_ids(response_part,    text_tokenizer)
 
     # Store some temporary stuff
     A_first = A_must[0]

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -331,8 +331,12 @@ def train_on_responses_only(
                 batch = self.collator(examples)
                 batch["labels"] = self.modifier_fn(batch)["labels"]
                 return batch
-        if hasattr(trainer, "data_collator") and not hasattr(trainer.data_collator, "collator"):
-            trainer.data_collator = UnslothResponseOnlyCollator(trainer.data_collator, _train_on_responses_only)
+        if hasattr(trainer, "data_collator"):
+            # If `UnslothResponseOnlyCollator` is found, extract internal collator to avoid double wrapping
+            if hasattr(trainer.data_collator, "collator"):
+                trainer.data_collator = UnslothResponseOnlyCollator(trainer.data_collator.collator, _train_on_responses_only)
+            else:
+                trainer.data_collator = UnslothResponseOnlyCollator(trainer.data_collator, _train_on_responses_only)
         else:
             pass
     # Check if all labels randomnly got masked to nothing - maybe wrong chat template?

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -331,7 +331,7 @@ def train_on_responses_only(
                 batch = self.collator(examples)
                 batch["labels"] = self.modifier_fn(batch)["labels"]
                 return batch
-        if hasattr(trainer, "data_collator") and not isinstance(trainer.data_collator, UnslothResponseOnlyCollator):
+        if hasattr(trainer, "data_collator") and hasattr(trainer.data_collator, "collator"):
             trainer.data_collator = UnslothResponseOnlyCollator(trainer.data_collator, _train_on_responses_only)
         else:
             pass


### PR DESCRIPTION
Make `train_on_response_only` compatible with VLM. Fix unslothai/unsloth#1396

In VLM, tokenization occurs within the `data_collator` rather than in `SFTTrainer._prepare_dataset`. To ensure consistency in the `train_on_response_only` interface, I modified the trainer’s `data_collator` to handle label construction.