### PR TITLE
Fix qwen lora extractor for diff peft versions

### DIFF
--- a/test_forward_native_moe_loop_lora.py
+++ b/test_forward_native_moe_loop_lora.py
@@ -1,0 +1,220 @@
+"""Regression tests for forward_native_moe_loop LoRA application.
+
+These tests cover the gate_up_proj and down_proj transpose-on-mismatch checks
+plus the once-per-forward dtype pre-cast that PR #618 introduces. They are
+PEFT-version-agnostic: they construct LoRA factors by hand in the same shape
+the extractor would produce, then verify that
+
+    forward_native_moe_loop(experts, x, top_k_idx, top_k_weights)
+
+produces the same per-expert output as the naive reference
+
+    base_out + (X @ first[e]) @ second[e] * scaling
+
+for both the canonical (E, 2*I, H) / (E, H, I) Qwen3-MoE storage AND the
+transposed (E, H, 2*I) / (E, I, H) Qwen3-VL-MoE storage.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from unsloth_zoo.temporary_patches.moe_utils import forward_native_moe_loop
+
+
+def _build_experts(num_experts, hidden, intermediate, transposed_storage):
+    """Build a minimal `experts` module that exposes the surface area
+    `forward_native_moe_loop` reads."""
+    experts = nn.Module()
+    experts.num_experts = num_experts
+    if transposed_storage:
+        # Qwen3-VL-MoE layout: (E, in, out) ready for grouped_mm
+        experts.gate_up_proj = nn.Parameter(
+            torch.randn(num_experts, hidden, 2 * intermediate, dtype=torch.float32)
+        )
+        experts.down_proj = nn.Parameter(
+            torch.randn(num_experts, intermediate, hidden, dtype=torch.float32)
+        )
+    else:
+        # Qwen3-MoE / Qwen3.5 / Qwen3-Next standard F.linear layout: (E, out, in)
+        experts.gate_up_proj = nn.Parameter(
+            torch.randn(num_experts, 2 * intermediate, hidden, dtype=torch.float32)
+        )
+        experts.down_proj = nn.Parameter(
+            torch.randn(num_experts, hidden, intermediate, dtype=torch.float32)
+        )
+    experts.act_fn = F.silu
+    return experts
+
+
+def _build_lora_for(experts, rank, scaling):
+    """Build (first_weight, second_weight, scaling) tuples in the layout
+    that `_make_qwen_moe_lora_extractor` returns: first=(E, in, R), second=(E, R, out).
+    """
+    E = experts.num_experts
+    if experts.gate_up_proj.shape[1] == 2 * (experts.down_proj.shape[1] if experts.down_proj.shape[1] != experts.gate_up_proj.shape[2] else experts.down_proj.shape[2]):
+        # Heuristic that holds for both layouts in this test
+        pass
+    # Derive in/out from the actual base shape to stay layout-agnostic
+    if experts.gate_up_proj.shape[1] > experts.gate_up_proj.shape[2]:
+        # standard (E, 2*I, H)
+        gate_up_in = experts.gate_up_proj.shape[2]
+        gate_up_out = experts.gate_up_proj.shape[1]
+    else:
+        # transposed (E, H, 2*I)
+        gate_up_in = experts.gate_up_proj.shape[1]
+        gate_up_out = experts.gate_up_proj.shape[2]
+    gate_up = (
+        torch.randn(E, gate_up_in, rank, dtype=torch.float32),
+        torch.randn(E, rank, gate_up_out, dtype=torch.float32),
+        scaling,
+    )
+
+    if experts.down_proj.shape[1] > experts.down_proj.shape[2]:
+        # standard (E, H, I)
+        down_in = experts.down_proj.shape[2]
+        down_out = experts.down_proj.shape[1]
+    else:
+        # transposed (E, I, H)
+        down_in = experts.down_proj.shape[1]
+        down_out = experts.down_proj.shape[2]
+    down = (
+        torch.randn(E, down_in, rank, dtype=torch.float32),
+        torch.randn(E, rank, down_out, dtype=torch.float32),
+        scaling,
+    )
+    return gate_up, down
+
+
+def _naive_forward(experts, hidden_states, top_k_index, top_k_weights, gate_up_lora, down_lora):
+    """Reference implementation that mirrors forward_native_moe_loop without
+    the under-test transpose / pre-cast logic. Used as ground truth.
+    """
+    E = experts.num_experts
+    out = torch.zeros_like(hidden_states)
+    expert_mask = F.one_hot(top_k_index, num_classes=E).permute(2, 1, 0)
+    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+    for ei_t in expert_hit:
+        ei = ei_t.item()
+        top_k_pos, token_idx = torch.where(expert_mask[ei])
+        x = hidden_states[token_idx]
+
+        gu_w = experts.gate_up_proj[ei]
+        if gu_w.shape[-1] != x.shape[-1]:
+            gu_w = gu_w.T
+        gu = F.linear(x, gu_w)
+        if gate_up_lora is not None:
+            f, s, sc = gate_up_lora
+            gu = gu + ((x @ f[ei]) @ s[ei]) * sc
+
+        gate, up = gu.chunk(2, dim=-1)
+        h = experts.act_fn(gate) * up
+
+        d_w = experts.down_proj[ei]
+        if d_w.shape[-1] != h.shape[-1]:
+            d_w = d_w.T
+        d = F.linear(h, d_w)
+        if down_lora is not None:
+            f, s, sc = down_lora
+            d = d + ((h @ f[ei]) @ s[ei]) * sc
+
+        d = d * top_k_weights[token_idx, top_k_pos, None]
+        out.index_add_(0, token_idx, d.to(out.dtype))
+    return out
+
+
+@pytest.mark.parametrize("transposed_storage", [False, True],
+                         ids=["canonical_storage", "transposed_storage"])
+def test_forward_native_moe_loop_with_lora_matches_naive(transposed_storage):
+    torch.manual_seed(0)
+    num_experts = 4
+    hidden = 32
+    intermediate = 24
+    rank = 4
+    num_tokens = 7
+    top_k = 2
+
+    experts = _build_experts(num_experts, hidden, intermediate, transposed_storage)
+    gate_up_lora, down_lora = _build_lora_for(experts, rank, scaling=2.0)
+
+    # Stash the LoRA tensors where forward_native_moe_loop expects them.
+    experts._unsloth_lora_gate_up_proj = gate_up_lora
+    experts._unsloth_lora_down_proj = down_lora
+
+    hidden_states = torch.randn(num_tokens, hidden, dtype=torch.float32)
+    top_k_index = torch.randint(0, num_experts, (num_tokens, top_k))
+    top_k_weights = torch.softmax(torch.randn(num_tokens, top_k), dim=-1)
+
+    out = forward_native_moe_loop(experts, hidden_states, top_k_index, top_k_weights)
+    ref = _naive_forward(experts, hidden_states, top_k_index, top_k_weights,
+                         gate_up_lora, down_lora)
+
+    torch.testing.assert_close(out, ref, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("transposed_storage", [False, True],
+                         ids=["canonical_storage", "transposed_storage"])
+def test_forward_native_moe_loop_no_lora_matches_naive(transposed_storage):
+    """Same but without LoRA. Confirms the down_proj transpose-on-mismatch
+    check (gemini HIGH) does not break the LoRA-disabled path.
+    """
+    torch.manual_seed(1)
+    num_experts = 3
+    hidden = 16
+    intermediate = 12
+    num_tokens = 5
+    top_k = 2
+
+    experts = _build_experts(num_experts, hidden, intermediate, transposed_storage)
+    hidden_states = torch.randn(num_tokens, hidden, dtype=torch.float32)
+    top_k_index = torch.randint(0, num_experts, (num_tokens, top_k))
+    top_k_weights = torch.softmax(torch.randn(num_tokens, top_k), dim=-1)
+
+    out = forward_native_moe_loop(experts, hidden_states, top_k_index, top_k_weights)
+    ref = _naive_forward(experts, hidden_states, top_k_index, top_k_weights,
+                         None, None)
+
+    torch.testing.assert_close(out, ref, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16],
+                         ids=["fp32", "bf16", "fp16"])
+def test_forward_native_moe_loop_lora_dtype_precast_no_loop_alloc(dtype):
+    """Ensure the new pre-cast (LoRA factors cast to hidden_states.dtype once
+    before the per-expert loop) produces correct output across dtypes."""
+    torch.manual_seed(2)
+    num_experts = 3
+    hidden = 16
+    intermediate = 12
+    rank = 2
+    num_tokens = 6
+    top_k = 2
+
+    experts = _build_experts(num_experts, hidden, intermediate, False)
+    gate_up_lora, down_lora = _build_lora_for(experts, rank, scaling=1.5)
+    # Cast everything (params + lora) to the target dtype.
+    experts.gate_up_proj.data = experts.gate_up_proj.data.to(dtype)
+    experts.down_proj.data = experts.down_proj.data.to(dtype)
+    experts._unsloth_lora_gate_up_proj = (
+        gate_up_lora[0].to(dtype), gate_up_lora[1].to(dtype), gate_up_lora[2],
+    )
+    experts._unsloth_lora_down_proj = (
+        down_lora[0].to(dtype), down_lora[1].to(dtype), down_lora[2],
+    )
+
+    hidden_states = torch.randn(num_tokens, hidden, dtype=dtype)
+    top_k_index = torch.randint(0, num_experts, (num_tokens, top_k))
+    top_k_weights = torch.softmax(torch.randn(num_tokens, top_k), dim=-1).to(dtype)
+
+    out = forward_native_moe_loop(experts, hidden_states, top_k_index, top_k_weights)
+    ref = _naive_forward(experts, hidden_states, top_k_index, top_k_weights,
+                         experts._unsloth_lora_gate_up_proj,
+                         experts._unsloth_lora_down_proj)
+
+    # Looser tolerance for low-precision dtypes
+    atol = 1e-4 if dtype == torch.float32 else 1e-1
+    rtol = 1e-4 if dtype == torch.float32 else 1e-1
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+    assert out.dtype == dtype

--- a/test_forward_native_moe_loop_lora.py
+++ b/test_forward_native_moe_loop_lora.py
@@ -179,6 +179,60 @@ def test_forward_native_moe_loop_no_lora_matches_naive(transposed_storage):
     torch.testing.assert_close(out, ref, atol=1e-4, rtol=1e-4)
 
 
+def test_forward_native_moe_loop_square_dim_uses_grouped_mm_flag():
+    """When `intermediate_dim == hidden_dim`, the shape-based transpose check
+    cannot tell which orientation the per-expert weight is stored in. The
+    explicit `_unsloth_grouped_mm_format` flag must take precedence so that
+    transposed storage is detected even at square dims.
+    """
+    torch.manual_seed(13)
+    num_experts = 3
+    dim = 16  # hidden == intermediate, so 2*intermediate == 2*hidden
+    rank = 2
+    num_tokens = 5
+    top_k = 2
+
+    # Use intermediate = dim so that down_proj is (E, dim, dim) — square.
+    # gate_up_proj is (E, 2*dim, dim) which is non-square so easy.
+    intermediate = dim
+    hidden = dim
+
+    experts = nn.Module()
+    experts.num_experts = num_experts
+    # Transposed (grouped_mm) storage:
+    experts.gate_up_proj = nn.Parameter(
+        torch.randn(num_experts, hidden, 2 * intermediate, dtype=torch.float32)
+    )
+    experts.down_proj = nn.Parameter(
+        torch.randn(num_experts, intermediate, hidden, dtype=torch.float32)
+    )
+    experts.act_fn = F.silu
+    experts._unsloth_grouped_mm_format = True
+
+    hidden_states = torch.randn(num_tokens, hidden, dtype=torch.float32)
+    top_k_index = torch.randint(0, num_experts, (num_tokens, top_k))
+    top_k_weights = torch.softmax(torch.randn(num_tokens, top_k), dim=-1)
+
+    out = forward_native_moe_loop(experts, hidden_states, top_k_index, top_k_weights)
+
+    # Reference manually transposes both weights regardless of shape.
+    ref = torch.zeros_like(hidden_states)
+    expert_mask = F.one_hot(top_k_index, num_classes=num_experts).permute(2, 1, 0)
+    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+    for ei_t in expert_hit:
+        ei = ei_t.item()
+        top_k_pos, token_idx = torch.where(expert_mask[ei])
+        x = hidden_states[token_idx]
+        gu = F.linear(x, experts.gate_up_proj[ei].T)
+        g, u = gu.chunk(2, dim=-1)
+        h = experts.act_fn(g) * u
+        d = F.linear(h, experts.down_proj[ei].T)
+        d = d * top_k_weights[token_idx, top_k_pos, None]
+        ref.index_add_(0, token_idx, d.to(ref.dtype))
+
+    torch.testing.assert_close(out, ref, atol=1e-4, rtol=1e-4)
+
+
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16],
                          ids=["fp32", "bf16", "fp16"])
 def test_forward_native_moe_loop_lora_dtype_precast_no_loop_alloc(dtype):

--- a/test_qwen_moe_lora_extractor.py
+++ b/test_qwen_moe_lora_extractor.py
@@ -153,6 +153,97 @@ def test_shared_factory_used_by_qwen3_5_and_next():
     assert qnx._make_qwen_moe_lora_extractor is _make_qwen_moe_lora_extractor
 
 
+class _SquareWrapper:
+    """Wrapper for the input_dim == output_dim ambiguity test.
+
+    Sets `_did_swap_in_out_features` to mimic what PEFT 0.19 sets after the
+    swap, so the extractor can disambiguate.
+    """
+    def __init__(self, parameter_name, dim, did_swap):
+        self.parameter_name = parameter_name
+        self.base_layer = type("_Base", (), {})()
+        if parameter_name == "down_proj":
+            # down_proj: (E, hidden_dim, intermediate_dim). Force in == out by
+            # setting intermediate_dim == hidden_dim.
+            self.base_layer.intermediate_dim = dim
+            self.base_layer.hidden_dim = dim
+        elif parameter_name == "gate_up_proj":
+            # gate_up_proj: input_dim = hidden_dim, output_dim = 2*intermediate_dim.
+            # Make square by intermediate_dim = hidden_dim/2.
+            self.base_layer.hidden_dim = dim
+            self.base_layer.intermediate_dim = dim // 2
+        self._did_swap_in_out_features = did_swap
+
+    def get_base_layer(self):
+        return self.base_layer
+
+
+@pytest.mark.parametrize("did_swap", [False, True], ids=["peft018", "peft019_swapped"])
+def test_extractor_disambiguates_square_dims_via_did_swap(did_swap):
+    """When input_dim == output_dim both branch predicates match. The extractor
+    must use `_did_swap_in_out_features` to pick the correct branch.
+    """
+    ext = _make_qwen_moe_lora_extractor()
+    E, R, dim = 4, 3, 16
+    torch.manual_seed(7)
+    wA = torch.randn(E * R, dim)
+    wB = torch.randn(dim, E * R)
+    wrapper = _SquareWrapper("down_proj", dim, did_swap=did_swap)
+    first, second, scaling, num_experts = ext(wrapper, wA, wB, 1.0, E)
+    assert first.shape == (E, dim, R)
+    assert second.shape == (E, R, dim)
+
+    # Reference: under PEFT 0.18 the reshape is the canonical permutation;
+    # under PEFT 0.19 swapped, weight_A and weight_B roles are flipped.
+    x = torch.randn(5, dim)
+    for e in range(E):
+        Ae = wA[e * R : (e + 1) * R]
+        Be = wB[:, e * R : (e + 1) * R]
+        if did_swap:
+            naive = x @ Be @ Ae   # PEFT 0.19 reversed
+        else:
+            naive = x @ Ae.T @ Be.T  # PEFT 0.18 canonical
+        via = (x @ first[e]) @ second[e]
+        torch.testing.assert_close(via, naive, atol=1e-4, rtol=1e-4)
+
+
+def test_extractor_fallback_warns_when_dims_mismatch(caplog):
+    """When neither branch matches, the extractor must warn before falling
+    through to the canonical permutation. Guards against the silent PR #601
+    failure mode resurfacing.
+    """
+    import logging
+
+    ext = _make_qwen_moe_lora_extractor()
+    E, R, in_dim, out_dim = 4, 3, 16, 24
+    torch.manual_seed(11)
+
+    # Build a wrapper that reports plausible dims but supplies LoRA factors
+    # whose shapes match neither branch (simulates a future PEFT layout).
+    wrapper = _Wrapper("gate_up_proj", (E, 2 * 16, in_dim))
+    weird_dim = 99
+    wA = torch.randn(E * R, weird_dim)
+    wB = torch.randn(weird_dim, E * R)
+
+    # The warning is gated on UNSLOTH_ENABLE_LOGGING; force-enable for the test.
+    import unsloth_zoo.temporary_patches.qwen3_moe as qwen3_moe_mod
+    prev = qwen3_moe_mod.UNSLOTH_ENABLE_LOGGING
+    try:
+        qwen3_moe_mod.UNSLOTH_ENABLE_LOGGING = True
+        with caplog.at_level(logging.WARNING):
+            first, second, *_ = ext(wrapper, wA, wB, 1.0, E)
+    finally:
+        qwen3_moe_mod.UNSLOTH_ENABLE_LOGGING = prev
+
+    assert first.shape == (E, weird_dim, R)
+    assert second.shape == (E, R, weird_dim)
+    # At least one warning record mentions the extractor.
+    assert any(
+        "Qwen MoE LoRA extractor could not match either layout" in rec.getMessage()
+        for rec in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+
 def test_extractor_output_not_aliasing_input():
     ext = _make_qwen_moe_lora_extractor()
     E, R, in_dim, out_dim = 2, 2, 8, 16

--- a/test_qwen_moe_lora_extractor.py
+++ b/test_qwen_moe_lora_extractor.py
@@ -4,6 +4,46 @@ import torch
 from unsloth_zoo.temporary_patches.qwen3_moe import _make_qwen_moe_lora_extractor
 
 
+class _Wrapper:
+    def __init__(self, parameter_name, shape):
+        self.parameter_name = parameter_name
+        self.base_layer = type("_Base", (), {})()
+        if parameter_name == "gate_up_proj":
+            self.base_layer.hidden_dim = shape[2]
+            self.base_layer.intermediate_dim = shape[1] // 2
+        elif parameter_name == "down_proj":
+            self.base_layer.hidden_dim = shape[1]
+            self.base_layer.intermediate_dim = shape[2]
+
+    def get_base_layer(self):
+        return self.base_layer
+
+
+def _make_layout_inputs(layout, E, R, in_dim, out_dim):
+    if layout == "canonical":
+        weight_A = torch.randn(E * R, in_dim)
+        weight_B = torch.randn(out_dim, E * R)
+    elif layout == "reversed":
+        weight_A = torch.randn(E * R, out_dim)
+        weight_B = torch.randn(in_dim, E * R)
+    else:
+        raise AssertionError(f"unknown layout: {layout}")
+    return weight_A, weight_B
+
+
+def _assert_layout_equivalence(layout, first, second, weight_A, weight_B, E, R, in_dim):
+    x = torch.randn(6, in_dim)
+    for e in range(E):
+        Ae = weight_A[e * R : (e + 1) * R]
+        Be = weight_B[:, e * R : (e + 1) * R]
+        if layout == "canonical":
+            naive = x @ Ae.T @ Be.T
+        else:
+            naive = x @ Be @ Ae
+        via = (x @ first[e]) @ second[e]
+        torch.testing.assert_close(via, naive, atol=1e-4, rtol=1e-4)
+
+
 @pytest.mark.parametrize(
     "E,R,in_dim,out_dim",
     [
@@ -27,7 +67,32 @@ def test_extractor_shapes(E, R, in_dim, out_dim):
     assert second.is_contiguous()
 
 
-def test_extractor_numerical_equivalence_per_expert():
+@pytest.mark.parametrize(
+    "parameter_name,base_shape,in_dim,out_dim,layout",
+    [
+        ("gate_up_proj", (4, 48, 16), 16, 48, "canonical"),
+        ("gate_up_proj", (4, 48, 16), 16, 48, "reversed"),
+        ("down_proj", (4, 16, 24), 24, 16, "canonical"),
+        ("down_proj", (4, 16, 24), 24, 16, "reversed"),
+    ],
+)
+def test_extractor_qwen_moe_layout(parameter_name, base_shape, in_dim, out_dim, layout):
+    ext = _make_qwen_moe_lora_extractor()
+    E, R = base_shape[0], 3
+    torch.manual_seed(0)
+    wrapper = _Wrapper(parameter_name, base_shape)
+    wA, wB = _make_layout_inputs(layout, E, R, in_dim, out_dim)
+    first, second, scaling, num_experts = ext(wrapper, wA, wB, 2.5, E)
+    assert first.shape == (E, in_dim, R)
+    assert second.shape == (E, R, out_dim)
+    assert scaling == 2.5
+    assert num_experts == E
+    assert first.is_contiguous()
+    assert second.is_contiguous()
+    _assert_layout_equivalence(layout, first, second, wA, wB, E, R, in_dim)
+
+
+def test_extractor_fallback_numerical_equivalence_per_expert():
     ext = _make_qwen_moe_lora_extractor()
     E, R, in_dim, out_dim = 4, 4, 64, 128
     torch.manual_seed(0)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1319,6 +1319,16 @@ def forward_native_moe_loop(
         gate_up_lora = _extract_lora_weights(
             self.gate_up_proj, num_experts=self.num_experts, experts_module=self
         )
+    # Pre-cast LoRA factors to the activation dtype once (avoid per-expert .to()
+    # inside the loop). Casting `scaling` is a no-op when it's a Python float;
+    # if it's a tensor, leave it alone — the multiply broadcasts.
+    if gate_up_lora is not None:
+        _gate_up_first, _gate_up_second, _gate_up_scaling = gate_up_lora
+        gate_up_lora = (
+            _gate_up_first.to(hidden_states.dtype),
+            _gate_up_second.to(hidden_states.dtype),
+            _gate_up_scaling,
+        )
 
     down_lora = getattr(self, "_unsloth_lora_down_proj", None)
     if down_lora is not None:
@@ -1330,6 +1340,13 @@ def forward_native_moe_loop(
     ):
         down_lora = _extract_lora_weights(
             self.down_proj, num_experts=self.num_experts, experts_module=self
+        )
+    if down_lora is not None:
+        _down_first, _down_second, _down_scaling = down_lora
+        down_lora = (
+            _down_first.to(hidden_states.dtype),
+            _down_second.to(hidden_states.dtype),
+            _down_scaling,
         )
 
     # Create expert mask and find which experts have tokens
@@ -1357,8 +1374,8 @@ def forward_native_moe_loop(
             gate_up = F.linear(current_state, gate_up_weight)
             if gate_up_lora is not None:
                 first_weight, second_weight, scaling = gate_up_lora
-                lora_delta = current_state @ first_weight[expert_idx].to(current_state.dtype)
-                lora_delta = lora_delta @ second_weight[expert_idx].to(current_state.dtype)
+                lora_delta = current_state @ first_weight[expert_idx]
+                lora_delta = lora_delta @ second_weight[expert_idx]
                 gate_up = gate_up + lora_delta * scaling
             gate, up = gate_up.chunk(2, dim=-1)
         else:
@@ -1369,11 +1386,17 @@ def forward_native_moe_loop(
 
         # Compute down projection for this expert only
         if hasattr(self, "down_proj"):
-            down = F.linear(current_hidden_states, self.down_proj[expert_idx])
+            down_weight = self.down_proj[expert_idx]
+            # Mirror the gate_up shape check: some MoE patches store the
+            # down weight in transposed (in_dim, out_dim) layout for
+            # grouped_mm, but F.linear needs (out_dim, in_dim).
+            if down_weight.shape[-1] != current_hidden_states.shape[-1]:
+                down_weight = down_weight.T
+            down = F.linear(current_hidden_states, down_weight)
             if down_lora is not None:
                 first_weight, second_weight, scaling = down_lora
-                lora_delta = current_hidden_states @ first_weight[expert_idx].to(current_hidden_states.dtype)
-                lora_delta = lora_delta @ second_weight[expert_idx].to(current_hidden_states.dtype)
+                lora_delta = current_hidden_states @ first_weight[expert_idx]
+                lora_delta = lora_delta @ second_weight[expert_idx]
                 down = down + lora_delta * scaling
             current_hidden_states = down
         else:

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1355,6 +1355,13 @@ def forward_native_moe_loop(
         expert_mask = expert_mask.permute(2, 1, 0)  # (num_experts, top_k, n_tokens)
         expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
 
+    # Some patches (Qwen3-VL-MoE) store experts in grouped_mm-friendly layout
+    # (E, in_dim, out_dim) rather than F.linear's (E, out_dim, in_dim). The
+    # patched __init__ sets `_unsloth_grouped_mm_format = True` to advertise
+    # this. Prefer it over the shape-only check below: the shape check is
+    # unsafe when intermediate_dim == hidden_dim (square dims).
+    grouped_mm_format = bool(getattr(self, "_unsloth_grouped_mm_format", False))
+
     # Only loop over experts that actually have tokens routed to them
     for expert_idx_t in expert_hit:
         expert_idx = expert_idx_t.item()
@@ -1369,7 +1376,7 @@ def forward_native_moe_loop(
         # Handle 'gate_up_proj' or 'w1'/'w3'
         if hasattr(self, "gate_up_proj"):
             gate_up_weight = self.gate_up_proj[expert_idx]
-            if gate_up_weight.shape[-1] != current_state.shape[-1]:
+            if grouped_mm_format or gate_up_weight.shape[-1] != current_state.shape[-1]:
                 gate_up_weight = gate_up_weight.T
             gate_up = F.linear(current_state, gate_up_weight)
             if gate_up_lora is not None:
@@ -1387,10 +1394,10 @@ def forward_native_moe_loop(
         # Compute down projection for this expert only
         if hasattr(self, "down_proj"):
             down_weight = self.down_proj[expert_idx]
-            # Mirror the gate_up shape check: some MoE patches store the
-            # down weight in transposed (in_dim, out_dim) layout for
-            # grouped_mm, but F.linear needs (out_dim, in_dim).
-            if down_weight.shape[-1] != current_hidden_states.shape[-1]:
+            # Mirror the gate_up handling: prefer the explicit
+            # `_unsloth_grouped_mm_format` flag over the shape heuristic, which
+            # is unsafe when intermediate_dim == hidden_dim.
+            if grouped_mm_format or down_weight.shape[-1] != current_hidden_states.shape[-1]:
                 down_weight = down_weight.T
             down = F.linear(current_hidden_states, down_weight)
             if down_lora is not None:

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1306,6 +1306,31 @@ def forward_native_moe_loop(
     """
     # This Unsloth Zoo code section is licensed under AGPL3
     final_hidden_states = torch.zeros_like(hidden_states)
