### PR TITLE
Fix flaky vllm.config ModuleNotFoundError in gemma4 LoRA patch test

### DIFF
--- a/tests/test_vllm_to_hf_conversion.py
+++ b/tests/test_vllm_to_hf_conversion.py
@@ -1362,6 +1362,13 @@ def test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes():
     ):
         saved[missing] = _sys.modules.get(missing)
         _sys.modules[missing] = None
+    # Evict any cached copy so the no-classes path is exercised against a
+    # fresh import regardless of test order. vllm_lora_worker_manager needs
+    # vllm.config (not stubbed here), which only resolves on a real vllm
+    # install; the early return must not pull it in.
+    saved_worker_manager = _sys.modules.pop(
+        "unsloth_zoo.vllm_lora_worker_manager", None
+    )
     try:
         # Must return without raising when no gemma4 class importable.
         empty_model.patch_gemma4_vllm_lora_support()
@@ -1373,6 +1380,8 @@ def test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes():
                 _sys.modules.pop(name, None)
             else:
                 _sys.modules[name] = prev
+        if saved_worker_manager is not None:
+            _sys.modules["unsloth_zoo.vllm_lora_worker_manager"] = saved_worker_manager
 
 
 def test_patch_gemma4_vllm_k_eq_v_support_noop_when_private_attr_missing():

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -352,7 +352,6 @@ def patch_gemma4_vllm_lora_support():
         from vllm.v1.worker import lora_model_runner_mixin
     except ImportError:
         lora_model_runner_mixin = None
-    from unsloth_zoo import vllm_lora_worker_manager
 
     gemma4_lora_classes = []
     classes_to_patch = []
@@ -370,6 +369,10 @@ def patch_gemma4_vllm_lora_support():
         pass
     if not classes_to_patch:
         return
+    # Deferred: this module imports vllm.config and friends, which only
+    # resolve on a real vllm install. Import once gemma4 classes exist.
+    from unsloth_zoo import vllm_lora_worker_manager
+
     gemma4_lora_classes = set(gemma4_lora_classes)
 
     for cls in classes_to_patch:


### PR DESCRIPTION
### What

Fixes the flaky Core CI failure in the unsloth repo:

```
FAILED tests/test_vllm_to_hf_conversion.py::test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes
ModuleNotFoundError: No module named 'vllm.config'
```

This currently fails on unsloth main and on unrelated PRs, on varying matrix legs.

### Root cause

`patch_gemma4_vllm_lora_support` imports `unsloth_zoo.vllm_lora_worker_manager` at the top of the function, before the early return that fires when no gemma4 classes are importable. That module unconditionally does `from vllm.config import LoRAConfig` (plus vllm.logger, vllm.lora.peft_helper, etc), which only resolves on a real vllm install.

The test stubs the vllm submodules the function itself touches, but not vllm.config. So the outcome depends on whether some earlier test already cached `unsloth_zoo.vllm_lora_worker_manager` in `sys.modules`: if cached, the import is a no-op and the test passes; on a fresh import it raises. Test ordering differs across CI matrix legs, which is why the failure hops between legs and sometimes disappears.

### Fix

- Move the `vllm_lora_worker_manager` import below the early return. It is only used after gemma4 classes are found, and on a real vllm install (the only case where classes are found) the import resolves the same as before. When no classes exist, the function now returns without touching the module, which matches the contract the test asserts.
- Harden the test: evict `unsloth_zoo.vllm_lora_worker_manager` from `sys.modules` before the call (restored afterwards) so the no-classes path is always exercised against a fresh import, making the test deterministic regardless of ordering instead of order dependent.

### Verification

- Pre-fix, the test fails deterministically when run in isolation with the exact CI traceback (vllm_lora_worker_manager.py line 22), and the hardened test also fails when the module is pre-cached
- Post-fix, it passes both in isolation and with a pre-cached fake module, and the cache is restored
- Full file before vs after: exactly one test flips to passing, every other result identical; tests/test_zoo_history_regressions_deep.py (34 tests) unaffected
