### PR TITLE
fix(mlx): align response-mask batching with CUDA

### DIFF
--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -350,13 +350,13 @@ def test_evaluate_dict_eval_datasets_records_split_metrics():
     trainer.model = Model()
     trainer.stop_requested = False
 
-    def loss_fn(_model, name):
+    def loss_fn(_model, name, _lengths, _labels):
         if name == "small":
             return mx.array(1.0), mx.array(2)
         return mx.array(3.0), mx.array(6)
 
     loss, ppl = trainer._evaluate(
-        {"small": [("small",)], "large": [("large",)]},
+        {"small": [("small", None, None)], "large": [("large", None, None)]},
         loss_fn,
         is_vlm=False,
     )

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -331,6 +331,31 @@ def test_train_on_responses_only_forwards_last_response_only(monkeypatch):
     assert received["last_response_only"] is True
 
 
+def test_response_mask_tokenizer_rejects_encode_only_tokenizer():
+    from unsloth_zoo.mlx.trainer import _resolve_response_mask_tokenizer
+
+    class EncodeOnlyTokenizer:
+        def encode(self, text):
+            return [1, 2, 3]
+
+        def convert_tokens_to_ids(self, token):
+            return 1
+
+    with pytest.raises(TypeError, match="requires a callable"):
+        _resolve_response_mask_tokenizer(EncodeOnlyTokenizer())
+
+
+def test_vlm_eval_batches_define_completion_only_loss_before_use():
+    import inspect
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    source = inspect.getsource(MLXTrainer._train_inner)
+    definition = source.index("text_completion_only_loss = _text_completion_only_loss_arg(args)")
+    eval_use = source.index("completion_only_loss=text_completion_only_loss")
+    assert definition < eval_use
+
+
 def test_evaluate_dict_eval_datasets_records_split_metrics():
     import mlx.core as mx
 

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -62,8 +62,26 @@ def test_mlx_training_config_is_dataclass_with_all_fields():
         "gradient_checkpointing",
         "dataset_order",
         "preserve_dataset_order",
+        "completion_only_loss",
     ):
         assert must_have in fields, f"missing field: {must_have}"
+
+
+def test_mlx_training_config_exposes_completion_only_loss():
+    from unsloth_zoo.mlx.trainer import (
+        MLXTrainingConfig,
+        _text_completion_only_loss_arg,
+    )
+
+    assert _text_completion_only_loss_arg(
+        MLXTrainingConfig(completion_only_loss=False)
+    ) is False
+    assert _text_completion_only_loss_arg(
+        MLXTrainingConfig(completion_only_loss=True)
+    ) is True
+    assert _text_completion_only_loss_arg(
+        MLXTrainingConfig(train_on_completions=True)
+    ) is True
 
 
 @pytest.mark.parametrize("optim_name", ["adamw", "adam", "sgd", "adafactor"])
@@ -292,6 +310,28 @@ def test_mlx_text_dataset_does_not_append_eos(monkeypatch):
     # trains the model to predict EOS.
     dataset_default = _prepare_dataset([{"text": "hello"}], Tokenizer())
     assert dataset_default[0] == ([1, 2, 3, 99], 0)
+
+
+def test_encode_mlx_text_keeps_raw_text_bos_when_template_has_bos():
+    from unsloth_zoo.mlx.utils import encode_mlx_text
+
+    class Tokenizer:
+        bos_token = "<s>"
+        chat_template = "{{ bos_token }}{{ messages }}"
+
+        def __init__(self):
+            self.add_special_tokens_seen = []
+
+        def encode(self, text, add_special_tokens=True):
+            self.add_special_tokens_seen.append(add_special_tokens)
+            return [1, 2, 3]
+
+    tokenizer = Tokenizer()
+
+    encode_mlx_text(tokenizer, "raw text")
+    encode_mlx_text(tokenizer, "<s>rendered text")
+
+    assert tokenizer.add_special_tokens_seen == [True, False]
 
 
 def test_mlx_text_loss_masks_exclude_position_at_sequence_length():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -331,6 +331,44 @@ def test_train_on_responses_only_forwards_last_response_only(monkeypatch):
     assert received["last_response_only"] is True
 
 
+def test_evaluate_dict_eval_datasets_records_split_metrics():
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    class Model:
+        def __init__(self):
+            self.modes = []
+
+        def eval(self):
+            self.modes.append("eval")
+
+        def train(self):
+            self.modes.append("train")
+
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model = Model()
+    trainer.stop_requested = False
+
+    def loss_fn(_model, name):
+        if name == "small":
+            return mx.array(1.0), mx.array(2)
+        return mx.array(3.0), mx.array(6)
+
+    loss, ppl = trainer._evaluate(
+        {"small": [("small",)], "large": [("large",)]},
+        loss_fn,
+        is_vlm=False,
+    )
+
+    assert loss == pytest.approx(2.5)
+    assert ppl == pytest.approx(__import__("math").exp(2.5))
+    assert trainer._last_eval_metrics["eval_small_loss"] == pytest.approx(1.0)
+    assert trainer._last_eval_metrics["eval_large_loss"] == pytest.approx(3.0)
+    assert trainer._last_eval_metrics["eval_loss"] == pytest.approx(2.5)
+    assert trainer.model.modes == ["eval", "train"]
+
+
 def test_vlm_cce_prefers_collated_position_ids_for_cuda_parity():
     import inspect
     from unsloth_zoo.mlx import utils as mlx_utils

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -302,6 +302,35 @@ def test_mlx_text_loss_masks_exclude_position_at_sequence_length():
     assert "steps < lengths[:, 1:]" in source
 
 
+def test_train_on_responses_only_forwards_last_response_only(monkeypatch):
+    import unsloth_zoo.dataset_utils as dataset_utils
+    from unsloth_zoo.mlx.trainer import train_on_responses_only
+
+    class CallableTokenizer:
+        def __call__(self, text, **kwargs):
+            return {"input_ids": [1, 2, 3]}
+
+    received = {}
+
+    def fake_hf(trainer, *, instruction_part=None, response_part=None,
+                force_match=True, tokenizer=None, return_function=False,
+                num_proc=None, last_response_only=False):
+        received["last_response_only"] = last_response_only
+        return lambda batch: batch
+
+    monkeypatch.setattr(dataset_utils, "train_on_responses_only", fake_hf)
+    train_on_responses_only(
+        None,
+        instruction_part="<user>",
+        response_part="<assistant>",
+        tokenizer=CallableTokenizer(),
+        return_function=True,
+        last_response_only=True,
+    )
+
+    assert received["last_response_only"] is True
+
+
 def test_vlm_cce_prefers_collated_position_ids_for_cuda_parity():
     import inspect
     from unsloth_zoo.mlx import utils as mlx_utils

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -300,6 +300,37 @@ def test_vlm_response_mask_formats_each_filtered_row_once():
     assert len(batches) == 1
 
 
+def test_vlm_filter_caches_only_kept_formatted_rows():
+    from unsloth_zoo.mlx.utils import _filter_trainable_vlm_indices
+
+    def formatting_func(item):
+        return {"text": item["text"]}
+
+    def mask_fn(batch):
+        labels = []
+        for row in batch["input_ids"]:
+            if 10 in row:
+                labels.append([-100] * len(row))
+            else:
+                labels.append([-100, 12, 13, 0])
+        return {"labels": labels}
+
+    kept, removed, formatted_items = _filter_trainable_vlm_indices(
+        [{"text": "bad"}, {"text": "good"}],
+        [0, 1],
+        _ResponseMaskFilteringProcessor(),
+        {},
+        max_seq_length=8,
+        image_size=16,
+        response_mask_fn=mask_fn,
+        formatting_func=formatting_func,
+    )
+
+    assert kept == [1]
+    assert removed == 1
+    assert formatted_items == {1: {"text": "good"}}
+
+
 def test_vlm_prompt_completion_skips_response_mask_like_cuda():
     from unsloth_zoo.mlx.utils import create_vlm_batches
 
@@ -407,6 +438,66 @@ def test_vlm_image_extraction_raises_process_errors_like_cuda(monkeypatch):
             [{"role": "user", "content": [{"type": "image"}]}],
             image_size=16,
         )
+
+
+def test_vlm_prompt_completion_top_level_image_errors_are_not_suppressed(monkeypatch):
+    import unsloth_zoo.vision_utils as vision_utils
+    from unsloth_zoo.mlx.utils import _extract_vlm_pc_images
+
+    def fail_process_vision_info(*_args, **_kwargs):
+        raise ValueError("bad top-level image")
+
+    monkeypatch.setattr(
+        vision_utils,
+        "process_vision_info",
+        fail_process_vision_info,
+    )
+
+    with pytest.raises(ValueError, match="bad top-level image"):
+        _extract_vlm_pc_images({}, [], [], image_size=16)
+
+
+def test_vlm_render_falls_back_to_content_part_templates():
+    from unsloth_zoo.mlx.utils import _render_vlm_messages
+
+    class ContentPartProcessor:
+        chat_template = "parts"
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+            assert tokenize is False
+            if messages and all(isinstance(part, dict) and "type" in part for part in messages):
+                return "parts:" + ",".join(part["type"] for part in messages)
+            raise ValueError("expected content parts")
+
+    rendered = _render_vlm_messages(
+        ContentPartProcessor(),
+        [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "Q"}]}],
+    )
+
+    assert rendered == "parts:image,text"
+
+
+def test_vlm_render_falls_back_to_text_templates():
+    from unsloth_zoo.mlx.utils import _render_vlm_messages
+
+    class TextTemplateProcessor:
+        chat_template = "text"
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+            assert tokenize is False
+            if messages and all(isinstance(message.get("content"), str) for message in messages):
+                return "|".join(message["content"] for message in messages)
+            raise ValueError("expected text content")
+
+    rendered = _render_vlm_messages(
+        TextTemplateProcessor(),
+        [
+            {"role": "user", "content": [{"type": "text", "text": "Q"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "A"}]},
+        ],
+    )
+
+    assert rendered == "Q|A"
 
 
 def test_vlm_processor_inputs_flattens_qwen_style_images():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -273,6 +273,36 @@ def test_vlm_response_mask_filters_before_batching_like_cuda():
     ]
 
 
+def test_vlm_streaming_response_mask_skips_fully_masked_rows():
+    from unsloth_zoo.mlx.utils import iterate_vlm_training_batches
+
+    class StreamingDataset:
+        def __iter__(self):
+            return iter([{"text": "bad"}, {"text": "good"}])
+
+    def mask_fn(batch):
+        labels = []
+        for row in batch["input_ids"]:
+            if 10 in row:
+                labels.append([-100] * len(row))
+            else:
+                labels.append([-100, 12, 13, 0])
+        return {"labels": labels}
+
+    batches = iterate_vlm_training_batches(
+        dataset=StreamingDataset(),
+        processor=_ResponseMaskFilteringProcessor(),
+        config={},
+        batch_size=2,
+        max_seq_length=8,
+        response_mask_fn=mask_fn,
+    )
+    batch = next(batches)
+
+    assert batch["input_ids"].tolist() == [[101, 12, 13, 0]]
+    assert batch["labels"].tolist() == [[-100, 12, 13, -100]]
+
+
 def test_vlm_response_mask_formats_each_filtered_row_once():
     from unsloth_zoo.mlx.utils import create_vlm_batches
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -49,6 +49,101 @@ class _FakeProcessor:
         }
 
 