+    use_separated_lora = _should_use_separated_lora()
+
+    gate_up_lora = getattr(self, "_unsloth_lora_gate_up_proj", None)
+    if gate_up_lora is not None:
+        gate_up_lora = gate_up_lora[:3]
+    elif (
+        use_separated_lora
+        and hasattr(self, "gate_up_proj")
+        and _has_lora_adapters(self.gate_up_proj)
+    ):
+        gate_up_lora = _extract_lora_weights(
+            self.gate_up_proj, num_experts=self.num_experts, experts_module=self
+        )
+
+    down_lora = getattr(self, "_unsloth_lora_down_proj", None)
+    if down_lora is not None:
+        down_lora = down_lora[:3]
+    elif (
+        use_separated_lora
+        and hasattr(self, "down_proj")
+        and _has_lora_adapters(self.down_proj)
+    ):
+        down_lora = _extract_lora_weights(
+            self.down_proj, num_experts=self.num_experts, experts_module=self
+        )
 
     # Create expert mask and find which experts have tokens
     with torch.no_grad():
@@ -1326,9 +1351,16 @@ def forward_native_moe_loop(
         # Compute gate_up projection for this expert only
         # Handle 'gate_up_proj' or 'w1'/'w3'
         if hasattr(self, "gate_up_proj"):
-            gate, up = F.linear(current_state, self.gate_up_proj[expert_idx]).chunk(
-                2, dim=-1
-            )
+            gate_up_weight = self.gate_up_proj[expert_idx]
+            if gate_up_weight.shape[-1] != current_state.shape[-1]:
+                gate_up_weight = gate_up_weight.T
+            gate_up = F.linear(current_state, gate_up_weight)
+            if gate_up_lora is not None:
+                first_weight, second_weight, scaling = gate_up_lora
+                lora_delta = current_state @ first_weight[expert_idx].to(current_state.dtype)
+                lora_delta = lora_delta @ second_weight[expert_idx].to(current_state.dtype)
+                gate_up = gate_up + lora_delta * scaling
+            gate, up = gate_up.chunk(2, dim=-1)
         else:
             gate = F.linear(current_state, self.w1[expert_idx])
             up = F.linear(current_state, self.w3[expert_idx])
@@ -1337,9 +1369,13 @@ def forward_native_moe_loop(
 
         # Compute down projection for this expert only
         if hasattr(self, "down_proj"):
-            current_hidden_states = F.linear(
-                current_hidden_states, self.down_proj[expert_idx]
-            )
+            down = F.linear(current_hidden_states, self.down_proj[expert_idx])
+            if down_lora is not None:
+                first_weight, second_weight, scaling = down_lora
+                lora_delta = current_hidden_states @ first_weight[expert_idx].to(current_hidden_states.dtype)
+                lora_delta = lora_delta @ second_weight[expert_idx].to(current_hidden_states.dtype)
+                down = down + lora_delta * scaling
+            current_hidden_states = down
         else:
             current_hidden_states = F.linear(current_hidden_states, self.w2[expert_idx])
 

--- a/unsloth_zoo/temporary_patches/qwen3_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe.py
@@ -43,19 +43,52 @@ from .moe_utils import (
 
 
 def _make_qwen_moe_lora_extractor():
+    def _get_qwen_moe_lora_dims(wrapper):
+        if wrapper is None or not hasattr(wrapper, "get_base_layer"):
+            return None, None
+
+        base = wrapper.get_base_layer()
+        param_name = getattr(wrapper, "parameter_name", None)
+        if param_name == "gate_up_proj":
+            input_dim = getattr(base, "hidden_dim", None)
+            output_dim = getattr(base, "intermediate_dim", None)
+            return input_dim, None if output_dim is None else 2 * output_dim
+        if param_name == "down_proj":
+            return getattr(base, "intermediate_dim", None), getattr(base, "hidden_dim", None)
+
+        return None, None
+
     def _qwen_moe_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts):
         """
         LoRA extractor for Qwen-family MoE (Qwen3-MoE, Qwen3.5/3.6, Qwen3-Next).
-
-        PEFT LoRA shapes are fixed by the linear's in/out dims, independent of
-        raw base-weight storage order, so no model-specific dispatch is needed:
-          weight_A: (E*R, in_dim)  -> (E, in_dim, R)
-          weight_B: (out_dim, E*R) -> (E, R, out_dim)
         """
         total_rank = weight_A.shape[0]
         rank_per_expert = total_rank // num_experts
-        dim_A = weight_A.shape[1]   # in_dim
-        dim_B = weight_B.shape[0]   # out_dim
+        dim_A = weight_A.shape[1]
+        dim_B = weight_B.shape[0]
+
+        input_dim, output_dim = _get_qwen_moe_lora_dims(wrapper)
+
+        # PEFT 0.18 used raw 3D parameter dims for ParamWrapper LoRA:
+        # https://github.com/huggingface/peft/blob/v0.18.0/src/peft/tuners/lora/layer.py#L1928-L1931
+        # PEFT 0.19 swaps non-transposed 3D params before creating lora_A/B:
+        # https://github.com/huggingface/peft/blob/v0.19.1/src/peft/tuners/lora/layer.py#L2201-L2205
+        if dim_A == input_dim and dim_B == output_dim:
+            first_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
+            first_weight = first_weight.permute(0, 2, 1).contiguous()
+
+            second_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
+            second_weight = second_weight.permute(1, 2, 0).contiguous()
+
+            return first_weight, second_weight, scaling, num_experts
+
+        if dim_A == output_dim and dim_B == input_dim:
+            first_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
+            first_weight = first_weight.permute(1, 0, 2).contiguous()
+
+            second_weight = weight_A.view(num_experts, rank_per_expert, dim_A).contiguous()
+
+            return first_weight, second_weight, scaling, num_experts
 
         first_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
         first_weight = first_weight.permute(0, 2, 1).contiguous()

--- a/unsloth_zoo/temporary_patches/qwen3_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe.py
@@ -58,9 +58,40 @@ def _make_qwen_moe_lora_extractor():
 
         return None, None
 
+    def _canonical(weight_A, weight_B, num_experts, rank_per_expert, dim_A, dim_B):
+        # PEFT 0.18 raw 3D parameter dims layout
+        first_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
+        first_weight = first_weight.permute(0, 2, 1).contiguous()
+        second_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
+        second_weight = second_weight.permute(1, 2, 0).contiguous()
+        return first_weight, second_weight
+
+    def _reversed_(weight_A, weight_B, num_experts, rank_per_expert, dim_A, dim_B):
+        # PEFT 0.19 swapped 3D parameter dims layout
+        first_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
+        first_weight = first_weight.permute(1, 0, 2).contiguous()
+        second_weight = weight_A.view(num_experts, rank_per_expert, dim_A).contiguous()
+        return first_weight, second_weight
+
     def _qwen_moe_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts):
         """
-        LoRA extractor for Qwen-family MoE (Qwen3-MoE, Qwen3.5/3.6, Qwen3-Next).
+        LoRA extractor for Qwen-family MoE (Qwen3-MoE, Qwen3.5/3.6, Qwen3-Next, Qwen3-VL-MoE).
+
+        Handles both PEFT layouts on the same MoE 3D parameter:
+          PEFT 0.18 keeps raw param.shape  (https://github.com/huggingface/peft/blob/v0.18.0/src/peft/tuners/lora/layer.py#L1928-L1931)
+          PEFT 0.19 swaps in/out features  (https://github.com/huggingface/peft/blob/v0.19.1/src/peft/tuners/lora/layer.py#L2201-L2205)
+
+        Dispatch order:
+          1. PEFT 0.19 sets `wrapper._did_swap_in_out_features = True` when it
+             actually swapped. That is the cleanest signal and is preferred over
+             any shape-based check, which can be ambiguous when input_dim ==
+             output_dim (e.g. tiny synthetic configs, or `gate_up_proj` with
+             hidden_dim == 2*intermediate_dim).
+          2. Otherwise compare (dim_A, dim_B) against the runtime
+             (input_dim, output_dim) read from the experts module.
+          3. If neither matches, warn loudly and fall through to the canonical
+             permutation. This used to be silent and was the exact failure mode
+             of PR #601 — so make it visible.
         """
         total_rank = weight_A.shape[0]
         rank_per_expert = total_rank // num_experts
@@ -68,34 +99,37 @@ def _make_qwen_moe_lora_extractor():
         dim_B = weight_B.shape[0]
 
         input_dim, output_dim = _get_qwen_moe_lora_dims(wrapper)
+        peft_swapped = bool(getattr(wrapper, "_did_swap_in_out_features", False))
 
-        # PEFT 0.18 used raw 3D parameter dims for ParamWrapper LoRA:
-        # https://github.com/huggingface/peft/blob/v0.18.0/src/peft/tuners/lora/layer.py#L1928-L1931
-        # PEFT 0.19 swaps non-transposed 3D params before creating lora_A/B:
-        # https://github.com/huggingface/peft/blob/v0.19.1/src/peft/tuners/lora/layer.py#L2201-L2205
+        if peft_swapped and input_dim is not None and dim_A == output_dim and dim_B == input_dim:
+            first_weight, second_weight = _reversed_(
+                weight_A, weight_B, num_experts, rank_per_expert, dim_A, dim_B,
+            )
+            return first_weight, second_weight, scaling, num_experts
+
         if dim_A == input_dim and dim_B == output_dim:
-            first_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
-            first_weight = first_weight.permute(0, 2, 1).contiguous()
-
-            second_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
-            second_weight = second_weight.permute(1, 2, 0).contiguous()
-
+            first_weight, second_weight = _canonical(
+                weight_A, weight_B, num_experts, rank_per_expert, dim_A, dim_B,
+            )
             return first_weight, second_weight, scaling, num_experts
 
         if dim_A == output_dim and dim_B == input_dim:
-            first_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
-            first_weight = first_weight.permute(1, 0, 2).contiguous()
-
-            second_weight = weight_A.view(num_experts, rank_per_expert, dim_A).contiguous()
-
+            first_weight, second_weight = _reversed_(
+                weight_A, weight_B, num_experts, rank_per_expert, dim_A, dim_B,
+            )
             return first_weight, second_weight, scaling, num_experts
 
-        first_weight = weight_A.view(num_experts, rank_per_expert, dim_A)
-        first_weight = first_weight.permute(0, 2, 1).contiguous()
-
-        second_weight = weight_B.view(dim_B, num_experts, rank_per_expert)
-        second_weight = second_weight.permute(1, 2, 0).contiguous()
-
+        if UNSLOTH_ENABLE_LOGGING and (input_dim is not None or output_dim is not None):
+            logger.warning(
+                "Unsloth: Qwen MoE LoRA extractor could not match either layout "
+                f"(weight_A={tuple(weight_A.shape)}, weight_B={tuple(weight_B.shape)}, "
+                f"expected input_dim={input_dim}, output_dim={output_dim}, "
+                f"num_experts={num_experts}). Falling back to canonical layout. "
+                "If this is a new PEFT version, the LoRA delta may be wrong."
+            )
+        first_weight, second_weight = _canonical(
+            weight_A, weight_B, num_experts, rank_per_expert, dim_A, dim_B,
+        )
         return first_weight, second_weight, scaling, num_experts
 
     return _qwen_moe_lora_extractor

--- a/unsloth_zoo/temporary_patches/qwen3_vl_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_vl_moe.py
@@ -47,6 +47,7 @@ from .moe_utils import (
     select_moe_backend,
     patch_param_wrapper_for_moe,
 )
+from .qwen3_moe import _make_qwen_moe_lora_extractor
 
 
 def patch_qwen3_vl_moe():
@@ -245,42 +246,7 @@ def patch_qwen3_vl_moe():
             force=True,
         )
 
