### PR TITLE
Redirect HF cache when the default location is read-only

### DIFF
--- a/tests/test_hf_cache_redirect.py
+++ b/tests/test_hf_cache_redirect.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Tests for the read-only HF cache redirect in ``unsloth_zoo/hf_cache.py``.
+
+The module is loaded directly via importlib so these tests do not import the
+full ``unsloth_zoo`` package (which pulls in torch + GPU init).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_HF_CACHE_PATH = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "hf_cache.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "zoo_hf_cache_under_test", _HF_CACHE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def hf_cache(monkeypatch):
+    # Clear the cache env so each test fully controls it.
+    for v in ("HF_HOME", "HF_HUB_CACHE", "HF_XET_CACHE"):
+        monkeypatch.delenv(v, raising = False)
+    return _load_module()
+
+
+def test_is_writable(hf_cache, tmp_path):
+    assert hf_cache._is_writable(tmp_path) is True
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    # Parent is a file, so mkdir can never succeed (reliable across uids).
+    assert hf_cache._is_writable(blocker / "hub") is False
+
+
+def test_writable_default_no_redirect(hf_cache, tmp_path, monkeypatch):
+    monkeypatch.setenv("HF_HOME", str(tmp_path))
+    assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert os.environ["HF_HOME"] == str(tmp_path)
+    assert "HF_HUB_CACHE" not in os.environ
+
+
+def test_explicit_writable_hub_honored(hf_cache, tmp_path, monkeypatch):
+    hub = tmp_path / "myhub"
+    monkeypatch.setenv("HF_HUB_CACHE", str(hub))
+    assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert os.environ["HF_HUB_CACHE"] == str(hub)
+
+
+def test_readonly_hub_redirects(hf_cache, tmp_path, monkeypatch):
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    monkeypatch.setenv("HF_HUB_CACHE", str(blocker / "hub"))  # not writable
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        result = hf_cache.redirect_hf_cache_if_readonly()
+    assert result == str(fallback)
+    assert os.environ["HF_HOME"] == str(fallback)
+    assert os.environ["HF_HUB_CACHE"] == str(fallback / "hub")
+    assert os.environ["HF_XET_CACHE"] == str(fallback / "xet")
+    assert hf_cache._is_writable(Path(os.environ["HF_HUB_CACHE"])) is True

--- a/tests/test_hf_cache_redirect.py
+++ b/tests/test_hf_cache_redirect.py
@@ -94,12 +94,34 @@ def test_home_resolution_failure_redirects(hf_cache, tmp_path, monkeypatch):
     monkeypatch.setattr(hf_cache.Path, "home", staticmethod(_no_home))
     fallback = tmp_path / "fallback"
     monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match = "could not be resolved"):
         result = hf_cache.redirect_hf_cache_if_readonly()
     assert result == str(fallback)
     assert os.environ["HF_HUB_CACHE"] == str(fallback / "hub")
 
 
+def test_no_writable_fallback_warns_and_leaves_env(hf_cache, tmp_path, monkeypatch):
+    _readonly_hub(tmp_path, monkeypatch)
+    blocked = tmp_path / "blocker2"
+    blocked.write_text("")
+    # The only candidate sits under a file, so it can never be created.
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [blocked / "base"])
+    with pytest.warns(UserWarning, match = "no writable fallback"):
+        assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert "HF_HOME" not in os.environ
+
+
+def test_empty_env_value_matches_hub_semantics(hf_cache, tmp_path, monkeypatch):
+    # Hub's os.getenv keeps a present-but-empty HF_HOME, yielding relative
+    # cache paths; the probe must target those same locations.
+    monkeypatch.setenv("HF_HOME", "")
+    monkeypatch.chdir(tmp_path)
+    assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert (tmp_path / "hub").is_dir()
+    assert (tmp_path / "xet").is_dir()
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "symlinks need privileges on Windows")
 def test_symlinked_fallback_rejected(hf_cache, tmp_path, monkeypatch):
     _readonly_hub(tmp_path, monkeypatch)
     target = tmp_path / "target"
@@ -216,6 +238,7 @@ def test_xet_env_value_probed_literally(hf_cache, tmp_path, monkeypatch):
     assert not (root / "xet").exists()
 
 
+@pytest.mark.skipif(os.name != "posix", reason = "symlinks need privileges on Windows")
 def test_explicit_symlinked_hub_cache_honored(hf_cache, tmp_path, monkeypatch):
     # Users symlink caches to large volumes; Hub writes through the link, so
     # a writable symlinked cache must not be redirected away.
@@ -238,12 +261,13 @@ def test_explicit_hub_cache_survives_home_failure(hf_cache, tmp_path, monkeypatc
     fallback = tmp_path / "fallback"
     monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
     # The hub cache stays put; only the unresolvable xet default moves.
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match = "xet cache location could not be resolved"):
         assert hf_cache.redirect_hf_cache_if_readonly() is None
     assert os.environ["HF_HUB_CACHE"] == str(hub)
     assert os.environ["HF_XET_CACHE"] == str(fallback / "xet")
 
 
+@pytest.mark.skipif(os.name != "posix", reason = "symlinks need privileges on Windows")
 def test_child_symlink_in_fallback_rejected(hf_cache, tmp_path, monkeypatch):
     _readonly_hub(tmp_path, monkeypatch)
     target = tmp_path / "target"

--- a/tests/test_hf_cache_redirect.py
+++ b/tests/test_hf_cache_redirect.py
@@ -30,7 +30,15 @@ def _load_module():
 @pytest.fixture
 def hf_cache(monkeypatch):
     # Clear the cache env so each test fully controls it.
-    for v in ("HF_HOME", "HF_HUB_CACHE", "HF_XET_CACHE", "HF_TOKEN", "HF_TOKEN_PATH"):
+    for v in (
+        "HF_HOME",
+        "HF_HUB_CACHE",
+        "HUGGINGFACE_HUB_CACHE",
+        "HF_XET_CACHE",
+        "XDG_CACHE_HOME",
+        "HF_TOKEN",
+        "HF_TOKEN_PATH",
+    ):
         monkeypatch.delenv(v, raising = False)
     return _load_module()
 
