### PR TITLE
fix(mlx): make_baseline_loss_fn byte-identical to mlx-lm default_loss when labels=None

### DIFF
--- a/tests/test_mlx_baseline_loss_parity.py
+++ b/tests/test_mlx_baseline_loss_parity.py
@@ -1,0 +1,124 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Pin `make_baseline_loss_fn` source so the labels=None fast path stays
+# byte-for-byte equivalent to mlx_lm.tuner.trainer.default_loss.
+#
+# Why pin source rather than run a numerical comparison: the test
+# harness uses a torch-based MLX shim that doesn't faithfully reproduce
+# MLX's autodiff graph or its rounding; an apples-to-apples numerical
+# parity check requires a real MLX runtime (Apple Silicon), so it's
+# done in the Round BP probe matrix on
+# danielhanchen/unsloth-staging-2. Locally we guard against future
+# refactors silently re-introducing the divergent code patterns
+# (fp32-cast mask, mx.where(safe_targets), _safe_token_denominator)
+# that mlx_lm.tuner.trainer.default_loss does NOT do.
+
+from __future__ import annotations
+
+import inspect
+import re
+import textwrap
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def _labels_none_block():
+    """Return CODE LINES (comments stripped) for the labels=None fast path."""
+    from unsloth_zoo.mlx import utils
+    src = inspect.getsource(utils.make_baseline_loss_fn)
+    m = re.search(
+        r"if labels is None:\s*\n(.*?)(?:# labels-aware path|else:\s*\n)",
+        src,
+        flags=re.DOTALL,
+    )
+    assert m, "make_baseline_loss_fn must keep a `labels is None` fast path"
+    raw = textwrap.dedent(m.group(1))
+    # Strip whole-line comments so test assertions on code don't trip on
+    # explanatory prose like "no safe_targets mx.where" in docstrings.
+    code_lines = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        code_lines.append(line)
+    return "\n".join(code_lines)
+
+
+def test_no_fp32_mask_cast_in_fast_path():
+    """The labels=None path must NOT cast the bool mask to fp32. mlx-lm's
+    default_loss multiplies the cross-entropy result by a raw bool mask;
+    casting to fp32 produces a different MLX autodiff graph and shifts
+    gradients by ~1e-2 per step on small fixtures."""
+    block = _labels_none_block()
+    # Anything that would cast a mask to fp32: `.astype(mx.float32)` or
+    # `astype(float32)` immediately on a `mask` / `length_mask` name.
+    bad_patterns = (
+        r"length_mask\.astype\(mx\.float32\)",
+        r"mask\s*=\s*[^=]*\.astype\(mx\.float32\)",
+    )
+    for pat in bad_patterns:
+        assert not re.search(pat, block), (
+            f"labels=None fast path must not contain `{pat}`; "
+            "matches mlx-lm requires a bool mask."
+        )
+
+
+def test_no_safe_targets_where_in_fast_path():
+    """The labels=None path has no -100 to worry about, so no mx.where
+    is needed on targets. The where node was empirically the cause of
+    step-2 loss divergence vs mlx-lm CLI (Round BO probe_31 vs probe_37)."""
+    block = _labels_none_block()
+    assert "mx.where" not in block, (
+        "labels=None fast path must not include mx.where on targets; "
+        "mlx-lm's default_loss does not call mx.where."
+    )
+    assert "safe_targets" not in block, (
+        "labels=None fast path must use `targets` directly; "
+        "`safe_targets = mx.where(...)` belongs only to the labels-aware path."
+    )
+
+
+def test_no_safe_token_denominator_in_fast_path():
+    """mlx-lm's default_loss divides by raw `ntoks` (int). The fast path
+    must match that to preserve the autodiff graph; the safety wrapper
+    `_safe_token_denominator` introduces a fp32 cast + maximum() that
+    changes rounding in MLX."""
+    block = _labels_none_block()
+    assert "_safe_token_denominator" not in block, (
+        "labels=None fast path must divide by raw ntoks for mlx-lm parity. "
+        "_safe_token_denominator is fine on the labels-aware path."
+    )
+
+
+def test_fast_path_returns_ce_and_ntoks_in_that_order():
+    """Match the (loss, ntoks) return signature mlx-lm uses; the test
+    pins return-order so a future refactor doesn't accidentally swap."""
+    block = _labels_none_block()
+    # Look for a `return X, Y` somewhere in the fast path. The variable
+    # names are loose (mlx-lm uses `ce`; zoo previously used `loss`),
+    # but the order matters.
+    m = re.search(r"return\s+(\w+),\s*(\w+)", block)
+    assert m, "labels=None fast path must return a (loss, ntoks) tuple"
+    loss_name, ntoks_name = m.group(1), m.group(2)
+    assert ntoks_name in ("ntoks", "n_toks", "ntokens"), (
+        f"second return value name should look like a token count, got "
+        f"{ntoks_name!r}"
+    )
+
+
+def test_labels_aware_path_still_uses_safe_targets():
+    """The labels-aware path (train_on_responses_only) DOES need
+    `safe_targets` and the fp32 mask because labels can contain -100."""
+    from unsloth_zoo.mlx import utils
+    src = inspect.getsource(utils.make_baseline_loss_fn)
+    # The labels-aware path lives after the fast path's `return`. Look
+    # at the full source to verify the machinery still exists somewhere.
+    assert "mx.where" in src, (
+        "make_baseline_loss_fn must still call mx.where on the labels-aware path"
+    )
+    assert "safe_targets" in src, "labels-aware path must keep safe_targets"

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -412,25 +412,12 @@ def make_baseline_loss_fn():
     Returns:
         A function (model, batch, lengths, labels=None) -> (loss, ntoks).
         When labels is provided, uses labels[:,1:] for targets with
