### PR TITLE
fix csm for latest transformers

### DIFF
--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -178,7 +178,11 @@ def patch_CsmDepthDecoderForCausalLM_forward():
         logits_to_keep: Union[int, torch.Tensor] = 0,
         **kwargs: KWARGS_TYPE,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
-        return old_forward(**locals())
+        new_kwargs = locals().copy()
+        new_kwargs.pop('old_forward', None)
+        kwargs = new_kwargs.pop('kwargs', dict())
+        new_kwargs.update(kwargs)
+        return old_forward(**new_kwargs)
     patch_function(transformers.models.csm.modeling_csm.CsmDepthDecoderForCausalLM, "forward", forward)
 pass
 TEMPORARY_PATCHES.append(patch_CsmDepthDecoderForCausalLM_forward)
@@ -329,7 +333,11 @@ def patch_CsmForConditionalGeneration_forward():
         logits_to_keep: Union[int, torch.Tensor] = 0,
         **kwargs: KWARGS_TYPE,
     ) -> Union[Tuple, CsmOutputWithPast]:
-        return old_forward(**locals())
+        new_kwargs = locals().copy()
+        new_kwargs.pop('old_forward', None)
+        kwargs = new_kwargs.pop('kwargs', dict())
+        new_kwargs.update(kwargs)
+        return old_forward(**new_kwargs)
     patch_function(transformers.models.csm.modeling_csm.CsmForConditionalGeneration, "forward", forward)
 pass
 TEMPORARY_PATCHES.append(patch_CsmForConditionalGeneration_forward)


### PR DESCRIPTION
The temporary patches were not unpacking kwargs and num_items_in_batch was not getting passed. This PR Fixes the issue.

Tested on T4 and works.
https://colab.research.google.com/drive/1tiqNqkCy-zugBCXshpXgEO09N19p6xd5?usp=sharing