### PR TITLE
Update e to error

### DIFF
--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -268,7 +268,7 @@ def create_empty_causal_lm(config, dtype = torch.float16):
     # Suppress warning on uninited weights
     os.environ["UNSLOTH_WARN_UNINITIALIZED"] = old_warn
     if error is not None and original_meta_model is None:
-        print(f"Failed to create original_meta_model for AutoModelForCausalLM. Error {e}")
+        print(f"Failed to create original_meta_model for AutoModelForCausalLM. Error {error}")
         original_meta_model = None
 
     new_config = deepcopy(config)


### PR DESCRIPTION
Wrong variable "e" was used for printing an unhandled error instead of "error"

Error trace:

[rank0]:   File "/common/users/cp1234/grpo_unsloth/venv/lib/python3.10/site-packages/unsloth_zoo/empty_model.py", line 271, in create_empty_causal_lm
[rank0]:     print(f"Failed to create original_meta_model for AutoModelForCausalLM. Error {e}")
[rank0]: UnboundLocalError: local variable 'e' referenced before assignment

After the fix, it print the correct error.