### PR TITLE
Honour offline env vars when enabling hf_transfer

### DIFF
--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -23,8 +23,18 @@ import re
 if "TOKENIZERS_PARALLELISM" not in os.environ:
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-# Hugging Face Hub faster downloads
-if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ:
+# Detect offline mode first. hf_transfer is a Rust downloader that bypasses
+# huggingface_hub's offline guard, so leaving it on defeats HF_HUB_OFFLINE
+# and TRANSFORMERS_OFFLINE entirely.
+_OFFLINE_TRUE = {"1", "true", "yes", "on"}
+_offline_env = (
+    os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _OFFLINE_TRUE
+    or os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in _OFFLINE_TRUE
+    or os.environ.get("HF_DATASETS_OFFLINE", "").strip().lower() in _OFFLINE_TRUE
+)
+
+# Hugging Face Hub faster downloads (skipped when offline mode is requested).
+if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ and not _offline_env:
     os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 
 # More stable downloads
@@ -34,16 +44,14 @@ if os.environ.get("UNSLOTH_STABLE_DOWNLOADS", "0") == "1":
     os.environ["HF_HUB_DISABLE_XET"] = "1" # Disable XET
     os.environ["HF_XET_HIGH_PERFORMANCE"] = "0" # This causes "429 Too Many Requests"
 
-# Check offline mode as well. Cross-sync HF_HUB_OFFLINE,
-# TRANSFORMERS_OFFLINE, and HF_DATASETS_OFFLINE so setting any one of
-# the three implies all three. Without HF_DATASETS_OFFLINE here,
-# load_dataset() still issues a network call for dataset metadata even
-# when the rest of the HF stack is offline (and fails with
-# ConnectionError instead of resolving from cache).
-_OFFLINE_VARS = ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE")
-if any(os.environ.get(v, "0") == "1" for v in _OFFLINE_VARS):
-    for _v in _OFFLINE_VARS:
+# Cross-sync HF_HUB_OFFLINE, TRANSFORMERS_OFFLINE, HF_DATASETS_OFFLINE so
+# setting any one of the three implies all three. Without HF_DATASETS_OFFLINE
+# here, load_dataset() still issues a network call for dataset metadata even
+# when the rest of the HF stack is offline.
+if _offline_env:
+    for _v in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"):
         os.environ[_v] = "1"
+del _OFFLINE_TRUE, _offline_env
 
 # Check "429 Too Many Requests" and set HF_XET_HIGH_PERFORMANCE
 from pathlib import Path


### PR DESCRIPTION
## Summary

`unsloth_zoo/__init__.py` unconditionally set `HF_HUB_ENABLE_HF_TRANSFER=1` at import time, before `unsloth/dataprep/synthetic.py` and before any `from_pretrained` call could re-evaluate the offline env vars. Because `hf_transfer` is a Rust-side downloader that bypasses `huggingface_hub`'s python offline guard, this defeated `HF_HUB_OFFLINE` and `TRANSFORMERS_OFFLINE` entirely for any caller who set those vars (including the pattern in #5316 and the companion fix in unsloth#5598).

## Changes

- Detect offline state once at the top of `__init__.py` using the same truthy set Unsloth's loader and `has_internet()` already use: `{"1", "true", "yes", "on"}`, checked on `HF_HUB_OFFLINE`, `TRANSFORMERS_OFFLINE`, and `HF_DATASETS_OFFLINE`.
- Skip setting `HF_HUB_ENABLE_HF_TRANSFER` when any of those is truthy.
- The existing cross-sync block (set all three offline vars when any one is set) now shares the same detection so the wider truthy parsing applies to it too. Previously it only matched exactly `"1"`.

Behaviour when no offline env var is set is identical to before (`HF_HUB_ENABLE_HF_TRANSFER=1` is still added by default).

## Test plan

Smoke checks with the patched `__init__.py` installed:

```
case 1 (no env):                       HF_HUB_ENABLE_HF_TRANSFER = 1
case 2 (HF_HUB_OFFLINE=1):             HF_HUB_ENABLE_HF_TRANSFER = None
                                       cross-sync TR=1, DS=1
case 3 (TRANSFORMERS_OFFLINE=true):    HF_HUB_ENABLE_HF_TRANSFER = None
                                       cross-sync HF=1
```

End-to-end check with unsloth#5598 plus this PR applied: 14/14 simulation cases pass against the matrix of `{HF_HUB_OFFLINE, TRANSFORMERS_OFFLINE} x {1, true, TRUE, yes, ON, 0, garbage} x {load_in_4bit, load_in_8bit, full_finetuning, qat_scheme}`. With only unsloth#5598 (and unsloth_zoo unchanged), 10/14 cases still showed `HF_HUB_ENABLE_HF_TRANSFER=1` after import, defeating the loader-side fix.

Pairs with unslothai/unsloth#5598.