### PR TITLE
fix(mlx): enforce save_total_limit checkpoint rotation

### DIFF
--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -364,6 +364,34 @@ def _clip_grad_norm_fp32(grad, max_norm):
     return tree_map(lambda g: g * scale.astype(g.dtype), grad), total_norm
 
 
+def _prune_stale_checkpoints(output_dir, save_total_limit):
+    """Keep the newest ``save_total_limit`` checkpoint-* dirs (HF Trainer parity).
+
+    ``-1`` / ``0`` / ``None`` preserve the existing "no limit" contract.
+    """
+    if not save_total_limit or save_total_limit < 1:
+        return
+    import shutil
+    from pathlib import Path
+
+    checkpoints = []
+    for child in Path(output_dir).glob("checkpoint-*"):
+        # Only prune real step-checkpoint dirs the trainer created; never
+        # follow symlinks or touch user paths that share the prefix.
+        if child.is_symlink() or not child.is_dir():
+            continue
+        try:
+            step = int(child.name.removeprefix("checkpoint-"))
+        except ValueError:
+            continue
+        checkpoints.append((step, child))
+    checkpoints.sort()
+    for _, stale in checkpoints[:-save_total_limit]:
+        shutil.rmtree(stale, ignore_errors=True)
+        print(f"  Unsloth: pruned old checkpoint {stale} "
+              f"(save_total_limit={save_total_limit})")
+
+
 @dataclass
 class MLXTrainingConfig:
     """Training configuration mirroring SFTConfig / TrainingArguments field names."""
@@ -1779,6 +1807,7 @@ class MLXTrainer:
                     except Exception as e:
                         print(f"  Unsloth: checkpoint saved without resume state ({e})")
                     print(f"  Saved checkpoint to {ckpt_dir}")
+                    _prune_stale_checkpoints(args.output_dir, args.save_total_limit)
 
         total_time = time.perf_counter() - start_time
         avg_loss = (

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1801,6 +1801,7 @@ class MLXTrainer:
                     # can restore Adam moments, step counter, and loss history.
                     # Adapter save was successful -- treat the extra writes as
                     # best-effort: log on failure but don't undo the adapter save.
+                    checkpoint_complete = False
                     try:
                         save_optimizer_state(optimizer, ckpt_dir)
                         save_trainer_state(
@@ -1810,10 +1811,12 @@ class MLXTrainer:
                             },
                             ckpt_dir,
                         )
+                        checkpoint_complete = True
                     except Exception as e:
                         print(f"  Unsloth: checkpoint saved without resume state ({e})")
                     print(f"  Saved checkpoint to {ckpt_dir}")
-                    _prune_stale_checkpoints(args.output_dir, args.save_total_limit)
+                    if checkpoint_complete:
+                        _prune_stale_checkpoints(args.output_dir, args.save_total_limit)
 
         total_time = time.perf_counter() - start_time
         avg_loss = (

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -385,9 +385,15 @@ def _prune_stale_checkpoints(output_dir, save_total_limit):
         except ValueError:
             continue
         checkpoints.append((step, child))
+    if len(checkpoints) <= save_total_limit:
+        return
     checkpoints.sort()
     for _, stale in checkpoints[:-save_total_limit]:
-        shutil.rmtree(stale, ignore_errors=True)
+        try:
+            shutil.rmtree(stale)
+        except Exception as exc:
+            print(f"  Unsloth: failed to prune old checkpoint {stale}: {exc}")
+            continue
         print(f"  Unsloth: pruned old checkpoint {stale} "
               f"(save_total_limit={save_total_limit})")
 


### PR DESCRIPTION
## Summary

Adds MLX checkpoint rotation support for `save_total_limit`, matching the regular Hugging Face Trainer checkpoint retention behavior.

When MLXTrainer saves `checkpoint-{step}` during training, it now prunes older numeric checkpoint directories and keeps the newest `save_total_limit` checkpoints.

## Details

- Adds `_prune_stale_checkpoints()`
- Keeps newest numeric `checkpoint-*` directories by step number
- Ignores nonnumeric checkpoint-like paths such as `checkpoint-best`
- Ignores files and symlinks
- Treats `None`, `0`, and negative limits as no limit
- Runs pruning only after a checkpoint is saved successfully

## Validation

- Compared behavior against `transformers.trainer_utils.rotate_checkpoints()`
- Tested `save_total_limit=None`, `-1`, `0`, `1`, `2`, and `10`
- Ran `python -m compileall -q unsloth_zoo/mlx/trainer.py`
- Ran `git diff --check`