### PR TITLE
swap x with kwargs in loss_utils.py

### DIFF
--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -313,7 +313,7 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
                     mark_dynamic(attention_mask, 1)
                     token_count &= (attention_mask[..., 1:] != 0)
                 if "token_type_ids" in x:
-                    token_type_ids = kwargs["token_type_ids"]
+                    token_type_ids = x["token_type_ids"]
                     mark_static (token_type_ids, 0)
                     mark_dynamic(token_type_ids, 1)
                 token_counts.append(token_count.sum())


### PR DESCRIPTION
A few models erroring with a [KeyError](https://discord.com/channels/1179035537009545276/1391803826322800862/1395432886865367134)
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
/usr/local/lib/python3.11/dist-packages/unsloth_zoo/loss_utils.py in _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device, *args, **kwargs)
    315                 if "token_type_ids" in x:
--> 316                     token_type_ids = kwargs["token_type_ids"]
    317                     mark_static (token_type_ids, 0)

KeyError: 'token_type_ids'

During handling of the above exception, another exception occurred:

RuntimeError                              Traceback (most recent call last)
/usr/local/lib/python3.11/dist-packages/accelerate/utils/memory.py in decorator(*args, **kwargs)
    166             try:
--> 167                 return function(batch_size, *args, **kwargs)
    168             except Exception as e:

/usr/local/lib/python3.11/dist-packages/unsloth_zoo/compiler.py in _fast_inner_training_loop(self, batch_size, args, resume_from_checkpoint, trial, ignore_keys_for_eval)

/usr/local/lib/python3.11/dist-packages/unsloth_zoo/loss_utils.py in _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device, *args, **kwargs)
    327         except Exception as exception:
--> 328             raise RuntimeError(exception)
    329     pass

RuntimeError: 'token_type_ids'
```

the fix is a simple rename from kwargs to x, which I presume is the original intent of the code.


gemma 3 vision has the same error on colab, and this notebook test that the fix works. Etherl also confirmed on discord it doesn't have the error anymore.

https://colab.research.google.com/drive/13WDkAefYeYBSPNVpMqkxhsyIX1rOyKVv?usp=sharing