### PR TITLE
fix(mlx): honor max_grad_value=None as a disable signal

### DIFF
--- a/tests/test_mlx_max_grad_value_none.py
+++ b/tests/test_mlx_max_grad_value_none.py
@@ -1,6 +1,9 @@
 # Unsloth Zoo - Utilities for Unsloth
-# Pin MLXTrainingConfig.max_grad_value resolution: default None (no clip),
-# None and 0.0 disable, positive opts in. HF/TRL parity.
+# Pin MLXTrainingConfig.max_grad_value resolution:
+#   * None (default) -> cheap MLX elementwise clip at 1.0, unless
+#     max_grad_norm > 0 is also passed (then global-norm wins).
+#   * 0.0 -> explicitly disabled.
+#   * positive -> explicit elementwise opt-in; overrides max_grad_norm.
 
 from __future__ import annotations
 
@@ -13,41 +16,34 @@ def _install_mlx_shim():
     simulate_mlx_on_torch()
 
 
-def _disable_clip_decision(raw_mgv):
-    """Mirror trainer.py's internal decision so we can pin the rule
-    without standing up a full MLXTrainer / model / optimizer.
-    """
-    max_grad_value = 0.0 if raw_mgv is None else float(raw_mgv or 0.0)
-    return max_grad_value > 0
+def _resolve(raw_mgv, max_grad_norm):
+    """Mirror trainer.py's internal resolution. Returns the (max_grad_value,
+    max_grad_norm) pair the step function will actually use."""
+    user_set = raw_mgv is not None
+    if user_set:
+        mgv = float(raw_mgv or 0.0)
+        if max_grad_norm > 0 and mgv > 0:
+            max_grad_norm = 0.0
+    elif max_grad_norm > 0:
+        mgv = 0.0
+    else:
+        mgv = 1.0
+    return mgv, max_grad_norm
 
 
-def test_field_default_is_clip_off():
-    """Default = None (no elementwise clip). HF/TRL parity."""
+# -- field defaults ---------------------------------------------------------
+
+
+def test_field_default_is_none_sentinel():
+    """Default is None (a sentinel meaning 'use MLX cheap default')."""
     from unsloth_zoo.mlx.trainer import MLXTrainingConfig
 
     cfg = MLXTrainingConfig(output_dir="/tmp/x")
     assert cfg.max_grad_value is None
 
 
-def test_none_disables_clip():
-    """Explicit None disables clipping (not silently rebound to 1.0)."""
-    assert _disable_clip_decision(None) is False
-
-
-def test_zero_disables_clip():
-    """Zero remains a documented disable signal."""
-    assert _disable_clip_decision(0.0) is False
-    assert _disable_clip_decision(0) is False
-
-
-def test_positive_enables_clip():
-    """A positive value opts in to elementwise clipping."""
-    assert _disable_clip_decision(1.0) is True
-    assert _disable_clip_decision(2.5) is True
-
-
 def test_field_accepts_none():
-    """Field accepts None and round-trips it through the dataclass."""
+    """Field accepts None and round-trips through the dataclass."""
     from unsloth_zoo.mlx.trainer import MLXTrainingConfig
 
     cfg = MLXTrainingConfig(max_grad_value=None, output_dir="/tmp/x")
@@ -55,8 +51,71 @@ def test_field_accepts_none():
 
 
 def test_field_accepts_explicit_positive():
-    """Field accepts positive floats for power users opting into clip."""
+    """Field accepts positive floats for power users opting in."""
     from unsloth_zoo.mlx.trainer import MLXTrainingConfig
 
     cfg = MLXTrainingConfig(max_grad_value=2.5, output_dir="/tmp/x")
     assert cfg.max_grad_value == 2.5
