### PR TITLE
feat: Add Qwen 3 VL video metadata support

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -35,23 +35,23 @@ __all__ = [
 
 global IMAGE_TOKENS
 IMAGE_TOKENS = [
-    "<|image|>",          # Llama 3.2 Vision, Phi 3.5
-    "<|vision_start|>",   # Qwen
-    "<|vision_end|>",     # Qwen
-    "<|vision_pad|>",     # Qwen
-    "<|image_pad|>",      # Qwen
-    "<|video_pad|>",      # Qwen
-    "<image>",            # PaliGemma / Llava
-    "[IMG]",              # Mistral
-    "[IMG_BREAK]",        # Mistral
-    "[IMG_END]",          # Mistral
-    "<image_soft_token>", # Gemma 3
-    "<start_of_image>",   # Gemma 3
-    "<end_of_image>",     # Gemma 3
-    "<|START_OF_IMG|>",   # Cohere
-    "<|END_OF_IMG|>",     # Cohere
-    "<|IMG_LINE_BREAK|>", # Cohere
-    "<|IMG_PATCH|>",      # Cohere
+    "<|image|>",  # Llama 3.2 Vision, Phi 3.5
+    "<|vision_start|>",  # Qwen
+    "<|vision_end|>",  # Qwen
+    "<|vision_pad|>",  # Qwen
+    "<|image_pad|>",  # Qwen
+    "<|video_pad|>",  # Qwen
+    "<image>",  # PaliGemma / Llava
+    "[IMG]",  # Mistral
+    "[IMG_BREAK]",  # Mistral
+    "[IMG_END]",  # Mistral
+    "<image_soft_token>",  # Gemma 3
+    "<start_of_image>",  # Gemma 3
+    "<end_of_image>",  # Gemma 3
+    "<|START_OF_IMG|>",  # Cohere
+    "<|END_OF_IMG|>",  # Cohere
+    "<|IMG_LINE_BREAK|>",  # Cohere
+    "<|IMG_PATCH|>",  # Cohere
 ]
 
 import torch
@@ -70,9 +70,11 @@ import torchvision
 from packaging import version
 from typing import Union, Tuple, List, Dict, Sequence
 from itertools import takewhile
+
 try:
     from torchvision import io, transforms
     from torchvision.transforms import InterpolationMode
+
     HAS_TORCHVISION = True
 except:
     HAS_TORCHVISION = False
@@ -81,7 +83,7 @@ from .log import logger
 
 from .hf_utils import dtype_from_config, HAS_TORCH_DTYPE
 
-UNSLOTH_ENABLE_LOGGING  = os.environ.get("UNSLOTH_ENABLE_LOGGING",  "0") == "1"
+UNSLOTH_ENABLE_LOGGING = os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1"
 
 IMAGE_FACTOR = 28
 MIN_PIXELS = 4 * 28 * 28
@@ -90,7 +92,9 @@ MAX_RATIO = 200
 
 VIDEO_MIN_PIXELS = 128 * 28 * 28
 VIDEO_MAX_PIXELS = 768 * 28 * 28
-VIDEO_TOTAL_PIXELS = int(float(os.environ.get('VIDEO_MAX_PIXELS', 128000 * 28 * 28 * 0.9)))
+VIDEO_TOTAL_PIXELS = int(
+    float(os.environ.get("VIDEO_MAX_PIXELS", 128000 * 28 * 28 * 0.9))
+)
 if UNSLOTH_ENABLE_LOGGING:
     logger.info(f"Unsloth: set VIDEO_TOTAL_PIXELS: {VIDEO_TOTAL_PIXELS}")
 FRAME_FACTOR = 2
@@ -102,21 +106,33 @@ FPS_MAX_FRAMES = 768
 def round_by_factor(number: int, factor: int) -> int:
     """Returns the closest integer to 'number' that is divisible by 'factor'."""
     return round(number / factor) * factor
+
+
 pass
+
 
 def ceil_by_factor(number: int, factor: int) -> int:
     """Returns the smallest integer greater than or equal to 'number' that is divisible by 'factor'."""
     return math.ceil(number / factor) * factor
+
+
 pass
+
 
 def floor_by_factor(number: int, factor: int) -> int:
     """Returns the largest integer less than or equal to 'number' that is divisible by 'factor'."""
     return math.floor(number / factor) * factor
+
+
 pass
 
 
 def smart_resize(
-    height: int, width: int, factor: int = IMAGE_FACTOR, min_pixels: int = MIN_PIXELS, max_pixels: int = MAX_PIXELS
+    height: int,
+    width: int,
+    factor: int = IMAGE_FACTOR,
+    min_pixels: int = MIN_PIXELS,
+    max_pixels: int = MAX_PIXELS,
 ) -> tuple[int, int]:
     """
     Rescales the image so that the following conditions are met:
@@ -142,6 +158,8 @@ def smart_resize(
         h_bar = ceil_by_factor(height * beta, factor)
         w_bar = ceil_by_factor(width * beta, factor)
     return h_bar, w_bar
+
+
 pass
 
 
@@ -182,7 +200,9 @@ def fetch_image(
             image_obj = Image.open(requests.get(image["url"], stream=True).raw)
 
     if image_obj is None:
-        raise ValueError(f"Unrecognized image input. We support local path, http url, base64 and PIL.Image, bytes and dict formats. Instead we got `{type(image).__name__}`")
+        raise ValueError(
+            f"Unrecognized image input. We support local path, http url, base64 and PIL.Image, bytes and dict formats. Instead we got `{type(image).__name__}`"
+        )
     image = image_obj.convert("RGB")
     ## resize
     if "resized_height" in ele and "resized_width" in ele:
@@ -205,7 +225,10 @@ def fetch_image(
     image = image.resize((resized_width, resized_height))
 
     return image
+
+
 pass
+
 
 def smart_nframes(
     ele: dict,
@@ -230,21 +253,29 @@ def smart_nframes(
     Returns:
         int: the number of frames for video used for model inputs.
     """
-    assert not ("fps" in ele and "nframes" in ele), "Only accept either `fps` or `nframes`"
+    assert not ("fps" in ele and "nframes" in ele), (
+        "Only accept either `fps` or `nframes`"
+    )
     if "nframes" in ele:
         nframes = round_by_factor(ele["nframes"], FRAME_FACTOR)
     else:
         fps = ele.get("fps", FPS)
         min_frames = ceil_by_factor(ele.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR)
-        max_frames = floor_by_factor(ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)), FRAME_FACTOR)
+        max_frames = floor_by_factor(
+            ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)), FRAME_FACTOR
+        )
         nframes = total_frames / video_fps * fps
         if nframes > total_frames:
             if UNSLOTH_ENABLE_LOGGING:
-                logger.warning(f"Unsloth: smart_nframes: nframes[{nframes}] > total_frames[{total_frames}]")
+                logger.warning(
+                    f"Unsloth: smart_nframes: nframes[{nframes}] > total_frames[{total_frames}]"
+                )
         nframes = min(min(max(nframes, min_frames), max_frames), total_frames)
         nframes = floor_by_factor(nframes, FRAME_FACTOR)
     if not (FRAME_FACTOR <= nframes and nframes <= total_frames):
