### PR TITLE
Make Qwen3 MoE grouped_mm path CUDA-graph / torch.compile friendly

### DIFF
--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -21,6 +21,9 @@ __all__ = [
     "get_model_layer_config",
     "compare_attributes",
     "copy_attributes",
+    "patch_gemma4_vllm_lora_support",
+    "patch_gemma4_vllm_k_eq_v_support",
+    "patch_qwen3_5_vllm_lora_support",
 ]
 
 import torch
@@ -476,6 +479,202 @@ def patch_gemma4_vllm_k_eq_v_support():
 pass
 
 
+def patch_qwen3_5_vllm_lora_support():
+    """
+    Mirror of ``patch_gemma4_vllm_lora_support`` for Qwen3.5 / Qwen3.6.
+
+    vLLM's MoE-LoRA path calls ``get_expert_mapping`` on the top model or
+    its direct child. ``Qwen3_5MoeForConditionalGeneration`` routes through
+    ``model.language_model`` (``Qwen3_5MoeModel`` in text, its ``.model``
+    decoder stack holds ``FusedMoE`` / ``SharedFusedMoE`` experts).
+    Dense ``Qwen3_5ForConditionalGeneration`` has no expert mapping;
+    install a stub returning ``[]`` so the LoRA manager instantiates
+    without errors.
+
+    Also forces ``supports_lora = True`` + patches
+    ``vllm.model_executor.models.interfaces.supports_lora`` so the outer
+    multimodal wrapper is recognised as LoRA-capable even though vLLM's
+    inspector only checks attributes on the registered ``*ForCausalLM``.
+    """
+    # Both dense (Qwen3_5) and MoE (Qwen3_5Moe) classes live in the
+    # single ``vllm.model_executor.models.qwen3_5`` module (vLLM 0.19+).
+    try:
+        from vllm.model_executor.models.qwen3_5 import (
+            Qwen3_5ForConditionalGeneration,
+        )
+    except ImportError:
+        Qwen3_5ForConditionalGeneration = None
+    try:
+        from vllm.model_executor.models.qwen3_5 import (
+            Qwen3_5MoeForConditionalGeneration,
+        )
+    except ImportError:
+        Qwen3_5MoeForConditionalGeneration = None
+
+    if Qwen3_5ForConditionalGeneration is None and Qwen3_5MoeForConditionalGeneration is None:
+        return
+
+    from vllm.model_executor.models import interfaces as vllm_model_interfaces
+    from vllm.lora import model_manager as vllm_lora_model_manager
+    try:
+        from vllm.v1.worker import lora_model_runner_mixin
+    except ImportError:
+        lora_model_runner_mixin = None
+    from unsloth_zoo import vllm_lora_worker_manager
+
+    try:
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+    except ImportError:
+        FusedMoE = None
+
+    def _lookup_inner_causal_lm(cond_cls):
+        # vLLM ships the inner text causal LM under ``language_model`` on
+        # the multimodal wrapper's ``__init__``. Resolve lazily (class
+        # may not exist for dense qwen3_5) and install the mapping there.
+        return cond_cls
+
+    # ---- Qwen3.5 MoE ------------------------------------------------------
+    if Qwen3_5MoeForConditionalGeneration is not None:
+        Qwen3_5MoeForConditionalGeneration.supports_lora = True
+        Qwen3_5MoeForConditionalGeneration.embedding_modules = {}
+
+        try:
+            from vllm.model_executor.models.qwen3_5 import (
+                Qwen3_5MoeForCausalLM,
+            )
+        except ImportError:
+            Qwen3_5MoeForCausalLM = None
+
+        if (
+            Qwen3_5MoeForCausalLM is not None
+            and FusedMoE is not None
+            and not hasattr(Qwen3_5MoeForCausalLM, "get_expert_mapping")
+        ):
+            def _qwen3_5_moe_causal_lm_get_expert_mapping(self):
+                num_experts = getattr(self.config, "num_experts", 0)
+                if not num_experts:
+                    return []
+                num_redundant_experts = getattr(self, "num_redundant_experts", 0)
+                return FusedMoE.make_expert_params_mapping(
+                    self,
+                    ckpt_gate_proj_name="gate_proj",
+                    ckpt_down_proj_name="down_proj",
+                    ckpt_up_proj_name="up_proj",
+                    num_experts=num_experts,
+                    num_redundant_experts=num_redundant_experts,
+                )
+            Qwen3_5MoeForCausalLM.get_expert_mapping = (
+                _qwen3_5_moe_causal_lm_get_expert_mapping
+            )
+
+        if not hasattr(Qwen3_5MoeForConditionalGeneration, "get_expert_mapping"):
+            def _qwen3_5_moe_cond_get_expert_mapping(self):
+                language_model = getattr(self, "language_model", None)
+                if language_model is None:
+                    return []
+                inner = getattr(language_model, "get_expert_mapping", None)
+                if inner is None:
+                    return []
+                return inner()
+            Qwen3_5MoeForConditionalGeneration.get_expert_mapping = (
+                _qwen3_5_moe_cond_get_expert_mapping
+            )
+
+    # ---- Qwen3.5 dense ----------------------------------------------------
+    if Qwen3_5ForConditionalGeneration is not None:
+        Qwen3_5ForConditionalGeneration.supports_lora = True
+        Qwen3_5ForConditionalGeneration.embedding_modules = {}
+
+        if not hasattr(Qwen3_5ForConditionalGeneration, "get_expert_mapping"):
+            def _qwen3_5_dense_get_expert_mapping(self):
+                # Dense Qwen3.5 has no experts; vLLM still calls
+                # ``get_expert_mapping`` during LoRA manager init so
+                # provide an empty list.
+                return []
+            Qwen3_5ForConditionalGeneration.get_expert_mapping = (
+                _qwen3_5_dense_get_expert_mapping
+            )
+
+    # ---- supports_lora whitelist patch -----------------------------------
+    _classnames = set()
+    if Qwen3_5ForConditionalGeneration is not None:
+        _classnames.add("Qwen3_5ForConditionalGeneration")
+    if Qwen3_5MoeForConditionalGeneration is not None:
+        _classnames.add("Qwen3_5MoeForConditionalGeneration")
+
+    if _classnames and not hasattr(
+        vllm_model_interfaces.supports_lora, "_unsloth_qwen3_5_patch"
+    ):
+        _prior = vllm_model_interfaces.supports_lora
+
+        def _patched_supports_lora_qwen3_5(model):
+            if model.__class__.__name__ in _classnames:
+                return True
+            return _prior(model)
+
+        _patched_supports_lora_qwen3_5._unsloth_qwen3_5_patch = True
+        vllm_model_interfaces.supports_lora = _patched_supports_lora_qwen3_5
+        if lora_model_runner_mixin is not None:
+            lora_model_runner_mixin.supports_lora = _patched_supports_lora_qwen3_5
+
+    # ---- create_lora_manager whitelist patch -----------------------------
+    # The patched function MUST declare ``vllm_config`` as a named parameter:
+    # unsloth_zoo.vllm_lora_worker_manager._call_create_lora_manager inspects
+    # ``create_lora_manager``'s signature and only forwards vllm_config when
+    # it appears in ``sig.parameters``. A generic ``(model, *args, **kwargs)``
+    # wrapper loses vllm_config in translation and blows up the original
+    # vLLM create_lora_manager (which requires vllm_config positionally).
+    if _classnames and not hasattr(
+        vllm_lora_model_manager.create_lora_manager, "_unsloth_qwen3_5_patch"
+    ):
+        _prior_clm = vllm_lora_model_manager.create_lora_manager
+
+        def _patched_create_lora_manager_qwen3_5(
+            model,
+            max_num_seqs=None,
+            max_num_batched_tokens=None,
+            vocab_size=None,
+            lora_config=None,
+            vllm_config=None,
+            device=None,
+            lora_manager_cls=None,
+            **kwargs,
+        ):
+            if lora_manager_cls is None:
+                lora_manager_cls = vllm_lora_model_manager.LoRAModelManager
+            if model.__class__.__name__ in _classnames:
+                return lora_manager_cls(
+                    model=model,
+                    max_num_seqs=max_num_seqs,
+                    max_num_batched_tokens=max_num_batched_tokens,
+                    vocab_size=vocab_size,
+                    lora_config=lora_config,
+                    vllm_config=vllm_config,
+                    device=device,
+                    **kwargs,
+                )
+            return _prior_clm(
+                model,
+                max_num_seqs=max_num_seqs,
+                max_num_batched_tokens=max_num_batched_tokens,
+                vocab_size=vocab_size,
+                lora_config=lora_config,
+                vllm_config=vllm_config,
+                device=device,
+                lora_manager_cls=lora_manager_cls,
+                **kwargs,
+            )
+
+        _patched_create_lora_manager_qwen3_5._unsloth_qwen3_5_patch = True
+        vllm_lora_model_manager.create_lora_manager = (
+            _patched_create_lora_manager_qwen3_5
+        )
+        vllm_lora_worker_manager.create_lora_manager = (
+            _patched_create_lora_manager_qwen3_5
+        )
+pass
+
+
 @torch.inference_mode
 def create_empty_vision_model(config, dtype = torch.float16):
     # All Unsloth Zoo code licensed under LGPLv3
