### PR TITLE
configure proper handler for logging system

### DIFF
--- a/unsloth_zoo/log.py
+++ b/unsloth_zoo/log.py
@@ -23,4 +23,5 @@ import os
 UNSLOTH_ENABLE_LOGGING = os.environ.get("UNSLOTH_ENABLE_LOGGING",  "0") == "1"
 logger = logging.getLogger(__name__)
 if UNSLOTH_ENABLE_LOGGING:
+    logging.basicConfig(level=logging.DEBUG, format='%(name)s - %(levelname)s - %(message)s')
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
### Problem
The `logger.debug()` statements were not printing any output even when `UNSLOTH_ENABLE_LOGGING=1` was set. This occurred because while the logger's level was set to `DEBUG`, there was no handler configured to actually output the log messages.

### Solution
Added `logging.basicConfig()` to configure a default handler for the logging system. Python's logging requires two components to work:

1. **Logger level**: Controls what messages the logger accepts (we had this)
2. **Handler**: Actually outputs/processes the messages (we were missing this)

Without `basicConfig()`, the logger accepts DEBUG messages but has nowhere to send them. The `basicConfig()` call creates a default console handler that prints messages to stderr, allowing our debug output to become visible.