### PR TITLE
Fix/video collate

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -449,10 +449,10 @@ FORCE_UNSLOTH_VIDEO_READER = os.getenv("FORCE_UNSLOTH_VIDEO_READER", None)
 def get_video_reader_backend() -> str:
     if FORCE_UNSLOTH_VIDEO_READER is not None:
         video_reader_backend = FORCE_UNSLOTH_VIDEO_READER
-    elif is_torchcodec_available():
-        video_reader_backend = "torchcodec"
     elif is_decord_available():
         video_reader_backend = "decord"
+    elif is_torchcodec_available():
+        video_reader_backend = "torchcodec"
     elif HAS_TORCHVISION:
         video_reader_backend = "torchvision"
     else:
@@ -650,7 +650,7 @@ class UnslothVisionDataCollator:
         response_part    = None,
         force_match      = True, # Match newlines as well!
         num_proc         = None,
-        completion_only_loss = False,
+        completion_only_loss = True,
         pad_to_multiple_of = None,
         resize_dimension = 0, # can be 0, 1, 'max' or 'min' (max resizes based on the max of height width, min the min size, 0 the first dim, etc)
         snap_to_patch_size = False,


### PR DESCRIPTION
This PR makes a few updates to the vision data collator which mostly affect video and prompt completion processing.

Specifically, two bugs were addressed for video datasets. For prompt completion datasets there were a couple of bugs, additional handling for token_type_ids (gemma), and an efficiency improvement to flush_to_side.

We also update the logic to mask prompts in prompt completion datasets by default.

Old Collator:
qwen3vl: https://colab.research.google.com/drive/13cHImIKg2t00qBgaO_9GmLIwN8_ozMNN?usp=sharing
pixtral: https://colab.research.google.com/drive/1YQY3p4jmQRCA7wswnlwx4_y-aGSIs2FY?usp=sharing
qwen25vl: https://colab.research.google.com/drive/1VoqKqRvzKrpXdLK3h29goN_-1ohfdQMh?usp=sharing
llamavl: https://colab.research.google.com/drive/1LlTgYdrU6ug10vVNw-Ng664akqWF13BZ?usp=sharing
gemma3n: https://colab.research.google.com/drive/1vGrhglCAVThw-KhS_veR_qRxOdx_OV-K?usp=sharing
gemma3: https://colab.research.google.com/drive/1hXzYzxBCBrgCFw9kBeokJBKkH21wtZm_?usp=sharing

New Collator:
qwen3vl: https://colab.research.google.com/drive/1RFHt1RcIB9K9y7A9h_w3bWmTfYvUo3Hn?usp=sharing
pixtral: https://colab.research.google.com/drive/1J4xQtJY4RjHeB0ZeOhUFqA2HGbzmm8bV?usp=sharing
qwen25vl: https://colab.research.google.com/drive/1XA2p6GtNOuVHh4Pi4udLvjb4Ur7zAKgY?usp=sharing
llamavl: https://colab.research.google.com/drive/1naUzOF5KWRy--PtgIQfNFjeULA2aR-xH?usp=sharing
gemma3n: https://colab.research.google.com/drive/1Wl4owxrUv1-J0XP2Abvf0YkK1XvhnDc0?usp=sharing
gemma3: https://colab.research.google.com/drive/1drhCI_xXZKq6IFqB8TVa4PrJSMGZnJsv?usp=sharing
