### PR TITLE
Fix GRPO full finetuning KV cache dtype mismatch on no-bf16 GPUs

### DIFF
--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 import inspect
 import importlib
+import functools
 from collections.abc import Mapping
 from typing import Any, List, Optional, Tuple, Union, Dict, Set, Callable
 from .common import TEMPORARY_PATCHES, torch_compile, _torch_compile
@@ -1684,3 +1685,46 @@ def patch_qwen2vl_image_processor_pixel_attrs():
         pass
 pass
 TEMPORARY_PATCHES.append(patch_qwen2vl_image_processor_pixel_attrs)
+
+
+def patch_kv_cache_compute_dtype():
+    # Full finetuning upcasts the trainable weights to float32, but the rollout used
+    # by GRPO (and eval generation) runs under a bf16/fp16 autocast. apply_rotary_pos_emb
+    # rotates the keys through the float32 cos/sin buffers, so the key reaching the cache
+    # is float32 while the value (no RoPE) stays the compute dtype. transformers sizes the
+    # cache buffer from the first key written (float32), then the value write mismatches:
+    #   cache_utils.py  self.values.index_copy_(...)  ->  self Float vs source BFloat16
+    # Align the key and value at the cache write: the first write follows the value
+    # (compute) dtype, so the rollout cache is allocated in fp16/bf16 (fast, half the KV
+    # memory), and later writes follow the existing cache dtype, so they can never disagree.
+    # A no-op when the key and value already match (LoRA, QLoRA, plain float32 inference).
+    try:
+        import transformers.cache_utils as cache_utils
+        base = cache_utils.CacheLayerMixin
+    except Exception as e:
+        return raise_error("transformers.cache_utils.CacheLayerMixin", e)
+
+    def make_dtype_safe_update(original_update):
+        if getattr(original_update, "_unsloth_dtype_safe", False):
+            return original_update
+        @functools.wraps(original_update)
+        def update(self, key_states, value_states, cache_kwargs = None):
+            cache_dtype = getattr(self, "dtype", None)
+            if getattr(self, "is_initialized", False) and cache_dtype is not None:
+                if key_states.dtype   != cache_dtype: key_states   = key_states.to(cache_dtype)
+                if value_states.dtype != cache_dtype: value_states = value_states.to(cache_dtype)
+            elif key_states.dtype != value_states.dtype:
+                # First write: the un-rotated value carries the true compute dtype.
+                key_states = key_states.to(value_states.dtype)
+            return original_update(self, key_states, value_states, cache_kwargs)
+        update._unsloth_dtype_safe = True
+        return update
+
+    for cls in list(vars(cache_utils).values()):
+        if not (isinstance(cls, type) and issubclass(cls, base) and cls is not base):
+            continue
+        original_update = cls.__dict__.get("update", None)
+        if original_update is None: continue
+        cls.update = make_dtype_safe_update(original_update)
+pass
+TEMPORARY_PATCHES.append(patch_kv_cache_compute_dtype)


### PR DESCRIPTION
## Summary

GRPO full finetuning crashes during the generation rollout with `RuntimeError: index_copy_(): self and source expected to have the same dtype, but got (self) Float and (source) BFloat16` (or `Half` on a no-bf16 GPU). This blocks GRPO full finetuning on V100 / T4 and on any setup that runs the rollout under a low precision autocast.

## Root cause

Full finetuning upcasts the trainable weights to float32, so `model.dtype` is float32. The GRPO rollout runs `generate()` under the trainer's bf16/fp16 autocast. Inside attention, `apply_rotary_pos_emb` rotates the keys through the float32 `cos/sin` buffers, so the key reaching the cache is float32, while the value has no RoPE and stays the compute dtype (bf16/fp16).

`transformers/cache_utils.py` sizes the cache buffer lazily from the first key written (float32). The following value write then mismatches:

```
cache_utils.py  self.values.index_copy_(2, cache_position, value_states)
RuntimeError: index_copy_(): self and source expected to have the same dtype,
              but got (self) Float and (source) BFloat16
```

This is full finetuning specific: LoRA and QLoRA keep fp16/bf16 weights, so the keys and values agree and never diverge. It is also independent of `config.torch_dtype`: the buffer dtype comes from the runtime key dtype, not from the config, so changing `config.torch_dtype` does not address it.

## Fix

A new temporary patch (`patch_kv_cache_compute_dtype` in `unsloth_zoo/temporary_patches/misc.py`) aligns the key and value dtype at the cache write for every `CacheLayerMixin` subclass:

- First write: cast the key to the value (compute) dtype, so the rollout cache is allocated in fp16/bf16 (fast, half the KV memory).
- Later writes: cast both to the existing cache dtype, so they can never disagree.
- No-op when the key and value already match.

The value carries the true compute dtype because it is the un-rotated projection. This covers both the static cache (used by the vision fast generate path) and the dynamic cache (used by the llama fast generate path).

## Behavior

- Full finetuning rollout: the `index_copy_` crash is gone and the cache is allocated in the compute dtype (bf16/fp16) instead of float32, which is faster and uses half the KV memory.
- LoRA / QLoRA: no change. The keys and values already match, so the patch is a no-op and training is unaffected.
- Plain `model.generate()` for a full finetuned model (the float32 autocast inference path): the keys and values are both float32, so the patch is a no-op and the existing behavior is preserved.

## Validation

On `unsloth/Qwen2.5-0.5B-Instruct`, eager:

- Full finetuning GRPO, before: `index_copy_(): self Float vs source BFloat16`.
- Full finetuning GRPO, after: rollout first write `k_in=float32 v_in=bfloat16 -> cache buffer=bfloat16` for both the static and dynamic cache layers; the `index_copy_` crash is gone and the rollout completes.
- LoRA GRPO: trains to a finite loss, identical with and without the patch (the patch never fires).
- Plain `model.generate()` full finetuned: keys and values both float32, patch is a no-op, generation succeeds.

## Related

- Complements unslothai/unsloth#5880 (trainer precision selection for no-bf16 GPUs), which lets the no-bf16 full finetuning path reach the rollout in the first place.
- Orthogonal to the `config.torch_dtype` handling in PR #424; this fix does not require changing it.

## Note on a separate issue

After this fix, full finetuning GRPO reaches a distinct, pre-existing failure in the chunked selective log-softmax path (`chunk_hidden_states.to(lm_head.dtype) @ lm_head.t()`), where already projected logits are fed back through `lm_head` (a shape mismatch under eager, a Dynamo "same reduction dim" error under compile). That is unrelated to the KV cache dtype and is tracked separately.
