### PR TITLE
fix: add UTF-8 encoding to all file operations (#232)

### DIFF
--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -287,7 +287,7 @@ def get_auto_processor(name, **kwargs):
         processor_config = os.path.join(name, filename)
         if os.path.exists(processor_config):
             try:
-                with open(processor_config, "r") as f: f = f.read()
+                with open(processor_config, "r", encoding="utf-8") as f: f = f.read()
                 config = json.loads(f)
                 processor_class = config["processor_class"]
                 model_type = reversal_map[processor_class]

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -884,11 +884,11 @@ def fix_tokenizer_config_json(tokenizer, saved_folder):
         old_chat_template = getattr(tokenizer, "chat_template", None)
         if old_chat_template is not None:
             try:
-                with open(tokenizer_config_path, "r") as f:
+                with open(tokenizer_config_path, "r", encoding="utf-8") as f:
                     f = json.load(f)
                 if "chat_template" not in f or f["chat_template"] is None:
                     f["chat_template"] = tokenizer.chat_template
-                with open(tokenizer_config_path, "w") as new_f:
+                with open(tokenizer_config_path, "w", encoding="utf-8") as new_f:
                     json.dump(f, new_f, indent = 2, ensure_ascii = False)
             except:
                 pass
@@ -896,11 +896,11 @@ def fix_tokenizer_config_json(tokenizer, saved_folder):
 
         # Remove chat_template if NULL
         try:
-            with open(tokenizer_config_path, "r") as f:
+            with open(tokenizer_config_path, "r", encoding="utf-8") as f:
                 f = json.load(f)
             if "chat_template" in f and (f["chat_template"] == "" or f["chat_template"] is None):
                 del f["chat_template"]
-            with open(tokenizer_config_path, "w") as new_f:
+            with open(tokenizer_config_path, "w", encoding="utf-8") as new_f:
                 json.dump(f, new_f, indent = 2, ensure_ascii = False)
         except:
             pass
@@ -909,11 +909,11 @@ def fix_tokenizer_config_json(tokenizer, saved_folder):
     config_file_path = os.path.join(saved_folder, "config.json")
     if os.path.exists(config_file_path):
         try:
-            with open(config_file_path, "r") as f:
+            with open(config_file_path, "r", encoding="utf-8") as f:
                 data = f.read()
             data = data.replace('"dtype"', '"torch_dtype"')
             data = data.replace("'dtype'", "'torch_dtype'")
-            with open(config_file_path, "w") as f:
+            with open(config_file_path, "w", encoding="utf-8") as f:
                 f.write(data)
         except:
             pass


### PR DESCRIPTION
## Summary
Fix #232: Add explicit `encoding="utf-8"` to all file open operations to prevent `UnicodeDecodeError` when processing files with non-ASCII characters.

## Problem
Files containing non-ASCII characters (like emoji in chat templates or international characters in config files) would fail to read on systems where the default encoding isn't UTF-8, causing:
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 31733
```

## Changes
- `hf_utils.py`: Add encoding to processor_config file reading
- `saving_utils.py`: Add encoding to tokenizer_config.json and config.json read/write operations

## Test plan
- [ ] Verify files with Unicode content can be read successfully
- [ ] Verify config files are saved correctly with non-ASCII characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)