### PR TITLE
Fix gradient checkpointing warning filter implementation

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1000,7 +1000,7 @@ def apply_fused_lm_head(forward):
 
         cross_entropy_replacement = cross_entropy_replacement\
             .replace(
-                "$KWARGS$", 
+                "$KWARGS$",
                 "locals().get('loss_kwargs', {}) or locals().get('kwargs', {})"
             )
 
@@ -1179,7 +1179,7 @@ def patch_gradient_checkpointing(module, source):
         .replace("LAYER", layer).replace("MODULELIST_ITEM", modulelist_item)\
         .replace("ARGS", args).replace("$", spaces)
     forward = forward.replace(forward[span[0] : span[1]], replacer)
-    
+
     # Also fix init
     spaces = init.find("def")
     init = init + "\n" + (spaces + 4) * " " + "self.gradient_checkpointing = False\n\n"
@@ -1381,10 +1381,10 @@ def patch_gradient_accumulation(modeling_file, module):
 
     functions = dir(modeling_file)
     module = eval(f"modeling_file.{module}")
-    try: 
+    try:
         forward = module.forward
         source = inspect.getsource(forward)
-    except: 
+    except:
         return None
     has_kwargs = tuple(inspect.signature(forward).parameters.values())[-1].kind == inspect._VAR_KEYWORD
     if has_kwargs: return None
@@ -1450,6 +1450,10 @@ def unsloth_compile_transformers(
     disable                : bool = False,
     return_logits          : bool = False,
 ):
+    # import transformers logging module and instantiate model_type logging instance.
+    from transformers import logging as transformers_logging
+    model_logger = transformers_logging.get_logger(f"modeling_{model_type}")
+
     # All Unsloth Zoo code licensed under LGPLv3
     disable = disable or (os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1")
     if fast_residual_stream:
@@ -1461,8 +1465,9 @@ def unsloth_compile_transformers(
     modeling_file = eval(model_location)
     if hasattr(modeling_file, "__UNSLOTH_PATCHED__"): return
 
-    # Remove `use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`
-    exec("modeling_file.logger.addFilter(HideLoggingMessage('Setting `use_cache=False`'))", globals(), locals())
+    # Use transformers model_type logger to supress message: Remove `use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`
+    exec("model_logger.addFilter(HideLoggingMessage('Setting `use_cache=False`'))", globals(), locals())
+
 
     # torch_compile_options
     UNSLOTH_COMPILE_DEBUG         = os.environ.get("UNSLOTH_COMPILE_DEBUG",         "0") == "1"
@@ -1792,7 +1797,7 @@ def unsloth_compile_transformers(
             # Disable if torch < 2.5 or V100s 7.0 (Tesla T4 7.5 works) or old Triton < 3
             if OLD_CUDA_ARCH_VERSION or OLD_TORCH_VERSION or OLD_TRITON_VERSION:
                 continue
-            
+
             module_class = eval(f"modeling_file.{module}")
             if hasattr(module_class, "forward") and issubclass(module_class, GenerationMixin):
                 try:


### PR DESCRIPTION
## Fix Logger Filter Implementation for Gradient Checkpointing Warnings


### Description

This PR fixes a bug in the `unsloth_compile_transformers` method in `compiler.py` that causes an AttributeError when trying to suppress gradient checkpointing warnings. The current implementation incorrectly assumes that the model file has a `logger` attribute, but logger instances are typically module-level variables, not attributes.


### Changes

- Replaced the problematic `exec()` call that was looking for `modeling_file.logger`

- Implemented a proper logging filter that gets the correct logger instance via the transformers logging system

- Ensures the filter works across different model architectures (Gemma, Mistral, etc.)


### Bug Details

The current code attempts to suppress warnings with:

```python

exec("modeling_file.logger.addFilter(HideLoggingMessage('Setting `use_cache=False`'))", globals(), locals())

```

This fails with 
```
AttributeError: module 'transformers.models.mistral3.modeling_mistral3' has no attribute 'logger'` because the logger is a module-level variable, not a model attribute.
```

### Solution

The fix gets the appropriate logger directly from the transformers logging module and applies a filter to target only the specific gradient checkpointing warning message.


### Testing

Verified the solution works with:

- Gemma 3 models

- Mistral 3 models


### Related Issues

Fixes:
- unsloth-zoo issue [#90](https://github.com/unslothai/unsloth-zoo/issues/90)
- unsloth issue [#2146](https://github.com/unslothai/unsloth/issues/2146)