-        (targets != -100) as the loss mask.
-
-    Numerical parity with mlx-lm:
-        The labels=None path is intentionally byte-identical to
-        ``mlx_lm.tuner.trainer.default_loss``. The labels-aware path
-        adds the -100 / safe_targets / fp32-mask machinery needed for
-        train_on_responses_only. Keeping the two paths separated means
-        that running zoo's MLXTrainer with no per-token label mask
-        produces value-for-value identical loss AND gradient sequences
-        to mlx-lm CLI on the same data + seed.
+        (targets != -100) as the loss mask. The labels=None branch is
+        byte-identical to ``mlx_lm.tuner.trainer.default_loss``.
     """
     def loss_fn(model, batch, lengths, labels=None):
         if labels is None:
-            # mlx-lm parity fast path. Matches mlx_lm.tuner.trainer.default_loss
-            # byte-for-byte: bool mask (not fp32 cast), raw ntoks division (not
-            # _safe_token_denominator), no `safe_targets` mx.where. Differences
-            # of that kind altered the autodiff graph and produced ~0.01-0.06
-            # step-2 loss divergence vs mlx-lm CLI on identical configs
-            # (gemma-3-270m-it, see Round BO probe_31/probe_37 paired-seed data).
+            # byte-identical to mlx_lm.tuner.trainer.default_loss
             inputs = batch[:, :-1]
             targets = batch[:, 1:]
             logits = model(inputs)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -413,20 +413,40 @@ def make_baseline_loss_fn():
         A function (model, batch, lengths, labels=None) -> (loss, ntoks).
         When labels is provided, uses labels[:,1:] for targets with
         (targets != -100) as the loss mask.
+
+    Numerical parity with mlx-lm:
+        The labels=None path is intentionally byte-identical to
+        ``mlx_lm.tuner.trainer.default_loss``. The labels-aware path
+        adds the -100 / safe_targets / fp32-mask machinery needed for
+        train_on_responses_only. Keeping the two paths separated means
+        that running zoo's MLXTrainer with no per-token label mask
+        produces value-for-value identical loss AND gradient sequences
+        to mlx-lm CLI on the same data + seed.
     """
     def loss_fn(model, batch, lengths, labels=None):
         if labels is None:
-            inputs, targets = batch[:, :-1], batch[:, 1:]
-        else:
+            # mlx-lm parity fast path. Matches mlx_lm.tuner.trainer.default_loss
+            # byte-for-byte: bool mask (not fp32 cast), raw ntoks division (not
+            # _safe_token_denominator), no `safe_targets` mx.where. Differences
+            # of that kind altered the autodiff graph and produced ~0.01-0.06
+            # step-2 loss divergence vs mlx-lm CLI on identical configs
+            # (gemma-3-270m-it, see Round BO probe_31/probe_37 paired-seed data).
             inputs = batch[:, :-1]
-            targets = labels[:, 1:]
+            targets = batch[:, 1:]
+            logits = model(inputs)
+            steps = mx.arange(1, targets.shape[1] + 1)
+            mask = mx.logical_and(steps >= lengths[:, 0:1], steps <= lengths[:, 1:])
+            ce = nn.losses.cross_entropy(logits, targets) * mask
+            ntoks = mask.sum()
+            ce = ce.astype(mx.float32).sum() / ntoks
+            return ce, ntoks
+        # labels-aware path: train_on_responses_only style masking.
+        inputs = batch[:, :-1]
+        targets = labels[:, 1:]
         logits = model(inputs)
         steps = mx.arange(1, targets.shape[1] + 1)
         length_mask = mx.logical_and(steps >= lengths[:, 0:1], steps <= lengths[:, 1:])
