### PR TITLE
[ROCm] add hip device path

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -77,6 +77,8 @@ minor = None
 if DEVICE_TYPE == "cuda":
     major, minor = torch.cuda.get_device_capability()
     OLD_CUDA_ARCH_VERSION = (major <= 7) and (minor < 5)
+elif DEVICE_TYPE == "hip":
+    OLD_CUDA_ARCH_VERSION = False
 elif DEVICE_TYPE == "xpu":
     OLD_CUDA_ARCH_VERSION = False
 pass

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -53,6 +53,12 @@ if DEVICE_TYPE == "cuda":
     else:
         HAS_CUT_CROSS_ENTROPY = False
     pass
+elif DEVICE_TYPE == "hip":
+    try:
+        from cut_cross_entropy import linear_cross_entropy
+        HAS_CUT_CROSS_ENTROPY = True
+    except:
+        HAS_CUT_CROSS_ENTROPY = False
 elif DEVICE_TYPE == "xpu":
     try:
         from cut_cross_entropy import linear_cross_entropy

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -72,6 +72,8 @@ def _return_self(self, *args, **kwargs): return self
 def _return_self_tokenizer(self, *args, **kwargs): return self.tokenizer
 
 def get_target_device(index = 0):
+    if DEVICE_TYPE == "hip":
+        return torch.device("cuda", index)
     return torch.device(DEVICE_TYPE, index)
 
 def get_mem_info():
@@ -1332,6 +1334,8 @@ def load_vllm(
 
     # Get correct dtype
     if DEVICE_TYPE == "cuda" and major_version >= 8: _dtype = torch.bfloat16
+    elif DEVICE_TYPE == "hip":
+        _dtype = torch.bfloat16
     elif DEVICE_TYPE == "xpu":
         _dtype = torch.bfloat16
     else:
@@ -1380,6 +1384,8 @@ def load_vllm(
         if (major_version < 7) or (major_version == 7 and minor_version < 5):
             print("Unsloth: Your GPU does not support prefix caching - will disable!")
             enable_prefix_caching = False
+    elif DEVICE_TYPE == "hip":
+        enable_prefix_caching = True
     elif DEVICE_TYPE == "xpu":
         enable_prefix_caching = True
 


### PR DESCRIPTION
This patch is to add hip specific device code path into unsloth-zoo so we willl fold amd related change into this code path without interference on other hardware device e.g. cuda, xpu. cc @danielhanchen @shimmyshimmer 