### PR TITLE
Keep audio feature extractors right padded in UnslothVisionDataCollator

### DIFF
--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -37,6 +37,7 @@ import torch
 
 from unsloth_zoo.vision_utils import (
     UnslothVisionDataCollator,
+    _fix_audio_feature_extractor_padding_side,
     extract_audio_info,
 )
 
@@ -241,6 +242,39 @@ def test_inline_audio_decode_false_dict_resolved():
     part = {"type": "audio", "audio": {"bytes": None, "path": "/tmp/a.wav"}}
     out = extract_audio_info(msgs(part), sampling_rate=16000)
     assert out == ["/tmp/a.wav"]
+
+
+# ---------------------------------------------------------------------------
+# _fix_audio_feature_extractor_padding_side
+# ---------------------------------------------------------------------------
+
+def test_left_padded_feature_extractor_reset_to_right():
+    # The model loader leaks padding_side="left" into the audio feature
+    # extractor; left-padded waveforms desync mel frame masks from audio
+    # placeholder counts (crashes Gemma 4 on transformers < 5.10).
+    proc = _FakeProcessor()
+    proc.feature_extractor.padding_side = "left"
+    _fix_audio_feature_extractor_padding_side(proc)
+    assert proc.feature_extractor.padding_side == "right"
+
+
+def test_right_padded_feature_extractor_untouched():
+    proc = _FakeProcessor()
+    proc.feature_extractor.padding_side = "right"
+    _fix_audio_feature_extractor_padding_side(proc)
+    assert proc.feature_extractor.padding_side == "right"
+
+
+def test_processor_without_feature_extractor_noop():
+    class _TextOnly:
+        pass
+    _fix_audio_feature_extractor_padding_side(_TextOnly())
+
+
+def test_feature_extractor_without_padding_side_noop():
+    proc = _FakeProcessor()
+    _fix_audio_feature_extractor_padding_side(proc)
+    assert not hasattr(proc.feature_extractor, "padding_side")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -249,9 +249,6 @@ def test_inline_audio_decode_false_dict_resolved():
 # ---------------------------------------------------------------------------
 
 def test_left_padded_feature_extractor_reset_to_right():
-    # The model loader leaks padding_side="left" into the audio feature
-    # extractor; left-padded waveforms desync mel frame masks from audio
-    # placeholder counts (crashes Gemma 4 on transformers < 5.10).
     proc = _FakeProcessor()
     proc.feature_extractor.padding_side = "left"
     _fix_audio_feature_extractor_padding_side(proc)

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -550,7 +550,7 @@ def _fix_audio_feature_extractor_padding_side(processor):
     # padding_side = "left" (a text setting) to AutoProcessor.from_pretrained,
     # which forwards it to every sub-component including the feature extractor.
     feature_extractor = getattr(processor, "feature_extractor", None)
-    if getattr(feature_extractor, "padding_side", None) == "left":
+    if feature_extractor is not None and getattr(feature_extractor, "padding_side", None) == "left":
         feature_extractor.padding_side = "right"
 
 

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -542,13 +542,9 @@ def _check_audio_sampling_rate(sampling_rate, target_sampling_rate):
 
 
 def _fix_audio_feature_extractor_padding_side(processor):
-    # Audio feature extractors must keep their stock right padding: their
-    # frame-validity masks assume trailing padding, so a left-padded waveform
-    # gains an extra valid mel frame on some clip lengths. On Gemma 4 with
-    # transformers < 5.10 that desyncs audio features from audio placeholder
-    # tokens and crashes the forward pass. The model loader passes
-    # padding_side = "left" (a text setting) to AutoProcessor.from_pretrained,
-    # which forwards it to every sub-component including the feature extractor.
+    # The loader's padding_side="left" (a text setting) leaks into the audio
+    # feature extractor via from_pretrained. Frame-validity masks assume right
+    # padding; left padding desyncs Gemma 4 audio token counts (crash on tf < 5.10).
     feature_extractor = getattr(processor, "feature_extractor", None)
     if feature_extractor is not None and getattr(feature_extractor, "padding_side", None) == "left":
         feature_extractor.padding_side = "right"

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -541,6 +541,19 @@ def _check_audio_sampling_rate(sampling_rate, target_sampling_rate):
         )
 
 
