### PR TITLE
Fix/csm training 4.5X-5.5

### DIFF
--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -885,104 +885,35 @@ def test_csm_depth_decoder_for_causal_lm_forward_named_params():
     )
 
 
-def test_csm_depth_decoder_leaf_embedding_hook_backward():
-    """misc.py CSM patch must avoid upstream's leaf-view CopySlices crash.
-
-    Zoo's gradient-checkpointing hook can mark frozen embedding outputs as
-    leaf tensors requiring grad. Upstream CSM then assigns into
-    ``inputs_embeds[:, 0]`` and autograd raises before LoRA training starts.
-    """
-    torch = pytest.importorskip("torch")
+def _tiny_csm_depth_decoder(torch):
     csm = pytest.importorskip("transformers.models.csm.modeling_csm")
     config_mod = pytest.importorskip("transformers.models.csm.configuration_csm")
-
-    from unsloth_zoo.temporary_patches.misc import patch_CsmDepthDecoderForCausalLM_forward
-
-    patch_CsmDepthDecoderForCausalLM_forward()
-
     config = config_mod.CsmDepthDecoderConfig(
-        vocab_size=11,
-        num_codebooks=4,
-        backbone_hidden_size=8,
-        hidden_size=8,
-        intermediate_size=16,
-        num_hidden_layers=1,
-        num_attention_heads=2,
-        num_key_value_heads=1,
-        max_position_embeddings=8,
-        head_dim=4,
-        attention_dropout=0.0,
-        use_cache=False,
+        vocab_size=11, num_codebooks=4, backbone_hidden_size=8,
+        hidden_size=8, intermediate_size=16, num_hidden_layers=1,
+        num_attention_heads=2, num_key_value_heads=1,
+        max_position_embeddings=8, head_dim=4, use_cache=False,
         pad_token_id=0,
     )
     config._attn_implementation = "eager"
     model = csm.CsmDepthDecoderForCausalLM(config).train()
     model.model.embed_tokens.weight.requires_grad_(False)
-
-    hook = model.model.embed_tokens.register_forward_hook(
-        lambda module, args, output: output.requires_grad_(True)
-    )
-    try:
-        input_ids = torch.tensor([[0, 2, 3, 4]], dtype=torch.long)
-        labels = torch.tensor([[5, 6, 7, 8]], dtype=torch.long)
-        backbone_last_hidden_state = torch.randn(1, 8, requires_grad=True)
-
-        out = model(
-            input_ids=input_ids,
-            backbone_last_hidden_state=backbone_last_hidden_state,
-            labels=labels,
-            return_dict=True,
-        )
-        out.loss.backward()
-
-        assert backbone_last_hidden_state.grad is not None
-        assert torch.isfinite(backbone_last_hidden_state.grad).all()
-        assert torch.count_nonzero(backbone_last_hidden_state.grad) > 0
-    finally:
-        hook.remove()
+    return model
 
 
-def test_csm_depth_decoder_keeps_gc_sentinel_with_frozen_backbone_state():
-    """Detached replacement states still need a grad-requiring model input.
-
-    This covers depth-decoder-only adapter training under reentrant gradient
-    checkpointing, where the hook-created sentinel is the only grad-requiring
-    input before the first checkpointed decoder block.
-    """
+@pytest.mark.parametrize("backbone_requires_grad", [True, False])
+def test_csm_depth_decoder_leaf_embedding_hook_backward(backbone_requires_grad):
+    """CSM patch handles GC hook leaf embeddings without losing grad input."""
     torch = pytest.importorskip("torch")
-    csm = pytest.importorskip("transformers.models.csm.modeling_csm")
-    config_mod = pytest.importorskip("transformers.models.csm.configuration_csm")
-
     from unsloth_zoo.temporary_patches.misc import patch_CsmDepthDecoderForCausalLM_forward
 
     patch_CsmDepthDecoderForCausalLM_forward()
-
-    config = config_mod.CsmDepthDecoderConfig(
-        vocab_size=11,
-        num_codebooks=4,
-        backbone_hidden_size=8,
-        hidden_size=8,
-        intermediate_size=16,
-        num_hidden_layers=1,
-        num_attention_heads=2,
-        num_key_value_heads=1,
-        max_position_embeddings=8,
-        head_dim=4,
-        attention_dropout=0.0,
-        use_cache=False,
-        pad_token_id=0,
-    )
-    config._attn_implementation = "eager"
-    model = csm.CsmDepthDecoderForCausalLM(config).train()
-    model.model.embed_tokens.weight.requires_grad_(False)
-
+    model = _tiny_csm_depth_decoder(torch)
     seen = {}
     original_forward = model.model.forward
 
     def wrapped_model_forward(*args, **kwargs):
-        inputs_embeds = kwargs.get("inputs_embeds")
-        if inputs_embeds is not None:
-            seen["requires_grad"] = inputs_embeds.requires_grad
+        seen["inputs_embeds_requires_grad"] = kwargs["inputs_embeds"].requires_grad
         return original_forward(*args, **kwargs)
 
     model.model.forward = wrapped_model_forward
@@ -990,15 +921,19 @@ def test_csm_depth_decoder_keeps_gc_sentinel_with_frozen_backbone_state():
         lambda module, args, output: output.requires_grad_(True)
     )
     try:
+        backbone_state = torch.randn(1, 8, requires_grad=backbone_requires_grad)
         out = model(
             input_ids=torch.tensor([[0, 2, 3, 4]], dtype=torch.long),
-            backbone_last_hidden_state=torch.randn(1, 8),
+            backbone_last_hidden_state=backbone_state,
             labels=torch.tensor([[5, 6, 7, 8]], dtype=torch.long),
             return_dict=True,
         )
