### PR TITLE
Fix gpt-oss inference BlockMask TypeError

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2155,7 +2155,31 @@ def patch_GptOssModel():
                         return arg
                 return f(*args, **kwargs)
             else:
-                # Eager
+                # Eager inference path. The config may still have
+                # _attn_implementation="flex_attention" (set for training), in
+                # which case the underlying mask factory returns a BlockMask.
+                # Unsloth uses eager attention for inference (flex with KV
+                # cache returns gibberish, see forward_function above), and
+                # the eager forward cannot index a BlockMask, raising
+                #   TypeError: unsupported operand type(s) for +=:
+                #       'Tensor' and 'BlockMask'
+                # Temporarily swap to eager so the factory returns a dense
+                # 4D float mask (0 / -inf) the eager path can consume.
+                config = kwargs.get("config", None)
+                if config is None:
+                    for arg in args:
+                        if hasattr(arg, "_attn_implementation"):
+                            config = arg
+                            break
+                if config is not None and getattr(
+                    config, "_attn_implementation", None
+                ) == "flex_attention":
+                    original_impl = config._attn_implementation
+                    config._attn_implementation = "eager"
+                    try:
+                        return f(*args, **kwargs)
+                    finally:
+                        config._attn_implementation = original_impl
                 return f(*args, **kwargs)
             pass
         return return_attention_mask
@@ -2185,6 +2209,29 @@ def patch_GptOssModel():
         transformers.generation.utils.create_masks_for_generate = wrap(transformers.generation.utils.create_masks_for_generate)
         transformers.masking_utils.__patched_causal_mask__ = True
     pass
