### PR TITLE
Auto-apply four upstream / runtime monkey-patches for notebook compatibility

### DIFF
--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -16,6 +16,12 @@
 
 __version__ = "2026.5.4"
 
+# Stub numpy._core.tests._natype FIRST -- before anything that might pull in
+# scipy.linalg / transformers.generation / trust_remote_code modelling files.
+# See unsloth_zoo/numpy_compat.py for the full rationale (slim numpy wheels
+# missing the tests/ subpackage that numpy.testing requires).
+from . import numpy_compat  # noqa: F401
+
 import os
 import warnings
 import re

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -400,8 +400,24 @@ def create_empty_model(config, dtype = torch.float16, is_vision_model = False):
 
 @torch.inference_mode
 def set_additional_modules(new_model, quant_state_dict, config):
-    if hasattr(new_model, "language_model"):
+    # Locate the text submodule that holds `embed_tokens`. Three layouts are
+    # observed across transformers >= 5.0:
+    #   1. new_model.language_model.embed_tokens    (old VL: Gemma3, Mistral3,
+    #      Llama-VL via *ForConditionalGeneration with `language_model` exposed
+    #      directly on the outer class).
+    #   2. new_model.model.embed_tokens            (text-only models and
+    #      Qwen3-VL which folds embed_tokens onto the outer .model wrapper).
+    #   3. new_model.model.language_model.embed_tokens (Qwen2.5-VL: outer is
+    #      Qwen2_5_VLForConditionalGeneration, .model is Qwen2_5_VLModel which
+    #      stores the text model under .language_model).
+    # The prefix has to match the key path in quant_state_dict so the embed/
+    # norm/lm_head lookups below resolve correctly.
+    if hasattr(new_model, "language_model") and hasattr(new_model.language_model, "embed_tokens"):
         language_model = new_model.language_model
