### PR TITLE
fix: Make `lora_tensors` check more robust

### DIFF
--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -177,7 +177,6 @@ class WorkerLoRAManager(AbstractWorkerManager):
                              f"is greater than lora_extra_vocab_size "
                              f"{self.lora_config.lora_extra_vocab_size}.")
         return lora
-      
 
     def add_dummy_lora(self, lora_request: LoRARequest, rank: int) -> bool:
         if lora_request.lora_int_id in self.list_adapters():
@@ -295,3 +294,4 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
                 lora_request.lora_int_id) is not None
         self._adapter_manager.activate_adapter(lora_request.lora_int_id)
         return loaded
+      

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -177,6 +177,7 @@ class WorkerLoRAManager(AbstractWorkerManager):
                              f"is greater than lora_extra_vocab_size "
                              f"{self.lora_config.lora_extra_vocab_size}.")
         return lora
+      
 
     def add_dummy_lora(self, lora_request: LoRARequest, rank: int) -> bool:
         if lora_request.lora_int_id in self.list_adapters():

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -131,7 +131,7 @@ class WorkerLoRAManager(AbstractWorkerManager):
                     and model.hf_to_vllm_mapper is not None):
                 hf_to_vllm_mapper = model.hf_to_vllm_mapper
 
-            if lora_request.lora_tensors is not None:
+            if getattr(lora_request, "lora_tensors", None) is not None:
                 lora = self._lora_model_cls.from_lora_tensors(
                     lora_model_id=lora_request.lora_int_id,
                     tensors=lora_request.lora_tensors,

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -294,4 +294,3 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
                 lora_request.lora_int_id) is not None
         self._adapter_manager.activate_adapter(lora_request.lora_int_id)
         return loaded
-      


### PR DESCRIPTION
Make the `lora_tensors` check more robust in case `LoRARequest` is a standard vLLM `LoRARequest` (such as when it is constructed by the OpenAI-compatible server).

Potentially a more "root cause" solution for addressing #237.