### PR TITLE
Harden UnslothVisionDataCollator audio extraction and add tests

### DIFF
--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -174,6 +174,14 @@ def test_inline_nested_list_mono_squeezed():
     assert len(out) == 1 and out[0].shape == (16,)
 
 
+def test_inline_list_of_strings_clip_raises():
+    # one content part is one clip; a list of paths inside it is user error
+    collator = make_collator()
+    with pytest.raises(ValueError, match="list of strings"):
+        collator._extract_audio_for_example(
+            {}, msgs({"type": "audio", "audio": ["/tmp/a.wav", "/tmp/b.wav"]}))
+
+
 def test_top_level_list_of_clips():
     collator = make_collator()
     out = collator._extract_audio_for_example(

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -165,10 +165,45 @@ def test_torch_tensor_converted_to_numpy():
     assert len(out) == 1 and isinstance(out[0], np.ndarray) and out[0].ndim == 1
 
 
+def test_mono_torchaudio_tensor_squeezed():
+    # torchaudio.load returns [channels, frames]; mono is (1, N)
+    collator = make_collator()
+    out = collator._extract_audio_for_example({"audio": torch.zeros(1, 16)}, [])
+    assert len(out) == 1 and isinstance(out[0], np.ndarray)
+    assert out[0].shape == (16,)
+
+
 def test_stereo_raises():
     collator = make_collator()
     with pytest.raises(ValueError, match="mono"):
         collator._extract_audio_for_example({"audio": np.zeros((2, 16))}, [])
+
+
+def test_top_level_dict_path_resolved():
+    # datasets.Audio(decode=False) style payload: {"bytes": None, "path": ...}
+    collator = make_collator()
+    out = collator._extract_audio_for_example(
+        {"audio": {"bytes": None, "path": "/tmp/a.wav"}}, [])
+    assert out == ["/tmp/a.wav"]
+
+
+def test_top_level_dict_no_payload_raises():
+    collator = make_collator()
+    with pytest.raises(ValueError, match="cannot be loaded"):
+        collator._extract_audio_for_example({"audio": {"sampling_rate": 16000}}, [])
+
+
+def test_top_level_list_dict_path_resolved():
+    collator = make_collator()
+    out = collator._extract_audio_for_example(
+        {"audio": [{"path": "/tmp/a.wav"}, {"array": CLIP, "sampling_rate": 16000}]}, [])
+    assert out[0] == "/tmp/a.wav" and out[1] is CLIP
+
+
+def test_inline_audio_decode_false_dict_resolved():
+    part = {"type": "audio", "audio": {"bytes": None, "path": "/tmp/a.wav"}}
+    out = extract_audio_info(msgs(part), sampling_rate=16000)
+    assert out == ["/tmp/a.wav"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -1,0 +1,230 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Audio support in UnslothVisionDataCollator (PRs #723 and follow-ups).
+
+Hermetic CPU tests with stub processors, no model or network needed:
+
+1. ``extract_audio_info``: inline arrays, HF Audio dicts, url/path content
+   parts, payload-less parts raising instead of silently training text-only,
+   and sampling-rate validation.
+2. ``_extract_audio_for_example``: top-level dict / ndarray / flat list /
+   list-of-clips columns, None fallback to inline audio, torch tensor
+   conversion, and the mono-only guard.
+3. ``_truncate_sequence_tensors``: per-token-key allowlist (audio feature
+   tensors must never be sliced even on dimension collisions), left-padding
+   aware slicing, and the audio-span truncation guard.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from unsloth_zoo.vision_utils import (
+    UnslothVisionDataCollator,
+    extract_audio_info,
+)
+
+AUDIO_ID = 9
+PAD_ID = 0
+
+
+class _FakeTokenizer:
+    pad_token_id = PAD_ID
+    audio_token = "<|audio|>"
+
+    def __init__(self, padding_side="left"):
+        self.padding_side = padding_side
+
+    def convert_tokens_to_ids(self, tokens):
+        table = {"<|audio|>": AUDIO_ID}
+        if isinstance(tokens, str):
+            return table.get(tokens, -1)
+        return [table.get(t, -1) for t in tokens]
+
+
+class _FakeFeatureExtractor:
+    sampling_rate = 16000
+
+
+class _FakeProcessor:
+    def __init__(self, padding_side="left"):
+        self.tokenizer = _FakeTokenizer(padding_side)
+        self.feature_extractor = _FakeFeatureExtractor()
+
+
+def make_collator(max_seq_length=4, padding_side="left"):
+    collator = UnslothVisionDataCollator.__new__(UnslothVisionDataCollator)
+    collator.processor = _FakeProcessor(padding_side)
+    collator.max_seq_length = max_seq_length
+    collator.truncation = True
+    return collator
+
+
+def msgs(part):
+    return [{"role": "user", "content": [part, {"type": "text", "text": "hi"}]}]
+
+
+CLIP = np.zeros(16, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# extract_audio_info
+# ---------------------------------------------------------------------------
+
+def test_inline_array():
+    out = extract_audio_info(msgs({"type": "audio", "audio": CLIP}))
+    assert len(out) == 1 and out[0] is CLIP
+
+
+def test_inline_hf_dict_unwrapped():
+    part = {"type": "audio", "audio": {"array": CLIP, "sampling_rate": 16000}}
+    out = extract_audio_info(msgs(part), sampling_rate=16000)
+    assert len(out) == 1 and out[0] is CLIP
+
+
+def test_inline_url_and_path_resolved():
+    for key in ("url", "path"):
+        out = extract_audio_info(msgs({"type": "audio", key: "/tmp/a.wav"}))
+        assert out == ["/tmp/a.wav"]
+
+
+def test_inline_no_payload_raises():
+    with pytest.raises(ValueError, match="cannot be loaded"):
+        extract_audio_info(msgs({"type": "audio"}))
+
+
+def test_inline_sampling_rate_mismatch_raises():
+    part = {"type": "audio", "audio": {"array": CLIP, "sampling_rate": 44100}}
+    with pytest.raises(ValueError, match="sampling_rate"):
+        extract_audio_info(msgs(part), sampling_rate=16000)
+
+
+def test_non_audio_parts_ignored():
+    out = extract_audio_info(msgs({"type": "image", "image": "x.png"}))
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# _extract_audio_for_example
+# ---------------------------------------------------------------------------
+
+def test_top_level_dict_unwrapped():
+    collator = make_collator()
+    out = collator._extract_audio_for_example(
+        {"audio": {"array": CLIP, "sampling_rate": 16000}}, [])
+    assert len(out) == 1 and out[0] is CLIP
+
+
+def test_top_level_dict_rate_mismatch_raises():
+    collator = make_collator()
+    with pytest.raises(ValueError, match="sampling_rate"):
+        collator._extract_audio_for_example(
+            {"audio": {"array": CLIP, "sampling_rate": 44100}}, [])
+
+
+def test_top_level_flat_list_is_one_clip():
+    collator = make_collator()
+    flat = [0.0] * 16
+    out = collator._extract_audio_for_example({"audio": flat}, [])
+    assert len(out) == 1 and out[0] is flat
+
+
+def test_top_level_list_of_clips():
+    collator = make_collator()
+    out = collator._extract_audio_for_example(
+        {"audio": [CLIP, {"array": CLIP, "sampling_rate": 16000}]}, [])
+    assert len(out) == 2 and out[0] is CLIP and out[1] is CLIP
+
+
+def test_top_level_none_falls_back_to_inline():
+    collator = make_collator()
+    out = collator._extract_audio_for_example(
+        {"audio": None}, msgs({"type": "audio", "audio": CLIP}))
+    assert len(out) == 1 and out[0] is CLIP
+
+
+def test_torch_tensor_converted_to_numpy():
+    collator = make_collator()
+    out = collator._extract_audio_for_example({"audio": torch.zeros(16)}, [])
+    assert len(out) == 1 and isinstance(out[0], np.ndarray) and out[0].ndim == 1
+
+
+def test_stereo_raises():
+    collator = make_collator()
+    with pytest.raises(ValueError, match="mono"):
+        collator._extract_audio_for_example({"audio": np.zeros((2, 16))}, [])
+
+
+# ---------------------------------------------------------------------------
+# _truncate_sequence_tensors
+# ---------------------------------------------------------------------------
+
+def _batch_left_padded():
+    # seq_len 6, max_seq_length 4. Row 0 is short (2 left pads + 2 audio + 2
+    # text tokens), row 1 is full length. input_features last dim deliberately
+    # equals seq_len to prove the old shape-collision bug stays fixed.
+    return {
+        "input_ids": torch.tensor([[PAD_ID, PAD_ID, AUDIO_ID, AUDIO_ID, 5, 6],
+                                   [1, 2, 3, 4, 5, 6]]),
+        "attention_mask": torch.tensor([[0, 0, 1, 1, 1, 1],
+                                        [1, 1, 1, 1, 1, 1]]),
+        "mm_token_type_ids": torch.tensor([[0, 0, 3, 3, 0, 0],
+                                           [0, 0, 0, 0, 0, 0]]),
+        "input_features": torch.zeros(2, 3, 6),
+        "input_features_mask": torch.ones(2, 6),
+    }
+
+
+def test_truncation_left_padding_keeps_short_row_content():
+    collator = make_collator(max_seq_length=4, padding_side="left")
+    batch = collator._truncate_sequence_tensors(_batch_left_padded(), seq_len=6)
+    # Short row keeps its content (audio span intact), not its padding
+    assert batch["input_ids"][0].tolist() == [AUDIO_ID, AUDIO_ID, 5, 6]
+    assert batch["attention_mask"][0].tolist() == [1, 1, 1, 1]
+    # Long row truncates its tail
+    assert batch["input_ids"][1].tolist() == [1, 2, 3, 4]
+    assert batch["attention_mask"].shape == (2, 4)
+    assert batch["mm_token_type_ids"].shape == (2, 4)
+
+
+def test_truncation_never_slices_audio_features():
+    collator = make_collator(max_seq_length=4, padding_side="left")
+    batch = collator._truncate_sequence_tensors(_batch_left_padded(), seq_len=6)
+    assert batch["input_features"].shape == (2, 3, 6)
+    assert batch["input_features_mask"].shape == (2, 6)
+
+
+def test_truncation_right_padding_slices_head():
+    collator = make_collator(max_seq_length=4, padding_side="right")
+    batch = {
+        "input_ids": torch.tensor([[AUDIO_ID, AUDIO_ID, 5, 6, PAD_ID, PAD_ID]]),
+        "attention_mask": torch.tensor([[1, 1, 1, 1, 0, 0]]),
+    }
+    batch = collator._truncate_sequence_tensors(batch, seq_len=6)
+    assert batch["input_ids"][0].tolist() == [AUDIO_ID, AUDIO_ID, 5, 6]
+
+
+def test_truncation_cutting_audio_span_raises():
+    collator = make_collator(max_seq_length=3, padding_side="right")
+    batch = {
+        "input_ids": torch.tensor([[1, 2, AUDIO_ID, AUDIO_ID, AUDIO_ID, 6]]),
+        "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 1]]),
+    }
+    with pytest.raises(ValueError, match="audio tokens"):
+        collator._truncate_sequence_tensors(batch, seq_len=6)

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -140,9 +140,38 @@ def test_top_level_dict_rate_mismatch_raises():
 
 def test_top_level_flat_list_is_one_clip():
     collator = make_collator()
-    flat = [0.0] * 16
-    out = collator._extract_audio_for_example({"audio": flat}, [])
-    assert len(out) == 1 and out[0] is flat
+    out = collator._extract_audio_for_example({"audio": [0.0] * 16}, [])
+    assert len(out) == 1 and isinstance(out[0], np.ndarray)
+    assert out[0].shape == (16,)
+
+
+def test_top_level_list_of_path_strings_are_clips():
+    collator = make_collator()
+    out = collator._extract_audio_for_example({"audio": ["/tmp/a.wav", "/tmp/b.wav"]}, [])
+    assert out == ["/tmp/a.wav", "/tmp/b.wav"]
+
+
+def test_top_level_list_of_flat_list_clips():
+    collator = make_collator()
+    out = collator._extract_audio_for_example({"audio": [[0.0] * 16, [1.0] * 8]}, [])
+    assert len(out) == 2
+    assert out[0].shape == (16,) and out[1].shape == (8,)
+
+
+def test_inline_nested_list_stereo_raises():
+    # stereo serialized as nested Python lists must hit the mono guard too
+    collator = make_collator()
+    stereo = [[0.0] * 16, [1.0] * 16]
+    with pytest.raises(ValueError, match="mono"):
+        collator._extract_audio_for_example(
+            {}, msgs({"type": "audio", "audio": stereo}))
+
+
+def test_inline_nested_list_mono_squeezed():
+    collator = make_collator()
+    out = collator._extract_audio_for_example(
+        {}, msgs({"type": "audio", "audio": [[0.0] * 16]}))
+    assert len(out) == 1 and out[0].shape == (16,)
 
 
 def test_top_level_list_of_clips():

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1011,6 +1011,11 @@ class UnslothVisionDataCollator:
             if torch.is_tensor(clip):
                 clip = clip.detach().cpu().numpy()
             elif isinstance(clip, (list, tuple)):
+                if len(clip) > 0 and isinstance(clip[0], str):
+                    raise ValueError(
+                        "Unsloth: an audio clip cannot be a list of strings. Pass each "
+                        "path or url as its own clip or content part."
+                    )
                 # Catches stereo-as-nested-lists in the mono guard below
                 try:
                     clip = np.asarray(clip)

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -58,6 +58,7 @@ AUDIO_TOKENS = [
 ]
 
 import torch
+import numpy as np
 from PIL import Image
 import base64
 from io import BytesIO
@@ -984,7 +985,8 @@ class UnslothVisionDataCollator:
             if len(audio_val) == 0:
                 clips = []
             # A flat list of samples is one clip, not a list of clips
-            elif not isinstance(audio_val[0], (dict, list, tuple)) and getattr(audio_val[0], "ndim", 0) == 0:
+            # (strings are path/url clips, so they stay in the list-of-clips branch)
+            elif not isinstance(audio_val[0], (dict, list, tuple, str)) and getattr(audio_val[0], "ndim", 0) == 0:
                 clips = [audio_val]
             else:
                 clips = []
@@ -1008,6 +1010,14 @@ class UnslothVisionDataCollator:
         for clip in clips:
             if torch.is_tensor(clip):
                 clip = clip.detach().cpu().numpy()
+            elif isinstance(clip, (list, tuple)):
+                # Catches stereo-as-nested-lists in the mono guard below
+                try:
+                    clip = np.asarray(clip)
+                except Exception as e:
+                    raise ValueError(
+                        f"Unsloth: could not interpret an audio clip list as a waveform: {e}"
+                    ) from e
             if getattr(clip, "ndim", 1) > 1:
                 # torchaudio.load returns [channels, frames]; accept mono (1, N)
                 if clip.shape[0] == 1:

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -527,7 +527,23 @@ def extract_vision_info(conversations: Union[List[Dict], List[List[Dict]]]) -> L
     return vision_infos
 
 
-def extract_audio_info(conversations: Union[List[Dict], List[List[Dict]]]) -> List:
+def _check_audio_sampling_rate(sampling_rate, target_sampling_rate):
+    if (
+        sampling_rate is not None
+        and target_sampling_rate is not None
+        and sampling_rate != target_sampling_rate
+    ):
+        raise ValueError(
+            f"Unsloth: audio sampling_rate = {sampling_rate} does not match the feature "
+            f"extractor's {target_sampling_rate}, so the clip would be processed at the wrong speed. "
+            f'Resample first, e.g. dataset = dataset.cast_column("audio", Audio(sampling_rate={target_sampling_rate})).'
+        )
+
+
+def extract_audio_info(
+    conversations: Union[List[Dict], List[List[Dict]]],
+    sampling_rate: int = None,
+) -> List:
     audio_inputs = []
     if len(conversations) == 0:
         return audio_inputs
@@ -538,13 +554,22 @@ def extract_audio_info(conversations: Union[List[Dict], List[List[Dict]]]) -> Li
             content = message.get("content")
             if isinstance(content, list):
                 for ele in content:
-                    if isinstance(ele, dict) and ele.get("type") == "audio" and "audio" in ele:
-                        audio = ele["audio"]
-                        # HuggingFace Audio feature dict -> raw waveform
-                        if isinstance(audio, dict):
-                            audio = audio.get("array")
-                        if audio is not None:
-                            audio_inputs.append(audio)
+                    if not (isinstance(ele, dict) and ele.get("type") == "audio"):
+                        continue
+                    audio = ele.get("audio")
+                    # Feature extractors also accept local paths and URLs as strings
+                    if audio is None:
+                        audio = ele.get("url") or ele.get("path")
+                    # HuggingFace Audio feature dict -> raw waveform
+                    if isinstance(audio, dict):
+                        _check_audio_sampling_rate(audio.get("sampling_rate"), sampling_rate)
+                        audio = audio.get("array")
+                    if audio is None:
+                        raise ValueError(
+                            "Unsloth: an audio content part has no `audio`, `url` or `path` data, "
+                            "so the clip cannot be loaded and the example would train as text only."
+                        )
+                    audio_inputs.append(audio)
     return audio_inputs
 
 
@@ -932,28 +957,47 @@ class UnslothVisionDataCollator:
         return image, video, video_kwarg
 
     def _extract_audio_for_example(self, example, messages):
+        feature_extractor = getattr(self.processor, "feature_extractor", None)
+        target_sr = getattr(feature_extractor, "sampling_rate", None)
         audio_val = example.get("audio")
         if audio_val is None:
             # No usable top-level audio -> fall back to inline message content
-            return extract_audio_info(messages)
+            clips = extract_audio_info(messages, sampling_rate=target_sr)
         # HuggingFace Audio feature: {"array": np.ndarray, "sampling_rate": int, ...}
-        if isinstance(audio_val, dict):
-            return [audio_val["array"]] if "array" in audio_val else []
-        if isinstance(audio_val, (list, tuple)):
+        elif isinstance(audio_val, dict):
+            _check_audio_sampling_rate(audio_val.get("sampling_rate"), target_sr)
+            clips = [audio_val["array"]] if "array" in audio_val else []
+        elif isinstance(audio_val, (list, tuple)):
             if len(audio_val) == 0:
-                return []
+                clips = []
             # A flat list of samples is one clip, not a list of clips
-            if not isinstance(audio_val[0], (dict, list, tuple)) and getattr(audio_val[0], "ndim", 0) == 0:
-                return [audio_val]
-            clips = []
-            for clip in audio_val:
-                if isinstance(clip, dict):
-                    clip = clip.get("array")
-                if clip is not None:
-                    clips.append(clip)
-            return clips
-        # Raw ndarray or other single-clip value
-        return [audio_val]
+            elif not isinstance(audio_val[0], (dict, list, tuple)) and getattr(audio_val[0], "ndim", 0) == 0:
+                clips = [audio_val]
+            else:
+                clips = []
+                for clip in audio_val:
+                    if isinstance(clip, dict):
+                        _check_audio_sampling_rate(clip.get("sampling_rate"), target_sr)
+                        clip = clip.get("array")
+                    if clip is not None:
+                        clips.append(clip)
+        else:
+            # Raw ndarray or other single-clip value
+            clips = [audio_val]
+        return self._normalize_audio_clips(clips)
+
+    def _normalize_audio_clips(self, clips):
+        normalized = []
+        for clip in clips:
+            if torch.is_tensor(clip):
+                clip = clip.detach().cpu().numpy()
+            if getattr(clip, "ndim", 1) > 1:
+                raise ValueError(
+                    f"Unsloth: audio clips must be mono 1D waveforms, got shape {tuple(clip.shape)}. "
+                    "Convert stereo to mono first, e.g. waveform.mean(axis=0)."
+                )
+            normalized.append(clip)
+        return normalized
 
     def _truncate_sequence_tensors(self, batch, seq_len):
         # Slice only per-token tensors. Matching on shape[-1] == seq_len can clip

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -540,6 +540,16 @@ def _check_audio_sampling_rate(sampling_rate, target_sampling_rate):
         )
 
 
+def _resolve_audio_dict(audio, sampling_rate=None):
+    # HuggingFace Audio feature dict -> waveform array, else a path / url string
+    # (covers Audio(decode=False) payloads like {"bytes": None, "path": ...})
+    _check_audio_sampling_rate(audio.get("sampling_rate"), sampling_rate)
+    value = audio.get("array")
+    if value is None:
+        value = audio.get("path") or audio.get("url")
+    return value
+
+
 def extract_audio_info(
     conversations: Union[List[Dict], List[List[Dict]]],
     sampling_rate: int = None,
@@ -560,10 +570,8 @@ def extract_audio_info(
                     # Feature extractors also accept local paths and URLs as strings
                     if audio is None:
                         audio = ele.get("url") or ele.get("path")
-                    # HuggingFace Audio feature dict -> raw waveform
                     if isinstance(audio, dict):
-                        _check_audio_sampling_rate(audio.get("sampling_rate"), sampling_rate)
-                        audio = audio.get("array")
+                        audio = _resolve_audio_dict(audio, sampling_rate)
                     if audio is None:
                         raise ValueError(
                             "Unsloth: an audio content part has no `audio`, `url` or `path` data, "
@@ -965,8 +973,13 @@ class UnslothVisionDataCollator:
             clips = extract_audio_info(messages, sampling_rate=target_sr)
         # HuggingFace Audio feature: {"array": np.ndarray, "sampling_rate": int, ...}
         elif isinstance(audio_val, dict):
-            _check_audio_sampling_rate(audio_val.get("sampling_rate"), target_sr)
-            clips = [audio_val["array"]] if "array" in audio_val else []
+            clip = _resolve_audio_dict(audio_val, target_sr)
+            if clip is None:
+                raise ValueError(
+                    "Unsloth: the `audio` column dict has no `array`, `path` or `url` data, "
+                    "so the clip cannot be loaded and the example would train as text only."
+                )
+            clips = [clip]
         elif isinstance(audio_val, (list, tuple)):
             if len(audio_val) == 0:
                 clips = []
@@ -977,8 +990,12 @@ class UnslothVisionDataCollator:
                 clips = []
                 for clip in audio_val:
                     if isinstance(clip, dict):
-                        _check_audio_sampling_rate(clip.get("sampling_rate"), target_sr)
-                        clip = clip.get("array")
+                        clip = _resolve_audio_dict(clip, target_sr)
+                        if clip is None:
+                            raise ValueError(
+                                "Unsloth: an `audio` column entry has no `array`, `path` or `url` data, "
+                                "so the clip cannot be loaded and the example would train as text only."
+                            )
                     if clip is not None:
                         clips.append(clip)
         else:
@@ -992,10 +1009,14 @@ class UnslothVisionDataCollator:
             if torch.is_tensor(clip):
                 clip = clip.detach().cpu().numpy()
             if getattr(clip, "ndim", 1) > 1:
-                raise ValueError(
-                    f"Unsloth: audio clips must be mono 1D waveforms, got shape {tuple(clip.shape)}. "
-                    "Convert stereo to mono first, e.g. waveform.mean(axis=0)."
-                )
+                # torchaudio.load returns [channels, frames]; accept mono (1, N)
+                if clip.shape[0] == 1:
+                    clip = clip.reshape(-1)
+                else:
+                    raise ValueError(
+                        f"Unsloth: audio clips must be mono 1D waveforms, got shape {tuple(clip.shape)}. "
+                        "Convert stereo to mono first, e.g. waveform.mean(axis=0)."
+                    )
             normalized.append(clip)
         return normalized
 


### PR DESCRIPTION
Follow-ups to #723 covering the remaining audio input forms that either failed silently or crashed with confusing errors. All are small additions to the extraction path in `vision_utils.py`, plus a hermetic CPU test suite for the audio collator which previously had no coverage.

**Fixes**

1. `{"type": "audio", "url": ...}` and `{"type": "audio", "path": ...}` content parts were silently dropped: the chat template still emitted the `<|audio|>` placeholder but no clip reached the processor, so the example trained as text only (same failure class as unslothai/unsloth#6004). The feature extractor already accepts path and URL strings, so these keys are now resolved. An audio part with no usable payload now raises instead of silently training text only.
2. HF Audio dicts with a `sampling_rate` different from the feature extractor's were processed at the wrong speed with no warning (a 1s clip at 44.1kHz became 2.75s of 16kHz audio). This now raises with a pointer to `dataset.cast_column("audio", Audio(sampling_rate=16000))`. Resampling in the collator was deliberately avoided to keep dependencies unchanged.
3. `torch.Tensor` clips (what `torchaudio.load` returns) crashed inside the feature extractor with a cryptic broadcast error. They are now converted to numpy. Stereo 2-D arrays now raise a clear "convert to mono" error instead of the same cryptic failure.

**Tests**

`tests/test_vision_collator_audio.py`: 17 hermetic CPU tests with stub processors covering `extract_audio_info` (inline arrays, HF dicts, url/path, payload-less raise, rate validation), `_extract_audio_for_example` (top-level dict/ndarray/flat list/list-of-clips columns, None fallback, tensor conversion, mono guard) and `_truncate_sequence_tensors` (per-token-key allowlist so audio feature tensors are never sliced on dimension collisions, left-padding aware slicing, audio-span truncation guard).

**Verification**

- All 17 new tests pass.
- Verified against the real Gemma 4 processor on transformers 5.10.2: url/path parts produce correct `input_features`, the three new errors fire with clear messages, torch tensors work, and the plain ndarray happy path is unchanged (25 placeholder tokens, 99 frames for a 1s clip).
- Re-ran the full collator comparison harness against main: text only, image only, image truncation and prompt-completion batches remain bit identical, and the truncation collision cases stay fixed.

Decisions worth noting from the review of #723: audio boundary tokens (`<|audio>`, `<audio|>`) intentionally stay trainable in labels, matching the image policy where `<|image>` and `<image|>` are trainable while soft tokens are masked. The stale prompt-length `mm_token_type_ids` in the prompt-completion path is pre-existing, only consumed by the larger Gemma 4 variants with bidirectional vision attention, and is left for a separate fix.
