### PR TITLE
update the null check for logit_softcapping to is not None

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -803,7 +803,7 @@ else:
         logits = logits * (\\2)
     if (\\3) != ():
         logits = logits / (\\3)
-    if (\\4) is not None:
+    if (\\4) is not None or (\\4) != ():
         logits = logits / (\\4)
         logits = torch.tanh(logits)
         logits = logits * (\\4)

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -793,7 +793,7 @@ elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not N
         output_labels        = labels,
         logit_scale_multiply = (\\2) if (\\2) != () else 0,
         logit_scale_divide   = (\\3) if (\\3) != () else 0,
-        logit_softcapping    = (\\4) if (\\4) is not None else 0,
+        logit_softcapping    = (\\4) if (\\4) is not None or (\\4) != () else 0,
         vocab_size           = (\\8),
         n_items              = n_items if n_items is not None else 0,
     )
@@ -904,7 +904,7 @@ if labels is not None:
         mask                 = \\5,
         logit_scale_multiply = (\\1) if (\\1) != () else 0,
         logit_scale_divide   = (\\2) if (\\2) != () else 0,
-        logit_softcapping    = (\\3) if (\\3) is not None else 0,
+        logit_softcapping    = (\\3) if (\\3) is not None or (\\3) != () else 0,
         vocab_size           = (\\6),
         n_items              = n_items if n_items is not None else 0,
     )

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -793,7 +793,7 @@ elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not N
         output_labels        = labels,
         logit_scale_multiply = (\\2) if (\\2) != () else 0,
         logit_scale_divide   = (\\3) if (\\3) != () else 0,
-        logit_softcapping    = (\\4) if (\\4) != () else 0,
+        logit_softcapping    = (\\4) if (\\4) is not None else 0,
         vocab_size           = (\\8),
         n_items              = n_items if n_items is not None else 0,
     )
@@ -803,7 +803,7 @@ else:
         logits = logits * (\\2)
     if (\\3) != ():
         logits = logits / (\\3)
-    if (\\4) != ():
+    if (\\4) is not None:
         logits = logits / (\\4)
         logits = torch.tanh(logits)
         logits = logits * (\\4)
@@ -904,7 +904,7 @@ if labels is not None:
         mask                 = \\5,
         logit_scale_multiply = (\\1) if (\\1) != () else 0,
         logit_scale_divide   = (\\2) if (\\2) != () else 0,
-        logit_softcapping    = (\\3) if (\\3) != () else 0,
+        logit_softcapping    = (\\3) if (\\3) is not None else 0,
         vocab_size           = (\\6),
         n_items              = n_items if n_items is not None else 0,
     )


### PR DESCRIPTION
There are current issues for full finetuning gemma3. [#2101](https://github.com/unslothai/unsloth/issues/2101). logit_softcapping gets passed as None. The compiler checks for != () instead of is not None like transformers. This PR swaps the check for empty tuple to is not None. Gemma3 notebook below showing that it works.

https://colab.research.google.com/drive/1dKVqnEWOBBcjpiPk3GVScQG-Iir5uV5H?usp=sharing