### PR TITLE
Removed deprecated ConstantLengthDataset import & check

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -477,7 +477,6 @@ pass
 
 
 from datasets import (Dataset, IterableDataset,)
-from trl.trainer.utils import ConstantLengthDataset
 # Faster SFTTrainer prepare_dataset
 def sft_prepare_dataset(
     self,
@@ -489,7 +488,6 @@ def sft_prepare_dataset(
     dataset_name: str,
 ) -> Union[Dataset, IterableDataset]:
     # All Unsloth Zoo code licensed under LGPLv3
-    if isinstance(dataset, ConstantLengthDataset): return dataset
 
     map_kwargs = {}
     use_desc = isinstance(dataset, Dataset)


### PR DESCRIPTION
#219 

Removed deprecated import & instance check for the now deprecated (https://github.com/huggingface/trl/commit/e102ac8df194caaa91ff1f40d6a757e6eada0352) `ConstantLengthDataset` from trl's latest version, 0.20.0