### PR TITLE
Add `typing.Any` import to compiled files

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -342,6 +342,7 @@ def create_new_function(
     imports += "import torch\n"
     imports += "import torch.nn as nn\n"
     imports += "from torch.nn import functional as F\n"
+    imports += "from typing import Any\n"
     imports += f"from {model_location} import (" + ", ".join(x for x in items) + ")" if len(items) != 0 else ""
     new_source = imports + "\n\n" + new_source
     new_source = prepend + new_source + append


### PR DESCRIPTION
Looks like `peft==0.16.0` started type hinting functions and we hardcode our own imports, so update that to pull in the type hints it wants now If `peft<0.16.0` or something non-PEFT is being patched then this'll just be a useless import that doesn't do anything but doesn't waste any time