### PR TITLE
Make the generated EmptyLogits sentinel picklable and comparable for accelerate debug mode

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1550,6 +1550,11 @@ class EmptyLogits:
     __getattr__ = raise_getattr_error
     def __repr__(self): return LOGITS_ERROR_STRING
     def __str__ (self): return LOGITS_ERROR_STRING
+    # Stateless pickling so accelerate gather_object works on the sentinel
+    def __reduce__(self): return (type(self), ())
+    # Gathered copies must compare equal in accelerate debug mode
+    def __eq__(self, other): return type(other).__name__ == "EmptyLogits"
+    __hash__ = object.__hash__
 pass
 EMPTY_LOGITS = EmptyLogits()
 functions = dir(torch.Tensor)
@@ -1558,6 +1563,11 @@ for j, function in enumerate(functions):
         exec(f"def raise_{j}(*args, **kwargs): print('{function}')", globals(), locals())
         try: exec(f"EMPTY_LOGITS.{function} = raise_{j}", globals(), locals())
         except: continue
+pass
+# The loop above stomps pickle hooks with stubs returning None; restore them.
+for function in ("__reduce__", "__reduce_ex__", "__getstate__", "__setstate__"):
+    try: delattr(EMPTY_LOGITS, function)
+    except Exception: pass
 pass
 
 


### PR DESCRIPTION
Companion to unslothai/unsloth#6092.

The `_cross_entropy_code` template stamps an `EmptyLogits` class into every compiled module, and the dunder stub loop right after it stomps the singleton's pickle hooks with stubs that return None. Two consequences in Accelerate debug mode (`ACCELERATE_DEBUG_MODE=1`) on real distributed runs:

- `verify_operation` calls `gather_object` on shape metadata, which pickles the sentinel and raises `PicklingError: __reduce__ must return a string or tuple`.
- Gathered copies on different ranks compared unequal (default identity equality), producing spurious `DistributedOperationException` shape mismatch errors.

### Changes

All inside the `_cross_entropy_code` template, so every regenerated compiled module picks them up:

- `EmptyLogits.__reduce__` returns `(type(self), ())` for stateless pickling.
- `EmptyLogits.__eq__` compares by type name so gathered copies (and the unsloth side `EmptyLogits`) compare equal; `__hash__` is restored explicitly since a class body `__eq__` would otherwise null it.
- The stomped `__reduce__`, `__reduce_ex__`, `__getstate__`, `__setstate__` instance stubs are removed from `EMPTY_LOGITS` after the loop.

### Verification

Regenerated compiled modules for Qwen3 (`unsloth_compiled_module_qwen3`, `unsloth_compiled_module_siglip`) with this branch:

- `pickle.loads(pickle.dumps(EMPTY_LOGITS))` round trips and the copy compares equal to the original in both directions, including against `unsloth.models._utils.EMPTY_LOGITS`.
- `hash()` and dict/set membership still work.
- The instructive `UNSLOTH_RETURN_LOGITS` error message is preserved for tensor style access on unpickled copies.
- `compiler.py` and the extracted template both pass AST parsing; the template executes inside generated modules unchanged otherwise.

unslothai/unsloth#6092 contains the matching fix for the unsloth side `EmptyLogits` plus the accelerate `recursively_apply` / `find_device` patch and its startup wiring; the 2 process NCCL and gloo debug mode runs over there exercise this same flow end to end.
