### PR TITLE
fix(mlx): warn on bf16 -> fp16 downcast in FastMLXModel loader

### DIFF
--- a/tests/test_mlx_dtype_downcast_warning.py
+++ b/tests/test_mlx_dtype_downcast_warning.py
@@ -58,6 +58,25 @@ def test_force_float32_list_exported():
     assert "qwen3_5" in unsloth_zoo.FORCE_FLOAT32
 
 
+def test_force_float32_matches_config_json_model_types():
+    """Entries are HuggingFace `config.json` `model_type` values (the same
+    strings returned by `get_transformers_model_type`). The MLX matcher
+    must accept the real on-disk variants verbatim."""
+    from unsloth_zoo.mlx.loader import _is_force_float32_arch
+    # Real config.json model_type strings as they appear on the Hub.
+    real_world = [
+        "gemma3",       # google/gemma-3-*
+        "gemma3_text",  # google/embeddinggemma-*
+        "gemma3n",      # google/gemma-3n-*
+        "gpt_oss",      # openai/gpt-oss-*
+        "qwen3_5",      # Qwen/Qwen3.5-*
+    ]
+    for model_type in real_world:
+        assert _is_force_float32_arch(model_type) is True, (
+            f"FORCE_FLOAT32 must match real config.json model_type {model_type!r}"
+        )
+
+
 def test_warns_on_bf16_to_fp16_for_gemma3():
     """The production scenario: gemma3 bf16 weights downcast to fp16."""
     import torch

--- a/tests/test_mlx_dtype_downcast_warning.py
+++ b/tests/test_mlx_dtype_downcast_warning.py
@@ -1,0 +1,155 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Test the bf16->fp16 downcast warning in unsloth_zoo.mlx.loader._convert_mlx_dtype.
+#
+# Gemma3-270m's native bf16 storage carries activations whose magnitudes
+# exceed fp16's finite range. Silent bf16->fp16 downcast in
+# FastMLXModel.from_pretrained(dtype="float16") was observed to drop a
+# single-row LoRA memorization fixture's greedy-decode pass rate from
+# 47% (dtype=None) to 15% (dtype="float16") across 15 seeds. The cast
+# remains supported (users on M1/M2 need it), but it now emits a
+# warning so callers see the trade-off.
+
+from __future__ import annotations
+
+import pytest
+import warnings
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+class _FakeArray:
+    """Minimal stand-in for an mx.array carrying just a dtype field.
+
+    _convert_mlx_dtype only reads .dtype and calls .astype on params, both
+    of which the shim implements via the underlying torch tensor; using a
+    real torch tensor here keeps the path fully exercised.
+    """
+    def __init__(self, dtype):
+        import torch
+        # Empty tensor is fine — _convert_mlx_dtype doesn't read data.
+        self._t = torch.zeros((1,), dtype=dtype)
+
+    @property
+    def dtype(self):
+        return self._t.dtype
+
+    def astype(self, target_dtype):
+        return _FakeArray(target_dtype)
+
+
+class _FakeModel:
+    """The smallest object _convert_mlx_dtype needs:
+    a .parameters() returning a flat dict and .update() that accepts the
+    tree_map output.
+    """
+    def __init__(self, params):
+        self._params = params
+
+    def parameters(self):
+        return self._params
+
+    def update(self, new_params):
+        self._params = new_params
+
+
+def _make_model(dtype_map):
+    """Build a fake model with named params at the given dtypes."""
+    import torch
+    return _FakeModel({name: _FakeArray(dt) for name, dt in dtype_map.items()})
+
+
+def test_warns_on_bf16_to_fp16_downcast():
+    """The exact production scenario: native bf16 weights, user asks for fp16."""
+    import torch
+    from unsloth_zoo.mlx.loader import _convert_mlx_dtype
+
+    model = _make_model({"w1": torch.bfloat16, "w2": torch.bfloat16})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _convert_mlx_dtype(model, torch.float16)
+
+    msgs = [str(w.message) for w in caught]
+    assert any("bfloat16" in m and "float16" in m for m in msgs), (
+        f"Expected a bf16->fp16 downcast warning, got: {msgs}"
+    )
+
+
+def test_no_warning_on_bf16_to_fp32_upcast():
+    """Upcasts are safe; no warning."""
+    import torch
+    from unsloth_zoo.mlx.loader import _convert_mlx_dtype
+
+    model = _make_model({"w1": torch.bfloat16})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _convert_mlx_dtype(model, torch.float32)
+
+    bf_fp_msgs = [
+        str(w.message) for w in caught
+        if "bfloat16" in str(w.message) and "float16" in str(w.message)
+    ]
+    assert bf_fp_msgs == [], (
+        f"Did not expect a bf16->fp16 warning for a bf16->fp32 upcast; got: {bf_fp_msgs}"
+    )
+
+
+def test_no_warning_on_fp32_to_fp16_downcast():
+    """fp32->fp16 is lossy too but is a different (already-explicit) regime."""
+    import torch
+    from unsloth_zoo.mlx.loader import _convert_mlx_dtype
+
+    model = _make_model({"w1": torch.float32})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _convert_mlx_dtype(model, torch.float16)
+
+    bf_fp_msgs = [
+        str(w.message) for w in caught
+        if "bfloat16" in str(w.message) and "float16" in str(w.message)
+    ]
+    assert bf_fp_msgs == [], (
+        f"Did not expect a bf16->fp16 warning for a fp32->fp16 cast; got: {bf_fp_msgs}"
+    )
+
+
+def test_no_warning_when_no_cast_needed():
+    """All params already at target_dtype -> early return, no warnings."""
+    import torch
+    from unsloth_zoo.mlx.loader import _convert_mlx_dtype
+
+    model = _make_model({"w1": torch.float16, "w2": torch.float16})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _convert_mlx_dtype(model, torch.float16)
+
+    bf_fp_msgs = [
+        str(w.message) for w in caught
+        if "bfloat16" in str(w.message) and "float16" in str(w.message)
+    ]
+    assert bf_fp_msgs == [], (
+        f"Did not expect a warning when no cast is needed; got: {bf_fp_msgs}"
+    )
+
+
+def test_cast_still_happens_after_warning():
+    """The warning is advisory only — the requested cast still occurs."""
+    import torch
+    from unsloth_zoo.mlx.loader import _convert_mlx_dtype
+
+    model = _make_model({"w1": torch.bfloat16})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        _convert_mlx_dtype(model, torch.float16)
+
+    # _FakeArray.astype returns a fresh _FakeArray with the new dtype,
+    # so the parameter tree now reflects the target dtype.
+    assert model._params["w1"].dtype == torch.float16

