### PR TITLE
fix: decode llama.cpp subprocess output as UTF-8 on Windows

### DIFF
--- a/tests/test_llama_cpp_subprocess_utf8_encoding.py
+++ b/tests/test_llama_cpp_subprocess_utf8_encoding.py
@@ -1,0 +1,125 @@
+# Regression tests for the Windows UnicodeDecodeError class in the llama.cpp
+# build/run path (unslothai/unsloth#2660).
+#
+# On Windows the default text encoding is the locale code page (e.g. cp1252),
+# not UTF-8. ``subprocess.run`` / ``subprocess.Popen`` opened in text mode
+# (``text=True`` / ``universal_newlines=True``) without an explicit
+# ``encoding`` therefore decode child output with cp1252. The llama.cpp
+# clone/cmake/quantize/convert pipeline emits non-ASCII content -- localized
+# compiler/cmake messages, progress / box-drawing glyphs, and model/tensor
+# names or file paths (e.g. ``C:\\Users\\Jose\\...``). When a byte undefined
+# in cp1252 appears (e.g. ``0x9d``, which sits inside the UTF-8 encoding of
+# common punctuation), the read raises ``UnicodeDecodeError`` and aborts the
+# build/quantize/convert.
+#
+# ``test_llama_cpp_subprocess_text_calls_declare_utf8_encoding`` is a
+# source-level drift detector: it parses ``unsloth_zoo/llama_cpp.py`` (no
+# import, so it needs neither torch nor a built llama.cpp) and fails if any
+# text-mode subprocess call is missing ``encoding="utf-8"``. Red before the
+# fix, green after.
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+LLAMA_CPP = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "llama_cpp.py"
+
+
+def _is_subprocess_call(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in {"Popen", "run"}
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "subprocess"
+    )
+
+
+def _kw(node: ast.Call, name: str):
+    for kw in node.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _is_true(value) -> bool:
+    return isinstance(value, ast.Constant) and value.value is True
+
+
+def _is_text_mode(node: ast.Call) -> bool:
+    return _is_true(_kw(node, "text")) or _is_true(_kw(node, "universal_newlines"))
+
+
+def _text_mode_subprocess_calls() -> list[ast.Call]:
+    tree = ast.parse(LLAMA_CPP.read_text(encoding="utf-8"), filename=str(LLAMA_CPP))
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_subprocess_call(node) and _is_text_mode(node)
+    ]
+
+
+def test_text_mode_subprocess_calls_exist():
+    # Guard the guard: if llama_cpp.py stops using text-mode subprocess calls
+    # the drift test would pass vacuously.
+    calls = _text_mode_subprocess_calls()
+    assert len(calls) >= 8, (
+        f"Expected many text-mode subprocess calls in {LLAMA_CPP.name}, "
+        f"found {len(calls)} -- has the file been restructured?"
+    )
+
+
+def test_llama_cpp_subprocess_text_calls_declare_utf8_encoding():
+    """Every text-mode subprocess call in llama_cpp.py must pin encoding='utf-8'.
+
+    Without it, reading llama.cpp build/quantize/convert output crashes on
+    Windows (cp1252). Fails before the #2660 fix, passes after.
+    """
+    offenders = []
+    for node in _text_mode_subprocess_calls():
+        enc = _kw(node, "encoding")
+        if not (isinstance(enc, ast.Constant) and enc.value == "utf-8"):
+            offenders.append(node.lineno)
+
+    assert not offenders, (
+        "Text-mode subprocess call(s) in unsloth_zoo/llama_cpp.py missing "
+        'encoding="utf-8" (UnicodeDecodeError on Windows, #2660) at line(s): '
+        + ", ".join(map(str, sorted(offenders)))
+    )
+
+
+def test_utf8_replace_decodes_non_cp1252_subprocess_output():
+    """Document the failure and the fix with a real subprocess.
+
+    The child emits U+201D (right double quote), whose UTF-8 encoding
+    ``E2 80 9D`` contains byte 0x9D -- undefined in cp1252. Decoding the raw
+    bytes as cp1252 raises (the bug); the kwargs the fix adds read it cleanly.
+    """
+    child = (
+        "import sys; "
+        "sys.stdout.buffer.write(('tensor ' + chr(0x201D) + ' x\\n').encode('utf-8'))"
+    )
+
+    raw = subprocess.run([sys.executable, "-c", child], capture_output=True).stdout
+    assert b"\x9d" in raw  # precondition: output carries the cp1252-undefined byte
+
+    # Failing behaviour before the fix: cp1252 (the Windows default) cannot
+    # decode this output.
+    with pytest.raises(UnicodeDecodeError):
+        raw.decode("cp1252")
+
+    # Correct behaviour after the fix: the kwargs llama_cpp.py now uses.
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.stdout.startswith("tensor ")
+    assert "”" in result.stdout

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -266,7 +266,7 @@ def install_package(package, sudo = False, print_output = False, print_outputs =
                 '--accept-source-agreements',
             ] + extra_args
 