-        if labels is None:
-            mask = length_mask.astype(mx.float32)
-        else:
-            mask = mx.logical_and(targets != -100, length_mask).astype(mx.float32)
+        mask = mx.logical_and(targets != -100, length_mask).astype(mx.float32)
         # Replace -100 with 0 before CE — MLX has no ignore_index;
         # the mask already zeros out these positions in the loss.
         safe_targets = mx.where(targets == -100, 0, targets)


### PR DESCRIPTION
## Summary
`make_baseline_loss_fn` previously routed both the `labels=None` case and the labels-aware case through the same code, with three small differences from `mlx_lm.tuner.trainer.default_loss`:

1. mask cast to fp32 (`length_mask.astype(mx.float32)`) instead of leaving the bool mask alone.
2. `safe_targets = mx.where(targets == -100, 0, targets)` even when there are no -100 entries in the `labels=None` path.
3. division by `_safe_token_denominator(ntoks)` (fp32 cast + maximum with 1.0) instead of raw `ce.sum() / ntoks`.

This PR restructures the function so the `labels=None` branch is byte-for-byte identical to mlx-lm's `default_loss`; the labels-aware branch keeps the existing -100 / safe_targets / fp32-mask machinery (it needs all three).

## Why
Mathematically all three differences are no-ops when there are no -100 entries (i.e. on the `labels=None` path), but each adds an extra node to the MLX autodiff graph and changes rounding inside the backward pass.

Empirical (`unsloth/gemma-3-270m-it` single-row LoRA memorization, paired-seed data from `danielhanchen/unsloth-staging-2` Round BO probes 31 (mlx-lm manual loop) vs 35 / 37 (zoo MLXTrainer), 5 representative seeds):

| step | probe 31 (mlx-lm) | probe 35 (zoo, compile=True) | probe 37 (zoo, compile=False, no clip) | $\Delta$ probe 31 - probe 35 |
|---|---|---|---|---|
| 1 | 9.769231 | 9.769231 | 9.769231 | 0 |
| 2 | 5.254807 | 5.276443 | 5.276443 | -0.021635 |
| 3 | 3.206731 | 3.221154 | 3.221154 | -0.014423 |
| 4 | 1.894231 | 1.947115 | 1.947115 | -0.052885 |
| 5 | 1.163462 | 1.168269 | 1.180288 | -0.004808 |
| 28+ | 0 | 0 | 0 | 0 |

Step 1's forward loss is identical (same initial weights, same data), but the gradient applied at step 1 differs between mlx-lm and zoo — so step 2 onward the loss curves are 0.01-0.06 apart until both converge to 0. The model still memorizes either way (`cf_loss = 0` in 15/15 seeds for every config). But callers cannot reproduce mlx-lm CLI's loss curve numerically, which makes diagnostic side-by-side comparisons useless.

After this PR the `labels=None` fast path produces an autodiff graph value-for-value identical to `mlx_lm.tuner.trainer.default_loss`, so probes against the same fixture should converge value-for-value with mlx-lm CLI.

## Behavior
- `loss_fn(model, batch, lengths)` (no labels) $\to$ identical numerical path to `mlx_lm.tuner.trainer.default_loss`. **Changed (parity).**
- `loss_fn(model, batch, lengths, labels)` (labels-aware, e.g. `train_on_responses_only`) $\to$ existing path with fp32 mask, `safe_targets`, `_safe_token_denominator`. **Unchanged.**

## Test plan
- [x] `tests/test_mlx_baseline_loss_parity.py` $\to$ 5 source-level assertions pinning the fast-path code patterns. Guards against future refactors silently re-introducing `length_mask.astype(mx.float32)`, `mx.where(safe_targets)`, or `_safe_token_denominator` on the `labels=None` branch. Verifies the labels-aware path still uses `safe_targets`.
- [x] Local: `pytest tests/test_mlx_baseline_loss_parity.py -v` $\to$ 5 passed.
- [x] Broader regression: `pytest tests/test_pr_a_*.py tests/test_mlx_*.py` $\to$ 58 passed, 1 skipped, no regressions.
- [ ] Round BP probe 38 on Apple Silicon (in flight) captures per-step loss + grad_norm for both paths to confirm value-for-value parity at all steps after this fix.

## Related
Sixth PR in the MLX vs `mlx-lm` parity series:
- `#669` $\to$ `finetune_last_n_layers` knob (zoo).
- `unslothai/unsloth#5564` $\to$ same knob, CUDA path.
- `#670` $\to$ warn on bf16$\to$fp16 downcast.
- `#671` $\to$ `max_grad_value=None` default + HF/TRL parity (closes `#662`).
- `#672` $\to$ `_create_labeled_batches` padding matches mlx-lm.
- This PR $\to$ `make_baseline_loss_fn` `labels=None` fast path matches mlx-lm.