+class _ResponseMaskFilteringProcessor:
+    tokenizer = _FakeTokenizer()
+    image_processor = object()
+    chat_template = "{{ messages }}"
+
+    def __call__(self, text, **_kwargs):
+        rows = []
+        masks = []
+        for value in text:
+            if "bad" in value:
+                row = [101, 10, 0, 0]
+                mask = [1, 1, 0, 0]
+            else:
+                row = [101, 12, 13, 0]
+                mask = [1, 1, 1, 0]
+            rows.append(row)
+            masks.append(mask)
+        return {
+            "input_ids": np.array(rows, dtype=np.int32),
+            "attention_mask": np.array(masks, dtype=np.int32),
+        }
+
+
+class _PromptCompletionProcessor:
+    tokenizer = _FakeTokenizer()
+    image_processor = object()
+    chat_template = "{{ messages }}"
+
+    def __call__(self, text, **_kwargs):
+        rows = []
+        masks = []
+        for value in text:
+            if value == "prompt":
+                row = [101, 0, 0, 0]
+                mask = [1, 0, 0, 0]
+            else:
+                row = [101, 102, 103, 0]
+                mask = [1, 1, 1, 0]
+            rows.append(row)
+            masks.append(mask)
+        return {
+            "input_ids": np.array(rows, dtype=np.int32),
+            "attention_mask": np.array(masks, dtype=np.int32),
+        }
+
+
+class _ConversationalPromptCompletionProcessor:
+    tokenizer = _FakeTokenizer()
+    image_processor = object()
+    chat_template = "{{ messages }}"
+
+    def __init__(self):
+        self.images_seen = []
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        assert tokenize is False
+        parts = []
+        for message in messages:
+            content = message.get("content", "")
+            if isinstance(content, list):
+                content = "".join(
+                    part.get("text", "")
+                    for part in content
+                    if isinstance(part, dict) and part.get("type") == "text"
+                )
+            if message.get("role") == "user":
+                parts.append(f"USER:{content}")
+            elif message.get("role") == "assistant":
+                parts.append(f"ASSISTANT:{content}")
+        if add_generation_prompt:
+            parts.append("ASSISTANT:")
+        return "\n".join(parts)
+
+    def __call__(self, text, images=None, **_kwargs):
+        self.images_seen.append(images)
+        rows = []
+        masks = []
+        for value in text:
+            if value == "USER:Q\nASSISTANT:":
+                row = [101, 102, 0]
+                mask = [1, 1, 0]
+            elif value == "A":
+                row = [103, 0, 0]
+                mask = [1, 0, 0]
+            else:
+                row = [999, 0, 0]
+                mask = [1, 0, 0]
+            rows.append(row)
+            masks.append(mask)
+        return {
+            "input_ids": np.array(rows, dtype=np.int32),
+            "attention_mask": np.array(masks, dtype=np.int32),
+        }
+
+
 def test_vlm_collate_creates_sft_labels_and_masks_special_tokens():
     from unsloth_zoo.mlx.utils import (
         _collate_vlm_batch,
@@ -98,6 +193,220 @@ def test_vlm_response_mask_reapplies_special_token_masks():
     )
 
     assert out["labels"].tolist() == [[-100, -100, 13, -100]]
+
+
+def test_vlm_response_mask_preserves_existing_labels_like_cuda():
+    from unsloth_zoo.mlx.utils import _apply_response_mask_to_vlm_batch
+
+    batch = {
+        "input_ids": mx.array([[101, 12, 13, 0]], dtype=mx.int32),
+        "attention_mask": mx.array([[1, 1, 1, 0]], dtype=mx.int32),
+        "labels": mx.array([[-100, 777, -100, -100]], dtype=mx.int64),
+    }
+
+    def mask_fn(mask_batch):
+        old_labels = mask_batch["labels"].tolist()
+        return {"labels": [[-100, old_labels[0][1], old_labels[0][2], -100]]}
+
+    out = _apply_response_mask_to_vlm_batch(batch, mask_fn, ignore_token_ids=[0])
+
+    assert out["labels"].tolist() == [[-100, 777, -100, -100]]
+
+
+def test_vlm_response_mask_drops_fully_masked_rows():
+    from unsloth_zoo.mlx.utils import create_vlm_batches
+
+    def mask_fn(batch):
+        labels = []
+        for row in batch["input_ids"]:
+            if 10 in row:
+                labels.append([-100] * len(row))
+            else:
+                labels.append([-100, 12, 13, 0])
+        return {"labels": labels}
+
+    batches = create_vlm_batches(
+        dataset=[{"text": "bad"}, {"text": "good"}],
+        processor=_ResponseMaskFilteringProcessor(),
+        config={},
+        batch_size=2,
+        max_seq_length=8,
+        response_mask_fn=mask_fn,
+        dataset_order="sequential",
+    )
+
+    assert len(batches) == 1
+    assert batches[0]["input_ids"].tolist() == [[101, 12, 13, 0]]
+    assert batches[0]["labels"].tolist() == [[-100, 12, 13, -100]]
+
+
+def test_vlm_response_mask_filters_before_batching_like_cuda():
+    from unsloth_zoo.mlx.utils import create_vlm_batches
+
+    def mask_fn(batch):
+        labels = []
+        for row in batch["input_ids"]:
+            if 10 in row:
+                labels.append([-100] * len(row))
+            else:
+                labels.append([-100, 12, 13, 0])
+        return {"labels": labels}
+
+    batches = create_vlm_batches(
+        dataset=[{"text": "good-1"}, {"text": "bad"}, {"text": "good-2"}],
+        processor=_ResponseMaskFilteringProcessor(),
+        config={},
+        batch_size=2,
+        max_seq_length=8,
+        response_mask_fn=mask_fn,
+        dataset_order="sequential",
+    )
+
+    assert len(batches) == 1
+    assert batches[0]["input_ids"].tolist() == [
+        [101, 12, 13, 0],
+        [101, 12, 13, 0],
+    ]
+    assert batches[0]["labels"].tolist() == [
+        [-100, 12, 13, -100],
+        [-100, 12, 13, -100],
+    ]
+
+
+def test_vlm_response_mask_formats_each_filtered_row_once():
+    from unsloth_zoo.mlx.utils import create_vlm_batches
+
+    calls = []
+
+    def formatting_func(item):
+        calls.append(item["text"])
+        return {"text": item["text"]}
+
+    def mask_fn(batch):
+        return {"labels": [[-100, 12, 13, 0] for _ in batch["input_ids"]]}
+
+    batches = create_vlm_batches(
+        dataset=[{"text": "good-1"}, {"text": "good-2"}],
+        processor=_ResponseMaskFilteringProcessor(),
+        config={},
+        batch_size=2,
+        max_seq_length=8,
+        response_mask_fn=mask_fn,
+        formatting_func=formatting_func,
+        dataset_order="sequential",
+    )
+
+    assert calls == ["good-1", "good-2"]
+    assert len(batches) == 1
+
+
+def test_vlm_prompt_completion_skips_response_mask_like_cuda():
+    from unsloth_zoo.mlx.utils import create_vlm_batches
+
+    def mask_fn(_batch):
+        raise AssertionError("CUDA VLM prompt/completion returns before response masking")
+
+    batches = create_vlm_batches(
+        dataset=[{"prompt": "prompt", "completion": "completion"}],
+        processor=_PromptCompletionProcessor(),
+        config={},
+        batch_size=1,
+        max_seq_length=8,
+        response_mask_fn=mask_fn,
+        dataset_order="sequential",
+    )
+
+    assert batches[0]["labels"].tolist() == [[-100, 101, 102, 103]]
+
+
+def test_vlm_prompt_completion_honors_completion_only_loss_false():
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch
+
+    default_batch = _collate_vlm_batch(
+        [{"prompt": "prompt", "completion": "completion"}],
+        _PromptCompletionProcessor(),
+        max_seq_length=8,
+        image_size=16,
+    )
+    batch = _collate_vlm_batch(
+        [{"prompt": "prompt", "completion": "completion"}],
+        _PromptCompletionProcessor(),
+        max_seq_length=8,
+        image_size=16,
+        completion_only_loss=False,
+    )
+
+    assert default_batch["labels"].tolist() == [[-100, 101, 102, 103]]
+    assert batch["labels"].tolist() == [[101, 101, 102, 103]]
+
+
+def test_vlm_prompt_completion_conversational_uses_cuda_prompt_split():
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch
+
+    processor = _ConversationalPromptCompletionProcessor()
+    batch = _collate_vlm_batch(
+        [{
+            "prompt": [{"role": "user", "content": [{"type": "text", "text": "Q"}]}],
+            "completion": [{"role": "assistant", "content": [{"type": "text", "text": "A"}]}],
+        }],
+        processor,
+        max_seq_length=8,
+        image_size=16,
+    )
+
+    assert batch["input_ids"].tolist() == [[101, 102, 103]]
+    assert batch["labels"].tolist() == [[-100, -100, 103]]
+
+
+def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch
+
+    processor = _ConversationalPromptCompletionProcessor()
+    _collate_vlm_batch(
+        [{
+            "image": "top-level",
+            "prompt": [{
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": "embedded"},
+                    {"type": "text", "text": "Q"},
+                ],
+            }],
+            "completion": [{"role": "assistant", "content": [{"type": "text", "text": "A"}]}],
+        }],
+        processor,
+        max_seq_length=8,
+        image_size=16,
+    )
+
+    assert processor.images_seen[0] == ["embedded"]
+
+
+def test_vlm_top_level_image_key_is_not_cuda_images_alias():
+    from unsloth_zoo.mlx.utils import _extract_vlm_images
+
+    assert _extract_vlm_images({"image": "top-level"}, [], image_size=16) == []
+
+
+def test_vlm_image_extraction_raises_process_errors_like_cuda(monkeypatch):
+    import unsloth_zoo.vision_utils as vision_utils
+    from unsloth_zoo.mlx.utils import _extract_vlm_images
+
+    def fail_process_vision_info(*_args, **_kwargs):
+        raise ValueError("bad image")
+
+    monkeypatch.setattr(
+        vision_utils,
+        "process_vision_info",
+        fail_process_vision_info,
+    )
+
+    with pytest.raises(ValueError, match="bad image"):
+        _extract_vlm_images(
+            [{"role": "user", "content": [{"type": "image"}]}],
+            [{"role": "user", "content": [{"type": "image"}]}],
+            image_size=16,
+        )
 
 
 def test_vlm_processor_inputs_flattens_qwen_style_images():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -440,7 +440,7 @@ def test_vlm_image_extraction_raises_process_errors_like_cuda(monkeypatch):
         )
 
 
-def test_vlm_prompt_completion_top_level_image_errors_are_not_suppressed(monkeypatch):
+def test_vlm_prompt_completion_top_level_image_errors_are_suppressed_like_cuda(monkeypatch):
     import unsloth_zoo.vision_utils as vision_utils
     from unsloth_zoo.mlx.utils import _extract_vlm_pc_images
 