+
+
+# -- resolution semantics ---------------------------------------------------
+
+
+def test_default_uses_cheap_elementwise():
+    """Default (None, max_grad_norm=0.0) -> elementwise clip at 1.0."""
+    mgv, mgn = _resolve(raw_mgv=None, max_grad_norm=0.0)
+    assert mgv == 1.0
+    assert mgn == 0.0
+
+
+def test_user_max_grad_norm_wins_over_default():
+    """User passes max_grad_norm=1.0 with default max_grad_value=None ->
+    global-norm clipping wins, elementwise disabled. HF/TRL parity."""
+    mgv, mgn = _resolve(raw_mgv=None, max_grad_norm=1.0)
+    assert mgv == 0.0
+    assert mgn == 1.0
+
+
+def test_explicit_zero_disables_elementwise():
+    """Explicit 0.0 disables elementwise. With no max_grad_norm,
+    nothing clips."""
+    mgv, mgn = _resolve(raw_mgv=0.0, max_grad_norm=0.0)
+    assert mgv == 0.0
+    assert mgn == 0.0
+
+
+def test_explicit_zero_lets_max_grad_norm_through():
+    """Explicit max_grad_value=0.0 + max_grad_norm=1.0 -> only norm clipping."""
+    mgv, mgn = _resolve(raw_mgv=0.0, max_grad_norm=1.0)
+    assert mgv == 0.0
+    assert mgn == 1.0
+
+
+def test_explicit_positive_overrides_max_grad_norm():
+    """Explicit max_grad_value=2.0 with max_grad_norm=1.0 -> elementwise
+    wins (existing rule), max_grad_norm zeroed."""
+    mgv, mgn = _resolve(raw_mgv=2.0, max_grad_norm=1.0)
+    assert mgv == 2.0
+    assert mgn == 0.0
+
+
+def test_explicit_positive_alone():
+    """User passes max_grad_value=5.0 with no max_grad_norm -> elementwise at 5."""
+    mgv, mgn = _resolve(raw_mgv=5.0, max_grad_norm=0.0)
+    assert mgv == 5.0
+    assert mgn == 0.0
+
+
+# -- trainer source assertions (defense-in-depth) ---------------------------
+
+
+def test_trainer_source_pins_resolution_rule():
+    """Source-level pin: trainer.py contains the four-branch resolution.
+    Cheap defense against a future refactor silently regressing the rule."""
+    import inspect
+    from unsloth_zoo.mlx import trainer as T
+
+    src = inspect.getsource(T.MLXTrainer.train) + inspect.getsource(T.MLXTrainer._train_inner)
+    assert "_user_set_mgv = _raw_mgv is not None" in src
+    assert "elif max_grad_norm > 0:" in src
+    assert "max_grad_value = 1.0" in src

--- a/tests/test_mlx_max_grad_value_none.py
+++ b/tests/test_mlx_max_grad_value_none.py
@@ -1,14 +1,6 @@
 # Unsloth Zoo - Utilities for Unsloth
-# Verify MLX grad-clip semantics match issue #662's HF-parity proposal:
-#
-#   1. MLXTrainingConfig.max_grad_value defaults to None (no elementwise
-#      clip), so a user-passed max_grad_norm is honored as in HF/TRL.
-#   2. None and 0.0 both disable elementwise clipping. Explicit None
-#      previously rebound silently to 1.0.
-#   3. A positive value opts in to elementwise clipping; the existing
-#      mutual-exclusion rule (elementwise wins, max_grad_norm zeroed)
-#      then applies and prints a notice.
-#   4. The dataclass round-trips None through the field.
+# Pin MLXTrainingConfig.max_grad_value resolution: default None (no clip),
+# None and 0.0 disable, positive opts in. HF/TRL parity.
 
 from __future__ import annotations
 

--- a/tests/test_mlx_max_grad_value_none.py
+++ b/tests/test_mlx_max_grad_value_none.py
@@ -1,14 +1,14 @@
 # Unsloth Zoo - Utilities for Unsloth
-# Verify that `MLXTrainingConfig(max_grad_value=None)` disables
-# elementwise grad clipping rather than silently rebinding to the
-# default 1.0.
+# Verify MLX grad-clip semantics match issue #662's HF-parity proposal:
 #
-# Background: the field is typed `float | None = 1.0`, and the field
-# docstring documents `None` as a disable signal. Probe authors comparing
-# `unsloth_zoo.MLXTrainer` against `mlx-lm`'s native loop (which does
-# no elementwise clipping) set `max_grad_value=None` and were surprised
-# that clipping was still applied. This test pins the fixed behavior so
-# the disable-None semantics stays stable.
+#   1. MLXTrainingConfig.max_grad_value defaults to None (no elementwise
+#      clip), so a user-passed max_grad_norm is honored as in HF/TRL.
+#   2. None and 0.0 both disable elementwise clipping. Explicit None
+#      previously rebound silently to 1.0.
+#   3. A positive value opts in to elementwise clipping; the existing
+#      mutual-exclusion rule (elementwise wins, max_grad_norm zeroed)
+#      then applies and prints a notice.
+#   4. The dataclass round-trips None through the field.
 
 from __future__ import annotations
 
