### PR TITLE
Fix Gemma3 full finetuning on float32 weights (no-bf16 GPUs)

### DIFF
--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -449,6 +449,45 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma3MLP)
 
 
+def patch_Gemma3MultiModalProjector():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "0": return
+    try:
+        import transformers.models.gemma3.modeling_gemma3
+        transformers.models.gemma3.modeling_gemma3.Gemma3MultiModalProjector
+    except Exception as e:
+        return raise_error("Gemma3MultiModalProjector.forward", e)
+
+    def forward(self, vision_outputs: torch.Tensor):
+        batch_size, _, seq_length = vision_outputs.shape
+
+        reshaped_vision_outputs = vision_outputs.transpose(1, 2)
+        reshaped_vision_outputs = reshaped_vision_outputs.reshape(
+            batch_size, seq_length, self.patches_per_image, self.patches_per_image
+        )
+        reshaped_vision_outputs = reshaped_vision_outputs.contiguous()
+
+        pooled_vision_outputs = self.avg_pool(reshaped_vision_outputs)
+        pooled_vision_outputs = pooled_vision_outputs.flatten(2)
+        pooled_vision_outputs = pooled_vision_outputs.transpose(1, 2)
+
+        # mm_soft_emb_norm is a Gemma3RMSNorm, so under FORCE_FLOAT32 it can emit a float32
+        # activation (when its weight is upcast for stability) while mm_input_projection_weight
+        # stays a low-precision dtype -> "mat1 and mat2 must have the same dtype: float != Half"
+        # in the matmul below. Narrow the normed output to the projection weight's boundary
+        # dtype, exactly like the MLP/attention Linear boundaries: fp16 weights -> fp16 (with
+        # the overflow clamp, bit-identical to stock), fp32 weights (full finetuning) -> fp32.
+        normed_vision_outputs = self.mm_soft_emb_norm(pooled_vision_outputs)
+        boundary_dtype = _module_compute_dtype(self, "mm_input_projection_weight")
+        normed_vision_outputs = _narrow_to_boundary(normed_vision_outputs.to(torch.float32), boundary_dtype)
+
+        projected_vision_outputs = torch.matmul(normed_vision_outputs, self.mm_input_projection_weight)
+        return projected_vision_outputs.type_as(vision_outputs)
+    pass
+    patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3MultiModalProjector, "forward", forward, fullgraph = False)
+pass
+TEMPORARY_PATCHES.append(patch_Gemma3MultiModalProjector)
+
+
 def patch_Gemma3Attention():
     if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "0": return
     try:

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -74,10 +74,11 @@ def _module_compute_dtype(module, *attr_names):
 def _narrow_to_boundary(x_fp32, dtype):
     """Cast a float32 tensor to ``dtype`` for a Linear boundary.
 
-    For float16 we preserve the original overflow-safety clamp + downcast so the
-    fp16 path stays numerically identical to the unfixed forced patches. For
-    float32 this is a no-op (no narrowing happens). bfloat16 is clamped to its
-    own (very wide) range, which never actually clips, then downcast.
+    For float16 we clamp to the fp16 range then downcast, matching what the
+    RMSNorm patch already did. For in-range activations this equals the original
+    bare ``.to(float16)`` at the MLP/attention boundaries; for activations above
+    the fp16 max it clamps instead of overflowing to inf (strictly safer). For
+    float32 this is a no-op. bfloat16 clamps to its own (very wide) range first.
     """
     if dtype == torch.float32:
         return x_fp32
@@ -435,8 +436,9 @@ def patch_Gemma3MLP():
         activated_fp32 = self.act_fn(gate_proj_fp32) # Activation in fp32
         intermediate_fp32 = activated_fp32 * up_proj_fp32 # Product in fp32
 
-        # Narrow to the down_proj weight dtype before the down_proj matmul:
-        # fp16 weights -> fp16 (clamped, bit-identical to before); fp32 -> stays fp32.
+        # Narrow to the down_proj weight dtype: fp16 weights -> fp16 (now clamped to
+        # fp16 range like RMSNorm, vs the old bare cast; equal for in-range values,
+        # safer otherwise); fp32 weights (full finetuning) -> stays fp32.
         boundary_dtype = _module_compute_dtype(self, "down_proj", "gate_proj", "up_proj")
         intermediate = _narrow_to_boundary(intermediate_fp32, boundary_dtype)
         down_proj_out = self.down_proj(intermediate)
