### PR TITLE
compiler: single-matmul opt-in for UNSLOTH_RETURN_LOGITS=1

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1769,9 +1769,17 @@ elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not N
     )
 elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None:
     # UNSLOTH_RETURN_LOGITS=1 path. Prepended `logits = self.lm_head(...)`
-    # has already materialised the full lm_head matmul; route the loss
-    # through self.loss_function on those same logits instead of letting
-    # unsloth_fused_ce_loss redo the chunked matmul.
+    # already materialised the full lm_head matmul; apply the captured logit
+    # scale/softcap transforms and route loss through self.loss_function on
+    # those logits instead of letting unsloth_fused_ce_loss redo the matmul.
+    if (\\2) != ():
+        logits = logits * (\\2)
+    if (\\3) != ():
+        logits = logits / (\\3)
+    if (\\4) not in (None, (),):
+        logits = logits / (\\4)
+        logits = torch.tanh(logits)
+        logits = logits * (\\4)
     loss = self.loss_function(logits, labels.to(self.lm_head.weight.device), vocab_size=\\8, **\\9)
 else:
     logits = self.lm_head(hidden_states\\1)

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1744,7 +1744,7 @@ elif ((\\2) == () and (\\3) == ()) and (UNSLOTH_ENABLE_CCE) and NOT_RETURN_LOGIT
         num_items_in_batch = n_items,
         logit_softcapping  = None if (\\4) == () else (\\4),
     )
-elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None:
+elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None and NOT_RETURN_LOGITS:
     lm_head_weight = self.lm_head.weight
     lm_head_bias   = getattr(self.lm_head, "bias", None)
 
@@ -1767,6 +1767,12 @@ elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not N
         logit_scale_divide   = (\\3) if (\\3) != () else 0,
         logit_softcapping    = (\\4) if (\\4) != () else 0,
     )
+elif self.loss_function.__name__.endswith("ForCausalLMLoss") and labels is not None:
+    # UNSLOTH_RETURN_LOGITS=1 path. Prepended `logits = self.lm_head(...)`
+    # has already materialised the full lm_head matmul; route the loss
+    # through self.loss_function on those same logits instead of letting
+    # unsloth_fused_ce_loss redo the chunked matmul.
+    loss = self.loss_function(logits, labels.to(self.lm_head.weight.device), vocab_size=\\8, **\\9)
 else:
     logits = self.lm_head(hidden_states\\1)
     if (\\2) != ():


### PR DESCRIPTION
## Summary

Backports the single-matmul shape from #665 to `cross_entropy_replacement_2` in `unsloth_zoo/compiler.py`. Pairs with the matching PR on `unslothai/unsloth` (`daniel/three-followups-from-pr665`) which fixes the `num_logits_to_keep` regression and flips `patch_loss_functions(torch_compile=True)` at the FastModel call site.

## What was wrong

When `UNSLOTH_RETURN_LOGITS=1` and labels are present, the rewritten forward did two `lm_head` matmuls for one tensor:

1. The prepended line at `compiler.py:2074` materialised the full lm_head matmul:
   ```
   logits = self.lm_head(hidden_states[:, slice_indices, :]) if UNSLOTH_RETURN_LOGITS=='1' else EMPTY_LOGITS
   ```
2. Then the `else` clause of `cross_entropy_replacement_2` called `unsloth_fused_ce_loss(hidden_states, lm_head_weight, ...)` which chunks the same `hidden @ lm_head.T` matmul internally to compute CE.

Compute-wise this was wasteful on the opt-in path. PR #665 fixed the same shape in the AST-installed forward; this PR brings the compiler-rewritten forward in line.

## Change

Split the `ForCausalLMLoss` + `labels is not None` branch into two paths:

```python
elif self.loss_function.__name__.endswith(\"ForCausalLMLoss\") and labels is not None and NOT_RETURN_LOGITS:
    # existing unsloth_fused_ce_loss path -- default hot path
    ...
elif self.loss_function.__name__.endswith(\"ForCausalLMLoss\") and labels is not None:
    # UNSLOTH_RETURN_LOGITS=1: logits was already materialised by the prepend.
    # Route loss through self.loss_function on those same logits.
    loss = self.loss_function(logits, labels.to(self.lm_head.weight.device), vocab_size=\\8, **\\9)
```

`self.loss_function` resolves to `UnslothForCausalLMLoss` (Triton CE, no `.float()` upcast) once `patch_loss_functions` has run, which the FastModel.from_pretrained path does.

Default behaviour is unchanged: when `UNSLOTH_RETURN_LOGITS` is unset, `NOT_RETURN_LOGITS=True` and the same `unsloth_fused_ce_loss` branch fires.

Templates 1 and 3 (legacy explicit-CE shapes) still have the double-matmul on this rare combination. They would need inline `F.cross_entropy` since they lack a `self.loss_function` capture in their find pattern. Out of scope here; modern modeling code post-4.56 all hits template 2.

## Test plan

- [x] `tests/test_fused_forward_install.py` + `tests/test_compiler_rewriter_exhaustive.py`: 96 passed on B200, torch 2.9.1, transformers 4.57.6.
- [x] Inspected the rewritten Gemma3 forward in `unsloth_compiled_cache/unsloth_compiled_module_gemma3.py`: the new branch appears twice (once per CausalLM class in the module), correctly stamped from `compiler.py`.
- [x] Gemma3 1B GRPO smoke (max_steps=3) returns bit-identical losses (0.256 / 0.4393 / 0.2031) vs current main with the same seed. Default path unchanged at training-loop level.

## Compatibility

No behavioural change when `UNSLOTH_RETURN_LOGITS` is unset (the default in every existing workflow). The new branch only fires when the env var is explicitly set, which today only happens inside paths that already expected this contract from the compiled forward.

Pairs with: `unslothai/unsloth daniel/three-followups-from-pr665` (`Fix num_logits_to_keep on transformers >= 4.51 + compile loss_function`).