### PR TITLE
Use packaging.version to compare numpy versions

### DIFF
--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -116,7 +116,7 @@ _np_mod = _sys.modules.get("numpy")
 if _np_mod is not None and hasattr(_np_mod, "__version__"):
     try:
         _installed_numpy = _get_pkg_version("numpy")
-        if parse_version(_np_mod.__version__).base_version != parse_version(_installed_numpy).base_version:
+        if parse_version(_np_mod.__version__).public != parse_version(_installed_numpy).public:
             raise RuntimeError(
                 f"***** numpy was upgraded mid-session (loaded: {_np_mod.__version__}, "
                 f"installed: {_installed_numpy}) but the kernel still has the old version "

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -109,14 +109,19 @@ except:
 # be reloaded, so raise a clear restart error.
 import sys as _sys
 from importlib.metadata import version as _get_pkg_version
-from packaging.version import parse as parse_version
+try:
+    from packaging.version import parse as parse_version
+except Exception:
+    parse_version = None # Fall back to raw string compare below.
 
 # numpy: C extensions cannot be reloaded, so must restart.
 _np_mod = _sys.modules.get("numpy")
 if _np_mod is not None and hasattr(_np_mod, "__version__"):
     try:
         _installed_numpy = _get_pkg_version("numpy")
-        if parse_version(_np_mod.__version__).public != parse_version(_installed_numpy).public:
+        # Compare public versions so local labels (e.g. +computecanada) don't false-trigger.
+        _public = (lambda v: parse_version(v).public) if parse_version is not None else (lambda v: v)
+        if _public(_np_mod.__version__) != _public(_installed_numpy):
             raise RuntimeError(
                 f"***** numpy was upgraded mid-session (loaded: {_np_mod.__version__}, "
                 f"installed: {_installed_numpy}) but the kernel still has the old version "

--- a/unsloth_zoo/temporary_patches/utils.py
+++ b/unsloth_zoo/temporary_patches/utils.py
@@ -109,13 +109,14 @@ except:
 # be reloaded, so raise a clear restart error.
 import sys as _sys
 from importlib.metadata import version as _get_pkg_version
+from packaging.version import parse as parse_version
 
 # numpy: C extensions cannot be reloaded, so must restart.
 _np_mod = _sys.modules.get("numpy")
 if _np_mod is not None and hasattr(_np_mod, "__version__"):
     try:
         _installed_numpy = _get_pkg_version("numpy")
-        if _np_mod.__version__ != _installed_numpy:
+        if parse_version(_np_mod.__version__).base_version != parse_version(_installed_numpy).base_version:
             raise RuntimeError(
                 f"***** numpy was upgraded mid-session (loaded: {_np_mod.__version__}, "
                 f"installed: {_installed_numpy}) but the kernel still has the old version "


### PR DESCRIPTION
Allow to compare versions that contains local versions, ie `2.4.2+dev`.

Fixes #752