### PR TITLE
Updated llamacpp regrex.

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -356,7 +356,7 @@ def _download_convert_hf_to_gguf(
         )
 
     # Get all supported models
-    supported_types = re.findall(rb"@ModelBase\.register\(([^)]{1,})\)", converter_latest)
+    supported_types = re.findall(rb"@(?:Model|ModelBase)\.register\(\s*([^)]+?)\s*\)",converter_latest)
     supported_types = b", ".join(supported_types).decode("utf-8")
     supported_types = re.findall(r"[\'\"]([^\'\"]{1,})[\'\"]", supported_types)
     supported_types = frozenset(supported_types)

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -356,7 +356,7 @@ def _download_convert_hf_to_gguf(
         )
 
     # Get all supported models
-    supported_types = re.findall(rb"@Model\.register\(([^)]{1,})\)", converter_latest)
+    supported_types = re.findall(rb"@ModelBase\.register\(([^)]{1,})\)", converter_latest)
     supported_types = b", ".join(supported_types).decode("utf-8")
     supported_types = re.findall(r"[\'\"]([^\'\"]{1,})[\'\"]", supported_types)
     supported_types = frozenset(supported_types)


### PR DESCRIPTION
Updated llama.cpp regrex to handle all models, including Gemma3ForCausalLM.

Resolving the error:

NotImplementedError: Unsloth: llama.cpp GGUF conversion does not yet support converting model types of `Gemma3ForCausalLM`.

This pull request is **just** for resolving the BaseModel issue, since users (like myself) are unable to use unsloth-zoo properly with Gemma 3 finetuning. If others wish to expand on this moving forward for other class fixes, that's fine, but at minimum, this will get some users back up and running without any negative consequences.