### PR TITLE
Off by 1 masking

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -240,7 +240,7 @@ def train_on_responses_only(
                         else: break
                     pass
                     # assistant_j = j
-                    assistant_k = k
+                    assistant_k = k + 1
 
                     j = assistant_k
                     # Given <assistant>, now find next user


### PR DESCRIPTION
Current implementation appears to bring in the last token of A_right_forward during the copy at line 277.