### PR TITLE
Fix "Inference tensors cannot be saved for backward" when using add_new_tokens

### DIFF
--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -68,7 +68,6 @@ def mean_of_trained_tokens(model, eps = 1e-16):
 pass
 
 
-@torch.inference_mode
 def add_new_tokens(
     model,
     tokenizer,
@@ -157,13 +156,15 @@ def add_new_tokens(
             mean_lm_head_token   = mean_lm_head  *(1-interpolation) + mean_lm_head_token  *interpolation
 
             # Set the new vector
-            embedding_matrix[old_length+j] = mean_embedding_token
-            lm_head_matrix  [old_length+j] = mean_lm_head_token
+            with torch.no_grad():
+                embedding_matrix[old_length+j] = mean_embedding_token
+                lm_head_matrix  [old_length+j] = mean_lm_head_token
         pass
     else:
         # Now set the new tokens to the mean!
-        embedding_matrix[old_length:] = mean_embedding
-        lm_head_matrix  [old_length:] = mean_lm_head
+        with torch.no_grad():
+            embedding_matrix[old_length:] = mean_embedding
+            lm_head_matrix  [old_length:] = mean_lm_head
     pass
 
     # We set a flag to say we need to train embeddings


### PR DESCRIPTION
The `@torch.inference_mode` on top of `add_new_tokens` causes the `Inference tensors cannot be saved for backward` error during full fine-tuning because gradients seem to be turned off for lm_head weight under the inference_mode decorator. My workaround is to get rid of this decorator and wrap part of the function under `torch.no_grad` as needed. I'm not sure if this will allow correct gradient flow through the lm heads and embeddings during full fine-tuning, so I'd appreciate your review and feedback.

Illustration of the error:
```
model, tokenizer = FastLanguageModel.from_pretrained(
    model_name='Qwen/Qwen3-0.6B-Base',
    load_in_4bit=False,
    load_in_8bit=False,
    full_finetuning=True,
)

new_tokens = [f"<NEW_TOKEN_{i}>" for i in range(10)]
add_new_tokens(model, tokenizer, new_tokens=new_tokens)

# Training the modified model throws the following error

The new embeddings will be initialized from a multivariate normal distribution that has old embeddings' mean and covariance. As described in this article: https://nlp.stanford.edu/~johnhew/vocab-expansion.html. To disable this, use `mean_resizing=False`

`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "<project_dir>/train_llm.py", line 201, in <module>
    train_qwen_on_visual_tokens(cfg)
  File "<project_dir>/train_llm.py", line 158, in train_qwen_on_visual_tokens
    outputs = qwen_model(input_ids=input_ids, labels=lm_labels)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<python_libs>/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<python_libs>/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<compiled_qwen_module>/unsloth_compiled_module_qwen3.py", line 598, in forward
    return Qwen3ForCausalLM_forward(self, input_ids, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, output_attentions, output_hidden_states, cache_position, logits_to_keep, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<python_libs>/transformers/utils/generic.py", line 965, in wrapper
    output = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<python_libs>/transformers/utils/deprecation.py", line 172, in wrapped_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "<compiled_qwen_module>/unsloth_compiled_module_qwen3.py", line 464, in Qwen3ForCausalLM_forward
    logits = self.lm_head(hidden_states[:, slice_indices, :])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<python_libs>/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<python_libs>/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<python_libs>/torch/nn/modules/linear.py", line 125, in forward
    return F.linear(input, self.weight, self.bias)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Inference tensors cannot be saved for backward. To work around you can make a clone to get a normal tensor and use it in autograd.
```