### PR TITLE
Accept the transformers router_indices/routing_weights call in Mxfp4GptOssExperts

### DIFF
--- a/tests/test_gpt_oss_routing_from_topk.py
+++ b/tests/test_gpt_oss_routing_from_topk.py
@@ -1,0 +1,72 @@
+"""topk_to_routing_tensors must order picks exactly as triton_kernels.routing does.
+
+The reference below is triton_kernels.routing.routing_torch with the dataclasses
+stripped, so the check is against the ordering the MXFP4 matmul_ogs kernels are
+tested against upstream. It runs on CPU; no triton needed.
+"""
+
+import pytest
+import torch
+
+from unsloth_zoo.temporary_patches.gpt_oss import topk_to_routing_tensors
+
+
+def _routing_torch_reference(logits, top_k):
+    # triton_kernels/routing.py::routing_torch, sm_first=False, no user indices
+    n_expts_tot = logits.shape[1]
+    expt_scal, expt_indx = torch.topk(logits, top_k, dim=1)
+    expt_scal = torch.softmax(expt_scal, dim=-1)
+    expt_indx, order = torch.sort(expt_indx, dim=1)
+    expt_scal = torch.gather(expt_scal, 1, order)
+    expt_scal = expt_scal.reshape(-1)
+    expt_indx = expt_indx.reshape(-1).to(torch.int32)
+    combine_indx = torch.argsort(expt_indx, stable=True)
+    dispatch_indx = torch.argsort(combine_indx, stable=True)
+    gate_scal = expt_scal[combine_indx]
+    hist = torch.histc(expt_indx.float(), bins=n_expts_tot, min=0, max=n_expts_tot - 1).int()
+    return gate_scal, hist, combine_indx.int(), dispatch_indx.int()
+
+
+def _hf_router(logits, top_k):
+    # tail of GptOssTopKRouter.forward as patched in gpt_oss.py
+    top_val, idx = torch.topk(logits, top_k, dim=-1)
+    top_val = torch.softmax(top_val, dim=1, dtype=top_val.dtype)
+    scores = torch.zeros_like(logits).scatter_(1, idx, top_val)
+    return scores, idx
+
+
+@pytest.mark.parametrize("seed", range(5))
+@pytest.mark.parametrize("n_tokens, n_experts, top_k", [(37, 32, 4), (1, 32, 4), (64, 128, 4), (5, 8, 8)])
+def test_matches_routing_torch(seed, n_tokens, n_experts, top_k):
+    logits = torch.randn(n_tokens, n_experts, generator=torch.Generator().manual_seed(seed))
+    scores, idx = _hf_router(logits, top_k)
+    got = topk_to_routing_tensors(idx, scores, n_experts)
+    want = _routing_torch_reference(logits, top_k)
+    for g, w in zip(got, want):
+        assert g.dtype == w.dtype
+        torch.testing.assert_close(g, w, rtol=0, atol=0)
+
+
+def test_weights_are_the_routers_not_renormalised():
+    # The review's point: feeding the scores back through routing() as logits would
+    # softmax an already-normalised distribution. gate_scal must be the router's
+    # weights themselves, only permuted.
+    n_tokens, n_experts, top_k = 16, 32, 4
+    logits = torch.randn(n_tokens, n_experts, generator=torch.Generator().manual_seed(0))
+    scores, idx = _hf_router(logits, top_k)
+    gate_scal, hist, combine_indx, dispatch_indx = topk_to_routing_tensors(idx, scores, n_experts)
+
+    # undo the expert-major permutation: slot s = token * top_k + j
+    picks = torch.empty(n_tokens * top_k)
+    picks[combine_indx.long()] = gate_scal
+    picks = picks.view(n_tokens, top_k)
+    assert torch.equal(picks.sort(dim=1).values, torch.gather(scores, 1, idx).sort(dim=1).values)
+    torch.testing.assert_close(picks.sum(dim=1), torch.ones(n_tokens))
+    assert int(hist.sum()) == n_tokens * top_k
+    assert torch.equal(dispatch_indx[combine_indx.long()], torch.arange(n_tokens * top_k, dtype=torch.int32))
+
+
+def test_rejects_topk_shaped_weights():
+    idx = torch.zeros(4, 2, dtype=torch.int64)
+    with pytest.raises(ValueError):
+        topk_to_routing_tensors(idx, torch.ones(4, 2), n_expts_tot=8)

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -111,6 +111,45 @@ def swiglu_torch_backward(pre_act, alpha, limit, g1):
     return g1 * grad.to(g1.dtype)
 pass
 