-        raise ValueError(f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}.")
+        raise ValueError(
+            f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}."
+        )
     return nframes
 
 
@@ -265,7 +296,9 @@ def _read_video_torchvision(
     video_path = ele["video"]
     if version.parse(torchvision.__version__) < version.parse("0.19.0"):
         if "http://" in video_path or "https://" in video_path:
-            warnings.warn("torchvision < 0.19.0 does not support http/https video path, please upgrade to 0.19.0.")
+            warnings.warn(
+                "torchvision < 0.19.0 does not support http/https video path, please upgrade to 0.19.0."
+            )
         if "file://" in video_path:
             video_path = video_path[7:]
     st = time.time()
@@ -279,16 +312,24 @@ def _read_video_torchvision(
     try:
         video_fps = info["video_fps"]
     except Exception as e:
-        print('error getting video_fps there is probably a path issue', e)
+        print("error getting video_fps there is probably a path issue", e)
         video_fps = 2.0
     total_frames, video_fps = video.size(0), video_fps
     if UNSLOTH_ENABLE_LOGGING:
-        logger.info(f"Unsloth: torchvision:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
+        logger.info(
+            f"Unsloth: torchvision:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s"
+        )
     nframes = smart_nframes(ele, total_frames=total_frames, video_fps=video_fps)
     idx = torch.linspace(0, total_frames - 1, nframes).round().long()
     sample_fps = nframes / max(total_frames, 1e-6) * video_fps
     video = video[idx]
-    return video, sample_fps
+    video_metadata = dict(
+        fps=video_fps,
+        frames_indices=idx.tolist(),
+        total_num_frames=total_frames,
+        video_backend="torchvision",
+    )
+    return video, video_metadata, sample_fps
 
 
 def is_decord_available() -> bool:
@@ -352,7 +393,9 @@ def calculate_video_frame_range(
         )
 
     if UNSLOTH_ENABLE_LOGGING:
-        logger.info(f"Unsloth: calculate video frame range: {start_frame=}, {end_frame=}, {total_frames=} from {video_start=}, {video_end=}, {video_fps=:.3f}")
+        logger.info(
+            f"Unsloth: calculate video frame range: {start_frame=}, {end_frame=}, {total_frames=} from {video_start=}, {video_end=}, {video_fps=:.3f}"
+        )
     return start_frame, end_frame, end_frame - start_frame + 1
 
 
@@ -371,6 +414,7 @@ def _read_video_decord(
         torch.Tensor: the video tensor with shape (T, C, H, W).
     """
     import decord
+
     video_path = ele["video"]
     st = time.time()
     vr = decord.VideoReader(video_path)
@@ -385,18 +429,28 @@ def _read_video_decord(
     video = vr.get_batch(idx).asnumpy()
     video = torch.tensor(video).permute(0, 3, 1, 2)  # Convert to TCHW format
     if UNSLOTH_ENABLE_LOGGING:
-        logger.info(f"Unsloth: decord:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
+        logger.info(
+            f"Unsloth: decord:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s"
+        )
     sample_fps = nframes / max(total_frames, 1e-6) * video_fps
-    return video, sample_fps
+    video_metadata = dict(
+        fps=video_fps,
+        frames_indices=idx,
+        total_num_frames=total_frames,
+        video_backend="decord",
+    )
+    return video, video_metadata, sample_fps
 
 
 def is_torchcodec_available() -> bool:
     """Check if torchcodec is available and properly installed."""
     try:
         import importlib.util
+
         if importlib.util.find_spec("torchcodec") is None:
             return False
         from torchcodec.decoders import VideoDecoder
+
         return True
     except (ImportError, AttributeError, Exception):
         return False
@@ -417,7 +471,8 @@ def _read_video_torchcodec(
         torch.Tensor: the video tensor with shape (T, C, H, W).
     """
     from torchcodec.decoders import VideoDecoder
-    TORCHCODEC_NUM_THREADS = int(os.environ.get('TORCHCODEC_NUM_THREADS', 8))
+
+    TORCHCODEC_NUM_THREADS = int(os.environ.get("TORCHCODEC_NUM_THREADS", 8))
     if UNSLOTH_ENABLE_LOGGING:
         logger.info(f"Unsloth: set TORCHCODEC_NUM_THREADS: {TORCHCODEC_NUM_THREADS}")
     video_path = ele["video"]
@@ -443,8 +498,16 @@ def _read_video_torchcodec(
         if video.shape[-1] in (1, 3, 4) and video.shape[1] not in (1, 3, 4):
             video = video.permute(0, 3, 1, 2).contiguous()
     if UNSLOTH_ENABLE_LOGGING:
-        logger.info(f"Unsloth: torchcodec:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
-    return video, sample_fps
+        logger.info(
+            f"Unsloth: torchcodec:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s"
+        )
+    video_metadata = dict(
+        fps=video_fps,
+        frames_indices=idx,
+        total_num_frames=total_frames,
+        video_backend="torchcodec",
+    )
+    return video, video_metadata, sample_fps
 
 
 VIDEO_READER_BACKENDS = {
@@ -467,31 +530,51 @@ def get_video_reader_backend() -> str:
     elif HAS_TORCHVISION:
         video_reader_backend = "torchvision"
     else:
-        raise ValueError("Unsloth: No video reader backend available, please install decord or torchvision or torchcodec to process video inputs.")
+        raise ValueError(
+            "Unsloth: No video reader backend available, please install decord or torchvision or torchcodec to process video inputs."
+        )
     if UNSLOTH_ENABLE_LOGGING:
-        logger.info(f"Unsloth: unsloth_zoo/vision_utils using {video_reader_backend} to read video.")
+        logger.info(
+            f"Unsloth: unsloth_zoo/vision_utils using {video_reader_backend} to read video."
+        )
     return video_reader_backend
 
 
-def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> Union[torch.Tensor, list[Image.Image]]:
+def fetch_video(
+    ele: dict,
+    image_factor: int = IMAGE_FACTOR,
+    return_video_sample_fps: bool = False,
+    return_video_metadata: bool = False,
+) -> Union[torch.Tensor, list[Image.Image]]:
     if isinstance(ele["video"], str):
         video_reader_backend = get_video_reader_backend()
         try:
-            video, sample_fps = VIDEO_READER_BACKENDS[video_reader_backend](ele)
+            video, video_metadata, sample_fps = VIDEO_READER_BACKENDS[
+                video_reader_backend
+            ](ele)
         except Exception as e:
             if UNSLOTH_ENABLE_LOGGING:
-                logger.warning(f"Unsloth: video_reader_backend {video_reader_backend} error, use torchvision as default, msg: {e}")
-            video, sample_fps = VIDEO_READER_BACKENDS["torchvision"](ele)
+                logger.warning(
+                    f"Unsloth: video_reader_backend {video_reader_backend} error, use torchvision as default, msg: {e}"
+                )
+            video, video_metadata, sample_fps = VIDEO_READER_BACKENDS["torchvision"](
+                ele
+            )
 
         nframes, _, height, width = video.shape
         min_pixels = ele.get("min_pixels", VIDEO_MIN_PIXELS)
         total_pixels = ele.get("total_pixels", VIDEO_TOTAL_PIXELS)
-        max_pixels = max(min(VIDEO_MAX_PIXELS, total_pixels / nframes * FRAME_FACTOR), int(min_pixels * 1.05))
+        max_pixels = max(
+            min(VIDEO_MAX_PIXELS, total_pixels / nframes * FRAME_FACTOR),
+            int(min_pixels * 1.05),
+        )
         max_pixels_supposed = ele.get("max_pixels", max_pixels)
 
         if max_pixels_supposed > max_pixels:
             if UNSLOTH_ENABLE_LOGGING:
-                logger.warning(f"Unsloth: The given max_pixels[{max_pixels_supposed}] exceeds limit[{max_pixels}].")
+                logger.warning(
+                    f"Unsloth: The given max_pixels[{max_pixels_supposed}] exceeds limit[{max_pixels}]."
+                )
 
         max_pixels = min(max_pixels_supposed, max_pixels)
 
@@ -515,24 +598,38 @@ def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample
             interpolation=InterpolationMode.BICUBIC,
             antialias=True,
         )
+        final_video = (video, video_metadata) if return_video_metadata else video
         if return_video_sample_fps:
-            return video, sample_fps
-        return video
+            return final_video, sample_fps
+        return final_video
     else:
         assert isinstance(ele["video"], (list, tuple))
         process_info = ele.copy()
         process_info.pop("type", None)
         process_info.pop("video", None)
         images = [
-            fetch_image({"image": video_element, **process_info}, size_factor=image_factor)
+            fetch_image(
+                {"image": video_element, **process_info}, size_factor=image_factor
+            )
             for video_element in ele["video"]
-   ]
+        ]
         nframes = ceil_by_factor(len(images), FRAME_FACTOR)
         if len(images) < nframes:
             images.extend([images[-1]] * (nframes - len(images)))
+        sample_fps = process_info.pop("fps", 2.0)
+        # Fake video metadata for list-of-frames input
+        raw_fps = process_info.pop("raw_fps", sample_fps)
+        video_metadata = dict(
+            fps=raw_fps,
+            frames_indices=[i for i in range(len(images))],
+            total_num_frames=(nframes / sample_fps) * raw_fps,
+            video_backend="list_of_frames",
+        )
+        final_video = (images, video_metadata) if return_video_metadata else images
         if return_video_sample_fps:
-            return images, process_info.pop("fps", 2.0)
-        return images
+            return final_video, sample_fps
+        return final_video
+
 
 def collapse_fps(fps, tol=1e-4):
     """Return a single float if all fps equal (within tol), else a list; pass None through."""
@@ -544,10 +641,16 @@ def collapse_fps(fps, tol=1e-4):
     if not vals:
         return None
     f0 = vals[0]
-    return float(f0) if all(math.isclose(v, f0, rel_tol=tol, abs_tol=tol) for v in vals[1:]) else vals
+    return (
+        float(f0)
+        if all(math.isclose(v, f0, rel_tol=tol, abs_tol=tol) for v in vals[1:])
+        else vals
+    )
 
 
-def extract_vision_info(conversations: Union[List[Dict], List[List[Dict]]]) -> List[Dict]:
+def extract_vision_info(
+    conversations: Union[List[Dict], List[List[Dict]]],
+) -> List[Dict]:
     vision_infos = []
     if isinstance(conversations[0], dict):
         conversations = [conversations]
@@ -558,6 +661,8 @@ def extract_vision_info(conversations: Union[List[Dict], List[List[Dict]]]) -> L
                     if ele["type"] in ("image", "image_url", "video"):
                         vision_infos.append(ele)
     return vision_infos
+
+
 pass
 
 
@@ -565,10 +670,13 @@ def process_vision_info(
     conversations: Union[List[Dict], List[List[Dict]]],
     size_factor: int = IMAGE_FACTOR,
     return_video_kwargs: bool = False,
-) -> Tuple[Union[List[Image.Image], None], Union[List[Union[torch.Tensor, List[Image.Image]]], None]]:
-    
+    return_video_metadata: bool = False,
+) -> Tuple[
+    Union[List[Image.Image], None],
+    Union[List[Union[torch.Tensor, List[Image.Image]]], None],
+]:
     vision_infos = extract_vision_info(conversations)
-   
+
     ## Read images or videos
     image_inputs = []
     video_inputs = []
@@ -578,7 +686,12 @@ def process_vision_info(
         if "image" in vision_info or "image_url" in vision_info:
             image_inputs.append(fetch_image(vision_info, size_factor=size_factor))
         elif "video" in vision_info:
-            video_input, video_sample_fps = fetch_video(vision_info, image_factor=size_factor, return_video_sample_fps=True)
+            video_input, video_sample_fps = fetch_video(
+                vision_info,
+                image_factor=size_factor,
+                return_video_sample_fps=True,
+                return_video_metadata=return_video_metadata,
+            )
             video_sample_fps_list.append(video_sample_fps)
             video_inputs.append(video_input)
         else:
@@ -587,9 +700,17 @@ def process_vision_info(
         image_inputs = None
     if len(video_inputs) == 0:
         video_inputs = None
+
+    # For Qwen 3 VL compatibility: use do_sample_frames=False when returning video metadata
+    video_kwargs = {"do_sample_frames": False} if return_video_metadata else {}
+    if not return_video_metadata:  # BC for qwen2.5vl and older
+        video_kwargs["fps"] = video_sample_fps_list
+
     if return_video_kwargs:
-        return image_inputs, video_inputs, {'fps': video_sample_fps_list}
+        return image_inputs, video_inputs, video_kwargs
     return image_inputs, video_inputs
+
+
 pass
 
 
@@ -611,6 +732,8 @@ def get_padding_tokens_ids(tokenizer):
     padding_token_ids = list(set(padding_token_ids))
     padding_token_ids = torch.IntTensor(padding_token_ids)
     return padding_token_ids
+
+
 pass
 
 
@@ -623,57 +746,78 @@ def _get_dtype(dtype):
         "bfloat16": torch.bfloat16,
         torch.bfloat16: torch.bfloat16,
     }
-    if   dtype is None or dtype == None: return None
-    elif dtype in __DTYPE_MAP: return __DTYPE_MAP[dtype]
+    if dtype is None or dtype == None:
+        return None
+    elif dtype in __DTYPE_MAP:
+        return __DTYPE_MAP[dtype]
     else:
         print(f"Unsloth: {dtype} is not recognized, so we'll default to None")
         return None
     pass
+
+
 pass
 
 import PIL.Image
+
 LANCZOS = PIL.Image.Resampling.LANCZOS
 from .dataset_utils import train_on_responses_only as _train_on_responses_only
+
 
 class UnslothVisionDataCollator:
     # All Unsloth Zoo code licensed under LGPLv3
     __slots__ = (
-        "padding_token_ids", "dtype", "ignore_index",
-        "processor", "formatting_func", "image_size",
-        "max_seq_length", "truncation", "train_on_responses_only",
-        "num_proc", "assistant_single_content", "patch_size",
-        "resize_dimension", "snap_to_patch_size",
-        "completion_only_loss", "pad_to_multiple_of", "size_func",
+        "padding_token_ids",
+        "dtype",
+        "ignore_index",
+        "processor",
+        "formatting_func",
+        "image_size",
+        "max_seq_length",
+        "truncation",
+        "train_on_responses_only",
+        "num_proc",
+        "assistant_single_content",
+        "patch_size",
+        "resize_dimension",
+        "snap_to_patch_size",
+        "completion_only_loss",
+        "pad_to_multiple_of",
+        "size_func",
+        "return_video_metadata",  # For Qwen 3 VL support
     )
 
     def __init__(
         self,
         model,
         processor,
-        max_seq_length  = None,
-        formatting_func = None,
-        resize = "min", # Can be (10, 10) or "min" to resize to fit
-                        # the model's default image_size or "max"
-                        # for no resizing and leave image intact
-        ignore_index = -100,
-        train_on_responses_only = False,
-        instruction_part = None,
-        response_part    = None,
-        force_match      = True, # Match newlines as well!
-        num_proc         = None,
-        completion_only_loss = True,
-        pad_to_multiple_of = None,
-        resize_dimension = 0, # can be 0, 1, 'max' or 'min' (max resizes based on the max of height width, min the min size, 0 the first dim, etc)
-        snap_to_patch_size = False,
+        max_seq_length=None,
+        formatting_func=None,
+        resize="min",  # Can be (10, 10) or "min" to resize to fit
+        # the model's default image_size or "max"
+        # for no resizing and leave image intact
+        ignore_index=-100,
+        train_on_responses_only=False,
+        instruction_part=None,
+        response_part=None,
+        force_match=True,  # Match newlines as well!
+        num_proc=None,
+        completion_only_loss=True,
+        pad_to_multiple_of=None,
+        resize_dimension=0,  # can be 0, 1, 'max' or 'min' (max resizes based on the max of height width, min the min size, 0 the first dim, etc)
+        snap_to_patch_size=False,
+        return_video_metadata=None,  # Auto-detect for Qwen 3 VL, or set explicitly
     ):
         if not hasattr(processor, "image_processor"):
-            raise TypeError("Unsloth: UnslothVisionDataCollator is only for image models!")
+            raise TypeError(
+                "Unsloth: UnslothVisionDataCollator is only for image models!"
+            )
 
         self.padding_token_ids = get_padding_tokens_ids(processor)
         self.dtype = _get_dtype(
             dtype_from_config(model.config)
-            if HAS_TORCH_DTYPE else
-            model.get_input_embeddings().weight.dtype
+            if HAS_TORCH_DTYPE
+            else model.get_input_embeddings().weight.dtype
         )
         self.ignore_index = ignore_index
         self.processor = processor
@@ -684,10 +828,12 @@ class UnslothVisionDataCollator:
         try:
             self.patch_size = model.config.vision_config.patch_size
         except:
-            if hasattr(model.config, 'vision_config') and hasattr(model.config.vision_config, 'model_type'):
+            if hasattr(model.config, "vision_config") and hasattr(
+                model.config.vision_config, "model_type"
+            ):
                 lower_name = model.config.vision_config.model_type.lower()
-                if 'gemma3n' in lower_name or 'pixtral' in lower_name:
-                    self.patch_size = 16 #  really gemma3n doesn't have a patch size but expects images in 256, 512, or 768
+                if "gemma3n" in lower_name or "pixtral" in lower_name:
+                    self.patch_size = 16  #  really gemma3n doesn't have a patch size but expects images in 256, 512, or 768
                 else:
                     self.patch_size = IMAGE_FACTOR // 2
             else:
@@ -704,79 +850,113 @@ class UnslothVisionDataCollator:
         elif resize == "max":
             self.image_size = None
         elif isinstance(resize, (tuple, list)):
-            assert(len(resize) == 2)
-            assert(isinstance(resize[0], int) and isinstance(resize[1], int))
+            assert len(resize) == 2
+            assert isinstance(resize[0], int) and isinstance(resize[1], int)
             self.image_size = tuple(resize)
         elif type(resize) is int:
             self.image_size = resize
         else:
             raise TypeError(
-                "Unsloth: resize accepts 'min', 'max', a tuple of 2 numbers or 1 number\n"\
+                "Unsloth: resize accepts 'min', 'max', a tuple of 2 numbers or 1 number\n"
                 "For example (224, 224) or just 224. The default is 'min' which auto resizes images!"
             )
         pass
-        if resize_dimension not in [0, 1, 'max', 'min']:
+        if resize_dimension not in [0, 1, "max", "min"]:
             raise TypeError(
-                "Unsloth: resize_dimension accepts 0, 1, 'max' or 'min'\n"\
+                "Unsloth: resize_dimension accepts 0, 1, 'max' or 'min'\n"
                 "For example 0 resizes the first dimension, 1 the second, 'max' resizes based on the max of height width, 'min' the min size"
             )
         elif resize_dimension in [0, 1]:
             self.size_func = lambda x: x.size[resize_dimension]
-        elif resize_dimension == 'max':
+        elif resize_dimension == "max":
             self.size_func = lambda x: max(x.size[0], x.size[1])
-        elif resize_dimension == 'min':
+        elif resize_dimension == "min":
             self.size_func = lambda x: min(x.size[0], x.size[1])
         else:
             raise TypeError(
-                "Unsloth: resize_dimension accepts 0, 1, 'max' or 'min'\n"\
+                "Unsloth: resize_dimension accepts 0, 1, 'max' or 'min'\n"
                 "For example 0 resizes the first dimension, 1 the second, 'max' resizes based on the max of height width, 'min' the min size"
             )
         self.resize_dimension = resize_dimension
 
         # Sequence lengths
         if max_seq_length is None:
-            if hasattr(model, "max_seq_length"): max_seq_length = model.max_seq_length
-        self.max_seq_length = max(max_seq_length, 0) if type(max_seq_length) is int else None
+            if hasattr(model, "max_seq_length"):
+                max_seq_length = model.max_seq_length
+        self.max_seq_length = (
+            max(max_seq_length, 0) if type(max_seq_length) is int else None
+        )
         self.truncation = self.max_seq_length is not None
 
         # Train on reponses if provided
         if train_on_responses_only:
-            assert(isinstance(instruction_part, str) and isinstance(response_part, str))
+            assert isinstance(instruction_part, str) and isinstance(response_part, str)
             self.train_on_responses_only = _train_on_responses_only(
                 None,
-                instruction_part = instruction_part,
-                response_part    = response_part,
-                force_match      = force_match,
-                tokenizer        = processor,
-                return_function  = True,
-                num_proc         = num_proc,
+                instruction_part=instruction_part,
+                response_part=response_part,
+                force_match=force_match,
+                tokenizer=processor,
+                return_function=True,
+                num_proc=num_proc,
             )
         else:
             self.train_on_responses_only = None
 
+        # Auto-detect Qwen 3 VL for video metadata support
+        if return_video_metadata is None:
+            # Auto-detect based on model type
+            model_type = getattr(model.config, "model_type", "").lower()
+            # Qwen 3 VL needs video metadata, Qwen 2.5 VL uses fps
+            if "qwen3" in model_type or "qwen_3" in model_type:
+                self.return_video_metadata = True
+            elif hasattr(model.config, "_name_or_path"):
+                name = model.config._name_or_path.lower()
+                self.return_video_metadata = (
+                    "qwen3" in name or "qwen-3" in name or "qwen_3" in name
+                )
+            else:
+                self.return_video_metadata = False
+        else:
+            self.return_video_metadata = return_video_metadata
+
         # Check what type for assistant VLM tokenizer allows!
         # Good for Mistral V3 and Pixtral I think
         try:
-            processor.apply_chat_template([
-                {"role": "user", "content": [
-                    {"type": "image"},
-                    {"type": "text", "text": "Hello!"}]},
-                {"role": "assistant", "content": [
-                    {"type": "text", "text": "How can I help you?"}]}
-            ])
+            processor.apply_chat_template(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image"},
+                            {"type": "text", "text": "Hello!"},
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "How can I help you?"}],
+                    },
+                ]
+            )
             self.assistant_single_content = False
         except TypeError:
             try:
-                processor.apply_chat_template([
-                    {"role": "user", "content": [
-                        {"type": "image"},
-                        {"type": "text", "text": "Hello!"}]},
-                    {"role": "assistant", "content": "How can I help you?"}
-                ])
+                processor.apply_chat_template(
+                    [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "image"},
+                                {"type": "text", "text": "Hello!"},
+                            ],
+                        },
+                        {"role": "assistant", "content": "How can I help you?"},
+                    ]
+                )
                 self.assistant_single_content = True
                 print(
-                    f"Unsloth: {processor.__class__.__name__} only accepts 1 "\
-                    "text field for assistant roles!\n"\
+                    f"Unsloth: {processor.__class__.__name__} only accepts 1 "
+                    "text field for assistant roles!\n"
                     "We will auto fix the data collator to support it!"
                 )
             except Exception as e:
