### PR TITLE
saving: layout-aware MoE LoRA merge + loud-fail on fallback (#5410)

### DIFF
--- a/tests/test_unsloth_zoo_lora_merge.py
+++ b/tests/test_unsloth_zoo_lora_merge.py
@@ -342,14 +342,9 @@ def test_merge_moe_fused_down_proj_expert(is_transposed):
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
 
 
-# ---------------------------------------------------------------------------
-# 8. PEFT 0.19+ "standard" (non-swapped) layout coverage for per-expert helpers
-#    (issue #5410). PEFT 0.19 swaps in/out features for non-transposed 3D
-#    parameters, so lora_A / lora_B come out flipped relative to PEFT 0.18.
-# ---------------------------------------------------------------------------
+# 8. PEFT 0.19+ standard layout (#5410).
 
 def test_merge_moe_gate_expert_standard_layout():
-    """Standard layout: lora_A (E*r, H), lora_B (2I, E*r); take first I rows of B."""
     torch.manual_seed(SEED)
     num_experts, rank_per, inter_dim, hidden_dim = 4, 4, 8, 12
     total_rank = num_experts * rank_per
@@ -366,9 +361,9 @@ def test_merge_moe_gate_expert_standard_layout():
         output_dtype=torch.bfloat16,
     )
     s, e = expert_idx * rank_per, (expert_idx + 1) * rank_per
-    a_slice = lora_A[s:e].to(torch.float32)              # (r, H)
-    b_slice = lora_B[:, s:e].to(torch.float32)           # (2I, r)
-    delta = b_slice[:inter_dim, :] @ a_slice             # (I, H)
+    a_slice = lora_A[s:e].to(torch.float32)
+    b_slice = lora_B[:, s:e].to(torch.float32)
+    delta = b_slice[:inter_dim, :] @ a_slice
     expected = gate_W.to(torch.float32) + alpha * delta
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
 
@@ -392,13 +387,12 @@ def test_merge_moe_up_expert_standard_layout():
     s, e = expert_idx * rank_per, (expert_idx + 1) * rank_per
     a_slice = lora_A[s:e].to(torch.float32)
     b_slice = lora_B[:, s:e].to(torch.float32)
-    delta = b_slice[inter_dim:, :] @ a_slice             # second half of B
+    delta = b_slice[inter_dim:, :] @ a_slice
     expected = up_W.to(torch.float32) + alpha * delta
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
 
 
 def test_merge_moe_down_proj_expert_standard_layout():
-    """Standard layout: lora_A (E*r, I), lora_B (H, E*r); delta = B @ A directly."""
     torch.manual_seed(SEED)
     num_experts, rank_per = 4, 4
     total_rank = num_experts * rank_per
@@ -406,8 +400,8 @@ def test_merge_moe_down_proj_expert_standard_layout():
     alpha = 8.0
 
     down_W = torch.randn(H, I, dtype=torch.bfloat16)
