### PR TITLE
fixes base_model attribute error for 4bit merge save_pretrained_merged mode

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -689,10 +689,11 @@ def merge_and_overwrite_lora(
     if tokenizer is not None: tokenizer.save_pretrained(save_directory = save_directory,)
 
     # --- Handle 4-bit merging first ---
-    if save_method == "merged_4bit":
+    if save_method == "merged_4bit" or save_method == "forced_merged_4bit":
+        base_model = model.base_model if isinstance(model, PeftModel) else model
         print(f"Unsloth: Merging LoRA weights into 4bit model...")
-        if not isinstance(model, PeftModelForCausalLM):
-             raise TypeError("Model must be a PeftModelForCausalLM for 'merged_4bit' save.")
+        if not isinstance(model, PeftModelForCausalLM) or not isinstance(model, PeftModel):
+             raise TypeError("Model must be a PeftModelForCausalLM or PeftModel for 'merged_4bit' save.")
         if not getattr(model.config, "quantization_config", None):
              raise ValueError("Model does not appear to be quantized. Cannot use 'merged_4bit'.")
 


### PR DESCRIPTION
## Problem

We replaced base_model with inner_model in last logic rework for 16bit, while 4bit merge logic still references a base_model attribute. This resulted in attribute error while using "forced_merged_4bit" save_method when using save_pretrained_merged.

## Solution
This fixes the issue by reinstating base_model.
Also adds additional small checks

## Tests

Tested with Qwen2.5vl notebook on colab T4+HighRAM
Tested on LLama3.1-8b notebook on colab T4+HighRAM