### PR TITLE
Fix MoE loading in 4bit

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -33,11 +33,12 @@ import re
 # Skip some modules sensitive to quantization
 SKIP_QUANTIZATION_MODULES = [
     "lm_head",
-    "multi_modal_projector", # Llama 3.2 Vision, Pixtral, Llava
-    "merger",                # Qwen2 VL
-    "modality_projection",   # Idefics, SmolVLM
-    "router",                # MoE Router
-    "gate",                  # MoE Router
+    "multi_modal_projector",    # Llama 3.2 Vision, Pixtral, Llava
+    "merger",                   # Qwen2 VL
+    "modality_projection",      # Idefics, SmolVLM
+    "router",                   # MoE Router
+    "mlp.gate",                 # MoE Router
+    "block_sparse_moe.gate",    # MoE Router
     'mamba',
 ]
 


### PR DESCRIPTION
Currently, `gate` is a SKIP module, so the accelerate memory planner checks if `'gate' in module_name`, and since gate will match gate_up_proj from_pretrained estimates the memory usage in full precision rather than 4bit. For a smaller GPU, this ends up spilling over the the cpu which is problematic. 

This PR scopes gate SKIP_QUANTIZATION_MODULE so it doesn't include gate_up*. Manual search for models with gate modules shows that they sit in mlp.gate (most models) or block_sparse_moe.gate (Mixtral). 

Notebook showing that we can load and train the qwen3_moe model on an L4. 
https://colab.research.google.com/drive/15hXmzRnUnOWQIQguJqXsQaSHtZGvFF-p?usp=sharing

