### PR TITLE
Guard chunked log-softmax against receiving logits in GRPO

### DIFF
--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -88,10 +88,19 @@ def chunked_hidden_states_selective_log_softmax(
     chunked_hidden_states = torch.chunk(flat_hidden_states, chunks=chunks, dim=0)
     chunked_index = torch.chunk(flat_index, chunks=chunks, dim=0)
 
+    # If UNSLOTH_RETURN_HIDDEN_STATES could not be honored (e.g. a full finetuning forward that
+    # returns logits), the incoming tensor is already logits, not hidden states. Detect that
+    # (last dim == vocab) and skip the lm_head projection; logits are exactly
+    # hidden_states @ lm_head.t(), so using them directly is equivalent. No-op for hidden states.
+    already_logits = hidden_states.shape[-1] == lm_head.shape[0]
+
     all_per_token_logps = []
 
     for chunk_hidden_states, chunk_index in zip(chunked_hidden_states, chunked_index):
-        chunk_logits = chunk_hidden_states.to(lm_head.dtype) @ lm_head.t()
+        if already_logits:
+            chunk_logits = chunk_hidden_states
+        else:
+            chunk_logits = chunk_hidden_states.to(lm_head.dtype) @ lm_head.t()
 
         if logit_scale_multiply != 0.0:
             chunk_logits = chunk_logits * logit_scale_multiply


### PR DESCRIPTION
## Summary

Defensive guard for unslothai/unsloth-zoo#708. If a forward returns logits instead of hidden states (for example full finetuning, where `UNSLOTH_RETURN_HIDDEN_STATES` could not be honored), `chunked_hidden_states_selective_log_softmax` projected already projected logits through `lm_head` again and crashed:

```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (Nx151936 and 896x151936)
```

## Change (`unsloth_zoo/rl_replacements.py`)

In `chunked_hidden_states_selective_log_softmax`, detect when the incoming tensor's last dim already equals the vocab size (`lm_head.shape[0]`), i.e. it is already logits, and skip the `lm_head` projection. Logits are exactly `hidden_states @ lm_head.t()`, so using them directly is numerically equivalent. It is a no-op for genuine hidden states (last dim is the hidden size), so LoRA / QLoRA are unchanged.

## Behavior

- A forward that returns logits no longer crashes the log-prob step; the logits are used directly.
- Genuine hidden states take the normal projection path, so there is no change for LoRA / QLoRA or any model that honors `UNSLOTH_RETURN_HIDDEN_STATES`.
- The added branch is on a static shape, so it does not break `torch.compile` (validated: full finetuning and LoRA both compile with zero recompiles).

## Validation

On `unsloth/Qwen2.5-0.5B-Instruct` (with unsloth-zoo#707 applied so the rollout reaches the log-prob step):

| Mode | Compile | Before | After |
|------|---------|--------|-------|
| full finetuning | eager | crash `(4x151936 and 896x151936)` | trains, finite loss |
| full finetuning | compiled | crash | trains, 0 recompiles |
| LoRA | eager | trains | trains, identical (no-op) |
| QLoRA | eager | trains | trains |

## Related

This is the consumer-side guard. The upstream cause (full finetuning forward returning logits) is fixed in unslothai/unsloth, which makes the forward return hidden states again so the chunked path stays memory efficient. This guard is complementary insurance against any model whose forward returns logits, and is independent of that fix.
