### PR TITLE
Fix/indentation compiler

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -206,6 +206,9 @@ def patch_GptOssExperts_MXFP4():
                 # are hit this time around
                 expert_hitted = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
             for expert_idx in expert_hitted[:]:
+                _expert_idx = expert_idx.item()
+                torch._check_is_size(_expert_idx)
+                torch._check(_expert_idx <= 512) # Large number for expert check
                 with torch.no_grad():
                     _, token_idx = torch.where(expert_mask[expert_idx[0]])
                 current_state = hidden_states[token_idx]


### PR DESCRIPTION
New push to main broke the patching of GptOss for Bitsandbytes

This is because the patching like `transformers.models.gpt_oss.modeling_gpt_oss.GptOssExperts = GptOssExperts` works like `inspect.getsource` where it captures the indentation of the class as well. The result is that in the `unsloth_compiled_module_gpt_oss.py` become something like this :

<img width="2336" height="1516" alt="image" src="https://github.com/user-attachments/assets/c1dc116c-9364-4409-8c4f-243316b72351" />

Therefore, the fix is just to remove the indentation by bringing the class to outside the function