### PR TITLE
Remove hardcode compile_threads number in unsloth_compile_transformers

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1636,7 +1636,6 @@ def unsloth_compile_transformers(
         "memory_planning"           : True,
         "coordinate_descent_tuning" : UNSLOTH_COMPILE_MAXIMUM,
         "trace.graph_diagram"       : UNSLOTH_COMPILE_DEBUG or debug,
-        "compile_threads"           : 24,
         "combo_kernels"             : False, # Causes incompatible gradient sizes on 2.6
         "group_fusion"              : True,
         "disable_progress"          : not UNSLOTH_ENABLE_LOGGING,


### PR DESCRIPTION
Current setting for `compile_threads` makes Windows functionality fail, only compile_threads=1 is supported on Windows.
`compile_threads` is Pytorch inductor module variable, so we can follow Pytorch `decide_compile_threads` logic without changing. I think this function already covered all cases. https://github.com/pytorch/pytorch/blob/ab2294d8289a7757a2fc321cdefac88e2b378edf/torch/_inductor/config.py#L771
```
    if "TORCHINDUCTOR_COMPILE_THREADS" in os.environ:
        compile_threads = int(os.environ["TORCHINDUCTOR_COMPILE_THREADS"])
        log.info("compile_threads set to %d via env", compile_threads)
    elif sys.platform == "win32":
        compile_threads = 1
        log.info("compile_threads set to 1 for win32")
    elif is_fbcode() and not parallel_compile_enabled_internally():
        compile_threads = 1
        log.info("compile_threads set to 1 in fbcode")
    else:
        cpu_count = (
            len(os.sched_getaffinity(0))
            if hasattr(os, "sched_getaffinity")
            else os.cpu_count()
        )
        assert cpu_count
        compile_threads = min(32, cpu_count)
        log.info("compile_threads set to %d", compile_threads)
```
if Windows, the number is 1, if Linux, which depends on cpu count, and the maximum number is 32.