### PR TITLE
fix(mlx): seed mx.random immediately before linear_to_lora_layers (re-PR of #674)

### DIFF
--- a/tests/test_mlx_get_peft_model_seed_ordering.py
+++ b/tests/test_mlx_get_peft_model_seed_ordering.py
@@ -1,0 +1,90 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Pin the seed-immediately-before-linear_to_lora_layers ordering in
+# FastMLXModel.get_peft_model so we match mlx-lm CLI's basin family.
+#
+# The actual numerical test (lora_a values bit-identical to
+# `mlx_lm.tuner.utils.linear_to_lora_layers` after `mx.random.seed`)
+# needs real MLX runtime; that's covered by probe 39 on
+# danielhanchen/unsloth-staging-2. Locally we guard against a future
+# refactor reverting to a single `_seed_mlx_random_state` call far
+# above `linear_to_lora_layers` again.
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def _get_peft_model_source():
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    return inspect.getsource(FastMLXModel.get_peft_model)
+
+
+def test_seed_immediately_precedes_each_linear_to_lora_layers_call():
+    """Every `linear_to_lora_layers(...)` call inside get_peft_model
+    must be preceded -- within ~20 source lines, with no other MLX op
+    or model-tree walk in between -- by a `_seed_mlx_random_state` call.
+
+    Background: empirically (Round BQ probe 39 on Apple Silicon), having
+    the seed call >100 lines above the LoRA construction allows lazy MLX
+    state advances to slip in between seeding and lora_a init, producing
+    lora_a matrices different from mlx-lm CLI's despite both paths
+    re-seeding to the same int. The fix is to seed immediately above
+    each `linear_to_lora_layers` call.
+    """
+    src = _get_peft_model_source()
+    lines = src.splitlines()
+
+    call_lines = [
+        i for i, line in enumerate(lines)
+        if "linear_to_lora_layers(" in line and not line.strip().startswith("#")
+    ]
+    assert call_lines, "expected at least one linear_to_lora_layers call in get_peft_model"
+
+    for call_idx in call_lines:
+        window_start = max(0, call_idx - 20)
+        window = "\n".join(lines[window_start:call_idx])
+        assert "_seed_mlx_random_state" in window, (
+            f"linear_to_lora_layers at line {call_idx+1} of get_peft_model "
+            f"is not preceded by `_seed_mlx_random_state` within the prior "
+            f"20 lines. Move the seed call closer to the LoRA construction "
+            f"to keep mlx-lm CLI parity."
+        )
+
+
+def test_get_peft_model_still_accepts_random_state_arg():
+    """Ensure the API surface didn't change while moving the seed."""
+    import inspect
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    sig = inspect.signature(FastMLXModel.get_peft_model)
+    assert "random_state" in sig.parameters
+    assert sig.parameters["random_state"].default == 3407
+
+
+def test_no_other_mlx_op_between_seed_and_linear_to_lora_layers():
+    """Between the seed-just-above-LoRA call and the linear_to_lora_layers
+    call itself, the only allowed code is the LoRA call. Anything else --
+    even pure Python -- is a tripwire because it makes it easy to slip
+    in an mx.eval/random call later. Enforced as a regex tripwire."""
+    src = _get_peft_model_source()
+    pattern = re.compile(
+        r"_seed_mlx_random_state\(random_state\)\s*"
+        r"(?:\n\s*#[^\n]*)*"
+        r"\s*\n\s*linear_to_lora_layers\(",
+    )
+    matches = pattern.findall(src)
+    assert len(matches) >= 2, (
+        "Expected at least two seed+LoRA-call tight pairings in "
+        "get_peft_model (one for VLM language LoRA, one for text). "
+        f"Found {len(matches)}. The seed call must immediately precede "
+        "each linear_to_lora_layers invocation with only comment lines "
+        "in between."
+    )

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2741,10 +2741,6 @@ class FastMLXModel:
                 "Install via: pip install unsloth-zoo[mlx]"
             )
 
-        # Seed mlx random state so LoRA matrix init (lora_b is zero, lora_a
-        # is random Gaussian) is reproducible across runs.
-        _seed_mlx_random_state(random_state)
-
         # finetune_vision_layers (None = use train_vision arg; bool overrides it)
         if finetune_vision_layers is not None:
             train_vision = bool(finetune_vision_layers)
@@ -2824,6 +2820,10 @@ class FastMLXModel:
                     num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
                 language_lora_keys = _resolve_lora_keys(lm, target_modules)
                 if language_lora_keys is None or len(language_lora_keys) > 0:
+                    # Match mlx_lm/tuner/lora.py (def train) -- seed
+                    # mx.random immediately before LoRA init; lazy MLX
+                    # state advances otherwise leak into lora_a sampling.
+                    _seed_mlx_random_state(random_state)
                     linear_to_lora_layers(
                         lm,
                         num_layers=num_layers,
@@ -2907,6 +2907,10 @@ class FastMLXModel:
                 language_lora_keys = _resolve_lora_keys(model, target_modules)
                 if language_lora_keys is not None and len(language_lora_keys) == 0:
                     _raise_no_lora_targets(target_modules)
+                # Match mlx_lm/tuner/lora.py (def train) -- seed
+                # mx.random immediately before LoRA init; lazy MLX
+                # state advances otherwise leak into lora_a sampling.
+                _seed_mlx_random_state(random_state)
                 linear_to_lora_layers(
                     model,
                     num_layers=num_layers,


### PR DESCRIPTION
## Summary

PR #674 was accidentally merged into the stale `fix-mlx-num-layers-parity` branch (which had already been squashed-and-superseded into main as #669), so the seed-ordering fix never reached `main`. This PR re-applies that fix cleanly against the current `main`.

## What this fixes

`FastMLXModel.get_peft_model` previously called `_seed_mlx_random_state(random_state)` near the top of the method, ~100+ source lines above the actual `linear_to_lora_layers` call. Between them sit `target_modules` normalization, `_fix_missing_no_grad`, `_resolve_lora_keys`, and (on the VLM branch) model-tree walks. MLX's lazy evaluation can advance `mx.random.state` between the early seed call and `lora_a` init via `mx.random.uniform`, producing `lora_a` matrices that differ from mlx-lm CLI's despite both paths seeding to the same int.

This PR moves `_seed_mlx_random_state(random_state)` to immediately before each `linear_to_lora_layers(...)` call (both VLM language path and text path). Matches mlx-lm's own ordering in `mlx_lm/tuner/lora.py` (the seed is the last thing it does before `linear_to_lora_layers`).

## Verification

Probe 39 on `danielhanchen/unsloth-staging-2` (5 seeds × 30 steps, gemma-3-270m-it, FastMLXModel vs mlx-lm CLI through the same manual training loop):

| seed | max \|dloss\| | max \|dgrad_norm\| |
|---|---|---|
| 1 | 0.0 | 0.0 |
| 42 | 0.0 | 0.0 |
| 999 | 0.0 | 0.0 |
| 3407 | 0.0 | 0.0 |
| 22222 | 0.0 | 0.0 |

Bit-identical losses AND gradient norms across all 30 steps × 5 seeds. Before the fix, lora_a values diverged from step 1.

## Test plan

- [x] `pytest tests/test_mlx_get_peft_model_seed_ordering.py` → 3/3 pass (source-pinning tripwires).
- [x] Numerical canary on Apple Silicon via Round BR probe 39.
- [ ] Reviewer to confirm CI green.

## Stranded branch

For history: the original PR #674 lives in `fix-mlx-num-layers-parity` at commit `74902b2a`. That branch is now obsolete and can be deleted.