### PR TITLE
fix: set _unsloth_grouped_mm_format on stock transformers GptOssExperts so MoE LoRA grouped_mm works

### DIFF
--- a/tests/test_forward_native_moe_loop_lora.py
+++ b/tests/test_forward_native_moe_loop_lora.py
@@ -272,3 +272,46 @@ def test_forward_native_moe_loop_lora_dtype_precast_no_loop_alloc(dtype):
     rtol = 1e-4 if dtype == torch.float32 else 1e-1
     torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
     assert out.dtype == dtype
+
+
+class GptOssExperts(nn.Module):
+    """Stock gpt-oss layout: (E, in, out) weights, biases, clamped swiglu."""
+
+    def __init__(self, num_experts=4, hidden=16, intermediate=12):
+        super().__init__()
+        self.num_experts = num_experts
+        self.alpha = 1.702
+        self.limit = 7.0
+        self.gate_up_proj = nn.Parameter(
+            torch.randn(num_experts, hidden, 2 * intermediate) * 0.1)
+        self.gate_up_proj_bias = nn.Parameter(
+            torch.randn(num_experts, 2 * intermediate) * 0.1)
+        self.down_proj = nn.Parameter(
+            torch.randn(num_experts, intermediate, hidden) * 0.1)
+        self.down_proj_bias = nn.Parameter(torch.randn(num_experts, hidden) * 0.1)
+        self._unsloth_grouped_mm_format = True
+
+
+def test_forward_native_moe_loop_gpt_oss_matches_naive():
+    torch.manual_seed(0)
+    num_experts, hidden, num_tokens, top_k = 4, 16, 8, 2
+    experts = GptOssExperts(num_experts, hidden)
+    hidden_states = torch.randn(num_tokens, hidden)
+    top_k_index = torch.stack(
+        [torch.randperm(num_experts)[:top_k] for _ in range(num_tokens)])
+    top_k_weights = torch.softmax(torch.randn(num_tokens, top_k), dim=-1)
+
+    out = forward_native_moe_loop(experts, hidden_states, top_k_index, top_k_weights)
+
+    ref = torch.zeros_like(hidden_states)
+    for t in range(num_tokens):
+        for k in range(top_k):
+            e = top_k_index[t, k].item()
+            h = hidden_states[t] @ experts.gate_up_proj[e] + experts.gate_up_proj_bias[e]
+            gate, up = h[::2], h[1::2]
+            gate = gate.clamp(max=experts.limit)
+            up = up.clamp(min=-experts.limit, max=experts.limit)
+            inter = (up + 1.0) * (gate * torch.sigmoid(gate * experts.alpha))
+            ref[t] += top_k_weights[t, k] * (
+                inter @ experts.down_proj[e] + experts.down_proj_bias[e])
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-4)

--- a/tests/test_moe_grouped_mm_format.py
+++ b/tests/test_moe_grouped_mm_format.py
@@ -199,3 +199,17 @@ def test_model_without_experts_does_not_raise_or_set_flags():
     assert patch_gpt_oss_grouped_mm_format(model) == 0
     assert not hasattr(model, "_unsloth_grouped_mm_format")
     assert not hasattr(model.dense, "_unsloth_grouped_mm_format")
