### PR TITLE
Add GraniteMoeHybridForCausalLM compiler support

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1556,7 +1556,7 @@ $LOGITSCALINGMULTIPLY$
 $LOGITSCALINGDIVISION$
 $LOGITSOFTCAPPING$
 loss = None
-if labels is not None:$SPACES$loss = self.loss_function($NEWLINES$$LOGITS$, $LABELS$, $VOCABSIZE$$KWARGS$$NEWLINES$)
+if labels is not None:$SPACES$loss = self.loss_function($NEWLINES$$LOGITS$,$NEWLINES$$LABELS$,$NEWLINES$$VOCABSIZE$$KWARGS$,?$NEWLINES$)
 """
 
 cross_entropy_replacement_2 = """
@@ -1775,7 +1775,7 @@ def apply_fused_lm_head(forward, module=None):
                 r"self\.config\.text_config\.vocab_size"
                 ")",
             )
-            .replace("$KWARGS$", r"(?:, \*\*(loss_kwargs|kwargs))?")
+            .replace("$KWARGS$", r"(?:,[\s\n]{0,}\*\*(loss_kwargs|kwargs))?")
             .replace("$LOGITSUPCAST$", r"(?:logits = logits\.float\(\))?")
             .replace("$LABELSDEVICE$", r"(?:labels = labels\.to\([^\)]{1,}\))?")
             .replace(
@@ -1985,6 +1985,9 @@ def test_apply_fused_lm_head():
     from transformers.models.granite.modeling_granite import GraniteForCausalLM
 
     forwards.append(GraniteForCausalLM)
+    from transformers.models.granitemoehybrid.modeling_granitemoehybrid import GraniteMoeHybridForCausalLM
+
+    forwards.append(GraniteMoeHybridForCausalLM)
     from transformers.models.gemma2.modeling_gemma2 import Gemma2ForCausalLM
 
     forwards.append(Gemma2ForCausalLM)


### PR DESCRIPTION
## Summary

Adds compiler support for `GraniteMoeHybridForCausalLM` (IBM Granite 4 h-family models) and fixes the `cross_entropy_find_2` regex to handle multi-line `loss_function` call formatting.

### Changes

1. **Add `GraniteMoeHybridForCausalLM` to the forwards list** — the compiler now processes its `forward` method for fused cross-entropy and `UNSLOTH_RETURN_HIDDEN_STATES` support.

2. **Fix multi-line `loss_function` regex** — the `cross_entropy_find_2` template used literal `, ` (comma-space) between arguments, which only matched single-line formatting (e.g. Llama). GraniteMoeHybrid (and potentially other models) format the call across multiple lines:
   ```python
   # Single-line (Llama) - matched before
   loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)

   # Multi-line (GraniteMoeHybrid) - now also matched
   loss = self.loss_function(
       logits,
       labels,
       vocab_size=self.config.vocab_size,
       **kwargs,
   )
   ```

3. **Fix `$KWARGS$` regex** — same issue: `, **kwargs` had a literal space that didn't match `\n    **kwargs`.

4. **Trailing comma tolerance** — added `,?` before the closing paren to handle the trailing comma in multi-line formatting.

### Testing

Verified that `apply_fused_lm_head` successfully patches all three model types:
- `LlamaForCausalLM` (single-line format) ✅
- `Qwen3ForCausalLM` (single-line format) ✅
- `GraniteMoeHybridForCausalLM` (multi-line format) ✅

Also ran end-to-end RL training (ART/GRPO with LoRA) on `granite-4.0-h-tiny` to confirm the patched forward works correctly with `UNSLOTH_RETURN_HIDDEN_STATES=1`.

### Related

Companion PR for loader.py approach: https://github.com/unslothai/unsloth/pull/4373

## Test plan
- [x] `apply_fused_lm_head` matches Llama, Qwen3, GraniteMoeHybrid
- [x] End-to-end training with GraniteMoeHybrid completes without shape mismatch errors