### PR TITLE
Update logging_utils.py, put entropy in removed metrics

### DIFF
--- a/unsloth_zoo/logging_utils.py
+++ b/unsloth_zoo/logging_utils.py
@@ -28,7 +28,8 @@ METRICS_MOVE_TO_END = [
 REMOVED_METRICS = [
     "num_tokens", # All extras - not necessary
     "mean_token_accuracy", # SFT extras
-
+    "entropy",
+    
     # GRPO extras
     "clip_ratio",
     'clip_ratio/low_mean',


### PR DESCRIPTION
So here is the cause of the issue: https://github.com/huggingface/trl/commit/da167d88b2d557b972cb608663344969bb909e56. SFT trainer added entropy as a new recorded metric recently and this pr just removes it from being recorded on jupyternotebooks. 