### PR TITLE
Install prebuilt llama.cpp release binaries before compiling from source

### DIFF
--- a/tests/test_llama_cpp_prebuilt.py
+++ b/tests/test_llama_cpp_prebuilt.py
@@ -1,0 +1,273 @@
+# Tests for the prebuilt-first llama.cpp install path: release resolution,
+# asset selection, archive extraction/placement, fallback-to-compile contract,
+# and reuse of an existing prebuilt install without deletion.
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+
+def _load_llama_cpp_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+    spec = importlib.util.spec_from_file_location("llama_cpp_under_test_prebuilt", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+llama_cpp = _load_llama_cpp_module()
+
+IS_POSIX = os.name == "posix"
+
+FAKE_QUANTIZE = "#!/bin/sh\necho 'usage: llama-quantize [--help] model-f32.gguf'\nexit 0\n"
+FAKE_QUANTIZE_BROKEN = "#!/bin/sh\necho 'segfault'\nexit 1\n"
+
+
+def _add_file(tar, name, data, mode = 0o644):
+    raw = data.encode() if isinstance(data, str) else data
+    info = tarfile.TarInfo(name)
+    info.size = len(raw)
+    info.mode = mode
+    tar.addfile(info, io.BytesIO(raw))
+
+
+def _make_binary_archive(path, tag, quantize_script = FAKE_QUANTIZE):
+    with tarfile.open(path, "w:gz") as tar:
+        _add_file(tar, f"llama-{tag}/llama-quantize", quantize_script, mode = 0o755)
+        _add_file(tar, f"llama-{tag}/llama-cli", FAKE_QUANTIZE, mode = 0o755)
+        _add_file(tar, f"llama-{tag}/libggml-base.so", "not really elf")
+        _add_file(tar, f"llama-{tag}/LICENSE", "MIT-ish")
+
+
+def _make_source_archive(path, tag):
+    with tarfile.open(path, "w:gz") as tar:
+        _add_file(tar, f"llama.cpp-{tag}/convert_hf_to_gguf.py", "# converter entrypoint\n")
+        _add_file(tar, f"llama.cpp-{tag}/conversion/__init__.py", "TEXT_MODEL_MAP = {}\n")
+        _add_file(tar, f"llama.cpp-{tag}/gguf-py/gguf/tensor_mapping.py", "mappings_cfg = {}\n")
+
+
+def _fake_release(tag, asset_names):
+    return tag, {name: f"https://example.invalid/{name}" for name in asset_names}
+
+
+def _patch_platform(monkeypatch, system, machine):
+    monkeypatch.setattr(llama_cpp.platform, "system", lambda: system)
+    monkeypatch.setattr(llama_cpp.platform, "machine", lambda: machine)
+
+
+# --- asset selection ---------------------------------------------------------
+
+@pytest.mark.parametrize("system,machine,expected", [
+    ("Linux",   "x86_64",  "llama-b9000-bin-ubuntu-x64.tar.gz"),
+    ("Linux",   "AMD64",   "llama-b9000-bin-ubuntu-x64.tar.gz"),
+    ("Linux",   "aarch64", "llama-b9000-bin-ubuntu-arm64.tar.gz"),
+    ("Darwin",  "arm64",   "llama-b9000-bin-macos-arm64.tar.gz"),
+    ("Darwin",  "x86_64",  "llama-b9000-bin-macos-x64.tar.gz"),
+    ("Windows", "AMD64",   "llama-b9000-bin-win-cpu-x64.zip"),
+    ("Windows", "ARM64",   "llama-b9000-bin-win-cpu-arm64.zip"),
+])
+def test_select_asset_matrix(monkeypatch, system, machine, expected):
+    _patch_platform(monkeypatch, system, machine)
+    tag, assets = _fake_release("b9000", [expected, "llama-b9000-ui.tar.gz"])
+    name, url = llama_cpp._select_prebuilt_asset(tag, assets)
+    assert name == expected
+    assert url.endswith(expected)
+
+
+@pytest.mark.parametrize("system,machine", [
+    ("Linux", "i686"),
+    ("FreeBSD", "x86_64"),
+])
+def test_select_asset_unsupported_platform(monkeypatch, system, machine):
+    _patch_platform(monkeypatch, system, machine)
+    tag, assets = _fake_release("b9000", ["llama-b9000-bin-ubuntu-x64.tar.gz"])
+    assert llama_cpp._select_prebuilt_asset(tag, assets) is None
+
+
+def test_select_asset_missing_from_release(monkeypatch):
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    tag, assets = _fake_release("b9000", ["llama-b9000-bin-macos-arm64.tar.gz"])
+    assert llama_cpp._select_prebuilt_asset(tag, assets) is None
+
+
+# --- release resolution ------------------------------------------------------
+
+def test_resolve_release_env_pin_hits_tag_endpoint(monkeypatch):
+    seen = {}
+    class FakeResponse:
+        def json(self):
+            return {"tag_name": "b7777", "assets": [
+                {"name": "a.tar.gz", "browser_download_url": "https://example.invalid/a.tar.gz"},
+            ]}
+    def fake_get(url, **kwargs):
+        seen["url"] = url
+        return FakeResponse()
+    monkeypatch.setenv("UNSLOTH_LLAMA_TAG", "b7777")
+    monkeypatch.setattr(llama_cpp, "_requests_get_with_retries", fake_get)
+    tag, assets = llama_cpp._resolve_llama_cpp_release()
+    assert tag == "b7777"
+    assert seen["url"].endswith("/releases/tags/b7777")
+    assert assets == {"a.tar.gz": "https://example.invalid/a.tar.gz"}
+
+
+def test_resolve_release_failure_returns_none(monkeypatch):
+    def fake_get(url, **kwargs):
+        raise llama_cpp.requests.exceptions.ConnectionError("offline")
+    monkeypatch.delenv("UNSLOTH_LLAMA_TAG", raising = False)
+    monkeypatch.setattr(llama_cpp, "_requests_get_with_retries", fake_get)
+    assert llama_cpp._resolve_llama_cpp_release() is None
+
+
+# --- gates -------------------------------------------------------------------
+
+def test_force_compile_skips_prebuilt(monkeypatch, tmp_path):
+    monkeypatch.setenv("UNSLOTH_LLAMA_FORCE_COMPILE", "1")
+    def boom(*a, **k):
+        raise AssertionError("network must not be touched")
+    monkeypatch.setattr(llama_cpp, "_resolve_llama_cpp_release", boom)
+    assert llama_cpp._maybe_install_llama_cpp_prebuilt(str(tmp_path / "llama.cpp")) is None
+
+
+def test_gpu_support_skips_prebuilt(monkeypatch, tmp_path):
+    monkeypatch.delenv("UNSLOTH_LLAMA_FORCE_COMPILE", raising = False)
+    def boom(*a, **k):
+        raise AssertionError("network must not be touched")
+    monkeypatch.setattr(llama_cpp, "_resolve_llama_cpp_release", boom)
+    assert llama_cpp._maybe_install_llama_cpp_prebuilt(str(tmp_path / "llama.cpp"), gpu_support = True) is None
+
+
+# --- extraction and placement ------------------------------------------------
+
+def test_extract_rejects_path_traversal(tmp_path):
+    evil = tmp_path / "evil.tar.gz"
+    with tarfile.open(evil, "w:gz") as tar:
+        _add_file(tar, "../escape.txt", "pwned")
+    with pytest.raises(RuntimeError, match = "escapes extraction dir"):
+        llama_cpp._extract_archive(str(evil), str(tmp_path / "out"))
+
+
+@pytest.mark.skipif(not IS_POSIX, reason = "shell-script fake binaries")
+def test_extract_and_place_linux(tmp_path):
+    archive = tmp_path / "llama-b9000-bin-ubuntu-x64.tar.gz"
+    _make_binary_archive(str(archive), "b9000")
+    extract_dir = tmp_path / "extracted"
+    os.makedirs(extract_dir)
+    llama_cpp._extract_archive(str(archive), str(extract_dir))
+    root = llama_cpp._single_extracted_root(str(extract_dir))
+    assert os.path.basename(root) == "llama-b9000"
+    install = tmp_path / "install"
+    llama_cpp._place_prebuilt_binaries(root, str(install))
+    quantizer = install / "llama-quantize"
+    assert quantizer.is_file() and os.access(quantizer, os.X_OK)
+    assert (install / "libggml-base.so").is_file()
+
+
+# --- full install orchestration ----------------------------------------------
+
+def _wire_fake_downloads(monkeypatch, tmp_path, tag, quantize_script = FAKE_QUANTIZE):
+    """Point release resolution and downloads at local fixture archives."""
+    binary = tmp_path / "fixtures" / f"llama-{tag}-bin-ubuntu-x64.tar.gz"
+    source = tmp_path / "fixtures" / "source.tar.gz"
+    os.makedirs(binary.parent, exist_ok = True)
+    _make_binary_archive(str(binary), tag, quantize_script)
+    _make_source_archive(str(source), tag)
+
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    monkeypatch.delenv("UNSLOTH_LLAMA_FORCE_COMPILE", raising = False)
+    monkeypatch.setattr(
+        llama_cpp, "_resolve_llama_cpp_release",
+        lambda: _fake_release(tag, [f"llama-{tag}-bin-ubuntu-x64.tar.gz"]),
+    )
+    def fake_download(url, dest_path):
+        fixture = binary if "-bin-" in os.path.basename(dest_path) else source
+        with open(fixture, "rb") as fr, open(dest_path, "wb") as fw:
+            fw.write(fr.read())
+    monkeypatch.setattr(llama_cpp, "_download_archive", fake_download)
+    monkeypatch.setattr(llama_cpp, "try_execute", lambda *a, **k: "")
+    monkeypatch.setattr(llama_cpp, "check_pip", lambda: "pip")
+
+
+@pytest.mark.skipif(not IS_POSIX, reason = "shell-script fake binaries")
+def test_full_prebuilt_install_happy_path(monkeypatch, tmp_path):
+    _wire_fake_downloads(monkeypatch, tmp_path, "b9000")
+    folder = str(tmp_path / "llama.cpp")
+    result = llama_cpp._install_llama_cpp_prebuilt(folder)
+    assert result is not None
+    quantizer, converter = result
+    assert quantizer == os.path.join(folder, "llama-quantize")
+    assert converter == os.path.join(folder, "convert_hf_to_gguf.py")
+    assert os.path.isfile(os.path.join(folder, "gguf-py", "gguf", "tensor_mapping.py"))
+    assert os.path.isfile(os.path.join(folder, "conversion", "__init__.py"))
+    marker = json.load(open(os.path.join(folder, llama_cpp.UNSLOTH_PREBUILT_INFO_FILENAME)))
+    assert marker["tag"] == "b9000"
+    assert marker["asset"] == "llama-b9000-bin-ubuntu-x64.tar.gz"
+    # Staging directories are cleaned up
+    leftovers = [e for e in os.listdir(tmp_path) if e.startswith(".llama_cpp_prebuilt_")]
+    assert leftovers == []
+
+
+@pytest.mark.skipif(not IS_POSIX, reason = "shell-script fake binaries")
+def test_validation_failure_falls_back(monkeypatch, tmp_path):
+    _wire_fake_downloads(monkeypatch, tmp_path, "b9000", quantize_script = FAKE_QUANTIZE_BROKEN)
+    folder = str(tmp_path / "llama.cpp")
+    assert llama_cpp._install_llama_cpp_prebuilt(folder) is None
+    # A failed install never materializes the target folder
+    assert not os.path.exists(folder)
+
+
+def test_corrupt_archive_falls_back(monkeypatch, tmp_path):
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    monkeypatch.delenv("UNSLOTH_LLAMA_FORCE_COMPILE", raising = False)
+    monkeypatch.setattr(
+        llama_cpp, "_resolve_llama_cpp_release",
+        lambda: _fake_release("b9000", ["llama-b9000-bin-ubuntu-x64.tar.gz"]),
+    )
+    def fake_download(url, dest_path):
+        with open(dest_path, "wb") as f:
+            f.write(b"this is not a tarball")
+    monkeypatch.setattr(llama_cpp, "_download_archive", fake_download)
+    folder = str(tmp_path / "llama.cpp")
+    assert llama_cpp._install_llama_cpp_prebuilt(folder) is None
+    assert not os.path.exists(folder)
+
+
+@pytest.mark.skipif(not IS_POSIX, reason = "shell-script fake binaries")
+def test_install_llama_cpp_reuses_prebuilt_without_delete(monkeypatch, tmp_path):
+    # First call installs via the (stubbed) prebuilt path; the second must hit
+    # the existing-install reuse and NOT rmtree the marker-bearing folder.
+    folder = str(tmp_path / "llama.cpp")
+
+    def fake_prebuilt(llama_cpp_folder, **kwargs):
+        os.makedirs(llama_cpp_folder, exist_ok = True)
+        quantizer = os.path.join(llama_cpp_folder, "llama-quantize")
+        with open(quantizer, "w") as f:
+            f.write(FAKE_QUANTIZE)
+        os.chmod(quantizer, 0o755)
+        converter = os.path.join(llama_cpp_folder, "convert_hf_to_gguf.py")
+        with open(converter, "w") as f:
+            f.write("# converter\n")
+        with open(os.path.join(llama_cpp_folder, llama_cpp.UNSLOTH_PREBUILT_INFO_FILENAME), "w") as f:
+            json.dump({"tag": "b9000"}, f)
+        with open(os.path.join(llama_cpp_folder, "sentinel.txt"), "w") as f:
+            f.write("must survive")
+        return quantizer, converter
+
+    monkeypatch.setattr(llama_cpp, "_maybe_install_llama_cpp_prebuilt", fake_prebuilt)
+    def no_rmtree(path, *a, **k):
+        raise AssertionError(f"rmtree must not run on {path}")
+    monkeypatch.setattr(llama_cpp.shutil, "rmtree", no_rmtree)
+
+    q1, c1 = llama_cpp.install_llama_cpp(llama_cpp_folder = folder)
+    q2, c2 = llama_cpp.install_llama_cpp(llama_cpp_folder = folder)
+    assert (q1, c1) == (q2, c2)
+    assert os.path.isfile(os.path.join(folder, "sentinel.txt"))

--- a/tests/test_llama_cpp_prebuilt.py
+++ b/tests/test_llama_cpp_prebuilt.py
@@ -138,12 +138,146 @@ def test_force_compile_skips_prebuilt(monkeypatch, tmp_path):
     assert llama_cpp._maybe_install_llama_cpp_prebuilt(str(tmp_path / "llama.cpp")) is None
 
 
-def test_gpu_support_skips_prebuilt(monkeypatch, tmp_path):
+def test_gpu_without_detectable_target_falls_back(monkeypatch, tmp_path):
     monkeypatch.delenv("UNSLOTH_LLAMA_FORCE_COMPILE", raising = False)
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    monkeypatch.setattr(llama_cpp, "_detect_gpu_target", lambda: None)
     def boom(*a, **k):
         raise AssertionError("network must not be touched")
     monkeypatch.setattr(llama_cpp, "_resolve_llama_cpp_release", boom)
     assert llama_cpp._maybe_install_llama_cpp_prebuilt(str(tmp_path / "llama.cpp"), gpu_support = True) is None
+
+
+# --- GPU asset selection (unslothai/llama.cpp fork bundles) -------------------
+
+FORK_MANIFEST = {"artifacts": [
+    {"asset_name": "app-b9585-linux-x64-cuda12-older.tar.gz",    "install_kind": "linux-cuda",
+     "runtime_line": "cuda12", "coverage_class": "older",    "supported_sms": ["70","75","80","86","89"],
+     "min_sm": 70, "max_sm": 89, "rank": 10},
+    {"asset_name": "app-b9585-linux-x64-cuda12-newer.tar.gz",    "install_kind": "linux-cuda",
+     "runtime_line": "cuda12", "coverage_class": "newer",    "supported_sms": ["86","89","90","100","103","120"],
+     "min_sm": 86, "max_sm": 120, "rank": 20},
+    {"asset_name": "app-b9585-linux-x64-cuda12-portable.tar.gz", "install_kind": "linux-cuda",
+     "runtime_line": "cuda12", "coverage_class": "portable", "supported_sms": ["70","75","80","86","89","90","100","103","120"],
+     "min_sm": 70, "max_sm": 120, "rank": 30},
+    {"asset_name": "app-b9585-linux-x64-cuda13-newer.tar.gz",    "install_kind": "linux-cuda",
+     "runtime_line": "cuda13", "coverage_class": "newer",    "supported_sms": ["86","89","90","100","103","120"],
+     "min_sm": 86, "max_sm": 120, "rank": 50},
+    {"asset_name": "app-b9585-linux-x64-rocm-gfx110X.tar.gz",    "install_kind": "linux-rocm"},
+    {"asset_name": "app-b9585-linux-x64-rocm-gfx120X.tar.gz",    "install_kind": "linux-rocm"},
+]}
+FORK_ASSETS = {a["asset_name"]: f"https://example.invalid/{a['asset_name']}" for a in FORK_MANIFEST["artifacts"]}
+FORK_ASSETS["llama-b9585-bin-macos-arm64.tar.gz"] = "https://example.invalid/llama-b9585-bin-macos-arm64.tar.gz"
+
+
+def test_select_gpu_assets_narrowest_coverage_first(monkeypatch):
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    monkeypatch.setattr(llama_cpp, "_detect_gpu_target", lambda: ("cuda", 86, "cuda12"))
+    names = [n for n, _ in llama_cpp._select_gpu_assets("b9585", FORK_ASSETS, FORK_MANIFEST)]
+    # sm86 fits cuda12-older (range 19) before cuda12-newer (range 34),
+    # then the cuda12 portable, then the other runtime line.
+    assert names[:2] == [
+        "app-b9585-linux-x64-cuda12-older.tar.gz",
+        "app-b9585-linux-x64-cuda12-portable.tar.gz",
+    ]
+    assert "app-b9585-linux-x64-cuda13-newer.tar.gz" in names
+
+
+def test_select_gpu_assets_prefers_torch_runtime_line(monkeypatch):
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    monkeypatch.setattr(llama_cpp, "_detect_gpu_target", lambda: ("cuda", 100, "cuda13"))
+    names = [n for n, _ in llama_cpp._select_gpu_assets("b9585", FORK_ASSETS, FORK_MANIFEST)]
+    assert names[0] == "app-b9585-linux-x64-cuda13-newer.tar.gz"
+
+
+def test_select_gpu_assets_rocm_family(monkeypatch):
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    monkeypatch.setattr(llama_cpp, "_detect_gpu_target", lambda: ("rocm", "gfx1100"))
+    names = [n for n, _ in llama_cpp._select_gpu_assets("b9585", FORK_ASSETS, FORK_MANIFEST)]
+    assert names == ["app-b9585-linux-x64-rocm-gfx110X.tar.gz"]
+
+
+def test_select_gpu_assets_macos_metal_bundle(monkeypatch):
+    # macOS needs no torch GPU detection; the fork Metal bundle is selected.
+    _patch_platform(monkeypatch, "Darwin", "arm64")
+    monkeypatch.setattr(llama_cpp, "_detect_gpu_target", lambda: None)
+    names = [n for n, _ in llama_cpp._select_gpu_assets("b9585", FORK_ASSETS, FORK_MANIFEST)]
+    assert names == ["llama-b9585-bin-macos-arm64.tar.gz"]
+
+
+def test_rocm_gfx_family_mapping():
+    assert llama_cpp._rocm_gfx_family("gfx1100") == "gfx110X"
+    assert llama_cpp._rocm_gfx_family("gfx1030") == "gfx103X"
+    assert llama_cpp._rocm_gfx_family("gfx1201") == "gfx120X"
+    assert llama_cpp._rocm_gfx_family("gfx1151") == "gfx1151"
+    assert llama_cpp._rocm_gfx_family("gfx906") is None
+
+
+@pytest.mark.skipif(not IS_POSIX, reason = "shell-script fake binaries")
+def test_gpu_full_install_happy_path(monkeypatch, tmp_path):
+    tag = "b9585"
+    asset = f"app-{tag}-linux-x64-cuda12-newer.tar.gz"
+    binary = tmp_path / "fixtures" / asset
+    source = tmp_path / "fixtures" / "source.tar.gz"
+    os.makedirs(binary.parent, exist_ok = True)
+    _make_binary_archive(str(binary), tag)
+    _make_source_archive(str(source), tag)
+    sha = llama_cpp._sha256_file(str(binary))
+
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    monkeypatch.delenv("UNSLOTH_LLAMA_FORCE_COMPILE", raising = False)
+    monkeypatch.setattr(llama_cpp, "_detect_gpu_target", lambda: ("cuda", 100, "cuda12"))
+    monkeypatch.setattr(
+        llama_cpp, "_resolve_llama_cpp_release",
+        lambda releases_api = None: (tag, {asset: f"https://example.invalid/{asset}"}),
+    )
+    monkeypatch.setattr(
+        llama_cpp, "_fetch_release_json_asset",
+        lambda assets, name: FORK_MANIFEST if "manifest" in name else {"artifacts": {asset: {"sha256": sha}}},
+    )
+    def fake_download(url, dest_path):
+        fixture = binary if "app-" in os.path.basename(dest_path) else source
+        with open(fixture, "rb") as fr, open(dest_path, "wb") as fw:
+            fw.write(fr.read())
+    monkeypatch.setattr(llama_cpp, "_download_archive", fake_download)
+    monkeypatch.setattr(llama_cpp, "try_execute", lambda *a, **k: "")
+    monkeypatch.setattr(llama_cpp, "check_pip", lambda: "pip")
+
+    folder = str(tmp_path / "llama.cpp")
+    result = llama_cpp._install_llama_cpp_prebuilt(folder, gpu_support = True)
+    assert result is not None
+    marker = json.load(open(os.path.join(folder, llama_cpp.UNSLOTH_PREBUILT_INFO_FILENAME)))
+    assert marker["repo"] == "unslothai/llama.cpp"
+    assert marker["asset"] == asset
+
+
+@pytest.mark.skipif(not IS_POSIX, reason = "shell-script fake binaries")
+def test_gpu_sha256_mismatch_falls_back(monkeypatch, tmp_path):
+    tag = "b9585"
+    asset = f"app-{tag}-linux-x64-cuda12-newer.tar.gz"
+    binary = tmp_path / "fixtures" / asset
+    os.makedirs(binary.parent, exist_ok = True)
+    _make_binary_archive(str(binary), tag)
+
+    _patch_platform(monkeypatch, "Linux", "x86_64")
+    monkeypatch.delenv("UNSLOTH_LLAMA_FORCE_COMPILE", raising = False)
+    monkeypatch.setattr(llama_cpp, "_detect_gpu_target", lambda: ("cuda", 100, "cuda12"))
+    monkeypatch.setattr(
+        llama_cpp, "_resolve_llama_cpp_release",
+        lambda releases_api = None: (tag, {asset: f"https://example.invalid/{asset}"}),
+    )
+    monkeypatch.setattr(
+        llama_cpp, "_fetch_release_json_asset",
+        lambda assets, name: FORK_MANIFEST if "manifest" in name else {"artifacts": {asset: {"sha256": "0" * 64}}},
+    )
+    def fake_download(url, dest_path):
+        with open(binary, "rb") as fr, open(dest_path, "wb") as fw:
+            fw.write(fr.read())
+    monkeypatch.setattr(llama_cpp, "_download_archive", fake_download)
+
+    folder = str(tmp_path / "llama.cpp")
+    assert llama_cpp._install_llama_cpp_prebuilt(folder, gpu_support = True) is None
+    assert not os.path.exists(folder)
 
 
 # --- extraction and placement ------------------------------------------------

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -137,11 +137,17 @@ LLAMA_CPP_DEFAULT_DIR = os.environ.get(
     os.path.join(UNSLOTH_HOME, "llama.cpp"),
 )
 
-# Prebuilt llama.cpp binaries from official releases. Marker file
-# distinguishes a prebuilt install from a corrupted source checkout.
+# Prebuilt llama.cpp binaries. CPU builds come from upstream ggml-org
+# releases; GPU (CUDA/ROCm/Metal) bundles come from the unslothai/llama.cpp
+# fork that Unsloth Studio also installs from, selected via its manifest and
+# verified against its published sha256 list. Marker file distinguishes a
+# prebuilt install from a corrupted source checkout.
 UNSLOTH_PREBUILT_INFO_FILENAME = "UNSLOTH_PREBUILT_INFO.json"
 LLAMA_CPP_RELEASES_API = "https://api.github.com/repos/ggml-org/llama.cpp/releases"
+LLAMA_CPP_PUBLISHED_RELEASES_API = "https://api.github.com/repos/unslothai/llama.cpp/releases"
 LLAMA_CPP_SOURCE_TARBALL = "https://codeload.github.com/ggml-org/llama.cpp/tar.gz/refs/tags/{tag}"
+LLAMA_CPP_PREBUILT_MANIFEST_ASSET = "llama-prebuilt-manifest.json"
+LLAMA_CPP_PREBUILT_SHA256_ASSET = "llama-prebuilt-sha256.json"
 
 
 def _resolve_local_convert_script():
@@ -649,11 +655,11 @@ def _requests_get_with_retries(url, timeout = (10, 120), headers = None, stream 
     raise last_error
 
 
-def _resolve_llama_cpp_release():
+def _resolve_llama_cpp_release(releases_api = LLAMA_CPP_RELEASES_API):
     """Return (tag, {asset_name: download_url}) for the UNSLOTH_LLAMA_TAG
     pinned release or the latest one, or None when resolution fails."""
     tag = os.environ.get("UNSLOTH_LLAMA_TAG", "").strip()
-    url = f"{LLAMA_CPP_RELEASES_API}/tags/{tag}" if tag else f"{LLAMA_CPP_RELEASES_API}/latest"
+    url = f"{releases_api}/tags/{tag}" if tag else f"{releases_api}/latest"
     try:
         release = _requests_get_with_retries(url, headers = _github_auth_headers()).json()
         assets = {a["name"]: a["browser_download_url"] for a in release.get("assets", [])}
@@ -661,6 +667,125 @@ def _resolve_llama_cpp_release():
     except Exception as e:
         logger.warning("Unsloth: Could not resolve a llama.cpp release (%s).", e)
         return None
+
+
+def _fetch_release_json_asset(assets, asset_name):
+    url = assets.get(asset_name)
+    if not url:
+        return None
+    try:
+        return _requests_get_with_retries(url, headers = _github_auth_headers()).json()
+    except Exception as e:
+        logger.warning("Unsloth: Could not fetch %s (%s).", asset_name, e)
+        return None
+
+
+def _detect_gpu_target():
+    """Return ("cuda", sm, "cuda12"/"cuda13"/None) or ("rocm", "gfxNNNN")
+    from torch, or None when no GPU target is detectable."""
+    if torch is None:
+        return None
+    try:
+        if not torch.cuda.is_available():
+            return None
+        if getattr(torch.version, "hip", None):
+            gfx = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "") or ""
+            gfx = gfx.split(":")[0]
+            return ("rocm", gfx) if gfx.startswith("gfx") else None
+        major, minor = torch.cuda.get_device_capability(0)
+        cuda_version = getattr(torch.version, "cuda", None)
+        line = f"cuda{cuda_version.split('.')[0]}" if cuda_version else None
+        return ("cuda", major * 10 + minor, line)
+    except Exception:
+        return None
+
+
+def _rocm_gfx_family(gfx):
+    """Map a gcnArchName to the fork's per-family ROCm bundle suffix."""
+    if gfx in ("gfx1150", "gfx1151"):
+        return gfx
+    for prefix, family in (("gfx103", "gfx103X"), ("gfx110", "gfx110X"), ("gfx120", "gfx120X")):
+        if gfx.startswith(prefix):
+            return family
+    return None
+
+
+def _select_gpu_assets(tag, assets, manifest):
+    """Ordered download attempts [(asset_name, url), ...] of unslothai/llama.cpp
+    GPU bundles for this host: narrowest CUDA coverage for the torch runtime
+    line first, that line's portable build next, then the other line; ROCm by
+    gfx family; macOS by the fork's Metal bundles. Empty list = compile."""
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"): arch = "x64"
+    elif machine in ("aarch64", "arm64"): arch = "arm64"
+    else: return []
+    system = platform.system()
+
+    if system == "Darwin":
+        name = f"llama-{tag}-bin-macos-{arch}.tar.gz"
+        return [(name, assets[name])] if name in assets else []
+
+    target = _detect_gpu_target()
+    if target is None:
+        return []
+    artifacts = (manifest or {}).get("artifacts", [])
+
+    if target[0] == "rocm":
+        if arch != "x64":
+            return []
+        family = _rocm_gfx_family(target[1])
+        kind = "windows-rocm" if system == "Windows" else "linux-rocm"
+        if family is None:
+            return []
+        return [
+            (a["asset_name"], assets[a["asset_name"]])
+            for a in artifacts
+            if a.get("install_kind") == kind
+            and family in a.get("asset_name", "")
+            and a.get("asset_name") in assets
+        ]
+
+    _, sm, preferred_line = target
+    if system == "Windows":
+        kind = "windows-cuda"
+    elif system == "Linux":
+        kind = "linux-arm64-cuda" if arch == "arm64" else "linux-cuda"
+    else:
+        return []
+    kind_artifacts = [
+        a for a in artifacts
+        if a.get("install_kind") == kind and a.get("asset_name") in assets
+    ]
+    lines = [preferred_line] if preferred_line else []
+    lines += [l for l in ("cuda13", "cuda12") if l not in lines]
+
+    attempts = []
+    for line in lines:
+        covering = []
+        portable = None
+        for a in (a for a in kind_artifacts if a.get("runtime_line") == line):
+            supported = {int(s) for s in a.get("supported_sms", []) if str(s).isdigit()}
+            if sm not in supported:
+                continue
+            if a.get("coverage_class") == "portable":
+                portable = a
+            else:
+                covering.append(a)
+        covering.sort(key = lambda a: ((a.get("max_sm") or 0) - (a.get("min_sm") or 0), a.get("rank") or 0))
+        for a in covering[:1] + ([portable] if portable else []):
+            entry = (a["asset_name"], assets[a["asset_name"]])
+            if entry not in attempts:
+                attempts.append(entry)
+    return attempts
+
+
+def _sha256_file(path):
+    import hashlib
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _select_prebuilt_asset(tag, assets):
@@ -722,14 +847,17 @@ def _single_extracted_root(extract_dir):
 def _place_prebuilt_binaries(extracted_root, install_folder):
     """Copy executables + shared libs where check_llama_cpp/quantize_gguf
     look: folder root on Linux/macOS (RPATH $ORIGIN needs libs as siblings),
-    build/bin/Release on Windows."""
+    build/bin/Release on Windows. ROCm bundles also carry hipblaslt/ and
+    rocblas/ Tensile kernel trees that must sit next to the libs."""
     dest = os.path.join(install_folder, "build", "bin", "Release") if IS_WINDOWS else install_folder
     os.makedirs(dest, exist_ok = True)
     n_executables = 0
-    lib_suffixes = (".so", ".dylib", ".dll", ".metal", ".txt", ".md")
+    lib_suffixes = (".so", ".dylib", ".dll", ".metal", ".txt", ".md", ".json")
     for entry in sorted(os.listdir(extracted_root)):
         source = os.path.join(extracted_root, entry)
-        if not os.path.isfile(source):
+        if os.path.isdir(source):
+            if entry in ("hipblaslt", "rocblas"):
+                shutil.copytree(source, os.path.join(dest, entry), dirs_exist_ok = True)
             continue
         target = os.path.join(dest, entry)
         shutil.copy2(source, target)
@@ -764,10 +892,11 @@ def _hydrate_converter_sources(tag, install_folder):
             shutil.copytree(conversion, os.path.join(install_folder, "conversion"), dirs_exist_ok = True)
 
 
-def _write_prebuilt_marker(install_folder, tag, asset_name):
+def _write_prebuilt_marker(install_folder, tag, asset_name, repo = "ggml-org/llama.cpp"):
     try:
         info = {
-            "source"           : "ggml-org/llama.cpp official release",
+            "source"           : f"{repo} prebuilt release",
+            "repo"             : repo,
             "tag"              : tag,
             "asset"            : asset_name,
             "installed_at_utc" : time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -778,30 +907,21 @@ def _write_prebuilt_marker(install_folder, tag, asset_name):
         logger.warning("Unsloth: Could not write prebuilt marker (%s).", e)
 
 
-def _install_llama_cpp_prebuilt(llama_cpp_folder, print_output = False):
-    """Install official prebuilt llama.cpp binaries plus same-tag converter
-    sources into llama_cpp_folder. Returns (quantizer, converter) on success,
-    None on any failure so the caller compiles from source as before."""
-    staging = None
+def _stage_prebuilt_install(llama_cpp_folder, tag, asset_name, asset_url, expected_sha256 = None, repo = "ggml-org/llama.cpp"):
+    """Download one prebuilt asset, verify, hydrate, validate in staging,
+    then activate into llama_cpp_folder. Raises on any failure."""
+    parent_dir = os.path.dirname(llama_cpp_folder) or "."
+    os.makedirs(parent_dir, exist_ok = True)
+    # Stage next to the target so activation is an atomic same-fs move,
+    # and validate before touching the real folder.
+    staging = tempfile.mkdtemp(prefix = ".llama_cpp_prebuilt_", dir = parent_dir)
     try:
-        resolved = _resolve_llama_cpp_release()
-        if resolved is None:
-            return None
-        tag, assets = resolved
-        selected = _select_prebuilt_asset(tag, assets)
-        if selected is None:
-            logger.warning("Unsloth: No prebuilt llama.cpp asset for this platform in release %s.", tag)
-            return None
-        asset_name, asset_url = selected
-        print(f"Unsloth: Installing prebuilt llama.cpp {tag} ({asset_name}) - skipping compilation.")
-
-        parent_dir = os.path.dirname(llama_cpp_folder) or "."
-        os.makedirs(parent_dir, exist_ok = True)
-        # Stage next to the target so activation is an atomic same-fs move,
-        # and validate before touching the real folder.
-        staging = tempfile.mkdtemp(prefix = ".llama_cpp_prebuilt_", dir = parent_dir)
         archive_path = os.path.join(staging, asset_name)
         _download_archive(asset_url, archive_path)
+        if expected_sha256:
+            actual = _sha256_file(archive_path)
+            if actual != expected_sha256:
+                raise RuntimeError(f"Unsloth: sha256 mismatch for {asset_name}: expected {expected_sha256}, got {actual}")
         extract_dir = os.path.join(staging, "extracted")
         os.makedirs(extract_dir)
         _extract_archive(archive_path, extract_dir)
@@ -809,7 +929,7 @@ def _install_llama_cpp_prebuilt(llama_cpp_folder, print_output = False):
         os.makedirs(staged_install)
         _place_prebuilt_binaries(_single_extracted_root(extract_dir), staged_install)
         _hydrate_converter_sources(tag, staged_install)
-        _write_prebuilt_marker(staged_install, tag, asset_name)
+        _write_prebuilt_marker(staged_install, tag, asset_name, repo = repo)
         check_llama_cpp(llama_cpp_folder = staged_install)
 
         if not os.path.exists(llama_cpp_folder):
@@ -818,32 +938,78 @@ def _install_llama_cpp_prebuilt(llama_cpp_folder, print_output = False):
             # Folder exists with broken/missing binaries: merge into it
             # rather than deleting a tree the user may own.
             shutil.copytree(staged_install, llama_cpp_folder, dirs_exist_ok = True)
-
-        try:
-            try_execute(f"{check_pip()} install gguf protobuf sentencepiece mistral_common", print_output = print_output)
-        except Exception as e:
-            logger.warning("Unsloth: Converter dependency install failed (%s); conversion self-heals if needed.", e)
-
         return check_llama_cpp(llama_cpp_folder = llama_cpp_folder)
+    finally:
+        shutil.rmtree(staging, ignore_errors = True)
+
+
+def _install_llama_cpp_prebuilt(llama_cpp_folder, gpu_support = False, print_output = False):
+    """Install prebuilt llama.cpp binaries plus same-tag converter sources
+    into llama_cpp_folder. CPU builds come from ggml-org releases; GPU builds
+    from the unslothai/llama.cpp bundles Studio publishes. Returns
+    (quantizer, converter) on success, None on any failure so the caller
+    compiles from source as before."""
+    try:
+        if gpu_support:
+            # Cheap host check before any network: no detectable GPU target
+            # (and not macOS Metal) means no bundle could match.
+            if platform.system() != "Darwin" and _detect_gpu_target() is None:
+                logger.warning("Unsloth: gpu_support requested but no GPU target detected - compiling instead.")
+                return None
+            repo = "unslothai/llama.cpp"
+            resolved = _resolve_llama_cpp_release(LLAMA_CPP_PUBLISHED_RELEASES_API)
+            if resolved is None:
+                return None
+            tag, assets = resolved
+            manifest = _fetch_release_json_asset(assets, LLAMA_CPP_PREBUILT_MANIFEST_ASSET)
+            checksums = _fetch_release_json_asset(assets, LLAMA_CPP_PREBUILT_SHA256_ASSET) or {}
+            checksums = checksums.get("artifacts", {})
+            attempts = _select_gpu_assets(tag, assets, manifest)
+            if not attempts:
+                logger.warning("Unsloth: No prebuilt GPU llama.cpp bundle matches this host in release %s.", tag)
+                return None
+        else:
+            repo = "ggml-org/llama.cpp"
+            resolved = _resolve_llama_cpp_release()
+            if resolved is None:
+                return None
+            tag, assets = resolved
+            checksums = {}
+            selected = _select_prebuilt_asset(tag, assets)
+            if selected is None:
+                logger.warning("Unsloth: No prebuilt llama.cpp asset for this platform in release %s.", tag)
+                return None
+            attempts = [selected]
+
+        for asset_name, asset_url in attempts:
+            print(f"Unsloth: Installing prebuilt llama.cpp {tag} ({asset_name}) - skipping compilation.")
+            try:
+                result = _stage_prebuilt_install(
+                    llama_cpp_folder, tag, asset_name, asset_url,
+                    expected_sha256 = (checksums.get(asset_name) or {}).get("sha256"),
+                    repo = repo,
+                )
+            except Exception as e:
+                logger.warning("Unsloth: Prebuilt %s failed (%s) - trying next option.", asset_name, e)
+                continue
+            try:
+                try_execute(f"{check_pip()} install gguf protobuf sentencepiece mistral_common", print_output = print_output)
+            except Exception as e:
+                logger.warning("Unsloth: Converter dependency install failed (%s); conversion self-heals if needed.", e)
+            return result
+        return None
     except Exception as e:
         logger.warning("Unsloth: Prebuilt llama.cpp install failed (%s) - falling back to source build.", e)
         return None
-    finally:
-        if staging and os.path.exists(staging):
-            shutil.rmtree(staging, ignore_errors = True)
 
 
 def _maybe_install_llama_cpp_prebuilt(llama_cpp_folder, gpu_support = False, print_output = False):
-    """Gate for the prebuilt path. Skipped when the caller asked for GPU
-    builds (official releases ship no Linux CUDA binaries, and gpu_support
-    means compiled CUDA targets were requested) or when
-    UNSLOTH_LLAMA_FORCE_COMPILE is set."""
+    """Gate for the prebuilt path; UNSLOTH_LLAMA_FORCE_COMPILE=1 always
+    compiles. No exception ever propagates to install_llama_cpp."""
     try:
-        if gpu_support:
-            return None
         if os.environ.get("UNSLOTH_LLAMA_FORCE_COMPILE", "0").lower() in ("1", "true", "yes", "on"):
             return None
-        return _install_llama_cpp_prebuilt(llama_cpp_folder, print_output = print_output)
+        return _install_llama_cpp_prebuilt(llama_cpp_folder, gpu_support = gpu_support, print_output = print_output)
     except Exception as e:
         logger.warning("Unsloth: Prebuilt llama.cpp path errored (%s) - falling back to source build.", e)
         return None

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -43,6 +43,9 @@ import tempfile
 import logging
 import shlex
 import shutil
+import tarfile
+import zipfile
+import platform
 try:
     import torch
 except ImportError:
@@ -133,6 +136,12 @@ LLAMA_CPP_DEFAULT_DIR = os.environ.get(
     "UNSLOTH_LLAMA_CPP_PATH",
     os.path.join(UNSLOTH_HOME, "llama.cpp"),
 )
+
+# Prebuilt llama.cpp binaries from official releases. Marker file
+# distinguishes a prebuilt install from a corrupted source checkout.
+UNSLOTH_PREBUILT_INFO_FILENAME = "UNSLOTH_PREBUILT_INFO.json"
+LLAMA_CPP_RELEASES_API = "https://api.github.com/repos/ggml-org/llama.cpp/releases"
+LLAMA_CPP_SOURCE_TARBALL = "https://codeload.github.com/ggml-org/llama.cpp/tar.gz/refs/tags/{tag}"
 
 
 def _resolve_local_convert_script():
@@ -615,6 +624,231 @@ def _is_safe_to_delete(path):
     return False
 
 
+def _github_auth_headers():
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _requests_get_with_retries(url, timeout = (10, 120), headers = None, stream = False, max_attempts = 3):
+    last_error = None
+    for attempt in range(max_attempts):
+        try:
+            response = requests.get(url, timeout = timeout, headers = headers, stream = stream)
+            if response.status_code in (403, 429):
+                logger.warning(
+                    "Unsloth: GitHub returned HTTP %s for %s. "
+                    "Set GH_TOKEN or GITHUB_TOKEN to raise the rate limit.",
+                    response.status_code, url,
+                )
+            response.raise_for_status()
+            return response
+        except requests.exceptions.RequestException as e:
+            last_error = e
+            if attempt + 1 < max_attempts:
+                time.sleep(2 ** attempt)
+    raise last_error
+
+
+def _resolve_llama_cpp_release():
+    """Return (tag, {asset_name: download_url}) for the UNSLOTH_LLAMA_TAG
+    pinned release or the latest one, or None when resolution fails."""
+    tag = os.environ.get("UNSLOTH_LLAMA_TAG", "").strip()
+    url = f"{LLAMA_CPP_RELEASES_API}/tags/{tag}" if tag else f"{LLAMA_CPP_RELEASES_API}/latest"
+    try:
+        release = _requests_get_with_retries(url, headers = _github_auth_headers()).json()
+        assets = {a["name"]: a["browser_download_url"] for a in release.get("assets", [])}
+        return release["tag_name"], assets
+    except Exception as e:
+        logger.warning("Unsloth: Could not resolve a llama.cpp release (%s).", e)
+        return None
+
+
+def _select_prebuilt_asset(tag, assets):
+    """Map this host to the official CPU archive. llama-quantize is CPU-only,
+    so the CPU bundle suffices even on GPU machines. Returns (name, url) or
+    None for unsupported platforms or releases missing the asset."""
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"): arch = "x64"
+    elif machine in ("aarch64", "arm64"): arch = "arm64"
+    else: return None
+    name = {
+        ("Linux",   "x64")   : f"llama-{tag}-bin-ubuntu-x64.tar.gz",
+        ("Linux",   "arm64") : f"llama-{tag}-bin-ubuntu-arm64.tar.gz",
+        ("Darwin",  "x64")   : f"llama-{tag}-bin-macos-x64.tar.gz",
+        ("Darwin",  "arm64") : f"llama-{tag}-bin-macos-arm64.tar.gz",
+        ("Windows", "x64")   : f"llama-{tag}-bin-win-cpu-x64.zip",
+        ("Windows", "arm64") : f"llama-{tag}-bin-win-cpu-arm64.zip",
+    }.get((platform.system(), arch))
+    if name is None or name not in assets:
+        return None
+    return name, assets[name]
+
+
+def _download_archive(url, dest_path):
+    response = _requests_get_with_retries(url, headers = _github_auth_headers(), stream = True)
+    with open(dest_path, "wb") as f:
+        for chunk in response.iter_content(chunk_size = 1 << 20):
+            f.write(chunk)
+
+
+def _extract_archive(archive_path, extract_dir):
+    """Extract a release .zip / .tar.gz, refusing path-escaping members."""
+    real_root = os.path.realpath(extract_dir)
+    def _check(name):
+        target = os.path.realpath(os.path.join(extract_dir, name))
+        if target != real_root and not target.startswith(real_root + os.sep):
+            raise RuntimeError(f"Unsloth: Archive member escapes extraction dir: {name}")
+    if archive_path.endswith(".zip"):
+        with zipfile.ZipFile(archive_path) as archive:
+            for member in archive.namelist(): _check(member)
+            archive.extractall(extract_dir)
+    else:
+        tar_kwargs = {"filter": "data"} if sys.version_info >= (3, 12) else {}
+        with tarfile.open(archive_path, "r:gz") as archive:
+            for member in archive.getmembers(): _check(member.name)
+            archive.extractall(extract_dir, **tar_kwargs)
+
+
+def _single_extracted_root(extract_dir):
+    """Release archives nest contents under llama-{tag}/ (source tarballs
+    under llama.cpp-{tag}/); flat archives extract in place."""
+    entries = [os.path.join(extract_dir, e) for e in os.listdir(extract_dir)]
+    dirs = [e for e in entries if os.path.isdir(e)]
+    if len(dirs) == 1 and len(entries) == 1:
+        return dirs[0]
+    return extract_dir
+
+
+def _place_prebuilt_binaries(extracted_root, install_folder):
+    """Copy executables + shared libs where check_llama_cpp/quantize_gguf
+    look: folder root on Linux/macOS (RPATH $ORIGIN needs libs as siblings),
+    build/bin/Release on Windows."""
+    dest = os.path.join(install_folder, "build", "bin", "Release") if IS_WINDOWS else install_folder
+    os.makedirs(dest, exist_ok = True)
+    n_executables = 0
+    lib_suffixes = (".so", ".dylib", ".dll", ".metal", ".txt", ".md")
+    for entry in sorted(os.listdir(extracted_root)):
+        source = os.path.join(extracted_root, entry)
+        if not os.path.isfile(source):
+            continue
+        target = os.path.join(dest, entry)
+        shutil.copy2(source, target)
+        is_lib = entry.startswith("lib") or any(s in entry for s in lib_suffixes)
+        if not is_lib:
+            if not IS_WINDOWS:
+                os.chmod(target, 0o755)
+            n_executables += 1
+    if n_executables == 0:
+        raise RuntimeError("Unsloth: No executables found in the prebuilt archive.")
+
+
+def _hydrate_converter_sources(tag, install_folder):
+    """Copy convert_hf_to_gguf.py, conversion/ and gguf-py/ from the same-tag
+    source tarball so check_llama_cpp and the converter machinery work
+    without a git checkout, and tensor mappings match the binaries."""
+    with tempfile.TemporaryDirectory(dir = os.path.dirname(install_folder) or ".") as source_dir:
+        archive_path = os.path.join(source_dir, "source.tar.gz")
+        _download_archive(LLAMA_CPP_SOURCE_TARBALL.format(tag = tag), archive_path)
+        extract_dir = os.path.join(source_dir, "extracted")
+        os.makedirs(extract_dir)
+        _extract_archive(archive_path, extract_dir)
+        root = _single_extracted_root(extract_dir)
+        converter = os.path.join(root, "convert_hf_to_gguf.py")
+        gguf_py = os.path.join(root, "gguf-py")
+        if not (os.path.isfile(converter) and os.path.isdir(gguf_py)):
+            raise RuntimeError(f"Unsloth: Source tarball for {tag} is missing converter files.")
+        shutil.copy2(converter, os.path.join(install_folder, "convert_hf_to_gguf.py"))
+        shutil.copytree(gguf_py, os.path.join(install_folder, "gguf-py"), dirs_exist_ok = True)
+        conversion = os.path.join(root, "conversion")
+        if os.path.isdir(conversion):
+            shutil.copytree(conversion, os.path.join(install_folder, "conversion"), dirs_exist_ok = True)
+
+
+def _write_prebuilt_marker(install_folder, tag, asset_name):
+    try:
+        info = {
+            "source"           : "ggml-org/llama.cpp official release",
+            "tag"              : tag,
+            "asset"            : asset_name,
+            "installed_at_utc" : time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        with open(os.path.join(install_folder, UNSLOTH_PREBUILT_INFO_FILENAME), "w", encoding = "utf-8") as f:
+            json.dump(info, f, indent = 2)
+    except Exception as e:
+        logger.warning("Unsloth: Could not write prebuilt marker (%s).", e)
+
+
+def _install_llama_cpp_prebuilt(llama_cpp_folder, print_output = False):
+    """Install official prebuilt llama.cpp binaries plus same-tag converter
+    sources into llama_cpp_folder. Returns (quantizer, converter) on success,
+    None on any failure so the caller compiles from source as before."""
+    staging = None
+    try:
+        resolved = _resolve_llama_cpp_release()
+        if resolved is None:
+            return None
+        tag, assets = resolved
+        selected = _select_prebuilt_asset(tag, assets)
+        if selected is None:
+            logger.warning("Unsloth: No prebuilt llama.cpp asset for this platform in release %s.", tag)
+            return None
+        asset_name, asset_url = selected
+        print(f"Unsloth: Installing prebuilt llama.cpp {tag} ({asset_name}) - skipping compilation.")
+
+        parent_dir = os.path.dirname(llama_cpp_folder) or "."
+        os.makedirs(parent_dir, exist_ok = True)
+        # Stage next to the target so activation is an atomic same-fs move,
+        # and validate before touching the real folder.
+        staging = tempfile.mkdtemp(prefix = ".llama_cpp_prebuilt_", dir = parent_dir)
+        archive_path = os.path.join(staging, asset_name)
+        _download_archive(asset_url, archive_path)
+        extract_dir = os.path.join(staging, "extracted")
+        os.makedirs(extract_dir)
+        _extract_archive(archive_path, extract_dir)
+        staged_install = os.path.join(staging, "install")
+        os.makedirs(staged_install)
+        _place_prebuilt_binaries(_single_extracted_root(extract_dir), staged_install)
+        _hydrate_converter_sources(tag, staged_install)
+        _write_prebuilt_marker(staged_install, tag, asset_name)
+        check_llama_cpp(llama_cpp_folder = staged_install)
+
+        if not os.path.exists(llama_cpp_folder):
+            shutil.move(staged_install, llama_cpp_folder)
+        else:
+            # Folder exists with broken/missing binaries: merge into it
+            # rather than deleting a tree the user may own.
+            shutil.copytree(staged_install, llama_cpp_folder, dirs_exist_ok = True)
+
+        try:
+            try_execute(f"{check_pip()} install gguf protobuf sentencepiece mistral_common", print_output = print_output)
+        except Exception as e:
+            logger.warning("Unsloth: Converter dependency install failed (%s); conversion self-heals if needed.", e)
+
+        return check_llama_cpp(llama_cpp_folder = llama_cpp_folder)
+    except Exception as e:
+        logger.warning("Unsloth: Prebuilt llama.cpp install failed (%s) - falling back to source build.", e)
+        return None
+    finally:
+        if staging and os.path.exists(staging):
+            shutil.rmtree(staging, ignore_errors = True)
+
+
+def _maybe_install_llama_cpp_prebuilt(llama_cpp_folder, gpu_support = False, print_output = False):
+    """Gate for the prebuilt path. Skipped when the caller asked for GPU
+    builds (official releases ship no Linux CUDA binaries, and gpu_support
+    means compiled CUDA targets were requested) or when
+    UNSLOTH_LLAMA_FORCE_COMPILE is set."""
+    try:
+        if gpu_support:
+            return None
+        if os.environ.get("UNSLOTH_LLAMA_FORCE_COMPILE", "0").lower() in ("1", "true", "yes", "on"):
+            return None
+        return _install_llama_cpp_prebuilt(llama_cpp_folder, print_output = print_output)
+    except Exception as e:
+        logger.warning("Unsloth: Prebuilt llama.cpp path errored (%s) - falling back to source build.", e)
+        return None
+
+
 def install_llama_cpp(
     llama_cpp_folder = LLAMA_CPP_DEFAULT_DIR,
     llama_cpp_targets = LLAMA_CPP_TARGETS,
@@ -653,9 +887,12 @@ def install_llama_cpp(
             pass  # CWD copy is broken, proceed with default location
 
     if os.path.exists(llama_cpp_folder):
-        # Repo integrity check -- key directories must exist
+        # Repo integrity check -- a source checkout has src/ggml/common; a
+        # prebuilt install instead carries the UNSLOTH_PREBUILT_INFO.json marker
         required_dirs = ['src', 'ggml', 'common']
-        if not all(os.path.isdir(os.path.join(llama_cpp_folder, d)) for d in required_dirs):
+        is_source_checkout = all(os.path.isdir(os.path.join(llama_cpp_folder, d)) for d in required_dirs)
+        is_prebuilt_install = os.path.isfile(os.path.join(llama_cpp_folder, UNSLOTH_PREBUILT_INFO_FILENAME))
+        if not (is_source_checkout or is_prebuilt_install):
             print("Unsloth: llama.cpp repo appears corrupted (missing src/ggml/common) - will re-clone")
             # C4: Only delete if the path is safe
             if _is_safe_to_delete(llama_cpp_folder):
@@ -681,6 +918,17 @@ def install_llama_cpp(
         needs_clone = True
         needs_build = True
     pass
+
+    # Prefer official prebuilt binaries before any source-build work
+    # (no system package installs, no clone, no compile).
+    if needs_build and not just_clone_repo:
+        prebuilt = _maybe_install_llama_cpp_prebuilt(
+            llama_cpp_folder,
+            gpu_support = (gpu_support == "ON"),
+            print_output = print_output,
+        )
+        if prebuilt is not None:
+            return prebuilt
 
     print_outputs = []
     missing_packages, system_type = check_build_requirements()


### PR DESCRIPTION
## What

`install_llama_cpp` currently clones llama.cpp and compiles it from source. This PR makes it install prebuilt binaries first, with the existing clone and compile flow kept unchanged as the fallback:

- CPU installs (the `save_pretrained_gguf` path, which forces `gpu_support=False` since `llama-quantize` is CPU-only) use the official CPU archives from ggml-org/llama.cpp GitHub releases
- GPU installs (`gpu_support=True`) use the same prebuilt CUDA/ROCm/Metal bundles Unsloth Studio publishes on unslothai/llama.cpp, selected via the release manifest and verified against its published sha256 list

## How

CPU path (upstream ggml-org releases):
- Resolve the latest release tag (or an `UNSLOTH_LLAMA_TAG` pin) through the GitHub API, using `GH_TOKEN`/`GITHUB_TOKEN` when set
- Select the CPU asset for the host: `ubuntu-x64`/`ubuntu-arm64` tar.gz on Linux, `macos-arm64`/`macos-x64` tar.gz on macOS, `win-cpu-x64`/`win-cpu-arm64` zip on Windows

GPU path (unslothai/llama.cpp bundles, same source as Studio):
- CUDA: read `llama-prebuilt-manifest.json` and pick the narrowest coverage bundle whose supported SMs include the host GPU (torch device capability), preferring the runtime line that matches torch's CUDA major; that line's portable build and the other line are queued as follow-up attempts
- ROCm: map `gcnArchName` to the per-gfx family bundles and copy the hipblaslt/rocblas Tensile kernel trees next to the libs
- macOS: the fork's Metal bundles, no torch detection needed
- Verify downloads against `llama-prebuilt-sha256.json` before extraction

Shared machinery:
- Download and extract into a staging dir (path-traversal guarded), place binaries and shared libs where `check_llama_cpp` and `quantize_gguf` already look (folder root on Linux/macOS for the `$ORIGIN` RPATH, `build/bin/Release` on Windows)
- Hydrate `convert_hf_to_gguf.py`, `conversion/` and `gguf-py/` from the same tag's source tarball so the converter machinery and tensor mappings stay consistent with the binaries
- Validate `llama-quantize --help` in staging before activating atomically, then write an `UNSLOTH_PREBUILT_INFO.json` marker recording repo, tag and asset
- Teach the folder integrity check to accept marker-bearing installs; prebuilt folders lack the `src`/`ggml`/`common` dirs of a checkout and were previously rmtree'd as corrupted on the next call
- Every failure (rate limit, missing asset, corrupt archive, checksum mismatch, bundle that cannot load on the host) logs the reason and advances to the next candidate and ultimately to the unchanged compile path; `UNSLOTH_LLAMA_FORCE_COMPILE=1` bypasses prebuilts entirely

## Verification

- 27 CPU tests in `tests/test_llama_cpp_prebuilt.py` (asset selection matrices for CPU and GPU, runtime-line preference, ROCm family mapping, macOS routing, tag pinning, gates, extraction safety, mocked full installs, sha256 mismatch and other fallback drills, reuse without deletion); 102 tests pass across the llama_cpp suites
- Live CPU on Linux x64: prebuilt install of `b9596` completes in about 4 seconds versus minutes of cloning plus compiling; second call reuses the install
- Live GPU on a B200 (SM 100, torch CUDA 12.8): selects `app-b9585-linux-x64-cuda12-newer.tar.gz`, installs in 12 seconds versus a much longer CUDA source build, `llama-quantize` validates, and `llama-server --list-devices` enumerates the GPU through the bundled CUDA backend
- End to end with the Llama 3.2 3B conversational notebook flow: trained 60 steps, exported `q4_k_m` twice, once with a compiled llama.cpp and once through the prebuilt path on a fresh dir. The prebuilt run shows zero clone or cmake/make activity and the two Q4_K_M GGUFs are byte-identical in size (2,019,378,176 bytes)
- Fallback drills: a bogus `UNSLOTH_LLAMA_TAG` falls back cleanly without creating the target folder, and `UNSLOTH_LLAMA_FORCE_COMPILE=1` skips the prebuilt path
