### PR TITLE
fix: add audio support to UnslothVisionDataCollator

### DIFF
--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -586,7 +586,12 @@ def extract_audio_info(conversations: Union[List[Dict], List[List[Dict]]]) -> Li
             if isinstance(content, list):
                 for ele in content:
                     if isinstance(ele, dict) and ele.get("type") == "audio" and "audio" in ele:
-                        audio_inputs.append(ele["audio"])
+                        audio = ele["audio"]
+                        # HuggingFace Audio feature dict -> raw waveform
+                        if isinstance(audio, dict):
+                            audio = audio.get("array")
+                        if audio is not None:
+                            audio_inputs.append(audio)
     return audio_inputs
 
 
@@ -890,9 +895,7 @@ class UnslothVisionDataCollator:
         if audios and self.truncation and self.max_seq_length:
             seq_len = batch["input_ids"].shape[1]
             if seq_len > self.max_seq_length:
-                for key in list(batch.keys()):
-                    if isinstance(batch[key], torch.Tensor) and batch[key].shape[-1] == seq_len:
-                        batch[key] = batch[key][..., :self.max_seq_length]
+                batch = self._truncate_sequence_tensors(batch, seq_len)
 
         # Cannot remove due to bidirectional attention from Gemma 3!
         # batch.pop("token_type_ids", None)
@@ -976,19 +979,63 @@ class UnslothVisionDataCollator:
         return image, video, video_kwarg
 
     def _extract_audio_for_example(self, example, messages):
-        if "audio" in example:
-            audio_val = example["audio"]
-            if audio_val is None:
+        audio_val = example.get("audio")
+        if audio_val is None:
+            # No usable top-level audio -> fall back to inline message content
+            return extract_audio_info(messages)
+        # HuggingFace Audio feature: {"array": np.ndarray, "sampling_rate": int, ...}
+        if isinstance(audio_val, dict):
+            return [audio_val["array"]] if "array" in audio_val else []
+        if isinstance(audio_val, (list, tuple)):
+            if len(audio_val) == 0:
                 return []
-            # HuggingFace Audio feature: {"array": np.ndarray, "sampling_rate": int, ...}
-            if isinstance(audio_val, dict):
-                return [audio_val["array"]] if "array" in audio_val else []
-            # Already a list/tuple of clips
-            if isinstance(audio_val, (list, tuple)):
-                return list(audio_val)
-            # Raw ndarray or other single-clip value
-            return [audio_val]
-        return extract_audio_info(messages)
+            # A flat list of samples is one clip, not a list of clips
+            if not isinstance(audio_val[0], (dict, list, tuple)) and getattr(audio_val[0], "ndim", 0) == 0:
+                return [audio_val]
+            clips = []
+            for clip in audio_val:
+                if isinstance(clip, dict):
+                    clip = clip.get("array")
+                if clip is not None:
+                    clips.append(clip)
+            return clips
+        # Raw ndarray or other single-clip value
+        return [audio_val]
+
+    def _truncate_sequence_tensors(self, batch, seq_len):
+        # Slice only per-token tensors. Matching on shape[-1] == seq_len can clip
+        # input_features [B, frames, mel] or input_features_mask [B, frames].
+        new_len = self.max_seq_length
+        keys = [
+            k for k in ("input_ids", "attention_mask", "token_type_ids", "mm_token_type_ids")
+            if k in batch and isinstance(batch[k], torch.Tensor) and batch[k].shape[-1] == seq_len
+        ]
+        tok = getattr(self.processor, "tokenizer", self.processor)
+        audio_tokens = list(AUDIO_TOKENS)
+        if getattr(tok, "audio_token", None) is not None:
+            audio_tokens.append(tok.audio_token)
+        audio_ids = torch.tensor(
+            [i for i in tok.convert_tokens_to_ids(audio_tokens) if isinstance(i, int) and i >= 0],
+            device=batch["input_ids"].device,
+        )
+        n_audio = int(torch.isin(batch["input_ids"], audio_ids).sum())
+        if self._tokenizer_padding_side() == "left":
+            # Keep each row's first new_len content tokens and re-pad on the left,
+            # otherwise short rows keep only their left padding.
+            lengths = batch["attention_mask"].sum(-1)
+            starts = seq_len - torch.clamp(lengths, min=new_len)
+            gather_idx = starts.unsqueeze(1) + torch.arange(new_len, device=starts.device)
+            for k in keys:
+                batch[k] = torch.gather(batch[k], 1, gather_idx)
+        else:
+            for k in keys:
+                batch[k] = batch[k][..., :new_len]
+        if int(torch.isin(batch["input_ids"], audio_ids).sum()) != n_audio:
+            raise ValueError(
+                f"Unsloth: max_seq_length = {new_len} cuts into the expanded audio tokens, which "
+                "breaks audio alignment at model forward. Increase max_seq_length or shorten the audio."
+            )
+        return batch
 
     def _extract_images_for_pc(self, example, p_msgs, c_msgs):
         # PC: prefer embedded across prompt+completion; else top-level first image; else []
