### PR TITLE
Vision utils decode image improvement

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1267,9 +1267,8 @@ class UnslothVisionDataCollator:
             if isinstance(content, list):
                 for item in content:
                     if isinstance(item, dict):
-                        old_keys = list(item.keys())
-                        for k in old_keys:
-                            if item[k] is None:
-                                del item[k]
+                        keys_to_remove = [k for k, v in item.items() if v is None]
+                        for k in keys_to_remove:
+                            del item[k]
         return messages
 pass


### PR DESCRIPTION
Adds support for datasets that process images as a dict with bytes or paths. You can load an image from bytes or a str path. This format often comes after dataset.map with arrow backed datasets.

Cleans up None images and texts so the collator can process cleanly.

Allows for VLM training with **_streaming_** datasets

Pixtral: https://colab.research.google.com/drive/19RkOx_KC1RULFuYYPN7o5D28xOm6uuwV?usp=sharing
qwen 2.5 vl: https://colab.research.google.com/drive/1a0HvCsD4DwnsKtM3CO_5KVtTvUTF_OCu?usp=sharing
llama 3.2: https://colab.research.google.com/drive/1YUspBSuXtIPSR5U6nHqBPs0Ece2G9rI5?usp=sharing
gemma3: https://colab.research.google.com/drive/1d73N6Brr7BZhW2IAJPimkK9F3U2ZWGqQ?usp=sharing
deepseek ocr: https://colab.research.google.com/drive/1_AyvUhyD1u76Y9q2nbH_6GyAuGJnP6K5?usp=sharing
qwen3 vl: https://colab.research.google.com/drive/1hqYJlUUqk2KW0Xa1tqMvUDxHAP5voqvA?usp=sharing
ministral: https://colab.research.google.com/drive/10xaddx0NpRzB-IOp4VumIGlYLrs8WBXW?usp=sharing