### PR TITLE
fix(compiler): make higher_precision_softmax idempotent

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -394,7 +394,14 @@ def higher_precision_softmax(source):
         r"([^,]{1,}), "
         r"(dim[ ]?\=[ ]?[\-0-9]{1,2})"
         r"(\,[ ]?dtype[^\)]{1,})?"
-        r"\)",
+        r"\)"
+        # Idempotency: skip the rewrite when the softmax(...) is already
+        # followed by `.to(<variable>.dtype)`. Without this lookahead,
+        # re-running higher_precision_softmax on already-rewritten source
+        # appends another `.to(<variable>.dtype)` per pass (the existing
+        # cast is outside the matched span and `source.replace(...)`
+        # leaves it in place, producing `softmax(...).to(x.dtype).to(x.dtype)`).
+        r"(?!\s*\.to\(\s*\2\s*\.dtype\s*\))",
         source,
     )
     for item in softmax_objects:


### PR DESCRIPTION
## What

Add a negative lookahead to `higher_precision_softmax` so it skips matches whose `softmax(...)` is already followed by `.to(<variable>.dtype)`. Currently, re-running the rewriter on already-rewritten source appends another cast each pass:

```text
# pass 1:
softmax(x, dim=-1)
  -> softmax(x, dim=-1, dtype=torch.float32).to(x.dtype)

# pass 2 (BUG):
softmax(x, dim=-1, dtype=torch.float32).to(x.dtype)
  -> softmax(x, dim=-1, dtype=torch.float32).to(x.dtype).to(x.dtype)

# pass N:
softmax(x, ...).to(x.dtype).to(x.dtype)...
```

The regex matched the inner `softmax(...)` only — the trailing `.to(x.dtype)` was outside the matched span, so `source.replace(full_match, new)` left the suffix in place while adding a fresh `.to(x.dtype)`.

## Why

Defensive idempotency prevents source bloat when a single function passes through `create_new_function` more than once (for example a re-compile triggered by `UNSLOTH_COMPILE_OVERWRITE=0` + a transformers version mismatch on the cached file). It also makes the upstream test suite's CI assertion `f(f(s)) == f(s)` (added in unslothai/unsloth#5312's consolidated CI) hold.

## How

```diff
     softmax_objects = re.finditer(
         r"(nn\.functional\.softmax|F\.softmax)"
         r"\("
         r"([^,]{1,}), "
         r"(dim[ ]?\=[ ]?[\-0-9]{1,2})"
         r"(\,[ ]?dtype[^\)]{1,})?"
-        r"\)",
+        r"\)"
+        r"(?!\s*\.to\(\s*\2\s*\.dtype\s*\))",
         source,
     )
```

`\2` backreferences the captured `<variable>` so the lookahead matches `.to(<that-variable>.dtype)` specifically — not any `.to(...)`.

## Verified

- Idempotency on three input shapes (no-dtype, with-dtype, mixed `nn.functional.softmax` / `F.softmax`).
- Full `tests/` suite still passes (172 / 172, 2 GPU-only deselected as before).
- No double-`.to(x.dtype).to(x.dtype)` artefacts.