### PR TITLE
fix(cpu): return "cpu" from get_device_type() instead of raising when no GPU found

### DIFF
--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -248,7 +248,7 @@ else:
 IS_HIP_RUNTIME = (DEVICE_TYPE == "hip") or bool(is_hip())
 
 # Torch >= 2.9 uses PYTORCH_ALLOC_CONF and treats legacy per-backend vars as deprecated.
-if _HAS_TORCH and IS_TORCH_2_9_OR_NEWER:
+if IS_TORCH_2_9_OR_NEWER:
     # Preserve explicit legacy allocator settings when user did not directly set PYTORCH_ALLOC_CONF.
     if not _HAS_ORIGINAL_PYTORCH_ALLOC_CONF:
         promoted = _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -263,7 +263,7 @@ if IS_TORCH_2_9_OR_NEWER:
     delete_key("PYTORCH_HIP_ALLOC_CONF")
 
 # Specify PYTORCH_CUDA_ALLOC_CONF or PYTORCH_HIP_ALLOC_CONF
-if _HAS_TORCH and IS_HIP_RUNTIME:
+if IS_HIP_RUNTIME:
     if IS_TORCH_2_9_OR_NEWER:
         # PyTorch >= 2.9 uses PYTORCH_ALLOC_CONF. expandable_segments is unsupported on HIP.
         remove_expandable_segments("PYTORCH_ALLOC_CONF")

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -102,11 +102,6 @@ _NO_TORCH_MODE = os.environ.get("UNSLOTH_NO_TORCH", "0").strip().lower() in (
 if (not _HAS_TORCH) and (not _NO_TORCH_MODE):
     _NO_TORCH_MODE = True
     os.environ["UNSLOTH_NO_TORCH"] = "1"
-if (not _HAS_TORCH) and _NO_TORCH_MODE:
-    warnings.warn(
-        "Unsloth: running in no-torch mode. Training and non-GGUF inference features are disabled.",
-        stacklevel = 2,
-    )
 
 # Keep original allocator settings to preserve explicit user config precedence.
 if _HAS_TORCH:
@@ -251,10 +246,9 @@ if _HAS_TORCH:
 else:
     def is_hip():
         return False
-    pass
+
     def get_device_type():
         return "cpu"
-    pass
     DEVICE_TYPE = "cpu"
     DEVICE_TYPE_TORCH = "cpu"
     DEVICE_COUNT = 1
@@ -329,7 +323,6 @@ else:
         raise ImportError(
             "Unsloth: encode_conversations_with_harmony requires torch. Install torch to enable this feature."
         )
-    pass
 from .rl_environments import (
     check_python_modules,
     create_locked_down_function,

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -92,26 +92,50 @@ if (os.environ.get("UNSLOTH_COMPILE_DEBUG", "0") == "1"):
 from importlib.util import find_spec
 if find_spec("unsloth") is None:
     raise ImportError("Please install Unsloth via `pip install unsloth`!")
-if find_spec("torch") is None:
+_HAS_TORCH = find_spec("torch") is not None
+_NO_TORCH_MODE = os.environ.get("UNSLOTH_NO_TORCH", "0").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+if (not _HAS_TORCH) and (not _NO_TORCH_MODE):
     raise ImportError(
         "Unsloth: Pytorch is not installed. Go to https://pytorch.org/.\n"\
         "We also have some installation instructions on our Github page."
     )
+if (not _HAS_TORCH) and _NO_TORCH_MODE:
+    warnings.warn(
+        "Unsloth: running in no-torch mode. Training and non-GGUF inference features are disabled.",
+        stacklevel = 2,
+    )
 
 # Keep original allocator settings to preserve explicit user config precedence.
-_ORIGINAL_PYTORCH_CUDA_ALLOC_CONF = os.environ.get("PYTORCH_CUDA_ALLOC_CONF")
-_ORIGINAL_PYTORCH_HIP_ALLOC_CONF = os.environ.get("PYTORCH_HIP_ALLOC_CONF")
-_HAS_ORIGINAL_PYTORCH_ALLOC_CONF = "PYTORCH_ALLOC_CONF" in os.environ
+if _HAS_TORCH:
+    _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF = os.environ.get("PYTORCH_CUDA_ALLOC_CONF")
+    _ORIGINAL_PYTORCH_HIP_ALLOC_CONF = os.environ.get("PYTORCH_HIP_ALLOC_CONF")
+    _HAS_ORIGINAL_PYTORCH_ALLOC_CONF = "PYTORCH_ALLOC_CONF" in os.environ
+else:
+    _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF = None
+    _ORIGINAL_PYTORCH_HIP_ALLOC_CONF = None
+    _HAS_ORIGINAL_PYTORCH_ALLOC_CONF = False
 
 # We support Pytorch 2
 # Fixes https://github.com/unslothai/unsloth/issues/38
 from importlib.metadata import version as importlib_version
-torch_version_raw = str(importlib_version("torch"))
-torch_version = str(re.match(r"[0-9\.]{3,}", torch_version_raw).group(0)).split(".")
-major_torch, minor_torch = torch_version[0], torch_version[1]
-major_torch, minor_torch = int(major_torch), int(minor_torch)
-IS_TORCH_2_9_OR_NEWER = (major_torch > 2) or (major_torch == 2 and minor_torch >= 9)
-IS_TORCH_ROCM_BUILD = "+rocm" in torch_version_raw.lower()
+if _HAS_TORCH:
+    torch_version_raw = str(importlib_version("torch"))
+    torch_version = str(re.match(r"[0-9\.]{3,}", torch_version_raw).group(0)).split(".")
+    major_torch, minor_torch = torch_version[0], torch_version[1]
+    major_torch, minor_torch = int(major_torch), int(minor_torch)
+    IS_TORCH_2_9_OR_NEWER = (major_torch > 2) or (major_torch == 2 and minor_torch >= 9)
+    IS_TORCH_ROCM_BUILD = "+rocm" in torch_version_raw.lower()
+else:
+    torch_version_raw = ""
+    torch_version = ["0", "0"]
+    major_torch, minor_torch = 0, 0
+    IS_TORCH_2_9_OR_NEWER = False
+    IS_TORCH_ROCM_BUILD = False
 
 # Reduce VRAM usage by reducing fragmentation
 # And optimize pinning of memory
@@ -175,20 +199,20 @@ def clean_expandable_segments_value(value):
     return ",".join(parts) if len(parts) else None
 
 
-if (major_torch < 2):
+if _HAS_TORCH and (major_torch < 2):
     raise ImportError("Unsloth only supports Pytorch 2 for now. Please update your Pytorch to 2.1.\n"\
                       "We have some installation instructions on our Github page.")
-elif (major_torch == 2) and (minor_torch < 2):
+elif _HAS_TORCH and (major_torch == 2) and (minor_torch < 2):
     # Disable expandable_segments
     delete_key("PYTORCH_CUDA_ALLOC_CONF")
     delete_key("PYTORCH_HIP_ALLOC_CONF")
     delete_key("PYTORCH_ALLOC_CONF")
-elif bool(os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP")):
+elif _HAS_TORCH and bool(os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP")):
     # Expandable segments does NOT work on WSL
     delete_key("PYTORCH_CUDA_ALLOC_CONF")
     delete_key("PYTORCH_HIP_ALLOC_CONF")
     delete_key("PYTORCH_ALLOC_CONF")
-elif os.name == 'nt':
+elif _HAS_TORCH and os.name == 'nt':
     # Expandable segments does NOT work on Windows
     delete_key("PYTORCH_CUDA_ALLOC_CONF")
     delete_key("PYTORCH_HIP_ALLOC_CONF")
@@ -196,7 +220,7 @@ elif os.name == 'nt':
 
 # IMPORTANT: run ROCm cleanup before importing device_type (which imports torch).
 # HIP allocator settings can be read during torch initialization.
-if IS_TORCH_ROCM_BUILD:
+if _HAS_TORCH and IS_TORCH_ROCM_BUILD:
     remove_expandable_segments("PYTORCH_CUDA_ALLOC_CONF")
     remove_expandable_segments("PYTORCH_HIP_ALLOC_CONF")
     remove_expandable_segments("PYTORCH_ALLOC_CONF")
@@ -217,18 +241,30 @@ torchao_logger.addFilter(HideLoggingMessage("Skipping import"))
 del logging, torchao_logger, HideLoggingMessage
 
 # Get device types and other variables
-from .device_type import (
-    is_hip,
-    get_device_type,
-    DEVICE_TYPE,
-    DEVICE_TYPE_TORCH,
-    DEVICE_COUNT,
-    ALLOW_PREQUANTIZED_MODELS,
-)
+if _HAS_TORCH:
+    from .device_type import (
+        is_hip,
+        get_device_type,
+        DEVICE_TYPE,
+        DEVICE_TYPE_TORCH,
+        DEVICE_COUNT,
+        ALLOW_PREQUANTIZED_MODELS,
+    )
+else:
+    def is_hip():
+        return False
+    pass
+    def get_device_type():
+        return "cpu"
+    pass
+    DEVICE_TYPE = "cpu"
+    DEVICE_TYPE_TORCH = "cpu"
+    DEVICE_COUNT = 1
+    ALLOW_PREQUANTIZED_MODELS = False
 IS_HIP_RUNTIME = (DEVICE_TYPE == "hip") or bool(is_hip())
 
 # Torch >= 2.9 uses PYTORCH_ALLOC_CONF and treats legacy per-backend vars as deprecated.
-if IS_TORCH_2_9_OR_NEWER:
+if _HAS_TORCH and IS_TORCH_2_9_OR_NEWER:
     # Preserve explicit legacy allocator settings when user did not directly set PYTORCH_ALLOC_CONF.
     if not _HAS_ORIGINAL_PYTORCH_ALLOC_CONF:
         promoted = _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF
@@ -243,7 +279,7 @@ if IS_TORCH_2_9_OR_NEWER:
     delete_key("PYTORCH_HIP_ALLOC_CONF")
 
 # Specify PYTORCH_CUDA_ALLOC_CONF or PYTORCH_HIP_ALLOC_CONF
-if IS_HIP_RUNTIME:
+if _HAS_TORCH and IS_HIP_RUNTIME:
     if IS_TORCH_2_9_OR_NEWER:
         # PyTorch >= 2.9 uses PYTORCH_ALLOC_CONF. expandable_segments is unsupported on HIP.
         remove_expandable_segments("PYTORCH_ALLOC_CONF")
@@ -260,13 +296,13 @@ if IS_HIP_RUNTIME:
         remove_expandable_segments("PYTORCH_HIP_ALLOC_CONF")
         remove_expandable_segments("PYTORCH_ALLOC_CONF")
         delete_key("PYTORCH_CUDA_ALLOC_CONF")
-elif DEVICE_TYPE == "cuda" and not IS_HIP_RUNTIME and not IS_TORCH_2_9_OR_NEWER:
+elif _HAS_TORCH and DEVICE_TYPE == "cuda" and not IS_HIP_RUNTIME and not IS_TORCH_2_9_OR_NEWER:
     delete_key("PYTORCH_HIP_ALLOC_CONF")
     delete_key("PYTORCH_ALLOC_CONF")
 
 # CCE fails on Torch 2.8 and above
 # OutOfResources: out of resource: shared memory, Required: 98304, Hardware limit: 65536. Reducing block sizes or `num_stages`
-if (major_torch >= 2 and minor_torch >= 8) or (major_torch > 2):
+if _HAS_TORCH and ((major_torch >= 2 and minor_torch >= 8) or (major_torch > 2)):
     os.environ["UNSLOTH_ENABLE_CCE"] = "0"
 elif DEVICE_TYPE == "hip":
     # CCE also fails in HIP / AMD
@@ -286,9 +322,16 @@ except:
 # Log Unsloth-Zoo Utilities
 os.environ["UNSLOTH_ZOO_IS_PRESENT"] = "1"
 
-from .temporary_patches import (
-    encode_conversations_with_harmony,
-)
+if _HAS_TORCH:
+    from .temporary_patches import (
+        encode_conversations_with_harmony,
+    )
+else:
+    def encode_conversations_with_harmony(*args, **kwargs):
+        raise ImportError(
+            "Unsloth: encode_conversations_with_harmony requires torch. Install torch to enable this feature."
+        )
+    pass
 from .rl_environments import (
     check_python_modules,
     create_locked_down_function,
@@ -310,4 +353,5 @@ try:
 except:
     pass
 
+del _HAS_TORCH, _NO_TORCH_MODE
 del os, warnings, re

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -93,14 +93,6 @@ from importlib.util import find_spec
 if find_spec("unsloth") is None:
     raise ImportError("Please install Unsloth via `pip install unsloth`!")
 _HAS_TORCH = find_spec("torch") is not None
-_NO_TORCH_MODE = os.environ.get("UNSLOTH_NO_TORCH", "0").strip().lower() in (
-    "1",
-    "true",
-    "yes",
-    "on",
-)
-if not _HAS_TORCH:
-    _NO_TORCH_MODE = True
 
 # Keep original allocator settings to preserve explicit user config precedence.
 if _HAS_TORCH:
@@ -344,5 +336,5 @@ try:
 except:
     pass
 
-del _HAS_TORCH, _NO_TORCH_MODE
+del _HAS_TORCH
 del os, warnings, re

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -99,9 +99,8 @@ _NO_TORCH_MODE = os.environ.get("UNSLOTH_NO_TORCH", "0").strip().lower() in (
     "yes",
     "on",
 )
-if (not _HAS_TORCH) and (not _NO_TORCH_MODE):
+if not _HAS_TORCH:
     _NO_TORCH_MODE = True
-    os.environ["UNSLOTH_NO_TORCH"] = "1"
 
 # Keep original allocator settings to preserve explicit user config precedence.
 if _HAS_TORCH:

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -100,10 +100,8 @@ _NO_TORCH_MODE = os.environ.get("UNSLOTH_NO_TORCH", "0").strip().lower() in (
     "on",
 )
 if (not _HAS_TORCH) and (not _NO_TORCH_MODE):
-    raise ImportError(
-        "Unsloth: Pytorch is not installed. Go to https://pytorch.org/.\n"\
-        "We also have some installation instructions on our Github page."
-    )
+    _NO_TORCH_MODE = True
+    os.environ["UNSLOTH_NO_TORCH"] = "1"
 if (not _HAS_TORCH) and _NO_TORCH_MODE:
     warnings.warn(
         "Unsloth: running in no-torch mode. Training and non-GGUF inference features are disabled.",

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -249,6 +249,7 @@ else:
 
     def get_device_type():
         return "cpu"
+
     DEVICE_TYPE = "cpu"
     DEVICE_TYPE_TORCH = "cpu"
     DEVICE_COUNT = 1

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -215,7 +215,7 @@ def get_device_type():
             amd_hint = _amd_installation_hint()
             if amd_hint is not None:
                 raise NotImplementedError(amd_hint)
-            raise NotImplementedError("Unsloth cannot find any torch accelerator? You need a GPU.")
+            return "cpu"
         accelerator = str(torch.accelerator.current_accelerator())
         if accelerator in ("cuda", "xpu", "hip"):
             raise RuntimeError(
@@ -226,7 +226,7 @@ def get_device_type():
     amd_hint = _amd_installation_hint()
     if amd_hint is not None:
         raise NotImplementedError(amd_hint)
-    raise NotImplementedError("Unsloth currently only works on NVIDIA, AMD and Intel GPUs.")
+    return "cpu"
 pass
 DEVICE_TYPE : str = get_device_type()
 # HIP fails for autocast and other torch functions. Use CUDA instead

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1137,8 +1137,11 @@ from ..device_type import DEVICE_TYPE
 
 if DEVICE_TYPE == "xpu":
     device_memory = torch.xpu.memory.mem_get_info(0)[-1]
-else:
+elif DEVICE_TYPE in ("cuda", "hip") and hasattr(torch, "cuda") and torch.cuda.is_available():
     device_memory = torch.cuda.memory.mem_get_info(0)[-1]
+else:
+    # CPU-only and no-accelerator builds should not query CUDA memory.
+    device_memory = 0
 use_combo_kernels = False if device_memory/1024/1024/1024 <= 40 else True
 fused_torch_compile_options = get_torch_compile_options(
     epilogue_fusion = True,

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -232,7 +232,7 @@ def _check_grouped_gemm_available():
         from unsloth.kernels.moe.grouped_gemm.interface import grouped_gemm, supports_tma
         _GROUPED_GEMM_AVAILABLE = True
         _init_triton_allocator()
-    except (ImportError, ModuleNotFoundError):
+    except Exception:
         _GROUPED_GEMM_AVAILABLE = False
     return _GROUPED_GEMM_AVAILABLE
 


### PR DESCRIPTION
Companion branch: https://github.com/LeoBorcherding/unsloth/tree/fix/cpu-no-torch-import
Companion issue: unslothai/unsloth#5008

## Changes
- `device_type.py`: return `"cpu"` instead of raising `NotImplementedError` when no GPU accelerator found
- `__init__.py`: gate all torch-dependent imports and allocator config behind `_HAS_TORCH`, add CPU stubs for device type functions
- `temporary_patches/gpt_oss.py`: guard CUDA memory query behind device type check to avoid crash on CPU

## Validation
Validated in LeoBorcherding/unsloth@fix/cpu-no-torch-import. Full validation log posted in [unsloth/pull/5119](https://github.com/unslothai/unsloth/pull/5119).