### PR TITLE
tests: drift detectors cover transformers 5.x (mirror unsloth PR #5423)

### DIFF
--- a/tests/test_upstream_import_fixes_drift.py
+++ b/tests/test_upstream_import_fixes_drift.py
@@ -187,7 +187,12 @@ def test_pretrained_model_enable_input_require_grads_uses_old_pattern():
     transformers PR #41993 rewrote ``enable_input_require_grads`` to
     iterate ``for module in self.modules()`` and call
     ``module.get_input_embeddings()``, which raises NotImplementedError
-    on vision sub-modules (GLM V4.6's ``self.visual``)."""
+    on vision sub-modules (GLM V4.6's ``self.visual``). Healthy state:
+    either the upstream rewrite isn't present (pre-HF#41993), OR the
+    patch installed a NotImplementedError-tolerant replacement. The
+    bare ``for module in self.modules()`` check alone cannot tell the
+    two apart because unsloth's replacement deliberately also uses
+    that loop, just wrapped in ``try / except NotImplementedError``."""
     pytest.importorskip("transformers")
     from transformers import PreTrainedModel
 
@@ -196,24 +201,34 @@ def test_pretrained_model_enable_input_require_grads_uses_old_pattern():
     except Exception as exc:
         pytest.skip(f"could not getsource(enable_input_require_grads): {exc!r}")
 
-    if "for module in self.modules()" in src:
-        pytest.fail(
-            "DRIFT DETECTED: PreTrainedModel.enable_input_require_grads now "
-            "iterates self.modules() (post HF#41993). "
-            "patch_enable_input_require_grads has to install a "
-            "NotImplementedError-tolerant replacement."
-        )
+    if "for module in self.modules()" not in src:
+        return  # healthy: pre-HF#41993 shape
+    if "NotImplementedError" in src:
+        return  # healthy: unsloth's tolerant replacement is installed
+
+    pytest.fail(
+        "DRIFT DETECTED: PreTrainedModel.enable_input_require_grads now "
+        "iterates self.modules() (post HF#41993) and has NOT been "
+        "wrapped by patch_enable_input_require_grads; vision submodules "
+        "(e.g. GLM V4.6's self.visual) will raise NotImplementedError "
+        "from get_input_embeddings and crash the whole call."
+    )
 
 
 def test_transformers_torchcodec_available_flag_is_present():
-    """``disable_torchcodec_if_broken`` (import_fixes.py 1291-1317).
-    Flips ``transformers.utils.import_utils._torchcodec_available`` to
-    False when torchcodec's native FFmpeg deps fail to load."""
+    """``disable_torchcodec_if_broken`` (import_fixes.py 1291-1317). Needs
+    either the pre-5.x module-level ``_torchcodec_available`` flag, or
+    the 5.x ``is_torchcodec_available`` public function; one of the two
+    is the patch site the fix monkey-patches when FFmpeg is missing."""
     tf_iu = pytest.importorskip("transformers.utils.import_utils")
-    assert hasattr(tf_iu, "_torchcodec_available"), (
-        "transformers.utils.import_utils._torchcodec_available was "
-        "removed/renamed upstream; disable_torchcodec_if_broken can no "
-        "longer disable a broken torchcodec install."
+    has_flag = hasattr(tf_iu, "_torchcodec_available")
+    has_func = callable(getattr(tf_iu, "is_torchcodec_available", None))
+    assert has_flag or has_func, (
+        "transformers.utils.import_utils dropped both "
+        "``_torchcodec_available`` (pre-5.x) AND "
+        "``is_torchcodec_available`` (>=5.x); "
+        "disable_torchcodec_if_broken can no longer disable a broken "
+        "torchcodec install."
     )
 
 


### PR DESCRIPTION
## Summary

The two transformers-targeting drift detectors in `tests/test_upstream_import_fixes_drift.py` have predicates written against transformers 4.x only. On the Core matrix's `HF=latest + TRL=latest` cell (`transformers>=5,<6`) they fire DRIFT DETECTED even when the upstream / unsloth fix combination is healthy.

Companion PR on unsloth: unslothai/unsloth#5423 (merged) shipped the matching `disable_torchcodec_if_broken` change and the same two predicate relaxations on its side. This PR mirrors just the test changes onto zoo (zoo no longer carries the import_fixes source, only the drift detectors, since PR #639).

## What changes

### 1. `test_pretrained_model_enable_input_require_grads_uses_old_pattern`

Fired whenever the source contains `for module in self.modules()`. But the unsloth replacement that `patch_enable_input_require_grads` installs deliberately ALSO uses that pattern, just wrapped in `try / except NotImplementedError`. The predicate could not distinguish broken upstream from the working patch. Accept either:

- pre-HF#41993 shape (no `self.modules()` loop in the source), or
- post-patch shape (loop + `NotImplementedError` handler in the source).

### 2. `test_transformers_torchcodec_available_flag_is_present`

Asserted the pre-5.x module-level `_torchcodec_available` flag. transformers 5 replaced it with an `lru_cache`'d `is_torchcodec_available()` callable. Accept either symbol; the patch site in `unsloth/import_fixes.py` now targets both (PR #5423).

## Local verification

- transformers 4.57.6 + trl 0.25.1 + peft 0.19.1 + triton 3.5.1 + vllm 0.15.1+cu130 (Core HF=4.57.6 cell shape): **18 passed**.
- transformers 5.8.1 + peft 0.19.1 + torch 2.9 CPU (no trl / vllm / datasets / xformers): **12 passed, 6 skipped** on missing optional libs, 0 failed.

## Test plan

- [x] `pytest tests/test_upstream_import_fixes_drift.py` is 18/18 on the HF=4.57.6 cell shape.
- [x] Same suite is 12 passed / 6 skipped / 0 failed on transformers 5.8.1 + minimal deps.
- [ ] CI passes.