@@ -453,8 +453,52 @@ def test_vlm_prompt_completion_top_level_image_errors_are_not_suppressed(monkeyp
         fail_process_vision_info,
     )
 
-    with pytest.raises(ValueError, match="bad top-level image"):
-        _extract_vlm_pc_images({}, [], [], image_size=16)
+    assert _extract_vlm_pc_images({"images": ["bad"]}, [], [], image_size=16) == []
+
+
+def test_vlm_prompt_completion_top_level_images_use_cuda_process_shape(monkeypatch):
+    import unsloth_zoo.vision_utils as vision_utils
+    from unsloth_zoo.mlx.utils import _extract_vlm_pc_images
+
+    seen = {}
+
+    def fake_process_vision_info(conversations, **kwargs):
+        seen["conversations"] = conversations
+        seen["kwargs"] = kwargs
+        return ["processed"], None, {"fps": []}
+
+    monkeypatch.setattr(
+        vision_utils,
+        "process_vision_info",
+        fake_process_vision_info,
+    )
+
+    assert _extract_vlm_pc_images({"images": ["raw"]}, [], [], image_size=16) == ["processed"]
+    assert seen == {
+        "conversations": [{"image": "raw"}],
+        "kwargs": {"return_video_kwargs": True},
+    }
+
+
+def test_vlm_prompt_completion_message_rows_do_not_fallback_to_top_level_images(monkeypatch):
+    import unsloth_zoo.vision_utils as vision_utils
+    from unsloth_zoo.mlx.utils import _extract_vlm_pc_images
+
+    def fake_process_vision_info(_conversations, **_kwargs):
+        return None, None, {"fps": []}
+
+    monkeypatch.setattr(
+        vision_utils,
+        "process_vision_info",
+        fake_process_vision_info,
+    )
+
+    assert _extract_vlm_pc_images(
+        {"images": ["top-level"]},
+        [{"role": "user", "content": [{"type": "text", "text": "Q"}]}],
+        [{"role": "assistant", "content": [{"type": "text", "text": "A"}]}],
+        image_size=16,
+    ) == []
 
 
 def test_vlm_render_falls_back_to_content_part_templates():

--- a/tests/test_pr684_review_fixes_a.py
+++ b/tests/test_pr684_review_fixes_a.py
@@ -310,7 +310,7 @@ def _run_train_on_responses_only(monkeypatch, args):
 
     def fake_hf(trainer, *, instruction_part=None, response_part=None,
                 force_match=True, tokenizer=None, return_function=False,
-                num_proc=None):
+                num_proc=None, last_response_only=False):
         return _identity_mask_fn
 
     monkeypatch.setattr(dataset_utils, "train_on_responses_only", fake_hf)
@@ -575,7 +575,7 @@ def test_thread5_noncallable_proxy_wrapper_unwraps_for_masking(monkeypatch):
 
     def fake_hf(trainer, *, instruction_part=None, response_part=None,
                 force_match=True, tokenizer=None, return_function=False,
-                num_proc=None):
+                num_proc=None, last_response_only=False):
         received["tokenizer"] = tokenizer
         return lambda batch: batch
 

--- a/tests/test_pr684_review_fixes_a.py
+++ b/tests/test_pr684_review_fixes_a.py
@@ -54,6 +54,11 @@ class _SpaceTokenizer:
     eos_token_id = 99
     unk_token_id = -1
 
+    def __call__(self, texts, **_kwargs):
+        if isinstance(texts, str):
+            return {"input_ids": self.encode(texts)}
+        return {"input_ids": [self.encode(text) for text in texts]}
+
     def encode(self, text):
         return [int(part) for part in str(text).split()]
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2327,7 +2327,8 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
     # Such samples cause NaN loss since cross_entropy(mean) computes 0/0.
     def _has_valid_labels(labels):
         """Return whether a response-masked row still has trainable labels."""
-        return any(label != -100 for label in labels)
+        # Loss supervises labels[1:] (causal shift), so the first label never trains.
+        return any(label != -100 for label in labels[1:])
 
     max_workers = min(4, os.cpu_count() or 1)
     all_items = []

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -112,28 +112,21 @@ def _resolve_response_mask_tokenizer(tokenizer):
         # mlx-lm TokenizerWrapper stores the HF tokenizer under _tokenizer.
         # HF fast tokenizers also expose _tokenizer, but that is the low-level
         # Rust tokenizer and is not callable like PreTrainedTokenizerBase.
-        if hasattr(tokenizer, "_tokenizer"):
-            wrapped = getattr(tokenizer, "_tokenizer", None)
-            if (
-                wrapped is not None
-                and wrapped is not tokenizer
-                and (
-                    not hasattr(tokenizer, "convert_tokens_to_ids")
-                    or callable(wrapped)
-                )
-            ):
-                tokenizer = wrapped
-                continue
+        wrapped = getattr(tokenizer, "_tokenizer", None)
+        if (
+            wrapped is not None
+            and wrapped is not tokenizer
+            and (
+                not hasattr(tokenizer, "convert_tokens_to_ids")
+                or callable(wrapped)
+            )
+        ):
+            tokenizer = wrapped
+            continue
 
         break
 
-    if not (
-        callable(tokenizer)
-        or (
-            hasattr(tokenizer, "encode")
-            and hasattr(tokenizer, "convert_tokens_to_ids")
-        )
-    ):
+    if not callable(tokenizer):
         raise TypeError(
             "Unsloth MLX: train_on_responses_only requires a callable "
             "Hugging Face tokenizer or a processor/tokenizer wrapper that "
@@ -1589,6 +1582,7 @@ class MLXTrainer:
 
         # Prepare eval batches
         eval_batches = None
+        text_completion_only_loss = _text_completion_only_loss_arg(args)
         if args.eval_steps > 0 and self.eval_dataset is not None:
             # Use pre-built labeled eval batches if available
             _labeled_eval = getattr(self, '_eval_batches_labeled', None)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -142,6 +142,16 @@ def _resolve_response_mask_tokenizer(tokenizer):
     return tokenizer
 
 
+def _text_completion_only_loss_arg(args):
+    """Resolve SFT-compatible completion-only loss defaults."""
+    value = getattr(args, "completion_only_loss", None)
+    if value is not None:
+        return value
+    if bool(getattr(args, "train_on_completions", False)):
+        return True
+    return None
+
+
 def _normalize_mlx_optimizer_name(name):
     opt_name = str(name or "adamw").strip().lower()
     if opt_name not in SUPPORTED_MLX_OPTIMIZERS:
@@ -1600,6 +1610,7 @@ class MLXTrainer:
                             seed=args.seed,
                             response_mask_fn=_vlm_mask_fn,
                             formatting_func=self.formatting_func,
+                            completion_only_loss=text_completion_only_loss,
                         )
                     return create_batches(
                         dataset=eval_dataset,
@@ -2002,6 +2013,7 @@ class MLXTrainer:
             args.max_steps * args.gradient_accumulation_steps
             if args.max_steps > 0 else None
         )
+        text_completion_only_loss = _text_completion_only_loss_arg(args)
 
         if is_vlm:
             _vlm_mask_fn = getattr(self, '_vlm_response_mask_fn', None)
@@ -2030,6 +2042,7 @@ class MLXTrainer:
                     response_mask_fn=_vlm_mask_fn,
                     formatting_func=self.formatting_func,
                     dataset_order=vlm_dataset_order,
+                    completion_only_loss=text_completion_only_loss,
                 )
             else:
                 self._prepared_batches_include_epochs = vlm_num_epochs is not None
@@ -2045,6 +2058,7 @@ class MLXTrainer:
                     formatting_func=self.formatting_func,
                     dataset_order=vlm_dataset_order,
                     num_epochs=vlm_num_epochs,
+                    completion_only_loss=text_completion_only_loss,
                 )
                 if _vlm_mask_fn is not None and batches:
                     _check_vlm_all_masked(batches)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -88,6 +88,59 @@ from .compile import (
 )
 
 
+def _is_hf_tokenizer(tokenizer):
+    """Check whether a wrapper has already resolved to an HF tokenizer."""
+    try:
+        from transformers import PreTrainedTokenizerBase
+    except Exception:
+        return False
+    return isinstance(tokenizer, PreTrainedTokenizerBase)
+
+
+def _resolve_response_mask_tokenizer(tokenizer):
+    """Return a callable HF tokenizer for the CUDA response-mask helper."""
+    for _ in range(3):
+        if _is_hf_tokenizer(tokenizer):
+            return tokenizer
+
+        processor_tokenizer = getattr(tokenizer, "tokenizer", None)
+        if processor_tokenizer is not None and processor_tokenizer is not tokenizer:
+            tokenizer = processor_tokenizer
+            continue
+
+        # mlx-lm TokenizerWrapper stores the HF tokenizer under _tokenizer.
+        # HF fast tokenizers also expose _tokenizer, but that is the low-level
+        # Rust tokenizer and is not callable like PreTrainedTokenizerBase.
+        if hasattr(tokenizer, "_tokenizer"):
+            wrapped = getattr(tokenizer, "_tokenizer", None)
+            if (
+                wrapped is not None
+                and wrapped is not tokenizer
+                and (
+                    not hasattr(tokenizer, "convert_tokens_to_ids")
+                    or callable(wrapped)
+                )
+            ):
+                tokenizer = wrapped
+                continue
+
+        break
+
+    if not (
+        callable(tokenizer)
+        or (
+            hasattr(tokenizer, "encode")
+            and hasattr(tokenizer, "convert_tokens_to_ids")
+        )
+    ):
+        raise TypeError(
+            "Unsloth MLX: train_on_responses_only requires a callable "
+            "Hugging Face tokenizer or a processor/tokenizer wrapper that "
+            "contains one."
+        )
+    return tokenizer
+
+
 def _normalize_mlx_optimizer_name(name):
     opt_name = str(name or "adamw").strip().lower()
     if opt_name not in SUPPORTED_MLX_OPTIMIZERS:
