### PR TITLE
Fix for updated llama.cpp syntax.

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -356,7 +356,7 @@ def _download_convert_hf_to_gguf(
         )
 
     # Get all supported models
-    supported_types = re.findall(rb"@Model\.register\(([^)]{1,})\)", converter_latest)
+    supported_types = re.findall(rb"@ModelBase\.register\(([^)]{1,})\)", converter_latest)
     supported_types = b", ".join(supported_types).decode("utf-8")
     supported_types = re.findall(r"[\'\"]([^\'\"]{1,})[\'\"]", supported_types)
     supported_types = frozenset(supported_types)


### PR DESCRIPTION
Fixed syntax issue resolving: NotImplementedError: Unsloth: llama.cpp GGUF conversion does not yet support converting model types of `Gemma3ForCausalLM`.