### PR TITLE
Guard GPT-OSS allocator warmup on low-memory 4-bit loads

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1154,6 +1154,7 @@ def create_standalone_class(
                     if (
                         "use_experts_implementation" in stripped
                         or "use_kernel_forward_from_hub" in stripped
+                        or "use_kernelized_func" in stripped
                         or stripped.startswith("@auto_docstring")
                     ):
                         decorator_name = stripped.split("(")[0].lstrip("@")
@@ -1274,6 +1275,7 @@ def create_standalone_class(
 
     # Remove @auto_docstring
     source = re.sub(r"@auto_docstring[\s]{0,}(\([^\)]{0,}\))?", "", source)
+    source = re.sub(r"@use_kernelized_func[\s]{0,}(\([^\)]{0,}\))?", "", source)
     source = re.sub(r"@check_model_inputs[\s]{0,}(\([^\)]{0,}\))?", "", source)
     # source = source.replace("@auto_docstring", "")
 

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1151,8 +1151,12 @@ def create_standalone_class(
             for line in lines:
                 stripped = line.strip()
                 if stripped.startswith("@"):
-                    if "use_experts_implementation" in stripped:
-                        logger.info(f'Unsloth: stripped use_experts_implementation decorator from {module}')
+                    if (
+                        "use_experts_implementation" in stripped
+                        or "use_kernel_forward_from_hub" in stripped
+                    ):
+                        decorator_name = stripped.split("(")[0].lstrip("@")
+                        logger.info(f"Unsloth: stripped {decorator_name} decorator from {module}")
                         continue # Strip it
                     else:
                         logger.warning(f"Unsloth: Warning: Unknown decorator {stripped} found for {module}.")

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1154,6 +1154,7 @@ def create_standalone_class(
                     if (
                         "use_experts_implementation" in stripped
                         or "use_kernel_forward_from_hub" in stripped
+                        or stripped.startswith("@auto_docstring")
                     ):
                         decorator_name = stripped.split("(")[0].lstrip("@")
                         logger.info(f"Unsloth: stripped {decorator_name} decorator from {module}")

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1394,15 +1394,19 @@ def _should_use_gpt_oss_bnb4bit() -> bool:
     Default: True when load_in_4bit is active.
     Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to force BF16 path.
     """
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "gpt_oss" not in _normalized_unsloth_model_name():
         return False
-    if "_load_in_4bit_" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "_load_in_4bit_" not in _normalized_unsloth_model_name():
         return False
     return os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_DISABLE", "0") != "1"
 
 
 def _is_gpt_oss_4bit_load() -> bool:
-    return "_load_in_4bit_" in os.environ.get("UNSLOTH_MODEL_NAME", "")
+    return "_load_in_4bit_" in _normalized_unsloth_model_name()
+
+
+def _normalized_unsloth_model_name() -> str:
+    return os.environ.get("UNSLOTH_MODEL_NAME", "").replace("-", "_")
 
 
 def _is_transformers_v5() -> bool:
@@ -1418,7 +1422,7 @@ def patch_gpt_oss_moe_for_lora():
     IMPORTANT: We only patch the forward method, NOT replace the entire class.
     This preserves the original class structure so weights load correctly.
     """
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "gpt_oss" not in _normalized_unsloth_model_name():
         return
     if _is_gpt_oss_4bit_load() or _should_use_gpt_oss_bnb4bit():
         # 4-bit loads should keep quantized weights and use default PEFT LoRA.
@@ -1852,8 +1856,8 @@ def patch_gpt_oss_linearized():
     Patch GPT OSS for 4bit loading with grouped_mm support.
     Only patches the GptOssExperts forward method - keeps original classes for proper weight loading.
     """
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""): return
-    if "_load_in_4bit_" not in os.environ.get("UNSLOTH_MODEL_NAME", ""): return
+    if "gpt_oss" not in _normalized_unsloth_model_name(): return
+    if "_load_in_4bit_" not in _normalized_unsloth_model_name(): return
     if _should_use_gpt_oss_bnb4bit(): return
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss
@@ -1891,7 +1895,7 @@ TEMPORARY_PATCHES.append(patch_gpt_oss_linearized)
 
 def patch_GptOssAttention():
     if os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0": return
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""): return
+    if "gpt_oss" not in _normalized_unsloth_model_name(): return
     try:
         from ..flex_attention import (
             flex_attention_with_sink,
@@ -2132,7 +2136,7 @@ TEMPORARY_PATCHES.append(patch_GptOssAttention)
 
 def patch_GptOssModel():
     if os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0": return
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""): return
+    if "gpt_oss" not in _normalized_unsloth_model_name(): return
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss
         transformers.models.gpt_oss.modeling_gpt_oss.GptOssModel
@@ -2817,7 +2821,7 @@ except Exception as e:
 
 
 def patch_gpt_oss_init_weights_modulelist_fix():
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "gpt_oss" not in _normalized_unsloth_model_name():
         return
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss
@@ -2862,7 +2866,7 @@ def patch_gpt_oss_for_grpo():
     When UNSLOTH_RETURN_HIDDEN_STATES=1, return hidden_states instead of logits.
     This fixes the matrix multiplication dimension mismatch issue in GRPO training.
     """
-    if "gpt_oss" not in os.environ.get("UNSLOTH_MODEL_NAME", ""):
+    if "gpt_oss" not in _normalized_unsloth_model_name():
         return
 
     try:

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1125,9 +1125,6 @@ def _should_skip_transformers_allocator_warmup() -> bool:
     are loaded, which can OOM constrained GPUs.
     """
     mode = os.environ.get("UNSLOTH_ALLOCATOR_WARMUP", "").strip().lower()
-    if mode == "":
-        # Backward compatible alias for previous override variable.
-        mode = os.environ.get("UNSLOTH_GPT_OSS_ALLOCATOR_WARMUP", "auto").strip().lower()
     if mode in ("off", "disable", "0", "false"):
         return True
     if mode in ("on", "enable", "1", "true"):


### PR DESCRIPTION
## Summary
- Guard `transformers.modeling_utils.caching_allocator_warmup` in Unsloth patch flow.
- Auto-skip warmup on low effective accelerator memory (`< 24 GiB`) across model loads.
- Keep explicit override:
  - `UNSLOTH_ALLOCATOR_WARMUP=on|off|auto`
- Rename warmup guard identifiers to generic names.
- Normalize GPT-OSS model-name guards to handle hyphenated names (`gpt-oss` -> `gpt_oss`) consistently.
- Remove legacy `UNSLOTH_GPT_OSS_ALLOCATOR_WARMUP` alias support.
- Use the active accelerator index (not hardcoded device `0`) for memory and per-process-fraction checks.
- Strip `@use_kernel_forward_from_hub(...)` and `@auto_docstring` decorators in class rewrite path to remove unknown-decorator warning noise.

## Why
- `caching_allocator_warmup` can allocate a large single chunk before weights load. On low-memory setups this can OOM before model load completes.
- GPT-OSS patch activation checks were using raw `UNSLOTH_MODEL_NAME` substring checks in multiple places. Hyphenated names can skip patch paths that should apply for 4-bit GPT-OSS loads.
- Multi-GPU/non-default-device runs can mis-detect memory when checks are hardcoded to device `0`.

## Validation
Run dir:
- `logs/memory_investigation_20260226_000809/warmup_24gb_global_20260226_014122`

On `Unsloth 2026.2.1` / `transformers 4.56.2`:
- `cap16_auto_unsloth2026_generic_names.log`: PASS
  - `GPU_RESERVED_GB_AFTER_LOAD 11.85`
  - `GPU_PEAK_RESERVED_GB_AFTER_LOAD 12.932`
- `cap16_force_on_unsloth2026_generic_names.log`: FAIL (expected control)
  - `OutOfMemoryError` with `Tried to allocate 18.93 GiB`
- `test_llama_compile_smoke.log`: PASS

Hyphen-guard/load checks:
- `logs/hyphen_guard_verify_20260226_020925/repro_uninitialized_after_local_patch.log`: PASS (`LOAD_OK`)

Version matrix (`transformers==4.56.2`):
- Run dir: `logs/version_matrix_gpt_oss_20260226_020432`
- `old_2025_12` (`unsloth==2025.12.10`, `unsloth-zoo==2025.12.8`):
  - `load_ok=true`, `train_ok=true`, `exception_type=null`
  - `losses=[1.165579, 4.171052, 3.063763]`
  - `grad_norms=[2.650939, inf, 1.8630026331731638e+17]`
- `new_2026_2_1` (`unsloth==2026.2.1`, `unsloth-zoo==2026.2.1`):
  - `load_ok=true`, `train_ok=true`, `exception_type=null`
  - `losses=[1.156882, 4.137518, 3.050902]`
  - `grad_norms=[2.590222, 5.900850786987662e+17, 9147114459174.867]`

Sanity check for active-device memory helpers:
- imported patched module from installed wheel path and verified:
  - `_get_active_accelerator_index` present
  - `_get_accelerator_total_memory_bytes` / `_get_effective_accelerator_memory_bytes` return values

## Notes
- High-memory accelerators keep warmup by default (`auto`).
- In this environment, the uninitialized-weights load exception did not reproduce on either `2025.12` or `2026.2.1`; both loaded successfully.
