### PR TITLE
llama.cpp: block symlink/hardlink path escapes when extracting prebuilt archives

### DIFF
--- a/tests/test_llama_cpp_prebuilt.py
+++ b/tests/test_llama_cpp_prebuilt.py
@@ -290,6 +290,57 @@ def test_extract_rejects_path_traversal(tmp_path):
         llama_cpp._extract_archive(str(evil), str(tmp_path / "out"))
 
 
+def _add_link(tar, name, linkname, link_type = tarfile.SYMTYPE):
+    info = tarfile.TarInfo(name)
+    info.type = link_type
+    info.linkname = linkname
+    tar.addfile(info)
+
+
+def test_extract_rejects_symlink_escape(tmp_path):
+    evil = tmp_path / "evil-symlink.tar.gz"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    with tarfile.open(evil, "w:gz") as tar:
+        _add_link(tar, "link", str(outside))
+        _add_file(tar, "link/pwned.txt", "pwned")
+    with pytest.raises(RuntimeError, match = "escapes extraction dir"):
+        llama_cpp._extract_archive(str(evil), str(tmp_path / "out"))
+    assert not (outside / "pwned.txt").exists()
+
+
+def test_extract_rejects_hardlink_escape(tmp_path):
+    evil = tmp_path / "evil-hardlink.tar.gz"
+    with tarfile.open(evil, "w:gz") as tar:
+        _add_link(tar, "link", "../../../../etc/passwd", link_type = tarfile.LNKTYPE)
+    with pytest.raises(RuntimeError, match = "escapes extraction dir"):
+        llama_cpp._extract_archive(str(evil), str(tmp_path / "out"))
+
+
+def test_extract_rejects_zip_symlink(tmp_path):
+    import zipfile
+    evil = tmp_path / "evil.zip"
+    with zipfile.ZipFile(evil, "w") as archive:
+        info = zipfile.ZipInfo("link")
+        info.external_attr = 0o120777 << 16  # S_IFLNK
+        archive.writestr(info, str(tmp_path / "outside"))
+    with pytest.raises(RuntimeError, match = "symlink"):
+        llama_cpp._extract_archive(str(evil), str(tmp_path / "out"))
+
+
+@pytest.mark.skipif(not IS_POSIX, reason = "symlink semantics")
+def test_extract_allows_in_tree_symlink(tmp_path):
+    # Real release tarballs ship relative .so symlinks that stay in-tree.
+    archive = tmp_path / "libs.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        _add_file(tar, "libllama.so.0", "not really elf")
+        _add_link(tar, "libllama.so", "libllama.so.0")
+    out = tmp_path / "out"
+    llama_cpp._extract_archive(str(archive), str(out))
+    assert (out / "libllama.so").is_symlink()
+    assert (out / "libllama.so").resolve() == (out / "libllama.so.0").resolve()
+
+
 @pytest.mark.skipif(not IS_POSIX, reason = "shell-script fake binaries")
 def test_extract_and_place_linux(tmp_path):
     archive = tmp_path / "llama-b9000-bin-ubuntu-x64.tar.gz"

--- a/tests/test_llama_cpp_prebuilt.py
+++ b/tests/test_llama_cpp_prebuilt.py
@@ -328,6 +328,24 @@ def test_extract_rejects_zip_symlink(tmp_path):
         llama_cpp._extract_archive(str(evil), str(tmp_path / "out"))
 
 
+@pytest.mark.skipif(not IS_POSIX or os.geteuid() == 0, reason = "read-only dir perms (non-root POSIX)")
+def test_extract_allows_readonly_dir_before_contents(tmp_path):
+    # A read-only dir entry preceding its files must not trip extraction:
+    # extractall defers directory perms until contents are written.
+    archive = tmp_path / "ro.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        d = tarfile.TarInfo("ro")
+        d.type = tarfile.DIRTYPE
+        d.mode = 0o555
+        tar.addfile(d)
+        _add_file(tar, "ro/file.txt", "ok")
+    out = tmp_path / "out"
+    llama_cpp._extract_archive(str(archive), str(out))
+    content = (out / "ro" / "file.txt").read_text()
+    os.chmod(out / "ro", 0o755)  # restore write bit so tmp_path cleanup can unlink
+    assert content == "ok"
+
+
 @pytest.mark.skipif(not IS_POSIX, reason = "symlink semantics")
 def test_extract_allows_in_tree_symlink(tmp_path):
     # Real release tarballs ship relative .so symlinks that stay in-tree.

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -869,7 +869,10 @@ def _extract_archive(archive_path, extract_dir):
     """Extract a release .zip / .tar.gz, refusing path-escaping members."""
     real_root = os.path.realpath(extract_dir)
     def _escapes(target):
-        return target != real_root and not target.startswith(real_root + os.sep)
+        try:
+            return os.path.commonpath([real_root, target]) != real_root
+        except ValueError:
+            return True
     def _check(name):
         target = os.path.realpath(os.path.join(extract_dir, name))
         if _escapes(target):
