### PR TITLE
fix(gpt_oss): move BnB-4bit helpers before patch registration (#581)

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1111,6 +1111,31 @@ def restore_gpt_oss_original():
         pass
     return False
 
+def _should_use_gpt_oss_bnb4bit() -> bool:
+    """
+    Decide if GPT-OSS should use BnB-compatible 4-bit experts.
+    Default: True when load_in_4bit is active.
+    Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to force BF16 path.
+    """
+    if "gpt_oss" not in _normalized_unsloth_model_name():
+        return False
+    if "_load_in_4bit_" not in _normalized_unsloth_model_name():
+        return False
+    return os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_DISABLE", "0") != "1"
+
+
+def _is_gpt_oss_4bit_load() -> bool:
+    return "_load_in_4bit_" in _normalized_unsloth_model_name()
+
+
+def _normalized_unsloth_model_name() -> str:
+    return os.environ.get("UNSLOTH_MODEL_NAME", "").replace("-", "_")
+
+
+def _is_transformers_v5() -> bool:
+    return transformers_version >= Version("5.0.0.dev0")
+
+
 def patch_gpt_oss_bnb4bit_auto():
     """
     Auto-patch GPT-OSS for BnB 4-bit when load_in_4bit is active.
@@ -1346,31 +1371,6 @@ from .moe_utils import (
     forward_native_grouped_mm,
     # torch_native_forward,
 )
-
-
-def _should_use_gpt_oss_bnb4bit() -> bool:
-    """
-    Decide if GPT-OSS should use BnB-compatible 4-bit experts.
-    Default: True when load_in_4bit is active.
-    Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to force BF16 path.
-    """
-    if "gpt_oss" not in _normalized_unsloth_model_name():
-        return False
-    if "_load_in_4bit_" not in _normalized_unsloth_model_name():
-        return False
-    return os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_DISABLE", "0") != "1"
-
-
-def _is_gpt_oss_4bit_load() -> bool:
-    return "_load_in_4bit_" in _normalized_unsloth_model_name()
-
-
-def _normalized_unsloth_model_name() -> str:
-    return os.environ.get("UNSLOTH_MODEL_NAME", "").replace("-", "_")
-
-
-def _is_transformers_v5() -> bool:
-    return transformers_version >= Version("5.0.0.dev0")
 
 
 def patch_gpt_oss_moe_for_lora():


### PR DESCRIPTION
## Summary

Closes #581.

`patch_gpt_oss_bnb4bit_auto` is registered with `TEMPORARY_PATCHES.append(...)` immediately after its definition, but the helpers it calls (`_should_use_gpt_oss_bnb4bit`, `_normalized_unsloth_model_name`, `_is_gpt_oss_4bit_load`, `_is_transformers_v5`) were defined ~220 lines later. With the helpers below the registration:

- A reader has to scroll past unrelated combo-kernel and torch.compile setup to learn what the patch actually does.
- If anything in that intervening module-level code raised at import (e.g. `torch.cuda.memory.mem_get_info(0)` on a system with no usable CUDA context), the helpers were never bound, and the already-registered patch would later trip `NameError: '_should_use_gpt_oss_bnb4bit' is not defined` when its turn came in the patch list.

This PR moves the four helpers to immediately before `patch_gpt_oss_bnb4bit_auto` (and thus before the `TEMPORARY_PATCHES.append` call). Pure reorder; no behavior change in the success path.

## What changed

- `unsloth_zoo/temporary_patches/gpt_oss.py`: moved `_should_use_gpt_oss_bnb4bit`, `_is_gpt_oss_4bit_load`, `_normalized_unsloth_model_name`, `_is_transformers_v5` from after the combo-kernel block (around line 1351 in pre-PR ordering) to immediately before `def patch_gpt_oss_bnb4bit_auto`. Function bodies are byte-for-byte identical; only their position in the file moved.

## Verification

- Total file size unchanged (125,768 bytes), since this is a pure reorder.
- All other call sites of the moved helpers are still below their (new) definitions.
- Both `Version` and `transformers_version` (used by `_is_transformers_v5`) are imported at the top of the file, so the moved helpers have all the symbols they need at their new location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)