### PR TITLE
Fix wrong index causing double BOS

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -547,7 +547,7 @@ def sft_prepare_dataset(
                 )
             test_text = test_text[0]
         else:
-            test_text = next(iter(dataset))[dataset_text_field][0]
+            test_text = next(iter(dataset))[dataset_text_field]
 
         # Get chat template
         chat_template = getattr(processing_class, 'chat_template', '')


### PR DESCRIPTION
In Gemma-4B colab,

`tokenizer.decode(trainer.train_dataset[100]["input_ids"])` gives:
`<bos><bos><start_of_turn>user\nWhat...`

Modifying the code by adding `print("\n\nTest text:", test_text)` prints: `Test text: <` , showing that indexing with [0] is unnecessary as it indexes the first letter of the test text.

After modifying, `print("\n\nTest text:", test_text)` now gives: `Test text: <bos><start_of_turn>user\nExplain what boolean...`

Does not apply to `formatting_func` as  the `formatting_func` should return a list of processed strings.