+def _fix_audio_feature_extractor_padding_side(processor):
+    # Audio feature extractors must keep their stock right padding: their
+    # frame-validity masks assume trailing padding, so a left-padded waveform
+    # gains an extra valid mel frame on some clip lengths. On Gemma 4 with
+    # transformers < 5.10 that desyncs audio features from audio placeholder
+    # tokens and crashes the forward pass. The model loader passes
+    # padding_side = "left" (a text setting) to AutoProcessor.from_pretrained,
+    # which forwards it to every sub-component including the feature extractor.
+    feature_extractor = getattr(processor, "feature_extractor", None)
+    if getattr(feature_extractor, "padding_side", None) == "left":
+        feature_extractor.padding_side = "right"
+
+
 def _resolve_audio_dict(audio, sampling_rate=None):
     # HuggingFace Audio feature dict -> waveform array, else a path / url string
     # (covers Audio(decode=False) payloads like {"bytes": None, "path": ...})
@@ -695,6 +708,7 @@ class UnslothVisionDataCollator:
         )
         self.ignore_index = ignore_index
         self.processor = processor
+        _fix_audio_feature_extractor_padding_side(processor)
         self.formatting_func = formatting_func
         self.completion_only_loss = completion_only_loss
         self.pad_to_multiple_of = pad_to_multiple_of


### PR DESCRIPTION
## Problem

Gemma 4 E2B/E4B audio SFT crashes on transformers 5.5.0 through 5.9.x with:

```
Audio features and audio tokens do not match, tokens: 99, features: 153600
```

The shipped Gemma 4 audio notebooks pin transformers==5.5.0, so this hits real users once the collator audio support from #723/#740 lands in a release.

## Root cause

FastModel passes `padding_side="left"` to `AutoProcessor.from_pretrained` (a text generation setting), and `ProcessorMixin` forwards the kwarg to every sub-component, including the audio feature extractor. Audio feature extractors are right padded in stock transformers: their frame-validity masks assume trailing padding. With left padding, clip lengths that do not land on a hop boundary gain one extra valid mel frame, so the audio tower emits more pooled features than the processor counted placeholder tokens.

Measured on `unsloth/gemma-4-E2B-it`, 3.97 s clip (63520 samples, 397 mel frames):

| Arm | mask valid frames | tower features | placeholder tokens | forward |
|---|---|---|---|---|
| stock processor (right padded) | 396 | 99 | 99 | OK |
| unsloth-loaded processor (left padded) | 397 | 100 | 99 | crash |

On transformers >= 5.10 the placeholder count is mask-derived so it follows the flip (100 == 100, no crash), but training silently uses one extra audio token per clip and boundary-shifted mel frames vs stock. The stock 5.5.0 processor itself is correct: a 9-combination clip-length probe passes 9/9 without unsloth in the picture.

## Fix

Restore the stock right padding on the processor's audio feature extractor when the collator is constructed (4 lines, `_fix_audio_feature_extractor_padding_side`). Text tokenization padding is untouched; `padding_side` is a TextKwargs-only key in 5.x so it never reaches per-call audio kwargs, making the instance attribute the single leak point.

## Validation

- transformers 5.5.0 + unsloth 2026.6.1: 9-combination clip-length forward probe went from 4 failures to 9/9 OK; mask/tower/token counts now match stock exactly
- transformers 5.5.0 SFT smoke (LibriSpeech dummy, LoRA, 20 steps): previously crashed on step 0, now trains end to end, loss 5.12 -> 0.97, audio tower active on every batch
- transformers 5.10.2: 9/9 OK and token counts now match stock (99 vs the previous off-stock 100 for the 3.97 s case)
- 4 new hermetic CPU tests in `tests/test_vision_collator_audio.py` (31 total pass); no model or network needed
- transformers 4.57.6: helper is inert (plain attribute check), covered by the CPU tests and existing CI matrix