### PR TITLE
fix: lazily re-import openai_harmony so install-after-import works

### DIFF
--- a/tests/test_encode_conversations_with_harmony.py
+++ b/tests/test_encode_conversations_with_harmony.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import importlib
 import importlib.machinery
 import importlib.util
@@ -215,16 +216,6 @@ def test_encode_conversations_with_harmony_loads_encoding_for_both_prompt_branch
     assert encoding.calls[0][0] == expected_call
 
 
-def test_encode_conversations_with_harmony_missing_import_keeps_install_hint(
-    monkeypatch,
-    gpt_oss_module,
-):
-    monkeypatch.delattr(gpt_oss_module, "SystemContent", raising = False)
-
-    with pytest.raises(ImportError, match = "pip install openai_harmony"):
-        gpt_oss_module.encode_conversations_with_harmony([])
-
-
 def test_encode_conversations_with_harmony_load_failure_is_named(
     monkeypatch,
     gpt_oss_module,
@@ -241,3 +232,218 @@ def test_encode_conversations_with_harmony_load_failure_is_named(
         gpt_oss_module.encode_conversations_with_harmony([])
 
     assert isinstance(error.value.__cause__, ValueError)
+
+
+_UNSET = object()
+
+
+@pytest.fixture()
+def harmony_state(gpt_oss_module):
+    # Snapshot and restore the harmony globals so lazy re-import (which rebinds them via
+    # globals().update) cannot leak fake symbols into other tests.
+    names = list(gpt_oss_module._HARMONY_SYMBOLS) + ["encoding"]
+    saved = {name: getattr(gpt_oss_module, name, _UNSET) for name in names}
+    try:
+        yield gpt_oss_module
+    finally:
+        for name, value in saved.items():
+            if value is _UNSET:
+                if hasattr(gpt_oss_module, name):
+                    delattr(gpt_oss_module, name)
+            else:
+                setattr(gpt_oss_module, name, value)
+
+
+def _fake_harmony_module(load_harmony_encoding, omit = ()):
+    module = types.ModuleType("openai_harmony")
+    members = {
+        "Author": _Author,
+        "Conversation": _Conversation,
+        "DeveloperContent": _ChainContent,
+        "HarmonyEncodingName": _HarmonyEncodingName,
+        "Message": _Message,
+        "Role": _Role,
+        "SystemContent": _ChainContent,
+        "ToolDescription": _ToolDescription,
+        "load_harmony_encoding": load_harmony_encoding,
+        "ReasoningEffort": _ReasoningEffort,
+    }
+    for name, value in members.items():
+        if name not in omit:
+            setattr(module, name, value)
+    return module
+
+
+def _simulate_absent_at_import(gpt_oss):
+    # Mimic openai_harmony not being importable when gpt_oss.py was first imported, so the
+    # module-level symbols were never bound (the Colab "install after import" scenario).
+    for name in gpt_oss._HARMONY_SYMBOLS:
+        if hasattr(gpt_oss, name):
+            delattr(gpt_oss, name)
+    gpt_oss.encoding = None
+
+
+def _block_harmony_import(monkeypatch, exc):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "openai_harmony":
+            raise exc
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_encode_conversations_with_harmony_install_after_import_succeeds(
+    monkeypatch,
+    harmony_state,
+):
+    # Regression for unsloth#3361: openai_harmony installed after `import unsloth`.
+    gpt_oss = harmony_state
+    _simulate_absent_at_import(gpt_oss)
+
+    encoding = _Encoding()
+    monkeypatch.setitem(
+        sys.modules, "openai_harmony", _fake_harmony_module(lambda name: encoding)
+    )
+
+    decoded_text, input_ids = gpt_oss.encode_conversations_with_harmony(
+        [{"role": "user", "content": "hello"}],
+    )
+
+    assert input_ids == [101]
+    assert decoded_text == "decoded:[101]"
+    assert encoding.calls[0][0] == "completion"
+
+
+def test_encode_conversations_with_harmony_missing_package_keeps_install_hint(
+    monkeypatch,
+    harmony_state,
+):
+    gpt_oss = harmony_state
+    _simulate_absent_at_import(gpt_oss)
+    _block_harmony_import(
+        monkeypatch,
+        ModuleNotFoundError("No module named 'openai_harmony'", name = "openai_harmony"),
+    )
+
+    with pytest.raises(ImportError, match = "pip install openai_harmony") as error:
+        gpt_oss.encode_conversations_with_harmony([])
+
+    assert isinstance(error.value.__cause__, ModuleNotFoundError)
+
+
+def test_encode_conversations_with_harmony_transitive_dependency_named(
+    monkeypatch,
+    harmony_state,
+):
+    gpt_oss = harmony_state
+    _simulate_absent_at_import(gpt_oss)
+    _block_harmony_import(
+        monkeypatch,
+        ModuleNotFoundError("No module named 'tiktoken'", name = "tiktoken"),
+    )
+
+    with pytest.raises(ImportError, match = "dependency `tiktoken`") as error:
+        gpt_oss.encode_conversations_with_harmony([])
+
+    assert "pip install openai_harmony`" not in str(error.value)
+    assert isinstance(error.value.__cause__, ModuleNotFoundError)
+
+
+def test_encode_conversations_with_harmony_broken_install_named(
+    monkeypatch,
+    harmony_state,
+):
+    gpt_oss = harmony_state
+    _simulate_absent_at_import(gpt_oss)
+    _block_harmony_import(monkeypatch, ImportError("partially initialized module"))
+
+    with pytest.raises(ImportError, match = "failed to import openai_harmony") as error:
+        gpt_oss.encode_conversations_with_harmony([])
+
+    assert isinstance(error.value.__cause__, ImportError)
+
+
+def test_encode_conversations_with_harmony_internal_submodule_missing_is_broken_install(
+    monkeypatch,
+    harmony_state,
+):
+    gpt_oss = harmony_state
+    _simulate_absent_at_import(gpt_oss)
+    _block_harmony_import(
+        monkeypatch,
+        ModuleNotFoundError(
+            "No module named 'openai_harmony._internal'",
+            name = "openai_harmony._internal",
+        ),
+    )
+
+    with pytest.raises(ImportError, match = "failed to import openai_harmony") as error:
+        gpt_oss.encode_conversations_with_harmony([])
+
+    assert "pip install openai_harmony" not in str(error.value)
+    assert isinstance(error.value.__cause__, ModuleNotFoundError)
+
+
+def test_encode_conversations_with_harmony_non_import_error_wrapped(
+    monkeypatch,
+    harmony_state,
+):
+    gpt_oss = harmony_state
+    _simulate_absent_at_import(gpt_oss)
+    _block_harmony_import(monkeypatch, RuntimeError("bad binary wheel"))
+
+    with pytest.raises(ImportError, match = "failed to import openai_harmony") as error:
+        gpt_oss.encode_conversations_with_harmony([])
+
+    assert isinstance(error.value.__cause__, RuntimeError)
+
+
+def test_encode_conversations_with_harmony_partial_build_lists_missing_symbol(
+    monkeypatch,
+    harmony_state,
+):
+    gpt_oss = harmony_state
+    _simulate_absent_at_import(gpt_oss)
+    monkeypatch.setitem(
+        sys.modules,
+        "openai_harmony",
+        _fake_harmony_module(lambda name: _Encoding(), omit = ("ReasoningEffort",)),
+    )
+
+    with pytest.raises(ImportError, match = "ReasoningEffort"):
+        gpt_oss.encode_conversations_with_harmony([])
+
+
+def test_encode_conversations_with_harmony_load_failure_retried_then_cached(
+    monkeypatch,
+    harmony_state,
+):
+    gpt_oss = harmony_state
+    _simulate_absent_at_import(gpt_oss)
+
+    calls = {"n": 0}
+    encoding = _Encoding()
+
+    def load_harmony_encoding(name):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise ValueError(f"transient failure {calls['n']}")
+        return encoding
+
+    monkeypatch.setitem(
+        sys.modules, "openai_harmony", _fake_harmony_module(load_harmony_encoding)
+    )
+
+    messages = [{"role": "user", "content": "hi"}]
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match = "failed to load the gpt-oss harmony encoding"):
+            gpt_oss.encode_conversations_with_harmony(messages)
+
+    decoded_text, input_ids = gpt_oss.encode_conversations_with_harmony(messages)
+    assert input_ids == [101]
+    assert calls["n"] == 3
+
+    gpt_oss.encode_conversations_with_harmony(messages)
+    assert calls["n"] == 3

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2487,6 +2487,22 @@ TEMPORARY_PATCHES.append(patch_GptOssModel)
 
 encoding = None
 
+_HARMONY_SYMBOLS = (
+    "Author",
+    "Conversation",
+    "DeveloperContent",
+    "HarmonyEncodingName",
+    "Message",
+    "Role",
+    "SystemContent",
+    "ToolDescription",
+    "load_harmony_encoding",
+    "ReasoningEffort",
+)
+
+# Best-effort eager import; when openai_harmony is installed after this module was
+# imported, _ensure_harmony rebinds the symbols lazily at call time.
+# See https://github.com/unslothai/unsloth/issues/3361
 try:
     from openai_harmony import (
         Author,
@@ -2500,17 +2516,39 @@ try:
         load_harmony_encoding,
         ReasoningEffort
     )
-except:
+except Exception:
     pass
+
+
+def _ensure_harmony():
+    g = globals()
+    if all(g.get(name) is not None for name in _HARMONY_SYMBOLS):
+        return
+    try:
+        import openai_harmony
+    except ModuleNotFoundError as e:
+        if not e.name or e.name == "openai_harmony":
+            raise ImportError("Please install openai_harmony via `pip install openai_harmony`") from e
+        if e.name.startswith("openai_harmony."):
+            raise ImportError(f"Unsloth: failed to import openai_harmony: {e}") from e
+        raise ImportError(f"Unsloth: failed to import openai_harmony; its dependency `{e.name}` is missing: {e}") from e
+    except Exception as e:
+        raise ImportError(f"Unsloth: failed to import openai_harmony: {e}") from e
+
+    missing = [name for name in _HARMONY_SYMBOLS if getattr(openai_harmony, name, None) is None]
+    if missing:
+        raise ImportError(
+            f"Unsloth: openai_harmony is installed but is missing required symbols ({', '.join(missing)}); "
+            f"please upgrade via `pip install --upgrade openai_harmony`"
+        )
+    for name in _HARMONY_SYMBOLS:
+        g[name] = getattr(openai_harmony, name)
+pass
 
 
 def _get_gpt_oss_harmony_encoding():
     global encoding
-    try:
-        HarmonyEncodingName
-        load_harmony_encoding
-    except:
-        raise ImportError("Please install openai_harmony via `pip install openai_harmony`")
+    _ensure_harmony()
 
     if encoding is None:
         try:
@@ -2529,11 +2567,6 @@ def encode_conversations_with_harmony(
     developer_instructions = None,
     model_identity = "You are ChatGPT, a large language model trained by OpenAI.",
 ):
-    try:
-        SystemContent
-    except:
-        raise ImportError("Please install openai_harmony via `pip install openai_harmony`")
-
     harmony_encoding = _get_gpt_oss_harmony_encoding()
 
     assert reasoning_effort in ("low", "medium", "high")


### PR DESCRIPTION
## Summary

`encode_conversations_with_harmony` only bound the `openai_harmony` symbols once at module import, inside a swallowed try/except. Users who install `openai_harmony` after `import unsloth` (common in Colab) were stuck with a misleading `ImportError: Please install openai_harmony ...` for the rest of the process even though the package was present at call time. Reported in unslothai/unsloth#3361.

This adds `_ensure_harmony()`, which rebinds the symbols lazily at call time when the eager import did not run, with a precise error for each failure mode:

- package not installed: the existing install hint, unchanged type and message
- missing transitive dependency: the error names the dependency, original exception chained
- broken install (import raises anything else, or an internal `openai_harmony.*` submodule is missing): the error says the import failed, original exception chained
- installed but missing required symbols: the error lists exactly which symbols

It also closes a partial-binding gap: `from openai_harmony import (...)` binds names sequentially, so a build missing one late symbol (for example `ReasoningEffort`) used to pass the old guards and then crash with `NameError` mid-function.

Follow-up to #718. The encoding-load semantics from that PR are preserved: lazy load, failed loads retried on the next call, success cached, named `RuntimeError` with chained cause. The bare `except:` guards are replaced with precise exception handling.

## Validation

- Install-after-import repro: on main the call raises the misleading install hint; with this change it succeeds and returns real tokens.
- Happy path is byte-identical: 9 conversation shapes (all reasoning efforts, generation prompt on and off, developer instructions, tools, assistant thinking, tool calls, tool results, multi-turn) produce identical input ids and decoded text with openai_harmony 0.0.8 before and after the change.
- `from .gpt_oss import *` export surface is unchanged; the new helpers are private.
- Tests extended from 4 to 11: install-after-import, missing package, missing transitive dependency, broken install, internal submodule missing, non-ImportError import failures wrapped as ImportError, partial build listing missing symbols, and load failure retried then cached. Mutation check: neutering the new helper makes the new tests fail.
- Full suite: 1144 passed, 51 skipped, 1 pre-existing failure (`test_mlx_finetune_last_n_layers`, fails identically on main, unrelated).

Note: in the exotic broken-install scenarios the error message is now more specific than the old generic install hint; the exception type stays `ImportError`, so existing `except ImportError` callers are unaffected.

Fixes unslothai/unsloth#3361