### PR TITLE
fix(temporary_patches/utils): add missing comma in __all__ (raise_error / Unpack)

### DIFF
--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -20,7 +20,7 @@ __all__ = [
     "process_return",
     "process_output_options",
     "KWARGS_TYPE",
-    "raise_error"
+    "raise_error",
     "Unpack",
     "Cache",
     "DynamicCache",


### PR DESCRIPTION
## Problem

In `unsloth_zoo/temporary_patches/utils.py`, the `__all__` list has a missing comma between `"raise_error"` and `"Unpack"`:

```python
__all__ = [
    ...
    "KWARGS_TYPE",
    "raise_error"     # ← missing trailing comma
    "Unpack",
    ...
]
```

Python's [implicit string concatenation](https://docs.python.org/3/reference/lexical_analysis.html#string-literal-concatenation) merges adjacent string literals at compile time, so `"raise_error" "Unpack"` becomes the single string `"raise_errorUnpack"`. The list ends up with that bogus entry instead of two separate exports.

This means:
- `Unpack` is silently dropped from the module's public API (so `from unsloth_zoo.temporary_patches.utils import Unpack` fails)
- `__all__` advertises a non-existent `raise_errorUnpack` symbol

Reported in [unsloth#5247](https://github.com/unslothai/unsloth/issues/5247).

## Fix

Add the missing trailing comma after `"raise_error"`. One-character change, no behavior change beyond restoring the intended exports.

After the fix, `__all__` evaluates to:

```python
['patch_function', 'patch_function_past_key_values', 'process_return',
 'process_output_options', 'KWARGS_TYPE', 'raise_error', 'Unpack',
 'Cache', 'DynamicCache', 'HybridCache', 'StaticCache', ...]
```

Both `raise_error` (defined in this file) and `Unpack` (re-exported from `typing` / `typing_extensions`) are now correctly exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
