### PR TITLE
fix Gemma3n: make image_features and audio_features optional in Gemma3nModel get_place_holder_mask()

### DIFF
--- a/unsloth_zoo/temporary_patches/gemma3n.py
+++ b/unsloth_zoo/temporary_patches/gemma3n.py
@@ -64,3 +64,57 @@ def patch_Gemma3nTextAltUp_functions():
         patch_function(transformers.models.gemma3n.modeling_gemma3n.Gemma3nTextAltUp, "scale_corrected_output", Gemma3nTextAltUp.scale_corrected_output, fullgraph = True)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma3nTextAltUp_functions)
+
+def patch_Gemma3nModel_get_placeholder_mask():
+    try:
+        import transformers.models.gemma3n.modeling_gemma3n
+        from transformers.models.gemma3n.modeling_gemma3n import Gemma3nModel
+    except Exception as e:
+        return raise_error("Gemma3nModel.get_place_holder_mask", e)
+
+    def get_placeholder_mask(
+        self,
+        input_ids: torch.LongTensor,
+        inputs_embeds: torch.FloatTensor,
+        image_features: Optional[torch.FloatTensor] = None,
+        audio_features: Optional[torch.FloatTensor] = None,
+    ):
+        """
+        Obtains multimodal placeholdr mask from `input_ids` or `inputs_embeds`, and checks that the placeholder token count is
+        equal to the length of multimodal features. If the lengths are different, an error is raised.
+        """
+        if input_ids is None:
+            special_image_mask = inputs_embeds == self.get_input_embeddings()(
+                torch.tensor(self.config.image_token_id, dtype=torch.long, device=inputs_embeds.device)
+            )
+            special_image_mask = special_image_mask.all(-1)
+            special_audio_mask = (
+                inputs_embeds
+                == self.get_input_embeddings()(
+                    torch.tensor(self.config.audio_token_id, dtype=torch.long, device=inputs_embeds.device)
+                )
+            ).all(-1)
+        else:
+            special_image_mask = input_ids == self.config.image_token_id
+            special_audio_mask = input_ids == self.config.audio_token_id
+
+        n_image_tokens = special_image_mask.sum()
+        special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+        if image_features is not None and inputs_embeds[special_image_mask].numel() != image_features.numel():
+            raise ValueError(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {image_features.shape[0] * image_features.shape[1]}"
+            )
+
+        n_audio_tokens = special_audio_mask.sum()
+        special_audio_mask = special_audio_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
+        if audio_features is not None and inputs_embeds[special_audio_mask].numel() != audio_features.numel():
+            raise ValueError(
+                f"Audio features and image tokens do not match: tokens: {n_audio_tokens}, features {audio_features.shape[0] * audio_features.shape[1]}"
+            )
+
+        return special_image_mask, special_audio_mask
+    pass
+    # fullgraph not used here as it breaks due to dynamic shapes
+    patch_function(transformers.models.gemma3n.modeling_gemma3n.Gemma3nModel, "get_placeholder_mask", get_placeholder_mask, match_level="relaxed")
+pass
+TEMPORARY_PATCHES.append(patch_Gemma3nModel_get_placeholder_mask)


### PR DESCRIPTION
### Problem
When using Gemma3n models with Unsloth (e.g., `unsloth/gemma-3n-E4B-it-unsloth-bnb-4bit`), the model fails during inference with the error:

```
TypeError: Gemma3nModel.get_placeholder_mask() missing 1 required positional argument: 'audio_features'
```

This occurs because the newly introduced `get_placeholder_mask()` transformers 4.55.0 method for the Gemma3n model requires 4 positional arguments (`input_ids`, `inputs_embeds`, `image_features`, `audio_features`), but the method is being called in the forward pass with only 3 arguments in some cases.

The issue stems from inconsistent method signatures in the transformers 4.55.0 library's Gemma3n implementation of `get_placeholder_mask()`, where:
1. The method signature requires both `image_features` and `audio_features` as mandatory parameters
2. But the forward method calls it with only one multimodal feature type at a time
3. This breaks multimodal inference for both vision-only and audio-only use cases

### Solution
Added a temporary patch in `unsloth_zoo/gemma3n.py` that modifies the `get_placeholder_mask()` method signature to make `image_features` and `audio_features` optional parameters with default values of `None`:

```python
def get_placeholder_mask(
    self,
    input_ids: torch.LongTensor,
    inputs_embeds: torch.FloatTensor,
    image_features: Optional[torch.FloatTensor] = None,
    audio_features: Optional[torch.FloatTensor] = None,
):
```

This patch:
- Makes both multimodal feature parameters optional to match the actual usage patterns in the forward method
- Maintains backward compatibility with existing code
- Allows the method to handle cases where only one type of multimodal feature is present
- Preserves all existing validation logic for feature/token count matching

The patch is applied through Unsloth's temporary patch system (`TEMPORARY_PATCHES`) and will be automatically applied when loading Gemma3n models until the upstream transformers library fixes this issue.

### Tests
The fix enables successful loading and inference with Gemma3n multimodal models:
- Vision tasks work correctly (image + text input)
- Audio tasks work correctly (audio + text input) 
- Mixed multimodal tasks work correctly
- Text-only tasks continue to work as expected

This resolves the immediate blocking issue for Gemma3n model usage in Unsloth while maintaining full functionality.
