### PR TITLE
Fix: long import times

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "hf_transfer",
     "cut_cross_entropy",
     "pillow",
-    "appdirs ~= 1.4.4"
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "hf_transfer",
     "cut_cross_entropy",
     "pillow",
+    "appdirs ~= 1.4.4"
 ]
 
 [tool.setuptools.dynamic]

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -33,7 +33,7 @@ import types
 import time
 import logging
 import sys
-import appdirs
+import tempfile
 from .utils import Version, is_main_process
 import triton
 from .peft_utils import get_lora_layer_modules
@@ -64,7 +64,7 @@ global COMBINED_UNSLOTH_NAME
 global UNSLOTH_COMPILE_LOCATION
 global UNSLOTH_CREATED_FUNCTIONS
 COMBINED_UNSLOTH_NAME = "unsloth_compiled_module"
-UNSLOTH_COMPILE_LOCATION = appdirs.user_data_dir("unsloth_compiled_cache")
+UNSLOTH_COMPILE_LOCATION = os.path.join(tempfile.gettempdir(), "unsloth_compiled_cache")
 UNSLOTH_CREATED_FUNCTIONS = []
 
 


### PR DESCRIPTION
## Problem Description

This PR addresses two related issues with Unsloth's module importing mechanism:

1. **Slow/hanging imports when called from entry points**: When importing Unsloth via Python entry points (defined in pyproject.toml), import times can exceed 60 seconds or even hang indefinitely (https://github.com/unslothai/unsloth/issues/1859) due to an improper retry mechanism. This occurs because the module import system fails differently depending on how Python is invoked.

2. **Inconsistent cache locations**: Previously, the `UNSLOTH_COMPILE_LOCATION` was set as a relative path (`"unsloth_compiled_cache"`), which would create different cache directories depending on the working directory where a script was launched.

## Root Cause Analysis

The core issue was in the `create_new_function` method's module loading mechanism:

1. It tried to import modules using `importlib.import_module(UNSLOTH_COMPILE_LOCATION + "." + name)`, but this fails when the directory is not in `sys.path` (common when running through entry points).

2. The fallback mechanism used a `while True` loop that could potentially run indefinitely, with each iteration adding another sleep delay (https://github.com/unslothai/unsloth/issues/1859#issuecomment-2699836525).

## Solution

1. Standardized cache location using `appdirs.user_data_dir()` for consistency across sessions.

2. Fixed module importing by temporarily adding the cache directory to `sys.path`.

3. Eliminated the infinite loop in the fallback mechanism with proper exception handling.

4. Added clearer error messages to simplify troubleshooting.

## Testing

Tested the changes with both direct module invocation (`python -m`) and through entry points, confirming:
- Consistent import times (5-7 seconds) regardless of invocation method
- Consistent cache location across multiple runs and directories