-        # ====================================================================
-        # Define LoRA extraction function for Qwen3-VL-MoE (Transposed Format)
-        # ====================================================================
-        def _qwen3_vl_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts):
-            """
-            Custom LoRA extractor for Qwen3-VL-MoE which uses Transposed Grouped MM format.
-            Base weights are (E, in_dim, out_dim).
-
-            Expectation for grouped_mm (Transposed):
-            - first (Input):  (E, H, R)
-            - second (Output): (E, R, Out)
-
-            Qwen3-VL Weights:
-            - weight_A (E*R, H): Input projection. Reshape(E, R, H) -> Permute(0, 2, 1) -> (E, H, R).
-            - weight_B (Out, E*R): Output projection. Reshape(Out, E, R) -> Permute(1, 2, 0) -> (E, R, Out).
-            """
-            # This Unsloth Zoo code section is licensed under AGPL3
-
-            total_rank = weight_A.shape[0]
-            rank_per_expert = total_rank // num_experts
-            dim1 = weight_A.shape[1]
-            dim2 = weight_B.shape[0]
-
-            # TRANSPOSED FORMAT logic from old moe_utils.py
-            # first_weight: (E, in_dim, R) - from lora_A
-            # second_weight: (E, R, out_dim) - from lora_B
-
-            first_weight = weight_A.view(num_experts, rank_per_expert, dim1)
-            first_weight = first_weight.permute(0, 2, 1).contiguous()  # (E, in_dim, R)
-
-            second_weight = weight_B.view(dim2, num_experts, rank_per_expert)
-            second_weight = second_weight.permute(1, 2, 0).contiguous()  # (E, R, out_dim)
-
-            return first_weight, second_weight, scaling, num_experts
-
-        # Register the extractor on the Experts class
+        _qwen3_vl_lora_extractor = _make_qwen_moe_lora_extractor()
         transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe.Qwen3VLMoeTextExperts._unsloth_lora_extractor_fn = staticmethod(_qwen3_vl_lora_extractor)
 
 


