### PR TITLE
additional import try except handling for mlx

### DIFF
--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -161,7 +161,18 @@ class _LazyMLXAlias(_types.ModuleType):
         # (e.g. FastMLXModel) still resolves through to the new submodule.
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
-        return getattr(self._resolve(), name)
+        try:
+            real = self._resolve()
+        except ModuleNotFoundError:
+            # mlx is Apple-only. On non-mlx hosts the real submodule import
+            # fails. Surface as AttributeError so callers that walk sys.modules
+            # (notably pickle.whichmodule, used by torch._inductor's FX graph
+            # hash pickler) skip this stub cleanly instead of crashing the
+            # whole compile. Real user attribute access on a non-mlx host
+            # still surfaces a useful error -- they will see the AttributeError
+            # rather than a torch._dynamo.exc.BackendCompilerFailed wrapper.
+            raise AttributeError(name)
+        return getattr(real, name)
 
 for _old_name in _LazyMLXAlias._LEGACY_TO_NEW:
     if _old_name in _sys.modules:


### PR DESCRIPTION
## Summary

Fix `ModuleNotFoundError: No module named 'mlx'` raised inside any `torch.compile`
/ inductor compile path on non-Apple hosts. The bug surfaces as
`torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
ModuleNotFoundError: No module named 'mlx'` and breaks training for any model
whose attention implementation triggers an inductor compile (Qwen3 FFT through
the compiled-cache shim, Gemma3 default through `flex_attention`, etc.) on
machines where `mlx` is not installed (every Linux/CUDA host).

## Root cause

`unsloth_zoo/__init__.py` registers six legacy-name shim modules in
`sys.modules` at import time, one per `unsloth_zoo.mlx_*` legacy name:

```python
for _old_name in _LazyMLXAlias._LEGACY_TO_NEW:
    sys.modules[_old_name] = _LazyMLXAlias(_old_name)

Each shim's __getattr__ lazy-imports the real unsloth_zoo.mlx.* submodule
on first attribute access, which transitively does import mlx.core as mx at
the top of unsloth_zoo/mlx/compile.py. The intent is to support Apple
Silicon scripts that still use the flat module names without paying the mlx
import cost on every host.

The shim filters dunder attribute probes
(__file__, __path__, inspect.getmodule, hasattr(m, '__name__'), etc.)
so torch's own sys.modules walks during init never trigger the lazy import.
However, pickle.whichmodule() does not restrict itself to dunder
attributes. From CPython:

def whichmodule(obj, name):
    # name is the qualname of a function/class being pickled, e.g.
    # "Qwen3Attention_fast_forward" or some inductor-generated symbol.
    for module_name, module in sys.modules.copy().items():
        if module_name == '__main__' or module is None: continue
        try:
            if _getattribute(module, name)[0] is obj:
                return module_name
        except (AttributeError, KeyError):
            pass

It iterates every entry in sys.modules and does
getattr(module, name) with a real, non-dunder attribute name. When it hits
one of our six shims, the dunder filter does not catch the call, so
_resolve() runs, the real mlx.compile module is imported, and
import mlx.core raises ModuleNotFoundError.

torch._inductor.codecache.compiled_fx_graph_hash calls pickler.dumps(obj)
on the FX graph being compiled, which in turn invokes pickle.whichmodule()
for any function or class node. Result: every inductor-bound training path
crashes during graph hash on Linux.

Fix

One try/except in _LazyMLXAlias.__getattr__. If the real submodule import
fails because mlx is not installed, surface the failure as an
AttributeError so pickle.whichmodule's
except (AttributeError, KeyError) handler catches it cleanly and pickle
moves on to the next module:

def __getattr__(self, name):
    if name.startswith("__") and name.endswith("__"):
        raise AttributeError(name)
    try:
        real = self._resolve()
    except ModuleNotFoundError:
        raise AttributeError(name)
    return getattr(real, name)

Real user attribute access on a non-mlx host (e.g. from unsloth_zoo.mlx_loader import FastMLXModel) still surfaces a useful error: an AttributeError on
the legacy shim instead of a wrapped BackendCompilerFailed.

Reproduction

Minimal repro on any Linux/CUDA host without mlx installed, transformers 5.5
or 4.57.6, torch 2.10:

import os
os.environ['CUDA_VISIBLE_DEVICES'] = '0'

from unsloth import FastLanguageModel
import torch

model, tok = FastLanguageModel.from_pretrained(
    model_name="unsloth/Qwen3-0.6B",
    max_seq_length=1024,
    load_in_16bit=True,
    full_finetuning=True,
    dtype=torch.bfloat16,
)
# ... run a single SFTTrainer step. Crashes inside compile_fx_inner ->
# FxGraphCache.prepare_key -> compiled_fx_graph_hash -> pickle.dumps
# -> pickle.whichmodule -> _LazyMLXAlias.__getattr__ -> import mlx.core
