### PR TITLE
Fix LoRA fast_inference on new vLLM: get_dummy_lora_warmup_rank + compile downgrade

### DIFF
--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -232,6 +232,13 @@ class WorkerLoRAManager(AbstractWorkerManager):
                 self._cached_dummy_lora = dummy_lora
         return self._adapter_manager.add_adapter(dummy_lora)
 
+    def get_dummy_lora_warmup_rank(self, default_rank: int) -> int:
+        # vLLM >= 0.23 queries this before LoRA warmup profiling; older vLLM has
+        # no such method on the model manager, so fall back to the given rank.
+        manager = getattr(self, "_adapter_manager", None)
+        inner = getattr(manager, "get_dummy_lora_warmup_rank", None)
+        return inner(default_rank) if inner is not None else default_rank
+
     def pin_adapter(self, adapter_id: int) -> bool:
         return self._adapter_manager.pin_adapter(adapter_id)
 

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2154,6 +2154,27 @@ def load_vllm(
     # Get device as well
     device = get_target_device()
 
+    # vLLM >= 0.19.0 ships a piecewise graph-partition pass (`_decompose_size_nodes`,
+    # vllm-project/vllm#36038) that crashes on Unsloth's LoRA graph under
+    # compilation_config=3: "Tried to erase Node size_N but it still had N users".
+    # Still unpatched as of vLLM 0.23. compilation_config=2 skips piecewise splitting and
+    # is unaffected, so step 3 -> 2 while the installed vLLM ships the broken pass. Detect
+    # by the pass itself (not a version number) so this self-heals once vLLM fixes it.
+    # Set UNSLOTH_VLLM_PIECEWISE_COMPILE=1 to force compilation_config=3 regardless.
+    if compilation_config == 3 and os.environ.get("UNSLOTH_VLLM_PIECEWISE_COMPILE", "0") != "1":
+        try:
+            import vllm.compilation.backends as _vllm_backends
+            broken_piecewise = hasattr(_vllm_backends, "_decompose_size_nodes")
+        except Exception:
+            broken_piecewise = False
+        if broken_piecewise:
+            print(
+                "Unsloth: This vLLM's piecewise compile is incompatible with LoRA "
+                "(compilation_config=3); using compilation_config=2 instead. "
+                "Set UNSLOTH_VLLM_PIECEWISE_COMPILE=1 to override."
+            )
+            compilation_config = 2
+
     if compilation_config == 3:
         try:
             from vllm.config import CompilationConfig


### PR DESCRIPTION
This PR fixes two sequential crashes that stop `fast_inference=True` (vLLM `load_vllm`) from working on recent vLLM with LoRA. A user hits them one after the other when loading a LoRA model on new vLLM, so both are needed for the path to work end to end.

## Fix 1: add `get_dummy_lora_warmup_rank` (vLLM >= 0.23)

### Problem

On vLLM >= 0.23, loading a model with `fast_inference=True` and LoRA enabled crashes during the KV-cache profiling / LoRA warmup with:

```
RuntimeError: 'LRUCacheWorkerLoRAManager' object has no attribute 'get_dummy_lora_warmup_rank'
```

### Root cause

vLLM 0.23 added `WorkerLoRAManager.get_dummy_lora_warmup_rank(default_rank)` (vllm/lora/worker_manager.py), which delegates to `self._adapter_manager.get_dummy_lora_warmup_rank(...)` and is now called during dummy-LoRA warmup. unsloth_zoo ships its own `WorkerLoRAManager` / `LRUCacheWorkerLoRAManager` (in `vllm_lora_worker_manager.py`) that replace vLLM's, and they did not implement this new method, so the attribute lookup fails on newer vLLM.

### Fix

Add `get_dummy_lora_warmup_rank` to unsloth_zoo's `WorkerLoRAManager` (inherited by `LRUCacheWorkerLoRAManager`). It mirrors vLLM's behaviour by delegating to the underlying adapter manager, and is guarded so it stays a no-op fallback on older vLLM that has no such method:

```python
def get_dummy_lora_warmup_rank(self, default_rank: int) -> int:
    manager = getattr(self, "_adapter_manager", None)
    inner = getattr(manager, "get_dummy_lora_warmup_rank", None)
    return inner(default_rank) if inner is not None else default_rank
```

No behaviour change on older vLLM (the method is never called there; the fallback returns the requested rank). On vLLM >= 0.23 it delegates to the real implementation.

## Fix 2: step `compilation_config` 3 -> 2 when vLLM's piecewise compile is broken (vLLM >= 0.19.0)

### Problem

After Fix 1, the load gets further and then crashes during torch.compile with:

```
RuntimeError: Tried to erase Node size_1 but it still had 2 users in the graph: {getitem_3: None, getitem_4: None}!
```

### Root cause

The crash is raised in `vllm/compilation/backends.py::_decompose_size_nodes`, the piecewise graph-partition pass added in vllm-project/vllm#36038 ("[compile][graph_partition] Add tensor size handling"). It first ships in a stable vLLM release in 0.19.0 and is still unpatched as of 0.23 (the later #38360 "Bug fix for _decompose_size_nodes" does not cover the LoRA case). It only runs for `compilation_config=3` (piecewise); `compilation_config=2` (DYNAMO_TRACE_ONCE) never does piecewise splitting and is unaffected on every version.

### Fix

Before building the `compilation_config=3` `CompilationConfig`, detect whether the installed vLLM ships the broken pass and, if so, step `compilation_config` 3 -> 2. Detection is by the pass itself rather than a version number, so it self-heals once vLLM fixes it, and `UNSLOTH_VLLM_PIECEWISE_COMPILE=1` forces `compilation_config=3` regardless.

```python
if compilation_config == 3 and os.environ.get("UNSLOTH_VLLM_PIECEWISE_COMPILE", "0") != "1":
    try:
        import vllm.compilation.backends as _vllm_backends
        broken_piecewise = hasattr(_vllm_backends, "_decompose_size_nodes")
    except Exception:
        broken_piecewise = False
    if broken_piecewise:
        print(
            "Unsloth: This vLLM's piecewise compile is incompatible with LoRA "
            "(compilation_config=3); using compilation_config=2 instead. "
            "Set UNSLOTH_VLLM_PIECEWISE_COMPILE=1 to override."
        )
        compilation_config = 2
```

## Verification

Both fixes verified against real vLLM installs (`unsloth/Qwen3-4B-Base`, `fast_inference=True`, `enable_lora=True`) in isolated per-version venvs.

Fix 1: reproduced the `get_dummy_lora_warmup_rank` AttributeError on vLLM 0.23.0; load + generate works after the change.

Fix 2: the pass-presence detection matches the crash boundary exactly, and the downgrade resolves it without touching unaffected versions:

| vLLM   | `_decompose_size_nodes` present | cc=3 before | cc=3 after |
|--------|---------------------------------|-------------|------------|
| 0.15.1 | no                              | OK          | OK (stays cc=3) |
| 0.18.0 | no                              | OK          | OK (stays cc=3) |
| 0.18.1 | no                              | OK          | OK (stays cc=3) |
| 0.19.0 | yes                             | crash       | OK (-> cc=2)    |
| 0.20.0 | yes                             | crash       | OK (-> cc=2)    |
| 0.23.0 | yes                             | crash       | OK (-> cc=2)    |

`compilation_config=2` was confirmed to load and generate on both 0.19.0 and 0.23.0.
