### PR TITLE
fix(compiler): unblock all model_types across transformers 4.57.6 and 5.x

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -815,7 +815,8 @@ def create_new_function(
     # Fix all softmax low precisions to float32
     new_source = higher_precision_softmax(new_source)
 
-    if new_source[0] == " ":
+    # Empty new_source (e.g. dpr, rag) -> skip dedent (avoids IndexError).
+    if new_source and new_source[0] == " ":
         spaces = new_source.find("def")
         new_source = new_source.split("\n")
         new_source = "\n".join(x[spaces:] for x in new_source)
@@ -844,6 +845,30 @@ def create_new_function(
     # Patch for SiglipEncoder and others
     if "SiglipEncoder" in new_source:
         items += ["SiglipEncoder"]
+    # Detect base-class references whose base isn't defined in new_source.
+    # `functions` is pre-filtered to exclude torch_modules, so a base class
+    # like Sam3LiteTextLayerScaledResidual (no own forward, used only as
+    # a base) drops out of items. Pull it back in by scanning `class X(Y...)`
+    # bases against the full modeling-file dir.
+    try:
+        _modeling_file = eval(model_location)
+        _modeling_dir = set(dir(_modeling_file))
+    except Exception:
+        _modeling_dir = set()
+    if _modeling_dir:
+        for base in re.findall(r"^class\s+\w+\(([^)]*)\)\s*:", new_source, flags=re.MULTILINE):
+            for b in base.split(","):
+                b = b.strip().split(".")[0]
+                if (
+                    b
+                    and b in _modeling_dir
+                    and b not in items
+                    and b != name
+                    and f"class {b}(" not in new_source
+                    and f"class {b}:" not in new_source
+                    and f"def {b}(" not in new_source
+                ):
+                    items.append(b)
     # Check for create_causal_mask, create_masks_for_generate, create_sliding_window_causal_mask
     mask_functions = get_mask_functions()
     for mask_function in mask_functions:
@@ -1339,14 +1364,20 @@ def create_standalone_class(
     # Combine all into file
     source = source + full_class
 
-    # Remove @auto_docstring
-    source = re.sub(r"@auto_docstring[\s]{0,}(\([^\)]{0,}\))?", "", source)
-    source = re.sub(r"@use_kernelized_func[\s]{0,}(\([^\)]{0,}\))?", "", source)
-    source = re.sub(r"@check_model_inputs[\s]{0,}(\([^\)]{0,}\))?", "", source)
-    # Transformers 5.x decorators on forward methods
-    source = re.sub(r"@merge_with_config_defaults[\s]{0,}(\([^\)]{0,}\))?", "", source)
-    source = re.sub(r"@capture_outputs[\s]{0,}(\([^\)]{0,}\))?", "", source)
-    # source = source.replace("@auto_docstring", "")
+    # Strip decorators that the cache cannot import. `[^\)]*` is unsafe
+    # when the decorator argument is a string with a literal ')' inside
+    # (voxtral / audioflamingo3 etc. use auto_docstring with custom_intro
+    # strings that contain "(a log mel spectrogram)") -- the lazy
+    # close-paren match stopped early and left the rest of the string
+    # in the cache, raising "unterminated string literal". Use a
+    # recursive group so nested parens balance correctly.
+    _PAREN_GROUP = r"(?P<grp>\((?:[^()'\"]|'[^'\\]*(?:\\.[^'\\]*)*'|\"[^\"\\]*(?:\\.[^\"\\]*)*\"|(?P>grp))*\))"
+    for _dec in (
+        "auto_docstring", "use_kernelized_func", "check_model_inputs",
+        # Transformers 5.x decorators on forward methods
+        "merge_with_config_defaults", "capture_outputs",
+    ):
+        source = regex.sub(rf"@{_dec}\s*(?:{_PAREN_GROUP})?", "", source)
 
     # Fix Gemma 3 ignore_index being not set!
     source = source.replace("self.config.ignore_index", "-100")
@@ -1866,13 +1897,22 @@ def apply_fused_lm_head(forward, module=None):
             "$KWARGS$", "locals().get('loss_kwargs', {}) or locals().get('kwargs', {})"
         )
 
-        # Fix Idefics and Idefics3
-        forward = forward.replace(
-            "loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))",
-            "shift_logits = shift_logits.view(-1, self.config.text_config.vocab_size)\n"
-            "shift_labels = shift_labels.view(-1)\n"
-            "shift_labels = shift_labels.to(shift_logits.device)\n"
-            "loss = loss_fct(shift_logits, shift_labels)",
+        # Fix Idefics and Idefics3. Anchor to start-of-line + capture leading
+        # whitespace so this doesn't substring-match `lm_loss = loss_fct(...)`
+        # (gpt2 / electra / tapas) or emit unindented lines that the downstream
+        # dedent then chops 4 chars off.
+        forward = re.sub(
+            r"^([ \t]+)loss = loss_fct\("
+            r"shift_logits\.view\(-1, shift_logits\.size\(-1\)\), "
+            r"shift_labels\.view\(-1\)\)$",
+            lambda m: (
+                f"{m.group(1)}shift_logits = shift_logits.view(-1, self.config.text_config.vocab_size)\n"
+                f"{m.group(1)}shift_labels = shift_labels.view(-1)\n"
+                f"{m.group(1)}shift_labels = shift_labels.to(shift_logits.device)\n"
+                f"{m.group(1)}loss = loss_fct(shift_logits, shift_labels)"
+            ),
+            forward,
+            flags=re.MULTILINE,
         )
 
         # Find matches
@@ -2116,6 +2156,12 @@ def convert_attention_masks_to_bool(module, old_source):
     all_splits = source.strip().split("\n")
     splits = all_splits[-1].strip()
     if "return" not in splits:
+        return old_source
+    # Skip non-bare returns (e.g. kosmos2 `return x.masked_fill(...)`); the
+    # findall regex below can't parse nested parens and would produce an
+    # unbalanced `final.replace(...)` rewrite.
+    return_body = splits[len("return"):].strip()
+    if "(" in return_body:
         return old_source
     vars = re.findall(r"return[\s]{1,}(?:([^\,]{1,})\,[\s]{0,}){0,}([^\s]{1,})", splits)
     if len(vars) != 1:
@@ -2692,7 +2738,12 @@ def patch_gradient_accumulation(modeling_file, module):
     # All Unsloth Zoo code licensed under LGPLv3
 
     functions = dir(modeling_file)
-    module = eval(f"modeling_file.{module}")
+    # `module` may be a class name from dir() that isn't runtime-accessible
+    # (e.g. modeling_bit.Linear). Skip rather than abort.
+    try:
+        module = eval(f"modeling_file.{module}")
+    except AttributeError:
+        return None
     try:
         forward = module.forward
         source = inspect.getsource(forward)
@@ -2716,7 +2767,10 @@ def patch_gradient_accumulation(modeling_file, module):
 
     total_has_kwargs = False
     for call_class, inner_class in inner_classes:
-        inner_class = eval(f"modeling_file.{inner_class}")
+        try:
+            inner_class = eval(f"modeling_file.{inner_class}")
+        except AttributeError:
+            continue
         has_kwargs = (
             tuple(inspect.signature(inner_class.forward).parameters.values())[-1].kind
             == inspect._VAR_KEYWORD
@@ -3208,9 +3262,23 @@ def unsloth_compile_transformers(
     modeling_file.__UNSLOTH_PATCHED__ = True
     functions = dir(modeling_file)
     full_source = inspect.getsource(modeling_file)
-    # Order functions by ascending order
+
+    # Order by definition position. Bare-name find() hits forward refs
+    # (annotations, docstrings, `Union[..., NAME]`) so subclasses can land
+    # before their base class -- e.g. perceiver PerceiverTextPreprocessor
+    # at offset 26072 (annotation) vs its definition at 111990, raising
+    # NameError on AbstractPreprocessor at cache import.
+    def _def_pos(name):
+        for prefix in (f"class {name}(", f"class {name}:", f"def {name}("):
+            i = full_source.find(prefix)
+            if i != -1:
+                return i
+        # Fallback: bare-name (for module-level aliases without a def/class).
+        i = full_source.find(name)
+        return i if i != -1 else len(full_source)
+
     functions = list(
-        np.array(functions)[np.argsort([full_source.find(x) for x in functions])]
+        np.array(functions)[np.argsort([_def_pos(x) for x in functions])]
     )
     ordered_functions = functions.copy()
 
@@ -3394,7 +3462,11 @@ def unsloth_compile_transformers(
     disabled_scaled_dot_product_attention_modules = []
 
     for module in scaled_dot_product_attention_modules.keys():
-        source = eval(f"{model_location}.{module}")
+        # Skip class names that aren't runtime-accessible (see disable_causal_masks).
+        try:
+            source = eval(f"{model_location}.{module}")
+        except AttributeError:
+            continue
         try:
             source = inspect.getsource(source.forward)
         except:
@@ -3447,7 +3519,14 @@ def unsloth_compile_transformers(
     remove_causal_masks = []
     if disable_causal_masks:
         for module in other_classes:
-            source = eval(f"{model_location}.{module}")
+            # `other_classes` (from dir() / class regex) can include names
+            # that aren't runtime-accessible: e.g. modeling_auto._BaseModelWithGenerate
+            # (in __all__ but unbound) or modeling_{bit,regnet,resnet}.Linear
+            # (nn.Linear alias missing on some transformers versions).
+            try:
+                source = eval(f"{model_location}.{module}")
+            except AttributeError:
+                continue
             if not hasattr(source, "_update_causal_mask"):
                 continue
 
@@ -3473,7 +3552,10 @@ def unsloth_compile_transformers(
     # actively disable certain modules
     disable_modules = set()
     for module, fullgraph in torch_modules.items():
-        source = eval(f"{model_location}.{module}")
+        try:
+            source = eval(f"{model_location}.{module}")
+        except AttributeError:
+            continue
         if not hasattr(source, "forward"):
             continue
         try:
@@ -3754,7 +3836,11 @@ def unsloth_compile_transformers(
     # Allow gradient checkpointing if not enabled
     if gradient_checkpointing:
         for module in other_classes:
-            source = eval(f"{model_location}.{module}")
+            # Skip non-runtime-accessible names (see disable_causal_masks).
+            try:
+                source = eval(f"{model_location}.{module}")
+            except AttributeError:
+                continue
             if "(GradientCheckpointingLayer)" in full_source:
                 if module in FIX_GC_LAYER_CALLER_MODULES:
                     output = patch_gradient_checkpointing_layer_caller(module, source)
@@ -3791,7 +3877,11 @@ def unsloth_compile_transformers(
         if module in all_standalone_classes:
             source = all_standalone_classes[module]
         else:
-            module_cls = eval(f"{model_location}.{module}")
+            # Skip non-runtime-accessible names (see disable_causal_masks).
+            try:
+                module_cls = eval(f"{model_location}.{module}")
+            except AttributeError:
+                continue
             if hasattr(module_cls, "forward"):
                 source = inspect.getsource(module_cls.forward)
             else:
@@ -3824,7 +3914,11 @@ def unsloth_compile_transformers(
 
     if len(router_logit_cast_modules) > 0:
         for module in router_logit_cast_modules:
-            module_cls = eval(f"{model_location}.{module}")
+            # Skip non-runtime-accessible names (see disable_causal_masks).
+            try:
+                module_cls = eval(f"{model_location}.{module}")
+            except AttributeError:
+                continue
             if hasattr(module_cls, "forward"):
                 source = inspect.getsource(module_cls.forward)
             else:
@@ -3977,6 +4071,12 @@ def unsloth_compile_transformers(
                 print(f"Unsloth: Cannot run inspect.getsource on {module} with error = {e}")
                 continue
 
+            # str(inspect.signature) and source can disagree on quote style
+            # ('foo' vs "foo") or fully-qualified annotations, making find()
+            # return -1. Keep OLD `code_section = source[find("\n")+1:]` so
+            # bad_params detection still sees multi-line sig continuations
+            # (e.g. `def f(\n    a: T,\n    b: U,\n):`); only restore the
+            # trailing `:` at rebuild time below.
             where = source.find(str(parameters))
             if where == -1:
                 where = source.find("\n") + 1
@@ -4003,7 +4103,18 @@ def unsloth_compile_transformers(
                     flags=re.DOTALL,
                 )
             pass
-            parameters = f"def {module}" + parameters + code_section
+            sig = f"def {module}{parameters}"
+            # Restore `:` (and `\n` if the find()-fallback consumed it):
+            #  - find() hit:  code_section starts with `:` -> just concat
+            #  - lstrip-newline: append `:` (sig ended cleanly at a newline)
+            #  - else (find()=-1 path): append `:\n` so the body lands as
+            #    a proper indented suite instead of ` def fn(...)    """..."""`
+            if code_section.lstrip(" \t").startswith(":"):
+                parameters = sig + code_section
+            elif code_section.startswith("\n"):
+                parameters = sig + ":" + code_section
+            else:
+                parameters = sig + ":\n" + code_section
             print(f"Unsloth: Fixed up function {module}.")
 
             if module in disable_compile_functions:
@@ -4062,6 +4173,11 @@ def unsloth_compile_transformers(
                     break
             pass
             if not bad:
+                # Functions defined under `if/else` (e.g. xLSTM `soft_cap`)
+                # come back indented from inspect.getsource; dedent before
+                # prepending the decorator to avoid "unexpected indent".
+                if source and source[0] in (" ", "\t"):
+                    source = textwrap.dedent(source)
                 if module in disable_compile_functions:
                     source = re.sub(
                         r"@torch.compile\([^\n]*\)\n",

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -815,7 +815,7 @@ def create_new_function(
     # Fix all softmax low precisions to float32
     new_source = higher_precision_softmax(new_source)
 
-    # Empty new_source (e.g. dpr, rag) -> skip dedent (avoids IndexError).
+    # Skip dedent on empty source to avoid IndexError.
     if new_source and new_source[0] == " ":
         spaces = new_source.find("def")
         new_source = new_source.split("\n")
@@ -845,11 +845,9 @@ def create_new_function(
     # Patch for SiglipEncoder and others
     if "SiglipEncoder" in new_source:
         items += ["SiglipEncoder"]
-    # Detect base-class references whose base isn't defined in new_source.
-    # `functions` is pre-filtered to exclude torch_modules, so a base class
-    # like Sam3LiteTextLayerScaledResidual (no own forward, used only as
-    # a base) drops out of items. Pull it back in by scanning `class X(Y...)`
-    # bases against the full modeling-file dir.
+    # Pull back base classes referenced in the emitted source whose
+    # name was filtered out of `items`. Without this the cache imports
+    # a class whose base is undefined.
     try:
         _modeling_file = eval(model_location)
         _modeling_dir = set(dir(_modeling_file))
@@ -1364,17 +1362,12 @@ def create_standalone_class(
     # Combine all into file
     source = source + full_class
 
-    # Strip decorators that the cache cannot import. `[^\)]*` is unsafe
-    # when the decorator argument is a string with a literal ')' inside
-    # (voxtral / audioflamingo3 etc. use auto_docstring with custom_intro
-    # strings that contain "(a log mel spectrogram)") -- the lazy
-    # close-paren match stopped early and left the rest of the string
-    # in the cache, raising "unterminated string literal". Use a
-    # recursive group so nested parens balance correctly.
+    # Strip decorators with a paren-balanced match. A `[^\)]*` group
+    # stops at the first `)` inside a string argument and leaves an
+    # unterminated literal in the emitted source.
     _PAREN_GROUP = r"(?P<grp>\((?:[^()'\"]|'[^'\\]*(?:\\.[^'\\]*)*'|\"[^\"\\]*(?:\\.[^\"\\]*)*\"|(?P>grp))*\))"
     for _dec in (
         "auto_docstring", "use_kernelized_func", "check_model_inputs",
-        # Transformers 5.x decorators on forward methods
         "merge_with_config_defaults", "capture_outputs",
     ):
         source = regex.sub(rf"@{_dec}\s*(?:{_PAREN_GROUP})?", "", source)
@@ -1897,10 +1890,10 @@ def apply_fused_lm_head(forward, module=None):
             "$KWARGS$", "locals().get('loss_kwargs', {}) or locals().get('kwargs', {})"
         )
 
-        # Fix Idefics and Idefics3. Anchor to start-of-line + capture leading
-        # whitespace so this doesn't substring-match `lm_loss = loss_fct(...)`
-        # (gpt2 / electra / tapas) or emit unindented lines that the downstream
-        # dedent then chops 4 chars off.
+        # Idefics-style loss rewrite. Anchor to start-of-line and capture
+        # leading whitespace so the match doesn't fire inside e.g.
+        # `lm_loss = loss_fct(...)` and so emitted lines inherit the
+        # surrounding indent.
         forward = re.sub(
             r"^([ \t]+)loss = loss_fct\("
             r"shift_logits\.view\(-1, shift_logits\.size\(-1\)\), "
@@ -2157,9 +2150,8 @@ def convert_attention_masks_to_bool(module, old_source):
     splits = all_splits[-1].strip()
     if "return" not in splits:
         return old_source
-    # Skip non-bare returns (e.g. kosmos2 `return x.masked_fill(...)`); the
-    # findall regex below can't parse nested parens and would produce an
-    # unbalanced `final.replace(...)` rewrite.
+    # Skip returns whose body contains parens. The findall regex below
+    # cannot parse nested parens and would produce an unbalanced rewrite.
     return_body = splits[len("return"):].strip()
     if "(" in return_body:
         return old_source
@@ -2738,8 +2730,8 @@ def patch_gradient_accumulation(modeling_file, module):
     # All Unsloth Zoo code licensed under LGPLv3
 
     functions = dir(modeling_file)
-    # `module` may be a class name from dir() that isn't runtime-accessible
-    # (e.g. modeling_bit.Linear). Skip rather than abort.
+    # `module` may be a name from dir() that isn't runtime-accessible
+    # (unbound aliases in __all__). Skip rather than abort.
     try:
         module = eval(f"modeling_file.{module}")
     except AttributeError:
@@ -3263,17 +3255,16 @@ def unsloth_compile_transformers(
     functions = dir(modeling_file)
     full_source = inspect.getsource(modeling_file)
 
-    # Order by definition position. Bare-name find() hits forward refs
-    # (annotations, docstrings, `Union[..., NAME]`) so subclasses can land
-    # before their base class -- e.g. perceiver PerceiverTextPreprocessor
-    # at offset 26072 (annotation) vs its definition at 111990, raising
-    # NameError on AbstractPreprocessor at cache import.
+    # Order by definition position. A bare-name find() also matches
+    # forward references in annotations, docstrings and type unions,
+    # which can land subclasses before their base class and raise
+    # NameError at cache import. Match the definition forms first.
     def _def_pos(name):
         for prefix in (f"class {name}(", f"class {name}:", f"def {name}("):
             i = full_source.find(prefix)
             if i != -1:
                 return i
-        # Fallback: bare-name (for module-level aliases without a def/class).
+        # Module-level aliases without a def/class fall back to bare name.
         i = full_source.find(name)
         return i if i != -1 else len(full_source)
 
@@ -3462,7 +3453,7 @@ def unsloth_compile_transformers(
     disabled_scaled_dot_product_attention_modules = []
 
     for module in scaled_dot_product_attention_modules.keys():
-        # Skip class names that aren't runtime-accessible (see disable_causal_masks).
+        # Skip names that aren't runtime-accessible.
         try:
             source = eval(f"{model_location}.{module}")
         except AttributeError:
@@ -3519,10 +3510,10 @@ def unsloth_compile_transformers(
     remove_causal_masks = []
     if disable_causal_masks:
         for module in other_classes:
-            # `other_classes` (from dir() / class regex) can include names
-            # that aren't runtime-accessible: e.g. modeling_auto._BaseModelWithGenerate
-            # (in __all__ but unbound) or modeling_{bit,regnet,resnet}.Linear
-            # (nn.Linear alias missing on some transformers versions).
+            # `other_classes` (from dir() / class regex) can include
+            # names that aren't runtime-accessible: unbound entries in
+            # __all__, or aliases that are missing on some transformers
+            # versions.
             try:
                 source = eval(f"{model_location}.{module}")
             except AttributeError:
@@ -3836,7 +3827,7 @@ def unsloth_compile_transformers(
     # Allow gradient checkpointing if not enabled
     if gradient_checkpointing:
         for module in other_classes:
-            # Skip non-runtime-accessible names (see disable_causal_masks).
+            # Skip names that aren't runtime-accessible.
             try:
                 source = eval(f"{model_location}.{module}")
             except AttributeError:
@@ -3877,7 +3868,7 @@ def unsloth_compile_transformers(
         if module in all_standalone_classes:
             source = all_standalone_classes[module]
         else:
-            # Skip non-runtime-accessible names (see disable_causal_masks).
+            # Skip names that aren't runtime-accessible.
             try:
                 module_cls = eval(f"{model_location}.{module}")
             except AttributeError:
@@ -3914,7 +3905,7 @@ def unsloth_compile_transformers(
 
     if len(router_logit_cast_modules) > 0:
         for module in router_logit_cast_modules:
-            # Skip non-runtime-accessible names (see disable_causal_masks).
+            # Skip names that aren't runtime-accessible.
             try:
                 module_cls = eval(f"{model_location}.{module}")
             except AttributeError:
@@ -4071,12 +4062,10 @@ def unsloth_compile_transformers(
                 print(f"Unsloth: Cannot run inspect.getsource on {module} with error = {e}")
                 continue
 
-            # str(inspect.signature) and source can disagree on quote style
-            # ('foo' vs "foo") or fully-qualified annotations, making find()
-            # return -1. Keep OLD `code_section = source[find("\n")+1:]` so
-            # bad_params detection still sees multi-line sig continuations
-            # (e.g. `def f(\n    a: T,\n    b: U,\n):`); only restore the
-            # trailing `:` at rebuild time below.
+            # str(inspect.signature) can disagree with source on quote
+            # style or fully-qualified annotations, so find() may return
+            # -1. Fall back to the first newline so multi-line signatures
+            # still split correctly; the trailing `:` is restored below.
             where = source.find(str(parameters))
             if where == -1:
                 where = source.find("\n") + 1
@@ -4104,11 +4093,8 @@ def unsloth_compile_transformers(
                 )
             pass
             sig = f"def {module}{parameters}"
-            # Restore `:` (and `\n` if the find()-fallback consumed it):
-            #  - find() hit:  code_section starts with `:` -> just concat
-            #  - lstrip-newline: append `:` (sig ended cleanly at a newline)
-            #  - else (find()=-1 path): append `:\n` so the body lands as
-            #    a proper indented suite instead of ` def fn(...)    """..."""`
+            # Restore the trailing `:` (and a newline when the find()
+            # fallback consumed it) so the body lands as an indented suite.
             if code_section.lstrip(" \t").startswith(":"):
                 parameters = sig + code_section
             elif code_section.startswith("\n"):
@@ -4173,9 +4159,9 @@ def unsloth_compile_transformers(
                     break
             pass
             if not bad:
-                # Functions defined under `if/else` (e.g. xLSTM `soft_cap`)
-                # come back indented from inspect.getsource; dedent before
-                # prepending the decorator to avoid "unexpected indent".
+                # Functions defined inside an if/else come back indented
+                # from inspect.getsource; dedent before prepending the
+                # decorator so the result parses.
                 if source and source[0] in (" ", "\t"):
                     source = textwrap.dedent(source)
                 if module in disable_compile_functions:


### PR DESCRIPTION
## Summary

`unsloth_compile_transformers()` now compiles every transformers model_type that has a `modeling_<x>.py` file, on both transformers 4.57.6 and 5.x:

|  | transformers 4.57.6 | transformers 5.8.0 |
|---|---|---|
| Total model_types | 383 | 465 |
| Skipped (no modeling file) | 24 | 26 |
| Compiled cleanly | **359 / 359** | **439 / 439** |
| Broken | **0** | **0** |

Production models (llama, qwen3, gemma3, mistral, mixtral, idefics{,2,3}, gpt_oss, deepseek_v3, ...) keep working unchanged on both versions.

## Models unblocked

| Category | Symptom | tf | Models |
|---|---|---|---|
| A | `IndexError: string index out of range` | 4.x | colpali, colqwen2, colmodernvbert, dpr, gemma4_assistant, rag, shieldgemma2, timm_backbone (8) |
| B | `unexpected indent` / `expected ':'` | 4.x | clvp, electra, falcon_mamba, gpt2, imagegpt, mamba, tapas, xlstm (8) |
| B-2 | `unterminated string literal` | 5.x | audioflamingo3, musicflamingo, voxtral, voxtral_realtime (4) |
| C | unclosed paren in emitted file | 4.x | kosmos2, kosmos2_5 (2) |
| D | `module has no attribute _BaseModelWithGenerate` / `Linear` | 4.x | auto, bit, regnet, resnet (4) |
| E | `name 'AbstractPreprocessor' is not defined` | 4.x | perceiver, sam3_lite_text (2) |
| E-2 | base-class import missing | 5.x | sam3_lite_text |

## Nine narrowly-scoped fixes

1. **`create_new_function`: empty `new_source[0]` IndexError.** Guard with `if new_source and new_source[0] == " "`.

2. **`convert_attention_masks_to_bool`: nested-paren regex mis-parse.** The `findall` regex doesn't handle nested parens like `return inverted_mask.masked_fill(inverted_mask.to(torch.bool), torch.finfo(dtype).min)`. Skip when the return body contains `(`.

3. **`eval(f"{loc}.{module}")` AttributeError on `dir()`-derived names.** Wrap 6 eval() sites with `try/except AttributeError: continue` (private names in `__all__` like `_BaseModelWithGenerate`, or `nn.Linear` aliases that fail attribute lookup on some transformers versions).

4. **Idefics-style `loss = loss_fct(...)` rewrite: substring + dedent double-corruption.** The flat `forward.replace(...)` matched inside `lm_loss = loss_fct(...)` and inserted unindented lines that the downstream dedent then chopped 4 chars off. Replace with `re.sub` anchored to `^([ \t]+)loss = ...$` that captures and inherits the leading whitespace.

5. **`called_functions` sig-rebuild fallback dropped trailing `:`.** When `inspect.signature` repr disagrees with source quote style or fully-qualified annotation, the fallback consumed the colon. Restore `:` and `\n` so the body lands as a proper indented suite.

6. **Decorator prepended without dedenting indented source.** `textwrap.dedent` before adding the `@torch.compile(...)` decorator (xLSTM `soft_cap` is defined under an `else:` so `inspect.getsource` returns it indented 4 chars).

7. **Topological ordering by `full_source.find(name)` used the wrong match.** Bare-name find hits forward refs in docstrings / type annotations / `Union[..., NAME]` before the actual `class NAME` definition. Switch to `find("class N(") / find("class N:") / find("def N(")`.

8. **`@auto_docstring` (and 4 sibling decorators) used `[^)]*` to match the argument list,** which stops at the first `)` inside a string like `"... (a log mel spectrogram), meaning ..."` and leaves an unterminated string literal in the cache. Switch to a `regex` recursive group that respects nested parens AND nested string literals (single and triple-quoted).

9. **Base-class import missing for classes used purely as bases.** `Sam3LiteTextLayerScaledResidual` has only an inherited `forward` so it's filtered out of the per-module compile and out of `functions`, but `class Sam3LiteTextRepMixer(Sam3LiteTextLayerScaledResidual)` references it. Scan `class N(B1, B2, ...)` patterns in the emitted source and add bases that exist on the modeling file but aren't defined-in-cache to the auto-import list.

All fixes either widen `try/except`, anchor a substitution to respect indentation, switch to a strictly-more-correct sort key, or detect-and-import a previously-missed reference. None of them change semantics for working models.

## Test plan

- [x] **Production-relevant models** (llama, qwen3, qwen3_moe, qwen2, gemma{,2,3,3n}, mistral, mixtral, phi{,3,4}, starcoder2, codegen, bart, t5, whisper, idefics{,2,3}, vit, clip, siglip, dinov2, wav2vec2, llava{,_next,_onevision}, qwen2_vl, qwen2_5_vl, qwen2_5_omni, gpt_oss, deepseek_v3, dbrx, gpt_neo{,x}, olmo{,2}) -> **39/39 ok** on both tf 4.57.6 and tf 5.8.0.
- [x] **Idefics family** (the original target of the `loss=loss_fct` rewrite) -> 3/3 ok; synthetic equivalence test confirms the new `re.sub` produces a properly-indented expansion vs the old `.replace()`'s broken zero-indent emit.
- [x] **`convert_attention_masks_to_bool`** -> simple-return rewrite still fires (Case A), tuple-of-bare-names still rewrites (Case C), nested-paren returns are correctly skipped (Case B).
- [x] **Full sweep on transformers 4.57.6**: 359/359 with modeling files compile, 0 broken.
- [x] **Full sweep on transformers 5.8.0**: 439/439 with modeling files compile, 0 broken.