### PR TITLE
fix tensor write dtype to match original tensor dtype in mixed precision models

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -472,6 +472,7 @@ def _merge_and_overwrite_lora(
                 action_logged = False
                 # Standard 16-bit model
                 W = file.get_tensor(key)
+                W_original_dtype = W.dtype
 
                 if W is None:
                     continue
@@ -485,7 +486,7 @@ def _merge_and_overwrite_lora(
                     count += 1
 
                 # FIXED: Direct tensor writing using torch
-                success = _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key, W, output_dtype)
+                success = _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key, W, W_original_dtype)
 
                 if not success:
                     raise RuntimeError(f"Failed to write tensor to model file.")


### PR DESCRIPTION
Current version of `_write_tensor_direct_torch` method uses model's config `torch_dtype` setting as dtype of tensors that are to be written back into the base model. However some base models like `csm`, are mixed precision models with some parameters having `float16` while others have `float32 precision` and the model's `config.dtype` shows `float16`.

This can lead to size mismatch problems as the method tries to write a tensor in `float32` back into a tensor that should be in `float16`

We change the method to actually identify and use the original dtype of each tensor and use that while overwriting tensor in base model file.