### PR TITLE
Update compiler.py - resolution of the encoding related error on windows

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -343,7 +343,8 @@ def create_new_function(
     if not overwrite and os.path.isfile(function_location):
 
         # Check if exactly equivalent
-        with open(function_location, "r") as f: file_source = f.read()
+        with open(function_location, "r", encoding="utf-8") as f:
+            file_source = f.read()
 
         if file_source != write_new_source:
             overwrite = True


### PR DESCRIPTION
On Linux and macOS, this defaults to UTF-8.
On many Windows systems, this defaults to cp1252.
So the current change will fix the encoding related error on windows machine especially the windows server