### PR TITLE
training_utils: respect PEFT bias training in prepare_model_for_training (#2343)

### DIFF
--- a/tests/test_prepare_model_for_training_bias.py
+++ b/tests/test_prepare_model_for_training_bias.py
@@ -1,0 +1,200 @@
+"""Regression tests for unsloth#2343: bias training was silently disabled.
+
+Pre-fix bug: `prepare_model_for_training`'s LoRA branch froze every parameter
+that was not a LoRA adapter weight:
+
+    if ".lora_A." in name or ".lora_B." in name or ".lora_magnitude_vector" in name:
+        requires_grad = True
+    else:
+        requires_grad = False   # <- also froze biases PEFT had marked trainable
+
+So `LoraConfig(bias="all")` / `bias="lora_only"` had no effect: PEFT enabled the
+biases, then this loop re-froze them. The fix keeps the PEFT decision for params
+whose name ends in `.bias` (preserve their incoming requires_grad and upcast the
+trainable ones to fp32 like LoRA adapters). `bias="none"` (the default) leaves
+biases frozen, so the common path is byte-identical.
+
+Pure CPU, tiny random Llama. The PEFT end-to-end test is gated on peft being
+importable (peft is excluded on darwin/arm64).
+"""
+import os
+
+import pytest
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM
+
+
+def _tiny_llama(dtype=torch.float32, with_bias=True):
+    cfg = LlamaConfig(
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        attention_bias=with_bias,
+        mlp_bias=with_bias,
+        tie_word_embeddings=False,
+    )
+    model = LlamaForCausalLM(cfg)
+    if dtype != torch.float32:
+        model = model.to(dtype)
+    model.config.torch_dtype = dtype
+    return model
+
+
+def _bias_names(model):
+    return [n for n, _ in model.named_parameters() if n.endswith(".bias")]
+
+
+# ---------------- core fix (no peft): PEFT's bias decision is respected -------
+
+def test_marked_biases_stay_trainable_after_prepare():
+    """Simulate PEFT bias='all' (every bias requires_grad=True). After prepare
+    the biases must remain trainable and the non-bias base weights frozen."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    model = _tiny_llama()
+    biases = _bias_names(model)
+    assert biases, "fixture must have bias params"
+    for n, p in model.named_parameters():
+        p.requires_grad_(n.endswith(".bias"))  # PEFT bias='all' shape
+
+    prepare_model_for_training(
+        model, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=False,
+    )
+
+    params = dict(model.named_parameters())
+    for n in biases:
+        assert params[n].requires_grad, f"{n} should stay trainable (bias='all')"
+    # A representative non-bias base weight must be frozen.
+    assert not params["model.layers.0.self_attn.q_proj.weight"].requires_grad
+
+
+def test_default_biases_stay_frozen():
+    """bias='none' shape: nothing marked trainable -> biases stay frozen, i.e.
+    byte-identical to pre-fix behaviour on the common path."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    model = _tiny_llama()
+    for _, p in model.named_parameters():
+        p.requires_grad_(False)
+
+    prepare_model_for_training(
+        model, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=False,
+    )
+
+    params = dict(model.named_parameters())
+    for n in _bias_names(model):
+        assert not params[n].requires_grad, f"{n} should stay frozen (bias='none')"
+
+
+def test_trainable_bias_is_upcast_to_fp32():
+    """A trainable bias is upcast to fp32 (like LoRA adapters); a frozen one
+    keeps its loaded (bf16) dtype."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    model = _tiny_llama(dtype=torch.bfloat16)
+    names = _bias_names(model)
+    trainable_bias = names[0]
+    # Mark exactly one bias trainable (mimics bias='lora_only' picking a subset).
+    for n, p in model.named_parameters():
+        p.requires_grad_(n == trainable_bias)
+
+    prepare_model_for_training(
+        model, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=False, float32_mixed_precision=True,
+    )
+
+    params = dict(model.named_parameters())
+    assert params[trainable_bias].dtype == torch.float32
+    assert params[trainable_bias].requires_grad
+    # An untouched, frozen bias is not recast.
+    frozen_bias = names[1]
+    assert params[frozen_bias].dtype == torch.bfloat16
+    assert not params[frozen_bias].requires_grad
+
+
+def test_bias_gradient_flows_after_backward():
+    """End-to-end on CPU: with biases trainable, a backward pass populates
+    their .grad; a frozen base weight gets no grad."""
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    model = _tiny_llama()
+    for n, p in model.named_parameters():
+        p.requires_grad_(n.endswith(".bias"))
+
+    prepare_model_for_training(
+        model, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=False,
+    )
+
+    input_ids = torch.randint(0, 64, (1, 8))
+    out = model(input_ids=input_ids, labels=input_ids)
+    out.loss.backward()
+
+    params = dict(model.named_parameters())
+    a_bias = _bias_names(model)[0]
+    assert params[a_bias].grad is not None, "trainable bias must receive a grad"
+    assert params[a_bias].grad.abs().sum() >= 0  # finite, allocated
+    # A frozen base weight must not accumulate a grad.
+    assert params["model.layers.0.self_attn.q_proj.weight"].grad is None
+
+
+# ---------------- PEFT end-to-end (gated on peft) ----------------------------
+
+def test_peft_bias_all_end_to_end():
+    """Through real PEFT: LoraConfig(bias='all') biases stay trainable after
+    prepare_model_for_training (the exact path from the issue repro)."""
+    peft = pytest.importorskip("peft")
+    from peft import LoraConfig, get_peft_model
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    model = _tiny_llama()
+    model = get_peft_model(
+        model,
+        LoraConfig(
+            r=8, lora_alpha=8, bias="all",
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                            "gate_proj", "up_proj", "down_proj"],
+        ),
+    )
+    trainable_before = sum(
+        p.requires_grad for n, p in model.named_parameters() if n.endswith(".bias"))
+    assert trainable_before > 0  # PEFT enabled the biases
+
+    prepare_model_for_training(
+        model, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=False,
+    )
+
+    trainable_after = sum(
+        p.requires_grad for n, p in model.named_parameters() if n.endswith(".bias"))
+    assert trainable_after == trainable_before, (
+        f"bias='all' lost trainable biases: {trainable_before} -> {trainable_after}")
+
+
+def test_peft_bias_none_end_to_end():
+    """bias='none' (default): no biases trainable before or after -> unchanged."""
+    pytest.importorskip("peft")
+    from peft import LoraConfig, get_peft_model
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    model = _tiny_llama()
+    model = get_peft_model(
+        model,
+        LoraConfig(
+            r=8, lora_alpha=8, bias="none",
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                            "gate_proj", "up_proj", "down_proj"],
+        ),
+    )
+    prepare_model_for_training(
+        model, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=False,
+    )
+    trainable_after = sum(
+        p.requires_grad for n, p in model.named_parameters() if n.endswith(".bias"))
+    assert trainable_after == 0

--- a/tests/test_prepare_model_for_training_bias.py
+++ b/tests/test_prepare_model_for_training_bias.py
@@ -1,16 +1,9 @@
 """Regression tests for unsloth#2343: bias training was silently disabled.
 
-The LoRA branch of prepare_model_for_training froze every non-adapter param, so
-LoraConfig(bias="all"/"lora_only") had no effect. The fix preserves PEFT's bias
-decision; properties guarded below:
-  * bias="all"/"lora_only": PEFT-enabled biases stay trainable.
-  * bias="none" (default): biases stay frozen.
-  * a trainable bias keeps its loaded dtype, not fp32 (an fp32 bias on a bf16/fp16
-    Linear breaks the matmul with a dtype mismatch).
-  * gated to PEFT models, so a non-PEFT model's biases stay frozen on the LoRA path.
-
-Pure CPU, tiny random Llama. PEFT tests import-or-skip (peft is excluded on
-darwin/arm64).
+The LoRA branch froze every non-adapter param, so LoraConfig(bias="all"/"lora_only")
+had no effect. The fix preserves PEFT's bias decision (trainable biases keep their
+loaded dtype, frozen on bias="none", gated to PEFT models). Pure CPU, tiny Llama;
+PEFT tests import-or-skip.
 """
 import pytest
 import torch
@@ -75,7 +68,7 @@ def test_peft_bias_all_stays_trainable():
     )
     after = _trainable_bias_count(model)
     assert after == before, f"bias='all' lost trainable biases: {before} -> {after}"
-    # The non-bias base weights must remain frozen.
+    # Base weights stay frozen.
     params = dict(model.named_parameters())
     base_w = next(n for n in params
                   if n.endswith("q_proj.base_layer.weight"))
@@ -96,8 +89,8 @@ def test_peft_bias_none_stays_frozen():
 
 
 def test_peft_trainable_bias_keeps_module_dtype():
-    """A trainable bias keeps its Linear's bf16 dtype, not fp32; an fp32 bias on a
-    bf16 weight raises 'self and mat2 must have the same dtype'."""
+    """A trainable bias keeps its Linear's bf16 dtype, not fp32 (else the matmul
+    dtype mismatches)."""
     pytest.importorskip("peft")
     from unsloth_zoo.training_utils import prepare_model_for_training
 
@@ -127,9 +120,8 @@ def test_peft_bias_gradient_flows_after_backward():
     )
 
     input_ids = torch.randint(0, 64, (1, 8))
-    # Loss from logits, not labels=: with unsloth the labelled forward uses the
-    # fused CUDA cross-entropy, which aborts on a CPU-only build. A logits scalar
-    # stays CPU-only while still driving a real backward.
+    # Loss from logits, not labels=: the labelled forward uses fused CUDA CE that
+    # aborts on a CPU-only build; logits stay CPU-only and still drive a backward.
     logits = model(input_ids=input_ids).logits.float()
     loss = torch.nn.functional.cross_entropy(
         logits.view(-1, logits.size(-1)), input_ids.view(-1))
@@ -141,7 +133,7 @@ def test_peft_bias_gradient_flows_after_backward():
     a_grad = params[a_bias].grad
     assert a_grad is not None, "trainable bias must receive a grad"
     assert torch.isfinite(a_grad).all(), "bias grad must be finite"
-    # Strictly > 0 proves a gradient actually flowed, not just that grad exists.
+    # > 0 proves a gradient actually flowed, not just that grad exists.
     assert a_grad.abs().sum() > 0, "bias grad must be non-zero (gradient flowed)"
     base_w = next(n for n in params if n.endswith("q_proj.base_layer.weight"))
     assert params[base_w].grad is None, "frozen base weight must not accumulate grad"
@@ -169,17 +161,14 @@ def test_non_peft_model_biases_stay_frozen():
 # ---------------- modules_to_save biases are not a bias decision -------------
 
 def test_modules_to_save_bias_not_preserved_on_bias_none():
-    """bias='none' + modules_to_save: PEFT marks the saved module trainable because
-    the whole module is saved, not as a bias decision. With patch_modules_to_save=False
-    the saved weight stays frozen, so its bias must too (else a saved head is partially
-    trained, changing the bias='none' path, #2343 review). Bias and weight must share
-    requires_grad."""
+    """bias='none' + modules_to_save: a saved module is trainable because the whole
+    module is saved, not as a bias decision; with patch_modules_to_save=False bias and
+    weight stay frozen together (#2343 review)."""
     pytest.importorskip("peft")
     from peft import LoraConfig, get_peft_model
     from unsloth_zoo.training_utils import prepare_model_for_training
 
-    # gate_proj has a bias (mlp_bias=True) and is not a LoRA target, so PEFT wraps
-    # it as a saved module: gate_proj.modules_to_save.default.*.
+    # gate_proj has a bias and isn't a LoRA target, so PEFT wraps it as a saved module.
     model = get_peft_model(
         _tiny_llama(),
         LoraConfig(
@@ -199,7 +188,6 @@ def test_modules_to_save_bias_not_preserved_on_bias_none():
         full_finetuning=False, patch_modules_to_save=False,
     )
     params = dict(model.named_parameters())
-    # No bias leaks trainable on the bias='none' path...
     assert _trainable_bias_count(model) == 0, "bias='none' must leave all biases frozen"
-    # ...and the saved bias matches its weight (both frozen, not partially trained).
+    # Saved bias matches its weight (both frozen, not partially trained).
     assert params[saved_bias].requires_grad == params[saved_weight].requires_grad

--- a/tests/test_prepare_model_for_training_bias.py
+++ b/tests/test_prepare_model_for_training_bias.py
@@ -134,7 +134,15 @@ def test_peft_bias_gradient_flows_after_backward():
     )
 
     input_ids = torch.randint(0, 64, (1, 8))
-    model(input_ids=input_ids, labels=input_ids).loss.backward()
+    # Build the loss from logits on the CPU side rather than passing `labels=`:
+    # with unsloth installed the labelled forward routes through the fused CUDA
+    # cross-entropy (unsloth_fused_lm_head_loss), which calls torch.cuda
+    # mem_get_info and aborts on a CPU-only build. A plain logits-based scalar
+    # keeps this test genuinely CPU-only while still driving a real backward.
+    logits = model(input_ids=input_ids).logits.float()
+    loss = torch.nn.functional.cross_entropy(
+        logits.view(-1, logits.size(-1)), input_ids.view(-1))
+    loss.backward()
 
     params = dict(model.named_parameters())
     a_bias = next(n for n in params

--- a/tests/test_prepare_model_for_training_bias.py
+++ b/tests/test_prepare_model_for_training_bias.py
@@ -1,24 +1,22 @@
 """Regression tests for unsloth#2343: bias training was silently disabled.
 
 Pre-fix bug: `prepare_model_for_training`'s LoRA branch froze every parameter
-that was not a LoRA adapter weight:
+that was not a LoRA adapter weight, so `LoraConfig(bias="all")` / `bias="lora_only"`
+had no effect (PEFT enabled the biases, then this loop re-froze them).
 
-    if ".lora_A." in name or ".lora_B." in name or ".lora_magnitude_vector" in name:
-        requires_grad = True
-    else:
-        requires_grad = False   # <- also froze biases PEFT had marked trainable
+The fix preserves PEFT's bias decision. Important properties (each guarded below):
+  * bias="all"/"lora_only": the biases PEFT marked trainable stay trainable.
+  * bias="none" (default): biases stay frozen (byte-identical common path).
+  * a trainable bias keeps its loaded dtype, NOT fp32: upcasting a bias while its
+    Linear's weight stays bf16/fp16 breaks the matmul ("self and mat2 must have
+    the same dtype") -- the dtype-mismatch the fix must avoid.
+  * the preservation is gated to PEFT models: a freshly-loaded non-PEFT model
+    (whose nn.Linear biases default to requires_grad=True) is left frozen on the
+    LoRA (not full_finetuning) path.
 
-So `LoraConfig(bias="all")` / `bias="lora_only"` had no effect: PEFT enabled the
-biases, then this loop re-froze them. The fix keeps the PEFT decision for params
-whose name ends in `.bias` (preserve their incoming requires_grad and upcast the
-trainable ones to fp32 like LoRA adapters). `bias="none"` (the default) leaves
-biases frozen, so the common path is byte-identical.
-
-Pure CPU, tiny random Llama. The PEFT end-to-end test is gated on peft being
-importable (peft is excluded on darwin/arm64).
+Pure CPU, tiny random Llama. PEFT is required for the bias-preservation tests
+(peft is excluded on darwin/arm64), so those import-or-skip.
 """
-import os
-
 import pytest
 import torch
 from transformers import LlamaConfig, LlamaForCausalLM
@@ -47,154 +45,121 @@ def _bias_names(model):
     return [n for n, _ in model.named_parameters() if n.endswith(".bias")]
 
 
-# ---------------- core fix (no peft): PEFT's bias decision is respected -------
+def _lora(model, bias):
+    from peft import LoraConfig, get_peft_model
 
-def test_marked_biases_stay_trainable_after_prepare():
-    """Simulate PEFT bias='all' (every bias requires_grad=True). After prepare
-    the biases must remain trainable and the non-bias base weights frozen."""
+    return get_peft_model(
+        model,
+        LoraConfig(
+            r=8, lora_alpha=8, bias=bias,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                            "gate_proj", "up_proj", "down_proj"],
+        ),
+    )
+
+
+def _trainable_bias_count(model):
+    return sum(
+        p.requires_grad for n, p in model.named_parameters() if n.endswith(".bias"))
+
+
+# ---------------- PEFT bias decision is preserved ----------------------------
+
+def test_peft_bias_all_stays_trainable():
+    """bias='all': every bias PEFT enabled stays trainable after prepare."""
+    pytest.importorskip("peft")
     from unsloth_zoo.training_utils import prepare_model_for_training
 
-    model = _tiny_llama()
-    biases = _bias_names(model)
-    assert biases, "fixture must have bias params"
-    for n, p in model.named_parameters():
-        p.requires_grad_(n.endswith(".bias"))  # PEFT bias='all' shape
+    model = _lora(_tiny_llama(), bias="all")
+    before = _trainable_bias_count(model)
+    assert before > 0, "PEFT should enable biases for bias='all'"
 
     prepare_model_for_training(
         model, use_gradient_checkpointing=False, use_reentrant=False,
         full_finetuning=False,
     )
-
+    after = _trainable_bias_count(model)
+    assert after == before, f"bias='all' lost trainable biases: {before} -> {after}"
+    # The non-bias base weights must remain frozen.
     params = dict(model.named_parameters())
-    for n in biases:
-        assert params[n].requires_grad, f"{n} should stay trainable (bias='all')"
-    # A representative non-bias base weight must be frozen.
-    assert not params["model.layers.0.self_attn.q_proj.weight"].requires_grad
+    base_w = next(n for n in params
+                  if n.endswith("q_proj.base_layer.weight"))
+    assert not params[base_w].requires_grad
 
 
-def test_default_biases_stay_frozen():
-    """bias='none' shape: nothing marked trainable -> biases stay frozen, i.e.
-    byte-identical to pre-fix behaviour on the common path."""
+def test_peft_bias_none_stays_frozen():
+    """bias='none' (default): no biases trainable before or after -> unchanged."""
+    pytest.importorskip("peft")
     from unsloth_zoo.training_utils import prepare_model_for_training
 
-    model = _tiny_llama()
-    for _, p in model.named_parameters():
-        p.requires_grad_(False)
-
+    model = _lora(_tiny_llama(), bias="none")
     prepare_model_for_training(
         model, use_gradient_checkpointing=False, use_reentrant=False,
         full_finetuning=False,
     )
-
-    params = dict(model.named_parameters())
-    for n in _bias_names(model):
-        assert not params[n].requires_grad, f"{n} should stay frozen (bias='none')"
+    assert _trainable_bias_count(model) == 0
 
 
-def test_trainable_bias_is_upcast_to_fp32():
-    """A trainable bias is upcast to fp32 (like LoRA adapters); a frozen one
-    keeps its loaded (bf16) dtype."""
+def test_peft_trainable_bias_keeps_module_dtype():
+    """A trainable bias must keep its Linear's (bf16) dtype, NOT be upcast to
+    fp32 -- otherwise the bf16 weight @ fp32 bias matmul raises
+    'self and mat2 must have the same dtype'. Regression guard for the review fix.
+    """
+    pytest.importorskip("peft")
     from unsloth_zoo.training_utils import prepare_model_for_training
 
-    model = _tiny_llama(dtype=torch.bfloat16)
-    names = _bias_names(model)
-    trainable_bias = names[0]
-    # Mark exactly one bias trainable (mimics bias='lora_only' picking a subset).
-    for n, p in model.named_parameters():
-        p.requires_grad_(n == trainable_bias)
-
+    model = _lora(_tiny_llama(dtype=torch.bfloat16), bias="all")
     prepare_model_for_training(
         model, use_gradient_checkpointing=False, use_reentrant=False,
         full_finetuning=False, float32_mixed_precision=True,
     )
-
     params = dict(model.named_parameters())
-    assert params[trainable_bias].dtype == torch.float32
-    assert params[trainable_bias].requires_grad
-    # An untouched, frozen bias is not recast.
-    frozen_bias = names[1]
-    assert params[frozen_bias].dtype == torch.bfloat16
-    assert not params[frozen_bias].requires_grad
+    bias_name = next(n for n in params
+                     if n.endswith(".bias") and params[n].requires_grad)
+    weight_name = bias_name[:-len("bias")] + "weight"
+    assert params[bias_name].dtype == torch.bfloat16, params[bias_name].dtype
+    assert params[bias_name].dtype == params[weight_name].dtype
 
 
-def test_bias_gradient_flows_after_backward():
-    """End-to-end on CPU: with biases trainable, a backward pass populates
-    their .grad; a frozen base weight gets no grad."""
+def test_peft_bias_gradient_flows_after_backward():
+    """End-to-end on CPU: with bias='all', a backward pass populates a finite
+    gradient on a trainable bias; a frozen base weight gets none."""
+    pytest.importorskip("peft")
     from unsloth_zoo.training_utils import prepare_model_for_training
 
-    model = _tiny_llama()
-    for n, p in model.named_parameters():
-        p.requires_grad_(n.endswith(".bias"))
-
+    model = _lora(_tiny_llama(), bias="all")
     prepare_model_for_training(
         model, use_gradient_checkpointing=False, use_reentrant=False,
         full_finetuning=False,
     )
 
     input_ids = torch.randint(0, 64, (1, 8))
-    out = model(input_ids=input_ids, labels=input_ids)
-    out.loss.backward()
+    model(input_ids=input_ids, labels=input_ids).loss.backward()
 
     params = dict(model.named_parameters())
-    a_bias = _bias_names(model)[0]
+    a_bias = next(n for n in params
+                  if n.endswith(".bias") and params[n].requires_grad)
     assert params[a_bias].grad is not None, "trainable bias must receive a grad"
-    assert params[a_bias].grad.abs().sum() >= 0  # finite, allocated
-    # A frozen base weight must not accumulate a grad.
-    assert params["model.layers.0.self_attn.q_proj.weight"].grad is None
+    assert torch.isfinite(params[a_bias].grad).all(), "bias grad must be finite"
+    base_w = next(n for n in params if n.endswith("q_proj.base_layer.weight"))
+    assert params[base_w].grad is None, "frozen base weight must not accumulate grad"
 
 
-# ---------------- PEFT end-to-end (gated on peft) ----------------------------
+# ---------------- non-PEFT models are left frozen ----------------------------
 
-def test_peft_bias_all_end_to_end():
-    """Through real PEFT: LoraConfig(bias='all') biases stay trainable after
-    prepare_model_for_training (the exact path from the issue repro)."""
-    peft = pytest.importorskip("peft")
-    from peft import LoraConfig, get_peft_model
+def test_non_peft_model_biases_stay_frozen():
+    """A non-PEFT model's nn.Linear biases default to requires_grad=True. On the
+    LoRA (not full_finetuning) path they must still be frozen -- the bias
+    preservation is only a PEFT decision, so a raw model is unaffected."""
     from unsloth_zoo.training_utils import prepare_model_for_training
 
-    model = _tiny_llama()
-    model = get_peft_model(
-        model,
-        LoraConfig(
-            r=8, lora_alpha=8, bias="all",
-            target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
-                            "gate_proj", "up_proj", "down_proj"],
-        ),
-    )
-    trainable_before = sum(
-        p.requires_grad for n, p in model.named_parameters() if n.endswith(".bias"))
-    assert trainable_before > 0  # PEFT enabled the biases
+    model = _tiny_llama()  # plain LlamaForCausalLM, no PEFT
+    assert any(p.requires_grad for n, p in model.named_parameters()
+               if n.endswith(".bias")), "fresh nn.Linear biases default to trainable"
 
     prepare_model_for_training(
         model, use_gradient_checkpointing=False, use_reentrant=False,
         full_finetuning=False,
     )
-
-    trainable_after = sum(
-        p.requires_grad for n, p in model.named_parameters() if n.endswith(".bias"))
-    assert trainable_after == trainable_before, (
-        f"bias='all' lost trainable biases: {trainable_before} -> {trainable_after}")
-
-
-def test_peft_bias_none_end_to_end():
-    """bias='none' (default): no biases trainable before or after -> unchanged."""
-    pytest.importorskip("peft")
-    from peft import LoraConfig, get_peft_model
-    from unsloth_zoo.training_utils import prepare_model_for_training
-
-    model = _tiny_llama()
-    model = get_peft_model(
-        model,
-        LoraConfig(
-            r=8, lora_alpha=8, bias="none",
-            target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
-                            "gate_proj", "up_proj", "down_proj"],
-        ),
-    )
-    prepare_model_for_training(
-        model, use_gradient_checkpointing=False, use_reentrant=False,
-        full_finetuning=False,
-    )
-    trainable_after = sum(
-        p.requires_grad for n, p in model.named_parameters() if n.endswith(".bias"))
-    assert trainable_after == 0
+    assert _trainable_bias_count(model) == 0, \
+        "non-PEFT biases must be frozen on the LoRA path"

