### PR TITLE
Fix patch_gemma4_vllm_lora_support crash before early return

### DIFF
--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -352,7 +352,6 @@ def patch_gemma4_vllm_lora_support():
         from vllm.v1.worker import lora_model_runner_mixin
     except ImportError:
         lora_model_runner_mixin = None
-    from unsloth_zoo import vllm_lora_worker_manager
 
     gemma4_lora_classes = []
     classes_to_patch = []
@@ -370,6 +369,8 @@ def patch_gemma4_vllm_lora_support():
         pass
     if not classes_to_patch:
         return
+    # Import after the early return: pulls in hard vllm internals.
+    from unsloth_zoo import vllm_lora_worker_manager
     gemma4_lora_classes = set(gemma4_lora_classes)
 
     for cls in classes_to_patch:


### PR DESCRIPTION
## What

Fixes the Core CI failure on main:

```
FAILED tests/test_vllm_to_hf_conversion.py::test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes
ModuleNotFoundError: No module named 'vllm.config'
```

This is currently failing the Core (HF=default + TRL=default) and Core (HF=latest + TRL=latest) jobs for every PR in unslothai/unsloth, since that workflow runs the unsloth_zoo suite at main.

## Root cause

`patch_gemma4_vllm_lora_support` imports `unsloth_zoo.vllm_lora_worker_manager` before its early-return guard. That module hard-imports vllm internals at top level (`from vllm.config import LoRAConfig`, line 22), which is intentional per the upstream-ref tests in `tests/test_zoo_source_upstream_refs.py`. The function is supposed to return early when no gemma4 classes are importable, but it crashes on the worker manager import before ever reaching the guard.

## Fix

Move the `vllm_lora_worker_manager` import below the `if not classes_to_patch: return` guard in `unsloth_zoo/empty_model.py`. The import sits right before its only use (patching `create_lora_manager`), so behavior when gemma4 classes exist is unchanged.

The worker manager module itself is untouched: its top-level imports are by design and covered by their own source tests.

## Verification

- Reproduced the failure on unmodified main in a clean venv, then confirmed the test passes with this change
- Ran the full tests/ suite on main and on this branch in the same environment and diffed the failure sets: this change fixes exactly the one failing test and introduces zero regressions