### PR TITLE
Fix mlx-ci.yml torch install gap + finetune-last-n-layers FakeModel stubs

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -51,8 +51,17 @@ jobs:
       - name: Install zoo with MLX extras
         # pyproject gates MLX deps on darwin+arm64; `.[mlx]` picks them up
         # without the torch-on-Linux-CUDA path.
+        #
+        # NOTE: pyproject also gates `torch` OFF on darwin+arm64 (mlx is the
+        # native path on Apple Silicon), but tests/mlx_simulation/__init__.py
+        # unconditionally `import torch` so the torch-spoof shim that powers
+        # the test suite can monkeypatch torch.Tensor with MLX-only methods.
+        # Install the CPU wheel explicitly first so collection of
+        # tests/test_mlx_torch_shim_smoke.py does not fail with
+        # ModuleNotFoundError: No module named 'torch'.
         run: |
           python -m pip install --upgrade pip
+          pip install "torch>=2.4.0,<2.11.0"
           pip install -e .[mlx]
           pip install pytest==9.0.3
 

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -61,7 +61,7 @@ jobs:
         # ModuleNotFoundError: No module named 'torch'.
         run: |
           python -m pip install --upgrade pip
-          pip install "torch>=2.4.0,<2.11.0"
+          pip install "torch>=2.4.0,<2.13.0"
           pip install -e .[mlx]
           pip install pytest==9.0.3
 

--- a/tests/test_mlx_finetune_last_n_layers.py
+++ b/tests/test_mlx_finetune_last_n_layers.py
@@ -72,6 +72,15 @@ def test_get_peft_model_passes_finetune_last_n_layers_through():
         _is_vlm_model = False
         def freeze(self): pass
         def unfreeze(self, **kwargs): pass
+        # get_peft_model prints a "Unsloth: LoRA applied -- N trainable
+        # params (P% of T total)" stats line at the tail of the function
+        # via mlx.utils.tree_flatten(model.trainable_parameters()) and
+        # model.parameters(). The synthetic FakeModel doesn't carry real
+        # mlx parameters; return empty dicts so tree_flatten yields zero
+        # entries and the stats line prints "0.00% of 0 total" without
+        # raising AttributeError.
+        def trainable_parameters(self): return {}
+        def parameters(self): return {}
 
     # Capture num_layers values seen by linear_to_lora_layers.
     captured = {"calls": []}


### PR DESCRIPTION
Two unrelated cleanups surfaced while validating #697.

## 1. \`.github/workflows/mlx-ci.yml\` fails on every scheduled run

\`pyproject.toml\` gates \`torch\` off on darwin+arm64 (mlx is the native path on Apple Silicon), so \`pip install -e .[mlx]\` on macos-14 does not pull torch. But \`tests/mlx_simulation/__init__.py:52\` unconditionally does \`import torch\` -- the autouse shim that powers the test suite needs it to monkeypatch \`torch.Tensor\` with MLX-only methods (\`.astype\`, \`.expand_dims\`, \`.at[]\`).

Collection of \`tests/test_mlx_torch_shim_smoke.py\` blows up with \`ModuleNotFoundError: No module named 'torch'\` before any test runs.

Reproduces: most recent scheduled cron run on \`main\` (run id [26499388502](https://github.com/unslothai/unsloth-zoo/actions/runs/26499388502)) failed in 52s with exactly that error at collection time.

Fix: install the CPU torch wheel explicitly before \`.[mlx]\`, matching the local-dev install order.

## 2. \`tests/test_mlx_finetune_last_n_layers.py\` FakeModel is incomplete

\`unsloth_zoo/mlx/loader.py::FastMLXModel.get_peft_model\` prints a \"LoRA applied -- N trainable params (P% of T total)\" stats line at the tail of the function via \`mlx.utils.tree_flatten(model.trainable_parameters())\` plus \`model.parameters()\`. The synthetic FakeModel in this test never implemented those two methods, so the assertion targeting \`linear_to_lora_layers\`'s captured \`num_layers\` is never reached -- the test crashes at \`loader.py:3712\` with \`AttributeError: 'FakeModel' object has no attribute 'trainable_parameters'\`.

The test exercises a parameter passthrough; the stats line is incidental. Fix: stub \`trainable_parameters\` and \`parameters\` on FakeModel to return empty dicts so \`tree_flatten\` yields zero entries and the stats line prints \"0.00% of 0 total\" without raising.

## Verification

\`\`\`
python -m pytest tests/test_mlx_finetune_last_n_layers.py -v
  2 passed
python -m pytest tests/test_mlx_*.py -q
  180 passed, 1 skipped
python -m pytest tests/ -q --ignore=tests/security
  1017 passed, 50 skipped
\`\`\`

Both fixes are independent of each other and of #697; bundled here because both surfaced in the same audit pass.