### PR TITLE
[intel] enable vllm for Intel GPU for unsloth

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -689,10 +689,11 @@ def merge_and_overwrite_lora(
     if tokenizer is not None: tokenizer.save_pretrained(save_directory = save_directory,)
 
     # --- Handle 4-bit merging first ---
-    if save_method == "merged_4bit":
+    if save_method == "merged_4bit" or save_method == "forced_merged_4bit":
+        base_model = model.base_model if isinstance(model, PeftModel) else model
         print(f"Unsloth: Merging LoRA weights into 4bit model...")
-        if not isinstance(model, PeftModelForCausalLM):
-             raise TypeError("Model must be a PeftModelForCausalLM for 'merged_4bit' save.")
+        if not isinstance(model, PeftModelForCausalLM) or not isinstance(model, PeftModel):
+             raise TypeError("Model must be a PeftModelForCausalLM or PeftModel for 'merged_4bit' save.")
         if not getattr(model.config, "quantization_config", None):
              raise ValueError("Model does not appear to be quantized. Cannot use 'merged_4bit'.")
 

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -70,6 +70,7 @@ def get_mem_info():
         free_memory, total_memory = torch.xpu.mem_get_info()
     else:
         free_memory, total_memory = torch.cuda.mem_get_info()
+    return free_memory, total_memory
 
 
 if importlib.util.find_spec("vllm") is not None:

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1186,7 +1186,7 @@ def load_vllm(
             print("Unsloth: Your GPU does not support prefix caching - will disable!")
             enable_prefix_caching = False
     elif DEVICE_TYPE == "xpu":
-        enable_prefix_caching = False
+        enable_prefix_caching = True
 
     pass
 
@@ -1268,11 +1268,7 @@ def load_vllm(
     )
 
     # Get device as well
-<<<<<<< HEAD
     device = get_target_device()
-=======
-    device = "cuda:0" if DEVICE_TYPE == "cuda" else "xpu:0"
->>>>>>> main
 
     if compilation_config == 3:
         try:

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1261,7 +1261,7 @@ def load_vllm(
     )
 
     # Get device as well
-    device = "cuda:0" if DEVICE_TYPE == "cuda" else "xpu:0"
+    device = get_target_device()
 
     if compilation_config == 3:
         try:


### PR DESCRIPTION
This pr aims at enable Intel GPU with vllm support for unsloth.
Currently, all Intel GPU use prefix_caching and use dtype=bf16 if possible.