--- a/tests/test_prepare_model_for_training_bias.py
+++ b/tests/test_prepare_model_for_training_bias.py
@@ -1,21 +1,16 @@
 """Regression tests for unsloth#2343: bias training was silently disabled.
 
-Pre-fix bug: `prepare_model_for_training`'s LoRA branch froze every parameter
-that was not a LoRA adapter weight, so `LoraConfig(bias="all")` / `bias="lora_only"`
-had no effect (PEFT enabled the biases, then this loop re-froze them).
+The LoRA branch of prepare_model_for_training froze every non-adapter param, so
+LoraConfig(bias="all"/"lora_only") had no effect. The fix preserves PEFT's bias
+decision; properties guarded below:
+  * bias="all"/"lora_only": PEFT-enabled biases stay trainable.
+  * bias="none" (default): biases stay frozen.
+  * a trainable bias keeps its loaded dtype, not fp32 (an fp32 bias on a bf16/fp16
+    Linear breaks the matmul with a dtype mismatch).
+  * gated to PEFT models, so a non-PEFT model's biases stay frozen on the LoRA path.
 
-The fix preserves PEFT's bias decision. Important properties (each guarded below):
-  * bias="all"/"lora_only": the biases PEFT marked trainable stay trainable.
-  * bias="none" (default): biases stay frozen (byte-identical common path).
-  * a trainable bias keeps its loaded dtype, NOT fp32: upcasting a bias while its
-    Linear's weight stays bf16/fp16 breaks the matmul ("self and mat2 must have
-    the same dtype") -- the dtype-mismatch the fix must avoid.
-  * the preservation is gated to PEFT models: a freshly-loaded non-PEFT model
-    (whose nn.Linear biases default to requires_grad=True) is left frozen on the
-    LoRA (not full_finetuning) path.
-
-Pure CPU, tiny random Llama. PEFT is required for the bias-preservation tests
-(peft is excluded on darwin/arm64), so those import-or-skip.
+Pure CPU, tiny random Llama. PEFT tests import-or-skip (peft is excluded on
+darwin/arm64).
 """
 import pytest
 import torch
