### PR TITLE
MoE: Cast routing_weights dtype correctly

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1613,7 +1613,7 @@ pass
 MOE_ROUTING_WEIGHTS_CAST_PATTERN = r"(\brouting_weights\s*=\s*routing_weights\.to\(\s*)hidden_states(\.dtype\s*\))"
 MOE_ROUTING_WEIGHTS_CAST_REPLACE = r"\1router_logits\2"
 
-def patch_moe_routing_weights_cast(module_cls: Any, source: str) -> str:
+def patch_moe_routing_weights_cast(module_cls: Any, source: str) -> Tuple[str, Dict[str, str]]:
     new_route_sources = {}
     for method_name, obj in module_cls.__dict__.items():
         if isinstance(obj, (staticmethod, classmethod)):


### PR DESCRIPTION
Update compiled to cast routing_weight tensors to router_logits.dtype instead of hidden_states.dtype.

This will patch the forward method, and any other methods that cast routing_weights to hidden_states.dtype. 

Qwen3 Moe Test:
https://colab.research.google.com/drive/1z9KopzSJylyM3g8KJ3bnvvpo97LISHTm?usp=sharing

<img width="653" height="293" alt="image" src="https://github.com/user-attachments/assets/7d9a0078-9c1f-454e-bdce-9e41a619b176" />
