### PR TITLE
deps: bump torch upper cap to <2.13.0 (allow xpu 2.11.0 / 2.12.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     # --- GPU-only deps (skipped on macOS arm64) ---
-    "torch>=2.4.0,<2.11.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
+    "torch>=2.4.0,<2.13.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "torchao>=0.13.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
     "triton>=3.0.0 ; ('linux' in sys_platform)",
     "tyro ; (sys_platform != 'darwin' or platform_machine != 'arm64')",

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = "2026.5.1"
+__version__ = "2026.5.2"
 
 import os
 import warnings


### PR DESCRIPTION
## Summary

Bumps the torch upper bound from `<2.11.0` to `<2.13.0` in the base dependency block so that the new `torch-2.11.0+xpu` and `torch-2.12.0+xpu` intel-gpu extras in unsloth (added in unslothai/unsloth#5484) can actually resolve.

## Why

`unsloth/pyproject.toml` now ships:

- `intel-gpu-torch2110` -> pins `torch-2.11.0+xpu`
- `intel-gpu-torch2120` -> pins `torch-2.12.0+xpu`

Without this PR, pip rejects those extras because every recent `unsloth_zoo` release declares `torch>=2.4.0,<2.11.0` in its own dependency block. The reporter on unslothai/unsloth#5494 hit this directly: their install of `.[intelgputorch2120]` fell back to a stale unsloth_zoo (2026.3.6) and they had to manually run `uv pip install --upgrade --no-deps unsloth_zoo` to bypass the cap.

## What

A single character bump on the torch upper bound, leaves everything else untouched:

```diff
-    "torch>=2.4.0,<2.11.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
+    "torch>=2.4.0,<2.13.0 ; (sys_platform != 'darwin' or platform_machine != 'arm64')",
```

`<2.13.0` keeps a defensive cap on future torch versions while admitting the two new pinned versions we ship today.

## Test plan

After cutting a release that contains this change, the matching unsloth pyproject change (forthcoming follow-up to add `unsloth_zoo>=2026.X.Y` floor on `huggingfacenotorch`) will pull this version through `pip install unsloth[intel-gpu-torch2120]` and the resolver will pick `torch==2.12.0+xpu` + `triton-xpu==3.7.1` + latest unsloth_zoo, instead of falling back to a stale unsloth_zoo as today.

Closes part of unslothai/unsloth#5494 (the other half is the unsloth-side floor, which depends on a release containing this commit).