### PR TITLE
Fix Qwen3.5 attention wrapper to accept new mlx-vlm kwargs

### DIFF
--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -511,7 +511,7 @@ def _fix_qwen35_attention_cache(model):
 
     original_attn_call = attn_cls.__call__
 
-    def patched_attn_call(self, x, mask=None, cache=None, position_ids=None):
+    def patched_attn_call(self, x, mask=None, cache=None, position_ids=None, **kwargs):
         # When training (cache=None) and position_ids=None, compute them
         if cache is None and position_ids is None:
             import mlx.core as mx
@@ -519,7 +519,7 @@ def _fix_qwen35_attention_cache(model):
             position_ids = mx.arange(L)
             position_ids = mx.expand_dims(position_ids, axis=0)
             position_ids = mx.tile(position_ids, (3, 1, 1))
-        return original_attn_call(self, x, mask=mask, cache=cache, position_ids=position_ids)
+        return original_attn_call(self, x, mask=mask, cache=cache, position_ids=position_ids, **kwargs)
 
     attn_cls.__call__ = patched_attn_call
     attn_cls._unsloth_cache_patched = True


### PR DESCRIPTION
mlx-vlm 0.6.1 added position_embeddings and target_verify kwargs to Qwen3_5Attention.__call__. The patched wrapper rejected them with a TypeError on training start.

Add **kwargs to the signature and forward to the original call. Using **kwargs instead of named params for durability as mlx-vlm frequently adds new kwargs to this interface.

Fixes #6002 (first crash)