### PR TITLE
tests: skip MoE LoRA extractor coverage when discovery finds zero classes

### DIFF
--- a/tests/test_moe_lora_extractor_coverage.py
+++ b/tests/test_moe_lora_extractor_coverage.py
@@ -302,11 +302,27 @@ def test_every_patched_moe_experts_class_has_lora_extractor():
     _apply_all_temporary_patches()
 
     patched = _discover_patched_moe_classes()
-    assert patched, (
-        "Discovery produced zero patched MoE classes. Either no MoE "
-        "transformers module imported on this transformers version, or the "
-        "_unsloth_already_patched marker convention changed. Investigate."
-    )
+    if not patched:
+        # Two situations produce zero discoveries:
+        #   1. The transformers version installed predates the MoE class
+        #      surface unsloth_zoo patches (e.g. transformers 4.57.6 ships
+        #      none of the gemma4 / llama4 / qwen3_moe / mxfp4 classes the
+        #      TEMPORARY_PATCHES list targets, so every patch fn no-ops).
+        #   2. The `_unsloth_already_patched` marker convention drifted
+        #      (the regression this test guards against).
+        # We can't tell (1) and (2) apart by discovery alone. Skip rather
+        # than fail: a CI cell pinned to an older transformers should not
+        # surface as a red regression here. CI cells running the
+        # transformers version the PR actually pins (and any newer one)
+        # will discover patched classes and run the real assertion.
+        pytest.skip(
+            "No patched MoE classes discovered on this transformers version. "
+            "Either transformers is older than the MoE class surface "
+            "unsloth_zoo patches, or the _unsloth_already_patched marker "
+            "convention changed. The latter is a real regression but "
+            "indistinguishable from the former here; skip and let cells "
+            "running newer transformers exercise the real assertion."
+        )
 
     # Hard contract: extractor must be registered on every patched class.
     missing = [

--- a/tests/test_moe_lora_extractor_coverage.py
+++ b/tests/test_moe_lora_extractor_coverage.py
@@ -303,25 +303,60 @@ def test_every_patched_moe_experts_class_has_lora_extractor():
 
     patched = _discover_patched_moe_classes()
     if not patched:
-        # Two situations produce zero discoveries:
-        #   1. The transformers version installed predates the MoE class
-        #      surface unsloth_zoo patches (e.g. transformers 4.57.6 ships
-        #      none of the gemma4 / llama4 / qwen3_moe / mxfp4 classes the
-        #      TEMPORARY_PATCHES list targets, so every patch fn no-ops).
-        #   2. The `_unsloth_already_patched` marker convention drifted
-        #      (the regression this test guards against).
-        # We can't tell (1) and (2) apart by discovery alone. Skip rather
-        # than fail: a CI cell pinned to an older transformers should not
-        # surface as a red regression here. CI cells running the
-        # transformers version the PR actually pins (and any newer one)
-        # will discover patched classes and run the real assertion.
+        # Disambiguate two zero-discovery causes:
+        #   (a) the installed transformers predates every MoE class surface
+        #       unsloth_zoo targets (TEMPORARY_PATCHES entries no-op silently
+        #       when their target submodule is absent) -- legitimate skip; or
+        #   (b) the `_original_<modeling_tail>_<ClassName>_forward` marker
+        #       convention used by `temporary_patches.utils.patch_function`
+        #       (and read by `_has_unsloth_patched_forward` above) drifted --
+        #       a real regression that the test must surface.
+        # Probe a stable canary: if ANY of the known MoE classes the patch
+        # functions target is importable on this transformers, then the
+        # patch surface exists and (a) is ruled out -- a zero discovery
+        # under that condition is (b), and we fail loudly. Otherwise we
+        # genuinely have no patch surface to test and skip.
+        # Structural canary: walk every transformers.models.*.modeling_* module
+        # and ask "does ANY class declare `gate_up_proj` + `down_proj` as 3D
+        # `nn.Parameter`?" That is precisely the surface
+        # `_looks_like_grouped_moe_experts` filters discovery on. If at least
+        # one such class exists anywhere in transformers, the surface this
+        # test guards IS present on this version, and discovery returning 0
+        # is a real regression (either `_has_unsloth_patched_forward`'s marker
+        # convention drifted or every TEMPORARY_PATCHES entry that targets
+        # such a class silently failed before reaching `patch_function`).
+        # Scanning the live tree avoids hard-coding model names that change
+        # as transformers grows new MoE families.
+        importable = [
+            f"{cls.__module__}.{cls.__name__}"
+            for modeling in _iter_modeling_modules()
+            for _, cls in inspect.getmembers(modeling, inspect.isclass)
+            if isinstance(cls, type)
+            and getattr(cls, "__module__", None) == modeling.__name__
+            and _looks_like_grouped_moe_experts(cls)
+        ]
+        if importable:
+            raise AssertionError(
+                "Discovery produced zero patched MoE classes, but transformers "
+                f"ships {len(importable)} class(es) whose `__init__` declares "
+                "`gate_up_proj` + `down_proj` as 3D `nn.Parameter`s -- the "
+                "exact surface this test targets. Examples: "
+                f"{importable[:5]}. That means TEMPORARY_PATCHES entries ran "
+                "without recording the `_original_<modeling_tail>_<ClassName>_"
+                "forward` marker that `_has_unsloth_patched_forward` reads. "
+                "Either `patch_function` no longer stores the original under "
+                "that attribute name, or the patch fn for every grouped-MoE "
+                "family silently failed before reaching `patch_function`. "
+                "This is the regression the test guards against -- do not "
+                "convert this back into a skip without first re-establishing "
+                "the marker convention."
+            )
         pytest.skip(
-            "No patched MoE classes discovered on this transformers version. "
-            "Either transformers is older than the MoE class surface "
-            "unsloth_zoo patches, or the _unsloth_already_patched marker "
-            "convention changed. The latter is a real regression but "
-            "indistinguishable from the former here; skip and let cells "
-            "running newer transformers exercise the real assertion."
+            "No patched MoE classes discovered AND no class anywhere in "
+            "transformers.models.* declares `gate_up_proj` + `down_proj` as "
+            "3D `nn.Parameter`s. The grouped-MoE patch surface this test "
+            "guards is absent on this transformers version; cells running a "
+            "newer transformers exercise the real assertion."
         )
 
     # Hard contract: extractor must be registered on every patched class.


### PR DESCRIPTION
## Summary

`test_every_patched_moe_experts_class_has_lora_extractor` (PR #624) is
designed to prevent a regression where a class flagged
`_unsloth_already_patched=True` is missing `_unsloth_lora_extractor_fn`.
Its defensive precondition was "discovery produced at least one patched
class"; failing that, the test raised an AssertionError telling the
reader to investigate.

That precondition fires on any transformers version older than the MoE
class surface `unsloth_zoo.temporary_patches` targets. With
`transformers==4.57.6` for example, none of the gemma4 / llama4 /
qwen3_moe / mxfp4 classes the `TEMPORARY_PATCHES` list patches exist,
so every patch fn no-ops and discovery returns `[]`. The "zero
discoveries" outcome on an older transformers is **not** a regression
of the bug being prevented; it just means the relevant classes aren't
there to patch.

Replace `assert patched, ...` with `pytest.skip(...)` and a comment
explaining the two indistinguishable cases. CI cells running newer
transformers (where the classes do exist) still exercise the real
assertion below; the older-transformers cell skips cleanly.

## Test plan

- [x] Locally: with the workspace's pyproject-pinned transformers (5.x
      cap), discovery still produces patched classes and the real
      assertion runs.
- [ ] CI on unslothai/unsloth#5312 cell `transformers==4.57.6 + trl<1`
      should drop the failure on this test on the next run.

## Why this isn't `pytest.mark.skipif(transformers_version < X.Y)`

A version-string skipif would have to encode every minimum version
across the `TEMPORARY_PATCHES` list (gemma3, gemma4, llama4, qwen3_moe,
mxfp4 each landed in a different transformers release) AND track
upstream renames. The "zero patched classes" runtime check is the
precise condition we actually care about: skip when nothing is there
to verify.

Surfaced by the consolidated CPU-CI matrix on unslothai/unsloth#5312.