@@ -2413,6 +2466,7 @@ def train_on_responses_only(
     tokenizer=None,
     return_function=False,
     num_proc=None,
+    last_response_only=False,
 ):
     """Mask instruction tokens from loss — train only on assistant responses.
 
@@ -2428,6 +2482,8 @@ def train_on_responses_only(
         tokenizer: Optional override; defaults to trainer.tokenizer.
         return_function: If True, return the masking closure only.
         num_proc: Accepted for HF API compat, unused on MLX.
+        last_response_only: If True, only the final assistant response is
+            unmasked, matching the CUDA helper.
 
     Returns:
         The trainer (for chaining), or the closure if return_function=True.
@@ -2446,16 +2502,7 @@ def train_on_responses_only(
             "kwarg or via trainer.tokenizer."
         )
 
-    # Unwrap to a callable HF tokenizer (mlx-lm TokenizerWrapper._tokenizer,
-    # or VLM processor.tokenizer). The HF masking impl calls tokenizer(...),
-    # and mlx-lm's TokenizerWrapper proxies attributes but is not callable,
-    # so require both. HF fast tokenizers already speak the API and their
-    # _tokenizer is the Rust backend, so leave those as-is.
-    if not (callable(_tokenizer) and hasattr(_tokenizer, "convert_tokens_to_ids")):
-        if hasattr(_tokenizer, "_tokenizer"):
-            _tokenizer = _tokenizer._tokenizer
-        elif hasattr(_tokenizer, "tokenizer"):
-            _tokenizer = _tokenizer.tokenizer
+    _tokenizer = _resolve_response_mask_tokenizer(_tokenizer)
 
     # Get masking closure from the HF/CUDA implementation
     mask_fn = _hf_train_on_responses_only(
@@ -2465,6 +2512,7 @@ def train_on_responses_only(
         force_match=force_match,
         tokenizer=_tokenizer,
         return_function=True,
+        last_response_only=last_response_only,
     )
 
     if return_function:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -883,9 +883,8 @@ class MLXTrainer:
                 unsupported.append((name, tuple(getattr(value, "shape", ()))))
         return unsupported
 
-    def _evaluate(self, eval_batches, loss_fn, is_vlm=False):
-        """Run evaluation loop; returns (avg_loss, perplexity)."""
-        self.model.eval()
+    def _evaluate_batch_totals(self, eval_batches, loss_fn, is_vlm=False):
+        """Accumulate weighted loss totals for one flat eval batch stream."""
         all_losses = mx.array(0.0)
         ntokens = mx.array(0)
 
@@ -901,9 +900,47 @@ class MLXTrainer:
             ntokens += ntoks
             mx.eval(all_losses, ntokens)
 
+        return all_losses, ntokens
+
+    def _evaluate(self, eval_batches, loss_fn, is_vlm=False):
+        """Run evaluation loop.
+
+        Returns:
+            (avg_loss, perplexity) tuple.
+        """
+        self.model.eval()
+        metrics = {}
+        if isinstance(eval_batches, dict):
+            all_losses = mx.array(0.0)
+            ntokens = mx.array(0)
+            for split_name, split_batches in eval_batches.items():
+                split_losses, split_tokens = self._evaluate_batch_totals(
+                    split_batches, loss_fn, is_vlm=is_vlm,
+                )
+                all_losses += split_losses
+                ntokens += split_tokens
+                mx.eval(all_losses, ntokens)
+                split_loss = (
+                    (split_losses / split_tokens).item()
+                    if split_tokens.item() > 0 else 0.0
+                )
+                split_ppl = math.exp(min(split_loss, 100))
+                split_prefix = f"eval_{split_name}"
+                metrics[f"{split_prefix}_loss"] = split_loss
+                metrics[f"{split_prefix}_perplexity"] = split_ppl
+                if self.stop_requested:
+                    break
+        else:
+            all_losses, ntokens = self._evaluate_batch_totals(
+                eval_batches, loss_fn, is_vlm=is_vlm,
+            )
+
         self.model.train()
         avg_loss = (all_losses / ntokens).item() if ntokens.item() > 0 else 0.0
         perplexity = math.exp(min(avg_loss, 100))
+        metrics["eval_loss"] = avg_loss
+        metrics["eval_perplexity"] = perplexity
+        self._last_eval_metrics = metrics
         return avg_loss, perplexity
 
     @staticmethod
@@ -1547,41 +1584,55 @@ class MLXTrainer:
             _labeled_eval = getattr(self, '_eval_batches_labeled', None)
             if _labeled_eval is not None:
                 eval_batches = _labeled_eval
-            elif is_vlm:
-                processor = self._resolve_vlm_processor()
-                config = getattr(self.model, "_config", {})
-                _vlm_mask_fn = getattr(self, '_vlm_response_mask_fn', None)
-                eval_batches = create_vlm_batches(
-                    dataset=self.eval_dataset,
-                    processor=processor,
-                    config=config,
-                    batch_size=args.per_device_train_batch_size,
-                    max_seq_length=args.max_seq_length,
-                    seed=args.seed,
-                    response_mask_fn=_vlm_mask_fn,
-                    formatting_func=self.formatting_func,
-                )
             else:
-                eval_batches = create_batches(
-                    dataset=self.eval_dataset,
-                    tokenizer=self.tokenizer,
-                    batch_size=args.per_device_train_batch_size,
-                    max_seq_length=args.max_seq_length,
-                    seed=args.seed,
-                    dataset_text_field=args.dataset_text_field,
-                    formatting_func=self.formatting_func,
-                    chat_template=getattr(args, "chat_template", None),
-                    model_name=getattr(self.model, "_hf_repo", None),
-                    model_type=(
-                        getattr(self.model, "_config", {}).get("model_type")
-                        if isinstance(getattr(self.model, "_config", {}), dict)
-                        else None
-                    ),
-                    append_eos=bool(getattr(args, "append_eos", True)),
-                )
+                def _create_eval_batches(eval_dataset):
+                    """Materialize eval batches for one dataset split."""
+                    if is_vlm:
+                        processor = self._resolve_vlm_processor()
+                        config = getattr(self.model, "_config", {})
+                        _vlm_mask_fn = getattr(self, '_vlm_response_mask_fn', None)
+                        return create_vlm_batches(
+                            dataset=eval_dataset,
+                            processor=processor,
+                            config=config,
+                            batch_size=args.per_device_train_batch_size,
+                            max_seq_length=args.max_seq_length,
+                            seed=args.seed,
+                            response_mask_fn=_vlm_mask_fn,
+                            formatting_func=self.formatting_func,
+                        )
+                    return create_batches(
+                        dataset=eval_dataset,
+                        tokenizer=self.tokenizer,
+                        batch_size=args.per_device_train_batch_size,
+                        max_seq_length=args.max_seq_length,
+                        seed=args.seed,
+                        dataset_text_field=args.dataset_text_field,
+                        formatting_func=self.formatting_func,
+                        chat_template=getattr(args, "chat_template", None),
+                        model_name=getattr(self.model, "_hf_repo", None),
+                        model_type=(
+                            getattr(self.model, "_config", {}).get("model_type")
+                            if isinstance(getattr(self.model, "_config", {}), dict)
+                            else None
+                        ),
+                        append_eos=bool(getattr(args, "append_eos", True)),
+                    )
+
+                if isinstance(self.eval_dataset, dict):
+                    eval_batches = {
+                        key: _create_eval_batches(value)
+                        for key, value in self.eval_dataset.items()
+                    }
+                else:
+                    eval_batches = _create_eval_batches(self.eval_dataset)
             if eval_batches:
+                eval_batch_count = (
+                    sum(len(value) for value in eval_batches.values())
+                    if isinstance(eval_batches, dict) else len(eval_batches)
+                )
                 print(f"Unsloth: Eval enabled every {args.eval_steps} steps "
-                      f"({len(eval_batches)} eval batches).")
+                      f"({eval_batch_count} eval batches).")
 
         features = []
         if is_vlm:
@@ -2577,26 +2628,36 @@ def train_on_responses_only(
 
         # Process eval dataset too
         if trainer.eval_dataset is not None:
-            eval_batches = _create_labeled_batches(
-                dataset=trainer.eval_dataset,
-                tokenizer=_tokenizer,
-                mask_fn=mask_fn,
-                batch_size=args.per_device_train_batch_size,
-                max_seq_length=args.max_seq_length,
-                formatting_func=trainer.formatting_func,
-                dataset_text_field=args.dataset_text_field,
-                seed=args.seed,
-                chat_template=getattr(args, "chat_template", None),
-                model_name=getattr(trainer.model, "_hf_repo", None),
-                model_type=(
-                    getattr(trainer.model, "_config", {}).get("model_type")
-                    if isinstance(getattr(trainer.model, "_config", {}), dict)
-                    else None
-                ),
-                append_eos=bool(getattr(args, "append_eos", True)),
-                dataset_order=getattr(args, "dataset_order", "default"),
-                preserve_dataset_order=bool(getattr(args, "preserve_dataset_order", False)),
-            )
+            def _create_labeled_eval_batches(eval_dataset):
+                """Build response-masked eval batches for one dataset split."""
+                return _create_labeled_batches(
+                    dataset=eval_dataset,
+                    tokenizer=_tokenizer,
+                    mask_fn=mask_fn,
+                    batch_size=args.per_device_train_batch_size,
+                    max_seq_length=args.max_seq_length,
+                    formatting_func=trainer.formatting_func,
+                    dataset_text_field=args.dataset_text_field,
+                    seed=args.seed,
+                    chat_template=getattr(args, "chat_template", None),
+                    model_name=getattr(trainer.model, "_hf_repo", None),
+                    model_type=(
+                        getattr(trainer.model, "_config", {}).get("model_type")
+                        if isinstance(getattr(trainer.model, "_config", {}), dict)
+                        else None
+                    ),
+                    append_eos=bool(getattr(args, "append_eos", True)),
+                    dataset_order=getattr(args, "dataset_order", "default"),
+                    preserve_dataset_order=bool(getattr(args, "preserve_dataset_order", False)),
+                )
+
+            if isinstance(trainer.eval_dataset, dict):
+                eval_batches = {
+                    key: _create_labeled_eval_batches(value)
+                    for key, value in trainer.eval_dataset.items()
+                }
+            else:
+                eval_batches = _create_labeled_eval_batches(trainer.eval_dataset)
             trainer._eval_batches_labeled = eval_batches
 
         print(f"Unsloth: train_on_responses_only enabled "

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -64,6 +64,7 @@ from .utils import (
     iterate_vlm_training_batches,
     normalize_mlx_chat_template,
     normalize_vlm_processor_chat_template,
+    encode_mlx_text,
     _get_vlm_ignore_token_ids,
     collect_mlx_texts,
     save_lora_adapters,
@@ -2246,7 +2247,7 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
 
     # 2. Tokenize + mask in parallel (HF fast tokenizers are thread-safe).
     def _process_text(text):
-        encoded = tokenizer.encode(text)
+        encoded = encode_mlx_text(tokenizer, text)
         # Mirror `_prepare_dataset`'s EOS contract; mismatch desyncs labeled vs unlabeled.
         if append_eos and eos_id is not None and (not encoded or encoded[-1] != eos_id):
             encoded.append(eos_id)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -498,6 +498,7 @@ class MLXTrainingConfig:
 
     # VLM / completion masking
     train_on_completions: bool = False  # Mask prompt tokens in loss
+    completion_only_loss: bool | None = None  # None = SFT/VLM default; False trains on prompt+completion
     assistant_token_id: int = 0  # Token ID marking start of assistant response
     vlm_chat_template: object = None  # Unsloth template name/tuple or raw Jinja string
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2207,12 +2207,34 @@ def _create_labeled_batches(dataset, tokenizer, mask_fn, batch_size,
             labels = labels.tolist()
         return (encoded, labels[0])
 
+    # Filter out samples where all labels are -100 (no valid training signal).
+    # This can happen when truncation cuts off the response_part entirely,
+    # e.g. long reasoning/analysis channels in GPT-OSS that exceed max_seq_length.
+    # Such samples cause NaN loss since cross_entropy(mean) computes 0/0.
+    def _has_valid_labels(labels):
+        """Return whether a response-masked row still has trainable labels."""
+        return any(label != -100 for label in labels)
+
     max_workers = min(4, os.cpu_count() or 1)
     all_items = []
+    n_before_filter = 0
+    n_removed = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         for result in executor.map(_process_text, all_texts):
             if result is not None:
-                all_items.append(result)
+                n_before_filter += 1
+                if _has_valid_labels(result[1]):
+                    all_items.append(result)
+                else:
+                    n_removed += 1
+
+    if n_removed > 0:
+        print(
+            f"Unsloth: Removed {n_removed} out of {n_before_filter} samples "
+            f"from train_dataset where all labels were -100 "
+            f"(no response found after truncation). "
+            f"This prevents NaN loss during training."
+        )
 
     if not all_items:
         raise ValueError(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2225,6 +2225,39 @@ def _collapse_vlm_assistant_content(messages):
     return collapsed
 
 
+def _flatten_vlm_content_for_text_template(messages):
+    """Render list-style VLM content as text for text-only chat templates."""
+    flattened = copy.deepcopy(messages)
+    for message in flattened:
+        content = message.get("content", "")
+        if not isinstance(content, list):
+            continue
+        texts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                texts.append(str(part.get("text", "")))
+            elif isinstance(part, str):
+                texts.append(part)
+        message["content"] = "".join(texts)
+    return flattened
+
+
+def _flatten_vlm_messages_to_content_parts(messages):
+    """Flatten role messages for mlx-vlm processors with content-part templates."""
+    parts = []
+    for message in messages:
+        content = message.get("content", "")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, str):
+                    parts.append({"type": "text", "text": part})
+                elif isinstance(part, dict):
+                    parts.append(_clean_vlm_none_keys(part))
+        elif content:
+            parts.append({"type": "text", "text": str(content)})
+    return parts
+
+
 def _count_vlm_image_parts(messages):
     if isinstance(messages, str):
         return 0
@@ -2302,6 +2335,10 @@ def _render_vlm_messages(
     if not _processor_accepts_assistant_list_content(processor):
         render_messages = _collapse_vlm_assistant_content(render_messages)
 
+    first_error = None
+    second_error = None
+    third_error = None
+
     try:
         text = processor.apply_chat_template(
             render_messages,
@@ -2312,12 +2349,39 @@ def _render_vlm_messages(
         if isinstance(text, str) and text.strip():
             return text
     except Exception as exc:
+        first_error = exc
+
+    try:
+        text = processor.apply_chat_template(
+            _flatten_vlm_messages_to_content_parts(messages),
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+        )
+        text = _repair_deepseek_rendered_image_tokens(processor, text, messages)
+        if isinstance(text, str) and text.strip():
+            return text
+    except Exception as exc:
+        second_error = exc
+
+    try:
+        text = processor.apply_chat_template(
+            _flatten_vlm_content_for_text_template(render_messages),
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+        )
+        text = _repair_deepseek_rendered_image_tokens(processor, text, messages)
+        if isinstance(text, str) and text.strip():
+            return text
+    except Exception as exc:
+        third_error = exc
+
+    if first_error is not None:
         raise RuntimeError(
             "Unsloth MLX VLM: failed to render chat messages with this "
             "processor chat_template. Check that the dataset roles/content "
             "schema matches the model family, or pass a formatting_func that "
             "returns pre-rendered text."
-        ) from exc
+        ) from (third_error or second_error or first_error)
 
     return ""
 
@@ -2512,7 +2576,7 @@ def _extract_vlm_pc_images(item, prompt_messages, completion_messages, image_siz
         item,
         [],
         image_size,
-        suppress_process_errors=True,
+        suppress_process_errors=False,
     )
 
 
@@ -3090,7 +3154,6 @@ def _filter_trainable_vlm_indices(
         item = dataset[idx]
         if formatting_func is not None:
             item = formatting_func(item)
-            formatted_items[idx] = item
         batch_dict, is_prompt_completion = _build_response_masked_vlm_batch(
             [item],
             processor,
@@ -3105,12 +3168,16 @@ def _filter_trainable_vlm_indices(
         )
         if is_prompt_completion:
             kept_indices.append(idx)
+            if formatted_items is not None:
+                formatted_items[idx] = item
             continue
         valid_rows = _vlm_trainable_label_rows(batch_dict)
         if valid_rows is not None and len(valid_rows) == 1 and not valid_rows[0]:
             removed += 1
             continue
         kept_indices.append(idx)
+        if formatted_items is not None:
+            formatted_items[idx] = item
     return kept_indices, removed, formatted_items
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2074,10 +2074,7 @@ def encode_mlx_text(tokenizer, text):
     """Tokenize text while mirroring Unsloth's double-BOS guard."""
     add_special_tokens = True
     bos_token = getattr(tokenizer, "bos_token", None)