@@ -648,9 +650,10 @@ def patch_Gemma3Attention():
         # Using -1 for the last dimension is robust and aligns with your original example.
         attn_output_fp32 = attn_output_fp32.reshape(bsz, q_len, -1) # REVISED FIX
 
-        # Narrow to the o_proj weight dtype: fp16 weights -> fp16 (clamped,
-        # bit-identical to before); fp32 weights (full finetuning) -> stays fp32
-        # so o_proj is float32 x float32 instead of crashing on Half != float.
+        # Narrow to the o_proj weight dtype: fp16 weights -> fp16 (now clamped to
+        # fp16 range like RMSNorm, vs the old bare cast; equal for in-range values,
+        # safer otherwise); fp32 weights (full finetuning) -> stays fp32 so o_proj
+        # is float32 x float32 instead of crashing on Half != float.
         boundary_dtype = _module_compute_dtype(self, "o_proj", "q_proj", "k_proj", "v_proj")
         attn_output_narrowed = _narrow_to_boundary(attn_output_fp32, boundary_dtype)
 

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -40,6 +40,56 @@ import inspect
 _UNSLOTH_FLEX_ATTENTION_DISABLED = os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0"
 
 
+def _module_compute_dtype(module, *attr_names):
+    """Derive the low-precision *boundary* dtype for a forced-float32 Gemma3 patch
+    from the module's own (trainable) weights instead of hard-coding float16.
+
+    The FORCE_FLOAT32 patches run heavy reductions (RMSNorm variance, SwiGLU,
+    attention) in float32 for fp16 overflow-safety, then narrow back to a
+    low-precision dtype at each Linear/projection boundary. That boundary dtype
+    must match the dtype of the weights actually multiplying the activations:
+
+      * LoRA (FORCE_FLOAT32): base proj weights stay float16  -> boundary float16
+        (identical to the original hard-coded behaviour, incl. the fp16 clamp).
+      * Full finetuning      : trainable weights upcast to float32 -> boundary
+        float32, so a float32 activation meets a float32 weight (no Half != float).
+      * bfloat16 weights     : boundary bfloat16 (clamp is a no-op at bf16 range).
+
+    We look at the first attribute that is a tensor / has a floating ``.dtype``.
+    If none is found (should not happen for these modules) we fall back to
+    float16 so behaviour is unchanged from before this patch.
+    """
+    for name in attr_names:
+        obj = getattr(module, name, None)
+        if obj is None:
+            continue
+        # nn.Linear (q_proj, gate_proj, ...) -> .weight ; or a raw Parameter (RMSNorm.weight)
+        weight = getattr(obj, "weight", obj)
+        dtype = getattr(weight, "dtype", None)
+        if dtype is not None and dtype.is_floating_point:
+            return dtype
+    return torch.float16
+
+
+def _narrow_to_boundary(x_fp32, dtype):
+    """Cast a float32 tensor to ``dtype`` for a Linear boundary.
+
+    For float16 we preserve the original overflow-safety clamp + downcast so the
+    fp16 path stays numerically identical to the unfixed forced patches. For
+    float32 this is a no-op (no narrowing happens). bfloat16 is clamped to its
+    own (very wide) range, which never actually clips, then downcast.
+    """
+    if dtype == torch.float32:
+        return x_fp32
+    if dtype == torch.float16:
+        fp16_max = torch.finfo(torch.float16).max
+        fp16_min = torch.finfo(torch.float16).min
+        return torch.clamp(x_fp32, min = fp16_min, max = fp16_max).to(torch.float16)
+    # bfloat16 (or any other low-precision float): clamp to its own range then cast.
+    finfo = torch.finfo(dtype)
+    return torch.clamp(x_fp32, min = finfo.min, max = finfo.max).to(dtype)
+
+
 def _prepare_gemma3_sdpa_attention_mask(attention_mask, query_states, key_states, sliding_window=None):
     if attention_mask is None or attention_mask.dim() != 2:
         return attention_mask
