### PR TITLE
Honor UNSLOTH_RETURN_LOGITS in fused forward

### DIFF
--- a/tests/test_fused_forward_install.py
+++ b/tests/test_fused_forward_install.py
@@ -106,15 +106,11 @@ def test_ast_rewriter_matches_keyword_form():
     assert "EMPTY_LOGITS" in new_src
     # The original self.loss_function call must be gone from the rewritten src.
     assert "self.loss_function" not in new_src
-    # Three branches mirror unsloth_zoo/compiler.py: return-hidden first,
-    # then the labels branch with the UNSLOTH_RETURN_LOGITS opt-in, then
-    # plain generation.
-    assert "UNSLOTH_RETURN_HIDDEN_STATES" in new_src
+    # Labels branch carries the UNSLOTH_RETURN_LOGITS opt-in; the hidden-
+    # states branch is intentionally absent (handled by the compiled
+    # forward in unsloth_zoo/compiler.py).
     assert "UNSLOTH_RETURN_LOGITS" in new_src
-    idx_hidden = new_src.index("UNSLOTH_RETURN_HIDDEN_STATES")
-    idx_labels = new_src.index("labels is not None")
-    idx_logits = new_src.index("UNSLOTH_RETURN_LOGITS")
-    assert idx_hidden < idx_labels < idx_logits, new_src
+    assert "UNSLOTH_RETURN_HIDDEN_STATES" not in new_src
 
 
 def test_ast_rewriter_matches_positional_with_float_wrapper():
@@ -667,7 +663,7 @@ def test_adapter_num_items_in_batch_as_int_and_tensor_equal():
 
 
 # ---------------------------------------------------------------------------
-# Env-var branches: UNSLOTH_RETURN_HIDDEN_STATES / UNSLOTH_RETURN_LOGITS
+# Env-var branch: UNSLOTH_RETURN_LOGITS
 # ---------------------------------------------------------------------------
 
 
@@ -695,32 +691,6 @@ def _toy_instance(cls, dtype, V=64, H=32):
         )
     inst.loss_function = _reference_loss
     return inst