@@ -784,6 +964,7 @@ class UnslothVisionDataCollator:
         except Exception as e:
             raise RuntimeError(e)
         return
+
     pass
 
     def __call__(self, examples):
@@ -792,14 +973,17 @@ class UnslothVisionDataCollator:
 
         if self.formatting_func is not None:
             examples = [self.formatting_func(example) for example in examples]
-        
+
         if "prompt" in examples[0] and "completion" in examples[0]:
             return self._collate_prompt_completion(examples)
 
-        texts  = []
+        texts = []
         images = []
         videos = []
-        video_kwargs = {'fps': []}
+        video_metadata_list = []  # For Qwen 3 VL
+        video_kwargs = (
+            {"do_sample_frames": False} if self.return_video_metadata else {"fps": []}
+        )
         for example in examples:
             messages = self._select_messages_or_raw(example)
 
@@ -816,29 +1000,56 @@ class UnslothVisionDataCollator:
 
             message = self.processor.apply_chat_template(
                 messages,
-                tokenize = False,
-                add_generation_prompt = False,
+                tokenize=False,
+                add_generation_prompt=False,
             )
             texts.append(message)
             # Dataset with 2 columns messages / images
-            image, video, video_kwarg = self._extract_images_videos_for_example(example, messages)
+            image, video, video_kwarg = self._extract_images_videos_for_example(
+                example, messages
+            )
             image = self._resize_images_inplace(image)
             if len(image) > 0:
                 images.append(image)
 
             if len(video) > 0:  # Works for list, tuple or tensor