-            result = subprocess.run(cmd, capture_output=True, text=True)
+            result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
             if result.returncode != 0:
                 raise RuntimeError(
                     f"Unsloth: Failed to install {winget_id} via winget.\n"
@@ -421,6 +421,8 @@ def check_pip():
             stdout = subprocess.PIPE,
             stderr = subprocess.STDOUT,
             text = True,
+            encoding = "utf-8",
+            errors = "replace",
         )
         output = probe.stdout or ""
 
@@ -439,7 +441,7 @@ pass
 def try_execute(command, sudo = False, print_output = False, print_outputs = None, cwd = None, system_type = "debian", ignore_deprecation = False):
     # All Unsloth Zoo code licensed under LGPLv3
 
-    with subprocess.Popen(command, shell = True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT, cwd = cwd, text=True) as sp:
+    with subprocess.Popen(command, shell = True, stdout = subprocess.PIPE, stderr = subprocess.STDOUT, cwd = cwd, text=True, encoding="utf-8", errors="replace") as sp:
         stdout, stderr = sp.communicate()
         stdout = stdout or ""
         stderr = stderr or ""
@@ -529,7 +531,7 @@ def _find_lib_path(lib_name):
     try:
         result = subprocess.run(
             ['gcc', f'-print-file-name={lib_name}'],
-            capture_output=True, text=True
+            capture_output=True, text=True, encoding="utf-8", errors="replace"
         )
         path = os.path.realpath(result.stdout.strip())
         if os.path.isabs(path) and os.path.exists(path):
@@ -589,6 +591,8 @@ def check_llama_cpp(llama_cpp_folder = LLAMA_CPP_DEFAULT_DIR):
                     [location, "--help"],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=5
                 )
                 if result.returncode == 0 or "usage" in result.stdout.lower() or "usage" in result.stderr.lower():
