### PR TITLE
Fix transformers 5.x drift: FP8Linear constructor signature and Gemma3 double-BOS strip under padding

### DIFF
--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -189,11 +189,23 @@ def patch_Gemma3Processor():
         # text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"], return_tensors="np")
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", True)
 
-        text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
-        # Fix double BOS tokens
+        # Tokenize WITHOUT padding: stripping a double BOS after padding only
+        # shortens rows that still start with [bos, bos] (under left padding,
+        # just the longest row), re-ragging the batch and desyncing
+        # attention_mask. Strip first, then pad once.
+        text_kwargs = dict(output_kwargs["text_kwargs"])
+        pad_kwargs = {k: text_kwargs.pop(k) for k in ("padding", "max_length", "pad_to_multiple_of", "padding_side") if k in text_kwargs}
+        text_inputs = self.tokenizer(text=text, **text_kwargs)
+        # Fix double BOS tokens, keeping attention_mask in sync
         double_bos_token_id = [self.tokenizer.bos_token_id]*2
         input_ids = text_inputs["input_ids"]
-        text_inputs["input_ids"] = [x[1:] if x[:2] == double_bos_token_id else x for x in input_ids]
+        stripped = [x[1:] if x[:2] == double_bos_token_id else x for x in input_ids]
+        if "attention_mask" in text_inputs:
+            text_inputs["attention_mask"] = [m[1:] if len(k) != len(x) else m for x, k, m in zip(input_ids, stripped, text_inputs["attention_mask"])]
+        text_inputs["input_ids"] = stripped
+        if pad_kwargs.get("padding", False) not in (False, None, "do_not_pad"):
+            pad_params = inspect.signature(self.tokenizer.pad).parameters
+            text_inputs = self.tokenizer.pad(text_inputs, **{k: v for k, v in pad_kwargs.items() if k in pad_params})
 
         # Add token type ids manually, as tokenizer can't do arbitrary position token types
         # [TODO] FAILS for batched tokens since text_inputs["input_ids"] is a list of lists, so np.array creates an object!

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -1426,12 +1426,13 @@ def convert_vllm_to_huggingface(quant_state_dict, config, dtype = torch.float16,
                     layer.weight.input_scale_ub = kwargs['input_scale_ub']
                     layer.quant_method = "fbgemm_fp8"
                 elif fp8_weight_scale.ndim == 2:
-                    # FP8 dynamic quantized. transformers 5.0+ renamed
-                    # bias -> has_bias and removed device.
-                    if Version("transformers") < Version("5.0.0"):
-                        fp8_kwargs = dict(in_features=0, out_features=0, bias=has_bias, dtype=dtype, block_size=kwargs['block_size'], activation_scheme=kwargs['activation_scheme'], device=get_target_device())
-                    else:
-                        fp8_kwargs = dict(in_features=0, out_features=0, has_bias=has_bias, dtype=dtype, block_size=kwargs['block_size'], activation_scheme=kwargs['activation_scheme'])
+                    # FP8 dynamic quantized. FP8Linear's signature drifts across
+                    # transformers versions (4.x: bias/dtype/device; 5.x:
+                    # has_bias, no dtype/device), so keep only accepted kwargs.
+                    fp8_kwargs = dict(in_features=0, out_features=0, bias=has_bias, has_bias=has_bias, dtype=dtype, block_size=kwargs['block_size'], activation_scheme=kwargs['activation_scheme'], device=get_target_device())
+                    fp8_params = inspect.signature(FP8Linear.__init__).parameters
+                    if not any(p.kind is p.VAR_KEYWORD for p in fp8_params.values()):
+                        fp8_kwargs = {k: v for k, v in fp8_kwargs.items() if k in fp8_params}
                     layer = FP8Linear(**fp8_kwargs)
                     layer.in_features = weight.shape[1]
                     layer.out_features = weight.shape[0]


### PR DESCRIPTION
Two transformers 5.x drift fixes, both backwards compatible with 4.57.6.

## FP8Linear constructor signature drift

transformers 4.57.6 builds `FP8Linear(in_features, out_features, bias, dtype, block_size, device, activation_scheme)`. transformers 5.x changed the signature to `(in_features, out_features, block_size, activation_scheme, scale_fmt, has_bias)`: `bias`, `dtype`, `device` are gone and `has_bias` arrived. `vllm_utils.py` passed the 4.x layout positionally, so FP8 models crashed on 5.x with a TypeError.

The fix builds a superset kwargs dict (`bias`, `has_bias`, `dtype`, `device`, `block_size`, `activation_scheme`) and filters it against `inspect.signature(FP8Linear.__init__)` before calling, with a VAR_KEYWORD guard so a future `**kwargs` signature receives everything. Works unchanged on 4.57.6, 5.x, and signatures in between.

## Gemma3 processor double-BOS under batched padding

The existing Gemma3 patch stripped a duplicated BOS by checking `input_ids[:2]` after tokenization with padding. Under left padding only the longest row starts with `[bos, bos]`, so the strip re-ragged the batch and desynced `attention_mask`.

The fix tokenizes unpadded, strips the duplicate BOS per row while keeping the attention mask in sync, then pads once via `tokenizer.pad` with the pad kwargs filtered against its signature (transformers 5 changed which kwargs `pad` accepts).

## Validation

Unit tests for both paths pass on transformers 4.57.6 and 5.11 (same scripts, both versions).

End to end inside the unsloth/unsloth Docker validation image (B200, torch 2.10 cu128, vllm 0.19.1, transformers 5.11), notebooks from unslothai/notebooks run with these fixes applied:

| Notebook | Result |
| --- | --- |
| Gemma3_(4B)-Vision-GRPO | pass, 13.6 min |
| Llama_FP8_GRPO | pass, 8.6 min |
| Qwen3_8B_FP8_GRPO | pass, 12.1 min |
| Qwen3_(4B)-GRPO (control, no FP8/Gemma path) | pass, 11.9 min |

Both fixes are runtime monkey patches scoped to the existing patch sites; no behavior change when the installed transformers matches the old signatures.
