### PR TITLE
[codex] Fix GGUF converter sibling imports

### DIFF
--- a/tests/test_llama_cpp_loader.py
+++ b/tests/test_llama_cpp_loader.py
@@ -1,0 +1,35 @@
+import sys
+import textwrap
+import importlib.util
+from pathlib import Path
+
+
+def _load_llama_cpp_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+    spec = importlib.util.spec_from_file_location("llama_cpp_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_module_from_path_resolves_sibling_imports(tmp_path):
+    llama_cpp = _load_llama_cpp_module()
+    (tmp_path / "conversion.py").write_text("VALUE = 'loaded from sibling'\n")
+    script = tmp_path / "original_gguf_test.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            from conversion import VALUE
+
+            RESULT = VALUE
+            """
+        )
+    )
+
+    sys.modules.pop("conversion", None)
+    module = llama_cpp._load_module_from_path(str(script), "original_gguf_test")
+
+    assert module.RESULT == "loaded from sibling"
+    assert str(tmp_path) in sys.path

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -903,6 +903,9 @@ def _load_module_from_path(filepath, module_name):
     if spec is None or spec.loader is None:
             raise ImportError(f"Could not load spec for module {module_name} at {filepath}")
     module = importlib.util.module_from_spec(spec)
+    script_dir = os.path.dirname(os.path.abspath(filepath))
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
     # Register module before execution to handle circular imports within the script if any
     sys.modules[module_name] = module
     try:


### PR DESCRIPTION
## Summary
- Add the cached converter script directory to sys.path before executing it.
- Cover sibling imports such as llama.cpp conversion.py with a focused regression test.

## Root cause
llama.cpp convert_hf_to_gguf.py imports sibling helper modules by bare name. Unsloth caches the script under ~/.unsloth/llama.cpp and executes it by path, but that directory was not on sys.path, so Kaggle could fail with ModuleNotFoundError: No module named conversion.

## Validation
- pytest tests/test_llama_cpp_loader.py
