### PR TITLE
pixtral attention to temporary patches and remove compiler replacements

### DIFF
--- a/unsloth_zoo/compiler_replacements.py
+++ b/unsloth_zoo/compiler_replacements.py
@@ -20,63 +20,6 @@ __all__ = [
 
 compiler_replacements = {}
 
-compiler_replacements["PixtralAttention"] = \
-"""class PixtralAttention(torch.nn.Module):
-
-    def __init__(self, config):
-        super().__init__()
-        self.config = config
-        self.embed_dim = config.hidden_size
-        self.num_heads = config.num_attention_heads
-        self.head_dim = self.embed_dim // self.num_heads
-
-        self.scale = self.head_dim**-0.5
-        self.dropout = config.attention_dropout
-
-        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
-        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
-        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
-        self.o_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
-    pass
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_embeddings: Optional[torch.Tensor] = None,
-        output_attentions: Optional[bool] = False,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-
-        batch_size, patches, _ = hidden_states.size()
-
-        query_states = self.q_proj(hidden_states)
-        key_states   = self.k_proj(hidden_states)
-        value_states = self.v_proj(hidden_states)
-
-        query_states = query_states.view(batch_size, patches, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states   = key_states  .view(batch_size, patches, self.num_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(batch_size, patches, self.num_heads, self.head_dim).transpose(1, 2)
-
-        cos, sin = position_embeddings
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, unsqueeze_dim=0)
-
-        attn_output = torch.nn.functional.scaled_dot_product_attention(
-            query_states,
-            key_states,
-            value_states,
-            attn_mask = attention_mask,
-            dropout_p = self.dropout if self.training else 0.0,
-            scale     = self.scale,
-        )
-
-        attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.reshape(batch_size, patches, -1)
-        attn_output = self.o_proj(attn_output)
-        return attn_output, None
-    pass
-pass
-"""
-
 # Unsloth Zoo - Utilities for Unsloth
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -20,3 +20,4 @@ from .gemma import *
 from .misc import *
 from .gemma3n import *
 from .gpt_oss import *
+from .pixtral import *

--- a/unsloth_zoo/temporary_patches/pixtral.py
+++ b/unsloth_zoo/temporary_patches/pixtral.py
@@ -1,0 +1,98 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import torch
+import torch.nn as nn
+from typing import Optional, Tuple
+from .common import TEMPORARY_PATCHES
+from .utils import (
+    patch_function,
+    KWARGS_TYPE,
+    raise_error,
+)
+
+def patch_PixtralAttention():
+    try:
+        import transformers.models.pixtral.modeling_pixtral
+        from transformers.models.pixtral.modeling_pixtral import apply_rotary_pos_emb
+    except Exception as e:
+        return raise_error("PixtralAttention", e)
+
+    def __init__(self, config):
+        super(transformers.models.pixtral.modeling_pixtral.PixtralAttention, self).__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+
+        self.scale = self.head_dim**-0.5
+        self.dropout = config.attention_dropout
+
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
+        self.o_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
+    pass
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+        output_attentions: Optional[bool] = False,
+        **kwargs: KWARGS_TYPE,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+
+        batch_size, patches, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states   = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(batch_size, patches, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states   = key_states  .view(batch_size, patches, self.num_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(batch_size, patches, self.num_heads, self.head_dim).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, unsqueeze_dim=0)
+
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            attn_mask = attention_mask,
+            dropout_p = self.dropout if self.training else 0.0,
+            scale     = self.scale,
+        )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(batch_size, patches, -1)
+        attn_output = self.o_proj(attn_output)
+        return attn_output, None
+
+    patch_function(
+        transformers.models.pixtral.modeling_pixtral.PixtralAttention,
+        "__init__",
+        __init__,
+    )
+
+    patch_function(
+        transformers.models.pixtral.modeling_pixtral.PixtralAttention,
+        "forward",
+        forward,
+    )
+pass
+TEMPORARY_PATCHES.append(patch_PixtralAttention)


### PR DESCRIPTION
transformers updated pixtral attention forward to include kwargs. This PR moves the patch to temporary_patches and adds the kwarg check.

pixtral notebook: https://colab.research.google.com/drive/1QoFFflAKhESZUSg-DqBqm-5Wd7qvMtj3?usp=sharing
