### PR TITLE
Consistent handling of dtypes for siglip model (gemma3)

### DIFF
--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -231,11 +231,13 @@ def patch_model_and_tokenizer(
     if do_forced_float32:
         correct_dtype = torch.float16
         for name, module in model.named_modules():
-            if "down_proj" in name or "up_proj" in name or "gate_proj" in name:
+            if "down_proj" in name or "up_proj" in name or "gate_proj" in name or "fc1" in name or "fc2" in name:
                 exec(f"module.to(torch.float16)")
-            if "q_proj" in name or "k_proj" in name or "v_proj" in name or "o_proj" in name:
+            if "q_proj" in name or "k_proj" in name or "v_proj" in name or "o_proj" in name or "out_proj" in name:
                 exec(f"module.to(torch.float16)")
             if "lm_head" in name or "embed_tokens" in name:
+                exec(f"module.to(torch.float16)")
+            if "patch_embedding" in name:
                 exec(f"module.to(torch.float16)")
             if "norm" in name:
                 exec(f"module.to(torch.float32)")


### PR DESCRIPTION
When working on [#2131](https://github.com/unslothai/unsloth/issues/2131), I encountered a problem training with a T4. 

```
---> 67     return torch.layer_norm(
     68         input, normalized_shape, weight, bias, eps, torch.backends.cudnn.enabled
     69     ).to(input.dtype)

RuntimeError: expected scalar type BFloat16 but found Float
```

I found that the vision portion of the model wasn't getting casted to the correct dtype and specifically in `patch_model_and_tokenizer` it skips over the mlp, out_proj, and patch_embeddings due to different naming conventions. I added checks for those.

But then I also noticed that the gemma3 vision model wasn't getting quantized at all. If I look at the dtypes of the safetensors I can see the language_model has quantized weights but the vision_model doesn't. Then looking at the uploaded weight I see it's set to skip quantization for all vision mlp layers, and self_attn modules  (except for layer 25?). 

In any case since the vision layers skip quantization it uses regular nn.Linear layers which don't have the same upcasting/downcasting logic as the patched Linears from unsloth. This PR + fixing the skipped modules on the huggingface upload will fix the runtime error.

Alternatively, if those modules are meant to be skipped maybe we could add a patched Linear module for these types of cases.