### PR TITLE
[Intel] remove triton windows for intel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ dependencies = [
     "typing_extensions",
 ]
 
-
-
 [tool.setuptools.dynamic]
 version = {attr = "unsloth_zoo.__init__.__version__"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "typing_extensions",
 ]
 
+
+
 [tool.setuptools.dynamic]
 version = {attr = "unsloth_zoo.__init__.__version__"}
 
@@ -58,6 +60,30 @@ exclude = ["images*"]
 
 [project.optional-dependencies]
 huggingface = [
+    "packaging>=24.1",
+    "tyro",
+    "transformers>=4.51.3,!=4.47.0,!=4.52.0,!=4.52.1,!=4.52.2,!=4.52.3",
+    "datasets>=3.4.1,<4.0.0",
+    "sentencepiece>=0.2.0",
+    "tqdm",
+    "psutil",
+    "wheel>=0.42.0",
+    "numpy",
+    "accelerate>=0.34.1",
+    "trl>=0.7.9,!=0.9.0,!=0.9.1,!=0.9.2,!=0.9.3,!=0.15.0,!=0.19.0",
+    "peft>=0.7.1,!=0.11.0",
+    "protobuf",
+    "huggingface_hub>=0.34.0",
+    "hf_transfer",
+    "cut_cross_entropy",
+    "pillow",
+    "regex",
+    "msgspec",
+    "typing_extensions",
+]
+intel-gpu = [
+    "torch>=2.4.0",
+    "triton ; platform_system == 'Linux'",
     "packaging>=24.1",
     "tyro",
     "transformers>=4.51.3,!=4.47.0,!=4.52.0,!=4.52.1,!=4.52.2,!=4.52.3",


### PR DESCRIPTION
Due to triton-windows is conflict with intel's triton, this pr will create a build option 'intel-gpu', once use this build option will not install triton-windows anymore