### PR TITLE
fix(mlx): gate gemma4 kv sharing shim

### DIFF
--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -437,17 +437,35 @@ class _TrainingKVStore:
         return keys, values
 
 
+def _gemma4_has_native_shared_kv(backbone):
+    """Return whether mlx-vlm already threads Gemma4 shared K/V for training."""
+    layers = getattr(backbone, "layers", None) or []
+    previous_kvs = getattr(backbone, "previous_kvs", None)
+    if (
+        isinstance(previous_kvs, (list, tuple))
+        and layers
+        and len(previous_kvs) == len(layers)
+    ):
+        return True
+
+    try:
+        call_params = inspect.signature(backbone.__class__.__call__).parameters
+    except (TypeError, ValueError):
+        return False
+
+    return "shared_kv_sink" in call_params
+
+
 def _fix_gemma4_kv_sharing(model):
-    """Fix Gemma4 KV-shared layers producing wrong K/V during training.
+    """Fix legacy Gemma4 KV-shared layers producing wrong K/V during training.
 
     Gemma4 E2B/E4B have num_kv_shared_layers shared attention layers that
     borrow K/V from earlier "store" layers via the KV cache. When cache=None
     (training), shared layers fall through to computing their own K/V from
     the wrong hidden state — silently producing incorrect attention.
 
-    Fix: monkey-patch the text backbone's __call__ to create _TrainingKVStore
-    objects when cache=None, so store layers populate them and shared layers
-    read correct K/V.
+    mlx-vlm 0.5.0+ threads shared_kv natively; only older backbones need the
+    cache shim.
     """
     lm = getattr(model, "language_model", None)
     if lm is None:
@@ -460,6 +478,9 @@ def _fix_gemma4_kv_sharing(model):
     num_layers = getattr(backbone, "num_hidden_layers", None)
     if first_shared is None or num_layers is None or first_shared >= num_layers:
         return  # No shared layers
+
+    if _gemma4_has_native_shared_kv(backbone):
+        return  # Native mlx-vlm shared_kv support
 
     cls = backbone.__class__
     if getattr(cls, "_kv_sharing_patched", False):


### PR DESCRIPTION
This PR fixes a stale MLX Gemma4 training workaround around KV sharing.

Bug:
- `mlx-vlm < 0.5.0` needed Unsloth’s `_TrainingKVStore` shim because Gemma4 shared-KV layers still routed through cache objects during training.
- `mlx-vlm >= 0.5.0` added native Gemma4 `shared_kv` threading, so applying the old shim can interfere with the upstream path.

Root cause:
- Unsloth always applied `_fix_gemma4_kv_sharing()` for Gemma4 VLM loads and LoRA setup.
- The workaround was correct for older `mlx-vlm`, but stale once upstream introduced native shared-KV coordination in `mlx-vlm` https://github.com/Blaizzy/mlx-vlm/pull/1030 / `v0.5.0`.

Fix:
- Detect native Gemma4 shared-KV support from the loaded backbone.
- Skip the legacy `_TrainingKVStore` shim when native `shared_kv` support is present.
- Keep the shim active for older `mlx-vlm` versions such as `0.4.4`.
