### PR TITLE
fix(full-FT): upcast LayerNorm weights to fp32 for bf16 training

### DIFF
--- a/tests/_pickle_base.py
+++ b/tests/_pickle_base.py
@@ -1,0 +1,14 @@
+"""Importable base model for the cross-process pickle test. Lives in its own
+module so a fresh subprocess can resolve the base class by name (mirrors a real
+transformers model class)."""
+import torch.nn as nn
+
+
+class PickleBaseNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.norm = nn.LayerNorm(8)
+        self.lin = nn.Linear(8, 8)
+
+    def forward(self, x):
+        return self.lin(self.norm(x))

--- a/tests/_pickle_base.py
+++ b/tests/_pickle_base.py
@@ -1,4 +1,4 @@
-"""Importable base model for the cross-process pickle test. Lives in its own
+"""Importable base model for the cross-process pickle tests. Lives in its own
 module so a fresh subprocess can resolve the base class by name (mirrors a real
 transformers model class)."""
 import torch.nn as nn
@@ -10,5 +10,8 @@ class PickleBaseNet(nn.Module):
         self.norm = nn.LayerNorm(8)
         self.lin = nn.Linear(8, 8)
 
-    def forward(self, x):
+    def _impl(self, x):
         return self.lin(self.norm(x))
+
+    def forward(self, x):
+        return self._impl(x)

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -687,3 +687,89 @@ def test_legacy_upcast_layernorm_defers_to_external_policy():
     assert m.norm1.weight.dtype == torch.float32
     # externally managed norm preserved (fp32, untouched)
     assert m.managed_norm.weight.dtype == torch.float32
+
+
+def test_canonical_module_name_strips_only_trailing_suffix():
+    """#A: only a TRAILING .weight/.bias must be stripped; names that merely
+    contain those as substrings (bias_proj, weight_scale, bias_layernorm) must
+    keep their module path intact."""
+    from unsloth_zoo.training_utils import _canonical_module_name
+    assert _canonical_module_name("model.layers.0.input_layernorm.weight") == \
+        "model.layers[0].input_layernorm"
+    assert _canonical_module_name("model.layers.0.self_attn.bias_proj.weight") == \
+        "model.layers[0].self_attn.bias_proj"
+    assert _canonical_module_name("model.decoder.bias_layernorm.weight") == \
+        "model.decoder.bias_layernorm"
+    assert _canonical_module_name("model.x.weight_scale.weight") == \
+        "model.x.weight_scale"
+    assert _canonical_module_name("model.norm.bias") == "model.norm"
+
+
+def test_full_ft_handles_bias_substring_module_names():
+    """#A: a module named with a `.bias`/`.weight` substring must not crash
+    prepare_model_for_training (the canonicalizer used to resolve a bogus
+    attribute path)."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    class _M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.input_layernorm = nn.LayerNorm(8)
+            self.bias_proj = nn.Linear(8, 8)      # name contains ".bias"
+            self.weight_scale = nn.Linear(8, 8)   # name contains ".weight"
+            self.embed_tokens = nn.Embedding(16, 8)
+            self.to(torch.bfloat16)
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def get_input_embeddings(self):
+            return self.embed_tokens
+
+        def forward(self, x):
+            return self.weight_scale(self.bias_proj(self.input_layernorm(x)))
+
+    m = _M()
+    prepare_model_for_training(  # must not raise
+        m, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=True, train_layernorms=True,
+        float32_mixed_precision=False,
+    )
+    assert m.input_layernorm.weight.dtype == torch.float32
+    assert m.bias_proj.weight.dtype == torch.bfloat16
+    assert m.weight_scale.weight.dtype == torch.bfloat16
+
+
+def test_instance_forward_wrapper_rebinds_on_deepcopy():
+    """#B: when wrapping an instance-level forward, deepcopy must rebind the
+    wrapper to the COPY's parameters, not leak back to the original."""
+    import copy
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    class _M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(4, 4, bias=False)
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def _impl(self, x):
+            return self.lin(x)
+
+        def forward(self, x):
+            return self._impl(x)
+
+    m = _M()
+    with torch.no_grad():
+        m.lin.weight.fill_(1.0)
+    m.forward = m._impl  # instance-level forward
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+
+    m2 = copy.deepcopy(m)
+    with torch.no_grad():
+        m2.lin.weight.fill_(2.0)
+    assert m.lin.weight.data_ptr() != m2.lin.weight.data_ptr()
+
+    x = torch.zeros(1, 4, dtype=torch.bfloat16)
+    x[0, 0] = 1.0
+    y1 = m(x)   # original weights = 1.0
+    y2 = m2(x)  # copy weights = 2.0 -- must NOT see the original's 1.0
+    assert torch.allclose(y1.float(), torch.full_like(y1, 1.0, dtype=torch.float32))
+    assert torch.allclose(y2.float(), torch.full_like(y2, 2.0, dtype=torch.float32))

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -171,34 +171,6 @@ def test_full_ft_norm_biases_follow_module_cast():
             f"{n} should follow its norm module's dtype cast, got {p[n].dtype}"
 
 
-def test_full_ft_embed_stays_compute_dtype():
-    m, p = _run(full_finetuning=True)
-    assert p["model.embed_tokens.weight"].dtype == torch.bfloat16
-
-
-def test_full_ft_lm_head_stays_compute_dtype():
-    # lm_head shares storage with embed_tokens (weight tying).
-    m, p = _run(full_finetuning=True)
-    assert m.lm_head.weight.dtype == torch.bfloat16
-    assert m.lm_head.weight is m.model.embed_tokens.weight
-
-
-def test_full_ft_linear_bias_stays_compute_dtype():
-    m, p = _run(full_finetuning=True, with_bias=True)
-    assert p["model.layers.0.self_attn.q_proj.bias"].dtype == torch.bfloat16
-
-
-def test_full_ft_base_linear_stays_compute_dtype():
-    m, p = _run(full_finetuning=True)
-    assert p["model.layers.0.self_attn.q_proj.weight"].dtype == torch.bfloat16
-
-
-def test_full_ft_all_params_remain_trainable():
-    m, p = _run(full_finetuning=True)
-    for n, param in p.items():
-        assert param.requires_grad, f"{n} should be trainable in full-FT"
-
-
 # ---------------- deferral to external _pre_set_compute_dtype ----------------
 
 def test_full_ft_defers_to_pre_set_compute_dtype_on_norm():
@@ -232,20 +204,6 @@ def test_lora_norms_stay_bf16_frozen():
     ):
         assert p[n].dtype == torch.bfloat16
         assert p[n].requires_grad is False
-
-
-def test_lora_embed_stays_bf16_frozen():
-    m, p = _run(full_finetuning=False)
-    qp = p["model.embed_tokens.weight"]
-    assert qp.dtype == torch.bfloat16
-    assert qp.requires_grad is False
-
-
-def test_lora_base_linear_stays_bf16_frozen():
-    m, p = _run(full_finetuning=False)
-    qp = p["model.layers.0.self_attn.q_proj.weight"]
-    assert qp.dtype == torch.bfloat16
-    assert qp.requires_grad is False
 
 
 # ---------------- rollback env switch ----------------
@@ -282,11 +240,6 @@ def test_matcher_catches_vit_style_norm1_norm2():
     assert p["model.visual.blocks.0.norm1.bias"].dtype == torch.float32
     assert p["model.visual.blocks.0.norm2.weight"].dtype == torch.float32
     assert p["model.visual.blocks.0.norm2.bias"].dtype == torch.float32
-
-
-def test_full_ft_weight_tying_preserved():
-    m, p = _run(full_finetuning=True)
-    assert m.lm_head.weight is m.model.embed_tokens.weight
 
 
 # ---------------- autocast wrapper: signature / meta-device / deepcopy ------

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -287,3 +287,112 @@ def test_matcher_catches_vit_style_norm1_norm2():
 def test_full_ft_weight_tying_preserved():
     m, p = _run(full_finetuning=True)
     assert m.lm_head.weight is m.model.embed_tokens.weight
+
+
+# ---------------- autocast wrapper: signature / meta-device / deepcopy ------
+
+
+class _TinyForSig(nn.Module):
+    """Model with an `input_ids`/`labels` style forward so we can inspect
+    the signature `Trainer._set_signature_columns_if_needed` would see."""
+
+    def __init__(self):
+        super().__init__()
+        self.norm = nn.LayerNorm(8)
+        self.proj = nn.Linear(8, 8)
+        self.to(torch.bfloat16)
+        self.config = _Cfg(dtype=torch.bfloat16)
+
+    def forward(self, input_ids, attention_mask=None, labels=None):
+        x = self.norm(input_ids.to(self.norm.weight.dtype))
+        return self.proj(x)
+
+
+def test_wrapper_preserves_forward_signature():
+    """Regression: HF Trainer reads `inspect.signature(model.forward)` to
+    decide which dataset columns to keep under `remove_unused_columns=True`.
+    A bare `(*args, **kwargs)` wrapper would drop every named column."""
+    import inspect
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    m = _TinyForSig()
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    sig = inspect.signature(m.forward)
+    names = list(sig.parameters.keys())
+    assert "input_ids" in names, names
+    assert "attention_mask" in names, names
+    assert "labels" in names, names
+
+
+def test_wrapper_meta_device_does_not_crash():
+    """Regression: torch.is_autocast_enabled('meta') raises on
+    unsupported device types. We must probe is_autocast_available first."""
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    class _MetaModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def forward(self, x):
+            return x
+
+    m = _MetaModel()
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    # Passing a meta tensor would previously crash inside the wrapper
+    # at torch.is_autocast_enabled('meta'); the reordered guards must
+    # treat 'meta' as "autocast unavailable, fall through".
+    out = m(torch.zeros(2, device="meta"))
+    assert out.device.type == "meta"
+
+
+def test_wrapper_survives_deepcopy_and_uses_copy_weights():
+    """Regression: EMA / model averaging deepcopies the model. The closure-
+    based capture pinned `_orig_forward` to the original instance, so the
+    copy ran forward against the ORIGINAL weights. Subclass+self-bind via
+    types.MethodType-equivalent (class override) must rebind cleanly."""
+    import copy
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    class _Owner(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(4, 4, bias=False)
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def forward(self, x):
+            return self.lin(x)
+
+    m = _Owner()
+    with torch.no_grad():
+        m.lin.weight.fill_(1.0)
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+
+    m2 = copy.deepcopy(m)
+    with torch.no_grad():
+        m2.lin.weight.fill_(2.0)
+
+    # Distinct parameter storage after deepcopy.
+    assert m.lin.weight.data_ptr() != m2.lin.weight.data_ptr()
+
+    x = torch.zeros(1, 4, dtype=torch.bfloat16)
+    x[0, 0] = 1.0
+    # Original sees fills of 1.0 (row sum = 1).
+    y1 = m(x)
+    # Copy with weights overwritten to 2.0 must see 2.0 (row sum = 2),
+    # NOT the original's 1.0. The pre-fix closure leaked to original.
+    y2 = m2(x)
+    assert torch.allclose(y1.float(), torch.full_like(y1, 1.0, dtype=torch.float32))
+    assert torch.allclose(y2.float(), torch.full_like(y2, 2.0, dtype=torch.float32))
+
+
+def test_wrapper_idempotent():
+    """Calling _wrap twice does NOT double-wrap (and the second call is a
+    no-op, returning the same model object with the same class)."""
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    m = _TinyForSig()
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    cls_after_first = type(m)
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    assert type(m) is cls_after_first

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -412,3 +412,56 @@ def test_matcher_catches_top_level_norm1_norm2():
     )
     assert m.norm1.weight.dtype == torch.float32
     assert m.norm2.weight.dtype == torch.float32
