### PR TITLE
mlx: lower max_grad_value default from 5.0 to 1.0

### DIFF
--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -119,10 +119,12 @@ class MLXTrainingConfig:
     optim: str = "adamw"  # "adafactor", "adamw", "adam", "sgd", "muon", "lion"
     weight_decay: float = 0.001
     max_grad_norm: float = 0.0  # disabled by default on MLX to avoid clip-memory overhead
-    # Elementwise clipping (PyTorch's torch.nn.utils.clip_grad_value_).
-    # Clamps every grad value to [-max_grad_value, max_grad_value] leaf-by-leaf
-    # with no cross-leaf reduction. Set 0.0 to disable.
-    max_grad_value: float | None = 5.0
+    # Elementwise clip ([-max_grad_value, max_grad_value], per-leaf, no
+    # cross-leaf reduction). Set 0.0 to disable. Default 1.0: |g_i| > 5
+    # rarely fires on real transformer grads, so the historical 5.0 was
+    # effectively a no-op; 1.0 matches the universal clip_grad_norm=1.0
+    # baseline while staying on MLX's fast tree_map(mx.clip) path.
+    max_grad_value: float | None = 1.0
     seed: int = 3407
     lora_plus_ratio: float = 0.0  # 0 = disabled, 16.0 = recommended
     embedding_learning_rate: float = 0.0  # 0 = disabled, 5e-5 = recommended
@@ -726,8 +728,8 @@ class MLXTrainer:
         # Elementwise clip (clip_grad_value_): leaf-local, free memory.
         # Prefer value clipping when both clipping modes are requested; global
         # norm clipping is exact but materially increases memory on MLX.
-        _raw_mgv = getattr(args, "max_grad_value", 5.0)  # TODO: expose MLX grad-clip in Studio UI for power users
-        max_grad_value = 5.0 if _raw_mgv is None else float(_raw_mgv or 0.0)
+        _raw_mgv = getattr(args, "max_grad_value", 1.0)  # TODO: expose MLX grad-clip in Studio UI for power users
+        max_grad_value = 1.0 if _raw_mgv is None else float(_raw_mgv or 0.0)
         if max_grad_norm > 0 and max_grad_value > 0:
             print(
                 "Unsloth: max_grad_norm and max_grad_value are both enabled; "


### PR DESCRIPTION
## Summary
- Drop ``MLXTrainingConfig.max_grad_value`` default from **5.0** to **1.0** (dataclass field + the inline ``getattr`` fallback and its sentinel branch in ``MLXTrainer.fit``).
- 5.0 was effectively a no-op on real workloads: per-element transformer gradients in steady state are 1e-3..1e-1, so |g_i| > 5 essentially never fires, leaving the trainer with no protection in the regimes where clipping actually matters (spike batches, mixed-precision overflow, RL gradient bursts).
- 1.0 keeps MLX on the fast per-leaf ``tree_map(mx.clip, ...)`` path (no global reduction, no cross-leaf sync) while actually catching outliers and aligning with the universal LLM ``clip_grad_norm=1.0`` baseline used by HF Trainer / TRL / PEFT / AutoTrain.
- Behaviour preserved when callers explicitly pass ``max_grad_value``; only the unset path changes. The \"max_grad_value wins when both set\" policy is kept for now.

## Empirical sanity-check
CUDA mirror of \`tests/studio/run_real_mlx_smoke.py\` (same model / LoRA r=8 alpha=16 on attention + MLP / 7 steps / bs=2 ga=3 / lr=1e-3 / adamw / seed=3407, clipping reproduced by torch \`clip_grad_value_\`):

| clip                              | losses[0] | losses[-1] | trajectory |
|---|---|---|---|
| max_grad_norm=1.0 (control)       | 7.64      | **0.006**  | monotone down (passes the smoke) |
| max_grad_value=5.0 (old default)  | 7.29      | **8.39**   | diverges after step 4 |
| max_grad_value=1.0 (new default)  | 7.29      | 3.4 across 3 seeds (3.21..3.65) | stable plateau, no divergence |
| max_grad_value < 1.0              | varied    | similar plateau | noisier, no improvement |

On real long-horizon training the difference is invisible; 1.0 only kicks in when needed. On the overfitting smoke 5.0 lets the optimizer overshoot the local basin.

Companion PR in \`unslothai/unsloth\` (Studio worker) tracks the same default so Studio's pinned config does not silently disagree.

## Test plan
- [ ] Existing MLX trainer tests pass with the new default.
- [ ] Long-horizon training run shows no regression in loss curve / wallclock.