@@ -351,16 +401,16 @@ def patch_Gemma3RMSNorm():
         variance = x_fp32.pow(2).mean(-1, keepdim=True)
         hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + self.eps)
 
-        # self.weight is bf16 (from vision.py loading if UNSLOTH_FORCE_FLOAT32="1")
-        # So, cast self.weight to fp32 for the (1.0 + weight) operation
+        # self.weight is fp16 for LoRA (FORCE_FLOAT32) and fp32 once full finetuning
+        # upcasts the trainable params. Cast it to fp32 for the (1.0 + weight) math.
         output_fp32 = hidden_states_fp32 * (1.0 + self.weight.to(torch.float32))
 
-        # Clamp to fp16 range before casting back to fp16
-        fp16_max = torch.finfo(torch.float16).max
-        fp16_min = torch.finfo(torch.float16).min
-        clamped_output_fp32 = torch.clamp(output_fp32, min=fp16_min, max=fp16_max)
-
-        return clamped_output_fp32.to(torch.float16) # Output fp16
+        # Narrow to the boundary dtype of the downstream Linear, derived from this
+        # norm's own (trainable) weight: fp16 weights -> fp16 output with the
+        # original overflow clamp (bit-identical to before); fp32 weights ->
+        # fp32 output so the next projection matmul is float32 x float32.
+        boundary_dtype = _module_compute_dtype(self, "weight")
+        return _narrow_to_boundary(output_fp32, boundary_dtype)
     pass
     patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3RMSNorm, "forward", forward, fullgraph = True)
 pass
@@ -375,7 +425,7 @@ def patch_Gemma3MLP():
     except Exception as e:
         return raise_error("Gemma3MLP.forward", e)
 
-    def forward(self, x): # x is fp16 from RMSNorm
+    def forward(self, x): # x matches proj weight dtype (fp16 LoRA / fp32 full-FT)
         gate_proj_out = self.gate_proj(x)
         up_proj_out = self.up_proj(x)
 
@@ -385,9 +435,11 @@ def patch_Gemma3MLP():
         activated_fp32 = self.act_fn(gate_proj_fp32) # Activation in fp32
         intermediate_fp32 = activated_fp32 * up_proj_fp32 # Product in fp32
 
-        # Downcast and down_proj
-        intermediate_fp16 = intermediate_fp32.to(torch.float16)
-        down_proj_out = self.down_proj(intermediate_fp16)
+        # Narrow to the down_proj weight dtype before the down_proj matmul:
+        # fp16 weights -> fp16 (clamped, bit-identical to before); fp32 -> stays fp32.
+        boundary_dtype = _module_compute_dtype(self, "down_proj", "gate_proj", "up_proj")
+        intermediate = _narrow_to_boundary(intermediate_fp32, boundary_dtype)
+        down_proj_out = self.down_proj(intermediate)
         return down_proj_out
     pass
     patch_function(transformers.models.gemma3.modeling_gemma3.Gemma3MLP, "forward", forward, fullgraph = False)
@@ -596,10 +648,14 @@ def patch_Gemma3Attention():
         # Using -1 for the last dimension is robust and aligns with your original example.
         attn_output_fp32 = attn_output_fp32.reshape(bsz, q_len, -1) # REVISED FIX
 
-        attn_output_fp16 = attn_output_fp32.to(torch.float16)
+        # Narrow to the o_proj weight dtype: fp16 weights -> fp16 (clamped,
+        # bit-identical to before); fp32 weights (full finetuning) -> stays fp32
+        # so o_proj is float32 x float32 instead of crashing on Half != float.
+        boundary_dtype = _module_compute_dtype(self, "o_proj", "q_proj", "k_proj", "v_proj")
+        attn_output_narrowed = _narrow_to_boundary(attn_output_fp32, boundary_dtype)
 
-        # 8. Output Projection (o_proj) in fp16
-        attn_output_projected = self.o_proj(attn_output_fp16) # fp16 output
+        # 8. Output Projection (o_proj)
+        attn_output_projected = self.o_proj(attn_output_narrowed)
 
         return attn_output_projected, attn_weights # 3-tuple return
     pass


