### PR TITLE
[FIX] [DDP] Fix compile for distributed training

### DIFF
--- a/unsloth_zoo/utils.py
+++ b/unsloth_zoo/utils.py
@@ -98,13 +98,9 @@ pass
 def distributed_function(n = 1, function = None, *args, **kwargs):
     assert function is not None
 
-    # Not launched distributed at all
-    if not is_distributed():
-        out = function(*args, **kwargs)
-        return out if n == 1 else out
-
-    # If process group isn't initialized yet, all ranks must run independently.
-    # This happens during import when torchrun is used but init_process_group() wasn't called yet.
+    # Run independently if process group isn't initialized yet.
+    # This covers both: (1) not distributed at all, and (2) torchrun launched
+    # but init_process_group() wasn't called yet (e.g. during module imports).
     # Ref: https://github.com/unslothai/unsloth/issues/3703
     if not torch_distributed_is_initialized():
         out = function(*args, **kwargs)


### PR DESCRIPTION
Fixes : unslothai/unsloth#3703 unslothai/unsloth#3685

Without this, trainer throws the following error
```
$ cd /home/datta0/unsloth && UNSLOTH_COMPILE_LOCATION=/tmp/unsloth_compile_cache ~/.venvs/pyenv/bin/torchrun --nproc_per_node=2 unsloth-cli.py \
W1211 12:51:49.592000 178520 torch/distributed/run.py:774] 
W1211 12:51:49.592000 178520 torch/distributed/run.py:774] *****************************************
W1211 12:51:49.592000 178520 torch/distributed/run.py:774] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W1211 12:51:49.592000 178520 torch/distributed/run.py:774] *****************************************
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
INFO 12-11 12:51:55 [__init__.py:216] Automatically detected platform cuda.
INFO 12-11 12:51:55 [__init__.py:216] Automatically detected platform cuda.
🦥 Unsloth Zoo will now patch everything to make training faster!
🦥 Unsloth Zoo will now patch everything to make training faster!
Unsloth: Could not import trl.trainer.alignprop_trainer: Failed to import trl.trainer.alignprop_trainer because of the following error (look up to see its traceback):
Failed to import trl.models.modeling_sd_base because of the following error (look up to see its traceback):
Failed to import diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion because of the following error (look up to see its traceback):
Failed to import diffusers.loaders.ip_adapter because of the following error (look up to see its traceback):
Requires Flash-Attention version >=2.7.1,<=2.8.2 but got 2.8.3.
Unsloth: Could not import trl.trainer.alignprop_trainer: Failed to import trl.trainer.alignprop_trainer because of the following error (look up to see its traceback):
Failed to import trl.models.modeling_sd_base because of the following error (look up to see its traceback):
Failed to import diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion because of the following error (look up to see its traceback):
Failed to import diffusers.loaders.ip_adapter because of the following error (look up to see its traceback):
Requires Flash-Attention version >=2.7.1,<=2.8.2 but got 2.8.3.
Unsloth: Could not import trl.trainer.ddpo_trainer: Failed to import trl.trainer.ddpo_trainer because of the following error (look up to see its traceback):
Failed to import trl.models.modeling_sd_base because of the following error (look up to see its traceback):
Failed to import diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion because of the following error (look up to see its traceback):
Failed to import diffusers.loaders.ip_adapter because of the following error (look up to see its traceback):
Requires Flash-Attention version >=2.7.1,<=2.8.2 but got 2.8.3.
Traceback (most recent call last):
  File "/home/datta0/unsloth/unsloth-cli.py", line 441, in <module>
    run(args)
  File "/home/datta0/unsloth/unsloth-cli.py", line 37, in run
    from unsloth import FastLanguageModel
  File "/home/datta0/unsloth/unsloth/__init__.py", line 257, in <module>
    from .models import *
  File "/home/datta0/unsloth/unsloth/models/__init__.py", line 15, in <module>
    from .llama import FastLlamaModel
  File "/home/datta0/unsloth/unsloth/models/llama.py", line 3400, in <module>
    PatchFastRL(FastLanguageModel = FastLlamaModel)
  File "/home/datta0/unsloth/unsloth/models/rl.py", line 1347, in PatchFastRL
    patch_trl_rl_trainers()
  File "/home/datta0/unsloth/unsloth/models/rl.py", line 1333, in patch_trl_rl_trainers
    _patch_trl_rl_trainers(trainer)
  File "/home/datta0/unsloth/unsloth/models/rl.py", line 1003, in _patch_trl_rl_trainers
    created_module = create_new_function(
                     ^^^^^^^^^^^^^^^^^^^^
  File "/home/datta0/.venvs/pyenv/lib/python3.12/site-packages/unsloth_zoo/compiler.py", line 573, in create_new_function
    function_location = os.path.join(compile_folder, f"{name}.py")
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 76, in join
TypeError: expected str, bytes or os.PathLike object, not NoneType
[unsloth_zoo.log|WARNING]Unsloth: Failed to import trl openenv: No module named 'trl.experimental'
==((====))==  Unsloth 2025.12.4: Fast Llama patching. Transformers: 4.57.1. vLLM: 0.11.0.
   \\   /|    NVIDIA H100 80GB HBM3. Num GPUs = 2. Max memory: 79.179 GB. Platform: Linux.
O^O/ \_/ \    Torch: 2.8.0+cu128. CUDA: 9.0. CUDA Toolkit: 12.8. Triton: 3.4.0
\        /    Bfloat16 = TRUE. FA [Xformers = None. FA2 = True]
 "-____-"     Free license: http://github.com/unslothai/unsloth
W1211 12:52:00.431000 178520 torch/distributed/elastic/multiprocessing/api.py:900] Sending process 178576 closing signal SIGTERM
E1211 12:52:00.946000 178520 torch/distributed/elastic/multiprocessing/api.py:874] failed (exitcode: 1) local_rank: 1 (pid: 178577) of binary: /home/datta0/.venvs/pyenv/bin/python3
Traceback (most recent call last):
  File "/home/datta0/.venvs/pyenv/bin/torchrun", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/datta0/.venvs/pyenv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/datta0/.venvs/pyenv/lib/python3.12/site-packages/torch/distributed/run.py", line 901, in main
    run(args)
  File "/home/datta0/.venvs/pyenv/lib/python3.12/site-packages/torch/distributed/run.py", line 892, in run
    elastic_launch(
  File "/home/datta0/.venvs/pyenv/lib/python3.12/site-packages/torch/distributed/launcher/api.py", line 143, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/datta0/.venvs/pyenv/lib/python3.12/site-packages/torch/distributed/launcher/api.py", line 277, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
============================================================
unsloth-cli.py FAILED
------------------------------------------------------------
Failures:
  <NO_OTHER_FAILURES>
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2025-12-11_12:52:00
  host      : h100-v3-datta.us-east4-b.c.unsloth.internal
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 178577)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
============================================================
```