### PR TITLE
Input grads fix for gemma3

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1489,7 +1489,7 @@ def unsloth_compile_transformers(
     if "UNSLOTH_FULLGRAPH" not in os.environ:
         os.environ["UNSLOTH_FULLGRAPH"] = UNSLOTH_FULLGRAPH
     else:
-        UNSLOTH_FULLGRAPH = os.environ["UNSLOTH_FULLGRAPH"] == "1"
+        UNSLOTH_FULLGRAPH = os.environ["UNSLOTH_FULLGRAPH"]
     pass
     UNSLOTH_FULLGRAPH = UNSLOTH_FULLGRAPH == "1"
 
@@ -1565,6 +1565,13 @@ def unsloth_compile_transformers(
         try: source = inspect.getsource(source.__init__)
         except: continue
         fullgraph = not ("nn.Linear" in source or "nn.ModuleList" in source)
+
+        if module == 'SiglipVisionEmbeddings' or module == 'CLIPVisionEmbeddings':
+            # sometimes we attach a post forward call to make sure requires grad is set
+            # this breaks full graph mode and fails so instead we relax the full graph check
+            # We attach via post forward call, since the forward call only passes keyword
+            # arguments in transformers and pre_forward hook doesn't pass kwargs.
+            fullgraph = False
 
         # Check if other modules is used as well
         for another_module in torch_modules:

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -272,7 +272,7 @@ def requires_grad_for_gradient_checkpointing(model):
     module_name = "model." + ".".join(name_components[:final_where])
     module = eval(module_name)
 
-    if hasattr(module, "config") and module.config.__class__.__name__ == "CLIPVisionConfig":
+    if hasattr(module, "config") and (module.config.__class__.__name__ == "CLIPVisionConfig" or module.config.__class__.__name__ == "SiglipVisionConfig"):
         # CLIP - backtrack to get_input_embeddings since requires_grad fails!
         old_module = model
         for module_name, module in model.named_modules():


### PR DESCRIPTION
This PR resolve [#2131](https://github.com/unslothai/unsloth/issues/2131).

The hook to enable gradients for vision embeddings gets attached to a function that has no position arguments, only keywords. The torch pre_forward_hook doesn't pass kwargs so the hook throws an error as it expects one positional argument. The `requires_grad_for_gradient_checkpointing` has a workaround for CLIP embeddings and I add a check to to include siglip vision embeddings in this handler.

This would work as is, excecpt I noticed an issue in compiler.py. FULLGRAPH variable starts as "0" or "1" while the env variable is True or False. But the second time it's called `UNSLOTH_FULLGRAPH = os.environ["UNSLOTH_FULLGRAPH"] == "1"` followed by `UNSLOTH_FULLGRAPH = UNSLOTH_FULLGRAPH == "1"`. This makes the first UNSLOTH_FULLGRAPH eval to True, but then the second eval to false. So fullgraph becomes false for everything compiled after siglip.

I fixed this so that it should eval to True. But then the issue still remains that we are trying to compile the embedding forward for Siglip and CLIP vision embeddings. I add a check right after the nn.Linear and ModuleDict check to specifically set fullgraph to false for these embeddings. Felt like a reasonable place to fix but I'm open to handling this in a more robust way.

I have a colab note book testing the changes [here](https://colab.research.google.com/drive/1SPM0g1NJFPgYgZbvX7keUNcvRnuJOqJ3?usp=sharing). Llava, llama, and gemma3 vision training all work, but gemma3 fails on a T4. There is a separate issue where the vision model bfloat16 weights do not get converted to float32 but the language component does. Will open a separate PR for that.