### PR TITLE
update compiler for XLMRobertaModel

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -2662,7 +2662,7 @@ def unsloth_compile_transformers(
             if OLD_CUDA_ARCH_VERSION or OLD_TORCH_VERSION or OLD_TRITON_VERSION:
                 continue
 
-            module_class = eval(f"modeling_file.{module}")
+            module_class = getattr(modeling_file, module)
             if isinstance(module_class, type) and hasattr(module_class, "forward") and issubclass(module_class, GenerationMixin):
                 try:
                     source = inspect.getsource(module_class.forward)


### PR DESCRIPTION
This fixes an issue when trying to compile XLMRobertaModel.

the XLMRobertaModel models have a "forward" entry in their dir(), but they are not classes, so issubclass fails.

this just adds a check to make sure issubclass is only used on classes.