### PR TITLE
Updates _unsloth_get_batch_samples to accept a 4th device parameter.

### DIFF
--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -223,7 +223,7 @@ pass
 global ALLOWED_NUM_ITEMS_IN_BATCH
 ALLOWED_NUM_ITEMS_IN_BATCH = dict()
 
-def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None):
+def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None, *args, **kwargs):
     # All Unsloth Zoo code licensed under LGPLv3
     batch_samples = []
     num_items_in_batch = None

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -223,7 +223,7 @@ pass
 global ALLOWED_NUM_ITEMS_IN_BATCH
 ALLOWED_NUM_ITEMS_IN_BATCH = dict()
 
-def _unsloth_get_batch_samples(self, epoch_iterator, num_batches):
+def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None):
     # All Unsloth Zoo code licensed under LGPLv3
     batch_samples = []
     num_items_in_batch = None
@@ -287,11 +287,18 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches):
                     [((x["labels"][..., 1:] != -100) & (x["attention_mask"][..., 1:] != 0))\
                     .sum() for x in batch_samples]
                 )
-            if self.args.average_tokens_across_devices:
-                num_items_in_batch = self.accelerator.gather(num_items_in_batch).sum().item()
-            if torch.is_tensor(num_items_in_batch):
-                num_items_in_batch = num_items_in_batch.item()
-            pass
+            if device is None: # transformers < 4.50.0 path
+                if self.args.average_tokens_across_devices:
+                    num_items_in_batch = self.accelerator.gather(num_items_in_batch).sum().item()
+                if torch.is_tensor(num_items_in_batch):
+                    num_items_in_batch = num_items_in_batch.item()
+                pass
+            else: # transformers >= 4.50.0 path
+                if self.args.average_tokens_across_devices:
+                    num_items_in_batch = self.accelerator.gather(num_items_in_batch).sum()
+                if torch.is_tensor(num_items_in_batch):
+                    num_items_in_batch = num_items_in_batch.to(device)
+                pass
 
         except Exception as exception:
             raise RuntimeError(exception)


### PR DESCRIPTION
get_batch_samples patch currently takes 3 parameters and transformer 4.50.0 has changed it to take 4 parameters. I've updated the function to take device = None. The default keyword maintains backward compatibility.

A few users are experiencing the issue. [Discord](https://discord.com/channels/1179035537009545276/1352688094343860297/1352688094343860297)