@@ -1257,6 +1304,11 @@ class UnslothVisionDataCollator:
                     vids_kwarg = {"fps": []}
                 video_kwargs['fps'].extend(vids_kwarg['fps'])
 
+            if is_c_msgs and extract_audio_info(c):
+                raise ValueError(
+                    "Unsloth: audio inside `completion` is not supported yet. "
+                    "Move the audio content parts into `prompt`."
+                )
             audio = self._extract_audio_for_example(ex, p if is_p_msgs else [])
             audios.extend(audio)
 

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -858,14 +858,21 @@ class UnslothVisionDataCollator:
             audios.extend(audio)
 
         # Tokenize the texts and process the images
+        # When audio is present, omit max_length/truncation from the top-level processor
+        # call — passing them at top-level causes _merge_kwargs to broadcast them into
+        # audio_kwargs, which makes the audio feature extractor truncate the waveform to
+        # max_length *samples* (e.g. 512 samples = 32ms) instead of leaving it intact.
+        # We truncate input_ids manually after the call instead.
         proc_kwargs = dict(
             text=texts,
             padding=True,
-            truncation=self.truncation,
-            max_length=self.max_seq_length,
             return_tensors="pt",
             add_special_tokens=False,
         )
+        if not audios:
+            # Safe to pass truncation kwargs top-level when no audio is involved
+            proc_kwargs["truncation"] = self.truncation
+            proc_kwargs["max_length"] = self.max_seq_length
         if images:
             proc_kwargs["images"] = images
         if videos:
@@ -878,6 +885,14 @@ class UnslothVisionDataCollator:
         if self.pad_to_multiple_of is not None:
             proc_kwargs["pad_to_multiple_of"] = self.pad_to_multiple_of
         batch = self.processor(**proc_kwargs)
+
+        # Truncate manually when audio is present (couldn't pass max_length to processor)
+        if audios and self.truncation and self.max_seq_length:
+            seq_len = batch["input_ids"].shape[1]
+            if seq_len > self.max_seq_length:
+                for key in list(batch.keys()):
+                    if isinstance(batch[key], torch.Tensor) and batch[key].shape[-1] == seq_len:
+                        batch[key] = batch[key][..., :self.max_seq_length]
 
         # Cannot remove due to bidirectional attention from Gemma 3!
         # batch.pop("token_type_ids", None)
@@ -1245,15 +1260,15 @@ class UnslothVisionDataCollator:
             audio = self._extract_audio_for_example(ex, p if is_p_msgs else [])
             audios.extend(audio)
 