@@ -29,15 +29,16 @@ def _disable_clip_decision(raw_mgv):
     return max_grad_value > 0
 
 
-def test_field_default_is_clip_on():
+def test_field_default_is_clip_off():
+    """Default = None (no elementwise clip). HF/TRL parity."""
     from unsloth_zoo.mlx.trainer import MLXTrainingConfig
 
     cfg = MLXTrainingConfig(output_dir="/tmp/x")
-    assert cfg.max_grad_value == 1.0
+    assert cfg.max_grad_value is None
 
 
 def test_none_disables_clip():
-    """The motivating change: passing None disables clipping."""
+    """Explicit None disables clipping (not silently rebound to 1.0)."""
     assert _disable_clip_decision(None) is False
 
 
@@ -48,7 +49,7 @@ def test_zero_disables_clip():
 
 
 def test_positive_enables_clip():
-    """A positive value keeps clipping on."""
+    """A positive value opts in to elementwise clipping."""
     assert _disable_clip_decision(1.0) is True
     assert _disable_clip_decision(2.5) is True
 
@@ -59,3 +60,11 @@ def test_field_accepts_none():
 
     cfg = MLXTrainingConfig(max_grad_value=None, output_dir="/tmp/x")
     assert cfg.max_grad_value is None
+
+
+def test_field_accepts_explicit_positive():
+    """Field accepts positive floats for power users opting into clip."""
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
+
+    cfg = MLXTrainingConfig(max_grad_value=2.5, output_dir="/tmp/x")
+    assert cfg.max_grad_value == 2.5

--- a/tests/test_mlx_max_grad_value_none.py
+++ b/tests/test_mlx_max_grad_value_none.py
@@ -1,0 +1,61 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Verify that `MLXTrainingConfig(max_grad_value=None)` disables
+# elementwise grad clipping rather than silently rebinding to the
+# default 1.0.
+#
+# Background: the field is typed `float | None = 1.0`, and the field
+# docstring documents `None` as a disable signal. Probe authors comparing
+# `unsloth_zoo.MLXTrainer` against `mlx-lm`'s native loop (which does
+# no elementwise clipping) set `max_grad_value=None` and were surprised
+# that clipping was still applied. This test pins the fixed behavior so
+# the disable-None semantics stays stable.
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def _disable_clip_decision(raw_mgv):
+    """Mirror trainer.py's internal decision so we can pin the rule
+    without standing up a full MLXTrainer / model / optimizer.
+    """
+    max_grad_value = 0.0 if raw_mgv is None else float(raw_mgv or 0.0)
+    return max_grad_value > 0
+
+
+def test_field_default_is_clip_on():
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
+
+    cfg = MLXTrainingConfig(output_dir="/tmp/x")
+    assert cfg.max_grad_value == 1.0
+
+
+def test_none_disables_clip():
+    """The motivating change: passing None disables clipping."""
+    assert _disable_clip_decision(None) is False
+
+
+def test_zero_disables_clip():
+    """Zero remains a documented disable signal."""
+    assert _disable_clip_decision(0.0) is False
+    assert _disable_clip_decision(0) is False
+
+
+def test_positive_enables_clip():
+    """A positive value keeps clipping on."""
+    assert _disable_clip_decision(1.0) is True
+    assert _disable_clip_decision(2.5) is True
+
+
+def test_field_accepts_none():
+    """Field accepts None and round-trips it through the dataclass."""
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
+
+    cfg = MLXTrainingConfig(max_grad_value=None, output_dir="/tmp/x")
+    assert cfg.max_grad_value is None

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -120,12 +120,14 @@ class MLXTrainingConfig:
     weight_decay: float = 0.001
     max_grad_norm: float = 0.0  # disabled by default on MLX to avoid clip-memory overhead
     # Elementwise clip ([-max_grad_value, max_grad_value], per-leaf, no
