### PR TITLE
Fix inf grad_norm on Qwen3.5 at seq_len > 65536 with tighter SDPA guards

### DIFF
--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -511,39 +511,12 @@ TEMPORARY_PATCHES.append(patch_transformers_masks)
 
 
 def patch_sdpa_bool_causal_mask():
-    """Drop materialised bool causal masks before dispatching to SDPA.
+    """Fix unslothai/unsloth#4906: inf grad_norm on Qwen3.5 at seq_len > 65536.
 
-    Fixes unslothai/unsloth#4906 -- inf grad_norm on Qwen3.5 at seq_len > 65536.
-
-    When `patch_transformers_masks` (above) wraps `create_causal_mask` with
-    `torch.compile(dynamic=True)`, HF's `find_packed_sequence_indices` takes
-    the `is_tracing` branch and returns a non-None packed_sequence_mask even
-    for sequential positions. That sets `allow_is_causal_skip=False` inside
-    `create_causal_mask`, so `sdpa_mask` materialises a dense [1, 1, Q, K]
-    bool causal mask instead of returning None.
-
-    On builds that fall through to PyTorch SDPA's memory-efficient (Cutlass)
-    backend -- e.g. head_dim=256 models without flash-attn installed --
-    that backend with bf16 + a dense bool causal mask at seq_len > 65536
-    produces wrong forward outputs AND wrong gradients. The 65536 = 2**16
-    boundary matches a hard Cutlass int16 sequence-index limit.
-
-    Fix: wrap `sdpa_attention_forward` so that when the incoming
-    attention_mask is a plain lower-triangular 4D bool causal mask with
-    Q == K, we discard it and call SDPA with `attention_mask=None,
-    is_causal=True`. SDPA's native causal path does not hit the broken
-    backward kernel and is also faster.
-
-    For non-pure-causal bool masks at long sequence lengths (packed
-    sequences, sliding window), we convert bool -> float additive bias
-    to avoid the Cutlass bool-mask bug while preserving mask semantics.
-
-    Guardrails (all O(1) Python-level checks, no CUDA ops):
-      - module.is_causal must be True (protects BERT/bidirectional).
-      - sliding_window kwarg must be None (protects Gemma2/Mistral).
-      - 4D torch.bool with Q == K == query seq_len (not cross-attn).
-      - Two-cell spot-check: m[0,0,0,1]==False AND m[0,0,-1,0]==True
-        (pure causal vs packed/padded/custom masks).
+    Cutlass SDPA backward (no flash-attn, head_dim=256, bf16) returns garbage
+    gradients when fed a dense bool causal mask at seq_len >= 2**16. Drop pure
+    causal bool masks and call SDPA with is_causal=True; convert non-pure bool
+    masks to float additive bias to dodge the Cutlass bool-mask path.
     """
     if os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1":
         return
@@ -574,8 +547,7 @@ def patch_sdpa_bool_causal_mask():
     ):
         m = attention_mask
 
-        # Resolve is_causal: explicit param takes priority, else module attr.
-        # Non-causal modules (BERT encoder, SigLIP) must keep their masks.
+        # Non-causal modules (BERT, SigLIP) keep their masks; explicit param wins.
         resolved_is_causal = (
             is_causal if is_causal is not None
             else getattr(module, "is_causal", True)
@@ -587,8 +559,7 @@ def patch_sdpa_bool_causal_mask():
                 **kwargs,
             )
 
-        # Sliding-window layers (Gemma2, Mistral, Qwen2/3) must keep their
-        # windowed masks -- do not replace with full causal.
+        # Sliding-window layers (Gemma2, Mistral, Qwen2/3) keep windowed masks.
         if kwargs.get("sliding_window", None) is not None:
             return _orig(
                 module, query, key, value, attention_mask,
@@ -596,7 +567,7 @@ def patch_sdpa_bool_causal_mask():
                 **kwargs,
             )
 
-        # Hybrid models (e.g. Qwen3.5) may pass a dict keyed by layer type.
+        # Hybrid models (Qwen3.5) may pass a dict keyed by layer type.
         if isinstance(m, dict):
             layer_type = getattr(module, "layer_type", None)
             if layer_type not in m:
@@ -607,8 +578,7 @@ def patch_sdpa_bool_causal_mask():
                 )
             m = m[layer_type]
 
-        # Only intercept 4D bool masks where Q == K == query seq_len
-        # (self-attention prefill, not cross-attention or kv-cache decode).
+        # Only intercept 4D bool self-attn masks (not cross-attn or kv-cache decode).
         if not (
             isinstance(m, torch.Tensor)
             and m.dtype == torch.bool
@@ -622,35 +592,27 @@ def patch_sdpa_bool_causal_mask():
                 **kwargs,
             )
 
-        # Spot-check: a pure lower-triangular causal mask has:
-        #   m[0,0,0,1]==False  (first query cannot see second key)
-        #   m[0,0,-1,0]==True  (last query can see first key)
-        # Packed-sequence masks fail the second check because the last
-        # segment's first query cannot see the first segment's first key.
-        # Padded masks may also fail if the first position is masked out.
-        # Two O(1) probes, no CUDA ops.
+        # Pure lower-triangular check via two O(1) probes: upper-tri is False
+        # and last row sees first col. Packed/padded masks fail the second.
         S = m.shape[-1]
         is_pure_causal = (
             (S < 2)
             or (
-                not m[0, 0, 0, 1].item()       # upper triangle is False
-                and m[0, 0, S - 1, 0].item()   # last row sees first col
+                not m[0, 0, 0, 1].item()
+                and m[0, 0, S - 1, 0].item()
             )
         )
 
         if is_pure_causal:
-            # Safe to drop the mask entirely -- native is_causal path avoids
-            # the Cutlass >65536 bug and is faster.
+            # Drop mask, use native is_causal path (avoids Cutlass >65536 bug, faster).
             return _orig(
                 module, query, key, value, None,
                 dropout = dropout, scaling = scaling, is_causal = True,
                 **kwargs,
             )
 
-        # Non-pure-causal bool mask (packed sequences, custom patterns).
-        # Convert bool -> float additive bias to avoid the Cutlass bool-mask
-        # bug while preserving mask semantics. SDPA dispatches to a different
-        # (working) kernel for float attn_mask inputs.
+        # Non-pure bool mask (packed sequences, custom patterns): convert to float
+        # additive bias so SDPA dispatches to the working (non-bool) kernel.
         m_float = torch.where(m, 0.0, torch.finfo(query.dtype).min).to(query.dtype)
         return _orig(
             module, query, key, value, m_float,

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -542,8 +542,8 @@ def patch_sdpa_bool_causal_mask():
       - module.is_causal must be True (protects BERT/bidirectional).
       - sliding_window kwarg must be None (protects Gemma2/Mistral).
       - 4D torch.bool with Q == K == query seq_len (not cross-attn).
-      - Upper-triangle spot-check m[0,0,0,1]==False (pure causal vs
-        packed/custom masks).
+      - Two-cell spot-check: m[0,0,0,1]==False AND m[0,0,-1,0]==True
+        (pure causal vs packed/padded/custom masks).
     """
     if os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1":
         return
