### PR TITLE
Add _get_vocab_size utility function for config handling

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -611,6 +611,18 @@ def sft_prepare_dataset(
     return dataset
 pass
 
+def _get_vocab_size(config):
+    """
+    Safely get vocab_size from config, handling both old and new config structures.
+    New configs may have vocab_size in text_config.
+    """
+    if hasattr(config, 'vocab_size'):
+        return config.vocab_size
+    elif hasattr(config, 'text_config') and hasattr(config.text_config, 'vocab_size'):
+        return config.text_config.vocab_size
+    else:
+        raise AttributeError("Could not find vocab_size in config or text_config")
+
 # Unsloth Zoo - Utilities for Unsloth
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -23,6 +23,7 @@ import os
 import logging
 
 from .common import TEMPORARY_PATCHES, torch_compile_options
+from ..dataset_utils import _get_vocab_size
 
 logger = logging.getLogger(__name__)
 
@@ -284,7 +285,7 @@ def patch_Gemma3ForConditionalGeneration():
             # Flatten the tokens
             loss_fct = nn.CrossEntropyLoss()
 
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
+            flat_logits = shift_logits.view(-1, _get_vocab_size(self.config))
             flat_labels = shift_labels.view(-1).to(shift_logits.device)
             loss = loss_fct(flat_logits, flat_labels)
         loss = outputs.loss
@@ -376,7 +377,7 @@ def patch_Gemma3ForConditionalGeneration():
             # Flatten the tokens
             loss_fct = nn.CrossEntropyLoss()
 
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
+            flat_logits = shift_logits.view(-1, _get_vocab_size(self.config))
             flat_labels = shift_labels.view(-1).to(shift_logits.device)
             loss = loss_fct(flat_logits, flat_labels)
         loss = outputs.loss

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 import inspect
 from typing import List, Optional, Tuple, Union
 from .common import TEMPORARY_PATCHES
+from ..dataset_utils import _get_vocab_size
 
 
 def patch_SmolVLMForConditionalGeneration_forward():
@@ -44,7 +45,7 @@ def patch_SmolVLMForConditionalGeneration_forward():
     current_forward_source = inspect.getsource(
         transformers.models.smolvlm.modeling_smolvlm.SmolVLMForConditionalGeneration.forward
     )
-    if normalize_text("loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size, **kwargs)") in normalize_text(current_forward_source):
+    if normalize_text("loss = self.loss_function(logits=logits, labels=labels, vocab_size=_get_vocab_size(self.config), **kwargs)") in normalize_text(current_forward_source):
         return  # Already patched
 
     def forward(
@@ -269,7 +270,7 @@ def patch_CsmDepthDecoderForCausalLM_forward():
             shift_labels = labels[..., 1:].contiguous()
             loss_fct = ForCausalLMLoss
             loss = loss_fct(
-                logits=logits, labels=None, vocab_size=self.config.vocab_size, shift_labels=shift_labels, **kwargs
+                logits=logits, labels=None, vocab_size=_get_vocab_size(self.config), shift_labels=shift_labels, **kwargs
             )
 
         return CausalLMOutputWithPast(
@@ -359,7 +360,7 @@ def patch_CsmForConditionalGeneration_forward():
             # select first codebook as labels for the backbone model
             backbone_labels = labels[:, :, 0]
             backbone_loss = self.loss_function(
-                logits=backbone_logits, labels=backbone_labels, vocab_size=self.config.vocab_size, **kwargs
+                logits=backbone_logits, labels=backbone_labels, vocab_size=_get_vocab_size(self.config), **kwargs
             )
 
             # for the depth decoder, we need to select the frames to train on

--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -20,6 +20,7 @@ import numpy as np
 import itertools
 import datasets
 import re
+from .dataset_utils import _get_vocab_size
 
 __all__ = [
     "mean_of_trained_tokens",
@@ -109,7 +110,7 @@ def add_new_tokens(
     old_output_embedding = model.get_output_embeddings().weight
     old_input_length  = old_input_embedding .shape[0]
     old_output_length = old_output_embedding.shape[0]
-    old_config_size   = model.config.vocab_size
+    old_config_size   = _get_vocab_size(model.config)
 
     # Check for tied weights as well
     is_tied = (old_input_embedding.data_ptr() == old_output_embedding.data_ptr()) \
@@ -135,7 +136,7 @@ def add_new_tokens(
         raise RuntimeError(
             "Unsloth: LM Head matrix size did not get resized properly. Please file a bug report!"
         )
-    if model.config.vocab_size   != (old_config_size   + len(new_tokens)):
+    if _get_vocab_size(model.config) != (old_config_size + len(new_tokens)):
         raise RuntimeError(
             "Unsloth: Model's config vocab_size did not get resized properly. Please file a bug report!"
         )

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -48,6 +48,7 @@ import inspect
 from functools import partial
 from .utils import _get_dtype
 from .patching_utils import patch_model_and_tokenizer
+from .dataset_utils import _get_vocab_size
 global LORA_REQUEST_ID
 
 # Ignore logging messages
@@ -493,7 +494,7 @@ def get_vllm_state_dict(llm, return_state_dict = False, config = None):
     pass
 
     assert(config is not None)
-    vocab_size = config.vocab_size
+    vocab_size = _get_vocab_size(config)
 
     state_dict = OrderedDict()
     quant_state_dict = OrderedDict()


### PR DESCRIPTION
Introduced a new utility function, _get_vocab_size, to safely retrieve the vocab_size from both old and new config structures. Updated relevant files to utilize this function, ensuring consistent vocab_size access across the codebase.