### PR TITLE
Restore #588 and #659 (revert the accidental merge-revert)

### DIFF
--- a/tests/test_gemma4_clippable_linear_peft_reload.py
+++ b/tests/test_gemma4_clippable_linear_peft_reload.py
@@ -1,0 +1,43 @@
+import sys
+import types
+
+import torch
+
+
+def test_gemma4_clippable_linear_peft_reload_patch(monkeypatch):
+    from peft.tuners.lora.model import LoraModel
+    from unsloth_zoo.temporary_patches.gemma4 import patch_Gemma4ClippableLinear_peft_reload
+
+    class Gemma4ClippableLinear(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 2)
+
+    fake_module = types.ModuleType("transformers.models.gemma4.modeling_gemma4")
+    fake_module.Gemma4ClippableLinear = Gemma4ClippableLinear
+    monkeypatch.setitem(sys.modules, "transformers.models.gemma4.modeling_gemma4", fake_module)
+
+    calls = []
+
+    def original(self, peft_config, adapter_name, target, target_name, parent, current_key=None, **kwargs):
+        calls.append((target, target_name, parent, current_key, kwargs))
+        return "created"
+
+    monkeypatch.setattr(LoraModel, "_create_and_replace", original)
+
+    patch_Gemma4ClippableLinear_peft_reload()
+    patched = LoraModel._create_and_replace
+
+    target = Gemma4ClippableLinear()
+    assert patched(None, None, "default", target, "q_proj", object(), current_key="model.q_proj") == "created"
+    assert calls[-1][0] is target.linear
+    assert calls[-1][1] == "linear"
+    assert calls[-1][2] is target
+    assert calls[-1][3] == "model.q_proj"
+
+    ordinary = torch.nn.Linear(2, 2)
+    parent = object()
+    assert patched(None, None, "default", ordinary, "q_proj", parent, current_key="model.q_proj") == "created"
+    assert calls[-1][0] is ordinary
+    assert calls[-1][1] == "q_proj"
+    assert calls[-1][2] is parent

--- a/tests/test_moe_grouped_mm_alignment_fallback.py
+++ b/tests/test_moe_grouped_mm_alignment_fallback.py
@@ -1,0 +1,46 @@
+import pytest
+import torch
+
+
+def test_grouped_mm_alignment_fallback_is_differentiable(monkeypatch):
+    from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
+
+    inputs = torch.randn(5, 4, requires_grad=True)
+    weight = torch.randn(3, 4, 2, requires_grad=True)
+    offsets = torch.tensor([2, 2, 5], dtype=torch.int32)
+
+    def raise_alignment_error(*args, **kwargs):
+        raise RuntimeError("strides should be multiple of 16 bytes")
+
+    monkeypatch.setattr(torch, "_grouped_mm", raise_alignment_error, raising=False)
+
+    actual = _grouped_mm_with_backward_fix(inputs, weight, offsets)
+    expected = torch.cat(
+        [
+            inputs[:2] @ weight[0],
+            inputs[2:5] @ weight[2],
+        ],
+        dim=0,
+    )
+
+    torch.testing.assert_close(actual, expected)
+    actual.square().sum().backward()
+    assert inputs.grad is not None
+    assert weight.grad is not None
+
+
+def test_grouped_mm_alignment_fallback_reraises_other_errors(monkeypatch):
+    from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
+
+    inputs = torch.randn(1, 4)
+    weight = torch.randn(1, 4, 2)
+    offsets = torch.tensor([1], dtype=torch.int32)
+
+    def raise_shape_error(*args, **kwargs):
+        raise RuntimeError("matmul shape mismatch")
+
+    monkeypatch.setattr(torch, "_grouped_mm", raise_shape_error, raising=False)
+
+    with pytest.raises(RuntimeError, match="shape mismatch"):
+        _grouped_mm_with_backward_fix(inputs, weight, offsets)
+

--- a/tests/test_moe_quant_cleanup.py
+++ b/tests/test_moe_quant_cleanup.py
@@ -1,0 +1,188 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Structural pins for the PR #659 cleanup.
+
+These tests don't exercise the FP8 / bnb4bit forward kernels — that's the
+job of the existing MoE integration tests. They lock in the structural
+invariants we relied on while restructuring:
+
+1. The post-load FP8 scale reattach machinery (which never had a caller)
+   is gone.
+2. _call_with_temporary_moe_weights has been unified in moe_utils and
+   removed from both moe_utils_fp8 and moe_utils_bnb4bit.
+3. The PEFT bnb4bit MoE merge/unmerge patches live alongside the rest
+   of the bnb4bit code, not in misc.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+_DEAD_FP8_REATTACH_SYMBOLS = (
+    "_maybe_patch_glm4_stacked_moe_fp8_scales",
+    "_do_glm4_scale_patching",
+    "maybe_patch_stacked_moe_expert_fp8_scales",
+    "_maybe_attach_dropped_moe_fp8_scales",
+    "_attach_stacked_scales",
+    "_attach_per_expert_scales",
+    "_annotate_block_size",
+    "_resolve_safetensors_shards",
+)
+
+
+def test_dead_fp8_reattach_machinery_is_gone():
+    from unsloth_zoo.temporary_patches import moe_utils_fp8
+    leftover = [s for s in _DEAD_FP8_REATTACH_SYMBOLS if hasattr(moe_utils_fp8, s)]
+    assert not leftover, f"dead FP8 reattach symbols still present: {leftover}"
+
+
+def test_moe_utils_fp8_does_not_open_safetensors_at_load_time():
+    """The deleted reattach path was the only consumer of safetensors /
+    hf_hub_download inside moe_utils_fp8 (load-time, after-the-fact). After
+    cleanup, nothing in this module reopens checkpoint shards."""
+    from pathlib import Path
+    import unsloth_zoo.temporary_patches.moe_utils_fp8 as m
+    src = Path(m.__file__).read_text()
+    forbidden = ("safetensors.safe_open", "hf_hub_download", "safetensors.torch")
+    for needle in forbidden:
+        assert needle not in src, (
+            f"moe_utils_fp8.py still mentions {needle!r}; "
+            "the post-load reattach machinery should have been removed."
+        )
+
+
+def test_call_with_temporary_moe_weights_unified():
+    """One canonical helper in moe_utils; FP8 and bnb4bit import it."""
+    from unsloth_zoo.temporary_patches import moe_utils, moe_utils_fp8, moe_utils_bnb4bit
+
+    assert callable(getattr(moe_utils, "swap_moe_weights_for_call", None))
+    assert not hasattr(moe_utils_fp8, "_call_with_temporary_moe_weights")
+    assert not hasattr(moe_utils_bnb4bit, "_call_with_temporary_moe_weights")
+
+
+def test_peft_bnb4bit_moe_patches_live_in_moe_utils_bnb4bit():
+    """The three PEFT-bnb4bit helpers moved out of misc.py."""
+    from unsloth_zoo.temporary_patches import misc, moe_utils_bnb4bit
+
+    moved = (
+        "_ParamShapeProxy",
+        "patch_peft_param_wrapper_4bit_expert_shape",
+        "patch_peft_param_wrapper_merge_4bit",
+    )
+    for sym in moved:
+        assert hasattr(moe_utils_bnb4bit, sym), f"missing in moe_utils_bnb4bit: {sym}"
+        assert not hasattr(misc, sym), f"still in misc.py: {sym}"
+
+
+def test_temporary_patches_register_expected_count():
+    """Phase 3 must NOT silently drop a TEMPORARY_PATCHES.append entry.
+    moe_utils_bnb4bit now registers 3 more patches than before."""
+    from unsloth_zoo.temporary_patches import moe_utils_bnb4bit
+    import inspect
+
+    src = inspect.getsource(moe_utils_bnb4bit)
+    # Count is sticky to the file; if Phase 3 forgets the .append, we drop one.
+    count = src.count("TEMPORARY_PATCHES.append(")
+    assert count == 6, (
+        f"moe_utils_bnb4bit registers {count} patches; expected 6 "
+        "(4 original bnb4bit patches + the 2 PEFT MoE patches relocated from misc.py)."
+    )
+
+
+def test_transformers_v5_moe_quant_gate_false_without_param_needs_quantization(monkeypatch):
+    """Transformers v4-style Bnb4BitHfQuantizer has no v5 quantization gate.
+    PR #659's v5-only patch set must not register for that API shape."""
+    from transformers.quantizers import quantizer_bnb_4bit
+    from unsloth_zoo.temporary_patches import common
+
+    class V4StyleBnb4BitHfQuantizer:
+        pass
+
+    monkeypatch.setattr(
+        quantizer_bnb_4bit,
+        "Bnb4BitHfQuantizer",
+        V4StyleBnb4BitHfQuantizer,
+    )
+    common.is_transformers_v5_moe_quantization_available.cache_clear()
+    try:
+        assert common.is_transformers_v5_moe_quantization_available() is False
+    finally:
+        common.is_transformers_v5_moe_quantization_available.cache_clear()
+
+
+def test_bnb4bit_param_needs_quantization_patch_noops_when_hook_absent(monkeypatch):
+    """The direct traceback was an AttributeError on this missing hook."""
+    from transformers.quantizers import quantizer_bnb_4bit
+    from unsloth_zoo.temporary_patches import moe_utils_bnb4bit
+
+    class V4StyleBnb4BitHfQuantizer:
+        pass
+
+    monkeypatch.setattr(
+        quantizer_bnb_4bit,
+        "Bnb4BitHfQuantizer",
+        V4StyleBnb4BitHfQuantizer,
+    )
+
+    moe_utils_bnb4bit.patch_bnb4bit_quantizer_param_needs_quantization()
+    assert not hasattr(V4StyleBnb4BitHfQuantizer, "param_needs_quantization")
+
+
+def test_v5_moe_quant_registration_helpers_respect_gate(monkeypatch):
+    """If capability detection says v4/non-v5, registration must be a no-op."""
+    from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
+    from unsloth_zoo.temporary_patches import moe_utils_bnb4bit, moe_utils_fp8
+
+    before = list(TEMPORARY_PATCHES)
+    monkeypatch.setattr(
+        moe_utils_bnb4bit,
+        "is_transformers_v5_moe_quantization_available",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        moe_utils_fp8,
+        "is_transformers_v5_moe_quantization_available",
+        lambda: False,
+    )
+
+    moe_utils_bnb4bit._register_transformers_v5_moe_bnb4bit_patches()
+    moe_utils_fp8._register_transformers_v5_moe_fp8_patches()
+    assert TEMPORARY_PATCHES == before
+
+
+def test_v5_moe_quant_patches_registered_when_capability_exists():
+    """On the v5 API shape, PR #659's v5-only patches remain active."""
+    from unsloth_zoo.temporary_patches import common, moe_utils_bnb4bit, moe_utils_fp8
+
+    common.is_transformers_v5_moe_quantization_available.cache_clear()
+    if not common.is_transformers_v5_moe_quantization_available():
+        pytest.skip("Transformers v5 MoE quantization APIs are not available")
+
+    expected = {
+        moe_utils_bnb4bit.patch_bnb4bit_quantize_convert,
+        moe_utils_bnb4bit.patch_bnb4bit_quantizer_param_needs_quantization,
+        moe_utils_bnb4bit.patch_bnb4bit_quantizer_process_model,
+        moe_utils_bnb4bit.patch_transformers_weight_converter_kwargs,
+        moe_utils_bnb4bit.patch_peft_param_wrapper_4bit_expert_shape,
+        moe_utils_bnb4bit.patch_peft_param_wrapper_merge_4bit,
+        moe_utils_fp8.patch_fp8_experts_interface,
+        moe_utils_fp8.patch_fp8_validate_quantization_for_training,
+    }
+    registered = set(common.TEMPORARY_PATCHES)
+    missing = expected - registered
+    assert not missing, f"v5 MoE quant patch(es) not registered: {missing}"

--- a/tests/test_moe_quant_handler_registry.py
+++ b/tests/test_moe_quant_handler_registry.py
@@ -1,0 +1,179 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Save-side MoE quant handler registry: FP8 dequant/requant lives in
+moe_utils_fp8.py and saving_utils.py consults it via apply_moe_quant_load.
+
+These tests pin the wiring (no inline FP8 helpers in saving_utils anymore),
+exercise the FP8 round-trip end-to-end with a synthetic safetensors-like
+file, and lock in the _MOE_QUANT_UNSAFE sentinel path for the missing-scale
+case.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def test_saving_utils_uses_registry_not_inline_helpers():
+    """saving_utils.py must NOT redefine FP8 dequant/requant locally; those
+    helpers live in moe_utils_fp8.py and are imported in."""
+    from unsloth_zoo import saving_utils
+
+    # Inline FP8 helpers removed from saving_utils.
+    for sym in (
+        "_FP8_E4M3_MAX",
+        "_fp8_dequant_blockwise",
+        "_fp8_requant_blockwise",
+        "_FP8_MERGE_UNSAFE",
+        "_fp8_load_for_merge",
+    ):
+        assert not hasattr(saving_utils, sym), (
+            f"saving_utils still defines {sym!r}; it should live in moe_utils_fp8."
+        )
+
+    # Registry entry points wired in.
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import (
+        apply_moe_quant_load,
+        _MOE_QUANT_UNSAFE,
+    )
+    assert saving_utils._apply_moe_quant_load is apply_moe_quant_load
+    assert saving_utils._MOE_QUANT_UNSAFE is _MOE_QUANT_UNSAFE
+    assert callable(saving_utils._merge_moe_expert_quant_aware)
+
+
+def test_registry_contains_fp8_handler():
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import (
+        _MOE_QUANT_HANDLERS,
+        _fp8_save_handler,
+    )
+    assert _fp8_save_handler in _MOE_QUANT_HANDLERS
+
+
+def _build_fake_fp8_file():
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import _fp8_requant_blockwise
+
+    torch.manual_seed(0)
+    W_real = (torch.randn(128, 256, dtype=torch.float32) * 0.1)
+    W_fp8, scale_inv = _fp8_requant_blockwise(W_real, (64, 128), torch.bfloat16)
+
+    class FakeFile:
+        def __init__(self, tensors):
+            self._tensors = tensors
+
+        def get_tensor(self, key):
+            return self._tensors[key]
+
+    header = {
+        "X.weight":             {"dtype": "F8_E4M3"},
+        "X.weight_scale_inv":   {"dtype": "BF16"},
+    }
+    file = FakeFile({"X.weight": W_fp8, "X.weight_scale_inv": scale_inv})
+    return W_real, W_fp8, scale_inv, header, file
+
+
+def test_fp8_handler_roundtrip_identity_merge():
+    """Identity 'merge' (no LoRA delta) must round-trip the FP8 weight
+    bytes within the FP8 quantization error budget."""
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import (
+        _fp8_save_handler,
+        _fp8_dequant_blockwise,
+        _MOE_QUANT_UNSAFE,
+    )
+    W_real, W_fp8, scale_inv, header, file = _build_fake_fp8_file()
+
+    loaded = _fp8_save_handler(file, header, "X.weight")
+    assert loaded is not None
+    W_bf16, requant = loaded
+    assert W_bf16 is not _MOE_QUANT_UNSAFE
+    assert W_bf16.dtype == torch.bfloat16
+    assert tuple(W_bf16.shape) == tuple(W_fp8.shape)
+
+    new_fp8, write_dtype, extras = requant(W_bf16)
+    assert write_dtype == torch.float8_e4m3fn
+    assert len(extras) == 1
+    scale_key, new_scale, scale_dtype = extras[0]
+    assert scale_key == "X.weight_scale_inv"
+    assert scale_dtype == torch.bfloat16
+    assert tuple(new_scale.shape) == tuple(scale_inv.shape)
+
+    # Round-trip drift bound: dequant -> requant of bf16 dequant should be
+    # tight enough that re-dequantising stays within 2x the single-pass FP8
+    # quantisation budget.
+    re_dequant = _fp8_dequant_blockwise(new_fp8, new_scale)
+    max_err = (re_dequant.to(torch.float32) - W_real).abs().max().item()
+    assert max_err < 0.05, f"round-trip drift too large: {max_err}"
+
+
+def test_fp8_handler_returns_sentinel_when_scale_missing():
+    """When the companion scale is absent, the handler must surface the
+    _MOE_QUANT_UNSAFE sentinel so saving_utils skips the merge."""
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import (
+        _fp8_save_handler,
+        _fp8_requant_blockwise,
+        _MOE_QUANT_UNSAFE,
+    )
+
+    W_real = (torch.randn(64, 128, dtype=torch.float32) * 0.1)
+    W_fp8, _scale = _fp8_requant_blockwise(W_real, (32, 64), torch.bfloat16)
+
+    class FakeFile:
+        def __init__(self, tensors):
+            self._tensors = tensors
+
+        def get_tensor(self, key):
+            return self._tensors[key]
+
+    header = {"Y.weight": {"dtype": "F8_E4M3"}}
+    file = FakeFile({"Y.weight": W_fp8})
+
+    result = _fp8_save_handler(file, header, "Y.weight")
+    assert result == (_MOE_QUANT_UNSAFE, None)
+
+
+def test_fp8_handler_returns_none_for_non_fp8_keys():
+    """Non-FP8 tensors must be ignored so the generic loader path takes over."""
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import _fp8_save_handler
+
+    class FakeFile:
+        def get_tensor(self, key):
+            return torch.randn(8, 8, dtype=torch.bfloat16)
+
+    # dtype hint is bf16 → handler bails without touching the file.
+    header = {"Z.weight": {"dtype": "BF16"}}
+    assert _fp8_save_handler(FakeFile(), header, "Z.weight") is None
+
+
+def test_apply_moe_quant_load_dispatch():
+    """apply_moe_quant_load consults handlers in order and falls back to
+    file.get_tensor(key) when no handler matches."""
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import apply_moe_quant_load
+
+    class FakeFile:
+        def __init__(self):
+            self.calls = []
+
+        def get_tensor(self, key):
+            self.calls.append(key)
+            return torch.tensor([1.0, 2.0, 3.0])
+
+    file = FakeFile()
+    header = {"plain.weight": {"dtype": "BF16"}}
+    W, requant = apply_moe_quant_load(file, header, "plain.weight")
+    assert requant is None
+    assert torch.equal(W, torch.tensor([1.0, 2.0, 3.0]))
+    assert file.calls == ["plain.weight"]

--- a/tests/test_saving_utils_quant_aware_merge.py
+++ b/tests/test_saving_utils_quant_aware_merge.py
@@ -1,0 +1,186 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""End-to-end behaviour for `_merge_moe_expert_quant_aware`.
+
+The registry inversion pushed FP8 dequant/requant out of saving_utils into
+moe_utils_fp8. These tests pin both legs:
+
+- bf16 base weight: the helper writes the merged tensor unchanged in shape,
+  no companion-scale write, no fallback recorded.
+- FP8 base weight: the helper dequantises, applies the LoRA merge in bf16,
+  requantises back to FP8, writes the data tensor AND the companion
+  weight_scale_inv to the output mm.
+- FP8 base without companion scale: the helper records a merge fallback
+  and skips writing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+
+@dataclass
+class _FakeLoraStats:
+    lora_A: torch.Tensor = None
+    lora_B: torch.Tensor = None
+    scaling: float = 1.0
+    module: object = None
+
+
+class _FakeFile:
+    def __init__(self, tensors):
+        self._tensors = tensors
+
+    def get_tensor(self, key):
+        return self._tensors[key]
+
+
+class _FakeMM:
+    """Stand-in for the mmap-backed safetensors output. Collects writes so
+    we can assert on them."""
+
+    def __init__(self):
+        self.writes = []  # list of (key, tensor, dtype) tuples
+
+
+def _identity_merge(W, lora_stats, expert_idx, num_experts, output_dtype):
+    """Stand-in 'merge' that returns the input unchanged. Lets us pin the
+    quant-aware wrapper without depending on the real LoRA math."""
+    return W.to(output_dtype)
+
+
+@pytest.fixture(autouse=True)
+def _stub_write_tensor_direct_torch(monkeypatch):
+    """`_write_tensor_direct_torch` does real safetensors header arithmetic on
+    a torch storage; for these tests we just capture (key, tensor, dtype)."""
+    from unsloth_zoo import saving_utils
+
+    def _capture(mm, header_metadata, length_of_header, key, tensor, dtype):
+        mm.writes.append((key, tensor.detach().clone(), dtype))
+
+    monkeypatch.setattr(saving_utils, "_write_tensor_direct_torch", _capture)
+    yield
+
+
+def _make_header_for(keys_to_dtype):
+    return {k: {"dtype": d} for k, d in keys_to_dtype.items()}
+
+
+def test_bf16_weight_writes_only_the_merged_tensor():
+    from unsloth_zoo.saving_utils import _merge_moe_expert_quant_aware
+
+    W = torch.randn(64, 128, dtype=torch.bfloat16)
+    file = _FakeFile({"layer.0.experts.0.gate_proj.weight": W})
+    hdr = _make_header_for({"layer.0.experts.0.gate_proj.weight": "BF16"})
+    mm = _FakeMM()
+
+    ok = _merge_moe_expert_quant_aware(
+        "gate", "layer.0.experts.0.gate_proj.weight", file, hdr, _FakeLoraStats(),
+        0, 1, None, mm, 0, set(), _identity_merge,
+    )
+    assert ok is True
+    assert len(mm.writes) == 1
+    written_key, written_tensor, written_dtype = mm.writes[0]
+    assert written_key == "layer.0.experts.0.gate_proj.weight"
+    assert written_dtype == torch.bfloat16
+    assert torch.equal(written_tensor.to(torch.bfloat16), W)
+
+
+def test_fp8_weight_writes_data_and_scale():
+    from unsloth_zoo.saving_utils import _merge_moe_expert_quant_aware
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import _fp8_requant_blockwise
+
+    torch.manual_seed(0)
+    W_real = torch.randn(128, 256, dtype=torch.float32) * 0.1
+    W_fp8, scale_inv = _fp8_requant_blockwise(W_real, (64, 128), torch.bfloat16)
+
+    file = _FakeFile({
+        "layer.0.experts.0.gate_proj.weight":           W_fp8,
+        "layer.0.experts.0.gate_proj.weight_scale_inv": scale_inv,
+    })
+    hdr = _make_header_for({
+        "layer.0.experts.0.gate_proj.weight":           "F8_E4M3",
+        "layer.0.experts.0.gate_proj.weight_scale_inv": "BF16",
+    })
+    mm = _FakeMM()
+
+    ok = _merge_moe_expert_quant_aware(
+        "gate", "layer.0.experts.0.gate_proj.weight", file, hdr, _FakeLoraStats(),
+        0, 1, None, mm, 0, set(), _identity_merge,
+    )
+    assert ok is True
+
+    # Two writes: the scale companion first (extra_writes), then the data.
+    assert len(mm.writes) == 2
+    keys = [w[0] for w in mm.writes]
+    assert keys == [
+        "layer.0.experts.0.gate_proj.weight_scale_inv",
+        "layer.0.experts.0.gate_proj.weight",
+    ]
+    _, scale_written, scale_dtype = mm.writes[0]
+    assert scale_dtype == torch.bfloat16
+    assert tuple(scale_written.shape) == tuple(scale_inv.shape)
+    _, data_written, data_dtype = mm.writes[1]
+    assert data_dtype == torch.float8_e4m3fn
+    assert tuple(data_written.shape) == tuple(W_fp8.shape)
+
+
+def test_fp8_weight_missing_scale_records_fallback_and_skips_write():
+    from unsloth_zoo import saving_utils
+    from unsloth_zoo.saving_utils import _merge_moe_expert_quant_aware
+
+    # Sentinel-trigger: FP8 weight in header but NO companion scale key.
+    fp8 = torch.zeros(64, 128, dtype=torch.float8_e4m3fn)
+    file = _FakeFile({"layer.0.experts.0.down_proj.weight": fp8})
+    hdr = _make_header_for({"layer.0.experts.0.down_proj.weight": "F8_E4M3"})
+    mm = _FakeMM()
+
+    fallback_log = []
+
+    def _capture_fallback(*args, **kwargs):
+        fallback_log.append((args, kwargs))
+
+    # Patch in-place on the module to observe.
+    original = saving_utils._record_moe_merge_fallback
+    saving_utils._record_moe_merge_fallback = _capture_fallback
+    try:
+        ok = _merge_moe_expert_quant_aware(
+            "down", "layer.0.experts.0.down_proj.weight", file, hdr, _FakeLoraStats(),
+            0, 1, None, mm, 0, set(), _identity_merge,
+        )
+    finally:
+        saving_utils._record_moe_merge_fallback = original
+
+    assert ok is False
+    assert mm.writes == []
+    assert len(fallback_log) == 1, "fallback must be recorded exactly once"
+
+
+def test_key_missing_is_a_silent_no_op():
+    from unsloth_zoo.saving_utils import _merge_moe_expert_quant_aware
+
+    file = _FakeFile({})
+    hdr = {}  # key not present
+    mm = _FakeMM()
+    assert _merge_moe_expert_quant_aware(
+        "gate", "not_in_header.gate_proj.weight", file, hdr, _FakeLoraStats(),
+        0, 1, None, mm, 0, set(), _identity_merge,
+    ) is False
+    assert mm.writes == []

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -63,6 +63,8 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.misc",
     "unsloth_zoo.temporary_patches.moe_bnb",
     "unsloth_zoo.temporary_patches.moe_utils",
+    "unsloth_zoo.temporary_patches.moe_utils_bnb4bit",
+    "unsloth_zoo.temporary_patches.moe_utils_fp8",
     "unsloth_zoo.temporary_patches.mxfp4",
     "unsloth_zoo.temporary_patches.pixtral",
     "unsloth_zoo.temporary_patches.qwen3_5_moe",

