### PR TITLE
Tests: gate the None use_cache contract on strict transformers v5 configs

### DIFF
--- a/tests/test_training_utils_use_cache.py
+++ b/tests/test_training_utils_use_cache.py
@@ -68,6 +68,24 @@ class _ConfigCarrier(nn.Module):
         self.linear = nn.Linear(4, 4)
 
 
+def _none_use_cache_supported() -> bool:
+    """transformers v5 configs are strict huggingface_hub dataclasses whose
+    use_cache field is typed bool, so None ("defer to the model default") is
+    unrepresentable there and the legacy preserve-None contract only applies
+    to stacks that accept it."""
+    try:
+        LlamaConfig(use_cache = None)
+    except Exception:
+        return False
+    return True
+
+
+requires_none_use_cache = pytest.mark.skipif(
+    not _none_use_cache_supported(),
+    reason = "strict transformers configs type use_cache as bool; None is unrepresentable",
+)
+
+
 @pytest.mark.parametrize("mode", [True, "unsloth"])
 def test_top_level_use_cache_disabled(mode):
     model = _tiny_llama(use_cache = True)
@@ -82,7 +100,10 @@ def test_no_gradient_checkpointing_leaves_use_cache():
     assert model.config.use_cache is True
 
 
-@pytest.mark.parametrize("initial", [None, False])
+@pytest.mark.parametrize(
+    "initial",
+    [pytest.param(None, marks = requires_none_use_cache), False],
+)
 def test_falsy_use_cache_preserved(initial):
     # None means "defer to the model default": it must NOT be coerced to False.
     model = _tiny_llama(use_cache = initial)
@@ -151,6 +172,7 @@ def test_restore_without_prepare_is_noop():
     assert model.config.use_cache is True
 
 
+@requires_none_use_cache
 def test_restore_preserves_falsy_values():
     # Configs whose use_cache was None/False are never recorded, so a
     # restore after prepare must not invent True values for them.


### PR DESCRIPTION
## Summary

The two None-based use_cache tests fail on the transformers v5 stack before they can assert anything: v5 configs are strict huggingface_hub dataclasses whose `use_cache` field is typed `bool`, so `LlamaConfig(use_cache = None)` raises `StrictDataclassFieldValidationError` at construction. Reproduced exactly on transformers 5.10.2 + huggingface_hub 1.18.0:

```
FAILED tests/test_training_utils_use_cache.py::test_falsy_use_cache_preserved[None]
FAILED tests/test_training_utils_use_cache.py::test_restore_preserves_falsy_values
```

This is what has been turning the unsloth repo's Core (HF=latest + TRL=latest) checks red on every PR today (for example unslothai/unsloth#6146 and unslothai/unsloth#6148, both of which touch unrelated code).

`disable_use_cache` / `restore_use_cache` themselves are already safe on v5: they only record truthy values and never assign None, so this is purely a test-contract issue. The "None means defer to the model default" contract is unrepresentable on strict configs by upstream design.

## Change

Gate the two None-based tests on a cheap construction probe (`LlamaConfig(use_cache = None)` in a try/except) via a `skipif` marker:

- legacy stacks: all 14 tests run and pass (contract still fully pinned)
- strict v5 stacks: 12 pass, 2 skip with an explanatory reason

## Testing

- transformers 5.10.2 + huggingface_hub 1.18.0 (the failing CI stack): `12 passed, 2 skipped`
- huggingface_hub 0.36.2 legacy stack: `14 passed`
