### PR TITLE
Fix brittle anchor in convert_vllm_to_huggingface regex test

### DIFF
--- a/tests/test_vllm_to_hf_conversion.py
+++ b/tests/test_vllm_to_hf_conversion.py
@@ -1122,12 +1122,13 @@ def test_convert_regex_handles_trailing_digit_parameter_paths():
 
 def test_convert_vllm_to_huggingface_uses_robust_bracket_regex():
     # The Parameter-assignment path must use the anchor-or-end regex so keys
-    # ending in `.DIGIT` get bracketed.
+    # ending in `.DIGIT` get bracketed. Anchor on the bracketing code (first
+    # occurrence is this branch), not a comment, so the check survives reworded
+    # comments.
     from unsloth_zoo import vllm_utils
     src = inspect.getsource(vllm_utils.convert_vllm_to_huggingface)
     assert r'r"\.([\d]+)(?=\.|$)"' in src
-    param_branch_anchor = "# for attributes of type nn.Parameter, there's no .weight"
-    idx = src.index(param_branch_anchor)
+    idx = src.index("layer_name_br = re.sub(")
     nearby = src[idx:idx + 400]
     assert r'r"\.([\d]+)(?=\.|$)"' in nearby
     assert r'r"\.([\d]{1,})\."' not in nearby


### PR DESCRIPTION
## Summary

`test_convert_vllm_to_huggingface_uses_robust_bracket_regex` locates the Parameter-assignment branch of `convert_vllm_to_huggingface` by searching the function source for a literal comment string:

```python
param_branch_anchor = "# for attributes of type nn.Parameter, there's no .weight"
idx = src.index(param_branch_anchor)
```

The repo-wide comment pass in #733 reworded that comment to `# nn.Parameter attributes have no .weight`, so `src.index(...)` now raises `ValueError: substring not found`. That turns the `Core` job red on every downstream PR, because `unslothai/unsloth`'s `Core` workflow runs this repo's full test suite against `unsloth-zoo @ main`.

## Fix

Anchor on the bracketing code line `layer_name_br = re.sub(` instead of comment prose. Its first occurrence is the Parameter branch, so the existing 400-char window still:

- requires the anchor-or-end regex `r"\.([\d]+)(?=\.|$)"` in that branch, and
- forbids the old fragile `r"\.([\d]{1,})\."` nearby (that pattern legitimately remains in a different branch further down).

The test keeps its original intent and no longer depends on comment wording.

## Verification

```
python -m pytest tests/test_vllm_to_hf_conversion.py -q
58 passed
```

Both the fixed test and the sibling `test_convert_regex_handles_trailing_digit_parameter_paths` pass.
