### PR TITLE
Proposal: Allow env variable to override default cache location

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -57,7 +57,12 @@ global COMBINED_UNSLOTH_NAME
 COMBINED_UNSLOTH_NAME = "unsloth_compiled_module"
 
 global UNSLOTH_COMPILE_LOCATION
-UNSLOTH_COMPILE_LOCATION = "unsloth_compiled_cache"
+if 'UNSLOTH_COMPILE_LOCATION' not in globals():
+    _loc = os.getenv("UNSLOTH_COMPILE_LOCATION", None)
+    if _loc:
+        UNSLOTH_COMPILE_LOCATION = _loc
+    else:
+        UNSLOTH_COMPILE_LOCATION = "unsloth_compiled_cache"
 
 global UNSLOTH_COMPILE_USE_TEMP
 UNSLOTH_COMPILE_USE_TEMP = False


### PR DESCRIPTION
It doesn't seem possible to specify a compile cache folder and it would be nice to isolate runs that use the same script. This PR will still keep the default unsloth_compiled_cache folder but allow users to specify an env variable called UNSLOTH_COMPILE_LOCATION to use instead.

https://colab.research.google.com/drive/1fKdrrng-r2VV8xBSVXdoqOIYv-wwO4Hh?usp=sharing