+        out.loss.backward()
 
-        assert out.loss.requires_grad
-        assert seen["requires_grad"] is True
+        assert seen["inputs_embeds_requires_grad"] is True
+        if backbone_requires_grad:
+            assert backbone_state.grad is not None
+            assert torch.count_nonzero(backbone_state.grad) > 0
     finally:
         hook.remove()
         model.model.forward = original_forward
@@ -2481,4 +2416,3 @@ def test_temporary_patches_directory_has_expected_files():
             f"DRIFT DETECTED: temporary_patches/ is missing files {missing}; "
             f"either they were renamed or dropped without updating the test"
         )
-

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -939,6 +939,37 @@ def test_csm_depth_decoder_leaf_embedding_hook_backward(backbone_requires_grad):
         model.model.forward = original_forward
 
 
+def test_csm_audio_eos_label_mask_respects_processor_ignore():
+    torch = pytest.importorskip("torch")
+    from unsloth_zoo.temporary_patches.misc import _csm_audio_eos_label_mask
+
+    audio_eos_token_mask = torch.tensor([[False, True, True]])
+    labels = torch.tensor([[128002, -100, 128003]])
+
+    assert _csm_audio_eos_label_mask(audio_eos_token_mask, labels).tolist() == [[False, False, True]]
+
+
+def test_csm_audio_embeddings_tie_helper():
+    torch = pytest.importorskip("torch")
+    from types import SimpleNamespace
+    from unsloth_zoo.temporary_patches.misc import _tie_csm_audio_embeddings
+
+    audio = torch.nn.Embedding(4, 3)
+    depth = torch.nn.Embedding(4, 3)
+    model = SimpleNamespace(
+        backbone_model=SimpleNamespace(
+            embed_tokens=SimpleNamespace(embed_audio_tokens=audio),
+        ),
+        depth_decoder=SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=depth),
+        ),
+    )
+
+    assert audio.weight.data_ptr() != depth.weight.data_ptr()
+    _tie_csm_audio_embeddings(model)
+    assert audio.weight.data_ptr() == depth.weight.data_ptr()
+
+
 def test_csm_for_conditional_generation_forward_named_params():
     """misc.py:373 patches CsmForConditionalGeneration.forward (input_ids,
     input_values, ..., logits_to_keep). Resolves via ``_original_*``

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -960,6 +960,27 @@ def test_csm_audio_embeddings_tie_helper():
     assert audio.weight.data_ptr() == depth.weight.data_ptr()
 
 
+def test_csm_audio_embeddings_tie_helper_respects_config():
+    torch = pytest.importorskip("torch")
+    from types import SimpleNamespace
+    from unsloth_zoo.temporary_patches.misc import _tie_csm_audio_embeddings
+
+    audio = torch.nn.Embedding(4, 3)
+    depth = torch.nn.Embedding(4, 3)
+    model = SimpleNamespace(
+        config=SimpleNamespace(tie_codebooks_embeddings=False),
+        backbone_model=SimpleNamespace(
+            embed_tokens=SimpleNamespace(embed_audio_tokens=audio),
+        ),
+        depth_decoder=SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=depth),
+        ),
+    )
+
+    _tie_csm_audio_embeddings(model)
+    assert audio.weight.data_ptr() != depth.weight.data_ptr()
+
+
 def test_csm_audio_eos_label_helper_keeps_trainer_counts_aligned():
     torch = pytest.importorskip("torch")
     from unsloth_zoo.temporary_patches.misc import _label_csm_audio_eos_tokens
@@ -970,6 +991,46 @@ def test_csm_audio_eos_label_helper_keeps_trainer_counts_aligned():
     labels = _label_csm_audio_eos_tokens(input_ids, labels, 128003)
 
     assert labels.tolist() == [[-100, 128002, 128003, -100]]
+
+
+def test_csm_audio_eos_label_helper_supports_numpy():
+    np = pytest.importorskip("numpy")
+    from unsloth_zoo.temporary_patches.misc import _label_csm_audio_eos_tokens
+
+    labels = np.array([[-100, 128002, -100, -100]])
+    input_ids = np.array([[128000, 128002, 128003, 0]])
+
+    labels = _label_csm_audio_eos_tokens(input_ids, labels, 128003)
+
+    assert labels.tolist() == [[-100, 128002, 128003, -100]]
+
+
+def test_csm_processor_output_uses_configured_audio_eos_id():
+    torch = pytest.importorskip("torch")
+    from types import SimpleNamespace
+    from unsloth_zoo.temporary_patches.misc import _label_csm_processor_output
+
+    processor = SimpleNamespace(audio_eos_token_id=42)
+    output = {
+        "input_ids": torch.tensor([[128000, 128002, 42, 0]]),
+        "labels": torch.tensor([[-100, 128002, -100, -100]]),
+    }
+
+    output = _label_csm_processor_output(processor, output)
+
+    assert output["labels"].tolist() == [[-100, 128002, 42, -100]]
+
+
+def test_csm_processor_output_ignores_non_mappings():
+    torch = pytest.importorskip("torch")
+    from types import SimpleNamespace
+    from unsloth_zoo.temporary_patches.misc import _label_csm_processor_output
+
+    tensor_output = torch.tensor([[128000, 128002]])
+    text_output = "input_ids and labels are just rendered text"
+
+    assert _label_csm_processor_output(SimpleNamespace(), tensor_output) is tensor_output
+    assert _label_csm_processor_output(SimpleNamespace(), text_output) is text_output
 
 
 def test_csm_for_conditional_generation_forward_named_params():

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -960,22 +960,16 @@ def test_csm_audio_embeddings_tie_helper():
     assert audio.weight.data_ptr() == depth.weight.data_ptr()
 
 
-def test_csm_num_items_counts_masked_audio_eos():
+def test_csm_audio_eos_label_helper_keeps_trainer_counts_aligned():
     torch = pytest.importorskip("torch")
-    from unsloth_zoo.loss_utils import _csm_token_count_mask
+    from unsloth_zoo.temporary_patches.misc import _label_csm_audio_eos_tokens
 
     labels = torch.tensor([[-100, 128002, -100, -100]])
     input_ids = torch.tensor([[128000, 128002, 128003, 0]])
-    attention_mask = torch.tensor([[1, 1, 1, 0]])
 
-    mask = _csm_token_count_mask(
-        labels,
-        input_ids=input_ids,
-        attention_mask=attention_mask,
-        audio_eos_token_id=128003,
-    )
+    labels = _label_csm_audio_eos_tokens(input_ids, labels, 128003)
 
-    assert mask.tolist() == [[True, True, False]]
+    assert labels.tolist() == [[-100, 128002, 128003, -100]]
 
 
 def test_csm_for_conditional_generation_forward_named_params():

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -939,16 +939,6 @@ def test_csm_depth_decoder_leaf_embedding_hook_backward(backbone_requires_grad):
         model.model.forward = original_forward
 
 
-def test_csm_audio_eos_label_mask_respects_processor_ignore():
-    torch = pytest.importorskip("torch")
-    from unsloth_zoo.temporary_patches.misc import _csm_audio_eos_label_mask
-
-    audio_eos_token_mask = torch.tensor([[False, True, True]])
-    labels = torch.tensor([[128002, -100, 128003]])
-
-    assert _csm_audio_eos_label_mask(audio_eos_token_mask, labels).tolist() == [[False, False, True]]
-
-
 def test_csm_audio_embeddings_tie_helper():
     torch = pytest.importorskip("torch")
     from types import SimpleNamespace
@@ -968,6 +958,24 @@ def test_csm_audio_embeddings_tie_helper():
     assert audio.weight.data_ptr() != depth.weight.data_ptr()
     _tie_csm_audio_embeddings(model)
     assert audio.weight.data_ptr() == depth.weight.data_ptr()
+
+
+def test_csm_num_items_counts_masked_audio_eos():
+    torch = pytest.importorskip("torch")
+    from unsloth_zoo.loss_utils import _csm_token_count_mask
+
+    labels = torch.tensor([[-100, 128002, -100, -100]])
+    input_ids = torch.tensor([[128000, 128002, 128003, 0]])
+    attention_mask = torch.tensor([[1, 1, 1, 0]])
+
+    mask = _csm_token_count_mask(
+        labels,
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        audio_eos_token_id=128003,
+    )
+
+    assert mask.tolist() == [[True, True, False]]
 
 
 def test_csm_for_conditional_generation_forward_named_params():

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -885,6 +885,125 @@ def test_csm_depth_decoder_for_causal_lm_forward_named_params():
     )
 
 
+def test_csm_depth_decoder_leaf_embedding_hook_backward():
+    """misc.py CSM patch must avoid upstream's leaf-view CopySlices crash.
+
+    Zoo's gradient-checkpointing hook can mark frozen embedding outputs as
+    leaf tensors requiring grad. Upstream CSM then assigns into
+    ``inputs_embeds[:, 0]`` and autograd raises before LoRA training starts.
+    """
+    torch = pytest.importorskip("torch")
+    csm = pytest.importorskip("transformers.models.csm.modeling_csm")
+    config_mod = pytest.importorskip("transformers.models.csm.configuration_csm")
+
+    from unsloth_zoo.temporary_patches.misc import patch_CsmDepthDecoderForCausalLM_forward
+
+    patch_CsmDepthDecoderForCausalLM_forward()
+
+    config = config_mod.CsmDepthDecoderConfig(
+        vocab_size=11,
+        num_codebooks=4,
+        backbone_hidden_size=8,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        max_position_embeddings=8,
+        head_dim=4,
+        attention_dropout=0.0,
+        use_cache=False,
+        pad_token_id=0,
+    )
+    config._attn_implementation = "eager"
+    model = csm.CsmDepthDecoderForCausalLM(config).train()
+    model.model.embed_tokens.weight.requires_grad_(False)
+
+    hook = model.model.embed_tokens.register_forward_hook(
+        lambda module, args, output: output.requires_grad_(True)
+    )
+    try:
+        input_ids = torch.tensor([[0, 2, 3, 4]], dtype=torch.long)
+        labels = torch.tensor([[5, 6, 7, 8]], dtype=torch.long)
+        backbone_last_hidden_state = torch.randn(1, 8, requires_grad=True)
+
+        out = model(
+            input_ids=input_ids,
+            backbone_last_hidden_state=backbone_last_hidden_state,
+            labels=labels,
+            return_dict=True,
+        )
+        out.loss.backward()
+
+        assert backbone_last_hidden_state.grad is not None
+        assert torch.isfinite(backbone_last_hidden_state.grad).all()
+        assert torch.count_nonzero(backbone_last_hidden_state.grad) > 0
+    finally:
+        hook.remove()
+
+
+def test_csm_depth_decoder_keeps_gc_sentinel_with_frozen_backbone_state():
+    """Detached replacement states still need a grad-requiring model input.
+
+    This covers depth-decoder-only adapter training under reentrant gradient
+    checkpointing, where the hook-created sentinel is the only grad-requiring
+    input before the first checkpointed decoder block.
+    """
+    torch = pytest.importorskip("torch")
+    csm = pytest.importorskip("transformers.models.csm.modeling_csm")
+    config_mod = pytest.importorskip("transformers.models.csm.configuration_csm")
+
+    from unsloth_zoo.temporary_patches.misc import patch_CsmDepthDecoderForCausalLM_forward
+
+    patch_CsmDepthDecoderForCausalLM_forward()
+
+    config = config_mod.CsmDepthDecoderConfig(
+        vocab_size=11,
+        num_codebooks=4,
+        backbone_hidden_size=8,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        max_position_embeddings=8,
+        head_dim=4,
+        attention_dropout=0.0,
+        use_cache=False,
+        pad_token_id=0,
+    )
+    config._attn_implementation = "eager"
+    model = csm.CsmDepthDecoderForCausalLM(config).train()
+    model.model.embed_tokens.weight.requires_grad_(False)
+
+    seen = {}
+    original_forward = model.model.forward
+
+    def wrapped_model_forward(*args, **kwargs):
+        inputs_embeds = kwargs.get("inputs_embeds")
+        if inputs_embeds is not None:
+            seen["requires_grad"] = inputs_embeds.requires_grad
+        return original_forward(*args, **kwargs)
+
+    model.model.forward = wrapped_model_forward
+    hook = model.model.embed_tokens.register_forward_hook(
+        lambda module, args, output: output.requires_grad_(True)
+    )
+    try:
+        out = model(
+            input_ids=torch.tensor([[0, 2, 3, 4]], dtype=torch.long),
+            backbone_last_hidden_state=torch.randn(1, 8),
+            labels=torch.tensor([[5, 6, 7, 8]], dtype=torch.long),
+            return_dict=True,
+        )
+
+        assert out.loss.requires_grad
+        assert seen["requires_grad"] is True
+    finally:
+        hook.remove()
+        model.model.forward = original_forward
+
+
 def test_csm_for_conditional_generation_forward_named_params():
     """misc.py:373 patches CsmForConditionalGeneration.forward (input_ids,
     input_values, ..., logits_to_keep). Resolves via ``_original_*``
