### PR TITLE
Route mm_token_type_ids through prompt-completion collation

### DIFF
--- a/tests/test_vision_collator_prompt_completion.py
+++ b/tests/test_vision_collator_prompt_completion.py
@@ -16,13 +16,9 @@
 
 """Prompt-completion collation: token type id routing.
 
-Gemma 3n emits ``token_type_ids`` and Gemma 4 emits ``mm_token_type_ids``.
-Both must be concatenated, flushed, and truncated in lock-step with
-``input_ids``; before this fix the mm variant was left in the output as a
-stale prompt-width copy whose vision block positions no longer lined up
-with the flushed sequence (silent attention mis-masking on Gemma 4 12B+).
-
-Hermetic CPU tests with a stub whitespace processor, no model or network.
+Gemma 3n emits ``token_type_ids``, Gemma 4 ``mm_token_type_ids``; both must
+move in lock-step with ``input_ids`` instead of staying a stale prompt-width
+copy. Hermetic CPU tests with a stub whitespace processor.
 """
 
 from __future__ import annotations
@@ -51,8 +47,6 @@ class _FakeFeatureExtractor:
 
 
 class _FakeProcessor:
-    """Whitespace tokenizer emitting a configurable token-type-ids key."""
-
     def __init__(self, tt_key):
         self.tokenizer = _FakeTokenizer()
         self.feature_extractor = _FakeFeatureExtractor()
@@ -96,9 +90,7 @@ def make_collator(tt_key, max_seq_length=None):
     return collator
 
 