-                videos.append(video)
+                # When return_video_metadata=True, video is a list of (tensor, metadata) tuples
+                # We need to extract tensors and metadata separately for the processor
+                if self.return_video_metadata and video:
+                    # Extract video tensors and metadata from (video, metadata) tuples
+                    for v in video:
+                        if isinstance(v, tuple) and len(v) == 2:
+                            videos.append(v[0])  # Video tensor
+                            video_metadata_list.append(v[1])  # Metadata dict
+                        else:
+                            videos.append(v)
+                            # Create default metadata if not provided
+                            video_metadata_list.append(None)
+                else:
+                    videos.append(video)
                 if video_kwarg is None:
-                    video_kwarg = {"fps": []}
-                video_kwargs['fps'].extend(video_kwarg['fps'])
+                    video_kwarg = (
+                        {"fps": []}
+                        if not self.return_video_metadata
+                        else {"do_sample_frames": False}
+                    )
+                if not self.return_video_metadata and "fps" in video_kwarg:
+                    video_kwargs["fps"].extend(video_kwarg["fps"])
         pass
 
         # Tokenize the texts and process the images
+        # NOTE: For VLM models with videos, we disable truncation to avoid token mismatch
+        # The video/image tokens must match between text and input_ids
+        has_visual_content = (images and len(images) > 0) or (
+            videos and len(videos) > 0
+        )
         proc_kwargs = dict(
             text=texts,
             padding=True,
-            truncation=self.truncation,
-            max_length=self.max_seq_length,
+            truncation=False
+            if has_visual_content
+            else self.truncation,  # Disable truncation for visual content
+            max_length=self.max_seq_length if not has_visual_content else None,
             return_tensors="pt",
             add_special_tokens=False,
         )
