### PR TITLE
Example: Making fine-tuning LFM2.5-VL-1.6B work for datasets with system prompt and vision layer fine-tuning.

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -280,7 +280,7 @@ def requires_grad_for_gradient_checkpointing(model):
     module_name = "model." + ".".join(name_components[:final_where])
     module = eval(module_name)
 
-    if hasattr(module, "config") and (module.config.__class__.__name__ in ("CLIPVisionConfig", "SiglipVisionConfig",)):
+    if hasattr(module, "config") and (module.config.__class__.__name__ in ("CLIPVisionConfig", "SiglipVisionConfig", "Siglip2VisionConfig",)):
         # CLIP - backtrack to get_input_embeddings since requires_grad fails!
         old_module = model
         for module_name, module in model.named_modules():

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -66,6 +66,7 @@ from functools import lru_cache
 
 
 import requests
+from transformers import Lfm2VlProcessor
 import torchvision
 from packaging import version
 from typing import Union, Tuple, List, Dict, Sequence
@@ -879,6 +880,8 @@ class UnslothVisionDataCollator:
             return example
 
     def _validate_and_normalize_first_message(self, messages):
+        jinja_system_prompt_as_content_string_classes = (Lfm2VlProcessor,)
+
         if len(messages) == 0:
             return
         message = messages[0]
@@ -891,6 +894,11 @@ class UnslothVisionDataCollator:
         content = message.get("content")
         if isinstance(content, str):
             message["content"] = [{"type": "text", "text": content}]
+        if isinstance(content, list) and \
+            isinstance(self.processor, jinja_system_prompt_as_content_string_classes) \
+            and message.get("role") == "system" \
+            and len(content):
+            message["content"] = content[0]["text"]
         elif isinstance(content, (list, tuple)):
             part = content[0]
             assert "type" in part

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -894,7 +894,7 @@ class UnslothVisionDataCollator:
         content = message.get("content")
         if isinstance(content, str):
             message["content"] = [{"type": "text", "text": content}]
-        if isinstance(content, list) and \
+        elif isinstance(content, list) and \
             isinstance(self.processor, jinja_system_prompt_as_content_string_classes) \
             and message.get("role") == "system" \
             and len(content):


### PR DESCRIPTION
See: https://github.com/unslothai/unsloth/issues/3938

Currently, `unsloth` seems to be breaking when trying to fine tune `LiquidAI/LFM2.5-VL-1.6B`. 

Reasons:
1. Chat template for the model assumes system prompt is a string, not a list. Normalization in vision utils will assume array and will break the collation process.
2. Vision layers cannot be fine tuned because the encoder is SigLIP2.
