### PR TITLE
Self-heal GGUF conversion when the converter environment is broken

### DIFF
--- a/tests/test_convert_to_gguf_self_heal.py
+++ b/tests/test_convert_to_gguf_self_heal.py
@@ -1,0 +1,119 @@
+"""Tests for convert_to_gguf's self-heal on a broken converter environment.
+
+A stale or missing converter package (usually `gguf`) makes the converter
+subprocess exit 1. convert_to_gguf should reinstall the deps into the
+converter's own interpreter and retry once, surface the real traceback if the
+failure persists, and never reinstall on a genuine model error.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import textwrap
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_llama_cpp_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+    spec = importlib.util.spec_from_file_location("llama_cpp_under_test_self_heal", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_model_dir(tmp_path: Path) -> Path:
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps({"architectures": ["LlamaForCausalLM"]}))
+    return model_dir
+
+
+def _write_converter(tmp_path: Path, body: str) -> Path:
+    fake = tmp_path / "fake_convert.py"
+    fake.write_text("import sys, argparse, os\n" + textwrap.dedent(body))
+    return fake
+
+
+def _convert(mod, tmp_path, converter):
+    return mod.convert_to_gguf(
+        model_name="llama-3.2-3b-instruct",
+        input_folder=str(_make_model_dir(tmp_path)),
+        quantization_type="bf16",
+        converter_location=str(converter),
+        print_output=False,
+    )
+
+
+def test_stale_package_self_heals(tmp_path, monkeypatch):
+    mod = _load_llama_cpp_module()
+    monkeypatch.chdir(tmp_path)
+
+    # Fail with an ImportError until a "healed" marker exists, then succeed.
+    converter = _write_converter(tmp_path, '''
+        p = argparse.ArgumentParser()
+        p.add_argument("--outfile"); p.add_argument("--outtype"); p.add_argument("--split-max-size")
+        a, _ = p.parse_known_args()
+        if os.path.exists("healed"):
+            open(a.outfile, "wb").write(b"GGUF"); sys.exit(0)
+        sys.stderr.write("ImportError: cannot import name 'GGUFWriter' from 'gguf'\\n")
+        sys.exit(1)
+    ''')
+
+    calls = {"n": 0}
+    def fake_reinstall(python_exe, print_output=False):
+        calls["n"] += 1
+        open("healed", "w").close()
+        return types.SimpleNamespace(returncode=0, stdout="reinstalled gguf")
+    monkeypatch.setattr(mod, "_reinstall_converter_deps", fake_reinstall)
+
+    files, _is_vlm = _convert(mod, tmp_path, converter)
+    assert calls["n"] == 1
+    assert files and os.path.exists(files[0])
+
+
+def test_reinstall_failure_surfaces_error(tmp_path, monkeypatch):
+    mod = _load_llama_cpp_module()
+    monkeypatch.chdir(tmp_path)
+
+    converter = _write_converter(tmp_path, '''
+        sys.stderr.write("ModuleNotFoundError: No module named 'gguf'\\n")
+        sys.exit(1)
+    ''')
+    monkeypatch.setattr(
+        mod, "_reinstall_converter_deps",
+        lambda python_exe, print_output=False: types.SimpleNamespace(returncode=1, stdout="ERROR: offline"),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _convert(mod, tmp_path, converter)
+    msg = str(excinfo.value)
+    assert "No module named 'gguf'" in msg
+    assert "dependency reinstall failed" in msg
+
+
+def test_genuine_model_error_not_repaired(tmp_path, monkeypatch):
+    mod = _load_llama_cpp_module()
+    monkeypatch.chdir(tmp_path)
+
+    converter = _write_converter(tmp_path, '''
+        sys.stderr.write("NotImplementedError: Architecture FooForCausalLM not supported\\n")
+        sys.exit(1)
+    ''')
+    calls = {"n": 0}
+    def spy(python_exe, print_output=False):
+        calls["n"] += 1
+        return types.SimpleNamespace(returncode=0, stdout="")
+    monkeypatch.setattr(mod, "_reinstall_converter_deps", spy)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _convert(mod, tmp_path, converter)
+    assert "Architecture FooForCausalLM not supported" in str(excinfo.value)
+    assert calls["n"] == 0

--- a/tests/test_convert_to_gguf_self_heal.py
+++ b/tests/test_convert_to_gguf_self_heal.py
@@ -117,3 +117,79 @@ def test_genuine_model_error_not_repaired(tmp_path, monkeypatch):
         _convert(mod, tmp_path, converter)
     assert "Architecture FooForCausalLM not supported" in str(excinfo.value)
     assert calls["n"] == 0
+
+
+def test_single_retry_no_infinite_loop(tmp_path, monkeypatch):
+    # Reinstall "succeeds" but the converter stays broken: stop after one retry.
+    mod = _load_llama_cpp_module()
+    monkeypatch.chdir(tmp_path)
+    converter = _write_converter(tmp_path, '''
+        open("calls.txt", "a").write("x")
+        sys.stderr.write("ImportError: still broken\\n")
+        sys.exit(1)
+    ''')
+    calls = {"n": 0}
+    def spy(python_exe, print_output=False):
+        calls["n"] += 1
+        return types.SimpleNamespace(returncode=0, stdout="")
+    monkeypatch.setattr(mod, "_reinstall_converter_deps", spy)
+
+    with pytest.raises(RuntimeError):
+        _convert(mod, tmp_path, converter)
+    assert calls["n"] == 1
+    assert (tmp_path / "calls.txt").read_text() == "xx"  # original + one retry
+
+
+def test_reinstall_raises_is_caught(tmp_path, monkeypatch):
+    mod = _load_llama_cpp_module()
+    monkeypatch.chdir(tmp_path)
+    converter = _write_converter(tmp_path, 'sys.stderr.write("ImportError: x\\n"); sys.exit(1)\n')
+    def boom(python_exe, print_output=False):
+        raise RuntimeError("pip subprocess exploded")
+    monkeypatch.setattr(mod, "_reinstall_converter_deps", boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _convert(mod, tmp_path, converter)
+    assert "pip subprocess exploded" in str(excinfo.value)
+    assert "ImportError: x" in str(excinfo.value)
+
+
+def test_non_utf8_output_does_not_crash(tmp_path, monkeypatch):
+    # Non-UTF8 bytes on stderr must surface as RuntimeError, not UnicodeDecodeError.
+    mod = _load_llama_cpp_module()
+    monkeypatch.chdir(tmp_path)
+    converter = _write_converter(tmp_path, '''
+        os.write(2, bytes([0x81, 0xff, 0xfe]))
+        sys.stderr.flush()
+        sys.stderr.write("\\nNotImplementedError: weird bytes\\n")
+        sys.exit(1)
+    ''')
+    with pytest.raises(RuntimeError) as excinfo:
+        _convert(mod, tmp_path, converter)
+    assert "weird bytes" in str(excinfo.value)
+
+
+def test_reinstall_bootstraps_pip_via_ensurepip(monkeypatch):
+    # pip absent (eg uv venv): bootstrap via ensurepip, then the install retries.
+    mod = _load_llama_cpp_module()
+    calls = []
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        if "install" in cmd and sum(1 for c in calls if "install" in c) == 1:
+            return types.SimpleNamespace(returncode=1, stdout="No module named pip")
+        return types.SimpleNamespace(returncode=0, stdout="ok")
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    res = mod._reinstall_converter_deps("/fake/python")
+    assert res.returncode == 0
+    assert any("ensurepip" in c for c in calls)
+
+
+def test_reinstall_no_ensurepip_when_pip_present(monkeypatch):
+    mod = _load_llama_cpp_module()
+    calls = []
+    monkeypatch.setattr(mod.subprocess, "run",
+                        lambda cmd, **kw: calls.append(cmd) or types.SimpleNamespace(returncode=0, stdout="ok"))
+    res = mod._reinstall_converter_deps("/fake/python")
+    assert res.returncode == 0
+    assert not any("ensurepip" in c for c in calls)

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -1589,11 +1589,17 @@ def _reinstall_converter_deps(python_exe, print_output = False):
             f"Unsloth: The GGUF converter environment looks broken (stale/missing "
             f"package). Reinstalling {', '.join(_CONVERTER_PYTHON_DEPS)} and retrying..."
         )
-    command = [
-        python_exe, "-m", "pip", "install", "--upgrade", "--force-reinstall",
-        *_CONVERTER_PYTHON_DEPS,
-    ]
-    return subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    def _run(cmd):
+        return subprocess.run(cmd, encoding="utf-8", errors="replace",
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    install = [python_exe, "-m", "pip", "install", "--upgrade", "--force-reinstall",
+               *_CONVERTER_PYTHON_DEPS]
+    result = _run(install)
+    # Some envs (eg uv-created venvs) ship without pip; bootstrap it once.
+    if result.returncode != 0 and "no module named pip" in (result.stdout or "").lower():
+        _run([python_exe, "-m", "ensurepip", "--upgrade"])
+        result = _run(install)
+    return result
 
 
 def convert_to_gguf(
@@ -1734,13 +1740,16 @@ def convert_to_gguf(
         repair_note = ""
         while True:
             try:
+                # encoding/errors pinned so non-UTF8 output never crashes decoding.
                 if print_output:
-                    result = subprocess.run(command, shell=False, check=True, text=True,
+                    result = subprocess.run(command, shell=False, check=True,
+                                          encoding="utf-8", errors="replace",
                                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                     print(result.stdout)
                 else:
-                    # Capture as text so a failure surfaces the real traceback.
-                    subprocess.run(command, shell=False, check=True, text=True,
+                    # Capture so a failure surfaces the real traceback.
+                    subprocess.run(command, shell=False, check=True,
+                                   encoding="utf-8", errors="replace",
                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 break
             except subprocess.CalledProcessError as e:
@@ -1753,10 +1762,13 @@ def convert_to_gguf(
                 # interpreter) and retry once instead of failing.
                 if not attempted_repair and _looks_like_converter_dep_error(captured):
                     attempted_repair = True
-                    repair = _reinstall_converter_deps(command[0], print_output = print_output)
-                    if repair.returncode == 0:
-                        continue
-                    repair_note = f"\n--- dependency reinstall failed ---\n{(repair.stdout or '').strip()}"
+                    try:
+                        repair = _reinstall_converter_deps(command[0], print_output = print_output)
+                        if repair.returncode == 0:
+                            continue
+                        repair_note = f"\n--- dependency reinstall failed ---\n{(repair.stdout or '').strip()}"
+                    except Exception as repair_error:
+                        repair_note = f"\n--- dependency reinstall failed ---\n{repair_error}"
 
                 if print_output and getattr(e, 'stdout', None):
                     print(e.stdout)
@@ -1901,12 +1913,14 @@ def quantize_gguf(
 
     try:
         if print_output:
-            result = subprocess.run(command, shell=True, check=True, text=True,
+            result = subprocess.run(command, shell=True, check=True,
+                                  encoding="utf-8", errors="replace",
                                   stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             print(result.stdout)
         else:
-            # Capture as text so llama-quantize's output can be surfaced on failure.
-            subprocess.run(command, shell=True, check=True, text=True,
+            # Capture so llama-quantize's output can be surfaced on failure.
+            subprocess.run(command, shell=True, check=True,
+                           encoding="utf-8", errors="replace",
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     except subprocess.CalledProcessError as e:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -1559,6 +1559,43 @@ def check_max_shard_size(max_shard_size = "50GB"):
 pass
 
 
+# Deps the converter imports. Only installed in install_llama_cpp(), which is
+# skipped when llama.cpp already exists, so a stale `gguf` can fail with exit 1.
+_CONVERTER_PYTHON_DEPS = ("gguf", "protobuf", "sentencepiece", "mistral_common")
+
+# Markers that mean the converter env is broken, not the model. Only these
+# trigger auto-repair; genuine model errors are surfaced as-is.
+_CONVERTER_DEP_ERROR_MARKERS = (
+    "ModuleNotFoundError",
+    "No module named",
+    "ImportError",
+    "cannot import name",
+    "DLL load failed",      # common Windows broken-package symptom
+    "undefined symbol",
+)
+
+
+def _looks_like_converter_dep_error(text):
+    # All Unsloth Zoo code licensed under LGPLv3
+    if not text: return False
+    return any(marker in text for marker in _CONVERTER_DEP_ERROR_MARKERS)
+
+
+def _reinstall_converter_deps(python_exe, print_output = False):
+    # All Unsloth Zoo code licensed under LGPLv3
+    # Force-reinstall the converter deps into its own interpreter to self-heal.
+    if print_output:
+        print(
+            f"Unsloth: The GGUF converter environment looks broken (stale/missing "
+            f"package). Reinstalling {', '.join(_CONVERTER_PYTHON_DEPS)} and retrying..."
+        )
+    command = [
+        python_exe, "-m", "pip", "install", "--upgrade", "--force-reinstall",
+        *_CONVERTER_PYTHON_DEPS,
+    ]
+    return subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+
 def convert_to_gguf(
     model_name,
     input_folder,
@@ -1691,18 +1728,49 @@ def convert_to_gguf(
                 command.extend([str(key), str(value)])
         command.append(str(input_folder))
 
-        try:
-            if print_output:
-                result = subprocess.run(command, shell=False, check=True, text=True,
-                                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                print(result.stdout)
-            else:
-                subprocess.run(command, shell=False, check=True, capture_output=True)
-        except subprocess.CalledProcessError as e:
-            if print_output and hasattr(e, 'stdout') and e.stdout:
-                print(e.stdout)
-            cmd = " ".join(str(x) for x in command)
-            raise RuntimeError(f"Unsloth: Failed to convert {description} to GGUF with command `{cmd}`: {e}")
+        # Run the converter; self-heal and retry once if the env (not the model)
+        # is broken. No cost on the happy path.
+        attempted_repair = False
+        repair_note = ""
+        while True:
+            try:
+                if print_output:
+                    result = subprocess.run(command, shell=False, check=True, text=True,
+                                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    print(result.stdout)
+                else:
+                    # Capture as text so a failure surfaces the real traceback.
+                    subprocess.run(command, shell=False, check=True, text=True,
+                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                break
+            except subprocess.CalledProcessError as e:
+                captured = ""
+                for stream in (getattr(e, "stderr", None), getattr(e, "stdout", None)):
+                    if stream:
+                        captured += stream if isinstance(stream, str) else stream.decode("utf-8", errors="replace")
+
+                # Self-heal: reinstall the converter deps (command[0] = its
+                # interpreter) and retry once instead of failing.
+                if not attempted_repair and _looks_like_converter_dep_error(captured):
+                    attempted_repair = True
+                    repair = _reinstall_converter_deps(command[0], print_output = print_output)
+                    if repair.returncode == 0:
+                        continue
+                    repair_note = f"\n--- dependency reinstall failed ---\n{(repair.stdout or '').strip()}"
+
+                if print_output and getattr(e, 'stdout', None):
+                    print(e.stdout)
+                cmd = " ".join(str(x) for x in command)
+                # Surface the converter output, else the failure is just "exit
+                # status 1" with the real traceback discarded.
+                details = ""
+                for label, stream in (("stderr", getattr(e, "stderr", None)),
+                                      ("stdout", getattr(e, "stdout", None))):
+                    if not stream: continue
+                    text = stream if isinstance(stream, str) else stream.decode("utf-8", errors="replace")
+                    text = text.strip()
+                    if text: details += f"\n--- converter {label} ---\n{text}"
+                raise RuntimeError(f"Unsloth: Failed to convert {description} to GGUF with command `{cmd}`: {e}{details}{repair_note}")
 
         # Simple validation using native Python - check for main file or sharded files
         if os.path.exists(output_file):
@@ -1837,12 +1905,21 @@ def quantize_gguf(
                                   stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             print(result.stdout)
         else:
-            subprocess.run(command, shell=True, check=True, capture_output=True)
+            # Capture as text so llama-quantize's output can be surfaced on failure.
+            subprocess.run(command, shell=True, check=True, text=True,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     except subprocess.CalledProcessError as e:
         if print_output and hasattr(e, 'stdout') and e.stdout:
             print(e.stdout)
-        raise RuntimeError(f"Failed to quantize {input_gguf} to {_display_quant_type}: {e}")
+        details = ""
+        for label, stream in (("stderr", getattr(e, "stderr", None)),
+                              ("stdout", getattr(e, "stdout", None))):
+            if not stream: continue
+            text = stream if isinstance(stream, str) else stream.decode("utf-8", errors="replace")
+            text = text.strip()
+            if text: details += f"\n--- llama-quantize {label} ---\n{text}"
+        raise RuntimeError(f"Failed to quantize {input_gguf} to {_display_quant_type}: {e}{details}")
 
     # Verify output exists and get size using pathlib
     output_path = Path(output_gguf)


### PR DESCRIPTION
### Problem

GGUF export (including from Unsloth Studio) can fail with an undiagnosable error:

```
Unsloth: GGUF conversion failed: ... unsloth_convert_hf_to_gguf.py ...
Command '[...]' returned non-zero exit status 1.
```

The real cause is hidden. `convert_to_gguf` runs the converter with
`capture_output=True` and, when `print_output=False` (the default unless
`UNSLOTH_ENABLE_LOGGING=1`), re-raises only the `CalledProcessError` string, so
the converter's actual Python traceback is discarded.

### Root cause

The converter's Python deps (`gguf`, `protobuf`, `sentencepiece`,
`mistral_common`) are installed only inside `install_llama_cpp()`, which returns
early when llama.cpp already exists ("llama.cpp found in the system. Skipping
installation."). The convert script is re-downloaded from llama.cpp master each
run, so a stale or broken `gguf` drifts out of sync with it and the subprocess
exits 1. Users had to manually uninstall and reinstall to recover.

### Fix

`convert_to_gguf` now:

- Surfaces the converter's stderr/stdout on failure instead of an opaque exit
  status, so any failure is diagnosable.
- On an import/module error, reinstalls the converter deps into the converter's
  own interpreter and retries the conversion once, so a stale package self-heals
  with no user action.
- Leaves genuine model errors untouched (no spurious reinstall).

`quantize_gguf` gets the same stderr surfacing.

### Tests

Adds `tests/test_convert_to_gguf_self_heal.py` covering three paths:

- stale-package error self-heals and the retry succeeds
- reinstall failure surfaces the converter stderr plus a clear note
- a genuine model error is surfaced as-is with no reinstall attempted

```
tests/test_convert_to_gguf_self_heal.py ... 3 passed
tests/test_convert_hf_to_gguf_patcher.py ... 22 passed
```

No behavior change on the happy path; the repair only runs after a failure that
looks like a broken environment.
