### PR TITLE
Add Idefics3 fast_inference support

### DIFF
--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -403,6 +403,10 @@ def set_additional_modules(new_model, quant_state_dict, config):
     if hasattr(new_model, "language_model"):
         language_model = new_model.language_model
         language_model_prefix = "model.language_model"
+    elif hasattr(new_model, "model") and hasattr(new_model.model, "text_model"):
+        # Idefics3, SmolVLM2: model wraps text_model/vision_model/connector
+        language_model = new_model.model.text_model
+        language_model_prefix = "model.text_model"
     else:
         language_model_prefix = "model"
         language_model = new_model.model
@@ -491,7 +495,7 @@ def set_additional_modules(new_model, quant_state_dict, config):
     # Preferably norms, embeddings and convolution type layers.
     additional_keys = set(
         x for x in quant_state_dict.keys()
-        if not any(substr in x for substr in ("layers", "blocks", embed_tokens_key, norm_key, "lm_head", "mlp", "linear", "list"))
+        if not any(substr in x for substr in ("layers", "blocks", embed_tokens_key, norm_key, "lm_head", "mlp", "linear", "list", "connector"))
     )
     print(f'Performing substitution for {additional_keys=}')
 
@@ -539,6 +543,17 @@ def get_model_layer_config(return_non_layered=True):
             "model.layers.{kk}.mlp.up_proj",
             "model.layers.{kk}.mlp.gate_up_proj", # for extracting from vLLM (phi3 architecture)
             "model.layers.{kk}.mlp.down_proj",
+
+            # Idefics3 (granite-docling, SmolVLM2): text model under model.text_model
+            "model.text_model.layers.{kk}.self_attn.q_proj",
+            "model.text_model.layers.{kk}.self_attn.k_proj",
+            "model.text_model.layers.{kk}.self_attn.v_proj",
+            "model.text_model.layers.{kk}.self_attn.qkv_proj",
+            "model.text_model.layers.{kk}.self_attn.o_proj",
+            "model.text_model.layers.{kk}.mlp.gate_proj",
+            "model.text_model.layers.{kk}.mlp.up_proj",
+            "model.text_model.layers.{kk}.mlp.gate_up_proj",
+            "model.text_model.layers.{kk}.mlp.down_proj",
         },
         'layernorms': {
             "model.language_model.layers.{kk}.input_layernorm",
@@ -567,6 +582,12 @@ def get_model_layer_config(return_non_layered=True):
 
             # qwen3 vl
             "model.visual.deepstack_merger_list.{kk}.norm",
+
+            # Idefics3 (granite-docling, SmolVLM2)
+            "model.text_model.layers.{kk}.input_layernorm",
+            "model.text_model.layers.{kk}.post_attention_layernorm",
+            "model.vision_model.encoder.layers.{kk}.layer_norm1",
+            "model.vision_model.encoder.layers.{kk}.layer_norm2",
         },
         'vision_layers': {
 
@@ -635,6 +656,15 @@ def get_model_layer_config(return_non_layered=True):
             "model.visual.blocks.{kk}.mlp.linear_fc1",
             "model.visual.blocks.{kk}.mlp.linear_fc2",
 
+            # Idefics3 (granite-docling, SmolVLM2)
+            "model.vision_model.encoder.layers.{kk}.self_attn.q_proj",
+            "model.vision_model.encoder.layers.{kk}.self_attn.k_proj",
+            "model.vision_model.encoder.layers.{kk}.self_attn.v_proj",
+            "model.vision_model.encoder.layers.{kk}.self_attn.qkv_proj",
+            "model.vision_model.encoder.layers.{kk}.self_attn.out_proj",
+            "model.vision_model.encoder.layers.{kk}.mlp.fc1",
+            "model.vision_model.encoder.layers.{kk}.mlp.fc2",
+
         },
         'additional_layers': {
             # Primarily for layers that are neither language decoder layers or vision transformer layers/blocks.
@@ -655,6 +685,9 @@ def get_model_layer_config(return_non_layered=True):
             "model.visual.deepstack_merger_list.{kk}.linear_fc1",
             "model.visual.deepstack_merger_list.{kk}.linear_fc2",
             "model.visual.merger.linear_fc{kk}",
+
+            # Idefics3 (granite-docling, SmolVLM2)
+            "model.connector.modality_projection.proj",
 
         },
         "non_layered_components":{
@@ -689,6 +722,11 @@ def get_model_layer_config(return_non_layered=True):
             # qwen 3 vl
             "model.visual.pos_embed",
             "model.visual.merger.norm",
+
+            # Idefics3 (granite-docling, SmolVLM2)
+            "model.vision_model.embeddings.patch_embedding",
+            "model.vision_model.embeddings.position_embedding",
+            "model.vision_model.post_layernorm",
         }
     }
 
