### PR TITLE
fix: skip non-attention layers in _get_vllm_state_dict (fixes unslothai/unsloth#4073)

### DIFF
--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1121,7 +1121,7 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
         else:
             # Skip layers that don't have self_attn or cross_attn (e.g. Mamba/SSM layers
             # like LFM2's mixer layers). Full Mamba state dict extraction can be added later.
-            logger.info(f"Unsloth: Skipping layer {kk} — no self_attn or cross_attn found.")
+            logger.info(f"Unsloth: Skipping layer {kk} - no self_attn or cross_attn found.")
             continue
 
         get_state_dict(f"{prefix}.o_proj", 0, state_dict, o_proj)

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1118,6 +1118,11 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
             get_state_dict(f"{prefix}.q_proj", 0, state_dict, q_proj)
             get_state_dict(f"{prefix}.k_proj", 1, state_dict, kv_proj)
             get_state_dict(f"{prefix}.v_proj", 2, state_dict, kv_proj)
+        else:
+            # Skip layers that don't have self_attn or cross_attn (e.g. Mamba/SSM layers
+            # like LFM2's mixer layers). Full Mamba state dict extraction can be added later.
+            logger.info(f"Unsloth: Skipping layer {kk} — no self_attn or cross_attn found.")
+            continue
 
         get_state_dict(f"{prefix}.o_proj", 0, state_dict, o_proj)
 


### PR DESCRIPTION
## Problem

`_get_vllm_state_dict` crashes with `UnboundLocalError: cannot access local variable 'prefix'` when processing LFM2/Mamba models (e.g. `LiquidAI/LFM2.5-1.2B-Thinking`).

The layer iteration loop only sets `prefix` inside `if hasattr(layer, "self_attn")` and `elif hasattr(layer, "cross_attn")` branches. Mamba/SSM layers use `mixer` instead, so neither branch executes and `prefix` is never assigned before the subsequent `get_state_dict(f"{prefix}.o_proj", ...)` call.

## Fix

Add an `else` branch that logs and skips layers without `self_attn` or `cross_attn`. This is the minimal-invasive fix — it prevents the crash and allows models with mixed layer types (attention + Mamba) to still extract the attention layers correctly.

## Future work

A more complete fix would add an `elif hasattr(layer, "mixer")` branch that properly extracts Mamba layer state dicts (A, B, C, D matrices, dt projections, etc.) for full round-trip fidelity. This skip-based approach is a safe stopgap.

Fixes unslothai/unsloth#4073