### PR TITLE
Fix: Add UTF-8 encoding to file read in logging_utils.py

### DIFF
--- a/unsloth_zoo/logging_utils.py
+++ b/unsloth_zoo/logging_utils.py
@@ -168,7 +168,7 @@ def get_trl_metrics():
     for trainer in trainers:
         filename = os.path.join(filepath, f"{trainer}.py")
         if not os.path.exists(filename): continue
-        with open(filename, "r") as file: file = file.read()
+        with open(filename, "r", encoding="utf-8") as file: file = file.read()
 
         # Get metrics['kl'] or stats['kl']
         metrics = re.findall(r"_?metrics\[[\"\']([^\"\']{1,})[\"\']\]", file)


### PR DESCRIPTION
Ran into an issue where Windows was unable to recognize the character encoding of the file being read in `logging_utils.py` adding UTF-8 appears to fix the issue.