### PR TITLE
Fix GPU-less import of gpt_oss.py and tighten gpt-oss name detection

### DIFF
--- a/tests/test_moe_grouped_mm_format.py
+++ b/tests/test_moe_grouped_mm_format.py
@@ -213,3 +213,23 @@ def test_lazy_path_does_not_flag_qwen_layout_named_gpt_oss():
     assert _get_moe_lora_io_dims(_Wrapper("gate_up_proj", experts)) == (16, 24)
     assert _get_moe_lora_io_dims(_Wrapper("down_proj", experts)) == (12, 16)
     assert not hasattr(experts, "_unsloth_grouped_mm_format")
+
+
+def test_name_or_path_matches_only_final_path_component():
+    from unsloth_zoo.temporary_patches.moe_utils import _is_gpt_oss_model
+
+    class _NamedConfig:
+        def __init__(self, name):
+            self.model_type = "unknown"
+            self._name_or_path = name
+
+    class _NamedModel(nn.Module):
+        def __init__(self, name):
+            super().__init__()
+            self.config = _NamedConfig(name)
+
+    assert _is_gpt_oss_model(_NamedModel("unsloth/gpt-oss-20b-BF16"))
+    assert _is_gpt_oss_model(_NamedModel("/data/models/gpt-oss-20b/"))
+    assert _is_gpt_oss_model(_NamedModel("C:\\models\\gpt-oss-20b"))
+    assert not _is_gpt_oss_model(_NamedModel("/data/gpt-oss-tests/qwen3-7b"))
+    assert not _is_gpt_oss_model(_NamedModel("/home/u/my-gpt-oss-runs/Qwen3-30B-A3B"))

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -112,3 +112,26 @@ def test_temporary_patches_submodule_list_is_complete():
         "TEMPORARY_PATCHES_SUBMODULES references modules that don't "
         f"exist on disk: {sorted(extra)}. Remove them."
     )
+
+
+def test_gpt_oss_imports_without_visible_gpus():
+    """gpt_oss.py computes device_memory at import; with UNSLOTH_ALLOW_CPU=1
+    DEVICE_TYPE stays "cuda" on GPU-less hosts, so mem_get_info must be
+    guarded. Subprocess so conftest's mem_get_info stub cannot mask it."""
+    import os
+    import subprocess
+    import sys
+
+    env = {
+        **os.environ,
+        "UNSLOTH_ALLOW_CPU": "1",
+        "CUDA_VISIBLE_DEVICES": "",
+        "HIP_VISIBLE_DEVICES": "",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c",
+         "import unsloth_zoo.temporary_patches.gpt_oss; print('IMPORT_OK')"],
+        env=env, capture_output=True, text=True, timeout=600,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert "IMPORT_OK" in result.stdout

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1107,7 +1107,7 @@ from ..device_type import DEVICE_TYPE
 
 # UNSLOTH_ALLOW_CPU=1 keeps DEVICE_TYPE="cuda" on GPU-less hosts, so guard
 # with is_available() like device_synchronize() does.
-if DEVICE_TYPE == "xpu" and torch.xpu.is_available():
+if DEVICE_TYPE == "xpu" and hasattr(torch, "xpu") and torch.xpu.is_available():
     device_memory = torch.xpu.memory.mem_get_info(0)[-1]
 elif DEVICE_TYPE in ("cuda", "hip") and torch.cuda.is_available():
     device_memory = torch.cuda.memory.mem_get_info(0)[-1]

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1105,9 +1105,11 @@ TEMPORARY_PATCHES.append(patch_gpt_oss_bnb4bit_auto)
 # Combo kernels uses too much VRAM for low memory GPUs
 from ..device_type import DEVICE_TYPE
 
-if DEVICE_TYPE == "xpu":
+# UNSLOTH_ALLOW_CPU=1 keeps DEVICE_TYPE="cuda" on GPU-less hosts, so guard
+# with is_available() like device_synchronize() does.
+if DEVICE_TYPE == "xpu" and torch.xpu.is_available():
     device_memory = torch.xpu.memory.mem_get_info(0)[-1]
-elif DEVICE_TYPE in ("cuda", "hip"):
+elif DEVICE_TYPE in ("cuda", "hip") and torch.cuda.is_available():
     device_memory = torch.cuda.memory.mem_get_info(0)[-1]
 else:
     device_memory = 0

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -767,7 +767,13 @@ def _is_gpt_oss_model(model) -> bool:
             return True
 
         for attr in ("_name_or_path", "name_or_path"):
-            if "gpt_oss" in _normalize_model_type(getattr(config, attr, None)):
+            name = getattr(config, attr, None)
+            if name is None:
+                continue
+            # Match only the final path component so parent directories like
+            # /data/gpt-oss-tests/qwen3-7b do not count as gpt-oss.
+            base = str(name).replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+            if "gpt_oss" in _normalize_model_type(base):
                 return True
 
     return False

--- a/unsloth_zoo/temporary_patches/qwen3_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe.py
@@ -205,7 +205,11 @@ def patch_qwen3_moe():
     # Transformers >= 5       uses self.gate_up_proj = nn.Parameter(...)
     # whilst old transformers uses self.experts = nn.ModuleList(...)
 
-    # Patch ParamWrapper.forward for MoE separated LoRA
+    # Patch ParamWrapper.forward for MoE separated LoRA.
+    # Ordering is load-bearing: this unconditional call installs the
+    # peft.get_peft_model wrapper during the import-time patch pass, before
+    # unsloth.models.llama/vision capture their get_peft_model alias. Do not
+    # gate it by model name or move it below the qwen3 import check.
     patch_param_wrapper_for_moe()
 
     try:


### PR DESCRIPTION
Two small follow ups from the gpt-oss MoE LoRA work in #717.

**1. GPU-less import crash in gpt_oss.py**

gpt_oss.py computes device_memory at import time via mem_get_info gated only on DEVICE_TYPE. With UNSLOTH_ALLOW_CPU=1, get_device_type() intentionally returns cuda on GPU-less hosts, so importing unsloth_zoo crashed with RuntimeError: No CUDA GPUs are available. CPU CI never caught this because tests/conftest.py stubs torch.cuda.memory.mem_get_info before imports.

Fix: guard the two mem_get_info calls with is_available(), matching the convention device_synchronize() already uses. GPU-less hosts get device_memory 0 and use_combo_kernels False, which is the conservative setting. GPU hosts are byte-for-byte unchanged (verified use_combo_kernels still True on a B200). The new regression test imports the module in a subprocess so the conftest stub cannot mask it, and works on both CUDA builds with hidden devices and CPU-only torch.

**2. gpt-oss name detection false positive**

_is_gpt_oss_model matched gpt_oss anywhere in config._name_or_path, so any local checkpoint under a parent directory containing gpt-oss (for example /data/gpt-oss-tests/qwen3-7b) was treated as gpt-oss. Now only the final path component is matched, with Windows backslash and trailing slash handling. Hub ids like unsloth/gpt-oss-20b-BF16 and local dirs like /data/models/gpt-oss-20b still match. Low practical risk either way since the flag setter is shape-gated after #717, but the detector should not lie.

Also documents that the patch_param_wrapper_for_moe call at the top of patch_qwen3_moe is load-bearing for import ordering: it installs the peft.get_peft_model wrapper during the import-time patch pass, before unsloth.models.llama and vision capture their get_peft_model alias. Comment only, no behavior change.

Tested: 67 tests pass across the MoE format, imports, native loop and qwen extractor suites including the two new regression tests; the previously crashing GPU-less import now succeeds.
