### PR TITLE
Make bitsandbytes optional on ROCm

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -146,11 +146,17 @@ def get_lora_layer_modules():
     for file in files:
         if file == "__init__.py" or not file.endswith(".py"): continue
         item = f"peft.tuners.lora.{file[:-len('.py')]}"
-        exec(f"import {item}", locals(), globals())
+        try:
+            exec(f"import {item}", locals(), globals())
+        except Exception:
+            continue
         modules = dir(eval(item))
         modules = [x for x in modules if x.startswith("Linear") or x.endswith("Linear")]
         if len(modules) == 0: continue
-        exec(f"from {item} import ({', '.join(modules)})", locals(), globals())
+        try:
+            exec(f"from {item} import ({', '.join(modules)})", locals(), globals())
+        except Exception:
+            continue
         Linear_LoRA_Layers += [(eval(x), item, x,) for x in modules]
     pass
     return tuple(Linear_LoRA_Layers)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -61,7 +61,10 @@ This {model_type} model was trained 2x faster with [Unsloth](https://github.com/
 """
 
 import torch
-import bitsandbytes as bnb
+try:
+    import bitsandbytes as bnb
+except Exception:
+    bnb = None
 try:
     from huggingface_hub import get_token
 except:
@@ -84,7 +87,7 @@ def find_skipped_quantized_modules(model):
     skipped_modules = []
     quantized_modules = []
     for name, module in model.named_modules():
-        if isinstance(module, bnb.nn.Linear4bit):
+        if (bnb is not None) and isinstance(module, bnb.nn.Linear4bit):
             if hasattr(module.weight, 'quant_state') and module.weight.quant_state is not None:
                 quantized_modules.append(name)
             else:


### PR DESCRIPTION
This makes bitsandbytes an optional dependency so ROCm environments without bitsandbytes can still run Unsloth-Zoo workflows (16bit / bf16) end to end.

Changes:
- patching_utils: guard patch_compiling_bitsandbytes when bitsandbytes is not installed
- patching_utils: treat Linear4bit types as optional and avoid raising when bnb is missing
- saving_utils: guard bitsandbytes import and isinstance checks
- peft_utils: skip LoRA layer modules that fail to import (eg peft.tuners.lora.bnb) instead of crashing

This is NVIDIA-safe: when bitsandbytes is installed, behavior is unchanged.