### PR TITLE
fix(gemma4): hide num_kv_shared_layers from safe-proxy iteration

### DIFF
--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -105,6 +105,10 @@ class _Gemma4KVSharedSafeProxy:
 
     __slots__ = ("_real",)
 
+    # __dict__/vars() still expose num_kv_shared_layers (no instance dict -> forwards
+    # to _real); keep it that way -- to_dict() deepcopies __dict__, so sealing it
+    # would drop the field from serialization. #6089
+
     def __init__(self, real):
         object.__setattr__(self, "_real", real)
 
@@ -127,14 +131,17 @@ class _Gemma4KVSharedSafeProxy:
     # PreTrainedConfig.__iter__ yields attribute names from self.__dict__.
     # Validators such as validate_token_ids rely on this iteration.
     def __iter__(self):
-        return iter(object.__getattribute__(self, "_real"))
+        # Hide num_kv_shared_layers, like __getattr__/__contains__/__getitem__:
+        # validate_token_ids does `for n in cfg: getattr(cfg, n)`, so yielding it
+        # would re-raise the AttributeError from __getattr__. See unslothai/unsloth#6089.
+        for name in object.__getattribute__(self, "_real"):
+            if name == "num_kv_shared_layers":
+                continue
+            yield name
 
     def __len__(self):
-        real = object.__getattribute__(self, "_real")
-        try:
-            return len(real)
-        except TypeError:
-            return len(getattr(real, "__dict__", {}))
+        # Consistent with __iter__ (hidden attr excluded).
+        return sum(1 for _ in self)
 
     def __contains__(self, item):
         if item == "num_kv_shared_layers":

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -643,7 +643,12 @@ def patch_Gemma4ClippableLinear_peft_reload():
         current_key=None,
         **kwargs,
     ):
-        if isinstance(target, Gemma4ClippableLinear):
+        # Match by identity OR name+structure: the compiler emits a duplicate
+        # Gemma4ClippableLinear, so a compiled model's modules aren't isinstance of the
+        # transformers class (breaks a 2nd adapter, e.g. GRPO "ref"). #6089
+        if isinstance(target, Gemma4ClippableLinear) or (
+            type(target).__name__ == "Gemma4ClippableLinear" and hasattr(target, "linear")
+        ):
             return original_create_and_replace(
                 self,
                 peft_config,


### PR DESCRIPTION
## Summary

This PR fixes two Gemma-4 finetuning blockers found while running the Gemma-4 E2B GRPO 2048 notebook end-to-end:

1. Config loading crashed on `transformers >= 5.9` with a misleading `Unsloth: No config file found`.
2. GRPO/ref-adapter creation crashed on compiled Gemma-4 PEFT models with:

```text
ValueError: Target module Gemma4ClippableLinear(...) is not supported
```

## Fix 1: Gemma-4 config load crash

`_Gemma4KVSharedSafeProxy` intentionally hides `num_kv_shared_layers` when its value is `0` so upstream `hasattr(...)` checks skip a buggy cache path. However, the proxy still exposed the field through `__iter__`.

In `transformers >= 5.9`, `validate_token_ids` iterates config keys and calls `getattr(cfg, name)`, which surfaced `num_kv_shared_layers` and re-raised the proxy’s intentional `AttributeError`.

### Change

* Make `__iter__` skip `num_kv_shared_layers`.
* Derive `__len__` from `__iter__` so both stay consistent.
* Preserve the existing behavior where `hasattr(proxy, "num_kv_shared_layers")` remains `False`.
* Keep the field in `__dict__`/`vars()` so `to_dict()` and save round-trips still persist it.

### Test

Verified on `transformers 5.10.2` / Colab T4:

* `AutoConfig.from_pretrained("unsloth/gemma-4-E2B-it")` returns `gemma4`.
* `FastVisionModel.from_pretrained(...)` loads successfully.
* Save round-trip for real `num_kv_shared_layers == 0` configs still persists the field.

## Fix 2: LoRA ref-adapter on compiled Gemma-4 models

`patch_Gemma4ClippableLinear_peft_reload` redirects `Gemma4ClippableLinear` targets to their inner `.linear` so PEFT can attach LoRA.

The previous check used `isinstance(target, Gemma4ClippableLinear)`. After Unsloth compilation, Gemma-4 modules are redefined into the compiled cache, creating a duplicate `Gemma4ClippableLinear` class. As a result, compiled instances failed the `isinstance` check and fell through to stock PEFT, which cannot wrap the outer wrapper module.

### Change

Match `Gemma4ClippableLinear` by either class identity or name+structure:

```python
type(target).__name__ == "Gemma4ClippableLinear" and hasattr(target, "linear")
```

This lets compiled-class instances redirect to `.linear` as intended. For ref adapters, `.linear` is already a `lora.Linear`, so PEFT updates the adapter instead of failing.

### Test

On a compiled Gemma-4 PEFT model:

```python
model.add_adapter("ref", model.peft_config["default"])
```

succeeds, and `GRPOTrainer(...)` initializes without the PEFT `ValueError`.

## Related

Closes unslothai/unsloth#6089
