### PR TITLE
gpt_oss: reorder helpers before patch_gpt_oss_bnb4bit_auto

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1111,6 +1111,31 @@ def restore_gpt_oss_original():
         pass
     return False
 
+def _normalized_unsloth_model_name() -> str:
+    return os.environ.get("UNSLOTH_MODEL_NAME", "").replace("-", "_")
+
+
+def _should_use_gpt_oss_bnb4bit() -> bool:
+    """
+    Decide if GPT-OSS should use BnB-compatible 4-bit experts.
+    Default: True when load_in_4bit is active.
+    Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to force BF16 path.
+    """
+    if "gpt_oss" not in _normalized_unsloth_model_name():
+        return False
+    if "_load_in_4bit_" not in _normalized_unsloth_model_name():
+        return False
+    return os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_DISABLE", "0") != "1"
+
+
+def _is_gpt_oss_4bit_load() -> bool:
+    return "_load_in_4bit_" in _normalized_unsloth_model_name()
+
+
+def _is_transformers_v5() -> bool:
+    return transformers_version >= Version("5.0.0.dev0")
+
+
 def patch_gpt_oss_bnb4bit_auto():
     """
     Auto-patch GPT-OSS for BnB 4-bit when load_in_4bit is active.
@@ -1348,31 +1373,6 @@ from .moe_utils import (
     forward_native_grouped_mm,
     # torch_native_forward,
 )
-
-
-def _should_use_gpt_oss_bnb4bit() -> bool:
-    """
-    Decide if GPT-OSS should use BnB-compatible 4-bit experts.
-    Default: True when load_in_4bit is active.
-    Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to force BF16 path.
-    """
-    if "gpt_oss" not in _normalized_unsloth_model_name():
-        return False
-    if "_load_in_4bit_" not in _normalized_unsloth_model_name():
-        return False
-    return os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_DISABLE", "0") != "1"
-
-
-def _is_gpt_oss_4bit_load() -> bool:
-    return "_load_in_4bit_" in _normalized_unsloth_model_name()
-
-
-def _normalized_unsloth_model_name() -> str:
-    return os.environ.get("UNSLOTH_MODEL_NAME", "").replace("-", "_")
-
-
-def _is_transformers_v5() -> bool:
-    return transformers_version >= Version("5.0.0.dev0")
 
 
 def patch_gpt_oss_moe_for_lora():


### PR DESCRIPTION
## Summary
- Move the 4 module-level helpers (`_normalized_unsloth_model_name`, `_should_use_gpt_oss_bnb4bit`, `_is_gpt_oss_4bit_load`, `_is_transformers_v5`) up so they are defined before `patch_gpt_oss_bnb4bit_auto` (the first patch function that references them).
- Fixes the `NameError: name '_should_use_gpt_oss_bnb4bit' is not defined` surfaced by `unslothai/unsloth` PR #5340's Core CI matrix (HF=4.57.6 / default / latest) during `_run_temporary_patches("init")`.

## Test plan
- [x] Local reorder verified by `python -c "import unsloth; from unsloth_zoo.temporary_patches.gpt_oss import patch_gpt_oss_bnb4bit_auto; patch_gpt_oss_bnb4bit_auto()"` returning cleanly.
- [ ] CI Core matrix passes (the matrix that was RED on PR #5340).
- [ ] No behavior change: the reorder is pure motion, no semantic edits.