### PR TITLE
Indicating encoding explicitly in logging_utils.py

### DIFF
--- a/unsloth_zoo/logging_utils.py
+++ b/unsloth_zoo/logging_utils.py
@@ -158,7 +158,7 @@ def get_trl_metrics():
     for trainer in trainers:
         filename = os.path.join(filepath, f"{trainer}.py")
         if not os.path.exists(filename): continue
-        with open(filename, "r") as file: file = file.read()
+        with open(filename, "r", encoding="utf-8") as file: file = file.read()
 
         # Get metrics['kl'] or stats['kl']
         metrics = re.findall(r"metrics\[[\"\']([^\"\']{1,})[\"\']\]", file)


### PR DESCRIPTION
As I detailed in the issue number #109 
without indicating explicitly the encoding when reading the Trainer files from the trl library, a UnicodeDecodeError could arise if the the locale preferred encoding is not set to utf-8. 
I have tested the GRPO Trainer after with this minor change and it worked as intended.