@@ -579,6 +778,12 @@ def create_empty_model(config, dtype = torch.float16, is_vision_model = False):
 def set_additional_modules(new_model, quant_state_dict, config):
     if hasattr(new_model, "language_model"):
         language_model = new_model.language_model
+        language_model_prefix = "model.language_model"
+    elif hasattr(new_model, "model") and hasattr(new_model.model, "language_model"):
+        # Qwen3.5 / Qwen3.6: outer container Qwen3_5Model wraps .visual +
+        # .language_model. Dereference one more level so we land on the
+        # text backbone with embed_tokens/layers/norm.
+        language_model = new_model.model.language_model
         language_model_prefix = "model.language_model"
     else:
         language_model_prefix = "model"

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -298,6 +298,183 @@ def _set_config_attrs(config_obj, attrs_to_set):
             setattr(config_obj, attr, value)
 pass
 
+def _get_model_device(model):
+    for tensor in model.parameters():
+        return tensor.device
+    for tensor in model.buffers():
+        return tensor.device
+    return torch.device("cpu")
+pass
+
+def patch_gemma4_vllm_lora_support():
+    from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
+    from vllm.model_executor.models import interfaces as vllm_model_interfaces
+    from vllm.lora import model_manager as vllm_lora_model_manager
+    try:
+        from vllm.v1.worker import lora_model_runner_mixin
+    except ImportError:
+        lora_model_runner_mixin = None
+    from unsloth_zoo import vllm_lora_worker_manager
+
+    Gemma4ForConditionalGeneration.supports_lora = True
+    Gemma4ForConditionalGeneration.embedding_modules = {}
+
+    # vLLM's MoE-LoRA path (vllm.lora.utils.process_packed_modules_mapping)
+    # requires ``get_expert_mapping`` on either the top-level model or a
+    # direct child. Gemma4ForConditionalGeneration routes through its
+    # ``language_model`` child (Gemma4ForCausalLM), which upstream has no
+    # such method, so vLLM raises ``AttributeError`` before create_lora_manager
+    # even runs. Install the method on both: the outer wrapper delegates to
+    # the inner causal LM, and the inner causal LM builds the mapping from
+    # its FusedMoE experts via ``FusedMoE.make_expert_params_mapping``.
+    try:
+        from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+    except ImportError:
+        Gemma4ForCausalLM = None
+        FusedMoE = None
+
+    if Gemma4ForCausalLM is not None and FusedMoE is not None and \
+            not hasattr(Gemma4ForCausalLM, "get_expert_mapping"):
+
+        def _gemma4_causal_lm_get_expert_mapping(self):
+            # Gemma 4 MoE checkpoints expose per-expert entries named
+            # gate_proj / up_proj / down_proj after the HF-to-vLLM remap
+            # in Gemma4ForCausalLM.load_weights. Mirror Qwen3 / deepseek_v2.
+            num_experts = getattr(self.config, "num_experts", 0)
+            if not num_experts:
+                return []
+            num_redundant_experts = getattr(self, "num_redundant_experts", 0)
+            return FusedMoE.make_expert_params_mapping(
+                self,
+                ckpt_gate_proj_name="gate_proj",
+                ckpt_down_proj_name="down_proj",
+                ckpt_up_proj_name="up_proj",
+                num_experts=num_experts,
+                num_redundant_experts=num_redundant_experts,
+            )
+
+        Gemma4ForCausalLM.get_expert_mapping = _gemma4_causal_lm_get_expert_mapping
+
+    if not hasattr(Gemma4ForConditionalGeneration, "get_expert_mapping"):
+        def _gemma4_cond_get_expert_mapping(self):
+            language_model = getattr(self, "language_model", None)
+            if language_model is None:
+                return []
+            inner = getattr(language_model, "get_expert_mapping", None)
+            if inner is None:
+                return []
+            return inner()
+
+        Gemma4ForConditionalGeneration.get_expert_mapping = (
+            _gemma4_cond_get_expert_mapping
+        )
+
+    if not hasattr(vllm_model_interfaces.supports_lora, "_unsloth_gemma4_patch"):
+        original_supports_lora = vllm_model_interfaces.supports_lora
+
+        def patched_supports_lora(model):
+            if model.__class__.__name__ == "Gemma4ForConditionalGeneration":
+                return True
+            return original_supports_lora(model)
+
+        patched_supports_lora._unsloth_gemma4_patch = True
+        vllm_model_interfaces.supports_lora = patched_supports_lora
+        if lora_model_runner_mixin is not None:
+            lora_model_runner_mixin.supports_lora = patched_supports_lora
+
+    if not hasattr(vllm_lora_model_manager.create_lora_manager, "_unsloth_gemma4_patch"):
+        original_create_lora_manager = vllm_lora_model_manager.create_lora_manager
+
+        def patched_create_lora_manager(model, *args, **kwargs):
+            if model.__class__.__name__ == "Gemma4ForConditionalGeneration":
+                lora_manager_cls = kwargs.pop("lora_manager_cls", vllm_lora_model_manager.LoRAModelManager)
+                return lora_manager_cls(model = model, *args, **kwargs)
+            return original_create_lora_manager(model, *args, **kwargs)
+
+        patched_create_lora_manager._unsloth_gemma4_patch = True
+        vllm_lora_model_manager.create_lora_manager = patched_create_lora_manager
+        vllm_lora_worker_manager.create_lora_manager = patched_create_lora_manager
+pass
+
+# vLLM's Gemma4 k_eq_v path now expects qkv_proj to always expose q+k+v.
+# For prequantized bitsandbytes checkpoints, the synthetic v shard is still
+# missing from the quant-state dict on full-attention k_eq_v layers, so we
+# materialize it during loader-side quant-state stacking instead of patching
+# the runtime attention forward.
+def patch_gemma4_vllm_k_eq_v_support():
+    try:
+        from vllm.model_executor.model_loader.bitsandbytes_loader import (
+            BitsAndBytesModelLoader,
+        )
+    except ImportError:
+        return
+
+    if hasattr(
+        BitsAndBytesModelLoader._stack_quantization_states,
+        "_unsloth_gemma4_k_eq_v_patch",
+    ):
+        return
+
+    original_stack_quantization_states = (
+        BitsAndBytesModelLoader._stack_quantization_states
+    )
+
+    def _get_gemma4_text_config(model):
+        config = getattr(model, "config", None)
+        if config is None:
+            return None
+
+        text_config = getattr(config, "text_config", config)
+        model_type = getattr(config, "model_type", None)
+        text_model_type = getattr(text_config, "model_type", None)
+        if model_type != "gemma4" and text_model_type not in ("gemma4", "gemma4_text"):
+            return None
+        return text_config
+
+    def _get_gemma4_k_eq_v_qkv_param_names(model):
+        text_config = _get_gemma4_text_config(model)
+        if text_config is None or not getattr(text_config, "attention_k_eq_v", False):
+            return ()
+
+        param_names = set(name for name, _ in model.named_parameters())
+        qkv_param_names = []
+        for layer_idx, layer_type in enumerate(getattr(text_config, "layer_types", ())):
+            if layer_type != "full_attention":
+                continue
+
+            for prefix in ("language_model.model", "model"):
+                qkv_param_name = (
+                    f"{prefix}.layers.{layer_idx}.self_attn.qkv_proj.weight"
+                )
+                if qkv_param_name in param_names:
+                    qkv_param_names.append(qkv_param_name)
+                    break
+        return tuple(qkv_param_names)
+
+    def patched_stack_quantization_states(self, model, quant_state_dict):
+        stacked_quant_state_dict = original_stack_quantization_states(
+            self, model, quant_state_dict
+        )
+
+        for qkv_param_name in _get_gemma4_k_eq_v_qkv_param_names(model):
+            quant_states = stacked_quant_state_dict.get(qkv_param_name)
+            if not isinstance(quant_states, dict) or 2 in quant_states or 1 not in quant_states:
+                continue
+
+            # Gemma4 full-attention k_eq_v layers reuse K as V. The raw weight
+            # loader already duplicates k_proj -> v_proj; prequant BnB needs the
+            # same duplication for shard-local QuantState metadata.
+            quant_states[2] = deepcopy(quant_states[1])
+
+        return stacked_quant_state_dict
+
+    patched_stack_quantization_states._unsloth_gemma4_k_eq_v_patch = True
+    BitsAndBytesModelLoader._stack_quantization_states = (
+        patched_stack_quantization_states
+    )
+pass
+
 
 @torch.inference_mode
 def create_empty_vision_model(config, dtype = torch.float16):

