### PR TITLE
fix(compiler): Correct positional argument error in loss function patching for full finetuning

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -798,7 +798,7 @@ else:
         logits = logits / (\\4)
         logits = torch.tanh(logits)
         logits = logits * (\\4)
-    loss = self.loss_function(\\6, \\7.to(self.lm_head.weight.device), \\8, **\\9)
+    loss = self.loss_function(\\6, \\7.to(self.lm_head.weight.device), vocab_size=\\8, **\\9)
 """
 
 cross_entropy_find_3 = """


### PR DESCRIPTION
**Issue:**

When performing a full finetuning, a `SyntaxError: positional argument follows keyword argument` error occurs during the model compilation step.

This happens because the Unsloth compiler script (`models/compiler.py`) incorrectly patches the model's forward pass, specifically the call to `self.loss_function`. The script generates a function call where a positional argument for `vocab_size` is placed after keyword arguments for `logits` and `labels`.

**Example of erroneous generated code:**
```python
loss = self.loss_function(logits=logits, labels=labels.to(...), self.config.vocab_size, **kwargs)
```

**Root Cause:**

The regular expression for finding the `vocab_size` argument was designed to capture only the value (e.g., `self.config.vocab_size`), while the replacement string did not prepend the required `vocab_size=` keyword. This resulted in it being treated as a positional argument.

**Solution:**

This pull request fixes the issue by modifying the replacement string in `cross_entropy_replacement_2`. The fix explicitly adds the `vocab_size=` keyword in front of the captured `vocab_size` value.

**Change made in `unsloth/models/compiler.py`:**

```diff
- loss = self.loss_function(\\6, \\7.to(self.lm_head.weight.device), \\8, **\\9)
+ loss = self.loss_function(\\6, \\7.to(self.lm_head.weight.device), vocab_size=\\8, **\\9)
```
Fixes https://github.com/unslothai/unsloth/issues/2814

> **Note:** I noticed that sometimes simply rerunning the notebook cell would fix the issue. This might indicate that there is another issue with choosing the right patching strategies?