### PR TITLE
Now it works on a uv venv

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -66,11 +66,11 @@ LLAMA_CPP_TARGETS = [
 ]
 
 PIP_OPTIONS = [
+    "uv pip", # Astral's uv
     "pip",
     "pip3",
     "python3 -m pip", # Python standalone installation
     "py -m pip", # Windows
-    "uv pip", # Astral's uv
     "poetry", # Poetry
 ]
 


### PR DESCRIPTION

<sub>This is my first pull request, [I know is not much but is honest work](https://en.meming.world/wiki/But_It%27s_Honest_Work)<sub>

# GGUF AND LLAMA.cpp does not work inside a uv venv

Trying to test unslothai/unsloth#3215 I discovered that when inside a ``uv venv``, the automatic installation of GGUF and llama.cpp overflows into the global system pip env 

From what @rolandtannous said on unslothai/unsloth#3487 , ``python -m venv venv`` does not work, A conda env works as intended      

My fix will allow unsloth to work on a ``uv venv`` without conda

# Simple as f****

This morning I was doing a lot of stuff to check if the interpreter was inside a venv, if uv was installed etc.... 

Basically I was trying to check if you were in a venv, in that case check if the venv was created with ``uv`` checking ``pyvenv.cfg`` and in that case override ``final_pip`` on ``check_pip`` 

But I figure out if on the ``PIP_OPTIONS`` I change the order, will try to use ``uv`` before the rest, and in the case that it is installed but you are not in a uv venv it should be compatible

## Tests

Tested on uv venv and conda env on debian 
