### PR TITLE
fix: psutil import at function level and GGUF sharding support

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -195,6 +195,7 @@ def train_on_responses_only(
     the labels with -100 for the instruction part.
     """
     # All Unsloth Zoo code licensed under LGPLv3
+    import psutil  # Import at function level to ensure it's captured during compilation
     if tokenizer is None and trainer is not None:
         tokenizer = trainer.processing_class if hasattr(trainer, "processing_class") else trainer.tokenizer
     # Get non vision tokenizer
@@ -329,7 +330,6 @@ def train_on_responses_only(
         return _train_on_responses_only
 
     if num_proc is None or type(num_proc) is not int:
-        import psutil
         num_proc = min(max(psutil.cpu_count()+4, 2), 64)
         # Check memory left so we can reduce multiprocessing to converse memory
         memory_gb_left = psutil.virtual_memory().available / (1024**3)
@@ -517,6 +517,7 @@ def sft_prepare_dataset(
     dataset_name: str,
 ) -> Union[Dataset, IterableDataset]:
     # All Unsloth Zoo code licensed under LGPLv3
+    import psutil  # Import at function level to ensure it's captured during compilation
     try:
         if isinstance(dataset, ConstantLengthDataset): return dataset
     except:
@@ -613,7 +614,6 @@ def sft_prepare_dataset(
         if not isinstance(dataset, IterableDataset):
             dataset_num_proc = getattr(args, "dataset_num_proc", None)
             if dataset_num_proc is None:
-                import psutil
                 dataset_num_proc = max(psutil.cpu_count()+4, 2)
                 # Check memory left so we can reduce multiprocessing to converse memory
                 memory_gb_left = psutil.virtual_memory().available / (1024**3)

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -1003,20 +1003,48 @@ def convert_to_gguf(
             raise RuntimeError(f"Unsloth: Failed to convert {description} to GGUF: {e}")
 
         # Simple validation using native Python
-        if not os.path.exists(output_file):
+        # Check for both single file and sharded files (when model > split-max-size)
+        output_exists = os.path.exists(output_file)
+        sharded_files = []
+        if not output_exists:
+            # Check for sharded output pattern: model.BF16-00001-of-00002.gguf
+            # When llama.cpp splits output, it uses format: {base}-{shard:05d}-of-{total:05d}.gguf
+            base_name = output_file.rsplit('.gguf', 1)[0]
+            shard_pattern = f"{base_name}-*-of-*.gguf"
+            sharded_files = sorted(Path(output_file).parent.glob(Path(shard_pattern).name)) if '/' in output_file or '\\' in output_file else sorted(Path('.').glob(shard_pattern))
+            output_exists = len(sharded_files) > 0
+
+        if not output_exists:
             raise RuntimeError(f"Unsloth: Failed to convert {description} - output file {output_file} not created")
 
-        all_output_files.append(output_file)
+        # Append either single file or list of sharded files
+        if sharded_files:
+            all_output_files.extend([str(f) for f in sharded_files])
+            if print_output:
+                print(f"Unsloth: Model was sharded into {len(sharded_files)} files due to size limit")
+        else:
+            all_output_files.append(output_file)
 
         if print_output:
-            file_size_bytes = os.path.getsize(output_file)
-            if file_size_bytes >= 1024**3:  # GB
-                size_str = f"{file_size_bytes / (1024**3):.1f}G"
-            elif file_size_bytes >= 1024**2:  # MB
-                size_str = f"{file_size_bytes / (1024**2):.1f}M"
+            if sharded_files:
+                # Calculate total size across all shards
+                total_size_bytes = sum(f.stat().st_size for f in sharded_files)
+                if total_size_bytes >= 1024**3:
+                    size_str = f"{total_size_bytes / (1024**3):.1f}G"
+                elif total_size_bytes >= 1024**2:
+                    size_str = f"{total_size_bytes / (1024**2):.1f}M"
+                else:
+                    size_str = f"{total_size_bytes / 1024:.1f}K"
+                print(f"Unsloth: Successfully saved {description} GGUF ({len(sharded_files)} shards, total size: {size_str})")
             else:
-                size_str = f"{file_size_bytes / 1024:.1f}K"
-            print(f"Unsloth: Successfully saved {description} GGUF to: {output_file} (size: {size_str})")
+                file_size_bytes = os.path.getsize(output_file)
+                if file_size_bytes >= 1024**3:  # GB
+                    size_str = f"{file_size_bytes / (1024**3):.1f}G"
+                elif file_size_bytes >= 1024**2:  # MB
+                    size_str = f"{file_size_bytes / (1024**2):.1f}M"
+                else:
+                    size_str = f"{file_size_bytes / 1024:.1f}K"
+                print(f"Unsloth: Successfully saved {description} GGUF to: {output_file} (size: {size_str})")
 
     return all_output_files, is_vlm
 pass


### PR DESCRIPTION
## Summary

This PR addresses two issues:

### 1. Fix psutil import for compiled code (related to unsloth#3800)

**Problem:** When `SFTTrainer` code is compiled/cached via `inspect.getsource()`, the `import psutil` statement inside conditional blocks (`if dataset_num_proc is None:`) was being lost, causing `NameError: name 'psutil' is not defined`.

**Solution:** Moved `import psutil` to function level in both:
- `train_on_responses_only()` 
- `sft_prepare_dataset()`

This ensures the import is captured during code compilation.

### 2. Add support for sharded GGUF files (fixes unsloth#3773)

**Problem:** When converting large models (>50GB) to GGUF, `llama.cpp` automatically shards the output (e.g., `model.BF16-00001-of-00002.gguf`), but Unsloth only checked for the single file name and threw `RuntimeError`.

**Solution:** 
- Added detection for sharded output files using glob pattern matching
- Properly handles sharded file lists in `all_output_files`
- Added proper size reporting that sums all shard sizes

## Test plan

- [x] Code follows the existing style in the repository
- [ ] Tested psutil fix by running SFTTrainer with `TrainingArguments`
- [ ] Tested GGUF sharding with a large model (>50GB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)