### PR TITLE
Add Alpine, openSUSE and Gentoo to the llama.cpp package-manager paths

### DIFF
--- a/tests/test_llama_cpp_distro_support.py
+++ b/tests/test_llama_cpp_distro_support.py
@@ -1,0 +1,132 @@
+"""Distro detection and package-manager mapping in llama_cpp.py.
+
+Covers the Alpine / openSUSE / Gentoo additions: `check_linux_type` picks them
+up from their release files or /etc/os-release, the per-distro package maps
+have an entry for each, and the package-not-found detection matches each
+manager's own phrase without matching an ordinary "not found" line.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_llama_cpp_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+    spec = importlib.util.spec_from_file_location("llama_cpp_under_test_distro", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def llama_cpp():
+    return _load_llama_cpp_module()
+
+
+def _only_these_files_exist(monkeypatch, present):
+    real_exists = os.path.exists
+
+    def fake_exists(path):
+        if str(path).startswith("/etc/"):
+            return str(path) in present
+        return real_exists(path)
+
+    monkeypatch.setattr(os.path, "exists", fake_exists)
+
+
+@pytest.mark.parametrize(
+    "release_file, expected",
+    [
+        ("/etc/debian_version", "debian"),
+        ("/etc/fedora-release", "rpm"),
+        ("/etc/arch-release", "arch"),
+        ("/etc/alpine-release", "alpine"),
+        ("/etc/gentoo-release", "gentoo"),
+    ],
+)
+def test_check_linux_type_from_release_file(llama_cpp, monkeypatch, release_file, expected):
+    monkeypatch.setattr(llama_cpp.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(llama_cpp, "_os_release_ids", lambda: set())
+    _only_these_files_exist(monkeypatch, {release_file})
+    assert llama_cpp.check_linux_type() == expected
+
+
+@pytest.mark.parametrize(
+    "ids, expected",
+    [
+        ({"opensuse-leap", "suse", "opensuse"}, "suse"),  # openSUSE Leap: ID + ID_LIKE
+        ({"opensuse-tumbleweed", "suse", "opensuse"}, "suse"),
+        ({"sles"}, "suse"),  # SLES sets ID=sles, ID_LIKE=suse on most releases
+        ({"ubuntu", "debian"}, "unknown"),  # no release file matched, os-release is not suse
+        (set(), "unknown"),
+    ],
+)
+def test_check_linux_type_from_os_release(llama_cpp, monkeypatch, ids, expected):
+    monkeypatch.setattr(llama_cpp.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(llama_cpp, "_os_release_ids", lambda: ids)
+    _only_these_files_exist(monkeypatch, set())
+    assert llama_cpp.check_linux_type() == expected
+
+
+def test_os_release_ids_parses_id_and_id_like(llama_cpp, tmp_path, monkeypatch):
+    os_release = tmp_path / "os-release"
+    os_release.write_text('NAME="openSUSE Leap"\nID="opensuse-leap"\nID_LIKE="suse opensuse"\nVERSION_ID="15.6"\n')
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/etc/os-release":
+            return real_open(os_release, *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert llama_cpp._os_release_ids() == {"opensuse-leap", "suse", "opensuse"}
+
+
+def test_os_release_ids_is_empty_when_unreadable(llama_cpp, monkeypatch):
+    def fake_open(path, *args, **kwargs):
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert llama_cpp._os_release_ids() == set()
+
+
+@pytest.mark.parametrize("system_type", ["rpm", "arch", "alpine", "suse", "gentoo"])
+def test_every_distro_has_a_manager_name_and_build_tools(llama_cpp, system_type):
+    assert system_type in llama_cpp.PACKAGE_MANAGER_NAMES
+    assert "build-essential" in llama_cpp.DISTRO_PACKAGES[system_type]
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "E: Unable to locate package libcurl4-openssl-dev",  # apt-get
+        "Error: No match for argument: libcurl-devel",  # dnf
+        "error: target not found: curl",  # pacman
+        "ERROR: unable to select packages:",  # apk
+        "No provider of 'libcurl-devel' found.",  # zypper
+        "emerge: there are no ebuilds to satisfy \"net-misc/curl\".",  # emerge
+    ],
+)
+def test_package_not_found_matches_each_manager(llama_cpp, line):
+    assert any(marker in line for marker in llama_cpp.PACKAGE_NOT_FOUND)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "Setting up libcurl4-openssl-dev (8.5.0-2ubuntu10) ...",
+        "(1/3) Installing curl-dev (8.9.1-r1)",
+        "Package 'libgomp1' is not found in cache, downloading.",  # a plain "not found" that is not an error
+        "  Fetching https://... (cache not found, retrying)",
+    ],
+)
+def test_package_not_found_ignores_ordinary_output(llama_cpp, line):
+    assert not any(marker in line for marker in llama_cpp.PACKAGE_NOT_FOUND)

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -83,6 +83,38 @@ COMMANDS_NOT_FOUND = (
     "not found",
     "No such file or directory",
 )
+
+# What each package manager prints when a package does not exist. Matching the
+# manager's own phrase (rather than any "not found") keeps ordinary installer
+# output from aborting a working install.
+PACKAGE_NOT_FOUND = (
+    "Unable to locate package",   # apt-get
+    "No match for argument",      # dnf / yum
+    "error: target not found",    # pacman
+    "unable to select packages",  # apk
+    "No provider of",             # zypper
+    "there are no ebuilds",       # emerge
+)
+
+PACKAGE_MANAGER_NAMES = {
+    "rpm": "yum/dnf",
+    "arch": "pacman",
+    "alpine": "apk",
+    "suse": "zypper",
+    "gentoo": "emerge",
+}
+
+# Debian package name -> what the same tool is called elsewhere. Missing
+# entries keep the Debian name.
+DISTRO_PACKAGES = {
+    "rpm":    {"build-essential": "gcc gcc-c++ make"},
+    "arch":   {"build-essential": "base-devel"},
+    "alpine": {"build-essential": "build-base"},
+    "suse":   {"build-essential": "gcc gcc-c++ make"},
+    "gentoo": {"build-essential": "sys-devel/gcc sys-devel/make", "cmake": "dev-build/cmake",
+               "curl": "net-misc/curl", "git": "dev-vcs/git"},
+}
+
 PIP_MODULE_NOT_FOUND = (
     "no module named pip",
     "no module named 'pip'",
@@ -341,6 +373,12 @@ def install_package(package, sudo = False, print_output = False, print_outputs =
         install_cmd = f"{'sudo ' if sudo else ''}{pkg_manager} install {package} -y"
     elif system_type == "arch":
         install_cmd = f"{'sudo ' if sudo else ''}pacman -S --noconfirm {package}"
+    elif system_type == "alpine":
+        install_cmd = f"{'sudo ' if sudo else ''}apk add {package}"
+    elif system_type == "suse":
+        install_cmd = f"{'sudo ' if sudo else ''}zypper --non-interactive install {package}"
+    elif system_type == "gentoo":
+        install_cmd = f"{'sudo ' if sudo else ''}emerge --ask=n {package}"
     else:  # Default to debian/apt-get
         install_cmd = f"{'sudo ' if sudo else ''}apt-get install {package} -y"
 
@@ -363,9 +401,9 @@ def install_package(package, sudo = False, print_output = False, print_outputs =
                     )
             elif line.endswith(COMMANDS_NOT_FOUND):
                 sp.terminate()
-                pkg_mgr_name = {"rpm": "yum/dnf", "arch": "pacman"}.get(system_type, "apt-get")
+                pkg_mgr_name = PACKAGE_MANAGER_NAMES.get(system_type, "apt-get")
                 raise RuntimeError(f"[FAIL] Unsloth: {pkg_mgr_name} does not exist when installing {package}? Is this NOT a Linux / Mac based computer?")
-            elif "Unable to locate package" in line:
+            elif any(marker in line for marker in PACKAGE_NOT_FOUND):
                 sp.terminate()
                 raise RuntimeError(f"[FAIL] Unsloth: Could not install package {package} since it does not exist.")
             if print_output: print(line, flush = True, end = "")
@@ -390,6 +428,14 @@ def do_we_need_sudo(system_type="debian"):
         update_cmd = f"{pkg_manager} check-update"
     elif system_type == "arch":
         update_cmd = "pacman -Sy"
+    elif system_type == "alpine":
+        update_cmd = "apk update"
+    elif system_type == "suse":
+        update_cmd = "zypper --non-interactive refresh"
+    elif system_type == "gentoo":
+        # `emerge --sync` takes minutes and would trip the 180 s no-internet check
+        # below; portage always needs root, so answer from the effective uid.
+        return os.geteuid() != 0
     else:
         update_cmd = "apt-get update -y"
 
@@ -403,7 +449,7 @@ def do_we_need_sudo(system_type="debian"):
                 break
             elif line.endswith(COMMANDS_NOT_FOUND):
                 sp.terminate()
-                pkg_mgr_name = {"rpm": "yum/dnf", "arch": "pacman"}.get(system_type, "apt-get")
+                pkg_mgr_name = PACKAGE_MANAGER_NAMES.get(system_type, "apt-get")
                 raise RuntimeError(f"[FAIL] Unsloth: {pkg_mgr_name} does not exist? Is this NOT a Linux / Mac based computer?")
             elif "failure resolving" in line or "Err:" in line:
                 sp.terminate()
@@ -3311,22 +3357,7 @@ def check_build_requirements():
             result = subprocess.run(['which', tool], capture_output=True, text=True)
             if result.returncode != 0:
                 # Adjust package names for non-Debian systems
-                if system_type == "rpm":
-                    distro_packages = {
-                        'build-essential': 'gcc gcc-c++ make',
-                        'cmake': 'cmake',
-                        'curl': 'curl',
-                        'git': 'git',
-                    }
-                    package = distro_packages.get(package, package)
-                elif system_type == "arch":
-                    distro_packages = {
-                        'build-essential': 'base-devel',
-                        'cmake': 'cmake',
-                        'curl': 'curl',
-                        'git': 'git',
-                    }
-                    package = distro_packages.get(package, package)
+                package = DISTRO_PACKAGES.get(system_type, {}).get(package, package)
                 missing_packages.append(package)
         except Exception:
             missing_packages.append(package)
@@ -3334,13 +3365,15 @@ def check_build_requirements():
     # Check for libgomp (OpenMP runtime) - needed for llama.cpp CPU backend linking
     gomp_path = _find_lib_path('libgomp.so')
     if gomp_path is None:
-        gomp_packages = {'debian': 'libgomp1', 'rpm': 'libgomp-devel', 'arch': 'gcc'}
+        gomp_packages = {'debian': 'libgomp1', 'rpm': 'libgomp-devel', 'arch': 'gcc',
+                         'alpine': 'libgomp', 'suse': 'libgomp1', 'gentoo': 'sys-devel/gcc'}
         missing_packages.append(gomp_packages.get(system_type, 'libgomp1'))
 
     # Check for libssl-dev (OpenSSL development) - needed for HTTPS support
     ssl_path = _find_lib_path('libssl.so')
     if ssl_path is None:
-        ssl_packages = {'debian': 'libssl-dev', 'rpm': 'openssl-devel', 'arch': 'openssl'}
+        ssl_packages = {'debian': 'libssl-dev', 'rpm': 'openssl-devel', 'arch': 'openssl',
+                        'alpine': 'openssl-dev', 'suse': 'libopenssl-devel', 'gentoo': 'dev-libs/openssl'}
         missing_packages.append(ssl_packages.get(system_type, 'libssl-dev'))
 
     # Check for libcurl development headers
@@ -3388,8 +3421,44 @@ def check_libcurl_dev():
         except Exception:
             return False, package_name
 
+    elif system_type == "alpine":
+        package_name = "curl-dev"
+        try:
+            result = subprocess.run(['apk', 'info', '-e', package_name], capture_output=True, text=True)
+            return result.returncode == 0, package_name
+        except Exception:
+            return False, package_name
+
+    elif system_type == "suse":
+        package_name = "libcurl-devel"
+        try:
+            result = subprocess.run(['rpm', '-q', package_name], capture_output=True, text=True)
+            return result.returncode == 0, package_name
+        except Exception:
+            return False, package_name
+
+    elif system_type == "gentoo":
+        # net-misc/curl always installs its headers, so the header is the test.
+        return os.path.exists('/usr/include/curl/curl.h'), "net-misc/curl"
+
     return False, "libcurl4-openssl-dev"
 pass
+
+
+def _os_release_ids():
+    """ID and ID_LIKE tokens from /etc/os-release, lower-cased. Empty if unreadable."""
+    ids = set()
+    try:
+        with open('/etc/os-release', encoding='utf-8', errors='replace') as f:
+            for line in f:
+                key, _, value = line.strip().partition('=')
+                if key in ('ID', 'ID_LIKE'):
+                    ids.update(value.strip().strip('"').lower().split())
+    except OSError:
+        pass
+    return ids
+pass
+
 
 def check_linux_type():
     """Determine the linux distribution type"""
@@ -3414,6 +3483,17 @@ def check_linux_type():
     # Check if it's Arch-based (Arch/Manjaro):
     elif os.path.exists('/etc/arch-release'):
         return 'arch'
+
+    elif os.path.exists('/etc/alpine-release'):
+        return 'alpine'
+
+    elif os.path.exists('/etc/gentoo-release'):
+        return 'gentoo'
+
+    # openSUSE and SLES no longer ship /etc/SuSE-release; both put "suse" in
+    # ID or ID_LIKE of /etc/os-release.
+    elif _os_release_ids() & {'suse', 'sles'}:
+        return 'suse'
 
     return 'unknown'
 pass


### PR DESCRIPTION
Fixes #251.

`check_linux_type` only knew Debian, RPM and Arch, so on Alpine, openSUSE and Gentoo the llama.cpp build path fell through to `apt-get`. This adds the three:

- detection: `/etc/alpine-release`, `/etc/gentoo-release`, and `suse` or `sles` in the `ID` / `ID_LIKE` of `/etc/os-release` (openSUSE and SLES no longer ship `/etc/SuSE-release`)
- install and refresh commands for `apk`, `zypper` and `emerge`. Gentoo skips the refresh probe in `do_we_need_sudo`, because `emerge --sync` takes minutes and would trip the 180 s no-internet check, and answers the sudo question from the effective uid instead
- package names for build tools, libgomp, libssl and the libcurl headers on each, folded into one `DISTRO_PACKAGES` map next to the existing RPM and Arch entries

Per review, the "package does not exist" check no longer matches any line containing "not found". `PACKAGE_NOT_FOUND` lists the phrase each manager prints for that case, so ordinary installer output cannot abort a working install.

Rebased onto current main; the earlier version of this branch predates the Arch and Windows support that landed in the meantime.

**Tests.** `tests/test_llama_cpp_distro_support.py` covers detection from release files and from os-release, the per-distro maps, and that each manager's not-found phrase is matched while lines such as `Package 'libgomp1' is not found in cache` are not. 27 pass locally on Python 3.12. I have not run the install path on the three distros themselves; the commands are the standard non-interactive forms for each manager.
