### PR TITLE
diffusion_studio: split shim thought channels into reasoning_content

### DIFF
--- a/tests/test_diffusion_shim_thought_split.py
+++ b/tests/test_diffusion_shim_thought_split.py
@@ -1,0 +1,166 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Thought-channel splitting in the DiffusionGemma OpenAI shim.
+
+The shim splits the model's thinking out of committed text into OpenAI-style
+``reasoning_content``. DiffusionGemma emits two thinking dialects -- the chat
+template's native ``<|channel>thought ... <channel|>`` and DeepSeek-style
+``<think> ... </think>`` when thinking is not explicitly templated -- and
+commits arrive in 256-token canvas blocks, so a marker can straddle a block
+boundary mid-stream. These tests pin the splitter and the streaming holdback
+that keeps marker fragments out of both channels.
+"""
+
+import pytest
+
+# The shim imports fastapi/uvicorn at module level; neither ships in the
+# [core] extras the CI runners install, so skip (not fail) collection there.
+pytest.importorskip("fastapi")
+pytest.importorskip("uvicorn")
+
+from unsloth_zoo.diffusion_studio.shim import (  # noqa: E402
+    _marker_holdback,
+    _split_thought_channels,
+)
+
+
+# ── _split_thought_channels ──────────────────────────────────────────
+
+
+def test_no_markers_is_all_content():
+    assert _split_thought_channels("Hello!") == ("", "Hello!")
+
+
+def test_angle_brackets_without_markers_pass_through():
+    text = "compare a < b | c > d and 1 << 2"
+    assert _split_thought_channels(text) == ("", text)
+
+
+def test_channel_dialect_splits():
+    reasoning, content = _split_thought_channels(
+        "<|channel>thought\nPlan: greet the user.\n<channel|>Hello! How can I help?"
+    )
+    assert reasoning == "Plan: greet the user."
+    assert content == "Hello! How can I help?"
+
+
+def test_think_dialect_splits():
+    reasoning, content = _split_thought_channels(
+        "<think>The user said hi.\nRespond politely.</think>Hi there!"
+    )
+    assert reasoning == "The user said hi.\nRespond politely."
+    assert content == "Hi there!"
+
+
+def test_unterminated_thought_is_all_reasoning():
+    # Length-truncated generation: the end marker never arrives.
+    reasoning, content = _split_thought_channels("<think>still thinking...")
+    assert reasoning == "still thinking..."
+    assert content == ""
+
+
+def test_multiple_blocks_and_mixed_dialects():
+    reasoning, content = _split_thought_channels(
+        "<think>A</think>x<|channel>thought\nB<channel|>y"
+    )
+    assert reasoning == "A\nB"
+    assert content == "xy"
+
+
+def test_marker_text_never_reaches_either_channel():
+    for text in (
+        "<|channel>thought\nT\n<channel|>C",
+        "<think>T</think>C",
+        "lead<think>T</think>tail",
+    ):
+        reasoning, content = _split_thought_channels(text)
+        for fragment in ("<|channel>", "<channel|>", "<think>", "</think>"):
+            assert fragment not in reasoning
+            assert fragment not in content
+
+
+# ── _marker_holdback ─────────────────────────────────────────────────
+
+
+def test_holdback_zero_when_no_partial_marker():
+    assert _marker_holdback("plain text") == 0
+    assert _marker_holdback("ends with full <think>") == 0  # complete marker, nothing partial
+
+
+def test_holdback_covers_partial_markers():
+    assert _marker_holdback("text<thi") == len("<thi")
+    assert _marker_holdback("text<|channel>thoug") == len("<|channel>thoug")
+    assert _marker_holdback("text</thin") == len("</thin")
+
+
+# ── streaming reconstruction (mirrors the shim's gen() loop) ─────────
+
+
+def _stream(full):
+    """Replay *full* one character per commit through the shim's split + holdback
+    + per-channel prefix-diff logic; return the concatenated channel outputs."""
+    sent_reasoning = ""
+    sent_content = ""
+    out_reasoning = []
+    out_content = []
+    for cut in range(1, len(full) + 1):
+        snapshot = full[:cut]
+        done = cut == len(full)
+        if done:
+            reasoning, content = _split_thought_channels(snapshot)
+        else:
+            held = _marker_holdback(snapshot)
+            safe = snapshot[: len(snapshot) - held] if held else snapshot
+            reasoning, content = _split_thought_channels(safe)
+        new_reasoning = reasoning[len(sent_reasoning):]
+        if new_reasoning:
+            out_reasoning.append(new_reasoning)
+            sent_reasoning = reasoning
+        new_content = content[len(sent_content):]
+        if new_content:
+            out_content.append(new_content)
+            sent_content = content
+    return "".join(out_reasoning), "".join(out_content)
+
+
+@pytest.mark.parametrize(
+    "full, expected_reasoning, expected_content",
+    [
+        (
+            "<|channel>thought\nthink hard\n<channel|>The answer is 42.",
+            "think hard",
+            "The answer is 42.",
+        ),
+        ("<think>quick thought</think>Done.", "quick thought", "Done."),
+        ("No thinking, straight answer.", "", "No thinking, straight answer."),
+    ],
+)
+def test_streaming_every_chunk_boundary(full, expected_reasoning, expected_content):
+    # One char per commit exercises every possible marker-straddling boundary.
+    reasoning, content = _stream(full)
+    assert reasoning == expected_reasoning
+    assert content == expected_content
+    for fragment in ("<|channel>", "<channel|>", "<think>", "</think>"):
+        assert fragment not in reasoning
+        assert fragment not in content
+
+
+def test_streaming_preserves_literal_angle_text():
+    full = "Use a < b and c | d; never a <thinko> typo."
+    reasoning, content = _stream(full)
+    assert reasoning == ""
+    assert content == full

--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -22,6 +22,10 @@ device-resident self-conditioning). Per streaming request it (a) streams the com
 normal OpenAI deltas and (b) streams per-step "diffusion_frame" events so the 256-token canvas resolves
 in place in the chat bubble, like the terminal. Set DG_ARTIFACT=1 to also append a replay HTML artifact.
 
+The model's thought channel (``<|channel>thought ... <channel|>``) is split out of the committed text
+and emitted as OpenAI-style ``reasoning_content`` (matching llama-server's reasoning extraction), so
+chat UIs fold it into a collapsible thinking section instead of showing raw channel markers.
+
 Exposes /v1/models and /v1/chat/completions (streaming SSE + non-streaming) plus /health. The model loads
 once; requests are serialized (the decoder is single-sequence / stateful SC).
 
@@ -76,6 +80,58 @@ def _chunk(cid, created, delta, finish=None):
 
 def _sse(obj):
     return f"data: {json.dumps(obj)}\n\n"
+
+
+# DiffusionGemma thought markers. The chat template's native format is
+# ``<|channel>thought\n ... <channel|>``, but the model also free-runs DeepSeek-style
+# ``<think> ... </think>`` when thinking is not explicitly templated, so both are split.
+_THOUGHT_MARKERS = (
+    ("<|channel>thought", "<channel|>"),
+    ("<think>", "</think>"),
+)
+
+
+def _split_thought_channels(full):
+    """Split raw committed text into ``(reasoning, content)``, dropping the thought markers.
+
+    Handles text with no markers (all content), an unterminated thought (everything after the
+    start marker is reasoning -- e.g. a length-truncated generation), multiple thought blocks,
+    and either marker dialect. Marker text never reaches either channel."""
+    reasoning, content = [], []
+    rest = full
+    while True:
+        best = None  # earliest start marker wins
+        for start, end in _THOUGHT_MARKERS:
+            i = rest.find(start)
+            if i >= 0 and (best is None or i < best[0]):
+                best = (i, start, end)
+        if best is None:
+            content.append(rest)
+            break
+        i, start, end = best
+        content.append(rest[:i])
+        body = rest[i + len(start):]
+        j = body.find(end)
+        if j < 0:
+            reasoning.append(body)
+            break
+        reasoning.append(body[:j])
+        rest = body[j + len(end):]
+    return "".join(reasoning).strip("\n"), "".join(content)
+
+
+def _marker_holdback(full):
+    """Length of a trailing partial thought marker in *full* to withhold from streaming until the
+    next commit disambiguates it (a block boundary can land mid-marker)."""
+    longest = 0
+    for pair in _THOUGHT_MARKERS:
+        for marker in pair:
+            upper = min(len(marker) - 1, len(full))
+            for k in range(upper, 0, -1):
+                if full.endswith(marker[:k]):
+                    longest = max(longest, k)
+                    break
+    return longest
 
 
 def _timings_from_stats(stats):
@@ -189,9 +245,13 @@ async def chat(req: Request):
                 "usage": {"prompt_tokens": exc.needed, "completion_tokens": 0, "total_tokens": exc.needed},
             })
         _, P, G = _timings_from_stats(stats_box)
+        reasoning, content = _split_thought_channels(text)
+        message = {"role": "assistant", "content": content}
+        if reasoning:
+            message["reasoning_content"] = reasoning
         return JSONResponse({
             "id": cid, "object": "chat.completion", "created": created, "model": MODEL_ID,
-            "choices": [{"index": 0, "message": {"role": "assistant", "content": text},
+            "choices": [{"index": 0, "message": message,
                          "finish_reason": "stop"}],
             "usage": {"prompt_tokens": P, "completion_tokens": G, "total_tokens": P + G},
         })
@@ -225,7 +285,12 @@ async def chat(req: Request):
 
         threading.Thread(target=work, daemon=True).start()
         yield _sse(_chunk(cid, created, {"role": "assistant"}))
-        sent = ""
+        # Committed text is split into the thought channel (streamed as reasoning_content, like
+        # llama-server's reasoning extraction) and the answer (normal content deltas). Each channel
+        # diffs against what it already sent; a trailing partial marker is withheld until the next
+        # commit so marker text never leaks into either channel.
+        sent_reasoning = ""
+        sent_content = ""
         while True:
             kind, payload = await q.get()
             if kind == "frame":
@@ -236,11 +301,21 @@ async def chat(req: Request):
                             "block": block, "step": step, "total": total, "text": text})
                 continue
             if kind in ("delta", "done"):
-                new = payload[len(sent):]
-                if new:
+                if kind == "done":
+                    reasoning, content = _split_thought_channels(payload)
+                else:
+                    cut = _marker_holdback(payload)
+                    safe = payload[: len(payload) - cut] if cut else payload
+                    reasoning, content = _split_thought_channels(safe)
+                new_r = reasoning[len(sent_reasoning):]
+                if new_r:
+                    yield _sse(_chunk(cid, created, {"reasoning_content": new_r}))
+                    sent_reasoning = reasoning
+                new_c = content[len(sent_content):]
+                if new_c:
                     # committed block: normal assistant text (what the transcript keeps).
-                    yield _sse(_chunk(cid, created, {"content": new}))
-                    sent = payload
+                    yield _sse(_chunk(cid, created, {"content": new_c}))
+                    sent_content = content
                 if kind == "done":
                     if _WANT_ARTIFACT:
                         art = _artifact(frames)


### PR DESCRIPTION
The shim streamed DiffusionGemma's committed text verbatim, so thought markers rendered as raw text in chat UIs. The model emits two thinking
dialects: the chat template's native <|channel>thought ... <channel|>
and DeepSeek-style <think> ... </think> when thinking is not explicitly templated. Split both out of committed text into OpenAI-style reasoning_content (matching llama-server's reasoning extraction) for both streaming and non-streaming responses, so chat UIs fold the thinking into a collapsible section instead of showing raw markers.

Streaming withholds a trailing partial marker until the next block commit, so a marker split across the 256-token canvas block boundary never leaks fragments into either channel. Handles unterminated thoughts (length-truncated generations) and multiple thought blocks.

Before:

<img width="854" height="357" alt="image" src="https://github.com/user-attachments/assets/f3bce86c-0dd2-4bdf-9741-b07a3f3d14c0" />

After:

<img width="729" height="440" alt="image" src="https://github.com/user-attachments/assets/1ebd04b5-9ba8-43c7-8a31-6386f9d95178" />
