### PR TITLE
fix: replace exec/eval with importlib in patch_compiling_bitsandbytes

### DIFF
--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -48,16 +48,18 @@ def patch_compiling_bitsandbytes():
         for x in ["bitsandbytes.nn.modules", "peft.tuners.lora.bnb",]:
             try:
                 module = importlib.import_module(x)
-            except ImportError:
-                # peft is required for LoRA training; give a helpful message
+            except ImportError as e:
+                # peft is required for LoRA training
                 if x.startswith("peft"):
                     raise ImportError(
                         "Unsloth: Please install peft via `pip install peft`"
-                    )
+                    ) from e
+                if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
+                    print(f"Unsloth: Skipping {x} - import failed: {e}")
                 continue
             for fx in dir(module):
                 try: layer = getattr(module, fx)
-                except: continue
+                except Exception: continue
                 if not hasattr(layer, "forward"): continue
                 if hasattr(layer.forward, "__wrapped__"): continue
                 layer.forward = torch._disable_dynamo(layer.forward)

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -18,6 +18,7 @@ import torch
 import os
 import re
 import ast
+import importlib
 
 __all__ = [
     "patch_compiling_bitsandbytes",
@@ -45,14 +46,21 @@ def patch_compiling_bitsandbytes():
         if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
             print("Unsloth: Bitsandbytes < 0.46.0 does not support torch.compile - disabling.")
         for x in ["bitsandbytes.nn.modules", "peft.tuners.lora.bnb",]:
-            exec(f"import {x}", globals(), locals())
-            layers = dir(eval(x))
-            for fx in layers:
-                try: layer = eval(f"{x}.{fx}")
+            try:
+                module = importlib.import_module(x)
+            except ImportError:
+                # peft is required for LoRA training; give a helpful message
+                if x.startswith("peft"):
+                    raise ImportError(
+                        "Unsloth: Please install peft via `pip install peft`"
+                    )
+                continue
+            for fx in dir(module):
+                try: layer = getattr(module, fx)
                 except: continue
                 if not hasattr(layer, "forward"): continue
-                if hasattr(eval(f"{x}.{fx}.forward"), "__wrapped__"): continue
-                exec(f"{x}.{fx}.forward = torch._disable_dynamo({x}.{fx}.forward)", globals(), locals())
+                if hasattr(layer.forward, "__wrapped__"): continue
+                layer.forward = torch._disable_dynamo(layer.forward)
             pass
         pass
     pass


### PR DESCRIPTION
Fixes #311

### Problem

`patch_compiling_bitsandbytes()` iterated over the dotted module strings `["bitsandbytes.nn.modules", "peft.tuners.lora.bnb"]` and used:

```python
exec(f"import {x}", globals(), locals())
layers = dir(eval(x))
```

to pull the module out and walk its attributes. Two problems:

1. `exec("import a.b.c", globals, locals)` does **not** reliably bind the top-level name `a` into the supplied namespaces; the subsequent `eval("a.b.c")` then raises `NameError: name 'a' is not defined`. This is the failure reported in #311 ("peft not defined") and is consistent with CPython's documented behaviour around `exec` with explicit `globals`/`locals` mappings.
2. If `peft` isn't installed, the user just sees a bare `ImportError` from inside an Unsloth internal patch with no hint that they need to `pip install peft`.

### Fix

Replace the `exec` / `eval` dance with `importlib.import_module(x)` + `getattr(module, fx)` — the standard, well-defined way to import a module by string name and walk its attributes. Wrap it in `try/except ImportError` so:

- if `bitsandbytes.nn.modules` somehow isn't importable, we just `continue`;
- if `peft.tuners.lora.bnb` is missing, we re-raise with a clear `ImportError("Unsloth: Please install peft via 'pip install peft'")`.

No behaviour change in the happy path (still calls `torch._disable_dynamo` on every `forward` that isn't already wrapped), but the unhappy paths no longer crash mysteriously.

### Notes

- Only touches the `< 0.46.0` branch; the `>= 0.46.0` branch is unchanged.
- Added `import importlib` at the top of the file.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>