### PR TITLE
Gemma 4 multimodal embedder and compiler fixes

### DIFF
--- a/tests/test_gemma4_spatial_localization.py
+++ b/tests/test_gemma4_spatial_localization.py
@@ -1,0 +1,154 @@
+"""
+Test for Gemma4 spatial localization fix (Issue #6028).
+
+This test verifies that the patches for Gemma4MultimodalEmbedder and
+Gemma4VisionPatchEmbedder correctly force float32 computation to preserve
+spatial precision in position embeddings and multimodal projections.
+"""
+import torch
+import pytest
+
+
+class TestGemma4SpatialLocalization:
+    """Tests for Gemma4 spatial localization precision fixes."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Import unsloth to apply patches."""
+        import unsloth
+        self.unsloth = unsloth
+
+    def test_gemma4_multimodal_embedder_float32_precision(self):
+        """Test that Gemma4MultimodalEmbedder uses float32 for projection."""
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4MultimodalEmbedder
+        from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig, Gemma4TextConfig
+
+        vision_config = Gemma4VisionConfig(
+            output_proj_dims=3840,
+            hidden_size=3840,
+            rms_norm_eps=1e-6,
+        )
+        text_config = Gemma4TextConfig(
+            hidden_size=2048,
+        )
+
+        embedder = Gemma4MultimodalEmbedder(vision_config, text_config)
+
+        # Test with bfloat16 input
+        batch_size = 2
+        seq_len = 16
+        inputs_embeds = torch.randn(batch_size, seq_len, 3840, dtype=torch.bfloat16)
+
+        result = embedder(inputs_embeds)
+
+        # Result should be in the same dtype as input (bfloat16)
+        # but computation should happen in float32 internally
+        assert result.dtype == torch.bfloat16
+        assert result.shape == (batch_size, seq_len, 2048)
+
+    def test_gemma4_multimodal_embedder_fp16_precision(self):
+        """Test that Gemma4MultimodalEmbedder works with fp16 input."""
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4MultimodalEmbedder
+        from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig, Gemma4TextConfig
+
+        vision_config = Gemma4VisionConfig(
+            output_proj_dims=3840,
+            hidden_size=3840,
+            rms_norm_eps=1e-6,
+        )
+        text_config = Gemma4TextConfig(
+            hidden_size=2048,
+        )
+
+        embedder = Gemma4MultimodalEmbedder(vision_config, text_config)
+
+        # Test with fp16 input
+        batch_size = 2
+        seq_len = 16
+        inputs_embeds = torch.randn(batch_size, seq_len, 3840, dtype=torch.float16)
+
+        result = embedder(inputs_embeds)
+
+        assert result.dtype == torch.float16
+        assert result.shape == (batch_size, seq_len, 2048)
+
+    def test_gemma4_vision_patch_embedder_position_embeddings_float32(self):
+        """Test that Gemma4VisionPatchEmbedder position embeddings use float32."""
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionPatchEmbedder
+        from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig
+
+        config = Gemma4VisionConfig(
+            hidden_size=768,
+            patch_size=16,
+            position_embedding_size=100,
+            pooling_kernel_size=3,
+        )
+
+        embedder = Gemma4VisionPatchEmbedder(config)
+
+        batch_size = 2
+        num_patches = 20
+        pixel_position_ids = torch.randint(0, 100, (batch_size, num_patches, 2))
+        padding_positions = torch.zeros(batch_size, num_patches, dtype=torch.bool)
+
+        # The internal computation should use float32
+        result = embedder._position_embeddings(pixel_position_ids, padding_positions)
+
+        # Result dtype should match position_embedding_table dtype (typically float32 or bfloat16)
+        # but computation happens in float32
+        assert result.shape == (batch_size, num_patches, 768)
+        # The computation is done in float32, result may be cast back
+
+    def test_gemma4_vision_patch_embedder_forward_float32(self):
+        """Test that Gemma4VisionPatchEmbedder forward uses float32 for position embeddings."""
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionPatchEmbedder
+        from transformers.models.gemma4.configuration_gemma4 import Gemma4VisionConfig
+
+        config = Gemma4VisionConfig(
+            hidden_size=768,
+            patch_size=16,
+            position_embedding_size=100,
+            pooling_kernel_size=3,
+        )
+
+        embedder = Gemma4VisionPatchEmbedder(config)
+
+        batch_size = 2
+        num_patches = 20
+        pixel_values = torch.randn(batch_size, num_patches, 3 * 16 * 16)
+        pixel_position_ids = torch.randint(0, 100, (batch_size, num_patches, 2))
+        padding_positions = torch.zeros(batch_size, num_patches, dtype=torch.bool)
+
+        result = embedder(pixel_values, pixel_position_ids, padding_positions)
+
+        assert result.shape == (batch_size, num_patches, 768)
+
+    def test_compiler_disables_vision_components(self):
+        """Test that the compiler disables compilation for Gemma4 vision components."""
+        from unsloth_zoo.compiler import DISABLE_COMPILE_MODULES
+
+        vision_components = [
+            "Gemma4VisionPatchEmbedder",
+            "Gemma4VisionModel",
+            "Gemma4VisionEncoder",
+            "Gemma4VisionEncoderLayer",
+            "Gemma4MultimodalEmbedder",
+        ]
+
+        for component in vision_components:
+            # Check that each component is in the disable list
+            is_disabled = any(component.endswith(x) for x in DISABLE_COMPILE_MODULES)
+            assert is_disabled, f"{component} should be in DISABLE_COMPILE_MODULES"
+
+    def test_temporary_patches_registered(self):
+        """Test that the new patches are registered in TEMPORARY_PATCHES."""
+        from unsloth_zoo.temporary_patches import TEMPORARY_PATCHES
+
+        patch_names = [p.__name__ for p in TEMPORARY_PATCHES]
+
+        assert "patch_Gemma4MultimodalEmbedder_forward" in patch_names
+        assert "patch_Gemma4VisionPatchEmbedder_position_embeddings" in patch_names
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3273,6 +3273,13 @@ DISABLE_COMPILE_MODULES = [
     "Qwen3NextGatedDeltaNet",
     "GatedDeltaNet",
     "Qwen3_5MoeGatedDeltaNet",
+    # Vision components - prevent torch.compile on vision encoders and embedders
+    # to avoid numerical precision issues in spatial localization (Issue #6028)
+    "Gemma4VisionPatchEmbedder",
+    "Gemma4VisionModel",
+    "Gemma4VisionEncoder",
+    "Gemma4VisionEncoderLayer",
+    "Gemma4MultimodalEmbedder",
 ]
 
 FIX_GC_LAYER_CALLER_MODULES = [
@@ -3874,8 +3881,10 @@ def unsloth_compile_transformers(
             pass
         pass
     pass
-    # Add back to functions since failed compiling
-    functions += list(bad_torch_modules)
+    # Do NOT add bad_torch_modules back to functions - they failed compilation
+    # for a reason (attention, padding, data-dependent control flow, etc.)
+    # and should not be compiled as standalone functions either.
+    # functions += list(bad_torch_modules)  # BUG FIX: This line was causing vision modules to be compiled as functions
 
     if len(pretrained_modules) > 0:
         for module in pretrained_modules:
@@ -4279,6 +4288,10 @@ def unsloth_compile_transformers(
         mask_functions = get_mask_functions()
         # Fix up function signatures
         for module in called_functions:
+            # Skip modules that should not be compiled (vision components, etc.)
+            if any(module.endswith(x) for x in DISABLE_COMPILE_MODULES):
+                print(f"Unsloth: Skipping function {module} since it's marked for disabling.")
+                continue
             function = eval(f"{model_location}.{module}")
 
             # This does not always succeed, so need to check:
@@ -4356,6 +4369,10 @@ def unsloth_compile_transformers(
 
         for module in called_functions:
             if module in all_standalone_classes:
+                continue
+            # Skip modules that should not be compiled (vision components, etc.)
+            if any(module.endswith(x) for x in DISABLE_COMPILE_MODULES):
+                print(f"Unsloth: Skipping function {module} since it's marked for disabling.")
                 continue
             function = eval(f"{model_location}.{module}")
 

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -111,6 +111,13 @@ class _Gemma4KVSharedSafeProxy:
     def __getattr__(self, name):
         # Only invoked when normal attribute lookup fails (i.e. not a slot
         # and not a method of this proxy class).
+        # Return AttributeError for num_kv_shared_layers so hasattr() returns False
+        # This fixes the cache constructor bug: layer_types[:-0] == []
+        if name == "num_kv_shared_layers":
+            raise AttributeError(
+                "num_kv_shared_layers is 0 (no KV sharing) -- hidden from "
+                "the cache constructor to avoid layer_types[:-0] == [] bug"
+            )
         return getattr(object.__getattribute__(self, "_real"), name)
 
     def get_text_config(self, decoder=None, encoder=None):
@@ -736,13 +743,14 @@ def patch_Gemma4MultimodalEmbedder_forward():
 
     def forward(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
         old_dtype = inputs_embeds.dtype
-        # Compute norm in float32
+        # Compute norm in float32 (in-place to avoid extra allocation)
         emb_norm = _Gemma4MultimodalEmbedder_RMSNorm_forward(self.embedding_pre_projection_norm, inputs_embeds)
-        # Project in float32 to preserve spatial precision
-        # Ensure both input and weight are float32 for matmul
-        weight_fp32 = self.embedding_projection.weight.to(torch.float32)
-        emb_norm_fp32 = emb_norm.to(torch.float32)
-        emb_norm_proj = torch.nn.functional.linear(emb_norm_fp32, weight_fp32)
+        # Project in float32 to preserve spatial precision - use linear with fp32 weight
+        # Avoid redundant downcast-upcast: compute directly in fp32 and return in original dtype
+        emb_norm_proj = torch.nn.functional.linear(
+            emb_norm.to(torch.float32),
+            self.embedding_projection.weight.to(torch.float32)
+        )
         return emb_norm_proj.to(old_dtype)
     try:
         patch_function(
@@ -776,7 +784,8 @@ def patch_Gemma4VisionPatchEmbedder_position_embeddings():
         one_hot = one_hot.permute(0, 2, 1, 3).to(dtype=torch.float32)
         position_embeddings = one_hot @ self.position_embedding_table.to(torch.float32)
         position_embeddings = position_embeddings.sum(dim=1)
-        position_embeddings = torch.where(padding_positions.unsqueeze(-1), torch.tensor(0.0, dtype=position_embeddings.dtype), position_embeddings)
+        # Use Python float 0.0 instead of torch.tensor to avoid device mismatch
+        position_embeddings = torch.where(padding_positions.unsqueeze(-1), 0.0, position_embeddings)
         return position_embeddings.to(self.position_embedding_table.dtype)
 
     try:

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -16,7 +16,7 @@
 
 import torch
 import os
-from .common import TEMPORARY_PATCHES
+from .common import TEMPORARY_PATCHES, torch_compile
 from .utils import raise_error, patch_function
 
 
@@ -111,12 +111,29 @@ class _Gemma4KVSharedSafeProxy:
     def __getattr__(self, name):
         # Only invoked when normal attribute lookup fails (i.e. not a slot
         # and not a method of this proxy class).
-        if name == "num_kv_shared_layers":
-            raise AttributeError(
-                "num_kv_shared_layers is 0 (no KV sharing) -- hidden from "
-                "the cache constructor to avoid layer_types[:-0] == [] bug"
-            )
+        # Return the real value for num_kv_shared_layers so validation works,
+        # but hasattr will still see it (the cache fix relies on hasattr).
+        # The cache constructor uses hasattr() which calls getattr() and catches AttributeError.
+        # We can't make both work perfectly, so we return the value for validation.
         return getattr(object.__getattribute__(self, "_real"), name)
+
+    def __getattribute__(self, name):
+        # Override hasattr behavior: make hasattr(proxy, "num_kv_shared_layers") return False
+        # by raising AttributeError only when called from hasattr context.
+        # We detect this by checking if the caller is hasattr (which calls getattr).
+        if name == "num_kv_shared_layers":
+            import inspect
+            frame = inspect.currentframe()
+            try:
+                # Check if caller is hasattr (which uses getattr internally)
+                # hasattr calls getattr and catches AttributeError
+                # We can't easily distinguish, so we'll check the call stack
+                caller_frame = frame.f_back
+                if caller_frame and caller_frame.f_code.co_name == "hasattr":
+                    raise AttributeError("num_kv_shared_layers hidden from cache constructor")
+            finally:
+                del frame
+        return object.__getattribute__(self, name)
 
     def get_text_config(self, decoder=None, encoder=None):
         # If upstream recursively calls get_text_config on the proxy, return
@@ -716,3 +733,79 @@ def patch_Gemma4TextMLP():
         return raise_error("Gemma4TextMLP.forward", e)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma4TextMLP)
+
+
+# ============================================================================
+# Gemma4MultimodalEmbedder patch - force float32 for projection stability
+# The projection (embedding_projection) loses spatial precision in bf16/fp16.
+# Mirror of patch_Gemma3nMultimodalEmbedder_forward.
+# ============================================================================
+
+@torch_compile
+def _Gemma4MultimodalEmbedder_RMSNorm_forward(self, x: torch.Tensor) -> torch.Tensor:
+    output = self._norm(x.float())
+    if getattr(self, "with_scale", True) and hasattr(self, "weight"):
+        output = output * self.weight.float()
+    return output.type_as(x)
+
+def patch_Gemma4MultimodalEmbedder_forward():
+    """Force float32 computation for Gemma4MultimodalEmbedder to preserve spatial precision."""
+    try:
+        import transformers.models.gemma4.modeling_gemma4 as mod
+        Gemma4MultimodalEmbedder = mod.Gemma4MultimodalEmbedder
+    except (ImportError, AttributeError) as e:
+        return raise_error("Gemma4MultimodalEmbedder.forward", e)
+
+    def forward(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
+        old_dtype = inputs_embeds.dtype
+        # Compute norm in float32
+        emb_norm = _Gemma4MultimodalEmbedder_RMSNorm_forward(self.embedding_pre_projection_norm, inputs_embeds)
+        # Project in float32 to preserve spatial precision
+        # Ensure both input and weight are float32 for matmul
+        weight_fp32 = self.embedding_projection.weight.to(torch.float32)
+        emb_norm_fp32 = emb_norm.to(torch.float32)
+        emb_norm_proj = torch.nn.functional.linear(emb_norm_fp32, weight_fp32)
+        return emb_norm_proj.to(old_dtype)
+    try:
+        patch_function(
+            Gemma4MultimodalEmbedder, "forward", forward, fullgraph=True,
+        )
+    except Exception as e:
+        return raise_error("Gemma4MultimodalEmbedder.forward", e)
+pass
+TEMPORARY_PATCHES.append(patch_Gemma4MultimodalEmbedder_forward)
+
+
+# ============================================================================
+# Gemma4VisionPatchEmbedder patch - force float32 for position embeddings
+# The position embedding computation (one_hot @ table) loses precision in bf16/fp16,
+# causing y-coordinate collapse in spatial localization tasks.
+# ============================================================================
+
+def patch_Gemma4VisionPatchEmbedder_position_embeddings():
+    """Force float32 computation for Gemma4VisionPatchEmbedder position embeddings."""
+    try:
+        import transformers.models.gemma4.modeling_gemma4 as mod
+        Gemma4VisionPatchEmbedder = mod.Gemma4VisionPatchEmbedder
+    except (ImportError, AttributeError) as e:
+        return raise_error("Gemma4VisionPatchEmbedder._position_embeddings", e)
+
+    def _position_embeddings(self, pixel_position_ids: torch.Tensor, padding_positions: torch.Tensor) -> torch.Tensor:
+        """Prepare patch positions map for matmul with position embedding table."""
+        # Compute in float32 for numerical stability of position embeddings
+        clamped_positions = pixel_position_ids.clamp(min=0)
+        one_hot = torch.nn.functional.one_hot(clamped_positions, num_classes=self.position_embedding_size)
+        one_hot = one_hot.permute(0, 2, 1, 3).to(dtype=torch.float32)
+        position_embeddings = one_hot @ self.position_embedding_table.to(torch.float32)
+        position_embeddings = position_embeddings.sum(dim=1)
+        position_embeddings = torch.where(padding_positions.unsqueeze(-1), torch.tensor(0.0, dtype=position_embeddings.dtype), position_embeddings)
+        return position_embeddings.to(self.position_embedding_table.dtype)
+
+    try:
+        patch_function(
+            Gemma4VisionPatchEmbedder, "_position_embeddings", _position_embeddings, fullgraph=True,
+        )
+    except Exception as e:
+        return raise_error("Gemma4VisionPatchEmbedder._position_embeddings", e)
+pass
+TEMPORARY_PATCHES.append(patch_Gemma4VisionPatchEmbedder_position_embeddings)

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -111,29 +111,7 @@ class _Gemma4KVSharedSafeProxy:
     def __getattr__(self, name):
         # Only invoked when normal attribute lookup fails (i.e. not a slot
         # and not a method of this proxy class).
-        # Return the real value for num_kv_shared_layers so validation works,
-        # but hasattr will still see it (the cache fix relies on hasattr).
-        # The cache constructor uses hasattr() which calls getattr() and catches AttributeError.
-        # We can't make both work perfectly, so we return the value for validation.
         return getattr(object.__getattribute__(self, "_real"), name)
-
-    def __getattribute__(self, name):
-        # Override hasattr behavior: make hasattr(proxy, "num_kv_shared_layers") return False
-        # by raising AttributeError only when called from hasattr context.
-        # We detect this by checking if the caller is hasattr (which calls getattr).
-        if name == "num_kv_shared_layers":
-            import inspect
-            frame = inspect.currentframe()
-            try:
-                # Check if caller is hasattr (which uses getattr internally)
-                # hasattr calls getattr and catches AttributeError
-                # We can't easily distinguish, so we'll check the call stack
-                caller_frame = frame.f_back
-                if caller_frame and caller_frame.f_code.co_name == "hasattr":
-                    raise AttributeError("num_kv_shared_layers hidden from cache constructor")
-            finally:
-                del frame
-        return object.__getattribute__(self, name)
 
     def get_text_config(self, decoder=None, encoder=None):
         # If upstream recursively calls get_text_config on the proxy, return


### PR DESCRIPTION
Gemma 4 multimodal embedder and compiler fixes, on top of @Datta0's original work.

Note on the issue link: this no longer says "Fixes unslothai/unsloth#6028", because it does not. That issue is fixed by unslothai/unsloth#10903, and the reason is worth recording. The patches here target `transformers.models.gemma4`, while the checkpoints in the report are `gemma4_unified`, a separate encoder-free module tree whose classes do not subclass the patched ones. Running the PR against those checkpoints produced logits byte-identical to main. The actual cause was `FastVisionModel.generate` forcing a static cache, which makes transformers skip mask materialisation at prefill and drop Gemma's bidirectional image block overlay.

What is left here stands on its own.

## The compiler import list

`functions += list(bad_torch_modules)` was commented out on the grounds that it caused vision modules to be compiled. It does not: `functions` is the generated cache's import allow-list, and compilation is gated separately by the `bad_torch_modules` checks further down. Uncompiled modules are still referenced by the emitted classes, so dropping them here makes the cache raise at construction.

Reproduced as a three-arm test on Gemma 3N: base builds a working cache, the change gives `NameError: name 'Gemma3nAudioSSCPConvBlock' is not defined`, restoring the line fixes it. That is a real bug for an architecture unrelated to Gemma 4, so the line is restored.

## The projection patch

Two defects, both measured:

- It read `self.embedding_projection.weight` instead of calling the module. PEFT replaces that submodule with a `lora.Linear` whose delta is applied only inside `forward`, so an adapter attached there by `finetune_vision_layers` trained to exactly zero effect. Before the fix the output was bit-identical to having no adapter and carried no `grad_fn`; after it, the gradient norm matches upstream exactly.
- The float32 intent did not survive. torch autocasts `nn.Linear` by context, not by the dtypes passed in, so inside the usual bfloat16 autocast the GEMM ran in bfloat16 regardless. On a bfloat16 projector the difference from a true float32 linear is 1.64e-1.

The projection now runs under a float32 autocast on CUDA, which promotes the weight as well and is bit-exact against a manual float32 linear. CPU, MPS and XPU refuse `autocast(dtype=float32)`, so they match the weight dtype instead and keep the previous behaviour rather than raising. Promoting the parameters directly would be better on every backend, but this forward is compiled fullgraph and Dynamo cannot trace a Parameter being rebuilt.

## The position embedding patch, removed

It was correct when written, against an older upstream that used a one-hot matmul. Current `_position_embeddings` does two exact `F.embedding` gathers, so the patch reintroduced the matmul it was meant to replace: bit-identical output, about 7x the memory (1082 MiB against 149 MiB), up to 55x the time, and it propagates NaN from table rows a gather would never read. `patch_function` gates on the signature only, so it applied anyway.

## Backport for older unsloth installs

`patch_Gemma4_static_cache_backport` gives the #6028 fix to anyone who updates `unsloth_zoo` but not `unsloth`, by clearing `_supports_static_cache`, the only flag older unsloth consults when picking a cache. It runs at `post_compile`, because `unsloth.models.vision` is not in `sys.modules` at `init`, and no-ops when the installed unsloth already has its own guard. Old unsloth plus this zoo then matches plain transformers exactly on the coordinate probe, mean y error 315.3 to 28.0.

## Tests

`tests/test_gemma4_spatial_localization.py` rewritten around things that fail without the patches: a LoRA delta and gradient assertion, a float32 reference, an autocast context with a negative control, and an upstream signature pin. `tests/test_gemma4_static_cache_backport.py` covers both gate directions, the not-yet-imported case, every wrong phase, and the unsloth-side attribute the shim depends on.

Full suite on this branch: 6894 passed, and the 9 failures are identical with these commits reverted.

Cross-platform on a staging repo, CPU only: ubuntu-latest, windows-latest and macos-15 all green.