+
+
+class _AudioRMSNorm(nn.Module):
+    """Custom RMSNorm whose param names (`norm_out`, `norm_pre_attn`) do NOT
+    match any name substring pattern -- mirrors Gemma-4/3n audio tower."""
+
+    def __init__(self, dim=8):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return x * self.weight
+
+
+def test_matcher_catches_norm_by_module_class_when_name_unmatched():
+    """Gemma audio tower uses RMSNorm modules named `norm_out` / `norm_pre_attn`
+    / `norm_post_attn`. The param names match none of the substring patterns,
+    so detection must fall back to the owning module's class name."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    class _AudioBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm_pre_attn = _AudioRMSNorm(8)
+            self.norm_post_attn = _AudioRMSNorm(8)
+            self.norm_out = _AudioRMSNorm(8)
+            self.proj = nn.Linear(8, 8)
+
+    class _AudioModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.audio_tower = _AudioBlock()
+            self.embed_tokens = nn.Embedding(16, 8)
+            self.to(torch.bfloat16)
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def get_input_embeddings(self):
+            return self.embed_tokens
+
+        def forward(self, x):
+            return self.audio_tower.proj(x)
+
+    m = _AudioModel()
+    prepare_model_for_training(
+        m, use_gradient_checkpointing=False,
+        full_finetuning=True, train_layernorms=True,
+        float32_mixed_precision=False,
+    )
+    assert m.audio_tower.norm_pre_attn.weight.dtype == torch.float32
+    assert m.audio_tower.norm_post_attn.weight.dtype == torch.float32
+    assert m.audio_tower.norm_out.weight.dtype == torch.float32
+    # non-norm linear stays bf16
+    assert m.audio_tower.proj.weight.dtype == torch.bfloat16

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -689,26 +689,10 @@ def test_legacy_upcast_layernorm_defers_to_external_policy():
     assert m.managed_norm.weight.dtype == torch.float32
 
 
-def test_canonical_module_name_strips_only_trailing_suffix():
-    """#A: only a TRAILING .weight/.bias must be stripped; names that merely
-    contain those as substrings (bias_proj, weight_scale, bias_layernorm) must
-    keep their module path intact."""
-    from unsloth_zoo.training_utils import _canonical_module_name
-    assert _canonical_module_name("model.layers.0.input_layernorm.weight") == \
-        "model.layers[0].input_layernorm"
-    assert _canonical_module_name("model.layers.0.self_attn.bias_proj.weight") == \
-        "model.layers[0].self_attn.bias_proj"
-    assert _canonical_module_name("model.decoder.bias_layernorm.weight") == \
-        "model.decoder.bias_layernorm"
-    assert _canonical_module_name("model.x.weight_scale.weight") == \
-        "model.x.weight_scale"
-    assert _canonical_module_name("model.norm.bias") == "model.norm"
-
-
 def test_full_ft_handles_bias_substring_module_names():
-    """#A: a module named with a `.bias`/`.weight` substring must not crash
-    prepare_model_for_training (the canonicalizer used to resolve a bogus
-    attribute path)."""
+    """A module named with a `.bias`/`.weight` substring must not crash
+    prepare_model_for_training. The caster now sets `param.data` directly, so
+    there is no param-name -> module-path resolution to corrupt."""
     from unsloth_zoo.training_utils import prepare_model_for_training
 
     class _M(nn.Module):
@@ -773,3 +757,52 @@ def test_instance_forward_wrapper_rebinds_on_deepcopy():
     y2 = m2(x)  # copy weights = 2.0 -- must NOT see the original's 1.0
     assert torch.allclose(y1.float(), torch.full_like(y1, 1.0, dtype=torch.float32))
     assert torch.allclose(y2.float(), torch.full_like(y2, 2.0, dtype=torch.float32))
+
+
+def test_instance_forward_wrapper_is_picklable():
+    """#C: a model wrapped via the instance-forward path must stay picklable.
+    The wrapper must NOT store an instance-bound local function in __dict__
+    (that cannot be resolved by import path on torch.load); forward must be a
+    class attribute reconstructed via __reduce__."""
+    import io
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+    from _pickle_base import PickleBaseNet
+
+    m = PickleBaseNet()
+    m.forward = m._impl  # instance-level forward (bound method, importable base)
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    assert getattr(m, "_unsloth_bf16_autocast_wrapped", False)
+    assert "forward" not in m.__dict__  # routed through the subclass, not __dict__
+
+    buf = io.BytesIO()
+    torch.save(m, buf)  # would raise (local function) without the subclass route
+    buf.seek(0)
+    m2 = torch.load(buf, weights_only=False)
+    out = m2(torch.zeros(2, 8, dtype=torch.bfloat16))
+    assert out.shape == (2, 8)
+
+
+def test_instance_forward_wrapper_unpickles_in_fresh_interpreter(tmp_path):
+    """#C cross-process: instance-forward-wrapped model loads in a fresh
+    interpreter that never ran the wrapper."""
+    import os, subprocess, sys
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+    from _pickle_base import PickleBaseNet
+
+    m = PickleBaseNet()
+    m.forward = m._impl
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    blob = tmp_path / "m.pt"
+    torch.save(m, str(blob))
+
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    script = (
+        "import sys; sys.path.insert(0, %r);"
+        "import unsloth, torch;"
+        "m = torch.load(%r, weights_only=False);"
+        "out = m(torch.zeros(2, 8, dtype=torch.bfloat16));"
+        "assert tuple(out.shape) == (2, 8);"
+        "print('FRESH_OK')"
+    ) % (tests_dir, str(blob))
+    r = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert "FRESH_OK" in r.stdout, (r.stdout + "\n" + r.stderr)[-2000:]

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -371,33 +371,32 @@ def test_wrapper_is_picklable():
     assert out.shape == (2, 8)
 
 
-def test_wrapper_unpickles_in_fresh_interpreter():
-    """Regression for the cross-process checkpoint handoff: a torch.save(model)
-    pickle must be loadable in a FRESH interpreter that never called
-    `_wrap_forward_in_bf16_autocast` (so the runtime-registered subclass symbol
-    does not exist there). We simulate that by pickling, then deleting the
-    registered symbol AND clearing the subclass cache before unpickling --
-    `__reduce__` must reconstruct the subclass from the importable base class."""
-    import pickle
-    import unsloth_zoo.training_utils as tu
+def test_wrapper_unpickles_in_fresh_interpreter(tmp_path):
+    """Cross-process checkpoint handoff: a torch.save(model) pickle must be
+    loadable in a genuinely FRESH interpreter that never called
+    `_wrap_forward_in_bf16_autocast`. Reconstruction is driven by `__reduce__`
+    via the importable base class, not by the runtime-registered symbol."""
+    import os, subprocess, sys
     from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+    from _pickle_base import PickleBaseNet
 
-    m = _TinyForSig()
+    m = PickleBaseNet()
     _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
-    gen_name = type(m).__name__
-    blob = pickle.dumps(m)
+    blob = tmp_path / "m.pt"
+    torch.save(m, str(blob))
 
-    # Simulate a fresh process: drop the runtime registration + cache so the
-    # generated symbol is NOT resolvable by name.
-    if hasattr(tu, gen_name):
-        delattr(tu, gen_name)
-    tu._BF16_AUTOCAST_SUBCLASSES.clear()
-
-    m2 = pickle.loads(blob)
-    assert type(m2).__name__ == gen_name
-    assert type(m2).__name__.endswith("WithUnslothBf16Autocast")
-    out = m2(torch.zeros(2, 8, dtype=torch.bfloat16))
-    assert out.shape == (2, 8)
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    script = (
+        "import sys; sys.path.insert(0, %r);"
+        "import unsloth, torch;"
+        "m = torch.load(%r, weights_only=False);"
+        "assert type(m).__qualname__.endswith('WithUnslothBf16Autocast'), type(m).__qualname__;"
+        "out = m(torch.zeros(2, 8, dtype=torch.bfloat16));"
+        "assert tuple(out.shape) == (2, 8);"
+        "print('FRESH_OK')"
+    ) % (tests_dir, str(blob))
+    r = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert "FRESH_OK" in r.stdout, (r.stdout + "\n" + r.stderr)[-2000:]
 
 
 def test_wrapper_subclass_is_cached_across_instances():
@@ -494,3 +493,197 @@ def test_matcher_catches_norm_by_module_class_when_name_unmatched():
     assert m.audio_tower.norm_out.weight.dtype == torch.float32
     # non-norm linear stays bf16
     assert m.audio_tower.proj.weight.dtype == torch.bfloat16
+
+
+# ---------------- reviewer-driven regression tests ----------------
+
+
+def test_wrapper_intercepts_instance_level_forward():
+    """#2: an instance-level `forward` (e.g. Unsloth runtime forward patching)
+    shadows class-method overrides. The wrapper must wrap the instance
+    attribute, otherwise fp32 norm output meets a bf16 linear with no autocast
+    and crashes."""
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    class _M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = nn.LayerNorm(8).to(torch.float32)
+            self.lin = nn.Linear(8, 8).to(torch.bfloat16)
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def _impl(self, x):
+            return self.lin(self.norm(x.float()))
+
+        def forward(self, x):
+            return self._impl(x)
+
+    m = _M()
+    m.forward = m._impl  # instance-level forward shadows the class method
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    # Must not raise a dtype mismatch: autocast downcasts fp32 norm out to bf16.
+    out = m(torch.randn(2, 8))
+    assert out.dtype == torch.bfloat16
+
+
+def test_wrapper_not_installed_when_no_fp32_norm():
+    """#7: do not class-mutate / wrap a bf16 full-FT model that has no fp32
+    norm (e.g. train_layernorms=False)."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    m = _Tiny(dtype=torch.bfloat16)
+    prepare_model_for_training(
+        m, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=True, train_layernorms=False,
+        float32_mixed_precision=False,
+    )
+    assert not getattr(m, "_unsloth_bf16_autocast_wrapped", False)
+    assert not type(m).__qualname__.endswith("WithUnslothBf16Autocast")
+
+
+def test_wrapper_installed_for_external_fp32_norm_even_when_upcast_disabled():
+    """#5: when an external `_pre_set_compute_dtype` policy leaves a norm in
+    fp32 but UNSLOTH_DISABLE_FLOAT32_UPCAST=1 suppresses our own upcast, the
+    wrapper must STILL be installed so the fp32 norm does not crash a bf16
+    linear without autocast."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    class _RMSNorm(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(8))
+
+        def forward(self, x):
+            return self.weight * x
+
+    class _M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = _RMSNorm()
+            self.proj = nn.Linear(8, 8, bias=False)
+            self.embed_tokens = nn.Embedding(16, 8)
+            self.to(torch.bfloat16)
+            self.norm.to(torch.float32)
+            self.norm._pre_set_compute_dtype = torch.float32
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def get_input_embeddings(self):
+            return self.embed_tokens
+
+        def forward(self, x):
+            return self.proj(self.norm(x))
+
+    os.environ["UNSLOTH_DISABLE_FLOAT32_UPCAST"] = "1"
+    m = _M()
+    prepare_model_for_training(
+        m, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=True, train_layernorms=True,
+        float32_mixed_precision=False,
+    )
+    assert m.norm.weight.dtype == torch.float32  # external policy preserved
+    assert getattr(m, "_unsloth_bf16_autocast_wrapped", False)
+    assert m(torch.ones(2, 8, dtype=torch.bfloat16)).dtype == torch.bfloat16
+
+
+def test_wrapper_preserves_save_pretrained_architecture(tmp_path):
+    """#8/#9: save_pretrained must record the BASE architecture, not the
+    generated wrapper class name."""
+    import json
+    from transformers import LlamaConfig, LlamaForCausalLM
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    cfg = LlamaConfig(vocab_size=32, hidden_size=8, intermediate_size=16,
+                      num_hidden_layers=1, num_attention_heads=2,
+                      num_key_value_heads=2, torch_dtype=torch.bfloat16)
+    model = LlamaForCausalLM(cfg).to(torch.bfloat16)
+    prepare_model_for_training(
+        model, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=True, train_layernorms=True,
+        float32_mixed_precision=False,
+    )
+    assert getattr(model, "_unsloth_bf16_autocast_wrapped", False)
+    model.save_pretrained(str(tmp_path))
+    arch = json.loads((tmp_path / "config.json").read_text())["architectures"]
+    assert arch == ["LlamaForCausalLM"], arch
+
+
+def test_wrapper_can_be_removed_on_reprepare(tmp_path):
+    """#10: preparing the same object bf16 then fp32 must drop the bf16 wrapper
+    so fp32 compute is not silently downcast to bf16."""
+    from unsloth_zoo.training_utils import (
+        _wrap_forward_in_bf16_autocast, _unwrap_forward_in_bf16_autocast)
+
+    class _M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(8, 8)
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def forward(self, x):
+            return self.lin(x)
+
+    m = _M()
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    assert getattr(m, "_unsloth_bf16_autocast_wrapped", False)
+    _unwrap_forward_in_bf16_autocast(m)
+    assert not getattr(m, "_unsloth_bf16_autocast_wrapped", False)
+    assert not type(m).__qualname__.endswith("WithUnslothBf16Autocast")
+
+
+def test_wrapper_device_detection_in_nested_container():
+    """#11: a CPU dict/list batch must not be mis-detected as cuda; the wrapper
+    should find the tensor device (and not crash enabling cuda autocast on CPU
+    inputs)."""
+    from unsloth_zoo.training_utils import _find_tensor_device_type
+
+    x = torch.zeros(2, 8)
+    assert _find_tensor_device_type({"input_ids": x}) == "cpu"
+    assert _find_tensor_device_type([{"a": [x]}]) == "cpu"
+    assert _find_tensor_device_type({"no": "tensors"}) is None
+
+
+def test_legacy_upcast_layernorm_defers_to_external_policy():
+    """#1/#3/#4: the legacy UNSLOTH_UPCAST_LAYERNORM path must honour the
+    external `_pre_set_compute_dtype` deferral and the broadened matcher."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    class _RMSNorm(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(8))
+
+        def forward(self, x):
+            return self.weight * x
+
+    class _M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.input_layernorm = nn.LayerNorm(8)   # name-matched
+            self.norm1 = nn.LayerNorm(8)             # union-matched (norm1.)
+            self.managed_norm = _RMSNorm()           # externally managed
+            self.proj = nn.Linear(8, 8)
+            self.embed_tokens = nn.Embedding(16, 8)
+            self.to(torch.bfloat16)
+            self.managed_norm.to(torch.float32)
+            self.managed_norm._pre_set_compute_dtype = torch.float32
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def get_input_embeddings(self):
+            return self.embed_tokens
+
+        def forward(self, x):
+            return self.proj(x)
+
+    os.environ["UNSLOTH_UPCAST_LAYERNORM"] = "1"
+    os.environ["UNSLOTH_DISABLE_FLOAT32_UPCAST"] = "1"  # only legacy path upcasts
+    m = _M()
+    prepare_model_for_training(
+        m, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=True, train_layernorms=True,
+        float32_mixed_precision=False,
+    )
+    # legacy path upcasts both name- and union-matched norms
+    assert m.input_layernorm.weight.dtype == torch.float32
+    assert m.norm1.weight.dtype == torch.float32
+    # externally managed norm preserved (fp32, untouched)
+    assert m.managed_norm.weight.dtype == torch.float32

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -371,6 +371,35 @@ def test_wrapper_is_picklable():
     assert out.shape == (2, 8)
 
 
