### PR TITLE
Fix Python 3.9 type hint compatibility

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -46,11 +46,11 @@ def get_peft_regex(
     finetune_language_layers   : bool = True,
     finetune_attention_modules : bool = True,
     finetune_mlp_modules       : bool = True,
-    target_modules             : list[str] = None,
-    vision_tags                : list[str] = ["vision", "image", "visual", "patch",],
-    language_tags              : list[str] = ["language", "text",],
-    attention_tags             : list[str] = ["self_attn", "attention", "attn",],
-    mlp_tags                   : list[str] = ["mlp", "feed_forward", "ffn", "dense",],
+    target_modules             : List[str] = None,
+    vision_tags                : List[str] = ["vision", "image", "visual", "patch",],
+    language_tags              : List[str] = ["language", "text",],
+    attention_tags             : List[str] = ["self_attn", "attention", "attn",],
+    mlp_tags                   : List[str] = ["mlp", "feed_forward", "ffn", "dense",],
 ) -> str:
     """
     Create a regex pattern to apply LoRA to only select layers of a model.

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -64,6 +64,7 @@ from transformers.modeling_utils import PushToHubMixin
 import json
 import os
 from pathlib import Path
+from typing import Union, List, Optional
 import tempfile
 from peft import PeftModelForCausalLM, PeftModel
 
@@ -863,10 +864,10 @@ pass
 
 def _try_copy_all_from_cache(
     repo_id: str,
-    filenames_to_check: list[str],
+    filenames_to_check: List[str],
     target_dir_str: str, # Expect string path for target directory
-    hf_cache_dir: Path | None,
-    token: str | None,
+    hf_cache_dir: Optional[Path],
+    token: Optional[str],
 ) -> bool:
     """
     Checks if ALL specified files exist in the HF cache. If yes, creates the
@@ -930,7 +931,7 @@ def _try_copy_all_from_cache(
         return False
 pass
 
-def _copy_file_from_source(src_path: str | Path, target_dir_str: str, filename: str):
+def _copy_file_from_source(src_path: Union[str, Path], target_dir_str: str, filename: str):
     """Copies a file from src_path to target_dir_str/filename using os.path."""
     src_path = Path(src_path) # Keep Path for source checking ease
     dst_path = os.path.join(target_dir_str, filename) # Use os.path.join for destination
@@ -946,7 +947,7 @@ def _copy_file_from_source(src_path: str | Path, target_dir_str: str, filename: 
         raise IOError(f"Failed to copy {src_path} to {dst_path}: {e}") from e
 pass
 
-def _get_hf_cache_dir() -> Path | None:
+def _get_hf_cache_dir() -> Optional[Path]:
     """Determines the Hugging Face Hub cache directory."""
     potential_paths = []
     if "HF_HUB_CACHE" in os.environ:

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -60,7 +60,7 @@ import base64
 from io import BytesIO
 import math
 import requests
-from typing import Union, Tuple
+from typing import Union, Tuple, List, Dict
 IMAGE_FACTOR = 28
 MIN_PIXELS = 4 * 28 * 28
 MAX_PIXELS = 16384 * 28 * 28
@@ -93,7 +93,7 @@ pass
 
 def smart_resize(
     height: int, width: int, factor: int = IMAGE_FACTOR, min_pixels: int = MIN_PIXELS, max_pixels: int = MAX_PIXELS
-) -> tuple[int, int]:
+) -> Tuple[int, int]:
     """
     Rescales the image so that the following conditions are met:
 
@@ -122,7 +122,7 @@ pass
 
 
 def fetch_image(
-    ele: dict[Union[Tuple[str, str], Image.Image]],
+    ele: Dict[Union[Tuple[str, str], Image.Image]],
     size_factor: int = IMAGE_FACTOR,
 ) -> Image.Image:
     if "image" in ele:
@@ -173,7 +173,7 @@ def fetch_image(
 pass
 
 
-def extract_vision_info(conversations: Union[list[dict], list[list[dict]]]) -> list[dict]:
+def extract_vision_info(conversations: Union[List[Dict], List[List[Dict]]]) -> List[Dict]:
     vision_infos = []
     if isinstance(conversations[0], dict):
         conversations = [conversations]
@@ -193,8 +193,8 @@ pass
 
 
 def process_vision_info(
-    conversations: Union[list[dict], list[list[dict]]],
-) -> tuple[Union[list[Image.Image], None], Union[list[Union[torch.Tensor, list[Image.Image]]], None]]:
+    conversations: Union[List[Dict], List[List[Dict]]],
+) -> Tuple[Union[List[Image.Image], None], Union[List[Union[torch.Tensor, List[Image.Image]]], None]]:
     vision_infos = extract_vision_info(conversations)
     ## Read images or videos
     image_inputs = []

--- a/unsloth_zoo/vllm_lora_request.py
+++ b/unsloth_zoo/vllm_lora_request.py
@@ -1,6 +1,6 @@
 # From https://github.com/vllm-project/vllm/pull/12609
 import warnings
-from typing import Optional
+from typing import Optional, Dict
 
 import msgspec
 import torch
@@ -28,12 +28,12 @@ class LoRARequest(
     lora_name: str
     lora_int_id: int
     lora_path: str = ""
-    lora_tensors: Optional[dict[str, torch.Tensor]] = None
-    lora_config: Optional[dict] = None,
+    lora_tensors: Optional[Dict[str, torch.Tensor]] = None
+    lora_config: Optional[Dict] = None,
     lora_local_path: Optional[str] = msgspec.field(default=None)
     long_lora_max_len: Optional[int] = None
     base_model_name: Optional[str] = msgspec.field(default=None)
-    lora_embeddings: Optional[dict[str, torch.Tensor]] = None
+    lora_embeddings: Optional[Dict[str, torch.Tensor]] = None
 
     @property
     def adapter_id(self):

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -478,7 +478,7 @@ def patch_vllm_enable_sleep_mode():
         gc.collect()
         torch.cuda.empty_cache()
 
-    def wake_up(self, tags: Optional[list[str]] = None) -> None:
+    def wake_up(self, tags: Optional[List[str]] = None) -> None:
         """
         Wake up the allocator from sleep mode.
         All data that is previously offloaded will be loaded back to GPU 


### PR DESCRIPTION
Replace pipe operator union types (|) with typing.Union for Python 3.9 compatibility. Update lowercase built-in type annotations (list, dict, tuple) to use capitalized typing imports (List, Dict, Tuple) as required for Python 3.9.

Changes:
- Replace str | None with Optional[str]
- Replace Path | None with Optional[Path]
- Replace str | Path with Union[str, Path]
- Replace list[str] with List[str]
- Replace dict[...] with Dict[...]
- Replace tuple[...] with Tuple[...]
- Add missing typing imports where needed