### PR TITLE
Only install torchao ROCm stub on Windows ROCm

### DIFF
--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -244,7 +244,27 @@ class _ROCmTorchaoFinder(_MetaPathFinder):
         return None
 
 
-if "torchao" not in _sys_rocm_stub.modules:
+# Only Windows + ROCm (HIP) PyTorch actually needs this stub: that is the one
+# build where `import torchao` crashes on the missing torch.distributed
+# C-extension stack. On every other platform a failing `import torchao` simply
+# means torchao is not installed -- transformers handles that correctly on its
+# own. Installing the stub there is actively harmful: transformers'
+# is_torchao_available() would then read torchao.__version__, get a sentinel
+# class, and crash in packaging.version.parse() with
+# "'_ROCmSentinelMeta' object is not iterable".
+_is_windows_rocm = False
+if _sys_rocm_stub.platform == "win32":
+    try:
+        import torch as _torch_rocm_probe
+        _is_windows_rocm = bool(
+            getattr(getattr(_torch_rocm_probe, "version", None), "hip", None)
+            or "rocm" in getattr(_torch_rocm_probe, "__version__", "").lower()
+        )
+        del _torch_rocm_probe
+    except Exception:
+        _is_windows_rocm = False
+
+if _is_windows_rocm and "torchao" not in _sys_rocm_stub.modules:
     try:
         import torchao  # noqa: F401
     except Exception:
@@ -256,6 +276,7 @@ if "torchao" not in _sys_rocm_stub.modules:
 # alive -- the loader and sentinel classes call them at runtime.
 del _ROCmTorchaoLoader, _ROCmTorchaoFinder
 del _MetaPathFinder, _Loader, _ModuleSpec, _sys_rocm_stub, _types_rocm_stub
+del _is_windows_rocm
 
 try:
     from transformers.processing_utils import Unpack


### PR DESCRIPTION
## Problem

`import unsloth_zoo` crashes on any platform where `torchao` is not installed (the common case on Linux CI and most Linux/macOS setups):

```
TypeError: '_ROCmSentinelMeta' object is not iterable
  packaging/version.py ... in parse
  transformers/utils/import_utils.py ... in is_torchao_available
```

This is currently failing CI on multiple branches/PRs across both repos.

## Root cause

The torchao Windows-ROCm stub in `temporary_patches/utils.py` (added in #703) was installed whenever `import torchao` raised:

```python
if "torchao" not in sys.modules:
    try:
        import torchao
    except Exception:
        sys.meta_path.insert(0, _ROCmTorchaoFinder())
```

On a normal Linux machine `import torchao` raises simply because torchao is not installed. The guard then installs the meta-path finder anyway, so every later `import torchao` returns a sentinel stub. transformers' `is_torchao_available()` reads `torchao.__version__`, gets a `_ROCmSentinelMeta` class instead of a version string, and `packaging.version.parse()` crashes on it.

The stub is only ever needed on Windows ROCm, where `import torchao` crashes on the incomplete `torch.distributed` C-extension stack. Everywhere else a failing `import torchao` just means "not installed", which transformers already handles correctly.

## Fix

Gate the stub install on an actual Windows ROCm build before touching `sys.meta_path`:

```python
_is_windows_rocm = False
if sys.platform == "win32":
    try:
        import torch
        _is_windows_rocm = bool(
            getattr(getattr(torch, "version", None), "hip", None)
            or "rocm" in getattr(torch, "__version__", "").lower()
        )
    except Exception:
        _is_windows_rocm = False

if _is_windows_rocm and "torchao" not in sys.modules:
    try:
        import torchao
    except Exception:
        sys.meta_path.insert(0, _ROCmTorchaoFinder())
```

The Windows ROCm path is unchanged. Every other platform keeps transformers' own torchao handling, so `import unsloth_zoo` no longer crashes when torchao is absent.

## Verification

A scope-faithful simulation execs the real stub classes and the real patched gate under faked `sys.platform` / `torch` / `torchao` conditions:

| Scenario | Result |
| --- | --- |
| Linux, torchao absent, old gate | reproduces `'_ROCmSentinelMeta' object is not iterable` |
| Linux, torchao absent, new gate | no stub installed, no crash |
| Windows ROCm, `import torchao` fails, new gate | stub installed; `isinstance(x, torchao.dtypes.AffineQuantizedTensor)` returns False with no TypeError; deep `torchao.a.b.c` resolves |
| Windows ROCm, torchao importable, new gate | no stub (real torchao used) |
| Windows CUDA, new gate | no stub |

`python -m py_compile` passes on the changed file.