+
+    # transformers 4.x uses `input_embeds` and accepts `cache_position`;
+    # transformers 5.x renamed to `inputs_embeds` and dropped `cache_position`.
+    # Inspect the mask factory signatures once and pass only the kwargs they
+    # actually accept so this patch works on both 4.x and 5.x.
+    import inspect as _inspect
+    _ccm_params = set(_inspect.signature(create_causal_mask).parameters)
+    _cswc_params = set(_inspect.signature(create_sliding_window_causal_mask).parameters)
+    _mask_params = _ccm_params | _cswc_params
+
+    def _build_mask_kwargs(config, inputs_embeds, attention_mask, cache_position, past_key_values):
+        mk = {
+            "config": config,
+            "attention_mask": attention_mask,
+            "past_key_values": past_key_values,
+        }
+        if "inputs_embeds" in _mask_params:
+            mk["inputs_embeds"] = inputs_embeds
+        if "input_embeds" in _mask_params:
+            mk["input_embeds"] = inputs_embeds
+        if "cache_position" in _mask_params:
+            mk["cache_position"] = cache_position
+        return mk
 
     from ..flex_attention import (
         is_flex_attention_decoding,
@@ -2378,17 +2425,33 @@ def patch_GptOssModel():
 
         # It may already have been prepared by e.g. `generate`
         if not self.training and not isinstance(attention_mask, dict):
-            mask_kwargs = {
-                "config": self.config,
-                "input_embeds": inputs_embeds,
-                "attention_mask": attention_mask,
-                "cache_position": cache_position,
-                "past_key_values": past_key_values,
-            }
-            attention_mask = {
-                "full_attention": create_causal_mask(**mask_kwargs),
-                "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
-            }
+            # Inference uses eager attention. If the config still has
+            # _attn_implementation="flex_attention" (set for training), the
+            # mask factory returns a BlockMask which eager cannot consume.
+            # Temporarily swap to "eager" so a dense 4D float mask is built.
+            _orig_attn_impl = getattr(self.config, "_attn_implementation", None)
+            _swap_attn_impl = _orig_attn_impl == "flex_attention"
+            if _swap_attn_impl:
+                self.config._attn_implementation = "eager"
+            try:
+                mask_kwargs = _build_mask_kwargs(
+                    config=self.config,
+                    inputs_embeds=inputs_embeds,
+                    attention_mask=attention_mask,
+                    cache_position=cache_position,
+                    past_key_values=past_key_values,
+                )
+                attention_mask = {
+                    "full_attention": create_causal_mask(**{
+                        k: v for k, v in mask_kwargs.items() if k in _ccm_params
+                    }),
+                    "sliding_attention": create_sliding_window_causal_mask(**{
+                        k: v for k, v in mask_kwargs.items() if k in _cswc_params
+                    }),
+                }
+            finally:
+                if _swap_attn_impl:
+                    self.config._attn_implementation = _orig_attn_impl
 
         # is_decoding = is_flex_attention_decoding(self.layers[0].self_attn, hidden_states)
         bsz, qlen, hd = hidden_states.shape

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2104,6 +2104,38 @@ def patch_GptOssAttention():
         return forward_function(self, hidden_states, position_embeddings, attention_mask, past_key_values, cache_position, **kwargs)
 
     functions.append(forward)
+
+    # Transformers >= 5.0 dropped `cache_position` from GptOssAttention.forward's
+    # signature, so the variants above fail the strict signature match and the
+    # attention patch silently does not apply (leaving stock attention, which
+    # then mismatches the sliding-window mask the model patch builds). Provide
+    # cache_position-free variants (it still arrives via **kwargs) so the patch
+    # installs on transformers 5.x too.
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_value: Optional[Cache] = None,
+        **kwargs: KWARGS_TYPE,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
+        cache_position = kwargs.pop("cache_position", None)
+        return forward_function(self, hidden_states, position_embeddings, attention_mask, past_key_value, cache_position, **kwargs)
+
+    functions.append(forward)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        **kwargs: KWARGS_TYPE,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
+        cache_position = kwargs.pop("cache_position", None)
+        return forward_function(self, hidden_states, position_embeddings, attention_mask, past_key_values, cache_position, **kwargs)
+
+    functions.append(forward)
     patch_function_past_key_values(transformers.models.gpt_oss.modeling_gpt_oss.GptOssAttention, "forward", functions)
     # Set env variable for padding purposes
     os.environ["UNSLOTH_ENABLE_FLEX_ATTENTION"] = "1"


### PR DESCRIPTION
## Summary

Fixes a `TypeError: unsupported operand type(s) for +=: 'Tensor' and 'BlockMask'` raised by `model.generate()` on gpt-oss when the config still has `_attn_implementation="flex_attention"` from training.

### Root cause

`gpt-oss` is loaded with `attn_implementation="flex_attention"` for training. Inside `GptOssModel.forward` (both transformers' own and Unsloth's patched copy), `create_causal_mask` / `create_sliding_window_causal_mask` dispatch on `config._attn_implementation` and the flex branch returns `torch.nn.attention.flex_attention.BlockMask` objects.

Unsloth uses eager attention for inference (flex attention with KV cache returns gibberish, see the `forward_function` in `patch_GptOssAttention`). The eager forward indexes the mask as `attention_mask[:, :, :, : key_states.shape[-2]]` and then does `attn_weights += causal_mask`, which crashes because `BlockMask` does not support `+=` against a tensor:

```
File "unsloth_zoo/temporary_patches/gpt_oss.py", line 1932,
    in inplace_eager_attention_forward
    attn_weights += causal_mask
TypeError: unsupported operand type(s) for +=: 'Tensor' and 'BlockMask'
```

### Fix

1. In `wrap(f)` over `create_causal_mask` / `create_sliding_window_causal_mask` / `create_masks_for_generate`: on the inference branch, if `config._attn_implementation == "flex_attention"`, temporarily swap to `"eager"` for the duration of the call so the mask factory returns a dense 4D float mask (`0` / `-inf`) the eager path can consume, then restore the original implementation.
2. In the patched `GptOssModel.forward`: same temporary swap before building `causal_mask_mapping`. Mask kwargs are now built via `inspect`-driven filtering so the patch works on both transformers 4.x (`input_embeds` plus `cache_position`) and 5.x (`inputs_embeds`, no `cache_position`).

The fix is forwards and backwards compatible with transformers 4.57.6 and the 5.x line, and is independent of TRL (no TRL surface is touched).

## Test plan

Reproduced and verified against the `nb/gpt-oss-(20B)-Fine-tuning.ipynb` notebook, run end-to-end on a single B200 with `attn_implementation="flex_attention"` and `max_steps=30`:

- [x] Pre-train inference at `reasoning_effort` low / medium / high all succeed and stream sensible output (previously crashed with the BlockMask TypeError).
- [x] SFT training completes 30/30 steps, `train_loss=1.025`, `train_runtime=247s`.
- [x] Post-train inference at `reasoning_effort="medium"` succeeds.
- [x] `model.save_pretrained("gpt_oss_lora")` writes the adapter files.
- [x] Post-save inference at `reasoning_effort="high"` succeeds.