@@ -101,10 +96,8 @@ def test_peft_bias_none_stays_frozen():
 
 
 def test_peft_trainable_bias_keeps_module_dtype():
-    """A trainable bias must keep its Linear's (bf16) dtype, NOT be upcast to
-    fp32 -- otherwise the bf16 weight @ fp32 bias matmul raises
-    'self and mat2 must have the same dtype'. Regression guard for the review fix.
-    """
+    """A trainable bias keeps its Linear's bf16 dtype, not fp32; an fp32 bias on a
+    bf16 weight raises 'self and mat2 must have the same dtype'."""
     pytest.importorskip("peft")
     from unsloth_zoo.training_utils import prepare_model_for_training
 
@@ -134,11 +127,9 @@ def test_peft_bias_gradient_flows_after_backward():
     )
 
     input_ids = torch.randint(0, 64, (1, 8))
-    # Build the loss from logits on the CPU side rather than passing `labels=`:
-    # with unsloth installed the labelled forward routes through the fused CUDA
-    # cross-entropy (unsloth_fused_lm_head_loss), which calls torch.cuda
-    # mem_get_info and aborts on a CPU-only build. A plain logits-based scalar
-    # keeps this test genuinely CPU-only while still driving a real backward.
+    # Loss from logits, not labels=: with unsloth the labelled forward uses the
+    # fused CUDA cross-entropy, which aborts on a CPU-only build. A logits scalar
+    # stays CPU-only while still driving a real backward.
     logits = model(input_ids=input_ids).logits.float()
     loss = torch.nn.functional.cross_entropy(
         logits.view(-1, logits.size(-1)), input_ids.view(-1))
