### PR TITLE
Enable FP8 + RL training

### DIFF
--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -239,7 +239,7 @@ def create_empty_causal_lm(config, dtype = torch.float16):
     # Suppress warning on uninited weights
     old_warn = os.environ.get("UNSLOTH_WARN_UNINITIALIZED", "1")
     os.environ["UNSLOTH_WARN_UNINITIALIZED"] = "0"
-    model_name = getattr(config, 'model_name')
+    model_name = getattr(config, 'model_name', None)
     kwargs = {"torch_dtype" if HAS_TORCH_DTYPE else "dtype" : dtype_from_config(config)}
     original_meta_model = None
     error = None

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -559,9 +559,8 @@ def grpo_accumulated_loss(
     image_grid_thw = kwargs.get('image_grid_thw',None)
     pixel_attention_mask = kwargs.get('pixel_attention_mask',None)
     image_sizes = kwargs.get('image_sizes',None)
-    sampling_per_token_logps = kwargs.get("sampling_per_token_logps", None)
     #delete this from kwargs so less issues 
-    del kwargs["sampling_per_token_logps"]
+    sampling_per_token_logps = kwargs.pop("sampling_per_token_logps", None)
     kwargs["vllm_importance_sampling_cap"] = trainer.vllm_importance_sampling_cap if sampling_per_token_logps is not None else None
     kwargs["use_vllm"] = trainer.use_vllm
     # Find closest multiple


### PR DESCRIPTION
This commit works around a bug in PyTorch that doesn't let us use inference mode with tensor subclasses. TorchAO's fp8 quantization leverages tensor subclasses so we are affected by this error. For more details, see https://github.com/pytorch/pytorch/issues/164872. The workaround is to use `torch.no_grad` in this case instead of `torch.inference_mode`.