### PR TITLE
Fix harmony analysis channel using thinking instead of content

### DIFF
--- a/tests/test_encode_conversations_with_harmony.py
+++ b/tests/test_encode_conversations_with_harmony.py
@@ -517,6 +517,93 @@ def test_mixed_multi_turn_preserves_channels_and_branches(
     assert tool_message.content == "tool result"
 
 
+def test_assistant_thinking_with_tool_calls_keeps_both(
+    monkeypatch,
+    gpt_oss_module,
+):
+    # An assistant turn carrying BOTH reasoning and a tool call must emit the analysis
+    # message AND the commentary tool call. The tool call must not be dropped.
+    messages = [
+        {
+            "role": "assistant",
+            "thinking": "decide to call the tool",
+            "tool_calls": [{"name": "lookup", "arguments": "{\"city\": \"Paris\"}"}],
+        },
+    ]
+    assistant_messages = _encode_and_capture_messages(
+        monkeypatch, gpt_oss_module, messages
+    )
+
+    channels = [m.channel for m in assistant_messages]
+    assert channels == ["analysis", "commentary"]
+    assert assistant_messages[0].content == "decide to call the tool"
+    tool_message = assistant_messages[1]
+    assert tool_message.recipient == "functions.lookup"
+    assert tool_message.content_type == "json"
+    assert tool_message.content == "{\"city\": \"Paris\"}"
+
+
+def test_assistant_thinking_none_falls_back_to_final(
+    monkeypatch,
+    gpt_oss_module,
+):
+    # A nullable "thinking" column materialized as None must not be passed into Harmony.
+    # The turn should fall back to a single final-channel message from content.
+    messages = [
+        {"role": "assistant", "thinking": None, "content": "the answer"},
+    ]
+    assistant_messages = _encode_and_capture_messages(
+        monkeypatch, gpt_oss_module, messages
+    )
+
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].channel == "final"
+    assert assistant_messages[0].content == "the answer"
+
+
+def test_assistant_thinking_empty_string_falls_back_to_final(
+    monkeypatch,
+    gpt_oss_module,
+):
+    # Empty-string thinking is treated as absent (no empty analysis message); only the
+    # final-channel message from content is emitted.
+    messages = [
+        {"role": "assistant", "thinking": "", "content": "the answer"},
+    ]
+    assistant_messages = _encode_and_capture_messages(
+        monkeypatch, gpt_oss_module, messages
+    )
+
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].channel == "final"
+    assert assistant_messages[0].content == "the answer"
+
+
+def test_assistant_thinking_tool_calls_and_content_keeps_analysis_and_tool_call(
+    monkeypatch,
+    gpt_oss_module,
+):
+    # When a turn has thinking, tool_calls and content, tool_calls and content stay
+    # mutually exclusive: the tool call wins (the final answer comes after the tool
+    # result), so we emit analysis + commentary and drop the content for this turn.
+    messages = [
+        {
+            "role": "assistant",
+            "thinking": "reason first",
+            "content": "should not be emitted in a tool-call turn",
+            "tool_calls": [{"name": "search", "arguments": "{\"q\": \"x\"}"}],
+        },
+    ]
+    assistant_messages = _encode_and_capture_messages(
+        monkeypatch, gpt_oss_module, messages
+    )
+
+    channels = [m.channel for m in assistant_messages]
+    assert channels == ["analysis", "commentary"]
+    assert "final" not in channels
+    assert assistant_messages[1].recipient == "functions.search"
+
+
 def test_encode_conversations_with_harmony_load_failure_retried_then_cached(
     monkeypatch,
     harmony_state,

--- a/tests/test_encode_conversations_with_harmony.py
+++ b/tests/test_encode_conversations_with_harmony.py
@@ -416,6 +416,107 @@ def test_encode_conversations_with_harmony_partial_build_lists_missing_symbol(
         gpt_oss.encode_conversations_with_harmony([])
 
 
+def _encode_and_capture_messages(monkeypatch, gpt_oss, messages):
+    # Run the encoder with the fake harmony stubs and return the per-channel assistant
+    # Message objects that were appended to the conversation (the system message is index 0).
+    encoding = _Encoding()
+    _install_fake_harmony(monkeypatch, gpt_oss, lambda name: encoding)
+    gpt_oss.encode_conversations_with_harmony(messages)
+    conversation = encoding.calls[0][1]
+    return [m for m in conversation if m.role == _Role.ASSISTANT]
+
+
+def test_assistant_thinking_with_content_emits_analysis_and_final(
+    monkeypatch,
+    gpt_oss_module,
+):
+    # Core regression for unsloth-zoo#246: the analysis channel must carry the reasoning
+    # from message["thinking"], and the answer in message["content"] must still be emitted
+    # on the final channel rather than dropped.
+    messages = [
+        {"role": "assistant", "thinking": "let me reason", "content": "the answer"},
+    ]
+    assistant_messages = _encode_and_capture_messages(
+        monkeypatch, gpt_oss_module, messages
+    )
+
+    analysis = [m for m in assistant_messages if m.channel == "analysis"]
+    final = [m for m in assistant_messages if m.channel == "final"]
+
+    assert len(analysis) == 1
+    assert analysis[0].content == "let me reason"
+    assert len(final) == 1
+    assert final[0].content == "the answer"
+
+
+def test_assistant_thinking_only_emits_single_analysis(
+    monkeypatch,
+    gpt_oss_module,
+):
+    # A pure-reasoning turn (thinking present, no/empty content) must produce only the
+    # analysis message carrying the reasoning, and no final message.
+    messages = [
+        {"role": "assistant", "thinking": "just reasoning", "content": ""},
+    ]
+    assistant_messages = _encode_and_capture_messages(
+        monkeypatch, gpt_oss_module, messages
+    )
+
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].channel == "analysis"
+    assert assistant_messages[0].content == "just reasoning"
+
+
+def test_assistant_plain_content_unchanged_final_only(
+    monkeypatch,
+    gpt_oss_module,
+):
+    # No thinking and no tool_calls: exactly one final-channel message from content.
+    messages = [
+        {"role": "assistant", "content": "plain answer"},
+    ]
+    assistant_messages = _encode_and_capture_messages(
+        monkeypatch, gpt_oss_module, messages
+    )
+
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].channel == "final"
+    assert assistant_messages[0].content == "plain answer"
+
+
+def test_mixed_multi_turn_preserves_channels_and_branches(
+    monkeypatch,
+    gpt_oss_module,
+):
+    # user -> assistant(thinking+content) -> tool -> assistant(final): confirm channel
+    # ordering and that the tool_calls / tool branches stay untouched.
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "thinking": "reason about it", "content": "first answer"},
+        {"role": "tool", "name": "lookup", "content": "tool result"},
+        {"role": "assistant", "content": "final answer"},
+    ]
+    encoding = _Encoding()
+    _install_fake_harmony(monkeypatch, gpt_oss_module, lambda name: encoding)
+    gpt_oss_module.encode_conversations_with_harmony(messages)
+    conversation = encoding.calls[0][1]
+
+    # Drop the leading system message, then assert the channel sequence.
+    body = [m for m in conversation if m.role != _Role.SYSTEM]
+    channels = [m.channel for m in body]
+    assert channels == [None, "analysis", "final", "commentary", "final"]
+
+    analysis = body[1]
+    assert analysis.content == "reason about it"
+    first_final = body[2]
+    assert first_final.content == "first answer"
+
+    tool_message = body[3]
+    assert tool_message.channel == "commentary"
+    assert tool_message.recipient == "assistant"
+    assert tool_message.content == "tool result"
+
+
 def test_encode_conversations_with_harmony_load_failure_retried_then_cached(
     monkeypatch,
     harmony_state,

--- a/tests/test_encode_conversations_with_harmony_render.py
+++ b/tests/test_encode_conversations_with_harmony_render.py
@@ -1,0 +1,182 @@
+"""Real-renderer regression tests for ``encode_conversations_with_harmony``.
+
+The companion test module ``test_encode_conversations_with_harmony.py`` stubs out the
+entire ``openai_harmony`` library, so it only validates how the encoder *constructs*
+Message objects, never what the real renderer puts into the returned token IDs. These
+tests exercise the genuine ``openai_harmony`` renderer end to end and assert against the
+decoded output.
+
+They are skipped automatically when ``openai_harmony`` is not installed, or when the
+gpt-oss harmony encoding cannot be loaded (e.g. no network to fetch the vocab), so the
+suite stays runnable in hermetic CI while still covering the real behavior locally.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.machinery
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+
+openai_harmony = pytest.importorskip("openai_harmony")
+
+
+_MODULE_NAME = "unsloth_zoo.temporary_patches.gpt_oss"
+_PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1] / "unsloth_zoo"
+
+
+def _package_shell(name, path):
+    module = types.ModuleType(name)
+    module.__path__ = [str(path)]
+    module.__package__ = name
+    module.__spec__ = importlib.machinery.ModuleSpec(name, loader = None, is_package = True)
+    return module
+
+
+@pytest.fixture()
+def gpt_oss_module():
+    # Mirror the import strategy used by the stubbed test module so the submodule can be
+    # imported standalone (without a full unsloth install).
+    if "unsloth_zoo" in sys.modules or importlib.util.find_spec("unsloth") is not None:
+        try:
+            module = importlib.import_module(_MODULE_NAME)
+        except ImportError as error:
+            if "Please install Unsloth" not in str(error):
+                raise
+        else:
+            yield module
+            return
+
+    before_modules = set(sys.modules)
+    sys.modules.pop("unsloth_zoo", None)
+    sys.modules.pop("unsloth_zoo.temporary_patches", None)
+    sys.modules.pop(_MODULE_NAME, None)
+    sys.modules["unsloth_zoo"] = _package_shell("unsloth_zoo", _PACKAGE_ROOT)
+    sys.modules["unsloth_zoo.temporary_patches"] = _package_shell(
+        "unsloth_zoo.temporary_patches",
+        _PACKAGE_ROOT / "temporary_patches",
+    )
+    try:
+        yield importlib.import_module(_MODULE_NAME)
+    finally:
+        for module_name in list(sys.modules):
+            if module_name == "unsloth_zoo" or module_name.startswith("unsloth_zoo."):
+                if module_name not in before_modules:
+                    sys.modules.pop(module_name, None)
+
+
+@pytest.fixture(scope = "module")
+def real_encoding():
+    try:
+        return openai_harmony.load_harmony_encoding(
+            openai_harmony.HarmonyEncodingName.HARMONY_GPT_OSS
+        )
+    except Exception as error:  # pragma: no cover - environment dependent (e.g. no network)
+        pytest.skip(f"gpt-oss harmony encoding unavailable: {error}")
+
+
+def _decode(messages, gpt_oss_module, **kwargs):
+    decoded_text, _ = gpt_oss_module.encode_conversations_with_harmony(messages, **kwargs)
+    return decoded_text
+
+
+def test_renderer_drops_analysis_before_final_by_default(real_encoding):
+    # Characterization of the upstream renderer: with auto_drop_analysis (the default),
+    # an analysis message that precedes a final message in the last assistant turn is
+    # dropped, while disabling auto_drop_analysis keeps it. This is exactly why a
+    # thinking+content turn does not surface reasoning in the default-rendered IDs.
+    Role = openai_harmony.Role
+    Message = openai_harmony.Message
+    Conversation = openai_harmony.Conversation
+
+    convo = Conversation.from_messages([
+        Message.from_role_and_content(Role.USER, "user prompt"),
+        Message.from_role_and_content(Role.ASSISTANT, "THINK_SENTINEL").with_channel("analysis"),
+        Message.from_role_and_content(Role.ASSISTANT, "ANSWER_SENTINEL").with_channel("final"),
+    ])
+
+    default_text = real_encoding.decode(real_encoding.render_conversation(convo))
+    assert "ANSWER_SENTINEL" in default_text
+    assert "THINK_SENTINEL" not in default_text
+
+    kept_text = real_encoding.decode(
+        real_encoding.render_conversation(
+            convo,
+            openai_harmony.RenderConversationConfig(auto_drop_analysis = False),
+        )
+    )
+    assert "ANSWER_SENTINEL" in kept_text
+    assert "THINK_SENTINEL" in kept_text
+
+
+def test_thinking_with_content_preserves_answer(real_encoding, gpt_oss_module):
+    # The #246 contract: the visible answer (content) must survive into the encoded
+    # output on the final channel. (Reasoning is dropped by Harmony's default
+    # auto_drop_analysis when a final follows it; that is intended for this render path.)
+    decoded = _decode(
+        [{"role": "assistant", "thinking": "REASON_SENTINEL", "content": "ANSWER_SENTINEL"}],
+        gpt_oss_module,
+    )
+    assert "ANSWER_SENTINEL" in decoded
+
+
+def test_thinking_only_preserves_reasoning(real_encoding, gpt_oss_module):
+    # A pure-reasoning turn ends in analysis (no trailing final), so the reasoning is
+    # kept in the rendered output.
+    decoded = _decode(
+        [{"role": "assistant", "thinking": "REASON_SENTINEL"}],
+        gpt_oss_module,
+    )
+    assert "REASON_SENTINEL" in decoded
+
+
+def test_thinking_with_tool_calls_keeps_tool_call(real_encoding, gpt_oss_module):
+    # Regression: a turn with both thinking and a tool call must keep the tool call in
+    # the encoded output (the old unconditional continue dropped it).
+    decoded = _decode(
+        [{
+            "role": "assistant",
+            "thinking": "REASON_SENTINEL",
+            "tool_calls": [{"name": "lookup_weather", "arguments": '{"city": "CITY_SENTINEL"}'}],
+        }],
+        gpt_oss_module,
+    )
+    assert "lookup_weather" in decoded
+    assert "CITY_SENTINEL" in decoded
+
+
+def test_thinking_tool_calls_and_content_keeps_tool_call(real_encoding, gpt_oss_module):
+    decoded = _decode(
+        [{
+            "role": "assistant",
+            "thinking": "REASON_SENTINEL",
+            "content": "ANSWER_SENTINEL",
+            "tool_calls": [{"name": "mixed_tool", "arguments": '{"value": "ARG_SENTINEL"}'}],
+        }],
+        gpt_oss_module,
+    )
+    assert "mixed_tool" in decoded
+    assert "ARG_SENTINEL" in decoded
+
+
+@pytest.mark.parametrize("thinking", [None, ""])
+def test_nullable_thinking_does_not_crash(real_encoding, gpt_oss_module, thinking):
+    # Nullable / empty thinking columns must not raise; the answer must still be encoded.
+    decoded = _decode(
+        [{"role": "assistant", "thinking": thinking, "content": "ANSWER_SENTINEL"}],
+        gpt_oss_module,
+    )
+    assert "ANSWER_SENTINEL" in decoded
+
+
+def test_plain_content_still_encodes(real_encoding, gpt_oss_module):
+    decoded = _decode(
+        [{"role": "assistant", "content": "PLAIN_SENTINEL"}],
+        gpt_oss_module,
+    )
+    assert "PLAIN_SENTINEL" in decoded

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2621,8 +2621,16 @@ def encode_conversations_with_harmony(
             convos.append(Message.from_role_and_content(Role.USER, message["content"]))
         elif message["role"] == "assistant":
             if "thinking" in message:
-                x = Message.from_role_and_content(Role.ASSISTANT, message["content"])
+                x = Message.from_role_and_content(Role.ASSISTANT, message["thinking"])
                 x = x.with_channel("analysis")
+                convos.append(x)
+                # An assistant turn can carry both reasoning and a final answer; emit the
+                # final-channel response too so it is not dropped from the encoded conversation.
+                if message.get("content"):
+                    final = Message.from_role_and_content(Role.ASSISTANT, message["content"])
+                    final = final.with_channel("final")
+                    convos.append(final)
+                continue
             elif "tool_calls" in message:
                 x = Message.from_role_and_content(Role.ASSISTANT, message["tool_calls"][0]["arguments"])
                 x = x.with_channel("commentary").with_recipient(f"functions.{message['tool_calls'][0]['name']}").with_content_type("json")

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2620,24 +2620,25 @@ def encode_conversations_with_harmony(
         if message["role"] == "user":
             convos.append(Message.from_role_and_content(Role.USER, message["content"]))
         elif message["role"] == "assistant":
-            if "thinking" in message:
+            # An assistant turn can independently carry reasoning, a tool call, and/or a
+            # final answer. Treat the parts separately so none silently suppresses another.
+            # Guard on truthiness (not key membership) so a nullable "thinking" column
+            # materialized as None or "" does not get passed into Harmony, which rejects it.
+            if message.get("thinking"):
                 x = Message.from_role_and_content(Role.ASSISTANT, message["thinking"])
                 x = x.with_channel("analysis")
                 convos.append(x)
-                # An assistant turn can carry both reasoning and a final answer; emit the
-                # final-channel response too so it is not dropped from the encoded conversation.
-                if message.get("content"):
-                    final = Message.from_role_and_content(Role.ASSISTANT, message["content"])
-                    final = final.with_channel("final")
-                    convos.append(final)
-                continue
-            elif "tool_calls" in message:
+            if message.get("tool_calls"):
                 x = Message.from_role_and_content(Role.ASSISTANT, message["tool_calls"][0]["arguments"])
                 x = x.with_channel("commentary").with_recipient(f"functions.{message['tool_calls'][0]['name']}").with_content_type("json")
-            else:
+                convos.append(x)
+            elif message.get("content"):
+                # A tool-call turn does not also emit a final answer (the answer comes
+                # after the tool result), so tool_calls and content stay mutually exclusive.
                 x = Message.from_role_and_content(Role.ASSISTANT, message["content"])
                 x = x.with_channel("final")
-            convos.append(x)
+                convos.append(x)
+            continue
         elif message["role"] == "tool":
             x = Message.from_author_and_content(Author.new(Role.TOOL, f"functions.{message['name']}"), message["content"])
             x = x.with_recipient("assistant").with_channel("commentary")


### PR DESCRIPTION
## Summary
In `temporary_patches/gpt_oss.py`, `encode_conversations_with_harmony` built the
`analysis`-channel `Message` from `message["content"]` inside the `"thinking"`
branch, so the reasoning text in `message["thinking"]` was silently dropped and
the visible answer was emitted on the wrong channel. This now encodes the
`analysis` channel from `message["thinking"]`, and when the same assistant turn
also has non-empty `content`, additionally emits a `final`-channel message so the
answer is preserved instead of being lost. The `tool_calls` and plain final-only
branches are unchanged.

## Why this matters
Assistant turns carrying both reasoning and an answer previously lost their
reasoning and mis-routed their content, corrupting the encoded Harmony
conversation used for gpt-oss training/inference. See
https://github.com/unslothai/unsloth-zoo/issues/246

## Testing
`python3 -m pytest tests/test_encode_conversations_with_harmony.py -q` -> 15 passed.
Four new hermetic CPU-only cases cover thinking+content (analysis carries thinking,
final carries content), thinking-only (single analysis message), plain content
(unchanged final-only), and a mixed multi-turn conversation confirming channel
ordering and that the tool branches stay untouched.

Fixes #246
