### PR TITLE
Fix swapped first/second weight in Qwen MoE LoRA extractor

### DIFF
--- a/unsloth_zoo/temporary_patches/qwen3_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe.py
@@ -75,15 +75,17 @@ def _make_qwen_moe_lora_extractor():
         param_name = getattr(wrapper, "parameter_name", None)
 
         if param_name == "down_proj" and intermediate_dim is not None and hidden_dim is not None:
-            first_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
-            first_weight = first_weight.permute(1, 0, 2).contiguous()
-            second_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
+            first_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
+            first_weight = first_weight.permute(0, 2, 1).contiguous()
+            second_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
+            second_weight = second_weight.permute(1, 2, 0).contiguous()
             return first_weight, second_weight, scaling, num_experts
 
         elif param_name == "gate_up_proj" and hidden_dim is not None:
-            first_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
-            first_weight = first_weight.permute(1, 0, 2).contiguous()
-            second_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
+            first_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
+            first_weight = first_weight.permute(0, 2, 1).contiguous()
+            second_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
+            second_weight = second_weight.permute(1, 2, 0).contiguous()
             return first_weight, second_weight, scaling, num_experts
 
         if hidden_dim is not None:


### PR DESCRIPTION
## Summary

- The two named branches (`param_name == "down_proj"` and `param_name == "gate_up_proj"`) of `_qwen_moe_lora_extractor` in `unsloth_zoo/temporary_patches/qwen3_moe.py` assigned `first_weight` from `weight_B` and `second_weight` from `weight_A`, violating the extractor's own contract (docstring lines 50-52):
  - `first_weight:  (E, in_dim, R)`   [input -> rank]
  - `second_weight: (E, R, out_dim)`  [rank -> output]
- The fallback branch at the bottom of the same function already does it correctly. This PR aligns the named branches with the fallback.

## Why it matters

With the new transformers-5 stacked layout `gate_up_proj: (E, 2I, H) = (128, 1536, 2048)` and PEFT producing `lora_A: (E*R, H) = (1024, 2048)` + `lora_B: (2I, E*R) = (1536, 1024)`, the old `gate_up_proj` branch built `first_weight = (E, 2I, R) = (128, 1536, 8)`. The downstream call in `unsloth_compiled_cache/moe_utils.py::forward_native_grouped_mm` does `torch._grouped_mm(permuted_input, first_weight, offs=offsets)` where `permuted_input` has inner dim `H = 2048`, but `first_weight`'s inner dim was `2I = 1536`. The kernel raises:

```
RuntimeError: contraction dimension of mat_a and mat_b must match
```

on any `UNSLOTH_MOE_BACKEND=grouped_mm` + LoRA run on Qwen3-30B-A3B-* under transformers >= 5. That is the default backend on Hopper / Blackwell, so end-users hit this unless they fall back to `native_torch` and lose the grouped-GEMM speedup.

## Verification

Phase-1 smoke on `unsloth/Qwen3-30B-A3B-Instruct-2507` + LoRA rank 8 + 2 steps, on B200:

| Backend       | Step 1 loss / grad_norm      | Step 2 loss / grad_norm      |
|---------------|------------------------------|------------------------------|
| native_torch  | 0 / 5.905e-12                | -2.716e-13 / 3.063e-11       |
| grouped_mm    | 5.476e-07 / 2.624e-05        | 5.226e-07 / 1.725e-05        |

Before this patch, the `grouped_mm` column raised the contraction-dim error immediately. Both backends now complete end-to-end. The dummy reward has zero std so losses are near-zero (advantage normalisation collapses) - this matches what both backends produce.

## Test plan

- [x] `python tests/moe_grpo_hf_smoke.py --backend grouped_mm --max_steps 2 --lora_rank 8` completes.
- [x] `python tests/moe_grpo_hf_smoke.py --backend native_torch --max_steps 2 --lora_rank 8` still completes (regression).
- [x] `python tests/flex_lazy_batch_smoke.py` still passes.
- [ ] (Follow-up) audit `gpt_oss_moe.py` / `llama4_moe.py` for the same shape swap.