### PR TITLE
fix(mlx): cast Gemma3 language MLP activation to fp32 to prevent backward NaN

### DIFF
--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -961,6 +961,50 @@ def _fix_gemma3_vision_mlp_fp32_activation(model=None):
     return True
 
 
+def _fix_gemma3_language_mlp_fp32_activation(model=None):
+    """Compute the language-tower GEGLU activation in fp32, then cast back.
+
+    Mirrors _fix_gemma3_vision_mlp_fp32_activation for the language tower.
+    Without this, the gelu_approx forward intermediates (x^3 term in the
+    tanh-form) overflow in bf16 / fp16 for some prompts and produce NaN
+    gradients in the backward pass — observed at language layers 0-11 of
+    gemma-3-4b-it during multimodal LoRA finetuning. The vision-side fix
+    above is not sufficient because the language MLP has its own activation
+    site that does not share that code path.
+    """
+
+    try:
+        import mlx.core as mx
+        import mlx.nn as nn
+        language_module = importlib.import_module("mlx_vlm.models.gemma3.language")
+    except Exception:
+        return False
+
+    mlp_cls = getattr(language_module, "MLP", None)
+    if mlp_cls is None:
+        return False
+    if getattr(mlp_cls, "_unsloth_fp32_activation_patched", False):
+        if model is not None:
+            model._unsloth_gemma3_language_mlp_fp32_activation = True
+        return True
+
+    def patched_mlp_call(self, x):
+        orig_dtype = x.dtype
+        gate_pre = self.gate_proj(x)
+        gate_post = nn.gelu_approx(gate_pre.astype(mx.float32)).astype(orig_dtype)
+        up = self.up_proj(x)
+        return self.down_proj(gate_post * up)
+
+    try:
+        mlp_cls.__call__ = patched_mlp_call
+        mlp_cls._unsloth_fp32_activation_patched = True
+    except Exception:
+        return False
+    if model is not None:
+        model._unsloth_gemma3_language_mlp_fp32_activation = True
+    return True
+
+
 def _fix_gemma3_vision_encoder_fp32_layernorm(model=None):
     """Match CUDA SigLIP LayerNorm math in fp32 while preserving bf16 activations."""
 
@@ -992,8 +1036,13 @@ def _fix_gemma3_vision_encoder_fp32_layernorm(model=None):
         return y.astype(orig_dtype)
 
     def patched_encoder_layer_call(self, x, mask=None):
-        r = self.self_attn(torch_like_layer_norm(self.layer_norm1, x), mask)
-        h = x + r
+        # [BISECT-B] Run attention in fp32. Attention softmax/QK^T is the
+        # classic overflow site for vision towers with large hidden dims.
+        residual_dtype = x.dtype
+        _n1 = torch_like_layer_norm(self.layer_norm1, x)
+        _n1_fp32 = _n1.astype(mx.float32)
+        attn_out = self.self_attn(_n1_fp32, mask).astype(residual_dtype)
+        h = x + attn_out
         r = self.mlp(torch_like_layer_norm(self.layer_norm2, h))
         return h + r
 
@@ -4041,6 +4090,7 @@ class FastMLXModel:
             _fix_gemma3_vision_encoder_fp32_layernorm(model)
             _fix_gemma3_vision_post_layernorm_fp32(model)
             _fix_gemma3_vision_mlp_fp32_activation(model)
+            _fix_gemma3_language_mlp_fp32_activation(model)
             _fix_gemma3_multimodal_image_feature_scale(model)
 
             model._config = getattr(model, "_config", config_data)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -1036,13 +1036,8 @@ def _fix_gemma3_vision_encoder_fp32_layernorm(model=None):
         return y.astype(orig_dtype)
 
     def patched_encoder_layer_call(self, x, mask=None):
-        # [BISECT-B] Run attention in fp32. Attention softmax/QK^T is the
-        # classic overflow site for vision towers with large hidden dims.
-        residual_dtype = x.dtype
-        _n1 = torch_like_layer_norm(self.layer_norm1, x)
-        _n1_fp32 = _n1.astype(mx.float32)
-        attn_out = self.self_attn(_n1_fp32, mask).astype(residual_dtype)
-        h = x + attn_out
+        r = self.self_attn(torch_like_layer_norm(self.layer_norm1, x), mask)
+        h = x + r
         r = self.mlp(torch_like_layer_norm(self.layer_norm2, h))
         return h + r
 


### PR DESCRIPTION
## Summary

Mirrors `_fix_gemma3_vision_mlp_fp32_activation` for the language tower. Adds a sibling helper `_fix_gemma3_language_mlp_fp32_activation` that wraps `mlx_vlm.models.gemma3.language.MLP.__call__` to compute the GEGLU activation in fp32, then casts back to the source dtype before the multiply with `up_proj`.

## Bug

`gemma-3-4b-it` under multimodal LoRA training NaN's at every language layer 0-11 on the first backward pass, propagating to all upstream parameters and poisoning the run from step 2 onward.

## Why

`gelu_approx`'s tanh form is `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))`. The `0.044715 * x^3` term's forward intermediates overflow in bf16 for the activation magnitudes that arise on the multimodal embed-then-decode path. The backward through `gelu_approx` then produces NaN gradients which propagate up the residual chain.

The existing vision-side patch covers the SigLIP MLP but doesn't address the language tower's separate GEGLU activation site.

## Fix

Cast `gate_proj`'s output to fp32 before `gelu_approx`, cast back to source dtype before the multiply with `up_proj`. All matmuls stay in native dtype — only the activation function runs in fp32.

## Verification

A/B on `gemma-3-4b-it` + `unsloth/LaTeX_OCR`, bs=1, seq=1024, language LoRA:

| | step 1 Grad | step 1 Loss | Avg loss (5 steps) | Peak mem |
|---|---|---|---|---|
| Vanilla | **nan** | 6.4850 | nan | 11.4 GB |
| Patched | **39.11** | 6.4751 | 4.91 | 11.7 GB |

Patched run loss trajectory: 6.48 → 5.02 → 4.80 → 3.94 → 4.32. Bit-identical across patched runs, confirming determinism.

Additional configs (seq=512, 4-bit):
- Vision + language LoRA combo: step-1 Grad=39.41, Avg=4.06, peak 11.87 GB ✓
- Vision-only LoRA: step-1 Grad=11.36, Avg=5.54, peak 11.51 GB ✓