### PR TITLE
Guard mlx import in test_qwen35_vjp_metal so Linux collection skips cleanly

### DIFF
--- a/tests/test_qwen35_vjp_metal.py
+++ b/tests/test_qwen35_vjp_metal.py
@@ -17,11 +17,14 @@ Run on an Apple Silicon machine (CI installs unsloth-zoo with ``pip install -e .
 Target runtime: well under ~2 minutes on an M1.
 """
 
-import mlx.core as mx
-import mlx.nn as nn
 import pytest
 
-_HAS_METAL = mx.metal.is_available() and mx.default_device() == mx.gpu
+try:
+    import mlx.core as mx
+    import mlx.nn as nn
+    _HAS_METAL = mx.metal.is_available() and mx.default_device() == mx.gpu
+except Exception:
+    _HAS_METAL = False
 _SKIP_REASON = (
     "Requires Apple Silicon Metal GPU (mx.metal.is_available() and default "
     "device == gpu); the qwen3_5 VJP crash is Metal-kernel-specific and cannot "


### PR DESCRIPTION
## Summary

`tests/test_qwen35_vjp_metal.py` imported `mlx.core` and `mlx.nn` at module top
level. On a machine without mlx (Linux), pytest raises
`ModuleNotFoundError: No module named 'mlx'` during collection and aborts the
whole run with exit code 2 -- even though every test in the file is already
gated to Apple Silicon Metal via the `metal_only` skipif.

This breaks the collection-only sanity step that scans both repos (e.g. the
"Core" workflow in `unslothai/unsloth`):

```
ERROR collecting tests/test_qwen35_vjp_metal.py
ModuleNotFoundError: No module named 'mlx'
1513 tests collected, 1 error in 2.60s
```

## Fix

Wrap the import in `try/except` and set `_HAS_METAL = False` on failure -- the
same pattern the sibling Metal tests already use
(`test_mlx_training_e2e_metal.py`, `test_mlx_pr684_full_validation_metal.py`).
The module stays collectable on Linux (the four tests show as skipped via
`metal_only`) and runs unchanged on Apple Silicon.

This file is already wired into the MLX CI lane (`mlx-ci.yml`, `macos-14`), so
on real Metal the tests execute exactly as before; only the Linux collection
behavior changes.

## Verification (no mlx installed)

```
# before
ERROR tests/test_qwen35_vjp_metal.py
Interrupted: 1 error during collection            (exit 2)

# after
4 tests collected                                  (collect-only, exit 0)
4 skipped                                           (run, exit 0)
```

No behavior change where mlx is present: `mx` / `nn` resolve to the real
modules and the existing `metal_only` gating is untouched.
