### PR TITLE
Add safeguard for missing quant_state in vision models

### DIFF
--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -284,6 +284,11 @@ def patch_model_and_tokenizer(
     for name, module in model.named_modules():
         if isinstance(module, (Bnb_Linear4bit, Peft_Linear4bit)):
             weight = module.weight
+            # Check if quant_state exists for vision models like unsloth/Llama-3.2-11B-Vision-Instruct-bnb-4bit, unsloth/granite-vision-3.2-2b
+            if not hasattr(weight, 'quant_state'):
+                print(f"Skipping {name}: no quant_state found")
+                continue
+
             quant_state = weight.quant_state
 
             if type(quant_state) is list:


### PR DESCRIPTION
This PR adds a check to safely skip vision models that do not have the quant_state attribute, such as:

unsloth/Llama-3.2-11B-Vision-Instruct-bnb-4bit

unsloth/granite-vision-3.2-2b

Without this check, attempting to access quant_state on these models results in an AttributeError. This update ensures robustness when loading or iterating over models in the unsloth_zoo package by printing a warning and continuing gracefully.

This pr is linked to [#2701](https://github.com/unslothai/unsloth/pull/2704)  pr in unsloth.