### PR DESCRIPTION
## Summary

Full finetuning of the Gemma3 family on a GPU without bfloat16 (V100, T4) crashed with `RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::Half != float`.

The `UNSLOTH_FORCE_FLOAT32` patches for Gemma3 (`patch_Gemma3RMSNorm`, `patch_Gemma3MLP`, `patch_Gemma3Attention`) run the heavy reductions in float32 for fp16 overflow safety, then narrow back to float16 at every Linear boundary. That hard-coded float16 assumes the projection weights are float16, which holds for LoRA / QLoRA (base weights stay fp16). Full finetuning upcasts the trainable weights to float32, so a float16 activation then meets a float32 weight and the matmul fails.

## Root cause

In `unsloth_zoo/temporary_patches/gemma.py`, the forced patches always did `.to(torch.float16)` (plus the fp16 overflow clamp) at the RMSNorm output, the MLP `down_proj` input, and the attention `o_proj` input. The boundary dtype was fixed at float16 regardless of the actual weight dtype.

## Changes

All in `unsloth_zoo/temporary_patches/gemma.py`. The boundary dtype is now derived from the module's own weights instead of being hard-coded:

- Added `_module_compute_dtype(module, *attrs)`: returns the dtype of the first floating weight found (e.g. `down_proj.weight`), so the narrow target follows the real weights.
- Added `_narrow_to_boundary(x_fp32, dtype)`: float16 keeps the original clamp + downcast (bit-identical to before), float32 is a no-op (stays float32), bfloat16 clamps to its own range then casts.
- `patch_Gemma3RMSNorm`, `patch_Gemma3MLP`, `patch_Gemma3Attention`: the final `.to(torch.float16)` becomes `_narrow_to_boundary(..., _module_compute_dtype(self, ...))`.

The non-forced `*_generic` patches are untouched. All heavy reductions still run in float32 in both regimes, so the fp16 overflow safety is preserved.

## Behavior

- LoRA / QLoRA (fp16 weights): bit-identical to before. The fp16 clamp and downcast are unchanged, so there is no numerical change on the common path.
- Full finetuning (float32 weights): the whole Gemma3 block runs in float32, so there is no Half vs float mismatch. This is the correct pure float32 behavior for a model that cannot use float16.
- bfloat16 GPUs, AMD, Intel and MLX are unaffected: those use the untouched generic patches, and the fix uses only `tensor.to(dtype)` and `weight.dtype`, with no device specific calls.

## Validation

The crash reproduces on a Tesla T4 (sm_75, no bf16) and on a B200 (forcing `dtype=float16` to enter the `UNSLOTH_FORCE_FLOAT32` path with full finetuning), and the fix resolves it. Using the real transformers Gemma3 RMSNorm, MLP and attention modules with the patches applied:

- RMSNorm fp16 output is bit-identical to before (it always clamped). The MLP down_proj and attention o_proj boundaries now clamp to the fp16 range too (matching RMSNorm) rather than a bare downcast: identical to the old output for in-range activations, and clamped instead of overflowing to inf otherwise, which is strictly safer. LoRA and QLoRA losses match the old path to about four significant figures.
- float32 path matches a clean unpatched transformers float32 reference (max abs diff 0), with finite gradients.
- torch.compile enabled smoke test passes for both regimes (the boundary dtype is a per instance constant, so no graph break).
- Validated on a real Tesla T4 (sm_75, no bf16) together with unslothai/unsloth#5880: gemma3 full finetuning that crashed before now trains to a finite loss with 40 step stability (loss trends down), and LoRA / QLoRA still train with unchanged precision flags.

Only Gemma3 / Gemma3 text carry this hard-coded float16 assumption. gemma3n, gpt_oss and qwen3_5 already derive their boundary dtype from the running tensors, so they do not crash and need no change.

## Related

This is the downstream half of the V100 / no-bf16 full finetuning fix in unslothai/unsloth#5880, which corrects the trainer precision selection so the model reaches a clean float32 forward. With both, the Gemma3 family can be full finetuned on no-bf16 GPUs. The non-forced Gemma3 MLP `compute_dtype` handling in #462 is complementary and independent of this forced-path fix.