@@ -60,6 +68,7 @@ def test_writable_default_no_redirect(hf_cache, tmp_path, monkeypatch):
 def test_explicit_writable_hub_honored(hf_cache, tmp_path, monkeypatch):
     hub = tmp_path / "myhub"
     monkeypatch.setenv("HF_HUB_CACHE", str(hub))
+    monkeypatch.setenv("HF_XET_CACHE", str(tmp_path / "myxet"))
     assert hf_cache.redirect_hf_cache_if_readonly() is None
     assert os.environ["HF_HUB_CACHE"] == str(hub)
 
@@ -141,6 +150,126 @@ def test_token_path_preserved_on_redirect(hf_cache, tmp_path, monkeypatch):
     with pytest.warns(UserWarning):
         hf_cache.redirect_hf_cache_if_readonly()
     assert os.environ["HF_TOKEN_PATH"] == str(old_home / "token")
+
+
+def test_xdg_cache_home_writable_no_redirect(hf_cache, tmp_path, monkeypatch):
+    xdg = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(xdg))
+    assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert "HF_HUB_CACHE" not in os.environ
+    # The probe must target where Hub will actually write.
+    assert (xdg / "huggingface" / "hub").is_dir()
+
+
+def test_xdg_cache_home_blocked_redirects(hf_cache, tmp_path, monkeypatch):
+    xdg_blocker = tmp_path / "xdg_blocker"
+    xdg_blocker.write_text("")  # file, so nothing can be created beneath it
+    monkeypatch.setenv("XDG_CACHE_HOME", str(xdg_blocker))
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        assert hf_cache.redirect_hf_cache_if_readonly() == str(fallback)
+    assert os.environ["HF_HUB_CACHE"] == str(fallback / "hub")
+
+
+def test_legacy_hub_cache_env_honored(hf_cache, tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy_hub"
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(legacy))
+    monkeypatch.setenv("HF_XET_CACHE", str(tmp_path / "myxet"))
+    assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert "HF_HUB_CACHE" not in os.environ
+
+
+def test_legacy_hub_cache_env_blocked_redirects(hf_cache, tmp_path, monkeypatch):
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(blocker / "hub"))
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        assert hf_cache.redirect_hf_cache_if_readonly() == str(fallback)
+    assert os.environ["HF_HUB_CACHE"] == str(fallback / "hub")
+
+
+def test_env_vars_in_paths_expanded(hf_cache, tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    monkeypatch.setenv("MY_CACHE_ROOT", str(root))
+    monkeypatch.setenv("HF_HUB_CACHE", "$MY_CACHE_ROOT/hub")
+    monkeypatch.setenv("HF_XET_CACHE", "$MY_CACHE_ROOT/xet")
+    assert hf_cache.redirect_hf_cache_if_readonly() is None
+    # Probed the expanded path, not a literal "$MY_CACHE_ROOT" directory.
+    assert (root / "hub").is_dir()
+    assert not Path("$MY_CACHE_ROOT").exists()
+
+
+def test_explicit_hub_cache_survives_home_failure(hf_cache, tmp_path, monkeypatch):
+    def _no_home():
+        raise RuntimeError("could not determine home directory")
+    monkeypatch.setattr(hf_cache.Path, "home", staticmethod(_no_home))
+    hub = tmp_path / "myhub"
+    monkeypatch.setenv("HF_HUB_CACHE", str(hub))
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    # The hub cache stays put; only the unresolvable xet default moves.
+    with pytest.warns(UserWarning):
+        assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert os.environ["HF_HUB_CACHE"] == str(hub)
+    assert os.environ["HF_XET_CACHE"] == str(fallback / "xet")
+
+
+def test_child_symlink_in_fallback_rejected(hf_cache, tmp_path, monkeypatch):
+    _readonly_hub(tmp_path, monkeypatch)
+    target = tmp_path / "target"
+    target.mkdir()
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "hub").symlink_to(target)
+    good = tmp_path / "good"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [bad, good])
+    with pytest.warns(UserWarning):
+        assert hf_cache.redirect_hf_cache_if_readonly() == str(good)
+    assert os.environ["HF_HUB_CACHE"] == str(good / "hub")
+
+
+def test_explicit_writable_xet_kept_on_redirect(hf_cache, tmp_path, monkeypatch):
+    _readonly_hub(tmp_path, monkeypatch)
+    xet = tmp_path / "fast_xet"
+    monkeypatch.setenv("HF_XET_CACHE", str(xet))
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        assert hf_cache.redirect_hf_cache_if_readonly() == str(fallback)
+    assert os.environ["HF_XET_CACHE"] == str(xet)
+
+
+def test_xet_only_breakage_moves_only_xet(hf_cache, tmp_path, monkeypatch):
+    home = tmp_path / "hfhome"
+    (home / "hub").mkdir(parents = True)
+    (home / "xet").write_text("")  # file blocks the xet dir
+    monkeypatch.setenv("HF_HOME", str(home))
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert os.environ["HF_HOME"] == str(home)
+    assert "HF_HUB_CACHE" not in os.environ
+    assert os.environ["HF_XET_CACHE"] == str(fallback / "xet")
+
+
+def test_resolve_hf_home_none_on_failure(hf_cache, monkeypatch):
+    def _no_home():
+        raise RuntimeError("could not determine home directory")
+    monkeypatch.setattr(hf_cache.Path, "home", staticmethod(_no_home))
+    assert hf_cache._resolve_hf_home() is None
+
+
+def test_safe_user_uid_fallback(hf_cache, monkeypatch):
+    monkeypatch.delenv("USER", raising = False)
+    monkeypatch.delenv("USERNAME", raising = False)
+    user = hf_cache._safe_user()
+    assert user
+    if hasattr(os, "getuid"):
+        assert user == str(os.getuid())
 
 
 def test_explicit_token_env_not_overridden(hf_cache, tmp_path, monkeypatch):

--- a/tests/test_hf_cache_redirect.py
+++ b/tests/test_hf_cache_redirect.py
@@ -30,9 +30,16 @@ def _load_module():
 @pytest.fixture
 def hf_cache(monkeypatch):
     # Clear the cache env so each test fully controls it.