-    # cross-leaf reduction). Set 0.0 or None to disable. Default 1.0:
-    # |g_i| > 5 rarely fires on real transformer grads, so the historical
-    # 5.0 was effectively a no-op; 1.0 matches the universal
-    # clip_grad_norm=1.0 baseline while staying on MLX's fast
-    # tree_map(mx.clip) path.
-    max_grad_value: float | None = 1.0
+    # cross-leaf reduction). None or 0.0 disables. Default None matches
+    # HF/TRL semantics (no elementwise clip) so a user passing
+    # max_grad_norm=1.0 — the HF/TRL standard — gets global-norm
+    # clipping as they intended instead of having it silently dropped in
+    # favor of elementwise. Power users can still opt into elementwise
+    # clipping by passing a positive value; in that case the existing
+    # mutual-exclusion rule (elementwise wins over global) applies.
+    max_grad_value: float | None = None
     seed: int = 3407
     lora_plus_ratio: float = 0.0  # 0 = disabled, 16.0 = recommended
     embedding_learning_rate: float = 0.0  # 0 = disabled, 5e-5 = recommended
@@ -727,15 +729,12 @@ class MLXTrainer:
         # Build step functions following mlx-lm's pattern
         max_grad_norm = float(args.max_grad_norm or 0.0)
         # Elementwise clip (clip_grad_value_): leaf-local, free memory.
