### PR TITLE
fix: strip MTP config keys before GGUF export to prevent block_count inflation

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2126,8 +2126,7 @@ def convert_to_gguf(
 
     # Check if arch is supported
     supported_types = (supported_vision_archs or set()) | (supported_text_archs or set())
-    if supported_types:
-        assert("architectures" in config_file)
+    if supported_types and "architectures" in config_file:
         arch = config_file["architectures"][0]
         if arch not in supported_types:
             raise NotImplementedError(
@@ -2137,8 +2136,11 @@ def convert_to_gguf(
     pass
 
     if is_vlm and supported_vision_archs is not None:
-        arch = config_file["architectures"][0]
-        if arch not in supported_vision_archs:
+        if "architectures" in config_file:
+            arch = config_file["architectures"][0]
+        else:
+            arch = None  # MLX-style config; skip mmproj arch check
+        if arch is not None and arch not in supported_vision_archs:
                 is_vlm = False
                 print(f"Unsloth: {arch} is not supported for MMPROJ conversion. Converting as text-only model.")
 

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2115,13 +2115,26 @@ def convert_to_gguf(
     if not os.path.exists(input_folder):
         raise RuntimeError(f"Unsloth: `{input_folder}` does not exist?")
 
-    config_file = os.path.join(input_folder, "config.json")
-    if not os.path.exists(config_file):
+    config_path = os.path.join(input_folder, "config.json")
+    if not os.path.exists(config_path):
         raise RuntimeError(f"Unsloth: `config.json` does not exist inside `{input_folder}`.")
 
     # Load config.json
-    with open(config_file, "r", encoding = "utf-8") as config_file:
-        config_file = json.load(config_file)
+    with open(config_path, "r", encoding = "utf-8") as f:
+        config_file = json.load(f)
+
+    # Strip MTP / nextn config keys so the downstream convert_hf_to_gguf.py
+    # doesn't inflate block_count / inject nextn_predict_layers.
+    _changed = False
+    for _key in ("mtp_num_hidden_layers", "unsloth_fixed_mtp"):
+        if config_file.pop(_key, None) is not None:
+            _changed = True
+        _tc = config_file.get("text_config")
+        if _tc and _tc.pop(_key, None) is not None:
+            _changed = True
+    if _changed:
+        with open(config_path, "w", encoding = "utf-8") as f:
+            json.dump(config_file, f, indent = 2)
     pass
 
     # Check if arch is supported

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5100,6 +5100,33 @@ def save_pretrained_gguf(
                     f"{rewritten} MLX VLM tensors for llama.cpp GGUF export."
                 )
 
+        # Strip MTP/nextn config keys so llama.cpp converter
+        # doesn't inflate block_count / inject nextn_predict_layers.
+        # Also restore architectures from the original HF config since
+        # mlx-vlm's save_config strips that key.
+        _config_path = tmp_path / "config.json"
+        if _config_path.exists():
+            _cfg = json.loads(_config_path.read_text())
+            _changed = False
+            for _key in ("mtp_num_hidden_layers", "unsloth_fixed_mtp"):
+                if _cfg.pop(_key, None) is not None:
+                    _changed = True
+                _tc = _cfg.get("text_config")
+                if _tc and _tc.pop(_key, None) is not None:
+                    _changed = True
+            # Restore architectures from the original HF config
+            if "architectures" not in _cfg:
+                _orig_cfg_path = getattr(tokenizer, "name_or_path", None)
+                if _orig_cfg_path:
+                    _orig_cfg_file = os.path.join(_orig_cfg_path, "config.json")
+                    if os.path.exists(_orig_cfg_file):
+                        _orig_cfg = json.load(open(_orig_cfg_file))
+                        if "architectures" in _orig_cfg:
+                            _cfg["architectures"] = _orig_cfg["architectures"]
+                            _changed = True
+            if _changed:
+                _config_path.write_text(json.dumps(_cfg, indent=2))
+
         # Step 2: Ensure llama.cpp is installed and gguf package is available
         llama_cpp_folder = LLAMA_CPP_DEFAULT_DIR
         try:


### PR DESCRIPTION
Strip `mtp_num_hidden_layers` and `unsloth_fixed_mtp` from `config.json` (both top-level and `text_config`) before the llama.cpp converter reads it.

**Three changes:**

1. **`unsloth_zoo/mlx/utils.py`** — `save_pretrained_gguf`: strip MTP keys from temp config after saving the merged model. Also restores `architectures` key from original HF config (`mlx-vlm.save_config` strips it).

2. **`unsloth_zoo/llama_cpp.py`** — `convert_to_gguf`: strip MTP keys from config.json on disk before running `convert_hf_to_gguf.py`. This is the central entry point that covers **all** callers (Studio UI, direct API, etc.).

3. **`unsloth_zoo/llama_cpp.py`** — `convert_to_gguf`: make architecture/vision checks graceful when `architectures` key is missing (MLX-style configs).

Fixes GGUF export for Qwen3.5-2B and other MTP-enabled models on MLX.