### PR TITLE
tests/offline-cross-sync: realign with #675 broadened truthy parse

### DIFF
--- a/tests/test_offline_env_cross_sync.py
+++ b/tests/test_offline_env_cross_sync.py
@@ -71,11 +71,20 @@ class TestOfflineCrossSync:
         assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
         assert os.environ.get("HF_DATASETS_OFFLINE") == "1"
 
-    def test_only_value_1_triggers(self, monkeypatch, reload_zoo):
-        # The cross-sync only matches the literal "1" (existing convention).
-        # Other truthy spellings are left as-is; documented behaviour.
-        monkeypatch.setenv("HF_HUB_OFFLINE", "true")
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "yes", "on"])
+    def test_truthy_spellings_trigger_and_normalize(self, monkeypatch, reload_zoo, value):
+        # Since #675, any value in {"1","true","yes","on"} (case-insensitive)
+        # triggers cross-sync and normalizes all three to "1".
+        monkeypatch.setenv("HF_HUB_OFFLINE", value)
         reload_zoo()
-        assert os.environ.get("HF_HUB_OFFLINE") == "true"
+        assert os.environ.get("HF_HUB_OFFLINE") == "1"
+        assert os.environ.get("TRANSFORMERS_OFFLINE") == "1"
+        assert os.environ.get("HF_DATASETS_OFFLINE") == "1"
+
+    def test_falsy_value_does_not_trigger(self, monkeypatch, reload_zoo):
+        # Falsy values leave the other two vars unset.
+        monkeypatch.setenv("HF_HUB_OFFLINE", "0")
+        reload_zoo()
+        assert os.environ.get("HF_HUB_OFFLINE") == "0"
         assert os.environ.get("TRANSFORMERS_OFFLINE", "0") != "1"
         assert os.environ.get("HF_DATASETS_OFFLINE", "0") != "1"


### PR DESCRIPTION
## Summary

[#675](https://github.com/unslothai/unsloth-zoo/pull/675) (Honour offline env vars when enabling hf_transfer) replaced the "exact `1` only" trigger with a truthy set (`{\"1\",\"true\",\"yes\",\"on\"}`, case-insensitive) and made the cross-sync block write literal `\"1\"` to all three vars instead of leaving the source string in place. `tests/test_offline_env_cross_sync.py::test_only_value_1_triggers` still asserted the old contract (`HF_HUB_OFFLINE=\"true\"` left as-is, no cross-sync), so it broke on the very first CI run after #675 merged and is currently red on every downstream PR's `Core (HF=latest + TRL=latest)` matrix in `unslothai/unsloth`.

## Changes

- Drop the stale `test_only_value_1_triggers` (its name and assertions both contradict the new contract).
- Add a parametrised replacement that exercises every spelling the new detector accepts and asserts the documented normalisation:
  - `true`, `True`, `TRUE`, `yes`, `on` all trigger cross-sync.
  - All three vars come back as the literal `\"1\"`.
- Add `test_falsy_value_does_not_trigger` (`HF_HUB_OFFLINE=\"0\"`) to lock in the negative path.

## Test plan

\`\`\`
$ pytest tests/test_offline_env_cross_sync.py -v
...
10 passed in 0.07s
\`\`\`

Verified locally on Python 3.12 with \`unsloth_zoo @ main\` (post-#675).