### PR TITLE
fix: Add LRUCacheWorkerLoRAManager patching opt-out

### DIFF
--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -324,6 +324,8 @@ if importlib.util.find_spec("vllm") is not None:
             vllm.v1.worker.lora_model_runner_mixin.LRUCacheWorkerLoRAManager = PatchedLRUCacheWorkerLoRAManager
         except:
             pass
+        if os.getenv("UNSLOTH_DO_NOT_PATCH_V0_LRU_LORA_MANAGER", "0") == "1":
+            return
         try:
             import vllm.worker.model_runner
             vllm.worker.model_runner.LRUCacheWorkerLoRAManager = PatchedLRUCacheWorkerLoRAManager


### PR DESCRIPTION
In ART we've found patching the V0 LRUCacheWorkerLoRAManager breaks engine LoRA adapter loading. Sensitive to the fact that this patch was probably added for a good reason, we propose adding an opt-out environment variable. If you think we could remove the patching altogether let us know. Thanks in advance! 🙏