### PR TITLE
Transformers fix v.4.57 rename from PretrainedConfig to PreTrainedConfig

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2148,7 +2148,7 @@ def unsloth_compile_transformers(
     # Get all functions as well
     functions = [x for x in functions if x not in torch_modules or not compile_torch_modules or not compile_custom_modules]
 
-    # Get all PretrainedModel classes
+    # Get all PreTrainedModel classes
     pretrained_modules = re.findall(r"class ([^\s]{1,})\(.+?PreTrainedModel\)", full_source)
 
     # Remove if no forward function

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -47,7 +47,12 @@ def compare_dicts(orig_dict, new_dict, prefix=""):
             print(f"Dict key {key_path} type mismatch: original {type(orig_val)} != new model {type(new_val)}")
 
 def compare_attributes(original_model, new_model):
-    from transformers.configuration_utils import PretrainedConfig
+    try:
+        from transformers.configuration_utils import PreTrainedConfig
+        PretrainedConfig = PreTrainedConfig
+    except:
+        from transformers.configuration_utils import PretrainedConfig
+
     print("=== ATTRIBUTE COMPARISON REPORT ===")
     missing_attrs = []
     type_mismatches = []

--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -21,7 +21,12 @@ import torch
 import json
 import re
 from .log import logger
-from transformers import PretrainedConfig
+try:
+    from transformers import PreTrainedConfig
+    PretrainedConfig = PreTrainedConfig
+except:
+    from transformers import PretrainedConfig
+
 HAS_TORCH_DTYPE = "torch_dtype" in PretrainedConfig.__doc__
 
 __all__ = [

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -242,7 +242,12 @@ pass
 
 def patch_to_dict():
     from functools import wraps
-    from transformers.configuration_utils import PretrainedConfig
+    try:
+        from transformers.configuration_utils import PreTrainedConfig
+        PretrainedConfig = PreTrainedConfig
+    except:
+        from transformers.configuration_utils import PretrainedConfig
+
     from .hf_utils import _normalize_dict_dtypes
     original_to_dict = PretrainedConfig.to_dict
     original_to_diff_dict = PretrainedConfig.to_diff_dict

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1780,7 +1780,7 @@ pass
 def _convert_lora_keys_to_safetensor_format(
     lora_weights,        # Global dict of LoraStats objects
     safetensor_keys,     # List of keys from the CURRENT shard
-    model_class_name="PretrainedModel" # The actual model instance (e.g. Qwen2VLForConditionalGeneration)
+    model_class_name="PreTrainedModel" # The actual model instance (e.g. Qwen2VLForConditionalGeneration)
 ):
     import re
 

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1414,7 +1414,13 @@ pass
 # RuntimeError: Unsloth: Failed to load model. Both AutoConfig and PeftConfig loading failed.
 # AutoConfig error: 'GptOssConfig' object has no attribute 'max_position_embeddings'
 try:
-    from transformers.configuration_utils import PretrainedConfig, layer_type_validation
+    from transformers.configuration_utils import layer_type_validation
+    try:
+        from transformers.configuration_utils import PreTrainedConfig
+        PretrainedConfig = PreTrainedConfig
+    except:
+        from transformers.configuration_utils import PretrainedConfig
+
     from transformers.modeling_rope_utils import rope_config_validation
 
     class Old_GptOssConfig(PretrainedConfig):


### PR DESCRIPTION
Fixes https://github.com/unslothai/unsloth/issues/3415

Users also report it fixes the issue for them. The change is needed due to transformers renaming PretrainedConfig to PreTrainedConfig in the main version of transformers.

