### PR TITLE
ROCm: disable cache in generate and fix GPT-OSS dtype

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1205,11 +1205,11 @@ def create_standalone_class(
     if getattr(torch.version, "hip", None):
         source = source.replace(
             "router_logits = F.linear(hidden_states, self.weight, self.bias)",
-            "router_logits = F.linear(hidden_states.to(self.weight.dtype), self.weight, self.bias)",
+            "router_logits = F.linear(hidden_states if hidden_states.dtype == self.weight.dtype else hidden_states.to(self.weight.dtype), self.weight, self.bias)",
         )
         source = source.replace(
             "router_logits = torch.nn.functional.linear(hidden_states, self.weight, self.bias)",
-            "router_logits = torch.nn.functional.linear(hidden_states.to(self.weight.dtype), self.weight, self.bias)",
+            "router_logits = torch.nn.functional.linear(hidden_states if hidden_states.dtype == self.weight.dtype else hidden_states.to(self.weight.dtype), self.weight, self.bias)",
         )
 
     return source

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1200,6 +1200,18 @@ def create_standalone_class(
     # Fix RotaryEmbeddings being in the wrong precision
     source = fix_rotary_embedding_dtype(source)
 
+    # ROCm: keep router linear inputs aligned with router weight dtype.
+    # Some compiled GPT-OSS router paths otherwise hit Float vs BF16 matmul.
+    if getattr(torch.version, "hip", None):
+        source = source.replace(
+            "router_logits = F.linear(hidden_states, self.weight, self.bias)",
+            "router_logits = F.linear(hidden_states.to(self.weight.dtype), self.weight, self.bias)",
+        )
+        source = source.replace(
+            "router_logits = torch.nn.functional.linear(hidden_states, self.weight, self.bias)",
+            "router_logits = torch.nn.functional.linear(hidden_states.to(self.weight.dtype), self.weight, self.bias)",
+        )
+
     return source
 
 
@@ -2766,7 +2778,6 @@ DISABLE_COMPILE_MODULES = [
     "Gemma3nTextModel",
     "Glm4MoeLiteNaiveMoe",
 ]
-
 FIX_GC_LAYER_CALLER_MODULES = [
     "WhisperDecoder",
 ]

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -24,6 +24,7 @@ __all__ = [
 ]
 
 import torch
+import os
 import functools
 from .utils import Version
 import inspect
@@ -77,6 +78,10 @@ ALLOW_PREQUANTIZED_MODELS : bool = True
 # HSA_STATUS_ERROR_EXCEPTION checks - sometimes AMD fails for BnB
 ALLOW_BITSANDBYTES : bool = True
 if DEVICE_TYPE == "hip":
+    # Disable AITER by default on ROCm to avoid JIT build locks and runtime faults.
+    # Users can override by explicitly setting env vars.
+    os.environ.setdefault("AITER_DISABLE", "1")
+    os.environ.setdefault("USE_ROCM_AITER_ROPE_BACKEND", "0")
     try:
         from bitsandbytes.nn.modules import Params4bit
         if "blocksize = 64 if not HIP_ENVIRONMENT else 128" in inspect.getsource(Params4bit):

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -760,13 +760,12 @@ class GptOssExperts(nn.Module):
         self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None
     ) -> torch.Tensor:
         """Forward using grouped_mm or loop fallback with LoRA support."""
-        # ROCm: ensure hidden_states matches expert weight dtype to avoid matmul type errors
-        if getattr(getattr(torch, "version", None), "hip", None):
-            target_dtype = getattr(getattr(self.down_proj, "weight", None), "dtype", None)
-            if target_dtype is None:
-                target_dtype = self.dtype
-            if hidden_states is not None and hidden_states.dtype != target_dtype:
-                hidden_states = hidden_states.to(target_dtype)
+        # Keep activations aligned with expert weights to avoid mixed-dtype matmul errors.
+        target_dtype = getattr(getattr(self.down_proj, "weight", None), "dtype", None)
+        if target_dtype is None:
+            target_dtype = self.dtype
+        if hidden_states is not None and hidden_states.dtype != target_dtype:
+            hidden_states = hidden_states.to(target_dtype)
         # Use optimized grouped_mm if available
         if _check_torch_grouped_mm_supported():
             return forward_native_grouped_mm(self, hidden_states, router_indices, routing_weights)
@@ -1259,6 +1258,12 @@ def moe_forward_inference_bf16(self, hidden_states):
         down_proj = down_proj.get_param()
     elif hasattr(down_proj, "weight"):
         down_proj = down_proj.weight
+
+    # Keep activations aligned with expert weights to avoid mixed-dtype
+    # bmm mismatches in inference kernels.
+    target_dtype = gate_up_proj.dtype if gate_up_proj is not None else down_proj.dtype
+    if hidden_states is not None and hidden_states.dtype != target_dtype:
+        hidden_states = hidden_states.to(target_dtype)
 
     return _moe_forward_inference_bf16_kernel(
         hidden_states,


### PR DESCRIPTION
## Summary
- Force GenerationMixin.generate to use_cache=False on HIP to avoid ROCm HSA exceptions
- Cast GPT-OSS expert inputs to expert weight dtype on HIP to avoid matmul type mismatch
- Disable AITER and ROCm RoPE backend by default on HIP

## Testing
- Llama3.2_(1B_and_3B)-Conversational.ipynb (60 steps)
- Gemma3_(4B)-Vision.ipynb (30 steps)
- gpt-oss-(20B)-GRPO.ipynb (30 steps)