-    for v in ("HF_HOME", "HF_HUB_CACHE", "HF_XET_CACHE"):
+    for v in ("HF_HOME", "HF_HUB_CACHE", "HF_XET_CACHE", "HF_TOKEN", "HF_TOKEN_PATH"):
         monkeypatch.delenv(v, raising = False)
     return _load_module()
+
+
+def _readonly_hub(tmp_path, monkeypatch):
+    # Point HF_HUB_CACHE under a file so mkdir can never succeed.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    monkeypatch.setenv("HF_HUB_CACHE", str(blocker / "hub"))
 
 
 def test_is_writable(hf_cache, tmp_path):
@@ -58,9 +65,7 @@ def test_explicit_writable_hub_honored(hf_cache, tmp_path, monkeypatch):
 
 
 def test_readonly_hub_redirects(hf_cache, tmp_path, monkeypatch):
-    blocker = tmp_path / "blocker"
-    blocker.write_text("")
-    monkeypatch.setenv("HF_HUB_CACHE", str(blocker / "hub"))  # not writable
+    _readonly_hub(tmp_path, monkeypatch)
     fallback = tmp_path / "fallback"
     monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
     with pytest.warns(UserWarning):
@@ -70,3 +75,83 @@ def test_readonly_hub_redirects(hf_cache, tmp_path, monkeypatch):
     assert os.environ["HF_HUB_CACHE"] == str(fallback / "hub")
     assert os.environ["HF_XET_CACHE"] == str(fallback / "xet")
     assert hf_cache._is_writable(Path(os.environ["HF_HUB_CACHE"])) is True
+
+
+def test_home_resolution_failure_redirects(hf_cache, tmp_path, monkeypatch):
+    # Unresolvable home (arbitrary-uid containers) must not crash the import
+    # and must fall through to a writable fallback.
+    def _no_home():
+        raise RuntimeError("could not determine home directory")
+    monkeypatch.setattr(hf_cache.Path, "home", staticmethod(_no_home))
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        result = hf_cache.redirect_hf_cache_if_readonly()
+    assert result == str(fallback)
+    assert os.environ["HF_HUB_CACHE"] == str(fallback / "hub")
+
+
+def test_symlinked_fallback_rejected(hf_cache, tmp_path, monkeypatch):
+    _readonly_hub(tmp_path, monkeypatch)
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target)
+    good = tmp_path / "good"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [link, good])
+    with pytest.warns(UserWarning):
+        result = hf_cache.redirect_hf_cache_if_readonly()
+    assert result == str(good)
+    assert os.environ["HF_HOME"] == str(good)
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX permission bits")
+def test_fallback_clamped_to_0700(hf_cache, tmp_path, monkeypatch):
+    _readonly_hub(tmp_path, monkeypatch)
+    fallback = tmp_path / "fallback"
+    fallback.mkdir()
+    fallback.chmod(0o777)
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        assert hf_cache.redirect_hf_cache_if_readonly() == str(fallback)
+    assert (fallback.stat().st_mode & 0o777) == 0o700
+
+
+def test_blocked_xet_rejects_candidate(hf_cache, tmp_path, monkeypatch):
+    _readonly_hub(tmp_path, monkeypatch)
+    bad = tmp_path / "bad"
+    (bad / "hub").mkdir(parents = True)
+    (bad / "xet").write_text("")  # file blocks the xet dir
+    good = tmp_path / "good"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [bad, good])
+    with pytest.warns(UserWarning):
+        result = hf_cache.redirect_hf_cache_if_readonly()
+    assert result == str(good)
+    assert os.environ["HF_XET_CACHE"] == str(good / "xet")
+
+
+def test_token_path_preserved_on_redirect(hf_cache, tmp_path, monkeypatch):
+    old_home = tmp_path / "oldhome"
+    old_home.mkdir()
+    (old_home / "token").write_text("hf_dummy")
+    (old_home / "hub").write_text("")  # file, so the hub cache is unwritable
+    monkeypatch.setenv("HF_HOME", str(old_home))
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        hf_cache.redirect_hf_cache_if_readonly()
+    assert os.environ["HF_TOKEN_PATH"] == str(old_home / "token")
+
+
+def test_explicit_token_env_not_overridden(hf_cache, tmp_path, monkeypatch):
+    old_home = tmp_path / "oldhome"
+    old_home.mkdir()
+    (old_home / "token").write_text("hf_dummy")
+    (old_home / "hub").write_text("")
+    monkeypatch.setenv("HF_HOME", str(old_home))
+    monkeypatch.setenv("HF_TOKEN", "hf_explicit")
+    fallback = tmp_path / "fallback"
+    monkeypatch.setattr(hf_cache, "_fallback_bases", lambda: [fallback])
+    with pytest.warns(UserWarning):
+        hf_cache.redirect_hf_cache_if_readonly()
+    assert "HF_TOKEN_PATH" not in os.environ

--- a/tests/test_hf_cache_redirect.py
+++ b/tests/test_hf_cache_redirect.py
@@ -191,15 +191,42 @@ def test_legacy_hub_cache_env_blocked_redirects(hf_cache, tmp_path, monkeypatch)
     assert os.environ["HF_HUB_CACHE"] == str(fallback / "hub")
 
 
-def test_env_vars_in_paths_expanded(hf_cache, tmp_path, monkeypatch):
+def test_env_vars_in_hub_path_expanded(hf_cache, tmp_path, monkeypatch):
     root = tmp_path / "root"
     monkeypatch.setenv("MY_CACHE_ROOT", str(root))
     monkeypatch.setenv("HF_HUB_CACHE", "$MY_CACHE_ROOT/hub")
-    monkeypatch.setenv("HF_XET_CACHE", "$MY_CACHE_ROOT/xet")
+    monkeypatch.setenv("HF_XET_CACHE", str(root / "xet"))
+    monkeypatch.chdir(tmp_path)
     assert hf_cache.redirect_hf_cache_if_readonly() is None
     # Probed the expanded path, not a literal "$MY_CACHE_ROOT" directory.
     assert (root / "hub").is_dir()
