### PR TITLE
Fix unsloth_triton MoE backend dropping gate_up LoRA adapters

### DIFF
--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1107,6 +1107,19 @@ def forward_triton_grouped_gemm(
 
     use_separated_lora = _should_use_separated_lora()
 
+    # Prepare gate_up LoRA data (mirrors the down block below).
+    # Attribute is populated by the patched ParamWrapper forward.
+    gate_up_lora = None
+    if getattr(self, "_unsloth_lora_gate_up_proj", None) is not None:
+        gate_up_lora = self._unsloth_lora_gate_up_proj[:3]
+    elif (
+        use_separated_lora
+        and hasattr(self, "gate_up_proj")
+        and _has_lora_adapters(self.gate_up_proj)
+    ):
+        gate_up_lora = _extract_lora_weights(
+            self.gate_up_proj, num_experts=self.num_experts
+        )
 
     # Handle 3D inputs (batch_size, seq_len, hidden_dim)
     is_3d = hidden_states.dim() == 3
@@ -1184,6 +1197,26 @@ def forward_triton_grouped_gemm(
         kernel_config_bwd_dW=bwd_dW_config_1,
         is_first_gemm=True,
     )
+
+    # Add separated LoRA contribution for gate_up.
+    # grouped_gemm above ran with permute_x=True (internal gather); first_gemm_output
+    # is in expert-sorted order. _apply_lora_grouped_mm expects pre-permuted input,
+    # so gather hidden_states using gather_indices // top_k (maps expert-sorted row
+    # back to its originating token row).
+    if gate_up_lora is not None:
+        first_weight, second_weight, scaling = gate_up_lora
+        first_weight = first_weight.to(hidden_states.dtype)
+        second_weight = second_weight.to(hidden_states.dtype)
+        permuted_hidden = hidden_states[gather_indices // top_k]
+        gate_up_lora_delta = _apply_lora_grouped_mm(
+            permuted_hidden,
+            first_weight,
+            second_weight,
+            offsets,
+            scaling,
+            grouped_mm_func=native_moe_grouped_mm,
+        )
+        first_gemm_output = first_gemm_output + gate_up_lora_delta
 
     # Apply activation and multiply gate with up
     if hasattr(self, 'act_fn') and callable(self.act_fn):


### PR DESCRIPTION
## Summary

`forward_triton_grouped_gemm` in `unsloth_zoo/temporary_patches/moe_utils.py` was applying `down_proj` LoRA correctly but never routing `gate_up_proj` LoRA into the loss graph. With two PEFT `ParamWrapper` layers stacked on `Qwen3MoeExperts` (`down_proj -> gate_up_proj -> Qwen3MoeExperts`, per the comment at `moe_utils.py:677`), `named_parameters()` surfaces the outer wrapper at `experts.lora_{A,B}` (down) and the inner wrapper at `experts.base_layer.lora_{A,B}` (gate_up), so exactly half of the MoE LoRAs never saw a gradient path when training with `UNSLOTH_MOE_BACKEND=unsloth_triton`.

The fix mirrors the existing `down_proj` block at `moe_utils.py:1197-1246`:

1. Extract `gate_up_lora` using the same attribute-first / `_extract_lora_weights` fallback pattern.
2. Inject the LoRA contribution between the first `grouped_gemm` output and the activation, using `_apply_lora_grouped_mm` with pre-permuted input `hidden_states[gather_indices // top_k]` so the LoRA path sees tokens in the same expert-sorted order that `grouped_gemm` produced internally via `permute_x=True`.

## Probe results (Qwen3-30B-A3B, rank 8, 3 SFT steps, seed 3407)

Script: `tests/moe_lora_update_probe.py` (counts MoE LoRA tensors with non-zero delta after training).

| Backend | MoE LoRAs updated | train_loss | max abs delta (MoE) |
|---|---|---|---|
| grouped_mm (reference) | 192 / 192 | 1.2133 | 1.04e-01 |
| unsloth_triton (before fix) | 96 / 192 | 1.3043 | 3.33e-02 |
| unsloth_triton (after fix) | 192 / 192 | 1.2390 | 1.44e-01 |

Attention LoRAs were unaffected at 384/384 in all runs (separate code path, never broken).

## Parity vs grouped_mm

Pairwise final-weight diffs from the probe state dicts:

| Comparison | MoE max abs delta | MoE mean abs delta | Attn max abs delta | Attn mean abs delta |
|---|---|---|---|---|
| grouped_mm self-consistency (two runs, identical code) | 1.73e-01 | 3.99e-05 | 3.28e-03 | 3.12e-05 |
| unsloth_triton (fixed) vs grouped_mm | 1.44e-01 | 1.22e-04 | 4.45e-03 | 4.66e-05 |
| unsloth_triton (pre-fix) vs grouped_mm | 1.89e-01 | 2.28e-04 | 6.31e-03 | 9.73e-05 |

- `grouped_mm` is itself non-deterministic run-to-run at ~1.7e-01 MoE max abs delta (atomic-add races in the grouped-mm backward), so bit-exact parity across backends is not achievable.
- Fixed `unsloth_triton` sits inside that noise envelope on max abs delta and within 1.5x of the run-to-run floor on attention LoRAs. Mean MoE abs delta is about 3x the floor, reflecting kernel-level numerical differences between Triton `grouped_gemm` and `torch._grouped_mm` in the base forward, not a correctness gap.
- Training-loss gap vs grouped_mm closes from 0.089 (pre-fix) to 0.026 (post-fix).

## Out of scope

`forward_native_moe_loop` (the `native_torch` backend) still drops both gate_up and down LoRAs; that path uses per-expert `F.linear(current_state, self.gate_up_proj[expert_idx])` calls with no LoRA injection and is unrelated to this change. A separate follow-up PR is needed there.

## Test plan

- [x] `tests/moe_lora_update_probe.py --backend unsloth_triton` reports 192/192 MoE LoRAs updated, max abs delta 1.44e-01, train_loss 1.2390
- [x] `tests/moe_lora_update_probe.py --backend grouped_mm` unchanged at 192/192 (sanity, no regression)
- [x] Three MoE SFT notebooks at `max_steps=20` complete cleanly on the default `grouped_mm` backend: `GLM_Flash_A100(80GB).ipynb`, `gpt-oss-(120B)_A100-Fine-tuning.ipynb`, `Qwen3_MoE.ipynb`. Losses and grad-norms trend down across 20 steps, no NaN / Inf, peaks well under GPU capacity