### PR TITLE
FIX: Ensure modules_to_save are merged

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1447,8 +1447,9 @@ def merge_and_overwrite_lora(
     has_embed = any(key.endswith("embed_tokens") for key in lora_weights)
     has_head  = any(key.endswith("lm_head") for key in lora_weights)
     if has_embed and has_head:
-        has_embed_tensor = any("embed_tokens" in key for key in safetensor_keys_seen)
-        has_head_tensor  = any("lm_head"      in key for key in safetensor_keys_seen)
+        # Only count actual weight tensors; lm_head.bias alone should not mask tied-embedding cases.
+        has_embed_tensor = any(key.endswith("embed_tokens.weight") for key in safetensor_keys_seen)
+        has_head_tensor  = any(key.endswith("lm_head.weight")      for key in safetensor_keys_seen)
         if has_embed_tensor ^ has_head_tensor:  # exactly one side present on disk
             effective_loras -= 1
 


### PR DESCRIPTION
This PR fixes https://github.com/unslothai/unsloth/issues/3444. Current merging code does not properly save `modules_to_save` what makes `lm_head`/`embed_token` left untrained after merging.

Ensured that `modules_to_save` (if used during finetuning) are properly propagated into the merged model.

Tested with `.save_pretrained_merged(..., save_method="merged_16bit"), model Qwen3-8B-Base (training in 4bit, 2 new tokens in the vocab).

Also a small fix with stripping `transformers` version from the model config after merge because it led to an error when loading the merged model.