### PR TITLE
Reduce and tighten code comments and docstrings repo-wide

### DIFF
--- a/scripts/enforce_kwargs_spacing.py
+++ b/scripts/enforce_kwargs_spacing.py
@@ -15,12 +15,8 @@ from pathlib import Path
 
 
 def _atomic_write_text(path: Path, data: str, encoding: str) -> None:
-    """Write ``data`` to ``path`` atomically.
-
-    Stages a tmp file in the same directory (so it's on the same
-    filesystem as the destination), fsyncs, then `os.replace`s into
-    place. A crash mid-write therefore leaves either the previous
-    content or the fully new content -- never a truncated source file.
+    """Write ``data`` to ``path`` atomically: stage a same-dir tmp file, fsync,
+    then os.replace, so a crash leaves old or new content, never a truncated file.
     """
     dirpath = str(path.parent) or "."
     fd, tmp_path = tempfile.mkstemp(prefix=".kwargs_fix.", dir=dirpath)

--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -4,34 +4,22 @@
 
 """Refuse dangerous GitHub Actions trigger patterns at PR time.
 
-Two patterns are banned outright, both of which powered the TanStack
-GHSA-g7cv-rxg3-hmpx supply-chain compromise:
+Flags three patterns from the TanStack GHSA-g7cv-rxg3-hmpx compromise:
 
-1.  `pull_request_target` -- runs a fork's workflow YAML against the
-    BASE repository's secrets and permissions. The fork can inject
-    arbitrary code into the base context. The TanStack worm used this
-    to land base-context execution from a fork PR. There is essentially
-    no safe use of this trigger for a public open-source project;
-    `pull_request` is the safe alternative.
+1.  `pull_request_target` -- runs a fork's workflow YAML against the BASE
+    repo's secrets/permissions, letting the fork inject code into the base
+    context. No safe use for public projects; use `pull_request` instead.
 
-2.  `workflow_run` chained to a PR-triggered workflow -- carries the
-    same trust boundary problem one hop later. If a PR-triggered
-    workflow can poison artifacts/caches and a `workflow_run` trigger
-    fires off the result with elevated permissions, the attacker still
-    reaches the trusted context.
+2.  `workflow_run` chained to a PR-triggered workflow -- same trust-boundary
+    problem one hop later: a PR can poison artifacts/caches that the
+    elevated-permission run then consumes.
 
-3.  Shared cache keys between PR-triggered workflows and publish /
-    release / push-triggered workflows. The TanStack worm poisoned the
-    Actions cache from a fork PR and the legitimate release workflow
-    then restored the poisoned cache. Cache keys must be partitioned
-    so that nothing a PR can write is ever read by a workflow that
-    holds secrets.
+3.  Shared cache keys between PR-triggered and publish/release/push
+    workflows -- a fork PR can poison the cache the release run restores.
+    Keys must be partitioned so secrets-holding workflows never read what a
+    PR can write.
 
-Exit codes
-==========
-
-  0   no findings
-  1   one or more findings; stderr lists each with file path
+Exit codes: 0 = no findings; 1 = findings (stderr lists each with file path).
 
 Run from repo root:
     python3 scripts/lint_workflow_triggers.py

--- a/scripts/verify_comment_only_diff.py
+++ b/scripts/verify_comment_only_diff.py
@@ -11,20 +11,14 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
-"""Deterministic comment / docstring-only verifier.
+"""Deterministic comment / docstring-only diff verifier.
 
-Compares a list of changed files between two git refs and reports whether
-each diff is strictly comments / docstrings (Python) or comments
-(YAML / GitHub Actions). Useful for gating a "comment trim" /
-"docstring refactor" PR against accidental code drift.
-
-Per .py file: parse both revs into AST, strip module / class / function
-docstrings, then compare ast.unparse output. Pure Python comments are
-discarded by the parser by construction, so any post-strip diff is real
-code. Per .yml file: yaml.safe_load both sides and compare the parsed
-Python object; if scalar values differ, also strip shell comments inside
-``run: |`` block bodies before comparing. Exit code 0 = all OK, 1 = at
-least one file has a real (non-comment) diff or an error.
+Reports whether each file's diff between two git refs is strictly comments /
+docstrings, to gate a "comment trim" PR against accidental code drift.
+Per .py: AST-parse both revs, strip docstrings, compare ast.unparse (pure
+comments are dropped by the parser). Per .yml: yaml.safe_load and compare the
+parsed object, also stripping shell comments in ``run: |`` bodies. Exit 0 =
+all OK, 1 = a real (non-comment) diff or error.
 
 Usage:
     python scripts/verify_comment_only_diff.py [--base REF] [--head REF] path ...
@@ -54,9 +48,8 @@ def _git_show(rev: str, path: str) -> str:
 
 
 def _strip_docstrings(tree: ast.AST) -> ast.AST:
-    """Remove every string-literal docstring (Module / FunctionDef /
-    AsyncFunctionDef / ClassDef). Empty body becomes ``pass`` so
-    ast.unparse stays valid."""
+    """Remove docstrings from Module / FunctionDef / AsyncFunctionDef /
+    ClassDef; an emptied body becomes ``pass`` so ast.unparse stays valid."""
     for node in ast.walk(tree):
         if isinstance(
             node,
@@ -84,9 +77,8 @@ def _normalize_py(src: str) -> str:
 
 
 def _strip_shell_comments(s: str) -> str:
-    """Strip pure-comment lines and inline trailing comments from a shell
-    snippet, then collapse runs of blank lines. Heuristic only: leaves a
-    line untouched if it has an odd quote count (open string)."""
+    """Strip comment lines + inline trailing comments from a shell snippet and
+    collapse blank runs. Heuristic: leaves lines with an odd quote count alone."""
     out = []
     for line in s.splitlines():
         stripped = line.lstrip()
@@ -113,9 +105,8 @@ def _strip_shell_comments(s: str) -> str:
 
 
 def _normalize_yaml_run_strings(obj: Any) -> Any:
-    """Walk the parsed YAML object; for any multi-line string (i.e. a
-    ``run: |`` script body), strip shell comments. Returns a normalised
-    copy."""
+    """Return a copy with shell comments stripped from every multi-line string
+    (i.e. ``run: |`` script bodies)."""
     if isinstance(obj, dict):
         return {k: _normalize_yaml_run_strings(v) for k, v in obj.items()}
     if isinstance(obj, list):

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -37,9 +37,8 @@ def test_fixture_files_exist():
 def test_fixture_bytes_are_deterministic(tmp_path):
     """Re-running `_build.py` must produce byte-identical archives.
 
-    The build helper sets every member's mtime/uid/gid/mode and emits
-    members in sorted order. We rebuild into a temp dir and compare
-    SHA-256 against the committed bytes.
+    The build helper pins each member's mtime/uid/gid/mode and sorts members;
+    we rebuild into a temp dir and compare SHA-256 against the committed bytes.
     """
     # Snapshot committed hashes.
     expected: dict[str, str] = {}
@@ -204,16 +203,12 @@ def test_may12_ioc_caught_by_scan_archive():
 
 
 def test_scan_packages_pip_download_failure_propagates(tmp_path):
-    """A pip download failure must NOT be silently swallowed into a
-    `0 findings, exit 0` report. Item (4) of the silent-failure
-    hardening: an obviously unresolvable spec is fed to the scanner
-    as a subprocess; the orchestrator must exit 2 (scan incomplete)
-    and the stderr must carry the SCAN INCOMPLETE banner.
+    """A pip download failure must not be swallowed into a `0 findings,
+    exit 0` report: an unresolvable spec must make the orchestrator exit 2
+    (scan incomplete) with the SCAN INCOMPLETE banner on stderr.
 
-    The spec name is deliberately long + random-looking so it cannot
-    accidentally resolve on any real package index. We do not rely on
-    network reachability: even an offline runner will get a clean
-    "could not resolve" failure from pip.
+    The spec name is deliberately long + random so it can't resolve on any
+    real index; even an offline runner gets a clean "could not resolve".
     """
     script = REPO_ROOT / "scripts" / "scan_packages.py"
     assert script.is_file(), script

--- a/tests/test_active_merge_device_matrix.py
+++ b/tests/test_active_merge_device_matrix.py
@@ -14,24 +14,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
-Comprehensive _active_merge_device() dispatch matrix.
+"""_active_merge_device() dispatch matrix.
 
-Drives every supported accelerator combination from a single test host
-by spoofing torch.cuda.is_available, torch.xpu.is_available,
-torch.backends.mps.is_available, and torch.version.hip so we can
-exercise the cascade
-
-    cuda (covers ROCm)  ->  xpu  ->  mps  ->  cpu
-
-deterministically without owning the actual hardware.
-
-This is the regression net for the LoRA merge fix landed in PR #620.
-A future change that hardcodes "cuda", reorders the cascade, or drops
-a backend will fail loudly here.
-
-Add a row to ``PROFILES`` to extend coverage; tests parametrize over
-it automatically. No real hardware required.
+Spoofs torch.cuda/xpu/mps availability and torch.version.hip to exercise the
+cascade `cuda (covers ROCm) -> xpu -> mps -> cpu` without real hardware.
+Regression net for the LoRA merge fix in PR #620. Add a row to ``PROFILES``
+to extend coverage; tests parametrize over it automatically.
 """
 
 from __future__ import annotations
@@ -108,15 +96,9 @@ PROFILE_IDS = [p.name for p in PROFILES]
 
 @pytest.fixture
 def spoof_accelerator(monkeypatch):
-    """Apply an AcceleratorProfile to torch in-process and reset the
-    @lru_cache on _active_merge_device so the next call re-probes.
-
-    Cache hygiene: ``_active_merge_device`` is decorated with
-    ``functools.lru_cache(maxsize=1)`` so its first return is sticky for
-    the rest of the process. The fixture clears the cache before AND
-    after each test so neither this test nor any subsequent test in the
-    session sees a stale "cpu" / "mps" answer baked in by an earlier
-    spoof.
+    """Apply an AcceleratorProfile to torch in-process and clear the
+    lru_cache(maxsize=1) on _active_merge_device before and after each test so
+    no stale "cpu"/"mps" answer leaks across the session.
     """
     from unsloth_zoo.saving_utils import _active_merge_device
 
@@ -165,9 +147,9 @@ def test_active_merge_device_cascade(profile, spoof_accelerator):
 
 
 def test_active_merge_device_takes_no_args(spoof_accelerator):
-    """The helper has no required positional args. The pre-fix signature was
-    _active_merge_device(W) which silently dropped MPS and propagated the
-    foreign device.index across families.
+    """The helper has no required positional args. The pre-fix
+    _active_merge_device(W) silently dropped MPS and propagated the foreign
+    device.index across families.
     """
     from unsloth_zoo.saving_utils import _active_merge_device
     spoof_accelerator(PROFILES[0])
@@ -201,10 +183,8 @@ def test_xpu_takes_priority_over_mps(spoof_accelerator):
 
 
 def test_lru_cache_freezes_first_result(spoof_accelerator):
-    """_active_merge_device() is @functools.lru_cache(maxsize=1). After the
-    first call returns, subsequent calls under different spoofs return
-    the cached value until cache_clear() is invoked. The fixture's
-    cache_clear discipline is what makes the parametrized tests reliable.
+    """_active_merge_device() is lru_cache(maxsize=1): subsequent calls under
+    different spoofs return the cached value until cache_clear() is invoked.
     """
     from unsloth_zoo.saving_utils import _active_merge_device
 

--- a/tests/test_compiler_dynamic_exec.py
+++ b/tests/test_compiler_dynamic_exec.py
@@ -11,20 +11,17 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
-"""End-to-end drift detectors for ``unsloth_zoo/compiler.py``'s DYNAMIC
-CODE CREATION pipeline.
+"""End-to-end drift detectors for ``unsloth_zoo/compiler.py``'s dynamic
+code-creation pipeline.
 
-Companion to ``test_upstream_source_patterns.py`` (which pins the
-upstream patterns BEFORE the rewrite). This file drives each rewriter
-end-to-end against real upstream transformers source and asserts the
-rewritten output ``ast.parse``s, ``compile`` + ``exec``s, and (for
-named-symbol rewrites) the symbol is gone after rewrite.
+Companion to ``test_upstream_source_patterns.py``. Drives each rewriter
+against real transformers source and asserts the output ``ast.parse``s,
+``compile`` + ``exec``s, and (for named-symbol rewrites) the symbol is gone.
+Also drives ``unsloth_compile_transformers(model_type=X)`` per known model
+type and AST-parses the emitted cache.
 
-Also drives ``unsloth_compile_transformers(model_type=X)`` end-to-end
-across every known model type and AST-parses the emitted cache file.
-
-CPU-only; drift -> ``pytest.fail("DRIFT DETECTED: ...")``. Model types
-absent from the installed transformers are skipped (environment).
+CPU-only; drift -> ``pytest.fail("DRIFT DETECTED: ...")``. Model types absent
+from the installed transformers are skipped.
 """
 
 from __future__ import annotations
@@ -38,8 +35,7 @@ import textwrap
 import pytest
 
 
-# Disable torch.compile side effects so we only exercise the SOURCE
-# rewrite + ast.parse pipeline (no GPU / no torch.compile cost).
+# Disable torch.compile so we only exercise the source rewrite + ast.parse.
 os.environ.setdefault("UNSLOTH_COMPILE_DISABLE", "1")
 
 
@@ -47,9 +43,8 @@ transformers = pytest.importorskip("transformers")
 compiler = pytest.importorskip("unsloth_zoo.compiler")
 
 
-# Model types the zoo compiler drives end-to-end; sourced from
-# unsloth_compile_transformers(model_type=...) call sites in unsloth +
-# unsloth_zoo and from test_apply_fused_lm_head's enumerated families.
+# Model types the zoo compiler drives end-to-end (from
+# unsloth_compile_transformers call sites and test_apply_fused_lm_head).
 KNOWN_MODEL_TYPES = [
     "llama",
     "llama4",
@@ -123,9 +118,8 @@ def _assert_parseable(rewritten: str, entry_point: str, *, dedent: bool = False)
 
 
 def _assert_execs(rewritten: str, entry_point: str, *, dedent: bool = False):
-    """compile + exec rewritten in a sandbox; NameError -> DRIFT.
-    ImportError / other runtime errors at top-level are out of scope
-    (env, not drift); only NameError indicates a dangling identifier."""
+    """compile + exec in a sandbox; only NameError (a dangling identifier)
+    is DRIFT. ImportError / other runtime errors are env, not drift."""
     source = textwrap.dedent(rewritten) if dedent else rewritten
     sandbox = {"__name__": "test_compiler_dynamic_exec_sandbox"}
     try:
@@ -150,9 +144,8 @@ def _assert_execs(rewritten: str, entry_point: str, *, dedent: bool = False):
 
 
 # Per-rewriter tests against real transformers source. gemma3 is the
-# canonical driver: moderately-sized and exercises almost every
-# rewriter path (RMSNorm, sliding-window attn, RoPE, MoE-shaped
-# routing, multi-modal projector, ForConditionalGeneration head).
+# canonical driver: it exercises almost every rewriter path (RMSNorm,
+# sliding-window attn, RoPE, MoE routing, projector, ForConditionalGeneration).
 
 
 @pytest.fixture(scope="module")
@@ -405,8 +398,7 @@ def test_patch_gradient_accumulation_for_conditional_gen(gemma3_mod):
     )
 
 
-# Rewriter passthrough robustness on shapes the rewriter is NOT meant
-# to touch (guards against accidental corruption of unrelated source).
+# Passthrough robustness on shapes the rewriter must not touch.
 
 
 PASSTHROUGH_SOURCE = (
@@ -459,7 +451,7 @@ def test_two_arg_rewriter_passthrough_on_plain_python(name_args):
     _assert_parseable(out, f"{name}(plain-python)")
 
 
-# Targeted symbol-removal asserts (the rewrite must LAND, not silently no-op).
+# Targeted symbol-removal asserts: the rewrite must land, not silently no-op.
 
 
 def test_higher_precision_softmax_inserts_float32_cast():
@@ -521,11 +513,10 @@ def test_replace_with_grouped_query_attention_inserts_enable_gqa():
     )
 
 
-# End-to-end: unsloth_compile_transformers(model_type=X). Master entry
-# point chaining every rewriter; emits combined module to
-# unsloth_compiled_cache/. Drive for every known model type, AST-parse
-# the cache file. Cache name: unsloth_compiled_module_<type>.py (see
-# ``unsloth_zoo/compiler.py:66-67`` COMBINED_UNSLOTH_NAME).
+# End-to-end: unsloth_compile_transformers(model_type=X) chains every
+# rewriter and emits unsloth_compiled_module_<type>.py to
+# unsloth_compiled_cache/ (see ``unsloth_zoo/compiler.py:66-67``
+# COMBINED_UNSLOTH_NAME). Drive per known model type, AST-parse the cache.
 
 
 def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
@@ -562,9 +553,8 @@ def _compile_and_get_cache(model_type: str, monkeypatch) -> str:
 def test_unsloth_compile_transformers_emits_parseable_cache(
     model_type, monkeypatch,
 ):
-    """End-to-end pipeline drive per model_type + AST-parse the emitted
-    combined cache. Master pipeline exec()'s rewritten transformers
-    source; any rewriter producing invalid Python surfaces here."""
+    """Drive the pipeline per model_type + AST-parse the combined cache; any
+    rewriter producing invalid Python surfaces here."""
     cache_path = _compile_and_get_cache(model_type, monkeypatch)
 
     if not os.path.isfile(cache_path):
@@ -597,10 +587,9 @@ def test_unsloth_compile_transformers_emits_parseable_cache(
 
 
 def test_smoke_unsloth_compile_transformers_gemma3(monkeypatch):
-    """Spec smoke: ``unsloth_compile_transformers("gemma3", ...)`` returns
-    valid Python on the installed transformers. Real zoo signature (see
-    ``unsloth_zoo/compiler.py:3116-3143``) doesn't accept
-    trust_remote_code/fast_inference; pass what it does accept."""
+    """Smoke: ``unsloth_compile_transformers("gemma3", ...)`` returns valid
+    Python. The real signature (``unsloth_zoo/compiler.py:3116-3143``)
+    rejects trust_remote_code/fast_inference; pass only what it accepts."""
     monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
     monkeypatch.setenv("UNSLOTH_COMPILE_OVERWRITE", "1")
     _load_modeling("gemma3")
@@ -646,9 +635,8 @@ def test_smoke_unsloth_compile_transformers_unknown_model_type(monkeypatch):
     )
 
 
-# AST validity of CONSTANT source blocks pasted inside compiler.py.
-# These are exec()'d verbatim by ``create_new_function`` (see
-# ``unsloth_zoo/compiler.py:801-1126``).
+# AST validity of constant source blocks in compiler.py, exec()'d verbatim
+# by ``create_new_function`` (see ``unsloth_zoo/compiler.py:801-1126``).
 
 
 @pytest.mark.parametrize(
@@ -663,9 +651,8 @@ def test_smoke_unsloth_compile_transformers_unknown_model_type(monkeypatch):
     ],
 )
 def test_compiler_constant_source_blocks_parse(const_name):
-    """Each constant is a Python source block embedded in
-    ``unsloth_zoo/compiler.py`` and exec()'d as-is. Must be valid Python
-    (after documented placeholder substitution where applicable)."""
+    """Each constant is a source block exec()'d as-is by compiler.py; must be
+    valid Python (after placeholder substitution where applicable)."""
     block = getattr(compiler, const_name, None)
     if block is None:
         pytest.skip(f"{const_name} not present (renamed?)")

--- a/tests/test_compiler_rewriter_exhaustive.py
+++ b/tests/test_compiler_rewriter_exhaustive.py
@@ -11,18 +11,9 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
-"""Exhaustive drift detectors for the ``unsloth_zoo`` / ``unsloth``
-source-string and regex rewriters (round 3 of coverage).
-
-Pins sites in compiler.py, temporary_patches/*.py, patching_utils.py,
-saving_utils.py, rl_replacements.py, training_utils.py, unsloth/trainer.py,
-unsloth/models/rl.py that aren't already pinned by
-test_upstream_source_patterns.py.
-
-Each test cites its rewriter file:line. Missing pinned string / regex ->
-``pytest.fail("DRIFT DETECTED: zoo/unsloth source-rewriter at <file:line>
-expects '<pattern>' in <upstream module>, found 0 matches")``. CPU-only.
-"""
+"""Drift detectors for zoo/unsloth source-string and regex rewriters not
+covered by test_upstream_source_patterns.py. Each test cites its rewriter
+file:line and fails with a DRIFT DETECTED message. CPU-only."""
 
 from __future__ import annotations
 
@@ -42,8 +33,7 @@ except Exception:
 
 
 def _skip_if_transformers_5x(reason: str) -> None:
-    """Skip when transformers 5.x removed the anchor the rewriter
-    probe pins. Keep the detector strict on 4.57.6."""
+    """Skip on transformers 5.x; keep the detector strict on 4.57.6."""
     if _TX_IS_5X:
         pytest.skip(
             f"transformers {_TX_VERSION}: {reason} (zoo rewriter silently "
@@ -55,7 +45,7 @@ def _skip_if_transformers_5x(reason: str) -> None:
 
 def _drift(zoo_site: str, pattern: str, upstream_path: str,
            extra: str = "") -> None:
-    """``pytest.fail`` with the standardized DRIFT message."""
+    """pytest.fail with the standardized DRIFT message."""
     msg = (
         f"DRIFT DETECTED: zoo/unsloth source-rewriter at {zoo_site} expects "
         f"{pattern!r} in {upstream_path}, found 0 matches."
@@ -99,9 +89,8 @@ def _probe_modules(candidates, predicate):
 
 
 def test_compiler_higher_precision_softmax_idempotency_lookahead():
-    """``unsloth_zoo/compiler.py:391-405`` higher_precision_softmax negative
-    lookahead skips already-rewritten softmax. Pins the upstream
-    ``softmax(..., dim=N)`` keyword form so the finder isn't dormant."""
+    """compiler.py:391-405 higher_precision_softmax: pin the upstream
+    ``softmax(..., dim=N)`` form so the float32 upcast finder isn't dormant."""
     pytest.importorskip("transformers")
     pattern = re.compile(
         r"(?:nn\.functional\.softmax|F\.softmax)"
@@ -127,9 +116,8 @@ def test_compiler_higher_precision_softmax_idempotency_lookahead():
 
 
 def test_compiler_fix_rotary_embedding_cos_to_dtype_pattern():
-    """``unsloth_zoo/compiler.py:510-517`` fix_rotary_embedding_dtype
-    replaces ``cos.to(dtype=x.dtype)`` / ``sin.to(dtype=x.dtype)``;
-    UNSLOTH_FORCE_CUSTOM_DTYPE-gated. Pin: some rotary cast site exists."""
+    """compiler.py:510-517 fix_rotary_embedding_dtype (UNSLOTH_FORCE_CUSTOM_DTYPE
+    -gated): pin that some rotary cos/sin cast site exists."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.models.llama.modeling_llama",
@@ -162,8 +150,8 @@ def test_compiler_fix_rotary_embedding_cos_to_dtype_pattern():
 
 
 def test_compiler_higher_precision_layernorms_norm_class_marker():
-    """``unsloth_zoo/compiler.py:560-597`` higher_precision_layernorms
-    locates ``class <X>Norm(nn.Module):`` blocks; without one,
+    """compiler.py:560-597 higher_precision_layernorms locates
+    ``class <X>Norm(nn.Module):`` blocks; without one,
     UNSLOTH_HIGH_PRECISION_LAYERNORM is never auto-toggled."""
     pytest.importorskip("transformers")
     pattern = re.compile(
@@ -214,9 +202,9 @@ def test_compiler_embedding_oob_clamp_input_ids_pattern():
 
 
 def test_compiler_apply_mask_attention_mask_kwargs_pinned_pattern():
-    """``unsloth_zoo/compiler.py:2128-2140`` apply_mask_attention_mask_out
-    needs ``attention_mask=attention_mask,`` AND ``labels=labels,`` together
-    in a ForConditionalGeneration forward."""
+    """compiler.py:2128-2140 apply_mask_attention_mask_out needs
+    ``attention_mask=attention_mask,`` AND ``labels=labels,`` together in
+    a ForConditionalGeneration forward."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.models.llava.modeling_llava",
@@ -358,10 +346,9 @@ def test_compiler_strip_kw_for_loop_pattern_targetable():
 
 
 def test_compiler_dtype_mismatch_finfo_attention_mask_pinned():
-    """``unsloth_zoo/compiler.py:2381-2391`` patch_finfo_attention_mask_dtype_mismatch
-    pins pre-4.50 ``<X> = <X>/torch.finfo(<X>.dtype).min`` followed by
-    ``<X> = (1.0 - <X>).int()``. Forward-looking: only DRIFT when the
-    underlying primitives are also gone."""
+    """compiler.py:2381-2391 patch_finfo_attention_mask_dtype_mismatch pins
+    pre-4.50 ``<X> = <X>/torch.finfo(<X>.dtype).min`` then
+    ``<X> = (1.0 - <X>).int()``; DRIFT only when the primitives are also gone."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.modeling_attn_mask_utils",
@@ -390,8 +377,8 @@ def test_compiler_dtype_mismatch_finfo_attention_mask_pinned():
 
 
 def test_compiler_lora_forward_result_clone_pinned_string():
-    """``unsloth_zoo/compiler.py:2539`` replaces ``result = result.clone()``
-    in peft's LoRA forward (defeats in-place ops)."""
+    """compiler.py:2539 replaces ``result = result.clone()`` in peft's LoRA
+    forward (defeats in-place ops)."""
     pytest.importorskip("peft")
     try:
         from peft.tuners.lora.layer import Linear as LoraLinear
@@ -450,11 +437,8 @@ def test_compiler_lora_def_forward_rename_pinned_string():
 
 
 def test_compiler_lora_x_cast_dtype_pinned_strings():
-    """``unsloth_zoo/compiler.py:2578-2581,2596`` pins three peft LoRA
-    targets: ``x = x.to(lora_A.weight.dtype)`` / ``x =
-    self._cast_input_dtype(x, lora_A.weight.dtype)`` /
-    ``self._check_forward_args(x, *args, **kwargs)``. DRIFT only when
-    ALL THREE are gone."""
+    """compiler.py:2578-2581,2596 pins three peft LoRA targets (x dtype cast,
+    _cast_input_dtype, _check_forward_args); DRIFT only when ALL THREE are gone."""
     pytest.importorskip("peft")
     try:
         from peft.tuners.lora.layer import Linear as LoraLinear
@@ -480,9 +464,8 @@ def test_compiler_lora_x_cast_dtype_pinned_strings():
 
 
 def test_compiler_variant_kwarg_keys_pinned_token():
-    """``unsloth_zoo/compiler.py:2649-2655`` peft >= 0.18.0
-    ``VARIANT_KWARG_KEYS`` at the layer module level; the FIND must
-    succeed for the fallback to fire."""
+    """compiler.py:2649-2655 peft >= 0.18.0 ``VARIANT_KWARG_KEYS`` at the layer
+    module level; the FIND must succeed for the fallback to fire."""
     pytest.importorskip("peft")
     try:
         import peft.tuners.lora.layer as ly
@@ -498,9 +481,9 @@ def test_compiler_variant_kwarg_keys_pinned_token():
 
 
 def test_compiler_patch_residual_stream_residual_plus_hidden_states_pattern():
-    """``unsloth_zoo/compiler.py:2698-2705`` second patch_residual_stream
-    regex matches ``<h> = residual + (<h> * <expr>|<expr> * <h>)``
-    (addcmul / fused-add target on VLM cross-attention encoders)."""
+    """compiler.py:2698-2705 second patch_residual_stream regex matches
+    ``<h> = residual + (<h> * <expr>|<expr> * <h>)`` (addcmul / fused-add
+    target on VLM cross-attention encoders)."""
     pytest.importorskip("transformers")
     pattern = re.compile(
         r"(hidden_state(?:s)?) = residual \+ "
@@ -781,10 +764,9 @@ def test_compiler_conv_forward_def_first_param_pattern():
 
 
 def test_patching_utils_compiled_autograd_end_capture_return_compiled_fn_pinned():
-    """``unsloth_zoo/patching_utils.py:544-547`` wraps
-    ``AutogradCompilerInstance.end_capture``'s ``return compiled_fn(...)``
-    in ``with disable():`` (PR #135795 double-compile fix). Signature
-    drift silently no-ops the rewriter."""
+    """patching_utils.py:544-547 wraps AutogradCompilerInstance.end_capture's
+    ``return compiled_fn(...)`` in ``with disable():`` (PR #135795
+    double-compile fix). Signature drift silently no-ops the rewriter."""
     pytest.importorskip("torch")
     try:
         import torch._dynamo.compiled_autograd as ca
@@ -817,18 +799,15 @@ def test_patching_utils_compiled_autograd_end_capture_return_compiled_fn_pinned(
         return
     needle = "return compiled_fn(inputs, sizes, scalars, hooks)"
     pattern = re.compile(r"\n([ ]{1,})return compiled_fn")
-    # Contract: pass if exact str+regex present (rewriter works), or
-    # `with disable()` / `with _disable()` already in src (torch 2.7+
-    # native fix). torch 2.7+ end_capture signature drifted (added
-    # packed_inputs, nested with-block); rewriter no-ops cleanly.
+    # Pass if exact str+regex present (rewriter works), or `with disable()`
+    # / `with _disable()` already in src (torch 2.7+ native fix).
     if needle in src and pattern.search(src) is not None:
         return
     if "with disable()" in src or "with _disable()" in src:
         return
     if "compiled_fn(" in src:
-        # BENIGN on torch 2.7+: upstream fixed PR #135795 natively with
-        # ``with _disable()``; zoo's patch_compiled_autograd recognises
-        # both forms and no-ops cleanly.
+        # BENIGN on torch 2.7+: upstream fixed PR #135795 natively; zoo
+        # recognises both forms and no-ops cleanly.
         pytest.skip(
             "BENIGN: torch 2.7+ fixed PR #135795-style double-compile "
             "upstream natively (now wraps compiled_fn in `with _disable()`); "
@@ -868,9 +847,8 @@ def test_patching_utils_compiled_autograd_end_capture_rename_target():
 
 
 def test_patching_utils_autograd_engine_call_method_compiled_autograd_enabled_pinned():
-    """``unsloth_zoo/patching_utils.py:564-573`` replaces
-    ``compiled_autograd_enabled`` -> ``in_compiled_autograd_region`` in
-    ``AutogradEngineVariable.call_method``."""
+    """patching_utils.py:564-573 replaces ``compiled_autograd_enabled`` ->
+    ``in_compiled_autograd_region`` in AutogradEngineVariable.call_method."""
     pytest.importorskip("torch")
     try:
         import torch._dynamo.variables.misc as misc
@@ -909,11 +887,10 @@ def test_patching_utils_autograd_engine_call_method_rename_target():
 
 
 def test_patching_utils_replace_with_bnb_linear_skip_modules_pinned():
-    """``unsloth_zoo/patching_utils.py:695-699`` replaces
-    ``name in quantization_config.llm_int8_skip_modules\\n`` on
-    ``bnb._replace_with_bnb_linear`` (dynamic-4bit conversion).
-    Resolves UPSTREAM source via inspect.getsourcefile because zoo has
-    already rebound the function by test time."""
+    """patching_utils.py:695-699 replaces ``name in
+    quantization_config.llm_int8_skip_modules\\n`` on
+    ``bnb._replace_with_bnb_linear`` (dynamic-4bit conversion). Resolves
+    UPSTREAM source via inspect.getsourcefile (zoo has already rebound it)."""
     pytest.importorskip("transformers")
     try:
         import transformers.integrations.bitsandbytes as bnb
@@ -926,9 +903,8 @@ def test_patching_utils_replace_with_bnb_linear_skip_modules_pinned():
         )
         return
 
-    # Resolve upstream source directly from the module file (zoo rebinds
-    # bnb._replace_with_bnb_linear so inspect.getsource off the live
-    # function returns the patched body, never upstream).
+    # Read upstream source from the module file: zoo rebinds the live
+    # function, so inspect.getsource off it returns the patched body.
     live = bnb._replace_with_bnb_linear
     is_zoo_patched = (
         getattr(live, "__name__", "") == "_unsloth_replace_with_bnb_linear"
@@ -1041,7 +1017,7 @@ def test_patching_utils_current_key_name_str_marker():
 
 
 def test_patching_utils_replace_with_bnb_linear_ast_wrap_target():
-    """``unsloth_zoo/patching_utils.py:701-704`` AST-wraps recursive
+    """patching_utils.py:701-704 AST-wraps recursive
     ``= _replace_with_bnb_linear(...)`` calls in try/finally with
     parent-class marking."""
     pytest.importorskip("transformers")
@@ -1056,8 +1032,7 @@ def test_patching_utils_replace_with_bnb_linear_ast_wrap_target():
         src = inspect.getsource(bnb._replace_with_bnb_linear)
     except (OSError, TypeError):
         pytest.skip("Source unavailable")
-    # The recursive call is the AST anchor. Match patterns like:
-    # ``_, has_been_replaced = _replace_with_bnb_linear(...)``
+    # The recursive call is the AST anchor.
     pattern = re.compile(r"=\s*_replace_with_bnb_linear\s*\(")
     if pattern.search(src) is None:
         _drift(
@@ -1074,9 +1049,9 @@ def test_patching_utils_replace_with_bnb_linear_ast_wrap_target():
 
 
 def test_saving_utils_save_pretrained_state_dict_split_pinned_string():
-    """``unsloth_zoo/saving_utils.py:2675-2677`` hard-fails (RuntimeError)
-    when ``state_dict_split = split_torch_state_dict_into_shards`` is
-    missing from PreTrainedModel.save_pretrained."""
+    """saving_utils.py:2675-2677 hard-fails (RuntimeError) when
+    ``state_dict_split = split_torch_state_dict_into_shards`` is missing
+    from PreTrainedModel.save_pretrained."""
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
     try:
@@ -1095,17 +1070,10 @@ def test_saving_utils_save_pretrained_state_dict_split_pinned_string():
 
 
 def test_saving_utils_save_pretrained_state_dict_contiguous_pinned_string():
-    """``unsloth_zoo/saving_utils.py:2680-2686`` requires
-    ``state_dict[tensor].contiguous()`` in upstream + replace to
-    ``merge_lora_weights(...)``; RuntimeError otherwise.
-
-    transformers 5.x rewrote PreTrainedModel.save_pretrained (sharding /
-    state-dict iteration moved). zoo's saving_utils.py upfront-anchor
-    check (``_required_anchors``) detects the missing string and falls
-    back to vanilla ``model.save_pretrained`` with a warning. The
-    detector becomes a positive-assertion on 5.x: confirm the anchor is
-    gone AND zoo's _required_anchors list flags it AND the warning path
-    fires gracefully (no RuntimeError).
+    """saving_utils.py:2680-2686 requires ``state_dict[tensor].contiguous()``
+    + replace to ``merge_lora_weights(...)``; RuntimeError otherwise. On 5.x
+    the anchor moved: assert it's gone AND zoo's _required_anchors flags it so
+    the graceful vanilla-save fallback fires instead of RuntimeError.
     """
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
@@ -1120,8 +1088,7 @@ def test_saving_utils_save_pretrained_state_dict_contiguous_pinned_string():
             "on 5.x but is present; refresh the zoo prod-fix anchor "
             "list at saving_utils.py:_required_anchors"
         )
-        # Positive assertion: zoo's prod-fix correctly identifies the
-        # missing anchor in its preflight check.
+        # Assert zoo's preflight check includes the now-missing anchor.
         import unsloth_zoo.saving_utils as zsu
         zsu_src = inspect.getsource(zsu.merge_and_dequantize_lora)
         assert needle in zsu_src, (
@@ -1143,8 +1110,8 @@ def test_saving_utils_save_pretrained_state_dict_contiguous_pinned_string():
 
 
 def test_saving_utils_save_pretrained_def_marker():
-    """``unsloth_zoo/saving_utils.py:2688-2694`` renames
-    ``save_pretrained`` -> ``save_pretrained_dequantized``."""
+    """saving_utils.py:2688-2694 renames ``save_pretrained`` ->
+    ``save_pretrained_dequantized``."""
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
     try:
@@ -1160,9 +1127,8 @@ def test_saving_utils_save_pretrained_def_marker():
 
 
 def test_saving_utils_incremental_save_os_makedirs_pinned_regex():
-    """``unsloth_zoo/saving_utils.py:2517`` re.search
-    ``os.makedirs(save_directory...)`` in save_pretrained; absent ->
-    incremental_save_pretrained aborts push-to-hub path."""
+    """saving_utils.py:2517 re.search ``os.makedirs(save_directory...)`` in
+    save_pretrained; absent -> incremental_save_pretrained aborts push-to-hub."""
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
     try:
@@ -1181,16 +1147,10 @@ def test_saving_utils_incremental_save_os_makedirs_pinned_regex():
 
 
 def test_saving_utils_incremental_save_for_loop_filename_to_tensors_pinned():
-    """``unsloth_zoo/saving_utils.py:2526-2533`` requires
-    ``for shard_file, tensors in filename_to_tensors`` in
-    save_pretrained; RuntimeError otherwise.
-
-    transformers 5.x renamed the iterator. zoo's prod fix in
-    ``merge_and_dequantize_lora`` runs an upfront anchor check that
-    includes this string and falls back to vanilla
-    ``model.save_pretrained`` (with a warning) when push_to_hub=True
-    and the anchor is missing. On 5.x: assert the anchor is gone AND
-    zoo's preflight check covers it.
+    """saving_utils.py:2526-2533 requires
+    ``for shard_file, tensors in filename_to_tensors`` in save_pretrained;
+    RuntimeError otherwise. On 5.x (renamed iterator): assert the anchor is
+    gone AND zoo's preflight check covers it so push-to-hub falls back cleanly.
     """
     pytest.importorskip("transformers")
     import transformers.modeling_utils as mu
@@ -1224,9 +1184,8 @@ def test_saving_utils_incremental_save_for_loop_filename_to_tensors_pinned():
 
 
 def test_saving_utils_config_json_dtype_torch_dtype_rename_targets():
-    """``unsloth_zoo/saving_utils.py:1827-1828`` save-time replaces
-    ``"dtype"`` -> ``"torch_dtype"`` in config.json; needs model
-    config.to_dict() to expose either field."""
+    """saving_utils.py:1827-1828 save-time replaces ``"dtype"`` ->
+    ``"torch_dtype"`` in config.json; needs config.to_dict() to expose either."""
     pytest.importorskip("transformers")
     try:
         from transformers import LlamaConfig
@@ -1245,10 +1204,9 @@ def test_saving_utils_config_json_dtype_torch_dtype_rename_targets():
 
 
 def test_saving_utils_lora_key_normalize_replacements_targetable():
-    """``unsloth_zoo/saving_utils.py:309-314`` five str.replace on LoRA
-    keys (.base_layer, .modules_to_save.default, .original_module,
-    .lora_A.default, .lora_B.default). Pin peft's ``base_layer`` /
-    ``lora_A.default`` naming."""
+    """saving_utils.py:309-314 five str.replace on LoRA keys (.base_layer,
+    .modules_to_save.default, .original_module, .lora_A/B.default). Pin peft's
+    ``base_layer`` / ``lora_A.default`` naming."""
     pytest.importorskip("peft")
     try:
         import peft.tuners.lora.layer as ly
@@ -1267,9 +1225,8 @@ def test_saving_utils_lora_key_normalize_replacements_targetable():
 
 
 def test_saving_utils_moe_experts_gate_up_proj_regex_targetable():
-    """``unsloth_zoo/saving_utils.py:600,653,700`` rebuilds fused
-    gate_up_proj from per-expert shards via three re.match on
-    ``mlp.experts.<i>.<proj>.weight``."""
+    """saving_utils.py:600,653,700 rebuilds fused gate_up_proj from per-expert
+    shards via three re.match on ``mlp.experts.<i>.<proj>.weight``."""
     pytest.importorskip("transformers")
     candidates = [
         "transformers.models.mixtral.modeling_mixtral",
@@ -1299,8 +1256,8 @@ def test_saving_utils_moe_experts_gate_up_proj_regex_targetable():
 
 
 def test_saving_utils_hf_sharded_safetensors_regex_pattern():
-    """``unsloth_zoo/saving_utils.py:1838`` sharded-safetensors regex
-    must match canonical HF format ``<prefix>-<shard>-of-<total>.safetensors``."""
+    """saving_utils.py:1838 sharded-safetensors regex must match canonical HF
+    format ``<prefix>-<shard>-of-<total>.safetensors``."""
     pattern = re.compile(r"^(.+?)-(\d+)-of-(\d+)\.safetensors$")
     if pattern.match("model-00001-of-00005.safetensors") is None:
         _drift(
@@ -1313,9 +1270,8 @@ def test_saving_utils_hf_sharded_safetensors_regex_pattern():
 
 
 def test_saving_utils_lora_reverse_mapping_replacement_regex():
-    """``unsloth_zoo/saving_utils.py:2923`` re.sub regex must preserve a
-    typical mapping value like ``"model.language_model."`` (no leading
-    caret, no parens, no ?)."""
+    """saving_utils.py:2923 re.sub regex must preserve a typical mapping value
+    like ``"model.language_model."`` (no leading caret, no parens, no ?)."""
     sample = "model.language_model."
     out = re.sub(r"\^?([^(?]+).*", r"\1", sample.lstrip("^"))
     if out != sample:
@@ -1333,9 +1289,8 @@ def test_saving_utils_lora_reverse_mapping_replacement_regex():
 
 
 def test_training_utils_name_replace_base_model_pattern():
-    """``unsloth_zoo/training_utils.py:172-190`` builds exec-able
-    accessor from PEFT module names: replace base_model -> model,
-    .<i>. -> [<i>]., strip .weight."""
+    """training_utils.py:172-190 builds exec-able accessor from PEFT module
+    names: base_model -> model, .<i>. -> [<i>]., strip .weight."""
     pytest.importorskip("peft")
     sample = "base_model.model.model.layers.0.self_attn.q_proj.weight"
     out = sample.replace("base_model", "model", 1)
@@ -1356,9 +1311,8 @@ def test_training_utils_name_replace_base_model_pattern():
 
 
 def test_misc_merge_quantization_configs_classmethod_marker():
-    """``unsloth_zoo/temporary_patches/misc.py:141`` strips cls when
-    upstream ``AutoHfQuantizer.merge_quantization_configs`` is a
-    classmethod."""
+    """misc.py:141 strips cls when upstream
+    ``AutoHfQuantizer.merge_quantization_configs`` is a classmethod."""
     pytest.importorskip("transformers")
     try:
         from transformers.quantizers.auto import AutoHfQuantizer
@@ -1369,7 +1323,7 @@ def test_misc_merge_quantization_configs_classmethod_marker():
     except (OSError, TypeError):
         pytest.skip("source unavailable")
     if "@classmethod" not in src.lstrip().splitlines()[0] and "classmethod" not in src[:200]:
-        # Drift only if neither cls nor self in def line (exec binding broken).
+        # Drift only if neither cls nor self in the def line.
         first_def = next(
             (line for line in src.splitlines() if "def " in line),
             "",
@@ -1384,8 +1338,8 @@ def test_misc_merge_quantization_configs_classmethod_marker():
 
 
 def test_misc_merge_quantization_configs_dedent_def_marker():
-    """``unsloth_zoo/temporary_patches/misc.py:142`` requires ``def `` in
-    the source (``source = source[source.find("def"):]``)."""
+    """misc.py:142 requires ``def `` in the source
+    (``source = source[source.find("def"):]``)."""
     pytest.importorskip("transformers")
     try:
         from transformers.quantizers.auto import AutoHfQuantizer
@@ -1404,9 +1358,8 @@ def test_misc_merge_quantization_configs_dedent_def_marker():
 
 
 def test_misc_mamba_ssm_tl_dot_finder_regex_targetable():
-    """``unsloth_zoo/temporary_patches/misc.py:1082-1085``
-    fix_mamba_ssm_float32 finds ``tl.dot(`` in mamba_ssm Triton
-    chunk-scan source."""
+    """misc.py:1082-1085 fix_mamba_ssm_float32 finds ``tl.dot(`` in mamba_ssm
+    Triton chunk-scan source."""
     try:
         import mamba_ssm.ops.triton.ssd_chunk_scan as ssd
     except ImportError:
@@ -1431,16 +1384,10 @@ def test_misc_mamba_ssm_tl_dot_finder_regex_targetable():
 
 
 def test_gpt_oss_config_old_class_dedent_compare_marker():
-    """``unsloth_zoo/temporary_patches/gpt_oss.py:2808-2810``
-    line-by-line equality compare of dedented GptOssConfig vs OLD
-    class; pin ``initial_context_length`` / ``rope_scaling`` field
-    presence (the Old_GptOssConfig regression target).
-
-    transformers 5.x replaced ``rope_theta`` / ``rope_scaling`` /
-    ``initial_context_length`` with the ``rope_parameters`` dict. zoo's
-    ``patch_gpt_oss_config`` gates on
-    ``inspect.getsource(GptOssConfig) == Old_GptOssConfig``, so the
-    patch silently no-ops on the new shape -- skip the detector on 5.x.
+    """gpt_oss.py:2808-2810 line-by-line equality compare of dedented
+    GptOssConfig vs OLD class; pin ``initial_context_length`` /
+    ``rope_scaling`` field presence (the Old_GptOssConfig regression target).
+    Skipped on 5.x where these moved into the rope_parameters dict.
     """
     _skip_if_transformers_5x(
         "GptOssConfig replaced rope_theta/rope_scaling/initial_context_length "
@@ -1470,9 +1417,8 @@ def test_gpt_oss_config_old_class_dedent_compare_marker():
 
 
 def test_rl_replacements_grpo_compute_loss_def_marker():
-    """``unsloth_zoo/rl_replacements.py:560-565`` renames
-    ``def grpo_compute_loss`` -> ``def grpo_compute_loss_slow``
-    (slow-fallback RL_REPLACEMENTS variant)."""
+    """rl_replacements.py:560-565 renames ``def grpo_compute_loss`` ->
+    ``def grpo_compute_loss_slow`` (slow-fallback RL_REPLACEMENTS variant)."""
     try:
         from unsloth_zoo.rl_replacements import grpo_compute_loss
     except ImportError:
@@ -1502,9 +1448,8 @@ def test_rl_replacements_grpo_compute_loss_def_marker():
 
 
 def test_unsloth_rl_trainer_signature_columns_pinned_string():
-    """``unsloth/models/rl.py:1667-1670`` augments SFTTrainer
-    ``self._signature_columns`` with ``"labels"``. DRIFT when
-    ``_signature_columns`` is gone from SFTTrainer source."""
+    """rl.py:1667-1670 augments SFTTrainer ``self._signature_columns`` with
+    ``"labels"``. DRIFT when ``_signature_columns`` is gone."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1526,9 +1471,9 @@ def test_unsloth_rl_trainer_signature_columns_pinned_string():
 
 
 def test_unsloth_rl_trainer_vlm_signature_columns_old_form_pinned():
-    """``unsloth/models/rl.py:1706-1713`` pins TRL 0.22.x VLM form
-    ``["messages", "prompt", "completion", "images"]``. DRIFT only when
-    ALL four member tokens are gone from SFTTrainer."""
+    """rl.py:1706-1713 pins TRL 0.22.x VLM form
+    ``["messages", "prompt", "completion", "images"]``. DRIFT only when ALL
+    four member tokens are gone from SFTTrainer."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1550,9 +1495,8 @@ def test_unsloth_rl_trainer_vlm_signature_columns_old_form_pinned():
 
 
 def test_unsloth_rl_trainer_prepare_dataset_pattern():
-    """``unsloth/models/rl.py:1717-1721`` injects
-    ``self._unsloth_model_ref = model`` before SFTTrainer's
-    ``self._prepare_dataset(`` call (token_type_ids detection)."""
+    """rl.py:1717-1721 injects ``self._unsloth_model_ref = model`` before
+    SFTTrainer's ``self._prepare_dataset(`` call (token_type_ids detection)."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1574,7 +1518,7 @@ def test_unsloth_rl_trainer_prepare_dataset_pattern():
 
 
 def test_unsloth_rl_trainer_is_loaded_in_4bit_pinned_string():
-    """``unsloth/models/rl.py:1662-1665`` replaces TRL's
+    """rl.py:1662-1665 replaces TRL's
     ``if getattr(model, "is_loaded_in_4bit"/"is_loaded_in_8bit", ...)``
     bf16 cast block with ``if False:``."""
     pytest.importorskip("trl")
@@ -1608,9 +1552,8 @@ def test_unsloth_rl_trainer_is_loaded_in_4bit_pinned_string():
 
 
 def test_unsloth_rl_trainer_peft_config_branches_pinned():
-    """``unsloth/models/rl.py:1842-1857`` six peft_config str.replace
-    targets (peft_config branches, get_peft_model, prepare_peft_model);
-    DRIFT only when ``peft_config`` is gone from every TRL trainer."""
+    """rl.py:1842-1857 six peft_config str.replace targets; DRIFT only when
+    ``peft_config`` is gone from every TRL trainer."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -1644,8 +1587,8 @@ def test_unsloth_rl_trainer_peft_config_branches_pinned():
 
 
 def test_unsloth_rl_init_comments_with_brackets_pattern():
-    """``unsloth/models/rl.py:1832-1833`` normalises bracketed
-    ``#...(...)`` comments to ``[...]`` in SFTTrainer __init__."""
+    """rl.py:1832-1833 normalises bracketed ``#...(...)`` comments to
+    ``[...]`` in SFTTrainer __init__."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1664,9 +1607,8 @@ def test_unsloth_rl_init_comments_with_brackets_pattern():
 
 
 def test_unsloth_rl_init_use_vllm_marker():
-    """``unsloth/models/rl.py:1895-1928`` vLLM-engine wiring needs
-    ``args.use_vllm`` / ``self.use_vllm`` marker in some TRL RL
-    trainer __init__."""
+    """rl.py:1895-1928 vLLM-engine wiring needs ``args.use_vllm`` /
+    ``self.use_vllm`` marker in some TRL RL trainer __init__."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -1696,7 +1638,7 @@ def test_unsloth_rl_init_use_vllm_marker():
 
 
 def test_unsloth_rl_vllm_part_findall_pattern_targetable():
-    """``unsloth/models/rl.py:1932-1936`` matches 8-space-indented
+    """rl.py:1932-1936 matches 8-space-indented
     ``if (self|args).use_vllm:\\n...else:\\n`` branch in TRL trainer."""
     pytest.importorskip("trl")
     import importlib
@@ -1731,9 +1673,8 @@ def test_unsloth_rl_vllm_part_findall_pattern_targetable():
 
 
 def test_unsloth_rl_sampling_params_findall_pattern_targetable():
-    """``unsloth/models/rl.py:1949-1953`` patches
-    ``self.X = SamplingParams(...)`` in TRL trainer; pin
-    ``SamplingParams(`` presence."""
+    """rl.py:1949-1953 patches ``self.X = SamplingParams(...)`` in TRL trainer;
+    pin ``SamplingParams(`` presence."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -1762,8 +1703,7 @@ def test_unsloth_rl_sampling_params_findall_pattern_targetable():
 
 
 def test_unsloth_rl_state_dict_strip_pattern():
-    """``unsloth/models/rl.py:2072-2076`` strips ``.state_dict()`` from
-    TRL function source via re.sub."""
+    """rl.py:2072-2076 strips ``.state_dict()`` from TRL source via re.sub."""
     pytest.importorskip("trl")
     sample = (
         "    llm_model.load_weights(model.state_dict().items())\n"
@@ -1780,9 +1720,8 @@ def test_unsloth_rl_state_dict_strip_pattern():
 
 
 def test_unsloth_rl_llm_generate_chat_capture_pattern():
-    """``unsloth/models/rl.py:2087-2093`` injects ``lora_request =
-    self.model.load_lora(...)`` into ``self.llm.(generate|chat)(...)``
-    calls."""
+    """rl.py:2087-2093 injects ``lora_request = self.model.load_lora(...)``
+    into ``self.llm.(generate|chat)(...)`` calls."""
     sample = "self.llm.generate(prompts, sampling_params=sp)"
     rewritten = re.sub(
         r"(self\.llm\.(?:generate|chat)\([^\)]{1,})\)",
@@ -1800,8 +1739,7 @@ def test_unsloth_rl_llm_generate_chat_capture_pattern():
 
 
 def test_unsloth_rl_sampling_params_kwargs_replace_pinned():
-    """``unsloth/models/rl.py:2107-2115`` replaces
-    ``SamplingParams(**generation_kwargs)`` with
+    """rl.py:2107-2115 replaces ``SamplingParams(**generation_kwargs)`` with
     ``SamplingParams(**grpo_update_SamplingParams(...))``."""
     pytest.importorskip("trl")
     import importlib
@@ -1833,8 +1771,8 @@ def test_unsloth_rl_sampling_params_kwargs_replace_pinned():
 
 
 def test_unsloth_rl_class_rename_pinned():
-    """``unsloth/models/rl.py:2137-2139`` renames ``class SFTTrainer``
-    -> ``class _UnslothSFTTrainer``."""
+    """rl.py:2137-2139 renames ``class SFTTrainer`` -> ``class
+    _UnslothSFTTrainer``."""
     pytest.importorskip("trl")
     try:
         from trl.trainer.sft_trainer import SFTTrainer
@@ -1855,8 +1793,8 @@ def test_unsloth_rl_class_rename_pinned():
 
 
 def test_unsloth_rl_torch_compile_options_dict_pattern():
-    """``unsloth/models/rl.py:1622-1625`` re.sub on
-    ``torch_compile_options = {...}`` dict assignment."""
+    """rl.py:1622-1625 re.sub on ``torch_compile_options = {...}`` dict
+    assignment."""
     sample = 'torch_compile_options = {"epilogue_fusion": True, "max_autotune": False}'
     out = re.sub(
         r"torch_compile_options\s*=\s*\{[^}]*\}",
@@ -1875,9 +1813,9 @@ def test_unsloth_rl_torch_compile_options_dict_pattern():
 
 
 def test_unsloth_rl_add_adapter_block_pattern_regex():
-    """``unsloth/models/rl.py:1865-1870`` comments out the "ref"
-    adapter creation block in GRPOTrainer; needs ``is_peft_available()``
-    AND ``ref_param.data.copy_`` together in TRL trainer source."""
+    """rl.py:1865-1870 comments out the "ref" adapter creation block in
+    GRPOTrainer; needs ``is_peft_available()`` AND ``ref_param.data.copy_``
+    together in TRL trainer source."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -1907,9 +1845,8 @@ def test_unsloth_rl_add_adapter_block_pattern_regex():
 
 
 def test_unsloth_rl_warmup_ratio_keyword_pattern():
-    """``unsloth/models/rl.py:1323-1333`` re.sub on
-    ``<kwarg> = <value>,\\n`` config-arguments block (warmup_ratio,
-    warmup_steps, etc.)."""
+    """rl.py:1323-1333 re.sub on ``<kwarg> = <value>,\\n`` config-arguments
+    block (warmup_ratio, warmup_steps, etc.)."""
     sample = (
         "warmup_ratio = 0.1,\n"
         "learning_rate = 5e-5,\n"
@@ -1930,8 +1867,8 @@ def test_unsloth_rl_warmup_ratio_keyword_pattern():
 
 
 def test_unsloth_rl_anihilate_typo_marker_search():
-    """``unsloth/models/rl.py:1725-1746`` searches both ``anihilate``
-    (typo) and ``annihilate`` in SFTTrainer to strip the surrounding
+    """rl.py:1725-1746 searches both ``anihilate`` (typo) and ``annihilate``
+    in SFTTrainer to strip the surrounding
     ``args.per_device_train_batch_size == 1`` warning block."""
     pytest.importorskip("trl")
     try:
@@ -1952,8 +1889,8 @@ def test_unsloth_rl_anihilate_typo_marker_search():
 
 
 def test_unsloth_rl_per_device_train_batch_size_marker():
-    """``unsloth/models/rl.py:1730-1731`` searches
-    ``if args.per_device_train_batch_size == 1`` in TRL trainer."""
+    """rl.py:1730-1731 searches ``if args.per_device_train_batch_size == 1``
+    in TRL trainer."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -1983,8 +1920,8 @@ def test_unsloth_rl_per_device_train_batch_size_marker():
 
 
 def test_unsloth_rl_processing_class_call_args_pattern():
-    """``unsloth/models/rl.py:980-985`` injects tokenizer fallback:
-    ``processing_class = processing_class`` ->
+    """rl.py:980-985 injects tokenizer fallback: ``processing_class =
+    processing_class`` ->
     ``= tokenizer if tokenizer is not None else processing_class``."""
     sample = "processing_class = processing_class,\nmodel = model"
     out = sample.replace(
@@ -2002,9 +1939,8 @@ def test_unsloth_rl_processing_class_call_args_pattern():
 
 
 def test_unsloth_rl_shuffle_sequence_dict_pinned_pattern():
-    """``unsloth/models/rl.py:2051-2055`` wraps
-    ``generation_batch = shuffle_sequence_dict(...)`` in try/except
-    pass (torch 2.8 AcceleratorError workaround)."""
+    """rl.py:2051-2055 wraps ``generation_batch = shuffle_sequence_dict(...)``
+    in try/except pass (torch 2.8 AcceleratorError workaround)."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2033,9 +1969,8 @@ def test_unsloth_rl_shuffle_sequence_dict_pinned_pattern():
 
 
 def test_unsloth_rl_model_executor_driver_worker_pinned_pattern():
-    """``unsloth/models/rl.py:2058-2062`` strips
-    ``model_executor.driver_worker`` vLLM internal-API call so zoo's
-    vllm-engine wiring can replace it."""
+    """rl.py:2058-2062 strips ``model_executor.driver_worker`` vLLM
+    internal-API call so zoo's vllm-engine wiring can replace it."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2065,8 +2000,8 @@ def test_unsloth_rl_model_executor_driver_worker_pinned_pattern():
 
 
 def test_unsloth_rl_load_weights_strip_pinned_pattern():
-    """``unsloth/models/rl.py:2065-2069`` strips ``load_weights(...)``
-    lines from TRL trainer source via re.sub."""
+    """rl.py:2065-2069 strips ``load_weights(...)`` lines from TRL trainer
+    source via re.sub."""
     pytest.importorskip("trl")
     import importlib
     candidates = [
@@ -2095,9 +2030,8 @@ def test_unsloth_rl_load_weights_strip_pinned_pattern():
 
 
 def test_unsloth_rl_peft_pattern_27_marker():
-    """``unsloth/models/rl.py:1629-1633,1641-1646`` TWO PEFT init-block
-    regexes (TRL 0.26.0 and 0.27.0 shapes) ending in
-    ``param.data = param.data.to(torch.bfloat16)``."""
+    """rl.py:1629-1633,1641-1646 TWO PEFT init-block regexes (TRL 0.26.0 and
+    0.27.0 shapes) ending in ``param.data = param.data.to(torch.bfloat16)``."""
     pytest.importorskip("trl")
     try:
         import trl.trainer.grpo_trainer as gt
@@ -2120,17 +2054,9 @@ def test_unsloth_rl_peft_pattern_27_marker():
 
 
 def test_unsloth_trainer_exec_marker():
-    """``unsloth/trainer.py:614`` exec()'s synthesized trainer source;
-    pin that unsloth.trainer is importable.
-
-    Skips on a host without a real accelerator: ``import unsloth`` raises
-    ``NotImplementedError("Unsloth cannot find any torch accelerator")``
-    at top-level on a CPU-only CI runner, which is neither an ImportError
-    nor a drift signal -- it's just the harness gate. ``importorskip``
-    only converts ``ImportError`` to ``skip``, so we have to wrap the
-    whole import path. Treat the no-accelerator case as skip so the
-    no-GPU CI cell goes green; the GPU cell still exercises the import
-    end-to-end.
+    """unsloth/trainer.py:614 exec()'s synthesized trainer source; pin that
+    unsloth.trainer is importable. Treat the no-accelerator case as skip
+    (NotImplementedError, not ImportError) so the no-GPU CI cell goes green.
     """
     try:
         import unsloth  # noqa: F401
@@ -2168,9 +2094,8 @@ def test_unsloth_trainer_exec_marker():
 
 
 def test_zoo_compiler_replace_gradient_checkpointing_template_format():
-    """``unsloth_zoo/compiler.py:2226-2234`` template
-    ``replace_gradient_checkpointing`` placeholders LAYER /
-    MODULELIST_ITEM / ARGS / $ must all be present."""
+    """compiler.py:2226-2234 template ``replace_gradient_checkpointing``
+    placeholders LAYER / MODULELIST_ITEM / ARGS / $ must all be present."""
     import importlib
     compiler = importlib.import_module("unsloth_zoo.compiler")
     template = getattr(compiler, "replace_gradient_checkpointing", None)
@@ -2195,9 +2120,8 @@ def test_zoo_compiler_replace_gradient_checkpointing_template_format():
 
 
 def test_zoo_compiler_moe_routing_weights_replace_substitution_well_formed():
-    """``unsloth_zoo/compiler.py:2423-2426`` MOE_ROUTING_WEIGHTS_CAST
-    PATTERN/REPLACE rewrites ``routing_weights.to(hidden_states.dtype)``
-    -> ``...to(router_logits.dtype)``."""
+    """compiler.py:2423-2426 MOE_ROUTING_WEIGHTS_CAST PATTERN/REPLACE rewrites
+    ``routing_weights.to(hidden_states.dtype)`` -> ``...to(router_logits.dtype)``."""
     import importlib
     compiler = importlib.import_module("unsloth_zoo.compiler")
     pat = getattr(compiler, "MOE_ROUTING_WEIGHTS_CAST_PATTERN", None)
@@ -2222,8 +2146,8 @@ def test_zoo_compiler_moe_routing_weights_replace_substitution_well_formed():
 
 
 def test_zoo_compiler_dtype_mismatch_constants_targetable():
-    """``unsloth_zoo/compiler.py:2381-2391`` DTYPE_MISMATCH_FIND /
-    REPLACE constants must contain their pinned sentinel substrings."""
+    """compiler.py:2381-2391 DTYPE_MISMATCH_FIND / REPLACE constants must
+    contain their pinned sentinel substrings."""
     import importlib
     compiler = importlib.import_module("unsloth_zoo.compiler")
     find = getattr(compiler, "DTYPE_MISMATCH_FIND", None)

--- a/tests/test_convert_to_gguf_self_heal.py
+++ b/tests/test_convert_to_gguf_self_heal.py
@@ -1,9 +1,9 @@
 """Tests for convert_to_gguf's self-heal on a broken converter environment.
 
-A stale or missing converter package (usually `gguf`) makes the converter
-subprocess exit 1. convert_to_gguf should reinstall the deps into the
-converter's own interpreter and retry once, surface the real traceback if the
-failure persists, and never reinstall on a genuine model error.
+When a stale/missing converter package (usually `gguf`) makes the subprocess
+exit 1, convert_to_gguf should reinstall deps into the converter's interpreter
+and retry once, surface the real traceback if it persists, and never reinstall
+on a genuine model error.
 """
 
 from __future__ import annotations

--- a/tests/test_extended_dep_api_pins.py
+++ b/tests/test_extended_dep_api_pins.py
@@ -43,8 +43,7 @@ import pytest
 
 
 def _resolve(dotted: str) -> object:
-    """``importlib.import_module`` + ``getattr`` chain. Any failure is
-    surfaced as AssertionError tagged DRIFT DETECTED."""
+    """import_module + getattr chain; failures raise AssertionError tagged DRIFT DETECTED."""
     parts = dotted.split(".")
     obj: object = None
     consumed: list[str] = []

--- a/tests/test_forward_native_moe_loop_lora.py
+++ b/tests/test_forward_native_moe_loop_lora.py
@@ -1,18 +1,10 @@
 """Regression tests for forward_native_moe_loop LoRA application.
 
-These tests cover the gate_up_proj and down_proj transpose-on-mismatch checks
-plus the once-per-forward dtype pre-cast that PR #618 introduces. They are
-PEFT-version-agnostic: they construct LoRA factors by hand in the same shape
-the extractor would produce, then verify that
-
-    forward_native_moe_loop(experts, x, top_k_idx, top_k_weights)
-
-produces the same per-expert output as the naive reference
-
-    base_out + (X @ first[e]) @ second[e] * scaling
-
-for both the canonical (E, 2*I, H) / (E, H, I) Qwen3-MoE storage AND the
-transposed (E, H, 2*I) / (E, I, H) Qwen3-VL-MoE storage.
+Cover the gate_up_proj/down_proj transpose-on-mismatch checks and the
+once-per-forward dtype pre-cast (PR #618). PEFT-version-agnostic: build LoRA
+factors by hand and check forward_native_moe_loop matches the naive reference
+base_out + (X @ first[e]) @ second[e] * scaling, for both canonical Qwen3-MoE
+and transposed Qwen3-VL-MoE storage.
 """
 
 import pytest
@@ -24,8 +16,7 @@ from unsloth_zoo.temporary_patches.moe_utils import forward_native_moe_loop
 
 
 def _build_experts(num_experts, hidden, intermediate, transposed_storage):
-    """Build a minimal `experts` module that exposes the surface area
-    `forward_native_moe_loop` reads."""
+    """Minimal `experts` module exposing what `forward_native_moe_loop` reads."""
     experts = nn.Module()
     experts.num_experts = num_experts
     if transposed_storage:
@@ -180,10 +171,8 @@ def test_forward_native_moe_loop_no_lora_matches_naive(transposed_storage):
 
 
 def test_forward_native_moe_loop_square_dim_uses_grouped_mm_flag():
-    """When `intermediate_dim == hidden_dim`, the shape-based transpose check
-    cannot tell which orientation the per-expert weight is stored in. The
-    explicit `_unsloth_grouped_mm_format` flag must take precedence so that
-    transposed storage is detected even at square dims.
+    """At square dims (intermediate_dim == hidden_dim) the shape check can't tell
+    the weight orientation; the `_unsloth_grouped_mm_format` flag must win.
     """
     torch.manual_seed(13)
     num_experts = 3
@@ -192,8 +181,7 @@ def test_forward_native_moe_loop_square_dim_uses_grouped_mm_flag():
     num_tokens = 5
     top_k = 2
 
-    # Use intermediate = dim so that down_proj is (E, dim, dim) — square.
-    # gate_up_proj is (E, 2*dim, dim) which is non-square so easy.
+    # intermediate = dim makes down_proj (E, dim, dim) square; gate_up stays easy.
     intermediate = dim
     hidden = dim
 

--- a/tests/test_fused_forward_install.py
+++ b/tests/test_fused_forward_install.py
@@ -8,18 +8,9 @@
 
 """Tests for the fused lm_head + cross_entropy auto-installer.
 
-Covers:
-  - AST rewriter recognises the canonical HF triplet shape (keyword form,
-    positional vocab_size, `.float()` wrapper, no-`loss = None` initialiser).
-  - AST rewriter declines on non-matching forwards (no triplet, missing
-    if-labels block, missing loss_function call).
-  - install_for_class:
-      * no-op when UNSLOTH_FUSED_FORWARD is off
-      * patches a synthetic *ForCausalLM whose forward matches the triplet
-      * leaves a hand-crafted bespoke forward in _UNMATCHED
-      * is idempotent
-  - Numerical equivalence of the rewritten forward vs the original at
-    small shapes (mean MSE under 1e-4 on bf16 -> fp32).
+Covers the AST rewriter (matches the canonical HF triplet, declines non-matching
+forwards), install_for_class (env opt-out, patching, _UNMATCHED, idempotency),
+and numerical equivalence of the rewritten forward vs the original.
 """
 
 from __future__ import annotations
@@ -104,13 +95,11 @@ def test_ast_rewriter_matches_keyword_form():
     assert cap.logits_name == "logits"
     assert "unsloth_fused_lm_head_loss" in new_src
     assert "EMPTY_LOGITS" in new_src
-    # self.loss_function appears exactly once: on the UNSLOTH_RETURN_LOGITS
-    # opt-in path, where we materialise logits via the original RHS and
-    # route the loss through it to avoid a second lm_head matmul.
+    # self.loss_function only on the UNSLOTH_RETURN_LOGITS opt-in path, routing
+    # the loss through materialised logits to avoid a second lm_head matmul.
     assert new_src.count("self.loss_function") == 1
-    # Labels branch carries the UNSLOTH_RETURN_LOGITS opt-in; the hidden-
-    # states branch is intentionally absent (handled by the compiled
-    # forward in unsloth_zoo/compiler.py).
+    # Labels branch carries the RETURN_LOGITS opt-in; RETURN_HIDDEN_STATES is
+    # absent (handled by the compiled forward in unsloth_zoo/compiler.py).
     assert "UNSLOTH_RETURN_LOGITS" in new_src
     assert "UNSLOTH_RETURN_HIDDEN_STATES" not in new_src
 
@@ -264,10 +253,8 @@ _SYNTH_COUNTER = 0
 def _make_synthetic_class(forward_src: str, name: str = "SyntheticForCausalLM"):
     """Build a class whose forward source is recoverable via inspect.getsource.
 
-    `inspect.getsource` relies on `linecache`. Exec'd functions without a
-    real file backing return OSError, which is what the installer falls
-    back on. To exercise the rewriter we register a unique synthetic file
-    name with `linecache` and compile through it.
+    getsource relies on linecache, so register a unique synthetic file name and
+    compile through it (exec'd funcs without a file backing raise OSError).
     """
     import linecache
     global _SYNTH_COUNTER
@@ -436,8 +423,7 @@ def test_rewritten_forward_loss_matches_reference(fresh_install, enable_env):
     instance.lm_head = torch.nn.Linear(H, V, bias=False).cuda().to(torch.bfloat16)
 
     def _reference_loss(logits, labels, vocab_size, **kw):
-        # unsloth_fused_ce_loss shifts labels by one (causal LM convention).
-        # Mirror that here so the two losses are apples-to-apples.
+        # Mirror unsloth_fused_ce_loss's causal one-token label shift.
         shifted = labels.clone()
         shifted[..., :-1] = labels[..., 1:]
         shifted[..., -1] = -100

--- a/tests/test_gemma4_moe_lora_registration.py
+++ b/tests/test_gemma4_moe_lora_registration.py
@@ -1,26 +1,12 @@
-"""Regression tests for the Gemma-4 MoE LoRA extractor registration added by
-PR #624. These tests do NOT require ``transformers.models.gemma4`` to exist;
-they exercise the registration helper against a synthetic stand-in class
-with the same surface (gate_up_proj (E, 2*I, H), down_proj (E, H, I),
-hidden_dim, intermediate_dim).
+"""Regression tests for the Gemma-4 MoE LoRA extractor registration (PR #624).
 
-What is covered:
-
-1. Successful registration attaches the Qwen extractor and the model-type
-   tag without overwriting unrelated state.
-2. Registration is idempotent across repeated calls (callable identity is
-   preserved, no double-wrapping).
-3. ``_register_gemma4_lora_extractor(None)`` returns False without raising,
-   matching the legacy import path where ``Gemma4TextMoEBlock`` may be
-   absent.
-4. If the underlying extractor factory raises, registration returns False
-   and leaves the class state untouched (no half-registered attributes).
-5. The registered extractor produces (E, in, R) / (E, R, out) tensors that
-   numerically reconstruct the per-expert delta on both the PEFT 0.18 raw
-   layout and the PEFT 0.19 ``_did_swap_in_out_features`` swapped layout,
-   for both ``gate_up_proj`` and ``down_proj`` parameters.
-6. Sibling MoE families' existing extractor registrations are not disturbed
-   by Gemma-4 registration.
+Do NOT require ``transformers.models.gemma4``; they drive the registration
+helper against a synthetic stand-in with the same surface (gate_up_proj
+(E, 2*I, H), down_proj (E, H, I), hidden_dim, intermediate_dim). Cover:
+registration attaches the Qwen extractor + model-type tag, is idempotent,
+returns False (no raise / no half-registered state) on None or a raising
+factory, reconstructs the per-expert delta on PEFT 0.18 raw and 0.19 swapped
+layouts for both params, and does not disturb sibling families.
 """
 
 from __future__ import annotations
@@ -51,9 +37,8 @@ def _fresh_stub_class():
 
 
 class _StubWrapper:
-    """Mimics the surface ``_make_qwen_moe_lora_extractor`` reads from a
-    PEFT ParamWrapper: ``parameter_name``, ``get_base_layer()``,
-    optionally ``_did_swap_in_out_features``."""
+    """PEFT ParamWrapper surface read by ``_make_qwen_moe_lora_extractor``:
+    ``parameter_name``, ``get_base_layer()``, ``_did_swap_in_out_features``."""
 
     def __init__(self, parameter_name: str, base_layer, peft_swapped: bool):
         self.parameter_name = parameter_name
@@ -76,8 +61,7 @@ def test_register_is_idempotent():
     cls = _fresh_stub_class()
     assert g4._register_gemma4_lora_extractor(cls) is True
     fn_before = cls._unsloth_lora_extractor_fn
-    # Second call must short-circuit on the registered flag and leave the
-    # extractor identity untouched.
+    # Second call short-circuits on the registered flag; identity unchanged.
     assert g4._register_gemma4_lora_extractor(cls) is True
     assert cls._unsloth_lora_extractor_fn is fn_before
     assert cls._unsloth_model_type == "gemma4_moe"
@@ -100,22 +84,18 @@ def test_register_failure_preserves_class_state(monkeypatch):
 
 
 def test_register_does_not_disturb_sibling_registration():
-    # qwen3_moe registers its extractor when patch_qwen3_moe is invoked.
-    # Without invoking it, we verify that an unrelated class registered by
-    # Gemma-4 does NOT touch any class qwen3_moe would later target.
+    # Gemma-4 registration must not touch any class qwen3_moe would target.
     cls = _fresh_stub_class()
     assert g4._register_gemma4_lora_extractor(cls) is True
-    # The Qwen extractor factory is still callable and independent.
     qwen_extractor = _make_qwen_moe_lora_extractor()
     assert callable(qwen_extractor)
-    # The Gemma-4 stub extractor and a freshly built Qwen extractor are
-    # distinct instances even though they originate from the same factory.
+    # Same factory, distinct instances.
     assert cls._unsloth_lora_extractor_fn is not qwen_extractor
 
 
 def _drive_extractor(cls, parameter_name: str, peft_swapped: bool):
-    """Drive the registered extractor against hand-built LoRA factors and
-    compare per-expert reconstructed delta to a naive reference."""
+    """Drive the registered extractor on hand-built LoRA factors and compare
+    the per-expert reconstructed delta to a naive reference."""
     torch.manual_seed(0)
     base = cls()
     if parameter_name == "gate_up_proj":
@@ -186,22 +166,16 @@ def test_extractor_down_swapped_peft019():
 
 
 def test_patch_gemma4_moe_is_noop_without_gemma4(monkeypatch):
-    """End-to-end sanity check: when transformers lacks
-    ``models.gemma4.modeling_gemma4`` (the case in this env), the public
-    entrypoint must not raise. Both inner patch functions guard their
-    imports, and ``patch_gemma4_moe`` short-circuits via ``raise_error``
-    which returns rather than raising."""
-    # Act: just call the entrypoint. transformers.models.gemma4 is not
-    # importable on transformers 4.57.6 in this environment.
+    """When transformers lacks ``models.gemma4.modeling_gemma4``, the public
+    entrypoint must not raise: inner patches guard their imports and
+    ``patch_gemma4_moe`` short-circuits via ``raise_error`` (returns)."""
     g4.patch_gemma4_moe()  # must not raise
 
 
 def test_register_handles_legacy_block_class_shape():
-    """Sanity check that a class shaped like Gemma4TextMoEBlock (legacy
-    layout) accepts registration the same way as Gemma4TextExperts. The
-    legacy block also exposes ``num_experts``/``hidden_dim``/
-    ``intermediate_dim`` plus ``gate_up_proj``/``down_proj``, so the
-    Qwen extractor is layout-compatible."""
+    """A legacy Gemma4TextMoEBlock-shaped class registers like
+    Gemma4TextExperts: it exposes the same num_experts/hidden_dim/
+    intermediate_dim + gate_up_proj/down_proj surface."""
     LegacyBlock = _fresh_stub_class()
     assert g4._register_gemma4_lora_extractor(LegacyBlock) is True
     _drive_extractor(LegacyBlock, "gate_up_proj", peft_swapped=False)

--- a/tests/test_gpt_oss_attention_mask.py
+++ b/tests/test_gpt_oss_attention_mask.py
@@ -16,26 +16,15 @@
 
 """Runtime regression check for the gpt-oss BlockMask leak (PR #690).
 
-The behavioural sibling tests (static AST guards over wrap and the
-patched GptOssModel.forward, plus the PR #691 _align_kv_to_mask static
-check, plus the inspect-driven mask-kwargs filter check) live in
-tests/test_zoo_history_regressions.py so they auto-run under the
-consolidated Tests CI workflow.
+The static AST guards live in tests/test_zoo_history_regressions.py. This file
+is the runtime invariant: call the wrapped create_causal_mask with a tiny
+GptOssConfig (_attn_implementation="flex_attention") and assert the return is
+not a BlockMask. Runs in a clean subprocess so torch.compile can be replaced
+with identity BEFORE any unsloth_zoo import (the wrap captures torch.compile at
+load time, and on CPU the compiled wrapper drops kwarg names, masking the real
+invariant with a misleading "missing positional argument" error).
 
-This file is the *runtime* invariant: actually call the wrapped
-transformers.masking_utils.create_causal_mask with a tiny GptOssConfig
-that has _attn_implementation="flex_attention" and assert the return is
-not a BlockMask. The check runs in a clean subprocess so torch.compile
-can be replaced with identity BEFORE any unsloth_zoo import -- the wrap
-captures _torch_compile = functools.partial(torch.compile, ...) at
-module load time and on CPU torch the compiled wrapper drops kwarg
-names, which would otherwise mask the real BlockMask invariant with a
-misleading "missing positional argument" error.
-
-CPU-only; no GPU required. The repo's existing tests/conftest.py GPU-free
-harness (device_type preload, mem_get_info / get_device_capability
-stubs, UNSLOTH_ALLOW_CPU=1) handles the inner subprocess via env
-inheritance.
+CPU-only; tests/conftest.py's GPU-free harness covers the inner subprocess.
 """
 from __future__ import annotations
 
@@ -108,12 +97,10 @@ except Exception:
 
 
 def test_pr690_runtime_blockmask_does_not_reach_eager_inference_path():
-    """Runtime invariant: with _attn_implementation='flex_attention' and
-    a non-grad inputs_embeds, the patched create_causal_mask must return
-    a tensor (or None), never a BlockMask. Without PR #690 this returns
-    a BlockMask and gpt-oss generate() crashes with
-        TypeError: unsupported operand type(s) for +=:
-            'Tensor' and 'BlockMask'
+    """Runtime invariant: with _attn_implementation='flex_attention' and a
+    non-grad inputs_embeds, the patched create_causal_mask returns a tensor (or
+    None), never a BlockMask. Without PR #690 it returns a BlockMask and
+    gpt-oss generate() crashes (Tensor += BlockMask TypeError).
     """
     import subprocess
     import sys as _sys

--- a/tests/test_mlx_adapter_metadata_persistence.py
+++ b/tests/test_mlx_adapter_metadata_persistence.py
@@ -1,19 +1,8 @@
 """Coverage for MLX LoRA adapter save/reload metadata persistence.
 
-Targets the helpers that infer rank/scale/dropout from live MLX LoRA
-modules and the reload-time wrapper that recreates non-language LoRA
-paths before loading adapter weights:
-
-  - _get_mlx_dropout_probability prefers MLX Dropout._p_1 keep-probability
-    over the stale .p attribute used by compatibility shims.
-  - _infer_mlx_lora_rank reads MoE/Switch rank from lora_a.shape[-2] and
-    cross-checks lora_b shape, returning None on mismatch and handling
-    None/missing-shape inputs without raising.
-  - _enrich_mlx_adapter_config persists rank/scale/dropout under an
-    explicit filter that does NOT borrow metadata from unselected modules
-    while still honoring caller-provided topology metadata exactly.
-  - _apply_lora_at_paths TypeError-fallback restores both scale AND
-    dropout when older mlx-lm wrappers reject those kwargs.
+Targets the helpers that infer rank/scale/dropout from live MLX LoRA modules
+(_get_mlx_dropout_probability, _infer_mlx_lora_rank, _enrich_mlx_adapter_config)
+and the reload-time wrapper that restores scale/dropout on older mlx-lm wrappers.
 """
 
 import os
@@ -477,12 +466,9 @@ def test_enrich_mlx_adapter_config_normalizes_pathlike_explicit_paths():
 
 
 def test_enrich_mlx_adapter_config_coerces_mxarray_scale_without_aborting():
-    # _enrich_mlx_adapter_config previously used raw float(module.scale).
-    # A LoRASwitchLinear that exposes scale as a multi-element mx.array
-    # made float() raise, which the outer try/except: pass swallowed -
-    # silently dropping unsloth_mlx_lora_module_paths so the reload path
-    # could not re-attach vision/projector LoRA wrappers. Mirror the
-    # trainer-side .item() / fallback-1.0 coercion in enrich too.
+    # A multi-element mx.array scale used to make float() raise, swallowed by an
+    # outer try/except that dropped unsloth_mlx_lora_module_paths. Enrich must
+    # mirror the trainer-side .item() / fallback-1.0 coercion.
     mlx_utils = _load_utils()
 
     class _MultiExpertScale:

--- a/tests/test_mlx_baseline_loss_parity.py
+++ b/tests/test_mlx_baseline_loss_parity.py
@@ -2,15 +2,12 @@
 # Pin `make_baseline_loss_fn` source so the labels=None fast path stays
 # byte-for-byte equivalent to mlx_lm.tuner.trainer.default_loss.
 #
-# Why pin source rather than run a numerical comparison: the test
-# harness uses a torch-based MLX shim that doesn't faithfully reproduce
-# MLX's autodiff graph or its rounding; an apples-to-apples numerical
-# parity check requires a real MLX runtime (Apple Silicon), so it's
-# done in the Round BP probe matrix on
-# danielhanchen/unsloth-staging-2. Locally we guard against future
-# refactors silently re-introducing the divergent code patterns
-# (fp32-cast mask, mx.where(safe_targets), _safe_token_denominator)
-# that mlx_lm.tuner.trainer.default_loss does NOT do.
+# Source is pinned rather than numerically compared because the torch-based
+# MLX shim doesn't reproduce MLX's autodiff graph / rounding (real numerical
+# parity needs Apple Silicon, done in the Round BP probe matrix on
+# danielhanchen/unsloth-staging-2). Locally we guard against refactors
+# re-introducing the divergent patterns (fp32-cast mask, mx.where(safe_targets),
+# _safe_token_denominator) that default_loss does NOT do.
 
 from __future__ import annotations
 
@@ -38,8 +35,7 @@ def _labels_none_block():
     )
     assert m, "make_baseline_loss_fn must keep a `labels is None` fast path"
     raw = textwrap.dedent(m.group(1))
-    # Strip whole-line comments so test assertions on code don't trip on
-    # explanatory prose like "no safe_targets mx.where" in docstrings.
+    # Strip whole-line comments so assertions on code ignore explanatory prose.
     code_lines = []
     for line in raw.splitlines():
         stripped = line.strip()

--- a/tests/test_mlx_batch_padding.py
+++ b/tests/test_mlx_batch_padding.py
@@ -1,20 +1,13 @@
 # Unsloth Zoo - Utilities for Unsloth
-# Pin MLXTrainer's batch padding to match mlx-lm's iterate_batches
-# semantics: pad to `1 + _PAD_MULTIPLE * ceil(L / _PAD_MULTIPLE)`.
+# Pin MLXTrainer's batch padding to match mlx-lm's iterate_batches:
+# `1 + _PAD_MULTIPLE * ceil(L / _PAD_MULTIPLE)`.
 #
-# Why this matters:
-# mlx-lm's tuner trainer (`mlx_lm/tuner/trainer.py:158`) pads each
-# batch to `1 + 32 * ceil(max_len / 32)`. The default loss then
-# slices `inputs = batch[:, :-1]` / `targets = batch[:, 1:]`, so the
-# effective per-position-attention length is `32 * ceil(max_len/32)`.
-# unsloth_zoo's `create_text_batches` previously rounded WITHOUT the
-# `+1` (just `32 * ceil(max_len/32)`), which dropped one token of
-# input length after the autoregressive shift, putting the trainer
-# one token shy of mlx-lm. On a single-row LoRA memorization fixture
-# against gemma-3-270m-it, the one-token gap moved the run into a
-# different convergence basin (probe 31 manual loop = 10/15 = 67%
-# vs probe 33-37 MLXTrainer = 6-8/15 = 40-53% on paired seeds, see
-# danielhanchen/unsloth-staging-2).
+# mlx-lm (mlx_lm/tuner/trainer.py:158) pads to `1 + 32*ceil(max_len/32)`;
+# default_loss then slices [:, :-1] / [:, 1:]. unsloth_zoo's
+# create_text_batches previously dropped the `+1`, leaving the input one
+# token short after the autoregressive shift, which shifted small fixtures
+# into a different convergence basin (probe 31 = 67% vs probe 33-37 = 40-53%,
+# see danielhanchen/unsloth-staging-2).
 
 from __future__ import annotations
 

--- a/tests/test_mlx_cce_target_classification.py
+++ b/tests/test_mlx_cce_target_classification.py
@@ -7,12 +7,11 @@
 # (at your option) any later version.
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# MLX CCE target-classification coverage that runs on non-Apple-Silicon
-# hosts via the simulation shim. The companion file
-# tests/test_mlx_runtime_cce_compile.py gates on real Metal and skips
-# under the shim, leaving the pure-Python validation, in-vocab
-# ignore_index precedence, and logit_softcap fallback paths without
-# Linux CI coverage. This file fills those gaps.
+# MLX CCE target-classification coverage on non-Apple-Silicon hosts via the
+# simulation shim. tests/test_mlx_runtime_cce_compile.py gates on real Metal
+# and skips under the shim, leaving the pure-Python validation, in-vocab
+# ignore_index precedence, and logit_softcap fallback paths uncovered on Linux
+# CI. This file fills those gaps.
 
 from __future__ import annotations
 

--- a/tests/test_mlx_dtype_downcast_warning.py
+++ b/tests/test_mlx_dtype_downcast_warning.py
@@ -59,9 +59,8 @@ def test_force_float32_list_exported():
 
 
 def test_force_float32_matches_config_json_model_types():
-    """Entries are HuggingFace `config.json` `model_type` values (the same
-    strings returned by `get_transformers_model_type`). The MLX matcher
-    must accept the real on-disk variants verbatim."""
+    """Entries are real config.json `model_type` strings; the MLX matcher must
+    accept the on-disk variants verbatim."""
     from unsloth_zoo.mlx.loader import _is_force_float32_arch
     # Real config.json model_type strings as they appear on the Hub.
     real_world = [
@@ -125,12 +124,10 @@ def test_no_warning_for_safe_architecture():
 
 
 def test_gemma3_comma_does_not_match_gemma3n():
-    """The trailing-comma trick: 'gemma3,' must NOT match 'gemma3n_audio'."""
+    """The trailing-comma trick: 'gemma3,' must NOT prefix-match other variants."""
     import torch
     from unsloth_zoo.mlx.loader import _is_force_float32_arch
-    # gemma3n is its own entry and DOES match; we're testing that the
-    # 'gemma3,' entry doesn't accidentally swallow gemma3n variants by
-    # prefix match. gemma3n itself still matches via its own entry.
+    # gemma3n matches via its own entry, not by 'gemma3,' prefix-swallowing.
     assert _is_force_float32_arch("gemma3") is True
     assert _is_force_float32_arch("gemma3n") is True
     assert _is_force_float32_arch("gemma3text") is True

--- a/tests/test_mlx_finetune_last_n_layers.py
+++ b/tests/test_mlx_finetune_last_n_layers.py
@@ -16,17 +16,12 @@
 
 """Tests for `finetune_last_n_layers` in FastMLXModel.get_peft_model.
 
-mlx-lm CLI's CONFIG_DEFAULTS sets num_layers=16 (lora.py:56), meaning
-LoRA is applied to the last 16 transformer blocks only. unsloth-zoo's
-get_peft_model historically applied LoRA to ALL transformer layers,
-matching HF PEFT/CUDA semantics. The two paths could produce different
-trained models on the same fixture (different basin) because (a) the
-extra layers contribute extra LoRA modules whose lora_a init consumes
-mx.random state, shifting init for the later layers, and (b) the
-trainable-parameter set differs.
-
-`finetune_last_n_layers` lets users opt into mlx-lm CLI semantics
-without changing the existing default (which remains None = all layers).
+mlx-lm CLI defaults to num_layers=16 (lora.py:56): LoRA on the last 16 blocks
+only. unsloth-zoo historically applied LoRA to ALL layers (HF PEFT/CUDA
+parity). The paths can diverge because extra layers add LoRA modules whose
+lora_a init consumes mx.random state (shifting later-layer init) and change the
+trainable set. `finetune_last_n_layers` opts into mlx-lm semantics; the default
+stays None (all layers).
 """
 
 from __future__ import annotations
@@ -51,13 +46,11 @@ def test_get_peft_model_has_finetune_last_n_layers_param():
 
 
 def test_get_peft_model_passes_finetune_last_n_layers_through():
-    """When finetune_last_n_layers is set, linear_to_lora_layers is
-    called with that num_layers value.
+    """linear_to_lora_layers receives the right num_layers value.
 
-    Patches mlx_lm.tuner.utils.linear_to_lora_layers to record the
-    num_layers it sees. The test runs against a tiny synthetic text
-    model (no real layers needed -- the value of num_layers passed is
-    what we assert, not the side effects on a real architecture).
+    Patches mlx_lm.tuner.utils.linear_to_lora_layers to record num_layers and
+    runs against a synthetic text model (we assert the passed value, not real
+    side effects).
     """
     import sys
     import unsloth_zoo.mlx.loader as loader_mod

--- a/tests/test_mlx_get_peft_model_seed_ordering.py
+++ b/tests/test_mlx_get_peft_model_seed_ordering.py
@@ -1,13 +1,9 @@
 # Unsloth Zoo - Utilities for Unsloth
 # Pin the seed-immediately-before-linear_to_lora_layers ordering in
 # FastMLXModel.get_peft_model so we match mlx-lm CLI's basin family.
-#
-# The actual numerical test (lora_a values bit-identical to
-# `mlx_lm.tuner.utils.linear_to_lora_layers` after `mx.random.seed`)
-# needs real MLX runtime; that's covered by probe 39 on
-# danielhanchen/unsloth-staging-2. Locally we guard against a future
-# refactor reverting to a single `_seed_mlx_random_state` call far
-# above `linear_to_lora_layers` again.
+# The numerical test (bit-identical lora_a) needs real MLX and is
+# covered by probe 39 on danielhanchen/unsloth-staging-2; locally we
+# guard against a refactor moving the seed call far from the LoRA init.
 
 from __future__ import annotations
 
@@ -29,16 +25,12 @@ def _get_peft_model_source():
 
 
 def test_seed_immediately_precedes_each_linear_to_lora_layers_call():
-    """Every `linear_to_lora_layers(...)` call inside get_peft_model
-    must be preceded -- within ~20 source lines, with no other MLX op
-    or model-tree walk in between -- by a `_seed_mlx_random_state` call.
+    """Every `linear_to_lora_layers(...)` in get_peft_model must be
+    preceded within ~20 lines by `_seed_mlx_random_state`.
 
-    Background: empirically (Round BQ probe 39 on Apple Silicon), having
-    the seed call >100 lines above the LoRA construction allows lazy MLX
-    state advances to slip in between seeding and lora_a init, producing
-    lora_a matrices different from mlx-lm CLI's despite both paths
-    re-seeding to the same int. The fix is to seed immediately above
-    each `linear_to_lora_layers` call.
+    Empirically (probe 39 on Apple Silicon), a far-away seed lets lazy
+    MLX state advances slip in before lora_a init, diverging from mlx-lm
+    CLI; fix is to seed immediately above each LoRA construction.
     """
     src = _get_peft_model_source()
     lines = src.splitlines()
@@ -70,10 +62,9 @@ def test_get_peft_model_still_accepts_random_state_arg():
 
 
 def test_no_other_mlx_op_between_seed_and_linear_to_lora_layers():
-    """Between the seed-just-above-LoRA call and the linear_to_lora_layers
-    call itself, the only allowed code is the LoRA call. Anything else --
-    even pure Python -- is a tripwire because it makes it easy to slip
-    in an mx.eval/random call later. Enforced as a regex tripwire."""
+    """Only comment lines may sit between the seed call and the
+    linear_to_lora_layers call; anything else risks an mx.eval/random op
+    slipping in later. Enforced as a regex tripwire."""
     src = _get_peft_model_source()
     pattern = re.compile(
         r"_seed_mlx_random_state\(random_state\)\s*"

--- a/tests/test_mlx_save_lora_adapters_filter.py
+++ b/tests/test_mlx_save_lora_adapters_filter.py
@@ -16,16 +16,12 @@
 
 """Regression coverage for save_lora_adapters / save_trainable_adapters.
 
-- save_lora_adapters keeps only module-anchored lora_a / lora_b tensors,
-  even when base weights are listed as trainable, and raises if no
-  LoRA modules are present.
-- save_trainable_adapters preserves every trainable tensor for in-loop
-  checkpoints.
-- The module-anchored filter does not leak paths that merely contain
-  "lora_" (e.g. router.lora_gate.weight).
+- save_lora_adapters keeps only module-anchored lora_a/lora_b, even when base
+  weights are trainable, and raises if no LoRA modules are present.
+- save_trainable_adapters preserves every trainable tensor for in-loop checkpoints.
+- The filter does not leak paths that merely contain "lora_" (e.g. router.lora_gate.weight).
 
-Runs on Linux + Windows via the mlx_simulation shim, on macOS against
-real MLX.
+Runs on Linux/Windows via the mlx_simulation shim, on macOS against real MLX.
 """
 
 from __future__ import annotations

--- a/tests/test_mlx_torch_shim_smoke.py
+++ b/tests/test_mlx_torch_shim_smoke.py
@@ -33,9 +33,8 @@ import pytest
 import torch
 
 
-# Install the shim once at session start.  All later `import mlx*` calls
-# resolve to the stubs.  The shim package lives at workspace_1/mlx_simulation/
-# (loaded via the workspace conftest.py that puts the workspace on sys.path).
+# Install the shim once at session start so all later `import mlx*` resolve to
+# the stubs (loaded via the workspace conftest.py that puts it on sys.path).
 @pytest.fixture(autouse=True, scope="session")
 def _install_mlx_shim():
     from mlx_simulation import simulate_mlx_on_torch

--- a/tests/test_moe_lora_extractor_coverage.py
+++ b/tests/test_moe_lora_extractor_coverage.py
@@ -1,39 +1,21 @@
 """Dynamic regression-prevention test for the PR #624 failure mode.
 
-PR #624 fixed a Gemma-4 MoE LoRA training crash whose root cause was:
+PR #624 fixed a Gemma-4 MoE LoRA crash: the patch set
+`Gemma4TextExperts._unsloth_already_patched=True` but never registered
+`_unsloth_lora_extractor_fn`. Without the extractor the default canonical
+permutation yields tensors whose contraction dims mismatch for
+`torch._grouped_mm` on PEFT 0.19+ swapped 3D LoRA layouts, crashing on the
+first training step with `RuntimeError: contraction dimension of mat_a and
+mat_b must match`.
 
-    Gemma4TextExperts._unsloth_already_patched = True
-    Gemma4TextExperts._unsloth_lora_extractor_fn  -> NOT REGISTERED
-
-`unsloth_zoo.temporary_patches.gemma4_moe._patch_gemma4_moe_current` patched
-`forward` to call the grouped-MoE backend but forgot to attach the LoRA
-extractor. Without the extractor, `moe_utils._extract_lora_from_wrapper`
-falls through to its default canonical permutation, which produces tensors
-whose contraction dimensions do not match for `torch._grouped_mm` on PEFT
-0.19+ swapped 3D LoRA layouts. The crash surfaces on the first training
-step as `RuntimeError: contraction dimension of mat_a and mat_b must match`.
-
-This test prevents that exact regression for every current and future MoE
-family. It applies every `TEMPORARY_PATCHES` entry, walks every loaded
-`transformers.models.*` module, and asserts that every class flagged
-`_unsloth_already_patched=True` whose source defines `gate_up_proj` and
-`down_proj` 3D parameters also has `_unsloth_lora_extractor_fn` registered.
-
-Design constraints:
-  - GPU-free. Instantiation, when attempted, uses tiny synthetic configs.
-  - Transformers-version-agnostic. Discovery walks the live tree; nothing
-    is hard-coded to specific class names.
-  - Single test. Discovery + assertion live together in one pytest case so
-    the contract is one signal, not many.
-  - Opportunistic parity. If we can instantiate a discovered class without
-    a checkpoint, we additionally drive its registered extractor on hand-
-    built PEFT 0.18 raw and PEFT 0.19 swapped LoRA factors and assert
-    per-expert delta parity. Failures here surface as a separate assertion
-    so registration coverage and orientation correctness are distinguishable.
-
-The test is deliberately defensive: importing transformers submodules is
-allowed to fail (the full transformers tree pulls in optional deps), and
-those failures are reported as `unimported` not as test failures.
+This test applies every `TEMPORARY_PATCHES` entry, walks loaded
+`transformers.models.*`, and asserts every patched class with 3D
+`gate_up_proj`/`down_proj` params also has `_unsloth_lora_extractor_fn`.
+GPU-free, version-agnostic (walks the live tree), single test. When a
+class can be instantiated it also drives per-expert delta parity on PEFT
+0.18 raw and 0.19 swapped factors, surfaced as a separate assertion.
+Importing transformers submodules may fail (optional deps); such failures
+are skipped, not test failures.
 """
 
 from __future__ import annotations
@@ -49,17 +31,14 @@ import pytest
 import torch
 import torch.nn as nn
 
-# Apply every TEMPORARY_PATCHES entry. Importing the package side-effect-
-# populates the list; we run each entry once and ignore individual failures
-# (a missing transformers submodule is the standard no-op signal).
+# Importing the package side-effect-populates TEMPORARY_PATCHES.
 import unsloth_zoo.temporary_patches  # noqa: F401  side effect: register patches
 from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
 
 
-# Regex for "self.gate_up_proj = nn.Parameter(torch.empty(...))" / similar
-# 3D parameter declarations on the class body. We also accept the variant
-# spelling used by some unsloth_zoo internals (Mxfp4 / GptOss style does
-# NOT match this on purpose -- those classes use a different LoRA path).
+# Match 3D `self.gate_up_proj`/`self.down_proj = nn.Parameter(...)` class
+# declarations. Mxfp4 / GptOss style is intentionally not matched (different
+# LoRA path).
 _3D_PARAM_PATTERNS = [
     re.compile(r"self\.gate_up_proj\s*=\s*nn\.Parameter\("),
     re.compile(r"self\.down_proj\s*=\s*nn\.Parameter\("),
@@ -75,8 +54,7 @@ def _apply_all_temporary_patches() -> None:
 
 
 def _iter_modeling_modules():
-    """Yield every transformers.models.<x>.modeling_<y> module that imports
-    cleanly. Failures (missing optional deps) are skipped silently."""
+    """Yield every cleanly-importable transformers.models.*.modeling_* module."""
     import transformers.models as tm
 
     with warnings.catch_warnings():
@@ -100,9 +78,8 @@ def _iter_modeling_modules():
 
 
 def _looks_like_grouped_moe_experts(cls: type) -> bool:
-    """Return True if `cls.__init__` source declares both `gate_up_proj`
-    and `down_proj` as `nn.Parameter`s. This is the surface that the
-    grouped-MoE LoRA extractor reads."""
+    """True if `cls.__init__` declares both `gate_up_proj` and `down_proj`
+    as `nn.Parameter`s (the grouped-MoE LoRA extractor's surface)."""
     try:
         src = inspect.getsource(cls.__init__)
     except (OSError, TypeError):
@@ -111,12 +88,10 @@ def _looks_like_grouped_moe_experts(cls: type) -> bool:
 
 
 def _has_unsloth_patched_forward(cls: type) -> bool:
-    """Detect that `unsloth_zoo.temporary_patches.utils.patch_function` has
-    replaced `cls.forward`. `patch_function` stores the original under a
-    per-class attribute named `_original_<modeling_module_tail>_<ClassName>_
-    forward` (`utils.py:_get_unique_storage_name`). The presence of that
-    attribute on the class is a uniform marker independent of any family-
-    specific bool flag like `_unsloth_already_patched`.
+    """True when `patch_function` has replaced `cls.forward`. It stores the
+    original under `_original_<modeling_tail>_<ClassName>_forward`
+    (`utils.py:_get_unique_storage_name`); that attribute is a uniform marker
+    independent of family-specific flags like `_unsloth_already_patched`.
     """
     cls_name = cls.__name__
     for attr in dir(cls):
@@ -126,14 +101,10 @@ def _has_unsloth_patched_forward(cls: type) -> bool:
 
 
 def _discover_patched_moe_classes() -> list[type]:
-    """Find every transformers class that unsloth-zoo has replaced the
-    `forward` of AND whose source matches the grouped-MoE 3D-parameter
-    shape (`gate_up_proj` + `down_proj` declared as `nn.Parameter`).
-
-    The combination is the load-bearing contract: `forward` was swapped to
-    the grouped-MoE backend, so the LoRA path through that backend must
-    have an extractor registered. PR #624 was an instance of registration
-    being forgotten on a class that satisfied both conditions.
+    """Find every class whose `forward` unsloth-zoo replaced AND whose source
+    matches the grouped-MoE 3D shape (`gate_up_proj` + `down_proj`
+    nn.Parameters). That combination requires a registered extractor; PR #624
+    was a class satisfying both where registration was forgotten.
     """
     seen: set[type] = set()
     out: list[type] = []
@@ -170,16 +141,13 @@ class _StubWrapper:
 
 
 def _try_instantiate_experts(cls: type):
-    """Best-effort instantiation of an MoE experts class with tiny synthetic
-    dims. Returns the instance or None if any path fails.
+    """Best-effort instantiate an MoE experts class with tiny synthetic dims;
+    returns the instance or None.
 
-    Dim choice: H=16, I=10, 2*I=20. All three values are distinct (so
-    PEFT-version dispatch can't be ambiguous) and the relation
-    `H > I` and `2*I > H` matches production MoE configs (Qwen3-MoE,
-    Gemma-4 MoE, Glm4-MoE-Lite, DeepSeek-V3 all live in this regime). A
-    test in a different regime would surface known-fragile extractor
-    orientation behavior that is independent of the PR #624 contract this
-    test exists to enforce."""
+    Dims H=16, I=10, 2*I=20 are all distinct (no ambiguous PEFT dispatch) and
+    keep `H > I`, `2*I > H` to match production MoE configs (Qwen3-MoE,
+    Gemma-4 MoE, Glm4-MoE-Lite, DeepSeek-V3). Other regimes surface fragile
+    orientation behavior unrelated to the PR #624 contract."""
     cfg_cls = _find_sibling_config(cls)
     if cfg_cls is None:
         return None
@@ -210,7 +178,7 @@ def _try_instantiate_experts(cls: type):
         cfg = cfg_cls(**kwargs)
     except Exception:
         return None
-    # Some experts modules want a nested text_config; try that if direct fails.
+    # Some experts modules want a nested text_config; try it if direct fails.
     for cfg_arg in (cfg, getattr(cfg, "text_config", None)):
         if cfg_arg is None:
             continue
@@ -226,9 +194,8 @@ def _try_instantiate_experts(cls: type):
 
 
 def _find_sibling_config(cls: type):
-    """Find the most likely Config class living in the same modeling module
-    as `cls`. Tries Foo<...>Config and Foo<...>TextConfig forms by stripping
-    common experts suffixes from the class name."""
+    """Find the likely Config class in `cls`'s modeling module, trying
+    Foo*Config / Foo*TextConfig after stripping common experts suffixes."""
     mod = importlib.import_module(cls.__module__)
     base = cls.__name__
     for suffix in ("Experts", "NaiveMoe", "MoEBlock", "MoeBlock", "MoE", "Moe"):
@@ -293,39 +260,25 @@ def _parity_one(extractor, experts, name: str, in_dim: int, out_dim: int,
 
 
 def test_every_patched_moe_experts_class_has_lora_extractor():
-    """Regression-prevention test for PR #624. Every class whose `forward`
-    unsloth-zoo has patched to use the grouped-MoE backend AND whose layout
-    matches the standard `(E, 2*I, H)` / `(E, H, I)` 3D-parameter shape
-    MUST have `_unsloth_lora_extractor_fn` registered. Without it, LoRA
-    training crashes on the first step with a `torch._grouped_mm`
-    contraction-dim mismatch on PEFT 0.19+."""
+    """Regression test for PR #624: every class whose `forward` unsloth-zoo
+    patched to the grouped-MoE backend with `(E, 2*I, H)`/`(E, H, I)` 3D
+    params MUST register `_unsloth_lora_extractor_fn`, else LoRA crashes on
+    step 1 with a `torch._grouped_mm` contraction-dim mismatch on PEFT
+    0.19+."""
     _apply_all_temporary_patches()
 
     patched = _discover_patched_moe_classes()
     if not patched:
-        # Disambiguate three zero-discovery causes:
-        #   (a) the installed transformers predates every MoE class surface
-        #       unsloth_zoo targets, AND no patch fn ran far enough to set
-        #       any marker -- legitimate skip;
-        #   (b) the runtime environment broke ALL targeting patches (e.g. a
-        #       CPU-only runner where some patch fn raises before its
-        #       `_unsloth_already_patched = True` line) but transformers
-        #       itself ships unpatched MoE classes -- this is a real
-        #       infrastructure failure, but it does not necessarily mean
-        #       the marker convention drifted: the patch fn never reached
-        #       the marker, so blaming the test helper is wrong; or
-        #   (c) the `_original_<modeling_tail>_<ClassName>_forward` marker
-        #       convention `_has_unsloth_patched_forward` reads drifted
-        #       relative to `patch_function`'s storage convention -- a
-        #       real test-helper regression.
-        # Distinguish them via the `_unsloth_already_patched=True` boolean
-        # the patch fns set explicitly: that flag is the patch fn's own
-        # claim "I reached the end successfully." If at least one class
-        # carries it, AT LEAST one patch fn ran fully -- discovery missing
-        # such a class is therefore the test-helper drift in (c) and is a
-        # real regression. If NO class carries it, the patch fns either
-        # all early-exited (a) or hit a runtime issue (b); in either case
-        # this test cannot reach its target so we skip.
+        # Zero discovery has three causes: (a) transformers predates every
+        # targeted MoE class and no patch fn set a marker -- legit skip;
+        # (b) the runtime broke ALL targeting patches before their
+        # `_unsloth_already_patched = True` line -- infra failure, not marker
+        # drift; (c) the `_original_..._forward` convention
+        # `_has_unsloth_patched_forward` reads drifted from `patch_function`
+        # -- a real test-helper regression.
+        # Disambiguate via `_unsloth_already_patched=True`: if any class
+        # carries it, a patch fn ran fully so missing discovery is (c), a real
+        # regression. If none carries it, we're in (a)/(b) and skip.
         already = []
         for modeling in _iter_modeling_modules():
             for _name, cls in inspect.getmembers(modeling, inspect.isclass):
@@ -373,10 +326,8 @@ def test_every_patched_moe_experts_class_has_lora_extractor():
         f"in the patch function. Offenders: {missing}"
     )
 
-    # Soft contract: opportunistic per-expert parity. Failures here are the
-    # extractor-orientation bug class (PR #624 was a registration bug, not
-    # an orientation bug, but the same one-test-catches-both contract is
-    # cheap to assert here).
+    # Soft contract: opportunistic per-expert parity catches the
+    # extractor-orientation bug class (cheap to assert alongside).
     parity_failures = []
     for cls in patched:
         experts = _try_instantiate_experts(cls)
@@ -399,10 +350,8 @@ def test_every_patched_moe_experts_class_has_lora_extractor():
                     )
 
     if parity_failures:
-        # Surface the orientation drift but keep the registration assertion
-        # above as the primary signal. We use pytest.fail not assert so the
-        # registration coverage assertion can still pass-or-fail
-        # independently of orientation.
+        # pytest.fail (not assert) keeps orientation separate from the
+        # primary registration-coverage assertion above.
         pytest.fail(
             "Per-expert delta parity failed for some patched MoE families. "
             "This is independent of registration coverage but indicates an "

--- a/tests/test_moe_quant_cleanup.py
+++ b/tests/test_moe_quant_cleanup.py
@@ -14,18 +14,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Structural pins for the PR #659 cleanup.
+"""Structural pins for the PR #659 cleanup (not the FP8/bnb4bit kernels):
 
-These tests don't exercise the FP8 / bnb4bit forward kernels — that's the
-job of the existing MoE integration tests. They lock in the structural
-invariants we relied on while restructuring:
-
-1. The post-load FP8 scale reattach machinery (which never had a caller)
-   is gone.
-2. _call_with_temporary_moe_weights has been unified in moe_utils and
-   removed from both moe_utils_fp8 and moe_utils_bnb4bit.
-3. The PEFT bnb4bit MoE merge/unmerge patches live alongside the rest
-   of the bnb4bit code, not in misc.py.
+1. The unused post-load FP8 scale reattach machinery is gone.
+2. _call_with_temporary_moe_weights is unified in moe_utils (removed from
+   moe_utils_fp8 and moe_utils_bnb4bit).
+3. The PEFT bnb4bit MoE merge/unmerge patches live in moe_utils_bnb4bit,
+   not misc.py.
 """
 
 from __future__ import annotations
@@ -53,8 +48,7 @@ def test_dead_fp8_reattach_machinery_is_gone():
 
 def test_moe_utils_fp8_does_not_open_safetensors_at_load_time():
     """The deleted reattach path was the only consumer of safetensors /
-    hf_hub_download inside moe_utils_fp8 (load-time, after-the-fact). After
-    cleanup, nothing in this module reopens checkpoint shards."""
+    hf_hub_download in moe_utils_fp8; nothing should reopen checkpoint shards."""
     from pathlib import Path
     import unsloth_zoo.temporary_patches.moe_utils_fp8 as m
     src = Path(m.__file__).read_text()

--- a/tests/test_offline_env_cross_sync.py
+++ b/tests/test_offline_env_cross_sync.py
@@ -3,20 +3,13 @@
 
 """Regression tests for the offline env cross-sync at import time.
 
-``unsloth_zoo/__init__.py`` cross-syncs three env vars so that setting
-any one of them implies all three:
+``unsloth_zoo/__init__.py`` cross-syncs three env vars so setting any one
+implies all three: ``HF_HUB_OFFLINE`` (huggingface_hub),
+``TRANSFORMERS_OFFLINE`` (transformers), ``HF_DATASETS_OFFLINE`` (datasets).
+Without ``HF_DATASETS_OFFLINE`` in the sync, ``load_dataset()`` still hits the
+network for metadata and fails with ``ConnectionError`` instead of using cache.
 
-* ``HF_HUB_OFFLINE``       used by ``huggingface_hub``
-* ``TRANSFORMERS_OFFLINE`` used by ``transformers``
-* ``HF_DATASETS_OFFLINE``  used by ``datasets``
-
-Without ``HF_DATASETS_OFFLINE`` in the sync, ``load_dataset()`` still
-issues a network call for dataset metadata when the rest of the HF
-stack has been switched offline, and fails with ``ConnectionError``
-instead of resolving from cache.
-
-These tests reload ``unsloth_zoo`` with each combination of env vars
-preset to exercise the import-time cross-sync.
+Tests reload ``unsloth_zoo`` with each env-var combination preset.
 """
 
 from __future__ import annotations
@@ -30,13 +23,12 @@ import pytest
 
 @pytest.fixture
 def reload_zoo(monkeypatch):
-    """Strip all three offline env vars, allow the test to set what it
-    wants, then reload ``unsloth_zoo`` so its import-time block runs."""
+    """Strip the three offline env vars, then reload ``unsloth_zoo`` so its
+    import-time cross-sync runs."""
     for v in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"):
         monkeypatch.delenv(v, raising = False)
 
     def _reload():
-        # Force a fresh import so the module-level cross-sync runs.
         sys.modules.pop("unsloth_zoo", None)
         return importlib.import_module("unsloth_zoo")
 

--- a/tests/test_patch_loss_functions_coverage.py
+++ b/tests/test_patch_loss_functions_coverage.py
@@ -8,22 +8,16 @@
 
 """Regression for unslothai/unsloth#5441.
 
-PreTrainedModel.__init__ resolves loss_type from the class name. Anything
-whose name doesn't appear as a literal LOSS_MAPPING key falls back to a
-regex match, which means `Qwen3_5ForConditionalGeneration` lands on
-`LOSS_MAPPING["ForConditionalGeneration"]`. That entry, plus
-`CsmForConditionalGeneration`, is aliased to the stock `ForCausalLMLoss`
-in transformers. `patch_loss_functions()` only rewrote
-`LOSS_MAPPING["ForCausalLM"]`, leaving those aliases pointing at the
-un-patched loss which does `logits.float()` and OOMs on <= 24 GB GPUs at
-large vocab sizes.
+PreTrainedModel.__init__ resolves loss_type from the class name via regex when
+it isn't a literal LOSS_MAPPING key, so `Qwen3_5ForConditionalGeneration` lands
+on `LOSS_MAPPING["ForConditionalGeneration"]` (aliased, like
+`CsmForConditionalGeneration`, to stock `ForCausalLMLoss`). `patch_loss_functions()`
+only rewrote `LOSS_MAPPING["ForCausalLM"]`, leaving those aliases on the
+un-patched loss that does `logits.float()` and OOMs on <= 24 GB GPUs at large
+vocab sizes.
 
-This suite pins:
-  - Every key originally aliased to ForCausalLMLoss is replaced with
-    the Unsloth kernel.
-  - Keys aliased to other loss types (ForMaskedLMLoss, segmentation,
-    detection, etc.) are not overwritten.
-  - The patch is idempotent.
+Pins: every key aliased to ForCausalLMLoss is replaced with the Unsloth kernel;
+keys aliased to other loss types are not; the patch is idempotent.
 """
 
 from __future__ import annotations

--- a/tests/test_pr_a_components.py
+++ b/tests/test_pr_a_components.py
@@ -14,13 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
-PR-A end-to-end component exercises through the shim.
-
-Goes one level deeper than test_pr_a_imports.py: actually constructs
-inputs and runs the function bodies.  Each test focuses on one
-critical PR-A code path.
-"""
+"""PR-A end-to-end component exercises through the shim: constructs inputs and
+runs the function bodies (deeper than test_pr_a_imports.py)."""
 
 from __future__ import annotations
 
@@ -142,14 +137,12 @@ def test_dequantize_affine_roundtrip():
     """Construct a known-good packed weight and verify dequant."""
     from mlx_simulation.mlx_helpers.quant import dequantize_affine
 
-    # 4-bit affine: 8 elements packed into 1 uint32 word (4 bits each, 8 elements per word).
-    # Group size = 8, bits = 4. Use a simple test vector.
+    # 4-bit affine, group_size 8: pack values 0..7 (4 bits each) into one
+    # uint32, element 0 in the lowest bits.
     bits = 4
     group_size = 8
     elements_per_word = 32 // bits  # = 8
 
-    # Pack values 0..7 (4-bit each) into a single uint32.
-    # Element 0 in lowest bits, element 7 in highest.
     packed_value = 0
     for i, v in enumerate([0, 1, 2, 3, 4, 5, 6, 7]):
         packed_value |= v << (i * bits)
@@ -252,7 +245,7 @@ def test_tensor_at_set():
 
 def test_transpose_multi_axis_is_permute():
     t = torch.zeros(2, 3, 4, 5)
-    # 4-axis transpose = full permute, shape becomes (5, 4, 3, 2)
+    # 4-axis transpose = full permute -> (5, 4, 3, 2)
     out = t.transpose(3, 2, 1, 0)
     assert out.shape == (5, 4, 3, 2)
 

--- a/tests/test_pr_a_deep_components.py
+++ b/tests/test_pr_a_deep_components.py
@@ -14,11 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
-PR-A deeper component exercises: trainer, compile discovery,
-cce backward, and quantization helpers — beyond just imports.
-
-If a test fails, the failing component identifies the next gap.
+"""PR-A deeper component exercises beyond imports: trainer, compile discovery,
+cce backward, and quantization helpers. A failing test names the next gap.
 """
 
 from __future__ import annotations

--- a/tests/test_pr_a_dequantize.py
+++ b/tests/test_pr_a_dequantize.py
@@ -17,13 +17,10 @@
 """
 PR-A integration: exercise unsloth_zoo.mlx.loader._dequantize_selected_mlx_modules.
 
-Builds a synthetic MLX-style model with one QuantizedLinear submodule,
-runs PR-A's dequantize-and-replace helper, verifies the result is
-a numerically correct nn.Linear with the dequantized weight.
-
-This is the canonical PR-A code path: load_in_4bit=False (or
-selective requantize) walks named_modules, finds QuantizedLinear,
-calls mx.dequantize with mode='affine', and swaps in nn.Linear.
+Builds a synthetic model with one QuantizedLinear, runs the
+dequantize-and-replace helper, and verifies the result is a numerically
+correct nn.Linear. This is the canonical PR-A path: walk named_modules, find
+QuantizedLinear, mx.dequantize with mode='affine', swap in nn.Linear.
 """
 
 from __future__ import annotations

--- a/tests/test_pr_a_imports.py
+++ b/tests/test_pr_a_imports.py
@@ -14,12 +14,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
-PR-A integration: verify every MLX-using unsloth_zoo module imports
-under the shim and exposes the symbols PR-B's Studio code calls.
-
-If a test fails with `_Noop` / NotImplementedError, the failing symbol
-identifies a TODO in mlx_simulation/.
+"""PR-A integration: every MLX-using unsloth_zoo module imports under the shim
+and exposes the symbols PR-B's Studio code calls. A `_Noop` /
+NotImplementedError failure points at a TODO in mlx_simulation/.
 """
 
 from __future__ import annotations
@@ -85,17 +82,16 @@ def test_full_finetune_dtype_default_matches_torch_bf16():
 
 
 def test_fast_mlx_model_save_helpers_exist():
-    """PR-B calls model.save_pretrained_merged / save_lora_adapters /
-    push_to_hub_merged on the FastMLXModel INSTANCE returned by
-    FastMLXModel.from_pretrained.  The helpers are module-level in
-    loader.py and attached via types.MethodType after load.
+    """PR-B calls save_pretrained_merged / save_lora_adapters / push_to_hub_merged
+    on the FastMLXModel instance; the helpers are module-level in loader.py and
+    attached via types.MethodType after load.
     """
     import unsloth_zoo.mlx.loader as ml
-    # The free functions must exist:
+    # Free functions must exist.
     assert hasattr(ml, "_mlx_save_pretrained_merged")
     assert hasattr(ml, "_mlx_save_lora_adapters")
     assert hasattr(ml, "_mlx_push_to_hub_merged")
-    # And the underlying utils targets:
+    # And the underlying utils targets.
     import unsloth_zoo.mlx.utils as mu
     assert hasattr(mu, "save_pretrained_merged")
     assert hasattr(mu, "save_lora_adapters")
@@ -196,14 +192,12 @@ def test_gated_delta_vjp_imports():
 def test_trainer_config_smoke():
     """MLXTrainingConfig should construct with sane defaults."""
     from unsloth_zoo.mlx.trainer import MLXTrainingConfig
-    # Try the default constructor — many MLX configs require keyword args.
     import dataclasses
     try:
         cfg = MLXTrainingConfig()
         ok = True
     except TypeError:
-        # Required positional/keyword args; that's fine for now.
-        # We just want the class to be inspectable.
+        # Required args are fine; we only need the class to be inspectable.
         ok = dataclasses.is_dataclass(MLXTrainingConfig) or True
     assert ok
 

--- a/tests/test_pypi_version_sync.py
+++ b/tests/test_pypi_version_sync.py
@@ -41,17 +41,13 @@ PYPI_JSON_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 
 
 def _parse_version(value: str):
-    """Best-effort PEP 440 parser. Falls back to packaging.version if
-    available; otherwise a lexicographic numeric-aware split that's
-    safe for the simple `X.Y.Z[.devN|rcN|postN]` shape zoo uses.
-    """
+    """Best-effort PEP 440 parser; uses packaging.version, else a numeric-aware
+    split safe for the simple X.Y.Z[.devN|rcN|postN] shape zoo uses."""
     try:
         from packaging.version import Version
         return Version(value)
     except Exception:
-        # Tuple of ints + suffix string -- monotonically orderable for
-        # versions of the same shape. Good enough for the simple bump
-        # case this test guards against.
+        # Int tuple, orderable for same-shape versions; enough for simple bumps.
         parts = value.split("+", 1)[0].split("-", 1)[0]
         nums, _, _suffix = parts.partition("rc")
         ints = []
@@ -64,11 +60,8 @@ def _parse_version(value: str):
 
 
 def _get_pypi_latest_version(timeout: float = 10.0):
-    """Fetch the latest published version of unsloth_zoo from PyPI's
-    JSON API. Returns None on network failure (we skip the test
-    rather than fail it -- the gate only matters when PyPI is
-    reachable).
-    """
+    """Fetch unsloth_zoo's latest published version from PyPI's JSON API;
+    returns None on network failure so the test skips rather than fails."""
     request = urllib.request.Request(
         PYPI_JSON_URL,
         headers = {"User-Agent": "unsloth-zoo-ci/test_pypi_version_sync"},
@@ -86,18 +79,13 @@ def _get_pypi_latest_version(timeout: float = 10.0):
 
 
 def _get_main_version():
-    """Read the `__version__` attribute zoo's setuptools dynamic
-    metadata reads from `unsloth_zoo/__init__.py`. We do this WITHOUT
-    importing `unsloth_zoo` because importing the package on a
-    CI runner without CUDA / XPU / HIP fires the device-type
-    detection which is intercepted by tests/conftest.py only when
-    pytest is collecting -- safer to read the source file directly.
-    """
+    """Read `__version__` from unsloth_zoo/__init__.py WITHOUT importing the
+    package: importing on a CI runner without CUDA/XPU/HIP fires device-type
+    detection, so reading the source file directly is safer."""
     import pathlib
     import re
 
-    # __file__ is .../<repo-root>/tests/test_pypi_version_sync.py
-    # so the repo root is parents[1] (parents[0] = tests/).
+    # repo root is parents[1] (parents[0] = tests/).
     repo_root = pathlib.Path(__file__).resolve().parents[1]
     init_py = repo_root / "unsloth_zoo" / "__init__.py"
     text = init_py.read_text(encoding = "utf-8")

--- a/tests/test_quantize_gguf_q2_k_l.py
+++ b/tests/test_quantize_gguf_q2_k_l.py
@@ -74,9 +74,8 @@ def test_q2_k_l_expands_to_q2_k_with_dynamic_recipe(monkeypatch):  # noqa: D401
 
     cmd = captured["cmd"]
     assert isinstance(cmd, str), f"command should be a shell string (existing convention); got {type(cmd)!r}"
-    # The literal preset name must NOT reach llama-quantize.
+    # Preset name must NOT reach llama-quantize; expanded ftype must, as a token.
     assert "q2_k_l" not in cmd, f"q2_k_l leaked into llama-quantize command: {cmd!r}"
-    # The expanded ftype must appear, as a standalone token.
     assert " q2_k " in cmd, f"q2_k token missing: {cmd!r}"
     # All four preset flags must appear.
     assert "--output-tensor-type Q6_K" in cmd, f"--output-tensor-type Q6_K missing: {cmd!r}"
@@ -93,7 +92,6 @@ def test_q2_k_l_expands_to_q2_k_with_dynamic_recipe(monkeypatch):  # noqa: D401
     assert first_tt < cmd.index("/tmp/in.gguf"), (
         f"--tensor-type must precede positional args: {cmd!r}"
     )
-    # Sanity: input/output paths and thread count are still present.
     assert "/tmp/in.gguf" in cmd
     assert "/tmp/out.gguf" in cmd
     assert " 4" in cmd, f"n_threads missing: {cmd!r}"
@@ -158,11 +156,9 @@ def test_q2_k_l_is_case_insensitive(monkeypatch):
 
 
 def test_other_quant_types_are_untouched(monkeypatch):
-    """Non-preset ftypes must traverse the original code path byte-for-byte.
+    """Non-preset ftypes traverse the original code path unchanged.
 
-    Linux + Windows non-regression: ensures the q2_k_l branch does not affect
-    any other ftype. q3_k_l is a real llama.cpp ftype distinct from q2_k_l and
-    must be passed through verbatim.
+    q3_k_l is a real llama.cpp ftype distinct from q2_k_l and must pass through verbatim.
     """
 
     llama_cpp = _load_llama_cpp_module()

--- a/tests/test_qwen_moe_lora_extractor.py
+++ b/tests/test_qwen_moe_lora_extractor.py
@@ -163,13 +163,11 @@ class _SquareWrapper:
         self.parameter_name = parameter_name
         self.base_layer = type("_Base", (), {})()
         if parameter_name == "down_proj":
-            # down_proj: (E, hidden_dim, intermediate_dim). Force in == out by
-            # setting intermediate_dim == hidden_dim.
+            # down_proj (E, hidden_dim, intermediate_dim): force in == out
             self.base_layer.intermediate_dim = dim
             self.base_layer.hidden_dim = dim
         elif parameter_name == "gate_up_proj":
-            # gate_up_proj: input_dim = hidden_dim, output_dim = 2*intermediate_dim.
-            # Make square by intermediate_dim = hidden_dim/2.
+            # gate_up_proj in=hidden_dim, out=2*intermediate_dim: square via intermediate_dim=hidden_dim/2
             self.base_layer.hidden_dim = dim
             self.base_layer.intermediate_dim = dim // 2
         self._did_swap_in_out_features = did_swap

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -8,12 +8,10 @@
 
 """CPU-pure unit tests for `unsloth_zoo.rl_replacements`.
 
-The GRPO replacement helpers in `rl_replacements.py` are normally
-exercised inside a torch.compile'd GRPO training step on a real
-GPU. Several of them are pure-Python / pure-torch shape ops with
-well-defined IO contracts, though: this module pins their
-behaviour with tiny CPU tensor fixtures so future refactors of
-the GRPO step cannot silently break the contract.
+The GRPO replacement helpers are normally exercised inside a torch.compile'd
+GRPO step on GPU. Several are pure-torch shape ops with well-defined IO
+contracts; this pins them with tiny CPU fixtures so refactors can't silently
+break the contract.
 
 Covers:
   - `calculate_pad_tokens_in_prompt` (left-pad counter)

--- a/tests/test_saving_utils_quant_aware_merge.py
+++ b/tests/test_saving_utils_quant_aware_merge.py
@@ -53,23 +53,21 @@ class _FakeFile:
 
 
 class _FakeMM:
-    """Stand-in for the mmap-backed safetensors output. Collects writes so
-    we can assert on them."""
+    """Stand-in for the mmap-backed safetensors output; collects writes to assert on."""
 
     def __init__(self):
         self.writes = []  # list of (key, tensor, dtype) tuples
 
 
 def _identity_merge(W, lora_stats, expert_idx, num_experts, output_dtype):
-    """Stand-in 'merge' that returns the input unchanged. Lets us pin the
-    quant-aware wrapper without depending on the real LoRA math."""
+    """Stand-in 'merge' returning input unchanged; pins the wrapper without real LoRA math."""
     return W.to(output_dtype)
 
 
 @pytest.fixture(autouse=True)
 def _stub_write_tensor_direct_torch(monkeypatch):
-    """`_write_tensor_direct_torch` does real safetensors header arithmetic on
-    a torch storage; for these tests we just capture (key, tensor, dtype)."""
+    """`_write_tensor_direct_torch` does real safetensors header arithmetic;
+    here we just capture (key, tensor, dtype)."""
     from unsloth_zoo import saving_utils
 
     def _capture(mm, header_metadata, length_of_header, key, tensor, dtype):

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -6,21 +6,14 @@
 # the Free Software Foundation, either version 3 of the License, or (at
 # your option) any later version.
 
-"""Exhaustive upstream-signature pinning for the (class, method) pairs
-that ``unsloth_zoo/temporary_patches/<file>.py`` rebinds (tail not
-covered by the sibling test_upstream_signatures /
-test_upstream_pinned_symbols_transformers / test_zoo_source_upstream_refs
-/ test_upstream_source_patterns files).
+"""Exhaustive upstream-signature pinning for (class, method) pairs that
+``unsloth_zoo/temporary_patches/<file>.py`` rebinds (tail not covered by the
+sibling test_upstream_* files).
 
-Each (model_class, method) pair below maps 1:1 to a
-``patch_function(...)`` call or attribute reassignment in zoo. Upstream
-rename / drop -> zoo's patch silently no-ops via ``raise_error()``; this
-file makes that drift loud.
-
-CPU-only; ``pytest.importorskip`` for optional libs (timm, bitsandbytes).
-Drift -> ``pytest.fail("DRIFT DETECTED: zoo temporary_patches/<file>.py
-expects <class>.<method>(<params>) but installed transformers has
-<signature>")``.
+Each pair maps 1:1 to a ``patch_function(...)`` call or attribute reassignment
+in zoo; an upstream rename/drop makes that patch silently no-op via
+``raise_error()``, and this file makes the drift loud. CPU-only;
+``pytest.importorskip`` for optional libs.
 """
 
 from __future__ import annotations
@@ -43,13 +36,9 @@ _TX_IS_5X = Version(_TX_VERSION) >= Version("5.0.0")
 
 
 def _skip_if_transformers_5x(reason: str) -> None:
-    """transformers 5.x moved many ForCausalLM.forward named params
-    (notably ``cache_position``) into ``**kwargs: Unpack[TransformersKwargs]``
-    and renamed others (``rope_theta`` -> ``rope_parameters`` on GptOssConfig).
-    The runtime patches gracefully no-op via try/except + relaxed
-    patch_function, so the drift detector serves no purpose on 5.x and
-    just blocks CI. Skip with the upstream-removal reason; keep the
-    detector active on 4.57.6 where real drift can still surface."""
+    """Skip on 5.x: it folded many forward params into ``**kwargs`` and the
+    runtime patches no-op gracefully, so the detector only blocks CI here.
+    Stays active on 4.57.6 where real drift can still surface."""
     if _TX_IS_5X:
         pytest.skip(
             f"transformers {_TX_VERSION}: {reason} (zoo patch silently "
@@ -106,13 +95,11 @@ def _original_attr_name(cls, attr: str) -> str:
 
 
 def _resolve_upstream_method(cls, method_name: str):
-    """Return UPSTREAM (unpatched) method body for cls.method_name.
+    """Return the UPSTREAM (unpatched) method body for cls.method_name.
 
-    apply_import_fixes() and temporary_patches runner monkey-patch at
-    import time, so naive ``cls.method_name`` returns zoo's
-    ``(self, *args, **kwargs)`` wrapper. Resolution order:
-      1. ``_original_<module>_<class>_<method>`` stash from patch_function.
-      2. Live attribute (caller checks _maybe_skip_if_patched if needed).
+    Zoo monkey-patches at import time, so naive ``cls.method_name`` is zoo's
+    wrapper. Prefer the ``_original_<module>_<class>_<method>`` stash, else the
+    live attribute (caller may guard via _maybe_skip_if_patched).
     """
     if not hasattr(cls, method_name):
         return None
@@ -171,12 +158,8 @@ def _assert_params_superset(
     got = _param_names(func)
     missing = [name for name in required if name not in got]
     if missing and _has_var_keyword(func):
-        # Newer transformers wrap many upstream forwards as
-        # ``(self, *args, **kwargs)`` (attention-impl dispatch, generic
-        # decorators, etc.). The zoo patch's call site stays valid because
-        # kwargs flow through verbatim; static param-name verification is
-        # not meaningful for a wrapped signature. Skip rather than emit
-        # spurious DRIFT.
+        # Newer transformers wrap forwards as ``(self, *args, **kwargs)``; kwargs
+        # flow through verbatim so static param checks aren't meaningful. Skip.
         pytest.skip(
             f"{label} is wrapped as `(self, *args, **kwargs)` on "
             f"transformers {_TX_VERSION}; static param-name verification "
@@ -721,14 +704,9 @@ def test_mxfp4_gpt_oss_experts_class_present_and_init_signature():
 
 
 def test_gpt_oss_config_class_construction_signature():
-    """gpt_oss.py:2813 replaces GptOssConfig with Old_GptOssConfig; pin
-    kwarg names (num_hidden_layers, num_local_experts, vocab_size, ...).
-
-    transformers 5.x renamed ``rope_theta`` -> ``rope_parameters``. The
-    zoo patch site (`patch_gpt_oss_config`) gates on
-    ``inspect.getsource(GptOssConfig) == Old_GptOssConfig`` and skips the
-    replacement when the 5.x version's source no longer matches, so the
-    pin is dormant on 5.x. Keep it strict on 4.57.6.
+    """gpt_oss.py:2813 replaces GptOssConfig with Old_GptOssConfig; pin kwarg
+    names. Dormant on 5.x (rope_theta -> rope_parameters; patch gates on a
+    source-match and skips), strict on 4.57.6.
     """
     _skip_if_transformers_5x(
         "GptOssConfig.__init__ renamed rope_theta -> rope_parameters"
@@ -1848,15 +1826,9 @@ def test_misc_all_attention_functions_modeling_utils_top_level():
 
 
 def test_misc_modernbert_model_update_attention_mask_present():
-    """misc.py:662 patches
-    ``ModernBertModel._update_attention_mask`` (SDPA-stride fix).
-
-    transformers 5.x removed ``_update_attention_mask`` from
-    ModernBertModel (mask construction moved into the central
-    masking-utils path). zoo's patch site is fully guarded
-    (`misc.py:644-678`: import try/except + `getattr(..., None)` on
-    both the class and the method), so the SDPA-stride fix silently
-    no-ops on 5.x. Skip the drift here, keep it strict on 4.57.6.
+    """misc.py:662 patches ``ModernBertModel._update_attention_mask`` (SDPA-stride
+    fix). Removed on 5.x (mask moved into masking-utils); zoo's patch is fully
+    guarded so it no-ops there. Skip on 5.x, strict on 4.57.6.
     """
     _skip_if_transformers_5x(
         "ModernBertModel._update_attention_mask removed (mask construction "
@@ -2367,12 +2339,9 @@ def test_static_cache_class_present():
 def test_hybrid_cache_class_present():
     """gemma.py:260 isinstance(past_key_values, HybridCache).
 
-    Drift on 4.57.6: HybridCache must exist (zoo's gemma mask path
-    dispatches isinstance against it). Drift on 5.x: HybridCache was
-    removed; zoo's utils.py falls back to ``HybridCache = typing.Any``
-    and ``HAS_HYBRID_CACHE = False``, and gemma.py:260 gates the
-    isinstance on the flag so the runtime no-ops cleanly without
-    raising ``TypeError: isinstance() arg 2 must be a type``.
+    4.57.6: HybridCache must exist. 5.x: it was removed; zoo's utils.py falls
+    back to ``HybridCache = typing.Any`` / ``HAS_HYBRID_CACHE = False`` and
+    gemma.py:260 gates the isinstance on the flag, so it no-ops cleanly.
     """
     cu = importlib.import_module("transformers.cache_utils")
     from unsloth_zoo.temporary_patches.utils import HAS_HYBRID_CACHE

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -8,29 +8,15 @@
 
 """Import-smoke regression suite for `unsloth_zoo.temporary_patches`.
 
-The temporary-patches subsystem is the model-specific monkey-patch
-layer that lands ahead of upstream HF/TRL changes. It has 22
-submodules (one per model family) and an `__init__.py` that
-star-imports every one of them. A broken decorator or top-level
-syntax error in ANY submodule cascades into the whole package
-failing to import, which is exactly what zoo's downstream users
-hit at training time -- a confusing `ImportError: cannot import
-name 'PatchUnsloth_GPT_OSS_Triton'` rather than the actual file
-that broke.
-
-This suite pins that contract:
-
+The subsystem star-imports every model-family submodule from __init__.py, so
+a broken decorator or syntax error in any one cascades into a confusing
+package-wide ImportError at training time. This suite pins:
   - Every submodule imports cleanly.
-  - The `__init__.py` star-import chain succeeds (so
-    `from unsloth_zoo.temporary_patches import *` doesn't blow up).
-  - `temporary_patches.common.torch_compile_options` is a dict
-    (rl_replacements.py imports it at module top, so a contract
-    break here breaks RL training too).
+  - The __init__.py star-import chain succeeds.
+  - `common.torch_compile_options` is a dict (rl_replacements.py imports it
+    at module top, so a break here breaks RL training too).
 
-Runs under the GPU-free harness in `tests/conftest.py` which
-pre-loads `unsloth_zoo.device_type` under a mocked
-`torch.cuda.is_available()`. No GPU required; no actual model
-forward pass.
+Runs under the GPU-free harness in tests/conftest.py; no GPU required.
 """
 
 from __future__ import annotations
@@ -41,10 +27,8 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
-# Per-submodule import smoke. One parametrize per file under
-# unsloth_zoo/temporary_patches/. New files added there should land on
-# this list -- the suite is intentionally explicit (not a glob) so a
-# silent drop or rename surfaces as a missing test, not a green CI.
+# Per-submodule import smoke. Explicit (not a glob) so a silent drop or rename
+# surfaces as a missing test; new files must be added to this list.
 # ---------------------------------------------------------------------------
 
 
@@ -82,20 +66,14 @@ def test_temporary_patches_submodule_imports(module_path):
 
 
 def test_temporary_patches_star_import_chain():
-    """`unsloth_zoo.temporary_patches.__init__` star-imports every
-    submodule above. If ANY submodule blows up at import time, the
-    star-import chain fails wholesale and downstream `from
-    unsloth_zoo.temporary_patches import *` users get a wall of red.
-    """
+    """The __init__ star-imports every submodule; if any blows up at import,
+    downstream `from unsloth_zoo.temporary_patches import *` fails wholesale."""
     importlib.import_module("unsloth_zoo.temporary_patches")
 
 
 def test_torch_compile_options_is_dict():
-    """`temporary_patches.common.torch_compile_options` is imported
-    by `unsloth_zoo.rl_replacements` at module top level. If the
-    contract changes from dict to None / callable / removed, every
-    @torch.compile decorator in rl_replacements.py breaks at import.
-    """
+    """`common.torch_compile_options` is imported by rl_replacements at module
+    top; a non-dict contract breaks every @torch.compile decorator there."""
     from unsloth_zoo.temporary_patches import common
     assert hasattr(common, "torch_compile_options"), (
         "common.torch_compile_options removed -- rl_replacements.py "
@@ -111,11 +89,8 @@ def test_torch_compile_options_is_dict():
 
 
 def test_temporary_patches_submodule_list_is_complete():
-    """The hand-maintained TEMPORARY_PATCHES_SUBMODULES list above
-    must stay in sync with the actual files on disk. A new
-    submodule added to the directory without being added here would
-    silently bypass the per-submodule import smoke above.
-    """
+    """TEMPORARY_PATCHES_SUBMODULES must stay in sync with files on disk; a new
+    submodule not added here would silently bypass the import smoke above."""
     import unsloth_zoo.temporary_patches as tp
     import pathlib
 

--- a/tests/test_unsloth_zoo_lora_merge.py
+++ b/tests/test_unsloth_zoo_lora_merge.py
@@ -14,20 +14,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
-Tier 0 LoRA merge correctness tests for unsloth_zoo/saving_utils.py.
+"""Tier 0 LoRA merge correctness tests for unsloth_zoo/saving_utils.py.
 
-These run on Linux+CUDA without any MLX shim.  They exercise:
-
-1. _active_merge_device() returns the active accelerator family string
-   (cuda on a CUDA host).  This is the recently-pushed fix that replaced
-   the W-based helper which leaked device indices across device types.
-2. _merge_lora computes  W + alpha * lora_B @ lora_A  with the right
-   shapes, dtypes, and device placement.
-3. _merge_lora handles the vocab-resize case (lora_B taller than W).
-4. _merge_lora raises on non-finite values.
-5. The 5 MoE expert-merge variants compute the correct per-expert
-   updates against a numpy reference.
+Run on Linux+CUDA without an MLX shim. Cover _active_merge_device(), _merge_lora
+(base merge, vocab-resize, non-finite guard), and the 5 MoE expert-merge variants
+against a numpy reference.
 """
 
 from __future__ import annotations
@@ -110,11 +101,8 @@ def test_merge_lora_standard(dtype):
 def test_merge_lora_moves_cpu_inputs_to_active_device():
     """W on CPU should land on the active device after _merge_lora.
 
-    Pre-fix: the W-based helper returned torch.device('cuda') (no index)
-    when W was on CPU, which delegates to current_device() — mostly
-    correct on single-GPU but unreliable on multi-GPU.
-    Post-fix: returns the string 'cuda', .to('cuda') uses current_device
-    consistently.
+    The W-based helper returned an indexless torch.device('cuda') for CPU W
+    (unreliable on multi-GPU); the fix returns the string 'cuda' instead.
     """
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -127,10 +115,7 @@ def test_merge_lora_moves_cpu_inputs_to_active_device():
 
 
 def test_merge_lora_vocab_resize():
-    """When lora_B has more rows than W, the merge expands W with zero-padding.
-
-    This path is used when fine-tuning grows the vocab (added tokens).
-    """
+    """lora_B taller than W: merge zero-pads W (vocab-grow / added-tokens path)."""
     torch.manual_seed(SEED)
     old_vocab, new_vocab, dim, rank = 100, 128, 32, 8
     alpha = 16.0

--- a/tests/test_upstream_import_fixes_drift.py
+++ b/tests/test_upstream_import_fixes_drift.py
@@ -11,13 +11,10 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 
-"""Drift detectors for the ``unsloth/import_fixes.py`` workarounds.
-
-Every test maps 1:1 to a ``fix_*`` / ``patch_*`` in ``import_fixes.py``.
-DRIFT-DETECTED framing: assert the healthy shape; surface an active
-pathology as ``pytest.fail("DRIFT DETECTED: ...")``; ``importorskip``
-genuinely optional libs. Each test cites the source-of-truth file:line.
-"""
+"""Drift detectors for the ``unsloth/import_fixes.py`` workarounds. Each test
+maps 1:1 to a ``fix_*`` / ``patch_*``: assert the healthy shape, surface an
+active pathology as pytest.fail("DRIFT DETECTED: ..."), importorskip optional
+libs. Each cites the source file:line."""
 
 from __future__ import annotations
 
@@ -32,8 +29,8 @@ from importlib.metadata import version as importlib_version
 import pytest
 
 
-# Mirrors Version() in import_fixes.py (51-68): strips dev/post/local
-# suffixes so packaging.Version handles "0.0.33.post2" / "0.15.1+cu130".
+# Mirrors Version() in import_fixes.py (51-68): strips dev/post/local suffixes
+# so packaging.Version handles "0.0.33.post2" / "0.15.1+cu130".
 from packaging.version import Version as _PkgVersion
 
 
@@ -55,9 +52,8 @@ def _safe_version(raw):
 
 
 def test_protobuf_message_factory_get_prototype_or_get_message_class_present():
-    """``fix_message_factory_issue`` (import_fixes.py 264-308). On a healthy
-    install ``MessageFactory.GetPrototype`` OR module-level
-    ``GetMessageClass`` must be reachable."""
+    """fix_message_factory_issue (import_fixes.py 264-308): healthy install has
+    ``MessageFactory.GetPrototype`` OR module-level ``GetMessageClass``."""
     mf = pytest.importorskip("google.protobuf.message_factory")
     has_mf_class = hasattr(mf, "MessageFactory")
     has_get_prototype = has_mf_class and hasattr(
@@ -84,9 +80,9 @@ def test_protobuf_message_factory_get_prototype_or_get_message_class_present():
 
 
 def test_datasets_version_not_in_broken_recursion_range():
-    """``patch_datasets`` (import_fixes.py 574-586). datasets 4.4.0-4.5.0
-    inclusive triggers ``_thread.RLock_recursion_count`` errors deep in the
-    Arrow loader; assert the installed version is outside it."""
+    """patch_datasets (import_fixes.py 574-586): datasets 4.4.0-4.5.0 triggers
+    ``_thread.RLock_recursion_count`` errors in the Arrow loader; assert the
+    installed version is outside that range."""
     pytest.importorskip("datasets")
     ds_v = _safe_version(importlib_version("datasets"))
     lo = _PkgVersion("4.4.0")
@@ -104,10 +100,10 @@ def test_datasets_version_not_in_broken_recursion_range():
 
 
 def test_trl_is_x_available_returns_bool_not_tuple():
-    """``fix_trl_vllm_ascend`` (import_fixes.py 493-516). transformers
-    >=4.48's ``_is_package_available`` returns ``(bool, version)``; TRL
-    caches that tuple as truthy, firing unconditional ``import vllm``.
-    Healthy state: every ``is_*_available()`` returns a real bool."""
+    """fix_trl_vllm_ascend (import_fixes.py 493-516): transformers >=4.48's
+    ``_is_package_available`` returns ``(bool, version)``; TRL caches that
+    tuple as truthy and fires unconditional ``import vllm``. Healthy: every
+    ``is_*_available()`` returns a real bool."""
     pytest.importorskip("trl")
     try:
         import trl.import_utils as tiu
@@ -154,9 +150,9 @@ def test_trl_is_x_available_returns_bool_not_tuple():
 
 
 def test_trl_cached_available_flags_are_not_tuples():
-    """``fix_trl_vllm_ascend`` (import_fixes.py 493-516). Same pathology
-    as above but checks the module-level cached ``_*_available`` attrs --
-    this is where the tuple drift actually lives."""
+    """fix_trl_vllm_ascend (import_fixes.py 493-516): same pathology, checked
+    on the module-level cached ``_*_available`` attrs where the tuple drift
+    actually lives."""
     pytest.importorskip("trl")
     try:
         import trl.import_utils as tiu
@@ -183,16 +179,12 @@ def test_trl_cached_available_flags_are_not_tuples():
 
 
 def test_pretrained_model_enable_input_require_grads_uses_old_pattern():
-    """``patch_enable_input_require_grads`` (import_fixes.py 609-670).
-    transformers PR #41993 rewrote ``enable_input_require_grads`` to
-    iterate ``for module in self.modules()`` and call
-    ``module.get_input_embeddings()``, which raises NotImplementedError
-    on vision sub-modules (GLM V4.6's ``self.visual``). Healthy state:
-    either the upstream rewrite isn't present (pre-HF#41993), OR the
-    patch installed a NotImplementedError-tolerant replacement. The
-    bare ``for module in self.modules()`` check alone cannot tell the
-    two apart because unsloth's replacement deliberately also uses
-    that loop, just wrapped in ``try / except NotImplementedError``."""
+    """patch_enable_input_require_grads (import_fixes.py 609-670): HF PR #41993
+    rewrote ``enable_input_require_grads`` to iterate ``self.modules()`` and
+    call ``get_input_embeddings()``, which raises NotImplementedError on vision
+    submodules (GLM V4.6's ``self.visual``). Healthy: either the rewrite is
+    absent (pre-#41993) OR the tolerant replacement (the same loop wrapped in
+    ``try/except NotImplementedError``) is installed."""
     pytest.importorskip("transformers")
     from transformers import PreTrainedModel
 
@@ -216,10 +208,9 @@ def test_pretrained_model_enable_input_require_grads_uses_old_pattern():
 
 
 def test_transformers_torchcodec_available_flag_is_present():
-    """``disable_torchcodec_if_broken`` (import_fixes.py 1291-1317). Needs
-    either the pre-5.x module-level ``_torchcodec_available`` flag, or
-    the 5.x ``is_torchcodec_available`` public function; one of the two
-    is the patch site the fix monkey-patches when FFmpeg is missing."""
+    """disable_torchcodec_if_broken (import_fixes.py 1291-1317): needs the
+    pre-5.x ``_torchcodec_available`` flag OR the 5.x
+    ``is_torchcodec_available`` function -- the patch site for missing FFmpeg."""
     tf_iu = pytest.importorskip("transformers.utils.import_utils")
     has_flag = hasattr(tf_iu, "_torchcodec_available")
     has_func = callable(getattr(tf_iu, "is_torchcodec_available", None))
@@ -233,10 +224,9 @@ def test_transformers_torchcodec_available_flag_is_present():
 
 
 def test_transformers_is_causal_conv1d_available_symbol_present():
-    """``_disable_transformers_causal_conv1d`` (import_fixes.py 1881-1895).
-    Needs at least one of ``is_causal_conv1d_available`` /
-    ``_causal_conv1d_available`` / ``_is_causal_conv1d_available`` to
-    mask a broken-binary causal_conv1d install."""
+    """_disable_transformers_causal_conv1d (import_fixes.py 1881-1895): needs
+    one of is_causal_conv1d_available / _causal_conv1d_available /
+    _is_causal_conv1d_available to mask a broken causal_conv1d binary."""
     tf_iu = pytest.importorskip("transformers.utils.import_utils")
     candidates = [
         "is_causal_conv1d_available",
@@ -258,10 +248,9 @@ def test_transformers_is_causal_conv1d_available_symbol_present():
 
 
 def test_transformers_and_accelerate_is_wandb_available_callable():
-    """``disable_broken_wandb`` (import_fixes.py 1320-1372). Patches
+    """disable_broken_wandb (import_fixes.py 1320-1372): patches
     ``is_wandb_available`` on transformers.integrations.integration_utils,
-    accelerate.utils.imports, AND accelerate.utils (a protobuf mismatch
-    can make ``import wandb`` raise). All three locations must exist."""
+    accelerate.utils.imports, AND accelerate.utils. All three must exist."""
     pytest.importorskip("transformers")
     pytest.importorskip("accelerate")
     from transformers.integrations import integration_utils as tf_integration
@@ -290,12 +279,11 @@ def test_transformers_and_accelerate_is_wandb_available_callable():
 
 
 def test_peft_transformers_weight_conversion_importable_and_signature():
-    """``patch_peft_weight_converter_compatibility`` (import_fixes.py
-    1375-1454). Wraps ``build_peft_weight_mapping`` to retrofit
-    ``distributed_operation`` / ``quantization_operation`` kwargs;
-    must import cleanly AND keep
-    ``(weight_conversions, adapter_name, peft_config=None)``. An
-    unimportable module IS drift -- the fix's bare except silently no-ops."""
+    """patch_peft_weight_converter_compatibility (import_fixes.py 1375-1454):
+    wraps ``build_peft_weight_mapping`` to retrofit distributed/quantization
+    operation kwargs; must import cleanly AND keep ``(weight_conversions,
+    adapter_name, peft_config=None)``. An unimportable module IS drift (the
+    fix's bare except silently no-ops)."""
     pytest.importorskip("peft")
     try:
         from peft.utils import transformers_weight_conversion as twc
@@ -325,18 +313,17 @@ def test_peft_transformers_weight_conversion_importable_and_signature():
 
 
 def test_triton_compiled_kernel_has_num_ctas_and_cluster_dims():
-    """``fix_triton_compiled_kernel_missing_attrs`` (import_fixes.py
-    923-968). triton 3.6.0+ dropped ``num_ctas`` / ``cluster_dims`` on
-    CompiledKernel but torch 2.9.x Inductor still eagerly evaluates them
-    -- without the fix torch.compile paths blow up before reaching the
-    new launch contract."""
+    """fix_triton_compiled_kernel_missing_attrs (import_fixes.py 923-968):
+    triton 3.6.0+ dropped ``num_ctas`` / ``cluster_dims`` on CompiledKernel
+    but torch 2.9.x Inductor still eagerly evaluates them, so torch.compile
+    blows up without the fix."""
     pytest.importorskip("torch")
     triton_mod = pytest.importorskip("triton")  # noqa: F841
     tc = pytest.importorskip("triton.compiler.compiler")
 
     ck_cls = tc.CompiledKernel
-    # Healthy if either: pre-3.6 class attr present, or unsloth wrapped
-    # ``__init__`` to install num_ctas + cluster_dims per instance.
+    # Healthy if the pre-3.6 class attr is present, or unsloth wrapped
+    # __init__ to install num_ctas + cluster_dims per instance.
     if hasattr(ck_cls, "num_ctas"):
         return
     init = getattr(ck_cls, "__init__", None)
@@ -389,9 +376,8 @@ def _is_custom_torch_build(raw_version_str):
 
 
 def test_installed_torch_torchvision_pair_is_compatible():
-    """``torchvision_compatibility_check`` (import_fixes.py 708-798).
-    Mirrors the upstream compat table; custom or prerelease builds get
-    downgraded to a warning, so this test skips for those."""
+    """torchvision_compatibility_check (import_fixes.py 708-798): mirrors the
+    upstream compat table; skips custom/prerelease builds (warning-only there)."""
     pytest.importorskip("torch")
     pytest.importorskip("torchvision")
 
@@ -438,10 +424,9 @@ def test_installed_torch_torchvision_pair_is_compatible():
 
 
 def test_vllm_guided_decoding_params_or_structured_outputs_present():
-    """``fix_vllm_guided_decoding_params`` (import_fixes.py 446-490).
-    vLLM PR #22772 renamed ``GuidedDecodingParams`` ->
-    ``StructuredOutputsParams``; trl still imports the old name so the
-    fix re-aliases. At least one must exist at module load."""
+    """fix_vllm_guided_decoding_params (import_fixes.py 446-490): vLLM PR #22772
+    renamed ``GuidedDecodingParams`` -> ``StructuredOutputsParams``; trl still
+    imports the old name so the fix re-aliases. At least one must exist."""
     pytest.importorskip("vllm")
     try:
         sp = importlib.import_module("vllm.sampling_params")
@@ -465,9 +450,8 @@ def test_vllm_guided_decoding_params_or_structured_outputs_present():
 
 
 def test_vllm_aimv2_ovis_config_is_past_fix_version():
-    """``fix_vllm_aimv2_issue`` (import_fixes.py 404-443). vLLM < 0.10.1
-    has an Ovis config that unconditionally
-    ``AutoConfig.register("aimv2", AIMv2Config)`` and trips
+    """fix_vllm_aimv2_issue (import_fixes.py 404-443): vLLM < 0.10.1's Ovis
+    config unconditionally ``AutoConfig.register("aimv2", ...)`` and trips
     ``ValueError: 'aimv2' is already used by a Transformers config``."""
     pytest.importorskip("vllm")
     vllm_v = _safe_version(importlib_version("vllm"))
@@ -486,10 +470,9 @@ def test_vllm_aimv2_ovis_config_is_past_fix_version():
 
 
 def test_huggingface_hub_is_offline_mode_or_hf_hub_offline_present():
-    """``fix_huggingface_hub`` (import_fixes.py 913-920). huggingface_hub
-    removed the top-level ``is_offline_mode()`` helper; unsloth
-    re-injects it from ``huggingface_hub.constants.HF_HUB_OFFLINE``. At
-    least one of the two must still exist."""
+    """fix_huggingface_hub (import_fixes.py 913-920): huggingface_hub removed
+    top-level ``is_offline_mode()``; unsloth re-injects it from
+    ``huggingface_hub.constants.HF_HUB_OFFLINE``. At least one must exist."""
     hub = pytest.importorskip("huggingface_hub")
     has_top_level = False
     try:
@@ -518,9 +501,9 @@ def test_huggingface_hub_is_offline_mode_or_hf_hub_offline_present():
 
 
 def test_torch_nn_init_trunc_normal_exists():
-    """``patch_trunc_normal_precision_issue`` (import_fixes.py 971-1050).
-    The fp16/bf16 stability wrapper monkey-patches
-    ``torch.nn.init.trunc_normal_``; a rename silently fails the install."""
+    """patch_trunc_normal_precision_issue (import_fixes.py 971-1050): the
+    fp16/bf16 stability wrapper monkey-patches ``torch.nn.init.trunc_normal_``;
+    a rename silently fails the install."""
     pytest.importorskip("torch")
     import torch.nn.init as init_mod
 
@@ -536,9 +519,8 @@ def test_torch_nn_init_trunc_normal_exists():
 
 
 def test_xformers_is_post_num_splits_key_fix_or_not_installed():
-    """``fix_xformers_performance_issue`` (import_fixes.py 312-341).
-    xformers < 0.0.29 has the ``num_splits_key=-1`` perf bug that
-    unsloth rewrites at install time."""
+    """fix_xformers_performance_issue (import_fixes.py 312-341): xformers <
+    0.0.29 has the ``num_splits_key=-1`` perf bug unsloth rewrites at install."""
     if importlib.util.find_spec("xformers") is None:
         pytest.skip("xformers not installed -- nothing to drift-check.")
     x_v = _safe_version(importlib_version("xformers"))
@@ -557,9 +539,9 @@ def test_xformers_is_post_num_splits_key_fix_or_not_installed():
 
 
 def test_transformers_pretrained_model_has_get_input_embeddings():
-    """``patch_enable_input_require_grads`` (import_fixes.py 609-670).
-    The replacement function calls ``module.get_input_embeddings()`` on
-    every submodule; a rename breaks the replacement."""
+    """patch_enable_input_require_grads (import_fixes.py 609-670): the
+    replacement calls ``module.get_input_embeddings()`` on every submodule;
+    a rename breaks it."""
     pytest.importorskip("transformers")
     from transformers import PreTrainedModel
 
@@ -575,9 +557,9 @@ def test_transformers_pretrained_model_has_get_input_embeddings():
 
 
 def test_accelerate_utils_imports_module_present():
-    """``disable_broken_wandb`` + ``fix_trl_vllm_ascend`` (import_fixes.py
-    493-516, 1320-1372). Both reach into ``accelerate.utils.imports``;
-    a restructuring silently no-ops the monkey-patches."""
+    """disable_broken_wandb + fix_trl_vllm_ascend (import_fixes.py 493-516,
+    1320-1372): both reach into ``accelerate.utils.imports``; a restructuring
+    silently no-ops the monkey-patches."""
     pytest.importorskip("accelerate")
     mod = pytest.importorskip("accelerate.utils.imports")
     # is_wandb_available is the representative symbol disable_broken_wandb targets.

--- a/tests/test_upstream_pinned_symbols_transformers.py
+++ b/tests/test_upstream_pinned_symbols_transformers.py
@@ -94,10 +94,9 @@ def _first_match(repo: str, ref: str, paths: list[str]) -> tuple[str, str] | Non
     return None
 
 
-# Gemma3 attention surface, zoo PR #635 / #488 / #571.
-# unsloth_zoo/temporary_patches/gemma.py imports Gemma3Attention,
-# Gemma3RMSNorm, Gemma3MLP, Gemma3TextScaledWordEmbedding plus
-# apply_rotary_pos_emb / ALL_ATTENTION_FUNCTIONS / eager_attention_forward.
+# Gemma3 attention surface, zoo PR #635 / #488 / #571. gemma.py imports
+# Gemma3Attention/RMSNorm/MLP/TextScaledWordEmbedding plus apply_rotary_pos_emb
+# / ALL_ATTENTION_FUNCTIONS / eager_attention_forward.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
@@ -175,9 +174,9 @@ def test_ministral_attention_module_present(tag: str):
 
 
 # gpt_oss MoE patch surface, zoo PR #525 / #472 / #471 / #470 / #467.
-# gpt_oss.py reads transformers.models.gpt_oss.modeling_gpt_oss.{
-# GptOssExperts, GptOssTopKRouter, GptOssAttention, GptOssModel,
-# GptOssPreTrainedModel} and reassigns .GptOssExperts.forward.
+# gpt_oss.py reads modeling_gpt_oss.{GptOssExperts, GptOssTopKRouter,
+# GptOssAttention, GptOssModel, GptOssPreTrainedModel} and reassigns
+# .GptOssExperts.forward.
 
 
 @pytest.mark.parametrize("tag", TRANSFORMERS_TAGS)
@@ -224,8 +223,8 @@ def test_qwen3_moe_required_classes(tag: str):
     )
     if src is None:
         pytest.skip(f"{tag}: modeling_qwen3_moe.py not present")
-    # Qwen3MoeSparseMoeBlock: stable across the entire support window
-    # (zoo qwen3_moe.py:215 + L337-L340 read it).
+    # Qwen3MoeSparseMoeBlock: stable across the support window
+    # (qwen3_moe.py:215 + L337-L340 read it).
     assert _has_def(src, "Qwen3MoeSparseMoeBlock", "class"), (
         f"{tag}: class Qwen3MoeSparseMoeBlock missing; "
         f"unsloth_zoo/temporary_patches/qwen3_moe.py forward / LoRA "

--- a/tests/test_upstream_signatures.py
+++ b/tests/test_upstream_signatures.py
@@ -6,15 +6,11 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-"""Signature pins for upstream functions / methods ``unsloth_zoo``
-monkey-patches, wraps, or calls with positional shape assumptions.
-
-DRIFT-DETECTED framing: each test uses ``inspect.signature(...)`` on the
-INSTALLED upstream symbol and asserts the parameter list the matching
-zoo override assumes. Real drift -> ``pytest.fail("DRIFT DETECTED:
-...")``; optional deps gated with ``pytest.importorskip``. Source-of-truth
-zoo callsite cited in every docstring.
-"""
+"""Signature pins for upstream functions/methods that unsloth_zoo patches,
+wraps, or calls with positional assumptions. Each test inspects the INSTALLED
+symbol and asserts the params the zoo override assumes; real drift ->
+pytest.fail("DRIFT DETECTED: ..."), optional deps gated by importorskip. The
+zoo callsite is cited in every docstring."""
 
 from __future__ import annotations
 
@@ -34,11 +30,8 @@ except Exception:
 
 
 def _skip_if_transformers_5x(reason: str) -> None:
-    """Skip when transformers 5.x removed the named param the drift
-    detector anchors on. The companion zoo patch wraps with **kwargs
-    via patch_function(match_level='relaxed'), so the runtime call
-    still works -- the source-string anchor just isn't there to probe.
-    Keep the detector strict on 4.57.6."""
+    """Skip on transformers 5.x (zoo patch wraps via **kwargs relaxed
+    match, so runtime still works); keep the detector strict on 4.57.6."""
     if _TX_IS_5X:
         pytest.skip(
             f"transformers {_TX_VERSION}: {reason} (zoo patch silently "
@@ -66,8 +59,7 @@ def _assert_params_superset(
     zoo_callsite: str,
 ):
     """Assert every name in ``required`` appears in ``func``'s params.
-    Upstream may add NEW params (zoo just won't forward them) but MUST
-    NOT drop a param that zoo forwards by name."""
+    Upstream may add params, but must not drop one zoo forwards by name."""
     got = _param_names(func)
     missing = [name for name in required if name not in got]
     if missing:
@@ -83,8 +75,8 @@ def _assert_positional_arity_at_least(
     arity: int,
     zoo_callsite: str,
 ):
-    """Assert ``func`` accepts >= ``arity`` non-self positionals. Catches
-    ``super().forward(a, b, c, d)`` when upstream dropped a positional."""
+    """Assert ``func`` accepts >= ``arity`` non-self positionals (catches a
+    dropped upstream positional in ``super().forward(...)``)."""
     sig = inspect.signature(func)
     params = list(sig.parameters.values())
     if params and params[0].name in ("self", "cls"):
@@ -104,8 +96,7 @@ def _assert_positional_arity_at_least(
         )
 
 
-# Single module-level importorskip so missing transformers gives one
-# clean failure instead of N hard import errors.
+# Module-level importorskip: one clean skip if transformers is missing.
 pytest.importorskip("transformers")
 
 
@@ -647,21 +638,14 @@ def test_Gemma3nModel_get_placeholder_mask_signature():
 # ===========================================================================
 
 def test_MinistralAttention_forward_signature():
-    """ministral.py:99 patches MinistralAttention.forward with
-    match_level='relaxed'. Pin ``hidden_states``,
-    ``position_embeddings``, ``attention_mask``.
+    """ministral.py:99 patches MinistralAttention.forward (relaxed). Pin
+    hidden_states / position_embeddings / attention_mask.
 
-    Zoo's patch wraps the actual implementation with
-    ``def forward(self, *args, **kwargs): return _full_forward(...)``
-    so ``check_args_kwargs`` accepts removed params on 5.x. After the
-    wrap, ``inspect.signature(MinistralAttention.forward)`` is the
-    generic wrapper. The pre-wrap implementation (with the real named
-    params) is stashed under
-    ``_original_modeling_ministral_MinistralAttention_forward``; probe
-    that when it exists, else fall back to the live attr. If the live
-    attr is the relaxed wrapper, the named-param probe isn't applicable
-    -- the runtime call still works because the wrapper forwards via
-    kwargs.
+    The relaxed wrap turns the live signature into (self, *args, **kwargs), so
+    probe the pre-wrap impl stashed under
+    ``_original_modeling_ministral_MinistralAttention_forward`` when present;
+    if only the wrapper is available the named-param probe doesn't apply
+    (runtime still works via kwargs forwarding).
     """
     try:
         from transformers.models.ministral.modeling_ministral import (
@@ -956,8 +940,8 @@ def test_CsmForConditionalGeneration_merge_input_ids_signature():
 
 def test_MllamaVisionEncoderLayer_forward_signature():
     """misc.py:1146-1172 -- ``MllamaVisionEncoderLayer.forward(self,
-    hidden_state, attention_mask=None)``. NOTE: upstream uses
-    ``hidden_state`` (singular), not ``hidden_states``."""
+    hidden_state, attention_mask=None)``. Upstream uses ``hidden_state``
+    (singular), not ``hidden_states``."""
     try:
         from transformers.models.mllama.modeling_mllama import (
             MllamaVisionEncoderLayer,
@@ -979,10 +963,9 @@ def test_MllamaVisionEncoderLayer_forward_signature():
 # ===========================================================================
 
 def test_SiglipEncoderLayer_forward_signature():
-    """misc.py:1187-1228 -- ``SiglipEncoderLayer.forward(self,
-    hidden_states, attention_mask, output_attentions=False)``. zoo's
-    body still references ``output_attentions`` so upstream removing it
-    leaves the patched body broken when callers stop passing it."""
+    """misc.py:1187-1228 -- ``SiglipEncoderLayer.forward(self, hidden_states,
+    attention_mask, output_attentions=False)``. zoo's body still references
+    ``output_attentions``, so upstream removing it breaks the patched body."""
     from transformers.models.siglip.modeling_siglip import SiglipEncoderLayer
     _assert_params_superset(
         SiglipEncoderLayer.forward,
@@ -1028,11 +1011,8 @@ def test_Qwen3VLMoeTextSparseMoeBlock_forward_signature():
 
 
 def test_Qwen3VLMoeTextExperts_forward_signature():
-    """qwen3_vl_moe.py:376 patches ``Qwen3VLMoeTextExperts.forward``.
-    Zoo's replacement is ``(self, hidden_states, top_k_index,
-    top_k_weights)`` while upstream uses ``(hidden_states,
-    routing_weights, router_indices)``; pin only positional arity (3
-    after self)."""
+    """qwen3_vl_moe.py:376 patches ``Qwen3VLMoeTextExperts.forward``. Zoo's
+    replacement renames the params, so pin only positional arity (3 after self)."""
     try:
         from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
             Qwen3VLMoeTextExperts,

--- a/tests/test_upstream_source_patterns.py
+++ b/tests/test_upstream_source_patterns.py
@@ -13,16 +13,11 @@
 
 """Drift detectors for ``unsloth_zoo`` source-string / regex rewriters.
 
-Patches in ``unsloth_zoo/compiler.py`` and
-``unsloth_zoo/temporary_patches/*.py`` fetch upstream function source
-via ``inspect.getsource`` and ``str.replace`` / ``re.sub`` against
-literal strings. If upstream renames/refactors/reflows the targeted
-region, the rewriter silently no-ops and the zoo patch becomes invisible.
-
-DRIFT-DETECTED framing: when the pinned string / regex is gone, fire
-``pytest.fail("DRIFT DETECTED: zoo source-rewriter at <zoo file:line>
-expects '<pattern>' in <upstream module>, not found")``. Each test
-cites the zoo file:line it pins.
+Patches in ``unsloth_zoo/compiler.py`` and ``temporary_patches/*.py`` rewrite
+upstream source via ``inspect.getsource`` + ``str.replace`` / ``re.sub`` on
+literal strings; if upstream reflows the target, the rewriter silently no-ops.
+Each test pins the zoo file:line and fails with a "DRIFT DETECTED" message when
+its pinned pattern is gone.
 """
 
 from __future__ import annotations

--- a/tests/test_vllm_to_hf_conversion.py
+++ b/tests/test_vllm_to_hf_conversion.py
@@ -88,14 +88,13 @@ def test_extract_gdn_layers_raises_when_offsets_underivable():
 
 
 def test_extract_gdn_layers_has_bnb_quant_state_preservation():
-    # Pre-fix: merged in_proj_qkvz path only stored raw weight slices; BnB prequantized
-    # checkpoints lost quant_state metadata and were rebuilt as plain nn.Linear.
-    # Behavioral test requires real BnB; source-level check confirms the branch exists.
+    # Pre-fix: merged in_proj_qkvz stored raw weight slices; BnB prequantized
+    # checkpoints lost quant_state and were rebuilt as plain nn.Linear.
+    # Source-level check (behavioral test needs real BnB).
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.extract_gdn_layers)
     assert "bnb_quant_state" in src
-    # quant-state keys are now emitted via a helper that concatenates
-    # f"{name}.weight.quant_state"; check the prefixes and suffix separately.
+    # Quant-state keys are emitted via a helper; check prefixes + suffix.
     assert "in_proj_qkv" in src
     assert "in_proj_z" in src
     assert "in_proj_b" in src
@@ -142,7 +141,7 @@ def _config(model_type="qwen3_5", has_vision=False):
 
 def test_finalize_fixes_layer_idx_on_standard_causal_lm():
     # Pre-fix: only new_model.model.language_model.layers was traversed, so
-    # standard-LM paths kept layer_idx at the empty-model stub value.
+    # standard-LM paths kept the stub layer_idx.
     from unsloth_zoo.empty_model import finalize_huggingface_model
     model = _StandardLM(n_layers=4)
     finalize_huggingface_model(
@@ -221,9 +220,8 @@ def test_set_dtype_in_config_no_torch_dtype_deprecation():
 
 
 def test_set_dtype_in_config_writes_torch_dtype_value():
-    # set_dtype_in_config stores a JSON-safe string (e.g. "float16"), so that
-    # downstream config.save_pretrained() and string comparisons in
-    # patching_utils.patch_model_and_tokenizer keep working.
+    # set_dtype_in_config stores a JSON-safe string (e.g. "float16") so
+    # config.save_pretrained() and patching_utils string comparisons work.
     from transformers import PretrainedConfig
     from unsloth_zoo.hf_utils import set_dtype_in_config, dtype_from_config
     cfg = PretrainedConfig()
@@ -242,9 +240,8 @@ def test_set_dtype_in_config_accepts_string_input():
 
 
 def test_set_dtype_in_config_stores_json_safe_string():
-    # Regression: prior PR iteration stored torch.dtype objects which broke
-    # config.save_pretrained() (JSON serialization) and string equality against
-    # "float16"/"bfloat16"/"float32" in patching_utils.patch_model_and_tokenizer.
+    # Regression: storing torch.dtype objects broke config.save_pretrained()
+    # JSON serialization and string equality in patching_utils.
     import json
     from transformers import PretrainedConfig
     from unsloth_zoo.hf_utils import set_dtype_in_config, dtype_from_config
@@ -264,10 +261,9 @@ def test_normalize_state_dict_tensor_guards_non_tensor():
 
 
 def test_gemma4_lora_patch_preserves_signature_for_inspect():
-    # Pre-fix: patched_create_lora_manager(model, *args, **kwargs) hid vllm_config,
-    # breaking _call_create_lora_manager's signature-based forwarding. Current
-    # fix wraps with functools.wraps and delegates to the original manager so
-    # vLLM shim kwargs reach the constructor correctly.
+    # Pre-fix: patched_create_lora_manager(model, *args, **kwargs) hid
+    # vllm_config, breaking _call_create_lora_manager's signature forwarding.
+    # Fix wraps with functools.wraps and delegates to the original manager.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
     assert "@wraps(original_create_lora_manager)" in src
@@ -276,8 +272,8 @@ def test_gemma4_lora_patch_preserves_signature_for_inspect():
 
 
 def test_gemma4_k_eq_v_patch_handles_split_kv_layout():
-    # Pre-fix: only packed self_attn.qkv_proj.weight was searched, so current upstream
-    # Gemma4 split q_proj/k_proj/v_proj layout never got synthetic V quant-state.
+    # Pre-fix: only packed self_attn.qkv_proj.weight was searched, so the
+    # upstream split q/k/v_proj Gemma4 layout never got synthetic V quant-state.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
     assert "k_proj.weight" in src and "v_proj.weight" in src
@@ -295,8 +291,8 @@ class _FakeQuantState:
 
 
 class _FakeBnBParam(torch.nn.Parameter):
-    # torch.nn.Parameter is a Tensor subclass; we attach bnb_quant_state on it
-    # so the wrapper-vs-raw-tensor distinction is preserved.
+    # Parameter is a Tensor subclass; attaching bnb_quant_state keeps the
+    # wrapper-vs-raw-tensor distinction.
     def __new__(cls, data, bnb_quant_state=None):
         inst = torch.nn.Parameter.__new__(cls, data, requires_grad=False)
         inst.bnb_quant_state = bnb_quant_state
@@ -348,8 +344,8 @@ class _FakeBnBGDN(torch.nn.Module):
 
 def test_extract_gdn_layers_emits_bnb_quant_state_for_all_shards():
     # Pre-fix: extract_gdn_layers() unwrapped Params4bit before reading
-    # `bnb_quant_state`, so the attribute was always None. Also the in_proj_ba
-    # split never emitted quant-state entries for in_proj_b/in_proj_a.
+    # `bnb_quant_state` (always None), and the in_proj_ba split emitted no
+    # quant-state for in_proj_b/in_proj_a.
     from unsloth_zoo.empty_model import extract_gdn_layers
     gdn = _FakeBnBGDN()
     state_dict, quant_state_dict = {}, {}
@@ -357,16 +353,14 @@ def test_extract_gdn_layers_emits_bnb_quant_state_for_all_shards():
     for shard in ("in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a"):
         key = f"prefix.{shard}.weight.quant_state"
         assert key in quant_state_dict, f"missing quant_state for {shard}"
-    # and the sharded companion keys from QuantState.as_dict should have been
-    # expanded into state_dict via the helper
+    # QuantState.as_dict companion keys should be expanded into state_dict.
     assert "prefix.in_proj_qkv.weight.absmax" in state_dict
     assert "prefix.in_proj_b.weight.absmax" in state_dict
 
 
 def test_assert_same_state_dict_tied_embed_fallback_has_tolerances():
-    # Pre-fix: tied-embeddings fallback used strict tolerances while the outer
-    # comparison used atol=1e-4, rtol=1e-3. Mismatched tolerances produced
-    # spurious failures.
+    # Pre-fix: tied-embeddings fallback used strict tolerances vs the outer
+    # atol=1e-4, rtol=1e-3, producing spurious failures.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.assert_same_state_dict)
     tied_idx = src.index("model.embed_tokens.weight")
@@ -387,9 +381,9 @@ def test_gemma4_lora_soft_imports_vllm_v1_worker():
 
 
 def test_conv1d_rebuild_uses_real_channels_and_groups():
-    # Pre-fix: conv1d was stacked into `layernorm_names` and rebuilt by
-    # weight-swap only, leaving the placeholder Conv1d with groups=1,
-    # kernel_size=1 which crashes on first forward.
+    # Pre-fix: conv1d was treated as a layernorm and rebuilt by weight-swap
+    # only, leaving a placeholder Conv1d(groups=1, kernel_size=1) that crashes
+    # on first forward.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
     assert '".conv1d"' in src
@@ -400,9 +394,8 @@ def test_conv1d_rebuild_uses_real_channels_and_groups():
 
 
 def test_lm_head_extraction_collapsed_to_single_path():
-    # Pre-fix: two `elif` fallbacks for vllm_internals.language_model.lm_head
-    # and vllm_internals.lm_head were dead code because named_modules() already
-    # traverses the full subtree.
+    # Pre-fix: the two lm_head elif fallbacks were dead code since
+    # named_modules() already traverses the full subtree.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils._get_vllm_state_dict)
     lm_start = src.index("# LM Head")
@@ -412,8 +405,8 @@ def test_lm_head_extraction_collapsed_to_single_path():
 
 
 def test_gemma4_kv_shared_set_uses_shared_config_helper():
-    # Keep Gemma4 config matching routed through the shared helper so text-only
-    # Gemma4 configs (model_type == "gemma4_text") are matched too.
+    # Route Gemma4 config matching through the shared helper so text-only
+    # configs (model_type == "gemma4_text") match too.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils._get_vllm_state_dict)
     assert "if _is_gemma4_config(config):" in src
@@ -440,8 +433,8 @@ def test_gemma4_k_eq_v_does_not_skip_v_proj_extraction():
 
 
 def test_merger_linear_fc_moved_to_non_layered():
-    # Pre-fix: model.visual.merger.linear_fc1/linear_fc2 (no {kk} placeholder)
-    # sat in additional_layers and were reassigned once per layer iteration.
+    # Pre-fix: model.visual.merger.linear_fc1/2 (no {kk} placeholder) sat in
+    # additional_layers and were reassigned once per layer.
     from unsloth_zoo.empty_model import get_model_layer_config
     cfg = get_model_layer_config()
     additional = set(cfg["additional_layers"])
@@ -453,9 +446,8 @@ def test_merger_linear_fc_moved_to_non_layered():
 
 
 def test_finalize_does_not_overwrite_unrelated_submodule_config_dtype():
-    # Behavioral: a submodule that carries its own config (with a distinct
-    # identity from the top-level/text/vision/audio configs) must NOT get its
-    # dtype overwritten by finalize_huggingface_model.
+    # Behavioral: a submodule with its own config (distinct identity from the
+    # top/text/vision/audio configs) must not get its dtype overwritten.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _SubConfig:
@@ -489,16 +481,16 @@ def test_finalize_does_not_overwrite_unrelated_submodule_config_dtype():
 
 
 def test_finalize_keeps_gemma4_rotary_buffers_float32_after_dtype_cast():
-    # Behavioral: on Gemma4, even after finalize casts the model to bfloat16/
-    # float16, rotary_emb buffers must remain in float32 for rotary math.
+    # Behavioral: on Gemma4, rotary_emb buffers stay float32 even after
+    # finalize casts the model to bf16/fp16.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _RotaryCfg:
         pass
 
     class _FakeRotaryEmb(torch.nn.Module):
-        # Mimics the minimal interface finalize touches: a `config` attribute
-        # plus float buffers that should survive at float32 on Gemma4.
+        # Minimal interface finalize touches: a config plus float buffers that
+        # stay float32 on Gemma4.
         def __init__(self, config=None, device=None):
             super().__init__()
             self.config = config if config is not None else _RotaryCfg()
@@ -537,8 +529,8 @@ def test_finalize_keeps_gemma4_rotary_buffers_float32_after_dtype_cast():
 
 
 def test_finalize_non_gemma4_rotary_buffers_follow_model_dtype():
-    # Behavioral sanity check: for non-Gemma4 models the rotary buffer dtype
-    # should follow the requested model dtype (buffer_dtype = dtype branch).
+    # Behavioral: non-Gemma4 rotary buffers follow the requested model dtype
+    # (buffer_dtype = dtype branch).
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _RotaryCfg:
@@ -581,8 +573,8 @@ def test_finalize_non_gemma4_rotary_buffers_follow_model_dtype():
 
 
 def test_set_dtype_in_config_else_branch_picks_correct_field():
-    # Pre-fix: the else-branch selection was inverted. This exercises the
-    # neither-attribute path explicitly.
+    # Pre-fix: the else-branch selection was inverted; exercise the
+    # neither-attribute path.
     from unsloth_zoo.hf_utils import set_dtype_in_config, HAS_TORCH_DTYPE
 
     class _Bare:
@@ -599,14 +591,14 @@ def test_set_dtype_in_config_else_branch_picks_correct_field():
 
 def test_assert_same_state_dict_ignores_quantstate_entries():
     # Behavioral: _normalize_state_dict_tensor returns None for non-tensor
-    # values like BnB QuantState dicts, and the comparison loop skips those.
-    # Previously these entries caused an AttributeError masked into failures.
+    # values (BnB QuantState dicts) and the loop skips them; previously these
+    # caused an AttributeError masked into failures.
     from unsloth_zoo.vllm_utils import assert_same_state_dict
 
     w = torch.randn(4, 4)
     old = {"x.weight": w, "x.weight.quant_state": {"some": "metadata"}}
     new = {"x.weight": w, "x.weight.quant_state": {"some": "metadata"}}
-    # Must not raise: the QuantState-shaped dict is skipped, the tensor matches.
+    # Must not raise: QuantState dict skipped, tensor matches.
     assert_same_state_dict(old, new)
 
 
@@ -630,7 +622,7 @@ class _FakeLinearModule(torch.nn.Module):
 
 class _FakeGemma4Layer(torch.nn.Module):
     # Minimal stand-in so hasattr(layer, "per_layer_input_gate") hits the new
-    # extraction branch without needing a real Gemma4 model.
+    # extraction branch without a real Gemma4 model.
     def __init__(self, hidden=4):
         super().__init__()
         self.per_layer_input_gate = _FakeLinearModule(hidden, hidden)
@@ -638,9 +630,9 @@ class _FakeGemma4Layer(torch.nn.Module):
 
 
 def test_gemma4_per_layer_extraction_emits_state_dict_entries():
-    # Behavioral: when a decoder layer exposes per_layer_input_gate /
-    # per_layer_projection, extraction must populate state_dict with those
-    # paths so the reconstruction templates have something to read.
+    # Behavioral: a layer exposing per_layer_input_gate / per_layer_projection
+    # must populate state_dict with those paths for the reconstruction
+    # templates.
     state_dict = {}
 
     def fake_get_state_dict(prefix, kk, sd, module, slice_weights=True):
@@ -649,9 +641,8 @@ def test_gemma4_per_layer_extraction_emits_state_dict_entries():
     layer = _FakeGemma4Layer()
     kk = 0
     prefix = "model.language_model"
-    # Mirror the exact calls the fix adds in _get_vllm_state_dict so the test
-    # pins the shape of the emitted keys without reproducing all of
-    # _get_vllm_state_dict's setup.
+    # Mirror the calls the fix adds in _get_vllm_state_dict to pin the emitted
+    # key shape without reproducing its full setup.
     if hasattr(layer, "per_layer_input_gate"):
         fake_get_state_dict(
             f"{prefix}.layers.{kk}.per_layer_input_gate",
@@ -667,9 +658,8 @@ def test_gemma4_per_layer_extraction_emits_state_dict_entries():
 
 
 def test_set_additional_modules_loads_visual_merger_linear_fc():
-    # Regression: the "linear" filter in set_additional_modules dropped
-    # model.visual.merger.linear_fc1/2 after the PR moved them into
-    # non_layered_components. set_additional_modules must now restore them.
+    # Regression: the "linear" filter dropped model.visual.merger.linear_fc1/2
+    # after they moved into non_layered_components; they must be restored.
     from unsloth_zoo.empty_model import set_additional_modules
 
     class _LM(torch.nn.Module):
@@ -718,9 +708,9 @@ def test_set_additional_modules_loads_visual_merger_linear_fc():
 
 
 def test_get_vllm_state_dict_extracts_layernorm_when_layer_lacks_mlp():
-    # Regression: the early `continue` for layers without `mlp` previously
-    # short-circuited before the layernorm extraction loop, dropping
-    # input_layernorm.weight on linear-attention / MoE-only layers.
+    # Regression: the early `continue` for layers without `mlp` ran before the
+    # layernorm loop, dropping input_layernorm.weight on linear-attn / MoE
+    # layers.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils._get_vllm_state_dict)
     layernorm_idx = src.index('layer_config[\'layernorms\']')
@@ -732,10 +722,9 @@ def test_get_vllm_state_dict_extracts_layernorm_when_layer_lacks_mlp():
 
 
 def test_finalize_huggingface_model_dtype_propagates_to_replaced_live_config():
-    # Regression: copy_attributes can replace new_model.config with a config
-    # object whose id() differs from the input `config`, so the id-keyed
-    # dtype reapply loop missed it. After the fix, the live config tree is
-    # also brought up to date.
+    # Regression: copy_attributes can replace new_model.config with an object
+    # whose id() differs from the input config, so the id-keyed dtype reapply
+    # loop missed it; the fix also updates the live config tree.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _LiveCfg:
@@ -762,10 +751,9 @@ def test_finalize_huggingface_model_dtype_propagates_to_replaced_live_config():
 
 
 def test_finalize_huggingface_model_vision_rotary_uses_identity_check():
-    # Regression: previously vision rotary classification compared __class__
-    # of the rotary's config against vision_config's class, which misfires
-    # when text and vision configs share a Python class. Identity-based
-    # check must not reroute a text rotary to vision_config in that case.
+    # Regression: comparing the rotary config's __class__ against
+    # vision_config's class misfires when text and vision share a class. The
+    # identity check must not reroute a text rotary to vision_config.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _SharedCfg:
@@ -817,9 +805,9 @@ def test_finalize_huggingface_model_vision_rotary_uses_identity_check():
 
 
 def test_layer_scalar_keeps_buffer_registration_after_conversion():
-    # Regression: the `if layer_name in quant_state_dict` branch in
-    # convert_vllm_to_huggingface always wrapped the value in nn.Parameter,
-    # silently moving HF Gemma4 layer_scalar from `_buffers` to `_parameters`.
+    # Regression: the `if layer_name in quant_state_dict` branch always wrapped
+    # the value in nn.Parameter, moving Gemma4 layer_scalar from _buffers to
+    # _parameters.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
     assert "_buffers" in src
@@ -827,10 +815,9 @@ def test_layer_scalar_keeps_buffer_registration_after_conversion():
 
 
 def test_assert_same_state_dict_uses_tight_tolerance_for_same_dtype():
-    # Regression: assert_same_state_dict previously applied atol=1e-4 /
-    # rtol=1e-3 unconditionally, masking weight-extraction errors on
-    # same-dtype non-FP8 weights. The relaxed tolerance must now only
-    # apply to the dtype-mismatch / FP8 upcast branch.
+    # Regression: assert_same_state_dict applied atol=1e-4/rtol=1e-3
+    # unconditionally, masking extraction errors on same-dtype non-FP8 weights.
+    # The relaxed tolerance must apply only to the dtype-mismatch / FP8 branch.
     from unsloth_zoo.vllm_utils import assert_same_state_dict
     a = torch.randn(8, 8, dtype=torch.float32)
     b = a.clone()
@@ -844,8 +831,8 @@ def test_assert_same_state_dict_uses_tight_tolerance_for_same_dtype():
 
 
 def test_conv1d_branch_requires_linear_attn_in_layer_name():
-    # Regression: `endswith(".conv1d")` would silently rebuild any future
-    # non-GDN .conv1d layer as depthwise. Branch must require linear_attn.
+    # Regression: bare `endswith(".conv1d")` would rebuild any non-GDN .conv1d
+    # as depthwise; the branch must require linear_attn.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
     assert 'endswith(".conv1d") and "linear_attn" in layer_name' in src
@@ -862,8 +849,8 @@ def test_gemma4_lora_patch_covers_both_classes():
 
 def test_get_model_layer_config_includes_gemma4_top_level_ple_modules():
     # Regression: top-level Gemma4 PLE modules (embed_tokens_per_layer,
-    # per_layer_model_projection, per_layer_projection_norm) were missing
-    # from extraction tables, leaving them with random init.
+    # per_layer_model_projection, per_layer_projection_norm) were absent from
+    # extraction tables, leaving them randomly initialized.
     from unsloth_zoo.empty_model import get_model_layer_config
     cfg = get_model_layer_config()
     non_layered = set(cfg["non_layered_components"])
@@ -873,11 +860,10 @@ def test_get_model_layer_config_includes_gemma4_top_level_ple_modules():
 
 
 def test_finalize_non_gemma4_rotary_stays_fp32_through_to_dtype():
-    # Regression: the non-Gemma4 branch previously skipped the float32 rotary
-    # buffer restoration after new_model.to(dtype), downcasting inv_freq /
-    # original_inv_freq to bf16/fp16 for Qwen3.5 and other non-Gemma4 models.
-    # Must exercise the (quantization_config == {} and bnb_config is None)
-    # path so .to(dtype) actually runs.
+    # Regression: the non-Gemma4 branch skipped float32 rotary restoration
+    # after new_model.to(dtype), downcasting inv_freq / original_inv_freq to
+    # bf16/fp16. Exercise the (quantization_config == {} and bnb_config is
+    # None) path so .to(dtype) runs.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _Cfg:
@@ -920,11 +906,10 @@ def test_finalize_non_gemma4_rotary_stays_fp32_through_to_dtype():
 
 
 def test_finalize_tolerates_rotary_rebuild_failure_without_crashing():
-    # Regression: module.rotary_emb.__class__(config=..., device=...) can
-    # raise for Gemma4 multimodal rotary when copy_attributes drifts the
-    # config identity so the vision rotary ends up with a text config shape.
-    # finalize_huggingface_model must catch the exception, keep the existing
-    # rotary instance, and still float32-lift its buffers.
+    # Regression: rotary_emb.__class__(config=..., device=...) can raise for
+    # Gemma4 multimodal rotary when copy_attributes drifts config identity.
+    # finalize must catch it, keep the existing rotary, and float32-lift its
+    # buffers.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _BadCfg:
@@ -971,10 +956,9 @@ def test_finalize_tolerates_rotary_rebuild_failure_without_crashing():
 
 
 def test_finalize_routes_vision_tower_rotary_to_vision_config_by_module_path():
-    # Regression: id()-based text/vision routing drifted after copy_attributes,
-    # misrouting vision rotary through text_config (which lacks the vision
-    # rope_parameters shape). The fix adds a module-path fallback so a rotary
-    # under 'vision_tower' is built with vision_config even when identity
+    # Regression: id()-based routing drifted after copy_attributes, misrouting
+    # vision rotary through text_config. The fix adds a module-path fallback so
+    # a rotary under 'vision_tower' builds with vision_config when identity
     # match fails.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
@@ -998,8 +982,8 @@ def test_finalize_routes_vision_tower_rotary_to_vision_config_by_module_path():
     class _Inner(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            # New unrelated config instance so id() match against the top-level
-            # vision_config fails; module path must take over.
+            # Unrelated config so id() match against top-level vision_config
+            # fails; the module-path fallback must take over.
             self.rotary_emb = _Rotary(config=object())
 
     class _VisionTower(torch.nn.Module):
@@ -1031,9 +1015,8 @@ def test_finalize_routes_vision_tower_rotary_to_vision_config_by_module_path():
 
 def test_extract_gdn_layers_dequantize_uses_unpacked_midpoint():
     # Regression: `mid = ba_weight.shape[0] // 2` was computed on the packed
-    # uint8 Params4bit buffer (numel/2 shape), then reused to slice the
-    # dequantized full tensor whose shape[0] is out_features. When those two
-    # differ, in_proj_b / in_proj_a ended up with wrong rows.
+    # uint8 buffer then reused to slice the dequantized full tensor (shape[0] =
+    # out_features); when they differ, in_proj_b/a got wrong rows.
     from unsloth_zoo.empty_model import extract_gdn_layers
 
     class _PlainProj(torch.nn.Module):
@@ -1109,9 +1092,8 @@ def test_extract_gdn_layers_dequantize_uses_unpacked_midpoint():
 
 
 def test_lm_head_lookup_uses_exact_name_not_substring():
-    # Regression: `"lm_head" in name` would match a submodule named e.g.
-    # 'lm_head_norm' before the real 'lm_head', returning the wrong module.
-    # The fix requires an exact match or a .lm_head suffix.
+    # Regression: `"lm_head" in name` matched e.g. 'lm_head_norm' before the
+    # real 'lm_head'; the fix requires exact match or a .lm_head suffix.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils._get_vllm_state_dict)
     assert 'name == "lm_head"' in src
@@ -1124,10 +1106,9 @@ def test_lm_head_lookup_uses_exact_name_not_substring():
 
 
 def test_convert_regex_handles_trailing_digit_parameter_paths():
-    # Pre-fix: `re.sub(r"\.([\d]{1,})\.", r"[\1].", layer_name)` required a
-    # trailing dot, so a parameter-list-style key such as
-    # `model.language_model.embed_tokens_per_layer.0` was not converted to
-    # bracket form and `exec(...)` hit a SyntaxError.
+    # Pre-fix: `re.sub(r"\.([\d]{1,})\.", ...)` required a trailing dot, so a
+    # trailing-index key like `...embed_tokens_per_layer.0` was not bracketed
+    # and `exec(...)` hit a SyntaxError.
     import re
     pattern = r"\.([\d]+)(?=\.|$)"
     sub = lambda x: f"[{x.group(1)}]"
@@ -1140,9 +1121,8 @@ def test_convert_regex_handles_trailing_digit_parameter_paths():
 
 
 def test_convert_vllm_to_huggingface_uses_robust_bracket_regex():
-    # The Parameter-assignment path for `if layer_name in quant_state_dict`
-    # must use the anchor-or-end regex so that keys ending in `.DIGIT` get
-    # converted to bracket form.
+    # The Parameter-assignment path must use the anchor-or-end regex so keys
+    # ending in `.DIGIT` get bracketed.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
     assert r'r"\.([\d]+)(?=\.|$)"' in src
@@ -1154,9 +1134,8 @@ def test_convert_vllm_to_huggingface_uses_robust_bracket_regex():
 
 
 def test_finalize_rotary_reinit_failure_skips_float32_lift():
-    # Regression: a bare `try/except Exception: pass` on rotary reinit used
-    # to float32-lift buffers on the stale rotary. The fix only lifts when
-    # reinit succeeds so wrong-shape placeholder buffers do not get blessed.
+    # Regression: a bare `try/except: pass` on rotary reinit float32-lifted
+    # buffers on the stale rotary; the fix lifts only when reinit succeeds.
     from unsloth_zoo.empty_model import finalize_huggingface_model
 
     class _BadCfg:
@@ -1231,10 +1210,10 @@ def test_load_vllm_routes_gemma4_gate_through_helper():
 
 
 def test_load_vllm_gemma4_patch_runs_after_bnb_autodetect():
-    # Regression: the Gemma4 k_eq_v patch was gated on the caller-provided
-    # `use_bitsandbytes` before model-name / quant_method auto-detection, so
-    # `-bnb-4bit` models with use_bitsandbytes=False at call time would skip
-    # the patch. The fix moves the gate below the autodetect line.
+    # Regression: the Gemma4 k_eq_v patch was gated on caller-provided
+    # `use_bitsandbytes` before model-name/quant_method autodetect, so
+    # `-bnb-4bit` models with use_bitsandbytes=False skipped it; the fix moves
+    # the gate below autodetect.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.load_vllm)
     autodetect_anchor = "use_bitsandbytes = use_bitsandbytes or"
@@ -1268,10 +1247,9 @@ def test_gemma4_bnb_skip_module_aliases_cover_vllm_text_prefixes():
 
 
 def test_patch_gemma4_vllm_lora_support_preserves_embedding_modules():
-    # Regression: `cls.embedding_modules = {}` clobbered a pre-existing
-    # embedding registry on the vLLM class, which vLLM's LoRA manager uses
-    # to route adapters to embedding layers. The fix guards the assignment
-    # so it only runs when the attribute is absent.
+    # Regression: `cls.embedding_modules = {}` clobbered the vLLM class's
+    # existing embedding registry (used to route adapters to embedding layers);
+    # the fix guards the assignment to run only when the attribute is absent.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
     assert 'if not hasattr(cls, "embedding_modules"):' in src
@@ -1283,9 +1261,9 @@ def test_patch_gemma4_vllm_lora_support_preserves_embedding_modules():
 
 
 def test_patch_gemma4_vllm_lora_support_guards_gemma4_mm_import():
-    # Regression: a hard `from vllm...gemma4_mm import ...` at top of the
-    # patch function crashed with ModuleNotFoundError on text-only Gemma4
-    # vLLM builds. The fix wraps each class import in try/except.
+    # Regression: a hard `from vllm...gemma4_mm import ...` crashed with
+    # ModuleNotFoundError on text-only Gemma4 vLLM builds; the fix wraps each
+    # class import in try/except.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_lora_support)
     mm_line = "from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration"
@@ -1298,9 +1276,9 @@ def test_patch_gemma4_vllm_lora_support_guards_gemma4_mm_import():
 
 
 def test_patch_gemma4_vllm_k_eq_v_support_guards_private_loader_attr():
-    # Regression: hasattr(BitsAndBytesModelLoader._stack_quantization_states, ...)
-    # raised AttributeError on vLLM builds where the private method was
-    # renamed or absent. Fix routes through getattr with a None default.
+    # Regression: hasattr(BitsAndBytesModelLoader._stack_quantization_states,
+    # ...) raised AttributeError when the private method was renamed/absent;
+    # the fix routes through getattr with a None default.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
     assert 'getattr(\n        BitsAndBytesModelLoader, "_stack_quantization_states", None' in src \
@@ -1309,9 +1287,9 @@ def test_patch_gemma4_vllm_k_eq_v_support_guards_private_loader_attr():
 
 
 def test_patch_gemma4_vllm_k_eq_v_support_searches_hf_style_prefix():
-    # Regression: _get_gemma4_k_eq_v_pairs only searched
-    # ("language_model.model", "model") prefixes, missing HF-style
-    # model.language_model for multimodal Gemma4.
+    # Regression: _get_gemma4_k_eq_v_pairs searched only
+    # ("language_model.model", "model"), missing HF-style model.language_model
+    # for multimodal Gemma4.
     from unsloth_zoo import empty_model
     src = inspect.getsource(empty_model.patch_gemma4_vllm_k_eq_v_support)
     assert '"model.language_model"' in src
@@ -1363,9 +1341,9 @@ def test_patch_gemma4_vllm_lora_support_early_returns_when_no_classes():
         saved[missing] = _sys.modules.get(missing)
         _sys.modules[missing] = None
     try:
-        # Must return without raising when no gemma4 class importable.
+        # Must not raise when no gemma4 class is importable.
         empty_model.patch_gemma4_vllm_lora_support()
-        # And the fake create_lora_manager must not have been replaced.
+        # fake create_lora_manager must be left in place.
         assert stub_packages["vllm.lora.model_manager"].create_lora_manager is fake_create
     finally:
         for name, prev in saved.items():

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -6,13 +6,9 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-"""Pin-down regression suite for past zoo bugs.
-
-Every test here corresponds to a SHIPPED fix on `main`. The goal is
-to catch the SAME bug class if it re-appears, not to retest the
-fix path itself. Each test has a `WHY` block citing the commit /
-PR that introduced the regression.
-"""
+"""Regression pins for past zoo bugs. Each test maps to a SHIPPED fix on
+`main` and catches the bug class if it re-appears (not the fix path itself);
+each cites the commit/PR that introduced the regression."""
 
 from __future__ import annotations
 
@@ -22,18 +18,11 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
-# Regression: temporary_patches/utils.py `__all__` missing comma between
-# entries silently concatenates the two strings ("raise_errorUnpack")
-# and the supposedly-public names become un-import-able under
-# `from temporary_patches.utils import *`.
-#
-# Source: `2e36f32 fix(temporary_patches/utils): add missing comma in
-# __all__ between 'raise_error' and 'Unpack' (#617)`
-#
-# This is a Python footgun -- there's no syntactic error, the
-# interpreter just concatenates adjacent string literals. The bug
-# stayed live until someone star-imported and noticed `Unpack` was
-# missing.
+# Regression: a missing comma in temporary_patches/utils.py `__all__` silently
+# concatenates adjacent string literals ("raise_errorUnpack"), making the
+# public names un-importable under `from ... import *`. No syntax error fires.
+# Source: 2e36f32 fix(temporary_patches/utils): add missing comma in __all__
+# between 'raise_error' and 'Unpack' (#617)
 # ---------------------------------------------------------------------------
 
 
@@ -55,27 +44,22 @@ def test_temporary_patches_utils_all_entries_are_valid_attributes():
 
 
 def test_temporary_patches_utils_no_concatenated_all_entries():
-    """No `__all__` entry should look like two separate names jammed
-    together (e.g. `raise_errorUnpack`). Heuristic: detect a name
-    that has BOTH (a) snake_case tokens (lowercase + underscore) AND
-    (b) a PascalCase / camelCase transition (lowercase letter
-    followed by uppercase letter). Pure `ALL_CAPS_CONSTANT` names
-    like `KWARGS_TYPE` have underscores but no lowercase->uppercase
-    transition, so they don't match.
+    """No `__all__` entry should look like two jammed names (e.g.
+    `raise_errorUnpack`). Heuristic: a name with BOTH a snake_case underscore
+    AND a lowercase->uppercase transition. Pure ALL_CAPS like `KWARGS_TYPE`
+    has no such transition, so it doesn't match.
     """
     from unsloth_zoo.temporary_patches import utils
     import re
 
-    # Matches a lowercase letter followed by an uppercase letter --
-    # the signature of a snake_case + CamelCase concatenation.
+    # lowercase->uppercase = a snake_case + CamelCase concatenation.
     camel_boundary = re.compile(r"[a-z][A-Z]")
     suspicious = []
     for name in utils.__all__:
         if name.startswith("_"):
             continue
         if "_" not in name:
-            # Pure CamelCase or pure lowercase -- not the bug class.
-            continue
+            continue  # pure CamelCase or lowercase -- not the bug class.
         if camel_boundary.search(name):
             suspicious.append(name)
     assert not suspicious, (
@@ -100,17 +84,12 @@ def test_temporary_patches_utils_known_public_names_present():
 
 
 # ---------------------------------------------------------------------------
-# Regression: `compiler.higher_precision_softmax` was not idempotent --
-# running it twice on the same source appended a duplicate
-# `.to(x.dtype).to(x.dtype)` because the lookahead that detects an
-# already-rewritten softmax was missing.
-#
-# Source: `f98dbbc fix(compiler): make higher_precision_softmax
-# idempotent (#631)`
-#
-# The compiler runs on user source mid-training; if it's invoked
-# twice (e.g. through a checkpoint reload that re-patches), the
-# emitted source must not drift. This test pins the contract.
+# Regression: `compiler.higher_precision_softmax` wasn't idempotent -- running
+# it twice appended a duplicate `.to(x.dtype).to(x.dtype)` (the
+# already-rewritten lookahead was missing). The compiler runs on user source
+# mid-training and may re-run (e.g. checkpoint reload), so emitted source must
+# not drift.
+# Source: f98dbbc fix(compiler): make higher_precision_softmax idempotent (#631)
 # ---------------------------------------------------------------------------
 
 
@@ -156,15 +135,10 @@ def test_higher_precision_softmax_does_not_double_cast():
 
 
 # ---------------------------------------------------------------------------
-# Regression: backend device helpers must guard against partial torch
-# builds (e.g. `torch.xpu` exists but `torch.xpu.synchronize` raises).
-# Two commits address this:
-#   `e08c1df Guard XPU synchronize call against partial torch.xpu builds`
-#   `35dc451 Guard XPU empty_cache call against partial torch.xpu builds`
-#
-# Test: calling device_synchronize / device_empty_cache must not raise
-# even if the resolved backend module is partial. Uses the same
-# stub harness as tests/conftest.py.
+# Regression: backend device helpers must guard against partial torch builds
+# (e.g. `torch.xpu` exists but `torch.xpu.synchronize` raises). Calling
+# device_synchronize / device_empty_cache must not raise on a partial backend.
+# Source: e08c1df (Guard XPU synchronize), 35dc451 (Guard XPU empty_cache).
 # ---------------------------------------------------------------------------
 
 
@@ -172,18 +146,14 @@ def test_device_synchronize_tolerates_partial_backend():
     """`device_synchronize()` must not raise on a minimal stub backend."""
     from unsloth_zoo.device_type import device_synchronize
 
-    # Just call it. On the GPU-free harness this resolves to the
-    # stub `lambda *a, **k: None`. The point is to assert the
-    # exported name exists and is callable -- the partial-backend
-    # guards live inside its implementation.
+    # On the GPU-free harness this resolves to a stub; the partial-backend
+    # guards live inside the implementation.
     device_synchronize()
 
 
 def test_device_type_module_has_expected_helpers():
-    """Pin the public API surface that downstream zoo / unsloth /
-    Studio code calls. A rename or removal here breaks consumers
-    silently (`AttributeError` at training time).
-    """
+    """Pin the public API downstream zoo/unsloth/Studio code calls; a rename
+    or removal here breaks consumers silently (AttributeError at train time)."""
     import unsloth_zoo.device_type as dt
 
     expected = [
@@ -198,14 +168,9 @@ def test_device_type_module_has_expected_helpers():
 
 # ---------------------------------------------------------------------------
 # Regression: RL_REPLACEMENTS dict integrity vs the GRPO refactor wave
-# (commits 466334c, 9829ade, 035f...). The dict is rebuilt as each
-# function is defined; a missing `RL_REPLACEMENTS[name] = fn`
-# assignment after a refactor is silent -- nothing fails at import.
-#
-# This test pins the registration count + the well-known public-API
-# keys. Duplicates the assertion in test_rl_replacements_cpu.py
-# deliberately: that file proves the IO contract of each function;
-# THIS file proves the registration survives a refactor.
+# (commits 466334c, 9829ade, 035f...). The dict is rebuilt per definition; a
+# missing `RL_REPLACEMENTS[name] = fn` after a refactor fails silently. Pins
+# the public-API keys (test_rl_replacements_cpu.py covers the IO contract).
 # ---------------------------------------------------------------------------
 
 
@@ -227,24 +192,13 @@ def test_rl_replacements_registration_survived_grpo_refactor():
 
 
 # ---------------------------------------------------------------------------
-# Regression: gpt-oss inference leaks a flex BlockMask into the eager
-# attention forward.
-#
-# Source: PR #690 (Fix gpt-oss inference BlockMask TypeError).
-# Latent since unsloth-zoo commit `ef819214` (2025-09-25, "Fix Flex")
-# which rewrote return_attention_mask -> wrap(f) that on the inference
-# branch unconditionally calls f(*args, **kwargs), AND switched
-# forward_function to use eager during inference. When
-# config._attn_implementation == "flex_attention" (set by training,
-# explicit user kwarg, or pre-#5701 resolver), the inference path
-# receives a BlockMask and inplace_eager_attention_forward crashes:
-#   TypeError: unsupported operand type(s) for +=:
-#       'Tensor' and 'BlockMask'
-#
-# AST-level guards. Two of them: one over wrap.return_attention_mask
-# (the path transformers' own GptOssModel.forward goes through), one
-# over patch_GptOssModel as a whole (the path Unsloth's patched forward
-# goes through). Catches silent deletion of the flex_attention literal.
+# Regression: gpt-oss inference leaks a flex BlockMask into the eager attention
+# forward. When config._attn_implementation == "flex_attention" the inference
+# path receives a BlockMask and inplace_eager_attention_forward crashes with
+#   TypeError: unsupported operand type(s) for +=: 'Tensor' and 'BlockMask'
+# Two AST guards (one over wrap.return_attention_mask, one over
+# patch_GptOssModel) catch silent deletion of the flex_attention literal.
+# Source: PR #690; latent since commit ef819214 ("Fix Flex").
 # ---------------------------------------------------------------------------
 
 
@@ -284,13 +238,9 @@ def test_gpt_oss_wrap_has_flex_attention_inference_guard():
 
 
 def test_gpt_oss_patched_model_forward_has_flex_attention_guard():
-    """The patched GptOssModel.forward body itself must hold the guard.
-
-    Locate the inner `forward` FunctionDef and assert its body carries
-    the _attn_implementation == 'flex_attention' literal. This is
-    independent of wrap's own guard, so removing the forward-level
-    swap while keeping wrap's literal cannot satisfy this test.
-    """
+    """The patched GptOssModel.forward body must carry the
+    _attn_implementation == 'flex_attention' guard, independent of wrap's own
+    guard (so removing the forward-level swap can't satisfy this test)."""
     import ast
     import inspect
     from unsloth_zoo.temporary_patches import gpt_oss as _M
@@ -319,30 +269,20 @@ def test_gpt_oss_patched_model_forward_has_flex_attention_guard():
 
 
 # ---------------------------------------------------------------------------
-# Regression: eager attention shape mismatch when KV cache is longer than
-# the attention mask's kv dimension.
-#
-# Source: PR #691 (gpt-oss: align eager KV length to the attention mask).
-# transformers 5.x cache pre-allocation hands a full-attention layer more
-# positions than the causal mask covers (e.g. k=161 against a 128-wide
-# mask). Both eager attention forwards in patch_GptOssAttention then do
-#   attn_weights += attention_mask[:, :, :, : key_states.shape[-2]]
-# which fails with:
-#   RuntimeError: The size of tensor a (N) must match the size of
-#       tensor b (M) at non-singleton dimension 3
-#
-# The fix is the _align_kv_to_mask helper that trims KV (or the mask) to
-# the shorter length. Static check: helper exists AND is invoked from
-# BOTH eager forward variants so the inplace and non-inplace paths agree.
+# Regression: eager attention shape mismatch when the KV cache is longer than
+# the attention mask's kv dim. transformers 5.x cache pre-allocation hands a
+# full-attention layer more positions than the causal mask covers (e.g. k=161
+# vs a 128-wide mask), so `attn_weights += attention_mask[...]` raises
+# RuntimeError on dim 3. The _align_kv_to_mask helper trims to the shorter
+# length; static check: it exists AND runs in BOTH eager forwards.
+# Source: PR #691.
 # ---------------------------------------------------------------------------
 
 
 def test_gpt_oss_eager_attention_aligns_kv_to_mask():
-    """Both eager forwards must invoke the KV alignment helper.
-
-    Per-function source-slice check rather than a global callsite count,
-    so a future refactor that consolidates eager paths into a shared
-    closure still passes as long as the alignment runs on both routes.
+    """Both eager forwards must invoke the KV alignment helper. Per-function
+    source-slice check (not a global callsite count) so consolidation into a
+    shared closure still passes if alignment runs on both routes.
     """
     import ast
     import inspect
@@ -382,14 +322,10 @@ def test_gpt_oss_eager_attention_aligns_kv_to_mask():
 
 
 # ---------------------------------------------------------------------------
-# Regression: gpt-oss patched GptOssModel.forward hard-codes the
-# transformers 4.x mask kwargs ("input_embeds", "cache_position") and
-# blows up on transformers 5.x which renamed to "inputs_embeds" and
-# dropped "cache_position" entirely.
-#
-# Source: PR #690 fix included inspect-driven kwarg filtering so the
-# patch supports both 4.x and 5.x simultaneously. Static check that the
-# filtering helper is present.
+# Regression: patched GptOssModel.forward hard-coded the 4.x mask kwargs
+# ("input_embeds", "cache_position") and blew up on 5.x (renamed to
+# "inputs_embeds", dropped "cache_position"). PR #690 added inspect-driven
+# kwarg filtering to support both; static check that the helper is present.
 # ---------------------------------------------------------------------------
 
 
@@ -398,8 +334,7 @@ def test_gpt_oss_model_forward_uses_inspect_filtered_mask_kwargs():
     from unsloth_zoo.temporary_patches import gpt_oss as _M
 
     src = inspect.getsource(_M.patch_GptOssModel)
-    # Either the inspect-driven helper (_build_mask_kwargs / _ccm_params)
-    # OR a guard string explicitly testing for inputs_embeds availability.
+    # The inspect-driven helper, or a guard testing inputs_embeds availability.
     has_inspect_filter = (
         "_build_mask_kwargs" in src
         or "_ccm_params" in src

--- a/tests/test_zoo_source_upstream_refs.py
+++ b/tests/test_zoo_source_upstream_refs.py
@@ -6,13 +6,9 @@
 # the Free Software Foundation, either version 3 of the License, or (at
 # your option) any later version.
 
-"""Importable-symbol pins for upstream references in ``unsloth_zoo`` source.
-
-Flat enumeration of every ``from <upstream> import <symbol>`` /
-``<upstream>.X.Y`` reference visible in ``unsloth_zoo/**.py``, exercised
-against the INSTALLED versions of transformers / trl / peft / datasets
-/ accelerate / vllm. Each test cites the zoo file:line it pins.
-"""
+"""Importable-symbol pins for every upstream reference in unsloth_zoo source,
+exercised against the INSTALLED transformers / trl / peft / datasets /
+accelerate / vllm. Each test cites the zoo file:line it pins."""
 
 from __future__ import annotations
 
@@ -28,14 +24,8 @@ import pytest
 # ---------------------------------------------------------------------------
 
 def _resolve(dotted: str) -> object:
-    """``importlib.import_module`` + ``getattr`` chain.
-
-    DRIFT-DETECTED policy: any failure to resolve is reported as an
-    AssertionError -- never a SKIP. Three failure modes all surface as
-    DRIFT: module-file missing, module-file present but import raises
-    (transitively-broken optional dep), or attribute missing on a
-    successfully-imported module.
-    """
+    """import_module + getattr chain. Any resolution failure (missing module,
+    import raises, or missing attribute) surfaces as DRIFT, never a SKIP."""
     parts = dotted.split(".")
     obj: object = None
     consumed: list[str] = []
@@ -714,23 +704,11 @@ def test_qwen2_vl_image_processor_class():
 
 
 def test_qwen2_5_vl_image_processor_class_gated_on_v5():
-    """unsloth_zoo/temporary_patches/misc.py:1501 --
-    Qwen2_5_VLImageProcessor.
+    """misc.py:1501 -- Qwen2_5_VLImageProcessor.
 
-    Originally added because zoo's patch site at misc.py:1501 references
-    this exact path; the version gate skipped on 4.x where the patch is
-    inert. transformers 5.x then DROPPED the slow image processors
-    entirely (no image_processing_qwen2_5_vl.py, no
-    image_processing_qwen2_5_vl_fast.py either): Qwen2.5-VL now reuses
-    ``Qwen2VLImageProcessor`` directly. zoo's misc.py:1500-1506 is
-    try/except ImportError-wrapped, so the no-longer-resolvable import
-    silently no-ops on 5.x and the runtime shim still fires via the
-    Qwen2VLImageProcessor patch at misc.py:1485-1498 (which is the
-    same class Qwen2.5-VL inherits at runtime).
-
-    On 4.57.6 the path still exists -- keep the strict drift check.
-    On 5.x the path is gone but the runtime is covered elsewhere --
-    skip.
+    On 4.57.6 the path exists -- keep the strict drift check. On 5.x the slow
+    image processors are gone (Qwen2.5-VL reuses Qwen2VLImageProcessor, covered
+    by the misc.py:1485-1498 patch); zoo's try/except import no-ops, so skip.
     """
     import transformers
     from packaging.version import Version

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -44,10 +44,9 @@ if os.environ.get("UNSLOTH_STABLE_DOWNLOADS", "0") == "1":
     os.environ["HF_HUB_DISABLE_XET"] = "1" # Disable XET
     os.environ["HF_XET_HIGH_PERFORMANCE"] = "0" # This causes "429 Too Many Requests"
 
-# Cross-sync HF_HUB_OFFLINE, TRANSFORMERS_OFFLINE, HF_DATASETS_OFFLINE so
-# setting any one of the three implies all three. Without HF_DATASETS_OFFLINE
-# here, load_dataset() still issues a network call for dataset metadata even
-# when the rest of the HF stack is offline.
+# Cross-sync the three offline flags: setting any one implies all three.
+# Without HF_DATASETS_OFFLINE, load_dataset() still hits the network for
+# dataset metadata even when the rest of the HF stack is offline.
 if _offline_env:
     for _v in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"):
         os.environ[_v] = "1"
@@ -106,13 +105,11 @@ from importlib.util import find_spec
 from .mlx.runtime import is_mlx_available
 from .model_lists import FORCE_FLOAT32
 
-# Import-time fixes live in ``unsloth/import_fixes.py`` and run at
-# ``import unsloth`` time. Zoo cannot be imported standalone (the GPU
-# init below requires ``find_spec("unsloth")``), so the patches are
-# always already in place here -- we do not re-host or re-apply them.
+# Import-time fixes live in ``unsloth/import_fixes.py`` and run at ``import
+# unsloth`` time. Zoo cannot be imported standalone (the GPU init below
+# requires ``find_spec("unsloth")``), so they are always already in place.
 
-# Detect Apple Silicon MLX mode:
-# Either torch is absent (pure MLX), or unsloth already detected MLX
+# Detect Apple Silicon MLX mode: torch absent (pure MLX) or unsloth detected MLX
 _is_mlx_only = is_mlx_available()
 
 if _is_mlx_only:
@@ -131,9 +128,8 @@ else:
     del _is_mlx_only, is_mlx_available
 
 # Inject triton & bitsandbytes stubs on Apple Silicon with MLX so unsloth's
-# CUDA-only imports don't error at startup. _SKIP_GPU_INIT=True is set only
-# when we're on Darwin/arm64 with mlx installed (the exact MLX case where
-# stubs are needed), so gate on that directly.
+# CUDA-only imports don't error at startup. _SKIP_GPU_INIT is True only on
+# Darwin/arm64 with mlx installed (the exact case stubs are needed).
 if _SKIP_GPU_INIT:
     from .stubs.triton_stub import inject_into_sys_modules as _inject_triton
     _inject_triton()
@@ -142,7 +138,7 @@ if _SKIP_GPU_INIT:
     del _inject_triton, _inject_bnb
 
 # Lazy bridge for downstream code that still imports the old flat MLX module
-# names. Installed on every host so external scripts don't get a hard
+# names. Installed on every host so external scripts don't hit a hard
 # ModuleNotFoundError at import time; the real import (which pulls in mlx)
 # is deferred to first attribute access. On non-MLX hosts that access
 # surfaces the same ModuleNotFoundError("mlx") users got pre-refactor.
@@ -169,22 +165,18 @@ class _LazyMLXAlias(_types.ModuleType):
         return real
 
     def __getattr__(self, name):
-        # Skip dunder probes (inspect.getmodule, hasattr(..., '__file__'),
-        # etc.) so we do not trigger an mlx import during torch's own
-        # init when it walks sys.modules. Real user attribute access
-        # (e.g. FastMLXModel) still resolves through to the new submodule.
+        # Skip dunder probes (inspect.getmodule, hasattr(..., '__file__'), etc.)
+        # so we don't trigger an mlx import while torch walks sys.modules during
+        # its own init. Real attribute access (e.g. FastMLXModel) still resolves.
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
         try:
             real = self._resolve()
         except ModuleNotFoundError:
-            # mlx is Apple-only. On non-mlx hosts the real submodule import
-            # fails. Surface as AttributeError so callers that walk sys.modules
-            # (notably pickle.whichmodule, used by torch._inductor's FX graph
-            # hash pickler) skip this stub cleanly instead of crashing the
-            # whole compile. Real user attribute access on a non-mlx host
-            # still surfaces a useful error -- they will see the AttributeError
-            # rather than a torch._dynamo.exc.BackendCompilerFailed wrapper.
+            # mlx is Apple-only; on non-mlx hosts the submodule import fails.
+            # Surface as AttributeError so sys.modules walkers (notably
+            # pickle.whichmodule, used by torch._inductor's FX graph hash
+            # pickler) skip this stub cleanly instead of crashing the compile.
             raise AttributeError(name)
         return getattr(real, name)
 
@@ -220,8 +212,7 @@ if not _SKIP_GPU_INIT:
     IS_TORCH_2_9_OR_NEWER = (major_torch > 2) or (major_torch == 2 and minor_torch >= 9)
     IS_TORCH_ROCM_BUILD = "+rocm" in torch_version_raw.lower()
 
-    # Reduce VRAM usage by reducing fragmentation
-    # And optimize pinning of memory
+    # Reduce VRAM fragmentation and optimize memory pinning
     if os.environ.get("UNSLOTH_VLLM_STANDBY", "0") == "0":
         if IS_TORCH_2_9_OR_NEWER:
             if "PYTORCH_ALLOC_CONF" not in os.environ:

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -629,11 +629,9 @@ pass
 
 def fix_attention_dtype_consistency(source):
     """
-    Fix dtype mismatch between Q/K and V in attention modules.
-    After apply_rotary_pos_emb, Q and K may be promoted to a different dtype
-    (e.g. float32) while V stays in the original dtype (e.g. float16/bfloat16).
-    This happens in 4-bit BNB mode when cos/sin from RoPE are in float32.
-    We insert a cast to align V's dtype with Q's dtype.
+    Fix Q/K vs V dtype mismatch in attention. apply_rotary_pos_emb may promote
+    Q/K (e.g. to float32 in 4-bit BNB when RoPE cos/sin are float32) while V stays
+    float16/bfloat16; insert a cast aligning V's dtype with Q's.
     """
     pattern = re.compile(
         r"([ \t]*)(query_states\s*,\s*key_states\s*=\s*apply_rotary_pos_emb\([^\)]+\))"
@@ -972,13 +970,12 @@ def create_new_function(
                     and f"def {b}(" not in new_source
                 ):
                     items.append(b)
-    # Check for create_causal_mask, create_masks_for_generate, create_sliding_window_causal_mask
+    # Pull in any create_*_mask functions referenced in the source
     mask_functions = get_mask_functions()
     for mask_function in mask_functions:
         if mask_function in new_source:
             items += [mask_function]
     pass
-    # Full import script
     imports = "from torch import Tensor\n"
     imports += "import torch\n"
     imports += "import torch.nn as nn\n"
@@ -1255,7 +1252,6 @@ def create_standalone_class(
      replacement so indentation and whitespace should be handled ahead of time!
     """
     # All Unsloth Zoo code licensed under LGPLv3
-    # Create optimized standalone forward function
     f = eval(f"{model_location}.{module}")
     full_class = inspect.getsource(f)
     old_source = inspect.getsource(f.forward)
@@ -1282,12 +1278,10 @@ def create_standalone_class(
     if full_class.lstrip().startswith("@"):
         start = re.search(r"^class ", full_class, flags=re.MULTILINE)
         if start:
-            # Found class definition - now check decorators
             class_start = start.start()
             preamble = full_class[:class_start]
             class_def = full_class[class_start:]
 
-            # Split preamble into lines
             lines = preamble.split('\n')
             new_lines = []
 
@@ -1302,7 +1296,7 @@ def create_standalone_class(
 
             for line in lines:
                 if skipping:
-                    # Continue skipping decorator args until balanced
+                    # Skip decorator args until parens balance
                     paren_depth += line.count("(") - line.count(")")
                     if paren_depth <= 0:
                         skipping = False
@@ -2265,7 +2259,6 @@ pass
 # Patch remaining functions
 def convert_attention_masks_to_bool(module, old_source):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Convert attention mask creation functions to boolean
     source = re.sub(r"\([\s]{0,}", "(", old_source)
     source = re.sub(r"[\s]{0,}\)", ")", source)
     all_splits = source.strip().split("\n")
@@ -2968,7 +2961,6 @@ def patch_gradient_accumulation(modeling_file, module):
     else:
         return None
 
-    # Now replace old forward with new one
     source = inspect.getsource(module).replace(inspect.getsource(forward), source)
     return source
 
@@ -3308,7 +3300,6 @@ def unsloth_compile_transformers(
     return_logits: bool = False,
     supports_sdpa: list = None,
 ):
-    # import transformers logging module and instantiate model_type logging instance.
     from transformers import logging as transformers_logging
 
     try:

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -45,38 +45,24 @@ pass
 
 
 def _longest_common_sublist(lists):
-    """
-    Finds the longest common sublist among multiple lists.
-
-    Parameters:
-    lists (List[List[int]]): A list of lists.
-
-    Returns:
-    List[int]: The longest common sublist. If multiple sublists have the same maximum length,
-               one of them is returned. If there's no common sublist, an empty list is returned.
-    """
+    """Longest common sublist among multiple lists (ties broken arbitrarily,
+    empty list if none)."""
     if not lists: return []
 
-    # Find the minimum length among all lists
     min_len = min(len(lst) for lst in lists)
     if min_len == 0: return []
 
     def has_common_sublist(length):
-        """
-        Checks if there's a common sublist of the given length across all lists.
-
-        Returns:
-        (bool, List): Tuple of whether such a sublist exists and the sublist itself.
-        """
+        """Return (exists, sublist) for a common sublist of `length`."""
         common = set()
         first = lists[0]
-        # Generate all possible sublists of the given length from the first list
+        # All sublists of `length` from the first list
         for i in range(len(first) - length + 1):
             sub = tuple(first[i:i + length])
             common.add(sub)
         pass
 
-        # Iterate over the remaining lists and retain only the common sublists
+        # Keep only sublists also present in every remaining list
         for lst in lists[1:]:
             current = set()
             for i in range(len(lst) - length + 1):
@@ -87,11 +73,10 @@ def _longest_common_sublist(lists):
             if not common:
                 return False, []
         pass
-        
-        # If common is not empty, return one of the common sublists
         return True, list(common.pop())
     pass
 
+    # Binary search on length
     left, right = 1, min_len
     result = []
 
@@ -99,10 +84,10 @@ def _longest_common_sublist(lists):
         mid = left + (right - left) // 2
         exists, sublist = has_common_sublist(mid)
         if exists:
-            result = sublist  # Update result with the latest found sublist
-            left = mid + 1    # Try to find a longer sublist
+            result = sublist
+            left = mid + 1
         else:
-            right = mid - 1   # Try with a shorter length
+            right = mid - 1
     pass
 
     return result
@@ -110,12 +95,10 @@ pass
 
 
 def _find_common_token_ids(component, tokenizer, force_match = False):
-    """
-    \n### User:\n\n
-    \n\n### User:\n\n
-    etc
-    we need to find the middle most repeatted part.
-    Tokenizers can tokenize newlines or spaces as 1 token!
+    """Find the middle-most repeated token sequence for a chat component.
+
+    Tokenizers may fold surrounding newlines/spaces into one token, so we probe
+    variants (e.g. "\\n### User:\\n\\n") to find the stable common core.
     """
     right_text = ""
     if   component.endswith (" "): right_text = " "
@@ -150,30 +133,26 @@ def _find_common_token_ids(component, tokenizer, force_match = False):
     # substring = [int(x) for x in substring if x.isdigit()]
     substring = _longest_common_sublist([x + [0] for x in all_input_ids])
 
-    # If substring is simply [0], this might be just the original single token
+    # substring == [0] may just be the original single token.
     # Fixes https://github.com/unslothai/unsloth/issues/1290
-    # Mistral [INST] [/INST] singular tokens breaks since we output [0] but we need [3] [4]
+    # Mistral [INST] [/INST] singular tokens break since we output [0] but need [3] [4].
     if substring == [0] and len(all_input_ids[0]) == 1:
         single_token = all_input_ids[0][0]
-        # Confirm single token in every single possible match
         if all(single_token in x for x in all_input_ids):
             substring = [single_token]
     pass
 
-    # Also if substring is original input_ids + [0], then leave it as the original one
-    # This happens when no newlines / spaces are used in chat template
-    # Eg Phi-4 does not use newlines or spaces
+    # If substring is original input_ids + [0], keep the original. Happens when
+    # the chat template uses no newlines/spaces (e.g. Phi-4).
     if (len(set(str(x) for x in all_input_ids)) == 1) and \
         (len(all_input_ids[0]) + 1 == len(substring)) and \
         (all_input_ids[0] == substring[:-1]):
 
-        # Use original un-changed substring
         substring = all_input_ids[0]
     pass
-    
-    # Also get rest of tokenized string
+
+    # Recover optional left/right tokens around the matched core
     original = tokenizer(component, add_special_tokens = False).input_ids
-    # Get optional left and right
     for j in range(len(original)):
         if original[j : j + len(substring)] == substring: break
     optional_left  = original[:j]
@@ -192,14 +171,11 @@ def train_on_responses_only(
     num_proc          = None,
     last_response_only = False, # Train only on the last assistant turn
 ):
-    """
-    Trains only on responses and not on the instruction by masking out
-    the labels with -100 for the instruction part.
+    """Train only on responses by masking instruction labels to -100.
 
-    If last_response_only=True, only the final assistant turn has its
-    labels unmasked; all earlier assistant turns remain masked at -100
-    (they are never written, so they keep the initialized -100 values
-    and are not copied from old_labels either).
+    With last_response_only=True, only the final assistant turn is unmasked;
+    earlier assistant turns stay at -100 (never written, never copied from
+    old_labels).
     """
     # All Unsloth Zoo code licensed under LGPLv3
     if tokenizer is None and trainer is not None:
@@ -270,13 +246,12 @@ def train_on_responses_only(
                 if (input_ids[j] == A_first) and \
                     (input_ids[j : (k := j + len_A_must)] == A_must):
 
-                    # Now backtrack to get previous optional tokens
+                    # Extend over optional tokens, backward then forward
                     for optional_left in A_left_reversed:
                         if j < 1: break
                         if optional_left == input_ids[j-1]: j -= 1
                         else: break
                     pass
-                    # And forwards look as well
                     for optional_right in A_right_forward:
                         if k >= n_minus_1: break
                         if optional_right == input_ids[k+1]: k += 1
@@ -286,21 +261,18 @@ def train_on_responses_only(
                     assistant_k = k
 
                     j = assistant_k
-                    # Given <assistant>, now find next user
+                    # Find the next <user> (or the final item if assistant is last)
                     while j < n:
-                        # Find <user>
-                        # Also accept last final item if assistant is the last turn
                         if (j == n_minus_1) or \
                             ((input_ids[j] == Q_first) and \
                              (input_ids[j : (k := j + len_Q_must)] == Q_must)):
 
-                            # Now backtrack to get previous optional tokens
+                            # Extend over optional tokens, backward then forward
                             for optional_left in Q_left_reversed:
                                 if j < 1: break
                                 if optional_left == input_ids[j-1]: j -= 1
                                 else: break
                             pass
-                            # And forwards look as well
                             for optional_right in Q_right_forward:
                                 if k >= n_minus_1: break
                                 if optional_right == input_ids[k+1]: k += 1
@@ -326,16 +298,14 @@ def train_on_responses_only(
                 j += 1
             pass
 
-            # Apply labels: only the last assistant turn when last_response_only=True.
-            # Note: spans[-1:] safely returns [] when spans is empty (no assistant turn
-            # was found), so a sample with no assistant turn stays fully masked at -100.
+            # Apply labels (last assistant turn only when last_response_only).
+            # spans[-1:] is [] when no assistant turn was found, so such samples
+            # stay fully masked at -100.
             apply_spans = spans[-1:] if last_response_only else spans
             for assistant_k, user_j in apply_spans:
                 if not use_old_labels:
-                    # Now copy input_ids to labels
                     labels[assistant_k : user_j] = input_ids [assistant_k : user_j]
                 else:
-                    # Copy over from old labels!
                     labels[assistant_k : user_j] = old_labels[assistant_k : user_j]
 
             all_labels.append(labels)
@@ -352,26 +322,23 @@ def train_on_responses_only(
         else:
             import psutil
             num_proc = min(max((psutil.cpu_count() or 1)+4, 2), 64)
-            # Check memory left so we can reduce multiprocessing to converse memory
+            # Cap by available memory to avoid OOM (1 proc per GB; 1 if <=2GB)
             memory_gb_left = psutil.virtual_memory().available / (1024**3)
             if memory_gb_left <= 2:
-                num_proc = 1 # Too risky, so set to 1
+                num_proc = 1
             else:
-                # Set it to int(memory_gb_left) so 16Gb = 16
                 num_proc = min(num_proc, int(memory_gb_left))
 
-    # In transformers 5.0+, VLM models skip dataset preparation in SFTTrainer.__init__
-    # (skip_prepare_dataset=True when _is_vlm=True). This means the dataset may not be
-    # tokenized yet. We need to tokenize it before applying _train_on_responses_only.
+    # transformers 5.0+ VLMs skip dataset prep in SFTTrainer.__init__
+    # (skip_prepare_dataset=True when _is_vlm), so tokenize before masking.
     def _maybe_tokenize_dataset(dataset):
         if dataset is None:
             return dataset
         sample = next(iter(dataset))
         if "input_ids" in sample:
             return dataset  # Already tokenized
-        # Need to tokenize - get the processing class from trainer
         _tokenizer = trainer.processing_class if hasattr(trainer, "processing_class") else trainer.tokenizer
-        # Get the actual tokenizer (not processor) for tokenization
+        # Use the actual tokenizer, not the processor
         if hasattr(_tokenizer, "tokenizer"):
             _tok = _tokenizer.tokenizer
         else:
@@ -390,10 +357,9 @@ def train_on_responses_only(
             return dataset.map(_tokenize_fn, **_map_kwargs)
     pass
 
-    # Filter out samples where all labels are -100 (no valid training signal).
-    # This can happen when truncation cuts off the response_part entirely,
-    # e.g. long reasoning/analysis channels in GPT-OSS that exceed max_seq_length.
-    # Such samples cause NaN loss since cross_entropy(mean) computes 0/0.
+    # Drop samples with all labels -100 (no training signal). Happens when
+    # truncation cuts off the response_part (e.g. long GPT-OSS reasoning
+    # channels), which would give NaN loss from cross_entropy(mean)'s 0/0.
     def _has_valid_labels(example):
         labels = example.get("labels")
         if labels is None: return True
@@ -479,22 +445,15 @@ def standardize_data_formats(
     batch_size            = 1000,
     num_proc              = None,
 ):
-    """
-    Standardizes ShareGPT and other formats to user/assistant Hugging Face format.
-    
-    Get aliases for the system, user and assistant roles.
-    These shall map to "system", "user" and "assistant" respectively.
-    
-    aliases_for_system    = ["system",],
-    aliases_for_user      = ["user", "human", "input",],
-    aliases_for_assistant = ["gpt", "assistant", "output",],
+    """Standardize ShareGPT and similar formats to user/assistant HF format.
+
+    The alias lists map source role names onto "system"/"user"/"assistant".
     """
     import collections
     import itertools
 
-    # Check if vision tokenizer is used - if yes, we must use the format:
-    # Text : {"role" : role, "content" : "Happy"}
-    # VLMs : {"role" : role, "content" : [{"type" : "text", "text" : "Happy"}]}
+    # VLMs need list-valued content ([{"type": "text", "text": ...}]); text
+    # models use a plain string.
     is_vlm = False
     if tokenizer is not None:
         if hasattr(tokenizer, "image_processor") or hasattr(tokenizer, "tokenizer"):
@@ -620,8 +579,7 @@ def sft_prepare_dataset(
     tokenizer = processing_class
     if is_vlm: tokenizer = processing_class.tokenizer
 
-    # Dynamic detection: check if model's module defines a function
-    # that requires token_type_ids when is_training=True
+    # Detect whether the model's module needs token_type_ids when training
     import sys as _sys
     _needs_token_type_ids = False
     # Split to avoid compiler substring match on masking_utils names
@@ -668,20 +626,17 @@ def sft_prepare_dataset(
     if _needs_token_type_ids:
         used_column_names.append("token_type_ids")
 
-    # Check if already tokenized so skip
+    # Skip tokenization if already tokenized; just set the data collator
     from transformers import DataCollatorForSeq2Seq, DataCollatorForLanguageModeling
     if "labels" in column_names:
         # Most likely forgot data collator!
         if is_vlm and not hasattr(tokenizer, "pad"):
-            # Check if processing_class has a .pad, if not, use tokenizer.tokenizer
             raise RuntimeError(f"Unsloth: {processing_class.__class__} does not have .pad!")
         self.data_collator = DataCollatorForSeq2Seq(tokenizer)
         used_column_names.append("labels")
         do_tokenize = False
     elif "input_ids" in column_names:
-        # Skip dataset prep, and set data collator
         if is_vlm and not hasattr(tokenizer, "pad"):
-            # Check if processing_class has a .pad, if not, use tokenizer.tokenizer
             raise RuntimeError(f"Unsloth: {processing_class.__class__} does not have .pad!")
         self.data_collator = DataCollatorForLanguageModeling(tokenizer, mlm = False)
         do_tokenize = False
@@ -698,7 +653,6 @@ def sft_prepare_dataset(
     pass
 
     if do_tokenize:
-        # Check double BOS tokens
         if do_formatting_func:
             test_text = formatting_func(next(iter(dataset)))
             if not isinstance(test_text, list):
@@ -726,14 +680,13 @@ def sft_prepare_dataset(
         else:
             test_text = next(iter(dataset))[dataset_text_field][0]
 
-        # Get chat template
         chat_template = getattr(processing_class, 'chat_template', '')
         if chat_template == '' and is_vlm:
             chat_template = getattr(tokenizer, 'chat_template', '')
         if chat_template is None:
             chat_template = ''
 
-        # Get bos_token
+        # Detect double BOS so we can drop the duplicate
         add_special_tokens = True
         bos_token_1 = getattr(processing_class, 'bos_token', None)
         bos_token_2 = getattr(tokenizer, 'bos_token', None)
@@ -745,7 +698,6 @@ def sft_prepare_dataset(
                 print("Unsloth: We found double BOS tokens - we shall remove one automatically.")
         pass
 
-        # Create tokenize function
         def _tokenize(example):
             return tokenizer(
                 example[dataset_text_field] if not do_formatting_func else formatting_func(example),
@@ -775,7 +727,6 @@ def sft_prepare_dataset(
             map_kwargs["batch_size"] = dataset._ex_iterable.batch_size
 
         if do_prompt_completion:
-            # Tokenize prompt/completion datasets for completion_only_loss
             _eos_token = getattr(tokenizer, 'eos_token', None)
 
             def _tokenize_pc(example):
@@ -833,14 +784,14 @@ def sft_prepare_dataset(
                 _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")
                 dataset = dataset.map(_tokenize, batched = True, remove_columns = list(column_names), **map_kwargs)
 
-        # If VLM, switch data collator since .pad is needed!
+        # VLMs need .pad; switch the data collator
         if is_vlm and not hasattr(processing_class, "pad") and not do_prompt_completion:
             data_collator = DataCollatorForLanguageModeling(tokenizer, mlm = False)
             self.data_collator = data_collator
         pass
     pass
     if packing:
-        # Try using new packing which works in TRL
+        # Use TRL's pack_dataset if available
         try:
             pack_dataset
         except:

--- a/unsloth_zoo/device_type.py
+++ b/unsloth_zoo/device_type.py
@@ -223,7 +223,6 @@ def get_device_type():
         return "cuda"
     elif hasattr(torch, "xpu") and torch.xpu.is_available():
         return "xpu"
-    # Check torch.accelerator
     if hasattr(torch, "accelerator"):
         if not torch.accelerator.is_available():
             # Test-only CPU fallback. The env var is read exactly once per
@@ -283,10 +282,7 @@ if DEVICE_TYPE == "hip":
 pass
 
 def device_synchronize():
-    """
-    Synchronize the current device (CUDA, XPU, or HIP).
-    This is a cross-platform replacement for torch.cuda.synchronize().
-    """
+    """Cross-platform torch.cuda.synchronize() (CUDA, XPU, or HIP)."""
     if DEVICE_TYPE in ("cuda", "hip"):
         if torch.cuda.is_available():
             torch.cuda.synchronize()
@@ -297,10 +293,7 @@ def device_synchronize():
 pass
 
 def device_empty_cache():
-    """
-    Empty the active device cache (CUDA, XPU, or HIP).
-    Cross-platform replacement for torch.cuda.empty_cache().
-    """
+    """Cross-platform torch.cuda.empty_cache() (CUDA, XPU, or HIP)."""
     if DEVICE_TYPE in ("cuda", "hip"):
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
@@ -311,10 +304,7 @@ def device_empty_cache():
 pass
 
 def device_is_bf16_supported():
-    """
-    Whether the active device (CUDA, XPU, or HIP) supports bfloat16.
-    Cross-platform replacement for torch.cuda.is_bf16_supported().
-    """
+    """Cross-platform torch.cuda.is_bf16_supported() (CUDA, XPU, or HIP)."""
     if DEVICE_TYPE in ("cuda", "hip"):
         if torch.cuda.is_available():
             return torch.cuda.is_bf16_supported()

--- a/unsloth_zoo/empty_model.py
+++ b/unsloth_zoo/empty_model.py
@@ -45,7 +45,7 @@ def _is_gemma4_config(config):
 pass
 
 def is_comparable(val):
-    # Don't treat tensors as comparable, only basic types
+    # Only basic types, not tensors
     from enum import Enum
     return isinstance(val, (int, float, bool, str, list, tuple, type(None), torch.dtype, Enum))
 
@@ -75,7 +75,6 @@ def compare_attributes(original_model, new_model):
     type_mismatches = []
     value_mismatches = []
 
-    # Extract all config keys at any level
     config_keys = _extract_all_config_keys(original_model.config) if hasattr(original_model, 'config') else set()
     config_keys = config_keys | {'config'}
 
@@ -88,19 +87,17 @@ def compare_attributes(original_model, new_model):
         buffer_names = {name for name,_ in original_module.named_buffers(recurse=False)}
 
 
-        # Find missing attributes (in original but not in new)
+        # Missing: in original but not in new
         missing_in_new = orig_attrs - new_attrs
         missing_in_new = missing_in_new - {'hf_device_map', 'source_cls'}
         if missing_in_new:
             for attr in sorted(missing_in_new):
                 missing_attrs.append(f"{name}.{attr}")
 
-        # Find extra attributes (in new but not in original)
+        # Extra: in new but not in original
         extra_in_new = new_attrs - orig_attrs
         if extra_in_new:
             print(f'Found some extra attributes like: {list(extra_in_new)[:5]}...')
-            # for attr in sorted(extra_in_new):
-            #     print(f"EXTRA ATTRIBUTE: {name}.{attr} (exists in new model but not original)")
 
         # Compare common attributes and buffer names
         common_attrs = orig_attrs & new_attrs
@@ -117,7 +114,6 @@ def compare_attributes(original_model, new_model):
             original_comparable = is_comparable(original_val)
             new_comparable = is_comparable(new_val)
 
-            # Check type mismatches first
             if type(original_val) != type(new_val):
                 if original_comparable or new_comparable:
                     type_mismatches.append(f"{name}.{attr}: original {type(original_val).__name__} != new {type(new_val).__name__}")
@@ -126,7 +122,6 @@ def compare_attributes(original_model, new_model):
             try:
                 if isinstance(original_val, dict) and isinstance(new_val, dict):
                     if attr in config_keys:
-                        # only compare those attributes that are relevant
                         compare_dicts(original_val, new_val, prefix=f"{name}.{attr}")
                 elif original_comparable and new_comparable:
                     if original_val != new_val:
@@ -140,7 +135,6 @@ def compare_attributes(original_model, new_model):
             except Exception as e:
                 type_mismatches.append(f"{name}.{attr}: comparison failed - {str(e)}")
 
-    # Print summary
     if missing_attrs:
         print(f"\n🚨 MISSING ATTRIBUTES ({len(missing_attrs)}):")
         for attr in missing_attrs:
@@ -160,7 +154,7 @@ def compare_attributes(original_model, new_model):
         print("\n✅ No missing attributes or type mismatches found!")
 
 def _extract_all_config_keys(config):
-    """Extract all keys from config at any nesting level"""
+    """Extract config keys at any nesting level."""
     keys = set()
 
     def _extract_keys(obj, prefix=""):
@@ -184,7 +178,6 @@ def copy_attributes(original_model, new_model):
         print("Cannot copy attributes: one of the models is None")
         return
 
-    # Extract all config keys at any level
     config_keys = _extract_all_config_keys(original_model.config) if hasattr(original_model, 'config') else set()
     config_keys = config_keys | {'config'}
     extra_attrs = {'hf_quantizer', }
@@ -205,14 +198,14 @@ def copy_attributes(original_model, new_model):
                 original_val = getattr(original_module, attr)
 
                 if attr in buffer_names and attr != "layer_scalar":
-                    # Some models like gemma3 have embed_scale and position_ids as buffers
-                    # Lets copy them over to avoid inconsistencies
+                    # gemma3 etc. keep embed_scale / position_ids as buffers; copy
+                    # them to avoid inconsistencies.
                     setattr(module, attr, original_val.to(new_model.device))
                 elif is_comparable(original_val):
                     setattr(module, attr, original_val)
                     copied_count += 1
                 elif isinstance(original_val, dict):
-                    # Only copy dictionaries whose attribute name exists in config keys
+                    # Only copy dicts whose attribute name exists in config keys
                     if attr in config_keys:
                         setattr(module, attr, deepcopy(original_val))
                         copied_count += 1
@@ -222,7 +215,7 @@ def copy_attributes(original_model, new_model):
                         skipped_attrs.append(f"{attr} (dict not in config)")
                         dict_skipped_count += 1
                 elif isinstance(original_val, PretrainedConfig):
-                    # Sometimes the .config in original model is of config class and not a dict. Copy it as is.
+                    # Sometimes .config is a config class, not a dict; copy as is.
                     setattr(module, attr, deepcopy(original_val))
                     copied_count += 1
                 elif attr in extra_attrs:
@@ -272,29 +265,25 @@ def create_empty_causal_lm(config, dtype = torch.float16):
     kwargs = {"torch_dtype" if HAS_TORCH_DTYPE else "dtype" : dtype}
     original_meta_model = None
     error = None
-    # [NOTE] init_empty_weights(include_buffers = True) is wrong
-    # include_buffers=False is required because buffers (non-trainable tensors like
-    # embed_scale, position_ids) must be initialized with actual values, not on meta
-    # device. Models like Gemma 3 use embed_scale as a buffer in their embedding layer.
-    # With include_buffers=True, buffers become empty meta tensors with no data,
-    # causing attribute access failures during inference.
+    # include_buffers=False is required: buffers (e.g. Gemma 3's embed_scale,
+    # position_ids) need real values, not empty meta tensors, or attribute
+    # access fails during inference.
     with init_empty_weights(include_buffers = False):
         if model_name is not None and not using_text_subconfig:
             try:
-                # This would persist quantization information for FP8 weights
+                # Persists quantization information for FP8 weights
                 original_meta_model = AutoModelForCausalLM.from_pretrained(model_name, **kwargs)
             except Exception as e:
                 error = str(e)
                 original_meta_model = None
         if original_meta_model is None:
             try:
-                # We must do this for 4.57.0 and above
+                # Required for transformers 4.57.0 and above
                 original_meta_model = AutoModelForCausalLM.from_config(causal_config)
             except Exception as e:
                 error = str(e)
                 original_meta_model = None
     pass
-    # Suppress warning on uninited weights
     os.environ["UNSLOTH_WARN_UNINITIALIZED"] = old_warn
     if error is not None and original_meta_model is None:
         print(f"Failed to create original_meta_model for AutoModelForCausalLM. Error {error}")
@@ -463,7 +452,7 @@ def patch_gemma4_vllm_k_eq_v_support():
             if quant_states is None:
                 continue
 
-            # k_eq_v reuses K as V: the raw-weight loader already duplicates
+            # k_eq_v reuses K as V; the raw-weight loader already duplicates
             # k_proj -> v_proj, so prequant BnB needs the matching QuantState.
             if kind == "packed":
                 if isinstance(quant_states, dict) and 2 not in quant_states and 1 in quant_states:
@@ -491,7 +480,6 @@ def create_empty_vision_model(config, dtype = torch.float16):
     # Patch SiglipVisionModel to skip weight init on meta device.
     if not hasattr(SiglipVisionModel, "_original_initialize_weights"):
         SiglipVisionModel._original_initialize_weights = SiglipVisionModel._init_weights
-        # Patch _init_weights to a no-op with correct signature
         def _init_weights(self, module):
             return
         SiglipVisionModel._init_weights = _init_weights
@@ -500,14 +488,10 @@ def create_empty_vision_model(config, dtype = torch.float16):
     model_cls = getattr(transformers, config.architectures[0])
 
     try:
-        # Use accelerate's init_empty_weights, not transformers.modeling_utils
+        # accelerate's init_empty_weights, not transformers.modeling_utils.
+        # Default include_buffers=False keeps buffers (e.g. Gemma 3's embed_scale)
+        # as real tensors so inference-time attribute access works.
         from accelerate import init_empty_weights
-        # [NOTE] init_empty_weights(include_buffers = True) is wrong
-        # include_buffers=False is required because buffers (non-trainable tensors like
-        # embed_scale, position_ids) must be initialized with actual values, not on meta
-        # device. Models like Gemma 3 use embed_scale as a buffer in their embedding layer.
-        # With include_buffers=True, buffers become empty meta tensors with no data,
-        # causing attribute access failures during inference.
         with init_empty_weights():
             original_meta_model = model_cls(config)
     except Exception as e:
@@ -550,7 +534,7 @@ def create_empty_vision_model(config, dtype = torch.float16):
         "patch_size": 1,
         "image_size": 1,
         "vision_output_dim": 1,
-        # The following are different names for the same concept
+        # Different names for the same concept
         "num_heads": 1,
         "attention_heads": 1,
         "num_attention_heads": 1,
@@ -600,7 +584,7 @@ def set_additional_modules(new_model, quant_state_dict, config):
         language_model = new_model.model
 
     embed_tokens_key = f"{language_model_prefix}.embed_tokens.weight"
-    # Explicit None check since pad_token_id=0 is valid.
+    # Explicit None check: pad_token_id=0 is valid.
     pad_token_id = getattr(config, "pad_token_id", None)
     if pad_token_id is None:
         text_config = getattr(config, "text_config", None)
@@ -621,10 +605,10 @@ def set_additional_modules(new_model, quant_state_dict, config):
         module.num_embeddings = num_embeddings
         module.embedding_dim = embedding_dim
 
-    set_embedding(language_model.embed_tokens, embed_tokens_key, pad_token_id) # This sets the embedding that we generally find in language (sub)model
+    set_embedding(language_model.embed_tokens, embed_tokens_key, pad_token_id)
 
     if 'model.visual.pos_embed.weight' in quant_state_dict:
-        # This is to handle visual embeddings in Qwen 3 VL
+        # Qwen 3 VL visual embeddings
         set_embedding(new_model.model.visual.pos_embed, 'model.visual.pos_embed.weight', None, requires_grad=False)
 
     norm_key = f"{language_model_prefix}.norm.weight"
@@ -633,9 +617,9 @@ def set_additional_modules(new_model, quant_state_dict, config):
     norm = torch.nn.Parameter(norm, requires_grad = False)
     language_model.norm.weight = norm
 
-    # LM Head. Do note that for some models, like Mistral3ForConditionalGeneration,
-    # there can be mismatch in the value of tie_word_embeddings between config and text_config
-    # we prefer picking the one in text_config. If you notice any issue later, please report it!
+    # LM Head. For some models (e.g. Mistral3ForConditionalGeneration)
+    # tie_word_embeddings can differ between config and text_config; prefer
+    # text_config.
     text_config = getattr(config, "text_config", config)
     if getattr(text_config, "tie_word_embeddings", False):
         lmhead_key = f"{language_model_prefix}.embed_tokens.weight"
@@ -678,7 +662,7 @@ def set_additional_modules(new_model, quant_state_dict, config):
     print(f'Performing substitution for {additional_keys=}')
 
     for key in additional_keys:
-        # sometimes it can be in new_model.model. instead of new_model.
+        # May live under new_model.model. instead of new_model.
         for prefix in ['new_', 'new_model.']:
             try:
                 val = quant_state_dict[key]
@@ -843,13 +827,7 @@ def finalize_huggingface_model(
 pass
 
 def get_model_layer_config(return_non_layered=True):
-    """
-    Returns a unified layer configuration containing the union of layer names
-    from all supported vision models. Serves as a fallback.
-
-    Returns:
-        dict: Dictionary containing layer templates for different components.
-    """
+    """Unified layer-name templates (union over supported vision models)."""
     layer_templates = {
         'standard_layers': {
             "model.language_model.layers.{kk}.layer_scalar",
@@ -1085,21 +1063,13 @@ def get_model_layer_config(return_non_layered=True):
 def get_model_type(config):
     model_type = getattr(config, "model_type", "causal_lm")
     if hasattr(config, "vision_config"):
-        # vllm curretly seems to be having qwen 2.5 vl model type as qwen2_5_vl_text for some reason
-        # aka vllm_config.model_type is qwen2_5_vl_text but config.vision_config.model_type is qwen2_5_vl
+        # vLLM reports qwen2_5_vl as qwen2_5_vl_text, but vision_config.model_type
+        # keeps the real qwen2_5_vl; prefer the vision_config value.
         model_type = getattr(config.vision_config, "model_type", model_type)
     return model_type
 
 def get_model_layer_counts(config):
-    """
-    Returns layer counts for different model types.
-
-    Args:
-        config: Model configuration
-
-    Returns:
-        int or dict: Number of layers (int for causal_lm, dict for VL models)
-    """
+    """Layer counts per model type (int for causal_lm, dict for VL models)."""
     model_type = get_model_type(config)
 
     if model_type == "mllama":
@@ -1323,11 +1293,7 @@ pass
 
 
 def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_state_dict):
-    """
-    Extracts vision layers for any supported vision model by dynamically using
-    a model-specific configuration. This approach is more robust and avoids
-    failures by correctly identifying layer paths and parameters.
-    """
+    """Extract vision layers via the model-specific layer config."""
     model_type = get_model_type(vllm_internals.config)
     layer_config = get_model_layer_config()
 
@@ -1347,22 +1313,21 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
             layer_module = _get_nested_attr(vllm_internals, layer_path)
 
             if 'language_model.model' in layer_path:
-                # vLLM uses vllm_internals.language_model.model.layers while HF uses model.language_model.layers
+                # vLLM uses language_model.model.layers; HF uses language_model.layers
                 layer_path = layer_path.replace('language_model.model', 'language_model')
 
 
             if layer_module is not None:
                 if "qkv" in layer_path:
                     if model_type in ("qwen2_5_vl", "qwen3_vl", "qwen3_5"):
-                        # If the HF model too prefers having merged qkv, we do this
-                        # This is evident in qwen-2.5-vl and qwen-3-vl so far.
+                        # HF keeps merged qkv for these (qwen-2.5-vl, qwen-3-vl)
                         get_state_dict(layer_path, 0, state_dict, layer_module, slice_weights=False)
                     else:
                          get_state_dict(f"{layer_path.replace('qkv_proj', 'q_proj')}", 0, state_dict, layer_module)
                          get_state_dict(f"{layer_path.replace('qkv_proj', 'k_proj')}", 1, state_dict, layer_module)
                          get_state_dict(f"{layer_path.replace('qkv_proj', 'v_proj')}", 2, state_dict, layer_module)
                 elif "gate_up_proj" in layer_path:
-                    # vLLM seems to have merged gate and up proj recently for qwen vl. This is to handle new variant
+                    # vLLM merged gate and up proj for qwen vl; split them back.
                     # https://github.com/jeejeelee/vllm/commit/a71e4765cc0c1534f2a8891aaf628e1751f6df07
                     get_state_dict(f"{layer_path.replace('gate_up_proj','gate_proj')}", 0, state_dict, layer_module)
                     get_state_dict(f"{layer_path.replace('gate_up_proj','up_proj')}", 1, state_dict, layer_module)
@@ -1378,21 +1343,20 @@ def extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_stat
                     else:
                         print(f"Unsloth: Skipping layer '{layer_path}' of unexpected type: {type(layer_module)}")
 
-    # Extract non-layered vision components using a more robust method
+    # Extract non-layered vision components
     non_layered_components = layer_config.get('non_layered_components', [])
     for component_path in non_layered_components:
         component = _get_nested_attr(vllm_internals, component_path)
 
         if component is not None:
             if hasattr(component, 'weight'):
-                # Prefer using get_state_dict when possible
                 get_state_dict(component_path, 0, state_dict, component)
             elif isinstance(component, torch.Tensor):
                 state_dict[component_path] = component.data
                 quant_state_dict[component_path] = component.data
             elif isinstance(component, torch.nn.Module):
                 for param_name, param in component.named_parameters():
-                    # if the parameter is to be extracted separately, skip it
+                    # Skip params extracted separately
                     if param_name.replace('.weight', '') in non_layered_components: continue
                     full_param_path = f"{component_path}.{param_name}"
                     if hasattr(param, 'weight'):

--- a/unsloth_zoo/flex_attention/attention_sink.py
+++ b/unsloth_zoo/flex_attention/attention_sink.py
@@ -51,7 +51,7 @@ def causal_mask_with_sink(batch, head, q_idx, kv_idx):
     1 X X X     2   X X
     2 X X X X   3   X X X
     """
-    # We add (q_idx + 1) since first column is sink token
+    # +1 on q_idx since the first column is the sink token
     causal_mask = (q_idx + 1) >= kv_idx
     sink_first_column = kv_idx == 0
     return causal_mask | sink_first_column
@@ -95,12 +95,9 @@ def old_flex_attention_with_sink(
     compile = True,
 ):
     """
-    Allows one sink token to be attended to for full/sliding window attention
-    Similar to Efficient Streaming Language Models with Attention Sinks
-    Primarily for GPT-OSS 2025
-
-    [WARNING] This only works for training. Inference fails since KV cache's
-    absolute positioning will fail.
+    One sink token attended to for full/sliding window attention (cf. Efficient
+    Streaming Language Models with Attention Sinks). Primarily for GPT-OSS 2025.
+    [WARNING] Training only; inference fails since KV cache absolute positioning breaks.
     """
     if not self_attn.training:
         raise NotImplementedError("Unsloth: This version of flex attention only works for training")
@@ -116,14 +113,13 @@ def old_flex_attention_with_sink(
     key_padded   = torch.cat([key  .new_zeros(bsz, heads_KV, 1, dim), key],   dim = 2)
     value_padded = torch.cat([value.new_zeros(bsz, heads_KV, 1, dim), value], dim = 2)
 
-    # Check for sliding window
     sliding_window = sliding_window or getattr(self_attn, "sliding_window", None)
     mask_mod = \
         generate_sliding_window_with_sink(sliding_window) \
         if type(sliding_window) is int and sliding_window != 0 else \
         causal_mask_with_sink
     score_mod = generate_sink_score_mod(sink_weights)
-    block_mask = compiled_create_block_mask(mask_mod, qlen_Q, qlen_KV+1, device = key.device) # Add 1 since we padded
+    block_mask = compiled_create_block_mask(mask_mod, qlen_Q, qlen_KV+1, device = key.device) # +1 for padding
     attn_output = (flex_attention if compile else uncompiled_flex_attention)(
         query,
         key_padded,
@@ -165,11 +161,9 @@ def flex_attention_with_sink(
     has_static_cache = True,
 ):
     """
-    Allows one sink token to be attended to for full/sliding window attention
-    Similar to Efficient Streaming Language Models with Attention Sinks
-    Primarily for GPT-OSS 2025
-
-    [WARNING] has higher error than old_flex_attention_with_sink, but works for inference
+    One sink token attended to for full/sliding window attention (cf. Efficient
+    Streaming Language Models with Attention Sinks). Primarily for GPT-OSS 2025.
+    [WARNING] higher error than old_flex_attention_with_sink, but works for inference.
     """
     assert getattr(self_attn, "sinks", None) is not None, "Unsloth: self_attn must have sinks"
     sink_weights = self_attn.sinks
@@ -179,13 +173,11 @@ def flex_attention_with_sink(
     bsz, heads_Q, qlen_Q, dim = query.shape
     _, heads_KV, qlen_KV, _ = key.shape
 
-    # Check for sliding window
     sliding_window = sliding_window or getattr(self_attn, "sliding_window", None)
     is_training = self_attn.training
     mask_mod = None
     block_mask = None
     has_flex_cache = hasattr(self_attn, "_flex_attention_cache")
-    # Handle inference and training
     if attention_mask is not None and has_static_cache:
         if is_training or (
             not is_training and (not has_flex_cache or qlen_Q != 1)
@@ -200,13 +192,11 @@ def flex_attention_with_sink(
                 # We must account for left padding
                 padding_start_idx = attention_mask.argmax(1).to(query.device)
                 do_padding = torch.arange(max(qlen_Q, qlen_KV), device = query.device).repeat((bsz, 1)) < padding_start_idx.unsqueeze(0).T
-                # We also make all padded tokens Q=1, K=-inf
-                # Note if Q=0, K=0, Q*K = 0, but exp(0) = 1, so that's wrong
-                # Only exp(-inf) = 0. So Q=1, K=-inf, Q*K = -inf
+                # Padded tokens: Q=1, K=-inf so Q*K=-inf (exp=0). Q=K=0 would
+                # give Q*K=0 with exp(0)=1, which is wrong.
                 query.transpose(2, 1)[do_padding[:, :qlen_Q ]] = 1
                 key  .transpose(2, 1)[do_padding[:, :qlen_KV]] = -torch.inf
                 value.transpose(2, 1)[do_padding[:, :qlen_KV]] = 0
-                # Use special padded mask creators
                 mask_mod = prefill_mask_mod = \
                     generate_sliding_window_mask_with_padding(sliding_window, padding_start_idx) \
                     if type(sliding_window) is int and sliding_window != 0 else \
@@ -220,7 +210,7 @@ def flex_attention_with_sink(
             block_mask = self_attn._flex_attention_cache(key)
         pass
     pass
-    # Create mask_mod on training and decoding steps
+    # mask_mod for training and decoding steps
     if mask_mod is None:
         mask_mod = \
             generate_sliding_window_mask(sliding_window) \

--- a/unsloth_zoo/flex_attention/utils.py
+++ b/unsloth_zoo/flex_attention/utils.py
@@ -102,23 +102,10 @@ try:
         return q_idx >= kv_idx
 
     def generate_causal_mask_with_padding(padding_start_idx = None):
-        """
-        Causal mask for Flex Attention with left padding support.
-        Normal causal mask:
-            k0 k1 k2 k3 k4
-        q0   X
-        q1   X  X
-        q2   X  X  X
-        q3   X  X  X  X
-        q4   X  X  X  X  X
-        If we add 2 tokens as padded tokens, we get:
-            #0 #1 k2 k3 k4
-        #0
-        #1
-        q2         X
-        q3         X  X
-        q4         X  X  X
-        Assume padding_start_idx == [2]
+        """Causal mask for Flex Attention with left-padding support.
+
+        Both q and kv below padding_start_idx[batch_idx] are masked out, so
+        padded tokens attend to nothing and are attended by nothing.
         """
         assert padding_start_idx is not None and type(padding_start_idx) is torch.Tensor
         assert padding_start_idx.dim() == 1
@@ -132,18 +119,7 @@ try:
         return causal_mask
 
     def generate_decoding_causal_mask_with_padding(padding_start_idx = None):
-        """
-        For decoding purposes only. We remove q_padded since decoding attends to 1 q
-        Assume padded tokens = 5
-            #0 #1 #2 #3 #4 k5 k6
-        #0   #
-        #1   #  #
-        #2   #  #  #
-        #3   #  #  #  #
-        #4   #  #  #  #  #
-        q5   #  #  #  #  #  X
-        q6   #  #  #  #  #  X  X
-        """
+        """Decoding-only causal mask: drop the q_padded check since decoding attends to 1 q."""
         assert padding_start_idx is not None and type(padding_start_idx) is torch.Tensor
         assert padding_start_idx.dim() == 1
         assert padding_start_idx.shape[0] >= 1
@@ -195,13 +171,8 @@ try:
         return sliding_window
 
     def generate_decoding_sliding_window_mask_with_padding(window_size: int, padding_start_idx = None):
-        """
-        We cannot use padding_start_idx[batch_idx] for SWA decoding since
-        assume padding_start_idx=[3406, 4000, 0] and SW=128 then it'll always
-        be masked since the KV size=128.
-
-        Since we set padded tokens = 0 always, we simply return the generic SWA.
-        """
+        """SWA decoding: padding_start_idx can exceed KV size (e.g. 3406 with SW=128),
+        masking everything; since padded tokens are always 0 we just return generic SWA."""
         return generate_sliding_window_mask(window_size)
 
     # For inference see https://pytorch.org/blog/flexattention-for-inference

--- a/unsloth_zoo/fused_losses/ast_rewriter.py
+++ b/unsloth_zoo/fused_losses/ast_rewriter.py
@@ -8,30 +8,23 @@
 
 """AST-level rewriter for the canonical HF lm_head / loss_function triplet.
 
-Match:
-    <LOGITS> = self.<HEAD>(<HIDDEN>)              # optional .float()/[slice]/.contiguous() wrappers
-    if labels is not None:
-        <LOSS> = self.loss_function(<LOGITS>, labels, vocab_size=..., **kwargs)
+Matches ``<LOGITS> = self.<HEAD>(<HIDDEN>)`` (optional .float()/[slice]/
+.contiguous() wrappers) followed by an ``if labels is not None:`` branch
+computing ``self.loss_function(<LOGITS>, labels, vocab_size=..., **kwargs)``.
 
-Rewrite the labels branch to two paths:
-  - default (``UNSLOTH_RETURN_LOGITS`` unset): ``unsloth_fused_lm_head_loss(
-    <HIDDEN>, self.<HEAD>, labels, ...)`` (skipping the bf16 logits + fp32
-    cast); ``logits = EMPTY_LOGITS``. No lm_head matmul on the hot path.
+Rewrites the labels branch to two paths:
+  - default (``UNSLOTH_RETURN_LOGITS`` unset): ``unsloth_fused_lm_head_loss``
+    (no lm_head matmul on the hot path); ``logits = EMPTY_LOGITS``.
   - opt-in (``UNSLOTH_RETURN_LOGITS=1``): materialise logits once via the
-    original ``self.<HEAD>(<HIDDEN>)`` expression, then route the loss
-    through the model's own ``self.loss_function`` on those logits. One
-    lm_head matmul total (vs two if we kept the fused kernel and computed
-    logits separately for the return slot).
+    original head expr, then route loss through ``self.loss_function`` on
+    them. One lm_head matmul total.
 
-The else (generation) branch keeps the original RHS verbatim. Forwards
-that miss the triplet fall through to ``_UNMATCHED``; the LOSS_MAPPING
-sweep is the backstop.
+The else (generation) branch keeps the original RHS. Forwards missing the
+triplet fall through; the LOSS_MAPPING sweep is the backstop.
 
-``UNSLOTH_RETURN_HIDDEN_STATES`` is intentionally not handled here:
-GRPO's hidden-states fast path lives in the compiler-rewritten forward
-(``unsloth_zoo/compiler.py``), which always overrides the AST forward
-for the unsloth-supported ``*ForCausalLM`` classes that callers actually
-use with that env var.
+``UNSLOTH_RETURN_HIDDEN_STATES`` is handled instead in the compiler-rewritten
+forward (``unsloth_zoo/compiler.py``), which overrides the AST forward for
+the supported ``*ForCausalLM`` classes used with that env var.
 """
 
 from __future__ import annotations
@@ -71,7 +64,7 @@ def _is_self_attr_call(node: ast.AST) -> bool:
 
 
 def _find_inner_self_call(value: ast.AST) -> ast.Call | None:
-    """First Call descendant whose func is `self.<X>`. Lets us see through
+    """First Call descendant whose func is `self.<X>`, seeing through
     `.float()` / `[slice]` / `.contiguous()` chains."""
     for node in ast.walk(value):
         if _is_self_attr_call(node):
@@ -80,8 +73,8 @@ def _find_inner_self_call(value: ast.AST) -> ast.Call | None:
 
 
 def _find_loss_function_call(if_block: ast.If) -> ast.Call | None:
-    # Only direct body statements -- nested ifs (guards) inside the labels
-    # branch would be silently dropped by the wholesale rewrite.
+    # Only direct body statements: nested ifs inside the labels branch would
+    # be dropped by the wholesale rewrite.
     for stmt in if_block.body:
         if isinstance(stmt, ast.Assign):
             v = stmt.value
@@ -129,8 +122,9 @@ def _capture(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> TripletCapture | Non
     if if_node is None:
         return None
 
-    # Reject non-trivial label branches: anything more than `[loss = self.loss_function(...)]`
-    # is silently lost by the wholesale rewrite (e.g. CSM auxiliary depth-decoder loss).
+    # Reject non-trivial label branches: anything beyond a single
+    # `loss = self.loss_function(...)` is lost by the wholesale rewrite (e.g.
+    # CSM auxiliary depth-decoder loss).
     if if_node.orelse:
         return None
     if len(if_node.body) != 1:
@@ -212,11 +206,10 @@ def _capture(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> TripletCapture | Non
             continue
         inner = _find_inner_self_call(stmt.value)
         if inner is None:
-            # The logits-bearing name is re-assigned by a non-lm_head
-            # expression (e.g. `logits = logits * self.logit_scale` for
-            # Cohere). Removing the original lm_head call would leave the
-            # rebinding referencing an undefined `logits`. Bail out and
-            # let the LOSS_MAPPING patch handle this class.
+            # logits re-assigned by a non-lm_head expr (e.g. Cohere's
+            # `logits = logits * self.logit_scale`); removing the lm_head call
+            # would leave it referencing an undefined `logits`. Bail and let
+            # LOSS_MAPPING handle this class.
             return None
         head_attr = inner.func.attr
         if not inner.args:
@@ -241,10 +234,9 @@ def _capture(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> TripletCapture | Non
             loss_init_idx = j
             break
 
-    # Bail if any statement between lm_head and the labels-if touches
-    # logits (e.g. Gemma3 final_logit_softcapping): it would run on
-    # EMPTY_LOGITS in the labels branch, so fused loss would see
-    # un-softcapped logits.
+    # Bail if any statement between lm_head and the labels-if touches logits
+    # (e.g. Gemma3 final_logit_softcapping): it would run on EMPTY_LOGITS in
+    # the labels branch, so fused loss would see un-softcapped logits.
     for j in range(lm_head_assign_idx + 1, if_idx):
         if j == loss_init_idx:
             continue
@@ -280,11 +272,10 @@ def _build_replacement(cap: TripletCapture) -> list[ast.stmt]:
     hidden_src = ast.unparse(cap.hidden_expr)
     logits_rhs = cap.logits_rhs_src or f"self.{head_attr}({hidden_src})"
 
-    # Labels branch. Default path: fused kernel, logits = EMPTY_LOGITS
-    # (no lm_head matmul at all). UNSLOTH_RETURN_LOGITS=1 path: materialise
-    # the full lm_head matmul once and route loss through the model's own
-    # self.loss_function on those logits. Avoids double matmul (fused
-    # kernel chunks lm_head internally; logits_rhs runs the full matmul).
+    # Labels branch. Default: fused kernel, logits = EMPTY_LOGITS (no lm_head
+    # matmul). UNSLOTH_RETURN_LOGITS=1: run the full lm_head matmul once and
+    # route loss through self.loss_function on those logits (avoids the double
+    # matmul of fused-kernel + separate logits_rhs).
     template = textwrap.dedent(f"""
         if labels is not None:
             if os.environ.get('UNSLOTH_RETURN_LOGITS', '0') == '1':
@@ -335,8 +326,8 @@ def rewrite_forward_source(source: str) -> tuple[str | None, TripletCapture | No
             continue
         new_body.append(stmt)
     fn.body = new_body
-    # @can_return_tuple carries return_dict=False semantics and must
-    # survive; only strip the docstring-only decorators below.
+    # @can_return_tuple carries return_dict=False semantics and must survive;
+    # strip only the docstring-only decorators below.
     _DROP_DECORATORS = {
         "auto_docstring",
         "add_start_docstrings",

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -33,9 +33,9 @@ from ..device_type import DEVICE_TYPE
 TARGET_GB = os.environ.get("UNSLOTH_CE_LOSS_TARGET_GB", None)
 N_CHUNKS = os.environ.get("UNSLOTH_CE_LOSS_N_CHUNKS", None)
 
-# Register grad_and_value_impl in trace_rules as defense-in-depth.
-# grad_impl is registered but grad_and_value_impl is not, which can cause
-# GB0149 "Unsupported functorch tracing attempt" in some configurations.
+# Register grad_and_value_impl in trace_rules (grad_impl is registered but
+# grad_and_value_impl is not, which can cause GB0149 "Unsupported functorch
+# tracing attempt" in some configurations).
 try:
     from torch._dynamo.trace_rules import manual_torch_name_rule_map as _trace_map
     from torch._dynamo.variables.higher_order_ops import FunctorchHigherOrderVariable as _FHOV
@@ -138,7 +138,7 @@ pass
 
 @functools.cache
 def _get_chunk_multiplier(vocab_size, target_gb = None):
-    """ Gets chunk size that fits the target max memory usage (1GB) """
+    """Chunk multiplier sized to fit target max memory usage."""
     if target_gb is None:
         # Find current VRAM left in the GPU, and use 50% or less of it
         free, total = torch.xpu.mem_get_info(0) if DEVICE_TYPE == "xpu" else torch.cuda.mem_get_info(0)
@@ -157,7 +157,7 @@ def _get_chunk_multiplier(vocab_size, target_gb = None):
 pass
 
 def get_chunk_size(bsz, qlen, vocab_size, target_gb = None):
-    """ Gets chunk size that fits the target max memory usage (1GB) """
+    """Number of chunks that fits the target max memory usage."""
     multiplier = _get_chunk_multiplier(vocab_size, target_gb)
     n_splits = (bsz*qlen) * multiplier
     # n_splits = max(round(n_splits / 4) * 4, 1) # Output only multiples of 4
@@ -166,8 +166,7 @@ def get_chunk_size(bsz, qlen, vocab_size, target_gb = None):
 pass
 
 class UnslothFusedLoss(torch.autograd.Function):
-    # One-time flag so the "scaling=0" info message is logged at most once per
-    # process, even if the condition triggers on every backward call.
+    # Log the "scaling=0" info message at most once per process.
     _scaling_zero_logged = False
 
     @staticmethod
@@ -514,11 +513,9 @@ class UnslothFusedLoss(torch.autograd.Function):
                         f"Fused losses grad_output scaled by {scale_factor_val} (got {grad_scale_val}, expected {scaling})"
                     )
 
-        # Out-of-place mul so that ctx.saved_tensors' version counter does not
-        # bump; this keeps retain_graph / double-backward-capable flows working.
-        # Measured peak-memory delta vs. in-place mul is <3 MB across 14
-        # configurations (LoRA, full-FT, MoE, vision, bsz up to 16, seq up to
-        # 8192) because the temporary is freed before peak-setting allocations.
+        # Out-of-place mul so ctx.saved_tensors' version counter doesn't bump,
+        # keeping retain_graph / double-backward flows working. Measured peak
+        # memory delta vs in-place is <3 MB across 14 configs.
         grad_inputs = grad_inputs * scale_factor
         if grad_lm_head is not None: grad_lm_head = grad_lm_head * scale_factor
         if grad_lm_head_bias is not None: grad_lm_head_bias = grad_lm_head_bias * scale_factor

--- a/unsloth_zoo/fused_losses/forward_adapter.py
+++ b/unsloth_zoo/fused_losses/forward_adapter.py
@@ -16,10 +16,10 @@
 
 """HF-call-convention adapter for unsloth_fused_ce_loss.
 
-The fused kernel takes hidden_states + lm_head.weight directly, skipping
-both the lm_head matmul and the fp32 logits materialisation that the HF
-template performs before `self.loss_function(...)`. `EMPTY_LOGITS` is the
-0-element sentinel slotted into the `logits=` return field.
+The fused kernel takes hidden_states + lm_head.weight directly, skipping the
+lm_head matmul and fp32 logits materialisation the HF template does before
+`self.loss_function(...)`. `EMPTY_LOGITS` is the 0-element sentinel for the
+`logits=` return field.
 """
 
 from __future__ import annotations
@@ -45,18 +45,17 @@ def unsloth_fused_lm_head_loss(
     **kwargs,
 ):
     """Replacement for the canonical `self.loss_function(logits=..., labels=...,
-    vocab_size=..., **kwargs)` call site. Routes through the chunked fused
-    cross-entropy kernel without materialising fp32 logits.
+    vocab_size=..., **kwargs)` call site, routing through the chunked fused CE
+    kernel without materialising fp32 logits.
 
     Args:
-        hidden_states: the tensor that was about to be fed into `self.lm_head`.
-        lm_head: the lm_head module (Linear). Weight + bias pulled off it.
+        hidden_states: tensor that was about to be fed into `self.lm_head`.
+        lm_head: the lm_head Linear module; weight + bias pulled off it.
         labels: integer label tensor.
-        vocab_size: ignored. Kernel reads it from `lm_head.weight.shape[0]`.
-        **kwargs: forwarded to the kernel. Accepts `num_items_in_batch`
-            (renamed to `n_items`), `logit_scale_multiply`, `logit_scale_divide`,
-            `logit_softcapping`, plus any other extras the original
-            `self.loss_function` would have ignored.
+        vocab_size: ignored; kernel reads it from `lm_head.weight.shape[0]`.
+        **kwargs: forwarded to the kernel. `num_items_in_batch` is renamed to
+            `n_items`; also accepts `logit_scale_multiply`, `logit_scale_divide`,
+            `logit_softcapping`, plus extras the original loss_function ignored.
     """
     n_items = kwargs.pop("num_items_in_batch", None)
     if n_items is None:
@@ -65,9 +64,8 @@ def unsloth_fused_lm_head_loss(
         kwargs.pop("n_items", None)
     # vocab_size is read from lm_head_weight.shape[0]; drop the keyword.
     kwargs.pop("vocab_size", None)
-    # If caller already shifted (e.g. trl padding_free with packing passes
-    # shift_labels=<tensor>), route the pre-shifted target into the fused
-    # kernel with shift_labels=False so we still get chunked logits.
+    # Caller may pass a pre-shifted target (e.g. trl padding_free + packing
+    # gives shift_labels=<tensor>); route it through with shift_labels=False.
     shift_labels_kw = kwargs.pop("shift_labels", None)
     pre_shifted_tensor = (
         shift_labels_kw is not None and not isinstance(shift_labels_kw, bool)

--- a/unsloth_zoo/fused_losses/forward_install.py
+++ b/unsloth_zoo/fused_losses/forward_install.py
@@ -9,14 +9,14 @@
 """Auto-installer for the fused lm_head + cross_entropy forward.
 
 Tier 1 swaps the forward via a hand-registered structural-hash allowlist
-(empty by default; populate with `register_canonical`). Tier 2 falls back
-to `ast_rewriter` which rewrites the canonical HF triplet in-place; misses
-go to `_UNMATCHED` and the LOSS_MAPPING sweep stays as the backstop.
+(empty by default; populate with `register_canonical`). Tier 2 falls back to
+`ast_rewriter`, which rewrites the canonical HF triplet in-place; misses go to
+`_UNMATCHED` with the LOSS_MAPPING sweep as backstop.
 
-On by default. Set `UNSLOTH_FUSED_FORWARD=0` to disable. Soft floor at
-transformers >= 4.56, the release where every `*ForCausalLM` settled on
-the `outputs.last_hidden_state` + `self.loss_function(logits, labels,
-vocab_size, **kwargs)` shape we match against.
+On by default; set `UNSLOTH_FUSED_FORWARD=0` to disable. Requires transformers
+>= 4.56, where every `*ForCausalLM` settled on the
+`outputs.last_hidden_state` + `self.loss_function(logits, labels, vocab_size,
+**kwargs)` shape we match against.
 """
 
 from __future__ import annotations
@@ -69,9 +69,8 @@ def is_enabled() -> bool:
 
 
 def register_canonical(forward_hash: str, replacement_forward) -> None:
-    """Register a hand-written canonical forward for a known structural hash.
-    Future installs that fingerprint to `forward_hash` get the replacement
-    directly without the AST rewrite step."""
+    """Register a hand-written canonical forward for a structural hash. Future
+    installs fingerprinting to `forward_hash` use it without the AST rewrite."""
     with _REGISTRY_LOCK:
         _CANONICAL_FORWARDS[forward_hash] = replacement_forward
 
@@ -222,8 +221,8 @@ def install_for_class(cls) -> bool:
         ns.setdefault("can_return_tuple", can_return_tuple)
     except Exception:
         pass
-    # Backfill transformers.modeling_outputs symbols; unsloth's compiled-cache
-    # forwards reference CausalLMOutputWithPast & friends in the return line.
+    # Backfill modeling_outputs symbols; rewritten forwards reference
+    # CausalLMOutputWithPast & friends in the return line.
     try:
         import transformers.modeling_outputs as _mo
         for _name in dir(_mo):

--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -17,9 +17,9 @@
 """
 Memory-efficient custom VJP for GatedDeltaNet (Qwen3.5).
 
-Replaces the T-step Python loop in gated_delta_ops with a single
-mx.custom_function that recomputes states during backward instead
-of storing all T intermediate states in the autograd graph.
+Replaces the T-step Python loop in gated_delta_ops with an mx.custom_function
+that recomputes states during backward instead of keeping all T intermediate
+states in the autograd graph.
 
 Usage:
     from gated_delta_vjp import patch_gated_delta
@@ -65,9 +65,8 @@ def gated_delta_ops_efficient(
 ) -> Tuple[mx.array, mx.array]:
     """Memory-efficient GDN forward+backward via custom VJP.
 
-    Instead of a Python for-loop that creates T graph nodes (each holding
-    state references), this wraps the entire recurrence in mx.custom_function.
-    The backward recomputes states on-the-fly during BPTT.
+    Wraps the recurrence in mx.custom_function so backward recomputes states
+    on the fly during BPTT instead of keeping T graph nodes alive.
     """
     B, T, Hk, Dk = q.shape
     Hv, Dv = v.shape[-2:]
@@ -78,9 +77,8 @@ def gated_delta_ops_efficient(
         q = mx.repeat(q, repeat_factor, -2)
         k = mx.repeat(k, repeat_factor, -2)
 
-    # Chunk the sequence into segments for checkpointed BPTT.
-    # Each chunk's forward is recomputed during backward.
-    # Memory: O(num_chunks * state_size) instead of O(T * state_size)
+    # Chunk for checkpointed BPTT: each chunk's forward is recomputed during
+    # backward. Memory: O(num_chunks * state_size) instead of O(T * state_size).
     CHUNK_SIZE = max(1, min(64, T))
     num_chunks = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
 
@@ -107,11 +105,10 @@ def gated_delta_ops_efficient(
         chunk_T = q_c.shape[1]
         _has_mask = mask_chunk is not None and mask_chunk.shape[-1] >= chunk_T
 
-        # Recompute the chunk's RETURNED states (post-mask). At step t the
-        # returned state is `where(mask, state_new, state_prev)` — so for
-        # masked steps `states[t+1] == states[t]`. We don't use these for
-        # the y-path backward (that needs state_new, recomputed below); we
-        # only need them as the entry point `state_prev` for each step.
+        # Recompute the chunk's RETURNED states (post-mask: where(mask,
+        # state_new, state_prev), so masked steps give states[t+1]==states[t]).
+        # Used only as each step's entry `state_prev`; the y-path backward needs
+        # state_new, recomputed below.
         states = [state_in]
         s = state_in
         for t in range(chunk_T):
@@ -122,10 +119,9 @@ def gated_delta_ops_efficient(
             )
             states.append(s)
 
-        # BPTT: backward through time. `d_state` holds the cotangent w.r.t.
-        # the RETURNED state at the current step's output (= input to step
-        # t+1). At chunk boundary it's d_state_out; subsequent iterations
-        # propagate it through the recurrence + mask.
+        # BPTT: `d_state` is the cotangent w.r.t. the RETURNED state at the
+        # current step (= input to step t+1). Starts at d_state_out, then
+        # propagates through the recurrence + mask.
         d_q = mx.zeros_like(q_c)
         d_k = mx.zeros_like(k_c)
         d_v = mx.zeros_like(v_c)
@@ -145,9 +141,8 @@ def gated_delta_ops_efficient(
             # Cotangent flowing into step t's output (state_returned).
             d_state_returned = d_state
 
-            # Recompute state_new (pre-mask). y always depends on state_new
-            # regardless of mask; using states[t+1] would be wrong when
-            # mask=False because states[t+1] equals state_prev there.
+            # Recompute state_new (pre-mask): y always depends on it, but
+            # states[t+1] equals state_prev when mask=False, so it can't be used.
             if g_t.ndim == 2:
                 decay = g_t[..., None, None]
             else:
@@ -157,10 +152,9 @@ def gated_delta_ops_efficient(
             delta = (v_t - kv_mem) * beta_t[..., None]
             state_new = state_decayed + k_t[..., None, :] * delta[..., None]
 
-            # Forward had: state_returned = where(mask, state_new, state_prev).
-            # Backward splits d_state_returned into:
-            #   d_state_new path (recurrence backward): only when mask=True
-            #   d_state_prev passthrough:               only when mask=False
+            # Forward: state_returned = where(mask, state_new, state_prev).
+            # Split d_state_returned: to d_state_new when mask=True, passthrough
+            # to d_state_prev when mask=False.
             if _has_mask:
                 m = mask_chunk[:, t]
                 m_exp = mx.expand_dims(m, axis=(1, 2, 3))
@@ -256,13 +250,10 @@ def patch_gated_delta():
         q, k, v, a, b, A_log, dt_bias,
         state=None, mask=None, use_kernel=True,
     ):
-        # Heuristic: training calls enter with state=None (start of sequence,
-        # no cache); inference with KV cache passes the cached state in.
-        # Route training through gated_delta_ops_efficient so the
-        # memory-efficient custom VJP actually runs — gated_delta_kernel
-        # has no custom VJP, so going through it forces mlx to keep all T
-        # intermediate states alive in the autograd graph and defeats the
-        # whole point of this module.
+        # Heuristic: training calls enter with state=None (no cache); inference
+        # passes the cached state in. Route training through the efficient ops
+        # so the custom VJP runs — gated_delta_kernel has none, so it would keep
+        # all T intermediate states alive and defeat this module.
         is_training_call = state is None
         beta = mx.sigmoid(b)
         g = gated_delta.compute_g(A_log, a, dt_bias)
@@ -271,13 +262,11 @@ def patch_gated_delta():
             Hv, Dv = v.shape[-2:]
             state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
 
-        # Training (or any call without an incoming state cache): always
-        # use the efficient ops path so backward is memory-efficient.
+        # No incoming state cache: use the memory-efficient ops path.
         if is_training_call:
             return gated_delta_ops_efficient(q, k, v, g, beta, state, mask)
 
-        # Inference with cached state: prefer the kernel for speed when
-        # available; fall back to efficient ops otherwise.
+        # Cached state: prefer the kernel for speed, else efficient ops.
         if not use_kernel or mx.default_device() != mx.gpu or not mx.metal.is_available():
             return gated_delta_ops_efficient(q, k, v, g, beta, state, mask)
         return gated_delta.gated_delta_kernel(q, k, v, g, beta, state, mask)

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -49,10 +49,10 @@ __all__ = [
 ]
 
 # Initial buffer sizes for gradient checkpointing
-INITIAL_CPU_BUFFER_SIZE = 128 * 1024       # Initial size per CPU buffer
-INITIAL_GPU_BUFFER_SIZE = 2 * 256 * 2048   # Initial size per GPU buffer
-INITIAL_CPU_BUFFER_COUNT = 200             # Initial number of CPU buffers
-DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # 512MB minimum free CUDA memory to enable double buffering
+INITIAL_CPU_BUFFER_SIZE = 128 * 1024       # per CPU buffer
+INITIAL_GPU_BUFFER_SIZE = 2 * 256 * 2048   # per GPU buffer
+INITIAL_CPU_BUFFER_COUNT = 200             # number of CPU buffers
+DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable double buffering
 
 torch_version = torch.__version__
 if Version(torch_version) < Version("2.4.0"):
@@ -82,7 +82,7 @@ def _calculate_n_gradient_checkpoints(
     size = n_layers // n_checkpoints
     sizes = np.full(n_checkpoints, size, dtype = int)
     leftovers = n_layers % n_checkpoints
-    # We append leftovers from the right
+    # Append leftovers from the right
     for k in range(leftovers):
         sizes[n_checkpoints-1-k] += 1
     boundaries = np.hstack((0, np.cumsum(sizes)))
@@ -279,14 +279,9 @@ from torch.utils.checkpoint import (
 )
 # Added [device_type] in Torch 2.5!
 def set_device_states(devices, states, *, device_type=None) -> None:
-    """Sets random number generator states for the specified devices.
+    """Set RNG states for the given devices.
 
-    Args:
-        devices: Device ids to set states for.
-        states: States to set.
-        device_type: ``device_type`` of the devices to set states for. Default
-            is the device returned by a call to ``DefaultDeviceType.get_device_type()``,
-            which is ``cuda`` if not changed by calling ``DefaultDeviceType::set_device_type()``.
+    device_type defaults to ``DefaultDeviceType.get_device_type()`` (cuda).
     """
     if device_type is None:
         device_type = DefaultDeviceType.get_device_type()
@@ -360,7 +355,7 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
         CPU_BUFFERS.append(x)
     pass
 
-    # Allocate buffers to how many GPUs
+    # Allocate one buffer per GPU
     n_gpus = torch.cuda.device_count() if DEVICE_TYPE in ("cuda", "hip") else torch.xpu.device_count()
     NEXT_BUFFER_SLOT = [0] * n_gpus
     try:
@@ -374,9 +369,9 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
         else:
             try:
                 GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
-                USE_DOUBLE_BUFFER = False # set false first, enabled after first pass if CUDA free memory > DOUBLE_BUFFER_HEADROOM
-                # Per-buffer events to prevent race conditions in double buffering.
-                # Each event tracks when compute on that buffer finishes
+                USE_DOUBLE_BUFFER = False # enabled after first pass if CUDA free memory > DOUBLE_BUFFER_HEADROOM
+                # Per-buffer events prevent double-buffering races; each tracks
+                # when compute on that buffer finishes
                 if DEVICE_TYPE in ("cuda", "hip"):
                     event_ctor = torch.cuda.Event
                 elif DEVICE_TYPE == "xpu":
@@ -412,7 +407,7 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     MINIMUM_SIZE = 2 * 1024 * 1024 // n_bytes
     USE_UNSLOTH_GC = True
 
-    # Disable offloading on the last layer - uses more VRAM and is slower
+    # Don't offload the last layer - uses more VRAM and is slower
     # See https://github.com/pytorch/torchtune/pull/1443
     LAST_GC_INDEX = 0
     FIRST_PASS = True
@@ -425,21 +420,17 @@ class UnslothCheckpointFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, run_function, preserve_rng_state, *args):
         # All Unsloth Zoo code licensed under LGPLv3
-        # check_backward_validity(args)
-        # Check if no requires_grad in inputs
         ctx.run_function = run_function
         ctx.preserve_rng_state = preserve_rng_state
-        # Accommodates the (remote) possibility that autocast is enabled for cpu AND gpu.
+        # Handle autocast enabled for cpu AND gpu.
         ctx.device_type = _infer_device_type(*args)
         ctx.device_autocast_kwargs, ctx.cpu_autocast_kwargs = _get_autocast_kwargs(
             ctx.device_type
         )
         if preserve_rng_state:
             ctx.fwd_cpu_state = torch.get_rng_state()
-            # Don't eagerly initialize the cuda context by accident.
-            # (If the user intends that the context is initialized later, within their
-            # run_function, we SHOULD actually stash the cuda state here.  Unfortunately,
-            # we have no way to anticipate this will happen before we run the function.)
+            # Don't eagerly initialize the cuda context by accident: we can't
+            # anticipate run_function initializing it later, so don't stash here.
             ctx.had_device_in_fwd = False
             device_module = _get_device_module(ctx.device_type)
             if getattr(device_module, "_initialized", False):
@@ -461,9 +452,9 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                     global FIRST_PASS
                     global LAST_GC_INDEX
                     if FIRST_PASS:
-                        # Save last layer index so next run we do not offload activations
-                        # Saves VRAM and saves some time
-                        # See https://github.com/pytorch/torchtune/pull/1443
+                        # Save last layer index so next run skips offloading it
+                        # (saves VRAM and time). See
+                        # https://github.com/pytorch/torchtune/pull/1443
                         LAST_GC_INDEX += 1
                     pass
                     global CURRENT_GC_INDEX
@@ -527,7 +518,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                             except RuntimeError as e:
                                 if "out of memory" not in str(e).lower():
                                     raise
-                                # clear Buffer B and try to resize Single Buffer
+                                # Clear buffer B and resize the single buffer
                                 if GPU_BUFFERS_B is not None:
                                     USE_DOUBLE_BUFFER = False
                                     for j in range(len(GPU_BUFFERS_B)):
@@ -537,7 +528,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                     GPU_BUFFER.resize_(new_size)
                                 else:
                                     raise
-                        # resize buffer B as needed if double buffering is enabled, disable and free Buffer B if OOM
+                        # Resize buffer B when double buffering; disable + free B on OOM
                         if USE_DOUBLE_BUFFER:
                             GPU_BUFFER_B = GPU_BUFFERS_B[device_index]
                             if new_size > GPU_BUFFER_B.numel():
@@ -546,9 +537,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                 except RuntimeError as e:
                                     if "out of memory" not in str(e).lower():
                                         raise
-                                    # OOM - disable double buffering
                                     USE_DOUBLE_BUFFER = False
-                                    # Reclaim buffer B
                                     for j in range(len(GPU_BUFFERS_B)):
                                         GPU_BUFFERS_B[j].resize_(0)
                                     GPU_BUFFERS_B = None
@@ -620,7 +609,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
             global GPU_BUFFERS_B
             global BUFFER_EVENTS_A
             global BUFFER_EVENTS_B
-            # Select which buffer to use based on per-device buffer_slot
+            # Select buffer from per-device buffer_slot
             if USE_DOUBLE_BUFFER and buffer_slot == 1:
                 buffer = GPU_BUFFERS_B[device_index][:new_size].view(shape)
             else:
@@ -630,11 +619,11 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
             # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
             if USE_DOUBLE_BUFFER:
-                # Wait for the last compute on THIS SPECIFIC buffer to finish
+                # Wait for the last compute on THIS buffer to finish
                 event_buffer = BUFFER_EVENTS_B if buffer_slot == 1 else BUFFER_EVENTS_A
                 EXTRA_STREAM.wait_event(event_buffer[device_index])
             else:
-                # Single buffer mode: Must wait for MAIN_STREAM to finish
+                # Single buffer mode: wait for MAIN_STREAM
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
 
             with torch_gpu_stream(EXTRA_STREAM):
@@ -657,9 +646,8 @@ class UnslothCheckpointFunction(torch.autograd.Function):
         global CURRENT_GC_INDEX
         CURRENT_GC_INDEX = 0
 
-        # Stash the surrounding rng state, and mimic the state that was
-        # present at this time during forward.  Restore the surrounding state
-        # when we're done.
+        # Stash the surrounding rng state, mimic the forward state, then
+        # restore the surrounding state when done.
         rng_devices = []
         if ctx.preserve_rng_state and ctx.had_device_in_fwd:
             rng_devices = ctx.fwd_devices
@@ -721,7 +709,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
             torch.autograd.backward(outputs_with_grad, args_with_grad)
         pass
 
-        # Record event after compute finishes so the copy stream knows
+        # Record event after compute so the copy stream can wait on it
         if CPU_INDEX is not None and USE_DOUBLE_BUFFER:
             event_buffer = BUFFER_EVENTS_B if buffer_slot == 1 else BUFFER_EVENTS_A
             event_buffer[device_index].record(MAIN_STREAM)
@@ -757,116 +745,27 @@ def unsloth_checkpoint(
     debug: bool = False,
     **kwargs
 ):
-    r"""Checkpoint a model or part of the model.
+    r"""Activation checkpoint a model or part of the model.
 
-    Activation checkpointing is a technique that trades compute for memory.
-    Instead of keeping tensors needed for backward alive until they are used in
-    gradient computation during backward, forward computation in checkpointed
-    regions omits saving tensors for backward and recomputes them during the
-    backward pass. Activation checkpointing can be applied to any part of a
-    model.
+    Trades compute for memory: forward in checkpointed regions omits saving
+    tensors for backward and recomputes them during the backward pass.
 
-    There are currently two checkpointing implementations available, determined
-    by the :attr:`use_reentrant` parameter. It is recommended that you use
-    ``use_reentrant=False``. Please refer the note below for a discussion of
-    their differences.
+    This is Unsloth's drop-in for ``torch.utils.checkpoint.checkpoint``; it
+    forces ``use_reentrant=True`` to route through UnslothCheckpointFunction
+    (smart CPU offloading). The ``context_fn`` / ``determinism_check`` /
+    ``debug`` args are only valid with ``use_reentrant=False`` and raise here.
 
     .. warning::
 
-        If the :attr:`function` invocation during the backward pass differs
-        from the forward pass, e.g., due to a global variable, the checkpointed
-        version may not be equivalent, potentially causing an
-        error being raised or leading to silently incorrect gradients.
-
-    .. warning::
-
-        The ``use_reentrant`` parameter should be passed explicitly. In version
-        2.4 we will raise an exception if ``use_reentrant`` is not passed.
-        If you are using the ``use_reentrant=True`` variant, please refer to the
-        note below for important considerations and potential limitations.
-
-    .. note::
-
-        The reentrant variant of checkpoint (``use_reentrant=True``) and
-        the non-reentrant variant of checkpoint (``use_reentrant=False``)
-        differ in the following ways:
-
-        * Non-reentrant checkpoint stops recomputation as soon as all needed
-          intermediate activations have been recomputed. This feature is enabled
-          by default, but can be disabled with :func:`set_checkpoint_early_stop`.
-          Reentrant checkpoint always recomputes :attr:`function` in its
-          entirety during the backward pass.
-
-        * The reentrant variant does not record the autograd graph during the
-          forward pass, as it runs with the forward pass under
-          :func:`torch.no_grad`. The non-reentrant version does record the
-          autograd graph, allowing one to perform backward on the graph within
-          checkpointed regions.
-
-        * The reentrant checkpoint only supports the
-          :func:`torch.autograd.backward` API for the backward pass without its
-          `inputs` argument, while the non-reentrant version supports all ways
-          of performing the backward pass.
-
-        * At least one input and output must have ``requires_grad=True`` for the
-          reentrant variant. If this condition is unmet, the checkpointed part
-          of the model will not have gradients. The non-reentrant version does
-          not have this requirement.
-
-        * The reentrant version does not consider tensors in nested structures
-          (e.g., custom objects, lists, dicts, etc) as participating in
-          autograd, while the non-reentrant version does.
-
-        * The reentrant checkpoint does not support checkpointed regions with
-          detached tensors from the computational graph, whereas the
-          non-reentrant version does. For the reentrant variant, if the
-          checkpointed segment contains tensors detached using ``detach()`` or
-          with :func:`torch.no_grad`, the backward pass will raise an error.
-          This is because ``checkpoint`` makes all the outputs require gradients
-          and this causes issues when a tensor is defined to have no gradient in
-          the model. To avoid this, detach the tensors outside of the
-          ``checkpoint`` function.
+        If :attr:`function` behaves differently in backward vs forward (e.g.
+        via a global), recomputation may error or yield wrong gradients.
 
     Args:
-        function: describes what to run in the forward pass of the model or
-            part of the model. It should also know how to handle the inputs
-            passed as the tuple. For example, in LSTM, if user passes
-            ``(activation, hidden)``, :attr:`function` should correctly use the
-            first input as ``activation`` and the second input as ``hidden``
-        preserve_rng_state(bool, optional):  Omit stashing and restoring
-            the RNG state during each checkpoint. Note that under torch.compile,
-            this flag doesn't take effect and we always preserve RNG state.
-            Default: ``True``
-        use_reentrant(bool):
-            specify whether to use the activation checkpoint variant that
-            requires reentrant autograd. This parameter should be passed
-            explicitly. In version 2.5 we will raise an exception if
-            ``use_reentrant`` is not passed. If ``use_reentrant=False``,
-            ``checkpoint`` will use an implementation that does not require
-            reentrant autograd. This allows ``checkpoint`` to support additional
-            functionality, such as working as expected with
-            ``torch.autograd.grad`` and support for keyword arguments input into
-            the checkpointed function.
-        context_fn(Callable, optional): A callable returning a tuple of two
-            context managers. The function and its recomputation will be run
-            under the first and second context managers respectively.
-            This argument is only supported if ``use_reentrant=False``.
-        determinism_check(str, optional): A string specifying the determinism
-            check to perform. By default it is set to ``"default"`` which
-            compares the shapes, dtypes, and devices of the recomputed tensors
-            against those the saved tensors. To turn off this check, specify
-            ``"none"``. Currently these are the only two supported values.
-            Please open an issue if you would like to see more determinism
-            checks. This argument is only supported if ``use_reentrant=False``,
-            if ``use_reentrant=True``, the determinism check is always disabled.
-        debug(bool, optional): If ``True``, error messages will also include
-            a trace of the operators ran during the original forward computation
-            as well as the recomputation. This argument is only supported if
-            ``use_reentrant=False``.
-        args: tuple containing inputs to the :attr:`function`
+        function: forward pass to run; must handle the passed input tuple.
+        args: inputs to :attr:`function`.
 
     Returns:
-        Output of running :attr:`function` on :attr:`*args`
+        Output of running :attr:`function` on :attr:`*args`.
     """
     # Force use_reentrant=True so UnslothCheckpointFunction (smart CPU offloading)
     # is always used. This is safe because unsloth_checkpoint is only active when
@@ -914,12 +813,11 @@ def patch_unsloth_smart_gradient_checkpointing(dtype = None):
         torch.utils.checkpoint._old_checkpoint = torch.utils.checkpoint.checkpoint
         torch.utils.checkpoint.checkpoint = unsloth_checkpoint
 
-    # Always patch transformers.modeling_utils.checkpoint so that
-    # gradient_checkpointing_enable() wraps unsloth_checkpoint, not the original.
-    # Without this, transformers 5.2's use_reentrant=False default bypasses
-    # UnslothCheckpointFunction entirely.
-    # Must be outside the conditional above since torch.utils.checkpoint.checkpoint
-    # may already be patched while transformers.modeling_utils.checkpoint is not.
+    # Always patch transformers.modeling_utils.checkpoint so
+    # gradient_checkpointing_enable() wraps unsloth_checkpoint; otherwise
+    # transformers 5.2's use_reentrant=False default bypasses
+    # UnslothCheckpointFunction. Outside the conditional above since
+    # torch.utils.checkpoint may already be patched while this one is not.
     import transformers.modeling_utils
     transformers.modeling_utils.checkpoint = unsloth_checkpoint
 pass
@@ -962,12 +860,11 @@ def unpatch_unsloth_smart_gradient_checkpointing():
 
         torch.utils.checkpoint.checkpoint = torch.utils.checkpoint._old_checkpoint
 
-    # Restore transformers.modeling_utils.checkpoint independently.
-    # Must be outside the conditional above because unpatch_unsloth_gradient_checkpointing()
-    # may run first (e.g. training_utils.py:201), deleting _old_checkpoint and restoring
-    # torch.utils.checkpoint.checkpoint, which makes the condition above False.
-    # Use _old_checkpoint if still available, otherwise torch.utils.checkpoint.checkpoint
-    # (which has already been restored to the original at that point).
+    # Restore transformers.modeling_utils.checkpoint independently: an earlier
+    # unpatch_unsloth_gradient_checkpointing() (e.g. training_utils.py:201) may
+    # have deleted _old_checkpoint and restored torch.utils.checkpoint,
+    # making the condition above False. Prefer _old_checkpoint, else the
+    # already-restored torch.utils.checkpoint.checkpoint.
     import transformers.modeling_utils
     if getattr(transformers.modeling_utils, "checkpoint", None) is unsloth_checkpoint:
         transformers.modeling_utils.checkpoint = getattr(
@@ -981,18 +878,11 @@ def reset_unsloth_gradient_checkpointing_buffers():
     """
     All Unsloth Zoo code licensed under LGPLv3
 
-    Resets CPU_BUFFERS and GPU_BUFFERS to their initial sizes after training.
+    Reset CPU_BUFFERS and GPU_BUFFERS to their initial sizes after training.
 
-    This function should be called after trainer.train() completes to free up
-    memory that was allocated during training while keeping the buffers ready
-    for another potential training run. Unlike unpatch_unsloth_smart_gradient_checkpointing,
-    this does NOT destroy the buffers or unpatch the checkpointing - it just resets
-    them to their initial state.
-
-    Usage:
-        trainer.train()
-        reset_unsloth_gradient_checkpointing_buffers()  # Free memory, stay ready
-        # Can run trainer.train() again without re-initializing
+    Call after trainer.train() to free training-allocated memory while keeping
+    buffers ready for another run. Unlike unpatch_unsloth_smart_gradient_checkpointing,
+    this neither destroys the buffers nor unpatches checkpointing.
     """
     global CPU_BUFFERS
     global GPU_BUFFERS
@@ -1008,20 +898,17 @@ def reset_unsloth_gradient_checkpointing_buffers():
     global BUFFER_EVENTS_A
     global BUFFER_EVENTS_B
 
-    # Check if buffers exist
     if CPU_BUFFERS is None or GPU_BUFFERS is None:
         return
     if len(CPU_BUFFERS) == 0:
         return
 
-    # Reset CPU buffers to initial size and remove excess buffers
+    # Reset CPU buffers to initial size; free any added during training
     for i in range(len(CPU_BUFFERS)):
         if i < INITIAL_CPU_BUFFER_COUNT:
-            # Resize existing buffers back to initial size
             if CPU_BUFFERS[i] is not None and hasattr(CPU_BUFFERS[i], "resize_"):
                 CPU_BUFFERS[i].resize_(INITIAL_CPU_BUFFER_SIZE)
         else:
-            # Free excess buffers that were added during training
             if CPU_BUFFERS[i] is not None and hasattr(CPU_BUFFERS[i], "resize_"):
                 CPU_BUFFERS[i].resize_(0)
             CPU_BUFFERS[i] = None
@@ -1038,13 +925,13 @@ def reset_unsloth_gradient_checkpointing_buffers():
             GPU_BUFFERS[i].resize_(INITIAL_GPU_BUFFER_SIZE)
     pass
 
-    # Reset state variables for fresh training run
+    # Reset state for a fresh training run
     CPU_INDEX = 0
     BACKWARD_PASS = True
     LAST_GC_INDEX = 0
     FIRST_PASS = True
     CURRENT_GC_INDEX = 0
-    USE_UNSLOTH_GC = True  # Re-enable the "Will smartly offload" message
+    USE_UNSLOTH_GC = True  # re-enable the "Will smartly offload" message
     if NEXT_BUFFER_SLOT is not None:
         for i in range(len(NEXT_BUFFER_SLOT)):
             NEXT_BUFFER_SLOT[i] = 0
@@ -1079,7 +966,6 @@ def reset_unsloth_gradient_checkpointing_buffers():
         except RuntimeError:
             pass
 
-    # Clean up freed memory
     torch.cuda.empty_cache()
     gc.collect()
 pass

--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -51,7 +51,6 @@ def dtype_from_config(config):
 
 def set_dtype_in_config(config, dtype):
     try:
-        # if dtype is not a string, convert it to a string
         string_dtype = str(dtype).split(".")[-1] if isinstance(dtype, torch.dtype) else dtype
         if HAS_TORCH_DTYPE:
             setattr(config, "torch_dtype", string_dtype)
@@ -81,10 +80,9 @@ def add_dtype_kwargs(dtype, kwargs_dict=None):
     return kwargs_dict
 
 def _dtype_stringify(x):
-    # Convert *values* (not the config) into JSON-safe strings when they are dtypes
+    # Convert dtype *values* into JSON-safe strings ("torch.float16" -> "float16")
     try:
         if isinstance(x, torch.dtype):
-            # str(torch.float16) -> "torch.float16" -> "float16"
             return str(x).split(".", 1)[-1]
         if isinstance(x, str) and x.startswith("torch."):
             tail = x.split(".", 1)[-1]
@@ -128,16 +126,16 @@ def get_transformers_model_type(config, trust_remote_code=False):
         if len(model_type_list) == 0:
             logger.info("*** `model_type_list` in `get_transformers_model_type` is None!")
         if len(model_type_list) != 0:
-            # Use transformers.models.gpt_oss.modeling_gpt_oss
+            # e.g. transformers.models.gpt_oss.modeling_gpt_oss
             model_type = model_type_list[0].group(1)
             model_types = [model_type]
         elif getattr(config, "auto_mapping", None) is not None:
-            # Use GptOssForCausalLM
+            # e.g. GptOssForCausalLM
             model_type = config.auto_mapping.get("base_model_class", None)
             if model_type is not None:
                 model_type = str(model_type)
                 model_type = model_type.rsplit("For", 1)[0].lower()
-                # Find exact name of modeling path
+                # Find exact modeling-path name
                 import transformers.models
                 supported_model_types = dir(transformers.models)
                 for modeling_file in supported_model_types:
@@ -155,7 +153,7 @@ def get_transformers_model_type(config, trust_remote_code=False):
         # Set model name for patching purposes
         os.environ["UNSLOTH_MODEL_NAME"] = base_model_name_or_path.lower()
 
-        # Last resort use model name unsloth/gpt-oss-20b-unsloth-bnb-4bit
+        # Last resort: derive from base model name via AutoConfig
         if model_types is None:
             from transformers import AutoConfig
             try:
@@ -181,7 +179,7 @@ def get_transformers_model_type(config, trust_remote_code=False):
         retry_config = True
     pass
 
-    # Check since we might have tried AutoConfig fallback last resort for LoRA
+    # May have tried the AutoConfig fallback as a last resort for LoRA
     if retry_config:
         from collections.abc import Mapping, Sequence
         def find(data, target_key):
@@ -189,13 +187,11 @@ def get_transformers_model_type(config, trust_remote_code=False):
             while stack:
                 obj = stack.pop()
                 if isinstance(obj, Mapping):
-                    # Emit values for matches
                     if target_key in obj:
                         yield obj[target_key]
-                    # Keep walking into nested values
                     stack.extend(obj.values())
                 elif isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
-                    # Walk sequences (lists/tuples/sets), but not strings/bytes
+                    # Walk sequences but not strings/bytes
                     stack.extend(obj)
         model_types = list(find(getattr(config, "to_dict", lambda *args, **kwargs: {})(), "model_type"))
     pass
@@ -223,7 +219,7 @@ def get_transformers_model_type(config, trust_remote_code=False):
         if model_type in _REMOTE_CODE_MODEL_TYPES:
             found_type = True
         elif model_type not in all_model_types:
-            # Try splitting on _ gemma3_text -> gemma3
+            # Try trimming, e.g. gemma3_text -> gemma3
             model_types = list(model_type)
             model_types = ["".join(model_types[:i]) for i in range(len(model_types), 0, -1)]
             for current_model_type in model_types:
@@ -271,7 +267,7 @@ pass
 
 
 def get_auto_processor(name, **kwargs):
-    # Allow AutoProcessor to work if config.json does not exist
+    # Allow AutoProcessor to work when config.json does not exist
     if not os.path.exists(name):
         return None
     try:
@@ -326,11 +322,11 @@ def get_auto_processor(name, **kwargs):
             raise TypeError(f"Unsloth: Failed loading a AutoProcessor from `{name}`")
     pass
 
-    # Make a temporary directory to copy all files
+    # Temp directory to copy all files into
     temp_directory = tempfile.TemporaryDirectory()
     temp_name = temp_directory.name
 
-    # Make a fake config.json file with just the model_type
+    # Fake config.json with just the model_type
     config_file = {"model_type" : model_type}
     with open(os.path.join(temp_name, "config.json"), "w") as f:
         f.write(json.dumps(config_file))

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -52,10 +52,9 @@ import psutil
 try:
     from .device_type import device_is_bf16_supported
 except (ImportError, NotImplementedError):
-    # device_type can fail two ways: ImportError when torch is
-    # absent, NotImplementedError when get_device_type() runs at
-    # import on an unrecognised platform. Fall through to the
-    # platform probe in either case.
+    # ImportError when torch is absent; NotImplementedError when
+    # get_device_type() runs at import on an unrecognised platform.
+    # Fall through to the platform probe either way.
     import platform as _platform
     _IS_APPLE_SILICON = (
         _platform.system() == "Darwin" and _platform.machine() == "arm64"
@@ -63,9 +62,8 @@ except (ImportError, NotImplementedError):
     def device_is_bf16_supported():
         return _IS_APPLE_SILICON
 
-# Get a logger instance
 logger = logging.getLogger(__name__)
-# Configure logging basic level if not already configured elsewhere
+# Configure basic logging if not already configured elsewhere
 if not logger.hasHandlers():
     logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(name)s: %(message)s')
 
@@ -138,12 +136,11 @@ LLAMA_CPP_DEFAULT_DIR = os.environ.get(
 
 
 def _resolve_local_convert_script():
-    """Returns (abs_path, mtime_ns, size) for a local convert_hf_to_gguf.py if
-    UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points at a directory containing one, else None.
-    The mtime_ns and size are part of the cache key on the cached implementation
-    so in-place updates to the same path are honored. When the env var is set
-    but invalid, this raises RuntimeError so an explicit pin fails closed
-    instead of silently falling back to the network."""
+    """Return (abs_path, mtime_ns, size) for a local convert_hf_to_gguf.py if
+    UNSLOTH_LLAMA_CPP_SCRIPTS_DIR holds one, else None. mtime_ns/size are part
+    of the cache key so in-place updates are honored. An invalid env var raises
+    RuntimeError (an explicit pin fails closed rather than hitting the network).
+    """
     scripts_dir = os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR")
     if not scripts_dir:
         return None
@@ -183,32 +180,29 @@ def use_local_gguf():
     original_gguf_modules = {}
 
     try:
-        # Add gguf-py to sys.path if it exists
         if os.path.exists(gguf_py_path):
             logger.debug(f"Adding {gguf_py_path} to sys.path")
             sys.path.insert(1, gguf_py_path)
 
-            # Remove system gguf modules to force reimport
+            # Drop system gguf modules to force a reimport from gguf-py
             gguf_modules = [key for key in sys.modules.keys() if key.startswith('gguf')]
             for module in gguf_modules:
-                original_gguf_modules[module] = sys.modules[module]  # Store original
+                original_gguf_modules[module] = sys.modules[module]
                 del sys.modules[module]
                 logger.debug(f"Removed system module {module}")
 
-        yield  # Let the conversion happen
+        yield
 
     finally:
-        # Restore original sys.path
         sys.path[:] = original_sys_path
 
-        # Remove any new gguf modules that were imported
+        # Remove any newly imported gguf modules
         new_modules = set(sys.modules.keys()) - original_modules
         gguf_modules_to_remove = [m for m in new_modules if m.startswith('gguf')]
         for module in gguf_modules_to_remove:
             del sys.modules[module]
             logger.debug(f"Cleaned up module {module}")
 
-        # Restore original gguf modules
         for module_name, module_obj in original_gguf_modules.items():
             sys.modules[module_name] = module_obj
             logger.debug(f"Restored original module {module_name}")
@@ -483,8 +477,8 @@ pass
 
 
 def _find_visual_studio():
-    """Detect Visual Studio Build Tools installation (aligned with setup.ps1 Find-VsBuildTools).
-    Returns (cmake_generator, vs_install_path) or (None, None) if not found."""
+    """Detect VS Build Tools (aligned with setup.ps1 Find-VsBuildTools).
+    Returns (cmake_generator, vs_install_path) or (None, None)."""
     program_files = [
         os.environ.get('ProgramFiles', r'C:\Program Files'),
         os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)'),
@@ -502,8 +496,8 @@ def _find_visual_studio():
 
 
 def _find_openssl_root():
-    """Find OpenSSL dev installation on Windows (aligned with setup.ps1 $OpenSslRoots).
-    Returns the root path if found, or None."""
+    """Find OpenSSL dev on Windows (aligned with setup.ps1 $OpenSslRoots).
+    Returns the root path or None."""
     openssl_roots = [
         r'C:\Program Files\OpenSSL-Win64',
         r'C:\Program Files\OpenSSL',
@@ -516,8 +510,7 @@ def _find_openssl_root():
 
 
 def _find_lib_path(lib_name):
-    """Find a shared library path using gcc's linker search.
-    Returns the absolute path if found, or None."""
+    """Find a shared library path via gcc's linker search; abs path or None."""
     try:
         result = subprocess.run(
             ['gcc', f'-print-file-name={lib_name}'],
@@ -930,10 +923,9 @@ _BRANDING_PATTERN = re.compile(
 
 
 def _get_llama_cpp_dir(local_script_info):
-    """Resolve the directory holding the converter being patched.
-    UNSLOTH_LLAMA_CPP_SCRIPTS_DIR wins when set; otherwise the default
-    ~/.unsloth/llama.cpp. Single anchor for layout detection, branding patch,
-    Qwen check, and sibling-info cache key."""
+    """Directory holding the converter being patched: UNSLOTH_LLAMA_CPP_SCRIPTS_DIR
+    when set, else ~/.unsloth/llama.cpp. Single anchor for layout detection,
+    branding patch, Qwen check, and sibling-info cache key."""
     if local_script_info is not None:
         return os.path.dirname(local_script_info[0])
     return LLAMA_CPP_DEFAULT_DIR
@@ -941,9 +933,9 @@ pass
 
 
 def _conversion_sibling_info(llama_cpp_dir):
-    """Hashable (path, mtime, size) tuples for conversion/{__init__,base,qwen}.py.
-    Folded into the patcher cache key so re-pulled llama.cpp checkouts re-patch.
-    Returns None on monolithic layout."""
+    """Hashable (path, mtime, size) tuples for conversion/{__init__,base,qwen}.py,
+    folded into the patcher cache key so re-pulled checkouts re-patch. None on
+    the monolithic layout."""
     conv_dir = os.path.join(llama_cpp_dir, "conversion")
     init_py  = os.path.join(conv_dir, "__init__.py")
     base_py  = os.path.join(conv_dir, "base.py")
@@ -965,9 +957,9 @@ pass
 
 
 def _detect_converter_layout(entry_content_bytes, llama_cpp_dir):
-    """Return 'package' for the new conversion/ package layout, else 'monolith'.
-    Detection is structural: entrypoint must contain `from conversion import`
-    AND conversion/__init__.py + conversion/base.py must exist on disk."""
+    """Return 'package' for the new conversion/ layout, else 'monolith'.
+    Structural: entrypoint must contain `from conversion import` AND
+    conversion/__init__.py + conversion/base.py must exist on disk."""
     try:
         if b"from conversion import" not in entry_content_bytes:
             return "monolith"
@@ -985,7 +977,7 @@ pass
 
 def _extract_dict_keys_from_conversion_init(conv_init_path, dict_name):
     """AST-parse conversion/__init__.py for TEXT_MODEL_MAP / MMPROJ_MODEL_MAP
-    string-literal keys. Used as the arch allowlist on the new layout because
+    keys. Used as the arch allowlist on the new layout, where
     ModelBase._model_classes is empty until load_all_models() runs."""
     try:
         with open(conv_init_path, "rb") as f:
@@ -1012,7 +1004,7 @@ pass
 
 def _apply_branding_patch_to_base(conv_base_path):
     """Insert Unsloth metadata branding after `self.metadata = gguf.Metadata.load(...)`
-    in conversion/base.py. Idempotent via a one-line marker.
+    in conversion/base.py (idempotent via a one-line marker).
     Returns 'applied' / 'already-applied' / 'pattern-missing'."""
     try:
         with open(conv_base_path, "rb") as f:
@@ -1048,10 +1040,10 @@ pass
 
 
 def _qwen_already_handles_expert_aliases(conv_qwen_path):
-    """True iff conversion/qwen.py already searches both num_local_experts AND
-    num_experts. Upstream master uses
-        self.find_hparam(["num_local_experts", "num_experts"])
-    so the legacy patch is a no-op and the warning is misleading."""
+    """True iff conversion/qwen.py already searches both num_local_experts and
+    num_experts (upstream master uses
+    find_hparam(["num_local_experts", "num_experts"])), making the legacy
+    patch a no-op with a misleading warning."""
     try:
         with open(conv_qwen_path, "rb") as f:
             content = f.read()
@@ -1062,11 +1054,10 @@ pass
 
 
 def _download_convert_hf_to_gguf(name = "unsloth_convert_hf_to_gguf"):
-    # Resolve env vars + sibling mtimes on every call; both are folded into
-    # the @lru_cache key so re-pulled llama.cpp checkouts re-run the patcher.
-    # Anchor the conversion/ lookup to the converter being patched, not
-    # always LLAMA_CPP_DEFAULT_DIR -- matters when UNSLOTH_LLAMA_CPP_SCRIPTS_DIR
-    # points at a different checkout.
+    # Resolve env vars + sibling mtimes each call; both feed the @lru_cache key
+    # so re-pulled checkouts re-run the patcher. Anchor conversion/ to the
+    # converter being patched (matters when UNSLOTH_LLAMA_CPP_SCRIPTS_DIR points
+    # at a different checkout), not always LLAMA_CPP_DEFAULT_DIR.
     local_script_info = _resolve_local_convert_script()
     return _download_convert_hf_to_gguf_cached(
         name,
@@ -1078,26 +1069,24 @@ def _download_convert_hf_to_gguf(name = "unsloth_convert_hf_to_gguf"):
 @lru_cache(1)
 def _download_convert_hf_to_gguf_cached(name, _local_script_info, _conversion_info):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Downloads from llama.cpp's GitHub repository, or reads a local copy when
+    # Download from llama.cpp's GitHub, or read a local copy when
     # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR is set. _local_script_info is
     # (path, mtime_ns, size); mtime/size in the cache key invalidate stale
     # entries on in-place updates. Cache size is 1 because the patched script
-    # is written to a single shared on-disk path, so a second cache entry
-    # would always read stale bytes off disk.
+    # is written to one shared on-disk path, so a second entry would read stale
+    # bytes.
 
     # Ensure llama.cpp directory exists
     os.makedirs(LLAMA_CPP_DEFAULT_DIR, exist_ok=True)
 
-    supported_types = set() # Initialize outside try block
+    supported_types = set()
     text_archs = set()
     vision_archs = set()
-    temp_original_file_path = None # Initialize for finally block
+    temp_original_file_path = None # for the finally block
     original_module_name = None    # Only set on the monolith branch
-    # Set by introspection; read by Patch 2 + Patch 3 below. Default to
-    # 'monolith' so a failed introspection still drives the legacy patches.
+    # Default to 'monolith' so a failed introspection still drives the legacy
+    # patches; set by introspection and read by Patch 2 + Patch 3 below.
     _layout = "monolith"
-    # Resolve once: same dir feeds layout detection, branding patch, Qwen
-    # check, sibling cache key. UNSLOTH_LLAMA_CPP_SCRIPTS_DIR overrides default.
     _llama_cpp_dir = _get_llama_cpp_dir(_local_script_info)
 
     _local_script = _local_script_info[0] if _local_script_info is not None else None
@@ -1131,12 +1120,11 @@ def _download_convert_hf_to_gguf_cached(name, _local_script_info, _conversion_in
             if original_content is None:
                 raise _last_err  # type: ignore[misc]
 
-        # 2. Detect layout BEFORE attempting to import. The package-layout
-        # entrypoint does `from conversion import ...`, which a temp-file
-        # import resolves against LLAMA_CPP_DEFAULT_DIR -- so when the user
-        # set UNSLOTH_LLAMA_CPP_SCRIPTS_DIR to a different checkout, the
-        # import would ModuleNotFoundError and abort the patcher before we
-        # could reach the AST-based arch extraction path.
+        # 2. Detect layout BEFORE importing: the package entrypoint does
+        # `from conversion import ...`, which a temp-file import resolves
+        # against LLAMA_CPP_DEFAULT_DIR; with a different
+        # UNSLOTH_LLAMA_CPP_SCRIPTS_DIR that would ModuleNotFoundError and
+        # abort before the AST-based arch extraction path.
         _layout = _detect_converter_layout(original_content, _llama_cpp_dir)
         logger.info(f"Unsloth: convert_hf_to_gguf layout detected: {_layout}")
         logger.info("Unsloth: Identifying llama.cpp gguf supported architectures...")
@@ -1559,12 +1547,12 @@ def check_max_shard_size(max_shard_size = "50GB"):
 pass
 
 
-# Deps the converter imports. Only installed in install_llama_cpp(), which is
-# skipped when llama.cpp already exists, so a stale `gguf` can fail with exit 1.
+# Converter deps, only installed in install_llama_cpp() (skipped when llama.cpp
+# already exists), so a stale `gguf` can fail with exit 1.
 _CONVERTER_PYTHON_DEPS = ("gguf", "protobuf", "sentencepiece", "mistral_common")
 
-# Markers that mean the converter env is broken, not the model. Only these
-# trigger auto-repair; genuine model errors are surfaced as-is.
+# Markers meaning the converter env (not the model) is broken; only these
+# trigger auto-repair, genuine model errors surface as-is.
 _CONVERTER_DEP_ERROR_MARKERS = (
     "ModuleNotFoundError",
     "No module named",
@@ -1583,7 +1571,7 @@ def _looks_like_converter_dep_error(text):
 
 def _reinstall_converter_deps(python_exe, print_output = False):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Force-reinstall the converter deps into its own interpreter to self-heal.
+    # Force-reinstall converter deps into their interpreter to self-heal.
     if print_output:
         print(
             f"Unsloth: The GGUF converter environment looks broken (stale/missing "
@@ -1878,14 +1866,12 @@ def quantize_gguf(
         import shlex
         return shlex.quote(s)
 
-    # Q2_K_L is an Unsloth preset (q2_k base with selective upcasts), not a
-    # native llama.cpp ftype. Recipe: token_embd -> Q4_K, output -> Q6_K, and
-    # every ffn_down / ffn_down_exps tensor (all layer ids, dense + MoE) ->
-    # Q3_K. llama-quantize matches --tensor-type with std::regex_search and
-    # iterates with first-match-wins, so we chain the more-specific MoE
-    # pattern first; the leading `\.` anchors on the GGUF path separator so
-    # the override does not slip into unrelated tensor names that happen to
-    # contain the substring "ffn_down".
+    # Q2_K_L is an Unsloth preset (q2_k base + selective upcasts), not a native
+    # llama.cpp ftype. Recipe: token_embd->Q4_K, output->Q6_K, every
+    # ffn_down/ffn_down_exps->Q3_K. llama-quantize matches --tensor-type via
+    # regex_search first-match-wins, so chain the more-specific MoE pattern
+    # first; the leading `\.` anchors on the GGUF path separator so the
+    # override doesn't leak into other tensors containing "ffn_down".
     _display_quant_type = quant_type
     _extra_flags = ""
     if str(quant_type).strip().lower() == "q2_k_l":

--- a/unsloth_zoo/logging_utils.py
+++ b/unsloth_zoo/logging_utils.py
@@ -68,10 +68,8 @@ def NotebookProgressCallback_on_train_begin(Trainer_metrics):
         self.first_column = "Epoch" if args.eval_strategy == IntervalStrategy.EPOCH else "Step"
         self.training_loss = 0
         self.last_log = 0
-        # Don't pre-create metric columns. Start with just the essentials;
-        # columns are added dynamically by write_line as metrics actually appear.
-        # This prevents empty "0 then blank" columns for conditional metrics
-        # (kl when beta=0, sampling/* without importance sampling, etc.)
+        # Don't pre-create metric columns; write_line adds them dynamically as
+        # metrics appear, avoiding empty columns for conditional metrics.
         column_names = [self.first_column] + ["Training Loss"]
         if args.eval_strategy != IntervalStrategy.NO:
             column_names.append("Validation Loss")
@@ -82,9 +80,8 @@ pass
 
 
 def NotebookProgressCallback_on_log(Trainer_metrics):
-    # Build an allowlist of known metrics (pre-extracted from TRL source).
-    # Only these + dynamic rewards/* metrics pass through. This blocks
-    # spurious keys injected at runtime (e.g. "train", "tools/*").
+    # Allowlist of known metrics (pre-extracted from TRL source); only these +
+    # dynamic rewards/* pass through, blocking runtime-injected keys.
     set_Trainer_metrics = frozenset(Trainer_metrics)
 
     def _NotebookProgressCallback_on_log(self, args, state, control, logs = None, **kwargs):
@@ -92,15 +89,14 @@ def NotebookProgressCallback_on_log(Trainer_metrics):
         if args.eval_strategy == IntervalStrategy.NO and "loss" in logs:
             values = {}
 
-            # 1) Pre-extracted metrics — only if actually present in logs
+            # 1) Pre-extracted metrics, only if present in logs
             for metric in Trainer_metrics:
                 if metric in logs:
                     values[metric.replace("/", " / ")] = logs[metric]
             pass
 
-            # 2) Dynamic per-reward-function metrics (rewards/*)
-            #    These have user-defined names so can't be pre-extracted.
-            #    Sort for stable column ordering across steps.
+            # 2) Dynamic per-reward-function metrics (rewards/*): user-defined
+            #    names, so sort for stable column ordering across steps.
             dynamic_reward_keys = sorted(
                 k for k in logs
                 if k.startswith("rewards/") and k not in set_Trainer_metrics
@@ -111,7 +107,7 @@ def NotebookProgressCallback_on_log(Trainer_metrics):
                     values[display_key] = logs[key]
             pass
 
-            # 3) Prepend Training Loss + Step (always first columns)
+            # 3) Prepend Training Loss + Step as first columns
             values = {"Training Loss": logs["loss"], **values}
             values[self.first_column] = state.global_step
             self.training_tracker.write_line(values)
@@ -134,12 +130,11 @@ def NotebookTrainingTracker_write_line(Trainer_metrics):
         else:
             columns = self.inner_table[0]
 
-            # Dynamically add new columns that appear in values
-            # (e.g. per-reward-func metrics discovered at step > 1)
+            # Add new columns appearing in values (e.g. per-reward-func metrics
+            # discovered at step > 1), back-filling previous rows.
             for key in values:
                 if key not in columns:
                     columns.append(key)
-                    # Back-fill previous rows with empty string
                     for row in self.inner_table[1:]:
                         row.append("")
             pass
@@ -152,7 +147,7 @@ def NotebookTrainingTracker_write_line(Trainer_metrics):
                     # write new line
                     self.inner_table.append([values[c] if c in values else "" for c in columns])
                 else:
-                    # update last line — preserve existing values for missing keys
+                    # update last line, preserving existing values for missing keys
                     new_values = values
                     for c in columns:
                         if c not in new_values:
@@ -193,20 +188,19 @@ def get_trl_metrics():
     filepath = inspect.getfile(trl.trainer)
     filepath = os.path.split(filepath)[0]
 
-    # TRL >= 0.26.0 moved many trainers to trl/experimental/*/
-    # The old trl/trainer/ files become thin shims that re-export.
-    # Build a map of trainer_name -> source file path, preferring the
-    # experimental (real) file when both exist.
+    # TRL >= 0.26.0 moved many trainers to trl/experimental/*/, leaving thin
+    # re-export shims in trl/trainer/. Map trainer -> source path, preferring
+    # the experimental (real) file when both exist.
     trl_root = os.path.split(filepath)[0]
     exp_dir = os.path.join(trl_root, "experimental")
     trainer_files = dict()
     for trainer in trainers:
         candidates = []
-        # 1) trl/trainer/{trainer}.py (original or shim)
+        # trl/trainer/{trainer}.py (original or shim)
         c1 = os.path.join(filepath, f"{trainer}.py")
         if os.path.exists(c1):
             candidates.append(c1)
-        # 2) trl/experimental/{name}/{trainer}.py (real code in >= 0.26.0)
+        # trl/experimental/{name}/{trainer}.py (real code in >= 0.26.0)
         if os.path.isdir(exp_dir):
             name = trainer.replace("_trainer", "")
             c2 = os.path.join(exp_dir, name, f"{trainer}.py")

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -138,10 +138,9 @@ def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
     import transformers.modeling_utils
     LOSS_MAPPING = transformers.loss.loss_utils.LOSS_MAPPING
     # Patch every key still aliased to the stock ForCausalLMLoss. PreTrainedModel
-    # resolves loss_type via regex on the class name, so classes like
-    # Qwen3_5ForConditionalGeneration land on LOSS_MAPPING["ForConditionalGeneration"]
-    # (and CsmForConditionalGeneration on its own key), both of which point at the
-    # stock ForCausalLMLoss. Without this sweep those models keep the un-patched
+    # resolves loss_type by regex on the class name, so e.g.
+    # Qwen3_5ForConditionalGeneration / CsmForConditionalGeneration land on keys
+    # pointing at the stock loss; without this sweep they keep the un-patched
     # loss and OOM via logits.float() at large vocab sizes.
     for _key, _fn in list(LOSS_MAPPING.items()):
         if getattr(_fn, "__name__", "") == "ForCausalLMLoss":
@@ -226,17 +225,8 @@ ALLOWED_NUM_ITEMS_IN_BATCH = dict()
 global TRAINING_ITERATIONS
 TRAINING_ITERATIONS = 0
 
-# Check for DataParallel
-#
-# DataParallel uses scatter and gather
-# cpu->0 scatter 0 --> 0 gather 0
-# cpu->0 scatter 1 --> 1 gather 0
-# cpu->0 scatter 2 --> 2 gather 0
-#
-# DistributedDataParallel is faster and launches multiple processes
-# cpu->0 ------------> 0 gather 0
-# cpu->1 ------------> 1 gather 0
-# cpu->2 ------------> 2 gather 0
+# ParallelMode distinguishes DataParallel (scatter/gather from one process)
+# from the faster DistributedDataParallel (one process per device).
 from transformers.training_args import ParallelMode
 
 # Cannot use sadly
@@ -277,9 +267,8 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
                         forward = __wrapped__
             pass
             name = forward.__qualname__
-            # Also check the class name as a fallback - patched forward methods
-            # (e.g. from temporary_patches) may have qualnames that don't contain
-            # the original class identifiers like "CausalLM".
+            # Fall back to the class name: patched forwards (temporary_patches)
+            # may have qualnames lacking identifiers like "CausalLM".
             class_name = type(m).__name__
             if "ForConditionalGeneration" in name or "ForConditionalGeneration" in class_name \
                 or "VisionText2Text" in name:
@@ -327,8 +316,8 @@ def _unsloth_get_batch_samples(self, epoch_iterator, num_batches, device = None,
                 count = token_count.sum()
                 seq_lengths = x.get("packed_seq_lengths")
                 if seq_lengths is not None:
-                    # When packing N sequences, there are N-1 internal boundaries
-                    # that shouldn't be counted as valid training positions
+                    # Packing N sequences has N-1 internal boundaries that
+                    # aren't valid training positions.
                     count -= torch.count_nonzero(seq_lengths > 0).item() - 1
                 token_counts.append(count)
             pass

--- a/unsloth_zoo/mlx/cce/__init__.py
+++ b/unsloth_zoo/mlx/cce/__init__.py
@@ -73,9 +73,5 @@ def _get_runtime_cce(
 
 
 def clear_cce_cache():
-    """Clear the CCE kernel cache.
-
-    Call this when switching models or devices to free cached Metal
-    kernels and compiled functions that may hold stale references.
-    """
+    """Clear the CCE kernel cache (call when switching models/devices)."""
     _RUNTIME_CCE_CACHE.clear()

--- a/unsloth_zoo/mlx/cce/runtime_cce.py
+++ b/unsloth_zoo/mlx/cce/runtime_cce.py
@@ -29,25 +29,9 @@ __all__ = [
 
 
 def _get_memory_budget() -> int:
-    """Return a per-chunk logit byte budget based on available hardware memory.
-
-    Two considerations in tension:
-      1. Smaller devices need aggressive chunking (more chunks, smaller each)
-         to avoid OOM.
-      2. The MLX scheduler benefits from small chunks regardless of device size
-         — but too many chunks incurs kernel-launch overhead.
-
-    We use 0.1% of the device's recommended working set as the budget, capped
-    at 128 MB.  The cap ensures the scheduler always gets enough granularity
-    (≥16 chunks for 128K vocab at any batch size ≤4), while the hardware
-    scaling ensures small devices chunk even more aggressively.
-
-      M4 Max 128GB → 103 GB recommended → min(103 MB, 128 MB) = 103 MB
-      M3 Pro 36GB  →  27 GB recommended → min(27 MB, 128 MB)  =  27 MB
-      M2 16GB      →  12 GB recommended → min(12 MB, 128 MB)  =  12 MB
-      M1 8GB       →   6 GB recommended → min(6 MB, 128 MB)   =   6 MB
-
-    Falls back to 128 MB if device info is unavailable.
+    """Per-chunk logit byte budget = 0.1% of the device's recommended working set,
+    capped at 128 MB (and floored at 4 MB). Small devices chunk more aggressively;
+    the cap keeps enough granularity (>=16 chunks for 128K vocab). 128 MB fallback.
     """
     try:
         import mlx.core as _mx
@@ -78,27 +62,14 @@ def _resolve_chunk_size(
     if _CHUNK_BUDGET is None:
         _CHUNK_BUDGET = _get_memory_budget()
 
-    # Goal: choose chunk_v so the MLX scheduler can free each chunk's logit
-    # tensor before the next chunk is computed, while keeping chunks large
-    # enough for efficient GEMM.
-    #
-    # Strategy: target 16 chunks as the baseline granularity.  The per-chunk
-    # byte budget (derived from hardware memory) caps how large each chunk can
-    # be.  On large-memory devices the cap is ~100 MB; on small devices it
-    # scales down to force more aggressive chunking.
-    #
-    # Constraints:
-    #   - min 2048 vocab entries per chunk  (GEMM efficiency floor)
-    #   - target 16 chunks                 (scheduler granularity sweet spot)
-    #   - per-chunk bytes ≤ hw budget       (adapts to device memory, ≤128 MB)
-
+    # Target 16 chunks (scheduler granularity), min 2048 vocab/chunk (GEMM floor),
+    # per-chunk bytes <= hw budget (<=128 MB), so each chunk frees before the next.
     min_chunk_v = 2048
     target_chunks = 16
 
-    # Compute chunk_v from target chunk count
     chunk_v = (vocab_size + target_chunks - 1) // target_chunks
 
-    # Enforce per-chunk byte limit (adapts to hardware)
+    # Enforce per-chunk byte limit
     chunk_bytes = n_tokens * chunk_v * bytes_per_element
     if chunk_bytes > _CHUNK_BUDGET and chunk_v > min_chunk_v:
         chunk_v = max(min_chunk_v, _CHUNK_BUDGET // (max(1, n_tokens) * bytes_per_element))
@@ -120,8 +91,8 @@ def _target_validity_masks(
     vocab_size: int,
     ignore_index: int,
 ) -> tuple[mx.array, mx.array]:
-    # Cast unsigned labels to int64 before comparisons: direct `>= 0` on
-    # uint16/32/64 crashes the torch-backed MLX shim ("ge_cpu" not implemented).
+    # Cast unsigned labels to int64 first: direct `>= 0` on uint16/32/64 crashes
+    # the torch-backed MLX shim ("ge_cpu" not implemented).
     _unsigned_safe_to_i64 = tuple(
         dtype for dtype in (
             getattr(mx, "uint8", None),
@@ -132,10 +103,10 @@ def _target_validity_masks(
     )
     _uint64_dtype = getattr(mx, "uint64", None)
     if _uint64_dtype is not None and targets.dtype == _uint64_dtype:
-        # uint64 -> int64: any value >= 2**63 wraps negative. Route those
-        # to an out-of-vocab sentinel (1<<62) so wrap artifacts like
-        # 2**64-100 NaN-poison instead of colliding with ignore_index.
-        # Avoid float validation: float32 loses precision above 2**24.
+        # uint64 -> int64: values >= 2**63 wrap negative. Route those to an
+        # out-of-vocab sentinel (1<<62) so wrap artifacts (e.g. 2**64-100)
+        # NaN-poison instead of colliding with ignore_index. Avoid float
+        # validation: float32 loses precision above 2**24.
         targets_i64 = targets.astype(mx.int64)
         overflow = targets_i64 < 0
         invalid_sentinel = mx.array(1 << 62, dtype=mx.int64)
@@ -159,8 +130,8 @@ def _target_validity_masks(
 
 
 def _poison_invalid_targets(values: mx.array, invalid: mx.array) -> mx.array:
-    # Use mx.full (real tensor) instead of a 0-d scalar: a scalar bakes
-    # into the Metal kernel as the literal token `nan`, which MSL rejects.
+    # mx.full (real tensor), not a 0-d scalar: a scalar bakes into the Metal
+    # kernel as the literal token `nan`, which MSL rejects.
     return mx.where(
         invalid,
         mx.full(values.shape, float("nan"), dtype=values.dtype),
@@ -303,10 +274,9 @@ def _build_forward_update_kernel() -> Callable:
     )
 
 
-# INVARIANT: kernel emits finite lse_out/loss_out for every row (no
-# vocab_size). Callers MUST _poison_invalid_targets(loss, invalid) and
-# (lse, invalid) before the dlogits kernel, or invalid rows get finite
-# wrong gradients silently.
+# INVARIANT: kernel emits finite lse_out/loss_out for every row (no vocab_size).
+# Callers MUST _poison_invalid_targets on loss and lse before the dlogits kernel,
+# else invalid rows silently get finite wrong gradients.
 def _build_forward_update_finalize_kernel() -> Callable:
     source = """
         uint gid = thread_position_in_grid.x;
@@ -527,14 +497,13 @@ def _forward_chunked_fused_finalize(
 ) -> tuple[mx.array, mx.array]:
     hidden_compute = hidden
     weight_compute = weight
-    # Validate in the original dtype so wide ints cannot wrap into a valid
-    # class id or ignore_index after the int32 narrow.
+    # Validate in the original dtype so wide ints can't wrap into a valid class
+    # id or ignore_index after the int32 narrow.
     targets_raw = targets
 
     n, _ = hidden_compute.shape
     vocab_size = weight_compute.shape[0]
-    # Reject rank-2 targets up front; they would slip past the length check
-    # and crash inside the kernels.
+    # Reject rank-2 targets up front; they slip past the length check and crash the kernels.
     if len(targets_raw.shape) != 1:
         raise ValueError(
             "MLX CCE: targets must be a flat 1D vector "
@@ -547,7 +516,7 @@ def _forward_chunked_fused_finalize(
                 "MLX CCE: hidden has 0 tokens but targets is non-empty "
                 f"(targets.shape={targets_raw.shape})."
             )
-        # Separate allocations so the VJP cannot alias loss into lse.
+        # Separate allocations so the VJP can't alias loss into lse.
         return (
             mx.zeros((0,), dtype=mx.float32),
             mx.zeros((0,), dtype=mx.float32),
@@ -670,8 +639,8 @@ def _forward_chunked_fused_finalize(
     raise RuntimeError("Unreachable: fused finalize path did not return outputs.")
 
 
-# Requires lse pre-poisoned with NaN for invalid rows; this fallback does
-# not re-check vocab bounds and relies on NaN propagation for the gradient.
+# Requires lse pre-poisoned with NaN for invalid rows: this fallback does not
+# re-check vocab bounds and relies on NaN propagation for the gradient.
 def _fallback_dlogits(
     logits: mx.array,
     lse: mx.array,
@@ -699,8 +668,8 @@ def _fallback_dlogits(
         t = mx.tanh(logits / softcap)
         d_capped = d_capped * (1.0 - t * t)
 
-    # Force NaN grad on lse-NaN rows BEFORE the ignore_index mask, so wide
-    # invalid labels that narrow to ignore_index do not silently zero-grad.
+    # NaN grad on lse-NaN rows BEFORE the ignore_index mask, so wide invalid
+    # labels that narrow to ignore_index do not silently zero-grad.
     invalid_lse = mx.isnan(lse)
     nan_grad = mx.full(d_capped.shape, float("nan"), dtype=d_capped.dtype)
     d_capped = mx.where(mx.expand_dims(invalid_lse, -1), nan_grad, d_capped)
@@ -735,8 +704,7 @@ def make_runtime_cce_loss_fused_finalize(
     ) -> tuple[int, list[int], list[mx.array], list[mx.array]]:
         n_tokens = hidden.shape[0]
         vocab_size = weight.shape[0]
-        # why: dtype drives compute_bytes; key must include it or a bf16
-        # plan is reused for fp32 and OOMs.
+        # dtype drives compute_bytes; key must include it or a bf16 plan is reused for fp32 and OOMs.
         key = (n_tokens, vocab_size, hidden.dtype)
         if key in chunk_plan_cache:
             return chunk_plan_cache[key]
@@ -865,10 +833,9 @@ def make_runtime_cce_loss_fused_finalize(
                     transpose=False,
                 )
 
-            # Quantized weight gradients are zero — correct for LoRA where the
-            # LM head is frozen and gradients flow through grad_hidden only.
-            # Full fine-tuning of quantized models would need
-            # dequantize → grad → requantize, which is not supported.
+            # Quantized weight gradients are zero: correct for LoRA (frozen LM head,
+            # gradients flow only through grad_hidden). Full fine-tuning of quantized
+            # models would need dequantize -> grad -> requantize, which is unsupported.
             return (
                 grad_hidden.astype(hidden.dtype),
                 mx.zeros_like(weight),
@@ -887,8 +854,8 @@ def make_runtime_cce_loss_fused_finalize(
             losses, lse = runtime_cce_loss_full(
                 hidden, weight, scales, biases, targets
             )
-            # Keep lse live for the custom VJP under mx.compile (reads it
-            # from outputs during backward); zero-weight add preserves losses.
+            # Keep lse live for the custom VJP under mx.compile (read from outputs
+            # during backward); zero-weight add preserves losses.
             return losses + lse * mx.array(0.0, dtype=mx.float32)
 
         return runtime_cce_loss, use_metal_kernel
@@ -934,9 +901,9 @@ def make_runtime_cce_loss_fused_finalize(
         vocab_size = weight_compute.shape[0]
 
         grad_hidden = mx.zeros_like(hidden_compute)
-        # Accumulate weight gradient in float32 to avoid precision loss
-        # when hidden is float16/bfloat16. Only matters for full fine-tuning
-        # (LoRA freezes the LM head so this VJP path is never reached).
+        # Accumulate weight gradient in float32 to avoid precision loss with
+        # float16/bfloat16 hidden. Only matters for full fine-tuning (LoRA
+        # freezes the LM head, so this VJP path is never reached).
         grad_weight = mx.zeros(weight_compute.shape, dtype=mx.float32)
         n_reads = 4
 
@@ -993,9 +960,8 @@ def make_runtime_cce_loss_fused_finalize(
 
     def runtime_cce_loss(hidden: mx.array, weight: mx.array, targets: mx.array) -> mx.array:
         losses, lse = runtime_cce_loss_full(hidden, weight, targets)
-        # Preserve the public return value/type as losses while keeping
-        # auxiliary log-sum-exp live for the custom VJP under mx.compile.
-        # The VJP reads lse from custom-function outputs during backward.
+        # Return losses, but keep lse live for the custom VJP under mx.compile
+        # (it reads lse from custom-function outputs during backward).
         return losses + lse * mx.array(0.0, dtype=mx.float32)
 
     return runtime_cce_loss, use_metal_kernel

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -16,24 +16,12 @@
 
 """Compile qualification, policy resolution, and runtime monkey patches for MLX.
 
-This module is the canonical compile entrypoint for Unsloth's MLX training
-stack. The file is large because it owns three different layers of behavior:
-
-1. Qualification:
-   Discover installed `mlx_vlm` architectures, scan them for known compile
-   blocker patterns, and report whether each architecture has been verified.
-2. Policy:
-   Decide whether a particular training run should use `mx.compile`, fall back
-   to eager mode, or raise when strict compile is requested.
-3. Runtime patching:
-   Install monkey patches for repeated blocker patterns so verified
-   architectures can run compiled training without carrying architecture-local
-   one-off shims throughout the trainer.
-
-The qualification matrix is intentionally conservative. Architectures are only
-marked compile-ready once explicitly verified. Everything else either runs eager
-or stays in "pattern candidate" state until a verifier or real training sweep
-confirms the patch set is functionally correct.
+Canonical compile entrypoint for Unsloth's MLX training stack. Owns three
+layers: qualification (scan installed `mlx_vlm` architectures for compile
+blockers), policy (decide compile / eager / raise per run), and runtime
+patching (install monkey patches so verified architectures compile without
+per-architecture shims). Qualification is conservative: architectures are
+compile-ready only once explicitly verified.
 """
 
 from __future__ import annotations
@@ -56,14 +44,10 @@ _PATCHED_ARCHES: set[str] = set()
 _PATCHED_PATTERN_BUNDLES: set[str] = set()
 _PATCH_BINDINGS: set[tuple[str, str, str, str]] = set()
 
-# Architectures explicitly verified for mlx compile support.
-# Training verification currently covers:
-# - qwen2_5_vl: real end-to-end compiled training via train.py
-# - qwen3_vl / qwen3_5 / qwen3_5_moe / gemma4 / paligemma / moondream3:
-#   compiled synthetic forward+backward
-# SmolVLM has processor/template support, but real mlx-vlm training still hits
-# MLX primitive-less-array failures after a compiled call. Keep it patched but
-# unqualified until a real dataset compile run passes.
+# Architectures explicitly verified for mlx compile support. qwen2_5_vl is
+# real end-to-end; others are compiled synthetic forward+backward. SmolVLM is
+# kept patched but unqualified: real mlx-vlm training still hits MLX
+# primitive-less-array failures after a compiled call.
 _VERIFIED_TRAINING_ARCHES: set[str] = {
     "aya_vision",
     "deepseekocr",
@@ -238,10 +222,8 @@ _TRAINING_VERIFIER_HINTS: dict[str, str] = {
 class MLXVLMTraitReport:
     """Static scan result for one installed `mlx_vlm` architecture.
 
-    Trait reports are architecture-level hints only. They are used to:
-    - surface likely compile blocker categories for maintainers
-    - identify shared patch bundles that can be applied generically
-    - explain why an architecture is qualified, unqualified, or a candidate
+    Architecture-level hints only: surface likely blocker categories, identify
+    shared patch bundles, and explain qualification state.
     """
 
     arch: str
@@ -256,16 +238,9 @@ class MLXVLMTraitReport:
 class CompilePatternBundle:
     """A reusable compile patch bundle keyed by architecture traits.
 
-    The bundle registry is intentionally declarative. A bundle describes:
-    - how to recognize a family via `matcher`
-    - which semantic patch primitives it needs
-    - which thin family adapter explains method/contract differences
-    - which runtime patch primitives implement the monkey patches
-
-    Installation happens through a generic patch-plan executor rather than
-    through per-architecture installer dispatch. That keeps the public surface
-    easy to trace even when a runtime primitive still needs specialized code
-    under the hood.
+    Declarative: a bundle names its `matcher`, semantic primitives, family
+    adapter, and runtime primitives. Installation runs through a generic
+    patch-plan executor rather than per-architecture installer dispatch.
     """
 
     name: str
@@ -333,10 +308,8 @@ class CompilePatchPrimitive:
 class CompilePatchAdapter:
     """Thin family-level contract description for shared patch primitives.
 
-    Adapters should prefer semantic matching over explicit architecture lists.
-    A future family should ideally pick up an existing adapter because it
-    exposes the same source traits or naming convention, not because we added
-    one more architecture string by hand.
+    Prefer semantic matching (source traits / naming) over explicit
+    architecture lists so future families pick up existing adapters.
     """
 
     name: str
@@ -348,11 +321,8 @@ class CompilePatchAdapter:
 
 @dataclass(frozen=True)
 class CompilePatchPlan:
-    """Resolved patch plan for one matched compile bundle.
-
-    Patch plans are the maintainer-facing bridge between the declarative bundle
-    registry and the actual monkey patches that get applied at runtime.
-    """
+    """Resolved patch plan: bridges the declarative bundle registry and the
+    monkey patches applied at runtime."""
 
     bundle_name: str
     adapter_name: str | None
@@ -447,8 +417,8 @@ class CompilePatchabilityReport:
 def _iter_arch_modules() -> Iterable[tuple[str, Path]]:
     """Yield installed `mlx_vlm.models.<arch>` package roots.
 
-    We inspect the installed package instead of maintaining a static registry so
-    the qualification layer reflects the actual venv contents.
+    Inspects the installed package (not a static registry) so qualification
+    reflects actual venv contents.
     """
 
     try:
@@ -554,10 +524,9 @@ def _support_state(
 ) -> str:
     """Return the user-facing support state for one architecture.
 
-    `supported_inferred` is reserved for architectures where the shared patch
-    system confidently matched reusable patterns, but the family has not yet
-    been promoted to explicitly verified. We still keep runtime compile policy
-    conservative unless verification exists.
+    `supported_inferred` means the shared patch system matched reusable
+    patterns but the family is not yet explicitly verified; runtime policy
+    stays conservative without verification.
     """
 
     if training_ok or generation_ok:
@@ -621,9 +590,8 @@ def list_protocol_requirements(
 ) -> tuple[CompileProtocolRequirement, ...]:
     """Return the protocol registry used for generic compile target discovery.
 
-    These protocols are intentionally broader than architecture names. They
-    describe the stable runtime contracts we look for when deciding whether an
-    existing patch primitive can be reused by a new family.
+    Protocols are broader than architecture names: they describe the stable
+    runtime contracts checked when reusing a patch primitive for a new family.
     """
 
     protocols = (
@@ -819,10 +787,9 @@ def _config_get(config, key, default=None):
 def _iter_backend_subconfigs(config) -> Iterable[tuple[str, object]]:
     """Yield likely nested backend configs from an MLX config object.
 
-    The explicit key allowlist keeps the common paths readable and stable, but
-    newer mlx-vlm families may introduce additional `*_config` children. We
-    therefore also scan the config object's visible attributes / mapping keys
-    for nested config-shaped values that advertise a `model_type`.
+    Checks the explicit `*_config` allowlist, then also scans visible
+    attributes / mapping keys for nested config-shaped values with a
+    `model_type` (to catch newer mlx-vlm families).
     """
 
     if config is None:
@@ -1100,10 +1067,9 @@ def discover_compile_protocol_targets(
 ) -> tuple[CompileProtocolTarget, ...]:
     """Discover patchable protocol targets for an architecture or loaded model.
 
-    This is the main maintainer helper for new-family triage. It inspects the
-    installed `mlx_vlm` modules for a family and reports which generic compile
-    protocols match actual classes/methods, plus any missing source tokens that
-    prevented a clean protocol match.
+    Main new-family triage helper: inspects installed `mlx_vlm` modules and
+    reports which generic compile protocols match classes/methods, plus any
+    missing source tokens that prevented a clean match.
     """
 
     arch = model_or_arch if isinstance(model_or_arch, str) else get_model_architecture(model_or_arch)
@@ -1255,10 +1221,8 @@ def find_similar_compile_families(
 ) -> tuple[tuple[str, float, tuple[str, ...]], ...]:
     """Return nearby families based on shared traits, bundles, and protocols.
 
-    This helper is aimed at maintainers adding support for a new family. It
-    answers "what existing architecture looks most like this one?" so the next
-    step is usually to compare patchability and trace output against a known
-    neighbor rather than reading every patch body from scratch.
+    Answers "what existing architecture looks most like this one?" when adding
+    a new family, so patchability/trace can be compared against a neighbor.
     """
 
     arch = model_or_arch if isinstance(model_or_arch, str) else get_model_architecture(model_or_arch)
@@ -1414,9 +1378,8 @@ def get_backend_compile_qualifications(model_or_arch) -> tuple[MLXVLMCompileQual
 def _model_repo_training_compile_block_reason(model_or_arch) -> str | None:
     """Return a repo-specific compile block reason when policy should stay eager.
 
-    This is intentionally separate from architecture qualification. Sometimes an
-    architecture is broadly patchable, but a known repo family still fails real
-    training due to an unresolved runtime issue.
+    Separate from architecture qualification: an arch can be patchable while a
+    known repo family still fails real training on an unresolved runtime issue.
     """
 
     if isinstance(model_or_arch, str):
@@ -1538,10 +1501,8 @@ def _adapter_matches(
 ) -> bool:
     """Return whether a declarative adapter applies to one architecture.
 
-    Adapters intentionally match on multiple signals:
-    - exact architecture names for true exceptions
-    - architecture prefixes for stable family naming
-    - required traits for semantic reuse across future variants
+    Matches on exact names (exceptions), prefixes (family naming), and
+    required traits (semantic reuse).
     """
 
     if arch in adapter.arch_names:
@@ -1576,8 +1537,8 @@ def _recommend_compile_settings(
 ) -> tuple[CompileSettingRecommendation, ...]:
     """Return compile-aware training setting recommendations.
 
-    Recommendations are intentionally conservative. They target settings that
-    materially affect compiled training stability or memory behavior.
+    Conservative: targets settings that materially affect compiled training
+    stability or memory behavior.
     """
 
     arch = model_or_arch if isinstance(model_or_arch, str) else get_model_architecture(model_or_arch)
@@ -1641,13 +1602,9 @@ def resolve_training_compile(
 ) -> ResolvedTrainingCompileDecision:
     """Resolve whether a training run should use `mx.compile`.
 
-    Resolution order:
-    1. Normalize the global policy and any per-arch/backend overrides.
-    2. Check for repo-specific blocklist reasons.
-    3. Require the main architecture and every backend architecture to be
-       training-qualified.
-    4. Return either an enabled compile decision or an eager fallback / raise
-       decision, depending on policy strictness.
+    Order: normalize policy + overrides; check repo blocklist; require main and
+    backend architectures training-qualified; return enabled, or eager
+    fallback / raise depending on policy strictness.
     """
 
     arch = model_or_arch if isinstance(model_or_arch, str) else get_model_architecture(model_or_arch)
@@ -1871,9 +1828,8 @@ def _patch_method(cls, name, fn):
 def _try_import_module(module_name: str):
     """Best-effort import for optional `mlx_vlm` modules.
 
-    Patch installers are intentionally permissive because the installed MLX
-    stack may not include every architecture. Silent `None` keeps the patch
-    registry idempotent across different environments.
+    Returns None silently since the installed MLX stack may not include every
+    architecture; keeps the patch registry idempotent across environments.
     """
 
     try:
@@ -1889,10 +1845,8 @@ def _iter_trait_model_modules(
 ):
     """Yield model modules for architectures that share a compile trait.
 
-    Most `mlx_vlm` architectures follow `mlx_vlm.models.<arch>.<arch>`. Using
-    trait discovery here lets a future architecture inherit a shared patch
-    automatically when it exposes the same source-level pattern and follows the
-    standard module layout.
+    Trait discovery (over the standard `mlx_vlm.models.<arch>.<arch>` layout)
+    lets future architectures inherit a shared patch automatically.
     """
 
     candidate_arches = set(include_arches)
@@ -1911,18 +1865,10 @@ def _iter_trait_model_modules(
 def _install_safe_fused_sdpa_mask_patches():
     """Work around MLX SDPA NaN gradients on fully masked query rows.
 
-    Patch `mx.fast.scaled_dot_product_attention` itself so every direct caller
-    in mlx-vlm inherits the fix, including `ensure_fused_sdpa` and models that
-    invoke the fast kernel directly.
-
-    The upstream failure mode is:
-    - additive float mask
-    - one or more query rows entirely masked (all `-inf`)
-    - finite forward output, non-finite backward gradients
-
-    Preserve the intended semantics by:
-    1. clearing fully masked rows in the additive mask before SDPA
-    2. zeroing the corresponding output rows after SDPA
+    Patches `mx.fast.scaled_dot_product_attention` itself so every direct
+    mlx-vlm caller inherits the fix. Upstream bug: an additive float mask with
+    a fully `-inf` query row gives finite forward but non-finite backward.
+    Fix: clear fully masked rows before SDPA, zero those output rows after.
     """
     fast_ns = getattr(mx, "fast", None)
     current = getattr(fast_ns, "scaled_dot_product_attention", None) if fast_ns is not None else None
@@ -1936,22 +1882,9 @@ def _install_safe_fused_sdpa_mask_patches():
     def safe_scaled_dot_product_attention(q, k, v, scale=1.0, mask=None, **kwargs):
         row_all_masked = None
         if mask is not None and hasattr(mask, "dtype") and mx.issubdtype(mask.dtype, mx.floating):
-            # MLX's fused SDPA backward is unstable when an additive float mask
-            # contains one or more query rows that are entirely masked out with
-            # negative infinity (every key position is -inf for that query
-            # row). Forward remains
-            # finite, but gradients can become NaN.
-            #
-            # Semantically those rows should contribute zero output because the
-            # query is padding / otherwise invalid. Preserve that meaning by:
-            # 1. clearing the all-masked rows before calling SDPA, avoiding the
-            #    upstream backward bug
-            # 2. explicitly zeroing those rows in the output afterward
-            #
-            # This only applies to additive float masks with true -inf rows.
-            # Large finite negative biases (for example -1e9 or -1e30) are
-            # valid finite masks with non-zero semantics and must pass through
-            # unchanged.
+            # Clear all-masked rows before SDPA (avoids the unstable backward),
+            # zero them in the output after. Only true -inf rows count: large
+            # finite negative biases (-1e9, -1e30) are valid and pass through.
             row_all_masked = mx.all(
                 mx.logical_and(mx.logical_not(mx.isfinite(mask)), mask < 0),
                 axis=-1,
@@ -1964,8 +1897,7 @@ def _install_safe_fused_sdpa_mask_patches():
 
         out = original_fast_sdpa(q, k, v, scale=scale, mask=mask, **kwargs)
         if row_all_masked is not None:
-            # Restore the intended zero-output semantics for fully masked query
-            # rows after the SDPA call.
+            # Restore zero-output for fully masked query rows.
             out = mx.where(
                 mx.expand_dims(row_all_masked, axis=-1),
                 mx.zeros_like(out),
@@ -2082,9 +2014,8 @@ def _merge_replacement_segments(inputs_embeds, replacements_by_batch):
 def _masked_scatter_no_numpy(final_embedding, image_mask_expanded, scaled_image_features):
     """Compile-safe replacement for `masked_scatter`-style multimodal merges.
 
-    Upstream `mlx_vlm` variants often flatten to NumPy or use mutation-heavy
-    scatter helpers. This version stays entirely in MLX array ops so it can run
-    under `mx.compile` and backward.
+    Stays in pure MLX array ops (no NumPy / mutation) so it runs under
+    `mx.compile` and backward.
     """
 
     import mlx.core as mx
@@ -3298,10 +3229,9 @@ def _install_paddleocr_vl_compile_patches():
 def _install_qwen_like_image_merge_patches():
     """Patch qwen-style placeholder-token image merges with a shared helper.
 
-    This covers the common pattern where a model replaces one placeholder token
-    per image feature segment. We intentionally exclude the Qwen3 family here
-    because it returns an additional broadcast mask and has its own multimodal
-    deepstack plumbing.
+    Covers the one-placeholder-token-per-image-segment pattern. Qwen3 is
+    excluded: it returns an extra broadcast mask and has its own deepstack
+    plumbing.
     """
 
     for arch, module in _iter_trait_model_modules(
@@ -3861,11 +3791,8 @@ def _install_gemma3n_compile_patches():
         return img
 
     def _safe_branch_magnitude(x):
-        # Gemma3n's AltUp branch rescaling squares hidden states to estimate an
-        # RMS magnitude. In fp16, some finite branch activations exceed the
-        # range where squaring remains finite, so `x ** 2` overflows even
-        # though `x` itself is still valid. Compute the magnitude in float32
-        # and cast back afterward to preserve the intended rescaling.
+        # AltUp RMS rescaling squares hidden states; in fp16 finite activations
+        # can overflow `x ** 2`, so compute the magnitude in float32.
         return (mx.mean(x.astype(mx.float32) ** 2, axis=-1, keepdims=True) ** 0.5)
 
     def patched_gemma3model_call(
@@ -4341,9 +4268,8 @@ def _install_masked_scatter_multimodal_patches():
 def _install_idefics_family_compile_patches():
     """Patch Idefics-family image filtering and multimodal merges for compile.
 
-    The shared issue here is Python-side filtering of padded images and image
-    placeholder merging. Architectures that expose the same source-level trait
-    and standard model module layout can inherit this patch automatically.
+    Shared issue: Python-side padded-image filtering and placeholder merging.
+    Architectures with the same trait and standard layout inherit this patch.
     """
 
     def patched_prepare_inputs_for_multimodal(self, image_features, inputs_embeds, input_ids):
@@ -4832,9 +4758,8 @@ def _install_phi4_multimodal_patches():
 def list_compile_pattern_bundles() -> tuple[CompilePatternBundle, ...]:
     """Return the shared compile patch registry.
 
-    This is the main maintainer entrypoint for adding new compile patterns.
-    Matchers should prefer source traits over hardcoded architecture lists when
-    the same fix is semantically reusable.
+    Main entrypoint for adding new compile patterns. Matchers should prefer
+    source traits over hardcoded architecture lists for reusable fixes.
     """
 
     return (
@@ -5112,10 +5037,8 @@ def _resolve_compile_patch_plan(bundle: CompilePatternBundle) -> CompilePatchPla
 def _runtime_patch_primitive_installers() -> dict[str, Callable[[], None]]:
     """Return the runtime primitive executor registry.
 
-    These runtime primitives are intentionally small semantic units that can be
-    composed by bundle plans. Some still wrap heavier helper bodies, but the
-    installation path itself no longer dispatches directly on architecture-
-    local installer names.
+    Small semantic units composed by bundle plans; installation no longer
+    dispatches on architecture-local installer names.
     """
 
     return {
@@ -5142,11 +5065,8 @@ def _runtime_patch_primitive_installers() -> dict[str, Callable[[], None]]:
 def _apply_compile_patch_plan(plan: CompilePatchPlan) -> None:
     """Apply one resolved runtime patch plan.
 
-    The plan executor is intentionally generic so new model families usually
-    only need registry updates:
-    - add or extend a trait matcher
-    - point a bundle at an adapter
-    - reuse or add runtime primitives
+    Generic executor: new families usually only need registry updates (extend a
+    trait matcher, point a bundle at an adapter, reuse/add runtime primitives).
     """
 
     executors = _runtime_patch_primitive_installers()
@@ -5163,9 +5083,8 @@ def _apply_compile_patch_plan(plan: CompilePatchPlan) -> None:
 def trace_patch_bindings(model_or_arch) -> tuple[tuple[str, str, str, str], ...]:
     """Return concrete runtime patch bindings applied for one architecture.
 
-    This is intentionally lower-level than `trace_compile_application(...)`.
-    It answers "what class/method names were actually monkey-patched?" so a
-    maintainer can quickly diff current bindings against upstream changes.
+    Lower-level than `trace_compile_application`: lists which class/method
+    names were actually monkey-patched, for diffing against upstream changes.
     """
 
     arch = model_or_arch if isinstance(model_or_arch, str) else get_model_architecture(model_or_arch)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
-Lightweight FastLanguageModel for Apple Silicon / MLX.
+"""Lightweight FastLanguageModel for Apple Silicon / MLX.
 
-No GPU dependencies — uses mlx-lm for model loading and LoRA.
-Supports both text-only models (mlx-lm) and VLMs (mlx-vlm).
-This avoids importing unsloth.models (which pulls in CUDA kernels).
+No GPU deps: uses mlx-lm (text) and mlx-vlm (VLM) instead of unsloth.models
+(which pulls in CUDA kernels).
 """
 
 import json
@@ -63,11 +61,10 @@ _LOAD_WEIGHTS_PATCH_LOCK = threading.RLock()
 
 @contextmanager
 def _temporary_hf_token_env(token):
-    """Expose an explicit HF token to libraries that only read auth from env.
+    """Expose an explicit HF token via env for the duration of the call.
 
-    mlx-lm / mlx-vlm do not consistently thread a ``token=`` argument through
-    every internal download path. Keep explicit token loads local to this call
-    without mutating persistent Hugging Face login state.
+    mlx-lm / mlx-vlm don't thread ``token=`` through every download path; this
+    keeps the token local without mutating persistent HF login state.
     """
     if not token or not isinstance(token, str):
         yield
@@ -89,9 +86,8 @@ def _temporary_hf_token_env(token):
 
 
 def _is_force_float32_arch(model_type: str) -> bool:
-    """Case-insensitive lookup of ``model_type`` in
-    ``unsloth_zoo.FORCE_FLOAT32``. Strips ``-``/``_`` and treats a
-    trailing comma on a list entry as an exact-match marker."""
+    """Case-insensitive ``model_type`` lookup in ``unsloth_zoo.FORCE_FLOAT32``
+    (strips ``-``/``_``; trailing comma marks an exact-match entry)."""
     if not model_type:
         return False
     from ..model_lists import FORCE_FLOAT32
@@ -108,12 +104,11 @@ def _is_force_float32_arch(model_type: str) -> bool:
 
 
 def _convert_mlx_dtype(model, target_dtype, model_type: str = "") -> None:
-    """Cast floating-point params to target_dtype (preserves quantized ints)
-    while honoring the model's optional path-based ``cast_predicate``.
+    """Cast float params to target_dtype (quantized ints preserved), honoring
+    the model's optional path-based ``cast_predicate``.
 
-    Warns on bfloat16 -> float16 for architectures in
-    ``unsloth_zoo.FORCE_FLOAT32`` (Gemma3 family, gpt_oss, Qwen3.5) where
-    fp16's narrower range silently NaN/Infs at training time.
+    Warns on bf16 -> fp16 for ``unsloth_zoo.FORCE_FLOAT32`` archs (Gemma3,
+    gpt_oss, Qwen3.5) where fp16's narrower range NaN/Infs in training.
     """
     import mlx.core as mx
     from mlx.utils import tree_flatten, tree_map_with_path
@@ -157,18 +152,12 @@ def _seed_mlx_random_state(random_state):
 
 
 def _collect_all_linear_target_names(model):
-    """Return suffix names of every Linear / QuantizedLinear leaf in `model`.
+    """Leaf-suffix names of every Linear / QuantizedLinear in `model`.
 
-    Mirrors PEFT's ``target_modules="all-linear"``: discover every
-    ``nn.Linear`` (and quantized variant) in the live module tree, and
-    return the leaf-suffix name of each. Numeric tokens (list indices like
-    ``experts.0``) are skipped — we want the semantic name (e.g. ``w1``,
-    ``router``, ``q_proj``, ``qkv_proj``, ``lm_head``).
-
-    The result is the set of names against which mlx-lm's
-    ``linear_to_lora_layers`` matches, so applying LoRA to this set covers
-    every Linear in the model — including fused-QKV archs, MoE
-    routers/experts, multimodal projector, and untied LM heads.
+    Mirrors PEFT's ``target_modules="all-linear"``: walk the live tree and
+    return each leaf's semantic name (``w1``, ``q_proj``, ``lm_head``, ...),
+    skipping numeric list indices. mlx-lm's ``linear_to_lora_layers`` matches
+    on these, so LoRA covers fused-QKV, MoE, projector, and untied heads.
     """
     import mlx.nn as nn
     linear_types = (nn.Linear, nn.QuantizedLinear)
@@ -182,19 +171,15 @@ def _collect_all_linear_target_names(model):
                     names.add(token)
                     break
     except Exception:
-        # Defensive: never let target-module discovery raise during LoRA
-        # setup. Caller will fall back to the canonical 7-name default.
+        # Never let discovery raise during LoRA setup; caller falls back to
+        # the canonical 7-name default.
         return []
     return sorted(names)
 
 
 def _is_vlm(config: dict) -> bool:
-    """Detect whether a model config describes a VLM.
-
-    Checks:
-    1. "vision_config" key in config → True
-    2. model_type is in mlx_vlm's supported model set (discovered dynamically)
-    """
+    """Detect whether a config describes a VLM (via "vision_config" or a
+    model_type in mlx_vlm's supported set)."""
     if "vision_config" in config:
         return True
 
@@ -261,15 +246,14 @@ def _load_mlx_lm_with_strict_fallback(
     mlx_load_kwargs,
     hf_token=None,
 ):
-    """Load text models through mlx-lm, retrying strict=False for known safe mismatches.
+    """Load text models via mlx-lm, retrying strict=False for known safe
+    mismatches (extra checkpoint tensors mlx-lm doesn't instantiate).
 
-    Some upstream checkpoints contain extra tensors that the current mlx-lm
-    implementation intentionally does not instantiate. mlx-lm's public load()
-    does not expose strict=False, so use the internal loader only for registered
-    mismatch signatures.
+    mlx-lm's public load() doesn't expose strict=False, so we use the internal
+    loader only for registered mismatch signatures.
     """
-    # why: mlx-lm 0.22.0 load() rejects return_config / revision; bypass it
-    # so signature drift between mlx-lm releases doesn't break loading.
+    # why: mlx-lm 0.22.0 load() rejects return_config / revision; bypass it so
+    # signature drift between releases doesn't break loading.
     from mlx_lm.utils import _download, load_model, load_tokenizer
 
     tokenizer_config = mlx_load_kwargs.get("tokenizer_config") or {}
@@ -319,10 +303,9 @@ def _load_mlx_vlm_with_extra_weight_filter(
 ):
     """Load VLMs, filtering known extra checkpoint tensors on retry.
 
-    Some upstream VLM checkpoints include tensors for modules that the current
-    mlx-vlm class does not instantiate. mlx-vlm does not expose strict=False
-    through load(), so retry with a temporary load_weights shim only for
-    registered mismatch signatures and exact allow-listed keys.
+    Some VLM checkpoints carry tensors mlx-vlm doesn't instantiate; since
+    load() lacks strict=False, retry with a temporary load_weights shim for
+    registered mismatch signatures and exact allow-listed keys only.
     """
     try:
         with _temporary_hf_token_env(hf_token):
@@ -361,11 +344,8 @@ def _load_mlx_vlm_with_extra_weight_filter(
 
 
 def _build_vlm_model_types():
-    """Build the set of model_type strings that mlx_vlm supports.
-
-    Uses dynamic discovery via pkgutil + MODEL_REMAPPING keys/values.
-    Returns frozenset; cached at module level by _is_vlm().
-    """
+    """Frozenset of model_type strings mlx_vlm supports (discovered via
+    pkgutil + MODEL_REMAPPING); cached at module level by _is_vlm()."""
     types_set = set()
     try:
         import mlx_vlm.models as vlm_models_pkg
@@ -378,7 +358,6 @@ def _build_vlm_model_types():
 
     try:
         from mlx_vlm.utils import MODEL_REMAPPING
-        # Add both source and target keys
         for src, tgt in MODEL_REMAPPING.items():
             types_set.add(src)
             types_set.add(tgt)
@@ -389,10 +368,10 @@ def _build_vlm_model_types():
 
 
 def _fix_missing_no_grad(model):
-    """Ensure every nn.Module submodule has _no_grad / _training.
+    """Ensure every submodule has _no_grad / _training.
 
-    Works around upstream model definitions that use __new__ without __init__
-    (e.g. gemma4 AudioRelativePositionEmbedding).
+    Works around upstream modules using __new__ without __init__ (e.g. gemma4
+    AudioRelativePositionEmbedding).
     """
     import mlx.nn as nn
     for _, mod in model.named_modules():
@@ -404,18 +383,13 @@ def _fix_missing_no_grad(model):
 
 
 class _TrainingKVStore:
-    """Lightweight KV store for Gemma4 KV-sharing during training.
+    """Minimal KV store for Gemma4 KV-sharing during training.
 
-    Gemma4 E2B/E4B have shared attention layers that borrow K/V from earlier
-    "store" layers via the KV cache. During training (cache=None), the shared
-    layers silently fall through to computing their own K/V from wrong hidden
-    states. This class provides a minimal interface so store layers can write
-    K/V and shared layers can read them, without autoregressive offset tracking.
-
-    Implements the subset of KVCache that Attention.__call__ needs:
-    - offset (always 0 for training — no prior tokens)
-    - state property (returns stored K/V)
-    - update_and_fetch (stores K/V from store layer)
+    Gemma4 E2B/E4B shared layers borrow K/V from earlier "store" layers via
+    the cache; with cache=None they'd recompute K/V from the wrong hidden
+    states. This lets store layers write and shared layers read, with no
+    autoregressive offset tracking. Implements just the KVCache surface
+    Attention.__call__ needs: offset (0), state, update_and_fetch.
     """
     __slots__ = ("keys", "values")
 
@@ -440,14 +414,9 @@ class _TrainingKVStore:
 def _fix_gemma4_kv_sharing(model):
     """Fix Gemma4 KV-shared layers producing wrong K/V during training.
 
-    Gemma4 E2B/E4B have num_kv_shared_layers shared attention layers that
-    borrow K/V from earlier "store" layers via the KV cache. When cache=None
-    (training), shared layers fall through to computing their own K/V from
-    the wrong hidden state — silently producing incorrect attention.
-
-    Fix: monkey-patch the text backbone's __call__ to create _TrainingKVStore
-    objects when cache=None, so store layers populate them and shared layers
-    read correct K/V.
+    With cache=None (training) the shared layers recompute K/V from the wrong
+    hidden state. Fix: patch the text backbone's __call__ to create
+    _TrainingKVStore objects when cache=None so shared layers read correct K/V.
     """
     lm = getattr(model, "language_model", None)
     if lm is None:
@@ -492,10 +461,9 @@ def _fix_gemma4_kv_sharing(model):
 def _fix_qwen35_attention_cache(model):
     """Fix Qwen3.5 attention crash when cache=None during training.
 
-    mlx-vlm's Qwen3.5 attention does `cache.offset + 1` without checking
-    if cache is None. During training cache is always None. Patch the
-    attention __call__ to handle cache=None by computing position_ids
-    from scratch.
+    mlx-vlm's Qwen3.5 attention does `cache.offset + 1` without a None check,
+    but training always passes cache=None. Patch __call__ to compute
+    position_ids from scratch in that case.
     """
     try:
         import importlib
@@ -512,7 +480,7 @@ def _fix_qwen35_attention_cache(model):
     original_attn_call = attn_cls.__call__
 
     def patched_attn_call(self, x, mask=None, cache=None, position_ids=None):
-        # When training (cache=None) and position_ids=None, compute them
+        # Compute position_ids when training (cache=None, position_ids=None).
         if cache is None and position_ids is None:
             import mlx.core as mx
             L = x.shape[1]
@@ -534,11 +502,8 @@ def _safe_getsource(obj) -> str:
 
 
 def _has_multimodal_strip_sanitize(model_or_cls) -> bool:
-    """Return whether a loader-side sanitize path strips multimodal towers.
-
-    We use this as a generic signal for "text-only load of a multimodal wrapper"
-    instead of hardcoding every Gemma-like family by name.
-    """
+    """Whether a sanitize path strips multimodal towers, a generic signal for
+    "text-only load of a multimodal wrapper" (vs hardcoding families)."""
 
     cls = model_or_cls if inspect.isclass(model_or_cls) else type(model_or_cls)
     sanitize = getattr(cls, "sanitize", None)
@@ -561,14 +526,12 @@ def _get_mlx_lm_model_class(model_type: str):
 
 
 def _prefer_vlm_loader_for_text(config: dict, model_type: str) -> bool:
-    """Return whether a multimodal wrapper should stay on the VLM load path.
+    """Whether a multimodal wrapper should stay on the VLM load path.
 
-    We still want a plain tokenizer API for text-only training, but some repos
-    are fundamentally multimodal wrappers whose `mlx_lm` text path works only
-    by stripping modality towers in `sanitize()`. That is a strong signal that
-    the text loader is reconstructing a different object graph than the actual
-    checkpoint. When that happens, keeping the runtime on the VLM model path is
-    more robust than trying to maintain one sanitizer workaround per family.
+    Some repos are multimodal wrappers whose mlx_lm text path works only by
+    stripping modality towers in `sanitize()`, meaning it reconstructs a
+    different object graph than the checkpoint. Keeping the VLM path is more
+    robust than a per-family sanitizer workaround.
     """
 
     if not _is_vlm(config):
@@ -584,13 +547,9 @@ def _prefer_vlm_loader_for_text(config: dict, model_type: str) -> bool:
 def _ensure_safe_text_wrapper_sanitize(model_type: str) -> None:
     """Patch nested-weight sanitize assumptions for text-only multimodal loads.
 
-    Some `mlx_lm` multimodal wrappers sanitize text-only checkpoints by first
-    unflattening weights and then blindly indexing `weights["model"]`. That is
-    brittle across upstream packing changes: some checkpoints expose the text
-    wrapper under `"model"`, others expose the same multimodal towers at the
-    top level. We patch the sanitize method by behavior, not by one exact
-    architecture, so any future loader with the same nested-vs-top-level
-    assumption is handled the same way.
+    Some mlx_lm wrappers unflatten then blindly index `weights["model"]`, which
+    breaks when towers sit at the top level instead. Patch by behavior, not by
+    one architecture, so any loader with the same assumption is handled.
     """
 
     if not model_type or model_type in _SAFE_TEXT_SANITIZE_PATCHED:
@@ -636,17 +595,13 @@ def _ensure_safe_text_wrapper_sanitize(model_type: str) -> None:
 
 
 def _fp16_needs_bf16_modules(model):
-    """Return modules that should stay bf16 under fp16 training.
+    """Modules that should stay bf16 under fp16 training.
 
-    Some Pixtral/Mistral3-family VLMs emit vision hidden states above fp16's
-    finite range on real OCR-style images. The projector output remains small,
-    but the selected vision features can exceed 65,504 before projection, so
-    a plain `model.set_dtype(mx.float16)` overflows inside get_input_embeddings.
-
-    Text-only loads of multimodal wrapper models can also be numerically shaky
-    in fp16. We detect those by behavior: if the wrapper sanitize path strips
-    multimodal towers before handing off to a text backbone, we keep that
-    backbone in bf16 under an fp16 training request.
+    Some Pixtral/Mistral3 VLMs emit vision features above fp16's range (>65,504)
+    before projection, so `model.set_dtype(mx.float16)` overflows in
+    get_input_embeddings. Text-only loads of multimodal wrappers are also shaky
+    in fp16; detect them by the strip-tower sanitize path and keep the text
+    backbone bf16.
     """
     model_module = type(model).__module__
     vision_tower = getattr(model, "vision_tower", None)
@@ -682,8 +637,8 @@ def _fp16_needs_bf16_modules(model):
 def _resolve_full_finetune_dtype(target_dtype, float32_mixed_precision, mx):
     if target_dtype == mx.bfloat16:
         if type(float32_mixed_precision) is not bool:
-            # Match the Torch post-patch default: bf16 full finetuning stays
-            # bf16 unless float32_mixed_precision=True is explicitly requested.
+            # Match Torch: bf16 full finetuning stays bf16 unless
+            # float32_mixed_precision=True is explicit.
             float32_mixed_precision = False
         if float32_mixed_precision is False:
             return mx.bfloat16, False
@@ -1074,11 +1029,10 @@ def _quant_config_from_resolved_map(resolved_map):
 
 
 def _normalize_mlx_lora_module_paths(module_paths):
-    """Normalize stored module paths into a list of non-empty strings.
+    """Normalize stored module paths to a list of non-empty strings.
 
-    Accepts str, list/tuple/set, dict ({"language": [...], "vision": [...]}),
-    and pathlib.Path; iterating a bare string would walk characters and
-    never wrap a real LoRA layer.
+    Accepts str, list/tuple/set, dict, and pathlib.Path; a bare string is
+    wrapped (not iterated char-by-char).
     """
     if module_paths is None:
         return []
@@ -1107,11 +1061,10 @@ def _normalize_mlx_lora_module_paths(module_paths):
 
 
 def _infer_rank_from_saved_adapter(adapter_weights_file, module_path):
-    """Read the rank dimension off the saved LoRA tensor for `module_path`.
+    """Read the rank from the saved LoRA tensor for `module_path`.
 
-    Compatibility shim for legacy direct-save adapters that wrote
-    `unsloth_mlx_lora_module_paths` without persisting rank/scale/dropout.
-    Returns None when the file/path is absent or imports fail.
+    Compat shim for legacy adapters that saved module paths without
+    rank/scale/dropout. Returns None if the file/path is absent or imports fail.
     """
     if not adapter_weights_file or not os.path.exists(adapter_weights_file):
         return None
@@ -1124,11 +1077,10 @@ def _infer_rank_from_saved_adapter(adapter_weights_file, module_path):
         ".lora_A.weight", ".lora_A",
         ".lora_embedding_a.weight", ".lora_embedding_a",
     )
-    # Suffixes whose 2-D shape is (rank, in_dims): mlx-lm's layer-backed
-    # `lora_a.weight` and PEFT-style uppercase `lora_A` / `lora_A.weight`.
-    # Raw lowercase `lora_a` keeps the older (in_dims, rank) shape so falls
-    # through to the default shape[-1] branch. `.lora_embedding_a*` is NOT
-    # in this set: LoRAEmbedding saves A as (num_embeddings, rank).
+    # Suffixes whose 2-D shape is (rank, in_dims): mlx-lm's `lora_a.weight` and
+    # PEFT-style `lora_A` / `lora_A.weight`. Raw lowercase `lora_a` keeps the
+    # older (in_dims, rank) shape (default shape[-1] branch). `.lora_embedding_a*`
+    # is excluded: LoRAEmbedding saves A as (num_embeddings, rank).
     _rank_first_2d_suffixes = frozenset({
         ".lora_a.weight",
         ".lora_A",
@@ -1145,7 +1097,7 @@ def _infer_rank_from_saved_adapter(adapter_weights_file, module_path):
                 shape = tuple(tensor.shape)
                 if not shape:
                     return None
-                # MoE/switch: (experts, rank, in_dims) → rank is shape[-2].
+                # MoE/switch (experts, rank, in_dims): rank is shape[-2].
                 if len(shape) >= 3:
                     return int(shape[-2])
                 if suffix in _rank_first_2d_suffixes:
@@ -1157,13 +1109,12 @@ def _infer_rank_from_saved_adapter(adapter_weights_file, module_path):
 
 
 def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=None):
-    """Recreate LoRA/DoRA layers at saved module paths so vision/projector
-    and MoE/embedding LoRA survives reload (mlx-lm's load_adapters only
-    rebuilds the language tower's Linear layers).
+    """Recreate LoRA/DoRA at saved module paths so vision/projector and
+    MoE/embedding LoRA survive reload (mlx-lm's load_adapters rebuilds only the
+    language tower).
 
-    Returns the number of new wrappers attached. `adapter_weights_file` is
-    a last-resort rank source for legacy adapters that wrote
-    `unsloth_mlx_lora_module_paths` without rank/scale/dropout.
+    Returns the number of wrappers attached. `adapter_weights_file` is a
+    last-resort rank source for legacy adapters lacking rank/scale/dropout.
     """
     import mlx.nn as nn
     from mlx_lm.tuner.lora import LoRALinear
@@ -1195,9 +1146,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
         if t is not None
     )
 
-    # DoRA path: refuse silent downgrade to plain LoRA when the saved
-    # model had DoRA modules; the per-module loop raises a specific
-    # ImportError if it hits one that needs the missing class.
+    # DoRA path: refuse silent downgrade to plain LoRA; the per-module loop
+    # raises ImportError if it needs a missing DoRA class.
     fine_tune_type = str(adapter_cfg.get("fine_tune_type", "lora")).lower()
     use_dora = fine_tune_type == "dora"
     DoRALinear_cls = DoRAEmbedding_cls = None
@@ -1211,9 +1161,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
         except Exception:
             DoRAEmbedding_cls = None
 
-    # Defer rank validation until the first module actually needs wrapping;
-    # a legacy adapter with no rank but paths already wrapped by mlx-lm.
-    # load_adapters should not crash here.
+    # Defer rank validation until a module needs wrapping, so a legacy adapter
+    # with no rank (but already wrapped by load_adapters) doesn't crash here.
     _metadata = {"rank": None, "scale": None, "dropout": None}
 
     def _ensure_metadata(module_path=None):
@@ -1222,8 +1171,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
         lora_params = adapter_cfg.get("lora_parameters") or {}
         raw_rank = lora_params.get("rank", adapter_cfg.get("rank"))
         if raw_rank is None and module_path is not None:
-            # Legacy direct-save fallback: recover rank from the saved
-            # tensor shape; scale/dropout stay at their 1.0 / 0.0 defaults.
+            # Legacy fallback: recover rank from the saved tensor shape;
+            # scale/dropout stay at 1.0 / 0.0.
             raw_rank = _infer_rank_from_saved_adapter(
                 adapter_weights_file, module_path,
             )
@@ -1235,12 +1184,9 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
                 "wrappers with placeholder rank=8. Re-save the adapter "
                 "with rank/scale/dropout populated."
             )
-        # Wrap the int/float conversions in a namespaced ValueError so
-        # malformed metadata (e.g. `"rank": "not-an-int"` in a hand-
-        # authored or stale config) raises the same "Unsloth MLX:" prefix
-        # the outer adapter detection catch preserves. Without this the
-        # plain `invalid literal for int()` ValueError can be swallowed
-        # by the fallback into a silent standard-load.
+        # Re-raise conversion errors with the "Unsloth MLX:" prefix the outer
+        # catch preserves; otherwise a plain `int()` ValueError on malformed
+        # metadata gets swallowed into a silent standard-load.
         try:
             _metadata["rank"] = int(raw_rank)
             _metadata["scale"] = float(
@@ -1260,9 +1206,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
     by_name = dict(model.named_modules())
     linear_types = (nn.Linear, nn.QuantizedLinear)
     attached = 0
-    # Track per-path skip reasons for the final warning so the user knows
-    # which paths could not be re-wrapped (the saved-vs-live key diff is
-    # the actual gate that raises).
+    # Track per-path skip reasons for the final warning (the saved-vs-live key
+    # diff is the gate that actually raises).
     _skipped_paths = []
     for name in module_paths:
         module = by_name.get(name)
@@ -1275,8 +1220,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
         lora_cls = None
         if isinstance(module, linear_types):
             if use_dora:
-                # Fail loud: silent downgrade to plain LoRA would drop the
-                # saved q_proj.m magnitude tensor on strict=False.
+                # Fail loud: a plain-LoRA downgrade drops the saved DoRA `.m`
+                # tensor on strict=False.
                 if DoRALinear_cls is None:
                     raise ImportError(
                         "Unsloth MLX: adapter_config.json says "
@@ -1288,8 +1233,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
             else:
                 lora_cls = LoRALinear
         elif switch_types and isinstance(module, switch_types):
-            # No DoRA on switch layers in mlx-lm; fail loud rather than
-            # silently dropping saved switch LoRA tensors.
+            # mlx-lm has no DoRA on switch layers; fail loud, don't drop saved
+            # switch LoRA tensors.
             if LoRASwitchLinear is None:
                 raise ImportError(
                     "Unsloth MLX: adapter_config.json contains a saved "
@@ -1310,8 +1255,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
                     )
                 lora_cls = DoRAEmbedding_cls
             else:
-                # Fail loud for the embedding path too: silent lora_cls=None
-                # would drop saved embedding LoRA tensors on strict=False.
+                # Fail loud for embeddings too: lora_cls=None would drop saved
+                # embedding LoRA tensors on strict=False.
                 if LoRAEmbedding is None:
                     raise ImportError(
                         "Unsloth MLX: adapter_config.json contains a saved "
@@ -1331,9 +1276,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
             lora_cls, module,
             _metadata["rank"], _metadata["scale"], _metadata["dropout"],
         )
-        # Walk numeric path segments (e.g. `vision_tower.merger.layers.0`)
-        # via `parent[int(seg)]` first then getattr; same try-int /
-        # setattr pattern on the leaf so list-indexed wrappers install.
+        # Resolve numeric path segments (e.g. `...layers.0`) via parent[int(seg)]
+        # then getattr; same pattern on the leaf so list-indexed wrappers install.
         parts = name.split(".")
         parent = model
         parent_reachable = True
@@ -1405,13 +1349,10 @@ _ADAPTER_LORA_KEY_SUFFIXES = (
 def _warn_missing_adapter_keys(model, adapter_weights_file):
     """Diff saved adapter LoRA keys against live params and warn.
 
-    Compares both presence AND shape so a wrong-rank live wrapper at a
-    matching key (e.g. mlx-lm wrapped the language tower at default
-    rank=8 over saved rank-4) is reported as missing. Called on both the
-    success and fallback branches; never blocks the following
-    load_weights() (exceptions are swallowed into a skip warning).
-    Returns the sorted missing-key list so the fallback can raise instead
-    of returning a partial adapter; `[]` means clean OR skipped.
+    Compares presence AND shape so a wrong-rank live wrapper (e.g. default
+    rank=8 over saved rank-4) counts as missing. Never blocks the following
+    load_weights() (exceptions become a skip warning). Returns the sorted
+    missing-key list so the fallback can raise; `[]` means clean or skipped.
     """
     if not adapter_weights_file or not os.path.exists(adapter_weights_file):
         return []
@@ -1431,10 +1372,8 @@ def _warn_missing_adapter_keys(model, adapter_weights_file):
                 continue
             shape = getattr(v, "shape", None)
             _bound_shapes[k] = tuple(shape) if shape is not None else None
-        # Compare presence AND shape so a wrong-rank live wrapper (e.g.
-        # default rank=8 over saved rank-4) is reported missing; a pure
-        # key-set diff would call it "fully bound" and strict=False would
-        # drop the saved tensors.
+        # Presence AND shape: a pure key-set diff would call a wrong-rank
+        # wrapper "fully bound" and strict=False would drop the saved tensors.
         _missing = sorted(
             k for k, saved_shape in _saved_shapes.items()
             if k not in _bound_shapes or _bound_shapes[k] != saved_shape
@@ -1494,10 +1433,9 @@ _FROM_BASE_SIGNATURE_NEEDLES = (
     "got multiple values",
     "no argument named",
     "takes no keyword",
-    # Manual-rejection phrasings from custom shims. Intentionally narrow:
-    # _is_from_base_kwarg_typeerror only treats these as signature
-    # mismatches when the error ALSO names one of our kwargs, so
-    # "rank 4 not supported" cannot silently downgrade rank.
+    # Manual-rejection phrasings; only treated as signature mismatches when the
+    # error also names one of our kwargs, so "rank 4 not supported" can't
+    # downgrade rank.
     "not accepted",
     "not supported",
 )
@@ -1507,8 +1445,8 @@ def _is_from_base_kwarg_typeerror(exc, kwarg=None, kwargs=None):
     """True when `exc` is a `from_base()` signature mismatch (older mlx-lm
     rejecting r/scale/dropout), not an internal wrapper TypeError.
 
-    Falling back through fewer-arg signatures on an unrelated TypeError
-    would silently downgrade rank to r=8 and mis-bind a wrong-rank wrapper.
+    Falling back on an unrelated TypeError would downgrade rank to r=8 and
+    mis-bind a wrong-rank wrapper.
     """
     import re
 
@@ -1530,8 +1468,8 @@ def _is_from_base_kwarg_typeerror(exc, kwarg=None, kwargs=None):
     if not any(needle in msg for needle in _FROM_BASE_SIGNATURE_NEEDLES):
         return False
 
-    # Require the kwarg as a standalone word so short kwargs like "r" do
-    # not match "rank" / "wrapper" / "are" in unrelated semantic errors.
+    # Require the kwarg as a whole word so "r" doesn't match "rank"/"are" in
+    # unrelated errors.
     return any(
         re.search(rf"(?<![\w]){re.escape(k)}(?![\w])", msg)
         for k in kwargs_lower
@@ -1539,11 +1477,8 @@ def _is_from_base_kwarg_typeerror(exc, kwarg=None, kwargs=None):
 
 
 def _no_rank_fallback_or_fail(from_base, module, rank):
-    """Call `from_base(module)` only when rank is the upstream default (8).
-
-    Any other rank must NOT silently downgrade; strict=False would then
-    drop the saved different-rank tensors.
-    """
+    """Call `from_base(module)` only when rank is the upstream default (8); any
+    other rank must not downgrade or strict=False drops the saved tensors."""
     if int(rank) != 8:
         raise ValueError(
             f"Unsloth MLX: this mlx-lm wrapper's from_base() does not "
@@ -1557,8 +1492,8 @@ def _no_rank_fallback_or_fail(from_base, module, rank):
 def _lora_from_base_compat(lora_cls, module, rank, scale, dropout):
     """Call lora_cls.from_base with older-signature fallback.
 
-    Only retries on signature-mismatch TypeErrors; internal wrapper
-    TypeErrors propagate so we never silently downgrade rank to r=8.
+    Retries only on signature-mismatch TypeErrors; internal wrapper TypeErrors
+    propagate so rank is never downgraded to r=8.
     """
     try:
         return lora_cls.from_base(module, r=rank, scale=scale, dropout=dropout)
@@ -1575,13 +1510,12 @@ def _lora_from_base_compat(lora_cls, module, rank, scale, dropout):
 
 
 def _patch_mlx_lora_from_base_compat():
-    """Monkey-patch mlx_lm LoRA/DoRA `from_base()` to accept scale/dropout
-    kwargs on older mlx-lm wheels.
+    """Monkey-patch mlx_lm LoRA/DoRA `from_base()` to accept scale/dropout on
+    older wheels.
 
-    The canonical mlx-lm walk (linear_to_lora_layers / load_adapters) calls
-    `from_base(..., scale=..., dropout=...)` directly with no fallback, so
-    without this an older wheel produces an asymmetric partial-LoRA model.
-    Idempotent: each class gets `_unsloth_from_base_compat = True`.
+    The canonical walk calls `from_base(..., scale=..., dropout=...)` with no
+    fallback, so an older wheel would yield a partial-LoRA model. Idempotent
+    via `_unsloth_from_base_compat`.
     """
     patch_targets = (
         ("mlx_lm.tuner.lora", ("LoRALinear", "LoRASwitchLinear", "LoRAEmbedding")),
@@ -1598,8 +1532,8 @@ def _patch_mlx_lora_from_base_compat():
             if lora_cls is None or getattr(lora_cls, "_unsloth_from_base_compat", False):
                 continue
 
-            # Stubs without from_base: skip rather than patch the wrong
-            # attribute; the upstream walk will surface AttributeError.
+            # Stubs without from_base: skip; the upstream walk surfaces the
+            # AttributeError.
             original_from_base = getattr(lora_cls, "from_base", None)
             if original_from_base is None:
                 continue
@@ -1612,11 +1546,10 @@ def _patch_mlx_lora_from_base_compat():
                 scale=20.0,
                 _orig=original_from_base,
             ):
-                # Pass-through on new mlx-lm; fall back through older
-                # signatures the same way _lora_from_base_compat does.
-                # Positional order MUST match upstream
-                # `LoRALinear.from_base(linear, r=8, dropout=0.0, scale=20.0)`
-                # so positional callers don't get scale/dropout swapped.
+                # Pass-through on new mlx-lm; else fall back like
+                # _lora_from_base_compat. Positional order MUST match upstream
+                # `from_base(linear, r=8, dropout=0.0, scale=20.0)` so callers
+                # don't swap scale/dropout.
                 try:
                     return _orig(module, r=r, dropout=dropout, scale=scale)
                 except TypeError as exc:
@@ -1630,8 +1563,7 @@ def _patch_mlx_lora_from_base_compat():
                         wrapped = _no_rank_fallback_or_fail(_orig, module, r)
                     return _apply_lora_metadata_to_wrapper(wrapped, scale, dropout)
 
-            # Best-effort patch; simulation stubs with __slots__ raise on
-            # assignment, which is the right surface for those builds.
+            # Best-effort; simulation stubs with __slots__ raise on assignment.
             try:
                 lora_cls.from_base = classmethod(_compat_from_base)
                 lora_cls._unsloth_from_base_compat = True
@@ -2099,12 +2031,11 @@ def _anchor_conversation_media_to_first_user_turn(
     num_audios,
     kwargs,
 ):
-    """Rebuild text-only chat while keeping conversation-level media on turn 1.
+    """Rebuild text-only chat, keeping conversation-level media on turn 1.
 
-    mlx-vlm's prompt helper used to attach `num_images` / `num_audios` to the
-    last user turn for list prompts. That shifts the image token between turns
-    during multi-turn chat, which breaks prompt-cache reuse for models like
-    Qwen3.5 that pre-compute multimodal rope positions from the full prompt.
+    mlx-vlm attached `num_images`/`num_audios` to the last user turn, shifting
+    the image token between turns and breaking prompt-cache reuse for models
+    like Qwen3.5 that precompute multimodal rope positions from the full prompt.
     """
     target_idx = _first_media_user_message_index(messages)
     if target_idx < 0:
@@ -2215,9 +2146,8 @@ def _build_role_prompt_fallback(processor, messages, *, add_generation_prompt):
 
 
 _EMPTY_VLM_CHAT_TEMPLATE_FALLBACKS = {
-    # Upstream Qwen2-VL MLX template expects a flat content list instead of
-    # standard role-wrapped chat messages, so normal chat rendering can return
-    # an empty string. Fall back to a simple role-prefixed prompt instead.
+    # Qwen2-VL's MLX template expects a flat content list, so role-wrapped chat
+    # can render empty; fall back to a role-prefixed prompt.
     "qwen2_vl": _build_role_prompt_fallback,
 }
 
@@ -2243,15 +2173,12 @@ def _prepare_vlm_template_messages(
     num_audios,
     kwargs,
 ):
-    """Normalize prompt input and apply the smallest rewrite needed for VLM chat.
+    """Normalize prompt input and apply the smallest VLM-chat rewrite.
 
-    There are two cases where we bypass mlx-vlm's higher-level helper and render
-    messages ourselves:
-    1. The prompt already uses structured multimodal content and must survive
-       intact instead of being flattened back to plain text.
-    2. The caller passes conversation-level `num_images` / `num_audios`. In
-       that case we anchor those media tokens to the first user turn so prompt
-       cache reuse does not silently change rope positions between turns.
+    Bypass mlx-vlm's helper and render ourselves when (1) the prompt already
+    has structured multimodal content (must survive intact) or (2) the caller
+    passes conversation-level `num_images`/`num_audios` (anchor media to the
+    first user turn so cache reuse doesn't shift rope positions).
     """
     prompt_items = prompt if isinstance(prompt, list) else [prompt]
     normalized_messages = _normalize_prompt_messages(prompt_utils_module, prompt_items)
@@ -2424,9 +2351,8 @@ def _mlx_save_pretrained_gguf(self, save_directory, tokenizer=None,
 def _mlx_push_to_hub_merged(self, repo_id, tokenizer=None, save_directory=None, **kwargs):
     from .utils import push_to_hub_merged
     tokenizer = tokenizer or self._tokenizer
-    # If save_directory wasn't given, fall back to repo_id (relative dir
-    # named after the repo). Callers that already saved locally should
-    # pass save_directory= to avoid a redundant re-save.
+    # Default save_directory to repo_id; callers that already saved locally
+    # should pass save_directory= to avoid a re-save.
     save_directory = save_directory or repo_id
     push_to_hub_merged(self, tokenizer, save_directory, repo_id=repo_id, **kwargs)
 
@@ -2701,13 +2627,11 @@ class FastMLXModel:
                 bf16 is emulated and ~40-70%% slower in prefill — fp16 is
                 recommended on those chips.
             load_in_4bit: Accepted for API compat with CUDA unsloth.
-            full_finetuning: When True, force-disable runtime quantization
-                (``load_in_4bit`` etc.) so the full-precision weights are
-                trainable. By default MLX mirrors Unsloth Torch full
-                finetuning and upcasts trainable floating weights to float32;
-                pass ``float32_mixed_precision=False`` to keep native bf16
-                weights on bf16-capable Apple Silicon. ``get_peft_model``
-                becomes a no-op for models loaded this way.
+            full_finetuning: When True, disable runtime quantization so
+                full-precision weights are trainable. MLX mirrors Unsloth Torch
+                and upcasts trainable float weights to float32; pass
+                ``float32_mixed_precision=False`` to keep native bf16 on
+                bf16-capable chips. ``get_peft_model`` becomes a no-op.
             token: HuggingFace token for gated models.
             text_only: Loading mode:
                 None  — auto-detect from config (default)
@@ -2822,14 +2746,13 @@ class FastMLXModel:
             force_requantize=force_requantize,
         )
 
-        # Seed mlx random state so any randomness during model construction
-        # (e.g. layer init for runtime-quantized models) is reproducible.
+        # Seed mlx random state so construction-time randomness (e.g. runtime
+        # quant layer init) is reproducible.
         _seed_mlx_random_state(random_state)
 
-        # Split download from config-read so a missing config.json
-        # does not clear local_path. LoRA-adapter directories carry
-        # adapter_config.json but no config.json; the adapter branch
-        # below needs local_path either way.
+        # Separate download from config-read so a missing config.json doesn't
+        # clear local_path: LoRA-adapter dirs have adapter_config.json but no
+        # config.json, and the adapter branch needs local_path.
         local_path = None
         try:
             with _temporary_hf_token_env(token):
@@ -2847,13 +2770,9 @@ class FastMLXModel:
                 except (json.JSONDecodeError, KeyError):
                     config_data = {}
 
-        # Reject full_finetuning against a pre-quantized repo. The weights on
-        # disk are int4/int8 packed; full FT would need them in a trainable
-        # float dtype, and our CCE backward returns mx.zeros for the quantized
-        # weight gradient (since dequant→grad→requant is not implemented).
-        # Without this check the user would silently train only the
-        # non-quantized params (LayerNorms, biases) while the bulk of the
-        # model's quantized linears never updated.
+        # Reject full_finetuning on a pre-quantized repo: int4/int8 weights
+        # aren't trainable (our CCE backward zeros the quantized weight grad),
+        # so full FT would silently update only LayerNorms/biases.
         if full_finetuning and _get_existing_mlx_quantization(config_data):
             raise ValueError(
                 f"Unsloth: full_finetuning=True was requested against "
@@ -2962,10 +2881,9 @@ class FastMLXModel:
                                     "Use the saved base quantization policy or retrain "
                                     "the adapter for the requested base quantization."
                                 )
-                    # Always reload the base via FastMLXModel.from_pretrained
-                    # (works for both text and VLM); the previous mlx_lm.load
-                    # fallback for non-quant-metadata adapters silently broke
-                    # VLM adapters because mlx-lm's load is text-only.
+                    # Reload the base via FastMLXModel.from_pretrained (text +
+                    # VLM); the old mlx_lm.load fallback broke VLM adapters
+                    # (mlx-lm load is text-only).
                     model, tokenizer = FastMLXModel.from_pretrained(
                         base_model_id,
                         max_seq_length=max_seq_length,
@@ -2991,29 +2909,26 @@ class FastMLXModel:
                         ),
                     )
                     _validate_mlx_adapter_base(model, adapter_cfg)
-                    # why: load_adapters only rebuilds language-tower LoRA;
-                    # vision/projector LoRA must be re-attached at the saved
-                    # paths first so load_weights binds the trained tensors.
+                    # why: load_adapters rebuilds only language-tower LoRA;
+                    # vision/projector LoRA must be re-attached so load_weights
+                    # binds the trained tensors.
                     _saved_lora_paths = _normalize_mlx_lora_module_paths(
                         adapter_cfg.get("unsloth_mlx_lora_module_paths"),
                     )
-                    # Call load_adapters FIRST (canonical walk rebuilds the
-                    # language tower); _apply_lora_at_paths runs AFTER and
-                    # skips already-wrapped paths, leaving only auxiliary
-                    # (vision / projector / MoE / embedding) to attach. The
-                    # old order produced nested LoRALinear(LoRALinear).
+                    # load_adapters FIRST (rebuilds the language tower);
+                    # _apply_lora_at_paths runs after and skips wrapped paths,
+                    # attaching only auxiliary (vision/projector/MoE/embedding).
+                    # The old order nested LoRALinear(LoRALinear).
                     from mlx_lm.tuner.utils import load_adapters
-                    # Compatibility patch so older mlx-lm's load_adapters
-                    # accepts scale=/dropout= without forcing a manual-wrap fallback.
+                    # Let older mlx-lm load_adapters accept scale=/dropout=.
                     _patch_mlx_lora_from_base_compat()
                     adapter_weights_file = os.path.join(local_path, "adapters.safetensors")
                     _load_adapters_ok = False
                     _load_adapters_exc = None
-                    # Staging-only R29 DoRA pre-validate: catch missing
-                    # mlx_lm.tuner.dora BEFORE load_adapters silently rebuilds
-                    # plain LoRA and drops saved DoRA `.m` tensors via
-                    # strict=False. Distinct from _apply_lora_at_paths's
-                    # post-check, which fires per-module after wrapping.
+                    # Pre-validate DoRA: catch missing mlx_lm.tuner.dora before
+                    # load_adapters rebuilds plain LoRA and drops saved DoRA
+                    # `.m` via strict=False (distinct from the per-module
+                    # post-check in _apply_lora_at_paths).
                     if adapter_cfg.get("fine_tune_type") == "dora":
                         try:
                             import mlx_lm.tuner.dora  # noqa: F401
@@ -3029,25 +2944,23 @@ class FastMLXModel:
                         model = load_adapters(model, local_path)
                         _load_adapters_ok = True
                     except Exception as _exc:
-                        # Fall through to the manual-wrap + strict=False
-                        # fallback below (needed for adapter sets lacking
-                        # mlx-lm metadata, e.g. missing num_layers).
+                        # Fall through to the manual-wrap + strict=False fallback
+                        # (for adapters lacking mlx-lm metadata, e.g. num_layers).
                         _load_adapters_exc = _exc
 
                     _aux_attached = 0
                     if _saved_lora_paths:
-                        # Attach auxiliary paths (vision / projector / MoE)
-                        # that linear_to_lora_layers does not walk; the
-                        # skip-if-wrapped guard makes language-tower paths
-                        # no-ops here.
+                        # Attach auxiliary paths (vision/projector/MoE) that
+                        # linear_to_lora_layers skips; language-tower paths are
+                        # no-ops via the skip-if-wrapped guard.
                         try:
                             _aux_attached = _apply_lora_at_paths(
                                 model, _saved_lora_paths, adapter_cfg,
                                 adapter_weights_file=adapter_weights_file,
                             ) or 0
                         except (ValueError, ImportError):
-                            # Caller-actionable contracts (missing rank
-                            # metadata / DoRA class); never downgrade.
+                            # Caller-actionable (missing rank / DoRA class); never
+                            # downgrade.
                             raise
                         except Exception as _exc:
                             warnings.warn(
@@ -3060,18 +2973,16 @@ class FastMLXModel:
                     # Bind aux tensors via a follow-up load_weights and run
                     # the shared key diff so silent drops surface here too.
                     if _load_adapters_ok and os.path.exists(adapter_weights_file):
-                        # Always diff (even when _aux_attached == 0): a
-                        # caller-declared aux path the live tree no longer
-                        # satisfies would otherwise sit in adapters.safetensors
-                        # with no live module to bind into.
+                        # Always diff (even _aux_attached == 0): a declared aux
+                        # path the live tree no longer satisfies has no module
+                        # to bind into.
                         _missing_after_success = _warn_missing_adapter_keys(
                             model, adapter_weights_file,
                         )
                         if _aux_attached > 0:
                             model.load_weights(adapter_weights_file, strict=False)
-                        # Refuse to return a partial adapter on ANY shape
-                        # mismatch (e.g. stale rank=8 over rank-4) so the
-                        # success branch stays in lockstep with the fallback.
+                        # Refuse a partial adapter on any shape mismatch (e.g.
+                        # stale rank=8 over rank-4), matching the fallback.
                         if _missing_after_success:
                             _preview = ", ".join(_missing_after_success[:5])
                             if len(_missing_after_success) > 5:
@@ -3088,9 +2999,8 @@ class FastMLXModel:
                             )
 
                     if not _load_adapters_ok:
-                        # No wrappers → strict=False would silently drop
-                        # every saved tensor and return a base model;
-                        # re-raise the original load_adapters error.
+                        # No wrappers: strict=False would drop every saved
+                        # tensor and return a base model; re-raise instead.
                         if _aux_attached == 0:
                             if _load_adapters_exc is not None:
                                 raise _load_adapters_exc
@@ -3100,14 +3010,13 @@ class FastMLXModel:
                                 "saved tensors against."
                             )
                         if os.path.exists(adapter_weights_file):
-                            # Diff saved-vs-live before strict=False; the
-                            # shared helper covers DoRA `.m` + lora_{a,b}.
+                            # Diff saved-vs-live before strict=False (covers DoRA
+                            # `.m` + lora_{a,b}).
                             _missing_saved_keys = _warn_missing_adapter_keys(
                                 model, adapter_weights_file,
                             )
-                            # Refuse an aux-only partial adapter (the language
-                            # tower would silently mis-train); re-raise the
-                            # original load_adapters error chained.
+                            # Refuse an aux-only partial adapter (language tower
+                            # would mis-train); chain the original error.
                             if _missing_saved_keys:
                                 _preview = ", ".join(_missing_saved_keys[:5])
                                 if len(_missing_saved_keys) > 5:
@@ -3128,8 +3037,7 @@ class FastMLXModel:
                                 raise _partial_err
                             model.load_weights(adapter_weights_file, strict=False)
                         else:
-                            # No safetensors fallback; surface the
-                            # original load_adapters failure.
+                            # No safetensors; surface the original failure.
                             if _load_adapters_exc is not None:
                                 raise _load_adapters_exc
                             raise RuntimeError(
@@ -3174,9 +3082,9 @@ class FastMLXModel:
                     _patch_mlx_saving(model, tokenizer)
                     return model, tokenizer
             except Exception as e:
-                # Preserve Unsloth-tagged ValueError/ImportError/RuntimeError
-                # so adapter-config-level failures aren't swallowed into
-                # a silent base-model fallback.
+                # Preserve Unsloth-tagged Value/Import/RuntimeError so
+                # adapter-config failures aren't swallowed into a base-model
+                # fallback.
                 _msg = str(e)
                 _is_unsloth = (
                     "Unsloth:" in _msg or "Unsloth MLX:" in _msg
@@ -3185,12 +3093,11 @@ class FastMLXModel:
                     e, (ValueError, ImportError, RuntimeError)
                 ):
                     raise
-                # Also preserve the namespaced Unsloth MLX RuntimeError
-                # signal from _apply_lora_at_paths.
+                # Preserve the Unsloth MLX RuntimeError from _apply_lora_at_paths.
                 if isinstance(e, RuntimeError) and "Unsloth MLX:" in str(e):
                     raise
-                # If adapter_config declared a LoRA/DoRA artifact, refuse
-                # the silent base-model fallback for any other exception.
+                # If a LoRA/DoRA artifact was declared, refuse the base-model
+                # fallback for any other exception.
                 _is_lora_adapter = False
                 if isinstance(adapter_cfg, dict):
                     _peft_type = str(adapter_cfg.get("peft_type", "")).upper()
@@ -3209,7 +3116,7 @@ class FastMLXModel:
 
         model_type = config_data.get("model_type", "")
 
-        # Step 2: Route based on text_only
+        # Route based on text_only.
         is_vlm = False
         force_vlm_text_path = bool(
             text_only is True and _prefer_vlm_loader_for_text(config_data, model_type)
@@ -3283,8 +3190,7 @@ class FastMLXModel:
                 mx.eval(model.parameters())
             else:
                 print(f"Unsloth: Loading {model_name} via mlx-vlm (VLM)...")
-                # Lazy-load when we need to convert dtype so weights are
-                # only materialized once in the target dtype.
+                # Lazy-load when converting dtype so weights materialize once.
                 vlm_kwargs = dict(extra_kwargs)
                 vlm_kwargs["revision"] = revision
                 if target_dtype is not None:
@@ -3466,12 +3372,9 @@ class FastMLXModel:
     ):
         """Apply LoRA via mlx-lm on Apple Silicon.
 
-        For VLMs, applies LoRA to the language model and optionally to the
-        vision tower (train_vision=True) and projector (train_projector=True).
-
-        When the model was loaded with ``full_finetuning=True``, this is a
-        no-op: the full-precision parameters stay trainable and the model
-        is returned as-is.
+        For VLMs, applies LoRA to the language model and optionally the vision
+        tower (train_vision=True) and projector (train_projector=True). No-op
+        when the model was loaded with ``full_finetuning=True``.
         """
         loftq_config = kwargs.pop("loftq_config", None)
         if loftq_config is not None:
@@ -3511,18 +3414,14 @@ class FastMLXModel:
             train_vision = bool(finetune_vision_layers)
 
 
-        # PEFT/CUDA semantics: target_modules="all-linear" means literally
-        # every nn.Linear in the model — fused QKV (qkv_proj), MoE routers
-        # and experts, vision tower linears, multimodal projector, untied
-        # lm_head, etc. Walk the model tree and collect those names instead
-        # of silently collapsing to the canonical 7-name list (which would
-        # leave fused-attention archs and MoEs with no LoRA on most of
-        # their linears).
+        # "all-linear" means every nn.Linear (fused QKV, MoE routers/experts,
+        # vision linears, projector, untied lm_head). Walk the tree for those
+        # names rather than collapsing to the canonical 7, which would leave
+        # fused-attention archs and MoEs mostly un-LoRA'd.
         if target_modules == ["all-linear"] or target_modules == "all-linear":
             target_modules = _collect_all_linear_target_names(model)
             if not target_modules:
-                # No Linear modules discovered (shouldn't happen on a real
-                # model). Fall back to the canonical default.
+                # No Linear modules found; fall back to the canonical default.
                 target_modules = [
                     "q_proj", "k_proj", "v_proj", "o_proj",
                     "gate_proj", "up_proj", "down_proj",
@@ -3534,10 +3433,8 @@ class FastMLXModel:
                 "gate_proj", "up_proj", "down_proj",
             ]
 
-        # Filter target_modules by finetune_attention_modules / finetune_mlp_modules.
-        # Applies whether target_modules came from the user as an explicit list,
-        # was built from defaults, or was normalized from "all-linear" — so
-        # toggling these flags always has effect.
+        # Filter by finetune_attention_modules / finetune_mlp_modules,
+        # whatever the source of target_modules, so these flags always apply.
         if isinstance(target_modules, list) and len(target_modules) > 0:
             _ATTN = {
                 "q_proj", "k_proj", "v_proj", "o_proj",
@@ -3567,12 +3464,12 @@ class FastMLXModel:
         is_vlm = getattr(model, "_is_vlm_model", False)
 
         if is_vlm:
-            # VLM path: freeze everything, then apply LoRA selectively
+            # Freeze everything, then apply LoRA selectively.
             _fix_missing_no_grad(model)
             _fix_gemma4_kv_sharing(model)
             model.freeze()
 
-            # Apply LoRA to the language model (filtered by target_modules)
+            # LoRA the language model (filtered by target_modules).
             language_lora_count = 0
             if finetune_language_layers and (
                 target_modules is None or (isinstance(target_modules, list) and len(target_modules) > 0)
@@ -3585,14 +3482,13 @@ class FastMLXModel:
                     num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
                 language_lora_keys = _resolve_lora_keys(lm, target_modules)
                 if language_lora_keys is None or len(language_lora_keys) > 0:
-                    # Compatibility patch (older mlx-lm rejects
-                    # scale=/dropout= on from_base); applied before
-                    # _seed_mlx_random_state since monkey-patching
-                    # Python classes does not advance mx.random.
+                    # Compat patch (older mlx-lm rejects scale=/dropout= on
+                    # from_base); before the seed since monkey-patching doesn't
+                    # advance mx.random.
                     _patch_mlx_lora_from_base_compat()
-                    # Match mlx_lm/tuner/lora.py (def train) -- seed
-                    # mx.random immediately before LoRA init; lazy MLX
-                    # state advances otherwise leak into lora_a sampling.
+                    # Seed mx.random immediately before LoRA init (like
+                    # mlx_lm/tuner/lora.py train); otherwise lazy state
+                    # advances leak into lora_a sampling.
                     _seed_mlx_random_state(random_state)
                     linear_to_lora_layers(
                         lm,
@@ -3602,7 +3498,7 @@ class FastMLXModel:
                     )
                     language_lora_count = len(language_lora_keys) if language_lora_keys is not None else num_layers
 
-            # Optionally apply LoRA to vision tower
+            # Optionally LoRA the vision tower.
             vision_lora_count = 0
             if train_vision:
                 vision_lora_count = _lora_walk_module(
@@ -3612,10 +3508,9 @@ class FastMLXModel:
                     attr_names=("vision_tower", "vision_model", "vision_encoder"),
                 )
 
-            # Optionally train the multimodal projector / connector. Prefer
-            # projector LoRA over unfreezing raw weights because many MLX VLM
-            # checkpoints expose projector layers as QuantizedLinear, and MLX
-            # does not backprop into quantized weights directly.
+            # Optionally LoRA the projector/connector. LoRA beats unfreezing
+            # raw weights since many projectors are QuantizedLinear and MLX
+            # can't backprop into quantized weights.
             projector_lora_count = 0
             if train_projector:
                 projector_lora_count = _lora_walk_module(
@@ -3654,12 +3549,11 @@ class FastMLXModel:
                     )
                 _raise_no_lora_targets(target_modules)
 
-            # Unfreeze all LoRA params across the entire tree
+            # Unfreeze all LoRA params across the tree.
             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
         else:
-            # Text-only path — filter by target_modules
-            # Fix missing _no_grad on modules that use __new__ without __init__
-            # (e.g. Gemma4 AudioRelativePositionEmbedding loaded via VLM path)
+            # Text-only path. _fix_missing_no_grad handles modules using
+            # __new__ without __init__ (e.g. Gemma4 AudioRelativePosition...).
             _fix_missing_no_grad(model)
 
             if not finetune_language_layers:
@@ -3677,13 +3571,13 @@ class FastMLXModel:
                 language_lora_keys = _resolve_lora_keys(model, target_modules)
                 if language_lora_keys is not None and len(language_lora_keys) == 0:
                     _raise_no_lora_targets(target_modules)
-                # Compatibility patch (older mlx-lm rejects scale=/dropout=
-                # on from_base); applied before _seed_mlx_random_state
-                # since monkey-patching does not advance mx.random.
+                # Compat patch (older mlx-lm rejects scale=/dropout= on
+                # from_base); before the seed since monkey-patching doesn't
+                # advance mx.random.
                 _patch_mlx_lora_from_base_compat()
-                # Match mlx_lm/tuner/lora.py (def train) -- seed
-                # mx.random immediately before LoRA init; lazy MLX
-                # state advances otherwise leak into lora_a sampling.
+                # Seed mx.random immediately before LoRA init (like
+                # mlx_lm/tuner/lora.py train); otherwise lazy state advances
+                # leak into lora_a sampling.
                 _seed_mlx_random_state(random_state)
                 linear_to_lora_layers(
                     model,
@@ -3697,8 +3591,7 @@ class FastMLXModel:
 
         _apply_mlx_lora_initialization(model, init_lora_weights)
 
-        # Apply gradient checkpointing if requested
-        # "mlx" (default) or True → apply; False or "none" → skip
+        # Gradient checkpointing: "mlx"/True -> apply; False/"none" -> skip.
         if isinstance(use_gradient_checkpointing, str):
             _apply_gc = use_gradient_checkpointing.lower() not in ("false", "none", "")
         else:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -122,11 +122,9 @@ class MLXTrainingConfig:
     optim: str = "adamw"  # "adafactor", "adamw", "adam", "sgd", "muon", "lion"
     weight_decay: float = 0.001
     max_grad_norm: float = 0.0  # disabled by default on MLX to avoid clip-memory overhead
-    # Elementwise clip ([-max_grad_value, max_grad_value], per-leaf).
-    # None (default) keeps the cheap MLX default of 1.0 unless the user
-    # passes max_grad_norm > 0, in which case global-norm clipping wins.
-    # 0.0 disables. A positive float opts in explicitly and overrides
-    # max_grad_norm with a warning.
+    # Elementwise clip ([-max_grad_value, max_grad_value], per-leaf). None
+    # defaults to 1.0 unless max_grad_norm > 0 (global-norm wins); 0.0
+    # disables; a positive float opts in and overrides max_grad_norm.
     max_grad_value: float | None = None
     seed: int = 3407
     lora_plus_ratio: float = 0.0  # 0 = disabled, 16.0 = recommended
@@ -215,11 +213,9 @@ class MLXTrainer:
             )
             self.args.packing = False
 
-        # Safety: freeze non-LoRA parameters if LoRA layers are detected.
-        # mlx-lm calls model.freeze() BEFORE linear_to_lora_layers(), but users
-        # might forget. Without this, LayerNorm weights remain trainable and
-        # adaptive optimizers (Adafactor, AdamW) produce NaN on the first step
-        # because their 1D second-moment initialization is numerically unstable.
+        # Freeze non-LoRA params when LoRA is detected. Otherwise LayerNorm
+        # weights stay trainable and adaptive optimizers NaN on step 1 (their
+        # 1D second-moment init is numerically unstable).
         self._ensure_lora_frozen(model)
 
         # Training state
@@ -265,30 +261,25 @@ class MLXTrainer:
 
     @staticmethod
     def _ensure_lora_frozen(model):
-        """Freeze accidentally trainable norm parameters when LoRA is active.
+        """Freeze accidentally trainable norm params when LoRA is active.
 
-        Without this, LayerNorm/RMSNorm weights remain trainable, and
-        adaptive optimizers produce NaN on 1D tensors at initialization
-        (the second-moment estimate starts at 0, causing division by ~eps).
-
-        Only freezes norm parameters — does NOT touch projector, vision, or
-        other intentionally trainable non-LoRA parameters.
+        LayerNorm/RMSNorm weights left trainable make adaptive optimizers NaN
+        on 1D tensors at init (second-moment starts at 0 -> divide by ~eps).
+        Only norms are frozen; projector/vision/other intentional non-LoRA
+        params are left alone.
         """
         trainable = dict(tree_flatten(model.trainable_parameters()))
         if not trainable:
-            return  # safe: nothing trainable, and stub models may lack model.parameters().
+            return  # nothing trainable; stub models may lack model.parameters().
         adapter_tensors = collect_mlx_lora_adapter_tensors(model)
         has_lora = any(name in trainable for name in adapter_tensors)
         if not has_lora:
             return  # Not a LoRA model — don't touch
 
-        # Only freeze params that look like accidentally unfrozen norms.
-        # Projector weights, vision tower weights, etc. are intentionally
-        # trainable when train_projector/train_vision is used.
+        # Only freeze accidentally-unfrozen norms; leave components the user
+        # explicitly unfroze (train_projector, train_vision) alone.
         _NORM_FRAGMENTS = (".norm.", "norm.weight", "norm.bias",
                            ".ln_", "ln_f.weight", "ln_f.bias")
-        # Don't freeze norms inside components the user explicitly unfroze
-        # (projector via train_projector, vision tower via train_vision).
         _INTENTIONAL_COMPONENTS = (
             "multi_modal_projector", "mm_projector", "connector", "aligner",
             "vision_tower", "vision_model", "vision_encoder",
@@ -366,12 +357,7 @@ class MLXTrainer:
         optimizer.learning_rate = self._schedule_value(schedule, step)
 
     def _build_optimizer(self, total_steps):
-        """Create MLX optimizer with LR schedule from config.
-
-        For optimizers that support weight_decay, wraps with
-        optim.decay_weight to exclude bias and norm parameters
-        (matching HuggingFace Trainer behavior).
-        """
+        """Create MLX optimizer with LR schedule from config."""
         schedule = self._build_schedule(total_steps)
         initial_lr = self._schedule_value(schedule, 0)
         self._lr_schedule = schedule if callable(schedule) else None
@@ -400,8 +386,8 @@ class MLXTrainer:
                 scale_parameter=False,
             )
         elif opt_name == "adamw":
-            # Match HF/PyTorch AdamW semantics. MLX defaults bias_correction
-            # to False, which makes early warmup updates much larger.
+            # Match HF/PyTorch AdamW: MLX defaults bias_correction to False,
+            # which makes early warmup updates much larger.
             optimizer = optim.AdamW(
                 learning_rate=initial_lr,
                 weight_decay=wd,
@@ -423,12 +409,11 @@ class MLXTrainer:
 
     @staticmethod
     def _adafactor_unsupported_parameters(model):
-        """Return trainable params that MLX Adafactor cannot update safely.
+        """Return trainable params MLX Adafactor cannot update safely.
 
-        MLX Adafactor currently treats every tensor with ndim >= 2 as factored
-        and reconstructs the update with a matrix multiply. That is correct for
-        2-D matrices, but rank-3/rank-4 tensors from vision patch embeddings,
-        convolutions, and some projectors fail or broadcast incorrectly.
+        It treats ndim >= 2 as factored and reconstructs via matmul (correct
+        for 2-D), but rank-3/4 tensors from vision patch embeddings, convs, and
+        some projectors fail or broadcast incorrectly.
         """
         unsupported = []
         try:
@@ -443,11 +428,7 @@ class MLXTrainer:
         return unsupported
 
     def _evaluate(self, eval_batches, loss_fn, is_vlm=False):
-        """Run evaluation loop.
-
-        Returns:
-            (avg_loss, perplexity) tuple.
-        """
+        """Run evaluation loop; returns (avg_loss, perplexity)."""
         self.model.eval()
         all_losses = mx.array(0.0)
         ntokens = mx.array(0)
@@ -478,15 +459,10 @@ class MLXTrainer:
             return None
 
     def _configure_memory_limits(self):
-        """Apply conservative Metal memory limits so failed runs exit cleanly.
+        """Apply conservative Metal memory caps so failed runs exit cleanly.
 
-        MLX exposes hard Metal allocator caps. Using them is much safer than
-        letting a large multimodal compile/eval run pressure the whole machine
-        into paging or a kernel panic. The default is intentionally conservative:
-        cap MLX to ~85% of Apple's recommended working-set size unless the user
-        overrides or disables it.
-
-        Disable shortcuts:
+        Defaults to ~85% of Apple's recommended working-set size to avoid
+        paging/kernel-panic on large multimodal runs. Disable shortcuts:
           - args.disable_memory_limits=True  ─► skip every cap (memory, cache, wired)
           - args.memory_limit_gb <= 0        ─► skip memory_limit AND wired_limit
           - args.wired_limit_gb  <= 0        ─► skip wired_limit only
@@ -507,13 +483,11 @@ class MLXTrainer:
             return {}
 
         configured = {}
-        # why: prior values must be restored after training; otherwise the
-        # process-global cap leaks into later operations.
+        # Prior values are restored after training; the cap is process-global.
         self._prior_metal_limits = {}
 
         # memory_limit_gb: None → 85% of recommended; <= 0 → disable BOTH this
-        # and the wired cap (the wired default is min(recommended, memory_limit)
-        # so disabling memory should also drop wired unless explicitly set).
+        # and the wired cap (wired default is min(recommended, memory_limit)).
         memory_limit_gb = getattr(args, "memory_limit_gb", None)
         memory_disabled = memory_limit_gb is not None and memory_limit_gb <= 0
         if memory_limit_gb is None:
@@ -533,8 +507,8 @@ class MLXTrainer:
 
         wired_limit_gb = getattr(args, "wired_limit_gb", None)
         if wired_limit_gb is None:
-            # Inherit "disabled" from memory_limit when the user didn't set one
-            # explicitly, so memory_limit_gb=-1 disables wired too.
+            # Inherit "disabled" from memory_limit so memory_limit_gb=-1
+            # disables wired too.
             if memory_disabled:
                 wired_limit_gb = None
             else:
@@ -568,15 +542,8 @@ class MLXTrainer:
         self._prior_metal_limits = {}
 
     def train(self):
-        """Run MLX-native training loop.
-
-        Follows mlx-lm's compiled step pattern with proper gradient accumulation:
-        one compiled function handles forward+backward, accumulates gradients across
-        micro-batches, and conditionally applies optimizer update.
-
-        Returns:
-            dict with training metrics (train_loss, train_runtime, etc.)
-        """
+        """Run MLX-native training loop following mlx-lm's compiled-step pattern
+        with gradient accumulation. Returns a dict of training metrics."""
         args = self.args
         model = self.model
         args.patch_mode = normalize_mlx_patch_mode(getattr(args, "patch_mode", "patched"))
@@ -655,7 +622,7 @@ class MLXTrainer:
         model = self.model
         is_vlm = self._is_vlm
 
-        # Pick loss function — returns (loss, ntoks) tuples
+        # Pick loss function (returns (loss, ntoks))
         use_cce = args.use_cce
 
         if is_vlm:
@@ -730,17 +697,11 @@ class MLXTrainer:
         _needs_grad_scaling = use_lora_plus or use_embedding_lr
         _warned_skip_optimizer_state_grad_norm = False
 
-        # Build step functions following mlx-lm's pattern.
-        # Resolution rule:
-        #   * max_grad_value=None (default) -> cheap MLX elementwise clip
-        #     at 1.0, unless the user also passed max_grad_norm > 0 -- in
-        #     that case the user opted into global-norm clipping (HF/TRL
-        #     parity) and elementwise is disabled to avoid double-clip.
-        #   * max_grad_value explicit (float or 0.0) -> honor exactly;
-        #     if both modes are positive, elementwise wins (warn).
-        # max_grad_norm uses MLX's clip_grad_norm helper which materially
-        # increases peak memory on bf16 VLM runs, hence the elementwise
-        # default.
+        # Clip resolution: max_grad_value=None -> elementwise clip at 1.0
+        # unless max_grad_norm > 0 (then global-norm wins, HF/TRL parity);
+        # explicit max_grad_value is honored, and if both positive elementwise
+        # wins (warn). Elementwise is the default because MLX's clip_grad_norm
+        # materially increases peak memory on bf16 VLM runs.
         max_grad_norm = float(args.max_grad_norm or 0.0)
         _raw_mgv = getattr(args, "max_grad_value", None)  # TODO: expose MLX grad-clip in Studio UI for power users
         _user_set_mgv = _raw_mgv is not None
@@ -760,10 +721,8 @@ class MLXTrainer:
             max_grad_value = 1.0
         _clip_grad_value = max_grad_value > 0
         state = [model.state, optimizer.state, mx.random.state]
-        # The direct grad_accum==1 fast path delegates clipping to
-        # mlx.optimizers.clip_grad_norm(). That helper is exact, but on current
-        # MLX it can materially increase peak memory on real bf16 VLM runs.
-        # Keep the shortcut only for unclipped updates.
+        # grad_accum==1 fast path: only for unclipped updates, since
+        # clip_grad_norm can spike peak memory on bf16 VLM runs.
         _direct_single_step_update = (
             grad_accum == 1 and
             not _needs_grad_scaling and
@@ -771,20 +730,17 @@ class MLXTrainer:
         )
 
         def _grad_leaf_scale(name, safe_toks_f, clip_scale=None, dtype=None):
-            """Return the exact scalar applied to one grad leaf before update.
+            """Return the scalar applied to one grad leaf before update.
 
-            Pass ``dtype`` (the leaf grad's dtype) to keep the final
-            ``value * scale`` in the leaf's native dtype — otherwise an fp32
-            scale promotes a bf16/fp16 grad tree to fp32, which then forces
-            optimizer.update to promote params/m/v to fp32 too.
+            Pass ``dtype`` (the leaf grad's dtype) so an fp32 scale doesn't
+            promote a bf16/fp16 grad tree to fp32 (which would force
+            optimizer.update to promote params/m/v too).
             """
             scale = mx.array(1.0, dtype=mx.float32) / safe_toks_f
-            # Suffix-anchor so a routing layer named lora_b_router.weight
-            # does not pick up the LoRA+ multiplier.
+            # Suffix-anchor so lora_b_router.weight doesn't pick up the LoRA+ mult.
             if use_lora_plus and (name == "lora_b" or name.endswith(".lora_b")):
                 scale = scale * lora_plus_ratio
-            # Segment-anchor so names like decoder.not_lm_head_router.weight
-            # do not pick up the embedding LR.
+            # Segment-anchor so not_lm_head_router.weight doesn't pick up embed LR.
             if use_embedding_lr:
                 _segments = name.split(".")
                 _is_embed_or_lm_head = (
@@ -840,18 +796,16 @@ class MLXTrainer:
             return grad_norm
 
         def _can_report_optimizer_state_norm():
-            # For Adam-family optimizers, recover ||g|| from the second moment
-            # after the update: v_t = beta2 * v_{t-1} + (1 - beta2) * g_t^2.
-            # This avoids adding a second consumer to the lazy backward graph.
+            # Adam-family: recover ||g|| from the second moment after update
+            # (v_t = beta2*v_{t-1} + (1-beta2)*g_t^2), avoiding a second
+            # consumer on the lazy backward graph.
             return getattr(optimizer, "betas", None)
 
         def _apply_update(grad, toks_f):
-            """Common gradient post-processing and optimizer update.
-
-            Scale accumulated gradients by supervised-token count, then apply
-            the selected clipping mode. Global norm clipping uses MLX's helper
-            and reports that norm. Non-global modes report after update from
-            Adam's optimizer state so the backward graph stays single-consumer.
+            """Scale accumulated grads by supervised-token count, apply the
+            selected clipping mode, and update. Global-norm clipping reports
+            its norm; non-global modes report after update from Adam state to
+            keep the backward graph single-consumer.
             """
             safe_toks_f = mx.maximum(
                 toks_f, mx.array(1.0, dtype=mx.float32)
@@ -879,23 +833,17 @@ class MLXTrainer:
             return grad_norm
 
         def _apply_update_direct(grad):
-            """Fast exact path for the common ``grad_accum == 1`` case.
+            """Fast exact path for ``grad_accum == 1`` with no per-leaf scaling.
 
-            When gradients are updated immediately and there is no additional
-            per-leaf scaling (LoRA+ / embedding LR), the older
-            ``grad * ntoks`` then ``/ ntoks`` round-trip only serves to
-            promote the whole tree into ``float32`` before clipping. That
-            significantly increases peak memory on large bf16/fp16 runs while
-            leaving the mathematical update unchanged.
-
-            In this case the raw gradients already represent the final
-            per-token average, so we can clip/update the original tree directly.
+            The raw grads already are the per-token average, so skip the
+            ``*ntoks`` then ``/ntoks`` round-trip (which only promotes the tree
+            to float32 and spikes peak memory) and clip/update directly.
             """
             grad_norm = None
             if max_grad_norm > 0:
                 grad, grad_norm = optim.clip_grad_norm(grad, max_norm=max_grad_norm)
             if _clip_grad_value:
-                # Elementwise clip per leaf — free memory (no cross-leaf reduction).
+                # Elementwise clip per leaf — no cross-leaf reduction.
                 grad = tree_map(
                     lambda g: mx.clip(g, -max_grad_value, max_grad_value),
                     grad,
@@ -903,9 +851,7 @@ class MLXTrainer:
             optimizer.update(model, grad)
             return grad_norm
 
-        # Unified step function for both VLM and text training.
-        # VLM: batch_data is a dict → loss_and_grad_fn(model, batch_dict)
-        # Text: batch_data is a tuple → loss_and_grad_fn(model, batch, lengths, labels)
+        # Unified step for VLM (dict batch) and text (tuple batch) training.
         def step_fn(batch_data, prev_state, do_update):
             if isinstance(batch_data, dict):
                 (lvalue, toks), grad = loss_and_grad_fn(model, batch_data)
@@ -919,15 +865,12 @@ class MLXTrainer:
             toks_f = toks.astype(mx.float32)
             grad_norm = mx.array(0.0, dtype=mx.float32)
 
-            # Scale-and-accumulate in a single tree_map per micro-batch, casting
-            # the scalar to each leaf's dtype so bf16/fp16 grad trees stay in
-            # their native dtype (avoids fp32 promotion that 3xs grad memory
-            # and forces optimizer.update to promote params/m/v to fp32).
+            # Scale-and-accumulate per micro-batch, casting the scalar to each
+            # leaf's dtype so bf16/fp16 grad trees avoid fp32 promotion.
             if prev_state is not None:
                 prev_grad, prev_toks = prev_state
-                # Accumulated gradients are optimizer state, not something to
-                # differentiate through on the next compiled micro-batch. This
-                # keeps custom VJP losses such as CCE from retaining/corrupting
+                # stop_gradient: accumulated grads are state, not something to
+                # differentiate through; keeps CCE-style VJPs from corrupting
                 # the carried bf16 accumulation graph.
                 prev_grad = tree_map(mx.stop_gradient, prev_grad)
                 prev_toks = mx.stop_gradient(prev_toks)
@@ -1409,7 +1352,7 @@ class MLXTrainer:
         )
         output_dir = output_dir or self.args.output_dir
 
-        # Detect LoRA from module structure so reloaded / frozen adapters
+        # Detect LoRA from module structure so reloaded/frozen adapters
         # still take the adapter-save path.
         adapter_tensors = collect_mlx_lora_adapter_tensors(self.model)
         has_lora = bool(adapter_tensors)
@@ -1418,18 +1361,17 @@ class MLXTrainer:
             hf_repo = getattr(self.model, "_hf_repo", None) or ""
 
 
-            # Infer rank/scale/dropout from the first reloadable module.
-            # Leave None on failure so we never persist placeholders that
-            # mis-scale the adapter; _enrich_mlx_adapter_config gets a
-            # second shot at filling these in.
+            # Infer rank/scale/dropout from the first reloadable module; leave
+            # None on failure rather than persisting mis-scaling placeholders
+            # (_enrich_mlx_adapter_config gets a second shot).
             _lora_rank = _lora_scale = _lora_dropout = None
             for _, m in iter_mlx_lora_modules(self.model):
                 inferred_rank = _infer_mlx_lora_rank(m)
                 if inferred_rank is None:
                     continue
                 _lora_rank = inferred_rank
-                # _coerce_mlx_lora_scale handles LoRASwitchLinear's per-expert
-                # mx.array where raw float()/.item() raise.
+                # _coerce handles LoRASwitchLinear's per-expert mx.array where
+                # raw float()/.item() raise.
                 _lora_scale = _coerce_mlx_lora_scale(getattr(m, "scale", 1.0))
                 _lora_dropout = _get_mlx_dropout_probability(
                     getattr(m, "dropout", None)
@@ -1438,9 +1380,8 @@ class MLXTrainer:
 
             from .utils import _get_transformer_layers
             layers = _get_transformer_layers(self.model)
-            # mlx-lm.load_adapters() attr-accesses config.num_layers, so
-            # the key MUST be present. -1 is the legacy "all layers"
-            # sentinel for the no-detect case.
+            # mlx-lm.load_adapters() attr-accesses config.num_layers, so the
+            # key MUST be present; -1 is the legacy "all layers" sentinel.
             try:
                 _num_layers = len(layers) if layers is not None else -1
             except TypeError:
@@ -1466,8 +1407,7 @@ class MLXTrainer:
                     self.model, "_unsloth_quantized_source", None,
                 ),
             }
-            # Always emit num_layers so mlx-lm.load_adapters() can attr-access
-            # it; -1 is the legacy "all layers" sentinel fallback.
+            # Always emit num_layers for mlx-lm.load_adapters() attr-access.
             adapter_config["num_layers"] = _num_layers
             if _lora_rank is not None:
                 adapter_config["lora_parameters"] = {
@@ -1480,11 +1420,10 @@ class MLXTrainer:
                 adapter_config["scale"] = _lora_scale
                 adapter_config["dropout"] = _lora_dropout
 
-            # Preserve intentionally trained non-LoRA tensors OUTSIDE any
-            # LoRA module; drop wrapped base weights INSIDE one (else
-            # q_proj.weight under a LoRA-wrapped q_proj re-leaks the
-            # original Studio reload bug). Uses the shared filter so this
-            # matches save_trainable_adapters / save_pretrained_merged.
+            # Keep intentionally-trained non-LoRA tensors OUTSIDE any LoRA
+            # module; drop wrapped base weights INSIDE one (else q_proj.weight
+            # under a LoRA-wrapped q_proj re-leaks the Studio reload bug). Uses
+            # the shared filter to match save_trainable_adapters / _merged.
             trainable = dict(tree_flatten(self.model.trainable_parameters()))
             adapter_keys = set(adapter_tensors)
             lora_module_prefixes = tuple(
@@ -1510,8 +1449,8 @@ class MLXTrainer:
                 save_lora_adapters(
                     self.model, output_dir, adapter_config=adapter_config,
                 )
-            # why: VLM processors include the inner tokenizer; double-save
-            # rewrites the same files. Skip when the processor will cover it.
+            # VLM processors include the inner tokenizer; skip the separate
+            # tokenizer save when the processor will cover it.
             _processor = self.processor or getattr(self.model, "_processor", None)
             _processor_saves_tokenizer = (
                 _processor is not None and hasattr(_processor, "save_pretrained")
@@ -1543,14 +1482,10 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
                             model_name=None, model_type=None):
     """Create padded batches with label masks for train_on_responses_only.
 
-    Tokenizes each dataset item, applies the masking closure to get labels,
-    sorts by length, and produces right-padded 3-tuple batches.
-
-    Returns:
-        List of (batch, lengths, labels) tuples where:
-        - batch: mx.array (BS, padded_len) — input_ids padded with 0
-        - lengths: mx.array (BS, 2) — [1, actual_len - 1] per sequence
-        - labels: mx.array (BS, padded_len) — labels padded with -100
+    Tokenizes, masks, sorts by length, and right-pads into 3-tuples:
+    - batch: mx.array (BS, padded_len) — input_ids padded with 0
+    - lengths: mx.array (BS, 2) — [1, actual_len - 1] per sequence
+    - labels: mx.array (BS, padded_len) — labels padded with -100
     """
     eos_id = tokenizer.eos_token_id
     tokenizer = normalize_mlx_chat_template(
@@ -1581,8 +1516,7 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
             if text:
                 all_texts.append(text)
 
-    # 2. Tokenize + mask in parallel (HF fast tokenizers are thread-safe;
-    #    slow tokenizers degrade gracefully via the GIL)
+    # 2. Tokenize + mask in parallel (HF fast tokenizers are thread-safe).
     def _process_text(text):
         encoded = tokenizer.encode(text)
         if eos_id is not None and (not encoded or encoded[-1] != eos_id):
@@ -1621,8 +1555,8 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
         if not batch_items:
             continue
         max_len = max(len(ids) for ids, _ in batch_items)
-        # Match mlx-lm iterate_batches: +1 gives the autoregressive
-        # shift headroom so post-shift length is a clean _PAD_MULTIPLE.
+        # +1 (like mlx-lm iterate_batches) gives autoregressive shift headroom
+        # so post-shift length is a clean _PAD_MULTIPLE.
         padded_len = 1 + ((max_len + _PAD_MULTIPLE - 1) // _PAD_MULTIPLE) * _PAD_MULTIPLE
         padded_len = min(padded_len, max_seq_length)
 
@@ -1659,10 +1593,8 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
 
 
 def _check_all_masked(batches, max_check=100):
-    """Safety check: raise if all labels in the first N batches are -100.
-
-    Mirrors fix_zero_training_loss from the HF path.
-    """
+    """Raise if all labels in the first N batches are -100 (mirrors
+    fix_zero_training_loss from the HF path)."""
     seen_bad = 0
     seen_good = 0
     checked = 0
@@ -1702,11 +1634,7 @@ def _check_all_masked(batches, max_check=100):
 
 
 def _check_vlm_all_masked(batches, max_check=100):
-    """Safety check for VLM batches: raise if all labels are -100.
-
-    Same purpose as _check_all_masked but for VLM batch dicts
-    (which have a "labels" key instead of a 3-tuple structure).
-    """
+    """_check_all_masked for VLM batch dicts (a "labels" key, not a 3-tuple)."""
     seen_bad = 0
     seen_good = 0
     checked = 0
@@ -1759,24 +1687,21 @@ def train_on_responses_only(
 ):
     """Mask instruction tokens from loss — train only on assistant responses.
 
-    Call after MLXTrainer(...), before trainer.train(). Works for both
-    text and VLM models. Mirrors the HF/unsloth API.
+    Call after MLXTrainer(...), before trainer.train(). Works for text and
+    VLM models; mirrors the HF/unsloth API.
 
     Args:
-        trainer: MLXTrainer instance (can be None when return_function=True
-            and tokenizer is provided).
-        instruction_part: String marking start of user/instruction turns
-            (e.g. "<|start_header_id|>user<|end_header_id|>\\n\\n").
-        response_part: String marking start of assistant/response turns
-            (e.g. "<|start_header_id|>assistant<|end_header_id|>\\n\\n").
-        force_match: Match newlines as well (forwarded to HF implementation).
-        tokenizer: Optional tokenizer override. If None, uses trainer.tokenizer.
-        return_function: If True, return the masking closure without touching
-            the trainer.
-        num_proc: Accepted for API compatibility with the HF path, unused on MLX.
+        trainer: MLXTrainer (may be None when return_function=True and a
+            tokenizer is given).
+        instruction_part: String marking the start of user/instruction turns.
+        response_part: String marking the start of assistant/response turns.
+        force_match: Match newlines too (forwarded to the HF implementation).
+        tokenizer: Optional override; defaults to trainer.tokenizer.
+        return_function: If True, return the masking closure only.
+        num_proc: Accepted for HF API compat, unused on MLX.
 
     Returns:
-        The trainer (for chaining), or the masking closure if return_function=True.
+        The trainer (for chaining), or the closure if return_function=True.
     """
     from ..dataset_utils import (
         train_on_responses_only as _hf_train_on_responses_only,
@@ -1792,9 +1717,8 @@ def train_on_responses_only(
             "kwarg or via trainer.tokenizer."
         )
 
-    # Unwrap to get a callable HF tokenizer.
-    # mlx-lm: TokenizerWrapper._tokenizer -> HF tokenizer
-    # VLM processors: processor.tokenizer -> HF tokenizer
+    # Unwrap to a callable HF tokenizer (mlx-lm TokenizerWrapper._tokenizer,
+    # or VLM processor.tokenizer).
     if hasattr(_tokenizer, "_tokenizer"):
         _tokenizer = _tokenizer._tokenizer
     elif hasattr(_tokenizer, "tokenizer"):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -46,8 +46,7 @@ def _safe_token_denominator(ntoks):
 def _get_transformer_layers(model):
     """Find transformer layers, unwrapping VLM wrappers if needed.
 
-    VLMs: model.language_model.model.layers
-    Text: model.layers or model.model.layers
+    VLMs: model.language_model.model.layers; text: model.(model.)layers.
     """
     m = getattr(model, 'language_model', model)
     m = getattr(m, 'model', m)
@@ -82,7 +81,7 @@ def _get_vision_encoder_layers(model):
 
 def _patch_layer_class_for_gc(layer_cls):
     if getattr(layer_cls, '_orig_call', None) is not None:
-        return  # already applied
+        return  # already patched
     layer_cls._orig_call = layer_cls.__call__
     fn = layer_cls.__call__
 
@@ -105,11 +104,10 @@ def _unpatch_layer_class_gc(layer_cls):
 def apply_gradient_checkpointing(model):
     """Apply gradient checkpointing to language and vision tower layers.
 
-    Patches each layer class's ``__call__`` with ``mx.checkpoint`` so MLX
-    recomputes the layer's forward during backward instead of storing
-    activations. Trades ~30% extra compute for substantial memory savings —
-    critical for VLMs where vision tower backward at native image
-    resolution can otherwise materialize tens of GB of activation tape.
+    Patches each layer class's ``__call__`` with ``mx.checkpoint`` to recompute
+    the forward during backward instead of storing activations. Trades ~30%
+    extra compute for large memory savings — critical for VLM vision towers at
+    native resolution, which can otherwise materialize tens of GB.
     """
     lm_layers = _get_transformer_layers(model)
     if lm_layers is not None and len(lm_layers) > 0:
@@ -133,10 +131,8 @@ def remove_gradient_checkpointing(model):
 def _get_text_model(model):
     """Get the inner text model, unwrapping multimodal wrappers if present.
 
-    Standard models (Llama, Qwen): model itself is the text model.
-    Multimodal wrappers (Gemma 4): model.language_model is the text model.
-
-    Returns the text model that has .model (backbone) and optionally .lm_head.
+    Standard models (Llama, Qwen) are themselves the text model; multimodal
+    wrappers (Gemma 4) expose it at model.language_model.
     """
     if hasattr(model, "language_model"):
         return model.language_model
@@ -218,12 +214,9 @@ def _forward_text_hidden_states(model, inputs, inputs_embeds=None, **kwargs):
 def _get_lm_head_layer(model):
     """Get the raw LM head layer (QuantizedLinear or Linear/Embedding).
 
-    Checks for a separate lm_head first (untied models like Qwen), then
-    falls back to embed_tokens (tied models like Gemma/Llama).
-    Handles multimodal wrappers (e.g. Gemma 4) via _get_text_model.
-
-    Returns the layer object (not its weight), so callers can access
-    .weight, .scales, .biases, .group_size, .bits for quantized layers.
+    Prefers a separate lm_head (untied models like Qwen), else falls back to
+    embed_tokens (tied models like Gemma/Llama). Returns the layer object (not
+    its weight) so callers can read .weight/.scales/.biases/.group_size/.bits.
     """
     tm = _get_text_model(model)
     if hasattr(tm, "lm_head") and tm.lm_head is not None:
@@ -249,11 +242,10 @@ def _get_logit_softcap(model):
 
 
 def _is_lm_head_trainable(model):
-    """Check if the LM head weight is trainable (not frozen by LoRA).
+    """Whether the LM head weight is trainable (not frozen by LoRA).
 
-    For LoRA training, the LM head weight is frozen — computing its gradient
-    in CCE is a wasted V x chunk_size x H matmul per chunk. Returns False
-    when the weight should be wrapped with mx.stop_gradient.
+    When frozen, its CCE gradient is a wasted V x chunk_size x H matmul per
+    chunk, so callers wrap the weight with mx.stop_gradient (returns False).
     """
     trainable = dict(mlx.utils.tree_flatten(model.trainable_parameters()))
     # Module-anchored so unrelated trainables containing the substring
@@ -272,8 +264,8 @@ def _is_lm_head_trainable(model):
             key, lora_module_prefixes, has_root_lora_module,
         ):
             continue
-        # Segment-match (not substring) so names like
-        # `decoder.not_lm_head_router.weight` are not classified as lm_head.
+        # Segment-match (not substring) so e.g.
+        # `decoder.not_lm_head_router.weight` is not classified as lm_head.
         segments = key.split(".")
         is_lm_head_param = "lm_head" in segments
         is_embed_tokens_weight = (
@@ -283,24 +275,18 @@ def _is_lm_head_trainable(model):
         )
         if is_lm_head_param or is_embed_tokens_weight:
             return True
-    return len(trainable) == 0  # no LoRA = full fine-tuning = trainable
+    return len(trainable) == 0  # no LoRA = full fine-tuning
 
 
 def make_cce_loss_fn(model):
-    """Create a CCE loss function using the bundled chunked cross-entropy engine.
+    """Create a chunked cross-entropy (CCE) loss function.
 
-    CCE computes cross-entropy directly from hidden states and the LM head weight,
-    avoiding full logit materialization. This saves significant memory for large
-    vocabularies.
+    CCE computes loss directly from hidden states and the LM head weight,
+    avoiding full logit materialization (big memory savings for large vocabs).
 
-    Args:
-        model: MLX model.
-
-    Returns:
-        A function (model, batch, lengths, labels=None) -> (loss, ntoks).
-        When labels is provided, uses labels[:,1:] for targets with
-        (targets != -100) as the loss mask.
-        The function has a ``_unsloth_cce_backend`` attribute for logging.
+    Returns a function (model, batch, lengths, labels=None) -> (loss, ntoks).
+    With labels, uses labels[:,1:] as targets and (targets != -100) as mask.
+    The returned function has a ``_unsloth_cce_backend`` attribute for logging.
     """
     softcap = _get_logit_softcap(model)
     if softcap > 0:
@@ -337,12 +323,11 @@ def make_cce_loss_fn(model):
         return backbone.embed_tokens
 
     if use_quantized:
-        # Backstop: the quantized CCE backward returns mx.zeros for the
-        # weight gradient (dequant→grad→requant is not implemented). That's
-        # fine when the LM head is frozen (LoRA on a quantized base — the
-        # gradient flows through grad_hidden into the LoRA adapters), but
-        # full fine-tuning would silently skip the LM head update. The
-        # loader rejects this combination earlier; this is a safety net.
+        # Backstop: quantized CCE backward zeros the weight gradient
+        # (dequant->grad->requant unimplemented). Fine when the LM head is
+        # frozen (LoRA on a quantized base flows grad through grad_hidden), but
+        # full fine-tuning would silently skip the LM head update. The loader
+        # rejects this earlier; this is a safety net.
         if getattr(model, "_unsloth_full_finetuning", False):
             raise ValueError(
                 "Unsloth: full_finetuning=True with a quantized LM head is "
@@ -434,16 +419,12 @@ def make_cce_loss_fn(model):
 
 
 def make_baseline_loss_fn():
-    """Create a standard cross-entropy loss function.
+    """Create a standard cross-entropy loss function (full logits via LM head).
 
-    Uses the full logit computation through the LM head, then applies
-    nn.losses.cross_entropy. Used when use_cce=False.
-
-    Returns:
-        A function (model, batch, lengths, labels=None) -> (loss, ntoks).
-        When labels is provided, uses labels[:,1:] for targets with
-        (targets != -100) as the loss mask. The labels=None branch is
-        byte-identical to ``mlx_lm.tuner.trainer.default_loss``.
+    Used when use_cce=False. Returns a function
+    (model, batch, lengths, labels=None) -> (loss, ntoks). With labels, uses
+    labels[:,1:] and (targets != -100) as mask. The labels=None branch is
+    byte-identical to ``mlx_lm.tuner.trainer.default_loss``.
     """
     def loss_fn(model, batch, lengths, labels=None):
         if labels is None:
@@ -484,7 +465,7 @@ def make_baseline_loss_fn():
 # ---------------------------------------------------------------------------
 
 # Image/vision special tokens that should never contribute to loss.
-# Mirrors unsloth's IMAGE_TOKENS list from vision_utils.py.
+# Mirrors unsloth's IMAGE_TOKENS list in vision_utils.py.
 _IMAGE_TOKEN_STRINGS = (
     "<|image|>",           # Llama 3.2 Vision, Phi 3.5, Gemma4
     "<|vision_start|>",    # Qwen
@@ -515,7 +496,7 @@ def _get_image_token_ids(model):
         try:
             tok_ids = tokenizer.convert_tokens_to_ids([tok_str])
             if tok_ids and tok_ids[0] is not None:
-                # Some tokenizers return the unk_token_id for unknown tokens
+                # Some tokenizers return unk_token_id for unknown tokens
                 unk_id = getattr(tokenizer, "unk_token_id", None)
                 if tok_ids[0] != unk_id:
                     ids.append(tok_ids[0])
@@ -573,17 +554,12 @@ def _normalize_cce_label_dtype(labels):
 def _mask_image_tokens(targets, image_token_ids):
     """Set image token positions in targets to -100 (ignore_index).
 
-    Prevents the model from training to predict image placeholder tokens,
-    which are fixed special tokens that provide no useful gradient signal.
-
-    Args:
-        targets: mx.array of token IDs.
-        image_token_ids: plain Python list of int token IDs, or None.
+    Image placeholder tokens are fixed specials with no useful gradient signal.
+    image_token_ids is a plain Python list of ints, or None.
     """
     if not image_token_ids:
         return targets
     targets = _normalize_cce_label_dtype(targets)
-    # Build a mask: True where target is any image token
     is_image = targets == image_token_ids[0]
     for tok_id in image_token_ids[1:]:
         is_image = is_image | (targets == tok_id)
@@ -592,13 +568,10 @@ def _mask_image_tokens(targets, image_token_ids):
 
 
 def _mask_prompt_tokens(targets, assistant_token_id):
-    """Mask all tokens before the first assistant response in each sequence.
+    """Mask tokens before the first assistant response (train_on_completions_only).
 
-    Scans each row of targets for assistant_token_id. All positions before
-    the first occurrence are set to -100 (ignore_index). If the token is
-    not found, the entire sequence is left unmasked (assumes all completion).
-
-    This implements train_on_completions_only for VLM training.
+    Per row, positions before the first assistant_token_id become -100. If the
+    token is absent, the row is left unmasked (assumed all completion).
     """
     if assistant_token_id <= 0:
         return targets
@@ -694,8 +667,7 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0):
         logits = logits.astype(mx.float32)
 
         if labels is not None:
-            # train_on_responses_only: labels encode instruction/padding masking.
-            # Still mask image placeholder tokens.
+            # labels encode instruction/padding masking; still mask image tokens
             targets = _normalize_cce_label_dtype(labels[:, 1:])
             targets = _mask_image_tokens(targets, _image_token_ids)
             logits, targets = _align_logits_with_labels(logits, targets)
@@ -707,7 +679,7 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0):
             target_source = batch_dict.get(_RAW_INPUT_IDS_FOR_LABELS, input_ids)
             targets = _normalize_cce_label_dtype(target_source[:, 1:])
 
-            # Handle sequence length mismatch from vision token injection
+            # Vision token injection can change seq length
             logits, targets = _align_logits_with_labels(logits, targets)
 
             # Build mask from attention_mask (shifted to match targets)
@@ -717,10 +689,9 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0):
             else:
                 length_mask = mx.ones_like(targets, dtype=mx.float32)
 
-            # Mask image placeholder tokens and prompt tokens
             targets = _mask_image_tokens(targets, _image_token_ids)
             targets = _mask_prompt_tokens(targets, _assistant_token_id)
-            # Update length_mask to exclude masked positions
+            # Exclude masked positions from length_mask
             mask = mx.where(
                 targets == -100,
                 mx.array(0, dtype=length_mask.dtype),
@@ -744,7 +715,7 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0):
 def _unpack_embed_result(embed_result, model):
     """Unpack get_input_embeddings result into embeds + backbone kwargs.
 
-    Handles both plain mx.array returns and InputEmbeddingsFeatures dataclass
+    Handles plain mx.array returns and the InputEmbeddingsFeatures dataclass
     (gemma4 per_layer_inputs, qwen3-vl position_ids/deepstack, etc.).
     """
     backbone_kwargs = {}
@@ -777,11 +748,10 @@ def _unpack_embed_result(embed_result, model):
     else:
         merged_embeds = embed_result
 
-    # Qwen-VL family: get_input_embeddings stashes position_ids on the
-    # language model wrapper; the inner backbone needs them explicitly.
-    # When no position_ids were stashed (e.g. text-only samples or simple
-    # images without grid_thw), generate sequential ones so the backbone
-    # doesn't crash accessing cache.offset with cache=None.
+    # Qwen-VL: get_input_embeddings stashes position_ids on the language model
+    # wrapper; the inner backbone needs them explicitly. When none were stashed
+    # (text-only or simple images without grid_thw), generate sequential ones
+    # so the backbone doesn't crash on cache.offset with cache=None.
     lm = getattr(model, "language_model", None)
     if lm is not None:
         _MISSING = object()
@@ -877,9 +847,7 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
     )
 
     if labels is not None:
-        # train_on_responses_only: labels already encode instruction and
-        # padding masking. Still need to mask image placeholder tokens
-        # since they provide no useful gradient signal.
+        # labels already encode instruction/padding masking; still mask image tokens
         targets = labels[:, 1:]
         masked_targets = _mask_image_tokens(targets, image_token_ids)
         ntoks = (masked_targets != -100).sum()
@@ -898,11 +866,8 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
         ignore = mx.array(-100, dtype=targets.dtype)
         masked_targets = mx.where(length_mask, targets, ignore)
 
-        # Mask image placeholder tokens, they're fixed special tokens that
-        # provide no useful gradient signal.
         masked_targets = _mask_image_tokens(masked_targets, image_token_ids)
-
-        # Completion-only masking: mask prompt tokens before first assistant response
+        # Completion-only: mask prompt before first assistant response
         masked_targets = _mask_prompt_tokens(masked_targets, assistant_token_id)
 
         ntoks = (masked_targets != -100).sum()
@@ -1601,22 +1566,13 @@ def _prepare_vlm_batch_for_compile(batch_dict, config):
 def make_vlm_cce_loss_fn(model, assistant_token_id=0):
     """Create a CCE loss function for VLMs.
 
-    Uses model.get_input_embeddings() to get merged vision+text embeddings,
-    then runs through the language model backbone to get hidden states before
-    the LM head, and applies CCE.
+    Uses model.get_input_embeddings() for merged vision+text embeddings, runs
+    the backbone to pre-lm_head hidden states, and applies CCE. Falls back to
+    baseline loss when get_input_embeddings is unavailable.
 
-    Falls back to baseline loss if get_input_embeddings is not available.
-
-    Args:
-        model: VLM model.
-        assistant_token_id: Token ID marking start of assistant responses.
-            When > 0, all tokens before the first occurrence are masked
-            from the loss (completion-only training).
-
-    Returns:
-        A function (model, batch_dict) -> (loss, ntoks).
+    assistant_token_id > 0 enables completion-only training (mask tokens before
+    the first occurrence). Returns a function (model, batch_dict) -> (loss, ntoks).
     """
-    # Check if the model supports get_input_embeddings
     if not hasattr(model, "get_input_embeddings"):
         import warnings
         warnings.warn(
@@ -1639,8 +1595,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0):
     softcap = _get_logit_softcap(model)
     lm_layer = _get_lm_head_layer(model)
     use_quantized = _is_quantized_layer(lm_layer)
-    # Evaluate once — trainability doesn't change during training.
-    # Must be called after LoRA setup.
+    # Evaluate once (after LoRA setup); trainability doesn't change mid-training.
     _skip_weight_grad = not _is_lm_head_trainable(model)
 
     _image_token_ids = _get_image_token_ids(model)
@@ -1651,9 +1606,9 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0):
         print(f"Unsloth: Completion-only training (assistant_token_id={_assistant_token_id}).")
 
     if use_quantized:
-        # Backstop: same as the text CCE path — full FT against a quantized
-        # LM head silently skips the LM head update. Reject loudly here in
-        # case the loader-level check is bypassed.
+        # Backstop (as in the text CCE path): full FT against a quantized LM
+        # head silently skips the LM head update. Reject loudly here in case
+        # the loader-level check is bypassed.
         if getattr(model, "_unsloth_full_finetuning", False):
             raise ValueError(
                 "Unsloth: full_finetuning=True with a quantized VLM LM head "
@@ -1718,16 +1673,15 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0):
 
 
 def _get_vlm_image_size(config, processor):
-    """Get target image size for uniform resizing, matching GPU collator.
+    """Get target image size for uniform resizing, matching the GPU collator.
 
-    Tries vision_config.image_size (dict OR dataclass), then
+    Tries vision_config.image_size (dict or dataclass), then
     processor.image_processor.size, falls back to 512.
 
-    Note: Qwen2.5-VL's processor.image_processor.size has
-    {'shortest_edge': 3136, 'longest_edge': 12845056} — those are
-    *area pixel counts* (min_pixels / max_pixels), not dimensions.
-    Reading them as "height" produces a 3136x3136 upsample → 50k patches
-    per image → OOM. Skip area-style ``size`` dicts.
+    Note: Qwen2.5-VL's image_processor.size holds *area pixel counts*
+    (shortest_edge/longest_edge = min/max pixels), not dimensions. Reading
+    them as height would 3136x3136-upsample -> 50k patches -> OOM, so skip
+    area-style ``size`` dicts.
     """
     vc = config.get("vision_config") if isinstance(config, dict) else getattr(config, "vision_config", None)
     if vc is not None:
@@ -2420,11 +2374,9 @@ def _collate_vlm_prompt_completion_batch(items, processor, max_seq_length, image
 def _collate_vlm_batch(items, processor, max_seq_length, image_size, formatting_func=None):
     """Collate a batch of VLM samples using the processor directly.
 
-    Mirrors Unsloth's GPU UnslothVisionDataCollator:
-    1. Extract images from messages or top-level keys
-    2. Resize to uniform size
-    3. apply_chat_template for text
-    4. Single processor() call handles tokenization + image processing + padding
+    Mirrors Unsloth's GPU UnslothVisionDataCollator: extract images, resize
+    to uniform size, apply_chat_template, then one processor() call for
+    tokenization + image processing + padding.
     """
     normalize_vlm_processor_chat_template(processor, strict=False)
     formatted_items = []
@@ -2754,9 +2706,9 @@ def _extract_mlx_lora_parameters(model):
     for _, m in iter_mlx_lora_modules(model):
         a_tensor = m.lora_a
         a_shape = tuple(getattr(a_tensor, "shape", ()))
-        # Switch LoRA layouts vary across mlx-lm versions; lora_b's last
-        # axis is always `rank`, so prefer it when num_experts is declared.
-        # Plain LoRALinear uses (in_dims, rank) where rank is shape[-1].
+        # Switch LoRA layouts vary across mlx-lm versions; lora_b's last axis is
+        # always `rank`, so prefer it when num_experts is declared. Plain
+        # LoRALinear uses (in_dims, rank) where rank is shape[-1].
         b_tensor = getattr(m, "lora_b", None)
         b_shape = tuple(getattr(b_tensor, "shape", ())) if b_tensor is not None else ()
         if hasattr(m, "num_experts") and len(b_shape) >= 3:
@@ -2768,7 +2720,7 @@ def _extract_mlx_lora_parameters(model):
         scale = getattr(m, "scale", 1.0)
 
         drop = getattr(m, "dropout", None)
-        # mlx.nn.Dropout stores keep-prob in _p_1; fall back to .p for shims.
+        # mlx.nn.Dropout stores keep-prob in _p_1; fall back to .p for shims
         if drop is None:
             dropout = 0.0
         else:
@@ -3192,10 +3144,10 @@ def _enrich_mlx_adapter_config(model, adapter_config):
         requires_runtime = True
     adapter_config["requires_unsloth_mlx_runtime_quantization"] = bool(requires_runtime)
 
-    # Only stamp LoRA-flavoured fields when the live model carries LoRA
-    # modules (or the caller already declared a lora/dora artifact);
-    # otherwise mlx-lm.load_adapters() would inject LoRA wrappers before
-    # binding the saved full-precision weights and break reload.
+    # Only stamp LoRA fields when the live model has LoRA modules (or the
+    # caller declared a lora/dora artifact); otherwise mlx-lm.load_adapters()
+    # would inject LoRA wrappers before binding full-precision weights and
+    # break reload.
     has_lora_modules = any(True for _ in iter_mlx_lora_modules(model))
     declared_lora_artifact = (
         has_lora_modules
@@ -3463,7 +3415,7 @@ def save_merged_model(model, tokenizer, path, dequantize=False):
     path = Path(path)
     path.mkdir(parents=True, exist_ok=True)
 
-    # Fuse LoRA weights into base model using mlx-lm's pattern
+    # Fuse LoRA weights into base model (mlx-lm pattern)
     model.eval()
     fused_linears = [
         (n, m.fuse(dequantize=dequantize))
@@ -3506,7 +3458,7 @@ def save_merged_model(model, tokenizer, path, dequantize=False):
     try:
         create_model_card(path, hf_repo)
     except Exception:
-        # Fails if hf_repo doesn't exist on Hub — create a minimal card
+        # hf_repo missing on Hub — write a minimal card
         readme = path / "README.md"
         if not readme.exists():
             readme.write_text("---\nlibrary_name: mlx\ntags:\n- mlx\n- unsloth\n---\n")
@@ -3834,7 +3786,7 @@ def _install_llama_cpp_macos(llama_cpp_folder="llama.cpp"):
             check=True,
         )
 
-    # Install Python dependencies — use gguf from the cloned repo to stay in sync
+    # Install deps; prefer gguf from the cloned repo to stay in sync
     gguf_py_dir = os.path.join(llama_cpp_folder, "gguf-py")
     if os.path.exists(gguf_py_dir):
         subprocess.run(
@@ -3940,7 +3892,7 @@ def save_pretrained_gguf(
         if quant_type in ("bf16", "f16", "f32"):
             first_conversion = quant_type
         else:
-            # All k-quants and q8_0 go through bf16 intermediate then llama-quantize
+            # k-quants and q8_0 go through a bf16 intermediate, then llama-quantize
             first_conversion = "bf16"
 
     # GGUF conversion requires torch (used by llama.cpp's convert_hf_to_gguf.py)
@@ -3967,8 +3919,8 @@ def save_pretrained_gguf(
             print("Unsloth: Installing llama.cpp (this only happens once)...")
             _install_llama_cpp_macos(llama_cpp_folder)
 
-        # Ensure gguf Python package is installed (may be missing if
-        # llama.cpp was built in a different venv)
+        # Ensure gguf is installed (may be missing if llama.cpp was built
+        # in a different venv)
         try:
             import gguf  # noqa: F401
         except ImportError:

--- a/unsloth_zoo/patch_torch_functions.py
+++ b/unsloth_zoo/patch_torch_functions.py
@@ -78,67 +78,6 @@ def cross_entropy(
     r"""Compute the cross entropy loss between input logits and target.
 
     See :class:`~torch.nn.CrossEntropyLoss` for details.
-
-    Args:
-        input (Tensor) : Predicted unnormalized logits;
-            see Shape section below for supported shapes.
-        target (Tensor) : Ground truth class indices or class probabilities;
-            see Shape section below for supported shapes.
-        weight (Tensor, optional): a manual rescaling weight given to each
-            class. If given, has to be a Tensor of size `C`
-        size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
-            the losses are averaged over each loss element in the batch. Note that for
-            some losses, there multiple elements per sample. If the field :attr:`size_average`
-            is set to ``False``, the losses are instead summed for each minibatch. Ignored
-            when reduce is ``False``. Default: ``True``
-        ignore_index (int, optional): Specifies a target value that is ignored
-            and does not contribute to the input gradient. When :attr:`size_average` is
-            ``True``, the loss is averaged over non-ignored targets. Note that
-            :attr:`ignore_index` is only applicable when the target contains class indices.
-            Default: -100
-        reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
-            losses are averaged or summed over observations for each minibatch depending
-            on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per
-            batch element instead and ignores :attr:`size_average`. Default: ``True``
-        reduction (str, optional): Specifies the reduction to apply to the output:
-            ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
-            ``'mean'``: the sum of the output will be divided by the number of
-            elements in the output, ``'sum'``: the output will be summed. Note: :attr:`size_average`
-            and :attr:`reduce` are in the process of being deprecated, and in the meantime,
-            specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
-        label_smoothing (float, optional): A float in [0.0, 1.0]. Specifies the amount
-            of smoothing when computing the loss, where 0.0 means no smoothing. The targets
-            become a mixture of the original ground truth and a uniform distribution as described in
-            `Rethinking the Inception Architecture for Computer Vision <https://arxiv.org/abs/1512.00567>`__. Default: :math:`0.0`.
-
-    Shape:
-        - Input: Shape :math:`(C)`, :math:`(N, C)` or :math:`(N, C, d_1, d_2, ..., d_K)` with :math:`K \geq 1`
-          in the case of `K`-dimensional loss.
-        - Target: If containing class indices, shape :math:`()`, :math:`(N)` or :math:`(N, d_1, d_2, ..., d_K)` with
-          :math:`K \geq 1` in the case of K-dimensional loss where each value should be between :math:`[0, C)`.
-          If containing class probabilities, same shape as the input and each value should be between :math:`[0, 1]`.
-
-        where:
-
-        .. math::
-            \begin{aligned}
-                C ={} & \text{number of classes} \\
-                N ={} & \text{batch size} \\
-            \end{aligned}
-
-    Examples::
-
-        >>> # Example of target with class indices
-        >>> input = torch.randn(3, 5, requires_grad=True)
-        >>> target = torch.randint(5, (3,), dtype=torch.int64)
-        >>> loss = F.cross_entropy(input, target)
-        >>> loss.backward()
-        >>>
-        >>> # Example of target with class probabilities
-        >>> input = torch.randn(3, 5, requires_grad=True)
-        >>> target = torch.randn(3, 5).softmax(dim=1)
-        >>> loss = F.cross_entropy(input, target)
-        >>> loss.backward()
     """
     if has_torch_function_variadic(input, target, weight):
         return handle_torch_function(
@@ -171,8 +110,7 @@ def patch_torch_functions():
     if not hasattr(torch.nn.functional, "_uncompiled_layer_norm"):
         torch.nn.functional._uncompiled_layer_norm = torch.nn.functional.layer_norm
         torch.nn.functional.layer_norm = layer_norm
-    # Remove compiling cross_entropy since too many errors
-    # We already compile this most likely anyways
+    # Don't compile cross_entropy (too many errors; already compiled elsewhere)
     # if not hasattr(torch.nn.functional, "_uncompiled_cross_entropy"):
     #     torch.nn.functional._uncompiled_cross_entropy = torch.nn.functional.cross_entropy
     #     torch.nn.functional.cross_entropy = cross_entropy

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -41,7 +41,7 @@ def patch_compiling_bitsandbytes():
         if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
             print("Unsloth: Bitsandbytes >= 0.46.0 supports torch.compile - enabling.")
     else:
-        # Disable dynamo on Linear4bit, Linear8bit and other future modules
+        # Disable dynamo on Linear4bit, Linear8bit etc
         if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
             print("Unsloth: Bitsandbytes < 0.46.0 does not support torch.compile - disabling.")
         for x in ["bitsandbytes.nn.modules", "peft.tuners.lora.bnb",]:
@@ -123,8 +123,8 @@ def patch_torch_compile(debug = False, O3 = False, ignore_errors = True):
     pass
 
     os.environ["UNSLOTH_PATCHED"] = "1"
-    # See https://pytorch.org/tutorials/recipes/torch_compile_caching_tutorial.html
-    # Caches kernel generations for faster restarts
+    # Cache kernel generations for faster restarts. See
+    # https://pytorch.org/tutorials/recipes/torch_compile_caching_tutorial.html
     # https://dev-discuss.pytorch.org/t/impact-of-multithreading-and-local-caching-on-torch-compile/2498/3
     os.environ["TORCHINDUCTOR_FX_GRAPH_CACHE"] = "1"
     os.environ["TORCHINDUCTOR_AUTOTUNE_REMOTE_CACHE"] = "1"
@@ -218,8 +218,7 @@ def get_model(model):
         elif hasattr(x, "model"):
             x = x.model
         elif hasattr(x, "base_model") and x.base_model !=x:
-            # for VLMs x.base_model = x causing this to be stuck in endless loop
-            # the check x.base_model != x is to prevent this
+            # x.base_model != x guards against VLMs where base_model is self (infinite loop)
             x = x.base_model
         elif hasattr(x, "language_model"):
             x = x.language_model
@@ -303,8 +302,7 @@ def patch_model_and_tokenizer(
         elif config_dtype ==  "float16": set_dtype_in_config(m.config, torch.float16)
     pass
 
-    # Also patch all dtypes - BnB seems to not allocate the correct type?
-    # BnB default dtype seems to be float16!
+    # Patch all dtypes: BnB defaults to float16 and may not allocate correctly
     try:
         from bitsandbytes.nn  import Linear4bit as Bnb_Linear4bit
     except:
@@ -315,7 +313,7 @@ def patch_model_and_tokenizer(
         raise ImportError("Unsloth: Please install peft via `pip install peft`")
     pass
 
-    # Get most likely the correct data-type of the model
+    # Determine the model's correct data type
     if correct_dtype is None:
         try:
             correct_dtype = _get_dtype(dtype_from_config(model.config))
@@ -389,18 +387,16 @@ def patch_model_and_tokenizer(
         except: pass
     pass
 
-    # since we are now setting actual dtypes in config
-    # and there is a transition from torch.dtype to dtype
-    # support for auto dtype conversion is not stable
-    # patch to dict makes sure that any torch.dtype is converted to
-    # string when trying to save the config or serialize it
+    # We now set actual dtypes in config; the torch.dtype -> dtype transition's
+    # auto conversion is unstable, so patch_to_dict() stringifies any torch.dtype
+    # when saving / serializing the config.
     patch_to_dict()
 
     # Check all params and patch!
     for name, module in model.named_modules():
         if isinstance(module, (Bnb_Linear4bit, Peft_Linear4bit)):
             weight = module.weight
-            # Check if quant_state exists for vision models like unsloth/Llama-3.2-11B-Vision-Instruct-bnb-4bit, unsloth/granite-vision-3.2-2b
+            # Some vision models (e.g. Llama-3.2-11B-Vision, granite-vision) lack quant_state
             if not hasattr(weight, 'quant_state'):
                 print(f"Skipping {name}: no quant_state found")
                 continue
@@ -413,8 +409,8 @@ def patch_model_and_tokenizer(
                 setted_dtype = correct_dtype
 
             if type(quant_state) is list:
-                # BnB seems to have float16 as default!
-                module.weight.quant_state[2] = setted_dtype # Cast to correct dtype
+                # BnB defaults to float16; cast to correct dtype
+                module.weight.quant_state[2] = setted_dtype
             else:
                 # https://github.com/TimDettmers/bitsandbytes/pull/763/files
                 quant_state.dtype = setted_dtype
@@ -591,28 +587,21 @@ def check_conversion_mappings(model, current_key_name_str, skip_modules):
     if model_root_cls is None:
         return False
     if hasattr(model_root_cls, "_checkpoint_conversion_mapping") and len(model_root_cls._checkpoint_conversion_mapping) > 0:
-        # if this is true, then it means that we must be on transformers >=4.52.0 because conversion_mappings was added in 4.52.0
-        # we cant know if the skip module naming convention is new or old
-        # but if we are supposed to skip this current_key_name_str, and it didn't pass
-        # (current_key_name_str in quantization_config.llm_int8_skip_modules)
-        # then new transformers + new module hierarchy means it should not be skipped, ie no BC check needed
-        # and new transformers + old module hierarchy means we still need to check to skip
-        # old transformers + old module hierarchy means no BC needed
-        # old transformers + new module hierarchy is problematic since we don't have the conversion_mappings to reverse
-        # follow the logic from save_pretrained in transformers.modeling_utils
+        # Non-empty conversion_mappings => transformers >=4.52.0. We can't tell
+        # if the skip-module naming is new or old, so reverse-map the key (per
+        # save_pretrained in transformers.modeling_utils) and re-check, which
+        # covers the old-module-hierarchy case that still needs the BC skip.
         reverse_conversion_mappings = {v: k for k, v in model_root_cls._checkpoint_conversion_mapping.items()}
         new_current_key_names_str = current_key_name_str
         for pattern, replacement in reverse_conversion_mappings.items():
             try:
-                replacement = replacement.lstrip("^")  # strip off un-needed chars and patterns
+                replacement = replacement.lstrip("^")  # strip unneeded chars/patterns
                 replacement = re.sub(r"\(.*?\)", "", replacement)
                 key, n_replace = re.subn(pattern, replacement, current_key_name_str)
-                # Early exit of the loop
                 if n_replace > 0:
                     new_current_key_names_str = key
                     break
             except Exception as e:
-                # skip this pattern but log
                 do_logging = os.environ.get('UNSLOTH_ENABLE_LOGGING', '0') == '1'
                 if do_logging:
                     print(f"Unsloth: Replace bnb issue: {str(e)}")
@@ -622,18 +611,18 @@ def check_conversion_mappings(model, current_key_name_str, skip_modules):
 
 
 def _mark_parent(child, parent_type):
-    """Attach the parent’s class so the child can inspect it later."""
+    """Attach the parent's class so the child can inspect it later."""
     child._root_cls = parent_type
 
 
 def _unmark_parent(child):
-    """Remove the temporary attribute if it is present."""
+    """Remove the temporary _root_cls attribute if present."""
     if hasattr(child, "_root_cls"):
         delattr(child, "_root_cls")
 
 
 def parsed_statement(code: str) -> ast.stmt:
-    """Return the statement parsed from a one-liner."""
+    """Parse a one-liner into a single statement node."""
     return ast.parse(code).body[0]
 
 
@@ -646,19 +635,8 @@ class WrapRecursiveCall(ast.NodeTransformer):
     unmark_statement = parsed_statement('_unmark_parent(module)')
 
     def visit_Assign(self, node: ast.Assign):
-        """
-        Replace
-            _, has_been_replaced = _replace_with_bnb_linear(...)
-        with
-            try:
-                _mark_parent(module,
-                             model._root_cls
-                             if hasattr(model, "_root_cls")
-                             else type(model))
-                _, has_been_replaced = _replace_with_bnb_linear(...)
-            finally:
-                _unmark_parent(module)
-        """
+        """Wrap each `_replace_with_bnb_linear(...)` call in try/finally that
+        marks the parent class before the call and unmarks it after."""
         if (
             isinstance(node.value, ast.Call)
             and getattr(node.value.func, "id", None) == self.function_name
@@ -689,8 +667,8 @@ if hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") a
     if "current_key_name_str" not in source:
         raise RuntimeError("Unsloth: Patch for dynamic quantization failed since current_key_name_str does not exist.")
 
-    # First patch recursive calls to mark the parent class
-    # we need it to access the parent class to check for conversion_mappings
+    # Patch recursive calls to mark the parent class, so we can access it
+    # when checking for conversion_mappings
     try:
         mark_parent_error = False
         new_source = source.replace(
@@ -721,7 +699,7 @@ if hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") a
         mark_parent_error = True
 
     if mark_parent_error:
-        # we sitll have the original source without the mark_parent and unmark_parent patches
+        # Fall back to original source without the mark/unmark patches
         source = source.replace(
             "name in quantization_config.llm_int8_skip_modules\n",
             "((name in quantization_config.llm_int8_skip_modules) or (current_key_name_str in quantization_config.llm_int8_skip_modules))\n",
@@ -752,13 +730,11 @@ if hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") a
     transformers.integrations.bitsandbytes._replace_with_bnb_linear = _unsloth_replace_with_bnb_linear
 pass
 
-# Patch for transformers 5.x: should_convert_module uses re.match (prefix-anchored)
-# and endswith, but does not do substring component matching. This means entries like
-# "vision_tower" in llm_int8_skip_modules fail to match module names like
-# "model.vision_tower.vision_model.encoder.layers.0.self_attn.q_proj".
-# On 4.x, Unsloth patches _replace_with_bnb_linear with check_conversion_mappings
-# (substring matching). On 5.x, _replace_with_bnb_linear doesn't exist, so we
-# patch should_convert_module instead.
+# Patch for transformers 5.x: should_convert_module uses re.match + endswith
+# but no substring component matching, so entries like "vision_tower" in
+# llm_int8_skip_modules miss names like "model.vision_tower.vision_model...".
+# 4.x patches _replace_with_bnb_linear (substring matching); on 5.x that no
+# longer exists, so patch should_convert_module instead.
 import transformers.quantizers.quantizers_utils as _quantizers_utils
 if not hasattr(transformers.integrations.bitsandbytes, "_replace_with_bnb_linear") and \
     hasattr(_quantizers_utils, "should_convert_module") and \

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -78,7 +78,6 @@ def get_peft_regex(
     pass
 
     from collections import Counter
-    # Get only linear layers
     modules = model.named_modules()
     linear_modules = [name for name, module in modules if isinstance(module, torch.nn.Linear)]
 
@@ -93,7 +92,7 @@ def get_peft_regex(
 
     all_linear_modules = Counter(x.rsplit(".")[-1] for x in linear_modules)
 
-    # Isolate lm_head / projection matrices if count == 1
+    # Isolate lm_head / projection matrices (count == 1)
     if target_modules is None:
         only_linear_modules = []
         projection_modules  = {}
@@ -108,7 +107,6 @@ def get_peft_regex(
         only_linear_modules = list(target_modules)
     pass
 
-    # Create regex matcher
     regex_model_parts = []
     if finetune_vision_layers:     regex_model_parts += vision_tags
     if finetune_language_layers:   regex_model_parts += language_tags
@@ -218,10 +216,10 @@ def requires_grad_for_gradient_checkpointing(model):
         if type_output is torch.Tensor:
             output.requires_grad_(True)
         else:
-            try: # For dataclass from HF, try on loss or logits
+            try: # For HF dataclass, try loss or logits
                 if hasattr(output, "loss") and output.loss is not None:
                     output.loss.requires_grad_(True)
-                elif hasattr(output, "logits") and output.logits is not None: #with RL like GRPO there are no loss as you don't provide labels
+                elif hasattr(output, "logits") and output.logits is not None: # RL like GRPO has no loss (no labels)
                     output.logits.requires_grad_(True)
                 elif hasattr(output, "last_hidden_state") and output.last_hidden_state is not None:
                     # Encoder / decoder-style embedding backbones (e.g. Qwen3-Embedding) return a
@@ -245,9 +243,9 @@ def requires_grad_for_gradient_checkpointing(model):
                 return
             pass
         pass
-        # Kwargs-only path (VLMs like Idefics3, SmolVLM2, Llava, Qwen2VL, etc.)
-        # Look for the float tensor by name. inputs_embeds is universal across VLMs;
-        # hidden_states covers vision encoders; pixel_values covers image inputs.
+        # Kwargs-only path (VLMs like Idefics3, SmolVLM2, Llava, Qwen2VL, etc.):
+        # inputs_embeds is universal; hidden_states covers vision encoders;
+        # pixel_values covers image inputs.
         for key in ("inputs_embeds", "hidden_states", "pixel_values"):
             tensor = kwargs.get(key)
             if tensor is not None and type(tensor) is torch.Tensor:

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -34,15 +34,12 @@ RL_REPLACEMENTS = dict()
 def selective_log_softmax(logits, index):
     logits = logits.to(torch.float32)
     selected_logits = torch.gather(logits, dim = -1, index = index.unsqueeze(-1)).squeeze(-1)
-    # loop to reduce peak mem consumption
-    # logsumexp_values = torch.stack([torch.logsumexp(lg, dim=-1) for lg in logits])
     logsumexp_values = torch.logsumexp(logits, dim = -1)
     per_token_logps = selected_logits - logsumexp_values  # log_softmax(x_i) = x_i - logsumexp(x)
     return per_token_logps
 pass
 
-# More memory efficient by chunking on (bsz+qlen) dimension
-# Exactly equivalent to the above
+# Memory-efficient chunked variant of the above on (bsz+qlen); exactly equivalent.
 @torch.compile(dynamic = True, fullgraph = True, options = torch_compile_options,)
 def chunked_selective_log_softmax(
     logits,
@@ -53,7 +50,7 @@ def chunked_selective_log_softmax(
     chunked_logits = torch.chunk(logits.reshape(-1, logits.shape[-1]), chunks = chunks, dim = 0)
     chunked_index  = torch.chunk(index.reshape(-1), chunks = chunks, dim = 0)
     all_per_token_logps = []
-    # Below loop does the same as selective_log_softmax(chunk_logits, chunk_index)
+    # Per-chunk selective_log_softmax.
     for chunk_logits, chunk_index in zip(chunked_logits, chunked_index):
         chunk_logits = chunk_logits.to(torch.float32)
         if temperature != 1.0:
@@ -122,9 +119,7 @@ def calculate_pad_tokens_in_prompt(
     logits_to_keep: int,
     pad_token_id: int
 ) -> torch.Tensor:
-    """
-    Given prompt tensor, it returns all the left padded tokens in that sequence. so [pad, pad, pad, cat] = 3 tokens
-    """
+    """Count left-padded tokens per sequence, e.g. [pad, pad, pad, cat] -> 3."""
     if logits_to_keep >= input_ids.shape[1]:
         raise ValueError("logits_to_keep must be smaller than the sequence length.")
 
@@ -145,12 +140,10 @@ def create_completion_attention_mask(
     max_left_pad: int,
     pad_token_id: int
 ) -> torch.Tensor:
-    """
-    Given that we have a sequence, [p,p,p,c,c,c,pad,pad,pad]
+    """Build a completion mask that zeros leading prompt and trailing pad tokens.
 
-    Where p are extra prompt tokens we got from slicing the torch tensor, c is completion tokens
-    and pad are pad tokens, this function would make a completion mask that would 0 out the pad
-    and p tokens. so in this example [0,0,0,1,1,1,0,0,0]
+    For [p,p,p,c,c,c,pad,pad,pad] (p=sliced prompt, c=completion, pad=padding)
+    this returns [0,0,0,1,1,1,0,0,0].
     """
     batch_size, completion_len = completion_input_ids.shape
     device = completion_input_ids.device
@@ -220,11 +213,9 @@ def _unsloth_fix_mm_token_type_ids(
 pass
 
 def left_pack_padding(tensor: torch.Tensor, pad_id: int) -> torch.Tensor:
-    """
-    Moves all padding tokens in each sequence of a batch to the right.
-    """
+    """Move all padding tokens in each sequence to the right."""
     mask = (tensor != pad_id)
-    # Must do stable=True since binary mark is unordered
+    # stable=True since the binary mask is unordered.
     sorted_indices = torch.argsort(mask, dim=1, descending=True, stable=True)
     packed_tensor = torch.gather(tensor, 1, sorted_indices)
     return packed_tensor
@@ -236,9 +227,7 @@ def align_logprobs_with_mask(
     attention_mask: torch.Tensor,
     pad_value: float = 0.0
 ) -> torch.Tensor:
-    """
-    Aligns a log probability tensor with a given attention mask.
-    """
+    """Align a log probability tensor with a given attention mask."""
 
     device = logprob_tensor.device
     batch_size, logprob_seq_len = logprob_tensor.shape
@@ -258,24 +247,14 @@ def align_logprobs_with_mask(
 
     dest_indices = left_pad_counts.unsqueeze(1) + cols
 
-    # Create destination row indices
-    # Shape: [batch_size, logprob_seq_len]
+    # Destination row indices, shape [batch_size, logprob_seq_len].
     row_indices = torch.arange(batch_size, device=device).unsqueeze(1).expand_as(dest_indices)
 
-    # --- 4. Filter out-of-bounds indices and perform assignment ---
-    # Create a mask to identify only the indices that are within the bounds
-    # of the target tensor's sequence length.
+    # Keep only in-bounds destinations, then scatter via advanced indexing.
     valid_mask = dest_indices < mask_seq_len
-
-    # Use this mask to select only the valid row indices, column indices,
-    # and the corresponding values from the logprob tensor.
-    # This flattens the selected elements into 1D tensors.
     valid_rows = row_indices[valid_mask]
     valid_cols = dest_indices[valid_mask]
     valid_vals = logprob_tensor[valid_mask]
-
-    # Place the valid values into their correct positions in the padded tensor
-    # using a single, efficient advanced indexing operation.
     padded_logprobs[valid_rows, valid_cols] = valid_vals
 
     return padded_logprobs
@@ -286,9 +265,7 @@ def align_completion_tool_mask(
     tool_mask: torch.Tensor,
     completion_mask: torch.Tensor,
 ) -> torch.Tensor:
-    """
-    Aligns a raw completion-length tool/env mask with Unsloth's repacked loss mask.
-    """
+    """Align a raw completion-length tool/env mask with Unsloth's repacked loss mask."""
     if tool_mask is None:
         return completion_mask
     if tool_mask.shape[0] != completion_mask.shape[0]:
@@ -324,13 +301,13 @@ def autotune_batch_and_chunks(
         free_bytes, _ = torch.cuda.mem_get_info()
         limit_gb = (free_bytes / (1024**3))*.80
     elif hasattr(torch, "xpu") and torch.xpu.is_available():
-        # For XPU: estimate free memory from total - reserved
+        # XPU: estimate free memory as total - reserved.
         total_mem = torch.xpu.get_device_properties(0).total_memory
         reserved_mem = torch.xpu.memory_reserved()
         free_bytes = total_mem - reserved_mem
         limit_gb = (free_bytes / (1024**3)) * 0.80
     else:
-        # Fallback: assume 8GB available
+        # Fallback: assume 8GB available.
         limit_gb = 8.0
 
     bytes_to_gb = 1024**3
@@ -362,7 +339,6 @@ RL_REPLACEMENTS["grpo_autotune_batch_and_chunks"] = autotune_batch_and_chunks
 def grpo_update_SamplingParams(SamplingParams, generation_kwargs, vllm_sampling_params = None):
     good_sampling_params_keys = inspect.signature(SamplingParams).parameters.keys()
 
-    # Filter generation_kwargs
     new_generation_kwargs = {}
     for key in generation_kwargs.keys():
         if key in good_sampling_params_keys:
@@ -405,7 +381,7 @@ def grpo_compute_loss(
     **kwargs
 ):
     # All Unsloth Zoo code licensed under AGPL3
-    # Set defaults for optional arguments
+    # Optional argument defaults.
     loss_type = kwargs.get("loss_type", "grpo")
     epsilon_low = kwargs.get("epsilon_low", 0.2)
     epsilon_high = kwargs.get("epsilon_high", 0.2)
@@ -443,16 +419,14 @@ def grpo_compute_loss(
 
     with torch.no_grad():
         if use_vllm and sampling_per_token_logps is not None:
-            #must filter out extra prompt tokens in begining after making input_ids left padded
+            # Filter out extra leading prompt tokens after left-padding input_ids.
             importance_sampling_ratio = torch.exp((old * mask) - sampling_per_token_logps)
             importance_sampling_ratio = torch.clamp(
                 importance_sampling_ratio, max=vllm_importance_sampling_cap
             )
     pass
 
-    # Must detach - otherwise gradients are not propagated correctly!
-    # exp(x - x) == 1
-    # loss_i = torch.exp(new - new.detach()) * advantages.unsqueeze(1)
+    # Must detach when old is None: exp(new - new.detach()) == 1 but keeps grads correct.
     if old is not None:
         log_ratio = new - old
     else:
@@ -471,26 +445,20 @@ def grpo_compute_loss(
 
     coef_1 =  torch.exp(log_importance_weights)
 
-    # Reverse KL
-    # Note that this is a low variance low bias estimator for the KL divergence as used in GRPO paper
+    # Reverse KL: low-variance low-bias estimator as used in the GRPO paper.
     if beta != 0.0:
         kl_i = torch.exp(ref - new) - (ref - new) - 1.0
 
     else:
-        # set kl_i to a tensor of zeros with the correct shape
+        # Zeros with the correct shape.
         if importance_sampling_level == "sequence":
             kl_i = new.new_zeros(new.size(0), 1)
         else:
             kl_i = torch.zeros_like(new)
-    # Full correct reverse KL divergence?? Missing term maybe?
-    # kl_i = torch.exp(new) * kl_i
 
-    # Below is forward KL (normal KL)
-    # kl_i = torch.exp(old) * (old - new)
     if loss_type == "cispo":
         clamped_ratios = torch.clamp(coef_1, max=epsilon_high).detach()
         loss_i = -clamped_ratios * advantages * new
-        #breakpoint()
     elif loss_type in ["grpo", "bnpo", "dr_grpo", "dapo"]:
         coef_2 = torch.clamp(coef_1, 1 - epsilon_low, 1 + epsilon_high)
 
@@ -506,7 +474,7 @@ def grpo_compute_loss(
             raise Exception(f"sapo is only available in TRL 0.26.0+")
         loss_i = torch.empty_like(coef_1)
         positive_advantages_mask = advantages.repeat([1, coef_1.shape[1]]) > 0
-        #since we have n_chunks some tensors may error if they dont have elements in them
+        # With n_chunks some tensors may be empty; guard the indexing.
         if coef_1[positive_advantages_mask].numel() != 0:
             loss_i[positive_advantages_mask] = get_sapo_token_loss(
                 coef_1[positive_advantages_mask], sapo_temperature_pos
@@ -538,7 +506,7 @@ def grpo_compute_loss(
 
     if use_vllm and sampling_per_token_logps is not None:
         loss_i = loss_i * importance_sampling_ratio
-        #delta for metric
+        # delta for the metric.
         with torch.no_grad():
             delta = torch.abs(old - sampling_per_token_logps)
             delta = delta * mask
@@ -568,9 +536,7 @@ def grpo_compute_loss(
     else:
         raise ValueError(f"Unknown loss type: {loss_type}")
 
-    # loss = (loss_i * mask).sum() / mask.sum()
-
-    # Get metrics as well which are folded
+    # Folded metrics.
     def masked_batch_mean(x):
         with torch.inference_mode():
             completion_length = n_mask_per_reward.mean()
@@ -613,9 +579,8 @@ class UnslothEfficientGRPO(torch.autograd.Function):
                 **extra_kwargs,
             )
 
-            # Scale loss if needed for mixed precision training
+            # Scale for mixed precision; return loss.detach() or autograd uses 2x VRAM.
             scaled_loss = loss * scaling
-            # Must add .loss.detach otherwise autograd uses 2x VRAM
             return scaled_loss, (loss.detach(), completion_length, mean_kl, delta, flat_is_ratio, coef_1)
         pass
 
@@ -679,11 +644,8 @@ class UnslothEfficientGRPO(torch.autograd.Function):
         mask               = torch.chunk(_mask,              chunks = n_chunks, dim = 0)
         advantages         = torch.chunk(_advantages,        chunks = n_chunks, dim = 0)
 
-        # Get mixed precision scaling if seen
+        # Mixed precision scaling if present.
         scaling = scaler.get_scale() if scaler is not None else 1.0
-
-        # Force torch.compile to use dynamic shapes for seqlen dim
-        # mark_dynamic = lambda x: torch._dynamo.mark_dynamic(x, 1)
 
         for (grad_inputs_j, new_logps_j, old_logps_j, ref_logps_j, sampling_per_token_logps_j, input_ids_j, mask_j, advantages_j, ) in \
             zip(grad_inputs_chunks, new_logps, old_logps, ref_logps, sampling_per_token_logps, input_ids, mask, advantages):
@@ -774,9 +736,9 @@ def grpo_accumulated_loss(
     logit_scale_multiply = kwargs.get("logit_scale_multiply", 0.0)
     logit_scale_divide   = kwargs.get("logit_scale_divide", 0.0)
     logit_softcapping    = kwargs.get("logit_softcapping", 0.0)
-    prev_max_left_pad    = kwargs.get("max_left_pad", 0) #Always get max_left_pad for when training LLMs, enabled by deafult.
+    prev_max_left_pad    = kwargs.get("max_left_pad", 0) # max_left_pad for LLM training, enabled by default.
 
-    #Delete this from kwargs so less issues
+    # Pop from kwargs to avoid downstream issues.
     _ = kwargs.pop("sampling_per_token_logps", None)
     kwargs["vllm_importance_sampling_cap"] = trainer.vllm_importance_sampling_cap if sampling_per_token_logps is not None else None
     kwargs["get_sapo_token_loss"] = trainer.get_sapo_token_loss if hasattr(trainer, "get_sapo_token_loss") else None
@@ -790,7 +752,7 @@ def grpo_accumulated_loss(
     kwargs["get_off_policy_mask"] = trainer.get_off_policy_mask if hasattr(trainer, "get_off_policy_mask") else None
     kwargs["off_policy_mask_threshold"] = trainer.args.off_policy_mask_threshold  if hasattr(trainer.args, "off_policy_mask_threshold") else None
     kwargs["use_vllm"] = trainer.use_vllm
-    # Find closest multiple
+    # Snap n_chunks to the closest divisor of bsz.
     factors = [i for i in range(1, bsz + 1) if bsz % i == 0]
     if n_chunks == -1: n_chunks = bsz
     n_chunks = factors[min(np.searchsorted(factors, n_chunks), len(factors)-1)]
@@ -853,7 +815,6 @@ def grpo_accumulated_loss(
         input_ids = left_pack_padding(input_ids, trainer.processing_class.pad_token_id)
 
         completion_input_ids = input_ids[:, -(logits_to_keep +max_left_pad):]
-
         completion_mask = create_completion_attention_mask(completion_input_ids, left_pad_tokens_per_prompt, max_left_pad, trainer.processing_class.pad_token_id).to(attention_mask.dtype)
 
         if trainer.use_vllm and sampling_per_token_logps is not None and getattr(trainer, "vllm_importance_sampling_correction", False):
@@ -977,14 +938,12 @@ def grpo_accumulated_loss(
         return tensor.to(device, non_blocking=non_blocking)
 
     class Unsloth_Offloaded_Log_Softmax(torch.autograd.Function):
-        """
-        Manual Gradient Checkpointing/CPU Offloading for Log Softmax.
-        """
+        """Manual gradient checkpointing / CPU offloading for log softmax."""
         @staticmethod
         def forward(ctx, hidden_states, lm_head, index, chunks,
                     logit_scale_multiply, logit_scale_divide,
                     logit_softcapping, temperature):
-            #Only the activations are needed so if we keep entire computational graph, keeps unnecessary memory on CPU so we detach it
+            # Detach so we don't keep the graph (and extra memory) on CPU.
             ctx.saved_hidden_states = hidden_states.detach().contiguous().to("cpu", non_blocking=True)
             ctx.device = hidden_states.device
             ctx.dtype = hidden_states.dtype
@@ -1038,7 +997,7 @@ def grpo_accumulated_loss(
                             logit_scale_multiply=0.0, logit_scale_divide=0.0,
                             logit_softcapping=0.0, temperature=1, batch_size=8):
         if (index.shape[1] <= 1024 and batch_size <= 8) or batch_size==1:
-            #We save a gigabyte or speed with the normal path under these specific conditions
+            # Normal path is faster / saves a GB under these conditions.
             return chunked_hidden_states_selective_log_softmax(
                 hidden_states,
                 lm_head,
@@ -1125,8 +1084,7 @@ def grpo_accumulated_loss(
 
                     new_hidden_states_chunk = new_hidden_states_chunk[:, :-1, :]
                     logprobs_chunk = compute_logprobs_chunk(new_hidden_states_chunk, completion_ids, input_ids_chunk)
-                #This is needed to avoid race conditions with GPT OSS offload_embbed=True
-                #However, it seems that this line does not slow down or disrupt models.
+                # Avoids race conditions with GPT OSS offload_embbed=True; no measurable slowdown.
                 device_synchronize()
             all_logprobs_list.append(logprobs_chunk)
 
@@ -1148,11 +1106,11 @@ def grpo_accumulated_loss(
             kwargs
         )
 
-    # Must force not returning hidden states but logits otherwise gibberish
+    # Force logits (not hidden states) again or output is gibberish.
     os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "0"
 
     return loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1, completion_mask
-    # Old non efficient code path
+    # Old non-efficient code path (dead).
     new_logits = torch.matmul(new_hidden_states, lm_head.t())
     new_logits = new_logits[:, :-1, :] # exclude the last logit: it corresponds to the next token pred
     old_logits = torch.matmul(old_hidden_states, lm_head.t())

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -30,8 +30,7 @@ from collections import defaultdict
 try:
     from transformers.integrations.mxfp4 import convert_moe_packed_tensors, convert_moe_packed_tensors_cpu
 except (ImportError, ModuleNotFoundError):
-    # Provide a fallback or a clear error if the function isn't available
-    # when not using mxfp4.
+    # Absent unless mxfp4 is in use
     convert_moe_packed_tensors     = None
     convert_moe_packed_tensors_cpu = None
 pass
@@ -116,20 +115,16 @@ def create_huggingface_repo(
     )
     username = repo_id.split("/")[0]
 
-    # Check if base_model is a local path
+    # If base_model is a local path, resolve to the original model ID so the
+    # card doesn't reference a local dir (which fails HF validation).
     base_model = model.config._name_or_path
     if os.path.exists(base_model) and os.path.isdir(base_model):
-        # Try to get the original model ID from config
         original_model_id = get_original_model_id(base_model)
         if original_model_id is not None and not os.path.exists(original_model_id):
-            # Use the original model ID if it doesn't look like a local path
             base_model = original_model_id
         else:
-            # If we can't determine the original model, use repo_id as a generic description
-            # that won't cause HF validation errors
-            base_model = repo_id
+            base_model = repo_id  # fall back to a generic, valid description
 
-    # Create model card
     content = MODEL_CARD.format(
         username   = username,
         base_model = base_model,
@@ -159,13 +154,10 @@ import os, shutil, re, functools
 
 @functools.lru_cache(maxsize = 1)
 def _active_merge_device():
-    """Pick the active accelerator family for LoRA merge math.
+    """Pick the active accelerator family for LoRA merge math, cached.
 
-    Hardcoding ``"cuda"`` breaks ROCm (AMD), XPU (Intel), and MPS (Apple
-    Silicon) backends. Routing through ``DEVICE_TYPE_TORCH`` only covers
-    cuda/xpu/hip and silently drops MPS, which the MLX backend relies on
-    for the on-host LoRA merge step. Probe the available accelerator
-    family at first call and cache the result.
+    Hardcoding "cuda" breaks ROCm/XPU/MPS; DEVICE_TYPE_TORCH drops MPS (needed
+    by the MLX backend's on-host merge). So probe at first call instead.
     """
     if torch.cuda.is_available():
         return "cuda"  # PyTorch ROCm aliases the cuda API, so this also covers HIP
@@ -202,7 +194,7 @@ def _get_modules_to_save_weight(module):
     if modules_to_save is None:
         return None
 
-    # Prefer the active/default adapter if present, else first entry
+    # Prefer the default adapter, else first entry with a weight
     for key in ("default",):
         try:
             candidate = modules_to_save[key]
@@ -284,9 +276,9 @@ pass
 
 
 def assert_same_keys(model, new_state_dict):
-    """
-    Normalize keys so MoE helper wrappers (base_layer, modules_to_save, original_module)
-    and LoRA suffixes don't trigger false mismatches. Compare only weight/bias tensors.
+    """Compare only weight/bias tensors, normalizing MoE helper wrappers
+    (base_layer, modules_to_save, original_module) and LoRA suffixes so they
+    don't trigger false mismatches.
     """
     inner_model = model.base_model.model if hasattr(model, "base_model") else model
 
@@ -302,14 +294,12 @@ def assert_same_keys(model, new_state_dict):
         )
 
     def _normalize(key: str) -> str:
-        # keep only weight/bias tensors
         if not (key.endswith(".weight") or key.endswith(".bias")):
             return ""
         # strip helper wrappers
         key = key.replace(".base_layer", "")
         key = key.replace(".modules_to_save.default", "")
         key = key.replace(".original_module", "")
-        # consolidate lora default suffix
         key = key.replace(".lora_A.default", ".lora_A")
         key = key.replace(".lora_B.default", ".lora_B")
         return key
@@ -421,11 +411,10 @@ def create_lora_statistics(model, merge_into_original = False, return_state_dict
             new_keys = expand_module_keys(name, module, set())
             for key in new_keys:
                 if not key.endswith((".weight", ".bias")):
-                    # Check if quantized item exactly which has ".weight"
+                    # Drop quantized sub-keys (".weight."); keep gate_tanh, embedding etc
                     if ".weight." in key:
                         remove_keys.add(key)
                     else:
-                        # Keep gate_tanh, embedding etc
                         pass
             remove_keys.add(name)
         pass
@@ -549,8 +538,7 @@ def _merge_and_overwrite_lora(
     if base_model_is_quantized and quant_type == "mxfp4" and save_method != "mxfp4":
         if UNSLOTH_ENABLE_LOGGING:
             logger.info("mxfp4 quantized model detected. Using safe rewrite strategy (requires temporary disk space).")
-        # Here, we fall back to the complete rewrite logic.
-        # This logic is extracted from your original 'working_code'.
+        # mxfp4 needs the full-rewrite path
         return _merge_and_overwrite_lora_mxfp4(
             save_directory, filename, lora_weights, output_dtype,
             model_class_name, base_model_is_quantized, quant_type,
@@ -573,15 +561,13 @@ def _merge_and_overwrite_lora(
         model_class_name = model_class_name,
     )
 
-    # Open original file for reading
     raw_pointer = None
     mm = None
     header_metadata = None
     length_of_header = 0
 
-    # Only if overwriting
     try:
-        # Memory map the file for direct access
+        # Memory-map for in-place overwrite
         raw_pointer = open(filename_original, "r+b")
         mm = mmap.mmap(raw_pointer.fileno(), length = 0, access = mmap.ACCESS_WRITE)
 
@@ -652,13 +638,12 @@ def _merge_and_overwrite_lora(
                 ):
                     logger.info(f"[merge_debug] First shard key example: {key}")
 
-                # FORCE memory cleanup before processing each tensor
+                # Free memory before each tensor
                 device_empty_cache()
                 device_synchronize()
 
-                # ---------- Special handling for MoE stacked expert params ----------
-                # gate_up_proj is stored fused in the model but sharded as gate_proj & up_proj per expert on disk.
-                # Gate / Up projection
+                # MoE stacked experts: gate_up_proj is fused in the model but
+                # sharded as per-expert gate_proj/up_proj on disk.
                 m_gate = re.match(r"^(.*mlp\.experts)\.(\d+)\.(gate_proj|up_proj)\.weight$", key)
                 if m_gate:
                     if UNSLOTH_ENABLE_LOGGING and len(processed_moe_gate) < 2:
@@ -666,24 +651,19 @@ def _merge_and_overwrite_lora(
                     base_prefix, expert_idx, proj_type = m_gate.groups()
                     expert_idx = int(expert_idx)
 
-                    # Skip experts that aren't present in this shard (defensive)
+                    # Skip experts not present in this shard (defensive)
                     available_experts = moe_num_experts.get(base_prefix, None)
                     if available_experts is not None and expert_idx >= available_experts:
                         continue
 
-                    # LoRA keys for gate_up_proj are stored on experts.base_layer in PEFT
-                    # Usually: model.layers.X.mlp.experts.base_layer
+                    # PEFT stores gate_up_proj LoRA on experts.base_layer
                     fused_key = base_prefix + ".base_layer"
                     lora_stats = converted_lora_weights.get(fused_key)
                     if lora_stats is None:
-                        # Fallback
                         fused_key = base_prefix + ".gate_up_proj"
                         lora_stats = converted_lora_weights.get(fused_key)
 
                     if lora_stats is not None and lora_stats.lora_A is not None and lora_stats.lora_B is not None:
-                        # Track processed (fused_key, expert_idx, proj_type) to avoid double counting if needed
-                        # But here we process per-file key, so we just process what we see.
-
                         num_experts = moe_num_experts.get(base_prefix, None)
 
                         W = file.get_tensor(key)
@@ -700,7 +680,7 @@ def _merge_and_overwrite_lora(
                         _write_tensor_direct_torch(mm, header_metadata, length_of_header, key, merged_W, W.dtype)
                         processed_mxfp4_keys.add(key)
 
-                        # We count the module as "saved" if we process at least one part of it.
+                        # Count the module once any part of it is processed
                         if fused_key not in counted_lora_modules:
                             count += 1
                             counted_lora_modules.add(fused_key)
@@ -713,7 +693,7 @@ def _merge_and_overwrite_lora(
                     available_experts = moe_num_experts.get(base_prefix, None)
                     if available_experts is not None and expert_idx >= available_experts:
                         continue
-                    fused_key = base_prefix  # down_proj LoRA stored directly on experts module
+                    fused_key = base_prefix  # down_proj LoRA stored on experts module
                     lora_stats = converted_lora_weights.get(fused_key)
                     if lora_stats is None and len(processed_moe_gate) < 3:
                         if UNSLOTH_ENABLE_LOGGING:
@@ -745,14 +725,13 @@ def _merge_and_overwrite_lora(
 
                 output_key = key
                 action_logged = False
-                # Standard 16-bit model
+                # Standard 16-bit tensor
                 W = file.get_tensor(key)
                 W_original_dtype = W.dtype
 
                 if W is None:
                     continue
 
-                # Check for LoRA merge
                 lora_key = output_key[:-len(".weight")] if output_key.endswith(".weight") else output_key
                 lora_stats = converted_lora_weights.get(lora_key, None)
                 # Fallback: handle Gemma4ClippableLinear (.linear.weight -> .weight)
@@ -775,7 +754,7 @@ def _merge_and_overwrite_lora(
                         lora_stats = converted_lora_weights.get("model." + lm_head_key, None)
 
                 if lora_stats is not None:
-                    # Prefer modules_to_save weights if present
+                    # Prefer modules_to_save weights when there's no LoRA delta
                     if getattr(lora_stats, "lora_A", None) is None and getattr(lora_stats, "module", None) is not None:
                         saved_weight = _get_modules_to_save_weight(lora_stats.module)
                         if saved_weight is None and hasattr(lora_stats.module, "weight"):
@@ -788,12 +767,10 @@ def _merge_and_overwrite_lora(
                         W = _merge_lora(W, lora_stats, output_key)
                         count += 1
 
-                # FIXED: Direct tensor writing using torch
                 success = _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key, W, W_original_dtype)
 
                 if not success:
-                    # Tensor was resized (e.g. new tokens added to embeddings).
-                    # Track it so the shard file can be rewritten afterwards.
+                    # Tensor was resized (e.g. vocab grew); track for rewrite
                     if not hasattr(_merge_and_overwrite_lora, "_resized"):
                         _merge_and_overwrite_lora._resized = {}
                     _merge_and_overwrite_lora._resized[output_key] = W.to(
@@ -803,7 +780,6 @@ def _merge_and_overwrite_lora(
                 del W
                 device_empty_cache()
             pass
-            # Success! Direct overwrite completed
         pass
         mm.flush()
         mm.close()
@@ -813,7 +789,7 @@ def _merge_and_overwrite_lora(
         resized = getattr(_merge_and_overwrite_lora, "_resized", {})
         if resized:
             _merge_and_overwrite_lora._resized = {}
-            # Reload the shard, replace resized tensors, save new file
+            # Reload shard, swap in resized tensors, save
             tensors = {}
             with safe_open(filename_original, framework="pt", device="cpu") as f:
                 for key in f.keys():
@@ -1035,10 +1011,10 @@ def _merge_moe_expert_quant_aware(
     processed_mxfp4_keys,
     merge_fn,
 ) -> bool:
-    """Read one expert weight (dequantising any quant kind via the registry),
-    apply `merge_fn`, requantise (if the handler returned a requant closure),
-    write data + any companion scale tensors back to `mm`. Returns True on a
-    successful merge+write, False on skip (key missing or sentinel)."""
+    """Read one expert weight (dequantising via the quant registry), apply
+    `merge_fn`, requantise if the handler gave a requant closure, and write
+    data + companion scales back to `mm`. True on merge+write, False on skip.
+    """
     if key not in header_metadata:
         return False
 
@@ -1076,15 +1052,12 @@ def _merge_moe_expert_quant_aware(
 
 
 def _peft_paramwrapper_swaps_in_out():
-    """True if installed PEFT version's ParamWrapper.update_layer performs the
-    `(experts, in, out) -> (experts, out, in)` swap for 3D non-transposed MoE
-    params. Introduced in PEFT 0.19; absent in 0.18 and earlier.
+    """True if PEFT's ParamWrapper.update_layer swaps
+    `(experts, in, out) -> (experts, out, in)` for 3D non-transposed MoE params
+    (PEFT 0.19+; absent in 0.18-).
 
-    Prefers `peft.__version__` (cheap, stable) and falls back to checking
-    whether `ParamWrapper` exposes `_did_swap_in_out_features` as a class
-    attribute (defined at __init__ time in 0.19, absent in 0.18). Last-resort
-    fallback to inspect.getsource if neither is available (e.g. a packaged
-    PEFT without a version string).
+    Uses `peft.__version__`, falling back to a source check for
+    `_did_swap_in_out_features` when no version string is available.
     """
     try:
         from peft import __version__ as _peft_version
@@ -1109,19 +1082,11 @@ _PEFT_AMBIGUOUS_LAYOUT_DEFAULT = "standard" if _peft_paramwrapper_swaps_in_out()
 def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim, lora_module=None):
     """Shape-classify as 'swapped' / 'standard' / 'unknown'; returns (layout, r).
 
-    When 2*I == H for the fused gate_up_proj (common when intermediate is
-    half the hidden dim), both 'standard' and 'swapped' shape checks pass.
-    For that ambiguous case the right default depends on whether PEFT swapped
-    in/out features when creating the ParamWrapper:
-
-    - PEFT 0.19+ swaps for 3D non-transposed MoE → `lora_A.dim_A == in_dim`,
-      which corresponds to the "standard" branch of the merge math.
-    - PEFT 0.18 and earlier do NOT swap → `lora_A.dim_A == out_dim`, which
-      corresponds to the "swapped" branch.
-
-    `_PEFT_AMBIGUOUS_LAYOUT_DEFAULT` is computed once at import time from the
-    installed PEFT version. A caller can still override per-call by passing a
-    `lora_module` with `_did_swap_in_out_features` set explicitly.
+    When 2*I == H for the fused gate_up_proj, both checks pass. That ambiguous
+    case resolves on whether PEFT swapped in/out features: 0.19+ swaps ->
+    "standard", 0.18- doesn't -> "swapped". The default comes from
+    `_PEFT_AMBIGUOUS_LAYOUT_DEFAULT` (computed at import) but a caller may
+    override via a `lora_module` with `_did_swap_in_out_features` set.
     """
     total_rank_A, dim_A = lora_A.shape
     dim_B, total_rank_B = lora_B.shape
@@ -1133,11 +1098,8 @@ def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim, lora_m
     standard_match = (dim_A == in_dim and dim_B == out_dim)
     swapped_match  = (dim_A == out_dim and dim_B == in_dim)
     if standard_match and swapped_match:
-        # Ambiguous shape (typically 2*I == H). Prefer an explicit per-wrapper
-        # signal when available, otherwise fall back to the PEFT-version-aware
-        # default. `_did_swap_in_out_features = True` means PEFT swapped in/out
-        # at training time, which corresponds to "standard" storage from the
-        # merge code's perspective.
+        # Ambiguous (typically 2*I == H): prefer the per-wrapper signal
+        # (_did_swap_in_out_features=True -> "standard"), else version default.
         if lora_module is not None and hasattr(lora_module, "_did_swap_in_out_features"):
             return ("standard" if lora_module._did_swap_in_out_features else "swapped"), r
         return _PEFT_AMBIGUOUS_LAYOUT_DEFAULT, r
@@ -1149,7 +1111,7 @@ def _detect_moe_lora_layout(lora_A, lora_B, num_experts, out_dim, in_dim, lora_m
 
 
 def _merge_moe_gate_or_up_expert(W, lora_stats, expert_idx, num_experts, output_dtype, *, role):
-    """Per-expert merge for gate_proj / up_proj. role='gate' -> first I, 'up' -> last I."""
+    """Per-expert merge for gate_proj/up_proj (role='gate' -> first I, 'up' -> last I)."""
     if lora_stats is None or lora_stats.lora_A is None or lora_stats.lora_B is None:
         return W
     _MOE_MERGE_STATE["attempted"] += 1
@@ -1158,10 +1120,9 @@ def _merge_moe_gate_or_up_expert(W, lora_stats, expert_idx, num_experts, output_
         if num_experts is None or num_experts <= 0:
             rank = getattr(lora_stats, "rank", 0) or 0
             if rank <= 0:
-                # No usable num_experts AND no rank metadata. Falling back to
-                # `total_rank // 1` would produce a degenerate r=1 slicing
-                # whose shape check happens to pass but emits a wrong delta —
-                # silently. Refuse to merge.
+                # No num_experts and no rank: `total_rank // 1` would give a
+                # degenerate r=1 slicing that passes the shape check but emits a
+                # wrong delta silently. Refuse to merge.
                 _record_moe_merge_fallback(
                     role, expert_idx,
                     "num_experts and lora_stats.rank both missing — cannot derive per-expert slicing",
@@ -1191,13 +1152,9 @@ def _merge_moe_gate_or_up_expert(W, lora_stats, expert_idx, num_experts, output_
 
         # unsloth's MoE forward (temporary_patches/moe_utils.py
         # `_canonical_lora_weights_for_grouped_mm`) views lora_B as
-        # (out, num_experts, r) — contiguous-r columns per expert. This
-        # MUST match here so the merged checkpoint reproduces the unsloth
-        # training-time forward. (PEFT's own `get_delta_weight` uses
-        # stride-E reshape `(out, r, E)`, but unsloth bypasses PEFT's
-        # forward via `patch_param_wrapper_for_moe`, so the stored
-        # tensors only need to be interpreted with the same convention as
-        # unsloth's forward.)
+        # (out, num_experts, r) — contiguous-r columns per expert. Must match
+        # here so the merged checkpoint reproduces the training-time forward.
+        # (unsloth bypasses PEFT's get_delta_weight via patch_param_wrapper_for_moe.)
         a_slice = lora_stats.lora_A[start:end, :]
         b_slice = lora_stats.lora_B[:, start:end]
         device  = _active_merge_device()
@@ -1607,10 +1564,9 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
 
         for expert_idx in range(num_experts):
             start, end = expert_idx * rank, (expert_idx + 1) * rank
-            # unsloth's MoE forward views lora_B contiguous-r per expert
-            # (see temporary_patches/moe_utils.py
-            # `_canonical_lora_weights_for_grouped_mm`); the merge must
-            # match so the saved checkpoint reproduces training-time forward.
+            # lora_B is contiguous-r per expert (see moe_utils.py
+            # _canonical_lora_weights_for_grouped_mm); must match for the saved
+            # checkpoint to reproduce the training-time forward.
             a_slice = lora_stats.lora_A[start:end, :]
             b_slice = lora_stats.lora_B[:, start:end]
             delta = b_slice.to(
@@ -1753,16 +1709,15 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
             W = None
             output_key = key
             action_logged = False
-            # --- START OF MODIFIED LOGIC ---
 
-            # This block handles ALL keys from a hybrid MXFP4 file.
+            # Handle all keys from a hybrid MXFP4 file
             if key.endswith("_blocks"):
                 if convert_moe_packed_tensors is None:
                     raise ImportError("MXFP4 dequantization is required, but `convert_moe_packed_tensors` could not be imported.")
 
                 base_name = key[:-len("_blocks")]
                 scales_key = base_name + "_scales"
-                output_key = base_name # Correct naming without .weight
+                output_key = base_name  # name without .weight
                 if scales_key not in safetensor_keys:
                     warnings.warn(f"Found mxfp4 tensor {key} but missing its scales tensor {scales_key}. Skipping.")
                     continue
@@ -1772,14 +1727,12 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                 device_synchronize()
                 device_empty_cache()
 
-                # Determine optimal device and chunk size for mxfp4 dequantization
+                # Pick device + chunk size for mxfp4 dequantization
                 device_type, device_id, rows_per_chunk = _choose_mxfp4_processing_strategy(
                     blocks_tensor, scales_tensor
                 )
 
-                # Apply dequantization with optimal parameters
                 if device_type == 'cpu':
-                    # Use CPU-optimized version
                     try:
                         from transformers.integrations.mxfp4 import convert_moe_packed_tensors_cpu
                         W = convert_moe_packed_tensors_cpu(
@@ -1788,12 +1741,10 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                         if UNSLOTH_ENABLE_LOGGING:
                             logger.info(f"[DEBUG] Using CPU dequantization for {base_name} with {rows_per_chunk:,} rows per chunk")
                     except ImportError:
-                        # Fallback to original function
                         W = convert_moe_packed_tensors(
                             blocks_tensor, scales_tensor, rows_per_chunk=rows_per_chunk
                         ).transpose(1, 2).contiguous()
                 else:
-                    # Use GPU version (original or patched)
                     W = convert_moe_packed_tensors(
                         blocks_tensor, scales_tensor, rows_per_chunk=rows_per_chunk
                     ).transpose(1, 2).contiguous()
@@ -1816,19 +1767,17 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                 continue
 
             else:
-                # Handle the 16-bit tensors (like attention layers)
-                # that are present in the same file as the MXFP4 tensors.
+                # 16-bit tensors (e.g. attention) coexisting with MXFP4 tensors
                 W = file.get_tensor(key)
 
 
-            # Remove .weight suffix to match LoRA key format
             lora_key = output_key[:-len(".weight")] if output_key.endswith(".weight") else output_key
             lora_stats = converted_lora_weights.get(lora_key, None)
 
             if W is not None and lora_stats is not None and hasattr(lora_stats, 'lora_A') and lora_stats.lora_A is not None:
                 if not action_logged:
                     count += 1
-                    W = _merge_lora(W, lora_stats, output_key)  # Assume _merge_lora is defined elsewhere
+                    W = _merge_lora(W, lora_stats, output_key)
                     action_logged = True
 
             if W is None:
@@ -2687,10 +2636,8 @@ def _try_copy_all_from_cache(
     hf_cache_dir: Optional[Path],
     token: Optional[str],
 ) -> bool:
-    """
-    Checks if ALL specified files exist in the HF cache. If yes, creates the
-    target_dir_str and copies ALL files into it using os functions.
-    Returns True if successful, False otherwise.
+    """If ALL files exist in the HF cache, copy them into target_dir_str.
+    Returns True on success, False otherwise.
     """
     from huggingface_hub.errors import LocalEntryNotFoundError
 
@@ -2784,29 +2731,25 @@ def _get_hf_cache_dir() -> Optional[Path]:
 
     for cache_dir in potential_paths:
         try:
-            # 1. Check if it exists and is a directory
             if cache_dir.is_dir():
-                # 2. Check if we have read/write/execute access
-                # Need W/X for potential lock files or internal operations by huggingface_hub
+                # Need R/W/X for HF's lock files and internal operations
                 if os.access(cache_dir, os.R_OK | os.W_OK | os.X_OK):
                     print(f"Found HuggingFace hub cache directory: {cache_dir.resolve()}")
-                    return cache_dir.resolve() # Return absolute path
+                    return cache_dir.resolve()
                 else:
                     print(f"Warning: Found cache directory {cache_dir}, but lack R/W/X permissions. Cannot use cache.")
-                    # Don't check other paths if we found the prioritized one but lack permissions
+                    # First prioritized path lacks permissions; stop here
                     return None
-            # If it exists but is not a dir, it's problematic, stop checking.
             elif cache_dir.exists():
+                 # Exists but not a directory: bail
                  print(f"Warning: Path {cache_dir} exists but is not a directory. Cannot use cache.")
                  return None
-            # If it doesn't exist, continue to check the next potential path
 
         except Exception as e:
-            # Handle potential issues like symlink loops, permissions errors during check
+            # symlink loops, permission errors, etc.
             print(f"Warning: Error accessing potential cache path {cache_dir}: {e}. Checking next option.")
-            continue # Try the next path
+            continue
 
-    # If none of the paths worked
     print("No existing and accessible Hugging Face cache directory found.")
     return None
 pass
@@ -2852,7 +2795,6 @@ def incremental_save_pretrained(
         save_pretrained[span[1]:]
     pass
 
-    # Find the main loop
     if "for shard_file, tensors in filename_to_tensors" not in save_pretrained:
         raise RuntimeError("Unsloth: Failed to find `for shard_file, tensors in filename_to_tensors`")
     for_loop = re.search(
@@ -3135,12 +3077,11 @@ def get_original_model_id(local_path: str):
 pass
 
 def _get_checkpoint_conversion_mapping(model_class_name):
-    """Get the checkpoint conversion mapping for a specific model class"""
+    """Get a model class's _checkpoint_conversion_mapping ({} if absent)."""
     try:
-        # Dynamically import the model class
         module = __import__('transformers', fromlist=[model_class_name])
         model_class = getattr(module, model_class_name)
-        return getattr(model_class, '_checkpoint_conversion_mapping', {})  # Returns {} if attribute doesn't exist
+        return getattr(model_class, '_checkpoint_conversion_mapping', {})
     except (ImportError, AttributeError):
         return {}
 pass
@@ -3153,54 +3094,44 @@ def detect_keys_format(keys_to_check, forward_mapping):
     count_matches_old_pattern = 0
     count_matches_new_pattern = 0
 
-    # Compile regex patterns for efficiency if called multiple times with same mapping (though here it's per call)
     old_regex_compiled = [re.compile(p) for p in forward_mapping.keys()]
-    # For new patterns (values of forward_mapping), treat them as literal prefixes to match
+    # New patterns (mapping values) are matched as literal prefixes
     new_regex_compiled = [re.compile(r"^" + re.escape(val)) for val in forward_mapping.values()]
 
     for key in keys_to_check:
         if not isinstance(key, str): continue
 
-        # A key is "new" if it starts with one of the new_prefix_strings (values of forward_mapping)
-        # A key is "old" if it matches one of the old_pattern_regex (keys of forward_mapping)
-        #   AND it does NOT start with one of the new_prefix_strings (to avoid double counting if patterns overlap badly)
-
+        # "new" = starts with a mapping value; "old" = matches a mapping key
+        # but not a new prefix (avoids double counting on overlap)
         matched_new = any(r.match(key) for r in new_regex_compiled)
         matched_old = any(r.match(key) for r in old_regex_compiled)
 
         if matched_new:
             count_matches_new_pattern += 1
-        elif matched_old: # Only count as old if not already counted as new
+        elif matched_old:
             count_matches_old_pattern += 1
 
-    # Decision logic
     if count_matches_new_pattern > 0 and count_matches_old_pattern == 0: return "new"
     if count_matches_old_pattern > 0 and count_matches_new_pattern == 0: return "old"
 
-    # If mixed,
+    # Mixed: go with the majority
     if count_matches_new_pattern > count_matches_old_pattern: return "new"
     if count_matches_old_pattern > count_matches_new_pattern: return "old"
 
-    return "new" # Default, assuming most models/keys will be in the "new" (current HF) format.
+    return "new" # Default to current HF format
 pass
 
 def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     """Infer missing key prefixes by matching LoRA keys against safetensor keys.
 
-    Some composite models (e.g. Qwen3.5) store safetensors with an extra
-    prefix like ``model.language_model.`` that differs from the runtime key
-    namespace ``model.``.  When no explicit ``_checkpoint_conversion_mapping``
-    exists, this helper detects the discrepancy and remaps LoRA keys so that
-    the merge loop can match them.
+    Composite models (e.g. Qwen3.5) may store safetensors under an extra prefix
+    (``model.language_model.``) that differs from the runtime ``model.``
+    namespace. With no ``_checkpoint_conversion_mapping``, remap per key:
+    already-matching keys are kept; keys with a single prefix candidate are
+    remapped; unmatched keys (e.g. fused MoE params) inherit the most common
+    inferred prefix.
 
-    Uses per-key matching: keys that already match a safetensor key are
-    preserved as-is, keys with a single unambiguous prefix candidate are
-    remapped. Keys that cannot be suffix-matched (e.g. MoE expert fused
-    parameters with different naming) inherit the most common inferred
-    prefix from the keys that were successfully matched.
-
-    Returns a remapped ``defaultdict`` on success, or ``None`` if no keys
-    were remapped (caller should fall back to returning keys unchanged).
+    Returns the remapped ``defaultdict``, or ``None`` if nothing was remapped.
     """
     if not safetensor_keys:
         return None
@@ -3215,11 +3146,11 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
         if not isinstance(k, str):
             remapped[k] = v
             continue
-        # Already matches a safetensor key -- keep as-is
+        # Already matches a safetensor key
         if (k + ".weight") in sf_key_set:
             remapped[k] = v
             continue
-        # Find all unique non-empty prefix candidates for this key
+        # Unique non-empty prefix candidates for this key
         suffix = k + ".weight"
         candidates = list(dict.fromkeys(
             sf_key[: -len(suffix)]
@@ -3237,9 +3168,7 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     if not changed:
         return None
 
-    # For keys that couldn't be suffix-matched (e.g. MoE expert fused
-    # parameters whose safetensor naming differs from LoRA naming),
-    # apply the most common prefix inferred from successful matches.
+    # Unmatched keys (e.g. fused MoE params): use the most common inferred prefix
     if unmatched_keys and inferred_prefixes:
         from collections import Counter
         common_prefix = Counter(inferred_prefixes).most_common(1)[0][0]
@@ -3259,7 +3188,6 @@ def _convert_lora_keys_to_safetensor_format(
 ):
     import re
 
-    # Get the forward mapping from the model class itself
     forward_mapping = _get_checkpoint_conversion_mapping(model_class_name)
 
     if not forward_mapping:
@@ -3268,11 +3196,9 @@ def _convert_lora_keys_to_safetensor_format(
             return remapped
         return defaultdict(lora_weights.default_factory, lora_weights)
 
-    # Create reverse mapping
     reverse_mapping = {}
     for pattern, replacement in forward_mapping.items():
         reverse_mapping[replacement] = pattern
-    # Determine formats
     lora_key_format_assumed = "new"
     shard_key_format = detect_keys_format(safetensor_keys, forward_mapping)
 
@@ -3288,8 +3214,7 @@ def _convert_lora_keys_to_safetensor_format(
         applied_conversion_for_this_key = False
 
         if lora_key_format_assumed == "new" and shard_key_format == "old":
-            # LoRA keys are new format, shard is old style -> convert LoRA key to old style
-            # Use reverse mapping
+            # New LoRA keys, old shard -> convert LoRA key to old via reverse mapping
             for pattern, replacement in reverse_mapping.items():
                 replacement = re.sub(r"\^?([^(?]+).*", r"\1", replacement.lstrip("^"))
                 temp_key, n_replace = re.subn(pattern, replacement, converted_key_for_lookup)
@@ -3299,7 +3224,7 @@ def _convert_lora_keys_to_safetensor_format(
                     break
 
         elif lora_key_format_assumed == "old" and shard_key_format == "new":
-            # LoRA keys are old format, shard is new format -> convert LoRA key to new style
+            # Old LoRA keys, new shard -> convert LoRA key to new
             for pattern, replacement in forward_mapping.items():
                 temp_key, n_replace = re.subn(pattern, replacement, converted_key_for_lookup)
                 if n_replace > 0:

--- a/unsloth_zoo/temporary_patches/bitsandbytes.py
+++ b/unsloth_zoo/temporary_patches/bitsandbytes.py
@@ -50,18 +50,12 @@ def patch_bitsandbytes_linear4bit_forward():
         return raise_error("bitsandbytes.Linear4bit", e)
 
     # Fix Params4bit.__torch_function__ infinite recursion under torch.compile.
-    # bitsandbytes >= 0.46 added a __torch_function__ to Params4bit that calls
-    # super().__torch_function__() for all ops except chunk/split. The super()
-    # call goes to Parameter.__torch_function__ which re-dispatches back to
-    # Params4bit.__torch_function__ since Params4bit is still in the types tuple.
-    # In eager mode, torch's _disabled_torch_function_impl prevents this, but
-    # under torch.compile's AOT autograd runtime, the re-dispatch is not blocked,
-    # causing infinite recursion (observed on T4 with torch 2.8.0 + bnb 0.49.2).
-    #
-    # Fix: remove Params4bit's __torch_function__ entirely so it inherits from
-    # Parameter/Tensor which use C-level dispatch that cannot recurse. The bnb
-    # implementation only adds chunk/split handling (rarely used for 4-bit weights)
-    # and delegates everything else to super() anyway.
+    # bnb >= 0.46's Params4bit.__torch_function__ delegates to super() (except
+    # chunk/split), which re-dispatches back to it since Params4bit is still in
+    # the types tuple. Eager mode blocks this via _disabled_torch_function_impl,
+    # but torch.compile's AOT autograd runtime does not (seen on T4 with torch
+    # 2.8.0 + bnb 0.49.2). Removing it falls back to Parameter/Tensor C-level
+    # dispatch that cannot recurse; bnb only added chunk/split handling anyway.
     if hasattr(Params4bit, "__torch_function__") and \
        "__torch_function__" in Params4bit.__dict__:
         delattr(Params4bit, "__torch_function__")

--- a/unsloth_zoo/temporary_patches/common.py
+++ b/unsloth_zoo/temporary_patches/common.py
@@ -50,11 +50,8 @@ pass
 
 @functools.lru_cache(1)
 def is_transformers_v5_moe_quantization_available():
-    """
-    True when Transformers exposes the v5 MoE weight-loading/dispatcher APIs
-    that PR #659 patches. Transformers v4 does not use bare nn.Parameter MoE
-    experts for these paths, so the v5-only patches should not be registered.
-    """
+    """True when Transformers exposes the v5 MoE weight-loading/dispatcher APIs
+    that PR #659 patches (v4 doesn't use bare nn.Parameter MoE experts here)."""
     try:
         from transformers.core_model_loading import WeightConverter
         from transformers.integrations import moe as transformers_moe
@@ -95,7 +92,7 @@ def get_torch_compile_options(
     # Needs integer
     multi_kernel = 1 if multi_kernel else 0
 
-    # Instead of Inductor Compilation:
+    # Relabel Inductor's compile progress bar
     try:
         import torch._inductor.async_compile
         from torch.hub import tqdm
@@ -162,22 +159,12 @@ torch_compile_options = get_torch_compile_options(
 from typing import Any, Callable, TypeVar
 F = TypeVar("F", bound=Callable[..., Any])
 def noop(*args: Any, **kwargs: Any):
-    """
-    A do-nothing decorator/adapter.
-
-    Works as:
-      - @noop
-      - @noop(...)
-      - noop(func, ...)
-    
-    Returns the original function unchanged in every case.
-    """
-    # If used like noop(func, **kwargs) or as @noop on a function,
-    # the first positional arg will be the function. Return it directly.
+    """No-op decorator/adapter usable as @noop, @noop(...), or noop(func, ...)."""
+    # @noop / noop(func, ...): first positional arg is the function.
     if args and callable(args[0]):
         return torch.compiler.disable(args[0]) # type: ignore[return-value]
 
-    # Otherwise, used as @noop(...): return a decorator that returns the function unchanged.
+    # @noop(...): return a decorator.
     def _decorator(func: F) -> F:
         return torch.compiler.disable(func)
     return _decorator

--- a/unsloth_zoo/temporary_patches/deepseek_v3_moe.py
+++ b/unsloth_zoo/temporary_patches/deepseek_v3_moe.py
@@ -46,12 +46,9 @@ from .moe_utils import (
 )
 
 def patch_deepseek_v3():
-    """
-    Patches DeepSeekV3 MoE to support Split LoRA using grouped GEMM.
-    """
+    """Patch DeepSeekV3 MoE to support Split LoRA via grouped GEMM."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # Try to import the DeepSeekV3 MoE classes
     try:
         from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
             DeepseekV3NaiveMoe,
@@ -60,19 +57,15 @@ def patch_deepseek_v3():
             DeepseekV3Config,
         )
     except Exception as e:
-        # DeepSeekV3 not available yet
-        return
+        return  # DeepSeekV3 not available yet
 
-    # Check if already patched
     if hasattr(DeepseekV3NaiveMoe, "_unsloth_already_patched"):
         return
 
     # Patch PEFT ParamWrapper for separated LoRA weights
     patch_param_wrapper_for_moe()
 
-    # ====================================================================
-    # Define LoRA extraction function for DeepSeekV3 (Standard Format)
-    # ====================================================================
+    # LoRA extraction function for DeepSeekV3 (standard format)
     def _deepseek_v3_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts):
         return extract_moe_lora_weights_for_grouped_mm(
             wrapper,
@@ -85,27 +78,16 @@ def patch_deepseek_v3():
             logger_obj=logger,
         )
 
-    # Register the extractor on the NaiveMoe class (avoid binding as instance method)
+    # Register extractor on the class (staticmethod, not bound) + mark model type
     DeepseekV3NaiveMoe._unsloth_lora_extractor_fn = staticmethod(_deepseek_v3_lora_extractor)
-    # Also mark the model type for weight preprocessing
     DeepseekV3NaiveMoe._unsloth_model_type = "deepseek_v3"
     DeepseekV3NaiveMoe._unsloth_already_patched = True
 
-    # ====================================================================
-    # Patch DeepseekV3NaiveMoe.forward to use backend dispatch in moe_utils
-    # ====================================================================
-
-    # Apply patch to DeepseekV3NaiveMoe
+    # DeepseekV3NaiveMoe.forward -> backend dispatch in moe_utils
     patch_function(DeepseekV3NaiveMoe, "forward", get_forward_moe_backend())
 
-    # ====================================================================
-    # Patch DeepseekV3MoE.forward to mark model type
-    # ====================================================================
-
     def patched_moe_forward(self, hidden_states):
-        """
-        Patched forward that adds model type marker for proper LoRA extraction.
-        """
+        """Forward that marks model type for proper LoRA extraction."""
         residuals = hidden_states
         orig_shape = hidden_states.shape
         router_logits = self.gate(hidden_states)
@@ -121,16 +103,13 @@ def patch_deepseek_v3():
         hidden_states = hidden_states + self.shared_experts(residuals)
         return hidden_states
 
-    # Apply patch to DeepseekV3MoE
     patch_function(DeepseekV3MoE, "forward", patched_moe_forward)
 
     if UNSLOTH_ENABLE_LOGGING:
         logger.info("Unsloth: Patched DeepSeekV3 MoE for Split LoRA support.")
 
-    # ====================================================================
-    # Patch DeepseekV3ForCausalLM.forward for GRPO training
-    # When UNSLOTH_RETURN_HIDDEN_STATES=1, return hidden_states instead of logits
-    # ====================================================================
+    # Patch DeepseekV3ForCausalLM.forward for GRPO: return hidden_states instead
+    # of logits when UNSLOTH_RETURN_HIDDEN_STATES=1.
     try:
         from transformers.models.deepseek_v3.modeling_deepseek_v3 import (
             DeepseekV3ForCausalLM,
@@ -158,7 +137,6 @@ def patch_deepseek_v3():
             RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
 
             if not RETURN_HIDDEN_STATES:
-                # Normal forward pass
                 return _original_causal_lm_forward(
                     self,
                     input_ids=input_ids,
@@ -174,7 +152,6 @@ def patch_deepseek_v3():
                     **kwargs,
                 )
 
-            # RETURN_HIDDEN_STATES mode - return hidden_states instead of logits
             outputs = self.model(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
@@ -189,14 +166,12 @@ def patch_deepseek_v3():
 
             hidden_states = outputs.last_hidden_state
 
-            # Apply slice_indices to hidden_states (same indexing as for logits)
-
-            # DeepSeekV3 implementation of logits_to_keep handling:
+            # Slice hidden_states the same way logits would be (logits_to_keep)
             if logits_to_keep != 0:
                 slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
                 hidden_states = hidden_states[:, slice_indices, :]
 
-            # Return hidden_states as "logits" for GRPO to use
+            # Return hidden_states as "logits" for GRPO
             return CausalLMOutputWithPast(
                 loss=None,
                 logits=hidden_states,
@@ -221,5 +196,4 @@ def patch_deepseek_v3():
     return True
 
 
-# Register the patch - it will be called when unsloth is imported
 TEMPORARY_PATCHES.append(patch_deepseek_v3)

--- a/unsloth_zoo/temporary_patches/flex_attention_bwd.py
+++ b/unsloth_zoo/temporary_patches/flex_attention_bwd.py
@@ -15,26 +15,18 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
-Patch for flex_attention backward kernel shared memory OOM on constrained GPUs.
+Patch flex_attention backward shared-memory OOM on constrained GPUs.
 
 On GPUs with limited shared memory per SM (RTX 3090/4090/5090, RTX PRO 6000,
-etc. -- typically ~100KB), the flex_attention backward kernel configs can exceed
-shared memory limits for large head_dims (e.g., 256 in Gemma3). For example,
-the default config (BLOCK=64, num_stages=2) requires ~141KB, but the hardware
-only has ~101KB.
+~100KB), the backward configs can exceed the limit for large head_dims (e.g.
+256 in Gemma3): the default BLOCK=64, num_stages=2 needs ~141KB vs ~101KB.
 
-This patch intercepts the backward config selection and adds safe fallback
-configs estimated to fit within the GPU's actual shared memory limit. The
-shared memory estimation uses:
+We intercept backward config selection and add safe fallbacks estimated via
     shmem ~ num_stages * max_block * head_dim * dtype_size * 2 + OVERHEAD
-where OVERHEAD is ~10KB from Triton runtime. This formula was validated
-against real crashes (estimated 141,312 vs actual 140,800 bytes).
+(OVERHEAD ~10KB from Triton; validated 141,312 estimated vs 140,800 actual).
+Fallbacks are only added when a config is estimated to exceed the limit.
 
-If the default configs already fit in shared memory, they are returned
-unchanged. Safe fallbacks are only added when a config is estimated to exceed
-the limit.
-
-This is a no-op on torch versions that do not have FlexBwDConfig (< 2.10).
+No-op on torch < 2.10 (no FlexBwDConfig).
 """
 
 import torch
@@ -47,10 +39,10 @@ _SHMEM_OVERHEAD = 10240  # 10KB, slightly conservative
 
 
 def _estimate_shmem(block_size, num_stages, head_dim, dtype):
-    """Estimate shared memory for a flex_attention backward config.
+    """Estimate shared memory for a backward config.
 
-    The backward kernel pipelines two tensor loads (qT + dO or kT + vT)
-    with num_stages copies each in shared memory.
+    The kernel pipelines two tensor loads (qT+dO or kT+vT), num_stages copies
+    each in shared memory.
     """
     dtype_size = 2 if dtype in (torch.bfloat16, torch.float16) else 4
     return num_stages * block_size * head_dim * dtype_size * 2 + _SHMEM_OVERHEAD
@@ -103,18 +95,16 @@ def patch_flex_attention_bwd_configs():
 
         def make_patched(orig):
             def patched_get_flex_attn_bwd_configs(self, head_dim, dtype):
-                # Query shared memory limit from the current device so this
-                # works correctly in heterogeneous multi-GPU setups.
+                # Per-device limit so heterogeneous multi-GPU setups work.
                 device = torch.cuda.current_device()
                 shmem_limit = torch.cuda.get_device_properties(device).shared_memory_per_multiprocessor
 
-                # Get original configs first
                 try:
                     configs = list(orig(self, head_dim, dtype))
                 except Exception:
                     configs = []
 
-                # Check if any original config exceeds shared memory
+                # Patch only if some original config exceeds shared memory.
                 needs_patch = False
                 for c in configs:
                     max_block = max(c.block_m1, c.block_n1, c.block_m2, c.block_n2)

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -71,7 +71,7 @@ def _prepare_gemma3_sdpa_attention_mask(attention_mask, query_states, key_states
 
 
 def _make_gemma3_attn_forwards(forward_function, has_cache_position):
-    """Build past_key_value / past_key_values forward variants for Gemma3Attention."""
+    """Build the past_key_value / past_key_values forward variants."""
     functions = []
     if has_cache_position:
         def forward_past_key_value(self, hidden_states, position_embeddings=None, attention_mask=None, past_key_value=None, cache_position=None, **kwargs):
@@ -259,9 +259,8 @@ def patch_Gemma3ForConditionalGeneration_causal_mask():
         if using_static_cache:
             target_length = past_key_values.get_max_cache_shape()
         elif HAS_HYBRID_CACHE and isinstance(past_key_values, HybridCache):
-            # HAS_HYBRID_CACHE gates the isinstance because transformers 5.x
-            # removed HybridCache; the fallback typing.Any from utils.py
-            # would otherwise raise TypeError here.
+            # Gated on HAS_HYBRID_CACHE: transformers 5.x removed HybridCache,
+            # and the typing.Any fallback from utils.py would raise here.
             target_length = past_key_values.get_max_cache_shape()
         else:
             target_length = (
@@ -346,13 +345,11 @@ def patch_Gemma3RMSNorm():
         return raise_error("Gemma3RMSNorm.forward", e)
 
     def forward(self, x): # x can be fp32 (from embeddings) or fp16 (from MLP/Attn)
-        # Internals in fp32
         x_fp32 = x.to(torch.float32)
         variance = x_fp32.pow(2).mean(-1, keepdim=True)
         hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + self.eps)
 
-        # self.weight is bf16 (from vision.py loading if UNSLOTH_FORCE_FLOAT32="1")
-        # So, cast self.weight to fp32 for the (1.0 + weight) operation
+        # self.weight may be bf16; cast to fp32 for the (1.0 + weight) op.
         output_fp32 = hidden_states_fp32 * (1.0 + self.weight.to(torch.float32))
 
         # Clamp to fp16 range before casting back to fp16
@@ -466,21 +463,18 @@ def patch_Gemma3Attention():
         **kwargs: KWARGS_TYPE,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
         bsz, q_len, _ = hidden_states.shape
-        input_shape = hidden_states.shape[:-1] # For reshaping o_proj output later
+        input_shape = hidden_states.shape[:-1]
 
-        # Determine head shapes
-        # Assuming these attributes are standard for Gemma3Attention
-        # If not, they might come from self.config
+        # Head shapes (fall back to config if attrs are absent)
         num_heads = getattr(self, "num_heads", self.config.num_attention_heads)
         num_key_value_heads = getattr(self, "num_key_value_heads", self.config.num_key_value_heads)
         head_dim = self.head_dim
 
-        # For projections view: (bsz, q_len, num_specific_heads, head_dim)
+        # Projection view shape: (bsz, q_len, num_specific_heads, head_dim)
         query_hidden_shape = (bsz, q_len, num_heads, head_dim)
         kv_hidden_shape    = (bsz, q_len, num_key_value_heads, head_dim)
 
         # 1. Projections (q, k, v) in fp16
-        # hidden_states is already fp16. Weights of q_proj, k_proj, v_proj are fp16.
         query_states_fp16 = self.q_proj(hidden_states) # output fp16
         key_states_fp16   = self.k_proj(hidden_states) # output fp16
         value_states_fp16 = self.v_proj(hidden_states) # output fp16
@@ -571,8 +565,7 @@ def patch_Gemma3Attention():
                 getattr(self, "sliding_window", None),
             )
             is_causal = query_states_fp32.shape[2] > 1 and attn_mask_for_sdpa is None and getattr(self, "is_causal", True)
-            # Shapes (e.g. query.shape[2]) are tensors during jit tracing, resulting in `is_causal` being a tensor.
-            # We convert it to a bool for the SDPA kernel that only accepts bools.
+            # During jit tracing shapes are tensors, so is_causal may be a tensor; SDPA needs a bool.
             if torch_jit_is_tracing() and isinstance(is_causal, torch.Tensor): is_causal = is_causal.item()
             attn_output_fp32 = scaled_dot_product_attention(
                 query_states_fp32.contiguous(),
@@ -586,15 +579,13 @@ def patch_Gemma3Attention():
             )
             attn_weights = None # Defaulting to None
 
-        # 7. Reshape and Downcast for Output Projection
-        # SDPA returns (bsz, num_heads, q_len, head_dim) and needs transposing
-        # flex_attention returns (bsz, q_len, num_heads, head_dim) already transposed
+        # 7. Reshape and downcast for output projection.
+        # SDPA returns (bsz, heads, q_len, head_dim) needing transpose;
+        # flex_attention returns (bsz, q_len, heads, head_dim) already transposed.
         if attn_impl != "flex_attention":
             attn_output_fp32 = attn_output_fp32.transpose(1, 2).contiguous()
 
-        # Reshape to (bsz, q_len, num_query_heads * head_dim) which is (bsz, q_len, model_hidden_size)
-        # Using -1 for the last dimension is robust and aligns with your original example.
-        attn_output_fp32 = attn_output_fp32.reshape(bsz, q_len, -1) # REVISED FIX
+        attn_output_fp32 = attn_output_fp32.reshape(bsz, q_len, -1)
 
         attn_output_fp16 = attn_output_fp32.to(torch.float16)
 
@@ -708,21 +699,18 @@ def patch_Gemma3Attention_generic():
         **kwargs: KWARGS_TYPE,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
         bsz, q_len, _ = hidden_states.shape
-        input_shape = hidden_states.shape[:-1] # For reshaping o_proj output later
+        input_shape = hidden_states.shape[:-1]
 
-        # Determine head shapes
-        # Assuming these attributes are standard for Gemma3Attention
-        # If not, they might come from self.config
+        # Head shapes (fall back to config if attrs are absent)
         num_heads = getattr(self, "num_heads", self.config.num_attention_heads)
         num_key_value_heads = getattr(self, "num_key_value_heads", self.config.num_key_value_heads)
         head_dim = self.head_dim
 
-        # For projections view: (bsz, q_len, num_specific_heads, head_dim)
+        # Projection view shape: (bsz, q_len, num_specific_heads, head_dim)
         query_hidden_shape = (bsz, q_len, num_heads, head_dim)
         kv_hidden_shape    = (bsz, q_len, num_key_value_heads, head_dim)
 
         # 1. Projections (q, k, v) in fp16
-        # hidden_states is already fp16. Weights of q_proj, k_proj, v_proj are fp16.
         query_states_fp16 = self.q_proj(hidden_states) # output fp16
         key_states_fp16   = self.k_proj(hidden_states) # output fp16
         value_states_fp16 = self.v_proj(hidden_states) # output fp16
@@ -813,8 +801,7 @@ def patch_Gemma3Attention_generic():
                 getattr(self, "sliding_window", None),
             )
             is_causal = query_states_fp32.shape[2] > 1 and attn_mask_for_sdpa is None and getattr(self, "is_causal", True)
-            # Shapes (e.g. query.shape[2]) are tensors during jit tracing, resulting in `is_causal` being a tensor.
-            # We convert it to a bool for the SDPA kernel that only accepts bools.
+            # During jit tracing shapes are tensors, so is_causal may be a tensor; SDPA needs a bool.
             if torch_jit_is_tracing() and isinstance(is_causal, torch.Tensor): is_causal = is_causal.item()
             attn_output_fp32 = scaled_dot_product_attention(
                 query_states_fp32.contiguous(),
@@ -828,15 +815,13 @@ def patch_Gemma3Attention_generic():
             )
             attn_weights = None # Defaulting to None
 
-        # 7. Reshape and Downcast for Output Projection
-        # SDPA returns (bsz, num_heads, q_len, head_dim) and needs transposing
-        # flex_attention returns (bsz, q_len, num_heads, head_dim) already transposed
+        # 7. Reshape and downcast for output projection.
+        # SDPA returns (bsz, heads, q_len, head_dim) needing transpose;
+        # flex_attention returns (bsz, q_len, heads, head_dim) already transposed.
         if attn_impl != "flex_attention":
             attn_output_fp32 = attn_output_fp32.transpose(1, 2).contiguous()
 
-        # Reshape to (bsz, q_len, num_query_heads * head_dim) which is (bsz, q_len, model_hidden_size)
-        # Using -1 for the last dimension is robust and aligns with your original example.
-        attn_output_fp32 = attn_output_fp32.reshape(bsz, q_len, -1) # REVISED FIX
+        attn_output_fp32 = attn_output_fp32.reshape(bsz, q_len, -1)
 
         attn_output_fp16 = attn_output_fp32#.to(torch.float16)
 

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -21,86 +21,45 @@ from .utils import raise_error, patch_function
 
 
 # ============================================================================
-# Gemma-4 variant summary (affects which fix engages which model):
-#
-#   - Gemma-4 31B:      num_kv_shared_layers = 0  -> Fix 1 engages, Fix 2 is a no-op
-#   - Gemma-4 26B-A4B:  num_kv_shared_layers = 0  -> Fix 1 engages, Fix 2 is a no-op
-#   - Gemma-4 E4B:      num_kv_shared_layers = 18 -> Fix 1 is a no-op, Fix 2 engages
-#   - Gemma-4 E2B:      num_kv_shared_layers = 20 -> Fix 1 is a no-op, Fix 2 engages
-#   - Gemma3n:          num_kv_shared_layers = 15 -> both are no-ops (different model)
-#   - Llama/Qwen/etc:   attribute absent          -> both are no-ops
-#
-# The two fixes are mutually exclusive at runtime: Fix 1 only acts when the
-# value is exactly 0, Fix 2 only acts when the value is strictly greater
-# than 0. Non-Gemma-4 models never hit either branch because the attribute
-# is not present.
+# Gemma-4 variant summary (which fix engages which model):
+#   - 31B / 26B-A4B:  num_kv_shared_layers = 0  -> Fix 1 engages, Fix 2 no-op
+#   - E4B (18) / E2B (20): num_kv_shared_layers > 0 -> Fix 1 no-op, Fix 2 engages
+#   - Gemma3n (15) / Llama / Qwen / etc.: both no-ops (different / absent attr)
+# The fixes are mutually exclusive: Fix 1 acts only when the value is exactly
+# 0, Fix 2 only when it is > 0.
 # ============================================================================
 
 
 # ============================================================================
 # Fix 1: num_kv_shared_layers == 0 cache-init bug (Gemma-4 31B and 26B-A4B).
 #
-# Root cause: transformers/cache_utils.py DynamicCache.__init__ (and StaticCache.
-# __init__) contains:
-#
+# Root cause: transformers/cache_utils.py DynamicCache/StaticCache __init__:
 #     if hasattr(decoder_config, "num_kv_shared_layers"):
 #         layer_types = layer_types[: -decoder_config.num_kv_shared_layers]
+# When num_kv_shared_layers == 0, `layer_types[:-0] == []`, so the cache gets
+# zero layer slots and the first attention forward raises IndexError from
+# Cache.update. Present in transformers 4.57.6, 5.5.0, and main (filed upstream).
 #
-# When num_kv_shared_layers == 0 (Gemma-4 26B-A4B and 31B both ship this way),
-# Python evaluates `layer_types[:-0] == layer_types[:0] == []`, so the cache is
-# constructed with zero layer slots and the very first attention forward
-# raises `IndexError: list index out of range` from `Cache.update`.
+# Primary fix (proxy): patch get_text_config on Gemma4Config / Gemma4TextConfig
+# to return a proxy that raises AttributeError for num_kv_shared_layers when it
+# is 0, so the upstream hasattr check is False and the buggy slice is skipped.
+# Preferred over wrapping Cache.__init__ because it touches only Gemma-4
+# classes, mutates nothing, and survives the compiler cache. Downstream reads
+# of config.num_kv_shared_layers still see 0 (they read self.config directly).
 #
-# Bug confirmed present in transformers 4.57.6, 5.5.0, and main.
-# Filed for upstream fix.
-#
-# Primary fix (proxy approach): patch `get_text_config` on Gemma4Config and
-# Gemma4TextConfig so that, when the resolved text config has
-# num_kv_shared_layers == 0, a thin proxy is returned that raises
-# AttributeError for that attribute. The upstream `hasattr(decoder_config,
-# "num_kv_shared_layers")` check becomes False, the buggy slice is skipped,
-# and the cache is built with the full layer list.
-#
-# Why the proxy approach is preferred over wrapping Cache.__init__:
-#   - Only Gemma-4 classes are touched. DynamicCache and StaticCache are
-#     byte-identical to upstream for every other model.
-#   - No attribute mutation: the real Gemma4TextConfig is never modified, so
-#     there are no thread-safety, finally-block, or __slots__ concerns.
-#   - Survives Unsloth's compiler cache (`unsloth_compiled_cache/
-#     unsloth_compiled_module_gemma4.py`) trivially. The compiler copies
-#     attention/MLP forward methods but never cache code, and the config
-#     classes are not touched by the compiler at all.
-#   - Downstream reads of `config.num_kv_shared_layers` (e.g.
-#     Gemma4TextMLP.__init__, Gemma4TextAttention.__init__) still see the
-#     original 0 because they read from `self.config` directly, not from
-#     `self.config.get_text_config(...)`.
-#
-# Fallback (wrapper approach): a hardened Cache.__init__ wrapper is also
-# installed as defense-in-depth. It only fires when the proxy path did not
-# apply (e.g. a future transformers refactor that bypasses get_text_config).
-# The wrapper uses a try/finally to hide-and-restore the attribute and bails
-# out to the original init on any mutation failure (rather than converting
-# IndexError -> TypeError by setting a None sentinel).
+# Fallback (wrapper): a hardened Cache.__init__ wrapper is installed as
+# defense-in-depth; it only fires if the proxy path did not apply.
 # ============================================================================
 
 
 class _Gemma4KVSharedSafeProxy:
-    """Thin read-only proxy around Gemma4TextConfig.
+    """Read-only proxy around Gemma4TextConfig hiding num_kv_shared_layers when 0.
 
-    When `num_kv_shared_layers == 0`, `hasattr(proxy, "num_kv_shared_layers")`
-    must return False so that upstream's `layer_types[:-0]` slice is skipped.
-    All other attribute lookups (`sliding_window`, `layer_types`,
-    `num_hidden_layers`, etc.) forward to the real config object.
-
-    Important: Python looks up dunder methods on the TYPE, not the instance,
-    so `__getattr__` alone is NOT sufficient for iteration, len, etc. We
-    explicitly forward every dunder method that PreTrainedConfig is known
-    to rely on so the proxy survives callers like
-    `PreTrainedConfig.validate_token_ids`, which does
-    `for value in self.get_text_config(decoder=True): ...`.
-
-    `__slots__` avoids creating a `__dict__`, which keeps the proxy cheap
-    and lets default `copy`/`deepcopy` traverse only the `_real` slot.
+    Makes `hasattr(proxy, "num_kv_shared_layers")` False so upstream's
+    `layer_types[:-0]` slice is skipped; all other lookups forward to the real
+    config. Dunder methods are forwarded explicitly because Python resolves them
+    on the type, so callers like PreTrainedConfig.validate_token_ids (which
+    iterates the config) still work. `__slots__` keeps the proxy cheap.
     """
 
     __slots__ = ("_real",)
@@ -109,8 +68,7 @@ class _Gemma4KVSharedSafeProxy:
         object.__setattr__(self, "_real", real)
 
     def __getattr__(self, name):
-        # Only invoked when normal attribute lookup fails (i.e. not a slot
-        # and not a method of this proxy class).
+        # Only invoked when normal attribute lookup fails.
         if name == "num_kv_shared_layers":
             raise AttributeError(
                 "num_kv_shared_layers is 0 (no KV sharing) -- hidden from "
@@ -119,13 +77,10 @@ class _Gemma4KVSharedSafeProxy:
         return getattr(object.__getattribute__(self, "_real"), name)
 
     def get_text_config(self, decoder=None, encoder=None):
-        # If upstream recursively calls get_text_config on the proxy, return
-        # self so the proxy is not unwrapped back into a raw config.
+        # Return self so recursive get_text_config calls don't unwrap the proxy.
         return self
 
-    # ---- dict-like dunder forwarding ----
-    # PreTrainedConfig.__iter__ yields attribute names from self.__dict__.
-    # Validators such as validate_token_ids rely on this iteration.
+    # ---- dict-like dunder forwarding (used by config validators) ----
     def __iter__(self):
         return iter(object.__getattribute__(self, "_real"))
 
@@ -173,10 +128,7 @@ class _Gemma4KVSharedSafeProxy:
 
 
 def _wrap_get_text_config_for_kv_zero(cls):
-    """Replace `cls.get_text_config` with a version that wraps the result
-    in `_Gemma4KVSharedSafeProxy` whenever the resolved config has
-    `num_kv_shared_layers == 0`. Idempotent.
-    """
+    """Wrap cls.get_text_config to return a proxy when num_kv_shared_layers == 0. Idempotent."""
     _sentinel = "_unsloth_kv_shared_get_text_config_patched"
     if getattr(cls.get_text_config, _sentinel, False):
         return
@@ -196,13 +148,11 @@ def _wrap_get_text_config_for_kv_zero(cls):
 
 
 def patch_Gemma4Config_kv_shared_zero():
-    """Patch Gemma4Config.get_text_config. This is the path exercised by
-    StaticCache (called from transformers.generation.utils) and any caller
-    that passes the top-level `model.config` to a cache constructor."""
+    """Patch Gemma4Config.get_text_config (StaticCache / top-level config path)."""
     try:
         from transformers.models.gemma4.configuration_gemma4 import Gemma4Config
     except ImportError:
-        # transformers < 5.x (e.g. 4.57.6) has no Gemma-4 -> nothing to patch.
+        # transformers < 5.x has no Gemma-4 -> nothing to patch.
         return
     except Exception as e:
         return raise_error("Gemma4Config.get_text_config kv_shared_zero fix", e)
@@ -215,10 +165,7 @@ TEMPORARY_PATCHES.append(patch_Gemma4Config_kv_shared_zero)
 
 
 def patch_Gemma4TextConfig_kv_shared_zero():
-    """Patch Gemma4TextConfig.get_text_config. This is the path exercised by
-    DynamicCache when `Gemma4TextModel.forward` auto-constructs the cache
-    with `DynamicCache(config=self.config)` where `self.config` is the
-    already-nested Gemma4TextConfig."""
+    """Patch Gemma4TextConfig.get_text_config (DynamicCache auto-construct path)."""
     try:
         from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
     except ImportError:
@@ -234,29 +181,14 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextConfig_kv_shared_zero)
 
 
 # ----------------------------------------------------------------------------
-# Defense-in-depth: hardened Cache.__init__ wrapper.
-#
-# This only takes effect if the proxy patches above did NOT apply (for
-# example, a hypothetical future transformers that bypasses get_text_config,
-# or a third-party composite model that wraps Gemma4TextConfig without
-# exposing it via get_text_config). In the steady state this wrapper is a
-# pure pass-through: the proxy catches the bug first.
+# Defense-in-depth: hardened Cache.__init__ wrapper, only active if the proxy
+# patches above did not apply. In steady state it is a pure pass-through.
 # ----------------------------------------------------------------------------
 
 def _make_kv_shared_zero_safe_init(_orig_init, _resolve_decoder_config):
-    """Return a hardened `__init__` wrapper.
-
-    Behavior:
-      1. Resolve the decoder config the cache class will see.
-      2. If num_kv_shared_layers is present AND equals 0 AND we have not
-         already been bypassed by the proxy (the proxy raises AttributeError
-         from hasattr, so the check short-circuits to pass-through), then
-         transiently delete the attribute and call the original init inside
-         a try/finally that restores the value.
-      3. If the attribute cannot be deleted (e.g. dataclass __slots__, frozen
-         config, C extension descriptor), BAIL OUT to the original init --
-         preserving the original IndexError rather than converting it to a
-         TypeError via a None sentinel (this was a bug in the first draft).
+    """Hardened cache __init__: transiently delete num_kv_shared_layers==0 around
+    the original init (try/finally restores it), bailing to the original init if
+    the attribute cannot be deleted so the upstream error surfaces unchanged.
     """
 
     def __init__(self, *args, **kwargs):
@@ -266,10 +198,8 @@ def _make_kv_shared_zero_safe_init(_orig_init, _resolve_decoder_config):
         except Exception:
             decoder_config = None
 
-        # Proxy path already bypassed the buggy branch via AttributeError,
-        # so hasattr returns False for the Gemma-4 zero case and this whole
-        # block is skipped. This check only fires if the proxy patch did not
-        # apply for some reason.
+        # Skipped when the proxy path applied (hasattr returns False there);
+        # this only fires if the proxy patch did not apply.
         if (
             decoder_config is not None
             and hasattr(decoder_config, "num_kv_shared_layers")
@@ -278,9 +208,7 @@ def _make_kv_shared_zero_safe_init(_orig_init, _resolve_decoder_config):
             try:
                 del decoder_config.num_kv_shared_layers
             except (AttributeError, TypeError):
-                # Attribute cannot be mutated -- fall through to original
-                # init and let the upstream error surface (no worse than
-                # without the patch).
+                # Cannot mutate; fall through to original init.
                 return _orig_init(self, *args, **kwargs)
             try:
                 _orig_init(self, *args, **kwargs)
@@ -358,56 +286,28 @@ TEMPORARY_PATCHES.append(patch_StaticCache_kv_shared_zero)
 # ============================================================================
 # Fix 2: use_cache=False with KV sharing produces garbage (Gemma-4 E2B and E4B).
 #
-# Root cause: Gemma4TextAttention.forward uses
+# Gemma4TextAttention.forward only reuses stored K/V from the cache for
+# is_kv_shared_layer layers; with use_cache=False, Gemma4TextModel.forward
+# never auto-constructs the cache, so those layers recompute K/V from the wrong
+# hidden states. Symptoms: training loss explodes, logits become garbage.
+# See huggingface/transformers#45242.
 #
-#     if self.is_kv_shared_layer and past_key_values is not None:
-#         key_states, value_states = past_key_values.shared_layers[...]
-#     else:
-#         # compute K/V locally from current hidden_states
+# Affects num_kv_shared_layers > 0 (E2B=20, E4B=18); 31B / 26B-A4B (=0) are
+# unaffected.
 #
-# The cache is the ONLY place where the KV values produced by the
-# "store_full_length_kv" layers are stashed for later reuse by the
-# is_kv_shared_layer layers. When the caller passes `use_cache=False`,
-# Gemma4TextModel.forward skips auto-construction of past_key_values:
-#
-#     if use_cache and past_key_values is None:
-#         past_key_values = DynamicCache(config=self.config)
-#
-# so every is_kv_shared_layer falls through to the `else` branch and
-# recomputes K/V from the current layer's hidden states, which is wrong.
-# Symptoms: training loss explodes, logits become garbage. See
-# huggingface/transformers#45242.
-#
-# Affects models with num_kv_shared_layers > 0 (Gemma-4 E2B=20, E4B=18).
-# Does NOT affect 31B or 26B-A4B (num_kv_shared_layers=0 -> no layer is
-# is_kv_shared_layer -> path is byte-identical with or without cache).
-#
-# Fix: wrap Gemma4TextModel.forward (and Gemma4Model.forward for the
-# multimodal parent) so that when num_kv_shared_layers > 0 and the caller
-# passes past_key_values=None with use_cache falsy, we transparently
-# construct a DynamicCache, run the original forward, then drop
-# past_key_values from the returned `BaseModelOutputWithPast` to preserve
-# the caller's use_cache=False semantics.
-#
-# This wrapper is a pure pass-through for:
-#   - Any model that doesn't expose num_kv_shared_layers (not Gemma-4)
-#   - Gemma-4 31B / 26B-A4B (num_kv_shared_layers == 0)
-#   - Any Gemma-4 call that already has past_key_values or use_cache=True
+# Fix: wrap Gemma4TextModel.forward (and Gemma4Model.forward) so that when KV
+# sharing is active and the caller passes past_key_values=None with use_cache
+# falsy, we build a DynamicCache, run the original forward, then drop it from
+# the output to preserve use_cache=False semantics. Pass-through otherwise.
 # ============================================================================
 
 def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):
-    """Wrap a Gemma-4 text-model-style forward so it builds an internal
-    DynamicCache when KV sharing is active but the caller passed use_cache=False.
-    The internal cache is nulled out in the returned output so the caller's
-    semantics are preserved.
+    """Wrap a Gemma-4 forward to build an internal DynamicCache when KV sharing
+    is active but the caller passed use_cache=False, nulling it from the output.
 
-    Argument resolution uses `inspect.signature.bind_partial` so that
-    `past_key_values` and `use_cache` are correctly resolved whether the
-    caller passed them positionally or by keyword. Calling the inner forward
-    via `bound.args` / `bound.kwargs` (rather than mixing positional and
-    keyword) avoids the `TypeError: got multiple values for argument`
-    case that a naive `kwargs[...] = ...` injection would trigger when the
-    caller already passed the same argument positionally.
+    Uses inspect.signature.bind_partial so past_key_values / use_cache resolve
+    whether passed positionally or by keyword, and calls the inner forward via
+    bound.args/bound.kwargs to avoid duplicate-argument TypeErrors.
     """
     import inspect
 
@@ -420,12 +320,11 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):
         num_kv_shared = getattr(
             getattr(self, "config", None), "num_kv_shared_layers", 0
         )
-        # Nothing to do for variants without KV sharing (31B, 26B-A4B, non-Gemma-4).
+        # No-op without KV sharing (31B, 26B-A4B, non-Gemma-4).
         if not num_kv_shared or num_kv_shared <= 0:
             return _orig_forward(self, *args, **kwargs)
 
-        # Resolve past_key_values and use_cache from EITHER args or kwargs.
-        # bind_partial handles both positional and keyword forms uniformly.
+        # Resolve past_key_values / use_cache from args or kwargs.
         if _sig is None:
             # Fallback if signature introspection failed: kwargs-only path.
             past_key_values = kwargs.get("past_key_values", None)
@@ -448,50 +347,38 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):
             else getattr(self.config, "use_cache", True)
         )
 
-        # Only intervene when the original forward would have left
-        # past_key_values as None (i.e. use_cache is explicitly False or
-        # config.use_cache is False and the caller did not pass one in).
+        # Only intervene when the original forward would leave past_key_values
+        # as None (use_cache falsy and no cache passed in).
         if past_key_values is not None or use_cache_resolved:
             return _orig_forward(self, *args, **kwargs)
 
-        # Build a local cache JUST for cross-layer KV sharing; do not leak
-        # it back to the caller since they asked for use_cache=False.
+        # Local cache for cross-layer KV sharing only; not leaked to the caller.
         try:
             from transformers.cache_utils import DynamicCache
         except Exception:
             return _orig_forward(self, *args, **kwargs)
 
-        # Inject the cache and force use_cache=True on the inner call so the
-        # original forward takes the same mask/position path it would have
-        # with a real cache. The outer result is cleaned up below to preserve
-        # the caller's use_cache=False contract.
+        # Inject the cache and force use_cache=True so the inner forward takes
+        # the same mask/position path; the result is cleaned up below.
         if arguments is not None:
             arguments["past_key_values"] = DynamicCache(config=self.config)
             arguments["use_cache"] = True
-            # Re-bind through args/kwargs to avoid duplicate-keyword TypeErrors
-            # if the caller had passed past_key_values or use_cache positionally.
+            # bound.args/kwargs derive from `arguments`, so the injected values
+            # land in the correct slot without duplicate-keyword TypeErrors.
             inner_args = bound.args
             inner_kwargs = bound.kwargs
-            # bound.args / bound.kwargs are derived from `arguments`, so they
-            # already contain the injected values in the correct slot.
             result = _orig_forward(*inner_args, **inner_kwargs)
         else:
             kwargs["past_key_values"] = DynamicCache(config=self.config)
             kwargs["use_cache"] = True
             result = _orig_forward(self, *args, **kwargs)
 
-        # Preserve the caller's use_cache=False contract: null the cache
-        # from EVERY shape the result might have:
-        #   1. ModelOutput (BaseModelOutputWithPast) -- attribute + dict slot
-        #   2. plain dict
-        #   3. tuple (Gemma4Model.forward is decorated with @can_return_tuple,
-        #      so return_dict=False produces a tuple where past_key_values is
-        #      typically the second element of BaseModelOutputWithPast.to_tuple())
+        # Null the cache from every result shape (ModelOutput, dict, tuple) to
+        # preserve the caller's use_cache=False contract.
         try:
             if isinstance(result, tuple):
-                # ModelOutput.to_tuple() drops None entries, so the cache
-                # may not be at a fixed index. Reconstruct by scanning for
-                # the injected DynamicCache instance and dropping it.
+                # to_tuple() drops None entries, so the cache index isn't fixed;
+                # scan for the injected DynamicCache and drop it.
                 injected = (
                     arguments["past_key_values"]
                     if arguments is not None
@@ -500,10 +387,8 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):
                 new_items = tuple(None if x is injected else x for x in result)
                 result = new_items
             else:
-                # ModelOutput subclasses behave like dicts internally; using
-                # __setitem__ keeps both the attribute slot and the underlying
-                # OrderedDict in sync. Fall back to attribute assignment if
-                # the result does not support __setitem__.
+                # ModelOutput acts dict-like; __setitem__ keeps the attribute
+                # slot and OrderedDict in sync. Fall back to attribute assignment.
                 set_via_item = False
                 try:
                     if hasattr(result, "__setitem__") and "past_key_values" in result:
@@ -534,9 +419,7 @@ def _patch_forward_for_kv_shared_no_cache(cls):
 
 
 def patch_Gemma4TextModel_forward_kv_shared_no_cache():
-    """Patch Gemma4TextModel.forward (the language decoder). This is the class
-    that auto-creates the cache and drives per-layer attention. Fires for
-    text-only model loading (Gemma4ForCausalLM -> Gemma4TextModel)."""
+    """Patch Gemma4TextModel.forward (the language decoder that drives attention)."""
     try:
         from transformers.models.gemma4.modeling_gemma4 import Gemma4TextModel
     except ImportError:
@@ -552,10 +435,8 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextModel_forward_kv_shared_no_cache)
 
 
 def patch_Gemma4Model_forward_kv_shared_no_cache():
-    """Patch Gemma4Model.forward (the multimodal parent). Its forward calls
-    into the nested Gemma4TextModel, so patching Gemma4TextModel alone is
-    enough to fix attention, but we also wrap Gemma4Model as a safety net
-    in case a future refactor moves cache auto-creation up a level."""
+    """Patch Gemma4Model.forward (multimodal parent) as a safety net in case a
+    refactor moves cache auto-creation above Gemma4TextModel."""
     try:
         from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
     except ImportError:
@@ -570,11 +451,9 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma4Model_forward_kv_shared_no_cache)
 
 
-# ============================================================================
-# Gemma4 AudioAttention patch - fix attention_invalid_logits_value overflow in fp16
-# The config value is -1e9 which overflows fp16 max (65504).
-# On Tesla T4, autocast can downcast attn_weights to fp16, causing masked_fill to fail.
-# ============================================================================
+# Gemma4 AudioAttention: config attention_invalid_logits_value (-1e9) overflows
+# fp16 max (65504); on Tesla T4 autocast downcasts attn_weights to fp16 and
+# masked_fill fails.
 
 def patch_Gemma4AudioAttention():
     try:
@@ -590,8 +469,8 @@ def patch_Gemma4AudioAttention():
     _original_audio_attn_forward = Gemma4AudioAttention.forward
 
     def forward(self, hidden_states, position_embeddings, attention_mask=None, **kwargs):
-        # Clamp attention_invalid_logits_value to dtype-safe range before attention
-        # Only needed for fp16 (Tesla T4) where -1e9 overflows. bf16 supports up to ~3.4e38.
+        # Clamp attention_invalid_logits_value: only fp16 (Tesla T4) overflows
+        # at -1e9; bf16 supports up to ~3.4e38.
         original_value = getattr(self.config, "attention_invalid_logits_value", -1e9)
         needs_clamp = hidden_states.dtype == torch.float16 and abs(original_value) > 65000.0
         if needs_clamp:
@@ -608,10 +487,8 @@ pass
 TEMPORARY_PATCHES.append(patch_Gemma4AudioAttention)
 
 
-# ============================================================================
-# Gemma4 PEFT reload patch - make PeftModel.from_pretrained handle adapters
-# saved against Gemma4ClippableLinear.inner .linear modules.
-# ============================================================================
+# Gemma4 PEFT reload: make PeftModel.from_pretrained handle adapters saved
+# against Gemma4ClippableLinear.inner .linear modules.
 
 def patch_Gemma4ClippableLinear_peft_reload():
     try:
@@ -668,23 +545,14 @@ TEMPORARY_PATCHES.append(patch_Gemma4ClippableLinear_peft_reload)
 # Gemma-4 float16 MLP overflow fix.
 #
 # `down_proj(act_fn(gate_proj(x)) * up_proj(x))` overflows fp16 at layers.0
-# (E2B) / layers.1 (E4B): the product + fp16 matmul accumulator saturate to
-# +-inf, poison the residual stream, and generation samples NaN logits that
-# trip the CUDA categorical sampler on GRPO step ~2.
-#
-# Fix: fp32 gate*up, clamp to a safe bound, fp16 cast, nan_to_num on the
-# down_proj output. Gated on gate output dtype so bf16/fp32 users see no
-# change and no env flag is required. RMSNorm / Attention / Embedding
-# patches are unnecessary (verified by bisection - identical loss/kl/grad
-# trajectories).
+# (E2B) / layers.1 (E4B): product + matmul accumulator saturate to +-inf,
+# poison the residual stream, and generation samples NaN logits that trip the
+# CUDA categorical sampler on GRPO step ~2. Fix: fp32 gate*up, clamp to a safe
+# bound, fp16 cast, nan_to_num. Gated on gate dtype so bf16/fp32 see no change.
 
 
 def patch_Gemma4TextMLP():
-    """fp16 overflow clamp for Gemma4TextMLP.
-
-    Does gate*up in fp32, clamps to a safe fp16 bound, then nan_to_nums
-    the down_proj output. Self-gated on gate dtype - no-op on bf16/fp32.
-    """
+    """fp16 overflow clamp for Gemma4TextMLP (no-op on bf16/fp32)."""
     try:
         import transformers.models.gemma4.modeling_gemma4 as mod
     except ImportError:
@@ -694,13 +562,12 @@ def patch_Gemma4TextMLP():
     except AttributeError as e:
         return raise_error("Gemma4TextMLP.forward", e)
 
-    # Largest value representable in both fp16 and bf16 (65536 rounds to
-    # fp16 inf).
+    # Largest value representable in both fp16 and bf16 (65536 rounds to fp16 inf).
     _SAFE_FP16 = 65280.0
 
     def forward(self, x):
         gate = self.gate_proj(x)
-        # Check matmul output dtype so autocast / PEFT fp16 casts are caught.
+        # Check matmul output dtype to catch autocast / PEFT fp16 casts.
         if gate.dtype != torch.float16:
             return self.down_proj(self.act_fn(gate) * self.up_proj(x))
         product = self.act_fn(gate.float()) * self.up_proj(x).float()

--- a/unsloth_zoo/temporary_patches/gemma4_moe.py
+++ b/unsloth_zoo/temporary_patches/gemma4_moe.py
@@ -24,25 +24,22 @@ from .moe_utils import (
     get_forward_moe_backend,
     extract_moe_lora_weights_for_grouped_mm,
 )
-# Reuse the Qwen-MoE standard-layout LoRA extractor. Gemma4TextExperts has the
-# same (E, out, in) layout, the same hidden_dim / intermediate_dim attribute
-# names, and per_expert_scale is folded into top_k_weights upstream by
-# Gemma4TextRouter.forward, so no Gemma-4-specific scale handling is needed
-# inside the extractor itself.
+# Reuse the Qwen-MoE standard-layout LoRA extractor: Gemma4TextExperts shares
+# the (E, out, in) layout and attribute names, and per_expert_scale is folded
+# into top_k_weights upstream by Gemma4TextRouter.forward, so no Gemma-4
+# specific scale handling is needed inside the extractor.
 from .qwen3_moe import _make_qwen_moe_lora_extractor
 
 
 def _register_gemma4_lora_extractor(experts_cls):
     """Attach _unsloth_lora_extractor_fn to a Gemma-4 experts class.
 
-    Idempotent and safe if experts_cls is None. Without this registration,
-    moe_utils._extract_lora_from_wrapper falls through to the default
-    canonical-permutation branch, which can produce shapes whose contraction
-    dimensions do not match for torch._grouped_mm on PEFT 0.19+ swapped
-    layouts. The crash surfaces as
-        RuntimeError: contraction dimension of mat_a and mat_b must match
-    on the first training step. Gemma-4 experts share the Qwen-MoE standard
-    layout, so the Qwen extractor handles both PEFT 0.18 and 0.19 cleanly.
+    Idempotent and safe if experts_cls is None. Without it,
+    _extract_lora_from_wrapper falls through to the default canonical-permutation
+    branch, which on PEFT 0.19+ swapped layouts yields mismatched contraction
+    dims for torch._grouped_mm (RuntimeError: contraction dimension of mat_a
+    and mat_b must match) on the first step. The Qwen extractor handles both
+    PEFT 0.18 and 0.19 cleanly.
     """
     if experts_cls is None:
         return False
@@ -79,9 +76,8 @@ def _gemma4_moe_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts
 def patch_gemma4_grpo_hidden_states():
     """Patch Gemma4ForConditionalGeneration.forward for GRPO hidden states.
 
-    Independent from any MoE layout changes so that a MoE-patching failure
-    (e.g. when Transformers renames expert classes across versions) does not
-    silently disable the GRPO memory optimization.
+    Independent of MoE layout changes so a MoE-patching failure (e.g. renamed
+    expert classes) doesn't silently disable the GRPO memory optimization.
     """
     try:
         from transformers.models.gemma4.modeling_gemma4 import (
@@ -173,11 +169,8 @@ def patch_gemma4_grpo_hidden_states():
         )
 
         sliced_hidden_states = outputs.last_hidden_state
-        # Match the qwen3_moe.py idiom: only slice when the caller explicitly
-        # asked for a suffix. With logits_to_keep=0, slice(-0, None) is
-        # slice(0, None) which is a no-op; guarding avoids the accidental
-        # dependency on Python's -0 == 0 and avoids misbehavior if a caller
-        # ever passes a negative int.
+        # Only slice when a suffix is requested. logits_to_keep=0 would make
+        # slice(-0, None) a no-op anyway; guarding avoids relying on -0 == 0.
         if logits_to_keep != 0:
             slice_indices = (
                 slice(-logits_to_keep, None)
@@ -222,26 +215,23 @@ def _patch_gemma4_moe_current():
         return False
 
     if getattr(Gemma4TextExperts, "_unsloth_already_patched", False):
-        # Even when forward is already patched, make sure the extractor is
-        # registered. Guards against an older unsloth-zoo that patched
-        # forward but lacked the extractor registration.
+        # Re-register the extractor even if forward is patched, guarding
+        # against an older unsloth-zoo that patched forward without it.
         _register_gemma4_lora_extractor(Gemma4TextExperts)
         return True
 
     _moe_backend = get_forward_moe_backend()
 
     def _gemma4_experts_forward(self, hidden_states, top_k_index, top_k_weights):
-        # Current Transformers Gemma4 already folds per_expert_scale into
-        # top_k_weights inside Gemma4TextRouter.forward, so we can just
-        # dispatch to the generic grouped-GEMM backend.
+        # Gemma4TextRouter.forward already folds per_expert_scale into
+        # top_k_weights, so dispatch straight to the grouped-GEMM backend.
         return _moe_backend(self, hidden_states, top_k_index, top_k_weights)
 
     ok = patch_function(Gemma4TextExperts, "forward", _gemma4_experts_forward, force=True)
     if ok:
         Gemma4TextExperts._unsloth_lora_extractor_fn = staticmethod(_gemma4_moe_lora_extractor)
         Gemma4TextExperts._unsloth_already_patched = True
-        # Register the Qwen-MoE-style standard-layout extractor so that the
-        # grouped-mm LoRA path produces correct contraction dimensions.
+        # Register the standard-layout extractor for correct grouped-mm dims.
         _register_gemma4_lora_extractor(Gemma4TextExperts)
     return ok
 
@@ -257,7 +247,6 @@ def _patch_gemma4_moe_legacy():
         return False
 
     if getattr(Gemma4TextMoEBlock, "_unsloth_already_patched", False):
-        # Same defensive re-registration as in the current-layout path.
         _register_gemma4_lora_extractor(Gemma4TextMoEBlock)
         return True
 
@@ -306,21 +295,18 @@ def _patch_gemma4_moe_legacy():
 
     Gemma4TextMoEBlock._unsloth_lora_extractor_fn = staticmethod(_gemma4_moe_lora_extractor)
     Gemma4TextMoEBlock._unsloth_already_patched = True
-    # Legacy MoE block has the same parameter layout (E, out, in). Register
-    # the same standard-layout extractor.
+    # Legacy block shares the (E, out, in) layout; use the same extractor.
     _register_gemma4_lora_extractor(Gemma4TextMoEBlock)
     return True
 
 
 def patch_gemma4_moe():
-    """Patch Gemma4 MoE to support Split LoRA using grouped GEMM.
+    """Patch Gemma4 MoE for Split LoRA via grouped GEMM.
 
     Tries the current Transformers >= 5 layout (Gemma4TextExperts +
     Gemma4TextRouter) first, then falls back to the legacy Gemma4TextMoEBlock
-    layout. Each path returns a boolean so that a missing-class or signature
-    mismatch is surfaced via logging rather than silently disabling the patch
-    (and the GRPO hidden-states patch which previously lived in the same
-    function).
+    layout. Each path returns a boolean so a missing-class / signature mismatch
+    is surfaced via logging rather than silently disabling the patch.
     """
     patch_param_wrapper_for_moe()
 
@@ -342,11 +328,10 @@ def patch_gemma4_moe():
         )
         return
 
-    # Neither layout matched. Warn loudly via logger.warning_once so the
-    # message is visible without UNSLOTH_ENABLE_LOGGING and doesn't spam on
-    # repeated invocations. Note: this affects split-LoRA grouped-GEMM only.
-    # The GRPO hidden-states patch is a separate TEMPORARY_PATCHES entry and
-    # may still be active (checked below so the user knows the real state).
+    # Neither layout matched. warning_once is visible without
+    # UNSLOTH_ENABLE_LOGGING and doesn't spam. This affects split-LoRA
+    # grouped-GEMM only; the GRPO hidden-states patch is separate and may
+    # still be active (checked below so the user knows the real state).
     grpo_active = False
     try:
         from transformers.models.gemma4.modeling_gemma4 import (

--- a/unsloth_zoo/temporary_patches/glm4_moe.py
+++ b/unsloth_zoo/temporary_patches/glm4_moe.py
@@ -23,25 +23,18 @@ from .moe_utils import (
     extract_moe_lora_weights_for_grouped_mm,
 )
 def patch_glm4_moe():
-    """
-    Patches GLM4 MoE to support Split LoRA using grouped GEMM.
-    """
-    # Patch PEFT ParamWrapper for separated LoRA weights
+    """Patch GLM4 MoE for Split LoRA using grouped GEMM."""
     patch_param_wrapper_for_moe()
 
-    # Try to import the GLM4 MoE classes
     try:
         from transformers.models.glm4_moe_lite.modeling_glm4_moe_lite import (
             Glm4MoeLiteMoE,
             Glm4MoeLiteNaiveMoe,
         )
     except ImportError:
-        # If classes aren't available (e.g. older transformers), just return
+        # Classes absent on older transformers
         return
 
-    # ====================================================================
-    # Define LoRA extraction function for GLM4-MoE (Standard Format)
-    # ====================================================================
     def _glm4_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts):
         return extract_moe_lora_weights_for_grouped_mm(
             wrapper,
@@ -56,44 +49,25 @@ def patch_glm4_moe():
 
     Glm4MoeLiteNaiveMoe._unsloth_lora_extractor_fn = staticmethod(_glm4_lora_extractor)
 
-
-    # 1. Patch Glm4MoeLiteNaiveMoe (The Expert Layer)
-    # This delegates to moe_utils which handles the Split LoRA logic
-
-    # 2. Patch Glm4MoeLiteMoE (The MoE Block)
-    # This must be patched to delegate expert computation to naive_moe_forward instead of inlining it
-
     def moe_block_forward(self, hidden_states) -> torch.Tensor:
-        """
-        Patched forward for MoE Block.
-        Computes routing using GLM4 logic, then calls experts (NaiveMoe), then adds shared experts.
-        """
+        """MoE block forward: GLM4 routing, NaiveMoe experts, plus shared experts."""
         residuals = hidden_states
         orig_shape = hidden_states.shape
 
-        # 1. Routing
         router_logits = self.gate(hidden_states)
         topk_indices, topk_weights = self.route_tokens_to_experts(router_logits)
 
-        # Cast routing weights to match hidden_states dtype if needed
-        # (Sigmoid output is float32, hidden_states usually bf16/fp16)
+        # Sigmoid output is float32; cast to hidden_states dtype (bf16/fp16)
         topk_weights = topk_weights.to(hidden_states.dtype)
 
-        # 2. Expert Computation (delegated to Glm4MoeLiteNaiveMoe)
-        # Flatten for experts input
+        # Experts (delegated to Glm4MoeLiteNaiveMoe)
         hidden_states_flat = hidden_states.view(-1, hidden_states.shape[-1])
-
         expert_output = self.experts(hidden_states_flat, topk_indices, topk_weights)
-
-        # Reshape back
         hidden_states = expert_output.view(*orig_shape)
 
-        # 3. Shared Experts
         shared_output = self.shared_experts(residuals)
-
         return hidden_states + shared_output
 
-    # Apply patches
     patch_function(Glm4MoeLiteNaiveMoe, "forward", get_forward_moe_backend())
     patch_function(Glm4MoeLiteMoE,      "forward", moe_block_forward)
 
@@ -128,6 +102,5 @@ def patch_glm4_moe_standard():
     if UNSLOTH_ENABLE_LOGGING:
         logger.info("Unsloth: Patched GLM4 MoE (standard) for Split LoRA support.")
 
-# Register the patches
 TEMPORARY_PATCHES.append(patch_glm4_moe)
 TEMPORARY_PATCHES.append(patch_glm4_moe_standard)

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -46,14 +46,12 @@ from .utils import (
 from ..hf_utils import dtype_from_config
 torch_cuda_device = torch.cuda.device
 
-# MXFP4 configuration
-# Set UNSLOTH_MXFP4_NO_DEQUANTIZE=1 to keep MXFP4 weights quantized (requires triton_kernels)
-# Otherwise, MXFP4 weights will be dequantized to bf16 for LoRA training
+# UNSLOTH_MXFP4_NO_DEQUANTIZE=1 keeps MXFP4 quantized (needs triton_kernels); else dequantized to bf16 for LoRA.
 UNSLOTH_MXFP4_NO_DEQUANTIZE = os.environ.get("UNSLOTH_MXFP4_NO_DEQUANTIZE", "0") == "1"
 
 
 def _check_triton_kernels_available():
-    """Check if OpenAI's triton_kernels package is available for MXFP4."""
+    """Is OpenAI's triton_kernels package available for MXFP4."""
     try:
         from triton_kernels import matmul_ogs, swiglu
 
@@ -319,12 +317,12 @@ def patch_gpt_oss():
 
         @property
         def gate_up_proj(self):
-            """Return gate_up_proj tensor (created from blocks/scales or stored directly)."""
-            # Check if already set as an attribute (from checkpoint loading or previous dequantization)
+            """gate_up_proj tensor, from blocks/scales or stored directly."""
+            # Already set from checkpoint loading or previous dequantization
             if "_gate_up_proj" in self.__dict__:
                 return self.__dict__["_gate_up_proj"]
 
-            # Check if MXFP4 weights are present (blocks and scales are not all zeros)
+            # MXFP4 weights present when blocks/scales are not all zeros
             blocks_valid = (
                 self.gate_up_proj_blocks.device.type != "meta"
                 and self.gate_up_proj_blocks.numel() > 0
@@ -332,18 +330,15 @@ def patch_gpt_oss():
             )
 
             if not blocks_valid:
-                # No MXFP4 weights and no regular weights loaded
                 raise AttributeError(
                     f"Mxfp4GptOssExperts.gate_up_proj: No weights loaded. "
                     f"Try 'openai/gpt-oss-20b' with load_in_4bit=True instead."
                 )
 
-            # MXFP4 weights present - dequantize them
+            # Dequantize: (E, out_dim, in_dim//32, 16) -> (E, out_dim, in_dim), then cache
             try:
                 from transformers.integrations.mxfp4 import dequantize
-                # Dequantize: (E, out_dim, in_dim//32, 16) -> (E, out_dim, in_dim)
                 dequantized = dequantize(self.gate_up_proj_blocks, self.gate_up_proj_scales)
-                # Cache for future accesses
                 self.__dict__["_gate_up_proj"] = dequantized
                 return dequantized
             except Exception as e:
@@ -354,12 +349,12 @@ def patch_gpt_oss():
 
         @gate_up_proj.setter
         def gate_up_proj(self, value):
-            """Set gate_up_proj tensor (called during checkpoint loading)."""
+            """Set gate_up_proj tensor (during checkpoint loading)."""
             self.__dict__["_gate_up_proj"] = value
 
         @property
         def down_proj(self):
-            """Return down_proj tensor (created from blocks/scales or stored directly)."""
+            """down_proj tensor, from blocks/scales or stored directly."""
             if "_down_proj" in self.__dict__:
                 return self.__dict__["_down_proj"]
 
@@ -374,12 +369,10 @@ def patch_gpt_oss():
                     f"Mxfp4GptOssExperts.down_proj: No weights loaded."
                 )
 
-            # MXFP4 weights present - dequantize them
+            # Dequantize: (E, out_dim, in_dim//32, 16) -> (E, out_dim, in_dim), then cache
             try:
                 from transformers.integrations.mxfp4 import dequantize
-                # Dequantize: (E, out_dim, in_dim//32, 16) -> (E, out_dim, in_dim)
                 dequantized = dequantize(self.down_proj_blocks, self.down_proj_scales)
-                # Cache for future accesses
                 self.__dict__["_down_proj"] = dequantized
                 return dequantized
             except Exception as e:
@@ -389,7 +382,7 @@ def patch_gpt_oss():
 
         @down_proj.setter
         def down_proj(self, value):
-            """Set down_proj tensor (called during checkpoint loading)."""
+            """Set down_proj tensor (during checkpoint loading)."""
             self.__dict__["_down_proj"] = value
 
         def forward(
@@ -486,8 +479,7 @@ def patch_gpt_oss():
                 scales_attr = f"{proj}_scales"
                 blocks = getattr(module, blocks_attr)
                 scales = getattr(module, scales_attr)
-                # Check if both blocks and scales both not on meta device AND not all zeros
-                # (if blocks are all zeros, they're from initialization, not from checkpoint)
+                # Valid = blocks/scales off meta AND non-zero (all-zeros means init, not checkpoint)
                 blocks_valid = (
                     blocks.device.type != "meta"
                     and scales.device.type != "meta"
@@ -573,45 +565,31 @@ TEMPORARY_PATCHES.append(patch_gpt_oss)
 
 class ParameterModule(nn.Linear):
     """
-    A module that wraps a parameter to look like a Linear layer for PEFT.
-    It inherits from nn.Linear but manages 3D <-> 2D weight conversion.
-    Unsloth grouped_mm requires 3D weights:
-      - gate_up: (E, H, 2I)
-      - down: (E, I, H)
-    PEFT Linear requires 2D weights: (Out, In).
-    We store the weight as 2D for PEFT, and reshape for Unsloth via get_param().
+    Wraps a parameter as an nn.Linear for PEFT, managing 3D <-> 2D weight conversion.
+    Unsloth grouped_mm needs 3D weights (gate_up: (E, H, 2I); down: (E, I, H)); PEFT
+    Linear needs 2D (Out, In). Stored 2D for PEFT, reshaped for Unsloth via get_param().
     """
 
     def __init__(
         self, in_features, out_features, shape_3d, permute_to_2d, permute_to_3d
     ):
-        # Initialize nn.Linear (creates weight of size (out, in))
         super().__init__(in_features, out_features, bias=False)
         self.shape_3d = shape_3d
         self.permute_to_2d = permute_to_2d
         self.permute_to_3d = permute_to_3d
-
-        # We expect the caller to set the weight content correctly.
-        # nn.Linear initialized it randomly. We will overwrite it.
+        # Caller must overwrite the randomly initialized weight.
 
     def extra_repr(self):
         return f"in_features={self.in_features}, out_features={self.out_features}, shape_3d={self.shape_3d}"
 
     def get_param(self):
-        """Restores the 3D weight for Unsloth computation."""
-        # 2D weight (Out, In) -> View (Unflattened 2D) -> Permute -> 3D(E, ...)
-        # We need to know the unflattened shape.
-        # gate_up: 2D (E*2I, H). View (E, 2I, H). Permute(0,2,1) -> (E, H, 2I).
-        # We store (E*2I, H).
-        # To restore: View (E, 2I, H)?
-        # (E, 2I, H) is shape_3d permuted by permute_to_2d.
-
+        """Restore the 3D weight for Unsloth computation."""
+        # 2D (Out, In) -> view to (E, 2I, H) [shape_3d permuted by permute_to_2d] -> permute -> 3D
         unflattened_shape = [self.shape_3d[i] for i in self.permute_to_2d]
         return self.weight.view(*unflattened_shape).permute(*self.permute_to_3d).contiguous()
 
     def set_weight_from_3d(self, weight_3d):
-        """Sets the 2D weight from a 3D tensor."""
-        # 3D -> Permute -> Flatten
+        """Set the 2D weight from a 3D tensor."""
         weight_2d = weight_3d.permute(*self.permute_to_2d).reshape(self.out_features, self.in_features)
         self.weight.data.copy_(weight_2d)
 
@@ -625,18 +603,12 @@ class ParameterModule(nn.Linear):
         unexpected_keys,
         error_msgs,
     ):
-        # 'gate_up_proj' in checkpoint is 3D.
-        # We need to load it into 'gate_up_proj.weight' (2D).
-        # key is '...gate_up_proj'
+        # Checkpoint 'gate_up_proj' is 3D; load into 'gate_up_proj.weight' (2D)
         key = prefix[:-1]
 
         if key in state_dict:
-            # Found the parameter (likely from original model structure where it was a Param)
             val = state_dict[key]
-            # Convert 3D val to 2D
             val_2d = val.permute(*self.permute_to_2d).reshape(self.out_features, self.in_features)
-
-            # Put into 'weight' key
             state_dict[prefix + "weight"] = val_2d
             del state_dict[key]
 
@@ -661,7 +633,7 @@ def patch_gpt_oss_compiler_exports():
         raise_error("transformers.models.gpt_oss.modeling_gpt_oss", e)
         return
 
-    # Export helpers so compiler generated GPT-OSS modules can resolve symbols.
+    # Export helpers so compiler-generated GPT-OSS modules can resolve symbols.
     m = transformers.models.gpt_oss.modeling_gpt_oss
     m.ParameterModule = ParameterModule
     m.swiglu_torch_forward = swiglu_torch_forward
@@ -673,10 +645,8 @@ TEMPORARY_PATCHES.append(patch_gpt_oss_compiler_exports)
 
 class GptOssExperts(nn.Module):
     """
-    GPT OSS MoE Experts layer with 3D stacked parameters.
-    Compatible with transformers' _init_weights and supports grouped_mm with split LoRA.
-
-    Uses the same structure as the original transformers GptOssExperts:
+    GPT OSS MoE Experts layer with 3D stacked parameters; supports grouped_mm with split LoRA.
+    Same structure as transformers GptOssExperts:
     - gate_up_proj: (num_experts, hidden_size, 2 * expert_dim)
     - gate_up_proj_bias: (num_experts, 2 * expert_dim)
     - down_proj: (num_experts, expert_dim, hidden_size)
@@ -694,8 +664,7 @@ class GptOssExperts(nn.Module):
         self.limit = getattr(config, "swiglu_limit", 7.0)
         self.dtype = dtype_from_config(config)
 
-        # gate_up_proj: 3D (E, H, 2I). Target 2D (E*2I, H).
-        # Permute (0, 2, 1) -> (E, 2I, H). Reverse (0, 2, 1).
+        # gate_up_proj: 3D (E, H, 2I) -> 2D (E*2I, H); permute (0,2,1), reverse (0,2,1)
         self.gate_up_proj = ParameterModule(
             in_features=self.hidden_size,
             out_features=self.num_experts * 2 * self.expert_dim,
@@ -703,7 +672,6 @@ class GptOssExperts(nn.Module):
             permute_to_2d=(0, 2, 1),
             permute_to_3d=(0, 2, 1),
         )
-        # Initialize 3D zero tensor and set 2D weight
         self.gate_up_proj.set_weight_from_3d(
             torch.zeros(
                 self.num_experts,
@@ -715,8 +683,7 @@ class GptOssExperts(nn.Module):
 
         self.gate_up_proj_bias = nn.Parameter(torch.zeros(self.num_experts, 2 * self.expert_dim, dtype=self.dtype))
 
-        # down_proj: 3D (E, I, H). Target 2D (H, E*I).
-        # Permute (2, 0, 1) -> (H, E, I). Reverse (1, 2, 0)
+        # down_proj: 3D (E, I, H) -> 2D (H, E*I); permute (2,0,1), reverse (1,2,0)
         self.down_proj = ParameterModule(
             in_features=self.num_experts * self.expert_dim,
             out_features=self.hidden_size,
@@ -743,32 +710,25 @@ class GptOssExperts(nn.Module):
         error_msgs,
     ):
         """
-        Override to handle loading 3D tensors (gate_up_proj, down_proj) from original checkpoints.
-        The original checkpoint has these as nn.Parameter (3D tensors), but we now have
-        them as ParameterModule (nn.Linear subclass) which expects .weight as 2D tensors.
-
-        This method intercepts the 3D tensors and converts them to the 2D format
-        that ParameterModule expects.
+        Convert checkpoint 3D tensors (gate_up_proj, down_proj nn.Parameter) to the 2D
+        .weight format that ParameterModule (nn.Linear subclass) expects.
         """
-        # Handle gate_up_proj: checkpoint has 3D tensor, we need 2D for ParameterModule.weight
         gate_up_key = prefix + "gate_up_proj"
         gate_up_weight_key = prefix + "gate_up_proj.weight"
         if gate_up_key in state_dict and gate_up_weight_key not in state_dict:
             val_3d = state_dict.pop(gate_up_key)
-            # gate_up_proj: 3D (E, H, 2I) -> permute (0, 2, 1) -> (E, 2I, H) -> reshape (E*2I, H)
+            # 3D (E, H, 2I) -> permute (0,2,1) -> (E, 2I, H) -> reshape (E*2I, H)
             val_2d = val_3d.permute(0, 2, 1).reshape(self.num_experts * 2 * self.expert_dim, self.hidden_size)
             state_dict[gate_up_weight_key] = val_2d
 
-        # Handle down_proj: checkpoint has 3D tensor, we need 2D for ParameterModule.weight
         down_key = prefix + "down_proj"
         down_weight_key = prefix + "down_proj.weight"
         if down_key in state_dict and down_weight_key not in state_dict:
             val_3d = state_dict.pop(down_key)
-            # down_proj: 3D (E, I, H) -> permute (2, 0, 1) -> (H, E, I) -> reshape (H, E*I)
+            # 3D (E, I, H) -> permute (2,0,1) -> (H, E, I) -> reshape (H, E*I)
             val_2d = val_3d.permute(2, 0, 1).reshape(self.hidden_size, self.num_experts * self.expert_dim)
             state_dict[down_weight_key] = val_2d
 
-        # Call parent implementation
         super()._load_from_state_dict(
             state_dict,
             prefix,
@@ -783,11 +743,8 @@ class GptOssExperts(nn.Module):
         self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None
     ) -> torch.Tensor:
         """Forward using grouped_mm or loop fallback with LoRA support."""
-        # Use optimized grouped_mm if available
         if _check_torch_grouped_mm_supported():
             return forward_native_grouped_mm(self, hidden_states, router_indices, routing_weights)
-
-        # Fallback to loop-based implementation
         return torch_native_forward(self, hidden_states, router_indices, routing_weights)
 
 
@@ -796,10 +753,9 @@ pass
 
 class _RouterLinearParams(nn.Module):
     """
-    Simple parameter container that stores weight/bias like nn.Linear
-    but is NOT nn.Linear itself, so BitsAndBytes will NOT quantize it.
-    State dict keys: linear.weight, linear.bias (matching BnB 4-bit checkpoints
-    where the router was saved via an nn.Linear submodule).
+    weight/bias container like nn.Linear but NOT nn.Linear, so BitsAndBytes will NOT quantize it.
+    State dict keys linear.weight/linear.bias match BnB 4-bit checkpoints where the router was
+    saved via an nn.Linear submodule.
     """
     def __init__(self, in_features, out_features, dtype):
         super().__init__()
@@ -816,12 +772,11 @@ class GptOssTopKRouter(nn.Module):
         self.top_k = config.num_experts_per_tok
         self.num_experts = config.num_local_experts
         self.hidden_dim = config.hidden_size
-        # Use _RouterLinearParams (not nn.Linear) to avoid BnB 4-bit quantization.
-        # State dict keys are router.linear.weight / router.linear.bias, matching
-        # the BnB 4-bit checkpoint format where router was stored via nn.Linear.
+        # _RouterLinearParams (not nn.Linear) avoids BnB 4-bit quantization; keys
+        # router.linear.weight/bias match the BnB 4-bit checkpoint format.
         self.linear = _RouterLinearParams(self.hidden_dim, self.num_experts, dtype=dtype_from_config(config))
 
-    # Properties for compatibility with transformers' _init_weights which expects .weight and .bias
+    # transformers' _init_weights expects .weight and .bias
     @property
     def weight(self):
         return self.linear.weight
@@ -855,9 +810,8 @@ pass
 # BitsAndBytes 4bit compatible classes for loading pre-quantized models
 class GptOssExpertsBnb4bit(nn.Module):
     """
-    GPT OSS MoE Experts using nn.Linear layers for BitsAndBytes 4bit compatibility.
-    This version uses gate_up_projs and down_projs as ModuleLists of Linear layers,
-    which can be properly quantized with BitsAndBytes.
+    GPT OSS MoE Experts using ModuleLists of nn.Linear (gate_up_projs, down_projs)
+    so BitsAndBytes can quantize them.
     """
 
     def __init__(self, config):
@@ -880,8 +834,7 @@ class GptOssExpertsBnb4bit(nn.Module):
             for _ in range(self.num_experts)
         ])
 
-        # Provide minimal tensors for transformers _init_weights compatibility.
-        # Keep them empty to avoid allocating large bf16 weights in 4-bit mode.
+        # Empty buffers for transformers _init_weights compat; avoid large bf16 alloc in 4-bit mode.
         self.register_buffer(
             "gate_up_proj", torch.empty(0, dtype=self.dtype), persistent=False
         )
@@ -922,7 +875,7 @@ class GptOssExpertsBnb4bit(nn.Module):
                 # Use pre-computed indices (no torch.where needed)
                 token_idx = sorted_tokens[offset:offset + count]
                 current_state = hidden_states[token_idx]
-                
+
                 gate_up = self.gate_up_projs[expert_idx](current_state)
                 gated_output = swiglu_torch_forward(gate_up, self.alpha, self.limit)
                 # gate, up = gate_up[..., ::2], gate_up[..., 1::2]
@@ -961,8 +914,7 @@ pass
 
 class GptOssTopKRouterBnb4bit(nn.Module):
     """
-    GPT OSS Router using direct parameters for BitsAndBytes 4bit compatibility.
-    This version uses weight/bias as direct nn.Parameter instead of nested Linear.
+    GPT OSS Router with weight/bias as direct nn.Parameter (not nested Linear) for BnB 4bit.
     """
 
     def __init__(self, config):
@@ -1041,9 +993,8 @@ pass
 
 def patch_gpt_oss_bnb4bit():
     """
-    Patch transformers to use BnB 4bit compatible classes when loading pre-quantized models.
-    This should be called before loading models that were saved with BitsAndBytes quantization
-    using the linear-based expert structure.
+    Patch transformers to use BnB 4bit compatible classes for pre-quantized models.
+    Call before loading models saved with BitsAndBytes (linear-based expert structure).
 
     Usage:
         from unsloth_zoo.temporary_patches.gpt_oss import patch_gpt_oss_bnb4bit
@@ -1055,32 +1006,28 @@ def patch_gpt_oss_bnb4bit():
     except Exception as e:
         return raise_error("transformers.models.gpt_oss.modeling_gpt_oss", e)
 
-    # Store original classes for potential restoration
+    # Store original classes for restoration
     if not hasattr(transformers.models.gpt_oss.modeling_gpt_oss, '_original_GptOssExperts'):
         transformers.models.gpt_oss.modeling_gpt_oss._original_GptOssExperts = \
             transformers.models.gpt_oss.modeling_gpt_oss.GptOssExperts
         transformers.models.gpt_oss.modeling_gpt_oss._original_GptOssTopKRouter = \
             transformers.models.gpt_oss.modeling_gpt_oss.GptOssTopKRouter
 
-    # Replace with BnB 4bit compatible versions
-    # Preserve original symbol names for compiler-generated modules.
+    # Replace with BnB 4bit versions; preserve original symbol names for compiler-generated modules.
     GptOssExpertsBnb4bit.__name__ = "GptOssExperts"
     GptOssExpertsBnb4bit.__qualname__ = "GptOssExperts"
 
     transformers.models.gpt_oss.modeling_gpt_oss.GptOssExperts = GptOssExpertsBnb4bit
-    # Use the unsloth GptOssTopKRouter (with self.linear = nn.Linear) for the router.
-    # The BnB 4-bit checkpoint stores router weights as router.linear.weight/bias.
-    # GptOssTopKRouterBnb4bit had self.weight/bias directly with a _load_from_state_dict
-    # override to remap keys, but transformers v5 bypasses _load_from_state_dict
-    # (uses accelerate's set_module_tensor_to_device), so the remapping never ran
-    # and router weights were randomly initialized - causing high loss (~4-5).
+    # Use unsloth GptOssTopKRouter (self.linear = nn.Linear): BnB 4-bit checkpoints store
+    # router.linear.weight/bias. GptOssTopKRouterBnb4bit remapped keys via _load_from_state_dict,
+    # but transformers v5 bypasses it (accelerate's set_module_tensor_to_device), so weights
+    # stayed randomly initialized -> high loss (~4-5).
     transformers.models.gpt_oss.modeling_gpt_oss.GptOssTopKRouter = GptOssTopKRouter
 
     logger.info("Unsloth: Patched GPT OSS with BitsAndBytes 4bit compatible classes")
     os.environ["UNSLOTH_GPT_OSS_BNB4BIT_PATCHED"] = "1"
 
-    # Inject BnB helpers so compiler-generated modules can import them
-    # from transformers.models.gpt_oss.modeling_gpt_oss
+    # Inject BnB helpers so compiler-generated modules can import them.
     m = transformers.models.gpt_oss.modeling_gpt_oss
     m._RouterLinearParams  = _RouterLinearParams
     m.swiglu_torch_forward = swiglu_torch_forward
@@ -1117,9 +1064,8 @@ def _normalized_unsloth_model_name() -> str:
 
 def _should_use_gpt_oss_bnb4bit() -> bool:
     """
-    Decide if GPT-OSS should use BnB-compatible 4-bit experts.
-    Default: True when load_in_4bit is active.
-    Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to force BF16 path.
+    Use BnB-compatible 4-bit experts (default when load_in_4bit active).
+    UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 forces the BF16 path.
     """
     if "gpt_oss" not in _normalized_unsloth_model_name():
         return False
@@ -1143,10 +1089,9 @@ def patch_gpt_oss_bnb4bit_auto():
     """
     if not _should_use_gpt_oss_bnb4bit():
         return
-    # BnB helpers are now injected into the transformers module by
-    # patch_gpt_oss_bnb4bit(), so the compiler can resolve all symbols.
+    # patch_gpt_oss_bnb4bit() injects BnB helpers so the compiler resolves all symbols.
     patch_gpt_oss_bnb4bit()
-    # Ensure inference path avoids torch.compile for 4-bit
+    # Inference path avoids torch.compile for 4-bit
     try:
         global moe_forward_inference
         moe_forward_inference = torch.compiler.disable(moe_forward_inference)
@@ -1210,9 +1155,8 @@ def moe_forward_inference(self, hidden_states):
     num_experts = routing_weights.shape[1]
     X_rep = hidden_states.unsqueeze(0).expand(num_experts, -1, -1)
 
-    # Check if using ModuleList (old style) or 3D parameters (new style)
+    # ModuleList (old style) vs 3D parameters (new style)
     if hasattr(moe, "gate_up_projs"):
-        # ModuleList style
         gate_up_list = [up_l(X_rep[e]) for e, up_l in enumerate(moe.gate_up_projs)]
         gate_up = torch.stack(gate_up_list, dim=0)
         dtype = torch.float32 if hidden_states.dtype != torch.bfloat16 else hidden_states.dtype
@@ -1224,8 +1168,7 @@ def moe_forward_inference(self, hidden_states):
             out_list = [down_l(fused[e].to(dtype)) for e, down_l in enumerate(moe.down_projs)]
         outs = torch.stack(out_list, dim=0)
     else:
-        # 3D parameter style (compatible with transformers)
-        # gate_up_proj: (E, hidden_size, 2*expert_dim) - bmm: (E, N, H) @ (E, H, 2I) -> (E, N, 2I)
+        # 3D parameter style: gate_up_proj (E, H, 2I); bmm (E, N, H) @ (E, H, 2I) -> (E, N, 2I)
         gate_up = torch.bmm(X_rep, moe.gate_up_proj) + moe.gate_up_proj_bias[..., None, :]
         dtype = torch.float32 if hidden_states.dtype != torch.bfloat16 else hidden_states.dtype
         fused = swiglu_torch_forward(gate_up, moe.alpha, moe.limit, dtype=dtype)
@@ -1233,7 +1176,7 @@ def moe_forward_inference(self, hidden_states):
         fused = fused.to(dtype)
         device_type = fused.device.type if isinstance(fused.device.type, str) and fused.device.type != "mps" else "cpu"
         with torch.autocast(device_type=device_type, enabled=False):
-            # down_proj: (E, expert_dim, hidden_size) - bmm: (E, N, I) @ (E, I, H) -> (E, N, H)
+            # down_proj (E, I, H); bmm (E, N, I) @ (E, I, H) -> (E, N, H)
             outs = torch.bmm(fused.to(dtype), moe.down_proj) + moe.down_proj_bias[..., None, :]
 
     rw = routing_weights.to(dtype).transpose(0, 1).unsqueeze(-1)
@@ -1304,8 +1247,7 @@ def moe_forward_inference_bf16(self, hidden_states):
 
     moe = _unwrap_peft_experts(self.experts)
 
-    # Handle ParameterModule (which wraps nn.Linear) vs direct 3D tensor
-    # Extract weights BEFORE the compiled region
+    # Extract weights (ParameterModule wrapping nn.Linear vs direct 3D tensor) before compiled region
     gate_up_proj = moe.gate_up_proj
     if hasattr(gate_up_proj, "get_param"):
         gate_up_proj = gate_up_proj.get_param()
@@ -1377,12 +1319,8 @@ from .moe_utils import (
 
 def patch_gpt_oss_moe_for_lora():
     """
-    Patch GPT OSS MoE experts for LoRA training with grouped GEMM support.
-    This patches the original GptOssExperts class (with 3D parameter tensors)
-    to use optimized grouped GEMM kernels with LoRA support.
-
-    IMPORTANT: We only patch the forward method, NOT replace the entire class.
-    This preserves the original class structure so weights load correctly.
+    Patch GptOssExperts (3D parameter tensors) forward to use grouped GEMM kernels with LoRA.
+    Only patches forward, not the class itself, so original structure loads weights correctly.
     """
     if "gpt_oss" not in _normalized_unsloth_model_name():
         return
@@ -1392,7 +1330,6 @@ def patch_gpt_oss_moe_for_lora():
     if not _is_transformers_v5():
         # Split-LoRA grouped_mm path is only needed for transformers v5+
         return
-    # First patch ParamWrapper for MoE separated LoRA
     patch_param_wrapper_for_moe()
 
     try:
@@ -1405,11 +1342,9 @@ def patch_gpt_oss_moe_for_lora():
             logger.warning(f"Unsloth: Could not patch GPT OSS MoE for LoRA: {e}")
         return
 
-    # Check if already patched
     if hasattr(GptOssExpertsClass, "_unsloth_lora_patched"):
         return
 
-    # Select backend
     backend = select_moe_backend()
 
     if backend == "grouped_mm":
@@ -1451,18 +1386,8 @@ def forward_mxfp4_gpt_oss_with_lora(
     scatter_idx,
 ) -> torch.Tensor:
     """
-    MXFP4 GPT OSS MoE forward pass with LoRA support.
-
-    For LoRA training with MXFP4:
-    - Base MXFP4 matmul is computed without gradients (frozen weights)
-    - LoRA delta is computed with gradients
-    - Output = base_output + lora_delta
-
-    This allows finetuning MXFP4 quantized models with LoRA.
-
-    Requires triton_kernels for native MXFP4 matmul.
-    If triton_kernels is not available, model should be loaded with
-    Mxfp4Config(dequantize=True) to convert to bf16.
+    MXFP4 GPT OSS MoE forward with LoRA: output = base_output (frozen MXFP4, no grad) + lora_delta.
+    Requires triton_kernels for native MXFP4 matmul; else load with Mxfp4Config(dequantize=True).
     """
     if not is_triton_kernels_available():
         raise RuntimeError(
@@ -1481,7 +1406,6 @@ def forward_mxfp4_gpt_oss_with_lora(
     FusedActivation = matmul_ogs.FusedActivation
     swiglu_fn = swiglu.swiglu_fn
 
-    # Get LoRA wrappers
     gate_up_wrapper = _get_lora_wrapper_for_param(self, "gate_up_proj")
     down_wrapper = _get_lora_wrapper_for_param(self, "down_proj")
 
@@ -1527,9 +1451,9 @@ def forward_mxfp4_gpt_oss_with_lora(
             )
         return intermediate_cache3
 
-    # With LoRA: compute base MXFP4 output (no grad) + LoRA delta (with grad)
+    # With LoRA: base MXFP4 output (no grad) + LoRA delta (with grad)
     with torch_cuda_device(hidden_states.device):
-        # 1. Compute MXFP4 base output (detached, no gradients for base weights)
+        # 1. MXFP4 base output, no gradients for base weights
         with torch.no_grad():
             if not hasattr(self, "act"):
                 self.act = FusedActivation(
@@ -1538,7 +1462,6 @@ def forward_mxfp4_gpt_oss_with_lora(
                     2,
                 )
 
-            # Gate-up projection (MXFP4)
             pre_activation = matmul_ogs_fn(
                 hidden_states.to(torch.bfloat16),
                 self.gate_up_proj,
@@ -1556,19 +1479,17 @@ def forward_mxfp4_gpt_oss_with_lora(
             if lora_data is not None:
                 lora_A, lora_B, scaling, num_experts = lora_data
 
-                # Convert triton_kernels routing format to grouped_mm offsets
-                # routing_data.exp_indx contains expert index for each token
+                # routing_data.exp_indx (expert index per token) -> grouped_mm offsets
                 gather_src = gather_idx.src_indx
                 permuted_input = hidden_states[gather_src].to(torch.bfloat16)
 
-                # Compute offsets from expert indices (cumsum of token counts)
+                # Offsets = cumsum of per-expert token counts
                 expert_ids = routing_data.exp_indx
                 num_tokens_per_expert = torch.bincount(
                     expert_ids.int(), minlength=num_experts
                 ).int()
                 offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
 
-                # Use grouped_mm for LoRA computation (much faster than loop!)
                 lora_delta = _apply_lora_grouped_mm(
                     permuted_input,
                     lora_A,
@@ -1602,14 +1523,12 @@ def forward_mxfp4_gpt_oss_with_lora(
             if lora_data is not None:
                 lora_A, lora_B, scaling, num_experts = lora_data
 
-                # Compute offsets from expert indices (reuse if available)
                 expert_ids = routing_data.exp_indx
                 num_tokens_per_expert = torch.bincount(
                     expert_ids.int(), minlength=num_experts
                 ).int()
                 offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
 
-                # Use grouped_mm for LoRA computation
                 lora_delta = _apply_lora_grouped_mm(
                     swiglu_output,
                     lora_A,
@@ -1631,17 +1550,11 @@ def forward_mxfp4_gpt_oss_with_lora(
 
 def patch_mxfp4_gpt_oss_for_lora():
     """
-    Patch MXFP4 GPT OSS experts for LoRA training.
-
-    This enables finetuning the MXFP4 quantized model (unsloth/gpt-oss-20b)
-    with LoRA.
-
-    IMPORTANT: Requires triton_kernels for native MXFP4 matmul.
-    If triton_kernels is not available, users must either:
-    - Use Mxfp4Config(dequantize=True) when loading, OR
-    - Use the BF16 model: 'unsloth/gpt-oss-20b-BF16'
+    Patch MXFP4 GPT OSS experts for LoRA training (unsloth/gpt-oss-20b).
+    Requires triton_kernels for native MXFP4 matmul; else use Mxfp4Config(dequantize=True)
+    or the BF16 model 'unsloth/gpt-oss-20b-BF16'.
     """
-    # First patch ParamWrapper for MoE separated LoRA (v5 only)
+    # ParamWrapper for MoE separated LoRA (v5 only)
     if _is_transformers_v5():
         patch_param_wrapper_for_moe()
 
@@ -1662,23 +1575,19 @@ def patch_mxfp4_gpt_oss_for_lora():
             logger.warning(f"Unsloth: Could not patch MXFP4 GPT OSS for LoRA: {e}")
         return
 
-    # Check if already patched
     if hasattr(Mxfp4GptOssExpertsClass, "_unsloth_mxfp4_lora_patched"):
         return
 
-    # Only patch if triton_kernels is available
-    # Without triton_kernels, MXFP4 weights cannot be used directly
-    # Users must use dequantization or BF16 model
+    # Without triton_kernels, MXFP4 weights cannot be used directly (need dequant or BF16 model)
     if is_triton_kernels_available():
-        # Use native MXFP4 + LoRA (keeps weights quantized)
+        # Native MXFP4 + LoRA, keeps weights quantized
         Mxfp4GptOssExpertsClass._original_forward = Mxfp4GptOssExpertsClass.forward
         Mxfp4GptOssExpertsClass.forward = forward_mxfp4_gpt_oss_with_lora
         Mxfp4GptOssExpertsClass._unsloth_mxfp4_lora_patched = True
         if UNSLOTH_ENABLE_LOGGING:
             logger.info("Unsloth: Patched MXFP4 GPT OSS MoE for LoRA training")
     else:
-        # triton_kernels NOT available - do NOT patch
-        # The model will fail with a helpful error if user tries to use MXFP4 without dequantization
+        # No triton_kernels: don't patch; model errors helpfully if MXFP4 used without dequant
         Mxfp4GptOssExpertsClass._unsloth_mxfp4_lora_patched = True
         if UNSLOTH_ENABLE_LOGGING:
             logger.warning(
@@ -1698,21 +1607,9 @@ _MXFP4_DEQUANT_WARNED = False
 
 def should_dequantize_mxfp4():
     """
-    Check if MXFP4 should be dequantized to bf16.
-
-    Returns True if:
-    - UNSLOTH_MXFP4_NO_DEQUANTIZE is not set or "0", OR
-    - UNSLOTH_MXFP4_NO_DEQUANTIZE="1" but triton_kernels is not available
-
-    Returns False if:
-    - UNSLOTH_MXFP4_NO_DEQUANTIZE="1" AND triton_kernels is available
-
-    MEMORY IMPACT:
-    - MXFP4 quantized: ~10GB for GPT-OSS 20B
-    - MXFP4 dequantized to bf16: ~40GB for GPT-OSS 20B
-
-    To keep MXFP4 quantized (requires triton_kernels):
-        export UNSLOTH_MXFP4_NO_DEQUANTIZE=1
+    Whether MXFP4 should be dequantized to bf16. False only when
+    UNSLOTH_MXFP4_NO_DEQUANTIZE="1" AND triton_kernels is available.
+    Memory for GPT-OSS 20B: ~10GB quantized vs ~40GB dequantized to bf16.
     """
     global _MXFP4_DEQUANT_WARNED
 
@@ -1819,14 +1716,14 @@ def torch_native_forward(
     pass
 pass
 
-# Use torch_native_forward which has full float32 protection (swiglu in float32,
-# autocast disabled around down_proj) to prevent NaN in fp16 training.
+# torch_native_forward has full float32 protection (swiglu in float32, autocast
+# disabled around down_proj) to prevent NaN in fp16 training.
 GptOssExpertsBnb4bit.forward = torch_native_forward
 
 def patch_gpt_oss_linearized():
     """
     Patch GPT OSS for 4bit loading with grouped_mm support.
-    Only patches the GptOssExperts forward method - keeps original classes for proper weight loading.
+    Only patches GptOssExperts.forward; keeps original classes for proper weight loading.
     """
     if "gpt_oss" not in _normalized_unsloth_model_name(): return
     if "_load_in_4bit_" not in _normalized_unsloth_model_name(): return
@@ -1836,8 +1733,7 @@ def patch_gpt_oss_linearized():
     except Exception as e:
         return raise_error("transformers.models.gpt_oss.modeling_gpt_oss", e)
 
-    # Don't replace classes - just patch the forward method of GptOssExperts
-    # This keeps the original class structure which properly handles 4-bit weight loading
+    # Patch only GptOssExperts.forward (not the class) to keep 4-bit weight loading working
     backend = select_moe_backend()
 
     if backend == "grouped_mm":
@@ -1895,8 +1791,8 @@ def patch_GptOssAttention():
 
     def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
         """
-        This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
-        num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+        Equivalent to torch.repeat_interleave(x, dim=1, repeats=n_rep): (batch,
+        num_key_value_heads, seqlen, head_dim) -> (batch, num_attention_heads, seqlen, head_dim).
         """
         batch, num_key_value_heads, slen, head_dim = hidden_states.shape
         if n_rep == 1:
@@ -1908,15 +1804,10 @@ def patch_GptOssAttention():
     F_dropout = nn.functional.dropout
     matmul = torch.matmul
     def _align_kv_to_mask(key_states, value_states, attention_mask):
-        # Eager attention does `attn_weights += attention_mask`, which requires the
-        # key/value length to equal the mask's key dimension. On some
-        # transformers/torch combinations (e.g. transformers 5.x on torch < 2.11)
-        # the KV cache hands back more positions than the causal mask covers
-        # (pre-allocated cache slots), so a full-attention layer can see e.g. 161
-        # keys against a 128-wide mask and crash. The surplus positions are masked
-        # out anyway, so attend only the overlap by trimming KV (and the mask) to
-        # the shorter length. This keeps the path correct and shape-consistent
-        # across transformers/torch versions.
+        # Eager `attn_weights += attention_mask` requires KV length == mask key dim. On some
+        # transformers/torch combos (e.g. transformers 5.x on torch < 2.11) the KV cache returns
+        # more positions than the mask covers (pre-allocated slots), crashing full-attention layers.
+        # Surplus positions are masked out anyway, so trim KV (and mask) to the shorter length.
         if attention_mask is None or not hasattr(attention_mask, "shape"):
             return key_states, value_states, attention_mask
         kvlen = key_states.shape[-2]
@@ -2974,12 +2865,9 @@ TEMPORARY_PATCHES.append(patch_gpt_oss_init_weights_modulelist_fix)
 # ============================================================================
 def patch_gpt_oss_for_grpo(phase="post_compile"):
     """
-    Patch GptOssForCausalLM.forward for GRPO training.
-    When UNSLOTH_RETURN_HIDDEN_STATES=1, return hidden_states instead of logits.
-    This fixes the matrix multiplication dimension mismatch issue in GRPO training.
-
-    Only runs post-compile so the compiler can pattern-match cross-entropy in the
-    original forward source and apply fused loss (preventing OOM from full logits).
+    Patch GptOssForCausalLM.forward for GRPO: when UNSLOTH_RETURN_HIDDEN_STATES=1, return
+    hidden_states instead of logits (fixes the GRPO matmul dimension mismatch).
+    Runs post-compile so the compiler can pattern-match cross-entropy and fuse loss (avoids OOM).
     """
     if phase != "post_compile":
         return

--- a/unsloth_zoo/temporary_patches/ministral.py
+++ b/unsloth_zoo/temporary_patches/ministral.py
@@ -26,11 +26,11 @@ from .utils import (
 )
 
 def patch_MinistralAttention():
-    """
-    Fix dtype mismatch in MinistralAttention where RoPE is applied to Q/K
-    but not V. In 4-bit (BNB) mode, cos/sin can promote Q/K to a different
-    dtype than V, causing scaled_dot_product_attention to fail with:
-      ValueError: Expected query, key, and value to have the same dtype
+    """Fix dtype mismatch in MinistralAttention: RoPE applies to Q/K but not V.
+
+    In 4-bit (BNB) mode cos/sin can promote Q/K to a different dtype than V,
+    causing scaled_dot_product_attention to fail with "Expected query, key,
+    and value to have the same dtype".
     """
     try:
         import transformers.models.ministral.modeling_ministral
@@ -61,9 +61,8 @@ def patch_MinistralAttention():
         cos, sin = position_embeddings
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
-        # Fix dtype mismatch: RoPE may promote Q/K dtype via cos/sin multiplication
-        # while V stays in the original dtype from the linear projection.
-        # In 4-bit BNB mode, this causes Q/K to be float32 while V is float16/bfloat16.
+        # RoPE may promote Q/K dtype via cos/sin while V keeps the projection
+        # dtype (4-bit BNB: Q/K float32, V float16/bfloat16). Realign V.
         if value_states.dtype != query_states.dtype:
             value_states = value_states.to(query_states.dtype)
 
@@ -91,10 +90,9 @@ def patch_MinistralAttention():
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
 
-    # Wrap so check_args_kwargs accepts removed params (e.g. cache_position in v5).
-    # Preserve the original signature on the wrapper so inspect.signature
-    # (used by transformers._validate_model_kwargs among others) still sees
-    # the real named parameters.
+    # Wrap so check_args_kwargs accepts removed params (e.g. cache_position in
+    # v5), but keep the original signature so inspect.signature (used by
+    # transformers._validate_model_kwargs) still sees the real parameters.
     target_cls = transformers.models.ministral.modeling_ministral.MinistralAttention
     _original_forward_signature = inspect.signature(target_cls.forward)
     _full_forward = forward
@@ -113,12 +111,11 @@ TEMPORARY_PATCHES.append(patch_MinistralAttention)
 
 
 def patch_MinistralModel_forward():
-    """
-    Fix MinistralModel.forward to handle sliding_window=None gracefully.
-    When the config has no sliding_window set (or it is None), the model
-    should skip creating a sliding window causal mask since calling
-    create_sliding_window_causal_mask raises ValueError.
-    This also handles the case where all layer_types are 'full_attention'.
+    """Handle sliding_window=None in MinistralModel.forward.
+
+    With no sliding_window set, skip the sliding-window causal mask, since
+    create_sliding_window_causal_mask raises ValueError. Also covers the case
+    where all layer_types are 'full_attention'.
     """
     try:
         from transformers.models.ministral.modeling_ministral import MinistralModel
@@ -139,18 +136,16 @@ def patch_MinistralModel_forward():
         *args,
         **kwargs,
     ):
-        # Check if sliding_window is properly set
         sw = getattr(self.config, "sliding_window", None)
         has_sliding_layers = any(
             lt == "sliding_attention"
             for lt in (getattr(self.config, "layer_types", None) or [])
         )
         if sw is None and not has_sliding_layers:
-            # All layers are full_attention and no sliding_window is set.
-            # Set sliding_window to max_position_embeddings so
-            # create_sliding_window_causal_mask does not raise. The mask will
-            # not actually be used by full_attention layers, but the value must
-            # be large enough to avoid unintended attention truncation.
+            # All full_attention, no sliding_window: set it to
+            # max_position_embeddings so create_sliding_window_causal_mask does
+            # not raise. The mask is unused, but must be large enough to avoid
+            # unintended attention truncation.
             self.config.sliding_window = getattr(
                 self.config, "max_position_embeddings", 32768
             )

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -41,9 +41,8 @@ import re
 import os
 
 def patch_ministral3_config_mapping():
-    # Fix for Ministral-3 VL models which have text_config.model_type = "ministral3"
-    # but transformers CONFIG_MAPPING doesn't have "ministral3" as a key
-    # The correct text config is MinistralConfig (model_type = "ministral")
+    # Ministral-3 VL models set text_config.model_type="ministral3", which is
+    # missing from CONFIG_MAPPING; the correct config is MinistralConfig.
     try:
         from transformers.models.auto.configuration_auto import CONFIG_MAPPING
         from transformers import MinistralConfig
@@ -57,9 +56,9 @@ TEMPORARY_PATCHES.append(patch_ministral3_config_mapping)
 
 
 def patch_tokenizer_convert_added_tokens():
-    # Fix for tokenizer_config.json files that have additional_special_tokens as dicts
-    # without the "__type": "AddedToken" field. These dicts have a "content" key instead.
-    # transformers expects either strings or AddedToken objects, so we need to convert them.
+    # Some tokenizer_config.json files store additional_special_tokens as dicts
+    # with a "content" key but no "__type": "AddedToken"; convert them to
+    # AddedToken since transformers expects strings or AddedToken objects.
     try:
         from transformers.tokenization_utils_base import PreTrainedTokenizerBase, AddedToken
     except Exception as e:
@@ -71,7 +70,7 @@ def patch_tokenizer_convert_added_tokens():
 
     @classmethod
     def patched_convert_added_tokens(cls, obj, save=False, add_type_field=True):
-        # Only convert if "content" is a string (AddedToken expects str), not a nested dict
+        # Only convert when "content" is a string (AddedToken expects str).
         if isinstance(obj, dict) and "content" in obj and "__type" not in obj and isinstance(obj["content"], str):
             return AddedToken(**obj)
         return original_convert_added_tokens.__func__(cls, obj, save=save, add_type_field=add_type_field)
@@ -83,9 +82,8 @@ TEMPORARY_PATCHES.append(patch_tokenizer_convert_added_tokens)
 
 
 def patch_tokenizer_extra_special_tokens():
-    # Fix for tokenizer_config.json files that have extra_special_tokens as a list
-    # instead of a dict. transformers expects extra_special_tokens to be a dict.
-    # This is a bug in some Mistral model tokenizer configs.
+    # Some Mistral tokenizer configs store extra_special_tokens as a list, but
+    # transformers expects a dict.
     try:
         from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     except Exception as e:
@@ -96,11 +94,9 @@ def patch_tokenizer_extra_special_tokens():
         return
 
     def patched_init(self, **kwargs):
-        # Convert extra_special_tokens from list to empty dict if needed
         extra_special_tokens = kwargs.get("extra_special_tokens", {})
         if isinstance(extra_special_tokens, list):
-            # extra_special_tokens should be a dict, but some models have it as a list
-            # Convert to empty dict to avoid errors, the tokens are still in added_tokens_decoder
+            # Coerce list to empty dict; the tokens remain in added_tokens_decoder.
             kwargs["extra_special_tokens"] = {}
         return original_init(self, **kwargs)
 
@@ -200,8 +196,8 @@ def patch_CsmDepthDecoderForCausalLM_forward():
             offset = codebook_idxs * self.model.vocab_size
             inputs_embeds = self.model.embed_tokens(input_ids + offset)
             if inputs_embeds.requires_grad and inputs_embeds.is_leaf:
-                # Use the cheap detach when backbone state supplies gradients;
-                # clone only when the GC sentinel itself must survive.
+                # Cheap detach when backbone supplies grads; clone only when the
+                # GC sentinel itself must survive.
                 inputs_embeds = (
                     inputs_embeds.detach()
                     if backbone_last_hidden_state.requires_grad
@@ -262,11 +258,10 @@ def patch_CsmDepthDecoderForCausalLM_forward():
         })
     pass
 
-    # Wrap with (self, *args, **kwargs) so check_args_kwargs accepts any
-    # removed params (output_attentions, output_hidden_states, cache_position).
-    # Copy the original class signature onto the wrapper so
-    # transformers._validate_model_kwargs (used by generate) still sees
-    # the real named parameters like backbone_last_hidden_state.
+    # Wrap with (self, *args, **kwargs) so check_args_kwargs accepts removed
+    # params, but copy the original signature onto the wrapper so
+    # transformers._validate_model_kwargs (used by generate) still sees the
+    # real named parameters like backbone_last_hidden_state.
     _original_forward_signature = inspect.signature(target_cls.forward)
     _full_forward = forward
     def forward(self, *args, **kwargs):
@@ -344,28 +339,26 @@ def patch_CsmForConditionalGeneration_forward():
                 logits=backbone_logits, labels=backbone_labels, vocab_size=self.config.vocab_size, **kwargs
             )
 
-            # for the depth decoder, we need to select the frames to train on
-            # those are frames where the label is not uniformly `ignore_index` along the codebook dimension
+            # Depth decoder trains on frames whose labels are not uniformly
+            # ignore_index across the codebook dimension.
             train_mask = ~(labels[:, :, 1:] == -100).all(dim=-1)
             depth_decoder_input_ids = labels[train_mask][..., : self.config.num_codebooks - 1]
-            # add place holder in position 0 that will be replaced by the backbone_last_hidden_state
+            # Position 0 placeholder, replaced later by backbone_last_hidden_state.
             depth_decoder_input_ids = torch.nn.functional.pad(depth_decoder_input_ids, (1, 0), value=0)
 
             train_idxs = train_mask.nonzero(as_tuple=True)
             backbone_last_hidden_states = backbone_hidden_states[train_idxs[0], train_idxs[1] - 1, :]
             depth_decoder_labels = labels[train_mask]
 
-            # Fix: explicitly pass kwargs to depth decoder to get access to num_items_in_batch
+            # Pass kwargs to the depth decoder so it sees num_items_in_batch.
             depth_decoder_kwargs = kwargs.copy()
-            # backbone loss num_items is based on the 0th codebooks index
-            # while depth loss num_items is based on the the remaining 31 codebooks
-            # therefore num_items_in_batch should be multiplied by 31
+            # Backbone num_items is the 0th codebook; depth covers the remaining
+            # 31 codebooks, so scale num_items_in_batch by 31.
             if 'num_items_in_batch' in depth_decoder_kwargs:
                 depth_decoder_kwargs['num_items_in_batch'] = depth_decoder_kwargs['num_items_in_batch'] * 31
 
-            # make sure return_dict is set to True
             depth_decoder_kwargs.pop('return_dict', None)
-            # Move output_attentions and output_hidden_states since transformers 4.54 deletes them
+            # Move output_attentions/output_hidden_states (transformers 4.54 deletes them)
             depth_decoder_kwargs["output_attentions"   ] = output_attentions
             depth_decoder_kwargs["output_hidden_states"] = output_hidden_states
 
@@ -377,7 +370,6 @@ def patch_CsmForConditionalGeneration_forward():
                 # output_hidden_states=output_hidden_states,
                 return_dict = True,
                 labels = depth_decoder_labels,
-                # Fix: explicitly pass kwargs to depth decoder to get access to num_items_in_batch
                 **depth_decoder_kwargs,
             )
 
@@ -403,9 +395,8 @@ def patch_CsmForConditionalGeneration_forward():
         })
     pass
 
-    # Preserve the original signature on the wrapper so inspect.signature
-    # (used by transformers._validate_model_kwargs among others) still sees
-    # the real named parameters.
+    # Preserve the original signature so inspect.signature (used by
+    # transformers._validate_model_kwargs) still sees the real named parameters.
     _original_forward_signature = inspect.signature(target_cls.forward)
     _full_forward = forward
     def forward(self, *args, **kwargs):
@@ -624,10 +615,9 @@ def patch_transformers_masks():
     masking_utils.create_sliding_window_causal_mask = wrap(compiled_create_sliding_window_causal_mask)
     masking_utils.create_masks_for_generate = wrap(masking_utils.create_masks_for_generate)
     generation_utils.create_masks_for_generate = masking_utils.create_masks_for_generate
-    # Multi-GPU device_map flex_attention fix: cache_position[0] returns a
-    # 0-dim tensor on one device, but inner_mask may run on another device.
-    # Move offset tensors to the executing device inside the closure instead of
-    # using .item(), which would cause a graph break under torch.compile tracing.
+    # Multi-GPU device_map flex_attention fix: offset tensors may live on a
+    # different device than inner_mask runs on. Move them inside the closure
+    # rather than .item() (which graph-breaks under torch.compile tracing).
     if hasattr(masking_utils, "add_offsets_to_mask_function"):
         _original_add_offsets = getattr(
             masking_utils,
@@ -645,9 +635,9 @@ def patch_transformers_masks():
             return inner_mask
         masking_utils.add_offsets_to_mask_function = add_offsets_wrapper
 
-    # Fix padding/packed mask functions for multi-GPU: captured tensors may be
-    # on a different device than the indices passed during flex_attention vmap.
-    # Cache per-device copies to avoid repeated cross-device transfers.
+    # Multi-GPU fix: captured mask tensors may be on a different device than
+    # the flex_attention vmap indices. Cache per-device copies to avoid
+    # repeated cross-device transfers.
     if hasattr(masking_utils, "padding_mask_function"):
         masking_utils._unsloth_original_padding_mask_function = getattr(
             masking_utils,
@@ -692,11 +682,10 @@ TEMPORARY_PATCHES.append(patch_transformers_masks)
 def patch_sdpa_bool_causal_mask():
     """Fix unslothai/unsloth#4906: inf grad_norm on Qwen3.5 at seq_len > 65536.
 
-    Upstream bug: pytorch/pytorch#162588. Cutlass SDPA returns garbage
-    gradients on bool causal masks at seq_len >= 2**16 (bf16, head_dim=256,
-    no flash-attn). Drop pure causal bool masks and call with is_causal=True;
-    convert non-pure bool masks to float additive bias. Below 2**16 we skip
-    the wrapper since the bug cannot fire.
+    Upstream bug pytorch/pytorch#162588: Cutlass SDPA returns garbage gradients
+    on bool causal masks at seq_len >= 2**16 (bf16, head_dim=256, no flash-attn).
+    Drop pure causal bool masks (is_causal=True); convert non-pure bool masks to
+    float additive bias. Skipped below 2**16 where the bug cannot fire.
     """
     if os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1":
         return
@@ -727,10 +716,9 @@ def patch_sdpa_bool_causal_mask():
     ):
         m = attention_mask
 
-        # Below 2**16 the Cutlass bool-mask overflow cannot fire
-        # (pytorch/pytorch#162588), so skip the wrapper. The pure-causal
-        # rewrite picks a heavier SDPA backend and costs ~2.5 GB on
-        # Gemma4-31B LoRA SFT (8192 seq_len).
+        # Below 2**16 the Cutlass bool-mask overflow (pytorch/pytorch#162588)
+        # cannot fire, so skip the wrapper. The pure-causal rewrite picks a
+        # heavier SDPA backend (~2.5 GB on Gemma4-31B LoRA SFT, 8192 seq_len).
         _q_len = query.shape[2] if query.dim() >= 3 else 0
         _mask_key_len = m.shape[-1] if isinstance(m, torch.Tensor) and m.dim() >= 1 else 0
         if _q_len < 65536 and _mask_key_len < 65536:
@@ -785,8 +773,8 @@ def patch_sdpa_bool_causal_mask():
                 **kwargs,
             )
 
-        # Pure lower-triangular check via two O(1) probes: upper-tri is False
-        # and last row sees first col. Packed/padded masks fail the second.
+        # Pure lower-triangular check via two O(1) probes: upper-tri False and
+        # last row sees first col. Packed/padded masks fail the second.
         S = m.shape[-1]
         is_pure_causal = (
             (S < 2)
@@ -804,8 +792,8 @@ def patch_sdpa_bool_causal_mask():
                 **kwargs,
             )
 
-        # Non-pure bool mask (packed sequences, custom patterns): convert to float
-        # additive bias so SDPA dispatches to the working (non-bool) kernel.
+        # Non-pure bool mask: convert to float additive bias so SDPA dispatches
+        # to the working (non-bool) kernel.
         m_float = torch.where(m, 0.0, torch.finfo(query.dtype).min).to(query.dtype)
         return _orig(
             module, query, key, value, m_float,
@@ -821,13 +809,12 @@ TEMPORARY_PATCHES.append(patch_sdpa_bool_causal_mask)
 
 
 def patch_modernbert_attention_mask():
-    """Fix ModernBERT attn_bias stride alignment for SDPA backward pass.
+    """Fix ModernBERT attn_bias stride alignment for the SDPA backward pass.
 
-    The attention mask created by _prepare_4d_attention_mask uses .expand()
-    which creates non-contiguous strides. The SDPA compiled backward kernel
-    requires strides to be multiples of 4. Fix: patch _update_attention_mask
-    on ModernBertModel to return contiguous masks BEFORE they enter
-    torch.compile regions, so the inductor backward graph uses aligned strides.
+    _prepare_4d_attention_mask uses .expand(), giving non-contiguous strides,
+    but the compiled SDPA backward kernel needs strides that are multiples of 4.
+    Patch _update_attention_mask to return contiguous masks before they enter
+    torch.compile regions so the inductor backward graph uses aligned strides.
     """
     try:
         import transformers.models.modernbert.modeling_modernbert as modernbert_module
@@ -844,8 +831,7 @@ def patch_modernbert_attention_mask():
 
     def _update_attention_mask_contiguous(self, attention_mask, output_attentions=False):
         global_attention_mask, sliding_window_mask = original_update(self, attention_mask, output_attentions=output_attentions)
-        # Make masks contiguous so SDPA backward (including compiled graphs)
-        # gets strides that are multiples of 4
+        # Make masks contiguous so SDPA backward gets multiple-of-4 strides.
         if global_attention_mask is not None and not global_attention_mask.is_contiguous():
             global_attention_mask = global_attention_mask.contiguous()
         if sliding_window_mask is not None and not sliding_window_mask.is_contiguous():
@@ -870,19 +856,11 @@ def patch_CsmForConditionalGeneration_merge():
         input_values_cutoffs: Optional[torch.Tensor] = None,
         labels: Optional[torch.Tensor] = None,
     ) -> Optional[torch.Tensor]:
-        """
-        Merges the input_ids and input_values to produce a single inputs_embeds tensor:
-        1 - Infers the codec model on the input_values to retreive codebook token.
-        2 - Embeds codebook tokens and places them at the correct positions in the inputs_embeds tensor.
-        3 - If labels are provided, expands them to match codebook dimensions and position the target codebook tokens in the inputs_embeds tensor.
+        """Merge input_ids and input_values into a single inputs_embeds tensor.
 
-        Args:
-            input_ids (`torch.Tensor` of shape `(batch_size, sequence_length)`):
-                The input ids to embed.
-            input_values (`torch.Tensor` of shape `(batch_size, channels, audio_sequence_length)`):
-                The audio input values to embed.
-            input_values_cutoffs (`torch.Tensor` of shape `(batch_size, max_num_audio)`):
-                The cutoffs of the audio input values relative to its batch index, padded with -1 when no audio.
+        Runs the codec model on input_values to get codebook tokens, embeds and
+        positions them, and (if labels are given) expands labels to codebook
+        dimensions. input_values_cutoffs are per-batch cutoffs padded with -1.
         """
         inputs_embeds = self.embed_text_tokens(input_ids)
 
@@ -951,14 +929,13 @@ TEMPORARY_PATCHES.append(patch_CsmForConditionalGeneration_merge)
 
 
 def patch_causal_conv1d_cuda_probe():
-    """Probe causal_conv1d CUDA kernels and force slow path if broken.
+    """Probe causal_conv1d CUDA kernels and force the slow path if broken.
 
-    On GPUs whose compute capability is not supported by pre-built causal_conv1d
-    CUDA kernels (e.g. sm_100 on B200), `import causal_conv1d` succeeds but calling
-    `causal_conv1d_fn(...)` fails at runtime with "no kernel image is available".
-    This probe runs a tiny forward pass at startup to detect the failure, then
-    nullifies causal_conv1d_fn/causal_conv1d_update everywhere so all Mamba-family
-    models fall back to their pure-PyTorch slow paths.
+    On unsupported compute capabilities (e.g. sm_100 on B200), import succeeds
+    but calling causal_conv1d_fn(...) fails with "no kernel image is available".
+    A tiny startup forward pass detects this, then nullifies
+    causal_conv1d_fn/causal_conv1d_update so Mamba-family models fall back to
+    their pure-PyTorch slow paths.
     """
     try:
         import causal_conv1d
@@ -1015,9 +992,9 @@ def patch_causal_conv1d_cuda_probe():
         pass
     pass
 
-    # 3. Dynamically scan all loaded modules and nullify broken causal_conv1d
-    #    references. Uses identity checks (is) against the original function objects
-    #    to avoid clobbering vllm's independent Triton-based causal_conv1d_fn/update.
+    # 3. Scan loaded modules and nullify broken causal_conv1d references. Uses
+    #    identity checks (is) against the originals so vllm's independent
+    #    Triton-based causal_conv1d_fn/update is left untouched.
     _original_fn = causal_conv1d_fn
     _original_update = causal_conv1d_update
 
@@ -1256,7 +1233,7 @@ def fix_mamba_ssm_float32():
     except Exception as e:
         return raise_error("mamba_ssm.ops.triton.ssd_chunk_scan", e)
 
-    # Find dst +=|= tl.dot(a, b)
+    # Find `dst = tl.dot(a, b)` / `dst += tl.dot(a, b)`
     matches = list(re.finditer(
         r" ([a-zA-Z0-9\_]{1,}) (\=|\+\=) tl\.dot\(([a-zA-Z0-9\_]{1,})\, ([a-zA-Z0-9\_]{1,})\)",
         file)
@@ -1368,15 +1345,10 @@ def patch_SiglipEncoderLayer():
         attention_mask: torch.Tensor,
         output_attentions: Optional[bool] = False,
     ) -> tuple[torch.FloatTensor]:
-        """
-        Args:
-            hidden_states (`torch.FloatTensor`):
-                Input to the layer of shape `(batch, seq_len, embed_dim)`.
-            attention_mask (`torch.FloatTensor`):
-                Attention mask of shape `(batch, 1, q_len, k_v_seq_len)` where padding elements are indicated by very large negative values.
-            output_attentions (`bool`, *optional*, defaults to `False`):
-                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
-                returned tensors for more detail.
+        """SiglipEncoderLayer forward forced to float32 internals.
+
+        hidden_states: (batch, seq_len, embed_dim); attention_mask:
+        (batch, 1, q_len, kv_seq_len) with padding as large negatives.
         """
         hidden_states = hidden_states.to(torch.float32)
         residual = hidden_states
@@ -1409,13 +1381,12 @@ TEMPORARY_PATCHES.append(patch_SiglipEncoderLayer)
 
 
 def patch_Lfm2VlMultiModalProjector():
-    """Fix Lfm2VlMultiModalProjector unconditionally creating LayerNorm.
+    """Backport the transformers 5.0.0 fix for Lfm2VlMultiModalProjector.
 
     transformers 4.57.6 ignores config.projector_use_layernorm and always
-    creates nn.LayerNorm + applies it in forward. The model checkpoint for
-    LFM2.5-VL-1.6B has projector_use_layernorm=False and ships no layer_norm
-    weights, so the LayerNorm gets randomly initialized and corrupts features.
-    Fixed in transformers 5.0.0. This patch backports the fix.
+    creates + applies nn.LayerNorm. LFM2.5-VL-1.6B has it False and ships no
+    layer_norm weights, so the LayerNorm is randomly initialized and corrupts
+    features.
     """
     try:
         import transformers.models.lfm2_vl.modeling_lfm2_vl as lfm2_vl_module
@@ -1457,11 +1428,11 @@ TEMPORARY_PATCHES.append(patch_Lfm2VlMultiModalProjector)
 
 
 def patch_peft_dispatch_bnb_4bit():
-    """Fix PEFT dispatch_bnb_4bit accessing compress_statistics on non-Params4bit weights.
+    """Fix PEFT dispatch_bnb_4bit reading compress_statistics on non-Params4bit weights.
 
-    In transformers 5.0+, BNB quantization loading order changed so weights may still be
-    nn.Parameter (not Params4bit) when PEFT tries to access .compress_statistics and .quant_type.
-    This wraps the original dispatch to catch AttributeError and provide defaults.
+    transformers 5.0+ changed BNB load order, so weights may still be
+    nn.Parameter (not Params4bit) when PEFT reads .compress_statistics /
+    .quant_type. Wrap dispatch to catch AttributeError and supply defaults.
     """
     try:
         import peft.tuners.lora.bnb as peft_bnb
@@ -1477,8 +1448,7 @@ def patch_peft_dispatch_bnb_4bit():
             return original_dispatch(target, adapter_name, **kwargs)
         except AttributeError as e:
             if "compress_statistics" in str(e) or "quant_type" in str(e):
-                # Transformers 5.0+: weight not yet quantized as Params4bit
-                # Retry after ensuring weight has needed attributes
+                # transformers 5.0+: weight not yet Params4bit; backfill attrs and retry.
                 w = target.weight
                 if not hasattr(w, "compress_statistics"):
                     w.compress_statistics = getattr(
@@ -1495,12 +1465,11 @@ pass
 TEMPORARY_PATCHES.append(patch_peft_dispatch_bnb_4bit)
 
 def patch_trl_push_to_hub_token():
-    """Ensure to_dict() always includes push_to_hub_token for TRL compat.
+    """Make TrainingArguments.to_dict() always include push_to_hub_token.
 
-    TRL 0.22.x through 0.27.1 do bare dict_args.pop("push_to_hub_token") in
-    SFTTrainer.__init__ and IterativeSFTTrainer.__init__. On transformers 5.0+,
-    TrainingArguments.to_dict() no longer includes push_to_hub_token, so the
-    bare pop raises KeyError. Fix: monkey-patch to_dict() to always include it.
+    TRL 0.22.x-0.27.1 bare-pop "push_to_hub_token" in SFTTrainer /
+    IterativeSFTTrainer __init__, but transformers 5.0+ drops it from
+    to_dict(), so the pop raises KeyError.
     """
     try:
         from unsloth_zoo.utils import Version
@@ -1527,14 +1496,10 @@ TEMPORARY_PATCHES.append(patch_trl_push_to_hub_token)
 def patch_trl_vision_model_mapping():
     """Fix DPO vision model detection for TRL 0.22.x + transformers 5.0+.
 
-    TRL 0.22.x does a bare import of MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES from
-    transformers.models.auto.modeling_auto. This name was removed in transformers
-    5.0.0, replaced by MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES. The import
-    failure prevents DPO trainer from loading at all.
-
-    Fix: inject the old name as an alias of the new name into the transformers
-    auto modeling module BEFORE TRL imports it, so the bare import succeeds.
-    Also patch already-loaded DPO module if it fell back to empty dict.
+    transformers 5.0.0 renamed MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES to
+    MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES, breaking TRL 0.22.x's bare
+    import and preventing the DPO trainer from loading. Inject the old name as
+    an alias before TRL imports it, and patch an already-loaded DPO module.
     """
     try:
         import transformers.models.auto.modeling_auto as auto_mod
@@ -1563,12 +1528,10 @@ TEMPORARY_PATCHES.append(patch_trl_vision_model_mapping)
 def patch_vllm_safe_apply_chat_template():
     """Fix vLLM safe_apply_chat_template for transformers 5.0+.
 
-    transformers 5.0.0 changed apply_chat_template(tokenize=True) to default
-    return_dict=True, returning BatchEncoding instead of list[int]. vLLM's
-    safe_apply_chat_template doesn't pass return_dict=False, causing TypeError
-    in _validate_model_input when max(BatchEncoding) returns a string key.
-
-    Fix: wrap the original function to inject return_dict=False when tokenize=True.
+    transformers 5.0.0 made apply_chat_template(tokenize=True) default
+    return_dict=True (BatchEncoding instead of list[int]); vLLM doesn't pass
+    return_dict=False, causing a TypeError in _validate_model_input. Wrap to
+    inject return_dict=False when tokenize=True.
     """
     try:
         from unsloth_zoo.utils import Version
@@ -1644,11 +1607,9 @@ TEMPORARY_PATCHES.append(patch_apply_chat_template_return_dict)
 def patch_qwen2vl_image_processor_pixel_attrs():
     """Add max_pixels/min_pixels property shims to Qwen2VLImageProcessor.
 
-    transformers 5.x removed these as direct instance attributes (they
-    are now stored inside self.size["longest_edge"/"shortest_edge"]).
-    vLLM 0.15.x accesses image_processor.max_pixels directly.
-    Only patch on transformers >= 5.0.0 to avoid breaking 4.x where
-    __init__ sets self.max_pixels as an instance attribute.
+    transformers 5.x moved these into self.size["longest_edge"/"shortest_edge"]
+    but vLLM 0.15.x reads image_processor.max_pixels directly. Only patched on
+    transformers >= 5.0.0 (4.x already sets them as instance attributes).
     """
     try:
         from unsloth_zoo.utils import Version

--- a/unsloth_zoo/temporary_patches/moe_bnb.py
+++ b/unsloth_zoo/temporary_patches/moe_bnb.py
@@ -13,18 +13,12 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""
-MoE 4-bit Quantization Module
+"""bitsandbytes-style 4-bit quantization for Mixture of Experts layers.
 
-Provides bitsandbytes-style 4-bit quantization for Mixture of Experts layers.
-This is necessary because transformers' Qwen3MoeExperts uses nn.Parameter
-tensors instead of nn.Linear modules, so bitsandbytes' standard quantization
-skips them.
-
-Design follows bitsandbytes patterns:
-- Uses Params4bit for per-expert weight quantization
-- Quantization happens on .to(cuda), just like Linear4bit
-- Integrates with model loading via replace_with_bnb_moe_experts()
+Needed because transformers' Qwen3MoeExperts uses nn.Parameter tensors
+instead of nn.Linear modules, which bitsandbytes' standard quantization
+skips. Follows bnb patterns: Params4bit per-expert weights, quantization
+on .to(cuda) like Linear4bit, integrated via replace_with_bnb_moe_experts().
 """
 
 import torch
@@ -49,7 +43,7 @@ except ImportError:
 
 
 def _check_bnb_available():
-    """Check if bitsandbytes is available and raise helpful error if not."""
+    """Raise a helpful error if bitsandbytes is unavailable."""
     if not HAS_BNB:
         raise ImportError(
             "bitsandbytes is required for MoE 4-bit quantization. "
@@ -58,20 +52,15 @@ def _check_bnb_available():
 
 
 class MoeExperts4bit(nn.Module):
-    """
-    Base class for 4-bit quantized MoE experts.
+    """Base class for 4-bit quantized MoE experts.
 
-    Follows bitsandbytes Linear4bit patterns for compatibility and maintainability:
-    - Stores per-expert weights as Params4bit
-    - Quantization happens when moving to CUDA (like Linear4bit)
-    - Self-contained forward using bnb.matmul_4bit for each expert
+    Follows bitsandbytes Linear4bit patterns: per-expert Params4bit weights,
+    quantized on .to(cuda), self-contained forward via bnb.matmul_4bit per
+    expert. Replaces Qwen3MoeExperts (or similar) with the same interface.
 
-    The module replaces Qwen3MoeExperts or similar, providing the same interface
-    but with quantized weights.
-
-    NOTE: BNB 4-bit MoE uses loop-based forward (each expert processed individually).
-    For maximum throughput, consider using grouped_mm backend with native bf16 weights.
-    Set UNSLOTH_MOE_BACKEND=grouped_mm environment variable.
+    NOTE: forward is loop-based (each expert processed individually). For max
+    throughput use the grouped_mm backend with native bf16 weights:
+    set UNSLOTH_MOE_BACKEND=grouped_mm.
     """
     _warned_loop_based = False
 
@@ -86,19 +75,7 @@ class MoeExperts4bit(nn.Module):
         quant_storage: torch.dtype = torch.uint8,
         device: Optional[torch.device] = None,
     ):
-        """
-        Initialize MoeExperts4bit.
-
-        Args:
-            num_experts: Number of experts in the MoE layer
-            hidden_dim: Hidden dimension of the model
-            intermediate_dim: Intermediate dimension of FFN
-            compute_dtype: Dtype for computation (typically bf16 or fp16)
-            compress_statistics: Whether to compress quantization statistics
-            quant_type: Quantization type ("nf4" or "fp4")
-            quant_storage: Storage dtype for quantized weights
-            device: Device to place weights on
-        """
+        """quant_type is "nf4" or "fp4"; compute_dtype is typically bf16/fp16."""
         super().__init__()
         _check_bnb_available()
 
@@ -111,21 +88,17 @@ class MoeExperts4bit(nn.Module):
         self.quant_type = quant_type
         self.quant_storage = quant_storage
 
-        # Flag for detection
         self._is_bnb_4bit = True
 
-        # Per-expert quantized weights stored as ParameterLists for proper registration
-        # Each expert's gate_up_proj: Params4bit of shape [2*intermediate_dim, hidden_dim]
-        # Each expert's down_proj: Params4bit of shape [hidden_dim, intermediate_dim]
+        # Per-expert quantized weights as ParameterLists (proper registration).
+        # gate_up_proj: [2*intermediate_dim, hidden_dim]; down_proj: [hidden_dim, intermediate_dim]
         self._bnb_gate_up_weights = nn.ParameterList()
         self._bnb_down_weights = nn.ParameterList()
 
-        # These will hold the original Parameters for weight loading
-        # They get converted to Params4bit when .to(cuda) is called
+        # Original Parameters held for loading; converted to Params4bit on .to(cuda)
         self._gate_up_proj_pending = None
         self._down_proj_pending = None
 
-        # Activation function
         self.act_fn = F.silu
 
     def set_compute_type(self, x: torch.Tensor):
@@ -141,30 +114,26 @@ class MoeExperts4bit(nn.Module):
                 warnings.filterwarnings("ignore", message=".*slow inference.*")
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
-        """
-        Override to handle loading 3D stacked weights and convert to Params4bit.
+        """Load 3D stacked weights and convert to Params4bit.
 
-        This is called during model.load_state_dict() - the key place where on-the-fly
-        quantization happens.
+        Called during model.load_state_dict() - where on-the-fly quantization happens.
         """
         gate_up_key = prefix + "gate_up_proj"
         down_key = prefix + "down_proj"
 
-        # Check if loading original stacked format
+        # Loading original stacked format
         if gate_up_key in state_dict:
-            # Store the weights temporarily - will be quantized on .to(cuda)
             gate_up_proj = state_dict.pop(gate_up_key)
             down_proj = state_dict.pop(down_key)
 
-            # If on CUDA, quantize immediately
             if gate_up_proj.device.type == 'cuda':
                 self._quantize_and_store(gate_up_proj, down_proj)
             else:
-                # Store for later quantization on .to(cuda)
+                # Defer quantization until .to(cuda)
                 self.register_buffer("_gate_up_proj_pending", gate_up_proj)
                 self.register_buffer("_down_proj_pending", down_proj)
         else:
-            # Try loading per-expert quantized format
+            # Per-expert quantized format
             super()._load_from_state_dict(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
 
     def _quantize_and_store(self, gate_up_proj: torch.Tensor, down_proj: torch.Tensor):
@@ -172,18 +141,16 @@ class MoeExperts4bit(nn.Module):
         num_experts = gate_up_proj.shape[0]
         self.num_experts = num_experts
 
-        # Clear existing
         self._bnb_gate_up_weights = nn.ParameterList()
         self._bnb_down_weights = nn.ParameterList()
 
         device = gate_up_proj.device
 
         for expert_idx in range(num_experts):
-            # Extract 2D weight for this expert
             gate_up_weight = gate_up_proj[expert_idx].detach().clone()  # [2*I, H]
             down_weight = down_proj[expert_idx].detach().clone()  # [H, I]
 
-            # Create Params4bit - quantization happens here since on CUDA
+            # Params4bit quantizes here (on CUDA)
             gate_up_4bit = Params4bit(
                 gate_up_weight,
                 requires_grad=False,
@@ -209,37 +176,25 @@ class MoeExperts4bit(nn.Module):
             self._bnb_gate_up_weights.append(gate_up_4bit)
             self._bnb_down_weights.append(down_4bit)
 
-        # Clear pending buffers
         if hasattr(self, "_gate_up_proj_pending") and self._gate_up_proj_pending is not None:
             del self._gate_up_proj_pending
         if hasattr(self, "_down_proj_pending") and self._down_proj_pending is not None:
             del self._down_proj_pending
 
     def _apply(self, fn, recurse=True):
-        """
-        Override _apply to handle quantization when .to(cuda) is called.
-
-        This is the key hook for on-the-fly quantization - when the model is moved
-        to CUDA, pending weights are quantized.
-        """
-        # Check if moving to CUDA and have pending weights
+        """Quantize pending weights when the model is moved to CUDA."""
         if hasattr(self, "_gate_up_proj_pending") and self._gate_up_proj_pending is not None:
-            # Apply the function to get the target device
-            test_tensor = fn(torch.zeros(1))
+            test_tensor = fn(torch.zeros(1))  # probe the target device
             if test_tensor.device.type == 'cuda':
-                # Quantize now
                 pending_gate_up = fn(self._gate_up_proj_pending)
                 pending_down = fn(self._down_proj_pending)
                 self._quantize_and_store(pending_gate_up, pending_down)
-                # Skip applying to pending weights since we've consumed them
-                return self
+                return self  # pending weights consumed
 
         return super()._apply(fn, recurse)
 
     def _matmul_4bit(self, x: torch.Tensor, weight: Params4bit) -> torch.Tensor:
-        """
-        Perform 4-bit matmul using bitsandbytes, following Linear4bit.forward pattern.
-        """
+        """4-bit matmul via bitsandbytes, following Linear4bit.forward."""
         quant_state = weight.quant_state
         w = weight.t()
         return bnb.matmul_4bit(x, w, bias=None, quant_state=quant_state)
@@ -250,16 +205,12 @@ class MoeExperts4bit(nn.Module):
         top_k_index: torch.Tensor,
         top_k_weights: torch.Tensor,
     ) -> torch.Tensor:
-        """
-        Optimized forward pass using bnb.matmul_4bit for each expert.
-        Only iterates over experts that actually have tokens routed to them.
-        """
+        """Forward via bnb.matmul_4bit, only over experts that have routed tokens."""
         # Set compute type on first forward (like Linear4bit)
         if not self.compute_type_is_set:
             self.set_compute_type(hidden_states)
             self.compute_type_is_set = True
 
-            # Warn about loop-based forward (only once)
             if UNSLOTH_ENABLE_LOGGING and not MoeExperts4bit._warned_loop_based:
                 MoeExperts4bit._warned_loop_based = True
                 logger.warning(
@@ -273,39 +224,28 @@ class MoeExperts4bit(nn.Module):
 
         final_hidden_states = torch.zeros_like(hidden_states)
 
-        # Optimized routing: only process experts that have tokens
-        # This is much faster than iterating over all 128 experts
+        # Only process experts that have tokens (much faster than all 128)
         with torch.no_grad():
             expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts)
             expert_mask = expert_mask.permute(2, 1, 0)  # [num_experts, top_k, num_tokens]
-            # Find which experts actually have tokens (sum across top_k and tokens dims)
             expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero(as_tuple=False)
 
-        # Only loop over experts that have tokens routed to them
         for expert_idx_t in expert_hit:
             expert_idx = expert_idx_t.item()
             top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
 
             current_state = hidden_states[token_idx]
 
-            # Get quantized weights for this expert
             gate_up_weight = self._bnb_gate_up_weights[expert_idx]
             down_weight = self._bnb_down_weights[expert_idx]
 
-            # Compute gate_up projection using bnb.matmul_4bit
             gate_up_out = self._matmul_4bit(current_state, gate_up_weight)
             gate, up = gate_up_out.chunk(2, dim=-1)
-
-            # Activation
             current_hidden_states = self.act_fn(gate) * up
-
-            # Compute down projection using bnb.matmul_4bit
             current_hidden_states = self._matmul_4bit(current_hidden_states, down_weight)
 
-            # Apply routing weights
+            # Apply routing weights and scatter back
             current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
-
-            # Scatter back
             final_hidden_states.index_add_(
                 0, token_idx, current_hidden_states
             )
@@ -314,9 +254,8 @@ class MoeExperts4bit(nn.Module):
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         """Save quantized weights to state dict, following Linear4bit pattern."""
-        # Handle case where weights haven't been loaded yet (empty ParameterLists)
+        # Weights not loaded yet (empty ParameterLists): default save
         if len(self._bnb_gate_up_weights) == 0:
-            # Fall back to default state dict saving
             super()._save_to_state_dict(destination, prefix, keep_vars)
             return
 
@@ -324,7 +263,6 @@ class MoeExperts4bit(nn.Module):
             gate_up_4bit = self._bnb_gate_up_weights[expert_idx]
             down_4bit = self._bnb_down_weights[expert_idx]
 
-            # Save weight data
             gate_up_prefix = f"{prefix}_bnb_gate_up_weights.{expert_idx}."
             down_prefix = f"{prefix}_bnb_down_weights.{expert_idx}."
 
@@ -359,18 +297,12 @@ def replace_with_bnb_moe_experts(
     model: nn.Module,
     quantization_config=None,
 ) -> Tuple[nn.Module, bool]:
-    """
-    Replace MoE expert modules with 4-bit quantized versions BEFORE weights are loaded.
+    """Replace MoE expert modules with 4-bit quantized versions before weights load.
 
-    This follows the same pattern as transformers' replace_with_bnb_linear - we replace
-    the modules on meta device, then weights are loaded and quantized on-the-fly.
+    Like transformers' replace_with_bnb_linear: swap modules on meta device,
+    then weights are loaded and quantized on-the-fly.
 
-    Args:
-        model: The model to convert
-        quantization_config: BitsAndBytesConfig with quantization parameters
-
-    Returns:
-        Tuple of (model, has_been_replaced)
+    Returns (model, has_been_replaced).
     """
     _check_bnb_available()
 
@@ -393,29 +325,25 @@ def replace_with_bnb_moe_experts(
         if hasattr(module, 'experts') and hasattr(module.experts, 'gate_up_proj'):
             experts = module.experts
 
-            # Skip if already quantized
             if getattr(experts, '_is_bnb_4bit', False):
-                continue
+                continue  # already quantized
 
-            # Get dimensions from the original module
             gate_up_proj = experts.gate_up_proj
             num_experts = gate_up_proj.shape[0]
 
-            # Determine quantized class based on module type
             module_class_name = type(module).__name__
             if 'Qwen3VL' in module_class_name or 'qwen3_vl' in type(module).__module__:
                 quantized_cls = Qwen3VLMoeExperts4bit
-                # Qwen3-VL has transposed weights in grouped_mm format (E, H, 2*I)
-                # gate_up_proj: (E, H, 2*I)
+                # Qwen3-VL: transposed grouped_mm format gate_up_proj (E, H, 2*I)
                 intermediate_dim = gate_up_proj.shape[2] // 2
                 hidden_dim = gate_up_proj.shape[1]
             else:
                 quantized_cls = Qwen3MoeExperts4bit
-                # Qwen3-MoE has weights in F.linear format (E, 2*I, H)
+                # Qwen3-MoE: F.linear format (E, 2*I, H)
                 intermediate_dim = gate_up_proj.shape[1] // 2
                 hidden_dim = gate_up_proj.shape[2]
 
-            # Create quantized version on meta device (like replace_with_bnb_linear does)
+            # Create quantized version on meta device (like replace_with_bnb_linear)
             with torch.device("meta"):
                 new_experts = quantized_cls(
                     num_experts=num_experts,
@@ -427,11 +355,9 @@ def replace_with_bnb_moe_experts(
                     quant_storage=quant_storage,
                 )
 
-            # Copy activation function if present
             if hasattr(experts, 'act_fn'):
                 new_experts.act_fn = experts.act_fn
 
-            # Replace the module
             module.experts = new_experts
             has_been_replaced = True
 
@@ -451,11 +377,9 @@ def is_moe_quantized(module: nn.Module) -> bool:
 
 # Compatibility functions for post-loading quantization (kept for manual use)
 def quantize_moe_experts_inplace(model: nn.Module, verbose: bool = True) -> int:
-    """
-    Post-loading quantization (uses more memory but works with any model).
+    """Post-loading quantization (more memory, but works with any model).
 
-    NOTE: Prefer replace_with_bnb_moe_experts() for on-the-fly quantization
-    which uses less peak memory.
+    Prefer replace_with_bnb_moe_experts() for lower-peak on-the-fly quantization.
     """
     _check_bnb_available()
 
@@ -504,11 +428,9 @@ def quantize_moe_experts_inplace(model: nn.Module, verbose: bool = True) -> int:
 
 
 def post_quantize_moe_experts(model: nn.Module, load_in_4bit: bool = False, verbose: bool = True) -> nn.Module:
-    """
-    Post-loading hook to quantize MoE experts to 4-bit.
+    """Post-loading hook to quantize MoE experts to 4-bit.
 
-    NOTE: This uses post-quantization which requires more peak memory.
-    For lower memory usage, use replace_with_bnb_moe_experts() before weight loading.
+    Uses more peak memory; prefer replace_with_bnb_moe_experts() before loading.
     """
     if not load_in_4bit or not HAS_BNB:
         return model

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -23,7 +23,6 @@ from typing import Optional, Tuple
 from torch.autograd import Function
 from unsloth_zoo.mlx import is_mlx_available
 
-# Get compile location
 UNSLOTH_COMPILE_LOCATION = os.environ.get(
     "UNSLOTH_COMPILE_LOCATION", "unsloth_compiled_cache"
 )
@@ -49,10 +48,7 @@ def _log_info(message: str):
 
 
 def install_to_cache(source_path, destination_filename=None):
-    """
-    Copies a file to the unsloth_compiled_cache directory
-    to ensure it is available for compiled modules.
-    """
+    """Copy a file into unsloth_compiled_cache so compiled modules can use it."""
     compile_location = _get_compile_location()
     if not os.path.exists(compile_location):
         try:
@@ -66,7 +62,6 @@ def install_to_cache(source_path, destination_filename=None):
 
     destination = os.path.abspath(os.path.join(compile_location, destination_filename))
 
-    # If source and dest are different, copy.
     if current_file != destination:
         try:
             shutil.copy(current_file, destination)
@@ -108,10 +103,7 @@ def _load_cached_moe_utils_module():
 
 
 def get_forward_moe_backend():
-    """
-    Resolve forward_moe_backend from the compiled cache copy when available.
-    Falls back to the local module definition.
-    """
+    """Resolve forward_moe_backend from the compiled cache copy, else the local def."""
     global _CACHED_FORWARD_MOE_BACKEND
     module = _load_cached_moe_utils_module()
     if module is not None and hasattr(module, "forward_moe_backend"):
@@ -121,21 +113,14 @@ def get_forward_moe_backend():
     _CACHED_FORWARD_MOE_BACKEND = forward_moe_backend
     return _CACHED_FORWARD_MOE_BACKEND
 
-# ============================================================================
-# Grouped MM wrapper
-# ============================================================================
-# Simple wrapper around torch._grouped_mm that ensures contiguous inputs.
-# Native backward works correctly - no custom autograd needed.
-# ============================================================================
+# Grouped MM wrapper around torch._grouped_mm; native backward works correctly.
 
 
 def _grouped_mm_with_backward_fix(
     inputs: torch.Tensor, weight: torch.Tensor, offsets: torch.Tensor
 ) -> torch.Tensor:
-    """
-    Grouped matmul with working backward pass.
+    """Grouped matmul via torch._grouped_mm with contiguous inputs.
 
-    Uses native torch._grouped_mm with contiguous inputs for correct gradients.
     Some low-rank LoRA weights are contiguous but still have row strides below
     the kernel alignment requirement, so keep a narrow fallback for those cases.
     """
@@ -153,9 +138,7 @@ def _grouped_mm_with_backward_fix(
 def _manual_grouped_mm(
     inputs: torch.Tensor, weight: torch.Tensor, offsets: torch.Tensor
 ) -> torch.Tensor:
-    """
-    Differentiable grouped matmul fallback for torch._grouped_mm alignment gaps.
-    """
+    """Differentiable grouped matmul fallback for torch._grouped_mm alignment gaps."""
     outputs = []
     start = 0
     for expert_idx, end in enumerate(offsets.detach().cpu().tolist()):
@@ -167,20 +150,15 @@ def _manual_grouped_mm(
     return inputs.new_empty((0, weight.shape[-1]))
 
 
-# Global flag to check if grouped GEMM is available
 _GROUPED_GEMM_AVAILABLE = None
 _TORCH_GROUPED_MM_AVAILABLE = hasattr(torch, "_grouped_mm")
 
-# Check if GPU supports torch._grouped_mm (verified via runtime check)
+# GPU support for torch._grouped_mm, verified via runtime probe.
 _TORCH_GROUPED_MM_SUPPORTED = None
 
 
 def _check_torch_grouped_mm_supported():
-    """
-    Check if torch._grouped_mm is actually supported on the current GPU.
-    We check for existence and verify with a dummy call.
-    A runtime probe is the only reliable check.
-    """
+    """Check torch._grouped_mm support on the current GPU; a runtime probe is the only reliable check."""
     global _TORCH_GROUPED_MM_SUPPORTED
     if _TORCH_GROUPED_MM_SUPPORTED is not None: return _TORCH_GROUPED_MM_SUPPORTED
 
@@ -193,13 +171,11 @@ def _check_torch_grouped_mm_supported():
         return False
 
     try:
-        # Attempt a dummy grouped_mm call to verify support.
-        # This handles cases where the symbol exists but hardware is unsupported (e.g. < H100).
-        # It also allows support on newer hardware or backports without code changes.
+        # Dummy call verifies real support (symbol may exist but hardware unsupported, e.g. < H100).
         device = torch.cuda.current_device()
         dtype = torch.float16
 
-        # Minimal dummy data: 1 expert, 1 token, dim 8 (safe alignment)
+        # 1 expert, 1 token, dim 8 (safe alignment).
         x = torch.ones((1, 8), device=device, dtype=dtype)
         w = torch.ones((1, 8, 8), device=device, dtype=dtype)
         offs = torch.tensor([1], device=device, dtype=torch.int32)
@@ -218,23 +194,17 @@ _PERSISTENT_BUFFER = None
 
 
 def _init_triton_allocator():
-    """
-    Initialize a persistent Triton allocator to avoid memory allocation overhead per call.
-    This significantly reduces GPU utilization fluctuation.
-    """
+    """Initialize a persistent Triton allocator to avoid per-call allocation overhead."""
     global _TRITON_ALLOCATOR_INITIALIZED, _PERSISTENT_BUFFER
     if _TRITON_ALLOCATOR_INITIALIZED: return
 
     try:
         import triton
 
-        # Create a persistent buffer that grows as needed
-        # This avoids allocating new memory on every kernel call
-
+        # Persistent buffer that grows as needed, avoiding per-kernel allocations.
         def persistent_alloc_fn(size: int, alignment: int, stream):
             global _PERSISTENT_BUFFER
-            # Round up size to avoid frequent reallocations
-            # Round to nearest 128 bytes for alignment
+            # Round up to nearest 128 bytes for alignment / fewer reallocations.
             rounded_size = ((size + 128 - 1) // 128) * 128
 
             if (
@@ -242,8 +212,7 @@ def _init_triton_allocator():
                 or _PERSISTENT_BUFFER.numel() * _PERSISTENT_BUFFER.element_size()
                 < rounded_size
             ):
-                # Allocate with small headroom (10%) to reduce reallocations
-                # Use ByteTensor (uint8) for raw byte storage
+                # 10% headroom; uint8 for raw byte storage.
                 _PERSISTENT_BUFFER = torch.empty(
                     int(rounded_size * 1.1), device="cuda", dtype=torch.uint8
                 )
@@ -279,10 +248,9 @@ from functools import lru_cache
 
 @lru_cache(maxsize=1)
 def select_moe_backend():
-    """
-    Selects the MoE backend based on UNSLOTH_MOE_BACKEND environment variable and availability.
-    Choices: "grouped_mm", "unsloth_triton", "native_torch".
-    Default if unspecified: "grouped_mm".
+    """Select MoE backend from UNSLOTH_MOE_BACKEND + availability.
+
+    Choices: "grouped_mm", "unsloth_triton", "native_torch" (default "grouped_mm").
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
@@ -306,11 +274,12 @@ def select_moe_backend():
 
 
 def swap_moe_weights_for_call(experts_module, gate_up_proj, down_proj, forward_fn, *args):
-    """Temporarily install dequantized weights on the experts module for one
-    forward call, then restore the originals. Uses object.__setattr__ to bypass
-    nn.Module's Parameter (de)registration, which would re-register hooks and
-    is unnecessary for read-only temporary tensors. Used by both the FP8 and
-    bnb4bit MoE dispatchers."""
+    """Temporarily install dequantized weights for one forward call, then restore.
+
+    Uses object.__setattr__ to bypass nn.Module Parameter (de)registration
+    (re-registers hooks, unnecessary for read-only temp tensors). Used by the
+    FP8 and bnb4bit MoE dispatchers.
+    """
     original_gate_up = experts_module.gate_up_proj
     original_down = experts_module.down_proj
     object.__setattr__(experts_module, "gate_up_proj", gate_up_proj)
@@ -328,19 +297,14 @@ def forward_moe_backend(
     top_k_index: torch.Tensor,
     top_k_weights: torch.Tensor,
 ) -> torch.Tensor:
-    """
-    Dispatch MoE forward to the selected backend.
-    Centralizes backend selection to keep model-specific patches minimal.
-    """
+    """Dispatch MoE forward to the selected backend (keeps model-specific patches minimal)."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # Use absolute imports — this function is also copied into
-    # `unsloth_compiled_cache/moe_utils.py` where relative imports of sibling
-    # helper modules don't resolve (only the dispatcher is copied, helpers stay
-    # in unsloth_zoo.temporary_patches).
-    # Narrow `except ImportError` to ONLY the import statement; runtime errors
-    # inside the bnb4bit/fp8 path must propagate so we don't silently fall
-    # through to a backend that will crash on unsupported dtypes.
+    # Absolute imports: this function is also copied into
+    # unsloth_compiled_cache/moe_utils.py where relative imports of sibling
+    # helpers don't resolve (only the dispatcher is copied).
+    # Keep `except ImportError` around ONLY the import; runtime errors in the
+    # bnb4bit/fp8 path must propagate, not fall through to a crashing backend.
     _moe_uses_bnb4bit_expert_weights = forward_moe_backend_bnb4bit = None
     try:
         from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import (
@@ -375,41 +339,34 @@ def forward_moe_backend(
 
 @torch.no_grad()
 def _get_routing_indices(selected_experts, num_experts):
-    """
-    Compute token→expert mapping for grouped GEMM.
-    Uses bincount instead of histc to avoid float conversion overhead.
+    """Compute token->expert mapping for grouped GEMM.
 
-    Returns:
-        token_counts_by_expert: (num_experts,) token counts per expert
-        gather_indices: (total_tokens,) indices for gathering tokens in expert order
+    Returns (token_counts_by_expert (num_experts,), gather_indices (total_tokens,)).
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
     flat_experts = selected_experts.view(-1)
 
-    # bincount is faster than histc since it doesn't require float conversion
+    # bincount avoids histc's float conversion overhead.
     token_counts_by_expert = torch.bincount(flat_experts, minlength=num_experts).to(torch.int32)
 
-    # argsort with stable=True preserves order within each expert
+    # stable=True preserves order within each expert.
     gather_indices = flat_experts.argsort(stable=True)
 
     return token_counts_by_expert, gather_indices
 
 
 def _silu_and_mul(x):
-    """Fused SiLU activation and element-wise multiply for gate/up projections."""
+    """Fused SiLU + element-wise multiply for gate/up projections."""
     gate, up = x.chunk(2, dim=-1)
     return F.silu(gate) * up
 
 
-# ============================================================================
-# Separated LoRA Helper Functions
-# ============================================================================
+# Separated LoRA helpers.
 
 
 def _has_lora_adapters(param) -> bool:
-    """Check if parameter has active LoRA adapters (PEFT ParamWrapper)."""
-    # Check if this is a PEFT LoRA wrapper
+    """Check for active LoRA adapters (PEFT ParamWrapper)."""
     if not hasattr(param, "lora_A") or not hasattr(param, "lora_B"):
         return False
     if hasattr(param, "disable_adapters") and param.disable_adapters:
@@ -579,37 +536,14 @@ def extract_moe_lora_weights_for_grouped_mm(
 def _extract_lora_from_wrapper(
     wrapper, adapter_name: str = "default", experts_module=None
 ) -> Optional[Tuple[torch.Tensor, torch.Tensor, float, int]]:
-    """
-    Extract LoRA weights from PEFT ParamWrapper for MoE separated computation.
+    """Extract LoRA weights from a PEFT ParamWrapper for MoE separated grouped_mm.
 
-    PEFT ParamWrapper for 3D parameters creates:
-    - lora_A: nn.Linear(in_dim, E*R) -> weight: (E*R, in_dim)
-    - lora_B: nn.Linear(E*R, out_dim) -> weight: (out_dim, E*R)
+    PEFT 3D ParamWrapper gives lora_A: (E*R, in_dim), lora_B: (out_dim, E*R);
+    reshaped to first_weight (E, in_dim, R), second_weight (E, R, out_dim) so
+    delta = X @ first @ second. Handles both standard (E, out, in) Qwen3-MoE and
+    transposed (E, in, out) Qwen3-VL-MoE base weight layouts.
 
-    For grouped_mm: X @ first_weight @ second_weight
-
-    STANDARD FORMAT (Qwen3-MoE): weights stored as (E, out_dim, in_dim) for F.linear
-      gate_up_proj: (E, 2*I, H) - input X is (N, H), output is (N, 2*I)
-      down_proj:    (E, H, I)   - input X is (N, I), output is (N, H)
-
-      For gate_up with (E, 2*I, H):
-        lora_A: (E*R, H), lora_B: (2*I, E*R)
-        Input X (N, H) needs: X @ (E, H, R) @ (E, R, 2*I) -> (N, 2*I)
-        first_weight from lora_A: (E*R, H) -> (E, H, R) after view/permute
-        second_weight from lora_B: (2*I, E*R) -> (E, R, 2*I) after view/permute
-
-    TRANSPOSED FORMAT (Qwen3-VL-MoE): weights stored as (E, in_dim, out_dim) for grouped_mm
-      gate_up_proj: (E, H, 2*I) - input X is (N, H), output is (N, 2*I)
-      down_proj:    (E, I, H)   - input X is (N, I), output is (N, H)
-
-      For gate_up with (E, H, 2*I):
-        lora_A: (E*R, H), lora_B: (2*I, E*R)
-        Input X (N, H) needs: X @ (E, H, R) @ (E, R, 2*I) -> (N, 2*I)
-        first_weight from lora_A: (E*R, H) -> (E, H, R)
-        second_weight from lora_B: (2*I, E*R) -> (E, R, 2*I)
-
-    Returns:
-        (first_weight, second_weight, scaling, num_experts) or None
+    Returns (first_weight, second_weight, scaling, num_experts) or None.
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
@@ -636,11 +570,10 @@ def _extract_lora_from_wrapper(
         scaling = wrapper.scaling[adapter_name]
         num_experts = getattr(wrapper, "num_experts", 1)
 
-        # GET EXPERTS MODULE TO CHECK FOR REGISTERED EXTRACTOR
         if experts_module is None:
             experts_module = wrapper.get_base_layer() if hasattr(wrapper, "get_base_layer") else None
 
-        # Check for model-specific LoRA extractor attached to the experts module
+        # Model-specific LoRA extractor attached to the experts module, if any.
         extractor_fn = getattr(experts_module, "_unsloth_lora_extractor_fn", None)
 
         if extractor_fn is not None:
@@ -662,33 +595,23 @@ def _extract_lora_from_wrapper(
 def _extract_lora_weights(
     param, adapter_name: str = "default", num_experts: int = None, experts_module=None
 ) -> Optional[Tuple[torch.Tensor, torch.Tensor, float]]:
-    """
-    Extract LoRA A and B weights from PEFT ParamWrapper.
-
-    This is a compatibility wrapper around _extract_lora_from_wrapper.
-    Use _extract_lora_from_wrapper directly for new code.
-
-    Returns:
-        (first_weight, second_weight, scaling) for (X @ first) @ second
-    """
+    """Compat wrapper around _extract_lora_from_wrapper; returns (first, second, scaling)."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # Set num_experts on param if provided, so _extract_lora_from_wrapper can use it
+    # Pass num_experts through so _extract_lora_from_wrapper can use it.
     if num_experts is not None and not hasattr(param, "num_experts"):
         param.num_experts = num_experts
 
     result = _extract_lora_from_wrapper(param, adapter_name, experts_module=experts_module)
     if result is None:
         return None
-    # Return first 3 elements (first_weight, second_weight, scaling) without num_experts
     return result[0], result[1], result[2]
 
 
 def _get_base_weight(param):
-    """Get base weight from potentially wrapped parameter or module."""
+    """Get base weight from a potentially wrapped parameter or module."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # Recursively unwrap PEFT layers
     while hasattr(param, "base_layer"):
         param = param.base_layer
 
@@ -706,7 +629,6 @@ def _get_base_weight(param):
     if hasattr(param, "get_param"):
         return param.get_param()
 
-    # Handle Modules (Linear, etc.)
     if hasattr(param, "weight"):
         return param.weight
 
@@ -714,20 +636,15 @@ def _get_base_weight(param):
 
 
 def _get_lora_wrapper_for_param(experts_module, param_name):
-    """
-    Get the PEFT ParamWrapper for a specific parameter (gate_up_proj or down_proj).
-    Uses the explicit key stored in __dict__ if available.
-    Does NOT lazily setup wrappers as that requires traversing logic not present here.
-    """
+    """Get the PEFT ParamWrapper for gate_up_proj or down_proj; does not lazily set up wrappers."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
     if hasattr(experts_module, f"{param_name}_lora_wrapper"):
         return getattr(experts_module, f"{param_name}_lora_wrapper")
 
-    # Check simple attributes if it's directly wrapped
     if hasattr(experts_module, param_name):
         attr = getattr(experts_module, param_name)
-        if hasattr(attr, "lora_A"):  # Is a ParamWrapper
+        if hasattr(attr, "lora_A"):  # ParamWrapper
             return attr
 
     return None
@@ -736,11 +653,7 @@ def _get_lora_wrapper_for_param(experts_module, param_name):
 def native_moe_grouped_mm(
     inputs: torch.Tensor, weight: torch.Tensor, offsets: torch.Tensor
 ) -> torch.Tensor:
-    """
-    Native implementation using grouped_mm with backward fix.
-
-    Uses custom autograd function to avoid PyTorch's grouped_mm backward stride bug.
-    """
+    """Grouped_mm with backward fix for PyTorch's grouped_mm backward stride bug."""
     return _grouped_mm_with_backward_fix(inputs, weight, offsets)
 
 
@@ -752,58 +665,32 @@ def _apply_lora_grouped_mm(
     scaling: float,
     grouped_mm_func=native_moe_grouped_mm,
 ) -> torch.Tensor:
-    """
-    Apply LoRA using grouped GEMM: result = ((X @ B) @ A) * scaling
+    """Apply LoRA via grouped GEMM: result = ((X @ B) @ A) * scaling.
 
-    Args:
-        inputs: (total_tokens, in_dim)
-        lora_B: (num_experts, in_dim, rank) - First projection
-        lora_A: (num_experts, rank, out_dim) - Second projection
-        offsets: Grouped GEMM offsets
-        scaling: LoRA scaling factor
-        grouped_mm_func: Function to use for grouped GEMM (default: native_moe_grouped_mm)
+    inputs (total_tokens, in_dim); lora_B (E, in_dim, R); lora_A (E, R, out_dim).
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # 1. First Matmul (X @ B)
-    # lora_B is (E, in_dim, R)
-    # Native needs (E, in_dim, R) -> No Transpose
+    # X @ B then result @ A; both already in native (E, ...) layout, no transpose.
     lora_intermediate = grouped_mm_func(inputs, lora_B.contiguous(), offsets)
-
-    # 2. Second Matmul (result @ A)
-    # lora_A is (E, R, out_dim)
-    # Native needs (E, R, out_dim) -> No Transpose
     lora_delta = grouped_mm_func(lora_intermediate, lora_A.contiguous(), offsets)
 
     return lora_delta * scaling
 
 
 def _should_use_separated_lora() -> bool:
-    """
-    Check if separated LoRA approach should be used (default: True).
-    Set UNSLOTH_MOE_LORA_MERGED=1 to use merged approach instead.
-    """
+    """Use separated LoRA (default True); UNSLOTH_MOE_LORA_MERGED=1 forces the merged path."""
     return os.environ.get("UNSLOTH_MOE_LORA_MERGED", "0") != "1"
 
 
-# ============================================================================
-# Model-specific Weight Preprocessing Hooks
-# ============================================================================
-# Each model can register its own preprocessing function for weight transposition.
-# This allows the generic backend to work with different model weight layouts.
+# Model-specific weight preprocessing hooks: each model registers a transposition
+# function so the generic backend works across weight layouts.
 
 _WEIGHT_PREPROCESSORS = {}
 
 
 def register_weight_preprocessor(model_type: str, preprocessor_fn):
-    """
-    Register a weight preprocessor for a specific model type.
-
-    Args:
-        model_type: Model identifier (e.g., "qwen3_moe", "qwen3_vl_moe")
-        preprocessor_fn: Function(weight, proj_type, hidden_dim) -> processed_weight
-                        proj_type is "gate_up" or "down"
-    """
+    """Register a weight preprocessor (weight, proj_type, hidden_dim) -> weight for a model type."""
     _WEIGHT_PREPROCESSORS[model_type] = preprocessor_fn
 
 
@@ -815,70 +702,54 @@ def get_weight_preprocessor(model_type: str):
 def preprocess_weight(
     weight: torch.Tensor, proj_type: str, hidden_dim: int, model_type=None
 ):
-    """
-    Preprocess weight tensor for grouped_mm compatibility.
+    """Preprocess a weight into (E, in_dim, out_dim) for grouped_mm.
 
-    Uses model-specific preprocessor if registered, otherwise uses default logic.
-
-    Args:
-        weight: Weight tensor (E, dim1, dim2) or similar
-        proj_type: "gate_up" or "down"
-        hidden_dim: Hidden dimension for shape inference
-        model_type: Optional model type to use specific preprocessor
-
-    Returns:
-        Weight tensor in (E, in_dim, out_dim) format for grouped_mm
+    Uses a registered model-specific preprocessor if present, else transposes
+    by shape. proj_type is "gate_up" or "down".
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
     if model_type and model_type in _WEIGHT_PREPROCESSORS:
         return _WEIGHT_PREPROCESSORS[model_type](weight, proj_type, hidden_dim)
 
-    # Default preprocessing: check if transposition is needed
     if proj_type == "gate_up":
-        # For gate_up, we need (E, hidden_dim, 2*intermediate)
+        # Want (E, hidden_dim, 2*intermediate).
         if weight.shape[1] == hidden_dim:
             return weight
         else:
             return weight.transpose(-2, -1)
     else:  # down
-        # For down, we need (E, intermediate, hidden_dim)
+        # Want (E, intermediate, hidden_dim).
         if weight.shape[2] == hidden_dim:
             return weight
         else:
             return weight.transpose(-2, -1)
 
 
-# ============================================================================
-# Generic MoE Detection and ParamWrapper Patching
-# ============================================================================
+# Generic MoE detection and ParamWrapper patching.
 
 
 def _is_moe_experts_module(module) -> bool:
-    """
-    Check if module is an MoE experts layer (generic, not model-specific).
+    """Generic check for an MoE experts layer with stacked 3D expert weights.
 
-    Detects modules with stacked expert weights as 3D nn.Parameter:
-    - gate_up_proj/down_proj pattern (Qwen3-MoE, Qwen3-VL-MoE, etc.)
-    - w1/w2/w3 pattern (older MoE models)
+    Matches gate_up_proj/down_proj (Qwen3-MoE etc.) or w1/w2/w3 (older models).
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
     import torch.nn as nn
 
-    # Check for gate_up_proj pattern
-    # After PEFT's nn.utils.parametrize wrapping, accessing gate_up_proj
-    # returns torch.Tensor (not nn.Parameter), so we must accept both.
+    # After PEFT's parametrize wrapping, gate_up_proj is a Tensor (not Parameter),
+    # so accept both.
     if hasattr(module, "gate_up_proj"):
         param = module.gate_up_proj
-        # 4-bit parameters are packed into 2D tensors (n_params, 1) or similar.
+        # 4-bit params are packed into 2D tensors.
         if HAS_BNB and isinstance(param, Params4bit) and param.ndim == 2:
             return True
         # Standard MoE weights are 3D (num_experts, in, out).
         if isinstance(param, (nn.Parameter, torch.Tensor)) and param.ndim in (2, 3):
             return True
 
-    # Check for w1/w2 pattern (separate gate/up projections)
+    # w1/w2 pattern (separate gate/up projections).
     if hasattr(module, "w1") and hasattr(module, "w2"):
         w1 = module.w1
         if isinstance(w1, (nn.Parameter, torch.Tensor)) and w1.ndim in (2, 3):
@@ -898,39 +769,30 @@ _original_param_wrapper_forward = None
 def _patched_param_wrapper_forward(
     self, x: torch.Tensor, *args, **kwargs
 ) -> torch.Tensor:
-    """
-    Patched ParamWrapper.forward for MoE separated LoRA.
+    """Patched ParamWrapper.forward for MoE separated LoRA.
 
-    For MoE expert modules:
-    - Bypasses PEFTs _activate_lora parametrization context
-    - Stores LoRA data by parameter_name for forward_native_grouped_mm to use
-
-    For non-MoE modules:
-    - Falls back to original PEFT forward
+    For MoE experts: bypass PEFT's _activate_lora and stash LoRA data by
+    parameter_name for forward_native_grouped_mm. For non-MoE: original forward.
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # CRITICAL: Use self.base_layer for forward call (immediate parent)
-    # NOT self.get_base_layer() which recursively traverses to deepest layer!
-    # The wrapper chain must be preserved: down_proj -> gate_up_proj -> Qwen3MoeExperts
+    # Use self.base_layer (immediate parent), NOT get_base_layer() which recurses
+    # to the deepest layer; the wrapper chain down_proj -> gate_up_proj ->
+    # Qwen3MoeExperts must be preserved.
     immediate_base_layer = self.base_layer
 
-    # For storing LoRA data, we DO need the actual experts module
-    # Use get_base_layer() to find it (recursive traversal is correct here)
+    # For stashing LoRA data we need the actual experts module (recursive lookup).
     experts_module = self.get_base_layer()
 
     use_separated = _should_use_separated_lora()
     param_name = getattr(self, "parameter_name", None)
 
-    # Check if this is an MoE experts module that should use separated LoRA
     if (
         use_separated
         and param_name in ("gate_up_proj", "down_proj")
         and _is_moe_experts_module(experts_module)
     ):
-        # MoE experts: bypass PEFT's _activate_lora, use separated computation
-
-        # Check adapter state
+        # MoE experts: bypass PEFT's _activate_lora, use separated computation.
         if self.disable_adapters:
             if self.merged:
                 self.unmerge()
@@ -939,7 +801,7 @@ def _patched_param_wrapper_forward(
         if self.merged:
             return immediate_base_layer(x, *args, **kwargs)
 
-        # Ensure wrapper.num_experts is set for LoRA weight reshaping
+        # Ensure wrapper.num_experts is set for LoRA weight reshaping.
         if not hasattr(self, "num_experts"):
             if hasattr(experts_module, "num_experts"):
                 self.num_experts = experts_module.num_experts
@@ -948,21 +810,18 @@ def _patched_param_wrapper_forward(
                 if hasattr(p, "shape") and len(p.shape) >= 1:
                     self.num_experts = p.shape[0]
 
-        # Extract LoRA for this specific parameter
+        # Extract LoRA for this parameter and stash on the experts module
+        # (not base_layer): _unsloth_lora_gate_up_proj / _unsloth_lora_down_proj.
         lora_data = _extract_lora_from_wrapper(self)
 
         if lora_data is not None and param_name:
-            # Store LoRA data on the EXPERTS MODULE (not base_layer)
-            # e.g., _unsloth_lora_gate_up_proj or _unsloth_lora_down_proj
             lora_attr = f"_unsloth_lora_{param_name}"
             setattr(experts_module, lora_attr, lora_data)
 
         try:
-            # Call IMMEDIATE base_layer to preserve wrapper chain
-            # (down_proj wrapper calls gate_up_proj wrapper calls Qwen3MoeExperts)
+            # Immediate base_layer preserves the wrapper chain.
             result = immediate_base_layer(x, *args, **kwargs)
         finally:
-            # Clean up
             if param_name:
                 lora_attr = f"_unsloth_lora_{param_name}"
                 if hasattr(experts_module, lora_attr):
@@ -970,16 +829,12 @@ def _patched_param_wrapper_forward(
 
         return result
 
-    # Non-MoE: use original PEFT forward with _activate_lora
+    # Non-MoE: original PEFT forward with _activate_lora.
     return _original_param_wrapper_forward(self, x, *args, **kwargs)
 
 
 def patch_param_wrapper_for_moe():
-    """
-    Patch PEFT's ParamWrapper.forward to use separated LoRA for MoE.
-
-    This should be called after PEFT is imported.
-    """
+    """Patch PEFT's ParamWrapper.forward for MoE separated LoRA (call after PEFT import)."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
     global _original_param_wrapper_forward
@@ -994,11 +849,9 @@ def patch_param_wrapper_for_moe():
     try:
         from peft.tuners.lora.layer import ParamWrapper
 
-        # Store original forward
         if _original_param_wrapper_forward is None:
             _original_param_wrapper_forward = ParamWrapper.forward
 
-        # Patch with our version
         ParamWrapper.forward = _patched_param_wrapper_forward
 
         return True
@@ -1012,14 +865,10 @@ def forward_native_grouped_mm(
     top_k_index: torch.Tensor,
     top_k_weights: torch.Tensor,
 ) -> torch.Tensor:
-    """
-    Native Pytorch grouped GEMM MoE forward pass.
-    Uses torch._grouped_mm which is significantly faster than loop and works without Triton dependencies.
-    Requires torch._grouped_mm support (verified via runtime check).
-    """
+    """Native PyTorch grouped-GEMM MoE forward via torch._grouped_mm (no Triton; needs runtime support)."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # Runtime safety check - defense in depth
+    # Runtime safety check (defense in depth).
     if not _check_torch_grouped_mm_supported():
         major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
         raise RuntimeError(
@@ -1036,33 +885,21 @@ def forward_native_grouped_mm(
 
     hidden_states = hidden_states.view(-1, hidden_dim)
 
-    # 1. Calculate routing
+    # Routing: count tokens per expert, sort to group by expert, gather inputs.
     flat_top_k = top_k_index.view(-1)
     num_tokens_per_expert = torch.bincount(flat_top_k, minlength=self.num_experts).int()
-
-    # 2. Sort indices to group tokens by expert
     sorted_indices = torch.argsort(flat_top_k, stable=True)
     token_indices = sorted_indices // top_k_index.shape[-1]
-
-    # 3. Permute Input
-    # We need to gather inputs. Since we may have expanded top_k, we use token_indices to map back to original input
     permuted_input = hidden_states[token_indices]
-
-    # 4. Prepare Grouped MM arguments
     offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
 
-    # ========================================================================
-    # Gate + Up projection with optional separated LoRA (DEFAULT)
-    # ========================================================================
+    # Gate + Up projection with optional separated LoRA (default).
     use_separated_lora = _should_use_separated_lora()
     gate_up_lora = None
 
-    # Check for injected LoRA data from patched ParamWrapper (preferred path)
+    # Prefer LoRA injected by the patched ParamWrapper; fall back to the parameter.
     if getattr(self, "_unsloth_lora_gate_up_proj", None) is not None:
-        gate_up_lora = self._unsloth_lora_gate_up_proj[
-            :3
-        ]  # (first_weight, second_weight, scaling)
-    # Fallback: check parameter directly (for older wrapping patterns)
+        gate_up_lora = self._unsloth_lora_gate_up_proj[:3]  # (first, second, scaling)
     elif (
         use_separated_lora
         and hasattr(self, "gate_up_proj")
@@ -1073,37 +910,28 @@ def forward_native_grouped_mm(
         )
 
     if hasattr(self, "gate_up_proj"):
-        # Get base weights (raw, without LoRA)
         gate_up_base = _get_base_weight(self.gate_up_proj)
-
-        # Get model type for preprocessing (if registered)
         model_type = getattr(self, "_unsloth_model_type", None)
 
-        # Handle different weight shapes using preprocessor
-        # torch._grouped_mm backward requires weights to be contiguous; preprocessing may return a transposed view.
+        # grouped_mm backward needs contiguous weights; preprocess may return a transposed view.
         w1 = preprocess_weight(gate_up_base, "gate_up", hidden_dim, model_type)
-        # Base forward: X @ W
         mm1_out = _grouped_mm_with_backward_fix(permuted_input, w1, offsets)
 
-        # Add separated LoRA contribution: + ((X @ first) @ second) * scaling
-        # _extract_lora_from_wrapper returns (first_weight, second_weight, scaling)
+        # Separated LoRA: + ((X @ first) @ second) * scaling.
         if gate_up_lora is not None:
             first_weight, second_weight, scaling = gate_up_lora
 
-            # Cast to input dtype (LoRA weights are float32, input may be bfloat16)
-            # Ensure contiguous for grouped_mm alignment requirements
+            # Cast to input dtype (LoRA is float32) and make contiguous for grouped_mm.
             first_weight = first_weight.to(permuted_input.dtype).contiguous()
             second_weight = second_weight.to(permuted_input.dtype).contiguous()
 
-            # Step 1: permuted_input @ first_weight
             try:
                 lora_out = _grouped_mm_with_backward_fix(permuted_input, first_weight, offsets)
                 lora_out = lora_out.contiguous()
             except RuntimeError as e:
                 raise e
 
-            # Step 2: result @ second_weight
-            # Handle unaligned O dimension or other grouped_mm failures
+            # Second matmul; pad an unaligned output dim or fall back on failure.
             try:
                 if second_weight.shape[-1] % 8 != 0:
                     pad_size = 8 - (second_weight.shape[-1] % 8)
@@ -1119,7 +947,7 @@ def forward_native_grouped_mm(
                         lora_out, second_weight, offsets
                     )
             except RuntimeError:
-                # Fallback to manual loop if grouped_mm fails (e.g. stride alignment)
+                # Manual loop fallback on grouped_mm failure (e.g. stride alignment).
                 lora_delta = torch.empty(
                     (lora_out.shape[0], second_weight.shape[-1]),
                     dtype=lora_out.dtype,
@@ -1134,7 +962,6 @@ def forward_native_grouped_mm(
                         )
                     prev_offset = end
 
-            # Add scaled LoRA contribution
             mm1_out = mm1_out + lora_delta * scaling
 
         if hasattr(self, "gate_up_proj_bias") and self.gate_up_proj_bias is not None:
@@ -1149,7 +976,7 @@ def forward_native_grouped_mm(
             gate, up = mm1_out.chunk(2, dim=-1)
 
     elif hasattr(self, "w1") and hasattr(self, "w3"):
-        # Separate w1/w3 weights (older models)
+        # Separate w1/w3 weights (older models).
         w1_base = _get_base_weight(self.w1)
         w3_base = _get_base_weight(self.w3)
 
@@ -1159,7 +986,7 @@ def forward_native_grouped_mm(
         gate = _grouped_mm_with_backward_fix(permuted_input, w1, offsets)
         up = _grouped_mm_with_backward_fix(permuted_input, w3, offsets)
 
-        # Add LoRA for w1 and w3 separately if present
+        # Add LoRA for w1 and w3 separately if present.
         if use_separated_lora:
             if _has_lora_adapters(self.w1):
                 w1_lora = _extract_lora_weights(self.w1, experts_module=self)
@@ -1189,7 +1016,7 @@ def forward_native_grouped_mm(
 
     # Activation
     if "GptOssExperts" in self.__class__.__name__:
-        # Custom activation from GptOss
+        # Custom GptOss activation.
         limit = getattr(self, "limit", 7.0)
         alpha = getattr(self, "alpha", 1.702)
 
@@ -1202,17 +1029,12 @@ def forward_native_grouped_mm(
     else:
         inter = F.silu(gate) * up
 
-    # ========================================================================
-    # Down projection with optional separated LoRA (DEFAULT)
-    # ========================================================================
+    # Down projection with optional separated LoRA (default).
     down_lora = None
 
-    # Check for injected LoRA data from patched ParamWrapper (preferred path)
+    # Prefer LoRA injected by the patched ParamWrapper; fall back to the parameter.
     if getattr(self, "_unsloth_lora_down_proj", None) is not None:
-        down_lora = self._unsloth_lora_down_proj[
-            :3
-        ]  # (first_weight, second_weight, scaling)
-    # Fallback: check parameter directly (for older wrapping patterns)
+        down_lora = self._unsloth_lora_down_proj[:3]  # (first, second, scaling)
     elif (
         use_separated_lora
         and hasattr(self, "down_proj")
@@ -1221,36 +1043,25 @@ def forward_native_grouped_mm(
         down_lora = _extract_lora_weights(self.down_proj, num_experts=self.num_experts, experts_module=self)
 
     if hasattr(self, "down_proj"):
-        # Get base weights
         down_base = _get_base_weight(self.down_proj)
-
-        # Get model type for preprocessing (if registered)
         model_type = getattr(self, "_unsloth_model_type", None)
-
-        # Handle different weight shapes using preprocessor
         w2 = preprocess_weight(down_base, "down", hidden_dim, model_type)
-
-        # Base forward
         mm2_out = _grouped_mm_with_backward_fix(inter, w2, offsets)
 
-        # Add separated LoRA contribution if present
-        # _extract_lora_from_wrapper returns (first_weight, second_weight, scaling)
         if down_lora is not None:
             first_weight, second_weight, scaling = down_lora
 
-            # Cast to input dtype (LoRA weights are float32, input may be bfloat16)
+            # Cast to input dtype (LoRA is float32) and make contiguous for grouped_mm.
             first_weight = first_weight.to(inter.dtype).contiguous()
             second_weight = second_weight.to(inter.dtype).contiguous()
 
-            # Step 1: inter @ first_weight
             lora_out = _grouped_mm_with_backward_fix(inter, first_weight, offsets)
             lora_out = lora_out.contiguous()
 
-            # Step 2: result @ second_weight
             try:
                 lora_delta = _grouped_mm_with_backward_fix(lora_out, second_weight, offsets)
             except RuntimeError:
-                # Fallback to manual loop
+                # Manual loop fallback.
                 lora_delta = torch.empty(
                     (lora_out.shape[0], second_weight.shape[-1]),
                     dtype=lora_out.dtype,
@@ -1265,7 +1076,6 @@ def forward_native_grouped_mm(
                         )
                     prev_offset = end
 
-            # Add scaled LoRA contribution
             mm2_out = mm2_out + lora_delta * scaling
 
         if hasattr(self, "down_proj_bias") and self.down_proj_bias is not None:
@@ -1277,11 +1087,8 @@ def forward_native_grouped_mm(
     elif hasattr(self, "w2"):
         w2_base = _get_base_weight(self.w2)
         w2 = w2_base.transpose(-2, -1)
-
-        # Base forward
         mm2_out = _grouped_mm_with_backward_fix(inter, w2, offsets)
 
-        # Add LoRA if present
         if use_separated_lora and _has_lora_adapters(self.w2):
             w2_lora = _extract_lora_weights(self.w2, experts_module=self)
             if w2_lora is not None:
@@ -1294,7 +1101,7 @@ def forward_native_grouped_mm(
     else:
         raise AttributeError("MoE layer must have 'down_proj' or 'w2'.")
 
-    # 5. Apply Routing Weights and Scatter Add (Reduce)
+    # Apply routing weights and scatter-add (reduce).
     flat_weights = top_k_weights.view(-1)
     permuted_weights = flat_weights[sorted_indices]
     mm2_out = mm2_out * permuted_weights.unsqueeze(-1)
@@ -1319,34 +1126,18 @@ def forward_triton_grouped_gemm(
     top_k_index: torch.Tensor,
     top_k_weights: torch.Tensor,
 ) -> torch.Tensor:
-    """
-    Grouped GEMM MoE forward pass using Triton kernels.
-    Compatible with torch.compile (recommended mode="max-autotune" with cudagraph_mark_step_begin).
-    """
+    """Grouped-GEMM MoE forward via Triton kernels (torch.compile-compatible, mode="max-autotune")."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    # Import grouped GEMM interface
     from unsloth.kernels.moe.grouped_gemm.interface import grouped_gemm
-
-    # Import autotune cache
     from unsloth.kernels.moe.autotune_cache import get_or_autotune_moe_kernels
-
-    # Helper to check TMA support - assumes helper function or just check directly
-    # In original: it was a cached closure. Here we can use _supports_tma() directly
-
-    # nonlocal _MODEL_DIMS_AND_CONFIGS # We need a way to store this!
-    # For now, let's attach it to self if possible, or use a global usage
-    # Attaching to self is cleaner: self._unsloth_moe_configs
-
-    # Create expert mask and find which experts have tokens
 
     if not hasattr(self, "_unsloth_moe_configs"):
         self._unsloth_moe_configs = None
 
     use_separated_lora = _should_use_separated_lora()
 
-    # Prepare gate_up LoRA data (mirrors the down block below).
-    # Attribute is populated by the patched ParamWrapper forward.
+    # gate_up LoRA from the patched ParamWrapper (mirrors the down block below).
     gate_up_lora = None
     if getattr(self, "_unsloth_lora_gate_up_proj", None) is not None:
         gate_up_lora = self._unsloth_lora_gate_up_proj[:3]
@@ -1359,13 +1150,12 @@ def forward_triton_grouped_gemm(
             self.gate_up_proj, num_experts=self.num_experts
         )
 
-    # Handle 3D inputs (batch_size, seq_len, hidden_dim)
+    # Flatten 3D inputs (batch_size, seq_len, hidden_dim).
     is_3d = hidden_states.dim() == 3
     if is_3d:
         batch_size, seq_len, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
         num_tokens = batch_size * seq_len
-        # Also flatten top_k inputs if they are 3D
         if top_k_index.dim() == 3:
             top_k_index = top_k_index.view(-1, top_k_index.shape[-1])
         if top_k_weights.dim() == 3:
@@ -1375,11 +1165,11 @@ def forward_triton_grouped_gemm(
 
     top_k = top_k_index.shape[1]
 
-    # Cache model dimensions and kernel configs on first call
+    # Cache model dims and kernel configs on first call.
     if self._unsloth_moe_configs is None:
         intermediate_dim = self.gate_up_proj.shape[1] // 2
 
-        # Autotune first GEMM
+        # Autotune first GEMM.
         gemm1_configs = get_or_autotune_moe_kernels(
             num_experts=self.num_experts,
             hidden_dim=hidden_dim,
@@ -1388,28 +1178,22 @@ def forward_triton_grouped_gemm(
             dtype=hidden_states.dtype,
         )
 
-        # Autotune second GEMM
+        # Autotune second GEMM (output dim is hidden_dim).
         gemm2_configs = get_or_autotune_moe_kernels(
             num_experts=self.num_experts,
             hidden_dim=intermediate_dim,
-            intermediate_dim=hidden_dim,  # Output dim for 2nd GEMM is hidden_dim
+            intermediate_dim=hidden_dim,
             top_k=top_k,
             dtype=hidden_states.dtype,
         )
 
         self._unsloth_moe_configs = (intermediate_dim, gemm1_configs, gemm2_configs)
-
-        # Clear autotuning memory overhead
         torch.cuda.empty_cache()
 
-    # Unpack cached configs
     intermediate_dim, gemm1_configs, gemm2_configs = self._unsloth_moe_configs
-
-    # Unpack specific kernel configs
     fwd_config_1, bwd_dX_config_1, bwd_dW_config_1 = gemm1_configs
     fwd_config_2, bwd_dX_config_2, bwd_dW_config_2 = gemm2_configs
 
-    # Compute routing indices for grouped GEMM
     token_counts_by_expert, gather_indices = _get_routing_indices(
         top_k_index, self.num_experts
     )
@@ -1420,7 +1204,7 @@ def forward_triton_grouped_gemm(
     else:
         w1 = self.gate_up_proj.transpose(-2, -1).contiguous()
 
-    # First grouped GEMM: gate_up projection
+    # First grouped GEMM: gate_up projection.
     first_gemm_output = grouped_gemm(
         X=hidden_states,
         W=w1,
@@ -1429,18 +1213,16 @@ def forward_triton_grouped_gemm(
         gather_indices=gather_indices,
         permute_x=True,
         permute_y=False,
-        autotune=False,  # We use cached configs
+        autotune=False,  # cached configs
         kernel_config_fwd=fwd_config_1,
         kernel_config_bwd_dX=bwd_dX_config_1,
         kernel_config_bwd_dW=bwd_dW_config_1,
         is_first_gemm=True,
     )
 
-    # Add separated LoRA contribution for gate_up.
-    # grouped_gemm above ran with permute_x=True (internal gather); first_gemm_output
-    # is in expert-sorted order. _apply_lora_grouped_mm expects pre-permuted input,
-    # so gather hidden_states using gather_indices // top_k (maps expert-sorted row
-    # back to its originating token row).
+    # Separated LoRA for gate_up. grouped_gemm ran permute_x=True so first_gemm_output
+    # is expert-sorted; _apply_lora_grouped_mm wants pre-permuted input, so gather via
+    # gather_indices // top_k (expert-sorted row -> originating token row).
     if gate_up_lora is not None:
         first_weight, second_weight, scaling = gate_up_lora
         first_weight = first_weight.to(hidden_states.dtype)
@@ -1456,15 +1238,14 @@ def forward_triton_grouped_gemm(
         )
         first_gemm_output = first_gemm_output + gate_up_lora_delta
 
-    # Apply activation and multiply gate with up
+    # Activation + gate*up.
     if hasattr(self, 'act_fn') and callable(self.act_fn):
         gate, up = first_gemm_output.chunk(2, dim=-1)
         intermediate = self.act_fn(gate) * up
     else:
         intermediate = _silu_and_mul(first_gemm_output)
 
-    # Grouped GEMM 2: down projection
-    # Prepare LoRA data
+    # Grouped GEMM 2: down projection.
     down_lora = None
     if getattr(self, "_unsloth_lora_down_proj", None) is not None:
         down_lora = self._unsloth_lora_down_proj[:3]
@@ -1488,19 +1269,16 @@ def forward_triton_grouped_gemm(
         gather_indices=gather_indices,
         permute_x=False,
         permute_y=True,
-        autotune=False,  # We use cached configs
+        autotune=False,  # cached configs
         kernel_config_fwd=fwd_config_2,
         kernel_config_bwd_dX=bwd_dX_config_2,
         kernel_config_bwd_dW=bwd_dW_config_2,
         is_first_gemm=False,
     )
 
-    # Add separated LoRA contribution for Down
+    # Separated LoRA for down (intermediate already permuted from step 1, same offsets).
     if down_lora is not None:
         first_weight, second_weight, scaling = down_lora
-
-        # Intermediate is already permuted from step 1.
-        # Offsets are same.
 
         first_weight = first_weight.to(intermediate.dtype)
         second_weight = second_weight.to(intermediate.dtype)
@@ -1516,9 +1294,8 @@ def forward_triton_grouped_gemm(
 
         second_gemm_output = second_gemm_output + lora_delta
 
-    # Apply routing weights and sum across top_k experts
+    # Apply routing weights and sum across top_k: (num_tokens, top_k, hidden) -> (num_tokens, hidden).
     top_k_weights_casted = top_k_weights.to(hidden_states.dtype)
-    # Output shape: (num_tokens, top_k, hidden_dim) -> (num_tokens, hidden_dim)
     final_hidden_states = (
         second_gemm_output.view(num_tokens, top_k, hidden_dim)
         * top_k_weights_casted[..., None]
@@ -1538,10 +1315,7 @@ def forward_native_moe_loop(
     top_k_index: torch.Tensor,
     top_k_weights: torch.Tensor,
 ) -> torch.Tensor:
-    """
-    Loop-based MoE forward pass. Loops over experts that have tokens routed to them.
-    Explicitly disabled for torch.compile to prevent graph breaks/recompilation issues with dynamic control flow.
-    """
+    """Loop over experts with routed tokens; torch.compile-disabled to avoid graph breaks on dynamic control flow."""
     # This Unsloth Zoo code section is licensed under AGPL3
     final_hidden_states = torch.zeros_like(hidden_states)
     use_separated_lora = _should_use_separated_lora()
@@ -1557,9 +1331,8 @@ def forward_native_moe_loop(
         gate_up_lora = _extract_lora_weights(
             self.gate_up_proj, num_experts=self.num_experts, experts_module=self
         )
-    # Pre-cast LoRA factors to the activation dtype once (avoid per-expert .to()
-    # inside the loop). Casting `scaling` is a no-op when it's a Python float;
-    # if it's a tensor, leave it alone — the multiply broadcasts.
+    # Pre-cast LoRA factors to the activation dtype once (avoid per-expert .to()).
+    # `scaling` is left alone: a Python float is a no-op, a tensor broadcasts.
     if gate_up_lora is not None:
         _gate_up_first, _gate_up_second, _gate_up_scaling = gate_up_lora
         gate_up_lora = (
@@ -1587,31 +1360,24 @@ def forward_native_moe_loop(
             _down_scaling,
         )
 
-    # Create expert mask and find which experts have tokens
+    # Expert mask -> which experts have tokens.
     with torch.no_grad():
         expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts)
         expert_mask = expert_mask.permute(2, 1, 0)  # (num_experts, top_k, n_tokens)
         expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
 
-    # Some patches (Qwen3-VL-MoE) store experts in grouped_mm-friendly layout
-    # (E, in_dim, out_dim) rather than F.linear's (E, out_dim, in_dim). The
-    # patched __init__ sets `_unsloth_grouped_mm_format = True` to advertise
-    # this. Prefer it over the shape-only check below: the shape check is
-    # unsafe when intermediate_dim == hidden_dim (square dims).
+    # Some patches (Qwen3-VL-MoE) store experts in grouped_mm layout (E, in, out)
+    # rather than F.linear's (E, out, in) and set _unsloth_grouped_mm_format=True.
+    # Prefer it over the shape check, which is unsafe when intermediate_dim == hidden_dim.
     grouped_mm_format = bool(getattr(self, "_unsloth_grouped_mm_format", False))
 
-    # Only loop over experts that actually have tokens routed to them
     for expert_idx_t in expert_hit:
         expert_idx = expert_idx_t.item()
 
-        # Find which tokens are routed to this expert
         top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
-
-        # Gather only the tokens for this expert
         current_state = hidden_states[token_idx]
 
-        # Compute gate_up projection for this expert only
-        # Handle 'gate_up_proj' or 'w1'/'w3'
+        # gate_up projection for this expert ('gate_up_proj' or 'w1'/'w3').
         if hasattr(self, "gate_up_proj"):
             gate_up_weight = self.gate_up_proj[expert_idx]
             if grouped_mm_format or gate_up_weight.shape[-1] != current_state.shape[-1]:
@@ -1629,12 +1395,10 @@ def forward_native_moe_loop(
 
         current_hidden_states = self.act_fn(gate) * up
 
-        # Compute down projection for this expert only
+        # down projection for this expert.
         if hasattr(self, "down_proj"):
             down_weight = self.down_proj[expert_idx]
-            # Mirror the gate_up handling: prefer the explicit
-            # `_unsloth_grouped_mm_format` flag over the shape heuristic, which
-            # is unsafe when intermediate_dim == hidden_dim.
+            # Mirror gate_up: prefer the flag over the shape heuristic (unsafe at square dims).
             if grouped_mm_format or down_weight.shape[-1] != current_hidden_states.shape[-1]:
                 down_weight = down_weight.T
             down = F.linear(current_hidden_states, down_weight)
@@ -1647,12 +1411,10 @@ def forward_native_moe_loop(
         else:
             current_hidden_states = F.linear(current_hidden_states, self.w2[expert_idx])
 
-        # Apply routing weights
         current_hidden_states = (
             current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
         )
 
-        # Scatter back to final output
         final_hidden_states.index_add_(
             0, token_idx, current_hidden_states.to(final_hidden_states.dtype)
         )

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -13,15 +13,13 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""
-bitsandbytes 4-bit support for transformers v5 MoE expert parameters.
+"""bitsandbytes 4-bit support for transformers v5 MoE expert parameters.
 
-transformers' bitsandbytes integration only quantizes nn.Linear modules. MoE
-expert weights in transformers v5 are bare 3-D nn.Parameters
-(gate_up_proj / down_proj on the experts module), so the integration skips
-them. The patches here teach the integration to recognize and quantize those
-parameters, and route the experts forward through the standard backend after
-on-the-fly dequantization.
+transformers' bnb integration only quantizes nn.Linear. In v5 the MoE expert
+weights are bare 3-D nn.Parameters (gate_up_proj / down_proj on the experts
+module), so the integration skips them. These patches teach it to recognize
+and quantize those parameters and route the experts forward through the
+standard backend after on-the-fly dequantization.
 """
 
 import os
@@ -82,9 +80,7 @@ def _moe_uses_bnb4bit_expert_weights(self) -> bool:
 
 
 def _is_expert_module(module: nn.Module) -> bool:
-    """A module is a transformers v5 MoE experts module iff gate_up_proj and
-    down_proj are both nn.Parameter (not nn.Linear).
-    """
+    """True iff gate_up_proj and down_proj are both nn.Parameter (v5 MoE experts)."""
     return (
         hasattr(module, "gate_up_proj")
         and hasattr(module, "down_proj")
@@ -98,8 +94,7 @@ def _is_expert_module(module: nn.Module) -> bool:
 # ============================================================================
 
 def _dequantize_bnb4bit_expert_weights(weight, target_dtype: torch.dtype):
-    """Dequantize a packed Params4bit MoE expert weight to logical 3D
-    `(E, in, out)` (or `(E, out, in)`, whichever the original storage was) at
+    """Dequantize a packed Params4bit MoE expert to its logical 3D shape at
     `target_dtype`. Returns None if `weight` isn't a quantized Params4bit.
     """
     if not _is_bnb4bit_param(weight):
@@ -128,12 +123,11 @@ def _log_moe_bnb4bit_backend_once(experts_module, message: str):
 
 
 def forward_moe_backend_bnb4bit(self, hidden_states, top_k_index, top_k_weights):
-    """
-    bnb 4-bit MoE forward: dequantize the expert weights to the input dtype,
-    then dispatch to the standard MoE backend (grouped_mm / triton / native).
+    """bnb 4-bit MoE forward: dequantize experts to the input dtype, then
+    dispatch to the standard MoE backend (grouped_mm / triton / native).
 
-    Mirrors `forward_moe_backend_fp8` structure. Base weights stay in 4-bit
-    Params4bit storage; the dequantized copies are temporary.
+    Mirrors `forward_moe_backend_fp8`. Base weights stay in 4-bit Params4bit
+    storage; dequantized copies are temporary.
     """
     from .moe_utils import (
         select_moe_backend,
@@ -150,8 +144,7 @@ def forward_moe_backend_bnb4bit(self, hidden_states, top_k_index, top_k_weights)
     gate_up_weight = _dequantize_bnb4bit_expert_weights(self.gate_up_proj, target_dtype)
     down_weight = _dequantize_bnb4bit_expert_weights(self.down_proj, target_dtype)
     if gate_up_weight is None or down_weight is None:
-        # Not bnb4bit after all (mixed state) — fall through to caller.
-        return None
+        return None  # not bnb4bit (mixed state) — fall through to caller
 
     backend = select_moe_backend()
     if backend == "grouped_mm":
@@ -185,9 +178,7 @@ def replace_expert_params_with_bnb_params(
     quantization_config = None,
     pre_quantized: bool = False,
 ) -> nn.Module:
-    """
-    Replace MoE parameters (gate_up_proj, down_proj) of nn.Parameter type with Params4bit.
-    """
+    """Replace MoE gate_up_proj / down_proj nn.Parameters with Params4bit."""
 
     try:
         from transformers.quantizers.quantizers_utils import should_convert_module
@@ -242,9 +233,8 @@ def replace_expert_params_with_bnb_params(
 
 
 def patch_bnb4bit_quantize_convert():
-    """
-    Expert modules of nn.Parameter type are converted to Params4bit placeholders during weight loading.
-    Also preserves the original shape of the expert parameters for PEFT LoRA compatibility.
+    """Convert nn.Parameter experts to Params4bit during weight loading,
+    preserving original shape for PEFT LoRA compatibility.
     """
 
     try:
@@ -363,12 +353,9 @@ pass
 
 
 def patch_transformers_weight_converter_kwargs():
-    """
-    PEFT 0.19 constructs WeightConverter with kwargs (distributed_operation,
-    quantization_operation, ...) that transformers 5.6.2's __init__ does not
-    accept, raising TypeError during PeftModel.from_pretrained for any MoE
-    4-bit model. Drop unknown kwargs so the installed transformers signature
-    only sees what it knows.
+    """Drop kwargs PEFT 0.19 passes to WeightConverter (distributed_operation,
+    quantization_operation, ...) that transformers 5.6.2's __init__ rejects,
+    which otherwise raises TypeError in PeftModel.from_pretrained for MoE 4-bit.
     """
     try:
         from transformers.core_model_loading import WeightConverter
@@ -400,18 +387,15 @@ pass
 
 # ============================================================================
 # PEFT LoRA support for stacked-MoE bnb 4-bit experts.
-# These hooks teach peft.tuners.lora.layer.ParamWrapper how to expose the
-# logical 3-D shape of a Params4bit (so LoRA picks the right (E, out, in)
-# layout) and how to merge / unmerge through a dequant -> add -> requant
-# cycle (so merge_and_unload() works against packed 4-bit storage).
-# They live here rather than in misc.py because they are functionally
-# partners to replace_expert_params_with_bnb_params + patch_bnb4bit_*.
+# Teach peft.tuners.lora.layer.ParamWrapper to expose a Params4bit's logical
+# 3-D shape (so LoRA picks the right (E, out, in) layout) and to merge/unmerge
+# via a dequant -> add -> requant cycle (so merge_and_unload() works against
+# packed 4-bit storage). Kept here as partners to
+# replace_expert_params_with_bnb_params + patch_bnb4bit_* rather than in misc.py.
 # ============================================================================
 
 class _ParamShapeProxy:
-    """
-    Wrapper class so that attributes for 4bit MoE params are exposed correctly for compatibility with PEFT LoRA, everything else delegates.
-    """
+    """Expose 4bit MoE param attributes correctly for PEFT LoRA; delegate the rest."""
 
     def __init__(self, param, shape):
         self._param = param
@@ -441,9 +425,8 @@ class _ParamShapeProxy:
 
 
 def patch_peft_param_wrapper_4bit_expert_shape():
-    """
-    ParamWrapper.get_param() derives shape from param.shape, which is incorrect for Params4bit parameters.
-    Patch ParamWrapper.get_param() to return a proxy that exposes .shape = _original_shape for 4bit MoE params.
+    """Patch ParamWrapper.get_param() to return a proxy exposing
+    .shape = _original_shape for 4bit MoE params (param.shape is wrong for them).
     """
     try:
         from peft.tuners.lora.layer import ParamWrapper
@@ -480,12 +463,11 @@ pass
 
 
 def patch_peft_param_wrapper_merge_4bit():
-    """
-    PEFT's ParamWrapper.merge does in-place `param.data += delta_weight`, which
-    fails for a Params4bit MoE expert because `param.data` is the packed
-    (N_packed, 1) uint8 storage and `delta_weight` is the logical 3D tensor.
-    Override merge/unmerge with a dequantize -> add -> re-quantize cycle when
-    the wrapped param is a Params4bit with a 3D _original_shape.
+    """Override ParamWrapper.merge/unmerge with a dequantize -> add ->
+    re-quantize cycle for Params4bit MoE experts with a 3D _original_shape.
+
+    PEFT's in-place `param.data += delta_weight` fails here: `param.data` is
+    packed (N_packed, 1) uint8 storage while `delta_weight` is the logical 3D.
     """
     try:
         from peft.tuners.lora.layer import ParamWrapper, check_adapters_to_merge
@@ -507,9 +489,8 @@ def patch_peft_param_wrapper_merge_4bit():
         return isinstance(param, Params4bit) and getattr(param, "_original_shape", None) is not None
 
     def _dequant_param_for_merge(param, parameter_name):
-        """Dequantize a Params4bit MoE expert to its logical 3D shape at the
-        compute dtype. Raises if `quant_state` hasn't been populated yet.
-        Shared helper between merge and unmerge."""
+        """Dequantize a Params4bit MoE expert to logical 3D at the compute
+        dtype; raises if `quant_state` is unpopulated. Shared by merge/unmerge."""
         quant_state = getattr(param, "quant_state", None)
         if quant_state is None:
             raise RuntimeError(

--- a/unsloth_zoo/temporary_patches/moe_utils_fp8.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_fp8.py
@@ -147,7 +147,6 @@ def _dequantize_expert_slice(
     if s.numel() == 1:
         return w * s.view(1, 1).to(target_dtype)
 
-    # Reshape 1D to column vector for per-row handling
     if s.ndim == 1:
         s = s.view(-1, 1)
 
@@ -176,8 +175,7 @@ def _dequantize_expert_slice(
 
         if block_size is not None and len(block_size) == 2:
             bm, bn = block_size
-            # Check if scale is transposed
-            if _ceil_div(M, bm) != p or _ceil_div(N, bn) != q:
+            if _ceil_div(M, bm) != p or _ceil_div(N, bn) != q:  # scale transposed?
                 if _ceil_div(M, bm) == q and _ceil_div(N, bn) == p:
                     s = s.T.contiguous()
                     p, q = s.shape
@@ -195,7 +193,7 @@ def _dequantize_expert_slice(
 
 
 def _dequantize_full_expert_weights_vectorized(weight: torch.Tensor, quant_state, target_dtype: torch.dtype,) -> Optional[torch.Tensor]:
-    """Vectorized dequantization: handles all experts in one batched op."""
+    """Dequantize all experts in one batched op."""
     if weight.ndim != 3 or weight.dtype != torch.float8_e4m3fn:
         return None
     if quant_state is None or not isinstance(quant_state, torch.Tensor):
@@ -219,8 +217,7 @@ def _dequantize_full_expert_weights_vectorized(weight: torch.Tensor, quant_state
         else:
             bm = _ceil_div(M, p)
             bn = _ceil_div(N, q)
-        # Expand block scales to full weight dims in one vectorized op
-        # (E, p, q) -> (E, p*bm, q*bn) -> trim to (E, M, N)
+        # Expand block scales (E, p, q) -> (E, p*bm, q*bn), trim to (E, M, N)
         s_expanded = (
             s.to(target_dtype)
             .repeat_interleave(bm, dim=1)[:, :M, :]
@@ -342,8 +339,7 @@ def _make_grouped_mm_rhs_column_major(weight: torch.Tensor) -> torch.Tensor:
 
 
 def _try_attach_block_size(tensor, block_size):
-    """Defensively attach block_size as an attribute, ignoring failures
-    (e.g. read-only Tensor subclasses)."""
+    """Attach block_size, ignoring failures (e.g. read-only Tensor subclasses)."""
     try:
         setattr(tensor, "block_size", block_size)
     except Exception:
@@ -353,8 +349,7 @@ def _try_attach_block_size(tensor, block_size):
 def _get_moe_weight_and_quant_info(experts_module, param_name: str):
     """Resolve the underlying expert weight tensor and (if present) its FP8
     block-quant scale tensor, walking through PEFT ParamWrapper if needed."""
-    # Use the FP8-aware unwrap so we get the raw FP8 tensor, NOT a
-    # bf16-merged ParamWrapper.get_param() value.
+    # FP8-aware unwrap returns the raw FP8 tensor, not a bf16-merged ParamWrapper value.
     weight = _unwrap_param_attr(experts_module, param_name)
     if weight is None:
         weight = getattr(experts_module, param_name, None)
@@ -594,11 +589,10 @@ def _unwrap_param_attr(module, name):
     obj = getattr(module, name, None)
     if obj is None:
         return None
-    # Already a tensor / Parameter.
     if isinstance(obj, torch.Tensor):
         return obj
-    # PEFT ParamWrapper exposes get_param() — call it BEFORE walking base_layer
-    # because base_layer points back to the experts module, not the tensor.
+    # Call get_param() BEFORE walking base_layer: base_layer points back to the
+    # experts module, not the tensor.
     while hasattr(obj, "get_param") and callable(obj.get_param):
         try:
             inner = obj.get_param()
@@ -609,8 +603,8 @@ def _unwrap_param_attr(module, name):
         if inner is obj:
             break
         obj = inner
-    # Last-ditch: if obj has a base_layer chain ending in something with the
-    # named attribute, recurse through it. (Handles nested ParamWrappers.)
+    # Walk a base_layer chain ending in something with the named attribute
+    # (handles nested ParamWrappers).
     seen = set()
     while hasattr(obj, "base_layer") and id(obj) not in seen:
         seen.add(id(obj))
@@ -747,7 +741,7 @@ def forward_moe_backend_fp8(self, hidden_states, top_k_index, top_k_weights):
 
     backend = select_moe_backend()
 
-    # 1. Try _scaled_grouped_mm (fast FP8 path on Hopper/Blackwell)
+    # 1. _scaled_grouped_mm (fast FP8 path on Hopper/Blackwell)
     if backend == "grouped_mm" and _check_torch_scaled_grouped_mm_supported():
         scaled_grouped_mm_output = _forward_scaled_grouped_mm_fp8(
             self,
@@ -762,7 +756,7 @@ def forward_moe_backend_fp8(self, hidden_states, top_k_index, top_k_weights):
             )
             return scaled_grouped_mm_output
 
-    # 2. Dequant FP8 weights to bf16/fp16 and run through normal MoE forward
+    # 2. Dequant FP8 weights to bf16/fp16, run through normal MoE forward
     target_dtype = _get_fp8_dequant_target_dtype(hidden_states)
     gate_up_base, gate_up_quant, gate_up_qkind = _get_moe_weight_and_quant_info(self, "gate_up_proj")
     down_base, down_quant, down_qkind = _get_moe_weight_and_quant_info(self, "down_proj")

--- a/unsloth_zoo/temporary_patches/mxfp4.py
+++ b/unsloth_zoo/temporary_patches/mxfp4.py
@@ -24,9 +24,8 @@ import math
 from .common import TEMPORARY_PATCHES, UNSLOTH_ENABLE_LOGGING, logger
 from .utils import patch_function, raise_error
 
-# MXFP4 configuration
-# Set UNSLOTH_MXFP4_NO_DEQUANTIZE=1 to keep MXFP4 weights quantized (requires triton_kernels)
-# Otherwise, MXFP4 weights will be dequantized to bf16 for LoRA training
+# UNSLOTH_MXFP4_NO_DEQUANTIZE=1 keeps MXFP4 quantized (needs triton_kernels);
+# otherwise weights dequantize to bf16 for LoRA training.
 UNSLOTH_MXFP4_NO_DEQUANTIZE = os.environ.get("UNSLOTH_MXFP4_NO_DEQUANTIZE", "0") == "1"
 
 
@@ -49,15 +48,9 @@ def is_triton_kernels_available():
 
 
 def should_dequantize_mxfp4():
-    """
-    Check if MXFP4 should be dequantized to bf16 for training.
+    """Whether MXFP4 should be dequantized to bf16 for training.
 
-    Returns True if:
-    - UNSLOTH_MXFP4_NO_DEQUANTIZE is not set or "0", OR
-    - UNSLOTH_MXFP4_NO_DEQUANTIZE="1" but triton_kernels is not available
-
-    Returns False if:
-    - UNSLOTH_MXFP4_NO_DEQUANTIZE="1" AND triton_kernels is available
+    True unless UNSLOTH_MXFP4_NO_DEQUANTIZE="1" and triton_kernels is available.
     """
     if not UNSLOTH_MXFP4_NO_DEQUANTIZE:
         return True  # Default: dequantize for compatibility
@@ -74,16 +67,10 @@ def should_dequantize_mxfp4():
 
 
 def get_mxfp4_config_for_training():
-    """
-    Get the appropriate Mxfp4Config for training.
-
-    Returns Mxfp4Config with dequantize=True unless:
-    - UNSLOTH_MXFP4_NO_DEQUANTIZE=1 AND triton_kernels is available
+    """Return the Mxfp4Config for training (dequantize=True unless
+    UNSLOTH_MXFP4_NO_DEQUANTIZE=1 and triton_kernels is available).
 
     Usage:
-        from unsloth_zoo.temporary_patches.mxfp4 import get_mxfp4_config_for_training
-        from transformers import AutoModelForCausalLM
-
         model = AutoModelForCausalLM.from_pretrained(
             "unsloth/gpt-oss-20b",
             quantization_config=get_mxfp4_config_for_training(),
@@ -105,9 +92,7 @@ def get_mxfp4_config_for_training():
     return Mxfp4Config(dequantize=dequantize)
 
 def patch_convert_moe_packed_tensors():
-    """
-    Pin the original GPU-optimized version of convert_moe_packed_tensors with smaller default chunk size.
-    """
+    """Pin the GPU convert_moe_packed_tensors with a smaller default chunk."""
     try:
         import transformers.integrations.mxfp4
         from transformers.integrations.mxfp4 import FP4_VALUES
@@ -121,17 +106,8 @@ def patch_convert_moe_packed_tensors():
         dtype: torch.dtype = torch.bfloat16,
         rows_per_chunk: int = 32768 * 1024,
     ) -> torch.Tensor:
-        """
-        Convert the mxfp4 weights again, dequantizing and makes them compatible with the forward
-        pass of GPT_OSS.
-
-        Args:
-            blocks: Packed quantized weights
-            scales: Quantization scales
-            dtype: Output data type
-            rows_per_chunk: Number of rows to process per chunk. .
-        """
-        # Check if blocks and scales are on CPU, and move to GPU if so
+        """Dequantize mxfp4 weights into GPT_OSS-compatible form (GPU path)."""
+        # Move CPU tensors to GPU if available.
         if not blocks.is_cuda and torch.cuda.is_available():
             blocks = blocks.cuda()
             scales = scales.cuda()
@@ -235,21 +211,13 @@ def patch_convert_moe_packed_tensors():
         dtype: torch.dtype = torch.bfloat16,
         rows_per_chunk: int = 1024 * 1024,  # CPU-optimized default (~2.6GB temp memory)
     ) -> torch.Tensor:
-        """
-        Convert the mxfp4 weights again, dequantizing and makes them compatible with the forward
-        pass of GPT_OSS. CPU-optimized version with smaller default chunk size.
+        """Dequantize mxfp4 weights into GPT_OSS-compatible form (CPU path,
+        smaller default chunk).
 
-        Args:
-            blocks: Packed quantized weights
-            scales: Quantization scales
-            dtype: Output data type
-            rows_per_chunk: Number of rows to process per chunk. CPU-optimized default: 1M rows.
-                           Memory usage per chunk (assuming B=128):
-                           - 8192: ~22 MB
-                           - 1048576 (1M): ~2.6 GB
-                           - 33554432 (32M): ~90 GB
+        rows_per_chunk default 1M rows; per-chunk memory at B=128: 8192 ~22 MB,
+        1M ~2.6 GB, 32M ~90 GB.
         """
-        # Ensure tensors are on CPU
+        # Force tensors onto CPU.
         if blocks.is_cuda:
             blocks = blocks.cpu()
         if scales.is_cuda:
@@ -259,7 +227,6 @@ def patch_convert_moe_packed_tensors():
 
         assert blocks.shape[:-1] == scales.shape, f"{blocks.shape[:-1]=} does not match {scales.shape=}"
 
-        # Create LUT on CPU
         lut = torch.tensor(FP4_VALUES, dtype=dtype, device='cpu')
 
         *prefix_shape, G, B = blocks.shape
@@ -268,7 +235,6 @@ def patch_convert_moe_packed_tensors():
         blocks = blocks.reshape(rows_total, B)
         scales = scales.reshape(rows_total, 1)
 
-        # Create output tensor on CPU
         out = torch.empty(rows_total, B * 2, dtype=dtype, device='cpu')
 
         for r0 in range(0, rows_total, rows_per_chunk):
@@ -292,7 +258,6 @@ def patch_convert_moe_packed_tensors():
         del blocks, scales, lut
         return out
 
-    # Add the new CPU function to the mxfp4 module
     if hasattr(transformers.integrations.mxfp4, 'convert_moe_packed_tensors'):
         transformers.integrations.mxfp4.convert_moe_packed_tensors_cpu = convert_moe_packed_tensors_cpu
         if UNSLOTH_ENABLE_LOGGING:

--- a/unsloth_zoo/temporary_patches/pixtral.py
+++ b/unsloth_zoo/temporary_patches/pixtral.py
@@ -84,10 +84,9 @@ def patch_PixtralAttention():
         attn_output = self.o_proj(attn_output)
         return attn_output, None
 
-    # Wrap so check_args_kwargs accepts removed params (e.g. output_attentions in v5).
-    # Preserve the original signature on the wrapper so inspect.signature
-    # (used by transformers._validate_model_kwargs among others) still sees
-    # the real named parameters.
+    # Wrap so check_args_kwargs accepts removed params (e.g. output_attentions in
+    # v5), but keep the original __signature__ so inspect.signature (used by
+    # transformers._validate_model_kwargs) still sees the real named parameters.
     target_cls = transformers.models.pixtral.modeling_pixtral.PixtralAttention
     _original_forward_signature = inspect.signature(target_cls.forward)
     _full_forward = forward

--- a/unsloth_zoo/temporary_patches/qwen3_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe.py
@@ -32,10 +32,7 @@ from .utils import (
 )
 
 
-# ============================================================================
 # Grouped GEMM kernel integration for MoE training acceleration
-# ============================================================================
-
 from .moe_utils import (
     patch_param_wrapper_for_moe,
     get_forward_moe_backend,
@@ -316,11 +313,8 @@ def patch_qwen3_moe():
                 final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
             return final_hidden_states.to(hidden_states.dtype), router_logits
     else:
-    # ====================================================================
-        # New transformers (5.0+) with stacked expert weights
-        # Uses Triton grouped GEMM kernels for high performance
-        # ====================================================================
-
+        # New transformers (5.0+) with stacked expert weights; uses Triton
+        # grouped GEMM kernels.
         _qwen3_lora_extractor = _make_qwen_moe_lora_extractor()
 
         transformers.models.qwen3_moe.modeling_qwen3_moe.Qwen3MoeExperts._unsloth_lora_extractor_fn = staticmethod(_qwen3_lora_extractor)
@@ -331,18 +325,16 @@ def patch_qwen3_moe():
             module_name=__name__,
         )
 
-    # For old transformers, patch Qwen3MoeSparseMoeBlock
-    # For new transformers, patch Qwen3MoeExperts (which has the expert loop)
+    # Old transformers: patch Qwen3MoeSparseMoeBlock.
+    # New transformers: patch Qwen3MoeExperts (which has the expert loop).
     if old_transformers:
         patch_function(transformers.models.qwen3_moe.modeling_qwen3_moe.Qwen3MoeSparseMoeBlock, "forward", forward)
     else:
         patch_function(transformers.models.qwen3_moe.modeling_qwen3_moe.Qwen3MoeExperts, "forward", forward)
         patch_function(transformers.models.qwen3_moe.modeling_qwen3_moe.Qwen3MoeSparseMoeBlock, "forward", sparse_moe_block_forward)
 
-    # ====================================================================
-    # Patch Qwen3MoeForCausalLM.forward for GRPO training
-    # When UNSLOTH_RETURN_HIDDEN_STATES=1, return hidden_states instead of logits
-    # ====================================================================
+    # Patch Qwen3MoeForCausalLM.forward for GRPO: return hidden_states instead
+    # of logits when UNSLOTH_RETURN_HIDDEN_STATES=1.
     try:
         from transformers.models.qwen3_moe.modeling_qwen3_moe import (
             Qwen3MoeForCausalLM,

--- a/unsloth_zoo/temporary_patches/qwen3_vl_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_vl_moe.py
@@ -76,8 +76,7 @@ def patch_qwen3_vl_moe():
         old_transformers = True
 
     if old_transformers:
-        # Fallback for older transformers if they exist (unlikely for Qwen3VL MoE but good for robustness)
-        # Assuming typical sparse block structure if Experts class is missing
+        # Fallback for older transformers missing the Experts class.
         @torch.compiler.disable
         def old_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
             """ """
@@ -97,7 +96,6 @@ def patch_qwen3_vl_moe():
             )
             if self.norm_topk_prob:
                 routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
-            # we cast back to the input dtype
             routing_weights = routing_weights.to(hidden_states.dtype)
 
             final_hidden_states = torch.zeros(
@@ -106,12 +104,11 @@ def patch_qwen3_vl_moe():
                 device=hidden_states.device,
             )
 
-            # One hot encode the selected experts to create an expert mask
+            # One-hot encode selected experts into an expert mask
             expert_mask = torch.nn.functional.one_hot(
                 selected_experts, num_classes=self.num_experts
             ).permute(2, 1, 0)
 
-            # Loop over all available experts in the model and perform the computation on each expert
             expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
             for expert_idx in expert_hit:
                 expert_layer = self.experts[expert_idx]
@@ -142,7 +139,6 @@ def patch_qwen3_vl_moe():
                 routing_weights = routing_weights / routing_weights.sum(
                     dim=-1, keepdim=True
                 )
-            # we cast back to the input dtype
             routing_weights = routing_weights.to(hidden_states.dtype)
             router_scores = torch.zeros_like(
                 router_logits, dtype=hidden_states.dtype
@@ -187,30 +183,17 @@ def patch_qwen3_vl_moe():
         # New transformers with stacked expert weights
         # ====================================================================
 
-        # Qwen3-VL-MoE checkpoints store weights in grouped_mm format (transposed):
-        #   gate_up_proj: (E, H, 2*I)  - ready for X @ W in grouped_mm
-        #   down_proj:    (E, I, H)    - ready for X @ W in grouped_mm
-        #
-        # But transformers defines them in F.linear format:
-        #   gate_up_proj: (E, 2*I, H)  - for F.linear: out = x @ weight.T
-        #   down_proj:    (E, H, I)
-        #
-        # We patch __init__ to match checkpoint format so loading works correctly.
-        # The forward() then uses these weights directly with grouped_mm.
+        # Qwen3-VL-MoE checkpoints store weights transposed for grouped_mm
+        # (gate_up_proj: (E, H, 2*I); down_proj: (E, I, H)), whereas transformers
+        # defines them in F.linear format. Patch __init__ to the checkpoint
+        # layout so loading works and forward() can use grouped_mm directly.
 
         from transformers.activations import ACT2FN
 
         def patched_experts_init(self, config):
-            """
-            Patched __init__ for Qwen3VLMoeTextExperts.
-
-            Creates weight parameters in grouped_mm format to match checkpoint:
-            - gate_up_proj: (E, H, 2*I) instead of (E, 2*I, H)
-            - down_proj: (E, I, H) instead of (E, H, I)
-
-            This ensures checkpoint loading works correctly, and the forward
-            can use weights directly with torch._grouped_mm without transposition.
-            """
+            """__init__ creating Qwen3VLMoeTextExperts weights in grouped_mm
+            layout (transposed from F.linear) so checkpoint loading and
+            torch._grouped_mm both work without transposition."""
             # This Unsloth Zoo code section is licensed under AGPL3
 
             super(
@@ -222,20 +205,19 @@ def patch_qwen3_vl_moe():
             self.hidden_dim = config.hidden_size
             self.intermediate_dim = config.moe_intermediate_size
 
-            # Weights in grouped_mm format (transposed from F.linear format)
-            # gate_up_proj: (E, H, 2*I) for X @ W where X is (N, H)
+            # grouped_mm layout: gate_up_proj (E, H, 2*I) for X @ W, X is (N, H)
             self.gate_up_proj = nn.Parameter(
                 torch.empty(
                     self.num_experts, self.hidden_dim, 2 * self.intermediate_dim
                 )
             )
-            # down_proj: (E, I, H) for X @ W where X is (N, I)
+            # down_proj (E, I, H) for X @ W, X is (N, I)
             self.down_proj = nn.Parameter(
                 torch.empty(self.num_experts, self.intermediate_dim, self.hidden_dim)
             )
             self.act_fn = ACT2FN[config.hidden_act]
 
-            # Mark that weights are already in grouped_mm format (no transpose needed)
+            # Weights already in grouped_mm format (no transpose needed)
             self._unsloth_grouped_mm_format = True
 
         # Patch __init__ before any model instantiation
@@ -260,10 +242,7 @@ def patch_qwen3_vl_moe():
                 top_k_index: torch.Tensor,
                 top_k_weights: torch.Tensor,
             ) -> torch.Tensor:
-                """
-                Native Pytorch grouped GEMM MoE forward pass.
-                Uses torch._grouped_mm which is significantly faster than loop and works without Triton dependencies.
-                """
+                """Native PyTorch grouped-GEMM MoE forward (torch._grouped_mm, no Triton)."""
                 return forward_native_grouped_mm(
                     self, hidden_states, top_k_index, top_k_weights
                 )
@@ -276,14 +255,7 @@ def patch_qwen3_vl_moe():
                 top_k_index: torch.Tensor,
                 top_k_weights: torch.Tensor,
             ) -> torch.Tensor:
-                """
-                Grouped GEMM MoE forward pass using Triton kernels.
-
-                Uses fused permutation (permute_x for first GEMM, permute_y for second GEMM)
-                to minimize memory traffic and achieve high GPU utilization.
-
-                Uses cached kernel configs (created once at start) for efficient operation.
-                """
+                """Grouped-GEMM MoE forward via Triton kernels (fused permutation, cached configs)."""
                 return forward_triton_grouped_gemm(
                     self, hidden_states, top_k_index, top_k_weights
                 )
@@ -302,16 +274,11 @@ def patch_qwen3_vl_moe():
                     self, hidden_states, top_k_index, top_k_weights
                 )
 
-        # SparseMoeBlock forward is disabled from compilation due to dynamic routing
+        # SparseMoeBlock forward not compiled due to dynamic routing
         @torch.compiler.disable
         def sparse_moe_block_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-            """
-            Forward for Qwen3VLMoeTextSparseMoeBlock in new transformers (v5+).
-
-            In v5, self.gate is Qwen3VLMoeTextTopKRouter which returns:
-                (router_logits, router_scores, router_indices)
-            where router_scores are already normalized.
-            """
+            """Qwen3VLMoeTextSparseMoeBlock forward for transformers v5+ (gate is
+            Qwen3VLMoeTextTopKRouter returning normalized router_scores)."""
             # This Unsloth Zoo code section is licensed under AGPL3
 
             if hidden_states.dim() == 3:
@@ -323,15 +290,13 @@ def patch_qwen3_vl_moe():
 
             hidden_states_reshaped = hidden_states.view(-1, hidden_dim)
 
-            # In v5, self.gate is Qwen3VLMoeTextTopKRouter
-            # It returns (router_logits, router_scores, router_indices)
             gate_output = self.gate(hidden_states_reshaped)
 
             if isinstance(gate_output, tuple):
-                # New transformers v5: (router_logits, router_scores, router_indices)
+                # v5: (router_logits, router_scores, router_indices)
                 _, routing_weights, selected_experts = gate_output
             else:
-                # Fallback: old-style gate that returns just logits
+                # Fallback: old-style gate returning just logits
                 router_logits = gate_output
                 top_k = getattr(self.gate, "top_k", getattr(self, "top_k", 2))
                 norm_topk_prob = getattr(
@@ -347,7 +312,6 @@ def patch_qwen3_vl_moe():
                         dim=-1, keepdim=True
                     )
                 routing_weights = routing_weights.to(hidden_states.dtype)
-
             final_hidden_states = self.experts(
                 hidden_states_reshaped, selected_experts, routing_weights
             )
@@ -365,14 +329,9 @@ def patch_qwen3_vl_moe():
             forward,
         )
     else:
-        # __init__ was patched above to create weights in grouped_mm format
-        # matching the Qwen3-VL-MoE checkpoint format:
-        #   gate_up_proj: (E, H, 2*I)  - for X @ W in grouped_mm
-        #   down_proj:    (E, I, H)    - for X @ W in grouped_mm
-        #
-        # The forward() uses these weights directly with torch._grouped_mm.
-        # LoRA extraction in moe_utils must account for this transposed layout.
-
+        # __init__ (patched above) creates weights in grouped_mm layout matching
+        # the checkpoint; forward() uses torch._grouped_mm directly. LoRA
+        # extraction in moe_utils must account for this transposed layout.
         patch_function(
             transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe.Qwen3VLMoeTextExperts,
             "forward",
@@ -386,10 +345,8 @@ def patch_qwen3_vl_moe():
             force=True,
         )
 
-    # ====================================================================
-    # Patch Qwen3VLMoeForConditionalGeneration.forward for GRPO training
-    # When UNSLOTH_RETURN_HIDDEN_STATES=1, return hidden_states instead of logits
-    # ====================================================================
+    # Patch Qwen3VLMoeForConditionalGeneration.forward for GRPO: when
+    # UNSLOTH_RETURN_HIDDEN_STATES=1, return hidden_states instead of logits.
     try:
         from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
             Qwen3VLMoeForConditionalGeneration,
@@ -437,7 +394,7 @@ def patch_qwen3_vl_moe():
                     **kwargs,
                 )
 
-            # RETURN_HIDDEN_STATES mode - return hidden_states instead of logits
+            # RETURN_HIDDEN_STATES mode: return hidden_states instead of logits
             outputs = self.model(
                 input_ids=input_ids,
                 pixel_values=pixel_values,
@@ -454,13 +411,13 @@ def patch_qwen3_vl_moe():
 
             hidden_states = outputs[0]
 
-            # Apply slice_indices to hidden_states (same indexing as for logits)
+            # Slice hidden_states the same way logits would be sliced
             slice_indices = (
                 slice(-logits_to_keep, None)
                 if isinstance(logits_to_keep, int)
                 else logits_to_keep
             )
-            # Return hidden_states as "logits" for GRPO to use
+            # Return hidden_states as "logits" for GRPO
             logits = hidden_states[:, slice_indices, :]
 
             return Qwen3VLMoeCausalLMOutputWithPast(
@@ -473,8 +430,8 @@ def patch_qwen3_vl_moe():
                 rope_deltas=outputs.rope_deltas,
             )
 
-        # Preserve __qualname__ so _unsloth_get_batch_samples can detect
-        # this is a ForConditionalGeneration forward and compute num_items_in_batch properly.
+        # Preserve __qualname__ so _unsloth_get_batch_samples can detect this is
+        # a ForConditionalGeneration forward and compute num_items_in_batch.
         _patched_causal_lm_forward.__qualname__ = _original_causal_lm_forward.__qualname__
         Qwen3VLMoeForConditionalGeneration.forward = _patched_causal_lm_forward
         if UNSLOTH_ENABLE_LOGGING:

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -64,7 +64,7 @@ def raise_error(f: str, exception: Any = None):
     return
 pass
 
-# Output classes sometimes might remove objects, so we make a fastpath
+# Fastpath: output classes sometimes drop args.
 global PROCESS_RETURN_ALLOWED_TYPES
 PROCESS_RETURN_ALLOWED_TYPES = {}
 def process_return(
@@ -98,23 +98,19 @@ def process_return(
     pass
 pass
 
-# Get Unpack
-# Python 3.10 doesnt have t_Unpack!
+# Get Unpack (Python 3.10 lacks t.Unpack).
 try:
     t_Unpack = t.Unpack
 except:
     from typing_extensions import Unpack as t_Unpack
-# Fix stale module caching (common on Kaggle/Colab after upgrading packages mid-session)
-# If packages were upgraded without restarting the kernel, old modules stay cached in
-# sys.modules. New on-disk files then fail when they reference symbols that only exist
-# in the upgraded version.
-# - PIL: can be fixed by clearing sys.modules (pure Python mismatch)
-# - numpy/scipy: C extensions are loaded into process memory and cannot be reloaded,
-#   so we must raise a clear error telling users to restart.
+# Fix stale module caching (Kaggle/Colab after upgrading packages mid-session):
+# old modules stay cached in sys.modules and fail when new on-disk files reference
+# upgraded-only symbols. PIL: clear sys.modules. numpy/scipy: C extensions cannot
+# be reloaded, so raise a clear restart error.
 import sys as _sys
 from importlib.metadata import version as _get_pkg_version
 
-# Check numpy -- C extensions cannot be reloaded, must restart
+# numpy: C extensions cannot be reloaded, so must restart.
 _np_mod = _sys.modules.get("numpy")
 if _np_mod is not None and hasattr(_np_mod, "__version__"):
     try:
@@ -129,9 +125,9 @@ if _np_mod is not None and hasattr(_np_mod, "__version__"):
     except RuntimeError:
         raise
     except Exception:
-        pass # Best-effort check -- non-critical if importlib.metadata is unavailable
+        pass # Best-effort; non-critical if importlib.metadata is unavailable.
 
-# Check PIL -- can fix by clearing sys.modules
+# PIL: fixable by clearing sys.modules.
 _pil_mod = _sys.modules.get("PIL")
 if _pil_mod is not None and hasattr(_pil_mod, "__version__"):
     try:
@@ -144,37 +140,23 @@ if _pil_mod is not None and hasattr(_pil_mod, "__version__"):
 del _sys, _pil_mod
 
 # ROCm on Windows ships PyTorch without the full torch.distributed C-extension
-# stack (torch._C._distributed_c10d, DeviceMesh, etc.).
-# torchao pulls the entire distributed chain in at module-import time
-# (torch.distributed._functional_collectives → _tensor → DeviceMesh …),
-# which cascades into ImportError even for code paths that never use
-# distributed features (e.g. plain LoRA training).
-# Fix: try to import torchao; if it fails due to the missing distributed
-# stack, register a minimal stub so subsequent imports (transformers →
-# quantizer_torchao → torchao) succeed.  Any runtime path that actually
-# needs a real distributed collective will still fail loudly.
-# Ref: https://github.com/ROCm/TheRock/issues/3284
-# ROCm on Windows ships PyTorch without the full torch.distributed C-extension
 # stack. torchao pulls the entire distributed chain in at module-import time,
 # cascading into ImportError even for code paths that never use distributed
 # features (e.g. plain LoRA training).
-#
-# Fix: if torchao can't be imported, install a sys.meta_path hook that
-# intercepts *all* "torchao" and "torchao.*" imports and returns self-contained
-# stub modules.  Each stub satisfies `from torchao.X import Y` by returning a
-# no-op sentinel class for any attribute, so transformers can define its
-# TorchAoHfQuantizer class at import time without the full torchao stack.
-# Any runtime call that actually needs a real torchao op will still fail loudly.
+# Fix: if torchao can't be imported, install a sys.meta_path hook intercepting
+# all "torchao"/"torchao.*" imports and returning self-contained stub modules.
+# Each stub satisfies `from torchao.X import Y` via a no-op sentinel class, so
+# transformers can define TorchAoHfQuantizer at import time. Any runtime call
+# needing a real torchao op still fails loudly.
 # Ref: https://github.com/ROCm/TheRock/issues/3284
 import sys as _sys_rocm_stub, types as _types_rocm_stub
 from importlib.abc import MetaPathFinder as _MetaPathFinder, Loader as _Loader
 from importlib.machinery import ModuleSpec as _ModuleSpec
 
 
-# Metaclass that makes sentinel classes chainable via attribute access,
-# e.g. AffineQuantizedTensor.subattr returns another sentinel class.
-# This is needed because peft does isinstance(weight, AffineQuantizedTensor)
-# which requires the second arg to be a real type, not a module.
+# Metaclass making sentinel classes chainable via attribute access
+# (AffineQuantizedTensor.subattr -> another sentinel). peft does
+# isinstance(weight, AffineQuantizedTensor), which needs a real type.
 class _ROCmSentinelMeta(type):
     def __getattr__(cls, name):
         child = _ROCmSentinelMeta(name, (), {"__module__": cls.__module__})
@@ -188,14 +170,11 @@ def _rocm_make_sentinel(attr, parent_name):
 
 
 def _rocm_make_torchao_stub(name):
-    """
-    Create a stub module for a torchao path.
+    """Create a stub module for a torchao path.
 
-    - Sub-module imports (torchao.dtypes, torchao.quantization …) are handled
-      by the meta_path finder and get proper module stubs.
-    - Direct attribute access on a stub (torchao.dtypes.AffineQuantizedTensor)
-      returns a sentinel CLASS so that isinstance() checks succeed (returning
-      False, since no real weight will ever be an instance of the sentinel).
+    Sub-module imports get module stubs via the meta_path finder; direct
+    attribute access returns a sentinel CLASS so isinstance() works (always
+    False, since no real weight is an instance of the sentinel).
     """
     import sys as _s, types as _t
     from importlib.machinery import ModuleSpec as _MS
@@ -207,11 +186,10 @@ def _rocm_make_torchao_stub(name):
 
     def _getattr(attr):
         full = f"{name}.{attr}"
-        # If a sub-module was already imported (via meta_path), use that.
+        # Reuse an already-imported sub-module; else a sentinel class.
         if full in _s.modules:
             obj = _s.modules[full]
         else:
-            # Otherwise return a sentinel class usable in isinstance().
             obj = _rocm_make_sentinel(attr, name)
         setattr(mod, attr, obj)
         return obj
@@ -227,7 +205,7 @@ class _ROCmTorchaoLoader(_Loader):
         return _rocm_make_torchao_stub(spec.name)
 
     def exec_module(self, module):
-        pass  # _rocm_make_torchao_stub already configures the module
+        pass  # _rocm_make_torchao_stub already configured it
 
 
 class _ROCmTorchaoFinder(_MetaPathFinder):
@@ -240,17 +218,15 @@ class _ROCmTorchaoFinder(_MetaPathFinder):
             return _MS(fullname, self._loader, is_package=True)
         return None
 
-    def find_module(self, fullname, path=None):   # Python < 3.12 compat shim
+    def find_module(self, fullname, path=None):   # Python < 3.12 shim
         return None
 
 
-# Only Windows + ROCm (HIP) PyTorch actually needs this stub: that is the one
-# build where `import torchao` crashes on the missing torch.distributed
-# C-extension stack. On every other platform a failing `import torchao` simply
-# means torchao is not installed -- transformers handles that correctly on its
-# own. Installing the stub there is actively harmful: transformers'
-# is_torchao_available() would then read torchao.__version__, get a sentinel
-# class, and crash in packaging.version.parse() with
+# Only Windows + ROCm (HIP) PyTorch needs this stub -- the one build where
+# `import torchao` crashes on the missing torch.distributed C-extension stack.
+# Elsewhere a failing import just means torchao isn't installed (transformers
+# handles that), and the stub would be harmful: is_torchao_available() reads a
+# sentinel torchao.__version__ and crashes in packaging.version.parse() with
 # "'_ROCmSentinelMeta' object is not iterable".
 _is_windows_rocm = False
 if _sys_rocm_stub.platform == "win32":
@@ -268,12 +244,12 @@ if _is_windows_rocm and "torchao" not in _sys_rocm_stub.modules:
     try:
         import torchao  # noqa: F401
     except Exception:
-        # torchao import fails on Windows ROCm -- install the meta path hook
-        # so every subsequent "import torchao.*" gets a harmless stub instead.
+        # torchao import failed on Windows ROCm: install the meta path hook so
+        # subsequent "import torchao.*" gets a harmless stub.
         _sys_rocm_stub.meta_path.insert(0, _ROCmTorchaoFinder())
 
-# _rocm_make_torchao_stub, _rocm_make_sentinel, _ROCmSentinelMeta are kept
-# alive -- the loader and sentinel classes call them at runtime.
+# Keep _rocm_make_torchao_stub / _rocm_make_sentinel / _ROCmSentinelMeta alive;
+# the loader and sentinel classes call them at runtime.
 del _ROCmTorchaoLoader, _ROCmTorchaoFinder
 del _MetaPathFinder, _Loader, _ModuleSpec, _sys_rocm_stub, _types_rocm_stub
 del _is_windows_rocm
@@ -318,15 +294,14 @@ pass
 KWARGS_TYPE = t_Unpack[t_TypedDictMeta]
 
 
-# Sometimes output classes change! Account for this
+# Account for output classes changing across versions.
 def process_output_options(
     self : Any,
     locals_items : Dict,
     kwargs : Dict,
 ) -> Dict:
     """ Latest transformers also deletes output_attentions and output_hidden_states """
-    # Preserve old transformers style
-    # 4.54.0 removes output_attentions and output_hidden_states
+    # transformers 4.54.0 removed output_attentions/output_hidden_states.
     output_attentions    = locals_items.get("output_attentions",    False)
     output_hidden_states = locals_items.get("output_hidden_states", False)
 
@@ -472,10 +447,7 @@ except:
     pass
 
 def _canonicalize_annotation(annotation: Any) -> Any:
-    """
-    Canonicalize type annotations for consistent comparison.
-    Makes List[int], typing.List[int], list[int] equivalent.
-    """
+    """Canonicalize annotations so List[int]/typing.List[int]/list[int] match."""
     if annotation is EMPTY:
         return EMPTY
 
@@ -484,8 +456,8 @@ def _canonicalize_annotation(annotation: Any) -> Any:
         if origin is not None:
             args = t.get_args(annotation)
             args = tuple(canonicalize_annotation(arg) for arg in args)
-            # Map origin to canonical form (e.g., types.UnionType -> typing.Union)
-            # so that `int | str` and `Union[int, str]` are equivalent
+            # Canonicalize origin (types.UnionType -> typing.Union) so
+            # `int | str` and `Union[int, str]` match.
             origin = TYPE_MAPPINGS.get(origin, origin)
             return (origin, args)
     return TYPE_MAPPINGS.get(annotation, annotation)
@@ -493,25 +465,21 @@ pass
 def canonicalize_annotation(annotation: Any) -> Any:
     annotation = _canonicalize_annotation(annotation)
     if type(annotation) is tuple and len(annotation) == 2:
-        # Fix up reordering of Union with sorting
-        # Union[str, List[str], list[str]] gets reduced to Union[str, list[str]]
-        # due to duplicates. We also sort Unions
+        # Dedupe + sort Union args (Union[str, List[str], list[str]] ->
+        # Union[str, list[str]]); sort by str(x) since sets are unordered.
         if annotation[0] == t.Union:
             args = list(set(annotation[1]))
-            # We must sort by str(x) since set is NOT ordered
             args.sort(key = lambda x: str(x))
             args = tuple(args)
             annotation = (annotation[0], args,)
-        # Fix up kwargs
-        # (typing.Unpack, (<class 'transformers.models.csm.modeling_csm.KwargsForCausalLM'>,)) to
-        # (typing.Unpack, (<class 'typing._TypedDictMeta'>,))
+        # Normalize Unpack[...Kwargs] to Unpack[_TypedDictMeta].
         elif annotation[0] == t_Unpack and \
             type(annotation[1]) is tuple and \
             len(annotation[1]) == 1 and \
             "Kwargs" in str(annotation[1][0]):
             annotation = (t_Unpack, (t_TypedDictMeta,),)
 
-        # (typing.Unpack, <class 'typing._TypedDictMeta'>,)
+        # Same normalization for the bare-type Unpack form.
         elif annotation[0] == t_Unpack and \
             type(annotation[1]) is type and \
             "Kwargs" in str(annotation[1]):
@@ -522,8 +490,8 @@ pass
 
 
 def get_function_fingerprint(func: Callable) -> List[Dict[str, Any]]:
-    """
-    Return a fingerprint we can use to compare function signatures.
+    """Fingerprint for comparing function signatures.
+
     Returns: [{'name': str, 'kind': int, 'is_required': bool, 'annotation': Any}]
     """
     try:
@@ -538,18 +506,17 @@ def get_function_fingerprint(func: Callable) -> List[Dict[str, Any]]:
         param_kind = param.kind.value # 4 is type VAR_KEYWORD **kwargs
         annotation = param.annotation
 
-        # If **kwargs is seen, then canonicalize name to simply kwargs
+        # Canonicalize any **kwargs name to "kwargs".
         if "kwargs" in param_name.lower():
             param_name = "kwargs"
-            # Also if no type set, set it to a default
+            # Default the annotation when untyped.
             if \
                 (param_kind == VAR_KEYWORD_ID) and \
                 (annotation == EMPTY) and \
                 (len(signature_parameters)-1 == kk):
                 annotation = (t_Unpack, (t_TypedDictMeta,),)
         pass
-        # If name is simply x, and annotation is empty, set to torch.Tensor
-        # For eg def forward(self, x)
+        # forward(self, x) with untyped x -> torch.Tensor.
         if \
             (param_name == "x") and \
             (len(signature_parameters) == 2) and \
@@ -632,8 +599,8 @@ def can_safely_patch(
 
 
     if len(old_fp) != len(new_fp):
-        # New transformers 4.54.0 removed output_attentions and output_hidden_states
-        # We check it and ignore if the old function has both these, and the new removed them
+        # transformers 4.54.0 dropped output_attentions/output_hidden_states;
+        # tolerate exactly that removal.
         removed_flags_list = removed_flags(old_fp, new_fp)
         if removed_flags_list == ("output_attentions", "output_hidden_states",):
             return False, f"New function removed output_attentions and output_hidden_states"
@@ -643,11 +610,10 @@ def can_safely_patch(
         return False, f"Parameter count mismatch: {len(old_fp)} vs {len(new_fp)}"
     pass
 
-    # Go through function one by one
     for old_param, new_param in zip(old_fp, new_fp):
         if (old_param['name'], old_param['kind']) != (new_param['name'], new_param['kind']):
             if match_level == "relaxed":
-                # Check one last time for *args, **kwargs replacement
+                # Last chance: *args, **kwargs replacement.
                 removed_flags_list = removed_flags(old_fp, new_fp)
                 result, error = check_args_kwargs(old_fp, new_fp, removed_flags_list)
                 if result == True:
@@ -657,7 +623,7 @@ def can_safely_patch(
         if new_param['is_required'] and not old_param['is_required']:
             return False, f"Parameter '{new_param['name']}' changed from optional to required"
 
-        # For strict matching, also check type annotations
+        # Strict matching also compares type annotations.
         if match_level == "strict" and old_param['annotation'] != new_param['annotation']:
             return False, \
             f"Parameter '{old_param['name']}' type annotation changed from:\n"\
@@ -672,9 +638,7 @@ def _get_unique_storage_name(
     target_obj: Any,
     attr_name: str,
 ) -> str:
-    """
-    Generate a unique name for storing the original function.
-    """
+    """Unique attribute name for stashing the original function."""
     if hasattr(target_obj, '__name__'):
         obj_name = target_obj.__name__
     elif hasattr(target_obj, '__class__'):
@@ -682,9 +646,9 @@ def _get_unique_storage_name(
     else:
         obj_name = str(type(target_obj).__name__)
 
-    # Include module if available for extra uniqueness
+    # Include module for extra uniqueness when available.
     if hasattr(target_obj, '__module__'):
-        module_name = target_obj.__module__.split('.')[-1]  # Just the last part
+        module_name = target_obj.__module__.split('.')[-1]
         return f"_original_{module_name}_{obj_name}_{attr_name}"
     else:
         return f"_original_{obj_name}_{attr_name}"
@@ -701,9 +665,7 @@ def patch_function(
     fullgraph = None,
     dynamic = True,
 ) -> bool:
-    """
-    Patch a function/method on an object.
-    """
+    """Patch a function/method on an object."""
     if not hasattr(target_obj, attr_name):
         if UNSLOTH_ENABLE_LOGGING:
             logger.error(f"Unsloth: Attribute '{attr_name}' not found on {target_obj.__name__}")
@@ -711,9 +673,9 @@ def patch_function(
 
     original_func = getattr(target_obj, attr_name)
 
-    # torch.compile function if requested
+    # torch.compile if requested.
     if fullgraph is not None and type(fullgraph) is bool and not UNSLOTH_COMPILE_DISABLE:
-        # Get wrapped function if already compiled
+        # Unwrap already-compiled functions.
         if hasattr(new_func, "get_compiler_config"):
             new_func = new_func.__wrapped__
         if hasattr(original_func, "get_compiler_config"):
@@ -726,7 +688,7 @@ def patch_function(
         )
     pass
 
-    # Store original for potential restoration with unique name
+    # Stash original under a unique name for later restoration.
     if store_original:
         unique_name = _get_unique_storage_name(target_obj, attr_name)
         setattr(target_obj, unique_name, original_func)
@@ -816,9 +778,7 @@ def patch_multiple(
     fullgraph = None,
     dynamic = True,
 ) -> Dict[str, bool]:
-    """
-    Apply multiple patches at once.
-    """
+    """Apply multiple patches at once."""
     results = {}
 
     for target_obj, attr_name, new_func in patches:
@@ -847,9 +807,7 @@ def restore_original(
     target_obj: Any,
     attr_name: str,
 ) -> bool:
-    """
-    Restore original function if it was stored.
-    """
+    """Restore the original function if it was stored."""
     unique_name = _get_unique_storage_name(target_obj, attr_name)
 
     if not hasattr(target_obj, unique_name):
@@ -860,7 +818,7 @@ def restore_original(
     try:
         original_func = getattr(target_obj, unique_name)
         setattr(target_obj, attr_name, original_func)
-        delattr(target_obj, unique_name)  # Clean up
+        delattr(target_obj, unique_name)
         if UNSLOTH_ENABLE_LOGGING:
             logger.info(f"Unsloth: Restored original {attr_name}")
         return True
@@ -872,27 +830,22 @@ pass
 
 
 def list_stored_originals(target_obj: Any) -> List[str]:
-    """
-    List all stored original functions on a target object.
-    """
+    """List all stored original functions on a target object."""
     stored = []
     for attr_name in dir(target_obj):
         if attr_name.startswith('_original_') and not attr_name.startswith('_original___'):
-            # Extract the original method name from the unique storage name
-            # Format: _original_{module}_{class}_{method} or _original_{class}_{method}
-            parts = attr_name.split('_')[2:]  # Skip '_original_'
+            # Name format: _original_{module}_{class}_{method} (method = last part).
+            parts = attr_name.split('_')[2:]
             if len(parts) >= 2:
-                method_name = parts[-1]  # Last part is the method name
+                method_name = parts[-1]
                 stored.append(method_name)
 
-    return sorted(list(set(stored)))  # Remove duplicates and sort
+    return sorted(list(set(stored)))
 pass
 
 
 def restore_multiple(target_objs_and_attrs: List[Tuple[Any, str]]) -> Dict[str, bool]:
-    """
-    Restore multiple original functions.
-    """
+    """Restore multiple original functions."""
     results = {}
 
     for target_obj, attr_name in target_objs_and_attrs:

--- a/unsloth_zoo/tiled_mlp.py
+++ b/unsloth_zoo/tiled_mlp.py
@@ -66,24 +66,21 @@ pass
 class TiledMLP(torch.autograd.Function):
     @staticmethod
     def handle_output(output, extra_lists):
-        """Extract main output and append extras to their lists"""
+        """Extract main output, append extras to their lists."""
         if isinstance(output, tuple):
-            # Initialize lists on first tuple
             if not extra_lists:
                 for _ in output[1:]:
                     extra_lists.append([])
-            # Append extras
             for i, extra in enumerate(output[1:]):
                 extra_lists[i].append(extra)
-            return output[0]  # Return main output
-        return output  # Single tensor
+            return output[0]
+        return output
 
     @staticmethod
     def structure_output(main_output, extra_lists):
-        """Reconstruct original structure"""
+        """Reconstruct original structure: cat extras along seq dim."""
         if not extra_lists:
             return main_output
-        # Cat extras along seq dim and return tuple
         extras = [torch.cat(extra_list, dim=-2) for extra_list in extra_lists]
         return (main_output, *extras)
 
@@ -119,10 +116,8 @@ class TiledMLP(torch.autograd.Function):
             preserve_rng_state = True
         ctx.preserve_rng_state = bool(preserve_rng_state)
 
-        # Save tensors needed in backward
         ctx.save_for_backward(x)
 
-        # RNG state capture if requested
         if ctx.preserve_rng_state:
             ctx.fwd_cpu_state = torch.get_rng_state()
             ctx.had_device_in_fwd = False

--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -33,9 +33,8 @@ __all__ = [
 @torch.inference_mode
 def mean_of_trained_tokens(model, eps = 1e-16):
     """
-    Llama-3 for eg has untrained vectors in the base model.
-    These include <|eot_id|>, <|start_header_id|>, <|end_header_id|>
-    We reset them to the mean of the rest of the tokens
+    Llama-3 etc have untrained vectors (<|eot_id|>, <|start_header_id|>, ...)
+    in the base model. Reset them to the mean of the trained tokens.
     """
     # All Unsloth Zoo code licensed under LGPLv3
     embedding_matrix = model.get_input_embeddings ().weight.clone()
@@ -77,8 +76,8 @@ def add_new_tokens(
     interpolation = 0.5,
 ):
     """
-    Smartly resizes the tokenizer and adds new tokens to the model.
-    We also disregard untrained tokens by removing them from the mean calculation.
+    Resize the tokenizer and add new tokens to the model, excluding untrained
+    tokens from the mean calculation.
     """
     # All Unsloth Zoo code licensed under LGPLv3
     assert(isinstance(new_tokens, (list, tuple)))
@@ -203,9 +202,8 @@ pass
 @torch.inference_mode
 def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAMES = [], eps = 1e-16):
     """
-    Llama-3 for eg has untrained vectors in the base model.
-    These include <|eot_id|>, <|start_header_id|>, <|end_header_id|>
-    We reset them to the mean of the rest of the tokens
+    Llama-3 etc have untrained vectors (<|eot_id|>, <|start_header_id|>, ...)
+    in the base model. Reset them to the mean of the trained tokens.
     """
     # All Unsloth Zoo code licensed under LGPLv3
     embedding_matrix = model.get_input_embeddings ().weight
@@ -473,10 +471,9 @@ POSSIBLE_RESERVED_TOKENS = (
     "<unused",                   # PaliGemma
 )
 
-# Vision-specific tokens that should not be used as pad_token for text-only models.
-# Qwen3 text models share the same vocab as Qwen3-VL and include these tokens,
-# but using them as pad_token is semantically wrong and confusing.
-# See https://github.com/unslothai/unsloth/issues/4104
+# Vision tokens that must not be a pad_token for text-only models. Qwen3 text
+# models share Qwen3-VL's vocab and include these, but using them as pad_token
+# is wrong. See https://github.com/unslothai/unsloth/issues/4104
 VISION_RESERVED_TOKENS = frozenset((
     "<|vision_pad|>",
     "<|image_pad|>",
@@ -486,10 +483,9 @@ VISION_RESERVED_TOKENS = frozenset((
 @torch.inference_mode
 def patch_tokenizer(model, tokenizer):
     """
-        Phi3's pad_token isn't set. We set it to <|placeholder...
-        Llama-3 is <|reserved...
-        Llama-2 is <unk>
-        Check if pad_token is not the same as eos_token otherwise the loss will ignore it!!
+        Set a sensible pad_token when missing (Phi3 -> <|placeholder...,
+        Llama-3 -> <|reserved..., Llama-2 -> <unk>) and ensure it differs from
+        eos_token so the loss does not ignore it.
         Fixes https://github.com/unslothai/unsloth/issues/5
     """
     # All Unsloth Zoo code licensed under LGPLv3
@@ -503,8 +499,7 @@ def patch_tokenizer(model, tokenizer):
 
     original_tokenizer = tokenizer
 
-    # Patch processor's __call__ for vision models to auto-apply chat template
-    # when conversation format is passed instead of a string
+    # Auto-apply chat template when a conversation is passed instead of a string
     if hasattr(tokenizer, "image_processor") and hasattr(tokenizer, "apply_chat_template"):
         patch_processor_call(tokenizer)
 
@@ -515,10 +510,8 @@ def patch_tokenizer(model, tokenizer):
             return model, original_tokenizer
         tokenizer = inner
 
-    # Detect if model is a vision model. Text-only models should not
-    # use vision-specific tokens (e.g. <|vision_pad|>) as pad_token,
-    # even if those tokens exist in the vocab.
-    # See https://github.com/unslothai/unsloth/issues/4104
+    # Text-only models must not use vision tokens (e.g. <|vision_pad|>) as
+    # pad_token. See https://github.com/unslothai/unsloth/issues/4104
     is_vision_model = hasattr(original_tokenizer, "image_processor")
     if not is_vision_model and model is not None and hasattr(model, "config"):
         model_type = getattr(model.config, "model_type", "") or ""
@@ -527,10 +520,9 @@ def patch_tokenizer(model, tokenizer):
 
     bad_pad_token = False
     if hasattr(tokenizer, "pad_token") and tokenizer.pad_token is not None:
-        # Check if pad_token is not the same as eos_token otherwise the loss will ignore it!!
+        # pad_token == eos_token makes the loss ignore it
         bad_pad_token = tokenizer.eos_token == tokenizer.pad_token
-        # Also fix text-only models that already have a vision token as pad_token
-        # (e.g. Qwen3 models with <|vision_pad|> baked into tokenizer_config.json)
+        # Also fix text-only models with a vision token baked in as pad_token
         if not bad_pad_token and not is_vision_model:
             bad_pad_token = tokenizer.pad_token in VISION_RESERVED_TOKENS
     elif hasattr(tokenizer, "pad_token") and tokenizer.pad_token is None:
@@ -648,17 +640,12 @@ pass
 
 
 def _is_conversation_format(text):
-    """
-    Check if text looks like a conversation format (list of dicts with 'role' keys).
-    This handles the case where users pass conversation format directly to processor.__call__
-    instead of first applying apply_chat_template.
-    """
+    """Return True if text is conversation format (list of dicts with 'role')."""
     # All Unsloth Zoo code licensed under LGPLv3
     if not isinstance(text, list):
         return False
     if len(text) == 0:
         return False
-    # Check first element - if it's a dict with 'role' key, it's conversation format
     first = text[0]
     if isinstance(first, dict) and "role" in first:
         return True
@@ -668,32 +655,22 @@ pass
 
 def patch_processor_call(processor):
     """
-    Patch processor's __call__ to auto-detect conversation format and apply chat template.
-
-    This fixes the issue where users call:
-        tokenizer(image, prompt, ...)
-    where prompt is a list of dicts (conversation format) instead of a string.
-
-    The Qwen3VL (and other VLM) processors expect text to be a string, not conversation format.
-    Without this patch, users get:
-        AttributeError: 'dict' object has no attribute 'replace'
+    Patch processor's __call__ to auto-apply the chat template when text is in
+    conversation format. VLM processors (e.g. Qwen3VL) expect a string; passing
+    a list of dicts otherwise raises
+    `AttributeError: 'dict' object has no attribute 'replace'`.
     """
     # All Unsloth Zoo code licensed under LGPLv3
     if not hasattr(processor, "apply_chat_template"):
         return processor
 
-    # Only patch if not already patched
     if hasattr(processor, "_unsloth_patched_call"):
         return processor
 
-    # Store the original __call__ from the class
     original_call = processor.__class__.__call__
 
-    # Create a wrapper that handles conversation format
     def patched_call(self, images=None, text=None, videos=None, **kwargs):
-        # Auto-apply chat template if text looks like conversation format
         if text is not None and _is_conversation_format(text):
-            # Text is conversation format - apply chat template first
             add_generation_prompt = kwargs.pop("add_generation_prompt", True)
             text = self.apply_chat_template(
                 text,
@@ -702,11 +679,8 @@ def patch_processor_call(processor):
             )
         return original_call(self, images=images, text=text, videos=videos, **kwargs)
 
-    # Patch at the class level to ensure it's used.
-    # Create a dynamic subclass just for this instance.
-    # Use the original class name so save_pretrained writes the correct
-    # processor_class into config files (fixes GitHub issue #4085).
-    # Double-patching is already prevented by _unsloth_patched_call check above.
+    # Patch via a dynamic subclass reusing the original class name so
+    # save_pretrained writes the correct processor_class (fixes issue #4085).
     original_class = processor.__class__
     patched_class = type(
         original_class.__name__,

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -42,10 +42,7 @@ __all__ = [
 
 @torch.inference_mode
 def fix_zero_training_loss(model, tokenizer, train_dataset):
-    """
-    Sometimes the labels get masked by all -100s, causing the loss
-    to be 0. We check for this!
-    """
+    """Warn/raise when labels are all -100 (masked), which zeroes the loss."""
     # All Unsloth Zoo code licensed under LGPLv3
     if isinstance(train_dataset, datasets.IterableDataset):
         # Skip the check since the code below assumes
@@ -119,9 +116,8 @@ def prepare_model_for_training(
         # We need to upcast to float32
         mixed_precision_dtype = torch.float32
         os.environ["UNSLOTH_MIXED_PRECISION"] = "float32"
-        # For full finetuning, update config dtype to match actual weight dtype.
-        # The KV cache uses model.config.torch_dtype, but weights are upcast to float32.
-        # Without this, generation fails with dtype mismatch in index_copy_().
+        # Full finetuning upcasts weights to float32; sync config dtype so the
+        # KV cache matches and generation avoids a dtype mismatch in index_copy_().
         if full_finetuning:
             model._unsloth_original_dtype = dtype
             model.config.torch_dtype = torch.float32
@@ -195,8 +191,7 @@ def prepare_model_for_training(
                 exec(f"model.{name}.to({str(torch.float32)})")
     pass
 
-    # Gradient checkpointing
-    # If the user requested vanilla GC (True/False), ensure any prior Unsloth patch is undone.
+    # Vanilla GC (True/False) requires undoing any prior Unsloth patch.
     if use_gradient_checkpointing != "unsloth":
         unpatch_unsloth_gradient_checkpointing()
         unpatch_unsloth_smart_gradient_checkpointing()
@@ -290,7 +285,6 @@ pass
 
 
 def set_training(model):
-    # Start training
     model.training = True
     while hasattr(model, "model"):
         model = model.model
@@ -300,7 +294,6 @@ pass
 
 
 def unset_training(model):
-    # End training
     model.training = False
     while hasattr(model, "model"):
         model = model.model
@@ -317,10 +310,8 @@ pass
 
 def unsloth_train(trainer):
     """
-    Unsloth Trainer
-    1. Fixes gradient accumulation
-    2. Scaled down version of HF's trainer
-    3. Much less feature complete
+    Minimal trainer: a scaled-down HF Trainer that fixes gradient accumulation.
+    Much less feature complete.
     """
     # All Unsloth Zoo code licensed under LGPLv3
     assert(hasattr(trainer, "args"))

--- a/unsloth_zoo/utils.py
+++ b/unsloth_zoo/utils.py
@@ -45,9 +45,8 @@ def Version(version):
         package_name = None
 
         if isinstance(version, str):
-            # Check if it looks like a package name (e.g. "trl", "transformers", "zope.interface")
-            # Package names start with a letter, can contain letters/digits/dots/hyphens/underscores,
-            # and must end with a letter or digit (no trailing hyphens/underscores)
+            # Treat as a package name (e.g. "trl") if it matches the pattern,
+            # else as a literal version string.
             if re.match(r'^[A-Za-z](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$', version):
                 try:
                     raw = importlib_version(version)
@@ -87,7 +86,7 @@ def Version(version):
 
         new_version = match.group(0).rstrip(".")
         if match_at_start and new_version != raw:
-            new_version += ".1" # Add .1 for dev / alpha / beta / rc
+            new_version += ".1" # for dev / alpha / beta / rc
         return TrueVersion(new_version)
     except:
         from inspect import getframeinfo, stack
@@ -138,10 +137,9 @@ except AttributeError:
 
 def is_main_process():
     if torch_distributed_is_initialized():
-        # torch.distributed.init_process_group was run, so get_rank works
         return torch_distributed_get_rank() == 0
     elif torch_distributed_is_torchelastic_launched():
-        # accelerate launch for example calls init_process_group later
+        # accelerate launch calls init_process_group later
         return os.environ.get("RANK", "0") == "0"
     return True
 pass
@@ -153,9 +151,9 @@ pass
 def distributed_function(n = 1, function = None, *args, **kwargs):
     assert function is not None
 
-    # Run independently if process group isn't initialized yet.
-    # This covers both: (1) not distributed at all, and (2) torchrun launched
-    # but init_process_group() wasn't called yet (e.g. during module imports).
+    # Run independently when the process group isn't initialized: not
+    # distributed, or torchrun launched but init_process_group() not yet
+    # called (e.g. during module imports).
     # Ref: https://github.com/unslothai/unsloth/issues/3703
     if not torch_distributed_is_initialized():
         out = function(*args, **kwargs)
@@ -168,12 +166,9 @@ def distributed_function(n = 1, function = None, *args, **kwargs):
     else:
         obj_list = [None for _ in range(n)]
 
-    # If the process group is initialized, we can synchronize / share the result
     if torch_distributed_is_initialized():
-        # Broadcast result to all ranks
         dist.broadcast_object_list(obj_list, src = 0)
-        # Barrier to make sure everyone waits until main is done
-        dist.barrier()
+        dist.barrier()  # wait until main is done
 
     return obj_list[0] if n == 1 else obj_list
 pass
@@ -185,15 +180,9 @@ def _lock_path_for(target: str) -> str:
     return str(locks_dir / f".lock.{pathlib.Path(target).name}")
 
 def get_lock(target: str, timeout: Optional[int] = None) -> FileLock:
-    """
-    Get a lock for a target file.
-    target: str, the path to the file to lock
-    timeout: int, the timeout in seconds for the lock
-    If timeout is not provided, it will use the value of
-    the environment variable UNSLOTH_LOCK_TIMEOUT, otherwise 10 seconds.
+    """Get a FileLock for `target`.
 
-    Returns:
-        FileLock, the lock for the target file
+    timeout defaults to env UNSLOTH_LOCK_TIMEOUT, otherwise 10 seconds.
     """
     lock_path = _lock_path_for(target)
     if timeout is None:

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -68,10 +68,8 @@ import requests
 from packaging import version
 from typing import Union, Tuple, List, Dict, Sequence
 from itertools import takewhile
-# torchvision is an optional dependency: the video reader path uses it but
-# the rest of vision_utils (image preprocessing, HF picker integration)
-# works without it. Guard the top-level import so a CPU-only zoo install
-# without torchvision can still import this module.
+# torchvision is optional (only the video reader path needs it); guard the
+# import so a CPU-only zoo install without it can still import this module.
 try:
     import torchvision
     from torchvision import io, transforms
@@ -122,14 +120,9 @@ def floor_by_factor(number: int, factor: int) -> int:
 def smart_resize(
     height: int, width: int, factor: int = IMAGE_FACTOR, min_pixels: int = MIN_PIXELS, max_pixels: int = MAX_PIXELS
 ) -> tuple[int, int]:
-    """
-    Rescales the image so that the following conditions are met:
-
-    1. Both dimensions (height and width) are divisible by 'factor'.
-
-    2. The total number of pixels is within the range ['min_pixels', 'max_pixels'].
-
-    3. The aspect ratio of the image is maintained as closely as possible.
+    """Rescale so both dims are divisible by 'factor', total pixels stay in
+    ['min_pixels', 'max_pixels'], and aspect ratio is preserved as closely
+    as possible.
     """
     if height <= 0 or width <= 0:
         raise ValueError(
@@ -220,23 +213,11 @@ def smart_nframes(
     total_frames: int,
     video_fps: Union[int, float],
 ) -> int:
-    """calculate the number of frames for video used for model inputs.
+    """Number of frames to extract for model inputs.
 
-    Args:
-        ele (dict): a dict contains the configuration of video.
-            support either `fps` or `nframes`:
-                - nframes: the number of frames to extract for model inputs.
-                - fps: the fps to extract frames for model inputs.
-                    - min_frames: the minimum number of frames of the video, only used when fps is provided.
-                    - max_frames: the maximum number of frames of the video, only used when fps is provided.
-        total_frames (int): the original total number of frames of the video.
-        video_fps (int | float): the original fps of the video.
-
-    Raises:
-        ValueError: nframes should in interval [FRAME_FACTOR, total_frames].
-
-    Returns:
-        int: the number of frames for video used for model inputs.
+    `ele` supports either `fps` (with optional `min_frames`/`max_frames`) or
+    `nframes`. Raises ValueError if the result is outside
+    [FRAME_FACTOR, total_frames].
     """
     assert not ("fps" in ele and "nframes" in ele), "Only accept either `fps` or `nframes`"
     if "nframes" in ele:
@@ -259,16 +240,10 @@ def smart_nframes(
 def _read_video_torchvision(
     ele: dict,
 ) -> tuple[torch.Tensor, float]:
-    """read video using torchvision.io.read_video
+    """Read video via torchvision.io.read_video.
 
-    Args:
-        ele (dict): a dict contains the configuration of video.
-        support keys:
-            - video: the path of video. support "file://", "http://", "https://" and local path.
-            - video_start: the start time of video.
-            - video_end: the end time of video.
-    Returns:
-        torch.Tensor: the video tensor with shape (T, C, H, W).
+    `ele` keys: video (path/file/http/https), video_start, video_end.
+    Returns a (T, C, H, W) tensor and the sample fps.
     """
     video_path = ele["video"]
     if version.parse(torchvision.__version__) < version.parse("0.19.0"):
@@ -310,19 +285,9 @@ def calculate_video_frame_range(
     total_frames: int,
     video_fps: float,
 ) -> tuple[int, int, int]:
-    """
-    Calculate the start and end frame indices based on the given time range.
-
-    Args:
-        ele (dict): A dictionary containing optional 'video_start' and 'video_end' keys (in seconds).
-        total_frames (int): Total number of frames in the video.
-        video_fps (float): Frames per second of the video.
-
-    Returns:
-        tuple: A tuple containing (start_frame, end_frame, frame_count).
-
-    Raises:
-        ValueError: If input parameters are invalid or the time range is inconsistent.
+    """Compute (start_frame, end_frame, frame_count) from `ele`'s optional
+    'video_start'/'video_end' (seconds). Raises ValueError on invalid params
+    or an inconsistent time range.
     """
     # Validate essential parameters
     if video_fps <= 0:
@@ -367,16 +332,10 @@ def calculate_video_frame_range(
 def _read_video_decord(
     ele: dict,
 ) -> tuple[torch.Tensor, float]:
-    """read video using decord.VideoReader
+    """Read video via decord.VideoReader.
 
-    Args:
-        ele (dict): a dict contains the configuration of video.
-        support keys:
-            - video: the path of video. support "file://", "http://", "https://" and local path.
-            - video_start: the start time of video.
-            - video_end: the end time of video.
-    Returns:
-        torch.Tensor: the video tensor with shape (T, C, H, W).
+    `ele` keys: video (path/file/http/https), video_start, video_end.
+    Returns a (T, C, H, W) tensor and the sample fps.
     """
     import decord
     video_path = ele["video"]
@@ -413,16 +372,10 @@ def is_torchcodec_available() -> bool:
 def _read_video_torchcodec(
     ele: dict,
 ) -> tuple[torch.Tensor, float]:
-    """read video using torchcodec.decoders.VideoDecoder
+    """Read video via torchcodec.decoders.VideoDecoder.
 
-    Args:
-        ele (dict): a dict contains the configuration of video.
-        support keys:
-            - video: the path of video. support "file://", "http://", "https://" and local path.
-            - video_start: the start time of video.
-            - video_end: the end time of video.
-    Returns:
-        torch.Tensor: the video tensor with shape (T, C, H, W).
+    `ele` keys: video (path/file/http/https), video_start, video_end.
+    Returns a (T, C, H, W) tensor and the sample fps.
     """
     from torchcodec.decoders import VideoDecoder
     TORCHCODEC_NUM_THREADS = int(os.environ.get('TORCHCODEC_NUM_THREADS', 8))

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -148,8 +148,6 @@ class WorkerLoRAManager(AbstractWorkerManager):
             else:
                 lora_request.lora_config["vllm_max_position_embeddings"] = self.max_position_embeddings
                 peft_helper = PEFTHelper.from_dict(lora_request.config)
-            # Validates the LoRA configuration against requirements before
-            # loading weights, throwing an exception if validation fails.
             peft_helper.validate_legal(self.lora_config)
 
             # For some models like Qwen2VL, we need to use hf_to_vllm_mapper
@@ -159,7 +157,6 @@ class WorkerLoRAManager(AbstractWorkerManager):
                     and model.hf_to_vllm_mapper is not None):
                 hf_to_vllm_mapper = model.hf_to_vllm_mapper
 
-            # Prepare common arguments
             lora_extra_vocab_size = getattr(self.lora_config, "lora_extra_vocab_size", 0)
             kwargs = {
                 "lora_model_id": lora_request.lora_int_id,

--- a/unsloth_zoo/vllm_rlhf_utils.py
+++ b/unsloth_zoo/vllm_rlhf_utils.py
@@ -22,12 +22,8 @@ __all__ = [
 
 def stateless_init_process_group(master_address, master_port, rank, world_size,
                                  device):
-    """
-    vLLM provides `StatelessProcessGroup` to create a process group
-    without considering the global process group in torch.distributed.
-    It is recommended to create `StatelessProcessGroup`, and then initialize
-    the data-plane communication (NCCL) between external (train processes) 
-    and vLLM workers.
+    """Init NCCL data-plane comms between train processes and vLLM workers via
+    vLLM's `StatelessProcessGroup` (avoids the global torch.distributed group).
     """
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
     from vllm.distributed.utils import StatelessProcessGroup
@@ -40,13 +36,10 @@ def stateless_init_process_group(master_address, master_port, rank, world_size,
 
 
 class WorkerExtension:
-    """
-    The class for vLLM's worker to inherit from.
-    By defining an extension class, the code can work no matter what is
-    the underlying worker class. This way, the code can be compatible
-    with both vLLM V0 and V1.
-    NOTE: we define this class in a separate module, and the main module
-    should pass the full qualified name as `worker_extension_cls` argument.
+    """Mixin for vLLM's worker (compatible with V0 and V1).
+
+    Lives in a separate module; pass its fully qualified name as the
+    `worker_extension_cls` argument.
     """
 
     def init_weight_update_group(self, master_address, master_port,
@@ -72,9 +65,7 @@ class WorkerExtension:
         del weight
 
     def check_weights_changed(self):
-        """
-        Check if the weights are updated to 0.
-        """
+        """Check if the weights are updated to 0."""
         weights_updated = True
         for name, p in self.model_runner.model.named_parameters():
             weights_updated = weights_updated and torch.allclose(
@@ -83,13 +74,10 @@ class WorkerExtension:
 
 
 class ColocateWorkerExtension:
-    """
-    The class for vLLM's worker to inherit from, in the colocate setting.
-    By defining an extension class, the code can work no matter what is
-    the underlying worker class. This way, the code can be compatible
-    with both vLLM V0 and V1.
-    NOTE: we define this class in a separate module, and the main module
-    should pass the full qualified name as `worker_extension_cls` argument.
+    """Mixin for vLLM's worker in the colocate setting (compatible with V0 and V1).
+
+    Lives in a separate module; pass its fully qualified name as the
+    `worker_extension_cls` argument.
     """
 
     def report_device_id(self) -> str:
@@ -104,8 +92,8 @@ class ColocateWorkerExtension:
         for name, handle in handles.items():
             func, args = handle
             list_args = list(args)
-            # the key is to change device id to the current device id
-            # in case two processes have different CUDA_VISIBLE_DEVICES
+            # Remap to the current device id in case two processes have
+            # different CUDA_VISIBLE_DEVICES.
             list_args[6] = device_id
             tensor = func(*list_args)
             weights.append((name, tensor))
@@ -128,9 +116,7 @@ class ColocateWorkerExtension:
         return vllm_loras_A
 
     def check_weights_changed(self):
-        """
-        Check if the weights are updated to 0.
-        """
+        """Check if the weights are updated to 0."""
         weights_updated = True
         for name, p in self.model_runner.model.named_parameters():
             weights_updated = weights_updated and torch.allclose(
@@ -142,9 +128,7 @@ class ColocateWorkerExtension:
         data = {}
         vllm_model = self.model_runner.model
         for name, p in vllm_model.named_parameters():
-            # the training actor might only have a subset of the weights
-            # and need to all-gather the weights from all the actors.
-            # for demonstration, here we assume all training actors have
-            # the full weights.
+            # Assumes all training actors hold the full weights (a real setup
+            # may hold a subset and need to all-gather across actors).
             data[name] = reduce_tensor(p.detach())
         return {self.device_uuid: data}

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -136,9 +136,8 @@ if importlib.util.find_spec("vllm") is not None:
 
     # Allow unsloth dynamic quants to work
     def is_layer_skipped_bnb(prefix: str, llm_int8_skip_modules):
-        # Split the prefix into its dot-separated components
         components = prefix.split('.')
-        # Check if any of the skip modules exactly matches any component
+        # Any skip module exactly matching a component
         vllm_check = any(
             module_name in components
             for module_name in llm_int8_skip_modules
@@ -151,9 +150,8 @@ if importlib.util.find_spec("vllm") is not None:
         return vllm_check or unsloth_check
     pass
 
-    # Since https://github.com/vllm-project/vllm/blob/4959915089f1bcf011f082136464e48b76c7e3d9/vllm/model_executor/model_loader/bitsandbytes_loader.py
-    # vLLM dequantizes the Double quant scalars on the fly
-    # We disable this
+    # vLLM dequantizes Double quant scalars on the fly; disable it.
+    # https://github.com/vllm-project/vllm/blob/4959915089f1bcf011f082136464e48b76c7e3d9/vllm/model_executor/model_loader/bitsandbytes_loader.py
     def dequantize_dq(quant_states):
         return quant_states
     def _dequantize_dq(self, quant_states):
@@ -180,14 +178,13 @@ if importlib.util.find_spec("vllm") is not None:
         vllm.model_executor.layers.quantization.bitsandbytes,
         "apply_bnb_4bit"
     ):
-        # Fix force using torch.bfloat16 all the time and make it dynamic
+        # Make the compute dtype dynamic instead of forcing torch.bfloat16
         def _apply_4bit_weight(
             self,
             layer: torch.nn.Module,
             x: torch.Tensor,
             bias: Optional[torch.Tensor] = None,
         ) -> torch.Tensor:
-            # only load the bitsandbytes module when needed
             from bitsandbytes import matmul_4bit
 
             original_type = x.dtype
@@ -242,7 +239,6 @@ if importlib.util.find_spec("vllm") is not None:
             x: torch.Tensor,
             bias: Optional[torch.Tensor] = None,
         ) -> torch.Tensor:
-            # only load the bitsandbytes module when needed
             original_type = x.dtype
             original_shape = x.shape
             reshape_after_matmul = False
@@ -286,7 +282,7 @@ if importlib.util.find_spec("vllm") is not None:
         try:
             from vllm.config import logger as vllm_config_logger
         except:
-            # vLLM refactored a lot of configs. Most of them are backwards compatible for imports. This seems to not be.
+            # vLLM config refactor: this import isn't backwards compatible.
             from vllm.config.model import logger as vllm_config_logger
         vllm_config_logger.addFilter(HideLoggingMessage("not supported"))
         vllm_config_logger.addFilter(HideLoggingMessage("is not tested"))
@@ -309,8 +305,7 @@ if importlib.util.find_spec("vllm") is not None:
 
     def patch_vllm_compute_dtype(dtype = torch.float16):
         # All Unsloth Zoo code licensed under LGPLv3
-        # vLLM defaults to using the model config file's compute_dtype
-        # We shall fix it dynamically!
+        # vLLM uses the config file's compute_dtype; override it dynamically.
         old_config = vllm.model_executor.layers.quantization.bitsandbytes.BitsAndBytesConfig
 
         dtype = str(dtype)
@@ -340,7 +335,7 @@ if importlib.util.find_spec("vllm") is not None:
         except:
             pass
         try:
-            # New vLLM is now a class!
+            # New vLLM: TokenizerGroup is a class
             import vllm.transformers_utils.tokenizer_group
             vllm.transformers_utils.tokenizer_group.TokenizerGroup.get_lora_tokenizer = _return_self_tokenizer
             vllm.transformers_utils.tokenizer_group.TokenizerGroup.get_lora_tokenizer_async = _return_self_tokenizer
@@ -376,8 +371,7 @@ if importlib.util.find_spec("vllm") is not None:
 
     def set_inductor_config(config, runtime_shape):
         if isinstance(runtime_shape, int):
-            # for a specific batchsize, tuning triton kernel parameters
-            # can be beneficial
+            # Per-batchsize triton kernel tuning can help
             config["max_autotune"] = False # Very slow so disable
             config["coordinate_descent_tuning"] = True
     pass
@@ -424,13 +418,10 @@ if importlib.util.find_spec("bitsandbytes") is not None:
     # Force offsets to be in float32 and not bfloat16 / float16
     @classmethod
     def from_dict(cls, qs_dict: Dict[str, Any], device: torch.device) -> "QuantState":
-        """
-        unpacks components of state_dict into QuantState
-        where necessary, convert into strings, torch.dtype, ints, etc.
+        """Unpack state_dict components into a QuantState (strings, dtypes, ints).
 
-        qs_dict: based on state_dict, with only relevant keys, striped of prefixes.
-
-        item with key `quant_state.bitsandbytes__[nf4/fp4]` may contain minor and non-tensor quant state items.
+        qs_dict: state_dict relevant keys, prefixes stripped. The
+        `quant_state.bitsandbytes__[nf4/fp4]` item may hold minor non-tensor items.
         """
 
         # unpacking tensor with non-tensor components
@@ -535,8 +526,7 @@ def patch_vllm_enable_sleep_mode():
     logger.info(f"Unsloth: Enabling vLLM standby mode")
 
     def __init__(self):
-        # This is a replica of the original CuMemAllocator.__init__()
-        # with no changes except modification to error message for better readability
+        # Replica of CuMemAllocator.__init__() with a clearer error message only.
         for check in ("PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_HIP_ALLOC_CONF", "PYTORCH_ALLOC_CONF",):
             conf = os.environ.get(check, "")
             assert "expandable_segments:True" not in conf, \
@@ -548,10 +538,8 @@ def patch_vllm_enable_sleep_mode():
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: dict[str, Any] = {}
         if hasattr(self, '_python_malloc_callback'):
-            # vllm changed something recently wrt cumem init
-            # new versions have function _python_malloc/free and set it to self.python_malloc/free
-            # old versions just have the function self.python_malloc/free so they need no such assignment
-            # this check is to make sure it works for both new versions and old alike
+            # Newer vLLM exposes _python_malloc/free and assigns them to
+            # python_malloc/free; old versions don't. Handle both.
             # https://github.com/vllm-project/vllm/commit/9dc30b7068ae07ceca89663e9f8403d00217256d
             self.python_malloc_callback = self._python_malloc_callback
         if hasattr(self, '_python_free_callback'):
@@ -561,17 +549,9 @@ def patch_vllm_enable_sleep_mode():
             self,
             offload_tags: Optional[Union[Tuple[str, ...],
                                             str]] = None) -> None:
-        """
-        Put the allocator in sleep mode.
-        All data in the memory allocation with the specified tag will be
-        offloaded to CPU memory, and others will be discarded.
-
-        :param offload_tags: The tags of the memory allocation that will be
-            offloaded. The rest of the memory allocation will be discarded.
-        """
+        """Sleep mode: offload allocations with offload_tags to CPU, discard the rest."""
         if offload_tags is None:
-            # by default, allocated tensors are offloaded
-            # when the allocator sleeps
+            # by default, allocated tensors are offloaded on sleep
             offload_tags = (CuMemAllocator.default_tag, )
         elif isinstance(offload_tags, str):
             offload_tags = (offload_tags, )
@@ -591,7 +571,7 @@ def patch_vllm_enable_sleep_mode():
             total_offloads += 1
             handle = data.handle
             if data.tag == 'weights':
-                # In unsloth's case we have weights managed by unsloth. So we neither offload/delete them nor onload/create them here.
+                # Weights are unsloth-managed; don't offload/delete them here.
                 continue
             if data.tag in offload_tags:
                 size_in_bytes = handle[1]
@@ -616,19 +596,11 @@ def patch_vllm_enable_sleep_mode():
     pass
 
     def wake_up(self, tags: Optional[List[str]] = None) -> None:
-        """
-        Wake up the allocator from sleep mode.
-        All data that is previously offloaded will be loaded back to GPU
-        memory, and the rest of the data will have empty memory.
-
-        :param tags: The tags of the memory allocation that will be loaded
-            back to GPU memory. If None, all memory allocation will be loaded
-            back to GPU memory.
-        """
+        """Wake from sleep mode: reload offloaded data to GPU (tags, or all if None)."""
         delete_memory()
         for ptr, data in self.pointer_to_data.items():
             if data.tag == "weights":
-                # In unsloth's case we have weights managed by unsloth. So we neither offload/delete them nor onload/create them here.
+                # Weights are unsloth-managed; don't onload/create them here.
                 continue
             if tags is None or data.tag in tags:
                 handle = data.handle
@@ -651,9 +623,7 @@ def patch_vllm_enable_sleep_mode():
     pass
 
     def print_memory_summary(self):
-        """
-        Print the total memory usage for weights and KVCache allocations.
-        """
+        """Log total memory used by weights and KVCache allocations."""
         weights_total = 0
         kv_cache_total = 0
         kv_cache_count = 0
@@ -674,7 +644,6 @@ def patch_vllm_enable_sleep_mode():
 
     def get_patched_generate(original_generate):
         def check_sleep_mode(self):
-            # LLM object has llm_engine as an attribute
             engine = getattr(self, "llm_engine", self)
             return hasattr(engine, "vllm_config") and hasattr(engine.vllm_config, "model_config") and getattr(engine.vllm_config.model_config, "enable_sleep_mode", False)
 
@@ -699,11 +668,7 @@ pass
 
 
 def patch_vllm_graph_capture():
-    """
-    Temporarily disable ``gc.collect`` to speed up CUDA graph capture.
-    This is a workaround to avoid the overhead of garbage collection
-    during the graph capture with torch.compile.
-    """
+    """Temporarily disable gc.collect to speed up CUDA graph capture with torch.compile."""
     from contextlib import contextmanager
     import gc
     import time
@@ -779,8 +744,7 @@ pass
 
 
 def patch_vllm(debug = True):
-    # Temporary patch to disable multiprocessing for vLLM
-    # Allows accessing model_executor
+    # Disable vLLM multiprocessing so we can access model_executor.
     logger.info(f'Unsloth: Patching vLLM')
     os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
     if debug or os.getenv("UNSLOTH_ENABLE_LOGGING", "0") == "1":
@@ -818,9 +782,8 @@ def vllm_dynamic_quant_supported(
 ) -> bool:
     # All Unsloth Zoo code licensed under LGPLv3
 
-    # Check if vLLM supports some Unsloth dynamic quants
-    # Sometimes we quantize modules within a layer, but not an entire layer
-    # If so, then we cannot use dynamic quants for now
+    # Dynamic quants are unsupported when only some modules within a layer are
+    # quantized (not the whole layer).
     if not model_name.lower().endswith("unsloth-bnb-4bit"): return True
     if "quantization_config" not in config: return True
 
@@ -828,12 +791,10 @@ def vllm_dynamic_quant_supported(
     if _is_gemma4_config(config) and _get_gemma4_bnb_skip_module_aliases(config.quantization_config) is not None:
         return True
 
-    # Only allow layer modules ie model.layers.1.mlp or model.layers.1.self_attn
-
-    # Exclude model.layers.27.mlp.gate_proj
+    # Allow only layer modules (model.layers.1.mlp / .self_attn), not deeper
+    # ones like model.layers.27.mlp.gate_proj.
     parent_llm_int8_skip_modules = []
     for module in llm_int8_skip_modules:
-        # $ means end of string
         if re.search(r"[\d]\.[^\.]{1,}$", module) or "." not in module:
             parent_llm_int8_skip_modules.append(module)
     pass
@@ -879,14 +840,10 @@ def get_vllm_state_dict(
     is_vision_model = False,
     load_in_fp8 = False,
 ):
-    # If the vllm state dict was quantized using torchao, we will run into
-    # the following error when calling ops like aten.t() in inference mode.
-    # This is a bug in PyTorch that affects all tensor subclasses.
-    #
-    #     Cannot set version_counter for inference tensor
-    #
-    # For now, we work around this issue by using torch.no_grad in this case.
-    # See https://github.com/pytorch/pytorch/issues/164872 for more details
+    # torchao-quantized state dicts hit "Cannot set version_counter for
+    # inference tensor" on ops like aten.t() in inference_mode (PyTorch bug for
+    # tensor subclasses); use no_grad instead.
+    # https://github.com/pytorch/pytorch/issues/164872
     if get_quant_type(config) == "torchao" or load_in_fp8:
         ctx_manager = torch.no_grad()
     else:
@@ -898,18 +855,16 @@ def get_vllm_state_dict(
 def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_vision_model = False):
     # All Unsloth Zoo code licensed under LGPLv3
     # Unmerges vLLM modules and returns HF equivalent state_dict
-    # vllm_state_dict = {}
     try:
         llm_engine = getattr(llm, "llm_engine", getattr(llm, "engine", llm))
-        # Handle V1 vs V0 engines
         if hasattr(llm_engine, "engine_core"):
-            # V1 engine - access through engine_core (multiprocessing is disabled by patch_vllm)
+            # V1 engine via engine_core (multiprocessing disabled by patch_vllm)
             vllm_internals = llm_engine.engine_core.engine_core.model_executor.driver_worker.model_runner.model
         else:
             # V0 engine - direct access
             vllm_internals = llm_engine.model_executor.driver_worker.model_runner.model
     except:
-        # Using a new VLLM version must use collective_rpc
+        # Newer vLLM must use collective_rpc
         try:
             vllm_state_dict = {}
             gpu_ids = llm.collective_rpc("report_device_id", args = tuple())
@@ -925,10 +880,10 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
 
     assert(config is not None)
 
-    # Determine model type from config BEFORE reassigning config
+    # Read model_type before reassigning config below
     model_type = getattr(config, "model_type", "causal_lm")
 
-    # Keep the original config for model_type but use text_config for vocab_size etc
+    # text_config holds vocab_size etc; keep original config for model_type
     text_config = getattr(config, "text_config", config)
 
     vocab_size = text_config.vocab_size
@@ -941,9 +896,9 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
 
 
     try:
-        # vLLM recently removed the transpose of weight scale for Hopper GPUs.
+        # vLLM removed the Hopper weight-scale transpose; check whether the
+        # weight-process function still transposes before we do.
         # https://github.com/vllm-project/vllm/pull/28431
-        # So now we check if the weight process function does a transpose of weight scale before doing so
         # https://github.com/vllm-project/vllm/commit/f9a4087182ffcd9404779fcda876f820b3b26d5f#diff-cce58c0ceb6a9b15a01f117d734b93736acc25ed89921c2eacc58ea05bd34d0eL1155-L1157
         from vllm.model_executor.layers.quantization.utils.fp8_utils import maybe_post_process_fp8_weight_block
         from inspect import getsource
@@ -955,7 +910,6 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
     is_deep_gemm_supported = False
     cutlass_block_fp8_supported = False
     if needs_transpose_check:
-        # Only try to import and check if we need to
         try:
             from vllm.utils.deep_gemm import is_deep_gemm_supported as vllm_is_deep_gemm_supported
             is_deep_gemm_supported = vllm_is_deep_gemm_supported()
@@ -972,14 +926,14 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
         proj = getattr(proj, "base_layer", proj)
         qweight = proj.weight
 
-        # Determine slicing offsets
+        # Slicing offsets
         output_sizes = getattr(proj, "output_sizes", None)
         if output_sizes is not None:
             dim_offsets = np.cumsum([0] + output_sizes)
         else:
             dim_offsets = [0, qweight.shape[0]]
 
-        ## Handle FP8 weights. For now only BlockQuantized
+        ## FP8 weights (BlockQuantized only for now)
         if qweight.dtype == torch.float8_e4m3fn:
             if hasattr(proj, 'weight_scale'):
                 weight_scale = proj.weight_scale
@@ -993,34 +947,29 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
             scale_suffix = '.weight_scale'
             if weight_scale.ndim == 2:
                 if weight_scale.shape[1] > 1:
-                    # Block quantized has 2D weight scale
-                    # for qwen 3 for eg, 4096 query and 1024 each for k and v. Weight block size say is [128, 128]
-                    # so the shape of qkv is [6144, 4096] and scale.T is [48, 32]. Now 48 should be split into [0, 32, 40, 48]
-                    # Also notice that vLLM stores scale in [32,48] which is transpose of what HF expects.
+                    # Block quantized: 2D weight scale. vLLM stores it transposed
+                    # vs what HF expects (e.g. qwen3 qkv [6144,4096], scale.T [48,32]).
                     scale_suffix = '.weight_scale_inv'
                     block_size = proj.weight_block_size[0]
                     is_compressed_linear = "CompressedTensors" in str(type(getattr(proj, 'quant_method', None)))
                     if is_compressed_linear:
-                        # Compressed linear doesn't seem to transpose the weight scale inv
-                        # Also preferes the name weight_scale (without _inv suffix)
-                        # We detect it based on the quant_method we see in proj's attributes
+                        # Compressed linear keeps weight_scale (no _inv) untransposed.
                         scale_suffix = '.weight_scale'
                     elif needs_transpose_check:
                         should_use_deepgemm = is_deep_gemm_supported and getattr(proj, "orig_dtype", torch.bfloat16) == torch.bfloat16 and qweight.shape[0] % 128 == 0 and qweight.shape[1] % 128 == 0
                         if sm_cap==90 and cutlass_block_fp8_supported and not should_use_deepgemm:
-                            # For H100 (at least), the scale seems to be a transpose of what HF expects, while on L4 it is right shape.
-                            # This is done by vLLM based on a few checks that we replicated above.
+                            # On H100 the scale is transposed vs HF (L4 isn't); mirror vLLM's checks.
                             # https://github.com/vllm-project/vllm/blob/294c805f1df9ddf62c2290989710da9d48ab4973/vllm/model_executor/layers/quantization/utils/fp8_utils.py#L1172-L1179
                             weight_scale = weight_scale.T
                             logger.info(f"Unsloth: Transposed weight scale for {prefix} for weight shape {qweight.shape} and scale shape {weight_scale.shape}")
                     pass
                     a, b = qweight.shape
                     p, q = weight_scale.shape
-                    # This is just a sanity check to ensure that we don't end up with wrongly sliced weight of shape [0, x] :)
+                    # Sanity check against wrongly sliced [0, x] weights
                     assert a // p == proj.weight_block_size[0] and b // q == proj.weight_block_size[1], f"Unsloth: vLLM weight for {prefix} has unexpected weight shape {qweight.shape} and scale {weight_scale.shape} and block size {proj.weight_block_size}"
                 else:
-                    # This is dynamic quantization (aka per row or per column). The scale is of shape [n,1]
-                    # The weight here is of shape [4096, 6144]. We need to transpose and then slice
+                    # Dynamic (per row/column) quant: scale [n,1], weight [4096,6144];
+                    # transpose then slice.
                     qweight = qweight.T
                     block_size = 1
 
@@ -1060,8 +1009,8 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
             else:
                 weight = qweight
 
-        # Apply vocab_size truncation for embedding and lm_head layers
-        # for mllama, prefer using org_vocab_size which is text_config.vocab_size + 8
+        # Truncate embedding / lm_head to vocab_size; mllama prefers
+        # org_vocab_size (= text_config.vocab_size + 8).
         # https://github.com/huggingface/transformers/blob/1cea763ba422b83778a8db0374ea90f43b09992b/src/transformers/models/mllama/modeling_mllama.py#L1147
         shrink_size = getattr(proj,"org_vocab_size", vocab_size)
         if shrink_size and ("embed_tokens" in prefix or "lm_head" in prefix):
@@ -1104,7 +1053,7 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
         vllm_text_model = vllm_internals.model
         vllm_text_model_prefix = "model"
     elif hasattr(vllm_internals, "language_model"):
-        # For Llama 3.2, Gemma 3 and Qwen 2.5 VL, they have text model in model.language_model.model
+        # Llama 3.2 / Gemma 3 / Qwen 2.5 VL keep the text model in model.language_model.model
         if not is_vision_model and not hasattr(config, "text_config"):
             vllm_text_model_prefix = "model"
         else:
@@ -1114,10 +1063,8 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
         raise RuntimeError(f'Unsloth: Cannot find vllm_internal_model!')
 
     embed_tokens = vllm_text_model.embed_tokens
-    # Use get_state_dict for consistent extraction and automatic truncation
     get_state_dict(f"{vllm_text_model_prefix}.embed_tokens", 0, state_dict, embed_tokens, slice_weights=False)
 
-    # Get layer configuration for this model type
     layer_config = get_model_layer_config()
 
     packed_modules_mapping = getattr(vllm_internals, "packed_modules_mapping", None)
@@ -1139,9 +1086,9 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
 
             use_fused_qkv = _is_fused_module("qkv_proj")
             if use_fused_qkv:
-                # For some model types like phi3 vllm will expect fused qkv (e.g. Phi3, Phi3.5-mini-instruct, Phi4-mini-instruct)
-                # so we should not split them here otherwise there will be a size mismatch when activating the adapter
-                # see https://github.com/vllm-project/vllm/blob/9b693d023cf595e60b5346fdeeb41cf2a6eda838/vllm/model_executor/models/phi3.py
+                # phi3 family keeps qkv fused; splitting causes a size mismatch
+                # when activating the adapter.
+                # https://github.com/vllm-project/vllm/blob/9b693d023cf595e60b5346fdeeb41cf2a6eda838/vllm/model_executor/models/phi3.py
                 get_state_dict(f"{prefix}.qkv_proj", 0, state_dict, qkv_proj, slice_weights=False)
             else:
                 get_state_dict(f"{prefix}.q_proj", 0, state_dict, qkv_proj)
@@ -1208,9 +1155,8 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
         proj = layer.mlp.gate_up_proj
         use_fused_gate_up = _is_fused_module("gate_up_proj")
         if use_fused_gate_up:
-            # For some model types like phi3 vllm will expect fused gate_up_proj (e.g. Phi3, Phi3.5-mini-instruct, Phi4-mini-instruct)
-            # so we should not split them here otherwise there will be a size mismatch when activating the adapter
-            # see https://github.com/vllm-project/vllm/blob/9b693d023cf595e60b5346fdeeb41cf2a6eda838/vllm/model_executor/models/phi3.py
+            # phi3 family keeps gate_up_proj fused; splitting breaks the adapter.
+            # https://github.com/vllm-project/vllm/blob/9b693d023cf595e60b5346fdeeb41cf2a6eda838/vllm/model_executor/models/phi3.py
             get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.gate_up_proj", 0, state_dict, proj, slice_weights=False)
         else:
             get_state_dict(f"{vllm_text_model_prefix}.layers.{kk}.mlp.gate_proj", 0, state_dict, proj)
@@ -1225,11 +1171,8 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
     pass
 
     if is_vision_model:
-        # Handle vision-specific layers using dedicated functions
         extract_vision_layers(vllm_internals, state_dict, quant_state_dict, get_state_dict)
-    # Norm
-    # For Gemma3 and similar multimodal models, norm should be under model.norm
-    # For standard models, also under model.norm
+    # Norm (under model.norm for both standard and multimodal models)
     norm_prefix = f"{vllm_text_model_prefix}.norm.weight"
     state_dict[norm_prefix] = vllm_text_model.norm.weight.data
     quant_state_dict[norm_prefix] = state_dict[norm_prefix]
@@ -1248,7 +1191,7 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
                 state_dict[key] = param.data
                 quant_state_dict[key] = param.data
 
-    # LM Head - Use get_state_dict for consistency
+    # LM Head
     if not getattr(text_config, "tie_word_embeddings", False):
         lm_layer = next((mod for name, mod in vllm_internals.named_modules() if name == "lm_head" or name.endswith(".lm_head")), None)
         if lm_layer is None:
@@ -1300,7 +1243,7 @@ def assert_same_state_dict(old_state_dict, new_state_dict):
                 continue
             loose_tol = old_val.dtype != new_val.dtype or (new_val.element_size() < 2)
             if loose_tol:
-                # upcast both to float32 just for comparison. For FP8, vLLM stores weight scale in FP32 while HF preferes 16bit
+                # Compare in fp32: vLLM stores FP8 weight scale in fp32, HF in 16bit
                 old_val = old_val.to(torch.float32)
                 new_val = new_val.to(torch.float32)
                 torch.testing.assert_close(old_val, new_val, check_stride = False, atol = 1e-4, rtol = 1e-3)
@@ -1337,7 +1280,7 @@ pass
 @torch.inference_mode
 def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16, bnb_config = None, is_vision_model = False):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Unmerges vLLM modules to create HF compatible model
+    # Unmerges vLLM modules into an HF-compatible model
     def _unwrap_tensor(value):
         return getattr(value, "data", value)
 
@@ -1424,12 +1367,12 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
             layer_name = layer_name.format(kk = kk)
 
             if 'language_model.model' in layer_name:
-                # vLLM uses vllm_internals.language_model.model.layers while HF uses model.language_model.layers
+                # vLLM uses language_model.model.layers; HF uses language_model.layers
                 layer_name = layer_name.replace('language_model.model', 'language_model')
 
             is_weight = True
             if layer_name in quant_state_dict:
-                # for attirbutes of type nn.Parameter, there's no .weight
+                # nn.Parameter attributes have no .weight
                 weight = quant_state_dict[layer_name]
                 is_weight = False
             else:
@@ -1459,7 +1402,7 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
             if fp8_weight_scale is not None: assert fp8_weight_scale.ndim in [1,2], f"we only support row quantized (ndim=1) and block quantized(ndim=2) fp8 but found {fp8_weight_scale.ndim}"
 
             if layer_name in quant_state_dict:
-                # for attributes of type nn.Parameter, there's no .weight
+                # nn.Parameter attributes have no .weight
                 layer_name_br = re.sub(r"\.([\d]+)(?=\.|$)", lambda x: f"[{x.group(1)}]", layer_name)
                 raw_value = _unwrap_tensor(weight)
                 parent_path, _, attr_name = layer_name_br.rpartition(".")
@@ -1472,7 +1415,7 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                 continue
             elif fp8_weight_scale is not None:
                 if fp8_weight_scale.ndim == 1:
-                    # This is FP8 quantized but not block quant. Either dynamic or static
+                    # FP8 dynamic/static (not block) quant
                     layer = FbgemmFp8Linear(in_features = 0, out_features = 0, bias = has_bias, weight_dtype = dtype).to(get_target_device())
                     layer.in_features = weight.shape[1]
                     layer.out_features = weight.shape[0]
@@ -1483,8 +1426,8 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                     layer.weight.input_scale_ub = kwargs['input_scale_ub']
                     layer.quant_method = "fbgemm_fp8"
                 elif fp8_weight_scale.ndim == 2:
-                    # This denotes that the model if FP8 dynamic quantized.
-                    # transformers 5.0+ renamed bias -> has_bias and removed device
+                    # FP8 dynamic quantized. transformers 5.0+ renamed
+                    # bias -> has_bias and removed device.
                     if Version("transformers") < Version("5.0.0"):
                         fp8_kwargs = dict(in_features=0, out_features=0, bias=has_bias, dtype=dtype, block_size=kwargs['block_size'], activation_scheme=kwargs['activation_scheme'], device=get_target_device())
                     else:
@@ -1530,7 +1473,7 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                 layer = Linear(0, 0, device = get_target_device(), bias = has_bias)
                 layer.in_features  = weight.shape[1]
                 layer.out_features = weight.shape[0]
-                # from vllm 0.11.1, the .weight is of dtype ModelWeightParameter, so try to extract the 'data' part
+                # vLLM 0.11.1+ wraps .weight as ModelWeightParameter; unwrap to data.
                 # https://github.com/vllm-project/vllm/commit/de94289a98d7ec52a5ef02719e01a1db8b505170#diff-7d6145ac4ba084231a441c2056c7fca23c3bae33e6542f4f602a6c9d4d2da64dL199-R208
                 layer.weight = torch.nn.Parameter(_unwrap_tensor(weight), requires_grad = False)
                 layer.bias = bias
@@ -1546,7 +1489,7 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                 continue
             pass
 
-            # Convert model.layers.0.self_attn.q_proj to model.layers[0].self_attn.q_proj
+            # model.layers.0.* -> model.layers[0].*
             layer_name = re.sub(r"\.([\d]{1,})", lambda x: f"[{x.group(1)}]", layer_name)
             exec(f"new_model.{layer_name} = layer")
         pass
@@ -1731,13 +1674,9 @@ pass
 
 
 def vllm_supports_flashinfer(config) -> bool:
-    """
-    Approximately checks if a vLLM model supports FLASHINFER by checking
-    vLLM's ModelRegistry, then inspecting if an `if self.attn_backend not in { ... }`
-    guard excludes FLASHINFER.
-
-    For eg Qwen3-VL does not work with flashinfer.
-    """
+    """Approximate check for vLLM FLASHINFER support: looks up the model in
+    ModelRegistry, then inspects for an `attn_backend not in {...}` guard that
+    excludes FLASHINFER (e.g. Qwen3-VL does not work with flashinfer)."""
     try:
         from vllm.model_executor.models.registry import ModelRegistry
     except Exception as e:
@@ -1791,16 +1730,14 @@ def vllm_supports_flashinfer(config) -> bool:
         if not matches:
             return False
 
-        # For each guard, see if FLASHINFER appears in the allowed set.
+        # If any guard's allowed set includes FLASHINFER, don't disallow.
         for m in matches:
             body = m.group("body")
             if "FLASHINFER" in body:
-                # Some allowed-set includes FLASHINFER → don't disallow.
                 return False
 
-        # We found at least one guard, but none of its allowed sets mention FLASHINFER.
-        # That's exactly the Qwen3-VL pattern:
-        # { FLASH_ATTN, TORCH_SDPA, ROCM_AITER_FA }
+        # Guards exist but none allow FLASHINFER -- the Qwen3-VL pattern
+        # { FLASH_ATTN, TORCH_SDPA, ROCM_AITER_FA }.
         return True
 
     return not _module_disallows_flashinfer(module)
@@ -1808,10 +1745,7 @@ pass
 
 
 def _get_torchao_fp8_config(fp8_mode: str):
-    """
-    Return a `torchao.quantization.Float8DynamicActivationFloat8WeightConfig`
-    to be used for `load_in_fp8=True`.
-    """
+    """Float8DynamicActivationFloat8WeightConfig for load_in_fp8=True."""
     from torchao.quantization import (
         Float8DynamicActivationFloat8WeightConfig,
         PerBlock,
@@ -1900,7 +1834,7 @@ def load_vllm(
         elif ten_percent >= 1.4: standby_target_gpu_util = 0.8
         elif ten_percent >= 1.0: standby_target_gpu_util = 0.775
         else: standby_target_gpu_util = 0.75
-        # Reduce memory usage for newer vLLM versions since it OOMs
+        # vLLM >= 0.11.0 uses more VRAM and OOMs; reduce further.
         if UNSLOTH_ENABLE_LOGGING:
             logger.info(f"Decreasing VRAM further since vLLM version >= 0.11.0 uses more")
         standby_target_gpu_util *= 0.95
@@ -1934,7 +1868,7 @@ def load_vllm(
     else:
         mem_config = config
 
-    # Determine the maximum LoRA rank since vLLM restricts the rank to some values
+    # vLLM only allows certain LoRA ranks; round up to a supported one.
     new_max_lora_rank = determine_max_lora_rank(max_lora_rank)
     if new_max_lora_rank != max_lora_rank:
         print(f"Unsloth: Changing the maximum lora rank to {new_max_lora_rank} from {max_lora_rank} for vLLM.")
@@ -1955,9 +1889,8 @@ def load_vllm(
     if is_fp8 and DEVICE_TYPE == "cuda":
         major_version, minor_version = torch.cuda.get_device_capability()
         if major_version == 10:
-            # It is noticed that Deepgemm is generally slower than triton for vLLM
+            # DeepGEMM is generally slower than triton for vLLM here.
             # https://x.com/TheZachMueller/status/2024619480580510117?s=20
-            # This might get implemented in vLLM later but till then we have this toggle
             os.environ['VLLM_USE_DEEP_GEMM'] = '0'
 
     assert not (use_bitsandbytes and is_fp8), f'`load_in_4bit` and `load_in_8bit` should be set to false for loading FP8 quantized models with fast inference'
@@ -1994,8 +1927,7 @@ def load_vllm(
         assert max_seq_length >= 8192, "Unsloth: MLLama requires max_seq_length >= 8192 for fast inference"
 
     else:
-        # Check max_num_batched_tokens for max_seq_length
-        # Must be >= max_num_batched_tokens
+        # max_num_batched_tokens must be >= max_seq_length
         if max_num_batched_tokens <= 0:
             max_seq_length = 256
             max_num_batched_tokens = 256
@@ -2033,13 +1965,12 @@ def load_vllm(
     # Fix up vLLM compute_dtype for bitsandbytes
     BitsAndBytesConfig = patch_vllm_compute_dtype(dtype)
 
-    # Use Flashinfer if possible (doesn't seem to be faster for BnB)
-    # Also seems to process 2x less sequences in 1 go so less throughput?
-    # Maybe FP8 Flashinfer is much better
+    # Use Flashinfer if possible (not faster for BnB, and seems lower throughput;
+    # FP8 Flashinfer may be better).
     # See https://docs.vllm.ai/en/latest/serving/env_vars.html
     if importlib.util.find_spec("flashinfer") and os.environ.get("UNSLOTH_VLLM_NO_FLASHINFER", "0") == "0":
-        # Pre-flight check: FlashInfer JIT-compiles CUDA kernels, requiring nvcc and ninja.
-        # If either is missing, skip FlashInfer so vLLM falls back to FLASH_ATTN + native sampler.
+        # FlashInfer JIT-compiles CUDA kernels; needs nvcc and ninja. If either
+        # is missing, skip it so vLLM falls back to FLASH_ATTN + native sampler.
         _has_nvcc = (
             shutil.which("nvcc") is not None
             or os.path.isfile(os.path.join(os.environ.get("CUDA_HOME", ""), "bin", "nvcc"))
@@ -2067,7 +1998,7 @@ def load_vllm(
             if os.environ.get("VLLM_ATTENTION_BACKEND", "") == "FLASHINFER":
                 del os.environ["VLLM_ATTENTION_BACKEND"]
         else:
-            # Check if FLASHINFER is supported - for eg Qwen3-VL and Qwen2-VL do not work
+            # FLASHINFER unsupported by some models (e.g. Qwen3-VL, Qwen2-VL)
             if "VLLM_ATTENTION_BACKEND" in os.environ and os.environ["VLLM_ATTENTION_BACKEND"] == "":
                 del os.environ["VLLM_ATTENTION_BACKEND"]
             elif not vllm_supports_flashinfer(config):
@@ -2120,11 +2051,8 @@ def load_vllm(
 
     from vllm import LLM, LLMEngine, AsyncLLMEngine, EngineArgs, AsyncEngineArgs
 
-    # Default vLLM max_num_seqs is 256
-    # This is how many sequences can be processed in parallel
-    # We do 64 on smaller GPUs
-    # batch_size = 16, num_generations = 4 for eg.
-    # We expand max_batched_tokens to 4096 on small GPUs and 8192 on large ones.
+    # max_num_seqs = sequences processed in parallel (vLLM default 256; we use
+    # 64 on smaller GPUs). max_batched_tokens scales 4096 -> 8192 small -> large.
     """
     Benchmarks for max_batched_tokens, max_num_seqs
     Around after max_num_seqs>=64, we see linear increase in memory usage.
@@ -2158,17 +2086,15 @@ def load_vllm(
     elif memory_left_for_kv_cache_gb >  80: max_num_batched_tokens, approx_max_num_seqs = 8192, 256 # + 16
 
     if is_vision_model:
-        # In vLLM profiling, each sequence contributes to an image. Which is generally in the order of thousand tokens.
-        # We don't want to go beyond 16 sequences for vision models.
-        # TODO: In vLLM V1, iirc, the profiling sets a cap on the max seqs based on the budget. Check it out.
+        # Each sequence carries an image (~thousands of tokens) in vLLM
+        # profiling; cap seqs low for vision models.
+        # TODO: vLLM V1 profiling may cap max seqs by budget; check.
         print(f'Unsloth: Vision model detected, setting approx_max_num_seqs to 1')
-        # [TODO] Check this
         approx_max_num_seqs = 1
-        # Single image would contribute to 6404 tokens in Llama 3.2 for eg. So have some more for text
-        # For qwen 2.5 VL, this single image/video contributes to 16Ki tokens
+        # One image is ~6404 tokens (Llama 3.2) / ~16Ki (qwen 2.5 VL); leave room for text.
         max_num_batched_tokens = max(8192, max_seq_length)
 
-    # float8 KV cache can fit more sequences in 1 go so more throughput
+    # float8 KV cache fits more sequences -> more throughput
     if float8_kv_cache: approx_max_num_seqs = int(approx_max_num_seqs * 1.05)
 
     # vLLM default max_num_batched_tokens is 2048
@@ -2183,7 +2109,7 @@ def load_vllm(
         elif memory_left_for_kv_cache_gb <= 80: chunked_prefill_tokens = 8192 # + 4096
         else: chunked_prefill_tokens = 8192 # + 0
 
-        # vLLM errors out from max_seq_length (2048) being bigger than chunked_prefill_tokens (1024)
+        # vLLM errors if max_seq_length exceeds chunked_prefill_tokens
         chunked_prefill_tokens = max_seq_length
 
     # Scale num_seqs by conservativeness
@@ -2326,8 +2252,7 @@ def load_vllm(
         enable_sleep_mode      = unsloth_vllm_standby,
     )
     if is_vision_model:
-        # To reduce memory usage, we limit the number of images/videos per prompt
-        # TODO: Make it configurable by user
+        # Limit images/videos per prompt to save memory. TODO: make configurable.
         engine_args["limit_mm_per_prompt"] = {"image": 1, "video": 0}
     if _is_gemma4_config(config) and use_bitsandbytes:
         gemma4_bnb_quantization_config = _get_gemma4_bnb_skip_module_aliases(
@@ -2367,9 +2292,8 @@ def load_vllm(
                 logger.info(f"Unsloth: Setting vLLM block_size=32 for head_dim={_head_dim} to avoid FlashInfer bug on Blackwell.")
     pass
 
-    # On-the-fly quantization is added in https://github.com/vllm-project/vllm/pull/23014
-    # This is only available in vllm >= 0.12.0. Older versions will do offline quantization
-    # by creating an FP8 checkpoint and loading it back in
+    # On-the-fly quantization (vLLM >= 0.12.0); older versions quantize offline.
+    # https://github.com/vllm-project/vllm/pull/23014
     if fp8_mode is not None and Version(vllm_version) >= Version("0.12.0"):
         from torchao.core.config import config_to_dict
         torchao_config = _get_torchao_fp8_config(fp8_mode)
@@ -2482,7 +2406,7 @@ pass
 
 def create_batches(requests, num_sequences = 64):
     # All Unsloth Zoo code licensed under LGPLv3
-    # llm.generate must be batched!
+    # llm.generate must be batched
     n_splits = int(math.ceil(len(requests) / num_sequences))
     offsets = np.arange(0, len(requests), num_sequences)
     if offsets[-1] != len(requests):
@@ -2738,7 +2662,7 @@ pass
 
 def generate_batches(llm, inputs, n_batches = None, lora_request = None, *args, **kwargs):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Cannot just use llm.generate or will OOM - split into batches
+    # Split into batches; a single llm.generate would OOM
     if n_batches is None:
         if "UNSLOTH_VLLM_BATCHES" in os.environ:
             n_batches = int(os.environ["UNSLOTH_VLLM_BATCHES"])
@@ -2916,14 +2840,12 @@ def _test_same_model(model, new_model, input_ids):
     B = new_model.model.norm(B)
     torch.testing.assert_close(A, B)
 
-    # LM Head testing with proper error handling
+    # LM Head testing
     try:
-        # Check if both models have lm_head
         if hasattr(model, 'lm_head') and hasattr(new_model, 'lm_head'):
             if model.lm_head.weight is not None and new_model.lm_head.weight is not None:
                 torch.testing.assert_close(model.lm_head.weight, new_model.lm_head.weight)
 
-        # Continue with lm_head forward pass if possible
         if hasattr(model, 'lm_head') and hasattr(new_model, 'lm_head'):
             A = model.lm_head(A)
             B = new_model.lm_head(B)
@@ -2968,17 +2890,13 @@ pass
 
 @torch.inference_mode()
 def test_model_conversion(original_model, new_model):
-    """
-    Simplified model testing using clean comparison utilities.
-    Replaces the complex _test_same_model function.
-    """
+    """Simplified model conversion test (replaces _test_same_model)."""
     print("=== MODEL CONVERSION TEST ===")
 
-    # Compare model attributes. Wouldn't throw error if some attributes are missing
+    # Compare attributes; missing ones don't raise.
     compare_attributes(original_model, new_model)
 
     try:
-        # compare state dicts
         assert_same_state_dict(original_model.state_dict(), new_model.state_dict())
         print("✅ State dict comparison passed!")
     except Exception as e:
@@ -3040,7 +2958,6 @@ def _test_is_same_vlm(model, new_model, processor, test_backward=False):
     print('Losses match !')
 
     if test_backward:
-        # Initialize per-model statistics dictionaries
         original_model_stats = {
             'pre': defaultdict(list),
             'post': defaultdict(list),
@@ -3053,24 +2970,19 @@ def _test_is_same_vlm(model, new_model, processor, test_backward=False):
             'backward': defaultdict(list)
         }
 
-        # Register hooks for both models
         register_hooks(model, original_model_stats)
         register_hooks(new_model, new_model_stats)
 
-        # Prepare inputs
         from copy import deepcopy
         inputs['labels'] = deepcopy(inputs['input_ids'])
         inputs['input_ids'].requires_grad = True
 
-        # Forward passes
         original_outputs = model(**inputs)
         new_outputs = new_model(**inputs)
 
-        # Check loss matches
         torch.testing.assert_close(original_outputs.loss, new_outputs.loss)
         print('Losses match!')
 
-        # Backward passes
         original_outputs.loss.backward()
         new_outputs.loss.backward()
 
@@ -3115,9 +3027,7 @@ pass
 
 
 def get_vllm_supported_vlm(_VAR_NAME = "VLLM_SUPPORTED_VLM"):
-    """
-    Parse VLLM_SUPPORTED_VLM from unsloth/models/vision.py as a literal.
-    """
+    """Parse VLLM_SUPPORTED_VLM from unsloth/models/vision.py as a literal."""
     src = _read_unsloth_vision_source()
     tree = ast.parse(src)
 
@@ -3220,7 +3130,7 @@ def _test_get_vllm_state_dict(
     extraction_config.model_name = model_name
     dense_state_dict, text_normalized_state_dict = _get_dense_causal_lm_state_dict(model)
 
-    # Patch vLLM to disable multiprocessing for state dict extraction
+    # Disable vLLM multiprocessing for state dict extraction
     patch_vllm()
 
     llm = load_vllm(
@@ -3287,7 +3197,7 @@ def _test_get_vllm_state_dict(
         )
 
         if not skip_generation:
-            # Cannot just use llm.generate or OOM - split into batches
+            # Split into batches to avoid OOM
             batches = create_batches(inputs, llm.approx_max_num_seqs)
             completion_ids = []
             for batch in batches:
@@ -3311,8 +3221,8 @@ def _test_get_vllm_state_dict(
         else:
             _test_whole_model_forward(model, new_model, input_ids)
     else:
-        # VLMs dont have a standardised forward pass mechanism. So we just test whole model forward pass and not layer wise
-        # TODO: Maybe add layer wise checks
+        # VLMs lack a standard forward path; test whole-model forward only.
+        # TODO: maybe add layer-wise checks.
         from transformers import AutoProcessor
         processor = AutoProcessor.from_pretrained(model_name)
         _test_is_same_vlm(model, new_model, processor, False)


### PR DESCRIPTION
Summary:
- Reduced redundant comments and tightened docstrings across the Python codebase (101 files).
- Preserved load-bearing rationale: upstream bug/version/hardware/numerical notes, reference URLs and issue/PR links, license/SPDX headers, and lint/type directives.
- No runtime behavior changes intended.

Scope and exclusions:
- Comment and docstring text only. No code, imports, string/regex literals, or AST-visible tokens changed.
- Left untouched: security mirror scripts/scan_packages.py, the tests/mlx_simulation stubs, the triton/bitsandbytes shims, and the vLLM-derived vllm_lora_request.py.

Verification:
- AST + token signature check passed with docstrings stripped: 101/101 comment-only.
- Repo guardrail scripts/verify_comment_only_diff.py passed for all changed files.
- python -m py_compile passed for every changed file.
- Source-scanning and drift tests pass (the suites that read the package's own source text).