--- a/tests/test_mlx_dtype_downcast_warning.py
+++ b/tests/test_mlx_dtype_downcast_warning.py
@@ -1,13 +1,6 @@
 # Unsloth Zoo - Utilities for Unsloth
 # Test the bf16->fp16 downcast warning in unsloth_zoo.mlx.loader._convert_mlx_dtype.
-#
-# Gemma3-270m's native bf16 storage carries activations whose magnitudes
-# exceed fp16's finite range. Silent bf16->fp16 downcast in
-# FastMLXModel.from_pretrained(dtype="float16") was observed to drop a
-# single-row LoRA memorization fixture's greedy-decode pass rate from
-# 47% (dtype=None) to 15% (dtype="float16") across 15 seeds. The cast
-# remains supported (users on M1/M2 need it), but it now emits a
-# warning so callers see the trade-off.
+# Warning gated on model_type being in unsloth_zoo.FORCE_FLOAT32.
 
 from __future__ import annotations
 
@@ -22,15 +15,9 @@ def _install_mlx_shim():
 
 
 class _FakeArray:
-    """Minimal stand-in for an mx.array carrying just a dtype field.
-
-    _convert_mlx_dtype only reads .dtype and calls .astype on params, both
-    of which the shim implements via the underlying torch tensor; using a
-    real torch tensor here keeps the path fully exercised.
-    """
+    """Minimal stand-in for an mx.array carrying just .dtype/.astype."""
     def __init__(self, dtype):
         import torch
-        # Empty tensor is fine — _convert_mlx_dtype doesn't read data.
         self._t = torch.zeros((1,), dtype=dtype)
 
     @property
@@ -42,10 +29,6 @@ class _FakeArray:
 
 
 class _FakeModel:
-    """The smallest object _convert_mlx_dtype needs:
-    a .parameters() returning a flat dict and .update() that accepts the
-    tree_map output.
-    """
     def __init__(self, params):
         self._params = params
 
@@ -57,13 +40,26 @@ class _FakeModel:
 
 
 def _make_model(dtype_map):
-    """Build a fake model with named params at the given dtypes."""
-    import torch
     return _FakeModel({name: _FakeArray(dt) for name, dt in dtype_map.items()})
 
 
-def test_warns_on_bf16_to_fp16_downcast():
-    """The exact production scenario: native bf16 weights, user asks for fp16."""
+def _bf_fp_msgs(caught):
+    return [
+        str(w.message) for w in caught
+        if "bfloat16" in str(w.message) and "float16" in str(w.message)
+    ]
+
+
+def test_force_float32_list_exported():
+    """FORCE_FLOAT32 is importable from the top-level unsloth_zoo namespace."""
+    import unsloth_zoo
+    assert "gemma3," in unsloth_zoo.FORCE_FLOAT32
+    assert "gpt_oss" in unsloth_zoo.FORCE_FLOAT32
+    assert "qwen3_5" in unsloth_zoo.FORCE_FLOAT32
+
+
+def test_warns_on_bf16_to_fp16_for_gemma3():
+    """The production scenario: gemma3 bf16 weights downcast to fp16."""
     import torch
     from unsloth_zoo.mlx.loader import _convert_mlx_dtype
 
@@ -71,16 +67,29 @@ def test_warns_on_bf16_to_fp16_downcast():
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        _convert_mlx_dtype(model, torch.float16)
+        _convert_mlx_dtype(model, torch.float16, model_type="gemma3")
 
