### PR TITLE
Add lora merge in mxfp4 format support for openai gpt-oss

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1074,7 +1074,7 @@ def merge_and_overwrite_lora(
     # Step 3: Conditional index handling
     import subprocess
     is_t4 = "Tesla T4" in str(torch.cuda.get_device_name(0))
-    needs_splitting = should_split_shards(is_t4, config, safetensors_list)
+    needs_splitting = should_split_shards(is_t4, config, safetensors_list) if save_method == "merged_16bit" else False
     _hf_cache_dir = _get_hf_cache_dir()
     copied_all_from_cache = False
     safe_tensor_index_files = ["model.safetensors.index.json"] if len(safetensors_list) > 1 else []
@@ -1124,7 +1124,7 @@ def merge_and_overwrite_lora(
     final_safetensors_list = []
 
     # Step 5: Iterate through original shards, merge LoRA, and overwrite/save
-    for filename in ProgressBar(safetensors_list, desc = "Unsloth: Merging weights into 16bit"):
+    for filename in ProgressBar(safetensors_list, desc = "Unsloth: Preparing safetensor model files"):
         file_path = os.path.join(save_directory, filename)
         # Only download if we didn't get everything from cache AND this specific file doesn't exist
         # AND we're in low disk space mode


### PR DESCRIPTION
## Overview
This PR introduces support for saving and merging loras into a model in MXFP4 quantization format 

## Changes Made

### Merging gpt-oss in mxfp4
Introduced a new `save_method="mxfp4"` parameter to the `_merge_and_overwrite_lora` function.
When activated:
- Preserves MXFP4 quantization for MOE layers during LoRA merge
- MXFP4 tensors (`*_blocks`, `*_scales`) remain untouched in their quantized format
- Other tensors are processed normally with LoRA weights merged
- Enables efficient storage while maintaining quantized model benefit

### Default Behavior
When `save_method="merged_16bit"` (default)
- Maintains existing behavior - fully backward compatible
- MXFP4 models are converted to 16-bit during merge using the safe rewrite strategy

## Using
To save and merge gpt-oss in 'mxfp4':
```
model.save_pretrained_merged(save_directory, tokenizer, save_method="mxfp4")
```
To save , merge and push gpt-oss to hub in 'mxfp4' format:
```
model.push_to_hub_merged("RTannous/gpt-oss-merged-mxfp4",tokenizer, token="hf_...", save_method="mxfp4")
```

## Tests

- Ran [gpt-oss-finetuning](https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/gpt-oss-(20B)-Fine-tuning.ipynb) on H100 , calling `save_pretrained_merged` with `save_method="mxfp4"`
- Successfully ran GGUF conversion and inference on merged mxfp4  model using llama.cpp
- Successfully loaded model using `FastLanguageModel` with `load_in_4bit=True` and ran inference
- Successfully loaded model and ran inference using transformers library
- Colab T4 [notebook](https://colab.research.google.com/drive/1Zq3PTePcl2CuKsbmRjoSaexeEbj-Wyhl?usp=sharing)demo with gpt-oss 20b
- Colab A100 [notebook](https://colab.research.google.com/drive/1HxA5FPzhcP_Yd7keDQWo9rEbXRgpX-tm?usp=sharing) with gpt-oss 120b. save and merge time of 120b got reduced from 45 mins-1hr  to 5mins with mxfp4.


