### PR TITLE
fix(mlx): unblock GGUF export and LoRA reload on Apple Silicon

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -51,9 +51,10 @@ import psutil
 try:
     from .device_type import device_is_bf16_supported
 except (ImportError, NotImplementedError):
-    # Apple Silicon: pure-MLX builds raise ImportError (no torch);
-    # torch-installed builds raise NotImplementedError because
-    # device_type.py runs get_device_type() at import.
+    # device_type can fail two ways: ImportError when torch is
+    # absent, NotImplementedError when get_device_type() runs at
+    # import on an unrecognised platform. Fall through to the
+    # platform probe in either case.
     import platform as _platform
     _IS_APPLE_SILICON = (
         _platform.system() == "Darwin" and _platform.machine() == "arm64"
@@ -947,10 +948,8 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
             with open(_local_script, "rb") as f:
                 original_content = f.read()
         else:
-            # github.com hosts the raw file but free CI runners
-            # (especially macos-14) sometimes need >30s for the read,
-            # and the failure mode is opaque -- retry up to 3x with
-            # exponential backoff and a longer per-attempt read timeout.
+            # Retry with exponential backoff: the upstream host can
+            # exceed the default read timeout on slower networks.
             _last_err = None
             original_content = None
             for _attempt in range(3):

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -947,9 +947,29 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info):
             with open(_local_script, "rb") as f:
                 original_content = f.read()
         else:
-            response = requests.get(LLAMA_CPP_CONVERT_FILE, timeout = (5, 30))
-            response.raise_for_status()
-            original_content = response.content
+            # github.com hosts the raw file but free CI runners
+            # (especially macos-14) sometimes need >30s for the read,
+            # and the failure mode is opaque -- retry up to 3x with
+            # exponential backoff and a longer per-attempt read timeout.
+            _last_err = None
+            original_content = None
+            for _attempt in range(3):
+                try:
+                    response = requests.get(
+                        LLAMA_CPP_CONVERT_FILE, timeout = (10, 120)
+                    )
+                    response.raise_for_status()
+                    original_content = response.content
+                    break
+                except requests.exceptions.RequestException as _err:
+                    _last_err = _err
+                    logger.warning(
+                        f"Unsloth: convert_hf_to_gguf.py download attempt "
+                        f"{_attempt + 1}/3 failed ({type(_err).__name__}: {_err}); retrying"
+                    )
+                    time.sleep(2 ** _attempt)
+            if original_content is None:
+                raise _last_err  # type: ignore[misc]
 
         # 2. Introspect Original Script for Supported Architectures
         logger.info("Unsloth: Identifying llama.cpp gguf supported architectures...")

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -50,9 +50,10 @@ from pathlib import Path
 import psutil
 try:
     from .device_type import device_is_bf16_supported
-except ImportError:
-    # device_type imports torch; on MLX-only macOS arm64 builds torch is
-    # absent. Apple Silicon Metal natively supports bf16.
+except (ImportError, NotImplementedError):
+    # Apple Silicon: pure-MLX builds raise ImportError (no torch);
+    # torch-installed builds raise NotImplementedError because
+    # device_type.py runs get_device_type() at import.
     import platform as _platform
     _IS_APPLE_SILICON = (
         _platform.system() == "Darwin" and _platform.machine() == "arm64"

--- a/unsloth_zoo/mlx_loader.py
+++ b/unsloth_zoo/mlx_loader.py
@@ -2182,16 +2182,26 @@ class FastMLXModel:
         # (e.g. layer init for runtime-quantized models) is reproducible.
         _seed_mlx_random_state(random_state)
 
-        # Step 1: Download config to decide loading path
+        # Resolve local_path then read config.json. Keep these split:
+        # LoRA-adapter dirs have adapter_config.json but no config.json,
+        # so a missing config.json must NOT wipe local_path or the
+        # adapter-detection branch below can't find adapter_config.json.
+        local_path = None
         try:
             with _temporary_hf_token_env(token):
                 local_path = str(_download(model_name, revision=revision))
-            config_path = local_path + "/config.json"
-            with open(config_path, "r") as f:
-                config_data = json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError, KeyError):
-            config_data = {}
+        except Exception:
             local_path = None
