### PR TITLE
fix(mlx): detect bitsandbytes models early on Apple Silicon

### DIFF
--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -25,6 +25,7 @@ import importlib
 import inspect
 import math
 import os
+import re
 import tempfile
 import types
 import warnings
@@ -3605,6 +3606,37 @@ class FastMLXModel:
             local_path, config_data = _materialize_mlx_vlm_config_override(
                 local_path,
                 config_data,
+            )
+
+        # bitsandbytes-quantized models are not loadable on Apple Silicon:
+        # bnb's NF4 sidecar tensors (.absmax, .quant_state.bitsandbytes__nf4,
+        # etc.) require the bitsandbytes runtime for dequantization, and bnb
+        # has no Apple Silicon backend. Without an early check, downstream
+        # loaders either explode with a quantization-config conflict (when
+        # load_in_4bit=True) or with a cryptic "Received N parameters not in
+        # model" (when load_in_4bit=False). Detect the bnb metadata up front
+        # and surface a clear, actionable error instead.
+        _existing_quant = _get_existing_mlx_quantization(config_data)
+        if (
+            isinstance(_existing_quant, dict)
+            and _existing_quant.get("quant_method") == "bitsandbytes"
+        ):
+            _suggested = re.sub(
+                r"-(?:unsloth-)?bnb-\d+bit$", "", model_name,
+            ) or model_name
+            _suggestion_line = (
+                f"  - Try the non-bnb variant: '{_suggested}'\n"
+                if _suggested != model_name
+                else "  - Try the non-bnb variant of this model (drop the "
+                     "'-bnb-4bit' suffix)\n"
+            )
+            raise ValueError(
+                f"Unsloth: '{model_name}' is a bitsandbytes-quantized model. "
+                "bitsandbytes does not run on Apple Silicon (no Metal "
+                "backend), so MLX cannot dequantize the NF4 weights.\n"
+                f"{_suggestion_line}"
+                "  - Or load this exact repo on a CUDA machine, save a "
+                "dequantized copy, and load that on Mac"
             )
 
         # Reject full_finetuning on a pre-quantized repo: int4/int8 weights


### PR DESCRIPTION
## Summary

bitsandbytes-quantized models cannot load on Apple Silicon — bnb's NF4 sidecar tensors (`.absmax`, `.quant_state.bitsandbytes__nf4`, etc.) need the bitsandbytes runtime for dequantization, and bnb has no Metal backend.

Before this patch, users hit one of two opaque errors:
- `load_in_4bit=True` → "per-module MLX quantization metadata ... but requested affine" (talks about quant configs, never mentions bnb)
- `load_in_4bit=False` → "Received N parameters not in model: ...absmax, ...nested_absmax, ...quant_state.bitsandbytes__nf4..." (cryptic, surfaces internal NF4 sidecar names)

Both errors fired AFTER downloading multi-gigabyte weights.

## Fix

Reads `config.json`'s `quant_method` field early in `from_pretrained` and raises a clear error suggesting the non-bnb variant. Detection happens before any weight download, so the failure is near-instant (~0.1s).

## Behavioral note

This guard also fires when `force_requantize=True` is passed on a bnb model. The previous `load_in_4bit=True` error pointed users at `force_requantize` as an escape hatch, but that path never actually succeeded on Mac (bnb NF4 weights cannot be dequantized without the bitsandbytes runtime), so surfacing the underlying reason is strictly clearer.

## Related

Complements the existing frontend filter that greys out bnb models in the Studio picker. Defense in depth: frontend prevents most users from selecting these models; loader catches direct API callers and anything that bypasses the picker.

## Verification

12-case harness on M2 across `{non-quant, bnb-4bit, already-MLX-4bit}` × `{text, VLM}` × `{load_in_4bit True, False}`:
- All 4 bnb cases now hit the clear error in ~0.1s
- The 8 non-bnb cases are unchanged

Edge-case checks:
- non-bnb models don't have `quant_method == "bitsandbytes"` (verified across 4 sampled models from `unsloth/` and `mlx-community/`)
- Suggested variant names resolve to real HF repos (verified for `Qwen3-VL-4B-Thinking-unsloth-bnb-4bit` → `Qwen3-VL-4B-Thinking` and similar)
- The `-bnb-Xbit` suffix regex doesn't false-positive on names where the pattern appears mid-string (e.g. `model-bnb-4bit-fp16`)