### PR TITLE
Make UNSLOTH_COMPILE_DISABLE=1 dtype-safe for fp32 upcast norms

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -4533,15 +4533,12 @@ def unsloth_compile_transformers(
             print(str(dir(combined_module)))
         combined_module = None
 
-    # The dtype-coercing forward rewrites below never compile anything
-    # (add_torch_compile=False), so they must also run when compiling is
-    # disabled: the fp32 norm weight upcast happens unconditionally at load,
-    # and without these casts eager F.layer_norm crashes on bf16 activations
-    # ("expected scalar type BFloat16 but found Float", eg Gemma 4 audio /
-    # Gemma 3 SigLIP towers under UNSLOTH_COMPILE_DISABLE=1).
+    # These rewrites never compile (add_torch_compile=False), so run them even
+    # when compiling is disabled: norms are fp32 upcast at load regardless, and
+    # eager F.layer_norm crashes on bf16 activations against fp32 weights.
     if compile_torch_modules:
         if not disable:
-            # Compiled global F.layer_norm; never install when compile is off
+            # Compiled global F.layer_norm: only when compiling is allowed
             from .patch_torch_functions import patch_torch_functions
 
             patch_torch_functions()
@@ -4589,12 +4586,9 @@ def unsloth_compile_transformers(
                 m = _re.search(r"def forward\(self,\s*(\w+)", source)
                 param_name = m.group(1) if m else "input"
                 if disable:
-                    # Eager F.layer_norm requires input dtype == weight dtype,
-                    # so cast the input to the (fp32 upcast) weight dtype and
-                    # the output back. Only under UNSLOTH_COMPILE_DISABLE: the
-                    # compiled path type-promotes inside the fused kernel, and
-                    # adding the cast there changes batched numerics. weight
-                    # is None when elementwise_affine/affine=False.
+                    # Eager F.layer_norm needs input dtype == weight dtype: cast in
+                    # and out. Compiled path left untouched (adding the cast there
+                    # changes batched numerics). weight is None when affine=False.
                     lines = source.split("\n")
                     def_line = lines[0]
                     body_lines = lines[1:]

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -4533,10 +4533,18 @@ def unsloth_compile_transformers(
             print(str(dir(combined_module)))
         combined_module = None
 
-    if compile_torch_modules and not disable:
-        from .patch_torch_functions import patch_torch_functions
+    # The dtype-coercing forward rewrites below never compile anything
+    # (add_torch_compile=False), so they must also run when compiling is
+    # disabled: the fp32 norm weight upcast happens unconditionally at load,
+    # and without these casts eager F.layer_norm crashes on bf16 activations
+    # ("expected scalar type BFloat16 but found Float", eg Gemma 4 audio /
+    # Gemma 3 SigLIP towers under UNSLOTH_COMPILE_DISABLE=1).
+    if compile_torch_modules:
+        if not disable:
+            # Compiled global F.layer_norm; never install when compile is off
+            from .patch_torch_functions import patch_torch_functions
 
-        patch_torch_functions()
+            patch_torch_functions()
 
         _conv_modules = frozenset([
             "Conv1d", "Conv2d", "Conv3d",
@@ -4580,7 +4588,26 @@ def unsloth_compile_transformers(
                 import re as _re
                 m = _re.search(r"def forward\(self,\s*(\w+)", source)
                 param_name = m.group(1) if m else "input"
-                append_str = f".to({param_name}.dtype)\n"
+                if disable:
+                    # Eager F.layer_norm requires input dtype == weight dtype,
+                    # so cast the input to the (fp32 upcast) weight dtype and
+                    # the output back. Only under UNSLOTH_COMPILE_DISABLE: the
+                    # compiled path type-promotes inside the fused kernel, and
+                    # adding the cast there changes batched numerics. weight
+                    # is None when elementwise_affine/affine=False.
+                    lines = source.split("\n")
+                    def_line = lines[0]
+                    body_lines = lines[1:]
+                    first_body = next((l for l in body_lines if l.strip()), "")
+                    body_indent = first_body[:len(first_body) - len(first_body.lstrip())]
+                    prologue = [
+                        body_indent + f"original_dtype = {param_name}.dtype",
+                        body_indent + f"if self.weight is not None: {param_name} = {param_name}.to(self.weight.dtype)",
+                    ]
+                    source = "\n".join([def_line] + prologue + body_lines)
+                    append_str = ".to(original_dtype)\n"
+                else:
+                    append_str = f".to({param_name}.dtype)\n"
 
             forward = create_new_function(
                 module,


### PR DESCRIPTION
## Problem

`UNSLOTH_COMPILE_DISABLE=1` (the documented torch.compile escape hatch) crashes Gemma 4 audio forwards on every transformers version with:

```
RuntimeError: expected scalar type BFloat16 but found Float
```

raised from eager `F.layer_norm`. The same applies to any model that combines a raw `nn.LayerNorm` with the norm fp32 upcast, e.g. the Gemma 3 SigLIP vision tower.

## Root cause

Three independent investigations converged on the same chain:

1. The loader sets `UNSLOTH_HIGH_PRECISION_LAYERNORM=1` unconditionally for gemma4 (also gemma3, gemma3n, granite4, gpt_oss). Every module named `*norm*` is then tagged and physically cast to fp32 at load time, in both compiled and disabled modes (74 fp32 norm params in the Gemma 4 audio tower alone).
2. The dtype-coercing `torch.nn` forward rewrites in `compiler.py` were gated behind `not disable`, so with compiling disabled the stock eager `nn.LayerNorm.forward` runs `F.layer_norm(bf16 input, fp32 weight)` and crashes. `Gemma4RMSNorm` self-upcasts internally, so only true `nn.LayerNorm` sites break.
3. The compiled path survives mixed dtypes only because inductor type-promotes inside the fused kernel; the existing norm rewrite casts the output but not the input, which eager ATen rejects.

## Fix (compiler.py, two coordinated changes)

- Run the forward rewrite loop regardless of `disable`. It never compiles anything (`add_torch_compile=False`); only the compiled global `F.layer_norm` from `patch_torch_functions` stays gated to the compiled path.
- Under `disable`, generate norm forwards that cast the input to the weight dtype before the op and restore the original activation dtype after (guarded for `affine=False` where `weight` is `None`). When compiling is enabled the generated source is byte-identical to before. This scoping is deliberate: prototyping showed that adding the input cast to the compiled path measurably shifts batched-audio numerics (loss 8.8907 to 8.8090 on a mixed-length batch), so the default path is left untouched.

Stale cached `LayerNorm.py` etc. regenerate automatically: `create_new_function(overwrite=False)` rewrites on source mismatch.

## Validation (gemma-4-E2B-it, B200)

| Arm | Before | After |
|---|---|---|
| transformers 5.5.0, eager (`UNSLOTH_COMPILE_DISABLE=1`) | crash on every batch | 3/3 batches OK |
| transformers 5.5.0, compiled default | baseline | bit-identical: loss and logit sums exact (`8.890680313110352 / -525244896.0` reproduced across three independent runs) |
| transformers 5.10.2, eager | crash | 3/3 OK, eager losses bit-identical to the 5.5.0 eager arm |
| transformers 5.10.2, compiled default | works | works |

Also verified: the rewritten forward source parses for all six affected torch classes (LayerNorm, RMSNorm, GroupNorm, BatchNorm1d/2d/3d, including multi-line return bodies and the `x` parameter name in RMSNorm), and the 186 compiler CPU tests pass. The change is pure Python source generation with no OS, accelerator, transformers, TRL, or vLLM version dependence; transformers 4.57.6 runs the identical generator code.

An observation for a possible follow-up: the pre-existing compiled mixed-dtype layer_norm is the numerical outlier on padded batches (eager fp32 math and the input-cast compiled variant agree with each other, the current compiled kernel does not). Left as-is here to keep the default path bit-stable.