### PR TITLE
Double-buffer GPU activations for overlapping H2D copy with backward compute

### DIFF
--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -360,16 +360,16 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     # Allocate buffers to how many GPUs
     n_gpus = torch.cuda.device_count() if DEVICE_TYPE in ("cuda", "hip") else torch.xpu.device_count()
     try:
-        GPU_BUFFERS = tuple([torch.empty(2*256*2048, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+        GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
         # Double buffering: try to allocate buffer B
         try:
-            GPU_BUFFERS_B = tuple([torch.empty(2*256*2048, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+            GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
             USE_DOUBLE_BUFFER = True
             # Per-buffer events to prevent race conditions in double buffering.
             # Each event tracks when compute on that buffer finishes
             BUFFER_EVENTS_A = tuple([torch.cuda.Event() for _ in range(n_gpus)])
             BUFFER_EVENTS_B = tuple([torch.cuda.Event() for _ in range(n_gpus)])
-        except:
+        except Exception as e:
             GPU_BUFFERS_B = None
             USE_DOUBLE_BUFFER = False
             BUFFER_EVENTS_A = None
@@ -494,7 +494,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                 try:
                                     GPU_BUFFER_B.resize_(new_size)
                                     print("Unsloth: Double buffering enabled (parallel H2D + compute) for backward pass.")
-                                except:
+                                except Exception as e:
                                     # OOM - disable double buffering
                                     USE_DOUBLE_BUFFER = False
                         x = x[:new_size].view(shape)

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -312,6 +312,7 @@ global FIRST_PASS
 global CURRENT_GC_INDEX
 global BUFFER_EVENTS_A
 global BUFFER_EVENTS_B
+global NEXT_BUFFER_SLOT
 
 if DEVICE_TYPE in ("cuda", "hip"):
     torch_gpu_stream = torch.cuda.stream
@@ -338,6 +339,7 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     global CURRENT_GC_INDEX
     global BUFFER_EVENTS_A
     global BUFFER_EVENTS_B
+    global NEXT_BUFFER_SLOT
     CPU_BUFFERS = []
     CPU_INDEX = 0
 
@@ -359,6 +361,7 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
 
     # Allocate buffers to how many GPUs
     n_gpus = torch.cuda.device_count() if DEVICE_TYPE in ("cuda", "hip") else torch.xpu.device_count()
+    NEXT_BUFFER_SLOT = [0] * n_gpus
     try:
         GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
         # Double buffering: try to allocate buffer B
@@ -367,9 +370,17 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
             USE_DOUBLE_BUFFER = True
             # Per-buffer events to prevent race conditions in double buffering.
             # Each event tracks when compute on that buffer finishes
-            BUFFER_EVENTS_A = tuple([torch.cuda.Event() for _ in range(n_gpus)])
-            BUFFER_EVENTS_B = tuple([torch.cuda.Event() for _ in range(n_gpus)])
-        except Exception as e:
+            if DEVICE_TYPE in ("cuda", "hip"):
+                event_ctor = torch.cuda.Event
+            elif DEVICE_TYPE == "xpu":
+                event_ctor = torch.xpu.Event
+            else:
+                raise RuntimeError(f"Double buffering unsupported on {DEVICE_TYPE}")
+            BUFFER_EVENTS_A = tuple([event_ctor() for _ in range(n_gpus)])
+            BUFFER_EVENTS_B = tuple([event_ctor() for _ in range(n_gpus)])
+        except RuntimeError as e:
+            if "out of memory" not in str(e).lower():
+                raise
             GPU_BUFFERS_B = None
             USE_DOUBLE_BUFFER = False
             BUFFER_EVENTS_A = None
@@ -493,8 +504,10 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                             if new_size > GPU_BUFFER_B.numel():
                                 try:
                                     GPU_BUFFER_B.resize_(new_size)
-                                    print("Unsloth: Double buffering enabled (parallel H2D + compute) for backward pass.")
-                                except Exception as e:
+                                    # print("Unsloth: Double buffering enabled (parallel H2D + compute) for backward pass.")
+                                except RuntimeError as e:
+                                    if "out of memory" not in str(e).lower():
+                                        raise
                                     # OOM - disable double buffering
                                     USE_DOUBLE_BUFFER = False
                         x = x[:new_size].view(shape)
@@ -504,7 +517,10 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                         with torch_gpu_stream(EXTRA_STREAM):
                             x.copy_(arg, non_blocking = True)
 
-                        ctx._saved_metadata = (new_size, shape, CPU_INDEX, device_index, MAIN_STREAM, EXTRA_STREAM,)
+                        global NEXT_BUFFER_SLOT
+                        buffer_slot = NEXT_BUFFER_SLOT[device_index]
+                        NEXT_BUFFER_SLOT[device_index] ^= 1
+                        ctx._saved_metadata = (new_size, shape, CPU_INDEX, device_index, MAIN_STREAM, EXTRA_STREAM, buffer_slot,)
                         CPU_INDEX += 1
                         tensor_inputs.append(None)
 
@@ -513,7 +529,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                             print("Unsloth: Will smartly offload gradients to save VRAM!")
                             USE_UNSLOTH_GC = False
                     else:
-                        ctx._saved_metadata = (None, None, None, None, None, None,)
+                        ctx._saved_metadata = (None, None, None, None, None, None, None,)
                         tensor_inputs.append(arg)
                     pass
                 else:
@@ -553,15 +569,15 @@ class UnslothCheckpointFunction(torch.autograd.Function):
         tensor_indices = ctx.tensor_indices
         tensors = ctx.saved_tensors
 
-        new_size, shape, CPU_INDEX, device_index, MAIN_STREAM, EXTRA_STREAM = ctx._saved_metadata
+        new_size, shape, CPU_INDEX, device_index, MAIN_STREAM, EXTRA_STREAM, buffer_slot = ctx._saved_metadata
         if CPU_INDEX is not None:
             global GPU_BUFFER
             global USE_DOUBLE_BUFFER
             global GPU_BUFFERS_B
             global BUFFER_EVENTS_A
             global BUFFER_EVENTS_B
-            # Select which buffer to use based on CPU_INDEX parity
-            if USE_DOUBLE_BUFFER and (CPU_INDEX % 2 == 1):
+            # Select which buffer to use based on per-device buffer_slot
+            if USE_DOUBLE_BUFFER and buffer_slot == 1:
                 buffer = GPU_BUFFERS_B[device_index][:new_size].view(shape)
             else:
                 buffer = GPU_BUFFERS[device_index][:new_size].view(shape)
@@ -571,10 +587,8 @@ class UnslothCheckpointFunction(torch.autograd.Function):
             # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
             if USE_DOUBLE_BUFFER:
                 # Wait for the last compute on THIS SPECIFIC buffer to finish
-                if CPU_INDEX % 2 == 1:
-                    EXTRA_STREAM.wait_event(BUFFER_EVENTS_B[device_index])
-                else:
-                    EXTRA_STREAM.wait_event(BUFFER_EVENTS_A[device_index])
+                event_buffer = BUFFER_EVENTS_B if buffer_slot == 1 else BUFFER_EVENTS_A
+                EXTRA_STREAM.wait_event(event_buffer[device_index])
             else:
                 # Single buffer mode: Must wait for MAIN_STREAM to finish
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
@@ -665,10 +679,8 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
         # Record event after compute finishes so the copy stream knows
         if CPU_INDEX is not None and USE_DOUBLE_BUFFER:
-            if CPU_INDEX % 2 == 1:
-                BUFFER_EVENTS_B[device_index].record(MAIN_STREAM)
-            else:
-                BUFFER_EVENTS_A[device_index].record(MAIN_STREAM)
+            event_buffer = BUFFER_EVENTS_B if buffer_slot == 1 else BUFFER_EVENTS_A
+            event_buffer[device_index].record(MAIN_STREAM)
 
         grads = tuple(
             inp.grad if isinstance(inp, torch.Tensor) else None
@@ -933,6 +945,11 @@ def reset_unsloth_gradient_checkpointing_buffers():
     global FIRST_PASS
     global CURRENT_GC_INDEX
     global USE_UNSLOTH_GC
+    global NEXT_BUFFER_SLOT
+    global GPU_BUFFERS_B
+    global USE_DOUBLE_BUFFER
+    global BUFFER_EVENTS_A
+    global BUFFER_EVENTS_B
 
     # Check if buffers exist
     if CPU_BUFFERS is None or GPU_BUFFERS is None:
@@ -971,6 +988,29 @@ def reset_unsloth_gradient_checkpointing_buffers():
     FIRST_PASS = True
     CURRENT_GC_INDEX = 0
     USE_UNSLOTH_GC = True  # Re-enable the "Will smartly offload" message
+    if NEXT_BUFFER_SLOT is not None:
+        for i in range(len(NEXT_BUFFER_SLOT)):
+            NEXT_BUFFER_SLOT[i] = 0
+
+    # Re-enable double buffering if buffer B still exists, or try to re-allocate
+    if GPU_BUFFERS_B is not None:
+        USE_DOUBLE_BUFFER = True
+    else:
+        try:
+            n_gpus = len(GPU_BUFFERS)
+            dtype = GPU_BUFFERS[0].dtype
+            GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype=dtype, device=f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+            if DEVICE_TYPE in ("cuda", "hip"):
+                event_ctor = torch.cuda.Event
+            elif DEVICE_TYPE == "xpu":
+                event_ctor = torch.xpu.Event
+            else:
+                raise RuntimeError(f"Double buffering unsupported on {DEVICE_TYPE}")
+            BUFFER_EVENTS_A = tuple([event_ctor() for _ in range(n_gpus)])
+            BUFFER_EVENTS_B = tuple([event_ctor() for _ in range(n_gpus)])
+            USE_DOUBLE_BUFFER = True
+        except RuntimeError:
+            pass
 
     # Clean up freed memory
     torch.cuda.empty_cache()

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -300,6 +300,8 @@ pass
 global CPU_BUFFERS
 global CPU_INDEX
 global GPU_BUFFERS
+global GPU_BUFFERS_B
+global USE_DOUBLE_BUFFER
 global BACKWARD_PASS
 global EXTRA_STREAMS
 global MAIN_STREAMS
@@ -322,6 +324,8 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     global CPU_BUFFERS
     global CPU_INDEX
     global GPU_BUFFERS
+    global GPU_BUFFERS_B
+    global USE_DOUBLE_BUFFER
     global BACKWARD_PASS
     global EXTRA_STREAMS
     global MAIN_STREAMS
@@ -353,6 +357,13 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     n_gpus = torch.cuda.device_count() if DEVICE_TYPE in ("cuda", "hip") else torch.xpu.device_count()
     try:
         GPU_BUFFERS = tuple([torch.empty(2*256*2048, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+        # Double buffering: try to allocate buffer B
+        try:
+            GPU_BUFFERS_B = tuple([torch.empty(2*256*2048, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+            USE_DOUBLE_BUFFER = True
+        except:
+            GPU_BUFFERS_B = None
+            USE_DOUBLE_BUFFER = False
     except Exception as e:
         print("="*10 + "\n")
         print("Unsloth: Your setup does not support `PYTORCH_CUDA_ALLOC_CONF`\n")
@@ -439,6 +450,8 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                         use_gpu_buffer = True
                         global CPU_BUFFERS
                         global GPU_BUFFERS
+                        global GPU_BUFFERS_B
+                        global USE_DOUBLE_BUFFER
                         global BACKWARD_PASS
                         global EXTRA_STREAMS
                         global MAIN_STREAMS
@@ -464,6 +477,16 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                         shape = arg.shape
                         if new_size > x.numel(): x.resize_(new_size)
                         if new_size > GPU_BUFFER.numel(): GPU_BUFFER.resize_(new_size)
+                        # resize buffer B as needed if double buffering is enabled, disable if OOM
+                        if USE_DOUBLE_BUFFER:
+                            GPU_BUFFER_B = GPU_BUFFERS_B[device_index]
+                            if new_size > GPU_BUFFER_B.numel():
+                                try:
+                                    GPU_BUFFER_B.resize_(new_size)
+                                    print("Unsloth: Double buffering enabled (parallel H2D + compute) for backward pass.")
+                                except:
+                                    # OOM - disable double buffering
+                                    USE_DOUBLE_BUFFER = False
                         x = x[:new_size].view(shape)
 
                         # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
@@ -523,11 +546,25 @@ class UnslothCheckpointFunction(torch.autograd.Function):
         new_size, shape, CPU_INDEX, device_index, MAIN_STREAM, EXTRA_STREAM = ctx._saved_metadata
         if CPU_INDEX is not None:
             global GPU_BUFFER
-            buffer = GPU_BUFFERS[device_index][:new_size].view(shape)
+            global USE_DOUBLE_BUFFER
+            global GPU_BUFFERS_B
+            # Select which buffer to use based on buffer index on CPU_INDEX if double buffering is enabled
+            if USE_DOUBLE_BUFFER and (CPU_INDEX % 2 == 1):
+                buffer = GPU_BUFFERS_B[device_index][:new_size].view(shape)
+            else:
+                buffer = GPU_BUFFERS[device_index][:new_size].view(shape)
+
             x = CPU_BUFFERS[CPU_INDEX][:new_size].view(shape)
 
             # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
-            EXTRA_STREAM.wait_stream(MAIN_STREAM)
+            if USE_DOUBLE_BUFFER:
+                # Double buffer mode: No need to wait for MAIN_STREAM because
+                # we're using a different buffer than the one being computed on
+                pass
+            else:
+                # Single buffer mode: Must wait for MAIN_STREAM to finish
+                EXTRA_STREAM.wait_stream(MAIN_STREAM)
+
             with torch_gpu_stream(EXTRA_STREAM):
                 buffer.copy_(x, non_blocking = True)
         else:

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -52,7 +52,7 @@ __all__ = [
 INITIAL_CPU_BUFFER_SIZE = 128 * 1024       # Initial size per CPU buffer
 INITIAL_GPU_BUFFER_SIZE = 2 * 256 * 2048   # Initial size per GPU buffer
 INITIAL_CPU_BUFFER_COUNT = 200             # Initial number of CPU buffers
-DOUBLE_BUFFER_HEADROOM = 256 * 1024 * 1024 # 256MB minimum free CUDA memory to enable double buffering
+DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # 512MB minimum free CUDA memory to enable double buffering
 
 torch_version = torch.__version__
 if Version(torch_version) < Version("2.4.0"):
@@ -528,7 +528,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                 if "out of memory" not in str(e).lower():
                                     raise
                                 # clear Buffer B and try to resize Single Buffer
-                                if USE_DOUBLE_BUFFER:
+                                if GPU_BUFFERS_B is not None:
                                     USE_DOUBLE_BUFFER = False
                                     for j in range(len(GPU_BUFFERS_B)):
                                         GPU_BUFFERS_B[j].resize_(0)

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -497,8 +497,22 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                         x = CPU_BUFFERS[CPU_INDEX]
                         shape = arg.shape
                         if new_size > x.numel(): x.resize_(new_size)
-                        if new_size > GPU_BUFFER.numel(): GPU_BUFFER.resize_(new_size)
-                        # resize buffer B as needed if double buffering is enabled, disable if OOM
+                        if new_size > GPU_BUFFER.numel():
+                            try:
+                                GPU_BUFFER.resize_(new_size)
+                            except RuntimeError as e:
+                                if "out of memory" not in str(e).lower():
+                                    raise
+                                # clear Buffer B and try to resize Single Buffer
+                                if USE_DOUBLE_BUFFER:
+                                    USE_DOUBLE_BUFFER = False
+                                    for j in range(len(GPU_BUFFERS_B)):
+                                        GPU_BUFFERS_B[j].resize_(0)
+                                    GPU_BUFFERS_B = None
+                                    GPU_BUFFER.resize_(new_size)
+                                else:
+                                    raise
+                        # resize buffer B as needed if double buffering is enabled, disable and free Buffer B if OOM
                         if USE_DOUBLE_BUFFER:
                             GPU_BUFFER_B = GPU_BUFFERS_B[device_index]
                             if new_size > GPU_BUFFER_B.numel():
@@ -510,6 +524,11 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                         raise
                                     # OOM - disable double buffering
                                     USE_DOUBLE_BUFFER = False
+                                    # Reclaim buffer B
+                                    for j in range(len(GPU_BUFFERS_B)):
+                                        GPU_BUFFERS_B[j].resize_(0)
+                                    GPU_BUFFERS_B = None
+
                         x = x[:new_size].view(shape)
 
                         # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
@@ -889,14 +908,27 @@ def unpatch_unsloth_smart_gradient_checkpointing():
         torch.utils.checkpoint.CheckpointFunction = torch.utils.checkpoint._old_CheckpointFunction
         global CPU_BUFFERS
         global GPU_BUFFERS
+        global GPU_BUFFERS_B
+        global USE_DOUBLE_BUFFER
+        global BUFFER_EVENTS_A
+        global BUFFER_EVENTS_B
+        global NEXT_BUFFER_SLOT
         for i in range(len(CPU_BUFFERS)):
             if hasattr(CPU_BUFFERS[i], "resize_"): CPU_BUFFERS[i].resize_(0)
             if type(CPU_BUFFERS) is list: CPU_BUFFERS[i] = None
         for i in range(len(GPU_BUFFERS)):
             if hasattr(GPU_BUFFERS[i], "resize_"): GPU_BUFFERS[i].resize_(0)
             if type(GPU_BUFFERS) is list: GPU_BUFFERS[i] = None
+        if GPU_BUFFERS_B is not None:
+            for i in range(len(GPU_BUFFERS_B)):
+                if hasattr(GPU_BUFFERS_B[i], "resize_"): GPU_BUFFERS_B[i].resize_(0)
+            GPU_BUFFERS_B = None
+            USE_DOUBLE_BUFFER = False
         CPU_BUFFERS = None
         GPU_BUFFERS = None
+        BUFFER_EVENTS_A = None
+        BUFFER_EVENTS_B = None
+        NEXT_BUFFER_SLOT = None
         torch.cuda.empty_cache()
         gc.collect()
 
@@ -994,6 +1026,9 @@ def reset_unsloth_gradient_checkpointing_buffers():
 
     # Re-enable double buffering if buffer B still exists, or try to re-allocate
     if GPU_BUFFERS_B is not None:
+        for i in range(len(GPU_BUFFERS_B)):
+            if GPU_BUFFERS_B[i] is not None and hasattr(GPU_BUFFERS_B[i], "resize_"):
+                GPU_BUFFERS_B[i].resize_(INITIAL_GPU_BUFFER_SIZE)
         USE_DOUBLE_BUFFER = True
     else:
         try:

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -494,7 +494,12 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                             BACKWARD_PASS = False
                             CPU_INDEX = 0
                             if not FIRST_PASS and not USE_DOUBLE_BUFFER and GPU_BUFFERS_B is not None:
-                                free_mem, _ = torch.cuda.mem_get_info(device_index)
+                                if DEVICE_TYPE in ("cuda", "hip"):
+                                    free_mem, _ = torch.cuda.mem_get_info(device_index)
+                                elif DEVICE_TYPE == "xpu":
+                                    free_mem, _ = torch.xpu.mem_get_info(device_index)
+                                else:
+                                    free_mem = 0
                                 if free_mem > DOUBLE_BUFFER_HEADROOM:
                                     USE_DOUBLE_BUFFER = True
                                     print(f"Unsloth: Double buffering enabled (parallel H2D + compute) for backward pass.")
@@ -1042,7 +1047,9 @@ def reset_unsloth_gradient_checkpointing_buffers():
             NEXT_BUFFER_SLOT[i] = 0
 
     # Reset double buffering if buffer B still exists, or try to re-allocate
-    if GPU_BUFFERS_B is not None:
+    if os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER", "0") == "1":
+        pass
+    elif GPU_BUFFERS_B is not None:
         for i in range(len(GPU_BUFFERS_B)):
             if GPU_BUFFERS_B[i] is not None and hasattr(GPU_BUFFERS_B[i], "resize_"):
                 GPU_BUFFERS_B[i].resize_(INITIAL_GPU_BUFFER_SIZE)

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -310,6 +310,8 @@ global USE_UNSLOTH_GC
 global LAST_GC_INDEX
 global FIRST_PASS
 global CURRENT_GC_INDEX
+global BUFFER_EVENTS_A
+global BUFFER_EVENTS_B
 
 if DEVICE_TYPE in ("cuda", "hip"):
     torch_gpu_stream = torch.cuda.stream
@@ -334,6 +336,8 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     global LAST_GC_INDEX
     global FIRST_PASS
     global CURRENT_GC_INDEX
+    global BUFFER_EVENTS_A
+    global BUFFER_EVENTS_B
     CPU_BUFFERS = []
     CPU_INDEX = 0
 
@@ -361,9 +365,15 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
         try:
             GPU_BUFFERS_B = tuple([torch.empty(2*256*2048, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
             USE_DOUBLE_BUFFER = True
+            # Per-buffer events to prevent race conditions in double buffering.
+            # Each event tracks when compute on that buffer finishes
+            BUFFER_EVENTS_A = tuple([torch.cuda.Event() for _ in range(n_gpus)])
+            BUFFER_EVENTS_B = tuple([torch.cuda.Event() for _ in range(n_gpus)])
         except:
             GPU_BUFFERS_B = None
             USE_DOUBLE_BUFFER = False
+            BUFFER_EVENTS_A = None
+            BUFFER_EVENTS_B = None
     except Exception as e:
         print("="*10 + "\n")
         print("Unsloth: Your setup does not support `PYTORCH_CUDA_ALLOC_CONF`\n")
@@ -548,7 +558,9 @@ class UnslothCheckpointFunction(torch.autograd.Function):
             global GPU_BUFFER
             global USE_DOUBLE_BUFFER
             global GPU_BUFFERS_B
-            # Select which buffer to use based on buffer index on CPU_INDEX if double buffering is enabled
+            global BUFFER_EVENTS_A
+            global BUFFER_EVENTS_B
+            # Select which buffer to use based on CPU_INDEX parity
             if USE_DOUBLE_BUFFER and (CPU_INDEX % 2 == 1):
                 buffer = GPU_BUFFERS_B[device_index][:new_size].view(shape)
             else:
@@ -558,9 +570,11 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
             # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
             if USE_DOUBLE_BUFFER:
-                # Double buffer mode: No need to wait for MAIN_STREAM because
-                # we're using a different buffer than the one being computed on
-                pass
+                # Wait for the last compute on THIS SPECIFIC buffer to finish
+                if CPU_INDEX % 2 == 1:
+                    EXTRA_STREAM.wait_event(BUFFER_EVENTS_B[device_index])
+                else:
+                    EXTRA_STREAM.wait_event(BUFFER_EVENTS_A[device_index])
             else:
                 # Single buffer mode: Must wait for MAIN_STREAM to finish
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
@@ -648,6 +662,13 @@ class UnslothCheckpointFunction(torch.autograd.Function):
         else:
             torch.autograd.backward(outputs_with_grad, args_with_grad)
         pass
+
+        # Record event after compute finishes so the copy stream knows
+        if CPU_INDEX is not None and USE_DOUBLE_BUFFER:
+            if CPU_INDEX % 2 == 1:
+                BUFFER_EVENTS_B[device_index].record(MAIN_STREAM)
+            else:
+                BUFFER_EVENTS_A[device_index].record(MAIN_STREAM)
 
         grads = tuple(
             inp.grad if isinstance(inp, torch.Tensor) else None

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -365,27 +365,33 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     NEXT_BUFFER_SLOT = [0] * n_gpus
     try:
         GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
-        # Double buffering: try to allocate buffer B
-        try:
-            GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
-            USE_DOUBLE_BUFFER = False # enabled after first pass if CUDA free memory > DOUBLE_BUFFER_HEADROOM
-            # Per-buffer events to prevent race conditions in double buffering.
-            # Each event tracks when compute on that buffer finishes
-            if DEVICE_TYPE in ("cuda", "hip"):
-                event_ctor = torch.cuda.Event
-            elif DEVICE_TYPE == "xpu":
-                event_ctor = torch.xpu.Event
-            else:
-                raise RuntimeError(f"Double buffering unsupported on {DEVICE_TYPE}")
-            BUFFER_EVENTS_A = tuple([event_ctor() for _ in range(n_gpus)])
-            BUFFER_EVENTS_B = tuple([event_ctor() for _ in range(n_gpus)])
-        except RuntimeError as e:
-            if "out of memory" not in str(e).lower():
-                raise
+        # Double buffering: try to allocate buffer B (can be disabled via env var)
+        if os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER", "0") == "1":
             GPU_BUFFERS_B = None
             USE_DOUBLE_BUFFER = False
             BUFFER_EVENTS_A = None
             BUFFER_EVENTS_B = None
+        else:
+            try:
+                GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+                USE_DOUBLE_BUFFER = False # set false first, enabled after first pass if CUDA free memory > DOUBLE_BUFFER_HEADROOM
+                # Per-buffer events to prevent race conditions in double buffering.
+                # Each event tracks when compute on that buffer finishes
+                if DEVICE_TYPE in ("cuda", "hip"):
+                    event_ctor = torch.cuda.Event
+                elif DEVICE_TYPE == "xpu":
+                    event_ctor = torch.xpu.Event
+                else:
+                    raise RuntimeError(f"Double buffering unsupported on {DEVICE_TYPE}")
+                BUFFER_EVENTS_A = tuple([event_ctor() for _ in range(n_gpus)])
+                BUFFER_EVENTS_B = tuple([event_ctor() for _ in range(n_gpus)])
+            except RuntimeError as e:
+                if "out of memory" not in str(e).lower():
+                    raise
+                GPU_BUFFERS_B = None
+                USE_DOUBLE_BUFFER = False
+                BUFFER_EVENTS_A = None
+                BUFFER_EVENTS_B = None
     except Exception as e:
         print("="*10 + "\n")
         print("Unsloth: Your setup does not support `PYTORCH_CUDA_ALLOC_CONF`\n")

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -52,6 +52,7 @@ __all__ = [
 INITIAL_CPU_BUFFER_SIZE = 128 * 1024       # Initial size per CPU buffer
 INITIAL_GPU_BUFFER_SIZE = 2 * 256 * 2048   # Initial size per GPU buffer
 INITIAL_CPU_BUFFER_COUNT = 200             # Initial number of CPU buffers
+DOUBLE_BUFFER_HEADROOM = 256 * 1024 * 1024 # 256MB minimum free CUDA memory to enable double buffering
 
 torch_version = torch.__version__
 if Version(torch_version) < Version("2.4.0"):
@@ -367,7 +368,7 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
         # Double buffering: try to allocate buffer B
         try:
             GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
-            USE_DOUBLE_BUFFER = True
+            USE_DOUBLE_BUFFER = False # enabled after first pass if CUDA free memory > DOUBLE_BUFFER_HEADROOM
             # Per-buffer events to prevent race conditions in double buffering.
             # Each event tracks when compute on that buffer finishes
             if DEVICE_TYPE in ("cuda", "hip"):
@@ -486,6 +487,15 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                         if BACKWARD_PASS:
                             BACKWARD_PASS = False
                             CPU_INDEX = 0
+                            if not FIRST_PASS and not USE_DOUBLE_BUFFER and GPU_BUFFERS_B is not None:
+                                free_mem, _ = torch.cuda.mem_get_info(device_index)
+                                if free_mem > DOUBLE_BUFFER_HEADROOM:
+                                    USE_DOUBLE_BUFFER = True
+                                    print(f"Unsloth: Double buffering enabled (parallel H2D + compute) for backward pass.")
+                                else:
+                                    for j in range(len(GPU_BUFFERS_B)):
+                                        GPU_BUFFERS_B[j].resize_(0)
+                                    GPU_BUFFERS_B = None
                         pass
 
                         # Extend buffer size
@@ -509,6 +519,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                     for j in range(len(GPU_BUFFERS_B)):
                                         GPU_BUFFERS_B[j].resize_(0)
                                     GPU_BUFFERS_B = None
+                                    print("Unsloth: Disabled double buffering due to insufficient VRAM.")
                                     GPU_BUFFER.resize_(new_size)
                                 else:
                                     raise
@@ -518,7 +529,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                             if new_size > GPU_BUFFER_B.numel():
                                 try:
                                     GPU_BUFFER_B.resize_(new_size)
-                                    # print("Unsloth: Double buffering enabled (parallel H2D + compute) for backward pass.")
                                 except RuntimeError as e:
                                     if "out of memory" not in str(e).lower():
                                         raise
@@ -528,6 +538,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                     for j in range(len(GPU_BUFFERS_B)):
                                         GPU_BUFFERS_B[j].resize_(0)
                                     GPU_BUFFERS_B = None
+                                    print("Unsloth: Disabled double buffering due to insufficient VRAM.")
 
                         x = x[:new_size].view(shape)
 
@@ -1024,12 +1035,12 @@ def reset_unsloth_gradient_checkpointing_buffers():
         for i in range(len(NEXT_BUFFER_SLOT)):
             NEXT_BUFFER_SLOT[i] = 0
 
-    # Re-enable double buffering if buffer B still exists, or try to re-allocate
+    # Reset double buffering if buffer B still exists, or try to re-allocate
     if GPU_BUFFERS_B is not None:
         for i in range(len(GPU_BUFFERS_B)):
             if GPU_BUFFERS_B[i] is not None and hasattr(GPU_BUFFERS_B[i], "resize_"):
                 GPU_BUFFERS_B[i].resize_(INITIAL_GPU_BUFFER_SIZE)
-        USE_DOUBLE_BUFFER = True
+        USE_DOUBLE_BUFFER = False
     else:
         try:
             n_gpus = len(GPU_BUFFERS)
@@ -1043,7 +1054,7 @@ def reset_unsloth_gradient_checkpointing_buffers():
                 raise RuntimeError(f"Double buffering unsupported on {DEVICE_TYPE}")
             BUFFER_EVENTS_A = tuple([event_ctor() for _ in range(n_gpus)])
             BUFFER_EVENTS_B = tuple([event_ctor() for _ in range(n_gpus)])
-            USE_DOUBLE_BUFFER = True
+            USE_DOUBLE_BUFFER = False
         except RuntimeError:
             pass
 

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -494,11 +494,14 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                             BACKWARD_PASS = False
                             CPU_INDEX = 0
                             if not FIRST_PASS and not USE_DOUBLE_BUFFER and GPU_BUFFERS_B is not None:
-                                if DEVICE_TYPE in ("cuda", "hip"):
-                                    free_mem, _ = torch.cuda.mem_get_info(device_index)
-                                elif DEVICE_TYPE == "xpu":
-                                    free_mem, _ = torch.xpu.mem_get_info(device_index)
-                                else:
+                                try:
+                                    if DEVICE_TYPE in ("cuda", "hip"):
+                                        free_mem, _ = torch.cuda.mem_get_info(device_index)
+                                    elif DEVICE_TYPE == "xpu":
+                                        free_mem, _ = torch.xpu.mem_get_info(device_index)
+                                    else:
+                                        free_mem = 0
+                                except Exception as e:
                                     free_mem = 0
                                 if free_mem > DOUBLE_BUFFER_HEADROOM:
                                     USE_DOUBLE_BUFFER = True
@@ -1048,7 +1051,12 @@ def reset_unsloth_gradient_checkpointing_buffers():
 
     # Reset double buffering if buffer B still exists, or try to re-allocate
     if os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER", "0") == "1":
-        pass
+        if GPU_BUFFERS_B is not None:
+            for i in range(len(GPU_BUFFERS_B)):
+                if GPU_BUFFERS_B[i] is not None and hasattr(GPU_BUFFERS_B[i], "resize_"):
+                    GPU_BUFFERS_B[i].resize_(0)
+            GPU_BUFFERS_B = None
+        USE_DOUBLE_BUFFER = False
     elif GPU_BUFFERS_B is not None:
         for i in range(len(GPU_BUFFERS_B)):
             if GPU_BUFFERS_B[i] is not None and hasattr(GPU_BUFFERS_B[i], "resize_"):


### PR DESCRIPTION
This PR implements a double-buffering optimization for activation reloading during the backward pass of gradient checkpointing with `use_gradient_checkpointing="unsloth"`. This means any model fine-tuned with Unsloth's gradient checkpointing will benefit from this PR.

Problem: With the current single-buffer implementation, the H2D memory copy for reloading offloaded activations during backward cannot overlap with GPU computation. The copy stream must wait for the compute stream to finish using the shared GPU buffer before writing the next activation into it, creating GPU idle bubbles.

Solution: Allocate a second GPU buffer (`GPU_BUFFERS_B`) and alternate between the two buffers based on layer index (CPU_INDEX % 2) with cuda event to prevent race condition. While the compute stream operates on buffer A, the copy stream can simultaneously load the next activation into buffer B, and vice versa — fully overlapping H2D transfers with backward computation. 

e.g. 
```text
Layer 23 backward:
  1. H2D copy into buffer A (EXTRA_STREAM)
  2. MAIN_STREAM.wait_stream(EXTRA_STREAM)  // wait for copy
  3. Compute on buffer A                   
Layer 22 backward:
  1. H2D copy into buffer B (EXTRA_STREAM)  // overlaps with step 3 above
  2. MAIN_STREAM.wait_stream(EXTRA_STREAM)
  3. Compute on buffer B                    
Layer 21 backward:
  1. H2D copy into buffer A (EXTRA_STREAM)  // Layer 23's compute already done
  2. MAIN_STREAM.wait_stream(EXTRA_STREAM)
  3. Compute on buffer A
```

Here are the nsys profiling traces:
* Without this PR
<img width="1164" height="279" alt="image" src="https://github.com/user-attachments/assets/67935c0c-563a-4f76-8c35-739d404964e6" />

* With this PR
<img width="1165" height="170" alt="image" src="https://github.com/user-attachments/assets/2d184648-f858-40b5-bf65-476313757f1a" />


### Performance: 
This method doesn’t take much memory as it only takes a buffer size in VRAM, e.g. in gpt-oss-20B model fine-tuning, one buffer takes around 47.18MB with batch size 8. 
This PR also implemented a smart double buffering enabling strategy, i.e. if there are enough VRAM we will enable double-buffering otherwise disable. 
In my experiments, this achieves approximately 10% speedup per backward pass during GPT-OSS-20B fine-tuning, though results may vary across different models, hyperparameters (e.g. seq_length, batch size etc.) and hardware configurations.
 