-    msgs = [str(w.message) for w in caught]
-    assert any("bfloat16" in m and "float16" in m for m in msgs), (
-        f"Expected a bf16->fp16 downcast warning, got: {msgs}"
+    assert _bf_fp_msgs(caught), (
+        f"Expected a bf16->fp16 downcast warning for gemma3, got: "
+        f"{[str(w.message) for w in caught]}"
     )
 
 
-def test_no_warning_on_bf16_to_fp32_upcast():
-    """Upcasts are safe; no warning."""
+def test_warns_for_other_force_float32_archs():
+    """gpt_oss and qwen3_5 also need the warning."""
+    import torch
+    from unsloth_zoo.mlx.loader import _convert_mlx_dtype
+
+    for mt in ("gpt_oss", "qwen3_5", "gemma3n", "gemma3text"):
+        model = _make_model({"w1": torch.bfloat16})
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _convert_mlx_dtype(model, torch.float16, model_type=mt)
+        assert _bf_fp_msgs(caught), f"Expected warning for {mt!r}"
+
+
+def test_no_warning_for_safe_architecture():
+    """A model NOT in FORCE_FLOAT32 (e.g. llama) downcasts silently."""
     import torch
     from unsloth_zoo.mlx.loader import _convert_mlx_dtype
 
@@ -88,19 +97,44 @@ def test_no_warning_on_bf16_to_fp32_upcast():
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        _convert_mlx_dtype(model, torch.float32)
+        _convert_mlx_dtype(model, torch.float16, model_type="llama")
 
-    bf_fp_msgs = [
-        str(w.message) for w in caught
-        if "bfloat16" in str(w.message) and "float16" in str(w.message)
-    ]
-    assert bf_fp_msgs == [], (
-        f"Did not expect a bf16->fp16 warning for a bf16->fp32 upcast; got: {bf_fp_msgs}"
+    assert _bf_fp_msgs(caught) == [], (
+        f"Did not expect a warning for llama; got: "
+        f"{[str(w.message) for w in caught]}"
     )
 
 
+def test_gemma3_comma_does_not_match_gemma3n():
+    """The trailing-comma trick: 'gemma3,' must NOT match 'gemma3n_audio'."""
+    import torch
+    from unsloth_zoo.mlx.loader import _is_force_float32_arch
+    # gemma3n is its own entry and DOES match; we're testing that the
+    # 'gemma3,' entry doesn't accidentally swallow gemma3n variants by
+    # prefix match. gemma3n itself still matches via its own entry.
+    assert _is_force_float32_arch("gemma3") is True
+    assert _is_force_float32_arch("gemma3n") is True
+    assert _is_force_float32_arch("gemma3text") is True
+    # An invented gemma3 variant not in the list returns False
+    assert _is_force_float32_arch("gemma3_audio_only_pretend") is False
+
+
+def test_no_warning_on_bf16_to_fp32_upcast():
+    """Upcasts are safe; no warning even for gemma3."""
+    import torch
+    from unsloth_zoo.mlx.loader import _convert_mlx_dtype
+
+    model = _make_model({"w1": torch.bfloat16})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _convert_mlx_dtype(model, torch.float32, model_type="gemma3")
+
+    assert _bf_fp_msgs(caught) == []
+
+
 def test_no_warning_on_fp32_to_fp16_downcast():
-    """fp32->fp16 is lossy too but is a different (already-explicit) regime."""
+    """fp32->fp16 is a different (explicit) regime; no warning."""
     import torch
     from unsloth_zoo.mlx.loader import _convert_mlx_dtype
 
@@ -108,39 +142,27 @@ def test_no_warning_on_fp32_to_fp16_downcast():
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        _convert_mlx_dtype(model, torch.float16)
+        _convert_mlx_dtype(model, torch.float16, model_type="gemma3")
 
-    bf_fp_msgs = [
-        str(w.message) for w in caught
-        if "bfloat16" in str(w.message) and "float16" in str(w.message)
-    ]
-    assert bf_fp_msgs == [], (
-        f"Did not expect a bf16->fp16 warning for a fp32->fp16 cast; got: {bf_fp_msgs}"
-    )
+    assert _bf_fp_msgs(caught) == []
 
 
 def test_no_warning_when_no_cast_needed():
-    """All params already at target_dtype -> early return, no warnings."""
+    """All params already at target_dtype -> early return."""
     import torch
     from unsloth_zoo.mlx.loader import _convert_mlx_dtype
 
-    model = _make_model({"w1": torch.float16, "w2": torch.float16})
+    model = _make_model({"w1": torch.float16})
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        _convert_mlx_dtype(model, torch.float16)
+        _convert_mlx_dtype(model, torch.float16, model_type="gemma3")
 
-    bf_fp_msgs = [
-        str(w.message) for w in caught
-        if "bfloat16" in str(w.message) and "float16" in str(w.message)
-    ]
-    assert bf_fp_msgs == [], (
-        f"Did not expect a warning when no cast is needed; got: {bf_fp_msgs}"
-    )
+    assert _bf_fp_msgs(caught) == []
 
 
 def test_cast_still_happens_after_warning():
-    """The warning is advisory only — the requested cast still occurs."""
+    """The warning is advisory only — the cast still occurs."""
     import torch
     from unsloth_zoo.mlx.loader import _convert_mlx_dtype
 
@@ -148,8 +170,6 @@ def test_cast_still_happens_after_warning():
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        _convert_mlx_dtype(model, torch.float16)
+        _convert_mlx_dtype(model, torch.float16, model_type="gemma3")
 
-    # _FakeArray.astype returns a fresh _FakeArray with the new dtype,
-    # so the parameter tree now reflects the target dtype.
     assert model._params["w1"].dtype == torch.float16

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -104,6 +104,7 @@ if (os.environ.get("UNSLOTH_COMPILE_DEBUG", "0") == "1"):
 
 from importlib.util import find_spec
 from .mlx.runtime import is_mlx_available
+from .model_lists import FORCE_FLOAT32
 
 # Import-time fixes live in ``unsloth/import_fixes.py`` and run at
 # ``import unsloth`` time. Zoo cannot be imported standalone (the GPU

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -19,6 +19,7 @@ __all__ = [
     "get_transformers_model_type",
     "unsloth_compile_transformers",
     "create_new_function",
+    "FORCE_FLOAT32",
 ]
 
 from typing import Any, List, Optional, Tuple, Union, Dict, Set, Callable
@@ -136,6 +137,10 @@ DISABLE_COMPILE_FUNCTIONS = [
     "chunk_gated_delta_rule",
     "fused_recurrent_gated_delta_rule",
 ]
+
+# Re-exported from .model_lists so callers can keep using
+# `from unsloth_zoo.compiler import FORCE_FLOAT32`.
+from .model_lists import FORCE_FLOAT32  # noqa: E402,F401
 
 
 _full_license_header = """

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -92,14 +92,8 @@ def _convert_mlx_dtype(model, target_dtype) -> None:
     """Cast floating-point params to target_dtype (preserves quantized ints)
     while honoring the model's optional path-based ``cast_predicate``.
 
-    Emits a single warning when casting bfloat16 -> float16: fp16's finite
-    range (~6.5e4) is much narrower than bf16's (~3.4e38), so models whose
-    native storage is bf16 can lose precision or overflow silently. This
-    has been observed on Gemma3-270m: a stochastic LoRA memorization
-    fixture shows ~28pp lower greedy-decode pass rate under dtype="float16"
-    vs dtype=None against the same checkpoint. Cast still happens (users
-    asking for fp16 on M1/M2 need it); the warning just makes the
-    trade-off visible.
+    Warns once on bfloat16 -> float16 since fp16's narrower range can
+    silently lose precision on bf16-native models.
     """
     import mlx.core as mx
     from mlx.utils import tree_flatten, tree_map_with_path

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -88,15 +88,36 @@ def _temporary_hf_token_env(token):
                     os.environ[name] = value
 
 
-def _convert_mlx_dtype(model, target_dtype) -> None:
+def _is_force_float32_arch(model_type: str) -> bool:
+    """Case-insensitive lookup of ``model_type`` in
+    ``unsloth_zoo.FORCE_FLOAT32``. Strips ``-``/``_`` and treats a
+    trailing comma on a list entry as an exact-match marker."""
+    if not model_type:
+        return False
+    from ..model_lists import FORCE_FLOAT32
+    def _norm(s: str) -> str:
+        return s.lower().replace("-", "").replace("_", "")
+    norm_input = _norm(model_type)
+    for entry in FORCE_FLOAT32:
+        e = entry.lower()
+        if e.endswith(","):
+            e = e[:-1]
+        if _norm(e) == norm_input:
+            return True
+    return False
+
+
+def _convert_mlx_dtype(model, target_dtype, model_type: str = "") -> None:
     """Cast floating-point params to target_dtype (preserves quantized ints)
     while honoring the model's optional path-based ``cast_predicate``.
 
-    Warns once on bfloat16 -> float16 since fp16's narrower range can
-    silently lose precision on bf16-native models.
+    Warns on bfloat16 -> float16 for architectures in
+    ``unsloth_zoo.FORCE_FLOAT32`` (Gemma3 family, gpt_oss, Qwen3.5) where
+    fp16's narrower range silently NaN/Infs at training time.
     """
     import mlx.core as mx
     from mlx.utils import tree_flatten, tree_map_with_path
+    from ..model_lists import FORCE_FLOAT32
     cast_pred = getattr(model, "cast_predicate", lambda _: True)
 
     needs_cast = False
@@ -109,14 +130,11 @@ def _convert_mlx_dtype(model, target_dtype) -> None:
     if not needs_cast:
         return
 
-    if has_bf16 and target_dtype == mx.float16:
+    if has_bf16 and target_dtype == mx.float16 and _is_force_float32_arch(model_type):
         warnings.warn(
-            "Unsloth: downcasting bfloat16 weights to float16. fp16's "
-            "range (~6.5e4) is narrower than bf16's (~3.4e38); models "
-            "with large activations (e.g. Gemma3) can lose precision or "
-            "overflow silently. Pass dtype=None to keep native bf16, or "
-            "dtype='bfloat16' to be explicit, on bf16-capable Apple "
-            "Silicon (M3+). Pass dtype='float32' for full precision.",
+            f"Unsloth: downcasting bfloat16 -> float16 on {model_type!r}, "
+            "which is known to NaN/Inf in fp16. Pass dtype=None to keep "
+            "native bf16, or dtype='float32' for full precision.",
             stacklevel=2,
         )
 
@@ -2549,7 +2567,7 @@ class FastMLXModel:
                 )
 
             if target_dtype is not None:
-                _convert_mlx_dtype(model, target_dtype)
+                _convert_mlx_dtype(model, target_dtype, model_type=model_type)
             elif want_runtime_quant:
                 import mlx.core as mx
                 mx.eval(model.parameters())
@@ -2660,7 +2678,7 @@ class FastMLXModel:
                 )
 
             if target_dtype is not None:
-                _convert_mlx_dtype(model, target_dtype)
+                _convert_mlx_dtype(model, target_dtype, model_type=model_type)
             elif want_runtime_quant:
                 import mlx.core as mx
                 mx.eval(model.parameters())

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -91,18 +91,40 @@ def _temporary_hf_token_env(token):
 def _convert_mlx_dtype(model, target_dtype) -> None:
     """Cast floating-point params to target_dtype (preserves quantized ints)
     while honoring the model's optional path-based ``cast_predicate``.
+
+    Emits a single warning when casting bfloat16 -> float16: fp16's finite
+    range (~6.5e4) is much narrower than bf16's (~3.4e38), so models whose
+    native storage is bf16 can lose precision or overflow silently. This
+    has been observed on Gemma3-270m: a stochastic LoRA memorization
+    fixture shows ~28pp lower greedy-decode pass rate under dtype="float16"
+    vs dtype=None against the same checkpoint. Cast still happens (users
+    asking for fp16 on M1/M2 need it); the warning just makes the
+    trade-off visible.
     """
     import mlx.core as mx
     from mlx.utils import tree_flatten, tree_map_with_path
     cast_pred = getattr(model, "cast_predicate", lambda _: True)
 
     needs_cast = False
+    has_bf16 = False
     for k, v in tree_flatten(model.parameters()):
         if cast_pred(k) and mx.issubdtype(v.dtype, mx.floating) and v.dtype != target_dtype:
             needs_cast = True
-            break
+            if v.dtype == mx.bfloat16:
+                has_bf16 = True
     if not needs_cast:
         return
+
+    if has_bf16 and target_dtype == mx.float16:
+        warnings.warn(
+            "Unsloth: downcasting bfloat16 weights to float16. fp16's "
+            "range (~6.5e4) is narrower than bf16's (~3.4e38); models "
+            "with large activations (e.g. Gemma3) can lose precision or "
+            "overflow silently. Pass dtype=None to keep native bf16, or "
+            "dtype='bfloat16' to be explicit, on bf16-capable Apple "
+            "Silicon (M3+). Pass dtype='float32' for full precision.",
+            stacklevel=2,
+        )
 
     model.update(tree_map_with_path(
         lambda k, v: v.astype(target_dtype)

--- a/unsloth_zoo/model_lists.py
+++ b/unsloth_zoo/model_lists.py
@@ -28,9 +28,23 @@ __all__ = ["FORCE_FLOAT32"]
 # must run in bf16 or fp32. Loaded as float16 they silently NaN/Inf at
 # training time. Shared source of truth for the CUDA loader
 # (unsloth/models/loader.py) and the MLX loader (unsloth_zoo/mlx/loader.py).
+#
+# Entries are HuggingFace ``config.json`` ``model_type`` strings (the same
+# values returned by ``unsloth_zoo.hf_utils.get_transformers_model_type``).
+# Examples on the Hub:
+#   google/gemma-3-*            -> "gemma3"
+#   google/embeddinggemma-*     -> "gemma3_text"   (matches "gemma3text" after _ stripping)
+#   google/gemma-3n-*           -> "gemma3n"
+#   openai/gpt-oss-*            -> "gpt_oss"
+#   Qwen/Qwen3.5-*              -> "qwen3_5"
+# The CUDA loader matches via substring against a comma-joined model_types
+# string, so the trailing comma on "gemma3," keeps it from prefix-matching
+# "gemma3n". The MLX helper ``_is_force_float32_arch`` strips ``-``/``_``
+# and the trailing comma before comparing, so ``"gpt-oss"`` / ``"gpt_oss"``
+# and ``"gemma3_text"`` / ``"gemma3text"`` all resolve correctly.
 FORCE_FLOAT32 = [
-    "gemma3,",     # trailing comma so "gemma3" doesn't match "gemma3n"
-    "gemma3text",  # EmbeddingGemma / standalone text-only Gemma3
+    "gemma3,",     # trailing comma is a substring-path delimiter for the CUDA loader
+    "gemma3text",  # EmbeddingGemma / standalone text-only Gemma3 (config: "gemma3_text")
     "gemma3n",
     "gpt_oss",
     "qwen3_5",     # Qwen3.5 GDN layers NaN on fp16

--- a/unsloth_zoo/model_lists.py
+++ b/unsloth_zoo/model_lists.py
@@ -1,0 +1,37 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Shared cross-platform model lists.
+
+Lives in its own dependency-free module so it can be imported during
+unsloth_zoo's early init without dragging in compiler.py's torch/triton
+imports.
+"""
+
+__all__ = ["FORCE_FLOAT32"]
+
+
+# Architectures whose activations exceed fp16's finite range (~6.5e4) and
+# must run in bf16 or fp32. Loaded as float16 they silently NaN/Inf at
+# training time. Shared source of truth for the CUDA loader
+# (unsloth/models/loader.py) and the MLX loader (unsloth_zoo/mlx/loader.py).
+FORCE_FLOAT32 = [
+    "gemma3,",     # trailing comma so "gemma3" doesn't match "gemma3n"
+    "gemma3text",  # EmbeddingGemma / standalone text-only Gemma3
+    "gemma3n",
+    "gpt_oss",
+    "qwen3_5",     # Qwen3.5 GDN layers NaN on fp16
+]


### PR DESCRIPTION
## Summary
- `_convert_mlx_dtype` silently downcasts native bf16 weights to fp16 when the user passes `dtype="float16"` to `FastMLXModel.from_pretrained`.
- fp16's finite range (~6.5e4) is much narrower than bf16's (~3.4e38); models with large activations (e.g. Gemma3) can lose precision or overflow silently.
- This PR adds a one-line warning when that downcast is about to happen; the cast still runs (users on M1/M2 without native bf16 GPU support need fp16).

## Why
Empirical (gemma-3-270m-it, single-row LoRA memorization, n=15 seeds, otherwise-identical setup):

| dtype= | greedy-decode pass | cf_loss=0 (15 seeds) |
|---|---|---|
| `None` (keeps native bf16) | 47% | 15/15 |
| `"float16"` (silent bf16 -> fp16) | 15% | 15/15 |

The 32pp drop is entirely from the silent bf16 -> fp16 cast. Teacher-forced completion loss is `0` in both cases — the model memorizes either way; only the first-token greedy argmax distribution diverges. CI smoke gating per `unslothai/unsloth#5537` stays green either way, but greedy-decode behavior diverges noticeably enough that a user comparing fp16 vs bf16 runs would suspect a different bug.

Tracked alongside two earlier MLX-parity PRs:
- `unslothai/unsloth-zoo#669` — `finetune_last_n_layers` knob (layer-selection mismatch).
- `unslothai/unsloth#5564` — same knob, CUDA path.

This PR addresses factor (4) of the four-factor bisection ($\Delta$ pass rate vs `mlx_lm.load + manual loop + last-16 layers`):
1. Layer selection (`unsloth-zoo#669`)
2. `MLXTrainer` overhead vs manual loop (-14pp)
3. `FastMLXModel` loader patches (-10pp)
4. **bf16 -> fp16 downcast (-28pp) — this PR**

## Behavior
- `dtype="float16"` against a bf16-native model: cast still happens, warning logged via `warnings.warn(...)`.
- `dtype="bfloat16"` / `dtype=None` / `dtype="float32"`: no warning, no change.
- `dtype="float16"` against a fp32-native or fp16-native model: no warning (the bf16 -> fp16 specific regression doesn't apply).

The warning message points the user at `dtype=None` on bf16-capable Apple Silicon (M3+) and `dtype="float32"` for full precision.

## Test plan
- [x] `tests/test_mlx_dtype_downcast_warning.py` — five cases:
  - `bf16 -> fp16` emits the warning.
  - `bf16 -> fp32` (upcast) does NOT emit it.
  - `fp32 -> fp16` (different lossy regime) does NOT emit it.
  - No-cast-needed early return does NOT emit it.
  - Cast still mutates `model.parameters()` after the warning.
- [x] Local: `pytest tests/test_mlx_dtype_downcast_warning.py -v` -> 5 passed.