@@ -896,12 +899,13 @@ def _extract_archive(archive_path, extract_dir):
     else:
         tar_kwargs = {"filter": "data"} if sys.version_info >= (3, 12) else {}
         with tarfile.open(archive_path, "r:gz") as archive:
-            for member in archive.getmembers():
-                # Validate immediately before extraction so previously-created
-                # symlinks cannot redirect later members outside extract_dir
-                # on Python versions without tarfile's data extraction filter.
-                _check_tar_member(member)
-                archive.extract(member, extract_dir, **tar_kwargs)
+            # Validate every member (rejecting links whose targets escape) before
+            # extracting anything, so no escaping symlink is ever written for a
+            # later member to traverse through. extractall defers directory attrs
+            # until contents are written, which per-member extract would break.
+            members = archive.getmembers()
+            for member in members: _check_tar_member(member)
+            archive.extractall(extract_dir, members = members, **tar_kwargs)
 
 
 def _single_extracted_root(extract_dir):

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -868,19 +868,40 @@ def _download_archive(url, dest_path):
 def _extract_archive(archive_path, extract_dir):
     """Extract a release .zip / .tar.gz, refusing path-escaping members."""
     real_root = os.path.realpath(extract_dir)
+    def _escapes(target):
+        return target != real_root and not target.startswith(real_root + os.sep)
     def _check(name):
         target = os.path.realpath(os.path.join(extract_dir, name))
-        if target != real_root and not target.startswith(real_root + os.sep):
+        if _escapes(target):
             raise RuntimeError(f"Unsloth: Archive member escapes extraction dir: {name}")
+        return target
+    def _check_tar_member(member):
+        member_target = _check(member.name)
+        if member.issym() or member.islnk():
+            # Hardlink targets are archive-relative (resolve from the root);
+            # symlink targets resolve from the link's own directory.
+            link_base = real_root if member.islnk() else os.path.dirname(member_target)
+            link_target = member.linkname if os.path.isabs(member.linkname) else os.path.join(link_base, member.linkname)
+            if _escapes(os.path.realpath(link_target)):
+                raise RuntimeError(f"Unsloth: Archive link escapes extraction dir: {member.name} -> {member.linkname}")
+        elif not (member.isfile() or member.isdir()):
+            raise RuntimeError(f"Unsloth: Unsupported archive member type: {member.name}")
     if archive_path.endswith(".zip"):
         with zipfile.ZipFile(archive_path) as archive:
-            for member in archive.namelist(): _check(member)
+            for member in archive.infolist():
+                _check(member.filename)
+                if (member.external_attr >> 16) & 0o170000 == 0o120000:
+                    raise RuntimeError(f"Unsloth: Archive contains an unsupported symlink: {member.filename}")
             archive.extractall(extract_dir)
     else:
         tar_kwargs = {"filter": "data"} if sys.version_info >= (3, 12) else {}
         with tarfile.open(archive_path, "r:gz") as archive:
-            for member in archive.getmembers(): _check(member.name)
-            archive.extractall(extract_dir, **tar_kwargs)
+            for member in archive.getmembers():
+                # Validate immediately before extraction so previously-created
+                # symlinks cannot redirect later members outside extract_dir
+                # on Python versions without tarfile's data extraction filter.
+                _check_tar_member(member)
+                archive.extract(member, extract_dir, **tar_kwargs)
 
 
 def _single_extracted_root(extract_dir):


### PR DESCRIPTION
Hardens `_extract_archive` so the prebuilt llama.cpp download/extract path is link-safe. On Python 3.12+ the code already passes `tarfile`'s `filter='data'`. On 3.9-3.11 it didn't, so a tar member could symlink outside the extract dir and a later member would write through it. This closes that gap and brings the pre-3.12 path in line with 3.12+.

## What changed

- Validate each tar member's link target stays inside the extract dir, and extract members one at a time so an in-tree symlink can't redirect a later member. Legit relative `.so` symlinks (which real release tarballs ship) still extract fine.
- Reject unsupported member types (devices/fifos).
- Same hardening on the `.zip` branch (Windows assets): reject symlink entries, matching the studio installer.
- Folded the duplicated containment check into one `_escapes` helper.

## Severity: defense-in-depth, not a critical fix

The archive source is fixed and trusted. `_resolve_llama_cpp_release` only hits the `ggml-org` / `unslothai` llama.cpp GitHub releases, and there's no way to point the download at an arbitrary URL. The payload is executables the installer runs by design (`check_llama_cpp` runs the downloaded quantizer). So anyone who could deliver a malicious archive already has code execution via the binary itself, and the symlink write is a strictly weaker primitive. Worth fixing as hygiene, and cheap insurance if the archive source ever becomes less trusted, but users aren't exposed today.

## Tests

Added regression tests for symlink escape, hardlink escape, and zip symlink, plus a positive test that in-tree `.so` symlinks still extract. Verified on Python 3.11, the actually-affected runtime: the escape tests fail on the unpatched code and pass after. Full prebuilt suite passes on 3.11 and 3.12 (31 tests).