@@ -736,6 +774,11 @@ def get_model_layer_counts(config):
         return {
             "text_layers": getattr(config.text_config, "num_hidden_layers", 32),
             "vision_layers": getattr(config.vision_config, "num_hidden_layers", 32),
+        }
+    elif model_type in ("idefics3_vision",):
+        return {
+            "text_layers": getattr(config.text_config, "num_hidden_layers", 30),
+            "vision_layers": getattr(config.vision_config, "num_hidden_layers", 12),
         }
     else:
         # Standard causal LM

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1064,7 +1064,11 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
     pass
 
     # Embedding
-    if hasattr(vllm_internals, "model"): # Standard Language models
+    if hasattr(vllm_internals, "model") and hasattr(vllm_internals.model, "text_model"):
+        # Idefics3, SmolVLM2: model wraps text_model/vision_model/connector
+        vllm_text_model = vllm_internals.model.text_model
+        vllm_text_model_prefix = "model.text_model"
+    elif hasattr(vllm_internals, "model"): # Standard Language models
         vllm_text_model = vllm_internals.model
         vllm_text_model_prefix = "model"
     elif hasattr(vllm_internals, "language_model"):
@@ -1212,8 +1216,8 @@ def assert_same_state_dict(old_state_dict, new_state_dict):
         except Exception as error:
             if key == "lm_head.weight":
                 # Try tied embeddings fallback
-                key1 = next((k for k in (key, "model.embed_tokens.weight", "model.language_model.embed_tokens.weight") if k in old_state_dict), None)
-                key2 = next((k for k in (key, "model.embed_tokens.weight", "model.language_model.embed_tokens.weight") if k in new_state_dict), None)
+                key1 = next((k for k in (key, "model.embed_tokens.weight", "model.language_model.embed_tokens.weight", "model.text_model.embed_tokens.weight") if k in old_state_dict), None)
+                key2 = next((k for k in (key, "model.embed_tokens.weight", "model.language_model.embed_tokens.weight", "model.text_model.embed_tokens.weight") if k in new_state_dict), None)
 
                 if key1 is not None and key2 is not None:
                     try:


### PR DESCRIPTION
## Summary

Adds full vLLM-to-HuggingFace weight conversion support for Idefics3 architecture models (e.g. `ibm-granite/granite-docling-258M`, SmolVLM2) when using `fast_inference=True`.

Idefics3 uses a composite model structure (`model.text_model` / `model.vision_model` / `model.connector`) that differs from both the standard LLM pattern (`model`) and the Gemma3/Llama-3.2 VL pattern (`language_model`). This PR handles the full extraction and reconstruction pipeline for this architecture.

**vllm_utils.py:**
- Detect Idefics3 composite model structure for correct text model extraction with `model.text_model` prefix
- Add `model.text_model.embed_tokens.weight` to tied embeddings fallback in `assert_same_state_dict`

**empty_model.py:**
- Add `model.text_model.layers.{kk}.*` templates to `standard_layers` for text model weight reconstruction
- Add Idefics3 vision encoder templates to `vision_layers` (handles vLLM merged `qkv_proj` -> split `q_proj`/`k_proj`/`v_proj`)
- Add Idefics3 layernorm templates for both text and vision encoder
- Add `connector.modality_projection.proj` to `additional_layers` for quantization-aware reconstruction
- Add vision embeddings to `non_layered_components`
- Add `idefics3_vision` layer count handler in `get_model_layer_counts`
- Add Idefics3 `text_model` detection branch in `set_additional_modules`
- Exclude `"connector"` from `additional_keys` catch-all to prevent overwriting properly reconstructed quantized connector weights

Companion to unslothai/unsloth#4241 which adds `"idefics3"` to `VLLM_SUPPORTED_VLM`.

## Test Results

Tested with `ibm-granite/granite-docling-258M`, `load_in_4bit=True`, `max_steps=61`, `seed=3407`:

| Run | fast_inference | Train Loss | Peak VRAM | Samples/s | Time |
|-----|---------------|------------|-----------|-----------|------|
| Without PR (SFT) | False | 0.9219 | 2.58 GB | 2.06 | 177.64s |
| With PR (SFT) | False | 0.9219 | 2.58 GB | 2.06 | 177.18s |
| With PR (fast_inf) | True | 0.8536 | 89.93 GB | 1.11 | 329.23s |

- Losses and grad norms match exactly between "Without PR" and "With PR" (`fast_inference=False`) runs, confirming no regression
- `fast_inference=True` training completes all 61 steps with proper loss convergence
- Inference/generation works correctly after training with `fast_inference=True`

## Test plan

- [x] `fast_inference=False` regression: losses/grad-norms match baseline exactly
- [x] `fast_inference=True` SFT training completes 61 steps
- [x] `fast_inference=True` inference/generation produces valid output
- [x] Vision encoder weights correctly reconstructed (768x768 attn, 3072x768 MLP)
- [x] Connector weights correctly reconstructed (576x12288)
- [x] Text model weights correctly reconstructed (576-dim hidden)