### PR TITLE
Fix Gemma3Model loss calculation for transformers v4.52.4 compatibility

### DIFF
--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -310,91 +310,93 @@ def patch_Gemma3ForConditionalGeneration():
         return
 
     def forward(
-        self,
-        input_ids: torch.LongTensor = None,
-        pixel_values: torch.FloatTensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[Union[List[torch.FloatTensor], Cache]] = None,
-        token_type_ids: Optional[torch.LongTensor] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        labels: Optional[torch.LongTensor] = None,
-        use_cache: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
-        logits_to_keep: Union[int, torch.Tensor] = 0,
-        **lm_kwargs,
-    ) -> Union[Tuple, Gemma3CausalLMOutputWithPast]:
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-        if labels is not None and attention_mask is not None:
-            attention_mask = attention_mask.to(device = labels.device)
-            labels[attention_mask == 0] = -100
-        pass
-        outputs = self.model(
-            input_ids=input_ids,
-            pixel_values=pixel_values,
-            token_type_ids=token_type_ids,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            inputs_embeds=inputs_embeds,
-            use_cache=use_cache,
-            labels=labels,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
-            cache_position=cache_position,
-            **lm_kwargs,
-        )
-        labels = None
-        # We NEVER ENTER if labels is not None: since we already accounted for it
-
-        hidden_states = outputs[0]
-        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-        logits = self.lm_head(hidden_states[:, slice_indices, :])
-
-        loss = None
-        if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            shift_logits = logits[..., :-1, :]
-            shift_labels = labels[..., 1:]
-            if attention_mask is not None:
-                # we use the input attention mask to shift the logits and labels, because it is 2D.
-                # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
-                shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
-                shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
-                shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
-            else:
-                shift_logits = shift_logits.contiguous()
-                shift_labels = shift_labels.contiguous()
-            # Flatten the tokens
-            loss_fct = nn.CrossEntropyLoss()
-
-            flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
-            flat_labels = shift_labels.view(-1).to(shift_logits.device)
-            loss = loss_fct(flat_logits, flat_labels)
-        loss = outputs.loss
-
-        if not return_dict:
-            output = (logits,) + outputs[1:]
-            return (loss,) + output if loss is not None else output
-
-        return Gemma3CausalLMOutputWithPast(
-            loss=loss,
-            logits=logits,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
-            image_hidden_states=outputs.image_hidden_states,
-        )
+      self,
+      input_ids: torch.LongTensor = None,
+      pixel_values: torch.FloatTensor = None,
+      attention_mask: Optional[torch.Tensor] = None,
+      position_ids: Optional[torch.LongTensor] = None,
+      past_key_values: Optional[Union[List[torch.FloatTensor], Cache]] = None,
+      token_type_ids: Optional[torch.LongTensor] = None,
+      cache_position: Optional[torch.LongTensor] = None,
+      inputs_embeds: Optional[torch.FloatTensor] = None,
+      labels: Optional[torch.LongTensor] = None,
+      use_cache: Optional[bool] = None,
+      output_attentions: Optional[bool] = None,
+      output_hidden_states: Optional[bool] = None,
+      return_dict: Optional[bool] = None,
+      logits_to_keep: Union[int, torch.Tensor] = 0,
+      **lm_kwargs,
+  ) -> Union[Tuple, Gemma3CausalLMOutputWithPast]:
+      # Initialize configuration flags
+      output_attentions = output_attentions or self.config.output_attentions
+      output_hidden_states = output_hidden_states or self.config.output_hidden_states
+      return_dict = return_dict or self.config.use_return_dict
+      
+      # Handle labels and attention mask
+      if labels is not None and attention_mask is not None:
+          attention_mask = attention_mask.to(device=labels.device)
+          # Clone labels to avoid modifying original tensor
+          labels = labels.clone()
+          labels[attention_mask == 0] = -100  # Ignore padding tokens in loss
+      pass
+      # Pass inputs to the model (without labels)
+      outputs = self.model(
+          input_ids=input_ids,
+          pixel_values=pixel_values,
+          token_type_ids=token_type_ids,
+          attention_mask=attention_mask,
+          position_ids=position_ids,
+          past_key_values=past_key_values,
+          inputs_embeds=inputs_embeds,
+          use_cache=use_cache,
+          output_attentions=output_attentions,
+          output_hidden_states=output_hidden_states,
+          return_dict=return_dict,
+          cache_position=cache_position,
+          **lm_kwargs,
+      )
+      
+      # Get hidden states and compute logits
+      hidden_states = outputs[0]
+      slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+      logits = self.lm_head(hidden_states[:, slice_indices, :])
+      
+      loss = None
+      if labels is not None:
+          logits = logits.float()
+          shift_logits = logits[..., :-1, :]
+          shift_labels = labels[..., 1:]
+          if attention_mask is not None:
+              # we use the input attention mask to shift the logits and labels, because it is 2D.
+              # we also crop attn mask in case it is longer, which happens in PrefixTuning with peft
+              shift_attention_mask = attention_mask[:, -shift_logits.shape[1] :].to(logits.device)
+              shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
+              shift_labels = shift_labels[shift_attention_mask.to(shift_labels.device) != 0].contiguous()
+          else:
+              shift_logits = shift_logits.contiguous()
+              shift_labels = shift_labels.contiguous()
+          
+          # Flatten tokens for loss calculation
+          loss_fct = nn.CrossEntropyLoss()
+          flat_logits = shift_logits.view(-1, self.config.text_config.vocab_size)
+          flat_labels = shift_labels.view(-1).to(shift_logits.device)
+          
+          # Compute loss (ignores positions with labels = -100)
+          loss = loss_fct(flat_logits, flat_labels)
+      
+      # Handle return types
+      if not return_dict:
+          output = (logits,) + outputs[1:]
+          return (loss,) + output if loss is not None else output
+      
+      return Gemma3CausalLMOutputWithPast(
+          loss=loss,
+          logits=logits,
+          past_key_values=outputs.past_key_values,
+          hidden_states=outputs.hidden_states,
+          attentions=outputs.attentions,
+          image_hidden_states=outputs.image_hidden_states,
+      )
     pass
 
     old_keys = inspect.signature(transformers.models.gemma3.modeling_gemma3.Gemma3ForConditionalGeneration.forward).parameters


