### PR TITLE
Fix Gemma-4 26B-A4B MoE LoRA merge dropping expert deltas

### DIFF
--- a/tests/test_moe_fused_narrow_expert_merge.py
+++ b/tests/test_moe_fused_narrow_expert_merge.py
@@ -16,17 +16,12 @@
 
 """CPU regression for the fused-3D MoE merge on narrow-expert layouts.
 
-Gemma-4 26B-A4B is a narrow-expert MoE: per expert gate_up is
-(2*intermediate, hidden) with 2*intermediate < hidden, and down is
-(hidden, intermediate). _merge_moe_experts_file infers the fused layout
-from a tensor-shape magnitude check and passes it as is_transposed; that
-check assumes 2*intermediate > hidden, so it mislabels these tensors as
-transposed and the per-expert delta is added with the wrong orientation,
-falling back to the base weight and silently dropping the LoRA delta.
-
-These tests feed the fused mergers a narrow-expert standard layout, both
-with no hint and with the WRONG is_transposed=True hint, and require the
-delta to be applied correctly (the LoRA-dimension layout must win).
+In a narrow-expert MoE (Gemma-4 26B-A4B, Qwen3.5-35B-A3B) gate_up is
+(2*intermediate, hidden) with 2*intermediate < hidden. The shape-magnitude
+heuristic assumes 2*intermediate > hidden, so it mislabels these as transposed
+and drops the LoRA delta. These tests feed a narrow-expert standard layout (no
+hint, and the WRONG is_transposed=True hint) and require the delta to still be
+applied -- the LoRA-dimension layout must win.
 """
 
 from __future__ import annotations