-    lora_A = torch.randn(total_rank, I, dtype=torch.bfloat16) * 0.05  # A.shape[1] = I = in_dim
-    lora_B = torch.randn(H, total_rank, dtype=torch.bfloat16) * 0.05  # B.shape[0] = H = out_dim
+    lora_A = torch.randn(total_rank, I, dtype=torch.bfloat16) * 0.05
+    lora_B = torch.randn(H, total_rank, dtype=torch.bfloat16) * 0.05
     expert_idx = 3
 
     out = _merge_moe_down_proj_expert(
@@ -418,14 +412,12 @@ def test_merge_moe_down_proj_expert_standard_layout():
     s, e = expert_idx * rank_per, (expert_idx + 1) * rank_per
     a_slice = lora_A[s:e].to(torch.float32)
     b_slice = lora_B[:, s:e].to(torch.float32)
-    delta = b_slice @ a_slice                            # (H, I)
+    delta = b_slice @ a_slice
     expected = down_W.to(torch.float32) + alpha * delta
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
 
 
-# ---------------------------------------------------------------------------
-# 9. Layout detection + fallback bookkeeping (issue #5410).
-# ---------------------------------------------------------------------------
+# 9. Layout detection + fallback (#5410).
 
 def test_detect_moe_lora_layout_classifies_both_conventions():
     from unsloth_zoo.saving_utils import _detect_moe_lora_layout
@@ -440,18 +432,15 @@ def test_detect_moe_lora_layout_classifies_both_conventions():
     A_bad = torch.empty(total_rank, out_dim + 1)
     B_bad = torch.empty(in_dim,     total_rank)
     assert _detect_moe_lora_layout(A_bad, B_bad, num_experts, out_dim, in_dim)[0] == "unknown"
-    # num_experts non-divisor of total_rank => unknown
     assert _detect_moe_lora_layout(A_swap, B_swap, num_experts + 1, out_dim, in_dim)[0] == "unknown"
 
 
 def test_moe_merge_fallback_counter_records_bad_layout():
-    """Unrecognised shape must increment the fallback counter and return W unchanged."""
     from unsloth_zoo.saving_utils import _MOE_MERGE_STATE, _reset_moe_merge_state
     _reset_moe_merge_state()
     num_experts, rank_per, inter_dim, hidden_dim = 4, 4, 8, 12
     total_rank = num_experts * rank_per
     gate_W = torch.randn(inter_dim, hidden_dim, dtype=torch.bfloat16)
-    # Mangled shapes: matches neither swapped nor standard
     lora_A = torch.randn(total_rank, hidden_dim + 7, dtype=torch.bfloat16)
     lora_B = torch.randn(hidden_dim, total_rank,    dtype=torch.bfloat16)
     out = _merge_moe_gate_expert(
@@ -466,7 +455,6 @@ def test_moe_merge_fallback_counter_records_bad_layout():
 
 
 def test_resolve_num_experts_walks_base_layer_chain():
-    """Authoritative num_experts must come off `.module` or any `.base_layer` ancestor."""
     from unsloth_zoo.saving_utils import _resolve_num_experts_from_lora_stats
 
     class Inner:

--- a/tests/test_unsloth_zoo_lora_merge.py
+++ b/tests/test_unsloth_zoo_lora_merge.py
@@ -340,3 +340,146 @@ def test_merge_moe_fused_down_proj_expert(is_transposed):
         expected[ei] = expected[ei] + alpha * (delta.T if is_transposed else delta)
 
     torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
+
+
+# ---------------------------------------------------------------------------
+# 8. PEFT 0.19+ "standard" (non-swapped) layout coverage for per-expert helpers
+#    (issue #5410). PEFT 0.19 swaps in/out features for non-transposed 3D
+#    parameters, so lora_A / lora_B come out flipped relative to PEFT 0.18.
+# ---------------------------------------------------------------------------
+
+def test_merge_moe_gate_expert_standard_layout():
+    """Standard layout: lora_A (E*r, H), lora_B (2I, E*r); take first I rows of B."""
+    torch.manual_seed(SEED)
+    num_experts, rank_per, inter_dim, hidden_dim = 4, 4, 8, 12
+    total_rank = num_experts * rank_per
+    alpha = 8.0
+
+    gate_W = torch.randn(inter_dim, hidden_dim, dtype=torch.bfloat16)
+    lora_A = torch.randn(total_rank, hidden_dim,  dtype=torch.bfloat16) * 0.05
+    lora_B = torch.randn(2 * inter_dim, total_rank, dtype=torch.bfloat16) * 0.05
+    expert_idx = 1
+
+    out = _merge_moe_gate_expert(
+        gate_W.clone(), _ls(lora_A, lora_B, alpha),
+        expert_idx=expert_idx, num_experts=num_experts,
+        output_dtype=torch.bfloat16,
+    )
+    s, e = expert_idx * rank_per, (expert_idx + 1) * rank_per
+    a_slice = lora_A[s:e].to(torch.float32)              # (r, H)
+    b_slice = lora_B[:, s:e].to(torch.float32)           # (2I, r)
+    delta = b_slice[:inter_dim, :] @ a_slice             # (I, H)
+    expected = gate_W.to(torch.float32) + alpha * delta
+    torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
+
+
+def test_merge_moe_up_expert_standard_layout():
+    torch.manual_seed(SEED)
+    num_experts, rank_per, inter_dim, hidden_dim = 4, 4, 8, 12
+    total_rank = num_experts * rank_per
+    alpha = 8.0
+
+    up_W = torch.randn(inter_dim, hidden_dim, dtype=torch.bfloat16)
+    lora_A = torch.randn(total_rank, hidden_dim,  dtype=torch.bfloat16) * 0.05
+    lora_B = torch.randn(2 * inter_dim, total_rank, dtype=torch.bfloat16) * 0.05
+    expert_idx = 2
+
+    out = _merge_moe_up_expert(
+        up_W.clone(), _ls(lora_A, lora_B, alpha),
+        expert_idx=expert_idx, num_experts=num_experts,
+        output_dtype=torch.bfloat16,
+    )
+    s, e = expert_idx * rank_per, (expert_idx + 1) * rank_per
+    a_slice = lora_A[s:e].to(torch.float32)
+    b_slice = lora_B[:, s:e].to(torch.float32)
+    delta = b_slice[inter_dim:, :] @ a_slice             # second half of B
+    expected = up_W.to(torch.float32) + alpha * delta
+    torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
+
+
+def test_merge_moe_down_proj_expert_standard_layout():
+    """Standard layout: lora_A (E*r, I), lora_B (H, E*r); delta = B @ A directly."""
+    torch.manual_seed(SEED)
+    num_experts, rank_per = 4, 4
+    total_rank = num_experts * rank_per
+    H, I = 12, 8
+    alpha = 8.0
+
+    down_W = torch.randn(H, I, dtype=torch.bfloat16)
+    lora_A = torch.randn(total_rank, I, dtype=torch.bfloat16) * 0.05  # A.shape[1] = I = in_dim
+    lora_B = torch.randn(H, total_rank, dtype=torch.bfloat16) * 0.05  # B.shape[0] = H = out_dim
+    expert_idx = 3
+
+    out = _merge_moe_down_proj_expert(
+        down_W.clone(), _ls(lora_A, lora_B, alpha),
+        expert_idx=expert_idx, num_experts=num_experts,
+        output_dtype=torch.bfloat16,
+    )
+    s, e = expert_idx * rank_per, (expert_idx + 1) * rank_per
+    a_slice = lora_A[s:e].to(torch.float32)
+    b_slice = lora_B[:, s:e].to(torch.float32)
+    delta = b_slice @ a_slice                            # (H, I)
+    expected = down_W.to(torch.float32) + alpha * delta
+    torch.testing.assert_close(out.to(torch.float32).cpu(), expected, atol=1e-1, rtol=1e-1)
+
+
+# ---------------------------------------------------------------------------
+# 9. Layout detection + fallback bookkeeping (issue #5410).
+# ---------------------------------------------------------------------------
+
+def test_detect_moe_lora_layout_classifies_both_conventions():
+    from unsloth_zoo.saving_utils import _detect_moe_lora_layout
+    num_experts, r, out_dim, in_dim = 4, 4, 16, 12
+    total_rank = num_experts * r
+    A_swap = torch.empty(total_rank, out_dim)
+    B_swap = torch.empty(in_dim,     total_rank)
+    assert _detect_moe_lora_layout(A_swap, B_swap, num_experts, out_dim, in_dim) == ("swapped", r)
+    A_std = torch.empty(total_rank, in_dim)
+    B_std = torch.empty(out_dim,    total_rank)
+    assert _detect_moe_lora_layout(A_std, B_std, num_experts, out_dim, in_dim) == ("standard", r)
+    A_bad = torch.empty(total_rank, out_dim + 1)
+    B_bad = torch.empty(in_dim,     total_rank)
+    assert _detect_moe_lora_layout(A_bad, B_bad, num_experts, out_dim, in_dim)[0] == "unknown"
+    # num_experts non-divisor of total_rank => unknown
+    assert _detect_moe_lora_layout(A_swap, B_swap, num_experts + 1, out_dim, in_dim)[0] == "unknown"
+
+
+def test_moe_merge_fallback_counter_records_bad_layout():
+    """Unrecognised shape must increment the fallback counter and return W unchanged."""
+    from unsloth_zoo.saving_utils import _MOE_MERGE_STATE, _reset_moe_merge_state
+    _reset_moe_merge_state()
+    num_experts, rank_per, inter_dim, hidden_dim = 4, 4, 8, 12
+    total_rank = num_experts * rank_per
+    gate_W = torch.randn(inter_dim, hidden_dim, dtype=torch.bfloat16)
+    # Mangled shapes: matches neither swapped nor standard
+    lora_A = torch.randn(total_rank, hidden_dim + 7, dtype=torch.bfloat16)
+    lora_B = torch.randn(hidden_dim, total_rank,    dtype=torch.bfloat16)
+    out = _merge_moe_gate_expert(
+        gate_W.clone(), _ls(lora_A, lora_B, 1.0),
+        expert_idx=0, num_experts=num_experts, output_dtype=torch.bfloat16,
+    )
+    torch.testing.assert_close(out.cpu(), gate_W)
+    assert _MOE_MERGE_STATE["fallback"] >= 1
+    assert _MOE_MERGE_STATE["first_error"] is not None
+    assert _MOE_MERGE_STATE["first_error"]["role"] == "gate"
+    _reset_moe_merge_state()
+
+
+def test_resolve_num_experts_walks_base_layer_chain():
+    """Authoritative num_experts must come off `.module` or any `.base_layer` ancestor."""
+    from unsloth_zoo.saving_utils import _resolve_num_experts_from_lora_stats
+
+    class Inner:
+        num_experts = 128
+
+    class Outer:
+        base_layer = Inner()
+
+    stats_inner_only = LoraStats(module=Inner(), lora_A=None, lora_B=None, alpha=1.0)
+    assert _resolve_num_experts_from_lora_stats(stats_inner_only, fallback=-1) == 128
+
+    stats_via_base_layer = LoraStats(module=Outer(), lora_A=None, lora_B=None, alpha=1.0)
+    assert _resolve_num_experts_from_lora_stats(stats_via_base_layer, fallback=-1) == 128
+
+    stats_none = LoraStats(module=None, lora_A=None, lora_B=None, alpha=1.0)
+    assert _resolve_num_experts_from_lora_stats(stats_none, fallback=17) == 17

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -609,6 +609,20 @@ def _merge_and_overwrite_lora(
                 safetensor_keys,
                 model_class_name = model_class_name,
             )
+            # Override shard-local expert counts with the authoritative model-
+            # config value walked off any sibling LoRA whose `.module` made it
+            # through `create_lora_statistics` (issue #5410). When experts are
+            # split across multiple safetensor shards, the shard-local max may
+            # be a non-divisor of `total_rank` (e.g. 17 of 128), which makes
+            # `_detect_moe_lora_layout` return "unknown" and forces a fallback.
+            for _lk, _ls in converted_lora_weights.items():
+                if not isinstance(_lk, str): continue
+                _pm = re.match(r"^(.*mlp\.experts)(?:\.base_layer)?$", _lk)
+                if not _pm: continue
+                _prefix = _pm.group(1)
+                _ne = _resolve_num_experts_from_lora_stats(_ls, fallback = None)
+                if _ne is not None and _ne > 1:
+                    moe_num_experts[_prefix] = _ne
             processed_mxfp4_keys = set()
             if UNSLOTH_ENABLE_LOGGING:
                 try:
@@ -918,128 +932,234 @@ def _merge_and_overwrite_lora(
     return count, safetensor_keys_seen
 pass
 
-def _merge_moe_gate_expert(gate_W, lora_stats, expert_idx, num_experts, output_dtype):
+# Per-expert MoE LoRA merge helpers (issue #5410). PEFT's ParamWrapper has two
+# possible LoRA tensor layouts. PEFT 0.18 keeps the raw 3D dims ("swapped");
+# PEFT 0.19+ swaps in/out for non-transposed 3D parameters ("standard"), see
+# https://github.com/huggingface/peft/pull/2521. Layouts (E=num_experts, r=rank
+# per expert, I=moe_intermediate, H=hidden):
+#
+#   gate_up_proj per-expert disk shape (I, H):
+#     swapped : lora_A (E*r, 2I), lora_B (H, E*r)  -> delta gate = (B @ A[:, :I]).T
+#     standard: lora_A (E*r, H),  lora_B (2I, E*r) -> delta gate =  B[:I, :] @ A
+#
+#   down_proj per-expert disk shape (H, I):
+#     swapped : lora_A (E*r, H),  lora_B (I,  E*r) -> delta = (B @ A).T
+#     standard: lora_A (E*r, I),  lora_B (H,  E*r) -> delta =  B @ A
+#
+# Layout is detected by shape against the per-expert disk weight, so works on
+# transformers 4.57.x / 5.x and peft 0.18.x / 0.19.x without version sniffing.
+# Any unrecognised layout or runtime error increments a counter that
+# merge_and_overwrite_lora raises on at the end so a partial merge cannot
+# be silently saved as successful.
+
+_MOE_MERGE_STATE = {
+    "attempted":   0,
+    "applied":     0,
+    "fallback":    0,
+    "first_error": None,
+}
+
+
+def _reset_moe_merge_state():
+    _MOE_MERGE_STATE["attempted"]   = 0
+    _MOE_MERGE_STATE["applied"]     = 0
+    _MOE_MERGE_STATE["fallback"]    = 0
+    _MOE_MERGE_STATE["first_error"] = None
+
+
+def _record_moe_merge_fallback(role, expert_idx, reason, lora_stats, W_shape):
+    _MOE_MERGE_STATE["fallback"] += 1
+    if _MOE_MERGE_STATE["first_error"] is None:
+        try:
+            a_shape = tuple(lora_stats.lora_A.shape) if lora_stats is not None and lora_stats.lora_A is not None else None
+            b_shape = tuple(lora_stats.lora_B.shape) if lora_stats is not None and lora_stats.lora_B is not None else None
+        except Exception:
+            a_shape, b_shape = None, None
+        _MOE_MERGE_STATE["first_error"] = {
+            "role":          role,
+            "expert_idx":    expert_idx,
+            "reason":        str(reason),
+            "lora_A_shape":  a_shape,
+            "lora_B_shape":  b_shape,
+            "per_expert_W":  W_shape,
+        }
+    logger.warning(
+        f"[Unsloth MoE merge fallback] role={role} expert={expert_idx} reason={reason}. "
+        f"per_expert_W={W_shape}. The base weight is being written through; "
+        "the merged checkpoint will be missing this delta."
+    )
+
+
+def _resolve_num_experts_from_lora_stats(lora_stats, fallback):
+    """Walk the wrapped module chain for the authoritative `num_experts`.
+    The shard-local key scan can be a non-divisor of total_rank when experts
+    are split across multiple safetensor shards.
     """
-    Merge LoRA for a single expert of gate_proj part of gate_up_proj.
+    module = getattr(lora_stats, "module", None)
+    while module is not None:
+        for attr in (
+            "num_experts",
+            "num_experts_per_group",
+            "num_routed_experts",
+            "num_local_experts",
+            "num_moe_experts",
+        ):
+            value = getattr(module, attr, None)
+            if isinstance(value, int) and value > 1:
+                return value
+        # ParamWrapper.base_layer is the underlying MoE module
+        module = getattr(module, "base_layer", None)
+    return fallback
+
+
+def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim):
+    """Classify the (lora_A, lora_B) pair as PEFT "swapped" / "standard" / "unknown"
+    by shape, given the per-expert 3D param OUTPUT / INPUT feature counts.
+    Returns (layout, rank_per_expert).
     """
+    total_rank_A, dim_A = lora_A.shape
+    dim_B, total_rank_B = lora_B.shape
+    if total_rank_A != total_rank_B or num_experts is None or num_experts <= 0:
+        return "unknown", 0
+    if total_rank_A % num_experts != 0:
+        return "unknown", 0
+    r = total_rank_A // num_experts
+    if dim_A == out_dim and dim_B == in_dim:
+        return "swapped", r
+    if dim_A == in_dim and dim_B == out_dim:
+        return "standard", r
+    return "unknown", r
+
+
+def _merge_moe_gate_or_up_expert(W, lora_stats, expert_idx, num_experts, output_dtype, *, role):
+    """Shared body for gate_proj / up_proj per-expert merges.
+
+    role: "gate" picks the first I rows / first I columns of the fused delta;
+          "up"  picks the last I rows / last I columns.
+    """
+    if lora_stats is None or lora_stats.lora_A is None or lora_stats.lora_B is None:
+        return W
+    _MOE_MERGE_STATE["attempted"] += 1
     try:
-        if lora_stats.lora_A is None or lora_stats.lora_B is None:
-            return gate_W
-
-        total_rank, two_inter = lora_stats.lora_A.shape
-        in_dim, total_rank_B = lora_stats.lora_B.shape
-
-        # Validation checks
-        if total_rank_B != total_rank or two_inter % 2 != 0:
-            return gate_W
-
+        # Prefer the authoritative num_experts off the wrapped module; the caller's
+        # value can be a shard-local count that doesn't divide total_rank when the
+        # experts are split across multiple safetensor shards.
+        num_experts = _resolve_num_experts_from_lora_stats(lora_stats, num_experts)
         if num_experts is None or num_experts <= 0:
-            num_experts = total_rank // max(1, getattr(lora_stats, "rank", 0) or 1)
-        if num_experts <= 0 or total_rank % num_experts != 0:
-            return gate_W
+            num_experts = lora_stats.lora_A.shape[0] // max(1, getattr(lora_stats, "rank", 0) or 1)
 
-        rank = total_rank // num_experts
-        start, end = expert_idx * rank, (expert_idx + 1) * rank
-        if end > total_rank:
-            return gate_W
+        I, H = W.shape   # per-expert disk weight: (intermediate, hidden)
+        layout, r = _detect_moe_lora_layout(
+            lora_stats.lora_A, lora_stats.lora_B,
+            num_experts = num_experts, out_dim = 2 * I, in_dim = H,
+        )
+        if layout == "unknown" or r <= 0:
+            _record_moe_merge_fallback(
+                role, expert_idx,
+                f"layout not detected (A={tuple(lora_stats.lora_A.shape)}, B={tuple(lora_stats.lora_B.shape)})",
+                lora_stats, (I, H),
+            )
+            return W
 
-        a_slice = lora_stats.lora_A[start:end, :]          # (r, 2I)
-        b_slice = lora_stats.lora_B[:, start:end]          # (H, r)
-        inter_dim = two_inter // 2
+        start, end = expert_idx * r, (expert_idx + 1) * r
+        if end > num_experts * r:
+            _record_moe_merge_fallback(role, expert_idx, "expert_idx out of range", lora_stats, (I, H))
+            return W
 
-        # gate_proj corresponds to first half of A
-        gate_a = a_slice[:, :inter_dim]                    # (r, I)
+        a_slice = lora_stats.lora_A[start:end, :]
+        b_slice = lora_stats.lora_B[:, start:end]
+        device  = _active_merge_device()
+        a_f     = a_slice.to(device, dtype = torch.float32, non_blocking = True)
+        b_f     = b_slice.to(device, dtype = torch.float32, non_blocking = True)
 
-        device = _active_merge_device()
-        gate_delta = b_slice.to(device, dtype = torch.float32, non_blocking = True) @ gate_a.to(device, dtype = torch.float32, non_blocking = True)
+        if layout == "swapped":
+            # lora_A: (r, 2I), lora_B: (H, r); pick the gate/up half along A's columns
+            half = a_f[:, :I] if role == "gate" else a_f[:, I:]   # (r, I)
+            delta = b_f @ half                                    # (H, I)
+            merged = W.to(device, dtype = torch.float32, non_blocking = True).add(
+                delta.transpose(0, 1), alpha = lora_stats.alpha,
+            )
+        else:
+            # 'standard': lora_A: (r, H), lora_B: (2I, r); pick the half along B's rows
+            half = b_f[:I, :] if role == "gate" else b_f[I:, :]   # (I, r)
+            delta = half @ a_f                                    # (I, H)
+            merged = W.to(device, dtype = torch.float32, non_blocking = True).add(
+                delta, alpha = lora_stats.alpha,
+            )
 
-        gate_merged = gate_W.to(device, dtype = torch.float32, non_blocking = True)
-        gate_merged = gate_merged.add(gate_delta.transpose(0, 1), alpha = lora_stats.alpha)
+        _MOE_MERGE_STATE["applied"] += 1
+        return merged.to(output_dtype)
+    except Exception as exc:
+        _record_moe_merge_fallback(role, expert_idx, repr(exc), lora_stats, tuple(W.shape))
+        return W
 
-        return gate_merged.to(output_dtype)
-    except Exception:
-        return gate_W
+
+def _merge_moe_gate_expert(gate_W, lora_stats, expert_idx, num_experts, output_dtype):
+    return _merge_moe_gate_or_up_expert(
+        gate_W, lora_stats, expert_idx, num_experts, output_dtype, role = "gate",
+    )
 
 
 def _merge_moe_up_expert(up_W, lora_stats, expert_idx, num_experts, output_dtype):
-    """
-    Merge LoRA for a single expert of up_proj part of gate_up_proj.
-    """
-    try:
-        if lora_stats.lora_A is None or lora_stats.lora_B is None:
-            return up_W
-
-        total_rank, two_inter = lora_stats.lora_A.shape
-        in_dim, total_rank_B = lora_stats.lora_B.shape
-
-        # Validation checks
-        if total_rank_B != total_rank or two_inter % 2 != 0:
-            return up_W
-
-        if num_experts is None or num_experts <= 0:
-            num_experts = total_rank // max(1, getattr(lora_stats, "rank", 0) or 1)
-        if num_experts <= 0 or total_rank % num_experts != 0:
-            return up_W
-
-        rank = total_rank // num_experts
-        start, end = expert_idx * rank, (expert_idx + 1) * rank
-        if end > total_rank:
-            return up_W
-
-        a_slice = lora_stats.lora_A[start:end, :]          # (r, 2I)
-        b_slice = lora_stats.lora_B[:, start:end]          # (H, r)
-        inter_dim = two_inter // 2
-
-        # up_proj corresponds to second half of A
-        up_a   = a_slice[:, inter_dim:]                    # (r, I)
-
-        device = _active_merge_device()
-        up_delta   = b_slice.to(device, dtype = torch.float32, non_blocking = True) @ up_a.to(device, dtype = torch.float32, non_blocking = True)
-
-        up_merged = up_W.to(device, dtype = torch.float32, non_blocking = True)
-        up_merged = up_merged.add(up_delta.transpose(0, 1), alpha = lora_stats.alpha)
-
-        return up_merged.to(output_dtype)
-    except Exception:
-        return up_W
+    return _merge_moe_gate_or_up_expert(
+        up_W, lora_stats, expert_idx, num_experts, output_dtype, role = "up",
+    )
 pass
 
+
 def _merge_moe_down_proj_expert(down_W, lora_stats, expert_idx, num_experts, output_dtype):
-    """
-    Merge LoRA for a single expert of down_proj.
-    LoRA weights are stacked per expert:
-      lora_A: (E*R, H)    (swapped)
-      lora_B: (I, E*R)    (swapped)
-    delta = (lora_B @ lora_A)^T
-    """
+    if lora_stats is None or lora_stats.lora_A is None or lora_stats.lora_B is None:
+        return down_W
+    _MOE_MERGE_STATE["attempted"] += 1
     try:
-        if lora_stats.lora_A is None or lora_stats.lora_B is None:
-            return down_W
-
-        total_rank, out_dim = lora_stats.lora_A.shape
-        in_dim, total_rank_B = lora_stats.lora_B.shape
-        if total_rank_B != total_rank:
-            return down_W
-
+        # Prefer the authoritative num_experts off the wrapped module; see
+        # _merge_moe_gate_or_up_expert for why the caller's value is unreliable
+        # when experts are split across shards.
+        num_experts = _resolve_num_experts_from_lora_stats(lora_stats, num_experts)
         if num_experts is None or num_experts <= 0:
-            num_experts = total_rank // max(1, getattr(lora_stats, "rank", 0) or 1)
-        if num_experts <= 0 or total_rank % num_experts != 0:
+            num_experts = lora_stats.lora_A.shape[0] // max(1, getattr(lora_stats, "rank", 0) or 1)
+
+        H, I = down_W.shape   # per-expert disk down_proj: (hidden, intermediate)
+        layout, r = _detect_moe_lora_layout(
+            lora_stats.lora_A, lora_stats.lora_B,
+            num_experts = num_experts, out_dim = H, in_dim = I,
+        )
+        if layout == "unknown" or r <= 0:
+            _record_moe_merge_fallback(
+                "down", expert_idx,
+                f"layout not detected (A={tuple(lora_stats.lora_A.shape)}, B={tuple(lora_stats.lora_B.shape)})",
+                lora_stats, (H, I),
+            )
             return down_W
 
-        rank = total_rank // num_experts
-        start, end = expert_idx * rank, (expert_idx + 1) * rank
-        if end > total_rank:
+        start, end = expert_idx * r, (expert_idx + 1) * r
+        if end > num_experts * r:
+            _record_moe_merge_fallback("down", expert_idx, "expert_idx out of range", lora_stats, (H, I))
             return down_W
 
-        a_slice = lora_stats.lora_A[start:end, :]     # (r, H_out)
-        b_slice = lora_stats.lora_B[:, start:end]     # (I_in, r)
+        a_slice = lora_stats.lora_A[start:end, :]
+        b_slice = lora_stats.lora_B[:, start:end]
+        device  = _active_merge_device()
+        a_f     = a_slice.to(device, dtype = torch.float32, non_blocking = True)
+        b_f     = b_slice.to(device, dtype = torch.float32, non_blocking = True)
 
-        device = _active_merge_device()
-        delta = b_slice.to(device, dtype = torch.float32, non_blocking = True) @ a_slice.to(device, dtype = torch.float32, non_blocking = True)
-        merged = down_W.to(device, dtype = torch.float32, non_blocking = True)
-        merged = merged.add(delta.transpose(0, 1), alpha = lora_stats.alpha)
+        if layout == "swapped":
+            # lora_A: (r, H), lora_B: (I, r); delta := (I, H), need transpose to (H, I)
+            delta = b_f @ a_f
+            merged = down_W.to(device, dtype = torch.float32, non_blocking = True).add(
+                delta.transpose(0, 1), alpha = lora_stats.alpha,
+            )
+        else:
+            # 'standard': lora_A: (r, I), lora_B: (H, r); delta is (H, I) directly
+            delta = b_f @ a_f
+            merged = down_W.to(device, dtype = torch.float32, non_blocking = True).add(
+                delta, alpha = lora_stats.alpha,
+            )
+
+        _MOE_MERGE_STATE["applied"] += 1
         return merged.to(output_dtype)
-    except Exception:
+    except Exception as exc:
+        _record_moe_merge_fallback("down", expert_idx, repr(exc), lora_stats, tuple(down_W.shape))
         return down_W
 pass
 
@@ -2097,6 +2217,18 @@ def merge_and_overwrite_lora(
         config.save_pretrained(save_directory)
         _remove_quantization_config(config_path = Path(save_directory) / "config.json")
         _remove_transformers_version(config_path = Path(save_directory) / "config.json")
+        # Also persist generation_config.json so the merged dir reloads with
+        # the same eos/pad/sampling defaults as the in-memory model
+        # (issue #5410: missing generation_config.json caused chat-tuned models
+        # to run past EOS and look like garbage on reload).
+        try:
+            gen_cfg = getattr(model, "generation_config", None)
+            if gen_cfg is None:
+                gen_cfg = getattr(getattr(model, "config", None), "generation_config", None)
+            if gen_cfg is not None:
+                gen_cfg.save_pretrained(save_directory)
+        except Exception as gen_cfg_err:
+            print(f"Unsloth: failed to save generation_config.json: {gen_cfg_err}")
     elif save_method == "mxfp4":
         from transformers import AutoConfig
         model_config = AutoConfig.from_pretrained(
@@ -2195,6 +2327,11 @@ def merge_and_overwrite_lora(
         )
 
     final_safetensors_list = []
+
+    # Reset the MoE merge fallback counter so anything left over from an earlier
+    # merge in the same process (e.g. an interactive notebook) cannot mask
+    # silent layout-mismatch failures here (issue #5410).
+    _reset_moe_merge_state()
 
     # Step 5: Iterate through original shards, merge LoRA, and overwrite/save
     for filename in ProgressBar(safetensors_list, desc = "Unsloth: Preparing safetensor model files"):
@@ -2332,6 +2469,31 @@ def merge_and_overwrite_lora(
             f"does not match # of saved modules = {n_saved_modules}. Please file a bug report!"
         )
     pass
+
+    # MoE merge sanity check (issue #5410): if any per-expert merge fell back to
+    # writing the base weight (silent layout mismatch, math exception, etc.) the
+    # saved checkpoint will silently lose the expert LoRA delta. Refuse to claim
+    # success in that case.
+    if _MOE_MERGE_STATE["fallback"] > 0:
+        err = _MOE_MERGE_STATE.get("first_error") or {}
+        raise RuntimeError(
+            "Unsloth: MoE LoRA merge fell back to the base weight on "
+            f"{_MOE_MERGE_STATE['fallback']} per-expert tensor(s) "
+            f"(of {_MOE_MERGE_STATE['attempted']} attempted, {_MOE_MERGE_STATE['applied']} applied). "
+            "The merged checkpoint would be missing the expert LoRA delta. "
+            f"First failure: role={err.get('role')} expert={err.get('expert_idx')} "
+            f"reason={err.get('reason')} lora_A={err.get('lora_A_shape')} "
+            f"lora_B={err.get('lora_B_shape')} per_expert_W={err.get('per_expert_W')}. "
+            "This usually means an unrecognised PEFT/Transformers MoE LoRA layout. "
+            "Please file a bug at https://github.com/unslothai/unsloth-zoo/issues "
+            "with these shapes."
+        )
+    if _MOE_MERGE_STATE["attempted"] > 0:
+        print(
+            f"Unsloth: MoE LoRA merge applied to "
+            f"{_MOE_MERGE_STATE['applied']}/{_MOE_MERGE_STATE['attempted']} "
+            "per-expert tensors."
+        )
 
     # --- Cleanup
     if temp_file is not None:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -993,10 +993,25 @@ def _record_moe_merge_fallback(role, expert_idx, reason, lora_stats, W_shape):
 def _resolve_num_experts_from_lora_stats(lora_stats, fallback):
     """Walk the wrapped module chain for the authoritative `num_experts`.
     The shard-local key scan can be a non-divisor of total_rank when experts
-    are split across multiple safetensor shards.
+    are split across multiple safetensor shards. The walk is bounded by a
+    max depth and a visited-id set so a cyclic or self-referential
+    `base_layer` cannot hang the merge.
     """
-    module = getattr(lora_stats, "module", None)
-    while module is not None:
+    try:
+        module = getattr(lora_stats, "module", None)
+    except Exception:
+        return fallback
+    seen = set()
+    for _ in range(16):
+        if module is None:
+            break
+        try:
+            mid = id(module)
+        except Exception:
+            break
+        if mid in seen:
+            break
+        seen.add(mid)
         for attr in (
             "num_experts",
             "num_experts_per_group",
@@ -1004,11 +1019,17 @@ def _resolve_num_experts_from_lora_stats(lora_stats, fallback):
             "num_local_experts",
             "num_moe_experts",
         ):
-            value = getattr(module, attr, None)
+            try:
+                value = getattr(module, attr, None)
+            except Exception:
+                value = None
             if isinstance(value, int) and value > 1:
                 return value
         # ParamWrapper.base_layer is the underlying MoE module
-        module = getattr(module, "base_layer", None)
+        try:
+            module = getattr(module, "base_layer", None)
+        except Exception:
+            break
     return fallback
 
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -609,12 +609,7 @@ def _merge_and_overwrite_lora(
                 safetensor_keys,
                 model_class_name = model_class_name,
             )
-            # Override shard-local expert counts with the authoritative model-
-            # config value walked off any sibling LoRA whose `.module` made it
-            # through `create_lora_statistics` (issue #5410). When experts are
-            # split across multiple safetensor shards, the shard-local max may
-            # be a non-divisor of `total_rank` (e.g. 17 of 128), which makes
-            # `_detect_moe_lora_layout` return "unknown" and forces a fallback.
+            # #5410: use the wrapped module's num_experts, not the shard-local one.
             for _lk, _ls in converted_lora_weights.items():
                 if not isinstance(_lk, str): continue
                 _pm = re.match(r"^(.*mlp\.experts)(?:\.base_layer)?$", _lk)
@@ -932,25 +927,10 @@ def _merge_and_overwrite_lora(
     return count, safetensor_keys_seen
 pass
 
-# Per-expert MoE LoRA merge helpers (issue #5410). PEFT's ParamWrapper has two
-# possible LoRA tensor layouts. PEFT 0.18 keeps the raw 3D dims ("swapped");
-# PEFT 0.19+ swaps in/out for non-transposed 3D parameters ("standard"), see
-# https://github.com/huggingface/peft/pull/2521. Layouts (E=num_experts, r=rank
-# per expert, I=moe_intermediate, H=hidden):
-#
-#   gate_up_proj per-expert disk shape (I, H):
-#     swapped : lora_A (E*r, 2I), lora_B (H, E*r)  -> delta gate = (B @ A[:, :I]).T
-#     standard: lora_A (E*r, H),  lora_B (2I, E*r) -> delta gate =  B[:I, :] @ A
-#
-#   down_proj per-expert disk shape (H, I):
-#     swapped : lora_A (E*r, H),  lora_B (I,  E*r) -> delta = (B @ A).T
-#     standard: lora_A (E*r, I),  lora_B (H,  E*r) -> delta =  B @ A
-#
-# Layout is detected by shape against the per-expert disk weight, so works on
-# transformers 4.57.x / 5.x and peft 0.18.x / 0.19.x without version sniffing.
-# Any unrecognised layout or runtime error increments a counter that
-# merge_and_overwrite_lora raises on at the end so a partial merge cannot
-# be silently saved as successful.
+# Per-expert MoE LoRA merge helpers (#5410). PEFT 0.18 = "swapped", PEFT 0.19+
+# = "standard" (huggingface/peft#3165). Layout detected by shape vs the
+# per-expert disk weight; unrecognised shapes increment fallback and the
+# outer raises so partial merges cannot save.
 
 _MOE_MERGE_STATE = {
     "attempted":   0,
@@ -991,12 +971,7 @@ def _record_moe_merge_fallback(role, expert_idx, reason, lora_stats, W_shape):
 
 
 def _resolve_num_experts_from_lora_stats(lora_stats, fallback):
-    """Walk the wrapped module chain for the authoritative `num_experts`.
-    The shard-local key scan can be a non-divisor of total_rank when experts
-    are split across multiple safetensor shards. The walk is bounded by a
-    max depth and a visited-id set so a cyclic or self-referential
-    `base_layer` cannot hang the merge.
-    """
+    """Walk module.base_layer for num_experts; bounded so cycles cannot hang."""
     try:
         module = getattr(lora_stats, "module", None)
     except Exception:
@@ -1025,7 +1000,6 @@ def _resolve_num_experts_from_lora_stats(lora_stats, fallback):
                 value = None
             if isinstance(value, int) and value > 1:
                 return value
-        # ParamWrapper.base_layer is the underlying MoE module
         try:
             module = getattr(module, "base_layer", None)
         except Exception:
@@ -1034,10 +1008,7 @@ def _resolve_num_experts_from_lora_stats(lora_stats, fallback):
 
 
 def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim):
-    """Classify the (lora_A, lora_B) pair as PEFT "swapped" / "standard" / "unknown"
-    by shape, given the per-expert 3D param OUTPUT / INPUT feature counts.
-    Returns (layout, rank_per_expert).
-    """
+    """Shape-classify as 'swapped' / 'standard' / 'unknown'; returns (layout, r)."""
     total_rank_A, dim_A = lora_A.shape
     dim_B, total_rank_B = lora_B.shape
     if total_rank_A != total_rank_B or num_experts is None or num_experts <= 0:
@@ -1053,23 +1024,16 @@ def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim):
 
 
 def _merge_moe_gate_or_up_expert(W, lora_stats, expert_idx, num_experts, output_dtype, *, role):
-    """Shared body for gate_proj / up_proj per-expert merges.
-
-    role: "gate" picks the first I rows / first I columns of the fused delta;
-          "up"  picks the last I rows / last I columns.
-    """
+    """Per-expert merge for gate_proj / up_proj. role='gate' -> first I, 'up' -> last I."""
     if lora_stats is None or lora_stats.lora_A is None or lora_stats.lora_B is None:
         return W
     _MOE_MERGE_STATE["attempted"] += 1
     try:
-        # Prefer the authoritative num_experts off the wrapped module; the caller's
-        # value can be a shard-local count that doesn't divide total_rank when the
-        # experts are split across multiple safetensor shards.
         num_experts = _resolve_num_experts_from_lora_stats(lora_stats, num_experts)
         if num_experts is None or num_experts <= 0:
             num_experts = lora_stats.lora_A.shape[0] // max(1, getattr(lora_stats, "rank", 0) or 1)
 
-        I, H = W.shape   # per-expert disk weight: (intermediate, hidden)
+        I, H = W.shape
         layout, r = _detect_moe_lora_layout(
             lora_stats.lora_A, lora_stats.lora_B,
             num_experts = num_experts, out_dim = 2 * I, in_dim = H,
@@ -1094,16 +1058,14 @@ def _merge_moe_gate_or_up_expert(W, lora_stats, expert_idx, num_experts, output_
         b_f     = b_slice.to(device, dtype = torch.float32, non_blocking = True)
 
         if layout == "swapped":
-            # lora_A: (r, 2I), lora_B: (H, r); pick the gate/up half along A's columns
-            half = a_f[:, :I] if role == "gate" else a_f[:, I:]   # (r, I)
-            delta = b_f @ half                                    # (H, I)
+            half = a_f[:, :I] if role == "gate" else a_f[:, I:]
+            delta = b_f @ half
             merged = W.to(device, dtype = torch.float32, non_blocking = True).add(
                 delta.transpose(0, 1), alpha = lora_stats.alpha,
             )
         else:
-            # 'standard': lora_A: (r, H), lora_B: (2I, r); pick the half along B's rows
-            half = b_f[:I, :] if role == "gate" else b_f[I:, :]   # (I, r)
-            delta = half @ a_f                                    # (I, H)
+            half = b_f[:I, :] if role == "gate" else b_f[I:, :]
+            delta = half @ a_f
             merged = W.to(device, dtype = torch.float32, non_blocking = True).add(
                 delta, alpha = lora_stats.alpha,
             )
@@ -1133,14 +1095,11 @@ def _merge_moe_down_proj_expert(down_W, lora_stats, expert_idx, num_experts, out
         return down_W
     _MOE_MERGE_STATE["attempted"] += 1
     try:
-        # Prefer the authoritative num_experts off the wrapped module; see
-        # _merge_moe_gate_or_up_expert for why the caller's value is unreliable
-        # when experts are split across shards.
         num_experts = _resolve_num_experts_from_lora_stats(lora_stats, num_experts)
         if num_experts is None or num_experts <= 0:
             num_experts = lora_stats.lora_A.shape[0] // max(1, getattr(lora_stats, "rank", 0) or 1)
 
-        H, I = down_W.shape   # per-expert disk down_proj: (hidden, intermediate)
+        H, I = down_W.shape
         layout, r = _detect_moe_lora_layout(
             lora_stats.lora_A, lora_stats.lora_B,
             num_experts = num_experts, out_dim = H, in_dim = I,
@@ -1164,15 +1123,12 @@ def _merge_moe_down_proj_expert(down_W, lora_stats, expert_idx, num_experts, out
         a_f     = a_slice.to(device, dtype = torch.float32, non_blocking = True)
         b_f     = b_slice.to(device, dtype = torch.float32, non_blocking = True)
 
+        delta = b_f @ a_f
         if layout == "swapped":
-            # lora_A: (r, H), lora_B: (I, r); delta := (I, H), need transpose to (H, I)
-            delta = b_f @ a_f
             merged = down_W.to(device, dtype = torch.float32, non_blocking = True).add(
                 delta.transpose(0, 1), alpha = lora_stats.alpha,
             )
         else:
-            # 'standard': lora_A: (r, I), lora_B: (H, r); delta is (H, I) directly
-            delta = b_f @ a_f
             merged = down_W.to(device, dtype = torch.float32, non_blocking = True).add(
                 delta, alpha = lora_stats.alpha,
             )
@@ -2238,10 +2194,7 @@ def merge_and_overwrite_lora(
         config.save_pretrained(save_directory)
         _remove_quantization_config(config_path = Path(save_directory) / "config.json")
         _remove_transformers_version(config_path = Path(save_directory) / "config.json")
-        # Also persist generation_config.json so the merged dir reloads with
-        # the same eos/pad/sampling defaults as the in-memory model
-        # (issue #5410: missing generation_config.json caused chat-tuned models
-        # to run past EOS and look like garbage on reload).
+        # #5410: keep trained eos / sampling defaults on reload.
         try:
             gen_cfg = getattr(model, "generation_config", None)
             if gen_cfg is None:
@@ -2349,10 +2302,7 @@ def merge_and_overwrite_lora(
 
     final_safetensors_list = []
 
-    # Reset the MoE merge fallback counter so anything left over from an earlier
-    # merge in the same process (e.g. an interactive notebook) cannot mask
-    # silent layout-mismatch failures here (issue #5410).
-    _reset_moe_merge_state()
+    _reset_moe_merge_state()  # #5410
 
     # Step 5: Iterate through original shards, merge LoRA, and overwrite/save
     for filename in ProgressBar(safetensors_list, desc = "Unsloth: Preparing safetensor model files"):
@@ -2491,11 +2441,7 @@ def merge_and_overwrite_lora(
         )
     pass
 
-    # MoE merge sanity check (issue #5410): if any per-expert merge fell back to
-    # writing the base weight (silent layout mismatch, math exception, etc.) the
-    # saved checkpoint will silently lose the expert LoRA delta. Refuse to claim
-    # success in that case.
-    if _MOE_MERGE_STATE["fallback"] > 0:
+    if _MOE_MERGE_STATE["fallback"] > 0:  # #5410: never claim success on a partial merge
         err = _MOE_MERGE_STATE.get("first_error") or {}
         raise RuntimeError(
             "Unsloth: MoE LoRA merge fell back to the base weight on "


### PR DESCRIPTION
## Summary

`save_pretrained_merged(..., save_method=\"merged_16bit\")` silently drops the entire MoE expert LoRA delta on Qwen3-MoE / Qwen3.5-MoE-style models when running on `peft >= 0.19.1` + `transformers >= 5.0` (reported in unslothai/unsloth#5410). Four issues stack up:

1. The per-expert helpers in `unsloth_zoo/saving_utils.py` hardcode the **PEFT 0.18 \"swapped\" layout** (`lora_A: (E*r, 2I)`, `lora_B: (H, E*r)` for fused gate_up_proj; `lora_A: (E*r, H)`, `lora_B: (I, E*r)` for fused down_proj). **PEFT 0.19+** swaps in/out features for non-transposed 3D parameters (huggingface/peft#2521) and produces the opposite shapes.
2. On layout mismatch an `addmm` shape error was swallowed by a bare `try / except Exception: return W` (and the dim-heuristic in the fused helpers fell through to `return W`), so the merge wrote the **unmodified base weight** and reported success.
3. On the dense `_merge_and_overwrite_lora` flow the per-expert merge loop's `num_experts` came from the **shard-local key scan**, which can be a non-divisor of `total_rank` whenever experts are split across multiple safetensor shards (16 / 17 in some shards of the 128-expert Qwen3-30B-A3B layout).
4. The merged dir was missing `generation_config.json`, so chat-tuned models reloaded with default eos / sampling and ran past EOS.

## Fix

- `_detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim)` classifies the layout by shape against the per-expert on-disk weight. No version sniffing, so it works on transformers 4.57.x / 5.x and peft 0.18.x / 0.19.x.
- `_merge_moe_gate_or_up_expert` and `_merge_moe_down_proj_expert` branch on the detected layout. The PEFT 0.18 \"swapped\" path is byte-identical to the previous behaviour.
- `_resolve_num_experts_from_lora_stats(lora_stats, fallback)` walks `module -> base_layer -> ...` to read the authoritative `num_experts` off the wrapped MoE module (`Qwen3MoeExperts` and similar). `_merge_and_overwrite_lora` calls it for every MoE LoRA in `converted_lora_weights` and overrides the shard-local value in `moe_num_experts` before the per-expert loop runs.
- `_MOE_MERGE_STATE` tracks `(attempted, applied, fallback, first_error)`. Helpers record fallbacks with role / expert / shapes / reason on any unrecognised layout or exception. After the shard loop `merge_and_overwrite_lora` raises `RuntimeError` if any fallback fired, so a partially merged checkpoint can no longer be silently written. On success it prints `applied/attempted`.
- The `merged_16bit` branch also calls `model.generation_config.save_pretrained(save_directory)` (best-effort, matching the same pattern as `fix_tokenizer_config_json`).

## Tests

`tests/test_unsloth_zoo_lora_merge.py` now covers:

- The existing 16 cases (PEFT 0.18 swapped layout, per-expert + fused + dense) still pass byte-for-byte.
- 6 new cases:
  - PEFT 0.19+ \"standard\" layout for `_merge_moe_gate_expert`, `_merge_moe_up_expert`, `_merge_moe_down_proj_expert`.
  - `_detect_moe_lora_layout` for swapped, standard, mismatched shapes, and non-divisor `num_experts`.
  - The fallback counter increments and `first_error` populates on unrecognised shapes.
  - `_resolve_num_experts_from_lora_stats` walks the `base_layer` chain (covers the inner ParamWrapper case for `mlp.experts.down_proj` where the outer ParamWrapper has `module = None`).

## End-to-end verification

Full Qwen3-30B-A3B (128 experts x 48 layers, fused 3D in memory, per-expert 2D on disk): load -> attach LoRA (`r=32, alpha=64, target_modules=[q,k,v,o,gate,up,down]_proj, lora_dropout=0`) -> 5 SFT steps -> `save_pretrained_merged(merged_16bit)` -> reload -> compare merged-reload logits to the trained in-memory model on a fixed eval batch.

| transformers | peft   | trl    | merged tensors | trained vs merged KL | samples | merged vs base KL | base vs trained KL |
|--------------|--------|--------|----------------|----------------------|---------|-------------------|--------------------|
| 5.5.0        | 0.19.1 | 0.25.1 | **18432 / 18432** | **1.6e-5**        | **3 / 3** | 17.81             | 17.85              |
| 5.5.0        | 0.18.1 | 0.25.1 | **18432 / 18432** | **1.3e-5**        | **3 / 3** | 18.91             | 19.05              |
| 4.57.6       | 0.19.1 | 0.25.1 | dense path        | **5.5e-5**        | **3 / 3** | 15.93             | 16.02              |
| 5.5.0        | 0.19.1 | 1.4.0  | **18432 / 18432** | **2.1e-4**        | **3 / 3** | 15.41             | 15.31              |

Reading: `KL = O(1e-4)` between merged-reload and trained model is bf16 noise; `samples = 3 / 3` means all 3 greedy generations on held-out prompts match exactly; `merged vs base KL` approx `base vs trained KL` confirms the full training delta is baked into the saved merged dir.

Before this patch the first row was KL = 1.86, samples = 1 / 3, **0 / 18432** expert LoRA deltas applied.

Notes:

- `transformers 4.57.6` has `Qwen3MoeSparseMoeBlock.experts = nn.ModuleList(Qwen3MoeMLP)` per expert (no fused 3D parameter), so the MoE merge helpers do not fire and every per-expert Linear takes the standard dense `_merge_lora` path. The MoE helpers are unreachable on `transformers < 5`; the patch only affects the path that produces the bug.
- The `trl 1.4` row uses `padding_free=False` in the reproducer (TRL 1.x raises when `padding_free=True` is combined with a finite `max_length` without packing). Unrelated to this patch.
- Dense Qwen3-0.6B-Base sanity check on `transformers 5.5 + peft 0.19 + trl 0.25` separately: trained vs merged KL = 1.1e-4, top-1 agreement = 0.978, samples 4 / 4. The dense `_merge_lora` path is untouched.

## Test plan

- [x] `pytest unsloth-zoo/tests/test_unsloth_zoo_lora_merge.py` -> 22 passed
- [x] Full Qwen3-30B-A3B end-to-end on all four version combinations in the table
- [x] Confirm `generation_config.json` is written into `save_directory` for `merged_16bit`
- [x] Confirm `_MOE_MERGE_STATE` raises a clear `RuntimeError` when the layout is unrecognised (synthetic test + a deliberately mangled shape fixture)

## Related

- Fixes unslothai/unsloth#5410
- Likely fixes unslothai/unsloth#4832 (same author, same \"garbage after save_pretrained_merged reload\" symptom on DevStral Small 2)
- Same class of failure recurs at unslothai/unsloth#2428 (canonical), #3454, #3428, #3547, #1519, #1832
- Complements #629 (Datta0's training-time MoE extractor fix). The training-time grouped-mm path and the save-time per-expert path are separate codepaths; #629 fixed training, this fixes save.