### PR TITLE
Add support for multiple instruction patterns in train_on_responses_only

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -376,7 +376,7 @@ def train_on_responses_only(
        not isinstance(trainer.data_collator, DataCollatorForSeq2Seq):
         trainer.data_collator = DataCollatorForSeq2Seq(tokenizer=tokenizer)
 
-    from unsloth_zoo.training_utils import fix_zero_training_loss
+    from .training_utils import fix_zero_training_loss
     fix_zero_training_loss(None, tokenizer, trainer.train_dataset)
     return trainer
 pass


### PR DESCRIPTION
This PR enhances the `train_on_responses_only` utility function by allowing the `instruction_part` argument to accept a list of instruction patterns rather than a single string.

### Changes:
- Updated the function signature to accept either a string or a list of strings for the `instruction_part` parameter.
- Implemented logic to compute token patterns separately for each provided instruction pattern.
- Updated the internal matching logic within the helper function to correctly identify and process each instruction pattern.

### Benefits:
- **Flexibility**: Now supports datasets containing various instruction types within the same training run (e.g., tool calls, multiple chat roles).
- **Enhanced use cases:** Particularly beneficial when handling tool calls, system messages, or multiple user roles within the same training dataset.

### Usage Examples:
- For ChatML-style chat templates:
```python
instruction_part = ["\n<|im_start|>user\n", "\n<|im_start|>system\n"]
response_part = "\n<|im_start|>assistant\n"

trainer = train_on_responses_only(
    trainer,
    instruction_part = instruction_part,
    response_part = response_part,
)
```

- For advanced chat templates, like Llama-3.1/3.2/3.3 with tool usage:
```python
instruction_part = [
    "<|start_header_id|>user<|end_header_id|>\n\n",
    "<|start_header_id|>system<|end_header_id|>\n\n",
    "<|start_header_id|>ipython<|end_header_id|>\n\n"
]
response_part = "<|start_header_id|>assistant<|end_header_id|>\n\n"

trainer = train_on_responses_only(
    trainer,
    instruction_part = instruction_part,
    response_part = response_part,
)
```