### PR TITLE
Allow local convert_hf_to_gguf.py via UNSLOTH_LLAMA_CPP_SCRIPTS_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 __pycache__/
 unsloth_zoo.egg-info/
-unsloth_compiled_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 unsloth_zoo.egg-info/
+unsloth_compiled_cache/

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -8,11 +8,11 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = [
     "convert_to_gguf",
@@ -121,9 +121,9 @@ LLAMA_CPP_DEFAULT_DIR = os.environ.get(
 
 def _resolve_local_convert_script():
     """Returns (abs_path, mtime_ns, size) for a local convert_hf_to_gguf.py if
-    UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at a directory containing one, else None.
-    The mtime_ns and size are part of the cache key on the cached implementation
-    so in-place updates to the same path are honored."""
+ UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at a directory containing one, else None.
+ The mtime_ns and size are part of the cache key on the cached implementation
+ so in-place updates to the same path are honored."""
     scripts_dir = os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR")
     if not scripts_dir:
         return None
@@ -462,7 +462,7 @@ pass
 
 def _find_visual_studio():
     """Detect Visual Studio Build Tools installation (aligned with setup.ps1 Find-VsBuildTools).
-    Returns (cmake_generator, vs_install_path) or (None, None) if not found."""
+ Returns (cmake_generator, vs_install_path) or (None, None) if not found."""
     program_files = [
         os.environ.get('ProgramFiles', r'C:\Program Files'),
         os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)'),
@@ -481,7 +481,7 @@ def _find_visual_studio():
 
 def _find_openssl_root():
     """Find OpenSSL dev installation on Windows (aligned with setup.ps1 $OpenSslRoots).
-    Returns the root path if found, or None."""
+ Returns the root path if found, or None."""
     openssl_roots = [
         r'C:\Program Files\OpenSSL-Win64',
         r'C:\Program Files\OpenSSL',
@@ -495,7 +495,7 @@ def _find_openssl_root():
 
 def _find_lib_path(lib_name):
     """Find a shared library path using gcc's linker search.
-    Returns the absolute path if found, or None."""
+ Returns the absolute path if found, or None."""
     try:
         result = subprocess.run(
             ['gcc', f'-print-file-name={lib_name}'],
@@ -1063,7 +1063,7 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
             num_experts_pattern = rb'n_experts = self\.hparams\[(["\'])num_experts\1\]'
             replacement = (
                 b"# Qwen3MoE seems to use num_local_experts instead of num_experts\n"
-                b"            n_experts = self.hparams.get('num_experts', None) or self.hparams.get('num_local_experts')"
+                b" n_experts = self.hparams.get('num_experts', None) or self.hparams.get('num_local_experts')"
             )
 
             new_patched_content = re.sub(num_experts_pattern, replacement, patched_content)
@@ -1871,8 +1871,8 @@ def add_llama_cpp_system_message(messages, tools, inplace = False):
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -123,31 +123,35 @@ def _resolve_local_convert_script():
     """Returns (abs_path, mtime_ns, size) for a local convert_hf_to_gguf.py if
     UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at a directory containing one, else None.
     The mtime_ns and size are part of the cache key on the cached implementation
-    so in-place updates to the same path are honored."""
+    so in-place updates to the same path are honored. When the env var is set
+    but invalid, this raises RuntimeError so an explicit pin fails closed
+    instead of silently falling back to the network."""
     scripts_dir = os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR")
     if not scripts_dir:
         return None
     scripts_dir = os.path.abspath(os.path.expanduser(scripts_dir))
     if not os.path.isdir(scripts_dir):
-        logger.warning(
-            f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' is not a directory; "
-            f"falling back to network download."
+        raise RuntimeError(
+            f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' is not a directory. "
+            f"Unset UNSLOTH_LLAMA_CPP_SCRIPTS_DIR to use the network converter, "
+            f"or point it at a directory containing convert_hf_to_gguf.py."
         )
-        return None
     for name in ("convert_hf_to_gguf.py", "convert-hf-to-gguf.py"):
         candidate = os.path.join(scripts_dir, name)
         try:
             if not os.path.isfile(candidate):
                 continue
             stat = os.stat(candidate)
-        except OSError:
-            continue
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unsloth: Could not inspect local llama.cpp converter at '{candidate}': {exc}"
+            ) from exc
         return (candidate, stat.st_mtime_ns, stat.st_size)
-    logger.warning(
-        f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' has no convert_hf_to_gguf.py or convert-hf-to-gguf.py; "
-        f"falling back to network download."
+    raise RuntimeError(
+        f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' has no "
+        f"convert_hf_to_gguf.py or convert-hf-to-gguf.py. Unset the env var "
+        f"to use the network converter."
     )
-    return None
 
 
 @contextlib.contextmanager
@@ -900,13 +904,15 @@ def _download_convert_hf_to_gguf(name = "unsloth_convert_hf_to_gguf"):
     return _download_convert_hf_to_gguf_cached(name, _resolve_local_convert_script())
 
 
-@lru_cache(8)
+@lru_cache(1)
 def _download_convert_hf_to_gguf_cached(name, _local_script_info):
     # All Unsloth Zoo code licensed under LGPLv3
     # Downloads from llama.cpp's GitHub repository, or reads a local copy when
     # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR is set. _local_script_info is
     # (path, mtime_ns, size); mtime/size in the cache key invalidate stale
-    # entries on in-place updates.
+    # entries on in-place updates. Cache size is 1 because the patched script
+    # is written to a single shared on-disk path, so a second cache entry
+    # would always read stale bytes off disk.
 
     # Ensure llama.cpp directory exists
     os.makedirs(LLAMA_CPP_DEFAULT_DIR, exist_ok=True)
@@ -925,7 +931,7 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
             with open(_local_script, "rb") as f:
                 original_content = f.read()
         else:
-            response = requests.get(LLAMA_CPP_CONVERT_FILE)
+            response = requests.get(LLAMA_CPP_CONVERT_FILE, timeout = 30)
             response.raise_for_status()
             original_content = response.content
 
@@ -1122,11 +1128,12 @@ pass
 
 
 # Preserve the pre-split lru_cache surface (cache_clear, cache_info,
-# cache_parameters, __wrapped__) so external callers and inspect.unwrap keep working.
+# cache_parameters) so external callers keep working. __wrapped__ is not
+# forwarded because the inner function takes a private (name, _local_script_info)
+# pair while the public wrapper is a single-arg callable.
 _download_convert_hf_to_gguf.cache_clear = _download_convert_hf_to_gguf_cached.cache_clear
 _download_convert_hf_to_gguf.cache_info = _download_convert_hf_to_gguf_cached.cache_info
 _download_convert_hf_to_gguf.cache_parameters = _download_convert_hf_to_gguf_cached.cache_parameters
-_download_convert_hf_to_gguf.__wrapped__ = _download_convert_hf_to_gguf_cached.__wrapped__
 
 
 def _split_str_to_n_bytes(split_str: str) -> int:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -120,11 +120,14 @@ LLAMA_CPP_DEFAULT_DIR = os.environ.get(
 
 
 def _resolve_local_convert_script():
-    """Returns absolute path to a local convert_hf_to_gguf.py if UNSLOTH_LLAMA_CPP_SCRIPTS_DIR
-    points at a directory containing one, else None."""
+    """Returns (abs_path, mtime_ns, size) for a local convert_hf_to_gguf.py if
+    UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at a directory containing one, else None.
+    The mtime_ns and size are part of the cache key on the cached implementation
+    so in-place updates to the same path are honored."""
     scripts_dir = os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR")
     if not scripts_dir:
         return None
+    scripts_dir = os.path.abspath(os.path.expanduser(scripts_dir))
     if not os.path.isdir(scripts_dir):
         logger.warning(
             f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' is not a directory; "
@@ -133,8 +136,9 @@ def _resolve_local_convert_script():
         return None
     for name in ("convert_hf_to_gguf.py", "convert-hf-to-gguf.py"):
         candidate = os.path.join(scripts_dir, name)
-        if os.path.exists(candidate):
-            return candidate
+        if os.path.isfile(candidate):
+            stat = os.stat(candidate)
+            return (candidate, stat.st_mtime_ns, stat.st_size)
     logger.warning(
         f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' has no convert_hf_to_gguf.py; "
         f"falling back to network download."
@@ -893,22 +897,27 @@ def _download_convert_hf_to_gguf(name = "unsloth_convert_hf_to_gguf"):
 
 
 @lru_cache(2)
-def _download_convert_hf_to_gguf_cached(name, _local_script):
+def _download_convert_hf_to_gguf_cached(name, _local_script_info):
     # All Unsloth Zoo code licensed under LGPLv3
     # Downloads from llama.cpp's Github report (or reads a local copy if
-    # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at one — _local_script is resolved
-    # by the wrapper above before the cache lookup)
+    # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at one — _local_script_info is
+    # resolved by the wrapper above as (path, mtime_ns, size); mtime_ns/size
+    # are part of the cache key so in-place updates invalidate the cache)
 
     # Ensure llama.cpp directory exists
     os.makedirs(LLAMA_CPP_DEFAULT_DIR, exist_ok=True)
 
     supported_types = set() # Initialize outside try block
+    text_archs = set()
+    vision_archs = set()
     temp_original_file_path = None # Initialize for finally block
+
+    _local_script = _local_script_info[0] if _local_script_info is not None else None
 
     try:
         # 1. Obtain the file (local override takes precedence over network)
         if _local_script is not None:
-            print(f"Unsloth: Using local convert_hf_to_gguf.py from {_local_script}")
+            logger.info(f"Unsloth: Using local convert_hf_to_gguf.py from {_local_script}")
             with open(_local_script, "rb") as f:
                 original_content = f.read()
         else:
@@ -1106,6 +1115,12 @@ def _download_convert_hf_to_gguf_cached(name, _local_script):
         logger.error(f"Unsloth: Unexpected error after introspection: {e}", exc_info=True)
         raise RuntimeError(f"Unsloth: Failed during patching/parsing of script content: {e}") from e
 pass
+
+
+# Preserve the public cache_clear / cache_info surface that existed before the
+# wrapper/cached split, so external callers and tests keep working.
+_download_convert_hf_to_gguf.cache_clear = _download_convert_hf_to_gguf_cached.cache_clear
+_download_convert_hf_to_gguf.cache_info = _download_convert_hf_to_gguf_cached.cache_info
 
 
 def _split_str_to_n_bytes(split_str: str) -> int:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -136,11 +136,15 @@ def _resolve_local_convert_script():
         return None
     for name in ("convert_hf_to_gguf.py", "convert-hf-to-gguf.py"):
         candidate = os.path.join(scripts_dir, name)
-        if os.path.isfile(candidate):
+        try:
+            if not os.path.isfile(candidate):
+                continue
             stat = os.stat(candidate)
-            return (candidate, stat.st_mtime_ns, stat.st_size)
+        except OSError:
+            continue
+        return (candidate, stat.st_mtime_ns, stat.st_size)
     logger.warning(
-        f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' has no convert_hf_to_gguf.py; "
+        f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' has no convert_hf_to_gguf.py or convert-hf-to-gguf.py; "
         f"falling back to network download."
     )
     return None
@@ -896,10 +900,10 @@ def _download_convert_hf_to_gguf(name = "unsloth_convert_hf_to_gguf"):
     return _download_convert_hf_to_gguf_cached(name, _resolve_local_convert_script())
 
 
-@lru_cache(2)
+@lru_cache(8)
 def _download_convert_hf_to_gguf_cached(name, _local_script_info):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Downloads from llama.cpp's Github report (or reads a local copy if
+    # Downloads from llama.cpp's GitHub repository (or reads a local copy if
     # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at one — _local_script_info is
     # resolved by the wrapper above as (path, mtime_ns, size); mtime_ns/size
     # are part of the cache key so in-place updates invalidate the cache)
@@ -1117,10 +1121,13 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
 pass
 
 
-# Preserve the public cache_clear / cache_info surface that existed before the
-# wrapper/cached split, so external callers and tests keep working.
+# Preserve the public lru_cache surface (cache_clear, cache_info,
+# cache_parameters, __wrapped__) that existed before the wrapper/cached split,
+# so external callers, inspect.unwrap, and tests keep working.
 _download_convert_hf_to_gguf.cache_clear = _download_convert_hf_to_gguf_cached.cache_clear
 _download_convert_hf_to_gguf.cache_info = _download_convert_hf_to_gguf_cached.cache_info
+_download_convert_hf_to_gguf.cache_parameters = _download_convert_hf_to_gguf_cached.cache_parameters
+_download_convert_hf_to_gguf.__wrapped__ = _download_convert_hf_to_gguf_cached.__wrapped__
 
 
 def _split_str_to_n_bytes(split_str: str) -> int:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -119,6 +119,29 @@ LLAMA_CPP_DEFAULT_DIR = os.environ.get(
 )
 
 
+def _resolve_local_convert_script():
+    """Returns absolute path to a local convert_hf_to_gguf.py if UNSLOTH_LLAMA_CPP_SCRIPTS_DIR
+    points at a directory containing one, else None."""
+    scripts_dir = os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR")
+    if not scripts_dir:
+        return None
+    if not os.path.isdir(scripts_dir):
+        logger.warning(
+            f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' is not a directory; "
+            f"falling back to network download."
+        )
+        return None
+    for name in ("convert_hf_to_gguf.py", "convert-hf-to-gguf.py"):
+        candidate = os.path.join(scripts_dir, name)
+        if os.path.exists(candidate):
+            return candidate
+    logger.warning(
+        f"Unsloth: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR='{scripts_dir}' has no convert_hf_to_gguf.py; "
+        f"falling back to network download."
+    )
+    return None
+
+
 @contextlib.contextmanager
 def use_local_gguf():
     """Context manager to temporarily use llama.cpp's local gguf-py"""
@@ -863,12 +886,18 @@ def _load_module_from_path(filepath, module_name):
 pass
 
 
-@lru_cache(1)
-def _download_convert_hf_to_gguf(
-    name = "unsloth_convert_hf_to_gguf",
-):
+def _download_convert_hf_to_gguf(name = "unsloth_convert_hf_to_gguf"):
+    # Resolve the env var on every call so changes between calls are honored;
+    # the resolved value is part of the cache key on the implementation below.
+    return _download_convert_hf_to_gguf_cached(name, _resolve_local_convert_script())
+
+
+@lru_cache(2)
+def _download_convert_hf_to_gguf_cached(name, _local_script):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Downloads from llama.cpp's Github report
+    # Downloads from llama.cpp's Github report (or reads a local copy if
+    # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at one — _local_script is resolved
+    # by the wrapper above before the cache lookup)
 
     # Ensure llama.cpp directory exists
     os.makedirs(LLAMA_CPP_DEFAULT_DIR, exist_ok=True)
@@ -877,10 +906,15 @@ def _download_convert_hf_to_gguf(
     temp_original_file_path = None # Initialize for finally block
 
     try:
-        # 1. Download the file
-        response = requests.get(LLAMA_CPP_CONVERT_FILE)
-        response.raise_for_status()
-        original_content = response.content
+        # 1. Obtain the file (local override takes precedence over network)
+        if _local_script is not None:
+            print(f"Unsloth: Using local convert_hf_to_gguf.py from {_local_script}")
+            with open(_local_script, "rb") as f:
+                original_content = f.read()
+        else:
+            response = requests.get(LLAMA_CPP_CONVERT_FILE)
+            response.raise_for_status()
+            original_content = response.content
 
         # 2. Introspect Original Script for Supported Architectures
         logger.info("Unsloth: Identifying llama.cpp gguf supported architectures...")

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -8,11 +8,11 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = [
     "convert_to_gguf",
@@ -121,9 +121,9 @@ LLAMA_CPP_DEFAULT_DIR = os.environ.get(
 
 def _resolve_local_convert_script():
     """Returns (abs_path, mtime_ns, size) for a local convert_hf_to_gguf.py if
- UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at a directory containing one, else None.
- The mtime_ns and size are part of the cache key on the cached implementation
- so in-place updates to the same path are honored."""
+    UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at a directory containing one, else None.
+    The mtime_ns and size are part of the cache key on the cached implementation
+    so in-place updates to the same path are honored."""
     scripts_dir = os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR")
     if not scripts_dir:
         return None
@@ -462,7 +462,7 @@ pass
 
 def _find_visual_studio():
     """Detect Visual Studio Build Tools installation (aligned with setup.ps1 Find-VsBuildTools).
- Returns (cmake_generator, vs_install_path) or (None, None) if not found."""
+    Returns (cmake_generator, vs_install_path) or (None, None) if not found."""
     program_files = [
         os.environ.get('ProgramFiles', r'C:\Program Files'),
         os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)'),
@@ -481,7 +481,7 @@ def _find_visual_studio():
 
 def _find_openssl_root():
     """Find OpenSSL dev installation on Windows (aligned with setup.ps1 $OpenSslRoots).
- Returns the root path if found, or None."""
+    Returns the root path if found, or None."""
     openssl_roots = [
         r'C:\Program Files\OpenSSL-Win64',
         r'C:\Program Files\OpenSSL',
@@ -495,7 +495,7 @@ def _find_openssl_root():
 
 def _find_lib_path(lib_name):
     """Find a shared library path using gcc's linker search.
- Returns the absolute path if found, or None."""
+    Returns the absolute path if found, or None."""
     try:
         result = subprocess.run(
             ['gcc', f'-print-file-name={lib_name}'],
@@ -1063,7 +1063,7 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
             num_experts_pattern = rb'n_experts = self\.hparams\[(["\'])num_experts\1\]'
             replacement = (
                 b"# Qwen3MoE seems to use num_local_experts instead of num_experts\n"
-                b" n_experts = self.hparams.get('num_experts', None) or self.hparams.get('num_local_experts')"
+                b"            n_experts = self.hparams.get('num_experts', None) or self.hparams.get('num_local_experts')"
             )
 
             new_patched_content = re.sub(num_experts_pattern, replacement, patched_content)
@@ -1871,8 +1871,8 @@ def add_llama_cpp_system_message(messages, tools, inplace = False):
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -903,10 +903,10 @@ def _download_convert_hf_to_gguf(name = "unsloth_convert_hf_to_gguf"):
 @lru_cache(8)
 def _download_convert_hf_to_gguf_cached(name, _local_script_info):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Downloads from llama.cpp's GitHub repository (or reads a local copy if
-    # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at one — _local_script_info is
-    # resolved by the wrapper above as (path, mtime_ns, size); mtime_ns/size
-    # are part of the cache key so in-place updates invalidate the cache)
+    # Downloads from llama.cpp's GitHub repository, or reads a local copy when
+    # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR is set. _local_script_info is
+    # (path, mtime_ns, size); mtime/size in the cache key invalidate stale
+    # entries on in-place updates.
 
     # Ensure llama.cpp directory exists
     os.makedirs(LLAMA_CPP_DEFAULT_DIR, exist_ok=True)
@@ -1121,9 +1121,8 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
 pass
 
 
-# Preserve the public lru_cache surface (cache_clear, cache_info,
-# cache_parameters, __wrapped__) that existed before the wrapper/cached split,
-# so external callers, inspect.unwrap, and tests keep working.
+# Preserve the pre-split lru_cache surface (cache_clear, cache_info,
+# cache_parameters, __wrapped__) so external callers and inspect.unwrap keep working.
 _download_convert_hf_to_gguf.cache_clear = _download_convert_hf_to_gguf_cached.cache_clear
 _download_convert_hf_to_gguf.cache_info = _download_convert_hf_to_gguf_cached.cache_info
 _download_convert_hf_to_gguf.cache_parameters = _download_convert_hf_to_gguf_cached.cache_parameters

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -56,6 +56,8 @@ if not logger.hasHandlers():
 LLAMA_CPP_CONVERT_FILE = \
     "https://github.com/ggerganov/llama.cpp/raw/refs/heads/master/convert_hf_to_gguf.py"
 
+LLAMA_CPP_CONVERTER_FILENAMES = ("convert_hf_to_gguf.py", "convert-hf-to-gguf.py")
+
 COMMANDS_NOT_FOUND = (
     "command not found",
     "not found",
@@ -136,7 +138,7 @@ def _resolve_local_convert_script():
             f"Unset UNSLOTH_LLAMA_CPP_SCRIPTS_DIR to use the network converter, "
             f"or point it at a directory containing convert_hf_to_gguf.py."
         )
-    for name in ("convert_hf_to_gguf.py", "convert-hf-to-gguf.py"):
+    for name in LLAMA_CPP_CONVERTER_FILENAMES:
         candidate = os.path.join(scripts_dir, name)
         try:
             if not os.path.isfile(candidate):
@@ -571,9 +573,9 @@ def check_llama_cpp(llama_cpp_folder = LLAMA_CPP_DEFAULT_DIR):
     pass
 
     # Check for converter script
-    for converter in ["convert-hf-to-gguf.py", "convert_hf_to_gguf.py"]:
+    for converter in LLAMA_CPP_CONVERTER_FILENAMES:
         location = os.path.join(llama_cpp_folder, converter)
-        if os.path.exists(location):
+        if os.path.isfile(location):
             converter_location = location
             break
     pass
@@ -931,7 +933,7 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
             with open(_local_script, "rb") as f:
                 original_content = f.read()
         else:
-            response = requests.get(LLAMA_CPP_CONVERT_FILE, timeout = 30)
+            response = requests.get(LLAMA_CPP_CONVERT_FILE, timeout = (5, 30))
             response.raise_for_status()
             original_content = response.content
 
@@ -1011,11 +1013,11 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
              del sys.modules[original_module_name]
 
     except Exception as e:
-         logger.error(f"Unsloth: Error during download or introspection of original script: {e}", exc_info=True)
+         logger.error(f"Unsloth: Error during loading or introspecting the original script: {e}", exc_info=True)
          if temp_original_file_path and os.path.exists(temp_original_file_path):
              try: os.remove(temp_original_file_path)
              except OSError as remove_error: logger.warning(f"Could not remove temp file {temp_original_file_path}: {remove_error}")
-         raise RuntimeError(f"Failed during download/introspection of original script: {e}") from e
+         raise RuntimeError(f"Failed during loading/introspection of original script: {e}") from e
     finally:
         if temp_original_file_path and os.path.exists(temp_original_file_path):
             try:


### PR DESCRIPTION
Add _resolve_local_convert_script() helper and an opt-in path in _download_convert_hf_to_gguf() that reads convert_hf_to_gguf.py from UNSLOTH_LLAMA_CPP_SCRIPTS_DIR instead of fetching master from GitHub. Lets callers (e.g. Studio) pin the convert script to the same llama.cpp ref as their llama-quantize binary and gguf-py, avoiding API drift. The cache key now includes _local_script so env-var changes are honored. Default behavior (env var unset) is unchanged: download from master.