@@ -150,8 +141,7 @@ def test_peft_bias_gradient_flows_after_backward():
     a_grad = params[a_bias].grad
     assert a_grad is not None, "trainable bias must receive a grad"
     assert torch.isfinite(a_grad).all(), "bias grad must be finite"
-    # Strictly > 0 (not just >= 0, which holds for any tensor): proves a gradient
-    # actually flowed into the bias rather than the param merely being allocated.
+    # Strictly > 0 proves a gradient actually flowed, not just that grad exists.
     assert a_grad.abs().sum() > 0, "bias grad must be non-zero (gradient flowed)"
     base_w = next(n for n in params if n.endswith("q_proj.base_layer.weight"))
     assert params[base_w].grad is None, "frozen base weight must not accumulate grad"
@@ -160,9 +150,8 @@ def test_peft_bias_gradient_flows_after_backward():
 # ---------------- non-PEFT models are left frozen ----------------------------
 
 def test_non_peft_model_biases_stay_frozen():
-    """A non-PEFT model's nn.Linear biases default to requires_grad=True. On the
-    LoRA (not full_finetuning) path they must still be frozen -- the bias
-    preservation is only a PEFT decision, so a raw model is unaffected."""
+    """A non-PEFT model's biases default to requires_grad=True but must still be
+    frozen on the LoRA path; bias preservation is a PEFT-only decision."""
     from unsloth_zoo.training_utils import prepare_model_for_training
 
     model = _tiny_llama()  # plain LlamaForCausalLM, no PEFT