@@ -2362,5 +2481,4 @@ def test_temporary_patches_directory_has_expected_files():
             f"DRIFT DETECTED: temporary_patches/ is missing files {missing}; "
             f"either they were renamed or dropped without updating the test"
         )
-
 

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -76,6 +76,30 @@ __all__ = [
 
 from .fused_losses import unsloth_fused_ce_loss
 
+def _get_csm_audio_eos_token_id(model):
+    try:
+        if hasattr(model, "get_base_model"):
+            model = model.get_base_model()
+        for attr in ("base_model", "model", "model"):
+            model = getattr(model, attr, model)
+        config = getattr(model, "config", None)
+        if getattr(config, "model_type", None) == "csm":
+            return getattr(config, "audio_eos_token_id", None)
+    except Exception:
+        pass
+    return None
+pass
+
+def _csm_token_count_mask(labels, input_ids = None, attention_mask = None, audio_eos_token_id = None):
+    token_count = labels[..., 1:] != -100
+    if audio_eos_token_id is not None and input_ids is not None:
+        # Older CSM processors masked audio EOS labels; the merge patch trains them.
+        token_count |= input_ids[..., 1:] == audio_eos_token_id
+    if attention_mask is not None:
+        token_count &= attention_mask[..., 1:] != 0
+    return token_count
+pass
+
 def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
     # All Unsloth Zoo code licensed under LGPLv3
     try:
@@ -304,22 +328,28 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
             break
     pass
 
+    csm_audio_eos_token_id = _get_csm_audio_eos_token_id(getattr(self, "model", None))
+
     # Get num_items_in_batch
     if has_kwargs and len(batch_samples) > 0 and "labels" in batch_samples[0]:
         try:
             token_counts = []
             for x in batch_samples:
                 labels = x["labels"]
-                token_count = (labels[..., 1:] != -100)
+                input_ids = x.get("input_ids")
+                attention_mask = x.get("attention_mask")
+                token_count = _csm_token_count_mask(
+                    labels,
+                    input_ids = input_ids,
+                    attention_mask = attention_mask,
+                    audio_eos_token_id = csm_audio_eos_token_id,
+                )
                 if "input_ids" in x:
-                    input_ids = x["input_ids"]
                     mark_static (input_ids, 0)
                     mark_dynamic(input_ids, 1)
                 if "attention_mask" in x:
-                    attention_mask = x["attention_mask"]
                     mark_static (attention_mask, 0)
                     mark_dynamic(attention_mask, 1)
-                    token_count &= (attention_mask[..., 1:] != 0)
                 if "token_type_ids" in x:
                     token_type_ids = x["token_type_ids"]
                     mark_static (token_type_ids, 0)

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -76,30 +76,6 @@ __all__ = [
 
 from .fused_losses import unsloth_fused_ce_loss
 
-def _get_csm_audio_eos_token_id(model):
-    try:
-        if hasattr(model, "get_base_model"):
-            model = model.get_base_model()
-        for attr in ("base_model", "model", "model"):
-            model = getattr(model, attr, model)
-        config = getattr(model, "config", None)
-        if getattr(config, "model_type", None) == "csm":
-            return getattr(config, "audio_eos_token_id", None)
-    except Exception:
-        pass
-    return None
-pass
-
-def _csm_token_count_mask(labels, input_ids = None, attention_mask = None, audio_eos_token_id = None):
-    token_count = labels[..., 1:] != -100
-    if audio_eos_token_id is not None and input_ids is not None:
-        # Older CSM processors masked audio EOS labels; the merge patch trains them.
-        token_count |= input_ids[..., 1:] == audio_eos_token_id
-    if attention_mask is not None:
-        token_count &= attention_mask[..., 1:] != 0
-    return token_count
-pass
-
 def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
     # All Unsloth Zoo code licensed under LGPLv3
     try:
@@ -328,28 +304,22 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
             break
     pass
 
-    csm_audio_eos_token_id = _get_csm_audio_eos_token_id(getattr(self, "model", None))
-
     # Get num_items_in_batch
     if has_kwargs and len(batch_samples) > 0 and "labels" in batch_samples[0]:
         try:
             token_counts = []
             for x in batch_samples:
                 labels = x["labels"]
-                input_ids = x.get("input_ids")
-                attention_mask = x.get("attention_mask")
-                token_count = _csm_token_count_mask(
-                    labels,
-                    input_ids = input_ids,
-                    attention_mask = attention_mask,
-                    audio_eos_token_id = csm_audio_eos_token_id,
-                )
+                token_count = (labels[..., 1:] != -100)
                 if "input_ids" in x:
+                    input_ids = x["input_ids"]
                     mark_static (input_ids, 0)
                     mark_dynamic(input_ids, 1)
                 if "attention_mask" in x:
+                    attention_mask = x["attention_mask"]
                     mark_static (attention_mask, 0)
                     mark_dynamic(attention_mask, 1)
+                    token_count &= (attention_mask[..., 1:] != 0)
                 if "token_type_ids" in x:
                     token_type_ids = x["token_type_ids"]
                     mark_static (token_type_ids, 0)

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 import inspect
 import importlib
+from collections.abc import Mapping
 from typing import Any, List, Optional, Tuple, Union, Dict, Set, Callable
 from .common import TEMPORARY_PATCHES, torch_compile, _torch_compile
 from .utils import (
@@ -416,11 +417,13 @@ TEMPORARY_PATCHES.append(patch_CsmForConditionalGeneration_forward)
 
 
 def _tie_csm_audio_embeddings(model):
+    if not getattr(getattr(model, "config", None), "tie_codebooks_embeddings", True):
+        return model
     try:
         audio_embeddings = model.backbone_model.embed_tokens.embed_audio_tokens
         depth_embeddings = model.depth_decoder.model.embed_tokens
         if audio_embeddings.weight.shape == depth_embeddings.weight.shape:
-            # Keep CSM's codebook tie alive when tie_word_embeddings=False.
+            # Keep CSM's configured codebook tie alive when tie_word_embeddings=False.
             audio_embeddings.weight = depth_embeddings.weight
     except Exception:
         pass
@@ -462,7 +465,15 @@ def _label_csm_audio_eos_tokens(input_ids, labels, audio_eos_token_id):
         return labels
     try:
         eos_mask = input_ids == audio_eos_token_id
-        previous_label_is_audio = torch.nn.functional.pad(labels[..., :-1] != -100, (1, 0), value=False)
+        previous_label_is_audio = labels[..., :-1] != -100
+        if torch.is_tensor(labels):
+            previous_label_is_audio = torch.nn.functional.pad(previous_label_is_audio, (1, 0), value=False)
+        else:
+            import numpy as np
+            previous_label_is_audio = np.concatenate(
+                [np.zeros_like(labels[..., :1], dtype=bool), previous_label_is_audio],
+                axis=-1,
+            )
         labels[eos_mask & previous_label_is_audio] = audio_eos_token_id
     except Exception:
         pass
@@ -470,44 +481,75 @@ def _label_csm_audio_eos_tokens(input_ids, labels, audio_eos_token_id):
 pass
 
 
+def _get_csm_processor_audio_eos_token_id(processor):
+    audio_eos_token_id = getattr(processor, "audio_eos_token_id", None)
+    if audio_eos_token_id is not None:
+        return audio_eos_token_id
+
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None:
+        return None
+
+    audio_eos_token_id = getattr(tokenizer, "audio_eos_token_id", None)
+    if audio_eos_token_id is not None:
+        return audio_eos_token_id
+
+    audio_eos_token = getattr(processor, "audio_eos_token", getattr(tokenizer, "audio_eos_token", "<|audio_eos|>"))
+    try:
+        return tokenizer.convert_tokens_to_ids(audio_eos_token)
+    except Exception:
+        return None
+pass
+
+
+def _label_csm_processor_output(processor, output):
+    if not isinstance(output, Mapping) or "input_ids" not in output or "labels" not in output:
+        return output
+    output["labels"] = _label_csm_audio_eos_tokens(
+        output.get("input_ids"),
+        output.get("labels"),
+        _get_csm_processor_audio_eos_token_id(processor),
+    )
+    return output
+pass
+
+
 def patch_CsmProcessor_apply_chat_template():
     try:
         import transformers.models.csm.processing_csm
     except Exception as e:
-        return raise_error("CsmProcessor.apply_chat_template", e)
+        return raise_error("CsmProcessor", e)
 
     target_cls = transformers.models.csm.processing_csm.CsmProcessor
-    storage_name = _get_unique_storage_name(target_cls, "apply_chat_template")
-    if hasattr(target_cls, storage_name):
-        original_apply_chat_template = getattr(target_cls, storage_name)
+    apply_storage_name = _get_unique_storage_name(target_cls, "apply_chat_template")
+    if hasattr(target_cls, apply_storage_name):
+        original_apply_chat_template = getattr(target_cls, apply_storage_name)
     else:
         original_apply_chat_template = target_cls.apply_chat_template
-        setattr(target_cls, storage_name, original_apply_chat_template)
+        setattr(target_cls, apply_storage_name, original_apply_chat_template)
+    pass
+    call_storage_name = _get_unique_storage_name(target_cls, "__call__")
+    if hasattr(target_cls, call_storage_name):
+        original_call = getattr(target_cls, call_storage_name)
+    else:
+        original_call = target_cls.__call__
+        setattr(target_cls, call_storage_name, original_call)
     pass
 
     def apply_chat_template(self, *args, **kwargs):
-        output = original_apply_chat_template(self, *args, **kwargs)
-        if hasattr(output, "__contains__") and "input_ids" in output and "labels" in output:
-            tokenizer = getattr(self, "tokenizer", None)
-            audio_eos_token_id = None
-            if tokenizer is not None:
-                try:
-                    audio_eos_token_id = tokenizer.convert_tokens_to_ids("<|audio_eos|>")
-                except Exception:
-                    audio_eos_token_id = None
-            pass
-            output["labels"] = _label_csm_audio_eos_tokens(
-                output.get("input_ids"),
-                output.get("labels"),
-                audio_eos_token_id,
-            )
-        return output
+        return _label_csm_processor_output(self, original_apply_chat_template(self, *args, **kwargs))
+    pass
+
+    def __call__(self, *args, **kwargs):
+        return _label_csm_processor_output(self, original_call(self, *args, **kwargs))
     pass
     try:
         apply_chat_template.__signature__ = inspect.signature(original_apply_chat_template)
+        __call__.__signature__ = inspect.signature(original_call)
     except Exception:
         pass
     target_cls.apply_chat_template = apply_chat_template
+    target_cls.__call__ = __call__
 pass
 TEMPORARY_PATCHES.append(patch_CsmProcessor_apply_chat_template)
 

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -415,11 +415,6 @@ pass
 TEMPORARY_PATCHES.append(patch_CsmForConditionalGeneration_forward)
 
 
-def _csm_audio_eos_label_mask(audio_eos_token_mask, labels):
-    return audio_eos_token_mask & (labels != -100)
-pass
-
-
 def _tie_csm_audio_embeddings(model):
     try:
         audio_embeddings = model.backbone_model.embed_tokens.embed_audio_tokens
@@ -845,9 +840,7 @@ def patch_CsmForConditionalGeneration_merge():
             if labels is not None:
                 labels_expanded = labels.unsqueeze(-1).repeat(1, 1, self.config.num_codebooks)
                 labels_expanded[audio_token_mask] = batched_audio_token_ids[audio_codes_mask]
-                # Preserve processor masking: 4.52 masks audio EOS, while newer processors label it.
-                audio_eos_label_mask = _csm_audio_eos_label_mask(audio_eos_token_mask, labels)
-                labels_expanded[audio_eos_label_mask] = audio_eos_frame_ids
+                labels_expanded[audio_eos_token_mask] = audio_eos_frame_ids
                 # mask depth decoder
                 depth_decoder_ignore_frames_idxs = (labels == -101).nonzero(as_tuple=True)
                 labels_expanded[depth_decoder_ignore_frames_idxs[0], depth_decoder_ignore_frames_idxs[1], 1:] = -100

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -198,17 +198,18 @@ def patch_CsmDepthDecoderForCausalLM_forward():
             codebook_idxs = torch.clamp(codebook_indices - 1, min=0)
             offset = codebook_idxs * self.model.vocab_size
             inputs_embeds = self.model.embed_tokens(input_ids + offset)
-            restore_input_grad = inputs_embeds.requires_grad and inputs_embeds.is_leaf
-            if restore_input_grad:
-                inputs_embeds = inputs_embeds.detach()
+            if inputs_embeds.requires_grad and inputs_embeds.is_leaf:
+                # Use the cheap detach when backbone state supplies gradients;
+                # clone only when the GC sentinel itself must survive.
+                inputs_embeds = (
+                    inputs_embeds.detach()
+                    if backbone_last_hidden_state.requires_grad
+                    else inputs_embeds.clone()
+                )
             inputs_embeds[:, 0] = backbone_last_hidden_state.to(
                 device=inputs_embeds.device,
                 dtype=inputs_embeds.dtype,
             )
-            # If the replacement state is frozen, keep GC's input-grad
-            # sentinel alive for decoder-only adapter training.
-            if restore_input_grad and not inputs_embeds.requires_grad:
-                inputs_embeds.requires_grad_(True)
             input_ids = None
             backbone_last_hidden_state = None
 

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -415,6 +415,53 @@ pass
 TEMPORARY_PATCHES.append(patch_CsmForConditionalGeneration_forward)
 
 
+def _csm_audio_eos_label_mask(audio_eos_token_mask, labels):
+    return audio_eos_token_mask & (labels != -100)
+pass
+
+
+def _tie_csm_audio_embeddings(model):
+    try:
+        audio_embeddings = model.backbone_model.embed_tokens.embed_audio_tokens
+        depth_embeddings = model.depth_decoder.model.embed_tokens
+        if audio_embeddings.weight.shape == depth_embeddings.weight.shape:
+            # Transformers 5.5 can miss this tie while loading older CSM checkpoints.
+            audio_embeddings.weight = depth_embeddings.weight
+    except Exception:
+        pass
+    return model
+pass
+
+
+def patch_CsmForConditionalGeneration_from_pretrained():
+    try:
+        import transformers.models.csm.modeling_csm
+    except Exception as e:
+        return raise_error("CsmForConditionalGeneration.from_pretrained", e)
+
+    target_cls = transformers.models.csm.modeling_csm.CsmForConditionalGeneration
+    storage_name = _get_unique_storage_name(target_cls, "from_pretrained")
+    if hasattr(target_cls, storage_name):
+        original_from_pretrained = getattr(target_cls, storage_name)
+    else:
+        original_from_pretrained = target_cls.from_pretrained
+        setattr(target_cls, storage_name, original_from_pretrained)
+    pass
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        model = original_from_pretrained(*args, **kwargs)
+        return _tie_csm_audio_embeddings(model)
+    pass
+    try:
+        from_pretrained.__signature__ = inspect.signature(original_from_pretrained)
+    except Exception:
+        pass
+    target_cls.from_pretrained = from_pretrained
+pass
+TEMPORARY_PATCHES.append(patch_CsmForConditionalGeneration_from_pretrained)
+
+
 def patch_transformers_masks():
     if os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1":
         return
@@ -798,8 +845,9 @@ def patch_CsmForConditionalGeneration_merge():
             if labels is not None:
                 labels_expanded = labels.unsqueeze(-1).repeat(1, 1, self.config.num_codebooks)
                 labels_expanded[audio_token_mask] = batched_audio_token_ids[audio_codes_mask]
-                # fix make sure to set eos_token_id as a valid label to predict
-                labels_expanded[audio_eos_token_mask] = audio_eos_frame_ids
+                # Preserve processor masking: 4.52 masks audio EOS, while newer processors label it.
+                audio_eos_label_mask = _csm_audio_eos_label_mask(audio_eos_token_mask, labels)
+                labels_expanded[audio_eos_label_mask] = audio_eos_frame_ids
                 # mask depth decoder
                 depth_decoder_ignore_frames_idxs = (labels == -101).nonzero(as_tuple=True)
                 labels_expanded[depth_decoder_ignore_frames_idxs[0], depth_decoder_ignore_frames_idxs[1], 1:] = -100

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -420,7 +420,7 @@ def _tie_csm_audio_embeddings(model):
         audio_embeddings = model.backbone_model.embed_tokens.embed_audio_tokens
         depth_embeddings = model.depth_decoder.model.embed_tokens
         if audio_embeddings.weight.shape == depth_embeddings.weight.shape:
-            # Transformers 5.5 can miss this tie while loading older CSM checkpoints.
+            # Keep CSM's codebook tie alive when tie_word_embeddings=False.
             audio_embeddings.weight = depth_embeddings.weight
     except Exception:
         pass
@@ -428,33 +428,88 @@ def _tie_csm_audio_embeddings(model):
 pass
 
 
-def patch_CsmForConditionalGeneration_from_pretrained():
+def patch_CsmForConditionalGeneration_tie_weights():
     try:
         import transformers.models.csm.modeling_csm
     except Exception as e:
-        return raise_error("CsmForConditionalGeneration.from_pretrained", e)
+        return raise_error("CsmForConditionalGeneration.tie_weights", e)
 
     target_cls = transformers.models.csm.modeling_csm.CsmForConditionalGeneration
-    storage_name = _get_unique_storage_name(target_cls, "from_pretrained")
+    storage_name = _get_unique_storage_name(target_cls, "tie_weights")
     if hasattr(target_cls, storage_name):
-        original_from_pretrained = getattr(target_cls, storage_name)
+        original_tie_weights = getattr(target_cls, storage_name)
     else:
-        original_from_pretrained = target_cls.from_pretrained
-        setattr(target_cls, storage_name, original_from_pretrained)
+        original_tie_weights = target_cls.tie_weights
+        setattr(target_cls, storage_name, original_tie_weights)
     pass
 
-    @classmethod
-    def from_pretrained(cls, *args, **kwargs):
-        model = original_from_pretrained(*args, **kwargs)
-        return _tie_csm_audio_embeddings(model)
+    def tie_weights(self, *args, **kwargs):
+        output = original_tie_weights(self, *args, **kwargs)
+        _tie_csm_audio_embeddings(self)
+        return output
     pass
     try:
-        from_pretrained.__signature__ = inspect.signature(original_from_pretrained)
+        tie_weights.__signature__ = inspect.signature(original_tie_weights)
     except Exception:
         pass
-    target_cls.from_pretrained = from_pretrained
+    target_cls.tie_weights = tie_weights
 pass
-TEMPORARY_PATCHES.append(patch_CsmForConditionalGeneration_from_pretrained)
+TEMPORARY_PATCHES.append(patch_CsmForConditionalGeneration_tie_weights)
+
+
+def _label_csm_audio_eos_tokens(input_ids, labels, audio_eos_token_id):
+    if input_ids is None or labels is None or audio_eos_token_id is None:
+        return labels
+    try:
+        eos_mask = input_ids == audio_eos_token_id
+        previous_label_is_audio = torch.nn.functional.pad(labels[..., :-1] != -100, (1, 0), value=False)
+        labels[eos_mask & previous_label_is_audio] = audio_eos_token_id
+    except Exception:
+        pass
+    return labels
+pass
+
+
+def patch_CsmProcessor_apply_chat_template():
+    try:
+        import transformers.models.csm.processing_csm
+    except Exception as e:
+        return raise_error("CsmProcessor.apply_chat_template", e)
+
+    target_cls = transformers.models.csm.processing_csm.CsmProcessor
+    storage_name = _get_unique_storage_name(target_cls, "apply_chat_template")
+    if hasattr(target_cls, storage_name):
+        original_apply_chat_template = getattr(target_cls, storage_name)
+    else:
+        original_apply_chat_template = target_cls.apply_chat_template
+        setattr(target_cls, storage_name, original_apply_chat_template)
+    pass
+
+    def apply_chat_template(self, *args, **kwargs):
+        output = original_apply_chat_template(self, *args, **kwargs)
+        if hasattr(output, "__contains__") and "input_ids" in output and "labels" in output:
+            tokenizer = getattr(self, "tokenizer", None)
+            audio_eos_token_id = None
+            if tokenizer is not None:
+                try:
+                    audio_eos_token_id = tokenizer.convert_tokens_to_ids("<|audio_eos|>")
+                except Exception:
+                    audio_eos_token_id = None
+            pass
+            output["labels"] = _label_csm_audio_eos_tokens(
+                output.get("input_ids"),
+                output.get("labels"),
+                audio_eos_token_id,
+            )
+        return output
+    pass
+    try:
+        apply_chat_template.__signature__ = inspect.signature(original_apply_chat_template)
+    except Exception:
+        pass
+    target_cls.apply_chat_template = apply_chat_template
+pass
+TEMPORARY_PATCHES.append(patch_CsmProcessor_apply_chat_template)
 
 
 def patch_transformers_masks():

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -191,6 +191,27 @@ def patch_CsmDepthDecoderForCausalLM_forward():
         else:
             codebook_indices = cache_position
 
+        if inputs_embeds is None and input_ids is not None and backbone_last_hidden_state is not None:
+            # Precompute inputs_embeds so self.model skips upstream's in-place
+            # first-token replacement. Zoo's GC hook can make frozen embeddings
+            # leaf tensors, so detach before CopySlices carries backbone grads.
+            codebook_idxs = torch.clamp(codebook_indices - 1, min=0)
+            offset = codebook_idxs * self.model.vocab_size
+            inputs_embeds = self.model.embed_tokens(input_ids + offset)
+            restore_input_grad = inputs_embeds.requires_grad and inputs_embeds.is_leaf
+            if restore_input_grad:
+                inputs_embeds = inputs_embeds.detach()
+            inputs_embeds[:, 0] = backbone_last_hidden_state.to(
+                device=inputs_embeds.device,
+                dtype=inputs_embeds.dtype,
+            )
+            # If the replacement state is frozen, keep GC's input-grad
+            # sentinel alive for decoder-only adapter training.
+            if restore_input_grad and not inputs_embeds.requires_grad:
+                inputs_embeds.requires_grad_(True)
+            input_ids = None
+            backbone_last_hidden_state = None
+
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         outputs = self.model(
             input_ids = input_ids,


### PR DESCRIPTION
## Summary

Fixes CSM LoRA training across Transformers 4.52.x, 4.57.x, and 5.x by keeping the CSM compatibility patches scoped to `temporary_patches/misc.py`.

This addresses two separate CSM regressions:

- Transformers 4.52.x processor outputs mask the audio EOS token, which makes Trainer compute `num_items_in_batch` before the EOS target is introduced by the model merge path.
- Transformers 5.x can miss the CSM audio/depth codebook embedding tie because CSM uses `tie_codebooks_embeddings` while generic tied-weight expansion is gated by `tie_word_embeddings=False`.

## Changes

- Patch `CsmProcessor.apply_chat_template` and `CsmProcessor.__call__` so older processor outputs label audio EOS before Trainer counts training items.
- Patch `CsmForConditionalGeneration.tie_weights` instead of wrapping `from_pretrained`, preserving Unsloth’s loader flow.
- Re-tie CSM audio/depth embeddings only when `config.tie_codebooks_embeddings=True`.
- Resolve audio EOS ids from the processor/tokenizer configuration instead of hard-coding `"<|audio_eos|>"`.
- Restrict processor relabeling to mapping-like outputs so `return_dict=False` tensor/string paths are left untouched.
- Add focused tests for the CSM tie helper, configured EOS id handling, non-mapping outputs, and NumPy-compatible label repair helper.

## Validation

- `pytest tests/test_temporary_patches_exhaustive.py -k 'csm' -q`
  - `14 passed, 102 deselected`
- `git diff --check`
  - clean
- Patch-apply probes pass on:
  - Transformers 4.52.3
  - Transformers 4.57.6
  - Transformers 5.5.0
- Synthetic one-step CSM training on GPU passes with matching first-step loss:
  - Transformers 4.52.3: `train_loss=5.683135032653809`
  - Transformers 4.57.6: `train_loss=5.683135032653809`
  - Transformers 5.5.0: `train_loss=5.683135032653809`
- Verified processor paths:
  - `apply_chat_template(..., return_dict=False)` does not crash.
  - direct `CsmProcessor.__call__(..., output_labels=True)` labels audio EOS correctly.
- Verified tie behavior:
  - `tie_codebooks_embeddings=True` ties audio/depth embeddings.
  - `tie_codebooks_embeddings=False` leaves them untied.