+def test_wrapper_unpickles_in_fresh_interpreter():
+    """Regression for the cross-process checkpoint handoff: a torch.save(model)
+    pickle must be loadable in a FRESH interpreter that never called
+    `_wrap_forward_in_bf16_autocast` (so the runtime-registered subclass symbol
+    does not exist there). We simulate that by pickling, then deleting the
+    registered symbol AND clearing the subclass cache before unpickling --
+    `__reduce__` must reconstruct the subclass from the importable base class."""
+    import pickle
+    import unsloth_zoo.training_utils as tu
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    m = _TinyForSig()
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+    gen_name = type(m).__name__
+    blob = pickle.dumps(m)
+
+    # Simulate a fresh process: drop the runtime registration + cache so the
+    # generated symbol is NOT resolvable by name.
+    if hasattr(tu, gen_name):
+        delattr(tu, gen_name)
+    tu._BF16_AUTOCAST_SUBCLASSES.clear()
+
+    m2 = pickle.loads(blob)
+    assert type(m2).__name__ == gen_name
+    assert type(m2).__name__.endswith("WithUnslothBf16Autocast")
+    out = m2(torch.zeros(2, 8, dtype=torch.bfloat16))
+    assert out.shape == (2, 8)
+
+
 def test_wrapper_subclass_is_cached_across_instances():
     """Two instances of the same base class must share one generated subclass
     so we register a single module-level symbol (stable pickle identity)."""

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -1,0 +1,289 @@
+"""Regression tests for the minimal fp32-norms-in-full-FT fix.
+
+Pre-fix bug: a dangling `else:` attached to `if train_lm_head:` clobbered
+`upcast = True` for layernorms above it, so norm weights ended up in bf16
+for bf16 full finetuning. Empirically that caused ~60% of bf16-storage
+norm-weight updates to round to zero on writeback when the adam step
+(`lr * m / sqrt(v)`) fell below the bf16 ULP at the current weight magnitude.
+
+Scope (intentionally narrow, byte-identical to pristine main outside full-FT):
+  * `full_finetuning=True` AND `train_layernorms=True`: norm weights identified
+    by the existing matcher (`"norm." in name or "_layernorm" in name`) are
+    upcast to float32.
+  * `full_finetuning=False` (LoRA / QLoRA): unchanged.
+  * `bias`, `lm_head`, `embed_tokens`: NOT in scope; stay at compute dtype
+    (matches pristine main's intent for those classes).
+  * If another mechanism already manages a norm module via
+    `_pre_set_compute_dtype` (e.g. UNSLOTH_HIGH_PRECISION_LAYERNORM), the fix
+    defers and does NOT overwrite that decision.
+  * `UNSLOTH_DISABLE_FLOAT32_UPCAST=1` reproduces pre-fix bf16-norm behaviour.
+
+The mock mirrors HF's `LlamaForCausalLM.model.layers[0].input_layernorm`-style
+shape so the existing `exec("model.layers[0]...")` path in the loop can
+actually navigate it (the loop tries `name` first, then falls back to
+`model.{name}` -- which is what real HF models hit since named_parameters
+already includes the top `model.` prefix).
+"""
+import os
+
+import pytest
+import torch
+import torch.nn as nn
+
+
+class _Cfg:
+    def __init__(self, dtype=torch.bfloat16):
+        self.torch_dtype = dtype
+
+
+class _Attn(nn.Module):
+    def __init__(self, with_bias=False):
+        super().__init__()
+        self.q_norm = nn.LayerNorm(8)
+        self.k_norm = nn.LayerNorm(8)
+        self.q_proj = nn.Linear(8, 8, bias=with_bias)
+
+
+class _Layer(nn.Module):
+    def __init__(self, with_bias=False):
+        super().__init__()
+        self.input_layernorm = nn.LayerNorm(8)
+        self.post_attention_layernorm = nn.LayerNorm(8)
+        self.self_attn = _Attn(with_bias=with_bias)
+
+
+class _VitBlock(nn.Module):
+    """ViT-style block with `norm1` / `norm2` naming (Qwen3-VL visual, DINO)."""
+
+    def __init__(self):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(8)
+        self.norm2 = nn.LayerNorm(8)
+
+
+class _Visual(nn.Module):
+    """ViT-style visual encoder root: `model.visual.blocks[0].norm1/2`."""
+
+    def __init__(self):
+        super().__init__()
+        self.blocks = nn.ModuleList([_VitBlock()])
+
+
+class _Inner(nn.Module):
+    def __init__(self, with_bias=False):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(16, 8)
+        self.layers = nn.ModuleList([_Layer(with_bias=with_bias)])
+        self.norm = nn.LayerNorm(8)
+        self.visual = _Visual()
+
+
+class _Tiny(nn.Module):
+    """`LlamaForCausalLM`-shaped wrapper: `.model.layers[0]...` paths resolve
+    so the existing exec-based caster in `prepare_model_for_training` works."""
+
+    def __init__(self, dtype=torch.bfloat16, with_bias=False):
+        super().__init__()
+        self.model = _Inner(with_bias=with_bias)
+        # Tied lm_head: same Parameter object as embed_tokens.weight.
+        self.lm_head = nn.Linear(8, 16, bias=False)
+        self.lm_head.weight = self.model.embed_tokens.weight
+        self.to(dtype)
+        self.config = _Cfg(dtype=dtype)
+
+
+def _params(m):
+    return dict(m.named_parameters())
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    keys = ("UNSLOTH_DISABLE_FLOAT32_UPCAST", "UNSLOTH_HIGH_PRECISION_LAYERNORM",
+            "UNSLOTH_UPCAST_LAYERNORM", "UNSLOTH_MIXED_PRECISION")
+    for k in keys:
+        os.environ.pop(k, None)
+    yield
+    for k in keys:
+        os.environ.pop(k, None)
+
+
+def _run(full_finetuning, with_bias=False, env=None,
+         tag_pre_set_compute_dtype=()):
+    """Run prepare_model_for_training on a fresh _Tiny.
+
+    `tag_pre_set_compute_dtype` is an iterable of dotted attribute paths
+    (relative to the inner model) to tag with `_pre_set_compute_dtype = fp32`
+    BEFORE the loop runs, simulating UNSLOTH_HIGH_PRECISION_LAYERNORM having
+    already claimed those modules.
+    """
+    from unsloth_zoo.training_utils import prepare_model_for_training
+    for k, v in (env or {}).items():
+        os.environ[k] = v
+    m = _Tiny(dtype=torch.bfloat16, with_bias=with_bias)
+    for path in tag_pre_set_compute_dtype:
+        node = m
+        for part in path.split("."):
+            node = node[int(part)] if part.isdigit() else getattr(node, part)
+        node._pre_set_compute_dtype = torch.float32
+    prepare_model_for_training(
+        m,
+        use_gradient_checkpointing=False,
+        use_reentrant=False,
+        full_finetuning=full_finetuning,
+        train_layernorms=full_finetuning,
+        train_embedding=full_finetuning,
+        train_lm_head=full_finetuning,
+        float32_mixed_precision=(not full_finetuning),
+        patch_modules_to_save=False,
+    )
+    return m, _params(m)
+
+
+# ---------------- full-FT: norm.weights become fp32 ----------------
+
+def test_full_ft_norm_weights_become_fp32():
+    m, p = _run(full_finetuning=True)
+    for n in (
+        "model.layers.0.input_layernorm.weight",
+        "model.layers.0.post_attention_layernorm.weight",
+        "model.layers.0.self_attn.q_norm.weight",
+        "model.layers.0.self_attn.k_norm.weight",
+        "model.norm.weight",
+    ):
+        assert p[n].dtype == torch.float32, \
+            f"{n} expected fp32, got {p[n].dtype}"
+
+
+def test_full_ft_norm_biases_follow_module_cast():
+    # The existing exec path is `module.to(dtype)`, so the LayerNorm's bias is
+    # cast alongside its weight even though the matcher only inspects names
+    # ending in `.weight`. This mirrors pristine main's behaviour and is fine
+    # for our purposes -- both halves of the LayerNorm op stay in lockstep.
+    m, p = _run(full_finetuning=True)
+    for n in (
+        "model.layers.0.input_layernorm.bias",
+        "model.layers.0.post_attention_layernorm.bias",
+        "model.layers.0.self_attn.q_norm.bias",
+        "model.layers.0.self_attn.k_norm.bias",
+        "model.norm.bias",
+    ):
+        assert p[n].dtype == torch.float32, \
+            f"{n} should follow its norm module's dtype cast, got {p[n].dtype}"
+
+
+def test_full_ft_embed_stays_compute_dtype():
+    m, p = _run(full_finetuning=True)
+    assert p["model.embed_tokens.weight"].dtype == torch.bfloat16
+
+
+def test_full_ft_lm_head_stays_compute_dtype():
+    # lm_head shares storage with embed_tokens (weight tying).
+    m, p = _run(full_finetuning=True)
+    assert m.lm_head.weight.dtype == torch.bfloat16
+    assert m.lm_head.weight is m.model.embed_tokens.weight
+
+
+def test_full_ft_linear_bias_stays_compute_dtype():
+    m, p = _run(full_finetuning=True, with_bias=True)
+    assert p["model.layers.0.self_attn.q_proj.bias"].dtype == torch.bfloat16
+
+
+def test_full_ft_base_linear_stays_compute_dtype():
+    m, p = _run(full_finetuning=True)
+    assert p["model.layers.0.self_attn.q_proj.weight"].dtype == torch.bfloat16
+
+
+def test_full_ft_all_params_remain_trainable():
+    m, p = _run(full_finetuning=True)
+    for n, param in p.items():
+        assert param.requires_grad, f"{n} should be trainable in full-FT"
+
+
+# ---------------- deferral to external _pre_set_compute_dtype ----------------
+
+def test_full_ft_defers_to_pre_set_compute_dtype_on_norm():
+    # A norm module owned by an external policy keeps its loaded dtype; the
+    # fix MUST NOT overwrite it. Other norms still upcast.
+    m, p = _run(full_finetuning=True,
+                tag_pre_set_compute_dtype=("model.layers.0.input_layernorm",))
+    assert p["model.layers.0.input_layernorm.weight"].dtype == torch.bfloat16
+    # Untagged norms still upcast.
+    assert p["model.norm.weight"].dtype == torch.float32
+    assert p["model.layers.0.self_attn.q_norm.weight"].dtype == torch.float32
+
+
+def test_full_ft_defers_per_module_not_globally():
+    m, p = _run(full_finetuning=True,
+                tag_pre_set_compute_dtype=("model.layers.0.self_attn.q_norm",
+                                           "model.layers.0.self_attn.k_norm"))
+    assert p["model.layers.0.self_attn.q_norm.weight"].dtype == torch.bfloat16
+    assert p["model.layers.0.self_attn.k_norm.weight"].dtype == torch.bfloat16
+    assert p["model.layers.0.input_layernorm.weight"].dtype == torch.float32
+
+
+# ---------------- LoRA / QLoRA path: zero behaviour change ----------------
+
+def test_lora_norms_stay_bf16_frozen():
+    m, p = _run(full_finetuning=False)
+    for n in (
+        "model.layers.0.input_layernorm.weight",
+        "model.layers.0.self_attn.q_norm.weight",
+        "model.norm.weight",
+    ):
+        assert p[n].dtype == torch.bfloat16
+        assert p[n].requires_grad is False
+
+
+def test_lora_embed_stays_bf16_frozen():
+    m, p = _run(full_finetuning=False)
+    qp = p["model.embed_tokens.weight"]
+    assert qp.dtype == torch.bfloat16
+    assert qp.requires_grad is False
+
+
+def test_lora_base_linear_stays_bf16_frozen():
+    m, p = _run(full_finetuning=False)
+    qp = p["model.layers.0.self_attn.q_proj.weight"]
+    assert qp.dtype == torch.bfloat16
+    assert qp.requires_grad is False
+
+
+# ---------------- rollback env switch ----------------
+
+def test_disable_float32_upcast_reproduces_pre_fix_bf16():
+    m, p = _run(full_finetuning=True,
+                env={"UNSLOTH_DISABLE_FLOAT32_UPCAST": "1"})
+    for n in (
+        "model.layers.0.input_layernorm.weight",
+        "model.layers.0.self_attn.q_norm.weight",
+        "model.norm.weight",
+    ):
+        assert p[n].dtype == torch.bfloat16
+
+
+# ---------------- matcher guard (no broadening from pristine main) ----------
+
+def test_matcher_catches_q_norm_and_k_norm():
+    m, p = _run(full_finetuning=True)
+    assert p["model.layers.0.self_attn.q_norm.weight"].dtype == torch.float32
+    assert p["model.layers.0.self_attn.k_norm.weight"].dtype == torch.float32
+
+
+def test_matcher_catches_final_model_norm():
+    m, p = _run(full_finetuning=True)
+    assert p["model.norm.weight"].dtype == torch.float32
+
+
+def test_matcher_catches_vit_style_norm1_norm2():
+    # ViT/DINO/Qwen3-VL visual encoders use `norm1`/`norm2` without a dot
+    # separator. The matcher must catch both .weight and .bias of these.
+    m, p = _run(full_finetuning=True)
+    assert p["model.visual.blocks.0.norm1.weight"].dtype == torch.float32
+    assert p["model.visual.blocks.0.norm1.bias"].dtype == torch.float32
+    assert p["model.visual.blocks.0.norm2.weight"].dtype == torch.float32
+    assert p["model.visual.blocks.0.norm2.bias"].dtype == torch.float32
+
+
+def test_full_ft_weight_tying_preserved():
+    m, p = _run(full_finetuning=True)
+    assert m.lm_head.weight is m.model.embed_tokens.weight

--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -349,3 +349,66 @@ def test_wrapper_idempotent():
     cls_after_first = type(m)
     _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
     assert type(m) is cls_after_first
+
+
+def test_wrapper_is_picklable():
+    """Regression: the generated subclass must be registered as a module-level
+    symbol so pickle / torch.save(model) can resolve it by module + qualname.
+    Otherwise the bf16 full-FT path makes the whole model unpicklable
+    (PicklingError)."""
+    import io
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    m = _TinyForSig()
+    _wrap_forward_in_bf16_autocast(m, torch.bfloat16)
+
+    buf = io.BytesIO()
+    torch.save(m, buf)  # would raise PicklingError pre-fix
+    buf.seek(0)
+    m2 = torch.load(buf, weights_only=False)
+    assert type(m2).__name__ == type(m).__name__
+    out = m2(torch.zeros(2, 8, dtype=torch.bfloat16))
+    assert out.shape == (2, 8)
+
+
+def test_wrapper_subclass_is_cached_across_instances():
+    """Two instances of the same base class must share one generated subclass
+    so we register a single module-level symbol (stable pickle identity)."""
+    from unsloth_zoo.training_utils import _wrap_forward_in_bf16_autocast
+
+    a = _TinyForSig()
+    b = _TinyForSig()
+    _wrap_forward_in_bf16_autocast(a, torch.bfloat16)
+    _wrap_forward_in_bf16_autocast(b, torch.bfloat16)
+    assert type(a) is type(b)
+
+
+def test_matcher_catches_top_level_norm1_norm2():
+    """norm1/norm2 params at the top level (no leading dot) must still be
+    matched -- the pattern uses a trailing dot only, like `norm.`."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    class _TopLevelNorm(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm1 = nn.LayerNorm(8)
+            self.norm2 = nn.LayerNorm(8)
+            self.embed_tokens = nn.Embedding(16, 8)
+            self.proj = nn.Linear(8, 8)
+            self.to(torch.bfloat16)
+            self.config = _Cfg(dtype=torch.bfloat16)
+
+        def get_input_embeddings(self):
+            return self.embed_tokens
+
+        def forward(self, x):
+            return self.proj(x)
+
+    m = _TopLevelNorm()
+    prepare_model_for_training(
+        m, use_gradient_checkpointing=False,
+        full_finetuning=True, train_layernorms=True,
+        float32_mixed_precision=False,
+    )
+    assert m.norm1.weight.dtype == torch.float32
+    assert m.norm2.weight.dtype == torch.float32

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -33,6 +33,7 @@ from .gradient_checkpointing import (
 import os
 import re
 import sys
+import types
 import functools
 
 __all__ = [
@@ -250,14 +251,21 @@ def _wrap_forward_in_bf16_autocast(model, compute_dtype):
         # An instance-level `forward` (e.g. Unsloth runtime forward patching)
         # shadows any class-method override -- `self.forward` resolves the
         # instance attribute first -- so mutating `__class__` would NOT
-        # intercept it. Wrap the instance attribute directly instead.
+        # intercept it. Wrap the instance attribute directly.
+        #
+        # Bind as a `types.MethodType` so the wrapper receives `self` and reads
+        # the original forward from `self.__dict__` instead of closing over the
+        # original `model`. `copy.deepcopy` rebinds a bound method's `__self__`
+        # to the copy, so the copy's wrapped forward executes against the copy's
+        # parameters (EMA / model averaging / checkpoint paths).
         @functools.wraps(instance_forward)
-        def _wrapped_instance_forward(*args, **kwargs):
+        def _wrapped_instance_forward(self, *args, **kwargs):
+            orig = self.__dict__["_unsloth_autocast_orig_forward"]
             return _call_forward_with_bf16_autocast(
-                instance_forward, model, args, kwargs, compute_dtype,
+                orig, self, args, kwargs, compute_dtype,
             )
         model._unsloth_autocast_orig_forward = instance_forward
-        model.forward = _wrapped_instance_forward
+        model.forward = types.MethodType(_wrapped_instance_forward, model)
     else:
         model.__class__ = _make_bf16_autocast_subclass(type(model), compute_dtype)
     model._unsloth_bf16_autocast_wrapped = True
@@ -284,11 +292,17 @@ def _unwrap_forward_in_bf16_autocast(model):
 def _canonical_module_name(name):
     """Convert a `named_parameters` key into an attribute path to the owning
     module (e.g. `model.layers.0.input_layernorm.weight` ->
-    `model.layers[0].input_layernorm`)."""
+    `model.layers[0].input_layernorm`). Only a TRAILING `.weight` / `.bias`
+    parameter suffix is stripped (end-anchored) -- a plain `.replace(...)` would
+    corrupt module names that merely contain `.weight`/`.bias` as a substring
+    (e.g. `...self_attn.bias_proj.weight` or `...weight_scale.weight`)."""
     module_name = name.replace("base_model", "model", 1)
     while re.search(r"\.(\d+)\.", module_name) is not None:
         module_name = re.sub(r"\.(\d+)\.", r"[\1].", module_name)
