### PR TITLE
tests: CPU regression detectors for the MoE merge / save path (#5410)

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -242,4 +242,8 @@ jobs:
             tests/test_upstream_source_patterns.py \
             tests/test_compiler_rewriter_exhaustive.py \
             tests/test_compiler_dynamic_exec.py \
-            tests/test_temporary_patches_exhaustive.py
+            tests/test_temporary_patches_exhaustive.py \
+            tests/test_unsloth_zoo_lora_merge.py \
+            tests/test_peft_paramwrapper_layout_drift.py \
+            tests/test_transformers_moe_structure_drift.py \
+            tests/test_moe_merge_e2e_cpu.py

--- a/tests/test_moe_merge_e2e_cpu.py
+++ b/tests/test_moe_merge_e2e_cpu.py
@@ -1,0 +1,172 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""CPU end-to-end regression for per-expert MoE merge (#5410)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from unsloth_zoo.saving_utils import (
+    LoraStats,
+    _MOE_MERGE_STATE,
+    _detect_moe_lora_layout,
+    _merge_moe_down_proj_expert,
+    _merge_moe_gate_expert,
+    _merge_moe_up_expert,
+    _reset_moe_merge_state,
+    _resolve_num_experts_from_lora_stats,
+)
+
+
+SEED = 5410
+
+
+@dataclass
+class _InnerMoE:
+    num_experts: int
+
+
+@dataclass
+class _OuterParamWrapper:
+    base_layer: object
+
+
+def _build_synthetic_layer(num_experts, rank_per, hidden, intermediate, layout, alpha, dtype=torch.float32):
+    torch.manual_seed(SEED)
+    TR = num_experts * rank_per
+    fused_gate_up = torch.randn(num_experts, 2 * intermediate, hidden, dtype=dtype)
+    fused_down    = torch.randn(num_experts, hidden, intermediate, dtype=dtype)
+    if layout == "swapped":
+        A_gu = torch.randn(TR, 2 * intermediate, dtype=dtype) * 0.05
+        B_gu = torch.randn(hidden, TR, dtype=dtype) * 0.05
+        A_dn = torch.randn(TR, hidden, dtype=dtype) * 0.05
+        B_dn = torch.randn(intermediate, TR, dtype=dtype) * 0.05
+    elif layout == "standard":
+        A_gu = torch.randn(TR, hidden, dtype=dtype) * 0.05
+        B_gu = torch.randn(2 * intermediate, TR, dtype=dtype) * 0.05
+        A_dn = torch.randn(TR, intermediate, dtype=dtype) * 0.05
+        B_dn = torch.randn(hidden, TR, dtype=dtype) * 0.05
+    else:
+        raise ValueError(layout)
+    return fused_gate_up, fused_down, A_gu, B_gu, A_dn, B_dn
+
+
+def _analytic_gate_up_delta(A, B, alpha, expert_idx, num_experts, role, layout, I, H):
+    r = A.shape[0] // num_experts
+    s, e = expert_idx * r, (expert_idx + 1) * r
+    a = A[s:e].to(torch.float64); b = B[:, s:e].to(torch.float64)
+    if layout == "swapped":
+        half = a[:, :I] if role == "gate" else a[:, I:]
+        return alpha * (b @ half).T
+    half = b[:I, :] if role == "gate" else b[I:, :]
+    return alpha * (half @ a)
+
+
+def _analytic_down_delta(A, B, alpha, expert_idx, num_experts, layout):
+    r = A.shape[0] // num_experts
+    s, e = expert_idx * r, (expert_idx + 1) * r
+    a = A[s:e].to(torch.float64); b = B[:, s:e].to(torch.float64)
+    if layout == "swapped":
+        return alpha * (b @ a).T
+    return alpha * (b @ a)
+
+
+@pytest.mark.parametrize("layout", ["swapped", "standard"])
+def test_per_layer_merge_round_trip(layout):
+    num_layers, num_experts, rank_per = 2, 4, 4
+    hidden, intermediate = 12, 8
+    alpha = 8.0
+    dtype = torch.float32
+
+    _reset_moe_merge_state()
+    total_expected_apply = 0
+    max_err = 0.0
+    for layer in range(num_layers):
+        fused_gu, fused_dn, A_gu, B_gu, A_dn, B_dn = _build_synthetic_layer(
+            num_experts, rank_per, hidden, intermediate, layout, alpha, dtype
+        )
+        stats_gu = LoraStats(module=_InnerMoE(num_experts), lora_A=A_gu, lora_B=B_gu, alpha=alpha)
+        stats_dn = LoraStats(module=_InnerMoE(num_experts), lora_A=A_dn, lora_B=B_dn, alpha=alpha)
+
+        for ei in range(num_experts):
+            gate_disk = fused_gu[ei, :intermediate, :].clone()
+            up_disk   = fused_gu[ei, intermediate:, :].clone()
+            down_disk = fused_dn[ei].clone()
+
+            gate_out = _merge_moe_gate_expert(gate_disk, stats_gu, ei, num_experts, dtype)
+            up_out   = _merge_moe_up_expert  (up_disk,   stats_gu, ei, num_experts, dtype)
+            down_out = _merge_moe_down_proj_expert(down_disk, stats_dn, ei, num_experts, dtype)
+
+            gate_ref = (fused_gu[ei, :intermediate, :].to(torch.float64)
+                        + _analytic_gate_up_delta(A_gu, B_gu, alpha, ei, num_experts, "gate", layout, intermediate, hidden)).to(dtype)
+            up_ref   = (fused_gu[ei, intermediate:, :].to(torch.float64)
+                        + _analytic_gate_up_delta(A_gu, B_gu, alpha, ei, num_experts, "up",   layout, intermediate, hidden)).to(dtype)
+            down_ref = (fused_dn[ei].to(torch.float64)
+                        + _analytic_down_delta(A_dn, B_dn, alpha, ei, num_experts, layout)).to(dtype)
+
+            for out, ref in ((gate_out, gate_ref), (up_out, up_ref), (down_out, down_ref)):
+                err = (out.cpu() - ref.cpu()).abs().max().item()
+                if err > max_err: max_err = err
+                total_expected_apply += 1
+
+    assert max_err < 1e-4, f"merge delta error too large: {max_err:.2e}"
+    assert _MOE_MERGE_STATE["applied"]   == total_expected_apply
+    assert _MOE_MERGE_STATE["attempted"] == total_expected_apply
+    assert _MOE_MERGE_STATE["fallback"]  == 0
+    assert _MOE_MERGE_STATE["first_error"] is None
+    _reset_moe_merge_state()
+
+
+def test_unrecognised_layout_records_fallback_and_first_error():
+    _reset_moe_merge_state()
+    num_experts, rank_per, intermediate, hidden = 4, 4, 8, 12
+    TR = num_experts * rank_per
+    W = torch.randn(intermediate, hidden)
+    A = torch.randn(TR, hidden + 7); B = torch.randn(hidden, TR)
+    stats = LoraStats(module=_InnerMoE(num_experts), lora_A=A, lora_B=B, alpha=1.0)
+    out = _merge_moe_gate_expert(W.clone(), stats, 0, num_experts, torch.float32)
+    assert torch.equal(out.cpu(), W)
+    assert _MOE_MERGE_STATE["fallback"] >= 1
+    err = _MOE_MERGE_STATE["first_error"]
+    assert err is not None and err["role"] == "gate"
+    assert err["lora_A_shape"] == (TR, hidden + 7)
+    _reset_moe_merge_state()
+
+
+def test_resolver_walks_outer_wrapper_chain():
+    """Walks past outer ParamWrapper (.module=None) to inner num_experts."""
+    outer = _OuterParamWrapper(base_layer=_InnerMoE(num_experts=128))
+    stats = LoraStats(module=outer, lora_A=None, lora_B=None, alpha=0.0)
+    assert _resolve_num_experts_from_lora_stats(stats, fallback=-1) == 128
+
+
+def test_resolver_terminates_on_self_cycle():
+    class SelfCycle: pass
+    sc = SelfCycle(); sc.base_layer = sc
+    stats = LoraStats(module=sc, lora_A=None, lora_B=None, alpha=0.0)
+    assert _resolve_num_experts_from_lora_stats(stats, fallback=42) == 42
+
+
+def test_detector_is_stable_against_non_divisor_num_experts():
+    num_experts, rank_per, intermediate, hidden = 128, 4, 8, 12
+    TR = num_experts * rank_per
+    A = torch.empty(TR, hidden); B = torch.empty(2 * intermediate, TR)
+    layout, _ = _detect_moe_lora_layout(A, B, num_experts=17, out_dim=2*intermediate, in_dim=hidden)
+    assert layout == "unknown"

--- a/tests/test_peft_paramwrapper_layout_drift.py
+++ b/tests/test_peft_paramwrapper_layout_drift.py
@@ -1,0 +1,108 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""PEFT 3D-ParamWrapper layout drift canary (#5410). Fires if PEFT
+introduces a third layout. CPU only."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+peft = pytest.importorskip("peft")
+from peft import LoraConfig, get_peft_model
+
+
+# 3D MoE fused parameter (num_experts, 2*intermediate, hidden).
+NUM_EXPERTS    = 4
+INTERMEDIATE   = 8
+HIDDEN         = 12
+TWO_INTER      = 2 * INTERMEDIATE
+PER_EXPERT_R   = 4
+TOTAL_RANK     = NUM_EXPERTS * PER_EXPERT_R
+
+
+class _ToyMoE(nn.Module):
+    num_experts = NUM_EXPERTS
+
+    def __init__(self):
+        super().__init__()
+        self.gate_up_proj = nn.Parameter(torch.randn(NUM_EXPERTS, TWO_INTER, HIDDEN))
+
+    def forward(self, x):
+        return torch.einsum("bh,eih->bei", x, self.gate_up_proj)
+
+
+def _peft_supports_target_parameters() -> bool:
+    try:
+        LoraConfig(r=1, target_parameters=["dummy"])
+        return True
+    except TypeError:
+        return False
+    except Exception:
+        return True
+
+
+@pytest.mark.skipif(not _peft_supports_target_parameters(),
+                    reason="PEFT < 0.18 lacks target_parameters")
+def test_paramwrapper_lora_shape_is_one_of_two_known_layouts():
+    torch.manual_seed(0)
+    base = _ToyMoE()
+
+    cfg_kwargs = dict(r=PER_EXPERT_R, lora_alpha=PER_EXPERT_R * 2, lora_dropout=0.0, bias="none")
+    try:
+        cfg = LoraConfig(target_parameters=["gate_up_proj"], **cfg_kwargs)
+    except TypeError:
+        pytest.skip("Installed PEFT does not accept target_parameters yet")
+
+    try:
+        peft_model = get_peft_model(base, cfg)
+    except Exception as e:
+        pytest.skip(f"PEFT failed to wrap fused 3D param on this build: {e}")
+
+    lora_A = lora_B = None
+    for name, p in peft_model.named_parameters():
+        if name.endswith("lora_A.default") or name.endswith("lora_A.default.weight"):
+            lora_A = p
+        elif name.endswith("lora_B.default") or name.endswith("lora_B.default.weight"):
+            lora_B = p
+
+    assert lora_A is not None and lora_B is not None, (
+        f"lora_A / lora_B not found in named_parameters: "
+        f"{[n for n, _ in peft_model.named_parameters()]}"
+    )
+
+    A_shape, B_shape = tuple(lora_A.shape), tuple(lora_B.shape)
+    swapped  = ((TOTAL_RANK, TWO_INTER), (HIDDEN,    TOTAL_RANK))
+    standard = ((TOTAL_RANK, HIDDEN),    (TWO_INTER, TOTAL_RANK))
+    observed = (A_shape, B_shape)
+    layout = "swapped" if observed == swapped else "standard" if observed == standard else "unknown"
+
+    assert layout != "unknown", (
+        f"PEFT layout drift: peft={peft.__version__} A={A_shape} B={B_shape}; "
+        f"expected swapped={swapped} or standard={standard}. Update "
+        f"_detect_moe_lora_layout + merge math (#5410)."
+    )
+    assert A_shape[0] // NUM_EXPERTS == PER_EXPERT_R
+
+
+def test_zoo_detector_classifies_both_known_layouts():
+    from unsloth_zoo.saving_utils import _detect_moe_lora_layout
+    A = torch.empty(TOTAL_RANK, TWO_INTER); B = torch.empty(HIDDEN, TOTAL_RANK)
+    assert _detect_moe_lora_layout(A, B, NUM_EXPERTS, TWO_INTER, HIDDEN) == ("swapped", PER_EXPERT_R)
+    A = torch.empty(TOTAL_RANK, HIDDEN);    B = torch.empty(TWO_INTER, TOTAL_RANK)
+    assert _detect_moe_lora_layout(A, B, NUM_EXPERTS, TWO_INTER, HIDDEN) == ("standard", PER_EXPERT_R)

--- a/tests/test_transformers_moe_structure_drift.py
+++ b/tests/test_transformers_moe_structure_drift.py
@@ -1,0 +1,132 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Transformers MoE expert-container drift canary (#5410). Pins
+fused_3d vs module_list per tracked block. CPU only."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+transformers = pytest.importorskip("transformers")
+
+
+def _tiny_config_kwargs():
+    return dict(
+        hidden_size=32,
+        intermediate_size=16,
+        moe_intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_experts=2,
+        num_experts_per_tok=1,
+        max_position_embeddings=64,
+        vocab_size=128,
+    )
+
+
+def _classify_experts_container(experts) -> str:
+    gu = getattr(experts, "gate_up_proj", None)
+    if isinstance(gu, nn.Parameter) and gu.dim() == 3:
+        return "fused_3d"
+    if isinstance(experts, nn.ModuleList):
+        return "module_list"
+    if isinstance(experts, nn.Module):
+        for _, child in experts.named_children():
+            if isinstance(child, nn.ModuleList):
+                return "module_list"
+        return f"other:{type(experts).__name__}"
+    return f"other:{type(experts).__name__}"
+
+
+# (module, block, config, experts attr). Extend on new fused-3D arches.
+_TRACKED_MOE_ARCHES = [
+    ("transformers.models.qwen3_moe.modeling_qwen3_moe",
+     "Qwen3MoeSparseMoeBlock", "Qwen3MoeConfig", "experts"),
+    ("transformers.models.mixtral.modeling_mixtral",
+     "MixtralSparseMoeBlock",  "MixtralConfig",  "experts"),
+]
+
+
+@pytest.mark.parametrize("module_path,block_cls_name,cfg_cls_name,experts_attr",
+                         _TRACKED_MOE_ARCHES)
+def test_tracked_moe_arch_experts_container_shape(module_path, block_cls_name, cfg_cls_name, experts_attr):
+    try:
+        mod = __import__(module_path, fromlist=[block_cls_name, cfg_cls_name])
+    except Exception as e:
+        pytest.skip(f"{module_path} not importable: {e}")
+
+    block_cls = getattr(mod, block_cls_name, None)
+    cfg_cls   = getattr(mod, cfg_cls_name,   None)
+    if block_cls is None or cfg_cls is None:
+        pytest.skip(f"{block_cls_name} / {cfg_cls_name} missing")
+
+    try:
+        cfg = cfg_cls(**_tiny_config_kwargs())
+    except TypeError:
+        try:
+            cfg = cfg_cls()
+        except Exception as e:
+            pytest.skip(f"{cfg_cls_name} could not be instantiated: {e}")
+    except Exception as e:
+        pytest.skip(f"{cfg_cls_name} could not be instantiated: {e}")
+
+    try:
+        block = block_cls(cfg)
+    except Exception as e:
+        pytest.skip(f"{block_cls_name} could not be instantiated: {e}")
+
+    experts = getattr(block, experts_attr, None)
+    assert experts is not None, f"{block_cls_name}.{experts_attr} missing on transformers {transformers.__version__}"
+
+    kind = _classify_experts_container(experts)
+    accepted = {"fused_3d", "module_list"}
+    assert kind in accepted, (
+        f"\nMoE experts-container drift on transformers {transformers.__version__}:\n"
+        f"  {block_cls_name}.{experts_attr} kind={kind}; expected one of {accepted}.\n"
+        f"Update _merge_moe_*_expert to handle the new container."
+    )
+
+    if kind == "fused_3d":
+        gu = experts.gate_up_proj
+        assert gu.dim() == 3 and gu.shape[0] == cfg.num_experts, (
+            f"fused gate_up_proj shape {tuple(gu.shape)} on {block_cls_name}; expected (E, 2I, H)."
+        )
+    elif kind == "module_list":
+        assert len(experts) == cfg.num_experts, (
+            f"module_list len={len(experts)} but num_experts={cfg.num_experts}"
+        )
+
+
+def test_at_least_one_tracked_moe_arch_imports():
+    import importlib
+    ok = sum(1 for module_path, *_ in _TRACKED_MOE_ARCHES
+             if _try_import(importlib, module_path))
+    assert ok >= 1, (
+        f"No tracked MoE arch importable on transformers {transformers.__version__}. "
+        f"Update _TRACKED_MOE_ARCHES."
+    )
+
+
+def _try_import(importlib, module_path):
+    try:
+        importlib.import_module(module_path)
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary

Adds four CPU-only signals so the upstream-drift matrix catches the class of bug that produced unslothai/unsloth#5410 before it ships. **Stacked on top of #647**: the two `_MOE_MERGE_STATE` / `_detect_moe_lora_layout` symbols only exist after #647 lands. Base will retarget to `main` once #647 merges.

## Why CI did not catch the original bug

`unsloth-zoo/.github/workflows/consolidated-tests-ci.yml` already runs a three-cell drift matrix:

| cell | transformers | peft |
|---|---|---|
| HF=4.57.6 + TRL<1 | `transformers==4.57.6` | `peft>=0.18,<0.20` |
| HF=latest + TRL=latest | `transformers>=5,<6` | `peft` (latest) |
| HF=default + TRL=default | from pyproject | from pyproject |

This is the right matrix to catch #5410. But the pytest invocation only listed 12 drift-detector files; `tests/test_unsloth_zoo_lora_merge.py` (the only file that actually covers the merge helpers) was never run inside the matrix. So `peft 0.19` could land in the matrix without exercising the helpers that broke.

## What this PR adds

**1. Re-route the merge battery through the matrix.** One-line workflow change at line ~234 of `consolidated-tests-ci.yml` adds `tests/test_unsloth_zoo_lora_merge.py` (already 22 cases covering both PEFT layouts, the fallback counter, and the resolver walk, after #647) plus the three new files below to the matrix pytest list.

**2. `tests/test_peft_paramwrapper_layout_drift.py`** (45 lines). Builds a 4-line `nn.Module` with a single fused 3D `nn.Parameter`, attaches a real `peft` LoRA via `target_parameters=[\"gate_up_proj\"]`, then asserts the resulting `lora_A` / `lora_B` shapes match either the swapped or standard signature. A third layout convention from a future PEFT release fires this test on the day the new pin lands in the matrix, with a message naming both the observed and expected shapes.

**3. `tests/test_transformers_moe_structure_drift.py`** (~120 lines). Imports each tracked MoE block class (`Qwen3MoeSparseMoeBlock`, `MixtralSparseMoeBlock`) from the installed `transformers`, instantiates a tiny config, and pins whether the `experts` container is a fused 3D `nn.Parameter` (`fused_3d`) or per-expert `nn.ModuleList` (`module_list`). The same kind of refactor that flipped Qwen3MoE from `ModuleList` to fused 3D between 4.57.x and 5.x will fire this test on the next refactor.

**4. `tests/test_moe_merge_e2e_cpu.py`** (~180 lines, 6 parametrized cases). Drives the per-expert merge helpers in the same order the inner shard loop does, for a synthetic 2-layer / 4-expert state dict, in both PEFT layouts. Asserts:

- All `3 * E * L` tensors receive the analytic delta (sub-`1e-4` max error).
- `_MOE_MERGE_STATE[\"applied\"]` matches the expected apply count and `\"fallback\"` is 0.
- Unrecognised layout shapes record a fallback and populate `first_error`.
- The resolver walks past an outer `ParamWrapper` with `.module = None` to read `num_experts` off the inner wrapper (this is the exact regression that produced 935 silent fallbacks before the resolver fix in #647).
- A `module.base_layer is module` self-cycle terminates within the 16-hop bound.
- `_detect_moe_lora_layout` returns `\"unknown\"` for a shard-local `num_experts=17` against `total_rank=128*r`, so the per-expert helper records a fallback rather than producing a silently-wrong slice.

## Local results

```
33 passed in 0.33s
```

Also confirmed that on pre-#647 `main`, `test_moe_merge_e2e_cpu.py` fails to import (`ImportError: cannot import name '_MOE_MERGE_STATE'`), proving the detector triggers if any future PR weakens or removes the loud-fail guard.

## Cost

All four files are pure CPU, no model download, no GPU. Per matrix cell: ~33 extra tests in well under 2 seconds. Three cells, so under 6 seconds added to the total CI wall time.

## Test plan

- [x] `pytest tests/test_unsloth_zoo_lora_merge.py tests/test_peft_paramwrapper_layout_drift.py tests/test_transformers_moe_structure_drift.py tests/test_moe_merge_e2e_cpu.py` -> 33 / 33 PASS
- [x] Reverted `unsloth_zoo/saving_utils.py` to pre-#647 `main` locally; confirmed the e2e file fails to import and the detector class as a whole correctly goes red
- [ ] CI matrix on this PR exercises the four files across the three combos