### PR TITLE
Fix docstring removing regex to support empty parentheses

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -806,8 +806,8 @@ def create_standalone_class(
     source = source + full_class
 
     # Remove @auto_docstring
-    source = re.sub(r"@auto_docstring[\s]{0,}(\([^\)]{1,}\))?", "", source)
-    source = re.sub(r"@check_model_inputs[\s]{0,}(\([^\)]{1,}\))?", "", source)
+    source = re.sub(r"@auto_docstring[\s]{0,}(\([^\)]{0,}\))?", "", source)
+    source = re.sub(r"@check_model_inputs[\s]{0,}(\([^\)]{0,}\))?", "", source)
     # source = source.replace("@auto_docstring", "")
 
     # Fix Gemma 3 ignore_index being not set!


### PR DESCRIPTION
While loading a Qwen3VL-derived model I got the following error on `from_pretrained` call:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/compiler.py", line 667, in create_new_function
    new_module, old_path = import_module(compile_folder, name)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/compiler.py", line 663, in import_module
    raise e
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/compiler.py", line 658, in import_module
    new_module = importlib.import_module(name)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 991, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1129, in get_code
  File "<frozen importlib._bootstrap_external>", line 1059, in source_to_code
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/trainer/unsloth_compiled_cache/unsloth_compiled_module_qwen3_vl.py", line 612
    ()
    ^
SyntaxError: invalid syntax
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/compiler.py", line 694, in create_new_function
    spec.loader.exec_module(new_module)
  File "<frozen importlib._bootstrap_external>", line 991, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1129, in get_code
  File "<frozen importlib._bootstrap_external>", line 1059, in source_to_code
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/tmp/unsloth_compiled_cache/unsloth_compiled_module_qwen3_vl.py", line 612
    ()
    ^
SyntaxError: invalid syntax
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/compiler.py", line 2971, in unsloth_compile_transformers
    combined_module = create_new_function(
                      ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/compiler.py", line 696, in create_new_function
    raise RuntimeError(f"Direct module loading failed for {name}: {e}")
RuntimeError: Direct module loading failed for unsloth_compiled_module_qwen3_vl: invalid syntax (unsloth_compiled_module_qwen3_vl.py, line 612)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/trainer/app.py", line 54, in <module>
    raise SystemExit(main())
                     ^^^^^^
  File "/trainer/app.py", line 50, in main
    return run_training(config)
           ^^^^^^^^^^^^^^^^^^^^
  File "/trainer/trainer/pipeline.py", line 78, in run_training
    model, tokenizer = initialize_model(config.model_loader, config.peft)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trainer/trainer/modeling.py", line 38, in initialize_model
    model, tokenizer = FastVisionModel.from_pretrained(**loader_kwargs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth/models/loader.py", line 1009, in from_pretrained
    model_types, supports_sdpa = unsloth_compile_transformers(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth/models/_utils.py", line 1858, in unsloth_compile_transformers
    _unsloth_compile_transformers(
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/compiler.py", line 2983, in unsloth_compile_transformers
    raise RuntimeError(exception)
RuntimeError: Direct module loading failed for unsloth_compiled_module_qwen3_vl: invalid syntax (unsloth_compiled_module_qwen3_vl.py, line 612)
```

I've traced the issue to a syntax error in the generated unsloth code - notice the faulty `()`:

```
@torch.compiler.disable(recursive = False)
()
def Qwen3VLModel_forward(
    self,
    input_ids: torch.LongTensor = None,
    attention_mask: Optional[torch.Tensor] = None,
    position_ids: Optional[torch.LongTensor] = None,
    past_key_values: Optional[Cache] = None,
    inputs_embeds: Optional[torch.FloatTensor] = None,
    pixel_values: Optional[torch.Tensor] = None,
    pixel_values_videos: Optional[torch.FloatTensor] = None,
    image_grid_thw: Optional[torch.LongTensor] = None,
    video_grid_thw: Optional[torch.LongTensor] = None,
    cache_position: Optional[torch.LongTensor] = None,
    **kwargs: Unpack[TransformersKwargs],
) -> Union[tuple, Qwen3VLModelOutputWithPast]:
```

It's caused by the regex not matching decorator with empty argument parentheses.

Ref: [https://github.com/huggingface/transformers/blob/8f129d256dfbd414b47f7f4a495a7834d95ffbf8/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py#L1132](https://github.com/huggingface/transformers/blob/8f129d256dfbd414b47f7f4a495a7834d95ffbf8/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py#L1132)

```
    @auto_docstring
    @check_model_inputs() # <-- this wasn't matched
    def forward(
        self,
        input_ids: torch.LongTensor = None,
        attention_mask: Optional[torch.Tensor] = None,
```

Seems to be caused by a faulty regex in `create_standalone_class`. My fix is to allow for zero or more characters between `(` and `)` in the replacement regex instead of expecting at least one non-`)` character. 

Not sure if this was the intended behavior, but it seems to fix my use case.