### PR TITLE
chore: trim verbose comments across PR #637 landing

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -1,37 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Python compatibility + repo test gate. Adapted from unsloth's
-# consolidated-tests-ci.yml; trimmed to zoo's actual surface.
-#
-# Zoo's 13 existing test files all import torch and (mostly)
-# unsloth_zoo internals -- they are MoE / LoRA shape tests that
-# assume a torch install.
-#
-# Three jobs:
-#   - python-version-collect:  pytest --collect-only across the
-#     supported Python matrix (3.10-3.13). Catches import / syntax
-#     regressions WITHOUT requiring a GPU. Hard gate.
-#   - repo-tests-cpu:          pytest tests/security + the
-#     CPU-pure tests from tests/test_*.py that the GPU-free harness
-#     in tests/conftest.py can run. Hard gate on tests/security;
-#     other CPU tests are continue-on-error during the CI-bootstrap
-#     phase and tighten later.
-#   - core-upstream-matrix:    `Core (HF=... + TRL=...)` matrix
-#     mirroring unslothai/unsloth's consolidated-tests-ci.yml shape.
-#     Three (transformers, TRL, peft) cells -- two pinned + one
-#     resolved from pyproject -- run the upstream-pinned-symbol
-#     tests (94 across 3 files) so transformers / TRL / peft drift
-#     surfaces as a red cell on the next PR, not silently in a
-#     downstream user's training run. This is THE high-value
-#     coverage for zoo specifically -- zoo IS the upstream-shim
-#     layer, so a matrix here catches more than the equivalent
-#     matrix on unsloth.
-#
-# Heavy GPU tests (test_active_merge_device_matrix.py,
-# test_forward_native_moe_loop_lora.py, etc.) are left as a
-# follow-up: they need a real CUDA runner + LoRA model fixtures
-# that don't exist on free GitHub Actions Linux runners.
+# Python compatibility + repo test gate. Adapted from unsloth's consolidated-tests-ci.yml.
+# Jobs: python-version-collect (pytest --collect-only on 3.10-3.13), repo-tests-cpu
+# (tests/security HARD GATE + CPU-pure zoo tests), core-upstream-matrix (HF/TRL/peft
+# drift detector across 3 cells -- the high-value zoo coverage).
 
 name: Tests CI
 
@@ -48,11 +21,7 @@ permissions:
   contents: read
 
 jobs:
-  # ─────────────────────────────────────────────────────────────────────
-  # Python compatibility matrix: pytest --collect-only on every
-  # supported interpreter. Catches imports / syntax / decorator
-  # regressions before they hit a release.
-  # ─────────────────────────────────────────────────────────────────────
+  # Python compatibility: pytest --collect-only per interpreter.
   python-version-collect:
     name: (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -77,17 +46,8 @@ jobs:
           cache: 'pip'
 
       - name: Install CPU-only torch + zoo runtime deps
-        # CPU index avoids pulling the multi-GB CUDA wheel set. The
-        # version pin matches pyproject.toml's `torch>=2.4.0,<2.11.0`
-        # for the GPU-platform lane; here on CPU we just need
-        # something import-compatible with the source tree.
-        #
-        # `pip install --no-deps unsloth` satisfies the
-        # `find_spec("unsloth") is None` guard in
-        # unsloth_zoo/__init__.py:128 (zoo refuses to import
-        # standalone). --no-deps keeps it cheap: we don't actually
-        # USE unsloth in these tests, just need the package metadata
-        # present so the guard passes.
+        # CPU index avoids the multi-GB CUDA wheel set. `--no-deps unsloth`
+        # satisfies the find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
         run: |
           python -m pip install --upgrade pip
           pip install --index-url https://download.pytorch.org/whl/cpu \
@@ -97,16 +57,10 @@ jobs:
           pip install pytest==9.0.3
 
       - name: pytest --collect-only
-        # Collect-only verifies every test imports cleanly. It will
-        # FAIL on syntax / import / decorator regressions in zoo
-        # itself, which is what we want.
         continue-on-error: true
         run: python -m pytest tests/ --collect-only -q
 
-  # ─────────────────────────────────────────────────────────────────────
-  # CPU-only repo tests. Hard gate on tests/security; other CPU-pure
-  # zoo tests are continue-on-error during CI bootstrap.
-  # ─────────────────────────────────────────────────────────────────────
+  # CPU-only repo tests. HARD GATE on tests/security.
   repo-tests-cpu:
     name: Repo tests (CPU)
     runs-on: ubuntu-latest
@@ -127,10 +81,7 @@ jobs:
           cache: 'pip'
 
       - name: Install runtime + test deps
-        # `pip install --no-deps unsloth` satisfies the
-        # `find_spec("unsloth") is None` guard in
-        # unsloth_zoo/__init__.py:128 -- zoo refuses to import
-        # standalone. --no-deps keeps the install cheap.
+        # --no-deps unsloth satisfies the find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
         run: |
           python -m pip install --upgrade pip
           pip install --index-url https://download.pytorch.org/whl/cpu \
@@ -143,17 +94,9 @@ jobs:
         run: python -m pytest tests/security -v
 
       - name: pytest tests/test_pr_a_imports + zoo-specific CPU tests
-        # CPU-pure zoo tests: import smoke (pr_a_imports), the new
-        # rl_replacements CPU unit tests, the new temporary_patches
-        # import smoke, the past-bug regression suite, and the PyPI
-        # version-sync check. All CPU-safe by construction (no
-        # @requires_gpu, no real CUDA call sites). Run as a SEPARATE
-        # pytest invocation from tests/security above: the
-        # tests/security/conftest.py installs a session-scoped
-        # `network_blocker` autouse fixture that replaces
-        # `socket.socket` for the whole pytest session, which would
-        # otherwise prevent test_pypi_version_sync from reaching
-        # pypi.org.
+        # Run as SEPARATE pytest invocation: tests/security/conftest.py installs a
+        # session-scoped network_blocker autouse fixture that would otherwise block
+        # test_pypi_version_sync from reaching pypi.org.
         continue-on-error: true
         run: |
           python -m pytest \
@@ -164,37 +107,8 @@ jobs:
             tests/test_pypi_version_sync.py \
             -v
 
-  # ─────────────────────────────────────────────────────────────────────
-  # Core (HF=... + TRL=...) upstream-version matrix. Mirrors the
-  # shape of unslothai/unsloth's consolidated-tests-ci.yml `Core`
-  # job, scoped to zoo's value: the upstream-pinned-symbol tests
-  # (test_upstream_pinned_symbols_transformers.py +
-  # test_upstream_pinned_symbols_trl_vllm.py +
-  # test_upstream_pinned_symbols_accelerator.py = 94 parametrized
-  # tests) are the dominant signal here -- they probe
-  # `transformers.models.X.modeling_X.Y`-style symbols that zoo's
-  # shim code references and that move around between transformers
-  # / TRL / peft releases.
-  #
-  # Three matrix cells (mirrors unsloth's exactly):
-  #   1. transformers==4.57.6 + TRL latest <1.0.0
-  #      (the just-before-5.x line; this is where most external
-  #      users sit today.)
-  #   2. transformers >=5,<6 + TRL >=1,<2
-  #      (absolute upstream tip. BEYOND zoo's pyproject caps
-  #      `transformers <=5.5.0` and `trl <=0.24.0`; explicitly
-  #      forces beyond-cap installs to surface drift signal early.)
-  #   3. transformers + TRL + peft resolved from pyproject.toml
-  #      (the "default" cell -- whatever a fresh `pip install
-  #      unsloth_zoo` lands on today.)
-  #
-  # fail-fast: false so a transformers / TRL drift in one cell does
-  # not cancel the others. continue-on-error: true on the test step
-  # during CI bootstrap -- the pinned-symbol tests are a fresh
-  # body of work and may surface latent zoo-source bugs unrelated
-  # to upstream drift; tighten to hard-gate in a follow-up after
-  # the first few real runs settle.
-  # ─────────────────────────────────────────────────────────────────────
+  # Core (HF/TRL/peft) drift matrix. Three cells: HF=4.57.6+TRL<1, HF=latest+TRL=latest,
+  # and pyproject defaults. fail-fast=false; drift in one cell shouldn't cancel others.
   core-upstream-matrix:
     name: "Core (${{ matrix.combo.label }})"
     runs-on: ubuntu-latest
@@ -223,24 +137,14 @@ jobs:
       MATRIX_TRL_SPEC: ${{ matrix.combo.trl_spec }}
       MATRIX_PEFT_SPEC: ${{ matrix.combo.peft_spec }}
       MATRIX_COMBO_ID: ${{ matrix.combo.id }}
-      # transformers' bundled *_pb2.py was generated against an older
-      # protoc; the C++ protobuf 4+/5+ implementation rejects them
-      # with "Descriptors cannot be created directly". The pure-Python
-      # parser bypasses the check at negligible speed cost.
+      # Pure-Python protobuf parser; transformers' bundled *_pb2.py is rejected by C++ protobuf 4+/5+.
       PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
       UNSLOTH_COMPILE_DISABLE: '1'
-      # unsloth_zoo/__init__.py:128 raises ImportError unless
-      # `find_spec("unsloth") is None` returns a hit. We satisfy that
-      # with `pip install --no-deps unsloth` below; UNSLOTH_IS_PRESENT
-      # is the secondary handshake the bootstrap looks for after
-      # the find_spec gate passes.
+      # Secondary handshake after find_spec("unsloth") guard at unsloth_zoo/__init__.py:128.
       UNSLOTH_IS_PRESENT: '1'
     steps:
       - name: Harden runner (audit)
-        # audit (not block) -- the matrix pulls arbitrary
-        # transformers / TRL / peft pins from PyPI; an allowlist
-        # would force us to enumerate every transitive dep PyPI
-        # mirror, which churns more than the matrix itself.
+        # audit (not block): matrix pulls arbitrary transformers/TRL/peft pins.
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
           egress-policy: audit
@@ -255,11 +159,7 @@ jobs:
           cache: 'pip'
 
       - name: Resolve matrix specs (handle __from_pyproject__ sentinel)
-        # The pyproject cell uses a sentinel; resolve the real
-        # `transformers`, `trl`, and `peft` constraints from zoo's
-        # pyproject.toml at job time. Walks top-level deps THEN every
-        # optional-dependencies extra, picking the first matching
-        # spec. Other cells pass their spec through unchanged.
+        # Resolve transformers/trl/peft from pyproject.toml when the sentinel is used.
         run: |
           set -euxo pipefail
           python <<'PY' >> "$GITHUB_ENV"
@@ -280,8 +180,7 @@ jobs:
               for _name, dep_list in proj.get("optional-dependencies", {}).items():
                   all_deps.extend(dep_list)
 
-              # Strip environment markers (everything after the first ` ; `)
-              # so the resolved spec is a plain pip-installable string.
+              # Strip environment markers so the resolved spec is pip-installable.
               def _strip_marker(s: str) -> str:
                   return s.split(";", 1)[0].strip()
 
@@ -301,16 +200,9 @@ jobs:
           grep RESOLVED_ "$GITHUB_ENV" || true
 
       - name: Install torch CPU + zoo + matrix-specified upstream libs
-        # Two-phase install:
-        #   1. `pip install -e .[core]` resolves zoo's pyproject defaults
-        #      for transformers / TRL / peft (cell 3 wants exactly this).
-        #   2. `pip install -U <RESOLVED_*>` overrides those defaults for
-        #      cells 1 / 2. The -U is critical -- without it pip will
-        #      not downgrade transformers from cell-3-default to cell-1
-        #      pin (4.57.6).
-        # --no-deps unsloth satisfies the find_spec("unsloth") guard in
-        # unsloth_zoo/__init__.py:128 without dragging unsloth's full
-        # CUDA-extension install chain onto a CPU runner.
+        # Two-phase: `-e .[core]` for pyproject defaults, then `-U <RESOLVED_*>` to override.
+        # The -U is critical so pip will downgrade transformers (e.g. cell-1 pin 4.57.6).
+        # --no-deps unsloth satisfies the find_spec guard at unsloth_zoo/__init__.py:128.
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
@@ -320,19 +212,10 @@ jobs:
           pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
           # Override with matrix-resolved specs.
           pip install -U "$RESOLVED_TRANSFORMERS_SPEC" "$RESOLVED_TRL_SPEC" "$RESOLVED_PEFT_SPEC"
-          # bitsandbytes: unsloth_zoo/saving_utils.py imports it at
-          # module scope (the `_active_merge_device` path the
-          # accelerator pinned-symbol tests exercise). Recent versions
-          # ship a CPU build that imports cleanly on Linux without a
-          # CUDA toolchain. Same pin as unsloth's Core matrix.
+          # bitsandbytes: imported at module scope in saving_utils.py (_active_merge_device path).
           pip install 'bitsandbytes>=0.45'
-          # IPython + ipywidgets: zoo's logging_utils.py:50 does
-          # `from transformers.utils.notebook import ...` (try/except
-          # wrapped). The pinned-symbol test for this path needs both
-          # so the import resolves; without them the test would FAIL
-          # with a DRIFT-DETECTED message even though the upstream
-          # API is fine. Install them here so the drift detector
-          # only fires on real drift, not on missing CI deps.
+          # IPython + ipywidgets: logging_utils.py:50 imports transformers.utils.notebook.
+          # Required so drift detector only fires on real drift, not missing CI deps.
           pip install 'ipython>=8' 'ipywidgets>=8'
           pip install pytest==9.0.3 packaging
           echo "::group::Installed transformers + trl + peft + torch versions"
@@ -343,126 +226,9 @@ jobs:
           echo "::endgroup::"
 
       - name: pytest upstream-regression suite (94 pinned + 117 expanded)
-        # SIX files run per matrix cell, 211 tests total:
-        #
-        #   tests/test_upstream_pinned_symbols_{transformers,trl_vllm,
-        #     accelerator}.py
-        #     -- 94 parametrized tests probing
-        #     `transformers.models.X.modeling_X.Y`, `trl.trainer.Z`,
-        #     and accelerator dispatch symbols. parametrize() decorators
-        #     ALREADY span multiple (transformers, peft)/(TRL) version
-        #     axes; this matrix multiplies that by the cell-level
-        #     (transformers, TRL, peft) install.
-        #
-        #   tests/test_zoo_history_regressions_deep.py
-        #     -- 34 regression tests mined from zoo PRs #4 through
-        #     #635 (Opus subagent ran the full merged-PR history).
-        #     Heuristic AST / regex / signature inspection; CPU-only;
-        #     ~8s total. Covers transformers API drift (PRs #322 / #91 /
-        #     #461 / #491 / #549 / #458), vLLM drift (#466 / #84 / #218),
-        #     compiler bug class (#533 / #552 / #564 / #482), GRPO/RL
-        #     math (#593 / #543 / #612), saving/dataset subtle bugs
-        #     (#4 / #477 / #595 / #615 / #559), cross-module sanity
-        #     (#422 / #374-425 / #580 / #617-generalisation / #432 /
-        #     #591 / #441).
-        #
-        #   tests/test_upstream_import_fixes_drift.py
-        #     -- 18 drift detectors mapped to fix functions in
-        #     unslothai/unsloth's unsloth/import_fixes.py (1932 LOC).
-        #     Each test fails or skip-with-marker when the upstream
-        #     pathology import_fixes guards against is currently
-        #     ACTIVE on the installed version: protobuf MessageFactory,
-        #     datasets 4.4.x recursion, trl tuple-vs-bool, transformers
-        #     PreTrainedModel.enable_input_require_grads source pattern,
-        #     torchcodec / causal_conv1d / wandb / peft weight-converter
-        #     / triton CompiledKernel attrs / torch-torchvision pairing /
-        #     vllm guided-decoding / huggingface_hub / xformers / etc.
-        #
-        #   tests/test_zoo_source_upstream_refs.py
-        #     -- 65 tests pinning every `transformers.X.Y.Z` /
-        #     `trl.X` / `peft.X` / `accelerate.X` / `datasets.X` /
-        #     `vllm.X` dotted reference Opus subagent C found in
-        #     unsloth_zoo/*.py. Each test resolves the dotted path
-        #     via importlib.import_module + getattr chain; failures
-        #     print the EXACT broken path. 24 zoo source files
-        #     covered; cross-version safe via candidate-list /
-        #     version-gate / importorskip patterns.
-        #
-        # The three matrix cells (HF=4.57.6, HF=default, HF=latest)
-        # multiplied by these 211 tests = the dominant zoo-side
-        # signal we have for catching transformers/trl/peft/vllm
-        # drift before users do.
-        #
-        # HARD GATE: no continue-on-error. A red cell means real
-        # upstream drift -- transformers/trl/peft/vllm/datasets/etc
-        # has renamed, moved, or removed a symbol zoo references, or
-        # one of the import_fixes pathologies is currently active
-        # without a corresponding zoo-side workaround. The drift
-        # signal is the entire point of the suite; making the cell
-        # green-by-default would defeat it.
-        #
-        # 626 tests total per cell across 12 files:
-        #
-        #   Round 1 (211 tests):
-        #     test_upstream_pinned_symbols_{transformers,trl_vllm,accelerator}.py
-        #       -- 94 pinned-symbol probes parametrized across
-        #          (transformers, peft) / (TRL, vllm) version axes.
-        #     test_zoo_history_regressions_deep.py
-        #       -- 34 deep PR-history regressions (#4 through #635).
-        #     test_upstream_import_fixes_drift.py
-        #       -- 18 detectors mapped to fix_*/patch_* in unsloth's
-        #          import_fixes.py. Three known-active drifts get
-        #          zoo-side workarounds in unsloth_zoo/import_fixes.py
-        #          (apply_import_fixes runs at zoo __init__).
-        #     test_zoo_source_upstream_refs.py
-        #       -- 65 pins for every transformers.X.Y / trl.X / peft.X
-        #          / accelerate.X / datasets.X / vllm.X dotted reference
-        #          extracted from unsloth_zoo/*.py.
-        #
-        #   Round 2 (143 tests):
-        #     test_upstream_signatures.py
-        #       -- 65 signature pins for every upstream function zoo
-        #          monkey-patches / wraps / calls with positional-arity
-        #          assumptions (loss_utils, gradient_checkpointing,
-        #          training_utils, compiler, empty_model, saving_utils,
-        #          vllm_utils, every temporary_patches/* module).
-        #     test_extended_dep_api_pins.py
-        #       -- 44 API pins for accelerate / safetensors /
-        #          bitsandbytes / triton / datasets / tokenizers /
-        #          huggingface_hub / xformers.
-        #     test_upstream_source_patterns.py
-        #       -- 34 source-rewriter pattern pins. zoo's compiler.py
-        #          + temporary_patches/misc.py + temporary_patches/
-        #          gpt_oss.py do str.replace / re.sub against upstream
-        #          source; this file pins every targeted string so a
-        #          silent no-op surfaces.
-        #
-        #   Round 3 (272 tests):
-        #     test_compiler_rewriter_exhaustive.py
-        #       -- 79 tests pinning every str.replace / re.sub /
-        #          re.search site across zoo's compiler.py /
-        #          patching_utils.py / saving_utils.py /
-        #          temporary_patches/* and unsloth's compiler.py /
-        #          models/rl.py / trainer.py. Picks up the
-        #          REMAINING source-rewriter sites that round-2's
-        #          34-pattern sample missed.
-        #     test_compiler_dynamic_exec.py
-        #       -- 85 tests addressing the user's #1 concern:
-        #          UNSLOTH DOES DYNAMIC CODE CREATION. Drives every
-        #          rewrite entry point in zoo's compiler END-TO-END
-        #          on REAL transformers source, then ast.parse +
-        #          exec-in-sandbox the rewritten output to confirm
-        #          it's valid Python. Plus per-model-type smoke for
-        #          39 model_types (gemma3/3n/4, qwen2/3 family,
-        #          gpt_oss, mistral/ministral, deepseek/2/3, llama,
-        #          cohere, phi, starcoder, olmo, falcon, granite,
-        #          glm, pixtral, paligemma, idefics, mllama).
-        #     test_temporary_patches_exhaustive.py
-        #       -- 108 tests exhaustively pinning every
-        #          (model_class, method_name) pair zoo's
-        #          temporary_patches/*.py touches. Catches signature
-        #          drift on Csm / Pixtral / Mxfp4 / GraniteMoeHybrid
-        #          / Mllama / Lfm2VlMultiModalProjector / etc.
+        # 626 drift-detector tests / cell across 12 files. HARD GATE: a red cell
+        # means real upstream drift (transformers/trl/peft/vllm/datasets renamed
+        # or removed a symbol zoo references). Zoo PRs #4 through #635 mined.
         run: |
           python -m pytest -v --tb=short -rs \
             tests/test_upstream_pinned_symbols_transformers.py \

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -1,17 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Whole-repo Python source-lint gate. Runs on every PR.
-#
-# Mirrors the shape of unslothai/unsloth's lint-ci.yml, scoped to
-# zoo's actual surface:
-#   - Python syntax (compileall) + ruff lint (narrow rule set, hard
-#     gate).
-#   - YAML + JSON round-trip for every committed config.
-# Skipped vs. unsloth:
-#   - shell lint (zoo has no committed *.sh)
-#   - TypeScript / Rust (Studio + Tauri are unsloth-side; zoo is
-#     pure Python).
+# Whole-repo Python source-lint gate. Adapted from unsloth's lint-ci.yml:
+# Python (compileall + narrow ruff) + YAML/JSON round-trip. Dropped vs unsloth:
+# shell lint (zoo has no committed *.sh), TypeScript/Rust (Studio/Tauri are unsloth-side).
 
 name: Lint CI
 
@@ -50,49 +42,25 @@ jobs:
       - run: pip install 'ruff==0.15.12' 'pyyaml>=6'
 
       - name: Python AST/syntax check (every committed .py must compile)
-        # python -m compileall uses the same parser the interpreter
-        # uses, so anything broken here would also crash at
-        # `import X` on a user's machine. Sub-second across the zoo
-        # source tree.
-        #
-        # continue-on-error during CI bootstrap: zoo's
-        # pyproject.toml declares `requires-python = ">=3.9,<3.15"`
-        # but unsloth_zoo/temporary_patches/gpt_oss.py uses a `match`
-        # statement (3.10+ syntax). Either bump the floor to 3.10 or
-        # rewrite the match. Tracking as a separate cleanup PR.
+        # continue-on-error during CI bootstrap: pyproject.toml declares
+        # `requires-python = ">=3.9,<3.15"` but temporary_patches/gpt_oss.py
+        # uses a 3.10+ `match` statement. Tracked as a separate cleanup PR.
         continue-on-error: true
         run: |
           python -m compileall -q -j 0 unsloth_zoo tests scripts
 
       - name: Python ruff check (narrow gate)
-        # Narrow rule set: E9 / F63 / F7 / F82 -- syntax errors,
-        # broken comparisons, undefined names. Anything stricter
-        # would surface latent style debt unrelated to this PR's
-        # CI-bootstrap goal; tighten later in a separate PR.
-        #
-        # continue-on-error during CI bootstrap: the first run on
-        # main surfaced 13 latent ruff findings (e.g. F821 undefined
-        # `old_hidden_states` in rl_replacements.py L1128, match
-        # statement on a file readable by Python 3.9 per
-        # pyproject.toml). Those are pre-existing zoo bugs unrelated
-        # to this PR; promote to fail-closed in a follow-up after
-        # the baseline is cleaned up.
+        # E9 / F63 / F7 / F82: syntax errors, broken comparisons, undefined names.
+        # continue-on-error during CI bootstrap: first run on main surfaced 13
+        # latent findings (rl_replacements.py L1128 F821, gpt_oss match-on-3.9).
         continue-on-error: true
         run: |
           ruff check --select E9,F63,F7,F82 unsloth_zoo tests scripts
 
       - name: No leftover debugger / pdb / breakpoint calls
-        # Matches the unsloth lint-ci pattern: catches `import pdb`,
-        # `pdb.set_trace()`, `breakpoint()`, `import ipdb` left in
-        # production code. Allowed in tests/ for debugger fixtures
-        # (none exist today; if any future test needs it, scope the
-        # exception explicitly).
-        #
-        # continue-on-error during CI bootstrap: rl_replacements.py
-        # has `#breakpoint()` (commented out) which the regex
-        # matches because `#` is `[^A-Za-z_]`. Fix in a follow-up by
-        # either removing the comment or tightening the regex to
-        # skip comment-prefixed lines.
+        # Catches `import pdb`, `pdb.set_trace()`, `breakpoint()`, `import ipdb`.
+        # continue-on-error during bootstrap: rl_replacements.py has a
+        # `#breakpoint()` comment the regex matches (# is [^A-Za-z_]).
         continue-on-error: true
         run: |
           set -e
@@ -148,9 +116,7 @@ jobs:
           PY
 
       - name: enforce kwargs spacing
-        # Mirrors the unsloth style rule -- function kwargs use
-        # `name = value` not `name=value`. Source-of-truth lives in
-        # scripts/enforce_kwargs_spacing.py.
+        # Style rule mirrored from unsloth: kwargs use `name = value` not `name=value`.
         continue-on-error: true
         run: |
           python3 scripts/enforce_kwargs_spacing.py unsloth_zoo

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -1,16 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# MLX-specific CI for unsloth-zoo. Runs on macOS arm64 (Apple
-# Silicon) so the actual mlx / mlx-lm / mlx-vlm wheels are
-# install-time resolvable. Mirrors unslothai/unsloth's mlx-ci.yml
-# shape, scoped to zoo's MLX surface:
-#   - install `unsloth_zoo[mlx]`
-#   - import smoke for every unsloth_zoo/mlx_*.py module
-#   - run the existing tests/test_mlx_torch_shim_smoke.py
-#
-# Gated by label + manual dispatch so we don't burn macOS-arm64
-# minutes on every PR. Add the `mlx` label to a PR to opt-in.
+# MLX-specific CI on macOS arm64 (Apple Silicon) so mlx / mlx-lm / mlx-vlm wheels
+# resolve. Installs `unsloth_zoo[mlx]`, smoke-imports unsloth_zoo/mlx_*.py modules,
+# runs tests/test_mlx_torch_shim_smoke.py. Opt-in via `mlx` label to save macOS minutes.
 
 name: MLX CI on Mac M1
 
@@ -32,9 +25,7 @@ permissions:
 jobs:
   mlx-smoke:
     name: MLX install + import smoke (Apple Silicon)
-    # Opt-in to save macOS minutes:
-    #   - schedule / workflow_dispatch always runs
-    #   - PR runs ONLY when the `mlx` label is present
+    # Opt-in: schedule / workflow_dispatch always run; PR runs only with `mlx` label.
     if: >-
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -42,9 +33,7 @@ jobs:
     runs-on: macos-14   # Apple Silicon (M1) hosted runner
     timeout-minutes: 30
     steps:
-      # harden-runner block-mode is Linux-only; we stay in audit on
-      # macOS so the workflow has parity with the Linux runs without
-      # the cross-OS instrumentation gap.
+      # harden-runner block-mode is Linux-only; stay in audit on macOS for parity.
       - name: Harden runner (audit)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
         with:
@@ -60,9 +49,7 @@ jobs:
           cache: 'pip'
 
       - name: Install zoo with MLX extras
-        # pyproject.toml gates the MLX-only deps on
-        # `sys_platform == 'darwin' and platform_machine == 'arm64'`
-        # so installing `.[mlx]` here picks up mlx / mlx-lm / mlx-vlm
+        # pyproject gates MLX deps on darwin+arm64; `.[mlx]` picks them up
         # without the torch-on-Linux-CUDA path.
         run: |
           python -m pip install --upgrade pip
@@ -70,9 +57,6 @@ jobs:
           pip install pytest==9.0.3
 
       - name: MLX module import smoke
-        # If any of these top-level imports breaks under the real
-        # MLX runtime, we want to see it BEFORE a Studio release
-        # downstream depends on the broken interface.
         run: |
           python -c "import unsloth_zoo.mlx_loader; print('mlx_loader OK')"
           python -c "import unsloth_zoo.mlx_compile; print('mlx_compile OK')"
@@ -81,8 +65,6 @@ jobs:
           python -c "import unsloth_zoo.mlx_cce; print('mlx_cce OK')"
 
       - name: tests/test_mlx_torch_shim_smoke.py
-        # The one zoo test that exercises the MLX-on-torch shim
-        # harness end-to-end. On real Apple Silicon it runs against
-        # the genuine mlx runtime; on Linux runners it would run
-        # against tests/mlx_simulation/ stubs.
+        # Exercises the MLX-on-torch shim end-to-end against the real mlx runtime
+        # on Apple Silicon; on Linux runners it would run against tests/mlx_simulation/ stubs.
         run: python -m pytest tests/test_mlx_torch_shim_smoke.py -v

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,26 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Pure-Python supply-chain audit for unsloth_zoo. Mirrors the shape of
-# unslothai/unsloth's security-audit.yml, with the npm / Cargo / Studio
-# jobs stripped (zoo has no `package-lock.json`, no `Cargo.lock`, no
-# frontend bundle).
-#
-# Jobs:
-#   - advisory-audit:        pip-audit + trufflehog secret scan.
-#   - pip-scan-packages:     downloads every PyPI archive in zoo's
-#                            transitive closure and pattern-scans for
-#                            install-time droppers / credential
-#                            stealers / known IOC strings. Uses the
-#                            same scripts/scan_packages.py ported
-#                            verbatim from unsloth.
-#   - workflow-trigger-lint: refuses pull_request_target /
-#                            cache-poisoning patterns in this very
-#                            workflow tree.
-#   - tests-security:        pytest tests/security regression suite
-#                            (pins the IOC tables + workflow-lint
-#                            invariants so future drift fails at PR
-#                            time, not in production).
+# Pure-Python supply-chain audit for unsloth_zoo. Mirrors unslothai/unsloth's
+# security-audit.yml with npm/Cargo/Studio jobs stripped (zoo is pure Python).
+# Jobs: advisory-audit (pip-audit + trufflehog), pip-scan-packages (transitive
+# closure pattern scan), workflow-trigger-lint, tests-security (HARD GATE).
 
 name: Security audit
 
@@ -46,10 +30,7 @@ permissions:
   contents: read
 
 jobs:
-  # ─────────────────────────────────────────────────────────────────────
-  # Advisory-DB audit: pip-audit + trufflehog. Non-blocking initially
-  # while the baseline settles -- promote to fail-closed once it's clean.
-  # ─────────────────────────────────────────────────────────────────────
+  # Advisory-DB audit: pip-audit + trufflehog. Non-blocking while baseline settles.
   advisory-audit:
     name: advisory audit (pip + secrets)
     runs-on: ubuntu-latest
@@ -81,9 +62,8 @@ jobs:
         run: python -m pip install --upgrade pip pip-audit
 
       - name: Build filtered requirements set
-        # Reads pyproject.toml's `project.dependencies` + all extras and
-        # writes a flat requirements file pip-audit can resolve. git+
-        # specs are skipped (advisory-DB can't resolve them anyway).
+        # Reads pyproject.toml deps + extras into a flat requirements file.
+        # git+ specs are skipped (advisory-DB can't resolve them).
         run: |
           mkdir -p audit-reqs
           python <<'PY' > audit-reqs/zoo-deps.txt
@@ -115,12 +95,8 @@ jobs:
           head: HEAD
           extra_args: --only-verified
 
-  # ─────────────────────────────────────────────────────────────────────
-  # pip-scan-packages: downloads every PyPI archive in zoo's transitive
-  # closure and runs scan_packages.py pattern checks. Catches the
-  # malicious-upload class (litellm 1.82.7, lightning 2.6.2 etc.) that
-  # advisory-DB lookups MISS because they precede CVE publication.
-  # ─────────────────────────────────────────────────────────────────────
+  # pip-scan-packages: downloads every PyPI archive in zoo's transitive closure and
+  # pattern-scans (catches the malicious-upload class that precedes CVE publication).
   pip-scan-packages:
     name: pip scan-packages (zoo transitive closure)
     runs-on: ubuntu-latest
@@ -149,10 +125,8 @@ jobs:
           cache: 'pip'
 
       - name: Install scan_packages.py runtime deps
-        # scan_packages.py imports requests + packaging at runtime to
-        # talk to PyPI's JSON API and to parse version specifiers. We
-        # do not install the packages it scans -- those are downloaded
-        # raw and inspected without ever touching `pip install`.
+        # requests + packaging for PyPI's JSON API. Scanned packages are
+        # downloaded raw and inspected, never `pip install`-ed.
         run: python -m pip install --upgrade pip requests packaging
 
       - name: Build filtered requirements set
@@ -176,19 +150,12 @@ jobs:
 
       - name: scan-packages (with deps)
         continue-on-error: true
-        # --with-deps makes the scan transitive. scan_packages.py
-        # downloads each archive and pattern-scans it WITHOUT
-        # installing -- an attacker cannot phone home from this runner
-        # via a malicious wheel because the wheel is never executed.
+        # --with-deps makes scan transitive. Archives are downloaded and
+        # pattern-scanned WITHOUT installing -- malicious wheels cannot execute.
         run: python3 scripts/scan_packages.py --requirements audit-reqs/zoo-deps.txt --with-deps
 
-  # ─────────────────────────────────────────────────────────────────────
-  # workflow-trigger-lint: refuses pull_request_target with any
-  # checkout-of-PR-head step, restricted workflow_run without an
-  # explicit justification comment, and PR/publish cache-key
-  # collisions. Pure-Python; pinned by tests/security regression
-  # suite below.
-  # ─────────────────────────────────────────────────────────────────────
+  # workflow-trigger-lint: refuses pull_request_target with PR-head checkout,
+  # restricted workflow_run without justification, and cache-key collisions.
   workflow-trigger-lint:
     name: workflow-trigger lint (pull_request_target / cache-poisoning)
     runs-on: ubuntu-latest
@@ -221,12 +188,8 @@ jobs:
       - name: Run workflow-trigger lint
         run: python3 scripts/lint_workflow_triggers.py
 
-  # ─────────────────────────────────────────────────────────────────────
-  # Regression tests for the scanner + lint scripts above. Hard gate
-  # (no continue-on-error) so future drift in the IOC tables or
-  # scanner exit semantics fails this PR at review time, not in a
-  # silent CI flake.
-  # ─────────────────────────────────────────────────────────────────────
+  # HARD GATE: regression tests for scanner + lint scripts. Drift in IOC tables
+  # or scanner exit semantics fails this PR at review time.
   tests-security:
     name: pytest tests/security
     runs-on: ubuntu-latest
@@ -254,11 +217,9 @@ jobs:
           python-version: '3.12'
 
       - name: Install pytest + PyYAML
-        # PyYAML is imported by scripts/lint_workflow_triggers.py, which
-        # the tests/security/test_lint_workflow_triggers.py regression
-        # suite exercises as a subprocess. (Same lesson learned on
-        # unsloth PR #5397 -- without pyyaml the lint script bails with
-        # exit 2 and the 5 lint regression tests fail.)
+        # PyYAML needed by scripts/lint_workflow_triggers.py, exercised via subprocess
+        # by tests/security/test_lint_workflow_triggers.py. (See unsloth PR #5397: without
+        # pyyaml the lint script exits 2.)
         run: pip install pytest==9.0.3 pyyaml==6.0.2
 
       - name: Run security regression tests

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Builds the PyPI wheel + sdist from the PR branch, then verifies the
-# built wheel contains what we expect to ship and is importable in a
-# clean venv. Adapted from unsloth's wheel-smoke.yml: zoo has no
-# frontend / Tauri / Studio tree, so the content checks pivot to
-# "unsloth_zoo package present, no tests/ shipped, no stray .pyc, real
-# version string from dynamic metadata, import smoke succeeds".
+# Build PyPI wheel + sdist, verify content sanity, import-smoke in a clean venv.
+# Adapted from unsloth's wheel-smoke.yml; zoo's content checks: package present,
+# no tests/ shipped, no stray .pyc, real version string, import smoke succeeds.
 
 name: Wheel CI
 
@@ -61,9 +58,7 @@ jobs:
               print("FAIL: no wheel produced"); sys.exit(2)
           w = wheels[0]
           print(f"wheel: {w}")
-          # Version sanity: dynamic metadata pulls from
-          # unsloth_zoo.__init__.__version__; assert the filename
-          # carries a non-zero SemVer-ish token, not "0.0.0".
+          # Version sanity: dynamic metadata pulls from unsloth_zoo.__init__.__version__.
           m = re.match(r"dist/unsloth_zoo-([^-]+)-py3-none-any\.whl", w)
           version = m.group(1) if m else None
           print(f"wheel version: {version}")
@@ -79,11 +74,8 @@ jobs:
                 "version is not 0.0.0":                 version is not None and version != "0.0.0",
                 "METADATA present":                     any(s.endswith(".dist-info/METADATA") for s in n),
               }
-              # Soft checks: warn only. Zoo's pyproject.toml currently
-              # doesn't exclude tests/ or scripts/ from setuptools'
-              # find_packages, so wheels DO ship them. Tightening
-              # the packaging config is a separate follow-up; failing
-              # the gate here would block this CI-bootstrap PR.
+              # Soft checks (warn only). Zoo's pyproject doesn't exclude tests/scripts;
+              # tightening the packaging config is a separate follow-up.
               soft_checks = {
                 "no tests/ shipped":                    not any(s.startswith("tests/") for s in n),
                 "no scripts/ shipped":                  not any(s.startswith("scripts/") for s in n),
@@ -101,15 +93,10 @@ jobs:
           PY
 
       - name: Import smoke (clean venv)
-        # unsloth_zoo/__init__.py:128 raises
-        # `ImportError("Please install Unsloth via 'pip install unsloth'!")`
-        # when the parent `unsloth` package is absent -- a deliberate
-        # guardrail that prevents standalone zoo use. So a bare
-        # `import unsloth_zoo` in a wheel-only venv WILL fail by
-        # design; the smoke check pivots to reading the version
-        # string from the installed dist-info METADATA instead. That
-        # confirms the wheel installed AND the version string is
-        # well-formed, without tripping the parent-import guard.
+        # unsloth_zoo/__init__.py:128 raises ImportError when parent `unsloth` is
+        # absent (deliberate guardrail). A bare `import unsloth_zoo` in a wheel-only
+        # venv will fail by design, so the smoke pivots to reading the version
+        # string from dist-info METADATA via importlib.metadata.
         run: |
           python -m venv /tmp/v
           /tmp/v/bin/pip install --upgrade pip

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,29 +143,12 @@ def _preload_real_device_type() -> bool:
 
 
 def _patch_torch_cuda_for_import() -> None:
-    """Guard concrete ``torch.cuda.*`` calls that ``unsloth_zoo.*``
-    modules make at IMPORT time on CPU-only CI runners.
+    """Stub torch.cuda.* calls made at IMPORT time on CPU-only CI runners.
 
-    Three crash classes covered:
-
-    1. ``torch.cuda.memory.mem_get_info`` -- some
-       ``unsloth_zoo.temporary_patches.*`` modules call this at
-       module init. Return a plausible (free, total) pair so the
-       memory-availability arithmetic succeeds.
-
-    2. ``torch.cuda.get_device_capability`` -- called at module top
-       level in ``unsloth_zoo/compiler.py:87`` and
-       ``unsloth_zoo/loss_utils.py:39`` to gate the cut_cross_entropy
-       import on Ampere+. CPU-only torch raises ``AssertionError:
-       Torch not compiled with CUDA enabled``, blocking every test
-       that does ``importlib.import_module("unsloth_zoo.compiler")``
-       or ``...loss_utils``. Patch to return ``(8, 0)`` so the
-       capability check passes (Ampere-equivalent); the actual
-       cut_cross_entropy import is try/except-wrapped anyway.
-
-    3. ``torch.cuda.get_device_properties`` -- similar shape, used
-       by other temporary_patches sites. Return a minimal namespace
-       with ``major`` / ``minor`` / ``total_memory`` attributes.
+    Covers mem_get_info (used by temporary_patches/*), get_device_capability
+    (compiler.py:87, loss_utils.py:39 -- gates cut_cross_entropy on Ampere+),
+    and get_device_properties. Return (8, 0) so Ampere-gated imports proceed;
+    the cut_cross_entropy import itself is try/except wrapped.
     """
     try:
         import torch  # type: ignore
@@ -217,29 +200,20 @@ if str(_TESTS_DIR) not in sys.path:
 
 
 # ---------------------------------------------------------------------------
-# 3. Apply upstream-drift fixes (triton CompiledKernel attrs, vLLM
-#    GuidedDecodingParams rename, peft transformers_weight_conversion shim,
-#    etc.) by triggering ``import unsloth``. The fixes are hosted on
-#    ``unsloth/import_fixes.py`` and applied at unsloth import time; zoo
-#    no longer carries a redundant copy of them. The production zoo
-#    import chain requires ``find_spec("unsloth")`` to succeed (see
-#    ``unsloth_zoo/__init__.py``), so unsloth has always already run by
-#    the time anything imports zoo at runtime; this conftest just forces
-#    the same ordering for the CPU-only test harness, which deliberately
-#    avoids triggering the full ``unsloth_zoo`` import chain itself (it
-#    requires CUDA / torch device init). Tests that don't have unsloth
-#    installed (e.g. security-only test runs in CI) keep passing because
-#    we swallow ImportError here.
+# 3. Apply upstream-drift fixes (triton CompiledKernel attrs, vLLM rename,
+#    peft transformers_weight_conversion shim, etc.) by triggering
+#    ``import unsloth``. Fixes live on ``unsloth/import_fixes.py`` and run
+#    at unsloth import time; zoo no longer carries a copy. Security-only
+#    test suites without unsloth installed keep passing -- ImportError is
+#    swallowed below.
 # ---------------------------------------------------------------------------
 
 def _apply_upstream_import_fixes_for_tests() -> None:
     try:
-        import unsloth  # noqa: F401  # side-effect: runs unsloth/import_fixes.py
+        import unsloth  # noqa: F401  # runs unsloth/import_fixes.py
     except Exception:
-        # unsloth not installed (security-only test suites), or it failed
-        # to import on this stack. Either way we don't want to take pytest
-        # collection down here -- individual drift-detector tests will
-        # surface any pathology that the missing patches would have hidden.
+        # unsloth missing (security-only suites) or import failed; drift
+        # detectors will surface any pathology the patches would mask.
         pass
 
 

--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -14,36 +14,17 @@
 """End-to-end drift detectors for ``unsloth_zoo/compiler.py``'s DYNAMIC
 CODE CREATION pipeline.
 
-Companion to ``test_upstream_source_patterns.py`` -- that file pins the
-upstream patterns the rewriters search for BEFORE the rewrite runs. THIS
-file drives each rewriter end-to-end against real upstream transformers
-source and asserts that the rewritten output:
+Companion to ``test_upstream_source_patterns.py`` (which pins the
+upstream patterns BEFORE the rewrite). This file drives each rewriter
+end-to-end against real upstream transformers source and asserts the
+rewritten output ``ast.parse``s, ``compile`` + ``exec``s, and (for
+named-symbol rewrites) the symbol is gone after rewrite.
 
-  1. ``ast.parse`` succeeds (no syntax / indent / unbalanced-paren bugs
-     introduced by the rewrite),
-  2. ``compile`` + ``exec`` in a sandboxed namespace succeed (the
-     rewritten code is loadable; no NameError on a dangling identifier
-     left behind after upstream refactored it away),
-  3. for rewrites that target named symbols, the symbol is gone from
-     the rewritten output (the rewrite actually landed; a silent
-     ``str.replace`` no-op is the canonical zoo bug).
+Also drives ``unsloth_compile_transformers(model_type=X)`` end-to-end
+across every known model type and AST-parses the emitted cache file.
 
-Also drives the full ``unsloth_compile_transformers(model_type=X)``
-pipeline (which is itself the master entry point that exec()'s the
-combined rewritten module) over every model type the zoo knows about
-on the installed transformers and AST-parses the resulting compiled
-cache file.
-
-Test contract:
-
-  * CPU-only -- inherits ``tests/conftest.py`` GPU-free harness.
-  * Drift / invalid rewritten Python -> ``pytest.fail`` with a loud
-    DRIFT DETECTED message. Never ``pytest.skip`` to hide a real
-    rewriter bug.
-  * Model types not present on the installed transformers build are
-    skipped with reason "model_type X not present on installed
-    transformers, can't drive compiler" -- that's environment, not
-    drift.
+CPU-only; drift -> ``pytest.fail("DRIFT DETECTED: ...")``. Model types
+absent from the installed transformers are skipped (environment).
 """
 
 from __future__ import annotations
@@ -57,12 +38,8 @@ import textwrap
 import pytest
 
 
-# Disable torch.compile-driven side effects, so we exercise the SOURCE
-# rewrite + ast.parse pipeline (which is what the user cares about
-# here) without paying GPU/torch.compile cost. ``disable=True`` is
-# passed explicitly to ``unsloth_compile_transformers``; the env var
-# additionally short-circuits ``@torch.compile`` decoration inside the
-# emitted source so the compiled cache file imports cleanly under CPU.
+# Disable torch.compile side effects so we only exercise the SOURCE
+# rewrite + ast.parse pipeline (no GPU / no torch.compile cost).
 os.environ.setdefault("UNSLOTH_COMPILE_DISABLE", "1")
 
 
@@ -70,17 +47,9 @@ transformers = pytest.importorskip("transformers")
 compiler = pytest.importorskip("unsloth_zoo.compiler")
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-# Model types the zoo compiler is expected to drive end-to-end. The set
-# comes from grepping ``unsloth_compile_transformers(model_type=...)``
-# call sites in ``unsloth`` + ``unsloth_zoo`` and from the model
-# families enumerated by ``test_apply_fused_lm_head`` in
-# ``unsloth_zoo/compiler.py``. Models that aren't present on this
-# transformers build are SKIPPED (env, not drift) -- see
-# ``_load_modeling`` below.
+# Model types the zoo compiler drives end-to-end; sourced from
+# unsloth_compile_transformers(model_type=...) call sites in unsloth +
+# unsloth_zoo and from test_apply_fused_lm_head's enumerated families.
 KNOWN_MODEL_TYPES = [
     "llama",
     "llama4",
@@ -91,7 +60,7 @@ KNOWN_MODEL_TYPES = [
     "gemma2",
     "gemma3",
     "gemma3n",
-    "gemma4",          # not on tf 4.57 but on newer; skip if missing
+    "gemma4",          # newer tf only; skip if missing
     "qwen2",
     "qwen2_moe",
     "qwen2_vl",
@@ -100,7 +69,7 @@ KNOWN_MODEL_TYPES = [
     "qwen3_moe",
     "qwen3_next",
     "qwen3_vl",
-    "deepseek",        # legacy; replaced by deepseek_v2/v3
+    "deepseek",        # legacy
     "deepseek_v2",
     "deepseek_v3",
     "gpt_oss",
@@ -127,14 +96,8 @@ KNOWN_MODEL_TYPES = [
 
 
 def _load_modeling(model_type: str):
-    """Import ``transformers.models.<model_type>.modeling_<model_type>``.
-
-    Returns the module on success. Calls ``pytest.skip`` with a clear
-    environment-not-drift reason when the model isn't shipped by this
-    transformers build, so the suite stays green across the supported
-    transformers version matrix while still firing loudly on real
-    rewriter bugs.
-    """
+    """Import transformers.models.<model_type>.modeling_<model_type>.
+    Skip on ModuleNotFoundError (env, not drift)."""
     mod_path = f"transformers.models.{model_type}.modeling_{model_type}"
     try:
         return importlib.import_module(mod_path)
@@ -146,14 +109,7 @@ def _load_modeling(model_type: str):
 
 
 def _assert_parseable(rewritten: str, entry_point: str, *, dedent: bool = False):
-    """``ast.parse`` ``rewritten`` and ``pytest.fail`` with a loud DRIFT
-    DETECTED message on SyntaxError / IndentationError.
-
-    ``dedent=True`` for rewriters whose input is a method source
-    (already indented relative to its class) -- the rewriter is
-    allowed to preserve that indentation and the test just dedents
-    before parsing.
-    """
+    """ast.parse(rewritten) or pytest.fail with DRIFT message."""
     source = textwrap.dedent(rewritten) if dedent else rewritten
     try:
         ast.parse(source)
@@ -167,14 +123,9 @@ def _assert_parseable(rewritten: str, entry_point: str, *, dedent: bool = False)
 
 
 def _assert_execs(rewritten: str, entry_point: str, *, dedent: bool = False):
-    """``compile`` + ``exec`` ``rewritten`` in a sandboxed namespace
-    and ``pytest.fail`` with a DRIFT message on syntax / load errors.
-
-    Only top-level definitions are exercised -- exec()'ing a function
-    body in isolation isn't meaningful, so callers should ensure the
-    source represents a top-level Python program (e.g. a full module,
-    or a dedented top-level def).
-    """
+    """compile + exec rewritten in a sandbox; NameError -> DRIFT.
+    ImportError / other runtime errors at top-level are out of scope
+    (env, not drift); only NameError indicates a dangling identifier."""
     source = textwrap.dedent(rewritten) if dedent else rewritten
     sandbox = {"__name__": "test_compiler_dynamic_exec_sandbox"}
     try:
@@ -188,36 +139,20 @@ def _assert_execs(rewritten: str, entry_point: str, *, dedent: bool = False):
     try:
         exec(code, sandbox)
     except NameError as exc:
-        # A NameError at top-level exec means the rewrite left behind a
-        # dangling identifier whose source we never imported. That's
-        # the classic drift mode this file is hunting for.
         pytest.fail(
             f"DRIFT DETECTED: {entry_point} top-level exec raised "
             f"NameError on dangling identifier: {exc}"
         )
     except ImportError:
-        # ImportError on a transitive dep at top-level (e.g. an
-        # ``import causal_conv1d`` line in a Mamba-flavoured rewrite)
-        # is environment, not drift. The compile+ast checks above are
-        # what we're really asserting.
         pass
     except Exception:
-        # Any other runtime error during top-level eval (e.g. a
-        # decorator that requires CUDA) is out of scope here; the
-        # ast.parse + compile checks are the load-bearing assertions.
         pass
 
 
-# ---------------------------------------------------------------------------
-# Per-rewriter tests against a real transformers source (gemma3)
-# ---------------------------------------------------------------------------
-
-# We deliberately pick gemma3 as the canonical driver: it's a
-# moderately-sized model file that exercises almost every rewriter
-# path (RMSNorm, sliding-window attention, RoPE, MoE-shaped routing,
-# multi-modal projector, ForConditionalGeneration head). If a
-# rewriter is going to silently corrupt source, gemma3 is the most
-# likely place to surface it.
+# Per-rewriter tests against real transformers source. gemma3 is the
+# canonical driver: moderately-sized and exercises almost every
+# rewriter path (RMSNorm, sliding-window attn, RoPE, MoE-shaped
+# routing, multi-modal projector, ForConditionalGeneration head).
 
 
 @pytest.fixture(scope="module")
@@ -236,9 +171,8 @@ def test_higher_precision_softmax_full_module(gemma3_full_source):
 
 
 def test_higher_precision_softmax_idempotent(gemma3_full_source):
-    """The rewrite has an explicit idempotency lookahead (see
-    ``unsloth_zoo/compiler.py:398-404``). Drive it twice and assert no
-    double ``.to(x.dtype).to(x.dtype)`` chains appear."""
+    """Pins ``unsloth_zoo/compiler.py:398-404`` idempotency lookahead;
+    drive twice and assert no doubled ``.to(x.dtype).to(x.dtype)`` chains."""
     once = compiler.higher_precision_softmax(gemma3_full_source)
     twice = compiler.higher_precision_softmax(once)
     _assert_parseable(twice, "higher_precision_softmax(gemma3)x2")
@@ -255,8 +189,8 @@ def test_higher_precision_sqrt_mean_full_module(gemma3_full_source):
 
 
 def test_fix_rotary_embedding_dtype_passthrough(gemma3_full_source):
-    """Without ``UNSLOTH_FORCE_CUSTOM_DTYPE`` the rewriter is a no-op.
-    Validate the no-op path doesn't accidentally corrupt source."""
+    """Without UNSLOTH_FORCE_CUSTOM_DTYPE the rewriter is a no-op;
+    validate the no-op path doesn't corrupt source."""
     out = compiler.fix_rotary_embedding_dtype(gemma3_full_source)
     _assert_parseable(out, "fix_rotary_embedding_dtype(gemma3)")
     assert out == gemma3_full_source, (
@@ -266,13 +200,11 @@ def test_fix_rotary_embedding_dtype_passthrough(gemma3_full_source):
 
 
 def test_fix_attention_dtype_consistency_full_module(gemma3_full_source):
-    """The rewrite inserts a ``value_states = value_states.to(...)``
-    cast directly after every ``apply_rotary_pos_emb(...)`` call. Drive
-    it on the full module source and assert the result parses."""
+    """Pins ``unsloth_zoo/compiler.py`` fix_attention_dtype_consistency:
+    inserts V-dtype cast directly after each ``apply_rotary_pos_emb(...)``."""
     out = compiler.fix_attention_dtype_consistency(gemma3_full_source)
     _assert_parseable(out, "fix_attention_dtype_consistency(gemma3)")
     if "apply_rotary_pos_emb(" in gemma3_full_source:
-        # The rewrite SHOULD have landed.
         assert (
             "value_states = value_states.to(query_states.dtype)" in out
         ), (
@@ -282,13 +214,10 @@ def test_fix_attention_dtype_consistency_full_module(gemma3_full_source):
 
 
 def test_higher_precision_layernorms_full_module(gemma3_full_source, monkeypatch):
-    """The rewriter mutates ``os.environ`` (sets
-    ``UNSLOTH_HIGH_PRECISION_LAYERNORM``); use monkeypatch so the
-    setting doesn't leak."""
+    """Rewriter mutates os.environ (UNSLOTH_HIGH_PRECISION_LAYERNORM);
+    monkeypatch prevents leak."""
     monkeypatch.delenv("UNSLOTH_HIGH_PRECISION_LAYERNORM", raising=False)
     compiler.higher_precision_layernorms(gemma3_full_source)
-    # No source returned -- side-effect only. Just assert the env var
-    # is now set (any value).
     assert "UNSLOTH_HIGH_PRECISION_LAYERNORM" in os.environ, (
         "DRIFT DETECTED: higher_precision_layernorms did not set "
         "UNSLOTH_HIGH_PRECISION_LAYERNORM env var on gemma3"
@@ -301,12 +230,9 @@ def test_fixup_fused_lm_head_full_module(gemma3_full_source):
 
 
 def test_fixup_fused_lm_head_walrus_dropped():
-    """``fixup_fused_lm_head`` pins the gemma3n-style walrus assignment
-    ``(final_logit_softcapping := ...)`` and rewrites it to a plain
-    ``self.config.get_text_config().final_logit_softcapping is not
-    None`` check (see ``unsloth_zoo/compiler.py:2815-2818``). Drive the
-    rewrite with that exact input shape and assert the walrus name no
-    longer appears."""
+    """Pins ``unsloth_zoo/compiler.py:2815-2818`` gemma3n walrus rewrite:
+    ``(final_logit_softcapping := ...)`` -> plain
+    ``.final_logit_softcapping is not None`` check."""
     src = (
         "def forward(self):\n"
         "    if (final_logit_softcapping := self.config.get_text_config().final_logit_softcapping) is not None:\n"
@@ -315,14 +241,11 @@ def test_fixup_fused_lm_head_walrus_dropped():
     )
     out = compiler.fixup_fused_lm_head(src)
     _assert_parseable(out, "fixup_fused_lm_head(walrus)")
-    # The walrus binding name should be gone from the rewritten check.
     if ":= self.config" in out or "(final_logit_softcapping :=" in out:
         pytest.fail(
             "DRIFT DETECTED: fixup_fused_lm_head left the walrus "
             "binding in place; gemma3n rewrite did not land"
         )
-    # And the bare ``final_logit_softcapping`` operand should have
-    # been canonicalised to ``self.config.get_text_config().final_logit_softcapping``.
     assert "self.config.get_text_config().final_logit_softcapping" in out
 
 
@@ -332,9 +255,7 @@ def test_apply_mask_attention_mask_out_full_module(gemma3_full_source):
 
 
 def test_convert_attention_masks_to_bool_passthrough(gemma3_full_source):
-    """For a module-level source without a bare ``return`` line, the
-    rewriter MUST passthrough unmodified -- otherwise it produces
-    invalid code."""
+    """Module-level source without bare ``return`` -> passthrough."""
     out = compiler.convert_attention_masks_to_bool("gemma3", gemma3_full_source)
     _assert_parseable(out, "convert_attention_masks_to_bool(gemma3, full)")
 
@@ -345,13 +266,11 @@ def test_patch_residual_stream_full_module(gemma3_full_source):
 
 
 def test_replace_with_grouped_query_attention_attention_method(gemma3_mod):
-    """Drive the GQA rewriter on the actual ``Gemma3Attention.forward``
-    method body."""
+    """GQA rewriter on real Gemma3Attention.forward."""
     attn_src = inspect.getsource(gemma3_mod.Gemma3Attention.forward)
     out = compiler.replace_with_grouped_query_attention(
         "Gemma3Attention", attn_src,
     )
-    # Method source is indented; dedent before parsing.
     _assert_parseable(out, "replace_with_grouped_query_attention(Gemma3Attention)", dedent=True)
 
 
@@ -362,7 +281,6 @@ def test_apply_fused_lm_head_gemma3_causallm(gemma3_mod):
     )
     _assert_parseable(out, "apply_fused_lm_head(Gemma3ForCausalLM)", dedent=True)
     if applied:
-        # Sentinel that the rewrite landed.
         if "NOT_RETURN_LOGITS" not in out:
             pytest.fail(
                 "DRIFT DETECTED: apply_fused_lm_head reported applied=True "
@@ -388,7 +306,6 @@ def test_apply_fused_lm_head_gemma3_conditional(gemma3_mod):
 @pytest.mark.parametrize("model_type", ["llama", "mistral", "qwen2", "qwen3"])
 def test_apply_fused_lm_head_other_text_models(model_type):
     mod = _load_modeling(model_type)
-    # Find the ForCausalLM class
     causal_cls_name = None
     for n in dir(mod):
         if n.endswith("ForCausalLM"):
@@ -405,16 +322,12 @@ def test_apply_fused_lm_head_other_text_models(model_type):
 
 
 def test_patch_gradient_checkpointing_text_decoder(gemma3_mod):
-    """Drive the rewriter against a real decoder. It returns
-    ``None`` when the upstream module already uses
-    ``GradientCheckpointingLayer`` (the modern path) -- that's not
-    drift, it's normal upstream evolution. If it DOES return a
-    rewritten init+forward, both must parse."""
+    """Returns None when upstream uses GradientCheckpointingLayer (modern
+    path, not drift). Otherwise both init + forward must parse."""
     out = compiler.patch_gradient_checkpointing(
         "Gemma3TextModel", gemma3_mod.Gemma3TextModel,
     )
     if out is None:
-        # Modern upstream path -- expected on transformers 4.57+.
         return
     init, forward = out
     _assert_parseable(init, "patch_gradient_checkpointing.init", dedent=True)
@@ -422,8 +335,7 @@ def test_patch_gradient_checkpointing_text_decoder(gemma3_mod):
 
 
 def test_patch_gradient_checkpointing_layer_caller_text_decoder(gemma3_mod):
-    """Companion rewriter for the modern ``GradientCheckpointingLayer``
-    path; same parse contract."""
+    """Companion rewriter for the modern GradientCheckpointingLayer path."""
     out = compiler.patch_gradient_checkpointing_layer_caller(
         "Gemma3TextModel", gemma3_mod.Gemma3TextModel,
     )
@@ -441,19 +353,16 @@ def test_patch_gradient_checkpointing_layer_caller_text_decoder(gemma3_mod):
 
 
 def test_strip_kw_from_module_calls_text_decoder(gemma3_mod):
-    """``strip_kw_from_module_calls`` is called by the GC-layer rewriter
-    to drop ``kwarg=`` annotations from layer call sites. Drive it
-    standalone."""
+    """Standalone strip_kw_from_module_calls drive (called internally by
+    the GC-layer rewriter to drop kwarg= annotations)."""
     fwd_src = inspect.getsource(gemma3_mod.Gemma3TextModel.forward)
     out = compiler.strip_kw_from_module_calls(fwd_src, "self.layers")
     _assert_parseable(out, "strip_kw_from_module_calls(gemma3.layers)", dedent=True)
 
 
 def test_patch_finfo_attention_mask_dtype_mismatch_passthrough(gemma3_mod):
-    """The rewriter requires a very specific upstream block. When the
-    block isn't present (the modern transformers path) the rewriter
-    passes through unmodified -- still must produce parseable
-    output."""
+    """Passthrough on modern transformers source (block not present);
+    still must produce parseable output."""
     fwd_src = inspect.getsource(gemma3_mod.Gemma3TextModel.forward)
     out = compiler.patch_finfo_attention_mask_dtype_mismatch(
         "Gemma3TextModel", fwd_src,
@@ -466,8 +375,7 @@ def test_patch_finfo_attention_mask_dtype_mismatch_passthrough(gemma3_mod):
 
 
 def test_patch_moe_routing_weights_cast_qwen3_moe():
-    """Drive the MoE routing-weights cast rewriter against the real
-    Qwen3 MoE block (which is the canonical user of this codepath)."""
+    """Real Qwen3 MoE block (canonical user of this codepath)."""
     qmoe = _load_modeling("qwen3_moe")
     cls = qmoe.Qwen3MoeSparseMoeBlock
     src = inspect.getsource(cls.forward)
@@ -484,10 +392,8 @@ def test_patch_moe_routing_weights_cast_qwen3_moe():
 
 
 def test_patch_gradient_accumulation_for_conditional_gen(gemma3_mod):
-    """``patch_gradient_accumulation`` consumes a whole modeling module
-    and a class name. Returns ``None`` when the inner classes already
-    accept ``**kwargs``; otherwise returns a rewritten class source
-    that must parse."""
+    """Returns None when inner classes already accept **kwargs; otherwise
+    rewritten class source must parse."""
     out = compiler.patch_gradient_accumulation(
         gemma3_mod, "Gemma3ForConditionalGeneration",
     )
@@ -499,10 +405,8 @@ def test_patch_gradient_accumulation_for_conditional_gen(gemma3_mod):
     )
 
 
-# ---------------------------------------------------------------------------
-# Rewriter passthrough robustness on shapes the rewriter is NOT meant to
-# touch -- these guard against accidental corruption of unrelated source.
-# ---------------------------------------------------------------------------
+# Rewriter passthrough robustness on shapes the rewriter is NOT meant
+# to touch (guards against accidental corruption of unrelated source).
 
 
 PASSTHROUGH_SOURCE = (
@@ -531,9 +435,6 @@ def test_rewriter_passthrough_on_plain_python(name):
     fn = getattr(compiler, name)
     out = fn(PASSTHROUGH_SOURCE)
     _assert_parseable(out, f"{name}(plain-python)")
-    # Plain Python with no triggers should be left effectively untouched.
-    # The rewriters may normalise whitespace; the strict equality below
-    # is a meaningful invariant for this synthetic input.
     assert out == PASSTHROUGH_SOURCE, (
         f"DRIFT DETECTED: {name} mutated trigger-free source -- "
         f"diff in {abs(len(out) - len(PASSTHROUGH_SOURCE))} chars"
@@ -551,7 +452,6 @@ def test_two_arg_rewriter_passthrough_on_plain_python(name_args):
     name, extra = name_args
     fn = getattr(compiler, name)
     result = fn(PASSTHROUGH_SOURCE, *extra) if name == "convert_attention_masks_to_bool" else fn(PASSTHROUGH_SOURCE, *extra)
-    # apply_fused_lm_head returns (source, applied)
     if isinstance(result, tuple):
         out, _applied = result
     else:
@@ -559,17 +459,12 @@ def test_two_arg_rewriter_passthrough_on_plain_python(name_args):
     _assert_parseable(out, f"{name}(plain-python)")
 
 
-# ---------------------------------------------------------------------------
-# Targeted symbol-removal asserts (the rewrite must LAND, not silently
-# no-op).
-# ---------------------------------------------------------------------------
+# Targeted symbol-removal asserts (the rewrite must LAND, not silently no-op).
 
 
 def test_higher_precision_softmax_inserts_float32_cast():
-    """The rewrite is supposed to turn every plain
-    ``F.softmax(x, dim=-1)`` into
-    ``F.softmax(x, dim=-1, dtype=torch.float32).to(x.dtype)``. Drive a
-    triggering input and assert the float32 cast LANDED."""
+    """Pin: F.softmax(x, dim=-1) -> F.softmax(x, dim=-1,
+    dtype=torch.float32).to(x.dtype)."""
     src = (
         "def f(x):\n"
         "    return F.softmax(x, dim=-1)\n"
@@ -589,10 +484,8 @@ def test_higher_precision_softmax_inserts_float32_cast():
 
 
 def test_fixup_fused_lm_head_gemma4_flat_logits_dropped():
-    """``fixup_fused_lm_head`` is supposed to rename gemma4's
-    ``flat_logits``/``flat_labels`` to ``shift_logits``/``shift_labels``
-    (see ``unsloth_zoo/compiler.py:2829-2843``). The named symbols
-    should no longer be in the rewritten output."""
+    """Pins ``unsloth_zoo/compiler.py:2829-2843`` gemma4
+    flat_logits/flat_labels -> shift_logits/shift_labels rename."""
     src = (
         "    flat_logits = shift_logits.view(-1, vocab)\n"
         "    flat_labels = shift_labels.view(-1).to(device)\n"
@@ -612,12 +505,9 @@ def test_fixup_fused_lm_head_gemma4_flat_logits_dropped():
 
 
 def test_replace_with_grouped_query_attention_inserts_enable_gqa():
-    """When the rewriter's matcher fires, it inserts the
-    ``enable_gqa=...`` kwarg (see ``unsloth_zoo/compiler.py:304-311``).
-    Drive the rewriter and assert the kwarg landed or the source is
-    unchanged (matcher didn't fire) -- but in NO case should the
-    output be invalid Python."""
-    # Use real attention source from a model that uses GQA-shaped attn.
+    """Pins ``unsloth_zoo/compiler.py:304-311`` enable_gqa= insertion;
+    either the kwarg lands or source is unchanged (matcher didn't fire).
+    Output must always be valid Python."""
     llama = _load_modeling("llama")
     if not hasattr(llama, "LlamaAttention"):
         pytest.skip("LlamaAttention not exposed on installed transformers")
@@ -631,26 +521,19 @@ def test_replace_with_grouped_query_attention_inserts_enable_gqa():
     )
 
 
-# ---------------------------------------------------------------------------
-# End-to-end: ``unsloth_compile_transformers(model_type=X)``.
-# This is the MASTER entry point. It chains every rewriter above and
-# emits a combined module to ``unsloth_compiled_cache/``. We drive it
-# for every known model type, then AST-parse the cache file.
-# ---------------------------------------------------------------------------
+# End-to-end: unsloth_compile_transformers(model_type=X). Master entry
+# point chaining every rewriter; emits combined module to
+# unsloth_compiled_cache/. Drive for every known model type, AST-parse
+# the cache file. Cache name: unsloth_compiled_module_<type>.py (see
+# ``unsloth_zoo/compiler.py:66-67`` COMBINED_UNSLOTH_NAME).
 
 
 def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
-    """Run the full ``unsloth_compile_transformers`` pipeline for
-    ``model_type`` and return the path of the emitted combined cache
-    file. The cache filename is ``unsloth_compiled_module_<type>.py``
-    inside the ``unsloth_compiled_cache`` folder (see
-    ``unsloth_zoo/compiler.py:66-67`` for ``COMBINED_UNSLOTH_NAME``)."""
-    # Ensure we don't accidentally drag torch.compile / GPU kernels in.
+    """Run unsloth_compile_transformers for model_type, return cache path."""
     monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
     monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "1")
 
-    # Clear ``__UNSLOTH_PATCHED__`` so the pipeline rebuilds each time;
-    # otherwise the rewrite emits nothing on a re-run.
+    # Clear __UNSLOTH_PATCHED__ so the pipeline rebuilds each time.
     try:
         mod = importlib.import_module(
             f"transformers.models.{model_type}.modeling_{model_type}",
@@ -679,21 +562,13 @@ def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
 def test_unsloth_compile_transformers_emits_parseable_cache(
     model_type, monkeypatch,
 ):
-    """Drive ``unsloth_compile_transformers`` end-to-end for every
-    known model type and AST-parse the emitted combined cache.
-
-    This is the user's headline concern in one test: the master
-    pipeline exec()'s rewritten transformers source; if ANY rewriter
-    on the chain produces invalid Python, the cache file written here
-    won't ``ast.parse``."""
+    """End-to-end pipeline drive per model_type + AST-parse the emitted
+    combined cache. Master pipeline exec()'s rewritten transformers
+    source; any rewriter producing invalid Python surfaces here."""
     cache_path = _compile_and_get_cache(model_type, monkeypatch)
 
     if not os.path.isfile(cache_path):
-        # Pipeline emitted nothing (full_disable / combined_module is
-        # None). That's not drift per se, but it does mean the rewrite
-        # chain bailed out before emitting -- which on transformers
-        # builds where the model IS present is suspicious. Still, do
-        # not fail; the pipeline has many legitimate early-exits.
+        # Pipeline emitted nothing (full_disable / early-exit); not drift.
         pytest.skip(
             f"unsloth_compile_transformers({model_type!r}) emitted no "
             f"combined cache file (pipeline early-exit)"
@@ -718,26 +593,18 @@ def test_unsloth_compile_transformers_emits_parseable_cache(
         )
 
 
-# ---------------------------------------------------------------------------
-# Headline smoke test from the spec: gemma3 end-to-end on installed
-# transformers.
-# ---------------------------------------------------------------------------
+# Headline smoke test: gemma3 end-to-end on installed transformers.
 
 
 def test_smoke_unsloth_compile_transformers_gemma3(monkeypatch):
-    """Smoke test from the spec: ``unsloth_compile_transformers("gemma3",
-    trust_remote_code=False, fast_inference=False)`` returns valid
-    Python on the installed transformers."""
+    """Spec smoke: ``unsloth_compile_transformers("gemma3", ...)`` returns
+    valid Python on the installed transformers. Real zoo signature (see
+    ``unsloth_zoo/compiler.py:3116-3143``) doesn't accept
+    trust_remote_code/fast_inference; pass what it does accept."""
     monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
     monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "1")
-    _load_modeling("gemma3")  # ensures present-on-tf gating
+    _load_modeling("gemma3")
 
-    # The spec wording mentions ``trust_remote_code`` /
-    # ``fast_inference`` kwargs, but the actual ``unsloth_zoo``
-    # signature (see ``unsloth_zoo/compiler.py:3116-3143``) doesn't
-    # accept those. Pass through what the real signature accepts; the
-    # net effect (no-GPU, disabled torch.compile, end-to-end source
-    # rewrite + emit) is identical.
     try:
         mod = importlib.import_module(
             "transformers.models.gemma3.modeling_gemma3",
@@ -768,9 +635,7 @@ def test_smoke_unsloth_compile_transformers_gemma3(monkeypatch):
 
 
 def test_smoke_unsloth_compile_transformers_unknown_model_type(monkeypatch):
-    """The pipeline must handle an unknown model type gracefully (early
-    return on ``ModuleNotFoundError``) rather than emit a corrupt
-    cache."""
+    """Unknown model type must early-return None (no corrupt cache)."""
     monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
     result = compiler.unsloth_compile_transformers(
         "this_model_type_does_not_exist_xyz_123", disable=True,
@@ -781,12 +646,9 @@ def test_smoke_unsloth_compile_transformers_unknown_model_type(monkeypatch):
     )
 
 
-# ---------------------------------------------------------------------------
 # AST validity of CONSTANT source blocks pasted inside compiler.py.
 # These are exec()'d verbatim by ``create_new_function`` (see
-# ``unsloth_zoo/compiler.py:801-1126``) so any syntax bug in them
-# fires the same drift mode this whole file is hunting.
-# ---------------------------------------------------------------------------
+# ``unsloth_zoo/compiler.py:801-1126``).
 
 
 @pytest.mark.parametrize(
@@ -801,19 +663,15 @@ def test_smoke_unsloth_compile_transformers_unknown_model_type(monkeypatch):
     ],
 )
 def test_compiler_constant_source_blocks_parse(const_name):
-    """Each of these constants is a Python source block embedded in
-    ``unsloth_zoo/compiler.py`` and exec()'d as-is at compile time.
-    They must be valid Python (possibly with some placeholder tokens
-    that get .replace()'d before exec); test that AT LEAST those
-    without placeholders parse, and those with placeholders parse
-    after the documented substitution."""
+    """Each constant is a Python source block embedded in
+    ``unsloth_zoo/compiler.py`` and exec()'d as-is. Must be valid Python
+    (after documented placeholder substitution where applicable)."""
     block = getattr(compiler, const_name, None)
     if block is None:
         pytest.skip(f"{const_name} not present (renamed?)")
-    # The replace_gradient_checkpointing template uses LAYER / ARGS /
-    # MODULELIST_ITEM / $ placeholders that get substituted in the
-    # rewriter; substitute representative values here so the parser
-    # sees real source.
+    # replace_gradient_checkpointing template has LAYER / ARGS /
+    # MODULELIST_ITEM / $ placeholders substituted in the rewriter;
+    # substitute representative values here so the parser sees real source.
     if const_name == "replace_gradient_checkpointing":
         block = (
             block.replace("LAYER", "layer")

--- a/tests/test_compiler_rewriter_exhaustive.py
+++ b/tests/test_compiler_rewriter_exhaustive.py
@@ -11,37 +11,17 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
-"""Exhaustive drift detectors for ``unsloth_zoo`` / ``unsloth`` source-string
-and regex rewriters (round 3 of upstream-regression test coverage).
+"""Exhaustive drift detectors for the ``unsloth_zoo`` / ``unsloth``
+source-string and regex rewriters (round 3 of coverage).
 
-The companion file ``test_upstream_source_patterns.py`` pins ~34 of the
-most commonly-tripped rewriter sites. This file pins the REMAINING sites
-walked across:
+Pins sites in compiler.py, temporary_patches/*.py, patching_utils.py,
+saving_utils.py, rl_replacements.py, training_utils.py, unsloth/trainer.py,
+unsloth/models/rl.py that aren't already pinned by
+test_upstream_source_patterns.py.
 
-  unsloth_zoo/compiler.py
-  unsloth_zoo/temporary_patches/*.py
-  unsloth_zoo/patching_utils.py
-  unsloth_zoo/saving_utils.py
-  unsloth_zoo/rl_replacements.py
-  unsloth_zoo/training_utils.py
-  unsloth/trainer.py
-  unsloth/models/rl.py
-
-Test contract (identical to the companion file):
-
-  * Each test cites the rewriter file:line it was extracted from so
-    a maintainer can grep back to the patch site.
-  * When the pinned string / regex is gone from the upstream module,
-    surface as ``pytest.fail("DRIFT DETECTED: zoo/unsloth source-rewriter
-    at <file:line> expects '<pattern>' in <upstream module>, found 0
-    matches")``. Never SKIP to hide drift.
-  * If the upstream module isn't importable in this venv,
-    ``pytest.importorskip`` (genuinely-optional upstream library; not
-    "skip to hide drift" because the rewriter wouldn't run either).
-  * CPU-only -- runs under ``tests/conftest.py`` GPU-free harness.
-
-Each test is a NEW site relative to ``test_upstream_source_patterns.py``;
-duplicates are deliberately omitted.
+Each test cites its rewriter file:line. Missing pinned string / regex ->
+``pytest.fail("DRIFT DETECTED: zoo/unsloth source-rewriter at <file:line>
+expects '<pattern>' in <upstream module>, found 0 matches")``. CPU-only.
 """
 
 from __future__ import annotations
@@ -52,14 +32,11 @@ import re
 import pytest
 
 
-# ---------------------------------------------------------------------------
-# Shared helpers (mirror test_upstream_source_patterns.py exactly so this
-# file is independently usable without import-coupling).
-# ---------------------------------------------------------------------------
+# Shared helpers (mirror test_upstream_source_patterns.py).
 
 def _drift(zoo_site: str, pattern: str, upstream_path: str,
            extra: str = "") -> None:
-    """Raise ``pytest.fail`` with the standardized DRIFT message."""
+    """``pytest.fail`` with the standardized DRIFT message."""
     msg = (
         f"DRIFT DETECTED: zoo/unsloth source-rewriter at {zoo_site} expects "
         f"{pattern!r} in {upstream_path}, found 0 matches."
@@ -83,10 +60,7 @@ def _assert_regex_in_source(regex: str, source: str, zoo_site: str,
 
 
 def _probe_modules(candidates, predicate):
-    """Return ``True`` if ``predicate(src)`` is true for at least one
-    importable module in ``candidates``. ``candidates`` is a list of
-    dotted module names. ``predicate`` receives the module source text.
-    """
+    """True if predicate(src) holds for at least one importable module."""
     import importlib
     for mod in candidates:
         try:
@@ -102,20 +76,13 @@ def _probe_modules(candidates, predicate):
     return False
 
 
-# ===========================================================================
-# unsloth_zoo/compiler.py: not-yet-covered rewriter sites
-# ===========================================================================
+# unsloth_zoo/compiler.py: not-yet-covered rewriter sites.
 
 
 def test_compiler_higher_precision_softmax_idempotency_lookahead():
-    """``unsloth_zoo/compiler.py:391-405`` -- the
-    ``higher_precision_softmax`` finder uses a negative lookahead
-    ``(?!\\s*\\.to\\(\\s*\\2\\s*\\.dtype\\s*\\))`` to skip already-
-    rewritten softmax calls. The rewriter ALSO needs the base
-    ``nn.functional.softmax`` / ``F.softmax`` plus ``dim=`` form to
-    exist somewhere upstream; otherwise the entire finder is dormant.
-    Asserts the ``dim=`` keyword form is still in use.
-    """
+    """``unsloth_zoo/compiler.py:391-405`` higher_precision_softmax negative
+    lookahead skips already-rewritten softmax. Pins the upstream
+    ``softmax(..., dim=N)`` keyword form so the finder isn't dormant."""
     pytest.importorskip("transformers")
     pattern = re.compile(
         r"(?:nn\.functional\.softmax|F\.softmax)"
@@ -141,15 +108,9 @@ def test_compiler_higher_precision_softmax_idempotency_lookahead():
 
 
 def test_compiler_fix_rotary_embedding_cos_to_dtype_pattern():
-    """``unsloth_zoo/compiler.py:510-517`` -- ``fix_rotary_embedding_dtype``
-    runs ``source.replace("cos.to(dtype=x.dtype)", ...)`` and
-    ``source.replace("sin.to(dtype=x.dtype)", ...)``. Activates only
-    when ``UNSLOTH_FORCE_CUSTOM_DTYPE`` is set, but the rewriter
-    TARGETS must still exist in some upstream rotary embedding for the
-    patch to ever fire. Pass if ANY of the literal forms (or the
-    bare ``cos.to(`` / ``sin.to(`` cast prefix) appear in a rotary
-    embedding module; DRIFT only when the entire idiom is gone.
-    """
+    """``unsloth_zoo/compiler.py:510-517`` fix_rotary_embedding_dtype
+    replaces ``cos.to(dtype=x.dtype)`` / ``sin.to(dtype=x.dtype)``;
+    UNSLOTH_FORCE_CUSTOM_DTYPE-gated. Pin: some rotary cast site exists."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.models.llama.modeling_llama",
@@ -182,17 +143,9 @@ def test_compiler_fix_rotary_embedding_cos_to_dtype_pattern():
 
 
 def test_compiler_higher_precision_layernorms_norm_class_marker():
-    """``unsloth_zoo/compiler.py:560-597`` -- ``higher_precision_layernorms``
-    locates ``class <X>Norm(nn.Module): ... def __init__ ... self.weight
-    ... class <Y>``. Then it probes the matched chunk for one of:
-    ``self.weight.to(torch.float32)``, ``(self.weight * hidden_states).to(``,
-    ``self.weight * hidden_states.to(``, ``self.weight.float()``, or
-    ``return output * self.weight`` to decide the upcasting dtype.
-    Asserts at least one transformers modeling file still has a
-    ``class <X>Norm(nn.Module)`` definition; otherwise the finder
-    matches nothing and ``UNSLOTH_HIGH_PRECISION_LAYERNORM`` is never
-    auto-toggled.
-    """
+    """``unsloth_zoo/compiler.py:560-597`` higher_precision_layernorms
+    locates ``class <X>Norm(nn.Module):`` blocks; without one,
+    UNSLOTH_HIGH_PRECISION_LAYERNORM is never auto-toggled."""
     pytest.importorskip("transformers")
     pattern = re.compile(
         r"\nclass[^\(\n]{1,}Norm\(nn\.Module\)",
@@ -219,12 +172,8 @@ def test_compiler_higher_precision_layernorms_norm_class_marker():
 
 
 def test_compiler_embedding_oob_clamp_input_ids_pattern():
-    """``unsloth_zoo/compiler.py:1383-1387`` -- runs
-    ``re.sub(r"self\\.([A-Za-z\\_]{0,}embedding)\\(input_ids (\\-|\\+) (self\\.[A-Za-z\\_]{1,})\\)", ...)``
-    to clamp Gemma 3N's input_ids offsets. Asserts Gemma 3N's modeling
-    file still has at least one ``self.<...>embedding(input_ids ...)``
-    site.
-    """
+    """``unsloth_zoo/compiler.py:1383-1387`` clamps Gemma 3N's input_ids
+    offsets via re.sub on ``self.<X>embedding(input_ids +/- self.<Y>)``."""
     pytest.importorskip("transformers")
     try:
         import transformers.models.gemma3n.modeling_gemma3n as g3n
@@ -246,14 +195,9 @@ def test_compiler_embedding_oob_clamp_input_ids_pattern():
 
 
 def test_compiler_apply_mask_attention_mask_kwargs_pinned_pattern():
-    """``unsloth_zoo/compiler.py:2128-2140`` -- ``apply_mask_attention_mask_out``
-    finds ``attention_mask=attention_mask,\\n`` AND
-    ``labels=labels,\\n`` in a ForConditionalGeneration forward, then
-    re.sub-replaces ``labels=labels,`` with a masked-labels call. Pass
-    if at least one VLM forward has BOTH pinned kwargs; DRIFT if no
-    upstream forward routes ``labels=labels`` and ``attention_mask=
-    attention_mask`` together.
-    """
+    """``unsloth_zoo/compiler.py:2128-2140`` apply_mask_attention_mask_out
+    needs ``attention_mask=attention_mask,`` AND ``labels=labels,`` together
+    in a ForConditionalGeneration forward."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.models.llava.modeling_llava",
@@ -284,12 +228,8 @@ def test_compiler_apply_mask_attention_mask_kwargs_pinned_pattern():
 
 
 def test_compiler_convert_attention_masks_to_bool_finfo_min_pattern():
-    """``unsloth_zoo/compiler.py:2161-2179`` -- ``convert_attention_masks_to_bool``
-    walks `return <vars>` and probes for
-    ``<var>.+?torch\\.finfo\\(.+?\\)\\.min``. Asserts at least one
-    transformers masking-utils module still uses
-    ``torch.finfo(...).min`` as the masked-fill sentinel.
-    """
+    """``unsloth_zoo/compiler.py:2161-2179`` convert_attention_masks_to_bool
+    needs upstream ``torch.finfo(...).min`` masked-fill sentinel."""
     pytest.importorskip("transformers")
     finfo_re = re.compile(r"torch\.finfo\([^\)]+\)\.min")
     candidates = [
@@ -311,13 +251,9 @@ def test_compiler_convert_attention_masks_to_bool_finfo_min_pattern():
 
 
 def test_compiler_patch_gradient_checkpointing_for_in_modulelist_pattern():
-    """``unsloth_zoo/compiler.py:2258-2270`` -- ``patch_gradient_checkpointing``
-    discovers ``self.<X> = nn.ModuleList(...)`` in `__init__` and then
-    matches ``for <var> in self.<X>:\\n    hidden_states = <var>(<args>)``
-    in `forward`. Asserts at least one transformers modeling file still
-    has the ``self.<X> = nn.ModuleList`` assignment pattern (the call-
-    site shape used by GradientCheckpointingLayer fall-back).
-    """
+    """``unsloth_zoo/compiler.py:2258-2270`` patch_gradient_checkpointing
+    needs ``self.<X> = nn.ModuleList(...)`` in __init__ (call-site shape
+    used by GradientCheckpointingLayer fall-back)."""
     pytest.importorskip("transformers")
     pattern = re.compile(r"self\.[^\s]{1,} = .*?nn\.ModuleList\(")
     candidates = [
@@ -340,25 +276,9 @@ def test_compiler_patch_gradient_checkpointing_for_in_modulelist_pattern():
 
 
 def test_compiler_qwen2vl_rotary_pos_emb_blk_call_variant_pinned():
-    """``unsloth_zoo/compiler.py:2200-2207`` pins the SECOND custom
-    blk-call variant (with ``rotary_pos_emb`` between cu_seqlens and
-    position_embeddings):
-
-        hidden_states = blk(
-                hidden_states,
-                cu_seqlens=cu_seqlens,
-                rotary_pos_emb=rotary_pos_emb,
-                position_embeddings=position_embeddings,
-                **kwargs,
-            )
-
-    This variant is the REPLACEMENT (not the find); for the rewriter
-    to ever produce it the FIND variant must match upstream. If the
-    Qwen2VL visual forward still has the find variant (covered by
-    test_upstream_source_patterns.py) AND `rotary_pos_emb` is still a
-    valid blk kwarg the rewriter remains correct. We pin
-    ``rotary_pos_emb=`` to confirm the replacement is meaningful.
-    """
+    """``unsloth_zoo/compiler.py:2200-2207`` second blk-call REPLACEMENT
+    variant references ``rotary_pos_emb=``; if upstream renamed the kwarg
+    the rewritten call is API-incompatible."""
     pytest.importorskip("transformers")
     try:
         import transformers.models.qwen2_vl.modeling_qwen2_vl as q2vl
@@ -377,9 +297,8 @@ def test_compiler_qwen2vl_rotary_pos_emb_blk_call_variant_pinned():
 
 
 def test_compiler_qwen2vl_attention_mask_blk_call_pinned():
-    """``unsloth_zoo/compiler.py:2208-2223`` pins the THIRD custom
-    blk-call FIND variant with ``attention_mask=attention_mask``.
-    """
+    """``unsloth_zoo/compiler.py:2208-2223`` third blk-call FIND variant
+    with ``attention_mask=attention_mask``."""
     pytest.importorskip("transformers")
     try:
         import transformers.models.qwen2_vl.modeling_qwen2_vl as q2vl
@@ -396,18 +315,10 @@ def test_compiler_qwen2vl_attention_mask_blk_call_pinned():
 
 
 def test_compiler_strip_kw_for_loop_pattern_targetable():
-    """``unsloth_zoo/compiler.py:2306-2346`` -- ``strip_kw_from_module_calls``
-    finds ``for <name>, <layer> in enumerate(self.<list>):`` or
-    ``for <layer> in self.<list>:`` and then strips kwarg names from
-    each ``<layer>(arg=arg, ...)`` call. Asserts a transformers
-    decoder layer still uses the ``for <layer> in self.<list>:`` form.
-    """
+    """``unsloth_zoo/compiler.py:2306-2346`` strip_kw_from_module_calls
+    needs ``for <layer> in self.<list>:`` decoder iteration."""
     pytest.importorskip("transformers")
-    # Modern transformers uses `for decoder_layer in self.layers:` (or
-    # similar), then a body that calls the layer; matches BOTH
-    # `for <layer> in self.<list>:` (single line) and the multi-line
-    # `for <layer> in self.<list>[a:b]:` shape. zoo's compiled regex
-    # is more flexible; just probe for `for <var> in self.<attr>`.
+    # Probe `for <var> in self.<attr>` (broader than zoo's compiled regex).
     pattern = re.compile(r"for\s+\w+\s+in\s+self\.\w+")
     candidates = [
         "transformers.models.llama.modeling_llama",
@@ -428,36 +339,23 @@ def test_compiler_strip_kw_for_loop_pattern_targetable():
 
 
 def test_compiler_dtype_mismatch_finfo_attention_mask_pinned():
-    """``unsloth_zoo/compiler.py:2381-2391`` -- ``patch_finfo_attention_mask_dtype_mismatch``
-    pins the EXACT two-line shape:
-
-        attention_mask_tensor = attention_mask_tensor / torch.finfo(attention_mask_tensor.dtype).min
-        attention_mask_tensor = (1.0 - attention_mask_tensor).int()
-
-    This pattern was the pre-4.50 sdpa_attention_mask_to_bool helper.
-    If upstream renamed the variable or split the line, the rewriter
-    silently no-ops.
-    """
+    """``unsloth_zoo/compiler.py:2381-2391`` patch_finfo_attention_mask_dtype_mismatch
+    pins pre-4.50 ``<X> = <X>/torch.finfo(<X>.dtype).min`` followed by
+    ``<X> = (1.0 - <X>).int()``. Forward-looking: only DRIFT when the
+    underlying primitives are also gone."""
     pytest.importorskip("transformers")
-    # Probe several modules; the variable name and exact split changed
-    # in 4.50+ (masking_utils now hosts an equivalent).
     candidates = [
         "transformers.modeling_attn_mask_utils",
         "transformers.masking_utils",
         "transformers.models.gemma3.modeling_gemma3",
         "transformers.models.gpt_oss.modeling_gpt_oss",
     ]
-    # The relevant idiom is `<X> = <X> / torch.finfo(<X>.dtype).min`
-    # followed by `<X> = (1.0 - <X>).int()`. Look for that finfo+1.0
-    # idiom in any of the candidates.
     pattern = re.compile(
         r"torch\.finfo\([^\)]+\.dtype\)\.min[\s\S]{0,200}\(1\.0\s*-"
     )
     if not _probe_modules(candidates, lambda s: pattern.search(s) is not None):
-        # Pre-existing drift acknowledged: this exact idiom was removed
-        # in masking_utils. Don't fail unless the underlying primitives
-        # (`torch.finfo(...).min` AND `(1.0 - <mask>)`) are also gone --
-        # the rewriter is forward-looking.
+        # Exact idiom removed in masking_utils 4.50+; only fail when both
+        # `torch.finfo(...).min` AND `(1.0 - <mask>)` primitives are gone.
         finfo_present = _probe_modules(
             candidates,
             lambda s: "torch.finfo" in s,
@@ -473,11 +371,8 @@ def test_compiler_dtype_mismatch_finfo_attention_mask_pinned():
 
 
 def test_compiler_lora_forward_result_clone_pinned_string():
-    """``unsloth_zoo/compiler.py:2539`` runs
-    ``source.replace("result = result.clone()", "")``. Asserts peft's
-    LoRA layer source still has this exact .clone() line (peft used
-    to put it in ``Linear.forward`` to defeat in-place ops).
-    """
+    """``unsloth_zoo/compiler.py:2539`` replaces ``result = result.clone()``
+    in peft's LoRA forward (defeats in-place ops)."""
     pytest.importorskip("peft")
     try:
         from peft.tuners.lora.layer import Linear as LoraLinear
@@ -496,13 +391,9 @@ def test_compiler_lora_forward_result_clone_pinned_string():
 
 
 def test_compiler_torch_result_dtype_pattern():
-    """``unsloth_zoo/compiler.py:2553`` runs
-    ``re.search(r"\\btorch_result_dtype\\s*=\\s*result\\.dtype\\b", source)``
-    against peft's LoRA forward. Asserts at least one peft layer
-    (Linear / Linear4bit / Linear8bitLt) STILL stashes
-    ``torch_result_dtype = result.dtype`` (Linear / GPTQ / LoraParallel
-    path); otherwise the rewriter picks the wrong dtype_cast branch.
-    """
+    """``unsloth_zoo/compiler.py:2553`` checks
+    ``torch_result_dtype = result.dtype`` in peft's LoRA forward;
+    absent -> rewriter falls back to ``result.dtype``."""
     pytest.importorskip("peft")
     try:
         import peft.tuners.lora.layer as ly
@@ -518,12 +409,8 @@ def test_compiler_torch_result_dtype_pattern():
 
 
 def test_compiler_lora_def_forward_rename_pinned_string():
-    """``unsloth_zoo/compiler.py:2563-2567`` runs
-    ``source.replace("def forward", "def unsloth_forward", 1)``.
-    Asserts peft's LoRA layer source still has ``def forward`` (this
-    is the function-name rewrite, and a regression where peft renames
-    forward would break the install entirely).
-    """
+    """``unsloth_zoo/compiler.py:2563-2567`` renames peft's
+    ``def forward`` -> ``def unsloth_forward``."""
     pytest.importorskip("peft")
     try:
         from peft.tuners.lora.layer import Linear as LoraLinear
@@ -544,16 +431,11 @@ def test_compiler_lora_def_forward_rename_pinned_string():
 
 
 def test_compiler_lora_x_cast_dtype_pinned_strings():
-    """``unsloth_zoo/compiler.py:2578-2581,2596`` pins TWO peft-side
-    LoRA dtype-cast variants:
-
-        old1: x = x.to(lora_A.weight.dtype)
-        old2: x = self._cast_input_dtype(x, lora_A.weight.dtype)
-        old3: self._check_forward_args(x, *args, **kwargs)
-
-    DRIFT (fail) only when ALL THREE are gone -- then the autocast
-    fixup AND the check-forward-args strip both no-op.
-    """
+    """``unsloth_zoo/compiler.py:2578-2581,2596`` pins three peft LoRA
+    targets: ``x = x.to(lora_A.weight.dtype)`` / ``x =
+    self._cast_input_dtype(x, lora_A.weight.dtype)`` /
+    ``self._check_forward_args(x, *args, **kwargs)``. DRIFT only when
+    ALL THREE are gone."""
     pytest.importorskip("peft")
     try:
         from peft.tuners.lora.layer import Linear as LoraLinear
@@ -579,13 +461,9 @@ def test_compiler_lora_x_cast_dtype_pinned_strings():
 
 
 def test_compiler_variant_kwarg_keys_pinned_token():
-    """``unsloth_zoo/compiler.py:2649-2655`` runs
-    ``re.search(r"\\bVARIANT_KWARG_KEYS\\b", source)``. Asserts peft >=
-    0.18.0 still exposes ``VARIANT_KWARG_KEYS`` at the layer module
-    level (it was added for alora). The rewriter installs an explicit
-    fallback if it's missing, but the FIND must succeed for the
-    fallback to ever fire.
-    """
+    """``unsloth_zoo/compiler.py:2649-2655`` peft >= 0.18.0
+    ``VARIANT_KWARG_KEYS`` at the layer module level; the FIND must
+    succeed for the fallback to fire."""
     pytest.importorskip("peft")
     try:
         import peft.tuners.lora.layer as ly
@@ -601,16 +479,10 @@ def test_compiler_variant_kwarg_keys_pinned_token():
 
 
 def test_compiler_patch_residual_stream_residual_plus_hidden_states_pattern():
-    """``unsloth_zoo/compiler.py:2698-2705`` -- the SECOND
-    ``patch_residual_stream`` regex matches
-    ``<h> = residual + (<h> * <expr>|<expr> * <h>)``. Asserts at least
-    one VLM cross-attention encoder still has ``hidden_state =
-    residual + hidden_state * ...`` (the addcmul / fused-add target).
-    """
+    """``unsloth_zoo/compiler.py:2698-2705`` second patch_residual_stream
+    regex matches ``<h> = residual + (<h> * <expr>|<expr> * <h>)``
+    (addcmul / fused-add target on VLM cross-attention encoders)."""
     pytest.importorskip("transformers")
-    # The pinned regex requires the variable to be either
-    # ``hidden_state`` or ``hidden_states``. The pattern body is:
-    # ``<h> = residual + (<h> * <expr>|<expr> * <h>)``
     pattern = re.compile(
         r"(hidden_state(?:s)?) = residual \+ "
         r"(?:\1 \* [^\n]+|[^\n]+ \* \1)"
@@ -633,11 +505,9 @@ def test_compiler_patch_residual_stream_residual_plus_hidden_states_pattern():
 
 
 def test_compiler_patch_gradient_accumulation_from_config_pattern():
-    """``unsloth_zoo/compiler.py:2757-2759`` -- ``patch_gradient_accumulation``
-    discovers ``self.<X> = <Y>._from_config(...)`` instances. Asserts
-    at least one VLM module still uses ``._from_config`` to build a
-    sub-model (used by Idefics3, Llava-family, Qwen2-VL, ...).
-    """
+    """``unsloth_zoo/compiler.py:2757-2759`` patch_gradient_accumulation
+    discovers ``self.<X> = <Y>._from_config(...)`` (Idefics3, Llava-family,
+    Qwen2-VL)."""
     pytest.importorskip("transformers")
     pattern = re.compile(r"self\.[^ ]+\s*=\s*[^\.]+\._from_config")
     candidates = [
@@ -660,12 +530,9 @@ def test_compiler_patch_gradient_accumulation_from_config_pattern():
 
 
 def test_compiler_efficientnet_block_class_finder_pattern():
-    """``unsloth_zoo/compiler.py:2925`` -- ``compile_timm_models`` runs
-    ``re.findall(r"class ([^ ]{1,})\\(.*?nn\\.Module\\)\\:", ...)``
-    against timm._efficientnet_blocks. If timm refactors so blocks
-    no longer subclass ``nn.Module`` (e.g. moves to a base class),
-    the finder returns 0 matches and zero blocks are torch.compile-d.
-    """
+    """``unsloth_zoo/compiler.py:2925`` compile_timm_models requires
+    ``class <X>(...nn.Module):`` in timm._efficientnet_blocks;
+    refactor -> zero blocks torch.compile-d."""
     timm = pytest.importorskip("timm")
     try:
         import timm.models._efficientnet_blocks as effb
@@ -687,12 +554,9 @@ def test_compiler_efficientnet_block_class_finder_pattern():
 
 
 def test_compiler_class_inheritance_finder_pattern():
-    """``unsloth_zoo/compiler.py:3310-3318`` -- the global compiler
-    discovers ``class <X>(...Module)`` then ``class <Y>(<X>)`` via
-    re.findall. Asserts at least one modeling file still has both
-    a torch ``.Module`` subclass and one nested class deriving from
-    another local class (the SDPA / Eager attention duo).
-    """
+    """``unsloth_zoo/compiler.py:3310-3318`` global compiler discovers
+    ``class <X>(...Module)`` then ``class <Y>(<X>)``; pin a top-level
+    Module subclass (SDPA / Eager attention duo)."""
     pytest.importorskip("transformers")
     base_pattern = re.compile(r"class [^\s]+\(.+?\.Module\)")
     candidates = [
@@ -713,12 +577,8 @@ def test_compiler_class_inheritance_finder_pattern():
 
 
 def test_compiler_class_pretrainedmodel_finder_pattern():
-    """``unsloth_zoo/compiler.py:3332-3334`` -- ``re.findall(
-    r"class ([^\\s]{1,})\\(.+?PreTrainedModel\\)", full_source)``.
-    Asserts at least one transformers model file still has a
-    ``PreTrainedModel`` subclass at module level (this is how the
-    compiler discovers backbone / for-causal-lm classes).
-    """
+    """``unsloth_zoo/compiler.py:3332-3334`` discovers PreTrainedModel
+    subclasses (backbone / for-causal-lm classes) via re.findall."""
     pytest.importorskip("transformers")
     pattern = re.compile(r"class [^\s]+\(.+?PreTrainedModel\)")
     candidates = [
@@ -739,10 +599,8 @@ def test_compiler_class_pretrainedmodel_finder_pattern():
 
 
 def test_compiler_routing_weights_to_marker_in_source():
-    """``unsloth_zoo/compiler.py:3376`` -- branches on
-    ``"routing_weights.to" in source``. Asserts at least one MoE
-    forward still has this exact substring.
-    """
+    """``unsloth_zoo/compiler.py:3376`` branches on ``routing_weights.to``
+    in MoE forward (router-logit-cast / bf16 router fix anchor)."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.models.mixtral.modeling_mixtral",
@@ -762,25 +620,10 @@ def test_compiler_routing_weights_to_marker_in_source():
 
 def test_compiler_supports_sdpa_marker_in_full_source():
     """``unsloth_zoo/compiler.py:3390-3392`` branches on
-    ``"_supports_sdpa = True" in full_source`` and
-    ``"_supports_sdpa = False" not in full_source``. Asserts at least
-    one modeling file still declares ``_supports_sdpa`` either way.
-
-    Status: BENIGN on transformers 4.50+.
-
-    transformers 4.50+ moved SDPA inference to
-    ``ALL_ATTENTION_FUNCTIONS`` (the "attention interface" refactor).
-    The class-level ``_supports_sdpa`` marker is gone from most modeling
-    files, so zoo's source-string probe at compiler.py:3390-3392 silently
-    no-ops on these builds. The branch is dormant, but the actual SDPA
-    dispatch still works correctly: transformers routes through the
-    registry at runtime regardless of the marker, and zoo's compiler.py
-    now has a third fallback (``_all_attention_functions_has_sdpa``) that
-    keeps SDPA enabled for the optimised pipeline. The dormant branch is
-    no longer a correctness risk; it is dead code path on this build.
-
-    Converted from FAIL to SKIP per maintainer review.
-    """
+    ``_supports_sdpa = True/False`` in modeling source. BENIGN on
+    transformers 4.50+ (moved to ALL_ATTENTION_FUNCTIONS); zoo has
+    ``_all_attention_functions_has_sdpa()`` fallback. Pin guards
+    re-introduction."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.models.llama.modeling_llama",
@@ -808,12 +651,9 @@ def test_compiler_supports_sdpa_marker_in_full_source():
 
 
 def test_compiler_data_dependent_nonzero_tolist_item_markers():
-    """``unsloth_zoo/compiler.py:3587-3596`` skips compilation when
-    ``.nonzero()`` / ``.tolist()`` / ``.item()`` appears, or when
-    ``torch.where(`` + ``.index_add`` appear. Asserts at least one MoE
-    modeling file STILL has a data-dependent op so the compile-skip
-    branch is reachable.
-    """
+    """``unsloth_zoo/compiler.py:3587-3596`` skips compile on
+    .nonzero()/.tolist()/.item() (or torch.where + .index_add); pin a
+    data-dependent op site so the skip branch is reachable."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.models.mixtral.modeling_mixtral",
@@ -835,13 +675,8 @@ def test_compiler_data_dependent_nonzero_tolist_item_markers():
 
 
 def test_compiler_logger_running_training_inner_loop_present():
-    """``unsloth_zoo/compiler.py:3988``'s `re.search` ALSO depends on
-    ``inner_training_loop`` (the Trainer source string) actually being
-    non-empty. Confirm
-    ``transformers.trainer.Trainer._inner_training_loop`` source is
-    fetchable (covered above) AND that the source spans more than a
-    few hundred chars (a stub would be a real regression).
-    """
+    """``unsloth_zoo/compiler.py:3988`` re.search needs non-empty
+    ``Trainer._inner_training_loop`` source (multi-hundred-line body)."""
     pytest.importorskip("transformers")
     from transformers.trainer import Trainer
     try:
@@ -866,12 +701,9 @@ def test_compiler_logger_running_training_inner_loop_present():
 
 
 def test_compiler_dict_attention_mask_gpt_oss_v5_pattern_present():
-    """``unsloth_zoo/compiler.py:4148-4158`` re-sub guards on BOTH
-    ``"attn_weights = attn_weights + attention_mask"`` AND ``"module"``
-    appearing in the source. Asserts gpt_oss's modeling source has
-    ``"module"`` referenced somewhere so the conditional fires when
-    the attn_weights add pattern is present.
-    """
+    """``unsloth_zoo/compiler.py:4148-4158`` guards on
+    ``attn_weights = attn_weights + attention_mask`` AND ``module`` in
+    gpt_oss source."""
     pytest.importorskip("transformers")
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss as gpt_oss
@@ -890,11 +722,9 @@ def test_compiler_dict_attention_mask_gpt_oss_v5_pattern_present():
 
 
 def test_compiler_conv_forward_def_first_param_pattern():
-    """``unsloth_zoo/compiler.py:4289`` runs
-    ``_re.search(r"def forward\\(self,\\s*(\\w+)", source)`` against
-    ``nn.Conv*`` and ``nn.*Norm`` forwards. Asserts at least one
-    torch.nn module exposes the ``def forward(self, <name>)`` shape.
-    """
+    """``unsloth_zoo/compiler.py:4289`` reads first-param name of
+    ``def forward(self, <name>)`` on nn.Conv* / nn.*Norm forwards;
+    absent -> falls back to 'input' which may not be the actual arg."""
     import torch.nn as nn
     pattern = re.compile(r"def forward\(self,\s*(\w+)")
     found = False
@@ -920,21 +750,14 @@ def test_compiler_conv_forward_def_first_param_pattern():
         )
 
 
-# ===========================================================================
-# unsloth_zoo/patching_utils.py rewriters
-# ===========================================================================
+# unsloth_zoo/patching_utils.py rewriters.
 
 
 def test_patching_utils_compiled_autograd_end_capture_return_compiled_fn_pinned():
-    """``unsloth_zoo/patching_utils.py:544-547`` runs
-    ``re.search(r"\\n([ ]{1,})return compiled_fn", source)`` against
-    ``torch._dynamo.compiled_autograd.AutogradCompilerInstance.end_capture``
-    and ``source.replace("return compiled_fn(inputs, sizes, scalars,
-    hooks)", "with disable():\\n    return compiled_fn(inputs, sizes,
-    scalars, hooks)")``. If the exact call signature changes the
-    str.replace silently no-ops AND the gradient-checkpointing
-    double-compile fix is dormant.
-    """
+    """``unsloth_zoo/patching_utils.py:544-547`` wraps
+    ``AutogradCompilerInstance.end_capture``'s ``return compiled_fn(...)``
+    in ``with disable():`` (PR #135795 double-compile fix). Signature
+    drift silently no-ops the rewriter."""
     pytest.importorskip("torch")
     try:
         import torch._dynamo.compiled_autograd as ca
@@ -967,38 +790,18 @@ def test_patching_utils_compiled_autograd_end_capture_return_compiled_fn_pinned(
         return
     needle = "return compiled_fn(inputs, sizes, scalars, hooks)"
     pattern = re.compile(r"\n([ ]{1,})return compiled_fn")
-    # Drift-detector contract: pass if EITHER the exact str AND the
-    # regex are present (the rewriter works), OR neither AND the
-    # `with disable():` line is already present (someone else patched
-    # / upstream merged). Otherwise: KNOWN ACTIVE DRIFT on torch >=
-    # 2.7 (the `end_capture` signature changed to (..., packed_inputs)
-    # and the return-call moved inside a nested with-block). The
-    # rewriter no-ops cleanly today; zoo's str.replace silently fails
-    # to find the old form. Surface as a forward-looking skip with a
-    # loud message so a maintainer can re-anchor when fixing PR
-    # #135795-equivalent upstream.
+    # Contract: pass if exact str+regex present (rewriter works), or
+    # `with disable()` / `with _disable()` already in src (torch 2.7+
+    # native fix). torch 2.7+ end_capture signature drifted (added
+    # packed_inputs, nested with-block); rewriter no-ops cleanly.
     if needle in src and pattern.search(src) is not None:
         return
     if "with disable()" in src or "with _disable()" in src:
-        # Upstream already wraps the compiled_fn call in a disable
-        # context (torch 2.7+ landed the fix natively, in either the
-        # bare or underscore-prefixed form). Zoo's recogniser now
-        # accepts both shapes and returns cleanly without rewriting.
         return
     if "compiled_fn(" in src:
-        # Status: BENIGN on torch 2.7+.
-        #
-        # The function name is still discoverable; the rewriter target
-        # exists in some form but the exact call signature drifted
-        # (added `packed_inputs`, moved the return inside a nested
-        # `with` block). Torch 2.7+ fixed the underlying double-compile
-        # bug upstream natively (with `with _disable()` wrapping). Zoo's
-        # str.replace silently no-ops on this build, which is the
-        # correct behaviour: there's nothing to patch when upstream has
-        # already fixed it. Zoo's patch_compiled_autograd now recognises
-        # both `with disable()` and `with _disable()` and bails early.
-        #
-        # Converted from FAIL to SKIP per maintainer review.
+        # BENIGN on torch 2.7+: upstream fixed PR #135795 natively with
+        # ``with _disable()``; zoo's patch_compiled_autograd recognises
+        # both forms and no-ops cleanly.
         pytest.skip(
             "BENIGN: torch 2.7+ fixed PR #135795-style double-compile "
             "upstream natively (now wraps compiled_fn in `with _disable()`); "
@@ -1018,10 +821,8 @@ def test_patching_utils_compiled_autograd_end_capture_return_compiled_fn_pinned(
 
 
 def test_patching_utils_compiled_autograd_end_capture_rename_target():
-    """``unsloth_zoo/patching_utils.py:548`` runs
-    ``source.replace("def end_capture", "def unsloth_end_capture", 1)``.
-    Asserts ``def end_capture`` exists in the source.
-    """
+    """``unsloth_zoo/patching_utils.py:548`` renames
+    ``def end_capture`` -> ``def unsloth_end_capture``."""
     pytest.importorskip("torch")
     try:
         import torch._dynamo.compiled_autograd as ca
@@ -1040,12 +841,9 @@ def test_patching_utils_compiled_autograd_end_capture_rename_target():
 
 
 def test_patching_utils_autograd_engine_call_method_compiled_autograd_enabled_pinned():
-    """``unsloth_zoo/patching_utils.py:564-573`` runs
-    ``source.replace("torch._dynamo.compiled_autograd.compiled_autograd_enabled",
-    "torch._dynamo.compiled_autograd.in_compiled_autograd_region", 1)``
-    on ``AutogradEngineVariable.call_method``. Asserts EITHER form
-    is present so the rewriter (or the upstream fix) is reachable.
-    """
+    """``unsloth_zoo/patching_utils.py:564-573`` replaces
+    ``compiled_autograd_enabled`` -> ``in_compiled_autograd_region`` in
+    ``AutogradEngineVariable.call_method``."""
     pytest.importorskip("torch")
     try:
         import torch._dynamo.variables.misc as misc
@@ -1066,10 +864,8 @@ def test_patching_utils_autograd_engine_call_method_compiled_autograd_enabled_pi
 
 
 def test_patching_utils_autograd_engine_call_method_rename_target():
-    """``unsloth_zoo/patching_utils.py:574`` runs
-    ``source.replace("def call_method", "def unsloth_call_method", 1)``.
-    Asserts ``def call_method`` exists.
-    """
+    """``unsloth_zoo/patching_utils.py:574`` renames ``def call_method``
+    -> ``def unsloth_call_method``."""
     pytest.importorskip("torch")
     try:
         import torch._dynamo.variables.misc as misc
@@ -1086,23 +882,11 @@ def test_patching_utils_autograd_engine_call_method_rename_target():
 
 
 def test_patching_utils_replace_with_bnb_linear_skip_modules_pinned():
-    """``unsloth_zoo/patching_utils.py:695-699`` runs
-    ``source.replace("name in quantization_config.llm_int8_skip_modules\\n",
-    ..., 1)`` against
-    ``transformers.integrations.bitsandbytes._replace_with_bnb_linear``.
-    Asserts the EXACT pinned token-with-newline is present in the
-    upstream source -- otherwise the dynamic-4bit conversion patch
-    no-ops.
-
-    Important: by the time this test runs in the suite,
-    ``unsloth_zoo/patching_utils.py`` has already rebound
-    ``bnb._replace_with_bnb_linear`` to ``_unsloth_replace_with_bnb_linear``
-    and rewritten the source string -- the needle below was deliberately
-    replaced. Reading ``inspect.getsource`` off the live function would
-    return the patched body and false-fail. We instead load the original
-    upstream source from the module file via ``inspect.getsourcefile``
-    so the drift detector still anchors to the genuine upstream API.
-    """
+    """``unsloth_zoo/patching_utils.py:695-699`` replaces
+    ``name in quantization_config.llm_int8_skip_modules\\n`` on
+    ``bnb._replace_with_bnb_linear`` (dynamic-4bit conversion).
+    Resolves UPSTREAM source via inspect.getsourcefile because zoo has
+    already rebound the function by test time."""
     pytest.importorskip("transformers")
     try:
         import transformers.integrations.bitsandbytes as bnb
@@ -1115,19 +899,15 @@ def test_patching_utils_replace_with_bnb_linear_skip_modules_pinned():
         )
         return
 
-    # Resolve the upstream source from the module file directly. Zoo's
-    # patch_utils.py monkey-patches `bnb._replace_with_bnb_linear` to a
-    # renamed `_unsloth_replace_with_bnb_linear` whose body is rewritten
-    # to bypass the needle below. Reading inspect.getsource off the live
-    # attribute would surface that patched source, never the upstream one.
+    # Resolve upstream source directly from the module file (zoo rebinds
+    # bnb._replace_with_bnb_linear so inspect.getsource off the live
+    # function returns the patched body, never upstream).
     live = bnb._replace_with_bnb_linear
     is_zoo_patched = (
         getattr(live, "__name__", "") == "_unsloth_replace_with_bnb_linear"
     )
     src = None
     if is_zoo_patched:
-        # Read original source from the module file -- truthful upstream
-        # signal regardless of how many import-fix runs ran first.
         from pathlib import Path
         try:
             mod_file = inspect.getsourcefile(bnb)
@@ -1158,11 +938,8 @@ def test_patching_utils_replace_with_bnb_linear_skip_modules_pinned():
 
 
 def test_patching_utils_replace_with_bnb_linear_rename_token():
-    """``unsloth_zoo/patching_utils.py:730-733`` runs
-    ``source.replace("_replace_with_bnb_linear", "_unsloth_replace_with_bnb_linear")``.
-    Asserts the upstream function name token still appears in the
-    source body (the rewriter renames every occurrence).
-    """
+    """``unsloth_zoo/patching_utils.py:730-733`` renames every occurrence
+    of ``_replace_with_bnb_linear`` -> ``_unsloth_replace_with_bnb_linear``."""
     pytest.importorskip("transformers")
     try:
         import transformers.integrations.bitsandbytes as bnb
@@ -1186,12 +963,8 @@ def test_patching_utils_replace_with_bnb_linear_rename_token():
 
 
 def test_patching_utils_replace_with_bnb_linear_current_key_name_pinned():
-    """``unsloth_zoo/patching_utils.py:738-748`` runs
-    ``re.sub(r"(^\\s*)(current_key_name\\.append\\(name\\))", ...,
-    source, flags=re.MULTILINE)`` to splice in the score-module skip.
-    Asserts the exact ``current_key_name.append(name)`` line is still
-    present in upstream.
-    """
+    """``unsloth_zoo/patching_utils.py:738-748`` splices score-module
+    skip via re.sub on ``current_key_name.append(name)``."""
     pytest.importorskip("transformers")
     try:
         import transformers.integrations.bitsandbytes as bnb
@@ -1216,15 +989,8 @@ def test_patching_utils_replace_with_bnb_linear_current_key_name_pinned():
 
 
 def test_patching_utils_current_key_name_str_marker():
-    """``unsloth_zoo/patching_utils.py:688`` asserts:
-
-        if "current_key_name_str" not in source:
-            raise RuntimeError(...)
-
-    So the rewriter HARD-fails when ``current_key_name_str`` is absent.
-    Pin the variable name as a drift detector so the failure isn't
-    surprising.
-    """
+    """``unsloth_zoo/patching_utils.py:688`` hard-fails with RuntimeError
+    when ``current_key_name_str`` is absent in upstream source."""
     pytest.importorskip("transformers")
     try:
         import transformers.integrations.bitsandbytes as bnb
@@ -1248,13 +1014,9 @@ def test_patching_utils_current_key_name_str_marker():
 
 
 def test_patching_utils_replace_with_bnb_linear_ast_wrap_target():
-    """``unsloth_zoo/patching_utils.py:701-704`` runs ``ast.parse`` +
-    ``WrapRecursiveCall().visit(...)`` + ``ast.unparse``. The AST
-    transformer wraps calls whose ``.func.id == "_replace_with_bnb_linear"``
-    in a try/finally that marks the parent. Pin the recursive call as
-    a regex against the upstream source so a function rename in
-    transformers surfaces immediately.
-    """
+    """``unsloth_zoo/patching_utils.py:701-704`` AST-wraps recursive
+    ``= _replace_with_bnb_linear(...)`` calls in try/finally with
+    parent-class marking."""
     pytest.importorskip("transformers")
     try:
         import transformers.integrations.bitsandbytes as bnb
@@ -1281,17 +1043,13 @@ def test_patching_utils_replace_with_bnb_linear_ast_wrap_target():
         )
 
 
-# ===========================================================================
-# unsloth_zoo/saving_utils.py rewriters
-# ===========================================================================
+# unsloth_zoo/saving_utils.py rewriters.
 
 
 def test_saving_utils_save_pretrained_state_dict_split_pinned_string():
-    """``unsloth_zoo/saving_utils.py:2675-2677`` runs
-    ``save_pretrained.find("state_dict_split = split_torch_state_dict_into_shards")``
-    and ``raise RuntimeError`` when it returns -1. Pin the exact
-    string against ``PreTrainedModel.save_pretrained`` source.
-    """
+    """``unsloth_zoo/saving_utils.py:2675-2677`` hard-fails (RuntimeError)
+    when ``state_dict_split = split_torch_state_dict_into_shards`` is
+    missing from PreTrainedModel.save_pretrained."""
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
     try:
@@ -1311,10 +1069,8 @@ def test_saving_utils_save_pretrained_state_dict_split_pinned_string():
 
 def test_saving_utils_save_pretrained_state_dict_contiguous_pinned_string():
     """``unsloth_zoo/saving_utils.py:2680-2686`` requires
-    ``"state_dict[tensor].contiguous()"`` to be in the upstream
-    source AND ``replace(..., "merge_lora_weights(...)", 1)`` it
-    once. RuntimeError otherwise.
-    """
+    ``state_dict[tensor].contiguous()`` in upstream + replace to
+    ``merge_lora_weights(...)``; RuntimeError otherwise."""
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
     try:
@@ -1333,11 +1089,8 @@ def test_saving_utils_save_pretrained_state_dict_contiguous_pinned_string():
 
 
 def test_saving_utils_save_pretrained_def_marker():
-    """``unsloth_zoo/saving_utils.py:2688-2694`` requires
-    ``"def save_pretrained" in save_pretrained`` for the rename
-    ``save_pretrained -> save_pretrained_dequantized``. RuntimeError
-    otherwise.
-    """
+    """``unsloth_zoo/saving_utils.py:2688-2694`` renames
+    ``save_pretrained`` -> ``save_pretrained_dequantized``."""
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
     try:
@@ -1353,10 +1106,9 @@ def test_saving_utils_save_pretrained_def_marker():
 
 
 def test_saving_utils_incremental_save_os_makedirs_pinned_regex():
-    """``unsloth_zoo/saving_utils.py:2517`` runs
-    ``re.search(r"os\\.makedirs\\(save_directory.+?\\n", save_pretrained)``
-    and asserts the match is not None. Pin the upstream pattern.
-    """
+    """``unsloth_zoo/saving_utils.py:2517`` re.search
+    ``os.makedirs(save_directory...)`` in save_pretrained; absent ->
+    incremental_save_pretrained aborts push-to-hub path."""
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
     try:
@@ -1376,9 +1128,8 @@ def test_saving_utils_incremental_save_os_makedirs_pinned_regex():
 
 def test_saving_utils_incremental_save_for_loop_filename_to_tensors_pinned():
     """``unsloth_zoo/saving_utils.py:2526-2533`` requires
-    ``"for shard_file, tensors in filename_to_tensors"`` in
-    save_pretrained source. RuntimeError otherwise.
-    """
+    ``for shard_file, tensors in filename_to_tensors`` in
+    save_pretrained; RuntimeError otherwise."""
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
     try:
@@ -1397,12 +1148,9 @@ def test_saving_utils_incremental_save_for_loop_filename_to_tensors_pinned():
 
 
 def test_saving_utils_config_json_dtype_torch_dtype_rename_targets():
-    """``unsloth_zoo/saving_utils.py:1827-1828`` runs
-    ``data.replace('"dtype"', '"torch_dtype"')`` on the saved
-    ``config.json`` (a string, not source). This is a save-time fix
-    -- assert the model's ``config.to_dict()`` exposes either ``dtype``
-    or ``torch_dtype`` so the rewriter has SOMETHING to normalize.
-    """
+    """``unsloth_zoo/saving_utils.py:1827-1828`` save-time replaces
+    ``"dtype"`` -> ``"torch_dtype"`` in config.json; needs model
+    config.to_dict() to expose either field."""
     pytest.importorskip("transformers")
     try:
         from transformers import LlamaConfig
@@ -1421,24 +1169,16 @@ def test_saving_utils_config_json_dtype_torch_dtype_rename_targets():
 
 
 def test_saving_utils_lora_key_normalize_replacements_targetable():
-    """``unsloth_zoo/saving_utils.py:309-314`` runs FIVE str.replace
-    on LoRA key names:
-
-        .base_layer, .modules_to_save.default, .original_module,
-        .lora_A.default, .lora_B.default
-
-    Asserts peft's LoRA layer naming still uses ``base_layer`` and
-    ``lora_A.default`` (the most common shapes). DRIFT if BOTH are
-    gone -- then the key-normalize pass strips nothing.
-    """
+    """``unsloth_zoo/saving_utils.py:309-314`` five str.replace on LoRA
+    keys (.base_layer, .modules_to_save.default, .original_module,
+    .lora_A.default, .lora_B.default). Pin peft's ``base_layer`` /
+    ``lora_A.default`` naming."""
     pytest.importorskip("peft")
     try:
         import peft.tuners.lora.layer as ly
     except ImportError:
         pytest.skip("peft.tuners.lora.layer missing")
     src = inspect.getsource(ly)
-    # The lora layer module emits keys like `.lora_A.default`; pin
-    # that token's presence (or alternative pin `base_layer`).
     if "base_layer" not in src and "lora_A.default" not in src and "lora_A" not in src:
         _drift(
             "unsloth_zoo/saving_utils.py:309-314",
@@ -1451,19 +1191,10 @@ def test_saving_utils_lora_key_normalize_replacements_targetable():
 
 
 def test_saving_utils_moe_experts_gate_up_proj_regex_targetable():
-    """``unsloth_zoo/saving_utils.py:600,653,700`` -- THREE re.match
-    regexes target MoE expert key naming:
-
-        ^(.*mlp\\.experts)\\.(\\d+)\\.(gate_proj|up_proj|down_proj)\\.weight$
-
-    The rewriter rebuilds fused gate_up_proj weights from per-expert
-    shards. Asserts upstream MoE models still expose
-    ``mlp.experts.<i>.<proj>.weight`` keys (the pre-fusion shard
-    format) -- via state_dict key probing on a Mixtral / Qwen MoE
-    config.
-    """
+    """``unsloth_zoo/saving_utils.py:600,653,700`` rebuilds fused
+    gate_up_proj from per-expert shards via three re.match on
+    ``mlp.experts.<i>.<proj>.weight``."""
     pytest.importorskip("transformers")
-    # Probe by inspecting modeling source for the canonical name.
     candidates = [
         "transformers.models.mixtral.modeling_mixtral",
         "transformers.models.qwen2_moe.modeling_qwen2_moe",
@@ -1492,11 +1223,8 @@ def test_saving_utils_moe_experts_gate_up_proj_regex_targetable():
 
 
 def test_saving_utils_hf_sharded_safetensors_regex_pattern():
-    """``unsloth_zoo/saving_utils.py:1838`` compiles
-    ``re.compile(r'^(.+?)-(\\d+)-of-(\\d+)\\.safetensors$')`` and
-    asserts ALL filenames match (returns False otherwise). Smoke-
-    test the regex itself against a canonical HF sharded filename.
-    """
+    """``unsloth_zoo/saving_utils.py:1838`` sharded-safetensors regex
+    must match canonical HF format ``<prefix>-<shard>-of-<total>.safetensors``."""
     pattern = re.compile(r"^(.+?)-(\d+)-of-(\d+)\.safetensors$")
     if pattern.match("model-00001-of-00005.safetensors") is None:
         _drift(
@@ -1509,13 +1237,9 @@ def test_saving_utils_hf_sharded_safetensors_regex_pattern():
 
 
 def test_saving_utils_lora_reverse_mapping_replacement_regex():
-    """``unsloth_zoo/saving_utils.py:2923`` runs
-    ``re.sub(r"\\^?([^(?]+).*", r"\\1", replacement.lstrip("^"))`` on
-    each forward_mapping ``replacement`` value. Asserts the regex
-    SHAPE accepts a typical mapping value like
-    ``"model.language_model."`` (no leading caret, no parens, no
-    ?).
-    """
+    """``unsloth_zoo/saving_utils.py:2923`` re.sub regex must preserve a
+    typical mapping value like ``"model.language_model."`` (no leading
+    caret, no parens, no ?)."""
     sample = "model.language_model."
     out = re.sub(r"\^?([^(?]+).*", r"\1", sample.lstrip("^"))
     if out != sample:
@@ -1529,25 +1253,14 @@ def test_saving_utils_lora_reverse_mapping_replacement_regex():
         )
 
 
-# ===========================================================================
-# unsloth_zoo/training_utils.py rewriters
-# ===========================================================================
+# unsloth_zoo/training_utils.py rewriters.
 
 
 def test_training_utils_name_replace_base_model_pattern():
-    """``unsloth_zoo/training_utils.py:172-175,187-190`` runs:
-
-        name = name.replace("base_model", "model", 1)
-        while re.search(r'\\.(\\d+)\\.', name) is not None:
-            name = re.sub(r'\\.(\\d+)\\.', r'[\\1].', name)
-        name = name.replace(".weight", "", 1)
-
-    on every PEFT module name to build an ``exec``-able accessor.
-    Asserts peft model.named_modules() typically yields names
-    containing ``base_model`` (the LoRA wrapper).
-    """
+    """``unsloth_zoo/training_utils.py:172-190`` builds exec-able
+    accessor from PEFT module names: replace base_model -> model,
+    .<i>. -> [<i>]., strip .weight."""
     pytest.importorskip("peft")
-    # Verify the regex idiom round-trips on a representative LoRA name.
     sample = "base_model.model.model.layers.0.self_attn.q_proj.weight"
     out = sample.replace("base_model", "model", 1)
     while re.search(r"\.(\d+)\.", out) is not None:
@@ -1563,17 +1276,13 @@ def test_training_utils_name_replace_base_model_pattern():
         )
 
 
-# ===========================================================================
-# unsloth_zoo/temporary_patches/misc.py rewriters
-# ===========================================================================
+# unsloth_zoo/temporary_patches/misc.py rewriters.
 
 
 def test_misc_merge_quantization_configs_classmethod_marker():
-    """``unsloth_zoo/temporary_patches/misc.py:141`` runs
-    ``source.startswith("@classmethod")`` to decide whether to strip
-    the ``cls`` parameter. Asserts the upstream method is still a
-    classmethod.
-    """
+    """``unsloth_zoo/temporary_patches/misc.py:141`` strips cls when
+    upstream ``AutoHfQuantizer.merge_quantization_configs`` is a
+    classmethod."""
     pytest.importorskip("transformers")
     try:
         from transformers.quantizers.auto import AutoHfQuantizer
@@ -1584,10 +1293,7 @@ def test_misc_merge_quantization_configs_classmethod_marker():
     except (OSError, TypeError):
         pytest.skip("source unavailable")
     if "@classmethod" not in src.lstrip().splitlines()[0] and "classmethod" not in src[:200]:
-        # Not classmethod anymore: zoo's branch still works (the strip
-        # is conditional), but the EXEC of the rewritten source may
-        # bind a different self type. Surface as drift if neither cls
-        # nor self appears in the def line.
+        # Drift only if neither cls nor self in def line (exec binding broken).
         first_def = next(
             (line for line in src.splitlines() if "def " in line),
             "",
@@ -1602,11 +1308,8 @@ def test_misc_merge_quantization_configs_classmethod_marker():
 
 
 def test_misc_merge_quantization_configs_dedent_def_marker():
-    """``unsloth_zoo/temporary_patches/misc.py:142`` runs
-    ``source = source[source.find("def"):]`` -- requires ``def`` to
-    appear in the (dedented) source. Asserts the source contains
-    ``def `` at all.
-    """
+    """``unsloth_zoo/temporary_patches/misc.py:142`` requires ``def `` in
+    the source (``source = source[source.find("def"):]``)."""
     pytest.importorskip("transformers")
     try:
         from transformers.quantizers.auto import AutoHfQuantizer
@@ -1625,13 +1328,9 @@ def test_misc_merge_quantization_configs_dedent_def_marker():
 
 
 def test_misc_mamba_ssm_tl_dot_finder_regex_targetable():
-    """``unsloth_zoo/temporary_patches/misc.py:1082-1085`` --
-    ``fix_mamba_ssm_float32`` runs
-    ``re.finditer(r" ([a-zA-Z0-9\\_]{1,}) (\\=|\\+\\=) tl\\.dot\\(...)", ...)``
-    against the mamba_ssm Triton chunk-scan file. ``mamba_ssm`` is
-    optional; if installed, the file MUST contain ``tl.dot(`` for
-    the rewriter to fire.
-    """
+    """``unsloth_zoo/temporary_patches/misc.py:1082-1085``
+    fix_mamba_ssm_float32 finds ``tl.dot(`` in mamba_ssm Triton
+    chunk-scan source."""
     try:
         import mamba_ssm.ops.triton.ssd_chunk_scan as ssd
     except ImportError:
@@ -1652,22 +1351,14 @@ def test_misc_mamba_ssm_tl_dot_finder_regex_targetable():
         )
 
 
-# ===========================================================================
-# unsloth_zoo/temporary_patches/gpt_oss.py rewriters
-# ===========================================================================
+# unsloth_zoo/temporary_patches/gpt_oss.py rewriters.
 
 
 def test_gpt_oss_config_old_class_dedent_compare_marker():
-    """``unsloth_zoo/temporary_patches/gpt_oss.py:2808-2810`` runs
-    ``dedent(inspect.getsource(GptOssConfig))`` and compares against
-    a dedented OLD class with ``.replace("Old_GptOssConfig",
-    "GptOssConfig")``. The comparison is line-by-line equality, so
-    even a 1-char change in upstream disables the patch.
-
-    Pin: ``GptOssConfig`` class must still expose
-    ``initial_context_length`` (one of the OLD shape's fields the
-    patch was introduced to add).
-    """
+    """``unsloth_zoo/temporary_patches/gpt_oss.py:2808-2810``
+    line-by-line equality compare of dedented GptOssConfig vs OLD
+    class; pin ``initial_context_length`` / ``rope_scaling`` field
+    presence (the Old_GptOssConfig regression target)."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.gpt_oss.configuration_gpt_oss import GptOssConfig
@@ -1677,9 +1368,6 @@ def test_gpt_oss_config_old_class_dedent_compare_marker():
         src = inspect.getsource(GptOssConfig)
     except (OSError, TypeError):
         pytest.skip("GptOssConfig source unavailable")
-    # `initial_context_length` was the field the Old_GptOssConfig
-    # patch added; if upstream renamed or removed it, the patch
-    # source-equality compare will MISS the upgrade window.
     if "initial_context_length" not in src and "rope_scaling" not in src:
         _drift(
             "unsloth_zoo/temporary_patches/gpt_oss.py:2808-2813",
@@ -1690,19 +1378,13 @@ def test_gpt_oss_config_old_class_dedent_compare_marker():
         )
 
 
-# ===========================================================================
-# unsloth_zoo/rl_replacements.py rewriters
-# ===========================================================================
+# unsloth_zoo/rl_replacements.py rewriters.
 
 
 def test_rl_replacements_grpo_compute_loss_def_marker():
-    """``unsloth_zoo/rl_replacements.py:560-565`` runs
-    ``RL_REPLACEMENTS["grpo_compute_loss_slow"].replace(
-        "def grpo_compute_loss", "def grpo_compute_loss_slow")``
-    on ``inspect.getsource(grpo_compute_loss)``. Asserts the source
-    of ``grpo_compute_loss`` still has the literal ``def
-    grpo_compute_loss`` token.
-    """
+    """``unsloth_zoo/rl_replacements.py:560-565`` renames
+    ``def grpo_compute_loss`` -> ``def grpo_compute_loss_slow``
+    (slow-fallback RL_REPLACEMENTS variant)."""
     try:
         from unsloth_zoo.rl_replacements import grpo_compute_loss
     except ImportError:
@@ -1728,24 +1410,13 @@ def test_rl_replacements_grpo_compute_loss_def_marker():
         )
 
 
-# ===========================================================================
-# unsloth/models/rl.py rewriters
-# ===========================================================================
+# unsloth/models/rl.py rewriters.
 
 
 def test_unsloth_rl_trainer_signature_columns_pinned_string():
-    """``unsloth/models/rl.py:1667-1670`` runs:
-
-        original_text = 'self._signature_columns = ["input_ids", "attention_mask", "completion_mask"]'
-        new_text = 'self._signature_columns = ["input_ids", "attention_mask", "completion_mask","labels"]'
-        RLTrainer_source = RLTrainer_source.replace(original_text, new_text)
-
-    on SFTTrainer source. Modern TRL (>= 0.25) reflowed the columns
-    list. DRIFT (fail) is when ``self._signature_columns = [``
-    appears nowhere in SFTTrainer source -- then the labels-column
-    augmentation has no possible anchor and the SFT labels regression
-    returns.
-    """
+    """``unsloth/models/rl.py:1667-1670`` augments SFTTrainer
+    ``self._signature_columns`` with ``"labels"``. DRIFT when
+    ``_signature_columns`` is gone from SFTTrainer source."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1767,16 +1438,9 @@ def test_unsloth_rl_trainer_signature_columns_pinned_string():
 
 
 def test_unsloth_rl_trainer_vlm_signature_columns_old_form_pinned():
-    """``unsloth/models/rl.py:1706-1713`` pins the EXACT VLM
-    signature columns form for TRL 0.22.x:
-
-        self._signature_columns = ["messages", "prompt", "completion", "images"]
-
-    DRIFT contract: pin the FOUR member tokens individually. If ALL
-    FOUR (``messages``, ``prompt``, ``completion``, ``images``) are
-    gone from SFTTrainer.__init__ source, the merge-vlm-cols
-    augmentation is unreachable.
-    """
+    """``unsloth/models/rl.py:1706-1713`` pins TRL 0.22.x VLM form
+    ``["messages", "prompt", "completion", "images"]``. DRIFT only when
+    ALL four member tokens are gone from SFTTrainer."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1798,14 +1462,9 @@ def test_unsloth_rl_trainer_vlm_signature_columns_old_form_pinned():
 
 
 def test_unsloth_rl_trainer_prepare_dataset_pattern():
-    """``unsloth/models/rl.py:1717-1721`` runs:
-
-        re.sub(r"([ \\t]*)train_dataset = self\\._prepare_dataset\\(", ...)
-
-    to inject ``self._unsloth_model_ref = model`` before the call.
-    Asserts SFTTrainer.__init__ source still has the
-    ``self._prepare_dataset(`` call site.
-    """
+    """``unsloth/models/rl.py:1717-1721`` injects
+    ``self._unsloth_model_ref = model`` before SFTTrainer's
+    ``self._prepare_dataset(`` call (token_type_ids detection)."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1816,7 +1475,6 @@ def test_unsloth_rl_trainer_prepare_dataset_pattern():
     except (OSError, TypeError):
         pytest.skip("SFTTrainer.__init__ source unavailable")
     if "self._prepare_dataset(" not in src:
-        # TRL may have renamed the helper; surface as drift.
         _drift(
             "unsloth/models/rl.py:1717-1721",
             "self._prepare_dataset(",
@@ -1828,18 +1486,9 @@ def test_unsloth_rl_trainer_prepare_dataset_pattern():
 
 
 def test_unsloth_rl_trainer_is_loaded_in_4bit_pinned_string():
-    """``unsloth/models/rl.py:1662-1665`` runs:
-
-        RLTrainer_source.replace(
-            'if getattr(model, "is_loaded_in_4bit", False) or '
-            'getattr(model, "is_loaded_in_8bit", False):',
-            "if False:",
-        )
-
-    on every TRL trainer's source to remove TRL's bf16 cast block.
-    Asserts SOME TRL trainer's source still has at least one of
-    the pinned getattr calls.
-    """
+    """``unsloth/models/rl.py:1662-1665`` replaces TRL's
+    ``if getattr(model, "is_loaded_in_4bit"/"is_loaded_in_8bit", ...)``
+    bf16 cast block with ``if False:``."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -1863,8 +1512,6 @@ def test_unsloth_rl_trainer_is_loaded_in_4bit_pinned_string():
             found = True
             break
     if not found:
-        # TRL >= 1.0 may have removed the explicit 4bit/8bit cast block;
-        # zoo's rewrite then no-ops cleanly. Surface forward-looking.
         pytest.skip(
             "No TRL trainer references is_loaded_in_4bit/8bit anymore; "
             "the cast-removal rewriter is dormant on this build. Pin "
@@ -1873,18 +1520,9 @@ def test_unsloth_rl_trainer_is_loaded_in_4bit_pinned_string():
 
 
 def test_unsloth_rl_trainer_peft_config_branches_pinned():
-    """``unsloth/models/rl.py:1842-1857`` runs SIX peft_config
-    str.replace targets:
-
-        elif peft_config is None: / elif peft_config is not None: /
-        if peft_config is None: / if peft_config is not None: /
-        get_peft_model(model, peft_config) /
-        prepare_peft_model / _prepare_peft_model
-
-    DRIFT contract: pin ``peft_config`` token. If it's gone from ALL
-    TRL trainer sources, the peft-disable rewriter has no target
-    and PEFT GRPO training silently re-enables the broken path.
-    """
+    """``unsloth/models/rl.py:1842-1857`` six peft_config str.replace
+    targets (peft_config branches, get_peft_model, prepare_peft_model);
+    DRIFT only when ``peft_config`` is gone from every TRL trainer."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -1918,13 +1556,8 @@ def test_unsloth_rl_trainer_peft_config_branches_pinned():
 
 
 def test_unsloth_rl_init_comments_with_brackets_pattern():
-    """``unsloth/models/rl.py:1832-1833`` runs
-    ``re.findall(r"\\#[^\\n]{1,}\\n", init)`` and filters comments
-    containing ``(`` or ``)``. These bracketed comments are then
-    transformed to ``[...]``. Pin: the upstream Trainer ``__init__``
-    must contain comments (lines starting with ``#``). If TRL strips
-    all comments, the rewriter is a no-op.
-    """
+    """``unsloth/models/rl.py:1832-1833`` normalises bracketed
+    ``#...(...)`` comments to ``[...]`` in SFTTrainer __init__."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1943,13 +1576,9 @@ def test_unsloth_rl_init_comments_with_brackets_pattern():
 
 
 def test_unsloth_rl_init_use_vllm_marker():
-    """``unsloth/models/rl.py:1895-1928`` branches on
-    ``"args.use_vllm" in init`` AND ``"model" in init`` AND
-    ``"args" in init``. If a TRL trainer's __init__ has none of
-    these markers, the vllm-engine wiring rewriter no-ops. Pass if
-    EITHER ``args.use_vllm`` or the alternate ``self.use_vllm`` form
-    appears in any TRL trainer's init source.
-    """
+    """``unsloth/models/rl.py:1895-1928`` vLLM-engine wiring needs
+    ``args.use_vllm`` / ``self.use_vllm`` marker in some TRL RL
+    trainer __init__."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -1979,12 +1608,8 @@ def test_unsloth_rl_init_use_vllm_marker():
 
 
 def test_unsloth_rl_vllm_part_findall_pattern_targetable():
-    """``unsloth/models/rl.py:1932-1936`` runs
-    ``re.findall(r"(\\n[\\s]{8}if (self|args)\\.use_vllm\\:.*?\\n[\\s]{8}else:\\n)",
-    init, flags=re.DOTALL | re.MULTILINE)``. Pin: at least one TRL
-    trainer __init__ has the if/else use_vllm branch at 8-space
-    indent.
-    """
+    """``unsloth/models/rl.py:1932-1936`` matches 8-space-indented
+    ``if (self|args).use_vllm:\\n...else:\\n`` branch in TRL trainer."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2018,11 +1643,9 @@ def test_unsloth_rl_vllm_part_findall_pattern_targetable():
 
 
 def test_unsloth_rl_sampling_params_findall_pattern_targetable():
-    """``unsloth/models/rl.py:1949-1953`` runs
-    ``re.findall(r"\\n[\\s]{4,}(self\\.[^\\s]{1,}[\\s]{0,}\\=[\\s]{0,}SamplingParams\\(.+?\\))",
-    new_vllm_part, flags=re.MULTILINE|re.DOTALL)``. Pin: a TRL
-    trainer references ``SamplingParams(`` somewhere in source.
-    """
+    """``unsloth/models/rl.py:1949-1953`` patches
+    ``self.X = SamplingParams(...)`` in TRL trainer; pin
+    ``SamplingParams(`` presence."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2051,18 +1674,13 @@ def test_unsloth_rl_sampling_params_findall_pattern_targetable():
 
 
 def test_unsloth_rl_state_dict_strip_pattern():
-    """``unsloth/models/rl.py:2072-2076`` runs
-    ``re.sub(r"\\.state_dict\\(\\)", r"", source)`` on every TRL
-    function source. Pin: the regex matches a canonical TRL load-
-    weights call site.
-    """
+    """``unsloth/models/rl.py:2072-2076`` strips ``.state_dict()`` from
+    TRL function source via re.sub."""
     pytest.importorskip("trl")
     sample = (
         "    llm_model.load_weights(model.state_dict().items())\n"
     )
     rewritten = re.sub(r"\.state_dict\(\)", r"", sample)
-    # After the strip, `.state_dict()` should be gone and the call
-    # should still parse syntactically as `model.items()`.
     if ".state_dict()" in rewritten or "model.items()" not in rewritten:
         _drift(
             "unsloth/models/rl.py:2072-2076",
@@ -2074,13 +1692,9 @@ def test_unsloth_rl_state_dict_strip_pattern():
 
 
 def test_unsloth_rl_llm_generate_chat_capture_pattern():
-    """``unsloth/models/rl.py:2087-2093`` runs
-    ``re.sub(r"(self\\.llm\\.(?:generate|chat)\\([^\\)]{1,})\\)",
-    r"\\1, lora_request = self.model.load_lora(...))", source)``.
-    Pin: the regex matches a synthetic ``self.llm.generate(prompts)``
-    call (sanity check on the regex itself; semantic anchor on TRL
-    is covered by the use_vllm marker test).
-    """
+    """``unsloth/models/rl.py:2087-2093`` injects ``lora_request =
+    self.model.load_lora(...)`` into ``self.llm.(generate|chat)(...)``
+    calls."""
     sample = "self.llm.generate(prompts, sampling_params=sp)"
     rewritten = re.sub(
         r"(self\.llm\.(?:generate|chat)\([^\)]{1,})\)",
@@ -2098,17 +1712,9 @@ def test_unsloth_rl_llm_generate_chat_capture_pattern():
 
 
 def test_unsloth_rl_sampling_params_kwargs_replace_pinned():
-    """``unsloth/models/rl.py:2107-2115`` runs:
-
-        source.replace(
-            "sampling_params = SamplingParams(**generation_kwargs)",
-            "sampling_params = SamplingParams(**grpo_update_SamplingParams(...))",
-        )
-
-    Pin: the pinned old shape is a SPECIFIC TRL formatting. Search
-    any TRL trainer source for the SUBSTRING; absence indicates a
-    TRL refactor where this rewriter is dormant.
-    """
+    """``unsloth/models/rl.py:2107-2115`` replaces
+    ``SamplingParams(**generation_kwargs)`` with
+    ``SamplingParams(**grpo_update_SamplingParams(...))``."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2139,14 +1745,8 @@ def test_unsloth_rl_sampling_params_kwargs_replace_pinned():
 
 
 def test_unsloth_rl_class_rename_pinned():
-    """``unsloth/models/rl.py:2137-2139`` runs:
-
-        RLTrainer_source.replace(
-            f"class {RLTrainer_name}", f"class _Unsloth{RLTrainer_name}", 1
-        )
-
-    Asserts SFTTrainer source still starts with ``class SFTTrainer``.
-    """
+    """``unsloth/models/rl.py:2137-2139`` renames ``class SFTTrainer``
+    -> ``class _UnslothSFTTrainer``."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -2167,11 +1767,8 @@ def test_unsloth_rl_class_rename_pinned():
 
 
 def test_unsloth_rl_torch_compile_options_dict_pattern():
-    """``unsloth/models/rl.py:1622-1625`` runs
-    ``re.sub(r"torch_compile_options\\s*=\\s*\\{[^}]*\\}",
-    new_options, RLTrainer_source, flags=re.DOTALL)``. Sanity-check
-    the regex against a representative dict assignment.
-    """
+    """``unsloth/models/rl.py:1622-1625`` re.sub on
+    ``torch_compile_options = {...}`` dict assignment."""
     sample = 'torch_compile_options = {"epilogue_fusion": True, "max_autotune": False}'
     out = re.sub(
         r"torch_compile_options\s*=\s*\{[^}]*\}",
@@ -2190,18 +1787,9 @@ def test_unsloth_rl_torch_compile_options_dict_pattern():
 
 
 def test_unsloth_rl_add_adapter_block_pattern_regex():
-    """``unsloth/models/rl.py:1865-1870`` builds the regex:
-
-        r"([ \\t]*)"
-        r"if\\s+is_peft_available\\(\\)\\s+and\\s+is_peft_model\\(model\\)\\s+and\\s+args\\.beta\\s*!=\\s*0\\.0\\s*:"
-        r"(.*?)"
-        r"ref_param\\.data\\.copy_\\(param\\.data\\)"
-
-    to comment out the "ref" adapter creation block in GRPOTrainer.
-    Pin: the SUBSTRINGS ``is_peft_available()`` AND
-    ``ref_param.data.copy_`` must appear together in some TRL trainer
-    source.
-    """
+    """``unsloth/models/rl.py:1865-1870`` comments out the "ref"
+    adapter creation block in GRPOTrainer; needs ``is_peft_available()``
+    AND ``ref_param.data.copy_`` together in TRL trainer source."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2231,15 +1819,9 @@ def test_unsloth_rl_add_adapter_block_pattern_regex():
 
 
 def test_unsloth_rl_warmup_ratio_keyword_pattern():
-    """``unsloth/models/rl.py:1323-1327,1330-1333`` runs:
-
-        x = f"{k}( = [^,\\n]{{1,}})?,\\n"
-        arguments = re.sub(x, y, arguments)
-
-    where ``k`` is e.g. ``"warmup_ratio"`` or ``"warmup_steps"``.
-    Sanity-check the regex against a synthetic config-arguments
-    block.
-    """
+    """``unsloth/models/rl.py:1323-1333`` re.sub on
+    ``<kwarg> = <value>,\\n`` config-arguments block (warmup_ratio,
+    warmup_steps, etc.)."""
     sample = (
         "warmup_ratio = 0.1,\n"
         "learning_rate = 5e-5,\n"
@@ -2260,12 +1842,9 @@ def test_unsloth_rl_warmup_ratio_keyword_pattern():
 
 
 def test_unsloth_rl_anihilate_typo_marker_search():
-    """``unsloth/models/rl.py:1725-1746`` searches for both spellings
-    ``anihilate`` (typo) AND ``annihilate`` (correct) in
-    SFTTrainer.__init__ source, then strips the surrounding
-    ``if args.per_device_train_batch_size == 1`` block. Pin: at
-    least one of the two spellings is present in SFTTrainer source.
-    """
+    """``unsloth/models/rl.py:1725-1746`` searches both ``anihilate``
+    (typo) and ``annihilate`` in SFTTrainer to strip the surrounding
+    ``args.per_device_train_batch_size == 1`` warning block."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -2285,10 +1864,8 @@ def test_unsloth_rl_anihilate_typo_marker_search():
 
 
 def test_unsloth_rl_per_device_train_batch_size_marker():
-    """``unsloth/models/rl.py:1730-1731`` looks backwards for
-    ``"if args.per_device_train_batch_size == 1"``. Pin: this exact
-    if condition appears in SOME TRL trainer source.
-    """
+    """``unsloth/models/rl.py:1730-1731`` searches
+    ``if args.per_device_train_batch_size == 1`` in TRL trainer."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2318,16 +1895,9 @@ def test_unsloth_rl_per_device_train_batch_size_marker():
 
 
 def test_unsloth_rl_processing_class_call_args_pattern():
-    """``unsloth/models/rl.py:980-985`` runs:
-
-        call_args.replace(
-            "processing_class = processing_class",
-            "processing_class = tokenizer if tokenizer is not None else processing_class",
-        )
-
-    on the (synthesized) call_args string. Sanity-check the
-    substitution is well-formed.
-    """
+    """``unsloth/models/rl.py:980-985`` injects tokenizer fallback:
+    ``processing_class = processing_class`` ->
+    ``= tokenizer if tokenizer is not None else processing_class``."""
     sample = "processing_class = processing_class,\nmodel = model"
     out = sample.replace(
         "processing_class = processing_class",
@@ -2344,17 +1914,9 @@ def test_unsloth_rl_processing_class_call_args_pattern():
 
 
 def test_unsloth_rl_shuffle_sequence_dict_pinned_pattern():
-    """``unsloth/models/rl.py:2051-2055`` runs:
-
-        re.sub(
-            r"(\\n[\\s]{4,})generation_batch = shuffle_sequence_dict\\(generation_batch\\)\\n",
-            r"\\n\\1try: ... except: pass\\n",
-            source,
-        )
-
-    Pin: ``shuffle_sequence_dict`` is referenced in some TRL trainer
-    source -- the rewriter targets a known crash mode in torch 2.8.
-    """
+    """``unsloth/models/rl.py:2051-2055`` wraps
+    ``generation_batch = shuffle_sequence_dict(...)`` in try/except
+    pass (torch 2.8 AcceleratorError workaround)."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2383,14 +1945,9 @@ def test_unsloth_rl_shuffle_sequence_dict_pinned_pattern():
 
 
 def test_unsloth_rl_model_executor_driver_worker_pinned_pattern():
-    """``unsloth/models/rl.py:2058-2062`` runs:
-
-        re.sub(r"(\\n[\\s]{4,}).+?model_executor\\.driver_worker.+?\\n", ...)
-
-    Pin: ``model_executor.driver_worker`` is referenced in TRL or
-    vLLM source -- the rewriter strips a vLLM internal-API call so
-    zoo's vllm-engine wiring can be used instead.
-    """
+    """``unsloth/models/rl.py:2058-2062`` strips
+    ``model_executor.driver_worker`` vLLM internal-API call so zoo's
+    vllm-engine wiring can replace it."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2420,12 +1977,8 @@ def test_unsloth_rl_model_executor_driver_worker_pinned_pattern():
 
 
 def test_unsloth_rl_load_weights_strip_pinned_pattern():
-    """``unsloth/models/rl.py:2065-2069`` runs:
-
-        re.sub(r"(\\n[\\s]{4,}).+?load_weights\\(.+?\\n", r"\\n\\1pass\\n", source)
-
-    Pin: ``load_weights(`` is referenced in some TRL trainer source.
-    """
+    """``unsloth/models/rl.py:2065-2069`` strips ``load_weights(...)``
+    lines from TRL trainer source via re.sub."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2454,22 +2007,9 @@ def test_unsloth_rl_load_weights_strip_pinned_pattern():
 
 
 def test_unsloth_rl_peft_pattern_27_marker():
-    """``unsloth/models/rl.py:1629-1633,1641-1646`` build TWO PEFT
-    init-block regexes:
-
-        trl >= 0.27.0:
-          if is_peft_available() and is_peft_model(model) and args.beta != 0.0:
-          ...
-          param.data = param.data.to(torch.bfloat16)
-
-        trl >= 0.26.0:
-          if is_peft_available() and isinstance(model, PeftModel) and peft_config is not None:
-          ...
-          param.data = param.data.to(torch.bfloat16)
-
-    Pin: at least ONE of the TWO pinned end-of-block lines is
-    present in GRPOTrainer source.
-    """
+    """``unsloth/models/rl.py:1629-1633,1641-1646`` TWO PEFT init-block
+    regexes (TRL 0.26.0 and 0.27.0 shapes) ending in
+    ``param.data = param.data.to(torch.bfloat16)``."""
     pytest.importorskip("trl")
     try:
         import trl.trainer.grpo_trainer as gt
@@ -2488,25 +2028,16 @@ def test_unsloth_rl_peft_pattern_27_marker():
         )
 
 
-# ===========================================================================
-# unsloth/trainer.py rewriters
-# ===========================================================================
+# unsloth/trainer.py rewriters.
 
 
 def test_unsloth_trainer_exec_marker():
-    """``unsloth/trainer.py:614`` runs ``exec(...)`` on a synthesized
-    trainer source. This is a passthrough rather than a substring
-    rewriter, but the trainer.py module MUST be importable for the
-    exec to fire. Pin: ``unsloth.trainer.UnslothTrainer`` (or the
-    equivalent) is importable.
-    """
-    # `unsloth` itself may not be installed in this venv; importorskip.
+    """``unsloth/trainer.py:614`` exec()'s synthesized trainer source;
+    pin that unsloth.trainer is importable."""
     pytest.importorskip("unsloth")
     try:
         import unsloth.trainer as trainer_mod
     except ImportError as e:
-        # If unsloth is installed but trainer.py raises on import, that
-        # IS a regression -- the exec sites are unreachable.
         _drift(
             "unsloth/trainer.py:614",
             "import unsloth.trainer",
@@ -2515,8 +2046,7 @@ def test_unsloth_trainer_exec_marker():
             "unreachable.",
         )
         return
-    # Sanity-check the module has SOMETHING the trainer rewriter would
-    # consume (any TRL- or Trainer-derived symbol).
+    # Module must expose some Trainer-family symbol downstream rewriter consumes.
     if not any(
         hasattr(trainer_mod, sym)
         for sym in ("UnslothTrainer", "Trainer", "_create_unsloth_optimizer", "unsloth_train")
@@ -2530,19 +2060,13 @@ def test_unsloth_trainer_exec_marker():
         )
 
 
-# ===========================================================================
-# Final smoke: confirm zoo's own source-string targets in the compiler
-# (i.e. the OUTPUT side, not the upstream input) are still well-formed.
-# ===========================================================================
+# Final smoke: zoo compiler's OUTPUT-side source-string targets.
 
 
 def test_zoo_compiler_replace_gradient_checkpointing_template_format():
-    """``unsloth_zoo/compiler.py:2226-2234`` defines
-    ``replace_gradient_checkpointing`` as a template with placeholders
-    ``LAYER``, ``MODULELIST_ITEM``, ``ARGS``, ``$``. The rewriter
-    substitutes these via .replace(). Pin: all four placeholders are
-    actually present in the template.
-    """
+    """``unsloth_zoo/compiler.py:2226-2234`` template
+    ``replace_gradient_checkpointing`` placeholders LAYER /
+    MODULELIST_ITEM / ARGS / $ must all be present."""
     import importlib
     compiler = importlib.import_module("unsloth_zoo.compiler")
     template = getattr(compiler, "replace_gradient_checkpointing", None)
@@ -2567,15 +2091,9 @@ def test_zoo_compiler_replace_gradient_checkpointing_template_format():
 
 
 def test_zoo_compiler_moe_routing_weights_replace_substitution_well_formed():
-    """``unsloth_zoo/compiler.py:2423-2426`` defines:
-
-        MOE_ROUTING_WEIGHTS_CAST_PATTERN = r"(\\brouting_weights\\s*=\\s*routing_weights\\.to\\(\\s*)hidden_states(\\.dtype\\s*\\))"
-        MOE_ROUTING_WEIGHTS_CAST_REPLACE = r"\\1router_logits\\2"
-
-    Sanity-check the substitution rewrites
-    ``routing_weights = routing_weights.to(hidden_states.dtype)``
-    to ``routing_weights = routing_weights.to(router_logits.dtype)``.
-    """
+    """``unsloth_zoo/compiler.py:2423-2426`` MOE_ROUTING_WEIGHTS_CAST
+    PATTERN/REPLACE rewrites ``routing_weights.to(hidden_states.dtype)``
+    -> ``...to(router_logits.dtype)``."""
     import importlib
     compiler = importlib.import_module("unsloth_zoo.compiler")
     pat = getattr(compiler, "MOE_ROUTING_WEIGHTS_CAST_PATTERN", None)
@@ -2600,11 +2118,8 @@ def test_zoo_compiler_moe_routing_weights_replace_substitution_well_formed():
 
 
 def test_zoo_compiler_dtype_mismatch_constants_targetable():
-    """``unsloth_zoo/compiler.py:2381-2391`` defines
-    ``DTYPE_MISMATCH_FIND`` and ``DTYPE_MISMATCH_REPLACE`` as
-    multi-line constants. Pin: both constants have the expected
-    sentinel substring.
-    """
+    """``unsloth_zoo/compiler.py:2381-2391`` DTYPE_MISMATCH_FIND /
+    REPLACE constants must contain their pinned sentinel substrings."""
     import importlib
     compiler = importlib.import_module("unsloth_zoo.compiler")
     find = getattr(compiler, "DTYPE_MISMATCH_FIND", None)

--- a/tests/test_extended_dep_api_pins.py
+++ b/tests/test_extended_dep_api_pins.py
@@ -14,33 +14,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Extended upstream-API pins for the dependencies zoo touches BEYOND
-the transformers / trl / peft / vllm surface covered by the existing
-``tests/test_upstream_pinned_symbols_*.py`` suite and the
-``tests/test_zoo_source_upstream_refs.py`` flat enumeration.
+"""Extended upstream-API pins for ``accelerate.*`` / ``safetensors.*``
+/ ``bitsandbytes.*`` / ``triton.*`` / ``datasets.*`` /
+``huggingface_hub.*`` / ``xformers.*`` references in
+``unsloth_zoo/**/*.py`` not already covered by
+``test_upstream_pinned_symbols_*.py`` or
+``test_zoo_source_upstream_refs.py``.
 
-This file enumerates every ``accelerate.*`` / ``safetensors.*`` /
-``bitsandbytes.*`` / ``triton.*`` / ``datasets.*`` / ``huggingface_hub.*``
-/ ``xformers.*`` dotted reference that survives in
-``unsloth_zoo/**/*.py`` once the existing suites' references are
-subtracted. Each reference is pinned against the INSTALLED version of
-the upstream library (matching the Core-matrix model).
-
-Contract per test:
-
-* CPU-only.
-* ``pytest.importorskip`` for libraries that are optional on this
-  install (xformers, mlx, etc.).
-* DRIFT == ``pytest.fail("DRIFT DETECTED: ...")``. Never ``pytest.skip``
-  when the symbol is referenced unconditionally in zoo and is missing
-  upstream -- that exactly defeats the matrix.
-
-The test file is grouped by library so a regression on (say) bnb 0.50
-lights up the bnb section without polluting the others.
-
-Each test cites the zoo callsite (file:line) it pins, so when a
-maintainer needs to remove the reference the matching test is one grep
-away.
+DRIFT-DETECTED framing: each test cites its zoo callsite. Failure ->
+``pytest.fail("DRIFT DETECTED: ...")``; never SKIP when zoo references
+the symbol unconditionally.
 """
 
 from __future__ import annotations
@@ -54,16 +37,14 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
-# Shared helpers (intentionally copies of the public surface in
-# test_zoo_source_upstream_refs.py so this file is grep-self-contained).
+# Shared helpers (intentional copies of test_zoo_source_upstream_refs.py
+# helpers so this file is grep-self-contained).
 # ---------------------------------------------------------------------------
 
 
 def _resolve(dotted: str) -> object:
     """``importlib.import_module`` + ``getattr`` chain. Any failure is
-    surfaced as an AssertionError tagged DRIFT DETECTED so the matrix
-    cell goes red rather than green-with-skips.
-    """
+    surfaced as AssertionError tagged DRIFT DETECTED."""
     parts = dotted.split(".")
     obj: object = None
     consumed: list[str] = []
@@ -113,35 +94,18 @@ def _resolve_all(dotted_paths: Iterable[str]) -> None:
 
 
 def _require_module(name: str):
-    """``pytest.importorskip``-style: the library is genuinely optional
-    on this install (xformers, mlx, triton, bitsandbytes on Apple-Silicon).
-    Once the top-level package is present, all subsequent symbol misses
-    are reported as DRIFT.
-    """
     return pytest.importorskip(name)
 
 
 # ===========================================================================
 # accelerate
 # ===========================================================================
-#
-# Existing coverage:
-#   test_zoo_source_upstream_refs.py::test_empty_model_accelerate_init_empty_weights
-#     pins accelerate.init_empty_weights existence.
-#   test_upstream_import_fixes_drift.py:: covers accelerate.utils.imports
-#     .is_wandb_available and accelerate.utils.is_wandb_available.
-#
-# This section adds: signature pin for init_empty_weights, plus the
-# attribute paths zoo's empty_model + saving paths rely on but the
-# existing tests don't shape-pin.
-# ---------------------------------------------------------------------------
 
 
 def test_accelerate_init_empty_weights_signature_shape():
-    """unsloth_zoo/empty_model.py:238, 322 -- `from accelerate import
-    init_empty_weights`. Both callsites use it as a CONTEXT MANAGER with
-    no args (the default include_buffers=None). A pre-3.0 accelerate
-    flipped this to a required first positional; pin the modern shape."""
+    """unsloth_zoo/empty_model.py:238, 322 -- ``with init_empty_weights():``
+    as zero-arg context manager (default include_buffers=None). Pre-3.0
+    flipped this to a required positional; pin the modern shape."""
     _require_module("accelerate")
     fn = _resolve("accelerate.init_empty_weights")
     sig = inspect.signature(fn)
@@ -163,11 +127,9 @@ def test_accelerate_init_empty_weights_signature_shape():
 
 
 def test_accelerate_init_empty_weights_is_context_manager():
-    """Same callsites: `with init_empty_weights():` -- the return value
-    must be a context manager (have __enter__/__exit__). A regression
-    that flips it to a plain function silently constructs a real-CPU
-    state dict instead of meta tensors and OOMs on Llama-70B-class
-    empty-model builds."""
+    """Return value must be a context manager. A regression that flips
+    it to a plain function silently constructs a real-CPU state dict
+    instead of meta tensors and OOMs on Llama-70B-class empty-model builds."""
     _require_module("accelerate")
     accelerate = importlib.import_module("accelerate")
     cm = accelerate.init_empty_weights()
@@ -177,14 +139,12 @@ def test_accelerate_init_empty_weights_is_context_manager():
             "returns a context manager; empty_model.py:238/322 "
             "`with init_empty_weights():` will TypeError at runtime."
         )
-    # Drain the manager so we don't leak state.
     cm.__enter__()
     cm.__exit__(None, None, None)
 
 
 def test_accelerate_utils_imports_module_surface():
-    """unsloth_zoo references accelerate at three layered paths; pin
-    the module-path surface so a restructuring of accelerate.utils
+    """Pin the module-path surface so accelerate.utils restructuring
     surfaces here, not at zoo import time."""
     _require_module("accelerate")
     _resolve_all([
@@ -196,41 +156,25 @@ def test_accelerate_utils_imports_module_surface():
 # ===========================================================================
 # safetensors
 # ===========================================================================
-#
-# Zoo callsites:
-#   saving_utils.py:65   import bitsandbytes as bnb        (covered below)
-#   saving_utils.py:153  from safetensors import safe_open
-#   saving_utils.py:154  from safetensors.torch import save_file
-#   saving_utils.py:506  import safetensors
-#   saving_utils.py:512  SAFETENSORS_DTYPES = safetensors.torch._TYPES
-#
-# Existing coverage: none of the existing test files pin safetensors
-# symbols; the *.py source-ref scan caught only the dataset / accelerate
-# top-levels. This section is the regression net.
-# ---------------------------------------------------------------------------
 
 
 def test_safetensors_safe_open_top_level_exists():
-    """unsloth_zoo/saving_utils.py:153 -- `from safetensors import
-    safe_open`. This is the streamed-read entry point used by every
-    LoRA save / merge / GGUF export path; a rename takes the whole
-    save surface down."""
+    """unsloth_zoo/saving_utils.py:153 -- ``from safetensors import
+    safe_open``. Streamed-read entry point for every LoRA save / merge
+    / GGUF export."""
     _resolve("safetensors.safe_open")
 
 
 def test_safetensors_safe_open_signature_shape():
-    """saving_utils.py uses safe_open(path, framework='pt', device=...).
-    Pin the 2-positional shape so a regression that drops the
-    ``framework`` arg (rare but observed in safetensors 0.4 dev
-    snapshots) crashes here, not in the LoRA merge runtime."""
+    """saving_utils.py uses ``safe_open(path, framework='pt',
+    device=...)``. Pin filename-first."""
     _require_module("safetensors")
     safe_open = _resolve("safetensors.safe_open")
-    # ``safe_open`` is a Rust-backed class in modern safetensors; either
-    # inspect.signature works OR the class has a __init__ we can probe.
+    # ``safe_open`` is a Rust-backed class; either inspect.signature
+    # works OR the class has an __init__ we can probe.
     try:
         sig = inspect.signature(safe_open)
     except (TypeError, ValueError):
-        # PyO3 builtins; fall back to constructor probe.
         if not hasattr(safe_open, "__init__"):
             pytest.fail(
                 "DRIFT DETECTED: safetensors.safe_open has no inspectable "
@@ -239,7 +183,6 @@ def test_safetensors_safe_open_signature_shape():
             )
         return
     params = list(sig.parameters)
-    # filename must be the first parameter, framework second.
     if not params or params[0] not in ("filename", "path"):
         pytest.fail(
             f"DRIFT DETECTED: safetensors.safe_open first parameter is "
@@ -248,15 +191,13 @@ def test_safetensors_safe_open_signature_shape():
 
 
 def test_safetensors_torch_save_file_top_level():
-    """saving_utils.py:154 -- `from safetensors.torch import save_file`.
-    This is the canonical write path for sharded LoRA / merged-model
-    safetensors output."""
+    """saving_utils.py:154 -- ``from safetensors.torch import save_file``.
+    Canonical write path for sharded LoRA / merged-model output."""
     _resolve("safetensors.torch.save_file")
 
 
 def test_safetensors_torch_save_file_signature():
-    """save_file is called with (tensors, filename, metadata=...) at
-    multiple zoo callsites. Pin those 3 parameters."""
+    """save_file is called with ``(tensors, filename, metadata=...)``."""
     _require_module("safetensors")
     save_file = _resolve("safetensors.torch.save_file")
     sig = inspect.signature(save_file)
@@ -271,10 +212,9 @@ def test_safetensors_torch_save_file_signature():
 
 
 def test_safetensors_torch_types_mapping_present():
-    """saving_utils.py:512 -- `SAFETENSORS_DTYPES = safetensors.torch._TYPES`.
-    The fallback branch logs and synthesises a default mapping, but
-    the silent fallback hides real dtype-coverage regressions in shard
-    writes (BF16 vs FP8 etc.). Pin the upstream-provided mapping."""
+    """saving_utils.py:512 -- ``SAFETENSORS_DTYPES = safetensors.torch._TYPES``.
+    Fallback silently mis-types BF16/FP8 weights in sharded save; pin
+    the upstream-provided mapping."""
     _require_module("safetensors")
     st_torch = importlib.import_module("safetensors.torch")
     if not hasattr(st_torch, "_TYPES"):
@@ -285,7 +225,6 @@ def test_safetensors_torch_types_mapping_present():
             "save."
         )
     types_map = st_torch._TYPES
-    # The map MUST cover the dtypes saving_utils.py reads (BF16, F16, F32).
     string_keys = {str(k).lower() for k in types_map.keys()}
     for needed in ("bf16", "f16", "f32"):
         if not any(needed in k for k in string_keys):
@@ -296,10 +235,8 @@ def test_safetensors_torch_types_mapping_present():
 
 
 def test_safetensors_torch_load_file_present():
-    """saving_utils.py's shard-merge codepaths call safetensors.torch
-    .load_file via the same import binding implied by `from safetensors
-    .torch import save_file`. A regression that ships only one direction
-    breaks the round-trip we rely on for delta-LoRA dequant verification."""
+    """saving_utils.py's shard-merge codepaths call ``safetensors.torch
+    .load_file``. Pin the round-trip needed for delta-LoRA dequant verify."""
     _require_module("safetensors")
     _resolve("safetensors.torch.load_file")
 
@@ -307,44 +244,12 @@ def test_safetensors_torch_load_file_present():
 # ===========================================================================
 # bitsandbytes
 # ===========================================================================
-#
-# Zoo callsites (deduplicated):
-#   device_type.py:257    from bitsandbytes.nn.modules import Params4bit
-#   device_type.py:260    import bitsandbytes; bitsandbytes.__version__
-#   patching_utils.py:309 from bitsandbytes.nn import Linear4bit as Bnb_Linear4bit
-#   saving_utils.py:65    import bitsandbytes as bnb; bnb.nn.Linear4bit
-#   temporary_patches/bitsandbytes.py:46
-#     bitsandbytes.nn.modules.Linear4bit
-#   temporary_patches/bitsandbytes.py:47
-#     bitsandbytes.nn.modules.Params4bit
-#   temporary_patches/bitsandbytes.py:48
-#     bitsandbytes.nn.modules.fix_4bit_weight_quant_state_from_module
-#   temporary_patches/bitsandbytes.py:106
-#     bitsandbytes.matmul_4bit
-#   temporary_patches/moe_bnb.py:43
-#     from bitsandbytes.nn import Params4bit
-#   temporary_patches/moe_bnb.py:44
-#     from bitsandbytes.functional import dequantize_4bit
-#   temporary_patches/moe_bnb.py:245
-#     bnb.matmul_4bit
-#   vllm_utils.py:190    from bitsandbytes import matmul_4bit
-#   vllm_utils.py:420    import bitsandbytes.functional
-#   vllm_utils.py:421    from bitsandbytes.utils import pack_dict_to_tensor, unpack_tensor_to_dict
-#   vllm_utils.py:481    import bitsandbytes.nn.modules
-#   vllm_utils.py:495    bitsandbytes.functional.QuantState.from_dict
-#   vllm_utils.py:1285   from bitsandbytes.nn.modules import Linear4bit, Params4bit
-#
-# Existing coverage: peft.tuners.lora.Linear4bit and the
-# transformers.integrations.bitsandbytes module are pinned in
-# test_zoo_source_upstream_refs.py. The bnb-internal surface is
-# untested. This section is the regression net.
-# ---------------------------------------------------------------------------
 
 
 def test_bnb_top_level_import_and_version_attr():
-    """device_type.py:260, saving_utils.py:65, plus every temporary_patches
-    callsite imports `bitsandbytes` and reads `.__version__`. A removal
-    of the dunder breaks the HIP / pre-0.46 cascades."""
+    """device_type.py:260, saving_utils.py:65, every temporary_patches
+    callsite reads ``bitsandbytes.__version__``. Drives HIP / pre-0.46
+    gate cascades."""
     bnb = _require_module("bitsandbytes")
     if not hasattr(bnb, "__version__"):
         pytest.fail(
@@ -355,10 +260,8 @@ def test_bnb_top_level_import_and_version_attr():
 
 
 def test_bnb_nn_linear4bit_top_level():
-    """patching_utils.py:309 -- `from bitsandbytes.nn import Linear4bit`.
-    saving_utils.py:88 isinstance-checks against it. The two import
-    paths (bitsandbytes.nn.Linear4bit and bitsandbytes.nn.modules.Linear4bit)
-    must BOTH resolve because zoo reaches both."""
+    """patching_utils.py:309 + saving_utils.py:88 isinstance-check.
+    Both import paths must resolve because zoo reaches both."""
     _require_module("bitsandbytes")
     _resolve_all([
         "bitsandbytes.nn.Linear4bit",
@@ -367,10 +270,9 @@ def test_bnb_nn_linear4bit_top_level():
 
 
 def test_bnb_linear4bit_constructor_kwargs_preserved():
-    """temporary_patches/bitsandbytes.py and vllm_utils.py:484 both pass
-    `compute_dtype=...` to Linear4bit.__init__. A regression that
-    renames or drops the kwarg silently disables UNSLOTH_bnb_4bit_compute_dtype
-    overrides."""
+    """temporary_patches/bitsandbytes.py + vllm_utils.py:484 pass
+    ``compute_dtype=...``. Regression silently disables
+    UNSLOTH_bnb_4bit_compute_dtype overrides."""
     _require_module("bitsandbytes")
     Linear4bit = _resolve("bitsandbytes.nn.Linear4bit")
     sig = inspect.signature(Linear4bit.__init__)
@@ -383,18 +285,18 @@ def test_bnb_linear4bit_constructor_kwargs_preserved():
 
 
 def test_bnb_nn_modules_params4bit_present():
-    """device_type.py:257 and temporary_patches/bitsandbytes.py:47 both
-    import `Params4bit` from `bitsandbytes.nn.modules`. The HIP-gate
-    blocksize source-inspection lives on the class' source."""
+    """device_type.py:257 + temporary_patches/bitsandbytes.py:47 import
+    Params4bit. HIP-gate blocksize source-inspection lives on the
+    class' source."""
     _require_module("bitsandbytes")
     _resolve("bitsandbytes.nn.modules.Params4bit")
 
 
 def test_bnb_fix_4bit_weight_quant_state_from_module_present():
-    """temporary_patches/bitsandbytes.py:48, 73 -- the helper repacks
-    a bnb-weight's quant_state attribute after transformers 5.x's
-    `weight.shape[-1] == 1` deferred-pack path. A rename takes the
-    whole Linear4bit forward replacement down."""
+    """temporary_patches/bitsandbytes.py:48, 73 -- repacks bnb-weight
+    quant_state after transformers 5.x's ``weight.shape[-1] == 1``
+    deferred-pack path. Rename takes the whole Linear4bit forward
+    replacement down."""
     _require_module("bitsandbytes")
     _resolve(
         "bitsandbytes.nn.modules.fix_4bit_weight_quant_state_from_module",
@@ -402,10 +304,9 @@ def test_bnb_fix_4bit_weight_quant_state_from_module_present():
 
 
 def test_bnb_matmul_4bit_top_level_and_signature():
-    """temporary_patches/bitsandbytes.py:106, temporary_patches/moe_bnb.py:245,
-    vllm_utils.py:190 -- bnb.matmul_4bit is the 4-bit GEMM kernel zoo
-    replaces Linear4bit.forward with. Pin its (A, B, quant_state, bias)
-    parameter shape."""
+    """temporary_patches/bitsandbytes.py:106, moe_bnb.py:245,
+    vllm_utils.py:190 -- ``bnb.matmul_4bit`` is the 4-bit GEMM kernel
+    zoo replaces Linear4bit.forward with. Pin ``(A, B, quant_state, bias)``."""
     _require_module("bitsandbytes")
     matmul_4bit = _resolve("bitsandbytes.matmul_4bit")
     sig = inspect.signature(matmul_4bit)
@@ -421,16 +322,15 @@ def test_bnb_matmul_4bit_top_level_and_signature():
 
 
 def test_bnb_functional_dequantize_4bit_present():
-    """temporary_patches/moe_bnb.py:44 -- the MoE BNB forward
-    pre-dequantizes expert weights via dequantize_4bit. A rename takes
-    out the entire MoE-on-bnb training surface."""
+    """temporary_patches/moe_bnb.py:44 -- pre-dequantizes expert weights
+    via dequantize_4bit. Rename takes out MoE-on-bnb training."""
     _require_module("bitsandbytes")
     _resolve("bitsandbytes.functional.dequantize_4bit")
 
 
 def test_bnb_functional_quantstate_present_and_from_dict():
-    """vllm_utils.py:495 -- monkeys QuantState.from_dict onto
-    bitsandbytes.functional.QuantState. The classmethod must exist
+    """vllm_utils.py:495 -- monkeys ``QuantState.from_dict`` onto
+    ``bitsandbytes.functional.QuantState``. The classmethod must exist
     pre-patch so the override is well-formed."""
     _require_module("bitsandbytes")
     QuantState = _resolve("bitsandbytes.functional.QuantState")
@@ -443,10 +343,9 @@ def test_bnb_functional_quantstate_present_and_from_dict():
 
 
 def test_bnb_utils_pack_unpack_tensor_dict_present():
-    """vllm_utils.py:421 -- `from bitsandbytes.utils import
-    pack_dict_to_tensor, unpack_tensor_to_dict`. Both names must
-    resolve; the vLLM 4-bit serialization path uses them as a matched
-    pair."""
+    """vllm_utils.py:421 -- ``pack_dict_to_tensor`` and
+    ``unpack_tensor_to_dict`` are the matched pair the vLLM 4-bit
+    serialization path uses."""
     _require_module("bitsandbytes")
     _resolve_all([
         "bitsandbytes.utils.pack_dict_to_tensor",
@@ -455,17 +354,16 @@ def test_bnb_utils_pack_unpack_tensor_dict_present():
 
 
 def test_bnb_functional_module_exists():
-    """vllm_utils.py:420 -- `import bitsandbytes.functional`. Module
-    path itself must be importable; some 0.50-dev wheels rearranged
-    bnb.functional into bnb._functional and re-exported under the
-    old name. The re-export is what zoo depends on."""
+    """vllm_utils.py:420 -- ``import bitsandbytes.functional``. 0.50-dev
+    wheels rearranged to ``bnb._functional`` and re-exported under the
+    old name; zoo depends on the re-export."""
     _require_module("bitsandbytes")
     _resolve("bitsandbytes.functional")
 
 
 def test_bnb_nn_modules_module_path_present():
-    """vllm_utils.py:481 -- `import bitsandbytes.nn.modules`. Module
-    path used for in-place class swap (Linear4bit -> custom subclass)."""
+    """vllm_utils.py:481 -- ``import bitsandbytes.nn.modules`` for
+    in-place class swap (Linear4bit -> custom subclass)."""
     _require_module("bitsandbytes")
     _resolve("bitsandbytes.nn.modules")
 
@@ -473,27 +371,11 @@ def test_bnb_nn_modules_module_path_present():
 # ===========================================================================
 # triton
 # ===========================================================================
-#
-# Zoo callsites:
-#   loss_utils.py:24      from triton import __version__ as triton_version
-#   compiler.py:50        import triton
-#   compiler.py:95        triton.__version__
-#   compiler.py:3030      from triton.runtime.autotuner import Autotuner
-#   temporary_patches/moe_utils.py:193 import triton
-#   temporary_patches/moe_utils.py:217 triton.set_allocator(...)
-#
-# Existing coverage:
-#   test_upstream_import_fixes_drift.py covers triton.compiler.compiler
-#   .CompiledKernel.num_ctas.
-# This section pins the version dunder, the autotuner module path, and
-# the set_allocator surface used by zoo PR #618.
-# ---------------------------------------------------------------------------
 
 
 def test_triton_top_level_version_attr():
-    """compiler.py:95 -- `Version(triton.__version__) < Version("3.0.0")`.
-    loss_utils.py:24 takes the same dunder under a rename. Missing dunder
-    -> zoo import-time AttributeError on every CUDA host."""
+    """compiler.py:95 -- ``Version(triton.__version__) < Version("3.0.0")``.
+    loss_utils.py:24 takes the same dunder."""
     triton_mod = _require_module("triton")
     if not hasattr(triton_mod, "__version__"):
         pytest.fail(
@@ -503,17 +385,16 @@ def test_triton_top_level_version_attr():
 
 
 def test_triton_runtime_autotuner_class_present():
-    """compiler.py:3030 -- `from triton.runtime.autotuner import
-    Autotuner`. The compile-rewriter introspects autotuner-decorated
-    kernels via this class; a removal breaks every Unsloth-compiled
-    kernel-replacement path on torch.compile."""
+    """compiler.py:3030 -- ``from triton.runtime.autotuner import
+    Autotuner``. Introspects autotuner-decorated kernels for the
+    compile-rewriter."""
     _require_module("triton")
     _resolve("triton.runtime.autotuner.Autotuner")
 
 
 def test_triton_set_allocator_top_level_present():
-    """temporary_patches/moe_utils.py:217 -- `triton.set_allocator(
-    persistent_alloc_fn)`. Required for the persistent-allocator MoE
+    """temporary_patches/moe_utils.py:217 -- ``triton.set_allocator(
+    persistent_alloc_fn)``. Required for persistent-allocator MoE
     expert-merge fast path."""
     triton_mod = _require_module("triton")
     if not hasattr(triton_mod, "set_allocator"):
@@ -525,9 +406,8 @@ def test_triton_set_allocator_top_level_present():
 
 
 def test_triton_set_allocator_signature_accepts_one_arg():
-    """The hook passes a single positional callable. A regression to
-    `set_allocator(name, fn)` form (proposed but not landed in triton
-    3.x main) breaks the moe_utils.py:217 callsite immediately."""
+    """A regression to ``set_allocator(name, fn)`` form (proposed in
+    triton 3.x main) breaks the single-arg callsite immediately."""
     triton_mod = _require_module("triton")
     set_alloc = triton_mod.set_allocator
     sig = inspect.signature(set_alloc)
@@ -548,17 +428,15 @@ def test_triton_set_allocator_signature_accepts_one_arg():
 
 
 def test_triton_language_namespace_present():
-    """compiler.py and the compiled-cache codegen reference triton.language
-    by attribute for constexpr / tl.constexpr; a removal of the
-    namespace breaks every Unsloth-compiled MoE kernel."""
+    """compiler.py + compiled-cache codegen reference ``triton.language``
+    for ``tl.constexpr``."""
     _require_module("triton")
     _resolve("triton.language")
 
 
 def test_triton_jit_decorator_present():
-    """triton.jit is the decorator zoo's MoE / CCE / RoPE kernels
-    depend on at codegen time; a rename to `triton.compile` (proposed
-    upstream) would break every kernel."""
+    """``triton.jit`` is the decorator zoo's MoE / CCE / RoPE kernels
+    depend on at codegen time."""
     triton_mod = _require_module("triton")
     if not callable(getattr(triton_mod, "jit", None)):
         pytest.fail(
@@ -570,37 +448,20 @@ def test_triton_jit_decorator_present():
 # ===========================================================================
 # datasets
 # ===========================================================================
-#
-# Zoo callsites:
-#   training_utils.py:19   import datasets
-#   training_utils.py:50   isinstance(train_dataset, datasets.IterableDataset)
-#   tokenizer_utils.py:21  import datasets
-#   tokenizer_utils.py:294 isinstance(train_dataset, datasets.IterableDataset)
-#   dataset_utils.py:594   from datasets import (Dataset, IterableDataset,)
-#   dataset_utils.py:873   from datasets.features._torchcodec import AudioDecoder
-#
-# Existing coverage: test_zoo_source_upstream_refs.py pins datasets.Dataset
-# and datasets.IterableDataset.
-# Adds: load_dataset / DatasetDict (used in zoo training paths via duck
-# typing) and the optional _torchcodec audio path (datasets >= 4.0).
-# ---------------------------------------------------------------------------
 
 
 def test_datasets_load_dataset_top_level():
-    """tokenizer_utils.py and training_utils.py instantiate datasets via
-    `datasets.load_dataset`. The function MUST be top-level on the
-    package; a private-rename silently changes the data-loading entry
-    point."""
+    """tokenizer_utils.py + training_utils.py instantiate datasets via
+    ``datasets.load_dataset``."""
     _require_module("datasets")
     _resolve("datasets.load_dataset")
 
 
 def test_datasets_iterable_dataset_classmethod_for_isinstance():
-    """tokenizer_utils.py:294 and training_utils.py:50 isinstance-check
-    against `datasets.IterableDataset`. A rename to `datasets.iterable
-    .IterableDataset` (proposed in datasets 4.x) breaks the streaming-
-    dataset routing silently (the isinstance returns False and the
-    streaming path is dropped)."""
+    """tokenizer_utils.py:294 + training_utils.py:50 isinstance-check
+    against ``datasets.IterableDataset``. A rename to
+    ``datasets.iterable.IterableDataset`` (proposed in 4.x) silently
+    drops the streaming path."""
     datasets = _require_module("datasets")
     ID = getattr(datasets, "IterableDataset", None)
     if ID is None:
@@ -618,43 +479,27 @@ def test_datasets_iterable_dataset_classmethod_for_isinstance():
 
 
 def test_datasets_dataset_dict_top_level():
-    """dataset_utils.py walks DatasetDict-shaped train/eval pairs in the
-    multi-split SFT path (via duck-typed `.column_names` access on
-    a returned object). DatasetDict must stay on the top-level
-    namespace."""
+    """dataset_utils.py walks DatasetDict-shaped train/eval pairs in
+    multi-split SFT via duck-typed ``.column_names``."""
     _require_module("datasets")
     _resolve("datasets.DatasetDict")
 
 
 def test_datasets_torchcodec_audio_decoder_present_or_absent_cleanly():
-    """dataset_utils.py:873 -- `from datasets.features._torchcodec
-    import AudioDecoder`. The whole block is wrapped in try/except so
-    its absence is tolerated, but if the module IS importable, the
-    AudioDecoder class MUST be on it (otherwise the patch silently
-    skips and audio dataset callers get a half-patched type).
+    """dataset_utils.py:873 -- ``from datasets.features._torchcodec
+    import AudioDecoder``. Wrapped in try/except so absence is tolerated;
+    if the module IS importable, AudioDecoder must be on it.
 
-    Note on `torchcodec` (separate package): datasets >=4.x's
-    `_torchcodec.py` does `from torchcodec.decoders import
-    AudioDecoder` at module top. That's a legitimate optional
-    transitive dep -- CI runners without audio support won't have
-    torchcodec, and zoo's call site survives via try/except. Treat
-    that environment as an importorskip, NOT a drift fail; a real
-    drift would be the symbol vanishing AFTER the module imports
-    cleanly."""
+    ``torchcodec`` (separate package) is a legitimate optional
+    transitive dep -- CI without audio support won't have it. Treat
+    that environment as importorskip, NOT drift."""
     _require_module("datasets")
     spec = importlib.util.find_spec("datasets.features._torchcodec")
     if spec is None:
-        # Module path absent on this datasets version. Zoo's
-        # try/except handles it. Healthy state.
         return
     try:
         mod = importlib.import_module("datasets.features._torchcodec")
     except ModuleNotFoundError as exc:
-        # Optional transitive dep (torchcodec itself, not zoo's call
-        # site) not installed on this CI box. zoo's `from
-        # datasets.features._torchcodec import AudioDecoder` is
-        # try/except wrapped at dataset_utils.py:873, so the absence
-        # is a tolerated runtime state, not drift.
         if "torchcodec" in str(exc):
             pytest.skip(
                 f"`datasets.features._torchcodec` requires the optional "
@@ -683,36 +528,12 @@ def test_datasets_torchcodec_audio_decoder_present_or_absent_cleanly():
 # ===========================================================================
 # huggingface_hub
 # ===========================================================================
-#
-# Zoo callsites (deduplicated):
-#   saving_utils.py:67     from huggingface_hub import get_token
-#   saving_utils.py:70     from huggingface_hub.utils import get_token
-#   saving_utils.py:73     from huggingface_hub.utils._token import get_token  (optional fallback)
-#   saving_utils.py:109    from huggingface_hub import ModelCard, HfApi
-#   saving_utils.py:148-152 from huggingface_hub import (snapshot_download,
-#                          hf_hub_download, HfFileSystem,)
-#   saving_utils.py:1602-1606 from huggingface_hub import (
-#                          split_state_dict_into_shards_factory,
-#                          get_torch_storage_size, get_torch_storage_id,)
-#   saving_utils.py:1652   from huggingface_hub.serialization._base import parse_size_to_int
-#   saving_utils.py:2365   from huggingface_hub.errors import LocalEntryNotFoundError
-#   saving_utils.py:3088   from huggingface_hub import hf_hub_download
-#   mlx_utils.py:3152      from huggingface_hub import HfApi
-#   mlx_utils.py:3195      from huggingface_hub import ModelCard
-#   mlx_utils.py:3248      from huggingface_hub import HfApi
-#
-# Existing coverage:
-#   test_upstream_import_fixes_drift.py::test_huggingface_hub_is_offline_mode_or_hf_hub_offline_present
-# covers is_offline_mode / HF_HUB_OFFLINE.
-# Everything else is unprotected. This section is the regression net.
-# ---------------------------------------------------------------------------
 
 
 def test_hf_hub_top_level_save_path_symbols():
-    """saving_utils.py:148-152 -- `from huggingface_hub import (
-    snapshot_download, hf_hub_download, HfFileSystem,)`. ALL THREE must
-    resolve on the top-level namespace; saving_utils does this import
-    at MODULE TOP LEVEL (no try/except)."""
+    """saving_utils.py:148-152 -- ``from huggingface_hub import (
+    snapshot_download, hf_hub_download, HfFileSystem,)`` at MODULE TOP
+    LEVEL (no try/except)."""
     _require_module("huggingface_hub")
     _resolve_all([
         "huggingface_hub.snapshot_download",
@@ -722,9 +543,8 @@ def test_hf_hub_top_level_save_path_symbols():
 
 
 def test_hf_hub_hfapi_and_modelcard_top_level():
-    """saving_utils.py:109 + mlx_utils.py:3152, 3195, 3248 --
-    HfApi and ModelCard are referenced unguardedly. Either rename
-    takes down the upload + model-card paths."""
+    """saving_utils.py:109 + mlx_utils.py:3152, 3195, 3248 -- HfApi and
+    ModelCard referenced unguardedly."""
     _require_module("huggingface_hub")
     _resolve_all([
         "huggingface_hub.HfApi",
@@ -733,9 +553,8 @@ def test_hf_hub_hfapi_and_modelcard_top_level():
 
 
 def test_hf_hub_hfapi_method_surface():
-    """saving_utils.py + mlx_utils.py call HfApi().create_repo /
-    .upload_file / .upload_folder / .create_commit / .file_exists.
-    Pin those method names on the class."""
+    """saving_utils.py + mlx_utils.py call ``HfApi().create_repo /
+    .upload_file / .upload_folder / .create_commit / .file_exists``."""
     _require_module("huggingface_hub")
     HfApi = _resolve("huggingface_hub.HfApi")
     expected = [
@@ -752,10 +571,9 @@ def test_hf_hub_hfapi_method_surface():
 
 
 def test_hf_hub_get_token_top_level_or_utils_fallback():
-    """saving_utils.py:67-73 try-cascade: get_token from top-level, then
-    huggingface_hub.utils, then huggingface_hub.utils._token. AT LEAST
-    ONE must resolve; the cascade exhausting means saving_utils gets
-    NameError on every upload path that needs a Bearer."""
+    """saving_utils.py:67-73 try-cascade: ``get_token`` from top-level,
+    then huggingface_hub.utils, then huggingface_hub.utils._token. At
+    least one must resolve."""
     _require_module("huggingface_hub")
     found = False
     for path in (
@@ -778,10 +596,8 @@ def test_hf_hub_get_token_top_level_or_utils_fallback():
 
 
 def test_hf_hub_split_state_dict_into_shards_factory_present_and_callable():
-    """saving_utils.py:1602-1606 -- imports three serialization helpers
-    at module top level. split_state_dict_into_shards_factory MUST be
-    callable; a removal kills sharded LoRA save (the core 5GB-shard
-    path uses it)."""
+    """saving_utils.py:1602 -- ``split_state_dict_into_shards_factory``
+    drives the core 5GB-shard path."""
     _require_module("huggingface_hub")
     fn = _resolve("huggingface_hub.split_state_dict_into_shards_factory")
     if not callable(fn):
@@ -793,8 +609,8 @@ def test_hf_hub_split_state_dict_into_shards_factory_present_and_callable():
 
 
 def test_hf_hub_get_torch_storage_size_and_id_present():
-    """saving_utils.py:1604-1605 -- get_torch_storage_size and
-    get_torch_storage_id underpin the LoRA delta dedup in sharded save."""
+    """saving_utils.py:1604-1605 -- underpin the LoRA delta dedup in
+    sharded save."""
     _require_module("huggingface_hub")
     _resolve_all([
         "huggingface_hub.get_torch_storage_size",
@@ -803,36 +619,32 @@ def test_hf_hub_get_torch_storage_size_and_id_present():
 
 
 def test_hf_hub_serialization_base_parse_size_to_int():
-    """saving_utils.py:1652 -- `from huggingface_hub.serialization._base
-    import parse_size_to_int`. Private module path; a refactor that
-    moves it out of _base breaks the shard-size CLI string parser."""
+    """saving_utils.py:1652 -- ``from huggingface_hub.serialization._base
+    import parse_size_to_int``. Private module path; refactor breaks
+    shard-size CLI string parser."""
     _require_module("huggingface_hub")
     _resolve("huggingface_hub.serialization._base.parse_size_to_int")
 
 
 def test_hf_hub_errors_local_entry_not_found_error():
-    """saving_utils.py:2365 -- `from huggingface_hub.errors import
-    LocalEntryNotFoundError`. Imported INSIDE an except clause to
-    re-classify a download failure; a removal silently lets the broader
-    Exception leak through."""
+    """saving_utils.py:2365 -- imported INSIDE an except clause to
+    re-classify a download failure."""
     _require_module("huggingface_hub")
     _resolve("huggingface_hub.errors.LocalEntryNotFoundError")
 
 
 def test_hf_hub_constants_module_path():
-    """fix_huggingface_hub from import_fixes.py re-injects
-    is_offline_mode from huggingface_hub.constants.HF_HUB_OFFLINE.
-    The CONSTANT-PATH-AS-MODULE side is exercised in
-    test_upstream_import_fixes_drift.py; pin the symbol HERE too so
-    a typo in either test catches the drift."""
+    """``huggingface_hub.constants.HF_HUB_OFFLINE`` is re-injected by
+    fix_huggingface_hub (import_fixes.py). Also covered in
+    test_upstream_import_fixes_drift.py; double-pin so a typo in either
+    test still catches drift."""
     _require_module("huggingface_hub")
     _resolve("huggingface_hub.constants.HF_HUB_OFFLINE")
 
 
 def test_hf_hub_modelcard_load_method():
-    """mlx_utils.py:3195 -- ModelCard.load(model_id) is the canonical
-    way zoo builds an MLX-derived model card by inheriting the source
-    card. A rename of the classmethod breaks the model-card lineage."""
+    """mlx_utils.py:3195 -- ``ModelCard.load(model_id)`` builds an
+    MLX-derived card by inheriting the source card."""
     _require_module("huggingface_hub")
     ModelCard = _resolve("huggingface_hub.ModelCard")
     if not hasattr(ModelCard, "load"):
@@ -844,10 +656,9 @@ def test_hf_hub_modelcard_load_method():
 
 
 def test_hf_hub_snapshot_download_signature_local_dir():
-    """saving_utils.py and mlx_utils.py call snapshot_download(repo_id,
-    local_dir=..., allow_patterns=...). Pin the local_dir kwarg
-    presence; a regression to local_dir_use_symlinks-only would break
-    every Unsloth offline workflow."""
+    """saving_utils.py + mlx_utils.py call ``snapshot_download(repo_id,
+    local_dir=...)``. Regression to local_dir_use_symlinks-only would
+    break every Unsloth offline workflow."""
     _require_module("huggingface_hub")
     fn = _resolve("huggingface_hub.snapshot_download")
     sig = inspect.signature(fn)
@@ -860,8 +671,8 @@ def test_hf_hub_snapshot_download_signature_local_dir():
 
 
 def test_hf_hub_hf_hub_download_signature_local_dir_and_repo_id():
-    """saving_utils.py:3088 calls hf_hub_download(repo_id=..., filename=...,
-    local_dir=...). Pin those three parameters."""
+    """saving_utils.py:3088 -- ``hf_hub_download(repo_id=..., filename=...,
+    local_dir=...)``."""
     _require_module("huggingface_hub")
     fn = _resolve("huggingface_hub.hf_hub_download")
     sig = inspect.signature(fn)
@@ -878,31 +689,17 @@ def test_hf_hub_hf_hub_download_signature_local_dir_and_repo_id():
 # ===========================================================================
 # xformers
 # ===========================================================================
-#
-# Zoo source has NO direct xformers imports; the only references are
-# in temporary_patches that re-export upstream xformers symbols if they
-# happen to be on the install. The existing
-# test_upstream_import_fixes_drift.py covers the >=0.0.29 num_splits_key
-# fix.
-#
-# Add a single skip-clean smoke that the xformers.ops module path
-# resolves IF xformers is installed, since transformers.modeling_utils
-# (which zoo unconditionally imports) probes xformers.ops at attention-
-# kernel-selection time. A regression in xformers' module layout
-# silently disables the memory-efficient attention dispatch zoo's
-# patches rely on.
-# ---------------------------------------------------------------------------
+# Zoo has no direct xformers imports; only re-exports if installed.
+# transformers.modeling_utils probes xformers.ops at attention-kernel
+# selection time -- a regression in xformers' module layout silently
+# disables the memory-efficient attention dispatch zoo's patches rely on.
 
 
 def test_xformers_ops_module_present_when_installed():
-    """xformers is optional. When installed, xformers.ops.memory_efficient_attention
-    is the symbol transformers.modeling_utils probes at attention-kernel
-    selection time. zoo's compiled-cache MoE / Gemma paths inherit the
-    kernel selection -- a regression in the dispatch path silently
-    falls back to the slow eager attention."""
+    """xformers.ops.memory_efficient_attention is the symbol
+    transformers.modeling_utils probes at attention-kernel selection."""
     if importlib.util.find_spec("xformers") is None:
         pytest.skip("xformers not installed -- nothing to drift-check.")
-    # Now that xformers is present, the .ops submodule MUST resolve.
     try:
         ops = importlib.import_module("xformers.ops")
     except Exception as exc:
@@ -921,14 +718,12 @@ def test_xformers_ops_module_present_when_installed():
 
 def test_xformers_components_module_present_when_installed():
     """xformers.components is the attention-block factory namespace
-    some transformers vision encoders probe at compile time. Skip
-    cleanly when xformers absent, drift-fail when present-but-broken."""
+    some transformers vision encoders probe at compile time."""
     if importlib.util.find_spec("xformers") is None:
         pytest.skip("xformers not installed -- nothing to drift-check.")
     spec = importlib.util.find_spec("xformers.components")
     if spec is None:
         # Some xformers builds (CPU-only) ship without .components.
-        # That's the upstream-supported optional state; pass cleanly.
         return
     try:
         importlib.import_module("xformers.components")

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -7,51 +7,20 @@
 # your option) any later version.
 
 """Exhaustive upstream-signature pinning for the (class, method) pairs
-that ``unsloth_zoo/temporary_patches/<file>.py`` rebinds.
+that ``unsloth_zoo/temporary_patches/<file>.py`` rebinds (tail not
+covered by the sibling test_upstream_signatures /
+test_upstream_pinned_symbols_transformers / test_zoo_source_upstream_refs
+/ test_upstream_source_patterns files).
 
-Why this file exists
-====================
-``tests/test_upstream_signatures.py``, ``test_upstream_pinned_symbols_transformers.py``,
-``test_zoo_source_upstream_refs.py``, and ``test_upstream_source_patterns.py`` pin
-roughly 50-70 (class, method) pairs that the ``temporary_patches/`` directory
-monkey-patches. A walk of every file in ``unsloth_zoo/temporary_patches/``
-turned up additional patch sites that no existing test covers. This file
-fills the tail.
+Each (model_class, method) pair below maps 1:1 to a
+``patch_function(...)`` call or attribute reassignment in zoo. Upstream
+rename / drop -> zoo's patch silently no-ops via ``raise_error()``; this
+file makes that drift loud.
 
-Patch-site discovery
-====================
-For every ``temporary_patches/<file>.py``, all of:
-
-    patch_function(target_cls, "name", ...)
-    patch_function_past_key_values(target_cls, "name", ...)
-    target_cls.method = patched_method
-    setattr(modeling_X, "Y", patched_Y)
-
-were extracted. Each (model_class, method) pair below maps 1:1 to a
-``patch_function(...)`` call (or attribute reassignment) in zoo. If
-upstream renames or drops the symbol, zoo's patch silently no-ops via
-``raise_error()`` and the user trains with a stock (unpatched) forward
-that the zoo patch was meant to fix -- exactly the silent-drift class of
-bug these tests catch.
-
-Contract
-========
-* CPU-only -- no GPU, no downloads, no network.
-* Genuinely optional upstream libs (``timm``, ``bitsandbytes``) use
-  ``pytest.importorskip``. ``transformers`` is required at module-level
-  importorskip, matching the rest of the test suite.
-* Version-gated patches (zoo guards a class behind ``if hasattr(...)`` or
-  a try/except ImportError because the class only exists on transformers
-  5.0+) are similarly gated here via ``pytest.skip`` so the test
-  legitimately reports "not on this transformers" instead of false-failing.
-* Drift detection: missing class or signature parameter dropped ->
-  ``pytest.fail("DRIFT DETECTED: zoo temporary_patches/<file>.py expects
-  <class>.<method>(<params>) but installed transformers has
-  <signature>")``.
-* Pairs already pinned in the sibling test files are intentionally
-  skipped here to keep this file focused on the uncovered tail.
-
-Runs under the GPU-free harness in ``tests/conftest.py``.
+CPU-only; ``pytest.importorskip`` for optional libs (timm, bitsandbytes).
+Drift -> ``pytest.fail("DRIFT DETECTED: zoo temporary_patches/<file>.py
+expects <class>.<method>(<params>) but installed transformers has
+<signature>")``.
 """
 
 from __future__ import annotations
@@ -65,25 +34,15 @@ from typing import Iterable
 import pytest
 
 
-# ---------------------------------------------------------------------------
-# Module-level pre-flight: every patch tested here calls into transformers.
-# A single importorskip at module load keeps the failure message useful.
-# ---------------------------------------------------------------------------
-
 pytest.importorskip("transformers")
 import transformers  # noqa: E402
 
 _TX_VERSION = getattr(transformers, "__version__", "0.0.0")
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 def _try_get_class(dotted_module: str, class_name: str):
-    """Import ``dotted_module`` and return ``class_name`` off it, or
-    return ``None`` if either is missing on this transformers. Used to
-    skip 5.0+-gated tests cleanly on a 4.x install."""
+    """Import ``dotted_module`` and return ``class_name`` off it (or None).
+    Used to skip 5.0+-gated tests on a 4.x install."""
     try:
         mod = importlib.import_module(dotted_module)
     except Exception:
@@ -92,10 +51,9 @@ def _try_get_class(dotted_module: str, class_name: str):
 
 
 def _require_class(dotted_module: str, class_name: str, zoo_file: str):
-    """Like ``_try_get_class`` but ``pytest.fail`` with a DRIFT message
-    if the class is missing AND the parent module exists. If the parent
-    module is itself missing (e.g. transformers doesn't ship gemma4 in
-    this version), skip -- that's a legitimate version gate, not drift."""
+    """Like ``_try_get_class`` but DRIFT-fail when the parent module
+    exists but the class is missing. Skip when parent module is missing
+    (legitimate version gate)."""
     try:
         mod = importlib.import_module(dotted_module)
     except Exception as exc:
@@ -122,71 +80,41 @@ def _param_names(func) -> list[str]:
 
 
 def _original_attr_name(cls, attr: str) -> str:
-    """Reconstruct the storage key used by
-    ``unsloth_zoo.temporary_patches.utils.patch_function`` to stash the
-    original method body before it overwrites the class attribute.
-
-    Mirrors ``_get_unique_storage_name`` in that file:
-    ``_original_<last-component-of-module>_<class-name>_<attr>``. We
-    re-derive the name here rather than import it so this test stays
-    importable even on a zoo build where the temporary_patches sub-package
-    can't be imported (e.g. minimal CPU CI).
-    """
+    """Storage key used by patch_function to stash the original method
+    body: ``_original_<last-module-component>_<class>_<attr>``. Mirrors
+    _get_unique_storage_name in temporary_patches/utils.py."""
     module_tail = getattr(cls, "__module__", "").rsplit(".", 1)[-1]
     class_name = getattr(cls, "__name__", "") or cls.__class__.__name__
     return f"_original_{module_tail}_{class_name}_{attr}"
 
 
 def _resolve_upstream_method(cls, method_name: str):
-    """Return the function object representing the UPSTREAM (unpatched)
-    method body for ``cls.method_name``.
+    """Return UPSTREAM (unpatched) method body for cls.method_name.
 
-    ``apply_import_fixes()`` and the ``temporary_patches`` runner both
-    monkey-patch classes at import time, so a naive ``cls.method_name``
-    lookup later in the test session returns the zoo-patched function
-    instead of the upstream one. That makes signature drift tests false-
-    positive on the patched ``(self, *args, **kwargs)`` wrapper rather
-    than the real upstream API.
-
-    Resolution order:
-      1. If ``cls`` has ``_original_<module>_<class>_<method>`` set by
-         ``patch_function``, return that. This is the authoritative source.
-      2. If the live attribute's ``__qualname__`` indicates a zoo patch
-         wrapper (``patch_<X>.<locals>.<method>``) but no original is
-         stashed, fall through to (3) to load the source from the module
-         file directly.
-      3. Otherwise return the live attribute -- upstream isn't patched
-         on this stack.
+    apply_import_fixes() and temporary_patches runner monkey-patch at
+    import time, so naive ``cls.method_name`` returns zoo's
+    ``(self, *args, **kwargs)`` wrapper. Resolution order:
+      1. ``_original_<module>_<class>_<method>`` stash from patch_function.
+      2. Live attribute (caller checks _maybe_skip_if_patched if needed).
     """
     if not hasattr(cls, method_name):
         return None
     live = getattr(cls, method_name)
-    # (1) explicit storage key from patch_function.
     storage_key = _original_attr_name(cls, method_name)
     original = getattr(cls, storage_key, None)
     if original is not None:
         return original
-    # (2) wrapper-by-qualname fallback.
     qualname = getattr(live, "__qualname__", "") or ""
     if ".<locals>." in qualname and qualname.split(".", 1)[0].startswith("patch_"):
-        # zoo patch wrapper, but no _original_ stash on the class. This
-        # is rare (force=True + store_original=False) but possible. Fall
-        # through; caller will skip cleanly via _maybe_skip_if_patched.
+        # zoo patch wrapper with no _original_ stash (rare: force=True +
+        # store_original=False); _maybe_skip_if_patched handles cleanly.
         return live
     return live
 
 
 def _maybe_skip_if_patched(cls, method_name: str, zoo_file: str) -> None:
-    """If the live ``cls.method_name`` is a zoo patch wrapper AND we
-    have no stored original to inspect, skip the test with a clear
-    "already-patched" reason rather than false-fail on the wrapper's
-    ``(self, *args, **kwargs)`` signature.
-
-    Used by signature-pin tests against classes that zoo replaces
-    wholesale via ``patch_function``. The skip is loud: the message
-    surfaces which zoo file did the patching so a future maintainer
-    can re-anchor the test if upstream's shape genuinely changes.
-    """
+    """Skip when live method is a zoo patch wrapper with no original
+    stash (avoid false-failing on ``(self, *args, **kwargs)``)."""
     if not hasattr(cls, method_name):
         return
     live = getattr(cls, method_name)
@@ -214,7 +142,6 @@ def _assert_method_exists(cls, method_name: str, zoo_file: str):
             f"{cls.__module__}.{cls.__name__}.{method_name} but installed "
             f"transformers {_TX_VERSION} has no such method on the class"
         )
-    # Prefer the upstream-original stash if zoo has patched the method.
     return _resolve_upstream_method(cls, method_name)
 
 
@@ -248,21 +175,13 @@ def _has_var_keyword(func) -> bool:
     )
 
 
-# ===========================================================================
-# bitsandbytes.py
-# ---------------------------------------------------------------------------
-# Patches: bitsandbytes.nn.modules.Linear4bit.forward (covered by
-# test_upstream_signatures::test_bnb_Linear4bit_forward_signature), AND a
-# second optional patch at bitsandbytes.nn.Linear4bit.forward (the
-# top-level re-export). The second one is wrapped in try/except in zoo,
-# but if the alias goes away without zoo noticing, the import-time guard
-# `bitsandbytes.nn.modules.Linear4bit` would mask the alias drift.
-# ===========================================================================
+# bitsandbytes.py: patches bitsandbytes.nn.modules.Linear4bit.forward
+# (covered elsewhere) + bitsandbytes.nn.Linear4bit.forward top-level
+# re-export alias.
 
 def test_bitsandbytes_top_level_Linear4bit_alias():
-    """bitsandbytes.py:110 wraps a patch on the top-level
-    ``bitsandbytes.nn.Linear4bit`` alias. Pin its presence and that it
-    has a forward method matching the modules.Linear4bit forward."""
+    """bitsandbytes.py:110 patches top-level ``bitsandbytes.nn.Linear4bit``
+    alias; pin presence + .forward method."""
     bnb = pytest.importorskip("bitsandbytes")
     top_level = getattr(bnb.nn, "Linear4bit", None)
     inner = getattr(bnb.nn.modules, "Linear4bit", None)
@@ -280,10 +199,8 @@ def test_bitsandbytes_top_level_Linear4bit_alias():
 
 
 def test_bitsandbytes_Params4bit_class_present():
-    """bitsandbytes.py:47 reads ``bitsandbytes.nn.modules.Params4bit`` and
-    line 65-67 conditionally deletes its ``__torch_function__``. If the
-    class disappears entirely, the patch ``raise_error()``-s silently and
-    the torch.compile infinite-recursion fix never applies."""
+    """bitsandbytes.py:47-67 reads ``Params4bit`` and conditionally
+    deletes ``__torch_function__`` (torch.compile recursion fix)."""
     bnb = pytest.importorskip("bitsandbytes")
     p4 = getattr(bnb.nn.modules, "Params4bit", None)
     if p4 is None:
@@ -294,10 +211,8 @@ def test_bitsandbytes_Params4bit_class_present():
 
 
 def test_bitsandbytes_fix_4bit_weight_quant_state_from_module_present():
-    """bitsandbytes.py:48 looks up
-    ``bitsandbytes.nn.modules.fix_4bit_weight_quant_state_from_module``
-    and passes ``self`` to it inside the patched forward. If this
-    function disappears, the patched forward NameErrors at runtime."""
+    """bitsandbytes.py:48 / :73 calls
+    ``fix_4bit_weight_quant_state_from_module(self)``."""
     bnb = pytest.importorskip("bitsandbytes")
     fn = getattr(bnb.nn.modules, "fix_4bit_weight_quant_state_from_module", None)
     if fn is None:
@@ -306,7 +221,7 @@ def test_bitsandbytes_fix_4bit_weight_quant_state_from_module_present():
             "bitsandbytes.nn.modules.fix_4bit_weight_quant_state_from_module "
             "but it is missing"
         )
-    # Patched forward calls fn(self) -- 1 positional. Reject zero-arity.
+    # Patched forward calls fn(self); reject zero-arity.
     sig = inspect.signature(fn)
     params = [
         p for p in sig.parameters.values()
@@ -323,9 +238,7 @@ def test_bitsandbytes_fix_4bit_weight_quant_state_from_module_present():
 
 
 def test_bitsandbytes_matmul_4bit_present():
-    """bitsandbytes.py:106 calls ``bitsandbytes.matmul_4bit(...)``. Pin
-    that the top-level function exists. If it moves, the patched forward
-    AttributeErrors at runtime."""
+    """bitsandbytes.py:106 calls top-level ``bitsandbytes.matmul_4bit(...)``."""
     bnb = pytest.importorskip("bitsandbytes")
     if not hasattr(bnb, "matmul_4bit"):
         pytest.fail(
@@ -334,20 +247,11 @@ def test_bitsandbytes_matmul_4bit_present():
         )
 
 
-# ===========================================================================
-# deepseek_v3_moe.py
-# ---------------------------------------------------------------------------
-# Patches: DeepseekV3NaiveMoe.forward (5.x), DeepseekV3MoE.forward
-# (covered), DeepseekV3ForCausalLM.forward (covered). The NaiveMoe class
-# is also used as a key for `_unsloth_already_patched` / `_unsloth_model_type`
-# attribute attachment.
-# ===========================================================================
+# deepseek_v3_moe.py: patches DeepseekV3{NaiveMoe,MoE,ForCausalLM}.forward.
 
 def test_deepseek_v3_naive_moe_class_gated_5x():
-    """deepseek_v3_moe.py:56-61 imports DeepseekV3NaiveMoe at the top of
-    patch_deepseek_v3 and bails via try/except when it's missing. This
-    class is transformers 5.x-only (added when the MoE forward was
-    factored out of DeepseekV3MoE). Skip on older transformers."""
+    """deepseek_v3_moe.py:56-61 imports DeepseekV3NaiveMoe (5.x-only;
+    bails via try/except on 4.x)."""
     cls = _try_get_class(
         "transformers.models.deepseek_v3.modeling_deepseek_v3",
         "DeepseekV3NaiveMoe",
@@ -361,9 +265,8 @@ def test_deepseek_v3_naive_moe_class_gated_5x():
 
 
 def test_deepseek_v3_topk_router_class_present():
-    """deepseek_v3_moe.py:59 imports DeepseekV3TopkRouter inside the same
-    try/except guard. The class is referenced (not patched) but if it
-    disappears, the whole patch entry silently no-ops."""
+    """deepseek_v3_moe.py:59 imports DeepseekV3TopkRouter as a gate;
+    missing -> whole patch entry silently no-ops."""
     mod = importlib.import_module(
         "transformers.models.deepseek_v3.modeling_deepseek_v3"
     )
@@ -390,10 +293,8 @@ def test_deepseek_v3_config_class_present():
 
 
 def test_deepseek_v3_moe_forward_single_positional():
-    """deepseek_v3_moe.py:125 patches DeepseekV3MoE.forward with
-    ``def patched_moe_forward(self, hidden_states)``. Re-pin here as the
-    sibling test only asserts param-superset; this asserts single-arg
-    shape (no extra required positionals)."""
+    """deepseek_v3_moe.py:125 patches DeepseekV3MoE.forward(self,
+    hidden_states); pin single required positional."""
     cls = _try_get_class(
         "transformers.models.deepseek_v3.modeling_deepseek_v3",
         "DeepseekV3MoE",
@@ -419,12 +320,9 @@ def test_deepseek_v3_moe_forward_single_positional():
 
 def test_deepseek_v3_for_causal_lm_forward_named_params():
     """deepseek_v3_moe.py:142 patches DeepseekV3ForCausalLM.forward with
-    a wrapper that forwards by name: input_ids, attention_mask,
-    position_ids, past_key_values, inputs_embeds, labels, use_cache,
-    output_router_logits, cache_position, logits_to_keep. Pin those names
-    are still accepted. ``output_router_logits`` may have been folded
-    into **kwargs upstream (TransformersKwargs catch-all), so we allow
-    either an explicit param OR a VAR_KEYWORD catch-all."""
+    by-name kwargs (input_ids, attention_mask, ..., output_router_logits,
+    cache_position, logits_to_keep); output_router_logits may be in
+    **kwargs (TransformersKwargs catch-all)."""
     cls = _try_get_class(
         "transformers.models.deepseek_v3.modeling_deepseek_v3",
         "DeepseekV3ForCausalLM",
@@ -432,7 +330,6 @@ def test_deepseek_v3_for_causal_lm_forward_named_params():
     if cls is None:
         pytest.skip(f"DeepseekV3ForCausalLM absent on transformers {_TX_VERSION}")
     fwd = _assert_method_exists(cls, "forward", "deepseek_v3_moe.py")
-    # Hard-required params (always part of an LM forward).
     _assert_params_superset(
         fwd,
         required=[
@@ -443,10 +340,7 @@ def test_deepseek_v3_for_causal_lm_forward_named_params():
         zoo_file="deepseek_v3_moe.py",
         label="DeepseekV3ForCausalLM.forward",
     )
-    # output_router_logits is forwarded by name from zoo's wrapper, but
-    # upstream folded it into **kwargs in 4.57. Pin that the upstream
-    # has SOME kwarg passthrough so zoo's by-name forwarding still
-    # reaches the underlying model.
+    # output_router_logits: explicit param OR **kwargs passthrough.
     if "output_router_logits" not in _param_names(fwd) and not _has_var_keyword(fwd):
         pytest.fail(
             "DRIFT DETECTED: zoo temporary_patches/deepseek_v3_moe.py:171 "
@@ -457,24 +351,12 @@ def test_deepseek_v3_for_causal_lm_forward_named_params():
         )
 
 
-# ===========================================================================
-# gemma.py
-# ---------------------------------------------------------------------------
-# Most of gemma.py is covered. The UNSLOTH_FORCE_FLOAT32-gated
-# Gemma3Model._update_causal_mask patch (gemma.py:308) is the only
-# remaining uncovered site. Upstream removed _update_causal_mask in
-# transformers 4.55+, so the patch is a no-op on modern installs.
-# ===========================================================================
+# gemma.py: UNSLOTH_FORCE_FLOAT32-gated Gemma3Model._update_causal_mask
+# patch (gemma.py:308); upstream removed in 4.55+, patch no-op on modern.
 
 def test_gemma3_force_fp32_update_causal_mask_gated():
-    """gemma.py:308-310 patches Gemma3Model._update_causal_mask and
-    Gemma3ForConditionalGeneration._update_causal_mask ONLY when
-    UNSLOTH_FORCE_FLOAT32=1. Upstream removed the method in 4.55+, so on
-    modern installs the gate-guarded import line will succeed (classes
-    still exist) but the method won't. Test that EITHER both classes
-    exist AND have the method (drift if class is here without method
-    while gate is active) OR the method is gone (legitimately upstream-
-    refactored)."""
+    """gemma.py:308-310 patches Gemma3{Model,ForConditionalGeneration}.
+    _update_causal_mask under UNSLOTH_FORCE_FLOAT32=1."""
     mod = importlib.import_module(
         "transformers.models.gemma3.modeling_gemma3"
     )
@@ -486,9 +368,7 @@ def test_gemma3_force_fp32_update_causal_mask_gated():
             "Gemma3Model and Gemma3ForConditionalGeneration but at least one is "
             f"missing on transformers {_TX_VERSION}"
         )
-    # Both classes must still exist. The method is allowed to have been
-    # removed: zoo's patch_function silently no-ops when the attribute
-    # isn't there. We just confirm the class survival here.
+    # Class presence required; method removal OK (zoo's patch_function no-ops).
     if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "1":
         if not hasattr(model, "_update_causal_mask"):
             pytest.fail(
@@ -499,18 +379,11 @@ def test_gemma3_force_fp32_update_causal_mask_gated():
             )
 
 
-# ===========================================================================
-# gemma3n.py
-# ---------------------------------------------------------------------------
-# Existing tests cover Gemma3nMultimodalEmbedder, Gemma3nTextAltUp.predict
-# /correct, Gemma3nModel.get_placeholder_mask. Missing: AltUp's
-# scale_corrected_output and the gemma3n module surface.
-# ===========================================================================
+# gemma3n.py: AltUp.scale_corrected_output (tail not covered by siblings).
 
 def test_gemma3n_text_alt_up_scale_corrected_output_signature():
     """gemma3n.py:148 patches Gemma3nTextAltUp.scale_corrected_output
-    with fullgraph=True. The original is ``(self, corrected)`` -- a
-    single-tensor method. Pin that shape."""
+    (fullgraph=True); shape: ``(self, corrected)``."""
     cls = _require_class(
         "transformers.models.gemma3n.modeling_gemma3n",
         "Gemma3nTextAltUp",
@@ -536,10 +409,8 @@ def test_gemma3n_text_alt_up_scale_corrected_output_signature():
 
 
 def test_gemma3n_text_alt_up_three_methods_present():
-    """gemma3n.py:143-148 inspects ``hasattr`` for predict / correct /
-    scale_corrected_output before patching. The hasattr guard masks a
-    full method-set rename: this test fails LOUDLY when all three are
-    simultaneously gone (i.e. the AltUp class was restructured)."""
+    """gemma3n.py:143-148 hasattr-guards predict / correct /
+    scale_corrected_output; loud-fail when ALL three are gone."""
     cls = _require_class(
         "transformers.models.gemma3n.modeling_gemma3n",
         "Gemma3nTextAltUp",
@@ -559,11 +430,10 @@ def test_gemma3n_text_alt_up_three_methods_present():
 
 
 def test_gemma3n_RMSNorm_helper_target_present():
-    """gemma3n.py:53 defines a module-level torch_compile'd
-    ``Gemma3nRMSNorm_forward`` that is then called by the patched
-    Multimodal embedder / AltUp.predict on ``self.soft_embedding_norm``,
-    ``self.router_norm``, etc. Those attributes must exist on
-    ``Gemma3nMultimodalEmbedder`` / ``Gemma3nTextAltUp``."""
+    """gemma3n.py:53-85 Gemma3nRMSNorm_forward helper dereferences
+    self.soft_embedding_norm / self.hard_embedding_norm /
+    self.embedding_projection / self.embedding_post_projection_norm on
+    Gemma3nMultimodalEmbedder."""
     embedder = _require_class(
         "transformers.models.gemma3n.modeling_gemma3n",
         "Gemma3nMultimodalEmbedder",
@@ -577,7 +447,7 @@ def test_gemma3n_RMSNorm_helper_target_present():
     except (OSError, TypeError):
         pytest.skip("Cannot read Gemma3nMultimodalEmbedder.__init__ source")
     for attr in ("soft_embedding_norm", "hard_embedding_norm",
-                 "embedding_projection", "embedding_post_projection_norm"):
+                  "embedding_projection", "embedding_post_projection_norm"):
         if attr not in src:
             pytest.fail(
                 f"DRIFT DETECTED: zoo temporary_patches/gemma3n.py:74-85 "
@@ -587,15 +457,11 @@ def test_gemma3n_RMSNorm_helper_target_present():
             )
 
 
-# ===========================================================================
-# gemma4.py
-# ---------------------------------------------------------------------------
-# Patches: Gemma4TextMLP.forward (gemma4.py:655). Gemma4 is 5.0+-only.
-# ===========================================================================
+# gemma4.py: Gemma4TextMLP.forward (gemma4.py:655); 5.0+-only.
 
 def test_gemma4_text_mlp_forward_signature():
-    """gemma4.py:655 patches Gemma4TextMLP.forward with
-    ``def forward(self, x)``. Pin a single positional arg."""
+    """gemma4.py:655 patches Gemma4TextMLP.forward(self, x); single
+    positional arg."""
     cls = _try_get_class(
         "transformers.models.gemma4.modeling_gemma4", "Gemma4TextMLP",
     )
@@ -620,9 +486,8 @@ def test_gemma4_text_mlp_forward_signature():
 
 
 def test_gemma4_text_mlp_has_required_attrs():
-    """gemma4.py:644-652 patched forward dereferences self.gate_proj,
-    self.up_proj, self.down_proj, self.act_fn. Pin those exist in the
-    __init__ source."""
+    """gemma4.py:644-652 patched forward dereferences self.{gate_proj,
+    up_proj, down_proj, act_fn}; pin presence in __init__ source."""
     cls = _try_get_class(
         "transformers.models.gemma4.modeling_gemma4", "Gemma4TextMLP",
     )
@@ -642,17 +507,12 @@ def test_gemma4_text_mlp_has_required_attrs():
             )
 
 
-# ===========================================================================
-# gemma4_moe.py
-# ---------------------------------------------------------------------------
-# Patches: Gemma4TextExperts.forward, Gemma4TextDecoderLayer.__init__,
-# Gemma4TextMoEBlock.forward, Gemma4ForConditionalGeneration.forward.
-# All transformers 5.0+-gated.
-# ===========================================================================
+# gemma4_moe.py: Gemma4Text{Experts,DecoderLayer,MoEBlock}{.forward,
+# .__init__}, Gemma4ForConditionalGeneration.forward. 5.0+-gated.
 
 def test_gemma4_text_experts_forward_signature():
-    """gemma4_moe.py:239 patches Gemma4TextExperts.forward with
-    ``forward(self, hidden_states, top_k_index, top_k_weights)``."""
+    """gemma4_moe.py:239 patches Gemma4TextExperts.forward(self,
+    hidden_states, top_k_index, top_k_weights)."""
     cls = _try_get_class(
         "transformers.models.gemma4.modeling_gemma4", "Gemma4TextExperts",
     )
@@ -671,8 +531,8 @@ def test_gemma4_text_experts_forward_signature():
 
 
 def test_gemma4_text_decoder_layer_init_signature():
-    """gemma4_moe.py:287 patches Gemma4TextDecoderLayer.__init__ with
-    ``def __init__(self, config, layer_idx)``. Pin those param names."""
+    """gemma4_moe.py:287 patches Gemma4TextDecoderLayer.__init__(self,
+    config, layer_idx)."""
     cls = _try_get_class(
         "transformers.models.gemma4.modeling_gemma4", "Gemma4TextDecoderLayer",
     )
@@ -690,8 +550,8 @@ def test_gemma4_text_decoder_layer_init_signature():
 
 
 def test_gemma4_text_moe_block_forward_signature():
-    """gemma4_moe.py:301 patches Gemma4TextMoEBlock.forward with
-    ``forward(self, hidden_states, top_k_index, top_k_weights)``."""
+    """gemma4_moe.py:301 patches Gemma4TextMoEBlock.forward(self,
+    hidden_states, top_k_index, top_k_weights)."""
     cls = _try_get_class(
         "transformers.models.gemma4.modeling_gemma4", "Gemma4TextMoEBlock",
     )
@@ -710,12 +570,9 @@ def test_gemma4_text_moe_block_forward_signature():
 
 
 def test_gemma4_for_conditional_generation_forward_named_params():
-    """gemma4_moe.py:208 patches Gemma4ForConditionalGeneration.forward
-    with a wrapper that forwards by name: input_ids, pixel_values,
-    pixel_values_videos, input_features, attention_mask,
-    input_features_mask, position_ids, image_position_ids,
-    video_position_ids, past_key_values, mm_token_type_ids,
-    inputs_embeds, labels, use_cache, logits_to_keep. Pin the names."""
+    """gemma4_moe.py:208 patches
+    Gemma4ForConditionalGeneration.forward; pin by-name kwargs
+    (input_ids, attention_mask, ..., logits_to_keep)."""
     cls = _try_get_class(
         "transformers.models.gemma4.modeling_gemma4",
         "Gemma4ForConditionalGeneration",
@@ -738,9 +595,8 @@ def test_gemma4_for_conditional_generation_forward_named_params():
 
 
 def test_gemma4_causal_lm_output_with_past_kwargs():
-    """gemma4_moe.py:189 constructs Gemma4CausalLMOutputWithPast(loss,
-    logits, past_key_values, hidden_states, attentions,
-    image_hidden_states, audio_hidden_states). Pin those kwarg names."""
+    """gemma4_moe.py:189 constructs Gemma4CausalLMOutputWithPast (loss,
+    logits, past_key_values, hidden_states, attentions, ...)."""
     mod = _try_get_class("transformers.models.gemma4", "modeling_gemma4")
     if mod is None:
         pytest.skip(f"gemma4 absent on transformers {_TX_VERSION}")
@@ -764,17 +620,11 @@ def test_gemma4_causal_lm_output_with_past_kwargs():
             )
 
 
-# ===========================================================================
-# glm4_moe.py
-# ---------------------------------------------------------------------------
-# Patches: Glm4MoeLiteNaiveMoe.forward, Glm4MoeLiteMoE.forward.
-# 5.0+-gated (the entire glm4_moe_lite module is 5.0+).
-# ===========================================================================
+# glm4_moe.py: Glm4MoeLite{NaiveMoe,MoE}.forward (5.0+-only).
 
 def test_glm4_moe_lite_naive_moe_forward_signature():
     """glm4_moe.py:97 patches Glm4MoeLiteNaiveMoe.forward via
-    ``get_forward_moe_backend()``. The backend forward signature is
-    ``(self, hidden_states, top_k_index, top_k_weights)``."""
+    ``get_forward_moe_backend()`` (self, hidden_states, ...)."""
     cls = _try_get_class(
         "transformers.models.glm4_moe_lite.modeling_glm4_moe_lite",
         "Glm4MoeLiteNaiveMoe",
@@ -794,8 +644,8 @@ def test_glm4_moe_lite_naive_moe_forward_signature():
 
 
 def test_glm4_moe_lite_moe_forward_signature():
-    """glm4_moe.py:98 patches Glm4MoeLiteMoE.forward with
-    ``moe_block_forward(self, hidden_states)``."""
+    """glm4_moe.py:98 patches Glm4MoeLiteMoE.forward(self,
+    hidden_states)."""
     cls = _try_get_class(
         "transformers.models.glm4_moe_lite.modeling_glm4_moe_lite",
         "Glm4MoeLiteMoE",
@@ -814,21 +664,13 @@ def test_glm4_moe_lite_moe_forward_signature():
     )
 
 
-# ===========================================================================
-# gpt_oss.py
-# ---------------------------------------------------------------------------
-# Patches: swizzle_mxfp4 (covered), Mxfp4GptOssExperts (NOT covered as a
-# signature test), mlp_forward (covered), load_and_swizzle_mxfp4 (covered),
-# replace_with_mxfp4_linear (covered), GptOssAttention.forward (covered),
-# GptOssModel.forward (covered), GptOssConfig (NOT covered, source-only
-# patch), GptOssPreTrainedModel._init_weights (covered),
-# GptOssForCausalLM.forward (NOT covered).
-# ===========================================================================
+# gpt_oss.py: Mxfp4GptOssExperts, GptOssConfig (source-only),
+# GptOssForCausalLM.forward (tail not covered by siblings).
 
 def test_mxfp4_gpt_oss_experts_class_present_and_init_signature():
-    """gpt_oss.py:433 replaces transformers.integrations.mxfp4
-    .Mxfp4GptOssExperts with a custom class. Pin that the upstream class
-    exists and its __init__ accepts (self, config)."""
+    """gpt_oss.py:433 replaces
+    transformers.integrations.mxfp4.Mxfp4GptOssExperts; pin class +
+    __init__(self, config)."""
     cls = _try_get_class(
         "transformers.integrations.mxfp4", "Mxfp4GptOssExperts",
     )
@@ -846,14 +688,8 @@ def test_mxfp4_gpt_oss_experts_class_present_and_init_signature():
 
 
 def test_gpt_oss_config_class_construction_signature():
-    """gpt_oss.py:2813 conditionally replaces
-    transformers.models.gpt_oss.configuration_gpt_oss.GptOssConfig with
-    Old_GptOssConfig. The replacement uses kwargs num_hidden_layers,
-    num_local_experts, vocab_size, hidden_size, intermediate_size,
-    head_dim, num_attention_heads, num_key_value_heads, sliding_window,
-    rope_theta, etc. Pin those names exist on the installed class so the
-    replacement (and any user constructing the config by kwarg) doesn't
-    silently miss a renamed param."""
+    """gpt_oss.py:2813 replaces GptOssConfig with Old_GptOssConfig; pin
+    kwarg names (num_hidden_layers, num_local_experts, vocab_size, ...)."""
     cls = _try_get_class(
         "transformers.models.gpt_oss.configuration_gpt_oss", "GptOssConfig",
     )
@@ -878,20 +714,16 @@ def test_gpt_oss_config_class_construction_signature():
 
 
 def test_gpt_oss_for_causal_lm_forward_named_params():
-    """gpt_oss.py:2890 patches GptOssForCausalLM.forward with a wrapper
-    that forwards by name: input_ids, attention_mask, position_ids,
-    past_key_values, inputs_embeds, labels, use_cache, output_attentions,
-    output_hidden_states, cache_position, logits_to_keep."""
+    """gpt_oss.py:2890 patches GptOssForCausalLM.forward with by-name
+    kwargs (input_ids, attention_mask, ..., logits_to_keep)."""
     cls = _try_get_class(
         "transformers.models.gpt_oss.modeling_gpt_oss", "GptOssForCausalLM",
     )
     if cls is None:
         pytest.skip(f"GptOssForCausalLM absent on transformers {_TX_VERSION}")
     fwd = _assert_method_exists(cls, "forward", "gpt_oss.py")
-    # Newer transformers may have already dropped output_attentions and
-    # output_hidden_states from forward signatures. Zoo's wrapper still
-    # accepts them as kwargs that go into **kwargs. Pin only the params
-    # that are guaranteed to remain.
+    # output_attentions / output_hidden_states may be folded into
+    # **kwargs on newer transformers; pin only guaranteed-stable params.
     _assert_params_superset(
         fwd,
         required=[
@@ -905,9 +737,8 @@ def test_gpt_oss_for_causal_lm_forward_named_params():
 
 
 def test_gpt_oss_moe_causal_lm_output_kwargs():
-    """gpt_oss.py:2949 constructs MoeCausalLMOutputWithPast(loss,
-    aux_loss, logits, past_key_values, hidden_states, attentions,
-    router_logits). Pin those kwarg names."""
+    """gpt_oss.py:2949 constructs MoeCausalLMOutputWithPast (loss,
+    aux_loss, logits, past_key_values, ...)."""
     cls = _try_get_class(
         "transformers.models.gpt_oss.modeling_gpt_oss",
         "MoeCausalLMOutputWithPast",
@@ -930,16 +761,13 @@ def test_gpt_oss_moe_causal_lm_output_kwargs():
 
 
 def test_gpt_oss_dynamic_cache_re_export():
-    """gpt_oss.py:2126 imports DynamicCache from
-    transformers.models.gpt_oss.modeling_gpt_oss as a soft try/except. If
-    the re-export goes away the patch still works (via the fallback
-    lambda), but pinning here surfaces the rename loudly."""
+    """gpt_oss.py:2126 imports DynamicCache from modeling_gpt_oss (soft
+    try/except). Zoo falls back to a no-op lambda silently; surface
+    rename loudly."""
     mod = importlib.import_module(
         "transformers.models.gpt_oss.modeling_gpt_oss"
     )
     if not hasattr(mod, "DynamicCache"):
-        # The fallback in zoo silently substitutes a no-op. Surface this
-        # so we know to land a real fix.
         pytest.fail(
             "DRIFT DETECTED: zoo temporary_patches/gpt_oss.py:2126 expects "
             "transformers.models.gpt_oss.modeling_gpt_oss.DynamicCache but "
@@ -950,8 +778,8 @@ def test_gpt_oss_dynamic_cache_re_export():
 
 
 def test_gpt_oss_apply_rotary_pos_emb_re_export():
-    """gpt_oss.py:2122 imports apply_rotary_pos_emb from the gpt_oss
-    modeling module. Re-export pin."""
+    """gpt_oss.py:2122 imports apply_rotary_pos_emb from
+    modeling_gpt_oss; re-export pin."""
     mod = importlib.import_module(
         "transformers.models.gpt_oss.modeling_gpt_oss"
     )
@@ -964,8 +792,8 @@ def test_gpt_oss_apply_rotary_pos_emb_re_export():
 
 
 def test_gpt_oss_moe_model_output_with_past_present():
-    """gpt_oss.py:2121 imports MoeModelOutputWithPast. The patched
-    GptOssModel.forward returns this output class."""
+    """gpt_oss.py:2121 imports MoeModelOutputWithPast (patched
+    GptOssModel.forward return type)."""
     mod = importlib.import_module(
         "transformers.models.gpt_oss.modeling_gpt_oss"
     )
@@ -977,29 +805,13 @@ def test_gpt_oss_moe_model_output_with_past_present():
         )
 
 
-# ===========================================================================
-# misc.py
-# ---------------------------------------------------------------------------
-# Patches:
-#   - AutoHfQuantizer.merge_quantization_configs (covered)
-#   - CsmDepthDecoderForCausalLM.forward (NOT covered)
-#   - CsmForConditionalGeneration.forward (NOT covered as forward; only
-#     _merge_input_ids_with_input_values is pinned)
-#   - GraniteMoeHybridMambaLayer.cuda_kernels_forward (covered)
-#   - SiglipEncoderLayer.forward (covered)
-#   - MllamaVisionEncoderLayer.forward (covered)
-# ===========================================================================
+# misc.py: CsmDepthDecoderForCausalLM.forward,
+# CsmForConditionalGeneration.forward (tail not covered by siblings).
 
 def test_csm_depth_decoder_for_causal_lm_forward_named_params():
     """misc.py:239 patches CsmDepthDecoderForCausalLM.forward with named
-    params: input_ids, backbone_last_hidden_state, attention_mask,
-    position_ids, past_key_values, inputs_embeds, labels, use_cache,
-    cache_position, logits_to_keep.
-
-    Resolves through the ``_original_*`` stash so we inspect the genuine
-    upstream signature even after zoo's TEMPORARY_PATCHES have replaced
-    the live ``forward`` with a ``(self, *args, **kwargs)`` wrapper.
-    """
+    params (input_ids, backbone_last_hidden_state, ..., logits_to_keep).
+    Resolves via ``_original_*`` stash past zoo's wrapper."""
     cls = _try_get_class(
         "transformers.models.csm.modeling_csm",
         "CsmDepthDecoderForCausalLM",
@@ -1023,15 +835,9 @@ def test_csm_depth_decoder_for_causal_lm_forward_named_params():
 
 
 def test_csm_for_conditional_generation_forward_named_params():
-    """misc.py:373 patches CsmForConditionalGeneration.forward. The
-    replacement forwards: input_ids, input_values, attention_mask,
-    input_values_cutoffs, position_ids, past_key_values, inputs_embeds,
-    labels, use_cache, cache_position, logits_to_keep.
-
-    Resolves through the ``_original_*`` stash so we inspect the genuine
-    upstream signature even after zoo's TEMPORARY_PATCHES have replaced
-    the live ``forward`` with a ``(self, *args, **kwargs)`` wrapper.
-    """
+    """misc.py:373 patches CsmForConditionalGeneration.forward (input_ids,
+    input_values, ..., logits_to_keep). Resolves via ``_original_*``
+    stash past zoo's wrapper."""
     cls = _try_get_class(
         "transformers.models.csm.modeling_csm",
         "CsmForConditionalGeneration",
@@ -1056,8 +862,7 @@ def test_csm_for_conditional_generation_forward_named_params():
 
 
 def test_csm_output_with_past_kwargs():
-    """misc.py constructs CausalLMOutputWithPast / CsmOutputWithPast.
-    Pin CsmOutputWithPast field set."""
+    """misc.py constructs CsmOutputWithPast; pin field set."""
     cls = _try_get_class(
         "transformers.models.csm.modeling_csm", "CsmOutputWithPast",
     )
@@ -1076,7 +881,7 @@ def test_csm_output_with_past_kwargs():
 
 def test_csm_for_causal_lm_loss_signature():
     """misc.py:221 calls ForCausalLMLoss(logits, labels, vocab_size,
-    shift_labels). Pin those keyword names accepted."""
+    shift_labels)."""
     fn = None
     try:
         from transformers.loss.loss_utils import ForCausalLMLoss
@@ -1096,9 +901,8 @@ def test_csm_for_causal_lm_loss_signature():
 
 
 def test_csm_merge_input_ids_with_input_values_param_count_realistic():
-    """misc.py:770 patches CsmForConditionalGeneration._merge_input_ids
-    _with_input_values. The sibling test pins by-name params; here we
-    pin that the method exists on the class regardless of name shuffles."""
+    """misc.py:770 patches CsmForConditionalGeneration.
+    _merge_input_ids_with_input_values; pin method existence."""
     cls = _try_get_class(
         "transformers.models.csm.modeling_csm",
         "CsmForConditionalGeneration",
@@ -1109,8 +913,7 @@ def test_csm_merge_input_ids_with_input_values_param_count_realistic():
 
 
 def test_misc_quantizers_auto_module_present():
-    """misc.py:153 patches transformers.quantizers.auto.AutoHfQuantizer.
-    Pin the dotted path."""
+    """misc.py:153 patches transformers.quantizers.auto.AutoHfQuantizer."""
     try:
         mod = importlib.import_module("transformers.quantizers.auto")
     except Exception as exc:
@@ -1126,10 +929,7 @@ def test_misc_quantizers_auto_module_present():
 
 
 def test_misc_granitemoehybrid_class_present():
-    """misc.py:1061 patches
-    transformers.models.granitemoehybrid.modeling_granitemoehybrid
-    .GraniteMoeHybridMambaLayer. Pin the dotted path; the sibling test
-    pins the cuda_kernels_forward signature."""
+    """misc.py:1061 patches GraniteMoeHybridMambaLayer; pin class."""
     cls = _try_get_class(
         "transformers.models.granitemoehybrid.modeling_granitemoehybrid",
         "GraniteMoeHybridMambaLayer",
@@ -1141,9 +941,7 @@ def test_misc_granitemoehybrid_class_present():
 
 
 def test_misc_siglip_encoder_layer_class_present():
-    """misc.py:1228 patches
-    transformers.models.siglip.modeling_siglip.SiglipEncoderLayer.
-    Pin the dotted path."""
+    """misc.py:1228 patches SiglipEncoderLayer."""
     cls = _try_get_class(
         "transformers.models.siglip.modeling_siglip", "SiglipEncoderLayer",
     )
@@ -1156,9 +954,8 @@ def test_misc_siglip_encoder_layer_class_present():
 
 
 def test_misc_mllama_vision_classes_present():
-    """misc.py:1116-1119 imports MllamaVisionConfig / MllamaVisionAttention
-    / MllamaVisionMLP / MllamaVisionEncoder from
-    transformers.models.mllama.modeling_mllama. Pin them as a set."""
+    """misc.py:1116-1119 imports MllamaVision{Config,Attention,MLP,Encoder,
+    EncoderLayer}."""
     mod_name = "transformers.models.mllama.modeling_mllama"
     try:
         mod = importlib.import_module(mod_name)
@@ -1179,20 +976,12 @@ def test_misc_mllama_vision_classes_present():
         )
 
 
-# ===========================================================================
-# mxfp4.py
-# ---------------------------------------------------------------------------
-# Patches: convert_moe_packed_tensors, dequantize (both at
-# transformers.integrations.mxfp4 module level). The sibling
-# test_mxfp4_swizzle_mxfp4_signature and test_mxfp4_replace_with_mxfp4
-# _linear_signature pin OTHER mxfp4 functions but NOT these two.
-# ===========================================================================
+# mxfp4.py: convert_moe_packed_tensors, dequantize (tail).
 
 def test_mxfp4_convert_moe_packed_tensors_signature():
     """mxfp4.py:173 patches
-    transformers.integrations.mxfp4.convert_moe_packed_tensors. The
-    replacement signature is ``(blocks, scales, *, dtype=torch.bfloat16,
-    rows_per_chunk=...)``. Pin the positional+kwonly names."""
+    ``transformers.integrations.mxfp4.convert_moe_packed_tensors``
+    (blocks, scales, *, dtype, rows_per_chunk)."""
     mod_name = "transformers.integrations.mxfp4"
     try:
         mod = importlib.import_module(mod_name)
@@ -1214,10 +1003,8 @@ def test_mxfp4_convert_moe_packed_tensors_signature():
 
 
 def test_mxfp4_dequantize_signature():
-    """mxfp4.py:220 patches
-    transformers.integrations.mxfp4.dequantize. The replacement signature
-    is ``(module, param_name, param_value, target_device, dq_param_name,
-    **kwargs)``."""
+    """mxfp4.py:220 patches ``mxfp4.dequantize`` (module, param_name,
+    param_value, target_device, dq_param_name, **kwargs)."""
     mod_name = "transformers.integrations.mxfp4"
     try:
         mod = importlib.import_module(mod_name)
@@ -1250,8 +1037,7 @@ def test_mxfp4_dequantize_signature():
 
 
 def test_mxfp4_fp4_values_constant_present():
-    """mxfp4.py:113 / 227 imports FP4_VALUES from
-    transformers.integrations.mxfp4. Pin the constant."""
+    """mxfp4.py:113 / :227 imports ``FP4_VALUES`` constant."""
     try:
         mod = importlib.import_module("transformers.integrations.mxfp4")
     except Exception as exc:
@@ -1264,16 +1050,10 @@ def test_mxfp4_fp4_values_constant_present():
 
 
 def test_mxfp4_shard_and_distribute_module_present():
-    """mxfp4.py:181 imports shard_and_distribute_module from
-    transformers.integrations.tensor_parallel. The patched dequantize
-    delegates to this when device_mesh is non-None.
-
-    Note: zoo's call site at mxfp4.py:196 passes ``set_param=False`` --
-    a kwarg added in transformers 5.x. On 4.x stacks this kwarg is
-    legitimately absent and the TP code path raises TypeError at call
-    time. The TP code path is only exercised when ``device_mesh is not
-    None``, so non-TP users are unaffected. Pin function existence here;
-    the set_param compatibility is gated in the separate test below."""
+    """mxfp4.py:181 imports
+    ``transformers.integrations.tensor_parallel.shard_and_distribute_module``;
+    patched dequantize delegates when device_mesh != None. Positional
+    arity must be 8 for zoo's call to land."""
     try:
         mod = importlib.import_module("transformers.integrations.tensor_parallel")
     except Exception as exc:
@@ -1288,11 +1068,8 @@ def test_mxfp4_shard_and_distribute_module_present():
             "shard_and_distribute_module but it is missing on transformers "
             f"{_TX_VERSION}"
         )
-    # Positional arity the call site uses (model, param_value,
-    # empty_param, dq_param_name, casting_dtype, to_contiguous, rank,
-    # device_mesh). Upstream renames between 4.x and 5.x (param ->
-    # param_value, parameter_name -> dq_param_name, etc.), but the
-    # POSITIONAL arity must remain at 8 for zoo's call to land.
+    # 8 positionals: model, param_value, empty_param, dq_param_name,
+    # casting_dtype, to_contiguous, rank, device_mesh.
     params = [
         p for p in inspect.signature(fn).parameters.values()
         if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD,
@@ -1308,24 +1085,14 @@ def test_mxfp4_shard_and_distribute_module_present():
 
 
 def test_mxfp4_shard_and_distribute_set_param_kwarg_or_4x_compat():
-    """mxfp4.py:196 passes ``set_param=False`` to
-    shard_and_distribute_module. This kwarg was added in transformers
-    5.x; on 4.x it doesn't exist and the call TypeErrors. The TP path is
-    only hit when device_mesh is not None, so most users are unaffected,
-    but we surface the version-skew explicitly so a future zoo PR can
-    decide whether to drop the kwarg conditionally on transformers
-    version."""
+    """mxfp4.py:196 passes ``set_param=False`` (5.x kwarg). 4.x without
+    **kwargs catch-all TypeErrors on the TP path; surface as skip."""
     mod = importlib.import_module("transformers.integrations.tensor_parallel")
     fn = mod.shard_and_distribute_module
     if "set_param" in _param_names(fn):
-        return  # 5.x; zoo's call site works
+        return  # 5.x
     if _has_var_keyword(fn):
-        return  # **kwargs catch-all swallows set_param
-    # 4.x without **kwargs: zoo's TP path will TypeError. This is a
-    # well-known version-skew limitation -- zoo expects users running
-    # mxfp4 + TP to be on transformers 5.x. Skip rather than fail so the
-    # general suite passes on 4.x dev installs; the explicit message
-    # makes the skew loud.
+        return  # **kwargs swallows set_param
     pytest.skip(
         f"transformers {_TX_VERSION} predates set_param kwarg on "
         "shard_and_distribute_module; zoo's TP path (device_mesh != None) "
@@ -1334,8 +1101,7 @@ def test_mxfp4_shard_and_distribute_set_param_kwarg_or_4x_compat():
 
 
 def test_mxfp4_mxfp4_config_top_level_class():
-    """mxfp4.py:93 imports Mxfp4Config from top-level transformers. Pin
-    it. Used as the quantization_config kwarg for AutoModelForCausalLM."""
+    """mxfp4.py:93 imports top-level ``transformers.Mxfp4Config``."""
     if not hasattr(transformers, "Mxfp4Config"):
         pytest.fail(
             "DRIFT DETECTED: zoo temporary_patches/mxfp4.py:93 expects "
@@ -1344,16 +1110,10 @@ def test_mxfp4_mxfp4_config_top_level_class():
         )
 
 
-# ===========================================================================
-# pixtral.py
-# ---------------------------------------------------------------------------
-# Patches: PixtralAttention.__init__ (pixtral.py:91), PixtralAttention.forward
-# (pixtral.py:97). Neither covered by existing tests.
-# ===========================================================================
+# pixtral.py: PixtralAttention.{__init__, forward}.
 
 def test_pixtral_attention_init_signature():
-    """pixtral.py:91 patches PixtralAttention.__init__ with
-    ``def __init__(self, config)``. Pin the single-config init."""
+    """pixtral.py:91 patches PixtralAttention.__init__(self, config)."""
     cls = _require_class(
         "transformers.models.pixtral.modeling_pixtral",
         "PixtralAttention",
@@ -1368,18 +1128,9 @@ def test_pixtral_attention_init_signature():
 
 
 def test_pixtral_attention_forward_signature():
-    """pixtral.py:97 patches PixtralAttention.forward with
-    ``forward(self, hidden_states, attention_mask, position_embeddings,
-    output_attentions=False, **kwargs)``. Pin those names.
-
-    Once apply_import_fixes / TEMPORARY_PATCHES have run, the live
-    ``PixtralAttention.forward`` is zoo's patch wrapper with signature
-    ``(self, *args, **kwargs)``; reading that signature would false-fail
-    the upstream-shape pin. We instead resolve through
-    ``_original_<module>_<class>_<attr>`` (stashed by zoo's
-    ``patch_function``) to read the genuine upstream signature, or skip
-    loudly with the patch-wrapper detail if no stash is available.
-    """
+    """pixtral.py:97 patches PixtralAttention.forward(self,
+    hidden_states, attention_mask, position_embeddings, ...). Resolves
+    via ``_original_*`` stash to read upstream past zoo's wrapper."""
     cls = _require_class(
         "transformers.models.pixtral.modeling_pixtral",
         "PixtralAttention",
@@ -1396,9 +1147,8 @@ def test_pixtral_attention_forward_signature():
 
 
 def test_pixtral_apply_rotary_pos_emb_present():
-    """pixtral.py:30 imports apply_rotary_pos_emb from the pixtral
-    modeling module. Re-export pin -- if it moves, the patch raises and
-    PixtralAttention falls back to the (broken) stock forward."""
+    """pixtral.py:30 imports apply_rotary_pos_emb from modeling_pixtral;
+    re-export pin."""
     mod = importlib.import_module(
         "transformers.models.pixtral.modeling_pixtral"
     )
@@ -1411,9 +1161,8 @@ def test_pixtral_apply_rotary_pos_emb_present():
 
 
 def test_pixtral_attention_init_attrs_present():
-    """pixtral.py:36-47 patched __init__ sets self.embed_dim, num_heads,
-    head_dim, scale, dropout, k_proj, v_proj, q_proj, o_proj. The config
-    must expose hidden_size, num_attention_heads, attention_dropout."""
+    """pixtral.py:36-47 patched __init__ reads self.config.{hidden_size,
+    num_attention_heads, attention_dropout}."""
     cls = _require_class(
         "transformers.models.pixtral.configuration_pixtral",
         "PixtralVisionConfig",
@@ -1431,13 +1180,8 @@ def test_pixtral_attention_init_attrs_present():
             )
 
 
-# ===========================================================================
-# qwen3_5_moe.py
-# ---------------------------------------------------------------------------
-# Patches: Qwen3_5MoeExperts.forward, Qwen3_5MoeSparseMoeBlock.forward,
-# Qwen3_5MoeForCausalLM.forward. All 5.0+-gated -- the module
-# qwen3_5_moe only exists on transformers 5.x.
-# ===========================================================================
+# qwen3_5_moe.py: Qwen3_5Moe{Experts,SparseMoeBlock,ForCausalLM}.forward
+# (5.0+-only).
 
 def test_qwen3_5_moe_sparse_moe_block_forward_signature():
     """qwen3_5_moe.py:66 patches Qwen3_5MoeSparseMoeBlock.forward."""
@@ -1480,8 +1224,8 @@ def test_qwen3_5_moe_experts_forward_signature():
 
 
 def test_qwen3_5_moe_for_causal_lm_class_present():
-    """qwen3_5_moe.py:77 reads Qwen3_5MoeForCausalLM and MoeCausalLMOutput
-    WithPast for the GRPO hidden-states patch. Pin those classes."""
+    """qwen3_5_moe.py:77-78 reads Qwen3_5MoeForCausalLM +
+    MoeCausalLMOutputWithPast (GRPO hidden-states patch)."""
     mod = _try_get_class(
         "transformers.models.qwen3_5_moe", "modeling_qwen3_5_moe",
     )
@@ -1510,19 +1254,12 @@ def test_qwen3_5_moe_for_causal_lm_class_present():
         )
 
 
-# ===========================================================================
-# qwen3_moe.py
-# ---------------------------------------------------------------------------
-# Patches: Qwen3MoeSparseMoeBlock.forward (covered), Qwen3MoeExperts.forward
-# (5.0+-gated, NOT covered with signature), Qwen3MoeForCausalLM.forward
-# (NOT covered).
-# ===========================================================================
+# qwen3_moe.py: Qwen3MoeExperts.forward (5.0+),
+# Qwen3MoeForCausalLM.forward (tail).
 
 def test_qwen3_moe_experts_forward_signature_5x():
-    """qwen3_moe.py:339 patches Qwen3MoeExperts.forward via
-    ``patch_function(...)`` on the 5.0+ stacked-experts branch. The
-    sibling test pins class EXISTENCE; this test pins the forward
-    signature accepts (hidden_states, top_k_index, top_k_weights)."""
+    """qwen3_moe.py:339 patches Qwen3MoeExperts.forward(hidden_states,
+    top_k_index, top_k_weights) on 5.0+ stacked-experts branch."""
     cls = _try_get_class(
         "transformers.models.qwen3_moe.modeling_qwen3_moe", "Qwen3MoeExperts",
     )
@@ -1541,11 +1278,8 @@ def test_qwen3_moe_experts_forward_signature_5x():
 
 
 def test_qwen3_moe_for_causal_lm_forward_named_params():
-    """qwen3_moe.py:351 indirectly patches Qwen3MoeForCausalLM.forward via
-    ``_patch_causal_lm_forward_for_hidden_states`` (qwen3_moe.py:138).
-    Patched signature is (input_ids, attention_mask, position_ids,
-    past_key_values, inputs_embeds, labels, use_cache,
-    output_router_logits, cache_position, logits_to_keep, **kwargs)."""
+    """qwen3_moe.py:351 patches Qwen3MoeForCausalLM.forward via
+    ``_patch_causal_lm_forward_for_hidden_states`` (qwen3_moe.py:138)."""
     cls = _try_get_class(
         "transformers.models.qwen3_moe.modeling_qwen3_moe",
         "Qwen3MoeForCausalLM",
@@ -1568,8 +1302,8 @@ def test_qwen3_moe_for_causal_lm_forward_named_params():
 
 
 def test_qwen3_moe_for_causal_lm_output_class_present():
-    """qwen3_moe.py:349 imports MoeCausalLMOutputWithPast from the same
-    qwen3_moe modeling module. Pin re-export."""
+    """qwen3_moe.py:349 imports MoeCausalLMOutputWithPast from
+    modeling_qwen3_moe."""
     mod = importlib.import_module(
         "transformers.models.qwen3_moe.modeling_qwen3_moe"
     )
@@ -1582,18 +1316,11 @@ def test_qwen3_moe_for_causal_lm_output_class_present():
         )
 
 
-# ===========================================================================
-# qwen3_next_moe.py
-# ---------------------------------------------------------------------------
-# Patches: Qwen3NextExperts.forward, Qwen3NextSparseMoeBlock.forward
-# (covered), Qwen3NextForCausalLM.forward (via the shared
-# _patch_causal_lm_forward_for_hidden_states helper).
-# ===========================================================================
+# qwen3_next_moe.py: Qwen3Next{Experts,ForCausalLM}.forward tail.
 
 def test_qwen3_next_experts_forward_signature():
-    """qwen3_next_moe.py:57 patches Qwen3NextExperts.forward (5.0+-only).
-    Pin signature accepts (hidden_states, ...) on installs where the
-    class is present."""
+    """qwen3_next_moe.py:57 patches Qwen3NextExperts.forward(self,
+    hidden_states, ...) on 5.0+."""
     cls = _try_get_class(
         "transformers.models.qwen3_next.modeling_qwen3_next",
         "Qwen3NextExperts",
@@ -1613,9 +1340,8 @@ def test_qwen3_next_experts_forward_signature():
 
 
 def test_qwen3_next_for_causal_lm_forward_named_params():
-    """qwen3_next_moe.py:79 indirectly patches Qwen3NextForCausalLM.forward
-    via ``_patch_causal_lm_forward_for_hidden_states``. Pin the named
-    params zoo's wrapper passes."""
+    """qwen3_next_moe.py:79 patches Qwen3NextForCausalLM.forward via
+    ``_patch_causal_lm_forward_for_hidden_states``."""
     cls = _try_get_class(
         "transformers.models.qwen3_next.modeling_qwen3_next",
         "Qwen3NextForCausalLM",
@@ -1637,20 +1363,12 @@ def test_qwen3_next_for_causal_lm_forward_named_params():
     )
 
 
-# ===========================================================================
-# qwen3_vl_moe.py
-# ---------------------------------------------------------------------------
-# Patches: Qwen3VLMoeTextSparseMoeBlock.forward (covered), Qwen3VLMoe
-# TextExperts.forward/__init__ (covered), Qwen3VLMoeForConditional
-# Generation.forward (NOT covered).
-# ===========================================================================
+# qwen3_vl_moe.py: Qwen3VLMoeForConditionalGeneration.forward (tail).
 
 def test_qwen3_vl_moe_for_conditional_generation_forward_named_params():
-    """qwen3_vl_moe.py:401 patches Qwen3VLMoeForConditionalGeneration.
-    forward. Patched signature forwards input_ids, attention_mask,
-    position_ids, past_key_values, inputs_embeds, labels, pixel_values,
-    pixel_values_videos, image_grid_thw, video_grid_thw, cache_position,
-    logits_to_keep."""
+    """qwen3_vl_moe.py:401 patches
+    Qwen3VLMoeForConditionalGeneration.forward with by-name kwargs
+    (input_ids, attention_mask, ..., logits_to_keep)."""
     cls = _try_get_class(
         "transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe",
         "Qwen3VLMoeForConditionalGeneration",
@@ -1676,8 +1394,7 @@ def test_qwen3_vl_moe_for_conditional_generation_forward_named_params():
 
 def test_qwen3_vl_moe_causal_lm_output_with_past_kwargs():
     """qwen3_vl_moe.py:466 constructs Qwen3VLMoeCausalLMOutputWithPast
-    (loss, aux_loss, logits, past_key_values, hidden_states, attentions,
-    rope_deltas). Pin kwarg names."""
+    (loss, aux_loss, ..., rope_deltas)."""
     cls = _try_get_class(
         "transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe",
         "Qwen3VLMoeCausalLMOutputWithPast",
@@ -1701,16 +1418,14 @@ def test_qwen3_vl_moe_causal_lm_output_with_past_kwargs():
 
 
 def test_qwen3_vl_moe_text_top_k_router_class_present():
-    """qwen3_vl_moe.py:326 expects ``self.gate`` to be
-    Qwen3VLMoeTextTopKRouter on the new (5.x) layout. The router returns
-    (router_logits, router_scores, router_indices). Pin the class."""
+    """qwen3_vl_moe.py:326 expects ``self.gate ==
+    Qwen3VLMoeTextTopKRouter`` on 5.x; tuple-unpack fallback otherwise."""
     cls = _try_get_class(
         "transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe",
         "Qwen3VLMoeTextTopKRouter",
     )
     if cls is None:
-        # The class is 5.x-only; if absent, zoo's tuple-unpack fallback
-        # at qwen3_vl_moe.py:333 still works. Don't fail here.
+        # 5.x-only; zoo's tuple-unpack fallback (qwen3_vl_moe.py:333) handles.
         pytest.skip(
             f"Qwen3VLMoeTextTopKRouter absent on transformers {_TX_VERSION} "
             "(zoo gracefully falls back to old-style logit gate)"
@@ -1718,9 +1433,7 @@ def test_qwen3_vl_moe_text_top_k_router_class_present():
 
 
 def test_qwen3_vl_moe_text_experts_class_present():
-    """qwen3_vl_moe.py:73 imports Qwen3VLMoeTextExperts. The sibling test
-    pins forward / __init__ signatures; this test gates the module
-    presence so a missing parent module surfaces clearly."""
+    """qwen3_vl_moe.py:73 imports Qwen3VLMoeTextExperts."""
     cls = _try_get_class(
         "transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe",
         "Qwen3VLMoeTextExperts",
@@ -1732,11 +1445,9 @@ def test_qwen3_vl_moe_text_experts_class_present():
 
 
 def test_qwen3_vl_moe_act2fn_dict_present():
-    """qwen3_vl_moe.py:201 imports ACT2FN from transformers.activations.
-    The patched __init__ does ``self.act_fn = ACT2FN[config.hidden_act]``.
-    Pin the import path."""
+    """qwen3_vl_moe.py:201 imports ACT2FN; patched __init__ does
+    ``self.act_fn = ACT2FN[config.hidden_act]``."""
     from transformers.activations import ACT2FN  # noqa: F401
-    # If hidden_act default is silu, ACT2FN must accept that key.
     if "silu" not in ACT2FN:
         pytest.fail(
             "DRIFT DETECTED: zoo temporary_patches/qwen3_vl_moe.py:236 expects "
@@ -1744,20 +1455,12 @@ def test_qwen3_vl_moe_act2fn_dict_present():
         )
 
 
-# ===========================================================================
-# moe_utils.py / moe_bnb.py / flex_attention_bwd.py
-# ---------------------------------------------------------------------------
-# These helper modules don't directly patch transformers (no
-# patch_function call sites). moe_utils provides helpers consumed by the
-# other temporary_patches/ files, and moe_bnb / flex_attention_bwd are
-# utility shims. Skip patch-site enumeration here; existing tests cover
-# the consumer sites already.
-# ===========================================================================
+# moe_utils.py / moe_bnb.py / flex_attention_bwd.py: helper modules
+# (no patch_function call sites); consumer sites covered elsewhere.
 
 def test_moe_utils_param_wrapper_target_present():
-    """moe_utils.py registers patches against peft.tuners.lora.layer
-    .ParamWrapper. If PEFT renames the class, zoo's split-LoRA grouped-GEMM
-    code path silently falls back to the unwrapped layout."""
+    """moe_utils.py registers patches against
+    peft.tuners.lora.layer.ParamWrapper (split-LoRA grouped-GEMM)."""
     peft = pytest.importorskip("peft")
     try:
         from peft.tuners.lora.layer import ParamWrapper  # noqa: F401
@@ -1768,20 +1471,13 @@ def test_moe_utils_param_wrapper_target_present():
         )
 
 
-# ===========================================================================
-# misc.py (additional patch sites)
-# ---------------------------------------------------------------------------
-# misc.py contains 19 separate ``patch_X`` entries. The existing tests
-# cover ~6 of them. The remainder fall into config-mapping, tokenizer
-# attribute, mask-utils wrap, modernbert mask-strides, lfm2 projector,
-# peft dispatch, trl push-to-hub, vllm chat-template, and qwen2-vl
-# image-processor compat shims. Pin upstream targets for each.
-# ===========================================================================
+# misc.py additional patch sites: config-mapping, tokenizer attrs,
+# mask-utils, modernbert, lfm2, peft dispatch, trl, vllm, qwen2-vl shims.
 
 def test_misc_config_mapping_present_for_ministral3_register():
-    """misc.py:47 imports CONFIG_MAPPING from
-    transformers.models.auto.configuration_auto and calls .register(...)
-    on it. Pin the import path and the mapping has a register method."""
+    """misc.py:47-53 imports CONFIG_MAPPING from
+    transformers.models.auto.configuration_auto + calls
+    ``.register(...)``."""
     try:
         from transformers.models.auto.configuration_auto import CONFIG_MAPPING
     except Exception as exc:
@@ -1800,8 +1496,8 @@ def test_misc_config_mapping_present_for_ministral3_register():
 
 
 def test_misc_ministral_config_top_level_import():
-    """misc.py:48 imports MinistralConfig from top-level transformers as
-    the value side of the ``ministral3`` -> MinistralConfig alias."""
+    """misc.py:48 imports top-level ``transformers.MinistralConfig``
+    (ministral3 alias target)."""
     if not hasattr(transformers, "MinistralConfig"):
         pytest.fail(
             "DRIFT DETECTED: zoo temporary_patches/misc.py:48 expects "
@@ -1811,8 +1507,8 @@ def test_misc_ministral_config_top_level_import():
 
 
 def test_misc_pretrained_tokenizer_base_convert_added_tokens_method():
-    """misc.py:67 expects PreTrainedTokenizerBase.convert_added_tokens
-    to be a classmethod. The patch reassigns it. Pin the attr name."""
+    """misc.py:67 expects
+    ``PreTrainedTokenizerBase.convert_added_tokens`` classmethod."""
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     if not hasattr(PreTrainedTokenizerBase, "convert_added_tokens"):
         pytest.fail(
@@ -1823,12 +1519,10 @@ def test_misc_pretrained_tokenizer_base_convert_added_tokens_method():
 
 
 def test_misc_added_token_class_present():
-    """misc.py:63 imports AddedToken from
-    transformers.tokenization_utils_base. The patched
-    convert_added_tokens constructs AddedToken(**obj)."""
+    """misc.py:63 / :75 imports AddedToken; patched convert_added_tokens
+    constructs ``AddedToken(content=...)``."""
     from transformers.tokenization_utils_base import AddedToken
     sig = inspect.signature(AddedToken)
-    # Pin a couple of expected fields so a rename surfaces here.
     field_names = list(sig.parameters.keys())
     for req in ("content",):
         if req not in field_names:
@@ -1840,8 +1534,8 @@ def test_misc_added_token_class_present():
 
 
 def test_misc_pretrained_tokenizer_base_init_takes_kwargs():
-    """misc.py:97 wraps PreTrainedTokenizerBase.__init__ and rejects /
-    coerces extra_special_tokens. Pin __init__ accepts **kwargs."""
+    """misc.py:97 wraps PreTrainedTokenizerBase.__init__(self, **kwargs)
+    (rejects / coerces extra_special_tokens)."""
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     if not _has_var_keyword(PreTrainedTokenizerBase.__init__):
         pytest.fail(
@@ -1853,11 +1547,9 @@ def test_misc_pretrained_tokenizer_base_init_takes_kwargs():
 
 
 def test_misc_masking_utils_create_block_mask_available_or_compile_flag():
-    """misc.py:391-409 imports BlockMask / create_block_mask from
-    torch.nn.attention.flex_attention and rewrites the masks function on
-    transformers.masking_utils. Pin the upstream masking_utils module
-    has create_causal_mask / create_sliding_window_causal_mask /
-    create_masks_for_generate (all consumed by the patch)."""
+    """misc.py:391-445 imports BlockMask / create_block_mask and rewrites
+    masking_utils.{create_causal_mask, create_sliding_window_causal_mask,
+    create_masks_for_generate}."""
     masking = importlib.import_module("transformers.masking_utils")
     for name in ("create_causal_mask", "create_sliding_window_causal_mask",
                  "create_masks_for_generate"):
@@ -1871,8 +1563,7 @@ def test_misc_masking_utils_create_block_mask_available_or_compile_flag():
 
 def test_misc_generation_utils_create_masks_for_generate():
     """misc.py:447 reassigns
-    transformers.generation.utils.create_masks_for_generate. Pin the
-    attribute exists pre-patch."""
+    ``transformers.generation.utils.create_masks_for_generate``."""
     gu = importlib.import_module("transformers.generation.utils")
     if not hasattr(gu, "create_masks_for_generate"):
         pytest.fail(
@@ -1883,9 +1574,8 @@ def test_misc_generation_utils_create_masks_for_generate():
 
 
 def test_misc_masking_utils_padding_and_packed_helpers():
-    """misc.py:472 / 490 conditionally wraps padding_mask_function and
-    packed_sequence_mask_function on masking_utils. The wraps are
-    gated by hasattr so absence isn't drift, but pin them when present."""
+    """misc.py:472 / :490 wraps padding_mask_function /
+    packed_sequence_mask_function on masking_utils (hasattr-gated)."""
     masking = importlib.import_module("transformers.masking_utils")
     if hasattr(masking, "padding_mask_function"):
         if not callable(masking.padding_mask_function):
@@ -1903,8 +1593,8 @@ def test_misc_masking_utils_padding_and_packed_helpers():
 
 
 def test_misc_sdpa_attention_forward_present():
-    """misc.py:525 patches
-    transformers.integrations.sdpa_attention.sdpa_attention_forward."""
+    """misc.py:525-530 patches
+    ``transformers.integrations.sdpa_attention.sdpa_attention_forward``."""
     try:
         mod = importlib.import_module("transformers.integrations.sdpa_attention")
     except Exception as exc:
@@ -1921,8 +1611,8 @@ def test_misc_sdpa_attention_forward_present():
 
 
 def test_misc_all_attention_functions_modeling_utils_top_level():
-    """misc.py:526 imports ALL_ATTENTION_FUNCTIONS from
-    transformers.modeling_utils. Pin the symbol presence."""
+    """misc.py:526 imports
+    ``transformers.modeling_utils.ALL_ATTENTION_FUNCTIONS``."""
     mu = importlib.import_module("transformers.modeling_utils")
     if not hasattr(mu, "ALL_ATTENTION_FUNCTIONS"):
         pytest.fail(
@@ -1933,9 +1623,8 @@ def test_misc_all_attention_functions_modeling_utils_top_level():
 
 
 def test_misc_modernbert_model_update_attention_mask_present():
-    """misc.py:662 patches ModernBertModel._update_attention_mask. The
-    patch is gated by hasattr; pin the method when ModernBertModel is
-    present so a rename surfaces."""
+    """misc.py:662 patches
+    ``ModernBertModel._update_attention_mask`` (SDPA-stride fix)."""
     cls = _try_get_class(
         "transformers.models.modernbert.modeling_modernbert",
         "ModernBertModel",
@@ -1959,9 +1648,8 @@ def test_misc_modernbert_model_update_attention_mask_present():
 
 def test_misc_csm_for_conditional_generation_merge_input_ids_target_present():
     """misc.py:687 patches
-    CsmForConditionalGeneration._merge_input_ids_with_input_values with
-    a 4-arg replacement (input_ids, input_values, input_values_cutoffs,
-    labels). Pin the upstream method accepts the same names."""
+    ``CsmForConditionalGeneration._merge_input_ids_with_input_values``
+    (input_ids, input_values, input_values_cutoffs, labels)."""
     cls = _try_get_class(
         "transformers.models.csm.modeling_csm", "CsmForConditionalGeneration",
     )
@@ -1979,9 +1667,8 @@ def test_misc_csm_for_conditional_generation_merge_input_ids_target_present():
 
 
 def test_misc_lfm2_vl_multimodal_projector_class_present():
-    """misc.py:1247 patches Lfm2VlMultiModalProjector.__init__ /
-    .forward. Pin class presence; the patch is gated on transformers
-    pre-5.0.0."""
+    """misc.py:1247 patches Lfm2VlMultiModalProjector.{__init__,
+    forward}; transformers pre-5.0.0-gated."""
     cls = _try_get_class(
         "transformers.models.lfm2_vl.modeling_lfm2_vl",
         "Lfm2VlMultiModalProjector",
@@ -1990,7 +1677,6 @@ def test_misc_lfm2_vl_multimodal_projector_class_present():
         pytest.skip(
             f"Lfm2VlMultiModalProjector absent on transformers {_TX_VERSION}"
         )
-    # Patched __init__: def patched_init(self, config, *args, **kwargs)
     _assert_params_superset(
         cls.__init__,
         required=["config"],
@@ -2000,8 +1686,8 @@ def test_misc_lfm2_vl_multimodal_projector_class_present():
 
 
 def test_misc_peft_dispatch_bnb_4bit_target_present():
-    """misc.py:1290 patches peft.tuners.lora.bnb.dispatch_bnb_4bit. Pin
-    the function exists in the installed PEFT."""
+    """misc.py:1289-1290 patches
+    ``peft.tuners.lora.bnb.dispatch_bnb_4bit`` (target, adapter_name)."""
     peft = pytest.importorskip("peft")
     try:
         import peft.tuners.lora.bnb as peft_bnb
@@ -2025,8 +1711,7 @@ def test_misc_peft_dispatch_bnb_4bit_target_present():
 
 
 def test_misc_trl_push_to_hub_target_training_arguments_to_dict():
-    """misc.py:1334 patches TrainingArguments.to_dict on transformers
-    5.0+. Pin the to_dict() target exists."""
+    """misc.py:1333-1334 patches ``TrainingArguments.to_dict`` on 5.0+."""
     if not hasattr(transformers, "TrainingArguments"):
         pytest.fail(
             "DRIFT DETECTED: zoo temporary_patches/misc.py:1333 expects "
@@ -2041,10 +1726,9 @@ def test_misc_trl_push_to_hub_target_training_arguments_to_dict():
 
 
 def test_misc_trl_vision_model_mapping_target_module_present():
-    """misc.py:1363 reads / writes
-    transformers.models.auto.modeling_auto.MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
-    (the 5.0+ name) and
-    MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES (the legacy name). At least one
+    """misc.py:1363-1371 reads
+    ``MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES`` (5.0+) or
+    ``MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES`` (legacy); at least one
     must exist."""
     auto_mod = importlib.import_module(
         "transformers.models.auto.modeling_auto"
@@ -2065,9 +1749,9 @@ def test_misc_trl_vision_model_mapping_target_module_present():
 
 
 def test_misc_apply_chat_template_signature_has_return_dict():
-    """misc.py:1446 checks ``return_dict`` is in
-    PreTrainedTokenizerBase.apply_chat_template signature on
-    transformers 5.0+. Pin the kwarg in the installed signature."""
+    """misc.py:1446-1455 sets ``kwargs['return_dict']=False`` when
+    tokenize=True; needs ``return_dict`` in
+    PreTrainedTokenizerBase.apply_chat_template signature."""
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     sig = inspect.signature(PreTrainedTokenizerBase.apply_chat_template)
     if "return_dict" not in sig.parameters and not _has_var_keyword(
@@ -2082,8 +1766,8 @@ def test_misc_apply_chat_template_signature_has_return_dict():
 
 
 def test_misc_qwen2_vl_image_processor_class_present():
-    """misc.py:1485 imports Qwen2VLImageProcessor and conditionally
-    attaches max_pixels / min_pixels properties. Pin the class."""
+    """misc.py:1485 imports Qwen2VLImageProcessor (max_pixels /
+    min_pixels properties)."""
     cls = _try_get_class(
         "transformers.models.qwen2_vl.image_processing_qwen2_vl",
         "Qwen2VLImageProcessor",
@@ -2094,14 +1778,11 @@ def test_misc_qwen2_vl_image_processor_class_present():
         )
 
 
-# ===========================================================================
-# gpt_oss.py (additional patch sites beyond the existing tests)
-# ===========================================================================
+# gpt_oss.py additional patch sites (beyond existing tests).
 
 def test_gpt_oss_mxfp4_quantizer_class_present():
-    """gpt_oss.py:127 monkey-patches
-    transformers.quantizers.quantizer_mxfp4.Mxfp4HfQuantizer.is_trainable.
-    Pin the class exists. Without it, the patch silently no-ops."""
+    """gpt_oss.py:124-127 patches
+    ``transformers.quantizers.quantizer_mxfp4.Mxfp4HfQuantizer.is_trainable``."""
     try:
         mod = importlib.import_module("transformers.quantizers.quantizer_mxfp4")
     except Exception as exc:
@@ -2119,8 +1800,7 @@ def test_gpt_oss_mxfp4_quantizer_class_present():
 
 def test_gpt_oss_mxfp4_quantizer_is_kernels_available_present():
     """gpt_oss.py:136 reassigns
-    transformers.quantizers.quantizer_mxfp4.is_kernels_available. Pin
-    the symbol."""
+    ``transformers.quantizers.quantizer_mxfp4.is_kernels_available``."""
     mod = importlib.import_module("transformers.quantizers.quantizer_mxfp4")
     if not hasattr(mod, "is_kernels_available"):
         pytest.fail(
@@ -2131,9 +1811,8 @@ def test_gpt_oss_mxfp4_quantizer_is_kernels_available_present():
 
 
 def test_gpt_oss_modeling_module_top_level_classes_present():
-    """gpt_oss.py:1060-1063 reassigns GptOssExperts and GptOssTopKRouter
-    via attribute setting on the modeling module. Pin both class names
-    exist as module attributes (they are the patch targets)."""
+    """gpt_oss.py:1060-1063 reassigns ``modeling_gpt_oss.GptOssExperts``
+    and ``.GptOssTopKRouter`` (BnB 4-bit GPT-OSS shim)."""
     mod = importlib.import_module(
         "transformers.models.gpt_oss.modeling_gpt_oss"
     )
@@ -2148,9 +1827,8 @@ def test_gpt_oss_modeling_module_top_level_classes_present():
 
 
 def test_gpt_oss_layer_type_validation_module_path():
-    """gpt_oss.py near the config patch reads ``layer_type_validation``
-    via the rope_utils path used by configuration_gpt_oss.py. Pin
-    via configuration module symbol."""
+    """gpt_oss.py:2801-2803 reads
+    ``transformers.models.gpt_oss.configuration_gpt_oss.GptOssConfig``."""
     try:
         cfg_mod = importlib.import_module(
             "transformers.models.gpt_oss.configuration_gpt_oss"
@@ -2170,9 +1848,8 @@ def test_gpt_oss_layer_type_validation_module_path():
 
 
 def test_gpt_oss_pretrained_model_present():
-    """gpt_oss.py:2832 reads
-    transformers.models.gpt_oss.modeling_gpt_oss.GptOssPreTrainedModel
-    as the patch target for _init_weights."""
+    """gpt_oss.py:2832 reads ``GptOssPreTrainedModel`` for
+    _init_weights patch."""
     mod = importlib.import_module(
         "transformers.models.gpt_oss.modeling_gpt_oss"
     )
@@ -2185,9 +1862,8 @@ def test_gpt_oss_pretrained_model_present():
 
 
 def test_gpt_oss_model_module_dynamic_cache_present():
-    """gpt_oss.py:2126 imports DynamicCache from gpt_oss modeling.
-    Already pinned by sibling test; here we pin from
-    transformers.cache_utils as the canonical fallback path."""
+    """gpt_oss.py:2126 fallback path pins
+    ``transformers.cache_utils.DynamicCache``."""
     cu = importlib.import_module("transformers.cache_utils")
     if not hasattr(cu, "DynamicCache"):
         pytest.fail(
@@ -2198,9 +1874,8 @@ def test_gpt_oss_model_module_dynamic_cache_present():
 
 
 def test_gpt_oss_attention_apply_rotary_pos_emb_imported_at_attention():
-    """gpt_oss.py:1875+ imports apply_rotary_pos_emb from the gpt_oss
-    modeling module for GptOssAttention.forward. Pin via separate
-    re-export check at a different line than the existing sibling test."""
+    """gpt_oss.py:1875 imports ``apply_rotary_pos_emb(q, k, cos, sin)``
+    (4 positionals) from modeling_gpt_oss."""
     mod = importlib.import_module(
         "transformers.models.gpt_oss.modeling_gpt_oss"
     )
@@ -2210,8 +1885,6 @@ def test_gpt_oss_attention_apply_rotary_pos_emb_imported_at_attention():
             "DRIFT DETECTED: zoo temporary_patches/gpt_oss.py:1875 expects "
             "modeling_gpt_oss.apply_rotary_pos_emb but it is missing"
         )
-    # apply_rotary_pos_emb is called as
-    #   apply_rotary_pos_emb(q, k, cos, sin) -> 4 positional args.
     params = [
         p for p in inspect.signature(apply).parameters.values()
         if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD,
@@ -2227,9 +1900,8 @@ def test_gpt_oss_attention_apply_rotary_pos_emb_imported_at_attention():
 
 
 def test_gpt_oss_eager_attention_forward_present():
-    """gpt_oss.py:2063 calls eager_attention_forward(self, q, k, v,
-    mask, dropout=..., scaling=..., sliding_window=..., s_aux=...,
-    **kwargs). Pin those by-name params on the upstream helper."""
+    """gpt_oss.py:2063 calls ``eager_attention_forward(self, q, k, v,
+    mask, ...)`` (5+ positionals)."""
     mod = importlib.import_module(
         "transformers.models.gpt_oss.modeling_gpt_oss"
     )
@@ -2240,8 +1912,7 @@ def test_gpt_oss_eager_attention_forward_present():
             "modeling_gpt_oss.eager_attention_forward but it is missing on "
             f"transformers {_TX_VERSION}"
         )
-    # Be lenient: only require the positional arity since the kwarg names
-    # change across transformers releases.
+    # Lenient: only positional arity (kwarg names change across releases).
     params = [
         p for p in inspect.signature(fn).parameters.values()
         if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD,
@@ -2256,15 +1927,12 @@ def test_gpt_oss_eager_attention_forward_present():
         )
 
 
-# ===========================================================================
-# gemma.py (Gemma3DecoderLayer, Gemma3TextModel survival as transitive
-# patch dependencies)
-# ===========================================================================
+# gemma.py transitive deps: Gemma3DecoderLayer, Gemma3TextModel,
+# Gemma3PreTrainedModel.
 
 def test_gemma3_decoder_layer_class_present():
-    """gemma.py imports Gemma3Attention from modeling_gemma3 and patches
-    Gemma3Attention.forward. The decoder layer is the parent and must
-    exist as a sibling pin so a rename surfaces."""
+    """gemma.py imports Gemma3Attention; the decoder-layer parent
+    Gemma3DecoderLayer must exist."""
     cls = _try_get_class(
         "transformers.models.gemma3.modeling_gemma3", "Gemma3DecoderLayer",
     )
@@ -2276,9 +1944,8 @@ def test_gemma3_decoder_layer_class_present():
 
 
 def test_gemma3_text_model_class_present():
-    """gemma.py:233 references Gemma3Model (the multimodal model). The
-    underlying text-only model Gemma3TextModel is the LM head's
-    backbone; pin it."""
+    """gemma.py:233 references Gemma3Model; pin Gemma3TextModel
+    (LM head backbone)."""
     cls = _try_get_class(
         "transformers.models.gemma3.modeling_gemma3", "Gemma3TextModel",
     )
@@ -2290,8 +1957,7 @@ def test_gemma3_text_model_class_present():
 
 
 def test_gemma3_pre_trained_model_class_present():
-    """gemma.py touches Gemma3 model surfaces -- Gemma3PreTrainedModel
-    is the base class. Pin its existence."""
+    """gemma.py touches Gemma3 surfaces; pin Gemma3PreTrainedModel base."""
     cls = _try_get_class(
         "transformers.models.gemma3.modeling_gemma3", "Gemma3PreTrainedModel",
     )
@@ -2303,9 +1969,8 @@ def test_gemma3_pre_trained_model_class_present():
 
 
 def test_gemma3_processor_kwargs_class_present():
-    """gemma.py:218 reads
-    transformers.models.gemma3.processing_gemma3.Gemma3ProcessorKwargs as
-    an Unpack type for __call__."""
+    """gemma.py:218 reads ``Gemma3ProcessorKwargs`` (Unpack type for
+    __call__)."""
     mod = importlib.import_module(
         "transformers.models.gemma3.processing_gemma3"
     )
@@ -2317,13 +1982,11 @@ def test_gemma3_processor_kwargs_class_present():
         )
 
 
-# ===========================================================================
-# gemma3n.py (additional pins)
-# ===========================================================================
+# gemma3n.py additional pins.
 
 def test_gemma3n_for_conditional_generation_class_present():
-    """gemma3n.py patches Gemma3nModel.get_placeholder_mask. The
-    conditional-generation head pins its existence."""
+    """gemma3n.py patches Gemma3nModel.get_placeholder_mask; pin
+    Gemma3nForConditionalGeneration."""
     cls = _try_get_class(
         "transformers.models.gemma3n.modeling_gemma3n",
         "Gemma3nForConditionalGeneration",
@@ -2336,10 +1999,8 @@ def test_gemma3n_for_conditional_generation_class_present():
 
 
 def test_gemma3n_RMSNorm_class_present():
-    """gemma3n.py:53 defines a Gemma3nRMSNorm_forward helper that the
-    patched MultimodalEmbedder forward delegates to. The actual upstream
-    class must exist so the patched forward's call to self.weight,
-    self._norm continues to compile."""
+    """gemma3n.py:53 Gemma3nRMSNorm_forward delegate needs upstream
+    Gemma3nRMSNorm class (self.weight / self._norm references)."""
     cls = _try_get_class(
         "transformers.models.gemma3n.modeling_gemma3n", "Gemma3nRMSNorm",
     )
@@ -2350,14 +2011,11 @@ def test_gemma3n_RMSNorm_class_present():
         )
 
 
-# ===========================================================================
-# qwen3_moe.py / qwen3_5_moe.py / qwen3_next_moe.py shared deps
-# ===========================================================================
+# qwen3_moe.py / qwen3_5_moe.py / qwen3_next_moe.py shared deps.
 
 def test_qwen3_moe_rms_norm_class_present():
-    """qwen3_moe.py's patched forward calls .gate(...) and .experts(...)
-    -- the parent module sets these as Linear / ModuleList. Pin a
-    well-known sibling class so a wholesale namespace rename surfaces."""
+    """qwen3_moe.py patched forward calls .gate / .experts; pin
+    Qwen3MoeRMSNorm sibling so namespace rename surfaces."""
     cls = _try_get_class(
         "transformers.models.qwen3_moe.modeling_qwen3_moe", "Qwen3MoeRMSNorm",
     )
@@ -2369,9 +2027,8 @@ def test_qwen3_moe_rms_norm_class_present():
 
 
 def test_qwen3_moe_pre_trained_model_present():
-    """qwen3_moe.py patches Qwen3MoeForCausalLM.forward -- the base
-    Qwen3MoePreTrainedModel must exist as a sibling class so the heads
-    inherit from a stable parent."""
+    """qwen3_moe.py patches Qwen3MoeForCausalLM.forward; pin
+    Qwen3MoePreTrainedModel base."""
     cls = _try_get_class(
         "transformers.models.qwen3_moe.modeling_qwen3_moe",
         "Qwen3MoePreTrainedModel",
@@ -2384,8 +2041,8 @@ def test_qwen3_moe_pre_trained_model_present():
 
 
 def test_qwen3_moe_model_present():
-    """qwen3_moe.py:170-179 inside _patch_causal_lm_forward_for_hidden_states
-    calls self.model(input_ids=..., ...). self.model is Qwen3MoeModel."""
+    """qwen3_moe.py:170-179 calls self.model(...); self.model is
+    Qwen3MoeModel."""
     cls = _try_get_class(
         "transformers.models.qwen3_moe.modeling_qwen3_moe", "Qwen3MoeModel",
     )
@@ -2398,8 +2055,7 @@ def test_qwen3_moe_model_present():
 
 
 def test_qwen3_next_model_class_present():
-    """qwen3_next_moe.py imports Qwen3NextForCausalLM. Its inner model
-    Qwen3NextModel must exist."""
+    """qwen3_next_moe.py needs inner ``Qwen3NextModel``."""
     cls = _try_get_class(
         "transformers.models.qwen3_next.modeling_qwen3_next", "Qwen3NextModel",
     )
@@ -2411,8 +2067,8 @@ def test_qwen3_next_model_class_present():
 
 
 def test_qwen3_vl_moe_text_model_class_present():
-    """qwen3_vl_moe.py patches Qwen3VLMoeTextSparseMoeBlock. The text
-    model Qwen3VLMoeTextModel is the parent stack -- pin it."""
+    """qwen3_vl_moe.py patches Qwen3VLMoeTextSparseMoeBlock; pin parent
+    Qwen3VLMoeTextModel."""
     cls = _try_get_class(
         "transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe",
         "Qwen3VLMoeTextModel",
@@ -2424,15 +2080,12 @@ def test_qwen3_vl_moe_text_model_class_present():
         )
 
 
-# ===========================================================================
-# Cache-output-class signature pins (zoo constructs these by kwarg in
-# several patch wrappers)
-# ===========================================================================
+# Cache-output-class signature pins (constructed by zoo patch wrappers).
 
 def test_modeling_outputs_causal_lm_output_with_past_kwargs():
-    """deepseek_v3_moe.py:200 and qwen3_next_moe.py construct
-    transformers.modeling_outputs.CausalLMOutputWithPast(loss, logits,
-    past_key_values, hidden_states, attentions). Pin the field set."""
+    """deepseek_v3_moe.py:200 + qwen3_next_moe.py construct
+    ``transformers.modeling_outputs.CausalLMOutputWithPast(loss, logits,
+    past_key_values, hidden_states, attentions)``."""
     from transformers.modeling_outputs import CausalLMOutputWithPast
     sig = inspect.signature(CausalLMOutputWithPast)
     field_names = list(sig.parameters.keys())
@@ -2446,9 +2099,9 @@ def test_modeling_outputs_causal_lm_output_with_past_kwargs():
 
 
 def test_modeling_outputs_moe_causal_lm_output_with_past_kwargs():
-    """qwen3_moe.py:191 constructs MoeCausalLMOutputWithPast(loss,
+    """qwen3_moe.py:191 constructs ``MoeCausalLMOutputWithPast(loss,
     logits, past_key_values, hidden_states, attentions, aux_loss,
-    router_logits). Pin top-level transformers.modeling_outputs path."""
+    router_logits)`` via top-level modeling_outputs."""
     from transformers.modeling_outputs import MoeCausalLMOutputWithPast
     sig = inspect.signature(MoeCausalLMOutputWithPast)
     field_names = list(sig.parameters.keys())
@@ -2461,12 +2114,10 @@ def test_modeling_outputs_moe_causal_lm_output_with_past_kwargs():
             )
 
 
-# ===========================================================================
-# Caches the patches require (zoo passes past_key_values=Cache())
-# ===========================================================================
+# Caches the patches require.
 
 def test_static_cache_class_present():
-    """gemma.py:255 isinstance(past_key_values, StaticCache). Pin."""
+    """gemma.py:255 isinstance(past_key_values, StaticCache)."""
     cu = importlib.import_module("transformers.cache_utils")
     if not hasattr(cu, "StaticCache"):
         pytest.fail(
@@ -2477,7 +2128,7 @@ def test_static_cache_class_present():
 
 
 def test_hybrid_cache_class_present():
-    """gemma.py:260 isinstance(past_key_values, HybridCache). Pin."""
+    """gemma.py:260 isinstance(past_key_values, HybridCache)."""
     cu = importlib.import_module("transformers.cache_utils")
     if not hasattr(cu, "HybridCache"):
         pytest.fail(
@@ -2487,15 +2138,13 @@ def test_hybrid_cache_class_present():
         )
 
 
-# ===========================================================================
-# bitsandbytes.py: process_output_options / utils.py helpers consumed
-# ===========================================================================
+# bitsandbytes.py: Linear4bit __init__ signature pin.
 
 def test_bitsandbytes_linear4bit_init_signature():
-    """bitsandbytes.py:46-47 looks up
-    bitsandbytes.nn.modules.Linear4bit. Pin __init__ accepts at least
-    the input_features / output_features positional args zoo's patched
-    forward implicitly assumes (self.weight, self.bias, etc.)."""
+    """bitsandbytes.py:46-47 needs
+    ``bitsandbytes.nn.modules.Linear4bit.__init__(input_features,
+    output_features, ...)`` (zoo's patched forward dereferences
+    self.weight / self.bias)."""
     bnb = pytest.importorskip("bitsandbytes")
     cls = getattr(bnb.nn.modules, "Linear4bit", None)
     if cls is None:
@@ -2511,14 +2160,10 @@ def test_bitsandbytes_linear4bit_init_signature():
     )
 
 
-# ===========================================================================
-# pixtral.py: PixtralVisionConfig + module-level apply_rotary_pos_emb pin
-# (additional)
-# ===========================================================================
+# pixtral.py: PixtralVisionConfig.
 
 def test_pixtral_vision_config_class_present():
-    """pixtral.py reads self.config.hidden_size etc on the patched
-    __init__ -- PixtralVisionConfig is the upstream config."""
+    """pixtral.py:36 reads self.config attrs; pin PixtralVisionConfig."""
     cls = _try_get_class(
         "transformers.models.pixtral.configuration_pixtral",
         "PixtralVisionConfig",
@@ -2531,13 +2176,11 @@ def test_pixtral_vision_config_class_present():
         )
 
 
-# ===========================================================================
-# gemma3n.py: gemma3n_TextConfig pin (used by config typing of AltUp)
-# ===========================================================================
+# gemma3n.py: Gemma3nTextConfig pin (AltUp.predict config typing).
 
 def test_gemma3n_text_config_class_present():
-    """gemma3n.py reads self.config.altup_active_idx etc inside the
-    patched AltUp.predict. Gemma3nTextConfig is the upstream config."""
+    """gemma3n.py:101-114 reads
+    self.config.{altup_num_inputs, altup_active_idx} in AltUp.predict."""
     cls = _try_get_class(
         "transformers.models.gemma3n.configuration_gemma3n",
         "Gemma3nTextConfig",
@@ -2559,14 +2202,11 @@ def test_gemma3n_text_config_class_present():
             )
 
 
-# ===========================================================================
-# Auto-attention function dictionary for the gemma3 patch chain
-# ===========================================================================
+# Auto-attention function dictionary for gemma3 patch chain.
 
 def test_gemma3_eager_attention_forward_kwargs_supported():
-    """gemma.py:407 calls eager_attention_forward(...,
-    dropout=..., scaling=..., sliding_window=..., **kwargs).
-    Pin those kwargs by-name."""
+    """gemma.py:407-412 calls ``eager_attention_forward(...,
+    dropout, scaling, sliding_window, **kwargs)``."""
     from transformers.models.gemma3.modeling_gemma3 import eager_attention_forward
     if not _has_var_keyword(eager_attention_forward):
         pytest.fail(
@@ -2577,14 +2217,10 @@ def test_gemma3_eager_attention_forward_kwargs_supported():
         )
 
 
-# ===========================================================================
-# Sanity: at least one TEMPORARY_PATCHES entry per file is registered
-# ===========================================================================
+# Sanity: temporary_patches/ inventory.
 
 def test_temporary_patches_directory_has_expected_files():
-    """Pin the set of patch files. If a file is added/removed, the
-    suite should adapt -- this test surfaces drift in the patch-file
-    inventory itself."""
+    """Pin the floor set of patch files; new files OK, missing -> DRIFT."""
     pkg_spec = importlib.util.find_spec("unsloth_zoo.temporary_patches")
     if pkg_spec is None or not pkg_spec.submodule_search_locations:
         pytest.skip("unsloth_zoo.temporary_patches not importable as a package")
@@ -2594,8 +2230,6 @@ def test_temporary_patches_directory_has_expected_files():
         if f.endswith(".py")
         and f not in ("__init__.py", "utils.py", "common.py")
     }
-    # Sanity floor: at minimum these files must exist. New files can be
-    # added freely without bumping this list.
     must_have = {
         "bitsandbytes.py", "deepseek_v3_moe.py", "gemma.py", "gemma3n.py",
         "gemma4.py", "gemma4_moe.py", "glm4_moe.py", "gpt_oss.py",

--- a/tests/test_upstream_import_fixes_drift.py
+++ b/tests/test_upstream_import_fixes_drift.py
@@ -11,39 +11,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
-"""Drift detectors for the class of upstream pathologies that
-``unsloth/import_fixes.py`` works around.
+"""Drift detectors for the ``unsloth/import_fixes.py`` workarounds.
 
-Every test in this file maps 1:1 to a ``fix_*`` / ``patch_*`` function
-in the unsloth package's ``import_fixes.py``. The fix function is a
-hand-rolled workaround for a specific upstream regression (protobuf
-``MessageFactory`` drift, datasets 4.4.x recursion, TRL tuple-vs-bool
-``_*_available`` caching, transformers ``enable_input_require_grads``
-source pattern flip, triton ``CompiledKernel`` missing attrs, etc.).
-
-``unsloth-zoo`` depends on the same upstream wheels but has NO test
-today that screams when one of these pathologies is currently ACTIVE
-on the installed stack. This suite is the drift detector.
-
-Contract for each test:
-
-  * Assert the *healthy* shape that the fix expects the upstream lib
-    to have ABSENT the regression.
-  * If the optional library isn't installed at all, ``importorskip``
-    the test (not relevant to this install).
-  * If the pathology is currently ACTIVE on this install, surface it
-    as ``pytest.fail("DRIFT DETECTED: <fix function> needed because
-    <observation>")`` so CI stays green locally but the drift is loud
-    in the verbose log -- exactly the same pattern a maintainer would
-    use to triage which fix has stopped being a no-op.
-  * Tests that require a GPU / specific accelerator skip cleanly on
-    CPU-only boxes.
-
-Every test cites the source-of-truth ``import_fixes.py`` function and
-line range it was reduced from, so when the workaround is removed or
-renamed upstream we can find the matching detector quickly.
-
-Runs under the GPU-free harness in ``tests/conftest.py``.
+Every test maps 1:1 to a ``fix_*`` / ``patch_*`` in ``import_fixes.py``.
+DRIFT-DETECTED framing: assert the healthy shape; surface an active
+pathology as ``pytest.fail("DRIFT DETECTED: ...")``; ``importorskip``
+genuinely optional libs. Each test cites the source-of-truth file:line.
 """
 
 from __future__ import annotations
@@ -59,26 +32,17 @@ from importlib.metadata import version as importlib_version
 import pytest
 
 
-# ---------------------------------------------------------------------------
-# Small helper: a tolerant parsed Version. Mirrors the local ``Version()``
-# in import_fixes.py (lines 51-68): strip dev / alpha / beta / rc suffixes
-# so packaging.Version doesn't choke on, say, "0.0.33.post2" or
-# "0.15.1+cu130".
-# ---------------------------------------------------------------------------
-
+# Mirrors Version() in import_fixes.py (51-68): strips dev/post/local
+# suffixes so packaging.Version handles "0.0.33.post2" / "0.15.1+cu130".
 from packaging.version import Version as _PkgVersion
 
 
 def _safe_version(raw):
-    """Parse a raw distribution version into packaging.Version, stripping
-    local identifiers and exotic dev / post suffixes if needed."""
     raw_str = str(raw)
-    # Drop local identifier (+cu130, +rocm6.3, +cpu, etc.)
     base = raw_str.split("+", 1)[0]
     try:
         return _PkgVersion(base)
     except Exception:
-        # Fallback: re-extract a [0-9.]+ prefix.
         match = re.match(r"[0-9]+(?:\.[0-9]+)*", base)
         if not match:
             raise
@@ -91,15 +55,9 @@ def _safe_version(raw):
 
 
 def test_protobuf_message_factory_get_prototype_or_get_message_class_present():
-    """Drift detector for ``fix_message_factory_issue``
-    (import_fixes.py lines 264-308).
-
-    The fix monkey-patches ``google.protobuf.message_factory.MessageFactory``
-    when ``GetPrototype`` is gone AND no ``GetMessageClass`` fallback
-    exists. On a healthy install ONE of these must be reachable, since
-    tensorflow / sentencepiece-driven tokenizer load paths call into
-    one of them. Asserts the post-fix invariant.
-    """
+    """``fix_message_factory_issue`` (import_fixes.py 264-308). On a healthy
+    install ``MessageFactory.GetPrototype`` OR module-level
+    ``GetMessageClass`` must be reachable."""
     mf = pytest.importorskip("google.protobuf.message_factory")
     has_mf_class = hasattr(mf, "MessageFactory")
     has_get_prototype = has_mf_class and hasattr(
@@ -126,14 +84,9 @@ def test_protobuf_message_factory_get_prototype_or_get_message_class_present():
 
 
 def test_datasets_version_not_in_broken_recursion_range():
-    """Drift detector for ``patch_datasets``
-    (import_fixes.py lines 574-586).
-
-    ``datasets`` 4.4.0 through 4.5.0 (inclusive) trigger
-    ``_thread.RLock_recursion_count`` recursion errors deep in the
-    Arrow loader. Unsloth raises ``NotImplementedError`` for that
-    range. Assert the installed version is outside it.
-    """
+    """``patch_datasets`` (import_fixes.py 574-586). datasets 4.4.0-4.5.0
+    inclusive triggers ``_thread.RLock_recursion_count`` errors deep in the
+    Arrow loader; assert the installed version is outside it."""
     pytest.importorskip("datasets")
     ds_v = _safe_version(importlib_version("datasets"))
     lo = _PkgVersion("4.4.0")
@@ -151,18 +104,10 @@ def test_datasets_version_not_in_broken_recursion_range():
 
 
 def test_trl_is_x_available_returns_bool_not_tuple():
-    """Drift detector for ``fix_trl_vllm_ascend``
-    (import_fixes.py lines 493-516).
-
-    transformers >= 4.48's ``_is_package_available(name)`` returns a
-    ``(bool, version_or_None)`` tuple. TRL's module-level
-    ``_*_available`` flags cache that tuple, and ``is_*_available()``
-    returns it directly. A non-empty tuple is always truthy, so
-    ``if is_vllm_available():`` fires even when vllm is absent and
-    triggers an unconditional ``import vllm`` that hard-crashes on
-    Ascend hosts (and any non-vllm host). Healthy state: every
-    ``is_*_available()`` returns a real ``bool``.
-    """
+    """``fix_trl_vllm_ascend`` (import_fixes.py 493-516). transformers
+    >=4.48's ``_is_package_available`` returns ``(bool, version)``; TRL
+    caches that tuple as truthy, firing unconditional ``import vllm``.
+    Healthy state: every ``is_*_available()`` returns a real bool."""
     pytest.importorskip("trl")
     try:
         import trl.import_utils as tiu
@@ -182,7 +127,6 @@ def test_trl_is_x_available_returns_bool_not_tuple():
     for name in accessor_names:
         accessor = getattr(tiu, name)
         try:
-            # Some accessors take args; skip those rather than guess.
             sig = inspect.signature(accessor)
             required = [
                 p
@@ -210,14 +154,9 @@ def test_trl_is_x_available_returns_bool_not_tuple():
 
 
 def test_trl_cached_available_flags_are_not_tuples():
-    """Drift detector for ``fix_trl_vllm_ascend``
-    (import_fixes.py lines 493-516).
-
-    Same pathology as above but checks the module-level cached
-    ``_*_available`` attributes directly -- this is where the tuple
-    drift actually lives. Healthy state: each ``_X_available`` is a
-    bool (or a callable/sentinel), never a tuple.
-    """
+    """``fix_trl_vllm_ascend`` (import_fixes.py 493-516). Same pathology
+    as above but checks the module-level cached ``_*_available`` attrs --
+    this is where the tuple drift actually lives."""
     pytest.importorskip("trl")
     try:
         import trl.import_utils as tiu
@@ -244,18 +183,11 @@ def test_trl_cached_available_flags_are_not_tuples():
 
 
 def test_pretrained_model_enable_input_require_grads_uses_old_pattern():
-    """Drift detector for ``patch_enable_input_require_grads``
-    (import_fixes.py lines 609-670).
-
-    transformers PR #41993 rewrote
-    ``PreTrainedModel.enable_input_require_grads`` to iterate via
-    ``for module in self.modules()`` and call
-    ``module.get_input_embeddings()`` on every submodule. Vision
-    sub-modules (GLM V4.6's ``self.visual``) raise
-    ``NotImplementedError`` from that accessor and crash the
-    whole call. Healthy (= pre-regression) state: source does NOT
-    contain ``for module in self.modules()``.
-    """
+    """``patch_enable_input_require_grads`` (import_fixes.py 609-670).
+    transformers PR #41993 rewrote ``enable_input_require_grads`` to
+    iterate ``for module in self.modules()`` and call
+    ``module.get_input_embeddings()``, which raises NotImplementedError
+    on vision sub-modules (GLM V4.6's ``self.visual``)."""
     pytest.importorskip("transformers")
     from transformers import PreTrainedModel
 
@@ -274,13 +206,9 @@ def test_pretrained_model_enable_input_require_grads_uses_old_pattern():
 
 
 def test_transformers_torchcodec_available_flag_is_present():
-    """Drift detector for ``disable_torchcodec_if_broken``
-    (import_fixes.py lines 1291-1317).
-
-    Unsloth flips ``transformers.utils.import_utils._torchcodec_available``
-    to ``False`` when torchcodec is installed but can't load its
-    native FFmpeg deps. The flag must exist for the patch to land.
-    """
+    """``disable_torchcodec_if_broken`` (import_fixes.py 1291-1317).
+    Flips ``transformers.utils.import_utils._torchcodec_available`` to
+    False when torchcodec's native FFmpeg deps fail to load."""
     tf_iu = pytest.importorskip("transformers.utils.import_utils")
     assert hasattr(tf_iu, "_torchcodec_available"), (
         "transformers.utils.import_utils._torchcodec_available was "
@@ -290,16 +218,10 @@ def test_transformers_torchcodec_available_flag_is_present():
 
 
 def test_transformers_is_causal_conv1d_available_symbol_present():
-    """Drift detector for ``_disable_transformers_causal_conv1d``
-    (import_fixes.py lines 1881-1895).
-
-    Unsloth needs ``transformers.utils.import_utils`` to expose
-    EITHER an ``is_causal_conv1d_available`` callable OR one of the
-    ``_causal_conv1d_available`` / ``_is_causal_conv1d_available``
-    cached flags so it can monkey-patch a broken-binary install to
-    ``False``. If transformers drops them ALL, the disable path
-    silently no-ops and model imports hard-fail later.
-    """
+    """``_disable_transformers_causal_conv1d`` (import_fixes.py 1881-1895).
+    Needs at least one of ``is_causal_conv1d_available`` /
+    ``_causal_conv1d_available`` / ``_is_causal_conv1d_available`` to
+    mask a broken-binary causal_conv1d install."""
     tf_iu = pytest.importorskip("transformers.utils.import_utils")
     candidates = [
         "is_causal_conv1d_available",
@@ -321,16 +243,10 @@ def test_transformers_is_causal_conv1d_available_symbol_present():
 
 
 def test_transformers_and_accelerate_is_wandb_available_callable():
-    """Drift detector for ``disable_broken_wandb``
-    (import_fixes.py lines 1320-1372).
-
-    Unsloth patches BOTH
-    ``transformers.integrations.integration_utils.is_wandb_available``
-    AND ``accelerate.utils.imports.is_wandb_available`` /
-    ``accelerate.utils.is_wandb_available``. The fix matters because
-    a protobuf mismatch can make ``import wandb`` raise. Both
-    accessor locations must continue to exist.
-    """
+    """``disable_broken_wandb`` (import_fixes.py 1320-1372). Patches
+    ``is_wandb_available`` on transformers.integrations.integration_utils,
+    accelerate.utils.imports, AND accelerate.utils (a protobuf mismatch
+    can make ``import wandb`` raise). All three locations must exist."""
     pytest.importorskip("transformers")
     pytest.importorskip("accelerate")
     from transformers.integrations import integration_utils as tf_integration
@@ -359,19 +275,12 @@ def test_transformers_and_accelerate_is_wandb_available_callable():
 
 
 def test_peft_transformers_weight_conversion_importable_and_signature():
-    """Drift detector for ``patch_peft_weight_converter_compatibility``
-    (import_fixes.py lines 1375-1454).
-
-    Unsloth wraps ``peft.utils.transformers_weight_conversion.
-    build_peft_weight_mapping`` to retrofit ``distributed_operation``
-    and ``quantization_operation`` kwargs onto legacy converter
-    ctors. Healthy state: module imports cleanly AND the function
-    signature still accepts ``(weight_conversions, adapter_name,
-    peft_config=None)``. If the module is unimportable on the
-    current peft/transformers pair, that IS the drift (the fix's
-    bare ``except (ImportError, AttributeError): return`` would
-    silently no-op).
-    """
+    """``patch_peft_weight_converter_compatibility`` (import_fixes.py
+    1375-1454). Wraps ``build_peft_weight_mapping`` to retrofit
+    ``distributed_operation`` / ``quantization_operation`` kwargs;
+    must import cleanly AND keep
+    ``(weight_conversions, adapter_name, peft_config=None)``. An
+    unimportable module IS drift -- the fix's bare except silently no-ops."""
     pytest.importorskip("peft")
     try:
         from peft.utils import transformers_weight_conversion as twc
@@ -401,36 +310,20 @@ def test_peft_transformers_weight_conversion_importable_and_signature():
 
 
 def test_triton_compiled_kernel_has_num_ctas_and_cluster_dims():
-    """Drift detector for ``fix_triton_compiled_kernel_missing_attrs``
-    (import_fixes.py lines 923-968).
-
-    triton 3.6.0+ dropped direct ``num_ctas`` / ``cluster_dims``
-    attributes on ``CompiledKernel`` but torch 2.9.x Inductor's
-    ``make_launcher`` still eagerly evaluates ``binary.metadata.num_ctas,
-    *binary.metadata.cluster_dims``. Without the fix, torch.compile
-    paths blow up before reaching the new launch contract. Healthy
-    state: a freshly-constructed CompiledKernel has both attrs.
-    """
+    """``fix_triton_compiled_kernel_missing_attrs`` (import_fixes.py
+    923-968). triton 3.6.0+ dropped ``num_ctas`` / ``cluster_dims`` on
+    CompiledKernel but torch 2.9.x Inductor still eagerly evaluates them
+    -- without the fix torch.compile paths blow up before reaching the
+    new launch contract."""
     pytest.importorskip("torch")
     triton_mod = pytest.importorskip("triton")  # noqa: F841
     tc = pytest.importorskip("triton.compiler.compiler")
 
     ck_cls = tc.CompiledKernel
-    # Two healthy shapes:
-    #   * pre-3.6 triton (or a future fix) exposes ``num_ctas`` as a
-    #     class attribute -- the upstream pathology is gone.
-    #   * post-3.6 triton with unsloth's fix applied: the class still
-    #     lacks the attr but ``CompiledKernel.__init__`` has been
-    #     wrapped to install both attrs on each new instance, which is
-    #     enough to satisfy torch Inductor's
-    #     ``hasattr(binary, "num_ctas")`` probe at launch time.
+    # Healthy if either: pre-3.6 class attr present, or unsloth wrapped
+    # ``__init__`` to install num_ctas + cluster_dims per instance.
     if hasattr(ck_cls, "num_ctas"):
-        return  # healthy: old-style triton with direct class attr
-    # Detect the instance-level wrapped __init__. Unsloth's
-    # ``fix_triton_compiled_kernel_missing_attrs`` rebinds the class's
-    # ``__init__`` to a closure named ``_patched_init`` whose qualname
-    # / source contains the num_ctas + cluster_dims injection. Probing
-    # the closure cells / co_freevars is GPU-free and idempotent.
+        return
     init = getattr(ck_cls, "__init__", None)
     if init is not None:
         code = getattr(init, "__code__", None)
@@ -439,7 +332,7 @@ def test_triton_compiled_kernel_has_num_ctas_and_cluster_dims():
         if "_orig_init" in freevars or {"num_ctas", "cluster_dims"}.issubset(
             co_names
         ):
-            return  # healthy: unsloth's __init__ wrapper is installed
+            return
 
     pytest.fail(
         "DRIFT DETECTED: triton.CompiledKernel lacks the `num_ctas` "
@@ -457,7 +350,7 @@ def test_triton_compiled_kernel_has_num_ctas_and_cluster_dims():
 
 
 # Mirrors TORCH_TORCHVISION_COMPAT in torchvision_compatibility_check
-# (import_fixes.py lines 708-798).
+# (import_fixes.py 708-798).
 _TORCH_TORCHVISION_COMPAT = {
     (2, 9): (0, 24),
     (2, 8): (0, 23),
@@ -469,8 +362,7 @@ _TORCH_TORCHVISION_COMPAT = {
 
 
 def _is_custom_torch_build(raw_version_str):
-    """Same logic as import_fixes._is_custom_torch_build
-    (lines 673-689)."""
+    """Same logic as import_fixes._is_custom_torch_build (673-689)."""
     if "+" not in raw_version_str:
         return False
     local = raw_version_str.split("+", 1)[1]
@@ -482,15 +374,9 @@ def _is_custom_torch_build(raw_version_str):
 
 
 def test_installed_torch_torchvision_pair_is_compatible():
-    """Drift detector for ``torchvision_compatibility_check``
-    (import_fixes.py lines 708-798).
-
-    Unsloth raises ``ImportError`` when the installed torch /
-    torchvision pair doesn't satisfy the known compatibility table.
-    Custom or prerelease torch builds get downgraded to warning.
-    Mirror that table here: assert the installed pair satisfies it
-    or skip cleanly for custom / prerelease builds.
-    """
+    """``torchvision_compatibility_check`` (import_fixes.py 708-798).
+    Mirrors the upstream compat table; custom or prerelease builds get
+    downgraded to a warning, so this test skips for those."""
     pytest.importorskip("torch")
     pytest.importorskip("torchvision")
 
@@ -502,7 +388,6 @@ def test_installed_torch_torchvision_pair_is_compatible():
     torch_major = torch_v.release[0]
     torch_minor = torch_v.release[1] if len(torch_v.release) > 1 else 0
 
-    # Only assert for entries that exist in the pinned table.
     required = _TORCH_TORCHVISION_COMPAT.get((torch_major, torch_minor))
     if required is None:
         pytest.skip(
@@ -538,14 +423,10 @@ def test_installed_torch_torchvision_pair_is_compatible():
 
 
 def test_vllm_guided_decoding_params_or_structured_outputs_present():
-    """Drift detector for ``fix_vllm_guided_decoding_params``
-    (import_fixes.py lines 446-490).
-
-    vLLM PR #22772 renamed ``GuidedDecodingParams`` to
-    ``StructuredOutputsParams``. trl still imports the old name, so
-    the fix re-aliases on demand. Healthy state: at least one of the
-    two symbols must exist at module load time.
-    """
+    """``fix_vllm_guided_decoding_params`` (import_fixes.py 446-490).
+    vLLM PR #22772 renamed ``GuidedDecodingParams`` ->
+    ``StructuredOutputsParams``; trl still imports the old name so the
+    fix re-aliases. At least one must exist at module load."""
     pytest.importorskip("vllm")
     try:
         sp = importlib.import_module("vllm.sampling_params")
@@ -569,15 +450,10 @@ def test_vllm_guided_decoding_params_or_structured_outputs_present():
 
 
 def test_vllm_aimv2_ovis_config_is_past_fix_version():
-    """Drift detector for ``fix_vllm_aimv2_issue``
-    (import_fixes.py lines 404-443).
-
-    vLLM < 0.10.1 has an Ovis config that unconditionally
+    """``fix_vllm_aimv2_issue`` (import_fixes.py 404-443). vLLM < 0.10.1
+    has an Ovis config that unconditionally
     ``AutoConfig.register("aimv2", AIMv2Config)`` and trips
-    ``ValueError: 'aimv2' is already used by a Transformers config``.
-    The fix only touches old versions. Assert installed vLLM is past
-    the cutoff (or skip cleanly if not).
-    """
+    ``ValueError: 'aimv2' is already used by a Transformers config``."""
     pytest.importorskip("vllm")
     vllm_v = _safe_version(importlib_version("vllm"))
     cutoff = _PkgVersion("0.10.1")
@@ -595,23 +471,16 @@ def test_vllm_aimv2_ovis_config_is_past_fix_version():
 
 
 def test_huggingface_hub_is_offline_mode_or_hf_hub_offline_present():
-    """Drift detector for ``fix_huggingface_hub``
-    (import_fixes.py lines 913-920).
-
-    huggingface_hub deprecated and removed the top-level
-    ``is_offline_mode()`` helper. Unsloth re-injects it from
-    ``huggingface_hub.constants.HF_HUB_OFFLINE``. Healthy state: the
-    re-injection target must still exist.
-    """
+    """``fix_huggingface_hub`` (import_fixes.py 913-920). huggingface_hub
+    removed the top-level ``is_offline_mode()`` helper; unsloth
+    re-injects it from ``huggingface_hub.constants.HF_HUB_OFFLINE``. At
+    least one of the two must still exist."""
     hub = pytest.importorskip("huggingface_hub")
-    # Either the function is still there OR the underlying constant
-    # used by the fix's re-injection is still importable.
     has_top_level = False
     try:
         has_top_level = callable(getattr(hub, "is_offline_mode", None))
     except Exception:
-        # huggingface_hub may use __getattr__ that raises AttributeError;
-        # treat that as "missing".
+        # huggingface_hub may use __getattr__ that raises AttributeError.
         has_top_level = False
 
     has_constant = False
@@ -634,13 +503,9 @@ def test_huggingface_hub_is_offline_mode_or_hf_hub_offline_present():
 
 
 def test_torch_nn_init_trunc_normal_exists():
-    """Drift detector for ``patch_trunc_normal_precision_issue``
-    (import_fixes.py lines 971-1050).
-
+    """``patch_trunc_normal_precision_issue`` (import_fixes.py 971-1050).
     The fp16/bf16 stability wrapper monkey-patches
-    ``torch.nn.init.trunc_normal_``. If that symbol is renamed or
-    removed the wrapper installation will fail silently.
-    """
+    ``torch.nn.init.trunc_normal_``; a rename silently fails the install."""
     pytest.importorskip("torch")
     import torch.nn.init as init_mod
 
@@ -656,13 +521,9 @@ def test_torch_nn_init_trunc_normal_exists():
 
 
 def test_xformers_is_post_num_splits_key_fix_or_not_installed():
-    """Drift detector for ``fix_xformers_performance_issue``
-    (import_fixes.py lines 312-341).
-
+    """``fix_xformers_performance_issue`` (import_fixes.py 312-341).
     xformers < 0.0.29 has the ``num_splits_key=-1`` perf bug that
-    Unsloth rewrites at install time. Healthy state: installed
-    xformers is >= 0.0.29 (or xformers isn't installed).
-    """
+    unsloth rewrites at install time."""
     if importlib.util.find_spec("xformers") is None:
         pytest.skip("xformers not installed -- nothing to drift-check.")
     x_v = _safe_version(importlib_version("xformers"))
@@ -681,13 +542,9 @@ def test_xformers_is_post_num_splits_key_fix_or_not_installed():
 
 
 def test_transformers_pretrained_model_has_get_input_embeddings():
-    """Drift detector for ``patch_enable_input_require_grads``
-    (import_fixes.py lines 609-670).
-
-    The replacement function the patch installs calls
-    ``module.get_input_embeddings()`` on every submodule. If that
-    accessor is renamed upstream the replacement is broken.
-    """
+    """``patch_enable_input_require_grads`` (import_fixes.py 609-670).
+    The replacement function calls ``module.get_input_embeddings()`` on
+    every submodule; a rename breaks the replacement."""
     pytest.importorskip("transformers")
     from transformers import PreTrainedModel
 
@@ -703,19 +560,12 @@ def test_transformers_pretrained_model_has_get_input_embeddings():
 
 
 def test_accelerate_utils_imports_module_present():
-    """Drift detector for ``disable_broken_wandb`` and
-    ``fix_trl_vllm_ascend`` (import_fixes.py lines 493-516, 1320-1372).
-
-    Both fixes reach into ``accelerate.utils.imports``. If accelerate
-    restructures that module path, both monkey-patches silently
-    no-op and broken-wandb / tuple-cached flag pathologies leak
-    through.
-    """
+    """``disable_broken_wandb`` + ``fix_trl_vllm_ascend`` (import_fixes.py
+    493-516, 1320-1372). Both reach into ``accelerate.utils.imports``;
+    a restructuring silently no-ops the monkey-patches."""
     pytest.importorskip("accelerate")
     mod = pytest.importorskip("accelerate.utils.imports")
-    # The module must at minimum still re-export some ``is_*_available``
-    # helper; checking for a single representative one (is_wandb_available)
-    # is sufficient because disable_broken_wandb specifically targets it.
+    # is_wandb_available is the representative symbol disable_broken_wandb targets.
     assert hasattr(mod, "is_wandb_available"), (
         "accelerate.utils.imports.is_wandb_available is gone; "
         "disable_broken_wandb cannot patch the source module."

--- a/tests/test_upstream_pinned_symbols_transformers.py
+++ b/tests/test_upstream_pinned_symbols_transformers.py
@@ -201,8 +201,9 @@ def test_gpt_oss_modeling_classes(tag: str):
     missing = [c for c in required if not _has_def(src, c, "class")]
     assert not missing, (
         f"{tag}: gpt_oss modeling missing classes {missing}; "
-        f"unsloth_zoo/temporary_patches/gpt_oss.py reassigns these by name, "
-        f"rename makes the MoE patches silently no-op"
+        f"unsloth_zoo/temporary_patches/gpt_oss.py reassigns these by name "
+        f"(.GptOssExperts = ..., .GptOssExperts.forward = ...) — rename "
+        f"makes the MoE patches silently no-op"
     )
 
 
@@ -299,7 +300,7 @@ def test_quantizers_should_convert_module_present_on_v5(tag: str):
     if src is None:
         pytest.skip(f"{tag}: quantizers_utils.py not present (legacy 4.x layout)")
     if tag.startswith("v4."):
-        pytest.skip(f"{tag}: 4.x line, function not expected here")
+        pytest.skip(f"{tag}: 4.x line — function not expected here")
     assert _has_def(src, "should_convert_module", "func"), (
         f"{tag}: function should_convert_module missing on transformers 5.x; "
         f"unsloth_zoo/patching_utils.py PR #491 substring-matching patch "

--- a/tests/test_upstream_pinned_symbols_transformers.py
+++ b/tests/test_upstream_pinned_symbols_transformers.py
@@ -5,18 +5,8 @@
 # under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or (at
 # your option) any later version.
-"""Pinned-symbol matrix tests: do the EXACT transformers / peft / datasets
-symbols that ``unsloth_zoo`` reaches into still exist with the expected
-shape?
-
-Each test is a CHEAP grep-on-raw-github-source check that catches the
-moment an upstream rename / removal / signature flip would silently
-no-op one of our monkey-patches. No GPU, no pip install, no model load
-required. Runs under the GPU-free harness in ``tests/conftest.py``.
-
-The matrix below covers the supported transformers window declared in
-``pyproject.toml`` plus a couple of bleeding-edge tags so we get early
-warning before users hit a regression.
+"""Pinned-symbol matrix tests for the transformers / peft / datasets
+symbols that ``unsloth_zoo`` reaches into.
 
 Motivating zoo PRs (each test docstring names the precise PR):
 
@@ -42,18 +32,14 @@ import urllib.request
 import pytest
 
 
-# ---------------------------------------------------------------------------
-# Version matrix. Keep aligned with the project's supported window.
-# transformers anchors per project spec: 4.57.6 and 5.5.0.
-# ---------------------------------------------------------------------------
-
+# transformers anchors per project spec: 4.57.6 (lower-bound) and 5.5.0.
 TRANSFORMERS_TAGS = [
-    "v4.57.6",  # anchor (lower-bound, must keep working)
+    "v4.57.6",
     "v5.0.0",
     "v5.1.0",
     "v5.2.0",
     "v5.3.0",
-    "v5.5.0",  # anchor
+    "v5.5.0",
     "main",
 ]
 
@@ -66,17 +52,9 @@ PEFT_TAGS = [
 ]
 
 
-# ---------------------------------------------------------------------------
-# Tiny self-contained helpers (no dependency on tests/version_compat/_fetch
-# because that directory does not exist in unsloth-zoo yet -- this file is
-# the first pinned-symbol test we ship from zoo's side).
-# ---------------------------------------------------------------------------
-
-
 def _fetch_text(repo: str, ref: str, path: str) -> str | None:
-    """GET https://raw.githubusercontent.com/{repo}/{ref}/{path}. Returns
-    None on 404 (path renamed/removed), pytest.skip on transient errors so
-    flaky CI doesn't false-fail."""
+    """GET raw.githubusercontent.com/{repo}/{ref}/{path}. Returns None on
+    404; pytest.skip on transient errors."""
     url = f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
     req = urllib.request.Request(url)
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
@@ -94,8 +72,7 @@ def _fetch_text(repo: str, ref: str, path: str) -> str | None:
 
 
 def _has_def(src: str, name: str, kind: str = "any") -> bool:
-    """Grep-based AST-equivalent. Accepts indented matches so class methods
-    pass the same check as module-level defs."""
+    """Grep-based AST-equivalent; accepts indented matches."""
     if kind in ("any", "class") and re.search(
         rf"^\s*class\s+{re.escape(name)}\b", src, re.MULTILINE
     ):
@@ -117,30 +94,17 @@ def _first_match(repo: str, ref: str, paths: list[str]) -> tuple[str, str] | Non
     return None
 
 
-# ===========================================================================
-# 1. Gemma3 attention surface — zoo PR #635 (gemma3 SDPA mask),
-#    PR #488 / #571 (Gemma3 5.x forward signature). Our patches in
-#    unsloth_zoo/temporary_patches/gemma.py do
-#
-#       from transformers.models.gemma3.modeling_gemma3 import (
-#           apply_rotary_pos_emb, ALL_ATTENTION_FUNCTIONS,
-#           eager_attention_forward,
-#       )
-#       transformers.models.gemma3.modeling_gemma3.Gemma3Attention
-#       transformers.models.gemma3.modeling_gemma3.Gemma3RMSNorm
-#       transformers.models.gemma3.modeling_gemma3.Gemma3MLP
-#       transformers.models.gemma3.modeling_gemma3.Gemma3TextScaledWordEmbedding
-#
-#    The patches no-op silently (via `raise_error` swallow) if any symbol
-#    is renamed; we want a loud test in CI instead.
-# ===========================================================================
+# Gemma3 attention surface, zoo PR #635 / #488 / #571.
+# unsloth_zoo/temporary_patches/gemma.py imports Gemma3Attention,
+# Gemma3RMSNorm, Gemma3MLP, Gemma3TextScaledWordEmbedding plus
+# apply_rotary_pos_emb / ALL_ATTENTION_FUNCTIONS / eager_attention_forward.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_gemma3_modeling_required_classes(tag: str):
-    """Zoo PR #635 + #488: every class referenced by
-    unsloth_zoo/temporary_patches/gemma.py must remain at the module path
-    transformers.models.gemma3.modeling_gemma3.<Name>."""
+    """Zoo PR #635 + #488: classes referenced by
+    unsloth_zoo/temporary_patches/gemma.py must remain at
+    transformers.models.gemma3.modeling_gemma3."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -164,12 +128,9 @@ def test_gemma3_modeling_required_classes(tag: str):
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_gemma3_apply_rotary_pos_emb_and_attention_funcs(tag: str):
-    """Zoo PR #488 / #571 / #635: gemma.py imports
-    ``apply_rotary_pos_emb``, ``ALL_ATTENTION_FUNCTIONS`` and
-    ``eager_attention_forward`` from the gemma3 module. These names must
-    stay reachable on that exact path; transformers occasionally moves
-    them to ``modeling_utils`` and ``modeling_layers``, which would make
-    the `from X import Y` line in gemma.py ImportError out."""
+    """Zoo PR #488 / #571 / #635: gemma.py:399 imports apply_rotary_pos_emb,
+    ALL_ATTENTION_FUNCTIONS, eager_attention_forward from the gemma3
+    module; must stay reachable on that exact path."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -177,7 +138,6 @@ def test_gemma3_apply_rotary_pos_emb_and_attention_funcs(tag: str):
     )
     if src is None:
         pytest.skip(f"{tag}: modeling_gemma3.py not present")
-    # Either defined locally, or re-exported (e.g. via `from ... import X`).
     for name in ("apply_rotary_pos_emb", "ALL_ATTENTION_FUNCTIONS", "eager_attention_forward"):
         assert name in src, (
             f"{tag}: `{name}` not reachable from "
@@ -186,20 +146,15 @@ def test_gemma3_apply_rotary_pos_emb_and_attention_funcs(tag: str):
         )
 
 
-# ===========================================================================
-# 2. ministral / mistral-3 forward signature — zoo PR #571, #509, #465.
-#    ministral.py imports `apply_rotary_pos_emb, eager_attention_forward,
-#    ALL_ATTENTION_FUNCTIONS` from modeling_ministral, then rebinds the
-#    class's `.forward`. If MinistralAttention disappears or moves we
-#    want CI to scream.
-# ===========================================================================
+# ministral / mistral-3 forward signature, zoo PR #571 / #509 / #465.
+# ministral.py:35-103 imports apply_rotary_pos_emb / eager_attention_forward
+# / ALL_ATTENTION_FUNCTIONS from modeling_ministral, then rebinds .forward.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_ministral_attention_module_present(tag: str):
-    """Zoo PR #571 / #509 / #465: MinistralAttention class must remain at
-    transformers.models.ministral.modeling_ministral.MinistralAttention.
-    """
+    """Zoo PR #571 / #509 / #465: MinistralAttention must remain at
+    transformers.models.ministral.modeling_ministral.MinistralAttention."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -211,9 +166,6 @@ def test_ministral_attention_module_present(tag: str):
         f"{tag}: class MinistralAttention missing; "
         f"unsloth_zoo/temporary_patches/ministral.py:35-103 patch breaks"
     )
-    # The same module is also expected to expose these names. (We don't
-    # require them to be DEFINED here -- just reachable as
-    # ``from transformers.models.ministral.modeling_ministral import X``.)
     for name in ("apply_rotary_pos_emb", "eager_attention_forward", "ALL_ATTENTION_FUNCTIONS"):
         assert name in src, (
             f"{tag}: `{name}` not reachable from "
@@ -222,21 +174,16 @@ def test_ministral_attention_module_present(tag: str):
         )
 
 
-# ===========================================================================
-# 3. gpt_oss MoE patch surface — zoo PR #525, #472, #471, #470, #467.
-#    gpt_oss.py reads `transformers.models.gpt_oss.modeling_gpt_oss.{
-#    GptOssExperts, GptOssTopKRouter, GptOssAttention, GptOssModel,
-#    GptOssPreTrainedModel }` and reassigns `.GptOssExperts.forward`.
-#    If any of these are renamed our MoE bnb / native pytorch / unwrap
-#    fixes silently disable themselves.
-# ===========================================================================
+# gpt_oss MoE patch surface, zoo PR #525 / #472 / #471 / #470 / #467.
+# gpt_oss.py reads transformers.models.gpt_oss.modeling_gpt_oss.{
+# GptOssExperts, GptOssTopKRouter, GptOssAttention, GptOssModel,
+# GptOssPreTrainedModel} and reassigns .GptOssExperts.forward.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_gpt_oss_modeling_classes(tag: str):
-    """Zoo PR #525 / #472 / #471: gpt_oss.py touches all five classes
-    below by attribute on the module — if any disappear, the gpt_oss
-    patches go silently dormant and grpo / bnb breakage returns."""
+    """Zoo PR #525 / #472 / #471: temporary_patches/gpt_oss.py touches all
+    five classes by attribute on the module."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -254,26 +201,21 @@ def test_gpt_oss_modeling_classes(tag: str):
     missing = [c for c in required if not _has_def(src, c, "class")]
     assert not missing, (
         f"{tag}: gpt_oss modeling missing classes {missing}; "
-        f"unsloth_zoo/temporary_patches/gpt_oss.py reassigns these by name "
-        f"(.GptOssExperts = ..., .GptOssExperts.forward = ...) — rename "
-        f"makes the MoE patches silently no-op"
+        f"unsloth_zoo/temporary_patches/gpt_oss.py reassigns these by name, "
+        f"rename makes the MoE patches silently no-op"
     )
 
 
-# ===========================================================================
-# 4. qwen3_moe MoE patch surface — zoo PR #601, #605, #607, #574, #618.
-#    qwen3_moe.py rebinds Qwen3MoeSparseMoeBlock.forward and
-#    Qwen3MoeExperts.forward via attribute assignment.
-# ===========================================================================
+# qwen3_moe MoE patch surface, zoo PR #601 / #605 / #607 / #574 / #618.
+# qwen3_moe.py rebinds Qwen3MoeSparseMoeBlock.forward and
+# Qwen3MoeExperts.forward via attribute assignment.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_qwen3_moe_required_classes(tag: str):
-    """Zoo PR #601 / #605 / #607 / #618: both Qwen3MoeSparseMoeBlock and
-    Qwen3MoeExperts must exist on
-    transformers.models.qwen3_moe.modeling_qwen3_moe. The zoo's LoRA
-    extractor and forward override are attribute-keyed, so a class
-    rename would silently bypass them."""
+    """Zoo PR #601 / #605 / #607 / #618: Qwen3MoeSparseMoeBlock (all tags)
+    and Qwen3MoeExperts (5.x only) must exist on
+    transformers.models.qwen3_moe.modeling_qwen3_moe."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -281,19 +223,15 @@ def test_qwen3_moe_required_classes(tag: str):
     )
     if src is None:
         pytest.skip(f"{tag}: modeling_qwen3_moe.py not present")
-    # Qwen3MoeSparseMoeBlock: stable across the entire support window —
-    # always required (zoo qwen3_moe.py:215 + L337-L340 read it).
+    # Qwen3MoeSparseMoeBlock: stable across the entire support window
+    # (zoo qwen3_moe.py:215 + L337-L340 read it).
     assert _has_def(src, "Qwen3MoeSparseMoeBlock", "class"), (
         f"{tag}: class Qwen3MoeSparseMoeBlock missing; "
         f"unsloth_zoo/temporary_patches/qwen3_moe.py forward / LoRA "
         f"extractor patch becomes a silent no-op"
     )
-    # Qwen3MoeExperts: 5.x-only — added when transformers split MoE
-    # weights into a dedicated `Experts` module. Zoo qwen3_moe.py:222
-    # comments `# New transformers has this`, so the patch is gated. We
-    # mirror that gate (must exist on 5.x and main; allowed absent on 4.x).
+    # Qwen3MoeExperts: 5.x-only. Zoo qwen3_moe.py:222 gates on this.
     if tag.startswith("v4."):
-        # 4.x predates the split — accept absence.
         return
     assert _has_def(src, "Qwen3MoeExperts", "class"), (
         f"{tag}: class Qwen3MoeExperts missing on transformers 5.x; "
@@ -303,26 +241,16 @@ def test_qwen3_moe_required_classes(tag: str):
     )
 
 
-# ===========================================================================
-# 5. transformers.modeling_utils MUST expose `checkpoint` AND a
-#    `PushToHubMixin` class.
-#    - Zoo PR #549 patches transformers.modeling_utils.checkpoint
-#      directly so that gradient_checkpointing_enable() picks up the
-#      Unsloth smart-offload variant. If transformers stops re-binding
-#      `checkpoint` in modeling_utils, our offload silently disables
-#      itself and users hit the documented #549 VRAM regression again.
-#    - unsloth_zoo/saving_utils.py imports PushToHubMixin from this
-#      module (5.x removed _create_repo but the class itself is still
-#      relied on for ._upload_modified_files / ._get_files_timestamps).
-# ===========================================================================
+# transformers.modeling_utils must expose `checkpoint` and PushToHubMixin.
+# Zoo PR #549 patches modeling_utils.checkpoint directly
+# (gradient_checkpointing.py:923); unsloth_zoo/saving_utils.py:76 imports
+# PushToHubMixin and calls ._upload_modified_files / ._get_files_timestamps.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_modeling_utils_checkpoint_and_pushtohubmixin(tag: str):
-    """Zoo PR #549 + saving_utils.py: ``transformers.modeling_utils``
-    must (a) bind ``checkpoint`` (we monkey-patch it) and (b) define
-    ``class PushToHubMixin`` (we call ._upload_modified_files /
-    ._get_files_timestamps on it)."""
+    """Zoo PR #549 + saving_utils.py:76: ``transformers.modeling_utils``
+    must bind ``checkpoint`` and reach ``PushToHubMixin``."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -330,10 +258,6 @@ def test_modeling_utils_checkpoint_and_pushtohubmixin(tag: str):
     )
     if src is None:
         pytest.skip(f"{tag}: modeling_utils.py missing")
-    # `checkpoint` must be reachable as a module attribute. Accept any of:
-    #   from torch.utils.checkpoint import checkpoint
-    #   import torch.utils.checkpoint as ...
-    #   checkpoint = torch.utils.checkpoint.checkpoint
     has_checkpoint = bool(
         re.search(r"^from\s+torch\.utils\.checkpoint\s+import\s+checkpoint", src, re.MULTILINE)
         or re.search(r"^import\s+torch\.utils\.checkpoint\b", src, re.MULTILINE)
@@ -344,11 +268,8 @@ def test_modeling_utils_checkpoint_and_pushtohubmixin(tag: str):
         f"unsloth_zoo/gradient_checkpointing.py:923 reassignment silently "
         f"no-ops and the PR #549 VRAM regression returns on transformers 5.2+"
     )
-    # PushToHubMixin: zoo does `from transformers.modeling_utils import
-    # PushToHubMixin`. The name can be class-defined locally (4.x) OR
-    # re-imported from `transformers.utils.hub` (5.x). Either is fine for
-    # the import to succeed — what we need is the NAME reachable on the
-    # module attribute surface. Match either an import line or a class def.
+    # PushToHubMixin: class-defined locally (4.x) OR re-imported from
+    # transformers.utils.hub (5.x); either satisfies the zoo import.
     has_pushtohub = bool(
         re.search(r"^\s*class\s+PushToHubMixin\b", src, re.MULTILINE)
         or re.search(r"\bPushToHubMixin\b", src)
@@ -359,35 +280,26 @@ def test_modeling_utils_checkpoint_and_pushtohubmixin(tag: str):
     )
 
 
-# ===========================================================================
-# 6. transformers.quantizers.quantizers_utils.should_convert_module —
-#    Zoo PR #491 / #488 patches this function on 5.x. The patch reads
-#    the function's source string and rewrites it; if the function is
-#    renamed, the patch silently no-ops and the vision_tower /
-#    audio_tower quantization-skip regression returns.
-# ===========================================================================
+# transformers.quantizers.quantizers_utils.should_convert_module, Zoo PR
+# #491 / #488 patches this on 5.x; rename silently no-ops the
+# vision_tower / audio_tower quantization-skip regression fix.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_quantizers_should_convert_module_present_on_v5(tag: str):
-    """Zoo PR #491 / #488: on transformers 5.x, the function
+    """Zoo PR #491 / #488 (patching_utils.py): on transformers 5.x,
     `should_convert_module` must live at
-    transformers.quantizers.quantizers_utils. (4.x predates this path —
-    the 4.x equivalent is `_replace_with_bnb_linear` and is covered by
-    a separate zoo patch path.)"""
+    transformers.quantizers.quantizers_utils. 4.x uses
+    `_replace_with_bnb_linear` via a separate zoo path."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
         "src/transformers/quantizers/quantizers_utils.py",
     )
     if src is None:
-        # 4.57.6 era: no such module yet. The legacy patch path keys off
-        # `_replace_with_bnb_linear` in transformers.integrations.bitsandbytes
-        # — separately validated below.
         pytest.skip(f"{tag}: quantizers_utils.py not present (legacy 4.x layout)")
-    # On 5.x the symbol MUST be present (PR #491 / #488 hinges on it).
     if tag.startswith("v4."):
-        pytest.skip(f"{tag}: 4.x line — function not expected here")
+        pytest.skip(f"{tag}: 4.x line, function not expected here")
     assert _has_def(src, "should_convert_module", "func"), (
         f"{tag}: function should_convert_module missing on transformers 5.x; "
         f"unsloth_zoo/patching_utils.py PR #491 substring-matching patch "
@@ -396,21 +308,15 @@ def test_quantizers_should_convert_module_present_on_v5(tag: str):
     )
 
 
-# ===========================================================================
-# 7. transformers.integrations.bitsandbytes._replace_with_bnb_linear —
-#    the 4.x companion of test 6. unsloth_zoo/patching_utils.py:678
-#    keys its substring-matching wrapper off the presence of this
-#    function.
-# ===========================================================================
+# transformers.integrations.bitsandbytes._replace_with_bnb_linear, 4.x
+# companion. unsloth_zoo/patching_utils.py:678 wraps it.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_integrations_bitsandbytes_legacy_replace_fn(tag: str):
-    """Zoo patching_utils.py:678 wraps
-    ``transformers.integrations.bitsandbytes._replace_with_bnb_linear`` —
-    on 4.x this MUST be present (else the substring-matching skip-list
-    feature silently disappears). On 5.x it's allowed to be absent (the
-    PR #491 path handles it via should_convert_module instead)."""
+    """patching_utils.py:678 wraps `_replace_with_bnb_linear`; on 4.x must
+    be present, on 5.x allowed absent (PR #491 path via
+    should_convert_module)."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -427,8 +333,6 @@ def test_integrations_bitsandbytes_legacy_replace_fn(tag: str):
             f"the substring-match Linear4bit skip-list breaks"
         )
     else:
-        # 5.x is allowed to drop _replace_with_bnb_linear; we just need
-        # one of the two forms reachable so SOMEONE handles BNB conv.
         assert has_legacy or has_new, (
             f"{tag}: neither _replace_with_bnb_linear (4.x) nor "
             f"replace_with_bnb_linear (5.x) present in "
@@ -436,23 +340,16 @@ def test_integrations_bitsandbytes_legacy_replace_fn(tag: str):
         )
 
 
-# ===========================================================================
-# 8. transformers.modeling_utils.caching_allocator_warmup —
-#    Zoo PR #569 wraps this. The wrap is guarded with hasattr() so an
-#    absence is OK, BUT if the function is renamed (not removed) we'd
-#    silently lose the low-VRAM OOM guard. Snapshot the name.
-# ===========================================================================
+# transformers.modeling_utils.caching_allocator_warmup, Zoo PR #569:
+# hasattr-guarded wrap; fail only on likely rename (not removal).
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_caching_allocator_warmup_reachable(tag: str):
-    """Zoo PR #569: ``transformers.modeling_utils.caching_allocator_warmup``
-    is the function we wrap with the <=24 GiB skip-guard. The wrap is
-    gated by hasattr(), so a removal degrades gracefully — but a RENAME
-    would silently drop the guard and reintroduce OOM-before-load on
-    low-VRAM cards. Just record presence/absence informationally and
-    fail only when we detect a likely RENAME (function vanished AND a
-    same-prefix `*warmup*` symbol appeared)."""
+    """Zoo PR #569 wraps modeling_utils.caching_allocator_warmup with a
+    <=24 GiB skip-guard via hasattr(). Removal degrades gracefully; only
+    a rename (function vanished AND a `*warmup*` sibling appeared)
+    silently drops the OOM-before-load guard."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -462,8 +359,8 @@ def test_caching_allocator_warmup_reachable(tag: str):
         pytest.skip(f"{tag}: modeling_utils.py missing")
     has_exact = _has_def(src, "caching_allocator_warmup", "func")
     if has_exact:
-        return  # all good
-    # Look for a likely rename — any other `def *_warmup(` in the file.
+        return
+    # Rename detection: any other `def *_warmup(` in the file.
     other_warmup = re.findall(r"^def\s+(\w*warmup\w*)\s*\(", src, re.MULTILINE)
     other_warmup = [n for n in other_warmup if n != "caching_allocator_warmup"]
     if other_warmup:
@@ -472,25 +369,18 @@ def test_caching_allocator_warmup_reachable(tag: str):
             f"candidates: {other_warmup}. Zoo PR #569 hasattr() guard would "
             f"silently skip the wrap, reintroducing the low-VRAM OOM regression."
         )
-    # Removed without rename — graceful degradation; OK.
     pytest.skip(f"{tag}: caching_allocator_warmup removed (graceful, hasattr-guarded)")
 
 
-# ===========================================================================
-# 9. transformers.masking_utils.{create_causal_mask,
-#    create_sliding_window_causal_mask} — zoo PR #488, #525, and the
-#    gpt_oss patch rebind these. Their NAMES must remain stable.
-# ===========================================================================
+# transformers.masking_utils.{create_causal_mask, create_sliding_window_causal_mask},
+# zoo PR #488 / #525; misc.py:382 + gpt_oss.py:2182-2183 rebind these.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
 def test_masking_utils_create_causal_mask_names(tag: str):
-    """unsloth_zoo/temporary_patches/misc.py:382 and gpt_oss.py:2182-2183
-    do `import transformers.masking_utils as masking_utils` and read
-    `masking_utils.create_causal_mask` + `.create_sliding_window_causal_mask`.
-    Both must remain reachable on every supported transformers tag.
-    Zoo PR #488 additionally adds ``create_causal_mask_mapping`` to
-    DISABLED_KEYWORDS — the 5.x rename — so we ALSO accept that name."""
+    """temporary_patches/misc.py:414 + gpt_oss.py:2182 + ministral.py:144
+    read masking_utils.create_causal_mask /
+    .create_sliding_window_causal_mask."""
     src = _fetch_text(
         "huggingface/transformers",
         tag,
@@ -498,7 +388,6 @@ def test_masking_utils_create_causal_mask_names(tag: str):
     )
     if src is None:
         pytest.skip(f"{tag}: masking_utils.py not present")
-    # create_causal_mask: stable through the entire window.
     assert _has_def(src, "create_causal_mask", "func"), (
         f"{tag}: transformers.masking_utils.create_causal_mask missing; "
         f"unsloth_zoo/temporary_patches/misc.py:414 and "
@@ -510,28 +399,18 @@ def test_masking_utils_create_causal_mask_names(tag: str):
     )
 
 
-# ===========================================================================
-# 10. peft LoraLayer 3D-parameter (MoE) attribute surface — zoo PR #618.
-#     The Qwen MoE LoRA extractor reads `wrapper.get_base_layer()` and
-#     then `.parameter_name`, `.hidden_dim`, `.intermediate_dim` on the
-#     base layer. The extractor also has to track peft's behaviour
-#     change between 0.18 and 0.19 where the 3D weight is now swapped
-#     in-place before LoRA is created. We don't try to verify the
-#     swap-aware path here (no install needed); instead we pin the
-#     simpler upstream contract: PEFT must keep emitting
-#     ``ParamWrapper`` (LoraLayer subclass) in peft/tuners/lora/layer.py
-#     for our `get_base_layer() / parameter_name` API to keep working.
-# ===========================================================================
+# peft LoraLayer 3D-parameter (MoE) attribute surface, zoo PR #618.
+# Qwen MoE LoRA extractor reads wrapper.get_base_layer() + .parameter_name
+# / .hidden_dim / .intermediate_dim. Pin: peft keeps emitting ParamWrapper
+# (LoraLayer subclass) in peft/tuners/lora/layer.py.
 
 
 @pytest.mark.parametrize("tag", PEFT_TAGS)
 def test_peft_lora_layer_paramwrapper_present(tag: str):
-    """Zoo PR #618: peft.tuners.lora.layer must keep defining the
-    LoraLayer + ParamWrapper surface that
-    unsloth_zoo/temporary_patches/qwen3_moe.py:46-77 walks via
-    ``wrapper.get_base_layer()`` and ``wrapper.parameter_name``. If
-    either disappears the MoE LoRA extractor silently returns
-    ``(None, None)`` and grouped-mm crashes."""
+    """Zoo PR #618: temporary_patches/qwen3_moe.py:46-77 walks
+    wrapper.get_base_layer() / wrapper.parameter_name on peft.tuners.lora
+    .layer.{LoraLayer,ParamWrapper}; missing -> MoE LoRA extractor
+    returns (None, None) and grouped-mm crashes."""
     src = _fetch_text("huggingface/peft", tag, "src/peft/tuners/lora/layer.py")
     if src is None:
         pytest.skip(f"{tag}: peft/tuners/lora/layer.py missing")
@@ -539,21 +418,17 @@ def test_peft_lora_layer_paramwrapper_present(tag: str):
         f"{tag}: class LoraLayer missing in peft.tuners.lora.layer; "
         f"unsloth_zoo qwen LoRA extractor and saving_utils.py break"
     )
-    # ParamWrapper or its forerunner — peft 0.17 didn't have it, peft 0.18+
-    # introduced it. Accept either name (peft has had a couple of stabs at
-    # the API) so we don't false-fail on legacy tags.
+    # ParamWrapper: peft 0.17 lacked it; 0.18+ has it. Either name accepted.
     has_param_wrapper = bool(
         re.search(r"^\s*class\s+ParamWrapper\b", src, re.MULTILINE)
         or "ParamWrapper" in src
     )
-    # `get_base_layer` is the unmodified-since-0.7 accessor we rely on.
     has_get_base = "get_base_layer" in src
     assert has_get_base, (
         f"{tag}: peft.tuners.lora.layer.LoraLayer no longer exposes "
         f"`get_base_layer`; unsloth qwen MoE extractor returns (None, None) "
         f"and grouped-mm crashes (PR #618 silently disabled)."
     )
-    # ParamWrapper is informational on very old peft, required on 0.18+.
     if tag in ("v0.18.0", "v0.19.1", "main") and not has_param_wrapper:
         pytest.fail(
             f"{tag}: peft 0.18+ should expose ParamWrapper in lora/layer.py "

--- a/tests/test_upstream_signatures.py
+++ b/tests/test_upstream_signatures.py
@@ -3,44 +3,17 @@
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or (at
-# your option) any later version.
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 
-"""Signature pinning tests for the upstream functions / methods that
-``unsloth_zoo`` monkey-patches, wraps, or calls with positional shape
-assumptions.
+"""Signature pins for upstream functions / methods ``unsloth_zoo``
+monkey-patches, wraps, or calls with positional shape assumptions.
 
-Class of bug this catches
-=========================
-Transformers / TRL / PEFT / Accelerate adds, removes, or renames a
-parameter on a function or method that ``unsloth_zoo`` overrides.
-``unsloth_zoo``'s override silently ignores or mis-positions the new
-parameter, downstream users get wrong-output bugs (NaN losses,
-mis-quantized layers, silent attention truncation, broken gradient
-checkpointing) with NO exception. Drift surfaces only as bad training
-runs days later.
-
-Each test below uses ``inspect.signature(...)`` on the **installed**
-upstream symbol and asserts the parameter list that the matching
-``unsloth_zoo`` monkey-patch / wrapper / positional call assumes.
-
-Contract
-========
-* CPU-only -- no GPU, no model downloads, no network.
-* Optional deps (``vllm``, ``mlx``, ``xformers``, ``timm``,
-  ``bitsandbytes``) are gated with ``pytest.importorskip`` so genuinely
-  uninstalled stacks don't false-fail.
-* Real drift -> ``pytest.fail("DRIFT DETECTED: <upstream.path>
-  signature changed: zoo expects {X} but installed has {Y}")``.
-* Never ``pytest.skip`` to hide drift -- skips are only for genuine
-  optional-dep absence and for upstream symbols that legitimately moved
-  / were renamed in versions ``unsloth_zoo`` doesn't claim to support.
-
-Source-of-truth callsite is cited in every test docstring so when an
-upstream rename lands we can find the matching zoo override in a single
-grep.
-
-Runs under the GPU-free harness in ``tests/conftest.py``.
+DRIFT-DETECTED framing: each test uses ``inspect.signature(...)`` on the
+INSTALLED upstream symbol and asserts the parameter list the matching
+zoo override assumes. Real drift -> ``pytest.fail("DRIFT DETECTED:
+...")``; optional deps gated with ``pytest.importorskip``. Source-of-truth
+zoo callsite cited in every docstring.
 """
 
 from __future__ import annotations
@@ -56,9 +29,6 @@ import pytest
 # ---------------------------------------------------------------------------
 
 def _param_names(func) -> list[str]:
-    """Return the ordered parameter-name list of a callable. Wraps
-    ``inspect.signature`` so a single ``inspect`` failure -> a test fail
-    with a useful message instead of a stack trace."""
     try:
         sig = inspect.signature(func)
     except (TypeError, ValueError) as exc:
@@ -73,10 +43,9 @@ def _assert_params_superset(
     required: Iterable[str],
     zoo_callsite: str,
 ):
-    """Assert that EVERY name in ``required`` appears in ``func``'s
-    parameter list. The upstream may add NEW params (that's OK -- zoo
-    just won't forward them yet) but MUST NOT drop any param that zoo
-    forwards by name."""
+    """Assert every name in ``required`` appears in ``func``'s params.
+    Upstream may add NEW params (zoo just won't forward them) but MUST
+    NOT drop a param that zoo forwards by name."""
     got = _param_names(func)
     missing = [name for name in required if name not in got]
     if missing:
@@ -92,13 +61,10 @@ def _assert_positional_arity_at_least(
     arity: int,
     zoo_callsite: str,
 ):
-    """Assert ``func`` accepts at least ``arity`` non-self positional
-    args (POSITIONAL_OR_KEYWORD or POSITIONAL_ONLY, plus VAR_POSITIONAL
-    counts as unlimited). Catches the case where zoo does
-    ``super().forward(a, b, c, d)`` but upstream removed a positional."""
+    """Assert ``func`` accepts >= ``arity`` non-self positionals. Catches
+    ``super().forward(a, b, c, d)`` when upstream dropped a positional."""
     sig = inspect.signature(func)
     params = list(sig.parameters.values())
-    # Drop a leading "self" / "cls" so the count is callsite-equivalent.
     if params and params[0].name in ("self", "cls"):
         params = params[1:]
     positional = 0
@@ -116,13 +82,8 @@ def _assert_positional_arity_at_least(
         )
 
 
-# ---------------------------------------------------------------------------
-# Pre-flight: every signature-pinning test below assumes transformers is
-# installed. If it isn't, the whole file is irrelevant -- mark a single
-# module-level importorskip so the failure message is "no transformers"
-# instead of N hard import failures.
-# ---------------------------------------------------------------------------
-
+# Single module-level importorskip so missing transformers gives one
+# clean failure instead of N hard import errors.
 pytest.importorskip("transformers")
 
 
@@ -132,11 +93,10 @@ pytest.importorskip("transformers")
 
 def test_torch_checkpoint_function_first_positional_arg():
     """gradient_checkpointing.py:222 defines
-    ``def unsloth_gradient_checkpoint(function, *args, use_reentrant=None,
-    **kwargs)`` and is assigned to ``transformers.modeling_utils.checkpoint``
-    and ``torch.utils.checkpoint.checkpoint``. Upstream must keep
-    ``function`` as the first positional arg AND must keep ``use_reentrant``
-    as a kwarg so zoo's override remains drop-in."""
+    ``unsloth_gradient_checkpoint(function, *args, use_reentrant=None,
+    **kwargs)`` and assigns to ``torch.utils.checkpoint.checkpoint``.
+    Upstream must keep ``function`` first positional + ``use_reentrant``
+    as kwarg."""
     import torch.utils.checkpoint as tuc
     sig = inspect.signature(tuc.checkpoint)
     params = list(sig.parameters.keys())
@@ -155,10 +115,9 @@ def test_torch_checkpoint_function_first_positional_arg():
 
 
 def test_transformers_modeling_utils_checkpoint_symbol_present():
-    """gradient_checkpointing.py:234 / 246 / 924 do
-    ``transformers.modeling_utils.checkpoint = unsloth_gradient_checkpoint``.
-    If upstream renames or removes this re-export, the patch silently
-    no-ops and stock checkpointing remains on -> long-context VRAM bug."""
+    """gradient_checkpointing.py:234/246/924 -- ``transformers.modeling_utils
+    .checkpoint = unsloth_gradient_checkpoint``. A removed re-export
+    silently no-ops the patch -> long-context VRAM bug."""
     import transformers.modeling_utils as mu
     if not hasattr(mu, "checkpoint"):
         pytest.fail(
@@ -170,15 +129,12 @@ def test_transformers_modeling_utils_checkpoint_symbol_present():
 
 # ===========================================================================
 # transformers.integrations.bitsandbytes._replace_with_bnb_linear
-# (patching_utils.py:751)
 # ===========================================================================
 
 def test_replace_with_bnb_linear_signature():
-    """patching_utils.py rebuilds upstream
-    ``_replace_with_bnb_linear`` via source rewrite (line 682
-    ``inspect.getsource(...)``) then re-installs as
-    ``_unsloth_replace_with_bnb_linear``. The rewrite assumes
-    parameters: ``(model, modules_to_not_convert, current_key_name,
+    """patching_utils.py:682 ``inspect.getsource(_replace_with_bnb_linear)``
+    + source rewrite -> re-installed as ``_unsloth_replace_with_bnb_linear``.
+    Pins ``(model, modules_to_not_convert, current_key_name,
     quantization_config, has_been_replaced)``."""
     pytest.importorskip("bitsandbytes")
     try:
@@ -186,10 +142,9 @@ def test_replace_with_bnb_linear_signature():
             _replace_with_bnb_linear,
         )
     except ImportError:
-        # On transformers 5.x this private was removed -- zoo guards
-        # this at patching_utils.py:678 and falls back to should_convert_module.
-        # That's a legitimate API migration, not drift. Confirm the
-        # fallback symbol exists instead.
+        # transformers 5.x removed this private; zoo guards at
+        # patching_utils.py:678 and falls back to should_convert_module.
+        # Confirm the fallback symbol exists.
         try:
             import transformers.quantizers.quantizers_utils as qu  # noqa
         except ImportError:
@@ -217,10 +172,9 @@ def test_replace_with_bnb_linear_signature():
 # ===========================================================================
 
 def test_pretrained_model_loss_function_exists():
-    """loss_utils.py:143-146 unwraps ``PreTrainedModel.loss_function.fget.__wrapped__``
-    if loss_function is a property. If upstream removes the property
-    entirely or makes it a plain attribute, the unwrap raises and the
-    patch silently aborts -> stock loss runs, no fused CE."""
+    """loss_utils.py:143-146 unwraps
+    ``PreTrainedModel.loss_function.fget.__wrapped__``. Removal of the
+    property silently aborts the patch -> no fused CE."""
     import transformers.modeling_utils as mu
     if not hasattr(mu.PreTrainedModel, "loss_function"):
         pytest.fail(
@@ -230,13 +184,9 @@ def test_pretrained_model_loss_function_exists():
 
 
 def test_LOSS_MAPPING_ForCausalLM_signature_compatible():
-    """loss_utils.py:140 sets ``LOSS_MAPPING['ForCausalLM'] =
-    UnslothForCausalLMLoss`` which is defined with parameters
-    ``(logits, labels, vocab_size, num_items_in_batch=None,
-    ignore_index=-100, **kwargs)``. Upstream loss callers must still
-    pass at least the first three positionally, else zoo's override
-    receives a swapped arg-order. We pin the ORIGINAL function's signature
-    so any rename surfaces immediately."""
+    """loss_utils.py:140 -- ``LOSS_MAPPING['ForCausalLM'] =
+    UnslothForCausalLMLoss``. Zoo's override expects ``(logits, labels,
+    vocab_size, ...)`` first three positionals; pin those."""
     from transformers.loss.loss_utils import LOSS_MAPPING
     if "ForCausalLM" not in LOSS_MAPPING:
         pytest.fail(
@@ -244,8 +194,6 @@ def test_LOSS_MAPPING_ForCausalLM_signature_compatible():
             "'ForCausalLM' key removed. loss_utils.py:140 monkey-patch no-ops."
         )
     upstream = LOSS_MAPPING["ForCausalLM"]
-    # Zoo's UnslothForCausalLMLoss expects logits, labels, vocab_size to be
-    # the first three positionals. Upstream must accept the same.
     _assert_params_superset(
         upstream,
         required=["logits", "labels", "vocab_size"],
@@ -254,10 +202,8 @@ def test_LOSS_MAPPING_ForCausalLM_signature_compatible():
 
 
 def test_fixed_cross_entropy_signature():
-    """loss_utils.py:99 inside UnslothFixedCrossEntropy calls back into
-    transformers' upstream cross entropy helper indirectly via the loss
-    function plumbing. The override uses ``num_items_in_batch`` and
-    ``ignore_index`` keyword-forwarded. Pin those."""
+    """loss_utils.py:99 -- UnslothFixedCrossEntropy keyword-forwards
+    ``num_items_in_batch`` and ``ignore_index``."""
     from transformers.loss.loss_utils import fixed_cross_entropy
     _assert_params_superset(
         fixed_cross_entropy,
@@ -273,9 +219,7 @@ def test_fixed_cross_entropy_signature():
 
 def test_Trainer_get_optimizer_cls_and_kwargs_signature():
     """training_utils.py:354 calls
-    ``Trainer.get_optimizer_cls_and_kwargs(training_args)`` as a single
-    positional arg. If upstream changes the signature shape, zoo's
-    isolated training loop builds a broken optimizer silently."""
+    ``Trainer.get_optimizer_cls_and_kwargs(training_args)`` -- one positional."""
     from transformers import Trainer
     _assert_positional_arity_at_least(
         Trainer.get_optimizer_cls_and_kwargs,
@@ -285,9 +229,9 @@ def test_Trainer_get_optimizer_cls_and_kwargs_signature():
 
 
 def test_Trainer_get_decay_parameter_names_signature():
-    """training_utils.py:355 calls ``Trainer.get_decay_parameter_names(
-    None, model)`` -- passes ``self=None`` and the model positionally. So
-    upstream must accept (self, model) at least."""
+    """training_utils.py:355 calls
+    ``Trainer.get_decay_parameter_names(None, model)`` -- self=None +
+    model positional."""
     from transformers import Trainer
     sig = inspect.signature(Trainer.get_decay_parameter_names)
     params = list(sig.parameters.keys())
@@ -300,13 +244,9 @@ def test_Trainer_get_decay_parameter_names_signature():
 
 
 def test_Trainer_inner_training_loop_signature_preserved():
-    """compiler.py:3966-4040 replaces ``Trainer._inner_training_loop`` with
-    ``_fast_inner_training_loop``. The rewriter uses
-    ``inspect.getsource`` on the original. Pin the parameters the
-    rewriter assumes exist: self, batch_size, args, resume_from_checkpoint,
-    trial, ignore_keys_for_eval. If upstream renames any of these, the
-    body-substitution targets that the rewriter performs at lines
-    4011-4038 silently fail to match -> stock loop remains."""
+    """compiler.py:3966-4040 replaces ``Trainer._inner_training_loop``
+    with ``_fast_inner_training_loop`` via ``inspect.getsource``. Pin
+    params the rewriter assumes exist."""
     from transformers import Trainer
     _assert_params_superset(
         Trainer._inner_training_loop,
@@ -324,12 +264,10 @@ def test_Trainer_inner_training_loop_signature_preserved():
 
 # ===========================================================================
 # transformers.set_seed / get_scheduler / seed_worker / DataCollator*
-# (training_utils.py:20-23, 345-349, dataset_utils.py:457/672/678/686)
 # ===========================================================================
 
 def test_set_seed_signature():
-    """training_utils.py:20 imports ``set_seed`` and uses it directly.
-    The first positional must be ``seed``."""
+    """training_utils.py:20 -- first positional must be ``seed``."""
     from transformers import set_seed
     sig = inspect.signature(set_seed)
     params = list(sig.parameters.keys())
@@ -341,9 +279,8 @@ def test_set_seed_signature():
 
 
 def test_get_scheduler_signature():
-    """training_utils.py:377 calls ``transformers_get_scheduler(name=...,
-    optimizer=..., num_warmup_steps=..., num_training_steps=...,
-    **lr_scheduler_kwargs)``. Pin those keyword args."""
+    """training_utils.py:377 -- ``transformers_get_scheduler(name=...,
+    optimizer=..., num_warmup_steps=..., num_training_steps=...)``."""
     from transformers import get_scheduler
     _assert_params_superset(
         get_scheduler,
@@ -354,9 +291,8 @@ def test_get_scheduler_signature():
 
 
 def test_seed_worker_imported_as_trainer_utils_seed_worker():
-    """training_utils.py:23 imports
-    ``transformers.trainer_utils.seed_worker as trainer_utils_seed_worker``
-    -- the import must succeed at zoo import time. Confirm presence."""
+    """training_utils.py:23 -- ``from transformers.trainer_utils import
+    seed_worker``. No fallback."""
     try:
         from transformers.trainer_utils import seed_worker  # noqa: F401
     except ImportError as exc:
@@ -367,9 +303,9 @@ def test_seed_worker_imported_as_trainer_utils_seed_worker():
 
 
 def test_DataCollatorForLanguageModeling_signature():
-    """training_utils.py:346 and dataset_utils.py:686 instantiate
+    """training_utils.py:346 + dataset_utils.py:686 --
     ``DataCollatorForLanguageModeling(tokenizer=..., mlm=False,
-    pad_to_multiple_of=4)``. Pin those three kwargs."""
+    pad_to_multiple_of=4)``."""
     from transformers import DataCollatorForLanguageModeling
     _assert_params_superset(
         DataCollatorForLanguageModeling.__init__,
@@ -380,8 +316,7 @@ def test_DataCollatorForLanguageModeling_signature():
 
 
 def test_DataCollatorForSeq2Seq_signature():
-    """dataset_utils.py:464 / 678 instantiate
-    ``DataCollatorForSeq2Seq(tokenizer=...)``."""
+    """dataset_utils.py:464 / 678 -- ``DataCollatorForSeq2Seq(tokenizer=...)``."""
     from transformers import DataCollatorForSeq2Seq
     _assert_params_superset(
         DataCollatorForSeq2Seq.__init__,
@@ -391,20 +326,16 @@ def test_DataCollatorForSeq2Seq_signature():
 
 
 # ===========================================================================
-# TrainingArguments (temporary_patches/misc.py:1334 patches to_dict)
+# TrainingArguments (temporary_patches/misc.py:1334)
 # ===========================================================================
 
 def test_TrainingArguments_to_dict_signature():
     """temporary_patches/misc.py:1334-1343 wraps
-    ``TrainingArguments.to_dict`` with one that injects
-    ``push_to_hub_token``. zoo's wrapper signature is ``def
-    _patched_to_dict(self)`` -- upstream must remain a zero-arg
-    (besides self) method, else the wrapper drops kwargs."""
+    ``TrainingArguments.to_dict`` with ``_patched_to_dict(self)`` --
+    no *args/**kwargs forwarding, so upstream must remain self-only."""
     from transformers import TrainingArguments
     sig = inspect.signature(TrainingArguments.to_dict)
     params = list(sig.parameters.keys())
-    # MUST be just self; anything else means upstream added params that
-    # zoo's wrapper would silently swallow.
     if params != ["self"]:
         pytest.fail(
             f"DRIFT DETECTED: TrainingArguments.to_dict: zoo wrapper at "
@@ -415,8 +346,7 @@ def test_TrainingArguments_to_dict_signature():
 
 
 def test_TrainingArguments_get_warmup_steps_signature():
-    """training_utils.py:380 calls
-    ``training_args.get_warmup_steps(max_steps)`` -- one positional."""
+    """training_utils.py:380 -- ``training_args.get_warmup_steps(max_steps)``."""
     from transformers import TrainingArguments
     _assert_positional_arity_at_least(
         TrainingArguments.get_warmup_steps,
@@ -430,11 +360,9 @@ def test_TrainingArguments_get_warmup_steps_signature():
 # ===========================================================================
 
 def test_PretrainedConfig_to_dict_signature():
-    """patching_utils.py:256-259 wraps
-    ``PretrainedConfig.to_dict`` with ``def wrapped_to_dict(self, *args,
-    **kwargs)``. That forwarding is correct so long as upstream
-    ``to_dict`` is a method. If upstream makes it a classmethod or moves
-    it, the @wraps target breaks."""
+    """patching_utils.py:256-259 wraps ``PretrainedConfig.to_dict`` with
+    ``def wrapped_to_dict(self, *args, **kwargs)``. ``to_dict`` and
+    ``to_diff_dict`` must remain methods."""
     try:
         from transformers.configuration_utils import PreTrainedConfig as Cfg
     except ImportError:
@@ -456,10 +384,8 @@ def test_PretrainedConfig_to_dict_signature():
 # ===========================================================================
 
 def test_PushToHubMixin_push_to_hub_signature():
-    """saving_utils.py:76 imports ``PushToHubMixin`` and uses it as a
-    mixin base for the save plumbing. Pin the canonical ``push_to_hub``
-    kwargs zoo expects (``repo_id``, ``commit_message``, ``token``,
-    ``private``, ``revision``, ``create_pr``)."""
+    """saving_utils.py:76 uses ``PushToHubMixin`` as a mixin base. Pin
+    the canonical push_to_hub kwargs zoo expects."""
     from transformers.modeling_utils import PushToHubMixin
     _assert_params_superset(
         PushToHubMixin.push_to_hub,
@@ -473,8 +399,8 @@ def test_PushToHubMixin_push_to_hub_signature():
 # ===========================================================================
 
 def test_accelerate_init_empty_weights_signature():
-    """empty_model.py:252 / 329 do ``with init_empty_weights(include_buffers
-    = False):``. Pin that parameter name."""
+    """empty_model.py:252 / 329 -- ``with init_empty_weights(include_buffers
+    =False):``. Pin the kwarg name."""
     pytest.importorskip("accelerate")
     from accelerate import init_empty_weights
     _assert_params_superset(
@@ -485,14 +411,13 @@ def test_accelerate_init_empty_weights_signature():
 
 
 # ===========================================================================
-# Masking-utils + GPT-OSS overrides (temporary_patches/gpt_oss.py)
+# Masking-utils + GPT-OSS overrides
 # ===========================================================================
 
 def test_masking_utils_create_causal_mask_signature():
-    """temporary_patches/gpt_oss.py:2178-2182 wraps
-    ``transformers.masking_utils.create_causal_mask`` via ``wrap()`` and
-    re-assigns. zoo's wrap is *args/**kwargs forwarding so positional
-    layout is invariant, but the SYMBOL must exist."""
+    """gpt_oss.py:2178-2182 wraps
+    ``transformers.masking_utils.create_causal_mask``. zoo's wrap is
+    *args/**kwargs so only the SYMBOL must exist."""
     try:
         from transformers.masking_utils import create_causal_mask  # noqa
     except ImportError as exc:
@@ -503,8 +428,7 @@ def test_masking_utils_create_causal_mask_signature():
 
 
 def test_masking_utils_create_sliding_window_causal_mask_signature():
-    """Companion of the above. gpt_oss.py:2179 wraps it; ministral.py
-    also depends on it being importable."""
+    """gpt_oss.py:2179 + ministral.py also depend on this being importable."""
     try:
         from transformers.masking_utils import (
             create_sliding_window_causal_mask,  # noqa
@@ -543,10 +467,8 @@ def test_masking_utils_create_masks_for_generate_signature():
 # ===========================================================================
 
 def test_gemma3_apply_rotary_pos_emb_signature():
-    """gemma.py:399 imports ``apply_rotary_pos_emb`` from gemma3 and
-    calls it as ``apply_rotary_pos_emb(query_states, key_states, cos,
-    sin)`` -- four positionals. So upstream must accept >=4 positional
-    args."""
+    """gemma.py:399 -- ``apply_rotary_pos_emb(query_states, key_states,
+    cos, sin)`` 4 positionals."""
     from transformers.models.gemma3.modeling_gemma3 import apply_rotary_pos_emb
     _assert_positional_arity_at_least(
         apply_rotary_pos_emb,
@@ -556,10 +478,8 @@ def test_gemma3_apply_rotary_pos_emb_signature():
 
 
 def test_gemma3_eager_attention_forward_signature():
-    """gemma.py:399 / ministral.py:38 import ``eager_attention_forward``
-    and the relaxed-mode patch passes ``module, query, key, value,
-    attention_mask, dropout, scaling`` -- pin those keyword/positional
-    forwardable names."""
+    """gemma.py:399 / ministral.py:38 -- relaxed-mode patch passes
+    ``module, query, key, value, attention_mask, dropout, scaling``."""
     from transformers.models.gemma3.modeling_gemma3 import eager_attention_forward
     _assert_params_superset(
         eager_attention_forward,
@@ -569,12 +489,10 @@ def test_gemma3_eager_attention_forward_signature():
 
 
 def test_gemma3_ALL_ATTENTION_FUNCTIONS_present():
-    """gemma.py:399 / ministral.py:39 import ``ALL_ATTENTION_FUNCTIONS``
-    from gemma3.modeling_gemma3. If upstream moves it to
-    ``transformers.modeling_utils`` only, the import in zoo fails at
-    patch-registration time."""
+    """gemma.py:399 / ministral.py:39 -- ``from gemma3.modeling_gemma3
+    import ALL_ATTENTION_FUNCTIONS``. Zoo subscripts it via
+    ``ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]``."""
     from transformers.models.gemma3.modeling_gemma3 import ALL_ATTENTION_FUNCTIONS  # noqa
-    # Must be a mapping-like object: zoo does ``ALL_ATTENTION_FUNCTIONS[name]``
     if not hasattr(ALL_ATTENTION_FUNCTIONS, "__getitem__"):
         pytest.fail(
             f"DRIFT DETECTED: gemma3.ALL_ATTENTION_FUNCTIONS: zoo subscripts "
@@ -584,10 +502,8 @@ def test_gemma3_ALL_ATTENTION_FUNCTIONS_present():
 
 
 def test_Gemma3Processor_call_signature():
-    """gemma.py:224 patches
-    ``Gemma3Processor.__call__`` with ``match_level='relaxed'``. The
-    replacement defines ``__call__(self, images, text, videos, audio,
-    **kwargs)`` -- pin those param names."""
+    """gemma.py:224 patches ``Gemma3Processor.__call__(self, images, text,
+    videos, audio, **kwargs)`` with match_level='relaxed'."""
     from transformers.models.gemma3.processing_gemma3 import Gemma3Processor
     _assert_params_superset(
         Gemma3Processor.__call__,
@@ -597,13 +513,11 @@ def test_Gemma3Processor_call_signature():
 
 
 def test_Gemma3RMSNorm_forward_signature():
-    """gemma.py:361 / 628 patches
-    ``Gemma3RMSNorm.forward(self, hidden_states)`` with fullgraph=True.
-    Upstream must keep it a one-tensor forward."""
+    """gemma.py:361 / 628 patches ``Gemma3RMSNorm.forward(self,
+    hidden_states)`` with fullgraph=True. One-tensor forward."""
     from transformers.models.gemma3.modeling_gemma3 import Gemma3RMSNorm
     sig = inspect.signature(Gemma3RMSNorm.forward)
     params = [p.name for p in sig.parameters.values() if p.name != "self"]
-    # zoo's replacement: def forward(self, hidden_states) -> single positional.
     if len(params) != 1:
         pytest.fail(
             f"DRIFT DETECTED: Gemma3RMSNorm.forward: zoo replacement at "
@@ -613,8 +527,8 @@ def test_Gemma3RMSNorm_forward_signature():
 
 
 def test_Gemma3MLP_forward_signature():
-    """gemma.py:389 patches Gemma3MLP.forward with a single-tensor
-    forward. Pin the positional shape."""
+    """gemma.py:389 patches ``Gemma3MLP.forward`` with a single-tensor
+    forward."""
     from transformers.models.gemma3.modeling_gemma3 import Gemma3MLP
     sig = inspect.signature(Gemma3MLP.forward)
     params = [p.name for p in sig.parameters.values() if p.name != "self"]
@@ -628,8 +542,7 @@ def test_Gemma3MLP_forward_signature():
 
 def test_Gemma3TextScaledWordEmbedding_forward_signature():
     """gemma.py:331 patches
-    ``Gemma3TextScaledWordEmbedding.forward(self, input_ids)`` with
-    fullgraph=True. Pin the (self, input_ids) shape."""
+    ``Gemma3TextScaledWordEmbedding.forward(self, input_ids)``."""
     from transformers.models.gemma3.modeling_gemma3 import (
         Gemma3TextScaledWordEmbedding,
     )
@@ -645,8 +558,7 @@ def test_Gemma3TextScaledWordEmbedding_forward_signature():
 
 def test_Gemma3Attention_forward_signature():
     """gemma.py:607/849 patches Gemma3Attention.forward via
-    ``patch_function_past_key_values`` with match_level='relaxed'. Pin
-    the keyword params zoo's forward variants forward by name."""
+    patch_function_past_key_values, match_level='relaxed'."""
     from transformers.models.gemma3.modeling_gemma3 import Gemma3Attention
     _assert_params_superset(
         Gemma3Attention.forward,
@@ -661,8 +573,7 @@ def test_Gemma3Attention_forward_signature():
 
 def test_Gemma3nMultimodalEmbedder_forward_signature():
     """gemma3n.py:88 patches
-    ``Gemma3nMultimodalEmbedder.forward(self, input_ids, inputs_embeds)``
-    with fullgraph=True. Pin those two positional kwargs."""
+    ``Gemma3nMultimodalEmbedder.forward(self, input_ids, inputs_embeds)``."""
     from transformers.models.gemma3n.modeling_gemma3n import (
         Gemma3nMultimodalEmbedder,
     )
@@ -675,8 +586,7 @@ def test_Gemma3nMultimodalEmbedder_forward_signature():
 
 def test_Gemma3nTextAltUp_predict_signature():
     """gemma3n.py:122 patches
-    ``Gemma3nTextAltUp.predict(self, hidden_states)`` with
-    fullgraph=True. Pin the one-positional shape."""
+    ``Gemma3nTextAltUp.predict(self, hidden_states)``."""
     from transformers.models.gemma3n.modeling_gemma3n import Gemma3nTextAltUp
     sig = inspect.signature(Gemma3nTextAltUp.predict)
     params = [p.name for p in sig.parameters.values() if p.name != "self"]
@@ -700,10 +610,8 @@ def test_Gemma3nTextAltUp_correct_signature():
 
 
 def test_Gemma3nModel_get_placeholder_mask_signature():
-    """gemma3n.py:201 patches
-    ``Gemma3nModel.get_placeholder_mask`` with match_level='relaxed'. Pin
-    the keyword params zoo forwards by name: ``input_ids``,
-    ``inputs_embeds``, ``image_features``, ``audio_features``."""
+    """gemma3n.py:201 patches ``Gemma3nModel.get_placeholder_mask`` with
+    match_level='relaxed'."""
     from transformers.models.gemma3n.modeling_gemma3n import Gemma3nModel
     _assert_params_superset(
         Gemma3nModel.get_placeholder_mask,
@@ -718,9 +626,8 @@ def test_Gemma3nModel_get_placeholder_mask_signature():
 
 def test_MinistralAttention_forward_signature():
     """ministral.py:99 patches MinistralAttention.forward with
-    match_level='relaxed'. zoo's replacement signature is
-    ``forward(self, hidden_states, position_embeddings, attention_mask=None,
-    past_key_values=None, cache_position=None, **kwargs)``."""
+    match_level='relaxed'. Pin ``hidden_states``,
+    ``position_embeddings``, ``attention_mask``."""
     try:
         from transformers.models.ministral.modeling_ministral import (
             MinistralAttention,
@@ -736,9 +643,9 @@ def test_MinistralAttention_forward_signature():
 
 def test_MinistralModel_forward_signature():
     """ministral.py:179 patches MinistralModel.forward with
-    match_level='relaxed'. zoo forwards by name: input_ids,
-    attention_mask, position_ids, past_key_values, inputs_embeds,
-    use_cache, cache_position."""
+    match_level='relaxed'. zoo forwards input_ids, attention_mask,
+    position_ids, past_key_values, inputs_embeds, use_cache,
+    cache_position by name."""
     try:
         from transformers.models.ministral.modeling_ministral import (
             MinistralModel,
@@ -761,9 +668,8 @@ def test_MinistralModel_forward_signature():
 
 
 def test_ministral_apply_rotary_pos_emb_signature():
-    """ministral.py:37 imports ``apply_rotary_pos_emb`` from ministral
-    and calls it ``apply_rotary_pos_emb(query_states, key_states, cos,
-    sin)`` -- 4 positionals."""
+    """ministral.py:37 -- ``apply_rotary_pos_emb(query_states, key_states,
+    cos, sin)`` 4 positionals."""
     try:
         from transformers.models.ministral.modeling_ministral import (
             apply_rotary_pos_emb,
@@ -782,11 +688,8 @@ def test_ministral_apply_rotary_pos_emb_signature():
 # ===========================================================================
 
 def test_GptOssExperts_class_present_and_init_takes_config():
-    """gpt_oss.py:1060 / 1070 / 1849 / 1858 monkey-patch
-    ``transformers.models.gpt_oss.modeling_gpt_oss.GptOssExperts``. The
-    class and its ``(self, config)`` __init__ must remain stable, since
-    zoo's GptOssExpertsBnb4bit / GptOssExperts override defines
-    ``__init__(self, config)``."""
+    """gpt_oss.py:1060/1070/1849/1858 monkey-patch ``GptOssExperts``.
+    Zoo's override defines ``__init__(self, config)``."""
     try:
         from transformers.models.gpt_oss.modeling_gpt_oss import GptOssExperts
     except ImportError:
@@ -799,10 +702,9 @@ def test_GptOssExperts_class_present_and_init_takes_config():
 
 
 def test_GptOssExperts_forward_signature():
-    """gpt_oss.py:1845 / 1852 replaces ``GptOssExperts.forward`` with
-    ``forward(self, hidden_states, router_indices=None,
-    routing_weights=None)``. Upstream must keep these param names since
-    they're forwarded by name."""
+    """gpt_oss.py:1845/1852 replaces
+    ``GptOssExperts.forward(self, hidden_states, router_indices=None,
+    routing_weights=None)``."""
     try:
         from transformers.models.gpt_oss.modeling_gpt_oss import GptOssExperts
     except ImportError:
@@ -815,9 +717,7 @@ def test_GptOssExperts_forward_signature():
 
 
 def test_GptOssTopKRouter_present():
-    """gpt_oss.py:1062 / 1077 monkey-patches
-    ``transformers.models.gpt_oss.modeling_gpt_oss.GptOssTopKRouter``.
-    The class must remain importable."""
+    """gpt_oss.py:1062/1077 monkey-patches ``GptOssTopKRouter``."""
     try:
         from transformers.models.gpt_oss.modeling_gpt_oss import (
             GptOssTopKRouter,
@@ -832,10 +732,9 @@ def test_GptOssTopKRouter_present():
 
 
 def test_GptOssAttention_forward_signature():
-    """gpt_oss.py:2201-2220 patches with ``pre_attention_decoding(self,
+    """gpt_oss.py:2201-2220 -- ``pre_attention_decoding(self,
     hidden_states, position_embeddings, attention_mask, past_key_values,
-    cache_position, **kwargs)``. The GptOssAttention.forward target
-    upstream must accept the same keyword forwarding."""
+    cache_position, **kwargs)``."""
     try:
         from transformers.models.gpt_oss.modeling_gpt_oss import (
             GptOssAttention,
@@ -851,8 +750,7 @@ def test_GptOssAttention_forward_signature():
 
 
 def test_GptOssModel_forward_signature():
-    """gpt_oss.py:2481 patches GptOssModel.forward with
-    match_level='relaxed'. Pin the kwargs zoo forwards by name."""
+    """gpt_oss.py:2481 patches GptOssModel.forward, match_level='relaxed'."""
     try:
         from transformers.models.gpt_oss.modeling_gpt_oss import GptOssModel
     except ImportError:
@@ -886,15 +784,12 @@ def test_GptOssPreTrainedModel_init_weights_signature():
 
 
 # ===========================================================================
-# Mxfp4 integrations (temporary_patches/gpt_oss.py:190/433/454/540/569)
+# Mxfp4 integrations (temporary_patches/gpt_oss.py)
 # ===========================================================================
 
 def test_mxfp4_swizzle_mxfp4_signature():
     """gpt_oss.py:190 patches
-    ``transformers.integrations.mxfp4.swizzle_mxfp4`` with
-    ``match_level='relaxed'``. The replacement signature in zoo accepts
-    ``w, w_scale, triton_kernels_hub`` -- upstream must keep at least
-    those three positional names."""
+    ``transformers.integrations.mxfp4.swizzle_mxfp4``, match_level='relaxed'."""
     try:
         from transformers.integrations.mxfp4 import swizzle_mxfp4
     except (ImportError, AttributeError):
@@ -907,10 +802,8 @@ def test_mxfp4_swizzle_mxfp4_signature():
 
 
 def test_mxfp4_load_and_swizzle_mxfp4_signature():
-    """gpt_oss.py:540 patches ``load_and_swizzle_mxfp4`` with
-    ``match_level='relaxed'``. zoo's replacement accepts
-    ``module, param_name, param_value, target_device,
-    triton_kernels_hub, **kwargs``."""
+    """gpt_oss.py:540 patches ``load_and_swizzle_mxfp4``,
+    match_level='relaxed'."""
     try:
         from transformers.integrations.mxfp4 import load_and_swizzle_mxfp4
     except (ImportError, AttributeError):
@@ -936,8 +829,7 @@ def test_mxfp4_replace_with_mxfp4_linear_signature():
 
 
 def test_mxfp4_mlp_forward_signature():
-    """gpt_oss.py:454 patches ``mlp_forward`` in
-    ``transformers.integrations.mxfp4``. zoo expects (self, hidden_states)."""
+    """gpt_oss.py:454 patches ``mlp_forward`` -- (self, hidden_states)."""
     try:
         from transformers.integrations.mxfp4 import mlp_forward
     except (ImportError, AttributeError):
@@ -955,9 +847,8 @@ def test_mxfp4_mlp_forward_signature():
 
 def test_AutoHfQuantizer_merge_quantization_configs_signature():
     """misc.py:153 patches
-    ``transformers.quantizers.auto.AutoHfQuantizer.merge_quantization_configs``.
-    zoo's replacement signature is ``(quantization_config,
-    quantization_config_from_args)``."""
+    ``transformers.quantizers.auto.AutoHfQuantizer.merge_quantization_configs(
+    quantization_config, quantization_config_from_args)``."""
     from transformers.quantizers.auto import AutoHfQuantizer
     _assert_params_superset(
         AutoHfQuantizer.merge_quantization_configs,
@@ -971,10 +862,9 @@ def test_AutoHfQuantizer_merge_quantization_configs_signature():
 # ===========================================================================
 
 def test_GraniteMoeHybridMambaLayer_cuda_kernels_forward_signature():
-    """misc.py:1061 patches
-    ``GraniteMoeHybridMambaLayer.cuda_kernels_forward`` -- the patch
-    expects ``(self, hidden_states, cache_params, cache_position,
-    attention_mask, seq_idx)``."""
+    """misc.py:1061 patches ``GraniteMoeHybridMambaLayer.cuda_kernels_forward
+    (self, hidden_states, cache_params, cache_position, attention_mask,
+    seq_idx)``."""
     try:
         from transformers.models.granitemoehybrid.modeling_granitemoehybrid import (
             GraniteMoeHybridMambaLayer,
@@ -990,9 +880,8 @@ def test_GraniteMoeHybridMambaLayer_cuda_kernels_forward_signature():
 
 def test_CsmForConditionalGeneration_merge_input_ids_signature():
     """misc.py:770 patches
-    ``CsmForConditionalGeneration._merge_input_ids_with_input_values``.
-    zoo's replacement signature is ``(self, input_ids, input_values,
-    input_values_cutoffs, labels)``."""
+    ``CsmForConditionalGeneration._merge_input_ids_with_input_values(self,
+    input_ids, input_values, input_values_cutoffs, labels)``."""
     try:
         from transformers.models.csm.modeling_csm import (
             CsmForConditionalGeneration,
@@ -1012,10 +901,9 @@ def test_CsmForConditionalGeneration_merge_input_ids_signature():
 # ===========================================================================
 
 def test_MllamaVisionEncoderLayer_forward_signature():
-    """misc.py:1146-1172 defines a replacement
-    ``MllamaVisionEncoderLayer.forward(self, hidden_state,
-    attention_mask=None)`` -- pin those param names. NOTE the upstream
-    uses ``hidden_state`` (singular), not ``hidden_states``."""
+    """misc.py:1146-1172 -- ``MllamaVisionEncoderLayer.forward(self,
+    hidden_state, attention_mask=None)``. NOTE: upstream uses
+    ``hidden_state`` (singular), not ``hidden_states``."""
     try:
         from transformers.models.mllama.modeling_mllama import (
             MllamaVisionEncoderLayer,
@@ -1037,13 +925,10 @@ def test_MllamaVisionEncoderLayer_forward_signature():
 # ===========================================================================
 
 def test_SiglipEncoderLayer_forward_signature():
-    """misc.py:1187-1228 defines a replacement
-    ``SiglipEncoderLayer.forward(self, hidden_states, attention_mask,
-    output_attentions=False)``. The replacement still references
-    ``output_attentions`` in the body, so upstream removing it (already
-    happened in some versions) leaves zoo's patched body broken when
-    callers stop passing it. Pin ``hidden_states`` + ``attention_mask``
-    as a minimum."""
+    """misc.py:1187-1228 -- ``SiglipEncoderLayer.forward(self,
+    hidden_states, attention_mask, output_attentions=False)``. zoo's
+    body still references ``output_attentions`` so upstream removing it
+    leaves the patched body broken when callers stop passing it."""
     from transformers.models.siglip.modeling_siglip import SiglipEncoderLayer
     _assert_params_superset(
         SiglipEncoderLayer.forward,
@@ -1053,13 +938,12 @@ def test_SiglipEncoderLayer_forward_signature():
 
 
 # ===========================================================================
-# Qwen3 MoE (qwen3_moe / qwen3_5_moe / qwen3_vl_moe / qwen3_next_moe)
+# Qwen3 MoE (qwen3_moe / qwen3_vl_moe / qwen3_next_moe)
 # ===========================================================================
 
 def test_Qwen3MoeSparseMoeBlock_forward_signature():
-    """qwen3_moe.py patches Qwen3MoeSparseMoeBlock.forward via
-    patch_function. zoo's replacement is single-positional
-    ``forward(self, hidden_states)``."""
+    """qwen3_moe.py patches ``Qwen3MoeSparseMoeBlock.forward(self,
+    hidden_states)``."""
     try:
         from transformers.models.qwen3_moe.modeling_qwen3_moe import (
             Qwen3MoeSparseMoeBlock,
@@ -1090,12 +974,11 @@ def test_Qwen3VLMoeTextSparseMoeBlock_forward_signature():
 
 
 def test_Qwen3VLMoeTextExperts_forward_signature():
-    """qwen3_vl_moe.py:376 patches Qwen3VLMoeTextExperts.forward. Zoo's
-    replacement signature is ``forward(self, hidden_states, top_k_index,
-    top_k_weights)`` BUT it overrides the upstream which uses
-    ``hidden_states, routing_weights, router_indices``. Pin only
-    ``hidden_states`` (1st positional) so the patch's positional arity
-    stays compatible."""
+    """qwen3_vl_moe.py:376 patches ``Qwen3VLMoeTextExperts.forward``.
+    Zoo's replacement is ``(self, hidden_states, top_k_index,
+    top_k_weights)`` while upstream uses ``(hidden_states,
+    routing_weights, router_indices)``; pin only positional arity (3
+    after self)."""
     try:
         from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
             Qwen3VLMoeTextExperts,
@@ -1111,8 +994,8 @@ def test_Qwen3VLMoeTextExperts_forward_signature():
 
 
 def test_Qwen3VLMoeTextExperts_init_signature():
-    """qwen3_vl_moe.py:242 patches ``Qwen3VLMoeTextExperts.__init__``
-    with ``patched_experts_init(self, config)``. Pin (self, config)."""
+    """qwen3_vl_moe.py:242 patches ``Qwen3VLMoeTextExperts.__init__(self,
+    config)``."""
     try:
         from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
             Qwen3VLMoeTextExperts,
@@ -1127,7 +1010,7 @@ def test_Qwen3VLMoeTextExperts_init_signature():
 
 
 def test_Qwen3NextSparseMoeBlock_forward_signature():
-    """qwen3_next_moe.py:67 patches Qwen3NextSparseMoeBlock.forward."""
+    """qwen3_next_moe.py:67 patches ``Qwen3NextSparseMoeBlock.forward``."""
     try:
         from transformers.models.qwen3_next.modeling_qwen3_next import (
             Qwen3NextSparseMoeBlock,
@@ -1146,8 +1029,8 @@ def test_Qwen3NextSparseMoeBlock_forward_signature():
 # ===========================================================================
 
 def test_DeepseekV3MoE_forward_signature():
-    """deepseek_v3_moe.py:125 patches DeepseekV3MoE.forward(self,
-    hidden_states)."""
+    """deepseek_v3_moe.py:125 patches ``DeepseekV3MoE.forward(self,
+    hidden_states)``."""
     try:
         from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
             DeepseekV3MoE,
@@ -1162,9 +1045,9 @@ def test_DeepseekV3MoE_forward_signature():
 
 
 def test_DeepseekV3ForCausalLM_forward_signature():
-    """deepseek_v3_moe.py:213 patches DeepseekV3ForCausalLM.forward.
-    Zoo's replacement forwards by name: input_ids, attention_mask,
-    position_ids, past_key_values, inputs_embeds, labels, use_cache."""
+    """deepseek_v3_moe.py:213 patches ``DeepseekV3ForCausalLM.forward``.
+    Zoo forwards input_ids, attention_mask, position_ids,
+    past_key_values, inputs_embeds, labels, use_cache by name."""
     try:
         from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
             DeepseekV3ForCausalLM,
@@ -1191,10 +1074,9 @@ def test_DeepseekV3ForCausalLM_forward_signature():
 # ===========================================================================
 
 def test_peft_dispatch_bnb_4bit_signature():
-    """misc.py:1297 wraps ``peft.tuners.lora.bnb.dispatch_bnb_4bit``
-    with ``def safe_dispatch_bnb_4bit(target, adapter_name, **kwargs)``.
-    Upstream must keep the first two positional params and the **kwargs
-    tail, else zoo's wrapper either drops or mis-positions arguments."""
+    """misc.py:1297 wraps ``peft.tuners.lora.bnb.dispatch_bnb_4bit`` with
+    ``safe_dispatch_bnb_4bit(target, adapter_name, **kwargs)``. Upstream
+    must keep the two positionals + **kwargs tail."""
     pytest.importorskip("peft")
     try:
         import peft.tuners.lora.bnb as peft_bnb
@@ -1212,9 +1094,8 @@ def test_peft_dispatch_bnb_4bit_signature():
 
 
 def test_peft_Linear4bit_importable():
-    """patching_utils.py:313 imports ``from peft.tuners.lora import
-    Linear4bit as Peft_Linear4bit`` and uses ``isinstance(module,
-    Peft_Linear4bit)``. Pin the import path."""
+    """patching_utils.py:313 -- ``from peft.tuners.lora import Linear4bit
+    as Peft_Linear4bit`` and ``isinstance(module, Peft_Linear4bit)``."""
     pytest.importorskip("peft")
     try:
         from peft.tuners.lora import Linear4bit  # noqa
@@ -1226,9 +1107,9 @@ def test_peft_Linear4bit_importable():
 
 
 def test_peft_get_peft_model_signature():
-    """peft.get_peft_model is the primary attach point used after
-    ``get_peft_regex`` in peft_utils.py. The signature must accept
-    ``model`` and ``peft_config`` (positionals 1 and 2)."""
+    """peft.get_peft_model is the primary attach point after
+    ``get_peft_regex`` in peft_utils.py. Must accept ``model`` and
+    ``peft_config`` as positionals."""
     pytest.importorskip("peft")
     from peft import get_peft_model
     _assert_positional_arity_at_least(
@@ -1239,15 +1120,13 @@ def test_peft_get_peft_model_signature():
 
 
 # ===========================================================================
-# Cache utilities (gemma4.py, qwen3_moe etc -- DynamicCache, StaticCache)
+# Cache utilities (gemma4.py, qwen3_moe etc)
 # ===========================================================================
 
 def test_DynamicCache_importable():
-    """gemma4.py:308 / 460 imports ``DynamicCache`` and ``StaticCache``
-    from ``transformers.cache_utils``. Confirm both still exist."""
+    """gemma4.py:308/460 -- ``from transformers.cache_utils import
+    DynamicCache, StaticCache``. Zoo callsites instantiate zero-arg."""
     from transformers.cache_utils import DynamicCache, StaticCache  # noqa
-    # All zoo callsites instantiate as ``DynamicCache()`` zero-arg; pin
-    # that there IS a callable constructor (signature varies wildly).
     if not callable(DynamicCache):
         pytest.fail("DRIFT DETECTED: DynamicCache is no longer callable.")
     if not callable(StaticCache):
@@ -1259,8 +1138,8 @@ def test_DynamicCache_importable():
 # ===========================================================================
 
 def test_bnb_Linear4bit_forward_signature():
-    """bitsandbytes.py:108 patches ``bitsandbytes.nn.modules.Linear4bit.forward``
-    with a replacement that takes ``(self, x)``."""
+    """bitsandbytes.py:108 patches
+    ``bitsandbytes.nn.modules.Linear4bit.forward(self, x)``."""
     bitsandbytes = pytest.importorskip("bitsandbytes")
     Linear4bit = getattr(bitsandbytes.nn.modules, "Linear4bit", None)
     if Linear4bit is None:
@@ -1281,9 +1160,8 @@ def test_bnb_Linear4bit_forward_signature():
 
 def test_vllm_SamplingParams_constructor():
     """vllm_utils.py's ``grpo_update_SamplingParams`` filters by
-    ``inspect.signature(vllm.SamplingParams).parameters``. If vllm
-    removes the constructor or changes it to a *args-only shape, the
-    filter swallows every kwarg silently."""
+    ``inspect.signature(vllm.SamplingParams).parameters``; a *args-only
+    shape swallows every kwarg silently."""
     vllm = pytest.importorskip("vllm")
     SamplingParams = getattr(vllm, "SamplingParams", None)
     if SamplingParams is None:

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -13,77 +13,16 @@
 
 """Drift detectors for ``unsloth_zoo`` source-string / regex rewriters.
 
-The companion files ``test_upstream_pinned_symbols_*.py`` and
-``test_zoo_source_upstream_refs.py`` cover *symbol-level* pins
-(``from <upstream> import <symbol>``). This file covers the OTHER half:
-the patches in ``unsloth_zoo/compiler.py`` and
-``unsloth_zoo/temporary_patches/*.py`` that fetch upstream function
-source via ``inspect.getsource`` and then ``str.replace`` / ``re.sub``
-against a specific literal string or regex.
+Patches in ``unsloth_zoo/compiler.py`` and
+``unsloth_zoo/temporary_patches/*.py`` fetch upstream function source
+via ``inspect.getsource`` and ``str.replace`` / ``re.sub`` against
+literal strings. If upstream renames/refactors/reflows the targeted
+region, the rewriter silently no-ops and the zoo patch becomes invisible.
 
-If upstream renames, refactors, or even reflows whitespace in the
-targeted region, the rewriter's ``str.replace`` silently no-ops and the
-zoo patch becomes invisible -- training proceeds without the fix, no
-exception is raised, and the regression only manifests at the
-benchmark level. This file is the loud canary for that class of drift.
-
-Test contract (mirrors ``test_upstream_import_fixes_drift.py``):
-
-  * Each test cites the zoo file:line it was extracted from in a
-    comment so a maintainer can grep back to the patch site.
-  * When the pinned string / regex is gone from the upstream module,
-    surface as ``pytest.fail("DRIFT DETECTED: zoo source-rewriter at
-    <zoo file:line> expects '<pattern>' in <upstream module>, not
-    found")``. Never SKIP to hide drift.
-  * If the upstream module isn't importable in this venv,
-    ``pytest.importorskip`` (not a SKIP-to-hide-drift; the module
-    simply isn't shipped on this transformers build).
-  * CPU-only -- runs under ``tests/conftest.py`` GPU-free harness.
-
-Patterns covered (zoo file:line → pattern):
-
-  unsloth_zoo/compiler.py:
-    298,304,308  GQA dropout enable_gqa replacement strings
-    316          if-output_attentions return super().forward regex
-    1379         ``self.config.ignore_index`` -> ``-100`` replacement
-    1404         per_layer_projection *= scale inplace fix
-    1827-1842    cross_entropy regex tokens ($CROSSENTROPYLOSS,
-                 $VOCABSIZE, $LABELSDEVICE, ...) -- via lm_head
-                 forward source presence
-    2192-2225   custom_gradient_checkpointing_replacements Qwen2VL
-                 ``hidden_states = blk(...)`` pinned strings
-    2423-2426   MOE_ROUTING_WEIGHTS_CAST_PATTERN regex
-    2539,2542,2543  PEFT lora forward old1/old2 pinned strings
-    2614-2616   8-bit base_layer call pinned string
-    2815-2825   Gemma 3N final_logit_softcapping str.replace targets
-    2831-2842   Gemma 4 flat_logits/flat_labels str.replace targets
-    3469-3478   causal_mask_find / scaled_dot_product_attention regex
-    3988-3990   Trainer ``logger.info('... Running training')`` regex
-    4027,4035   Trainer ``tpu_spmd_dataloader``,
-                 ``is_torch_tpu_available`` str.replace targets
-
-  unsloth_zoo/temporary_patches/misc.py:
-    133-136     AutoHfQuantizer.merge_quantization_configs single-line
-                 ``if quantization_config.__class__.__name__ ...``
-                 pinned string
-
-  unsloth_zoo/temporary_patches/misc.py:
-    1170-1172   MllamaVisionEncoder.forward ``gradient_checkpointing``
-                 substring probe
-
-  unsloth_zoo/temporary_patches/gpt_oss.py:
-    2808-2810   GptOssConfig source equality probe
-
-  unsloth/import_fixes.py (mirrored for zoo benefit):
-    609-670    PreTrainedModel.enable_input_require_grads pattern
-                 ``for module in self.modules()`` -- the
-                 ``new pattern`` the unsloth patch fires on.
-
-Because this is a drift detector, ``pytest.fail`` is emitted when the
-pinned pattern is MISSING (the rewriter would silently no-op). When the
-pattern is present, the rewriter still works -- the test passes.
-
-Runs under the GPU-free harness in ``tests/conftest.py``.
+DRIFT-DETECTED framing: when the pinned string / regex is gone, fire
+``pytest.fail("DRIFT DETECTED: zoo source-rewriter at <zoo file:line>
+expects '<pattern>' in <upstream module>, not found")``. Each test
+cites the zoo file:line it pins.
 """
 
 from __future__ import annotations
@@ -100,7 +39,6 @@ import pytest
 
 def _drift(zoo_site: str, pattern: str, upstream_path: str,
            extra: str = "") -> None:
-    """Raise ``pytest.fail`` with the standardized DRIFT message."""
     msg = (
         f"DRIFT DETECTED: zoo source-rewriter at {zoo_site} expects "
         f"{pattern!r} in {upstream_path}, not found."
@@ -112,7 +50,6 @@ def _drift(zoo_site: str, pattern: str, upstream_path: str,
 
 def _assert_in_source(needle: str, source: str, zoo_site: str,
                       upstream_path: str) -> None:
-    """Assert ``needle`` is in ``source`` or fire DRIFT."""
     if needle not in source:
         _drift(zoo_site, needle, upstream_path)
 
@@ -120,23 +57,18 @@ def _assert_in_source(needle: str, source: str, zoo_site: str,
 def _assert_regex_in_source(regex: str, source: str, zoo_site: str,
                             upstream_path: str,
                             flags: int = 0) -> None:
-    """Assert ``regex`` matches ``source`` or fire DRIFT."""
     if re.search(regex, source, flags=flags) is None:
         _drift(zoo_site, regex, upstream_path)
 
 
 def _get_source_of(dotted: str):
-    """``import`` the dotted path's parent module and return
-    ``inspect.getsource`` on the leaf. If the leaf or its parent are
-    missing the test ``importorskip`` (the module isn't shipped in this
-    transformers build; not a drift -- the rewriter wouldn't run
-    either)."""
+    """Import dotted parent module and return ``inspect.getsource`` on
+    the leaf. Missing leaf/parent -> ``importorskip`` (not drift)."""
     parts = dotted.split(".")
-    # Walk down to the leaf, ``importorskip``-ing at each module
-    # boundary.
     import importlib
     obj = None
     mod_name = None
+    consumed = 0
     for i in range(len(parts), 0, -1):
         candidate = ".".join(parts[:i])
         try:
@@ -148,8 +80,6 @@ def _get_source_of(dotted: str):
             continue
     if obj is None:
         pytest.importorskip(parts[0])
-        # importorskip should have raised SkipTest above -- this is a
-        # defensive return.
         return None  # pragma: no cover
     for attr in parts[consumed:]:
         try:
@@ -168,25 +98,14 @@ def _get_source_of(dotted: str):
 
 def test_compiler_gqa_enable_gqa_dropout_pinned_string_self_dropout():
     """``unsloth_zoo/compiler.py:304-307`` pins
-    ``"dropout_p=self.dropout if self.training else 0.0,"`` against
-    any attention-module forward that uses scaled_dot_product_attention.
-    The rewriter inserts ``enable_gqa=...`` after this exact substring.
+    ``"dropout_p=self.dropout if self.training else 0.0,"`` -- the
+    rewriter inserts ``enable_gqa=...`` after this substring.
 
-    This is a KNOWN ACTIVE DRIFT on transformers >=4.50: upstream
-    switched to ``dropout=self.attention_dropout if self.training
-    else 0.0,`` (no ``_p`` suffix). When that flip happens, zoo's
-    ``str.replace`` no-ops and the GQA fast-path is dormant.
-
-    Drift-detector contract: pass when EITHER the old ``dropout_p=``
-    form OR the broader ``dropout=...if self.training...`` form is
-    present in at least one attention module -- so a maintainer
-    knows the zoo str.replace target is still discoverable. Fail
-    only if the entire idiom is gone (upstream re-architected the
-    SDPA call site).
-    """
+    Known active drift on transformers >=4.50: upstream switched to
+    ``dropout=self.attention_dropout if self.training else 0.0,``
+    (no ``_p`` suffix). Pass if any old-or-new form is present
+    anywhere; fail only if the idiom is entirely gone."""
     pytest.importorskip("transformers")
-    # Probe a handful of modules; at least ONE must contain the pinned
-    # string for the rewriter to ever fire.
     candidate_modules = [
         "transformers.models.llama.modeling_llama",
         "transformers.models.mistral.modeling_mistral",
@@ -197,12 +116,6 @@ def test_compiler_gqa_enable_gqa_dropout_pinned_string_self_dropout():
         "transformers.models.gemma3.modeling_gemma3",
     ]
     import importlib
-    # Broader probe: zoo pins ``dropout_p=`` but accepts that upstream
-    # may have flipped to ``dropout=``. As long as ONE of these forms
-    # is present, the rewriter target shape is discoverable -- a
-    # maintainer can adapt the str.replace once we surface drift.
-    # Real DRIFT is when neither form is present anywhere (upstream
-    # re-architected the SDPA call site entirely).
     needles = (
         "dropout_p=self.dropout if self.training else 0.0,",
         "dropout_p=self.attention_dropout if self.training else 0.0,",
@@ -231,19 +144,11 @@ def test_compiler_gqa_enable_gqa_dropout_pinned_string_self_dropout():
 
 
 def test_compiler_replace_gqa_finder_regex():
-    """``unsloth_zoo/compiler.py:262-282`` builds the
-    ``grouped_query_attention_finder`` regex that targets the
-    ``key_states = repeat_kv(...) / value_states = repeat_kv(...) /
-    ... / query_states = query_states.contiguous() / key_states =
-    key_states.contiguous() / value_states = value_states.contiguous()``
-    chunk. Probes for the HEAD of the finder regex (``repeat_kv``
-    call) in any attention module.
-
-    In transformers >=4.50 the explicit ``repeat_kv`` + contiguous
-    chain was inlined into ``eager_attention_forward``, so the
-    finder regex may match 0 times on all modules -- the GQA rewrite
-    is then dormant.
-    """
+    """``unsloth_zoo/compiler.py:262-282`` -- the
+    ``grouped_query_attention_finder`` regex targets ``key_states =
+    repeat_kv(...) / value_states = repeat_kv(...) / ... contiguous()``.
+    transformers >=4.50 inlined repeat_kv into eager_attention_forward,
+    so the finder may match 0 times -> rewrite dormant."""
     pytest.importorskip("transformers")
     import importlib
     head = re.compile(r"key_states\s*=\s*repeat_kv\(")
@@ -267,7 +172,7 @@ def test_compiler_replace_gqa_finder_regex():
         except OSError:
             continue
         if head.search(src):
-            return  # OK
+            return
     _drift(
         "unsloth_zoo/compiler.py:262-282",
         r"key_states = repeat_kv(...)",
@@ -279,22 +184,13 @@ def test_compiler_replace_gqa_finder_regex():
 
 
 def test_compiler_output_attentions_super_forward_regex_targetable():
-    """``unsloth_zoo/compiler.py:316-321`` runs
-    ``re.sub(r'if output_attentions\\:.+?return super\\(\\).forward.+?\\)', ...)``
-    over attention-module forwards. The exact ``if output_attentions:
-    ... return super().forward(...)`` chain was the pre-4.50 SDPA-to-
-    eager fallback inside attention layers. Pass if the ``if
-    output_attentions`` marker is still discoverable anywhere in the
-    attention modules so a maintainer can re-anchor the regex;
-    Fail only if the marker is completely gone.
-    """
+    """``unsloth_zoo/compiler.py:316-321`` runs re.sub for
+    ``if output_attentions: ... return super().forward(...)``. 4.57
+    removed the immediate ``return super().forward`` follow-up; pass if
+    ``if output_attentions`` marker is still discoverable so a
+    maintainer can re-anchor."""
     pytest.importorskip("transformers")
     import importlib
-    # Broader probe: `if output_attentions` is still a common shape
-    # in modeling files (used to wire all_self_attns return); zoo's
-    # exact rewriter regex requires the immediate `return super().forward`
-    # follow-up which 4.57 removed. As long as the marker exists, a
-    # maintainer has a re-anchor target -- fail if it's gone entirely.
     marker = "if output_attentions"
     candidate_modules = [
         "transformers.models.llama.modeling_llama",
@@ -330,18 +226,11 @@ def test_compiler_output_attentions_super_forward_regex_targetable():
 
 def test_compiler_self_config_ignore_index_replacement():
     """``unsloth_zoo/compiler.py:1379`` runs
-    ``source.replace("self.config.ignore_index", "-100")`` on every
-    compiled class. Asserts a Gemma3 / Llava-style VLM forward still
-    contains the pinned substring -- the rewriter targets the
-    ``Gemma 3 ignore_index being not set`` regression specifically.
-    """
+    ``source.replace("self.config.ignore_index", "-100")``. By 4.57
+    only qwen2_audio still references it; pass if any upstream model
+    still has the exact string."""
     pytest.importorskip("transformers")
     import importlib
-    # Probe widely: ignore_index lived in many VLMs originally; by
-    # 4.57 only qwen2_audio still references it. The patch target is
-    # reachable as long as AT LEAST ONE upstream model still has the
-    # exact string -- because zoo.compiler.py:1379 fires on every
-    # compiled class.
     candidate_modules = [
         "transformers.models.gemma3.modeling_gemma3",
         "transformers.models.llava.modeling_llava",
@@ -377,11 +266,9 @@ def test_compiler_self_config_ignore_index_replacement():
 
 
 def test_compiler_per_layer_projection_inplace_regex():
-    """``unsloth_zoo/compiler.py:1404-1407`` rewrites
+    """``unsloth_zoo/compiler.py:1404-1407`` rewrites Gemma 3N's
     ``per_layer_projection *= self.per_layer_projection_scale.to(...)``
-    in Gemma 3N to a non-inplace form. Asserts the pinned regex still
-    matches Gemma 3N source.
-    """
+    to a non-inplace form."""
     pytest.importorskip("transformers")
     try:
         import transformers.models.gemma3n.modeling_gemma3n as g3n
@@ -400,13 +287,9 @@ def test_compiler_per_layer_projection_inplace_regex():
 
 
 def test_compiler_cross_entropy_lm_head_pattern_present():
-    """``unsloth_zoo/compiler.py:1508-1525`` (`cross_entropy_find_1`)
+    """``unsloth_zoo/compiler.py:1508-1525`` (cross_entropy_find_1)
     expects ``logits = self.lm_head(hidden_states`` at the head of the
-    loss block in every ForCausalLM forward, followed by
-    ``shift_logits = logits[..., :-1, :]`` and
-    ``CrossEntropyLoss()``. Asserts a representative Llama/Mistral
-    ForCausalLM forward still leads with the pinned shape.
-    """
+    loss block in every ForCausalLM forward."""
     pytest.importorskip("transformers")
     import importlib
     candidate_classes = [
@@ -446,11 +329,8 @@ def test_compiler_cross_entropy_lm_head_pattern_present():
 
 
 def test_compiler_cross_entropy_find_2_loss_function_signature():
-    """``unsloth_zoo/compiler.py:1593-1600`` (`cross_entropy_find_2`)
-    pins ``loss = self.loss_function(...$LOGITS$, $LABELS$,
-    $VOCABSIZE$...)``. Asserts that at least one ForCausalLM in
-    transformers still routes loss through ``self.loss_function``.
-    """
+    """``unsloth_zoo/compiler.py:1593-1600`` (cross_entropy_find_2) pins
+    ``loss = self.loss_function(...$LOGITS$, $LABELS$, $VOCABSIZE$...)``."""
     pytest.importorskip("transformers")
     import importlib
     candidate_classes = [
@@ -484,12 +364,9 @@ def test_compiler_cross_entropy_find_2_loss_function_signature():
 
 
 def test_compiler_cross_entropy_find_3_shift_logits_pattern():
-    """``unsloth_zoo/compiler.py:1683-1700`` (`cross_entropy_find_3`)
-    pins ``shift_logits = logits[..., :-1, :]`` /
-    ``shift_labels = labels[..., 1:]`` / ``CrossEntropyLoss()`` in
-    VLM ForConditionalGeneration forwards. Asserts Gemma 3 still uses
-    this shape.
-    """
+    """``unsloth_zoo/compiler.py:1683-1700`` (cross_entropy_find_3) pins
+    ``shift_logits = logits[..., :-1, :]`` / ``shift_labels = labels[..., 1:]``
+    in VLM ForConditionalGeneration forwards."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.gemma3.modeling_gemma3 import (
@@ -515,19 +392,10 @@ def test_compiler_cross_entropy_find_3_shift_logits_pattern():
 
 
 def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
-    """``unsloth_zoo/compiler.py:2192-2207`` pins the Qwen2-VL visual
-    block call as a multiline raw string:
-
-        hidden_states = blk(
-                hidden_states,
-                cu_seqlens=cu_seqlens,
-                position_embeddings=position_embeddings,
-                **kwargs,
-            )
-
-    If upstream re-indents (4 -> 8 spaces, or different keyword order)
-    the str.replace silently no-ops.
-    """
+    """``unsloth_zoo/compiler.py:2192-2207`` pins the Qwen2-VL multiline
+    raw string ``hidden_states = blk(\\n hidden_states,\\n
+    cu_seqlens=cu_seqlens,\\n position_embeddings=position_embeddings,\\n
+    **kwargs,\\n )``. A re-indent silently no-ops."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.qwen2_vl.modeling_qwen2_vl import (
@@ -552,14 +420,9 @@ def test_compiler_custom_gradient_checkpointing_qwen2_vl_blk():
 
 
 def test_compiler_moe_routing_weights_cast_pattern():
-    """``unsloth_zoo/compiler.py:2423-2425``
-    ``MOE_ROUTING_WEIGHTS_CAST_PATTERN`` =
-    ``(\\brouting_weights\\s*=\\s*routing_weights\\.to\\(\\s*)hidden_states(\\.dtype\\s*\\))``.
-
-    Asserts at least one MoE forward still has the
-    ``routing_weights = routing_weights.to(hidden_states.dtype)``
-    line, otherwise the bf16 router-logit dtype fix is invisible.
-    """
+    """``unsloth_zoo/compiler.py:2423-2425`` MOE_ROUTING_WEIGHTS_CAST_PATTERN
+    targets ``routing_weights = routing_weights.to(hidden_states.dtype)``;
+    needed for the bf16 router-logit dtype fix."""
     pytest.importorskip("transformers")
     import importlib
     pattern = re.compile(
@@ -591,16 +454,10 @@ def test_compiler_moe_routing_weights_cast_pattern():
 
 
 def test_compiler_peft_lora_forward_pinned_strings():
-    """``unsloth_zoo/compiler.py:2542-2543`` pins TWO peft LoRA
-    forward shapes:
-
+    """``unsloth_zoo/compiler.py:2542-2543`` pins:
         old1: "output = lora_B(lora_A(dropout(x))) * scaling"
         old2: "result = result + lora_B(lora_A(dropout(x))) * scaling"
-
-    If peft's ``Linear.forward`` drops parens / variable names, the
-    fast LoRA forward replacement no-ops and `unsloth_forward` is
-    never installed.
-    """
+    If peft drops parens/names, the fast LoRA forward never installs."""
     pytest.importorskip("peft")
     try:
         from peft.tuners.lora.layer import Linear as LoraLinear
@@ -623,8 +480,7 @@ def test_compiler_peft_lora_forward_pinned_strings():
 def test_compiler_peft_lora_base_layer_call_pinned_string():
     """``unsloth_zoo/compiler.py:2615,2631`` pins
     ``"result = self.base_layer(x, *args, **kwargs)"`` -- the 8-bit
-    base-layer call site, replaced with a dynamo-disabled helper.
-    """
+    base-layer call site, replaced with a dynamo-disabled helper."""
     pytest.importorskip("peft")
     try:
         from peft.tuners.lora.layer import Linear as LoraLinear
@@ -643,25 +499,15 @@ def test_compiler_peft_lora_base_layer_call_pinned_string():
 
 
 def test_compiler_gemma3n_final_logit_softcapping_walrus():
-    """``unsloth_zoo/compiler.py:2815-2825`` pins:
-
-        if (final_logit_softcapping := self.config.get_text_config().final_logit_softcapping) is not None:
-
-    AND
-
-        logits = logits / final_logit_softcapping
-        logits = logits * final_logit_softcapping
-
-    in Gemma 3N's ForConditionalGeneration forward. The rewriter
-    inlines `self.config.get_text_config().final_logit_softcapping`
-    so the LM-head fuser regex (cross_entropy_find_3) can match.
-    """
+    """``unsloth_zoo/compiler.py:2815-2825`` pins the walrus form
+    ``if (final_logit_softcapping := self.config.get_text_config()
+    .final_logit_softcapping) is not None:`` in Gemma 3N's
+    ForConditionalGeneration forward."""
     pytest.importorskip("transformers")
     try:
         import transformers.models.gemma3n.modeling_gemma3n as g3n
     except ImportError:
         pytest.skip("transformers.models.gemma3n not shipped")
-    # Find any ForConditionalGeneration class in the module
     src_module = inspect.getsource(g3n)
     needle_walrus = (
         "if (final_logit_softcapping := "
@@ -676,11 +522,9 @@ def test_compiler_gemma3n_final_logit_softcapping_walrus():
 
 
 def test_compiler_gemma3n_softcapping_divide_multiply_pins():
-    """``unsloth_zoo/compiler.py:2820-2825`` additionally pins:
-
-        logits = logits / final_logit_softcapping
-        logits = logits * final_logit_softcapping
-    """
+    """``unsloth_zoo/compiler.py:2820-2825`` also pins
+    ``logits = logits / final_logit_softcapping`` and
+    ``logits = logits * final_logit_softcapping``."""
     pytest.importorskip("transformers")
     try:
         import transformers.models.gemma3n.modeling_gemma3n as g3n
@@ -699,21 +543,13 @@ def test_compiler_gemma3n_softcapping_divide_multiply_pins():
 
 
 def test_compiler_gemma4_flat_logits_flat_labels_pins():
-    """``unsloth_zoo/compiler.py:2831-2842`` pins three Gemma 4
-    LM-head shape strings:
-
-        flat_logits = shift_logits.view(-1,
-        flat_labels = shift_labels.view(-1).to(...)
-        loss = loss_fct(flat_logits, flat_labels)
-
-    so the rewriter can renormalize them to shift_* form. We probe
-    Gemma 4 only -- the module may not exist on older transformers
-    builds.
-    """
+    """``unsloth_zoo/compiler.py:2831-2842`` pins Gemma 4 LM-head shape
+    strings; rewriter is forward-looking (Gemma 4 lands in >= 4.58).
+    Skip cleanly when pattern is absent."""
     pytest.importorskip("transformers")
     g4 = None
     for candidate in (
-        "transformers.models.gemma3.modeling_gemma3",  # gemma4 sometimes co-shipped
+        "transformers.models.gemma3.modeling_gemma3",
     ):
         try:
             g4 = __import__(candidate, fromlist=["*"])
@@ -727,18 +563,12 @@ def test_compiler_gemma4_flat_logits_flat_labels_pins():
     except ImportError:
         pytest.skip("Neither gemma3 nor gemma4 modeling shipped")
     src = inspect.getsource(g4)
-    # Gemma 4's pattern is a future-proof rewrite; if NONE of the
-    # pinned strings are present anywhere in the gemma family, the
-    # fix is dead.
     needles = (
         "flat_logits = shift_logits.view(-1,",
         "loss = loss_fct(flat_logits, flat_labels)",
     )
     found_any = any(n in src for n in needles)
     if not found_any:
-        # Gemma 4 wasn't part of 4.57.x; the rewriter is forward-looking.
-        # Don't fail here -- record as skip with explanation so a future
-        # release surfaces this test.
         pytest.skip(
             "Gemma 4 flat_logits pattern absent; rewriter is "
             "forward-looking (transformers >= 4.58 introduces Gemma 4)."
@@ -746,25 +576,12 @@ def test_compiler_gemma4_flat_logits_flat_labels_pins():
 
 
 def test_compiler_causal_mask_find_regex_pattern():
-    """``unsloth_zoo/compiler.py:3469-3473`` -- the
-    ``causal_mask_find`` regex inside ``create_standalone_class`` for
-    SDPA modules:
-
-        is_causal = True if (.+?_mask) is None and q_len > 1 else False
-        ...scaled_dot_product_attention(...attn_mask=..._mask...is_causal=...)
-
-    Probes for the ``causal_mask`` / ``is_causal`` markers + a
-    ``scaled_dot_product_attention`` call site somewhere in the
-    attention modules. In transformers >=4.50 the literal ``q_len > 1``
-    branch was folded away, but ``scaled_dot_product_attention`` is
-    still reachable.
-    """
+    """``unsloth_zoo/compiler.py:3469-3473`` causal_mask_find regex
+    targets ``is_causal = True if (.+?_mask) is None and q_len > 1
+    else False`` + scaled_dot_product_attention. Pass as long as
+    dispatcher + is_causal markers exist."""
     pytest.importorskip("transformers")
     import importlib
-    # Broader probe: as long as one module has scaled_dot_product_attention
-    # AND something like an is_causal assignment, the
-    # `create_standalone_class` SDPA fixup branch can fire even on
-    # the wider re.sub fallback.
     candidate_modules = [
         "transformers.models.llama.modeling_llama",
         "transformers.models.mistral.modeling_mistral",
@@ -801,13 +618,10 @@ def test_compiler_causal_mask_find_regex_pattern():
 
 
 def test_compiler_trainer_running_training_logger_regex():
-    """``unsloth_zoo/compiler.py:3988-3990`` runs
-    ``re.search(r'logger\\.info\\([\"'].+?Running training', ...)``
-    against ``Trainer._inner_training_loop`` source. The rewriter
-    splices the Unsloth banner in BEFORE this line. If upstream
-    renames the marker (e.g. ``logger.debug``, or drops the banner),
-    the splice site is lost and ``.span()[0]`` raises AttributeError.
-    """
+    """``unsloth_zoo/compiler.py:3988-3990`` re.searches
+    ``logger.info('***** Running training *****')`` in
+    ``Trainer._inner_training_loop``; rewriter splices the Unsloth
+    banner before this line."""
     pytest.importorskip("transformers")
     from transformers.trainer import Trainer
     try:
@@ -825,13 +639,9 @@ def test_compiler_trainer_running_training_logger_regex():
 
 
 def test_compiler_trainer_tpu_spmd_dataloader_pinned_string():
-    """``unsloth_zoo/compiler.py:4026-4029`` runs
-    ``inner_training_loop.replace(``
-        ``"train_dataloader = tpu_spmd_dataloader(train_dataloader)",``
-        ``"raise RuntimeError('Unsloth: TPUs are not yet supported!')",``
-    ``)``. If upstream drops the TPU SPMD shim, the replace no-ops
-    and ``_fast_inner_training_loop`` carries dead TPU code.
-    """
+    """``unsloth_zoo/compiler.py:4026-4029`` replaces
+    ``train_dataloader = tpu_spmd_dataloader(train_dataloader)`` with
+    a RuntimeError TPU stub."""
     pytest.importorskip("transformers")
     from transformers.trainer import Trainer
     try:
@@ -847,14 +657,9 @@ def test_compiler_trainer_tpu_spmd_dataloader_pinned_string():
 
 
 def test_compiler_trainer_is_torch_tpu_available_pinned_string():
-    """``unsloth_zoo/compiler.py:4035-4038`` runs
-    ``inner_training_loop.replace("is_torch_tpu_available()", "False")``.
-    Modern transformers (>=4.41) renamed this to
-    ``is_torch_xla_available``. Pattern is "active" if EITHER name
-    appears -- a maintainer can update zoo's str.replace to the new
-    name. DRIFT (fail) is only when BOTH are missing -- the whole TPU
-    detection branch is gone, and zoo's TPU-disable shim has no target.
-    """
+    """``unsloth_zoo/compiler.py:4035-4038`` replaces
+    ``is_torch_tpu_available()`` with ``False``. Modern transformers
+    renamed to ``is_torch_xla_available``; pass if EITHER name appears."""
     pytest.importorskip("transformers")
     from transformers.trainer import Trainer
     try:
@@ -875,11 +680,8 @@ def test_compiler_trainer_is_torch_tpu_available_pinned_string():
 
 
 def test_compiler_trainer_inner_training_loop_rename_pinned_string():
-    """``unsloth_zoo/compiler.py:4030-4034`` renames the function:
-    ``"_inner_training_loop" -> "_fast_inner_training_loop"`` with
-    ``replace(..., 1)``. The source MUST contain the literal
-    ``_inner_training_loop`` token at the top of the function def.
-    """
+    """``unsloth_zoo/compiler.py:4030-4034`` renames
+    ``_inner_training_loop -> _fast_inner_training_loop``."""
     pytest.importorskip("transformers")
     from transformers.trainer import Trainer
     try:
@@ -899,16 +701,11 @@ def test_compiler_trainer_inner_training_loop_rename_pinned_string():
 # ===========================================================================
 
 def test_misc_merge_quantization_configs_class_name_compare():
-    """``unsloth_zoo/temporary_patches/misc.py:133-136`` pins the
-    EXACT single-line form:
-
-        if quantization_config.__class__.__name__ != quantization_config_from_args.__class__.__name__:
-
-    in ``AutoHfQuantizer.merge_quantization_configs``. Modern
-    transformers reflowed this to a multiline `if (... \\n ... and
-    ... != ...)`. If single-line is absent, the zoo str.replace
-    silently no-ops and the Mxfp4Config-vs-None error returns.
-    """
+    """``unsloth_zoo/temporary_patches/misc.py:133-136`` pins the single-line
+    ``if quantization_config.__class__.__name__ !=
+    quantization_config_from_args.__class__.__name__:``. Modern
+    transformers reflowed this; pass as long as BOTH class-name compares
+    are present somewhere."""
     pytest.importorskip("transformers")
     try:
         from transformers.quantizers.auto import AutoHfQuantizer
@@ -920,23 +717,8 @@ def test_misc_merge_quantization_configs_class_name_compare():
         pytest.skip(
             "AutoHfQuantizer.merge_quantization_configs source unavailable"
         )
-    needle = (
-        "if quantization_config.__class__.__name__ != "
-        "quantization_config_from_args.__class__.__name__:"
-    )
-    # The exact single-line `if X.__class__.__name__ != Y.__class__.__name__:`
-    # form was reflowed to a multi-line `if (X is not None and
-    # X.__class__.__name__ != Y.__class__.__name__):` block in
-    # transformers >=4.55 (which fixes the very issue zoo was patching).
-    # As long as BOTH class-name compares are still present somewhere
-    # in the function the zoo str.replace's *target shape* is broadly
-    # discoverable.
-    class_name_check = (
-        "quantization_config.__class__.__name__"
-    )
-    args_class_name_check = (
-        "quantization_config_from_args.__class__.__name__"
-    )
+    class_name_check = "quantization_config.__class__.__name__"
+    args_class_name_check = "quantization_config_from_args.__class__.__name__"
     if (class_name_check not in src) or (args_class_name_check not in src):
         _drift(
             "unsloth_zoo/temporary_patches/misc.py:133-136",
@@ -951,15 +733,8 @@ def test_misc_merge_quantization_configs_class_name_compare():
 
 def test_misc_mllama_vision_encoder_gradient_checkpointing_probe():
     """``unsloth_zoo/temporary_patches/misc.py:1170-1172`` probes
-    ``MllamaVisionEncoder.forward`` source for the substring
-    ``"gradient_checkpointing"``. If absent (older transformers),
-    the patch installs Unsloth's MllamaVisionEncoderLayer. The
-    DRIFT case here is the opposite: if upstream removes the
-    encoder class entirely the patch becomes irrelevant.
-
-    We assert the encoder class STILL EXISTS so the patch site is
-    reachable.
-    """
+    ``MllamaVisionEncoder.forward`` for ``"gradient_checkpointing"``.
+    Drift = encoder class removed -> patch unreachable."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.mllama.modeling_mllama import (
@@ -979,9 +754,6 @@ def test_misc_mllama_vision_encoder_gradient_checkpointing_probe():
             "and the encoder-layer replacement won't install.",
         )
         return
-    # We don't require gradient_checkpointing to BE in the source --
-    # the patch precisely handles both cases. We only assert the
-    # probe target is reachable.
     assert isinstance(src, str) and "def forward" in src, (
         "DRIFT DETECTED: MllamaVisionEncoder.forward source unrecognizable; "
         "the zoo substring probe will misbehave."
@@ -993,24 +765,11 @@ def test_misc_mllama_vision_encoder_gradient_checkpointing_probe():
 # ===========================================================================
 
 def test_gpt_oss_config_class_source_equality_probe():
-    """``unsloth_zoo/temporary_patches/gpt_oss.py:2808-2810`` runs:
-
-        current_class = dedent(inspect.getsource(GptOssConfig))
-        new_class = dedent(inspect.getsource(Old_GptOssConfig)).replace(
-            "Old_GptOssConfig", "GptOssConfig"
-        )
-        if new_class == current_class: patch_function(...)
-
-    This is a "source-equality" probe -- the patch ONLY fires when
-    upstream's GptOssConfig matches the OLD shape exactly. Tiny
-    upstream churn (extra blank line, reordered field) silently
-    disables the patch.
-
-    DRIFT contract: the underlying ``GptOssConfig`` class MUST exist
-    AND ``max_position_embeddings`` MUST appear in its source -- if
-    not, the original regression (missing `max_position_embeddings`)
-    is back AND the patch can't even compare.
-    """
+    """``unsloth_zoo/temporary_patches/gpt_oss.py:2808-2810`` runs a
+    source-equality probe between ``GptOssConfig`` and the bundled
+    ``Old_GptOssConfig``. Drift contract: GptOssConfig must exist AND
+    ``max_position_embeddings`` must appear; otherwise the regression
+    the Old_GptOssConfig patch was introduced to fix is ACTIVE."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.gpt_oss.configuration_gpt_oss import (
@@ -1040,25 +799,12 @@ def test_gpt_oss_config_class_source_equality_probe():
 
 def test_unsloth_import_fixes_enable_input_require_grads_modules_loop():
     """``unsloth/import_fixes.py:609-670``'s
-    ``patch_enable_input_require_grads`` fires ONLY when
-    ``"for module in self.modules()" in inspect.getsource(
-    PreTrainedModel.enable_input_require_grads)``.
-
-    The NEW upstream shape (transformers >=5.0, PR #41993) iterates
-    over ``self.modules()``; the OLD shape is a one-liner
-    ``self._require_grads_hook = self.get_input_embeddings()...``.
-
-    Drift detector contract (drift = pattern unreachable):
-      * If neither old NOR new shape is recognizable -- DRIFT.
-      * If the old one-liner is gone but the new loop is present --
-        OK; the unsloth patch is now active.
-      * If the old one-liner is still present (transformers <=4.57)
-        the unsloth patch correctly no-ops on this venv -- OK.
-
-    Zoo would benefit from mirroring this patch since vision models
-    raise NotImplementedError from ``get_input_embeddings()``; this
-    test pins the upstream shape so a maintainer can mirror it.
-    """
+    ``patch_enable_input_require_grads`` fires only when ``"for module
+    in self.modules()"`` is in
+    ``PreTrainedModel.enable_input_require_grads`` source. Old shape is
+    a one-liner ``self._require_grads_hook = self.get_input_embeddings()
+    .register_forward_hook(make_inputs_require_grads)``. Drift = neither
+    shape recognizable."""
     pytest.importorskip("transformers")
     from transformers import PreTrainedModel
     try:
@@ -1079,10 +825,8 @@ def test_unsloth_import_fixes_enable_input_require_grads_modules_loop():
     )
     new_modules_loop = "for module in self.modules()"
     if new_modules_loop in src:
-        # New upstream shape, unsloth's patch is active. OK.
         return
     if old_one_liner in src:
-        # Pre-5.0 transformers; unsloth's patch correctly no-ops. OK.
         return
     _drift(
         "unsloth/import_fixes.py:609-670",
@@ -1096,12 +840,9 @@ def test_unsloth_import_fixes_enable_input_require_grads_modules_loop():
 
 
 def test_unsloth_import_fixes_make_inputs_require_grads_inner_fn():
-    """``unsloth/import_fixes.py:609-670``'s replacement function also
-    references the inner ``def make_inputs_require_grads(module, input,
-    output)`` and ``output.requires_grad_(True)``. If upstream renames
-    these so the inner function shape diverges, the unsloth patch's
-    replacement (and any zoo mirror) becomes API-incompatible.
-    """
+    """``unsloth/import_fixes.py:609-670``'s replacement also references
+    inner ``def make_inputs_require_grads(module, input, output)`` and
+    ``output.requires_grad_(True)``."""
     pytest.importorskip("transformers")
     from transformers import PreTrainedModel
     try:
@@ -1125,31 +866,22 @@ def test_unsloth_import_fixes_make_inputs_require_grads_inner_fn():
 
 
 # ===========================================================================
-# Smoke tests for additional source-rewriter pins.
+# Additional source-rewriter pins.
 # ===========================================================================
 
 def test_compiler_no_update_causal_mask_attribute_probe():
-    """``unsloth_zoo/compiler.py:3524, 3762`` runs ``hasattr(source,
-    "_update_causal_mask")`` against PreTrainedModel subclasses to
-    decide whether to install ``no_update_causal_mask``. If
-    transformers drops ``_update_causal_mask`` everywhere the install
-    is dead code.
-    """
+    """``unsloth_zoo/compiler.py:3524, 3762`` ``hasattr(source,
+    "_update_causal_mask")`` probe. Modern Llama/Mistral/Qwen3 dropped
+    it; legacy models (Bamba, Falcon, etc.) still expose it. Pass if any
+    model still has it."""
     pytest.importorskip("transformers")
     import importlib
-    # Modern Llama/Mistral/Qwen3 dropped this method when migrating
-    # to the masking-utils helpers, but legacy models (Bamba, Falcon,
-    # Dbrx, Bloom, Bart, etc.) still expose it. As long as ANY
-    # transformers model class has the method, zoo's removal
-    # optimization has a target and the patch is reachable.
     found_any = False
     candidates = [
-        # Modern (likely missing on 4.50+):
         ("transformers.models.llama.modeling_llama", "LlamaModel"),
         ("transformers.models.mistral.modeling_mistral", "MistralModel"),
         ("transformers.models.qwen2.modeling_qwen2", "Qwen2Model"),
         ("transformers.models.gemma.modeling_gemma", "GemmaModel"),
-        # Legacy (still expose _update_causal_mask):
         ("transformers.models.bamba.modeling_bamba", "BambaModel"),
         ("transformers.models.falcon.modeling_falcon", "FalconModel"),
         ("transformers.models.dbrx.modeling_dbrx", "DbrxModel"),
@@ -1177,16 +909,10 @@ def test_compiler_no_update_causal_mask_attribute_probe():
 
 
 def test_compiler_attn_weights_attention_mask_dict_pattern():
-    """``unsloth_zoo/compiler.py:4148-4158`` re.sub-rewrites the
-    pattern ``attn_weights = attn_weights + attention_mask`` (followed
-    by ``module`` reference) to handle gpt_oss's dict-mask v5 shape.
-
-    The pinned form is the OLD shape; upstream now uses
-    ``attn_weights + causal_mask`` (variable rename). Pass if EITHER
-    name appears in the source -- a maintainer can update zoo's
-    re.sub to the new name. Fail if neither mask add is present at all
-    (the dict-attention v5 fixup has no target).
-    """
+    """``unsloth_zoo/compiler.py:4148-4158`` rewrites ``attn_weights =
+    attn_weights + attention_mask`` (gpt_oss dict-mask v5 shape).
+    Upstream may rename ``attention_mask`` -> ``causal_mask``; pass on
+    either."""
     pytest.importorskip("transformers")
     try:
         import transformers.models.gpt_oss.modeling_gpt_oss as gpt_oss
@@ -1209,10 +935,7 @@ def test_compiler_attn_weights_attention_mask_dict_pattern():
 
 def test_compiler_gradient_checkpointing_layer_marker_in_full_source():
     """``unsloth_zoo/compiler.py:3841`` branches on
-    ``"(GradientCheckpointingLayer)" in full_source`` to decide which
-    of two gradient-checkpointing rewriters to call. Asserts a
-    representative model module still has the class as a base.
-    """
+    ``"(GradientCheckpointingLayer)" in full_source``."""
     pytest.importorskip("transformers")
     import importlib
     candidate_modules = [
@@ -1245,9 +968,7 @@ def test_compiler_gradient_checkpointing_layer_marker_in_full_source():
 
 def test_compiler_lm_head_self_lm_head_attribute_present():
     """``unsloth_zoo/compiler.py:1727,1736,1748-1758`` references
-    ``self.lm_head.weight`` repeatedly in the fused CE replacement.
-    Asserts ForCausalLM classes still expose ``lm_head``.
-    """
+    ``self.lm_head.weight`` in the fused CE replacement."""
     pytest.importorskip("transformers")
     import importlib
     candidate_classes = [
@@ -1287,10 +1008,8 @@ def test_compiler_lm_head_self_lm_head_attribute_present():
 
 def test_compiler_loss_function_for_causal_lm_loss_suffix():
     """``unsloth_zoo/compiler.py:1560,1639,1647`` keys the fused CE
-    fast-path on ``self.loss_function.__name__.endswith("ForCausalLMLoss")``.
-    Asserts the upstream loss-function registry still exposes a
-    `ForCausalLMLoss` entry.
-    """
+    fast-path on
+    ``self.loss_function.__name__.endswith("ForCausalLMLoss")``."""
     pytest.importorskip("transformers")
     try:
         from transformers.loss.loss_utils import ForCausalLMLoss
@@ -1303,7 +1022,6 @@ def test_compiler_loss_function_for_causal_lm_loss_suffix():
             "never fires.",
         )
         return
-    # Confirm the function name matches the suffix the rewriter probes.
     name = getattr(ForCausalLMLoss, "__name__", "")
     if not name.endswith("ForCausalLMLoss"):
         _drift(
@@ -1315,11 +1033,8 @@ def test_compiler_loss_function_for_causal_lm_loss_suffix():
 
 
 def test_compiler_softmax_higher_precision_finder_regex():
-    """``unsloth_zoo/compiler.py:391-397`` (`higher_precision_softmax`)
-    matches ``nn.functional.softmax(...)`` / ``F.softmax(...)`` calls
-    via a regex. Asserts a representative attention module still uses
-    one of these forms.
-    """
+    """``unsloth_zoo/compiler.py:391-397`` (higher_precision_softmax)
+    matches ``nn.functional.softmax(...)`` / ``F.softmax(...)``."""
     pytest.importorskip("transformers")
     import importlib
     pattern = re.compile(
@@ -1355,11 +1070,9 @@ def test_compiler_softmax_higher_precision_finder_regex():
 
 
 def test_compiler_sqrt_mean_higher_precision_finder_regex():
-    """``unsloth_zoo/compiler.py:428-438`` (`higher_precision_sqrt_mean`)
-    matches ``torch.mean(X ** 2, dim=-1, keepdim=True) ** 0.5`` /
-    ``torch.sum(...)`` constructs. Asserts at least one normalization
-    module still uses ``torch.mean`` with ``** 2``.
-    """
+    """``unsloth_zoo/compiler.py:428-438`` (higher_precision_sqrt_mean)
+    targets ``torch.mean(X ** 2, dim=-1, keepdim=True) ** 0.5``.
+    Currently dormant on modern models."""
     pytest.importorskip("transformers")
     import importlib
     pattern = re.compile(
@@ -1383,9 +1096,6 @@ def test_compiler_sqrt_mean_higher_precision_finder_regex():
             continue
         if pattern.search(src):
             return
-    # No model currently has this pattern -- the rewriter is dormant
-    # but the rewrite path is only relevant for Gemma 3N and similar
-    # models with explicit sqrt(mean(x**2)) ops.
     pytest.skip(
         "No probed model currently uses torch.mean(X**2)**0.5; rewrite "
         "is dormant. Test will surface this if/when zoo adds Gemma 3N-"
@@ -1394,11 +1104,8 @@ def test_compiler_sqrt_mean_higher_precision_finder_regex():
 
 
 def test_compiler_apply_rotary_pos_emb_attention_dtype_fix_target():
-    """``unsloth_zoo/compiler.py:533-535`` (`fix_attention_dtype_consistency`)
-    matches ``query_states, key_states = apply_rotary_pos_emb(...)``.
-    Asserts at least one attention module still uses this assignment
-    form (vs. e.g. tuple unpack-into-self.q_proj output).
-    """
+    """``unsloth_zoo/compiler.py:533-535`` (fix_attention_dtype_consistency)
+    matches ``query_states, key_states = apply_rotary_pos_emb(...)``."""
     pytest.importorskip("transformers")
     import importlib
     pattern = re.compile(
@@ -1432,17 +1139,10 @@ def test_compiler_apply_rotary_pos_emb_attention_dtype_fix_target():
 
 
 def test_compiler_residual_stream_finder_regex():
-    """``unsloth_zoo/compiler.py:2686-2705`` (`patch_residual_stream`)
-    matches:
-
-        if self.<gate>:
-            hidden_states = <expr> * hidden_states
-            hidden_states = residual + hidden_states
-
-    in transformers VLM cross-attention layers. Asserts Mllama still
-    has the ``if self.is_gated:`` / ``hidden_state = ... * hidden_state``
-    pattern.
-    """
+    """``unsloth_zoo/compiler.py:2686-2705`` (patch_residual_stream)
+    matches ``if self.<gate>: hidden_states = <expr> * hidden_states ...
+    hidden_states = residual + hidden_states`` in VLM cross-attention.
+    Pin ``if self.is_gated`` head in mllama."""
     pytest.importorskip("transformers")
     try:
         from transformers.models.mllama.modeling_mllama import (
@@ -1454,12 +1154,7 @@ def test_compiler_residual_stream_finder_regex():
         src = inspect.getsource(MllamaVisionEncoder)
     except (OSError, TypeError):
         pytest.skip("MllamaVisionEncoder source unavailable")
-    # The exact pinned regex is too tight to reproduce here, but its
-    # head -- ``if self.is_gated:`` -- must be present for the rewriter
-    # to fire at all.
     needle = "if self.is_gated"
-    # Try the wider mllama module if encoder doesn't include it (the
-    # gated check usually lives in the layer class).
     if needle not in src:
         try:
             import transformers.models.mllama.modeling_mllama as mll

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -68,7 +68,6 @@ def _get_source_of(dotted: str):
     import importlib
     obj = None
     mod_name = None
-    consumed = 0
     for i in range(len(parts), 0, -1):
         candidate = ".".join(parts[:i])
         try:
@@ -717,6 +716,10 @@ def test_misc_merge_quantization_configs_class_name_compare():
         pytest.skip(
             "AutoHfQuantizer.merge_quantization_configs source unavailable"
         )
+    needle = (
+        "if quantization_config.__class__.__name__ != "
+        "quantization_config_from_args.__class__.__name__:"
+    )
     class_name_check = "quantization_config.__class__.__name__"
     args_class_name_check = "quantization_config_from_args.__class__.__name__"
     if (class_name_check not in src) or (args_class_name_check not in src):

--- a/tests/test_zoo_history_regressions_deep.py
+++ b/tests/test_zoo_history_regressions_deep.py
@@ -6,18 +6,7 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-"""Deep regression suite mined from the merged-PR history of
-`unslothai/unsloth-zoo`.
-
-Each test pins ONE shipped fix. The goal is to catch the SAME bug class
-if it re-appears via a refactor that loses the guard, rather than
-re-test the fix path. Every test cites the PR number and a one-line
-description of the original failure mode.
-
-These are deliberately CPU-only, fast, and use source-AST inspection /
-regex / behavioural probes so they remain useful even after the bug
-is re-fixed.
-"""
+"""Regressions mined from merged-PR history of unslothai/unsloth-zoo."""
 
 from __future__ import annotations
 
@@ -32,18 +21,9 @@ import textwrap
 import pytest
 
 
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
-
 def _module_source_path(module_name: str) -> pathlib.Path:
-    """Resolve a zoo module name to its source file path WITHOUT executing
-    its top-level code. importlib.import_module would import the module --
-    on CPU-only CI runners that crashes at unsloth_zoo/compiler.py:87
-    (`torch.cuda.get_device_capability()`). importlib.util.find_spec is
-    purely metadata and never executes module code, so this stays
-    CPU-safe across all Core matrix cells.
-    """
+    # find_spec is metadata-only so we avoid running compiler.py:87's
+    # torch.cuda.get_device_capability() on CPU-only CI.
     spec = importlib.util.find_spec(module_name)
     if spec is None or spec.origin in (None, "built-in"):
         raise ImportError(f"could not locate source for {module_name!r}")
@@ -51,17 +31,6 @@ def _module_source_path(module_name: str) -> pathlib.Path:
 
 
 def _get_source(module_name: str, attr: str | None = None) -> str:
-    """Return the source text for `module_name` (or `module_name.attr`).
-
-    For module-level source we read the file via importlib.util.find_spec
-    so we avoid running the module's top-level code (zoo's compiler.py
-    calls torch.cuda APIs at import time which fails on CPU-only CI).
-
-    For attribute-level source we still need to import the module to
-    resolve the attribute -- only callers that pass an `attr` need to
-    accept that risk; current call sites are all module-level so the
-    attribute branch is purely defensive.
-    """
     if attr is None:
         return _module_source_path(module_name).read_text(encoding="utf-8")
     mod = importlib.import_module(module_name)
@@ -69,21 +38,9 @@ def _get_source(module_name: str, attr: str | None = None) -> str:
     return inspect.getsource(obj)
 
 
-# ---------------------------------------------------------------------------
-# PR #4: `Fix longest common substring implementation`
-# The legacy `_old_longest_common_substring` worked on `str(list)`, which
-# matches leading commas and then calls `int('')` -- crashes on
-# `train_on_responses_only`. The fix introduced `_longest_common_sublist`
-# that works on the lists directly.
-#
-# We pin the new helper's behaviour on the regression input class:
-# common-suffix lists where the only common sublist is `[0]`.
-# ---------------------------------------------------------------------------
-
-
 def test_longest_common_sublist_handles_singleton_overlap():
+    """PR #4: _longest_common_sublist works on lists (not str(list))."""
     from unsloth_zoo.dataset_utils import _longest_common_sublist
-    # Two prompt-token lists that share only the trailing zero.
     out = _longest_common_sublist([[1, 2, 3, 0], [4, 5, 6, 0]])
     assert out == [0], (
         "_longest_common_sublist should find the single shared element."
@@ -95,25 +52,12 @@ def test_longest_common_sublist_empty_and_no_overlap():
     from unsloth_zoo.dataset_utils import _longest_common_sublist
     assert _longest_common_sublist([]) == []
     assert _longest_common_sublist([[1, 2], []]) == []
-    # No common element returns [] not a crash.
     assert _longest_common_sublist([[1, 2], [3, 4]]) == []
 
 
-# ---------------------------------------------------------------------------
-# PR #322: transformers 4.57 renamed `PretrainedConfig` -> `PreTrainedConfig`.
-# Zoo used to import the legacy name unconditionally and crash on 4.57+.
-# Pin: no zoo source uses the bare legacy `PretrainedConfig` identifier
-# in a way that would fail on transformers 5.x; if it does, that import
-# must be guarded with a try / hasattr / getattr fallback.
-# ---------------------------------------------------------------------------
-
-
 def test_no_unguarded_legacy_pretrained_config_import():
-    """Find direct `from transformers import PretrainedConfig` style
-    imports (PR #322 renamed the symbol). The post-rename code should
-    use the new name, getattr/hasattr probing, or sit inside a
-    try/except guard with `PreTrainedConfig` as the primary import.
-    """
+    """PR #322: transformers 4.57 renamed PretrainedConfig -> PreTrainedConfig.
+    Reject unguarded legacy imports."""
     import pathlib
     root = pathlib.Path(
         importlib.import_module("unsloth_zoo").__file__,
@@ -129,12 +73,9 @@ def test_no_unguarded_legacy_pretrained_config_import():
             line = m.group(0)
             if "PreTrainedConfig" in line:
                 continue
-            # Tolerated forms: the import is inside indented block (a
-            # try/except guard), OR a separate `PreTrainedConfig` alias
-            # / import exists in the same file as a fallback.
             indent = m.group(1)
             if indent and len(indent) >= 4:
-                # Indented: caller is inside try/except.
+                # Indented: inside try/except guard.
                 continue
             if "PreTrainedConfig" in text:
                 continue
@@ -146,19 +87,9 @@ def test_no_unguarded_legacy_pretrained_config_import():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #374: `Update e to error`. `empty_model.create_empty_causal_lm`
-# used `print(f"... {e}")` after an exception bound to `error`, raising
-# `UnboundLocalError`. Pin: scan exception handlers in empty_model.py
-# for the name mismatch.
-# ---------------------------------------------------------------------------
-
-
 def test_empty_model_exception_var_consistent():
-    """Every `except Foo as <name>:` block must reference `<name>` (and
-    not some other single-letter variable) inside its body. The
-    original PR #374 bug used `error` as the bound name but printed `e`.
-    """
+    """PR #374: bound exception variable matches body references
+    (UnboundLocalError when `as error` body uses `e`)."""
     src = _get_source("unsloth_zoo.empty_model")
     tree = ast.parse(src)
 
@@ -169,15 +100,8 @@ def test_empty_model_exception_var_consistent():
         if node.name is None:
             continue
         bound = node.name
-        # Collect plain Name references inside this handler.
         names = {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
-        # The bug pattern: handler binds `error` (or `err`) but body
-        # references the OTHER short alias `e` (without it being a real
-        # local). We just demand: if `e` is referenced inside a handler
-        # whose bound name is NOT `e`, flag it.
         if bound != "e" and "e" in names:
-            # Need to also ensure `e` is not defined as a local in the
-            # handler body -- a quick AST walk for ast.Assign targets.
             local_targets = set()
             for sub in ast.walk(node):
                 if isinstance(sub, ast.Assign):
@@ -196,15 +120,8 @@ def test_empty_model_exception_var_consistent():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #422: `dist.broadcast_object_list` was called in
-# `utils.distributed_function` but the underlying import was missing.
-# Pin: import `unsloth_zoo.utils` and assert the module has a working
-# `dist` binding that resolves to `torch.distributed`.
-# ---------------------------------------------------------------------------
-
-
 def test_utils_distributed_import_present():
+    """PR #422: utils must bind `dist` to torch.distributed."""
     pytest.importorskip("torch")
     mod = importlib.import_module("unsloth_zoo.utils")
     assert hasattr(mod, "dist"), (
@@ -218,9 +135,7 @@ def test_utils_distributed_import_present():
 
 
 def test_distributed_function_runs_without_init():
-    """`distributed_function` must NOT crash when the process group
-    isn't initialised yet (the path that bit PR #421/#422 users).
-    """
+    """PR #422: distributed_function tolerates uninitialised process group."""
     from unsloth_zoo.utils import distributed_function
     out = distributed_function(n=1, function=lambda: 42)
     assert out == 42, (
@@ -229,21 +144,13 @@ def test_distributed_function_runs_without_init():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #425: `Version()` had an undefined `e` in its `raise Exception(str(e))`.
-# Modern impl raises `RuntimeError` from the outer except. Pin: garbage
-# input raises a clean RuntimeError, NOT NameError/UnboundLocalError.
-# ---------------------------------------------------------------------------
-
-
 def test_version_garbage_input_clean_error():
+    """PR #425: Version() raises clean RuntimeError on garbage input,
+    not NameError/UnboundLocalError on undefined `e`."""
     from unsloth_zoo.utils import Version
-    # Use a string that (a) doesn't match the package-name regex
-    # (contains dots) and (b) has no embeddable digit sequence so the
-    # version regex inside Version() can't pull a fragment out.
     bad_inputs = [
-        "not.a.real.package.name",  # dots break package-name regex
-        "alpha.beta.gamma",          # no digits at all
+        "not.a.real.package.name",
+        "alpha.beta.gamma",
     ]
     for bad in bad_inputs:
         try:
@@ -259,23 +166,14 @@ def test_version_garbage_input_clean_error():
                 f"failure: {msg!r}. Regression of PR #425."
             )
         else:
-            # If it returns something, it must be a clean Version.
             from packaging.version import Version as TrueVersion
             assert isinstance(v, TrueVersion)
 
 
-# ---------------------------------------------------------------------------
-# PR #461: `Version("trl")` should accept a package name string and
-# resolve it via importlib.metadata. Pin: calling Version with an
-# installed package name returns a parsable Version object.
-# ---------------------------------------------------------------------------
-
-
 def test_version_accepts_package_name_string():
+    """PR #461: Version(<pkg-name>) resolves via importlib.metadata."""
     from unsloth_zoo.utils import Version
-    # `packaging` is a transitive dep of unsloth_zoo so it's guaranteed.
     v = Version("packaging")
-    # Compare against a Version literal -- supports <, >, ==.
     assert v >= Version("0.0.1"), (
         "Version('packaging') did not yield a numeric Version "
         "(regression of PR #461 -- string lookup via importlib.metadata)."
@@ -283,23 +181,15 @@ def test_version_accepts_package_name_string():
 
 
 def test_version_falls_back_for_unknown_package_strings():
-    """Version('1.2.3') must keep treating raw version strings as
-    versions -- not regress to package-name lookup that returns None.
-    """
+    """PR #461: raw version strings still parse as versions."""
     from unsloth_zoo.utils import Version
     assert Version("1.2.3") == Version("1.2.3")
     assert Version("1.2.3") < Version("2.0.0")
 
 
-# ---------------------------------------------------------------------------
-# PR #458: `_canonicalize_annotation` did not pass `origin` through
-# `TYPE_MAPPINGS`, so `Union[int, str]` (origin=typing.Union) and
-# `int | str` (origin=types.UnionType) compared unequal under 3.10+.
-# Pin: the two forms canonicalise to the same tuple.
-# ---------------------------------------------------------------------------
-
-
 def test_canonicalize_annotation_union_pep604_equivalence():
+    """PR #458: Union[int, str] and int|str canonicalise identically
+    (origin must flow through TYPE_MAPPINGS)."""
     pytest.importorskip("transformers")
     from unsloth_zoo.temporary_patches.utils import canonicalize_annotation
     import typing as t
@@ -312,27 +202,14 @@ def test_canonicalize_annotation_union_pep604_equivalence():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #491: transformers 5.x's `should_convert_module` only uses
-# `re.match` (prefix-anchored) and `endswith`, missing entries like
-# `vision_tower` against `model.vision_tower.x.y`. Zoo patches it with
-# substring component matching. Pin: the patched logic in
-# `unsloth_zoo.patching_utils` does substring matching.
-# ---------------------------------------------------------------------------
-
-
 def test_patching_utils_should_convert_module_uses_substring():
-    """The `_unsloth_should_convert_module` body must do component
-    substring matching (e.g. `f'.{key}.' in f'.{full_name}.'`).
-    """
+    """PR #491: _unsloth_should_convert_module uses substring component
+    matching (transformers 5.x prefix-anchored re.match misses vision_tower)."""
     src = _get_source("unsloth_zoo.patching_utils")
     assert "_unsloth_should_convert_module" in src, (
         "The transformers-5.x should_convert_module patch is missing "
         "-- regression of PR #491."
     )
-    # Look for ANY substring-style match that handles the vision_tower
-    # case. Acceptable forms: `f".{key}." in f".{full_name}."`
-    # or equivalent surrounded-by-dot construction.
     substring_check = (
         re.search(
             r"f\"\.\{key\}\.\"\s+in\s+f\"\.\{full_name\}\.\"",
@@ -347,21 +224,14 @@ def test_patching_utils_should_convert_module_uses_substring():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #533: torch.compile fullgraph crash with `@dynamic_rope_update`.
-# The compiler must drop fullgraph when it sees that decorator.
-# Pin: regex over compiler.py confirms the `dynamic_rope_update` gate
-# disables fullgraph.
-# ---------------------------------------------------------------------------
-
-
 def test_compiler_disables_fullgraph_for_dynamic_rope_update():
+    """PR #533: compiler flips fullgraph=False when dynamic_rope_update
+    decorator is present (Phi-4 longrope data-dependent branching)."""
     src = _get_source("unsloth_zoo.compiler")
     assert "dynamic_rope_update" in src, (
         "compiler.py no longer references dynamic_rope_update -- "
         "regression of PR #533."
     )
-    # The gate flips fullgraph=False when the decorator is in source.
     flip = re.search(
         r"if\s+[\"']dynamic_rope_update[\"']\s+in\s+\w+:\s*\n\s*"
         r"fullgraph\s*=\s*False",
@@ -374,16 +244,9 @@ def test_compiler_disables_fullgraph_for_dynamic_rope_update():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #552: Conv1d/2d/3d wrappers must cast `input` to `self.weight.dtype`
-# BEFORE the conv op (under autocast bf16 weight + fp16 input crashes).
-# The patch saves `original_dtype = input.dtype` and casts input.
-# Pin: compiler.py's conv loop saves original_dtype and casts to
-# self.weight.dtype.
-# ---------------------------------------------------------------------------
-
-
 def test_compiler_conv_prologue_casts_to_weight_dtype():
+    """PR #552: Conv wrappers cast input to weight dtype BEFORE the op
+    (autocast bf16 weight + fp16 input crashes)."""
     src = _get_source("unsloth_zoo.compiler")
     has_save = re.search(r"original_dtype\s*=\s*input\.dtype", src)
     has_cast = re.search(
@@ -398,26 +261,16 @@ def test_compiler_conv_prologue_casts_to_weight_dtype():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #564: LoRA forward returned the wrong dtype when autocast was
-# disabled. The fix appends `.to(torch_result_dtype)` to the early
-# return so output dtype matches the base layer. Pin: compiler.py
-# still emits a `torch_result_dtype` cast on the LoRA path.
-# ---------------------------------------------------------------------------
-
-
 def test_compiler_lora_forward_emits_torch_result_dtype_cast():
+    """PR #564: LoRA forward early-return casts back to base-layer dtype
+    when autocast is disabled."""
     src = _get_source("unsloth_zoo.compiler")
-    # The fix appends `.to({dtype_cast})` to the early return, where
-    # dtype_cast is either `torch_result_dtype` or `result.dtype`. The
-    # regression is when the cast is omitted entirely.
     assert "torch_result_dtype" in src, (
         "compiler.py no longer references `torch_result_dtype` -- "
         "regression of PR #564 (autocast-disabled dtype mismatch on "
         "PEFT LoRA forward). The early-return must cast back to the "
         "base-layer dtype."
     )
-    # And the return-cast must actually be emitted somewhere.
     assert re.search(
         r"return\s+lora_forward\([^)]+\)\.to\(",
         src,
@@ -427,21 +280,14 @@ def test_compiler_lora_forward_emits_torch_result_dtype_cast():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #482: 4-bit Params4bit has `weight.dtype == uint8`. The compiled
-# PEFT forward used to cast `x.to(weight.dtype)` which corrupts inputs.
-# The fix skips the cast when `hasattr(self.base_layer.weight, 'quant_state')`.
-# Pin: compiler source contains that guard.
-# ---------------------------------------------------------------------------
-
-
 def test_compiler_peft_forward_skips_quantized_dtype_cast():
+    """PR #482: skip x.to(weight.dtype) on Params4bit (weight.dtype==uint8
+    corrupts inputs); gated by hasattr(weight, 'quant_state')."""
     src = _get_source("unsloth_zoo.compiler")
     assert "quant_state" in src, (
         "compiler.py has no `quant_state` mention -- regression of "
         "PR #482 (4-bit input corrupted by float16 -> uint8 cast)."
     )
-    # The guard must be in the autocast-disabled branch that casts x.
     guard = re.search(
         r"not\s+hasattr\(self\.base_layer\.weight,\s*['\"]quant_state['\"]\)",
         src,
@@ -452,18 +298,10 @@ def test_compiler_peft_forward_skips_quantized_dtype_cast():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #466: vllm LoRA worker manager passed `vllm_config` BOTH
-# positionally AND as a keyword -- `TypeError: got multiple values for
-# argument 'vllm_config'`. Pin: each call site to
-# `_call_create_lora_manager` does not pass vllm_config twice.
-# ---------------------------------------------------------------------------
-
-
 def test_vllm_lora_manager_no_duplicate_vllm_config_kwarg():
+    """PR #466: _call_create_lora_manager must not pass vllm_config
+    both positionally and as keyword."""
     src = _get_source("unsloth_zoo.vllm_lora_worker_manager")
-    # Find every _call_create_lora_manager(...) call body and verify
-    # no `vllm_config=` keyword sits AFTER a `vllm_config` positional.
     bad: list[str] = []
     for m in re.finditer(
         r"_call_create_lora_manager\((?P<args>.*?)\)",
@@ -471,10 +309,7 @@ def test_vllm_lora_manager_no_duplicate_vllm_config_kwarg():
         flags=re.DOTALL,
     ):
         body = m.group("args")
-        # `vllm_config` appears once positionally already (second arg);
-        # ensure NO `vllm_config = vllm_config` keyword form coexists.
         if re.search(r"vllm_config\s*=\s*vllm_config", body):
-            # That's the legacy double-pass.
             bad.append(body.strip())
     assert not bad, (
         "Duplicate `vllm_config=vllm_config` kwarg passed alongside "
@@ -483,15 +318,9 @@ def test_vllm_lora_manager_no_duplicate_vllm_config_kwarg():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #580: Gemma-4 inference with `num_kv_shared_layers == 0` hits
-# `layer_types[:-0] == []` -> IndexError. The fix wraps text_config in
-# a proxy that HIDES `num_kv_shared_layers` when it is 0. Pin: the
-# `_Gemma4KVSharedSafeProxy` proxy class exists and refuses the attr.
-# ---------------------------------------------------------------------------
-
-
 def test_gemma4_proxy_hides_zero_num_kv_shared_layers():
+    """PR #580: _Gemma4KVSharedSafeProxy hides num_kv_shared_layers==0
+    so transformers' layer_types[:-0] doesn't return []."""
     pytest.importorskip("torch")
     mod = importlib.import_module(
         "unsloth_zoo.temporary_patches.gemma4",
@@ -501,7 +330,6 @@ def test_gemma4_proxy_hides_zero_num_kv_shared_layers():
         "_Gemma4KVSharedSafeProxy is missing -- regression of PR #580."
     )
 
-    # Build a minimal stand-in `real_config` with the legacy attr.
     class _Real:
         num_kv_shared_layers = 0
         num_hidden_layers = 4
@@ -510,36 +338,25 @@ def test_gemma4_proxy_hides_zero_num_kv_shared_layers():
             return iter(["num_hidden_layers"])
 
     proxy = Proxy(_Real())
-    # The proxy must say it does NOT have num_kv_shared_layers when 0.
     assert not hasattr(proxy, "num_kv_shared_layers"), (
         "Proxy still exposes num_kv_shared_layers == 0 -- PR #580 "
         "regression. transformers will do layer_types[:-0] -> []."
     )
-    # But other attrs forward.
     assert proxy.num_hidden_layers == 4
-    # `in` should return False for the hidden name.
     assert "num_kv_shared_layers" not in proxy
 
 
-# ---------------------------------------------------------------------------
-# PR #593: `chunked_hidden_states_selective_log_softmax` used the WRONG
-# softcap formula (`logits * tanh(logits / cap)` instead of
-# `cap * tanh(logits / cap)`). For |logits| >> cap the cap was a no-op.
-# Pin: the source emits the cap-prefixed form.
-# ---------------------------------------------------------------------------
-
-
 def test_grpo_softcap_formula_is_cap_times_tanh():
+    """PR #593: softcap is `cap * tanh(logits/cap)`, not
+    `logits * tanh(logits/cap)` (else saturates to no-op)."""
     src = _get_source(
         "unsloth_zoo.rl_replacements",
         "chunked_hidden_states_selective_log_softmax",
     )
-    # Want a line of the shape `<var> = logit_softcapping * torch.tanh(<var> / logit_softcapping)`.
     correct = re.search(
         r"=\s*logit_softcapping\s*\*\s*torch\.tanh\([^)]+/\s*logit_softcapping\)",
         src,
     )
-    # The buggy form is `<var> * torch.tanh(<var> / logit_softcapping)`.
     buggy = re.search(
         r"=\s*\w+\s*\*\s*torch\.tanh\([^)]+/\s*logit_softcapping\)",
         src,
@@ -557,17 +374,10 @@ def test_grpo_softcap_formula_is_cap_times_tanh():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #543: `accumulated_loss` etc. must be initialised as scalar
-# tensors `torch.zeros(1, device=device)[0]` (shape []) so that the
-# transformers 5.x in-place accumulation doesn't hit the shape-[1]
-# vs shape-[] broadcast crash. Pin: regex over rl_replacements.py.
-# ---------------------------------------------------------------------------
-
-
 def test_rl_replacements_scalar_tensor_init_for_accumulators():
+    """PR #543: accumulated_loss = torch.zeros(1, ...)[0] (shape [])
+    so transformers 5.x in-place += doesn't broadcast-crash."""
     src = _get_source("unsloth_zoo.rl_replacements")
-    # We want `torch.zeros(1, device = device)[0]` (or w/o spaces).
     hit = re.search(
         r"accumulated_loss\s*=\s*torch\.zeros\(1[^)]*\)\[0\]",
         src,
@@ -579,17 +389,10 @@ def test_rl_replacements_scalar_tensor_init_for_accumulators():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #477: `sft_prepare_dataset` non-packing path must pass
-# `remove_columns=list(column_names)` to `.map(_tokenize, ...)` so
-# downstream collator doesn't see raw JSON columns like `messages`.
-# Pin: the `_tokenize` map call carries `remove_columns=`.
-# ---------------------------------------------------------------------------
-
-
 def test_sft_prepare_dataset_removes_original_columns_in_non_packing_path():
+    """PR #477: .map(_tokenize, ...) passes remove_columns= so raw
+    JSON columns don't leak to the collator."""
     src = _get_source("unsloth_zoo.dataset_utils")
-    # Locate the `.map(_tokenize, batched = True, ...)` call.
     m = re.search(
         r"\.map\(\s*_tokenize\s*,\s*batched\s*=\s*True[^)]*\)",
         src,
@@ -607,14 +410,9 @@ def test_sft_prepare_dataset_removes_original_columns_in_non_packing_path():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #595: Windows file-lock on shard rewrite. The fix uses ATOMIC
-# `os.replace(tmp, target)` instead of remove+move. Pin: the
-# `_merge_and_overwrite_lora` source uses `os.replace`.
-# ---------------------------------------------------------------------------
-
-
 def test_saving_utils_uses_atomic_replace_for_shard_rewrite():
+    """PR #595: _merge_and_overwrite_lora uses atomic os.replace
+    (not remove+move; Windows WinError 1224 on shard rewrite)."""
     src = _get_source(
         "unsloth_zoo.saving_utils", "_merge_and_overwrite_lora",
     )
@@ -622,12 +420,7 @@ def test_saving_utils_uses_atomic_replace_for_shard_rewrite():
         "_merge_and_overwrite_lora no longer uses os.replace -- "
         "regression of PR #595 (Windows WinError 1224 on shard rewrite)."
     )
-    # The old buggy pair would be `os.remove(<filename>) + shutil.move`;
-    # if both appear together in the rewrite branch, that's the bug.
     if "shutil.move(" in src and "os.remove(" in src:
-        # Only flag if remove/move follow each other in the rewrite
-        # branch (i.e. inside the same `if resized:`). Heuristic: both
-        # appear before the os.replace line.
         idx_replace = src.find("os.replace(")
         idx_remove  = src.find("os.remove(")
         idx_move    = src.find("shutil.move(")
@@ -639,18 +432,10 @@ def test_saving_utils_uses_atomic_replace_for_shard_rewrite():
             )
 
 
-# ---------------------------------------------------------------------------
-# PR #615: GGUF merge path used hardcoded CUDA. The fix uses
-# `DEVICE_TYPE` / `DEVICE_TYPE_TORCH` so XPU + ROCm work. Pin: no
-# `cuda.empty_cache` or `torch.cuda.synchronize` calls in
-# saving_utils.py without a DEVICE_TYPE guard.
-# ---------------------------------------------------------------------------
-
-
 def test_saving_utils_uses_device_type_helpers():
+    """PR #615: GGUF merge path uses DEVICE_TYPE helpers (XPU + ROCm
+    have no torch.cuda namespace)."""
     src = _get_source("unsloth_zoo.saving_utils")
-    # Either the module imports DEVICE_TYPE / DEVICE_TYPE_TORCH or it
-    # imports device_empty_cache / device_synchronize from device_type.
     has_helpers = (
         "DEVICE_TYPE" in src
         or "device_empty_cache" in src
@@ -663,14 +448,9 @@ def test_saving_utils_uses_device_type_helpers():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #91: `_unsloth_get_batch_samples` must accept the 4th `device`
-# parameter introduced in transformers 4.50. Pin: signature has either
-# a `device` param or `**kwargs` so 3- and 4-arg call sites both work.
-# ---------------------------------------------------------------------------
-
-
 def test_unsloth_get_batch_samples_accepts_4_args():
+    """PR #91: _unsloth_get_batch_samples accepts the 4th `device`
+    parameter transformers 4.50 added."""
     pytest.importorskip("transformers")
     mod = importlib.import_module("unsloth_zoo.loss_utils")
     fn = getattr(mod, "_unsloth_get_batch_samples", None)
@@ -694,31 +474,13 @@ def test_unsloth_get_batch_samples_accepts_4_args():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #617 follow-up: `__all__` integrity across more zoo public modules.
-# The original PR fixed `temporary_patches.utils`; we extend the
-# same heuristic to the top-level `unsloth_zoo.utils` and any other
-# module that declares `__all__` -- adjacent-string-concatenation is a
-# class of bug, not a one-off.
-# ---------------------------------------------------------------------------
-
-
 def test_all_modules_all_entries_have_no_concatenated_names():
-    """The PR #617 bug class is `["raise_error" "Unpack"]` -- missing
-    comma in `__all__` silently concatenates string literals. The
-    resulting names always contain a snake_case-to-CamelCase boundary
-    (`raise_errorUnpack`). Scan every zoo module's `__all__` for that
-    boundary -- regression-safe even if the inventory shifts over time.
-
-    Pure CamelCase / pure snake_case / SHOUTY_SNAKE names don't trip
-    this heuristic; only the concatenation accident does.
-    """
+    """PR #617: __all__ entries with snake_case+CamelCase boundary
+    (e.g. `raise_errorUnpack`) are the missing-comma bug fingerprint."""
     import pathlib
     root = pathlib.Path(
         importlib.import_module("unsloth_zoo").__file__,
     ).parent
-    # Detect a name that has BOTH a snake_case token AND a CamelCase
-    # transition (lowercase followed by uppercase).
     camel_boundary = re.compile(r"[a-z][A-Z]")
     suspicious: list[str] = []
     for py in root.rglob("*.py"):
@@ -751,19 +513,13 @@ def test_all_modules_all_entries_have_no_concatenated_names():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #612: Gemma4-MoE patch must NOT rely on the `slice(-0, None)`
-# Python identity. Pin: the `gemma4_moe.py` patched ForCondGen forward
-# guards the slice behind `if logits_to_keep != 0:`.
-# ---------------------------------------------------------------------------
-
-
 def test_gemma4_moe_guards_logits_to_keep_slice():
+    """PR #612: gemma4_moe guards the slice behind `if logits_to_keep != 0`
+    (Python's slice(-0, None) == slice(0, None) trap)."""
     try:
         src = _get_source("unsloth_zoo.temporary_patches.gemma4_moe")
     except Exception:
         pytest.skip("gemma4_moe module unavailable")
-    # The guard is the regression fix.
     assert re.search(
         r"if\s+logits_to_keep\s*!=\s*0", src,
     ), (
@@ -773,16 +529,9 @@ def test_gemma4_moe_guards_logits_to_keep_slice():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #549: Patch `transformers.modeling_utils.checkpoint` to wire up
-# Unsloth's smart gradient checkpointing on transformers 5.2+. The old
-# patch only replaced `torch.utils.checkpoint.checkpoint`. Pin: source
-# of `patch_unsloth_smart_gradient_checkpointing` references the
-# transformers.modeling_utils namespace.
-# ---------------------------------------------------------------------------
-
-
 def test_smart_gradient_checkpointing_patches_transformers_modeling_utils():
+    """PR #549: gradient_checkpointing patches transformers.modeling_utils
+    (transformers 5.2+ moved the checkpoint reference)."""
     pytest.importorskip("transformers")
     src = _get_source("unsloth_zoo.gradient_checkpointing")
     assert "transformers.modeling_utils" in src or "modeling_utils" in src, (
@@ -791,30 +540,18 @@ def test_smart_gradient_checkpointing_patches_transformers_modeling_utils():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #218: `vllm_utils` iterated a dict while mutating it -- "dict
-# changed size during iteration". Pin: scan vllm_utils for the bug
-# pattern `for k in <dict>:` followed by a `del <dict>[k]` or
-# `<dict>[k] = ...` that mutates the dict whose key set is being
-# iterated. Heuristic: any `del d[k]` inside a `for k in d:` or
-# `for k in d.keys():` block is suspicious; the safe form is
-# `for k in list(d):`.
-# ---------------------------------------------------------------------------
-
-
 def test_vllm_utils_no_unsafe_dict_mutation_during_iteration():
+    """PR #218: no `del d[k]` / `d.pop(k)` inside `for k in d:` loops
+    in vllm_utils (dict-changed-size-during-iteration)."""
     src = _get_source("unsloth_zoo.vllm_utils")
     tree = ast.parse(src)
     bad: list[str] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.For):
             continue
-        # iterating a bare dict: `for k in d:` where d is a Name
         if not isinstance(node.iter, ast.Name):
-            # Allow `for k in list(d):` etc.
             continue
         d_name = node.iter.id
-        # find del d[k] / d.pop(k) / d[k] = ... in body
         for sub in ast.walk(node):
             if isinstance(sub, ast.Delete):
                 for tgt in sub.targets:
@@ -841,20 +578,10 @@ def test_vllm_utils_no_unsafe_dict_mutation_during_iteration():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #84: `vllm_lora_worker_manager` had an extra `len()` assertion
-# that blocked `model.load_lora()`. The fix removed it. Pin: any
-# remaining `assert len(lora_tensors)` style guard inside the load
-# path is treated as a regression candidate.
-# ---------------------------------------------------------------------------
-
-
 def test_vllm_lora_worker_no_strict_len_assertion_on_lora_tensors():
+    """PR #84: no `assert len(lora_tensors)` guard (blocked load_lora
+    when filtering yields legitimately empty list)."""
     src = _get_source("unsloth_zoo.vllm_lora_worker_manager")
-    # The original buggy line was something like `assert len(lora_tensors)`
-    # right before the load. We allow `if not lora_tensors:` style but
-    # reject hard `assert len(...)` on a list that may be legitimately
-    # filtered to empty.
     bad = re.findall(
         r"^\s*assert\s+len\(lora_tensors\)\s*[!=<>]?[^A-Za-z]",
         src,
@@ -866,17 +593,9 @@ def test_vllm_lora_worker_no_strict_len_assertion_on_lora_tensors():
     )
 
 
-# ---------------------------------------------------------------------------
-# Bonus: PR #437 / #461 hardened Version parsing across modules. Pin:
-# `unsloth_zoo.utils.Version` is the same callable referenced from
-# every other zoo module that does version checks. The old failure mode
-# was duplicate divergent Version() helpers in compiler / vllm_utils.
-# Heuristic: no zoo module defines its OWN top-level `def Version` --
-# they should import the canonical one.
-# ---------------------------------------------------------------------------
-
-
 def test_only_one_canonical_version_helper():
+    """PR #437 / #461: only one top-level `def Version(...)` across zoo
+    (no duplicate divergent helpers)."""
     import pathlib
     root = pathlib.Path(
         importlib.import_module("unsloth_zoo").__file__,
@@ -886,7 +605,6 @@ def test_only_one_canonical_version_helper():
         if py.name == "utils.py" and py.parent == root:
             continue  # the canonical one
         text = py.read_text(encoding="utf-8", errors="ignore")
-        # Match `def Version(` at top-level indentation only.
         if re.search(r"^def\s+Version\s*\(", text, re.MULTILINE):
             bad.append(str(py.relative_to(root)))
     assert not bad, (
@@ -896,34 +614,18 @@ def test_only_one_canonical_version_helper():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #441: `logger.log(msg)` -> `logger.info(msg)`. The `Logger.log()`
-# API requires `(level, msg)`, so the legacy single-arg form raised
-# `TypeError: Logger.log() missing 1 required positional argument: 'msg'`
-# whenever `UNSLOTH_ENABLE_LOGGING=1`. Pin: zoo source contains no
-# `logger.log("string")` style single-arg call.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# PR #432: `_get_chunk_multiplier` divided by `target_gb` without
-# checking for zero -- `ZeroDivisionError` when GPU memory exhausted.
-# Pin: function has the explicit zero / epsilon guard before the divide.
-# ---------------------------------------------------------------------------
-
-
 def test_chunk_multiplier_guards_against_zero_target_gb():
+    """PR #432: _get_chunk_multiplier guards against zero target_gb
+    (ZeroDivisionError on GPU OOM)."""
     pytest.importorskip("torch")
     src = _get_source(
         "unsloth_zoo.fused_losses.cross_entropy_loss", "_get_chunk_multiplier",
     )
-    # Guard expression: `if target_gb <= 1e-9:` or `if target_gb == 0:`
     has_guard = bool(
         re.search(r"if\s+target_gb\s*<=\s*\d", src)
         or re.search(r"if\s+target_gb\s*==\s*0", src)
         or re.search(r"if\s+target_gb\s*<\s*\d", src)
     )
-    # Find the `/ target_gb` division.
     divides = list(re.finditer(r"/\s*target_gb\b|/\s*\(target_gb\)", src))
     assert has_guard, (
         "_get_chunk_multiplier no longer guards against zero target_gb "
@@ -935,20 +637,13 @@ def test_chunk_multiplier_guards_against_zero_target_gb():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #591: CE loss must use `.reshape(-1, hd)` (not `.view`) on
-# `hidden_states` so non-contiguous slices (`hidden_states[:, slice, :]`
-# from `logits_to_keep`) don't raise `RuntimeError: view size is not
-# compatible`. Pin: the hidden_states chunking line uses reshape.
-# ---------------------------------------------------------------------------
-
-
 def test_ce_loss_uses_reshape_for_hidden_states():
+    """PR #591: CE loss uses .reshape (not .view) on hidden_states slices
+    (non-contiguous from logits_to_keep slicing)."""
     pytest.importorskip("torch")
     src = _get_source(
         "unsloth_zoo.fused_losses.cross_entropy_loss",
     )
-    # The hidden_states chunking line. The view-form is the bug.
     has_view_form = re.search(
         r"torch\.chunk\(\s*hidden_states\.view\(-1,\s*\w+\)",
         src,
@@ -968,16 +663,10 @@ def test_ce_loss_uses_reshape_for_hidden_states():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #488: transformers 5.x renamed Gemma3 mask creation to
-# `create_causal_mask_mapping` which raises ValueError when compiled.
-# Pin: zoo's `DISABLED_KEYWORDS` includes the new name.
-# ---------------------------------------------------------------------------
-
-
 def test_compiler_disabled_keywords_includes_5x_gemma3_mask():
+    """PR #488: DISABLED_KEYWORDS includes create_causal_mask_mapping
+    (Gemma3/3N transformers 5.x compile crash)."""
     src = _get_source("unsloth_zoo.compiler")
-    # The list literal must contain the 5.x name.
     assert "create_causal_mask_mapping" in src, (
         "compiler.py DISABLED_KEYWORDS no longer mentions "
         "`create_causal_mask_mapping` -- regression of PR #488 "
@@ -985,28 +674,15 @@ def test_compiler_disabled_keywords_includes_5x_gemma3_mask():
     )
 
 
-# ---------------------------------------------------------------------------
-# PR #559: saving an embed_tokens layer crashed because the saving
-# snippet accessed `in_features` / `out_features` on the embedding
-# module (those exist on Linear, not Embedding). Pin: the saving code
-# has an attribute-existence check around in_features/out_features.
-# ---------------------------------------------------------------------------
-
-
 def test_saving_utils_guards_embedding_dims():
+    """PR #559: saving guards in_features/out_features access for
+    Embedding modules (which lack those attrs)."""
     src = _get_source("unsloth_zoo.saving_utils")
-    # Look for `in_features` and `out_features` accesses guarded by
-    # hasattr / getattr / try-except.
     if "in_features" not in src:
         pytest.skip(
             "saving_utils no longer touches in_features -- shape "
             "changed; ensure PR #559 fix is still needed."
         )
-    # The access must be inside a getattr/hasattr/try guard, not a
-    # bare `module.in_features`. We tolerate any of:
-    #   - `getattr(module, 'in_features'`
-    #   - `hasattr(module, 'in_features'`
-    #   - `isinstance(module, ...Linear...)` block surrounding it
     guarded = (
         "getattr" in src and "in_features" in src
         or "hasattr" in src and "in_features" in src
@@ -1020,20 +696,19 @@ def test_saving_utils_guards_embedding_dims():
 
 
 def test_no_single_arg_logger_log_calls():
+    """PR #441: no `logger.log(<str>)` single-arg calls (Logger.log
+    requires (level, msg); UNSLOTH_ENABLE_LOGGING=1 would TypeError)."""
     import pathlib
     root = pathlib.Path(
         importlib.import_module("unsloth_zoo").__file__,
     ).parent
     bad: list[str] = []
-    # Match logger.log(<single_str_arg>) -- a single argument that is a
-    # string literal (NOT a level constant like logging.INFO).
     pat = re.compile(
         r"\blogger\.log\(\s*[\"'fr]",
     )
     for py in root.rglob("*.py"):
         text = py.read_text(encoding="utf-8", errors="ignore")
         for m in pat.finditer(text):
-            # Find the matching close-paren (allow simple cases).
             i = m.end()
             depth = 1
             while i < len(text) and depth > 0:
@@ -1043,8 +718,6 @@ def test_no_single_arg_logger_log_calls():
                     depth -= 1
                 i += 1
             call_body = text[m.end(): i - 1]
-            # If a comma at the same paren depth exists, it's a 2-arg
-            # call (level, msg) -- skip it.
             depth = 0
             has_top_comma = False
             for ch in call_body:

--- a/tests/test_zoo_source_upstream_refs.py
+++ b/tests/test_zoo_source_upstream_refs.py
@@ -97,7 +97,7 @@ def _resolve_all(dotted_paths: Iterable[str]) -> None:
 
 
 def _skip_if_missing(module_name: str) -> None:
-    return pytest.importorskip(module_name)
+    pytest.importorskip(module_name)
 
 
 # ===========================================================================

--- a/tests/test_zoo_source_upstream_refs.py
+++ b/tests/test_zoo_source_upstream_refs.py
@@ -8,30 +8,10 @@
 
 """Importable-symbol pins for upstream references in ``unsloth_zoo`` source.
 
-The existing ``test_upstream_pinned_symbols_{transformers,trl_vllm,accelerator}.py``
-files cover a curated subset of the symbols zoo reaches into upstream
-libraries, mostly via raw-source GitHub fetches against pinned version
-tags. This file is the complement: a flat enumeration of every
-``from <upstream> import <symbol>`` and ``<upstream>.X.Y`` reference
-visible in ``unsloth_zoo/**.py`` -- exercised against the **installed**
-versions of transformers / trl / peft / datasets / accelerate / vllm.
-
-Why both files? The github-fetch tests catch upstream API drift before
-it lands in a user's venv. These tests catch the OPPOSITE failure mode:
-a user's venv has a transformers / peft / etc. version that drops or
-renames a symbol the zoo references unconditionally. The failure surface
-is the same -- an ImportError or AttributeError at zoo import time --
-but the trigger is different (venv content, not upstream main).
-
-Each test names the source file + line it was extracted from in a
-comment so a maintainer can grep back to the patch site. Tests use
-``importlib.import_module`` + ``getattr`` chains so the failure mode is
-a clean AssertionError with the missing dotted path printed.
-
-The matrix dimension is the upstream version (HF=4.57.6 / HF=default /
-HF=latest). A symbol that exists only on transformers >=X but is
-referenced unconditionally in zoo source is a forward-compat bug, and
-the test docstring flags that case.
+Flat enumeration of every ``from <upstream> import <symbol>`` /
+``<upstream>.X.Y`` reference visible in ``unsloth_zoo/**.py``, exercised
+against the INSTALLED versions of transformers / trl / peft / datasets
+/ accelerate / vllm. Each test cites the zoo file:line it pins.
 """
 
 from __future__ import annotations
@@ -50,20 +30,11 @@ import pytest
 def _resolve(dotted: str) -> object:
     """``importlib.import_module`` + ``getattr`` chain.
 
-    DRIFT-DETECTED policy (matches test_upstream_import_fixes_drift.py):
-    any failure to resolve a dotted path zoo references is reported as
-    an AssertionError -- never a SKIP. The matrix cell goes red when
-    drift is present, which is the whole point of the suite.
-
-    Three failure modes, all surface as AssertionError:
-      * module-file-actually-missing (find_spec returns None).
-      * module-file-present-but-import-raises (transitively-broken
-        optional dep, e.g. transformers.utils.notebook needing
-        IPython). The CI matrix step now installs the deps required
-        so zoo's try/except-wrapped callsites can be properly
-        exercised; if the import still fails the test reports it
-        as drift.
-      * attribute missing on a successfully-imported module.
+    DRIFT-DETECTED policy: any failure to resolve is reported as an
+    AssertionError -- never a SKIP. Three failure modes all surface as
+    DRIFT: module-file missing, module-file present but import raises
+    (transitively-broken optional dep), or attribute missing on a
+    successfully-imported module.
     """
     parts = dotted.split(".")
     obj: object = None
@@ -77,11 +48,7 @@ def _resolve(dotted: str) -> object:
         except (ImportError, ValueError):
             spec = None
         if spec is None:
-            # find_spec returning None means the module path is
-            # genuinely absent at this depth -- try a shorter prefix.
             continue
-        # Spec exists; importing should succeed unless the module
-        # itself has a transitively-broken optional dep.
         try:
             obj = importlib.import_module(mod_name)
             consumed = parts[:i]
@@ -104,7 +71,6 @@ def _resolve(dotted: str) -> object:
             + (f" Last ImportError: {last_import_error!r}"
                if last_import_error is not None else "")
         )
-    # Remaining parts must be attribute accesses on the module.
     for attr in parts[len(consumed):]:
         if not hasattr(obj, attr):
             walked = ".".join(consumed + [attr])
@@ -120,8 +86,7 @@ def _resolve(dotted: str) -> object:
 
 
 def _resolve_all(dotted_paths: Iterable[str]) -> None:
-    """Resolve every dotted path; collect missing entries into one
-    AssertionError so a maintainer sees the full damage at once."""
+    """Resolve every dotted path; collect misses into one AssertionError."""
     missing: list[str] = []
     for d in dotted_paths:
         try:
@@ -132,9 +97,7 @@ def _resolve_all(dotted_paths: Iterable[str]) -> None:
 
 
 def _skip_if_missing(module_name: str) -> None:
-    """Skip the test cleanly if the top-level upstream package isn't
-    installed in this venv (mirrors ``pytest.importorskip``)."""
-    pytest.importorskip(module_name)
+    return pytest.importorskip(module_name)
 
 
 # ===========================================================================
@@ -142,11 +105,9 @@ def _skip_if_missing(module_name: str) -> None:
 # ===========================================================================
 
 def test_compiler_modeling_flash_attention_utils_top_level():
-    """unsloth_zoo/compiler.py:218 — `from
-    transformers.modeling_flash_attention_utils import
-    is_flash_attn_available` is at module-top-level and UNGUARDED;
-    if upstream removes the module, `import unsloth_zoo` itself
-    ImportErrors during compile-cell construction."""
+    """unsloth_zoo/compiler.py:218 -- TOP-LEVEL unguarded
+    ``from transformers.modeling_flash_attention_utils import
+    is_flash_attn_available``; a removal ImportErrors ``import unsloth_zoo``."""
     _resolve_all([
         "transformers.modeling_flash_attention_utils",
         "transformers.modeling_flash_attention_utils.is_flash_attn_available",
@@ -154,28 +115,24 @@ def test_compiler_modeling_flash_attention_utils_top_level():
 
 
 def test_compiler_masking_utils():
-    """unsloth_zoo/compiler.py:372 — `import transformers.masking_utils`.
-    Module path is required for the compile-cell rewriter to inject the
-    causal-mask helpers."""
+    """unsloth_zoo/compiler.py:372 -- ``import transformers.masking_utils``."""
     _resolve("transformers.masking_utils")
 
 
 def test_compiler_transformers_logging():
-    """unsloth_zoo/compiler.py:3145 — `from transformers import logging
-    as transformers_logging`."""
+    """unsloth_zoo/compiler.py:3145 -- ``from transformers import logging``."""
     _resolve("transformers.logging")
 
 
 def test_compiler_generation_mixin():
-    """unsloth_zoo/compiler.py:3781 — `from transformers.generation
-    import GenerationMixin` — used to detect generate() availability
-    on a compiled model."""
+    """unsloth_zoo/compiler.py:3781 -- ``from transformers.generation import
+    GenerationMixin``."""
     _resolve("transformers.generation.GenerationMixin")
 
 
 def test_compiler_trainer_module_and_class():
-    """unsloth_zoo/compiler.py:3963, 3975 — `from transformers.trainer
-    import Trainer` AND `import transformers.trainer`."""
+    """unsloth_zoo/compiler.py:3963, 3975 -- ``from transformers.trainer
+    import Trainer`` AND ``import transformers.trainer``."""
     _resolve_all([
         "transformers.trainer",
         "transformers.trainer.Trainer",
@@ -187,10 +144,9 @@ def test_compiler_trainer_module_and_class():
 # ===========================================================================
 
 def test_loss_utils_training_args_parallel_mode():
-    """unsloth_zoo/loss_utils.py:232 — TOP-LEVEL unguarded import
-    `from transformers.training_args import ParallelMode`. Used by the
-    Trainer parallelism branch to decide whether logits gathering is
-    needed; a removal silently breaks distributed loss aggregation."""
+    """unsloth_zoo/loss_utils.py:232 -- TOP-LEVEL unguarded ``from
+    transformers.training_args import ParallelMode``; a removal silently
+    breaks distributed loss aggregation."""
     _resolve_all([
         "transformers.training_args",
         "transformers.training_args.ParallelMode",
@@ -198,27 +154,25 @@ def test_loss_utils_training_args_parallel_mode():
 
 
 def test_loss_utils_modeling_utils():
-    """unsloth_zoo/loss_utils.py:138 — `import transformers.modeling_utils`
-    feeds the `LOSS_MAPPING` rebind path."""
+    """unsloth_zoo/loss_utils.py:138 -- ``import transformers.modeling_utils``
+    feeds the LOSS_MAPPING rebind path."""
     _resolve("transformers.modeling_utils")
 
 
 def test_loss_utils_loss_module():
-    """unsloth_zoo/loss_utils.py:82 — `import transformers.loss.loss_utils`.
-    The whole loss-helper subpackage moved into transformers 4.50; zoo
-    relies on the `transformers.loss.loss_utils` path remaining stable."""
+    """unsloth_zoo/loss_utils.py:82 -- ``import transformers.loss.loss_utils``.
+    The loss-helper subpackage moved into transformers 4.50."""
     _resolve("transformers.loss.loss_utils")
 
 
 # ===========================================================================
-# unsloth_zoo/training_utils.py — ALL top-level imports
+# unsloth_zoo/training_utils.py
 # ===========================================================================
 
 def test_training_utils_top_level_transformers_surface():
-    """unsloth_zoo/training_utils.py:20-23 — four top-level imports.
-    Any single removal makes ``from unsloth_zoo import ...`` blow up at
-    every site that depends on training_utils (Trainer wrapper,
-    data-collator helpers, scheduler patching)."""
+    """unsloth_zoo/training_utils.py:20-23 -- four top-level imports; any
+    removal makes ``from unsloth_zoo import ...`` blow up at every site
+    depending on training_utils."""
     _resolve_all([
         "transformers.set_seed",
         "transformers.get_scheduler",
@@ -228,15 +182,15 @@ def test_training_utils_top_level_transformers_surface():
 
 
 def test_training_utils_data_collator_for_lm():
-    """unsloth_zoo/training_utils.py:345 — `from transformers import
-    DataCollatorForLanguageModeling`."""
+    """unsloth_zoo/training_utils.py:345 -- ``from transformers import
+    DataCollatorForLanguageModeling``."""
     _resolve("transformers.DataCollatorForLanguageModeling")
 
 
 def test_training_utils_peft_modules_to_save_wrapper():
-    """unsloth_zoo/training_utils.py:239 — `from peft.utils import
-    ModulesToSaveWrapper`. This wrapper is how zoo identifies non-LoRA
-    trainable adapter weights for the saving path."""
+    """unsloth_zoo/training_utils.py:239 -- ``from peft.utils import
+    ModulesToSaveWrapper``. Identifies non-LoRA trainable adapter weights
+    for the saving path."""
     _resolve("peft.utils.ModulesToSaveWrapper")
 
 
@@ -245,15 +199,14 @@ def test_training_utils_peft_modules_to_save_wrapper():
 # ===========================================================================
 
 def test_dataset_utils_datasets_top_level():
-    """unsloth_zoo/dataset_utils.py:594 — `from datasets import (Dataset,
-    IterableDataset,)`. Imported at module top-level; missing means the
-    SFT data pipeline never loads."""
+    """unsloth_zoo/dataset_utils.py:594 -- ``from datasets import (Dataset,
+    IterableDataset,)`` at module top-level."""
     _resolve_all(["datasets.Dataset", "datasets.IterableDataset"])
 
 
 def test_dataset_utils_data_collator_for_seq2seq():
-    """unsloth_zoo/dataset_utils.py:457, 672 — `from transformers import
-    DataCollatorForSeq2Seq` (both call sites)."""
+    """unsloth_zoo/dataset_utils.py:457, 672 -- ``from transformers import
+    DataCollatorForSeq2Seq``."""
     _resolve("transformers.DataCollatorForSeq2Seq")
 
 
@@ -262,16 +215,16 @@ def test_dataset_utils_data_collator_for_seq2seq():
 # ===========================================================================
 
 def test_saving_utils_pushtohubmixin():
-    """unsloth_zoo/saving_utils.py:76 — TOP-LEVEL unguarded
-    `from transformers.modeling_utils import PushToHubMixin`. We call
-    `._upload_modified_files` and `._get_files_timestamps` on it."""
+    """unsloth_zoo/saving_utils.py:76 -- TOP-LEVEL unguarded ``from
+    transformers.modeling_utils import PushToHubMixin``. Calls
+    ``._upload_modified_files`` / ``._get_files_timestamps``."""
     _resolve("transformers.modeling_utils.PushToHubMixin")
 
 
 def test_saving_utils_peft_top_level():
-    """unsloth_zoo/saving_utils.py:82 + 270 — TOP-LEVEL unguarded
-    `from peft import PeftModelForCausalLM, PeftModel` and
-    `from peft.utils.integrations import dequantize_module_weight`."""
+    """unsloth_zoo/saving_utils.py:82 + 270 -- TOP-LEVEL unguarded
+    ``from peft import PeftModelForCausalLM, PeftModel`` and ``from
+    peft.utils.integrations import dequantize_module_weight``."""
     _resolve_all([
         "peft.PeftModelForCausalLM",
         "peft.PeftModel",
@@ -280,8 +233,8 @@ def test_saving_utils_peft_top_level():
 
 
 def test_saving_utils_autoconfig():
-    """unsloth_zoo/saving_utils.py:2101 — `from transformers import
-    AutoConfig`. Used inside the save-path config rewrite."""
+    """unsloth_zoo/saving_utils.py:2101 -- ``from transformers import
+    AutoConfig``."""
     _resolve("transformers.AutoConfig")
 
 
@@ -290,10 +243,9 @@ def test_saving_utils_autoconfig():
 # ===========================================================================
 
 def test_patching_utils_pretrainedconfig_either_name():
-    """unsloth_zoo/patching_utils.py:247-251 — try `PreTrainedConfig`
-    (4.x removed the camel-case) then `PretrainedConfig`. At least one
-    MUST exist. Zoo source has BOTH forms gated by try/except so we
-    only require ONE to resolve."""
+    """unsloth_zoo/patching_utils.py:247-251 -- try ``PreTrainedConfig``
+    (5.x) then ``PretrainedConfig`` (4.x). Zoo gates both with
+    try/except, so only one needs to resolve."""
     found = False
     for name in ("PreTrainedConfig", "PretrainedConfig"):
         try:
@@ -310,24 +262,22 @@ def test_patching_utils_pretrainedconfig_either_name():
 
 
 def test_patching_utils_peft_linear4bit():
-    """unsloth_zoo/patching_utils.py:313 — `from peft.tuners.lora import
-    Linear4bit as Peft_Linear4bit`. This is the 4-bit LoRA layer that
-    zoo's dtype/dequant patch keys on."""
+    """unsloth_zoo/patching_utils.py:313 -- ``from peft.tuners.lora import
+    Linear4bit as Peft_Linear4bit``. The 4-bit LoRA layer zoo's
+    dtype/dequant patch keys on."""
     _resolve("peft.tuners.lora.Linear4bit")
 
 
 def test_patching_utils_integrations_bitsandbytes_module():
-    """unsloth_zoo/patching_utils.py:677 — `import
-    transformers.integrations.bitsandbytes`. Module path used at
-    IMPORT TIME (top-level) to introspect _replace_with_bnb_linear."""
+    """unsloth_zoo/patching_utils.py:677 -- ``import
+    transformers.integrations.bitsandbytes``. Used at IMPORT TIME
+    (top-level) to introspect _replace_with_bnb_linear."""
     _resolve("transformers.integrations.bitsandbytes")
 
 
 def test_patching_utils_quantizers_utils_module():
-    """unsloth_zoo/patching_utils.py:761 — `import
-    transformers.quantizers.quantizers_utils as _quantizers_utils`.
-    Top-level on transformers 5.x. (On 4.x this module is present too
-    in the installed window.)"""
+    """unsloth_zoo/patching_utils.py:761 -- ``import
+    transformers.quantizers.quantizers_utils``. Top-level on transformers 5.x."""
     _resolve("transformers.quantizers.quantizers_utils")
 
 
@@ -336,9 +286,9 @@ def test_patching_utils_quantizers_utils_module():
 # ===========================================================================
 
 def test_hf_utils_pretrainedconfig_either_name():
-    """unsloth_zoo/hf_utils.py:25-28 — same dance as patching_utils:
-    try `PreTrainedConfig` (5.x), fall back to `PretrainedConfig`
-    (4.x). At least one MUST exist on top-level `transformers`."""
+    """unsloth_zoo/hf_utils.py:25-28 -- try ``PreTrainedConfig`` (5.x),
+    fall back to ``PretrainedConfig`` (4.x). At least one must exist on
+    top-level ``transformers``."""
     found = False
     for name in ("PreTrainedConfig", "PretrainedConfig"):
         try:
@@ -355,9 +305,8 @@ def test_hf_utils_pretrainedconfig_either_name():
 
 
 def test_hf_utils_auto_processor_and_tokenizer():
-    """unsloth_zoo/hf_utils.py:322, 363, 372 — `from transformers
-    import AutoTokenizer` and `from transformers import AutoProcessor`.
-    These drive zoo's `unsloth_tokenizer_from_pretrained` shim."""
+    """unsloth_zoo/hf_utils.py:322, 363, 372 -- ``AutoTokenizer`` and
+    ``AutoProcessor`` drive zoo's ``unsloth_tokenizer_from_pretrained``."""
     _resolve_all([
         "transformers.AutoTokenizer",
         "transformers.AutoProcessor",
@@ -365,18 +314,17 @@ def test_hf_utils_auto_processor_and_tokenizer():
 
 
 def test_hf_utils_processor_mapping_names():
-    """unsloth_zoo/hf_utils.py:278 — `from
-    transformers.models.auto.processing_auto import
-    PROCESSOR_MAPPING_NAMES`. Used to enumerate VLM processors."""
+    """unsloth_zoo/hf_utils.py:278 -- ``from
+    transformers.models.auto.processing_auto import PROCESSOR_MAPPING_NAMES``.
+    Enumerates VLM processors."""
     _resolve(
         "transformers.models.auto.processing_auto.PROCESSOR_MAPPING_NAMES",
     )
 
 
 def test_hf_utils_peft_config_top_level():
-    """unsloth_zoo/hf_utils.py:119, 314 — `from peft import PeftConfig`.
-    Two callsites, both under try/except — but they both want the same
-    symbol. A removal disables BOTH adapter-detection paths."""
+    """unsloth_zoo/hf_utils.py:119, 314 -- ``from peft import PeftConfig``.
+    Two callsites, both try/except, same symbol."""
     _resolve("peft.PeftConfig")
 
 
@@ -385,8 +333,8 @@ def test_hf_utils_peft_config_top_level():
 # ===========================================================================
 
 def test_utils_auto_quantization_config():
-    """unsloth_zoo/utils.py:197 — `from transformers.quantizers import
-    AutoQuantizationConfig`. Quantization config dispatch shim."""
+    """unsloth_zoo/utils.py:197 -- ``from transformers.quantizers import
+    AutoQuantizationConfig``."""
     _resolve("transformers.quantizers.AutoQuantizationConfig")
 
 
@@ -395,35 +343,31 @@ def test_utils_auto_quantization_config():
 # ===========================================================================
 
 def test_empty_model_accelerate_init_empty_weights():
-    """unsloth_zoo/empty_model.py:238, 322 — `from accelerate import
-    init_empty_weights`. Two callsites, both top-level inside their
-    functions (no try/except). A removal makes meta-model loading
-    crash."""
+    """unsloth_zoo/empty_model.py:238, 322 -- ``from accelerate import
+    init_empty_weights``. Two callsites, no try/except; removal makes
+    meta-model loading crash."""
     _resolve("accelerate.init_empty_weights")
 
 
 def test_empty_model_siglip_vision_model():
-    """unsloth_zoo/empty_model.py:307 — `from
-    transformers.models.siglip.modeling_siglip import SiglipVisionModel`.
-    Used to detect SigLIP vision towers during empty-model construction."""
+    """unsloth_zoo/empty_model.py:307 -- ``from
+    transformers.models.siglip.modeling_siglip import SiglipVisionModel``."""
     _resolve("transformers.models.siglip.modeling_siglip.SiglipVisionModel")
 
 
 def test_empty_model_auto_model_for_causal_lm():
-    """unsloth_zoo/empty_model.py:237 — `from transformers import
-    AutoModelForCausalLM`."""
+    """unsloth_zoo/empty_model.py:237 -- ``from transformers import
+    AutoModelForCausalLM``."""
     _resolve("transformers.AutoModelForCausalLM")
 
 
 # ===========================================================================
 # unsloth_zoo/tokenizer_utils.py + unsloth_zoo/training_utils.py
-# (datasets top-level imports)
 # ===========================================================================
 
 def test_top_level_datasets_module():
-    """unsloth_zoo/tokenizer_utils.py:21 and training_utils.py:19 —
-    `import datasets` at module top-level. A missing datasets package
-    means the WHOLE tokenizer / training surface ImportErrors."""
+    """unsloth_zoo/tokenizer_utils.py:21, training_utils.py:19 --
+    ``import datasets`` at module top-level."""
     _resolve("datasets")
 
 
@@ -432,8 +376,8 @@ def test_top_level_datasets_module():
 # ===========================================================================
 
 def test_peft_utils_peft_tuners_lora_module():
-    """unsloth_zoo/peft_utils.py:157 — `import peft.tuners.lora`. Used to
-    enumerate LoRA-eligible layers."""
+    """unsloth_zoo/peft_utils.py:157 -- ``import peft.tuners.lora``.
+    Enumerates LoRA-eligible layers."""
     _resolve("peft.tuners.lora")
 
 
@@ -442,11 +386,10 @@ def test_peft_utils_peft_tuners_lora_module():
 # ===========================================================================
 
 def test_temporary_patches_utils_kwargs_typing():
-    """unsloth_zoo/temporary_patches/utils.py:146, 211, 231, 244 — the
-    KWARGS_TYPE alias is built from a try-cascade of upstream Unpack /
-    TransformersKwargs / FlashAttentionKwargs / LossKwargs. AT LEAST
-    ONE must resolve, else the cascade ends with a NameError at zoo
-    import time."""
+    """unsloth_zoo/temporary_patches/utils.py:146, 211, 231, 244 --
+    KWARGS_TYPE is built from a try-cascade of upstream Unpack /
+    TransformersKwargs / FlashAttentionKwargs / LossKwargs. At least one
+    must resolve, else cascade ends with NameError at zoo import."""
     found_any = False
     for path in (
         "transformers.processing_utils.Unpack",
@@ -467,8 +410,8 @@ def test_temporary_patches_utils_kwargs_typing():
 
 
 def test_temporary_patches_utils_transformers_version():
-    """unsloth_zoo/temporary_patches/utils.py:216 — `from transformers
-    import __version__`. Used by the temporary-patch version gates."""
+    """unsloth_zoo/temporary_patches/utils.py:216 -- ``from transformers
+    import __version__`` drives version gates."""
     _resolve("transformers.__version__")
 
 
@@ -477,17 +420,17 @@ def test_temporary_patches_utils_transformers_version():
 # ===========================================================================
 
 def test_temp_patches_misc_config_mapping():
-    """unsloth_zoo/temporary_patches/misc.py:47 — `from
-    transformers.models.auto.configuration_auto import CONFIG_MAPPING`."""
+    """unsloth_zoo/temporary_patches/misc.py:47 -- ``from
+    transformers.models.auto.configuration_auto import CONFIG_MAPPING``."""
     _resolve(
         "transformers.models.auto.configuration_auto.CONFIG_MAPPING",
     )
 
 
 def test_temp_patches_misc_tokenization_utils_base():
-    """unsloth_zoo/temporary_patches/misc.py:63, 89, 1438 — `from
+    """unsloth_zoo/temporary_patches/misc.py:63, 89, 1438 -- ``from
     transformers.tokenization_utils_base import PreTrainedTokenizerBase,
-    AddedToken`."""
+    AddedToken``."""
     _resolve_all([
         "transformers.tokenization_utils_base.PreTrainedTokenizerBase",
         "transformers.tokenization_utils_base.AddedToken",
@@ -495,88 +438,81 @@ def test_temp_patches_misc_tokenization_utils_base():
 
 
 def test_temp_patches_misc_quantizers_auto():
-    """unsloth_zoo/temporary_patches/misc.py:115 — `import
-    transformers.quantizers.auto`."""
+    """unsloth_zoo/temporary_patches/misc.py:115 -- ``import
+    transformers.quantizers.auto``."""
     _resolve("transformers.quantizers.auto")
 
 
 def test_temp_patches_misc_loss_for_causal_lm_loss():
-    """unsloth_zoo/temporary_patches/misc.py:162, 248 — `from
-    transformers.loss.loss_utils import ForCausalLMLoss`. The CSM
-    patches monkey-rebind this; a rename silently disables them."""
+    """unsloth_zoo/temporary_patches/misc.py:162, 248 -- ``from
+    transformers.loss.loss_utils import ForCausalLMLoss``. CSM patches
+    monkey-rebind this; a rename silently disables them."""
     _resolve("transformers.loss.loss_utils.ForCausalLMLoss")
 
 
 def test_temp_patches_misc_modeling_outputs_causal_lm_output():
-    """unsloth_zoo/temporary_patches/misc.py:161 (and several other
-    patch sites) — `from transformers.modeling_outputs import
-    CausalLMOutputWithPast`. Also referenced in
-    unsloth_zoo/temporary_patches/qwen3_next_moe.py:78."""
+    """unsloth_zoo/temporary_patches/misc.py:161 + qwen3_next_moe.py:78
+    -- ``from transformers.modeling_outputs import CausalLMOutputWithPast``."""
     _resolve("transformers.modeling_outputs.CausalLMOutputWithPast")
 
 
 def test_temp_patches_misc_generation_utils_module():
-    """unsloth_zoo/temporary_patches/misc.py:383 +
-    gpt_oss.py:2135 — `import transformers.generation.utils`. The
+    """unsloth_zoo/temporary_patches/misc.py:383 + gpt_oss.py:2135 --
+    ``import transformers.generation.utils``. The
     create_causal_mask_mapping patch rebinds names on this module."""
     _resolve("transformers.generation.utils")
 
 
 def test_temp_patches_misc_modeling_layers_grad_ckpt():
-    """unsloth_zoo/temporary_patches/misc.py:1121 — `from
-    transformers.modeling_layers import GradientCheckpointingLayer`.
-    The mllama vision encoder patch subclasses this."""
+    """unsloth_zoo/temporary_patches/misc.py:1121 -- ``from
+    transformers.modeling_layers import GradientCheckpointingLayer``.
+    Mllama vision encoder patch subclasses this."""
     _resolve(
         "transformers.modeling_layers.GradientCheckpointingLayer",
     )
 
 
 def test_temp_patches_misc_all_attention_functions():
-    """unsloth_zoo/temporary_patches/misc.py:526 — `from
-    transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS`. The
-    SDPA mask attention-fn registry. Renamed in some transformers 5
-    pre-release tags."""
+    """unsloth_zoo/temporary_patches/misc.py:526 -- ``from
+    transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS``.
+    Renamed in some transformers 5 pre-release tags."""
     _resolve("transformers.modeling_utils.ALL_ATTENTION_FUNCTIONS")
 
 
 def test_temp_patches_misc_integrations_sdpa_attention():
-    """unsloth_zoo/temporary_patches/misc.py:525 — `import
-    transformers.integrations.sdpa_attention`. Module rebinding site."""
+    """unsloth_zoo/temporary_patches/misc.py:525 -- ``import
+    transformers.integrations.sdpa_attention``. Module rebinding site."""
     _resolve("transformers.integrations.sdpa_attention")
 
 
 def test_temp_patches_misc_import_utils():
-    """unsloth_zoo/temporary_patches/misc.py:834 — `import
-    transformers.utils.import_utils`. Used to introspect optional
-    backends without paying the import cost."""
+    """unsloth_zoo/temporary_patches/misc.py:834 -- ``import
+    transformers.utils.import_utils``."""
     _resolve("transformers.utils.import_utils")
 
 
 def test_temp_patches_misc_peft_lora_bnb():
-    """unsloth_zoo/temporary_patches/misc.py:1289 — `import
-    peft.tuners.lora.bnb as peft_bnb`. The BNB dtype-promotion patch
-    iterates this module's Linear*bit classes."""
+    """unsloth_zoo/temporary_patches/misc.py:1289 -- ``import
+    peft.tuners.lora.bnb as peft_bnb``. BNB dtype-promotion patch."""
     _resolve("peft.tuners.lora.bnb")
 
 
 def test_temp_patches_misc_training_arguments():
-    """unsloth_zoo/temporary_patches/misc.py:1333 — `from transformers
-    import TrainingArguments`. Reassigned to patch deprecation
-    warnings."""
+    """unsloth_zoo/temporary_patches/misc.py:1333 -- ``from transformers
+    import TrainingArguments``. Reassigned to patch deprecation warnings."""
     _resolve("transformers.TrainingArguments")
 
 
 def test_temp_patches_misc_models_auto_modeling_auto():
-    """unsloth_zoo/temporary_patches/misc.py:1363 — `import
-    transformers.models.auto.modeling_auto as auto_mod`. Reads
+    """unsloth_zoo/temporary_patches/misc.py:1363 -- ``import
+    transformers.models.auto.modeling_auto as auto_mod``. Reads
     MODEL_FOR_*_MAPPING_NAMES off this module."""
     _resolve("transformers.models.auto.modeling_auto")
 
 
 def test_temp_patches_misc_pretrained_tokenizer_base_top_level():
-    """unsloth_zoo/temporary_patches/misc.py:1438 — `from transformers
-    import PreTrainedTokenizerBase`. Top-level import surface (not
-    the .tokenization_utils_base path)."""
+    """unsloth_zoo/temporary_patches/misc.py:1438 -- ``from transformers
+    import PreTrainedTokenizerBase`` (top-level surface)."""
     _resolve("transformers.PreTrainedTokenizerBase")
 
 
@@ -585,13 +521,8 @@ def test_temp_patches_misc_pretrained_tokenizer_base_top_level():
 # ===========================================================================
 
 def test_temp_patches_gemma_processing_surface():
-    """unsloth_zoo/temporary_patches/gemma.py:93-97 — five imports
-    used to rebuild the Gemma3 processor:
-      - transformers.models.gemma3.processing_gemma3.Gemma3ProcessorKwargs
-      - transformers.image_utils.make_nested_list_of_images
-      - transformers.feature_extraction_utils.BatchFeature
-      - transformers.utils.to_py_obj
-    Module-level installs that need ALL to resolve."""
+    """unsloth_zoo/temporary_patches/gemma.py:93-97 -- five module-level
+    imports used to rebuild the Gemma3 processor; all must resolve."""
     _resolve_all([
         "transformers.models.gemma3.processing_gemma3.Gemma3ProcessorKwargs",
         "transformers.image_utils.make_nested_list_of_images",
@@ -605,18 +536,17 @@ def test_temp_patches_gemma_processing_surface():
 # ===========================================================================
 
 def test_temp_patches_gpt_oss_modeling_rope_utils():
-    """unsloth_zoo/temporary_patches/gpt_oss.py:2602 — `from
-    transformers.modeling_rope_utils import rope_config_validation`."""
+    """unsloth_zoo/temporary_patches/gpt_oss.py:2602 -- ``from
+    transformers.modeling_rope_utils import rope_config_validation``."""
     _resolve(
         "transformers.modeling_rope_utils.rope_config_validation",
     )
 
 
 def test_temp_patches_gpt_oss_layer_type_validation():
-    """unsloth_zoo/temporary_patches/gpt_oss.py:2593 — `from
-    transformers.configuration_utils import layer_type_validation`.
-    Added in transformers 4.56 for layered config validation; the
-    gpt_oss config-rebind needs it on every supported version."""
+    """unsloth_zoo/temporary_patches/gpt_oss.py:2593 -- ``from
+    transformers.configuration_utils import layer_type_validation``
+    (added in transformers 4.56)."""
     _resolve(
         "transformers.configuration_utils.layer_type_validation",
     )
@@ -627,9 +557,9 @@ def test_temp_patches_gpt_oss_layer_type_validation():
 # ===========================================================================
 
 def test_temp_patches_qwen3_vl_moe_act2fn():
-    """unsloth_zoo/temporary_patches/qwen3_vl_moe.py:201 — `from
-    transformers.activations import ACT2FN`. The activation registry;
-    moved between modeling_utils and activations historically."""
+    """unsloth_zoo/temporary_patches/qwen3_vl_moe.py:201 -- ``from
+    transformers.activations import ACT2FN``. Moved between modeling_utils
+    and activations historically."""
     _resolve("transformers.activations.ACT2FN")
 
 
@@ -638,9 +568,9 @@ def test_temp_patches_qwen3_vl_moe_act2fn():
 # ===========================================================================
 
 def test_temp_patches_gemma4_cache_utils():
-    """unsloth_zoo/temporary_patches/gemma4.py:308, 334, 460 — `from
-    transformers.cache_utils import DynamicCache, StaticCache`. The
-    Gemma4 forward-rewrite branches on these classes."""
+    """unsloth_zoo/temporary_patches/gemma4.py:308, 334, 460 -- ``from
+    transformers.cache_utils import DynamicCache, StaticCache``. Gemma4
+    forward-rewrite branches on these classes."""
     _resolve_all([
         "transformers.cache_utils.DynamicCache",
         "transformers.cache_utils.StaticCache",
@@ -652,8 +582,8 @@ def test_temp_patches_gemma4_cache_utils():
 # ===========================================================================
 
 def test_temp_patches_moe_utils_param_wrapper():
-    """unsloth_zoo/temporary_patches/moe_utils.py:897 — `from
-    peft.tuners.lora.layer import ParamWrapper`. Required by zoo PR
+    """unsloth_zoo/temporary_patches/moe_utils.py:897 -- ``from
+    peft.tuners.lora.layer import ParamWrapper``. Required by zoo PR
     #618's 3D-weight LoRA dispatch."""
     _resolve("peft.tuners.lora.layer.ParamWrapper")
 
@@ -663,15 +593,15 @@ def test_temp_patches_moe_utils_param_wrapper():
 # ===========================================================================
 
 def test_logging_utils_utils_notebook():
-    """unsloth_zoo/logging_utils.py:50 — `from
-    transformers.utils.notebook import (...)`. The IPython progress-bar
-    helpers live here on all currently-supported transformers."""
+    """unsloth_zoo/logging_utils.py:50 -- ``from
+    transformers.utils.notebook import (...)``. IPython progress-bar
+    helpers."""
     _resolve("transformers.utils.notebook")
 
 
 def test_logging_utils_trainer_progress_callback():
-    """unsloth_zoo/logging_utils.py:174-178 — `from transformers.trainer
-    import is_in_notebook, DEFAULT_PROGRESS_CALLBACK`."""
+    """unsloth_zoo/logging_utils.py:174-178 -- ``from transformers.trainer
+    import is_in_notebook, DEFAULT_PROGRESS_CALLBACK``."""
     _resolve_all([
         "transformers.trainer.is_in_notebook",
         "transformers.trainer.DEFAULT_PROGRESS_CALLBACK",
@@ -679,9 +609,8 @@ def test_logging_utils_trainer_progress_callback():
 
 
 def test_logging_utils_trl_trainer_module():
-    """unsloth_zoo/logging_utils.py:190 — `import trl.trainer`. The
-    progress-callback override walks `trl.trainer.*Trainer` classes
-    by attribute."""
+    """unsloth_zoo/logging_utils.py:190 -- ``import trl.trainer``. The
+    progress-callback override walks ``trl.trainer.*Trainer`` classes."""
     _skip_if_missing("trl")
     _resolve("trl.trainer")
 
@@ -691,29 +620,24 @@ def test_logging_utils_trl_trainer_module():
 # ===========================================================================
 
 def test_temp_patches_pixtral_rotary_emb():
-    """unsloth_zoo/temporary_patches/pixtral.py:30 — `from
+    """unsloth_zoo/temporary_patches/pixtral.py:30 -- ``from
     transformers.models.pixtral.modeling_pixtral import
-    apply_rotary_pos_emb`. The Pixtral RoPE helper used by the
-    attention rewrite."""
+    apply_rotary_pos_emb``. Used by the attention rewrite."""
     _resolve(
         "transformers.models.pixtral.modeling_pixtral.apply_rotary_pos_emb",
     )
 
 
 # ===========================================================================
-# unsloth_zoo/vllm_lora_worker_manager.py — TOP-LEVEL UNGUARDED imports
+# unsloth_zoo/vllm_lora_worker_manager.py
 # ===========================================================================
 
 def test_vllm_lora_worker_manager_top_level():
-    """unsloth_zoo/vllm_lora_worker_manager.py:22, 23, 32-34 — five
-    TOP-LEVEL unguarded imports. Module fails to import outright if
-    any is missing on the installed vllm:
-      vllm.config.LoRAConfig
-      vllm.logger.init_logger
-      vllm.lora.peft_helper.PEFTHelper
-      vllm.lora.request.LoRARequest
-      vllm.lora.utils.get_adapter_absolute_path
-    """
+    """unsloth_zoo/vllm_lora_worker_manager.py:22, 23, 32-34 -- five
+    TOP-LEVEL unguarded imports; module fails to import if any is missing:
+      vllm.config.LoRAConfig, vllm.logger.init_logger,
+      vllm.lora.peft_helper.PEFTHelper, vllm.lora.request.LoRARequest,
+      vllm.lora.utils.get_adapter_absolute_path."""
     _skip_if_missing("vllm")
     _resolve_all([
         "vllm.config.LoRAConfig",
@@ -725,33 +649,31 @@ def test_vllm_lora_worker_manager_top_level():
 
 
 def test_vllm_lora_worker_manager_vllm_config_top_level():
-    """unsloth_zoo/vllm_lora_worker_manager.py:315 — `from vllm.config
-    import VllmConfig`. Constructor sig changed in vllm 0.10."""
+    """unsloth_zoo/vllm_lora_worker_manager.py:315 -- ``from vllm.config
+    import VllmConfig``. Constructor sig changed in vllm 0.10."""
     _skip_if_missing("vllm")
     _resolve("vllm.config.VllmConfig")
 
 
 # ===========================================================================
-# unsloth_zoo/vllm_utils.py — surface assertions for the unguarded paths
+# unsloth_zoo/vllm_utils.py
 # ===========================================================================
 
 def test_vllm_utils_top_level_peft_type():
-    """unsloth_zoo/vllm_utils.py:2520 — `from peft import PeftType`
-    at MODULE TOP LEVEL (no try/except)."""
+    """unsloth_zoo/vllm_utils.py:2520 -- ``from peft import PeftType`` at
+    MODULE TOP LEVEL (no try/except)."""
     _resolve("peft.PeftType")
 
 
 def test_vllm_utils_sampling_params_path():
-    """unsloth_zoo/vllm_utils.py:3107 — `from vllm import
-    SamplingParams`. (Constructor introspection is covered in the
-    trl/vllm pinned-symbols suite; this just pins the import path.)"""
+    """unsloth_zoo/vllm_utils.py:3107 -- ``from vllm import SamplingParams``."""
     _skip_if_missing("vllm")
     _resolve("vllm.SamplingParams")
 
 
 def test_vllm_utils_models_registry():
-    """unsloth_zoo/vllm_utils.py:1649 — `from
-    vllm.model_executor.models.registry import ModelRegistry`."""
+    """unsloth_zoo/vllm_utils.py:1649 -- ``from
+    vllm.model_executor.models.registry import ModelRegistry``."""
     _skip_if_missing("vllm")
     _resolve("vllm.model_executor.models.registry.ModelRegistry")
 
@@ -761,33 +683,28 @@ def test_vllm_utils_models_registry():
 # ===========================================================================
 
 def test_temp_patches_mxfp4_module_path():
-    """unsloth_zoo/temporary_patches/mxfp4.py — three sites import
-    `transformers.integrations.mxfp4` either as a module
-    (transformers.integrations.mxfp4) OR for `FP4_VALUES` /
-    `Mxfp4Config`. The module path itself MUST resolve so the patch
-    site can rebind FP4 conversion."""
+    """unsloth_zoo/temporary_patches/mxfp4.py -- three sites import
+    ``transformers.integrations.mxfp4``. The module path must resolve so
+    the patch site can rebind FP4 conversion."""
     _resolve("transformers.integrations.mxfp4")
 
 
 def test_temp_patches_mxfp4_tensor_parallel_helper():
-    """unsloth_zoo/temporary_patches/mxfp4.py:181 — `from
-    transformers.integrations.tensor_parallel import
-    shard_and_distribute_module`. Also used by gpt_oss.py:467."""
+    """unsloth_zoo/temporary_patches/mxfp4.py:181 + gpt_oss.py:467 --
+    ``from transformers.integrations.tensor_parallel import
+    shard_and_distribute_module``."""
     _resolve(
         "transformers.integrations.tensor_parallel.shard_and_distribute_module",
     )
 
 
 # ===========================================================================
-# Cross-cutting: the qwen2_vl + qwen2_5_vl image-processing surface used
-# by both compiler.py and temporary_patches/misc.py:1485, 1501.
+# qwen2_vl + qwen2_5_vl image-processing surface
 # ===========================================================================
 
 def test_qwen2_vl_image_processor_class():
-    """unsloth_zoo/temporary_patches/misc.py:1485 —
-    Qwen2VLImageProcessor at transformers.models.qwen2_vl
-    .image_processing_qwen2_vl. The patch site is wrapped in
-    try/except but the symbol IS reached when zoo runs on
+    """unsloth_zoo/temporary_patches/misc.py:1485 -- Qwen2VLImageProcessor.
+    The patch site is wrapped in try/except, but the symbol IS reached on
     transformers >= 5.0; pin the path so a rename produces a clean
     failure instead of a silent no-op."""
     _resolve(
@@ -796,17 +713,10 @@ def test_qwen2_vl_image_processor_class():
 
 
 def test_qwen2_5_vl_image_processor_class_gated_on_v5():
-    """unsloth_zoo/temporary_patches/misc.py:1501 —
-    Qwen2_5_VLImageProcessor at
-    transformers.models.qwen2_5_vl.image_processing_qwen2_5_vl.
-
-    The whole patch_qwen2vl_image_processor_pixel_attrs site is
-    early-returned on transformers < 5.0.0 (see misc.py:1478-1482),
-    and the qwen2_5_vl import is additionally wrapped in
-    try/except. So on 4.57.6 this symbol is allowed to be absent;
-    on >= 5.0 it MUST resolve."""
+    """unsloth_zoo/temporary_patches/misc.py:1501 --
+    Qwen2_5_VLImageProcessor. Version-gated on transformers >= 5.0.0
+    (misc.py:1478-1482)."""
     import transformers
-    # Match the version gate in unsloth_zoo/temporary_patches/misc.py:1479.
     from packaging.version import Version
     if Version(transformers.__version__) < Version("5.0.0"):
         pytest.skip(

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -92,13 +92,10 @@ if (os.environ.get("UNSLOTH_COMPILE_DEBUG", "0") == "1"):
 from importlib.util import find_spec
 import platform as _check_platform
 
-# Import-time pathology workarounds (peft <-> transformers v4 drift, triton
-# CompiledKernel attrs, vLLM rename, etc.) live on the ``unsloth`` package
-# in ``unsloth/import_fixes.py`` and are applied at ``import unsloth`` time.
-# ``unsloth_zoo`` cannot be imported standalone -- the GPU init path below
-# requires ``find_spec("unsloth")`` to succeed -- so ``import unsloth`` has
-# always already run by the time we get here, and the patches are in
-# place. We therefore do NOT re-host or re-apply them at zoo import time.
+# Import-time fixes live in ``unsloth/import_fixes.py`` and run at
+# ``import unsloth`` time. Zoo cannot be imported standalone (the GPU
+# init below requires ``find_spec("unsloth")``), so the patches are
+# always already in place here -- we do not re-host or re-apply them.
 
 # Detect Apple Silicon MLX mode:
 # Either torch is absent (pure MLX), or unsloth already detected MLX
@@ -328,10 +325,6 @@ if not _SKIP_GPU_INIT:
 
     # Log Unsloth-Zoo Utilities
     os.environ["UNSLOTH_ZOO_IS_PRESENT"] = "1"
-
-    # (Zoo-local import-time fixes are applied earlier in this module --
-    # before platform / torch initialization -- so they patch peft / triton /
-    # vllm BEFORE any zoo submodule transitively imports them.)
 
     from .temporary_patches import (
         encode_conversations_with_harmony,

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -537,12 +537,7 @@ def patch_compiled_autograd():
     fx = torch._dynamo.compiled_autograd.AutogradCompilerInstance.end_capture
     if fx.__name__ == "unsloth_end_capture": return
     source = inspect.getsource(fx)
-    # Recognise both the legacy `with disable()` and torch >= 2.7's
-    # underscore-prefixed `with _disable()` form. Either presence means
-    # upstream already wraps the compiled_fn call in a disable context,
-    # and zoo's patch is a no-op for this build. Forwards-compatible:
-    # any future `with foo_disable()` shape that contains `disable()`
-    # also short-circuits, which is the desired conservative behaviour.
+    # torch >= 2.7 renamed `with disable()` to `with _disable()`. Either means upstream already wraps compiled_fn; no-op.
     if "with disable()" in source or "with _disable()" in source: return
     spaces = source.find("def")
     source = source.split("\n")


### PR DESCRIPTION
Follow-up to #637. The squashed merge brought in a lot of new test code and workflow YAML where the comments had run a bit long. This PR trims multi-paragraph rationale paragraphs down to 1 to 3 line summaries while keeping everything that earns its keep: license headers, PR and commit citations, zoo file:line callsites, idempotence/no-op guarantees, the DRIFT DETECTED framing, and HARD GATE markers.

## Net change

18 files, plus 1541 / minus 4233 lines (net minus 2692).

## What got trimmed where

Tests (9 files):
- test_zoo_history_regressions_deep.py: minus 327
- test_upstream_import_fixes_drift.py: minus 141
- test_zoo_source_upstream_refs.py: minus 90
- test_upstream_signatures.py: minus 122
- test_upstream_source_patterns.py: minus 305
- test_extended_dep_api_pins.py: minus 205
- test_compiler_rewriter_exhaustive.py: minus 485
- test_compiler_dynamic_exec.py: minus 142
- test_temporary_patches_exhaustive.py: minus 366
- test_upstream_pinned_symbols_transformers.py: minus 125

Source (3 files):
- unsloth_zoo/__init__.py: minus 9 (apply_import_fixes wiring comments)
- unsloth_zoo/patching_utils.py: minus 5 (compiled_autograd disable rename block)
- tests/conftest.py: minus 49 (_patch_torch_cuda_for_import and import_fixes hook docstrings)

Workflows (5 files):
- consolidated-tests-ci.yml: minus 262 (collapsed the 12-file 626-test enumeration to a one-liner; HARD GATE label kept)
- security-audit.yml: minus 59
- wheel-smoke.yml: minus 23
- lint-ci.yml: minus 47
- mlx-ci.yml: minus 26

## Local verification

\`\`\`
pytest tests/test_upstream_pinned_symbols_*.py \\
       tests/test_zoo_history_regressions_deep.py \\
       tests/test_upstream_import_fixes_drift.py \\
       tests/test_zoo_source_upstream_refs.py \\
       tests/test_upstream_signatures.py \\
       tests/test_extended_dep_api_pins.py \\
       tests/test_upstream_source_patterns.py \\
       tests/test_compiler_rewriter_exhaustive.py \\
       tests/test_compiler_dynamic_exec.py \\
       tests/test_temporary_patches_exhaustive.py \\
       tests/security
\`\`\`

614 passed, 32 skipped, 0 failed (same as on main pre-trim).

YAML round-trip on all 5 workflow files OK. scripts/lint_workflow_triggers.py clean (6 files scanned, no pull_request_target, no unjustified workflow_run, no PR/publish cache-key collision).

## Test plan

- [ ] Confirm pytest pass-count holds across the 12 drift-detector test files plus tests/security.
- [ ] Confirm YAML round-trip on the 5 workflow files.
- [ ] Confirm scripts/lint_workflow_triggers.py passes.
- [ ] Spot-check that PR/commit citations and zoo file:line references are preserved in trimmed docstrings.