+
+
+def test_lazy_path_does_not_flag_qwen_layout_named_gpt_oss():
+    class GptOssExperts(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_experts = 4
+            self.gate_up_proj = nn.Parameter(torch.empty(4, 24, 16))
+            self.down_proj = nn.Parameter(torch.empty(4, 16, 12))
+
+    experts = GptOssExperts()
+    assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (16, 24)
+    assert _get_moe_lora_io_dims(_Wrapper("down_proj", experts)) == (12, 16)
+    assert not hasattr(experts, "_unsloth_grouped_mm_format")

--- a/tests/test_moe_grouped_mm_format.py
+++ b/tests/test_moe_grouped_mm_format.py
@@ -69,6 +69,14 @@ class _Wrapper:
         return self.base_layer
 
 
+class _PeftLikeWrapper(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.base_model = nn.Module()
+        self.base_model.model = model
+        self.config = _Config("lora")
+
+
 def _unwrap_base_layer(module):
     while hasattr(module, "base_layer"):
         module = module.base_layer
@@ -163,6 +171,15 @@ def test_gpt_oss_experts_name_is_gated_by_model_type():
 
     assert patch_gpt_oss_grouped_mm_format(model) == 0
     assert not hasattr(experts, "_unsloth_grouped_mm_format")
+
+
+def test_gpt_oss_detection_unwraps_peft_like_model():
+    experts = GptOssExperts()
+    model = _Model("gpt_oss", experts)
+    wrapped_model = _PeftLikeWrapper(model)
+
+    assert patch_gpt_oss_grouped_mm_format(wrapped_model) == 1
+    assert experts._unsloth_grouped_mm_format is True
 
 
 def test_existing_gpt_oss_grouped_mm_flag_is_preserved():

--- a/tests/test_moe_grouped_mm_format.py
+++ b/tests/test_moe_grouped_mm_format.py
@@ -1,8 +1,10 @@
 import torch
 import torch.nn as nn
+import pytest
 
 from unsloth_zoo.temporary_patches.moe_utils import (
     _get_moe_lora_io_dims,
+    patch_param_wrapper_for_moe,
     patch_gpt_oss_grouped_mm_format,
 )
 
@@ -23,9 +25,31 @@ class Qwen3MoeExperts(nn.Module):
         self.down_proj = nn.Parameter(torch.empty(4, 16, 12))
 
 
+class Qwen3VLMoeTextExperts(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_experts = 4
+        self.gate_up_proj = nn.Parameter(torch.empty(4, 16, 24))
+        self.down_proj = nn.Parameter(torch.empty(4, 12, 16))
+
+
+class Mxfp4GptOssExperts(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_experts = 4
+        self.gate_up_proj = nn.Parameter(torch.empty(4, 24, 16))
+        self.down_proj = nn.Parameter(torch.empty(4, 16, 12))
+
+
 class _Config:
     def __init__(self, model_type):
         self.model_type = model_type
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def to_dict(self):
+        return {"model_type": self.model_type}
 
 
 class _Model(nn.Module):
@@ -45,6 +69,12 @@ class _Wrapper:
         return self.base_layer
 
 
+def _unwrap_base_layer(module):
+    while hasattr(module, "base_layer"):
+        module = module.base_layer
+    return module
+
+
 def test_stock_gpt_oss_experts_get_grouped_mm_flag_and_dims():
     experts = GptOssExperts()
     model = _Model("gpt_oss", experts)
@@ -57,6 +87,39 @@ def test_stock_gpt_oss_experts_get_grouped_mm_flag_and_dims():
     assert _get_moe_lora_io_dims(_Wrapper("down_proj", experts)) == (12, 16)
 
 
+def test_peft_get_peft_model_marks_nested_gpt_oss_experts_and_dims():
+    peft = pytest.importorskip("peft")
+    LoraConfig = peft.LoraConfig
+
+    try:
+        config = LoraConfig(
+            r=2,
+            lora_alpha=4,
+            target_parameters=["experts.gate_up_proj", "experts.down_proj"],
+            bias="none",
+        )
+    except TypeError:
+        pytest.skip("Installed PEFT does not support target_parameters")
+
+    model = _Model("gpt_oss", GptOssExperts())
+    patch_param_wrapper_for_moe()
+
+    peft_model = peft.get_peft_model(model, config)
+    experts = _unwrap_base_layer(model.experts)
+
+    assert experts._unsloth_grouped_mm_format is True
+
+    wrappers = {
+        module.parameter_name: module
+        for module in peft_model.modules()
+        if module.__class__.__name__ == "ParamWrapper"
+        and getattr(module, "parameter_name", None) in ("gate_up_proj", "down_proj")
+    }
+    assert set(wrappers) == {"gate_up_proj", "down_proj"}
+    assert _get_moe_lora_io_dims(wrappers["gate_up_proj"]) == (16, 24)
+    assert _get_moe_lora_io_dims(wrappers["down_proj"]) == (12, 16)
+
+
 def test_qwen3_moe_experts_do_not_get_gpt_oss_grouped_mm_flag():
     experts = Qwen3MoeExperts()
     model = _Model("qwen3_moe", experts)
@@ -67,6 +130,31 @@ def test_qwen3_moe_experts_do_not_get_gpt_oss_grouped_mm_flag():
     assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (16, 24)
     assert _get_moe_lora_io_dims(_Wrapper("down_proj", experts)) == (12, 16)
     assert not hasattr(experts, "_unsloth_grouped_mm_format")
+
+
+def test_qwen3_vl_grouped_mm_layout_still_requires_explicit_flag():
+    experts = Qwen3VLMoeTextExperts()
+    model = _Model("qwen3_vl_moe", experts)
+
+    assert patch_gpt_oss_grouped_mm_format(model) == 0
+    assert not hasattr(experts, "_unsloth_grouped_mm_format")
+
+    assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (24, 16)
+
+    experts._unsloth_grouped_mm_format = True
+    assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (16, 24)
+    assert _get_moe_lora_io_dims(_Wrapper("down_proj", experts)) == (12, 16)
+
+
+def test_mxfp4_gpt_oss_experts_name_is_not_treated_as_bf16_gpt_oss():
+    experts = Mxfp4GptOssExperts()
+    model = _Model("gpt_oss", experts)
+
+    assert patch_gpt_oss_grouped_mm_format(model) == 0
+    assert not hasattr(experts, "_unsloth_grouped_mm_format")
+
+    assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (16, 24)
+    assert _get_moe_lora_io_dims(_Wrapper("down_proj", experts)) == (12, 16)
 
 
 def test_gpt_oss_experts_name_is_gated_by_model_type():

--- a/tests/test_moe_grouped_mm_format.py
+++ b/tests/test_moe_grouped_mm_format.py
@@ -1,0 +1,96 @@
+import torch
+import torch.nn as nn
+
+from unsloth_zoo.temporary_patches.moe_utils import (
+    _get_moe_lora_io_dims,
+    patch_gpt_oss_grouped_mm_format,
+)
+
+
+class GptOssExperts(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_experts = 4
+        self.gate_up_proj = nn.Parameter(torch.empty(4, 16, 24))
+        self.down_proj = nn.Parameter(torch.empty(4, 12, 16))
+
+
+class Qwen3MoeExperts(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_experts = 4
+        self.gate_up_proj = nn.Parameter(torch.empty(4, 24, 16))
+        self.down_proj = nn.Parameter(torch.empty(4, 16, 12))
+
+
+class _Config:
+    def __init__(self, model_type):
+        self.model_type = model_type
+
+
+class _Model(nn.Module):
+    def __init__(self, model_type, experts=None):
+        super().__init__()
+        self.config = _Config(model_type)
+        if experts is not None:
+            self.experts = experts
+
+
+class _Wrapper:
+    def __init__(self, parameter_name, base_layer):
+        self.parameter_name = parameter_name
+        self.base_layer = base_layer
+
+    def get_base_layer(self):
+        return self.base_layer
+
+
+def test_stock_gpt_oss_experts_get_grouped_mm_flag_and_dims():
+    experts = GptOssExperts()
+    model = _Model("gpt_oss", experts)
+
+    assert not hasattr(experts, "_unsloth_grouped_mm_format")
+    assert patch_gpt_oss_grouped_mm_format(model) == 1
+    assert experts._unsloth_grouped_mm_format is True
+
+    assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (16, 24)
+    assert _get_moe_lora_io_dims(_Wrapper("down_proj", experts)) == (12, 16)
+
+
+def test_qwen3_moe_experts_do_not_get_gpt_oss_grouped_mm_flag():
+    experts = Qwen3MoeExperts()
+    model = _Model("qwen3_moe", experts)
+
+    assert patch_gpt_oss_grouped_mm_format(model) == 0
+    assert not hasattr(experts, "_unsloth_grouped_mm_format")
+
+    assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (16, 24)
+    assert _get_moe_lora_io_dims(_Wrapper("down_proj", experts)) == (12, 16)
+    assert not hasattr(experts, "_unsloth_grouped_mm_format")
+
+
+def test_gpt_oss_experts_name_is_gated_by_model_type():
+    experts = GptOssExperts()
+    model = _Model("qwen3_moe", experts)
+
+    assert patch_gpt_oss_grouped_mm_format(model) == 0
+    assert not hasattr(experts, "_unsloth_grouped_mm_format")
+
+
+def test_existing_gpt_oss_grouped_mm_flag_is_preserved():
+    experts = GptOssExperts()
+    experts._unsloth_grouped_mm_format = True
+    model = _Model("gpt-oss", experts)
+
+    assert patch_gpt_oss_grouped_mm_format(model) == 0
+    assert experts._unsloth_grouped_mm_format is True
+    assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (16, 24)
+
+
+def test_model_without_experts_does_not_raise_or_set_flags():
+    model = _Model("gpt_oss")
+    model.dense = nn.Linear(2, 2)
+
+    assert patch_gpt_oss_grouped_mm_format(model) == 0
+    assert not hasattr(model, "_unsloth_grouped_mm_format")
+    assert not hasattr(model.dense, "_unsloth_grouped_mm_format")

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1371,6 +1371,7 @@ from .moe_utils import (
     select_moe_backend,
     patch_param_wrapper_for_moe,
     forward_native_grouped_mm,
+    forward_native_moe_loop,
     # torch_native_forward,
 )
 
@@ -1415,7 +1416,10 @@ def patch_gpt_oss_moe_for_lora():
     if backend == "grouped_mm":
         forward = forward_native_grouped_mm
     else:
-        forward = torch_native_forward
+        # torch_native_forward expects the bnb4bit ModuleList layout; the stock
+        # 3D GptOssExperts needs the generic loop, which handles gpt-oss
+        # activation, biases, and the separated LoRA stash.
+        forward = forward_native_moe_loop
 
     # Store original forward and patch - but DON'T replace the class!
     GptOssExpertsClass._original_forward = GptOssExpertsClass.forward

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -18,6 +18,7 @@ import torch.nn.functional as F
 import os
 import shutil
 import sys
+import importlib
 import importlib.util
 from typing import Optional, Tuple
 from torch.autograd import Function
@@ -768,15 +769,37 @@ def _normalize_model_type(value) -> str:
     return str(value).lower().replace("-", "_")
 
 
-def _is_gpt_oss_model(model) -> bool:
-    config = getattr(model, "config", None)
-    model_type = _normalize_model_type(getattr(config, "model_type", None))
-    if model_type == "gpt_oss":
-        return True
+def _iter_model_configs(model):
+    seen = set()
+    queue = [model]
+    while queue and len(seen) < 8:
+        current = queue.pop(0)
+        if current is None:
+            continue
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
 
-    for attr in ("_name_or_path", "name_or_path"):
-        if "gpt_oss" in _normalize_model_type(getattr(config, attr, None)):
+        config = getattr(current, "config", None)
+        if config is not None:
+            yield config
+
+        for attr in ("base_model", "model"):
+            nested = getattr(current, attr, None)
+            if nested is not None and nested is not current:
+                queue.append(nested)
+
+
+def _is_gpt_oss_model(model) -> bool:
+    for config in _iter_model_configs(model):
+        model_type = _normalize_model_type(getattr(config, "model_type", None))
+        if model_type == "gpt_oss":
             return True
+
+        for attr in ("_name_or_path", "name_or_path"):
+            if "gpt_oss" in _normalize_model_type(getattr(config, attr, None)):
+                return True
 
     return False
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -180,6 +180,7 @@ def _check_torch_grouped_mm_supported():
 
 _TRITON_ALLOCATOR_INITIALIZED = False
 _PERSISTENT_BUFFER = None
+_original_peft_get_peft_model = None
 
 
 def _init_triton_allocator():
@@ -239,7 +240,7 @@ def _check_grouped_gemm_available():
     return _GROUPED_GEMM_AVAILABLE
 
 
-from functools import lru_cache
+from functools import lru_cache, wraps
 
 
 @lru_cache(maxsize=1)
@@ -389,6 +390,7 @@ def _get_moe_lora_io_dims(wrapper, experts_module=None):
     source = experts_module if experts_module is not None else base
     if source is None:
         return None, None
+    _set_gpt_oss_grouped_mm_format_on_experts(source)
 
     shape = _get_param_shape_from_module(source, parameter_name)
     if shape is not None and len(shape) >= 3:
@@ -760,6 +762,104 @@ def preprocess_weight(
 # ============================================================================
 
 
+def _normalize_model_type(value) -> str:
+    if value is None:
+        return ""
+    return str(value).lower().replace("-", "_")
+
+
+def _is_gpt_oss_model(model) -> bool:
+    config = getattr(model, "config", None)
+    model_type = _normalize_model_type(getattr(config, "model_type", None))
+    if model_type == "gpt_oss":
+        return True
+
+    for attr in ("_name_or_path", "name_or_path"):
+        if "gpt_oss" in _normalize_model_type(getattr(config, attr, None)):
+            return True
+
+    return False
+
+
+def _set_gpt_oss_grouped_mm_format_on_experts(module) -> bool:
+    if module is None:
+        return False
+    if module.__class__.__name__ != "GptOssExperts":
+        return False
+    if bool(getattr(module, "_unsloth_grouped_mm_format", False)):
+        return False
+    module._unsloth_grouped_mm_format = True
+    return True
+
+
+def patch_gpt_oss_grouped_mm_format(model) -> int:
+    """
+    Mark GPT-OSS experts as storing weights in grouped_mm format.
+
+    Stock transformers GPT-OSS experts use (E, in_dim, out_dim) tensors but do
+    not carry Unsloth's `_unsloth_grouped_mm_format` instance flag. Set it on
+    live expert modules so the shared MoE LoRA extractor chooses GPT-OSS
+    ordering instead of the Qwen-style fallback.
+    """
+    # This Unsloth Zoo code section is licensed under AGPL3
+
+    if model is None or not _is_gpt_oss_model(model):
+        return 0
+
+    modules = getattr(model, "modules", None)
+    if not callable(modules):
+        return 0
+
+    updated = 0
+    for module in modules():
+        if _set_gpt_oss_grouped_mm_format_on_experts(module):
+            updated += 1
+    return updated
+
+
+def _patch_peft_get_peft_model_for_moe():
+    # This Unsloth Zoo code section is licensed under AGPL3
+
+    global _original_peft_get_peft_model
+    if _original_peft_get_peft_model is not None:
+        return
+
+    try:
+        import peft
+    except Exception:
+        return
+
+    original_get_peft_model = getattr(peft, "get_peft_model", None)
+    if original_get_peft_model is None:
+        return
+    if getattr(original_get_peft_model, "_unsloth_moe_patched", False):
+        return
+
+    _original_peft_get_peft_model = original_get_peft_model
+
+    @wraps(original_get_peft_model)
+    def patched_get_peft_model(model, *args, **kwargs):
+        peft_model = original_get_peft_model(model, *args, **kwargs)
+        try:
+            patch_gpt_oss_grouped_mm_format(model)
+            if peft_model is not model:
+                patch_gpt_oss_grouped_mm_format(peft_model)
+        except Exception:
+            pass
+        return peft_model
+
+    patched_get_peft_model._unsloth_moe_patched = True
+    peft.get_peft_model = patched_get_peft_model
+
+    for module_name in ("peft.mapping_func", "peft.mapping"):
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:
+            continue
+        if getattr(module, "get_peft_model", None) is original_get_peft_model:
+            module.get_peft_model = patched_get_peft_model
+
+
 def _is_moe_experts_module(module) -> bool:
     """
     Check if module is an MoE experts layer (generic, not model-specific).
@@ -904,6 +1004,7 @@ def patch_param_wrapper_for_moe():
 
         # Patch with our version
         ParamWrapper.forward = _patched_param_wrapper_forward
+        _patch_peft_get_peft_model_for_moe()
 
         return True
     except ImportError:

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -811,6 +811,18 @@ def _set_gpt_oss_grouped_mm_format_on_experts(module) -> bool:
         return False
     if bool(getattr(module, "_unsloth_grouped_mm_format", False)):
         return False
+    # Require the gpt-oss (E, in, out) weight signature: gate_up's out dim is
+    # twice down's in dim. Same-named classes with other layouts stay unflagged.
+    gate_shape = _get_param_shape_from_module(module, "gate_up_proj")
+    down_shape = _get_param_shape_from_module(module, "down_proj")
+    if gate_shape is None or down_shape is None:
+        return False
+    if len(gate_shape) < 3 or len(down_shape) < 3:
+        return False
+    if gate_shape[0] != down_shape[0]:
+        return False
+    if gate_shape[-2] != down_shape[-1] or gate_shape[-1] != 2 * down_shape[-2]:
+        return False
     module._unsloth_grouped_mm_format = True
     return True
 
@@ -1628,6 +1640,9 @@ def forward_native_moe_loop(
     # unsafe when intermediate_dim == hidden_dim (square dims).
     grouped_mm_format = bool(getattr(self, "_unsloth_grouped_mm_format", False))
 
+    # GPT-OSS uses interleaved gate/up, clamped swiglu, and per-expert biases.
+    is_gpt_oss = "GptOssExperts" in self.__class__.__name__
+
     # Only loop over experts that actually have tokens routed to them
     for expert_idx_t in expert_hit:
         expert_idx = expert_idx_t.item()
@@ -1650,12 +1665,28 @@ def forward_native_moe_loop(
                 lora_delta = current_state @ first_weight[expert_idx]
                 lora_delta = lora_delta @ second_weight[expert_idx]
                 gate_up = gate_up + lora_delta * scaling
-            gate, up = gate_up.chunk(2, dim=-1)
+            if is_gpt_oss:
+                gate_up_bias = getattr(self, "gate_up_proj_bias", None)
+                if gate_up_bias is not None:
+                    gate_up = gate_up + gate_up_bias[expert_idx].to(gate_up.dtype)
+                gate = gate_up[..., ::2]
+                up = gate_up[..., 1::2]
+            else:
+                gate, up = gate_up.chunk(2, dim=-1)
         else:
             gate = F.linear(current_state, self.w1[expert_idx])
             up = F.linear(current_state, self.w3[expert_idx])
 
-        current_hidden_states = self.act_fn(gate) * up
+        if is_gpt_oss:
+            limit = getattr(self, "limit", 7.0)
+            alpha = getattr(self, "alpha", 1.702)
+            gate = gate.clamp(min=None, max=limit)
+            up = up.clamp(min=-limit, max=limit)
+            current_hidden_states = (up + 1.0) * (gate * torch.sigmoid(gate * alpha))
+        elif hasattr(self, "act_fn") and callable(self.act_fn):
+            current_hidden_states = self.act_fn(gate) * up
+        else:
+            current_hidden_states = F.silu(gate) * up
 
         # Compute down projection for this expert only
         if hasattr(self, "down_proj"):
@@ -1671,6 +1702,10 @@ def forward_native_moe_loop(
                 lora_delta = current_hidden_states @ first_weight[expert_idx]
                 lora_delta = lora_delta @ second_weight[expert_idx]
                 down = down + lora_delta * scaling
+            if is_gpt_oss:
+                down_bias = getattr(self, "down_proj_bias", None)
+                if down_bias is not None:
+                    down = down + down_bias[expert_idx].to(down.dtype)
             current_hidden_states = down
         else:
             current_hidden_states = F.linear(current_hidden_states, self.w2[expert_idx])


### PR DESCRIPTION
## Summary

Sets `_unsloth_grouped_mm_format = True` on every gpt-oss expert module during MoE patching so `_get_moe_lora_io_dims` in `unsloth_zoo/temporary_patches/moe_utils.py` picks the gpt-oss `(num_experts, in_dim, out_dim)` weight layout. This fixes the `torch._grouped_mm` contraction-dimension crash on the first forward of a gpt-oss-20b MoE LoRA run under transformers 5.x.

## Why this matters

Issue #683 reports that gpt-oss-20b with `transformers==5.5.0` crashes on the first forward with a grouped_mm shape mismatch, reproduced on H100/H200/A100. The per-instance `_unsloth_grouped_mm_format` flag read at `moe_utils.py:395` was only set in Unsloth's own `GptOssExperts.__init__`, but under transformers 5.x the live modules are the stock `transformers.models.gpt_oss.modeling_gpt_oss.GptOssExperts`, so the flag stays unset, the Qwen3-MoE branch fires, and the reshape doubles the inner dim. The patch walks `model.modules()`, matches gpt-oss expert modules by type name regardless of whether they are the stock or Unsloth class, and sets the flag, leaving the existing shape heuristic as a fallback and gating the loop so Qwen3 modules are untouched.

## Testing

`tests/test_moe_grouped_mm_format.py` covers the happy path (stock `GptOssExperts` gets the flag and resolves to gpt-oss ordering), layout selection (Qwen3-MoE modules do not get the flag and stay on the Qwen3 branch), the already-subclassed regression case, and a model with no expert modules not raising. Full suite runs in CI.

Fixes #683
