### PR TITLE
Fix logit softcapping calculation in rl_replacements.py

### DIFF
--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -94,7 +94,7 @@ def chunked_hidden_states_selective_log_softmax(
         if logit_scale_divide != 0.0:
             chunk_logits = chunk_logits / logit_scale_divide
         if logit_softcapping != 0.0:
-            chunk_logits = chunk_logits * torch.tanh(chunk_logits / logit_softcapping)
+            chunk_logits = logit_softcapping * torch.tanh(chunk_logits / logit_softcapping)
 
         chunk_logits = chunk_logits.to(torch.float32)
 


### PR DESCRIPTION
## Problem

The softcap in [`chunked_hidden_states_selective_log_softmax`](https://github.com/unslothai/unsloth-zoo/blob/4b2b1708cf5b2a7198c070deb89ff4adba3eedfd/unsloth_zoo/rl_replacements.py#L97) is:

```python
chunk_logits = chunk_logits * torch.tanh(chunk_logits / logit_softcapping)
```

That multiplies logits by `tanh(logits / softcap)`. The correct Gemma softcap (what transformers does, and what the fused CE loss [right here](https://github.com/unslothai/unsloth-zoo/blob/4b2b1708cf5b2a7198c070deb89ff4adba3eedfd/unsloth_zoo/fused_losses/cross_entropy_loss.py#L113-L116) already does) is:

```python
softcap * tanh(logit / softcap)
```

With the buggy formula, once `|logit|` is bigger than about 2x softcap, `tanh` saturates to 1 and the result is just `logit`, so the cap does nothing.

## Impact

Affects GRPO, DPO, ORPO, KTO, RLOO, OnlineDPO on any model with `final_logit_softcapping` set, so Gemma 2, Gemma 3, Gemma 4. SFT is fine (uses the fused CE loss with the correct formula).

On `unsloth/gemma-4-E2B-it` the lm_head logits go up to ~124 and softcap is 30. Before the fix, min logprob on a completion was -125. After the fix, -31. Step 1 KL in GRPO drops from ~0.24 to ~1e-5 (matching what you'd expect when LoRA B is zero and ref should equal new).

## Fix

One line. `logit_softcapping * torch.tanh(...)` instead of `chunk_logits * torch.tanh(...)`.
