### PR TITLE
Bump version to 2026.6.3

### DIFF
--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__version__ = "2026.6.2"
+__version__ = "2026.6.3"
 
 import os
 import warnings


### PR DESCRIPTION
Bump to 2026.6.3 for the Gemma 4 audio fix train. Changes since 2026.6.2:

- Keep audio feature extractors right padded in UnslothVisionDataCollator (#747): fixes the Gemma 4 audio SFT crash on transformers 5.5.0 to 5.9.x and aligns 5.10+ token counts with stock transformers
- Route mm_token_type_ids through prompt-completion collation (#756): fixes silent attention mis-masking on Gemma 4 12B/26B/31B prompt-completion datasets
- Make UNSLOTH_COMPILE_DISABLE=1 dtype-safe for fp32 upcast norms (#758): fixes the eager escape hatch crash for Gemma 4 audio, Gemma 3 SigLIP, and other high-precision-layernorm families
- Fix GPU-less import of gpt_oss.py and tighten gpt-oss name detection (#744)
- Resolve file:// URIs per RFC 8089 in media readers (#745)
- CI: execute use_cache and mlx finetune_last_n_layers tests as a hard gate (#755)

Post-merge main was validated end to end on gemma-4-E2B-it with transformers 5.5.0: the 9-combination clip-length probe passes 9/9, a 20-step LibriSpeech SFT smoke converges (loss 5.12 to 0.96), the eager path passes, and the default compiled path is bit-identical to the pre-merge baseline. Full CPU suite: 1346 passed.