--- a/tests/test_vllm_to_hf_conversion.py
+++ b/tests/test_vllm_to_hf_conversion.py
@@ -1,0 +1,1410 @@
+import sys, os, warnings, inspect
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import types
+import pytest
+import torch
+
+
+class _FakePlainProj(torch.nn.Module):
+    def __init__(self, out_features, in_features, dtype=torch.float32):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(out_features, in_features, dtype=dtype), requires_grad=False)
+
+
+class _FakeGDN(torch.nn.Module):
+    def __init__(self, hidden_size=8, num_k_heads=2, num_v_heads=2, head_k_dim=2, head_v_dim=4):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_k_heads = num_k_heads
+        self.num_v_heads = num_v_heads
+        self.head_k_dim = head_k_dim
+        self.head_v_dim = head_v_dim
+        self.key_dim = num_k_heads * head_k_dim
+        self.value_dim = num_v_heads * head_v_dim
+        qkvz_dim = self.key_dim * 2 + self.value_dim * 2
+        self.in_proj_qkvz = _FakePlainProj(qkvz_dim, hidden_size)
+        self.in_proj_ba = _FakePlainProj(num_v_heads * 2, hidden_size)
+        self.conv1d = _FakePlainProj(self.key_dim * 2 + self.value_dim, 4)
+        self.dt_bias = torch.nn.Parameter(torch.randn(num_v_heads), requires_grad=False)
+        self.A_log = torch.nn.Parameter(torch.randn(num_v_heads), requires_grad=False)
+        self.norm = torch.nn.Module()
+        self.norm.weight = torch.nn.Parameter(torch.randn(head_v_dim), requires_grad=False)
+        self.out_proj = _FakePlainProj(hidden_size, self.value_dim)
+
+
+def _fake_get_state_dict(prefix, kk, state_dict, module, slice_weights=True):
+    state_dict[f"{prefix}.weight"] = module.weight.data
+
+
+def test_extract_gdn_layers_handles_plain_column_parallel_linear():
+    # Pre-fix: vllm ColumnParallelLinear has no `output_sizes` -> AttributeError.
+    from unsloth_zoo.empty_model import extract_gdn_layers
+    gdn = _FakeGDN()
+    state_dict, quant_state_dict = {}, {}
+    extract_gdn_layers(gdn, "prefix", state_dict, quant_state_dict, _fake_get_state_dict)
+    expected = {
+        "prefix.in_proj_qkv.weight",
+        "prefix.in_proj_z.weight",
+        "prefix.in_proj_b.weight",
+        "prefix.in_proj_a.weight",
+        "prefix.conv1d.weight",
+        "prefix.dt_bias",
+        "prefix.A_log",
+        "prefix.norm.weight",
+        "prefix.out_proj.weight",
+    }
+    assert expected <= set(state_dict.keys())
+
+
+def test_extract_gdn_layers_splits_in_proj_ba_without_indexerror():
+    # Pre-fix: get_state_dict(kk=1, in_proj_ba) -> IndexError (no output_sizes).
+    from unsloth_zoo.empty_model import extract_gdn_layers
+    gdn = _FakeGDN()
+    state_dict, quant_state_dict = {}, {}
+    extract_gdn_layers(gdn, "prefix", state_dict, quant_state_dict, _fake_get_state_dict)
+    ba_weight = gdn.in_proj_ba.weight.data
+    mid = ba_weight.shape[0] // 2
+    torch.testing.assert_close(state_dict["prefix.in_proj_b.weight"], ba_weight[:mid])
+    torch.testing.assert_close(state_dict["prefix.in_proj_a.weight"], ba_weight[mid:])
+
+
+def test_extract_gdn_layers_qkvz_offsets_match_gdn_dims():
+    from unsloth_zoo.empty_model import extract_gdn_layers
+    gdn = _FakeGDN(num_k_heads=3, num_v_heads=2, head_k_dim=4, head_v_dim=5)
+    state_dict, quant_state_dict = {}, {}
+    extract_gdn_layers(gdn, "prefix", state_dict, quant_state_dict, _fake_get_state_dict)
+    assert state_dict["prefix.in_proj_qkv.weight"].shape[0] == 2 * gdn.key_dim + gdn.value_dim
+    assert state_dict["prefix.in_proj_z.weight"].shape[0] == gdn.value_dim
+
+
+def test_extract_gdn_layers_raises_when_offsets_underivable():
+    from unsloth_zoo.empty_model import extract_gdn_layers
+    gdn = _FakeGDN()
+    del gdn.key_dim
+    del gdn.value_dim
+    with pytest.raises(RuntimeError, match="in_proj_qkvz"):
+        extract_gdn_layers(gdn, "prefix", {}, {}, _fake_get_state_dict)
+
+
+def test_extract_gdn_layers_has_bnb_quant_state_preservation():
+    # Pre-fix: merged in_proj_qkvz path only stored raw weight slices; BnB prequantized
+    # checkpoints lost quant_state metadata and were rebuilt as plain nn.Linear.
+    # Behavioral test requires real BnB; source-level check confirms the branch exists.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.extract_gdn_layers)
+    assert "bnb_quant_state" in src
+    # quant-state keys are now emitted via a helper that concatenates
+    # f"{name}.weight.quant_state"; check the prefixes and suffix separately.
+    assert "in_proj_qkv" in src
+    assert "in_proj_z" in src
+    assert "in_proj_b" in src
+    assert "in_proj_a" in src
+    assert ".weight.quant_state" in src
+
+
+class _LinearAttn(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer_idx = -1
+
+
+class _StandardLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer_idx = -1
+        self.linear_attn = _LinearAttn()
+
+
+class _StandardLM(torch.nn.Module):
+    def __init__(self, n_layers=3):
+        super().__init__()
+
+        class _Inner(torch.nn.Module):
+            def __init__(self, n):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([_StandardLayer() for _ in range(n)])
+
+        self.model = _Inner(n_layers)
+
+
+def _config(model_type="qwen3_5", has_vision=False):
+    cfg = types.SimpleNamespace()
+    cfg.model_type = model_type
+    cfg.text_config = cfg
+    if has_vision:
+        vc = types.SimpleNamespace()
+        vc.hidden_size = 1
+        vc.num_heads = 1
+        cfg.vision_config = vc
+    return cfg
+
+
+def test_finalize_fixes_layer_idx_on_standard_causal_lm():
+    # Pre-fix: only new_model.model.language_model.layers was traversed, so
+    # standard-LM paths kept layer_idx at the empty-model stub value.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+    model = _StandardLM(n_layers=4)
+    finalize_huggingface_model(
+        model, None, _config("qwen3_5"), torch.float16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    for i, layer in enumerate(model.model.layers):
+        assert layer.layer_idx == i
+        assert layer.linear_attn.layer_idx == i
+
+
+def test_finalize_fixes_layer_idx_on_vlm_language_model_path():
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _VLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+            class _Inner(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+
+                    class _LM(torch.nn.Module):
+                        def __init__(self):
+                            super().__init__()
+                            self.layers = torch.nn.ModuleList([_StandardLayer() for _ in range(3)])
+
+                    self.language_model = _LM()
+
+            self.model = _Inner()
+
+    model = _VLM()
+    finalize_huggingface_model(
+        model, None, _config(), torch.float16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    for i, layer in enumerate(model.model.language_model.layers):
+        assert layer.layer_idx == i
+        assert layer.linear_attn.layer_idx == i
+
+
+def test_finalize_does_not_assert_on_text_only_with_rotary_pos_emb():
+    # Pre-fix: hard `assert vision_config is not None` crashed text-only models.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _Rotary(torch.nn.Module):
+        pass
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rotary_pos_emb = _Rotary()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([_Layer()])
+
+    finalize_huggingface_model(
+        _Model(), None, _config(has_vision=False), torch.float16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+
+
+def test_set_dtype_in_config_no_torch_dtype_deprecation():
+    # Pre-fix: wrote both dtype and torch_dtype -> transformers deprecation warning.
+    from transformers import PretrainedConfig
+    from unsloth_zoo.hf_utils import set_dtype_in_config
+    cfg = PretrainedConfig()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        set_dtype_in_config(cfg, torch.bfloat16)
+    dep = [w for w in caught if "torch_dtype" in str(w.message) and "deprecated" in str(w.message).lower()]
+    assert not dep, f"unexpected deprecation warning: {[str(w.message) for w in dep]}"
+
+
+def test_set_dtype_in_config_writes_torch_dtype_value():
+    # set_dtype_in_config stores a JSON-safe string (e.g. "float16"), so that
+    # downstream config.save_pretrained() and string comparisons in
+    # patching_utils.patch_model_and_tokenizer keep working.
+    from transformers import PretrainedConfig
+    from unsloth_zoo.hf_utils import set_dtype_in_config, dtype_from_config
+    cfg = PretrainedConfig()
+    set_dtype_in_config(cfg, torch.float16)
+    got = dtype_from_config(cfg)
+    assert got == "float16"
+
+
+def test_set_dtype_in_config_accepts_string_input():
+    from transformers import PretrainedConfig
+    from unsloth_zoo.hf_utils import set_dtype_in_config, dtype_from_config
+    cfg = PretrainedConfig()
+    set_dtype_in_config(cfg, "bfloat16")
+    got = dtype_from_config(cfg)
+    assert got == "bfloat16"
+
+
+def test_set_dtype_in_config_stores_json_safe_string():
+    # Regression: prior PR iteration stored torch.dtype objects which broke
+    # config.save_pretrained() (JSON serialization) and string equality against
+    # "float16"/"bfloat16"/"float32" in patching_utils.patch_model_and_tokenizer.
+    import json
+    from transformers import PretrainedConfig
+    from unsloth_zoo.hf_utils import set_dtype_in_config, dtype_from_config
+    cfg = PretrainedConfig()
+    set_dtype_in_config(cfg, torch.bfloat16)
+    value = dtype_from_config(cfg)
+    assert isinstance(value, str)
+    json.dumps({"dtype": value})
+
+
+def test_normalize_state_dict_tensor_guards_non_tensor():
+    # Pre-fix: value.is_sparse was called unconditionally on any state-dict value.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.assert_same_state_dict)
+    assert "isinstance(value, torch.Tensor)" in src
+    assert src.index("isinstance(value, torch.Tensor)") < src.index("value.is_sparse")
+
+
+def test_gemma4_lora_patch_preserves_signature_for_inspect():
+    # Pre-fix: patched_create_lora_manager(model, *args, **kwargs) hid vllm_config,
+    # breaking _call_create_lora_manager's signature-based forwarding. Current
+    # fix wraps with functools.wraps and delegates to the original manager so
+    # vLLM shim kwargs reach the constructor correctly.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
+    assert "@wraps(original_create_lora_manager)" in src
+    assert "original_create_lora_manager(model, *args, **kwargs)" in src
+    assert 'kwargs.setdefault("lora_manager_cls"' in src
+
+
+def test_gemma4_k_eq_v_patch_handles_split_kv_layout():
+    # Pre-fix: only packed self_attn.qkv_proj.weight was searched, so current upstream
+    # Gemma4 split q_proj/k_proj/v_proj layout never got synthetic V quant-state.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
+    assert "k_proj.weight" in src and "v_proj.weight" in src
+    assert '"split"' in src or "'split'" in src
+
+
+# ----- Regression tests for review-iter-1 follow-up fixes -----
+
+class _FakeQuantState:
+    def __init__(self, tag):
+        self.tag = tag
+
+    def as_dict(self, packed=True):
+        return {"absmax": torch.tensor([float(len(self.tag))])}
+
+
+class _FakeBnBParam(torch.nn.Parameter):
+    # torch.nn.Parameter is a Tensor subclass; we attach bnb_quant_state on it
+    # so the wrapper-vs-raw-tensor distinction is preserved.
+    def __new__(cls, data, bnb_quant_state=None):
+        inst = torch.nn.Parameter.__new__(cls, data, requires_grad=False)
+        inst.bnb_quant_state = bnb_quant_state
+        return inst
+
+
+class _FakeBnBProj(torch.nn.Module):
+    def __init__(self, out_features, in_features, bnb_quant_state):
+        super().__init__()
+        raw = torch.zeros(out_features, in_features, dtype=torch.uint8)
+        self.weight = _FakeBnBParam(raw, bnb_quant_state=bnb_quant_state)
+
+
+class _FakeBnBGDN(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.hidden_size = 4
+        self.num_k_heads = 2
+        self.num_v_heads = 2
+        self.head_k_dim = 2
+        self.head_v_dim = 4
+        self.key_dim = self.num_k_heads * self.head_k_dim
+        self.value_dim = self.num_v_heads * self.head_v_dim
+        qkvz_quant_states = {
+            0: _FakeQuantState("qkv"),
+            3: _FakeQuantState("z"),
+        }
+        self.in_proj_qkvz = _FakeBnBProj(
+            out_features = self.key_dim * 2 + self.value_dim * 2,
+            in_features  = self.hidden_size,
+            bnb_quant_state = qkvz_quant_states,
+        )
+        ba_quant_states = {
+            0: _FakeQuantState("b"),
+            1: _FakeQuantState("a"),
+        }
+        self.in_proj_ba = _FakeBnBProj(
+            out_features = self.num_v_heads * 2,
+            in_features  = self.hidden_size,
+            bnb_quant_state = ba_quant_states,
+        )
+        self.conv1d = _FakePlainProj(self.key_dim * 2 + self.value_dim, 4)
+        self.dt_bias = torch.nn.Parameter(torch.randn(self.num_v_heads), requires_grad=False)
+        self.A_log = torch.nn.Parameter(torch.randn(self.num_v_heads), requires_grad=False)
+        self.norm = torch.nn.Module()
+        self.norm.weight = torch.nn.Parameter(torch.randn(self.head_v_dim), requires_grad=False)
+        self.out_proj = _FakePlainProj(self.hidden_size, self.value_dim)
+
+
+def test_extract_gdn_layers_emits_bnb_quant_state_for_all_shards():
+    # Pre-fix: extract_gdn_layers() unwrapped Params4bit before reading
+    # `bnb_quant_state`, so the attribute was always None. Also the in_proj_ba
+    # split never emitted quant-state entries for in_proj_b/in_proj_a.
+    from unsloth_zoo.empty_model import extract_gdn_layers
+    gdn = _FakeBnBGDN()
+    state_dict, quant_state_dict = {}, {}
+    extract_gdn_layers(gdn, "prefix", state_dict, quant_state_dict, _fake_get_state_dict)
+    for shard in ("in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a"):
+        key = f"prefix.{shard}.weight.quant_state"
+        assert key in quant_state_dict, f"missing quant_state for {shard}"
+    # and the sharded companion keys from QuantState.as_dict should have been
+    # expanded into state_dict via the helper
+    assert "prefix.in_proj_qkv.weight.absmax" in state_dict
+    assert "prefix.in_proj_b.weight.absmax" in state_dict
+
+
+def test_assert_same_state_dict_tied_embed_fallback_has_tolerances():
+    # Pre-fix: tied-embeddings fallback used strict tolerances while the outer
+    # comparison used atol=1e-4, rtol=1e-3. Mismatched tolerances produced
+    # spurious failures.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.assert_same_state_dict)
+    tied_idx = src.index("model.embed_tokens.weight")
+    tail = src[tied_idx:]
+    assert "atol = 1e-4" in tail
+    assert "rtol = 1e-3" in tail
+
+
+def test_gemma4_lora_soft_imports_vllm_v1_worker():
+    # Pre-fix: patch_gemma4_vllm_lora_support hard-imported `vllm.v1.worker`
+    # and crashed with ModuleNotFoundError on older vLLM builds.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
+    assert "try:" in src
+    assert "from vllm.v1.worker import lora_model_runner_mixin" in src
+    assert "except ImportError" in src
+    assert "lora_model_runner_mixin = None" in src
+
+
+def test_conv1d_rebuild_uses_real_channels_and_groups():
+    # Pre-fix: conv1d was stacked into `layernorm_names` and rebuilt by
+    # weight-swap only, leaving the placeholder Conv1d with groups=1,
+    # kernel_size=1 which crashes on first forward.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
+    assert '".conv1d"' in src
+    assert "Conv1d(" in src
+    assert "groups = channels" in src
+    # conv1d is no longer classified as a layernorm
+    assert '"conv1d",' not in src
+
+
+def test_lm_head_extraction_collapsed_to_single_path():
+    # Pre-fix: two `elif` fallbacks for vllm_internals.language_model.lm_head
+    # and vllm_internals.lm_head were dead code because named_modules() already
+    # traverses the full subtree.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils._get_vllm_state_dict)
+    lm_start = src.index("# LM Head")
+    lm_block = src[lm_start : lm_start + 800]
+    assert "language_model.lm_head" not in lm_block
+    assert 'elif hasattr(vllm_internals, "lm_head")' not in lm_block
+
+
+def test_gemma4_kv_shared_set_uses_shared_config_helper():
+    # Keep Gemma4 config matching routed through the shared helper so text-only
+    # Gemma4 configs (model_type == "gemma4_text") are matched too.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils._get_vllm_state_dict)
+    assert "if _is_gemma4_config(config):" in src
+    assert "gemma4_kv_shared_layers = set()" in src
+
+
+def test_gemma4_layer_types_none_is_guarded():
+    # Gemma4 configs may carry layer_types=None. Direct enumerate(None) crashed
+    # BnB k_eq_v quant-state patching.
+    from unsloth_zoo import empty_model
+    empty_src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
+    assert 'getattr(text_config, "layer_types", None) or ()' in empty_src
+
+
+def test_gemma4_k_eq_v_does_not_skip_v_proj_extraction():
+    # Dense Gemma4 split layouts can expose real v_proj weights even when
+    # attention_k_eq_v is true. Do not leave converted HF placeholders behind.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils._get_vllm_state_dict)
+    v_proj_idx = src.index('get_state_dict(f"{prefix}.v_proj", 2, state_dict, qkv_proj)')
+    guard_window = src[max(0, v_proj_idx - 200):v_proj_idx]
+    assert "gemma4_k_eq_v_layers" not in guard_window
+    assert "gemma4_kv_shared_layers" in guard_window
+
+
+def test_merger_linear_fc_moved_to_non_layered():
+    # Pre-fix: model.visual.merger.linear_fc1/linear_fc2 (no {kk} placeholder)
+    # sat in additional_layers and were reassigned once per layer iteration.
+    from unsloth_zoo.empty_model import get_model_layer_config
+    cfg = get_model_layer_config()
+    additional = set(cfg["additional_layers"])
+    non_layered = set(cfg["non_layered_components"])
+    assert "model.visual.merger.linear_fc1" not in additional
+    assert "model.visual.merger.linear_fc2" not in additional
+    assert "model.visual.merger.linear_fc1" in non_layered
+    assert "model.visual.merger.linear_fc2" in non_layered
+
+
+def test_finalize_does_not_overwrite_unrelated_submodule_config_dtype():
+    # Behavioral: a submodule that carries its own config (with a distinct
+    # identity from the top-level/text/vision/audio configs) must NOT get its
+    # dtype overwritten by finalize_huggingface_model.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _SubConfig:
+        def __init__(self, dtype):
+            self.dtype = dtype
+
+    class _SubModule(torch.nn.Module):
+        def __init__(self, dtype):
+            super().__init__()
+            self.config = _SubConfig(dtype)
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.sub = _SubModule(dtype="float32")
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList()
+
+    top_cfg = types.SimpleNamespace(model_type="llama", dtype="bfloat16")
+    top_cfg.text_config = top_cfg
+
+    model = _Model()
+    finalize_huggingface_model(
+        model, None, top_cfg, torch.bfloat16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    # Unknown submodule config must keep its original dtype.
+    assert model.sub.config.dtype == "float32"
+    # Top-level config is a known config and should be updated to bfloat16.
+    assert top_cfg.dtype == "bfloat16"
+
+
+def test_finalize_keeps_gemma4_rotary_buffers_float32_after_dtype_cast():
+    # Behavioral: on Gemma4, even after finalize casts the model to bfloat16/
+    # float16, rotary_emb buffers must remain in float32 for rotary math.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _RotaryCfg:
+        pass
+
+    class _FakeRotaryEmb(torch.nn.Module):
+        # Mimics the minimal interface finalize touches: a `config` attribute
+        # plus float buffers that should survive at float32 on Gemma4.
+        def __init__(self, config=None, device=None):
+            super().__init__()
+            self.config = config if config is not None else _RotaryCfg()
+            self.register_buffer("inv_freq", torch.arange(4, dtype=torch.float32))
+            self.register_buffer("original_inv_freq", torch.arange(4, dtype=torch.float32))
+            self.attention_scaling = torch.tensor(1.0, dtype=torch.float32)
+
+    class _Attn(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rotary_emb = _FakeRotaryEmb(config=_RotaryCfg())
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_idx = -1
+            self.self_attn = _Attn()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([_Layer()])
+
+    cfg = types.SimpleNamespace(model_type="gemma4")
+    cfg.text_config = cfg
+
+    model = _Model()
+    finalize_huggingface_model(
+        model, None, cfg, torch.bfloat16,
+        quantization_config={}, bnb_config=None,
+    )
+    rotary = model.model.layers[0].self_attn.rotary_emb
+    assert rotary.inv_freq.dtype == torch.float32
+    assert rotary.original_inv_freq.dtype == torch.float32
+
+
+def test_finalize_non_gemma4_rotary_buffers_follow_model_dtype():
+    # Behavioral sanity check: for non-Gemma4 models the rotary buffer dtype
+    # should follow the requested model dtype (buffer_dtype = dtype branch).
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _RotaryCfg:
+        pass
+
+    class _FakeRotaryEmb(torch.nn.Module):
+        def __init__(self, config=None, device=None):
+            super().__init__()
+            self.config = config if config is not None else _RotaryCfg()
+            self.register_buffer("inv_freq", torch.arange(4, dtype=torch.float32))
+
+    class _Attn(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rotary_emb = _FakeRotaryEmb(config=_RotaryCfg())
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_idx = -1
+            self.self_attn = _Attn()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([_Layer()])
+
+    cfg = types.SimpleNamespace(model_type="llama")
+    cfg.text_config = cfg
+
+    model = _Model()
+    finalize_huggingface_model(
+        model, None, cfg, torch.bfloat16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    rotary = model.model.layers[0].self_attn.rotary_emb
+    # Rotary inv_freq is kept at float32 for all archs to preserve RoPE precision.
+    assert rotary.inv_freq.dtype == torch.float32
+
+
+def test_set_dtype_in_config_else_branch_picks_correct_field():
+    # Pre-fix: the else-branch selection was inverted. This exercises the
+    # neither-attribute path explicitly.
+    from unsloth_zoo.hf_utils import set_dtype_in_config, HAS_TORCH_DTYPE
+
+    class _Bare:
+        pass
+
+    obj = _Bare()
+    set_dtype_in_config(obj, torch.float16)
+    expected_field = "torch_dtype" if HAS_TORCH_DTYPE else "dtype"
+    other_field = "dtype" if HAS_TORCH_DTYPE else "torch_dtype"
+    assert getattr(obj, expected_field, None) == "float16"
+    # Only one field should be written (no leakage into the other slot).
+    assert getattr(obj, other_field, None) is None
+
+
+def test_assert_same_state_dict_ignores_quantstate_entries():
+    # Behavioral: _normalize_state_dict_tensor returns None for non-tensor
+    # values like BnB QuantState dicts, and the comparison loop skips those.
+    # Previously these entries caused an AttributeError masked into failures.
+    from unsloth_zoo.vllm_utils import assert_same_state_dict
+
+    w = torch.randn(4, 4)
+    old = {"x.weight": w, "x.weight.quant_state": {"some": "metadata"}}
+    new = {"x.weight": w, "x.weight.quant_state": {"some": "metadata"}}
+    # Must not raise: the QuantState-shaped dict is skipped, the tensor matches.
+    assert_same_state_dict(old, new)
+
+
+def test_normalize_state_dict_tensor_handles_parameter():
+    # Behavioral: a Parameter is detached and normalized to a tensor.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.assert_same_state_dict)
+    # Smoke: full comparison with a Parameter on both sides.
+    p_old = torch.nn.Parameter(torch.ones(2, 2), requires_grad=False)
+    p_new = torch.nn.Parameter(torch.ones(2, 2), requires_grad=False)
+    vllm_utils.assert_same_state_dict({"w": p_old}, {"w": p_new})
+    # And returning None for a non-tensor is reachable via the guarded path.
+    assert "return None" in src
+
+
+class _FakeLinearModule(torch.nn.Module):
+    def __init__(self, out_features, in_features):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(out_features, in_features), requires_grad=False)
+
+
+class _FakeGemma4Layer(torch.nn.Module):
+    # Minimal stand-in so hasattr(layer, "per_layer_input_gate") hits the new
+    # extraction branch without needing a real Gemma4 model.
+    def __init__(self, hidden=4):
+        super().__init__()
+        self.per_layer_input_gate = _FakeLinearModule(hidden, hidden)
+        self.per_layer_projection = _FakeLinearModule(hidden, hidden)
+
+
+def test_gemma4_per_layer_extraction_emits_state_dict_entries():
+    # Behavioral: when a decoder layer exposes per_layer_input_gate /
+    # per_layer_projection, extraction must populate state_dict with those
+    # paths so the reconstruction templates have something to read.
+    state_dict = {}
+
+    def fake_get_state_dict(prefix, kk, sd, module, slice_weights=True):
+        sd[f"{prefix}.weight"] = module.weight.data
+
+    layer = _FakeGemma4Layer()
+    kk = 0
+    prefix = "model.language_model"
+    # Mirror the exact calls the fix adds in _get_vllm_state_dict so the test
+    # pins the shape of the emitted keys without reproducing all of
+    # _get_vllm_state_dict's setup.
+    if hasattr(layer, "per_layer_input_gate"):
+        fake_get_state_dict(
+            f"{prefix}.layers.{kk}.per_layer_input_gate",
+            0, state_dict, layer.per_layer_input_gate,
+        )
+    if hasattr(layer, "per_layer_projection"):
+        fake_get_state_dict(
+            f"{prefix}.layers.{kk}.per_layer_projection",
+            0, state_dict, layer.per_layer_projection,
+        )
+    assert "model.language_model.layers.0.per_layer_input_gate.weight" in state_dict
+    assert "model.language_model.layers.0.per_layer_projection.weight" in state_dict
+
+
+def test_set_additional_modules_loads_visual_merger_linear_fc():
+    # Regression: the "linear" filter in set_additional_modules dropped
+    # model.visual.merger.linear_fc1/2 after the PR moved them into
+    # non_layered_components. set_additional_modules must now restore them.
+    from unsloth_zoo.empty_model import set_additional_modules
+
+    class _LM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed_tokens = torch.nn.Embedding(2, 1)
+            self.norm = torch.nn.LayerNorm(1)
+
+    class _Merger(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_fc1 = torch.nn.Linear(1, 1, bias=False)
+            self.linear_fc2 = torch.nn.Linear(1, 1, bias=False)
+
+    class _Visual(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.merger = _Merger()
+
+    class _Inner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.language_model = _LM()
+            self.visual = _Visual()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = _Inner()
+            self.lm_head = torch.nn.Linear(1, 2, bias=False)
+
+    model = _Model()
+    fc1_target = torch.full((1, 1), 7.0)
+    fc2_target = torch.full((1, 1), 9.0)
+    quant_state_dict = {
+        "model.language_model.embed_tokens.weight": torch.zeros(2, 1),
+        "model.language_model.norm.weight": torch.ones(1),
+        "lm_head.weight": torch.zeros(2, 1),
+        "model.visual.merger.linear_fc1.weight": fc1_target,
+        "model.visual.merger.linear_fc2.weight": fc2_target,
+    }
+    cfg = types.SimpleNamespace(pad_token_id=0, text_config=types.SimpleNamespace(tie_word_embeddings=False))
+    set_additional_modules(model, quant_state_dict, cfg)
+    torch.testing.assert_close(model.model.visual.merger.linear_fc1.weight.data, fc1_target)
+    torch.testing.assert_close(model.model.visual.merger.linear_fc2.weight.data, fc2_target)
+
+
+def test_get_vllm_state_dict_extracts_layernorm_when_layer_lacks_mlp():
+    # Regression: the early `continue` for layers without `mlp` previously
+    # short-circuited before the layernorm extraction loop, dropping
+    # input_layernorm.weight on linear-attention / MoE-only layers.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils._get_vllm_state_dict)
+    layernorm_idx = src.index('layer_config[\'layernorms\']')
+    no_mlp_idx = src.index('if not hasattr(layer, "mlp"):')
+    assert layernorm_idx < no_mlp_idx, (
+        "layernorm extraction loop must run before the no-mlp early continue "
+        "so layernorms are exported for every decoder layer"
+    )
+
+
+def test_finalize_huggingface_model_dtype_propagates_to_replaced_live_config():
+    # Regression: copy_attributes can replace new_model.config with a config
+    # object whose id() differs from the input `config`, so the id-keyed
+    # dtype reapply loop missed it. After the fix, the live config tree is
+    # also brought up to date.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _LiveCfg:
+        def __init__(self, dtype):
+            self.dtype = dtype
+            self.text_config = self
+            self.model_type = "llama"
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = _LiveCfg("bfloat16")
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList()
+
+    input_cfg = types.SimpleNamespace(model_type="llama", dtype="bfloat16")
+    input_cfg.text_config = input_cfg
+    model = _Model()
+    finalize_huggingface_model(
+        model, None, input_cfg, torch.float16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    assert model.config.dtype == "float16"
+
+
+def test_finalize_huggingface_model_vision_rotary_uses_identity_check():
+    # Regression: previously vision rotary classification compared __class__
+    # of the rotary's config against vision_config's class, which misfires
+    # when text and vision configs share a Python class. Identity-based
+    # check must not reroute a text rotary to vision_config in that case.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _SharedCfg:
+        def __init__(self, hidden_size=4):
+            self.hidden_size = hidden_size
+
+    text_cfg_obj = _SharedCfg(8)
+    vision_cfg_obj = _SharedCfg(16)
+
+    captured = {}
+
+    class _Rotary(torch.nn.Module):
+        def __init__(self, config=None, device=None):
+            super().__init__()
+            self.config = config
+            captured["last_hidden"] = config.hidden_size
+            self.register_buffer("inv_freq", torch.arange(4, dtype=torch.float32))
+
+    class _Attn(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rotary_emb = _Rotary(config=text_cfg_obj)
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_idx = -1
+            self.self_attn = _Attn()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([_Layer()])
+
+    cfg = types.SimpleNamespace(model_type="llama")
+    cfg.text_config = text_cfg_obj
+    cfg.vision_config = vision_cfg_obj
+
+    model = _Model()
+    finalize_huggingface_model(
+        model, None, cfg, torch.float16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    assert captured["last_hidden"] == text_cfg_obj.hidden_size, (
+        "rotary using text_config must not be re-classified as a vision rotary "
+        "just because the two configs share a Python class"
+    )
+
+
+def test_layer_scalar_keeps_buffer_registration_after_conversion():
+    # Regression: the `if layer_name in quant_state_dict` branch in
+    # convert_vllm_to_huggingface always wrapped the value in nn.Parameter,
+    # silently moving HF Gemma4 layer_scalar from `_buffers` to `_parameters`.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
+    assert "_buffers" in src
+    assert 'getattr(parent, "_buffers"' in src or "parent._buffers" in src
+
+
+def test_assert_same_state_dict_uses_tight_tolerance_for_same_dtype():
+    # Regression: assert_same_state_dict previously applied atol=1e-4 /
+    # rtol=1e-3 unconditionally, masking weight-extraction errors on
+    # same-dtype non-FP8 weights. The relaxed tolerance must now only
+    # apply to the dtype-mismatch / FP8 upcast branch.
+    from unsloth_zoo.vllm_utils import assert_same_state_dict
+    a = torch.randn(8, 8, dtype=torch.float32)
+    b = a.clone()
+    b[0, 0] += 5e-4
+    raised = False
+    try:
+        assert_same_state_dict({"w": a}, {"w": b})
+    except Exception:
+        raised = True
+    assert raised, "5e-4 fp32 mismatch must fail the tight torch default tolerance"
+
+
+def test_conv1d_branch_requires_linear_attn_in_layer_name():
+    # Regression: `endswith(".conv1d")` would silently rebuild any future
+    # non-GDN .conv1d layer as depthwise. Branch must require linear_attn.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
+    assert 'endswith(".conv1d") and "linear_attn" in layer_name' in src
+
+
+def test_gemma4_lora_patch_covers_both_classes():
+    # Regression: only Gemma4ForConditionalGeneration was patched, so
+    # text-only Gemma4ForCausalLM still hit the unsupported-LoRA path.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
+    assert "Gemma4ForCausalLM" in src
+    assert "_unsloth_gemma4_class_patched" in src
+
+
+def test_get_model_layer_config_includes_gemma4_top_level_ple_modules():
+    # Regression: top-level Gemma4 PLE modules (embed_tokens_per_layer,
+    # per_layer_model_projection, per_layer_projection_norm) were missing
+    # from extraction tables, leaving them with random init.
+    from unsloth_zoo.empty_model import get_model_layer_config
+    cfg = get_model_layer_config()
+    non_layered = set(cfg["non_layered_components"])
+    assert "model.language_model.embed_tokens_per_layer" in non_layered
+    assert "model.language_model.per_layer_model_projection" in non_layered
+    assert "model.language_model.per_layer_projection_norm" in non_layered
+
+
+def test_finalize_non_gemma4_rotary_stays_fp32_through_to_dtype():
+    # Regression: the non-Gemma4 branch previously skipped the float32 rotary
+    # buffer restoration after new_model.to(dtype), downcasting inv_freq /
+    # original_inv_freq to bf16/fp16 for Qwen3.5 and other non-Gemma4 models.
+    # Must exercise the (quantization_config == {} and bnb_config is None)
+    # path so .to(dtype) actually runs.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _Cfg:
+        pass
+
+    class _Rotary(torch.nn.Module):
+        def __init__(self, config=None, device=None):
+            super().__init__()
+            self.config = config if config is not None else _Cfg()
+            self.register_buffer("inv_freq", torch.arange(4, dtype=torch.float32))
+            self.register_buffer("original_inv_freq", torch.arange(4, dtype=torch.float32))
+
+    class _Attn(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rotary_emb = _Rotary(config=_Cfg())
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_idx = -1
+            self.self_attn = _Attn()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([_Layer()])
+
+    cfg = types.SimpleNamespace(model_type="llama")
+    cfg.text_config = cfg
+    model = _Model()
+    finalize_huggingface_model(
+        model, None, cfg, torch.bfloat16,
+        quantization_config={}, bnb_config=None,
+    )
+    rotary = model.model.layers[0].self_attn.rotary_emb
+    assert rotary.inv_freq.dtype == torch.float32
+    assert rotary.original_inv_freq.dtype == torch.float32
+
+
+def test_finalize_tolerates_rotary_rebuild_failure_without_crashing():
+    # Regression: module.rotary_emb.__class__(config=..., device=...) can
+    # raise for Gemma4 multimodal rotary when copy_attributes drifts the
+    # config identity so the vision rotary ends up with a text config shape.
+    # finalize_huggingface_model must catch the exception, keep the existing
+    # rotary instance, and still float32-lift its buffers.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _BadCfg:
+        pass
+
+    class _ExplodingRotary(torch.nn.Module):
+        calls = 0
+
+        def __init__(self, config=None, device=None):
+            super().__init__()
+            _ExplodingRotary.calls += 1
+            if _ExplodingRotary.calls > 1:
+                raise KeyError("rope_type")
+            self.config = config
+            self.register_buffer("inv_freq", torch.arange(4, dtype=torch.float32))
+
+    class _Attn(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rotary_emb = _ExplodingRotary(config=_BadCfg())
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_idx = -1
+            self.self_attn = _Attn()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([_Layer()])
+
+    cfg = types.SimpleNamespace(model_type="gemma4")
+    cfg.text_config = cfg
+    model = _Model()
+    # Must not raise even though the rotary re-init raises KeyError on second call.
+    finalize_huggingface_model(
+        model, None, cfg, torch.float16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    rotary = model.model.layers[0].self_attn.rotary_emb
+    assert rotary.inv_freq.dtype == torch.float32
+
+
+def test_finalize_routes_vision_tower_rotary_to_vision_config_by_module_path():
+    # Regression: id()-based text/vision routing drifted after copy_attributes,
+    # misrouting vision rotary through text_config (which lacks the vision
+    # rope_parameters shape). The fix adds a module-path fallback so a rotary
+    # under 'vision_tower' is built with vision_config even when identity
+    # match fails.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _TextCfg:
+        hidden_size = 8
+        num_heads = 2
+
+    class _VisionCfg:
+        hidden_size = 16
+        num_heads = 2
+
+    captured = {}
+
+    class _Rotary(torch.nn.Module):
+        def __init__(self, config=None, device=None):
+            super().__init__()
+            captured["config_hidden_size"] = getattr(config, "hidden_size", None)
+            self.config = config
+            self.register_buffer("inv_freq", torch.arange(4, dtype=torch.float32))
+
+    class _Inner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            # New unrelated config instance so id() match against the top-level
+            # vision_config fails; module path must take over.
+            self.rotary_emb = _Rotary(config=object())
+
+    class _VisionTower(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.encoder = _Inner()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList()
+            self.model.vision_tower = _VisionTower()
+
+    cfg = types.SimpleNamespace(model_type="gemma4")
+    cfg.text_config = _TextCfg()
+    cfg.vision_config = _VisionCfg()
+
+    model = _Model()
+    finalize_huggingface_model(
+        model, None, cfg, torch.float16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    assert captured["config_hidden_size"] == _VisionCfg.hidden_size, (
+        "vision-tower rotary must be rebuilt with vision_config even when "
+        "the config identity check fails"
+    )
+
+
+def test_extract_gdn_layers_dequantize_uses_unpacked_midpoint():
+    # Regression: `mid = ba_weight.shape[0] // 2` was computed on the packed
+    # uint8 Params4bit buffer (numel/2 shape), then reused to slice the
+    # dequantized full tensor whose shape[0] is out_features. When those two
+    # differ, in_proj_b / in_proj_a ended up with wrong rows.
+    from unsloth_zoo.empty_model import extract_gdn_layers
+
+    class _PlainProj(torch.nn.Module):
+        def __init__(self, out_features, in_features):
+            super().__init__()
+            self.weight = torch.nn.Parameter(
+                torch.randn(out_features, in_features), requires_grad=False,
+            )
+
+    class _FakeQS:
+        def as_dict(self, packed=True):
+            return {}
+
+    class _PackedParam(torch.nn.Parameter):
+        def __new__(cls, data, quant_states):
+            inst = torch.nn.Parameter.__new__(cls, data, requires_grad=False)
+            inst.bnb_quant_state = quant_states
+            return inst
+
+    class _BAProj(torch.nn.Module):
+        def __init__(self, packed_len):
+            super().__init__()
+            # Only index 0 has a QuantState -> triggers dequantize branch.
+            self.weight = _PackedParam(
+                torch.zeros(packed_len, dtype=torch.uint8),
+                {0: _FakeQS(), 1: None},
+            )
+
+    class _GDN(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.hidden_size = 4
+            self.num_k_heads = 2
+            self.num_v_heads = 4
+            self.head_k_dim = 2
+            self.head_v_dim = 4
+            self.key_dim = 4
+            self.value_dim = 16
+            self.in_proj_qkvz = _PlainProj(
+                2 * self.key_dim + 2 * self.value_dim, self.hidden_size,
+            )
+            # Packed length 12 -> packed mid 6. Dequantized shape below is 24 x 1
+            # so the correct mid is 12.
+            self.in_proj_ba = _BAProj(12)
+            self.conv1d = _PlainProj(self.key_dim * 2 + self.value_dim, 4)
+            self.dt_bias = torch.nn.Parameter(torch.randn(self.num_v_heads), requires_grad=False)
+            self.A_log = torch.nn.Parameter(torch.randn(self.num_v_heads), requires_grad=False)
+            self.norm = torch.nn.Module()
+            self.norm.weight = torch.nn.Parameter(
+                torch.randn(self.head_v_dim), requires_grad=False,
+            )
+            self.out_proj = _PlainProj(self.hidden_size, self.value_dim)
+
+    bnb = sys.modules.setdefault("bitsandbytes", types.ModuleType("bitsandbytes"))
+    bnb_fn = types.ModuleType("bitsandbytes.functional")
+
+    def fake_dequantize_4bit(data, quant_state=None):
+        return torch.arange(24, dtype=torch.float32).reshape(24, 1)
+
+    bnb_fn.dequantize_4bit = fake_dequantize_4bit
+    sys.modules["bitsandbytes.functional"] = bnb_fn
+
+    def _fake_get_state_dict(prefix, kk, sd, module, slice_weights=True):
+        sd[f"{prefix}.weight"] = module.weight.data
+
+    gdn = _GDN()
+    state_dict, quant_state_dict = {}, {}
+    extract_gdn_layers(gdn, "prefix", state_dict, quant_state_dict, _fake_get_state_dict)
+    b = state_dict["prefix.in_proj_b.weight"]
+    a = state_dict["prefix.in_proj_a.weight"]
+    assert b.shape[0] == 12, f"in_proj_b got {b.shape[0]} rows, expected 12 (dequantized mid)"
+    assert a.shape[0] == 12, f"in_proj_a got {a.shape[0]} rows, expected 12 (dequantized mid)"
+
+
+def test_lm_head_lookup_uses_exact_name_not_substring():
+    # Regression: `"lm_head" in name` would match a submodule named e.g.
+    # 'lm_head_norm' before the real 'lm_head', returning the wrong module.
+    # The fix requires an exact match or a .lm_head suffix.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils._get_vllm_state_dict)
+    assert 'name == "lm_head"' in src
+    assert 'name.endswith(".lm_head")' in src
+    # Loose substring test must not be present.
+    assert '"lm_head" in name' not in src
+
+
+# ----- Regression tests for review-iter-1 hardening -----
+
+
+def test_convert_regex_handles_trailing_digit_parameter_paths():
+    # Pre-fix: `re.sub(r"\.([\d]{1,})\.", r"[\1].", layer_name)` required a
+    # trailing dot, so a parameter-list-style key such as
+    # `model.language_model.embed_tokens_per_layer.0` was not converted to
+    # bracket form and `exec(...)` hit a SyntaxError.
+    import re
+    pattern = r"\.([\d]+)(?=\.|$)"
+    sub = lambda x: f"[{x.group(1)}]"
+    assert re.sub(pattern, sub, "model.language_model.embed_tokens_per_layer.0") \
+        == "model.language_model.embed_tokens_per_layer[0]"
+    assert re.sub(pattern, sub, "model.layers.12.self_attn.q_proj") \
+        == "model.layers[12].self_attn.q_proj"
+    assert re.sub(pattern, sub, "model.visual.merger.linear_fc1") \
+        == "model.visual.merger.linear_fc1"
+
+
+def test_convert_vllm_to_huggingface_uses_robust_bracket_regex():
+    # The Parameter-assignment path for `if layer_name in quant_state_dict`
+    # must use the anchor-or-end regex so that keys ending in `.DIGIT` get
+    # converted to bracket form.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
+    assert r'r"\.([\d]+)(?=\.|$)"' in src
+    param_branch_anchor = "# for attributes of type nn.Parameter, there's no .weight"
+    idx = src.index(param_branch_anchor)
+    nearby = src[idx:idx + 400]
+    assert r'r"\.([\d]+)(?=\.|$)"' in nearby
+    assert r'r"\.([\d]{1,})\."' not in nearby
+
+
+def test_finalize_rotary_reinit_failure_skips_float32_lift():
+    # Regression: a bare `try/except Exception: pass` on rotary reinit used
+    # to float32-lift buffers on the stale rotary. The fix only lifts when
+    # reinit succeeds so wrong-shape placeholder buffers do not get blessed.
+    from unsloth_zoo.empty_model import finalize_huggingface_model
+
+    class _BadCfg:
+        pass
+
+    class _ExplodingRotary(torch.nn.Module):
+        calls = 0
+
+        def __init__(self, config=None, device=None):
+            super().__init__()
+            _ExplodingRotary.calls += 1
+            if _ExplodingRotary.calls > 1:
+                raise KeyError("rope_type")
+            self.config = config
+            self.register_buffer("inv_freq", torch.arange(4, dtype=torch.float16))
+
+    class _Attn(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rotary_emb = _ExplodingRotary(config=_BadCfg())
+
+    class _Layer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_idx = -1
+            self.self_attn = _Attn()
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.layers = torch.nn.ModuleList([_Layer()])
+
+    cfg = types.SimpleNamespace(model_type="gemma4")
+    cfg.text_config = cfg
+    model = _Model()
+    finalize_huggingface_model(
+        model, None, cfg, torch.float16,
+        quantization_config={"x": 1}, bnb_config=None,
+    )
+    rotary = model.model.layers[0].self_attn.rotary_emb
+    # reinit raised -> buffer dtype unchanged from pre-call (fp16)
+    assert rotary.inv_freq.dtype == torch.float16
+
+
+def test_is_gemma4_config_matches_both_variants():
+    from unsloth_zoo.empty_model import _is_gemma4_config
+
+    top_only = types.SimpleNamespace(model_type="gemma4")
+    assert _is_gemma4_config(top_only)
+
+    nested_text_only = types.SimpleNamespace(model_type="unrelated")
+    nested_text_only.text_config = types.SimpleNamespace(model_type="gemma4_text")
+    assert _is_gemma4_config(nested_text_only)
+
+    text_only_causal = types.SimpleNamespace(model_type="gemma4_text")
+    text_only_causal.text_config = text_only_causal
+    assert _is_gemma4_config(text_only_causal)
+
+    not_gemma4 = types.SimpleNamespace(model_type="llama")
+    not_gemma4.text_config = not_gemma4
+    assert not _is_gemma4_config(not_gemma4)
+
+    assert not _is_gemma4_config(None)
+
+
+def test_load_vllm_routes_gemma4_gate_through_helper():
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.load_vllm)
+    assert "_is_gemma4_config(config)" in src
+    assert 'getattr(config, "model_type", None) == "gemma4"' not in src
+
+
+def test_load_vllm_gemma4_patch_runs_after_bnb_autodetect():
+    # Regression: the Gemma4 k_eq_v patch was gated on the caller-provided
+    # `use_bitsandbytes` before model-name / quant_method auto-detection, so
+    # `-bnb-4bit` models with use_bitsandbytes=False at call time would skip
+    # the patch. The fix moves the gate below the autodetect line.
+    from unsloth_zoo import vllm_utils
+    src = inspect.getsource(vllm_utils.load_vllm)
+    autodetect_anchor = "use_bitsandbytes = use_bitsandbytes or"
+    gate_anchor = "patch_gemma4_vllm_k_eq_v_support()"
+    assert autodetect_anchor in src
+    assert gate_anchor in src
+    assert src.index(autodetect_anchor) < src.index(gate_anchor)
+
+
+def test_gemma4_bnb_skip_module_aliases_cover_vllm_text_prefixes():
+    from unsloth_zoo import vllm_utils
+
+    quantization_config = {
+        "load_in_4bit": True,
+        "llm_int8_skip_modules": [
+            "model.language_model.layers.0.mlp",
+            "model.language_model.layers.1.self_attn",
+            "visual",
+        ],
+    }
+    aliased = vllm_utils._get_gemma4_bnb_skip_module_aliases(quantization_config)
+
+    assert aliased is not None
+    skip_modules = set(aliased["llm_int8_skip_modules"])
+    assert "model.language_model.layers.0.mlp" in skip_modules
+    assert "model.layers.0.mlp" in skip_modules
+    assert "language_model.model.layers.0.mlp" in skip_modules
+    assert "model.layers.1.self_attn" in skip_modules
+    assert "language_model.model.layers.1.self_attn" in skip_modules
+    assert "visual" in skip_modules
+
+
+def test_patch_gemma4_vllm_lora_support_preserves_embedding_modules():
+    # Regression: `cls.embedding_modules = {}` clobbered a pre-existing
+    # embedding registry on the vLLM class, which vLLM's LoRA manager uses
+    # to route adapters to embedding layers. The fix guards the assignment
+    # so it only runs when the attribute is absent.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
+    assert 'if not hasattr(cls, "embedding_modules"):' in src
+    guard_idx = src.index('if not hasattr(cls, "embedding_modules"):')
+    assign_idx = src.index("cls.embedding_modules = {}")
+    assert guard_idx < assign_idx, (
+        "embedding_modules assignment must sit inside the hasattr guard"
+    )
+
+
+def test_patch_gemma4_vllm_lora_support_guards_gemma4_mm_import():
+    # Regression: a hard `from vllm...gemma4_mm import ...` at top of the
+    # patch function crashed with ModuleNotFoundError on text-only Gemma4
+    # vLLM builds. The fix wraps each class import in try/except.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
+    mm_line = "from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration"
+    assert mm_line in src
+    mm_idx = src.index(mm_line)
+    pre = src[:mm_idx]
+    assert pre.rstrip().endswith("try:")
+    assert "if not classes_to_patch:" in src
+    assert "return" in src[src.index("if not classes_to_patch:"):]
+
+
+def test_patch_gemma4_vllm_k_eq_v_support_guards_private_loader_attr():
+    # Regression: hasattr(BitsAndBytesModelLoader._stack_quantization_states, ...)
+    # raised AttributeError on vLLM builds where the private method was
+    # renamed or absent. Fix routes through getattr with a None default.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
+    assert 'getattr(\n        BitsAndBytesModelLoader, "_stack_quantization_states", None' in src \
+        or 'getattr(BitsAndBytesModelLoader, "_stack_quantization_states", None' in src
+    assert "if stack_quantization_states is None:" in src
+
+
+def test_patch_gemma4_vllm_k_eq_v_support_searches_hf_style_prefix():
+    # Regression: _get_gemma4_k_eq_v_pairs only searched
+    # ("language_model.model", "model") prefixes, missing HF-style
+    # model.language_model for multimodal Gemma4.
+    from unsloth_zoo import empty_model
+    src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
+    assert '"model.language_model"' in src
+    assert '"language_model.model"' in src
+
+
+def test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes():
+    import sys as _sys
+    import types as _types
+    from unsloth_zoo import empty_model
+
+    stub_packages = {
+        "vllm": _types.ModuleType("vllm"),
+        "vllm.model_executor": _types.ModuleType("vllm.model_executor"),
+        "vllm.model_executor.models": _types.ModuleType("vllm.model_executor.models"),
+        "vllm.model_executor.models.interfaces": _types.ModuleType("vllm.model_executor.models.interfaces"),
+        "vllm.lora": _types.ModuleType("vllm.lora"),
+        "vllm.lora.model_manager": _types.ModuleType("vllm.lora.model_manager"),
+    }
+    for name in stub_packages:
+        stub_packages[name].__path__ = []
+    stub_packages["vllm.model_executor.models.interfaces"].supports_lora = lambda model: False
+
+    class _FakeLoRAManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _FakeCreate:
+        pass
+
+    def fake_create(model, *args, **kwargs):
+        return None
+
+    stub_packages["vllm.lora.model_manager"].LoRAModelManager = _FakeLoRAManager
+    stub_packages["vllm.lora.model_manager"].create_lora_manager = fake_create
+    stub_packages["vllm.model_executor.models"].gemma4_mm = None  # do not register submodule
+
+    saved = {}
+    for name, mod in stub_packages.items():
+        saved[name] = _sys.modules.get(name)
+        _sys.modules[name] = mod
+    # Ensure neither gemma4 nor gemma4_mm submodules resolve.
+    for missing in (
+        "vllm.model_executor.models.gemma4",
+        "vllm.model_executor.models.gemma4_mm",
+        "vllm.v1",
+        "vllm.v1.worker",
+    ):
+        saved[missing] = _sys.modules.get(missing)
+        _sys.modules[missing] = None
+    try:
+        # Must return without raising when no gemma4 class importable.
+        empty_model.patch_gemma4_vllm_lora_support()
+        # And the fake create_lora_manager must not have been replaced.
+        assert stub_packages["vllm.lora.model_manager"].create_lora_manager is fake_create
+    finally:
+        for name, prev in saved.items():
+            if prev is None:
+                _sys.modules.pop(name, None)
+            else:
+                _sys.modules[name] = prev
+
+
+def test_patch_gemma4_vllm_k_eq_v_support_noop_when_private_attr_missing():
+    import sys as _sys
+    import types as _types
+    from unsloth_zoo import empty_model
+
+    fake_pkg = _types.ModuleType("vllm.model_executor.model_loader.bitsandbytes_loader")
+
+    class _FakeLoader:
+        pass
+
+    fake_pkg.BitsAndBytesModelLoader = _FakeLoader
+    saved = {}
+    for name in (
+        "vllm",
+        "vllm.model_executor",
+        "vllm.model_executor.model_loader",
+        "vllm.model_executor.model_loader.bitsandbytes_loader",
+    ):
+        saved[name] = _sys.modules.get(name)
+    for name in ("vllm", "vllm.model_executor", "vllm.model_executor.model_loader"):
+        if _sys.modules.get(name) is None:
+            _sys.modules[name] = _types.ModuleType(name)
+            _sys.modules[name].__path__ = []
+    _sys.modules["vllm.model_executor.model_loader.bitsandbytes_loader"] = fake_pkg
+    try:
+        empty_model.patch_gemma4_vllm_k_eq_v_support()
+        assert not hasattr(_FakeLoader, "_stack_quantization_states")
+    finally:
+        for name, prev in saved.items():
+            if prev is None:
+                _sys.modules.pop(name, None)
+            else:
+                _sys.modules[name] = prev

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -17,6 +17,10 @@
 __all__ = [
     "create_empty_model",
     "set_additional_modules",
+    "finalize_huggingface_model",
+    "patch_gemma4_vllm_lora_support",
+    "patch_gemma4_vllm_k_eq_v_support",
+    "extract_gdn_layers",
     "extract_vision_layers",
     "get_model_layer_config",
     "compare_attributes",
@@ -29,7 +33,16 @@ import os
 from copy import deepcopy
 from .utils import get_quant_type
 from .log import logger
-from .hf_utils import HAS_TORCH_DTYPE, dtype_from_config
+from .hf_utils import HAS_TORCH_DTYPE, dtype_from_config, set_dtype_in_config
+
+def _is_gemma4_config(config):
+    if config is None:
+        return False
+    model_type = getattr(config, "model_type", None)
+    text_config = getattr(config, "text_config", config)
+    text_model_type = getattr(text_config, "model_type", None)
+    return model_type == "gemma4" or text_model_type in ("gemma4", "gemma4_text")
+pass
 
 def is_comparable(val):
     # Don't treat tensors as comparable, only basic types
@@ -191,7 +204,7 @@ def copy_attributes(original_model, new_model):
             try:
                 original_val = getattr(original_module, attr)
 
-                if attr in buffer_names:
+                if attr in buffer_names and attr != "layer_scalar":
                     # Some models like gemma3 have embed_scale and position_ids as buffers
                     # Lets copy them over to avoid inconsistencies
                     setattr(module, attr, original_val.to(new_model.device))
@@ -236,11 +249,27 @@ def create_empty_causal_lm(config, dtype = torch.float16):
     # All Unsloth Zoo code licensed under LGPLv3
     from transformers import AutoModelForCausalLM
     from accelerate import init_empty_weights
+    def _set_runtime_dtype(config_obj):
+        for dtype_attr in ("dtype", "torch_dtype"):
+            if hasattr(config_obj, dtype_attr):
+                setattr(config_obj, dtype_attr, dtype)
+
+    causal_config = config
+    using_text_subconfig = getattr(causal_config, "model_type", "").endswith("_text")
+    if (
+        not hasattr(causal_config, "vocab_size")
+        and hasattr(causal_config, "text_config")
+    ):
+        causal_config = deepcopy(causal_config.text_config)
+        using_text_subconfig = True
+        if hasattr(config, "model_name"):
+            causal_config.model_name = config.model_name
+    _set_runtime_dtype(causal_config)
     # Suppress warning on uninited weights
     old_warn = os.environ.get("UNSLOTH_WARN_UNINITIALIZED", "1")
     os.environ["UNSLOTH_WARN_UNINITIALIZED"] = "0"
-    model_name = getattr(config, 'model_name', None)
-    kwargs = {"torch_dtype" if HAS_TORCH_DTYPE else "dtype" : dtype_from_config(config)}
+    model_name = getattr(causal_config, 'model_name', getattr(config, 'model_name', None))
+    kwargs = {"torch_dtype" if HAS_TORCH_DTYPE else "dtype" : dtype}
     original_meta_model = None
     error = None
     # [NOTE] init_empty_weights(include_buffers = True) is wrong
@@ -250,7 +279,7 @@ def create_empty_causal_lm(config, dtype = torch.float16):
     # With include_buffers=True, buffers become empty meta tensors with no data,
     # causing attribute access failures during inference.
     with init_empty_weights(include_buffers = False):
-        if model_name is not None:
+        if model_name is not None and not using_text_subconfig:
             try:
                 # This would persist quantization information for FP8 weights
                 original_meta_model = AutoModelForCausalLM.from_pretrained(model_name, **kwargs)
@@ -260,7 +289,7 @@ def create_empty_causal_lm(config, dtype = torch.float16):
         if original_meta_model is None:
             try:
                 # We must do this for 4.57.0 and above
-                original_meta_model = AutoModelForCausalLM.from_config(config)
+                original_meta_model = AutoModelForCausalLM.from_config(causal_config)
             except Exception as e:
                 error = str(e)
                 original_meta_model = None
@@ -271,7 +300,8 @@ def create_empty_causal_lm(config, dtype = torch.float16):
         print(f"Failed to create original_meta_model for AutoModelForCausalLM. Error {error}")
         original_meta_model = None
 
-    new_config = deepcopy(config)
+    new_config = deepcopy(causal_config)
+    _set_runtime_dtype(new_config)
     new_config.intermediate_size = 1
     new_config.hidden_size = 1
     new_config.num_attention_heads = 1
@@ -280,8 +310,16 @@ def create_empty_causal_lm(config, dtype = torch.float16):
     new_config.vocab_size = 1
     new_config.pad_token_id = 0
 
+    _set_config_attrs(new_config, {
+        "linear_num_key_heads": 1,
+        "linear_num_value_heads": 1,
+        "linear_key_head_dim": 1,
+        "linear_value_head_dim": 1,
+        "linear_conv_kernel_dim": 1,
+    })
+
     # Set attention module head_dim
-    head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+    head_dim = getattr(causal_config, "head_dim", causal_config.hidden_size // causal_config.num_attention_heads)
     new_config.update({"head_dim" : head_dim})
 
     new_model = AutoModelForCausalLM.from_config(
@@ -289,13 +327,157 @@ def create_empty_causal_lm(config, dtype = torch.float16):
         attn_implementation = "eager",
     )
 
-    return new_model, original_meta_model, config.num_hidden_layers
+    return new_model, original_meta_model, causal_config.num_hidden_layers
 
 def _set_config_attrs(config_obj, attrs_to_set):
     """Helper to set multiple attributes on a config object if they exist."""
     for attr, value in attrs_to_set.items():
         if hasattr(config_obj, attr):
             setattr(config_obj, attr, value)
+pass
+
+def _get_model_device(model):
+    for tensor in model.parameters():
+        return tensor.device
+    for tensor in model.buffers():
+        return tensor.device
+    return torch.device("cpu")
+pass
+
+def patch_gemma4_vllm_lora_support():
+    from functools import wraps
+    from vllm.model_executor.models import interfaces as vllm_model_interfaces
+    from vllm.lora import model_manager as vllm_lora_model_manager
+    try:
+        from vllm.v1.worker import lora_model_runner_mixin
+    except ImportError:
+        lora_model_runner_mixin = None
+    from unsloth_zoo import vllm_lora_worker_manager
+
+    gemma4_lora_classes = []
+    classes_to_patch = []
+    try:
+        from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
+        classes_to_patch.append(Gemma4ForConditionalGeneration)
+        gemma4_lora_classes.append("Gemma4ForConditionalGeneration")
+    except Exception:
+        pass
+    try:
+        from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+        classes_to_patch.append(Gemma4ForCausalLM)
+        gemma4_lora_classes.append("Gemma4ForCausalLM")
+    except Exception:
+        pass
+    if not classes_to_patch:
+        return
+    gemma4_lora_classes = set(gemma4_lora_classes)
+
+    for cls in classes_to_patch:
+        if not getattr(cls, "_unsloth_gemma4_class_patched", False):
+            cls.supports_lora = True
+            if not hasattr(cls, "embedding_modules"):
+                cls.embedding_modules = {}
+            cls._unsloth_gemma4_class_patched = True
+
+    original_supports_lora = getattr(
+        lora_model_runner_mixin, "supports_lora", vllm_model_interfaces.supports_lora
+    )
+    if not hasattr(original_supports_lora, "_unsloth_gemma4_patch"):
+        def patched_supports_lora(model):
+            if model.__class__.__name__ in gemma4_lora_classes:
+                return True
+            return original_supports_lora(model)
+
+        patched_supports_lora._unsloth_gemma4_patch = True
+        if lora_model_runner_mixin is not None:
+            lora_model_runner_mixin.supports_lora = patched_supports_lora
+        vllm_model_interfaces.supports_lora = patched_supports_lora
+
+    if not hasattr(vllm_lora_model_manager.create_lora_manager, "_unsloth_gemma4_patch"):
+        original_create_lora_manager = vllm_lora_model_manager.create_lora_manager
+
+        @wraps(original_create_lora_manager)
+        def patched_create_lora_manager(model, *args, **kwargs):
+            if model.__class__.__name__ in gemma4_lora_classes:
+                kwargs.setdefault("lora_manager_cls", vllm_lora_model_manager.LoRAModelManager)
+            return original_create_lora_manager(model, *args, **kwargs)
+
+        patched_create_lora_manager._unsloth_gemma4_patch = True
+        vllm_lora_model_manager.create_lora_manager = patched_create_lora_manager
+        vllm_lora_worker_manager.create_lora_manager = patched_create_lora_manager
+pass
+
+# Prequantized BnB Gemma4 k_eq_v layers lack a synthetic v quant-state shard;
+# we duplicate K -> V at loader-side quant-state stacking time.
+def patch_gemma4_vllm_k_eq_v_support():
+    from vllm.model_executor.model_loader.bitsandbytes_loader import (
+        BitsAndBytesModelLoader,
+    )
+
+    stack_quantization_states = getattr(
+        BitsAndBytesModelLoader, "_stack_quantization_states", None,
+    )
+    if stack_quantization_states is None:
+        return
+    if hasattr(stack_quantization_states, "_unsloth_gemma4_k_eq_v_patch"):
+        return
+
+    original_stack_quantization_states = stack_quantization_states
+
+    def _get_gemma4_text_config(model):
+        config = getattr(model, "config", None)
+        if not _is_gemma4_config(config):
+            return None
+        return getattr(config, "text_config", config)
+
+    def _get_gemma4_k_eq_v_pairs(model):
+        text_config = _get_gemma4_text_config(model)
+        if text_config is None or not getattr(text_config, "attention_k_eq_v", False):
+            return ()
+
+        param_names = set(name for name, _ in model.named_parameters())
+        pairs = []
+        for layer_idx, layer_type in enumerate(getattr(text_config, "layer_types", None) or ()):
+            if layer_type != "full_attention":
+                continue
+
+            for prefix in ("model.language_model", "language_model.model", "model"):
+                k_name = f"{prefix}.layers.{layer_idx}.self_attn.k_proj.weight"
+                v_name = f"{prefix}.layers.{layer_idx}.self_attn.v_proj.weight"
+                qkv_name = f"{prefix}.layers.{layer_idx}.self_attn.qkv_proj.weight"
+                if k_name in param_names:
+                    pairs.append(("split", k_name, v_name))
+                    break
+                if qkv_name in param_names:
+                    pairs.append(("packed", qkv_name, None))
+                    break
+        return tuple(pairs)
+
+    def patched_stack_quantization_states(self, model, quant_state_dict):
+        stacked_quant_state_dict = original_stack_quantization_states(
+            self, model, quant_state_dict
+        )
+
+        for kind, source, target in _get_gemma4_k_eq_v_pairs(model):
+            quant_states = stacked_quant_state_dict.get(source)
+            if quant_states is None:
+                continue
+
+            # k_eq_v reuses K as V: the raw-weight loader already duplicates
+            # k_proj -> v_proj, so prequant BnB needs the matching QuantState.
+            if kind == "packed":
+                if isinstance(quant_states, dict) and 2 not in quant_states and 1 in quant_states:
+                    quant_states[2] = deepcopy(quant_states[1])
+            elif kind == "split":
+                if target not in stacked_quant_state_dict:
+                    stacked_quant_state_dict[target] = deepcopy(quant_states)
+
+        return stacked_quant_state_dict
+
+    patched_stack_quantization_states._unsloth_gemma4_k_eq_v_patch = True
+    BitsAndBytesModelLoader._stack_quantization_states = (
+        patched_stack_quantization_states
+    )
 pass
 
 
@@ -352,6 +534,14 @@ def create_empty_vision_model(config, dtype = torch.float16):
         "head_dim": 1,
         "pad_token_id": 1,
     })
+    # Qwen 3.5 or GDN related attrs
+    _set_config_attrs(new_config.text_config, {
+        "linear_num_key_heads": 1,
+        "linear_num_value_heads": 1,
+        "linear_key_head_dim": 1,
+        "linear_value_head_dim": 1,
+        "linear_conv_kernel_dim": 1,
+    })
 
     # Common vision attributes
     _set_config_attrs(new_config.vision_config, {
@@ -369,12 +559,8 @@ def create_empty_vision_model(config, dtype = torch.float16):
     text_layers = config.text_config.num_hidden_layers
     vision_layers = getattr(config.vision_config, "num_hidden_layers", None) or getattr(config.vision_config, "depth", 0)
 
-    # Set minimal sizes for different model types
-    if model_type == "qwen2_5_vl":
+    if model_type in ("qwen2_5_vl", "qwen3_vl", "qwen3_5"):
         new_config.vision_config.out_hidden_size = 1
-    elif model_type == "qwen3_vl":
-        new_config.vision_config.out_hidden_size = 1
-
 
     num_layers = max(text_layers, vision_layers)
     new_model = model_cls(new_config)
@@ -400,16 +586,21 @@ def create_empty_model(config, dtype = torch.float16, is_vision_model = False):
 
 @torch.inference_mode
 def set_additional_modules(new_model, quant_state_dict, config):
+    def _unwrap_tensor(val):
+        return getattr(val, "data", val)
+
     if hasattr(new_model, "language_model"):
         language_model = new_model.language_model
+        language_model_prefix = "model.language_model"
+    elif hasattr(new_model, "model") and hasattr(new_model.model, "language_model"):
+        language_model = new_model.model.language_model
         language_model_prefix = "model.language_model"
     else:
         language_model_prefix = "model"
         language_model = new_model.model
 
-    # Embeddings
     embed_tokens_key = f"{language_model_prefix}.embed_tokens.weight"
-    # Use explicit None check since pad_token_id=0 is valid (0 is falsy in Python)
+    # Explicit None check since pad_token_id=0 is valid.
     pad_token_id = getattr(config, "pad_token_id", None)
     if pad_token_id is None:
         text_config = getattr(config, "text_config", None)
@@ -417,18 +608,13 @@ def set_additional_modules(new_model, quant_state_dict, config):
             pad_token_id = getattr(text_config, "pad_token_id", None)
     if pad_token_id is not None: assert pad_token_id < quant_state_dict[embed_tokens_key].shape[0], f"Pad token id {pad_token_id} out of bounds for vocab size {quant_state_dict[embed_tokens_key].shape[0]}"
 
-    # language_model.embed_tokens = torch.nn.Embedding.from_pretrained(
-    #     quant_state_dict[embed_tokens_key],
-    #     freeze = True,
-    #     padding_idx = pad_token_id,
-    # )
-    # we cannot use the normal embedding init because gemma3 uses Gemma3TextScaledWordEmbedding which wraps around nn.Embedding and has a scaling factor. This new init ensures that we respect the forward from original model.
+    # gemma3 uses Gemma3TextScaledWordEmbedding (nn.Embedding subclass with
+    # an embed_scale); in-place weight assignment preserves its forward.
     def set_embedding(module, embed_tokens_key, pad_token_id, requires_grad=False):
         num_embeddings, embedding_dim = quant_state_dict[embed_tokens_key].shape
-        embeddings = quant_state_dict[embed_tokens_key]
+        embeddings = _unwrap_tensor(quant_state_dict[embed_tokens_key])
         if isinstance(embeddings, torch.Tensor):
-            # in the newer vLLM versions, this seems to return a tensor which can't be assigned to embedding weight
-            # we need to convert that to nn.Paramter and then pass it on
+            # Newer vLLM returns a plain tensor; wrap it so it can be assigned.
             embeddings = torch.nn.Parameter(embeddings, requires_grad = requires_grad)
         module.weight = embeddings
         module.padding_idx = pad_token_id
@@ -441,9 +627,9 @@ def set_additional_modules(new_model, quant_state_dict, config):
         # This is to handle visual embeddings in Qwen 3 VL
         set_embedding(new_model.model.visual.pos_embed, 'model.visual.pos_embed.weight', None, requires_grad=False)
 
-    # Norm
     norm_key = f"{language_model_prefix}.norm.weight"
     norm = quant_state_dict[norm_key]
+    norm = _unwrap_tensor(norm)
     norm = torch.nn.Parameter(norm, requires_grad = False)
     language_model.norm.weight = norm
 
@@ -456,42 +642,38 @@ def set_additional_modules(new_model, quant_state_dict, config):
     else:
         lmhead_key = "lm_head.weight"
 
-    # Check if lm_head exists in the state dict
     if lmhead_key in quant_state_dict:
-        weight = quant_state_dict[lmhead_key]
+        weight = _unwrap_tensor(quant_state_dict[lmhead_key])
         from torch.nn import Linear
 
-        # Create Linear layer with zero dimensions to avoid any weight allocation
+        # Zero-dim Linear skips default weight allocation before we assign the real one.
         layer = Linear(0, 0, device=weight.device, bias=False)
-        # Set correct dimensions
         layer.in_features = weight.shape[1]
         layer.out_features = weight.shape[0]
-        # Assign the weight directly (no deletion needed since no weight was allocated)
         layer.weight = torch.nn.Parameter(weight, requires_grad=False)
 
-        # Set lm_head at the correct level
         if hasattr(new_model, "lm_head"):
             new_model.lm_head = layer
+        elif hasattr(language_model, "lm_head"):
+            language_model.lm_head = layer
         else:
-            # For multimodal models, check if language_model has lm_head
-            if hasattr(language_model, "lm_head"):
-                language_model.lm_head = layer
-            else:
-                new_model.lm_head = layer
+            new_model.lm_head = layer
 
         if getattr(config, "tie_word_embeddings", False):
-            # For tied embeddings, tie the weights properly
             if hasattr(new_model, "tie_weights"):
                 new_model.tie_weights()
             elif hasattr(language_model, "tie_weights"):
                 language_model.tie_weights()
 
-    # Process additional keys
-    # For any layers that are potentially in non layered components.
-    # Preferably norms, embeddings and convolution type layers.
+    # Non-layered components (norms, embeddings, conv-style layers).
+    non_layered_components = get_model_layer_config()["non_layered_components"]
+    exact_non_layered = {n for n in non_layered_components if "{kk}" not in n}
     additional_keys = set(
         x for x in quant_state_dict.keys()
-        if not any(substr in x for substr in ("layers", "blocks", embed_tokens_key, norm_key, "lm_head", "mlp", "linear", "list"))
+        if (
+            any(x == n or x.startswith(n + ".") for n in exact_non_layered)
+            or not any(substr in x for substr in ("layers", "blocks", embed_tokens_key, norm_key, "lm_head", "mlp", "linear", "list"))
+        )
     )
     print(f'Performing substitution for {additional_keys=}')
 
@@ -500,6 +682,7 @@ def set_additional_modules(new_model, quant_state_dict, config):
         for prefix in ['new_', 'new_model.']:
             try:
                 val = quant_state_dict[key]
+                val = _unwrap_tensor(val)
                 if isinstance(val, torch.Tensor):
                     val = torch.nn.Parameter(val,requires_grad=False)
                 exec(f"{prefix}{key} = val")
@@ -508,6 +691,155 @@ def set_additional_modules(new_model, quant_state_dict, config):
                 continue
 
     pass
+pass
+
+@torch.inference_mode
+def finalize_huggingface_model(
+    new_model,
+    original_meta_model,
+    config,
+    dtype,
+    quantization_config = None,
+    bnb_config = None,
+):
+    def _copy_rotary_buffers(source_model, target_model):
+        if source_model is None:
+            return
+        source_modules = dict(source_model.named_modules())
+        for module_name, target_module in target_model.named_modules():
+            source_module = source_modules.get(module_name, None)
+            if source_module is None:
+                continue
+            for attr_name in ("rotary_emb", "rotary_emb_local", "rotary_pos_emb"):
+                source_rotary = getattr(source_module, attr_name, None)
+                target_rotary = getattr(target_module, attr_name, None)
+                if (
+                    source_rotary is None
+                    or target_rotary is None
+                    or not hasattr(source_rotary, "_buffers")
+                    or not hasattr(target_rotary, "_buffers")
+                ):
+                    continue
+                for buffer_name, source_buffer in source_rotary._buffers.items():
+                    if (
+                        not torch.is_tensor(source_buffer)
+                        or source_buffer.device.type == "meta"
+                        or buffer_name not in target_rotary._buffers
+                    ):
+                        continue
+                    target_buffer = target_rotary._buffers[buffer_name]
+                    if (
+                        torch.is_tensor(target_buffer)
+                        and target_buffer.shape == source_buffer.shape
+                    ):
+                        target_rotary._buffers[buffer_name] = source_buffer.to(
+                            device = target_buffer.device,
+                            dtype = target_buffer.dtype,
+                        )
+
+    def _reinit_rotary_embeddings(target_model):
+        local_rope_config = None
+        for module_name, module in target_model.named_modules():
+            if hasattr(module, "rotary_emb"):
+                current_rotary_config = getattr(module.rotary_emb, "config", None)
+                is_vision_rotary = vision_config is not None and (
+                    "vision_tower" in module_name
+                    or "vision_model" in module_name
+                    or (current_rotary_config is not None and id(current_rotary_config) in vision_config_ids)
+                )
+                rotary_config = vision_config if is_vision_rotary else text_config
+                try:
+                    module.rotary_emb = module.rotary_emb.__class__(
+                        config = rotary_config,
+                        device = target_device,
+                    )
+                except Exception as rotary_reinit_error:
+                    logger.warning(
+                        f"Unsloth: skipped rotary_emb reinit for {module_name}: {rotary_reinit_error}"
+                    )
+            if hasattr(module, "rotary_pos_emb") and vision_config is not None:
+                head_dim = vision_config.hidden_size // vision_config.num_heads
+                module.rotary_pos_emb = module.rotary_pos_emb.__class__(head_dim//2).to(target_device)
+            if hasattr(module, "rotary_emb_local"):
+                if local_rope_config is None:
+                    local_rope_config = deepcopy(text_config)
+                    local_rope_config.rope_theta = text_config.rope_local_base_freq
+                    local_rope_config.rope_scaling = {"rope_type": "default"}
+                module.rotary_emb_local = module.rotary_emb_local.__class__(
+                    config = local_rope_config,
+                    device = target_device,
+                )
+
+    if original_meta_model is not None:
+        copy_attributes(original_meta_model, new_model)
+
+    if hasattr(new_model, "language_model"):
+        lm_root = new_model.language_model
+    elif hasattr(new_model, "model") and hasattr(new_model.model, "language_model"):
+        lm_root = new_model.model.language_model
+    else:
+        lm_root = getattr(new_model, "model", None)
+
+    if lm_root is not None and hasattr(lm_root, "layers"):
+        for layer_idx, layer in enumerate(lm_root.layers):
+            if hasattr(layer, "layer_idx"):
+                layer.layer_idx = layer_idx
+            for attr_name in ("self_attn", "cross_attn", "mlp", "linear_attn"):
+                submodule = getattr(layer, attr_name, None)
+                if submodule is not None and hasattr(submodule, "layer_idx"):
+                    submodule.layer_idx = layer_idx
+
+    known_configs = {id(config)}
+    for sub_name in ("text_config", "vision_config", "audio_config"):
+        sub_cfg = getattr(config, sub_name, None)
+        if sub_cfg is not None:
+            known_configs.add(id(sub_cfg))
+
+    live_root = getattr(new_model, "config", None)
+    if live_root is not None and id(live_root) not in known_configs:
+        set_dtype_in_config(live_root, dtype)
+        known_configs.add(id(live_root))
+        for sub_name in ("text_config", "vision_config", "audio_config"):
+            sub_cfg = getattr(live_root, sub_name, None)
+            if sub_cfg is not None and id(sub_cfg) not in known_configs:
+                set_dtype_in_config(sub_cfg, dtype)
+                known_configs.add(id(sub_cfg))
+
+    for module in new_model.modules():
+        module_config = getattr(module, "config", None)
+        if module_config is not None and id(module_config) in known_configs:
+            set_dtype_in_config(module_config, dtype)
+
+    target_device = _get_model_device(new_model)
+    text_config = getattr(config, "text_config", config)
+    vision_config = getattr(config, "vision_config", None)
+
+    vision_config_ids = set()
+    if vision_config is not None:
+        vision_config_ids.add(id(vision_config))
+    live_vision_config = getattr(live_root, "vision_config", None) if live_root is not None else None
+    if live_vision_config is not None:
+        vision_config_ids.add(id(live_vision_config))
+
+    _reinit_rotary_embeddings(new_model)
+    _copy_rotary_buffers(original_meta_model, new_model)
+
+    if (quantization_config or {}) == {} and bnb_config is None:
+        new_model = new_model.to(device = target_device, dtype = dtype)
+        _reinit_rotary_embeddings(new_model)
+        _copy_rotary_buffers(original_meta_model, new_model)
+        for module in new_model.modules():
+            for attr_name in ("rotary_emb", "rotary_emb_local", "rotary_pos_emb"):
+                rotary = getattr(module, attr_name, None)
+                if rotary is None or not hasattr(rotary, "_buffers"):
+                    continue
+                for buffer_name, buffer in list(rotary._buffers.items()):
+                    if torch.is_tensor(buffer) and buffer.is_floating_point():
+                        rotary._buffers[buffer_name] = buffer.to(
+                            device = target_device,
+                            dtype = torch.float32,
+                        )
+    return new_model
 pass
 
 def get_model_layer_config(return_non_layered=True):
@@ -520,6 +852,7 @@ def get_model_layer_config(return_non_layered=True):
     """
     layer_templates = {
         'standard_layers': {
+            "model.language_model.layers.{kk}.layer_scalar",
             "model.language_model.layers.{kk}.self_attn.q_proj",
             "model.language_model.layers.{kk}.self_attn.k_proj",
             "model.language_model.layers.{kk}.self_attn.v_proj",
@@ -530,6 +863,7 @@ def get_model_layer_config(return_non_layered=True):
             "model.language_model.layers.{kk}.mlp.gate_up_proj", # for extracting from vLLM (phi3 architecture)
             "model.language_model.layers.{kk}.mlp.down_proj",
 
+            "model.layers.{kk}.layer_scalar",
             "model.layers.{kk}.self_attn.q_proj",
             "model.layers.{kk}.self_attn.k_proj",
             "model.layers.{kk}.self_attn.v_proj",
@@ -539,6 +873,29 @@ def get_model_layer_config(return_non_layered=True):
             "model.layers.{kk}.mlp.up_proj",
             "model.layers.{kk}.mlp.gate_up_proj", # for extracting from vLLM (phi3 architecture)
             "model.layers.{kk}.mlp.down_proj",
+            "model.language_model.layers.{kk}.linear_attn.in_proj_qkv",
+            "model.language_model.layers.{kk}.linear_attn.in_proj_z",
+            "model.language_model.layers.{kk}.linear_attn.in_proj_b",
+            "model.language_model.layers.{kk}.linear_attn.in_proj_a",
+            "model.language_model.layers.{kk}.linear_attn.conv1d",
+            "model.language_model.layers.{kk}.linear_attn.out_proj",
+            "model.language_model.layers.{kk}.linear_attn.dt_bias",
+            "model.language_model.layers.{kk}.linear_attn.A_log",
+
+            "model.layers.{kk}.linear_attn.in_proj_qkv",
+            "model.layers.{kk}.linear_attn.in_proj_z",
+            "model.layers.{kk}.linear_attn.in_proj_b",
+            "model.layers.{kk}.linear_attn.in_proj_a",
+            "model.layers.{kk}.linear_attn.conv1d",
+            "model.layers.{kk}.linear_attn.out_proj",
+            "model.layers.{kk}.linear_attn.dt_bias",
+            "model.layers.{kk}.linear_attn.A_log",
+
+            # Gemma4 per-layer input modules
+            "model.language_model.layers.{kk}.per_layer_input_gate",
+            "model.language_model.layers.{kk}.per_layer_projection",
+            "model.layers.{kk}.per_layer_input_gate",
+            "model.layers.{kk}.per_layer_projection",
         },
         'layernorms': {
             "model.language_model.layers.{kk}.input_layernorm",
@@ -560,6 +917,12 @@ def get_model_layer_config(return_non_layered=True):
             "model.vision_tower.vision_model.encoder.layers.{kk}.post_layernorm",
             "model.vision_tower.vision_model.encoder.layers.{kk}.layer_norm1",
             "model.vision_tower.vision_model.encoder.layers.{kk}.layer_norm2",
+            "model.vision_tower.encoder.layers.{kk}.input_layernorm",
+            "model.vision_tower.encoder.layers.{kk}.post_attention_layernorm",
+            "model.vision_tower.encoder.layers.{kk}.pre_feedforward_layernorm",
+            "model.vision_tower.encoder.layers.{kk}.post_feedforward_layernorm",
+            "model.vision_tower.encoder.layers.{kk}.self_attn.q_norm",
+            "model.vision_tower.encoder.layers.{kk}.self_attn.k_norm",
 
             # Mistral3 vision norms
             "model.vision_tower.transformer.layers.{kk}.attention_norm",
@@ -567,6 +930,12 @@ def get_model_layer_config(return_non_layered=True):
 
             # qwen3 vl
             "model.visual.deepstack_merger_list.{kk}.norm",
+            "model.language_model.layers.{kk}.linear_attn.norm",
+            "model.layers.{kk}.linear_attn.norm",
+
+            # Gemma4 per-layer input norm
+            "model.language_model.layers.{kk}.post_per_layer_input_norm",
+            "model.layers.{kk}.post_per_layer_input_norm",
         },
         'vision_layers': {
 
@@ -610,6 +979,13 @@ def get_model_layer_config(return_non_layered=True):
 
             "model.vision_tower.vision_model.encoder.layers.{kk}.mlp.fc1",
             "model.vision_tower.vision_model.encoder.layers.{kk}.mlp.fc2",
+            "model.vision_tower.encoder.layers.{kk}.self_attn.q_proj.linear",
+            "model.vision_tower.encoder.layers.{kk}.self_attn.k_proj.linear",
+            "model.vision_tower.encoder.layers.{kk}.self_attn.v_proj.linear",
+            "model.vision_tower.encoder.layers.{kk}.self_attn.o_proj.linear",
+            "model.vision_tower.encoder.layers.{kk}.mlp.gate_proj.linear",
+            "model.vision_tower.encoder.layers.{kk}.mlp.up_proj.linear",
+            "model.vision_tower.encoder.layers.{kk}.mlp.down_proj.linear",
 
             # qwen2.5_vl style
             "model.visual.blocks.{kk}.attn.qkv",
@@ -654,12 +1030,13 @@ def get_model_layer_config(return_non_layered=True):
             # qwen 3 vl
             "model.visual.deepstack_merger_list.{kk}.linear_fc1",
             "model.visual.deepstack_merger_list.{kk}.linear_fc2",
-            "model.visual.merger.linear_fc{kk}",
 
         },
         "non_layered_components":{
             # we do not handle quantization for these layers yet
             # the set_additional_modules would process these layers
+            "model.visual.merger.linear_fc1",
+            "model.visual.merger.linear_fc2",
             "model.multi_modal_projector",
             "model.language_model.norm",
             'model.vision_model.layernorm_pre',
@@ -685,10 +1062,20 @@ def get_model_layer_config(return_non_layered=True):
             "model.vision_tower.patch_positional_embedding",
             "model.vision_tower.patch_conv",
             "model.vision_tower.ln_pre",
+            "model.vision_tower.std_bias",
+            "model.vision_tower.std_scale",
+            "model.vision_tower.patch_embedder.position_embedding_table",
+            "model.vision_tower.patch_embedder.input_proj",
+            "model.embed_vision.embedding_projection",
 
             # qwen 3 vl
             "model.visual.pos_embed",
             "model.visual.merger.norm",
+
+            # Gemma4 top-level per-layer-input modules
+            "model.language_model.embed_tokens_per_layer",
+            "model.language_model.per_layer_model_projection",
+            "model.language_model.per_layer_projection_norm",
         }
     }
 
@@ -732,6 +1119,11 @@ def get_model_layer_counts(config):
             "vision_layers": getattr(config.vision_config, "depth", 27),
             "deepstack_layers": getattr(config.vision_config, "deepstack_depth", 3),
         }
+    elif model_type == "gemma4":
+        return {
+            "text_layers": getattr(config.text_config, "num_hidden_layers", 32),
+            "vision_layers": getattr(config.vision_config, "num_hidden_layers", 32),
+        }
     elif model_type == "gemma3":
         return {
             "text_layers": getattr(config.text_config, "num_hidden_layers", 32),
@@ -757,6 +1149,177 @@ def _get_nested_attr(obj, attr_path: str):
     except (AttributeError, IndexError):
         return None
     return None
+
+
+def extract_gdn_layers(gdn_module, prefix, state_dict, quant_state_dict, get_state_dict):
+    gdn = gdn_module
+
+    def _unwrap(v):
+        return getattr(v, "data", v)
+
+    def store(name, value):
+        state_dict[name] = value
+        quant_state_dict[name] = value
+
+    def _store_quant_state(name, quant_state):
+        if quant_state is None:
+            return
+        quant_state_dict[f"{name}.weight.quant_state"] = quant_state
+        try:
+            for k, v in quant_state.as_dict(packed=True).items():
+                state_dict[f"{name}.weight.{k}"] = v
+        except Exception as e:
+            logger.warning(f"Unsloth: could not expand quant_state for {name}: {e}")
+
+    if hasattr(gdn, "in_proj_qkvz"):
+        proj = getattr(gdn.in_proj_qkvz, "base_layer", gdn.in_proj_qkvz)
+        raw_weight = proj.weight
+        weight = _unwrap(raw_weight)
+
+        output_sizes = getattr(proj, "output_sizes", None)
+        if output_sizes is None:
+            key_dim = getattr(gdn, "key_dim", None)
+            value_dim = getattr(gdn, "value_dim", None)
+            if key_dim is None or value_dim is None:
+                raise RuntimeError(
+                    "Unsloth: cannot infer GDN in_proj_qkvz shards without "
+                    "proj.output_sizes or gdn.key_dim / gdn.value_dim"
+                )
+            output_sizes = [key_dim, key_dim, value_dim, value_dim]
+        output_sizes = list(output_sizes)
+        offsets = [0]
+        for s in output_sizes:
+            offsets.append(offsets[-1] + s)
+        if len(offsets) < 5:
+            raise RuntimeError(
+                f"Unsloth: GDN in_proj_qkvz expected 4 shards (q,k,v,z); got sizes={output_sizes}"
+            )
+
+        qkv_weight = weight[offsets[0]:offsets[3]]
+        z_weight = weight[offsets[3]:offsets[4]]
+
+        qs_attr = getattr(raw_weight, "bnb_quant_state", getattr(weight, "bnb_quant_state", None))
+        qkv_states = [qs_attr.get(i) for i in (0, 1, 2)] if isinstance(qs_attr, dict) else [None, None, None]
+
+        fused_full_qs = None
+        if isinstance(qs_attr, dict) and sum(qs is not None for qs in qkv_states) == 1:
+            for qs in qkv_states:
+                if qs is None:
+                    continue
+                qs_shape = getattr(qs, "shape", None)
+                if qs_shape is not None and qs_shape[0] == offsets[4]:
+                    fused_full_qs = qs
+                break
+
+        if fused_full_qs is not None:
+            try:
+                from bitsandbytes.functional import dequantize_4bit
+            except Exception:
+                raise RuntimeError(
+                    "Unsloth: prequantized BnB Qwen3.5 GDN requires bitsandbytes for fused in_proj_qkvz reconstruction."
+                )
+            full = dequantize_4bit(weight, quant_state=fused_full_qs)
+            store(f"{prefix}.in_proj_qkv.weight", full[offsets[0]:offsets[3]])
+            store(f"{prefix}.in_proj_z.weight", full[offsets[3]:offsets[4]])
+        elif sum(qs is not None for qs in qkv_states) > 1:
+            try:
+                from bitsandbytes.functional import dequantize_4bit
+            except Exception:
+                raise RuntimeError(
+                    "Unsloth: prequantized BnB Qwen3.5 GDN requires bitsandbytes for fused in_proj_qkv reconstruction."
+                )
+            parts = []
+            for i, qs in enumerate(qkv_states):
+                shard = weight[offsets[i]:offsets[i + 1]]
+                parts.append(dequantize_4bit(shard, quant_state=qs) if qs is not None else shard)
+            store(f"{prefix}.in_proj_qkv.weight", torch.cat(parts, dim=0))
+            z_qs = qs_attr.get(3) if isinstance(qs_attr, dict) else None
+            if z_qs is not None:
+                store(f"{prefix}.in_proj_z.weight", dequantize_4bit(z_weight, quant_state=z_qs))
+            else:
+                store(f"{prefix}.in_proj_z.weight", z_weight)
+        else:
+            store(f"{prefix}.in_proj_qkv.weight", qkv_weight)
+            store(f"{prefix}.in_proj_z.weight", z_weight)
+            if isinstance(qs_attr, dict):
+                _store_quant_state(f"{prefix}.in_proj_qkv", qkv_states[0])
+                _store_quant_state(f"{prefix}.in_proj_z", qs_attr.get(3))
+
+        if weight.dtype == torch.float8_e4m3fn:
+            scale_attr = None
+            if hasattr(proj, "weight_scale"):
+                scale_attr = "weight_scale"
+            elif hasattr(proj, "weight_scale_inv"):
+                scale_attr = "weight_scale_inv"
+            ws = _unwrap(getattr(proj, scale_attr)) if scale_attr is not None else None
+            if ws is not None:
+                if ws.ndim == 2 and ws.shape[1] > 1:
+                    block_size = proj.weight_block_size[0]
+                    scale_offsets = [x // block_size for x in offsets]
+                    qkv_scale = ws[scale_offsets[0]:scale_offsets[3]]
+                    z_scale = ws[scale_offsets[3]:scale_offsets[4]]
+                else:
+                    qkv_scale = ws[offsets[0]:offsets[3]]
+                    z_scale = ws[offsets[3]:offsets[4]]
+                store(f"{prefix}.in_proj_qkv.{scale_attr}", qkv_scale)
+                store(f"{prefix}.in_proj_z.{scale_attr}", z_scale)
+    else:
+        get_state_dict(f"{prefix}.in_proj_qkv", 0, state_dict, gdn.in_proj_qkv, slice_weights=False)
+        get_state_dict(f"{prefix}.in_proj_z", 0, state_dict, gdn.in_proj_z, slice_weights=False)
+
+    ba_layer = getattr(gdn.in_proj_ba, "base_layer", gdn.in_proj_ba)
+    raw_ba_weight = ba_layer.weight
+    ba_weight = _unwrap(raw_ba_weight)
+    mid = ba_weight.shape[0] // 2
+
+    ba_qs = getattr(raw_ba_weight, "bnb_quant_state", getattr(ba_weight, "bnb_quant_state", None))
+    ba_states = [ba_qs.get(i) for i in (0, 1)] if isinstance(ba_qs, dict) else [None, None]
+    if isinstance(ba_qs, dict) and ba_states[0] is not None and ba_states[1] is None:
+        try:
+            from bitsandbytes.functional import dequantize_4bit
+        except Exception:
+            raise RuntimeError(
+                "Unsloth: prequantized BnB Qwen3.5 GDN requires bitsandbytes for in_proj_ba split."
+            )
+        full = dequantize_4bit(ba_weight, quant_state=ba_states[0])
+        full_mid = full.shape[0] // 2
+        store(f"{prefix}.in_proj_b.weight", full[:full_mid])
+        store(f"{prefix}.in_proj_a.weight", full[full_mid:])
+    else:
+        store(f"{prefix}.in_proj_b.weight", ba_weight[:mid])
+        store(f"{prefix}.in_proj_a.weight", ba_weight[mid:])
+        if isinstance(ba_qs, dict):
+            _store_quant_state(f"{prefix}.in_proj_b", ba_states[0])
+            _store_quant_state(f"{prefix}.in_proj_a", ba_states[1])
+
+    if ba_weight.dtype == torch.float8_e4m3fn:
+        scale_attr = None
+        if hasattr(ba_layer, "weight_scale"):
+            scale_attr = "weight_scale"
+        elif hasattr(ba_layer, "weight_scale_inv"):
+            scale_attr = "weight_scale_inv"
+        ws = _unwrap(getattr(ba_layer, scale_attr)) if scale_attr is not None else None
+        if ws is not None:
+            if ws.ndim == 2 and ws.shape[1] > 1:
+                block_size = ba_layer.weight_block_size[0]
+                scale_mid = mid // block_size
+                b_scale = ws[:scale_mid]
+                a_scale = ws[scale_mid:]
+            else:
+                b_scale = ws[:mid]
+                a_scale = ws[mid:]
+            store(f"{prefix}.in_proj_b.{scale_attr}", b_scale)
+            store(f"{prefix}.in_proj_a.{scale_attr}", a_scale)
+
+    store(f"{prefix}.conv1d.weight", gdn.conv1d.weight.data)
+    store(f"{prefix}.dt_bias", gdn.dt_bias.data)
+    store(f"{prefix}.A_log", gdn.A_log.data)
+
+    if hasattr(gdn, "norm") and hasattr(gdn.norm, "weight"):
+        store(f"{prefix}.norm.weight", gdn.norm.weight.data)
+
+    get_state_dict(f"{prefix}.out_proj", 0, state_dict, gdn.out_proj)
+pass
 
 
 def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_state_dict):
@@ -790,7 +1353,7 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
 
             if layer_module is not None:
                 if "qkv" in layer_path:
-                    if model_type in ("qwen2_5_vl", "qwen3_vl"):
+                    if model_type in ("qwen2_5_vl", "qwen3_vl", "qwen3_5"):
                         # If the HF model too prefers having merged qkv, we do this
                         # This is evident in qwen-2.5-vl and qwen-3-vl so far.
                         get_state_dict(layer_path, 0, state_dict, layer_module, slice_weights=False)
@@ -809,7 +1372,7 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
                     if isinstance(layer_module, torch.nn.Module):
                         if hasattr(layer_module, 'weight'):
                             get_state_dict(layer_path, 0, state_dict, layer_module)
-                    elif isinstance(layer_module, torch.nn.Parameter):
+                    elif isinstance(layer_module, torch.Tensor):
                         state_dict[f"{layer_path}"] = layer_module.data
                         quant_state_dict[f"{layer_path}"] = state_dict[f"{layer_path}"]
                     else:
@@ -824,7 +1387,7 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
             if hasattr(component, 'weight'):
                 # Prefer using get_state_dict when possible
                 get_state_dict(component_path, 0, state_dict, component)
-            elif isinstance(component, torch.nn.Parameter):
+            elif isinstance(component, torch.Tensor):
                 state_dict[component_path] = component.data
                 quant_state_dict[component_path] = component.data
             elif isinstance(component, torch.nn.Module):

--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -295,7 +295,7 @@ def get_auto_processor(name, **kwargs):
                 with open(processor_config, "r", encoding="utf-8") as f:
                     config = json.load(f)
                 processor_class = config["processor_class"]
-                # Strip _Unsloth_Patched_ prefix from old saves (issue #4085)
+                # Strip _Unsloth_Patched_ prefix from old saves (unsloth issue 4085)
                 if processor_class.startswith("_Unsloth_Patched_"):
                     processor_class = processor_class[len("_Unsloth_Patched_"):]
                 model_type = reversal_map[processor_class]
@@ -345,7 +345,7 @@ def get_auto_processor(name, **kwargs):
                 pass
     pass
 
-    # Fix _Unsloth_Patched_ prefix in copied config files (issue #4085)
+    # Fix _Unsloth_Patched_ prefix in copied config files (unsloth issue 4085)
     for cfg_name in ["processor_config.json", "preprocessor_config.json", "tokenizer_config.json"]:
         cfg_path = os.path.join(temp_name, cfg_name)
         if os.path.exists(cfg_path):

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1007,8 +1007,122 @@ def _resolve_num_experts_from_lora_stats(lora_stats, fallback):
     return fallback
 
 
-def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim):
-    """Shape-classify as 'swapped' / 'standard' / 'unknown'; returns (layout, r)."""
+# MoE-quant save-side dispatch. Each quant kind (FP8 today, room for bnb4bit
+# later) registers a handler in `unsloth_zoo.temporary_patches.moe_utils_fp8.
+# _MOE_QUANT_HANDLERS`; we consult that list via `apply_moe_quant_load`
+# instead of inlining quant-specific dequant/requant math here.
+try:
+    from unsloth_zoo.temporary_patches.moe_utils_fp8 import (
+        apply_moe_quant_load as _apply_moe_quant_load,
+        _MOE_QUANT_UNSAFE,
+    )
+except ImportError:
+    _apply_moe_quant_load = None
+    _MOE_QUANT_UNSAFE = object()
+
+
+def _merge_moe_expert_quant_aware(
+    role: str,
+    key: str,
+    file,
+    header_metadata,
+    lora_stats,
+    expert_idx: int,
+    num_experts: int,
+    output_dtype,
+    mm,
+    length_of_header,
+    processed_mxfp4_keys,
+    merge_fn,
+) -> bool:
+    """Read one expert weight (dequantising any quant kind via the registry),
+    apply `merge_fn`, requantise (if the handler returned a requant closure),
+    write data + any companion scale tensors back to `mm`. Returns True on a
+    successful merge+write, False on skip (key missing or sentinel)."""
+    if key not in header_metadata:
+        return False
+
+    if _apply_moe_quant_load is None:
+        W = file.get_tensor(key)
+        requant_fn = None
+    else:
+        loaded = _apply_moe_quant_load(file, header_metadata, key)
+        if loaded[0] is _MOE_QUANT_UNSAFE:
+            _record_moe_merge_fallback(
+                role, expert_idx,
+                f"{role} base at {key} has no usable quant companion scale; "
+                "skipping LoRA merge to avoid scale-loss corruption",
+                lora_stats, None,
+            )
+            return False
+        W, requant_fn = loaded
+
+    merged = merge_fn(W, lora_stats, expert_idx, num_experts, output_dtype or W.dtype)
+
+    if requant_fn is None:
+        write_dtype = W.dtype
+    else:
+        merged, write_dtype, extra_writes = requant_fn(merged)
+        for extra_key, extra_tensor, extra_dtype in extra_writes:
+            _write_tensor_direct_torch(
+                mm, header_metadata, length_of_header,
+                extra_key, extra_tensor, extra_dtype,
+            )
+            processed_mxfp4_keys.add(extra_key)
+
+    _write_tensor_direct_torch(mm, header_metadata, length_of_header, key, merged, write_dtype)
+    processed_mxfp4_keys.add(key)
+    return True
+
+
+def _peft_paramwrapper_swaps_in_out():
+    """True if installed PEFT version's ParamWrapper.update_layer performs the
+    `(experts, in, out) -> (experts, out, in)` swap for 3D non-transposed MoE
+    params. Introduced in PEFT 0.19; absent in 0.18 and earlier.
+
+    Prefers `peft.__version__` (cheap, stable) and falls back to checking
+    whether `ParamWrapper` exposes `_did_swap_in_out_features` as a class
+    attribute (defined at __init__ time in 0.19, absent in 0.18). Last-resort
+    fallback to inspect.getsource if neither is available (e.g. a packaged
+    PEFT without a version string).
+    """
+    try:
+        from peft import __version__ as _peft_version
+        major, minor = _peft_version.split(".")[:2]
+        return (int(major), int(minor)) >= (0, 19)
+    except Exception:
+        pass
+    try:
+        from peft.tuners.lora.layer import ParamWrapper
+        # PEFT 0.19's update_layer references `_did_swap_in_out_features`; the
+        # attribute is set on instances, not the class, so a hasattr check on
+        # the class doesn't suffice — fall back to source inspection.
+        import inspect
+        return "_did_swap_in_out_features" in inspect.getsource(ParamWrapper.update_layer)
+    except Exception:
+        return True  # assume modern PEFT
+
+
+_PEFT_AMBIGUOUS_LAYOUT_DEFAULT = "standard" if _peft_paramwrapper_swaps_in_out() else "swapped"
+
+
+def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim, lora_module=None):
+    """Shape-classify as 'swapped' / 'standard' / 'unknown'; returns (layout, r).
+
+    When 2*I == H for the fused gate_up_proj (common when intermediate is
+    half the hidden dim), both 'standard' and 'swapped' shape checks pass.
+    For that ambiguous case the right default depends on whether PEFT swapped
+    in/out features when creating the ParamWrapper:
+
+    - PEFT 0.19+ swaps for 3D non-transposed MoE → `lora_A.dim_A == in_dim`,
+      which corresponds to the "standard" branch of the merge math.
+    - PEFT 0.18 and earlier do NOT swap → `lora_A.dim_A == out_dim`, which
+      corresponds to the "swapped" branch.
+
+    `_PEFT_AMBIGUOUS_LAYOUT_DEFAULT` is computed once at import time from the
+    installed PEFT version. A caller can still override per-call by passing a
+    `lora_module` with `_did_swap_in_out_features` set explicitly.
+    """
     total_rank_A, dim_A = lora_A.shape
     dim_B, total_rank_B = lora_B.shape
     if total_rank_A != total_rank_B or num_experts is None or num_experts <= 0:
@@ -1016,10 +1130,21 @@ def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim):
     if total_rank_A % num_experts != 0:
         return "unknown", 0
     r = total_rank_A // num_experts
-    if dim_A == out_dim and dim_B == in_dim:
-        return "swapped", r
-    if dim_A == in_dim and dim_B == out_dim:
+    standard_match = (dim_A == in_dim and dim_B == out_dim)
+    swapped_match  = (dim_A == out_dim and dim_B == in_dim)
+    if standard_match and swapped_match:
+        # Ambiguous shape (typically 2*I == H). Prefer an explicit per-wrapper
+        # signal when available, otherwise fall back to the PEFT-version-aware
+        # default. `_did_swap_in_out_features = True` means PEFT swapped in/out
+        # at training time, which corresponds to "standard" storage from the
+        # merge code's perspective.
+        if lora_module is not None and hasattr(lora_module, "_did_swap_in_out_features"):
+            return ("standard" if lora_module._did_swap_in_out_features else "swapped"), r
+        return _PEFT_AMBIGUOUS_LAYOUT_DEFAULT, r
+    if standard_match:
         return "standard", r
+    if swapped_match:
+        return "swapped", r
     return "unknown", r
 
 
@@ -1031,12 +1156,25 @@ def _merge_moe_gate_or_up_expert(W, lora_stats, expert_idx, num_experts, output_
     try:
         num_experts = _resolve_num_experts_from_lora_stats(lora_stats, num_experts)
         if num_experts is None or num_experts <= 0:
-            num_experts = lora_stats.lora_A.shape[0] // max(1, getattr(lora_stats, "rank", 0) or 1)
+            rank = getattr(lora_stats, "rank", 0) or 0
+            if rank <= 0:
+                # No usable num_experts AND no rank metadata. Falling back to
+                # `total_rank // 1` would produce a degenerate r=1 slicing
+                # whose shape check happens to pass but emits a wrong delta —
+                # silently. Refuse to merge.
+                _record_moe_merge_fallback(
+                    role, expert_idx,
+                    "num_experts and lora_stats.rank both missing — cannot derive per-expert slicing",
+                    lora_stats, tuple(W.shape),
+                )
+                return W
+            num_experts = lora_stats.lora_A.shape[0] // rank
 
         I, H = W.shape
         layout, r = _detect_moe_lora_layout(
             lora_stats.lora_A, lora_stats.lora_B,
             num_experts = num_experts, out_dim = 2 * I, in_dim = H,
+            lora_module = getattr(lora_stats, "module", None),
         )
         if layout == "unknown" or r <= 0:
             _record_moe_merge_fallback(
@@ -1051,6 +1189,15 @@ def _merge_moe_gate_or_up_expert(W, lora_stats, expert_idx, num_experts, output_
             _record_moe_merge_fallback(role, expert_idx, "expert_idx out of range", lora_stats, (I, H))
             return W
 
+        # unsloth's MoE forward (temporary_patches/moe_utils.py
+        # `_canonical_lora_weights_for_grouped_mm`) views lora_B as
+        # (out, num_experts, r) — contiguous-r columns per expert. This
+        # MUST match here so the merged checkpoint reproduces the unsloth
+        # training-time forward. (PEFT's own `get_delta_weight` uses
+        # stride-E reshape `(out, r, E)`, but unsloth bypasses PEFT's
+        # forward via `patch_param_wrapper_for_moe`, so the stored
+        # tensors only need to be interpreted with the same convention as
+        # unsloth's forward.)
         a_slice = lora_stats.lora_A[start:end, :]
         b_slice = lora_stats.lora_B[:, start:end]
         device  = _active_merge_device()
@@ -1097,12 +1244,21 @@ def _merge_moe_down_proj_expert(down_W, lora_stats, expert_idx, num_experts, out
     try:
         num_experts = _resolve_num_experts_from_lora_stats(lora_stats, num_experts)
         if num_experts is None or num_experts <= 0:
-            num_experts = lora_stats.lora_A.shape[0] // max(1, getattr(lora_stats, "rank", 0) or 1)
+            rank = getattr(lora_stats, "rank", 0) or 0
+            if rank <= 0:
+                _record_moe_merge_fallback(
+                    "down", expert_idx,
+                    "num_experts and lora_stats.rank both missing — cannot derive per-expert slicing",
+                    lora_stats, tuple(down_W.shape),
+                )
+                return down_W
+            num_experts = lora_stats.lora_A.shape[0] // rank
 
         H, I = down_W.shape
         layout, r = _detect_moe_lora_layout(
             lora_stats.lora_A, lora_stats.lora_B,
             num_experts = num_experts, out_dim = H, in_dim = I,
+            lora_module = getattr(lora_stats, "module", None),
         )
         if layout == "unknown" or r <= 0:
             _record_moe_merge_fallback(
@@ -1117,6 +1273,7 @@ def _merge_moe_down_proj_expert(down_W, lora_stats, expert_idx, num_experts, out
             _record_moe_merge_fallback("down", expert_idx, "expert_idx out of range", lora_stats, (H, I))
             return down_W
 
+        # See _merge_moe_gate_or_up_expert for the slicing convention rationale.
         a_slice = lora_stats.lora_A[start:end, :]
         b_slice = lora_stats.lora_B[:, start:end]
         device  = _active_merge_device()
@@ -1367,37 +1524,26 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
             if is_gate:
                 gate_key = f"{prefix}.{expert_idx}.gate_proj.weight"
                 up_key   = f"{prefix}.{expert_idx}.up_proj.weight"
-
-                # Check for gate_proj
-                if gate_key in header_metadata:
-                    gate_W = file.get_tensor(gate_key)
-                    merged_gate = _merge_moe_gate_expert(
-                        gate_W, lora_stats, expert_idx, num_experts, output_dtype or gate_W.dtype
-                    )
-                    _write_tensor_direct_torch(mm, header_metadata, length_of_header, gate_key, merged_gate, gate_W.dtype)
-                    processed_mxfp4_keys.add(gate_key)
+                if _merge_moe_expert_quant_aware(
+                    "gate", gate_key, file, header_metadata, lora_stats,
+                    expert_idx, num_experts, output_dtype, mm, length_of_header,
+                    processed_mxfp4_keys, _merge_moe_gate_expert,
+                ):
                     module_updated = True
-
-                # Check for up_proj
-                if up_key in header_metadata:
-                    up_W = file.get_tensor(up_key)
-                    merged_up = _merge_moe_up_expert(
-                        up_W, lora_stats, expert_idx, num_experts, output_dtype or up_W.dtype
-                    )
-                    _write_tensor_direct_torch(mm, header_metadata, length_of_header, up_key, merged_up, up_W.dtype)
-                    processed_mxfp4_keys.add(up_key)
+                if _merge_moe_expert_quant_aware(
+                    "up", up_key, file, header_metadata, lora_stats,
+                    expert_idx, num_experts, output_dtype, mm, length_of_header,
+                    processed_mxfp4_keys, _merge_moe_up_expert,
+                ):
                     module_updated = True
             else:
                 down_key = f"{prefix}.{expert_idx}.down_proj.weight"
-                if down_key not in header_metadata:
-                    continue
-                down_W = file.get_tensor(down_key)
-                merged_down = _merge_moe_down_proj_expert(
-                    down_W, lora_stats, expert_idx, num_experts, output_dtype or down_W.dtype
-                )
-                _write_tensor_direct_torch(mm, header_metadata, length_of_header, down_key, merged_down, down_W.dtype)
-                processed_mxfp4_keys.add(down_key)
-                module_updated = True
+                if _merge_moe_expert_quant_aware(
+                    "down", down_key, file, header_metadata, lora_stats,
+                    expert_idx, num_experts, output_dtype, mm, length_of_header,
+                    processed_mxfp4_keys, _merge_moe_down_proj_expert,
+                ):
+                    module_updated = True
         if module_updated and not already_counted:
             count += 1
             counted_lora_modules.add(lora_key)
@@ -1412,8 +1558,13 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
       - Standard (Gemma4):    (E, 2*I, H) with lora_A (E*R, H), lora_B (2*I, E*R)
     is_transposed: if provided, overrides dimension-based heuristic (needed when dims are equal).
     """
+    _MOE_MERGE_STATE["attempted"] += 1
     try:
         if lora_stats.lora_A is None or lora_stats.lora_B is None:
+            _record_moe_merge_fallback(
+                "fused_gate_up", -1, "lora_A or lora_B is None",
+                lora_stats, tuple(gate_up_W.shape),
+            )
             return gate_up_W
 
         num_experts, dim1, dim2 = gate_up_W.shape
@@ -1421,10 +1572,20 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
         dim_B, total_rank_B = lora_stats.lora_B.shape
 
         if total_rank_B != total_rank:
+            _record_moe_merge_fallback(
+                "fused_gate_up", -1,
+                f"total_rank mismatch (A.shape[0]={total_rank}, B.shape[1]={total_rank_B})",
+                lora_stats, tuple(gate_up_W.shape),
+            )
             return gate_up_W
 
         rank = total_rank // num_experts
         if total_rank % num_experts != 0:
+            _record_moe_merge_fallback(
+                "fused_gate_up", -1,
+                f"total_rank {total_rank} not divisible by num_experts {num_experts}",
+                lora_stats, tuple(gate_up_W.shape),
+            )
             return gate_up_W
 
         if is_transposed is not None:
@@ -1434,6 +1595,11 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
         elif dim_A == dim2 and dim_B == dim1:
             use_transpose = False
         else:
+            _record_moe_merge_fallback(
+                "fused_gate_up", -1,
+                f"layout ambiguous (W.shape={tuple(gate_up_W.shape)}, A.shape={tuple(lora_stats.lora_A.shape)}, B.shape={tuple(lora_stats.lora_B.shape)})",
+                lora_stats, tuple(gate_up_W.shape),
+            )
             return gate_up_W
 
         device = _active_merge_device()
@@ -1441,6 +1607,10 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
 
         for expert_idx in range(num_experts):
             start, end = expert_idx * rank, (expert_idx + 1) * rank
+            # unsloth's MoE forward views lora_B contiguous-r per expert
+            # (see temporary_patches/moe_utils.py
+            # `_canonical_lora_weights_for_grouped_mm`); the merge must
+            # match so the saved checkpoint reproduces training-time forward.
             a_slice = lora_stats.lora_A[start:end, :]
             b_slice = lora_stats.lora_B[:, start:end]
             delta = b_slice.to(
@@ -1451,8 +1621,13 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
                 delta.T if use_transpose else delta, alpha=lora_stats.alpha
             )
 
+        _MOE_MERGE_STATE["applied"] += 1
         return gate_up_merged.to(output_dtype)
-    except Exception:
+    except Exception as exc:
+        _record_moe_merge_fallback(
+            "fused_gate_up", -1, repr(exc),
+            lora_stats, tuple(gate_up_W.shape),
+        )
         return gate_up_W
 
 
@@ -1464,8 +1639,13 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
       - Standard (Gemma4):    (E, H, I) with lora_A (E*R, H), lora_B (I, E*R)
     is_transposed: if provided, overrides dimension-based heuristic (needed when H==I).
     """
+    _MOE_MERGE_STATE["attempted"] += 1
     try:
         if lora_stats.lora_A is None or lora_stats.lora_B is None:
+            _record_moe_merge_fallback(
+                "fused_down", -1, "lora_A or lora_B is None",
+                lora_stats, tuple(down_W.shape),
+            )
             return down_W
 
         num_experts, dim1, dim2 = down_W.shape
@@ -1473,10 +1653,20 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
         dim_B, total_rank_B = lora_stats.lora_B.shape
 
         if total_rank_B != total_rank:
+            _record_moe_merge_fallback(
+                "fused_down", -1,
+                f"total_rank mismatch (A.shape[0]={total_rank}, B.shape[1]={total_rank_B})",
+                lora_stats, tuple(down_W.shape),
+            )
             return down_W
 
         rank = total_rank // num_experts
         if total_rank % num_experts != 0:
+            _record_moe_merge_fallback(
+                "fused_down", -1,
+                f"total_rank {total_rank} not divisible by num_experts {num_experts}",
+                lora_stats, tuple(down_W.shape),
+            )
             return down_W
 
         if is_transposed is not None:
@@ -1486,6 +1676,11 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
         elif dim_A == dim2 and dim_B == dim1:
             use_transpose = False
         else:
+            _record_moe_merge_fallback(
+                "fused_down", -1,
+                f"layout ambiguous (W.shape={tuple(down_W.shape)}, A.shape={tuple(lora_stats.lora_A.shape)}, B.shape={tuple(lora_stats.lora_B.shape)})",
+                lora_stats, tuple(down_W.shape),
+            )
             return down_W
 
         device = _active_merge_device()
@@ -1493,6 +1688,7 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
 
         for expert_idx in range(num_experts):
             start, end = expert_idx * rank, (expert_idx + 1) * rank
+            # See _merge_moe_fused_gate_up_expert for the slicing rationale.
             a_slice = lora_stats.lora_A[start:end, :]
             b_slice = lora_stats.lora_B[:, start:end]
             delta = b_slice.to(
@@ -1503,8 +1699,13 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
                 delta.T if use_transpose else delta, alpha=lora_stats.alpha
             )
 
+        _MOE_MERGE_STATE["applied"] += 1
         return down_merged.to(output_dtype)
-    except Exception:
+    except Exception as exc:
+        _record_moe_merge_fallback(
+            "fused_down", -1, repr(exc),
+            lora_stats, tuple(down_W.shape),
+        )
         return down_W
 
 

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -32,4 +32,6 @@ from .pixtral import *
 from .ministral import *
 from .mxfp4 import *
 from .bitsandbytes import *
+from .moe_utils_bnb4bit import *
+from .moe_utils_fp8 import *
 from .flex_attention_bwd import *

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -20,6 +20,7 @@ __all__ = [
     "UNSLOTH_ENABLE_LOGGING",
     "UNSLOTH_COMPILE_DISABLE",
     "get_torch_compile_options",
+    "is_transformers_v5_moe_quantization_available",
     "logger",
     "torch_compile",
     "_torch_compile",
@@ -46,6 +47,30 @@ def determine_compile_threads():
     cpu_count = os.cpu_count()
     return min(32, max(4, cpu_count))
 pass
+
+@functools.lru_cache(1)
+def is_transformers_v5_moe_quantization_available():
+    """
+    True when Transformers exposes the v5 MoE weight-loading/dispatcher APIs
+    that PR #659 patches. Transformers v4 does not use bare nn.Parameter MoE
+    experts for these paths, so the v5-only patches should not be registered.
+    """
+    try:
+        from transformers.core_model_loading import WeightConverter
+        from transformers.integrations import moe as transformers_moe
+        from transformers.quantizers.quantizer_bnb_4bit import Bnb4BitHfQuantizer
+    except (ImportError, AttributeError):
+        return False
+
+    return (
+        WeightConverter is not None
+        and getattr(Bnb4BitHfQuantizer, "param_needs_quantization", None) is not None
+        and getattr(transformers_moe, "ALL_EXPERTS_FUNCTIONS", None) is not None
+        and (
+            getattr(transformers_moe, "grouped_mm_experts_forward", None) is not None
+            or getattr(transformers_moe, "batched_mm_experts_forward", None) is not None
+        )
+    )
 
 def get_torch_compile_options(
     epilogue_fusion = True,

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -608,6 +608,63 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma4AudioAttention)
 
 
+# ============================================================================
+# Gemma4 PEFT reload patch - make PeftModel.from_pretrained handle adapters
+# saved against Gemma4ClippableLinear.inner .linear modules.
+# ============================================================================
+
+def patch_Gemma4ClippableLinear_peft_reload():
+    try:
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4ClippableLinear
+        from peft.tuners.lora.model import LoraModel
+    except ImportError:
+        return
+    except Exception as e:
+        return raise_error("Gemma4ClippableLinear PEFT reload", e)
+
+    original_create_and_replace = LoraModel._create_and_replace
+    if getattr(original_create_and_replace, "_unsloth_gemma4_clippable_linear_patched", False):
+        return
+
+    def create_and_replace(
+        self,
+        peft_config,
+        adapter_name,
+        target,
+        target_name,
+        parent,
+        current_key=None,
+        **kwargs,
+    ):
+        if isinstance(target, Gemma4ClippableLinear):
+            return original_create_and_replace(
+                self,
+                peft_config,
+                adapter_name,
+                target.linear,
+                "linear",
+                target,
+                current_key=current_key,
+                **kwargs,
+            )
+        return original_create_and_replace(
+            self,
+            peft_config,
+            adapter_name,
+            target,
+            target_name,
+            parent,
+            current_key=current_key,
+            **kwargs,
+        )
+
+    create_and_replace._unsloth_gemma4_clippable_linear_patched = True
+    create_and_replace._unsloth_original_create_and_replace = original_create_and_replace
+    LoraModel._create_and_replace = create_and_replace
+pass
+TEMPORARY_PATCHES.append(patch_Gemma4ClippableLinear_peft_reload)
+
+
 # Gemma-4 float16 MLP overflow fix.
 #
 # `down_proj(act_fn(gate_proj(x)) * up_proj(x))` overflows fp16 at layers.0

--- a/unsloth_zoo/temporary_patches/glm4_moe.py
+++ b/unsloth_zoo/temporary_patches/glm4_moe.py
@@ -98,7 +98,36 @@ def patch_glm4_moe():
     patch_function(Glm4MoeLiteMoE,      "forward", moe_block_forward)
 
     if UNSLOTH_ENABLE_LOGGING:
-        logger.info("Unsloth: Patched GLM4 MoE for Split LoRA support.")
+        logger.info("Unsloth: Patched GLM4 MoE Lite for Split LoRA support.")
 
-# Register the patch
+
+def patch_glm4_moe_standard():
+    """Patches standard (non-lite) GLM4 MoE for Split LoRA using grouped GEMM."""
+    patch_param_wrapper_for_moe()
+
+    try:
+        from transformers.models.glm4_moe.modeling_glm4_moe import Glm4MoeNaiveMoe
+    except ImportError:
+        return
+
+    def _glm4_std_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts):
+        return extract_moe_lora_weights_for_grouped_mm(
+            wrapper,
+            weight_A,
+            weight_B,
+            scaling,
+            num_experts,
+            model_name="GLM4 MoE",
+            enable_logging=UNSLOTH_ENABLE_LOGGING,
+            logger_obj=logger,
+        )
+
+    Glm4MoeNaiveMoe._unsloth_lora_extractor_fn = staticmethod(_glm4_std_lora_extractor)
+    patch_function(Glm4MoeNaiveMoe, "forward", get_forward_moe_backend())
+
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: Patched GLM4 MoE (standard) for Split LoRA support.")
+
+# Register the patches
 TEMPORARY_PATCHES.append(patch_glm4_moe)
+TEMPORARY_PATCHES.append(patch_glm4_moe_standard)

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -1494,7 +1494,6 @@ def patch_peft_dispatch_bnb_4bit():
 pass
 TEMPORARY_PATCHES.append(patch_peft_dispatch_bnb_4bit)
 
-
 def patch_trl_push_to_hub_token():
     """Ensure to_dict() always includes push_to_hub_token for TRL compat.
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -28,6 +28,14 @@ UNSLOTH_COMPILE_LOCATION = os.environ.get(
     "UNSLOTH_COMPILE_LOCATION", "unsloth_compiled_cache"
 )
 
+try:
+    import bitsandbytes as bnb
+    from bitsandbytes.nn import Params4bit
+    HAS_BNB = True
+except ImportError:
+    HAS_BNB = False
+    Params4bit = None
+
 
 def _get_compile_location() -> str:
     return os.path.abspath(
@@ -128,8 +136,35 @@ def _grouped_mm_with_backward_fix(
     Grouped matmul with working backward pass.
 
     Uses native torch._grouped_mm with contiguous inputs for correct gradients.
+    Some low-rank LoRA weights are contiguous but still have row strides below
+    the kernel alignment requirement, so keep a narrow fallback for those cases.
     """
-    return torch._grouped_mm(inputs, weight, offs=offsets)
+    inputs = inputs.contiguous()
+    weight = weight.contiguous()
+    try:
+        return torch._grouped_mm(inputs, weight, offs=offsets)
+    except RuntimeError as exc:
+        message = str(exc)
+        if "strides should be multiple of 16 bytes" not in message:
+            raise
+        return _manual_grouped_mm(inputs, weight, offsets)
+
+
+def _manual_grouped_mm(
+    inputs: torch.Tensor, weight: torch.Tensor, offsets: torch.Tensor
+) -> torch.Tensor:
+    """
+    Differentiable grouped matmul fallback for torch._grouped_mm alignment gaps.
+    """
+    outputs = []
+    start = 0
+    for expert_idx, end in enumerate(offsets.detach().cpu().tolist()):
+        if start < end:
+            outputs.append(torch.matmul(inputs[start:end], weight[expert_idx]))
+        start = end
+    if outputs:
+        return torch.cat(outputs, dim=0)
+    return inputs.new_empty((0, weight.shape[-1]))
 
 
 # Global flag to check if grouped GEMM is available
@@ -270,6 +305,23 @@ def select_moe_backend():
     return "native_torch"
 
 
+def swap_moe_weights_for_call(experts_module, gate_up_proj, down_proj, forward_fn, *args):
+    """Temporarily install dequantized weights on the experts module for one
+    forward call, then restore the originals. Uses object.__setattr__ to bypass
+    nn.Module's Parameter (de)registration, which would re-register hooks and
+    is unnecessary for read-only temporary tensors. Used by both the FP8 and
+    bnb4bit MoE dispatchers."""
+    original_gate_up = experts_module.gate_up_proj
+    original_down = experts_module.down_proj
+    object.__setattr__(experts_module, "gate_up_proj", gate_up_proj)
+    object.__setattr__(experts_module, "down_proj", down_proj)
+    try:
+        return forward_fn(experts_module, *args)
+    finally:
+        object.__setattr__(experts_module, "gate_up_proj", original_gate_up)
+        object.__setattr__(experts_module, "down_proj", original_down)
+
+
 def forward_moe_backend(
     self,
     hidden_states: torch.Tensor,
@@ -281,6 +333,37 @@ def forward_moe_backend(
     Centralizes backend selection to keep model-specific patches minimal.
     """
     # This Unsloth Zoo code section is licensed under AGPL3
+
+    # Use absolute imports — this function is also copied into
+    # `unsloth_compiled_cache/moe_utils.py` where relative imports of sibling
+    # helper modules don't resolve (only the dispatcher is copied, helpers stay
+    # in unsloth_zoo.temporary_patches).
+    # Narrow `except ImportError` to ONLY the import statement; runtime errors
+    # inside the bnb4bit/fp8 path must propagate so we don't silently fall
+    # through to a backend that will crash on unsupported dtypes.
+    _moe_uses_bnb4bit_expert_weights = forward_moe_backend_bnb4bit = None
+    try:
+        from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import (
+            _moe_uses_bnb4bit_expert_weights,
+            forward_moe_backend_bnb4bit,
+        )
+    except ImportError:
+        pass
+    if _moe_uses_bnb4bit_expert_weights is not None and _moe_uses_bnb4bit_expert_weights(self):
+        result = forward_moe_backend_bnb4bit(self, hidden_states, top_k_index, top_k_weights)
+        if result is not None:
+            return result
+
+    _moe_uses_fp8_expert_weights = forward_moe_backend_fp8 = None
+    try:
+        from unsloth_zoo.temporary_patches.moe_utils_fp8 import (
+            _moe_uses_fp8_expert_weights,
+            forward_moe_backend_fp8,
+        )
+    except ImportError:
+        pass
+    if _moe_uses_fp8_expert_weights is not None and _moe_uses_fp8_expert_weights(self):
+        return forward_moe_backend_fp8(self, hidden_states, top_k_index, top_k_weights)
 
     backend = select_moe_backend()
     if backend == "grouped_mm":
@@ -609,6 +692,17 @@ def _get_base_weight(param):
     while hasattr(param, "base_layer"):
         param = param.base_layer
 
+    if HAS_BNB and isinstance(param, Params4bit):
+        if getattr(param, "quant_state", None) is None:
+            raise RuntimeError(
+                "unsloth: _get_base_weight saw a Params4bit with quant_state=None. "
+                "This usually means the model was used in forward before loading "
+                "completed quantization (meta placeholder still in place), or the "
+                "MoE quantizer patch did not fire for this expert. "
+                f"data.shape={tuple(param.data.shape)}, device={param.device}."
+            )
+        return bnb.functional.dequantize_4bit(param.data, param.quant_state)
+
     if hasattr(param, "get_param"):
         return param.get_param()
 
@@ -778,6 +872,8 @@ def _is_moe_experts_module(module) -> bool:
     if hasattr(module, "gate_up_proj"):
         param = module.gate_up_proj
         # 4-bit parameters are packed into 2D tensors (n_params, 1) or similar.
+        if HAS_BNB and isinstance(param, Params4bit) and param.ndim == 2:
+            return True
         # Standard MoE weights are 3D (num_experts, in, out).
         if isinstance(param, (nn.Parameter, torch.Tensor)) and param.ndim in (2, 3):
             return True

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -1,0 +1,618 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+bitsandbytes 4-bit support for transformers v5 MoE expert parameters.
+
+transformers' bitsandbytes integration only quantizes nn.Linear modules. MoE
+expert weights in transformers v5 are bare 3-D nn.Parameters
+(gate_up_proj / down_proj on the experts module), so the integration skips
+them. The patches here teach the integration to recognize and quantize those
+parameters, and route the experts forward through the standard backend after
+on-the-fly dequantization.
+"""
+
+import os
+from typing import Optional, List, Union
+
+import torch
+import torch.nn as nn
+
+from .common import (
+    TEMPORARY_PATCHES,
+    UNSLOTH_ENABLE_LOGGING,
+    is_transformers_v5_moe_quantization_available,
+    logger,
+)
+from .utils import patch_function, raise_error
+
+
+try:
+    import bitsandbytes as bnb
+    from bitsandbytes.nn import Params4bit
+    HAS_BNB = True
+except ImportError:
+    HAS_BNB = False
+    Params4bit = None
+
+
+__all__ = [
+    "patch_bnb4bit_quantize_convert",
+    "patch_bnb4bit_quantizer_param_needs_quantization",
+    "patch_bnb4bit_quantizer_process_model",
+    "patch_transformers_weight_converter_kwargs",
+    "replace_expert_params_with_bnb_params",
+    "forward_moe_backend_bnb4bit",
+    "_moe_uses_bnb4bit_expert_weights",
+]
+
+
+# ============================================================================
+# Detection
+# ============================================================================
+
+def _is_bnb4bit_param(param) -> bool:
+    """True iff `param` is a Params4bit with a populated quant_state."""
+    return (
+        HAS_BNB
+        and isinstance(param, Params4bit)
+        and getattr(param, "quant_state", None) is not None
+    )
+
+
+def _moe_uses_bnb4bit_expert_weights(self) -> bool:
+    """True iff this experts module's gate_up_proj / down_proj are bnb 4-bit."""
+    if not HAS_BNB:
+        return False
+    return _is_bnb4bit_param(getattr(self, "gate_up_proj", None)) or _is_bnb4bit_param(
+        getattr(self, "down_proj", None)
+    )
+
+
+def _is_expert_module(module: nn.Module) -> bool:
+    """A module is a transformers v5 MoE experts module iff gate_up_proj and
+    down_proj are both nn.Parameter (not nn.Linear).
+    """
+    return (
+        hasattr(module, "gate_up_proj")
+        and hasattr(module, "down_proj")
+        and isinstance(module.gate_up_proj, nn.Parameter)
+        and isinstance(module.down_proj, nn.Parameter)
+    )
+
+
+# ============================================================================
+# Dequantization
+# ============================================================================
+
+def _dequantize_bnb4bit_expert_weights(weight, target_dtype: torch.dtype):
+    """Dequantize a packed Params4bit MoE expert weight to logical 3D
+    `(E, in, out)` (or `(E, out, in)`, whichever the original storage was) at
+    `target_dtype`. Returns None if `weight` isn't a quantized Params4bit.
+    """
+    if not _is_bnb4bit_param(weight):
+        return None
+    dequant = bnb.functional.dequantize_4bit(weight.data, weight.quant_state)
+    original_shape = getattr(weight, "_original_shape", None)
+    if original_shape is not None and tuple(dequant.shape) != tuple(original_shape):
+        dequant = dequant.reshape(original_shape)
+    return dequant.to(target_dtype)
+
+
+# ============================================================================
+# Forward dispatcher
+# ============================================================================
+
+_LOGGED_BACKENDS = set()
+
+
+def _log_moe_bnb4bit_backend_once(experts_module, message: str):
+    key = (id(type(experts_module)), message)
+    if key in _LOGGED_BACKENDS:
+        return
+    _LOGGED_BACKENDS.add(key)
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info(message)
+
+
+def forward_moe_backend_bnb4bit(self, hidden_states, top_k_index, top_k_weights):
+    """
+    bnb 4-bit MoE forward: dequantize the expert weights to the input dtype,
+    then dispatch to the standard MoE backend (grouped_mm / triton / native).
+
+    Mirrors `forward_moe_backend_fp8` structure. Base weights stay in 4-bit
+    Params4bit storage; the dequantized copies are temporary.
+    """
+    from .moe_utils import (
+        select_moe_backend,
+        forward_native_grouped_mm,
+        forward_triton_grouped_gemm,
+        forward_native_moe_loop,
+        swap_moe_weights_for_call,
+    )
+
+    target_dtype = hidden_states.dtype
+    if not target_dtype.is_floating_point:
+        target_dtype = torch.bfloat16
+
+    gate_up_weight = _dequantize_bnb4bit_expert_weights(self.gate_up_proj, target_dtype)
+    down_weight = _dequantize_bnb4bit_expert_weights(self.down_proj, target_dtype)
+    if gate_up_weight is None or down_weight is None:
+        # Not bnb4bit after all (mixed state) — fall through to caller.
+        return None
+
+    backend = select_moe_backend()
+    if backend == "grouped_mm":
+        _log_moe_bnb4bit_backend_once(self, "Unsloth: MoE bnb4bit using dequantize-plus-grouped_mm.")
+        forward_fn = forward_native_grouped_mm
+    elif backend == "unsloth_triton":
+        _log_moe_bnb4bit_backend_once(self, "Unsloth: MoE bnb4bit using dequantize-plus-Triton grouped GEMM.")
+        forward_fn = forward_triton_grouped_gemm
+    else:
+        _log_moe_bnb4bit_backend_once(self, "Unsloth: MoE bnb4bit using dequantize-plus-native_torch loop.")
+        forward_fn = forward_native_moe_loop
+
+    return swap_moe_weights_for_call(
+        self,
+        gate_up_weight,
+        down_weight,
+        forward_fn,
+        hidden_states.to(target_dtype),
+        top_k_index,
+        top_k_weights,
+    )
+
+
+# ============================================================================
+# transformers integration patches
+# ============================================================================
+
+def replace_expert_params_with_bnb_params(
+    model: nn.Module,
+    modules_to_not_convert: Optional[List[str]] = None,
+    quantization_config = None,
+    pre_quantized: bool = False,
+) -> nn.Module:
+    """
+    Replace MoE parameters (gate_up_proj, down_proj) of nn.Parameter type with Params4bit.
+    """
+
+    try:
+        from transformers.quantizers.quantizers_utils import should_convert_module
+    except Exception as e:
+        return raise_error("transformers.quantizers.quantizers_utils.should_convert_module", e)
+
+    has_been_replaced = False
+
+    for module_name, module in model.named_modules():
+        if not should_convert_module(module_name, modules_to_not_convert):
+            continue
+
+        if not _is_expert_module(module):
+            continue
+
+        gate_up_proj = module.gate_up_proj
+        down_proj = module.down_proj
+
+        if isinstance(gate_up_proj, Params4bit) or isinstance(down_proj, Params4bit):
+            continue
+        with torch.device("meta"):
+            placeholder_gate_up = Params4bit(
+                torch.zeros(gate_up_proj.shape),
+                requires_grad=False,
+                compress_statistics=quantization_config.bnb_4bit_use_double_quant,
+                quant_type=quantization_config.bnb_4bit_quant_type,
+                quant_storage=quantization_config.bnb_4bit_quant_storage,
+            )
+
+            placeholder_down = Params4bit(
+                torch.zeros(down_proj.shape),
+                requires_grad=False,
+                compress_statistics=quantization_config.bnb_4bit_use_double_quant,
+                quant_type=quantization_config.bnb_4bit_quant_type,
+                quant_storage=quantization_config.bnb_4bit_quant_storage,
+            )
+
+        module.gate_up_proj = placeholder_gate_up
+        module.down_proj = placeholder_down
+        has_been_replaced = True
+
+        if UNSLOTH_ENABLE_LOGGING:
+            logger.info(f"Unsloth: Prepared {module_name}'s gate_up_proj & down_proj for BNB 4-bit quantization (shapes: {gate_up_proj.shape}, {down_proj.shape})")
+
+    if not has_been_replaced and UNSLOTH_ENABLE_LOGGING:
+        logger.info(
+            f"Unsloth: No MoE expert parameters were found to be replaced for "
+            f"{getattr(model, 'name_or_path', type(model).__name__)} (expected for non-MoE)"
+        )
+
+    return model
+
+
+def patch_bnb4bit_quantize_convert():
+    """
+    Expert modules of nn.Parameter type are converted to Params4bit placeholders during weight loading.
+    Also preserves the original shape of the expert parameters for PEFT LoRA compatibility.
+    """
+
+    try:
+        from transformers.integrations.bitsandbytes import Bnb4bitQuantize
+    except Exception as e:
+        return raise_error("transformers.integrations.bitsandbytes.Bnb4bitQuantize", e)
+
+    if hasattr(Bnb4bitQuantize.convert, "_unsloth_moe_patched"):
+        return
+
+    original_convert = Bnb4bitQuantize.convert
+
+    def patched_convert(
+        self,
+        input_dict: dict[str, Union[list[torch.Tensor], torch.Tensor]],
+        full_layer_name: str | None = None,
+        model: torch.nn.Module | None = None,
+        **kwargs,
+    ) -> dict[str, torch.Tensor]:
+        value = list(input_dict.values())[0]
+        if isinstance(value, (list, tuple)):
+            value = value[0]
+
+        try:
+            from transformers.quantizers.quantizers_utils import get_module_from_name
+            module, _ = get_module_from_name(model, full_layer_name)
+
+            if _is_expert_module(module):
+                old_value = model.get_parameter_or_buffer(full_layer_name)
+                old_dict = {k: v for k, v in old_value.__dict__.items()}
+                new_value = Params4bit(value, requires_grad=False, **old_dict).to(value.device)
+                # _original_shape is needed by PEFT LoRA to recover the logical 3D shape.
+                new_value._original_shape = value.shape
+                module._is_hf_initialized = True
+                return {full_layer_name: new_value}
+
+        except (KeyError, AttributeError) as e:
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.info(f"Unsloth: expert convert fall-through for {full_layer_name}: {e}")
+
+        return original_convert(self, input_dict, full_layer_name=full_layer_name, model=model, **kwargs)
+
+    patched_convert._unsloth_moe_patched = True
+    patch_function(Bnb4bitQuantize, "convert", patched_convert, match_level = "relaxed")
+
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: Patched Bnb4bitQuantize.convert for MoE expert parameter support")
+pass
+
+
+def patch_bnb4bit_quantizer_param_needs_quantization():
+    """Recognize MoE expert modules of Params4bit type as needing quantization."""
+
+    try:
+        from transformers.quantizers.quantizer_bnb_4bit import Bnb4BitHfQuantizer
+        from transformers.quantizers.quantizers_utils import get_module_from_name
+    except Exception as e:
+        return raise_error("transformers.quantizers.quantizer_bnb_4bit.Bnb4BitHfQuantizer", e)
+
+    original_param_needs_quantization = getattr(Bnb4BitHfQuantizer, "param_needs_quantization", None)
+    if original_param_needs_quantization is None:
+        return
+
+    if getattr(original_param_needs_quantization, "_unsloth_moe_patched", False):
+        return
+
+    def patched_param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
+        if original_param_needs_quantization(self, model, param_name, **kwargs):
+            return True
+
+        try:
+            module, name = get_module_from_name(model, param_name)
+            if name in ("gate_up_proj", "down_proj"):
+                param = getattr(module, name, None)
+                if isinstance(param, Params4bit) and not getattr(param, "bnb_quantized", False):
+                    return True
+        except (KeyError, AttributeError) as e:
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.info(f"Unsloth: param_needs_quantization fall-through for {param_name}: {e}")
+
+        return False
+
+    patched_param_needs_quantization._unsloth_moe_patched = True
+    patch_function(Bnb4BitHfQuantizer, "param_needs_quantization", patched_param_needs_quantization)
+
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: Patched Bnb4BitHfQuantizer.param_needs_quantization for MoE expert parameters")
+pass
+
+
+def patch_bnb4bit_quantizer_process_model():
+    try:
+        from transformers.quantizers.quantizer_bnb_4bit import Bnb4BitHfQuantizer
+    except Exception as e:
+        return raise_error("transformers.quantizers.quantizer_bnb_4bit.Bnb4BitHfQuantizer", e)
+
+    if hasattr(Bnb4BitHfQuantizer._process_model_before_weight_loading, "_unsloth_moe_patched"):
+        return
+
+    original_process_model_before_weight_loading = Bnb4BitHfQuantizer._process_model_before_weight_loading
+
+    def patched_process_model_before_weight_loading(self, model, device_map, **kwargs):
+        original_process_model_before_weight_loading(self, model, device_map, **kwargs)
+
+        model = replace_expert_params_with_bnb_params(
+            model,
+            modules_to_not_convert=self.modules_to_not_convert,
+            quantization_config=self.quantization_config,
+            pre_quantized=self.pre_quantized,
+        )
+        return model
+
+    patched_process_model_before_weight_loading._unsloth_moe_patched = True
+    patch_function(Bnb4BitHfQuantizer, "_process_model_before_weight_loading", patched_process_model_before_weight_loading, match_level = "relaxed")
+pass
+
+
+def patch_transformers_weight_converter_kwargs():
+    """
+    PEFT 0.19 constructs WeightConverter with kwargs (distributed_operation,
+    quantization_operation, ...) that transformers 5.6.2's __init__ does not
+    accept, raising TypeError during PeftModel.from_pretrained for any MoE
+    4-bit model. Drop unknown kwargs so the installed transformers signature
+    only sees what it knows.
+    """
+    try:
+        from transformers.core_model_loading import WeightConverter
+    except ImportError:
+        return
+
+    if getattr(WeightConverter.__init__, "_unsloth_kwargs_patched", False):
+        return
+
+    _original_init = WeightConverter.__init__
+
+    import inspect
+    try:
+        original_params = set(inspect.signature(_original_init).parameters)
+    except (TypeError, ValueError):
+        original_params = {"self", "source_patterns", "target_patterns", "operations"}
+
+    def _patched_init(self, *args, **kwargs):
+        accepted = {k: v for k, v in kwargs.items() if k in original_params}
+        return _original_init(self, *args, **accepted)
+
+    _patched_init._unsloth_kwargs_patched = True
+    WeightConverter.__init__ = _patched_init
+
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: Patched transformers WeightConverter.__init__ to ignore unknown kwargs (peft 0.19 forward-compat)")
+pass
+
+
+# ============================================================================
+# PEFT LoRA support for stacked-MoE bnb 4-bit experts.
+# These hooks teach peft.tuners.lora.layer.ParamWrapper how to expose the
+# logical 3-D shape of a Params4bit (so LoRA picks the right (E, out, in)
+# layout) and how to merge / unmerge through a dequant -> add -> requant
+# cycle (so merge_and_unload() works against packed 4-bit storage).
+# They live here rather than in misc.py because they are functionally
+# partners to replace_expert_params_with_bnb_params + patch_bnb4bit_*.
+# ============================================================================
+
+class _ParamShapeProxy:
+    """
+    Wrapper class so that attributes for 4bit MoE params are exposed correctly for compatibility with PEFT LoRA, everything else delegates.
+    """
+
+    def __init__(self, param, shape):
+        self._param = param
+        self._shape = shape
+        self._ndim = len(shape)
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def ndim(self) -> int:
+        return self._ndim
+
+    @property
+    def dtype(self):
+        # Surface the pre-quant compute dtype so PEFT's `tensor.to(param.dtype)`
+        # casts don't truncate bf16 LoRA deltas to the uint8 packed storage dtype.
+        quant_state = getattr(self._param, "quant_state", None)
+        qs_dtype = getattr(quant_state, "dtype", None) if quant_state is not None else None
+        if qs_dtype is not None and (qs_dtype.is_floating_point or qs_dtype.is_complex):
+            return qs_dtype
+        return self._param.dtype
+
+    def __getattr__(self, name):
+        return getattr(self._param, name)
+
+
+def patch_peft_param_wrapper_4bit_expert_shape():
+    """
+    ParamWrapper.get_param() derives shape from param.shape, which is incorrect for Params4bit parameters.
+    Patch ParamWrapper.get_param() to return a proxy that exposes .shape = _original_shape for 4bit MoE params.
+    """
+    try:
+        from peft.tuners.lora.layer import ParamWrapper
+        from peft.utils.integrations import get_bnb_param_type
+    except (ImportError, AttributeError):
+        return
+
+    if getattr(ParamWrapper.get_param, "_unsloth_4bit_expert_patched", False):
+        return
+
+    _original_get_param = ParamWrapper.get_param
+
+    def _patched_get_param(self):
+        param = _original_get_param(self)
+        if get_bnb_param_type(param) == "4bit":
+            shape = getattr(param, "_original_shape", None)
+            if shape is not None and len(shape) == 3:
+                # Don't touch in_features/out_features: PEFT 0.19's update_layer
+                # swaps them for 3D params and calls get_param() again afterwards.
+                self.num_experts = shape[0]
+                return _ParamShapeProxy(param, shape)
+            raise ValueError(
+                "unsloth: ParamWrapper.get_param() encountered a 4-bit Params4bit "
+                f"without a 3D _original_shape attribute (param shape={tuple(param.shape)}). "
+                "This usually means the MoE quantizer patch did not run during model load, "
+                "or this parameter is not a stacked MoE expert and should not be in "
+                "LoraConfig.target_parameters."
+            )
+        return param
+
+    _patched_get_param._unsloth_4bit_expert_patched = True
+    patch_function(ParamWrapper, "get_param", _patched_get_param)
+pass
+
+
+def patch_peft_param_wrapper_merge_4bit():
+    """
+    PEFT's ParamWrapper.merge does in-place `param.data += delta_weight`, which
+    fails for a Params4bit MoE expert because `param.data` is the packed
+    (N_packed, 1) uint8 storage and `delta_weight` is the logical 3D tensor.
+    Override merge/unmerge with a dequantize -> add -> re-quantize cycle when
+    the wrapped param is a Params4bit with a 3D _original_shape.
+    """
+    try:
+        from peft.tuners.lora.layer import ParamWrapper, check_adapters_to_merge
+    except (ImportError, AttributeError):
+        return
+    try:
+        import bitsandbytes as bnb
+        from bitsandbytes.nn import Params4bit
+    except ImportError:
+        return
+
+    if getattr(ParamWrapper.merge, "_unsloth_4bit_moe_patched", False):
+        return
+
+    _original_merge = ParamWrapper.merge
+    _original_unmerge = ParamWrapper.unmerge
+
+    def _is_4bit_moe_param(param):
+        return isinstance(param, Params4bit) and getattr(param, "_original_shape", None) is not None
+
+    def _dequant_param_for_merge(param, parameter_name):
+        """Dequantize a Params4bit MoE expert to its logical 3D shape at the
+        compute dtype. Raises if `quant_state` hasn't been populated yet.
+        Shared helper between merge and unmerge."""
+        quant_state = getattr(param, "quant_state", None)
+        if quant_state is None:
+            raise RuntimeError(
+                "unsloth: ParamWrapper saw a Params4bit MoE expert with "
+                f"quant_state=None on {parameter_name}. The MoE quantizer "
+                "patch likely did not finish before merge_and_unload()."
+            )
+        compute_dtype = getattr(quant_state, "dtype", None) or torch.bfloat16
+        dequant = _dequantize_bnb4bit_expert_weights(param, compute_dtype)
+        return dequant, compute_dtype
+
+    def _requantize_like(reference, new_data, original_shape):
+        kwargs = dict(
+            requires_grad=False,
+            blocksize=getattr(reference, "blocksize", 64),
+            compress_statistics=getattr(reference, "compress_statistics", True),
+            quant_type=getattr(reference, "quant_type", "nf4"),
+            quant_storage=getattr(reference, "quant_storage", torch.uint8),
+        )
+        device = reference.device
+        if device.type == "meta":
+            device = torch.device("cuda", torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+        new_param = Params4bit(new_data.detach().to("cpu").contiguous(), **kwargs).to(device)
+        new_param._original_shape = torch.Size(original_shape)
+        return new_param
+
+    def _patched_merge(self, safe_merge=False, adapter_names=None):
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            return
+
+        base_layer = self.get_base_layer()
+        param = getattr(base_layer, self.parameter_name)
+
+        if not _is_4bit_moe_param(param):
+            return _original_merge(self, safe_merge=safe_merge, adapter_names=adapter_names)
+
+        for active_adapter in adapter_names:
+            if active_adapter not in self.lora_A.keys():
+                continue
+            param = getattr(base_layer, self.parameter_name)
+            original_shape = torch.Size(getattr(param, "_original_shape"))
+            dequant, compute_dtype = _dequant_param_for_merge(param, self.parameter_name)
+            delta_weight = self.get_delta_weight(active_adapter).to(
+                device=dequant.device, dtype=compute_dtype
+            )
+            if delta_weight.shape != dequant.shape:
+                raise RuntimeError(
+                    f"unsloth: delta_weight shape {tuple(delta_weight.shape)} does not "
+                    f"match dequantized expert shape {tuple(dequant.shape)} for "
+                    f"{self.parameter_name}/adapter={active_adapter}."
+                )
+            merged = dequant + delta_weight
+
+            if safe_merge and not torch.isfinite(merged).all():
+                raise ValueError(
+                    f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
+                )
+
+            new_param = _requantize_like(param, merged, original_shape)
+            setattr(base_layer, self.parameter_name, new_param)
+            self.merged_adapters.append(active_adapter)
+
+    def _patched_unmerge(self):
+        if not self.merged:
+            import warnings
+            warnings.warn("Already unmerged. Nothing to do.")
+            return
+
+        base_layer = self.get_base_layer()
+        param = getattr(base_layer, self.parameter_name)
+        if not _is_4bit_moe_param(param):
+            return _original_unmerge(self)
+
+        while len(self.merged_adapters) > 0:
+            active_adapter = self.merged_adapters.pop()
+            if active_adapter not in self.lora_A.keys():
+                continue
+            param = getattr(base_layer, self.parameter_name)
+            original_shape = torch.Size(getattr(param, "_original_shape"))
+            dequant, compute_dtype = _dequant_param_for_merge(param, self.parameter_name)
+            delta_weight = self.get_delta_weight(active_adapter).to(
+                device=dequant.device, dtype=compute_dtype
+            )
+            unmerged = dequant - delta_weight
+            new_param = _requantize_like(param, unmerged, original_shape)
+            setattr(base_layer, self.parameter_name, new_param)
+
+    _patched_merge._unsloth_4bit_moe_patched = True
+    _patched_unmerge._unsloth_4bit_moe_patched = True
+    patch_function(ParamWrapper, "merge", _patched_merge, match_level="relaxed")
+    patch_function(ParamWrapper, "unmerge", _patched_unmerge, match_level="relaxed")
+pass
+
+
+def _register_transformers_v5_moe_bnb4bit_patches():
+    if not is_transformers_v5_moe_quantization_available():
+        return
+    TEMPORARY_PATCHES.append(patch_bnb4bit_quantize_convert)
+    TEMPORARY_PATCHES.append(patch_bnb4bit_quantizer_param_needs_quantization)
+    TEMPORARY_PATCHES.append(patch_bnb4bit_quantizer_process_model)
+    TEMPORARY_PATCHES.append(patch_transformers_weight_converter_kwargs)
+    TEMPORARY_PATCHES.append(patch_peft_param_wrapper_4bit_expert_shape)
+    TEMPORARY_PATCHES.append(patch_peft_param_wrapper_merge_4bit)
+pass
+_register_transformers_v5_moe_bnb4bit_patches()

--- a/unsloth_zoo/temporary_patches/moe_utils_fp8.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_fp8.py
@@ -1,0 +1,1018 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+_TORCH_SCALED_GROUPED_MM_AVAILABLE = hasattr(torch, "_scaled_grouped_mm")
+_TORCH_SCALED_GROUPED_MM_SUPPORTED = None
+
+
+def _is_float8_tensor(tensor: Optional[torch.Tensor]) -> bool:
+    return tensor is not None and getattr(tensor, "dtype", None) == torch.float8_e4m3fn
+
+
+def _get_fp8_dequant_target_dtype(hidden_states: torch.Tensor) -> torch.dtype:
+    if hidden_states.dtype in (torch.float32, torch.float16, torch.bfloat16):
+        return hidden_states.dtype
+    if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+        return torch.bfloat16
+    return torch.float16
+
+
+def _log_moe_fp8_backend_once(experts_module, message: str):
+    from .common import logger
+    from .moe_utils import _log_info
+
+    if getattr(experts_module, "_unsloth_logged_fp8_backend", None) == message:
+        return
+    experts_module._unsloth_logged_fp8_backend = message
+    logger.info(message)
+    _log_info(message)
+
+
+def _check_torch_scaled_grouped_mm_supported():
+    global _TORCH_SCALED_GROUPED_MM_SUPPORTED
+    if _TORCH_SCALED_GROUPED_MM_SUPPORTED is not None:
+        return _TORCH_SCALED_GROUPED_MM_SUPPORTED
+
+    if not _TORCH_SCALED_GROUPED_MM_AVAILABLE:
+        _TORCH_SCALED_GROUPED_MM_SUPPORTED = False
+        return False
+    if not torch.cuda.is_available():
+        _TORCH_SCALED_GROUPED_MM_SUPPORTED = False
+        return False
+
+    # The symbol can exist on unsupported GPUs, and the light probe can still
+    # pass on SM100 while real MoE kernels later emit incompatible MMA
+    # instructions and poison the CUDA context asynchronously. Restrict the
+    # FP8 scaled_grouped_mm path to Hopper (SM 9.x) only for now.
+    major, _minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+    if major != 9:
+        _TORCH_SCALED_GROUPED_MM_SUPPORTED = False
+        return False
+
+    try:
+        device = torch.cuda.current_device()
+        x = torch.randn((16, 16), device=device, dtype=torch.bfloat16)
+        w_hp = torch.randn((1, 16, 16), device=device, dtype=torch.bfloat16)
+        x_fp8, x_scale = _manual_fp8_rowwise_quantize(x)
+        w_fp8, w_scale = _manual_fp8_rowwise_quantize(w_hp.view(-1, w_hp.shape[-1]))
+        w_fp8 = w_fp8.view_as(w_hp)
+        w_fp8 = _make_grouped_mm_rhs_column_major(w_fp8)
+        w_scale = w_scale.view(w_hp.shape[0], w_hp.shape[1])
+        offs = torch.tensor([16], device=device, dtype=torch.int32)
+        torch._scaled_grouped_mm(
+            x_fp8.contiguous(),
+            w_fp8,
+            x_scale.contiguous(),
+            w_scale.contiguous(),
+            offs=offs,
+            out_dtype=torch.bfloat16,
+            use_fast_accum=True,
+        )
+        _TORCH_SCALED_GROUPED_MM_SUPPORTED = True
+        torch.cuda.synchronize(device)
+    except Exception:
+        _TORCH_SCALED_GROUPED_MM_SUPPORTED = False
+    return _TORCH_SCALED_GROUPED_MM_SUPPORTED
+
+
+def _slice_fp8_quant_state(weight: torch.Tensor, quant_state, expert_idx: int):
+    if quant_state is None or not isinstance(quant_state, torch.Tensor):
+        return quant_state
+
+    if quant_state.numel() == 1:
+        sliced = quant_state
+    elif quant_state.shape[0] == weight.shape[0]:
+        sliced = quant_state[expert_idx]
+    elif quant_state.shape[0] % weight.shape[0] == 0:
+        chunk_size = quant_state.shape[0] // weight.shape[0]
+        start = expert_idx * chunk_size
+        end = start + chunk_size
+        sliced = quant_state[start:end]
+    else:
+        return None
+
+    block_size = getattr(weight, "block_size", None) or getattr(quant_state, "block_size", None)
+    if block_size is not None:
+        _try_attach_block_size(sliced, block_size)
+    return sliced
+
+
+def _ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def _dequantize_expert_slice(
+    expert_weight: torch.Tensor,
+    expert_quant_state,
+    target_dtype: torch.dtype,
+    quant_kind=None,
+) -> Optional[torch.Tensor]:
+    """Dequantize one expert's FP8 weight to target_dtype using pure PyTorch."""
+    if expert_weight.dtype != torch.float8_e4m3fn:
+        return expert_weight.to(target_dtype)
+
+    if expert_quant_state is None:
+        return expert_weight.to(target_dtype)
+
+    s = expert_quant_state
+    if not isinstance(s, torch.Tensor):
+        return expert_weight.to(target_dtype)
+
+    if quant_kind == "weight_scale_inv":
+        s = s.reciprocal()
+
+    w = expert_weight.to(target_dtype)
+
+    # Per-tensor scale
+    if s.numel() == 1:
+        return w * s.view(1, 1).to(target_dtype)
+
+    # Reshape 1D to column vector for per-row handling
+    if s.ndim == 1:
+        s = s.view(-1, 1)
+
+    # Per-row scale: (m, 1)
+    if s.ndim == 2 and s.shape[1] == 1:
+        # Per-sub-projection scalar scales (e.g. 2 scales for gate+up stacked weight).
+        if (
+            s.shape[0] > 1
+            and s.shape[0] < w.shape[0]
+            and w.shape[0] % s.shape[0] == 0
+        ):
+            repeat_factor = w.shape[0] // s.shape[0]
+            s = s.repeat_interleave(repeat_factor, dim=0)
+
+        if w.shape[0] == s.shape[0]:
+            return w * s.to(target_dtype)
+        elif w.shape[1] == s.shape[0]:
+            return (w.t() * s.to(target_dtype)).t()
+        return w * s.to(target_dtype)
+
+    # Block scale: (ceil(m/bm), ceil(n/bn)) — expand to weight shape
+    if s.ndim == 2:
+        block_size = getattr(expert_weight, "block_size", None) or getattr(s, "block_size", None)
+        M, N = w.shape
+        p, q = s.shape
+
+        if block_size is not None and len(block_size) == 2:
+            bm, bn = block_size
+            # Check if scale is transposed
+            if _ceil_div(M, bm) != p or _ceil_div(N, bn) != q:
+                if _ceil_div(M, bm) == q and _ceil_div(N, bn) == p:
+                    s = s.T.contiguous()
+                    p, q = s.shape
+                else:
+                    return expert_weight.to(target_dtype)
+        else:
+            # Infer block size from scale grid
+            bm = _ceil_div(M, p)
+            bn = _ceil_div(N, q)
+
+        s_expanded = s.to(target_dtype).repeat_interleave(bm, dim=0)[:M].repeat_interleave(bn, dim=1)[:, :N]
+        return w * s_expanded
+
+    return expert_weight.to(target_dtype)
+
+
+def _dequantize_full_expert_weights_vectorized(weight: torch.Tensor, quant_state, target_dtype: torch.dtype,) -> Optional[torch.Tensor]:
+    """Vectorized dequantization: handles all experts in one batched op."""
+    if weight.ndim != 3 or weight.dtype != torch.float8_e4m3fn:
+        return None
+    if quant_state is None or not isinstance(quant_state, torch.Tensor):
+        return weight.to(target_dtype)
+
+    E, M, N = weight.shape
+    s = quant_state
+
+    w = weight.to(target_dtype)
+
+    # Per-tensor scalar
+    if s.numel() == 1:
+        return w * s.to(target_dtype).view(1, 1, 1)
+
+    # 3D block scales: (E, ceil(M/bm), ceil(N/bn))
+    if s.ndim == 3 and s.shape[0] == E:
+        block_size = getattr(weight, "block_size", None) or getattr(s, "block_size", None)
+        p, q = s.shape[1], s.shape[2]
+        if block_size is not None and len(block_size) == 2:
+            bm, bn = block_size
+        else:
+            bm = _ceil_div(M, p)
+            bn = _ceil_div(N, q)
+        # Expand block scales to full weight dims in one vectorized op
+        # (E, p, q) -> (E, p*bm, q*bn) -> trim to (E, M, N)
+        s_expanded = (
+            s.to(target_dtype)
+            .repeat_interleave(bm, dim=1)[:, :M, :]
+            .repeat_interleave(bn, dim=2)[:, :, :N]
+        )
+        return w * s_expanded
+
+    # 2D per-row scales: (E, M) or (E, 1)
+    if s.ndim == 2 and s.shape[0] == E:
+        if s.shape[1] == 1:
+            return w * s.to(target_dtype).unsqueeze(-1)
+        if s.shape[1] == M:
+            return w * s.to(target_dtype).unsqueeze(-1)
+        if s.shape[1] == N:
+            return w * s.to(target_dtype).unsqueeze(1)
+
+    # 1D: single per-row scale shared across experts
+    if s.ndim == 1:
+        if s.shape[0] == M:
+            return w * s.to(target_dtype).view(1, -1, 1)
+        if s.shape[0] == N:
+            return w * s.to(target_dtype).view(1, 1, -1)
+
+    return None
+
+
+def _dequantize_full_expert_weights_unsloth(weight, scale, target_dtype):
+    """
+    Dequantize 3-D FP8 expert weights using unsloth.kernels.fp8.weight_dequant_block.
+
+    Expects layout from compressed-tensors / finegrained_fp8:
+      weight (E, M, N) float8_e4m3fn
+      scale  (E, ceil(M/bm), ceil(N/bn)) bf16/fp32  -- "weight_scale_inv": dequant = q * s
+    Returns (E, M, N) target_dtype, or None if shapes don't match the expected layout.
+    """
+    if weight.ndim != 3 or weight.dtype != torch.float8_e4m3fn:
+        return None
+    if not isinstance(scale, torch.Tensor) or scale.ndim != 3 or scale.shape[0] != weight.shape[0]:
+        return None
+    try:
+        from unsloth.kernels.fp8 import weight_dequant_block
+    except ImportError:
+        return None
+
+    E, M, N = weight.shape
+    p, q = scale.shape[1], scale.shape[2]
+    if p == 0 or q == 0:
+        return None
+    bm = _ceil_div(M, p)
+    bn = _ceil_div(N, q)
+    if bm != bn:
+        # weight_dequant_block uses a single BLOCK_SIZE; fall through to caller.
+        return None
+
+    # Fast path: when M is exactly p*bm and both tensors are expert-major contiguous,
+    # flatten (E, M, N) -> (E*M, N) and dequant in ONE kernel call. The 2-D dequant
+    # kernel's row-major scale index r // bm equals e*p + (r%M)//bm for the flattened
+    # layout, which matches scale.view(E*p, q). On B200 this is ~25x faster than the
+    # per-expert loop because it removes 128 kernel launches.
+    if M == p * bm and weight.is_contiguous() and scale.is_contiguous():
+        w_flat = weight.view(E * M, N)
+        s_flat = scale.view(E * p, q).to(torch.float32).contiguous()
+        out_flat = weight_dequant_block(w_flat, s_flat, block_size=bm, dtype=target_dtype)
+        return out_flat.view(E, M, N)
+
+    out = torch.empty((E, M, N), dtype=target_dtype, device=weight.device)
+    for e in range(E):
+        out[e] = weight_dequant_block(
+            weight[e].contiguous(),
+            scale[e].contiguous().to(torch.float32),
+            block_size=bm,
+            dtype=target_dtype,
+        )
+    return out
+
+
+def _dequantize_full_expert_weights(weight: torch.Tensor, quant_state, target_dtype: torch.dtype, quant_kind=None):
+    if weight.ndim != 3:
+        return None
+
+    block_size = getattr(weight, "block_size", None)
+    if block_size is not None and quant_state is not None:
+        _try_attach_block_size(quant_state, block_size)
+        _try_attach_block_size(weight, block_size)
+
+    # Preferred: validated Triton block dequant kernel from unsloth.
+    result = _dequantize_full_expert_weights_unsloth(weight, quant_state, target_dtype)
+    if result is not None:
+        return result
+
+    # Fallback 1: vectorized PyTorch dequant.
+    result = _dequantize_full_expert_weights_vectorized(weight, quant_state, target_dtype)
+    if result is not None:
+        return result
+
+    # Fallback 2: per-expert loop. Only reachable when scale is 2-D with an
+    # explicit transposed block_size annotation; vectorized + unsloth Triton
+    # paths above cover every standard 3-D scale layout.
+    if (
+        not isinstance(quant_state, torch.Tensor)
+        or quant_state.ndim != 2
+        or block_size is None
+    ):
+        return None
+    dequantized = []
+    for expert_idx in range(weight.shape[0]):
+        expert_weight = weight[expert_idx].contiguous()
+        _try_attach_block_size(expert_weight, block_size)
+        expert_quant_state = _slice_fp8_quant_state(weight, quant_state, expert_idx)
+        expert_dequant = _dequantize_expert_slice(expert_weight, expert_quant_state, target_dtype, quant_kind=quant_kind)
+        if expert_dequant is None:
+            return None
+        dequantized.append(expert_dequant)
+    return torch.stack(dequantized, dim=0)
+
+
+def _make_grouped_mm_rhs_column_major(weight: torch.Tensor) -> torch.Tensor:
+    return weight.mT.contiguous()
+
+
+def _try_attach_block_size(tensor, block_size):
+    """Defensively attach block_size as an attribute, ignoring failures
+    (e.g. read-only Tensor subclasses)."""
+    try:
+        setattr(tensor, "block_size", block_size)
+    except Exception:
+        pass
+
+
+def _get_moe_weight_and_quant_info(experts_module, param_name: str):
+    """Resolve the underlying expert weight tensor and (if present) its FP8
+    block-quant scale tensor, walking through PEFT ParamWrapper if needed."""
+    # Use the FP8-aware unwrap so we get the raw FP8 tensor, NOT a
+    # bf16-merged ParamWrapper.get_param() value.
+    weight = _unwrap_param_attr(experts_module, param_name)
+    if weight is None:
+        weight = getattr(experts_module, param_name, None)
+    param = getattr(experts_module, param_name, None)
+    quant_state = getattr(weight, "quant_state", None) if weight is not None else None
+    quant_kind = "quant_state" if quant_state is not None else None
+
+    if quant_state is None:
+        quant_state = getattr(experts_module, f"{param_name}_weight_scale_inv", None)
+        if quant_state is not None:
+            quant_kind = "weight_scale_inv"
+        else:
+            quant_state = getattr(experts_module, f"{param_name}_weight_scale", None)
+            if quant_state is not None:
+                quant_kind = "weight_scale"
+        if quant_state is None:
+            quant_state = getattr(experts_module, f"{param_name}_scale_inv", None)
+            if quant_state is not None:
+                quant_kind = "weight_scale_inv"
+            else:
+                quant_state = getattr(experts_module, f"{param_name}_scale", None)
+                if quant_state is not None:
+                    quant_kind = "weight_scale"
+
+    block_size = getattr(param, "block_size", None)
+    if block_size is None:
+        block_size = getattr(experts_module, f"{param_name}_block_size", None)
+    if block_size is None:
+        # FP8Experts stores block_size on the module itself
+        block_size = getattr(experts_module, "block_size", None)
+    if block_size is not None:
+        _try_attach_block_size(weight, block_size)
+        if quant_state is not None:
+            _try_attach_block_size(quant_state, block_size)
+    return weight, quant_state, quant_kind
+
+
+def _extract_scaled_grouped_mm_weight_scale(original_weight, processed_weight, quant_state, quant_kind):
+    if quant_state is None or not isinstance(quant_state, torch.Tensor):
+        return None
+    if quant_kind == "quant_state":
+        return None
+    if getattr(original_weight, "block_size", None) is not None:
+        return None
+    if getattr(quant_state, "block_size", None) is not None:
+        return None
+
+    scale = quant_state
+    if scale.ndim == 0:
+        scale = scale.view(1, 1).expand(processed_weight.shape[0], processed_weight.shape[-1])
+    elif scale.ndim == 1:
+        if scale.shape[0] != processed_weight.shape[-1]:
+            return None
+        scale = scale.view(1, -1).expand(processed_weight.shape[0], -1)
+    elif scale.ndim == 3:
+        if scale.shape[1] == 1:
+            scale = scale.squeeze(1)
+        elif scale.shape[2] == 1:
+            scale = scale.squeeze(2)
+        else:
+            return None
+    elif scale.ndim != 2:
+        return None
+
+    if scale.ndim != 2:
+        return None
+    if scale.shape[0] != processed_weight.shape[0] or scale.shape[1] != processed_weight.shape[-1]:
+        return None
+
+    scale = scale.to(torch.float32)
+    if quant_kind == "weight_scale_inv":
+        scale = scale.reciprocal()
+    return scale.contiguous()
+
+
+def _prepare_scaled_grouped_mm_weight(experts_module, param_name: str, proj_type: str, hidden_dim: int, model_type=None):
+    from .moe_utils import preprocess_weight
+
+    weight, quant_state, quant_kind = _get_moe_weight_and_quant_info(experts_module, param_name)
+    if not _is_float8_tensor(weight):
+        return None
+    processed_weight = preprocess_weight(weight, proj_type, hidden_dim, model_type)
+    processed_weight = _make_grouped_mm_rhs_column_major(processed_weight)
+    scale = _extract_scaled_grouped_mm_weight_scale(weight, processed_weight, quant_state, quant_kind)
+    if scale is None:
+        return None
+    return processed_weight, scale
+
+
+def _manual_fp8_rowwise_quantize(inputs: torch.Tensor):
+    inputs_fp32 = inputs.to(torch.float32)
+    max_fp8 = torch.finfo(torch.float8_e4m3fn).max
+    amax = inputs_fp32.abs().amax(dim=-1, keepdim=True).clamp(min=1e-12)
+    quant_scale = max_fp8 / amax
+    quantized = (inputs_fp32 * quant_scale).to(torch.float8_e4m3fn)
+    decode_scale = quant_scale.reciprocal().squeeze(-1).to(torch.float32)
+    return quantized.contiguous(), decode_scale.contiguous()
+
+
+def _moe_separated_lora_delta(lora_data, permuted_input, offsets, out_dtype):
+    """Compute (X @ first) @ second * scaling for separated MoE LoRA — mirrors
+    the inline path in moe_utils.forward_native_grouped_mm. Returns the delta
+    to ADD to the base grouped-mm output, or None when no LoRA is active."""
+    if lora_data is None:
+        return None
+    first_weight, second_weight, scaling = lora_data[:3]
+    first_weight = first_weight.to(permuted_input.dtype).contiguous()
+    second_weight = second_weight.to(permuted_input.dtype).contiguous()
+    lora_out = torch._grouped_mm(permuted_input, first_weight, offs=offsets).contiguous()
+    # grouped_mm requires the trailing dim to be a multiple of 8.
+    if second_weight.shape[-1] % 8 != 0:
+        pad_size = 8 - (second_weight.shape[-1] % 8)
+        padded = F.pad(second_weight, (0, pad_size)).contiguous()
+        lora_delta = torch._grouped_mm(lora_out, padded, offs=offsets)[:, :-pad_size]
+    else:
+        lora_delta = torch._grouped_mm(lora_out, second_weight, offs=offsets)
+    return (lora_delta * scaling).to(out_dtype)
+
+
+def _expand_grouped_bias(bias, num_tokens_per_expert):
+    """Expand per-expert bias (E, out_dim) to (total_tokens, out_dim) by
+    repeating row i exactly num_tokens_per_expert[i] times — matches the
+    permuted-input layout used by grouped_mm."""
+    num_repeats = num_tokens_per_expert.to(bias.device)
+    return bias.repeat_interleave(num_repeats, dim=0)
+
+
+def _forward_scaled_grouped_mm_fp8(self, hidden_states, top_k_index, top_k_weights):
+    if not _check_torch_scaled_grouped_mm_supported():
+        return None
+    if not hasattr(self, "gate_up_proj") or not hasattr(self, "down_proj"):
+        return None
+
+    is_2d_input = hidden_states.dim() == 2
+    if is_2d_input:
+        sequence_length, hidden_dim = hidden_states.shape
+        batch_size = 1
+    else:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+
+    input_dtype = hidden_states.dtype
+    hidden_states = hidden_states.view(-1, hidden_dim)
+    flat_top_k = top_k_index.view(-1)
+    num_tokens_per_expert = torch.bincount(flat_top_k, minlength=self.num_experts).int()
+    sorted_indices = torch.argsort(flat_top_k, stable=True)
+    token_indices = sorted_indices // top_k_index.shape[-1]
+    permuted_input = hidden_states[token_indices]
+    offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+    from .moe_utils import _should_use_separated_lora
+    use_separated_lora = _should_use_separated_lora()
+    model_type = getattr(self, "_unsloth_model_type", None)
+
+    gate_up_prepared = _prepare_scaled_grouped_mm_weight(self, "gate_up_proj", "gate_up", hidden_dim, model_type)
+    down_prepared = _prepare_scaled_grouped_mm_weight(self, "down_proj", "down", hidden_dim, model_type)
+    if gate_up_prepared is None or down_prepared is None:
+        return None
+    gate_up_weight, gate_up_scale = gate_up_prepared
+    down_weight, down_scale = down_prepared
+
+    target_dtype = _get_fp8_dequant_target_dtype(permuted_input)
+    permuted_input_fp8, input_scale = _manual_fp8_rowwise_quantize(permuted_input.to(target_dtype))
+    mm1_out = torch._scaled_grouped_mm(
+        permuted_input_fp8,
+        gate_up_weight,
+        input_scale,
+        gate_up_scale,
+        offs=offsets,
+        out_dtype=target_dtype,
+        use_fast_accum=True,
+    )
+
+    gate_up_lora = getattr(self, "_unsloth_lora_gate_up_proj", None) if use_separated_lora else None
+    gate_up_delta = _moe_separated_lora_delta(gate_up_lora, permuted_input, offsets, mm1_out.dtype)
+    if gate_up_delta is not None:
+        mm1_out = mm1_out + gate_up_delta
+    if hasattr(self, "gate_up_proj_bias") and self.gate_up_proj_bias is not None:
+        bias_expanded = _expand_grouped_bias(self.gate_up_proj_bias, num_tokens_per_expert)
+        mm1_out = mm1_out + bias_expanded.to(mm1_out.dtype)
+
+    if "GptOssExperts" in self.__class__.__name__:
+        gate = mm1_out[..., ::2]
+        up = mm1_out[..., 1::2]
+        limit = getattr(self, "limit", 7.0)
+        alpha = getattr(self, "alpha", 1.702)
+        gate = gate.clamp(min=None, max=limit)
+        up = up.clamp(min=-limit, max=limit)
+        inter = (up + 1.0) * (gate * torch.sigmoid(gate * alpha))
+    else:
+        gate, up = mm1_out.chunk(2, dim=-1)
+        inter = F.silu(gate) * up
+
+    inter_fp8, inter_scale = _manual_fp8_rowwise_quantize(inter)
+    mm2_out = torch._scaled_grouped_mm(
+        inter_fp8,
+        down_weight,
+        inter_scale,
+        down_scale,
+        offs=offsets,
+        out_dtype=mm1_out.dtype,
+        use_fast_accum=True,
+    )
+
+    down_lora = getattr(self, "_unsloth_lora_down_proj", None) if use_separated_lora else None
+    down_delta = _moe_separated_lora_delta(down_lora, inter, offsets, mm2_out.dtype)
+    if down_delta is not None:
+        mm2_out = mm2_out + down_delta
+    if hasattr(self, "down_proj_bias") and self.down_proj_bias is not None:
+        bias_expanded = _expand_grouped_bias(self.down_proj_bias, num_tokens_per_expert).to(mm2_out.device)
+        mm2_out = mm2_out + bias_expanded.to(mm2_out.dtype)
+
+    flat_weights = top_k_weights.view(-1)
+    permuted_weights = flat_weights[sorted_indices]
+    mm2_out = mm2_out * permuted_weights.unsqueeze(-1)
+    final_hidden_states = torch.zeros(
+        (batch_size * sequence_length, hidden_dim),
+        dtype=input_dtype,
+        device=hidden_states.device,
+    )
+    final_hidden_states.index_add_(0, token_indices, mm2_out.to(input_dtype))
+    if is_2d_input:
+        return final_hidden_states
+    return final_hidden_states.view(batch_size, sequence_length, hidden_dim)
+
+
+def _moe_uses_fp8_expert_weights(self) -> bool:
+    if not hasattr(self, "gate_up_proj") or not hasattr(self, "down_proj"):
+        return False
+    for name in ("gate_up_proj", "down_proj"):
+        if _is_float8_tensor(_unwrap_param_attr(self, name)):
+            return True
+    return False
+
+
+def _unwrap_param_attr(module, name):
+    """Resolve the underlying tensor for an experts-module attribute that
+    may have been wrapped by PEFT ParamWrapper (or a chain of them)."""
+    obj = getattr(module, name, None)
+    if obj is None:
+        return None
+    # Already a tensor / Parameter.
+    if isinstance(obj, torch.Tensor):
+        return obj
+    # PEFT ParamWrapper exposes get_param() — call it BEFORE walking base_layer
+    # because base_layer points back to the experts module, not the tensor.
+    while hasattr(obj, "get_param") and callable(obj.get_param):
+        try:
+            inner = obj.get_param()
+        except Exception:
+            break
+        if isinstance(inner, torch.Tensor):
+            return inner
+        if inner is obj:
+            break
+        obj = inner
+    # Last-ditch: if obj has a base_layer chain ending in something with the
+    # named attribute, recurse through it. (Handles nested ParamWrappers.)
+    seen = set()
+    while hasattr(obj, "base_layer") and id(obj) not in seen:
+        seen.add(id(obj))
+        base = obj.base_layer
+        if hasattr(base, name) and isinstance(getattr(base, name), torch.Tensor):
+            return getattr(base, name)
+        obj = base
+    return None
+
+
+def _slice_fp8_linear_quant_state(experts_module, param_name: str, expert_idx: int):
+    weight, quant_state, quant_kind = _get_moe_weight_and_quant_info(experts_module, param_name)
+    expert_quant_state = _slice_fp8_quant_state(weight, quant_state, expert_idx)
+    if not isinstance(expert_quant_state, torch.Tensor):
+        return expert_quant_state
+    if quant_kind == "weight_scale_inv":
+        expert_quant_state = expert_quant_state.reciprocal()
+    if expert_quant_state.ndim == 1:
+        expert_quant_state = expert_quant_state.view(-1, 1)
+    return expert_quant_state
+
+
+def _forward_native_fp8_expert_loop(self, hidden_states, top_k_index, top_k_weights):
+    # This is the last-resort FP8 path (no scaled_grouped_mm support AND
+    # _dequantize_full_expert_weights returned None for either projection).
+    # It computes the FP8 forward but does NOT consume the separated LoRA
+    # attributes that `patch_param_wrapper_for_moe` injects, so reaching this
+    # path while LoRA is active would silently train without the adapter.
+    # Refuse rather than corrupt: the user can disable LoRA or fix the
+    # missing kernel before retrying.
+    if (
+        getattr(self, "_unsloth_lora_gate_up_proj", None) is not None
+        or getattr(self, "_unsloth_lora_down_proj", None) is not None
+    ):
+        raise RuntimeError(
+            "Unsloth: MoE FP8 fell through to the per-expert fp8_linear "
+            "fallback while LoRA adapters are attached. This path does not "
+            "apply the separated LoRA delta and would silently train without "
+            "it. Install unsloth.kernels.fp8 (or a torch with "
+            "_scaled_grouped_mm support, or a working FP8 dequant) so a "
+            "LoRA-aware backend can be selected."
+        )
+    try:
+        from unsloth.kernels.fp8 import fp8_linear
+    except ImportError:
+        fp8_linear = None
+
+    original_shape = hidden_states.shape
+    hidden_dim = hidden_states.shape[-1]
+    input_dtype = hidden_states.dtype
+    hidden_states = hidden_states.view(-1, hidden_dim)
+    top_k_index = top_k_index.view(-1, top_k_index.shape[-1])
+    top_k_weights = top_k_weights.view(-1, top_k_weights.shape[-1])
+    final_hidden_states = torch.zeros_like(hidden_states)
+
+    gate_up_weight, _, _ = _get_moe_weight_and_quant_info(self, "gate_up_proj")
+    down_weight, _, _ = _get_moe_weight_and_quant_info(self, "down_proj")
+
+    with torch.no_grad():
+        expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts)
+        expert_mask = expert_mask.permute(2, 1, 0)
+        expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+    gate_up_bias = getattr(self, "gate_up_proj_bias", None)
+    down_bias = getattr(self, "down_proj_bias", None)
+
+    for expert_idx in expert_hit:
+        expert_idx = expert_idx[0]
+        if expert_idx == self.num_experts:
+            continue
+
+        top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+        current_state = hidden_states[token_idx]
+
+        expert_gate_up = gate_up_weight[expert_idx]
+        gate_up_qstate = _slice_fp8_linear_quant_state(self, "gate_up_proj", expert_idx)
+        gate_up_bias_expert = None if gate_up_bias is None else gate_up_bias[expert_idx]
+        if _is_float8_tensor(expert_gate_up) and fp8_linear is not None:
+            gate_up_out = fp8_linear(current_state, expert_gate_up, gate_up_qstate, gate_up_bias_expert)
+        elif _is_float8_tensor(expert_gate_up):
+            target_dtype = _get_fp8_dequant_target_dtype(current_state)
+            expert_dequant = _dequantize_expert_slice(expert_gate_up, gate_up_qstate, target_dtype)
+            gate_up_out = F.linear(current_state, expert_dequant, gate_up_bias_expert)
+        else:
+            gate_up_out = F.linear(current_state, expert_gate_up, gate_up_bias_expert)
+
+        if "GptOssExperts" in self.__class__.__name__:
+            gate = gate_up_out[..., ::2]
+            up = gate_up_out[..., 1::2]
+            limit = getattr(self, "limit", 7.0)
+            alpha = getattr(self, "alpha", 1.702)
+            gate = gate.clamp(min=None, max=limit)
+            up = up.clamp(min=-limit, max=limit)
+            current_hidden_states = (up + 1.0) * (gate * torch.sigmoid(gate * alpha))
+        else:
+            gate, up = gate_up_out.chunk(2, dim=-1)
+            act_fn = getattr(self, "act_fn", None)
+            if act_fn is None:
+                act_fn = F.silu
+            current_hidden_states = act_fn(gate) * up
+
+        expert_down = down_weight[expert_idx]
+        down_qstate = _slice_fp8_linear_quant_state(self, "down_proj", expert_idx)
+        down_bias_expert = None if down_bias is None else down_bias[expert_idx]
+        if _is_float8_tensor(expert_down) and fp8_linear is not None:
+            current_hidden_states = fp8_linear(
+                current_hidden_states,
+                expert_down,
+                down_qstate,
+                down_bias_expert,
+            )
+        elif _is_float8_tensor(expert_down):
+            target_dtype = _get_fp8_dequant_target_dtype(current_hidden_states)
+            expert_dequant = _dequantize_expert_slice(expert_down, down_qstate, target_dtype)
+            current_hidden_states = F.linear(current_hidden_states, expert_dequant, down_bias_expert)
+        else:
+            current_hidden_states = F.linear(current_hidden_states, expert_down, down_bias_expert)
+
+        current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
+        final_hidden_states.index_add_(0, token_idx, current_hidden_states.to(input_dtype))
+
+    return final_hidden_states.view(original_shape)
+
+
+@torch.compiler.disable
+def forward_moe_backend_fp8(self, hidden_states, top_k_index, top_k_weights):
+    from .moe_utils import (
+        select_moe_backend,
+        forward_native_grouped_mm,
+        forward_triton_grouped_gemm,
+        forward_native_moe_loop,
+        swap_moe_weights_for_call,
+    )
+
+    backend = select_moe_backend()
+
+    # 1. Try _scaled_grouped_mm (fast FP8 path on Hopper/Blackwell)
+    if backend == "grouped_mm" and _check_torch_scaled_grouped_mm_supported():
+        scaled_grouped_mm_output = _forward_scaled_grouped_mm_fp8(
+            self,
+            hidden_states,
+            top_k_index,
+            top_k_weights,
+        )
+        if scaled_grouped_mm_output is not None:
+            _log_moe_fp8_backend_once(
+                self,
+                "Unsloth: MoE FP8 is using _scaled_grouped_mm.",
+            )
+            return scaled_grouped_mm_output
+
+    # 2. Dequant FP8 weights to bf16/fp16 and run through normal MoE forward
+    target_dtype = _get_fp8_dequant_target_dtype(hidden_states)
+    gate_up_base, gate_up_quant, gate_up_qkind = _get_moe_weight_and_quant_info(self, "gate_up_proj")
+    down_base, down_quant, down_qkind = _get_moe_weight_and_quant_info(self, "down_proj")
+    gate_up_weight = _dequantize_full_expert_weights(gate_up_base, gate_up_quant, target_dtype, quant_kind=gate_up_qkind)
+    down_weight = _dequantize_full_expert_weights(down_base, down_quant, target_dtype, quant_kind=down_qkind)
+
+    if gate_up_weight is not None and down_weight is not None:
+        if backend == "grouped_mm":
+            _log_moe_fp8_backend_once(self, "Unsloth: MoE FP8 is using dequantize-plus-grouped_mm.")
+            forward_fn = forward_native_grouped_mm
+        elif backend == "unsloth_triton":
+            _log_moe_fp8_backend_once(self, "Unsloth: MoE FP8 is using dequantize-plus-Triton grouped GEMM.")
+            forward_fn = forward_triton_grouped_gemm
+        else:
+            _log_moe_fp8_backend_once(self, "Unsloth: MoE FP8 is using dequantize-plus-native_torch loop.")
+            forward_fn = forward_native_moe_loop
+
+        return swap_moe_weights_for_call(
+            self,
+            gate_up_weight,
+            down_weight,
+            forward_fn,
+            hidden_states.to(target_dtype),
+            top_k_index,
+            top_k_weights,
+        )
+
+    # 3. Last resort: per-expert fp8_linear loop
+    _log_moe_fp8_backend_once(
+        self,
+        "Unsloth: MoE FP8 is using per-expert fp8_linear loop.",
+    )
+    return _forward_native_fp8_expert_loop(self, hidden_states, top_k_index, top_k_weights)
+
+
+# ============================================================================
+# Save-side hooks: dequant base FP8 weights before LoRA merge, requant after.
+# saving_utils.py consults `_MOE_QUANT_HANDLERS` for every expert weight key
+# it reads, so the FP8 plumbing stays local to this file instead of polluting
+# the generic save path.
+# ============================================================================
+
+# FP8 e4m3 max representable magnitude — matches transformers' Fp8Quantize.convert
+# (finegrained_fp8.py:838-859) and compressed-tensors' fp8 encode path.
+_FP8_E4M3_MAX = 448.0
+
+# Sentinel returned by a handler when it positively identifies its quant kind on
+# the key but cannot safely apply a LoRA merge (e.g. missing companion scale).
+# saving_utils.py treats this as "skip this expert, record a fallback".
+_MOE_QUANT_UNSAFE = object()
+
+
+def _fp8_dequant_blockwise(W_fp8: torch.Tensor, scale_inv: torch.Tensor) -> torch.Tensor:
+    """Block-wise dequant of float8_e4m3fn weight via per-block weight_scale_inv.
+
+    Inverse of compressed-tensors / DeepSeek-style FP8 quantization:
+        W_real = decode_fp8(W) * scale_inv_broadcast(block_size)
+    where scale_inv has shape (rows/bm, cols/bn) and each scalar tiles its
+    bm x bn block of the dequantized weight.
+    """
+    rows, cols = W_fp8.shape
+    srows, scols = scale_inv.shape
+    bm, bn = rows // srows, cols // scols
+    W_bf16 = W_fp8.to(scale_inv.dtype)
+    return (
+        W_bf16.reshape(srows, bm, scols, bn)
+        * scale_inv.unsqueeze(-1).unsqueeze(1)
+    ).reshape(rows, cols)
+
+
+def _fp8_requant_blockwise(W: torch.Tensor, block_shape: tuple, scale_dtype: torch.dtype):
+    """Block-wise FP8 e4m3 re-quantization. Returns (W_fp8, new_scale_inv).
+
+    Per (bm, bn) block: scale_inv = max_abs / 448, W_fp8 = clamp(W / scale_inv, ±448).
+    Zero-blocks clamp scale_inv to 1e-12 (avoids div-by-zero; the encoded fp8
+    is 0 either way, so on reload `0 * 1e-12 == 0` round-trips cleanly).
+    """
+    rows, cols = W.shape
+    bm, bn = block_shape
+    srows, scols = rows // bm, cols // bn
+    W_blocks = W.to(torch.float32).reshape(srows, bm, scols, bn)
+    block_max = W_blocks.abs().amax(dim=(1, 3))
+    scale_inv = (block_max / _FP8_E4M3_MAX).clamp_min(1e-12)
+    W_scaled = (
+        W_blocks / scale_inv.unsqueeze(-1).unsqueeze(1)
+    ).clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX)
+    W_fp8 = W_scaled.reshape(rows, cols).to(torch.float8_e4m3fn)
+    return W_fp8, scale_inv.to(scale_dtype)
+
+
+def _fp8_save_handler(file, header_metadata, weight_key):
+    """MoE-quant save handler for FP8 base weights.
+
+    Returns:
+      - None if `weight_key` is not FP8 (so other handlers / the plain
+        `file.get_tensor(key)` path takes over).
+      - `(_MOE_QUANT_UNSAFE, None)` if FP8 is detected but the companion
+        `weight_scale_inv` / `weight_scale` cannot be located or its block
+        layout does not divide the weight cleanly.
+      - `(W_bf16, requant_fn)` otherwise, where `requant_fn(merged_W)` returns
+        `(W_fp8, "extra_writes": [(scale_key, scale_tensor, scale_dtype)],
+         storage_dtype)` so the caller can write the re-quantised data plus
+        the new scale alongside it.
+    """
+    dtype_str = header_metadata.get(weight_key, {}).get("dtype")
+    # Cheap probe: skip non-FP8 keys without paying for a tensor read.
+    if dtype_str not in ("F8_E4M3",):
+        # Only FP8 keys are our concern; let the generic loader handle the rest.
+        if dtype_str is None:
+            # Unknown layout — fall back to full read to learn the dtype.
+            W = file.get_tensor(weight_key)
+            if W.dtype != torch.float8_e4m3fn:
+                return None
+        else:
+            return None
+    else:
+        W = file.get_tensor(weight_key)
+        if W.dtype != torch.float8_e4m3fn:
+            return None
+
+    base = weight_key[: -len(".weight")] if weight_key.endswith(".weight") else weight_key
+    candidate_keys = (base + ".weight_scale_inv", base + ".weight_scale")
+    scale_key = next((k for k in candidate_keys if k in header_metadata), None)
+    if scale_key is None:
+        return _MOE_QUANT_UNSAFE, None
+    scale_inv = file.get_tensor(scale_key)
+    if scale_inv.ndim != 2 or W.ndim != 2:
+        return _MOE_QUANT_UNSAFE, None
+    rows, cols = W.shape
+    srows, scols = scale_inv.shape
+    if rows % srows != 0 or cols % scols != 0:
+        return _MOE_QUANT_UNSAFE, None
+    bm, bn = rows // srows, cols // scols
+    block_shape = (bm, bn)
+    scale_dtype = scale_inv.dtype
+    W_bf16 = _fp8_dequant_blockwise(W, scale_inv)
+
+    def _requant(merged_W):
+        W_fp8, new_scale = _fp8_requant_blockwise(merged_W, block_shape, scale_dtype)
+        return W_fp8, torch.float8_e4m3fn, [(scale_key, new_scale, scale_dtype)]
+
+    return W_bf16, _requant
+
+
+# Ordered list of save-side handlers. First non-None return wins.
+_MOE_QUANT_HANDLERS = [_fp8_save_handler]
+
+
+def apply_moe_quant_load(file, header_metadata, key):
+    """Public entry point used by saving_utils._merge_moe_experts_file.
+
+    Returns one of:
+      - `(W_real, requant_fn_or_None)`
+      - `(_MOE_QUANT_UNSAFE, None)`
+    """
+    for handler in _MOE_QUANT_HANDLERS:
+        result = handler(file, header_metadata, key)
+        if result is not None:
+            return result
+    return file.get_tensor(key), None
+
+
+# ============================================================================
+# Hook FP8 experts dispatch + relax HF Trainer FP8 guard
+# ============================================================================
+#
+# transformers swaps a model's experts class with FP8Experts at load time when
+# the checkpoint is FP8 (compressed-tensors / finegrained_fp8). The per-arch
+# patch (patch_qwen3_moe etc.) targets the original Qwen3MoeExperts class, so
+# the FP8 instance never sees our patched forward. Override the transformers
+# FP8 experts registry directly so every FP8Experts.forward routes through
+# forward_moe_backend_fp8.
+
+from .common import (
+    TEMPORARY_PATCHES,
+    UNSLOTH_ENABLE_LOGGING,
+    is_transformers_v5_moe_quantization_available,
+)
+from .utils import logger
+
+
+def patch_fp8_experts_interface():
+    try:
+        from transformers.integrations.finegrained_fp8 import ALL_FP8_EXPERTS_FUNCTIONS
+    except ImportError:
+        return
+
+    sentinel = "_unsloth_fp8_dispatcher"
+    if getattr(ALL_FP8_EXPERTS_FUNCTIONS, sentinel, False):
+        return
+
+    def _unsloth_fp8_dispatch(self, hidden_states, top_k_index, top_k_weights, *args, **kwargs):
+        return forward_moe_backend_fp8(self, hidden_states, top_k_index, top_k_weights)
+
+    for key in ("grouped_mm", "batched_mm", "deepgemm"):
+        try:
+            ALL_FP8_EXPERTS_FUNCTIONS[key] = _unsloth_fp8_dispatch
+        except Exception:
+            pass
+
+    setattr(ALL_FP8_EXPERTS_FUNCTIONS, sentinel, True)
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: routed transformers ALL_FP8_EXPERTS_FUNCTIONS through forward_moe_backend_fp8")
+
+
+def patch_fp8_validate_quantization_for_training():
+    """
+    HF Trainer rejects FP8 base models outright via validate_quantization_for_training.
+    With LoRA the FP8 weights stay frozen and the adapter trains in bf16, which is the
+    same contract the guard already accepts for bnb4bit / bnb8bit. Make the guard a
+    no-op when the model is FP8-quantized; leave other quant kinds alone.
+    """
+    try:
+        import transformers.trainer as _trainer_mod
+        import transformers.trainer_utils as _trainer_utils_mod
+    except ImportError:
+        return
+
+    _original = getattr(_trainer_utils_mod, "validate_quantization_for_training", None)
+    if _original is None:
+        return
+
+    sentinel = "_unsloth_fp8_guard_patched"
+    if getattr(_original, sentinel, False):
+        return
+
+    def _is_fp8_quantized(model):
+        hq = getattr(model, "hf_quantizer", None)
+        if hq is None:
+            return False
+        cfg = getattr(hq, "quantization_config", None)
+        method = getattr(cfg, "quant_method", None)
+        return method is not None and "fp8" in str(method).lower()
+
+    def _patched(model):
+        if _is_fp8_quantized(model):
+            return None
+        return _original(model)
+
+    setattr(_patched, sentinel, True)
+    _trainer_utils_mod.validate_quantization_for_training = _patched
+    _trainer_mod.validate_quantization_for_training = _patched
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: relaxed HF validate_quantization_for_training for FP8+LoRA")
+
+
+def _register_transformers_v5_moe_fp8_patches():
+    if not is_transformers_v5_moe_quantization_available():
+        return
+    TEMPORARY_PATCHES.append(patch_fp8_experts_interface)
+    TEMPORARY_PATCHES.append(patch_fp8_validate_quantization_for_training)
+pass
+_register_transformers_v5_moe_fp8_patches()

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -53,6 +53,7 @@ import inspect
 from functools import partial
 from .utils import _get_dtype, get_quant_type, Version
 from .empty_model import *
+from .empty_model import _is_gemma4_config
 from .hf_utils import (
     dtype_from_config,
     add_dtype_kwargs,
@@ -824,6 +825,8 @@ def vllm_dynamic_quant_supported(
     if "quantization_config" not in config: return True
 
     llm_int8_skip_modules = config.quantization_config.get("llm_int8_skip_modules", {})
+    if _is_gemma4_config(config) and _get_gemma4_bnb_skip_module_aliases(config.quantization_config) is not None:
+        return True
 
     # Only allow layer modules ie model.layers.1.mlp or model.layers.1.self_attn
 
@@ -843,6 +846,29 @@ def vllm_dynamic_quant_supported(
         # Could not find parent
         if find_regex.search(module) is None: return False
     return True
+pass
+
+def _get_gemma4_bnb_skip_module_aliases(quantization_config):
+    if not isinstance(quantization_config, dict):
+        return None
+    skip_modules = quantization_config.get("llm_int8_skip_modules", None)
+    if skip_modules is None:
+        return None
+
+    aliases = set(skip_modules)
+    for module in skip_modules:
+        if module.startswith("model.language_model."):
+            text_module = module[len("model.language_model."):]
+            aliases.add("model." + text_module)
+            aliases.add("language_model.model." + text_module)
+        elif module.startswith("language_model.model."):
+            aliases.add("model." + module[len("language_model.model."):])
+    if len(aliases) == len(skip_modules):
+        return None
+
+    quantization_config = quantization_config.copy()
+    quantization_config["llm_int8_skip_modules"] = sorted(aliases)
+    return quantization_config
 pass
 
 
@@ -1063,13 +1089,26 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
             quant_state_dict[prefix + ".bias"] = bias_tensor
     pass
 
+    if _is_gemma4_config(config):
+        num_kv_shared_layers = getattr(text_config, "num_kv_shared_layers", 0) or 0
+        num_hidden_layers = getattr(text_config, "num_hidden_layers", 0) or 0
+        gemma4_kv_shared_layers = set(range(
+            max(num_hidden_layers - num_kv_shared_layers, 0),
+            num_hidden_layers,
+        ))
+    else:
+        gemma4_kv_shared_layers = set()
+
     # Embedding
     if hasattr(vllm_internals, "model"): # Standard Language models
         vllm_text_model = vllm_internals.model
         vllm_text_model_prefix = "model"
     elif hasattr(vllm_internals, "language_model"):
         # For Llama 3.2, Gemma 3 and Qwen 2.5 VL, they have text model in model.language_model.model
-        vllm_text_model_prefix = "model.language_model"
+        if not is_vision_model and not hasattr(config, "text_config"):
+            vllm_text_model_prefix = "model"
+        else:
+            vllm_text_model_prefix = "model.language_model"
         vllm_text_model = vllm_internals.language_model.model
     else:
         raise RuntimeError(f'Unsloth: Cannot find vllm_internal_model!')
@@ -1106,8 +1145,11 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
                 get_state_dict(f"{prefix}.qkv_proj", 0, state_dict, qkv_proj, slice_weights=False)
             else:
                 get_state_dict(f"{prefix}.q_proj", 0, state_dict, qkv_proj)
-                get_state_dict(f"{prefix}.k_proj", 1, state_dict, qkv_proj)
-                get_state_dict(f"{prefix}.v_proj", 2, state_dict, qkv_proj)
+                if kk not in gemma4_kv_shared_layers:
+                    get_state_dict(f"{prefix}.k_proj", 1, state_dict, qkv_proj)
+                if kk not in gemma4_kv_shared_layers:
+                    get_state_dict(f"{prefix}.v_proj", 2, state_dict, qkv_proj)
+            get_state_dict(f"{prefix}.o_proj", 0, state_dict, o_proj)
         elif hasattr(layer, "cross_attn"):
             prefix = f"{vllm_text_model_prefix}.layers.{kk}.cross_attn"
             qkv_proj = layer.cross_attn.qkv_proj
@@ -1119,8 +1161,49 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
             get_state_dict(f"{prefix}.q_proj", 0, state_dict, q_proj)
             get_state_dict(f"{prefix}.k_proj", 1, state_dict, kv_proj)
             get_state_dict(f"{prefix}.v_proj", 2, state_dict, kv_proj)
+            get_state_dict(f"{prefix}.o_proj", 0, state_dict, o_proj)
+        elif hasattr(layer, "linear_attn"):
+            # Qwen3.5 Gated Delta Net (GDN) linear attention layers
+            extract_gdn_layers(
+                layer.linear_attn,
+                f"{vllm_text_model_prefix}.layers.{kk}.linear_attn",
+                state_dict, quant_state_dict, get_state_dict,
+            )
+        pass
 
-        get_state_dict(f"{prefix}.o_proj", 0, state_dict, o_proj)
+        if hasattr(layer, "per_layer_input_gate"):
+            get_state_dict(
+                f"{vllm_text_model_prefix}.layers.{kk}.per_layer_input_gate",
+                0, state_dict, layer.per_layer_input_gate,
+            )
+        if hasattr(layer, "per_layer_projection"):
+            get_state_dict(
+                f"{vllm_text_model_prefix}.layers.{kk}.per_layer_projection",
+                0, state_dict, layer.per_layer_projection,
+            )
+
+        # Use layernorms from the layer configuration
+        layernorm_names = [name.format(kk=kk) for name in layer_config['layernorms']]
+
+        for layernorm_name in layernorm_names:
+            if kk in gemma4_kv_shared_layers and ".self_attn.k_norm" in layernorm_name:
+                continue
+            vllm_name = layernorm_name.replace(f".{kk}.", f"[{kk}].").replace(vllm_text_model_prefix, "vllm_text_model")
+            try:
+                layernorm = eval(vllm_name).state_dict()["weight"]
+                layernorm_name = f"{layernorm_name}.weight"
+                state_dict[layernorm_name] = layernorm
+                quant_state_dict[layernorm_name] = state_dict[layernorm_name]
+            except Exception as e:
+                skipped_layernorms.append(layernorm_name.split(".")[-1])
+        pass
+
+        if hasattr(layer, "layer_scalar"):
+            state_dict[f"{vllm_text_model_prefix}.layers.{kk}.layer_scalar"] = layer.layer_scalar.data
+            quant_state_dict[f"{vllm_text_model_prefix}.layers.{kk}.layer_scalar"] = layer.layer_scalar.data
+
+        if not hasattr(layer, "mlp"):
+            continue
 
         proj = layer.mlp.gate_up_proj
         use_fused_gate_up = _is_fused_module("gate_up_proj")
@@ -1135,20 +1218,6 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
 
         proj = layer.mlp.down_proj
         get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.down_proj", 0, state_dict, proj)
-
-        # Use layernorms from the layer configuration
-        layernorm_names = [name.format(kk=kk) for name in layer_config['layernorms']]
-
-        for layernorm_name in layernorm_names:
-            vllm_name = layernorm_name.replace(f".{kk}.", f"[{kk}].").replace(vllm_text_model_prefix, "vllm_text_model")
-            try:
-                layernorm = eval(vllm_name).state_dict()["weight"]
-                layernorm_name = f"{layernorm_name}.weight"
-                state_dict[layernorm_name] = layernorm
-                quant_state_dict[layernorm_name] = state_dict[layernorm_name]
-            except Exception as e:
-                skipped_layernorms.append(layernorm_name.split(".")[-1])
-        pass
     pass
 
     if len(skipped_layernorms) != 0:
@@ -1165,11 +1234,26 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
     state_dict[norm_prefix] = vllm_text_model.norm.weight.data
     quant_state_dict[norm_prefix] = state_dict[norm_prefix]
 
+    # Gemma4 top-level per-layer-input modules
+    for extra_name in ("embed_tokens_per_layer", "per_layer_model_projection", "per_layer_projection_norm"):
+        component = getattr(vllm_text_model, extra_name, None)
+        if component is None:
+            continue
+        prefix = f"{vllm_text_model_prefix}.{extra_name}"
+        if hasattr(component, "weight"):
+            get_state_dict(prefix, 0, state_dict, component, slice_weights=False)
+        else:
+            for param_name, param in component.named_parameters():
+                key = f"{prefix}.{param_name}"
+                state_dict[key] = param.data
+                quant_state_dict[key] = param.data
+
     # LM Head - Use get_state_dict for consistency
     if not getattr(text_config, "tie_word_embeddings", False):
-        lm_layer = [mod for name,mod in vllm_internals.named_modules() if "lm_head" in name]
-        # Use get_state_dict for consistent extraction and automatic truncation
-        get_state_dict("lm_head", 0, state_dict, lm_layer[0], slice_weights=False)
+        lm_layer = next((mod for name, mod in vllm_internals.named_modules() if name == "lm_head" or name.endswith(".lm_head")), None)
+        if lm_layer is None:
+            raise RuntimeError("Unsloth: could not find lm_head in vLLM internals")
+        get_state_dict("lm_head", 0, state_dict, lm_layer, slice_weights=False)
     else:
         # Fallback to embed_tokens for tied embeddings
         embed_key = f"{vllm_text_model_prefix}.embed_tokens.weight"
@@ -1186,8 +1270,16 @@ pass
 @torch.inference_mode
 def assert_same_state_dict(old_state_dict, new_state_dict):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Check if state_dict are equivalent
-    # hf, vllm
+    # args: hf, vllm
+
+    def _normalize_state_dict_tensor(value):
+        if isinstance(value, torch.nn.Parameter):
+            value = value.detach()
+        if not isinstance(value, torch.Tensor):
+            return None
+        if value.is_sparse:
+            value = value.to_dense()
+        return value.contiguous()
 
     difference = new_state_dict.keys() ^ old_state_dict.keys()
     difference -= set(("model.lm_head.weight","model.language_model.lm_head.weight", "lm_head.weight"))
@@ -1202,13 +1294,18 @@ def assert_same_state_dict(old_state_dict, new_state_dict):
 
     for key in old_state_dict:
         try:
-            old_val = old_state_dict[key]
-            new_val = new_state_dict[key]
-            if old_val.dtype != new_val.dtype or (new_val.element_size() < 2):
+            old_val = _normalize_state_dict_tensor(old_state_dict[key])
+            new_val = _normalize_state_dict_tensor(new_state_dict[key])
+            if old_val is None or new_val is None:
+                continue
+            loose_tol = old_val.dtype != new_val.dtype or (new_val.element_size() < 2)
+            if loose_tol:
                 # upcast both to float32 just for comparison. For FP8, vLLM stores weight scale in FP32 while HF preferes 16bit
                 old_val = old_val.to(torch.float32)
                 new_val = new_val.to(torch.float32)
-            torch.testing.assert_close(old_val, new_val, check_stride = False, atol = 1e-4, rtol = 1e-3)
+                torch.testing.assert_close(old_val, new_val, check_stride = False, atol = 1e-4, rtol = 1e-3)
+            else:
+                torch.testing.assert_close(old_val, new_val, check_stride = False)
         except Exception as error:
             if key == "lm_head.weight":
                 # Try tied embeddings fallback
@@ -1217,7 +1314,13 @@ def assert_same_state_dict(old_state_dict, new_state_dict):
 
                 if key1 is not None and key2 is not None:
                     try:
-                        torch.testing.assert_close(old_state_dict[key1].contiguous(), new_state_dict[key2].contiguous(), check_stride = True)
+                        torch.testing.assert_close(
+                            _normalize_state_dict_tensor(old_state_dict[key1]),
+                            _normalize_state_dict_tensor(new_state_dict[key2]),
+                            check_stride = False,
+                            atol = 1e-4,
+                            rtol = 1e-3,
+                        )
                     except Exception:
                         failures[key] = error
                 else:
@@ -1235,7 +1338,14 @@ pass
 def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16, bnb_config = None, is_vision_model = False):
     # All Unsloth Zoo code licensed under LGPLv3
     # Unmerges vLLM modules to create HF compatible model
+    def _unwrap_tensor(value):
+        return getattr(value, "data", value)
+
     set_dtype_in_config(config, dtype)
+    for subconfig_name in ("text_config", "vision_config", "audio_config"):
+        subconfig = getattr(config, subconfig_name, None)
+        if subconfig is not None:
+            set_dtype_in_config(subconfig, dtype)
     new_model, original_meta_model, layer_count, layer_names = create_empty_model(config, dtype, is_vision_model)
     new_model = new_model.to(device = get_target_device(), dtype = dtype)
     quantization_config = getattr(config, "quantization_config", {})
@@ -1331,16 +1441,14 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                 weight = quant_state_dict[f"{layer_name}.weight"]
 
             if f"{layer_name}.bias" in quant_state_dict:
-                # Has bias!
                 has_bias = True
-                bias = quant_state_dict[f"{layer_name}.bias"]
+                bias = _unwrap_tensor(quant_state_dict[f"{layer_name}.bias"])
                 bias = torch.nn.Parameter(bias, requires_grad = False)
             else:
                 has_bias = False
                 bias = None
             pass
 
-            # check if either of layer_name.weight_scale or layer_name.weight_scale_inv exists and set that attribute to fp8_weight_scale
             fp8_weight_scale = None
             if f"{layer_name}.weight_scale" in quant_state_dict:
                 fp8_weight_scale = quant_state_dict[f"{layer_name}.weight_scale"]
@@ -1352,9 +1460,15 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
 
             if layer_name in quant_state_dict:
                 # for attributes of type nn.Parameter, there's no .weight
-                layer_name_br = re.sub(r"\.([\d]{1,})\.", r"[\1].", layer_name.replace('model.','',1))
-                layer = torch.nn.Parameter(weight, requires_grad = False)
-                exec(f"new_model.{layer_name_br} = layer")
+                layer_name_br = re.sub(r"\.([\d]+)(?=\.|$)", lambda x: f"[{x.group(1)}]", layer_name)
+                raw_value = _unwrap_tensor(weight)
+                parent_path, _, attr_name = layer_name_br.rpartition(".")
+                parent = eval(f"new_model.{parent_path}") if parent_path else new_model
+                if attr_name in getattr(parent, "_buffers", {}):
+                    parent._buffers[attr_name] = raw_value
+                else:
+                    layer = torch.nn.Parameter(raw_value, requires_grad = False)
+                    exec(f"new_model.{layer_name_br} = layer")
                 continue
             elif fp8_weight_scale is not None:
                 if fp8_weight_scale.ndim == 1:
@@ -1362,7 +1476,7 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                     layer = FbgemmFp8Linear(in_features = 0, out_features = 0, bias = has_bias, weight_dtype = dtype).to(get_target_device())
                     layer.in_features = weight.shape[1]
                     layer.out_features = weight.shape[0]
-                    layer.weight = torch.nn.Parameter(weight, requires_grad = False)
+                    layer.weight = torch.nn.Parameter(_unwrap_tensor(weight), requires_grad = False)
                     layer.bias = bias
                     layer.input_scale_ub = kwargs['input_scale_ub']
                     layer.weight_scale = torch.nn.Parameter(fp8_weight_scale, requires_grad = False)
@@ -1378,12 +1492,11 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                     layer = FP8Linear(**fp8_kwargs)
                     layer.in_features = weight.shape[1]
                     layer.out_features = weight.shape[0]
-                    layer.weight = torch.nn.Parameter(weight, requires_grad = False)
+                    layer.weight = torch.nn.Parameter(_unwrap_tensor(weight), requires_grad = False)
                     layer.bias = bias
                     layer.weight_scale_inv = torch.nn.Parameter(fp8_weight_scale, requires_grad = False)
                     layer.quant_method = "fp8"
             elif f"{layer_name}.weight.quant_state" in quant_state_dict:
-                # Layer is quantized!
                 quant_state = quant_state_dict[f"{layer_name}.weight.quant_state"]
                 layer = Linear4bit(0, 0, device = get_target_device(), bias = has_bias, compute_dtype = compute_dtype, **kwargs)
                 layer.in_features  = quant_state.shape[1]
@@ -1396,22 +1509,37 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                 layer.to = partial(_override_to, layer)
                 layer.weight.to = partial(_override_to, layer.weight)
 
+            elif layer_name.endswith(".conv1d") and "linear_attn" in layer_name:
+                # Qwen3.5 GDN depthwise Conv1d: rebuild with real channels/kernel/groups.
+                from torch.nn import Conv1d
+                conv_weight = _unwrap_tensor(weight)
+                channels = conv_weight.shape[0]
+                kernel_size = conv_weight.shape[-1]
+                layer = Conv1d(
+                    in_channels = channels,
+                    out_channels = channels,
+                    kernel_size = kernel_size,
+                    groups = channels,
+                    padding = kernel_size - 1,
+                    bias = has_bias,
+                    device = get_target_device(),
+                )
+                layer.weight = torch.nn.Parameter(conv_weight, requires_grad = False)
+                layer.bias = bias
             elif not any(x in layer_name for x in layernorm_names):
                 layer = Linear(0, 0, device = get_target_device(), bias = has_bias)
                 layer.in_features  = weight.shape[1]
                 layer.out_features = weight.shape[0]
                 # from vllm 0.11.1, the .weight is of dtype ModelWeightParameter, so try to extract the 'data' part
                 # https://github.com/vllm-project/vllm/commit/de94289a98d7ec52a5ef02719e01a1db8b505170#diff-7d6145ac4ba084231a441c2056c7fca23c3bae33e6542f4f602a6c9d4d2da64dL199-R208
-                layer.weight = torch.nn.Parameter(getattr(weight, 'data', weight), requires_grad = False)
+                layer.weight = torch.nn.Parameter(_unwrap_tensor(weight), requires_grad = False)
                 layer.bias = bias
             else:
                 # LayerNorms (including vision norms)
-                weight_param = torch.nn.Parameter(weight, requires_grad=False)
+                weight_param = torch.nn.Parameter(_unwrap_tensor(weight), requires_grad=False)
                 layer_name_br = re.sub(r"\.([\d]{1,})\.", r"[\1].", layer_name)
-                # Set weight
                 exec(f"new_model.{layer_name_br}.weight = None")
                 exec(f"new_model.{layer_name_br}.weight = weight_param")
-                # Set bias if it exists
                 if bias is not None:
                     exec(f"new_model.{layer_name_br}.bias = None")
                     exec(f"new_model.{layer_name_br}.bias = bias")
@@ -1425,49 +1553,14 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
     pass
 
     set_additional_modules(new_model, quant_state_dict, config)
-
-    if original_meta_model is not None:
-        copy_attributes(original_meta_model, new_model)
-
-    # # Set config on model and modules using clean approach
-    # new_model.config = config
-    # for module in new_model.modules():
-    #     if hasattr(module, "config"):
-    #         module.config = config
-    # for param in new_model.parameters():
-    #     if hasattr(param, "config"):
-    #         param.config = config
-
-    text_config = getattr(config, "text_config", config) #try using text config for VLMs
-    vision_config = getattr(config, "vision_config", None)
-    # Fix up rotary_emb by re-initing them
-    for module in new_model.modules():
-        if hasattr(module, "rotary_emb"):
-            module.rotary_emb = module.rotary_emb.__class__(
-                config = text_config,
-                device = get_target_device(),
-            )
-        if hasattr(module, "rotary_pos_emb"):
-            # Qwen 2.5 VL has a rotary_pos_emb in vision submodel
-            # https://github.com/huggingface/transformers/blob/a871f6f58d49f3a05ae9dae519caa8aa9d919a07/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L337
-            assert vision_config is not None, "Unsloth: vision_config is required for models with vision rotary_pos_emb"
-            head_dim = vision_config.hidden_size // vision_config.num_heads
-            module.rotary_pos_emb = module.rotary_pos_emb.__class__(head_dim//2).to(get_target_device())
-        if hasattr(module, "rotary_emb_local"):
-            # gemma3 has a rotary_emb_local
-            # https://github.com/huggingface/transformers/blob/008c0ba8e2a1226a6ef5a61c4915a0a8a340c157/src/transformers/models/gemma3/modeling_gemma3.py#L469-L471
-            # Gemma3 uses different defaults for local and global RoPE. Copy the config for modification.
-            local_rope_config = deepcopy(text_config)
-            local_rope_config.rope_theta = text_config.rope_local_base_freq
-            local_rope_config.rope_scaling = {"rope_type": "default"}
-            # gemma3 has a rotary_emb_local
-            module.rotary_emb_local = module.rotary_emb_local.__class__(
-                config = local_rope_config,
-                device = get_target_device(),
-            )
-            del local_rope_config
-        pass
-    pass
+    new_model = finalize_huggingface_model(
+        new_model,
+        original_meta_model,
+        config,
+        dtype,
+        quantization_config = quantization_config,
+        bnb_config = bnb_config,
+    )
 
     # Must override or else Bitsandbytes will error
     new_model.to = partial(_override_to, new_model)
@@ -1851,6 +1944,12 @@ def load_vllm(
     use_bitsandbytes = use_bitsandbytes or \
         model_name.lower().endswith("-bnb-4bit") or (quant_method == "bitsandbytes")
 
+    if _is_gemma4_config(config):
+        if enable_lora:
+            patch_gemma4_vllm_lora_support()
+        if use_bitsandbytes:
+            patch_gemma4_vllm_k_eq_v_support()
+
     is_fp8 = "fp8" in model_name.lower() or (quant_method in ("fp8", "fbgemm_fp8"))
 
     if is_fp8 and DEVICE_TYPE == "cuda":
@@ -2230,6 +2329,14 @@ def load_vllm(
         # To reduce memory usage, we limit the number of images/videos per prompt
         # TODO: Make it configurable by user
         engine_args["limit_mm_per_prompt"] = {"image": 1, "video": 0}
+    if _is_gemma4_config(config) and use_bitsandbytes:
+        gemma4_bnb_quantization_config = _get_gemma4_bnb_skip_module_aliases(
+            getattr(config, "quantization_config", None)
+        )
+        if gemma4_bnb_quantization_config is not None:
+            engine_args["hf_overrides"] = {
+                "quantization_config": gemma4_bnb_quantization_config,
+            }
 
     # [[CRITICAL for RL on policy]]
     # Check for Cascade Attention which fails on A100 / L40 for vLLM < 0.11.0 versions
@@ -2827,6 +2934,38 @@ def _test_same_model(model, new_model, input_ids):
     return
 pass
 
+def _get_dense_causal_lm_state_dict(model):
+    state_dict = model.state_dict()
+    if not any(key.startswith("model.language_model.") for key in state_dict):
+        return state_dict, False
+
+    normalized = {}
+    prefix = "model.language_model."
+    for key, value in state_dict.items():
+        if key.startswith(prefix):
+            normalized["model." + key[len(prefix):]] = value
+        elif key.startswith("lm_head."):
+            normalized[key] = value
+    return normalized, True
+pass
+
+def _test_whole_model_forward(model, new_model, input_ids):
+    kwargs = dict(
+        input_ids = input_ids,
+        labels = input_ids,
+        output_hidden_states = True,
+        use_cache = False,
+    )
+    old_outputs = model(**kwargs)
+    new_outputs = new_model(**kwargs)
+    torch.testing.assert_close(old_outputs.logits, new_outputs.logits)
+    if getattr(old_outputs, "loss", None) is not None and getattr(new_outputs, "loss", None) is not None:
+        torch.testing.assert_close(old_outputs.loss, new_outputs.loss)
+    if getattr(old_outputs, "hidden_states", None) is not None and getattr(new_outputs, "hidden_states", None) is not None:
+        for old_hidden, new_hidden in zip(old_outputs.hidden_states, new_outputs.hidden_states):
+            torch.testing.assert_close(old_hidden, new_hidden, rtol = 1e-3, atol = 1e-4)
+pass
+
 @torch.inference_mode()
 def test_model_conversion(original_model, new_model):
     """
@@ -2866,10 +3005,27 @@ def _test_is_same_vlm(model, new_model, processor, test_backward=False):
         messages, tokenize=False, add_generation_prompt=True
     )
 
-    inputs = processor.apply_chat_template(
-        messages, add_generation_prompt=True, tokenize=True,
-        return_dict=True, return_tensors="pt"
-    ).to(model.device, dtype=model.dtype)
+    if processor.__class__.__name__ in ("Gemma3Processor", "Gemma4Processor"):
+        try:
+            from transformers.image_utils import load_image
+            image = load_image(messages[0]["content"][0]["image"])
+        except Exception:
+            from PIL import Image
+            image = Image.new("RGB", (224, 224), color = (128, 128, 128))
+        inputs = processor(
+            text = [text],
+            images = [image],
+            return_tensors = "pt",
+        )
+    else:
+        inputs = processor.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=True,
+            return_dict=True, return_tensors="pt",
+        )
+    inputs = inputs.to(model.device)
+    for _k, _v in list(inputs.items()):
+        if torch.is_tensor(_v) and torch.is_floating_point(_v):
+            inputs[_k] = _v.to(dtype = model.dtype)
 
     with torch.no_grad():
         original_outputs = model(**inputs)
@@ -2989,6 +3145,7 @@ def _test_get_vllm_state_dict(
     load_in_4bit = False,
     skip_generation = False,
     is_vision_model = False,
+    compilation_config = None,
 ):
     # All Unsloth Zoo code licensed under LGPLv3
     # Check if model is allowed to be used in vLLM
@@ -3027,7 +3184,9 @@ def _test_get_vllm_state_dict(
     # patch_bitsandbytes_compute_dtype(dtype)
     model_type = getattr(config, "model_type", "causal_lm")
 
-    enable_lora = model_type != "mllama"
+    enable_lora = model_type not in ("mllama", "gemma4")
+    if compilation_config is None and model_type == "gemma4":
+        compilation_config = 0
 
     if not is_vision_model:
         model_class = AutoModelForCausalLM
@@ -3054,6 +3213,12 @@ def _test_get_vllm_state_dict(
         param.requires_grad_(False)
     model, _ = patch_model_and_tokenizer(model, None)
     model.eval()
+    if not is_vision_model and _is_gemma4_config(model.config):
+        extraction_config = getattr(model.config, "text_config", model.config)
+    else:
+        extraction_config = model.config if not is_vision_model else config
+    extraction_config.model_name = model_name
+    dense_state_dict, text_normalized_state_dict = _get_dense_causal_lm_state_dict(model)
 
     # Patch vLLM to disable multiprocessing for state dict extraction
     patch_vllm()
@@ -3069,19 +3234,25 @@ def _test_get_vllm_state_dict(
         use_bitsandbytes       = load_in_4bit,
         is_vision_model        = is_vision_model,
         enable_lora            = enable_lora,
+        compilation_config     = compilation_config,
     )
 
     state_dict, quant_state_dict = get_vllm_state_dict(
         llm,
         return_state_dict = True,
-        config = config,
+        config = extraction_config,
         is_vision_model = is_vision_model,
     )
 
-    assert_same_state_dict(model.state_dict(), state_dict)
+    assert_same_state_dict(dense_state_dict, state_dict)
 
-    new_model = convert_vllm_to_huggingface(quant_state_dict, config, dtype, is_vision_model = is_vision_model)
-    test_model_conversion(model, new_model)
+    new_model = convert_vllm_to_huggingface(quant_state_dict, extraction_config, dtype, is_vision_model = is_vision_model)
+    if text_normalized_state_dict:
+        assert_same_state_dict(dense_state_dict, new_model.state_dict())
+    else:
+        test_model_conversion(model, new_model)
+    new_model, _ = patch_model_and_tokenizer(new_model, None)
+    new_model.eval()
 
     # Run the model as well
     if not is_vision_model:
@@ -3128,7 +3299,17 @@ def _test_get_vllm_state_dict(
         # Check all hidden states manually
         input_ids = tokenizer(inputs[0], add_special_tokens = False, return_tensors = "pt")
         input_ids = input_ids["input_ids"].to("cuda", non_blocking = True)
-        _test_same_model(model, new_model, input_ids)
+        model_layers = getattr(getattr(model, "model", None), "layers", ())
+        supports_layerwise_test = (
+            not text_normalized_state_dict
+            and len(model_layers) != 0
+            and all(hasattr(layer, "self_attn") for layer in model_layers)
+            and hasattr(getattr(model, "model", None), "rotary_emb")
+        )
+        if supports_layerwise_test:
+            _test_same_model(model, new_model, input_ids)
+        else:
+            _test_whole_model_forward(model, new_model, input_ids)
     else:
         # VLMs dont have a standardised forward pass mechanism. So we just test whole model forward pass and not layer wise
         # TODO: Maybe add layer wise checks


### PR DESCRIPTION
## Summary

Commit `0bd6a8d3` on `main` reverted the merge commit created by a `git pull`. Reverting a pull-merge undoes every diff the pull brought in, so two already-merged PRs were silently stripped out of the tree even though both still show as Merged on GitHub:

- **#588** [Qwen 3.5][gemma4] Qwen35 and Gemma 4 fast inference
- **#659** [MoE] Quantisation support and patches: Bnb and FP8

Their commits stayed reachable in history (only the diffs were reverted), so a plain re-merge would not bring them back: git considers them already merged. The fix is to revert the revert, which this PR does.

## What this restores

`+5025 / -182` across 20 files, including 8 files that were fully deleted by the revert:

- `unsloth_zoo/temporary_patches/moe_utils_fp8.py` (1018 lines)
- `unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py` (618 lines)
- `tests/test_vllm_to_hf_conversion.py` (1410 lines)
- `tests/test_moe_quant_cleanup.py`, `tests/test_moe_quant_handler_registry.py`, `tests/test_saving_utils_quant_aware_merge.py`, `tests/test_moe_grouped_mm_alignment_fallback.py`, `tests/test_gemma4_clippable_linear_peft_reload.py`

plus reverted hunks in `vllm_utils.py`, `empty_model.py`, `saving_utils.py`, `gemma4.py`, `moe_utils.py`, `glm4_moe.py`, `hf_utils.py`, and the `temporary_patches` `__init__`/`common`/`misc` files.

## Verification

- After the revert-the-revert, the source tree is byte-identical to the merged tip `c235bea5` (the state both PRs produced).
- The only intentional difference from `c235bea5` is `.github/CODEOWNERS`, which keeps the separate CODEOWNERS update from `b4522bd8`.
- `py_compile` passes on all restored modules.