### PR TITLE
fix: use thinking content in encode_conversations_with_harmony

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1345,8 +1345,16 @@ def encode_conversations_with_harmony(
             )
         elif message["role"] == "assistant":
             if "thinking" in message:
-                x = Message.from_role_and_content(Role.ASSISTANT, message["content"])
+                # Add the thinking content with "analysis" channel
+                x = Message.from_role_and_content(Role.ASSISTANT, message["thinking"])
                 x = x.with_channel("analysis")
+                convos.append(x)
+                # Also add the final content if present
+                if "content" in message and message["content"]:
+                    x = Message.from_role_and_content(Role.ASSISTANT, message["content"])
+                    x = x.with_channel("final")
+                    convos.append(x)
+                continue  # Skip the convos.append at the end since we already appended
             elif "tool_calls" in message:
                 x = Message.from_role_and_content(Role.ASSISTANT, message['tool_calls'][0]["arguments"])
                 x = x.with_channel("commentary")\


### PR DESCRIPTION
## Summary
- Fixes `encode_conversations_with_harmony` to properly use `message["thinking"]` instead of `message["content"]` when the "thinking" key is present
- Also includes the final content with "final" channel when both thinking and content are present
- Previously, the thinking/analysis content was completely lost

## Related Issue
Fixes #246

## Test plan
- [ ] Verify messages with `thinking` key now properly encode the thinking content with "analysis" channel
- [ ] Verify messages with both `thinking` and `content` include both pieces of content
- [ ] Verify messages without `thinking` still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)