### PR TITLE
N items qwen

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -969,7 +969,7 @@ def apply_fused_lm_head(forward):
                      r"self\.config\.vocab_size|"\
                      r"self\.config\.text_config\.vocab_size"\
                      ")")\
-            .replace("$KWARGS$", r"(?:, \*\*(loss_kwargs|kwargs))?")\
+            .replace("$KWARGS$",       r"(?:, \*\*(loss_kwargs|kwargs))?")\
             .replace("$LOGITSUPCAST$", r"(?:logits = logits\.float\(\))?")\
             .replace("$LABELSDEVICE$", r"(?:labels = labels\.to\([^\)]{1,}\))?")\
             .replace("$LOGITSCALINGMULTIPLY$",

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1065,12 +1065,12 @@ def apply_fused_lm_head(forward):
             "logits = EMPTY_LOGITS\n" + \
             (len(spaces)-4)*" " + "loss = None\n" + \
             replacement + "\n"
-
         try:
             forward = regex.sub(
                 cross_entropy_find,
                 replacement,
                 forward,
+                flags = regex.DOTALL | regex.MULTILINE,
             )
         except:
             continue


### PR DESCRIPTION
currently qwen 2.5 VL notebook fails on inference based on some recent changes to compiler.py. This is PR is a draft at a solution that aim's to be safe and backward compatible with old transformers versions.

Sometimes loss_kwargs and kwargs aren't ever matched and end up with an empty tuple, and then we fail to get `num_items_in_batch`. So now we make KWARGS a named group, place a sentinel in the replacement if needed, check for a match, and if not default to check loss_kwargs and kwargs.

Added bonus that ConditionalGeneration get's compiled for fast fuse linear.

Tested on Qwen 2.5VL notebook
https://colab.research.google.com/drive/1ANPMeUhUIdHaCy8qNecOdk42iSs_1KV2?usp=sharing