@@ -1201,7 +1205,7 @@ def install_llama_cpp(
                 print(f"Unsloth: cmake configure with {cmake_generator}")
                 print(f"Unsloth: cmake args: {' '.join(cmake_args)}")
 
-            result = subprocess.run(cmake_args, capture_output=True, text=True)
+            result = subprocess.run(cmake_args, capture_output=True, text=True, encoding="utf-8", errors="replace")
             if result.returncode != 0:
                 raise RuntimeError(
                     f"cmake configure failed (exit {result.returncode}):\n"
@@ -1216,7 +1220,7 @@ def install_llama_cpp(
 
             if print_output: print("Unsloth: Building llama.cpp (this may take several minutes)...")
 
-            result = subprocess.run(build_cmd, capture_output=True, text=True)
+            result = subprocess.run(build_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
             if result.returncode != 0:
                 raise RuntimeError(
                     f"cmake build failed (exit {result.returncode}):\n"
@@ -1909,6 +1913,8 @@ def _convert_to_gguf(command, output_filename, print_output = False, print_outpu
         stdout = subprocess.PIPE,
         stderr = subprocess.STDOUT,
         universal_newlines = True,
+        encoding = "utf-8",
+        errors = "replace",
         shell = True,
     )
     ProgressBar._instances.clear()
@@ -2574,7 +2580,7 @@ def check_build_requirements():
 
     for tool, package in required_tools.items():
         try:
-            result = subprocess.run(['which', tool], capture_output=True, text=True)
+            result = subprocess.run(['which', tool], capture_output=True, text=True, encoding="utf-8", errors="replace")
             if result.returncode != 0:
                 # Adjust package names for non-Debian systems
                 if system_type == "rpm":
@@ -2630,7 +2636,7 @@ def check_libcurl_dev():
     if system_type == "debian":
         package_name = "libcurl4-openssl-dev"
         try:
-            result = subprocess.run(['dpkg','-l', package_name], capture_output = True, text = True)
+            result = subprocess.run(['dpkg','-l', package_name], capture_output = True, text = True, encoding = "utf-8", errors = "replace")
             is_installed = result.returncode == 0 and 'ii' in result.stdout
             return is_installed, package_name
         except Exception:
@@ -2639,7 +2645,7 @@ def check_libcurl_dev():
     elif system_type == "rpm":
         package_name = "libcurl-devel"
         try:
-            result = subprocess.run(['rpm', '-q', package_name], capture_output = True, text = True)
+            result = subprocess.run(['rpm', '-q', package_name], capture_output = True, text = True, encoding = "utf-8", errors = "replace")
             is_installed = result.returncode == 0
             return is_installed, package_name
         except Exception:
@@ -2648,7 +2654,7 @@ def check_libcurl_dev():
     elif system_type == "arch":
         package_name = "curl"
         try:
-            result = subprocess.run(['pacman', '-Q', package_name], capture_output=True, text=True)
+            result = subprocess.run(['pacman', '-Q', package_name], capture_output=True, text=True, encoding="utf-8", errors="replace")
             is_installed = result.returncode == 0
             return is_installed, package_name
         except Exception:


### PR DESCRIPTION
Part of unslothai/unsloth#2660

## Problem

`unsloth_zoo/llama_cpp.py` clones, cmake-builds, quantizes and converts llama.cpp through text-mode subprocess calls (`text=True` / `universal_newlines=True`) that never set an `encoding`. On Windows the output is decoded as cp1252 (the locale default) instead of UTF-8. The build/convert pipeline prints non-ASCII along the way (localized cmake and compiler messages on non-English Windows, progress and box-drawing glyphs, model/tensor names, file paths), so when a byte cp1252 can't map shows up (0x9d is the usual one, it sits inside the UTF-8 encoding of common punctuation) the read raises `UnicodeDecodeError` and the build or convert aborts, often after a long compile. Valid-but-wrong bytes corrupt the captured text silently instead.

Reproduced on Windows (cp1252, `PYTHONUTF8` unset) using the `try_execute()` pattern:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 24: character maps to <undefined>
```

This is the shared-engine half of the bug, the one both unsloth and Studio call under the hood. The `unsloth` save.py half is unslothai/unsloth#6218.

## Fix

- `unsloth_zoo/llama_cpp.py`
  - add `encoding="utf-8", errors="replace"` to all 12 text-mode subprocess calls, matching each call's existing spacing. Covers `try_execute` (streams the build/convert output), `_convert_to_gguf`, the cmake configure/build steps, and the winget/gcc/which/dpkg/rpm/pacman probes. `errors="replace"` means a stray byte can neither crash a build nor silently mangle the output.
- `tests/test_llama_cpp_subprocess_utf8_encoding.py` (new)
  - AST drift test: parses `llama_cpp.py` and fails if any text-mode subprocess call is missing `encoding="utf-8"`. No torch or built llama.cpp needed. Flagged all 12 call sites before the change, passes after.
  - behavioural test: spawns a real subprocess emitting a curly quote, asserts the raw bytes fail under cp1252 and read cleanly with the new kwargs.

Validation: `pytest tests/test_llama_cpp_subprocess_utf8_encoding.py` passes 3/3 (1 failed before the fix); `python -m compileall` is OK; `ruff check --select E9,F63,F7,F82` is clean.