-    return module_name.replace(".weight", "", 1).replace(".bias", "", 1)
+    for suffix in (".weight", ".bias"):
+        if module_name.endswith(suffix):
+            return module_name[: -len(suffix)]
+    return module_name
 
 
 def _cast_named_module(model, name, dtype):

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -101,6 +101,45 @@ pass
 _BF16_AUTOCAST_SUBCLASSES = {}
 
 
+def _find_tensor_device_type(*values):
+    """Device type of the first tensor found in args/kwargs, recursing into
+    mappings / lists / tuples (HF batches are often dicts; VLM inputs nest
+    tensors). Returns None if no tensor is found."""
+    from collections.abc import Mapping
+    stack = list(values)
+    while stack:
+        value = stack.pop()
+        if torch.is_tensor(value):
+            return value.device.type
+        if isinstance(value, Mapping):
+            stack.extend(value.values())
+        elif isinstance(value, (tuple, list)):
+            stack.extend(value)
+    return None
+
+
+def _call_forward_with_bf16_autocast(forward, model, args, kwargs, compute_dtype):
+    """Run `forward(*args, **kwargs)` inside `torch.amp.autocast(compute_dtype)`.
+    Device type is sniffed from the inputs (recursing into containers), falling
+    back to the model's parameter device, then "cuda". Defers to an outer
+    autocast that is already active, and to unsupported device types (meta).
+    Shared by both the subclass and instance-attribute wrapper paths."""
+    device_type = _find_tensor_device_type(*args, *kwargs.values())
+    if device_type is None:
+        try:
+            device_type = next(model.parameters()).device.type
+        except StopIteration:
+            device_type = "cuda"
+    # Order matters: is_autocast_enabled raises on unsupported device types
+    # (e.g. "meta"); is_autocast_available returns False cleanly.
+    if not torch.amp.is_autocast_available(device_type):
+        return forward(*args, **kwargs)
+    if torch.is_autocast_enabled(device_type):
+        return forward(*args, **kwargs)
+    with torch.amp.autocast(device_type=device_type, dtype=compute_dtype):
+        return forward(*args, **kwargs)
+
+
 def _reconstruct_bf16_autocast_model(base_cls, compute_dtype):
     """Pickle / deepcopy reconstructor. Rebuilds (or fetches) the autocast
     subclass from the IMPORTABLE base class, then returns a blank instance for
@@ -144,41 +183,30 @@ def _make_bf16_autocast_subclass(cls, compute_dtype):
 
     @functools.wraps(_orig_forward)
     def _wrapped(self, *args, **kwargs):
-        device_type = "cuda"
-        for t in args:
-            if torch.is_tensor(t):
-                device_type = t.device.type
-                break
-        else:
-            for t in kwargs.values():
-                if torch.is_tensor(t):
-                    device_type = t.device.type
-                    break
-        # Order matters: is_autocast_enabled raises on unsupported device
-        # types (e.g. "meta"); is_autocast_available returns False cleanly.
-        if not torch.amp.is_autocast_available(device_type):
-            return _orig_forward(self, *args, **kwargs)
-        if torch.is_autocast_enabled(device_type):
-            return _orig_forward(self, *args, **kwargs)
-        with torch.amp.autocast(device_type=device_type, dtype=compute_dtype):
-            return _orig_forward(self, *args, **kwargs)
+        return _call_forward_with_bf16_autocast(
+            lambda *a, **k: _orig_forward(self, *a, **k),
+            self, args, kwargs, compute_dtype,
+        )
 
-    name = cls.__name__ + "WithUnslothBf16Autocast"
+    # `pickle_name` is unique (for the module-level registration / same-process
+    # class pickling); the subclass keeps the ORIGINAL `__name__` so HF
+    # save_pretrained writes the base class into config.architectures rather
+    # than the generated wrapper name.
+    pickle_name = cls.__name__ + "WithUnslothBf16Autocast"
     module = sys.modules[__name__]
-    # Disambiguate if two different base classes share the same __name__ so
-    # each registered symbol resolves back to exactly one subclass.
-    if hasattr(module, name) and getattr(module, name) is not None:
-        name = f"{name}_{len(_BF16_AUTOCAST_SUBCLASSES)}"
+    if hasattr(module, pickle_name) and getattr(module, pickle_name) is not None:
+        pickle_name = f"{pickle_name}_{len(_BF16_AUTOCAST_SUBCLASSES)}"
 
-    new_cls = type(name, (cls,), {
+    new_cls = type(pickle_name, (cls,), {
         "forward": _wrapped,
         "__module__": __name__,
         "__reduce__": _bf16_autocast_reduce,
         "_unsloth_autocast_base": cls,
         "_unsloth_autocast_dtype": compute_dtype,
     })
-    new_cls.__qualname__ = name
-    setattr(module, name, new_cls)
+    new_cls.__name__ = cls.__name__
+    new_cls.__qualname__ = pickle_name
+    setattr(module, pickle_name, new_cls)
     _BF16_AUTOCAST_SUBCLASSES[(cls, compute_dtype)] = new_cls
     return new_cls
 
@@ -217,9 +245,61 @@ def _wrap_forward_in_bf16_autocast(model, compute_dtype):
     if getattr(model, "_unsloth_bf16_autocast_wrapped", False):
         return model
 
-    model.__class__ = _make_bf16_autocast_subclass(type(model), compute_dtype)
+    instance_forward = model.__dict__.get("forward")
+    if instance_forward is not None:
+        # An instance-level `forward` (e.g. Unsloth runtime forward patching)
+        # shadows any class-method override -- `self.forward` resolves the
+        # instance attribute first -- so mutating `__class__` would NOT
+        # intercept it. Wrap the instance attribute directly instead.
+        @functools.wraps(instance_forward)
+        def _wrapped_instance_forward(*args, **kwargs):
+            return _call_forward_with_bf16_autocast(
+                instance_forward, model, args, kwargs, compute_dtype,
+            )
+        model._unsloth_autocast_orig_forward = instance_forward
+        model.forward = _wrapped_instance_forward
+    else:
+        model.__class__ = _make_bf16_autocast_subclass(type(model), compute_dtype)
     model._unsloth_bf16_autocast_wrapped = True
     return model
+
+
+def _unwrap_forward_in_bf16_autocast(model):
+    """Undo a previous `_wrap_forward_in_bf16_autocast`. Without this, reusing
+    the same model object across prepare modes (e.g. bf16 full-FT then fp32)
+    would leave a stale bf16 autocast forcing bf16 compute on fp32 weights."""
+    if not getattr(model, "_unsloth_bf16_autocast_wrapped", False):
+        return model
+    orig_forward = model.__dict__.pop("_unsloth_autocast_orig_forward", None)
+    if orig_forward is not None:
+        model.forward = orig_forward
+    else:
+        base_cls = getattr(type(model), "_unsloth_autocast_base", None)
+        if base_cls is not None:
+            model.__class__ = base_cls
+    model._unsloth_bf16_autocast_wrapped = False
+    return model
+
+
+def _canonical_module_name(name):
+    """Convert a `named_parameters` key into an attribute path to the owning
+    module (e.g. `model.layers.0.input_layernorm.weight` ->
+    `model.layers[0].input_layernorm`)."""
+    module_name = name.replace("base_model", "model", 1)
+    while re.search(r"\.(\d+)\.", module_name) is not None:
+        module_name = re.sub(r"\.(\d+)\.", r"[\1].", module_name)
+    return module_name.replace(".weight", "", 1).replace(".bias", "", 1)
+
+
+def _cast_named_module(model, name, dtype):
+    """Cast the module that owns parameter `name` to `dtype` in place. Shared by
+    the main full-FT cast path and the legacy UNSLOTH_UPCAST_LAYERNORM path so
+    both honour the same module resolution."""
+    module_name = _canonical_module_name(name)
+    try:
+        exec(f"{module_name}.to({str(dtype)})")
+    except Exception:
+        exec(f"model.{module_name}.to({str(dtype)})")
 
 
 @torch.no_grad
@@ -282,7 +362,10 @@ def prepare_model_for_training(
     _norm_param_ids = set()
     for _, _module in model.named_modules():
         if hasattr(_module, "_pre_set_compute_dtype"):
-            for _, _p in _module.named_parameters(recurse=False):
+            # Recurse: the external policy casts the tagged module recursively
+            # (`module.to(module._pre_set_compute_dtype)`), so every descendant
+            # parameter is externally managed and must not be re-cast here.
+            for _p in _module.parameters(recurse=True):
                 _externally_managed_param_ids.add(id(_p))
         if _norm_class_re.search(type(_module).__name__):
             for _, _p in _module.named_parameters(recurse=False):
@@ -292,9 +375,23 @@ def prepare_model_for_training(
     _disable_float32_norm_upcast = (
         os.environ.get("UNSLOTH_DISABLE_FLOAT32_UPCAST", "0") == "1")
 
+    def _is_norm_parameter(nm, p):
+        # Union matcher (also used by the legacy UNSLOTH_UPCAST_LAYERNORM path):
+        # owning-module class name OR known parameter-name substrings.
+        return (
+            id(p) in _norm_param_ids
+            or "norm." in nm
+            or "_layernorm" in nm
+            or "layer_norm" in nm
+            or "norm1." in nm
+            or "norm2." in nm
+        )
+
     for name, param in model.named_parameters():
+        original_name = name
         upcast = False
         requires_grad = False
+        _is_norm = _is_norm_parameter(original_name, param)
         if not full_finetuning:
             if ".lora_A." in name or ".lora_B." in name or ".lora_magnitude_vector" in name:
                 upcast = True
@@ -310,24 +407,8 @@ def prepare_model_for_training(
             # silently clobbered the `upcast = True` set for norms above it.
             requires_grad = True
             upcast = False
-            # Norm matcher: union of (a) owning-module class name being a
-            # RMSNorm/LayerNorm (robust, catches any naming), and (b) the
-            # parameter-name patterns we've seen in the wild:
-            #   Llama/Qwen3:        "input_layernorm", "model.norm",
-            #                       "self_attn.q_norm", "self_attn.k_norm"
-            #   SigLIP/CLIP vision: "encoder.layers.0.layer_norm1/2"
-            #   ViT/DINO/Qwen3-VL:  "visual.blocks.0.norm1/2"
-            #   Gemma audio tower:  "norm_out", "norm_pre_attn", "norm_post_attn"
-            _is_norm_name = (
-                id(param) in _norm_param_ids
-                or "norm." in name
-                or "_layernorm" in name
-                or "layer_norm" in name
-                or "norm1." in name
-                or "norm2." in name
-            )
             if (train_layernorms
-                    and _is_norm_name
+                    and _is_norm
                     and id(param) not in _externally_managed_param_ids
                     and not _disable_float32_norm_upcast):
                 upcast = True
@@ -343,42 +424,40 @@ def prepare_model_for_training(
         # policy will have already cast them) so we don't silently downcast
         # their fp32 storage back to the compute dtype here.
         if requires_grad and id(param) not in _externally_managed_param_ids:
-            name = name.replace("base_model", "model", 1)
-            while re.search(r'\.(\d+)\.', name) is not None:
-                name = re.sub(r'\.(\d+)\.', r'[\1].', name)
-            name = name.replace(".weight", "", 1)
             dtype = torch.float32 if upcast else mixed_precision_dtype
-            try:
-                # Try original name
-                exec(f"{name}.to({str(dtype)})")
-            except:
-                # Maybe model.model
-                exec(f"model.{name}.to({str(dtype)})")
+            _cast_named_module(model, original_name, dtype)
         pass
 
-        if ('norm.' in name or '_layernorm' in name) and os.environ.get("UNSLOTH_UPCAST_LAYERNORM", "0") == "1":
-            try:
-                name = name.replace("base_model", "model", 1)
-                while re.search(r'\.(\d+)\.', name) is not None:
-                    name = re.sub(r'\.(\d+)\.', r'[\1].', name)
-                name = name.replace(".weight", "", 1)
-                # Try original name
-                exec(f"{name}.to({str(torch.float32)})")
-            except:
-                # Maybe model.model
-                exec(f"model.{name}.to({str(torch.float32)})")
+        # Legacy UNSLOTH_UPCAST_LAYERNORM path. Now uses the SAME union matcher
+        # and honours the external-policy deferral guard, so it can no longer
+        # (a) miss norm1/norm2/class-detected norms or (b) clobber an externally
+        # managed norm. Fp32 norms it creates are still handled by the wrapper
+        # because installation is gated on the presence of fp32 norms below.
+        if (_is_norm
+                and id(param) not in _externally_managed_param_ids
+                and os.environ.get("UNSLOTH_UPCAST_LAYERNORM", "0") == "1"):
+            _cast_named_module(model, original_name, torch.float32)
     pass
 
-    # When the bf16 full-FT path now has fp32 norm weights, those norms'
-    # forward returns fp32 tensors (e.g. `weight * downcast_hidden` in
-    # transformers' Llama/Qwen3 RMSNorm). Without an autocast context, that
-    # fp32 then enters the next bf16 linear and trips F.linear's dtype check.
-    # Wrap forward in torch.amp.autocast(bf16) so linear/matmul inputs get
-    # downcast at the op boundary -- the canonical PyTorch mixed-precision
-    # pattern HF / PEFT / Accelerate all use. Cheap no-op when not needed.
-    if (full_finetuning and not _disable_float32_norm_upcast
-            and mixed_precision_dtype == torch.bfloat16):
+    # Install the bf16 autocast wrapper iff fp32 norm weights ACTUALLY exist
+    # (from our upcast, the legacy env upcast, or an external
+    # `_pre_set_compute_dtype` policy). Gating on the presence of fp32 norms --
+    # not on the upcast DECISION -- means: (1) `UNSLOTH_DISABLE_FLOAT32_UPCAST=1`
+    # never leaves externally-managed fp32 norms exposed to a bf16 linear with
+    # no autocast context, and (2) we never class-mutate a model that has no
+    # fp32 norm. With fp32 norms, the norm forward returns fp32 which would trip
+    # the next bf16 linear's dtype check; autocast(bf16) downcasts at the op
+    # boundary -- the canonical PyTorch mixed-precision pattern.
+    _has_fp32_norms = any(
+        _is_norm_parameter(nm, p) and p.dtype == torch.float32
+        for nm, p in model.named_parameters()
+    )
+    if (full_finetuning
+            and mixed_precision_dtype == torch.bfloat16
+            and _has_fp32_norms):
         _wrap_forward_in_bf16_autocast(model, torch.bfloat16)
+    else:
+        _unwrap_forward_in_bf16_autocast(model)
 
     # Gradient checkpointing
     # If the user requested vanilla GC (True/False), ensure any prior Unsloth patch is undone.

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -92,6 +92,40 @@ def fix_zero_training_loss(model, tokenizer, train_dataset):
 pass
 
 
+def _wrap_forward_in_bf16_autocast(model, compute_dtype):
+    """For bf16 full-FT with fp32 norm weights, the norm forward returns an
+    fp32 tensor which then meets the next bf16 linear and trips
+    `F.linear`'s dtype-equality check. Wrap `model.forward` in
+    `torch.amp.autocast(compute_dtype)` so linear/matmul inputs are
+    downcast at the op boundary -- the standard PyTorch mixed-precision
+    pattern PEFT and Accelerate already rely on. Idempotent; defers to an
+    outer autocast context if one is already active.
+    """
+    if compute_dtype in (None, torch.float32):
+        return model
+    if getattr(model, "_unsloth_bf16_autocast_wrapped", False):
+        return model
+    _orig_forward = model.forward
+
+    def _wrapped(*args, **kwargs):
+        # Try to pick the right device_type from the first tensor we see.
+        device_type = "cuda"
+        for t in list(args) + list(kwargs.values()):
+            if torch.is_tensor(t):
+                device_type = t.device.type
+                break
+        if torch.is_autocast_enabled(device_type):
+            return _orig_forward(*args, **kwargs)
+        if not torch.amp.is_autocast_available(device_type):
+            return _orig_forward(*args, **kwargs)
+        with torch.amp.autocast(device_type=device_type, dtype=compute_dtype):
+            return _orig_forward(*args, **kwargs)
+
+    model.forward = _wrapped
+    model._unsloth_bf16_autocast_wrapped = True
+    return model
+
+
 @torch.no_grad
 def prepare_model_for_training(
     model                      : Any,
@@ -138,6 +172,20 @@ def prepare_model_for_training(
         mixed_precision_dtype = torch.float32
         os.environ["UNSLOTH_MIXED_PRECISION"] = "float32"
     pass
+    # Defer to any external compute-dtype policy already in effect on norm
+    # modules (e.g. UNSLOTH_HIGH_PRECISION_LAYERNORM which tags norm modules
+    # with `_pre_set_compute_dtype`). Record those parameter ids so we leave
+    # them alone instead of overwriting that policy.
+    _externally_managed_param_ids = set()
+    for _, _module in model.named_modules():
+        if hasattr(_module, "_pre_set_compute_dtype"):
+            for _, _p in _module.named_parameters(recurse=False):
+                _externally_managed_param_ids.add(id(_p))
+    # Rollback switch (defaults off = corrected behaviour). Set to 1 to keep
+    # norm weights at their loaded dtype like the pre-fix code path.
+    _disable_float32_norm_upcast = (
+        os.environ.get("UNSLOTH_DISABLE_FLOAT32_UPCAST", "0") == "1")
+
     for name, param in model.named_parameters():
         upcast = False
         requires_grad = False
@@ -148,18 +196,31 @@ def prepare_model_for_training(
             else:
                 requires_grad = False
         else:
-            if train_layernorms and ("norm." in name or "_layernorm" in name):
-                requires_grad = True
-                upcast = True # Must upcast layernorms to float32
-            if train_embedding and ("embed_tokens" in name or "embedding" in name):
-                requires_grad = True
-                upcast = False # Can leave in bfloat16
-            if train_lm_head and ("lm_head" in name):
-                requires_grad = True
-                upcast = False # Can leave in bfloat16
-            else:
-                requires_grad = True
-                upcast = False # Can leave in bfloat16
+            # Full finetuning: train everything by default at compute dtype.
+            # Norm weights must be upcast to float32 for adam writeback
+            # precision -- without this ~60% of bf16 adam updates round to
+            # zero on writeback (measured on Qwen3-0.6B input_layernorm).
+            # Previously a dangling `else:` attached to `if train_lm_head:`
+            # silently clobbered the `upcast = True` set for norms above it.
+            requires_grad = True
+            upcast = False
+            # Norm-name matcher catches the patterns we've seen in the wild:
+            #   Llama/Qwen3:        "input_layernorm", "model.norm",
+            #                       "self_attn.q_norm", "self_attn.k_norm"
+            #   SigLIP/CLIP vision: "encoder.layers.0.layer_norm1/2"
+            #   ViT/DINO/Qwen3-VL:  "visual.blocks.0.norm1/2"
+            _is_norm_name = (
+                "norm." in name
+                or "_layernorm" in name
+                or "layer_norm" in name
+                or ".norm1." in name
+                or ".norm2." in name
+            )
+            if (train_layernorms
+                    and _is_norm_name
+                    and id(param) not in _externally_managed_param_ids
+                    and not _disable_float32_norm_upcast):
+                upcast = True
         pass
         # Set training or not
         if requires_grad:
@@ -167,8 +228,11 @@ def prepare_model_for_training(
         else:
             param.requires_grad_(False)
 
-        # Upcast to float32 if needed
-        if requires_grad:
+        # Upcast to float32 if needed. Skip params owned by a module that
+        # already has `_pre_set_compute_dtype` set (the external compute-dtype
+        # policy will have already cast them) so we don't silently downcast
+        # their fp32 storage back to the compute dtype here.
+        if requires_grad and id(param) not in _externally_managed_param_ids:
             name = name.replace("base_model", "model", 1)
             while re.search(r'\.(\d+)\.', name) is not None:
                 name = re.sub(r'\.(\d+)\.', r'[\1].', name)
@@ -194,6 +258,17 @@ def prepare_model_for_training(
                 # Maybe model.model
                 exec(f"model.{name}.to({str(torch.float32)})")
     pass
+
+    # When the bf16 full-FT path now has fp32 norm weights, those norms'
+    # forward returns fp32 tensors (e.g. `weight * downcast_hidden` in
+    # transformers' Llama/Qwen3 RMSNorm). Without an autocast context, that
+    # fp32 then enters the next bf16 linear and trips F.linear's dtype check.
+    # Wrap forward in torch.amp.autocast(bf16) so linear/matmul inputs get
+    # downcast at the op boundary -- the canonical PyTorch mixed-precision
+    # pattern HF / PEFT / Accelerate all use. Cheap no-op when not needed.
+    if (full_finetuning and not _disable_float32_norm_upcast
+            and mixed_precision_dtype == torch.bfloat16):
+        _wrap_forward_in_bf16_autocast(model, torch.bfloat16)
 
     # Gradient checkpointing
     # If the user requested vanilla GC (True/False), ensure any prior Unsloth patch is undone.

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -33,7 +33,6 @@ from .gradient_checkpointing import (
 import os
 import re
 import sys
-import types
 import functools
 
 __all__ = [
@@ -141,7 +140,7 @@ def _call_forward_with_bf16_autocast(forward, model, args, kwargs, compute_dtype
         return forward(*args, **kwargs)
 
 
-def _reconstruct_bf16_autocast_model(base_cls, compute_dtype):
+def _reconstruct_bf16_autocast_model(base_cls, compute_dtype, instance_mode=False):
     """Pickle / deepcopy reconstructor. Rebuilds (or fetches) the autocast
     subclass from the IMPORTABLE base class, then returns a blank instance for
     `__setstate__` to populate. Because reconstruction is driven by the base