-
-
-def test_rewritten_forward_returns_hidden_states_when_env_set(
-    fresh_install, enable_env, monkeypatch,
-):
-    # UNSLOTH_RETURN_HIDDEN_STATES=1 must take priority over the labels
-    # branch: returned logits slot carries hidden_states (hidden_dim),
-    # not vocab-dim, and loss is None. GRPO's _get_per_token_logps_and_
-    # entropies relies on this early return.
-    torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
-
-    cls = _install_toy_cls(fresh_install)
-    B, T, H, V = 2, 8, 32, 64
-    inst = _toy_instance(cls, dtype=torch.bfloat16, V=V, H=H)
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
-    labels = torch.randint(0, V, (B, T), device="cuda")
-
-    monkeypatch.setenv("UNSLOTH_RETURN_HIDDEN_STATES", "1")
-    loss, logits = cls.forward(inst, hidden, labels=labels)
-    assert loss is None
-    assert logits.shape[-1] == H, (
-        f"expected hidden_dim={H}, got last dim {logits.shape[-1]}"
-    )
-    assert torch.equal(logits, hidden)
 
 
 def test_rewritten_forward_returns_real_logits_when_env_set(
@@ -752,8 +722,9 @@ def test_rewritten_forward_returns_real_logits_when_env_set(
 def test_rewritten_forward_default_labels_branch_yields_empty_logits(
     fresh_install, enable_env, monkeypatch,
 ):
-    # Defaults (neither env var set): labels branch still returns
-    # EMPTY_LOGITS so we don't pay the lm_head matmul on the hot path.
+    # Defaults (env var unset): labels branch returns EMPTY_LOGITS so we
+    # don't pay the lm_head matmul on the hot path. Byte-identical to
+    # the pre-PR behaviour.
     torch = pytest.importorskip("torch")
     if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
         pytest.skip("requires CUDA")
@@ -764,33 +735,11 @@ def test_rewritten_forward_default_labels_branch_yields_empty_logits(
     hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
     labels = torch.randint(0, V, (B, T), device="cuda")
 
-    monkeypatch.delenv("UNSLOTH_RETURN_HIDDEN_STATES", raising=False)
     monkeypatch.delenv("UNSLOTH_RETURN_LOGITS", raising=False)
     loss, logits = cls.forward(inst, hidden, labels=labels)
     assert loss is not None
     assert torch.isfinite(loss)
     assert logits.numel() == 0
-
-
-def test_rewritten_forward_hidden_states_takes_priority_over_logits(
-    fresh_install, enable_env, monkeypatch,
-):
-    # Both env vars set: return-hidden wins (matches compiler.py ordering).
-    torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
-
-    cls = _install_toy_cls(fresh_install)
-    B, T, H, V = 2, 8, 32, 64
-    inst = _toy_instance(cls, dtype=torch.bfloat16, V=V, H=H)
-    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
-    labels = torch.randint(0, V, (B, T), device="cuda")
-
-    monkeypatch.setenv("UNSLOTH_RETURN_HIDDEN_STATES", "1")
-    monkeypatch.setenv("UNSLOTH_RETURN_LOGITS", "1")
-    loss, logits = cls.forward(inst, hidden, labels=labels)
-    assert loss is None
-    assert logits.shape[-1] == H
 
 
 def test_fused_kernel_label_smoothing_changes_loss():

--- a/tests/test_fused_forward_install.py
+++ b/tests/test_fused_forward_install.py
@@ -104,8 +104,10 @@ def test_ast_rewriter_matches_keyword_form():
     assert cap.logits_name == "logits"
     assert "unsloth_fused_lm_head_loss" in new_src
     assert "EMPTY_LOGITS" in new_src
-    # The original self.loss_function call must be gone from the rewritten src.
-    assert "self.loss_function" not in new_src
+    # self.loss_function appears exactly once: on the UNSLOTH_RETURN_LOGITS
+    # opt-in path, where we materialise logits via the original RHS and
+    # route the loss through it to avoid a second lm_head matmul.
+    assert new_src.count("self.loss_function") == 1
     # Labels branch carries the UNSLOTH_RETURN_LOGITS opt-in; the hidden-
     # states branch is intentionally absent (handled by the compiled
     # forward in unsloth_zoo/compiler.py).
@@ -696,10 +698,10 @@ def _toy_instance(cls, dtype, V=64, H=32):
 def test_rewritten_forward_returns_real_logits_when_env_set(
     fresh_install, enable_env, monkeypatch,
 ):
-    # UNSLOTH_RETURN_LOGITS=1 with labels present: loss is computed via
-    # the fused kernel, AND the logits slot carries real lm_head output
-    # rather than EMPTY_LOGITS. Lets callers train + collect logits for
-    # eval / custom metrics in one forward.
+    # UNSLOTH_RETURN_LOGITS=1 with labels present: logits slot carries
+    # real lm_head output and loss is computed via self.loss_function on
+    # those materialised logits. Critically, only ONE lm_head matmul
+    # happens (no fused-kernel re-matmul).
     torch = pytest.importorskip("torch")
     if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
         pytest.skip("requires CUDA")
@@ -710,12 +712,35 @@ def test_rewritten_forward_returns_real_logits_when_env_set(
     hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
     labels = torch.randint(0, V, (B, T), device="cuda")
 
+    # Count lm_head invocations to prove single-matmul on the opt-in path.
+    lm_head_calls = {"n": 0}
+    orig_call = inst.lm_head.__class__.__call__
+    def _counting_call(self, *a, **kw):
+        lm_head_calls["n"] += 1
+        return orig_call(self, *a, **kw)
+    monkeypatch.setattr(inst.lm_head.__class__, "__call__", _counting_call)
+
+    # Also count self.loss_function invocations to confirm the opt-in path
+    # routes through the model's own loss function.
+    loss_fn_calls = {"n": 0}
+    real_loss_fn = inst.loss_function
+    def _counting_loss_fn(*a, **kw):
+        loss_fn_calls["n"] += 1
+        return real_loss_fn(*a, **kw)
+    inst.loss_function = _counting_loss_fn
+
     monkeypatch.setenv("UNSLOTH_RETURN_LOGITS", "1")
     loss, logits = cls.forward(inst, hidden, labels=labels)
     assert loss is not None
     assert torch.isfinite(loss)
     assert logits.shape == (B, T, V), (
         f"expected real logits {(B, T, V)}, got {tuple(logits.shape)}"
+    )
+    assert lm_head_calls["n"] == 1, (
+        f"opt-in path must do exactly one lm_head matmul, observed {lm_head_calls['n']}"
+    )
+    assert loss_fn_calls["n"] == 1, (
+        f"opt-in path must call self.loss_function once, observed {loss_fn_calls['n']}"
     )
 
 

--- a/tests/test_fused_forward_install.py
+++ b/tests/test_fused_forward_install.py
@@ -106,6 +106,15 @@ def test_ast_rewriter_matches_keyword_form():
     assert "EMPTY_LOGITS" in new_src
     # The original self.loss_function call must be gone from the rewritten src.
     assert "self.loss_function" not in new_src
+    # Three branches mirror unsloth_zoo/compiler.py: return-hidden first,
+    # then the labels branch with the UNSLOTH_RETURN_LOGITS opt-in, then
+    # plain generation.
+    assert "UNSLOTH_RETURN_HIDDEN_STATES" in new_src
+    assert "UNSLOTH_RETURN_LOGITS" in new_src
+    idx_hidden = new_src.index("UNSLOTH_RETURN_HIDDEN_STATES")
+    idx_labels = new_src.index("labels is not None")
+    idx_logits = new_src.index("UNSLOTH_RETURN_LOGITS")
+    assert idx_hidden < idx_labels < idx_logits, new_src
 
 
 def test_ast_rewriter_matches_positional_with_float_wrapper():
@@ -655,6 +664,133 @@ def test_adapter_num_items_in_batch_as_int_and_tensor_equal():
     assert torch.allclose(fused_int, fused_tensor, atol=1e-6), (
         f"int vs tensor n_items disagree: {fused_int.item()} vs {fused_tensor.item()}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Env-var branches: UNSLOTH_RETURN_HIDDEN_STATES / UNSLOTH_RETURN_LOGITS
+# ---------------------------------------------------------------------------
+
+
+def _install_toy_cls(fresh_install):
+    cls = _make_synthetic_class(_toy_forward_src(), name="EnvVarToyForCausalLM")
+    assert fresh_install.install_for_class(cls) is True
+    return cls
+
+
+def _toy_instance(cls, dtype, V=64, H=32):
+    import torch
+    class _Config:
+        vocab_size = V
+    inst = cls()
+    inst.config = _Config()
+    inst.lm_head = torch.nn.Linear(H, V, bias=False).cuda().to(dtype)
+    def _reference_loss(logits, labels, vocab_size, **kw):
+        shifted = labels.clone()
+        shifted[..., :-1] = labels[..., 1:]
+        shifted[..., -1] = -100
+        return torch.nn.functional.cross_entropy(
+            logits.float().view(-1, vocab_size),
+            shifted.view(-1),
+            ignore_index=-100,
+        )
+    inst.loss_function = _reference_loss
+    return inst
+
+
+def test_rewritten_forward_returns_hidden_states_when_env_set(
+    fresh_install, enable_env, monkeypatch,
+):
+    # UNSLOTH_RETURN_HIDDEN_STATES=1 must take priority over the labels
+    # branch: returned logits slot carries hidden_states (hidden_dim),
+    # not vocab-dim, and loss is None. GRPO's _get_per_token_logps_and_
+    # entropies relies on this early return.
+    torch = pytest.importorskip("torch")
+    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
+        pytest.skip("requires CUDA")
+
+    cls = _install_toy_cls(fresh_install)
+    B, T, H, V = 2, 8, 32, 64
+    inst = _toy_instance(cls, dtype=torch.bfloat16, V=V, H=H)
+    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
+    labels = torch.randint(0, V, (B, T), device="cuda")
+
+    monkeypatch.setenv("UNSLOTH_RETURN_HIDDEN_STATES", "1")
+    loss, logits = cls.forward(inst, hidden, labels=labels)
+    assert loss is None
+    assert logits.shape[-1] == H, (
+        f"expected hidden_dim={H}, got last dim {logits.shape[-1]}"
+    )
+    assert torch.equal(logits, hidden)
+
+
+def test_rewritten_forward_returns_real_logits_when_env_set(
+    fresh_install, enable_env, monkeypatch,
+):
+    # UNSLOTH_RETURN_LOGITS=1 with labels present: loss is computed via
+    # the fused kernel, AND the logits slot carries real lm_head output
+    # rather than EMPTY_LOGITS. Lets callers train + collect logits for
+    # eval / custom metrics in one forward.
+    torch = pytest.importorskip("torch")
+    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
+        pytest.skip("requires CUDA")
+
+    cls = _install_toy_cls(fresh_install)
+    B, T, H, V = 2, 8, 32, 64
+    inst = _toy_instance(cls, dtype=torch.bfloat16, V=V, H=H)
+    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
+    labels = torch.randint(0, V, (B, T), device="cuda")
+
+    monkeypatch.setenv("UNSLOTH_RETURN_LOGITS", "1")
+    loss, logits = cls.forward(inst, hidden, labels=labels)
+    assert loss is not None
+    assert torch.isfinite(loss)
+    assert logits.shape == (B, T, V), (
+        f"expected real logits {(B, T, V)}, got {tuple(logits.shape)}"
+    )
+
+
+def test_rewritten_forward_default_labels_branch_yields_empty_logits(
+    fresh_install, enable_env, monkeypatch,
+):
+    # Defaults (neither env var set): labels branch still returns
+    # EMPTY_LOGITS so we don't pay the lm_head matmul on the hot path.
+    torch = pytest.importorskip("torch")
+    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
+        pytest.skip("requires CUDA")
+
+    cls = _install_toy_cls(fresh_install)
+    B, T, H, V = 2, 8, 32, 64
+    inst = _toy_instance(cls, dtype=torch.bfloat16, V=V, H=H)
+    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
+    labels = torch.randint(0, V, (B, T), device="cuda")
+
+    monkeypatch.delenv("UNSLOTH_RETURN_HIDDEN_STATES", raising=False)
+    monkeypatch.delenv("UNSLOTH_RETURN_LOGITS", raising=False)
+    loss, logits = cls.forward(inst, hidden, labels=labels)
+    assert loss is not None
+    assert torch.isfinite(loss)
+    assert logits.numel() == 0
+
+
+def test_rewritten_forward_hidden_states_takes_priority_over_logits(
+    fresh_install, enable_env, monkeypatch,
+):
+    # Both env vars set: return-hidden wins (matches compiler.py ordering).
+    torch = pytest.importorskip("torch")
+    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
+        pytest.skip("requires CUDA")
+
+    cls = _install_toy_cls(fresh_install)
+    B, T, H, V = 2, 8, 32, 64
+    inst = _toy_instance(cls, dtype=torch.bfloat16, V=V, H=H)
+    hidden = torch.randn(B, T, H, device="cuda", dtype=torch.bfloat16)
+    labels = torch.randint(0, V, (B, T), device="cuda")
+
+    monkeypatch.setenv("UNSLOTH_RETURN_HIDDEN_STATES", "1")
+    monkeypatch.setenv("UNSLOTH_RETURN_LOGITS", "1")
+    loss, logits = cls.forward(inst, hidden, labels=labels)
+    assert loss is None
+    assert logits.shape[-1] == H
 
 
 def test_fused_kernel_label_smoothing_changes_loss():

--- a/unsloth_zoo/fused_losses/ast_rewriter.py
+++ b/unsloth_zoo/fused_losses/ast_rewriter.py
@@ -13,11 +13,22 @@ Match:
     if labels is not None:
         <LOSS> = self.loss_function(<LOGITS>, labels, vocab_size=..., **kwargs)
 
-Rewrite the labels branch to call `unsloth_fused_lm_head_loss(<HIDDEN>,
-self.<HEAD>, labels, ...)` (skipping the bf16 logits + fp32 cast) and
-substitute EMPTY_LOGITS for the returned logits. The else (generation)
-branch keeps the original RHS verbatim. Forwards that miss the triplet
-fall through to `_UNMATCHED`; the LOSS_MAPPING sweep is the backstop.
+Rewrite expands the original two-branch block into three branches that
+mirror the compiler-rewritten forward in ``unsloth_zoo/compiler.py``:
+
+  1. ``UNSLOTH_RETURN_HIDDEN_STATES=1`` -> return hidden_states in the
+     logits slot, no lm_head matmul, no loss. GRPO and other callers
+     that compute their own logprobs from hidden_states + lm_head rely
+     on this early return.
+  2. ``labels is not None`` -> call ``unsloth_fused_lm_head_loss`` for
+     the loss. The logits slot becomes ``EMPTY_LOGITS`` unless
+     ``UNSLOTH_RETURN_LOGITS=1`` is set, in which case the original
+     ``self.<HEAD>(<HIDDEN>)`` expression runs so the caller still
+     gets real logits (eval / custom metrics).
+  3. otherwise (generation) -> original RHS verbatim, ``loss = None``.
+
+Forwards that miss the triplet fall through to ``_UNMATCHED``; the
+LOSS_MAPPING sweep is the backstop.
 """
 
 from __future__ import annotations
@@ -254,7 +265,7 @@ def _capture(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> TripletCapture | Non
 
 
 def _build_replacement(cap: TripletCapture) -> list[ast.stmt]:
-    """Build the AST nodes for the rewritten labels-branch / else-branch."""
+    """Build the AST nodes for the rewritten three-branch block."""
     head_attr = cap.head_attr
     logits = cap.logits_name
     loss = cap.loss_name
@@ -266,13 +277,21 @@ def _build_replacement(cap: TripletCapture) -> list[ast.stmt]:
     hidden_src = ast.unparse(cap.hidden_expr)
     logits_rhs = cap.logits_rhs_src or f"self.{head_attr}({hidden_src})"
 
+    # Priority matches unsloth_zoo/compiler.py: return-hidden first, then
+    # the labels (fused-loss) branch, then plain generation.
     template = textwrap.dedent(f"""
-        if labels is not None:
+        if os.environ.get('UNSLOTH_RETURN_HIDDEN_STATES', '0') == '1':
+            {logits} = {hidden_src}
+            {loss} = None
+        elif labels is not None:
             {loss} = unsloth_fused_lm_head_loss(
                 {hidden_src}, self.{head_attr}, labels,
                 vocab_size={vocab}{extra}{kwargs_unpack},
             )
-            {logits} = EMPTY_LOGITS
+            if os.environ.get('UNSLOTH_RETURN_LOGITS', '0') == '1':
+                {logits} = {logits_rhs}
+            else:
+                {logits} = EMPTY_LOGITS
         else:
             {logits} = {logits_rhs}
             {loss} = None

--- a/unsloth_zoo/fused_losses/ast_rewriter.py
+++ b/unsloth_zoo/fused_losses/ast_rewriter.py
@@ -13,22 +13,20 @@ Match:
     if labels is not None:
         <LOSS> = self.loss_function(<LOGITS>, labels, vocab_size=..., **kwargs)
 
-Rewrite expands the original two-branch block into three branches that
-mirror the compiler-rewritten forward in ``unsloth_zoo/compiler.py``:
+Rewrite the labels branch to call ``unsloth_fused_lm_head_loss(<HIDDEN>,
+self.<HEAD>, labels, ...)`` (skipping the bf16 logits + fp32 cast). The
+logits slot becomes ``EMPTY_LOGITS`` unless ``UNSLOTH_RETURN_LOGITS=1``
+is set, in which case the original ``self.<HEAD>(<HIDDEN>)`` expression
+runs so the caller still gets real logits (eval / custom metrics). The
+else (generation) branch keeps the original RHS verbatim. Forwards that
+miss the triplet fall through to ``_UNMATCHED``; the LOSS_MAPPING sweep
+is the backstop.
 
-  1. ``UNSLOTH_RETURN_HIDDEN_STATES=1`` -> return hidden_states in the
-     logits slot, no lm_head matmul, no loss. GRPO and other callers
-     that compute their own logprobs from hidden_states + lm_head rely
-     on this early return.
-  2. ``labels is not None`` -> call ``unsloth_fused_lm_head_loss`` for
-     the loss. The logits slot becomes ``EMPTY_LOGITS`` unless
-     ``UNSLOTH_RETURN_LOGITS=1`` is set, in which case the original
-     ``self.<HEAD>(<HIDDEN>)`` expression runs so the caller still
-     gets real logits (eval / custom metrics).
-  3. otherwise (generation) -> original RHS verbatim, ``loss = None``.
-
-Forwards that miss the triplet fall through to ``_UNMATCHED``; the
-LOSS_MAPPING sweep is the backstop.
+``UNSLOTH_RETURN_HIDDEN_STATES`` is intentionally not handled here:
+GRPO's hidden-states fast path lives in the compiler-rewritten forward
+(``unsloth_zoo/compiler.py``), which always overrides the AST forward
+for the unsloth-supported ``*ForCausalLM`` classes that callers actually
+use with that env var.
 """
 
 from __future__ import annotations
@@ -265,7 +263,7 @@ def _capture(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> TripletCapture | Non
 
 
 def _build_replacement(cap: TripletCapture) -> list[ast.stmt]:
-    """Build the AST nodes for the rewritten three-branch block."""
+    """Build the AST nodes for the rewritten labels-branch / else-branch."""
     head_attr = cap.head_attr
     logits = cap.logits_name
     loss = cap.loss_name
@@ -277,13 +275,10 @@ def _build_replacement(cap: TripletCapture) -> list[ast.stmt]:
     hidden_src = ast.unparse(cap.hidden_expr)
     logits_rhs = cap.logits_rhs_src or f"self.{head_attr}({hidden_src})"
 
-    # Priority matches unsloth_zoo/compiler.py: return-hidden first, then
-    # the labels (fused-loss) branch, then plain generation.
+    # Labels branch goes through the fused kernel. The logits slot is
+    # EMPTY_LOGITS by default, or real logits when UNSLOTH_RETURN_LOGITS=1.
     template = textwrap.dedent(f"""
-        if os.environ.get('UNSLOTH_RETURN_HIDDEN_STATES', '0') == '1':
-            {logits} = {hidden_src}
-            {loss} = None
-        elif labels is not None:
+        if labels is not None:
             {loss} = unsloth_fused_lm_head_loss(
                 {hidden_src}, self.{head_attr}, labels,
                 vocab_size={vocab}{extra}{kwargs_unpack},

--- a/unsloth_zoo/fused_losses/ast_rewriter.py
+++ b/unsloth_zoo/fused_losses/ast_rewriter.py
@@ -13,14 +13,19 @@ Match:
     if labels is not None:
         <LOSS> = self.loss_function(<LOGITS>, labels, vocab_size=..., **kwargs)
 
-Rewrite the labels branch to call ``unsloth_fused_lm_head_loss(<HIDDEN>,
-self.<HEAD>, labels, ...)`` (skipping the bf16 logits + fp32 cast). The
-logits slot becomes ``EMPTY_LOGITS`` unless ``UNSLOTH_RETURN_LOGITS=1``
-is set, in which case the original ``self.<HEAD>(<HIDDEN>)`` expression
-runs so the caller still gets real logits (eval / custom metrics). The
-else (generation) branch keeps the original RHS verbatim. Forwards that
-miss the triplet fall through to ``_UNMATCHED``; the LOSS_MAPPING sweep
-is the backstop.
+Rewrite the labels branch to two paths:
+  - default (``UNSLOTH_RETURN_LOGITS`` unset): ``unsloth_fused_lm_head_loss(
+    <HIDDEN>, self.<HEAD>, labels, ...)`` (skipping the bf16 logits + fp32
+    cast); ``logits = EMPTY_LOGITS``. No lm_head matmul on the hot path.
+  - opt-in (``UNSLOTH_RETURN_LOGITS=1``): materialise logits once via the
+    original ``self.<HEAD>(<HIDDEN>)`` expression, then route the loss
+    through the model's own ``self.loss_function`` on those logits. One
+    lm_head matmul total (vs two if we kept the fused kernel and computed
+    logits separately for the return slot).
+
+The else (generation) branch keeps the original RHS verbatim. Forwards
+that miss the triplet fall through to ``_UNMATCHED``; the LOSS_MAPPING
+sweep is the backstop.
 
 ``UNSLOTH_RETURN_HIDDEN_STATES`` is intentionally not handled here:
 GRPO's hidden-states fast path lives in the compiler-rewritten forward
@@ -275,17 +280,21 @@ def _build_replacement(cap: TripletCapture) -> list[ast.stmt]:
     hidden_src = ast.unparse(cap.hidden_expr)
     logits_rhs = cap.logits_rhs_src or f"self.{head_attr}({hidden_src})"
 
-    # Labels branch goes through the fused kernel. The logits slot is
-    # EMPTY_LOGITS by default, or real logits when UNSLOTH_RETURN_LOGITS=1.
+    # Labels branch. Default path: fused kernel, logits = EMPTY_LOGITS
+    # (no lm_head matmul at all). UNSLOTH_RETURN_LOGITS=1 path: materialise
+    # the full lm_head matmul once and route loss through the model's own
+    # self.loss_function on those logits. Avoids double matmul (fused
+    # kernel chunks lm_head internally; logits_rhs runs the full matmul).
     template = textwrap.dedent(f"""
         if labels is not None:
-            {loss} = unsloth_fused_lm_head_loss(
-                {hidden_src}, self.{head_attr}, labels,
-                vocab_size={vocab}{extra}{kwargs_unpack},
-            )
             if os.environ.get('UNSLOTH_RETURN_LOGITS', '0') == '1':
                 {logits} = {logits_rhs}
+                {loss} = self.loss_function({logits}, labels, vocab_size={vocab}{extra}{kwargs_unpack})
             else:
+                {loss} = unsloth_fused_lm_head_loss(
+                    {hidden_src}, self.{head_attr}, labels,
+                    vocab_size={vocab}{extra}{kwargs_unpack},
+                )
                 {logits} = EMPTY_LOGITS
         else:
             {logits} = {logits_rhs}

--- a/unsloth_zoo/fused_losses/forward_install.py
+++ b/unsloth_zoo/fused_losses/forward_install.py
@@ -215,7 +215,7 @@ def install_for_class(cls) -> bool:
     ns = dict(getattr(forward, "__globals__", {}))
     ns["unsloth_fused_lm_head_loss"] = unsloth_fused_lm_head_loss
     ns["EMPTY_LOGITS"] = EMPTY_LOGITS
-    # The rewritten body reads UNSLOTH_RETURN_HIDDEN_STATES / UNSLOTH_RETURN_LOGITS.
+    # The rewritten body reads UNSLOTH_RETURN_LOGITS via os.environ.get.
     ns.setdefault("os", os)
     try:
         from transformers.utils.generic import can_return_tuple

--- a/unsloth_zoo/fused_losses/forward_install.py
+++ b/unsloth_zoo/fused_losses/forward_install.py
@@ -215,6 +215,8 @@ def install_for_class(cls) -> bool:
     ns = dict(getattr(forward, "__globals__", {}))
     ns["unsloth_fused_lm_head_loss"] = unsloth_fused_lm_head_loss
     ns["EMPTY_LOGITS"] = EMPTY_LOGITS
+    # The rewritten body reads UNSLOTH_RETURN_HIDDEN_STATES / UNSLOTH_RETURN_LOGITS.
+    ns.setdefault("os", os)
     try:
         from transformers.utils.generic import can_return_tuple
         ns.setdefault("can_return_tuple", can_return_tuple)


### PR DESCRIPTION
## Summary

Follow-up to #657. The AST-rewritten forward only had two branches: labels-not-None (fused CE, `EMPTY_LOGITS`) and else (real logits, no loss). It silently ignored `UNSLOTH_RETURN_LOGITS`, which the compiler-rewritten forward in `unsloth_zoo/compiler.py` already honors.

For training callers that want both fused CE and real logits in a single forward (eval, custom metrics, custom inspection), the AST forward currently has no way to give them logits. This PR closes that gap.

`UNSLOTH_RETURN_HIDDEN_STATES` is intentionally not handled here. The hidden-states fast path is owned by the compiled forward, which always overrides the AST forward for the `*ForCausalLM` classes GRPO actually runs on.

## Change

`ast_rewriter._build_replacement` template:

```
if labels is not None:
    if os.environ.get('UNSLOTH_RETURN_LOGITS', '0') == '1':
        logits = <original RHS>                       # one matmul
        loss   = self.loss_function(logits, labels,   # same logits
                                    vocab_size=V, ...)
    else:
        loss   = unsloth_fused_lm_head_loss(...)      # chunked, fused
        logits = EMPTY_LOGITS
else:
    logits = <original RHS>
    loss   = None
```

The opt-in path routes the loss through the model's own `self.loss_function` on the already-materialised logits. This avoids the double `lm_head` matmul that an earlier revision had (chunked matmul inside the fused kernel + full matmul to populate the return slot). One matmul total when `UNSLOTH_RETURN_LOGITS=1`, zero matmuls on the default hot path.

`forward_install.py` seeds the rewritten forward's globals with `os` so the env-var read works on classes whose original forward did not `import os`.

## Test plan

- [x] `tests/test_fused_forward_install.py`: keyword-form assertion confirms exactly one `self.loss_function` reference appears (the opt-in path), carries `UNSLOTH_RETURN_LOGITS`, and does NOT mention `UNSLOTH_RETURN_HIDDEN_STATES`.
- [x] Two CUDA-gated behaviour tests:
  - `test_rewritten_forward_returns_real_logits_when_env_set` -> counts `lm_head` invocations (==1) and `self.loss_function` invocations (==1) on the opt-in call; verifies `(B, T, V)` logits and finite loss.
  - `test_rewritten_forward_default_labels_branch_yields_empty_logits` -> default (env var unset) still returns `EMPTY_LOGITS` (no behaviour change for the hot path).
- [x] Full file: `29 passed` on B200, CUDA 12.8, torch 2.9.1.
- [x] Loss equivalence on a toy: default chunked fused CE vs opt-in `self.loss_function(self.lm_head(hidden), ...)` give `5.003798` vs `5.003798` (abs_delta `0.000000`).
- [x] End-to-end Gemma3 1B GRPO smoke (max_steps=3) returns bit-identical losses (`0.256 / 0.4393 / 0.2031`) vs current main with the same seed. The default path is unchanged at the training-loop level.

## Compatibility

Default observable behaviour is byte-identical to current main when `UNSLOTH_RETURN_LOGITS` is unset:
- labels-not-None still returns `EMPTY_LOGITS` and fused CE loss
- else branch still returns the original logits RHS and `loss = None`

The new branch only fires when the env var is explicitly set, which today only happens inside unsloth code paths that already expect this contract from the compiled forward.