-# Skewed lengths: row 0 has the long prompt (with an image token), row 1 has
-# the long completion, so prompt left pads and completion right pads both
-# appear and the flush genuinely moves tokens.
+# Skewed lengths so both pad sides appear and the flush genuinely moves tokens
 EXAMPLES = [
     {"prompt": "<img> a b", "completion": "x"},
     {"prompt": "a", "completion": "x y z w"},
@@ -109,9 +101,8 @@ def test_mm_token_type_ids_routed_through_pc_path():
     out = make_collator("mm_token_type_ids")(EXAMPLES)
     assert "token_type_ids" not in out
     mm = out["mm_token_type_ids"]
-    # Stale pre-fix copy kept the prompt-only width (2, 3)
+    # Pre-fix the stale copy kept the prompt-only width (2, 3)
     assert mm.shape == out["input_ids"].shape
-    # Type ids must move in lock-step with input_ids through flush/truncate
     assert torch.equal(mm, (out["input_ids"] == IMG_ID).long())
 
 

--- a/tests/test_vision_collator_prompt_completion.py
+++ b/tests/test_vision_collator_prompt_completion.py
@@ -1,0 +1,136 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Prompt-completion collation: token type id routing.
+
+Gemma 3n emits ``token_type_ids`` and Gemma 4 emits ``mm_token_type_ids``.
+Both must be concatenated, flushed, and truncated in lock-step with
+``input_ids``; before this fix the mm variant was left in the output as a
+stale prompt-width copy whose vision block positions no longer lined up
+with the flushed sequence (silent attention mis-masking on Gemma 4 12B+).
+
+Hermetic CPU tests with a stub whitespace processor, no model or network.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from unsloth_zoo.vision_utils import UnslothVisionDataCollator
+
+PAD_ID = 0
+IMG_ID = 7
+VOCAB = {"<img>": IMG_ID, "a": 1, "b": 2, "x": 3, "y": 4, "z": 5, "w": 6}
+
+
+class _FakeTokenizer:
+    pad_token_id = PAD_ID
+    padding_side = "right"
+
+    def convert_tokens_to_ids(self, tokens):
+        if isinstance(tokens, str):
+            return VOCAB.get(tokens, -1)
+        return [VOCAB.get(t, -1) for t in tokens]
+
+
+class _FakeFeatureExtractor:
+    sampling_rate = 16000
+
+
+class _FakeProcessor:
+    """Whitespace tokenizer emitting a configurable token-type-ids key."""
+
+    def __init__(self, tt_key):
+        self.tokenizer = _FakeTokenizer()
+        self.feature_extractor = _FakeFeatureExtractor()
+        self.tt_key = tt_key
+
+    def __call__(self, text, padding=True, padding_side="right", return_tensors="pt",
+                 add_special_tokens=False, **kwargs):
+        rows = [[VOCAB[t] for t in s.split()] for s in text]
+        width = max(len(r) for r in rows)
+        ids, mask = [], []
+        for r in rows:
+            pad = [PAD_ID] * (width - len(r))
+            if padding_side == "left":
+                ids.append(pad + r)
+                mask.append([0] * len(pad) + [1] * len(r))
+            else:
+                ids.append(r + pad)
+                mask.append([1] * len(r) + [0] * len(pad))
+        out = {
+            "input_ids": torch.tensor(ids),
+            "attention_mask": torch.tensor(mask),
+        }
+        if self.tt_key is not None:
+            # Mirrors ProcessorMixin.create_mm_token_type_ids: 0 text, 1 image
+            out[self.tt_key] = (out["input_ids"] == IMG_ID).long()
+        return out
+
+
+def make_collator(tt_key, max_seq_length=None):
+    collator = UnslothVisionDataCollator.__new__(UnslothVisionDataCollator)
+    collator.processor = _FakeProcessor(tt_key)
+    collator.formatting_func = None
+    collator.max_seq_length = max_seq_length
+    collator.truncation = max_seq_length is not None
+    collator.ignore_index = -100
+    collator.completion_only_loss = True
+    collator.pad_to_multiple_of = None
+    collator.image_size = None
+    collator.patch_size = 14
+    collator.padding_token_ids = torch.tensor([PAD_ID, IMG_ID])
+    return collator
+
+
+# Skewed lengths: row 0 has the long prompt (with an image token), row 1 has
+# the long completion, so prompt left pads and completion right pads both
+# appear and the flush genuinely moves tokens.
+EXAMPLES = [
+    {"prompt": "<img> a b", "completion": "x"},
+    {"prompt": "a", "completion": "x y z w"},
+]
+
+
+def test_mm_token_type_ids_routed_through_pc_path():
+    out = make_collator("mm_token_type_ids")(EXAMPLES)
+    assert "token_type_ids" not in out
+    mm = out["mm_token_type_ids"]
+    # Stale pre-fix copy kept the prompt-only width (2, 3)
+    assert mm.shape == out["input_ids"].shape
+    # Type ids must move in lock-step with input_ids through flush/truncate
+    assert torch.equal(mm, (out["input_ids"] == IMG_ID).long())
+
+
+def test_token_type_ids_still_routed():
+    out = make_collator("token_type_ids")(EXAMPLES)
+    assert "mm_token_type_ids" not in out
+    tt = out["token_type_ids"]
+    assert tt.shape == out["input_ids"].shape
+    assert torch.equal(tt, (out["input_ids"] == IMG_ID).long())
+
+
+def test_mm_token_type_ids_truncation_stays_aligned():
+    out = make_collator("mm_token_type_ids", max_seq_length=4)(EXAMPLES)
+    mm = out["mm_token_type_ids"]
+    assert mm.shape == out["input_ids"].shape == (2, 4)
+    assert torch.equal(mm, (out["input_ids"] == IMG_ID).long())
+
+
+def test_no_type_ids_emitted_is_a_noop():
+    out = make_collator(None)(EXAMPLES)
+    assert "token_type_ids" not in out and "mm_token_type_ids" not in out
+    assert out["input_ids"].shape == out["attention_mask"].shape

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1417,12 +1417,20 @@ class UnslothVisionDataCollator:
 
         p_ids, c_ids = proc_prompts["input_ids"], proc_completions["input_ids"]
         p_m, c_m = proc_prompts["attention_mask"], proc_completions["attention_mask"]
-        p_tt, c_tt = proc_prompts.get("token_type_ids", None), proc_completions.get("token_type_ids", None)
+        # Gemma 3n emits token_type_ids, Gemma 4 emits mm_token_type_ids; route
+        # whichever is present through the concat/flush/truncate path below, else
+        # `out = dict(proc_prompts)` keeps a stale prompt-width copy whose vision
+        # block positions no longer align with the flushed input_ids.
+        tt_key = "token_type_ids" if "token_type_ids" in proc_prompts else "mm_token_type_ids"
+        p_tt, c_tt = proc_prompts.get(tt_key, None), proc_completions.get(tt_key, None)
 
         input_ids = torch.cat((p_ids, c_ids), dim=1)
         attention_mask = torch.cat((p_m, c_m), dim=1)
         completion_mask = torch.cat((torch.zeros_like(p_m), c_m), dim=1)
-        if p_tt is not None and c_tt is not None:
+        if p_tt is not None or c_tt is not None:
+            # A side missing the key is text-only: type 0 in both vocabularies
+            if p_tt is None: p_tt = torch.zeros_like(p_ids)
+            if c_tt is None: c_tt = torch.zeros_like(c_ids)
             token_type_ids = torch.cat((p_tt, c_tt), dim=1)
         else:
             token_type_ids = None
@@ -1476,7 +1484,7 @@ class UnslothVisionDataCollator:
         out["attention_mask"] = attention_mask
         out["labels"] = labels
         if token_type_ids is not None:
-            out["token_type_ids"] = token_type_ids
+            out[tt_key] = token_type_ids
         if 'pixel_values' in out:
             out = self._cast_pixel_values_dtype_inplace(out)
         if 'pixel_values_videos' in out:

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1417,10 +1417,8 @@ class UnslothVisionDataCollator:
 
         p_ids, c_ids = proc_prompts["input_ids"], proc_completions["input_ids"]
         p_m, c_m = proc_prompts["attention_mask"], proc_completions["attention_mask"]
-        # Gemma 3n emits token_type_ids, Gemma 4 emits mm_token_type_ids; route
-        # whichever is present through the concat/flush/truncate path below, else
-        # `out = dict(proc_prompts)` keeps a stale prompt-width copy whose vision
-        # block positions no longer align with the flushed input_ids.
+        # Gemma 3n emits token_type_ids, Gemma 4 mm_token_type_ids; route whichever
+        # exists, else dict(proc_prompts) keeps a stale prompt-width copy.
         tt_key = "token_type_ids" if "token_type_ids" in proc_prompts else "mm_token_type_ids"
         p_tt, c_tt = proc_prompts.get(tt_key, None), proc_completions.get(tt_key, None)
 


### PR DESCRIPTION
## Problem

The prompt-completion collation path (`_collate_prompt_completion`) only routes `token_type_ids` (Gemma 3n's key) through its concat/flush/truncate plumbing. Gemma 4 emits `mm_token_type_ids` instead, so the tensor falls through every step and `out = dict(proc_prompts)` keeps the stale prompt-width copy in the batch.

Verified repro: a 2-row prompt-completion batch with skewed lengths produces `input_ids` of shape (2, 313) next to `mm_token_type_ids` of shape (2, 310) whose vision block positions no longer line up with the flushed sequence; 41 completion text tokens end up marked as vision-block members.

Impact is limited to models that consume the key for attention, i.e. `text_config.use_bidirectional_attention == "vision"`: Gemma 4 12B, 26B, 31B. The result is silent attention mis-masking, not a crash. E2B/E4B never read the key, and the standard `messages` path (all shipped notebooks) is unaffected.

Dropping the key instead would not be safe: the model then defaults the block ids and silently disables bidirectional vision attention for prompt images on 12B+.

## Fix

Detect whichever key the processor emitted (`token_type_ids` or `mm_token_type_ids`), route it through the existing token type id concat/flush/truncate path, and write it back under the same key. A side missing the key (text-only completions) is synthesized as zeros, which is exact: type 0 means text in both vocabularies (`create_mm_token_type_ids` assigns 0 text, 1 image, 2 video, 3 audio).

## Tests

New hermetic CPU file `tests/test_vision_collator_prompt_completion.py` (stub whitespace processor, no model or network):

- Gemma 4 style `mm_token_type_ids`: output width matches `input_ids` and type ids stay aligned with image token positions through the flush
- Gemma 3n style `token_type_ids`: unchanged behavior (regression guard)
- Truncation keeps alignment under `max_seq_length`
- Processors emitting neither key are a noop

The two mm tests fail against the previous code and pass with the fix; the existing 27 audio collator tests still pass.