### PR TITLE
Harden vLLM and patch utilities for edge cases

### DIFF
--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -409,6 +409,16 @@ def set_additional_modules(new_model, quant_state_dict, config):
 
     # Embeddings
     embed_tokens_key = f"{language_model_prefix}.embed_tokens.weight"
+    if embed_tokens_key not in quant_state_dict:
+        for alt_key in (
+            "model.embed_tokens.weight",
+            "language_model.embed_tokens.weight",
+            "model.text_model.embed_tokens.weight",
+            "model.language_model.model.embed_tokens.weight",
+        ):
+            if alt_key in quant_state_dict:
+                embed_tokens_key = alt_key
+                break
     # Use explicit None check since pad_token_id=0 is valid (0 is falsy in Python)
     pad_token_id = getattr(config, "pad_token_id", None)
     if pad_token_id is None:


### PR DESCRIPTION
## Summary
- relax vLLM standby checks and add HF fallback on generate failures
- fix FP8Linear construction when device arg is unsupported
- add embed_tokens fallback for missing quant_state keys
- fix compiler kwargs collisions for generated signatures
- harden CSM depth decoder and model forward in edge cases
- add synthetic data kit fallback for empty inputs
- guard GPT OSS init weights and PEFT BnB dispatch
- soften bitsandbytes quant_state access in 4bit linear

## Testing
- python -m py_compile unsloth_zoo/vllm_utils.py unsloth_zoo/compiler.py unsloth_zoo/empty_model.py unsloth_zoo/temporary_patches/misc.py unsloth_zoo/temporary_patches/bitsandbytes.py