@@ -45,7 +40,6 @@ from unsloth_zoo.saving_utils import (
 SEED = 5410
 NUM_EXPERTS, RANK, ALPHA = 4, 2, 8.0
 # Narrow-expert ratios (2*intermediate < hidden), scaled down from real models.
-# Both Gemma-4 26B-A4B and Qwen3.5-35B-A3B fall in this class.
 GEOMS = {"gemma4_26B_A4B": (16, 3), "qwen3_5_35B_A3B": (18, 4)}  # (hidden, intermediate)
 
 

--- a/tests/test_moe_fused_narrow_expert_merge.py
+++ b/tests/test_moe_fused_narrow_expert_merge.py
@@ -43,21 +43,23 @@ from unsloth_zoo.saving_utils import (
 )
 
 SEED = 5410
-# Narrow expert (Gemma-4 26B-A4B ratio): 2*intermediate < hidden.
-NUM_EXPERTS, RANK, HIDDEN, INTERMEDIATE, ALPHA = 4, 2, 16, 3, 8.0
+NUM_EXPERTS, RANK, ALPHA = 4, 2, 8.0
+# Narrow-expert ratios (2*intermediate < hidden), scaled down from real models.
+# Both Gemma-4 26B-A4B and Qwen3.5-35B-A3B fall in this class.
+GEOMS = {"gemma4_26B_A4B": (16, 3), "qwen3_5_35B_A3B": (18, 4)}  # (hidden, intermediate)
 
 
-def _build(dtype=torch.float32):
+def _build(hidden, intermediate, dtype=torch.float32):
     torch.manual_seed(SEED)
     TR = NUM_EXPERTS * RANK
-    twoI = 2 * INTERMEDIATE
-    gate_up_W = torch.randn(NUM_EXPERTS, twoI, HIDDEN, dtype=dtype)          # (E, 2I, H)
-    down_W    = torch.randn(NUM_EXPERTS, HIDDEN, INTERMEDIATE, dtype=dtype)  # (E, H, I)
+    twoI = 2 * intermediate
+    gate_up_W = torch.randn(NUM_EXPERTS, twoI, hidden, dtype=dtype)          # (E, 2I, H)
+    down_W    = torch.randn(NUM_EXPERTS, hidden, intermediate, dtype=dtype)  # (E, H, I)
     # standard PEFT fused: lora_A=(E*r, in), lora_B=(out, E*r)
-    A_gu = torch.randn(TR, HIDDEN, dtype=dtype) * 0.05
+    A_gu = torch.randn(TR, hidden, dtype=dtype) * 0.05
     B_gu = torch.randn(twoI, TR, dtype=dtype) * 0.05
-    A_dn = torch.randn(TR, INTERMEDIATE, dtype=dtype) * 0.05
-    B_dn = torch.randn(HIDDEN, TR, dtype=dtype) * 0.05
+    A_dn = torch.randn(TR, intermediate, dtype=dtype) * 0.05
+    B_dn = torch.randn(hidden, TR, dtype=dtype) * 0.05
     return gate_up_W, down_W, A_gu, B_gu, A_dn, B_dn
 
 
@@ -69,10 +71,12 @@ def _reference(W, A, B, alpha):
     return out
 
 
-# is_transposed=True is the wrong value the magnitude heuristic produces here.
+# is_transposed=True is the wrong value the magnitude heuristic produces for these.
+@pytest.mark.parametrize("model", sorted(GEOMS))
 @pytest.mark.parametrize("hint", [None, True])
-def test_fused_narrow_expert_merge_applies_delta(hint):
-    gate_up_W, down_W, A_gu, B_gu, A_dn, B_dn = _build()
+def test_fused_narrow_expert_merge_applies_delta(model, hint):
+    hidden, intermediate = GEOMS[model]
+    gate_up_W, down_W, A_gu, B_gu, A_dn, B_dn = _build(hidden, intermediate)
     stats_gu = LoraStats(module=None, lora_A=A_gu, lora_B=B_gu, alpha=ALPHA)
     stats_dn = LoraStats(module=None, lora_A=A_dn, lora_B=B_dn, alpha=ALPHA)
     kw = {} if hint is None else {"is_transposed": hint}

--- a/tests/test_moe_fused_narrow_expert_merge.py
+++ b/tests/test_moe_fused_narrow_expert_merge.py
@@ -1,0 +1,95 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""CPU regression for the fused-3D MoE merge on narrow-expert layouts.
+
+Gemma-4 26B-A4B is a narrow-expert MoE: per expert gate_up is
+(2*intermediate, hidden) with 2*intermediate < hidden, and down is
+(hidden, intermediate). _merge_moe_experts_file infers the fused layout
+from a tensor-shape magnitude check and passes it as is_transposed; that
+check assumes 2*intermediate > hidden, so it mislabels these tensors as
+transposed and the per-expert delta is added with the wrong orientation,
+falling back to the base weight and silently dropping the LoRA delta.
+
+These tests feed the fused mergers a narrow-expert standard layout, both
+with no hint and with the WRONG is_transposed=True hint, and require the
+delta to be applied correctly (the LoRA-dimension layout must win).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from unsloth_zoo.saving_utils import (
+    LoraStats,
+    _MOE_MERGE_STATE,
+    _merge_moe_fused_down_proj_expert,
+    _merge_moe_fused_gate_up_expert,
+    _reset_moe_merge_state,
+)
+
+SEED = 5410
+# Narrow expert (Gemma-4 26B-A4B ratio): 2*intermediate < hidden.
+NUM_EXPERTS, RANK, HIDDEN, INTERMEDIATE, ALPHA = 4, 2, 16, 3, 8.0
+
+
+def _build(dtype=torch.float32):
+    torch.manual_seed(SEED)
+    TR = NUM_EXPERTS * RANK
+    twoI = 2 * INTERMEDIATE
+    gate_up_W = torch.randn(NUM_EXPERTS, twoI, HIDDEN, dtype=dtype)          # (E, 2I, H)
+    down_W    = torch.randn(NUM_EXPERTS, HIDDEN, INTERMEDIATE, dtype=dtype)  # (E, H, I)
+    # standard PEFT fused: lora_A=(E*r, in), lora_B=(out, E*r)
+    A_gu = torch.randn(TR, HIDDEN, dtype=dtype) * 0.05
+    B_gu = torch.randn(twoI, TR, dtype=dtype) * 0.05
+    A_dn = torch.randn(TR, INTERMEDIATE, dtype=dtype) * 0.05
+    B_dn = torch.randn(HIDDEN, TR, dtype=dtype) * 0.05
+    return gate_up_W, down_W, A_gu, B_gu, A_dn, B_dn
+
+
+def _reference(W, A, B, alpha):
+    out = W.clone().to(torch.float64)
+    for e in range(NUM_EXPERTS):
+        s, t = e * RANK, (e + 1) * RANK
+        out[e] += alpha * (B[:, s:t].to(torch.float64) @ A[s:t, :].to(torch.float64))
+    return out
+
+
+# is_transposed=True is the wrong value the magnitude heuristic produces here.
+@pytest.mark.parametrize("hint", [None, True])
+def test_fused_narrow_expert_merge_applies_delta(hint):
+    gate_up_W, down_W, A_gu, B_gu, A_dn, B_dn = _build()
+    stats_gu = LoraStats(module=None, lora_A=A_gu, lora_B=B_gu, alpha=ALPHA)
+    stats_dn = LoraStats(module=None, lora_A=A_dn, lora_B=B_dn, alpha=ALPHA)
+    kw = {} if hint is None else {"is_transposed": hint}
+
+    _reset_moe_merge_state()
+    gu_out = _merge_moe_fused_gate_up_expert(gate_up_W.clone(), stats_gu, torch.float32, **kw)
+    dn_out = _merge_moe_fused_down_proj_expert(down_W.clone(), stats_dn, torch.float32, **kw)
+
+    gu_ref = _reference(gate_up_W, A_gu, B_gu, ALPHA)
+    dn_ref = _reference(down_W, A_dn, B_dn, ALPHA)
+    gu_err = (gu_out.cpu().to(torch.float64) - gu_ref).abs().max().item()
+    dn_err = (dn_out.cpu().to(torch.float64) - dn_ref).abs().max().item()
+
+    assert _MOE_MERGE_STATE["fallback"] == 0, _MOE_MERGE_STATE["first_error"]
+    assert _MOE_MERGE_STATE["applied"] == 2
+    assert gu_err < 1e-4 and dn_err < 1e-4, f"gate_up={gu_err:.2e} down={dn_err:.2e}"
+    # delta must actually be applied, not the base written through
+    assert not torch.equal(gu_out.cpu(), gate_up_W)
+    assert not torch.equal(dn_out.cpu(), down_W)
+    _reset_moe_merge_state()

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1545,12 +1545,16 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
             )
             return gate_up_W
 
