### PR TITLE
fixed issues related to saving and pushing to hub merged models and model shards

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -557,7 +557,6 @@ def merge_and_overwrite_lora(
     low_disk_space_usage = False,
     use_temp_file        = False,
     cleanup_temp_file    = True,
-    overwrite_merge      = True,
 ):
     # All Unsloth Zoo code licensed under LGPLv3
     # Directly downloads 16bit original weights and merges LoRA

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -100,10 +100,24 @@ def create_huggingface_repo(
         token = token,
     )
     username = repo_id.split("/")[0]
+
+    # Check if base_model is a local path
+    base_model = model.config._name_or_path
+    if os.path.exists(base_model) and os.path.isdir(base_model):
+        # Try to get the original model ID from config
+        original_model_id = get_original_model_id(base_model)
+        if original_model_id is not None and not os.path.exists(original_model_id):
+            # Use the original model ID if it doesn't look like a local path
+            base_model = original_model_id
+        else:
+            # If we can't determine the original model, use repo_id as a generic description
+            # that won't cause HF validation errors
+            base_model = repo_id
+
     # Create model card
     content = MODEL_CARD.format(
         username   = username,
-        base_model = model.config._name_or_path,
+        base_model = base_model,
         model_type = model.config.model_type,
         method     = "",
         extra      = "unsloth",
@@ -543,6 +557,7 @@ def merge_and_overwrite_lora(
     low_disk_space_usage = False,
     use_temp_file        = False,
     cleanup_temp_file    = True,
+    overwrite_merge      = True,
 ):
     # All Unsloth Zoo code licensed under LGPLv3
     # Directly downloads 16bit original weights and merges LoRA
@@ -556,23 +571,69 @@ def merge_and_overwrite_lora(
     except:
         model_name = model.config._name_or_path
 
-    # Find repository's max shard size and total size of everything
-    try:
-        file_list = HfFileSystem(token = token).ls(model_name, detail = True)
-    except:
-        original_model_id = get_original_model_id(model_name)
-        model_name = original_model_id
-        file_list = HfFileSystem(token = token).ls(model_name, detail = True)
-
     safetensors_list = []
     max_size_in_bytes = 0
     total_size_in_bytes = 0
-    for x in file_list:
-        if not x["name"].endswith(".safetensors"): continue
-        safetensors_list.append(os.path.split(x["name"])[-1])
-        max_size_in_bytes = max(max_size_in_bytes, x["size"])
-        total_size_in_bytes += x["size"]
-    pass
+
+    # Handle case for local model where config._name_or_path is a local os path
+    # https://github.com/unslothai/unsloth/issues/2140
+    is_local_path = False
+    if os.path.exists(model_name) and os.path.isdir(model_name):
+        is_local_path = True
+        print(f"Detected local model directory: {model_name}")
+
+        # Get safetensors files from local directory
+        for file in os.listdir(model_name):
+            if file.endswith(".safetensors"):
+                safetensors_list.append(file)
+                file_path = os.path.join(model_name, file)
+                file_size = os.path.getsize(file_path)
+                max_size_in_bytes = max(max_size_in_bytes, file_size)
+                total_size_in_bytes += file_size
+
+        # Check for index file
+        index_path = os.path.join(model_name, "model.safetensors.index.json")
+        if os.path.exists(index_path):
+            try:
+                with open(index_path, 'r') as f:
+                    index_data = json.load(f)
+                    # Extract file names from the index if available
+                    if "weight_map" in index_data:
+                        # Get unique filenames from weight map
+                        indexed_files = set(index_data["weight_map"].values())
+                        # Only use these if we didn't find files directly
+                        if not safetensors_list:
+                            safetensors_list = list(indexed_files)
+                            # Need to compute sizes for these files
+                            for file in safetensors_list:
+                                file_path = os.path.join(model_name, file)
+                                if os.path.exists(file_path):
+                                    file_size = os.path.getsize(file_path)
+                                    max_size_in_bytes = max(max_size_in_bytes, file_size)
+                                    total_size_in_bytes += file_size
+            except Exception as e:
+                print(f"Warning: Could not process index file: {e}")
+    else:
+        # Original HF repo logic
+        try:
+            file_list = HfFileSystem(token = token).ls(model_name, detail = True)
+        except:
+            original_model_id = get_original_model_id(model_name)
+            model_name = original_model_id
+            if original_model_id is None:
+                raise ValueError(f"Could not determine original model ID from {model_name}. "
+                                "If using a local model, ensure the path exists and contains safetensors files.")
+            file_list = HfFileSystem(token = token).ls(model_name, detail = True)
+
+        # Process HF file listing
+        for x in file_list:
+            if not x["name"].endswith(".safetensors"): continue
+            safetensors_list.append(os.path.split(x["name"])[-1])
+            max_size_in_bytes = max(max_size_in_bytes, x["size"])
+            total_size_in_bytes += x["size"]
+
+    if not safetensors_list:
+         raise RuntimeError(f"No '.safetensors' files found for the base model: {model_name}")
     assert(max_size_in_bytes != 0 and total_size_in_bytes != 0)
 
     (
@@ -595,6 +656,7 @@ def merge_and_overwrite_lora(
         use_temp_file = use_temp_file,
     )
     use_temp_file = use_temp_file or new_use_temp_file
+    _save_dir_path = Path(save_directory)
 
     n_saved_modules = 0
     def upload_items(filename = None):
@@ -613,77 +675,165 @@ def merge_and_overwrite_lora(
     # Save config / generation_config via no state_dict and tokenizer
     if tokenizer is not None: tokenizer.save_pretrained(save_directory = save_directory,)
 
-    if save_method == "merged_16bit":
-        inner_model.save_pretrained(
-            save_directory = save_directory,
-            state_dict = {},
-        )
-        _remove_quantization_config(config_path = Path(save_directory) / "config.json")
-    elif save_method == "merged_4bit":
-        print(f"Unsloth: Saving model 4bit...")
-        base_model = base_model.merge_and_unload()
-        skipped_modules, quantized_modules = find_skipped_quantized_modules(base_model)
-        if len(skipped_modules) > 0:
-            # Reconstruct skipped modules so that it can be loaded
-            base_model.config.quantization_config["llm_int8_skip_modules"] = skipped_modules
+    # --- Handle 4-bit merging first ---
+    if save_method == "merged_4bit":
+        print(f"Unsloth: Merging LoRA weights into 4bit model...")
+        if not isinstance(model, PeftModelForCausalLM):
+             raise TypeError("Model must be a PeftModelForCausalLM for 'merged_4bit' save.")
+        if not getattr(model.config, "quantization_config", None):
+             raise ValueError("Model does not appear to be quantized. Cannot use 'merged_4bit'.")
 
-        base_model.save_pretrained(
-            save_directory = save_directory,
-        )
-    # Remove the quantization_config in the config.json file if it exists,
+        # Perform the merge
+        try:
+            # Use the base_model reference which points to the PeftModel's base
+            merged_model = base_model.merge_and_unload()
+            print(f"Unsloth: Merging finished.")
+        except Exception as e:
+            raise RuntimeError(f"Failed to merge LoRA weights for 4-bit save: {e}")
+
+        # Check for skipped modules (optional but good practice)
+        skipped_modules, _ = find_skipped_quantized_modules(merged_model)
+        if len(skipped_modules) > 0:
+            print(f"Unsloth: Found skipped modules: {skipped_modules}. Updating config.")
+            # Ensure quantization_config exists before modifying
+            if not hasattr(merged_model.config, "quantization_config"):
+                merged_model.config.quantization_config = {} # Initialize if somehow missing
+            merged_model.config.quantization_config["llm_int8_skip_modules"] = skipped_modules
+
+        print(f"Unsloth: Saving merged 4bit model to {save_directory}...")
+        try:
+            merged_model.save_pretrained(save_directory = save_directory)
+            print(f"Unsloth: Merged 4bit model saved.")
+        except Exception as e:
+             raise RuntimeError(f"Failed to save merged 4-bit model: {e}")
+
+        # Upload the saved 4-bit model files
+        if push_to_hub:
+            upload_items() # Upload the entire directory content
+
+        # Clean up temp file if created
+        if cleanup_temp_file and temp_file is not None:
+            print("Unsloth: Cleaning up temporary file...")
+            try: temp_file.cleanup()
+            except Exception as e: print(f"Warning: Failed to cleanup temp file: {e}")
+
+        print("Unsloth: Merged 4bit model process completed.")
+        return save_directory # <<<--- EARLY RETURN for 4-bit path
+
+
+    # Default handle 16 bit merge and save/push
+    # Step 1: Save base model config/architecture (no weights needed here)
+
+    inner_model.save_pretrained(
+        save_directory = save_directory,
+        state_dict = {},
+    )
+    _remove_quantization_config(config_path = Path(save_directory) / "config.json")
+        # Remove the quantization_config in the config.json file if it exists,
     # as we are exporting the model in 16-bit format.
 
-    if push_to_hub: upload_items()
+    # Step 2: Initial upload of non-model files (config, tokenizer)
+    if push_to_hub:
+        upload_items()
 
-    if save_method == "merged_16bit":
-        safe_tensor_index_files = ["model.safetensors.index.json"] if len(safetensors_list) > 1 else []
-        if not low_disk_space_usage:
-            # Download all safetensors in 1 go!
-            print(f"Downloading safetensors for {model_name}...")
-            snapshot_download(
-                repo_id = model_name,
-                local_dir = save_directory,
-                allow_patterns = safe_tensor_index_files + safetensors_list,
-            )
-        elif safe_tensor_index_files:
-            print(f"Downloading safetensors index for {model_name}...")
-            snapshot_download(
-                repo_id = model_name,
-                local_dir = save_directory,
-                allow_patterns = ["model.safetensors.index.json"],
-            )
 
-        for filename in ProgressBar(safetensors_list, desc = "Unsloth: Merging weights into 16bit"):
-            if low_disk_space_usage:
-                hf_hub_download(
-                    repo_id = model_name,
-                    filename = filename,
-                    repo_type = "model",
-                    local_dir = save_directory,
-                )
-            pass
-            n_saved_modules += _merge_and_overwrite_lora(
-                save_directory = save_directory,
+    # Step 3: Handle original 16-bit shard retrieval (cache/download)
+    _hf_cache_dir = _get_hf_cache_dir()
+    copied_all_from_cache = False
+    safe_tensor_index_files = ["model.safetensors.index.json"] if len(safetensors_list) > 1 else []
+
+    # For local models, we'll copy from the local directory instead of cache/download
+    if is_local_path:
+        print(f"Copying safetensors from local directory: {model_name}")
+        os.makedirs(save_directory, exist_ok=True)
+
+        # Copy index file if it exists
+        local_index_path = os.path.join(model_name, "model.safetensors.index.json")
+        if os.path.exists(local_index_path):
+            shutil.copy2(local_index_path, os.path.join(save_directory, "model.safetensors.index.json"))
+            print(f"Copied safetensors index file from local model")
+
+        # We'll handle the actual files in the later loop
+        copied_all_from_cache = True  # Mark as handled to skip download
+
+    elif _hf_cache_dir is not None:
+        copied_all_from_cache = _try_copy_all_from_cache(
+            repo_id=model_name,
+            filenames_to_check=safetensors_list,
+            target_dir_str=save_directory,
+            hf_cache_dir=_hf_cache_dir,
+            token=token,
+        )
+    if not copied_all_from_cache and not low_disk_space_usage and not is_local_path:
+        print(f"Downloading safetensors for {model_name}...")
+        snapshot_download(
+            repo_id = model_name,
+            local_dir = save_directory,
+            allow_patterns = safe_tensor_index_files + safetensors_list,
+        )
+    elif safe_tensor_index_files and not is_local_path:
+        print(f"Downloading safetensors index for {model_name}...")
+        snapshot_download(
+            repo_id = model_name,
+            local_dir = save_directory,
+            allow_patterns = ["model.safetensors.index.json"],
+        )
+
+    # Step 4: Ensure the index file is uploaded for sharded models, regardless of low_disk_space_usage
+    if push_to_hub and len(safetensors_list) > 1 and os.path.exists(os.path.join(save_directory, "model.safetensors.index.json")):
+        upload_items("model.safetensors.index.json")
+
+    # Step 5: Iterate through original shards, merge LoRA, and overwrite/save
+    for filename in ProgressBar(safetensors_list, desc = "Unsloth: Merging weights into 16bit"):
+        file_path = os.path.join(save_directory, filename)
+        # Only download if we didn't get everything from cache AND this specific file doesn't exist
+        # AND we're in low disk space mode
+        # For local models, copy the file if needed
+        if is_local_path and not os.path.exists(file_path):
+            local_file_path = os.path.join(model_name, filename)
+            if os.path.exists(local_file_path):
+                shutil.copy2(local_file_path, file_path)
+                print(f"Copied {filename} from local model directory")
+
+        elif not copied_all_from_cache and low_disk_space_usage and not os.path.exists(file_path) and not is_local_path:
+            hf_hub_download(
+                repo_id = model_name,
                 filename = filename,
-                lora_weights = lora_weights,
-                output_dtype = output_dtype,
-            )
-            torch.cuda.empty_cache()
-            if low_disk_space_usage and push_to_hub:
-                upload_items(filename)
-                os.remove(os.path.join(save_directory, filename)) # Remove to conserve disk space
-            pass
-        pass
-
-        # Check for errors
-        if len(lora_weights) != n_saved_modules:
-            raise RuntimeError(
-                f"Unsloth: Saving LoRA finetune failed since # of LoRAs = {len(lora_weights)} "\
-                f"does not match # of saved modules = {n_saved_modules}. Please file a bug report!"
+                repo_type = "model",
+                local_dir = save_directory,
             )
         pass
-    if not low_disk_space_usage and push_to_hub: upload_items()
+        n_saved_modules += _merge_and_overwrite_lora(
+            save_directory = save_directory,
+            filename = filename,
+            lora_weights = lora_weights,
+            output_dtype = output_dtype,
+        )
+        torch.cuda.empty_cache()
+        if low_disk_space_usage and push_to_hub:
+            upload_items(filename)
+            os.remove(os.path.join(save_directory, filename)) # Remove to conserve disk space
+        pass
+    pass
 
+    # Step 6: Final upload of all shards if not using low disk space mode and pushing
+    if not low_disk_space_usage and push_to_hub:
+
+        # Explicitly upload all safetensors files if not already handled
+        for filename in safetensors_list:
+            upload_items(filename)
+        upload_items()
+
+
+    # Step 7: Check for errors
+    if len(lora_weights) != n_saved_modules:
+        raise RuntimeError(
+            f"Unsloth: Saving LoRA finetune failed since # of LoRAs = {len(lora_weights)} "\
+            f"does not match # of saved modules = {n_saved_modules}. Please file a bug report!"
+        )
+    pass
+
+    # --- Cleanup
     if temp_file is not None:
         try: temp_file.cleanup()
         except: pass
@@ -691,6 +841,128 @@ def merge_and_overwrite_lora(
 
     return save_directory
 pass
+
+def _try_copy_all_from_cache(
+    repo_id: str,
+    filenames_to_check: list[str],
+    target_dir_str: str, # Expect string path for target directory
+    hf_cache_dir: Path | None,
+    token: str | None,
+) -> bool:
+    """
+    Checks if ALL specified files exist in the HF cache. If yes, creates the
+    target_dir_str and copies ALL files into it using os functions.
+    Returns True if successful, False otherwise.
+    """
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    if not hf_cache_dir or not filenames_to_check:
+        print("Skipping cache check: No cache directory or no files specified.") # Verbose
+        return False
+
+    hf_cache_dir_str = str(hf_cache_dir)
+    print(f"Checking cache directory for required files...") # Verbose
+    cached_paths_map = {}
+
+    all_found = True
+    for filename in filenames_to_check:
+        try:
+            cached_path_str = hf_hub_download(repo_id=repo_id, filename=filename, local_files_only=True)
+            cached_paths_map[filename] = Path(cached_path_str) # Store Path for checking
+        except LocalEntryNotFoundError:
+            print(f"Cache check failed: {filename} not found in local cache.") # Verbose
+            all_found = False
+            break
+        except Exception as check_err:
+            print(f"Cache check failed: Error checking for {filename}: {check_err}.")
+            all_found = False
+            break
+
+    if not all_found:
+        print("Not all required files found in cache. Will proceed with downloading.") # Verbose
+        return False
+
+    try:
+        # Create target directory using os.makedirs
+        os.makedirs(target_dir_str, exist_ok=True)
+        if not os.access(target_dir_str, os.W_OK | os.X_OK):
+             raise PermissionError(f"No write/execute permission for target directory: {target_dir_str}")
+    except Exception as dir_err:
+        print(f"Cache copy failed: Could not create or access target directory {target_dir_str}: {dir_err}")
+        return False
+
+    all_copied = True
+    for filename, cached_path in cached_paths_map.items():
+        try:
+            # Pass string target_dir_str to copy helper
+            _copy_file_from_source(cached_path, target_dir_str, filename)
+        except (IOError, PermissionError, FileNotFoundError) as copy_err:
+             print(f"Cache copy failed: Error copying {filename} from {cached_path} to {target_dir_str}: {copy_err}")
+             all_copied = False; break
+        except Exception as e:
+            print(f"Cache copy failed: An unexpected error occurred copying {filename}: {e}")
+            all_copied = False; break
+
+    if all_copied:
+        print(f"Successfully copied all {len(filenames_to_check)} files from cache to {target_dir_str}.")
+        return True
+    else:
+        print("Failed to copy one or more files from cache. Will proceed with downloading.")
+        return False
+pass
+
+def _copy_file_from_source(src_path: str | Path, target_dir_str: str, filename: str):
+    """Copies a file from src_path to target_dir_str/filename using os.path."""
+    src_path = Path(src_path) # Keep Path for source checking ease
+    dst_path = os.path.join(target_dir_str, filename) # Use os.path.join for destination
+
+    if not src_path.is_file():
+        raise FileNotFoundError(f"Source {src_path} is not a valid file.")
+    if not os.access(src_path, os.R_OK):
+         raise PermissionError(f"No read permission for source file: {src_path}")
+    # Target dir creation and permission check is handled by caller (_try_copy_all_from_cache)
+    try:
+        shutil.copy2(str(src_path), dst_path) # Use string paths for shutil
+    except Exception as e:
+        raise IOError(f"Failed to copy {src_path} to {dst_path}: {e}") from e
+pass
+
+def _get_hf_cache_dir() -> Path | None:
+    """Determines the Hugging Face Hub cache directory."""
+    potential_paths = []
+    if "HF_HUB_CACHE" in os.environ:
+        potential_paths.append(Path(os.environ["HF_HUB_CACHE"]))
+    if "HF_HOME" in os.environ:
+        potential_paths.append(Path(os.environ["HF_HOME"]) / "hub")
+    potential_paths.append(Path.home() / ".cache" / "huggingface" / "hub")
+
+    for cache_dir in potential_paths:
+        try:
+            # 1. Check if it exists and is a directory
+            if cache_dir.is_dir():
+                # 2. Check if we have read/write/execute access
+                # Need W/X for potential lock files or internal operations by huggingface_hub
+                if os.access(cache_dir, os.R_OK | os.W_OK | os.X_OK):
+                    print(f"Found HuggingFace hub cache directory: {cache_dir.resolve()}")
+                    return cache_dir.resolve() # Return absolute path
+                else:
+                    print(f"Warning: Found cache directory {cache_dir}, but lack R/W/X permissions. Cannot use cache.")
+                    # Don't check other paths if we found the prioritized one but lack permissions
+                    return None
+            # If it exists but is not a dir, it's problematic, stop checking.
+            elif cache_dir.exists():
+                 print(f"Warning: Path {cache_dir} exists but is not a directory. Cannot use cache.")
+                 return None
+            # If it doesn't exist, continue to check the next potential path
+
+        except Exception as e:
+            # Handle potential issues like symlink loops, permissions errors during check
+            print(f"Warning: Error accessing potential cache path {cache_dir}: {e}. Checking next option.")
+            continue # Try the next path
+
+    # If none of the paths worked
+    print("No existing and accessible Hugging Face cache directory found.")
+    return None
 
 
 _PUSHING_CODE = \
@@ -788,7 +1060,7 @@ def incremental_save_pretrained(
             f"repo_id = '{repo_id}'\n"
     pass
     save_pretrained = save_pretrained.replace(for_loop, new_for_loop)
-    
+
     if not low_disk_space_usage:
         save_pretrained = save_pretrained.replace(
             "for shard_file, tensors in filename_to_tensors",
@@ -952,25 +1224,25 @@ pass
 def get_original_model_id(local_path: str):
     import json
     import os
-    
+
     config_path = os.path.join(local_path, "config.json")
     if os.path.exists(config_path):
         with open(config_path, "r") as f:
             config = json.load(f)
-            
+
         # Check for _name_or_path that's not a local path
         # When we load using AutoConfig, the _name_or_path changed into the local path instead
         if "_name_or_path" in config:
             return config["_name_or_path"]
-        
+
     config_path = os.path.join(local_path, "adapter_config.json")
     if os.path.exists(config_path):
         with open(config_path, "r") as f:
             config = json.load(f)
-            
+
         if "base_model_name_or_path" in config:
             return config["base_model_name_or_path"]
-    
+
     return None
 
 # Unsloth Zoo - Utilities for Unsloth


### PR DESCRIPTION
# Resolves:

- [[Bug] push_to_hub_merged does not upload model.safetensors.index.json](https://github.com/unslothai/unsloth/issues/2355)
- [[BUG] Gemma3 notebook: model.save_pretrained_merged() always downloads all safetensors every run](https://github.com/unslothai/unsloth/issues/2283)
- [model.save_pretrained_merged is trying to access the repository on the Hugging Face Hub](https://github.com/unslothai/unsloth/issues/2150)
- [Cannot save pretrained merged vision model locally](https://github.com/unslothai/unsloth/issues/1695)
- [HFValidationError Repo id & FileNotFoundError when merging lora model into a LOCAL base model](https://github.com/unslothai/unsloth/issues/2140)
- [OSError: does not appear to have a file named pytorch_model.bin, model.safetensors, tf_model.h5, model.ckpt or flax_model.msgpack](https://github.com/unslothai/unsloth/issues/1521)

# Problem Description

- push_to_hub_merged() fails to upload model.safetensors.index.json file for sharded models
- push_to_hub_merged() and save_pretrained_merged() always download model safetensors even if model has snapshot in local huggingface hub cache
- If using previously trained and merged model saved locally to continue lora finetuning, save_pretrained_merged() and push_to_hub_merged() fail to save or push to hub

# Reproduction Step

Refer to linked issues

# Updated Behavior

- Uploads model.safetensors.index.json for sharded models
- Uses local huggingface hub models cache instead of downloading every single time, if model is available in local cache.
- Properly handles saving, reloading, pushing to hub locally saved models.

# Testing

Ran extensive testing (50 testing runs in total) on:
- vision models: Gemma3, llama3.2, Qwen2.5
- text models: Llama3.1, GEmma3-1b

Ran 3 scenarios for each model.
## Scenario 1:
1. Pick any vision notebook from unsloth.ai [notebooks page](https://docs.unsloth.ai/get-started/unsloth-notebooks#vision-multimodal-notebooks)
2. Alternate between single file models like gemma-3-1b and sharded models like gemma3-4b or llama3.2-11b
3. Run notebook end to end , making sure to run ```save_pretrained_merged()``` and ```push_to_hub_merged()```
4. Make sure that operations have successfully completed.
5. Verify that model.safetensors.index.json is uploaded to the HuggingFace repo for sharded models.
6. observe how unsloth uses local huggingface hub cache if model has local snapshot in cache instead of downloading safetensors from HF repo, to merge model

## Scenario 2:
1. Load any adapter checkpoint resulting from Scenario 1, using ```FastVisualModel.from_pretrained(...)```
2. Skip finetuning and data prep
3. Run ```save_pretrained_merged()``` and ```push_to_hub_merged()```
4. Make sure the operations are successful and model.safetensors.index.json is uploaded for sharded models.
7. observe how unsloth uses local huggingface hub cache if model has local snapshot in cache instead of downloading safetensors from HF repo, to merge model

## Scenario 3:
1. Load merged local model from scenario 1.
2. Load peft layer
3. Data prep and finetune
4. Run ```save_pretrained_merged()``` and ```push_to_hub_merged()```
6. Check that the operations are successful and model.safetensors.index.json
8. observe how unsloth uses local huggingface hub cache if model has local snapshot in cache instead of downloading safetensors from HF repo, to merge model.


This PR should resolve most issues related to save_pretrained_merged() and push_to_hub_merged()