+def topk_to_routing_tensors(router_indices, routing_weights, n_expts_tot):
+    """Order the router's top-k picks expert-major, as triton_kernels.routing does.
+
+    This is triton_kernels.routing.routing_torch from its sort step onward, fed the
+    router's own weights instead of recomputing softmax(logits): GptOssTopKRouter
+    has already softmaxed over the top-k, so pushing its scores back through
+    routing() would normalise them a second time.
+
+    router_indices:  (n_tokens, top_k) expert id per pick.
+    routing_weights: (n_tokens, n_expts_tot) dense scores, zero off the top-k.
+
+    Returns (gate_scal, expt_hist, combine_indx, dispatch_indx):
+      gate_scal     (n_tokens * top_k,)  pick weights in expert-major order
+      expt_hist     (n_expts_tot,) int32 picks per expert
+      combine_indx  (n_tokens * top_k,) int32 expert-major position -> flat pick slot
+      dispatch_indx its inverse
+    """
+    n_tokens, top_k = router_indices.shape
+    if routing_weights.shape != (n_tokens, n_expts_tot):
+        raise ValueError(
+            f"routing_weights must be dense (n_tokens, n_experts) = {(n_tokens, n_expts_tot)}, "
+            f"got {tuple(routing_weights.shape)}"
+        )
+    expt_indx = router_indices.to(torch.int64)
+    expt_scal = torch.gather(routing_weights, 1, expt_indx)
+    # routing_torch sorts each token's picks by expert id before flattening
+    expt_indx, order = torch.sort(expt_indx, dim = 1)
+    expt_scal = torch.gather(expt_scal, 1, order)
+    expt_indx = expt_indx.reshape(-1)
+    expt_scal = expt_scal.reshape(-1)
+    # then sorts all picks by expert id so each expert's rows are contiguous
+    combine_indx = torch.argsort(expt_indx, stable = True)
+    dispatch_indx = torch.argsort(combine_indx, stable = True)
+    gate_scal = expt_scal[combine_indx]
+    expt_hist = torch.bincount(expt_indx, minlength = n_expts_tot).to(torch.int32)
+    return gate_scal, expt_hist, combine_indx.to(torch.int32), dispatch_indx.to(torch.int32)
+pass
+
+
 def patch_gpt_oss():
     try:
         import triton_kernels
@@ -274,6 +313,27 @@ def patch_gpt_oss():
 
     pass
 
+    def routing_from_topk(router_indices, routing_weights, n_expts_tot):
+        """RoutingData / GatherIndx / ScatterIndx from the HF router's (indices, scores)."""
+        import triton_kernels.routing as tk_routing
+        n_expts_act = router_indices.shape[-1]
+        n_gates = router_indices.numel()
+        with torch_cuda_device(routing_weights.device):
+            gate_scal, expt_hist, combine_indx, dispatch_indx = topk_to_routing_tensors(
+                router_indices, routing_weights, n_expts_tot,
+            )
+            # newer triton_kernels precompute the tile metadata on the torch side;
+            # older ones derive it inside matmul_ogs from expt_hist.
+            compute_expt_data_torch = getattr(tk_routing, "compute_expt_data_torch", None)
+            expt_data = None
+            if compute_expt_data_torch is not None:
+                expt_data = compute_expt_data_torch(expt_hist, n_expts_tot, n_gates)
+        gather_idx = tk_routing.GatherIndx(src_indx = combine_indx, dst_indx = dispatch_indx)
+        scatter_idx = tk_routing.ScatterIndx(src_indx = dispatch_indx, dst_indx = combine_indx)
+        routing_data = tk_routing.RoutingData(gate_scal, expt_hist, n_expts_tot, n_expts_act, expt_data)
+        return routing_data, gather_idx, scatter_idx
+    pass
+
     class Mxfp4GptOssExperts(nn.Module):
         def __init__(self, config):
             super().__init__()
