### PR TITLE
Fix transformers 5.x compat: GRPO token_type_ids, gpt_oss BlockMask, compiler decorators

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1178,6 +1178,8 @@ def create_standalone_class(
     # Remove @auto_docstring
     source = re.sub(r"@auto_docstring[\s]{0,}(\([^\)]{0,}\))?", "", source)
     source = re.sub(r"@check_model_inputs[\s]{0,}(\([^\)]{0,}\))?", "", source)
+    source = re.sub(r"@merge_with_config_defaults[\s]{0,}(\([^\)]{0,}\))?", "", source)
+    source = re.sub(r"@capture_outputs[\s]{0,}(\([^\)]{0,}\))?", "", source)
     # source = source.replace("@auto_docstring", "")
 
     # Fix Gemma 3 ignore_index being not set!


### PR DESCRIPTION
## Summary

Fixes three issues that break Unsloth when running with `transformers>=5.2.0`:

- **compiler.py**: Strip `@merge_with_config_defaults` and `@capture_outputs` decorators during source extraction. These decorators inspect `func.__code__.co_varnames` to find positional parameter names, but when stacked the wrapper signature `(self, *args, **kwargs)` is resolved instead of the original function's parameters. This caused `got multiple values for argument 'use_cache'` on Gemma3N and similar models.

- **rl_replacements.py**: Forward `token_type_ids` through `grpo_accumulated_loss` to the model's forward call. In transformers 5.x, Gemma3's `create_causal_mask_mapping` requires `token_type_ids` during training to construct bidirectional attention masks for image vs text tokens. TRL and the Unsloth data collator already provide `token_type_ids` in the inputs dict, but the GRPO accumulated loss path never extracted or passed it to the model. Uses `**_extra_fwd_kwargs` pattern to maintain backwards compatibility with models that do not accept `token_type_ids`.

- **gpt_oss.py**: Prevent `BlockMask` creation during inference. The `GptOssModel.forward` function calls `create_causal_mask()` which, when `_attn_implementation="flex_attention"`, dispatches to `flex_attention_mask()` returning a `BlockMask`. But Unsloth uses eager attention for inference, which cannot handle `BlockMask` objects (`TypeError: unsupported operand type(s) for +=: 'Tensor' and 'BlockMask'`). The fix directly checks `_attn_implementation` in the forward function and passes `None` for the flex_attention case, rather than relying on the module-level wrapper which was bypassed due to closure variable capture. Also fixes the `input_embeds` to `inputs_embeds` rename in the mask kwargs dict.

## Test plan

- [x] Gemma3N 4B Vision SFT training passes on transformers 5.2.0 (use_cache fix via compiler)
- [x] Gemma3 4B Vision GRPO training completes 30/30 steps on transformers 5.2.0 (token_type_ids fix)
- [x] gpt_oss 20B GRPO training completes 30/30 steps on transformers 5.2.0 (BlockMask fix)
- [x] gpt_oss 20B RL 2048 Game training completes 30/30 steps on transformers 5.2.0 (BlockMask fix)
- [x] Backwards compatible with transformers 4.57.6: token_type_ids defaults to None when not provided, gpt_oss eager path unchanged for non-flex_attention configs, decorator stripping is no-op when decorators are absent