@@ -622,11 +622,21 @@ def patch_sdpa_bool_causal_mask():
                 **kwargs,
             )
 
-        # Spot-check: a pure lower-triangular causal mask has m[0,0,0,1]==False
-        # (first query cannot see second key). Packed-sequence masks and other
-        # non-trivial patterns will have True in the upper triangle.
+        # Spot-check: a pure lower-triangular causal mask has:
+        #   m[0,0,0,1]==False  (first query cannot see second key)
+        #   m[0,0,-1,0]==True  (last query can see first key)
+        # Packed-sequence masks fail the second check because the last
+        # segment's first query cannot see the first segment's first key.
+        # Padded masks may also fail if the first position is masked out.
+        # Two O(1) probes, no CUDA ops.
         S = m.shape[-1]
-        is_pure_causal = (S < 2) or (not m[0, 0, 0, 1].item())
+        is_pure_causal = (
+            (S < 2)
+            or (
+                not m[0, 0, 0, 1].item()       # upper triangle is False
+                and m[0, 0, S - 1, 0].item()   # last row sees first col
+            )
+        )
 
         if is_pure_causal:
             # Safe to drop the mask entirely -- native is_causal path avoids

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -510,6 +510,151 @@ pass
 TEMPORARY_PATCHES.append(patch_transformers_masks)
 
 
