### PR TITLE
CI: execute use_cache and mlx finetune_last_n_layers tests as a hard gate

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -93,6 +93,19 @@ jobs:
       - name: pytest tests/security (HARD GATE)
         run: python -m pytest tests/security -v
 
+      - name: pytest behavioral gates (HARD GATE)
+        # Deterministic, CPU-pure, sub-second files executed as a gate.
+        # test_mlx_finetune_last_n_layers was born broken in #669 and stayed
+        # invisible until #739 because no job executed it (collect-only plus
+        # the macOS shim smoke). test_training_utils_use_cache pins the
+        # use_cache disable/restore contract for gradient checkpointing
+        # (#715). Executing both here keeps fixture/source drift visible.
+        run: |
+          python -m pytest \
+            tests/test_training_utils_use_cache.py \
+            tests/test_mlx_finetune_last_n_layers.py \
+            -v
+
       - name: pytest tests/test_pr_a_imports + zoo-specific CPU tests
         # Run as SEPARATE pytest invocation: tests/security/conftest.py installs a
         # session-scoped network_blocker autouse fixture that would otherwise block


### PR DESCRIPTION
Follow-up to #739. That PR fixed test_get_peft_model_passes_finetune_last_n_layers_through, which had been failing since #669 introduced it, but the reason it stayed invisible is still in place: no CI job executes the file. The Python version matrix runs pytest --collect-only, mlx-ci runs only the torch shim smoke test on macOS, and the zoo-specific CPU list in repo-tests-cpu does not include it.

This adds a small hard-gate step to repo-tests-cpu that executes two deterministic, CPU-pure files:

- tests/test_mlx_finetune_last_n_layers.py, so the #739 class of fixture/source drift fails CI instead of hiding
- tests/test_training_utils_use_cache.py, pinning the use_cache disable/restore contract for gradient checkpointing from #715

Both run in under a second locally (16 tests), and repo-tests-cpu already installs everything they need (CPU torch, core extras, unsloth no-deps). Kept as a separate step from the continue-on-error zoo list so a regression in these contracts actually blocks.