-    assert not Path("$MY_CACHE_ROOT").exists()
+    assert not (tmp_path / "$MY_CACHE_ROOT").exists()
+
+
+def test_xet_env_value_probed_literally(hf_cache, tmp_path, monkeypatch):
+    # Hub does NOT expandvars/expanduser HF_XET_CACHE, so the probe must
+    # target the same literal path Hub will use.
+    root = tmp_path / "root"
+    monkeypatch.setenv("MY_CACHE_ROOT", str(root))
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "hfhome"))
+    monkeypatch.setenv("HF_XET_CACHE", "$MY_CACHE_ROOT/xet")
+    monkeypatch.chdir(tmp_path)
+    assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert (tmp_path / "$MY_CACHE_ROOT" / "xet").is_dir()
+    assert not (root / "xet").exists()
+
+
+def test_explicit_symlinked_hub_cache_honored(hf_cache, tmp_path, monkeypatch):
+    # Users symlink caches to large volumes; Hub writes through the link, so
+    # a writable symlinked cache must not be redirected away.
+    target = tmp_path / "real_hub"
+    target.mkdir()
+    link = tmp_path / "hub_link"
+    link.symlink_to(target, target_is_directory = True)
+    monkeypatch.setenv("HF_HUB_CACHE", str(link))
+    monkeypatch.setenv("HF_XET_CACHE", str(tmp_path / "xet"))
+    assert hf_cache.redirect_hf_cache_if_readonly() is None
+    assert os.environ["HF_HUB_CACHE"] == str(link)
 
 
 def test_explicit_hub_cache_survives_home_failure(hf_cache, tmp_path, monkeypatch):

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -72,9 +72,17 @@ from .hf_cache import redirect_hf_cache_if_readonly
 redirect_hf_cache_if_readonly()
 del redirect_hf_cache_if_readonly
 
-hf_home = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface")).expanduser()
-xet_cache = Path(os.environ.get("HF_XET_CACHE", hf_home / "xet")).expanduser()
-os.environ.setdefault("HF_XET_HIGH_PERFORMANCE", has_429_exact_full_read(xet_cache / "logs"))
+try:
+    hf_home = Path(os.environ.get("HF_HOME") or Path.home() / ".cache" / "huggingface").expanduser()
+    xet_cache = Path(os.environ.get("HF_XET_CACHE") or hf_home / "xet").expanduser()
+except Exception:
+    # Path.home() can raise on locked-down machines with an unresolvable home
+    # directory; "1" matches the probe's no-logs-found default.
+    hf_home = xet_cache = None
+os.environ.setdefault(
+    "HF_XET_HIGH_PERFORMANCE",
+    has_429_exact_full_read(xet_cache / "logs") if xet_cache is not None else "1",
+)
 os.environ.setdefault("HF_XET_CHUNK_CACHE_SIZE_BYTES", "0")
 os.environ.setdefault("HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY", "0")
 os.environ.setdefault("HF_XET_NUM_CONCURRENT_RANGE_GETS", "64")

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -68,17 +68,13 @@ def has_429_exact_full_read(log_dir: str | Path) -> str:
 
 # Redirect the HF cache off a read-only default (locked-down machines) so
 # snapshot_download() can write. Runs before any huggingface_hub import.
-from .hf_cache import redirect_hf_cache_if_readonly
+from .hf_cache import redirect_hf_cache_if_readonly, _active_caches
 redirect_hf_cache_if_readonly()
-del redirect_hf_cache_if_readonly
 
