### PR TITLE
fix(mlx): pass a flat image list to mlx-vlm processor in VLM collator

### DIFF
--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2332,7 +2332,11 @@ def _collate_vlm_prompt_completion_batch(items, processor, max_seq_length, image
 
         prompt_texts.append(prompt_text)
         combined_texts.append(combined_text)
-        all_images.append(images)
+        # mlx-vlm >= 0.6 expects a flat list of images across the whole batch;
+        # the text placeholders pair positionally with each image. Same fix
+        # as the message-collator path -- this path handles prompt+completion
+        # datasets where messages are split across two fields.
+        all_images.extend(images)
 
     combined_inputs = _processor_vlm_inputs(
         processor, combined_texts, all_images, max_seq_length
@@ -2419,7 +2423,11 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size, formatting_
             )
         images = _extract_vlm_images(item, messages, image_size)
         all_texts.append(text)
-        all_images.append(images)
+        # mlx-vlm >= 0.6 expects a flat list of images across the whole batch;
+        # the text placeholders pair positionally with each image. Using
+        # extend instead of append avoids the nested-list shape that crashes
+        # the per-image processor (image.shape unpacking).
+        all_images.extend(images)
         all_suffixes.append(item.get("suffix") if isinstance(item, dict) else None)
 
     inputs = _processor_vlm_inputs(


### PR DESCRIPTION
## Summary

Training any VLM (vision LoRA or vision-frozen) on `unslothai/unsloth-zoo:main` crashes before step 1 with:

```
ValueError: too many values to unpack (expected 3)
```

raised from `mlx_vlm/models/qwen3_vl/processing_qwen3_vl.py:193` (`C, H, W = image.shape`).

## Root cause

Two VLM batch collators in `unsloth_zoo/mlx/utils.py` build `all_images` as a **list of lists**, one inner list per sample:

- `_collate_vlm_batch` (line 2422, messages-based path)
- `_collate_vlm_prompt_completion_batch` (line 2335, prompt+completion path)

Both do:
```python
images = _extract_vlm_images(item, messages, image_size)  # returns [PIL_img, ...]
all_images.append(images)                                  # nested
```

But mlx-vlm 0.6.x's processor iterates the outer list and calls `_process_one` on each element, expecting each element to be a *single image* (3-D ndarray or PIL.Image):

```python
# mlx_vlm/models/qwen3_vl/processing_qwen3_vl.py
if not isinstance(images, list):
    images = [images]
imgs = [
    img if (isinstance(img, np.ndarray) and img.ndim == 3) else _to_numpy_image(img)
    for img in images
]
for v in imgs:
    patches, thw = self._process_one(v, **image_kwargs)
```

When the outer element is a list, `_to_numpy_image` produces a 4-D `(1, C, H, W)` ndarray and `_process_one` crashes unpacking it into 3 dims.

## Fix

Use `extend` instead of `append` per sample in both collators so `all_images` is a flat list across the batch.

Image order is preserved (texts and images are built sample-by-sample in lockstep), and the rendered text's `<image>` placeholders pair positionally with the flat image list as mlx-vlm expects.

## Batch-shape verification

| Batch | Images / sample | `all_images` after extend |
|---|---|---|
| bs=1 | 1 | `[img]` |
| bs=2 | 1 each | `[img, img]` |
| bs=1 | 2 (multi-image sample) | `[img, img]` |
| bs=2 | 1 and 2 | `[img, img, img]` |

All shapes feed `mlx-vlm` correctly: each top-level element is a single PIL image, `_to_numpy_image` returns 3-D, and `_process_one` succeeds.

## Verified

- **Repro** (before fix): `unsloth/Qwen3-VL-2B-Instruct` + `unsloth/LaTeX_OCR`, bs=1, seq_len=1024, mlx-vlm 0.6.2, MLX on M2 16GB → crashes at the collator before step 1
- **After fix**: collator no longer raises; training proceeds past the dataloader