### PR TITLE
Add video processing utils to vision_utils

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -59,9 +59,29 @@ from PIL import Image
 import base64
 from io import BytesIO
 import math
+import time
+import warnings
+import os
+from functools import lru_cache
+
+
 import requests
+import torchvision
+from packaging import version
 from typing import Union, Tuple, List, Dict
+try:
+    from torchvision import io, transforms
+    from torchvision.transforms import InterpolationMode
+    HAS_TORCHVISION = True
+except:
+    HAS_TORCHVISION = False
+
+from .log import logger
+
 from .hf_utils import dtype_from_config, HAS_TORCH_DTYPE
+
+UNSLOTH_ENABLE_LOGGING  = os.environ.get("UNSLOTH_ENABLE_LOGGING",  "0") == "1"
+
 IMAGE_FACTOR = 28
 MIN_PIXELS = 4 * 28 * 28
 MAX_PIXELS = 16384 * 28 * 28
@@ -69,7 +89,9 @@ MAX_RATIO = 200
 
 VIDEO_MIN_PIXELS = 128 * 28 * 28
 VIDEO_MAX_PIXELS = 768 * 28 * 28
-VIDEO_TOTAL_PIXELS = 24576 * 28 * 28
+VIDEO_TOTAL_PIXELS = int(float(os.environ.get('VIDEO_MAX_PIXELS', 128000 * 28 * 28 * 0.9)))
+if UNSLOTH_ENABLE_LOGGING:
+    logger.info(f"Unsloth: set VIDEO_TOTAL_PIXELS: {VIDEO_TOTAL_PIXELS}")
 FRAME_FACTOR = 2
 FPS = 2.0
 FPS_MIN_FRAMES = 4
