### PR TITLE
Update patching_utils.py

### DIFF
--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -593,7 +593,7 @@ if hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") a
     )
 
     score_code = """if name == 'score':
-        modules_to_not_convert.append("score")"""
+    modules_to_not_convert.append("score")"""
 
     pattern = r"(^\s*)(current_key_name\.append\(name\))"
 

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -565,7 +565,7 @@ if hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") a
 
         # will raise error if patch fails
         compile(new_source, '<temp_patched>', 'exec')
-        if '_mark_parent' not in new_source or '_unmark_parent' not in new_source:
+        if '_mark_parent' not in new_source and '_unmark_parent' not in new_source:
             do_logging = os.environ.get('UNSLOTH_ENABLE_LOGGING', '0') == '1'
             if do_logging:
                 print(f"Unsloth: Could not wrap replace_with_bnb_linear but may not be an issue")
@@ -587,11 +587,26 @@ if hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") a
             1,
         )
 
-    # Need more than 1 replacement since recursion is done
     source = source.replace(
         "_replace_with_bnb_linear",
         "_unsloth_replace_with_bnb_linear",
     )
+
+    score_code = """if name == 'score':
+        modules_to_not_convert.append("score")"""
+
+    pattern = r"(^\s*)(current_key_name\.append\(name\))"
+
+    def add_score_code(match):
+        indentation = match.group(1)  # Captured indentation
+        line_content = match.group(2) # The line 'current_key_name.append(name)'
+        
+        indented_breakpoint_code = "\n".join([f"{indentation}{line}" for line in score_code.splitlines()])
+        
+        return f"{indentation}{line_content}\n{indented_breakpoint_code}"
+
+    source = re.sub(pattern, add_score_code, source, flags=re.MULTILINE)
+
     exec(source, globals())
     transformers.integrations.bitsandbytes._replace_with_bnb_linear = _unsloth_replace_with_bnb_linear
 pass


### PR DESCRIPTION
This makes sure when loaded sequence classification score is not quantized, as transformers also should not quantize score when 4bit quantization is done. 