-        if is_transposed is not None:
-            use_transpose = is_transposed
-        elif dim_A == dim1 and dim_B == dim2:
-            use_transpose = True
-        elif dim_A == dim2 and dim_B == dim1:
+        # LoRA dims fix the layout: standard (E,out,in) has dim_A==dim2, dim_B==dim1;
+        # transposed (E,in,out) the reverse. Hint only breaks the square (in==out) tie.
+        std = (dim_A == dim2 and dim_B == dim1)
+        trn = (dim_A == dim1 and dim_B == dim2)
+        if std and not trn:
             use_transpose = False
+        elif trn and not std:
+            use_transpose = True
+        elif is_transposed is not None:
+            use_transpose = is_transposed
         else:
             _record_moe_merge_fallback(
                 "fused_gate_up", -1,
@@ -1625,12 +1629,16 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
             )
             return down_W
 
-        if is_transposed is not None:
-            use_transpose = is_transposed
-        elif dim_A == dim1 and dim_B == dim2:
-            use_transpose = True
-        elif dim_A == dim2 and dim_B == dim1:
+        # LoRA dims fix the layout: standard (E,out,in) has dim_A==dim2, dim_B==dim1;
+        # transposed (E,in,out) the reverse. Hint only breaks the square (in==out) tie.
+        std = (dim_A == dim2 and dim_B == dim1)
+        trn = (dim_A == dim1 and dim_B == dim2)
+        if std and not trn:
             use_transpose = False
