### PR TITLE
Skip classification heads during 4-bit quantization (#5027)

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -42,6 +42,9 @@ SKIP_QUANTIZATION_MODULES = [
     'mamba',
     "audio_tower",              # Gemma3N audio encoder conformer
     "vision_tower",             # Gemma3 vision encoder (SigLIP)
+    "score",                    # *ForSequenceClassification head
+    "classifier",               # *ForTokenClassification, *ForImageClassification, BERT-family head
+    "qa_outputs",               # *ForQuestionAnswering head
 ]
 
 def get_peft_regex(


### PR DESCRIPTION
## Summary

Fixes [unslothai/unsloth#5027](https://github.com/unslothai/unsloth/issues/5027): `FastLanguageModel.from_pretrained(..., num_labels=N)` crashes with `NotImplementedError: "normal_kernel_cuda" not implemented for 'Byte'` on pre-quantized bnb 4-bit checkpoints (for example `unsloth/Qwen3-4B-bnb-4bit`) when running on `transformers>=5.0`.

Root cause: the freshly added classification head (`score` for `*ForSequenceClassification`, `classifier` for BERT-family / token / image classification, `qa_outputs` for QA) is converted to `bitsandbytes.nn.Linear4bit` by `replace_with_bnb_linear`. Its weight is then uint8 storage. Transformers' missing-key flow calls `self.initialize_weights()` which runs `torch.nn.init.normal_(module.weight, ...)` on every module not yet marked initialized, and `normal_` is not implemented for the `Byte` dtype.

This mirrors the existing `lm_head` handling. `unsloth._utils._RaiseUninitialized` already whitelists `score.weight` and `classifier.weight` as expected newly initialized parameters, so the intent is already documented on the Unsloth side; this commit makes `replace_with_bnb_linear` leave these heads in the compute dtype.

## Changes

Add three entries to `SKIP_QUANTIZATION_MODULES` in `unsloth_zoo/peft_utils.py`:

- `score` for `*ForSequenceClassification`
- `classifier` for `*ForTokenClassification`, `*ForImageClassification`, BERT-family heads
- `qa_outputs` for `*ForQuestionAnswering`

Note: this PR on its own is necessary but not sufficient for pre-quantized checkpoints on transformers 5.x, because transformers reads `llm_int8_skip_modules` from the checkpoint's baked-in `config.json`, not from the runtime `BitsAndBytesConfig` that Unsloth passes via kwargs. A companion PR to `unslothai/unsloth` merges this skip list into `model_config.quantization_config.llm_int8_skip_modules` before `from_pretrained` so the checkpoint-bundled list is respected.

## Test plan

- [x] Repro on `transformers==5.5.0`: load `unsloth/Qwen3-4B-bnb-4bit` with `num_labels=3`, no `NotImplementedError`, `model.score` is `nn.Linear` in `bfloat16` (not `Linear4bit`)
- [x] Same for `unsloth/Qwen3-4B` (non-bnb repo, `load_in_4bit=True`) and `unsloth/Llama-3.2-1B-Instruct`
- [x] 3 SFT steps with `num_labels=3`, gradient reaches `score.weight`, weight updates between steps
- [x] Causal LM path unchanged: backbone still contains `Linear4bit`, `lm_head` stays `nn.Linear` in `bfloat16`
- [x] Trimmed `notebooks/nb/bert_classification.ipynb` (ModernBERT + `classifier` head, 3 steps): loss decreases
- [x] Skip-list collision check: no accidental matches inside Qwen3 or Llama backbones
- [x] Full test suite green on both `transformers==4.57.6` and `transformers==5.5.0`