@@ -846,19 +1057,29 @@ class UnslothVisionDataCollator:
             proc_kwargs["images"] = images
         if videos and len(videos) > 0:
             proc_kwargs["videos"] = videos
-            video_kwargs["fps"] = collapse_fps(video_kwargs['fps'])
-            for k, v in video_kwargs.items():
-                proc_kwargs[k] = v
+            if self.return_video_metadata:
+                # For Qwen 3 VL: use do_sample_frames=False and pass video_metadata
+                proc_kwargs["do_sample_frames"] = False
+                # Pass video metadata if available
+                if video_metadata_list and any(
+                    m is not None for m in video_metadata_list
+                ):
+                    proc_kwargs["video_metadata"] = video_metadata_list
+            else:
+                # For Qwen 2.5 VL and others: use fps
+                video_kwargs["fps"] = collapse_fps(video_kwargs["fps"])
+                for k, v in video_kwargs.items():
+                    proc_kwargs[k] = v
         if self.pad_to_multiple_of is not None:
             proc_kwargs["pad_to_multiple_of"] = self.pad_to_multiple_of
         batch = self.processor(**proc_kwargs)
 
         # Cannot remove due to bidirectional attention from Gemma 3!
         # batch.pop("token_type_ids", None)
-        if 'pixel_values' in batch:
+        if "pixel_values" in batch:
             batch = self._cast_pixel_values_dtype_inplace(batch)
-        if 'pixel_values_videos' in batch:
-            batch = self._cast_pixel_values_dtype_inplace(batch, 'pixel_values_videos')
+        if "pixel_values_videos" in batch:
+            batch = self._cast_pixel_values_dtype_inplace(batch, "pixel_values_videos")
 
         # Mask image tokens and pad tokens
         labels = batch["input_ids"].clone()
