### PR TITLE
Fix getattr fallback bug in GPT-OSS causal mask creation causing Type Error

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -982,14 +982,18 @@ def patch_GptOssModel():
     pass
     create_causal_mask = getattr(
         transformers.masking_utils,
-        "create_causal_mask",
-        getattr(transformers.masking_utils,"_old_create_causal_mask"),
+        "_old_create_causal_mask",
+        getattr(transformers.masking_utils, "create_causal_mask", None),
     )
     create_sliding_window_causal_mask = getattr(
         transformers.masking_utils,
-        "create_sliding_window_causal_mask",
-        getattr(transformers.masking_utils, "_old_create_sliding_window_causal_mask"),
+        "_old_create_sliding_window_causal_mask",
+        getattr(transformers.masking_utils, "create_sliding_window_causal_mask", None),
     )
+    if create_causal_mask is None:
+        return raise_error("transformers.masking_utils.create_causal_mask")
+    if create_sliding_window_causal_mask is None:
+        return raise_error("transformers.masking_utils.create_sliding_window_causal_mask")
     if not hasattr(transformers.masking_utils, "__patched_causal_mask__"):
         transformers.masking_utils._old_create_causal_mask = _torch_compile(transformers.masking_utils.create_causal_mask, fullgraph = False, dynamic = True)
         transformers.masking_utils._old_create_sliding_window_causal_mask = _torch_compile(transformers.masking_utils.create_sliding_window_causal_mask, fullgraph = False, dynamic = True)

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -982,13 +982,13 @@ def patch_GptOssModel():
     pass
     create_causal_mask = getattr(
         transformers.masking_utils,
-        "_old_create_causal_mask",
-        getattr(transformers.masking_utils,"create_causal_mask"),
+        "create_causal_mask",
+        getattr(transformers.masking_utils,"_old_create_causal_mask"),
     )
     create_sliding_window_causal_mask = getattr(
         transformers.masking_utils,
-        "_old_create_sliding_window_causal_mask",
-        getattr(transformers.masking_utils, "create_sliding_window_causal_mask"),
+        "create_sliding_window_causal_mask",
+        getattr(transformers.masking_utils, "_old_create_sliding_window_causal_mask"),
     )
     if not hasattr(transformers.masking_utils, "__patched_causal_mask__"):
         transformers.masking_utils._old_create_causal_mask = _torch_compile(transformers.masking_utils.create_causal_mask, fullgraph = False, dynamic = True)

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -983,12 +983,12 @@ def patch_GptOssModel():
     create_causal_mask = getattr(
         transformers.masking_utils,
         "_old_create_causal_mask",
-        "create_causal_mask",
+        getattr(transformers.masking_utils,"create_causal_mask"),
     )
     create_sliding_window_causal_mask = getattr(
         transformers.masking_utils,
         "_old_create_sliding_window_causal_mask",
-        "create_sliding_window_causal_mask",
+        getattr(transformers.masking_utils, "create_sliding_window_causal_mask"),
     )
     if not hasattr(transformers.masking_utils, "__patched_causal_mask__"):
         transformers.masking_utils._old_create_causal_mask = _torch_compile(transformers.masking_utils.create_causal_mask, fullgraph = False, dynamic = True)

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -51,13 +51,13 @@ from .common import UNSLOTH_ENABLE_LOGGING, UNSLOTH_COMPILE_DISABLE, torch_compi
 
 EMPTY = inspect._empty
 
-def raise_error(f: str, exception: Any):
+def raise_error(f: str, exception: Any = None):
     # Raises error only if logging is on
     if UNSLOTH_ENABLE_LOGGING:
         logger.error(
             f"==================\n"\
             f"Failed to patch {f}. Error\n"\
-            f"{str(exception)}\n"\
+            f"{str(exception) if exception is not None else ''}\n"\
             f"==================\n"
         )
     return


### PR DESCRIPTION
### Problem
When loading models with unsloth, I encountered a `TypeError: 'str' object is not callable` originating from the gptoss patch linked to the causal mask creation 
```
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/support/.local/share/mamba/envs/unsloth_main_repo/lib/python3.11/site-packages/unsloth_zoo/temporary_patches/unsloth_compiled_cache/unsloth_compiled_module_llava.py", line 492, in prepare_inputs_for_generation
    model_inputs = super().prepare_inputs_for_generation(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/support/.local/share/mamba/envs/unsloth_main_repo/lib/python3.11/site-packages/transformers/generation/utils.py", line 653, in prepare_inputs_for_generation
    attention_mask = causal_mask_creation_function(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/support/.local/share/mamba/envs/unsloth_main_repo/lib/python3.11/site-packages/unsloth_zoo/temporary_patches/gpt_oss.py", line 979, in return_attention_mask
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/support/.local/share/mamba/envs/unsloth_main_repo/lib/python3.11/site-packages/transformers/masking_utils.py", line 1087, in create_masks_for_generate
    return create_causal_mask(**mask_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/support/.local/share/mamba/envs/unsloth_main_repo/lib/python3.11/site-packages/unsloth_zoo/temporary_patches/gpt_oss.py", line 979, in return_attention_mask
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
TypeError: 'str' object is not callable
```
The issue occurred in the causal mask creation function where `getattr()` was incorrectly configured with string literals as fallback values instead of actual function references.

### Solution
Replaced the string fallback values in the the `getattr()` calls in the GPT-OSS patch script, with function objects retrieval code.
Before with string call back values:
```
create_causal_mask = getattr(

        transformers.masking_utils,

        "_old_create_causal_mask",

        "create_causal_mask"

    )

create_sliding_window_causal_mask = getattr(

      transformers.masking_utils,

      "_old_create_sliding_window_causal_mask",

      "create_sliding_window_causal_mask"

  )
```

After, with function objects as call back values:
```
create_causal_mask = getattr(

        transformers.masking_utils,

        "_old_create_causal_mask",

        getattr(transformers.masking_utils,"create_causal_mask"),

 )

  create_sliding_window_causal_mask = getattr(

      transformers.masking_utils,

      "_old_create_sliding_window_causal_mask",

      getattr(transformers.masking_utils, "create_sliding_window_causal_mask"),

  )
```

# Tests
- Type Error is no longer raised
- type of `create_causal_mask` and `create_sliding_window_causal_mask` when printed return a `function object` instead of `str`
