### PR TITLE
fix(peft): allow embedding models to train with gradient checkpointing

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -215,13 +215,19 @@ def requires_grad_for_gradient_checkpointing(model):
         if type_output is torch.Tensor:
             output.requires_grad_(True)
         else:
-            try: # For dataclass from HF, try on loss or logits 
+            try: # For dataclass from HF, try on loss or logits
                 if hasattr(output, "loss") and output.loss is not None:
                     output.loss.requires_grad_(True)
-                elif hasattr(output, "logits") and output.logits is not None: #with RL like GRPO there are no loss as you don't provide labels 
+                elif hasattr(output, "logits") and output.logits is not None: #with RL like GRPO there are no loss as you don't provide labels
                     output.logits.requires_grad_(True)
+                elif hasattr(output, "last_hidden_state") and output.last_hidden_state is not None:
+                    # Encoder / decoder-style embedding backbones (e.g. Qwen3-Embedding) return a
+                    # BaseModelOutputWithPast with only last_hidden_state (no loss/logits) when called
+                    # for sentence embeddings. Make it require grad so gradient checkpointing works.
+                    # See https://github.com/unslothai/unsloth/issues/5360
+                    output.last_hidden_state.requires_grad_(True)
                 else:
-                    raise ValueError("Neither loss nor logits are available for grad post hook.")
+                    raise ValueError("Neither loss, logits, nor last_hidden_state are available for grad post hook.")
             except Exception as e:
                 raise RuntimeError(f"Unsloth: Failed to make output require gradients: {e}")
     pass


### PR DESCRIPTION
  ## Summary

  Decoder/encoder-style embedding models (Qwen3-Embedding 0.6B/4B/8B, and similar)
  crash on the first training step when fine-tuned with LoRA +
  `use_gradient_checkpointing="unsloth"`. This adds a `last_hidden_state` branch to
  `requires_grad_post_hook` so those models train instead of raising.

  ## Motivation

  Fixes unslothai/unsloth#5360. Training a Qwen3-Embedding model with
  `MultipleNegativesRankingLoss` fails on step 1:

  ```
  RuntimeError: Unsloth: Failed to make output require gradients:
  Neither loss nor logits are available for grad post hook.
  ```

  The bug is gated to transformers v5. On v4 it trains fine, which is why it was
  hard to reproduce.

  Root cause: `collect_hook_targets()` localizes the decoder layer stack by reading
  `inspect.getsource(module.forward)` and string-matching `for ... in self.layers:`.
  In transformers v5, `Qwen3Model.forward` is wrapped in decorators
  (`@capture_outputs`, `@auto_docstring`, ...), so `getsource` returns the wrapper
  and the match fails. Every candidate module then falls into `fallback_targets`,
  where `requires_grad_post_hook` is installed on the module output. For an
  embedding backbone that output is a `BaseModelOutputWithPast` with only
  `last_hidden_state` (no `loss`, no `logits`), so the hook hit the `else: raise`.

  ## Changes

  - `unsloth_zoo/peft_utils.py`: add an `elif` for `last_hidden_state` in
    `requires_grad_post_hook`, calling `output.last_hidden_state.requires_grad_(True)`,
    mirroring the existing `loss` and `logits` branches. Update the fallback raise
    message to list all three checked attributes.

  The change is additive. It only runs on the path that previously raised (output
  with no `loss` and no `logits`), so it cannot alter behavior for any model that
  already trained.

  ## How to test

  On transformers v5 (the broken stack), with a small embedding model:

  ```python
  # pip install "transformers>=5.5" "sentence-transformers>=5.5"
  from unsloth import FastSentenceTransformer
  from sentence_transformers import SentenceTransformerTrainer, losses
  from sentence_transformers.training_args import SentenceTransformerTrainingArguments, BatchSamplers
  from datasets import Dataset

  model = FastSentenceTransformer.from_pretrained("unsloth/Qwen3-Embedding-0.6B", max_seq_length=512)
  model = FastSentenceTransformer.get_peft_model(
      model, r=16, target_modules=["q_proj","k_proj","v_proj","o_proj"],
      lora_alpha=32, lora_dropout=0.05, bias="none",
      use_gradient_checkpointing="unsloth", task_type="FEATURE_EXTRACTION",
  )
  data = Dataset.from_list([{"anchor": f"a{i}", "positive": f"p{i}", "negative": f"n{i}"} for i in range(64)])
  SentenceTransformerTrainer(
      model=model, train_dataset=data, loss=losses.MultipleNegativesRankingLoss(model),
      args=SentenceTransformerTrainingArguments(
          output_dir="out", max_steps=2, per_device_train_batch_size=2,
          gradient_accumulation_steps=2, report_to="none",
          batch_sampler=BatchSamplers.NO_DUPLICATES,
      ),
  ).train()
  ```

  Before: raises on step 1. After: completes, loss decreases (1.34 -> 1.00 in a
  2-step run on Colab, transformers 5.5.0 / sentence-transformers 5.5.0 /
  Qwen3-Embedding-0.6B). Verified grads reach `layers.0.self_attn.q_proj.lora_B`,
  so gradient flow is end-to-end, not just error suppression.

  ## Notes for reviewers

  - The hook is a grad trigger, not a connector. When LoRA params feed the
    backbone, `last_hidden_state` already requires grad and the call is a no-op.
    When the graph is genuinely disconnected, the gradient-checkpointing
    autograd function raises rather than training with zero grads. So the branch
    can only turn a former crash into correct training; it cannot silently
    produce wrong gradients.
  - This fixes the fallback hook, not the routing. The deeper issue is that
    `collect_hook_targets` can't see through transformers-v5 forward decorators,
    so all v5 backbones now ride the fallback post-hook path. A routing fix
    (`inspect.unwrap` before `getsource`, or detecting the layer stack via
    `nn.ModuleList`) changes hook placement for every v5 model and wants its own
    regression-gated PR, so it is intentionally out of scope here.
  - The `loss`/`logits`/`last_hidden_state` branches don't guard
    `torch.is_floating_point` the way `requires_grad_pre_hook` does. A non-float
    output would raise (caught by the existing `except`). No backbone in scope
    emits a non-float `last_hidden_state`; flagging as a pre-existing nit.
  - The fix lives in `unsloth_zoo`; the issue is filed against `unsloth`. `unsloth`
    pins `unsloth_zoo>=2026.4.8` (floor only), so that floor should be bumped to
    the release carrying this fix, otherwise users won't pick it up.

  ## Related

  Fixes unslothai/unsloth#5360