### PR TITLE
fix: transformers save_pretrained ignores empty state_dict in 45.6.0 …

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -862,6 +862,15 @@ def merge_and_overwrite_lora(
             save_directory = save_directory,
             state_dict = {},
         )
+        # Remove any weight files that shouldn't have been saved (transformers 4.56.0 bug)
+        import glob
+        weight_files = glob.glob(os.path.join(save_directory, "*.bin")) + \
+                       glob.glob(os.path.join(save_directory, "*.safetensors"))
+
+        for weight_file in weight_files:
+            os.remove(weight_file)
+            print(f"DEBUG: Removed incorrectly saved weight file: {os.path.basename(weight_file)}")
+
         _remove_quantization_config(config_path = Path(save_directory) / "config.json")
         # Remove the quantization_config in the config.json file if it exists,
     # as we are exporting the model in 16-bit format.


### PR DESCRIPTION
transformers save_pretrained ignores empty state_dict in new 4.56.0 version, while worked fine in previous versions (<=4.55.4). removing safetensors explicitely in saving_utils when removing dequantization from config to solve.

tested using sample scripts form https://github.com/rolandtannous/unsloth/tree/main/tests/saving/language_models and  https://github.com/rolandtannous/unsloth/tree/main/tests/saving/vision_models