### PR TITLE
tests: verify the MoE fused experts + attention merge (qwen3_5_moe build + model-space check, gemma4)

### DIFF
--- a/tests/_merge_e2e_helpers.py
+++ b/tests/_merge_e2e_helpers.py
@@ -510,9 +510,14 @@ def _shrink_generic(family, kind, cfg, **kw):
                           ("num_attention_heads", _HEADS), ("num_key_value_heads", _KV),
                           ("vocab_size", _VOCAB), ("max_position_embeddings", _POS),
                           ("num_experts", _EXPERTS), ("num_local_experts", _EXPERTS),
-                          ("num_experts_per_tok", 2), ("decoder_sparse_step", 1)):
+                          ("num_experts_per_tok", 2), ("top_k_experts", 2),
+                          ("decoder_sparse_step", 1)):
             if hasattr(obj, attr):
                 setattr(obj, attr, val)
+        # Some families (gemma4) gate MoE behind a flag; enable it so the tiny
+        # config materializes experts to exercise the fused-merge path.
+        if hasattr(obj, "enable_moe_block"):
+            obj.enable_moe_block = True
         # strict/hybrid archs (lfm2_moe, qwen3_5_moe) need an explicit per-layer
         # schedule matching num_hidden_layers or instantiation raises.
         if hasattr(obj, "layer_types") and getattr(obj, "num_hidden_layers", None):


### PR DESCRIPTION
## Summary

Make `test_merge_e2e_moe_fused.py` actually **run and verify** the full fused-experts + attention merge for composite / gated MoE families instead of skipping. This unblocks `unslothai/unsloth`'s `Core (HF=default + TRL=default)` CI cell (which runs unsloth-zoo @ main), where `[qwen3_5_moe]` was failing:

```
AttributeError: 'Qwen3_5MoeConfig' object has no attribute 'vocab_size'
```

The production merge (`saving_utils.merge_and_overwrite_lora`, which `unsloth`'s `save_pretrained_merged` also calls) was already correct; the test fixture couldn't build the model or verify the result for these layouts.

## Changes (test fixtures only)

1. **`build_and_save_base` — build composite MoE from `text_config`.** `qwen3_5_moe` keeps `vocab_size` under `text_config`; on transformers 5.5.0 `from_config` builds the text backbone from the top-level config and raises `AttributeError`. On that error, retry from `text_config` (mirrors `unsloth_zoo.create_empty_causal_lm`). The fallback only triggers when the top-level build fails, so other versions are untouched.

2. **`assert_merge_correct_model_space` — verify packed-in-memory / per-expert-on-disk experts.** `qwen3_5_moe` packs experts in memory (`mlp.experts.gate_up_proj`) but serializes them per-expert on disk (`experts.<e>.gate_proj.weight`), so the packed adapted key maps to no single safetensor and the byte-level check skipped on **every** transformers version. The merge itself is correct (`_MOE_MERGE_STATE` reports `applied == attempted`, `fallback == 0`). The new verifier loads base + merged and compares in the in-memory (re-packed) space, where parameter names line up with the adapted keys and `_ref_fused`/`_ref_dense` apply directly. `assert_merge_correct` routes to it **only** when a fused adapted key cannot be resolved on disk, so `gpt_oss` and the per-expert families keep the byte-level path.

3. **`_shrink_generic` — materialize gated MoE blocks.** `gemma4` gates experts behind `enable_moe_block` (and uses `top_k_experts`); set them so the tiny config builds MoE layers and its fused-merge path is exercised.

## Verified (CPU, isolated venvs, transformers 5.5.0 and 5.8.0)

Full (experts **+** attention) and attention-only merges, via the production merge path:

| family | serialization | full (experts+attn) | attn-only |
|---|---|---|---|
| gpt_oss | fused | PASS | PASS |
| qwen3_5_moe | fused (composite) | PASS | PASS |
| gemma4 | fused (gated) | PASS | PASS |
| qwen3_moe | per-expert | PASS | PASS |
| glm4_moe | per-expert | PASS | PASS |

All four `test_merge_e2e_*` files: **32 passed, 1 skipped** on both versions, no regressions. The 1 skip is `lfm2_moe` full — a hybrid conv/attention arch with distinct naming (`self_attn.out_proj`, `feed_forward.experts`) whose tiny-config module count doesn't line up; covered by the real-model sweep.