### PR TITLE
fix: tuple patch size and gradient checkpointing default

### DIFF
--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -198,8 +198,10 @@ def prepare_model_for_training(
         m.gradient_checkpointing_enable()
 
     # Also set HF version manually to stop failures
+    # Only enable if use_gradient_checkpointing is True or "unsloth"
     if hasattr(model, "_set_gradient_checkpointing"):
-        model._set_gradient_checkpointing()
+        enable = use_gradient_checkpointing in (True, "unsloth")
+        model._set_gradient_checkpointing(enable=enable)
 
     # If use_reentrant = True which is the Pytorch default, we just make the input requires_grad.
     if use_reentrant:

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -682,7 +682,11 @@ class UnslothVisionDataCollator:
         self.pad_to_multiple_of = pad_to_multiple_of
         self.snap_to_patch_size = snap_to_patch_size
         try:
-            self.patch_size = model.config.vision_config.patch_size
+            patch_size = model.config.vision_config.patch_size
+            # Handle tuple patch sizes (e.g., (14, 14)) by using the first element
+            if isinstance(patch_size, (tuple, list)):
+                patch_size = patch_size[0]
+            self.patch_size = patch_size
         except:
             if hasattr(model.config, 'vision_config') and hasattr(model.config.vision_config, 'model_type'):
                 lower_name = model.config.vision_config.model_type.lower()


### PR DESCRIPTION
## Summary

This PR fixes two issues:

### 1. Fix #316: Handle tuple patch sizes in UnslothVisionDataCollator

**Problem:** Models like [InternVL3-2B-hf](https://huggingface.co/OpenGVLab/InternVL3-2B-hf/blob/main/config.json) specify `patch_size` as a tuple of 2 ints (e.g., `(14, 14)`), but `UnslothVisionDataCollator` expected an int and crashed when trying to do arithmetic (`self.patch_size * 2`).

**Solution:** Check if `patch_size` is a tuple/list and extract the first element.

```python
patch_size = model.config.vision_config.patch_size
if isinstance(patch_size, (tuple, list)):
    patch_size = patch_size[0]
self.patch_size = patch_size
```

### 2. Fix #320: Respect use_gradient_checkpointing=False setting

**Problem:** In `prepare_model_for_training()`, `model._set_gradient_checkpointing()` was called without any arguments. The transformers library defaults to `enable=True`, which overrides the user's explicit `use_gradient_checkpointing=False` setting.

**Solution:** Pass the `enable` parameter based on the user's `use_gradient_checkpointing` value:

```python
enable = use_gradient_checkpointing in (True, "unsloth")
model._set_gradient_checkpointing(enable=enable)
```

## Test plan

- [x] Code follows the existing style in the repository
- [ ] Tested with InternVL3 or similar model with tuple patch_size
- [ ] Tested with `use_gradient_checkpointing=False` to verify checkpointing is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)