### PR TITLE
Fix qwen2.5 vl for transformers 4.57.1

### DIFF
--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -358,7 +358,7 @@ def create_empty_vision_model(config, dtype = torch.float16):
     vision_layers = getattr(config.vision_config, "num_hidden_layers", None) or getattr(config.vision_config, "depth", 0)
 
     # Set minimal sizes for different model types
-    if model_type == "qwen2_5_vl":
+    if "qwen2_5_vl" in model_type:
         new_config.vision_config.out_hidden_size = 1
 
 
@@ -661,7 +661,7 @@ def get_model_layer_counts(config):
             "vision_layers": getattr(config.vision_config, "num_hidden_layers", 32),
             "global_layers": getattr(config.vision_config, "num_global_layers", 8),
         }
-    elif model_type == "qwen2_5_vl":
+    elif "qwen2_5_vl" in model_type:
         return {
             "text_layers": getattr(config, "num_hidden_layers", 32),
             "vision_layers": getattr(config.vision_config, "num_hidden_layers", 32),
@@ -724,7 +724,7 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
 
             if layer_module is not None:
                 if "qkv" in layer_path:
-                    if model_type == "qwen2_5_vl":
+                    if "qwen2_5_vl" in model_type:
                         get_state_dict(layer_path, 0, state_dict, layer_module, slice_weights=False)
                     else:
                          get_state_dict(f"{layer_path.replace('qkv_proj', 'q_proj')}", 0, state_dict, layer_module)


### PR DESCRIPTION
Transformers 4.57.1 changes the output of this line here: https://github.com/unslothai/unsloth-zoo/blob/ed558edd8bcb9affd3710e6e2f31fa1cbea03e09/unsloth_zoo/empty_model.py#L702. Instead of it being `model_type == "qwen2_5_vl"` it becomes  "qwen2_5_vl_text" I changed the check to `"qwen2_5_vl" in model_type:` and the GRPO losses for 5 steps each match up: 

Run with transformers==4.56.2

https://wandb.ai/tckeithccc-drexel-university/unsloth_test/runs/ivuo9ub8?nw=nwusertckeithccc

Run with transformers==4.57.1

https://wandb.ai/tckeithccc-drexel-university/unsloth_test/runs/ou51ji9q?nw=nwusertckeithccc