### PR TITLE
Classify import failures in patch_compiling_bitsandbytes

### DIFF
--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -49,13 +49,23 @@ def patch_compiling_bitsandbytes():
             try:
                 module = importlib.import_module(x)
             except ImportError as e:
+                # Genuinely absent package = the missing module is the target
+                # or one of its parents. Anything else (e.g. a broken
+                # transitive dependency inside an installed package) must
+                # surface its real error, not an install hint.
+                missing = getattr(e, "name", "") or ""
+                target_missing = isinstance(e, ModuleNotFoundError) and missing and (
+                    x == missing or x.startswith(missing + ".")
+                )
+                if not target_missing:
+                    raise
                 # peft is required for LoRA training
                 if x.startswith("peft"):
                     raise ImportError(
                         "Unsloth: Please install peft via `pip install peft`"
                     ) from e
                 if os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
-                    print(f"Unsloth: Skipping {x} - import failed: {e}")
+                    print(f"Unsloth: Skipping {x} - module not found: {e}")
                 continue
             for fx in dir(module):
                 try: layer = getattr(module, fx)


### PR DESCRIPTION
Follow-up to #710, addressing a review finding: `except ImportError` treated every import failure of `peft.tuners.lora.bnb` as "peft is not installed", so an installed but broken peft (a failing transitive dependency during its import) was mislabeled with the `pip install peft` hint. Similarly, a corrupted bitsandbytes install was silently skipped on the < 0.46.0 branch.

This classifies the failure using `ModuleNotFoundError.name`:

- Target module or one of its parents genuinely missing: keep current behavior, the actionable `pip install peft` message with the cause chained, or skipping the bitsandbytes leg with an optional log line.
- Anything else (broken transitive dependency, `cannot import name ...`): re-raise the original error unchanged so the real failure stays visible.

Verified with six subprocess scenarios on Python 3.13.12:

- Happy path wraps both target modules under bitsandbytes < 0.46.0.
- Genuinely missing peft raises the install hint with the original cause chained.
- A broken transitive peft import now surfaces its real error instead of "install peft".
- A genuinely missing bitsandbytes submodule is skipped and peft still gets patched.
- A corrupted bitsandbytes build now surfaces its real error instead of being silently skipped.
- bitsandbytes >= 0.46.0 stays a no-op.

The four regression tests from #742 also pass unchanged against this code.
