### PR TITLE
Fix: Remove problematic vision data checks.

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -181,12 +181,7 @@ def extract_vision_info(conversations: Union[List[Dict], List[List[Dict]]]) -> L
         for message in conversation:
             if isinstance(message["content"], list):
                 for ele in message["content"]:
-                    if (
-                        "image" in ele
-                        or "image_url" in ele
-                        or "video" in ele
-                        or ele["type"] in ("image", "image_url", "video")
-                    ):
+                    if ele["type"] in ("image", "image_url", "video"):
                         vision_infos.append(ele)
     return vision_infos
 pass


### PR DESCRIPTION
The `UnslothVisionDataCollator` should follow the conversational format and listen to the `type` field.

For example, in the following entry, it should understand that the type of the entry is `text`, but the old code would look for an image.
```py
{"type": "text", "text": "Hello", "image": None}
```
This scenario occurs when building datasets with HuggingFace, as it fills in None values to maintain column consistency.

It should be upon the user to make sure the `type` field is correct.