### PR TITLE
Correct the package name of libcurl-devel for RPM-based systems

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2059,7 +2059,7 @@ def check_libcurl_dev():
             return False, package_name
 
     elif system_type == "rpm":
-        package_name = "libcurl-dev"
+        package_name = "libcurl-devel"
         try:
             result = subprocess.run(['rpm', '-q', package_name], capture_output = True, text = True)
             is_installed = result.returncode == 0


### PR DESCRIPTION
This corrects the package name of `libcurl-devel` in RPM-based systems such as Fedora.

This solves the issue unslothai/unsloth#5666. After digging into the said issue, it was discovered that the cause of the issue is a code found in the `unsloth-zoo` project.

Below is a screenshot showing a smooth run using this fixed code for `unsloth-zoo`:

<img width="2035" height="768" alt="image psd(1)" src="https://github.com/user-attachments/assets/ed0d8c21-e3f1-4c47-8c28-cc0244320981" />


