### PR TITLE
diffusion_studio: live denoising chat mode and honest throughput stats

### DIFF
--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -89,8 +89,9 @@ def _timings_from_stats(stats):
         return (n / ms * 1000.0) if ms > 0 else 0.0
     P = int(stats.get("prompt_n", 0))
     G = int(stats.get("predicted_n", 0))
-    prep_ms   = float(stats.get("prompt_prepare_ms", 0.0))
-    wall_ms   = float(stats.get("wall_ms", 0.0))
+    # Fall back to the older STATS names so an older visual server still reports non-zero timings.
+    prep_ms   = float(stats.get("prompt_prepare_ms", stats.get("prompt_ms", 0.0)))
+    wall_ms   = float(stats.get("wall_ms", stats.get("predicted_ms", 0.0)))
     decode_ms = float(stats.get("decode_ms", 0.0))
     steps     = int(stats.get("steps", 0))
     blocks    = int(stats.get("blocks", 0))
@@ -228,11 +229,11 @@ async def chat(req: Request):
         while True:
             kind, payload = await q.get()
             if kind == "frame":
-                # type-tagged event on the tool_status channel; no assistant content, so plain
-                # OpenAI clients ignore it and still get the committed text.
+                # A valid (empty-delta) chunk plus a type tag: Studio routes on the tag, while a
+                # strict OpenAI client parses it as a no-op chunk and ignores the extra fields.
                 block, step, total, text = payload
-                yield _sse({"type": "diffusion_frame", "block": block, "step": step,
-                            "total": total, "text": text})
+                yield _sse({**_chunk(cid, created, {}), "type": "diffusion_frame",
+                            "block": block, "step": step, "total": total, "text": text})
                 continue
             if kind in ("delta", "done"):
                 new = payload[len(sent):]

--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -19,13 +19,11 @@ llama.cpp / OpenAI-compatible server.
 Drives the OPTIMIZED visual decoder (visual_engine -> llama-diffusion-gemma-visual-server, the same
 on-device entropy-bound path as the CLI's --diffusion-visual: Stage 1 device sampling + Stage 2
 device-resident self-conditioning). Per streaming request it (a) streams the committed answer text as