### PR DESCRIPTION
Initially introduced in #601  as an attempt to fix the extractor. 
When I initially designed it, I tried to make it shape inferring because transformers v5 was still a WIP. The above mentioned PR modified that functionality to fix a regression.
The root cause of the regression seems to be peft changing the lora addition for MoE

PEFT 0.18 used raw 3D parameter dims for ParamWrapper LoRA:
https://github.com/huggingface/peft/blob/v0.18.0/src/peft/tuners/lora/layer.py#L1928-L1931
```
if param.ndim == 3:
    self.num_experts, self.in_features, self.out_features = param.shape
else:
    self.num_experts, self.in_features, self.out_features = 1, param.shape[1], param.shape[0]
```
PEFT 0.19 swaps non-transposed 3D params before creating lora_A/B:
https://github.com/huggingface/peft/blob/v0.19.1/src/peft/tuners/lora/layer.py#L2201-L2205
```
# for some MoE layers, the order is (experts, out_features, in_features)
is_transposed = getattr(self.get_base_layer(), "is_transposed", False)
swap_in_out_features = (self.get_param().ndim == 3) and not is_transposed
if swap_in_out_features and not self._did_swap_in_out_features:
    self.in_features, self.out_features = self.out_features, self.in_features
    self._did_swap_in_out_features = True
```