### PR DESCRIPTION
This PR addresses the issue outlined in the linked GitHub [issue.](https://github.com/unslothai/unsloth/issues/2656#issuecomment-2933588699)

Problem:
Running the current code with the latest version of transformers raises the following error:
AttributeError: 'Gemma3ModelOutputWithPast' object has no attribute 'loss'.
This occurs because Gemma3Model (used in the current implementation) and therefore does not return a loss attribute by default.

Solution:
To fix this, we conditionally compute the loss only when labels are present, thereby bypassing the need for a loss attribute in the model output.

How to Test:
Run the modified code with the latest version of transformers. The error should no longer occur, and training/evaluation should proceed normally when labels are provided.

`
import torch
from datasets import load_from_disk
from unsloth import FastLanguageModel, is_bfloat16_supported, FastModel
from trl import SFTTrainer
from transformers import TrainingArguments

model, tokenizer = FastModel.from_pretrained(
    model_name = "unsloth/gemma-3-4b-it",
    max_seq_length = 2048,
    load_in_4bit = True,  
    load_in_8bit = False, 
    full_finetuning = False
)
model = FastModel.get_peft_model(
    model,
    finetune_vision_layers     = False, 
    finetune_language_layers   = True,  
    finetune_attention_modules = True, 
    finetune_mlp_modules       = True,  
    r = 8,          
    lora_alpha = 8,  
    lora_dropout = 0,
    bias = "none",
    random_state = 3407,
)
from unsloth.chat_templates import get_chat_template
tokenizer = get_chat_template(
    tokenizer,
    chat_template = "gemma-3",
)

from datasets import load_dataset

dataset = load_dataset("dvgodoy/yoda_sentences", split="train")
dataset

dataset = dataset.rename_column("sentence", "prompt")
dataset = dataset.rename_column("translation_extra", "completion")
dataset = dataset.remove_columns(["translation"])
dataset


from unsloth.chat_templates import standardize_data_formats
dataset = standardize_data_formats(dataset)
def to_conversations(batch): # This function converts my two column dataset into a single column "conversations".
    return {
        "conversations": [
            [
                {"role": "user",  "content": p},
                {"role": "model", "content": c},
            ]
            for p, c in zip(batch["prompt"], batch["completion"])
        ]
    }

dataset = dataset.map(to_conversations, batched=True, remove_columns=["prompt", "completion"])
def formatting_prompts_func(examples): # formatting func that was given in the notebook
   convos = examples["conversations"]
   texts = [tokenizer.apply_chat_template(convo, tokenize = False, add_generation_prompt = False).removeprefix('<bos>') for convo in convos]
   return { "text" : texts, }
dataset = dataset.map(formatting_prompts_func, batched = True)
dataset[0]["text"]





from trl import SFTTrainer, SFTConfig
from transformers import TrainingArguments

arg = args=TrainingArguments(                
        per_device_train_batch_size=1,
        per_device_eval_batch_size=1,
        gradient_accumulation_steps=4,
        num_train_epochs=10,
        # eval_strategy="steps",
        eval_steps=8,
        save_strategy="steps", 
        save_steps=100,
        learning_rate=5e-6,
        # fp16=not is_bfloat16_supported(),
        fp16=False,
        bf16=True,
        logging_steps=8,
        optim="adamw_8bit",
        weight_decay=0.01,
        lr_scheduler_type="linear",
        seed=3407,
        output_dir="./qwen3_screenplay_sft",
        report_to="none",
    )

trainer = SFTTrainer(
    model = model,
    tokenizer = tokenizer,
    train_dataset = dataset,
    eval_dataset = None, # Can set up evaluation!
    args = args)




from unsloth.chat_templates import train_on_responses_only
trainer = train_on_responses_only(
    trainer,
    instruction_part = "<start_of_turn>user\n",
    response_part = "<start_of_turn>model\n",
)

trainer.train()
`