-        prompt_kwargs = dict(
-            padding=True,
-            padding_side="left",
-            return_tensors="pt",
-            add_special_tokens=False,
-        )
         completion_kwargs = dict(
             padding=True,
             padding_side="right",
+            return_tensors="pt",
+            add_special_tokens=False,
+        )
+        prompt_kwargs = dict(
+            padding=True,
+            padding_side="left",
             return_tensors="pt",
             add_special_tokens=False,
         )

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -53,6 +53,10 @@ IMAGE_TOKENS = [
     "<|IMG_PATCH|>",      # Cohere
 ]
 
+AUDIO_TOKENS = [
+    "<|audio|>",  # Gemma 4
+]
+
 import torch
 from PIL import Image
 import base64
@@ -570,6 +574,21 @@ def extract_vision_info(conversations: Union[List[Dict], List[List[Dict]]]) -> L
     return vision_infos
 
 
+def extract_audio_info(conversations: Union[List[Dict], List[List[Dict]]]) -> List:
+    audio_inputs = []
+    if len(conversations) == 0:
+        return audio_inputs
+    if isinstance(conversations[0], dict):
+        conversations = [conversations]
+    for conversation in conversations:
+        for message in conversation:
+            if isinstance(message["content"], list):
+                for ele in message["content"]:
+                    if ele.get("type") == "audio" and "audio" in ele:
+                        audio_inputs.append(ele["audio"])
+    return audio_inputs
+
+
 def process_vision_info(
     conversations: Union[List[Dict], List[List[Dict]]],
     size_factor: int = IMAGE_FACTOR,
@@ -602,14 +621,16 @@ def process_vision_info(
 
 
 def get_padding_tokens_ids(tokenizer):
-    global IMAGE_TOKENS
+    global IMAGE_TOKENS, AUDIO_TOKENS
 
     tokenizer = tokenizer.tokenizer if hasattr(tokenizer, "tokenizer") else tokenizer
-    image_tokens = IMAGE_TOKENS
+    placeholder_tokens = IMAGE_TOKENS + AUDIO_TOKENS
     if hasattr(tokenizer, "image_token"):
-        image_tokens = IMAGE_TOKENS + [tokenizer.image_token]
+        placeholder_tokens = placeholder_tokens + [tokenizer.image_token]
+    if hasattr(tokenizer, "audio_token"):
+        placeholder_tokens = placeholder_tokens + [tokenizer.audio_token]
 
-    padding_token_ids = tokenizer.convert_tokens_to_ids(image_tokens)
+    padding_token_ids = tokenizer.convert_tokens_to_ids(placeholder_tokens)
     if hasattr(tokenizer, "pad_token_id"):
         padding_token_ids.append(tokenizer.pad_token_id)
 
@@ -799,6 +820,7 @@ class UnslothVisionDataCollator:
         texts  = []
         images = []
         videos = []
+        audios = []
         video_kwargs = {'fps': []}
         for example in examples:
             messages = self._select_messages_or_raw(example)
@@ -831,6 +853,9 @@ class UnslothVisionDataCollator:
                     video_kwarg = {"fps": []}
                 video_kwargs['fps'].extend(video_kwarg['fps'])
 
+            audio = self._extract_audio_for_example(example, messages)
+            audios.extend(audio)
+
         # Tokenize the texts and process the images
         proc_kwargs = dict(
             text=texts,
@@ -847,6 +872,8 @@ class UnslothVisionDataCollator:
             video_kwargs["fps"] = collapse_fps(video_kwargs['fps'])
             for k, v in video_kwargs.items():
                 proc_kwargs[k] = v
+        if audios:
+            proc_kwargs["audio"] = audios
         if self.pad_to_multiple_of is not None:
             proc_kwargs["pad_to_multiple_of"] = self.pad_to_multiple_of
         batch = self.processor(**proc_kwargs)
@@ -931,6 +958,11 @@ class UnslothVisionDataCollator:
             if image is None: image = []
             if video is None: video = []
         return image, video, video_kwarg
+
+    def _extract_audio_for_example(self, example, messages):
+        if "audio" in example:
+            return list(example["audio"])
+        return extract_audio_info(messages)
 
     def _extract_images_for_pc(self, example, p_msgs, c_msgs):
         # PC: prefer embedded across prompt+completion; else top-level first image; else []

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -582,9 +582,10 @@ def extract_audio_info(conversations: Union[List[Dict], List[List[Dict]]]) -> Li
         conversations = [conversations]
     for conversation in conversations:
         for message in conversation:
-            if isinstance(message["content"], list):
-                for ele in message["content"]:
-                    if ele.get("type") == "audio" and "audio" in ele:
+            content = message.get("content")
+            if isinstance(content, list):
+                for ele in content:
+                    if isinstance(ele, dict) and ele.get("type") == "audio" and "audio" in ele:
                         audio_inputs.append(ele["audio"])
     return audio_inputs
 
@@ -961,7 +962,17 @@ class UnslothVisionDataCollator:
 
     def _extract_audio_for_example(self, example, messages):
         if "audio" in example:
-            return list(example["audio"])
+            audio_val = example["audio"]
+            if audio_val is None:
+                return []
+            # HuggingFace Audio feature: {"array": np.ndarray, "sampling_rate": int, ...}
+            if isinstance(audio_val, dict):
+                return [audio_val["array"]] if "array" in audio_val else []
+            # Already a list/tuple of clips
+            if isinstance(audio_val, (list, tuple)):
+                return list(audio_val)
+            # Raw ndarray or other single-clip value
+            return [audio_val]
         return extract_audio_info(messages)
 
     def _extract_images_for_pc(self, example, p_msgs, c_msgs):

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1195,7 +1195,7 @@ class UnslothVisionDataCollator:
         return [input_ids, attention_mask, completion_mask] + ([token_type_ids] if token_type_ids is not None else [])
 
     def _collate_prompt_completion(self, examples):
-        prompt_texts, completion_texts, images, videos = [], [], [], []
+        prompt_texts, completion_texts, images, videos, audios = [], [], [], [], []
         video_kwargs = {'fps': []}
 
         for ex in examples:
@@ -1242,6 +1242,9 @@ class UnslothVisionDataCollator:
                     vids_kwarg = {"fps": []}
                 video_kwargs['fps'].extend(vids_kwarg['fps'])
 
+            audio = self._extract_audio_for_example(ex, p if is_p_msgs else [])
+            audios.extend(audio)
+
         prompt_kwargs = dict(
             padding=True,
             padding_side="left",
@@ -1261,6 +1264,8 @@ class UnslothVisionDataCollator:
             video_kwargs["fps"] = collapse_fps(video_kwargs['fps'])
             for k, v in video_kwargs.items():
                 prompt_kwargs[k] = v
+        if audios:
+            prompt_kwargs["audio"] = audios
 
         proc_prompts = self.processor(text=prompt_texts, **prompt_kwargs)
         # Encode completions (RIGHT pad) text-only


### PR DESCRIPTION
## Summary

- `UnslothVisionDataCollator` silently dropped `{"type": "audio"}` content parts — `extract_vision_info` only matched `image`/`image_url`/`video`, so audio-only batches produced no `input_features` and the audio encoder never ran
- Add `AUDIO_TOKENS` list (`<|audio|>` for Gemma 4) and include them in `get_padding_tokens_ids` so audio placeholder tokens are correctly masked in labels
- Add `extract_audio_info` to pull audio arrays out of message content parts
- Add `_extract_audio_for_example` method on the collator (checks top-level `example["audio"]` column first, falls back to inline extraction)
- Wire audio collection into `__call__` and pass `audio=` to the processor so the audio encoder actually runs

Fixes: https://github.com/unslothai/unsloth/issues/6004

## Test plan

- [x] Run the standalone repro from issue #6004 — `input_features` should now be present in the batch
- [x] Verify `<|audio|>` tokens are masked (`-100`) in labels, not trained as text
- [ ] Smoke test Gemma 4 E2B/E4B SFT with an audio dataset under `SFTTrainer`