### PR TITLE
relax trl 0.x upper bound from <=0.24.0 to <0.30.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "triton>=3.0.0 ; ('linux' in sys_platform)",
     "tyro ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "accelerate>=0.34.1 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
-    "trl>=0.18.2,!=0.19.0,<=0.24.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
+    "trl>=0.18.2,!=0.19.0,<=0.30.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "peft>=0.18.0,!=0.11.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "cut_cross_entropy ; python_version >= '3.10' and (sys_platform != 'darwin' or platform_machine != 'arm64')",
     # --- MLX-only deps (macOS arm64) ---
@@ -80,7 +80,7 @@ core = [
     "wheel>=0.42.0",
     "numpy",
     "accelerate>=0.34.1",
-    "trl>=0.18.2,!=0.19.0,<=0.24.0",
+    "trl>=0.18.2,!=0.19.0,<=0.30.0",
     "peft>=0.18.0,!=0.11.0",
     "protobuf",
     "huggingface_hub>=0.34.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "triton>=3.0.0 ; ('linux' in sys_platform)",
     "tyro ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "accelerate>=0.34.1 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
-    "trl>=0.18.2,!=0.19.0,<=0.30.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
+    "trl>=0.18.2,!=0.19.0,<0.30.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "peft>=0.18.0,!=0.11.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "cut_cross_entropy ; python_version >= '3.10' and (sys_platform != 'darwin' or platform_machine != 'arm64')",
     # --- MLX-only deps (macOS arm64) ---
@@ -80,7 +80,7 @@ core = [
     "wheel>=0.42.0",
     "numpy",
     "accelerate>=0.34.1",
-    "trl>=0.18.2,!=0.19.0,<=0.30.0",
+    "trl>=0.18.2,!=0.19.0,<0.30.0",
     "peft>=0.18.0,!=0.11.0",
     "protobuf",
     "huggingface_hub>=0.34.0",


### PR DESCRIPTION
# Relax `trl` 0.x upper bound from `<=0.24.0` to `<0.30.0`

## Problem

`unsloth-zoo==2026.5.1` and current `main` pin:

```toml
trl>=0.18.2,!=0.19.0,<=0.24.0
```

This blocks users who intentionally need TRL 0.25-0.29, even though these versions remain in the pre-1.0 line. For example, post-0.24 GRPO work includes newer configuration and trainer surface such as `multi_objective_aggregation`, SAPO-related loss knobs, `off_policy_mask_threshold`, vLLM configuration updates, and optional tool/environment rollout support.

With the current cap, dependency resolution fails:

```bash
uv pip install "unsloth-zoo==2026.5.1" "trl==0.29.1"
# -> No solution found: unsloth-zoo requires trl<=0.24.0
```

## Compatibility notes

The `<=0.24.0` ceiling appears stricter than the current package metadata needs:

- `GRPOTrainer.__init__` in `trl==0.29.1` keeps the existing required arguments (`model`, `reward_funcs`) and only adds optional parameters (`tools`, `rollout_func`, `environment_factory`).
- `GRPOConfig` in both `trl==0.24.0` and `trl==0.29.1` exposes `num_iterations` and `importance_sampling_level`.
- `num_mini_batches` is not used by `unsloth-zoo`.
- `unsloth-zoo` already runtime-detects newer TRL GRPO loss features (`get_sapo_token_loss`, `get_off_policy_mask`, `sapo_temperature_*`, `off_policy_mask_threshold`) via `hasattr` guards in `rl_replacements.py`.

This PR intentionally keeps an upper bound at `<0.30.0`. TRL 1.x is a larger version jump and should be evaluated separately.

## Fix

Change `<=0.24.0` to `<0.30.0` in both `pyproject.toml` dependency lists:

```diff
-    "trl>=0.18.2,!=0.19.0,<=0.24.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
+    "trl>=0.18.2,!=0.19.0,<0.30.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
```

and in `[project.optional-dependencies] core`:

```diff
-    "trl>=0.18.2,!=0.19.0,<=0.24.0",
+    "trl>=0.18.2,!=0.19.0,<0.30.0",
```

## Testing

Environment: Python 3.11.14, uv 0.9.16.

Current published metadata fails as expected:

```bash
uv pip install --dry-run "unsloth-zoo==2026.5.1" "trl==0.29.1"
# -> No solution found: unsloth-zoo requires trl<=0.24.0
```

Patched local checkout resolves:

```bash
uv pip install --dry-run "./unsloth-zoo" "trl==0.29.1"
# -> Resolved successfully
```

Also checked:

| `trl` version | Result with patched constraint |
|---------------|--------------------------------|
| `0.24.0`      | resolves                       |
| `0.27.2`      | resolves                       |
| `0.29.1`      | resolves                       |
| `1.4.0`       | rejected by `<0.30.0`          |

The patched checkout was also resolver-tested with `--python-platform linux` for `trl==0.29.1`.
