### PR TITLE
fix: video fps accumulation bug in _collate_prompt_completion

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1123,6 +1123,7 @@ class UnslothVisionDataCollator:
 
     def _collate_prompt_completion(self, examples):
         prompt_texts, completion_texts, images, videos = [], [], [], []
+        video_kwargs = {'fps': []}
 
         for ex in examples:
             p, c = ex["prompt"], ex["completion"]
@@ -1164,9 +1165,8 @@ class UnslothVisionDataCollator:
 
             if vids and len(vids) > 0:  # Works for list, tuple or tensor
                 videos.append(vids)
-                if vids_kwarg is None:
-                    vids_kwarg = {"fps": []}
-                vids_kwarg['fps'].extend(vids_kwarg['fps'])
+                if vids_kwarg is not None and 'fps' in vids_kwarg:
+                    video_kwargs['fps'].extend(vids_kwarg['fps'])
 
         prompt_kwargs = dict(
             padding=True,
@@ -1184,8 +1184,8 @@ class UnslothVisionDataCollator:
             prompt_kwargs["images"] = images
         if len(videos) > 0:
             prompt_kwargs["videos"] = videos
-            vids_kwarg["fps"] = collapse_fps(vids_kwarg['fps'])
-            for k, v in vids_kwarg.items():
+            video_kwargs["fps"] = collapse_fps(video_kwargs['fps'])
+            for k, v in video_kwargs.items():
                 prompt_kwargs[k] = v
 
         proc_prompts = self.processor(text=prompt_texts, **prompt_kwargs)


### PR DESCRIPTION
## Summary
- Fixed broken video fps handling in prompt/completion collation path
- Enables video-only samples to work correctly

## Problem
In `_collate_prompt_completion`, there were multiple bugs with fps accumulation:

1. **No batch-level accumulator**: `video_kwargs` was not initialized, so fps values couldn't be accumulated across examples
2. **Self-extending bug**: Line `vids_kwarg['fps'].extend(vids_kwarg['fps'])` was extending the list with itself, doubling values on each iteration
3. **Wrong variable used**: After the loop, `vids_kwarg` (last example's kwargs) was used instead of accumulated values

This caused video-only batches to fail because fps list length didn't match video count.

## Changes
- `unsloth_zoo/vision_utils.py`:
  - Initialize `video_kwargs = {'fps': []}` at batch level
  - Fix accumulation: `video_kwargs['fps'].extend(vids_kwarg['fps'])` 
  - Use `video_kwargs` instead of `vids_kwarg` after loop

Fixes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)