@@ -180,18 +169,17 @@ def test_non_peft_model_biases_stay_frozen():
 # ---------------- modules_to_save biases are not a bias decision -------------
 
 def test_modules_to_save_bias_not_preserved_on_bias_none():
-    """bias='none' + modules_to_save: PEFT marks the saved module's bias trainable
-    because the whole module is saved, NOT because of a LoRA bias decision. With the
-    default patch_modules_to_save=False the saved module's weight stays frozen here,
-    so its bias must stay frozen too -- otherwise we partially train a saved head and
-    silently change the bias='none' path (#2343 review). The saved bias and weight
-    must end up with the same requires_grad state."""
+    """bias='none' + modules_to_save: PEFT marks the saved module trainable because
+    the whole module is saved, not as a bias decision. With patch_modules_to_save=False
+    the saved weight stays frozen, so its bias must too (else a saved head is partially
+    trained, changing the bias='none' path, #2343 review). Bias and weight must share
+    requires_grad."""
     pytest.importorskip("peft")
     from peft import LoraConfig, get_peft_model
     from unsloth_zoo.training_utils import prepare_model_for_training
 
-    # gate_proj is an nn.Linear with a bias (mlp_bias=True) and is NOT a LoRA target
-    # here, so PEFT wraps it as a saved module: gate_proj.modules_to_save.default.*.
+    # gate_proj has a bias (mlp_bias=True) and is not a LoRA target, so PEFT wraps
+    # it as a saved module: gate_proj.modules_to_save.default.*.
     model = get_peft_model(
         _tiny_llama(),
         LoraConfig(

--- a/tests/test_prepare_model_for_training_bias.py
+++ b/tests/test_prepare_model_for_training_bias.py
@@ -139,8 +139,12 @@ def test_peft_bias_gradient_flows_after_backward():
     params = dict(model.named_parameters())
     a_bias = next(n for n in params
                   if n.endswith(".bias") and params[n].requires_grad)
-    assert params[a_bias].grad is not None, "trainable bias must receive a grad"
-    assert torch.isfinite(params[a_bias].grad).all(), "bias grad must be finite"
+    a_grad = params[a_bias].grad
+    assert a_grad is not None, "trainable bias must receive a grad"
+    assert torch.isfinite(a_grad).all(), "bias grad must be finite"
+    # Strictly > 0 (not just >= 0, which holds for any tensor): proves a gradient
+    # actually flowed into the bias rather than the param merely being allocated.
+    assert a_grad.abs().sum() > 0, "bias grad must be non-zero (gradient flowed)"
     base_w = next(n for n in params if n.endswith("q_proj.base_layer.weight"))
     assert params[base_w].grad is None, "frozen base weight must not accumulate grad"
 
@@ -163,3 +167,43 @@ def test_non_peft_model_biases_stay_frozen():
     )
     assert _trainable_bias_count(model) == 0, \
         "non-PEFT biases must be frozen on the LoRA path"
+
+
+# ---------------- modules_to_save biases are not a bias decision -------------
+
+def test_modules_to_save_bias_not_preserved_on_bias_none():
+    """bias='none' + modules_to_save: PEFT marks the saved module's bias trainable
+    because the whole module is saved, NOT because of a LoRA bias decision. With the
+    default patch_modules_to_save=False the saved module's weight stays frozen here,
+    so its bias must stay frozen too -- otherwise we partially train a saved head and
+    silently change the bias='none' path (#2343 review). The saved bias and weight
+    must end up with the same requires_grad state."""
+    pytest.importorskip("peft")
+    from peft import LoraConfig, get_peft_model
+    from unsloth_zoo.training_utils import prepare_model_for_training
+
+    # gate_proj is an nn.Linear with a bias (mlp_bias=True) and is NOT a LoRA target
+    # here, so PEFT wraps it as a saved module: gate_proj.modules_to_save.default.*.
+    model = get_peft_model(
+        _tiny_llama(),
+        LoraConfig(
+            r=8, lora_alpha=8, bias="none",
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            modules_to_save=["gate_proj"],
+        ),
+    )
+    saved = [n for n, _ in model.named_parameters() if ".modules_to_save." in n]
+    saved_bias = next(n for n in saved if n.endswith(".bias"))
+    saved_weight = next(n for n in saved if n.endswith(".weight"))
+    params = dict(model.named_parameters())
+    assert params[saved_bias].requires_grad, "PEFT should mark the saved module trainable"
+
+    prepare_model_for_training(
+        model, use_gradient_checkpointing=False, use_reentrant=False,
+        full_finetuning=False, patch_modules_to_save=False,
+    )
+    params = dict(model.named_parameters())
+    # No bias leaks trainable on the bias='none' path...
+    assert _trainable_bias_count(model) == 0, "bias='none' must leave all biases frozen"
+    # ...and the saved bias matches its weight (both frozen, not partially trained).
+    assert params[saved_bias].requires_grad == params[saved_weight].requires_grad

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -369,9 +369,8 @@ def prepare_model_for_training(
             or "norm2." in nm
         )
 
-    # Gate the bias branch to PEFT models: a non-PEFT model's nn.Linear biases
-    # default to requires_grad=True, which would otherwise keep them all trainable
-    # on the LoRA (not full_finetuning) path (#2343 review).
+    # Gate the bias branch to PEFT: non-PEFT nn.Linear biases default to
+    # requires_grad=True and would all stay trainable on the LoRA path (#2343 review).
     _is_peft_model = hasattr(model, "peft_config")
 
     for name, param in model.named_parameters():
@@ -386,15 +385,11 @@ def prepare_model_for_training(
                 requires_grad = True
             elif (_is_peft_model and "bias" in name and param.requires_grad
                     and ".modules_to_save." not in name):
-                # Respect PEFT's bias decision: LoraConfig(bias="all"/"lora_only")
-                # marks biases trainable, and blindly freezing them here disabled
-                # bias training (#2343). bias="none" keeps biases frozen via the else.
-                # Keep the bias at its loaded dtype: upcasting to fp32 while the
-                # Linear weight stays bf16/fp16 breaks the matmul (dtype mismatch).
-                # Exclude modules_to_save: PEFT marks those trainable because the whole
-                # module is saved, not as a bias decision; with the default
-                # patch_modules_to_save=False the saved weight stays frozen, so keeping
-                # its bias would partially train a saved head (#2343 review).
+                # Respect PEFT's bias decision: bias="all"/"lora_only" marks biases
+                # trainable; freezing them here disabled bias training (#2343).
+                # _keep_param_dtype: keep the loaded dtype, since fp32 on a bf16/fp16
+                # Linear breaks the matmul. modules_to_save is excluded so a saved head
+                # with a frozen weight isn't partially trained via its bias (#2343 review).
                 requires_grad = True
                 _keep_param_dtype = True
             else:
@@ -417,8 +412,8 @@ def prepare_model_for_training(
             param.requires_grad_(False)
 
         # Cast storage in place (keeps Parameter identity so tied weights stay tied);
-        # skip externally-managed params (preserve their fp32 cast) and params pinned
-        # to their loaded dtype (trainable biases must match their Linear weight).
+        # skip externally-managed params (preserve their fp32 cast) and dtype-pinned
+        # params (trainable biases must match their Linear weight).
         if (requires_grad
                 and not _keep_param_dtype
                 and id(param) not in _externally_managed_param_ids):

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -369,23 +369,33 @@ def prepare_model_for_training(
             or "norm2." in nm
         )
 
+    # Only honor an incoming bias requires_grad as a PEFT decision on an actual
+    # PEFT model. On a freshly-loaded non-PEFT model every nn.Linear bias defaults
+    # to requires_grad=True, so without this gate the bias branch below would keep
+    # all biases trainable for a LoRA-style (not full_finetuning) call (#2343 review).
+    _is_peft_model = hasattr(model, "peft_config")
+
     for name, param in model.named_parameters():
         original_name = name
         upcast = False
         requires_grad = False
+        _keep_param_dtype = False
         _is_norm = _is_norm_parameter(original_name, param)
         if not full_finetuning:
             if ".lora_A." in name or ".lora_B." in name or ".lora_magnitude_vector" in name:
                 upcast = True
                 requires_grad = True
-            elif name.endswith(".bias"):
+            elif _is_peft_model and "bias" in name and param.requires_grad:
                 # Respect PEFT's bias decision. LoraConfig(bias="all"/"lora_only")
-                # marks the relevant biases trainable; blindly freezing every
-                # non-LoRA param here silently disabled bias training (#2343).
-                # bias="none" (the default) leaves biases frozen, so this keeps
-                # requires_grad = False and is a no-op for the common path.
-                requires_grad = param.requires_grad
-                upcast = requires_grad
+                # marks bias params trainable (PEFT itself tests `"bias" in name`);
+                # blindly freezing every non-LoRA param here silently disabled bias
+                # training (#2343). bias="none" (the default) leaves biases frozen,
+                # so they fall through to the else and stay frozen. Keep a trainable
+                # bias at its loaded dtype: upcasting it to fp32 while the Linear's
+                # weight stays bf16/fp16 breaks the matmul ("self and mat2 must have
+                # the same dtype").
+                requires_grad = True
+                _keep_param_dtype = True
             else:
                 requires_grad = False
         else:
@@ -406,8 +416,12 @@ def prepare_model_for_training(
             param.requires_grad_(False)
 
         # Cast storage in place (keeps Parameter identity so tied weights stay tied);
-        # skip externally-managed params so we don't undo their fp32 cast.
-        if requires_grad and id(param) not in _externally_managed_param_ids:
+        # skip externally-managed params so we don't undo their fp32 cast, and skip
+        # params we must leave at their loaded dtype (trainable biases, which have to
+        # match their Linear's weight dtype).
+        if (requires_grad
+                and not _keep_param_dtype
+                and id(param) not in _externally_managed_param_ids):
             dtype = torch.float32 if upcast else mixed_precision_dtype
             if param.dtype != dtype:
                 param.data = param.data.to(dtype)

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -369,10 +369,9 @@ def prepare_model_for_training(
             or "norm2." in nm
         )
 
-    # Only honor an incoming bias requires_grad as a PEFT decision on an actual
-    # PEFT model. On a freshly-loaded non-PEFT model every nn.Linear bias defaults
-    # to requires_grad=True, so without this gate the bias branch below would keep
-    # all biases trainable for a LoRA-style (not full_finetuning) call (#2343 review).
+    # Gate the bias branch to PEFT models: a non-PEFT model's nn.Linear biases
+    # default to requires_grad=True, which would otherwise keep them all trainable
+    # on the LoRA (not full_finetuning) path (#2343 review).
     _is_peft_model = hasattr(model, "peft_config")
 
     for name, param in model.named_parameters():
@@ -387,20 +386,15 @@ def prepare_model_for_training(
                 requires_grad = True
             elif (_is_peft_model and "bias" in name and param.requires_grad
                     and ".modules_to_save." not in name):
-                # Respect PEFT's bias decision. LoraConfig(bias="all"/"lora_only")
-                # marks bias params trainable (PEFT itself tests `"bias" in name`);
-                # blindly freezing every non-LoRA param here silently disabled bias
-                # training (#2343). bias="none" (the default) leaves biases frozen,
-                # so they fall through to the else and stay frozen. Keep a trainable
-                # bias at its loaded dtype: upcasting it to fp32 while the Linear's
-                # weight stays bf16/fp16 breaks the matmul ("self and mat2 must have
-                # the same dtype").
-                # Exclude modules_to_save: PEFT marks a saved module's bias trainable
-                # because the whole module is saved, not as a LoRA bias decision. With
-                # the default patch_modules_to_save=False the saved weight stays frozen
-                # here, so preserving its bias would partially train a saved head and
-                # change the bias="none" path (#2343 review). When the caller opts into
-                # patch_modules_to_save the block below re-enables the whole module.
+                # Respect PEFT's bias decision: LoraConfig(bias="all"/"lora_only")
+                # marks biases trainable, and blindly freezing them here disabled
+                # bias training (#2343). bias="none" keeps biases frozen via the else.
+                # Keep the bias at its loaded dtype: upcasting to fp32 while the
+                # Linear weight stays bf16/fp16 breaks the matmul (dtype mismatch).
+                # Exclude modules_to_save: PEFT marks those trainable because the whole
+                # module is saved, not as a bias decision; with the default
+                # patch_modules_to_save=False the saved weight stays frozen, so keeping
+                # its bias would partially train a saved head (#2343 review).
                 requires_grad = True
                 _keep_param_dtype = True
             else:
@@ -423,9 +417,8 @@ def prepare_model_for_training(
             param.requires_grad_(False)
 
         # Cast storage in place (keeps Parameter identity so tied weights stay tied);
-        # skip externally-managed params so we don't undo their fp32 cast, and skip
-        # params we must leave at their loaded dtype (trainable biases, which have to
-        # match their Linear's weight dtype).
+        # skip externally-managed params (preserve their fp32 cast) and params pinned
+        # to their loaded dtype (trainable biases must match their Linear weight).
         if (requires_grad
                 and not _keep_param_dtype
                 and id(param) not in _externally_managed_param_ids):

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -385,7 +385,8 @@ def prepare_model_for_training(
             if ".lora_A." in name or ".lora_B." in name or ".lora_magnitude_vector" in name:
                 upcast = True
                 requires_grad = True
-            elif _is_peft_model and "bias" in name and param.requires_grad:
+            elif (_is_peft_model and "bias" in name and param.requires_grad
+                    and ".modules_to_save." not in name):
                 # Respect PEFT's bias decision. LoraConfig(bias="all"/"lora_only")
                 # marks bias params trainable (PEFT itself tests `"bias" in name`);
                 # blindly freezing every non-LoRA param here silently disabled bias
@@ -394,6 +395,12 @@ def prepare_model_for_training(
                 # bias at its loaded dtype: upcasting it to fp32 while the Linear's
                 # weight stays bf16/fp16 breaks the matmul ("self and mat2 must have
                 # the same dtype").
+                # Exclude modules_to_save: PEFT marks a saved module's bias trainable
+                # because the whole module is saved, not as a LoRA bias decision. With
+                # the default patch_modules_to_save=False the saved weight stays frozen
+                # here, so preserving its bias would partially train a saved head and
+                # change the bias="none" path (#2343 review). When the caller opts into
+                # patch_modules_to_save the block below re-enables the whole module.
                 requires_grad = True
                 _keep_param_dtype = True
             else:

--- a/unsloth_zoo/training_utils.py
+++ b/unsloth_zoo/training_utils.py
@@ -378,6 +378,14 @@ def prepare_model_for_training(
             if ".lora_A." in name or ".lora_B." in name or ".lora_magnitude_vector" in name:
                 upcast = True
                 requires_grad = True
+            elif name.endswith(".bias"):
+                # Respect PEFT's bias decision. LoraConfig(bias="all"/"lora_only")
+                # marks the relevant biases trainable; blindly freezing every
+                # non-LoRA param here silently disabled bias training (#2343).
+                # bias="none" (the default) leaves biases frozen, so this keeps
+                # requires_grad = False and is a no-op for the common path.
+                requires_grad = param.requires_grad
+                upcast = requires_grad
             else:
                 requires_grad = False
         else:


### PR DESCRIPTION
### Summary

Fixes unslothai/unsloth#2343: bias training is silently disabled. `prepare_model_for_training`
froze every parameter that was not a LoRA adapter weight:

```python
if ".lora_A." in name or ".lora_B." in name or ".lora_magnitude_vector" in name:
    requires_grad = True
else:
    requires_grad = False   # also froze biases PEFT had marked trainable
```

So `LoraConfig(bias="all")` / `bias="lora_only"` had no effect: PEFT enables the biases, then this
loop re-freezes them. The reporter saw the trainable-parameter count stay identical regardless of the
`bias` setting, which I reproduced on a tiny model:

```
bias='none'  total_bias=14  trainable_after_PEFT= 0  trainable_after_prepare= 0
bias='all'   total_bias=14  trainable_after_PEFT=14  trainable_after_prepare= 0   <- bug
```

### Change

Keep PEFT's decision for parameters whose name ends in `.bias`: preserve their incoming
`requires_grad` and upcast the trainable ones to float32 like the LoRA adapters. `bias="none"` (the
default) leaves biases frozen, so the common LoRA / QLoRA path is byte-identical. Full finetuning is
untouched (the change is inside the `if not full_finetuning:` branch).

After the fix:

```
bias='all'   total_bias=14  trainable_after_PEFT=14  trainable_after_prepare=14   <- fixed
bias='none'  total_bias=14  trainable_after_PEFT= 0  trainable_after_prepare= 0   <- unchanged
```

### Tests

`tests/test_prepare_model_for_training_bias.py` (pure CPU, tiny random Llama):

- marked biases stay trainable, default biases stay frozen, the non-bias base weights stay frozen;
- a trainable bias is upcast to fp32 while a frozen one keeps its loaded dtype;
- a real forward / backward populates the trainable bias `.grad` and leaves a frozen weight with none;
- a PEFT end-to-end check for `bias="all"` / `bias="none"` (gated on peft being importable, since peft
  is excluded on darwin/arm64).

Existing `prepare_model_for_training` suites still pass locally (the fp32-norms, use-cache, and
upstream source-pattern / signature tests), so there is no regression to the LoRA, full-FT, or norm
paths.
