### PR TITLE
stop casting hidden states to float32 for cut cross entropy

### DIFF
--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -168,7 +168,7 @@ def fused_linear_cross_entropy(
     reduction = "sum" if num_items_in_batch is not None else "mean"
     if logit_softcapping == 0: logit_softcapping = None
     loss = linear_cross_entropy(
-        hidden_states.to(lm_weight.dtype),
+        hidden_states.to(lm_weight.dtype if lm_weight.dtype in (torch.float16, torch.bfloat16) else hidden_states.dtype),
         lm_weight,
         targets      = labels,
         ignore_index = ignore_index,


### PR DESCRIPTION
T4 currently has an issue training lm_head's since bfloat16 is not supported. A few users have experienced the same issue and it's reproducible. 

[#2171](https://github.com/unslothai/unsloth/issues/2127)
[#2253](https://github.com/unslothai/unsloth/issues/2253)


[Original PR](https://github.com/unslothai/unsloth/pull/1200) casts lm_head to float32 since it's a module to save when training the lm head with lora. Before going to cut cross entropy, the output embeddings are casted to the same dtype as lm_head. Cut cross entropy specifically asserts that the embeddings are float16 or bfloat16 and raises an AssertionError if something else like float32. It's not clear why embeddings can't be float32, but I presume it's due to code not being optimized for that type.

This change only allows casting hidden_states to the weight's dtype if it's one of float16 or bfloat16. Otherwise it keeps the original dtype. Even though this code touches almost all unsloth finetuning usecases it's a low risk change since cut cross entropy would fail anyways if the dtype wasn't one of float16 or bfloat16.


