### PR TITLE
fix(mlx): keep Qwen3-VL vision MLP fp32 when activation dtype is fp16

### DIFF
--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -555,6 +555,41 @@ def test_qwen3_vl_vision_rotary_uses_transformers_fp32_math():
     assert "k = _qwen3_vision_rotary_fp32(k, rotary_pos_emb)" in source
 
 
+def test_qwen3_vl_vision_block_mlp_fp32_guard_for_fp16():
+    """Pin the fp16 MLP overflow guard in patched_qwen3_vision_block_call.
+
+    On M1/M2 Macs (no native bf16), MLX defaults to float16 for the vision
+    tower. The vision block's MLP linear_fc1 (up-projection) produces output
+    magnitudes that exceed fp16's 65504 ceiling for some inputs; downcasting
+    to fp16 saturates to inf and cascades to NaN in the backward.
+
+    Fix: when activation dtype is fp16, upcast the MLP input to fp32 so the
+    entire MLP (fc1, GELU, fc2) runs in fp32. The output is cast back to
+    source dtype at the residual add. bf16/fp32 keep the original path.
+    """
+    import inspect
+    import unsloth_zoo.mlx.compile as mc
+
+    source = inspect.getsource(mc._install_qwen3_family_compile_patches)
+
+    # Guard is present
+    assert "linear_fc1 (up-projection) overflows fp16" in source, (
+        "Missing comment documenting the fp16 overflow rationale"
+    )
+    # Dtype-conditional branch keys on residual_dtype (the activation dtype)
+    assert "if residual_dtype == mx.float16:" in source, (
+        "MLP fp32 guard must be gated on residual_dtype == mx.float16"
+    )
+    # fp16 path: upcast input to fp32 before calling self.mlp
+    assert "self.mlp(mlp_norm_out.astype(mx.float32))" in source, (
+        "fp16 branch must upcast mlp input to fp32"
+    )
+    # non-fp16 path: original (cheaper) cast-only flow preserved
+    assert "self.mlp(mlp_norm_out)" in source, (
+        "bf16/fp32 path must keep the original self.mlp(...) call"
+    )
+
+
 def test_qwen3_vl_training_compile_verified():
     import unsloth_zoo.mlx.compile as mc
 

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -2676,6 +2676,7 @@ def _install_qwen3_family_compile_patches():
         return y
 
     def patched_qwen3_vision_block_call(self, hidden_states, cu_seqlens, rotary_pos_emb):
+        import mlx.core as mx
         residual_dtype = hidden_states.dtype
         attn_output = self.attn(
             _qwen3_torch_like_layer_norm(self.norm1, hidden_states),
@@ -2683,9 +2684,17 @@ def _install_qwen3_family_compile_patches():
             rotary_pos_emb=rotary_pos_emb,
         )
         hidden_states = (hidden_states + attn_output.astype(residual_dtype)).astype(residual_dtype)
-        mlp_output = self.mlp(
-            _qwen3_torch_like_layer_norm(self.norm2, hidden_states)
-        )
+        # Vision MLP linear_fc1 (up-projection) overflows fp16: its output magnitude
+        # exceeds 65504 for some inputs, so downcasting to fp16 saturates to inf and
+        # cascades to NaN in the backward. Keep the MLP path in fp32 when activation
+        # dtype is fp16; only cast back at the residual add. bf16/fp32 have enough
+        # range to avoid the saturation, so they keep the original (cheaper) path.
+        # This affects M1/M2 Macs (no native bf16 -> MLX defaults to fp16).
+        mlp_norm_out = _qwen3_torch_like_layer_norm(self.norm2, hidden_states)
+        if residual_dtype == mx.float16:
+            mlp_output = self.mlp(mlp_norm_out.astype(mx.float32))
+        else:
+            mlp_output = self.mlp(mlp_norm_out)
         hidden_states = (hidden_states + mlp_output.astype(residual_dtype)).astype(residual_dtype)
         return hidden_states
 


### PR DESCRIPTION
## Summary

Retargeted from PR (https://github.com/mmathew23/unsloth-zoo/pull/3) (against `mmathew23:explore/mlx`) per Daniel's request to PR directly against unslothai/unsloth-zoo. Same single-commit fix; cherry-picked clean onto current `unslothai/main`.

Training Qwen3-VL with `finetune_vision_layers=True` on M1/M2 (where MLX defaults to float16 since these chips lack native bf16 support) produces `grad=NaN` at step 1, corrupting the adapter.

## Diagnosis (from original investigation)

Bisected `patched_qwen3_vision_block_call`:

| Variant | Result |
|---|---|
| Whole block default | NaN |
| norm1 fp32 (attn input fp32) | NaN |
| norm2 fp32 + downcast linear_fc1 output to fp16 | NaN |
| norm2 fp32 + whole MLP fp32, cast only at residual add | finite |

The MLP path is the source — `linear_fc1`'s output magnitude exceeds fp16's 65504 ceiling, saturates to inf when downcast, cascades to NaN in backward.

## Fix

When `residual_dtype == mx.float16`, upcast the MLP input to fp32 so the full MLP runs in fp32. Cast back at the residual add. bf16/fp32 paths keep the original cheaper flow.

## A/B verified today on current unslothai/main

Qwen3-VL-2B + LaTeX_OCR + vision LoRA r=16 + bs=1 on M2:

| | Step 1 Grad | Avg loss |
|---|---|---|
| Without fix (current unslothai/main) | **nan** | nan |
| With this patch | 1.06 | 1.997 |

Peak memory 3.71 GB with fix; bug reproduces deterministically without it.

## Follow-up

Could narrow to "act_fn input fp32 only" (same pattern as the Gemma3 language MLP fix). For Qwen3-VL the memory cost of full-MLP fp32 is small (<0.5 GB), so left as-is. Worth a follow-up if memory becomes a concern.

## Test

Source-inspection guard added to `tests/test_mlx_trainer_internals.py`, matching the existing fp32-rotary test for this same module.