### PR TITLE
Add last_response_only parameter to train_on_responses_only

### DIFF
--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -184,16 +184,20 @@ pass
 
 def train_on_responses_only(
     trainer,
-    instruction_part = None,
-    response_part    = None,
-    force_match      = True,  # Match newlines as well!
-    tokenizer        = None,  # Optional
-    return_function  = False, # Useful for iterating over lists
-    num_proc         = None,
+    instruction_part  = None,
+    response_part     = None,
+    force_match       = True,  # Match newlines as well!
+    tokenizer         = None,  # Optional
+    return_function   = False, # Useful for iterating over lists
+    num_proc          = None,
+    last_response_only = False, # Train only on the last assistant turn
 ):
     """
     Trains only on responses and not on the instruction by masking out
     the labels with -100 for the instruction part.
+
+    If last_response_only=True, only the final assistant turn has its
+    labels unmasked; all earlier assistant turns remain masked at -100.
     """
     # All Unsloth Zoo code licensed under LGPLv3
     if tokenizer is None and trainer is not None:
@@ -249,13 +253,16 @@ def train_on_responses_only(
         for input_ids, old_labels in zip(input_ids_, labels_):
             n = len(input_ids)
             labels = [-100] * n
-            
+
             use_old_labels = False
             if old_labels is not None:
                 use_old_labels = True
                 assert(n == len(old_labels))
             n_minus_1 = n - 1
             j = 0
+
+            # Collect all (assistant_k, user_j) spans for this sample
+            spans = []
             while j < n:
                 # Find <assistant>
                 if (input_ids[j] == A_first) and \
@@ -308,13 +315,7 @@ def train_on_responses_only(
                                 k = n
                             pass
 
-                            if not use_old_labels:
-                                # Now copy input_ids to labels
-                                labels[assistant_k : user_j] = input_ids [assistant_k : user_j]
-                                # print(assistant_j, assistant_k, user_j, user_k)
-                            else:
-                                # Copy over from old labels!
-                                labels[assistant_k : user_j] = old_labels[assistant_k : user_j]
+                            spans.append((assistant_k, user_j))
                             break
                         pass
                         j += 1
@@ -322,6 +323,17 @@ def train_on_responses_only(
                 pass
                 j += 1
             pass
+
+            # Apply labels: only the last assistant turn when last_response_only=True
+            apply_spans = spans[-1:] if last_response_only else spans
+            for assistant_k, user_j in apply_spans:
+                if not use_old_labels:
+                    # Now copy input_ids to labels
+                    labels[assistant_k : user_j] = input_ids [assistant_k : user_j]
+                else:
+                    # Copy over from old labels!
+                    labels[assistant_k : user_j] = old_labels[assistant_k : user_j]
+
             all_labels.append(labels)
         pass
         return { "labels" : torch.tensor(all_labels, dtype = torch.int64) if use_tensors else all_labels }

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -197,7 +197,9 @@ def train_on_responses_only(
     the labels with -100 for the instruction part.
 
     If last_response_only=True, only the final assistant turn has its
-    labels unmasked; all earlier assistant turns remain masked at -100.
+    labels unmasked; all earlier assistant turns remain masked at -100
+    (they are never written, so they keep the initialized -100 values
+    and are not copied from old_labels either).
     """
     # All Unsloth Zoo code licensed under LGPLv3
     if tokenizer is None and trainer is not None:
@@ -324,7 +326,9 @@ def train_on_responses_only(
                 j += 1
             pass
 
-            # Apply labels: only the last assistant turn when last_response_only=True
+            # Apply labels: only the last assistant turn when last_response_only=True.
+            # Note: spans[-1:] safely returns [] when spans is empty (no assistant turn
+            # was found), so a sample with no assistant turn stays fully masked at -100.
             apply_spans = spans[-1:] if last_response_only else spans
             for assistant_k, user_j in apply_spans:
                 if not use_old_labels:

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -656,6 +656,7 @@ class UnslothVisionDataCollator:
         response_part    = None,
         force_match      = True, # Match newlines as well!
         num_proc         = None,
+        last_response_only = False, # Train only on the last assistant turn
         completion_only_loss = True,
         pad_to_multiple_of = None,
         resize_dimension = 0, # can be 0, 1, 'max' or 'min' (max resizes based on the max of height width, min the min size, 0 the first dim, etc)
@@ -733,12 +734,13 @@ class UnslothVisionDataCollator:
             assert(isinstance(instruction_part, str) and isinstance(response_part, str))
             self.train_on_responses_only = _train_on_responses_only(
                 None,
-                instruction_part = instruction_part,
-                response_part    = response_part,
-                force_match      = force_match,
-                tokenizer        = processor,
-                return_function  = True,
-                num_proc         = num_proc,
+                instruction_part   = instruction_part,
+                response_part      = response_part,
+                force_match        = force_match,
+                tokenizer          = processor,
+                return_function    = True,
+                num_proc           = num_proc,
+                last_response_only = last_response_only,
             )
         else:
             self.train_on_responses_only = None

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -656,11 +656,11 @@ class UnslothVisionDataCollator:
         response_part    = None,
         force_match      = True, # Match newlines as well!
         num_proc         = None,
-        last_response_only = False, # Train only on the last assistant turn
         completion_only_loss = True,
         pad_to_multiple_of = None,
         resize_dimension = 0, # can be 0, 1, 'max' or 'min' (max resizes based on the max of height width, min the min size, 0 the first dim, etc)
         snap_to_patch_size = False,
+        last_response_only = False, # Train only on the last assistant turn
     ):
         if not hasattr(processor, "image_processor"):
             raise TypeError("Unsloth: UnslothVisionDataCollator is only for image models!")


### PR DESCRIPTION
# Add `last_response_only` parameter to `train_on_responses_only`

> **Note: This change was generated by an AI assistant (Claude). The repo owner should review it carefully before merging.**

---

## What & Why

`train_on_responses_only` currently unmasks the labels for **every** assistant turn in a multi-turn conversation. This is useful for general SFT, but there are common fine-tuning scenarios — e.g. training a model to follow a final instruction given a conversation history — where you only want to supervise the **last** assistant response and leave all earlier ones masked.

## Change

A single new parameter `last_response_only=False` is added to `train_on_responses_only`. The default is `False`, so existing behaviour is completely unchanged.

```python
train_on_responses_only(
    trainer,
    instruction_part="<|im_start|>user\n",
    response_part="<|im_start|>assistant\n",
    last_response_only=True,  # only the final assistant turn is trained on
)
```

## Implementation

The inner `_train_on_responses_only` was refactored slightly: instead of immediately writing labels when each `(assistant_start, response_end)` span is found, the loop now **collects all spans first**, then applies labels from either all of them or just `spans[-1:]` depending on the flag. This avoids duplicating the parsing logic.

The refactor is a no-op when `last_response_only=False`.

