### PR TITLE
fix(mlx): disable fused MRoPE for Qwen3-VL training to allow VJP

### DIFF
--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -691,6 +691,28 @@ def _fix_qwen35_attention_cache(model):
     print("Unsloth: Fixed Qwen3.5 attention for training (cache=None).")
 
 
+def _disable_fused_mrope(model):
+    """Route MRoPE through the differentiable cos/sin fallback for training.
+
+    mlx-vlm's MRoPERotaryEmbedding.apply_rotary uses a fused Metal kernel
+    whenever Metal is available, with no gradient support -- training dies
+    with [Primitive::vjp] Not implemented for CustomKernel. Flipping
+    fused_apply off makes apply_rotary take its pure-MLX fallback, which
+    differentiates fine.
+    """
+    count = 0
+    try:
+        modules = model.modules()
+    except Exception:
+        return
+    for module in modules:
+        if getattr(module, "fused_apply", False):
+            module.fused_apply = False
+            count += 1
+    if count:
+        print(f"Unsloth: Disabled fused MRoPE kernel on {count} modules for training (no VJP).")
+
+
 def _safe_getsource(obj) -> str:
     try:
         return inspect.getsource(obj)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -608,6 +608,14 @@ class MLXTrainer:
             _fix_qwen35_attention_cache(model)
             from ..gated_delta_vjp import patch_gated_delta
             patch_gated_delta()
+        # Qwen3-VL-specific fixes: the language tower's MRoPERotaryEmbedding
+        # uses the same non-differentiable fused Metal kernel that breaks
+        # training with [Primitive::vjp] Not implemented for CustomKernel.
+        # Flip fused_apply off so apply_rotary takes the differentiable
+        # fallback path.
+        if "qwen3_vl" in model_type:
+            from .loader import _disable_fused_mrope
+            _disable_fused_mrope(model)
 
         try:
             return self._train_inner()


### PR DESCRIPTION
## Summary

Training Qwen3-VL on MLX crashes in `value_and_grad` with:

```
ValueError: [Primitive::vjp] Not implemented for CustomKernel.
```

before step 1. The Qwen3-VL language tower's `MRoPERotaryEmbedding` routes through a fused Metal kernel when `fused_apply=True` (mlx-vlm 0.6.x default), and that kernel has no gradient implementation.

This is the same family of bug PR #738 fixes for `qwen3_5`. The function `_disable_fused_mrope` is generic — it walks the model and flips `fused_apply` off on any module that has it — but PR #738 only wires it into the `qwen3_5` trainer block. This PR adds the parallel wiring for Qwen3-VL.

## Relationship to #738

- **#738** introduces `_disable_fused_mrope` in `loader.py` and wires it for `qwen3_5`
- **This PR** also adds `_disable_fused_mrope` (so it can be tested standalone) and wires it for `qwen3_vl`

On rebase after #738 lands, the duplicate function definition resolves trivially (drop it from this PR, keep only the trainer-side wiring).

## Verification

```
$ grep -n 'fused_apply' .../mlx_vlm/models/qwen3_vl/language.py
224:            and not self.layers[0].self_attn.rotary_emb.fused_apply
```

Qwen3-VL's language tower gates `position_embeddings` precomputation on `fused_apply`, exactly mirroring qwen3_5. When `fused_apply=False`, `apply_rotary` takes the differentiable cos/sin fallback.

Tested on M2 16GB with `unsloth/Qwen3-VL-2B-Instruct` + `unsloth/LaTeX_OCR`, vision-frozen LoRA, 5 steps:

```
Unsloth: Disabled fused MRoPE kernel on 28 modules for training (no VJP).
...
Step 1/5 | Loss: 1.6067 | Grad: 4.3397
Step 2/5 | Loss: 1.9784 | Grad: 4.9310
Step 3/5 | Loss: 1.4756 | Grad: 3.6400
Step 4/5 | Loss: 2.0330 | Grad: 4.8749
Step 5/5 | Loss: 1.5666 | Grad: 3.4725
Unsloth: Training complete!
```

28 rotary modules had `fused_apply=True`; all flipped off, training proceeds with finite gradients throughout.

## Note on dependency

End-to-end Qwen3-VL training also requires PR #749 (mlx-vlm flat image list), which fixes an independent error in the dataloader. With #749 + this PR, training proceeds end-to-end on M2.