### PR TITLE
Update vllm_utils.py

### DIFF
--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -556,7 +556,8 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16)
         kwargs["compress_statistics"] = quantization_config["bnb_4bit_use_double_quant"]
         kwargs["quant_type"] = quantization_config["bnb_4bit_quant_type"]
         kwargs["quant_storage"] = _get_dtype(quantization_config["bnb_4bit_quant_storage"])
-    pass
+    else:
+        compute_dtype = dtype
 
     from bitsandbytes.nn.modules import Linear4bit, Params4bit
     from torch.nn.modules import Linear


### PR DESCRIPTION
Line 604 now 606 will error out without this change



```
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  9.22it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  9.21it/s]

INFO 03-15 23:05:47 model_runner.py:1115] Loading model weights took 0.1055 GB
INFO 03-15 23:05:47 punica_selector.py:18] Using PunicaWrapperGPU.
INFO 03-15 23:05:48 worker.py:267] Memory profiling takes 0.64 seconds
INFO 03-15 23:05:48 worker.py:267] the current vLLM instance can use total_gpu_memory (23.51GiB) x gpu_memory_utilization (0.38) = 8.95GiB
INFO 03-15 23:05:48 worker.py:267] model weights take 0.11GiB; non_torch_memory takes 0.11GiB; PyTorch activation peak memory takes 0.75GiB; the rest of the memory reserved for KV Cache is 7.98GiB.
INFO 03-15 23:05:48 executor_base.py:111] # cuda blocks: 46510, # CPU blocks: 29127
INFO 03-15 23:05:48 executor_base.py:116] Maximum concurrency for 288 tokens per request: 2583.89x
INFO 03-15 23:05:50 model_runner.py:1434] Capturing cudagraphs for decoding. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI. If out-of-memory error occurs during cudagraph capture, consider decreasing `gpu_memory_utilization` or switching to eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
Capturing CUDA graph shapes: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 33/33 [00:12<00:00,  2.70it/s]
INFO 03-15 23:06:02 model_runner.py:1562] Graph capturing finished in 12 secs, took 0.88 GiB
INFO 03-15 23:06:02 llm_engine.py:436] init engine (profile, create kv cache, warmup model) took 14.76 seconds
{}
torch.bfloat16
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/enochlev/Documents/School/childs/GRPO_trainer.py", line 55, in <module>
[rank0]:     model, tokenizer = FastLanguageModel.from_pretrained(
[rank0]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/enochlev/.local/share/virtualenvs/unlsoth--v9BSFsR/lib/python3.12/site-packages/unsloth/models/loader.py", line 351, in from_pretrained
[rank0]:     model, tokenizer = dispatch_model.from_pretrained(
[rank0]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/enochlev/.local/share/virtualenvs/unlsoth--v9BSFsR/lib/python3.12/site-packages/unsloth/models/llama.py", line 1825, in from_pretrained
[rank0]:     model = convert_vllm_to_huggingface(quant_state_dict, model_config, dtype)
[rank0]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/enochlev/.local/share/virtualenvs/unlsoth--v9BSFsR/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/enochlev/.local/share/virtualenvs/unlsoth--v9BSFsR/lib/python3.12/site-packages/unsloth_zoo/vllm_utils.py", line 610, in convert_vllm_to_huggingface
[rank0]:     layer = Linear4bit(0, 0, device = "cuda:0", bias = has_bias, compute_dtype = compute_dtype, **kwargs)
[rank0]:                                                                                  ^^^^^^^^^^^^^
[rank0]: UnboundLocalError: cannot access local variable 'compute_dtype' where it is not associated with a value
[rank0]:[W315 23:06:04.564751938 ProcessGroupNCCL.cpp:1250] Warning: WARNING: process group has NOT been destroyed before we destruct ProcessGroupNCCL. On normal program exit, the application should call destroy_process_group to ensure that any pending NCCL operations have finished in this process. In rare cases this process can exit before this point and block the progress of another member of the process group. This constraint has always been present,  but this warning has only been added since PyTorch 2.4 (function operator())
```

However after this change. It now works