### PR TITLE
Deepseekocr fix: save single model shard

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1201,7 +1201,13 @@ def merge_and_overwrite_lora(
             if safe_tensor_index_files:
                 local_index_path = os.path.join(model_name, "model.safetensors.index.json")
                 if os.path.exists(local_index_path):
-                    shutil.copy2(local_index_path, os.path.join(save_directory, "model.safetensors.index.json"))
+                    try:
+                        shutil.copy2(local_index_path, os.path.join(save_directory, "model.safetensors.index.json"))
+                    except shutil.SameFileError:
+                        pass
+                    except Exception as e:
+                        print(f"Error copying model.safetensors.index.json: {e}")
+                        raise e
         else:
             # Download from HF
             if "model.safetensors.index.json" in [f for f in safe_tensor_index_files]:


### PR DESCRIPTION
Sometimes local models may be saved with a single safetensor but in sharded model format ie https://huggingface.co/unsloth/DeepSeek-OCR/tree/main

In sharded format, when saving the full model we need the index.json file even if the safetensors list is 1. This change also checks the naming convention. If it matches the naming convention and num_shards == 1 it will still ask for the index.json.