+        elif trn and not std:
+            use_transpose = True
+        elif is_transposed is not None:
+            use_transpose = is_transposed
         else:
             _record_moe_merge_fallback(
                 "fused_down", -1,


### PR DESCRIPTION
## Summary

Merging a LoRA into a narrow-expert fused MoE silently drops the expert LoRA delta. On `unsloth/gemma-4-26B-A4B-it`, `save_pretrained_merged` reports:

```
Unsloth: MoE LoRA merge fell back to the base weight on 57 per-expert tensor(s) (of 60 attempted, 3 applied).
... reason=RuntimeError('The size of tensor a (704) must match the size of tensor b (2816) at non-singleton dimension 1')
lora_A=(4096, 704) lora_B=(2816, 4096) per_expert_W=(128, 2816, 704)
```

and the merged 16-bit / GGUF checkpoint ends up as the base model plus only a fraction of the expert deltas.

## Cause

`_merge_moe_experts_file` infers the fused `gate_up_proj` / `down_proj` layout from a tensor-shape magnitude check and passes it to the fused mergers as `is_transposed`:

```python
_is_transposed_format = shape[2] > shape[1]
```

That assumes `2*intermediate > hidden`. Narrow-expert MoEs, where the per-expert intermediate size is smaller than hidden, break the assumption (e.g. Gemma-4 26B-A4B per expert `gate_up` is `(2I=1408, H=2816)`, `down` is `(H=2816, I=704)`; Qwen3.5-35B-A3B is `(2I=1024, H=1152)` and `(H=1152, I=512)`). The hint then labels the standard layout as transposed, the per-expert delta is added with the wrong orientation, the shapes do not line up, and the tensor falls back to the base weight.

## Fix

Use the LoRA dimensions, which unambiguously encode in/out, as the source of truth for the layout in both `_merge_moe_fused_gate_up_expert` and `_merge_moe_fused_down_proj_expert`:

- standard `(E, out, in)`: `lora_A` in-dim == `W` dim2 and `lora_B` out-dim == `W` dim1
- transposed `(E, in, out)`: the reverse

`is_transposed` is now consulted only to break the genuinely ambiguous square (`in == out`) case, so the existing wide/transposed (GPT-OSS) path is unaffected.

## Verification

End-to-end on the real models (short QLoRA finetune, then `save_pretrained_merged`), comparing the previous code against this fix on the same adapter and a fresh base copy:

| Model | Expert format | Geometry | Before | After |
|---|---|---|---|---|
| gemma-4-26B-A4B-it | fused 3D | narrow (2I<H) | 3 of 60 applied (fallback) | 60 of 60 applied, fallback=0 |
| Qwen3.5-35B-A3B | fused 3D | narrow (2I<H) | 40 of 80 applied (fallback) | 80 of 80 applied, fallback=0 |
| gpt-oss-20b-BF16 | fused 3D | wide (2I>H) | 48 of 48 applied | 48 of 48 applied, byte-identical output |
| Qwen3-30B-A3B | per-expert 2D | n/a (separate path) | 18432 applied | 18432 applied, byte-identical output |
| GLM-4.7-Flash | per-expert 2D | n/a (separate path) | 8832 applied | 8832 applied, byte-identical output |

So the fix repairs the narrow-fused case (two real models), leaves the wide/transposed fused case (gpt-oss) byte-identical, and does not touch the per-expert path (Qwen3-30B, GLM).

The new CPU regression test `tests/test_moe_fused_narrow_expert_merge.py` builds narrow-expert standard layouts at both the Gemma-4 26B-A4B and Qwen3.5-35B-A3B ratios and feeds the wrong `is_transposed=True` hint; it fails on the old code with the exact fallback and passes with this fix.
