### PR TITLE
fix(tests): import unsloth_zoo (not unsloth) in fresh-interpreter pickle tests

### DIFF
--- a/tests/test_prepare_model_for_training_fp32_norms.py
+++ b/tests/test_prepare_model_for_training_fp32_norms.py
@@ -386,9 +386,12 @@ def test_wrapper_unpickles_in_fresh_interpreter(tmp_path):
     torch.save(m, str(blob))
 
     tests_dir = os.path.dirname(os.path.abspath(__file__))
+    # Import unsloth_zoo, not unsloth: reconstruction only needs the __reduce__
+    # target in unsloth_zoo.training_utils, and unsloth is GPU-only so it cannot
+    # import on the CPU CI runner.
     script = (
         "import sys; sys.path.insert(0, %r);"
-        "import unsloth, torch;"
+        "import unsloth_zoo, torch;"
         "m = torch.load(%r, weights_only=False);"
         "assert type(m).__qualname__.endswith('WithUnslothBf16Autocast'), type(m).__qualname__;"
         "out = m(torch.zeros(2, 8, dtype=torch.bfloat16));"
@@ -796,9 +799,12 @@ def test_instance_forward_wrapper_unpickles_in_fresh_interpreter(tmp_path):
     torch.save(m, str(blob))
 
     tests_dir = os.path.dirname(os.path.abspath(__file__))
+    # Import unsloth_zoo, not unsloth: reconstruction only needs the __reduce__
+    # target in unsloth_zoo.training_utils, and unsloth is GPU-only so it cannot
+    # import on the CPU CI runner.
     script = (
         "import sys; sys.path.insert(0, %r);"
-        "import unsloth, torch;"
+        "import unsloth_zoo, torch;"
         "m = torch.load(%r, weights_only=False);"
         "out = m(torch.zeros(2, 8, dtype=torch.bfloat16));"
         "assert tuple(out.shape) == (2, 8);"


### PR DESCRIPTION
## Problem

The CPU pytest job crashes in two tests in
`tests/test_prepare_model_for_training_fp32_norms.py`:

- `test_wrapper_unpickles_in_fresh_interpreter`
- `test_instance_forward_wrapper_unpickles_in_fresh_interpreter`

Each spawns a fresh interpreter that runs `import unsloth`. `unsloth` is
GPU-only. On the CPU runner, `UNSLOTH_ALLOW_CPU=1` makes `get_device_type()`
return `"cuda"` even with no device, so the import reaches
`torch.cuda.get_device_capability()` and raises:

```
RuntimeError: No CUDA GPUs are available
```

The subprocess exits non-zero, the `FRESH_OK` assertion fails, and the job goes
red. The other tests in the file pass because they only `import unsloth_zoo`,
which imports fine on CPU.

## Fix

These tests verify that a `torch.save(model)` pickle reconstructs in a genuinely
fresh interpreter. That reconstruction is driven by `__reduce__` via
`unsloth_zoo.training_utils._reconstruct_bf16_autocast_model`, so the subprocess
only needs `unsloth_zoo`, not the full GPU-only `unsloth`. Switch the import
accordingly. No production code changes.

## Validation

Reproduced the CI condition locally (`CUDA_VISIBLE_DEVICES="" UNSLOTH_ALLOW_CPU=1`):

- Before: the `import unsloth` subprocess exits 1 with `No CUDA GPUs are available`.
- After: all 29 tests in the file pass.