-normal OpenAI deltas, and (b) appends a self-contained ```html artifact that replays the per-step
-denoising canvas in place - Studio renders that fenced HTML as a sandboxed-iframe artifact, so the user
-watches the 256-token canvas resolve out of noise just like the terminal.
+normal OpenAI deltas and (b) streams per-step "diffusion_frame" events so the 256-token canvas resolves
+in place in the chat bubble, like the terminal. Set DG_ARTIFACT=1 to also append a replay HTML artifact.
 
 Exposes /v1/models and /v1/chat/completions (streaming SSE + non-streaming) plus /health. The model loads
-once; requests are serialized (the decoder is single-sequence / stateful SC). This process serves only
-DiffusionGemma, so the denoising artifact is emitted for every request.
+once; requests are serialized (the decoder is single-sequence / stateful SC).
 
 Run:  DG_VISUAL_BIN=.../llama-diffusion-gemma-visual-server \
           python -m unsloth_zoo.diffusion_studio.shim --gguf diffusion-gemma-Q8_0.gguf --gpu 0 --port 8123
@@ -48,6 +46,8 @@ from . import visual_engine as V          # optimized visual decoder driver (sel
 
 MODEL_ID = os.environ.get("DG_MODEL_ID", "diffusiongemma")
 _PLAYER_TEMPLATE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "canvas_player.html")
+# DG_ARTIFACT=1 also appends the legacy replay HTML artifact (export/debug); default is live frames only.
+_WANT_ARTIFACT = os.environ.get("DG_ARTIFACT", "") not in ("", "0", "false", "False", "no", "off")
 
 app = FastAPI()
 _STATE = {}          # server (VisualServer), player (html template str)
@@ -79,29 +79,47 @@ def _sse(obj):
 
 
 def _timings_from_stats(stats):
-    """Build a llama-server-style `timings` block (+ diffusion extras) from the server's STATS summary, so
-    Studio's stat tooltip lights up the same rich view it shows for ordinary GGUF models. Returns
-    (timings, prompt_tokens, completion_tokens)."""
+    """Build a `timings` block from the server STATS summary. Returns (timings, prompt_n, completion_n).
+
+    No autoregressive prefill exists, so we emit no prompt tok/s (the old one divided tokens by host
+    tokenize time and showed a meaningless ~14000). We report the diffusion CLI's two rates so Studio
+    matches the terminal: effective = canvas*blocks/wall (end-to-end, ~hundreds) and in-step parallel =
+    canvas*steps/wall (the model's real per-step rate, ~thousands)."""
+    def rate(n, ms):
+        return (n / ms * 1000.0) if ms > 0 else 0.0
     P = int(stats.get("prompt_n", 0))
     G = int(stats.get("predicted_n", 0))
-    pm = float(stats.get("prompt_ms", 0.0))
-    gm = float(stats.get("predicted_ms", 0.0))
+    prep_ms   = float(stats.get("prompt_prepare_ms", 0.0))
+    wall_ms   = float(stats.get("wall_ms", 0.0))
+    decode_ms = float(stats.get("decode_ms", 0.0))
+    steps     = int(stats.get("steps", 0))
+    blocks    = int(stats.get("blocks", 0))
+    canvas    = int(stats.get("canvas", 0))
+    # CLI-matching rates; wall_ms is the CLI's end-to-end measure (incl. visualization).
+    eff_tps   = rate(canvas * blocks, wall_ms)   # effective: total canvas tokens generated / wall
+    par_tps   = rate(canvas * steps,  wall_ms)   # in-step parallel: canvas / per_step (per_step = wall/steps)
+    out_tps   = rate(G, wall_ms)                 # committed answer tokens the user received / wall
     timings = {
-        "prompt_n": P,
-        "prompt_ms": pm,
-        "prompt_per_second": (P / pm * 1000.0) if pm > 0 else 0.0,
+        # Headline "Speed" = in-step parallel rate (the model's real per-step throughput, ~thousands tok/s,
+        # matching the CLI), not the old bogus 14000.
         "predicted_n": G,
-        "predicted_ms": gm,
-        "predicted_per_second": (G / gm * 1000.0) if gm > 0 else 0.0,
+        "predicted_ms": wall_ms,
+        "predicted_per_second": par_tps,
         "cache_n": 0,
+        # Diffusion-specific breakdown (Studio shows these in a dedicated tooltip section).
+        "diffusion": True,
+        "diffusion_blocks": blocks,
+        "diffusion_steps": steps,
+        "diffusion_canvas": canvas,
+        "diffusion_prompt_n": P,
+        "diffusion_prompt_prepare_ms": prep_ms,
+        "diffusion_decode_ms": decode_ms,
+        "diffusion_wall_ms": wall_ms,
+        "diffusion_effective_tok_s": eff_tps,   # canvas*blocks / wall  (CLI "throughput")
+        "diffusion_parallel_tok_s": par_tps,    # canvas / per_step      (CLI "in-step parallel")
+        "diffusion_output_tok_s": out_tps,      # committed answer tokens / wall
+        "diffusion_steps_per_second": rate(steps, wall_ms),
     }
-    # diffusion-specific extras (Studio renders these as additional rows; other clients ignore them)
-    if "blocks" in stats:
-        timings["diffusion_blocks"] = int(stats["blocks"])
-    if "steps" in stats:
-        timings["diffusion_steps"] = int(stats["steps"])
-    if "canvas" in stats:
-        timings["diffusion_canvas"] = int(stats["canvas"])
     return timings, P, G
 
 
@@ -179,11 +197,15 @@ async def chat(req: Request):
 
     async def gen():
         q: asyncio.Queue = asyncio.Queue()
-        frames = []        # collected denoising frames (worker thread owns until done)
+        frames = []        # retained only for the optional replay artifact (DG_ARTIFACT=1)
         stats_box = {}     # the server's end-of-request STATS summary
 
         def on_frame(block, step, total, text):
-            frames.append({"b": block, "s": step, "t": total, "x": text})
+            # Stream each frame (transient, not committed text); the frontend renders the canvas in
+            # place and drops it on commit.
+            loop.call_soon_threadsafe(q.put_nowait, ("frame", (block, step, total, text)))
+            if _WANT_ARTIFACT:
+                frames.append({"b": block, "s": step, "t": total, "x": text})
 
         def on_commit(cumulative):
             loop.call_soon_threadsafe(q.put_nowait, ("delta", cumulative))
@@ -205,17 +227,26 @@ async def chat(req: Request):
         sent = ""
         while True:
             kind, payload = await q.get()
+            if kind == "frame":
+                # type-tagged event on the tool_status channel; no assistant content, so plain
+                # OpenAI clients ignore it and still get the committed text.
+                block, step, total, text = payload
+                yield _sse({"type": "diffusion_frame", "block": block, "step": step,
+                            "total": total, "text": text})
+                continue
             if kind in ("delta", "done"):
                 new = payload[len(sent):]
                 if new:
+                    # committed block: normal assistant text (what the transcript keeps).
                     yield _sse(_chunk(cid, created, {"content": new}))
                     sent = payload
                 if kind == "done":
-                    art = _artifact(frames)
-                    if art:
-                        yield _sse(_chunk(cid, created, {"content": art}))
-                    # llama-server-style usage+timings chunk (empty choices) so Studio shows the rich
-                    # stat tooltip (tok/s, generation time, tokens) plus diffusion rows (steps, blocks).
+                    if _WANT_ARTIFACT:
+                        art = _artifact(frames)
+                        if art:
+                            yield _sse(_chunk(cid, created, {"content": art}))
+                    # llama-server-style usage+timings chunk (empty choices) so Studio shows the
+                    # stat tooltip plus the diffusion rows (steps, blocks).
                     timings, P, G = _timings_from_stats(stats_box)
                     yield _sse({"id": cid, "object": "chat.completion.chunk", "created": created,
                                 "model": MODEL_ID, "choices": [],

--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -169,8 +169,8 @@ def generate_visual(server, messages, seed=3407, max_blocks=8, on_frame=None, on
 
     on_frame(block, step, total, text): a denoising frame (the current argmax canvas, already decoded).
     on_commit(cumulative_text): cumulative committed answer text after each block (for live OpenAI deltas).
-    on_stats(stats_dict): the server's end-of-request summary (prompt_n, predicted_n, prompt_ms,
-        predicted_ms, blocks, steps, canvas, n_ctx) for surfacing generation statistics.
+    on_stats(stats_dict): the server's end-of-request summary (prompt_n, predicted_n,
+        prompt_prepare_ms, wall_ms, decode_ms, blocks, steps, canvas, n_ctx) for generation stats.
     Returns the full committed reply text. Raises ContextOverflow if the request exceeds the context budget.
 
     Self-heals a crash: if the server dies mid-turn and nothing was streamed yet (the usual case, since

--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -57,6 +57,11 @@ class ContextOverflow(RuntimeError):
         )
 
 
+class VisualServerCrashed(RuntimeError):
+    """The visual-server subprocess died mid-request (EOF or broken pipe), e.g. a CUDA fault on a long
+    context. The caller respawns it and, if nothing was streamed yet, retries the turn once."""
+
+
 def _set_pdeathsig():
     """Linux: ask the kernel to SIGTERM this child when its parent (the shim) dies for any reason, so a
     hard-killed shim never orphans a GPU process."""
@@ -82,14 +87,22 @@ class VisualServer:
     """Persistent optimized decoder: send chat messages, stream per-step canvas frames + committed text."""
 
     def __init__(self, gguf, gpu="0", maxtok=0, server_bin=None, req_path=None):
-        server_bin = _resolve_bin(server_bin)
+        self.gguf = gguf
+        self.server_bin = _resolve_bin(server_bin)
+        self.maxtok_req = int(maxtok)
         req_dir = "/dev/shm" if os.path.isdir("/dev/shm") else tempfile.gettempdir()
         self.req = req_path or os.path.join(req_dir, f"dg_visual_{os.getpid()}.req")
         env = dict(os.environ, CUDA_VISIBLE_DEVICES=str(gpu), NGL="99", MAXTOK=str(maxtok))
-        bin_dir = os.path.dirname(server_bin)
-        env["LD_LIBRARY_PATH"] = bin_dir + os.pathsep + env.get("LD_LIBRARY_PATH", "")
-        self.p = subprocess.Popen([server_bin, gguf], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                  env=env, bufsize=1, text=True,
+        env["LD_LIBRARY_PATH"] = os.path.dirname(self.server_bin) + os.pathsep + env.get("LD_LIBRARY_PATH", "")
+        self.env = env
+        self.p = None
+        self._spawn()
+
+    def _spawn(self):
+        """Launch the subprocess and finish the READY handshake. Used at startup and by restart()
+        after a crash (re-loads the model, so it costs tens of seconds)."""
+        self.p = subprocess.Popen([self.server_bin, self.gguf], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                  env=self.env, bufsize=1, text=True,
                                   preexec_fn=_set_pdeathsig if os.name == "posix" else None)
         line = self.p.stdout.readline().strip()
         if not line.startswith("READY"):
@@ -98,14 +111,35 @@ class VisualServer:
         # auto-sized it to fit VRAM when launched with MAXTOK=0). Older servers print only "READY <n_vocab>".
         parts = line.split()
         self.n_vocab = int(parts[1]) if len(parts) > 1 else 0
-        self.maxtok = int(parts[2]) if len(parts) > 2 else int(maxtok)
+        self.maxtok = int(parts[2]) if len(parts) > 2 else self.maxtok_req
+
+    def restart(self):
+        """Tear down a dead/stuck server and spawn a fresh one, so one bad turn does not leave every
+        later turn failing with a broken pipe."""
+        try:
+            if self.p is not None:
+                self.p.kill()
+                self.p.wait(timeout=10)
+        except Exception:
+            pass
+        self._spawn()
 
     def _send(self, messages, n_blocks, seed):
+        # A previous turn may have crashed the decoder; respawn before writing so a dead child does not
+        # strand this and every later turn with a broken pipe.
+        if self.p is None or self.p.poll() is not None:
+            self.restart()
         with open(self.req, "w") as f:
             json.dump({"seed": int(seed), "n_blocks": int(n_blocks), "messages": messages}, f,
                       ensure_ascii=False)
-        self.p.stdin.write(self.req + "\n")
-        self.p.stdin.flush()
+        try:
+            self.p.stdin.write(self.req + "\n")
+            self.p.stdin.flush()
+        except (BrokenPipeError, OSError):
+            # Died between the poll above and the write: respawn once and retry the send.
+            self.restart()
+            self.p.stdin.write(self.req + "\n")
+            self.p.stdin.flush()
 
     def close(self):
         try:
@@ -138,14 +172,40 @@ def generate_visual(server, messages, seed=3407, max_blocks=8, on_frame=None, on
     on_stats(stats_dict): the server's end-of-request summary (prompt_n, predicted_n, prompt_ms,
         predicted_ms, blocks, steps, canvas, n_ctx) for surfacing generation statistics.
     Returns the full committed reply text. Raises ContextOverflow if the request exceeds the context budget.
+
+    Self-heals a crash: if the server dies mid-turn and nothing was streamed yet (the usual case, since
+    the crash is in the per-block prefill before any frame), respawn and retry once; otherwise propagate.
     """
+    progressed = {"emitted": False}
+
+    def _frame(b, s, t, x):
+        progressed["emitted"] = True
+        if on_frame is not None:
+            on_frame(b, s, t, x)
+
+    def _commit(txt):
+        progressed["emitted"] = True
+        if on_commit is not None:
+            on_commit(txt)
+
+    for attempt in (0, 1):
+        try:
+            return _generate_visual_once(server, messages, seed, max_blocks, _frame, _commit, on_stats)
+        except VisualServerCrashed:
+            server.restart()  # always bring a fresh server up so the next turn works regardless
+            if attempt == 1 or progressed["emitted"]:
+                raise
+            # nothing emitted yet -> safe to transparently resend on the fresh server
+
+
+def _generate_visual_once(server, messages, seed, max_blocks, on_frame, on_commit, on_stats):
     server._send(messages, max_blocks, seed)
 
     full_text = ""
     while True:
         line = server.p.stdout.readline()
         if not line:
-            raise RuntimeError("visual server closed the stream")
+            raise VisualServerCrashed("visual server closed the stream")
         line = line.rstrip("\n")
         if line == "DONE":
             break


### PR DESCRIPTION
Follow-up to #748. Two improvements to the DiffusionGemma Studio decoder that landed after that PR was merged.

## Live denoising frames

The shim now streams each denoising step as a type-tagged `diffusion_frame` SSE event, so the 256-token canvas resolves in place inside the chat bubble instead of being appended as a post-hoc HTML replay artifact. The committed answer text still streams as normal OpenAI deltas, so plain OpenAI-compatible clients are unaffected and simply ignore the frame events. The legacy replay artifact is still available behind `DG_ARTIFACT=1` for export and debugging.

## Honest throughput stats

The old timings divided the predicted token count by the host-side tokenize time, which reported a meaningless number (around 14000 tok/s). The stats now mirror the standalone diffusion CLI:

- effective tok/s = canvas * blocks / wall (end to end, the rate the user watches resolve)
- in-step parallel = canvas * steps / wall (the model's real per-step throughput)

Studio renders these as a dedicated tooltip section alongside steps, blocks, and canvas size.

## Self-heal a crashed visual server

If the visual-server subprocess dies mid-turn (for example a CUDA fault on a very long context), the engine now respawns it and, when nothing was streamed yet, retries the turn once. Previously a single crash left every later turn failing with a broken pipe until the model was reloaded.

## Test plan

- Streamed a multi-turn chat and confirmed the canvas resolves in place per step, the committed text matches, and the tooltip shows the effective and in-step rates.
- Killed the visual-server child mid-session and confirmed the next turn transparently respawns and answers.
