### PR TITLE
Optimize LoRA merge to 16bit save and add end-to-end merge correctness suite

### DIFF
--- a/tests/_merge_e2e_helpers.py
+++ b/tests/_merge_e2e_helpers.py
@@ -1,0 +1,552 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Shared helpers for the end-to-end LoRA merge-to-16bit correctness suite.
+
+These helpers drive the real public merge path (`merge_and_overwrite_lora`) on
+tiny but architecturally-real models and check every saved tensor against an
+INDEPENDENT reference:
+
+    adapted module : merged == (base.float() + scale * (B @ A)).to(save_dtype)
+    pass-through   : merged is byte-identical to the base tensor
+
+The reference is built directly from the LoRA A/B/scaling read off the live PEFT
+model (not from the merge implementation), so it cannot mask a merge bug. Tiny
+configs use *distinct* hidden / intermediate sizes so fused-expert orientation is
+unambiguous and transpose bugs are visible.
+
+Not a `test_` module, so pytest does not collect it as tests.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+import hashlib
+from dataclasses import dataclass, field
+
+import torch
+from safetensors import safe_open
+
+from unsloth_zoo.saving_utils import merge_and_overwrite_lora
+
+
+SEED = 1234
+
+# dtype-aware tolerances for adapted tensors (atol, rtol). Pass-through tensors
+# are always compared with exact byte-identity, never these tolerances.
+_TOL = {
+    torch.float32:  (1e-5, 1e-5),
+    torch.bfloat16: (2e-2, 2e-2),
+    torch.float16:  (5e-3, 5e-3),
+}
+
+
+def set_offline_cpu_env():
+    """Make the merge run offline and tolerate CPU-only hosts (CI)."""
+    os.environ.setdefault("HF_HUB_OFFLINE", "1")
+    os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+    os.environ.setdefault("UNSLOTH_ALLOW_CPU", "1")
+    os.environ.setdefault("UNSLOTH_DISABLE_AUTO_UPDATES", "1")
+
+
+# ---------------------------------------------------------------------------
+# Reference: one adapted target (a single saved tensor that LoRA modifies).
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Adapted:
+    key: str            # safetensor key, e.g. model.layers.0.self_attn.q_proj.weight
+    lora_A: torch.Tensor
+    lora_B: torch.Tensor
+    alpha: float
+    fused: bool         # True for grouped 3D expert tensors (gate_up_proj/down_proj)
+
+
+def _strip_peft_prefix(name: str) -> str:
+    for pfx in ("base_model.model.", "base_model."):
+        if name.startswith(pfx):
+            return name[len(pfx):]
+    return name
+
+
+def _iter_lora_modules(peft_model):
+    """Yield (module_name, module) for every LoRA-bearing module (dense Linear
+    targets and target_parameters / fused expert wrappers)."""
+    for name, mod in peft_model.named_modules():
+        la = getattr(mod, "lora_A", None)
+        lb = getattr(mod, "lora_B", None)
+        if la is None or lb is None:
+            continue
+        if not (hasattr(la, "__contains__") and "default" in la and "default" in lb):
+            continue
+        yield name, mod
+
+
+def _module_to_key(name: str, param_name) -> str:
+    """Map a PEFT module name to the on-disk safetensor key it adapts."""
+    base = _strip_peft_prefix(name)
+    if param_name:  # target_parameters (fused expert param)
+        if base.endswith(".base_layer"):
+            base = base[: -len(".base_layer")]
+        return f"{base}.{param_name}"
+    return f"{base}.weight"
+
+
+def seed_lora(peft_model, seed: int = SEED):
+    """Fill lora_A and lora_B with deterministic, asymmetric, nonzero values.
+
+    PEFT inits lora_B to zero (no delta) and lora_A via kaiming; we overwrite
+    both with shaped values seeded by the *safetensor key* so the result is a
+    pure function of (key, seed) and independent of module-iteration order.
+    Shaped (not pure-randn) values make transpose / slice bugs visible on tiny
+    tensors.
+    """
+    with torch.no_grad():
+        for name, mod in _iter_lora_modules(peft_model):
+            key = _module_to_key(name, getattr(mod, "parameter_name", None))
+            for tag, bank in (("A", mod.lora_A), ("B", mod.lora_B)):
+                w = bank["default"].weight
+                # process-stable seed (Python's hash() is randomized per process)
+                h = hashlib.sha256(f"{key}|{tag}|{seed}".encode()).digest()
+                g = torch.Generator(device="cpu").manual_seed(
+                    int.from_bytes(h[:7], "big")
+                )
+                vals = torch.randn(w.numel(), generator=g)
+                # add a shaped, position-dependent ramp so values are asymmetric
+                ramp = torch.arange(w.numel(), dtype=torch.float32) * 1.0e-3
+                w.copy_((vals * 0.02 + ramp).reshape(w.shape).to(w.dtype))
+
+
+def extract_adapted(peft_model) -> dict[str, _Adapted]:
+    """Build {safetensor_key: _Adapted} from the live PEFT model. Independent of
+    the merge implementation; reuses only the A/B/scaling tensors."""
+    out: dict[str, _Adapted] = {}
+    for name, mod in _iter_lora_modules(peft_model):
+        param_name = getattr(mod, "parameter_name", None)
+        key = _module_to_key(name, param_name)
+        A = mod.lora_A["default"].weight.detach().cpu()
+        B = mod.lora_B["default"].weight.detach().cpu()
+        alpha = float(mod.scaling["default"])
+        out[key] = _Adapted(key=key, lora_A=A, lora_B=B, alpha=alpha,
+                            fused=bool(param_name))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Reference math.
+# ---------------------------------------------------------------------------
+
+def _ref_dense(base: torch.Tensor, a: _Adapted) -> torch.Tensor:
+    """2D Linear merge (also per-expert MoE, which is a plain Linear).
+
+    Handles the vocab-grow case where lora_B has more rows than base (zero-pad).
+    """
+    A = a.lora_A.to(torch.float64)
+    B = a.lora_B.to(torch.float64)
+    W = base.to(torch.float64)
+    if B.shape[0] != W.shape[0]:
+        new = torch.zeros(B.shape[0], W.shape[1], dtype=torch.float64)
+        new[: W.shape[0]] = W
+        W = new
+    return W + a.alpha * (B @ A)
+
+
+def _ref_fused(base3d: torch.Tensor, a: _Adapted) -> torch.Tensor:
+    """Grouped 3D expert merge. Per expert e: delta = B_e @ A_e, applied in the
+    orientation that fits base[e] (auto-detected from distinct dims)."""
+    E = base3d.shape[0]
+    r = a.lora_A.shape[0] // E
+    d1, d2 = base3d.shape[1], base3d.shape[2]
+    out = base3d.to(torch.float64).clone()
+    A = a.lora_A.to(torch.float64)
+    B = a.lora_B.to(torch.float64)
+    for e in range(E):
+        s, t = e * r, (e + 1) * r
+        delta = B[:, s:t] @ A[s:t, :]
+        if tuple(delta.shape) == (d1, d2):
+            out[e] += a.alpha * delta
+        elif tuple(delta.shape) == (d2, d1):
+            out[e] += a.alpha * delta.T
+        else:
+            raise AssertionError(
+                f"fused delta {tuple(delta.shape)} fits neither {(d1, d2)} nor "
+                f"{(d2, d1)} for key {a.key}; use distinct hidden/intermediate dims"
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Build + save a tiny base, attach LoRA, run the real merge.
+# ---------------------------------------------------------------------------
+
+def read_safetensors_dir(d: str) -> dict[str, torch.Tensor]:
+    out: dict[str, torch.Tensor] = {}
+    for f in sorted(os.listdir(d)):
+        if f.endswith(".safetensors"):
+            with safe_open(os.path.join(d, f), framework="pt", device="cpu") as g:
+                for k in g.keys():
+                    out[k] = g.get_tensor(k)
+    return out
+
+
+def read_index(d: str):
+    p = os.path.join(d, "model.safetensors.index.json")
+    if not os.path.exists(p):
+        return None
+    with open(p) as f:
+        return json.load(f)
+
+
+def run_merge(peft_model, base_dir, out_dir, *, save_dtype, tokenizer=None,
+              low_disk_space_usage=False):
+    """Canonical local-dir merge invocation. Returns out_dir."""
+    res = merge_and_overwrite_lora(
+        get_model_name=lambda *a, **k: base_dir,
+        model=peft_model,
+        tokenizer=tokenizer,
+        save_directory=out_dir,
+        save_method="merged_16bit",
+        output_dtype=save_dtype,
+        low_disk_space_usage=low_disk_space_usage,
+        push_to_hub=False,
+    )
+    return res
+
+
+# ---------------------------------------------------------------------------
+# The assertion engine.
+# ---------------------------------------------------------------------------
+
+_LORA_REMNANT_MARKERS = (".lora_A", ".lora_B", ".lora_embedding",
+                         ".base_layer", "modules_to_save", "original_module")
+
+
+class KeyResolutionError(AssertionError):
+    """The harness could not map an adapted module to a base safetensor key.
+
+    Raised (not for value mismatches) when a tiny config's on-disk key layout
+    differs from the LoRA module path in a way this reference builder does not
+    model (e.g. composite text+vision prefixes, or fused-vs-per-expert expert
+    serialization that varies across transformers versions). Tests treat this as
+    a skip (the merge itself is validated elsewhere), never as a value failure.
+    """
+
+
+def _resolve_key(adapted_key: str, base_keys: set[str]) -> str | None:
+    """Map an adapted key to an actual base safetensor key, tolerating an extra
+    prefix (VLM composite models, mirrors _infer_prefix_and_remap)."""
+    if adapted_key in base_keys:
+        return adapted_key
+    cands = [k for k in base_keys if k.endswith("." + adapted_key) or k.endswith(adapted_key)]
+    cands = [k for k in cands if k != adapted_key]
+    if len(cands) == 1:
+        return cands[0]
+    return None
+
+
+def assert_merge_correct(*, family, base_tensors, out_dir, save_dtype,
+                         adapted: dict[str, _Adapted], allow_missing_adapted=False):
+    """Verify every merged tensor against the independent reference.
+
+    base_tensors : {key: tensor} snapshot of the base BEFORE merge.
+    adapted      : {safetensor_key: _Adapted} from extract_adapted().
+    """
+    from unsloth_zoo.saving_utils import _MOE_MERGE_STATE
+
+    merged = read_safetensors_dir(out_dir)
+    assert merged, f"[{family}] no safetensors written to {out_dir}"
+    base_keys = set(base_tensors.keys())
+
+    # 1) no adapter remnants leaked into the merged checkpoint
+    leaked = [k for k in merged if any(m in k for m in _LORA_REMNANT_MARKERS)]
+    assert not leaked, f"[{family}] adapter remnants in merged output: {leaked[:5]}"
+
+    # 2) resolve adapted keys against the real base keys (VLM prefix tolerance)
+    resolved: dict[str, _Adapted] = {}
+    for ak, a in adapted.items():
+        rk = _resolve_key(ak, base_keys)
+        if rk is None:
+            if allow_missing_adapted:
+                # adapter targets a module absent from base safetensors (e.g. a
+                # vision-tower adapter). The merge must skip it without error;
+                # there is simply no merged tensor to check (mirrors PR #773).
+                continue
+            raise KeyResolutionError(
+                f"[{family}] adapted key {ak!r} not found among base keys "
+                f"(sample: {sorted(base_keys)[:4]})"
+            )
+        resolved[rk] = a
+
+    # 3) per-tensor check
+    atol, rtol = _TOL[save_dtype]
+    n_adapted = n_passthru = 0
+    for key, mt in merged.items():
+        if key in resolved:
+            a = resolved[key]
+            base = base_tensors[key]
+            ref = (_ref_fused(base, a) if a.fused else _ref_dense(base, a)).to(save_dtype)
+            _assert_close(family, key, mt, ref, atol, rtol, adapted=True)
+            n_adapted += 1
+        else:
+            assert key in base_tensors, (
+                f"[{family}] merged has unexpected key {key!r} absent from base"
+            )
+            _assert_equal(family, key, mt, base_tensors[key])
+            n_passthru += 1
+
+    # 4) every adapted target actually appeared and was checked
+    if not allow_missing_adapted:
+        missing = [k for k in resolved if k not in merged]
+        assert not missing, f"[{family}] adapted targets missing from merged output: {missing}"
+    assert n_adapted >= 1, f"[{family}] no adapted tensors were checked (LoRA not attached?)"
+
+    # 5) MoE merge must not have fallen back
+    assert _MOE_MERGE_STATE.get("fallback", 0) == 0, (
+        f"[{family}] MoE merge fell back: {_MOE_MERGE_STATE}"
+    )
+
+    # 6) index consistency
+    idx = read_index(out_dir)
+    if idx is not None:
+        wm = idx.get("weight_map", {})
+        for k, shard in wm.items():
+            assert os.path.exists(os.path.join(out_dir, shard)), (
+                f"[{family}] index points at missing shard {shard} for {k}"
+            )
+            assert k in merged, f"[{family}] index key {k} absent from shards"
+    return n_adapted, n_passthru
+
+
+def _diag(family, key, got, ref, adapted):
+    diff = (got.to(torch.float64) - ref.to(torch.float64)).abs()
+    maxe = diff.max().item() if diff.numel() else 0.0
+    denom = ref.to(torch.float64).abs().clamp_min(1e-12)
+    rele = (diff / denom).max().item() if diff.numel() else 0.0
+    flat = (got != ref).reshape(-1).nonzero()
+    first = int(flat[0].item()) if flat.numel() else -1
+    return (f"[{family}] key={key} adapted={adapted} shape={tuple(got.shape)} "
+            f"dtype={got.dtype} max_abs_err={maxe:.3e} max_rel_err={rele:.3e} "
+            f"first_diff_idx={first}")
+
+
+def _assert_close(family, key, got, ref, atol, rtol, *, adapted):
+    try:
+        torch.testing.assert_close(got.to(torch.float32), ref.to(torch.float32),
+                                   atol=atol, rtol=rtol)
+    except AssertionError as e:
+        raise AssertionError(_diag(family, key, got, ref, adapted) + "\n" + str(e))
+
+
+def _assert_equal(family, key, got, base):
+    if not torch.equal(got, base):
+        raise AssertionError("PASS-THROUGH NOT BYTE-IDENTICAL " +
+                             _diag(family, key, got, base, adapted=False))
+
+
+# ---------------------------------------------------------------------------
+# Tiny-config factory + LoRA attach.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FamilySpec:
+    family: str
+    kind: str                       # "dense" | "per_expert" | "fused"
+    config: object
+    auto: str = "causal"            # "causal" | "image_text"
+    attn_modules: tuple = ("q_proj", "k_proj", "v_proj", "o_proj")
+    mlp_modules: tuple = ("gate_proj", "up_proj", "down_proj")   # dense FFN
+    expert_modules: tuple = ()      # per-expert MoE target_modules
+    fused_params: tuple = ()        # target_parameters for fused experts
+
+
+# distinct dims so fused-expert orientation is unambiguous (transpose bugs show)
+_H = 32          # hidden
+_I = 64          # dense intermediate
+_MOE_I = 48      # MoE intermediate (distinct from hidden and 2*MoE_I)
+_HEADS = 4
+_KV = 2
+_VOCAB = 64
+_POS = 64
+_EXPERTS = 4
+
+
+def _common(**over):
+    d = dict(hidden_size=_H, intermediate_size=_I, num_hidden_layers=2,
+             num_attention_heads=_HEADS, num_key_value_heads=_KV, vocab_size=_VOCAB,
+             max_position_embeddings=_POS, tie_word_embeddings=False)
+    d.update(over)
+    return d
+
+
+def family_available(family: str) -> bool:
+    """True iff the installed transformers exposes this model_type."""
+    try:
+        from transformers import AutoConfig
+        AutoConfig.for_model(family)
+        return True
+    except Exception:
+        return False
+
+
+def make_spec(family: str) -> FamilySpec:
+    """Build a tiny FamilySpec for `family`. Raises if the arch is unavailable."""
+    import transformers as T
+
+    if family == "llama":
+        cfg = T.LlamaConfig(**_common())
+        return FamilySpec(family, "dense", cfg)
+    if family == "qwen3":
+        cfg = T.Qwen3Config(**_common(head_dim=_H // _HEADS))
+        return FamilySpec(family, "dense", cfg)
+    if family == "mistral":
+        cfg = T.MistralConfig(**_common())
+        return FamilySpec(family, "dense", cfg)
+    if family == "gemma2":
+        cfg = T.Gemma2Config(**_common(head_dim=_H // _HEADS, query_pre_attn_scalar=_H // _HEADS))
+        return FamilySpec(family, "dense", cfg)
+
+    if family == "qwen3_moe":
+        cfg = T.Qwen3MoeConfig(**_common(moe_intermediate_size=_MOE_I, num_experts=_EXPERTS,
+                                         num_experts_per_tok=2, decoder_sparse_step=1,
+                                         head_dim=_H // _HEADS))
+        return FamilySpec(family, "per_expert", cfg,
+                          expert_modules=("gate_proj", "up_proj", "down_proj"))
+    if family == "glm4_moe":
+        cfg = T.Glm4MoeConfig(**_common(moe_intermediate_size=_MOE_I, n_routed_experts=_EXPERTS,
+                                        n_shared_experts=1, num_experts_per_tok=2,
+                                        first_k_dense_replace=0, head_dim=_H // _HEADS))
+        return FamilySpec(family, "per_expert", cfg,
+                          expert_modules=("gate_proj", "up_proj", "down_proj"))
+    if family == "granitemoe":
+        cfg = T.GraniteMoeConfig(**_common(num_local_experts=_EXPERTS, num_experts_per_tok=2))
+        return FamilySpec(family, "per_expert", cfg,
+                          expert_modules=("input_linear", "output_linear"))
+
+    if family == "gpt_oss":
+        cfg = T.GptOssConfig(**_common(intermediate_size=_MOE_I, num_local_experts=_EXPERTS,
+                                       num_experts_per_tok=2))
+        return FamilySpec(family, "fused", cfg,
+                          fused_params=("mlp.experts.gate_up_proj", "mlp.experts.down_proj"))
+
+    # transformers 5.x only families
+    if family == "qwen3_5_moe":
+        cfg = T.AutoConfig.for_model("qwen3_5_moe")
+        # shrink whatever fields exist
+        return _shrink_generic(family, "fused", cfg,
+                               fused_params=("mlp.experts.gate_up_proj", "mlp.experts.down_proj"))
+    if family == "gemma4":
+        cfg = T.AutoConfig.for_model("gemma4")
+        return _shrink_generic(family, "fused", cfg,
+                               fused_params=("experts.gate_up_proj", "experts.down_proj"))
+    if family == "lfm2_moe":
+        cfg = T.AutoConfig.for_model("lfm2_moe")
+        return _shrink_generic(family, "fused", cfg,
+                               fused_params=("feed_forward.experts.gate_up_proj",
+                                             "feed_forward.experts.down_proj"))
+
+    raise ValueError(f"unknown family {family!r}")
+
+
+def _shrink_generic(family, kind, cfg, **kw):
+    """Best-effort shrink of an arbitrary config (used for 5.x-only fused MoEs)."""
+    text = getattr(cfg, "text_config", cfg)
+    objs = [cfg] if text is cfg else [cfg, text]
+    n_layers = 2
+    for obj in objs:
+        for attr, val in (("hidden_size", _H), ("intermediate_size", _I),
+                          ("moe_intermediate_size", _MOE_I), ("num_hidden_layers", n_layers),
+                          ("num_attention_heads", _HEADS), ("num_key_value_heads", _KV),
+                          ("vocab_size", _VOCAB), ("max_position_embeddings", _POS),
+                          ("num_experts", _EXPERTS), ("num_local_experts", _EXPERTS),
+                          ("num_experts_per_tok", 2), ("decoder_sparse_step", 1)):
+            if hasattr(obj, attr):
+                setattr(obj, attr, val)
+        # hybrid / strict-validated archs (lfm2_moe, qwen3_5_moe) require an explicit
+        # per-layer schedule matching num_hidden_layers, else instantiation raises.
+        if hasattr(obj, "layer_types") and getattr(obj, "num_hidden_layers", None):
+            try:
+                obj.layer_types = ["full_attention"] * obj.num_hidden_layers
+            except Exception:
+                pass
+        if hasattr(obj, "tie_word_embeddings"):
+            obj.tie_word_embeddings = False
+    return FamilySpec(family, kind, cfg, **kw)
+
+
+def build_and_save_base(spec: FamilySpec, base_dir: str, *, dtype=torch.float32,
+                        max_shard_size="5GB"):
+    """Instantiate the tiny model, save 16bit shards + index, return the model."""
+    from transformers import AutoModelForCausalLM
+    torch.manual_seed(SEED)
+    model = AutoModelForCausalLM.from_config(spec.config).to(dtype)
+    model.save_pretrained(base_dir, safe_serialization=True, max_shard_size=max_shard_size)
+    model.config._name_or_path = base_dir
+    return model
+
+
+def attach_lora(model, spec: FamilySpec, scenario: str, *, r=8, lora_alpha=16,
+                alpha_pattern=None, rank_pattern=None):
+    """Attach a PEFT LoRA adapter for the given scenario and seed it nonzero.
+
+    scenario in {full, attn_only, mlp_only, expert_only}.
+    Returns the PeftModel.
+    """
+    from peft import LoraConfig, get_peft_model
+    tm: list[str] = []
+    tp: list[str] = []
+    if scenario in ("full", "attn_only"):
+        tm += list(spec.attn_modules)
+    if scenario in ("full", "mlp_only") and spec.kind == "dense":
+        tm += list(spec.mlp_modules)
+    if scenario in ("full", "expert_only"):
+        if spec.kind == "per_expert":
+            tm += list(spec.expert_modules)
+        elif spec.kind == "fused":
+            tp += list(spec.fused_params)
+    kw = dict(r=r, lora_alpha=lora_alpha, lora_dropout=0.0, bias="none",
+              target_modules=tm)
+    if tp:
+        kw["target_parameters"] = tp
+    if alpha_pattern:
+        kw["alpha_pattern"] = alpha_pattern
+    if rank_pattern:
+        kw["rank_pattern"] = rank_pattern
+    torch.manual_seed(SEED)
+    peft_model = get_peft_model(model, LoraConfig(**kw))
+    seed_lora(peft_model)
+    return peft_model
+
+
+def run_case(family, scenario, work_dir, *, dtype=torch.float32, max_shard_size="5GB",
+             allow_missing_adapted=False, **attach_kw):
+    """End-to-end: build tiny base -> attach LoRA -> real merge -> assert correct.
+
+    Returns (n_adapted_checked, n_passthrough_checked). Raises on any mismatch.
+    """
+    set_offline_cpu_env()
+    spec = make_spec(family)
+    base_dir = os.path.join(work_dir, "base")
+    out_dir = os.path.join(work_dir, "merged")
+    model = build_and_save_base(spec, base_dir, dtype=dtype, max_shard_size=max_shard_size)
+    base_tensors = read_safetensors_dir(base_dir)
+    peft_model = attach_lora(model, spec, scenario, **attach_kw)
+    adapted = extract_adapted(peft_model)
+    run_merge(peft_model, base_dir, out_dir, save_dtype=dtype)
+    return assert_merge_correct(
+        family=family, base_tensors=base_tensors, out_dir=out_dir,
+        save_dtype=dtype, adapted=adapted, allow_missing_adapted=allow_missing_adapted,
+    )

--- a/tests/_merge_e2e_helpers.py
+++ b/tests/_merge_e2e_helpers.py
@@ -16,19 +16,10 @@
 
 """Shared helpers for the end-to-end LoRA merge-to-16bit correctness suite.
 
-These helpers drive the real public merge path (`merge_and_overwrite_lora`) on
-tiny but architecturally-real models and check every saved tensor against an
-INDEPENDENT reference:
-
-    adapted module : merged == (base.float() + scale * (B @ A)).to(save_dtype)
-    pass-through   : merged is byte-identical to the base tensor
-
-The reference is built directly from the LoRA A/B/scaling read off the live PEFT
-model (not from the merge implementation), so it cannot mask a merge bug. Tiny
-configs use *distinct* hidden / intermediate sizes so fused-expert orientation is
-unambiguous and transpose bugs are visible.
-
-Not a `test_` module, so pytest does not collect it as tests.
+Drives the real merge path on tiny architecturally-real models and checks each
+saved tensor against a reference built independently from the live PEFT LoRA
+(adapted: base + scale*(B@A); pass-through: byte-identical). Distinct hidden /
+intermediate sizes keep fused-expert orientation unambiguous. Not a test_ module.
 """
 
 from __future__ import annotations
@@ -46,8 +37,7 @@ from unsloth_zoo.saving_utils import merge_and_overwrite_lora
 
 SEED = 1234
 
-# dtype-aware tolerances for adapted tensors (atol, rtol). Pass-through tensors
-# are always compared with exact byte-identity, never these tolerances.
+# (atol, rtol) for adapted tensors; pass-through is always byte-exact.
 _TOL = {
     torch.float32:  (1e-5, 1e-5),
     torch.bfloat16: (2e-2, 2e-2),
@@ -56,24 +46,20 @@ _TOL = {
 
 
 def set_offline_cpu_env():
-    """Make the merge run offline and tolerate CPU-only hosts (CI)."""
+    """Make the merge run offline and CPU-tolerant for CI."""
     os.environ.setdefault("HF_HUB_OFFLINE", "1")
     os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
     os.environ.setdefault("UNSLOTH_ALLOW_CPU", "1")
     os.environ.setdefault("UNSLOTH_DISABLE_AUTO_UPDATES", "1")
 
 
-# ---------------------------------------------------------------------------
-# Reference: one adapted target (a single saved tensor that LoRA modifies).
-# ---------------------------------------------------------------------------
-
 @dataclass
 class _Adapted:
-    key: str            # safetensor key, e.g. model.layers.0.self_attn.q_proj.weight
+    key: str
     lora_A: torch.Tensor
     lora_B: torch.Tensor
     alpha: float
-    fused: bool         # True for grouped 3D expert tensors (gate_up_proj/down_proj)
+    fused: bool         # grouped 3D expert tensor (gate_up_proj/down_proj)
 
 
 def _strip_peft_prefix(name: str) -> str:
@@ -84,8 +70,7 @@ def _strip_peft_prefix(name: str) -> str:
 
 
 def _iter_lora_modules(peft_model):
-    """Yield (module_name, module) for every LoRA-bearing module (dense Linear
-    targets and target_parameters / fused expert wrappers)."""
+    """Yield (name, module) for every LoRA-bearing module."""
     for name, mod in peft_model.named_modules():
         la = getattr(mod, "lora_A", None)
         lb = getattr(mod, "lora_B", None)
@@ -97,9 +82,9 @@ def _iter_lora_modules(peft_model):
 
 
 def _module_to_key(name: str, param_name) -> str:
-    """Map a PEFT module name to the on-disk safetensor key it adapts."""
+    """Map a PEFT module name to the safetensor key it adapts."""
     base = _strip_peft_prefix(name)
-    if param_name:  # target_parameters (fused expert param)
+    if param_name:
         if base.endswith(".base_layer"):
             base = base[: -len(".base_layer")]
         return f"{base}.{param_name}"
@@ -107,33 +92,28 @@ def _module_to_key(name: str, param_name) -> str:
 
 
 def seed_lora(peft_model, seed: int = SEED):
-    """Fill lora_A and lora_B with deterministic, asymmetric, nonzero values.
+    """Fill lora_A/lora_B with deterministic asymmetric nonzero values.
 
-    PEFT inits lora_B to zero (no delta) and lora_A via kaiming; we overwrite
-    both with shaped values seeded by the *safetensor key* so the result is a
-    pure function of (key, seed) and independent of module-iteration order.
-    Shaped (not pure-randn) values make transpose / slice bugs visible on tiny
-    tensors.
+    Seeded by safetensor key (hashlib, since hash() is per-process random) so the
+    result is independent of module-iteration order; the shaped ramp makes
+    transpose/slice bugs visible on tiny tensors.
     """
     with torch.no_grad():
         for name, mod in _iter_lora_modules(peft_model):
             key = _module_to_key(name, getattr(mod, "parameter_name", None))
             for tag, bank in (("A", mod.lora_A), ("B", mod.lora_B)):
                 w = bank["default"].weight
-                # process-stable seed (Python's hash() is randomized per process)
                 h = hashlib.sha256(f"{key}|{tag}|{seed}".encode()).digest()
                 g = torch.Generator(device="cpu").manual_seed(
                     int.from_bytes(h[:7], "big")
                 )
                 vals = torch.randn(w.numel(), generator=g)
-                # add a shaped, position-dependent ramp so values are asymmetric
                 ramp = torch.arange(w.numel(), dtype=torch.float32) * 1.0e-3
                 w.copy_((vals * 0.02 + ramp).reshape(w.shape).to(w.dtype))
 
 
 def extract_adapted(peft_model) -> dict[str, _Adapted]:
-    """Build {safetensor_key: _Adapted} from the live PEFT model. Independent of
-    the merge implementation; reuses only the A/B/scaling tensors."""
+    """Build {safetensor_key: _Adapted} from the live PEFT model."""
     out: dict[str, _Adapted] = {}
     for name, mod in _iter_lora_modules(peft_model):
         param_name = getattr(mod, "parameter_name", None)
@@ -146,15 +126,8 @@ def extract_adapted(peft_model) -> dict[str, _Adapted]:
     return out
 
 
-# ---------------------------------------------------------------------------
-# Reference math.
-# ---------------------------------------------------------------------------
-
 def _ref_dense(base: torch.Tensor, a: _Adapted) -> torch.Tensor:
-    """2D Linear merge (also per-expert MoE, which is a plain Linear).
-
-    Handles the vocab-grow case where lora_B has more rows than base (zero-pad).
-    """
+    """2D Linear / per-expert merge, with vocab-grow zero-pad when B has more rows."""
     A = a.lora_A.to(torch.float64)
     B = a.lora_B.to(torch.float64)
     W = base.to(torch.float64)
@@ -166,8 +139,8 @@ def _ref_dense(base: torch.Tensor, a: _Adapted) -> torch.Tensor:
 
 
 def _ref_fused(base3d: torch.Tensor, a: _Adapted) -> torch.Tensor:
-    """Grouped 3D expert merge. Per expert e: delta = B_e @ A_e, applied in the
-    orientation that fits base[e] (auto-detected from distinct dims)."""
+    """Grouped 3D expert merge; per expert delta=B_e@A_e in the orientation that
+    fits base[e] (auto-detected from distinct dims)."""
     E = base3d.shape[0]
     r = a.lora_A.shape[0] // E
     d1, d2 = base3d.shape[1], base3d.shape[2]
@@ -188,10 +161,6 @@ def _ref_fused(base3d: torch.Tensor, a: _Adapted) -> torch.Tensor:
             )
     return out
 
-
-# ---------------------------------------------------------------------------
-# Build + save a tiny base, attach LoRA, run the real merge.
-# ---------------------------------------------------------------------------
 
 def read_safetensors_dir(d: str) -> dict[str, torch.Tensor]:
     out: dict[str, torch.Tensor] = {}
@@ -227,28 +196,22 @@ def run_merge(peft_model, base_dir, out_dir, *, save_dtype, tokenizer=None,
     return res
 
 
-# ---------------------------------------------------------------------------
-# The assertion engine.
-# ---------------------------------------------------------------------------
-
 _LORA_REMNANT_MARKERS = (".lora_A", ".lora_B", ".lora_embedding",
                          ".base_layer", "modules_to_save", "original_module")
 
 
 class KeyResolutionError(AssertionError):
-    """The harness could not map an adapted module to a base safetensor key.
+    """Adapted module could not be mapped to a base safetensor key.
 
     Raised (not for value mismatches) when a tiny config's on-disk key layout
-    differs from the LoRA module path in a way this reference builder does not
-    model (e.g. composite text+vision prefixes, or fused-vs-per-expert expert
-    serialization that varies across transformers versions). Tests treat this as
-    a skip (the merge itself is validated elsewhere), never as a value failure.
+    differs from the LoRA module path (composite VLM prefixes, or fused-vs-per-
+    expert serialization that varies by transformers version). Tests skip on it.
     """
 
 
 def _resolve_key(adapted_key: str, base_keys: set[str]) -> str | None:
-    """Map an adapted key to an actual base safetensor key, tolerating an extra
-    prefix (VLM composite models, mirrors _infer_prefix_and_remap)."""
+    """Resolve an adapted key to a base key, tolerating an extra prefix (VLM
+    composite models; mirrors _infer_prefix_and_remap)."""
     if adapted_key in base_keys:
         return adapted_key
     cands = [k for k in base_keys if k.endswith("." + adapted_key) or k.endswith(adapted_key)]
@@ -260,7 +223,7 @@ def _resolve_key(adapted_key: str, base_keys: set[str]) -> str | None:
 
 def assert_merge_correct(*, family, base_tensors, out_dir, save_dtype,
                          adapted: dict[str, _Adapted], allow_missing_adapted=False):
-    """Verify every merged tensor against the independent reference.
+    """Check every merged tensor against the independent reference.
 
     base_tensors : {key: tensor} snapshot of the base BEFORE merge.
     adapted      : {safetensor_key: _Adapted} from extract_adapted().
@@ -271,19 +234,18 @@ def assert_merge_correct(*, family, base_tensors, out_dir, save_dtype,
     assert merged, f"[{family}] no safetensors written to {out_dir}"
     base_keys = set(base_tensors.keys())
 
-    # 1) no adapter remnants leaked into the merged checkpoint
+    # no adapter remnants leaked
     leaked = [k for k in merged if any(m in k for m in _LORA_REMNANT_MARKERS)]
     assert not leaked, f"[{family}] adapter remnants in merged output: {leaked[:5]}"
 
-    # 2) resolve adapted keys against the real base keys (VLM prefix tolerance)
+    # resolve adapted keys against real base keys (VLM prefix tolerance)
     resolved: dict[str, _Adapted] = {}
     for ak, a in adapted.items():
         rk = _resolve_key(ak, base_keys)
         if rk is None:
             if allow_missing_adapted:
-                # adapter targets a module absent from base safetensors (e.g. a
-                # vision-tower adapter). The merge must skip it without error;
-                # there is simply no merged tensor to check (mirrors PR #773).
+                # target absent from base (e.g. vision-tower adapter): merge skips
+                # it, nothing to check (mirrors PR #773).
                 continue
             raise KeyResolutionError(
                 f"[{family}] adapted key {ak!r} not found among base keys "
@@ -291,7 +253,6 @@ def assert_merge_correct(*, family, base_tensors, out_dir, save_dtype,
             )
         resolved[rk] = a
 
-    # 3) per-tensor check
     atol, rtol = _TOL[save_dtype]
     n_adapted = n_passthru = 0
     for key, mt in merged.items():
@@ -308,18 +269,18 @@ def assert_merge_correct(*, family, base_tensors, out_dir, save_dtype,
             _assert_equal(family, key, mt, base_tensors[key])
             n_passthru += 1
 
-    # 4) every adapted target actually appeared and was checked
+    # every adapted target appeared and was checked
     if not allow_missing_adapted:
         missing = [k for k in resolved if k not in merged]
         assert not missing, f"[{family}] adapted targets missing from merged output: {missing}"
     assert n_adapted >= 1, f"[{family}] no adapted tensors were checked (LoRA not attached?)"
 
-    # 5) MoE merge must not have fallen back
+    # MoE merge must not have fallen back
     assert _MOE_MERGE_STATE.get("fallback", 0) == 0, (
         f"[{family}] MoE merge fell back: {_MOE_MERGE_STATE}"
     )
 
-    # 6) index consistency
+    # index consistency
     idx = read_index(out_dir)
     if idx is not None:
         wm = idx.get("weight_map", {})
@@ -357,26 +318,22 @@ def _assert_equal(family, key, got, base):
                              _diag(family, key, got, base, adapted=False))
 
 
-# ---------------------------------------------------------------------------
-# Tiny-config factory + LoRA attach.
-# ---------------------------------------------------------------------------
-
 @dataclass
 class FamilySpec:
     family: str
-    kind: str                       # "dense" | "per_expert" | "fused"
+    kind: str                       # dense | per_expert | fused
     config: object
-    auto: str = "causal"            # "causal" | "image_text"
+    auto: str = "causal"            # causal | image_text
     attn_modules: tuple = ("q_proj", "k_proj", "v_proj", "o_proj")
-    mlp_modules: tuple = ("gate_proj", "up_proj", "down_proj")   # dense FFN
+    mlp_modules: tuple = ("gate_proj", "up_proj", "down_proj")
     expert_modules: tuple = ()      # per-expert MoE target_modules
-    fused_params: tuple = ()        # target_parameters for fused experts
+    fused_params: tuple = ()        # fused-expert target_parameters
 
 
 # distinct dims so fused-expert orientation is unambiguous (transpose bugs show)
-_H = 32          # hidden
-_I = 64          # dense intermediate
-_MOE_I = 48      # MoE intermediate (distinct from hidden and 2*MoE_I)
+_H = 32
+_I = 64
+_MOE_I = 48      # distinct from _H and 2*_MOE_I
 _HEADS = 4
 _KV = 2
 _VOCAB = 64
@@ -445,7 +402,6 @@ def make_spec(family: str) -> FamilySpec:
     # transformers 5.x only families
     if family == "qwen3_5_moe":
         cfg = T.AutoConfig.for_model("qwen3_5_moe")
-        # shrink whatever fields exist
         return _shrink_generic(family, "fused", cfg,
                                fused_params=("mlp.experts.gate_up_proj", "mlp.experts.down_proj"))
     if family == "gemma4":
@@ -475,8 +431,8 @@ def _shrink_generic(family, kind, cfg, **kw):
                           ("num_experts_per_tok", 2), ("decoder_sparse_step", 1)):
             if hasattr(obj, attr):
                 setattr(obj, attr, val)
-        # hybrid / strict-validated archs (lfm2_moe, qwen3_5_moe) require an explicit
-        # per-layer schedule matching num_hidden_layers, else instantiation raises.
+        # strict/hybrid archs (lfm2_moe, qwen3_5_moe) need an explicit per-layer
+        # schedule matching num_hidden_layers or instantiation raises.
         if hasattr(obj, "layer_types") and getattr(obj, "num_hidden_layers", None):
             try:
                 obj.layer_types = ["full_attention"] * obj.num_hidden_layers
@@ -500,11 +456,8 @@ def build_and_save_base(spec: FamilySpec, base_dir: str, *, dtype=torch.float32,
 
 def attach_lora(model, spec: FamilySpec, scenario: str, *, r=8, lora_alpha=16,
                 alpha_pattern=None, rank_pattern=None):
-    """Attach a PEFT LoRA adapter for the given scenario and seed it nonzero.
-
-    scenario in {full, attn_only, mlp_only, expert_only}.
-    Returns the PeftModel.
-    """
+    """Attach a PEFT LoRA adapter (scenario in {full, attn_only, mlp_only,
+    expert_only}) and seed it nonzero. Returns the PeftModel."""
     from peft import LoraConfig, get_peft_model
     tm: list[str] = []
     tp: list[str] = []
@@ -533,10 +486,8 @@ def attach_lora(model, spec: FamilySpec, scenario: str, *, r=8, lora_alpha=16,
 
 def run_case(family, scenario, work_dir, *, dtype=torch.float32, max_shard_size="5GB",
              allow_missing_adapted=False, **attach_kw):
-    """End-to-end: build tiny base -> attach LoRA -> real merge -> assert correct.
-
-    Returns (n_adapted_checked, n_passthrough_checked). Raises on any mismatch.
-    """
+    """Build base -> attach LoRA -> real merge -> assert. Returns
+    (n_adapted_checked, n_passthrough_checked); raises on any mismatch."""
     set_offline_cpu_env()
     spec = make_spec(family)
     base_dir = os.path.join(work_dir, "base")

--- a/tests/test_merge_e2e_dense.py
+++ b/tests/test_merge_e2e_dense.py
@@ -16,11 +16,9 @@
 
 """End-to-end LoRA merge-to-16bit correctness for dense decoder models.
 
-Drives the real `merge_and_overwrite_lora` path on tiny but architecturally-real
-configs (Llama / Qwen3 / Mistral / Gemma2) and checks every saved tensor against
-an independent reference: adapted modules == base + scale*(B@A); every untargeted
-tensor stays byte-identical to the base. Covers full / attention-only / MLP-only
-targeting, per-module alpha+rank patterns, bf16 output, and forced sharding.
+Llama / Qwen3 / Mistral / Gemma2 via the real merge: adapted == base + scale*(B@A),
+untargeted tensors byte-identical. Covers full / attn-only / mlp-only, per-module
+alpha+rank, bf16, and forced multi-shard.
 """
 
 from __future__ import annotations
@@ -55,8 +53,8 @@ def test_dense_merge_bf16(family, tmp_path):
 
 
 def test_dense_per_module_alpha_rank_pattern(tmp_path):
-    """Different alpha/rank per module: the merge must read scale per module, not
-    assume a single global lora_alpha/r."""
+    """Per-module alpha/rank: the merge must read scale per module, not a single
+    global lora_alpha/r."""
     _skip_if_missing("llama")
     H.run_case(
         "llama", "full", str(tmp_path),
@@ -67,6 +65,6 @@ def test_dense_per_module_alpha_rank_pattern(tmp_path):
 
 def test_dense_forced_multishard(tmp_path):
     """Tiny max_shard_size forces multiple shards + index, catching stale-shard /
-    index-mismatch bugs (one shard merged, another left as base)."""
+    index-mismatch bugs."""
     _skip_if_missing("llama")
     H.run_case("llama", "full", str(tmp_path), max_shard_size="40KB")

--- a/tests/test_merge_e2e_dense.py
+++ b/tests/test_merge_e2e_dense.py
@@ -1,0 +1,72 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""End-to-end LoRA merge-to-16bit correctness for dense decoder models.
+
+Drives the real `merge_and_overwrite_lora` path on tiny but architecturally-real
+configs (Llama / Qwen3 / Mistral / Gemma2) and checks every saved tensor against
+an independent reference: adapted modules == base + scale*(B@A); every untargeted
+tensor stays byte-identical to the base. Covers full / attention-only / MLP-only
+targeting, per-module alpha+rank patterns, bf16 output, and forced sharding.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import _merge_e2e_helpers as H
+
+
+DENSE = ["llama", "qwen3", "mistral", "gemma2"]
+
+
+def _skip_if_missing(family):
+    if not H.family_available(family):
+        pytest.skip(f"{family} unavailable in this transformers")
+
+
+@pytest.mark.parametrize("family", DENSE)
+@pytest.mark.parametrize("scenario", ["full", "attn_only", "mlp_only"])
+def test_dense_merge(family, scenario, tmp_path):
+    _skip_if_missing(family)
+    n_adapted, n_pass = H.run_case(family, scenario, str(tmp_path))
+    assert n_adapted >= 1 and n_pass >= 1
+
+
+@pytest.mark.parametrize("family", DENSE)
+def test_dense_merge_bf16(family, tmp_path):
+    """bf16 output: pass-through stays byte-identical, adapted within bf16 tol."""
+    _skip_if_missing(family)
+    H.run_case(family, "full", str(tmp_path), dtype=torch.bfloat16)
+
+
+def test_dense_per_module_alpha_rank_pattern(tmp_path):
+    """Different alpha/rank per module: the merge must read scale per module, not
+    assume a single global lora_alpha/r."""
+    _skip_if_missing("llama")
+    H.run_case(
+        "llama", "full", str(tmp_path),
+        alpha_pattern={"q_proj": 4, "down_proj": 64},
+        rank_pattern={"q_proj": 4, "down_proj": 16},
+    )
+
+
+def test_dense_forced_multishard(tmp_path):
+    """Tiny max_shard_size forces multiple shards + index, catching stale-shard /
+    index-mismatch bugs (one shard merged, another left as base)."""
+    _skip_if_missing("llama")
+    H.run_case("llama", "full", str(tmp_path), max_shard_size="40KB")

--- a/tests/test_merge_e2e_moe_fused.py
+++ b/tests/test_merge_e2e_moe_fused.py
@@ -16,21 +16,15 @@
 
 """End-to-end LoRA merge correctness for fused-3D MoE models.
 
-These models pack all experts into single 3D parameters (`experts.gate_up_proj`,
-`experts.down_proj`) and attach grouped LoRA via PEFT `target_parameters`. The
-merge must slice the grouped adapter per expert and apply the delta in the
-orientation that fits each expert weight (auto-detected from distinct dims, so a
-single shared transpose flag - the narrow-expert bug fixed in #779 - cannot pass
-by luck).
+These pack all experts into single 3D params (experts.gate_up_proj/down_proj) with
+grouped LoRA via PEFT target_parameters. The merge slices the adapter per expert and
+applies the delta in the orientation that fits each expert (auto-detected from
+distinct dims, so the #779 narrow-expert transpose bug cannot pass by luck).
 
-gpt_oss is the guaranteed fused representative: it runs on both transformers
-4.57.6 and 5.x, full and attention-only. The remaining worry-model fused arches
-(qwen3_5_moe = Qwen3.5-35B-A3B, gemma4 = gemma-4-26B-A4B, lfm2_moe = LFM2.5-8B-A1B)
-are transformers-5.x-only and have arch-specific tiny-instantiation quirks (strict
-per-layer validators, composite text+vision count semantics, MoE that only
-materialises at larger sizes). They are attempted here and SKIP cleanly when a
-tiny config cannot exercise the fused path; their full-scale fused merge is
-validated by the real-model sweep and the #779 real-geometry checks.
+gpt_oss runs on transformers 4.57.6 and 5.x. The 5.x-only worry arches (qwen3_5_moe
+= Qwen3.5-35B-A3B, gemma4 = gemma-4-26B-A4B, lfm2_moe = LFM2.5-8B-A1B) skip cleanly
+when a tiny config cannot exercise the fused path; their full-scale merge is covered
+by the real-model sweep + #779.
 """
 
 from __future__ import annotations
@@ -59,11 +53,11 @@ FUSED = [
     pytest.param("lfm2_moe", marks=_gated_mark("lfm2_moe")),
 ]
 
-# arch-specific tiny-config / orchestration issues we tolerate (skip) only for the
-# gated 5.x families; gpt_oss must never hit these.
+# tiny-config / orchestration errors tolerated (skip) only for gated 5.x families;
+# gpt_oss must never hit these.
 _TOLERATED = ("validate_layer_type", "does not match # of saved modules",
               "could not be instantiated", "is not supported",
-              "not found among base keys")  # composite/per-expert serialization at tiny scale
+              "not found among base keys")
 
 
 def _skip_or_raise(family, exc):

--- a/tests/test_merge_e2e_moe_fused.py
+++ b/tests/test_merge_e2e_moe_fused.py
@@ -1,0 +1,119 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""End-to-end LoRA merge correctness for fused-3D MoE models.
+
+These models pack all experts into single 3D parameters (`experts.gate_up_proj`,
+`experts.down_proj`) and attach grouped LoRA via PEFT `target_parameters`. The
+merge must slice the grouped adapter per expert and apply the delta in the
+orientation that fits each expert weight (auto-detected from distinct dims, so a
+single shared transpose flag - the narrow-expert bug fixed in #779 - cannot pass
+by luck).
+
+gpt_oss is the guaranteed fused representative: it runs on both transformers
+4.57.6 and 5.x, full and attention-only. The remaining worry-model fused arches
+(qwen3_5_moe = Qwen3.5-35B-A3B, gemma4 = gemma-4-26B-A4B, lfm2_moe = LFM2.5-8B-A1B)
+are transformers-5.x-only and have arch-specific tiny-instantiation quirks (strict
+per-layer validators, composite text+vision count semantics, MoE that only
+materialises at larger sizes). They are attempted here and SKIP cleanly when a
+tiny config cannot exercise the fused path; their full-scale fused merge is
+validated by the real-model sweep and the #779 real-geometry checks.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+import torch
+
+import _merge_e2e_helpers as H
+
+GATED = {"qwen3_5_moe", "gemma4", "lfm2_moe"}  # transformers 5.x only
+
+
+def _gated_mark(family):
+    return pytest.mark.skipif(
+        not H.family_available(family),
+        reason=f"{family} needs a transformers version that exposes it (5.x)")
+
+
+FUSED = [
+    "gpt_oss",
+    pytest.param("qwen3_5_moe", marks=_gated_mark("qwen3_5_moe")),
+    pytest.param("gemma4", marks=_gated_mark("gemma4")),
+    pytest.param("lfm2_moe", marks=_gated_mark("lfm2_moe")),
+]
+
+# arch-specific tiny-config / orchestration issues we tolerate (skip) only for the
+# gated 5.x families; gpt_oss must never hit these.
+_TOLERATED = ("validate_layer_type", "does not match # of saved modules",
+              "could not be instantiated", "is not supported",
+              "not found among base keys")  # composite/per-expert serialization at tiny scale
+
+
+def _skip_or_raise(family, exc):
+    msg = f"{type(exc).__name__}: {exc}"
+    if family in GATED and any(s in msg for s in _TOLERATED):
+        pytest.skip(f"{family}: tiny config cannot exercise the fused path "
+                    f"({msg[:120]}); covered by the real-model sweep")
+    raise exc
+
+
+@pytest.mark.parametrize("family", FUSED)
+def test_fused_moe_full(family, tmp_path):
+    """Grouped expert LoRA + attention: every fused expert tensor matches the
+    per-expert reference; merge does not fall back."""
+    if not H.family_available(family):
+        pytest.skip(f"{family} unavailable")
+    H.set_offline_cpu_env()
+    try:
+        spec = H.make_spec(family)
+        base_dir = os.path.join(str(tmp_path), "base")
+        model = H.build_and_save_base(spec, base_dir)
+        base_tensors = H.read_safetensors_dir(base_dir)
+        pm = H.attach_lora(model, spec, "full")
+    except Exception as e:
+        _skip_or_raise(family, e)
+    adapted = H.extract_adapted(pm)
+    if not any(a.fused for a in adapted.values()):
+        if family in GATED:
+            pytest.skip(f"{family}: tiny config did not materialize fused experts "
+                        f"(covered by the real-model sweep)")
+        pytest.fail(f"{family}: expected fused expert adapters, found none")
+    out_dir = os.path.join(str(tmp_path), "merged")
+    try:
+        H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
+        H.assert_merge_correct(family=family, base_tensors=base_tensors,
+                               out_dir=out_dir, save_dtype=torch.float32, adapted=adapted)
+    except Exception as e:
+        _skip_or_raise(family, e)
+    assert sum(1 for a in adapted.values() if a.fused) >= 2
+
+
+@pytest.mark.parametrize("family", FUSED)
+def test_fused_moe_attention_only_keeps_experts_byte_identical(family, tmp_path):
+    """No LoRA on the fused experts -> the fused expert tensors stay byte-identical
+    to base (the merge must not rewrite/cast/transpose them)."""
+    if not H.family_available(family):
+        pytest.skip(f"{family} unavailable")
+    H.set_offline_cpu_env()
+    try:
+        n_adapted, n_pass = H.run_case(family, "attn_only", str(tmp_path))
+    except Exception as e:
+        _skip_or_raise(family, e)
+    assert n_adapted >= 1 and n_pass >= 1

--- a/tests/test_merge_e2e_moe_per_expert.py
+++ b/tests/test_merge_e2e_moe_per_expert.py
@@ -1,0 +1,74 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""End-to-end LoRA merge correctness for per-expert MoE models.
+
+Qwen3-MoE / GLM4-MoE / GraniteMoE store experts as separate 2D Linear modules, so
+each expert projection merges like a dense layer. The two cases that matter:
+
+  * full     -- expert + attention LoRA merges correctly per expert.
+  * attn_only -- the user's core worry: when NO LoRA targets the experts, every
+                 expert tensor (and shared experts / router) must stay
+                 byte-identical to the base.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import _merge_e2e_helpers as H
+
+
+# qwen3_moe == Qwen3-30B-A3B family; glm4_moe == GLM-4.x MoE / GLM-4.7-Flash family.
+# Both store experts as separate 2D Linear modules. (GraniteMoe uses fused parallel
+# expert modules, not 2D Linears, so it belongs with the fused-MoE suite.)
+PER_EXPERT = ["qwen3_moe", "glm4_moe"]
+
+
+def _skip_if_missing(family):
+    if not H.family_available(family):
+        pytest.skip(f"{family} unavailable in this transformers")
+
+
+@pytest.mark.parametrize("family", PER_EXPERT)
+def test_moe_per_expert_full(family, tmp_path):
+    """Experts + attention adapted: every adapted expert projection matches the
+    reference; nothing else changes."""
+    _skip_if_missing(family)
+    try:
+        n_adapted, _ = H.run_case(family, "full", str(tmp_path))
+    except H.KeyResolutionError as e:
+        # Some arches serialize experts fused-3D on newer transformers while PEFT
+        # adapts them per-expert (or vice versa); the tiny-config key layout then
+        # differs from this reference. The fused-3D merge path is covered by the
+        # fused suite + the real-model sweep.
+        pytest.skip(f"{family}: expert key layout differs on this transformers "
+                    f"version ({e}); covered by the fused suite / real-model sweep")
+    # full targets attention (4 per layer) + 3 expert projections * num_experts
+    assert n_adapted >= 4
+
+
+@pytest.mark.parametrize("family", PER_EXPERT)
+def test_moe_per_expert_attention_only_keeps_experts_byte_identical(family, tmp_path):
+    """No expert LoRA -> all expert/router/shared-expert tensors byte-identical.
+
+    assert_merge_correct already enforces byte-identity for every non-adapted
+    tensor, so a clean run here proves the MoE merge does not touch experts when
+    no adapter targets them.
+    """
+    _skip_if_missing(family)
+    n_adapted, n_pass = H.run_case(family, "attn_only", str(tmp_path))
+    assert n_adapted >= 1 and n_pass >= 1

--- a/tests/test_merge_e2e_moe_per_expert.py
+++ b/tests/test_merge_e2e_moe_per_expert.py
@@ -16,13 +16,9 @@
 
 """End-to-end LoRA merge correctness for per-expert MoE models.
 
-Qwen3-MoE / GLM4-MoE / GraniteMoE store experts as separate 2D Linear modules, so
-each expert projection merges like a dense layer. The two cases that matter:
-
-  * full     -- expert + attention LoRA merges correctly per expert.
-  * attn_only -- the user's core worry: when NO LoRA targets the experts, every
-                 expert tensor (and shared experts / router) must stay
-                 byte-identical to the base.
+Qwen3-MoE / GLM4-MoE / GraniteMoE store experts as separate 2D Linears, so each
+expert projection merges like a dense layer. Cases: full (expert + attention) and
+attn_only (no expert LoRA -> every expert/shared/router tensor stays byte-identical).
 """
 
 from __future__ import annotations
@@ -32,9 +28,7 @@ import pytest
 import _merge_e2e_helpers as H
 
 
-# qwen3_moe == Qwen3-30B-A3B family; glm4_moe == GLM-4.x MoE / GLM-4.7-Flash family.
-# Both store experts as separate 2D Linear modules. (GraniteMoe uses fused parallel
-# expert modules, not 2D Linears, so it belongs with the fused-MoE suite.)
+# qwen3_moe ~ Qwen3-30B-A3B; glm4_moe ~ GLM-4.7-Flash. (GraniteMoe is fused -> fused suite.)
 PER_EXPERT = ["qwen3_moe", "glm4_moe"]
 
 
@@ -51,24 +45,18 @@ def test_moe_per_expert_full(family, tmp_path):
     try:
         n_adapted, _ = H.run_case(family, "full", str(tmp_path))
     except H.KeyResolutionError as e:
-        # Some arches serialize experts fused-3D on newer transformers while PEFT
-        # adapts them per-expert (or vice versa); the tiny-config key layout then
-        # differs from this reference. The fused-3D merge path is covered by the
-        # fused suite + the real-model sweep.
+        # expert key layout differs across transformers versions (fused-3D vs
+        # per-expert); that path is covered by the fused suite + real-model sweep.
         pytest.skip(f"{family}: expert key layout differs on this transformers "
                     f"version ({e}); covered by the fused suite / real-model sweep")
-    # full targets attention (4 per layer) + 3 expert projections * num_experts
+    # attention + expert projections
     assert n_adapted >= 4
 
 
 @pytest.mark.parametrize("family", PER_EXPERT)
 def test_moe_per_expert_attention_only_keeps_experts_byte_identical(family, tmp_path):
-    """No expert LoRA -> all expert/router/shared-expert tensors byte-identical.
-
-    assert_merge_correct already enforces byte-identity for every non-adapted
-    tensor, so a clean run here proves the MoE merge does not touch experts when
-    no adapter targets them.
-    """
+    """No expert LoRA -> all expert/router/shared-expert tensors byte-identical
+    (assert_merge_correct enforces byte-identity for every non-adapted tensor)."""
     _skip_if_missing(family)
     n_adapted, n_pass = H.run_case(family, "attn_only", str(tmp_path))
     assert n_adapted >= 1 and n_pass >= 1

--- a/tests/test_merge_e2e_resized.py
+++ b/tests/test_merge_e2e_resized.py
@@ -1,0 +1,103 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""End-to-end LoRA merge correctness for the vocab-grow / resized rewrite path.
+
+Growing the tokenizer makes embed_tokens / lm_head larger than the base shard, so
+`_write_tensor_direct_torch` cannot overwrite in place and the merge falls back to
+the resized-shard rewrite (streaming on PR #777, or the disk-aware in-place
+variant). This test checks the rewritten embed/lm_head equal the model's resized
+weights, old rows are preserved, attention LoRA still merges, and everything else
+stays byte-identical.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+import _merge_e2e_helpers as H
+
+NEW_VOCAB = 80  # base vocab is 64 (H._VOCAB)
+
+
+def _build_resized_case(tmp_path, *, dtype=torch.float32, low_disk=False):
+    from transformers import AutoModelForCausalLM
+    from peft import LoraConfig, get_peft_model
+
+    H.set_offline_cpu_env()
+    if not H.family_available("llama"):
+        pytest.skip("llama unavailable")
+    spec = H.make_spec("llama")
+    base_dir = os.path.join(str(tmp_path), "base")
+    out_dir = os.path.join(str(tmp_path), "merged")
+
+    torch.manual_seed(H.SEED)
+    model = AutoModelForCausalLM.from_config(spec.config).to(dtype)
+    model.save_pretrained(base_dir, safe_serialization=True)
+    model.config._name_or_path = base_dir
+    base = H.read_safetensors_dir(base_dir)
+
+    model.resize_token_embeddings(NEW_VOCAB)
+    torch.manual_seed(H.SEED)
+    pm = get_peft_model(model, LoraConfig(
+        r=8, lora_alpha=16, lora_dropout=0.0, bias="none",
+        target_modules=["q_proj", "v_proj"],
+        modules_to_save=["embed_tokens", "lm_head"]))
+    H.seed_lora(pm)
+
+    ref_embed = pm.get_input_embeddings().weight.detach().cpu().clone().to(dtype)
+    ref_head = pm.get_output_embeddings().weight.detach().cpu().clone().to(dtype)
+    adapted = H.extract_adapted(pm)  # q_proj / v_proj only
+
+    H.run_merge(pm, base_dir, out_dir, save_dtype=dtype, low_disk_space_usage=low_disk)
+    merged = H.read_safetensors_dir(out_dir)
+    return base, merged, ref_embed, ref_head, adapted, dtype
+
+
+def _check(base, merged, ref_embed, ref_head, adapted, dtype):
+    embed_key = "model.embed_tokens.weight"
+    head_key = "lm_head.weight"
+
+    assert merged[embed_key].shape[0] == NEW_VOCAB
+    assert merged[head_key].shape[0] == NEW_VOCAB
+    # resized weights written through exactly
+    assert torch.equal(merged[embed_key], ref_embed), "resized embed mismatch"
+    assert torch.equal(merged[head_key], ref_head), "resized lm_head mismatch"
+    # old vocab rows preserved from the base
+    assert torch.equal(merged[embed_key][: base[embed_key].shape[0]], base[embed_key]), \
+        "old embed rows not preserved"
+
+    atol, rtol = H._TOL[dtype]
+    for key, mt in merged.items():
+        if key in (embed_key, head_key):
+            continue
+        if key in adapted:
+            ref = H._ref_dense(base[key], adapted[key]).to(dtype)
+            H._assert_close("resized", key, mt, ref, atol, rtol, adapted=True)
+        else:
+            H._assert_equal("resized", key, mt, base[key])
+
+
+def test_resized_vocab_grow_modules_to_save(tmp_path):
+    _check(*_build_resized_case(tmp_path))
+
+
+def test_resized_vocab_grow_low_disk_fallback(tmp_path):
+    """Same correctness when the disk-aware in-place fallback is requested."""
+    _check(*_build_resized_case(tmp_path, low_disk=True))

--- a/tests/test_merge_e2e_resized.py
+++ b/tests/test_merge_e2e_resized.py
@@ -17,11 +17,9 @@
 """End-to-end LoRA merge correctness for the vocab-grow / resized rewrite path.
 
 Growing the tokenizer makes embed_tokens / lm_head larger than the base shard, so
-`_write_tensor_direct_torch` cannot overwrite in place and the merge falls back to
-the resized-shard rewrite (streaming on PR #777, or the disk-aware in-place
-variant). This test checks the rewritten embed/lm_head equal the model's resized
-weights, old rows are preserved, attention LoRA still merges, and everything else
-stays byte-identical.
+the merge falls back to the resized-shard rewrite (streaming, or the disk-aware
+in-place variant). Checks the rewritten embed/lm_head match the resized weights, old
+rows are preserved, attention LoRA still merges, everything else is byte-identical.
 """
 
 from __future__ import annotations
@@ -67,10 +65,8 @@ def _build_resized_case(tmp_path, *, dtype=torch.float32, force_inplace=False,
     adapted = H.extract_adapted(pm)  # q_proj / v_proj only
 
     if force_inplace:
-        # The streaming-vs-in-place choice is made purely from free disk vs the
-        # estimated shard size (low_disk_space_usage does NOT select it for a
-        # local-dir merge). Force the in-place branch by making the estimate
-        # enormous, and spy on both rewrite paths to prove which one ran.
+        # streaming-vs-in-place is chosen purely from free disk vs estimated shard
+        # size; force in-place via an enormous estimate and spy on both paths.
         import unsloth_zoo.saving_utils as SU
         real_inplace = SU._inplace_rewrite_resized_shard
         real_stream = SU._stream_rewrite_resized_shard_and_replace
@@ -88,8 +84,7 @@ def _build_resized_case(tmp_path, *, dtype=torch.float32, force_inplace=False,
         monkeypatch.setattr(SU, "_estimate_resized_shard_bytes", lambda *a, **k: 1 << 60)
         monkeypatch.setattr(SU, "_inplace_rewrite_resized_shard", _spy_inplace)
         monkeypatch.setattr(SU, "_stream_rewrite_resized_shard_and_replace", _spy_stream)
-        # The in-place rewrite is non-atomic, so it is refused by default; opt in
-        # explicitly to exercise it (the fail-closed default is covered separately).
+        # in-place is non-atomic -> refused by default; opt in to exercise it.
         if optin:
             monkeypatch.setenv("UNSLOTH_ALLOW_NON_ATOMIC_RESIZED_REWRITE", "1")
         else:
@@ -129,10 +124,8 @@ def test_resized_vocab_grow_modules_to_save(tmp_path):
 
 
 def test_resized_vocab_grow_low_disk_inplace(tmp_path, monkeypatch):
-    """With the non-atomic rewrite explicitly opted in, the in-place branch (not the
-    streaming default) runs and produces the same correct output. The branch is
-    selected only when free disk < estimated shard bytes, so the estimate is patched
-    enormous to trigger it; spies on both rewrite paths confirm which one ran."""
+    """In-place branch (opt-in) produces the same correct output as streaming.
+    Forced via an enormous shard-size estimate; spies confirm which path ran."""
     calls = {"inplace": 0, "stream": 0}
     res = _build_resized_case(tmp_path, force_inplace=True, optin=True,
                               monkeypatch=monkeypatch, calls=calls)
@@ -142,8 +135,8 @@ def test_resized_vocab_grow_low_disk_inplace(tmp_path, monkeypatch):
 
 
 def test_resized_vocab_grow_low_disk_fail_closed(tmp_path, monkeypatch):
-    """Without the opt-in, a low-disk resized rewrite must fail closed (raise, leaving
-    the shard untouched) rather than fall back to the non-atomic in-place rewrite."""
+    """Without the opt-in, a low-disk resized rewrite fails closed (raises, shard
+    untouched) instead of the non-atomic in-place rewrite."""
     calls = {"inplace": 0, "stream": 0}
     with pytest.raises(RuntimeError, match="not enough free disk"):
         _build_resized_case(tmp_path, force_inplace=True, optin=False,

--- a/tests/test_merge_e2e_resized.py
+++ b/tests/test_merge_e2e_resized.py
@@ -37,7 +37,7 @@ NEW_VOCAB = 80  # base vocab is 64 (H._VOCAB)
 
 
 def _build_resized_case(tmp_path, *, dtype=torch.float32, force_inplace=False,
-                        monkeypatch=None, calls=None):
+                        optin=True, monkeypatch=None, calls=None):
     from transformers import AutoModelForCausalLM
     from peft import LoraConfig, get_peft_model
 
@@ -88,6 +88,12 @@ def _build_resized_case(tmp_path, *, dtype=torch.float32, force_inplace=False,
         monkeypatch.setattr(SU, "_estimate_resized_shard_bytes", lambda *a, **k: 1 << 60)
         monkeypatch.setattr(SU, "_inplace_rewrite_resized_shard", _spy_inplace)
         monkeypatch.setattr(SU, "_stream_rewrite_resized_shard_and_replace", _spy_stream)
+        # The in-place rewrite is non-atomic, so it is refused by default; opt in
+        # explicitly to exercise it (the fail-closed default is covered separately).
+        if optin:
+            monkeypatch.setenv("UNSLOTH_ALLOW_NON_ATOMIC_RESIZED_REWRITE", "1")
+        else:
+            monkeypatch.delenv("UNSLOTH_ALLOW_NON_ATOMIC_RESIZED_REWRITE", raising=False)
 
     H.run_merge(pm, base_dir, out_dir, save_dtype=dtype)
     merged = H.read_safetensors_dir(out_dir)
@@ -123,13 +129,24 @@ def test_resized_vocab_grow_modules_to_save(tmp_path):
 
 
 def test_resized_vocab_grow_low_disk_inplace(tmp_path, monkeypatch):
-    """Force the disk-aware in-place rewrite branch (not the streaming default) and
-    prove it produces the same correct output. The branch is selected only when free
-    disk < estimated shard bytes, so the estimate is patched enormous to trigger it;
-    spies on both rewrite paths confirm the in-place branch actually ran."""
+    """With the non-atomic rewrite explicitly opted in, the in-place branch (not the
+    streaming default) runs and produces the same correct output. The branch is
+    selected only when free disk < estimated shard bytes, so the estimate is patched
+    enormous to trigger it; spies on both rewrite paths confirm which one ran."""
     calls = {"inplace": 0, "stream": 0}
-    res = _build_resized_case(tmp_path, force_inplace=True, monkeypatch=monkeypatch,
-                              calls=calls)
+    res = _build_resized_case(tmp_path, force_inplace=True, optin=True,
+                              monkeypatch=monkeypatch, calls=calls)
     assert calls["inplace"] >= 1, "in-place resized rewrite branch was not exercised"
     assert calls["stream"] == 0, "streaming branch ran despite forced low disk"
     _check(*res)
+
+
+def test_resized_vocab_grow_low_disk_fail_closed(tmp_path, monkeypatch):
+    """Without the opt-in, a low-disk resized rewrite must fail closed (raise, leaving
+    the shard untouched) rather than fall back to the non-atomic in-place rewrite."""
+    calls = {"inplace": 0, "stream": 0}
+    with pytest.raises(RuntimeError, match="not enough free disk"):
+        _build_resized_case(tmp_path, force_inplace=True, optin=False,
+                            monkeypatch=monkeypatch, calls=calls)
+    assert calls["inplace"] == 0, "non-atomic in-place rewrite ran despite fail-closed default"
+    assert calls["stream"] == 0, "streaming branch ran despite forced low disk"

--- a/tests/test_merge_e2e_resized.py
+++ b/tests/test_merge_e2e_resized.py
@@ -36,7 +36,8 @@ import _merge_e2e_helpers as H
 NEW_VOCAB = 80  # base vocab is 64 (H._VOCAB)
 
 
-def _build_resized_case(tmp_path, *, dtype=torch.float32, low_disk=False):
+def _build_resized_case(tmp_path, *, dtype=torch.float32, force_inplace=False,
+                        monkeypatch=None, calls=None):
     from transformers import AutoModelForCausalLM
     from peft import LoraConfig, get_peft_model
 
@@ -65,7 +66,30 @@ def _build_resized_case(tmp_path, *, dtype=torch.float32, low_disk=False):
     ref_head = pm.get_output_embeddings().weight.detach().cpu().clone().to(dtype)
     adapted = H.extract_adapted(pm)  # q_proj / v_proj only
 
-    H.run_merge(pm, base_dir, out_dir, save_dtype=dtype, low_disk_space_usage=low_disk)
+    if force_inplace:
+        # The streaming-vs-in-place choice is made purely from free disk vs the
+        # estimated shard size (low_disk_space_usage does NOT select it for a
+        # local-dir merge). Force the in-place branch by making the estimate
+        # enormous, and spy on both rewrite paths to prove which one ran.
+        import unsloth_zoo.saving_utils as SU
+        real_inplace = SU._inplace_rewrite_resized_shard
+        real_stream = SU._stream_rewrite_resized_shard_and_replace
+
+        def _spy_inplace(*a, **k):
+            if calls is not None:
+                calls["inplace"] = calls.get("inplace", 0) + 1
+            return real_inplace(*a, **k)
+
+        def _spy_stream(*a, **k):
+            if calls is not None:
+                calls["stream"] = calls.get("stream", 0) + 1
+            return real_stream(*a, **k)
+
+        monkeypatch.setattr(SU, "_estimate_resized_shard_bytes", lambda *a, **k: 1 << 60)
+        monkeypatch.setattr(SU, "_inplace_rewrite_resized_shard", _spy_inplace)
+        monkeypatch.setattr(SU, "_stream_rewrite_resized_shard_and_replace", _spy_stream)
+
+    H.run_merge(pm, base_dir, out_dir, save_dtype=dtype)
     merged = H.read_safetensors_dir(out_dir)
     return base, merged, ref_embed, ref_head, adapted, dtype
 
@@ -98,6 +122,14 @@ def test_resized_vocab_grow_modules_to_save(tmp_path):
     _check(*_build_resized_case(tmp_path))
 
 
-def test_resized_vocab_grow_low_disk_fallback(tmp_path):
-    """Same correctness when the disk-aware in-place fallback is requested."""
-    _check(*_build_resized_case(tmp_path, low_disk=True))
+def test_resized_vocab_grow_low_disk_inplace(tmp_path, monkeypatch):
+    """Force the disk-aware in-place rewrite branch (not the streaming default) and
+    prove it produces the same correct output. The branch is selected only when free
+    disk < estimated shard bytes, so the estimate is patched enormous to trigger it;
+    spies on both rewrite paths confirm the in-place branch actually ran."""
+    calls = {"inplace": 0, "stream": 0}
+    res = _build_resized_case(tmp_path, force_inplace=True, monkeypatch=monkeypatch,
+                              calls=calls)
+    assert calls["inplace"] >= 1, "in-place resized rewrite branch was not exercised"
+    assert calls["stream"] == 0, "streaming branch ran despite forced low disk"
+    _check(*res)

--- a/tests/test_merge_e2e_vision_passthrough.py
+++ b/tests/test_merge_e2e_vision_passthrough.py
@@ -16,14 +16,12 @@
 
 """End-to-end LoRA merge correctness for vision / multimodal models.
 
-Language-side LoRA must merge correctly while every vision-tower / projector /
-audio tensor stays byte-identical to the base. These models also exercise the key
-remap that PR #773 hardens: the runtime LoRA path (``model.language_model.``)
-differs from the on-disk safetensor key (``language_model.model.``), so the
-reference keys are built with the production remapper
-``_convert_lora_keys_to_safetensor_format`` to match exactly what the merge does.
-A clean run also proves the key-count sanity check does not false-positive when
-adapters target the nested language model only.
+Language-side LoRA must merge while every vision-tower / projector / audio tensor
+stays byte-identical. Also exercises the #773 key remap (runtime
+`model.language_model.` vs on-disk `language_model.model.`): reference keys use the
+production remapper `_convert_lora_keys_to_safetensor_format`, and a clean run proves
+the key-count check does not false-positive when only the nested language model is
+adapted.
 """
 
 from __future__ import annotations
@@ -35,8 +33,7 @@ import torch
 
 import _merge_e2e_helpers as H
 
-# regex: target only the language model's q/v attention (NOT the vision encoder,
-# whose attention is also named q_proj/v_proj).
+# language model q/v only (the vision encoder also has q_proj/v_proj).
 _LANG_QV = r".*language_model.*\.(q_proj|v_proj)$"
 _VISION_MARKERS = ("vision", "visual", "multi_modal", "audio_tower", "vision_tower")
 
@@ -113,10 +110,8 @@ def test_vision_language_only_merge_preserves_vision(family, tmp_path):
             if sk in base:
                 ref[sk] = st
     if not ref:
-        # The production remapper could not line the language LoRA keys up with the
-        # on-disk keys on this transformers version (composite-model key layouts
-        # drift across versions). The vision-tower preservation below is the core
-        # check; exact language deltas are covered where keys resolve + real sweep.
+        # remapper could not line language LoRA keys to on-disk keys on this
+        # transformers version; vision preservation below is the core check.
         pytest.skip(f"{family}: language adapter keys did not resolve against base "
                     f"on this transformers version")
 

--- a/tests/test_merge_e2e_vision_passthrough.py
+++ b/tests/test_merge_e2e_vision_passthrough.py
@@ -1,0 +1,141 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""End-to-end LoRA merge correctness for vision / multimodal models.
+
+Language-side LoRA must merge correctly while every vision-tower / projector /
+audio tensor stays byte-identical to the base. These models also exercise the key
+remap that PR #773 hardens: the runtime LoRA path (``model.language_model.``)
+differs from the on-disk safetensor key (``language_model.model.``), so the
+reference keys are built with the production remapper
+``_convert_lora_keys_to_safetensor_format`` to match exactly what the merge does.
+A clean run also proves the key-count sanity check does not false-positive when
+adapters target the nested language model only.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+import _merge_e2e_helpers as H
+
+# regex: target only the language model's q/v attention (NOT the vision encoder,
+# whose attention is also named q_proj/v_proj).
+_LANG_QV = r".*language_model.*\.(q_proj|v_proj)$"
+_VISION_MARKERS = ("vision", "visual", "multi_modal", "audio_tower", "vision_tower")
+
+
+def _build_gemma3():
+    import transformers as T
+    text = dict(hidden_size=32, intermediate_size=64, num_hidden_layers=2,
+                num_attention_heads=4, num_key_value_heads=2, vocab_size=64,
+                max_position_embeddings=64, head_dim=8)
+    vision = dict(hidden_size=32, intermediate_size=64, num_hidden_layers=2,
+                  num_attention_heads=4, image_size=16, patch_size=8, num_channels=3)
+    return T.Gemma3Config(text_config=text, vision_config=vision)
+
+
+def _build_qwen3_vl():
+    import transformers as T
+    text = dict(hidden_size=32, intermediate_size=64, num_hidden_layers=2,
+                num_attention_heads=4, num_key_value_heads=2, vocab_size=64,
+                max_position_embeddings=64, head_dim=8, rope_scaling={"type": "default",
+                "mrope_section": [1, 1, 2]})
+    vision = dict(hidden_size=32, intermediate_size=64, depth=2, num_heads=4,
+                  patch_size=16, out_hidden_size=32)
+    return T.Qwen3VLConfig(text_config=text, vision_config=vision)
+
+
+_VLM_BUILDERS = {"gemma3": _build_gemma3, "qwen3_vl": _build_qwen3_vl}
+
+
+def _make_vlm(family):
+    import transformers as T
+    if not H.family_available(family):
+        pytest.skip(f"{family} unavailable in this transformers")
+    try:
+        cfg = _VLM_BUILDERS[family]()
+        torch.manual_seed(H.SEED)
+        model = T.AutoModelForImageTextToText.from_config(cfg).to(torch.float32)
+    except Exception as e:  # tiny VLM config quirks vary by version
+        pytest.skip(f"could not instantiate tiny {family}: {type(e).__name__}: {e}")
+    return model
+
+
+@pytest.mark.parametrize("family", list(_VLM_BUILDERS))
+def test_vision_language_only_merge_preserves_vision(family, tmp_path):
+    import unsloth_zoo.saving_utils as SU
+    from peft import LoraConfig, get_peft_model
+
+    H.set_offline_cpu_env()
+    model = _make_vlm(family)
+    cls_name = type(model).__name__
+    base_dir = os.path.join(str(tmp_path), "base")
+    out_dir = os.path.join(str(tmp_path), "merged")
+    model.save_pretrained(base_dir, safe_serialization=True)
+    model.config._name_or_path = base_dir
+    base = H.read_safetensors_dir(base_dir)
+    base_keys = list(base.keys())
+
+    pm = get_peft_model(model, LoraConfig(
+        r=8, lora_alpha=16, lora_dropout=0.0, bias="none", target_modules=_LANG_QV))
+    # no adapter may land on the vision tower
+    in_vision = [n for n, m in pm.named_modules()
+                 if getattr(m, "lora_A", None) is not None
+                 and hasattr(m.lora_A, "__contains__") and "default" in m.lora_A
+                 and any(s in n for s in _VISION_MARKERS)]
+    assert not in_vision, f"language-only LoRA leaked onto vision modules: {in_vision[:3]}"
+    H.seed_lora(pm)
+
+    # reference adapted keys via the PRODUCTION remapper (handles the VLM prefix swap)
+    lora_weights, _ = SU.create_lora_statistics(pm, merge_into_original=True)
+    remapped = SU._convert_lora_keys_to_safetensor_format(lora_weights, base_keys, cls_name)
+    ref = {}
+    for k, st in remapped.items():
+        if isinstance(k, str) and st.lora_A is not None:
+            sk = k + ".weight"
+            if sk in base:
+                ref[sk] = st
+    if not ref:
+        # The production remapper could not line the language LoRA keys up with the
+        # on-disk keys on this transformers version (composite-model key layouts
+        # drift across versions). The vision-tower preservation below is the core
+        # check; exact language deltas are covered where keys resolve + real sweep.
+        pytest.skip(f"{family}: language adapter keys did not resolve against base "
+                    f"on this transformers version")
+
+    H.run_merge(pm, base_dir, out_dir, save_dtype=torch.float32)
+    merged = H.read_safetensors_dir(out_dir)
+
+    atol, rtol = H._TOL[torch.float32]
+    n_lang = n_vision = 0
+    for key, mt in merged.items():
+        if key in ref:
+            st = ref[key]
+            A = st.lora_A.double().cpu(); B = st.lora_B.double().cpu()
+            expected = (base[key].double() + float(st.alpha) * (B @ A)).to(torch.float32)
+            H._assert_close(family, key, mt, expected, atol, rtol, adapted=True)
+            n_lang += 1
+        else:
+            H._assert_equal(family, key, mt, base[key])
+            if any(s in key for s in _VISION_MARKERS):
+                n_vision += 1
+
+    assert n_lang >= 1, "no language LoRA deltas were merged"
+    assert n_vision >= 1, "no vision tensors present to verify preservation"

--- a/tests/test_resized_shard_rewrite_parity.py
+++ b/tests/test_resized_shard_rewrite_parity.py
@@ -1,0 +1,104 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The resized-shard rewrite has two branches (streaming temp file vs low-disk
+in-place save_file). They must produce identical tensors, and both must preserve
+unchanged tensors byte-for-byte while swapping in the resized ones. CPU-only.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from unsloth_zoo.saving_utils import (
+    _estimate_resized_shard_bytes,
+    _inplace_rewrite_resized_shard,
+    _stream_rewrite_resized_shard_and_replace,
+)
+
+
+def _read_header(path):
+    with open(path, "rb") as f:
+        length_of_header = int.from_bytes(f.read(8), "little")
+        header_metadata = json.loads(f.read(length_of_header))
+    return length_of_header, header_metadata
+
+
+def _make_shard(path, tensors):
+    save_file(tensors, str(path), metadata = {"format": "pt"})
+
+
+@pytest.fixture
+def base_shard(tmp_path):
+    torch.manual_seed(0)
+    tensors = {
+        "model.embed_tokens.weight": torch.randn(10, 8),   # grows below
+        "model.norm.weight":         torch.randn(8),       # pass-through
+        "lm_head.weight":            torch.randn(10, 8),    # pass-through
+    }
+    path = tmp_path / "model.safetensors"
+    _make_shard(path, tensors)
+    return path, tensors
+
+
+def test_streaming_and_inplace_resized_rewrites_match(base_shard, tmp_path):
+    src, original = base_shard
+    length_of_header, header_metadata = _read_header(src)
+
+    # Vocab grew 10 -> 13: the merged embedding no longer fits its byte slot.
+    grown = torch.randn(13, 8)
+    resized = {"model.embed_tokens.weight": grown}
+
+    stream_path = tmp_path / "stream.safetensors"
+    inplace_path = tmp_path / "inplace.safetensors"
+    shutil.copy2(src, stream_path)
+    shutil.copy2(src, inplace_path)
+
+    _stream_rewrite_resized_shard_and_replace(
+        str(stream_path), str(tmp_path), header_metadata, length_of_header, dict(resized)
+    )
+    _inplace_rewrite_resized_shard(str(inplace_path), header_metadata, dict(resized))
+
+    with safe_open(str(stream_path), framework = "pt") as a, \
+         safe_open(str(inplace_path), framework = "pt") as b:
+        assert sorted(a.keys()) == sorted(b.keys()) == sorted(original.keys())
+        for key in original:
+            ta, tb = a.get_tensor(key), b.get_tensor(key)
+            # Both branches agree with each other...
+            assert torch.equal(ta, tb), f"branch mismatch for {key}"
+            # ...the resized tensor is the grown one, the rest are untouched.
+            expected = grown if key == "model.embed_tokens.weight" else original[key]
+            assert torch.equal(ta, expected), f"wrong content for {key}"
+
+
+def test_estimate_tracks_resized_growth(base_shard):
+    src, _ = base_shard
+    length_of_header, header_metadata = _read_header(src)
+    base_size = src.stat().st_size
+
+    grown = torch.randn(13, 8)  # +3 rows * 8 cols * 4 bytes = +96 bytes of data
+    est = _estimate_resized_shard_bytes(
+        header_metadata, {"model.embed_tokens.weight": grown}, length_of_header
+    )
+    assert est > base_size
+    assert est - base_size >= (13 - 10) * 8 * 4

--- a/tests/test_resized_shard_rewrite_parity.py
+++ b/tests/test_resized_shard_rewrite_parity.py
@@ -15,8 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """The resized-shard rewrite has two branches (streaming temp file vs low-disk
-in-place save_file). They must produce identical tensors, and both must preserve
-unchanged tensors byte-for-byte while swapping in the resized ones. CPU-only.
+in-place save_file): they must produce identical tensors and preserve unchanged
+tensors byte-for-byte while swapping in the resized ones. CPU-only.
 """
 
 from __future__ import annotations
@@ -84,9 +84,7 @@ def test_streaming_and_inplace_resized_rewrites_match(base_shard, tmp_path):
         assert sorted(a.keys()) == sorted(b.keys()) == sorted(original.keys())
         for key in original:
             ta, tb = a.get_tensor(key), b.get_tensor(key)
-            # Both branches agree with each other...
             assert torch.equal(ta, tb), f"branch mismatch for {key}"
-            # ...the resized tensor is the grown one, the rest are untouched.
             expected = grown if key == "model.embed_tokens.weight" else original[key]
             assert torch.equal(ta, expected), f"wrong content for {key}"
 

--- a/tests/test_zoo_history_regressions_deep.py
+++ b/tests/test_zoo_history_regressions_deep.py
@@ -411,13 +411,14 @@ def test_sft_prepare_dataset_removes_original_columns_in_non_packing_path():
 
 
 def test_saving_utils_uses_atomic_replace_for_shard_rewrite():
-    """PR #595: _merge_and_overwrite_lora uses atomic os.replace
-    (not remove+move; Windows WinError 1224 on shard rewrite)."""
+    """PR #595: the resized-shard rewrite uses atomic os.replace
+    (not remove+move; Windows WinError 1224 on shard rewrite). The rewrite +
+    replace now lives in _stream_rewrite_resized_shard_and_replace."""
     src = _get_source(
-        "unsloth_zoo.saving_utils", "_merge_and_overwrite_lora",
+        "unsloth_zoo.saving_utils", "_stream_rewrite_resized_shard_and_replace",
     )
     assert "os.replace(" in src, (
-        "_merge_and_overwrite_lora no longer uses os.replace -- "
+        "_stream_rewrite_resized_shard_and_replace no longer uses os.replace -- "
         "regression of PR #595 (Windows WinError 1224 on shard rewrite)."
     )
     if "shutil.move(" in src and "os.remove(" in src:

--- a/tests/test_zoo_history_regressions_deep.py
+++ b/tests/test_zoo_history_regressions_deep.py
@@ -411,9 +411,8 @@ def test_sft_prepare_dataset_removes_original_columns_in_non_packing_path():
 
 
 def test_saving_utils_uses_atomic_replace_for_shard_rewrite():
-    """PR #595: the resized-shard rewrite uses atomic os.replace
-    (not remove+move; Windows WinError 1224 on shard rewrite). The rewrite +
-    replace now lives in _stream_rewrite_resized_shard_and_replace."""
+    """PR #595: _stream_rewrite_resized_shard_and_replace uses atomic os.replace
+    (not remove+move; Windows WinError 1224 on shard rewrite)."""
     src = _get_source(
         "unsloth_zoo.saving_utils", "_stream_rewrite_resized_shard_and_replace",
     )

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -151,9 +151,8 @@ from collections import OrderedDict
 from tqdm import tqdm as ProgressBar
 import os, shutil, re, functools
 
-# Only flush the accelerator allocator after a merge that allocated a large tensor
-# (embed / lm_head / fused expert stacks). Per-tensor empty_cache()/synchronize()
-# over every key -- most of which never touch the GPU -- is a large wasted stall.
+# Flush the allocator only after a large-tensor merge (embed / lm_head / fused
+# experts); a per-key empty_cache/synchronize over every key is wasted GPU stall.
 _EMPTY_CACHE_BYTES_THRESHOLD = 256 * 1024 * 1024
 
 
@@ -559,8 +558,7 @@ def _merge_and_overwrite_lora(
     if counted_lora_modules is None:
         counted_lora_modules = set()   # fused lora keys counted toward n_saved_modules
 
-    # converted_lora_weights is built once below, after the real safetensor keys
-    # are known (the earlier empty-key conversion was discarded immediately).
+    # built once below, once the real safetensor keys are known.
     raw_pointer = None
     mm = None
     header_metadata = None
@@ -775,8 +773,7 @@ def _merge_and_overwrite_lora(
 
                 nbytes = W.numel() * W.element_size()
                 del W
-                # Only flush after a large tensor (embed / lm_head); the per-key
-                # flush over every small weight was pure GPU-driver stall.
+                # flush only after a large tensor; per-key flush was pure stall.
                 if nbytes >= _EMPTY_CACHE_BYTES_THRESHOLD:
                     device_empty_cache()
             pass
@@ -785,9 +782,8 @@ def _merge_and_overwrite_lora(
         mm.close()
         raw_pointer.close()
 
-        # Vocab grew, so resized tensors no longer fit their byte slots and the
-        # shard must be rewritten. Stream to a temp file (low RAM) when disk has
-        # room for the transient copy; otherwise rewrite in place (low disk).
+        # Vocab grew -> resized tensors no longer fit their byte slots; rewrite the
+        # shard. Stream to a temp file when disk allows, else rewrite in place.
         resized = getattr(_merge_and_overwrite_lora, "_resized", {})
         if resized:
             _merge_and_overwrite_lora._resized = {}
@@ -802,12 +798,9 @@ def _merge_and_overwrite_lora(
                 free_bytes = None
             margin = 64 * 1024 * 1024
             if free_bytes is not None and free_bytes < est_bytes + margin:
-                # Not enough room for the atomic temp-file rewrite. The in-place
-                # fallback overwrites the shard directly, which is non-atomic: an
-                # interrupted or failed write leaves the only output shard truncated
-                # (and on Windows the mmap section can stay locked). Refuse by default
-                # so a tight-disk save never silently corrupts the shard; let callers
-                # who accept the risk opt back in explicitly.
+                # No room for the atomic temp+replace rewrite. The in-place fallback
+                # overwrites the shard non-atomically (a failed write truncates it,
+                # worse on Windows mmap), so refuse by default; opt in to allow it.
                 if os.environ.get("UNSLOTH_ALLOW_NON_ATOMIC_RESIZED_REWRITE") != "1":
                     raise RuntimeError(
                         f"Unsloth: not enough free disk to rewrite resized shard "
@@ -3822,8 +3815,7 @@ pass
 
 
 def _estimate_resized_shard_bytes(header_metadata, resized, length_of_header):
-    # Size of the rewritten shard: resized tensors at their new byte count, the
-    # rest at their current slot, plus the header.
+    # Rewritten-shard size: resized tensors at new byte count, rest at current slot, + header.
     total = 0
     for k, entry in header_metadata.items():
         if k == "__metadata__":
@@ -3838,9 +3830,8 @@ def _estimate_resized_shard_bytes(header_metadata, resized, length_of_header):
 
 
 def _inplace_rewrite_resized_shard(filename_original, header_metadata, resized):
-    # Low-disk fallback for a resized shard: reload it, swap in the resized tensors,
-    # and save_file over the original (higher peak RAM, but no transient 2x-shard
-    # disk). Mirrors the pre-streaming behaviour for tight-disk / low-disk jobs.
+    # Low-disk fallback: reload the shard, swap in resized tensors, save_file over
+    # the original (higher RAM, no transient 2x-shard disk; non-atomic).
     meta = header_metadata.get("__metadata__", None)
     tensors = {}
     with safe_open(filename_original, framework = "pt", device = "cpu") as f:
@@ -3959,9 +3950,8 @@ def _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key
             return False
 
         # Zero-copy write into the mmap; avoids the bytes() copy that doubled peak
-        # RAM on large tensors (embed / lm_head). tensor_formatted is already
-        # contiguous CPU; reshape(-1) gives the 1D buffer the mmap slice needs
-        # (multi-dim memoryview assignment errors on some Pythons).
+        # RAM on large tensors. tensor_formatted is already contiguous CPU; reshape(-1)
+        # gives the 1D buffer the mmap slice needs (multi-dim assignment errors on some Pythons).
         tensor_view = tensor_formatted.detach().reshape(-1).view(torch.uint8)
         mm[index_L:index_R] = memoryview(tensor_view.numpy())
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3885,8 +3885,9 @@ def _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key
             return False
 
         # Zero-copy write into the mmap; avoids the bytes() copy that doubled peak
-        # RAM on large tensors (embed / lm_head).
-        tensor_view = tensor_formatted.detach().contiguous().view(torch.uint8)
+        # RAM on large tensors (embed / lm_head). Flatten first so the mmap slice
+        # gets a 1D buffer (multi-dim memoryview assignment errors on some Pythons).
+        tensor_view = tensor_formatted.detach().contiguous().reshape(-1).view(torch.uint8)
         mm[index_L:index_R] = memoryview(tensor_view.numpy())
 
         # Clear memory

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -802,14 +802,28 @@ def _merge_and_overwrite_lora(
                 free_bytes = None
             margin = 64 * 1024 * 1024
             if free_bytes is not None and free_bytes < est_bytes + margin:
-                # Not enough room for the atomic temp-file rewrite, so overwrite the
-                # shard in place. This is non-atomic: an interrupted save leaves the
-                # shard truncated. Warn unconditionally so the risk is visible.
+                # Not enough room for the atomic temp-file rewrite. The in-place
+                # fallback overwrites the shard directly, which is non-atomic: an
+                # interrupted or failed write leaves the only output shard truncated
+                # (and on Windows the mmap section can stay locked). Refuse by default
+                # so a tight-disk save never silently corrupts the shard; let callers
+                # who accept the risk opt back in explicitly.
+                if os.environ.get("UNSLOTH_ALLOW_NON_ATOMIC_RESIZED_REWRITE") != "1":
+                    raise RuntimeError(
+                        f"Unsloth: not enough free disk to rewrite resized shard "
+                        f"{filename_original} atomically (free={free_bytes}, "
+                        f"need~={est_bytes + margin}). The original shard was left "
+                        f"intact. Free disk space or point the save directory at a "
+                        f"larger volume, or set "
+                        f"UNSLOTH_ALLOW_NON_ATOMIC_RESIZED_REWRITE=1 to allow the "
+                        f"non-atomic in-place rewrite (which can corrupt the shard if "
+                        f"the write is interrupted)."
+                    )
                 logger.warning(
                     f"Unsloth: low disk to rewrite resized shard {filename_original} "
-                    f"(free={free_bytes}, need~={est_bytes}); rewriting in place. "
-                    f"This is non-atomic, so do not interrupt the save. Free "
-                    f"~{est_bytes + margin} bytes to get the safe atomic rewrite."
+                    f"(free={free_bytes}, need~={est_bytes}); rewriting in place via "
+                    f"UNSLOTH_ALLOW_NON_ATOMIC_RESIZED_REWRITE. This is non-atomic, so "
+                    f"do not interrupt the save."
                 )
                 _inplace_rewrite_resized_shard(filename_original, header_metadata, resized)
             else:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -785,9 +785,8 @@ def _merge_and_overwrite_lora(
         mm.close()
         raw_pointer.close()
 
-        # Vocab grew: merged embed / lm_head no longer fit their byte slots, so the
-        # shard is re-laid-out. Stream-rewrite to a temp file (peak RAM ~ one tensor),
-        # then atomic os.replace (Windows mmap-release lag handled below).
+        # Vocab grew, so resized tensors no longer fit their byte slots: stream-rewrite
+        # the shard to a temp file (peak RAM ~ one tensor), then atomic os.replace.
         resized = getattr(_merge_and_overwrite_lora, "_resized", {})
         if resized:
             _merge_and_overwrite_lora._resized = {}
@@ -3797,9 +3796,8 @@ def split_safetensors_to_shards(file_path, max_shard_size_gb=2):
 pass
 
 def _stream_rewrite_resized_shard(src_path, dst_path, header_metadata, length_of_header, resized):
-    # Re-lay-out a shard after a vocab resize, streaming one tensor at a time so peak
-    # RAM ~= one tensor (not the whole shard). Resized tensors come from `resized`; the
-    # rest are byte-copied from src (already merged). Tensor-identical to dict+save_file.
+    # Stream one tensor at a time (peak RAM ~ one tensor): resized tensors from
+    # `resized`, the rest byte-copied from src. Tensor-identical to dict+save_file.
     import struct
     src_data_start = 8 + length_of_header
     meta = header_metadata.get("__metadata__", None)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -785,100 +785,92 @@ def _merge_and_overwrite_lora(
         mm.close()
         raw_pointer.close()
 
-        # If any tensors were resized (vocab resize), rewrite the shard file
+        # Vocab grew: merged embed / lm_head no longer fit their byte slots, so the
+        # shard is re-laid-out. Stream-rewrite to a temp file (peak RAM ~ one tensor),
+        # then atomic os.replace (Windows mmap-release lag handled below).
         resized = getattr(_merge_and_overwrite_lora, "_resized", {})
         if resized:
             _merge_and_overwrite_lora._resized = {}
-            # Reload shard, swap in resized tensors, save
-            tensors = {}
-            with safe_open(filename_original, framework="pt", device="cpu") as f:
-                for key in f.keys():
-                    if key in resized:
-                        tensors[key] = resized[key]
-                    else:
-                        tensors[key] = f.get_tensor(key)
+            gc.collect()
+            device_empty_cache()
 
-            # POSIX: direct save. Windows: temp-file + os.replace to
-            # avoid WinError 1224 (mmap section release can lag).
-            if os.name != "nt":
-                save_file(tensors, filename_original)
-                del tensors
-            else:
+            max_retries = 5
+            base_delay  = 0.2  # seconds
+            temp_dir    = os.path.dirname(os.path.abspath(filename_original))
+            try:
+                original_mode = os.stat(filename_original).st_mode
+            except OSError:
+                original_mode = None
+
+            fd, tmp_path = tempfile.mkstemp(dir=temp_dir, suffix=".safetensors.tmp")
+            os.close(fd)
+
+            try:
+                _stream_rewrite_resized_shard(
+                    src_path = filename_original,
+                    dst_path = tmp_path,
+                    header_metadata = header_metadata,
+                    length_of_header = length_of_header,
+                    resized = resized,
+                )
+                if original_mode is not None:
+                    try:
+                        os.chmod(tmp_path, original_mode)
+                    except OSError:
+                        pass
+
+                del resized
                 gc.collect()
                 device_empty_cache()
 
-                max_retries = 5
-                base_delay  = 0.2  # seconds
-                temp_dir    = os.path.dirname(os.path.abspath(filename_original))
-                try:
-                    original_mode = os.stat(filename_original).st_mode
-                except OSError:
-                    original_mode = None
-
-                fd, tmp_path = tempfile.mkstemp(dir=temp_dir, suffix=".safetensors.tmp")
-                os.close(fd)
-
-                try:
-                    save_file(tensors, tmp_path)
-                    if original_mode is not None:
-                        try:
-                            os.chmod(tmp_path, original_mode)
-                        except OSError:
-                            pass
-
-                    # Drop mmap refs before os.replace
-                    del tensors
-                    gc.collect()
-                    device_empty_cache()
-
-                    for attempt in range(max_retries):
-                        try:
-                            os.replace(tmp_path, filename_original)
-                            tmp_path = None
-                            break
-                        except OSError as e:
-                            winerror  = getattr(e, "winerror", None)
-                            error_msg = str(e).lower()
-                            is_lock_error = (
-                                winerror in {32, 1224}
-                                or (
-                                    winerror == 5 and (
-                                        "user-mapped" in error_msg
-                                        or "being used by another process" in error_msg
-                                        or "sharing violation" in error_msg
-                                    )
+                for attempt in range(max_retries):
+                    try:
+                        os.replace(tmp_path, filename_original)
+                        tmp_path = None
+                        break
+                    except OSError as e:
+                        winerror  = getattr(e, "winerror", None)
+                        error_msg = str(e).lower()
+                        is_lock_error = (
+                            winerror in {32, 1224}
+                            or (
+                                winerror == 5 and (
+                                    "user-mapped" in error_msg
+                                    or "being used by another process" in error_msg
+                                    or "sharing violation" in error_msg
                                 )
-                                or "user-mapped" in error_msg
-                                or "being used by another process" in error_msg
                             )
-                            if is_lock_error and attempt < max_retries - 1:
-                                delay = base_delay * (2 ** attempt)
-                                if UNSLOTH_ENABLE_LOGGING:
-                                    logger.warning(
-                                        f"[Retry {attempt + 1}/{max_retries}] Windows file lock "
-                                        f"detected for {filename_original}: {e}. "
-                                        f"Waiting {delay:.1f}s before retry..."
-                                    )
-                                gc.collect()
-                                time.sleep(delay)
-                                continue
-                            if is_lock_error:
-                                raise RuntimeError(
-                                    f"Failed to rewrite {filename_original} after {max_retries} "
-                                    f"attempts due to Windows file lock. Original shard is intact "
-                                    f"(atomic replace never committed). "
-                                    f"Solutions: 1) Restart Unsloth Studio 2) Disable antivirus "
-                                    f"3) Close File Explorer windows"
-                                ) from e
+                            or "user-mapped" in error_msg
+                            or "being used by another process" in error_msg
+                        )
+                        if is_lock_error and attempt < max_retries - 1:
+                            delay = base_delay * (2 ** attempt)
+                            if UNSLOTH_ENABLE_LOGGING:
+                                logger.warning(
+                                    f"[Retry {attempt + 1}/{max_retries}] Windows file lock "
+                                    f"detected for {filename_original}: {e}. "
+                                    f"Waiting {delay:.1f}s before retry..."
+                                )
+                            gc.collect()
+                            time.sleep(delay)
+                            continue
+                        if is_lock_error:
                             raise RuntimeError(
-                                f"Model merge failed while rewriting {filename_original}: {e}"
+                                f"Failed to rewrite {filename_original} after {max_retries} "
+                                f"attempts due to Windows file lock. Original shard is intact "
+                                f"(atomic replace never committed). "
+                                f"Solutions: 1) Restart Unsloth Studio 2) Disable antivirus "
+                                f"3) Close File Explorer windows"
                             ) from e
-                finally:
-                    if tmp_path is not None and os.path.exists(tmp_path):
-                        try:
-                            os.remove(tmp_path)
-                        except OSError:
-                            pass
+                        raise RuntimeError(
+                            f"Model merge failed while rewriting {filename_original}: {e}"
+                        ) from e
+            finally:
+                if tmp_path is not None and os.path.exists(tmp_path):
+                    try:
+                        os.remove(tmp_path)
+                    except OSError:
+                        pass
 
         device_empty_cache()
         return count, safetensor_keys_seen
@@ -3804,6 +3796,67 @@ def split_safetensors_to_shards(file_path, max_shard_size_gb=2):
     return shards
 pass
 
+def _stream_rewrite_resized_shard(src_path, dst_path, header_metadata, length_of_header, resized):
+    # Re-lay-out a shard after a vocab resize, streaming one tensor at a time so peak
+    # RAM ~= one tensor (not the whole shard). Resized tensors come from `resized`; the
+    # rest are byte-copied from src (already merged). Tensor-identical to dict+save_file.
+    import struct
+    src_data_start = 8 + length_of_header
+    meta = header_metadata.get("__metadata__", None)
+    tensor_keys = [k for k in header_metadata.keys() if k != "__metadata__"]
+    tensor_keys.sort(key = lambda k: header_metadata[k]["data_offsets"][0])
+
+    # Cast resized tensors to the header dtype so bytes match the label.
+    res_t = {}
+    for k in resized:
+        dt = SAFETENSORS_DTYPES[header_metadata[k]["dtype"]]
+        res_t[k] = resized[k].detach().to(dt).contiguous().cpu()
+
+    new_header = {}
+    if meta is not None:
+        new_header["__metadata__"] = meta
+    layout = []  # (key, src_off0, nbytes, is_resized)
+    cursor = 0
+    for k in tensor_keys:
+        entry = header_metadata[k]
+        if k in res_t:
+            t = res_t[k]
+            shape = list(t.shape)
+            nbytes = t.numel() * t.element_size()
+        else:
+            shape = list(entry["shape"])
+            o0, o1 = entry["data_offsets"]
+            nbytes = o1 - o0
+        # dtype is unchanged by a vocab resize
+        new_header[k] = {"dtype": entry["dtype"], "shape": shape,
+                         "data_offsets": [cursor, cursor + nbytes]}
+        layout.append((k, entry["data_offsets"][0], nbytes, k in res_t))
+        cursor += nbytes
+
+    header_bytes = json.dumps(new_header, separators = (",", ":")).encode("utf-8")
+    header_bytes += b" " * ((8 - (len(header_bytes) % 8)) % 8)  # 8-byte align data start
+
+    CHUNK = 64 * 1024 * 1024
+    with open(dst_path, "wb") as out, open(src_path, "rb") as src:
+        out.write(struct.pack("<Q", len(header_bytes)))
+        out.write(header_bytes)
+        for k, src_off0, nbytes, is_resized in layout:
+            if is_resized:
+                out.write(memoryview(res_t[k].view(torch.uint8).numpy()))
+            else:
+                src.seek(src_data_start + src_off0)
+                remaining = nbytes
+                while remaining > 0:
+                    chunk = src.read(min(CHUNK, remaining))
+                    if not chunk:
+                        raise RuntimeError(
+                            f"Unsloth: unexpected EOF reading {src_path} for tensor {k}")
+                    out.write(chunk)
+                    remaining -= len(chunk)
+    res_t.clear()
+pass
+
+
 def _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key, tensor, output_dtype):
     """
     Write tensor directly to memory-mapped file using pure PyTorch operations
@@ -3832,20 +3885,12 @@ def _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key
                 logger.warning(f"Size mismatch for {output_key}: expected {expected_size}, got {tensor_bytes}")
             return False
 
-        # Use PyTorch's internal byte representation directly
-        # This avoids numpy conversion and preserves exact format
-        tensor_view = tensor_formatted.view(torch.uint8)
-
-        # Convert to bytes using PyTorch's .data_ptr() and ctypes
-        import ctypes
-        data_ptr = tensor_view.data_ptr()
-        byte_data = (ctypes.c_ubyte * tensor_view.numel()).from_address(data_ptr)
-
-        # Write directly to memory map
-        mm[index_L:index_R] = bytes(byte_data)
+        # Zero-copy write into the mmap; avoids the bytes() copy that doubled peak
+        # RAM on large tensors (embed / lm_head).
+        tensor_view = tensor_formatted.detach().contiguous().view(torch.uint8)
+        mm[index_L:index_R] = memoryview(tensor_view.numpy())
 
         # Clear memory
-        del data_ptr
         del tensor_view
         del tensor_formatted
         del tensor

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -3842,7 +3842,8 @@ def _stream_rewrite_resized_shard(src_path, dst_path, header_metadata, length_of
         out.write(header_bytes)
         for k, src_off0, nbytes, is_resized in layout:
             if is_resized:
-                out.write(memoryview(res_t[k].view(torch.uint8).numpy()))
+                # reshape(-1) so 0-dim scalars (e.g. Gemma-4 audio min/max) view as bytes
+                out.write(memoryview(res_t[k].reshape(-1).view(torch.uint8).numpy()))
             else:
                 src.seek(src_data_start + src_off0)
                 remaining = nbytes

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -23,7 +23,7 @@ import warnings
 from .peft_utils import get_lora_layer_modules
 from .utils import _get_dtype
 from .hf_utils import dtype_from_config
-from .device_type import DEVICE_TYPE, DEVICE_TYPE_TORCH, device_empty_cache, device_synchronize
+from .device_type import DEVICE_TYPE, DEVICE_TYPE_TORCH, device_empty_cache
 from .temporary_patches.common import UNSLOTH_ENABLE_LOGGING, logger
 from collections import defaultdict
 
@@ -802,11 +802,15 @@ def _merge_and_overwrite_lora(
                 free_bytes = None
             margin = 64 * 1024 * 1024
             if free_bytes is not None and free_bytes < est_bytes + margin:
-                if UNSLOTH_ENABLE_LOGGING:
-                    logger.info(
-                        f"Unsloth: low disk for resized rewrite of {filename_original}; "
-                        f"saving in place (free={free_bytes}, need~={est_bytes})"
-                    )
+                # Not enough room for the atomic temp-file rewrite, so overwrite the
+                # shard in place. This is non-atomic: an interrupted save leaves the
+                # shard truncated. Warn unconditionally so the risk is visible.
+                logger.warning(
+                    f"Unsloth: low disk to rewrite resized shard {filename_original} "
+                    f"(free={free_bytes}, need~={est_bytes}); rewriting in place. "
+                    f"This is non-atomic, so do not interrupt the save. Free "
+                    f"~{est_bytes + margin} bytes to get the safe atomic rewrite."
+                )
                 _inplace_rewrite_resized_shard(filename_original, header_metadata, resized)
             else:
                 _stream_rewrite_resized_shard_and_replace(

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -151,6 +151,11 @@ from collections import OrderedDict
 from tqdm import tqdm as ProgressBar
 import os, shutil, re, functools
 
+# Only flush the accelerator allocator after a merge that allocated a large tensor
+# (embed / lm_head / fused expert stacks). Per-tensor empty_cache()/synchronize()
+# over every key -- most of which never touch the GPU -- is a large wasted stall.
+_EMPTY_CACHE_BYTES_THRESHOLD = 256 * 1024 * 1024
+
 
 @functools.lru_cache(maxsize = 1)
 def _active_merge_device():
@@ -554,13 +559,8 @@ def _merge_and_overwrite_lora(
     if counted_lora_modules is None:
         counted_lora_modules = set()   # fused lora keys counted toward n_saved_modules
 
-    # Convert lora_weights to safetensor format
-    converted_lora_weights = _convert_lora_keys_to_safetensor_format(
-        lora_weights,
-        [],
-        model_class_name = model_class_name,
-    )
-
+    # converted_lora_weights is built once below, after the real safetensor keys
+    # are known (the earlier empty-key conversion was discarded immediately).
     raw_pointer = None
     mm = None
     header_metadata = None
@@ -637,10 +637,6 @@ def _merge_and_overwrite_lora(
                     and len(processed_mxfp4_keys) == 0
                 ):
                     logger.info(f"[merge_debug] First shard key example: {key}")
-
-                # Free memory before each tensor
-                device_empty_cache()
-                device_synchronize()
 
                 # MoE stacked experts: gate_up_proj is fused in the model but
                 # sharded as per-expert gate_proj/up_proj on disk.
@@ -777,99 +773,48 @@ def _merge_and_overwrite_lora(
                         dtype=W_original_dtype, device="cpu"
                     )
 
+                nbytes = W.numel() * W.element_size()
                 del W
-                device_empty_cache()
+                # Only flush after a large tensor (embed / lm_head); the per-key
+                # flush over every small weight was pure GPU-driver stall.
+                if nbytes >= _EMPTY_CACHE_BYTES_THRESHOLD:
+                    device_empty_cache()
             pass
         pass
         mm.flush()
         mm.close()
         raw_pointer.close()
 
-        # Vocab grew, so resized tensors no longer fit their byte slots: stream-rewrite
-        # the shard to a temp file (peak RAM ~ one tensor), then atomic os.replace.
+        # Vocab grew, so resized tensors no longer fit their byte slots and the
+        # shard must be rewritten. Stream to a temp file (low RAM) when disk has
+        # room for the transient copy; otherwise rewrite in place (low disk).
         resized = getattr(_merge_and_overwrite_lora, "_resized", {})
         if resized:
             _merge_and_overwrite_lora._resized = {}
             gc.collect()
             device_empty_cache()
 
-            max_retries = 5
-            base_delay  = 0.2  # seconds
-            temp_dir    = os.path.dirname(os.path.abspath(filename_original))
+            temp_dir = os.path.dirname(os.path.abspath(filename_original))
+            est_bytes = _estimate_resized_shard_bytes(header_metadata, resized, length_of_header)
             try:
-                original_mode = os.stat(filename_original).st_mode
+                free_bytes = shutil.disk_usage(temp_dir).free
             except OSError:
-                original_mode = None
-
-            fd, tmp_path = tempfile.mkstemp(dir=temp_dir, suffix=".safetensors.tmp")
-            os.close(fd)
-
-            try:
-                _stream_rewrite_resized_shard(
-                    src_path = filename_original,
-                    dst_path = tmp_path,
-                    header_metadata = header_metadata,
-                    length_of_header = length_of_header,
-                    resized = resized,
+                free_bytes = None
+            margin = 64 * 1024 * 1024
+            if free_bytes is not None and free_bytes < est_bytes + margin:
+                if UNSLOTH_ENABLE_LOGGING:
+                    logger.info(
+                        f"Unsloth: low disk for resized rewrite of {filename_original}; "
+                        f"saving in place (free={free_bytes}, need~={est_bytes})"
+                    )
+                _inplace_rewrite_resized_shard(filename_original, header_metadata, resized)
+            else:
+                _stream_rewrite_resized_shard_and_replace(
+                    filename_original, temp_dir, header_metadata, length_of_header, resized,
                 )
-                if original_mode is not None:
-                    try:
-                        os.chmod(tmp_path, original_mode)
-                    except OSError:
-                        pass
-
-                del resized
-                gc.collect()
-                device_empty_cache()
-
-                for attempt in range(max_retries):
-                    try:
-                        os.replace(tmp_path, filename_original)
-                        tmp_path = None
-                        break
-                    except OSError as e:
-                        winerror  = getattr(e, "winerror", None)
-                        error_msg = str(e).lower()
-                        is_lock_error = (
-                            winerror in {32, 1224}
-                            or (
-                                winerror == 5 and (
-                                    "user-mapped" in error_msg
-                                    or "being used by another process" in error_msg
-                                    or "sharing violation" in error_msg
-                                )
-                            )
-                            or "user-mapped" in error_msg
-                            or "being used by another process" in error_msg
-                        )
-                        if is_lock_error and attempt < max_retries - 1:
-                            delay = base_delay * (2 ** attempt)
-                            if UNSLOTH_ENABLE_LOGGING:
-                                logger.warning(
-                                    f"[Retry {attempt + 1}/{max_retries}] Windows file lock "
-                                    f"detected for {filename_original}: {e}. "
-                                    f"Waiting {delay:.1f}s before retry..."
-                                )
-                            gc.collect()
-                            time.sleep(delay)
-                            continue
-                        if is_lock_error:
-                            raise RuntimeError(
-                                f"Failed to rewrite {filename_original} after {max_retries} "
-                                f"attempts due to Windows file lock. Original shard is intact "
-                                f"(atomic replace never committed). "
-                                f"Solutions: 1) Restart Unsloth Studio 2) Disable antivirus "
-                                f"3) Close File Explorer windows"
-                            ) from e
-                        raise RuntimeError(
-                            f"Model merge failed while rewriting {filename_original}: {e}"
-                        ) from e
-            finally:
-                if tmp_path is not None and os.path.exists(tmp_path):
-                    try:
-                        os.remove(tmp_path)
-                    except OSError:
-                        pass
+            del resized
+            gc.collect()
+            device_empty_cache()
 
         device_empty_cache()
         return count, safetensor_keys_seen
@@ -1556,17 +1501,16 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
 
         device = _active_merge_device()
         gate_up_merged = gate_up_W.to(device, dtype=torch.float32, non_blocking=True)
+        # Move lora_A/lora_B to device once, then slice per expert.
+        lora_A_dev = lora_stats.lora_A.to(device, dtype=torch.float32, non_blocking=True)
+        lora_B_dev = lora_stats.lora_B.to(device, dtype=torch.float32, non_blocking=True)
 
         for expert_idx in range(num_experts):
             start, end = expert_idx * rank, (expert_idx + 1) * rank
             # lora_B is contiguous-r per expert (see moe_utils.py
             # _canonical_lora_weights_for_grouped_mm); must match for the saved
             # checkpoint to reproduce the training-time forward.
-            a_slice = lora_stats.lora_A[start:end, :]
-            b_slice = lora_stats.lora_B[:, start:end]
-            delta = b_slice.to(
-                device, dtype=torch.float32, non_blocking=True
-            ) @ a_slice.to(device, dtype=torch.float32, non_blocking=True)
+            delta = lora_B_dev[:, start:end] @ lora_A_dev[start:end, :]
 
             gate_up_merged[expert_idx] = gate_up_merged[expert_idx].add(
                 delta.T if use_transpose else delta, alpha=lora_stats.alpha
@@ -1640,15 +1584,14 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
 
         device = _active_merge_device()
         down_merged = down_W.to(device, dtype=torch.float32, non_blocking=True)
+        # Move lora_A/lora_B to device once, then slice per expert.
+        lora_A_dev = lora_stats.lora_A.to(device, dtype=torch.float32, non_blocking=True)
+        lora_B_dev = lora_stats.lora_B.to(device, dtype=torch.float32, non_blocking=True)
 
         for expert_idx in range(num_experts):
             start, end = expert_idx * rank, (expert_idx + 1) * rank
             # See _merge_moe_fused_gate_up_expert for the slicing rationale.
-            a_slice = lora_stats.lora_A[start:end, :]
-            b_slice = lora_stats.lora_B[:, start:end]
-            delta = b_slice.to(
-                device, dtype=torch.float32, non_blocking=True
-            ) @ a_slice.to(device, dtype=torch.float32, non_blocking=True)
+            delta = lora_B_dev[:, start:end] @ lora_A_dev[start:end, :]
 
             down_merged[expert_idx] = down_merged[expert_idx].add(
                 delta.T if use_transpose else delta, alpha=lora_stats.alpha
@@ -1701,10 +1644,6 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
             if key in processed_mxfp4_keys:
                 continue
 
-            # FORCE memory cleanup before processing each tensor
-            device_empty_cache()
-            device_synchronize()
-
             W = None
             output_key = key
             action_logged = False
@@ -1723,7 +1662,7 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
 
                 blocks_tensor, scales_tensor = file.get_tensor(key), file.get_tensor(scales_key)
 
-                device_synchronize()
+                # Free the allocator before the large dequant alloc.
                 device_empty_cache()
 
                 # Pick device + chunk size for mxfp4 dequantization
@@ -1799,8 +1738,9 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
 
             tensors[output_key] = W
 
-            # Free up VRAM after each merge
-            device_empty_cache()
+            # Free VRAM only after a large dequant/merge, not every small tensor.
+            if W.numel() * W.element_size() >= _EMPTY_CACHE_BYTES_THRESHOLD:
+                device_empty_cache()
 
     # CRITICAL: Force cleanup to release file handles on Windows
     if os.name == 'nt':
@@ -2514,18 +2454,25 @@ def merge_and_overwrite_lora(
     safetensor_keys_seen = set()
     counted_lora_modules_global = set()
 
+    # Per-shard-invariant: resolve the base model + tie flag once, not per shard.
+    _merge_base_model = find_lora_base_model(model)
+    _merge_model_class_name = _merge_base_model.__class__.__name__
+    _merge_tie_word_embeddings = bool(
+        getattr(_merge_base_model.config, "tie_word_embeddings", False)
+    )
+
     for filename in ProgressBar(final_safetensors_list, desc=f'Unsloth: Merging weights into {"mxfp4" if save_method=="mxfp4" else "16bit"}'):
         merged_count, shard_keys = _merge_and_overwrite_lora(
             save_directory = save_directory,
             filename = filename,
             lora_weights = lora_weights,
             output_dtype = output_dtype,
-            model_class_name = find_lora_base_model(model).__class__.__name__,
+            model_class_name = _merge_model_class_name,
             base_model_is_quantized = base_model_is_quantized,
             quant_type = quant_type,
             save_method = save_method,
             counted_lora_modules = counted_lora_modules_global,
-            tie_word_embeddings = bool(getattr(find_lora_base_model(model).config, "tie_word_embeddings", False)),
+            tie_word_embeddings = _merge_tie_word_embeddings,
         )
         n_saved_modules += merged_count
         safetensor_keys_seen.update(shard_keys)
@@ -3856,6 +3803,115 @@ def _stream_rewrite_resized_shard(src_path, dst_path, header_metadata, length_of
 pass
 
 
+def _estimate_resized_shard_bytes(header_metadata, resized, length_of_header):
+    # Size of the rewritten shard: resized tensors at their new byte count, the
+    # rest at their current slot, plus the header.
+    total = 0
+    for k, entry in header_metadata.items():
+        if k == "__metadata__":
+            continue
+        if k in resized:
+            t = resized[k]
+            total += t.numel() * t.element_size()
+        else:
+            o0, o1 = entry["data_offsets"]
+            total += o1 - o0
+    return total + 8 + length_of_header
+
+
+def _inplace_rewrite_resized_shard(filename_original, header_metadata, resized):
+    # Low-disk fallback for a resized shard: reload it, swap in the resized tensors,
+    # and save_file over the original (higher peak RAM, but no transient 2x-shard
+    # disk). Mirrors the pre-streaming behaviour for tight-disk / low-disk jobs.
+    meta = header_metadata.get("__metadata__", None)
+    tensors = {}
+    with safe_open(filename_original, framework = "pt", device = "cpu") as f:
+        for key in f.keys():
+            tensors[key] = resized[key] if key in resized else f.get_tensor(key)
+    save_file(tensors, filename_original, metadata = meta)
+    tensors.clear()
+
+
+def _stream_rewrite_resized_shard_and_replace(filename_original, temp_dir, header_metadata, length_of_header, resized):
+    # Stream the resized shard to a temp file then atomically os.replace it in
+    # (peak RAM ~ one tensor). Used when disk has room for the transient copy.
+    max_retries = 5
+    base_delay  = 0.2  # seconds
+    try:
+        original_mode = os.stat(filename_original).st_mode
+    except OSError:
+        original_mode = None
+
+    fd, tmp_path = tempfile.mkstemp(dir=temp_dir, suffix=".safetensors.tmp")
+    os.close(fd)
+
+    try:
+        _stream_rewrite_resized_shard(
+            src_path = filename_original,
+            dst_path = tmp_path,
+            header_metadata = header_metadata,
+            length_of_header = length_of_header,
+            resized = resized,
+        )
+        if original_mode is not None:
+            try:
+                os.chmod(tmp_path, original_mode)
+            except OSError:
+                pass
+
+        gc.collect()
+        device_empty_cache()
+
+        for attempt in range(max_retries):
+            try:
+                os.replace(tmp_path, filename_original)
+                tmp_path = None
+                break
+            except OSError as e:
+                winerror  = getattr(e, "winerror", None)
+                error_msg = str(e).lower()
+                is_lock_error = (
+                    winerror in {32, 1224}
+                    or (
+                        winerror == 5 and (
+                            "user-mapped" in error_msg
+                            or "being used by another process" in error_msg
+                            or "sharing violation" in error_msg
+                        )
+                    )
+                    or "user-mapped" in error_msg
+                    or "being used by another process" in error_msg
+                )
+                if is_lock_error and attempt < max_retries - 1:
+                    delay = base_delay * (2 ** attempt)
+                    if UNSLOTH_ENABLE_LOGGING:
+                        logger.warning(
+                            f"[Retry {attempt + 1}/{max_retries}] Windows file lock "
+                            f"detected for {filename_original}: {e}. "
+                            f"Waiting {delay:.1f}s before retry..."
+                        )
+                    gc.collect()
+                    time.sleep(delay)
+                    continue
+                if is_lock_error:
+                    raise RuntimeError(
+                        f"Failed to rewrite {filename_original} after {max_retries} "
+                        f"attempts due to Windows file lock. Original shard is intact "
+                        f"(atomic replace never committed). "
+                        f"Solutions: 1) Restart Unsloth Studio 2) Disable antivirus "
+                        f"3) Close File Explorer windows"
+                    ) from e
+                raise RuntimeError(
+                    f"Model merge failed while rewriting {filename_original}: {e}"
+                ) from e
+    finally:
+        if tmp_path is not None and os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+
 def _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key, tensor, output_dtype):
     """
     Write tensor directly to memory-mapped file using pure PyTorch operations
@@ -3885,9 +3941,10 @@ def _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key
             return False
 
         # Zero-copy write into the mmap; avoids the bytes() copy that doubled peak
-        # RAM on large tensors (embed / lm_head). Flatten first so the mmap slice
-        # gets a 1D buffer (multi-dim memoryview assignment errors on some Pythons).
-        tensor_view = tensor_formatted.detach().contiguous().reshape(-1).view(torch.uint8)
+        # RAM on large tensors (embed / lm_head). tensor_formatted is already
+        # contiguous CPU; reshape(-1) gives the 1D buffer the mmap slice needs
+        # (multi-dim memoryview assignment errors on some Pythons).
+        tensor_view = tensor_formatted.detach().reshape(-1).view(torch.uint8)
         mm[index_L:index_R] = memoryview(tensor_view.numpy())
 
         # Clear memory


### PR DESCRIPTION
## Summary

Optimizes the LoRA-merge to 16bit safetensors save path (`merge_and_overwrite_lora` in `unsloth_zoo/saving_utils.py`) and adds the first end-to-end correctness coverage for the whole merge pipeline. Output is tensor-identical to the previous behavior (byte-identical for the safetensors-written shards real models ship); only memory and timing change.

Rebased onto current `main`, so it now includes the Gemma-4/Qwen3.5 narrow-expert fused MoE fix (#779). Without that fix the fused merge on this branch dropped expert deltas; the new tests caught it, and the rebase resolves it cleanly.

## Optimizations

- Drop the per-tensor `device_empty_cache()` / `device_synchronize()` churn in the merge hot loop (standard and mxfp4 paths). Cleanup now runs only after a real GPU merge on a large tensor (>= 256MB) plus once at shard end. The post-merge `.cpu()` is synchronous, so removing the per-key sync introduces no async-copy hazard.
- Stream the vocab-resized shard rewrite to a temp file with an atomic `os.replace` (lower peak RAM, and crash-safe where `main` overwrote the shard in place). When free disk cannot fit the transient shard, fail closed and leave the original shard intact rather than risk a non-atomic in-place overwrite; set `UNSLOTH_ALLOW_NON_ATOMIC_RESIZED_REWRITE=1` to opt into the in-place rewrite for tight-disk jobs.
- Zero-copy mmap write: replace the `ctypes` / `bytes()` buffer copy in `_write_tensor_direct_torch` with a zero-copy `reshape(-1).view(torch.uint8)` + `memoryview` (the existing `.contiguous()` stays, guaranteeing the view shares storage). Halves peak RAM on large tensors and fixes a latent crash on 0-dim scalar tensors.
- Hoist per-shard-invariant lookups out of the merge loop; transfer the fused-MoE LoRA matrices to device once per layer instead of per expert.

## End-to-end correctness test suite

New `tests/test_merge_e2e_*.py` (plus `tests/_merge_e2e_helpers.py`) drive the real `merge_and_overwrite_lora` path on tiny but architecturally-real configs and verify every saved tensor against an independent reference: adapted modules equal `base + scale * (B @ A)`; every untargeted tensor (norms, router, biases, untargeted experts, vision tower) stays byte-identical to the base. This is the first coverage of the merge orchestration itself (key remap, sharding, pass-through, resized rewrite, MoE dispatch); existing tests only unit-test the merge primitives.

Coverage:
- Dense (Llama / Qwen3 / Mistral / Gemma2): full, attention-only, MLP-only, per-module alpha+rank patterns, bf16 output, forced multi-shard.
- Per-expert MoE (Qwen3-MoE, GLM4-MoE), including the no-expert-LoRA negative case proving experts stay byte-identical when untargeted.
- Fused-3D MoE (gpt-oss on 4.57.6 and 5.x; Qwen3.5 / Gemma4 / LFM2 gated to 5.x): grouped expert LoRA via `target_parameters`, per-expert reference with auto-detected orientation, distinct dims so a transpose bug cannot pass by luck.
- Vocab-grow / resized rewrite: embed/lm_head grow with old rows preserved.
- Vision (Gemma3): language-only LoRA merges exactly while the vision tower stays byte-identical.

Green on both CI transformers lanes (4.57.6 and 5.x). Families whose tiny-config key layout drifts across transformers versions skip with a clear reason rather than fail.

## Notes

- Verified output-neutral: running the same seeded merge under this branch vs `main` produces bit-identical merged tensors across dense, per-expert MoE, fused MoE, and resized scenarios.
- Touches the same file as #773 (VLM key-format remap). If #773 lands first this will rebase on top of it; the vision test already exercises the composite-model key remap path.