@@ -867,6 +1088,7 @@ class UnslothVisionDataCollator:
         if self.train_on_responses_only:
             batch["labels"] = self.train_on_responses_only(batch)["labels"]
         return batch
+
     pass
 
     def _select_messages_or_raw(self, example):
@@ -909,9 +1131,18 @@ class UnslothVisionDataCollator:
                     message["content"] = content[0]["text"]
         return messages
 
-    def _render_chat(self, prompt_messages, completion_messages=None, add_generation_prompt=False, continue_final_message=False):
+    def _render_chat(
+        self,
+        prompt_messages,
+        completion_messages=None,
+        add_generation_prompt=False,
+        continue_final_message=False,
+    ):
         return self.processor.apply_chat_template(
-            prompt_messages + (completion_messages or []), tokenize=False, add_generation_prompt=add_generation_prompt, continue_final_message=continue_final_message
+            prompt_messages + (completion_messages or []),
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+            continue_final_message=continue_final_message,
         )
 
     def _extract_images_videos_for_example(self, example, messages):
@@ -922,11 +1153,14 @@ class UnslothVisionDataCollator:
         else:
             image, video, video_kwarg = process_vision_info(
                 messages,
-                size_factor=self.patch_size*2,
+                size_factor=self.patch_size * 2,
                 return_video_kwargs=True,
+                return_video_metadata=self.return_video_metadata,
             )
-            if image is None: image = []
-            if video is None: video = [] 
+            if image is None:
+                image = []
+            if video is None:
+                video = []
         pass
         return image, video, video_kwarg
 
@@ -940,35 +1174,57 @@ class UnslothVisionDataCollator:
             if msg_list:
                 imgs, vids, vids_kwarg = process_vision_info(
                     msg_list,
-                    size_factor=self.patch_size*2,
+                    size_factor=self.patch_size * 2,
                     return_video_kwargs=True,
+                    return_video_metadata=self.return_video_metadata,
                 )
-                if imgs is None: imgs = []
-                if vids is None: vids = []
+                if imgs is None:
+                    imgs = []
+                if vids is None:
+                    vids = []
             else:
                 if "images" in example:
-                    vision_infos = [{'image': example['images'][i]} for i in range(len(example['images']))]
+                    vision_infos = [
+                        {"image": example["images"][i]}
+                        for i in range(len(example["images"]))
+                    ]
                     imgs, vids, vids_kwarg = process_vision_info(
                         vision_infos,
-                        size_factor=self.patch_size*2,
+                        size_factor=self.patch_size * 2,
                         return_video_kwargs=True,
+                        return_video_metadata=self.return_video_metadata,
                     )
-                    if imgs is None: imgs = []
-                    if vids is None: vids = []
+                    if imgs is None:
+                        imgs = []
+                    if vids is None:
+                        vids = []
         except Exception:
             imgs = []
             vids = []
-        
+
         return imgs, vids, vids_kwarg
 
     def _resize_images_inplace(self, image):
-
         def quantize_to_factor(x):
-            return max(factor, int(factor * (
-                math.ceil(x/factor) if x >= image_size - 1e-6 else math.floor(x/factor+0.5)
-            )))
+            return max(
+                factor,
+                int(
+                    factor
+                    * (
+                        math.ceil(x / factor)
+                        if x >= image_size - 1e-6
+                        else math.floor(x / factor + 0.5)
+                    )
+                ),
+            )
 
-        if image is None or self.image_size is None or (isinstance(self.image_size, (tuple, list)) and len(self.image_size) == 0):
+        if (
+            image is None
+            or self.image_size is None
+            or (
+                isinstance(self.image_size, (tuple, list)) and len(self.image_size) == 0
+            )
+        ):
             return image or []
         # Resize images
         image_size = self.image_size
@@ -980,17 +1236,24 @@ class UnslothVisionDataCollator:
                 elif self.size_func(img) > image_size and hasattr(img, "resize"):
                     w, h = img.size
                     # integer math rounding