-try:
-    hf_home = Path(os.environ.get("HF_HOME") or Path.home() / ".cache" / "huggingface").expanduser()
-    xet_cache = Path(os.environ.get("HF_XET_CACHE") or hf_home / "xet").expanduser()
-except Exception:
-    # Path.home() can raise on locked-down machines with an unresolvable home
-    # directory; "1" matches the probe's no-logs-found default.
-    hf_home = xet_cache = None
+# _active_caches mirrors Hub's env layering (XDG_CACHE_HOME included) and
+# returns None entries instead of raising when home is unresolvable; "1"
+# matches the probe's no-logs-found default.
+_, _, xet_cache = _active_caches()
 os.environ.setdefault(
     "HF_XET_HIGH_PERFORMANCE",
     has_429_exact_full_read(xet_cache / "logs") if xet_cache is not None else "1",
@@ -86,7 +82,7 @@ os.environ.setdefault(
 os.environ.setdefault("HF_XET_CHUNK_CACHE_SIZE_BYTES", "0")
 os.environ.setdefault("HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY", "0")
 os.environ.setdefault("HF_XET_NUM_CONCURRENT_RANGE_GETS", "64")
-del has_429_exact_full_read, hf_home, xet_cache
+del has_429_exact_full_read, xet_cache, redirect_hf_cache_if_readonly, _active_caches
 
 # More verbose HF Hub info
 if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -67,6 +67,12 @@ def has_429_exact_full_read(log_dir: str | Path) -> str:
             continue
     return "1"
 
+# Redirect the HF cache off a read-only default (locked-down machines) so
+# snapshot_download() can write. Runs before any huggingface_hub import.
+from .hf_cache import redirect_hf_cache_if_readonly
+redirect_hf_cache_if_readonly()
+del redirect_hf_cache_if_readonly
+
 hf_home = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface")).expanduser()
 xet_cache = Path(os.environ.get("HF_XET_CACHE", hf_home / "xet")).expanduser()
 os.environ.setdefault("HF_XET_HIGH_PERFORMANCE", has_429_exact_full_read(xet_cache / "logs"))

--- a/unsloth_zoo/hf_cache.py
+++ b/unsloth_zoo/hf_cache.py
@@ -34,8 +34,9 @@ __all__ = ["redirect_hf_cache_if_readonly"]
 
 
 def _expand_env_path(value: str) -> Path:
-    # Hub applies expandvars + expanduser to env-provided paths; mirror that.
-    return Path(os.path.expandvars(value)).expanduser()
+    # Hub applies os.path.expandvars(os.path.expanduser(...)) to env-provided
+    # paths; mirror the exact order.
+    return Path(os.path.expandvars(os.path.expanduser(value)))
 
 
 def _is_writable(path: Path) -> bool:
@@ -58,7 +59,23 @@ def _is_safe_private_dir(path: Path) -> bool:
     # token file Hub keeps under HF_HOME) are not readable by other users.
     # The ownership check is POSIX-only; Windows temp dirs are per-user.
     try:
-        path.mkdir(parents = True, exist_ok = True)
+        if hasattr(os, "getuid"):
+            # /tmp is safe against dir-swap races because of the sticky bit; a
+            # world-writable NON-sticky ancestor we do not own gives no such
+            # guarantee, so refuse to build a fallback there.
+            ancestor = path
+            while not ancestor.exists():
+                ancestor = ancestor.parent
+            st = ancestor.stat()
+            if (
+                st.st_mode & 0o002
+                and not st.st_mode & 0o1000
+                and st.st_uid != os.getuid()
+            ):
+                return False
+        # mode applies to the leaf, so a fresh dir is never looser than 0700
+        # even under a permissive umask; chmod below covers pre-existing dirs.
+        path.mkdir(mode = 0o700, parents = True, exist_ok = True)
         if path.is_symlink():
             return False
         if hasattr(os, "getuid") and path.stat().st_uid != os.getuid():
@@ -94,11 +111,13 @@ def _resolve_hf_home() -> Path | None:
     # raise on locked-down machines with an unresolvable home directory; treat
     # that as "no usable default" rather than crashing import.
     try:
+        # Presence-based (not truthiness) lookups mirror Hub's os.getenv
+        # semantics: a present-but-empty value resolves to a relative path.
         hf_home_env = os.environ.get("HF_HOME")
-        if hf_home_env:
+        if hf_home_env is not None:
             return _expand_env_path(hf_home_env)
         xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
-        if xdg_cache_home:
+        if xdg_cache_home is not None:
             return _expand_env_path(xdg_cache_home) / "huggingface"
         return Path.home() / ".cache" / "huggingface"
     except Exception:
@@ -110,19 +129,19 @@ def _active_caches() -> tuple[Path | None, Path | None, Path | None]:
     # vars are resolved first so they never depend on home resolution; the
     # legacy HUGGINGFACE_HUB_CACHE name is still honored by Hub.
     hf_home = _resolve_hf_home()
-    hub_cache_env = (
-        os.environ.get("HF_HUB_CACHE") or os.environ.get("HUGGINGFACE_HUB_CACHE")
-    )
+    hub_cache_env = os.environ.get("HF_HUB_CACHE")
+    if hub_cache_env is None:
+        hub_cache_env = os.environ.get("HUGGINGFACE_HUB_CACHE")
     xet_cache_env = os.environ.get("HF_XET_CACHE")
     try:
-        if hub_cache_env:
+        if hub_cache_env is not None:
             hub_cache = _expand_env_path(hub_cache_env)
         else:
             hub_cache = hf_home / "hub" if hf_home is not None else None
     except Exception:
         hub_cache = None
     try:
-        if xet_cache_env:
+        if xet_cache_env is not None:
             # Hub reads HF_XET_CACHE literally (no expanduser/expandvars),
             # unlike HF_HOME and HF_HUB_CACHE; probe the same literal path.
             xet_cache = Path(xet_cache_env)
@@ -142,8 +161,16 @@ def redirect_hf_cache_if_readonly() -> str | None:
     xet_ok = xet_cache is not None and _is_writable(xet_cache)
     if hub_ok and xet_ok:
         return None
+    if hub_cache is None:
+        reason = "default cache location could not be resolved"
+    elif not hub_ok:
+        reason = f"cache '{hub_cache}' is not writable"
+    elif xet_cache is None:
+        reason = "xet cache location could not be resolved"
+    else:
+        reason = f"xet cache '{xet_cache}' is not writable"
     # An explicitly set writable HF_XET_CACHE is kept as the user chose.
-    keep_explicit_xet = xet_ok and bool(os.environ.get("HF_XET_CACHE"))
+    keep_explicit_xet = xet_ok and "HF_XET_CACHE" in os.environ
 
     for base in _fallback_bases():
         if not _is_safe_private_dir(base):
@@ -155,7 +182,7 @@ def redirect_hf_cache_if_readonly() -> str | None:
                 continue
             os.environ["HF_XET_CACHE"] = str(base / "xet")
             warnings.warn(
-                f"Unsloth: Hugging Face xet cache '{xet_cache}' is not writable; "
+                f"Unsloth: Hugging Face {reason}; "
                 f"redirecting xet downloads to '{base / 'xet'}'.",
                 stacklevel = 2,
             )
@@ -180,15 +207,15 @@ def redirect_hf_cache_if_readonly() -> str | None:
             and old_token.is_file()
         ):
             os.environ["HF_TOKEN_PATH"] = str(old_token)
-        reason = (
-            f"cache '{hub_cache}' is not writable"
-            if hub_cache is not None
-            else "default cache location could not be resolved"
-        )
         warnings.warn(
             f"Unsloth: Hugging Face {reason}; "
             f"redirecting downloads to '{base}'.",
             stacklevel = 2,
         )
         return str(base)
+    warnings.warn(
+        f"Unsloth: Hugging Face {reason} and no writable fallback was found; "
+        f"downloads may fail. Set HF_HOME to a writable directory.",
+        stacklevel = 2,
+    )
     return None

--- a/unsloth_zoo/hf_cache.py
+++ b/unsloth_zoo/hf_cache.py
@@ -17,9 +17,9 @@
 """Redirect the Hugging Face cache when the default location is read-only.
 
 On locked-down machines the default cache (~/.cache/huggingface) is often not
-writable, so snapshot_download() fails. We probe the directory Hub writes to
-and, if it is not writable, point HF_HOME / HF_HUB_CACHE / HF_XET_CACHE at the
-first writable fallback (temp dir, then the working directory).
+writable, so snapshot_download() fails. We probe the directories Hub writes to
+and, if they are not writable, point HF_HOME / HF_HUB_CACHE / HF_XET_CACHE at
+the first writable fallback (temp dir, then the working directory).
 """
 
 from __future__ import annotations
@@ -33,9 +33,17 @@ from pathlib import Path
 __all__ = ["redirect_hf_cache_if_readonly"]
 
 
+def _expand_env_path(value: str) -> Path:
+    # Hub applies expandvars + expanduser to env-provided paths; mirror that.
+    return Path(os.path.expandvars(value)).expanduser()
+
+
 def _is_writable(path: Path) -> bool:
     # Create the dir and a throwaway file; any failure means not writable.
+    # Reject symlinks so a planted link cannot route cache writes elsewhere.
     try:
+        if path.is_symlink():
+            return False
         path.mkdir(parents = True, exist_ok = True)
         with tempfile.NamedTemporaryFile(dir = path):
             pass
@@ -49,6 +57,7 @@ def _is_safe_private_dir(path: Path) -> bool:
     # so a pre-existing dir could belong to another local user. Only accept a
     # non-symlink dir we own, and clamp it to 0700 so cached models (and the
     # token file Hub keeps under HF_HOME) are not readable by other users.
+    # The ownership check is POSIX-only; Windows temp dirs are per-user.
     try:
         path.mkdir(parents = True, exist_ok = True)
         if path.is_symlink():
@@ -80,45 +89,86 @@ def _fallback_bases() -> list[Path]:
     return bases
 
 
-def _default_caches() -> tuple[Path, Path] | None:
-    # Mirror Hub's layering: HF_HUB_CACHE, else HF_HOME/hub, else
-    # ~/.cache/huggingface/hub. Path.home() (and expanduser on "~" paths) can
+def _resolve_hf_home() -> Path | None:
+    # Mirror Hub's HF_HOME layering: HF_HOME, else XDG_CACHE_HOME/huggingface,
+    # else ~/.cache/huggingface. Path.home() (and expanduser on "~" paths) can
     # raise on locked-down machines with an unresolvable home directory; treat
     # that as "no usable default" rather than crashing import.
     try:
         hf_home_env = os.environ.get("HF_HOME")
         if hf_home_env:
-            hf_home = Path(hf_home_env).expanduser()
-        else:
-            hf_home = Path.home() / ".cache" / "huggingface"
-        hub_cache_env = os.environ.get("HF_HUB_CACHE")
-        if hub_cache_env:
-            hub_cache = Path(hub_cache_env).expanduser()
-        else:
-            hub_cache = hf_home / "hub"
-        return hf_home, hub_cache
+            return _expand_env_path(hf_home_env)
+        xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+        if xdg_cache_home:
+            return _expand_env_path(xdg_cache_home) / "huggingface"
+        return Path.home() / ".cache" / "huggingface"
     except Exception:
         return None
 
 
+def _active_caches() -> tuple[Path | None, Path | None, Path | None]:
+    # (hf_home, hub_cache, xet_cache) as Hub will resolve them. Explicit env
+    # vars are resolved first so they never depend on home resolution; the
+    # legacy HUGGINGFACE_HUB_CACHE name is still honored by Hub.
+    hf_home = _resolve_hf_home()
+    hub_cache_env = (
+        os.environ.get("HF_HUB_CACHE") or os.environ.get("HUGGINGFACE_HUB_CACHE")
+    )
+    xet_cache_env = os.environ.get("HF_XET_CACHE")
+    try:
+        if hub_cache_env:
+            hub_cache = _expand_env_path(hub_cache_env)
+        else:
+            hub_cache = hf_home / "hub" if hf_home is not None else None
+    except Exception:
+        hub_cache = None
+    try:
+        if xet_cache_env:
+            xet_cache = _expand_env_path(xet_cache_env)
+        else:
+            xet_cache = hf_home / "xet" if hf_home is not None else None
+    except Exception:
+        xet_cache = None
+    return hf_home, hub_cache, xet_cache
+
+
 def redirect_hf_cache_if_readonly() -> str | None:
     """Repoint HF_HOME and the hub/xet caches when the active hub cache is not
-    writable. Returns the new HF_HOME, or None when no change is needed."""
-    resolved = _default_caches()
-    if resolved is None:
-        hf_home = hub_cache = None
-    else:
-        hf_home, hub_cache = resolved
-        if _is_writable(hub_cache):
-            return None
+    writable; when only the xet cache is unusable, just HF_XET_CACHE moves.
+    Returns the new HF_HOME, or None when HF_HOME did not change."""
+    hf_home, hub_cache, xet_cache = _active_caches()
+    hub_ok = hub_cache is not None and _is_writable(hub_cache)
+    xet_ok = xet_cache is not None and _is_writable(xet_cache)
+    if hub_ok and xet_ok:
+        return None
+    # An explicitly set writable HF_XET_CACHE is kept as the user chose.
+    keep_explicit_xet = xet_ok and bool(os.environ.get("HF_XET_CACHE"))
+
     for base in _fallback_bases():
         if not _is_safe_private_dir(base):
             continue
-        if not (_is_writable(base / "hub") and _is_writable(base / "xet")):
+        if hub_ok:
+            # Only the xet cache is unusable. Keep the hub cache (and any
+            # already-downloaded models) where they are; move just the xet dir.
+            if not (_is_safe_private_dir(base / "xet") and _is_writable(base / "xet")):
+                continue
+            os.environ["HF_XET_CACHE"] = str(base / "xet")
+            warnings.warn(
+                f"Unsloth: Hugging Face xet cache '{xet_cache}' is not writable; "
+                f"redirecting xet downloads to '{base / 'xet'}'.",
+                stacklevel = 2,
+            )
+            return None
+        if not (_is_safe_private_dir(base / "hub") and _is_writable(base / "hub")):
+            continue
+        if not keep_explicit_xet and not (
+            _is_safe_private_dir(base / "xet") and _is_writable(base / "xet")
+        ):
             continue
         os.environ["HF_HOME"] = str(base)
         os.environ["HF_HUB_CACHE"] = str(base / "hub")
-        os.environ["HF_XET_CACHE"] = str(base / "xet")
+        if not keep_explicit_xet:
+            os.environ["HF_XET_CACHE"] = str(base / "xet")
         # Moving HF_HOME also moves Hub's default token lookup; keep a
         # readable token from the old location working.
         old_token = hf_home / "token" if hf_home is not None else None

--- a/unsloth_zoo/hf_cache.py
+++ b/unsloth_zoo/hf_cache.py
@@ -44,6 +44,23 @@ def _is_writable(path: Path) -> bool:
         return False
 
 
+def _is_safe_private_dir(path: Path) -> bool:
+    # Fallbacks live under predictable names in shared locations (e.g. /tmp),
+    # so a pre-existing dir could belong to another local user. Only accept a
+    # non-symlink dir we own, and clamp it to 0700 so cached models (and the
+    # token file Hub keeps under HF_HOME) are not readable by other users.
+    try:
+        path.mkdir(parents = True, exist_ok = True)
+        if path.is_symlink():
+            return False
+        if hasattr(os, "getuid") and path.stat().st_uid != os.getuid():
+            return False
+        os.chmod(path, 0o700)
+        return True
+    except Exception:
+        return False
+
+
 def _safe_user() -> str:
     user = os.environ.get("USER") or os.environ.get("USERNAME") or ""
     if not user and hasattr(os, "getuid"):
@@ -54,30 +71,73 @@ def _safe_user() -> str:
 def _fallback_bases() -> list[Path]:
     # Ordered writable candidates used when the default cache is read-only.
     user = _safe_user()
-    return [
-        Path(tempfile.gettempdir()) / f"huggingface_{user}",
-        Path.cwd() / ".cache" / "huggingface",
-    ]
+    bases = [Path(tempfile.gettempdir()) / f"huggingface_{user}"]
+    try:
+        bases.append(Path.cwd() / ".cache" / "huggingface")
+    except Exception:
+        # cwd can be deleted or unreadable; the temp candidate still stands.
+        pass
+    return bases
+
+
+def _default_caches() -> tuple[Path, Path] | None:
+    # Mirror Hub's layering: HF_HUB_CACHE, else HF_HOME/hub, else
+    # ~/.cache/huggingface/hub. Path.home() (and expanduser on "~" paths) can
+    # raise on locked-down machines with an unresolvable home directory; treat
+    # that as "no usable default" rather than crashing import.
+    try:
+        hf_home_env = os.environ.get("HF_HOME")
+        if hf_home_env:
+            hf_home = Path(hf_home_env).expanduser()
+        else:
+            hf_home = Path.home() / ".cache" / "huggingface"
+        hub_cache_env = os.environ.get("HF_HUB_CACHE")
+        if hub_cache_env:
+            hub_cache = Path(hub_cache_env).expanduser()
+        else:
+            hub_cache = hf_home / "hub"
+        return hf_home, hub_cache
+    except Exception:
+        return None
 
 
 def redirect_hf_cache_if_readonly() -> str | None:
     """Repoint HF_HOME and the hub/xet caches when the active hub cache is not
     writable. Returns the new HF_HOME, or None when no change is needed."""
-    hf_home = Path(
-        os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface")
-    ).expanduser()
-    hub_cache = Path(os.environ.get("HF_HUB_CACHE", hf_home / "hub")).expanduser()
-    if _is_writable(hub_cache):
-        return None
+    resolved = _default_caches()
+    if resolved is None:
+        hf_home = hub_cache = None
+    else:
+        hf_home, hub_cache = resolved
+        if _is_writable(hub_cache):
+            return None
     for base in _fallback_bases():
-        if _is_writable(base / "hub"):
-            os.environ["HF_HOME"] = str(base)
-            os.environ["HF_HUB_CACHE"] = str(base / "hub")
-            os.environ["HF_XET_CACHE"] = str(base / "xet")
-            warnings.warn(
-                f"Unsloth: Hugging Face cache '{hub_cache}' is not writable; "
-                f"redirecting downloads to '{base}'.",
-                stacklevel = 2,
-            )
-            return str(base)
+        if not _is_safe_private_dir(base):
+            continue
+        if not (_is_writable(base / "hub") and _is_writable(base / "xet")):
+            continue
+        os.environ["HF_HOME"] = str(base)
+        os.environ["HF_HUB_CACHE"] = str(base / "hub")
+        os.environ["HF_XET_CACHE"] = str(base / "xet")
+        # Moving HF_HOME also moves Hub's default token lookup; keep a
+        # readable token from the old location working.
+        old_token = hf_home / "token" if hf_home is not None else None
+        if (
+            old_token is not None
+            and "HF_TOKEN" not in os.environ
+            and "HF_TOKEN_PATH" not in os.environ
+            and old_token.is_file()
+        ):
+            os.environ["HF_TOKEN_PATH"] = str(old_token)
+        reason = (
+            f"cache '{hub_cache}' is not writable"
+            if hub_cache is not None
+            else "default cache location could not be resolved"
+        )
+        warnings.warn(
+            f"Unsloth: Hugging Face {reason}; "
+            f"redirecting downloads to '{base}'.",
+            stacklevel = 2,
+        )
+        return str(base)
     return None

--- a/unsloth_zoo/hf_cache.py
+++ b/unsloth_zoo/hf_cache.py
@@ -40,10 +40,9 @@ def _expand_env_path(value: str) -> Path:
 
 def _is_writable(path: Path) -> bool:
     # Create the dir and a throwaway file; any failure means not writable.
-    # Reject symlinks so a planted link cannot route cache writes elsewhere.
+    # Symlinks are allowed here: users legitimately symlink caches to large
+    # volumes. Fallback paths are hardened separately in _is_safe_private_dir.
     try:
-        if path.is_symlink():
-            return False
         path.mkdir(parents = True, exist_ok = True)
         with tempfile.NamedTemporaryFile(dir = path):
             pass
@@ -124,7 +123,9 @@ def _active_caches() -> tuple[Path | None, Path | None, Path | None]:
         hub_cache = None
     try:
         if xet_cache_env:
-            xet_cache = _expand_env_path(xet_cache_env)
+            # Hub reads HF_XET_CACHE literally (no expanduser/expandvars),
+            # unlike HF_HOME and HF_HUB_CACHE; probe the same literal path.
+            xet_cache = Path(xet_cache_env)
         else:
             xet_cache = hf_home / "xet" if hf_home is not None else None
     except Exception:

--- a/unsloth_zoo/hf_cache.py
+++ b/unsloth_zoo/hf_cache.py
@@ -1,0 +1,83 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Redirect the Hugging Face cache when the default location is read-only.
+
+On locked-down machines the default cache (~/.cache/huggingface) is often not
+writable, so snapshot_download() fails. We probe the directory Hub writes to
+and, if it is not writable, point HF_HOME / HF_HUB_CACHE / HF_XET_CACHE at the
+first writable fallback (temp dir, then the working directory).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import warnings
+from pathlib import Path
+
+__all__ = ["redirect_hf_cache_if_readonly"]
+
+
+def _is_writable(path: Path) -> bool:
+    # Create the dir and a throwaway file; any failure means not writable.
+    try:
+        path.mkdir(parents = True, exist_ok = True)
+        with tempfile.NamedTemporaryFile(dir = path):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+def _safe_user() -> str:
+    user = os.environ.get("USER") or os.environ.get("USERNAME") or ""
+    if not user and hasattr(os, "getuid"):
+        user = str(os.getuid())
+    return re.sub(r"[^\w.-]", "_", user) or "user"
+
+
+def _fallback_bases() -> list[Path]:
+    # Ordered writable candidates used when the default cache is read-only.
+    user = _safe_user()
+    return [
+        Path(tempfile.gettempdir()) / f"huggingface_{user}",
+        Path.cwd() / ".cache" / "huggingface",
+    ]
+
+
+def redirect_hf_cache_if_readonly() -> str | None:
+    """Repoint HF_HOME and the hub/xet caches when the active hub cache is not
+    writable. Returns the new HF_HOME, or None when no change is needed."""
+    hf_home = Path(
+        os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface")
+    ).expanduser()
+    hub_cache = Path(os.environ.get("HF_HUB_CACHE", hf_home / "hub")).expanduser()
+    if _is_writable(hub_cache):
+        return None
+    for base in _fallback_bases():
+        if _is_writable(base / "hub"):
+            os.environ["HF_HOME"] = str(base)
+            os.environ["HF_HUB_CACHE"] = str(base / "hub")
+            os.environ["HF_XET_CACHE"] = str(base / "xet")
+            warnings.warn(
+                f"Unsloth: Hugging Face cache '{hub_cache}' is not writable; "
+                f"redirecting downloads to '{base}'.",
+                stacklevel = 2,
+            )
+            return str(base)
+    return None

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2722,19 +2722,13 @@ pass
 
 def _get_hf_cache_dir() -> Optional[Path]:
     """Determines the Hugging Face Hub cache directory."""
-    potential_paths = []
-    if "HF_HUB_CACHE" in os.environ:
-        potential_paths.append(Path(os.environ["HF_HUB_CACHE"]))
-    if "HF_HOME" in os.environ:
-        potential_paths.append(Path(os.environ["HF_HOME"]) / "hub")
-    try:
-        potential_paths.append(Path.home() / ".cache" / "huggingface" / "hub")
-    except Exception:
-        # Home can be unresolvable on locked-down machines; the env-derived
-        # candidates above still apply.
-        pass
+    # Resolve through hf_cache._active_caches so cache reuse sees the same
+    # location Hub uses (XDG_CACHE_HOME, legacy HUGGINGFACE_HUB_CACHE,
+    # expanded env values, unresolvable-home handling).
+    from .hf_cache import _active_caches
+    _, cache_dir, _ = _active_caches()
 
-    for cache_dir in potential_paths:
+    if cache_dir is not None:
         try:
             if cache_dir.is_dir():
                 # Need R/W/X for HF's lock files and internal operations
@@ -2743,17 +2737,14 @@ def _get_hf_cache_dir() -> Optional[Path]:
                     return cache_dir.resolve()
                 else:
                     print(f"Warning: Found cache directory {cache_dir}, but lack R/W/X permissions. Cannot use cache.")
-                    # First prioritized path lacks permissions; stop here
                     return None
             elif cache_dir.exists():
                  # Exists but not a directory: bail
                  print(f"Warning: Path {cache_dir} exists but is not a directory. Cannot use cache.")
                  return None
-
         except Exception as e:
             # symlink loops, permission errors, etc.
-            print(f"Warning: Error accessing potential cache path {cache_dir}: {e}. Checking next option.")
-            continue
+            print(f"Warning: Error accessing potential cache path {cache_dir}: {e}.")
 
     print("No existing and accessible Hugging Face cache directory found.")
     return None

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2727,7 +2727,12 @@ def _get_hf_cache_dir() -> Optional[Path]:
         potential_paths.append(Path(os.environ["HF_HUB_CACHE"]))
     if "HF_HOME" in os.environ:
         potential_paths.append(Path(os.environ["HF_HOME"]) / "hub")
-    potential_paths.append(Path.home() / ".cache" / "huggingface" / "hub")
+    try:
+        potential_paths.append(Path.home() / ".cache" / "huggingface" / "hub")
+    except Exception:
+        # Home can be unresolvable on locked-down machines; the env-derived
+        # candidates above still apply.
+        pass
 
     for cache_dir in potential_paths:
         try:


### PR DESCRIPTION
## Summary

On locked-down machines the default Hugging Face cache (`~/.cache/huggingface`) is frequently not writable, so `snapshot_download()` fails partway through a model download. This adds an import-time probe that detects a read-only cache and transparently redirects to a writable location.

## How it works

New module `unsloth_zoo/hf_cache.py` exposes `redirect_hf_cache_if_readonly()`:

1. Resolve the directory Hub will actually write to (`HF_HUB_CACHE`, else `HF_HOME/hub`, else `~/.cache/huggingface/hub`).
2. Probe it by creating the directory and a throwaway file. If that succeeds, do nothing.
3. If it is not writable, set `HF_HOME`, `HF_HUB_CACHE`, and `HF_XET_CACHE` to the first writable fallback and warn once. Fallbacks, in order: the system temp dir (`<tmp>/huggingface_<user>`), then `<cwd>/.cache/huggingface`.

It is called from `unsloth_zoo/__init__.py` right before the existing `hf_home` block, so it runs before any `huggingface_hub` import and before the XET 429 probe picks up the cache path.

A writable default, or an explicitly set writable `HF_HUB_CACHE`, is left untouched.

## Notes

- Covers the HF hub/xet/home cache. The uv install cache (`UV_CACHE_DIR`) is a separate, install-time concern and is not touched here.
- The redirect is env-based, so as usual `import unsloth` should come before `transformers` / `huggingface_hub` for it to take effect.

## Testing

- `tests/test_hf_cache_redirect.py` (loads the module directly, no torch needed): writable default is left alone, an explicitly set writable `HF_HUB_CACHE` is honored, a read-only hub cache redirects all three vars to a writable fallback, and `_is_writable` is correct for a file-parent path. 4 passed.
- `python -m compileall` on the changed files: passes.
- `ruff check --select E9,F63,F7,F82` (the lint-ci gate): passes.
