### PR TITLE
Fix: handle key format mismatch for VLM models (Ministral-3-14B)

### DIFF
--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -88,6 +88,42 @@ def test_remap_qwen35_extra_prefix_still_works():
     assert out.get("model.language_model.layers.0.self_attn.q_proj") == "model.layers.0.self_attn.q_proj"
 
 
+def test_remap_strips_extra_wrapper_prefix_onto_base_tensor():
+    """A LoRA carrying an extra leading wrapper (model.vision_tower.*) strips onto the
+    base tensor (vision_tower.*) when that tensor exists on disk."""
+    disk = ["vision_tower.transformer.layers.0.attention.q_proj.weight"]
+    out = _infer_prefix_and_remap(
+        _lw(["model.vision_tower.transformer.layers.0.attention.q_proj"]), disk)
+    assert out is not None
+    tgt = "vision_tower.transformer.layers.0.attention.q_proj"
+    assert out.get(tgt) == "model.vision_tower.transformer.layers.0.attention.q_proj"
+
+
+def test_remap_mixed_language_reorder_and_vision_strip():
+    """Composite VLM where the language half reorders (model.language_model.* ->
+    language_model.model.*) and the vision half only drops the leading model.. Both
+    namespaces resolve onto their own base tensors, neither onto a nonexistent key."""
+    disk = (
+        [f"language_model.model.layers.0.self_attn.{p}.weight" for p in ("q_proj", "k_proj")]
+        + [f"vision_tower.transformer.layers.0.attention.{p}.weight" for p in ("q_proj", "k_proj")]
+    )
+    lora = (
+        [f"model.language_model.layers.0.self_attn.{p}" for p in ("q_proj", "k_proj")]
+        + [f"model.vision_tower.transformer.layers.0.attention.{p}" for p in ("q_proj", "k_proj")]
+    )
+    out = _infer_prefix_and_remap(_lw(lora), disk)
+    assert out is not None
+    for p in ("q_proj", "k_proj"):
+        assert out.get(f"language_model.model.layers.0.self_attn.{p}") == \
+            f"model.language_model.layers.0.self_attn.{p}"
+        assert out.get(f"vision_tower.transformer.layers.0.attention.{p}") == \
+            f"model.vision_tower.transformer.layers.0.attention.{p}"
+    # No invented keys: every remapped target backs a real on-disk tensor.
+    for tgt in out:
+        if isinstance(tgt, str):
+            assert (tgt + ".weight") in set(disk)
+
+
 # ---------------------------------------------------------------------------
 # _count_backed_lora_modules: count matches what the merge loop would write
 # ---------------------------------------------------------------------------

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -27,8 +27,17 @@ CPU-only, no disk or model download.
 from __future__ import annotations
 
 import collections
+import importlib.util
+import sys
+import types
 
-from unsloth_zoo.saving_utils import (
+# These are pure key-string / count helpers and never use bitsandbytes, but importing
+# saving_utils pulls bitsandbytes at module scope. Inject a tiny stub when it is absent so
+# collection works in a CPU-only environment without the optional dependency.
+if importlib.util.find_spec("bitsandbytes") is None:
+    sys.modules.setdefault("bitsandbytes", types.ModuleType("bitsandbytes"))
+
+from unsloth_zoo.saving_utils import (  # noqa: E402
     LoraStats,
     _infer_prefix_and_remap,
     _count_backed_lora_modules,
@@ -373,6 +382,31 @@ def test_remap_prefix_add_onto_linear_weight():
                                   ["model.language_model.layers.0.mlp.gate_proj.linear.weight"])
     assert out is not None
     assert out["model.language_model.layers.0.mlp.gate_proj"] == "model.layers.0.mlp.gate_proj"
+
+
+def test_remap_strip_does_not_drop_semantic_namespace_to_bare_layers():
+    """The wrapper-strip fallback must remove only generic wrapper components (model/
+    base_model/module), never a semantic namespace. An unbacked vision adapter sharing a
+    suffix with a bare language tensor must not be merged onto it."""
+    out = _infer_prefix_and_remap(
+        _lw(["model.vision_tower.layers.0.self_attn.q_proj"]),
+        ["layers.0.self_attn.q_proj.weight"],
+    )
+    assert out is None or out.get("model.vision_tower.layers.0.self_attn.q_proj") == \
+        "model.vision_tower.layers.0.self_attn.q_proj"
+    assert not (out and out.get("layers.0.self_attn.q_proj") ==
+                "model.vision_tower.layers.0.self_attn.q_proj")
+
+
+def test_remap_strip_still_drops_leading_model_wrapper():
+    """The legitimate case still works: model.vision_tower.* strips the leading model.
+    onto the real vision_tower.* base tensor."""
+    out = _infer_prefix_and_remap(
+        _lw(["model.vision_tower.transformer.layers.0.attention.q_proj"]),
+        ["vision_tower.transformer.layers.0.attention.q_proj.weight"])
+    assert out is not None
+    assert out["vision_tower.transformer.layers.0.attention.q_proj"] == \
+        "model.vision_tower.transformer.layers.0.attention.q_proj"
 
 
 def test_count_fused_named_gate_up_proj_backed_by_per_expert():

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -334,6 +334,56 @@ def test_remap_reordered_linear_applied_via_seeded_vote():
         "model.language_model.layers.0.mlp.gate_proj"
 
 
+def test_remap_short_reordered_embed_tokens_alone():
+    """A reordered short module (embed_tokens) on a shard that holds no longer layer keys
+    must still learn its own reorder via a short-suffix vote, guarded so it only fires for a
+    true component reordering. Otherwise the merge silently drops the embedding delta."""
+    out = _infer_prefix_and_remap(_lw(["model.language_model.embed_tokens"]),
+                                  ["language_model.model.embed_tokens.weight"])
+    assert out is not None
+    assert out["language_model.model.embed_tokens"] == "model.language_model.embed_tokens"
+
+
+def test_remap_short_reordered_lm_head_alone():
+    out = _infer_prefix_and_remap(_lw(["model.language_model.lm_head"]),
+                                  ["language_model.model.lm_head.weight"])
+    assert out is not None
+    assert out["language_model.model.lm_head"] == "model.language_model.lm_head"
+
+
+def test_remap_short_suffix_does_not_cross_namespaces():
+    """A short suffix match that is NOT a component reordering must not vote (no misroute).
+    model.embed_tokens vs language_model.model.embed_tokens is a prefix add, not a reorder;
+    it resolves by the unique-prefix path, never by a cross-namespace substitution."""
+    out = _infer_prefix_and_remap(
+        _lw(["model.vision_tower.embed_tokens", "model.language_model.layers.0.self_attn.q_proj"]),
+        ["language_model.model.layers.0.self_attn.q_proj.weight"])  # no vision embed tensor
+    # the vision embed has no backing tensor and must be left unmapped, never pulled onto
+    # the language tensor by a 1-component 'embed_tokens'/'q_proj' style vote.
+    assert out.get("language_model.model.layers.0.self_attn.q_proj") == \
+        "model.language_model.layers.0.self_attn.q_proj"
+    assert "model.vision_tower.embed_tokens" not in out or \
+        out["model.vision_tower.embed_tokens"] == "model.vision_tower.embed_tokens"
+
+
+def test_remap_prefix_add_onto_linear_weight():
+    """A prefix-add LoRA key whose only backing is a Gemma4 ClippableLinear .linear.weight
+    tensor must still remap via the unique-prefix path (not only direct .weight)."""
+    out = _infer_prefix_and_remap(_lw(["model.layers.0.mlp.gate_proj"]),
+                                  ["model.language_model.layers.0.mlp.gate_proj.linear.weight"])
+    assert out is not None
+    assert out["model.language_model.layers.0.mlp.gate_proj"] == "model.layers.0.mlp.gate_proj"
+
+
+def test_count_fused_named_gate_up_proj_backed_by_per_expert():
+    """A fused-named LoRA key ...experts.gate_up_proj is backed by per-expert descendants
+    ...experts.<e>.gate_proj.weight (the merge maps them onto it), so it must count."""
+    keys = ["model.layers.0.mlp.experts.gate_up_proj"]
+    disk = ["model.layers.0.mlp.experts.0.gate_proj.weight", "model.layers.0.mlp.experts.0.up_proj.weight",
+            "model.layers.0.mlp.experts.1.gate_proj.weight", "model.layers.0.mlp.experts.1.up_proj.weight"]
+    assert _count(keys, disk) == 1
+
+
 def test_count_native_mxfp4_does_not_count_packed():
     """Native mxfp4 save (save_method='mxfp4') preserves _blocks/_scales without merging,
     so a LoRA on a packed expert is not written and must not be counted (count_packed_mxfp4

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -132,11 +132,11 @@ def test_count_vision_tower_unbacked_excluded():
 
 def test_count_tied_embed_and_bare_lm_head():
     """Tied model, modules_to_save on model.embed_tokens and bare lm_head, only
-    embed_tokens.weight on disk. lm_head resolves to embed_tokens via the model.
-    add/strip, so both count; the Step-7 tied discount then makes it match the one
-    merged tensor."""
+    embed_tokens.weight on disk. The merge writes the embed delta and drops lm_head
+    (the tied bridge fires only when embed is not itself a target), so exactly one
+    tensor is merged and the merge-accurate count is 1, with no separate discount."""
     assert _count(["model.embed_tokens", "lm_head"], ["model.embed_tokens.weight"],
-                  model_class_name="LlamaForCausalLM", tie=True) == 2
+                  model_class_name="LlamaForCausalLM", tie=True) == 1
 
 
 def test_count_tied_bare_lm_head_with_layer():
@@ -151,3 +151,23 @@ def test_count_untied_lm_head_on_disk():
     assert _count(["lm_head", "model.layers.0.self_attn.q_proj"],
                   ["lm_head.weight", "model.layers.0.self_attn.q_proj.weight"],
                   model_class_name="LlamaForCausalLM", tie=False) == 2
+
+
+def test_count_composite_tied_embed_and_bare_lm_head():
+    """Composite VLM (deep model.language_model. prefix), tied, modules_to_save on the
+    deep embed_tokens and a bare lm_head, only the deep embed tensor on disk. The merge
+    writes the embed delta and cannot bridge the bare lm_head onto the deep-prefix embed,
+    so it merges one tensor and the count must mirror that as 1. The previous
+    discount-based scheme under-counted this to 0 and raised a false RuntimeError."""
+    assert _count(["model.language_model.embed_tokens", "lm_head"],
+                  ["model.language_model.embed_tokens.weight"],
+                  model_class_name="PreTrainedModel", tie=True) == 1
+
+
+def test_count_composite_tied_bare_lm_head_unbridgeable_dropped():
+    """Composite VLM, tied, a bare lm_head whose embed lives only at a deep prefix. The
+    merge cannot bridge a bare lm_head onto model.language_model.embed_tokens.weight, so
+    it is dropped and contributes 0 (the standard model.embed_tokens case still bridges
+    and counts, see test_count_tied_bare_lm_head_with_layer)."""
+    assert _count(["lm_head"], ["model.language_model.embed_tokens.weight"],
+                  model_class_name="PreTrainedModel", tie=True) == 0

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -207,3 +207,53 @@ def test_count_composite_tied_bare_lm_head_unbridgeable_dropped():
     and counts, see test_count_tied_bare_lm_head_with_layer)."""
     assert _count(["lm_head"], ["model.language_model.embed_tokens.weight"],
                   model_class_name="PreTrainedModel", tie=True) == 0
+
+
+def test_count_mxfp4_packed_experts():
+    """MXFP4 base: fused experts are stored packed as <module>_blocks / _scales and the
+    merge dequantizes them to <module> on save, so a LoRA on such a module has no .weight
+    on disk. It must still be counted as backed (the merge writes and counts it)."""
+    keys = ["model.layers.0.mlp.experts.gate_up_proj", "model.layers.0.mlp.experts.down_proj",
+            "model.layers.0.self_attn.q_proj"]
+    disk = ["model.layers.0.mlp.experts.gate_up_proj_blocks", "model.layers.0.mlp.experts.gate_up_proj_scales",
+            "model.layers.0.mlp.experts.down_proj_blocks", "model.layers.0.mlp.experts.down_proj_scales",
+            "model.layers.0.self_attn.q_proj.weight"]
+    assert _count(keys, disk) == 3
+
+
+def test_count_mxfp4_blocks_without_scales_not_counted():
+    """A packed module missing its _scales tensor is skipped by the merge (it cannot be
+    dequantized), so it must not be counted as backed."""
+    keys = ["model.layers.0.mlp.experts.gate_up_proj", "model.layers.0.self_attn.q_proj"]
+    disk = ["model.layers.0.mlp.experts.gate_up_proj_blocks",  # no matching _scales
+            "model.layers.0.self_attn.q_proj.weight"]
+    assert _count(keys, disk) == 1
+
+
+def test_count_cross_namespace_same_trailing_path_union():
+    """Sharded composite checkpoint where two namespaces (language reorder + vision strip)
+    share the same trailing module path but live in different shards. Counting against the
+    union of all shard keys must still resolve each LoRA onto its own tensor (count 2), not
+    collapse them into an ambiguous unbacked pair."""
+    keys = ["model.language_model.layers.0.self_attn.q_proj",
+            "model.vision_tower.transformer.layers.0.self_attn.q_proj"]
+    union = ["language_model.model.layers.0.self_attn.q_proj.weight",
+             "vision_tower.transformer.layers.0.self_attn.q_proj.weight"]
+    assert _count(keys, union) == 2
+
+
+def test_remap_cross_namespace_union_resolves_both():
+    """The remap, given the union of both shards' keys, routes the language key to its
+    reordered tensor and the vision key to its stripped tensor, never crossing namespaces."""
+    union = ["language_model.model.layers.0.self_attn.q_proj.weight",
+             "vision_tower.transformer.layers.0.self_attn.q_proj.weight"]
+    out = _infer_prefix_and_remap(
+        _lw(["model.language_model.layers.0.self_attn.q_proj",
+             "model.vision_tower.transformer.layers.0.self_attn.q_proj"]),
+        union,
+    )
+    assert out is not None
+    assert out.get("language_model.model.layers.0.self_attn.q_proj") == \
+        "model.language_model.layers.0.self_attn.q_proj"
+    assert out.get("vision_tower.transformer.layers.0.self_attn.q_proj") == \
+        "model.vision_tower.transformer.layers.0.self_attn.q_proj"

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -14,14 +14,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Unit tests for the LoRA-save key remap and the Step-7 backed-module count in
-unsloth_zoo/saving_utils.py.
+"""Tests for the LoRA-save key remap and backed-module count in saving_utils.py.
 
