### PR TITLE
Fix Gemma-4 E-series 4bit init crash and register MoE LoRA extractor

### DIFF
--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -20,6 +20,7 @@ from .gemma import *
 from .misc import *
 from .gemma3n import *
 from .gemma4 import *
+from .gemma4_init_weights import *
 from .gpt_oss import *
 from .qwen3_moe import *
 from .qwen3_vl_moe import *

--- a/unsloth_zoo/temporary_patches/gemma4_init_weights.py
+++ b/unsloth_zoo/temporary_patches/gemma4_init_weights.py
@@ -1,0 +1,151 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Skip non-float weight init for Gemma-4 E-series MatFormer 4-bit checkpoints.
+
+The E2B and E4B Gemma-4 unsloth-bnb-4bit checkpoints intentionally omit upper
+layer K, V and K-norm projections plus the tied lm_head. Those layers run in
+KV-shared mode, so the local k_proj / v_proj / k_norm tensors are never
+invoked at runtime, and lm_head is rebound to embed_tokens by tie_weights.
+
+transformers v5 fills the missing slots with torch.empty_like(param) against
+the underlying bnb-4bit Params4bit, which preserves the uint8 quant_storage
+dtype. Gemma4PreTrainedModel._init_weights then calls
+super()._init_weights(...) which dispatches to init.normal_(module.weight)
+on the uint8 tensor. PyTorch's normal_kernel_cuda is float-only, so the load
+crashes with:
+
+    RuntimeError: "normal_kernel_cuda" not implemented for 'Byte'
+
+This patch wraps Gemma4PreTrainedModel._init_weights so that any module whose
+primary weight tensor is non-floating-point is skipped. The placeholder is
+either filled from the state_dict immediately afterwards, or belongs to a
+KV-shared layer that the runtime never reads. The patch is a no-op on
+transformers builds that do not ship Gemma-4, and a no-op on float (non
+quantised) checkpoints because module.weight stays bfloat16 / float16 /
+float32.
+"""
+
+import torch
+import torch.nn as nn
+
+from .common import TEMPORARY_PATCHES, UNSLOTH_ENABLE_LOGGING
+from .utils import logger
+
+
+def _is_floating_point_dtype(dtype):
+    if dtype is None:
+        return False
+    try:
+        return dtype.is_floating_point
+    except AttributeError:
+        return False
+
+
+def _module_has_only_non_float_params(module):
+    """True if every direct param / buffer attached to this module is non-float
+    and the module has at least one such attachment.
+
+    Children get visited separately by initialize_weights' smart_apply, so we
+    only inspect direct attachments here.
+    """
+    saw_any = False
+    for p in module.parameters(recurse=False):
+        saw_any = True
+        if _is_floating_point_dtype(p.dtype):
+            return False
+    for b in module.buffers(recurse=False):
+        saw_any = True
+        if _is_floating_point_dtype(b.dtype):
+            return False
+    return saw_any
+
+
+def _weight_is_non_float(module):
+    """nn.Linear and bnb Linear4bit both expose `weight`. For E-series 4-bit
+    placeholders this is a uint8 Params4bit, which init.normal_ cannot touch.
+    Other Gemma-4 submodules (RMSNorm, Embedding, Router, Experts) keep float
+    weights and are left to the original initializer.
+    """
+    weight = getattr(module, "weight", None)
+    if weight is None:
+        return False
+    if not isinstance(weight, torch.Tensor):
+        return False
+    return not _is_floating_point_dtype(weight.dtype)
+
+
+def patch_gemma4_init_weights_skip_non_float():
+    """Wrap Gemma4PreTrainedModel._init_weights to skip non-float params.
+
+    Idempotent. Safe no-op when transformers does not ship Gemma-4.
+    """
+    try:
+        from transformers.models.gemma4.modeling_gemma4 import (
+            Gemma4PreTrainedModel,
+        )
+    except Exception:
+        return
+
+    if getattr(Gemma4PreTrainedModel, "_unsloth_init_weights_skip_non_float", False):
+        return
+
+    _original_init_weights = Gemma4PreTrainedModel._init_weights
+
+    @torch.no_grad()
+    def _patched_init_weights(self, module):
+        if _weight_is_non_float(module):
+            if UNSLOTH_ENABLE_LOGGING:
+                cls_name = type(module).__name__
+                weight = getattr(module, "weight", None)
+                w_dtype = weight.dtype if isinstance(weight, torch.Tensor) else None
+                logger.info(
+                    f"Unsloth: Skipping _init_weights on {cls_name} "
+                    f"(weight dtype={w_dtype}). Expected for bnb-4bit "
+                    f"placeholders on Gemma-4 E-series KV-shared layers."
+                )
+            return
+
+        if _module_has_only_non_float_params(module):
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.info(
+                    f"Unsloth: Skipping _init_weights on {type(module).__name__} "
+                    "(all direct params and buffers are non-floating-point)."
+                )
+            return
+
+        _original_init_weights(self, module)
+
+    _patched_init_weights.__qualname__ = _original_init_weights.__qualname__
+    _patched_init_weights.__name__ = getattr(
+        _original_init_weights, "__name__", "_init_weights",
+    )
+    _patched_init_weights.__doc__ = getattr(_original_init_weights, "__doc__", None)
+    _patched_init_weights.__wrapped__ = _original_init_weights
+
+    Gemma4PreTrainedModel._original_init_weights_pre_unsloth = _original_init_weights
+    Gemma4PreTrainedModel._init_weights = _patched_init_weights
+    Gemma4PreTrainedModel._unsloth_init_weights_skip_non_float = True
+
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(
+            "Unsloth: Patched Gemma4PreTrainedModel._init_weights to skip "
+            "non-float params (E-series MatFormer bnb-4bit fix)."
+        )
+
+
+TEMPORARY_PATCHES.append(patch_gemma4_init_weights_skip_non_float)

--- a/unsloth_zoo/temporary_patches/gemma4_moe.py
+++ b/unsloth_zoo/temporary_patches/gemma4_moe.py
@@ -17,12 +17,49 @@
 import os
 import torch
 import torch.nn as nn
-from .common import TEMPORARY_PATCHES
+from .common import TEMPORARY_PATCHES, UNSLOTH_ENABLE_LOGGING
 from .utils import patch_function, process_return, raise_error, logger
 from .moe_utils import (
     patch_param_wrapper_for_moe,
     get_forward_moe_backend,
 )
+# Reuse the Qwen-MoE standard-layout LoRA extractor. Gemma4TextExperts has the
+# same (E, out, in) layout, the same hidden_dim / intermediate_dim attribute
+# names, and per_expert_scale is folded into top_k_weights upstream by
+# Gemma4TextRouter.forward, so no Gemma-4-specific scale handling is needed
+# inside the extractor itself.
+from .qwen3_moe import _make_qwen_moe_lora_extractor
+
+
+def _register_gemma4_lora_extractor(experts_cls):
+    """Attach _unsloth_lora_extractor_fn to a Gemma-4 experts class.
+
+    Idempotent and safe if experts_cls is None. Without this registration,
+    moe_utils._extract_lora_from_wrapper falls through to the default
+    canonical-permutation branch, which can produce shapes whose contraction
+    dimensions do not match for torch._grouped_mm on PEFT 0.19+ swapped
+    layouts. The crash surfaces as
+        RuntimeError: contraction dimension of mat_a and mat_b must match
+    on the first training step. Gemma-4 experts share the Qwen-MoE standard
+    layout, so the Qwen extractor handles both PEFT 0.18 and 0.19 cleanly.
+    """
+    if experts_cls is None:
+        return False
+    if getattr(experts_cls, "_unsloth_lora_extractor_registered", False):
+        return True
+    try:
+        extractor = _make_qwen_moe_lora_extractor()
+        experts_cls._unsloth_lora_extractor_fn = staticmethod(extractor)
+        experts_cls._unsloth_model_type = "gemma4_moe"
+        experts_cls._unsloth_lora_extractor_registered = True
+        return True
+    except Exception as e:
+        if UNSLOTH_ENABLE_LOGGING:
+            logger.warning(
+                f"Unsloth: Could not register Gemma-4 MoE LoRA extractor on "
+                f"{getattr(experts_cls, '__name__', experts_cls)}: {e}"
+            )
+        return False
 
 
 def patch_gemma4_grpo_hidden_states():
@@ -171,6 +208,10 @@ def _patch_gemma4_moe_current():
         return False
 
     if getattr(Gemma4TextExperts, "_unsloth_already_patched", False):
+        # Even when forward is already patched, make sure the extractor is
+        # registered. Guards against an older unsloth-zoo that patched
+        # forward but lacked the extractor registration.
+        _register_gemma4_lora_extractor(Gemma4TextExperts)
         return True
 
     _moe_backend = get_forward_moe_backend()
@@ -184,6 +225,9 @@ def _patch_gemma4_moe_current():
     ok = patch_function(Gemma4TextExperts, "forward", _gemma4_experts_forward, force=True)
     if ok:
         Gemma4TextExperts._unsloth_already_patched = True
+        # Register the Qwen-MoE-style standard-layout extractor so that the
+        # grouped-mm LoRA path produces correct contraction dimensions.
+        _register_gemma4_lora_extractor(Gemma4TextExperts)
     return ok
 
 
@@ -198,6 +242,8 @@ def _patch_gemma4_moe_legacy():
         return False
 
     if getattr(Gemma4TextMoEBlock, "_unsloth_already_patched", False):
+        # Same defensive re-registration as in the current-layout path.
+        _register_gemma4_lora_extractor(Gemma4TextMoEBlock)
         return True
 
     # Remap decoder layer module names to match checkpoint key layout:
@@ -244,6 +290,9 @@ def _patch_gemma4_moe_legacy():
         return False
 
     Gemma4TextMoEBlock._unsloth_already_patched = True
+    # Legacy MoE block has the same parameter layout (E, out, in). Register
+    # the same standard-layout extractor.
+    _register_gemma4_lora_extractor(Gemma4TextMoEBlock)
     return True
 
 


### PR DESCRIPTION
## Summary

Two independent Studio crashes on Gemma-4. Both fixed in this PR.

### Bug 1: `unsloth/gemma-4-E2B-it-unsloth-bnb-4bit` and `unsloth/gemma-4-E4B-it-unsloth-bnb-4bit` crash on load with

```
RuntimeError: "normal_kernel_cuda" not implemented for 'Byte'
```

The E-series uses partial KV sharing across upper layers, so the checkpoint omits `self_attn.{k_proj,v_proj,k_norm}.weight` for those layers and `lm_head.weight`. transformers v5 materialises the missing slots with `torch.empty_like(param)` against the bnb-4bit `Params4bit`, which preserves the `quant_storage=torch.uint8` dtype. `Gemma4PreTrainedModel._init_weights` then dispatches to `init.normal_(module.weight)` on a uint8 tensor, which has no float kernel.

Fix: wrap `Gemma4PreTrainedModel._init_weights` to skip any module whose primary weight tensor is non-floating-point. Placeholders are filled from the state_dict immediately afterwards, or they belong to KV-shared layers that the runtime never reads.

New file: `unsloth_zoo/temporary_patches/gemma4_init_weights.py`. One line added to `unsloth_zoo/temporary_patches/__init__.py`.

### Bug 2: `unsloth/gemma-4-26B-A4B-it` crashes on the first training step with

```
RuntimeError: contraction dimension of mat_a and mat_b must match
```

raised from `torch._grouped_mm` in `moe_utils.native_moe_grouped_mm`. The gemma4_moe patch only patches `Gemma4TextExperts.forward` but never registers `_unsloth_lora_extractor_fn`. `_extract_lora_from_wrapper` falls through to the default branch which does not handle PEFT 0.19+ swapped 3D LoRA layouts.

Sibling MoE families that already register the extractor: `qwen3_moe`, `qwen3_5_moe`, `qwen3_next_moe`, `qwen3_vl_moe`, `glm4_moe`, `deepseek_v3_moe`.

Fix: register `_make_qwen_moe_lora_extractor()` on `Gemma4TextExperts` and the legacy `Gemma4TextMoEBlock`. Gemma-4 experts share the Qwen-MoE standard `(E, out, in)` layout and the same `hidden_dim` / `intermediate_dim` attribute names, so the Qwen extractor applies verbatim. `per_expert_scale` is folded into `top_k_weights` upstream by `Gemma4TextRouter.forward`, so no Gemma-4-specific handling is needed inside the extractor.

### Compatibility

Both patches gate on `from transformers.models.gemma4.modeling_gemma4 import ...` and no-op cleanly when Gemma-4 is not present, so transformers 4.57.6 is unaffected. Validated against transformers 5.5.0. The Qwen extractor handles PEFT 0.18 and 0.19+ via its existing `_did_swap_in_out_features` dispatch, so TRL 0.22.2 / 0.27.1 / 1.0.0 all work. Both patches are idempotent.

## Test plan

- [x] Load `unsloth/gemma-4-E2B-it-unsloth-bnb-4bit` via `FastVisionModel.from_pretrained` with `load_in_4bit=True`. Before this PR this crashed with the Byte init error. After this PR the load succeeds, the missing KV-shared slots stay uint8 placeholders, and the runtime never invokes them.
- [x] Load `unsloth/gemma-4-26B-A4B-it` with LoRA on attention plus `experts.gate_up_proj` and `experts.down_proj`, run one forward + backward. Before this PR this crashed with the contraction-dimension error on the first step. After this PR it returns a finite loss and a clean grad.
- [x] Confirm no regression for `unsloth/gemma-4-31B-it` (dense, did not hit either bug before).
- [x] Confirm sibling MoE families (Qwen3 variants, GLM4, DeepSeek-V3) are unchanged.