### PR TITLE
__init__: include HF_DATASETS_OFFLINE in the offline env cross-sync

### DIFF
--- a/tests/test_offline_env_cross_sync.py
+++ b/tests/test_offline_env_cross_sync.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Regression tests for the offline env cross-sync at import time.
+
+``unsloth_zoo/__init__.py`` cross-syncs three env vars so that setting
+any one of them implies all three:
+
+* ``HF_HUB_OFFLINE``       used by ``huggingface_hub``
+* ``TRANSFORMERS_OFFLINE`` used by ``transformers``
+* ``HF_DATASETS_OFFLINE``  used by ``datasets``
+
+Without ``HF_DATASETS_OFFLINE`` in the sync, ``load_dataset()`` still
+issues a network call for dataset metadata when the rest of the HF
+stack has been switched offline, and fails with ``ConnectionError``
+instead of resolving from cache.
+
+These tests reload ``unsloth_zoo`` with each combination of env vars
+preset to exercise the import-time cross-sync.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def reload_zoo(monkeypatch):
+    """Strip all three offline env vars, allow the test to set what it
+    wants, then reload ``unsloth_zoo`` so its import-time block runs."""
+    for v in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"):
+        monkeypatch.delenv(v, raising = False)
+
+    def _reload():
+        # Force a fresh import so the module-level cross-sync runs.
+        sys.modules.pop("unsloth_zoo", None)
+        return importlib.import_module("unsloth_zoo")
+
+    return _reload
+
+
+class TestOfflineCrossSync:
+    def test_unset_stays_unset(self, reload_zoo):
+        reload_zoo()
+        assert os.environ.get("HF_HUB_OFFLINE", "0") != "1"
+        assert os.environ.get("TRANSFORMERS_OFFLINE", "0") != "1"
+        assert os.environ.get("HF_DATASETS_OFFLINE", "0") != "1"
+
+    def test_hf_hub_offline_implies_all_three(self, monkeypatch, reload_zoo):
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        reload_zoo()
+        assert os.environ.get("HF_HUB_OFFLINE") == "1"
+        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+        assert os.environ.get("HF_DATASETS_OFFLINE") == "1"
+
+    def test_transformers_offline_implies_all_three(self, monkeypatch, reload_zoo):
+        monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+        reload_zoo()
+        assert os.environ.get("HF_HUB_OFFLINE") == "1"
+        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+        assert os.environ.get("HF_DATASETS_OFFLINE") == "1"
+
+    def test_hf_datasets_offline_implies_all_three(self, monkeypatch, reload_zoo):
+        monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
+        reload_zoo()
+        assert os.environ.get("HF_HUB_OFFLINE") == "1"
+        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+        assert os.environ.get("HF_DATASETS_OFFLINE") == "1"
+
+    def test_only_value_1_triggers(self, monkeypatch, reload_zoo):
+        # The cross-sync only matches the literal "1" (existing convention).
+        # Other truthy spellings are left as-is; documented behaviour.
+        monkeypatch.setenv("HF_HUB_OFFLINE", "true")
+        reload_zoo()
+        assert os.environ.get("HF_HUB_OFFLINE") == "true"
+        assert os.environ.get("TRANSFORMERS_OFFLINE", "0") != "1"
+        assert os.environ.get("HF_DATASETS_OFFLINE", "0") != "1"

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -34,11 +34,16 @@ if os.environ.get("UNSLOTH_STABLE_DOWNLOADS", "0") == "1":
     os.environ["HF_HUB_DISABLE_XET"] = "1" # Disable XET
     os.environ["HF_XET_HIGH_PERFORMANCE"] = "0" # This causes "429 Too Many Requests"
 
-# Check offline mode as well
-if os.environ.get("HF_HUB_OFFLINE", "0") == "1":
-    os.environ["TRANSFORMERS_OFFLINE"] = "1"
-if os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1":
-    os.environ["HF_HUB_OFFLINE"] = "1"
+# Check offline mode as well. Cross-sync HF_HUB_OFFLINE,
+# TRANSFORMERS_OFFLINE, and HF_DATASETS_OFFLINE so setting any one of
+# the three implies all three. Without HF_DATASETS_OFFLINE here,
+# load_dataset() still issues a network call for dataset metadata even
+# when the rest of the HF stack is offline (and fails with
+# ConnectionError instead of resolving from cache).
+_OFFLINE_VARS = ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE")
+if any(os.environ.get(v, "0") == "1" for v in _OFFLINE_VARS):
+    for _v in _OFFLINE_VARS:
+        os.environ[_v] = "1"
 
 # Check "429 Too Many Requests" and set HF_XET_HIGH_PERFORMANCE
 from pathlib import Path


### PR DESCRIPTION
## Summary

Today `unsloth_zoo/__init__.py` cross-syncs `HF_HUB_OFFLINE` and `TRANSFORMERS_OFFLINE` at import time so setting either implies the other:

```python
if os.environ.get(\"HF_HUB_OFFLINE\", \"0\") == \"1\":
    os.environ[\"TRANSFORMERS_OFFLINE\"] = \"1\"
if os.environ.get(\"TRANSFORMERS_OFFLINE\", \"0\") == \"1\":
    os.environ[\"HF_HUB_OFFLINE\"] = \"1\"
```

The `datasets` library has its own equivalent env var, `HF_DATASETS_OFFLINE`, which is not in the sync. Consequence: when a user (or a downstream caller like the Studio inference worker, which sets `HF_HUB_OFFLINE=1` after a 2s DNS probe fails) goes offline, `load_dataset()` still issues a network call for dataset metadata and raises `ConnectionError` instead of resolving from cache.

This PR extends the cross-sync to all three vars so any single one set implies all three.

## Behaviour preserved

- The existing convention of only matching the literal `\"1\"` is kept (other truthy spellings like `\"true\"` / `\"yes\"` are left alone). Documented in the new test.
- The unset case stays unset.
- A user who only sets `HF_DATASETS_OFFLINE` (e.g. a datasets-only flow) now also flips `HF_HUB_OFFLINE` and `TRANSFORMERS_OFFLINE`. That matches the existing two-way sync semantics.

## Test plan

- [x] 5 cases under `tests/test_offline_env_cross_sync.py`:
  - unset stays unset
  - each of the three env vars as trigger implies the other two
  - non-`\"1\"` truthy values do not trigger the sync
- [x] Local pytest pass: 5/5 in 11.5s.
- [ ] CI green.

## Related

Stacks on top of unslothai/unsloth#5505 and unslothai/unsloth#5512 (Studio inference / training offline DNS auto-detect). Both of those rely on this sync to make `load_dataset(...)` calls resolve from cache after the DNS probe trips.