### PR TITLE
Handle transformers move to dtype from torch_dtype

### DIFF
--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -1,0 +1,62 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import torch
+from transformers import PretrainedConfig
+HAS_TORCH_DTYPE = "torch_dtype" in PretrainedConfig.__doc__
+
+__all__ = [
+    "HAS_TORCH_DTYPE",
+    "dtype_from_config",
+    "add_dtype_kwargs",
+    "set_dtype_in_config",
+]
+
+def dtype_from_config(config):
+    return (
+        getattr(config, "dtype", None)
+        or getattr(config, "torch_dtype", None)
+    )
+
+def set_dtype_in_config(config, dtype):
+    try:
+        if HAS_TORCH_DTYPE:
+            setattr(config, "torch_dtype", dtype)
+        else:
+            setattr(config, "dtype", dtype)
+    except:
+        set_dtype_in_config_fallback(config, dtype)
+
+def set_dtype_in_config_fallback(config, dtype):
+    try:
+        string_dtype = str(dtype).split(".")[-1] if isinstance(dtype, torch.dtype) else dtype
+        if HAS_TORCH_DTYPE:
+            config.__dict__["torch_dtype"] = string_dtype
+        else:
+            config.__dict__["dtype"] = string_dtype
+    except:
+        if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
+            print("Unsloth: Failed to set dtype in config, fallback failed too")
+
+def add_dtype_kwargs(dtype, kwargs_dict=None):
+    if kwargs_dict is None:
+        kwargs_dict = {}
+    if HAS_TORCH_DTYPE:
+        kwargs_dict["torch_dtype"] = dtype
+    else:
+        kwargs_dict["dtype"] = dtype
+    return kwargs_dict

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -29,6 +29,7 @@ __all__ = [
 
 from .compiler import UNSLOTH_COMPILE_LOCATION
 from .utils import _get_dtype, Version
+from .hf_utils import dtype_from_config, set_dtype_in_config
 
 # Also disable compiling on bitsandbytes
 def patch_compiling_bitsandbytes():
@@ -250,20 +251,22 @@ def patch_model_and_tokenizer(
     assert(type(downcast_rope) is bool)
     import gc
 
-    # Fix torch_dtype
+    # Fix dtype
     m = model
     while hasattr(m, "model"):
         if hasattr(m, "config"):
-            if   m.config.torch_dtype ==  "float32": m.config.torch_dtype = torch.float32
-            elif m.config.torch_dtype == "bfloat16": m.config.torch_dtype = torch.bfloat16
-            elif m.config.torch_dtype ==  "float16": m.config.torch_dtype = torch.float16
+            config_dtype = dtype_from_config(m.config)
+            if   config_dtype ==  "float32": set_dtype_in_config(m.config, torch.float32)
+            elif config_dtype == "bfloat16": set_dtype_in_config(m.config, torch.bfloat16)
+            elif config_dtype ==  "float16": set_dtype_in_config(m.config, torch.float16)
         pass
         m = m.model
     pass
     if hasattr(m, "config"):
-        if   m.config.torch_dtype ==  "float32": m.config.torch_dtype = torch.float32
-        elif m.config.torch_dtype == "bfloat16": m.config.torch_dtype = torch.bfloat16
-        elif m.config.torch_dtype ==  "float16": m.config.torch_dtype = torch.float16
+        config_dtype = dtype_from_config(m.config)
+        if   config_dtype ==  "float32": set_dtype_in_config(m.config, torch.float32)
+        elif config_dtype == "bfloat16": set_dtype_in_config(m.config, torch.bfloat16)
+        elif config_dtype ==  "float16": set_dtype_in_config(m.config, torch.float16)
     pass
 
     # Also patch all dtypes - BnB seems to not allocate the correct type?
@@ -281,7 +284,7 @@ def patch_model_and_tokenizer(
     # Get most likely the correct data-type of the model
     if correct_dtype is None:
         try:
-            correct_dtype = _get_dtype(model.config.torch_dtype)
+            correct_dtype = _get_dtype(dtype_from_config(model.config))
         except:
             correct_dtype = model.get_input_embeddings().weight.dtype
     pass
@@ -329,13 +332,13 @@ def patch_model_and_tokenizer(
             module.to(module._pre_set_compute_dtype)
     pass
 
-    # Correct torch_dtype
+    # Correct dtype
     def __fix_dtype(config):
         if not hasattr(config, "to_dict"): return
         dicts = config.to_dict()
         for key, value in dicts.items():
-            if key == "torch_dtype":
-                setattr(config, "torch_dtype", correct_dtype)
+            if key == "torch_dtype" or key == "dtype":
+                set_dtype_in_config(config, correct_dtype)
             else:
                 __fix_dtype(getattr(config, key))
     m = model

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -22,6 +22,7 @@ __all__ = [
 import warnings
 from .peft_utils import get_lora_layer_modules
 from .utils import _get_dtype
+from .hf_utils import dtype_from_config
 
 MODEL_CARD = \
 """---
@@ -508,7 +509,7 @@ def prepare_saving(
         pass
     pass
 
-    if output_dtype is None: output_dtype = _get_dtype(model.config.torch_dtype)
+    if output_dtype is None: output_dtype = _get_dtype(dtype_from_config(model.config))
     assert(output_dtype in (torch.float32, torch.float16, torch.float64, torch.bfloat16))
     assert(type(torch.bfloat16) is torch.dtype)
     element_size = torch.tensor([], dtype = output_dtype).element_size()

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -29,6 +29,7 @@ from .utils import (
     logger,
     Cache,
 )
+from ..hf_utils import dtype_from_config
 torch_cuda_device = torch.cuda.device
 
 
@@ -435,7 +436,7 @@ class GptOssExperts(nn.Module):
         self.expert_dim = config.intermediate_size
         self.alpha = 1.702
         self.limit = getattr(config, "swiglu_limit", 7.0)
-        self.dtype = config.torch_dtype
+        self.dtype = dtype_from_config(config)
 
         self.gate_up_projs = nn.ModuleList([
             nn.Linear(self.hidden_size, 2 * self.expert_dim, dtype=self.dtype)
@@ -502,7 +503,7 @@ class GptOssTopKRouter(nn.Module):
         self.top_k = config.num_experts_per_tok
         self.num_experts = config.num_local_experts
         self.hidden_dim = config.hidden_size
-        self.linear = nn.Linear(self.hidden_dim, self.num_experts, dtype=config.torch_dtype)
+        self.linear = nn.Linear(self.hidden_dim, self.num_experts, dtype=dtype_from_config(config))
 
     @torch_compile(dynamic = True, fullgraph = True)
     def forward(self, hidden_states):

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -26,6 +26,7 @@ from packaging.version import Version
 import time
 from typing import Any, Optional, List, Dict, Tuple
 from .utils import _get_dtype
+from .hf_utils import dtype_from_config
 import os
 import re
 
@@ -106,7 +107,7 @@ def prepare_model_for_training(
     assert(type(train_lm_head) is bool)
     assert(type(float32_mixed_precision) is bool)
 
-    dtype = _get_dtype(model.config.torch_dtype)
+    dtype = _get_dtype(dtype_from_config(model.config))
     mixed_precision_dtype = torch.float32
     if dtype == torch.float16:
         # We need to upcast to float32
@@ -341,7 +342,8 @@ def unsloth_train(trainer):
 
     # Mixed precision scaling
     torch_version = torch.__version__
-    if model.config.torch_dtype == torch.float16:
+    config_dtype = dtype_from_config(model.config)
+    if config_dtype == torch.float16:
         mixed_precision = "fp16"
         mixed_dtype = torch.float16
         # torch.cuda.amp.autocast is deprecated >= 2.4

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -61,6 +61,7 @@ from io import BytesIO
 import math
 import requests
 from typing import Union, Tuple, List, Dict
+from .hf_utils import dtype_from_config, HAS_TORCH_DTYPE
 IMAGE_FACTOR = 28
 MIN_PIXELS = 4 * 28 * 28
 MAX_PIXELS = 16384 * 28 * 28
@@ -280,8 +281,8 @@ class UnslothVisionDataCollator:
 
         self.padding_token_ids = get_padding_tokens_ids(processor)
         self.dtype = _get_dtype(
-            model.config.torch_dtype \
-            if hasattr(model.config, "torch_dtype") else \
+            dtype_from_config(model.config)
+            if HAS_TORCH_DTYPE else
             model.get_input_embeddings().weight.dtype
         )
         self.ignore_index = ignore_index


### PR DESCRIPTION
The latest transformers is now using dtype instead of torch_dtype throughout. This PR handles this move as well as keep it BC for older transformer versions. 


Notebooks tested for training:
qwen3 sft: https://colab.research.google.com/drive/1a3GQf6fgiw8LvkcqUtjawweG-XNZoXsL?usp=sharing
llama 3.2: https://colab.research.google.com/drive/1xmHA144D_7BrXrsOYa4KRNf6Px0PDS_L?usp=sharing
gpt-oss: https://colab.research.google.com/drive/1ZonfSgVbuDBu8ZsbdUYQ1qpC4y5J5KlF?usp=sharing
gemma3n vision: https://colab.research.google.com/drive/1q_oXN7vARKPnV_Tgfn3CFhqIZvfsMa83?usp=sharing
grpo qwen3: https://colab.research.google.com/drive/1B247FF6xQSZhDYCitX90Eytsj2JSBz8X?usp=sharing
qwen 2.5vl: https://colab.research.google.com/drive/1xiGzQONx5J9cKbym-PEcsYY3b61jbjEA?usp=sharing
gemma3 270: https://colab.research.google.com/drive/1lCcO_5Ty32NtTRopZ2mSSk48_BC_YRJf?usp=sharing
orpheus: https://colab.research.google.com/drive/1aaqKA9CFkbkIh6-yFR7fO5mKcf8nVG9A?usp=sharing
grpo deepseek: https://colab.research.google.com/drive/1zbG-CXXT186V_o1cbK--g-f3zJakRwjF?usp=sharing