### PR TITLE
Add flashinfer toggle for vllm backend

### DIFF
--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1889,7 +1889,7 @@ def load_vllm(
     # Also seems to process 2x less sequences in 1 go so less throughput?
     # Maybe FP8 Flashinfer is much better
     # See https://docs.vllm.ai/en/latest/serving/env_vars.html
-    if importlib.util.find_spec("flashinfer"):
+    if importlib.util.find_spec("flashinfer") and os.environ.get("UNSLOTH_VLLM_NO_FLASHINFER", "0") == "0":
         # Check if FLASHINFER is supported - for eg Qwen3-VL and Qwen2-VL do not work
         if "VLLM_ATTENTION_BACKEND" in os.environ and os.environ["VLLM_ATTENTION_BACKEND"] == "":
             del os.environ["VLLM_ATTENTION_BACKEND"]


### PR DESCRIPTION
When running Qwen3VL-derived model GRPO training using vLLM fast inference I've encountered this error when vLLM was loading the model:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/vllm_utils.py", line 1975, in load_vllm
    llm = LLM(**engine_args)
          ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/llm.py", line 343, in __init__
    self.llm_engine = LLMEngine.from_engine_args(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/llm_engine.py", line 174, in from_engine_args
    return cls(
           ^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/llm_engine.py", line 108, in __init__
    self.engine_core = EngineCoreClient.make_client(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core_client.py", line 95, in make_client
    return InprocClient(vllm_config, executor_class, log_stats)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core_client.py", line 264, in __init__
    self.engine_core = EngineCore(*args, **kwargs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 102, in __init__
    self.model_executor = executor_class(vllm_config)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/abstract.py", line 101, in __init__
    self._init_executor()
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/uniproc_executor.py", line 48, in _init_executor
    self.driver_worker.load_model()
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 273, in load_model
    self.model_runner.load_model(eep_scale_up=eep_scale_up)
  File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 3276, in load_model
    self.model = model_loader.load_model(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/model_loader/base_loader.py", line 49, in load_model
    model = initialize_model(
            ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/model_loader/utils.py", line 55, in initialize_model
    return model_class(vllm_config=vllm_config, prefix=prefix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/qwen3_vl.py", line 1238, in __init__
    self.visual = Qwen3_VisionTransformer(
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/qwen3_vl.py", line 390, in __init__
    raise RuntimeError(
RuntimeError: Qwen3-VL does not support AttentionBackendEnum.FLASHINFER backend now.
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/trainer/app.py", line 96, in <module>
    raise SystemExit(main())
                     ^^^^^^
  File "/trainer/app.py", line 92, in main
    return run_training(config)
           ^^^^^^^^^^^^^^^^^^^^
  File "/trainer/trainer/pipeline.py", line 85, in run_training
    model, tokenizer = initialize_model(model_loader_cfg, config.peft)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trainer/trainer/modeling.py", line 38, in initialize_model
    model, tokenizer = FastVisionModel.from_pretrained(**loader_kwargs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth/models/loader.py", line 1065, in from_pretrained
    model, tokenizer = FastBaseModel.from_pretrained(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth/models/vision.py", line 724, in from_pretrained
    llm = load_vllm(**load_vllm_kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/unsloth_zoo/vllm_utils.py", line 1989, in load_vllm
    raise RuntimeError(error)
RuntimeError: Qwen3-VL does not support AttentionBackendEnum.FLASHINFER backend now.
```

I'm using latest vLLM release (0.11.2) with compatible pytorch (2.9.0) - this could potentially be fixed in the upcoming vLLM releases, so I've decided to make this toggleable for now using an environment variable.

Setting `UNSLOTH_VLLM_NO_FLASHINFER` to `1` prevents forcing flash infer when creating vllm backend.

The logic behind this could be improved - detecting incompatibilities sounds nice but it's outside of the scope of my research. I've also considered not overriding the `VLLM_ATTENTION_BACKEND` if it's already set, but I cannot confirm if that wouldn't interfere with different setups, so my safest bet was to introduce a new toggle for this specific behavior.