### PR TITLE
fix: multiple bug fixes (#390, #311, #316)

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -388,7 +388,7 @@ def install_llama_cpp(
 
     print_outputs = []
     missing_packages, system_type = check_build_requirements()
-    sudo = do_we_need_sudo()
+    sudo = do_we_need_sudo(system_type)
     kwargs = {"sudo" : sudo, "print_output" : print_output, "print_outputs" : print_outputs, "system_type": system_type}
 
     if not missing_packages:

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -44,15 +44,22 @@ def patch_compiling_bitsandbytes():
         # Disable dynamo on Linear4bit, Linear8bit and other future modules
         if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
             print("Unsloth: Bitsandbytes < 0.46.0 does not support torch.compile - disabling.")
+        # Use a namespace dictionary to properly store imported modules
+        namespace = {}
         for x in ["bitsandbytes.nn.modules", "peft.tuners.lora.bnb",]:
-            exec(f"import {x}", globals(), locals())
-            layers = dir(eval(x))
+            try:
+                exec(f"import {x}", namespace)
+            except ImportError:
+                # peft may not be installed, skip silently
+                continue
+            module = eval(x, namespace)
+            layers = dir(module)
             for fx in layers:
-                try: layer = eval(f"{x}.{fx}")
+                try: layer = getattr(module, fx)
                 except: continue
                 if not hasattr(layer, "forward"): continue
-                if hasattr(eval(f"{x}.{fx}.forward"), "__wrapped__"): continue
-                exec(f"{x}.{fx}.forward = torch._disable_dynamo({x}.{fx}.forward)", globals(), locals())
+                if hasattr(layer.forward, "__wrapped__"): continue
+                layer.forward = torch._disable_dynamo(layer.forward)
             pass
         pass
     pass

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -682,7 +682,11 @@ class UnslothVisionDataCollator:
         self.pad_to_multiple_of = pad_to_multiple_of
         self.snap_to_patch_size = snap_to_patch_size
         try:
-            self.patch_size = model.config.vision_config.patch_size
+            patch_size = model.config.vision_config.patch_size
+            # Handle tuple patch sizes (e.g., (14, 14) for InternVL3) - use first element
+            if isinstance(patch_size, (tuple, list)):
+                patch_size = patch_size[0]
+            self.patch_size = patch_size
         except:
             if hasattr(model.config, 'vision_config') and hasattr(model.config.vision_config, 'model_type'):
                 lower_name = model.config.vision_config.model_type.lower()


### PR DESCRIPTION
## Summary
- **Fix #390**: Pass `system_type` to `do_we_need_sudo()` for proper package manager detection on non-Debian systems (e.g., Fedora using yum/dnf)
- **Fix #311**: Use namespace dictionary for `exec/eval` in `patch_compiling_bitsandbytes` to properly access imported modules, add `ImportError` handling for optional peft dependency
- **Fix #316**: Handle tuple patch sizes (e.g., `(14, 14)` for InternVL3 models) in `UnslothVisionDataCollator` by extracting the first element

## Changes
1. `llama_cpp.py`: Pass `system_type` argument to `do_we_need_sudo()` call
2. `patching_utils.py`: Refactor import handling with proper namespace and error handling
3. `vision_utils.py`: Normalize tuple patch sizes to single integer

## Test plan
- [ ] Verify `do_we_need_sudo()` works correctly with different Linux distros
- [ ] Verify bitsandbytes/peft patching works without errors when peft is not installed
- [ ] Verify InternVL3-2B and other models with tuple patch sizes work correctly

Fixes #390, #311, #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)