### PR TITLE
Update vllm compatibility check for dequantization functions

### DIFF
--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -100,18 +100,26 @@ if importlib.util.find_spec("vllm") is not None:
     def _dequantize_dq(self, quant_states):
         return quant_states
 
-    import vllm.model_executor.model_loader.bitsandbytes_loader
-    if hasattr(
-        vllm.model_executor.model_loader.bitsandbytes_loader,
-        "dequantize_dq",
-    ):
-        vllm.model_executor.model_loader.bitsandbytes_loader.dequantize_dq = dequantize_dq
-    elif hasattr(
-        vllm.model_executor.model_loader.bitsandbytes_loader.BitsAndBytesModelLoader,
-        "_dequantize_dq",
-    ):
-        vllm.model_executor.model_loader.bitsandbytes_loader.BitsAndBytesModelLoader._dequantize_dq = _dequantize_dq
-    pass
+    # Only on old vllm
+    # Check if vllm is more than 0.9.0
+    from importlib.metadata import version as importlib_version
+    from packaging.version import Version
+
+    vllm_version = Version(importlib_version("vllm"))
+    is_vllm_new = vllm_version > Version("0.9.0")
+    if is_vllm_new:
+        import vllm.model_executor.model_loader.bitsandbytes_loader
+        if hasattr(
+            vllm.model_executor.model_loader.bitsandbytes_loader,
+            "dequantize_dq",
+        ):
+            vllm.model_executor.model_loader.bitsandbytes_loader.dequantize_dq = dequantize_dq
+        elif hasattr(
+            vllm.model_executor.model_loader.bitsandbytes_loader.BitsAndBytesModelLoader,
+            "_dequantize_dq",
+        ):
+            vllm.model_executor.model_loader.bitsandbytes_loader.BitsAndBytesModelLoader._dequantize_dq = _dequantize_dq
+        pass
 
     # Patch apply_bnb_4bit
     import vllm.model_executor.layers.quantization.bitsandbytes


### PR DESCRIPTION
`vllm.model_executor.model_loader.bitsandbytes_loader` only available on `vllm>=0.9.0` but our colab is working on `vllm==0.8.5.post1`. We cannot really upgrade the `vllm` version because it will reinstall colab's torch which currently is in `torch==2.6.0`.

 Hence, I just simply do a simple check to only do the patching if it's larger than 0.9.0