### PR TITLE
Fix different devices error when using multiple GPUs with FSDP

### DIFF
--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -367,7 +367,7 @@ def unsloth_fused_ce_loss(
     scaling = scaler.get_scale() if scaler is not None else scaling
 
     if torch.is_tensor(n_items):
-        n_items = n_items.to(lm_head_weight.device)  # Keep the same device when using multiple GPUs
+        n_items = n_items.to(lm_head_weight.device, non_blocking=True)  # Keep the same device when using multiple GPUs
     if hasattr(scaling, "get_scale"): scaling = scaling.get_scale()
     if TARGET_GB: target_gb = float(TARGET_GB)
     elif N_CHUNKS: kwargs["n_chunks"] = max(int(N_CHUNKS), 1)

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -125,6 +125,11 @@ def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
         shift_labels = torch.empty_like(labels)
         shift_labels[..., :-1] = labels[..., 1:]
         shift_labels[..., -1] = ignore_index
+
+        # Keep the same device when multiple GPUs are used
+        shift_labels = shift_labels.to(shift_logits.device, non_blocking = True)
+        if torch.is_tensor(num_items_in_batch):
+            num_items_in_batch = num_items_in_batch.to(shift_logits.device, non_blocking = True)
         loss = unsloth_fixed_cross_entropy(shift_logits, shift_labels, num_items_in_batch, ignore_index, **kwargs)
         return loss
     pass
@@ -196,16 +201,16 @@ def fused_linear_cross_entropy(
 ):
     # All Unsloth Zoo code licensed under LGPLv3
     if num_items_in_batch is not None and torch.is_tensor(num_items_in_batch):
-        num_items_in_batch = num_items_in_batch.to(hidden_states.device, non_blocking = True)
+        num_items_in_batch = num_items_in_batch.to(lm_weight.device, non_blocking = True)
 
     reduction = "sum" if num_items_in_batch is not None else "mean"
     if logit_softcapping == 0: logit_softcapping = None
 
     with current_device(lm_weight.device):
         loss = linear_cross_entropy(
-            hidden_states.to(lm_weight.dtype),
+            hidden_states.to(dtype=lm_weight.dtype, device=lm_weight.device, non_blocking = True),
             lm_weight,
-            targets      = labels,
+            targets      = labels.to(lm_weight.device, non_blocking = True),
             ignore_index = ignore_index,
             softcap      = logit_softcapping,
             reduction    = reduction,


### PR DESCRIPTION
I found that it will raise error when fine-tuned `Qwen3-1.7B-GPTQ-Int8`, there is the traceback:
```
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
NotImplementedError: Cannot access storage of TensorWrapper

The above exception was the direct cause of the following exception:

Unsupported                               Traceback (most recent call last)
/tmp/ipykernel_47/773422404.py in <cell line: 0>()
----> 1 trainer_stats = trainer.train()

/kaggle/working/unsloth_compiled_cache/UnslothSFTTrainer.py in wrapper(self, *args, **kwargs)
     53         if hasattr(self, 'model') and hasattr(self.model, "for_training"):
     54             self.model.for_training()
---> 55         output = f(self, *args, **kwargs)
     56         # Return inference mode
     57         if hasattr(self, 'model') and hasattr(self.model, "for_inference"):

/usr/local/lib/python3.11/dist-packages/transformers/trainer.py in train(self, resume_from_checkpoint, trial, ignore_keys_for_eval, **kwargs)
   2326                 hf_hub_utils.enable_progress_bars()
   2327         else:
-> 2328             return inner_training_loop(
   2329                 args=args,
   2330                 resume_from_checkpoint=resume_from_checkpoint,

/kaggle/working/unsloth_zoo/compiler.py in _fast_inner_training_loop(self, batch_size, args, resume_from_checkpoint, trial, ignore_keys_for_eval)

/kaggle/working/unsloth_compiled_cache/UnslothSFTTrainer.py in training_step(self, *args, **kwargs)
   1064     def training_step(self, *args, **kwargs):
   1065         with self.maybe_activation_offload_context:
-> 1066             return super().training_step(*args, **kwargs)
   1067 
   1068     def log(self, logs: dict[str, float], start_time: Optional[float] = None) -> None:

/kaggle/working/unsloth/models/_utils.py in _unsloth_training_step(self, model, inputs, num_items_in_batch)

/kaggle/working/unsloth_compiled_cache/UnslothSFTTrainer.py in compute_loss(self, model, inputs, return_outputs, num_items_in_batch)
   1053         self, model, inputs, return_outputs = False, num_items_in_batch = None
   1054     ):
-> 1055         outputs = super().compute_loss(
   1056             model,
   1057             inputs,

/kaggle/working/unsloth/models/_utils.py in _unsloth_pre_compute_loss(self, model, inputs, *args, **kwargs)
   1649             "Read more on gradient accumulation issues here: https://unsloth.ai/blog/gradient"
   1650         )
-> 1651     outputs = self._old_compute_loss(model, inputs, *args, **kwargs)
   1652     return outputs
   1653 

/kaggle/working/unsloth/models/_utils.py in compute_loss(self, model, inputs, return_outputs, num_items_in_batch)

/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py in _wrapped_call_impl(self, *args, **kwargs)
   1773             return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1774         else:
-> 1775             return self._call_impl(*args, **kwargs)
   1776 
   1777     # torchrec tests the code consistency with the following code

/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py in _call_impl(self, *args, **kwargs)
   1784                 or _global_backward_pre_hooks or _global_backward_hooks
   1785                 or _global_forward_hooks or _global_forward_pre_hooks):
-> 1786             return forward_call(*args, **kwargs)
   1787 
   1788         result = None

/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py in forward(*args, **kwargs)
    816 
    817     def forward(*args, **kwargs):
--> 818         return model_forward(*args, **kwargs)
    819 
    820     # To act like a decorator so that it can be popped when doing `extract_model_from_parallel`

/usr/local/lib/python3.11/dist-packages/accelerate/utils/operations.py in __call__(self, *args, **kwargs)
    804 
    805     def __call__(self, *args, **kwargs):
--> 806         return convert_to_fp32(self.model_forward(*args, **kwargs))
    807 
    808     def __getstate__(self):

/usr/local/lib/python3.11/dist-packages/torch/amp/autocast_mode.py in decorate_autocast(*args, **kwargs)
     42     def decorate_autocast(*args, **kwargs):
     43         with autocast_instance:
---> 44             return func(*args, **kwargs)
     45 
     46     decorate_autocast.__script_unsupported = (  # type: ignore[attr-defined]

/usr/local/lib/python3.11/dist-packages/peft/peft_model.py in forward(self, input_ids, attention_mask, inputs_embeds, labels, output_attentions, output_hidden_states, return_dict, task_ids, **kwargs)
   1843             with self._enable_peft_forward_hooks(**kwargs):
   1844                 kwargs = {k: v for k, v in kwargs.items() if k not in self.special_peft_forward_args}
-> 1845                 return self.base_model(
   1846                     input_ids=input_ids,
   1847                     attention_mask=attention_mask,

/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py in _wrapped_call_impl(self, *args, **kwargs)
   1773             return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1774         else:
-> 1775             return self._call_impl(*args, **kwargs)
   1776 
   1777     # torchrec tests the code consistency with the following code

/usr/local/lib/python3.11/dist-packages/torch/nn/modules/module.py in _call_impl(self, *args, **kwargs)
   1784                 or _global_backward_pre_hooks or _global_backward_hooks
   1785                 or _global_forward_hooks or _global_forward_pre_hooks):
-> 1786             return forward_call(*args, **kwargs)
   1787 
   1788         result = None

/usr/local/lib/python3.11/dist-packages/peft/tuners/tuners_utils.py in forward(self, *args, **kwargs)
    214 
    215     def forward(self, *args: Any, **kwargs: Any):
--> 216         return self.model.forward(*args, **kwargs)
    217 
    218     def _pre_injection_hook(self, model: nn.Module, config: PeftConfig, adapter_name: str) -> None:

/usr/local/lib/python3.11/dist-packages/accelerate/hooks.py in new_forward(module, *args, **kwargs)
    173                 output = module._old_forward(*args, **kwargs)
    174         else:
--> 175             output = module._old_forward(*args, **kwargs)
    176         return module._hf_hook.post_forward(module, output)
    177 

/kaggle/working/unsloth_compiled_cache/unsloth_compiled_module_qwen3.py in forward(self, input_ids, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, cache_position, logits_to_keep, **kwargs)
    616         **kwargs: Unpack[TransformersKwargs],
    617     ) -> CausalLMOutputWithPast:
--> 618         return Qwen3ForCausalLM_forward(self, input_ids, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, cache_position, logits_to_keep, **kwargs)

/usr/local/lib/python3.11/dist-packages/torch/_dynamo/external_utils.py in nonrecursive_disable_wrapper(*args, **kwargs)
    194     @functools.wraps(fn)
    195     def nonrecursive_disable_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
--> 196         return fn(*args, **kwargs)
    197 
    198     return nonrecursive_disable_wrapper

/usr/local/lib/python3.11/dist-packages/transformers/utils/generic.py in wrapper(self, *args, **kwargs)
    938         if return_dict_passed is not None:
    939             return_dict = return_dict_passed
--> 940         output = func(self, *args, **kwargs)
    941         if not return_dict and not isinstance(output, tuple):
    942             output = output.to_tuple()

/kaggle/working/unsloth_compiled_cache/unsloth_compiled_module_qwen3.py in Qwen3ForCausalLM_forward(self, input_ids, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, cache_position, logits_to_keep, **kwargs)
    552         torch._dynamo.mark_dynamic(_hidden_states, 1)
    553         torch._dynamo.mark_dynamic(labels, 1)
--> 554         loss = unsloth_fused_ce_loss(
    555             trainer              = None,
    556             hidden_states        = _hidden_states,

/kaggle/working/unsloth_zoo/fused_losses/cross_entropy_loss.py in unsloth_fused_ce_loss(trainer, hidden_states, lm_head_weight, lm_head_bias, labels, mask, n_items, scaling, target_gb, torch_compile, overwrite, **kwargs)
    369     if TARGET_GB: target_gb = float(TARGET_GB)
    370     elif N_CHUNKS: kwargs["n_chunks"] = max(int(N_CHUNKS), 1)
--> 371     return apply_autograd_function(UnslothFusedLoss, dict(
    372         loss_function = compute_fused_ce_loss,
    373         hidden_states = hidden_states,

/kaggle/working/unsloth_zoo/fused_losses/cross_entropy_loss.py in apply_autograd_function(autograd, mapping)
     44 def apply_autograd_function(autograd, mapping):
     45     parameters, defaults = _get_mapping(autograd)
---> 46     return getattr(autograd, "apply")(*(
     47         mapping.get(old_key, default) \
     48         for old_key, default in zip(parameters, defaults)

/usr/local/lib/python3.11/dist-packages/torch/autograd/function.py in apply(cls, *args, **kwargs)
    579             # See NOTE: [functorch vjp and autograd interaction]
    580             args = _functorch.utils.unwrap_dead_wrappers(args)
--> 581             return super().apply(*args, **kwargs)  # type: ignore[misc]
    582 
    583         if not is_setup_ctx_defined:

/kaggle/working/unsloth_zoo/fused_losses/cross_entropy_loss.py in forward(ctx, loss_function, hidden_states, lm_head_weight, lm_head_bias, labels, mask, n_items, scaling, shift_labels, target_gb, torch_compile, overwrite, extra_kwargs)
    307         for (grad_inputs_j, hidden_states_j, labels_j,) in \
    308             zip(__grad_inputs, __shift_states, __shift_labels,):
--> 309             accumulate_chunk(
    310                 n_chunks = n_chunks,
    311                 grad_inputs_j = grad_inputs_j,

/usr/local/lib/python3.11/dist-packages/torch/_dynamo/eval_frame.py in compile_wrapper(*args, **kwargs)
    839                         cur_exn.__cause__.with_traceback(None)
    840                         cur_exn = cur_exn.__cause__
--> 841                     raise e.with_traceback(None) from e.__cause__  # User compiler error
    842                 except ShortenTraceback as e:
    843                     # Failures in the backend likely don't have useful

Unsupported: NotImplementedError/UnsupportedFakeTensorException when running FX node
  Explanation: Dynamo failed to run FX node with fake tensors: call_function <function _autograd_grad at 0x7c0eaa85bc40>(*((GradTrackingTensor(lvl=1, value=
        FakeTensor(..., device='cuda:0', size=())
    ),), [GradTrackingTensor(lvl=1, value=
        FakeTensor(..., device='cuda:1', size=(s97, 2048), dtype=torch.float16,
                   requires_grad=True)
    )]), **{'create_graph': True}): got NotImplementedError('Cannot access storage of TensorWrapper')
  Hint: If the op is a PyTorch op, please file an issue to PyTorch.

  Developer debug context: 

 For more details about this graph break, please visit: https://meta-pytorch.github.io/compile-graph-break-site/gb/gb0087.html

from user code:
   File "/kaggle/working/unsloth_zoo/fused_losses/cross_entropy_loss.py", line 281, in accumulate_chunk
    (chunk_loss, (unscaled_loss,)) = torch.func.grad_and_value(
  File "/usr/local/lib/python3.11/dist-packages/torch/_functorch/apis.py", line 449, in wrapper
    return eager_transforms.grad_and_value_impl(
  File "/usr/local/lib/python3.11/dist-packages/torch/_functorch/vmap.py", line 47, in fn
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.11/dist-packages/torch/_functorch/eager_transforms.py", line 1390, in grad_and_value_impl
    flat_grad_input = _autograd_grad(

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```
There is a [Kaggle notebook](https://www.kaggle.com/code/gdhy9064/qwen3-gptq-fsdp) which can reproduce it.

And similarly for `Qwen3-Coder-30B-A3B-Instruct-GPTQ-4bit` when setting the environment variable `UNSLOTH_COMPILE_DISABLE=1`. The trackback is:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[9], line 1
----> 1 trainer_stats = trainer.train()

File ~/autodl-tmp/unsloth_compiled_cache/UnslothSFTTrainer.py:55, in prepare_for_training_mode.<locals>.wrapper(self, *args, **kwargs)
     53 if hasattr(self, 'model') and hasattr(self.model, "for_training"):
     54     self.model.for_training()
---> 55 output = f(self, *args, **kwargs)
     56 # Return inference mode
     57 if hasattr(self, 'model') and hasattr(self.model, "for_inference"):

File ~/miniconda3/lib/python3.10/site-packages/transformers/trainer.py:2237, in Trainer.train(self, resume_from_checkpoint, trial, ignore_keys_for_eval, **kwargs)
   2235         hf_hub_utils.enable_progress_bars()
   2236 else:
-> 2237     return inner_training_loop(
   2238         args=args,
   2239         resume_from_checkpoint=resume_from_checkpoint,
   2240         trial=trial,
   2241         ignore_keys_for_eval=ignore_keys_for_eval,
   2242     )

File <string>:320, in _fast_inner_training_loop(self, batch_size, args, resume_from_checkpoint, trial, ignore_keys_for_eval)

File ~/autodl-tmp/unsloth_compiled_cache/UnslothSFTTrainer.py:1064, in _UnslothSFTTrainer.training_step(self, *args, **kwargs)
   1062 def training_step(self, *args, **kwargs):
   1063     with self.maybe_activation_offload_context:
-> 1064         return super().training_step(*args, **kwargs)

File <string>:34, in _unsloth_training_step(self, model, inputs, num_items_in_batch)

File ~/autodl-tmp/unsloth_compiled_cache/UnslothSFTTrainer.py:1053, in _UnslothSFTTrainer.compute_loss(self, model, inputs, return_outputs, num_items_in_batch)
   1050 def compute_loss(
   1051     self, model, inputs, return_outputs = False, num_items_in_batch = None
   1052 ):
-> 1053     outputs = super().compute_loss(
   1054         model,
   1055         inputs,
   1056         return_outputs = return_outputs,
   1057         num_items_in_batch = num_items_in_batch,
   1058     )
   1059     return outputs

File ~/miniconda3/lib/python3.10/site-packages/unsloth/models/_utils.py:1651, in _unsloth_pre_compute_loss(self, model, inputs, *args, **kwargs)
   1644     name = inner_model.__class__.__name__
   1646     logger.warning_once(
   1647         f"Unsloth: Not an error, but {name} does not accept `num_items_in_batch`.\n"
   1648         "Using gradient accumulation will be very slightly less accurate.\n"
   1649         "Read more on gradient accumulation issues here: https://unsloth.ai/blog/gradient"
   1650     )
-> 1651 outputs = self._old_compute_loss(model, inputs, *args, **kwargs)
   1652 return outputs

File <string>:36, in compute_loss(self, model, inputs, return_outputs, num_items_in_batch)

File ~/miniconda3/lib/python3.10/site-packages/torch/nn/modules/module.py:1775, in Module._wrapped_call_impl(self, *args, **kwargs)
   1773     return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1774 else:
-> 1775     return self._call_impl(*args, **kwargs)

File ~/miniconda3/lib/python3.10/site-packages/torch/nn/modules/module.py:1786, in Module._call_impl(self, *args, **kwargs)
   1781 # If we don't have any hooks, we want to skip the rest of the logic in
   1782 # this function, and just call forward.
   1783 if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
   1784         or _global_backward_pre_hooks or _global_backward_hooks
   1785         or _global_forward_hooks or _global_forward_pre_hooks):
-> 1786     return forward_call(*args, **kwargs)
   1788 result = None
   1789 called_always_called_hooks = set()

File ~/miniconda3/lib/python3.10/site-packages/accelerate/utils/operations.py:819, in convert_outputs_to_fp32.<locals>.forward(*args, **kwargs)
    818 def forward(*args, **kwargs):
--> 819     return model_forward(*args, **kwargs)

File ~/miniconda3/lib/python3.10/site-packages/accelerate/utils/operations.py:807, in ConvertOutputsToFp32.__call__(self, *args, **kwargs)
    806 def __call__(self, *args, **kwargs):
--> 807     return convert_to_fp32(self.model_forward(*args, **kwargs))

File ~/miniconda3/lib/python3.10/site-packages/torch/amp/autocast_mode.py:44, in autocast_decorator.<locals>.decorate_autocast(*args, **kwargs)
     41 @functools.wraps(func)
     42 def decorate_autocast(*args, **kwargs):
     43     with autocast_instance:
---> 44         return func(*args, **kwargs)

File ~/miniconda3/lib/python3.10/site-packages/peft/peft_model.py:1850, in PeftModelForCausalLM.forward(self, input_ids, attention_mask, inputs_embeds, labels, output_attentions, output_hidden_states, return_dict, task_ids, **kwargs)
   1848     with self._enable_peft_forward_hooks(**kwargs):
   1849         kwargs = {k: v for k, v in kwargs.items() if k not in self.special_peft_forward_args}
-> 1850         return self.base_model(
   1851             input_ids=input_ids,
   1852             attention_mask=attention_mask,
   1853             inputs_embeds=inputs_embeds,
   1854             labels=labels,
   1855             output_attentions=output_attentions,
   1856             output_hidden_states=output_hidden_states,
   1857             return_dict=return_dict,
   1858             **kwargs,
   1859         )
   1861 batch_size = _get_batch_size(input_ids, inputs_embeds)
   1862 if attention_mask is not None:
   1863     # concat prompt attention mask

File ~/miniconda3/lib/python3.10/site-packages/torch/nn/modules/module.py:1775, in Module._wrapped_call_impl(self, *args, **kwargs)
   1773     return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1774 else:
-> 1775     return self._call_impl(*args, **kwargs)

File ~/miniconda3/lib/python3.10/site-packages/torch/nn/modules/module.py:1786, in Module._call_impl(self, *args, **kwargs)
   1781 # If we don't have any hooks, we want to skip the rest of the logic in
   1782 # this function, and just call forward.
   1783 if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
   1784         or _global_backward_pre_hooks or _global_backward_hooks
   1785         or _global_forward_hooks or _global_forward_pre_hooks):
-> 1786     return forward_call(*args, **kwargs)
   1788 result = None
   1789 called_always_called_hooks = set()

File ~/miniconda3/lib/python3.10/site-packages/peft/tuners/tuners_utils.py:222, in BaseTuner.forward(self, *args, **kwargs)
    221 def forward(self, *args: Any, **kwargs: Any):
--> 222     return self.model.forward(*args, **kwargs)

File ~/miniconda3/lib/python3.10/site-packages/accelerate/hooks.py:175, in add_hook_to_module.<locals>.new_forward(module, *args, **kwargs)
    173         output = module._old_forward(*args, **kwargs)
    174 else:
--> 175     output = module._old_forward(*args, **kwargs)
    176 return module._hf_hook.post_forward(module, output)

File ~/miniconda3/lib/python3.10/site-packages/transformers/utils/generic.py:961, in can_return_tuple.<locals>.wrapper(self, *args, **kwargs)
    959 if return_dict_passed is not None:
    960     return_dict = return_dict_passed
--> 961 output = func(self, *args, **kwargs)
    962 if not return_dict and not isinstance(output, tuple):
    963     output = output.to_tuple()

File ~/miniconda3/lib/python3.10/site-packages/transformers/models/qwen3_moe/modeling_qwen3_moe.py:670, in Qwen3MoeForCausalLM.forward(self, input_ids, attention_mask, position_ids, past_key_values, inputs_embeds, labels, use_cache, output_router_logits, cache_position, logits_to_keep, **kwargs)
    668 loss = None
    669 if labels is not None:
--> 670     loss = self.loss_function(logits, labels, self.vocab_size, **kwargs)
    672 aux_loss = None
    673 if output_router_logits:

File ~/miniconda3/lib/python3.10/site-packages/unsloth_zoo/loss_utils.py:126, in patch_loss_functions.<locals>.UnslothForCausalLMLoss(logits, labels, vocab_size, num_items_in_batch, ignore_index, **kwargs)
    124 shift_labels[..., :-1] = labels[..., 1:]
    125 shift_labels[..., -1] = ignore_index
--> 126 loss = unsloth_fixed_cross_entropy(shift_logits, shift_labels, num_items_in_batch, ignore_index, **kwargs)
    127 return loss

File ~/miniconda3/lib/python3.10/site-packages/unsloth_zoo/loss_utils.py:96, in patch_loss_functions.<locals>.unsloth_fixed_cross_entropy(source, target, num_items_in_batch, ignore_index, **kwargs)
     94 def unsloth_fixed_cross_entropy(source, target, num_items_in_batch: int = None, ignore_index: int = -100, **kwargs):
     95     if ignore_index == -100:
---> 96         loss = _fast_cross_entropy_loss(
     97             logits  = source,
     98             labels  = target,
     99             n_items = num_items_in_batch,
    100         )
    101     else:
    102         reduction = "sum" if num_items_in_batch is not None else "mean"

File ~/miniconda3/lib/python3.10/site-packages/unsloth/kernels/cross_entropy_loss.py:440, in fast_cross_entropy_loss(logits, labels, logit_softcapping, logit_scaling, n_items)
    437 batch, seq_len, d = logits.shape
    438 assert labels.shape == (batch, seq_len)
--> 440 loss = Fast_CrossEntropyLoss.apply(
    441     logits.view(batch * seq_len, d),
    442     labels.view(-1),
    443     logit_softcapping,
    444     logit_scaling,
    445 )
    446 if n_items is None:
    447     n_items = torch.count_nonzero(labels != -100)

File ~/miniconda3/lib/python3.10/site-packages/torch/autograd/function.py:581, in Function.apply(cls, *args, **kwargs)
    578 if not torch._C._are_functorch_transforms_active():
    579     # See NOTE: [functorch vjp and autograd interaction]
    580     args = _functorch.utils.unwrap_dead_wrappers(args)
--> 581     return super().apply(*args, **kwargs)  # type: ignore[misc]
    583 if not is_setup_ctx_defined:
    584     raise RuntimeError(
    585         "In order to use an autograd.Function with functorch transforms "
    586         "(vmap, grad, jvp, jacrev, ...), it must override the setup_context "
    587         "staticmethod. For more details, please see "
    588         "https://pytorch.org/docs/main/notes/extending.func.html"
    589     )

File ~/miniconda3/lib/python3.10/site-packages/unsloth/kernels/cross_entropy_loss.py:348, in Fast_CrossEntropyLoss.forward(ctx, logits, labels, logit_softcapping, logit_scaling)
    338 logsumexp = torch.empty(
    339     (
    340         n_rows,
   (...)
    344     device = device,
    345 )
    347 with torch_gpu_device(device):
--> 348     _chunked_cross_entropy_forward[
    349         (
    350             n_rows,
    351             n_chunks,
    352         )
    353     ](
    354         logits,
    355         logits.stride(0),
    356         losses,
    357         logsumexp,
    358         labels,
    359         VOCAB_SIZE = vocab_size,
    360         N_CHUNKS = n_chunks,
    361         BLOCK_SIZE = MAX_FUSED_SIZE,
    362         DO_SOFTCAPPING = DO_SOFTCAPPING,
    363         SOFTCAP = logit_softcapping,
    364         DO_LOGIT_SCALING = DO_LOGIT_SCALING,
    365         LOGIT_SCALE = logit_scaling,
    366         num_warps = 32 if not is_cdna() else 16,
    367     )
    368 # logsumexp(chunked_logsumexp) - x
    369 # Do the -x separately
    370 logsumexp = torch.logsumexp(logsumexp, dim = 1)  # Row sum

File ~/miniconda3/lib/python3.10/site-packages/triton/runtime/jit.py:419, in KernelInterface.__getitem__.<locals>.<lambda>(*args, **kwargs)
    413 def __getitem__(self, grid) -> T:
    414     """
    415     A JIT function is launched with: fn[grid](*args, **kwargs).
    416     Hence JITFunction.__getitem__ returns a callable proxy that
    417     memorizes the grid.
    418     """
--> 419     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)

File ~/miniconda3/lib/python3.10/site-packages/triton/runtime/autotuner.py:452, in Heuristics.run(self, *args, **kwargs)
    450 for v, heur in self.values.items():
    451     kwargs[v] = heur({**dict(zip(self.arg_names, args)), **kwargs})
--> 452 return self.fn.run(*args, **kwargs)

File ~/miniconda3/lib/python3.10/site-packages/triton/runtime/jit.py:757, in JITFunction.run(self, grid, warmup, *args, **kwargs)
    755     # launch kernel
    756     launch_metadata = kernel.launch_metadata(grid, stream, *bound_args.values())
--> 757     kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
    758                knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook, *bound_args.values())
    759 return kernel

File ~/miniconda3/lib/python3.10/site-packages/triton/backends/nvidia/driver.py:712, in CudaLauncher.__call__(self, gridX, gridY, gridZ, stream, function, *args)
    709 global_scratch = allocate_scratch(self.global_scratch_size, self.global_scratch_align, _allocation._allocator)
    710 profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
    711                                    _allocation._profile_allocator)
--> 712 self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
    713             global_scratch, profile_scratch, *args)

ValueError: Pointer argument (at 4) cannot be accessed from Triton (cpu tensor?)
```

I have fix them in this PR, please take a check.