@@ -149,45 +148,73 @@ def _reconstruct_bf16_autocast_model(base_cls, compute_dtype):
     runtime-generated subclass symbol, unpickling works in a FRESH interpreter
     where `_make_bf16_autocast_subclass` has not been called yet (e.g. loading
     a `torch.save(model)` checkpoint in another process / session)."""
-    cls = _make_bf16_autocast_subclass(base_cls, compute_dtype)
+    cls = _make_bf16_autocast_subclass(base_cls, compute_dtype, instance_mode)
     return cls.__new__(cls)
 
 
 def _bf16_autocast_reduce(self):
     """`__reduce__` for generated autocast subclasses. Serialize via the base
     class + the standard nn.Module state so no dynamically-generated class
-    symbol needs to be resolvable at unpickle time."""
+    symbol (and no instance-bound local function) needs to be resolvable at
+    unpickle time."""
     cls = type(self)
     base_cls = cls.__dict__.get("_unsloth_autocast_base", cls.__mro__[1])
     compute_dtype = cls.__dict__.get("_unsloth_autocast_dtype", torch.bfloat16)
+    instance_mode = cls.__dict__.get("_unsloth_autocast_instance_mode", False)
     getstate = getattr(self, "__getstate__", None)
     state = getstate() if getstate is not None else self.__dict__
-    return (_reconstruct_bf16_autocast_model, (base_cls, compute_dtype), state)
+    return (_reconstruct_bf16_autocast_model,
+            (base_cls, compute_dtype, instance_mode), state)
 
 
-def _make_bf16_autocast_subclass(cls, compute_dtype):
+def _bf16_autocast_instance_forward(self, *args, **kwargs):
+    """Class-level forward for the `instance_mode` subclass: wraps the model's
+    ORIGINAL instance-level forward (saved on `self._unsloth_autocast_orig_forward`)
+    in autocast. Defined at module scope (not a closure) and read from `self`,
+    so it pickles by import path and rebinds correctly on deepcopy."""
+    orig = self.__dict__["_unsloth_autocast_orig_forward"]
+    compute_dtype = type(self).__dict__.get(
+        "_unsloth_autocast_dtype", torch.bfloat16)
+    return _call_forward_with_bf16_autocast(orig, self, args, kwargs, compute_dtype)
+
+
+def _make_bf16_autocast_subclass(cls, compute_dtype, instance_forward=False):
     """Build (or fetch from cache) a subclass of `cls` whose `forward` is
     wrapped in `torch.amp.autocast(compute_dtype)`.
+
+    Two modes:
+      - default: wrap the base class's `forward`.
+      - `instance_forward=True`: wrap a per-instance original forward stored on
+        `self._unsloth_autocast_orig_forward` (used when the model carried an
+        instance-level `forward`, e.g. Unsloth runtime forward patching).
 
     Picklability: the subclass defines `__reduce__` (`_bf16_autocast_reduce`)
     so model instances serialize via their importable BASE class and are
     reconstructed by `_reconstruct_bf16_autocast_model` -- this is what makes
-    `torch.save(model)` checkpoints loadable in a fresh process. The subclass
-    is also registered as a module-level symbol so that pickling the class
-    object itself (and same-process `copy`/pickle) resolves by name.
+    `torch.save(model)` checkpoints loadable in a fresh process. `forward` is a
+    CLASS attribute (never instance state), so no instance-bound local function
+    is ever serialized. The subclass is also registered as a module-level symbol
+    so that pickling the class object itself resolves by name.
     """
-    cached = _BF16_AUTOCAST_SUBCLASSES.get((cls, compute_dtype))
+    cached = _BF16_AUTOCAST_SUBCLASSES.get((cls, compute_dtype, instance_forward))
     if cached is not None:
         return cached
 
-    _orig_forward = cls.forward
+    if instance_forward:
+        # Generic signature here -- the per-instance original forward is not
+        # available at class-creation time (the class is cached/shared), so
+        # `remove_unused_columns` falls back to keeping all columns for this
+        # (rare) path. Correctness/picklability take priority.
+        _wrapped = _bf16_autocast_instance_forward
+    else:
+        _orig_forward = cls.forward
 
-    @functools.wraps(_orig_forward)
-    def _wrapped(self, *args, **kwargs):
-        return _call_forward_with_bf16_autocast(
-            lambda *a, **k: _orig_forward(self, *a, **k),
-            self, args, kwargs, compute_dtype,
-        )
+        @functools.wraps(_orig_forward)
+        def _wrapped(self, *args, **kwargs):
+            return _call_forward_with_bf16_autocast(
+                lambda *a, **k: _orig_forward(self, *a, **k),
+                self, args, kwargs, compute_dtype,
+            )
 
     # `pickle_name` is unique (for the module-level registration / same-process
     # class pickling); the subclass keeps the ORIGINAL `__name__` so HF
@@ -204,11 +231,12 @@ def _make_bf16_autocast_subclass(cls, compute_dtype):
         "__reduce__": _bf16_autocast_reduce,
         "_unsloth_autocast_base": cls,
         "_unsloth_autocast_dtype": compute_dtype,
+        "_unsloth_autocast_instance_mode": instance_forward,
     })
     new_cls.__name__ = cls.__name__
     new_cls.__qualname__ = pickle_name
     setattr(module, pickle_name, new_cls)
-    _BF16_AUTOCAST_SUBCLASSES[(cls, compute_dtype)] = new_cls
+    _BF16_AUTOCAST_SUBCLASSES[(cls, compute_dtype, instance_forward)] = new_cls
     return new_cls
 
 
