### PR TITLE
fix(mlx): wrong gated-delta grads for batch rows past the first

### DIFF
--- a/unsloth_zoo/gated_delta_vjp.py
+++ b/unsloth_zoo/gated_delta_vjp.py
@@ -122,11 +122,17 @@ def gated_delta_ops_efficient(
         # BPTT: `d_state` is the cotangent w.r.t. the RETURNED state at the
         # current step (= input to step t+1). Starts at d_state_out, then
         # propagates through the recurrence + mask.
-        d_q = mx.zeros_like(q_c)
-        d_k = mx.zeros_like(k_c)
-        d_v = mx.zeros_like(v_c)
-        d_g = mx.zeros_like(g_c)
-        d_beta = mx.zeros_like(beta_c)
+        # Per-step grads are collected in lists and stacked afterwards: each
+        # t is produced exactly once, and mx `.at[:, t].add` scatter-add
+        # reads the update tensor with a wrong batch stride (wrong grads for
+        # every batch row past the first; verified against plain autodiff on
+        # mlx 0.31).
+        # Fixed upstream in ml-explore/mlx#3483, not yet in any release.
+        d_q_steps = []
+        d_k_steps = []
+        d_v_steps = []
+        d_g_steps = []
+        d_beta_steps = []
         d_state = d_state_out
 
         for t in range(chunk_T - 1, -1, -1):
@@ -171,7 +177,7 @@ def gated_delta_ops_efficient(
                 + dy_t[..., None].astype(mx.float32) * q_t[..., None, :].astype(mx.float32)
             )
             d_q_t = (dy_t[..., None].astype(mx.float32) * state_new).sum(axis=-2)
-            d_q = d_q.at[:, t].add(d_q_t.astype(d_q.dtype))
+            d_q_steps.append(d_q_t.astype(q_c.dtype))
 
             # state_new = state_decayed + k[..., None, :] * delta[..., None]
             d_kd = d_state_new
@@ -203,14 +209,21 @@ def gated_delta_ops_efficient(
                 d_g_t = d_decay
 
             d_k_t = d_k_t_from_update + d_k_t_from_kv
-            d_k = d_k.at[:, t].add(d_k_t.astype(d_k.dtype))
-            d_v = d_v.at[:, t].add(d_v_t.astype(d_v.dtype))
-            d_g = d_g.at[:, t].add(d_g_t.astype(d_g.dtype))
-            d_beta = d_beta.at[:, t].add(d_beta_t.astype(d_beta.dtype))
+            d_k_steps.append(d_k_t.astype(k_c.dtype))
+            d_v_steps.append(d_v_t.astype(v_c.dtype))
+            d_g_steps.append(d_g_t.astype(g_c.dtype))
+            d_beta_steps.append(d_beta_t.astype(beta_c.dtype))
 
             # d_state_prev = recurrence-derived gradient + mask passthrough.
             d_state = d_state_prev_via_recurrence + d_state_prev_passthrough
 
+        for steps in (d_q_steps, d_k_steps, d_v_steps, d_g_steps, d_beta_steps):
+            steps.reverse()
+        d_q = mx.stack(d_q_steps, axis=1)
+        d_k = mx.stack(d_k_steps, axis=1)
+        d_v = mx.stack(d_v_steps, axis=1)
+        d_g = mx.stack(d_g_steps, axis=1)
+        d_beta = mx.stack(d_beta_steps, axis=1)
         d_mask = mx.zeros_like(mask_chunk) if mask_chunk is not None else None
         return d_q, d_k, d_v, d_g, d_beta, d_state, d_mask
 


### PR DESCRIPTION
## What's changed

This is the narrow MLX gated-delta gradient workaround split out from https://github.com/unslothai/unsloth-zoo/pull/754.

MLX 0.31.2 scatter-add can read the update tensor with a wrong batch stride for `mx .at[:, t].add`, silently corrupting `d_q`/`d_k`/`d_v`/`d_g`/`d_beta` for every batch element except index 0. This PR avoids that path by collecting per-step grads in lists and stacking them after the reverse-time loop.

The MLX core issue only affects this gated-delta VJP path when `B > 1`. `B = 1` is included in validation and performance checks as a control case.

The underlying MLX regression is fixed upstream in https://github.com/ml-explore/mlx/pull/3483, but it's not included in latest mlx release `v0.31.2`.

## Validation

Checked against a plain autodiff recurrence:

- old scatter path matches on `mlx 0.31.1`
- old scatter path diverges on `mlx 0.31.2` for `B > 1`
- list+stack path matches on both versions

Local focused test:

- `python -m pytest tests/test_mlx_gated_delta.py -q` -> `3 passed`

## Focused VJP performance

Exact-import retest comparing the actual parent implementation (`d5224f48`, old scatter) against the actual PR branch (`2c748ab1`, fixed list+stack). Workload: full backward/VJP, `T=64`, `Hk=Hv=2`, `Dk=Dv=64`, no mask. Table reports median-of-round-medians.

| MLX | B | old `.at.add` | fixed branch | fixed delta |
|---|---:|---:|---:|---:|
| 0.31.2 | 1 | 12.93 ms | 12.19 ms | 5.7% faster |
| 0.31.2 | 2 | 13.34 ms | 12.33 ms | 7.6% faster |
| 0.31.2 | 4 | 13.15 ms | 12.46 ms | 5.3% faster |
| 0.31.2 | 8 | 13.97 ms | 13.10 ms | 6.3% faster |
| 0.31.1 | 1 | 13.12 ms | 11.55 ms | 12.0% faster |
| 0.31.1 | 2 | 13.08 ms | 11.62 ms | 11.2% faster |
| 0.31.1 | 4 | 13.23 ms | 11.75 ms | 11.2% faster |
| 0.31.1 | 8 | 13.60 ms | 12.36 ms | 9.1% faster |

Performance interpretation: the PR is a correctness workaround for the `mlx 0.31.2` scatter regression. In this focused VJP microbenchmark, the fixed path is also faster than the old scatter implementation, but this table should not be read as an end-to-end training throughput claim.