-    chat_template = getattr(tokenizer, "chat_template", "") or ""
-    if bos_token is not None and (
-        text.startswith(bos_token) or bos_token in chat_template
-    ):
+    if bos_token is not None and text.startswith(bos_token):
         add_special_tokens = False
 
     try:
@@ -3411,18 +3408,47 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                 "via `dataset.to_iterable_dataset()` -> list) or drop "
                 "the order request."
             )
+        def _filter_stream_item(item):
+            """Return a formatted trainable streaming row, or None to skip it."""
+            if response_mask_fn is None:
+                return item
+            if formatting_func is not None:
+                item = formatting_func(item)
+            batch_dict, is_prompt_completion = _build_response_masked_vlm_batch(
+                [item],
+                processor,
+                config,
+                max_seq_length,
+                image_size,
+                response_mask_fn=response_mask_fn,
+                formatting_func=None,
+                ignore_token_ids=ignore_token_ids,
+                completion_only_loss=completion_only_loss,
+                return_prompt_completion=True,
+            )
+            if is_prompt_completion:
+                return item
+            valid_rows = _vlm_trainable_label_rows(batch_dict)
+            if valid_rows is not None and len(valid_rows) == 1 and not valid_rows[0]:
+                return None
+            return item
+
+        batch_formatting_func = None if response_mask_fn is not None else formatting_func
         while True:
             pending = []
             yielded = False
             for item in dataset:
+                item = _filter_stream_item(item)
+                if item is None:
+                    continue
                 pending.append(item)
                 if len(pending) >= batch_size:
                     yielded = True
-                    yield _build_batch(pending, formatting_func)
+                    yield _build_batch(pending, batch_formatting_func)
                     pending = []
             if pending:
                 yielded = True
-                yield _build_batch(pending, formatting_func)
+                yield _build_batch(pending, batch_formatting_func)
             if not yielded:
                 raise ValueError("Unsloth MLX VLM: streaming dataset produced no rows.")
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2571,13 +2571,25 @@ def _extract_vlm_pc_images(item, prompt_messages, completion_messages, image_siz
         )
         if images:
             return images
+        return []
 
-    return _extract_vlm_images(
-        item,
-        [],
-        image_size,
-        suppress_process_errors=False,
-    )
+    if isinstance(item, dict) and "images" in item:
+        try:
+            from ..vision_utils import process_vision_info
+
+            raw_images = item["images"]
+            vision_infos = [{"image": raw_images[i]} for i in range(len(raw_images))]
+            extracted = process_vision_info(vision_infos, return_video_kwargs=True)
+            images = extracted[0] if isinstance(extracted, tuple) and extracted else None
+            if images is None:
+                images = []
+            elif not isinstance(images, list):
+                images = [images]
+        except Exception:
+            images = []
+        return _resize_vlm_images(images, image_size)
+
+    return []
 
 
 def _flatten_vlm_images(all_images):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2070,6 +2070,22 @@ def normalize_vlm_processor_chat_template(
     )
 
 
+def encode_mlx_text(tokenizer, text):
+    """Tokenize text while mirroring Unsloth's double-BOS guard."""
+    add_special_tokens = True
+    bos_token = getattr(tokenizer, "bos_token", None)
+    chat_template = getattr(tokenizer, "chat_template", "") or ""
+    if bos_token is not None and (
+        text.startswith(bos_token) or bos_token in chat_template
+    ):
+        add_special_tokens = False
+
+    try:
+        return tokenizer.encode(text, add_special_tokens=add_special_tokens)
+    except TypeError:
+        return tokenizer.encode(text)
+
+
 def _raise_mlx_chat_template_error(target, *, is_vlm=False):
     if is_vlm:
         _raise_vlm_chat_template_error(target)
