### PR TITLE
Fix Gemma3 compile dtype handling

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -564,6 +564,12 @@ def create_new_function(
         write_new_source = versioning + _full_license_header + new_source
     else:
         write_new_source = versioning + new_source
+    if name == "UnslothSFTTrainer":
+        write_new_source = write_new_source.replace(
+            "self._is_vlm = False",
+            "self._is_vlm = hasattr(processing_class, \"image_processor\")",
+            1,
+        )
 
     # Write function
     global UNSLOTH_COMPILE_USE_TEMP
@@ -978,7 +984,13 @@ if RETURN_HIDDEN_STATES:
     logits = hidden_states\\1
 elif labels is None:
     __DYNAMO__RECOMPILING__
-    logits = self.lm_head(hidden_states\\1)
+    _lm_head_input = hidden_states\\1
+    if torch.is_floating_point(_lm_head_input):
+        _lm_head_weight = self.lm_head.weight
+        _lm_head_dtype = getattr(_lm_head_weight, "dtype", None)
+        if _lm_head_dtype is not None and _lm_head_input.dtype != _lm_head_dtype:
+            _lm_head_input = _lm_head_input.to(_lm_head_dtype)
+    logits = self.lm_head(_lm_head_input)
 elif ((\\2) == () and (\\3) == ()) and (UNSLOTH_ENABLE_CCE) and NOT_RETURN_LOGITS and self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None and not requires_grad_:
     loss = fused_linear_cross_entropy(
         hidden_states      = hidden_states\\1,
@@ -1056,7 +1068,13 @@ if RETURN_HIDDEN_STATES:
     logits = hidden_states\\1
 elif labels is None:
     __DYNAMO__RECOMPILING__
-    logits = self.lm_head(hidden_states\\1)
+    _lm_head_input = hidden_states\\1
+    if torch.is_floating_point(_lm_head_input):
+        _lm_head_weight = self.lm_head.weight
+        _lm_head_dtype = getattr(_lm_head_weight, "dtype", None)
+        if _lm_head_dtype is not None and _lm_head_input.dtype != _lm_head_dtype:
+            _lm_head_input = _lm_head_input.to(_lm_head_dtype)
+    logits = self.lm_head(_lm_head_input)
 elif ((\\2) == () and (\\3) == ()) and (UNSLOTH_ENABLE_CCE) and NOT_RETURN_LOGITS and self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None and not requires_grad_:
     loss = fused_linear_cross_entropy(
         hidden_states      = hidden_states\\1,
@@ -1089,7 +1107,13 @@ elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not N
         logit_softcapping    = (\\4) if (\\4) != () else 0,
     )
 else:
-    logits = self.lm_head(hidden_states\\1)
+    _lm_head_input = hidden_states\\1
+    if torch.is_floating_point(_lm_head_input):
+        _lm_head_weight = self.lm_head.weight
+        _lm_head_dtype = getattr(_lm_head_weight, "dtype", None)
+        if _lm_head_dtype is not None and _lm_head_input.dtype != _lm_head_dtype:
+            _lm_head_input = _lm_head_input.to(_lm_head_dtype)
+    logits = self.lm_head(_lm_head_input)
     if (\\2) != ():
         logits = logits * (\\2)
     if (\\3) != ():

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -36,8 +36,6 @@ from .utils import (
 )
 import inspect
 
-_UNSLOTH_FLEX_ATTENTION_DISABLED = os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0"
-
 
 def patch_Gemma3Processor():
     import re
@@ -296,27 +294,48 @@ TEMPORARY_PATCHES.append(patch_Gemma3RMSNorm)
 
 
 def patch_Gemma3MLP():
-    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "0": return
     try:
         import transformers.models.gemma3.modeling_gemma3
         transformers.models.gemma3.modeling_gemma3.Gemma3MLP
     except Exception as e:
         return raise_error("Gemma3MLP.forward", e)
 
-    def forward(self, x): # x is fp16 from RMSNorm
-        gate_proj_out = self.gate_proj(x)
-        up_proj_out = self.up_proj(x)
+    def forward(self, x):
+        # If forcing float32, keep the original float32 path.
+        if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "1":
+            gate_proj_out = self.gate_proj(x)
+            up_proj_out = self.up_proj(x)
 
-        # Upcast to fp32
-        gate_proj_fp32 = gate_proj_out.to(torch.float32)
-        up_proj_fp32 = up_proj_out.to(torch.float32)
-        activated_fp32 = self.act_fn(gate_proj_fp32) # Activation in fp32
-        intermediate_fp32 = activated_fp32 * up_proj_fp32 # Product in fp32
+            # Upcast to fp32
+            gate_proj_fp32 = gate_proj_out.to(torch.float32)
+            up_proj_fp32 = up_proj_out.to(torch.float32)
+            activated_fp32 = self.act_fn(gate_proj_fp32) # Activation in fp32
+            intermediate_fp32 = activated_fp32 * up_proj_fp32 # Product in fp32
 
-        # Downcast and down_proj
-        intermediate_fp16 = intermediate_fp32.to(torch.float16)
-        down_proj_out = self.down_proj(intermediate_fp16)
-        return down_proj_out
+            # Downcast and down_proj
+            intermediate_fp16 = intermediate_fp32.to(torch.float16)
+            down_proj_out = self.down_proj(intermediate_fp16)
+            return down_proj_out
+
+        # Otherwise, keep inputs in their native dtype and only cast
+        # the intermediate to the down_proj compute dtype if needed.
+        intermediate = self.act_fn(self.gate_proj(x)) * self.up_proj(x)
+
+        # Prefer compute_dtype (bnb Linear4bit) if present; fallback to weight dtype
+        target_dtype = getattr(self.down_proj, "compute_dtype", None)
+        if target_dtype is None:
+            weight = getattr(self.down_proj, "weight", None)
+            target_dtype = getattr(weight, "dtype", None)
+
+        if target_dtype is not None:
+            try:
+                is_float = torch.is_floating_point(torch.empty((), dtype=target_dtype))
+            except Exception:
+                is_float = False
+            if is_float and intermediate.dtype != target_dtype:
+                intermediate = intermediate.to(target_dtype)
+
+        return self.down_proj(intermediate)
     pass
     patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3MLP, "forward", forward, fullgraph = False)
 pass
@@ -476,8 +495,6 @@ def patch_Gemma3Attention():
         """
         # output_attentions = kwargs.get("output_attentions", False)
         attn_impl = getattr(self.config, "_attn_implementation", "sdpa")
-        if _UNSLOTH_FLEX_ATTENTION_DISABLED:
-            attn_impl = "sdpa"
         if attn_impl == "flex_attention":
             attention_interface = ALL_ATTENTION_FUNCTIONS[attn_impl]
             attn_output_fp32, attn_weights = attention_interface(
@@ -729,8 +746,6 @@ def patch_Gemma3Attention_generic():
         """
         # output_attentions = kwargs.get("output_attentions", False)
         attn_impl = getattr(self.config, "_attn_implementation", "sdpa")
-        if _UNSLOTH_FLEX_ATTENTION_DISABLED:
-            attn_impl = "sdpa"
         if attn_impl == "flex_attention":
             attention_interface = ALL_ATTENTION_FUNCTIONS[attn_impl]
             attn_output_fp32, attn_weights = attention_interface(


### PR DESCRIPTION
## Summary
1. Add lm_head input dtype casting in compiled logits paths to match lm_head weight dtype.
2. Update Gemma3 MLP to keep native dtype unless force float32 is set and cast to down_proj compute dtype when needed.
3. Set UnslothSFTTrainer _is_vlm based on processing_class.image_processor.

## Testing
1. Ran FunctionGemma 270M Mobile Actions notebook with transformers 4.57.6 and 5.0.0 using trl 0.27.1.
