### PR TITLE
Disable block pointer usage in Triton configuration

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1509,7 +1509,7 @@ def unsloth_compile_transformers(
         "disable_progress"          : not UNSLOTH_ENABLE_LOGGING,
         "verbose_progress"          : UNSLOTH_ENABLE_LOGGING,
         "triton.multi_kernel"       : False, # Sometimes fails
-        "triton.use_block_ptr"      : True,
+        "triton.use_block_ptr"      : False,
         "triton.enable_persistent_tma_matmul" : True,
         "triton.autotune_at_compile_time"     : True,
     }


### PR DESCRIPTION
Found this error when working on the VL model :

```
Invalid match!
Index: 64*s2*((yindex//s2)) + (ModularIndexing(yindex, 1, s2))
Matched expression: ps1*((yindex//s2)) + (ModularIndexing(yindex, 1, s2))
```

This issue is also mentioned in :
https://github.com/unslothai/unsloth/issues/2555
https://github.com/unslothai/unsloth/issues/2230#issuecomment-2886731523

After investigating, it's because of one of the compiler options that is just introduced in the latest PR. This can be easily replicated with : 

```python
import torch
from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import dynamic_rope_update

torch_compile_options = {
    'epilogue_fusion': True,
    'max_autotune': False,
    'shape_padding': True,
    'trace.enabled': True,
    'triton.cudagraphs': False,
    'debug': True,
    'dce': True,
    'memory_planning': True,
    'coordinate_descent_tuning': True,
    'trace.graph_diagram': True,
    'compile_threads': 24,
    'combo_kernels': False,
    'group_fusion': True,
    'disable_progress': False,
    'verbose_progress': True,
    'triton.multi_kernel': False,
    'triton.use_block_ptr': True,
    'triton.enable_persistent_tma_matmul': True,
    'triton.autotune_at_compile_time': True
}

@torch.compile(fullgraph = True, dynamic = True,  options = torch_compile_options)
@torch.no_grad()
def Qwen2_5_VLRotaryEmbedding_forward(x, position_ids):
    # Create inv_freq with typical values (assuming dim=128 for head dimension)
    dim = 128  # reasonable default for head dimension
    inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2).float().to("cuda") / dim))
    
    # In contrast to other models, Qwen2_5_VL has different position ids for the grids
    # So we expand the inv_freq to shape (3, ...)
    inv_freq_expanded = inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
    position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)

    attention_scaling = 1.0  # typical default value

    device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
    with torch.autocast(device_type=device_type, enabled=False):  # Force float32
        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(2, 3)
        emb = torch.cat((freqs, freqs), dim=-1)
        cos = emb.cos() * attention_scaling
        sin = emb.sin() * attention_scaling

    return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)

import torch

# Example parameters
batch_size = 2
seq_length = 16
hidden_size = 768  # Typical hidden size for language models
head_dim = 128     # As defined in the function

# Create example input tensor 'x'
# Shape: [batch_size, seq_length, hidden_size]
x = torch.randn(batch_size, seq_length, hidden_size, dtype=torch.bfloat16, device="cuda")

# Create example position_ids
# Shape: [3, batch_size, positions]
# The 3 represents the separate position ids for different parts of the model
# (typically for text, image grids, etc. in multimodal models)
position_ids = torch.arange(seq_length).to("cuda").unsqueeze(0).unsqueeze(0).expand(3, batch_size, -1)

# Now you can call the function with these inputs
cos, sin = Qwen2_5_VLRotaryEmbedding_forward(x, position_ids)

# Expected output shapes
print(f"Input x shape: {x.shape}")
print(f"Position IDs shape: {position_ids.shape}")
print(f"Output cos shape: {cos.shape}")  
print(f"Output sin shape: {sin.shape}")
```

And the fix is just disabling the block_ptr options. Perhaps this is latest torch error? Oh, Matthew is the one who found the solution.