-Covers the VLM prefix reorder fix, its guards against misrouting a vision LoRA
-onto a language tensor, and the backed-module count across model families
-(normal, reordered VLM, Gemma4 ClippableLinear, fused/per-expert MoE, tied
-embeddings, and a vision tower absent from the base safetensors). Pure-function,
-CPU-only, no disk or model download.
+Covers the VLM prefix reorder fix, vision-onto-language misroute guards, and the
+backed-module count across model families (VLM, Gemma4 ClippableLinear, MoE, tied
+embeddings, absent vision tower). Pure-function, CPU-only, no disk/download.
 """
 
 from __future__ import annotations
@@ -31,9 +28,7 @@ import importlib.util
 import sys
 import types
 
-# These are pure key-string / count helpers and never use bitsandbytes, but importing
-# saving_utils pulls bitsandbytes at module scope. Inject a tiny stub when it is absent so
-# collection works in a CPU-only environment without the optional dependency.
+# saving_utils imports bitsandbytes at module scope; stub it so CPU-only collection works.
 if importlib.util.find_spec("bitsandbytes") is None:
     sys.modules.setdefault("bitsandbytes", types.ModuleType("bitsandbytes"))
 
@@ -45,16 +40,12 @@ from unsloth_zoo.saving_utils import (  # noqa: E402
 
 
 def _lw(keys):
-    """Build a lora_weights defaultdict; value is the key so we can trace remaps."""
+    """Build a lora_weights defaultdict whose value is the key, to trace remaps."""
     d = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
     for k in keys:
         d[k] = k
     return d
 
-
-# ---------------------------------------------------------------------------
-# _infer_prefix_and_remap: reorder fix + misroute guards
-# ---------------------------------------------------------------------------
 
 def test_remap_reorders_ministral_language_keys():
     """model.language_model.* LoRA keys remap onto language_model.model.* tensors."""
@@ -75,8 +66,7 @@ def test_remap_returns_none_when_already_aligned():
 
 
 def test_remap_does_not_misroute_vision_onto_language_tensor():
-    """A vision LoRA sharing a trailing path with a language tensor must not be
-    rewritten onto that language tensor when only the language tensor exists."""
+    """Vision LoRA sharing a trailing path with a language tensor isn't rewritten onto it."""
     disk = ["language_model.model.layers.0.self_attn.q_proj.weight"]
     out = _infer_prefix_and_remap(
         _lw([
@@ -98,8 +88,7 @@ def test_remap_qwen35_extra_prefix_still_works():
 
 
 def test_remap_strips_extra_wrapper_prefix_onto_base_tensor():
-    """A LoRA carrying an extra leading wrapper (model.vision_tower.*) strips onto the
-    base tensor (vision_tower.*) when that tensor exists on disk."""
+    """An extra leading wrapper (model.vision_tower.*) strips onto the base vision_tower.* tensor."""
     disk = ["vision_tower.transformer.layers.0.attention.q_proj.weight"]
     out = _infer_prefix_and_remap(
         _lw(["model.vision_tower.transformer.layers.0.attention.q_proj"]), disk)
@@ -109,9 +98,7 @@ def test_remap_strips_extra_wrapper_prefix_onto_base_tensor():
 
 
 def test_remap_mixed_language_reorder_and_vision_strip():
-    """Composite VLM where the language half reorders (model.language_model.* ->
-    language_model.model.*) and the vision half only drops the leading model.. Both
-    namespaces resolve onto their own base tensors, neither onto a nonexistent key."""
+    """Composite VLM: language half reorders, vision half strips leading model.; each resolves onto its own tensor."""
     disk = (
         [f"language_model.model.layers.0.self_attn.{p}.weight" for p in ("q_proj", "k_proj")]
         + [f"vision_tower.transformer.layers.0.attention.{p}.weight" for p in ("q_proj", "k_proj")]
@@ -127,15 +114,13 @@ def test_remap_mixed_language_reorder_and_vision_strip():
             f"model.language_model.layers.0.self_attn.{p}"
         assert out.get(f"vision_tower.transformer.layers.0.attention.{p}") == \
             f"model.vision_tower.transformer.layers.0.attention.{p}"
-    # No invented keys: every remapped target backs a real on-disk tensor.
+    # Every remapped target backs a real on-disk tensor; no invented keys.
     for tgt in out:
         if isinstance(tgt, str):
             assert (tgt + ".weight") in set(disk)
 
 
-# ---------------------------------------------------------------------------
-# _count_backed_lora_modules: count matches what the merge loop would write
-# ---------------------------------------------------------------------------
+# _count_backed_lora_modules: count must match what the merge loop would write.
 
 def _count(keys, disk_keys, model_class_name="PreTrainedModel", tie=False):
     return _count_backed_lora_modules(_lw(keys), set(disk_keys), model_class_name, tie)
@@ -176,10 +161,7 @@ def test_count_vision_tower_unbacked_excluded():
 
 
 def test_count_tied_embed_and_bare_lm_head():
-    """Tied model, modules_to_save on model.embed_tokens and bare lm_head, only
-    embed_tokens.weight on disk. The merge writes the embed delta and drops lm_head
-    (the tied bridge fires only when embed is not itself a target), so exactly one
-    tensor is merged and the merge-accurate count is 1, with no separate discount."""
+    """Tied embed + bare lm_head, only embed on disk: merge writes embed, drops lm_head, count 1."""
     assert _count(["model.embed_tokens", "lm_head"], ["model.embed_tokens.weight"],
                   model_class_name="LlamaForCausalLM", tie=True) == 1
 
@@ -199,29 +181,20 @@ def test_count_untied_lm_head_on_disk():
 
 
 def test_count_composite_tied_embed_and_bare_lm_head():
-    """Composite VLM (deep model.language_model. prefix), tied, modules_to_save on the
-    deep embed_tokens and a bare lm_head, only the deep embed tensor on disk. The merge
-    writes the embed delta and cannot bridge the bare lm_head onto the deep-prefix embed,
-    so it merges one tensor and the count must mirror that as 1. The previous
-    discount-based scheme under-counted this to 0 and raised a false RuntimeError."""
+    """Composite VLM, tied, deep embed + bare lm_head: lm_head can't bridge the deep embed, count 1."""
     assert _count(["model.language_model.embed_tokens", "lm_head"],
                   ["model.language_model.embed_tokens.weight"],
                   model_class_name="PreTrainedModel", tie=True) == 1
 
 
 def test_count_composite_tied_bare_lm_head_unbridgeable_dropped():
-    """Composite VLM, tied, a bare lm_head whose embed lives only at a deep prefix. The
-    merge cannot bridge a bare lm_head onto model.language_model.embed_tokens.weight, so
-    it is dropped and contributes 0 (the standard model.embed_tokens case still bridges
-    and counts, see test_count_tied_bare_lm_head_with_layer)."""
+    """Composite VLM, tied: a bare lm_head can't bridge a deep-prefix embed, so it's dropped (count 0)."""
     assert _count(["lm_head"], ["model.language_model.embed_tokens.weight"],
                   model_class_name="PreTrainedModel", tie=True) == 0
 
 
 def test_count_mxfp4_packed_experts():
-    """MXFP4 base: fused experts are stored packed as <module>_blocks / _scales and the
-    merge dequantizes them to <module> on save, so a LoRA on such a module has no .weight
-    on disk. It must still be counted as backed (the merge writes and counts it)."""
+    """MXFP4 fused experts (packed _blocks/_scales, no .weight) are dequantized on save, so counted."""
     keys = ["model.layers.0.mlp.experts.gate_up_proj", "model.layers.0.mlp.experts.down_proj",
             "model.layers.0.self_attn.q_proj"]
     disk = ["model.layers.0.mlp.experts.gate_up_proj_blocks", "model.layers.0.mlp.experts.gate_up_proj_scales",
@@ -231,8 +204,7 @@ def test_count_mxfp4_packed_experts():
 
 
 def test_count_mxfp4_blocks_without_scales_not_counted():
-    """A packed module missing its _scales tensor is skipped by the merge (it cannot be
-    dequantized), so it must not be counted as backed."""
+    """A packed module missing its _scales can't be dequantized, so it's not counted."""
     keys = ["model.layers.0.mlp.experts.gate_up_proj", "model.layers.0.self_attn.q_proj"]
     disk = ["model.layers.0.mlp.experts.gate_up_proj_blocks",  # no matching _scales
             "model.layers.0.self_attn.q_proj.weight"]
@@ -240,10 +212,7 @@ def test_count_mxfp4_blocks_without_scales_not_counted():
 
 
 def test_count_cross_namespace_same_trailing_path_union():
-    """Sharded composite checkpoint where two namespaces (language reorder + vision strip)
-    share the same trailing module path but live in different shards. Counting against the
-    union of all shard keys must still resolve each LoRA onto its own tensor (count 2), not
-    collapse them into an ambiguous unbacked pair."""
+    """Sharded VLM: two namespaces share a trailing path; against the key union each resolves (count 2)."""
     keys = ["model.language_model.layers.0.self_attn.q_proj",
             "model.vision_tower.transformer.layers.0.self_attn.q_proj"]
     union = ["language_model.model.layers.0.self_attn.q_proj.weight",
@@ -252,8 +221,7 @@ def test_count_cross_namespace_same_trailing_path_union():
 
 
 def test_remap_cross_namespace_union_resolves_both():
-    """The remap, given the union of both shards' keys, routes the language key to its
-    reordered tensor and the vision key to its stripped tensor, never crossing namespaces."""
+    """Given both shards' key union, the remap routes language and vision keys without crossing namespaces."""
     union = ["language_model.model.layers.0.self_attn.q_proj.weight",
              "vision_tower.transformer.layers.0.self_attn.q_proj.weight"]
     out = _infer_prefix_and_remap(
@@ -269,9 +237,7 @@ def test_remap_cross_namespace_union_resolves_both():
 
 
 def test_remap_common_prefix_still_applies_to_moe_expert_backing():
-    """The common-prefix fallback must prefix MoE LoRA keys that are backed by descendant
-    expert tensors (model.layers.0.mlp.experts.0.*.weight), not only keys with a direct
-    <key>.weight. Otherwise the prefixed key is dropped and the MoE delta is skipped."""
+    """Common-prefix fallback must prefix MoE keys backed by descendant expert tensors, not only direct .weight."""
     disk = [
         "model.layers.0.self_attn.q_proj.weight",
         "model.layers.0.mlp.experts.0.gate_proj.weight",
@@ -292,34 +258,28 @@ def test_remap_common_prefix_still_applies_to_moe_expert_backing():
 
 
 def test_count_fused_3d_experts_without_weight_suffix():
-    """Fused 3D MoE (GPT-OSS / Gemma4) stores experts as <prefix>.gate_up_proj /
-    <prefix>.down_proj with no .weight; _merge_moe_experts_file merges them, so they must
-    be counted as backed."""
+    """Fused 3D MoE (GPT-OSS/Gemma4) stores experts with no .weight; the merge handles them, so counted."""
     keys = ["model.layers.0.experts.base_layer", "model.layers.0.experts"]
     disk = ["model.layers.0.experts.gate_up_proj", "model.layers.0.experts.down_proj"]
     assert _count(keys, disk) == 2
 
 
 def test_count_moe_alias_resolves_to_fused_experts():
-    """A LoRA key using .moe is aliased to .experts by the merge, so it must count against
-    the fused expert tensors stored under .experts."""
+    """A .moe LoRA key is aliased to .experts by the merge, so it counts against the fused .experts tensors."""
     keys = ["model.layers.0.moe.base_layer", "model.layers.0.moe"]
     disk = ["model.layers.0.experts.gate_up_proj", "model.layers.0.experts.down_proj"]
     assert _count(keys, disk) == 2
 
 
 def test_count_mxfp4_per_expert_packed():
-    """Per-expert packed mxfp4 experts (descendant <prefix>.<e>.<proj>_blocks/_scales)
-    count as backed."""
+    """Per-expert packed mxfp4 experts (descendant <prefix>.<e>.<proj>_blocks/_scales) count as backed."""
     keys = ["model.layers.0.mlp.experts.base_layer"]
     disk = ["model.layers.0.mlp.experts.0.gate_proj_blocks", "model.layers.0.mlp.experts.0.gate_proj_scales"]
     assert _count(keys, disk) == 1
 
 
 def test_remap_reordered_clippable_linear():
-    """A reordered composite VLM whose module is stored as Gemma4 ClippableLinear
-    (<module>.linear.weight) must still learn the prefix substitution (the vote normalizes
-    .linear.weight to its module key) and accept the .linear-backed target."""
+    """Reordered VLM stored as Gemma4 ClippableLinear (<module>.linear.weight) still learns the prefix and is backed."""
     disk = ["language_model.model.layers.0.mlp.gate_proj.linear.weight"]
     out = _infer_prefix_and_remap(_lw(["model.language_model.layers.0.mlp.gate_proj"]), disk)
     assert out is not None
@@ -329,8 +289,7 @@ def test_remap_reordered_clippable_linear():
 
 
 def test_remap_reordered_linear_applied_via_seeded_vote():
-    """Vote seeded by a .weight attention key, then applied to a sibling .linear.weight
-    module: the application must accept the .linear backing, not only direct .weight."""
+    """A vote seeded by a .weight key, applied to a sibling .linear.weight module, accepts the .linear backing."""
     disk = ["language_model.model.layers.0.self_attn.q_proj.weight",
             "language_model.model.layers.0.mlp.gate_proj.linear.weight"]
     out = _infer_prefix_and_remap(
@@ -344,9 +303,7 @@ def test_remap_reordered_linear_applied_via_seeded_vote():
 
 
 def test_remap_short_reordered_embed_tokens_alone():
-    """A reordered short module (embed_tokens) on a shard that holds no longer layer keys
-    must still learn its own reorder via a short-suffix vote, guarded so it only fires for a
-    true component reordering. Otherwise the merge silently drops the embedding delta."""
+    """A reordered short module (embed_tokens) alone still learns its reorder via a guarded short-suffix vote."""
     out = _infer_prefix_and_remap(_lw(["model.language_model.embed_tokens"]),
                                   ["language_model.model.embed_tokens.weight"])
     assert out is not None
@@ -361,14 +318,11 @@ def test_remap_short_reordered_lm_head_alone():
 
 
 def test_remap_short_suffix_does_not_cross_namespaces():
-    """A short suffix match that is NOT a component reordering must not vote (no misroute).
-    model.embed_tokens vs language_model.model.embed_tokens is a prefix add, not a reorder;
-    it resolves by the unique-prefix path, never by a cross-namespace substitution."""
+    """A short-suffix match that is a prefix add, not a reorder, must not vote (no cross-namespace misroute)."""
     out = _infer_prefix_and_remap(
         _lw(["model.vision_tower.embed_tokens", "model.language_model.layers.0.self_attn.q_proj"]),
         ["language_model.model.layers.0.self_attn.q_proj.weight"])  # no vision embed tensor
-    # the vision embed has no backing tensor and must be left unmapped, never pulled onto
-    # the language tensor by a 1-component 'embed_tokens'/'q_proj' style vote.
+    # The vision embed has no backing tensor; it must stay unmapped, not be pulled onto the language tensor.
     assert out.get("language_model.model.layers.0.self_attn.q_proj") == \
         "model.language_model.layers.0.self_attn.q_proj"
     assert "model.vision_tower.embed_tokens" not in out or \
@@ -376,8 +330,7 @@ def test_remap_short_suffix_does_not_cross_namespaces():
 
 
 def test_remap_prefix_add_onto_linear_weight():
-    """A prefix-add LoRA key whose only backing is a Gemma4 ClippableLinear .linear.weight
-    tensor must still remap via the unique-prefix path (not only direct .weight)."""
+    """A prefix-add key backed only by a ClippableLinear .linear.weight still remaps via the unique-prefix path."""
     out = _infer_prefix_and_remap(_lw(["model.layers.0.mlp.gate_proj"]),
                                   ["model.language_model.layers.0.mlp.gate_proj.linear.weight"])
     assert out is not None
@@ -385,9 +338,7 @@ def test_remap_prefix_add_onto_linear_weight():
 
 
 def test_remap_strip_does_not_drop_semantic_namespace_to_bare_layers():
-    """The wrapper-strip fallback must remove only generic wrapper components (model/
-    base_model/module), never a semantic namespace. An unbacked vision adapter sharing a
-    suffix with a bare language tensor must not be merged onto it."""
+    """Wrapper-strip removes only generic wrappers, never a semantic namespace onto a bare language tensor."""
     out = _infer_prefix_and_remap(
         _lw(["model.vision_tower.layers.0.self_attn.q_proj"]),
         ["layers.0.self_attn.q_proj.weight"],
@@ -399,8 +350,7 @@ def test_remap_strip_does_not_drop_semantic_namespace_to_bare_layers():
 
 
 def test_remap_strip_still_drops_leading_model_wrapper():
-    """The legitimate case still works: model.vision_tower.* strips the leading model.
-    onto the real vision_tower.* base tensor."""
+    """The legitimate case still works: model.vision_tower.* strips onto the real vision_tower.* tensor."""
     out = _infer_prefix_and_remap(
         _lw(["model.vision_tower.transformer.layers.0.attention.q_proj"]),
         ["vision_tower.transformer.layers.0.attention.q_proj.weight"])
@@ -410,8 +360,7 @@ def test_remap_strip_still_drops_leading_model_wrapper():
 
 
 def test_count_fused_named_gate_up_proj_backed_by_per_expert():
-    """A fused-named LoRA key ...experts.gate_up_proj is backed by per-expert descendants
-    ...experts.<e>.gate_proj.weight (the merge maps them onto it), so it must count."""
+    """A fused-named key ...experts.gate_up_proj is backed by per-expert descendants, so it counts."""
     keys = ["model.layers.0.mlp.experts.gate_up_proj"]
     disk = ["model.layers.0.mlp.experts.0.gate_proj.weight", "model.layers.0.mlp.experts.0.up_proj.weight",
             "model.layers.0.mlp.experts.1.gate_proj.weight", "model.layers.0.mlp.experts.1.up_proj.weight"]
@@ -419,9 +368,7 @@ def test_count_fused_named_gate_up_proj_backed_by_per_expert():
 
 
 def test_count_native_mxfp4_does_not_count_packed():
-    """Native mxfp4 save (save_method='mxfp4') preserves _blocks/_scales without merging,
-    so a LoRA on a packed expert is not written and must not be counted (count_packed_mxfp4
-    =False). The dequantizing path (default True) does count it, since it merges."""
+    """Native mxfp4 save preserves packed experts without merging, so count_packed_mxfp4=False -> 0, True -> 1."""
     keys = ["model.layers.0.mlp.experts.gate_up_proj"]
     disk = ["model.layers.0.mlp.experts.gate_up_proj_blocks", "model.layers.0.mlp.experts.gate_up_proj_scales"]
     assert _count_backed_lora_modules(_lw(keys), set(disk), "PreTrainedModel", False,

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -1,0 +1,153 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Unit tests for the LoRA-save key remap and the Step-7 backed-module count in
+unsloth_zoo/saving_utils.py.
+
+Covers the VLM prefix reorder fix, its guards against misrouting a vision LoRA
+onto a language tensor, and the backed-module count across model families
+(normal, reordered VLM, Gemma4 ClippableLinear, fused/per-expert MoE, tied
+embeddings, and a vision tower absent from the base safetensors). Pure-function,
+CPU-only, no disk or model download.
+"""
+
+from __future__ import annotations
+
+import collections
+
+from unsloth_zoo.saving_utils import (
+    LoraStats,
+    _infer_prefix_and_remap,
+    _count_backed_lora_modules,
+)
+
+
+def _lw(keys):
+    """Build a lora_weights defaultdict; value is the key so we can trace remaps."""
+    d = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
+    for k in keys:
+        d[k] = k
+    return d
+
+
+# ---------------------------------------------------------------------------
+# _infer_prefix_and_remap: reorder fix + misroute guards
+# ---------------------------------------------------------------------------
+
+def test_remap_reorders_ministral_language_keys():
+    """model.language_model.* LoRA keys remap onto language_model.model.* tensors."""
+    disk = [f"language_model.model.layers.0.self_attn.{p}.weight" for p in ("q_proj", "k_proj")]
+    out = _infer_prefix_and_remap(
+        _lw([f"model.language_model.layers.0.self_attn.{p}" for p in ("q_proj", "k_proj")]),
+        disk,
+    )
+    assert out is not None
+    for p in ("q_proj", "k_proj"):
+        tgt = f"language_model.model.layers.0.self_attn.{p}"
+        assert out.get(tgt) == f"model.language_model.layers.0.self_attn.{p}"
+
+
+def test_remap_returns_none_when_already_aligned():
+    disk = ["model.layers.0.self_attn.q_proj.weight"]
+    assert _infer_prefix_and_remap(_lw(["model.layers.0.self_attn.q_proj"]), disk) is None
+
+
+def test_remap_does_not_misroute_vision_onto_language_tensor():
+    """A vision LoRA sharing a trailing path with a language tensor must not be
+    rewritten onto that language tensor when only the language tensor exists."""
+    disk = ["language_model.model.layers.0.self_attn.q_proj.weight"]
+    out = _infer_prefix_and_remap(
+        _lw([
+            "model.language_model.layers.0.self_attn.q_proj",  # legitimate language target
+            "model.vision_tower.layers.0.self_attn.q_proj",    # must NOT claim the language tensor
+        ]),
+        disk,
+    )
+    tgt = "language_model.model.layers.0.self_attn.q_proj"
+    assert out.get(tgt) == "model.language_model.layers.0.self_attn.q_proj"
+
+
+def test_remap_qwen35_extra_prefix_still_works():
+    """Extra-prefix remap (model.* -> model.language_model.*) is unaffected."""
+    disk = ["model.language_model.layers.0.self_attn.q_proj.weight"]
+    out = _infer_prefix_and_remap(_lw(["model.layers.0.self_attn.q_proj"]), disk)
+    assert out is not None
+    assert out.get("model.language_model.layers.0.self_attn.q_proj") == "model.layers.0.self_attn.q_proj"
+
+
+# ---------------------------------------------------------------------------
+# _count_backed_lora_modules: count matches what the merge loop would write
+# ---------------------------------------------------------------------------
+
+def _count(keys, disk_keys, model_class_name="PreTrainedModel", tie=False):
+    return _count_backed_lora_modules(_lw(keys), set(disk_keys), model_class_name, tie)
+
+
+def test_count_normal_aligned():
+    keys = [f"model.layers.0.self_attn.{p}" for p in ("q_proj", "k_proj", "v_proj")]
+    disk = [k + ".weight" for k in keys]
+    assert _count(keys, disk) == 3
+
+
+def test_count_reordered_vlm():
+    keys = [f"model.language_model.layers.0.self_attn.{p}" for p in ("q_proj", "k_proj", "v_proj")]
+    disk = [f"language_model.model.layers.0.self_attn.{p}.weight" for p in ("q_proj", "k_proj", "v_proj")]
+    assert _count(keys, disk) == 3
+
+
+def test_count_gemma4_clippable_linear():
+    keys = [f"model.layers.0.mlp.{p}" for p in ("gate_proj", "up_proj", "down_proj")]
+    disk = [f"model.layers.0.mlp.{p}.linear.weight" for p in ("gate_proj", "up_proj", "down_proj")]
+    assert _count(keys, disk) == 3
+
+
+def test_count_moe_per_expert():
+    keys = ["model.layers.0.mlp.experts.base_layer", "model.layers.0.mlp.experts"]
+    disk = [f"model.layers.0.mlp.experts.{e}.{p}.weight" for e in (0, 1) for p in ("gate_proj", "up_proj", "down_proj")]
+    assert _count(keys, disk) == 2
+
+
+def test_count_vision_tower_unbacked_excluded():
+    """A vision tower LoRA absent from the base safetensors is not counted."""
+    keys = [
+        "model.language_model.layers.0.self_attn.q_proj",
+        "model.vision_tower.transformer.layers.0.attention.q_proj",  # no backing tensor
+    ]
+    disk = ["language_model.model.layers.0.self_attn.q_proj.weight"]
+    assert _count(keys, disk) == 1
+
+
+def test_count_tied_embed_and_bare_lm_head():
+    """Tied model, modules_to_save on model.embed_tokens and bare lm_head, only
+    embed_tokens.weight on disk. lm_head resolves to embed_tokens via the model.
+    add/strip, so both count; the Step-7 tied discount then makes it match the one
+    merged tensor."""
+    assert _count(["model.embed_tokens", "lm_head"], ["model.embed_tokens.weight"],
+                  model_class_name="LlamaForCausalLM", tie=True) == 2
+
+
+def test_count_tied_bare_lm_head_with_layer():
+    """Bare lm_head + a normal layer; lm_head is backed via the tied embed tensor."""
+    assert _count(["lm_head", "model.layers.0.self_attn.q_proj"],
+                  ["model.embed_tokens.weight", "model.layers.0.self_attn.q_proj.weight"],
+                  model_class_name="LlamaForCausalLM", tie=True) == 2
+
+
+def test_count_untied_lm_head_on_disk():
+    """Untied: lm_head.weight present on disk, counted directly, no tie inflation."""
+    assert _count(["lm_head", "model.layers.0.self_attn.q_proj"],
+                  ["lm_head.weight", "model.layers.0.self_attn.q_proj.weight"],
+                  model_class_name="LlamaForCausalLM", tie=False) == 2

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -305,3 +305,42 @@ def test_count_mxfp4_per_expert_packed():
     keys = ["model.layers.0.mlp.experts.base_layer"]
     disk = ["model.layers.0.mlp.experts.0.gate_proj_blocks", "model.layers.0.mlp.experts.0.gate_proj_scales"]
     assert _count(keys, disk) == 1
+
+
+def test_remap_reordered_clippable_linear():
+    """A reordered composite VLM whose module is stored as Gemma4 ClippableLinear
+    (<module>.linear.weight) must still learn the prefix substitution (the vote normalizes
+    .linear.weight to its module key) and accept the .linear-backed target."""
+    disk = ["language_model.model.layers.0.mlp.gate_proj.linear.weight"]
+    out = _infer_prefix_and_remap(_lw(["model.language_model.layers.0.mlp.gate_proj"]), disk)
+    assert out is not None
+    assert out["language_model.model.layers.0.mlp.gate_proj"] == \
+        "model.language_model.layers.0.mlp.gate_proj"
+    assert _count(["model.language_model.layers.0.mlp.gate_proj"], disk) == 1
+
+
+def test_remap_reordered_linear_applied_via_seeded_vote():
+    """Vote seeded by a .weight attention key, then applied to a sibling .linear.weight
+    module: the application must accept the .linear backing, not only direct .weight."""
+    disk = ["language_model.model.layers.0.self_attn.q_proj.weight",
+            "language_model.model.layers.0.mlp.gate_proj.linear.weight"]
+    out = _infer_prefix_and_remap(
+        _lw(["model.language_model.layers.0.self_attn.q_proj",
+             "model.language_model.layers.0.mlp.gate_proj"]),
+        disk,
+    )
+    assert out is not None
+    assert out["language_model.model.layers.0.mlp.gate_proj"] == \
+        "model.language_model.layers.0.mlp.gate_proj"
+
+
+def test_count_native_mxfp4_does_not_count_packed():
+    """Native mxfp4 save (save_method='mxfp4') preserves _blocks/_scales without merging,
+    so a LoRA on a packed expert is not written and must not be counted (count_packed_mxfp4
+    =False). The dequantizing path (default True) does count it, since it merges."""
+    keys = ["model.layers.0.mlp.experts.gate_up_proj"]
+    disk = ["model.layers.0.mlp.experts.gate_up_proj_blocks", "model.layers.0.mlp.experts.gate_up_proj_scales"]
+    assert _count_backed_lora_modules(_lw(keys), set(disk), "PreTrainedModel", False,
+                                      count_packed_mxfp4=False) == 0
+    assert _count_backed_lora_modules(_lw(keys), set(disk), "PreTrainedModel", False,
+                                      count_packed_mxfp4=True) == 1

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -257,3 +257,51 @@ def test_remap_cross_namespace_union_resolves_both():
         "model.language_model.layers.0.self_attn.q_proj"
     assert out.get("vision_tower.transformer.layers.0.self_attn.q_proj") == \
         "model.vision_tower.transformer.layers.0.self_attn.q_proj"
+
+
+def test_remap_common_prefix_still_applies_to_moe_expert_backing():
+    """The common-prefix fallback must prefix MoE LoRA keys that are backed by descendant
+    expert tensors (model.layers.0.mlp.experts.0.*.weight), not only keys with a direct
+    <key>.weight. Otherwise the prefixed key is dropped and the MoE delta is skipped."""
+    disk = [
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.mlp.experts.0.gate_proj.weight",
+        "model.layers.0.mlp.experts.0.up_proj.weight",
+        "model.layers.0.mlp.experts.0.down_proj.weight",
+    ]
+    out = _infer_prefix_and_remap(
+        _lw([
+            "layers.0.self_attn.q_proj",
+            "layers.0.mlp.experts.base_layer",
+            "layers.0.mlp.experts",
+        ]),
+        disk,
+    )
+    assert out is not None
+    assert out["model.layers.0.mlp.experts.base_layer"] == "layers.0.mlp.experts.base_layer"
+    assert out["model.layers.0.mlp.experts"] == "layers.0.mlp.experts"
+
+
+def test_count_fused_3d_experts_without_weight_suffix():
+    """Fused 3D MoE (GPT-OSS / Gemma4) stores experts as <prefix>.gate_up_proj /
+    <prefix>.down_proj with no .weight; _merge_moe_experts_file merges them, so they must
+    be counted as backed."""
+    keys = ["model.layers.0.experts.base_layer", "model.layers.0.experts"]
+    disk = ["model.layers.0.experts.gate_up_proj", "model.layers.0.experts.down_proj"]
+    assert _count(keys, disk) == 2
+
+
+def test_count_moe_alias_resolves_to_fused_experts():
+    """A LoRA key using .moe is aliased to .experts by the merge, so it must count against
+    the fused expert tensors stored under .experts."""
+    keys = ["model.layers.0.moe.base_layer", "model.layers.0.moe"]
+    disk = ["model.layers.0.experts.gate_up_proj", "model.layers.0.experts.down_proj"]
+    assert _count(keys, disk) == 2
+
+
+def test_count_mxfp4_per_expert_packed():
+    """Per-expert packed mxfp4 experts (descendant <prefix>.<e>.<proj>_blocks/_scales)
+    count as backed."""
+    keys = ["model.layers.0.mlp.experts.base_layer"]
+    disk = ["model.layers.0.mlp.experts.0.gate_proj_blocks", "model.layers.0.mlp.experts.0.gate_proj_scales"]
+    assert _count(keys, disk) == 1

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3175,27 +3175,37 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     if unmatched_keys:
         from collections import Counter as _Counter2
         substitution_votes = _Counter2()
+        # A substitution is only recorded when the trailing 3 components match (the
+        # common_suffix_len >= 3 gate below), so group safetensor keys by their 3-component
+        # suffix and compare each unmatched key only against that bucket. This turns the
+        # scan from O(unmatched * safetensors) into roughly O(unmatched + safetensors),
+        # which matters when a whole namespace is unmatched on a large VLM.
+        sf_parts_by_suffix3 = defaultdict(list)
+        for sf in safetensor_keys:
+            if not sf.endswith(".weight"):
+                continue
+            sf_parts = sf[: -len(".weight")].split(".")
+            if len(sf_parts) >= 3:
+                sf_parts_by_suffix3[tuple(sf_parts[-3:])].append(sf_parts)
         for k, _ in unmatched_keys:
             if not isinstance(k, str):
                 continue
             k_parts = k.split(".")
-            for sf in safetensor_keys:
-                if not sf.endswith(".weight"):
-                    continue
-                sf_parts = sf[: -len(".weight")].split(".")
-                # Find the longest common suffix between the LoRA key and this safetensor key
-                common_suffix_len = 0
-                for i in range(1, min(len(k_parts), len(sf_parts)) + 1):
+            if len(k_parts) < 3:
+                continue
+            for sf_parts in sf_parts_by_suffix3.get(tuple(k_parts[-3:]), ()):
+                # The trailing 3 already match; extend the common suffix as far as it goes.
+                common_suffix_len = 3
+                for i in range(4, min(len(k_parts), len(sf_parts)) + 1):
                     if k_parts[-i] == sf_parts[-i]:
                         common_suffix_len = i
                     else:
                         break
-                if common_suffix_len >= 3:  # require at least 3 trailing components
-                    # Record the prefix substitution implied by this match
-                    lora_prefix = ".".join(k_parts[: -common_suffix_len]) + "." if common_suffix_len < len(k_parts) else ""
-                    sf_prefix = ".".join(sf_parts[: -common_suffix_len]) + "." if common_suffix_len < len(sf_parts) else ""
-                    if lora_prefix and sf_prefix and lora_prefix != sf_prefix:
-                        substitution_votes[(lora_prefix, sf_prefix)] += 1
+                # Record the prefix substitution implied by this match
+                lora_prefix = ".".join(k_parts[: -common_suffix_len]) + "." if common_suffix_len < len(k_parts) else ""
+                sf_prefix = ".".join(sf_parts[: -common_suffix_len]) + "." if common_suffix_len < len(sf_parts) else ""
+                if lora_prefix and sf_prefix and lora_prefix != sf_prefix:
+                    substitution_votes[(lora_prefix, sf_prefix)] += 1
 
         # Apply prefix substitutions, but only true reorderings of the same path
         # components (e.g. model.language_model. <-> language_model.model.), never
@@ -3332,12 +3342,15 @@ pass
 def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_name, tie_word_embeddings):
     """Count LoRA modules backed by a saved tensor, mirroring the key resolution of
     the merge loop in _merge_and_overwrite_lora (remap, Gemma4 .linear, fused MoE
-    experts, and the tied lm_head -> embed_tokens bridge). The tied bridge is keyed on
-    the DISK embed prefix and only fires when that embed is not itself a target, exactly
-    like the merge, so the count equals the number of tensors the merge writes and the
-    Step-7 sanity check needs no extra tied discount. Genuinely unbacked targets (e.g. a
-    vision tower absent from the base safetensors, or a bare lm_head whose composite-VLM
-    embed lives at a deep prefix the merge cannot bridge) are excluded.
+    experts, mxfp4 packed experts, and the tied lm_head -> embed_tokens bridge). The
+    tied bridge is keyed on the DISK embed prefix and only fires when that embed is not
+    itself a target, exactly like the merge, so the count equals the number of tensors
+    the merge writes and the Step-7 sanity check needs no extra tied discount. Genuinely
+    unbacked targets (e.g. a vision tower absent from the base safetensors, or a bare
+    lm_head whose composite-VLM embed lives at a deep prefix the merge cannot bridge) are
+    excluded. Known merge limitation, faithfully mirrored here: when only lm_head.weight
+    is on disk (not embed_tokens.weight), a tied embed_tokens target is dropped by the
+    merge and likewise not counted, so the save succeeds without that delta.
     """
     converted = _convert_lora_keys_to_safetensor_format(
         lora_weights, safetensor_keys_seen, model_class_name = model_class_name,
@@ -3349,6 +3362,11 @@ def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_n
         if (key + ".weight") in safetensor_keys_seen:
             return True
         if (key + ".linear.weight") in safetensor_keys_seen:   # Gemma4 ClippableLinear
+            return True
+        # mxfp4 packed experts: the base shard stores <module>_blocks / _scales and the
+        # merge dequantizes them to <module> on save (_merge_and_overwrite_lora_mxfp4),
+        # so a LoRA on such a module has no .weight on disk.
+        if (key + "_blocks") in safetensor_keys_seen and (key + "_scales") in safetensor_keys_seen:
             return True
         if ".experts" in key or ".moe" in key:                 # fused / per-expert MoE
             prefix = key[: -len(".base_layer")] if key.endswith(".base_layer") else key

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2570,7 +2570,51 @@ def merge_and_overwrite_lora(
 
 
     # Step 7: Check for errors
-    effective_loras = len(lora_weights)
+    # Only count LoRA modules that have at least one corresponding safetensor key.
+    # Some LoRA keys may target sub-modules that don't exist in the base
+    # safetensors (e.g. vision-tower adapters on a VLM whose base weights
+    # omit the vision tower).  Excluding those prevents a false-positive
+    # mismatch while keeping the sanity check meaningful.
+    from collections import Counter as _SanityCounter
+
+    _effective_lora_set: set = set()
+    _sub_votes = _SanityCounter()
+    for _lw_key in lora_weights:
+        if not isinstance(_lw_key, str):
+            continue
+        _k_parts = _lw_key.split(".")
+        _direct_ok = False
+        for _sf in safetensor_keys_seen:
+            _sf_parts = _sf[: -len(".weight")].split(".")
+            _cs = 0
+            for _i in range(1, min(len(_k_parts), len(_sf_parts)) + 1):
+                if _k_parts[-_i] == _sf_parts[-_i]:
+                    _cs = _i
+                else:
+                    break
+            if _cs >= 3:
+                _lp = ".".join(_k_parts[: -_cs]) + "." if _cs < len(_k_parts) else ""
+                _sp = ".".join(_sf_parts[: -_cs]) + "." if _cs < len(_sf_parts) else ""
+                if _lp == _sp:
+                    _direct_ok = True
+                    break
+                elif _lp and _sp:
+                    _sub_votes[(_lp, _sp)] += 1
+        if _direct_ok:
+            _effective_lora_set.add(_lw_key)
+
+    if _sub_votes:
+        (_best_lp, _best_sp), _ = _sub_votes.most_common(1)[0]
+        for _lw_key in lora_weights:
+            if not isinstance(_lw_key, str):
+                continue
+            if _lw_key in _effective_lora_set:
+                continue
+            if _lw_key.startswith(_best_lp):
+                _effective_lora_set.add(_lw_key)
+
+    effective_loras = len(_effective_lora_set)
+
     # For tied embeddings, PEFT can register both embed_tokens and lm_head as modules_to_save even
     # though only one tensor exists on disk. If we see both logical modules but only one backing
     # tensor key across shards, treat them as a single merged target to avoid an off-by-one on the
@@ -3127,6 +3171,12 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     remapped; unmatched keys (e.g. fused MoE params) inherit the most common
     inferred prefix.
 
+    Also handles the case where LoRA keys and safetensor keys have differently
+    ordered path components (e.g. LoRA has ``model.language_model.`` but
+    safetensor has ``language_model.model.`` in Ministral 3 / Mistral 3 VLMs)
+    by discovering a dominant prefix substitution rule from common suffix
+    matches across all unmatched keys, and applying it globally.
+
     Returns the remapped ``defaultdict``, or ``None`` if nothing was remapped.
     """
     if not safetensor_keys:
@@ -3158,16 +3208,58 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
             inferred_prefixes.append(candidates[0])
             changed = True
         else:
-            # No match or ambiguous -- defer to fallback
+            # No exact/prefix match -- defer to global substitution below
             unmatched_keys.append((k, v))
+
+    # Discover a dominant prefix substitution by comparing unmatched LoRA
+    # key prefixes against safetensor key prefixes. This avoids per-key
+    # false matches when different sub-modules (e.g. vision vs language)
+    # share the same trailing path components.
+    if unmatched_keys:
+        from collections import Counter as _Counter2
+        substitution_votes = _Counter2()
+        for k, _ in unmatched_keys:
+            if not isinstance(k, str):
+                continue
+            k_parts = k.split(".")
+            for sf in safetensor_keys:
+                sf_parts = sf[: -len(".weight")].split(".")
+                # Find the longest common suffix between the LoRA key and this safetensor key
+                common_suffix_len = 0
+                for i in range(1, min(len(k_parts), len(sf_parts)) + 1):
+                    if k_parts[-i] == sf_parts[-i]:
+                        common_suffix_len = i
+                    else:
+                        break
+                if common_suffix_len >= 3:  # require at least 3 trailing components
+                    # Record the prefix substitution implied by this match
+                    lora_prefix = ".".join(k_parts[: -common_suffix_len]) + "." if common_suffix_len < len(k_parts) else ""
+                    sf_prefix = ".".join(sf_parts[: -common_suffix_len]) + "." if common_suffix_len < len(sf_parts) else ""
+                    if lora_prefix and sf_prefix and lora_prefix != sf_prefix:
+                        substitution_votes[(lora_prefix, sf_prefix)] += 1
+
+        # Apply the most-voted substitution to ALL unmatched keys whose
+        # LoRA key starts with that prefix.
+        if substitution_votes:
+            (best_lora_prefix, best_sf_prefix), best_vote_count = substitution_votes.most_common(1)[0]
+            remaining_unmatched = []
+            for k, v in unmatched_keys:
+                if k.startswith(best_lora_prefix):
+                    new_key = best_sf_prefix + k[len(best_lora_prefix):]
+                    remapped[new_key] = v
+                    inferred_prefixes.append(best_sf_prefix)
+                    changed = True
+                else:
+                    remaining_unmatched.append((k, v))
+            unmatched_keys = remaining_unmatched
 
     if not changed:
         return None
 
-    # Unmatched keys (e.g. fused MoE params): use the most common inferred prefix
+    # Apply most common inferred prefix to any still-unmatched keys
     if unmatched_keys and inferred_prefixes:
-        from collections import Counter
-        common_prefix = Counter(inferred_prefixes).most_common(1)[0][0]
+        from collections import Counter as _Counter
+        common_prefix = _Counter(inferred_prefixes).most_common(1)[0][0]
         for k, v in unmatched_keys:
             remapped[common_prefix + k] = v
     else:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3224,17 +3224,48 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                 remaining_unmatched = still_unmatched
             unmatched_keys = remaining_unmatched
 
+    from collections import Counter as _Counter
+    common_prefix = _Counter(inferred_prefixes).most_common(1)[0][0] if inferred_prefixes else None
+
+    # A LoRA target can carry an extra wrapper prefix the base tensor lacks (e.g.
+    # model.vision_tower.* vs vision_tower.* on a Mistral 3 VLM, where the language
+    # half reorders but the vision half only drops the leading model.). Strip leading
+    # components onto the first existing tensor. This never crosses namespaces because
+    # it accepts only an exact on-disk match, and it resolves these keys regardless of
+    # whether the reorder vote above fired.
+    if unmatched_keys:
+        still_unmatched = []
+        for k, v in unmatched_keys:
+            target = None
+            if isinstance(k, str):
+                parts = k.split(".")
+                for i in range(1, len(parts)):
+                    cand = ".".join(parts[i:])
+                    if (cand + ".weight") in sf_key_set and cand not in remapped:
+                        target = cand
+                        break
+            if target is not None:
+                remapped[target] = v
+                changed = True
+            else:
+                still_unmatched.append((k, v))
+        unmatched_keys = still_unmatched
+
     if not changed:
         return None
 
-    # Apply most common inferred prefix to any still-unmatched keys
-    if unmatched_keys and inferred_prefixes:
-        from collections import Counter as _Counter
-        common_prefix = _Counter(inferred_prefixes).most_common(1)[0][0]
-        for k, v in unmatched_keys:
+    # Apply the most common inferred prefix to any remaining unmatched keys, but only
+    # when that lands on a real tensor; otherwise leave the key untouched so the merge
+    # skips a genuinely unbacked target (e.g. a vision adapter with no base tensor)
+    # instead of rewriting it onto a wrong or nonexistent key.
+    for k, v in unmatched_keys:
+        if (
+            common_prefix is not None and isinstance(k, str)
+            and (common_prefix + k + ".weight") in sf_key_set
+            and (common_prefix + k) not in remapped
+        ):
             remapped[common_prefix + k] = v
-    else:
-        for k, v in unmatched_keys:
+        else:
             remapped[k] = v
 
     return remapped

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2570,11 +2570,35 @@ def merge_and_overwrite_lora(
 
 
     # Step 7: Check for errors
-    # The remap above already aligns LoRA keys to the saved tensors, so every
-    # mergeable module is counted by n_saved_modules. Re-deriving "backed" keys
-    # here only drifts from the merge's own resolution (.linear, tied embeds,
-    # fused MoE) and caused false mismatches, so count all LoRA modules.
-    effective_loras = len(lora_weights)
+    # Count only LoRA modules backed by a saved tensor, using the same key
+    # resolution as the merge loop above (remap, Gemma4 .linear, fused MoE experts,
+    # tied lm_head -> embed_tokens). A looser re-derivation drifts from the merge
+    # and raises false mismatches; len(lora_weights) over-counts unbacked targets
+    # such as a vision tower absent from the base safetensors.
+    _converted_for_check = _convert_lora_keys_to_safetensor_format(
+        lora_weights,
+        safetensor_keys_seen,
+        model_class_name = find_lora_base_model(model).__class__.__name__,
+    )
+    _tie_word_embeddings = bool(getattr(find_lora_base_model(model).config, "tie_word_embeddings", False))
+
+    def _lora_is_backed(_key):
+        if not isinstance(_key, str):
+            return False
+        if (_key + ".weight") in safetensor_keys_seen:
+            return True
+        if (_key + ".linear.weight") in safetensor_keys_seen:   # Gemma4 ClippableLinear
+            return True
+        if ".experts" in _key or ".moe" in _key:                # fused / per-expert MoE
+            _p = _key[: -len(".base_layer")] if _key.endswith(".base_layer") else _key
+            if any(_s.startswith(_p + ".") and _s.endswith(".weight") for _s in safetensor_keys_seen):
+                return True
+        if _tie_word_embeddings and _key.endswith("lm_head"):   # tied: merged onto embed_tokens
+            if (_key[: -len("lm_head")] + "embed_tokens.weight") in safetensor_keys_seen:
+                return True
+        return False
+
+    effective_loras = sum(1 for _key in _converted_for_check if _lora_is_backed(_key))
 
     # For tied embeddings, PEFT can register both embed_tokens and lm_head as modules_to_save even
     # though only one tensor exists on disk. If we see both logical modules but only one backing
@@ -3201,20 +3225,25 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                     if lora_prefix and sf_prefix and lora_prefix != sf_prefix:
                         substitution_votes[(lora_prefix, sf_prefix)] += 1
 
-        # Apply ALL valid prefix substitutions, not just the top vote.
-        # Multiple namespaces (e.g. language + vision) may each need a
-        # different remap, and most_common(1) would drop the non-dominant.
+        # Apply prefix substitutions, but only true reorderings of the same path
+        # components (e.g. model.language_model. <-> language_model.model.), never
+        # cross-namespace rewrites. Only claim a target that exists on disk and is
+        # not already taken, so an unmatched vision key cannot overwrite a real
+        # language tensor.
         if substitution_votes:
             remaining_unmatched = list(unmatched_keys)
             applied_prefixes = set()
             for (lora_prefix, sf_prefix), _ in substitution_votes.most_common():
                 if lora_prefix in applied_prefixes:
                     continue
+                if _Counter2(p for p in lora_prefix.split(".") if p) != \
+                   _Counter2(p for p in sf_prefix.split(".") if p):
+                    continue
                 applied_prefixes.add(lora_prefix)
                 still_unmatched = []
                 for k, v in remaining_unmatched:
-                    if k.startswith(lora_prefix):
-                        new_key = sf_prefix + k[len(lora_prefix):]
+                    new_key = sf_prefix + k[len(lora_prefix):] if k.startswith(lora_prefix) else None
+                    if new_key is not None and (new_key + ".weight") in sf_key_set and new_key not in remapped:
                         remapped[new_key] = v
                         inferred_prefixes.append(sf_prefix)
                         changed = True

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1781,6 +1781,9 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
 
             lora_key = output_key[:-len(".weight")] if output_key.endswith(".weight") else output_key
             lora_stats = converted_lora_weights.get(lora_key, None)
+            # Gemma4 ClippableLinear (.linear.weight -> .weight), mirror the standard merge loop
+            if lora_stats is None and lora_key.endswith(".linear"):
+                lora_stats = converted_lora_weights.get(lora_key[: -len(".linear")], None)
 
             if W is not None and lora_stats is not None and hasattr(lora_stats, 'lora_A') and lora_stats.lora_A is not None:
                 if not action_logged:
@@ -3142,7 +3145,30 @@ def _safetensor_module_key(sf):
     return module_key
 pass
 
-def _lora_key_has_backing(key, keys_set, count_packed_mxfp4 = True):
+def _build_valid_prefixes(keys_set, count_packed_mxfp4 = True):
+    """Pre-compute every component-boundary parent prefix of the merge-backing tensors in
+    keys_set (keys ending in .weight, or mxfp4 _blocks paired with _scales). Lets the MoE
+    descendant check in _lora_key_has_backing do an O(1) `cand in prefixes` lookup instead
+    of an O(N) scan per key, which matters on large MoE checkpoints with tens of thousands
+    of tensors. Equivalent to `any(s.startswith(cand + '.') and <s is a backing tensor>)`.
+    """
+    valid_prefixes = set()
+    for s in keys_set:
+        if not isinstance(s, str):
+            continue
+        if s.endswith(".weight"):
+            pass
+        elif count_packed_mxfp4 and s.endswith("_blocks") and (s[: -len("_blocks")] + "_scales") in keys_set:
+            pass
+        else:
+            continue
+        parts = s.split(".")
+        for i in range(1, len(parts)):
+            valid_prefixes.add(".".join(parts[: i]))
+    return valid_prefixes
+pass
+
+def _lora_key_has_backing(key, keys_set, count_packed_mxfp4 = True, valid_prefixes = None):
     """True if a converted LoRA module path is backed by a tensor the merge loop would
     actually consume, mirroring _merge_and_overwrite_lora / _merge_moe_experts_file:
       - direct <key>.weight,
@@ -3178,13 +3204,18 @@ def _lora_key_has_backing(key, keys_set, count_packed_mxfp4 = True):
         for cand in cands:
             if (cand + ".gate_up_proj") in keys_set or (cand + ".down_proj") in keys_set:
                 return True                                  # fused 3D (GPT-OSS / Gemma4)
-            for s in keys_set:
-                if not (isinstance(s, str) and s.startswith(cand + ".")):
-                    continue
-                if s.endswith(".weight"):                    # per-expert 2D
+            if valid_prefixes is not None:
+                # O(1): cand is a parent prefix of some per-expert .weight (or packed) tensor.
+                if cand in valid_prefixes:
                     return True
-                if count_packed_mxfp4 and s.endswith("_blocks") and (s[: -len("_blocks")] + "_scales") in keys_set:
-                    return True                              # per-expert packed mxfp4
+            else:
+                for s in keys_set:
+                    if not (isinstance(s, str) and s.startswith(cand + ".")):
+                        continue
+                    if s.endswith(".weight"):                # per-expert 2D
+                        return True
+                    if count_packed_mxfp4 and s.endswith("_blocks") and (s[: -len("_blocks")] + "_scales") in keys_set:
+                        return True                          # per-expert packed mxfp4
     return False
 pass
 
@@ -3210,6 +3241,7 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
         return None
 
     sf_key_set = set(safetensor_keys)
+    valid_prefixes = _build_valid_prefixes(sf_key_set)  # O(1) MoE backing lookups
     remapped = defaultdict(lora_weights.default_factory)
     changed = False
     inferred_prefixes = []  # track prefixes from successful per-key matches
@@ -3305,7 +3337,7 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                 still_unmatched = []
                 for k, v in remaining_unmatched:
                     new_key = sf_prefix + k[len(lora_prefix):] if k.startswith(lora_prefix) else None
-                    if new_key is not None and new_key not in remapped and _lora_key_has_backing(new_key, sf_key_set):
+                    if new_key is not None and new_key not in remapped and _lora_key_has_backing(new_key, sf_key_set, valid_prefixes = valid_prefixes):
                         remapped[new_key] = v
                         inferred_prefixes.append(sf_prefix)
                         changed = True
@@ -3319,19 +3351,23 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
 
     # A LoRA target can carry an extra wrapper prefix the base tensor lacks (e.g.
     # model.vision_tower.* vs vision_tower.* on a Mistral 3 VLM, where the language
-    # half reorders but the vision half only drops the leading model.). Strip leading
-    # components onto the first existing tensor. This never crosses namespaces because
-    # it accepts only an exact on-disk match, and it resolves these keys regardless of
-    # whether the reorder vote above fired.
+    # half reorders but the vision half only drops the leading model.). Strip only
+    # GENERIC wrapper components (model / base_model / module), never a semantic
+    # namespace such as vision_tower or language_model: otherwise an unbacked vision
+    # adapter could strip down to a bare language suffix (layers.0....) and be merged
+    # onto the wrong tensor. Accepts only an exact on-disk backing for the stripped key.
     if unmatched_keys:
+        _WRAPPER_COMPONENTS = {"model", "base_model", "module"}
         still_unmatched = []
         for k, v in unmatched_keys:
             target = None
             if isinstance(k, str):
                 parts = k.split(".")
                 for i in range(1, len(parts)):
+                    if any(p not in _WRAPPER_COMPONENTS for p in parts[: i]):
+                        break  # would strip a semantic namespace -> stop
                     cand = ".".join(parts[i:])
-                    if cand not in remapped and _lora_key_has_backing(cand, sf_key_set):
+                    if cand not in remapped and _lora_key_has_backing(cand, sf_key_set, valid_prefixes = valid_prefixes):
                         target = cand
                         break
             if target is not None:
@@ -3354,7 +3390,7 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
         if (
             common_prefix is not None and isinstance(k, str)
             and (common_prefix + k) not in remapped
-            and _lora_key_has_backing(common_prefix + k, sf_key_set)
+            and _lora_key_has_backing(common_prefix + k, sf_key_set, valid_prefixes = valid_prefixes)
         ):
             remapped[common_prefix + k] = v
         else:
@@ -3437,13 +3473,15 @@ def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_n
     converted = _convert_lora_keys_to_safetensor_format(
         lora_weights, safetensor_keys_seen, model_class_name = model_class_name,
     )
+    # Pre-build parent prefixes once so the MoE backing check is O(1) per key, not O(N).
+    valid_prefixes = _build_valid_prefixes(safetensor_keys_seen, count_packed_mxfp4 = count_packed_mxfp4)
 
     def _backed(key):
         if not isinstance(key, str):
             return False
         # Direct, Gemma4 .linear, mxfp4 packed, and MoE (per-expert / fused 3D / .moe alias)
         # backing all mirror the merge loop via the shared helper.
-        if _lora_key_has_backing(key, safetensor_keys_seen, count_packed_mxfp4 = count_packed_mxfp4):
+        if _lora_key_has_backing(key, safetensor_keys_seen, count_packed_mxfp4 = count_packed_mxfp4, valid_prefixes = valid_prefixes):
             return True
         if tie_word_embeddings and key.endswith("lm_head"):    # tied: merged onto embed_tokens
             # The merge folds an lm_head LoRA onto an on-disk embed_tokens.weight, but only

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3314,9 +3314,10 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                     lora_prefix = ".".join(k_parts[: -common_suffix_len]) + "." if common_suffix_len < len(k_parts) else ""
                     sf_prefix = ".".join(sf_parts[: -common_suffix_len]) + "." if common_suffix_len < len(sf_parts) else ""
                     # Only a true reordering (same components, different order) seeds a vote.
+                    # sorted() equality is the multiset guard (cheaper than a Counter per pair).
                     if (lora_prefix and sf_prefix and lora_prefix != sf_prefix
-                            and _Counter2(p for p in lora_prefix.split(".") if p)
-                                == _Counter2(p for p in sf_prefix.split(".") if p)):
+                            and sorted(p for p in lora_prefix.split(".") if p)
+                                == sorted(p for p in sf_prefix.split(".") if p)):
                         substitution_votes[(lora_prefix, sf_prefix)] += 1
 
         # Apply prefix substitutions, but only true reorderings of the same path
@@ -3330,8 +3331,8 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
             for (lora_prefix, sf_prefix), _ in substitution_votes.most_common():
                 if lora_prefix in applied_prefixes:
                     continue
-                if _Counter2(p for p in lora_prefix.split(".") if p) != \
-                   _Counter2(p for p in sf_prefix.split(".") if p):
+                if sorted(p for p in lora_prefix.split(".") if p) != \
+                   sorted(p for p in sf_prefix.split(".") if p):
                     continue
                 applied_prefixes.add(lora_prefix)
                 still_unmatched = []

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2579,12 +2579,19 @@ def merge_and_overwrite_lora(
 
     _effective_lora_set: set = set()
     _sub_votes = _SanityCounter()
+    _prefix_remap_keys = []
     for _lw_key in lora_weights:
         if not isinstance(_lw_key, str):
+            continue
+        # O(1) direct match first
+        if (_lw_key + ".weight") in safetensor_keys_seen:
+            _effective_lora_set.add(_lw_key)
             continue
         _k_parts = _lw_key.split(".")
         _direct_ok = False
         for _sf in safetensor_keys_seen:
+            if not _sf.endswith(".weight"):
+                continue
             _sf_parts = _sf[: -len(".weight")].split(".")
             _cs = 0
             for _i in range(1, min(len(_k_parts), len(_sf_parts)) + 1):
@@ -2592,7 +2599,10 @@ def merge_and_overwrite_lora(
                     _cs = _i
                 else:
                     break
-            if _cs >= 3:
+            # Match requires either >=3 trailing components in common,
+            # or the common suffix covers the entire safetensor key
+            # (handles shallow targets like lm_head, embed_tokens).
+            if _cs >= 3 or (_cs > 0 and _cs == len(_sf_parts)):
                 _lp = ".".join(_k_parts[: -_cs]) + "." if _cs < len(_k_parts) else ""
                 _sp = ".".join(_sf_parts[: -_cs]) + "." if _cs < len(_sf_parts) else ""
                 if _lp == _sp:
@@ -2600,18 +2610,31 @@ def merge_and_overwrite_lora(
                     break
                 elif _lp and _sp:
                     _sub_votes[(_lp, _sp)] += 1
+                elif not _lp and _sp:
+                    # Prefix-only remap: the entire LoRA key is a suffix of
+                    # the safetensor key. Will be handled by
+                    # _infer_prefix_and_remap later.
+                    _prefix_remap_keys.append(_lw_key)
+                    break
         if _direct_ok:
             _effective_lora_set.add(_lw_key)
 
+    # Apply ALL substitution votes, not just the most common one.
+    # Each distinct prefix pair identifies a separate namespace that
+    # _infer_prefix_and_remap handles independently.
     if _sub_votes:
-        (_best_lp, _best_sp), _ = _sub_votes.most_common(1)[0]
-        for _lw_key in lora_weights:
-            if not isinstance(_lw_key, str):
-                continue
-            if _lw_key in _effective_lora_set:
-                continue
-            if _lw_key.startswith(_best_lp):
-                _effective_lora_set.add(_lw_key)
+        for (_lp, _sp), _ in _sub_votes.most_common():
+            for _lw_key in lora_weights:
+                if not isinstance(_lw_key, str):
+                    continue
+                if _lw_key in _effective_lora_set:
+                    continue
+                if _lw_key.startswith(_lp):
+                    _effective_lora_set.add(_lw_key)
+
+    # Prefix-only remapped keys (entire LoRA key is a suffix of safetensor key)
+    for _lw_key in _prefix_remap_keys:
+        _effective_lora_set.add(_lw_key)
 
     effective_loras = len(_effective_lora_set)
 
@@ -3223,6 +3246,8 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                 continue
             k_parts = k.split(".")
             for sf in safetensor_keys:
+                if not sf.endswith(".weight"):
+                    continue
                 sf_parts = sf[: -len(".weight")].split(".")
                 # Find the longest common suffix between the LoRA key and this safetensor key
                 common_suffix_len = 0
@@ -3238,19 +3263,26 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                     if lora_prefix and sf_prefix and lora_prefix != sf_prefix:
                         substitution_votes[(lora_prefix, sf_prefix)] += 1
 
-        # Apply the most-voted substitution to ALL unmatched keys whose
-        # LoRA key starts with that prefix.
+        # Apply ALL valid prefix substitutions, not just the top vote.
+        # Multiple namespaces (e.g. language + vision) may each need a
+        # different remap, and most_common(1) would drop the non-dominant.
         if substitution_votes:
-            (best_lora_prefix, best_sf_prefix), best_vote_count = substitution_votes.most_common(1)[0]
-            remaining_unmatched = []
-            for k, v in unmatched_keys:
-                if k.startswith(best_lora_prefix):
-                    new_key = best_sf_prefix + k[len(best_lora_prefix):]
-                    remapped[new_key] = v
-                    inferred_prefixes.append(best_sf_prefix)
-                    changed = True
-                else:
-                    remaining_unmatched.append((k, v))
+            remaining_unmatched = list(unmatched_keys)
+            applied_prefixes = set()
+            for (lora_prefix, sf_prefix), _ in substitution_votes.most_common():
+                if lora_prefix in applied_prefixes:
+                    continue
+                applied_prefixes.add(lora_prefix)
+                still_unmatched = []
+                for k, v in remaining_unmatched:
+                    if k.startswith(lora_prefix):
+                        new_key = sf_prefix + k[len(lora_prefix):]
+                        remapped[new_key] = v
+                        inferred_prefixes.append(sf_prefix)
+                        changed = True
+                    else:
+                        still_unmatched.append((k, v))
+                remaining_unmatched = still_unmatched
             unmatched_keys = remaining_unmatched
 
     if not changed:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3118,6 +3118,41 @@ def detect_keys_format(keys_to_check, forward_mapping):
     return "new" # Default to current HF format
 pass
 
+def _lora_key_has_backing(key, keys_set):
+    """True if a converted LoRA module path is backed by a tensor the merge loop would
+    actually consume, mirroring _merge_and_overwrite_lora / _merge_moe_experts_file:
+      - direct <key>.weight,
+      - Gemma4 ClippableLinear <key>.linear.weight,
+      - mxfp4 packed <key>_blocks + <key>_scales (dequantized to <key> on save),
+      - per-expert MoE descendants <prefix>.<e>.<proj>.weight (or packed _blocks/_scales),
+      - fused 3D MoE <prefix>.gate_up_proj / <prefix>.down_proj (no .weight, GPT-OSS/Gemma4),
+      including the .moe -> .experts alias the merge applies.
+    Shared by the save-count check and the remap fallback so both agree with what the
+    merge writes (and never invent a key with no backing).
+    """
+    if not isinstance(key, str):
+        return False
+    if (key + ".weight") in keys_set:
+        return True
+    if (key + ".linear.weight") in keys_set:                 # Gemma4 ClippableLinear
+        return True
+    if (key + "_blocks") in keys_set and (key + "_scales") in keys_set:  # mxfp4 packed
+        return True
+    if ".experts" in key or ".moe" in key:                   # fused / per-expert MoE
+        base = key.replace(".base_layer", "")
+        for cand in (base, base.replace(".moe", ".experts")):
+            if (cand + ".gate_up_proj") in keys_set or (cand + ".down_proj") in keys_set:
+                return True                                  # fused 3D (GPT-OSS / Gemma4)
+            for s in keys_set:
+                if not (isinstance(s, str) and s.startswith(cand + ".")):
+                    continue
+                if s.endswith(".weight"):                    # per-expert 2D
+                    return True
+                if s.endswith("_blocks") and (s[: -len("_blocks")] + "_scales") in keys_set:
+                    return True                              # per-expert packed mxfp4
+    return False
+pass
+
 def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     """Infer missing key prefixes by matching LoRA keys against safetensor keys.
 
@@ -3180,6 +3215,11 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
         # suffix and compare each unmatched key only against that bucket. This turns the
         # scan from O(unmatched * safetensors) into roughly O(unmatched + safetensors),
         # which matters when a whole namespace is unmatched on a large VLM.
+        # Known limitation: a reordered short module (e.g. model.language_model.embed_tokens)
+        # has no 3-component suffix to seed its own vote. In practice the per-layer targets
+        # trained alongside it seed the same reorder substitution, which is then applied to
+        # the short key below; only a degenerate run that trains the short module alone would
+        # miss it.
         sf_parts_by_suffix3 = defaultdict(list)
         for sf in safetensor_keys:
             if not sf.endswith(".weight"):
@@ -3265,14 +3305,16 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
         return None
 
     # Apply the most common inferred prefix to any remaining unmatched keys, but only
-    # when that lands on a real tensor; otherwise leave the key untouched so the merge
-    # skips a genuinely unbacked target (e.g. a vision adapter with no base tensor)
-    # instead of rewriting it onto a wrong or nonexistent key.
+    # when that lands on a real backing tensor; otherwise leave the key untouched so the
+    # merge skips a genuinely unbacked target (e.g. a vision adapter with no base tensor)
+    # instead of rewriting it onto a wrong or nonexistent key. Backing covers MoE experts
+    # (descendant / fused / packed) and Gemma4 .linear, not just a direct .weight, so a
+    # prefixed MoE LoRA key is not dropped.
     for k, v in unmatched_keys:
         if (
             common_prefix is not None and isinstance(k, str)
-            and (common_prefix + k + ".weight") in sf_key_set
             and (common_prefix + k) not in remapped
+            and _lora_key_has_backing(common_prefix + k, sf_key_set)
         ):
             remapped[common_prefix + k] = v
         else:
@@ -3359,19 +3401,10 @@ def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_n
     def _backed(key):
         if not isinstance(key, str):
             return False
-        if (key + ".weight") in safetensor_keys_seen:
+        # Direct, Gemma4 .linear, mxfp4 packed, and MoE (per-expert / fused 3D / .moe alias)
+        # backing all mirror the merge loop via the shared helper.
+        if _lora_key_has_backing(key, safetensor_keys_seen):
             return True
-        if (key + ".linear.weight") in safetensor_keys_seen:   # Gemma4 ClippableLinear
-            return True
-        # mxfp4 packed experts: the base shard stores <module>_blocks / _scales and the
-        # merge dequantizes them to <module> on save (_merge_and_overwrite_lora_mxfp4),
-        # so a LoRA on such a module has no .weight on disk.
-        if (key + "_blocks") in safetensor_keys_seen and (key + "_scales") in safetensor_keys_seen:
-            return True
-        if ".experts" in key or ".moe" in key:                 # fused / per-expert MoE
-            prefix = key[: -len(".base_layer")] if key.endswith(".base_layer") else key
-            if any(s.startswith(prefix + ".") and s.endswith(".weight") for s in safetensor_keys_seen):
-                return True
         if tie_word_embeddings and key.endswith("lm_head"):    # tied: merged onto embed_tokens
             # The merge folds an lm_head LoRA onto an on-disk embed_tokens.weight, but only
             # when that embed module is not itself a LoRA target (else the merge writes the

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2570,73 +2570,11 @@ def merge_and_overwrite_lora(
 
 
     # Step 7: Check for errors
-    # Only count LoRA modules that have at least one corresponding safetensor key.
-    # Some LoRA keys may target sub-modules that don't exist in the base
-    # safetensors (e.g. vision-tower adapters on a VLM whose base weights
-    # omit the vision tower).  Excluding those prevents a false-positive
-    # mismatch while keeping the sanity check meaningful.
-    from collections import Counter as _SanityCounter
-
-    _effective_lora_set: set = set()
-    _sub_votes = _SanityCounter()
-    _prefix_remap_keys = []
-    for _lw_key in lora_weights:
-        if not isinstance(_lw_key, str):
-            continue
-        # O(1) direct match first
-        if (_lw_key + ".weight") in safetensor_keys_seen:
-            _effective_lora_set.add(_lw_key)
-            continue
-        _k_parts = _lw_key.split(".")
-        _direct_ok = False
-        for _sf in safetensor_keys_seen:
-            if not _sf.endswith(".weight"):
-                continue
-            _sf_parts = _sf[: -len(".weight")].split(".")
-            _cs = 0
-            for _i in range(1, min(len(_k_parts), len(_sf_parts)) + 1):
-                if _k_parts[-_i] == _sf_parts[-_i]:
-                    _cs = _i
-                else:
-                    break
-            # Match requires either >=3 trailing components in common,
-            # or the common suffix covers the entire safetensor key
-            # (handles shallow targets like lm_head, embed_tokens).
-            if _cs >= 3 or (_cs > 0 and _cs == len(_sf_parts)):
-                _lp = ".".join(_k_parts[: -_cs]) + "." if _cs < len(_k_parts) else ""
-                _sp = ".".join(_sf_parts[: -_cs]) + "." if _cs < len(_sf_parts) else ""
-                if _lp == _sp:
-                    _direct_ok = True
-                    break
-                elif _lp and _sp:
-                    _sub_votes[(_lp, _sp)] += 1
-                elif not _lp and _sp:
-                    # Prefix-only remap: the entire LoRA key is a suffix of
-                    # the safetensor key. Will be handled by
-                    # _infer_prefix_and_remap later.
-                    _prefix_remap_keys.append(_lw_key)
-                    break
-        if _direct_ok:
-            _effective_lora_set.add(_lw_key)
-
-    # Apply ALL substitution votes, not just the most common one.
-    # Each distinct prefix pair identifies a separate namespace that
-    # _infer_prefix_and_remap handles independently.
-    if _sub_votes:
-        for (_lp, _sp), _ in _sub_votes.most_common():
-            for _lw_key in lora_weights:
-                if not isinstance(_lw_key, str):
-                    continue
-                if _lw_key in _effective_lora_set:
-                    continue
-                if _lw_key.startswith(_lp):
-                    _effective_lora_set.add(_lw_key)
-
-    # Prefix-only remapped keys (entire LoRA key is a suffix of safetensor key)
-    for _lw_key in _prefix_remap_keys:
-        _effective_lora_set.add(_lw_key)
-
-    effective_loras = len(_effective_lora_set)
+    # The remap above already aligns LoRA keys to the saved tensors, so every
+    # mergeable module is counted by n_saved_modules. Re-deriving "backed" keys
+    # here only drifts from the merge's own resolution (.linear, tied embeds,
+    # fused MoE) and caused false mismatches, so count all LoRA modules.
+    effective_loras = len(lora_weights)
 
     # For tied embeddings, PEFT can register both embed_tokens and lm_head as modules_to_save even
     # though only one tensor exists on disk. If we see both logical modules but only one backing

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2570,11 +2570,13 @@ def merge_and_overwrite_lora(
 
 
     # Step 7: Check for errors
-    # Count only LoRA modules backed by a saved tensor, using the same key
-    # resolution as the merge loop above (remap, Gemma4 .linear, fused MoE experts,
-    # tied lm_head -> embed_tokens). A looser re-derivation drifts from the merge
-    # and raises false mismatches; len(lora_weights) over-counts unbacked targets
-    # such as a vision tower absent from the base safetensors.
+    # Count only LoRA modules backed by a saved tensor, using the same key resolution
+    # as the merge loop above (remap, Gemma4 .linear, fused MoE experts, and the tied
+    # lm_head -> embed_tokens bridge with its embed-not-a-target guard). The count
+    # therefore equals the number of tensors the merge actually writes, so no separate
+    # tied discount is needed. A looser re-derivation drifts from the merge and raises
+    # false mismatches; len(lora_weights) over-counts unbacked targets such as a vision
+    # tower absent from the base safetensors.
     _base = find_lora_base_model(model)
     effective_loras = _count_backed_lora_modules(
         lora_weights,
@@ -2582,19 +2584,6 @@ def merge_and_overwrite_lora(
         _base.__class__.__name__,
         bool(getattr(_base.config, "tie_word_embeddings", False)),
     )
-
-    # For tied embeddings, PEFT can register both embed_tokens and lm_head as modules_to_save even
-    # though only one tensor exists on disk. If we see both logical modules but only one backing
-    # tensor key across shards, treat them as a single merged target to avoid an off-by-one on the
-    # sanity check while keeping the check meaningful for non-tied models.
-    has_embed = any(key.endswith("embed_tokens") for key in lora_weights)
-    has_head  = any(key.endswith("lm_head") for key in lora_weights)
-    if has_embed and has_head:
-        # Only count actual weight tensors; lm_head.bias alone should not mask tied-embedding cases.
-        has_embed_tensor = any(key.endswith("embed_tokens.weight") for key in safetensor_keys_seen)
-        has_head_tensor  = any(key.endswith("lm_head.weight")      for key in safetensor_keys_seen)
-        if has_embed_tensor ^ has_head_tensor:  # exactly one side present on disk
-            effective_loras -= 1
 
     if effective_loras != n_saved_modules:
         raise RuntimeError(
@@ -3312,10 +3301,12 @@ pass
 def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_name, tie_word_embeddings):
     """Count LoRA modules backed by a saved tensor, mirroring the key resolution of
     the merge loop in _merge_and_overwrite_lora (remap, Gemma4 .linear, fused MoE
-    experts, and the tied lm_head -> embed_tokens fallback with its model. add/strip).
-    Kept in sync with that loop so the save sanity check counts the same modules the
-    merge actually wrote; genuinely unbacked targets (e.g. a vision tower absent from
-    the base safetensors) are excluded.
+    experts, and the tied lm_head -> embed_tokens bridge). The tied bridge is keyed on
+    the DISK embed prefix and only fires when that embed is not itself a target, exactly
+    like the merge, so the count equals the number of tensors the merge writes and the
+    Step-7 sanity check needs no extra tied discount. Genuinely unbacked targets (e.g. a
+    vision tower absent from the base safetensors, or a bare lm_head whose composite-VLM
+    embed lives at a deep prefix the merge cannot bridge) are excluded.
     """
     converted = _convert_lora_keys_to_safetensor_format(
         lora_weights, safetensor_keys_seen, model_class_name = model_class_name,
@@ -3333,16 +3324,23 @@ def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_n
             if any(s.startswith(prefix + ".") and s.endswith(".weight") for s in safetensor_keys_seen):
                 return True
         if tie_word_embeddings and key.endswith("lm_head"):    # tied: merged onto embed_tokens
-            # Mirror the merge loop's model. add/strip so a bare lm_head key resolves
-            # to model.embed_tokens.weight (and a model.-prefixed key to the bare one).
-            prefix = key[: -len("lm_head")]
-            candidates = [prefix + "embed_tokens.weight"]
-            if prefix.startswith("model."):
-                candidates.append(prefix[len("model."):] + "embed_tokens.weight")
-            else:
-                candidates.append("model." + prefix + "embed_tokens.weight")
-            if any(c in safetensor_keys_seen for c in candidates):
-                return True
+            # The merge folds an lm_head LoRA onto an on-disk embed_tokens.weight, but only
+            # when that embed module is not itself a LoRA target (else the merge writes the
+            # embed delta and drops lm_head). Mirror that exactly, keying off the DISK embed
+            # prefix with the same model. strip/add the merge uses, so a bare lm_head resolves
+            # onto model.embed_tokens.weight (standard) yet a deep composite-VLM prefix
+            # model.language_model.embed_tokens.weight does not claim a bare lm_head it can
+            # never reach.
+            for sf in safetensor_keys_seen:
+                if not (isinstance(sf, str) and sf.endswith("embed_tokens.weight")):
+                    continue
+                embed_key = sf[: -len(".weight")]
+                if embed_key in converted:           # embed is a target -> lm_head dropped
+                    continue
+                lm_head_key = embed_key[: -len("embed_tokens")] + "lm_head"
+                bridged = lm_head_key[len("model."):] if lm_head_key.startswith("model.") else "model." + lm_head_key
+                if key == lm_head_key or key == bridged:
+                    return True
         return False
 
     return sum(1 for key in converted if _backed(key))

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3158,7 +3158,16 @@ def _lora_key_has_backing(key, keys_set, count_packed_mxfp4 = True):
         return True                                          # mxfp4 packed (dequantized on save)
     if ".experts" in key or ".moe" in key:                   # fused / per-expert MoE
         base = key.replace(".base_layer", "")
-        for cand in (base, base.replace(".moe", ".experts")):
+        cands = set()
+        for b in (base, base.replace(".moe", ".experts")):
+            cands.add(b)
+            # A fused-named LoRA key (<experts>.gate_up_proj / .down_proj) is also backed by
+            # the per-expert descendants under <experts>, since the merge maps disk
+            # <experts>.<e>.<proj>.weight onto <experts>.gate_up_proj (saving_utils ~L663).
+            for suf in (".gate_up_proj", ".down_proj"):
+                if b.endswith(suf):
+                    cands.add(b[: -len(suf)])
+        for cand in cands:
             if (cand + ".gate_up_proj") in keys_set or (cand + ".down_proj") in keys_set:
                 return True                                  # fused 3D (GPT-OSS / Gemma4)
             for s in keys_set:
@@ -3202,14 +3211,15 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
         if not isinstance(k, str):
             remapped[k] = v
             continue
-        # Already matches a safetensor key
-        if (k + ".weight") in sf_key_set:
+        # Already matches a safetensor key (direct, or Gemma4 ClippableLinear .linear.weight)
+        if (k + ".weight") in sf_key_set or (k + ".linear.weight") in sf_key_set:
             remapped[k] = v
             continue
-        # Unique non-empty prefix candidates for this key
-        suffix = k + ".weight"
+        # Unique non-empty prefix candidates for this key. Accept a .linear.weight shard
+        # (Gemma4 ClippableLinear) as well, so a prefix-add onto such a tensor is not dropped.
         candidates = list(dict.fromkeys(
             sf_key[: -len(suffix)]
+            for suffix in (k + ".weight", k + ".linear.weight")
             for sf_key in safetensor_keys
             if sf_key.endswith(suffix) and sf_key[: -len(suffix)]
         ))
@@ -3228,43 +3238,46 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     if unmatched_keys:
         from collections import Counter as _Counter2
         substitution_votes = _Counter2()
-        # A substitution is only recorded when the trailing 3 components match (the
-        # common_suffix_len >= 3 gate below), so group safetensor keys by their 3-component
-        # suffix and compare each unmatched key only against that bucket. This turns the
-        # scan from O(unmatched * safetensors) into roughly O(unmatched + safetensors),
-        # which matters when a whole namespace is unmatched on a large VLM.
-        # Known limitation: a reordered short module (e.g. model.language_model.embed_tokens)
-        # has no 3-component suffix to seed its own vote. In practice the per-layer targets
-        # trained alongside it seed the same reorder substitution, which is then applied to
-        # the short key below; only a degenerate run that trains the short module alone would
-        # miss it.
-        sf_parts_by_suffix3 = defaultdict(list)
+        # A vote is recorded only when the two prefixes are a true reordering of the same
+        # path components (the multiset guard below), so shorter trailing suffixes are safe
+        # to seed votes and cannot pull a key across namespaces. This lets a reordered short
+        # module (e.g. model.language_model.embed_tokens vs language_model.model.embed_tokens)
+        # learn its own reorder even on a shard that holds no longer layer keys to seed it.
+        # Group safetensor module keys by each trailing 1..3 component suffix so every
+        # unmatched key only scans plausible buckets (keeps this roughly O(n)).
+        sf_parts_by_suffix = defaultdict(list)
         for sf in safetensor_keys:
             module_key = _safetensor_module_key(sf)   # strips .weight and a trailing .linear
             if module_key is None:
                 continue
             sf_parts = module_key.split(".")
-            if len(sf_parts) >= 3:
-                sf_parts_by_suffix3[tuple(sf_parts[-3:])].append(sf_parts)
+            for sl in range(1, min(3, len(sf_parts)) + 1):
+                sf_parts_by_suffix[(sl, tuple(sf_parts[-sl:]))].append(sf_parts)
         for k, _ in unmatched_keys:
             if not isinstance(k, str):
                 continue
             k_parts = k.split(".")
-            if len(k_parts) < 3:
-                continue
-            for sf_parts in sf_parts_by_suffix3.get(tuple(k_parts[-3:]), ()):
-                # The trailing 3 already match; extend the common suffix as far as it goes.
-                common_suffix_len = 3
-                for i in range(4, min(len(k_parts), len(sf_parts)) + 1):
-                    if k_parts[-i] == sf_parts[-i]:
-                        common_suffix_len = i
-                    else:
-                        break
-                # Record the prefix substitution implied by this match
-                lora_prefix = ".".join(k_parts[: -common_suffix_len]) + "." if common_suffix_len < len(k_parts) else ""
-                sf_prefix = ".".join(sf_parts[: -common_suffix_len]) + "." if common_suffix_len < len(sf_parts) else ""
-                if lora_prefix and sf_prefix and lora_prefix != sf_prefix:
-                    substitution_votes[(lora_prefix, sf_prefix)] += 1
+            seen_sf = set()
+            for sl in range(min(3, len(k_parts)), 0, -1):
+                for sf_parts in sf_parts_by_suffix.get((sl, tuple(k_parts[-sl:])), ()):
+                    sf_id = tuple(sf_parts)
+                    if sf_id in seen_sf:        # process each sf once, at its longest match
+                        continue
+                    seen_sf.add(sf_id)
+                    # Extend the common suffix as far as it goes.
+                    common_suffix_len = sl
+                    for i in range(sl + 1, min(len(k_parts), len(sf_parts)) + 1):
+                        if k_parts[-i] == sf_parts[-i]:
+                            common_suffix_len = i
+                        else:
+                            break
+                    lora_prefix = ".".join(k_parts[: -common_suffix_len]) + "." if common_suffix_len < len(k_parts) else ""
+                    sf_prefix = ".".join(sf_parts[: -common_suffix_len]) + "." if common_suffix_len < len(sf_parts) else ""
+                    # Only a true reordering (same components, different order) seeds a vote.
+                    if (lora_prefix and sf_prefix and lora_prefix != sf_prefix
+                            and _Counter2(p for p in lora_prefix.split(".") if p)
+                                == _Counter2(p for p in sf_prefix.split(".") if p)):
+                        substitution_votes[(lora_prefix, sf_prefix)] += 1
 
         # Apply prefix substitutions, but only true reorderings of the same path
         # components (e.g. model.language_model. <-> language_model.model.), never

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2578,11 +2578,15 @@ def merge_and_overwrite_lora(
     # false mismatches; len(lora_weights) over-counts unbacked targets such as a vision
     # tower absent from the base safetensors.
     _base = find_lora_base_model(model)
+    # Native mxfp4 save (save_method="mxfp4") preserves _blocks/_scales untouched instead of
+    # merging, so a LoRA on a packed tensor is not written; don't count it as backed there.
+    _count_packed_mxfp4 = not (base_model_is_quantized and quant_type == "mxfp4" and save_method == "mxfp4")
     effective_loras = _count_backed_lora_modules(
         lora_weights,
         safetensor_keys_seen,
         _base.__class__.__name__,
         bool(getattr(_base.config, "tie_word_embeddings", False)),
+        count_packed_mxfp4 = _count_packed_mxfp4,
     )
 
     if effective_loras != n_saved_modules:
@@ -3118,7 +3122,19 @@ def detect_keys_format(keys_to_check, forward_mapping):
     return "new" # Default to current HF format
 pass
 
-def _lora_key_has_backing(key, keys_set):
+def _safetensor_module_key(sf):
+    """The LoRA module path a safetensor key backs: strip .weight, then a trailing
+    .linear (Gemma4 ClippableLinear) so a reordered <module>.linear.weight tensor lines up
+    with its LoRA key in the prefix-substitution vote. Returns None for non-.weight keys."""
+    if not isinstance(sf, str) or not sf.endswith(".weight"):
+        return None
+    module_key = sf[: -len(".weight")]
+    if module_key.endswith(".linear"):
+        module_key = module_key[: -len(".linear")]
+    return module_key
+pass
+
+def _lora_key_has_backing(key, keys_set, count_packed_mxfp4 = True):
     """True if a converted LoRA module path is backed by a tensor the merge loop would
     actually consume, mirroring _merge_and_overwrite_lora / _merge_moe_experts_file:
       - direct <key>.weight,
@@ -3128,7 +3144,9 @@ def _lora_key_has_backing(key, keys_set):
       - fused 3D MoE <prefix>.gate_up_proj / <prefix>.down_proj (no .weight, GPT-OSS/Gemma4),
       including the .moe -> .experts alias the merge applies.
     Shared by the save-count check and the remap fallback so both agree with what the
-    merge writes (and never invent a key with no backing).
+    merge writes (and never invent a key with no backing). count_packed_mxfp4=False mirrors
+    the native mxfp4 save path (save_method="mxfp4"), which preserves _blocks/_scales
+    untouched instead of merging, so a LoRA on a packed tensor is not written there.
     """
     if not isinstance(key, str):
         return False
@@ -3136,8 +3154,8 @@ def _lora_key_has_backing(key, keys_set):
         return True
     if (key + ".linear.weight") in keys_set:                 # Gemma4 ClippableLinear
         return True
-    if (key + "_blocks") in keys_set and (key + "_scales") in keys_set:  # mxfp4 packed
-        return True
+    if count_packed_mxfp4 and (key + "_blocks") in keys_set and (key + "_scales") in keys_set:
+        return True                                          # mxfp4 packed (dequantized on save)
     if ".experts" in key or ".moe" in key:                   # fused / per-expert MoE
         base = key.replace(".base_layer", "")
         for cand in (base, base.replace(".moe", ".experts")):
@@ -3148,7 +3166,7 @@ def _lora_key_has_backing(key, keys_set):
                     continue
                 if s.endswith(".weight"):                    # per-expert 2D
                     return True
-                if s.endswith("_blocks") and (s[: -len("_blocks")] + "_scales") in keys_set:
+                if count_packed_mxfp4 and s.endswith("_blocks") and (s[: -len("_blocks")] + "_scales") in keys_set:
                     return True                              # per-expert packed mxfp4
     return False
 pass
@@ -3222,9 +3240,10 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
         # miss it.
         sf_parts_by_suffix3 = defaultdict(list)
         for sf in safetensor_keys:
-            if not sf.endswith(".weight"):
+            module_key = _safetensor_module_key(sf)   # strips .weight and a trailing .linear
+            if module_key is None:
                 continue
-            sf_parts = sf[: -len(".weight")].split(".")
+            sf_parts = module_key.split(".")
             if len(sf_parts) >= 3:
                 sf_parts_by_suffix3[tuple(sf_parts[-3:])].append(sf_parts)
         for k, _ in unmatched_keys:
@@ -3265,7 +3284,7 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                 still_unmatched = []
                 for k, v in remaining_unmatched:
                     new_key = sf_prefix + k[len(lora_prefix):] if k.startswith(lora_prefix) else None
-                    if new_key is not None and (new_key + ".weight") in sf_key_set and new_key not in remapped:
+                    if new_key is not None and new_key not in remapped and _lora_key_has_backing(new_key, sf_key_set):
                         remapped[new_key] = v
                         inferred_prefixes.append(sf_prefix)
                         changed = True
@@ -3291,7 +3310,7 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                 parts = k.split(".")
                 for i in range(1, len(parts)):
                     cand = ".".join(parts[i:])
-                    if (cand + ".weight") in sf_key_set and cand not in remapped:
+                    if cand not in remapped and _lora_key_has_backing(cand, sf_key_set):
                         target = cand
                         break
             if target is not None:
@@ -3381,7 +3400,7 @@ def _convert_lora_keys_to_safetensor_format(
     return converted_lora_weights_output
 pass
 
-def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_name, tie_word_embeddings):
+def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_name, tie_word_embeddings, count_packed_mxfp4 = True):
     """Count LoRA modules backed by a saved tensor, mirroring the key resolution of
     the merge loop in _merge_and_overwrite_lora (remap, Gemma4 .linear, fused MoE
     experts, mxfp4 packed experts, and the tied lm_head -> embed_tokens bridge). The
@@ -3403,7 +3422,7 @@ def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_n
             return False
         # Direct, Gemma4 .linear, mxfp4 packed, and MoE (per-expert / fused 3D / .moe alias)
         # backing all mirror the merge loop via the shared helper.
-        if _lora_key_has_backing(key, safetensor_keys_seen):
+        if _lora_key_has_backing(key, safetensor_keys_seen, count_packed_mxfp4 = count_packed_mxfp4):
             return True
         if tie_word_embeddings and key.endswith("lm_head"):    # tied: merged onto embed_tokens
             # The merge folds an lm_head LoRA onto an on-disk embed_tokens.weight, but only

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2581,16 +2581,13 @@ def merge_and_overwrite_lora(
 
 
     # Step 7: Check for errors
-    # Count only LoRA modules backed by a saved tensor, using the same key resolution
-    # as the merge loop above (remap, Gemma4 .linear, fused MoE experts, and the tied
-    # lm_head -> embed_tokens bridge with its embed-not-a-target guard). The count
-    # therefore equals the number of tensors the merge actually writes, so no separate
-    # tied discount is needed. A looser re-derivation drifts from the merge and raises
-    # false mismatches; len(lora_weights) over-counts unbacked targets such as a vision
-    # tower absent from the base safetensors.
+    # Count only LoRA modules backed by a saved tensor, using the merge loop's key
+    # resolution (remap, Gemma4 .linear, fused MoE, tied lm_head -> embed_tokens), so the
+    # count equals what the merge writes and needs no tied discount. len(lora_weights)
+    # over-counts unbacked targets such as a vision tower absent from the base.
     _base = find_lora_base_model(model)
-    # Native mxfp4 save (save_method="mxfp4") preserves _blocks/_scales untouched instead of
-    # merging, so a LoRA on a packed tensor is not written; don't count it as backed there.
+    # Native mxfp4 save preserves _blocks/_scales instead of merging, so a LoRA on a packed
+    # tensor is not written; don't count it as backed there.
     _count_packed_mxfp4 = not (base_model_is_quantized and quant_type == "mxfp4" and save_method == "mxfp4")
     effective_loras = _count_backed_lora_modules(
         lora_weights,
@@ -3134,9 +3131,8 @@ def detect_keys_format(keys_to_check, forward_mapping):
 pass
 
 def _safetensor_module_key(sf):
-    """The LoRA module path a safetensor key backs: strip .weight, then a trailing
-    .linear (Gemma4 ClippableLinear) so a reordered <module>.linear.weight tensor lines up
-    with its LoRA key in the prefix-substitution vote. Returns None for non-.weight keys."""
+    """LoRA module path a .weight key backs: strip .weight, then a trailing .linear
+    (Gemma4 ClippableLinear). None for non-.weight keys."""
     if not isinstance(sf, str) or not sf.endswith(".weight"):
         return None
     module_key = sf[: -len(".weight")]
@@ -3146,12 +3142,9 @@ def _safetensor_module_key(sf):
 pass
 
 def _build_valid_prefixes(keys_set, count_packed_mxfp4 = True):
-    """Pre-compute every component-boundary parent prefix of the merge-backing tensors in
-    keys_set (keys ending in .weight, or mxfp4 _blocks paired with _scales). Lets the MoE
-    descendant check in _lora_key_has_backing do an O(1) `cand in prefixes` lookup instead
-    of an O(N) scan per key, which matters on large MoE checkpoints with tens of thousands
-    of tensors. Equivalent to `any(s.startswith(cand + '.') and <s is a backing tensor>)`.
-    """
+    """Component-boundary parent prefixes of merge-backing tensors (.weight, or mxfp4
+    _blocks paired with _scales). Lets _lora_key_has_backing test MoE descendants with an
+    O(1) `cand in prefixes` lookup instead of an O(N) scan per key on large checkpoints."""
     valid_prefixes = set()
     for s in keys_set:
         if not isinstance(s, str):
@@ -3169,19 +3162,12 @@ def _build_valid_prefixes(keys_set, count_packed_mxfp4 = True):
 pass
 
 def _lora_key_has_backing(key, keys_set, count_packed_mxfp4 = True, valid_prefixes = None):
-    """True if a converted LoRA module path is backed by a tensor the merge loop would
-    actually consume, mirroring _merge_and_overwrite_lora / _merge_moe_experts_file:
-      - direct <key>.weight,
-      - Gemma4 ClippableLinear <key>.linear.weight,
-      - mxfp4 packed <key>_blocks + <key>_scales (dequantized to <key> on save),
-      - per-expert MoE descendants <prefix>.<e>.<proj>.weight (or packed _blocks/_scales),
-      - fused 3D MoE <prefix>.gate_up_proj / <prefix>.down_proj (no .weight, GPT-OSS/Gemma4),
-      including the .moe -> .experts alias the merge applies.
-    Shared by the save-count check and the remap fallback so both agree with what the
-    merge writes (and never invent a key with no backing). count_packed_mxfp4=False mirrors
-    the native mxfp4 save path (save_method="mxfp4"), which preserves _blocks/_scales
-    untouched instead of merging, so a LoRA on a packed tensor is not written there.
-    """
+    """True if a converted LoRA module path is backed by a tensor the merge consumes:
+    direct <key>.weight, Gemma4 <key>.linear.weight, mxfp4 packed <key>_blocks/_scales,
+    per-expert MoE descendants, or fused 3D <prefix>.gate_up_proj/.down_proj (incl. the
+    .moe -> .experts alias). Shared by the save-count check and the remap fallback so both
+    match what the merge writes. count_packed_mxfp4=False mirrors the native mxfp4 save,
+    which preserves _blocks/_scales (so a LoRA on a packed tensor is not written)."""
     if not isinstance(key, str):
         return False
     if (key + ".weight") in keys_set:
@@ -3195,9 +3181,8 @@ def _lora_key_has_backing(key, keys_set, count_packed_mxfp4 = True, valid_prefix
         cands = set()
         for b in (base, base.replace(".moe", ".experts")):
             cands.add(b)
-            # A fused-named LoRA key (<experts>.gate_up_proj / .down_proj) is also backed by
-            # the per-expert descendants under <experts>, since the merge maps disk
-            # <experts>.<e>.<proj>.weight onto <experts>.gate_up_proj (saving_utils ~L663).
+            # fused-named key (.gate_up_proj/.down_proj) is also backed by its per-expert
+            # descendants, since the merge maps <experts>.<e>.<proj>.weight onto it.
             for suf in (".gate_up_proj", ".down_proj"):
                 if b.endswith(suf):
                     cands.add(b[: -len(suf)])
@@ -3222,19 +3207,12 @@ pass
 def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     """Infer missing key prefixes by matching LoRA keys against safetensor keys.
 
-    Composite models (e.g. Qwen3.5) may store safetensors under an extra prefix
-    (``model.language_model.``) that differs from the runtime ``model.``
-    namespace. With no ``_checkpoint_conversion_mapping``, remap per key:
-    already-matching keys are kept; keys with a single prefix candidate are
-    remapped; unmatched keys (e.g. fused MoE params) inherit the most common
-    inferred prefix.
-
-    Also handles the case where LoRA keys and safetensor keys have differently
-    ordered path components (e.g. LoRA has ``model.language_model.`` but
-    safetensor has ``language_model.model.`` in Ministral 3 / Mistral 3 VLMs)
-    by discovering a dominant prefix substitution rule from common suffix
-    matches across all unmatched keys, and applying it globally.
-
+    Composite models may store safetensors under an extra prefix
+    (``model.language_model.``) differing from the runtime ``model.`` namespace: keep
+    already-matching keys, remap single-candidate keys, and let unmatched keys (e.g.
+    fused MoE) inherit the most common inferred prefix. Also handles reordered path
+    components (``model.language_model.`` <-> ``language_model.model.`` on Mistral 3
+    VLMs) via a dominant prefix-substitution rule learned from common-suffix matches.
     Returns the remapped ``defaultdict``, or ``None`` if nothing was remapped.
     """
     if not safetensor_keys:
@@ -3255,8 +3233,8 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
         if (k + ".weight") in sf_key_set or (k + ".linear.weight") in sf_key_set:
             remapped[k] = v
             continue
-        # Unique non-empty prefix candidates for this key. Accept a .linear.weight shard
-        # (Gemma4 ClippableLinear) as well, so a prefix-add onto such a tensor is not dropped.
+        # unique prefix candidates; also accept a .linear.weight shard (Gemma4) so a
+        # prefix-add onto it is not dropped.
         candidates = list(dict.fromkeys(
             sf_key[: -len(suffix)]
             for suffix in (k + ".weight", k + ".linear.weight")
@@ -3271,20 +3249,15 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
             # No exact/prefix match -- defer to global substitution below
             unmatched_keys.append((k, v))
 
-    # Discover a dominant prefix substitution by comparing unmatched LoRA
-    # key prefixes against safetensor key prefixes. This avoids per-key
-    # false matches when different sub-modules (e.g. vision vs language)
-    # share the same trailing path components.
+    # Discover a dominant prefix substitution from unmatched-key suffix matches; the
+    # multiset guard below prevents false matches across sub-modules (vision vs language).
     if unmatched_keys:
         from collections import Counter as _Counter2
         substitution_votes = _Counter2()
-        # A vote is recorded only when the two prefixes are a true reordering of the same
-        # path components (the multiset guard below), so shorter trailing suffixes are safe
-        # to seed votes and cannot pull a key across namespaces. This lets a reordered short
-        # module (e.g. model.language_model.embed_tokens vs language_model.model.embed_tokens)
-        # learn its own reorder even on a shard that holds no longer layer keys to seed it.
-        # Group safetensor module keys by each trailing 1..3 component suffix so every
-        # unmatched key only scans plausible buckets (keeps this roughly O(n)).
+        # A vote is recorded only for a true reordering of the same path components
+        # (multiset guard below), so short trailing suffixes are safe to seed and cannot
+        # pull a key across namespaces. Bucket sf keys by trailing 1..3 components so each
+        # unmatched key scans only plausible buckets (~O(n)).
         sf_parts_by_suffix = defaultdict(list)
         for sf in safetensor_keys:
             module_key = _safetensor_module_key(sf)   # strips .weight and a trailing .linear
@@ -3320,11 +3293,9 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
                                 == sorted(p for p in sf_prefix.split(".") if p)):
                         substitution_votes[(lora_prefix, sf_prefix)] += 1
 
-        # Apply prefix substitutions, but only true reorderings of the same path
-        # components (e.g. model.language_model. <-> language_model.model.), never
-        # cross-namespace rewrites. Only claim a target that exists on disk and is
-        # not already taken, so an unmatched vision key cannot overwrite a real
-        # language tensor.
+        # Apply substitutions for true reorderings only (e.g. model.language_model. <->
+        # language_model.model.), never cross-namespace; claim only an on-disk target not
+        # already taken, so an unmatched vision key can't overwrite a real language tensor.
         if substitution_votes:
             remaining_unmatched = list(unmatched_keys)
             applied_prefixes = set()
@@ -3350,13 +3321,11 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     from collections import Counter as _Counter
     common_prefix = _Counter(inferred_prefixes).most_common(1)[0][0] if inferred_prefixes else None
 
-    # A LoRA target can carry an extra wrapper prefix the base tensor lacks (e.g.
-    # model.vision_tower.* vs vision_tower.* on a Mistral 3 VLM, where the language
-    # half reorders but the vision half only drops the leading model.). Strip only
-    # GENERIC wrapper components (model / base_model / module), never a semantic
-    # namespace such as vision_tower or language_model: otherwise an unbacked vision
-    # adapter could strip down to a bare language suffix (layers.0....) and be merged
-    # onto the wrong tensor. Accepts only an exact on-disk backing for the stripped key.
+    # A LoRA target may carry an extra wrapper prefix the base lacks (model.vision_tower.*
+    # vs vision_tower.* on Mistral 3). Strip only GENERIC wrappers (model/base_model/module),
+    # never a semantic namespace (vision_tower/language_model) -- else an unbacked vision
+    # adapter could strip to a bare language suffix and merge onto the wrong tensor. Requires
+    # an exact on-disk backing for the stripped key.
     if unmatched_keys:
         _WRAPPER_COMPONENTS = {"model", "base_model", "module"}
         still_unmatched = []
@@ -3381,12 +3350,10 @@ def _infer_prefix_and_remap(lora_weights, safetensor_keys):
     if not changed:
         return None
 
-    # Apply the most common inferred prefix to any remaining unmatched keys, but only
-    # when that lands on a real backing tensor; otherwise leave the key untouched so the
-    # merge skips a genuinely unbacked target (e.g. a vision adapter with no base tensor)
-    # instead of rewriting it onto a wrong or nonexistent key. Backing covers MoE experts
-    # (descendant / fused / packed) and Gemma4 .linear, not just a direct .weight, so a
-    # prefixed MoE LoRA key is not dropped.
+    # Apply the most common inferred prefix to remaining unmatched keys, but only when it
+    # lands on a real backing tensor; otherwise leave the key so the merge skips a genuinely
+    # unbacked target instead of rewriting it onto a wrong key. Backing covers MoE experts
+    # and Gemma4 .linear, not just direct .weight.
     for k, v in unmatched_keys:
         if (
             common_prefix is not None and isinstance(k, str)
@@ -3459,17 +3426,12 @@ def _convert_lora_keys_to_safetensor_format(
 pass
 
 def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_name, tie_word_embeddings, count_packed_mxfp4 = True):
-    """Count LoRA modules backed by a saved tensor, mirroring the key resolution of
-    the merge loop in _merge_and_overwrite_lora (remap, Gemma4 .linear, fused MoE
-    experts, mxfp4 packed experts, and the tied lm_head -> embed_tokens bridge). The
-    tied bridge is keyed on the DISK embed prefix and only fires when that embed is not
-    itself a target, exactly like the merge, so the count equals the number of tensors
-    the merge writes and the Step-7 sanity check needs no extra tied discount. Genuinely
-    unbacked targets (e.g. a vision tower absent from the base safetensors, or a bare
-    lm_head whose composite-VLM embed lives at a deep prefix the merge cannot bridge) are
-    excluded. Known merge limitation, faithfully mirrored here: when only lm_head.weight
-    is on disk (not embed_tokens.weight), a tied embed_tokens target is dropped by the
-    merge and likewise not counted, so the save succeeds without that delta.
+    """Count LoRA modules backed by a saved tensor, mirroring the merge loop's key
+    resolution (remap, Gemma4 .linear, fused MoE, mxfp4 packed, tied lm_head ->
+    embed_tokens). The count equals what the merge writes, so the Step-7 sanity check
+    needs no tied discount; genuinely unbacked targets (a vision tower absent from the
+    base, or a bare lm_head whose composite-VLM embed sits at an unbridgeable prefix) are
+    excluded, matching the merge.
     """
     converted = _convert_lora_keys_to_safetensor_format(
         lora_weights, safetensor_keys_seen, model_class_name = model_class_name,
@@ -3480,18 +3442,14 @@ def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_n
     def _backed(key):
         if not isinstance(key, str):
             return False
-        # Direct, Gemma4 .linear, mxfp4 packed, and MoE (per-expert / fused 3D / .moe alias)
-        # backing all mirror the merge loop via the shared helper.
+        # all backing cases mirror the merge loop via the shared helper.
         if _lora_key_has_backing(key, safetensor_keys_seen, count_packed_mxfp4 = count_packed_mxfp4, valid_prefixes = valid_prefixes):
             return True
         if tie_word_embeddings and key.endswith("lm_head"):    # tied: merged onto embed_tokens
-            # The merge folds an lm_head LoRA onto an on-disk embed_tokens.weight, but only
-            # when that embed module is not itself a LoRA target (else the merge writes the
-            # embed delta and drops lm_head). Mirror that exactly, keying off the DISK embed
-            # prefix with the same model. strip/add the merge uses, so a bare lm_head resolves
-            # onto model.embed_tokens.weight (standard) yet a deep composite-VLM prefix
-            # model.language_model.embed_tokens.weight does not claim a bare lm_head it can
-            # never reach.
+            # The merge folds an lm_head LoRA onto an on-disk embed_tokens.weight only when
+            # that embed is not itself a target. Mirror that, keying off the DISK embed prefix
+            # with the merge's model. strip/add, so a bare lm_head resolves to
+            # model.embed_tokens.weight but a deep composite-VLM embed prefix does not.
             for sf in safetensor_keys_seen:
                 if not (isinstance(sf, str) and sf.endswith("embed_tokens.weight")):
                     continue

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2575,30 +2575,13 @@ def merge_and_overwrite_lora(
     # tied lm_head -> embed_tokens). A looser re-derivation drifts from the merge
     # and raises false mismatches; len(lora_weights) over-counts unbacked targets
     # such as a vision tower absent from the base safetensors.
-    _converted_for_check = _convert_lora_keys_to_safetensor_format(
+    _base = find_lora_base_model(model)
+    effective_loras = _count_backed_lora_modules(
         lora_weights,
         safetensor_keys_seen,
-        model_class_name = find_lora_base_model(model).__class__.__name__,
+        _base.__class__.__name__,
+        bool(getattr(_base.config, "tie_word_embeddings", False)),
     )
-    _tie_word_embeddings = bool(getattr(find_lora_base_model(model).config, "tie_word_embeddings", False))
-
-    def _lora_is_backed(_key):
-        if not isinstance(_key, str):
-            return False
-        if (_key + ".weight") in safetensor_keys_seen:
-            return True
-        if (_key + ".linear.weight") in safetensor_keys_seen:   # Gemma4 ClippableLinear
-            return True
-        if ".experts" in _key or ".moe" in _key:                # fused / per-expert MoE
-            _p = _key[: -len(".base_layer")] if _key.endswith(".base_layer") else _key
-            if any(_s.startswith(_p + ".") and _s.endswith(".weight") for _s in safetensor_keys_seen):
-                return True
-        if _tie_word_embeddings and _key.endswith("lm_head"):   # tied: merged onto embed_tokens
-            if (_key[: -len("lm_head")] + "embed_tokens.weight") in safetensor_keys_seen:
-                return True
-        return False
-
-    effective_loras = sum(1 for _key in _converted_for_check if _lora_is_backed(_key))
 
     # For tied embeddings, PEFT can register both embed_tokens and lm_head as modules_to_save even
     # though only one tensor exists on disk. If we see both logical modules but only one backing
@@ -3324,6 +3307,45 @@ def _convert_lora_keys_to_safetensor_format(
 
         converted_lora_weights_output[converted_key_for_lookup] = lora_stats
     return converted_lora_weights_output
+pass
+
+def _count_backed_lora_modules(lora_weights, safetensor_keys_seen, model_class_name, tie_word_embeddings):
+    """Count LoRA modules backed by a saved tensor, mirroring the key resolution of
+    the merge loop in _merge_and_overwrite_lora (remap, Gemma4 .linear, fused MoE
+    experts, and the tied lm_head -> embed_tokens fallback with its model. add/strip).
+    Kept in sync with that loop so the save sanity check counts the same modules the
+    merge actually wrote; genuinely unbacked targets (e.g. a vision tower absent from
+    the base safetensors) are excluded.
+    """
+    converted = _convert_lora_keys_to_safetensor_format(
+        lora_weights, safetensor_keys_seen, model_class_name = model_class_name,
+    )
+
+    def _backed(key):
+        if not isinstance(key, str):
+            return False
+        if (key + ".weight") in safetensor_keys_seen:
+            return True
+        if (key + ".linear.weight") in safetensor_keys_seen:   # Gemma4 ClippableLinear
+            return True
+        if ".experts" in key or ".moe" in key:                 # fused / per-expert MoE
+            prefix = key[: -len(".base_layer")] if key.endswith(".base_layer") else key
+            if any(s.startswith(prefix + ".") and s.endswith(".weight") for s in safetensor_keys_seen):
+                return True
+        if tie_word_embeddings and key.endswith("lm_head"):    # tied: merged onto embed_tokens
+            # Mirror the merge loop's model. add/strip so a bare lm_head key resolves
+            # to model.embed_tokens.weight (and a model.-prefixed key to the bare one).
+            prefix = key[: -len("lm_head")]
+            candidates = [prefix + "embed_tokens.weight"]
+            if prefix.startswith("model."):
+                candidates.append(prefix[len("model."):] + "embed_tokens.weight")
+            else:
+                candidates.append("model." + prefix + "embed_tokens.weight")
+            if any(c in safetensor_keys_seen for c in candidates):
+                return True
+        return False
+
+    return sum(1 for key in converted if _backed(key))
 pass
 
 def find_lora_base_model(model_to_inspect):


### PR DESCRIPTION
Fixes unslothai/unsloth#6309

The issue occurs when saving merged LoRA models for VLMs like Mistral3ForConditionalGeneration (Ministral-3-14B-Instruct-2512). The LoRA keys follow HF module hierarchy (model.language_model.layers.X...) but the safetensor keys use mistral-common format (language_model.model.layers.X...).

Changes:
1. Enhanced _infer_prefix_and_remap to discover a global prefix substitution rule from common suffix matches across all unmatched keys, then apply it consistently. This handles models where the LoRA key path and safetensor key path have differently ordered components.

2. Fixed the sanity check to only count LoRA modules that have corresponding safetensor keys. Some LoRA keys (e.g. vision tower adapters) may target modules that do not exist in the base safetensors. This prevents false-positive mismatches.