### PR TITLE
Fix missing ParameterModule export in GPT-OSS compiler path

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1154,6 +1154,7 @@ def create_standalone_class(
                     if (
                         "use_experts_implementation" in stripped
                         or "use_kernel_forward_from_hub" in stripped
+                        or "use_kernelized_func" in stripped
                         or stripped.startswith("@auto_docstring")
                     ):
                         decorator_name = stripped.split("(")[0].lstrip("@")
@@ -1274,6 +1275,7 @@ def create_standalone_class(
 
     # Remove @auto_docstring
     source = re.sub(r"@auto_docstring[\s]{0,}(\([^\)]{0,}\))?", "", source)
+    source = re.sub(r"@use_kernelized_func[\s]{0,}(\([^\)]{0,}\))?", "", source)
     source = re.sub(r"@check_model_inputs[\s]{0,}(\([^\)]{0,}\))?", "", source)
     # source = source.replace("@auto_docstring", "")
 

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1151,8 +1151,12 @@ def create_standalone_class(
             for line in lines:
                 stripped = line.strip()
                 if stripped.startswith("@"):
-                    if "use_experts_implementation" in stripped:
-                        logger.info(f'Unsloth: stripped use_experts_implementation decorator from {module}')
+                    if (
+                        "use_experts_implementation" in stripped
+                        or "use_kernel_forward_from_hub" in stripped
+                    ):
+                        decorator_name = stripped.split("(")[0].lstrip("@")
+                        logger.info(f"Unsloth: stripped {decorator_name} decorator from {module}")
                         continue # Strip it
                     else:
                         logger.warning(f"Unsloth: Warning: Unknown decorator {stripped} found for {module}.")

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1154,6 +1154,7 @@ def create_standalone_class(
                     if (
                         "use_experts_implementation" in stripped
                         or "use_kernel_forward_from_hub" in stripped
+                        or stripped.startswith("@auto_docstring")
                     ):
                         decorator_name = stripped.split("(")[0].lstrip("@")
                         logger.info(f"Unsloth: stripped {decorator_name} decorator from {module}")

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1336,15 +1336,19 @@ def _should_use_gpt_oss_bnb4bit() -> bool:
     Default: True when load_in_4bit is active.
     Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to force BF16 path.
     """
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "gpt_oss" not in _normalized_unsloth_model_name():
         return False
-    if "_load_in_4bit_" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "_load_in_4bit_" not in _normalized_unsloth_model_name():
         return False
     return os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_DISABLE", "0") != "1"
 
 
 def _is_gpt_oss_4bit_load() -> bool:
-    return "_load_in_4bit_" in os.environ.get("UNSLOTH_MODEL_NAME", "")
+    return "_load_in_4bit_" in _normalized_unsloth_model_name()
+
+
+def _normalized_unsloth_model_name() -> str:
+    return os.environ.get("UNSLOTH_MODEL_NAME", "").replace("-", "_")
 
 
 def _is_transformers_v5() -> bool:
@@ -1360,7 +1364,7 @@ def patch_gpt_oss_moe_for_lora():
     IMPORTANT: We only patch the forward method, NOT replace the entire class.
     This preserves the original class structure so weights load correctly.
     """
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "gpt_oss" not in _normalized_unsloth_model_name():
         return
     if _is_gpt_oss_4bit_load() or _should_use_gpt_oss_bnb4bit():
         # 4-bit loads should keep quantized weights and use default PEFT LoRA.
@@ -1794,8 +1798,8 @@ def patch_gpt_oss_linearized():
     Patch GPT OSS for 4bit loading with grouped_mm support.
     Only patches the GptOssExperts forward method - keeps original classes for proper weight loading.
     """
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""): return
-    if "_load_in_4bit_" not in os.environ.get("UNSLOTH_MODEL_NAME", ""): return
+    if "gpt_oss" not in _normalized_unsloth_model_name(): return
+    if "_load_in_4bit_" not in _normalized_unsloth_model_name(): return
     if _should_use_gpt_oss_bnb4bit(): return
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss
@@ -1833,7 +1837,7 @@ TEMPORARY_PATCHES.append(patch_gpt_oss_linearized)
 
 def patch_GptOssAttention():
     if os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0": return
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""): return
+    if "gpt_oss" not in _normalized_unsloth_model_name(): return
     try:
         from ..flex_attention import (
             flex_attention_with_sink,
@@ -2074,7 +2078,7 @@ TEMPORARY_PATCHES.append(patch_GptOssAttention)
 
 def patch_GptOssModel():
     if os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0": return
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""): return
+    if "gpt_oss" not in _normalized_unsloth_model_name(): return
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss
         transformers.models.gpt_oss.modeling_gpt_oss.GptOssModel
@@ -2759,7 +2763,7 @@ except Exception as e:
 
 
 def patch_gpt_oss_init_weights_modulelist_fix():
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "gpt_oss" not in _normalized_unsloth_model_name():
         return
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss
@@ -2804,7 +2808,7 @@ def patch_gpt_oss_for_grpo():
     When UNSLOTH_RETURN_HIDDEN_STATES=1, return hidden_states instead of logits.
     This fixes the matrix multiplication dimension mismatch issue in GRPO training.
     """
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "gpt_oss" not in _normalized_unsloth_model_name():
         return
 
     try:

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -649,7 +649,8 @@ class ParameterModule(nn.Linear):
 
 
 def patch_gpt_oss_compiler_exports():
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    model_name = os.environ.get("UNSLOTH_MODEL_NAME", "").replace("-", "_")
+    if "gpt_oss" not in model_name:
         return
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -655,7 +655,8 @@ def patch_gpt_oss_compiler_exports():
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss
     except Exception as e:
-        return raise_error("transformers.models.gpt_oss.modeling_gpt_oss", e)
+        raise_error("transformers.models.gpt_oss.modeling_gpt_oss", e)
+        return
 
     # Export helpers so compiler generated GPT-OSS modules can resolve symbols.
     m = transformers.models.gpt_oss.modeling_gpt_oss
@@ -664,7 +665,6 @@ def patch_gpt_oss_compiler_exports():
     m.dtype_from_config = dtype_from_config
     m.transformers_version = transformers_version
     m.Version = Version
-pass
 TEMPORARY_PATCHES.append(patch_gpt_oss_compiler_exports)
 
 

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2099,12 +2099,25 @@ def patch_GptOssModel():
     import transformers.generation.utils
     def wrap(f):
         def return_attention_mask(*args, **kwargs):
-            if kwargs["input_embeds"].requires_grad:
+            input_embeds = kwargs.get("input_embeds", None)
+            if input_embeds is None:
+                input_embeds = kwargs.get("inputs_embeds", None)
+            if input_embeds is None:
+                for arg in args:
+                    if type(arg) is torch.Tensor and arg.is_floating_point():
+                        input_embeds = arg
+                        break
+
+            if input_embeds is not None and input_embeds.requires_grad:
                 if "attention_mask" in kwargs:
                     return kwargs["attention_mask"]
                 for arg in args:
-                    if type(arg) is torch.Tensor and arg.dtype == torch.int32:
+                    if (
+                        type(arg) is torch.Tensor and
+                        arg.dtype in (torch.int32, torch.int64, torch.bool)
+                    ):
                         return arg
+                return f(*args, **kwargs)
             else:
                 # Eager
                 return f(*args, **kwargs)


### PR DESCRIPTION
## Summary
Fixes GPT-OSS compiled-cache failures where generated modules can reference `ParameterModule` but the symbol is not available from `transformers.models.gpt_oss.modeling_gpt_oss`.

## Root cause
`ParameterModule` is defined in `unsloth_zoo.temporary_patches.gpt_oss`, but compiler-generated code expects symbols to be resolvable from the GPT-OSS modeling namespace.

## Changes
- Added `patch_gpt_oss_compiler_exports()` in `unsloth_zoo/temporary_patches/gpt_oss.py`.
- Exported compiler-required symbols into `transformers.models.gpt_oss.modeling_gpt_oss`:
  - `ParameterModule`
  - `swiglu_torch_forward`
  - `dtype_from_config`
  - `transformers_version`
  - `Version`
- Registered the hook via `TEMPORARY_PATCHES.append(patch_gpt_oss_compiler_exports)`.
- Normalized GPT-OSS guard matching with `UNSLOTH_MODEL_NAME.replace("-", "_")` usage across key 4-bit/load guards.
- Cleaned compiler export patch flow in exception path and removed redundant `pass`.
- Updated compiler decorator stripping to handle:
  - `@use_kernel_forward_from_hub(...)`
  - `@auto_docstring`
  This removes noisy unknown-decorator warnings in GPT-OSS compile paths.

## Validation
Run dirs:
- `logs/pr519_verify_20260226_031808/test_gpt_oss_compiler_export.log`
- `logs/pr519_verify_20260226_031808/test_gpt_oss_compiler_export_after_autodoc_reinstall.log`

Results:
- GPT-OSS compiler export smoke test: PASS
- `@use_kernel_forward_from_hub` unknown decorator warning: removed
- `@auto_docstring` unknown decorator warning: removed

## Notes
This change is scoped to symbol export and compile-time compatibility. It does not modify model math.
