### PR TITLE
Enable ROCm GPU acceleration for llama.cpp GGUF export

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -673,6 +673,37 @@ def install_llama_cpp(
     if gpu_support == "ON":
         print("Unsloth: Building llama.cpp with GPU support")
 
+    # Detect GPU backend for CMake flags (ROCm vs CUDA)
+    gpu_cmake_flags = f"-DGGML_CUDA={gpu_support}"
+    if gpu_support == "ON":
+        try:
+            import torch
+            if hasattr(torch.version, 'hip') and torch.version.hip is not None and torch.cuda.is_available():
+                # ROCm detected
+                try:
+                    gpu_arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+                except Exception:
+                    gpu_arch = ""
+                rocm_path = os.environ.get('ROCM_PATH', '/opt/rocm')
+                if gpu_arch:
+                    gpu_cmake_flags = (
+                        f"-DGGML_HIP=ON "
+                        f"-DCMAKE_C_COMPILER={rocm_path}/llvm/bin/clang "
+                        f"-DCMAKE_CXX_COMPILER={rocm_path}/llvm/bin/clang++ "
+                        f"-DCMAKE_HIP_ARCHITECTURES={gpu_arch}"
+                    )
+                else:
+                    gpu_cmake_flags = (
+                        f"-DGGML_HIP=ON "
+                        f"-DCMAKE_C_COMPILER={rocm_path}/llvm/bin/clang "
+                        f"-DCMAKE_CXX_COMPILER={rocm_path}/llvm/bin/clang++"
+                    )
+                print(f"Unsloth: Detected ROCm GPU{' (' + gpu_arch + ')' if gpu_arch else ''} -- building with HIP support")
+            else:
+                gpu_cmake_flags = f"-DGGML_CUDA={gpu_support}"
+        except Exception:
+            gpu_cmake_flags = f"-DGGML_CUDA={gpu_support}"
+
     build_success = False
     build_errors = []
 
@@ -708,7 +739,7 @@ def install_llama_cpp(
                 "-G", cmake_generator,
                 "-Wno-dev",
                 "-DBUILD_SHARED_LIBS=OFF",
-                f"-DGGML_CUDA={gpu_support}",
+                gpu_cmake_flags,
             ]
             if vs_install_path:
                 cmake_args.append(f"-DCMAKE_GENERATOR_INSTANCE={vs_install_path}")
@@ -773,7 +804,7 @@ def install_llama_cpp(
                 # Build cmake configure command with library detection
                 cmake_configure = (
                     f"cmake . -B build "
-                    f"-DBUILD_SHARED_LIBS=OFF -DGGML_CUDA={gpu_support}"
+                    f"-DBUILD_SHARED_LIBS=OFF {gpu_cmake_flags}"
                 )
 
                 # Detect OpenMP library path (fixes GOMP linker errors)

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -672,37 +672,30 @@ def install_llama_cpp(
         print("Unsloth: Building llama.cpp - please wait 1 to 3 minutes")
     if gpu_support == "ON":
         print("Unsloth: Building llama.cpp with GPU support")
-
-    # Detect GPU backend for CMake flags (ROCm vs CUDA)
-    gpu_cmake_flags = f"-DGGML_CUDA={gpu_support}"
-    if gpu_support == "ON":
+        # Detect GPU backend: ROCm uses HIP flags, CUDA uses CUDA flags
         try:
             import torch
             if hasattr(torch.version, 'hip') and torch.version.hip is not None and torch.cuda.is_available():
-                # ROCm detected
+                # ROCm detected: use HIP flags
                 try:
                     gpu_arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
                 except Exception:
                     gpu_arch = ""
                 rocm_path = os.environ.get('ROCM_PATH', '/opt/rocm')
-                if gpu_arch:
-                    gpu_cmake_flags = (
-                        f"-DGGML_HIP=ON "
-                        f"-DCMAKE_C_COMPILER={rocm_path}/llvm/bin/clang "
-                        f"-DCMAKE_CXX_COMPILER={rocm_path}/llvm/bin/clang++ "
-                        f"-DCMAKE_HIP_ARCHITECTURES={gpu_arch}"
-                    )
-                else:
-                    gpu_cmake_flags = (
-                        f"-DGGML_HIP=ON "
-                        f"-DCMAKE_C_COMPILER={rocm_path}/llvm/bin/clang "
-                        f"-DCMAKE_CXX_COMPILER={rocm_path}/llvm/bin/clang++"
-                    )
+                arch_flag = f" -DCMAKE_HIP_ARCHITECTURES={gpu_arch}" if gpu_arch else ""
+                gpu_cmake_flags = (
+                    f"-DGGML_HIP=ON"
+                    f" -DCMAKE_C_COMPILER={rocm_path}/llvm/bin/clang"
+                    f" -DCMAKE_CXX_COMPILER={rocm_path}/llvm/bin/clang++"
+                    f"{arch_flag}"
+                )
                 print(f"Unsloth: Detected ROCm GPU{' (' + gpu_arch + ')' if gpu_arch else ''} -- building with HIP support")
             else:
-                gpu_cmake_flags = f"-DGGML_CUDA={gpu_support}"
+                gpu_cmake_flags = "-DGGML_CUDA=ON"
         except Exception:
-            gpu_cmake_flags = f"-DGGML_CUDA={gpu_support}"
+            gpu_cmake_flags = "-DGGML_CUDA=ON"
+    else:
+        gpu_cmake_flags = f"-DGGML_CUDA={gpu_support}"  # "OFF"
 
     build_success = False
     build_errors = []


### PR DESCRIPTION
# Enable ROCm GPU acceleration for llama.cpp GGUF export

## Summary

Adds automatic ROCm/HIP detection in `install_llama_cpp()` so AMD GPU users get hardware-accelerated GGUF inference.

## Problem

On AMD ROCm systems, llama.cpp was compiled without GPU support, resulting in CPU-only inference that is 5–9x slower than GPU-accelerated.

## Solution

After `gpu_support = "ON"` is confirmed, detect the active GPU backend:
- **ROCm systems**: reads `torch.version.hip`, queries `gcnArchName` for the target arch, sets `-DGGML_HIP=ON` with clang/clang++ compilers and `CMAKE_HIP_ARCHITECTURES`
- **CUDA systems**: falls through to existing `-DGGML_CUDA=ON` flags (no behavior change)
- **`gpu_support=False` (default)**: entire block is skipped (no behavior change for existing users)

## Changes

**unsloth_zoo/llama_cpp.py** (`+33/-2`):
- ROCm detection block inserted after `gpu_support == "ON"` confirmation
- Hardcoded `-DGGML_CUDA={gpu_support}` replaced with dynamic `gpu_cmake_flags` in both Linux and Windows cmake paths
- Fixed guard bug from review: `if gpu_support == "ON":` (was `if gpu_support:` which treats `"OFF"` as truthy)

## Testing

Tested on AMD Radeon PRO W7900 (gfx1100, ROCm 7.1):
- GPU inference: **312.4 t/s** (5.9x faster than CPU-only)
- ROCm libraries correctly linked via HIP flags
- CUDA systems: no regression (guard prevents ROCm block from running)

## Notes

- Rebased cleanly onto current upstream main (1 commit ahead, 0 behind)
- Resolves conflict with upstream Windows cmake refactor
- Companion PR unslothai/unsloth#4103 (save.py `gpu_support=True`) was closed by @danielhanchen pending investigation of compile time. This PR keeps the detection logic ready for when that decision is revisited.