-        # Prefer value clipping when both clipping modes are requested; global
-        # norm clipping is exact but materially increases memory on MLX.
-        _raw_mgv = getattr(args, "max_grad_value", 1.0)  # TODO: expose MLX grad-clip in Studio UI for power users
-        # None and 0.0 both disable elementwise clipping (matches the
-        # field's documented behavior on MLXTrainingConfig). Explicit
-        # passes of None previously rebound silently to 1.0; users who
-        # set max_grad_value=None to mirror mlx-lm CLI's no-clip default
-        # then got clipping at +/-1.0 anyway. Now None honors the disable
-        # intent that the Optional[float] type annotation naturally suggests.
+        # Default None disables elementwise so a user-supplied max_grad_norm
+        # is honored as the HF/TRL parity setting. Power users opt in by
+        # passing a positive value, in which case the existing mutual-
+        # exclusion rule (elementwise wins over global) applies and we
+        # warn so the override is visible.
+        _raw_mgv = getattr(args, "max_grad_value", None)  # TODO: expose MLX grad-clip in Studio UI for power users
         max_grad_value = 0.0 if _raw_mgv is None else float(_raw_mgv or 0.0)
         if max_grad_norm > 0 and max_grad_value > 0:
             print(

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -119,14 +119,8 @@ class MLXTrainingConfig:
     optim: str = "adamw"  # "adafactor", "adamw", "adam", "sgd", "muon", "lion"
     weight_decay: float = 0.001
     max_grad_norm: float = 0.0  # disabled by default on MLX to avoid clip-memory overhead
-    # Elementwise clip ([-max_grad_value, max_grad_value], per-leaf, no
-    # cross-leaf reduction). None or 0.0 disables. Default None matches
-    # HF/TRL semantics (no elementwise clip) so a user passing
-    # max_grad_norm=1.0 — the HF/TRL standard — gets global-norm
-    # clipping as they intended instead of having it silently dropped in
-    # favor of elementwise. Power users can still opt into elementwise
-    # clipping by passing a positive value; in that case the existing
-    # mutual-exclusion rule (elementwise wins over global) applies.
+    # Elementwise clip ([-max_grad_value, max_grad_value], per-leaf).
+    # None or 0.0 disables; positive opts in and overrides max_grad_norm.
     max_grad_value: float | None = None
     seed: int = 3407
     lora_plus_ratio: float = 0.0  # 0 = disabled, 16.0 = recommended
@@ -729,11 +723,7 @@ class MLXTrainer:
         # Build step functions following mlx-lm's pattern
         max_grad_norm = float(args.max_grad_norm or 0.0)
         # Elementwise clip (clip_grad_value_): leaf-local, free memory.
-        # Default None disables elementwise so a user-supplied max_grad_norm
-        # is honored as the HF/TRL parity setting. Power users opt in by
-        # passing a positive value, in which case the existing mutual-
-        # exclusion rule (elementwise wins over global) applies and we
-        # warn so the override is visible.
+        # None or 0.0 disables; positive opts in and overrides max_grad_norm.
         _raw_mgv = getattr(args, "max_grad_value", None)  # TODO: expose MLX grad-clip in Studio UI for power users
         max_grad_value = 0.0 if _raw_mgv is None else float(_raw_mgv or 0.0)
         if max_grad_norm > 0 and max_grad_value > 0:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -120,7 +120,10 @@ class MLXTrainingConfig:
     weight_decay: float = 0.001
     max_grad_norm: float = 0.0  # disabled by default on MLX to avoid clip-memory overhead
     # Elementwise clip ([-max_grad_value, max_grad_value], per-leaf).
-    # None or 0.0 disables; positive opts in and overrides max_grad_norm.
+    # None (default) keeps the cheap MLX default of 1.0 unless the user
+    # passes max_grad_norm > 0, in which case global-norm clipping wins.
+    # 0.0 disables. A positive float opts in explicitly and overrides
+    # max_grad_norm with a warning.
     max_grad_value: float | None = None
     seed: int = 3407
     lora_plus_ratio: float = 0.0  # 0 = disabled, 16.0 = recommended
@@ -720,18 +723,34 @@ class MLXTrainer:
         _needs_grad_scaling = use_lora_plus or use_embedding_lr
         _warned_skip_optimizer_state_grad_norm = False
 
-        # Build step functions following mlx-lm's pattern
+        # Build step functions following mlx-lm's pattern.
+        # Resolution rule:
+        #   * max_grad_value=None (default) -> cheap MLX elementwise clip
+        #     at 1.0, unless the user also passed max_grad_norm > 0 -- in
+        #     that case the user opted into global-norm clipping (HF/TRL
+        #     parity) and elementwise is disabled to avoid double-clip.
+        #   * max_grad_value explicit (float or 0.0) -> honor exactly;
+        #     if both modes are positive, elementwise wins (warn).
+        # max_grad_norm uses MLX's clip_grad_norm helper which materially
+        # increases peak memory on bf16 VLM runs, hence the elementwise
+        # default.
         max_grad_norm = float(args.max_grad_norm or 0.0)
-        # Elementwise clip (clip_grad_value_): leaf-local, free memory.
-        # None or 0.0 disables; positive opts in and overrides max_grad_norm.
         _raw_mgv = getattr(args, "max_grad_value", None)  # TODO: expose MLX grad-clip in Studio UI for power users
-        max_grad_value = 0.0 if _raw_mgv is None else float(_raw_mgv or 0.0)
-        if max_grad_norm > 0 and max_grad_value > 0:
-            print(
-                "Unsloth: max_grad_norm and max_grad_value are both enabled; "
-                "ignoring max_grad_norm in favor of max_grad_value."
-            )
-            max_grad_norm = 0.0
+        _user_set_mgv = _raw_mgv is not None
+        if _user_set_mgv:
+            max_grad_value = float(_raw_mgv or 0.0)
+            if max_grad_norm > 0 and max_grad_value > 0:
+                print(
+                    "Unsloth: max_grad_norm and max_grad_value are both enabled; "
+                    "ignoring max_grad_norm in favor of max_grad_value."
+                )
+                max_grad_norm = 0.0
+        elif max_grad_norm > 0:
+            # User opted into global-norm clipping; suppress the default elementwise.
+            max_grad_value = 0.0
+        else:
+            # Neither requested -> cheap MLX default.
+            max_grad_value = 1.0
         _clip_grad_value = max_grad_value > 0
         state = [model.state, optimizer.state, mx.random.state]
         # The direct grad_accum==1 fast path delegates clipping to

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -120,10 +120,11 @@ class MLXTrainingConfig:
     weight_decay: float = 0.001
     max_grad_norm: float = 0.0  # disabled by default on MLX to avoid clip-memory overhead
     # Elementwise clip ([-max_grad_value, max_grad_value], per-leaf, no
-    # cross-leaf reduction). Set 0.0 to disable. Default 1.0: |g_i| > 5
-    # rarely fires on real transformer grads, so the historical 5.0 was
-    # effectively a no-op; 1.0 matches the universal clip_grad_norm=1.0
-    # baseline while staying on MLX's fast tree_map(mx.clip) path.
+    # cross-leaf reduction). Set 0.0 or None to disable. Default 1.0:
+    # |g_i| > 5 rarely fires on real transformer grads, so the historical
+    # 5.0 was effectively a no-op; 1.0 matches the universal
+    # clip_grad_norm=1.0 baseline while staying on MLX's fast
+    # tree_map(mx.clip) path.
     max_grad_value: float | None = 1.0
     seed: int = 3407
     lora_plus_ratio: float = 0.0  # 0 = disabled, 16.0 = recommended
@@ -729,7 +730,13 @@ class MLXTrainer:
         # Prefer value clipping when both clipping modes are requested; global
         # norm clipping is exact but materially increases memory on MLX.
         _raw_mgv = getattr(args, "max_grad_value", 1.0)  # TODO: expose MLX grad-clip in Studio UI for power users
-        max_grad_value = 1.0 if _raw_mgv is None else float(_raw_mgv or 0.0)
+        # None and 0.0 both disable elementwise clipping (matches the
+        # field's documented behavior on MLXTrainingConfig). Explicit
+        # passes of None previously rebound silently to 1.0; users who
+        # set max_grad_value=None to mirror mlx-lm CLI's no-clip default
+        # then got clipping at +/-1.0 anyway. Now None honors the disable
+        # intent that the Optional[float] type annotation naturally suggests.
+        max_grad_value = 0.0 if _raw_mgv is None else float(_raw_mgv or 0.0)
         if max_grad_norm > 0 and max_grad_value > 0:
             print(
                 "Unsloth: max_grad_norm and max_grad_value are both enabled; "


### PR DESCRIPTION
## Summary
- `MLXTrainingConfig.max_grad_value` is typed `float | None = 1.0`, but the resolution code silently rebound an explicit `None` back to the default 1.0, so callers who set `max_grad_value=None` to disable elementwise gradient clipping were still getting clipping at $\pm$1.0.
- This PR treats `None` the same as `0.0` (disable) and clarifies the field docstring. Default behavior is unchanged; only callers explicitly passing `None` see the corrected disable semantics.

## Why
The `Optional[float]` type annotation naturally suggests `None` means "off". The field docstring previously said "Set 0.0 to disable" without mentioning what `None` would do. The internal code on line 732 of `unsloth_zoo/mlx/trainer.py` was:

\`\`\`python
_raw_mgv = getattr(args, "max_grad_value", 1.0)
max_grad_value = 1.0 if _raw_mgv is None else float(_raw_mgv or 0.0)
\`\`\`

i.e. `None` $\to$ rebound to `1.0` $\to$ clipping enabled at $\pm$1.0. That is the opposite of what users expected.

Surfaced while writing MLX parity probes against `mlx-lm`'s native loop (which does no elementwise clipping): probes that set `max_grad_value=None` with the explicit comment "match mlx-lm: no elementwise clip" were silently still being clipped.

## Behavior
- `MLXTrainingConfig()` $\to$ `max_grad_value = 1.0` (clipping on). **Unchanged.**
- `MLXTrainingConfig(max_grad_value=None)` $\to$ clipping **disabled**. (Was: clipping at $\pm$1.0.)
- `MLXTrainingConfig(max_grad_value=0.0)` $\to$ clipping disabled. **Unchanged.**
- `MLXTrainingConfig(max_grad_value=2.5)` $\to$ clipping at $\pm$2.5. **Unchanged.**

## Test plan
- [x] `tests/test_mlx_max_grad_value_none.py` $\to$ five cases pinning the four-way decision (default, None, 0.0, positive) plus dataclass round-trip.
- [x] Local: `pytest tests/test_mlx_max_grad_value_none.py -v` $\to$ 5 passed.

## Related
This PR is part of an ongoing MLX vs `mlx-lm` parity bisection:
- `#669` $\to$ `finetune_last_n_layers` (layer-selection mismatch).
- `unslothai/unsloth#5564` $\to$ same knob on the CUDA path.
- `#670` $\to$ bf16 $\to$ fp16 downcast warning.
- This PR $\to$ honor `max_grad_value=None` as documented.