### PR TITLE
Fix born-broken FakeModel fixture in mlx finetune_last_n_layers test

### DIFF
--- a/tests/test_mlx_finetune_last_n_layers.py
+++ b/tests/test_mlx_finetune_last_n_layers.py
@@ -65,6 +65,10 @@ def test_get_peft_model_passes_finetune_last_n_layers_through():
         _is_vlm_model = False
         def freeze(self): pass
         def unfreeze(self, **kwargs): pass
+        # The trainable-parameter summary at the end of get_peft_model walks
+        # these; empty trees keep the count at 0 without touching the asserts.
+        def parameters(self): return {}
+        def trainable_parameters(self): return {}
 
     # Capture num_layers values seen by linear_to_lora_layers.
     captured = {"calls": []}


### PR DESCRIPTION
test_get_peft_model_passes_finetune_last_n_layers_through has been failing since it was introduced in #669. The trainable parameter summary at the end of get_peft_model (unsloth_zoo/mlx/loader.py, added in #634) calls model.trainable_parameters() and model.parameters(), which the synthetic FakeModel in this test never stubbed, so every run dies with AttributeError before the function returns. Verified by running the test at 049a14dd in a detached worktree: it fails identically there, so this was never a regression from later commits.

It went unnoticed because CI never executes this test body: consolidated-tests-ci.yml only does pytest --collect-only for this file, and mlx-ci.yml runs just the shim smoke test on macOS.

Fix is test-only: give FakeModel the two methods returning empty trees, matching the fixture convention already used throughout test_mlx_save_lora_adapters_filter.py. With empty trees the summary computes 0 of 0 params (the existing total > 0 guard avoids division by zero) and the test reaches its num_layers assertions as intended.

No library code changes, so there is no impact on any runtime path (CUDA, ROCm, XPU, MLX) or on transformers, TRL or vLLM version compatibility.

Full suite on this branch: 1134 passed, 51 skipped, 0 failed.