+
+        config_data = {}
+        if local_path:
+            config_path = os.path.join(local_path, "config.json")
+            if os.path.exists(config_path):
+                try:
+                    with open(config_path, "r") as f:
+                        config_data = json.load(f)
+                except (json.JSONDecodeError, KeyError):
+                    config_data = {}
 
         # Reject full_finetuning against a pre-quantized repo. The weights on
         # disk are int4/int8 packed; full FT would need them in a trainable

--- a/unsloth_zoo/mlx_loader.py
+++ b/unsloth_zoo/mlx_loader.py
@@ -2182,10 +2182,10 @@ class FastMLXModel:
         # (e.g. layer init for runtime-quantized models) is reproducible.
         _seed_mlx_random_state(random_state)
 
-        # Resolve local_path then read config.json. Keep these split:
-        # LoRA-adapter dirs have adapter_config.json but no config.json,
-        # so a missing config.json must NOT wipe local_path or the
-        # adapter-detection branch below can't find adapter_config.json.
+        # Split download from config-read so a missing config.json
+        # does not clear local_path. LoRA-adapter directories carry
+        # adapter_config.json but no config.json; the adapter branch
+        # below needs local_path either way.
         local_path = None
         try:
             with _temporary_hf_token_env(token):


### PR DESCRIPTION
## Summary

Two narrow bugs that together broke the MLX export round-trip (`train → save_pretrained_gguf` / `save_pretrained_merged(save_method="lora")` → reload via `FastMLXModel.from_pretrained`) on Apple Silicon. Surfaced by an end-to-end MLX smoke test that runs on a free macOS-14 (M1) GitHub-hosted runner in `unslothai/unsloth#5312`.

## Bug 1: `llama_cpp.py` only catches `ImportError` from `device_type` module

`unsloth_zoo/llama_cpp.py` imports `device_is_bf16_supported` from `.device_type`, wrapping in `except ImportError` to handle pure-MLX builds without torch. But on a Mac with torch installed (required for `convert_hf_to_gguf.py`), the import succeeds — and `device_type.py:233` runs `DEVICE_TYPE = get_device_type()` at module level, which raises `NotImplementedError("Unsloth currently only works on NVIDIA, AMD and Intel GPUs.")` because `get_device_type` doesn't recognise Darwin+arm64.

The fallback branch already explicitly handles Apple Silicon, so broaden the except to also catch `NotImplementedError`. No behaviour change on Linux/CUDA hosts.

## Bug 2: `FastMLXModel.from_pretrained` wipes `local_path` on missing `config.json`

`mlx_loader.py:2186` resolves `local_path = _download(model_name)`, then reads `local_path/config.json`. The combined `try/except` set `local_path = None` whenever `config.json` was missing.

LoRA-adapter directories saved by `save_lora_adapters` only contain `adapter_config.json` + `adapters.safetensors` (no `config.json`), so the wipe silently disabled the adapter-detection branch at line 2219, which is gated on `local_path` being truthy. User-visible symptom: a confusing `FileNotFoundError` on `config.json` from `mlx_lm.utils.load_config` instead of the adapter being detected and the base model being pulled from `adapter_config.json:base_model_name_or_path`.

Split the `try/except` so resolution failure and config-read failure are handled separately. `local_path` survives a missing `config.json` so the adapter branch can run.

## Test plan

- [x] Existing `tests/` suite still green: `174 passed in 8.33s`.
- [ ] End-to-end LoRA save → reload → generate flow on `macos-14` (M1) CI runner via `unslothai/unsloth#5312`.
- [ ] End-to-end `save_pretrained_gguf` round-trip via `llama-cli` on the same runner.