-                    new_w = (w * image_size + self.size_func(img) // 2) // self.size_func(img)
-                    new_h = (h * image_size + self.size_func(img) // 2) // self.size_func(img)
+                    new_w = (
+                        w * image_size + self.size_func(img) // 2
+                    ) // self.size_func(img)
+                    new_h = (
+                        h * image_size + self.size_func(img) // 2
+                    ) // self.size_func(img)
                     if self.snap_to_patch_size:
                         factor = self.patch_size * 2
-                        new_w, new_h = quantize_to_factor(new_w), quantize_to_factor(new_h)
+                        new_w, new_h = (
+                            quantize_to_factor(new_w),
+                            quantize_to_factor(new_h),
+                        )
 
                     image[i] = img.resize((new_w, new_h), LANCZOS)
 
         return image
 
-    def _cast_pixel_values_dtype_inplace(self, batch, key='pixel_values'):
+    def _cast_pixel_values_dtype_inplace(self, batch, key="pixel_values"):
         # Pixtral accepts multiple images, so we have to cast it individually
         pixel_values = batch[key]
         if type(pixel_values) is list:
@@ -1016,16 +1279,18 @@ class UnslothVisionDataCollator:
         tok = getattr(self.processor, "tokenizer", self.processor)
         pad_id = getattr(tok, "pad_token_id", None)
         if pad_id is None:
-            raise ValueError("Tokenizer must define `pad_token_id` for prompt–completion collation.")
+            raise ValueError(
+                "Tokenizer must define `pad_token_id` for prompt–completion collation."
+            )
         return pad_id
 
     @torch.no_grad()
     def _flush_to_side(
         self,
         attention_mask: torch.Tensor,
-        input_ids:     torch.Tensor,
-        side:          str,
-        pad_token_id:  int,
+        input_ids: torch.Tensor,
+        side: str,
+        pad_token_id: int,
         extra_tensors: Sequence[torch.Tensor] | None = None,
         extra_pad_values: Sequence[int | float | bool] | None = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, tuple[torch.Tensor, ...]]:
@@ -1033,7 +1298,7 @@ class UnslothVisionDataCollator:
         device = input_ids.device
 
         keep = attention_mask.to(device=device, dtype=torch.bool)
-        k    = keep.sum(dim=1)
+        k = keep.sum(dim=1)
         rank = keep.to(device=device, dtype=torch.int64).cumsum(dim=1) - 1
 
         if side == "left":
@@ -1043,13 +1308,13 @@ class UnslothVisionDataCollator:
         else:
             raise ValueError("side must be 'left' or 'right'")
 
-        new_ids  = input_ids.new_full((B, L), pad_token_id)
+        new_ids = input_ids.new_full((B, L), pad_token_id)
         new_attn = attention_mask.new_zeros((B, L))
 
         ridx, csrc = keep.nonzero(as_tuple=True)
         cdst = dst[ridx, csrc].to(torch.long)
 
-        new_ids[ridx,  cdst] = input_ids[ridx, csrc]
+        new_ids[ridx, cdst] = input_ids[ridx, csrc]
         if new_attn.dtype == torch.bool:
             new_attn[ridx, cdst] = True
         else:
@@ -1060,7 +1325,9 @@ class UnslothVisionDataCollator:
         if extra_tensors is not None:
             if extra_pad_values is None:
                 extra_pad_values = [0] * len(extra_tensors)
-            assert len(extra_pad_values) == len(extra_tensors), "extra_pad_values must match extra_tensors"
+            assert len(extra_pad_values) == len(extra_tensors), (
+                "extra_pad_values must match extra_tensors"
+            )
             for m, padv in zip(extra_tensors, extra_pad_values):
                 out = m.new_full(m.shape, padv)
                 out[ridx, cdst] = m[ridx, csrc]
@@ -1072,40 +1339,75 @@ class UnslothVisionDataCollator:
                 sl = slice(L - max_k, L)
             else:
                 sl = slice(0, max_k)
-            new_ids  = new_ids[:,  sl]
+            new_ids = new_ids[:, sl]
             new_attn = new_attn[:, sl]
             if new_extras:
                 new_extras = [e[:, sl] for e in new_extras]
 
         return new_attn, new_ids, tuple(new_extras)
 
-    def _truncate_by_side(self, input_ids, attention_mask, completion_mask, side, max_len, token_type_ids=None):
+    def _truncate_by_side(
+        self,
+        input_ids,
+        attention_mask,
+        completion_mask,
+        side,
+        max_len,
+        token_type_ids=None,
+    ):
         _, L = input_ids.shape
         if L <= max_len:
-            return [input_ids, attention_mask, completion_mask] + ([token_type_ids] if token_type_ids is not None else [])
+            return [input_ids, attention_mask, completion_mask] + (
+                [token_type_ids] if token_type_ids is not None else []
+            )
         sl = slice(-max_len, None) if side == "left" else slice(0, max_len)
 
-        input_ids       = input_ids[:, sl]
-        attention_mask  = attention_mask[:, sl]
+        input_ids = input_ids[:, sl]
+        attention_mask = attention_mask[:, sl]
         completion_mask = completion_mask[:, sl]
 
         if token_type_ids is not None:
             token_type_ids = token_type_ids[:, sl]
-        return [input_ids, attention_mask, completion_mask] + ([token_type_ids] if token_type_ids is not None else [])
+        return [input_ids, attention_mask, completion_mask] + (
+            [token_type_ids] if token_type_ids is not None else []
+        )
 
-    def _pad_to_multiple(self, input_ids, attention_mask, completion_mask, side, pad_id, multiple, token_type_ids=None, token_type_pad_id=0):
+    def _pad_to_multiple(
+        self,
+        input_ids,
+        attention_mask,
+        completion_mask,
+        side,
+        pad_id,
+        multiple,
+        token_type_ids=None,
+        token_type_pad_id=0,
+    ):
         B, L = input_ids.shape
         L2 = ((L + multiple - 1) // multiple) * multiple
         if L2 == L:
-            return [input_ids, attention_mask, completion_mask] + ([token_type_ids] if token_type_ids is not None else [])
+            return [input_ids, attention_mask, completion_mask] + (
+                [token_type_ids] if token_type_ids is not None else []
+            )
         pad_len = L2 - L
 
-        pad_ids = torch.full((B, pad_len), pad_id, dtype=input_ids.dtype, device=input_ids.device)
-        zeros_att = torch.zeros((B, pad_len), dtype=attention_mask.dtype, device=attention_mask.device)
-        zeros_comp = torch.zeros((B, pad_len), dtype=completion_mask.dtype, device=completion_mask.device)
+        pad_ids = torch.full(
+            (B, pad_len), pad_id, dtype=input_ids.dtype, device=input_ids.device
+        )
+        zeros_att = torch.zeros(
+            (B, pad_len), dtype=attention_mask.dtype, device=attention_mask.device
+        )
+        zeros_comp = torch.zeros(
+            (B, pad_len), dtype=completion_mask.dtype, device=completion_mask.device
+        )
 
         if token_type_ids is not None:
-            pad_token_type_ids = torch.full((B, pad_len), token_type_pad_id, dtype=token_type_ids.dtype, device=token_type_ids.device)
+            pad_token_type_ids = torch.full(
+                (B, pad_len),
+                token_type_pad_id,
+                dtype=token_type_ids.dtype,
+                device=token_type_ids.device,
+            )
 
         if side == "left":
             input_ids = torch.cat((pad_ids, input_ids), dim=1)
@@ -1119,10 +1421,13 @@ class UnslothVisionDataCollator:
             completion_mask = torch.cat((completion_mask, zeros_comp), dim=1)
             if token_type_ids is not None:
                 token_type_ids = torch.cat((token_type_ids, pad_token_type_ids), dim=1)
-        return [input_ids, attention_mask, completion_mask] + ([token_type_ids] if token_type_ids is not None else [])
+        return [input_ids, attention_mask, completion_mask] + (
+            [token_type_ids] if token_type_ids is not None else []
+        )
 
     def _collate_prompt_completion(self, examples):
         prompt_texts, completion_texts, images, videos = [], [], [], []
+        video_metadata_list = []  # For Qwen 3 VL
 
         for ex in examples:
             p, c = ex["prompt"], ex["completion"]
@@ -1136,7 +1441,9 @@ class UnslothVisionDataCollator:
                 if self.assistant_single_content:
                     self._collapse_assistant_content(p)
                 p = self._clean_none_keys(p)
-                p_txt = self._render_chat(p, add_generation_prompt=True, continue_final_message=False)
+                p_txt = self._render_chat(
+                    p, add_generation_prompt=True, continue_final_message=False
+                )
             else:
                 p_txt = str(p)
 
@@ -1148,13 +1455,17 @@ class UnslothVisionDataCollator:
                 pc_txt = self._render_chat(prompt_messages=p, completion_messages=c)
                 # some models append common template items so this removes them.
                 # see trl/data_utils.py
-                p_txt = "".join(x for x, _ in takewhile(lambda x: x[0] == x[1], zip(p_txt, pc_txt)))
-                c_txt = pc_txt[len(p_txt):]
+                p_txt = "".join(
+                    x for x, _ in takewhile(lambda x: x[0] == x[1], zip(p_txt, pc_txt))
+                )
+                c_txt = pc_txt[len(p_txt) :]
             else:
                 c_txt = str(c)
 
             # Images: prefer embedded; else first top-level image; else []
-            imgs, vids, vids_kwarg = self._extract_images_for_pc(ex, p if is_p_msgs else None, c if is_c_msgs else None)
+            imgs, vids, vids_kwarg = self._extract_images_for_pc(
+                ex, p if is_p_msgs else None, c if is_c_msgs else None
+            )
             imgs = self._resize_images_inplace(imgs)
 
             prompt_texts.append(p_txt)
@@ -1163,11 +1474,22 @@ class UnslothVisionDataCollator:
                 images.append(imgs)
 
             if vids and len(vids) > 0:  # Works for list, tuple or tensor
-                videos.append(vids)
-                if vids_kwarg is None:
-                    vids_kwarg = {"fps": []}
-                vids_kwarg['fps'].extend(vids_kwarg['fps'])
+                # When return_video_metadata=True, vids is a list of (tensor, metadata) tuples
+                # We need to extract tensors and metadata separately for the processor
+                if self.return_video_metadata and vids:
+                    for v in vids:
+                        if isinstance(v, tuple) and len(v) == 2:
+                            videos.append(v[0])  # Video tensor
+                            video_metadata_list.append(v[1])  # Metadata dict
+                        else:
+                            videos.append(v)
+                            video_metadata_list.append(None)
+                else:
+                    videos.append(vids)
 
+        video_kwargs = (
+            {"do_sample_frames": False} if self.return_video_metadata else {"fps": []}
+        )
         prompt_kwargs = dict(
             padding=True,
             padding_side="left",
@@ -1184,9 +1506,18 @@ class UnslothVisionDataCollator:
             prompt_kwargs["images"] = images
         if len(videos) > 0:
             prompt_kwargs["videos"] = videos
-            vids_kwarg["fps"] = collapse_fps(vids_kwarg['fps'])
-            for k, v in vids_kwarg.items():
-                prompt_kwargs[k] = v
+            if self.return_video_metadata:
+                # For Qwen 3 VL: use do_sample_frames=False and pass video_metadata
+                prompt_kwargs["do_sample_frames"] = False
+                if video_metadata_list and any(
+                    m is not None for m in video_metadata_list
+                ):
+                    prompt_kwargs["video_metadata"] = video_metadata_list
+            else:
+                # For Qwen 2.5 VL and others: use fps
+                video_kwargs["fps"] = collapse_fps(video_kwargs.get("fps", []))
+                for k, v in video_kwargs.items():
+                    prompt_kwargs[k] = v
 
         proc_prompts = self.processor(text=prompt_texts, **prompt_kwargs)
         # Encode completions (RIGHT pad) text-only
@@ -1194,7 +1525,10 @@ class UnslothVisionDataCollator:
 
         p_ids, c_ids = proc_prompts["input_ids"], proc_completions["input_ids"]
         p_m, c_m = proc_prompts["attention_mask"], proc_completions["attention_mask"]
-        p_tt, c_tt = proc_prompts.get("token_type_ids", None), proc_completions.get("token_type_ids", None)
+        p_tt, c_tt = (
+            proc_prompts.get("token_type_ids", None),
+            proc_completions.get("token_type_ids", None),
+        )
 
         input_ids = torch.cat((p_ids, c_ids), dim=1)
         attention_mask = torch.cat((p_m, c_m), dim=1)
@@ -1208,20 +1542,41 @@ class UnslothVisionDataCollator:
         pad_id = self._pad_token_id_or_fail()
         flush_side = self._tokenizer_padding_side()
         if token_type_ids is not None:
-            attention_mask, input_ids, (completion_mask, token_type_ids) = self._flush_to_side(
-                attention_mask, input_ids, flush_side, pad_id, (completion_mask, token_type_ids)
+            attention_mask, input_ids, (completion_mask, token_type_ids) = (
+                self._flush_to_side(
+                    attention_mask,
+                    input_ids,
+                    flush_side,
+                    pad_id,
+                    (completion_mask, token_type_ids),
+                )
             )
 
             # Truncate with side awareness
             if self.max_seq_length is not None:
-                input_ids, attention_mask, completion_mask, token_type_ids = self._truncate_by_side(
-                    input_ids, attention_mask, completion_mask, flush_side, self.max_seq_length, token_type_ids=token_type_ids
+                input_ids, attention_mask, completion_mask, token_type_ids = (
+                    self._truncate_by_side(
+                        input_ids,
+                        attention_mask,
+                        completion_mask,
+                        flush_side,
+                        self.max_seq_length,
+                        token_type_ids=token_type_ids,
+                    )
                 )
 
             # Optional pad-to-multiple-of (manual in PC)
             if self.pad_to_multiple_of and self.pad_to_multiple_of > 1:
-                input_ids, attention_mask, completion_mask, token_type_ids = self._pad_to_multiple(
-                    input_ids, attention_mask, completion_mask, flush_side, pad_id, self.pad_to_multiple_of, token_type_ids=token_type_ids
+                input_ids, attention_mask, completion_mask, token_type_ids = (
+                    self._pad_to_multiple(
+                        input_ids,
+                        attention_mask,
+                        completion_mask,
+                        flush_side,
+                        pad_id,
+                        self.pad_to_multiple_of,
+                        token_type_ids=token_type_ids,
+                    )
                 )
         else:
             attention_mask, input_ids, (completion_mask,) = self._flush_to_side(
@@ -1231,12 +1586,21 @@ class UnslothVisionDataCollator:
             # Truncate with side awareness
             if self.max_seq_length is not None:
                 input_ids, attention_mask, completion_mask = self._truncate_by_side(
-                    input_ids, attention_mask, completion_mask, flush_side, self.max_seq_length
+                    input_ids,
+                    attention_mask,
+                    completion_mask,
+                    flush_side,
+                    self.max_seq_length,
                 )
 
             if self.pad_to_multiple_of and self.pad_to_multiple_of > 1:
                 input_ids, attention_mask, completion_mask = self._pad_to_multiple(
-                    input_ids, attention_mask, completion_mask, flush_side, pad_id, self.pad_to_multiple_of
+                    input_ids,
+                    attention_mask,
+                    completion_mask,
+                    flush_side,
+                    pad_id,
+                    self.pad_to_multiple_of,
                 )
 
         # Labels: mask attention pads + image/pad tokens; completion-only if requested
@@ -1253,10 +1617,10 @@ class UnslothVisionDataCollator:
         out["labels"] = labels
         if token_type_ids is not None:
             out["token_type_ids"] = token_type_ids
-        if 'pixel_values' in out:
+        if "pixel_values" in out:
             out = self._cast_pixel_values_dtype_inplace(out)
-        if 'pixel_values_videos' in out:
-            out = self._cast_pixel_values_dtype_inplace(out, 'pixel_values_videos')
+        if "pixel_values_videos" in out:
+            out = self._cast_pixel_values_dtype_inplace(out, "pixel_values_videos")
 
         return out
 
@@ -1271,4 +1635,6 @@ class UnslothVisionDataCollator:
                         for k in keys_to_remove:
                             del item[k]
         return messages
+
+
 pass


### PR DESCRIPTION
## Summary
Adds video metadata support for Qwen 3 VL models in `UnslothVisionDataCollator`.

## Problem
Qwen 3 VL uses `video_metadata` + `do_sample_frames=False` instead of `fps` parameter (used by Qwen 2.5 VL), causing token mismatch errors during fine-tuning.

## Solution
- Video readers now return `video_metadata` dict (fps, frames_indices, total_num_frames, backend)
- Added `return_video_metadata` parameter to `fetch_video()` and `process_vision_info()`
- Auto-detects Qwen 3 VL models and uses appropriate video kwargs
- Disabled truncation for visual content to prevent token mismatch

## Backward Compatibility
✅ Fully backward compatible - Qwen 2.5 VL and other models work unchanged.