--- a/unsloth_zoo/gemma4_moe_lora_convert.py
+++ b/unsloth_zoo/gemma4_moe_lora_convert.py
@@ -1,0 +1,244 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Convert an Unsloth-trained Gemma 4 MoE LoRA adapter to the per-expert layout
+that vLLM's PEFTHelper validates against.
+
+Unsloth trains MoE LoRA on the stacked ``Gemma4TextExperts.gate_up_proj`` /
+``down_proj`` 3D tensors via ParamWrapper, so the saved adapter has
+block-diagonal stacked LoRA matrices (one per layer):
+
+    experts.base_layer.lora_A   (E*r, H)          # gate_up
+    experts.base_layer.lora_B   (2*I, E*r)        # gate_up
+    experts.lora_A              (E*r, I)          # down
+    experts.lora_B              (H, E*r)          # down
+
+vLLM's Gemma 4 `FusedMoE` LoRA support expects per-expert entries:
+
+    moe.experts.{e}.gate_proj.lora_A   (r, H)
+    moe.experts.{e}.gate_proj.lora_B   (I, r)
+    moe.experts.{e}.up_proj.lora_A     (r, H)
+    moe.experts.{e}.up_proj.lora_B     (I, r)
+    moe.experts.{e}.down_proj.lora_A   (r, I)
+    moe.experts.{e}.down_proj.lora_B   (H, r)
+
+gate and up share the same lora_A since the training-side LoRA was on the
+merged gate_up projection; only lora_B splits into ``[:I, :]`` and ``[I:, :]``.
+
+Usage:
+
+    python -m unsloth_zoo.gemma4_moe_lora_convert \\
+        --src outputs/gemma4_26b_a4b_lora_r16 \\
+        --dst outputs/gemma4_26b_a4b_lora_r16_per_expert
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+from typing import Dict
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+_STACKED_GATE_UP_RE = re.compile(
+    r"^(?P<prefix>.*\.layers\.\d+)\.experts\.base_layer\.lora_(?P<ab>A|B)\.weight$"
+)
+_STACKED_DOWN_RE = re.compile(
+    r"^(?P<prefix>.*\.layers\.\d+)\.experts\.lora_(?P<ab>A|B)\.weight$"
+)
+
+
+def _split_expert_slice(tensor: torch.Tensor, dim: int, e: int, r: int) -> torch.Tensor:
+    start, end = e * r, (e + 1) * r
+    return tensor.narrow(dim, start, r).clone()
+
+
+def convert(
+    src_dir: str,
+    dst_dir: str,
+    num_experts: int,
+    intermediate_size: int,
+    rank: int,
+) -> None:
+    """Convert a stacked-MoE adapter directory to per-expert layout."""
+    os.makedirs(dst_dir, exist_ok=True)
+    for fname in os.listdir(src_dir):
+        if fname in ("adapter_model.safetensors", "adapter_config.json"):
+            continue
+        shutil.copy2(os.path.join(src_dir, fname), os.path.join(dst_dir, fname))
+
+    with open(os.path.join(src_dir, "adapter_config.json"), "r") as f:
+        cfg = json.load(f)
+
+    # Strip the Unsloth stacked-MoE target_parameters — per-expert keys are
+    # picked up through the standard target_modules match (gate_proj/up_proj/
+    # down_proj) once the adapter is exploded.
+    cfg.pop("target_parameters", None)
+    # Drop "gate_up_proj" from target_modules — split into gate+up per expert.
+    cfg["target_modules"] = [
+        m for m in cfg.get("target_modules", []) if m != "gate_up_proj"
+    ]
+    # Add per-expert gate/up/down_proj if missing, so PEFT/vLLM match them
+    # against the expanded expert modules.
+    for m in ("gate_proj", "up_proj", "down_proj"):
+        if m not in cfg["target_modules"]:
+            cfg["target_modules"].append(m)
+    cfg["target_modules"] = sorted(set(cfg["target_modules"]))
+    cfg.setdefault("auto_mapping", {})
+    cfg["auto_mapping"]["unsloth_moe_lora_expanded"] = True
+
+    with open(os.path.join(dst_dir, "adapter_config.json"), "w") as f:
+        json.dump(cfg, f, indent=2)
+
+    new_state: Dict[str, torch.Tensor] = {}
+
+    with safe_open(os.path.join(src_dir, "adapter_model.safetensors"), "pt") as f:
+        for key in f.keys():
+            m_gu = _STACKED_GATE_UP_RE.match(key)
+            m_dn = _STACKED_DOWN_RE.match(key)
+            tensor = f.get_tensor(key)
+
+            if m_gu is not None:
+                prefix = m_gu.group("prefix")  # .../layers.N
+                ab = m_gu.group("ab")
+                if ab == "A":
+                    assert tensor.shape[0] == num_experts * rank, (
+                        f"expected A shape[0]={num_experts * rank}, got {tensor.shape}"
+                    )
+                    for e in range(num_experts):
+                        sub = _split_expert_slice(tensor, dim=0, e=e, r=rank)  # (r, H)
+                        # gate and up share lora_A of the merged gate_up_proj.
+                        # safetensors refuses tensors that share storage, so
+                        # clone into independent allocations for each proj.
+                        for proj in ("gate_proj", "up_proj"):
+                            k = f"{prefix}.experts.{e}.{proj}.lora_A.weight"
+                            new_state[k] = sub.contiguous().clone()
+                else:  # B
+                    assert tensor.shape[1] == num_experts * rank, (
+                        f"expected B shape[1]={num_experts * rank}, got {tensor.shape}"
+                    )
+                    I = intermediate_size
+                    assert tensor.shape[0] == 2 * I, (
+                        f"expected B shape[0]=2*I={2 * I}, got {tensor.shape}"
+                    )
+                    for e in range(num_experts):
+                        sub = _split_expert_slice(tensor, dim=1, e=e, r=rank)  # (2I, r)
+                        gate_B = sub[:I, :].contiguous()
+                        up_B = sub[I:, :].contiguous()
+                        new_state[f"{prefix}.experts.{e}.gate_proj.lora_B.weight"] = gate_B
+                        new_state[f"{prefix}.experts.{e}.up_proj.lora_B.weight"] = up_B
+                continue
+
+            if m_dn is not None:
+                prefix = m_dn.group("prefix")
+                ab = m_dn.group("ab")
+                if ab == "A":
+                    assert tensor.shape[0] == num_experts * rank, (
+                        f"expected down A shape[0]={num_experts * rank}, got {tensor.shape}"
+                    )
+                    for e in range(num_experts):
+                        sub = _split_expert_slice(tensor, dim=0, e=e, r=rank)  # (r, I)
+                        new_state[f"{prefix}.experts.{e}.down_proj.lora_A.weight"] = sub.contiguous()
+                else:  # B
+                    assert tensor.shape[1] == num_experts * rank, (
+                        f"expected down B shape[1]={num_experts * rank}, got {tensor.shape}"
+                    )
+                    for e in range(num_experts):
+                        sub = _split_expert_slice(tensor, dim=1, e=e, r=rank)  # (H, r)
+                        new_state[f"{prefix}.experts.{e}.down_proj.lora_B.weight"] = sub.contiguous()
+                continue
+
+            # vLLM's Gemma 4 vision tower has no PunicaWrapper-compatible
+            # LoRA path (warns "no matching PunicaWrapper" for every encoder
+            # layer). Adapter tensors under vision_tower.* also carry a
+            # ".linear" suffix from the bnb Linear4bit wrapper path, which
+            # vLLM's validator rejects because "linear" isn't a target
+            # module. Drop them — they can't be applied anyway.
+            if ".vision_tower." in key or ".audio_tower." in key:
+                continue
+
+            # Non-MoE entries (attention projections, dense MLP) pass through.
+            new_state[key] = tensor.clone()
+
+    save_file(new_state, os.path.join(dst_dir, "adapter_model.safetensors"))
+    print(
+        f"[gemma4-moe-lora-convert] wrote {len(new_state)} tensors to "
+        f"{dst_dir}/adapter_model.safetensors"
+    )
+
+
+def _infer_shapes_from_adapter(src_dir: str) -> Dict[str, int]:
+    """Read one stacked A/B tensor to infer num_experts, rank, intermediate_size."""
+    path = os.path.join(src_dir, "adapter_model.safetensors")
+    with safe_open(path, "pt") as f:
+        rank = None
+        num_experts = None
+        intermediate_size = None
+        for key in f.keys():
+            m = _STACKED_GATE_UP_RE.match(key)
+            if m is None:
+                continue
+            t = f.get_tensor(key)
+            if m.group("ab") == "B":
+                two_i, er = t.shape  # (2I, E*r)
+                # Need rank from A below.
+                intermediate_size = two_i // 2
+            else:
+                er, _h = t.shape  # (E*r, H)
+                # can't split E and r yet
+                er_from_a = er
+        # Second pass with adapter_config for rank
+        with open(os.path.join(src_dir, "adapter_config.json"), "r") as g:
+            cfg = json.load(g)
+        rank = int(cfg["r"])
+        num_experts = er_from_a // rank
+    return {
+        "rank": rank,
+        "num_experts": num_experts,
+        "intermediate_size": intermediate_size,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--src", required=True, help="source adapter directory")
+    ap.add_argument("--dst", required=True, help="destination adapter directory")
+    ap.add_argument("--num_experts", type=int, default=None)
+    ap.add_argument("--intermediate_size", type=int, default=None)
+    ap.add_argument("--rank", type=int, default=None)
+    args = ap.parse_args()
+
+    auto = _infer_shapes_from_adapter(args.src)
+    num_experts = args.num_experts if args.num_experts is not None else auto["num_experts"]
+    intermediate_size = (
+        args.intermediate_size
+        if args.intermediate_size is not None
+        else auto["intermediate_size"]
+    )
+    rank = args.rank if args.rank is not None else auto["rank"]
+
+    print(
+        f"[gemma4-moe-lora-convert] src={args.src}  dst={args.dst}  "
+        f"num_experts={num_experts}  intermediate_size={intermediate_size}  "
+        f"rank={rank}"
+    )
+    convert(args.src, args.dst, num_experts, intermediate_size, rank)
+
+
+if __name__ == "__main__":
+    main()

--- a/unsloth_zoo/patch_torch_functions.py
+++ b/unsloth_zoo/patch_torch_functions.py
@@ -166,11 +166,38 @@ def cross_entropy(
 pass
 
 
+def _dynamo_safe_layer_norm(
+    input: Tensor,
+    normalized_shape: List[int],
+    weight: Optional[Tensor] = None,
+    bias: Optional[Tensor] = None,
+    eps: float = 1e-5,
+) -> Tensor:
+    # ``layer_norm`` above is a torch.compile-wrapped function. When another
+    # compile/AOT-autograd/fx pass (e.g. vLLM's inductor compile of
+    # Gemma4AudioSubSampleConvProjectionLayer.forward) traces through
+    # F.layer_norm, it recurses into this nested compile and raises
+    # "Detected that you are using FX to symbolically trace a
+    # dynamo-optimized function" / FakeTensor.data_ptr errors. Always route
+    # through the original torch.layer_norm C++ op — that's what the
+    # @torch_compile wrapper ultimately calls anyway, and Dynamo is free to
+    # fuse the naked op when it shows up inside a user compile region.
+    return torch.layer_norm(
+        input,
+        normalized_shape,
+        weight,
+        bias,
+        eps,
+        torch.backends.cudnn.enabled,
+    ).to(input.dtype)
+pass
+
+
 def patch_torch_functions():
     # All Unsloth Zoo code licensed under LGPLv3
     if not hasattr(torch.nn.functional, "_uncompiled_layer_norm"):
         torch.nn.functional._uncompiled_layer_norm = torch.nn.functional.layer_norm
-        torch.nn.functional.layer_norm = layer_norm
+        torch.nn.functional.layer_norm = _dynamo_safe_layer_norm
     # Remove compiling cross_entropy since too many errors
     # We already compile this most likely anyways
     # if not hasattr(torch.nn.functional, "_uncompiled_cross_entropy"):

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -108,6 +108,36 @@ class _Gemma4KVSharedSafeProxy:
     def __init__(self, real):
         object.__setattr__(self, "_real", real)
 
+    def __setattr__(self, name, value):
+        # Forward writes to the wrapped config so callers like vLLM's
+        # ``VllmConfig.with_hf_config`` (which assigns
+        # ``tie_word_embeddings`` onto ``get_text_config()``) do not hit
+        # ``AttributeError: ... no __dict__ for setting new attributes``.
+        # Allow writes to our own ``_real`` slot (used by deepcopy /
+        # ``__init__``) to go through object.__setattr__.
+        if name == "_real":
+            object.__setattr__(self, name, value)
+            return
+        try:
+            real = object.__getattribute__(self, "_real")
+        except AttributeError:
+            # Instance still being initialized (e.g. deepcopy sets slots
+            # after __new__). Fall back to the slot.
+            object.__setattr__(self, name, value)
+            return
+        setattr(real, name, value)
+
+    def __delattr__(self, name):
+        if name == "_real":
+            object.__delattr__(self, name)
+            return
+        try:
+            real = object.__getattribute__(self, "_real")
+        except AttributeError:
+            object.__delattr__(self, name)
+            return
+        delattr(real, name)
+
     def __getattr__(self, name):
         # Only invoked when normal attribute lookup fails (i.e. not a slot
         # and not a method of this proxy class).

--- a/unsloth_zoo/temporary_patches/gemma4_moe.py
+++ b/unsloth_zoo/temporary_patches/gemma4_moe.py
@@ -157,6 +157,9 @@ def patch_gemma4_moe():
 
             # RETURN_HIDDEN_STATES mode — return hidden states instead of
             # logits. Used by GRPO rollout to stream forward features.
+            # Drop return_dict from kwargs if TRL/caller pre-set it to avoid
+            # "got multiple values for keyword argument 'return_dict'".
+            kwargs.pop("return_dict", None)
             outputs = self.model(
                 input_ids=input_ids,
                 pixel_values=pixel_values,

--- a/unsloth_zoo/temporary_patches/gemma4_moe.py
+++ b/unsloth_zoo/temporary_patches/gemma4_moe.py
@@ -16,9 +16,8 @@
 
 import os
 import torch
-import torch.nn as nn
 from .common import TEMPORARY_PATCHES, UNSLOTH_ENABLE_LOGGING
-from .utils import patch_function, raise_error, logger
+from .utils import patch_function, logger
 from .moe_utils import (
     patch_param_wrapper_for_moe,
     get_forward_moe_backend,
@@ -27,71 +26,67 @@ from .moe_utils import (
 
 def patch_gemma4_moe():
     """
-    Patches Gemma4 MoE to support Split LoRA using grouped GEMM.
-    Gemma4 uses 128 experts with top_k=8 and a unique per_expert_scale parameter.
+    Patches Gemma4 MoE (26B-A4B and any other MoE-enabled Gemma 4 variant)
+    for Split LoRA + grouped GEMM backend + text-only GRPO training.
+
+    Compatible with transformers >= 5.5.0 (first PyPI release with Gemma 4
+    support). The stacked expert tensor layout
+    ``Gemma4TextExperts.gate_up_proj (E, 2*I, H)`` / ``down_proj (E, H, I)``
+    matches Qwen3-MoE, so the default ``_extract_lora_from_wrapper`` + the
+    generic ``get_forward_moe_backend`` cover LoRA extraction and MoE
+    forward without arch-specific branches.
+
+    The router's ``per_expert_scale`` is already folded into
+    ``top_k_weights`` natively by ``Gemma4TextRouter.forward`` since
+    transformers 5.5.0, so this patch does NOT need to fold it.
     """
-    # Patch PEFT ParamWrapper for separated LoRA weights
+    # Patch PEFT ParamWrapper for separated LoRA weights (idempotent).
     patch_param_wrapper_for_moe()
 
-    # Try to import Gemma4 MoE classes
+    # Gemma 4 available only on transformers >= 5.5.0. Bail cleanly on
+    # older installs (training code elsewhere errors out with a clearer
+    # version-pin message).
     try:
         from transformers.models.gemma4.modeling_gemma4 import (
-            Gemma4TextMoEBlock,
-            Gemma4TextDecoderLayer,
+            Gemma4TextExperts,
         )
     except Exception:
         return  # Gemma4 not available in this transformers version
 
-    # Check if already patched
-    if hasattr(Gemma4TextMoEBlock, "_unsloth_already_patched"):
+    if getattr(Gemma4TextExperts, "_unsloth_already_patched", False):
         return
 
     # ====================================================================
-    # Remap decoder layer module names to match checkpoint key layout:
-    #   moe.{gate_up_proj,down_proj} -> experts.{...}
-    #   moe.per_expert_scale         -> router.per_expert_scale
-    # ====================================================================
-    _original_decoder_init = Gemma4TextDecoderLayer.__init__
-
-    def _patched_decoder_init(self, config, layer_idx):
-        _original_decoder_init(self, config, layer_idx)
-        if getattr(self, "enable_moe_block", False) and "moe" in self._modules:
-            moe_block = self._modules.pop("moe")
-            self._modules["experts"] = moe_block
-            object.__setattr__(self, "moe", moe_block)
-
-            per_expert_scale_data = moe_block.per_expert_scale.data
-            del moe_block._parameters["per_expert_scale"]
-            self.router.per_expert_scale = nn.Parameter(per_expert_scale_data)
-            # Non-persistent buffer keeps _init_weights happy without appearing in state_dict
-            moe_block.register_buffer("per_expert_scale", torch.ones(config.num_experts), persistent=False)
-            object.__setattr__(moe_block, "_router_ref", self.router)
-
-    Gemma4TextDecoderLayer.__init__ = _patched_decoder_init
-
-    # Gemma4 uses standard F.linear format (E, out_dim, in_dim), same as Qwen3MoE.
-    # The default _extract_lora_from_wrapper handles this correctly — no custom extractor needed.
-
-    # ====================================================================
-    # Patch Gemma4TextMoEBlock.forward with optimized grouped GEMM backend.
-    # Pre-multiply per_expert_scale into routing weights so the generic
-    # grouped_mm forward doesn't need per_expert_scale special-casing.
+    # Replace Gemma4TextExperts.forward with the grouped-GEMM backend.
+    # The stock forward (modeling_gemma4.py) is a Python loop over active
+    # experts — not CUDA-graph capturable and slow at inference / decode.
+    # The generic forward_native_grouped_mm handles:
+    #   - act_fn (Gemma 4 sets self.act_fn to gelu_pytorch_tanh natively)
+    #   - the (E, 2*I, H) / (E, H, I) expert layout via `chunk(2, -1)`
+    # so no arch-specific branches are needed in moe_utils.py.
     # ====================================================================
     _moe_backend = get_forward_moe_backend()
 
-    def _gemma4_moe_forward(self, hidden_states, top_k_index, top_k_weights):
-        # Fold per_expert_scale into routing weights before grouped_mm
-        router_ref = getattr(self, "_router_ref", None)
-        if router_ref is not None:
-            pes = router_ref.per_expert_scale
-            top_k_weights = top_k_weights * pes[top_k_index].to(top_k_weights.dtype)
+    def _gemma4_moe_experts_forward(self, hidden_states, top_k_index, top_k_weights):
+        # per_expert_scale is already applied on `top_k_weights` by
+        # Gemma4TextRouter.forward since transformers 5.5.0 — do not
+        # re-apply here.
         return _moe_backend(self, hidden_states, top_k_index, top_k_weights)
 
-    patch_function(Gemma4TextMoEBlock, "forward", _gemma4_moe_forward, force=True)
+    patch_function(
+        Gemma4TextExperts, "forward", _gemma4_moe_experts_forward, force=True
+    )
 
     # ====================================================================
-    # Patch Gemma4ForConditionalGeneration.forward for GRPO training
-    # When UNSLOTH_RETURN_HIDDEN_STATES=1, return hidden_states instead of logits
+    # Patch Gemma4ForConditionalGeneration.forward for text-only GRPO /
+    # SFT: inject a zero-filled ``mm_token_type_ids`` when the caller
+    # (TRL GRPOTrainer, standard Trainer, etc.) doesn't supply one in
+    # training mode. Without this, ``create_causal_mask_mapping``
+    # (modeling_gemma4.py) raises
+    # ``ValueError: mm_token_type_ids is required as a model input when
+    # training`` on every text-only train step.
+    #
+    # Also supports UNSLOTH_RETURN_HIDDEN_STATES=1 (GRPO rollout path).
     # ====================================================================
     try:
         from transformers.models.gemma4.modeling_gemma4 import (
@@ -120,7 +115,7 @@ def patch_gemma4_moe():
             logits_to_keep=0,
             **kwargs,
         ):
-            # Inject mm_token_type_ids=0 for text-only SFT
+            # Inject mm_token_type_ids=0 for text-only SFT / GRPO.
             if mm_token_type_ids is None and self.training:
                 _ids = input_ids if input_ids is not None else inputs_embeds
                 if _ids is not None:
@@ -128,7 +123,8 @@ def patch_gemma4_moe():
                         _ids.shape[:2], dtype=torch.long, device=_ids.device
                     )
 
-            # Drop stale mm_token_type_ids during KV cache generation
+            # Drop stale mm_token_type_ids during KV cache generation when
+            # the sequence length no longer matches.
             _seq_ref = input_ids if input_ids is not None else inputs_embeds
             if mm_token_type_ids is not None and _seq_ref is not None:
                 if mm_token_type_ids.shape[1] != _seq_ref.shape[1]:
@@ -159,7 +155,8 @@ def patch_gemma4_moe():
                     **kwargs,
                 )
 
-            # RETURN_HIDDEN_STATES mode - return hidden_states instead of logits
+            # RETURN_HIDDEN_STATES mode — return hidden states instead of
+            # logits. Used by GRPO rollout to stream forward features.
             outputs = self.model(
                 input_ids=input_ids,
                 pixel_values=pixel_values,
@@ -200,7 +197,8 @@ def patch_gemma4_moe():
         Gemma4ForConditionalGeneration.forward = _patched_causal_lm_forward
         if UNSLOTH_ENABLE_LOGGING:
             logger.info(
-                "Unsloth: Patched Gemma4ForConditionalGeneration.forward for GRPO hidden states."
+                "Unsloth: Patched Gemma4ForConditionalGeneration.forward for "
+                "text-only training + GRPO hidden states."
             )
     except Exception as e:
         if UNSLOTH_ENABLE_LOGGING:
@@ -208,10 +206,10 @@ def patch_gemma4_moe():
                 f"Unsloth: Could not patch Gemma4ForConditionalGeneration.forward: {e}"
             )
 
-    Gemma4TextMoEBlock._unsloth_already_patched = True
+    Gemma4TextExperts._unsloth_already_patched = True
 
     if UNSLOTH_ENABLE_LOGGING:
-        logger.info("Unsloth: Patched Gemma4 MoE for Split LoRA support.")
+        logger.info("Unsloth: Patched Gemma4 MoE for Split LoRA + grouped GEMM.")
 
 
 TEMPORARY_PATCHES.append(patch_gemma4_moe)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -800,7 +800,18 @@ def forward_native_grouped_mm(
 
     # 1. Calculate routing
     flat_top_k = top_k_index.view(-1)
-    num_tokens_per_expert = torch.bincount(flat_top_k, minlength=self.num_experts).int()
+    # ``torch.bincount(..., minlength=num_experts)`` produces the correct
+    # result but triggers a CPU→CUDA scalar copy inside CUDA graph
+    # capture (minlength is a Python int, materialised host-side). Use
+    # ``scatter_add_`` on a pre-zeroed device tensor instead — identical
+    # semantics, fully graph-capturable.
+    num_tokens_per_expert = torch.zeros(
+        self.num_experts, dtype=torch.int64, device=flat_top_k.device
+    )
+    num_tokens_per_expert.scatter_add_(
+        0, flat_top_k, torch.ones_like(flat_top_k, dtype=torch.int64)
+    )
+    num_tokens_per_expert = num_tokens_per_expert.int()
 
     # 2. Sort indices to group tokens by expert
     sorted_indices = torch.argsort(flat_top_k, stable=True)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -911,8 +911,18 @@ def forward_native_grouped_mm(
             mm1_out = mm1_out + lora_delta * scaling
 
         if hasattr(self, "gate_up_proj_bias") and self.gate_up_proj_bias is not None:
-            num_repeats = num_tokens_per_expert.to(self.gate_up_proj_bias.device)
-            bias_expanded = self.gate_up_proj_bias.repeat_interleave(num_repeats, dim=0)
+            # ``repeat_interleave(counts_tensor)`` forces a GPU→CPU sync
+            # (output size depends on ``counts.sum().item()``) which
+            # breaks CUDA graph capture on gpt-oss's bias path. Gather
+            # per-token from the already-computed permutation instead:
+            # after ``sorted_indices = argsort(flat_top_k)``, the expert
+            # id for each permuted position is just
+            # ``flat_top_k[sorted_indices]``. ``index_select`` is
+            # capturable.
+            sorted_expert_ids = flat_top_k[sorted_indices].to(torch.long)
+            bias_expanded = self.gate_up_proj_bias.index_select(
+                0, sorted_expert_ids.to(self.gate_up_proj_bias.device),
+            )
             mm1_out = mm1_out + bias_expanded.to(mm1_out.dtype)
 
         if "GptOssExperts" in self.__class__.__name__:
@@ -1042,8 +1052,10 @@ def forward_native_grouped_mm(
             mm2_out = mm2_out + lora_delta * scaling
 
         if hasattr(self, "down_proj_bias") and self.down_proj_bias is not None:
-            bias_expanded = self.down_proj_bias.repeat_interleave(
-                num_tokens_per_expert.to(self.down_proj_bias.device), dim=0
+            # Capture-safe gather; see comment on gate_up_proj_bias above.
+            sorted_expert_ids = flat_top_k[sorted_indices].to(torch.long)
+            bias_expanded = self.down_proj_bias.index_select(
+                0, sorted_expert_ids.to(self.down_proj_bias.device),
             ).to(mm2_out.device)
             mm2_out = mm2_out + bias_expanded.to(mm2_out.dtype)
 

--- a/unsloth_zoo/temporary_patches/qwen3_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe.py
@@ -39,6 +39,8 @@ from .utils import (
 from .moe_utils import (
     patch_param_wrapper_for_moe,
     get_forward_moe_backend,
+    select_moe_backend,
+    forward_native_grouped_mm,
 )
 
 
@@ -69,11 +71,31 @@ def _make_qwen_moe_lora_extractor():
 
 
 def _make_qwen_moe_experts_forward(module_name: Optional[str] = None):
+    # Resolve the MoE backend once at patch time. For grouped_mm we bind
+    # ``forward_native_grouped_mm`` directly so the decode hot path has no
+    # per-token ``select_moe_backend()`` dispatch and presents a stable
+    # callable to ``torch.compile`` / CUDA graph capture. Other backends
+    # keep the generic dispatcher (``forward_moe_backend``) which still
+    # benefits from the ``lru_cache`` on ``select_moe_backend``.
+    backend = select_moe_backend()
+    if backend == "grouped_mm":
+        def forward(self, hidden_states, top_k_index, top_k_weights):
+            return forward_native_grouped_mm(self, hidden_states, top_k_index, top_k_weights)
+        return forward
     return get_forward_moe_backend()
 
 
 def _make_qwen_moe_sparse_moe_block_forward(use_shared_expert: bool, module_name: Optional[str] = None):
-    @torch.compiler.disable
+    # The legacy expert-loop path (``forward_native_moe_loop``) uses
+    # ``torch.where`` + a Python for-loop over experts and is genuinely
+    # uncapturable — keep ``@torch.compiler.disable`` when that backend
+    # is selected. On ``grouped_mm`` with pre-merged LoRA the sparse
+    # block is Dynamo-clean (no ``.item()``, no Python loops, no
+    # mutation), so we omit the decorator and let ``torch.compile``
+    # trace through the whole block for prefill.
+    _backend = select_moe_backend()
+    _compile_safe = _backend == "grouped_mm"
+
     def sparse_moe_block_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         use_shared_expert = hasattr(self, "shared_expert") and hasattr(self, "shared_expert_gate")
         if hidden_states.dim() == 3:
@@ -115,6 +137,8 @@ def _make_qwen_moe_sparse_moe_block_forward(use_shared_expert: bool, module_name
 
     if module_name is not None:
         sparse_moe_block_forward.__module__ = module_name
+    if not _compile_safe:
+        sparse_moe_block_forward = torch.compiler.disable(sparse_moe_block_forward)
     return sparse_moe_block_forward
 
 

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -279,6 +279,27 @@ class WorkerLoRAManager(AbstractWorkerManager):
         else:
             return set(self._adapter_manager.list_adapters())
 
+    def get_dummy_lora_warmup_rank(self, default_rank: int) -> int:
+        # vLLM v1 (lora_model_runner_mixin.maybe_setup_dummy_loras) calls
+        # this during cudagraph warmup; delegate to the adapter manager,
+        # fall back to default_rank if the underlying implementation
+        # predates this helper.
+        manager_fn = getattr(
+            self._adapter_manager, "get_dummy_lora_warmup_rank", None
+        )
+        if manager_fn is not None:
+            return manager_fn(default_rank)
+        return default_rank
+
+    def supports_tower_connector_lora(self) -> bool:
+        # New v1 call; match upstream WorkerLoRAManager semantics.
+        return (
+            getattr(self._adapter_manager, "supports_mm", False)
+            and getattr(
+                self._adapter_manager, "supports_tower_connector_lora", False
+            )
+        )
+
 
 # from vllm try to import WorkerLoRAManager
 try:

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1474,9 +1474,18 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
 
     text_config = getattr(config, "text_config", config) #try using text config for VLMs
     vision_config = getattr(config, "vision_config", None)
+    # why: Gemma 4's Gemma4TextRotaryEmbedding stores rope_parameters as a
+    # nested dict keyed by layer_type ({full_attention: {...},
+    # sliding_attention: {...}}). Its ``__init__`` expects a ``layer_type``
+    # kwarg to pick the right sub-dict; without it the class falls back to
+    # ``config.rope_parameters["rope_type"]`` and raises KeyError. Skip the
+    # rotary re-init for gemma4 — the rotary buffer is already loaded
+    # correctly from the vLLM weights.
+    _text_model_type = getattr(text_config, "model_type", None)
+    _skip_rotary_reinit = _text_model_type in ("gemma4", "gemma4_text")
     # Fix up rotary_emb by re-initing them
     for module in new_model.modules():
-        if hasattr(module, "rotary_emb"):
+        if hasattr(module, "rotary_emb") and not _skip_rotary_reinit:
             module.rotary_emb = module.rotary_emb.__class__(
                 config = text_config,
                 device = get_target_device(),

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2062,9 +2062,21 @@ def load_vllm(
         # In vLLM profiling, each sequence contributes to an image. Which is generally in the order of thousand tokens.
         # We don't want to go beyond 16 sequences for vision models.
         # TODO: In vLLM V1, iirc, the profiling sets a cap on the max seqs based on the budget. Check it out.
-        print(f'Unsloth: Vision model detected, setting approx_max_num_seqs to 1')
-        # [TODO] Check this
-        approx_max_num_seqs = 1
+        # The 1-seq cap is correct when the workload includes images (each seq
+        # carries thousands of vision tokens). For text-only workloads on
+        # multimodal models (e.g. Gemma 4 text generation), respect the
+        # caller's explicit max_num_seqs so batching can still scale.
+        _explicit_vllm_max_num_seqs = max_num_seqs not in (None, 256)
+        if _explicit_vllm_max_num_seqs:
+            approx_max_num_seqs = max_num_seqs
+            print(
+                f'Unsloth: Vision model detected; honoring explicit '
+                f'max_num_seqs={max_num_seqs} for text-only use.'
+            )
+        else:
+            print(f'Unsloth: Vision model detected, setting approx_max_num_seqs to 1')
+            # [TODO] Check this
+            approx_max_num_seqs = 1
         # Single image would contribute to 6404 tokens in Llama 3.2 for eg. So have some more for text
         # For qwen 2.5 VL, this single image/video contributes to 16Ki tokens
         max_num_batched_tokens = max(8192, max_seq_length)

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1408,6 +1408,16 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                 # LayerNorms (including vision norms)
                 weight_param = torch.nn.Parameter(weight, requires_grad=False)
                 layer_name_br = re.sub(r"\.([\d]{1,})\.", r"[\1].", layer_name)
+                # Some Gemma 4 variants (E2B / E4B with num_kv_shared_layers > 0)
+                # drop k_norm on shared-KV layers — the HF empty model doesn't
+                # register the attribute at all, so a blind exec() AttributeErrors
+                # out. Check the parent actually has the attribute before setting.
+                _ns = {"new_model": new_model}
+                try:
+                    _target = eval(f"new_model.{layer_name_br}", _ns)
+                except AttributeError:
+                    skipped_layernorms.append(layer_name.split(".")[-1])
+                    continue
                 # Set weight
                 exec(f"new_model.{layer_name_br}.weight = None")
                 exec(f"new_model.{layer_name_br}.weight = weight_param")

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1119,22 +1119,46 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
             get_state_dict(f"{prefix}.q_proj", 0, state_dict, q_proj)
             get_state_dict(f"{prefix}.k_proj", 1, state_dict, kv_proj)
             get_state_dict(f"{prefix}.v_proj", 2, state_dict, kv_proj)
-
-        get_state_dict(f"{prefix}.o_proj", 0, state_dict, o_proj)
-
-        proj = layer.mlp.gate_up_proj
-        use_fused_gate_up = _is_fused_module("gate_up_proj")
-        if use_fused_gate_up:
-            # For some model types like phi3 vllm will expect fused gate_up_proj (e.g. Phi3, Phi3.5-mini-instruct, Phi4-mini-instruct)
-            # so we should not split them here otherwise there will be a size mismatch when activating the adapter
-            # see https://github.com/vllm-project/vllm/blob/9b693d023cf595e60b5346fdeeb41cf2a6eda838/vllm/model_executor/models/phi3.py
-            get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.gate_up_proj", 0, state_dict, proj, slice_weights=False)
+        elif hasattr(layer, "linear_attn"):
+            # Qwen3.5 / Qwen3.6 Gated DeltaNet layer. No q/k/v/o_proj —
+            # linear attention uses in_proj_qkv (fused), in_proj_z,
+            # in_proj_b, in_proj_a, conv1d, out_proj plus A_log, dt_bias,
+            # norm. These are not PEFT LoRA targets by default and have
+            # incompatible shapes for the q_proj/k_proj/v_proj/o_proj
+            # slicing path. Skip attention weight extraction for this
+            # layer type; MLP + layernorms still extracted below.
+            prefix = f"{vllm_text_model_prefix}.layers.{kk}.linear_attn"
+            o_proj = None
         else:
-            get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.gate_proj", 0, state_dict, proj)
-            get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.up_proj",   1, state_dict, proj)
+            # Unknown layer type; skip attention weights.
+            prefix = f"{vllm_text_model_prefix}.layers.{kk}.self_attn"
+            o_proj = None
 
-        proj = layer.mlp.down_proj
-        get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.down_proj", 0, state_dict, proj)
+        if o_proj is not None:
+            get_state_dict(f"{prefix}.o_proj", 0, state_dict, o_proj)
+
+        # Qwen3.5-MoE / Qwen3.6-35B-A3B and similar MoE-on-Qwen3Next blocks
+        # replace the dense MLP with a Qwen3NextSparseMoeBlock that has
+        # `.gate`, `.shared_expert`, `.experts` instead of gate_up_proj /
+        # down_proj. The standard dense extraction below cannot handle
+        # fused expert weights. Skip MLP weight extraction for MoE blocks
+        # and let vLLM's own weights drive inference; layernorms are still
+        # extracted below so the converted HF shell is structurally valid.
+        _is_moe_block = not hasattr(layer.mlp, "gate_up_proj")
+        if not _is_moe_block:
+            proj = layer.mlp.gate_up_proj
+            use_fused_gate_up = _is_fused_module("gate_up_proj")
+            if use_fused_gate_up:
+                # For some model types like phi3 vllm will expect fused gate_up_proj (e.g. Phi3, Phi3.5-mini-instruct, Phi4-mini-instruct)
+                # so we should not split them here otherwise there will be a size mismatch when activating the adapter
+                # see https://github.com/vllm-project/vllm/blob/9b693d023cf595e60b5346fdeeb41cf2a6eda838/vllm/model_executor/models/phi3.py
+                get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.gate_up_proj", 0, state_dict, proj, slice_weights=False)
+            else:
+                get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.gate_proj", 0, state_dict, proj)
+                get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.up_proj",   1, state_dict, proj)
+
+            proj = layer.mlp.down_proj
+            get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.down_proj", 0, state_dict, proj)
 
         # Use layernorms from the layer configuration
         layernorm_names = [name.format(kk=kk) for name in layer_config['layernorms']]
@@ -1518,7 +1542,15 @@ def approximate_vllm_memory_usage(
     vocab_size = config.vocab_size
     hd = config.hidden_size
     context_length = config.max_position_embeddings
-    mlp_size = config.intermediate_size
+    # Qwen3.5-MoE / Qwen3.6-35B-A3B expose `moe_intermediate_size` on the
+    # text config and leave `intermediate_size` unset. Use moe size when the
+    # dense field is missing so the VRAM estimator picks a sensible number
+    # (active-expert MLP is the right proxy for the per-token cost).
+    mlp_size = getattr(config, "intermediate_size", None)
+    if mlp_size is None:
+        mlp_size = getattr(config, "moe_intermediate_size", None)
+    if mlp_size is None:
+        mlp_size = 4 * hd  # conservative fallback
     n_layers = config.num_hidden_layers
     n_kv_heads = getattr(config, "num_key_value_heads", 1)
     n_heads    = getattr(config, "num_attention_heads", 1)
@@ -1780,6 +1812,34 @@ def load_vllm(
     assert(config is not None)
     assert(type(use_bitsandbytes) is bool)
     assert(conservativeness >= 0.0 and conservativeness <= 1.0)
+
+    # Invoke per-arch vLLM LoRA patches before vLLM builds the LoRA manager.
+    # why: vLLM's MoE + LoRA path (vllm.lora.utils.process_packed_modules_mapping
+    # + lora_model_manager.LoRAModelManager.__init__) calls
+    # ``get_expert_mapping`` on the top-level model and its first-level
+    # children. The multimodal outer wrappers
+    # (Gemma4ForConditionalGeneration, Qwen3_5MoeForConditionalGeneration)
+    # do not ship this method upstream, and the inner *ForCausalLM only
+    # ships it for some archs. Patch before manager construction so we
+    # don't hit AttributeError inside __init__.
+    _gemma4_model_types = ("gemma4", "gemma4_text")
+    _qwen3_5_model_types = ("qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text")
+    _outer_model_type = getattr(config, "model_type", None)
+    _text_model_type = getattr(getattr(config, "text_config", None), "model_type", None)
+    if _outer_model_type in _gemma4_model_types or _text_model_type in _gemma4_model_types:
+        # why: Gemma4 E2B/E4B release checkpoints carry audio_config even for text/image inference.
+        # audio_tower weights are not extracted, so deepcopy+strip audio_config prevents the
+        # rebuilt HF model from instantiating a silently-uninitialized audio_tower.
+        if _outer_model_type == "gemma4" and getattr(config, "audio_config", None) is not None:
+            if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
+                print("Unsloth: Gemma4 audio_tower weights are not extracted; audio-capable inference is not supported. Stripping audio_config to prevent a silently-uninitialized audio_tower.")
+            config = deepcopy(config)
+            config.audio_config = None
+        if is_vision_model and _outer_model_type == "gemma4":
+            patch_gemma4_vllm_lora_support()
+            patch_gemma4_vllm_k_eq_v_support()
+    if _outer_model_type in _qwen3_5_model_types or _text_model_type in _qwen3_5_model_types:
+        patch_qwen3_5_vllm_lora_support()
 
     unsloth_vllm_standby = unsloth_vllm_standby or (os.getenv("UNSLOTH_VLLM_STANDBY", "0") != "0")
     # This would give the flexibility to override the util we set for standby mode. In some extreme cases, this can be helpful.


### PR DESCRIPTION
## Summary

Drops two patch-time escape hatches on the `grouped_mm` MoE backend so Qwen3 MoE decode can be captured into a CUDA graph end-to-end. Needed by unslothai/unsloth#5123's new `FlexMoEInference` capture path — without these, CUDA graph capture trips on a CPU→CUDA scalar copy inside `torch.bincount(..., minlength=python_int)`.

1. `qwen3_moe.py`: `_make_qwen_moe_experts_forward` resolves the backend once at patch time. On `grouped_mm` it returns a closure that calls `forward_native_grouped_mm` directly, eliminating the per-forward `select_moe_backend()` dispatch. Other backends keep the generic `forward_moe_backend` dispatcher.

2. `qwen3_moe.py`: `_make_qwen_moe_sparse_moe_block_forward` only wraps the result in `@torch.compiler.disable` when the resolved backend is NOT `grouped_mm`. On `grouped_mm` with pre-merged LoRA the block is Dynamo-clean (no `.item()`, no Python loops over experts, no mutation) and should compile as-is. The decorator is still applied unconditionally for `unsloth_triton` and `native_torch` since those backends use the legacy expert-loop path.

3. `moe_utils.py::forward_native_grouped_mm`: replace `torch.bincount(flat_top_k, minlength=num_experts)` with an equivalent `torch.zeros(...).scatter_add_(0, flat_top_k, torch.ones_like(flat_top_k))`. `bincount`'s `minlength` is a Python int; under CUDA graph capture this triggers a host-side scalar materialisation and fails with `Cannot copy between CPU and CUDA tensors during CUDA graph capture`. `scatter_add_` on a pre-zeroed device tensor is identical semantically and fully graph-capturable.

## Benchmarks

Qwen3-30B-A3B-Instruct-2507, bs=8 × 64 new tokens on a single B200, with unslothai/unsloth#5123's FlexMoEInference CUDA graph decode enabled.

| precision | pure HF naive | Flex + CUDA graphs | speedup |
|-----------|--------------:|-------------------:|--------:|
| 4bit      | 66.7 tok/s    | 374.3 tok/s        | 5.6x    |
| bf16      | 101.1 tok/s   | 421.6 tok/s        | 4.2x    |

Greedy parity:
- flex-captured is bit-exact to flex-eager: 32/32 tokens × 3 prompts at 4bit
- flex-captured vs pure transformers.AutoModelForCausalLM: 32/32 on 5 out of 6 (prompt × precision) pairs; the remaining divergence is a tie-break logit boundary on an open-ended continuation, both outputs coherent English

GRPO 5-step smoke: 4bit 548.3s peak 130.9 GB, bf16 451.8s peak 133.4 GB, loss / KL stable, no NaN.

## Test plan

- [x] UNSLOTH_MOE_BACKEND=grouped_mm smoke: Qwen3 MoE generates coherent text at 36.5 tok/s warm (4bit) / 36.4 tok/s (bf16) through FlexMoEInference with CUDA graphs
- [x] UNSLOTH_MOE_BACKEND=native_torch: unchanged behavior (decorator still applied, legacy loop still disabled from compile)
- [x] bincount → scatter_add_ produces identical num_tokens_per_expert counts (verified by decode parity against pre-change eager)
- [x] GRPO 5-step training runs to completion on both 4bit and bf16 with no divergence