+def patch_sdpa_bool_causal_mask():
+    """Drop materialised bool causal masks before dispatching to SDPA.
+
+    Fixes unslothai/unsloth#4906 -- inf grad_norm on Qwen3.5 at seq_len > 65536.
+
+    When `patch_transformers_masks` (above) wraps `create_causal_mask` with
+    `torch.compile(dynamic=True)`, HF's `find_packed_sequence_indices` takes
+    the `is_tracing` branch and returns a non-None packed_sequence_mask even
+    for sequential positions. That sets `allow_is_causal_skip=False` inside
+    `create_causal_mask`, so `sdpa_mask` materialises a dense [1, 1, Q, K]
+    bool causal mask instead of returning None.
+
+    On builds that fall through to PyTorch SDPA's memory-efficient (Cutlass)
+    backend -- e.g. head_dim=256 models without flash-attn installed --
+    that backend with bf16 + a dense bool causal mask at seq_len > 65536
+    produces wrong forward outputs AND wrong gradients. The 65536 = 2**16
+    boundary matches a hard Cutlass int16 sequence-index limit.
+
+    Fix: wrap `sdpa_attention_forward` so that when the incoming
+    attention_mask is a plain lower-triangular 4D bool causal mask with
+    Q == K, we discard it and call SDPA with `attention_mask=None,
+    is_causal=True`. SDPA's native causal path does not hit the broken
+    backward kernel and is also faster.
+
+    For non-pure-causal bool masks at long sequence lengths (packed
+    sequences, sliding window), we convert bool -> float additive bias
+    to avoid the Cutlass bool-mask bug while preserving mask semantics.
+
+    Guardrails (all O(1) Python-level checks, no CUDA ops):
+      - module.is_causal must be True (protects BERT/bidirectional).
+      - sliding_window kwarg must be None (protects Gemma2/Mistral).
+      - 4D torch.bool with Q == K == query seq_len (not cross-attn).
+      - Upper-triangle spot-check m[0,0,0,1]==False (pure causal vs
+        packed/custom masks).
+    """
+    if os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1":
+        return
+    try:
+        import transformers.integrations.sdpa_attention as sdpa_mod
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    except Exception as e:
+        return raise_error("transformers.integrations.sdpa_attention", e)
+
+    current = getattr(sdpa_mod, "sdpa_attention_forward", None)
+    if current is None:
+        return
+    if getattr(current, "__unsloth_bool_causal_mask_fix__", False):
+        return  # already installed
+
+    _orig = current
+
+    def sdpa_attention_forward_unsloth(
+        module,
+        query,
+        key,
+        value,
+        attention_mask,
+        dropout = 0.0,
+        scaling = None,
+        is_causal = None,
+        **kwargs,
+    ):
+        m = attention_mask
+
+        # Resolve is_causal: explicit param takes priority, else module attr.
+        # Non-causal modules (BERT encoder, SigLIP) must keep their masks.
+        resolved_is_causal = (
+            is_causal if is_causal is not None
+            else getattr(module, "is_causal", True)
+        )
+        if not resolved_is_causal:
+            return _orig(
+                module, query, key, value, attention_mask,
+                dropout = dropout, scaling = scaling, is_causal = is_causal,
+                **kwargs,
+            )
+
+        # Sliding-window layers (Gemma2, Mistral, Qwen2/3) must keep their
+        # windowed masks -- do not replace with full causal.
+        if kwargs.get("sliding_window", None) is not None:
+            return _orig(
+                module, query, key, value, attention_mask,
+                dropout = dropout, scaling = scaling, is_causal = is_causal,
+                **kwargs,
+            )
+
+        # Hybrid models (e.g. Qwen3.5) may pass a dict keyed by layer type.
+        if isinstance(m, dict):
+            layer_type = getattr(module, "layer_type", None)
+            if layer_type not in m:
+                return _orig(
+                    module, query, key, value, attention_mask,
+                    dropout = dropout, scaling = scaling, is_causal = is_causal,
+                    **kwargs,
+                )
+            m = m[layer_type]
+
+        # Only intercept 4D bool masks where Q == K == query seq_len
+        # (self-attention prefill, not cross-attention or kv-cache decode).
+        if not (
+            isinstance(m, torch.Tensor)
+            and m.dtype == torch.bool
+            and m.dim() == 4
+            and m.shape[-1] == m.shape[-2]
+            and m.shape[-1] == query.shape[2]
+        ):
+            return _orig(
+                module, query, key, value, attention_mask,
+                dropout = dropout, scaling = scaling, is_causal = is_causal,
+                **kwargs,
+            )
+
+        # Spot-check: a pure lower-triangular causal mask has m[0,0,0,1]==False
+        # (first query cannot see second key). Packed-sequence masks and other
+        # non-trivial patterns will have True in the upper triangle.
+        S = m.shape[-1]
+        is_pure_causal = (S < 2) or (not m[0, 0, 0, 1].item())
+
+        if is_pure_causal:
+            # Safe to drop the mask entirely -- native is_causal path avoids
+            # the Cutlass >65536 bug and is faster.
+            return _orig(
+                module, query, key, value, None,
+                dropout = dropout, scaling = scaling, is_causal = True,
+                **kwargs,
+            )
+
+        # Non-pure-causal bool mask (packed sequences, custom patterns).
+        # Convert bool -> float additive bias to avoid the Cutlass bool-mask
+        # bug while preserving mask semantics. SDPA dispatches to a different
+        # (working) kernel for float attn_mask inputs.
+        m_float = torch.where(m, 0.0, torch.finfo(query.dtype).min).to(query.dtype)
+        return _orig(
+            module, query, key, value, m_float,
+            dropout = dropout, scaling = scaling, is_causal = False,
+            **kwargs,
+        )
+
+    sdpa_attention_forward_unsloth.__unsloth_bool_causal_mask_fix__ = True
+    sdpa_mod.sdpa_attention_forward = sdpa_attention_forward_unsloth
+    ALL_ATTENTION_FUNCTIONS["sdpa"] = sdpa_attention_forward_unsloth
+pass
+TEMPORARY_PATCHES.append(patch_sdpa_bool_causal_mask)
+
+
 def patch_modernbert_attention_mask():
     """Fix ModernBERT attn_bias stride alignment for SDPA backward pass.
 


### PR DESCRIPTION
## Summary
- Fixes #4906: LoRA training of Qwen3.5-4B/9B produces `grad_norm=inf` at `seq_len > 65536` when flash-attn is not installed
- Wraps `sdpa_attention_forward` to detect materialized bool causal masks and replace with `attention_mask=None, is_causal=True`
- Includes tighter guards than #582 to protect sliding-window, bidirectional, and packed-sequence masks
- Adds bool-to-float fallback for non-pure-causal masks to avoid the Cutlass bug while preserving mask semantics

## Root cause
`patch_transformers_masks` wraps `create_causal_mask` with `torch.compile(dynamic=True)`. Under tracing, `find_packed_sequence_indices` takes the `is_tracing` branch, forcing `allow_is_causal_skip=False`. This materializes a dense `[1,1,Q,K]` bool causal mask. PyTorch SDPA's Cutlass backend with bf16 + bool mask at `seq_len > 65536` produces wrong outputs/gradients (int16 sequence-index overflow at 2^16).

## Guards (all O(1), no CUDA ops)
1. `module.is_causal` check -- protects BERT/bidirectional encoders
2. `sliding_window` kwarg check -- protects Gemma2/Mistral/Qwen2/3
3. Dict-mask unwrap with safe fallback when `layer_type` not in dict
4. 4D bool + square + Q==K shape check -- not cross-attention or kv-cache decode
5. Upper-triangle spot-check `m[0,0,0,1]==False` -- distinguishes pure causal from packed-sequence masks
6. Bool-to-float additive bias fallback for non-pure-causal masks -- avoids Cutlass bug while preserving mask semantics

## Test results (NVIDIA B200, torch 2.9.1, transformers 5.5.1, no flash-attn)

**Qwen3.5-4B at seq_len=69632, 4-bit LoRA, 9 steps:**

| Method | Time | Peak Mem | Grad Norms [1st, 5th, 9th] |
|--------|------|----------|---------------------------|
| Without fix | 3649s | 74.27 GB | [inf, nan, nan] |
| With this fix | 2765s | 74.27 GB | [3.319, 3.219, 1.057] |

**Llama-3.2-1B regression at seq_len=2048, 21 steps:**
- Max loss delta vs baseline: 0.003
- Max grad_norm delta vs baseline: 0.06
- No regression

## Test plan
- [x] Reproduce `grad_norm=inf` at seq_len=69632 without fix
- [x] Verify finite grad_norms with fix at seq_len=69632
- [x] Llama short-context regression (max loss delta < 0.01)
- [ ] Sliding-window model test (Gemma2/Mistral)
- [ ] Packed-sequence training test