### PR TITLE
Make vllm_lora_worker_manager import-safe without vLLM

### DIFF
--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -19,8 +19,7 @@ except ImportError:
         def __init__(self, device):
             self.device = device
 
-# vLLM imports are guarded so this module stays importable without vLLM
-# (only the LoRA worker functionality, which needs real vLLM, uses them).
+# Guard vLLM imports so this module imports without vLLM (real LoRA work needs it).
 try:
     from vllm.config import LoRAConfig, VllmConfig
 except ImportError:

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -22,9 +22,10 @@ except ImportError:
 # vLLM imports are guarded so this module stays importable without vLLM
 # (only the LoRA worker functionality, which needs real vLLM, uses them).
 try:
-    from vllm.config import LoRAConfig
+    from vllm.config import LoRAConfig, VllmConfig
 except ImportError:
     class LoRAConfig: pass
+    class VllmConfig: pass
 try:
     from vllm.logger import init_logger
 except ImportError:
@@ -338,7 +339,6 @@ def old_init(
     # Lazily initialized by create_lora_manager.
     self._adapter_manager: LoRAModelManager
 
-from vllm.config import VllmConfig
 def new_init(
     self,
     vllm_config: VllmConfig,

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -19,19 +19,45 @@ except ImportError:
         def __init__(self, device):
             self.device = device
 
-from vllm.config import LoRAConfig
-from vllm.logger import init_logger
+# vLLM imports are guarded so this module stays importable without vLLM
+# (only the LoRA worker functionality, which needs real vLLM, uses them).
+try:
+    from vllm.config import LoRAConfig
+except ImportError:
+    class LoRAConfig: pass
+try:
+    from vllm.logger import init_logger
+except ImportError:
+    import logging
+    def init_logger(name): return logging.getLogger(name)
 try:
     from vllm.lora.models import (LoRAModel, LoRAModelManager,
                                 LRUCacheLoRAModelManager, create_lora_manager)
 except ImportError:
     # Newer vLLM version moved/split lora methods
     # https://github.com/vllm-project/vllm/pull/30253
-    from vllm.lora.lora_model import LoRAModel
-    from vllm.lora.model_manager import LoRAModelManager, LRUCacheLoRAModelManager, create_lora_manager
-from vllm.lora.peft_helper import PEFTHelper
-from vllm.lora.request import LoRARequest
-from vllm.lora.utils import get_adapter_absolute_path
+    try:
+        from vllm.lora.lora_model import LoRAModel
+        from vllm.lora.model_manager import LoRAModelManager, LRUCacheLoRAModelManager, create_lora_manager
+    except ImportError:
+        class LoRAModel: pass
+        class LoRAModelManager: pass
+        class LRUCacheLoRAModelManager: pass
+        def create_lora_manager(*args, **kwargs):
+            raise RuntimeError("vLLM is required for LoRA worker manager")
+try:
+    from vllm.lora.peft_helper import PEFTHelper
+except ImportError:
+    class PEFTHelper: pass
+try:
+    from vllm.lora.request import LoRARequest
+except ImportError:
+    class LoRARequest: pass
+try:
+    from vllm.lora.utils import get_adapter_absolute_path
+except ImportError:
+    def get_adapter_absolute_path(*args, **kwargs):
+        raise RuntimeError("vLLM is required for LoRA worker manager")
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
## What

Make `unsloth_zoo/vllm_lora_worker_manager.py` importable without vLLM installed.

## Why

The module had unguarded top-level vLLM imports:

```
from vllm.config import LoRAConfig
from vllm.logger import init_logger
from vllm.lora.peft_helper import PEFTHelper
from vllm.lora.request import LoRARequest
from vllm.lora.utils import get_adapter_absolute_path
```

plus the `vllm.lora.models` -> `vllm.lora.lora_model`/`model_manager` fallback,
whose `except` branch also imports vLLM and therefore crashes when vLLM is fully
absent.

`empty_model.patch_gemma4_vllm_lora_support()` imports this module before its
early-return, so importing it in an environment without vLLM (or with only a
partial vLLM, as the test harness sets up) raised:

```
ModuleNotFoundError: No module named 'vllm.config'
```

This is what turns the `Core` CI job red on `unslothai/unsloth` (it clones
`unsloth_zoo@main` and runs the full pytest):

```
FAILED tests/test_vllm_to_hf_conversion.py::test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes
  - ModuleNotFoundError: No module named 'vllm.config'
```

## Change

Guard every vLLM import with `try/except`, falling back to import-safe
placeholders so the module always loads:

- missing classes become empty placeholder classes (not `None`) so the module's
  annotations (`Type[LoRAModel]`, `Union[..., LoRAModel]`), default arguments
  (`= LoRAModel`) and `isinstance(...)` checks keep working at import time;
- `init_logger` falls back to `logging.getLogger`;
- `create_lora_manager` / `get_adapter_absolute_path` fall back to stubs that
  raise a clear `RuntimeError("vLLM is required ...")` if ever called without vLLM.

Real LoRA worker functionality still requires real vLLM; this only restores
import safety. When vLLM is present the imports resolve to the real symbols
exactly as before.

## Verification

- `tests/test_vllm_to_hf_conversion.py::test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes` now passes.
- Full `tests/test_vllm_to_hf_conversion.py` passes (58 passed).
- Full `pytest tests/` shows no new failures from this change (the one local
  failure, `test_mlx_finetune_last_n_layers`, fails identically without this
  change and is an unrelated local mlx-version issue; it passes in CI).
- With vLLM installed, `unsloth_zoo.vllm_lora_worker_manager.LoRAConfig` /
  `create_lora_manager` still resolve to the real `vllm.*` objects.