@@ -387,8 +447,31 @@ def patch_gpt_oss():
             self.__dict__["_down_proj"] = value
 
         def forward(
-            self, hidden_states: torch.Tensor, routing_data, gather_idx, scatter_idx
+            self,
+            hidden_states: torch.Tensor,
+            routing_data = None,
+            gather_idx = None,
+            scatter_idx = None,
+            *,
+            router_indices = None,
+            routing_weights = None,
         ) -> torch.Tensor:
+            # mlp_forward below passes triton routing structures positionally;
+            # transformers >= 4.57 and the GptOssMLP path further down call
+            # experts(hidden_states, router_indices=..., routing_weights=...) with
+            # hidden_states still (batch, seq, hidden).
+            leading_shape = None
+            if routing_data is None:
+                if router_indices is None or routing_weights is None:
+                    raise TypeError(
+                        "Mxfp4GptOssExperts.forward needs either (routing_data, gather_idx, scatter_idx) "
+                        "or router_indices= and routing_weights="
+                    )
+                leading_shape = hidden_states.shape[:-1]
+                hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+                routing_data, gather_idx, scatter_idx = routing_from_topk(
+                    router_indices, routing_weights, self.num_experts,
+                )
             with torch_cuda_device(hidden_states.device):
                 if not hasattr(self, "act"):
                     self.act = FusedActivation(FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")), (self.alpha, self.limit), 2)
@@ -420,6 +503,8 @@ def patch_gpt_oss():
                         gather_idx,
                         scatter_idx,
                     )
+            if leading_shape is not None:
+                intermediate_cache3 = intermediate_cache3.reshape(*leading_shape, intermediate_cache3.shape[-1])
             return intermediate_cache3
 
         pass


### PR DESCRIPTION
Fixes #385.

With `unsloth_tiled_mlp=True` (and transformers >= 4.57 in general) the MoE block calls `self.experts(hidden_states, router_indices=..., routing_weights=...)`, while the MXFP4 experts patched in here only took `(routing_data, gather_idx, scatter_idx)` from `mlp_forward`, so the call failed with `TypeError: unexpected keyword argument 'router_indices'`.

`Mxfp4GptOssExperts.forward` now accepts both forms. For the keyword form it builds `RoutingData`, `GatherIndx` and `ScatterIndx` directly from the router's indices and weights, as asked in review:

- `topk_to_routing_tensors` is `triton_kernels.routing.routing_torch` from its sort step onward: sort each token's picks by expert, then all picks by expert, `argsort` twice for the two index maps, `bincount` for the histogram.
- The router's already-softmaxed weights are used as `gate_scal` unchanged. The first version of this PR pushed the scores back through `routing()` as logits, which normalised them a second time.
- `hidden_states` arrives as `(batch, seq, hidden)` on this path, so it is flattened for the kernels and the output reshaped back. The first version sized `router_logits` from the batch dimension, which the Codex comment above caught.
- `compute_expt_data_torch` is used when the installed triton_kernels has it, which is what transformers' own `routing_torch_dist` does; older versions derive that metadata inside `matmul_ogs`.

**Tests.** `tests/test_gpt_oss_routing_from_topk.py` checks `topk_to_routing_tensors` against a copy of `routing_torch` on random logits for several shapes (bit-exact on `gate_scal`, the histogram and both index maps), that the weights come out as the router's own rather than renormalised, and the shape guard. Runs on CPU; 22 pass locally. I have not run the MXFP4 kernels end to end on a GPU with this branch.