@@ -250,22 +278,18 @@ def _wrap_forward_in_bf16_autocast(model, compute_dtype):
     if instance_forward is not None:
         # An instance-level `forward` (e.g. Unsloth runtime forward patching)
         # shadows any class-method override -- `self.forward` resolves the
-        # instance attribute first -- so mutating `__class__` would NOT
-        # intercept it. Wrap the instance attribute directly.
-        #
-        # Bind as a `types.MethodType` so the wrapper receives `self` and reads
-        # the original forward from `self.__dict__` instead of closing over the
-        # original `model`. `copy.deepcopy` rebinds a bound method's `__self__`
-        # to the copy, so the copy's wrapped forward executes against the copy's
-        # parameters (EMA / model averaging / checkpoint paths).
-        @functools.wraps(instance_forward)
-        def _wrapped_instance_forward(self, *args, **kwargs):
-            orig = self.__dict__["_unsloth_autocast_orig_forward"]
-            return _call_forward_with_bf16_autocast(
-                orig, self, args, kwargs, compute_dtype,
-            )
+        # instance attribute first -- so mutating `__class__` alone would NOT
+        # intercept it. Move the original forward to
+        # `_unsloth_autocast_orig_forward`, drop the instance attribute, and
+        # route through the SAME generated-subclass machinery (instance_mode).
+        # This keeps `forward` a CLASS attribute (never serialized as instance
+        # state), so the model stays picklable / deepcopy-safe via `__reduce__`
+        # -- a `types.MethodType` bound to a local function in `__dict__` would
+        # not survive `torch.load` in a fresh interpreter.
         model._unsloth_autocast_orig_forward = instance_forward
-        model.forward = types.MethodType(_wrapped_instance_forward, model)
+        del model.__dict__["forward"]
+        model.__class__ = _make_bf16_autocast_subclass(
+            type(model), compute_dtype, instance_forward=True)
     else:
         model.__class__ = _make_bf16_autocast_subclass(type(model), compute_dtype)
     model._unsloth_bf16_autocast_wrapped = True
@@ -278,42 +302,15 @@ def _unwrap_forward_in_bf16_autocast(model):
     would leave a stale bf16 autocast forcing bf16 compute on fp32 weights."""
     if not getattr(model, "_unsloth_bf16_autocast_wrapped", False):
         return model
+    base_cls = getattr(type(model), "_unsloth_autocast_base", None)
     orig_forward = model.__dict__.pop("_unsloth_autocast_orig_forward", None)
+    if base_cls is not None:
+        model.__class__ = base_cls
     if orig_forward is not None:
+        # restore the original instance-level forward
         model.forward = orig_forward
-    else:
-        base_cls = getattr(type(model), "_unsloth_autocast_base", None)
-        if base_cls is not None:
-            model.__class__ = base_cls
     model._unsloth_bf16_autocast_wrapped = False
     return model
-
-
-def _canonical_module_name(name):
-    """Convert a `named_parameters` key into an attribute path to the owning
-    module (e.g. `model.layers.0.input_layernorm.weight` ->
-    `model.layers[0].input_layernorm`). Only a TRAILING `.weight` / `.bias`
-    parameter suffix is stripped (end-anchored) -- a plain `.replace(...)` would
-    corrupt module names that merely contain `.weight`/`.bias` as a substring
-    (e.g. `...self_attn.bias_proj.weight` or `...weight_scale.weight`)."""
-    module_name = name.replace("base_model", "model", 1)
-    while re.search(r"\.(\d+)\.", module_name) is not None:
-        module_name = re.sub(r"\.(\d+)\.", r"[\1].", module_name)
-    for suffix in (".weight", ".bias"):
-        if module_name.endswith(suffix):
-            return module_name[: -len(suffix)]
-    return module_name
-
-
-def _cast_named_module(model, name, dtype):
-    """Cast the module that owns parameter `name` to `dtype` in place. Shared by
-    the main full-FT cast path and the legacy UNSLOTH_UPCAST_LAYERNORM path so
-    both honour the same module resolution."""
-    module_name = _canonical_module_name(name)
-    try:
-        exec(f"{module_name}.to({str(dtype)})")
-    except Exception:
-        exec(f"model.{module_name}.to({str(dtype)})")
 
 
 @torch.no_grad
@@ -433,24 +430,30 @@ def prepare_model_for_training(
         else:
             param.requires_grad_(False)
 
-        # Upcast to float32 if needed. Skip params owned by a module that
-        # already has `_pre_set_compute_dtype` set (the external compute-dtype
-        # policy will have already cast them) so we don't silently downcast
-        # their fp32 storage back to the compute dtype here.
+        # Cast the parameter storage in place. `param.data = param.data.to(dtype)`
+        # is exactly what `nn.Module._apply` does for a dtype cast: it preserves
+        # the Parameter object identity (so tied weights stay tied) and updates
+        # the storage without the fragile param-name -> module-attribute-path
+        # resolution the old `exec(...)` caster needed. Skip params owned by a
+        # module that already has `_pre_set_compute_dtype` set (the external
+        # compute-dtype policy will have already cast them) so we don't silently
+        # downcast their fp32 storage back to the compute dtype here.
         if requires_grad and id(param) not in _externally_managed_param_ids:
             dtype = torch.float32 if upcast else mixed_precision_dtype
-            _cast_named_module(model, original_name, dtype)
+            if param.dtype != dtype:
+                param.data = param.data.to(dtype)
         pass
 
-        # Legacy UNSLOTH_UPCAST_LAYERNORM path. Now uses the SAME union matcher
-        # and honours the external-policy deferral guard, so it can no longer
+        # Legacy UNSLOTH_UPCAST_LAYERNORM path. Uses the SAME union matcher and
+        # honours the external-policy deferral guard, so it can no longer
         # (a) miss norm1/norm2/class-detected norms or (b) clobber an externally
         # managed norm. Fp32 norms it creates are still handled by the wrapper
         # because installation is gated on the presence of fp32 norms below.
         if (_is_norm
                 and id(param) not in _externally_managed_param_ids
                 and os.environ.get("UNSLOTH_UPCAST_LAYERNORM", "0") == "1"):
-            _cast_named_module(model, original_name, torch.float32)
+            if param.dtype != torch.float32:
+                param.data = param.data.to(torch.float32)
     pass
 
     # Install the bf16 autocast wrapper iff fp32 norm weights ACTUALLY exist

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -94,17 +94,14 @@ def fix_zero_training_loss(model, tokenizer, train_dataset):
 pass
 
 
-# Cache of generated autocast subclasses, keyed by (base_class, compute_dtype).
-# Caching keeps the subclass identity stable across instances of the same base
-# class and lets us register each subclass exactly once as a module-level
-# symbol so pickle / torch.save(model) can resolve it by module + qualname.
+# Cache of generated autocast subclasses keyed by (base_class, compute_dtype):
+# stable identity per base class + one module-level symbol so pickle can resolve it.
 _BF16_AUTOCAST_SUBCLASSES = {}
 
 
 def _find_tensor_device_type(*values):
-    """Device type of the first tensor found in args/kwargs, recursing into
-    mappings / lists / tuples (HF batches are often dicts; VLM inputs nest
-    tensors). Returns None if no tensor is found."""
+    """Device type of the first tensor in args/kwargs, recursing into dict/list/tuple
+    (HF batches are dicts; VLM inputs nest tensors). None if no tensor found."""
     from collections.abc import Mapping
     stack = list(values)
     while stack:
@@ -119,19 +116,16 @@ def _find_tensor_device_type(*values):
 
 
 def _call_forward_with_bf16_autocast(forward, model, args, kwargs, compute_dtype):
-    """Run `forward(*args, **kwargs)` inside `torch.amp.autocast(compute_dtype)`.
-    Device type is sniffed from the inputs (recursing into containers), falling
-    back to the model's parameter device, then "cuda". Defers to an outer
-    autocast that is already active, and to unsupported device types (meta).
-    Shared by both the subclass and instance-attribute wrapper paths."""
+    """Run forward inside torch.amp.autocast(compute_dtype). Device is sniffed from
+    inputs, else model params, else "cuda". Defers to an active outer autocast and to
+    unsupported devices (meta). Shared by the subclass and instance-forward paths."""
     device_type = _find_tensor_device_type(*args, *kwargs.values())
     if device_type is None:
         try:
             device_type = next(model.parameters()).device.type
         except StopIteration:
             device_type = "cuda"
-    # Order matters: is_autocast_enabled raises on unsupported device types
-    # (e.g. "meta"); is_autocast_available returns False cleanly.
+    # Check availability first: is_autocast_enabled raises on e.g. "meta"; available returns False.
     if not torch.amp.is_autocast_available(device_type):
         return forward(*args, **kwargs)
     if torch.is_autocast_enabled(device_type):
@@ -141,22 +135,16 @@ def _call_forward_with_bf16_autocast(forward, model, args, kwargs, compute_dtype
 
 
 def _reconstruct_bf16_autocast_model(base_cls, compute_dtype, instance_mode=False):
-    """Pickle / deepcopy reconstructor. Rebuilds (or fetches) the autocast
-    subclass from the IMPORTABLE base class, then returns a blank instance for
-    `__setstate__` to populate. Because reconstruction is driven by the base
-    class (which IS importable by module + qualname) rather than by the
-    runtime-generated subclass symbol, unpickling works in a FRESH interpreter
-    where `_make_bf16_autocast_subclass` has not been called yet (e.g. loading
-    a `torch.save(model)` checkpoint in another process / session)."""
+    """Pickle/deepcopy reconstructor: rebuild the subclass from the importable base
+    class and return a blank instance for __setstate__. Driving off the base class
+    (not the generated symbol) lets unpickling work in a fresh interpreter."""
     cls = _make_bf16_autocast_subclass(base_cls, compute_dtype, instance_mode)
     return cls.__new__(cls)
 
 
 def _bf16_autocast_reduce(self):
-    """`__reduce__` for generated autocast subclasses. Serialize via the base
-    class + the standard nn.Module state so no dynamically-generated class
-    symbol (and no instance-bound local function) needs to be resolvable at
-    unpickle time."""
+    """__reduce__ for generated subclasses: serialize via the base class + nn.Module
+    state so no generated symbol or instance-bound function is needed at unpickle."""
     cls = type(self)
     base_cls = cls.__dict__.get("_unsloth_autocast_base", cls.__mro__[1])
     compute_dtype = cls.__dict__.get("_unsloth_autocast_dtype", torch.bfloat16)
@@ -168,10 +156,9 @@ def _bf16_autocast_reduce(self):
 
 
 def _bf16_autocast_instance_forward(self, *args, **kwargs):
-    """Class-level forward for the `instance_mode` subclass: wraps the model's
-    ORIGINAL instance-level forward (saved on `self._unsloth_autocast_orig_forward`)
-    in autocast. Defined at module scope (not a closure) and read from `self`,
-    so it pickles by import path and rebinds correctly on deepcopy."""
+    """Class-level forward for instance_mode: wraps the original instance forward
+    (saved on self._unsloth_autocast_orig_forward) in autocast. Module-scoped (not a
+    closure) and read from self, so it pickles by import path and rebinds on deepcopy."""
     orig = self.__dict__["_unsloth_autocast_orig_forward"]
     compute_dtype = type(self).__dict__.get(
         "_unsloth_autocast_dtype", torch.bfloat16)
@@ -179,32 +166,19 @@ def _bf16_autocast_instance_forward(self, *args, **kwargs):
 
 
 def _make_bf16_autocast_subclass(cls, compute_dtype, instance_forward=False):
-    """Build (or fetch from cache) a subclass of `cls` whose `forward` is
-    wrapped in `torch.amp.autocast(compute_dtype)`.
-
-    Two modes:
-      - default: wrap the base class's `forward`.
-      - `instance_forward=True`: wrap a per-instance original forward stored on
-        `self._unsloth_autocast_orig_forward` (used when the model carried an
-        instance-level `forward`, e.g. Unsloth runtime forward patching).
-
-    Picklability: the subclass defines `__reduce__` (`_bf16_autocast_reduce`)
-    so model instances serialize via their importable BASE class and are
-    reconstructed by `_reconstruct_bf16_autocast_model` -- this is what makes
-    `torch.save(model)` checkpoints loadable in a fresh process. `forward` is a
-    CLASS attribute (never instance state), so no instance-bound local function
-    is ever serialized. The subclass is also registered as a module-level symbol
-    so that pickling the class object itself resolves by name.
-    """
+    """Build (or fetch from cache) a subclass of cls whose forward runs in
+    torch.amp.autocast(compute_dtype). Default wraps the base forward;
+    instance_forward=True wraps the per-instance forward saved on the model (Unsloth
+    runtime patching). __reduce__ serializes via the importable base class and forward
+    is a class attribute, so torch.save(model) loads in a fresh process. The subclass
+    is registered as a module-level symbol so the class itself also pickles by name."""
     cached = _BF16_AUTOCAST_SUBCLASSES.get((cls, compute_dtype, instance_forward))
     if cached is not None:
         return cached
 
     if instance_forward:
-        # Generic signature here -- the per-instance original forward is not
-        # available at class-creation time (the class is cached/shared), so
-        # `remove_unused_columns` falls back to keeping all columns for this
-        # (rare) path. Correctness/picklability take priority.
+        # Generic signature: the per-instance forward is not known at (cached) class
+        # creation, so remove_unused_columns keeps all columns on this rare path.
         _wrapped = _bf16_autocast_instance_forward
     else:
         _orig_forward = cls.forward
@@ -216,10 +190,8 @@ def _make_bf16_autocast_subclass(cls, compute_dtype, instance_forward=False):
                 self, args, kwargs, compute_dtype,
             )
 
-    # `pickle_name` is unique (for the module-level registration / same-process
-    # class pickling); the subclass keeps the ORIGINAL `__name__` so HF
-    # save_pretrained writes the base class into config.architectures rather
-    # than the generated wrapper name.
+    # pickle_name is unique for module-level registration; the subclass keeps the
+    # original __name__ so save_pretrained records the base class in architectures.
     pickle_name = cls.__name__ + "WithUnslothBf16Autocast"
     module = sys.modules[__name__]
     if hasattr(module, pickle_name) and getattr(module, pickle_name) is not None:
@@ -241,34 +213,13 @@ def _make_bf16_autocast_subclass(cls, compute_dtype, instance_forward=False):
 
 
 def _wrap_forward_in_bf16_autocast(model, compute_dtype):
-    """For bf16 full-FT with fp32 norm weights, the norm forward returns an
-    fp32 tensor which then meets the next bf16 linear and trips
-    `F.linear`'s dtype-equality check. Wrap `model.forward` in
-    `torch.amp.autocast(compute_dtype)` so linear/matmul inputs are
-    downcast at the op boundary -- the standard PyTorch mixed-precision
-    pattern PEFT and Accelerate already rely on. Idempotent; defers to an
-    outer autocast context if one is already active.
-
-    Implementation notes:
-      - `functools.wraps(_orig_forward)` preserves the model's forward
-        signature so `inspect.signature(model.forward)` still reports
-        the real parameter names. HF `Trainer._set_signature_columns_if_needed`
-        reads that signature to decide which dataset columns to keep under
-        `remove_unused_columns=True`.
-      - The wrap is installed by subclassing `type(model)` and overriding
-        `forward` on the new class, rather than reassigning `model.forward`
-        to a closure. `copy.deepcopy(model)` (used by EMA / model averaging
-        / `Trainer._save_optimizer_and_scheduler` checkpoint paths) uses
-        `obj.__class__` to reconstruct the copy, so the subclass survives
-        and the copy's `forward` correctly binds to the copy's `self`.
-      - The subclass is cached and registered as a module-level symbol (see
-        `_make_bf16_autocast_subclass`) so `pickle` / `torch.save(model)` can
-        resolve it by `module + qualname` instead of raising `PicklingError`.
-      - `is_autocast_available(device_type)` is probed BEFORE
-        `is_autocast_enabled(device_type)` because the latter raises on
-        unsupported device types (e.g. "meta" tensors during materialise),
-        whereas `is_autocast_available` returns False cleanly.
-    """
+    """With fp32 norm weights the norm forward returns fp32, which trips the next
+    bf16 linear's dtype check; wrap model.forward in autocast(compute_dtype) so
+    linear/matmul inputs downcast at the op boundary (the standard PEFT/Accelerate
+    pattern). Idempotent and defers to an active outer autocast. Implemented by
+    subclassing type(model) (not reassigning forward) so the wrap survives
+    deepcopy/pickle/torch.save; functools.wraps preserves the forward signature for
+    HF Trainer's remove_unused_columns."""
     if compute_dtype in (None, torch.float32):
         return model
     if getattr(model, "_unsloth_bf16_autocast_wrapped", False):