@@ -94,7 +116,7 @@ pass
 
 def smart_resize(
     height: int, width: int, factor: int = IMAGE_FACTOR, min_pixels: int = MIN_PIXELS, max_pixels: int = MAX_PIXELS
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     """
     Rescales the image so that the following conditions are met:
 
@@ -123,7 +145,7 @@ pass
 
 
 def fetch_image(
-    ele: Dict,
+    ele: dict,
     size_factor: int = IMAGE_FACTOR,
 ) -> Image.Image:
     if "image" in ele:
@@ -173,6 +195,332 @@ def fetch_image(
     return image
 pass
 
+def smart_nframes(
+    ele: dict,
+    total_frames: int,
+    video_fps: Union[int, float],
+) -> int:
+    """calculate the number of frames for video used for model inputs.
+
+    Args:
+        ele (dict): a dict contains the configuration of video.
+            support either `fps` or `nframes`:
+                - nframes: the number of frames to extract for model inputs.
+                - fps: the fps to extract frames for model inputs.
+                    - min_frames: the minimum number of frames of the video, only used when fps is provided.
+                    - max_frames: the maximum number of frames of the video, only used when fps is provided.
+        total_frames (int): the original total number of frames of the video.
+        video_fps (int | float): the original fps of the video.
+
+    Raises:
+        ValueError: nframes should in interval [FRAME_FACTOR, total_frames].
+
+    Returns:
+        int: the number of frames for video used for model inputs.
+    """
+    assert not ("fps" in ele and "nframes" in ele), "Only accept either `fps` or `nframes`"
+    if "nframes" in ele:
+        nframes = round_by_factor(ele["nframes"], FRAME_FACTOR)
+    else:
+        fps = ele.get("fps", FPS)
+        min_frames = ceil_by_factor(ele.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR)
+        max_frames = floor_by_factor(ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)), FRAME_FACTOR)
+        nframes = total_frames / video_fps * fps
+        if nframes > total_frames:
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.warning(f"Unsloth: smart_nframes: nframes[{nframes}] > total_frames[{total_frames}]")
+        nframes = min(min(max(nframes, min_frames), max_frames), total_frames)
+        nframes = floor_by_factor(nframes, FRAME_FACTOR)
+    if not (FRAME_FACTOR <= nframes and nframes <= total_frames):
+        raise ValueError(f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}.")
+    return nframes
+
+
+def _read_video_torchvision(
+    ele: dict,
+) -> tuple[torch.Tensor, float]:
+    """read video using torchvision.io.read_video
+
+    Args:
+        ele (dict): a dict contains the configuration of video.
+        support keys:
+            - video: the path of video. support "file://", "http://", "https://" and local path.
+            - video_start: the start time of video.
+            - video_end: the end time of video.
+    Returns:
+        torch.Tensor: the video tensor with shape (T, C, H, W).
+    """
+    video_path = ele["video"]
+    if version.parse(torchvision.__version__) < version.parse("0.19.0"):
+        if "http://" in video_path or "https://" in video_path:
+            warnings.warn("torchvision < 0.19.0 does not support http/https video path, please upgrade to 0.19.0.")
+        if "file://" in video_path:
+            video_path = video_path[7:]
+    st = time.time()
+    video, audio, info = io.read_video(
+        video_path,
+        start_pts=ele.get("video_start", 0.0),
+        end_pts=ele.get("video_end", None),
+        pts_unit="sec",
+        output_format="TCHW",
+    )
+    total_frames, video_fps = video.size(0), info["video_fps"]
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(f"Unsloth: torchvision:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
+    nframes = smart_nframes(ele, total_frames=total_frames, video_fps=video_fps)
+    idx = torch.linspace(0, total_frames - 1, nframes).round().long()
+    sample_fps = nframes / max(total_frames, 1e-6) * video_fps
+    video = video[idx]
+    return video, sample_fps
+
+
+def is_decord_available() -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec("decord") is not None
+
+
+def calculate_video_frame_range(
+    ele: dict,
+    total_frames: int,
+    video_fps: float,
+) -> tuple[int, int, int]:
+    """
+    Calculate the start and end frame indices based on the given time range.
+
+    Args:
+        ele (dict): A dictionary containing optional 'video_start' and 'video_end' keys (in seconds).
+        total_frames (int): Total number of frames in the video.
+        video_fps (float): Frames per second of the video.
+
+    Returns:
+        tuple: A tuple containing (start_frame, end_frame, frame_count).
+
+    Raises:
+        ValueError: If input parameters are invalid or the time range is inconsistent.
+    """
+    # Validate essential parameters
+    if video_fps <= 0:
+        raise ValueError("video_fps must be a positive number")
+    if total_frames <= 0:
+        raise ValueError("total_frames must be a positive integer")
+
+    # Get start and end time in seconds
+    video_start = ele.get("video_start", None)
+    video_end = ele.get("video_end", None)
+    if video_start is None and video_end is None:
+        return 0, total_frames - 1, total_frames
+
+    max_duration = total_frames / video_fps
+    # Process start frame
+    if video_start is not None:
+        video_start_clamped = max(0.0, min(video_start, max_duration))
+        start_frame = math.ceil(video_start_clamped * video_fps)
+    else:
+        start_frame = 0
+    # Process end frame
+    if video_end is not None:
+        video_end_clamped = max(0.0, min(video_end, max_duration))
+        end_frame = math.floor(video_end_clamped * video_fps)
+        end_frame = min(end_frame, total_frames - 1)
+    else:
+        end_frame = total_frames - 1
+
+    # Validate frame order
+    if start_frame >= end_frame:
+        raise ValueError(
+            f"Invalid time range: Start frame {start_frame} (at {video_start_clamped if video_start is not None else 0}s) "
+            f"exceeds end frame {end_frame} (at {video_end_clamped if video_end is not None else max_duration}s). "
+            f"Video duration: {max_duration:.2f}s ({total_frames} frames @ {video_fps}fps)"
+        )
+
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(f"Unsloth: calculate video frame range: {start_frame=}, {end_frame=}, {total_frames=} from {video_start=}, {video_end=}, {video_fps=:.3f}")
+    return start_frame, end_frame, end_frame - start_frame + 1
+
+
+def _read_video_decord(
+    ele: dict,
+) -> tuple[torch.Tensor, float]:
+    """read video using decord.VideoReader
+
+    Args:
+        ele (dict): a dict contains the configuration of video.
+        support keys:
+            - video: the path of video. support "file://", "http://", "https://" and local path.
+            - video_start: the start time of video.
+            - video_end: the end time of video.
+    Returns:
+        torch.Tensor: the video tensor with shape (T, C, H, W).
+    """
+    import decord
+    video_path = ele["video"]
+    st = time.time()
+    vr = decord.VideoReader(video_path)
+    total_frames, video_fps = len(vr), vr.get_avg_fps()
+    start_frame, end_frame, total_frames = calculate_video_frame_range(
+        ele,
+        total_frames,
+        video_fps,
+    )
+    nframes = smart_nframes(ele, total_frames=total_frames, video_fps=video_fps)
+    idx = torch.linspace(start_frame, end_frame, nframes).round().long().tolist()
+    video = vr.get_batch(idx).asnumpy()
+    video = torch.tensor(video).permute(0, 3, 1, 2)  # Convert to TCHW format
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(f"Unsloth: decord:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
+    sample_fps = nframes / max(total_frames, 1e-6) * video_fps
+    return video, sample_fps
+
+
+def is_torchcodec_available() -> bool:
+    """Check if torchcodec is available and properly installed."""
+    try:
+        import importlib.util
+        if importlib.util.find_spec("torchcodec") is None:
+            return False
+        from torchcodec.decoders import VideoDecoder
+        return True
+    except (ImportError, AttributeError, Exception):
+        return False
+
+
+def _read_video_torchcodec(
+    ele: dict,
+) -> tuple[torch.Tensor, float]:
+    """read video using torchcodec.decoders.VideoDecoder
+
+    Args:
+        ele (dict): a dict contains the configuration of video.
+        support keys:
+            - video: the path of video. support "file://", "http://", "https://" and local path.
+            - video_start: the start time of video.
+            - video_end: the end time of video.
+    Returns:
+        torch.Tensor: the video tensor with shape (T, C, H, W).
+    """
+    from torchcodec.decoders import VideoDecoder
+    TORCHCODEC_NUM_THREADS = int(os.environ.get('TORCHCODEC_NUM_THREADS', 8))
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(f"Unsloth: set TORCHCODEC_NUM_THREADS: {TORCHCODEC_NUM_THREADS}")
+    video_path = ele["video"]
+    st = time.time()
+    decoder = VideoDecoder(video_path, num_ffmpeg_threads=TORCHCODEC_NUM_THREADS)
+    video_fps = decoder.metadata.average_fps
+    total_frames = decoder.metadata.num_frames
+    start_frame, end_frame, total_frames = calculate_video_frame_range(
+        ele,
+        total_frames,
+        video_fps,
+    )
+    nframes = smart_nframes(ele, total_frames=total_frames, video_fps=video_fps)
+    idx = torch.linspace(start_frame, end_frame, nframes).round().long().tolist()
+    sample_fps = nframes / max(total_frames, 1e-6) * video_fps
+    video = decoder.get_frames_at(indices=idx).data
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(f"Unsloth: torchcodec:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
+    return video, sample_fps
+
+
+VIDEO_READER_BACKENDS = {
+    "decord": _read_video_decord,
+    "torchvision": _read_video_torchvision,
+    "torchcodec": _read_video_torchcodec,
+}
+
+FORCE_UNSLOTH_VIDEO_READER = os.getenv("FORCE_UNSLOTH_VIDEO_READER", None)
+
+
+@lru_cache(maxsize=1)
+def get_video_reader_backend() -> str:
+    if FORCE_UNSLOTH_VIDEO_READER is not None:
+        video_reader_backend = FORCE_UNSLOTH_VIDEO_READER
+    elif is_torchcodec_available():
+        video_reader_backend = "torchcodec"
+    elif is_decord_available():
+        video_reader_backend = "decord"
+    elif HAS_TORCHVISION:
+        video_reader_backend = "torchvision"
+    else:
+        raise ValueError("Unsloth: No video reader backend available, please install decord or torchvision or torchcodec to process video inputs.")
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(f"Unsloth: unsloth_zoo/vision_utils using {video_reader_backend} to read video.")
+    return video_reader_backend
+
+
+def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> Union[torch.Tensor, list[Image.Image]]:
+    if isinstance(ele["video"], str):
+        video_reader_backend = get_video_reader_backend()
+        try:
+            video, sample_fps = VIDEO_READER_BACKENDS[video_reader_backend](ele)
+        except Exception as e:
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.warning(f"Unsloth: video_reader_backend {video_reader_backend} error, use torchvision as default, msg: {e}")
+            video, sample_fps = VIDEO_READER_BACKENDS["torchvision"](ele)
+
+        nframes, _, height, width = video.shape
+        min_pixels = ele.get("min_pixels", VIDEO_MIN_PIXELS)
+        total_pixels = ele.get("total_pixels", VIDEO_TOTAL_PIXELS)
+        max_pixels = max(min(VIDEO_MAX_PIXELS, total_pixels / nframes * FRAME_FACTOR), int(min_pixels * 1.05))
+        max_pixels_supposed = ele.get("max_pixels", max_pixels)
+
+        if max_pixels_supposed > max_pixels:
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.warning(f"Unsloth: The given max_pixels[{max_pixels_supposed}] exceeds limit[{max_pixels}].")
+
+        max_pixels = min(max_pixels_supposed, max_pixels)
+
+        if "resized_height" in ele and "resized_width" in ele:
+            resized_height, resized_width = smart_resize(
+                ele["resized_height"],
+                ele["resized_width"],
+                factor=image_factor,
+            )
+        else:
+            resized_height, resized_width = smart_resize(
+                height,
+                width,
+                factor=image_factor,
+                min_pixels=min_pixels,
+                max_pixels=max_pixels,
+            )
+        video = transforms.functional.resize(
+            video,
+            [resized_height, resized_width],
+            interpolation=InterpolationMode.BICUBIC,
+            antialias=True,
+        ).float()
+        if return_video_sample_fps:
+            return video, sample_fps
+        return video
+    else:
+        assert isinstance(ele["video"], (list, tuple))
+        process_info = ele.copy()
+        process_info.pop("type", None)
+        process_info.pop("video", None)
+        images = [
+            fetch_image({"image": video_element, **process_info}, size_factor=image_factor)
+            for video_element in ele["video"]
+        ]
+        nframes = ceil_by_factor(len(images), FRAME_FACTOR)
+        if len(images) < nframes:
+            images.extend([images[-1]] * (nframes - len(images)))
+        if return_video_sample_fps:
+            return images, process_info.pop("fps", 2.0)
+        return images
+
+def collapse_fps(fps, tol=1e-4):
+    """Return a single float if all fps equal (within tol), else a list; pass None through."""
+    if fps is None:
+        return None
+    if isinstance(fps, (int, float)):
+        return float(fps)
+    vals = [float(v) for v in fps]
+    if not vals:
+        return None
+    f0 = vals[0]
+    return float(f0) if all(isclose(v, f0, rel_tol=tol, abs_tol=tol) for v in vals[1:]) else vals
+
 
 def extract_vision_info(conversations: Union[List[Dict], List[List[Dict]]]) -> List[Dict]:
     vision_infos = []
@@ -191,22 +539,31 @@ pass
 def process_vision_info(
     conversations: Union[List[Dict], List[List[Dict]]],
     size_factor: int = IMAGE_FACTOR,
+    return_video_kwargs: bool = False,
 ) -> Tuple[Union[List[Image.Image], None], Union[List[Union[torch.Tensor, List[Image.Image]]], None]]:
+    
     vision_infos = extract_vision_info(conversations)
+   
     ## Read images or videos
     image_inputs = []
     video_inputs = []
+    video_sample_fps_list = []
+
     for vision_info in vision_infos:
         if "image" in vision_info or "image_url" in vision_info:
             image_inputs.append(fetch_image(vision_info, size_factor=size_factor))
         elif "video" in vision_info:
-            video_inputs.append(fetch_video(vision_info))
+            video_input, video_sample_fps = fetch_video(vision_info, image_factor=size_factor, return_video_sample_fps=True)
+            video_sample_fps_list.append(video_sample_fps)
+            video_inputs.append(video_input)
         else:
             raise ValueError("image, image_url or video should in content.")
     if len(image_inputs) == 0:
         image_inputs = None
     if len(video_inputs) == 0:
         video_inputs = None
+    if return_video_kwargs:
+        return image_inputs, video_inputs, {'fps': video_sample_fps_list}
     return image_inputs, video_inputs
 pass
 
@@ -416,6 +773,8 @@ class UnslothVisionDataCollator:
 
         texts  = []
         images = []
+        videos = []
+        video_kwargs = {'fps': []}
         for example in examples:
             messages = self._select_messages_or_raw(example)
 
@@ -436,9 +795,15 @@ class UnslothVisionDataCollator:
             )
             texts.append(message)
             # Dataset with 2 columns messages / images
-            image = self._extract_images_for_example(example, messages)
+            image, video, video_kwarg = self._extract_images_videos_for_example(example, messages)
             image = self._resize_images_inplace(image)
             images.append(image)
+
+            if len(video) > 0:  # Works for list, tuple or tensor
+                videos.append(video)
+                if video_kwarg is None:
+                    video_kwarg = {"fps": []}
+                video_kwargs['fps'].extend(video_kwarg['fps'])
         pass
 
         # Tokenize the texts and process the images
@@ -451,6 +816,11 @@ class UnslothVisionDataCollator:
             return_tensors="pt",
             add_special_tokens=False,
         )
+        if len(videos) > 0:
+            proc_kwargs["videos"] = videos
+            video_kwargs["fps"] = collapse_fps(video_kwargs['fps'])
+            for k, v in video_kwargs.items():
+                proc_kwargs[k] = v
         if self.pad_to_multiple_of is not None:
             proc_kwargs["pad_to_multiple_of"] = self.pad_to_multiple_of
         batch = self.processor(**proc_kwargs)
@@ -513,13 +883,21 @@ class UnslothVisionDataCollator:
             messages, tokenize=False, add_generation_prompt=False
         )
 
-    def _extract_images_for_example(self, example, messages):
+    def _extract_images_videos_for_example(self, example, messages):
         if "images" in example:
             image = [example["images"][0]]
+            video = []
+            video_kwarg = None
         else:
-            image, video = process_vision_info(messages, size_factor=self.patch_size*2)
+            image, video, video_kwarg = process_vision_info(
+                messages,
+                size_factor=self.patch_size*2,
+                return_video_kwargs=True,
+            )
             if image is None: image = []
-        return image
+            if video is None: video = [] 
+        pass
+        return image, video, video_kwarg
 
     def _extract_images_for_pc(self, example, p_msgs, c_msgs):
         # PC: prefer embedded across prompt+completion; else top-level first image; else []
@@ -527,14 +905,18 @@ class UnslothVisionDataCollator:
         try:
             msg_list = (p_msgs or []) + (c_msgs or [])
             if msg_list:
-                imgs, _ = process_vision_info(msg_list, size_factor=self.patch_size*2)
+                imgs, vids, vids_kwarg = process_vision_info(
+                    msg_list,
+                    size_factor=self.patch_size*2,
+                    return_video_kwargs=True,
+                )
+                if imgs is None: imgs = []
+                if vids is None: vids = []
         except Exception:
-            imgs = None
-        if imgs is None:
-            if "images" in example:
-                return [example["images"][0]]
-            return []
-        return imgs
+            imgs = []
+            vids = []
+        
+        return imgs, vids, vids_kwarg
 
     def _resize_images_inplace(self, image):
 


### PR DESCRIPTION
This is a cleaned up and merged version of
https://github.com/unslothai/unsloth-zoo/pull/240.

This adds video processing utilities for VLM finetuning.

It's based on qwen-vl-utils repo https://github.com/QwenLM/Qwen2.5-VL/tree/main/qwen-vl-utils

I tested all the Vision notebooks to confirm everything works. Video Finetuning notebook on the way.

Gemma3: https://colab.research.google.com/drive/1gzVgFvFou6dTE9UvMZR5DEiQTzqc3A4S?usp=sharing
Llama Vision: https://colab.research.google.com/drive/1E2xCsbh7-raFYMtkbFOwgvcfIyn64zLL?usp=sharing
Pixtral: https://colab.research.google.com/drive/1meeeZnE-IlV9IRuEUFqgbUNFpwxtrN5g?usp=sharing
Qwen 2.5VL: https://colab.research.google.com/drive/1RrRUnHBLMPSWfzHoc853iij4O4Yly7fr?usp=sharing

*qwen 2.5vl was tested with transformers 4.56.1