### PR TITLE
Update compiler.py: resolve AttributeError when loading Qwen3 models with LoRA adapters

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2235,6 +2235,7 @@ def unsloth_compile_transformers(
                 if x in source_code:
                     can_remove = False
                     break
+            pass
             if can_remove: remove_causal_masks.append(module)
         pass
     pass

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2212,18 +2212,29 @@ def unsloth_compile_transformers(
     remove_causal_masks = []
     if disable_causal_masks:
         for module in other_classes:
-            source = eval(f"{model_location}.{module}")
-            if not hasattr(source, "_update_causal_mask"): continue
-
-            try: source = inspect.getsource(source.__init__)
-            except: continue
-
+            try:
+                mod = eval(model_location)
+                if not hasattr(mod, module):
+                    continue
+                source = getattr(mod, module)
+            except (AttributeError, NameError, SyntaxError) as e:
+                # print debug and skip
+                print(f"Warning: Skip {model_location}.{module} - {e}")
+                continue
+                
+            if not hasattr(source, "_update_causal_mask"): 
+                continue
+    
+            try: 
+                source_code = inspect.getsource(source.__init__)
+            except: 
+                continue
+    
             can_remove = True
             for x in disabled_scaled_dot_product_attention_modules:
-                if x in source:
+                if x in source_code:
                     can_remove = False
                     break
-            pass
             if can_remove: remove_causal_masks.append(module)
         pass
     pass


### PR DESCRIPTION
## PR Description
Fixes [#3376](https://github.com/unslothai/unsloth/issues/3376)

This PR resolves an `AttributeError` that occurs when loading Qwen3 models with LoRA adapters using `FastLanguageModel.from_pretrained()`. The error was caused by unsafe attribute access during model compilation.

## Problem
When compiling certain model types (particularly Qwen3), the code attempted to access attributes that don't exist in the transformers module, specifically:
```python
AttributeError: module 'transformers.models.bit.modeling_bit' has no attribute 'Linear'
```

This prevented users from directly loading models with LoRA adapters, forcing them to use a two-stage loading process.