@@ -276,16 +227,10 @@ def _wrap_forward_in_bf16_autocast(model, compute_dtype):
 
     instance_forward = model.__dict__.get("forward")
     if instance_forward is not None:
-        # An instance-level `forward` (e.g. Unsloth runtime forward patching)
-        # shadows any class-method override -- `self.forward` resolves the
-        # instance attribute first -- so mutating `__class__` alone would NOT
-        # intercept it. Move the original forward to
-        # `_unsloth_autocast_orig_forward`, drop the instance attribute, and
-        # route through the SAME generated-subclass machinery (instance_mode).
-        # This keeps `forward` a CLASS attribute (never serialized as instance
-        # state), so the model stays picklable / deepcopy-safe via `__reduce__`
-        # -- a `types.MethodType` bound to a local function in `__dict__` would
-        # not survive `torch.load` in a fresh interpreter.
+        # An instance-level forward (e.g. Unsloth runtime patching) shadows a class
+        # override, so changing __class__ alone would not intercept it. Move it to
+        # _unsloth_autocast_orig_forward and route through the instance_mode subclass,
+        # keeping forward a class attribute so the model stays picklable/deepcopy-safe.
         model._unsloth_autocast_orig_forward = instance_forward
         del model.__dict__["forward"]
         model.__class__ = _make_bf16_autocast_subclass(
@@ -297,9 +242,8 @@ def _wrap_forward_in_bf16_autocast(model, compute_dtype):
 
 
 def _unwrap_forward_in_bf16_autocast(model):
-    """Undo a previous `_wrap_forward_in_bf16_autocast`. Without this, reusing
-    the same model object across prepare modes (e.g. bf16 full-FT then fp32)
-    would leave a stale bf16 autocast forcing bf16 compute on fp32 weights."""
+    """Undo _wrap_forward_in_bf16_autocast, so reusing a model across prepare modes
+    (bf16 full-FT then fp32) does not leave a stale autocast forcing bf16 on fp32."""
     if not getattr(model, "_unsloth_bf16_autocast_wrapped", False):
         return model
     base_cls = getattr(type(model), "_unsloth_autocast_base", None)
@@ -359,36 +303,27 @@ def prepare_model_for_training(
         mixed_precision_dtype = torch.float32
         os.environ["UNSLOTH_MIXED_PRECISION"] = "float32"
     pass
-    # Defer to any external compute-dtype policy already in effect on norm
-    # modules (e.g. UNSLOTH_HIGH_PRECISION_LAYERNORM which tags norm modules
-    # with `_pre_set_compute_dtype`). Record those parameter ids so we leave
-    # them alone instead of overwriting that policy.
+    # Defer to an external norm dtype policy (e.g. UNSLOTH_HIGH_PRECISION_LAYERNORM
+    # tags modules with _pre_set_compute_dtype); record those param ids and skip them.
     _externally_managed_param_ids = set()
-    # Also identify norm parameters by the OWNING MODULE's class name, not just
-    # by parameter-name substrings. Custom norm classes whose params don't carry
-    # a recognisable name token (e.g. Gemma audio tower's `norm_out`,
-    # `norm_pre_attn`, `norm_post_attn`) are missed by name matching alone but
-    # are still RMSNorm/LayerNorm modules that must be upcast for bf16 full-FT.
+    # Also detect norms by owning-module class name, catching custom norms whose
+    # param names lack a token (e.g. Gemma audio tower norm_out/norm_pre_attn).
     _norm_class_re = re.compile(r"(?i)(rms_?norm|layer_?norm)")
     _norm_param_ids = set()
     for _, _module in model.named_modules():
         if hasattr(_module, "_pre_set_compute_dtype"):
-            # Recurse: the external policy casts the tagged module recursively
-            # (`module.to(module._pre_set_compute_dtype)`), so every descendant
-            # parameter is externally managed and must not be re-cast here.
+            # The external policy casts the module recursively, so all descendants are managed.
             for _p in _module.parameters(recurse=True):
                 _externally_managed_param_ids.add(id(_p))
         if _norm_class_re.search(type(_module).__name__):
             for _, _p in _module.named_parameters(recurse=False):
                 _norm_param_ids.add(id(_p))
-    # Rollback switch (defaults off = corrected behaviour). Set to 1 to keep
-    # norm weights at their loaded dtype like the pre-fix code path.
+    # Rollback switch (default off): 1 keeps norm weights at their loaded dtype (pre-fix).
     _disable_float32_norm_upcast = (
         os.environ.get("UNSLOTH_DISABLE_FLOAT32_UPCAST", "0") == "1")
 
     def _is_norm_parameter(nm, p):
-        # Union matcher (also used by the legacy UNSLOTH_UPCAST_LAYERNORM path):
-        # owning-module class name OR known parameter-name substrings.
+        # Union matcher: owning-module class name OR known param-name substrings.
         return (
             id(p) in _norm_param_ids
             or "norm." in nm
@@ -410,12 +345,9 @@ def prepare_model_for_training(
             else:
                 requires_grad = False
         else:
-            # Full finetuning: train everything by default at compute dtype.
-            # Norm weights must be upcast to float32 for adam writeback
-            # precision -- without this ~60% of bf16 adam updates round to
-            # zero on writeback (measured on Qwen3-0.6B input_layernorm).
-            # Previously a dangling `else:` attached to `if train_lm_head:`
-            # silently clobbered the `upcast = True` set for norms above it.
+            # Full finetuning trains everything at compute dtype, but norms must be fp32
+            # for adam writeback precision (~60% of bf16 norm updates round to zero
+            # otherwise). A prior dangling else on `if train_lm_head:` had clobbered this.
             requires_grad = True
             upcast = False
             if (train_layernorms
@@ -430,25 +362,17 @@ def prepare_model_for_training(
         else:
             param.requires_grad_(False)
 
-        # Cast the parameter storage in place. `param.data = param.data.to(dtype)`
-        # is exactly what `nn.Module._apply` does for a dtype cast: it preserves
-        # the Parameter object identity (so tied weights stay tied) and updates
-        # the storage without the fragile param-name -> module-attribute-path
-        # resolution the old `exec(...)` caster needed. Skip params owned by a
-        # module that already has `_pre_set_compute_dtype` set (the external
-        # compute-dtype policy will have already cast them) so we don't silently
-        # downcast their fp32 storage back to the compute dtype here.
+        # Cast storage in place via param.data.to(dtype) (like nn.Module._apply): keeps
+        # the Parameter identity so tied weights stay tied, and avoids the old exec()
+        # path. Skip externally-managed params so we don't undo their fp32 cast.
         if requires_grad and id(param) not in _externally_managed_param_ids:
             dtype = torch.float32 if upcast else mixed_precision_dtype
             if param.dtype != dtype:
                 param.data = param.data.to(dtype)
         pass
 
-        # Legacy UNSLOTH_UPCAST_LAYERNORM path. Uses the SAME union matcher and
-        # honours the external-policy deferral guard, so it can no longer
-        # (a) miss norm1/norm2/class-detected norms or (b) clobber an externally
-        # managed norm. Fp32 norms it creates are still handled by the wrapper
-        # because installation is gated on the presence of fp32 norms below.
+        # Legacy UNSLOTH_UPCAST_LAYERNORM path: same union matcher + external-policy
+        # guard; any fp32 norms it creates are handled by the wrapper gate below.
         if (_is_norm
                 and id(param) not in _externally_managed_param_ids
                 and os.environ.get("UNSLOTH_UPCAST_LAYERNORM", "0") == "1"):
@@ -456,15 +380,9 @@ def prepare_model_for_training(
                 param.data = param.data.to(torch.float32)
     pass
 
-    # Install the bf16 autocast wrapper iff fp32 norm weights ACTUALLY exist
-    # (from our upcast, the legacy env upcast, or an external
-    # `_pre_set_compute_dtype` policy). Gating on the presence of fp32 norms --
-    # not on the upcast DECISION -- means: (1) `UNSLOTH_DISABLE_FLOAT32_UPCAST=1`
-    # never leaves externally-managed fp32 norms exposed to a bf16 linear with
-    # no autocast context, and (2) we never class-mutate a model that has no
-    # fp32 norm. With fp32 norms, the norm forward returns fp32 which would trip
-    # the next bf16 linear's dtype check; autocast(bf16) downcasts at the op
-    # boundary -- the canonical PyTorch mixed-precision pattern.
+    # Install the autocast wrapper only if fp32 norms actually exist (our upcast, the
+    # legacy env, or an external policy). Gating on presence (not the upcast decision)
+    # avoids exposing external fp32 norms under rollback and never wraps a model without them.
     _has_fp32_norms = any(
         _is_norm_parameter(nm, p) and p.dtype == torch.float32
         for nm, p in model.named_parameters()

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -101,15 +101,40 @@ pass
 _BF16_AUTOCAST_SUBCLASSES = {}
 
 
+def _reconstruct_bf16_autocast_model(base_cls, compute_dtype):
+    """Pickle / deepcopy reconstructor. Rebuilds (or fetches) the autocast
+    subclass from the IMPORTABLE base class, then returns a blank instance for
+    `__setstate__` to populate. Because reconstruction is driven by the base
+    class (which IS importable by module + qualname) rather than by the
+    runtime-generated subclass symbol, unpickling works in a FRESH interpreter
+    where `_make_bf16_autocast_subclass` has not been called yet (e.g. loading
+    a `torch.save(model)` checkpoint in another process / session)."""
+    cls = _make_bf16_autocast_subclass(base_cls, compute_dtype)
+    return cls.__new__(cls)
+
+
+def _bf16_autocast_reduce(self):
+    """`__reduce__` for generated autocast subclasses. Serialize via the base
+    class + the standard nn.Module state so no dynamically-generated class
+    symbol needs to be resolvable at unpickle time."""
+    cls = type(self)
+    base_cls = cls.__dict__.get("_unsloth_autocast_base", cls.__mro__[1])
+    compute_dtype = cls.__dict__.get("_unsloth_autocast_dtype", torch.bfloat16)
+    getstate = getattr(self, "__getstate__", None)
+    state = getstate() if getstate is not None else self.__dict__
+    return (_reconstruct_bf16_autocast_model, (base_cls, compute_dtype), state)
+
+
 def _make_bf16_autocast_subclass(cls, compute_dtype):
     """Build (or fetch from cache) a subclass of `cls` whose `forward` is
     wrapped in `torch.amp.autocast(compute_dtype)`.
 
-    The subclass is registered as a module-level attribute of this module so
-    that `pickle` (and therefore `torch.save(model, ...)`) can resolve it by
-    `module + qualname`. Without that registration, assigning a runtime
-    `type(...)` class to `model.__class__` makes the model unpicklable
-    (`PicklingError: attribute lookup ... failed`).
+    Picklability: the subclass defines `__reduce__` (`_bf16_autocast_reduce`)
+    so model instances serialize via their importable BASE class and are
+    reconstructed by `_reconstruct_bf16_autocast_model` -- this is what makes
+    `torch.save(model)` checkpoints loadable in a fresh process. The subclass
+    is also registered as a module-level symbol so that pickling the class
+    object itself (and same-process `copy`/pickle) resolves by name.
     """
     cached = _BF16_AUTOCAST_SUBCLASSES.get((cls, compute_dtype))
     if cached is not None:
@@ -145,7 +170,13 @@ def _make_bf16_autocast_subclass(cls, compute_dtype):
     if hasattr(module, name) and getattr(module, name) is not None:
         name = f"{name}_{len(_BF16_AUTOCAST_SUBCLASSES)}"
 
-    new_cls = type(name, (cls,), {"forward": _wrapped, "__module__": __name__})
+    new_cls = type(name, (cls,), {
+        "forward": _wrapped,
+        "__module__": __name__,
+        "__reduce__": _bf16_autocast_reduce,
+        "_unsloth_autocast_base": cls,
+        "_unsloth_autocast_dtype": compute_dtype,
+    })
     new_cls.__qualname__ = name
     setattr(module, name, new_cls)
     _BF16_AUTOCAST_SUBCLASSES[(cls, compute_dtype)] = new_cls

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -242,10 +242,20 @@ def prepare_model_for_training(
     # with `_pre_set_compute_dtype`). Record those parameter ids so we leave
     # them alone instead of overwriting that policy.
     _externally_managed_param_ids = set()
+    # Also identify norm parameters by the OWNING MODULE's class name, not just
+    # by parameter-name substrings. Custom norm classes whose params don't carry
+    # a recognisable name token (e.g. Gemma audio tower's `norm_out`,
+    # `norm_pre_attn`, `norm_post_attn`) are missed by name matching alone but
+    # are still RMSNorm/LayerNorm modules that must be upcast for bf16 full-FT.
+    _norm_class_re = re.compile(r"(?i)(rms_?norm|layer_?norm)")
+    _norm_param_ids = set()
     for _, _module in model.named_modules():
         if hasattr(_module, "_pre_set_compute_dtype"):
             for _, _p in _module.named_parameters(recurse=False):
                 _externally_managed_param_ids.add(id(_p))
+        if _norm_class_re.search(type(_module).__name__):
+            for _, _p in _module.named_parameters(recurse=False):
+                _norm_param_ids.add(id(_p))
     # Rollback switch (defaults off = corrected behaviour). Set to 1 to keep
     # norm weights at their loaded dtype like the pre-fix code path.
     _disable_float32_norm_upcast = (
@@ -269,13 +279,17 @@ def prepare_model_for_training(
             # silently clobbered the `upcast = True` set for norms above it.
             requires_grad = True
             upcast = False
-            # Norm-name matcher catches the patterns we've seen in the wild:
+            # Norm matcher: union of (a) owning-module class name being a
+            # RMSNorm/LayerNorm (robust, catches any naming), and (b) the
+            # parameter-name patterns we've seen in the wild:
             #   Llama/Qwen3:        "input_layernorm", "model.norm",
             #                       "self_attn.q_norm", "self_attn.k_norm"
             #   SigLIP/CLIP vision: "encoder.layers.0.layer_norm1/2"
             #   ViT/DINO/Qwen3-VL:  "visual.blocks.0.norm1/2"
+            #   Gemma audio tower:  "norm_out", "norm_pre_attn", "norm_post_attn"
             _is_norm_name = (
-                "norm." in name
+                id(param) in _norm_param_ids
+                or "norm." in name
                 or "_layernorm" in name
                 or "layer_norm" in name
                 or "norm1." in name

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -32,6 +32,7 @@ from .gradient_checkpointing import (
 )
 import os
 import re
+import sys
 import functools
 
 __all__ = [
@@ -93,6 +94,64 @@ def fix_zero_training_loss(model, tokenizer, train_dataset):
 pass
 
 
+# Cache of generated autocast subclasses, keyed by (base_class, compute_dtype).
+# Caching keeps the subclass identity stable across instances of the same base
+# class and lets us register each subclass exactly once as a module-level
+# symbol so pickle / torch.save(model) can resolve it by module + qualname.
+_BF16_AUTOCAST_SUBCLASSES = {}
+
+
+def _make_bf16_autocast_subclass(cls, compute_dtype):
+    """Build (or fetch from cache) a subclass of `cls` whose `forward` is
+    wrapped in `torch.amp.autocast(compute_dtype)`.
+
+    The subclass is registered as a module-level attribute of this module so
+    that `pickle` (and therefore `torch.save(model, ...)`) can resolve it by
+    `module + qualname`. Without that registration, assigning a runtime
+    `type(...)` class to `model.__class__` makes the model unpicklable
+    (`PicklingError: attribute lookup ... failed`).
+    """
+    cached = _BF16_AUTOCAST_SUBCLASSES.get((cls, compute_dtype))
+    if cached is not None:
+        return cached
+
+    _orig_forward = cls.forward
+
+    @functools.wraps(_orig_forward)
+    def _wrapped(self, *args, **kwargs):
+        device_type = "cuda"
+        for t in args:
+            if torch.is_tensor(t):
+                device_type = t.device.type
+                break
+        else:
+            for t in kwargs.values():
+                if torch.is_tensor(t):
+                    device_type = t.device.type
+                    break
+        # Order matters: is_autocast_enabled raises on unsupported device
+        # types (e.g. "meta"); is_autocast_available returns False cleanly.
+        if not torch.amp.is_autocast_available(device_type):
+            return _orig_forward(self, *args, **kwargs)
+        if torch.is_autocast_enabled(device_type):
+            return _orig_forward(self, *args, **kwargs)
+        with torch.amp.autocast(device_type=device_type, dtype=compute_dtype):
+            return _orig_forward(self, *args, **kwargs)
+
+    name = cls.__name__ + "WithUnslothBf16Autocast"
+    module = sys.modules[__name__]
+    # Disambiguate if two different base classes share the same __name__ so
+    # each registered symbol resolves back to exactly one subclass.
+    if hasattr(module, name) and getattr(module, name) is not None:
+        name = f"{name}_{len(_BF16_AUTOCAST_SUBCLASSES)}"
+
+    new_cls = type(name, (cls,), {"forward": _wrapped, "__module__": __name__})
+    new_cls.__qualname__ = name
+    setattr(module, name, new_cls)
+    _BF16_AUTOCAST_SUBCLASSES[(cls, compute_dtype)] = new_cls
+    return new_cls
+
+
 def _wrap_forward_in_bf16_autocast(model, compute_dtype):
     """For bf16 full-FT with fp32 norm weights, the norm forward returns an
     fp32 tensor which then meets the next bf16 linear and trips
@@ -114,6 +173,9 @@ def _wrap_forward_in_bf16_autocast(model, compute_dtype):
         / `Trainer._save_optimizer_and_scheduler` checkpoint paths) uses
         `obj.__class__` to reconstruct the copy, so the subclass survives
         and the copy's `forward` correctly binds to the copy's `self`.
+      - The subclass is cached and registered as a module-level symbol (see
+        `_make_bf16_autocast_subclass`) so `pickle` / `torch.save(model)` can
+        resolve it by `module + qualname` instead of raising `PicklingError`.
       - `is_autocast_available(device_type)` is probed BEFORE
         `is_autocast_enabled(device_type)` because the latter raises on
         unsupported device types (e.g. "meta" tensors during materialise),
@@ -124,31 +186,7 @@ def _wrap_forward_in_bf16_autocast(model, compute_dtype):
     if getattr(model, "_unsloth_bf16_autocast_wrapped", False):
         return model
 
-    _orig_forward = type(model).forward
-
-    @functools.wraps(_orig_forward)
-    def _wrapped(self, *args, **kwargs):
-        device_type = "cuda"
-        for t in list(args) + list(kwargs.values()):
-            if torch.is_tensor(t):
-                device_type = t.device.type
-                break
-        # Order matters: is_autocast_enabled raises on unsupported device
-        # types (e.g. "meta"); is_autocast_available returns False cleanly.
-        if not torch.amp.is_autocast_available(device_type):
-            return _orig_forward(self, *args, **kwargs)
-        if torch.is_autocast_enabled(device_type):
-            return _orig_forward(self, *args, **kwargs)
-        with torch.amp.autocast(device_type=device_type, dtype=compute_dtype):
-            return _orig_forward(self, *args, **kwargs)
-
-    cls = type(model)
-    new_cls = type(
-        cls.__name__ + "WithUnslothBf16Autocast",
-        (cls,),
-        {"forward": _wrapped},
-    )
-    model.__class__ = new_cls
+    model.__class__ = _make_bf16_autocast_subclass(type(model), compute_dtype)
     model._unsloth_bf16_autocast_wrapped = True
     return model
 
@@ -240,8 +278,8 @@ def prepare_model_for_training(
                 "norm." in name
                 or "_layernorm" in name
                 or "layer_norm" in name
-                or ".norm1." in name
-                or ".norm2." in name
+                or "norm1." in name
+                or "norm2." in name
             )
             if (train_layernorms
                     and _is_norm_name

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -32,6 +32,7 @@ from .gradient_checkpointing import (
 )
 import os
 import re
+import functools
 
 __all__ = [
     "fix_zero_training_loss",
@@ -100,28 +101,54 @@ def _wrap_forward_in_bf16_autocast(model, compute_dtype):
     downcast at the op boundary -- the standard PyTorch mixed-precision
     pattern PEFT and Accelerate already rely on. Idempotent; defers to an
     outer autocast context if one is already active.
+
+    Implementation notes:
+      - `functools.wraps(_orig_forward)` preserves the model's forward
+        signature so `inspect.signature(model.forward)` still reports
+        the real parameter names. HF `Trainer._set_signature_columns_if_needed`
+        reads that signature to decide which dataset columns to keep under
+        `remove_unused_columns=True`.
+      - The wrap is installed by subclassing `type(model)` and overriding
+        `forward` on the new class, rather than reassigning `model.forward`
+        to a closure. `copy.deepcopy(model)` (used by EMA / model averaging
+        / `Trainer._save_optimizer_and_scheduler` checkpoint paths) uses
+        `obj.__class__` to reconstruct the copy, so the subclass survives
+        and the copy's `forward` correctly binds to the copy's `self`.
+      - `is_autocast_available(device_type)` is probed BEFORE
+        `is_autocast_enabled(device_type)` because the latter raises on
+        unsupported device types (e.g. "meta" tensors during materialise),
+        whereas `is_autocast_available` returns False cleanly.
     """
     if compute_dtype in (None, torch.float32):
         return model
     if getattr(model, "_unsloth_bf16_autocast_wrapped", False):
         return model
-    _orig_forward = model.forward
 
-    def _wrapped(*args, **kwargs):
-        # Try to pick the right device_type from the first tensor we see.
+    _orig_forward = type(model).forward
+
+    @functools.wraps(_orig_forward)
+    def _wrapped(self, *args, **kwargs):
         device_type = "cuda"
         for t in list(args) + list(kwargs.values()):
             if torch.is_tensor(t):
                 device_type = t.device.type
                 break
-        if torch.is_autocast_enabled(device_type):
-            return _orig_forward(*args, **kwargs)
+        # Order matters: is_autocast_enabled raises on unsupported device
+        # types (e.g. "meta"); is_autocast_available returns False cleanly.
         if not torch.amp.is_autocast_available(device_type):
-            return _orig_forward(*args, **kwargs)
+            return _orig_forward(self, *args, **kwargs)
+        if torch.is_autocast_enabled(device_type):
+            return _orig_forward(self, *args, **kwargs)
         with torch.amp.autocast(device_type=device_type, dtype=compute_dtype):
-            return _orig_forward(*args, **kwargs)
+            return _orig_forward(self, *args, **kwargs)
 
-    model.forward = _wrapped
+    cls = type(model)
+    new_cls = type(
+        cls.__name__ + "WithUnslothBf16Autocast",
+        (cls,),
+        {"forward": _wrapped},
+    )
+    model.__class__ = new_cls
     model._unsloth_bf16_autocast_wrapped = True
     return model
 


### PR DESCRIPTION
## Summary

For bf16 full finetuning, LayerNorm / RMSNorm `.weight` parameters
were being left in bf16 instead of upcast to fp32. The root cause was
a dangling `else:` attached to the `if train_lm_head:` branch in
`prepare_model_for_training`, which clobbered the `upcast = True` set
above it for norm weights.

Empirical impact on `unsloth/Qwen3-0.6B` full-FT, one SGD step at
`lr=1e-2`, on `model.layers.0.input_layernorm.weight`:

| | before | after |
|---|---|---|
| norm weight storage | bf16 | fp32 |
| weight.grad.dtype | bf16 | fp32 |
| weight delta = 0 | 613 / 1024 (60%) | 0 / 128 |

About 60% of bf16 adam writeback updates rounded to zero at the bf16
ULP of the norm weight magnitude, so the norm weights effectively
stopped training.

## Scope

Strictly narrowed to bf16 full finetuning. LoRA and QLoRA
byte identical to current main; norms stay bf16 frozen.

- `full_finetuning=True` + `train_layernorms=True`: norm `.weight` is
  upcast to fp32 when matched by `"norm."` / `"_layernorm"
  `"layer_norm"` / `".norm1."` / `".norm2."`. The last two ViT-style
  patterns cover Qwen3-VL, DINO, SigLIP visual encoders.
- `full_finetuning=False` (LoRA / QLoRA): unchanged.
- `bias`, `lm_head`, `embed_tokens`: intentionally not in
  at compute dtype (matches pristine main).
- If a norm module already carries `_pre_set_compute_dtype
  by `UNSLOTH_HIGH_PRECISION_LAYERNORM=1`, which the loader auto-sets
  for Gemma-3, Gemma-3N, Granite-4, gpt_oss), this fix def
  policy and does not overwrite it.

## bf16 forward wrapper

With fp32 norm weights, the norm forward returns an fp32 tensor which
then meets the next bf16 linear and trips `F.linear`'s dty
check. To resolve this without changing user code, `model.forward` is
wrapped in `torch.amp.autocast(bf16)` so linear and matmul
downcast at the op boundary. This is the standard PyTorch mixed-
precision pattern that PEFT and Accelerate already rely on
defers to any outer autocast context.

The wrap is installed by subclassing `type(model)` and overriding
`forward` on the new class, not by reassigning `model.forw
closure. That makes the wrap survive `copy.deepcopy(model)` (used by
EMA, model averaging, checkpoint code paths): the copy cor
rebinds `self` to itself instead of leaking back to the original
instance. `functools.wraps` preserves the inspectable forw
signature so HF `Trainer`'s `remove_unused_columns` continues to keep
columns like `input_ids`, `attention_mask`, `labels`. The
availability probe runs before `is_autocast_enabled` so meta-device
tensors do not crash inside the wrapper.

## Rollback

`UNSLOTH_DISABLE_FLOAT32_UPCAST=1` reproduces the pre-fix
behaviour exactly.

## Test plan

- [x] 13 unit tests in
  `tests/test_prepare_model_for_training_fp32_norms.py` co
  - fp32 upcast for full-FT norm weights (incl. `q_norm`, `k_norm`,
    final `model.norm`, ViT `norm1` / `norm2`)
  - deferral to `_pre_set_compute_dtype`
  - LoRA path unchanged (norms stay bf16 frozen, regressio
  - rollback via `UNSLOTH_DISABLE_FLOAT32_UPCAST=1`
  - autocast wrapper preserves forward signature, survives
    is meta-device safe, and is idempotent
- [x] 3-step SFTTrainer smokes on a B200 across 9 architec
  transformers versions (4.57.6, 5.5.4, 5.7.0) x {lora, qlora,
  full-FT}: Llama-3.2-1B, Qwen3-1.7B, Qwen3-VL-2B, Gemma-3
  Gemma-3-4B vision, Gemma-4-E2B, Qwen3.5-0.8B, gpt-oss-20B,
  Qwen3.5-35B-A3B MoE. Cells that fail (e.g. Gemma-3-4B vi
  tfm 4.57 flex_attention) reproduce with the rollback env set and
  are pre-existing, not introduced by this patch.