### PR TITLE
Fix Protobuf<4.0 is deprecated, relax dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "accelerate>=0.34.1",
     "trl>=0.7.9,!=0.9.0,!=0.9.1,!=0.9.2,!=0.9.3,!=0.15.0,<=0.15.2",
     "peft>=0.7.1,!=0.11.0",
-    "protobuf<4.0.0",
+    "protobuf",
     "huggingface_hub",
     "hf_transfer",
     "cut_cross_entropy",


### PR DESCRIPTION
The last release was of [protobuf](https://pypi.org/project/protobuf/) `<4` was version `3.20.3` in Sept 2022.

## Problem

This dependency is not used in the project and causes conflicts in projects using a newer version.

The only reference to `protobuf` is  [here](https://github.com/unslothai/unsloth-zoo/blob/31fce522e291e95c3829dc8cc8ac29e03e6c0580/unsloth_zoo/llama_cpp.py#L284), and does not rely on the pinned version.

## Proposal

Relax the dependency or remove it completely from `pyproject.toml`.
