### PR TITLE
feat(mlx): implement resume_from_checkpoint for MLX training

### DIFF
--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -546,10 +546,10 @@ class MLXTrainer:
         self._prior_metal_limits = {}
 
     def train(self, resume_from_checkpoint: str | None = None):
-        # Stash for _train_inner. None = fresh start, a path = resume.
-        self._resume_from_checkpoint = resume_from_checkpoint
         """Run MLX-native training loop following mlx-lm's compiled-step pattern
         with gradient accumulation. Returns a dict of training metrics."""
+        # Stash for _train_inner. None = fresh start, a path = resume.
+        self._resume_from_checkpoint = resume_from_checkpoint
         args = self.args
         model = self.model
         args.patch_mode = normalize_mlx_patch_mode(getattr(args, "patch_mode", "patched"))
@@ -1081,7 +1081,7 @@ class MLXTrainer:
                         f"Unsloth: streaming dataset exhausted while "
                         f"fast-forwarding to resume step {_resume_step}. "
                         f"Dataset may be shorter than the killed run consumed."
-                    )
+                    ) from None
 
         for it in range(_resume_step * grad_accum + 1, total_steps * grad_accum + 1):
             if self.stop_requested:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -66,6 +66,10 @@ from .utils import (
     collect_mlx_texts,
     save_lora_adapters,
     save_trainable_adapters,
+    save_optimizer_state,
+    load_optimizer_state,
+    save_trainer_state,
+    load_trainer_state,
     collect_mlx_lora_adapter_tensors,
     iter_mlx_lora_modules,
     apply_gradient_checkpointing,
@@ -541,7 +545,9 @@ class MLXTrainer:
             pass
         self._prior_metal_limits = {}
 
-    def train(self):
+    def train(self, resume_from_checkpoint: str | None = None):
+        # Stash for _train_inner. None = fresh start, a path = resume.
+        self._resume_from_checkpoint = resume_from_checkpoint
         """Run MLX-native training loop following mlx-lm's compiled-step pattern
         with gradient accumulation. Returns a dict of training metrics."""
         args = self.args
@@ -675,6 +681,40 @@ class MLXTrainer:
 
         # Build optimizer with LR schedule
         optimizer = self._build_optimizer(total_steps)
+
+        # Resume from checkpoint: load adapter weights, optimizer state,
+        # and trainer state (step counter + loss history). Adapters were
+        # already loaded by the Studio worker into the model before train()
+        # was called, so we only handle optimizer and trainer state here.
+        # The step offset is applied below at loop start so the LR scheduler
+        # and dataloader fast-forward to the right position.
+        _resume_step = 0
+        _resume_from = getattr(self, "_resume_from_checkpoint", None)
+        if _resume_from:
+            try:
+                # 1. Load trained adapter weights into the model. The model
+                #    already has LoRA wrappers applied (Studio pipeline does
+                #    get_peft_model before training); strict=False ensures
+                #    only the LoRA params match and base weights are untouched.
+                model.load_weights(
+                    f"{_resume_from}/adapters.safetensors", strict=False,
+                )
+                # 2. Restore optimizer state (Adam moments m,v, step counter).
+                load_optimizer_state(optimizer, _resume_from)
+                # 3. Restore trainer scalars (step counter, loss history).
+                ts = load_trainer_state(_resume_from)
+                _resume_step = int(ts.get("global_step", 0))
+                self._train_loss_history = list(ts.get("train_loss_history", []))
+                print(
+                    f"Unsloth: Resuming from {_resume_from} "
+                    f"(step={_resume_step}, loss_history={len(self._train_loss_history)} entries)."
+                )
+            except FileNotFoundError as e:
+                raise RuntimeError(
+                    f"Unsloth: resume_from_checkpoint={_resume_from!r} but "
+                    f"resume state files are missing ({e}). Refusing to "
+                    f"silently restart from step 0."
+                ) from e
 
         # Build loss+grad function — returns ((loss, ntoks), grads)
         loss_and_grad_fn = nn.value_and_grad(model, loss_fn)
@@ -1023,9 +1063,27 @@ class MLXTrainer:
         trained_tokens = 0
         train_time = 0
         grad_accum_state = None
-        batch_idx = 0
+        # When resuming, start batch_idx at the resume position so
+        # batches[batch_idx % len(batches)] lands on the same batch the
+        # original run would have seen next.
+        batch_idx = _resume_step * grad_accum
 
-        for it in range(1, total_steps * grad_accum + 1):
+        # Streaming mode: fast-forward the iterator to the resume position.
+        # The seed is the same and create_batches/iterate_*_batches is
+        # deterministic, so consuming N batches gives us the same data
+        # ordering the killed run would have produced.
+        if _resume_step > 0 and batch_iter is not None:
+            for _ in range(_resume_step * grad_accum):
+                try:
+                    next(batch_iter)
+                except StopIteration:
+                    raise RuntimeError(
+                        f"Unsloth: streaming dataset exhausted while "
+                        f"fast-forwarding to resume step {_resume_step}. "
+                        f"Dataset may be shorter than the killed run consumed."
+                    )
+
+        for it in range(_resume_step * grad_accum + 1, total_steps * grad_accum + 1):
             if self.stop_requested:
                 print("Unsloth: Stop requested — ending training early.")
                 break
@@ -1200,6 +1258,21 @@ class MLXTrainer:
                 except ValueError as e:
                     print(f"  Unsloth: skipped checkpoint ({e})")
                 else:
+                    # Also write optimizer + trainer state so resume_from_checkpoint
+                    # can restore Adam moments, step counter, and loss history.
+                    # Adapter save was successful -- treat the extra writes as
+                    # best-effort: log on failure but don't undo the adapter save.
+                    try:
+                        save_optimizer_state(optimizer, ckpt_dir)
+                        save_trainer_state(
+                            {
+                                "global_step": current_step,
+                                "train_loss_history": list(self._train_loss_history),
+                            },
+                            ckpt_dir,
+                        )
+                    except Exception as e:
+                        print(f"  Unsloth: checkpoint saved without resume state ({e})")
                     print(f"  Saved checkpoint to {ckpt_dir}")
 
         total_time = time.perf_counter() - start_time

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2853,6 +2853,61 @@ def save_trainable_adapters(model, path, adapter_config=None):
     _save_adapter_artifacts(model, path, tensors, adapter_config=adapter_config)
 
 
+def save_optimizer_state(optimizer, path):
+    """Save MLX optimizer state (Adam/AdamW m,v moments, step, learning_rate)
+    to ``<path>/optimizer_state.safetensors`` so training can resume from a
+    checkpoint with identical optimizer dynamics.
+
+    The optimizer's ``.state`` is a nested dict whose leaves are ``mx.array``.
+    ``tree_flatten`` produces dotted-name string keys (e.g.
+    ``"layers.0.lora_a.weight.m"``), all values are arrays, so the whole tree
+    serializes cleanly with ``mx.save_safetensors``. Round-trip preserves
+    bytes exactly for the optimizer's ``.state`` dict.
+    """
+    import os
+    os.makedirs(path, exist_ok=True)
+    flat = dict(mlx.utils.tree_flatten(optimizer.state))
+    mx.save_safetensors(f"{path}/optimizer_state.safetensors", flat)
+
+
+def load_optimizer_state(optimizer, path):
+    """Inverse of save_optimizer_state. Loads
+    ``<path>/optimizer_state.safetensors`` and replaces ``optimizer.state``
+    with the unflattened tree.
+
+    Raises FileNotFoundError if the file is missing -- a resume request with
+    no optimizer state is a hard error, not silent fall-back, because resuming
+    with a fresh optimizer would silently restart Adam's moment estimates.
+    """
+    state_path = f"{path}/optimizer_state.safetensors"
+    flat = mx.load(state_path)
+    optimizer.state = mlx.utils.tree_unflatten(list(flat.items()))
+
+
+def save_trainer_state(trainer_state, path):
+    """Save trainer scalar state to ``<path>/trainer_state.json``.
+
+    ``trainer_state`` is a plain dict (JSON-serializable). Currently:
+      - ``global_step``: int, the step the checkpoint represents
+      - ``train_loss_history``: list[float], for UI continuity
+    Kept separate from the safetensors blob because these are scalars/lists,
+    not tensors, and JSON is easier to inspect.
+    """
+    import json
+    import os
+    os.makedirs(path, exist_ok=True)
+    with open(f"{path}/trainer_state.json", "w") as f:
+        json.dump(trainer_state, f, indent=2)
+
+
+def load_trainer_state(path):
+    """Inverse of save_trainer_state. Returns the dict, or raises
+    FileNotFoundError if not present (resume requires it)."""
+    import json
+    with open(f"{path}/trainer_state.json", "r") as f:
+        return json.load(f)
+
+
 def save_lora_adapters(model, path, adapter_config=None):
     """Save LoRA adapter weights (lora_a / lora_b only) to disk.
 


### PR DESCRIPTION
## Summary

Studio's Resume button silently restarted MLX runs from step 0. The MLX worker called `trainer.train()` with no args, and the MLX trainer didn't accept `resume_from_checkpoint`. The frontend already exposes a Resume action (and `can_resume_run` doesn't gate by hardware), so this was a real user-facing bug.

This PR adds the trainer-side support. The Studio worker change (passing the kwarg through) is a [companion PR in `unslothai/unsloth`](https://github.com/unslothai/unsloth/pulls?q=is%3Apr+author%3ABardiaKoopah+mlx-studio-resume-wiring).

## What gets saved

The checkpoint loop already wrote `adapters.safetensors` + `adapter_config.json` via `save_trainable_adapters`. After a successful adapter save we now also write, best-effort:

- **`optimizer_state.safetensors`** — `mx.save_safetensors(tree_flatten(optimizer.state))`. For Adam/AdamW this is per-parameter `m,v` + scalar `step` and `learning_rate`. Round-trip is byte-equal in mlx 0.31.2.
- **`trainer_state.json`** — `{global_step, train_loss_history}`. JSON rather than safetensors because these are scalars/lists, not tensors.

If the new writes fail, we print a warning and keep going. The adapter save was already successful at that point; only resume is unavailable.

This matches the contract Studio's backend already expects: `studio/backend/core/training/resume.py:has_resume_state()` looks for `trainer_state.json` in either `output_dir/` or `output_dir/checkpoint-N/`.

## What gets restored

`train()` now accepts `resume_from_checkpoint`. `_train_inner` does three things, in order, after building the optimizer:

1. **`model.load_weights(adapters.safetensors, strict=False)`** — the model already has LoRA wrappers (Studio's pipeline does `get_peft_model` before training), so we only need to load the trained adapter tensors back into them.

2. **`load_optimizer_state`** — restores Adam moments and the optimizer step. Without this, Adam would silently restart its moment estimates and the first post-resume step would be effectively a learning-rate-scaled gradient with zero momentum.

3. **`load_trainer_state`** — restores `global_step` and `train_loss_history`. `global_step` is used to fast-forward the loop counter and `batch_idx`; `train_loss_history` is restored so the UI's loss curve stays continuous across the resume boundary.

If `trainer_state.json` or `optimizer_state.safetensors` is missing on resume, we raise rather than silently restart from step 0 with a fresh optimizer. Silent restart is the worse outcome — it gives the user false confidence.

## Loop fast-forward

On resume we change the loop start to begin at `_resume_step * grad_accum + 1`, set `batch_idx = _resume_step * grad_accum`, and (for streaming mode where there is no random-access batch list) consume `_resume_step * grad_accum` items from the generator before entering the loop. All four data paths (`create_batches` / `iterate_training_batches` / `create_vlm_batches` / `iterate_vlm_training_batches`) take `seed=args.seed` and produce deterministic ordering, so fast-forward is sufficient — we don't need to save iterator position to disk.

The LR scheduler is a pure function of step, so once it starts at the right value the schedule is automatically correct.

## Verification

Stop-resume harness on M2 16GB, Qwen3-0.6B + unsloth/LaTeX_OCR, max_steps=10, save_steps=5, grad_accum=4:

| Step | Fresh loss | Resumed loss |
|------|-----------|--------------|
| 6    | 2.1686279773712158 | 2.168627977371216 |
| 7    | 1.6476788520812988 | 1.6476788520812988 |
| 8    | 1.4659109115600586 | 1.4659109115600586 |
| 9    | 1.4719936847686768 | 1.4719936847686768 |
| 10   | 1.4772168397903442 | 1.4772168397903442 |

Every loss after the resume boundary matches the fresh run bit for bit. LR schedule matches (`2e-04, 1.6e-04, 1.2e-04, 8e-05, 4e-05`). Checkpoint dir contains the expected 4 files.

## Note on Studio integration

This PR alone isn't enough to unblock the Studio Resume button — Studio's worker must also pass `resume_from_checkpoint` through to `trainer.train()`. That's a 2-line change in a companion PR.