### PR TITLE
Fix fast_inference crash on vLLM >= 0.22 (removed transformers_utils.tokenizer)

### DIFF
--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -325,12 +325,8 @@ if importlib.util.find_spec("vllm") is not None:
 
     def patch_vllm_lora_tokenizer():
         # All Unsloth Zoo code licensed under LGPLv3
-        # vLLM >= 0.22 removed `vllm.transformers_utils.tokenizer` (vLLM PR
-        # #35024, shipped in v0.21.1rc0 / v0.22.0; the `tokenizer_group` package
-        # and the per-LoRA tokenizers themselves went earlier in PR #24078).
-        # LoRA adapters now always reuse the base tokenizer, so there is nothing
-        # to patch and the import raises `No module named
-        # 'vllm.transformers_utils.tokenizer'` - guard it like the others below.
+        # vLLM >= 0.22 (PR #35024) removed this module; LoRA now reuses the base
+        # tokenizer, so guard the import like the tokenizer_group ones below.
         try:
             import vllm.transformers_utils.tokenizer
             vllm.transformers_utils.tokenizer.get_lora_tokenizer = _return_nothing

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -335,7 +335,7 @@ if importlib.util.find_spec("vllm") is not None:
             import vllm.transformers_utils.tokenizer
             vllm.transformers_utils.tokenizer.get_lora_tokenizer = _return_nothing
             vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing
-        except:
+        except ImportError:
             pass
 
         try:

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -324,9 +324,19 @@ if importlib.util.find_spec("vllm") is not None:
     pass
 
     def patch_vllm_lora_tokenizer():
-        import vllm.transformers_utils.tokenizer
-        vllm.transformers_utils.tokenizer.get_lora_tokenizer = _return_nothing
-        vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing
+        # All Unsloth Zoo code licensed under LGPLv3
+        # vLLM >= 0.22 removed `vllm.transformers_utils.tokenizer` (vLLM PR
+        # #35024, shipped in v0.21.1rc0 / v0.22.0; the `tokenizer_group` package
+        # and the per-LoRA tokenizers themselves went earlier in PR #24078).
+        # LoRA adapters now always reuse the base tokenizer, so there is nothing
+        # to patch and the import raises `No module named
+        # 'vllm.transformers_utils.tokenizer'` - guard it like the others below.
+        try:
+            import vllm.transformers_utils.tokenizer
+            vllm.transformers_utils.tokenizer.get_lora_tokenizer = _return_nothing
+            vllm.transformers_utils.tokenizer.get_lora_tokenizer_async = _return_nothing
+        except:
+            pass
 
         try:
             import vllm.transformers_utils.tokenizer_group.tokenizer_group


### PR DESCRIPTION
## Problem
Loading a model with `fast_inference=True` on recent vLLM crashes with:

    ModuleNotFoundError: No module named 'vllm.transformers_utils.tokenizer'

Reported in unslothai/unsloth#6385 (Colab, vLLM via pip, GRPO + fast_inference).

## Root cause
`patch_vllm_lora_tokenizer()` starts with an **unguarded** `import vllm.transformers_utils.tokenizer`.
vLLM deleted that module in vllm-project/vllm#35024 (shipped v0.21.1rc0 / v0.22.0,
still gone in the latest v0.23.0). The functions it patched — `get_lora_tokenizer` /
`get_lora_tokenizer_async` — were removed even earlier in vllm-project/vllm#24078
("Remove tokenizer group"); LoRA adapters now reuse the base tokenizer natively, so
there is nothing left to patch. The two `tokenizer_group` imports just below were
already wrapped in `try/except`; only this first import was not.

## Fix
Wrap the first import in `try/except` to match the others. No behaviour change on older
vLLM (module present → patched as before); a correct no-op on new vLLM.

Call path: `FastLanguageModel.from_pretrained(fast_inference=True)` → `fast_inference_setup()`
→ `patch_vllm()` → `patch_vllm_lora_tokenizer()`.


Companion defensive shim in the main repo: unslothai/unsloth#6390.