+        language_model_prefix = "model.language_model"
+    elif hasattr(new_model, "model") and hasattr(new_model.model, "language_model") \
+         and hasattr(new_model.model.language_model, "embed_tokens"):
+        language_model = new_model.model.language_model
         language_model_prefix = "model.language_model"
     else:
         language_model_prefix = "model"

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -277,8 +277,25 @@ def install_package(package, sudo = False, print_output = False, print_outputs =
         install_cmd = f"{'sudo ' if sudo else ''}apt-get install {package} -y"
 
     print(f"Unsloth: Installing packages: {package}")
-    if not (IS_COLAB_ENVIRONMENT or IS_KAGGLE_ENVIRONMENT):
-        acceptance = input(f"Missing system packages. We need to execute `{install_cmd}` - do you accept? Press ENTER. Type NO if not.")
+    # Non-interactive contexts (CI, docker containers, headless notebook
+    # runners) close stdin so input() raises EOFError, which surfaces to
+    # the caller as "GGUF conversion failed: EOF when reading a line".
+    # Treat closed/non-TTY stdin as auto-accept so save_pretrained_gguf
+    # can install build deps on its own. UNSLOTH_AUTO_ACCEPT_INSTALL=1
+    # also forces auto-accept even when stdin is a TTY (for scripts that
+    # want to skip the prompt).
+    auto_accept = (
+        os.environ.get("UNSLOTH_AUTO_ACCEPT_INSTALL", "0") == "1"
+        or not (sys.stdin and sys.stdin.isatty())
+    )
+    if not (IS_COLAB_ENVIRONMENT or IS_KAGGLE_ENVIRONMENT) and not auto_accept:
+        try:
+            acceptance = input(f"Missing system packages. We need to execute `{install_cmd}` - do you accept? Press ENTER. Type NO if not.")
+        except EOFError:
+            # Stdin closed mid-call (eg. docker run -i without -t after a
+            # subprocess took stdin). Treat the same as auto-accept rather
+            # than abort the GGUF export.
+            acceptance = ""
         if "no" in str(acceptance).lower():
             raise RuntimeError(
                 f"Unsloth: Execution of `{install_cmd}` was cancelled!\n"\

--- a/unsloth_zoo/numpy_compat.py
+++ b/unsloth_zoo/numpy_compat.py
@@ -1,0 +1,75 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Stub ``numpy._core.tests._natype`` when the test sub-package is missing.
+
+Some slim numpy 2.x wheels ship without the ``tests/`` sub-package, but
+``numpy/testing/_private/utils.py`` has a top-level
+``from numpy._core.tests._natype import pd_NA`` that mandates it. Importing
+``numpy.testing`` then raises ``ModuleNotFoundError``, which cascades through
+``scipy.linalg`` -> ``scipy.optimize`` -> ``transformers.generation`` ->
+any ``trust_remote_code`` modeling file that pulls in ``GenerationMixin``
+(e.g. ``deepseek-ai/DeepSeek-OCR``). Unsloth's loader catches the exception
+in a bare ``except Exception`` and surfaces the misleading
+``Unsloth: No config file found - are you sure the model_name is correct?``.
+
+Install a lightweight stub when (and only when) the real package is absent.
+The stub sets ``pd_NA = None``; ``numpy.testing`` only uses it for
+``assert_array_equal`` deep-comparison, which always compares with ``is``,
+so a ``None`` sentinel is functionally equivalent on the training path.
+
+Idempotent: safe to import twice. Cross-platform: pure stdlib.
+"""
+
+import sys
+import types
+
+__all__ = ["install_numpy_natype_stub"]
+
+
+def install_numpy_natype_stub() -> bool:
+    if "numpy._core.tests._natype" in sys.modules:
+        return True
+    try:
+        import numpy._core  # noqa: F401
+    except Exception:
+        # numpy not importable at all. Nothing to stub; let downstream
+        # imports fail with their native error.
+        return False
+    try:
+        import numpy._core.tests  # noqa: F401 type: ignore[import-not-found]
+        try:
+            import numpy._core.tests._natype  # noqa: F401 type: ignore[import-not-found]
+            return True  # real module exists, no stub needed.
+        except Exception:
+            pass
+    except Exception:
+        # numpy._core.tests missing entirely; create a placeholder package
+        # so the _natype submodule has a parent.
+        tests_pkg = types.ModuleType("numpy._core.tests")
+        tests_pkg.__path__ = []  # mark as namespace pkg
+        sys.modules["numpy._core.tests"] = tests_pkg
+    if "numpy._core.tests._natype" not in sys.modules:
+        natype = types.ModuleType("numpy._core.tests._natype")
+        # pd_NA is the pandas-NA sentinel that numpy.testing checks via
+        # `is pd_NA` only. A None placeholder is functionally equivalent
+        # for the normal training path.
+        natype.pd_NA = None
+        sys.modules["numpy._core.tests._natype"] = natype
+    return True
+
+
+install_numpy_natype_stub()

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -34,3 +34,4 @@ from .ministral import *
 from .mxfp4 import *
 from .bitsandbytes import *
 from .flex_attention_bwd import *
+from .synthetic_dataprep import *

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -16,6 +16,7 @@
 
 
 from .common import *
+from .notebook_deps import *
 from .gemma import *
 from .misc import *
 from .gemma3n import *

--- a/unsloth_zoo/temporary_patches/bitsandbytes.py
+++ b/unsloth_zoo/temporary_patches/bitsandbytes.py
@@ -68,15 +68,60 @@ def patch_bitsandbytes_linear4bit_forward():
     pass
 
     def forward(self, x: torch.Tensor):
-        # In transformers 5.0+, weights may not be in packed format yet during init
-        if self.weight.shape[-1] == 1:
-            fix_4bit_weight_quant_state_from_module(self)
+        # In transformers 5.0+, weights may not be in packed format yet during init.
+        # Recover the missing `quant_state` for both packed layouts that appear
+        # in transformers 4.x and 5.x with bitsandbytes >= 0.43:
+        #   * `[N, 1]` -- legacy column-packed (handled by bnb upstream's
+        #     `fix_4bit_weight_quant_state_from_module`, which asserts
+        #     `shape[1] == 1`).
+        #   * `[1, N]` -- flat-row-packed used by some Gemma3n /
+        #     conditional-generation layers (e.g. `per_layer_model_projection`).
+        #     bnb's recovery function asserts column-packed, so briefly reshape
+        #     the weight metadata to `[N, 1]` to satisfy the assertion, call
+        #     the recovery, and restore the original shape. Reshape is
+        #     metadata-only on the contiguous nibble buffer; storage bytes are
+        #     untouched and `quant_state.shape` carries the original
+        #     `[out_features, in_features]` for the matmul.
+        w = self.weight
+        if (
+            getattr(w, "quant_state", None) is None
+            and w.dim() == 2
+            and (w.shape[-1] == 1 or w.shape[0] == 1)
+        ):
+            original_shape = tuple(w.shape)
+            try:
+                if w.shape[-1] != 1:
+                    # `[1, N]` -> transient `[N, 1]` so bnb's assert passes.
+                    w.data = w.data.reshape(-1, 1)
+                fix_4bit_weight_quant_state_from_module(self)
+            except AssertionError:
+                # Module also lacks a stashed `module.quant_state`; fall
+                # through to the eager error below with a clearer message.
+                pass
+            finally:
+                if tuple(w.shape) != original_shape:
+                    w.data = w.data.reshape(*original_shape)
 
         # Some layers may not be quantized (no quant_state) - fall back to regular matmul
         quant_state = getattr(self.weight, "quant_state", None)
         if quant_state is None:
             bias = None if self.bias is None else self.bias
             weight = self.weight
+            # Hard-detect "still packed but unrecoverable": shape doesn't
+            # match (out_features, in_features). Emit a specific error
+            # instead of a confusing `mat1 x mat2` mismatch.
+            of = getattr(self, "out_features", None)
+            if_ = getattr(self, "in_features", None)
+            if of is not None and if_ is not None and tuple(weight.shape) != (of, if_):
+                raise RuntimeError(
+                    f"Unsloth: Linear4bit weight is in packed layout {tuple(weight.shape)} "
+                    f"but has no `quant_state` to dequantize. Expected dense "
+                    f"shape ({of}, {if_}). This usually means the model loader "
+                    f"did not register a `quant_state` for this layer. "
+                    f"Workarounds: (1) load with `load_in_4bit=False`, or "
+                    f"(2) add the layer prefix to `llm_int8_skip_modules` so "
+                    f"it is materialised as dense fp16/bf16."
+                )
             if weight.dtype != x.dtype:
                 weight = weight.to(x.dtype)
             if bias is not None and bias.dtype != x.dtype:

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -882,3 +882,104 @@ def patch_Gemma3Attention_generic():
     patch_function_past_key_values(transformers.models.gemma3.modeling_gemma3.Gemma3Attention, "forward", functions, match_level="relaxed")
 pass
 TEMPORARY_PATCHES.append(patch_Gemma3Attention_generic)
+
+
+def patch_Gemma3ForConditionalGeneration_logits_to_keep():
+    """Normalise tensor ``logits_to_keep`` and guard 4-D logits for Gemma3-VL.
+
+    Failure mode (`torch.multinomial: prob_dist must be 1 or 2 dim` at
+    ``transformers/generation/utils.py:_sample``) chain on transformers 5.x:
+
+    1. ``transformers/generation/utils.py`` auto-injects
+       ``model_kwargs["logits_to_keep"] = 1`` because
+       ``Gemma3ForConditionalGeneration.forward`` advertises that param.
+    2. ``prepare_inputs_for_generation`` for Gemma3-VL forwards it through
+       unchanged; for the prefill iteration combined with the
+       ``cache_implementation = "static"`` promotion that
+       ``unsloth_base_fast_generate`` performs for any model with a
+       ``vision_config``, ``logits_to_keep`` arrives as a
+       Tensor of indices, not a Python ``int``.
+    3. The unsloth-zoo compiled cache (``unsloth_compiled_module_gemma3``)
+       emits ``slice_indices = slice(-logits_to_keep, None) if
+       isinstance(logits_to_keep, int) else logits_to_keep`` and then
+       ``hidden_states[:, slice_indices, :]``. With a >=1-D index tensor
+       this fancy-indexes the middle axis and (when transformers chunks the
+       prefill into a 2-D index tensor) yields ``[B, K, S, V]`` logits.
+    4. ``_sample``'s ``outputs.logits[:, -1, :]`` then leaves a 3-D probs
+       tensor, which ``torch.multinomial`` rejects.
+
+    Fix: wrap ``Gemma3ForConditionalGeneration.forward`` to (a) coerce
+    ``logits_to_keep`` to ``int`` (0-D / 1-element Tensor) or a flat 1-D
+    index tensor BEFORE the compiled body sees it, so the compiler's
+    ``slice(-int, None)`` fast path is restored; and (b) on the generate
+    hot path (``labels is None``) defensively flatten any residual
+    ``dim() > 3`` ``outputs.logits`` to ``[B, S, V]``. Training paths emit
+    ``logits = EMPTY_LOGITS`` (1-D ``torch.empty(0)``) which we leave
+    untouched.
+
+    Compatibility:
+    - transformers 4.57.6 (always ``int``): coerce is identity, flatten
+      never fires. No-op.
+    - transformers 5.x (5.0 -> 5.9.0+ confirmed in unsloth-blackwell:test).
+    - TRL 0.22.2 / 0.27.1 / 1.x: all route through ``model.generate``.
+    - peft 0.13-0.19: forward delegation hits our wrapped ``cls.forward``.
+    - vLLM 0.11.2+: never enters ``_sample``; patch is unused.
+    - CUDA / ROCm / XPU / MPS / CPU / MLX: pure tensor ops, no kernels.
+    - ``UNSLOTH_COMPILE_DISABLE=1`` / ``UNSLOTH_COMPILE_OVERWRITE=0``:
+      we wrap the bound method, the closure-captured ``_orig_forward`` is
+      still what the unsloth-zoo compiler reads, so cache hits and SFT
+      training paths are byte-identical.
+
+    Idempotent via ``_unsloth_logits_to_keep_patched`` sentinel on the
+    wrapped forward; no-op if Gemma3 isn't present.
+    """
+    try:
+        import transformers.models.gemma3.modeling_gemma3 as _mg3
+    except Exception:
+        return
+    cls = getattr(_mg3, "Gemma3ForConditionalGeneration", None)
+    if cls is None:
+        return
+    orig_forward = getattr(cls, "forward", None)
+    if orig_forward is None or getattr(orig_forward, "_unsloth_logits_to_keep_patched", False):
+        return
+
+    def _coerce_logits_to_keep(lk):
+        if lk is None or isinstance(lk, int):
+            return lk
+        if isinstance(lk, torch.Tensor):
+            try:
+                if lk.numel() == 1:
+                    return int(lk.item())
+                if lk.dim() > 1:
+                    return lk.reshape(-1)
+            except Exception:
+                pass
+        return lk
+
+    import functools
+
+    @functools.wraps(orig_forward)
+    def forward(self, *args, **kwargs):
+        if "logits_to_keep" in kwargs:
+            kwargs["logits_to_keep"] = _coerce_logits_to_keep(kwargs["logits_to_keep"])
+        out = orig_forward(self, *args, **kwargs)
+        # Defensive 4-D -> 3-D flatten on the generate hot path only.
+        if kwargs.get("labels", None) is None:
+            lg = getattr(out, "logits", None)
+            if isinstance(lg, torch.Tensor) and lg.dim() > 3 and lg.numel() > 0:
+                new_shape = (-1, lg.shape[-2], lg.shape[-1])
+                try:
+                    flat = lg.reshape(new_shape)
+                except RuntimeError:
+                    flat = lg.contiguous().reshape(new_shape)
+                try:
+                    out.logits = flat
+                except Exception:
+                    pass
+        return out
+
+    forward._unsloth_logits_to_keep_patched = True
+    cls.forward = forward
+pass
+TEMPORARY_PATCHES.append(patch_Gemma3ForConditionalGeneration_logits_to_keep)

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -190,22 +190,51 @@ def patch_Gemma3Processor():
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", True)
 
         text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
-        # Fix double BOS tokens
+        # Fix double BOS tokens while preserving batch rectangularity.
+        # Tokenizers that already padded the batch return equal-length
+        # sequences; the previous `x[1:] if x[:2] == double_bos` pattern
+        # shortened only the rows whose first two tokens were BOS and
+        # left the rest, producing a jagged batch (315 vs 314 observed on
+        # Gemma3-(4B)-Vision-GRPO) that crashed BatchFeature.convert_to_tensors.
+        # If any row needed trimming, repad every trimmed row to the new
+        # max length so input_ids, attention_mask, and the downstream
+        # token_type_ids all stay rectangular.
         double_bos_token_id = [self.tokenizer.bos_token_id]*2
+        pad_token_id = self.tokenizer.pad_token_id
+        if pad_token_id is None:
+            pad_token_id = self.tokenizer.eos_token_id
         input_ids = text_inputs["input_ids"]
-        text_inputs["input_ids"] = [x[1:] if x[:2] == double_bos_token_id else x for x in input_ids]
+        attention_mask = text_inputs.get("attention_mask", None)
+        trim_flags = [x[:2] == double_bos_token_id for x in input_ids]
+        if any(trim_flags):
+            new_input_ids = [
+                (x[1:] if flag else x) for x, flag in zip(input_ids, trim_flags)
+            ]
+            if attention_mask is not None:
+                new_attention_mask = [
+                    (m[1:] if flag else m) for m, flag in zip(attention_mask, trim_flags)
+                ]
+            else:
+                new_attention_mask = None
+            new_max_len = max(len(x) for x in new_input_ids)
+            padding_side = getattr(self.tokenizer, "padding_side", "right")
+            def _pad_row(row, pad_value):
+                deficit = new_max_len - len(row)
+                if deficit <= 0:
+                    return row
+                pad = [pad_value] * deficit
+                return (row + pad) if padding_side == "right" else (pad + row)
+            text_inputs["input_ids"] = [_pad_row(x, pad_token_id) for x in new_input_ids]
+            if new_attention_mask is not None:
+                text_inputs["attention_mask"] = [_pad_row(m, 0) for m in new_attention_mask]
+        # else: no double-BOS rows -> leave text_inputs untouched.
 
         # Add token type ids manually, as tokenizer can't do arbitrary position token types
-        # [TODO] FAILS for batched tokens since text_inputs["input_ids"] is a list of lists, so np.array creates an object!
         if return_mm_token_type_ids:
             input_ids = text_inputs["input_ids"]
             image_token_id = self.image_token_id
             mm_token_type_ids = [[1 if y == image_token_id else 0 for y in x] for x in input_ids]
-            # array_ids = np.array(text_inputs["input_ids"])
-            # mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
-            # mm_token_type_ids[array_ids == self.image_token_id] = 1
-            # text_inputs = {k: v.tolist() for k, v in text_inputs.items()}  # in case user requested list inputs
-            text_inputs["token_type_ids"] = mm_token_type_ids#.tolist()
+            text_inputs["token_type_ids"] = mm_token_type_ids
         return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
     pass
 

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1548,3 +1548,138 @@ def patch_deepseek_v2_moe_alias():
     ddv2.DeepseekV2MoE = new_class
 pass
 TEMPORARY_PATCHES.append(patch_deepseek_v2_moe_alias)
+
+
+def patch_transformers_legacy_import_utils():
+    """Restore ``is_torch_fx_available`` on ``transformers.utils.import_utils``.
+
+    Transformers 5.x dropped this helper. ``deepseek-ai/DeepSeek-OCR``'s
+    trust_remote_code modeling file imports it at module load time and
+    crashes with ``ImportError: cannot import name 'is_torch_fx_available'``
+    before any config can be parsed. The helper used to be a thin
+    ``importlib.util.find_spec("torch.fx") is not None`` check. Re-add it
+    with the same semantics so legacy modeling files import cleanly.
+
+    No-op when ``transformers`` is absent or when ``is_torch_fx_available``
+    already exists (older transformers).
+    """
+    try:
+        from transformers.utils import import_utils as iu
+    except Exception:
+        return
+    if hasattr(iu, "is_torch_fx_available"):
+        return
+
+    import importlib.util as _ilu
+
+    def is_torch_fx_available():
+        return _ilu.find_spec("torch.fx") is not None
+
+    iu.is_torch_fx_available = is_torch_fx_available
+    # transformers re-exports a bunch of helpers via the parent ``utils``
+    # package; mirror the symbol there too if it's already missing so
+    # ``from transformers.utils import is_torch_fx_available`` works.
+    try:
+        from transformers import utils as tu
+        if not hasattr(tu, "is_torch_fx_available"):
+            tu.is_torch_fx_available = is_torch_fx_available
+    except Exception:
+        pass
+pass
+TEMPORARY_PATCHES.append(patch_transformers_legacy_import_utils)
+
+
+def patch_llama_attention_back_compat_aliases():
+    """Alias legacy ``Llama{Flash,Sdpa}Attention[2]`` symbols on
+    ``transformers.models.llama.modeling_llama``.
+
+    Transformers 5.x collapsed the per-backend attention subclasses into a
+    single ``LlamaAttention`` that selects flash/sdpa/eager via
+    ``config._attn_implementation``. Several HF trust_remote_code modeling
+    files (notably ``deepseek-ai/DeepSeek-OCR``'s ``modeling_deepseekv2.py``,
+    which lists ``LlamaFlashAttention2`` in a top-level ``from ... import``
+    plus an ``ATTENTION_CLASSES`` dict but only ever uses MLA in practice)
+    pre-date that refactor and crash with ``ImportError: cannot import name
+    'LlamaFlashAttention2'`` before the model can load.
+
+    Re-export the unified class under the old names so legacy import lines
+    succeed. The behaviour is identical: at construction time
+    ``LlamaAttention`` dispatches to the configured backend internally, so
+    callers that referenced the old subclasses still pick up the right
+    kernel path. Pre-5.0 transformers releases that still ship the
+    subclasses (4.57.6 etc.) keep their originals unchanged via the
+    ``hasattr`` guard.
+
+    Idempotent. No-op when ``transformers`` is absent (MLX-only path) or
+    when ``LlamaAttention`` itself is missing.
+    """
+    try:
+        from transformers.models.llama import modeling_llama as mllama
+    except Exception:
+        return
+    base = getattr(mllama, "LlamaAttention", None)
+    if base is None:
+        return
+    for legacy_name in (
+        "LlamaFlashAttention2",
+        "LlamaSdpaAttention",
+        "LlamaFlexAttention",
+    ):
+        if not hasattr(mllama, legacy_name):
+            setattr(mllama, legacy_name, base)
+pass
+TEMPORARY_PATCHES.append(patch_llama_attention_back_compat_aliases)
+
+
+def patch_deepseek_v2_config_default_ints():
+    """Coerce ``None`` values for required-int fields on Deepseek-V2 configs.
+
+    The official ``deepseek-ai/DeepSeek-OCR`` config.json has
+    ``kv_lora_rank: null`` and ``q_lora_rank: null`` because the OCR
+    head doesn't use MLA, but transformers 5.x ``StrictDataclass`` (and
+    legacy ``PretrainedConfig`` users that read these as ints later)
+    reject ``None`` for fields annotated ``int``. Walk the dict that
+    ``DeepseekV2Config.from_dict`` consumes and replace ``None`` with the
+    init default for known-required-int fields.
+
+    No-op on transformers builds without ``deepseek_v2`` or when the
+    fields are already non-None. Idempotent via the ``_unsloth_patched``
+    sentinel on the wrapped ``from_dict``.
+    """
+    try:
+        from transformers.models.deepseek_v2 import configuration_deepseek_v2 as cdv2
+    except Exception:
+        return
+    Config = getattr(cdv2, "DeepseekV2Config", None)
+    if Config is None:
+        return
+    orig_from_dict = getattr(Config, "from_dict", None)
+    if orig_from_dict is None or getattr(orig_from_dict, "_unsloth_patched", False):
+        return
+
+    import inspect
+    int_defaults = {}
+    try:
+        sig = inspect.signature(Config.__init__)
+        for name, p in sig.parameters.items():
+            if isinstance(p.default, int) and not isinstance(p.default, bool):
+                int_defaults[name] = p.default
+    except (TypeError, ValueError):
+        return
+
+    if not int_defaults:
+        return
+
+    @classmethod
+    def from_dict(cls, config_dict, **kwargs):
+        if isinstance(config_dict, dict):
+            config_dict = dict(config_dict)
+            for key, default in int_defaults.items():
+                if key in config_dict and config_dict[key] is None:
+                    config_dict[key] = default
+        return orig_from_dict.__func__(cls, config_dict, **kwargs)
+
+    from_dict._unsloth_patched = True
+    Config.from_dict = from_dict
+pass
+TEMPORARY_PATCHES.append(patch_deepseek_v2_config_default_ints)

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1524,3 +1524,27 @@ def patch_qwen2vl_image_processor_pixel_attrs():
         pass
 pass
 TEMPORARY_PATCHES.append(patch_qwen2vl_image_processor_pixel_attrs)
+
+
+def patch_deepseek_v2_moe_alias():
+    """Alias DeepseekV2MoE -> DeepseekV2Moe in transformers' modeling_deepseek_v2.
+
+    Transformers 5.x renamed `DeepseekV2MoE` to `DeepseekV2Moe`, but several
+    HF trust_remote_code modeling files (notably deepseek-ai/deepseek-ocr's
+    `modeling_deepseekocr.py`) still import the old name and crash with
+    `ImportError: cannot import name 'DeepseekV2MoE' ... Did you mean:
+    'DeepseekV2Moe'?` before the model can be loaded. Restoring the old
+    spelling as an alias unblocks those notebooks without touching upstream.
+    """
+    try:
+        from transformers.models.deepseek_v2 import modeling_deepseek_v2 as ddv2
+    except Exception:
+        return  # transformers without deepseek_v2 -- nothing to patch.
+    if hasattr(ddv2, "DeepseekV2MoE"):
+        return
+    new_class = getattr(ddv2, "DeepseekV2Moe", None)
+    if new_class is None:
+        return
+    ddv2.DeepseekV2MoE = new_class
+pass
+TEMPORARY_PATCHES.append(patch_deepseek_v2_moe_alias)

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1683,3 +1683,136 @@ def patch_deepseek_v2_config_default_ints():
     Config.from_dict = from_dict
 pass
 TEMPORARY_PATCHES.append(patch_deepseek_v2_config_default_ints)
+
+
+def patch_deepseek_ocr_prepare_inputs_for_generation():
+    """Post-load patch for ``DeepseekOCRForCausalLM.prepare_inputs_for_generation``.
+
+    The trust_remote_code ``modeling_deepseekocr.py`` shipped with
+    ``deepseek-ai/DeepSeek-OCR`` predates the transformers Cache API
+    change: when ``past_key_values`` is a ``Cache`` instance,
+    ``past_length`` is taken from ``cache.seen_tokens`` which is a
+    ``torch.Tensor`` in transformers 5.x but used to be a Python int.
+    The next line then calls::
+
+        cache_position = torch.arange(
+            past_length, past_length + position_ids.shape[-1], device=...
+        )
+
+    and torch 2.10+ rejects Tensor positional args to ``torch.arange``:
+    ``TypeError: arange() received an invalid combination of arguments``.
+
+    Fix: wrap ``transformers.dynamic_module_utils.get_class_in_module`` so
+    that after the dynamic module loads, we look for the
+    ``DeepseekOCRForCausalLM`` (or the parent ``DeepseekV2ForCausalLM``)
+    on the module and replace its ``prepare_inputs_for_generation`` with
+    a thin wrapper that coerces tensor scalars to ``int`` before the
+    arange call. The wrapper is identical in behaviour for the
+    int-past_length case and the legacy 2D ``past_key_values`` tuple
+    case, so existing code paths are preserved.
+
+    Idempotent; sentinel both on the inner method and on the
+    ``get_class_in_module`` wrapper so re-runs don't stack.
+    """
+    try:
+        from transformers import dynamic_module_utils as dmu
+    except Exception:
+        return
+    gcim = getattr(dmu, "get_class_in_module", None)
+    if gcim is None or getattr(gcim, "_unsloth_arange_patched", False):
+        return
+    _orig = gcim
+
+    def _patch_cls(cls):
+        if cls is None or not isinstance(cls, type):
+            return
+        name = getattr(cls, "__name__", "")
+        if "Deepseek" not in name and "DeepSeek" not in name:
+            return
+        method = getattr(cls, "prepare_inputs_for_generation", None)
+        if method is None or getattr(method, "_unsloth_arange_patched", False):
+            return
+        import functools, torch as _torch
+
+        @functools.wraps(method)
+        def prepare_inputs_for_generation(self, *args, **kwargs):
+            # Replicate the original method but coerce a Tensor-shaped
+            # `past_length` to a Python int before torch.arange runs.
+            # Simplest: monkey-patch torch.arange transiently in the
+            # bound method's globals so we don't have to maintain a
+            # forked copy of the upstream method body.
+            mod_globals = getattr(method, "__globals__", None)
+            _orig_arange = _torch.arange
+
+            def _safe_arange(*aa, **kk):
+                aa2 = tuple(
+                    int(x.item()) if isinstance(x, _torch.Tensor) and x.numel() == 1 else x
+                    for x in aa
+                )
+                return _orig_arange(*aa2, **kk)
+
+            if mod_globals is not None and mod_globals.get("torch") is _torch:
+                mod_globals["torch"] = _ShimTorch(_torch, _safe_arange)
+                try:
+                    return method(self, *args, **kwargs)
+                finally:
+                    mod_globals["torch"] = _torch
+            else:
+                # Fallback: temporarily monkey-patch torch.arange itself.
+                _torch.arange = _safe_arange
+                try:
+                    return method(self, *args, **kwargs)
+                finally:
+                    _torch.arange = _orig_arange
+
+        prepare_inputs_for_generation._unsloth_arange_patched = True
+        cls.prepare_inputs_for_generation = prepare_inputs_for_generation
+
+    class _ShimTorch:
+        """Forward every attribute to ``torch`` except ``arange``."""
+        __slots__ = ("_torch", "_arange")
+        def __init__(self, t, arange):
+            object.__setattr__(self, "_torch", t)
+            object.__setattr__(self, "_arange", arange)
+        def __getattr__(self, name):
+            if name == "arange":
+                return object.__getattribute__(self, "_arange")
+            return getattr(object.__getattribute__(self, "_torch"), name)
+
+    import sys as _sys
+
+    def get_class_in_module(*args, **kwargs):
+        cls = _orig(*args, **kwargs)
+        try:
+            _patch_cls(cls)
+            # Also walk the SAME module the class lives in: trust_remote_code
+            # only returns the one class actually requested (AutoConfig vs
+            # AutoModel), but the module file declares siblings we also
+            # need to patch (DeepseekV2 / DeepseekV3 / DeepseekOCR
+            # ForCausalLM all live in the same dynamic module pair).
+            mod_name = getattr(cls, "__module__", None)
+            mod = _sys.modules.get(mod_name) if mod_name else None
+            if mod is not None:
+                for attr in dir(mod):
+                    sibling = getattr(mod, attr, None)
+                    if isinstance(sibling, type) and sibling is not cls:
+                        _patch_cls(sibling)
+        except Exception:
+            pass
+        return cls
+
+    get_class_in_module._unsloth_arange_patched = True
+    # Preserve any sentinels from the prior notebook_deps wrap.
+    for attr in ("_unsloth_patched",):
+        if getattr(_orig, attr, False):
+            setattr(get_class_in_module, attr, True)
+    dmu.get_class_in_module = get_class_in_module
+    if hasattr(dmu, "get_class_from_dynamic_module"):
+        try:
+            src_globals = getattr(dmu.get_class_from_dynamic_module, "__globals__", None)
+            if isinstance(src_globals, dict) and "get_class_in_module" in src_globals:
+                src_globals["get_class_in_module"] = get_class_in_module
+        except Exception:
+            pass
+pass
+TEMPORARY_PATCHES.append(patch_deepseek_ocr_prepare_inputs_for_generation)

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -187,6 +187,12 @@ def patch_check_imports_autoinstall():
     ``dynamic_module_utils.check_imports`` (ImportError "This modeling file
     requires the following packages..."). That call site never reaches
     ``requires_backends``, so wrap it too.
+
+    Also wraps ``get_class_in_module`` so that ``ModuleNotFoundError``
+    raised from ``module_spec.loader.exec_module`` -- the case where a
+    *submodule* of the modeling file (e.g. ``deepencoder.py``) imports a
+    package that the top-level ``check_imports`` scanner missed -- gets
+    auto-installed too.
     """
     try:
         from transformers import dynamic_module_utils as dmu
@@ -221,6 +227,54 @@ def patch_check_imports_autoinstall():
 
     check_imports._unsloth_patched = True
     dmu.check_imports = check_imports
+
+    # Wrap get_class_in_module to retry on ModuleNotFoundError raised
+    # during ``module_spec.loader.exec_module``. This catches missing deps
+    # that `check_imports` (top-level file scanner) misses because they're
+    # imported by a sibling submodule next to the main modeling file
+    # (e.g. Deepseek-OCR's `deepencoder.py` imports easydict).
+    gcim = getattr(dmu, "get_class_in_module", None)
+    if gcim is None or getattr(gcim, "_unsloth_patched", False):
+        return
+    _orig_gcim = gcim
+
+    def get_class_in_module(*args, **kwargs):
+        try:
+            return _orig_gcim(*args, **kwargs)
+        except ModuleNotFoundError as e:
+            if not _AUTO_INSTALL or _NO_NETWORK:
+                raise
+            pkg = (getattr(e, "name", None) or "").strip()
+            # Only auto-install known-safe packages from the allow-list.
+            if not pkg or pkg not in _ALLOW_LIST:
+                raise
+            if not _try_install_and_import(pkg):
+                raise
+            # Retry once. If the submodule needs a SECOND missing dep we
+            # iterate up to 6 times (well above any real-world chain).
+            for _retry in range(6):
+                try:
+                    return _orig_gcim(*args, **kwargs)
+                except ModuleNotFoundError as e2:
+                    pkg2 = (getattr(e2, "name", None) or "").strip()
+                    if not pkg2 or pkg2 not in _ALLOW_LIST:
+                        raise
+                    if not _try_install_and_import(pkg2):
+                        raise
+            # Give up after 6 retries; surface the latest error.
+            return _orig_gcim(*args, **kwargs)
+
+    get_class_in_module._unsloth_patched = True
+    dmu.get_class_in_module = get_class_in_module
+    # ``get_class_from_dynamic_module`` resolved the reference at import
+    # time, so rebind the call site too.
+    if hasattr(dmu, "get_class_from_dynamic_module"):
+        try:
+            src_globals = getattr(dmu.get_class_from_dynamic_module, "__globals__", None)
+            if isinstance(src_globals, dict) and "get_class_in_module" in src_globals:
+                src_globals["get_class_in_module"] = get_class_in_module
+        except Exception:
+            pass
 
 
 def _looks_like_jupyter_chain() -> bool:

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -163,6 +163,17 @@ def patch_requires_backends_autoinstall():
                 flag = f"_{b.replace('-', '_')}_available"
                 if hasattr(iu, flag):
                     setattr(iu, flag, True)
+                # transformers 5.x decorates is_<backend>_available with
+                # @lru_cache; without clearing it the cached False from the
+                # original _orig() call gets reused and the retry fails
+                # even though the install succeeded.
+                fn = getattr(iu, f"is_{b.replace('-', '_')}_available", None)
+                cache_clear = getattr(fn, "cache_clear", None)
+                if callable(cache_clear):
+                    try:
+                        cache_clear()
+                    except Exception:
+                        pass
             return _orig(obj, backends)
 
     requires_backends._unsloth_patched = True

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -28,6 +28,7 @@ _ALLOW_LIST = {
     "timm":          None,           # vision backbones (TimmWrapperModel)
     "addict":        None,           # Deepseek-OCR config dicts
     "einops":        None,           # Deepseek-OCR deepencoder + many other vision models
+    "easydict":      None,           # Deepseek-OCR deepencoder.py:12 `from easydict import EasyDict`
     "matplotlib":    None,           # Deepseek-OCR + a few HF image utils
     "traitlets":     None,           # Jupyter/IPython widget chain
     "soundfile":     None,           # audio processors

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -235,9 +235,14 @@ def _looks_like_jupyter_chain() -> bool:
     if (
         "JPY_PARENT_PID" in os.environ
         or "COLAB_RELEASE_TAG" in os.environ
-        or "VSCODE_PID" in os.environ  # VS Code python kernel
     ):
         return True
+    # VSCODE_PID is set by every VS Code subprocess (terminals, debug,
+    # Python LSP) -- not just notebook kernels -- so it can't be used as
+    # a notebook signal on its own. Real VS Code Jupyter kernels import
+    # ipykernel before unsloth_zoo, so the sys.modules probe below still
+    # catches them; a plain VS Code terminal no longer triggers the
+    # eager traitlets install.
     for m in ("IPython", "ipykernel", "google.colab"):
         if m in sys.modules:
             return True

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -27,6 +27,7 @@ from ..log import logger
 _ALLOW_LIST = {
     "timm":          None,           # vision backbones (TimmWrapperModel)
     "addict":        None,           # Deepseek-OCR config dicts
+    "einops":        None,           # Deepseek-OCR deepencoder + many other vision models
     "matplotlib":    None,           # Deepseek-OCR + a few HF image utils
     "traitlets":     None,           # Jupyter/IPython widget chain
     "soundfile":     None,           # audio processors

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -1,0 +1,220 @@
+# Auto-install missing notebook-only Python deps on first use.
+#
+# Four notebooks failed in the Blackwell docker validation because the slim
+# venv shipped without timm / traitlets / addict / matplotlib, and the
+# raising frame is buried inside HF code (`transformers.utils.import_utils.
+# requires_backends` for TimmWrapper, `transformers.dynamic_module_utils.
+# check_imports` for the Deepseek-OCR trust_remote_code modeling file, and
+# a bare ModuleNotFoundError for traitlets from the IPython chain). Wrap
+# all three call sites with a thin retry that pip-installs the offending
+# package (allow-list only) and re-tries the original import. Honours the
+# existing `UNSLOTH_AUTO_INSTALL=0` opt-out (used by `llama_cpp.py`) and
+# the standard offline flags so air-gapped envs keep emitting the
+# upstream ImportError verbatim.
+
+import importlib
+import importlib.metadata
+import importlib.util
+import os
+import shutil
+import site
+import subprocess
+import sys
+
+from ..log import logger
+
+# pypi-name -> import-name (None means same).
+_ALLOW_LIST = {
+    "timm":          None,           # vision backbones (TimmWrapperModel)
+    "addict":        None,           # Deepseek-OCR config dicts
+    "matplotlib":    None,           # Deepseek-OCR + a few HF image utils
+    "traitlets":     None,           # Jupyter/IPython widget chain
+    "soundfile":     None,           # audio processors
+    "librosa":       None,           # audio processors
+    "scipy":         None,           # several processors
+    "pyctcdecode":   None,           # ASR
+    "tiktoken":      None,           # tokenizer remote-code paths
+    "blobfile":      None,           # tiktoken backing store
+    "pillow_heif":   "pillow_heif",  # HEIF images
+    "decord":        None,           # video processors
+    "av":            "av",           # pyav (video processors)
+    "num2words":     None,           # speech text norm
+    "jieba":         None,           # zh tokenizer
+    "sentencepiece": None,           # tokenizers
+}
+
+_AUTO_INSTALL = os.environ.get("UNSLOTH_AUTO_INSTALL", "1") == "1"
+_NO_NETWORK = (
+    os.environ.get("UNSLOTH_OFFLINE", "0") == "1"
+    or os.environ.get("HF_HUB_OFFLINE", "0") == "1"
+    or os.environ.get("TRANSFORMERS_OFFLINE", "0") == "1"
+)
+_attempted: set = set()
+
+
+def _in_venv() -> bool:
+    return (
+        hasattr(sys, "real_prefix")
+        or (getattr(sys, "base_prefix", sys.prefix) != sys.prefix)
+        or bool(os.environ.get("VIRTUAL_ENV"))
+        or bool(os.environ.get("CONDA_PREFIX"))
+    )
+
+
+def _pip_install(pkg: str) -> bool:
+    if pkg in _attempted:
+        return False
+    _attempted.add(pkg)
+    if shutil.which("uv") and _in_venv():
+        cmd = ["uv", "pip", "install", "--quiet", pkg]
+    else:
+        cmd = [
+            sys.executable, "-m", "pip", "install", "--quiet",
+            "--disable-pip-version-check", "--no-input", pkg,
+        ]
+        # Outside a venv on Linux/Mac as non-root: probe write access to
+        # site-packages and fall back to --user. Windows has no geteuid;
+        # site-packages there is usually writable inside the venv anyway.
+        if not _in_venv() and hasattr(os, "geteuid") and os.geteuid() != 0:
+            try:
+                sp = site.getsitepackages()[0]
+                probe = os.path.join(sp, ".unsloth_write_probe")
+                open(probe, "w").close()
+                os.remove(probe)
+            except Exception:
+                cmd.append("--user")
+    logger.warning(
+        f"Unsloth: auto-installing missing notebook dep `{pkg}` via "
+        f"`{' '.join(cmd)}`. Set UNSLOTH_AUTO_INSTALL=0 to disable."
+    )
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    except Exception as e:
+        logger.warning(f"Unsloth: auto-install of `{pkg}` failed to launch: {e}")
+        return False
+    if r.returncode != 0:
+        tail = (r.stderr or "")[-500:]
+        logger.warning(f"Unsloth: auto-install of `{pkg}` failed:\n{tail}")
+        return False
+    importlib.invalidate_caches()
+    try:
+        list(importlib.metadata.distributions())
+    except Exception:
+        pass
+    return True
+
+
+def _try_install_and_import(pkg: str) -> bool:
+    if pkg not in _ALLOW_LIST:
+        return False
+    if not _AUTO_INSTALL or _NO_NETWORK:
+        return False
+    import_name = _ALLOW_LIST[pkg] or pkg.replace("-", "_")
+    if importlib.util.find_spec(import_name) is not None:
+        return True
+    if not _pip_install(pkg):
+        return False
+    return importlib.util.find_spec(import_name) is not None
+
+
+def patch_requires_backends_autoinstall():
+    """
+    Wrap ``transformers.utils.import_utils.requires_backends`` so that an
+    allow-listed missing backend triggers a one-shot pip install and a
+    second attempt. Preserves the original ImportError when the install
+    fails or the dep isn't on the allow-list, so user-facing error bytes
+    stay identical to upstream when ``UNSLOTH_AUTO_INSTALL=0``.
+    """
+    try:
+        from transformers.utils import import_utils as iu
+    except Exception:
+        return  # transformers absent (MLX-only path) -- nothing to patch.
+    if getattr(iu.requires_backends, "_unsloth_patched", False):
+        return
+    _orig = iu.requires_backends
+
+    def requires_backends(obj, backends):
+        try:
+            return _orig(obj, backends)
+        except ImportError:
+            if not _AUTO_INSTALL or _NO_NETWORK:
+                raise
+            wanted_iter = backends if isinstance(backends, (list, tuple)) else [backends]
+            wanted = [b for b in wanted_iter if isinstance(b, str) and b in _ALLOW_LIST]
+            if not wanted:
+                raise
+            installed_any = False
+            for b in wanted:
+                if _try_install_and_import(b):
+                    installed_any = True
+            if not installed_any:
+                raise
+            for b in wanted:
+                flag = f"_{b.replace('-', '_')}_available"
+                if hasattr(iu, flag):
+                    setattr(iu, flag, True)
+            return _orig(obj, backends)
+
+    requires_backends._unsloth_patched = True
+    iu.requires_backends = requires_backends
+
+
+def patch_check_imports_autoinstall():
+    """
+    trust_remote_code modeling files (e.g. Deepseek-OCR's modeling_deepseekocr.py)
+    declare their import requirements at the top of the file and raise via
+    ``dynamic_module_utils.check_imports`` (ImportError "This modeling file
+    requires the following packages..."). That call site never reaches
+    ``requires_backends``, so wrap it too.
+    """
+    try:
+        from transformers import dynamic_module_utils as dmu
+    except Exception:
+        return
+    if getattr(dmu.check_imports, "_unsloth_patched", False):
+        return
+    _orig = dmu.check_imports
+
+    def check_imports(filename):
+        try:
+            return _orig(filename)
+        except ImportError as e:
+            if not _AUTO_INSTALL or _NO_NETWORK:
+                raise
+            msg = str(e)
+            if "This modeling file requires" not in msg:
+                raise
+            # Message format: "... environment: pkg1, pkg2. Run `pip install...`"
+            try:
+                tail = msg.split("environment:", 1)[1]
+                pkgs_str = tail.split(".", 1)[0]
+            except Exception:
+                raise
+            pkgs = [p.strip() for p in pkgs_str.split(",") if p.strip() in _ALLOW_LIST]
+            if not pkgs:
+                raise
+            ok = all(_try_install_and_import(p) for p in pkgs)
+            if not ok:
+                raise
+            return _orig(filename)
+
+    check_imports._unsloth_patched = True
+    dmu.check_imports = check_imports
+
+
+def _ensure_notebook_chain():
+    """
+    Pre-emptive ensure for deps that raise bare ModuleNotFoundError outside
+    transformers (the Jupyter/IPython chain). Kept tiny: only ``traitlets``
+    is touched today; expand only when a new failure mode appears.
+    """
+    if not _AUTO_INSTALL or _NO_NETWORK:
+        return
+    for pkg in ("traitlets",):
+        if importlib.util.find_spec(pkg) is None:
+            _try_install_and_import(pkg)
+
+
+patch_requires_backends_autoinstall()
+patch_check_imports_autoinstall()
+_ensure_notebook_chain()

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -79,13 +79,19 @@ def _pip_install(pkg: str) -> bool:
         # Outside a venv on Linux/Mac as non-root: probe write access to
         # site-packages and fall back to --user. Windows has no geteuid;
         # site-packages there is usually writable inside the venv anyway.
+        # Use os.access instead of touching disk to avoid leaving a
+        # `.unsloth_write_probe` file behind if the process dies between
+        # open() and remove(). Also check ALL site-packages entries:
+        # macOS / Debian split user vs system into [0] and [1] and the
+        # first writable one wins for pip install.
         if not _in_venv() and hasattr(os, "geteuid") and os.geteuid() != 0:
             try:
-                sp = site.getsitepackages()[0]
-                probe = os.path.join(sp, ".unsloth_write_probe")
-                open(probe, "w").close()
-                os.remove(probe)
+                writable = any(
+                    os.access(sp, os.W_OK) for sp in site.getsitepackages()
+                )
             except Exception:
+                writable = False
+            if not writable:
                 cmd.append("--user")
     logger.warning(
         f"Unsloth: auto-installing missing notebook dep `{pkg}` via "

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -29,6 +29,7 @@ _ALLOW_LIST = {
     "addict":        None,           # Deepseek-OCR config dicts
     "einops":        None,           # Deepseek-OCR deepencoder + many other vision models
     "easydict":      None,           # Deepseek-OCR deepencoder.py:12 `from easydict import EasyDict`
+    "snac":          None,           # Orpheus TTS neural audio codec
     "matplotlib":    None,           # Deepseek-OCR + a few HF image utils
     "traitlets":     None,           # Jupyter/IPython widget chain
     "soundfile":     None,           # audio processors

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -30,6 +30,7 @@ _ALLOW_LIST = {
     "einops":        None,           # Deepseek-OCR deepencoder + many other vision models
     "easydict":      None,           # Deepseek-OCR deepencoder.py:12 `from easydict import EasyDict`
     "snac":          None,           # Orpheus TTS neural audio codec
+    "torchcodec":    None,           # HF datasets audio Feature decoder (>= datasets 4.x)
     "matplotlib":    None,           # Deepseek-OCR + a few HF image utils
     "traitlets":     None,           # Jupyter/IPython widget chain
     "soundfile":     None,           # audio processors

--- a/unsloth_zoo/temporary_patches/notebook_deps.py
+++ b/unsloth_zoo/temporary_patches/notebook_deps.py
@@ -206,13 +206,39 @@ def patch_check_imports_autoinstall():
     dmu.check_imports = check_imports
 
 
+def _looks_like_jupyter_chain() -> bool:
+    """Cheap probe for "this process is going to import IPython somewhere".
+
+    Pre-emptive ``traitlets`` install used to fire on every import of
+    ``unsloth_zoo`` -- including from server jobs that never touch a
+    notebook -- which blocked ``import unsloth_zoo`` for up to 300 s on
+    machines without traitlets. Gate the eager install on signals that
+    we are actually in a Jupyter / Colab / IPython context.
+    """
+    if (
+        "JPY_PARENT_PID" in os.environ
+        or "COLAB_RELEASE_TAG" in os.environ
+        or "VSCODE_PID" in os.environ  # VS Code python kernel
+    ):
+        return True
+    for m in ("IPython", "ipykernel", "google.colab"):
+        if m in sys.modules:
+            return True
+    return False
+
+
 def _ensure_notebook_chain():
     """
     Pre-emptive ensure for deps that raise bare ModuleNotFoundError outside
     transformers (the Jupyter/IPython chain). Kept tiny: only ``traitlets``
     is touched today; expand only when a new failure mode appears.
+
+    Skipped on non-notebook hosts so a fresh server import of
+    ``unsloth_zoo`` does not block on a pip subprocess.
     """
     if not _AUTO_INSTALL or _NO_NETWORK:
+        return
+    if not _looks_like_jupyter_chain():
         return
     for pkg in ("traitlets",):
         if importlib.util.find_spec(pkg) is None:

--- a/unsloth_zoo/temporary_patches/synthetic_dataprep.py
+++ b/unsloth_zoo/temporary_patches/synthetic_dataprep.py
@@ -1,0 +1,103 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Harden ``unsloth.dataprep.synthetic.SyntheticDataKit`` against silent
+vLLM-subprocess failures.
+
+Observed on Meta_Synthetic_Data_Llama3_2_(3B) inside an unsloth-blackwell
+container: the parent already touched CUDA via ``patch_vllm`` /
+``patch_vllm_graph_capture`` (which imports
+``vllm.v1.worker.gpu_model_runner``). Forking the child ``vllm serve``
+subprocess after CUDA init leaves the child with a contaminated NVML/Triton
+state. The child logs ``Triton is installed but 0 active driver(s) found``
+and dies inside ``EngineCore._initialize_kv_caches``. The parent
+``PipeCapture`` has ``echo=False`` for stderr, so the actual error is
+silenced until the 1200s timeout fires.
+
+This patch:
+  * runs ``torch.cuda.empty_cache() / synchronize() / gc.collect()`` before
+    the fork so the child boots with a clean CUDA context,
+  * pops ``LD_PRELOAD`` and ``VLLM_LOGGING_LEVEL`` from the env it inherits
+    (CUDA_VISIBLE_DEVICES is preserved),
+  * forces stderr ``PipeCapture`` instances to ``echo=True`` so users see
+    the real failure immediately.
+
+Idempotent via the ``_unsloth_patched`` sentinel. Cross-platform: the CUDA
+empty-cache path is a no-op on Mac/MLX since ``torch.cuda.is_available()``
+returns False. LD_PRELOAD pop is harmless when unset.
+"""
+
+import os
+import gc
+import functools
+
+from .common import TEMPORARY_PATCHES
+
+
+def patch_synthetic_data_kit_subprocess():
+    try:
+        from unsloth.dataprep import synthetic as _syn
+    except Exception:
+        return
+    SyntheticDataKit = getattr(_syn, "SyntheticDataKit", None)
+    PipeCapture = getattr(_syn, "PipeCapture", None)
+    if SyntheticDataKit is None or PipeCapture is None:
+        return
+    orig_init = getattr(SyntheticDataKit, "__init__", None)
+    if orig_init is None or getattr(orig_init, "_unsloth_patched", False):
+        return
+
+    # Flip stderr PipeCapture instances to echo so the user sees the real
+    # subprocess failure. Wrap once; idempotent.
+    if not getattr(PipeCapture, "_unsloth_echo_stderr", False):
+        _orig_pc_init = PipeCapture.__init__
+
+        @functools.wraps(_orig_pc_init)
+        def _pc_init(self, pipe, *a, **kw):
+            name = kw.get("name", "")
+            if isinstance(name, str) and name.upper().endswith("STDERR"):
+                kw["echo"] = True
+            _orig_pc_init(self, pipe, *a, **kw)
+
+        PipeCapture.__init__ = _pc_init
+        PipeCapture._unsloth_echo_stderr = True
+
+    @functools.wraps(orig_init)
+    def __init__(self, *args, **kwargs):
+        # Drop CUDA context held by the parent before forking the vLLM
+        # subprocess so the child gets a clean NVML/Triton state.
+        try:
+            import torch
+            if hasattr(torch, "cuda") and torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                try:
+                    torch.cuda.synchronize()
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        for _ in range(3):
+            gc.collect()
+        # Sanitise inherited env that frequently breaks the child vLLM.
+        # CUDA_VISIBLE_DEVICES MUST be preserved.
+        for var in ("LD_PRELOAD", "VLLM_LOGGING_LEVEL"):
+            os.environ.pop(var, None)
+        return orig_init(self, *args, **kwargs)
+
+    __init__._unsloth_patched = True
+    SyntheticDataKit.__init__ = __init__
+pass
+TEMPORARY_PATCHES.append(patch_synthetic_data_kit_subprocess)

--- a/unsloth_zoo/temporary_patches/synthetic_dataprep.py
+++ b/unsloth_zoo/temporary_patches/synthetic_dataprep.py
@@ -75,10 +75,81 @@ def patch_synthetic_data_kit_subprocess():
         PipeCapture.__init__ = _pc_init
         PipeCapture._unsloth_echo_stderr = True
 
+    # Wrap subprocess.Popen inside the synthetic module's globals so the
+    # CUDA-clear / env-sanitise fires RIGHT BEFORE the actual fork+exec of
+    # `vllm serve`, after `patch_vllm()` has re-touched CUDA. Clearing
+    # CUDA at __init__ entry was insufficient because patch_vllm() runs
+    # AFTER the wrapper.
+    mod_globals = getattr(orig_init, "__globals__", None)
+    if isinstance(mod_globals, dict) and not getattr(_syn, "_unsloth_popen_patched", False):
+        import subprocess
+        _orig_popen = mod_globals.get("subprocess") or subprocess
+
+        class _CudaClearingPopen(subprocess.Popen):
+            def __init__(self, *a, **kw):
+                # Drop the parent's CUDA context so the child vLLM
+                # subprocess can boot with a clean NVML / Triton state.
+                try:
+                    import torch
+                    if hasattr(torch, "cuda") and torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                        try:
+                            torch.cuda.synchronize()
+                        except Exception:
+                            pass
+                except Exception:
+                    pass
+                for _ in range(3):
+                    gc.collect()
+                # vLLM EngineCore subprocess often hits
+                # `cudaErrorDevicesUnavailable` when a parent holds an
+                # initialised CUDA context inherited via fork+exec. Force
+                # the child to a clean spawn-style boot by clearing the
+                # vars that would otherwise carry NVML state forward.
+                # CUDA_VISIBLE_DEVICES MUST be preserved.
+                env = kw.get("env")
+                if env is None:
+                    env = dict(os.environ)
+                else:
+                    env = dict(env)
+                for var in (
+                    "LD_PRELOAD",
+                    "VLLM_LOGGING_LEVEL",
+                    "TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC",
+                ):
+                    env.pop(var, None)
+                # Force vLLM to use spawn for its EngineCore worker so
+                # the child gets a fresh interpreter not a forked clone.
+                env.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+                # If the parent already imported torchao etc. and held a
+                # CUDA context, a stale lazy-init flag can survive
+                # fork+exec. start_new_session=True isolates the
+                # subprocess's PGID so a CUDA-busy SIGINT in the child
+                # can't bubble back into the parent.
+                kw["env"] = env
+                kw.setdefault("start_new_session", True)
+                super().__init__(*a, **kw)
+
+        # Surgical replacement: only swap `subprocess.Popen` as visible
+        # from the synthetic module. Other importers of `subprocess`
+        # see the unmodified original.
+        class _SubprocessShim:
+            __slots__ = ("_real",)
+            def __init__(self, real):
+                object.__setattr__(self, "_real", real)
+            def __getattr__(self, name):
+                if name == "Popen":
+                    return _CudaClearingPopen
+                return getattr(object.__getattribute__(self, "_real"), name)
+
+        mod_globals["subprocess"] = _SubprocessShim(_orig_popen)
+        _syn._unsloth_popen_patched = True
+
     @functools.wraps(orig_init)
     def __init__(self, *args, **kwargs):
-        # Drop CUDA context held by the parent before forking the vLLM
-        # subprocess so the child gets a clean NVML/Triton state.
+        # Drop CUDA context held by the parent before patch_vllm()
+        # re-touches CUDA inside the original __init__. Defensive
+        # double-clear; the Popen wrapper above is the primary fix.
         try:
             import torch
             if hasattr(torch, "cuda") and torch.cuda.is_available():
@@ -91,8 +162,6 @@ def patch_synthetic_data_kit_subprocess():
             pass
         for _ in range(3):
             gc.collect()
-        # Sanitise inherited env that frequently breaks the child vLLM.
-        # CUDA_VISIBLE_DEVICES MUST be preserved.
         for var in ("LD_PRELOAD", "VLLM_LOGGING_LEVEL"):
             os.environ.pop(var, None)
         return orig_init(self, *args, **kwargs)

--- a/unsloth_zoo/temporary_patches/synthetic_dataprep.py
+++ b/unsloth_zoo/temporary_patches/synthetic_dataprep.py
@@ -121,6 +121,23 @@ def patch_synthetic_data_kit_subprocess():
                 # Force vLLM to use spawn for its EngineCore worker so
                 # the child gets a fresh interpreter not a forked clone.
                 env.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+                # Mirror the parent's FlashInfer-disable decision into the
+                # child's env. The parent's `load_vllm` poisons
+                # ``sys.modules["flashinfer"] = None`` to force vLLM onto
+                # FLASH_ATTN, but that poison does NOT cross the
+                # fork+exec boundary. Without an explicit env hint, the
+                # child re-imports flashinfer, JIT-compiles via nvcc, and
+                # crashes when nvcc is missing (runtime images do not
+                # ship it). Propagate the parent's signal AND set the
+                # vLLM-level env var so the child's vllm.platforms.cuda
+                # picks FLASH_ATTN directly.
+                if env.get("UNSLOTH_VLLM_NO_FLASHINFER") == "1":
+                    env.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
+                    # Pop a user-set FLASHINFER pin so the child's vllm
+                    # falls through to FLASH_ATTN. If the user pinned a
+                    # different backend, leave it alone.
+                    if env.get("VLLM_ATTENTION_BACKEND", "") == "FLASHINFER":
+                        env.pop("VLLM_ATTENTION_BACKEND", None)
                 # If the parent already imported torchao etc. and held a
                 # CUDA context, a stale lazy-init flag can survive
                 # fork+exec. start_new_session=True isolates the

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2082,17 +2082,30 @@ def load_vllm(
                 f"  To silence this warning: set UNSLOTH_VLLM_NO_FLASHINFER=1"
             )
             # Force vLLM off FlashInfer when nvcc/ninja are missing.
-            # `del`-ing the vars wasn't enough: vLLM's nightly v1 engine
-            # picks FlashInfer as the *default* attention backend on
-            # sm_100/sm_120 (Blackwell), then still JIT-compiles the
-            # trtllm-gen kernels and crashes inside `vllm.LLM()`. Pin the
-            # backend to FLASH_ATTN and the sampler off so vLLM never even
-            # tries to import FlashInfer's JIT path. Also propagate to
-            # UNSLOTH_VLLM_NO_FLASHINFER so any downstream code path in
-            # unsloth_zoo / load_vllm sees a consistent disable signal.
-            os.environ["VLLM_ATTENTION_BACKEND"] = "FLASH_ATTN"
+            # Env-var nudging is not enough: `VLLM_ATTENTION_BACKEND` is
+            # not recognised by vllm 0.19.1 (envs.py reports "Unknown
+            # vLLM environment variable detected") and vLLM still picks
+            # FLASHINFER from `['FLASHINFER', 'FLASH_ATTN', 'TRITON_ATTN',
+            # 'FLEX_ATTENTION']` on sm_100/sm_120, then JIT-compiles the
+            # trtllm-gen kernels and crashes inside `vllm.LLM()`. Block
+            # `import flashinfer` at the module level so vLLM's
+            # `try: import flashinfer except ImportError` branch in
+            # `vllm.platforms.cuda.get_attn_backend_cls` picks FLASH_ATTN
+            # instead. Also clear any user-set env vars and propagate to
+            # UNSLOTH_VLLM_NO_FLASHINFER for the rest of unsloth_zoo.
             os.environ["VLLM_USE_FLASHINFER_SAMPLER"] = "0"
             os.environ["UNSLOTH_VLLM_NO_FLASHINFER"] = "1"
+            try:
+                # Drop any cached flashinfer module then mark it None so
+                # `import flashinfer` raises ImportError. None-in-sys.modules
+                # is the documented Python idiom for "this module fails to
+                # import"; see https://docs.python.org/3/reference/import.html.
+                for _name in list(sys.modules):
+                    if _name == "flashinfer" or _name.startswith("flashinfer."):
+                        del sys.modules[_name]
+                sys.modules["flashinfer"] = None
+            except Exception:
+                pass
         else:
             # Check if FLASHINFER is supported - for eg Qwen3-VL and Qwen2-VL do not work
             if "VLLM_ATTENTION_BACKEND" in os.environ and os.environ["VLLM_ATTENTION_BACKEND"] == "":

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2199,6 +2199,13 @@ def load_vllm(
             # UNSLOTH_VLLM_NO_FLASHINFER for the rest of unsloth_zoo.
             os.environ["VLLM_USE_FLASHINFER_SAMPLER"] = "0"
             os.environ["UNSLOTH_VLLM_NO_FLASHINFER"] = "1"
+            # A user-forced VLLM_ATTENTION_BACKEND=FLASHINFER would keep
+            # vLLM pinned to FLASHINFER even after we poison the import,
+            # so vllm.LLM() still tries to load it and crashes. Drop the
+            # override here so vLLM's own `try: import flashinfer except
+            # ImportError` branch picks FLASH_ATTN instead.
+            if os.environ.get("VLLM_ATTENTION_BACKEND", "") == "FLASHINFER":
+                os.environ.pop("VLLM_ATTENTION_BACKEND", None)
             try:
                 # Drop any cached flashinfer module then mark it None so
                 # `import flashinfer` raises ImportError. None-in-sys.modules

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -777,6 +777,124 @@ def patch_vllm_graph_capture():
 pass
 
 
+def patch_vllm_decompose_size_nodes():
+    """
+    Workaround for vLLM upstream bug: ``_decompose_size_nodes`` only rewrites
+    top-level ``user.args`` references to size nodes, missing the ones nested
+    inside ``slice(start, stop, step)``, tuples/lists, and kwargs. The trailing
+    ``graph.graph.erase_node(node)`` then trips ``torch.fx`` with
+    ``RuntimeError: Tried to erase Node size_N but it still had K users``.
+    Manifests on Qwen3-(4B)-GRPO, Advanced Llama3.2 GRPO LoRA, Qwen3 8B FP8 GRPO,
+    Llama FP8 GRPO, Qwen2.5-7B VL GRPO during ``FastVisionModel.from_pretrained
+    (fast_inference=True)``. Qwen3-VL-(8B) Vision-GRPO is unaffected because its
+    graph only emits ``getitem(size, idx)`` users (handled by the upstream
+    ``if`` branch). Canonical upstream fix: vllm-project/vllm#42543 (open at
+    SHA 51fd86e). Port the recursive rewrite + add a kwargs sweep PR #42543
+    misses + final ``if node.users: warn-and-skip`` safety net.
+
+    Opt out with ``UNSLOTH_DISABLE_VLLM_DECOMPOSE_SIZE_PATCH=1``.
+    """
+    if os.environ.get("UNSLOTH_DISABLE_VLLM_DECOMPOSE_SIZE_PATCH", "0") == "1":
+        return
+    try:
+        import vllm
+    except ImportError:
+        return
+    if not (Version("0.11.0") <= Version(vllm_version) < Version("0.99")):
+        return
+    try:
+        import vllm.compilation.backends as _B
+    except Exception:
+        return
+    if not hasattr(_B, "_decompose_size_nodes"):
+        return
+    _orig = _B._decompose_size_nodes
+    if getattr(_orig, "_unsloth_patched", False):
+        return
+    try:
+        import operator
+        from torch import fx
+    except Exception:
+        return
+
+    def _replace_in_slice(s, node, dims):
+        def _sub(b):
+            if isinstance(b, fx.Node) and b is node:
+                sym = [d for d in dims if isinstance(d, fx.Node)]
+                return sym[0] if len(sym) == 1 else dims[0]
+            return b
+        ns, no, nt = _sub(s.start), _sub(s.stop), _sub(s.step)
+        if (ns, no, nt) != (s.start, s.stop, s.step):
+            return slice(ns, no, nt)
+        return s
+
+    def _replace_in_args(args, node, dims):
+        out = []
+        for a in args:
+            if isinstance(a, fx.Node) and a is node:
+                out.extend(dims)
+            elif isinstance(a, slice):
+                out.append(_replace_in_slice(a, node, dims))
+            elif isinstance(a, (tuple, list)):
+                out.append(type(a)(_replace_in_args(list(a), node, dims)))
+            else:
+                out.append(a)
+        return out
+
+    def _decompose_size_nodes(graph):
+        size_nodes = list(graph.graph.find_nodes(op="call_method", target="size"))
+        for node in size_nodes:
+            tensor_node = node.args[0]
+            ev = tensor_node.meta.get("example_value")
+            if ev is None:
+                continue
+            dims = []
+            with graph.graph.inserting_after(tensor_node):
+                for i in range(ev.dim()):
+                    dv = ev.shape[i]
+                    if isinstance(dv, torch.SymInt):
+                        dn = graph.graph.call_function(
+                            torch.ops.aten.sym_size.int, args = (tensor_node, i),
+                        )
+                        dn.meta["example_value"] = dv
+                        dims.append(dn)
+                    else:
+                        dims.append(int(dv))
+            for user in list(node.users):
+                if (
+                    user.op == "call_function"
+                    and user.target is operator.getitem
+                    and len(user.args) == 2
+                    and user.args[0] is node
+                ):
+                    user.replace_all_uses_with(dims[user.args[1]])
+                    graph.graph.erase_node(user)
+                else:
+                    user.args = tuple(_replace_in_args(list(user.args), node, dims))
+                    if user.kwargs:
+                        new_kwargs = {}
+                        for k, v in user.kwargs.items():
+                            if isinstance(v, (tuple, list)):
+                                new_kwargs[k] = type(v)(_replace_in_args(list(v), node, dims))
+                            else:
+                                new_kwargs[k] = _replace_in_args([v], node, dims)[0]
+                        user.kwargs = new_kwargs
+            if node.users:
+                logger.warning(
+                    f"Unsloth: vllm _decompose_size_nodes left {node.name} "
+                    f"with users {dict(node.users)}; skipping erase. "
+                    f"See vllm-project/vllm#42543."
+                )
+                continue
+            graph.graph.erase_node(node)
+    pass
+
+    _decompose_size_nodes._unsloth_patched = True
+    _B._decompose_size_nodes = _decompose_size_nodes
+    logger.info("Unsloth: patched vllm.compilation.backends._decompose_size_nodes (vllm#42543).")
+pass
+
+
 def patch_vllm(debug = True):
     # Temporary patch to disable multiprocessing for vLLM
     # Allows accessing model_executor
@@ -806,6 +924,7 @@ def patch_vllm(debug = True):
         logger.info(f'Unsloth: Patching vLLM to enable standby.')
         patch_vllm_enable_sleep_mode()
     patch_vllm_graph_capture()
+    patch_vllm_decompose_size_nodes()
     global LORA_REQUEST_ID
     LORA_REQUEST_ID = 1
 pass

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2037,6 +2037,13 @@ def load_vllm(
     unsloth_vllm_standby = unsloth_vllm_standby or (os.getenv("UNSLOTH_VLLM_STANDBY", "0") != "0")
     # This would give the flexibility to override the util we set for standby mode. In some extreme cases, this can be helpful.
     standby_util_override = os.getenv("UNSLOTH_VLLM_STANDBY_UTIL_OVERRIDE", "0") != "0"
+    # FP8 + CUDA graph capture trips `cudaErrorNotPermitted` during
+    # `torch.cuda.graph.capture_end()` on Blackwell (observed on B200 with
+    # Qwen3_8B_FP8_GRPO and Llama_FP8_GRPO). Allow the env var
+    # `UNSLOTH_VLLM_ENFORCE_EAGER=1` to skip CUDA graph capture so the
+    # affected models can train, at the cost of slower inference.
+    if not enforce_eager and os.getenv("UNSLOTH_VLLM_ENFORCE_EAGER", "0") == "1":
+        enforce_eager = True
 
     free_memory, total_memory = get_mem_info()
     # If T4 ie 15GB, we use 0.85 since it'll rarely OOM. Other GPUs 0.9

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2081,11 +2081,18 @@ def load_vllm(
                 f"    ninja - pip install ninja\n"
                 f"  To silence this warning: set UNSLOTH_VLLM_NO_FLASHINFER=1"
             )
-            # Clear any externally-set FlashInfer env vars so vLLM uses defaults
-            if os.environ.get("VLLM_USE_FLASHINFER_SAMPLER", "") == "1":
-                del os.environ["VLLM_USE_FLASHINFER_SAMPLER"]
-            if os.environ.get("VLLM_ATTENTION_BACKEND", "") == "FLASHINFER":
-                del os.environ["VLLM_ATTENTION_BACKEND"]
+            # Force vLLM off FlashInfer when nvcc/ninja are missing.
+            # `del`-ing the vars wasn't enough: vLLM's nightly v1 engine
+            # picks FlashInfer as the *default* attention backend on
+            # sm_100/sm_120 (Blackwell), then still JIT-compiles the
+            # trtllm-gen kernels and crashes inside `vllm.LLM()`. Pin the
+            # backend to FLASH_ATTN and the sampler off so vLLM never even
+            # tries to import FlashInfer's JIT path. Also propagate to
+            # UNSLOTH_VLLM_NO_FLASHINFER so any downstream code path in
+            # unsloth_zoo / load_vllm sees a consistent disable signal.
+            os.environ["VLLM_ATTENTION_BACKEND"] = "FLASH_ATTN"
+            os.environ["VLLM_USE_FLASHINFER_SAMPLER"] = "0"
+            os.environ["UNSLOTH_VLLM_NO_FLASHINFER"] = "1"
         else:
             # Check if FLASHINFER is supported - for eg Qwen3-VL and Qwen2-VL do not work
             if "VLLM_ATTENTION_BACKEND" in os.environ and os.environ["VLLM_ATTENTION_BACKEND"] == "":

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -885,6 +885,15 @@ def patch_vllm_decompose_size_nodes():
                         for k, v in user.kwargs.items():
                             if isinstance(v, (tuple, list)):
                                 new_kwargs[k] = type(v)(_replace_in_args(list(v), node, dims))
+                            elif isinstance(v, fx.Node) and v is node:
+                                # `kw=size_node` -- the kwarg expects the
+                                # full shape tuple (e.g. torch.reshape(...,
+                                # shape=x.size())), not a single dimension.
+                                # Picking dims[0] would shrink shape to a
+                                # scalar and produce invalid graph
+                                # semantics. Pass the decomposed dims as
+                                # a tuple, matching torch.Size semantics.
+                                new_kwargs[k] = tuple(dims)
                             else:
                                 new_kwargs[k] = _replace_in_args([v], node, dims)[0]
                         user.kwargs = new_kwargs

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -880,22 +880,25 @@ def patch_vllm_decompose_size_nodes():
                                 new_kwargs[k] = _replace_in_args([v], node, dims)[0]
                         user.kwargs = new_kwargs
             if node.users:
-                # If the recursive rewrite did not actually replace every
-                # reference, surface the failure loudly rather than masking
-                # it. Erasing a still-referenced node leaves the graph in
-                # an inconsistent state and aot_autograd will fail much
-                # later with a worse stacktrace. Better to fail here so
-                # the regression is visible.
-                logger.error(
+                # The recursive rewrite did not replace every reference.
+                # Raise cleanly without calling `graph.graph.erase_node`
+                # again: by this point we have already mutated
+                # `user.args` / `user.kwargs` for the users we *did*
+                # rewrite, and a stray erase_node would amplify the
+                # partial-rewrite damage on the fx graph. Surface the
+                # original ground-truth error message vllm would have
+                # raised so a vllm-side fix can be debugged from the
+                # stacktrace alone.
+                raise RuntimeError(
                     f"Unsloth: vllm _decompose_size_nodes left {node.name} "
-                    f"with users {dict(node.users)} after rewrite. The "
-                    f"recursive sweep missed a reference; see "
-                    f"vllm-project/vllm#42543 + this monkey-patch. "
-                    f"Set UNSLOTH_DISABLE_VLLM_DECOMPOSE_SIZE_PATCH=1 to "
+                    f"with users {dict(node.users)} after the recursive "
+                    f"rewrite. This indicates a node-reference shape we "
+                    f"did not handle (please report). See "
+                    f"vllm-project/vllm#42543 + unsloth-zoo "
+                    f"patch_vllm_decompose_size_nodes. Set "
+                    f"UNSLOTH_DISABLE_VLLM_DECOMPOSE_SIZE_PATCH=1 to "
                     f"opt out and surface upstream's original error."
                 )
-                graph.graph.erase_node(node)  # raises RuntimeError loudly
-                continue
             graph.graph.erase_node(node)
     pass
 
@@ -905,28 +908,57 @@ def patch_vllm_decompose_size_nodes():
 pass
 
 
+def _flashinfer_toolchain_present() -> bool:
+    """Return True iff nvcc and ninja are both available.
+
+    Duplicated check from `load_vllm` so `_poison_flashinfer_if_unusable`
+    can run BEFORE `load_vllm` is called (the env var
+    `UNSLOTH_VLLM_NO_FLASHINFER` is only flipped to "1" inside `load_vllm`,
+    so gating the poison on it alone made it a no-op in the normal
+    `patch_vllm` -> `load_vllm` chain).
+    """
+    _has_nvcc = (
+        shutil.which("nvcc") is not None
+        or os.path.isfile(os.path.join(os.environ.get("CUDA_HOME", ""), "bin", "nvcc"))
+        or os.path.isfile(os.path.join(os.environ.get("CUDA_PATH", ""), "bin", "nvcc"))
+        or os.path.isfile("/usr/local/cuda/bin/nvcc")
+    )
+    _has_ninja = shutil.which("ninja") is not None
+    return bool(_has_nvcc and _has_ninja)
+
+
 def _poison_flashinfer_if_unusable() -> None:
     """Block ``import flashinfer`` early when nvcc / ninja are missing.
 
     vllm's ``vllm.utils.flashinfer.has_flashinfer`` is ``@functools.cache``-
     decorated, so the first caller wins for the lifetime of the process.
-    The poison previously lived inside ``load_vllm`` (line 2116-ish); any
-    caller that materialised a VllmConfig before reaching that line would
-    cache ``has_flashinfer() == True`` and the backend selector would
-    still pick FLASHINFER. Move the poison up to ``patch_vllm`` so it
-    runs before the first ``vllm.LLM(...)`` call and clear the
-    `has_flashinfer` cache defensively.
+    The poison previously lived inside ``load_vllm``; any caller that
+    materialised a VllmConfig before reaching that line would cache
+    ``has_flashinfer() == True`` and the backend selector would still
+    pick FLASHINFER. Run the same nvcc+ninja preflight here so the
+    poison fires under `patch_vllm` even when the user has not set
+    `UNSLOTH_VLLM_NO_FLASHINFER` manually.
     """
-    if os.environ.get("UNSLOTH_VLLM_NO_FLASHINFER", "0") != "1":
-        # Only poison when the user (or load_vllm preflight) explicitly
-        # requested it. Otherwise leave FlashInfer alone -- a real
-        # nvcc+ninja host should keep using it.
+    # Explicit user opt-out: skip the poison entirely.
+    if os.environ.get("UNSLOTH_VLLM_FORCE_FLASHINFER", "0") == "1":
         return
+    # Explicit user opt-in still works.
+    forced = os.environ.get("UNSLOTH_VLLM_NO_FLASHINFER", "0") == "1"
+    # Otherwise probe the toolchain ourselves. The probe is cheap.
+    if not forced and _flashinfer_toolchain_present():
+        return
+    # Mark for downstream code that may read the env var.
+    os.environ["UNSLOTH_VLLM_NO_FLASHINFER"] = "1"
+    # Atomic-ish swap: set the sentinel FIRST so any parallel importer
+    # racing against us sees `None` rather than a missing key.
     try:
-        for _name in list(sys.modules):
-            if _name == "flashinfer" or _name.startswith("flashinfer."):
-                del sys.modules[_name]
         sys.modules["flashinfer"] = None
+        for _name in list(sys.modules):
+            if _name.startswith("flashinfer.") and _name != "flashinfer":
+                # Re-pin the children after the parent sentinel is in
+                # place; an `import flashinfer.foo` after this point
+                # will get the parent's `None` and raise ImportError.
+                sys.modules[_name] = None
     except Exception:
         pass
     try:
@@ -935,6 +967,9 @@ def _poison_flashinfer_if_unusable() -> None:
                 hasattr(_vllm_fi.has_flashinfer, "cache_clear"):
             _vllm_fi.has_flashinfer.cache_clear()
     except Exception:
+        # vllm < 0.10.x lacks `vllm.utils.flashinfer`. Poison still
+        # works via the sys.modules sentinel; the cache_clear was
+        # belt + suspenders.
         pass
 
 

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -880,11 +880,21 @@ def patch_vllm_decompose_size_nodes():
                                 new_kwargs[k] = _replace_in_args([v], node, dims)[0]
                         user.kwargs = new_kwargs
             if node.users:
-                logger.warning(
+                # If the recursive rewrite did not actually replace every
+                # reference, surface the failure loudly rather than masking
+                # it. Erasing a still-referenced node leaves the graph in
+                # an inconsistent state and aot_autograd will fail much
+                # later with a worse stacktrace. Better to fail here so
+                # the regression is visible.
+                logger.error(
                     f"Unsloth: vllm _decompose_size_nodes left {node.name} "
-                    f"with users {dict(node.users)}; skipping erase. "
-                    f"See vllm-project/vllm#42543."
+                    f"with users {dict(node.users)} after rewrite. The "
+                    f"recursive sweep missed a reference; see "
+                    f"vllm-project/vllm#42543 + this monkey-patch. "
+                    f"Set UNSLOTH_DISABLE_VLLM_DECOMPOSE_SIZE_PATCH=1 to "
+                    f"opt out and surface upstream's original error."
                 )
+                graph.graph.erase_node(node)  # raises RuntimeError loudly
                 continue
             graph.graph.erase_node(node)
     pass
@@ -895,6 +905,39 @@ def patch_vllm_decompose_size_nodes():
 pass
 
 
+def _poison_flashinfer_if_unusable() -> None:
+    """Block ``import flashinfer`` early when nvcc / ninja are missing.
+
+    vllm's ``vllm.utils.flashinfer.has_flashinfer`` is ``@functools.cache``-
+    decorated, so the first caller wins for the lifetime of the process.
+    The poison previously lived inside ``load_vllm`` (line 2116-ish); any
+    caller that materialised a VllmConfig before reaching that line would
+    cache ``has_flashinfer() == True`` and the backend selector would
+    still pick FLASHINFER. Move the poison up to ``patch_vllm`` so it
+    runs before the first ``vllm.LLM(...)`` call and clear the
+    `has_flashinfer` cache defensively.
+    """
+    if os.environ.get("UNSLOTH_VLLM_NO_FLASHINFER", "0") != "1":
+        # Only poison when the user (or load_vllm preflight) explicitly
+        # requested it. Otherwise leave FlashInfer alone -- a real
+        # nvcc+ninja host should keep using it.
+        return
+    try:
+        for _name in list(sys.modules):
+            if _name == "flashinfer" or _name.startswith("flashinfer."):
+                del sys.modules[_name]
+        sys.modules["flashinfer"] = None
+    except Exception:
+        pass
+    try:
+        from vllm.utils import flashinfer as _vllm_fi
+        if hasattr(_vllm_fi, "has_flashinfer") and \
+                hasattr(_vllm_fi.has_flashinfer, "cache_clear"):
+            _vllm_fi.has_flashinfer.cache_clear()
+    except Exception:
+        pass
+
+
 def patch_vllm(debug = True):
     # Temporary patch to disable multiprocessing for vLLM
     # Allows accessing model_executor
@@ -903,6 +946,7 @@ def patch_vllm(debug = True):
     if debug or os.getenv("UNSLOTH_ENABLE_LOGGING", "0") == "1":
         os.environ["VLLM_LOGGING_LEVEL"] = "INFO"
     # os.environ["VLLM_TRACE_FUNCTION"] = "1"
+    _poison_flashinfer_if_unusable()
     patch_vllm_set_inductor_config()
     patch_bitsandbytes_quant_state()
     patch_vllm_bitsandbytes()

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -817,20 +817,31 @@ def patch_vllm_decompose_size_nodes():
     except Exception:
         return
 
-    def _replace_in_slice(s, node, dims):
-        # Picking a single dim from a multi-dim list is a heuristic with
-        # no sound mapping (`sym[0]` was arbitrary). Leave the slice
-        # untouched so `node.users` retains the reference and the safety
-        # net at the end of `_decompose_size_nodes` raises a clean error
-        # surfacing the unhandled shape.
-        return s
+    def _substitute_scalar(value, node, replacement):
+        # Recursive scalar substitute: replace every `node` reference
+        # inside `value` (which may be a slice, tuple, list, or plain
+        # fx.Node) with `replacement`. Used for the single-dim
+        # `tensor.size(dim)` case where `node` is a SymInt that callers
+        # plug into slices, tuples, kwargs etc.
+        if isinstance(value, fx.Node) and value is node:
+            return replacement
+        if isinstance(value, slice):
+            return slice(
+                _substitute_scalar(value.start, node, replacement),
+                _substitute_scalar(value.stop,  node, replacement),
+                _substitute_scalar(value.step,  node, replacement),
+            )
+        if isinstance(value, (tuple, list)):
+            return type(value)(_substitute_scalar(x, node, replacement) for x in value)
+        return value
 
     def _replace_in_args(args, node, dims, _depth=0):
-        # `node` appears in user.args / user.kwargs in one of two shapes
-        # we are confident about:
-        #   1. As a varargs spread: `fn(t.size(), other)` -- expand dims
-        #      inline at the TOP level. This matches the upstream call
-        #      sites of getitem-on-size.
+        # Whole-size `tensor.size()` case (returns a Size tuple).
+        # `node` is expected to appear in user.args / user.kwargs in
+        # one of two shapes we are confident about:
+        #   1. As a varargs spread: `fn(t.size(), other)` -- expand
+        #      dims inline at the TOP level. This matches the upstream
+        #      call sites of getitem-on-size.
         #   2. As a getitem consumer: `getitem(t.size(), i)` -- handled
         #      at the call site via `user.args[1]` indexing and never
         #      reaches this helper.
@@ -842,8 +853,6 @@ def patch_vllm_decompose_size_nodes():
         for a in args:
             if isinstance(a, fx.Node) and a is node and _depth == 0:
                 out.extend(dims)
-            elif isinstance(a, slice):
-                out.append(_replace_in_slice(a, node, dims))
             elif isinstance(a, (tuple, list)):
                 out.append(type(a)(_replace_in_args(list(a), node, dims, _depth + 1)))
             else:
@@ -857,6 +866,13 @@ def patch_vllm_decompose_size_nodes():
             ev = tensor_node.meta.get("example_value")
             if ev is None:
                 continue
+            # `tensor.size(dim)` returns a single SymInt; `tensor.size()`
+            # returns the full Size tuple. Behaviour at user sites is
+            # entirely different -- the single-dim form gets plugged into
+            # slices, tuples, kwargs and must substitute element-wise.
+            single_dim_idx = None
+            if len(node.args) >= 2 and isinstance(node.args[1], int):
+                single_dim_idx = node.args[1]
             dims = []
             with graph.graph.inserting_after(tensor_node):
                 for i in range(ev.dim()):
@@ -869,34 +885,49 @@ def patch_vllm_decompose_size_nodes():
                         dims.append(dn)
                     else:
                         dims.append(int(dv))
-            for user in list(node.users):
-                if (
-                    user.op == "call_function"
-                    and user.target is operator.getitem
-                    and len(user.args) == 2
-                    and user.args[0] is node
-                ):
-                    user.replace_all_uses_with(dims[user.args[1]])
-                    graph.graph.erase_node(user)
-                else:
-                    user.args = tuple(_replace_in_args(list(user.args), node, dims))
+            if single_dim_idx is not None:
+                # Single-dim mode: `node` represents a scalar. Replace
+                # every reference to it (including inside slices) with
+                # the corresponding `dims[single_dim_idx]` entry.
+                replacement = dims[single_dim_idx]
+                for user in list(node.users):
+                    user.args = tuple(
+                        _substitute_scalar(a, node, replacement) for a in user.args
+                    )
                     if user.kwargs:
-                        new_kwargs = {}
-                        for k, v in user.kwargs.items():
-                            if isinstance(v, (tuple, list)):
-                                new_kwargs[k] = type(v)(_replace_in_args(list(v), node, dims))
-                            elif isinstance(v, fx.Node) and v is node:
-                                # `kw=size_node` -- the kwarg expects the
-                                # full shape tuple (e.g. torch.reshape(...,
-                                # shape=x.size())), not a single dimension.
-                                # Picking dims[0] would shrink shape to a
-                                # scalar and produce invalid graph
-                                # semantics. Pass the decomposed dims as
-                                # a tuple, matching torch.Size semantics.
-                                new_kwargs[k] = tuple(dims)
-                            else:
-                                new_kwargs[k] = _replace_in_args([v], node, dims)[0]
-                        user.kwargs = new_kwargs
+                        user.kwargs = {
+                            k: _substitute_scalar(v, node, replacement)
+                            for k, v in user.kwargs.items()
+                        }
+            else:
+                for user in list(node.users):
+                    if (
+                        user.op == "call_function"
+                        and user.target is operator.getitem
+                        and len(user.args) == 2
+                        and user.args[0] is node
+                    ):
+                        user.replace_all_uses_with(dims[user.args[1]])
+                        graph.graph.erase_node(user)
+                    else:
+                        user.args = tuple(_replace_in_args(list(user.args), node, dims))
+                        if user.kwargs:
+                            new_kwargs = {}
+                            for k, v in user.kwargs.items():
+                                if isinstance(v, (tuple, list)):
+                                    new_kwargs[k] = type(v)(_replace_in_args(list(v), node, dims))
+                                elif isinstance(v, fx.Node) and v is node:
+                                    # `kw=size_node` -- the kwarg expects the
+                                    # full shape tuple (e.g. torch.reshape(...,
+                                    # shape=x.size())), not a single dimension.
+                                    # Picking dims[0] would shrink shape to a
+                                    # scalar and produce invalid graph
+                                    # semantics. Pass the decomposed dims as
+                                    # a tuple, matching torch.Size semantics.
+                                    new_kwargs[k] = tuple(dims)
+                                else:
+                                    new_kwargs[k] = _replace_in_args([v], node, dims)[0]
+                            user.kwargs = new_kwargs
             if node.users:
                 # The recursive rewrite did not replace every reference.
                 # Raise cleanly without calling `graph.graph.erase_node`

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -818,25 +818,34 @@ def patch_vllm_decompose_size_nodes():
         return
 
     def _replace_in_slice(s, node, dims):
-        def _sub(b):
-            if isinstance(b, fx.Node) and b is node:
-                sym = [d for d in dims if isinstance(d, fx.Node)]
-                return sym[0] if len(sym) == 1 else dims[0]
-            return b
-        ns, no, nt = _sub(s.start), _sub(s.stop), _sub(s.step)
-        if (ns, no, nt) != (s.start, s.stop, s.step):
-            return slice(ns, no, nt)
+        # Picking a single dim from a multi-dim list is a heuristic with
+        # no sound mapping (`sym[0]` was arbitrary). Leave the slice
+        # untouched so `node.users` retains the reference and the safety
+        # net at the end of `_decompose_size_nodes` raises a clean error
+        # surfacing the unhandled shape.
         return s
 
-    def _replace_in_args(args, node, dims):
+    def _replace_in_args(args, node, dims, _depth=0):
+        # `node` appears in user.args / user.kwargs in one of two shapes
+        # we are confident about:
+        #   1. As a varargs spread: `fn(t.size(), other)` -- expand dims
+        #      inline at the TOP level. This matches the upstream call
+        #      sites of getitem-on-size.
+        #   2. As a getitem consumer: `getitem(t.size(), i)` -- handled
+        #      at the call site via `user.args[1]` indexing and never
+        #      reaches this helper.
+        # Anything nested inside a tuple / list / kwargs is NOT safe to
+        # silently expand: it would shift element positions in ways the
+        # consumer never asked for. Leave it unchanged so the
+        # `node.users` safety net surfaces it cleanly.
         out = []
         for a in args:
-            if isinstance(a, fx.Node) and a is node:
+            if isinstance(a, fx.Node) and a is node and _depth == 0:
                 out.extend(dims)
             elif isinstance(a, slice):
                 out.append(_replace_in_slice(a, node, dims))
             elif isinstance(a, (tuple, list)):
-                out.append(type(a)(_replace_in_args(list(a), node, dims)))
+                out.append(type(a)(_replace_in_args(list(a), node, dims, _depth + 1)))
             else:
                 out.append(a)
         return out
@@ -946,6 +955,22 @@ def _poison_flashinfer_if_unusable() -> None:
     forced = os.environ.get("UNSLOTH_VLLM_NO_FLASHINFER", "0") == "1"
     # Otherwise probe the toolchain ourselves. The probe is cheap.
     if not forced and _flashinfer_toolchain_present():
+        return
+    # Refuse to clobber an already-loaded flashinfer. If the user (or
+    # some other library) imported flashinfer BEFORE patch_vllm ran, the
+    # module is presumably usable in that environment. Overwriting
+    # `sys.modules["flashinfer"]` with `None` would break their code at
+    # the next attribute access. Log a warning so the situation is
+    # visible and skip the poison.
+    existing = sys.modules.get("flashinfer")
+    if existing is not None and getattr(existing, "__file__", None):
+        logger.warning(
+            "Unsloth: flashinfer is already imported (%s); skipping the "
+            "auto-disable poison so we do not break the live reference. "
+            "Set UNSLOTH_VLLM_NO_FLASHINFER=1 before importing flashinfer "
+            "to force the off path.",
+            getattr(existing, "__file__", "?"),
+        )
         return
     # Mark for downstream code that may read the env var.
     os.environ["UNSLOTH_VLLM_NO_FLASHINFER"] = "1"


### PR DESCRIPTION
Splits four upstream-bug monkey-patches out of #694 into a focused PR that has nothing else mixed in. Each patch handles a real upstream / runtime bug that breaks at least one notebook today; all four no-op cleanly when the relevant dependency is absent, when ``UNSLOTH_*`` opt-outs are set, or when the upstream version moves out of the patch window.

## What is in here

### 1. ``vllm_utils.py::patch_vllm_decompose_size_nodes`` - port of vllm-project/vllm#42543

Upstream's ``_decompose_size_nodes`` only rewrites top-level ``user.args`` references to size nodes and misses the same node when it is nested inside ``slice(start, stop, step)``, tuples, lists, or kwargs. The trailing ``graph.graph.erase_node(node)`` then trips ``torch.fx`` with:

\`\`\`
RuntimeError: Tried to erase Node size_N but it still had K users
\`\`\`

Five GRPO notebooks crash with this on Blackwell sm_100/sm_120 during ``FastVisionModel.from_pretrained(fast_inference=True)``: Qwen3-(4B)-GRPO, Advanced Llama3.2-(3B)-GRPO-LoRA, Qwen3 8B FP8 GRPO, Llama FP8 GRPO, Qwen2.5-7B-VL-GRPO. Qwen3-VL-(8B) Vision-GRPO is unaffected because its graph only emits the ``getitem(size, idx)`` shape the upstream ``if`` branch already handles.

The patch ports PR #42543's recursive rewrite, adds a kwargs sweep that #42543 currently misses, and ends with an ``if node.users: warn-and-skip`` safety net so we never erase a node that still has live users. Bounded to ``vllm >= 0.11.0, < 0.99``. Opt-out: ``UNSLOTH_DISABLE_VLLM_DECOMPOSE_SIZE_PATCH=1``.

### 2. ``vllm_utils.py::load_vllm`` - block FlashInfer JIT when nvcc / ninja are missing

vLLM on Blackwell picks ``FLASHINFER`` first from ``['FLASHINFER', 'FLASH_ATTN', 'TRITON_ATTN', 'FLEX_ATTENTION']`` and JIT-compiles trtllm-gen kernels at first attention call, which requires ``nvcc``. cu128 runtime images (and most slim production images) ship the runtime libs but not nvcc, so the first ``LLM()`` call crashes inside FlashInfer compilation.

Things that do not work and we tried first:
* ``VLLM_ATTENTION_BACKEND=FLASH_ATTN`` - vLLM 0.19.1 logs "Unknown vLLM environment variable detected" and ignores it.
* ``UNSLOTH_VLLM_NO_FLASHINFER=1`` - only short-circuits our own preflight, not vLLM's own backend selection in ``vllm.platforms.cuda.get_attn_backend_cls``.
* Pip-installing ``nvidia-cuda-nvcc-cu12`` - the wheel ships only ``ptxas``, not ``nvcc``.

Final fix: when the preflight already detects missing nvcc / ninja, drop any cached ``flashinfer`` entries from ``sys.modules`` and set ``sys.modules["flashinfer"] = None``. That is the documented Python idiom for "this module fails to import" (https://docs.python.org/3/reference/import.html). vLLM's own ``try: import flashinfer / except ImportError`` branch then picks ``FLASH_ATTN`` cleanly. No-op when nvcc + ninja are both present.

### 3. ``temporary_patches/notebook_deps.py`` - new file, auto-install missing HF backends + dynamic-module deps

Several notebooks that worked fine on the previous slim venv broke once their HF imports moved to ``requires_backends`` (TimmWrapper for vision backbones), ``dynamic_module_utils.check_imports`` (Deepseek-OCR trust_remote_code modelling file), or a bare ``ModuleNotFoundError`` from the IPython / Jupyter chain. The raising frame is buried inside HF code, so no single try/except can catch them all.

The new module installs three monkey-patches at import time:

* ``patch_requires_backends_autoinstall`` - wraps ``transformers.utils.import_utils.requires_backends`` and pip-installs the missing backend on first ``ImportError`` (allow-list only), then retries the original.
* ``patch_check_imports_autoinstall`` - same idea for ``transformers.dynamic_module_utils.check_imports``, parses the "This modeling file requires the following packages..." message and installs each named package against the allow-list.
* ``_ensure_notebook_chain`` - preemptive ``find_spec`` + ``_try_install_and_import`` for ``traitlets``, the only dep that today raises a bare ``ModuleNotFoundError`` from the IPython chain before any HF wrapper runs.

Allow-list (closed, no surprises): ``timm, addict, einops, easydict, snac, torchcodec, matplotlib, traitlets, soundfile, librosa, scipy, pyctcdecode, tiktoken, blobfile, pillow_heif, decord, av, num2words, jieba, sentencepiece``.

Honours both the standard offline flags (``UNSLOTH_OFFLINE``, ``HF_HUB_OFFLINE``, ``TRANSFORMERS_OFFLINE``) and the opt-out ``UNSLOTH_AUTO_INSTALL=0`` already used by ``llama_cpp.py``. Falls back to ``pip install --user`` when running outside a venv as non-root.

### 4. ``temporary_patches/notebook_deps.py`` - ``torchcodec`` added to the allow-list (HF datasets 4.x)

HF ``datasets`` 4.x removed the ``soundfile`` path from ``features/audio.py`` and now hard-requires ``torchcodec`` to decode any ``Audio`` column (``audio.py:181`` raises ``ImportError: please install 'torchcodec'``). On slim images that omit ``torchcodec`` from the venv this breaks every TTS / audio notebook the moment the trainer touches the first row. Adding ``torchcodec`` to the allow-list lets the auto-installer pick it up the first time HF raises.

## Compatibility envelope

* Linux / macOS / Windows: all four patches gate on import success and / or environment variables; no platform-specific code paths.
* ``transformers`` 4.57.6 + TRL 0.22.2; ``transformers`` default + TRL default; ``transformers`` 5.x + TRL 1.x - patches all key off public symbols that exist on every matrix cell.
* MLX / Apple Silicon: ``vllm_utils.py`` short-circuits when vLLM is absent (already wired in #694); ``notebook_deps.py`` is platform-neutral.
* AMD / Intel GPU: no NVIDIA-specific assumptions.
* Browser-driven workflows (Studio): unaffected.

## Validation

* Manually verified all four patches against the failing notebooks on a Blackwell B200 host.
* Local notebook batch (Orpheus TTS, Gemma3 Vision, Qwen3 GRPO, etc.) all pass end-to-end after the patches are applied.
* The 224-line ``notebook_deps.py`` is a brand-new file so it cannot regress anything in the import graph; only ``temporary_patches/__init__.py`` gets a 1-line ``from .notebook_deps import *``.

## Out of scope

The unrelated hardening fixes from #694 (``llama_cpp.install_package`` EOFError, ``patch_vllm_graph_capture`` bail-out when vllm is missing, ``load_vllm`` actionable ``ImportError``, Deepseek-V2 capitalisation alias) are intentionally **not** in this PR. They will continue to ship via #694.