### PR TITLE
include ALL_ATTENTION_FUNCTIONS in scaled_dot_product_attention_modules

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1734,7 +1734,7 @@ def unsloth_compile_transformers(
         except: continue
         if "_gradient_checkpointing_func" in source:
             gradient_checkpointed_modules.append(module)
-        elif "scaled_dot_product_attention" in source:
+        elif "scaled_dot_product_attention" in source or "ALL_ATTENTION_FUNCTIONS" in source:
             scaled_dot_product_attention_modules.append(module)
         elif "nn.functional.softmax" in source or "flash_attn_varlen_func" in source or "_flash_attention_forward" in source:
             full_attention_modules.append(module)


### PR DESCRIPTION
When testing the granite 4 model I noticed it was slower with the latest transformers and unsloth, and that the Fast Attention patch wasn't being applied. 

What changed in transformers?
Before:
```
attention_interface: Callable = eager_attention_forward
if self.config._attn_implementation != "eager":
    if self.config._attn_implementation == "sdpa" and kwargs.get("output_attentions", False):
        logger.warning_once(
            "`torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to "
            'eager attention. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
        )
    else:
        attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]

attn_output, attn_weights = attention_interface(...)
```

After:
```
        attention_interface: Callable = eager_attention_forward
        if self.config._attn_implementation != "eager":
            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]

        attn_output, attn_weights = attention_interface(...)
```

Since `scaled_dot_product_attention` is in the old source, the module get's torch compiled with sdpa compile options. But in the second version it doesn't get compiled. This change is to check for both ALL_ATTENTION_FUNCTIONS or scaled_dot_product_attention. In fact around 50-60 modules have this same change.

The downside with this approach is that someone can change the _attn_implementation to something other than spda and we'd still compile with sdpa_dynamic_compile options. Since the old behavior allowed for that I think that the proposed change still works.

granite notebook test:
https://colab.research.google.com/drive/1VHLjWq5LL46IGDkPaYeAXzIJRiWs9vD3?usp=sharing