### PR TITLE
Skip patch_sdpa_bool_causal_mask below 65536 seq_len to fix Gemma4 VRAM regression

### DIFF
--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -513,10 +513,11 @@ TEMPORARY_PATCHES.append(patch_transformers_masks)
 def patch_sdpa_bool_causal_mask():
     """Fix unslothai/unsloth#4906: inf grad_norm on Qwen3.5 at seq_len > 65536.
 
-    Cutlass SDPA backward (no flash-attn, head_dim=256, bf16) returns garbage
-    gradients when fed a dense bool causal mask at seq_len >= 2**16. Drop pure
-    causal bool masks and call SDPA with is_causal=True; convert non-pure bool
-    masks to float additive bias to dodge the Cutlass bool-mask path.
+    Upstream bug: pytorch/pytorch#162588. Cutlass SDPA returns garbage
+    gradients on bool causal masks at seq_len >= 2**16 (bf16, head_dim=256,
+    no flash-attn). Drop pure causal bool masks and call with is_causal=True;
+    convert non-pure bool masks to float additive bias. Below 2**16 we skip
+    the wrapper since the bug cannot fire.
     """
     if os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1":
         return
@@ -547,22 +548,12 @@ def patch_sdpa_bool_causal_mask():
     ):
         m = attention_mask
 
-        # Fast path: below the Cutlass 2**16 sequence index overflow, the
-        # original SDPA bool mask path is correct and cheaper than what this
-        # patch would otherwise do. Drop out of the wrapper entirely so
-        # short / medium context training does not pay any cost.
-        #
-        # Even the pure causal rewrite (attention_mask=None, is_causal=True)
-        # can pick a different SDPA backend than the bool mask path and
-        # increase reserved VRAM. On Gemma4-31B LoRA SFT at seq_len up to
-        # 8192, the wrapper adds about 2.5 GB of reserved VRAM vs the
-        # original code. Gate on both the query seq_len and, if present, the
-        # mask's last dim so both self attention and cross attention clear
-        # the check.
+        # Below 2**16 the Cutlass bool-mask overflow cannot fire
+        # (pytorch/pytorch#162588), so skip the wrapper. The pure-causal
+        # rewrite picks a heavier SDPA backend and costs ~2.5 GB on
+        # Gemma4-31B LoRA SFT (8192 seq_len).
         _q_len = query.shape[2] if query.dim() >= 3 else 0
-        _mask_key_len = (
-            m.shape[-1] if isinstance(m, torch.Tensor) and m.dim() >= 1 else 0
-        )
+        _mask_key_len = m.shape[-1] if isinstance(m, torch.Tensor) and m.dim() >= 1 else 0
         if _q_len < 65536 and _mask_key_len < 65536:
             return _orig(
                 module, query, key, value, attention_mask,

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -547,6 +547,29 @@ def patch_sdpa_bool_causal_mask():
     ):
         m = attention_mask
 
