### PR TITLE
Use torch.Tensor.reshape for non-contiguous tensor in ce loss function

### DIFF
--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -118,8 +118,8 @@ def compute_fused_ce_loss(
     # Calculate cross entropy loss
     reduction = "sum" if n_items is not None else "mean"
     loss = torch.nn.functional.cross_entropy(
-        input  = logits.view(-1, vocab_size).float().contiguous(),
-        target = labels.view(-1).to(device).contiguous(),
+        input  = logits.reshape(-1, vocab_size).float().contiguous(),
+        target = labels.reshape(-1).to(device).contiguous(),
         reduction = reduction,
     )
     loss = loss / n_items if n_items is not None else loss
@@ -199,7 +199,7 @@ class UnslothFusedLoss(torch.autograd.Function):
                 _labels[..., :-1][mask[..., 1:] == 0] = -100
             pass
             _labels[..., -1] = -100
-            _labels = _labels.view(-1)
+            _labels = _labels.reshape(-1)
             labels = _labels
         pass
 
@@ -228,8 +228,8 @@ class UnslothFusedLoss(torch.autograd.Function):
         if UNSLOTH_ENABLE_LOGGING:
             logger.info(f"Fused CE Loss [bsz={bsz}][qlen={qlen}][vocab_size={vocab_size}][n_chunks={n_chunks}]")
         __shift_labels = torch.chunk(labels,                     n_chunks, dim = 0)
-        __shift_states = torch.chunk(hidden_states.view(-1, hd), n_chunks, dim = 0)
-        __grad_inputs  = torch.chunk(grad_inputs.view(-1, hd),   n_chunks, dim = 0)
+        __shift_states = torch.chunk(hidden_states.reshape(-1, hd), n_chunks, dim = 0)
+        __grad_inputs  = torch.chunk(grad_inputs.reshape(-1, hd),   n_chunks, dim = 0)
 
         def accumulate_chunk(
             n_chunks,

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -118,8 +118,8 @@ def compute_fused_ce_loss(
     # Calculate cross entropy loss
     reduction = "sum" if n_items is not None else "mean"
     loss = torch.nn.functional.cross_entropy(
-        input  = logits.reshape(-1, vocab_size).float().contiguous(),
-        target = labels.reshape(-1).to(device).contiguous(),
+        input  = logits.view(-1, vocab_size).float().contiguous(),
+        target = labels.view(-1).to(device).contiguous(),
         reduction = reduction,
     )
     loss = loss / n_items if n_items is not None else loss
@@ -199,7 +199,7 @@ class UnslothFusedLoss(torch.autograd.Function):
                 _labels[..., :-1][mask[..., 1:] == 0] = -100
             pass
             _labels[..., -1] = -100
-            _labels = _labels.reshape(-1)
+            _labels = _labels.view(-1)
             labels = _labels
         pass
 
@@ -229,7 +229,7 @@ class UnslothFusedLoss(torch.autograd.Function):
             logger.info(f"Fused CE Loss [bsz={bsz}][qlen={qlen}][vocab_size={vocab_size}][n_chunks={n_chunks}]")
         __shift_labels = torch.chunk(labels,                     n_chunks, dim = 0)
         __shift_states = torch.chunk(hidden_states.reshape(-1, hd), n_chunks, dim = 0)
-        __grad_inputs  = torch.chunk(grad_inputs.reshape(-1, hd),   n_chunks, dim = 0)
+        __grad_inputs  = torch.chunk(grad_inputs.view(-1, hd),   n_chunks, dim = 0)
 
         def accumulate_chunk(
             n_chunks,


### PR DESCRIPTION
**Description:**

**Problem:**
When a user provides a value for the `logits_to_keep` parameter in the `forward` function, the hidden state is sliced (`hidden_states[:, slice_indices, :]`), resulting in a **non-contiguous tensor**. Calling `torch.Tensor.view()` on this non-contiguous tensor raises the following `RuntimeError`:

```python
File ".../unsloth_zoo/fused_losses/cross_entropy_loss.py", line 231, in forward
    __shift_states = torch.chunk(hidden_states.view(-1, hd), n_chunks, dim = 0)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```

**Solution:**
Updated 5 instances of `torch.Tensor.view()` to `torch.Tensor.reshape()` in `unsloth_zoo/fused_losses/cross_entropy_loss.py`. Because `.reshape()` automatically handles non-contiguous memory, this prevents the crash while maintaining the same expected behavior. 

Please have a look. Thank you! :)