### PR TITLE
mlx/cce: restore memory-budget worked examples and chunk-size strategy notes

### DIFF
--- a/unsloth_zoo/mlx/cce/runtime_cce.py
+++ b/unsloth_zoo/mlx/cce/runtime_cce.py
@@ -29,9 +29,25 @@ __all__ = [
 
 
 def _get_memory_budget() -> int:
-    """Per-chunk logit byte budget = 0.1% of the device's recommended working set,
-    capped at 128 MB (and floored at 4 MB). Small devices chunk more aggressively;
-    the cap keeps enough granularity (>=16 chunks for 128K vocab). 128 MB fallback.
+    """Return a per-chunk logit byte budget based on available hardware memory.
+
+    Two considerations in tension:
+      1. Smaller devices need aggressive chunking (more chunks, smaller each)
+         to avoid OOM.
+      2. The MLX scheduler benefits from small chunks regardless of device size
+         — but too many chunks incurs kernel-launch overhead.
+
+    We use 0.1% of the device's recommended working set as the budget, capped
+    at 128 MB and floored at 4 MB.  The cap ensures the scheduler always gets
+    enough granularity (≥16 chunks for 128K vocab at any batch size ≤4), while
+    the hardware scaling ensures small devices chunk even more aggressively.
+
+      M4 Max 128GB → 103 GB recommended → min(103 MB, 128 MB) = 103 MB
+      M3 Pro 36GB  →  27 GB recommended → min(27 MB, 128 MB)  =  27 MB
+      M2 16GB      →  12 GB recommended → min(12 MB, 128 MB)  =  12 MB
+      M1 8GB       →   6 GB recommended → min(6 MB, 128 MB)   =   6 MB
+
+    Falls back to 128 MB if device info is unavailable.
     """
     try:
         import mlx.core as _mx
@@ -62,14 +78,27 @@ def _resolve_chunk_size(
     if _CHUNK_BUDGET is None:
         _CHUNK_BUDGET = _get_memory_budget()
 
-    # Target 16 chunks (scheduler granularity), min 2048 vocab/chunk (GEMM floor),
-    # per-chunk bytes <= hw budget (<=128 MB), so each chunk frees before the next.
+    # Goal: choose chunk_v so the MLX scheduler can free each chunk's logit
+    # tensor before the next chunk is computed, while keeping chunks large
+    # enough for efficient GEMM.
+    #
+    # Strategy: target 16 chunks as the baseline granularity.  The per-chunk
+    # byte budget (derived from hardware memory) caps how large each chunk can
+    # be.  On large-memory devices the cap is ~100 MB; on small devices it
+    # scales down to force more aggressive chunking.
+    #
+    # Constraints:
+    #   - min 2048 vocab entries per chunk  (GEMM efficiency floor)
+    #   - target 16 chunks                 (scheduler granularity sweet spot)
+    #   - per-chunk bytes ≤ hw budget       (adapts to device memory, ≤128 MB)
+
     min_chunk_v = 2048
     target_chunks = 16
 
+    # Compute chunk_v from target chunk count
     chunk_v = (vocab_size + target_chunks - 1) // target_chunks
 
-    # Enforce per-chunk byte limit
+    # Enforce per-chunk byte limit (adapts to hardware)
     chunk_bytes = n_tokens * chunk_v * bytes_per_element
     if chunk_bytes > _CHUNK_BUDGET and chunk_v > min_chunk_v:
         chunk_v = max(min_chunk_v, _CHUNK_BUDGET // (max(1, n_tokens) * bytes_per_element))


### PR DESCRIPTION
The repo-wide comment cleanup (#733) over-condensed two docstrings/comment blocks in unsloth_zoo/mlx/cce/runtime_cce.py. Restore the detail:
- _get_memory_budget: the per-device worked examples (M4 Max 128GB -> 103 MB, M3 Pro, M2, M1) and the two-considerations rationale; keep the accurate 4 MB floor note.
- _resolve_chunk_size: the Goal / Strategy / Constraints explanation.

Docstring/comment-only: AST + token signature identical to main (comment_tools.py and scripts/verify_comment_only_diff.py); py_compile passes; CCE tests pass.