+        # Fast path: below the Cutlass 2**16 sequence index overflow, the
+        # original SDPA bool mask path is correct and cheaper than what this
+        # patch would otherwise do. Drop out of the wrapper entirely so
+        # short / medium context training does not pay any cost.
+        #
+        # Even the pure causal rewrite (attention_mask=None, is_causal=True)
+        # can pick a different SDPA backend than the bool mask path and
+        # increase reserved VRAM. On Gemma4-31B LoRA SFT at seq_len up to
+        # 8192, the wrapper adds about 2.5 GB of reserved VRAM vs the
+        # original code. Gate on both the query seq_len and, if present, the
+        # mask's last dim so both self attention and cross attention clear
+        # the check.
+        _q_len = query.shape[2] if query.dim() >= 3 else 0
+        _mask_key_len = (
+            m.shape[-1] if isinstance(m, torch.Tensor) and m.dim() >= 1 else 0
+        )
+        if _q_len < 65536 and _mask_key_len < 65536:
+            return _orig(
+                module, query, key, value, attention_mask,
+                dropout = dropout, scaling = scaling, is_causal = is_causal,
+                **kwargs,
+            )
+
         # Non-causal modules (BERT, SigLIP) keep their masks; explicit param wins.
         resolved_is_causal = (
             is_causal if is_causal is not None


### PR DESCRIPTION
## Summary

- Early exit from `patch_sdpa_bool_causal_mask`'s wrapper when both query seq_len and mask key length are below 2**16, so short / medium context training bypasses the workaround entirely
- Keeps the Qwen3.5 long context fix (unslothai/unsloth#4906, PR #587) in place for seq_len >= 65536
- Recovers 2.55 GB of reserved VRAM on Gemma4-31B LoRA SFT, restoring pre 2026.4.7 memory with no loss or grad norm changes

## Root cause

PR #587 installed a wrapper around `transformers.integrations.sdpa_attention.sdpa_attention_forward` that:

1. For pure causal bool masks, drops the mask and calls SDPA with `is_causal=True`
2. For non pure causal bool masks (packed sequences, label masking like `train_on_responses_only`), converts the bool mask to a `[B, H, S, S]` float additive bias via `torch.where`

Both transformations are necessary at seq_len >= 2**16 to avoid the Cutlass SDPA int16 sequence index overflow (pytorch/pytorch#162588, still open). At smaller seq_len they are not needed:

- The bool mask path through SDPA is correct
- Rewriting pure causal to `attention_mask=None, is_causal=True` can pick a different SDPA backend than the bool mask path and, on recent torch builds, actually increases reserved VRAM
- The `torch.where` float conversion allocates an `[B, H, S, S]` tensor per attention layer per forward that autograd holds live through backward

Across a Gemma4-31B LoRA SFT run these effects combine to add roughly 2.5 GB of reserved VRAM.

## Measurements

Hardware: 1x NVIDIA B200 (180 GB), torch 2.9.1+cu128, transformers 5.5.0, Gemma4-31B LoRA SFT, FineTome-100k 3000 rows, `per_device_train_batch_size=1, gradient_accumulation_steps=4, max_seq_length=8192, max_steps=60, seed=3407`, adamw_8bit, `train_on_responses_only`.

Phase 8 (trainer.train 60 steps):

| Config | peak_alloc GB | peak_reserved GB | total wall s |
|---|---:|---:|---:|
| unsloth 2026.4.4 + zoo 2026.4.6 (prev pypi) | 19.53 | 25.01 | 533.6 |
| unsloth 2026.4.5 + zoo 2026.4.7 (current pypi) | 19.83 | 27.56 | 566.8 |
| unsloth 2026.4.5 + zoo 2026.4.7 + this PR | 19.53 | 25.01 | 527.5 |

Training trajectory (this PR):

- Losses first 5: `[2.128, 0.626, 0.914, 1.588, 1.240]`
- Losses last 5:  `[0.925, 0.448, 0.759, 0.852, 0.749]`
- final `train_loss = 0.8154` (prev pypi: 0.8255; current pypi: 0.8205)
- Grad norms first 5: `[0.872, 0.399, 0.625, 1.176, 1.109]`
- Grad norms last 5:  `[0.420, 0.555, 0.417, 0.310, 0.506]`
- LoRA adapter_model.safetensors: 233.63 MB (identical across all three runs)

## Test plan

- [x] Bisected the regression to unsloth_zoo pypi 2026.4.6 -> 2026.4.7 (unsloth 2026.4.4 vs 2026.4.5 with the same zoo is a no op, zoo alone changes Phase 8 reserved from 25.01 GB to 27.56 GB)
- [x] Confirmed the source is `patch_sdpa_bool_causal_mask` via an env var gated early return: disabling the patch entirely recovered 25.01 GB exactly
- [x] Confirmed Gemma4-31B LoRA SFT 60 steps with this fix matches prev pypi peak / reserved / loss / grad norms
- [ ] Qwen3.5-4B / 9B at seq_len = 69632 regression check (still expected to apply the fallback because query seq_len >= 65536 bypasses the early exit)
- [ ] Sliding window model regression check (Gemma2 / Mistral / Qwen2, 3)

## Upstream

The underlying pytorch bug that this patch works around is still open: pytorch/pytorch#162588. Related: pytorch/pytorch#142228, pytorch/pytorch#180445. Until pytorch fixes the kernel, the wrapper is load bearing for long context Qwen3.5 training, but should not fire for everyone else.