### PR TITLE
Fix checkpoint and save from local file

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -208,7 +208,8 @@ def requires_grad_for_gradient_checkpointing(model):
                 raise RuntimeError("Unsloth: Failed to make input require gradients!")
                 # print(f"  WARNING: Empty list input to {module.__class__.__name__}!") # 
                 # return
-            input[0].requires_grad_(True)
+            if torch.is_floating_point(input[0]):
+                input[0].requires_grad_(True)
         else:
             raise RuntimeError("Unsloth: Failed to make input require gradients!")
     pass

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -927,8 +927,16 @@ def get_original_model_id(local_path: str):
             
         # Check for _name_or_path that's not a local path
         # When we load using AutoConfig, the _name_or_path changed into the local path instead
-        if "_name_or_path" in config and not os.path.exists(config["_name_or_path"]):
+        if "_name_or_path" in config:
             return config["_name_or_path"]
+        
+    config_path = os.path.join(local_path, "adapter_config.json")
+    if os.path.exists(config_path):
+        with open(config_path, "r") as f:
+            config = json.load(f)
+            
+        if "base_model_name_or_path" in config:
+            return config["base_model_name_or_path"]
     
     return None
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -61,6 +61,7 @@ except:
 pass
 from transformers.modeling_utils import PushToHubMixin
 import json
+import os
 from pathlib import Path
 import tempfile
 from peft import PeftModelForCausalLM
@@ -540,7 +541,13 @@ def merge_and_overwrite_lora(
         model_name = model.config._name_or_path
 
     # Find repository's max shard size and total size of everything
-    file_list = HfFileSystem(token = token).ls(model_name, detail = True)
+    try:
+        file_list = HfFileSystem(token = token).ls(model_name, detail = True)
+    except:
+        original_model_id = get_original_model_id(model_name)
+        model_name = original_model_id
+        file_list = HfFileSystem(token = token).ls(model_name, detail = True)
+
     safetensors_list = []
     max_size_in_bytes = 0
     total_size_in_bytes = 0
@@ -908,6 +915,22 @@ def merge_and_dequantize_lora(
         except: pass
     pass
 pass
+
+def get_original_model_id(local_path: str):
+    import json
+    import os
+    
+    config_path = os.path.join(local_path, "config.json")
+    if os.path.exists(config_path):
+        with open(config_path, "r") as f:
+            config = json.load(f)
+            
+        # Check for _name_or_path that's not a local path
+        # When we load using AutoConfig, the _name_or_path changed into the local path instead
+        if "_name_or_path" in config and not os.path.exists(config["_name_or_path"]):
+            return config["_name_or_path"]
+    
+    return None
 
 # Unsloth Zoo - Utilities for Unsloth
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.


### PR DESCRIPTION
Based on this https://github.com/unslothai/unsloth/issues/2013 . User cannot merge if they load the model from local, this is because `model.config._name_or_path` or `model.peft_config.base_model_name_or_path` will changed into the local path itself even though it's actually pointing to the repo in the huggingface repo.

Therefore, the fix is to manually read the `config.json` or `adapter_config.json` and infer the actual original huggingface repo from there.

Also while debugging this, I found an error when the gradient checkpointing on `Qwen 2 VL 2B`, it tries to put the checkpointing here -> `Unsloth: Making `model.base_model.model.visual` require **gradients**`, but this layer is a LoRA-ed layer, therefore it's an `uint8` datatype and cannot be placed as checkpointing. Which makes training or inference error, therefore I put another safety which sees whether the tensor that we want to put checkpoint is a floating data type or not.