@@ -3100,7 +3116,7 @@ def _prepare_dataset(dataset, tokenizer, dataset_text_field="text",
             self._eos_id = eos_id
 
         def process(self, item):
-            encoded = self.tokenizer.encode(item[self.text_key])
+            encoded = encode_mlx_text(self.tokenizer, item[self.text_key])
             if (
                 self._eos_id is not None
                 and (not encoded or encoded[-1] != self._eos_id)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2225,43 +2225,6 @@ def _collapse_vlm_assistant_content(messages):
     return collapsed
 
 
-def _flatten_vlm_content_for_text_template(messages):
-    flattened = copy.deepcopy(messages)
-    for message in flattened:
-        content = message.get("content", "")
-        if isinstance(content, list):
-            texts = []
-            for part in content:
-                if isinstance(part, dict) and part.get("type") == "text":
-                    texts.append(str(part.get("text", "")))
-                elif isinstance(part, str):
-                    texts.append(part)
-            message["content"] = "".join(texts)
-    return flattened
-
-
-def _flatten_vlm_messages_to_content_parts(messages):
-    """Flatten role messages for processors whose template expects content parts.
-
-    Some mlx-vlm base processors ship a VLM token template, not a chat template.
-    For example Qwen2-VL base templates iterate directly over content parts like
-    {"type": "image"} / {"type": "text"}, and render an empty string when given
-    role-wrapped messages.
-    """
-    parts = []
-    for message in messages:
-        content = message.get("content", "")
-        if isinstance(content, list):
-            for part in content:
-                if isinstance(part, str):
-                    parts.append({"type": "text", "text": part})
-                elif isinstance(part, dict):
-                    parts.append(_clean_vlm_none_keys(part))
-        elif content:
-            parts.append({"type": "text", "text": str(content)})
-    return parts
-
-
 def _count_vlm_image_parts(messages):
     if isinstance(messages, str):
         return 0
@@ -2325,7 +2288,12 @@ def _processor_accepts_assistant_list_content(processor):
             return True
 
 
-def _render_vlm_messages(processor, messages):
+def _render_vlm_messages(
+    processor,
+    messages,
+    *,
+    add_generation_prompt=False,
+):
     normalize_vlm_processor_chat_template(processor, strict=True)
     if isinstance(messages, str):
         return messages
@@ -2338,51 +2306,18 @@ def _render_vlm_messages(processor, messages):
         text = processor.apply_chat_template(
             render_messages,
             tokenize=False,
-            add_generation_prompt=False,
+            add_generation_prompt=add_generation_prompt,
         )
         text = _repair_deepseek_rendered_image_tokens(processor, text, messages)
         if isinstance(text, str) and text.strip():
             return text
-    except Exception as first_exc:
-        first_error = first_exc
-    else:
-        first_error = None
-
-    try:
-        text = processor.apply_chat_template(
-            _flatten_vlm_messages_to_content_parts(messages),
-            tokenize=False,
-            add_generation_prompt=False,
-        )
-        text = _repair_deepseek_rendered_image_tokens(processor, text, messages)
-        if isinstance(text, str) and text.strip():
-            return text
-    except Exception as second_exc:
-        second_error = second_exc
-    else:
-        second_error = None
-
-    try:
-        text = processor.apply_chat_template(
-            _flatten_vlm_content_for_text_template(render_messages),
-            tokenize=False,
-            add_generation_prompt=False,
-        )
-        text = _repair_deepseek_rendered_image_tokens(processor, text, messages)
-        if isinstance(text, str) and text.strip():
-            return text
-    except Exception as third_exc:
-        third_error = third_exc
-    else:
-        third_error = None
-
-    if first_error is not None:
+    except Exception as exc:
         raise RuntimeError(
             "Unsloth MLX VLM: failed to render chat messages with this "
             "processor chat_template. Check that the dataset roles/content "
             "schema matches the model family, or pass a formatting_func that "
             "returns pre-rendered text."
-        ) from (third_error or second_error or first_error)
+        ) from exc
 
     return ""
 
@@ -2520,10 +2455,16 @@ def _resize_vlm_images(images, image_size):
     return resized
 
 
-def _extract_vlm_images(item, messages, image_size):
+def _extract_vlm_images(
+    item,
+    messages,
+    image_size,
+    *,
+    suppress_process_errors=False,
+):
     images = []
     if isinstance(item, dict):
-        image = item.get("image", item.get("images"))
+        image = item.get("images")
         if image is not None:
             images = image if isinstance(image, list) else [image]
 
@@ -2548,9 +2489,31 @@ def _extract_vlm_images(item, messages, image_size):
                 if maybe_images is not None:
                     images = maybe_images if isinstance(maybe_images, list) else [maybe_images]
         except Exception:
-            pass
+            if not suppress_process_errors:
+                raise
 
     return _resize_vlm_images(images, image_size)
+
+
+def _extract_vlm_pc_images(item, prompt_messages, completion_messages, image_size):
+    """Extract VLM PC images with CUDA's embedded-then-top-level preference."""
+    messages = (prompt_messages or []) + (completion_messages or [])
+    if messages:
+        images = _extract_vlm_images(
+            {},
+            messages,
+            image_size,
+            suppress_process_errors=True,
+        )
+        if images:
+            return images
+
+    return _extract_vlm_images(
+        item,
+        [],
+        image_size,
+        suppress_process_errors=True,
+    )
 
 
 def _flatten_vlm_images(all_images):
@@ -2659,15 +2622,27 @@ def _to_mx_vlm_batch(inputs):
     return batch
 
 
-def _processor_vlm_inputs(processor, texts, all_images, max_seq_length, suffixes=None):
+def _processor_vlm_inputs(
+    processor,
+    texts,
+    all_images,
+    max_seq_length,
+    suffixes=None,
+    truncation=True,
+    padding_side=None,
+):
     base_kwargs = dict(
         text=texts,
         padding=True,
-        truncation=True,
-        max_length=max_seq_length,
         return_tensors="np",
         add_special_tokens=False,
     )
+    if truncation:
+        base_kwargs["truncation"] = True
+        if max_seq_length is not None:
+            base_kwargs["max_length"] = max_seq_length
+    if padding_side is not None:
+        base_kwargs["padding_side"] = padding_side
     images = _format_vlm_images_for_processor(all_images, processor=processor)
     if images is not None:
         image_layouts = (
@@ -2714,6 +2689,16 @@ def _processor_vlm_inputs(processor, texts, all_images, max_seq_length, suffixes
                     if len(image_layouts) == 1:
                         raise
                     continue
+            if "padding_side" in str(exc) and "padding_side" in proc_kwargs:
+                proc_kwargs.pop("padding_side", None)
+                try:
+                    return processor(**proc_kwargs)
+                except Exception as retry_exc:
+                    if first_error is None:
+                        first_error = retry_exc
+                    if len(image_layouts) == 1:
+                        raise
+                    continue
             if first_error is None:
                 first_error = exc
             if len(image_layouts) == 1:
@@ -2726,77 +2711,223 @@ def _processor_vlm_inputs(processor, texts, all_images, max_seq_length, suffixes
     raise first_error
 
 
-def _collate_vlm_prompt_completion_batch(items, processor, max_seq_length, image_size,
-                                         ignore_token_ids=None):
+def _as_numpy_vlm_field(inputs, key):
+    """Return a processor output field as a 2-D numpy array."""
+    value = inputs[key]
+    arr = np.asarray(value)
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    return arr
+
+
+def _common_text_prefix(left, right):
+    """Return CUDA's shared rendered prompt prefix for VLM PC rows."""
+    end = 0
+    for lhs, rhs in zip(left, right):
+        if lhs != rhs:
+            break
+        end += 1
+    return left[:end]
+
+
+def _vlm_tokenizer_padding_side(processor):
+    """Resolve the tokenizer padding side used by CUDA's VLM collator."""
+    tokenizer = _get_processor_tokenizer(processor)
+    side = getattr(tokenizer, "padding_side", "right")
+    return "left" if side == "left" else "right"
+
+
+def _vlm_pad_token_id(processor):
+    """Return the processor tokenizer pad id required for PC collation."""
+    tokenizer = _get_processor_tokenizer(processor)
+    pad_id = getattr(tokenizer, "pad_token_id", None)
+    if pad_id is None:
+        raise ValueError(
+            "Tokenizer must define `pad_token_id` for prompt-completion collation."
+        )
+    return int(pad_id)
+
+
+def _concat_vlm_token_type_ids(prompt_inputs, completion_inputs, p_ids, c_ids):
+    """Concatenate token-type metadata the same way CUDA's collator does."""
+    for key in ("token_type_ids", "mm_token_type_ids"):
+        if key not in prompt_inputs and key not in completion_inputs:
+            continue
+        p_tt = (
+            _as_numpy_vlm_field(prompt_inputs, key)
+            if key in prompt_inputs else np.zeros_like(p_ids)
+        )
+        c_tt = (
+            _as_numpy_vlm_field(completion_inputs, key)
+            if key in completion_inputs else np.zeros_like(c_ids)
+        )
+        return key, np.concatenate((p_tt, c_tt), axis=1)
+    return None, None
+
+
+def _flush_vlm_arrays_to_side(input_ids, attention_mask, side, pad_id, extras):
+    """Move non-pad VLM PC tokens to the tokenizer padding side."""
+    keep = attention_mask.astype(bool)
+    if keep.all():
+        return input_ids, attention_mask, extras
+
+    batch, seq_len = input_ids.shape
+    counts = keep.sum(axis=1)
+    ranks = np.cumsum(keep, axis=1) - 1
+    if side == "left":
+        dst = (seq_len - counts)[:, None] + ranks
+    else:
+        dst = ranks
+
+    row_idx, col_src = np.nonzero(keep)
+    col_dst = dst[row_idx, col_src].astype(np.int64)
+
+    new_ids = np.full(input_ids.shape, pad_id, dtype=input_ids.dtype)
+    new_mask = np.zeros(attention_mask.shape, dtype=attention_mask.dtype)
+    new_ids[row_idx, col_dst] = input_ids[row_idx, col_src]
+    new_mask[row_idx, col_dst] = 1
+
+    new_extras = {}
+    for key, values in extras.items():
+        out = np.zeros(values.shape, dtype=values.dtype)
+        out[row_idx, col_dst] = values[row_idx, col_src]
+        new_extras[key] = out
+
+    max_count = int(counts.max()) if counts.size else 0
+    if 0 < max_count < seq_len:
+        sl = slice(seq_len - max_count, seq_len) if side == "left" else slice(0, max_count)
+        new_ids = new_ids[:, sl]
+        new_mask = new_mask[:, sl]
+        new_extras = {key: value[:, sl] for key, value in new_extras.items()}
+
+    return new_ids, new_mask, new_extras
+
+
+def _truncate_vlm_arrays_by_side(input_ids, attention_mask, side, max_seq_length, extras):
+    """Truncate VLM PC arrays from the same side as CUDA."""
+    if max_seq_length is None or max_seq_length <= 0 or input_ids.shape[1] <= max_seq_length:
+        return input_ids, attention_mask, extras
+    sl = slice(-max_seq_length, None) if side == "left" else slice(0, max_seq_length)
+    return (
+        input_ids[:, sl],
+        attention_mask[:, sl],
+        {key: value[:, sl] for key, value in extras.items()},
+    )
+
+
+def _collate_vlm_prompt_completion_batch(
+    items,
+    processor,
+    max_seq_length,
+    image_size,
+    ignore_token_ids=None,
+    completion_only_loss=None,
+):
     prompt_texts = []
-    combined_texts = []
+    completion_texts = []
     all_images = []
 
     for item in items:
-        prompt = _normalize_vlm_messages(item.get("prompt", ""))
-        completion = _normalize_vlm_messages(item.get("completion", ""))
+        prompt_raw = item.get("prompt", "")
+        completion_raw = item.get("completion", "")
+        prompt = _normalize_vlm_messages(prompt_raw)
+        completion = _normalize_vlm_messages(completion_raw)
         prompt_messages = prompt if isinstance(prompt, list) else None
         completion_messages = completion if isinstance(completion, list) else None
 
-        if prompt_messages is not None and completion_messages is not None:
-            combined = prompt_messages + completion_messages
-            images = _extract_vlm_images(item, combined, image_size)
-            prompt_text = _render_vlm_messages(processor, prompt_messages)
-            combined_text = _render_vlm_messages(processor, combined)
+        if prompt_messages is not None:
+            prompt_text = _render_vlm_messages(
+                processor,
+                prompt_messages,
+                add_generation_prompt=True,
+            )
         else:
-            images = _extract_vlm_images(item, prompt_messages or [], image_size)
-            prompt_text = _render_vlm_messages(processor, prompt)
-            completion_text = _render_vlm_messages(processor, completion)
-            combined_text = prompt_text + completion_text
+            prompt_text = str(prompt)
+
+        if completion_messages is not None:
+            combined = prompt_messages + completion_messages
+            prompt_completion_text = _render_vlm_messages(processor, combined)
+            images = _extract_vlm_pc_images(
+                item, prompt_messages, completion_messages, image_size,
+            )
+            prompt_text = _common_text_prefix(
+                prompt_text, prompt_completion_text,
+            )
+            completion_text = prompt_completion_text[len(prompt_text):]
+        else:
+            images = _extract_vlm_pc_images(
+                item, prompt_messages, completion_messages, image_size,
+            )
+            completion_text = str(completion)
 
         prompt_texts.append(prompt_text)
-        combined_texts.append(combined_text)
+        completion_texts.append(completion_text)
         all_images.append(images)
 
-    combined_inputs = _processor_vlm_inputs(
-        processor, combined_texts, all_images, max_seq_length
-    )
     prompt_inputs = _processor_vlm_inputs(
-        processor, prompt_texts, all_images, max_seq_length
+        processor,
+        prompt_texts,
+        all_images,
+        max_seq_length,
+        truncation=False,
+        padding_side="left",
+    )
+    completion_inputs = _processor_vlm_inputs(
+        processor,
+        completion_texts,
+        [[] for _ in completion_texts],
+        max_seq_length,
+        truncation=False,
+        padding_side="right",
     )
 
-    # Build labels BEFORE _to_mx_vlm_batch narrows to int32 so wide invalid
-    # ids (e.g. uint32 wrap) reach the runtime CCE validity check intact.
-    # A direct int64 cast of uint64 would wrap 2**64-100 onto -100; saturate
-    # those rows to a positive out-of-vocab sentinel instead.
-    _raw_input_ids = np.asarray(combined_inputs["input_ids"])
-    if _raw_input_ids.dtype == np.uint64:
-        labels_np = np.where(
-            _raw_input_ids > np.uint64((1 << 63) - 1),
-            np.int64(1 << 62),
-            _raw_input_ids.astype(np.int64),
-        ).copy()
-    else:
-        labels_np = _raw_input_ids.astype(np.int64, copy=True)
+    p_ids = _as_numpy_vlm_field(prompt_inputs, "input_ids")
+    c_ids = _as_numpy_vlm_field(completion_inputs, "input_ids")
+    p_mask = _as_numpy_vlm_field(prompt_inputs, "attention_mask")
+    c_mask = _as_numpy_vlm_field(completion_inputs, "attention_mask")
+    input_ids = np.concatenate((p_ids, c_ids), axis=1)
+    attention_mask = np.concatenate((p_mask, c_mask), axis=1)
+    completion_mask = np.concatenate((np.zeros_like(p_mask), c_mask), axis=1)
+    token_type_key, token_type_ids = _concat_vlm_token_type_ids(
+        prompt_inputs, completion_inputs, p_ids, c_ids,
+    )
+
+    extras = {"completion_mask": completion_mask}
+    if token_type_key is not None:
+        extras[token_type_key] = token_type_ids
+
+    flush_side = _vlm_tokenizer_padding_side(processor)
+    pad_id = _vlm_pad_token_id(processor)
+    input_ids, attention_mask, extras = _flush_vlm_arrays_to_side(
+        input_ids, attention_mask, flush_side, pad_id, extras,
+    )
+    input_ids, attention_mask, extras = _truncate_vlm_arrays_by_side(
+        input_ids, attention_mask, flush_side, max_seq_length, extras,
+    )
+
+    combined_inputs = dict(prompt_inputs)
+    combined_inputs["input_ids"] = input_ids
+    combined_inputs["attention_mask"] = attention_mask
+    if token_type_key is not None:
+        combined_inputs[token_type_key] = extras[token_type_key]
     batch = _to_mx_vlm_batch(combined_inputs)
     batch["labels"] = _apply_vlm_label_masks(
         batch,
         ignore_token_ids=ignore_token_ids,
     )
 
-    # Read masked labels back (image + attention already applied by
-    # _apply_vlm_label_masks); int64 preserves wide invalid ids for CCE.
-    labels_np = np.asarray(batch["labels"].tolist(), dtype=np.int64)
-    prompt_batch = _to_mx_vlm_batch(prompt_inputs)
-    prompt_mask = prompt_batch.get("attention_mask")
-    prompt_ids = prompt_batch["input_ids"]
-    for row in range(labels_np.shape[0]):
-        if prompt_mask is not None:
-            prompt_len = int(mx.sum(prompt_mask[row]).item())
-        else:
-            prompt_len = int(mx.sum(prompt_ids[row] != 0).item())
-        labels_np[row, :prompt_len] = -100
-    batch["labels"] = mx.array(labels_np)
+    completion_only_loss_enabled = True if completion_only_loss is None else bool(completion_only_loss)
+    if completion_only_loss_enabled:
+        labels_np = np.asarray(batch["labels"].tolist(), dtype=np.int64)
+        labels_np[np.asarray(extras["completion_mask"]) == 0] = -100
+        batch["labels"] = mx.array(labels_np)
     return batch
 
 
 def _collate_vlm_batch(items, processor, max_seq_length, image_size,
-                       formatting_func=None, ignore_token_ids=None):
+                       formatting_func=None, ignore_token_ids=None,
+                       completion_only_loss=None,
+                       return_prompt_completion=False):
     """Collate a batch of VLM samples using the processor directly.
 
     Mirrors Unsloth's GPU UnslothVisionDataCollator: extract images, resize
@@ -2816,10 +2947,12 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         and "prompt" in formatted_items[0]
         and "completion" in formatted_items[0]
     ):
-        return _collate_vlm_prompt_completion_batch(
+        batch = _collate_vlm_prompt_completion_batch(
             formatted_items, processor, max_seq_length, image_size,
             ignore_token_ids=ignore_token_ids,
+            completion_only_loss=completion_only_loss,
         )
+        return (batch, True) if return_prompt_completion else batch
 
     all_texts = []
     all_images = []
@@ -2852,15 +2985,15 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         batch,
         ignore_token_ids=ignore_token_ids,
     )
-    return batch
+    return (batch, False) if return_prompt_completion else batch
 
 
 def _apply_response_mask_to_vlm_batch(batch_dict, mask_fn, ignore_token_ids=None):
     """Apply response masking to a VLM batch dict, adding 'labels' key.
 
     Converts input_ids to plain lists, runs the masking closure from
-    dataset_utils.train_on_responses_only, and stores the result as
-    an mx.array in batch_dict["labels"].
+    dataset_utils.train_on_responses_only with the current VLM labels, and
+    stores the result as an mx.array in batch_dict["labels"].
     """
     # Prefer the raw (pre-int32-narrowing) input_ids so the masking closure
     # sees original processor ids; wide invalid ids like uint32(2**32-100)
@@ -2868,7 +3001,15 @@ def _apply_response_mask_to_vlm_batch(batch_dict, mask_fn, ignore_token_ids=None
     raw_input_ids = batch_dict.pop(_RAW_INPUT_IDS_FOR_LABELS, None)
     input_ids = raw_input_ids if raw_input_ids is not None else batch_dict["input_ids"]
     ids_list = input_ids.tolist() if hasattr(input_ids, "tolist") else input_ids
-    result = mask_fn({"input_ids": ids_list})
+    mask_batch = {"input_ids": ids_list}
+    existing_labels = batch_dict.get("labels")
+    if existing_labels is not None:
+        labels_list = (
+            existing_labels.tolist()
+            if hasattr(existing_labels, "tolist") else existing_labels
+        )
+        mask_batch["labels"] = _normalize_numpy_cce_labels(labels_list)
+    result = mask_fn(mask_batch)
     labels_list = result["labels"]
     if hasattr(labels_list, "tolist"):
         labels_list = labels_list.tolist()
@@ -2886,10 +3027,97 @@ def _apply_response_mask_to_vlm_batch(batch_dict, mask_fn, ignore_token_ids=None
     return batch_dict
 
 
+def _vlm_trainable_label_rows(batch_dict):
+    """Return per-row trainability from VLM labels after response masking."""
+    labels = batch_dict.get("labels")
+    if labels is None:
+        return None
+    labels_np = np.asarray(labels.tolist() if hasattr(labels, "tolist") else labels)
+    if labels_np.ndim == 1:
+        labels_np = labels_np.reshape(1, -1)
+    return [bool(np.any(row != -100)) for row in labels_np]
+
+
+def _build_response_masked_vlm_batch(
+    items,
+    processor,
+    config,
+    max_seq_length,
+    image_size,
+    response_mask_fn=None,
+    formatting_func=None,
+    ignore_token_ids=None,
+    completion_only_loss=None,
+    return_prompt_completion=False,
+):
+    """Collate VLM rows and apply the CUDA response-mask closure."""
+    batch_dict, is_prompt_completion = _collate_vlm_batch(
+        items, processor, max_seq_length, image_size,
+        formatting_func=formatting_func,
+        ignore_token_ids=ignore_token_ids,
+        completion_only_loss=completion_only_loss,
+        return_prompt_completion=True,
+    )
+    batch_dict = _prepare_vlm_batch_for_compile(batch_dict, config)
+    if response_mask_fn is not None and not is_prompt_completion:
+        batch_dict = _apply_response_mask_to_vlm_batch(
+            batch_dict,
+            response_mask_fn,
+            ignore_token_ids=ignore_token_ids,
+        )
+    if return_prompt_completion:
+        return batch_dict, is_prompt_completion
+    return batch_dict
+
+
+def _filter_trainable_vlm_indices(
+    dataset,
+    indices,
+    processor,
+    config,
+    max_seq_length,
+    image_size,
+    response_mask_fn,
+    formatting_func=None,
+    ignore_token_ids=None,
+    completion_only_loss=None,
+):
+    """Filter VLM rows before batching, matching CUDA dataset.filter order."""
+    kept_indices = []
+    formatted_items = {} if formatting_func is not None else None
+    removed = 0
+    for idx in indices:
+        item = dataset[idx]
+        if formatting_func is not None:
+            item = formatting_func(item)
+            formatted_items[idx] = item
+        batch_dict, is_prompt_completion = _build_response_masked_vlm_batch(
+            [item],
+            processor,
+            config,
+            max_seq_length,
+            image_size,
+            response_mask_fn=response_mask_fn,
+            formatting_func=None,
+            ignore_token_ids=ignore_token_ids,
+            completion_only_loss=completion_only_loss,
+            return_prompt_completion=True,
+        )
+        if is_prompt_completion:
+            kept_indices.append(idx)
+            continue
+        valid_rows = _vlm_trainable_label_rows(batch_dict)
+        if valid_rows is not None and len(valid_rows) == 1 and not valid_rows[0]:
+            removed += 1
+            continue
+        kept_indices.append(idx)
+    return kept_indices, removed, formatted_items
+
+
 def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
                        num_batches=None, seed=42, response_mask_fn=None,
                        formatting_func=None, dataset_order="default",
-                       num_epochs=None):
+                       num_epochs=None, completion_only_loss=None):
     """Pre-materialize VLM training batches using the processor directly.
 
     Mirrors Unsloth's GPU UnslothVisionDataCollator:
@@ -2905,15 +3133,52 @@ def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
     epoch = 0
     base_seed = _normalize_seed(seed)
     target_epochs = 1 if num_batches is None and num_epochs is None else num_epochs
-    indices = list(range(len(dataset)))
-    if dataset_order == "torch_randperm":
-        indices = _torch_randperm_order(len(dataset), base_seed)
-    elif dataset_order in (None, "default"):
-        if num_batches is not None:
-            np.random.seed(base_seed)
-            np.random.shuffle(indices)
-    elif dataset_order != "sequential":
+    base_indices = list(range(len(dataset)))
+    total_removed = 0
+    formatted_items = None
+    if response_mask_fn is not None:
+        base_indices, total_removed, formatted_items = _filter_trainable_vlm_indices(
+            dataset,
+            base_indices,
+            processor,
+            config,
+            max_seq_length,
+            image_size,
+            response_mask_fn,
+            formatting_func=formatting_func,
+            ignore_token_ids=ignore_token_ids,
+            completion_only_loss=completion_only_loss,
+        )
+        if not base_indices and total_removed > 0:
+            raise ValueError(
+                "Unsloth MLX VLM: no trainable rows remain after "
+                "train_on_responses_only masking. Check instruction_part / "
+                "response_part and max_seq_length."
+            )
+    batch_formatting_func = None if formatted_items is not None else formatting_func
+
+    def _item(idx):
+        return formatted_items[idx] if formatted_items is not None else dataset[idx]
+
+    if dataset_order not in (None, "default", "sequential", "torch_randperm"):
         raise ValueError(f"Unsupported MLX VLM dataset_order: {dataset_order!r}")
+    if not base_indices:
+        return []
+
+    def _epoch_indices(epoch_idx):
+        """Return CUDA-style sampler order over the filtered VLM dataset."""
+        if dataset_order == "torch_randperm":
+            order = _torch_randperm_order(len(base_indices), base_seed + epoch_idx)
+            return [base_indices[i] for i in order]
+        indices = list(base_indices)
+        if dataset_order in (None, "default") and (
+            num_batches is not None or epoch_idx > 0
+        ):
+            np.random.seed(base_seed + epoch_idx)
+            np.random.shuffle(indices)
+        return indices
+
+    indices = _epoch_indices(epoch)
 
     while num_batches is None or len(batch_list) < num_batches:
         if seen >= len(indices):
@@ -2921,31 +3186,30 @@ def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
                 break
             epoch += 1
             seen = 0
-            indices = list(range(len(dataset)))
-            if dataset_order == "torch_randperm":
-                indices = _torch_randperm_order(len(dataset), base_seed + epoch)
-            elif dataset_order in (None, "default"):
-                np.random.seed(base_seed + epoch)
-                np.random.shuffle(indices)
+            indices = _epoch_indices(epoch)
 
         bi = indices[seen : seen + batch_size]
         seen += len(bi)
         if not bi:
             break
-        items = [dataset[idx] for idx in bi]
-        batch_dict = _collate_vlm_batch(
-            items, processor, max_seq_length, image_size,
-            formatting_func=formatting_func,
+        batch_dict = _build_response_masked_vlm_batch(
+            [_item(idx) for idx in bi],
+            processor,
+            config,
+            max_seq_length,
+            image_size,
+            response_mask_fn=response_mask_fn,
+            formatting_func=batch_formatting_func,
             ignore_token_ids=ignore_token_ids,
+            completion_only_loss=completion_only_loss,
         )
-        batch_dict = _prepare_vlm_batch_for_compile(batch_dict, config)
-        if response_mask_fn is not None:
-            batch_dict = _apply_response_mask_to_vlm_batch(
-                batch_dict,
-                response_mask_fn,
-                ignore_token_ids=ignore_token_ids,
-            )
         batch_list.append(batch_dict)
+
+    if total_removed > 0:
+        print(
+            f"Unsloth: Removed {total_removed} VLM samples where all labels "
+            f"were -100 after train_on_responses_only masking."
+        )
 
     # Evaluate all tensors
     all_tensors = []
@@ -2963,7 +3227,8 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                                   max_seq_length, seed=42,
                                   response_mask_fn=None,
                                   formatting_func=None,
-                                  dataset_order="default"):
+                                  dataset_order="default",
+                                  completion_only_loss=None):
     """Streaming VLM batch generator using processor directly.
 
     Yields batch dicts with input_ids, pixel_values, attention_mask,
@@ -2975,32 +3240,66 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
     ignore_token_ids = _get_vlm_ignore_token_ids(processor=processor, config=config)
     base_seed = _normalize_seed(seed)
 
-    def _emit(items):
-        batch_dict = _collate_vlm_batch(
-            items, processor, max_seq_length, image_size,
-            formatting_func=formatting_func,
+    def _build_batch(items, batch_formatting_func):
+        """Build one VLM batch with the selected formatting function."""
+        return _build_response_masked_vlm_batch(
+            items,
+            processor,
+            config,
+            max_seq_length,
+            image_size,
+            response_mask_fn=response_mask_fn,
+            formatting_func=batch_formatting_func,
             ignore_token_ids=ignore_token_ids,
+            completion_only_loss=completion_only_loss,
         )
-        batch_dict = _prepare_vlm_batch_for_compile(batch_dict, config)
-        if response_mask_fn is not None:
-            batch_dict = _apply_response_mask_to_vlm_batch(
-                batch_dict,
-                response_mask_fn,
-                ignore_token_ids=ignore_token_ids,
-            )
-        return batch_dict
 
     if hasattr(dataset, "__len__"):
         if len(dataset) <= 0:
             raise ValueError("Unsloth MLX VLM: streaming dataset produced no rows.")
+        base_indices = list(range(len(dataset)))
+        total_removed = 0
+        formatted_items = None
+        if response_mask_fn is not None:
+            base_indices, total_removed, formatted_items = _filter_trainable_vlm_indices(
+                dataset,
+                base_indices,
+                processor,
+                config,
+                max_seq_length,
+                image_size,
+                response_mask_fn,
+                formatting_func=formatting_func,
+                ignore_token_ids=ignore_token_ids,
+                completion_only_loss=completion_only_loss,
+            )
+            if not base_indices and total_removed > 0:
+                raise ValueError(
+                    "Unsloth MLX VLM: no trainable rows remain after "
+                    "train_on_responses_only masking. Check instruction_part / "
+                    "response_part and max_seq_length."
+                )
+            if total_removed > 0:
+                print(
+                    f"Unsloth: Removed {total_removed} VLM samples where all "
+                    f"labels were -100 after train_on_responses_only masking."
+                )
+        if not base_indices:
+            raise ValueError("Unsloth MLX VLM: streaming dataset produced no rows.")
+
+        def _item(idx):
+            return formatted_items[idx] if formatted_items is not None else dataset[idx]
+
+        batch_formatting_func = None if formatted_items is not None else formatting_func
         epoch = 0
         while True:
             if dataset_order == "torch_randperm":
-                indices = _torch_randperm_order(len(dataset), base_seed + epoch)
+                order = _torch_randperm_order(len(base_indices), base_seed + epoch)
+                indices = [base_indices[i] for i in order]
             elif dataset_order == "sequential":
-                indices = list(range(len(dataset)))
+                indices = list(base_indices)
             elif dataset_order in (None, "default"):
-                indices = list(range(len(dataset)))
+                indices = list(base_indices)
                 batch_indices = [
                     indices[i : i + batch_size]
                     for i in range(0, len(indices), batch_size)
@@ -3009,15 +3308,19 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                 rng = np.random.default_rng(base_seed + epoch)
                 order = rng.permutation(len(batch_indices))
                 for b in order:
-                    items = [dataset[idx] for idx in batch_indices[b]]
-                    yield _emit(items)
+                    yield _build_batch(
+                        [_item(idx) for idx in batch_indices[b]],
+                        batch_formatting_func,
+                    )
                 epoch += 1
                 continue
             else:
                 raise ValueError(f"Unsupported MLX VLM dataset_order: {dataset_order!r}")
             for start in range(0, len(indices), batch_size):
-                items = [dataset[idx] for idx in indices[start : start + batch_size]]
-                yield _emit(items)
+                yield _build_batch(
+                    [_item(idx) for idx in indices[start : start + batch_size]],
+                    batch_formatting_func,
+                )
             epoch += 1
     else:
         # Streaming has no index space; refuse rather than silently misorder.
@@ -3036,11 +3339,11 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                 pending.append(item)
                 if len(pending) >= batch_size:
                     yielded = True
-                    yield _emit(pending)
+                    yield _build_batch(pending, formatting_func)
                     pending = []
             if pending:
                 yielded = True
-                yield _emit(pending)
+                yield _build_batch(pending, formatting_func)
             if not yielded:
                 raise ValueError("Unsloth MLX VLM: streaming dataset produced no rows.")
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2905,6 +2905,10 @@ def _collate_vlm_prompt_completion_batch(
         completion_raw = item.get("completion", "")
         prompt = _normalize_vlm_messages(prompt_raw)
         completion = _normalize_vlm_messages(completion_raw)
+        # Coerce a raw prompt to a chat message when the completion is chat-style so
+        # both render through one template and split cleanly (avoids None + list).
+        if isinstance(completion, list) and isinstance(prompt, str):
+            prompt = [{"role": "user", "content": prompt}]
         prompt_messages = prompt if isinstance(prompt, list) else None
         completion_messages = completion if isinstance(completion, list) else None
 
@@ -3108,7 +3112,8 @@ def _vlm_trainable_label_rows(batch_dict):
     labels_np = np.asarray(labels.tolist() if hasattr(labels, "tolist") else labels)
     if labels_np.ndim == 1:
         labels_np = labels_np.reshape(1, -1)
-    return [bool(np.any(row != -100)) for row in labels_np]
+    # Loss supervises labels[:, 1:] (causal shift), so the first column never trains.
+    return [bool(np.any(row[1:] != -100)) for row in labels_np]
 
 
 def _build_response_masked_vlm_batch(


### PR DESCRIPTION
## Summary

This improves MLX response-mask dataset parity with CUDA for both text and VLM training.

- Filter text samples whose labels become entirely `-100` after `train_on_responses_only`, avoiding batches with no trainable tokens.
- Apply the same fully-masked filtering to VLM response-mask datasets before batching, including unsized MLX VLM streaming batches.
- Preserve CUDA behavior for VLM prompt/completion rows by handling `completion_only_loss` separately instead of applying the response-mask closure again.
- Expose `completion_only_loss` on `MLXTrainingConfig` so direct MLX users can opt out of prompt masking for prompt/completion datasets.
- Keep response masking compatible with wrapped MLX/HF tokenizers, including processor/tokenizer wrappers.
- Forward `last_response_only` into the CUDA masking helper.
- Avoid double BOS insertion when text is already rendered with BOS, while preserving tokenizer-added BOS for raw text rows.
- Support dict eval datasets and record per-split eval metrics.
- Align VLM prompt/completion collation closer to CUDA, including prompt/completion split masking, padding-side handling, token type ids, truncation side, and CUDA-matching image extraction behavior.
- Match CUDA's VLM prompt/completion image extraction behavior: message-list rows use embedded images only, while plain prompt/completion rows follow CUDA's top-level `images` processing path and suppress extraction errors.

The loss / grad curve tracks the CUDA reference more closely on Gemma3 + Thytu/ChessInstruct over 30 steps.

<img width="2430" height="864" alt="图片" src="https://github.com/user-attachments/assets/d45bee6d-8637-4f59-9d33-104cc7c7042f" />

## Validation

- `python -m pytest tests/test_mlx_trainer_internals.py tests/test_mlx_vlm_label_masks.py -q -k 'not cce_backward_via_torch_autograd'`
  - `90 passed, 1 deselected`
- `python -m pytest tests/test_mlx_trainer_internals.py tests/test_mlx_vlm_label_masks.py tests/test_pr684_review_fixes_a.py -q -k 'not thread4 and not compiler_review_guards_are_present and not cce_backward_via_torch_autograd'`
  - `102 passed, 6 deselected`
