### PR TITLE
fix(diffusion_studio): specify utf-8 encoding for Windows compatibility

### DIFF
--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -355,7 +355,7 @@ def main():
                     help="per-turn context budget; 0 = auto-size the largest that fits VRAM")
     args = ap.parse_args()
 
-    _STATE["player"] = open(_PLAYER_TEMPLATE).read()
+    _STATE["player"] = open(_PLAYER_TEMPLATE, encoding="utf-8").read()
     print(f"loading {args.gguf} on GPU {args.gpu} (optimized visual decoder) ...", flush=True)
     _STATE["server"] = V.VisualServer(args.gguf, gpu=args.gpu, maxtok=args.maxtok)
     print(f"DiffusionGemma OpenAI shim ready on http://{args.host}:{args.port}  (model={MODEL_ID})",

--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -194,7 +194,7 @@ class VisualServer:
         """Launch the subprocess and finish the READY handshake. Used at startup and by restart()
         after a crash (re-loads the model, so it costs tens of seconds)."""
         self.p = subprocess.Popen([self.server_bin, self.gguf], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                  env=self.env, bufsize=1, text=True,
+                                  env=self.env, bufsize=1, text=True, encoding="utf-8",
                                   preexec_fn=_set_pdeathsig if os.name == "posix" else None)
         line = self.p.stdout.readline().strip()
         if not line.startswith("READY"):
@@ -221,7 +221,7 @@ class VisualServer:
         # strand this and every later turn with a broken pipe.
         if self.p is None or self.p.poll() is not None:
             self.restart()
-        with open(self.req, "w") as f:
+        with open(self.req, "w", encoding="utf-8") as f:
             json.dump({"seed": int(seed), "n_blocks": int(n_blocks), "messages": messages}, f,
                       ensure_ascii=False)
         try:


### PR DESCRIPTION
# Bug Report: UnicodeEncodeError (charmap codec) on Windows

## Problem Description

When running **Unsloth Studio** on Windows, if a chat prompt, system prompt, or template contains non-ASCII Unicode characters (such as the right arrow symbol `→` / `\u2192`, which is common in many chat templates), the inference process crashes immediately with a Python encoding error:

```
[engine error: 'charmap' codec can't encode character '\u2192' in position 3140: character maps to <undefined>]
```

This error is generated by the `unsloth_zoo.diffusion_studio.shim` server process and returned to the client as an assistant response block.

---

## Root Cause

On Windows, Python's built-in `open()` function and the `subprocess.Popen(..., text=True)` interface default to the system's preferred ANSI code page (typically `cp1252` or another charmap encoding depending on the system locale), rather than UTF-8. 

There are three places in the Unsloth Studio backend where this triggers crashes or potential text corruption:

1. **`visual_engine.py` — File I/O encoding:**
   In `visual_engine.py`, the request file used to communicate with the child process (`VisualServer`) is written using:
   ```python
   with open(self.req, "w") as f:
       json.dump({"seed": int(seed), "n_blocks": int(n_blocks), "messages": messages}, f, ensure_ascii=False)
   ```
   Because `encoding="utf-8"` is not specified and `ensure_ascii=False` is passed, `json.dump` attempts to write raw Unicode characters directly to the file stream. The ANSI file stream fails to encode the character `→` (`\u2192`) and throws a `UnicodeEncodeError`.

2. **`visual_engine.py` — Subprocess Pipe encoding:**
   The `VisualServer` subprocess (`llama-diffusion-gemma-visual-server`) is spawned with `text=True`:
   ```python
   self.p = subprocess.Popen([self.server_bin, self.gguf], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                             env=self.env, bufsize=1, text=True, ...)
   ```
   Without an explicit `encoding="utf-8"`, the parent Python process reads the child process's stdout pipe using the system default ANSI encoding. If the child process output contains Unicode characters, reading lines from stdout will result in incorrect decoding (text corruption) or a `UnicodeDecodeError`.

3. **`shim.py` — Template loader encoding:**
   The canvas player HTML template is loaded via:
   ```python
   _STATE["player"] = open(_PLAYER_TEMPLATE).read()
   ```
   This should also specify `encoding="utf-8"` to prevent crashes if the HTML template or surrounding paths ever contain non-ASCII characters.

---

## Proposed Fix / Git Diff

Applying the following modifications ensures that Unsloth Studio handles UTF-8 correctly across all platforms, including Windows:

### 1. Patch for `unsloth_zoo/diffusion_studio/visual_engine.py`

```diff
diff --git a/unsloth_zoo/diffusion_studio/visual_engine.py b/unsloth_zoo/diffusion_studio/visual_engine.py
index a204ba0..b272405 100644
--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -194,7 +194,7 @@ class VisualServer:
     def _spawn(self):
         """Launch the subprocess and finish the READY handshake."""
         self.p = subprocess.Popen([self.server_bin, self.gguf], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                  env=self.env, bufsize=1, text=True,
+                                  env=self.env, bufsize=1, text=True, encoding="utf-8",
                                   preexec_fn=_set_pdeathsig if os.name == "posix" else None)
         line = self.p.stdout.readline().strip()
         if not line.startswith("READY"):
@@ -221,7 +221,7 @@ class VisualServer:
         # strand this and every later turn with a broken pipe.
         if self.p is None or self.p.poll() is not None:
             self.restart()
-        with open(self.req, "w") as f:
+        with open(self.req, "w", encoding="utf-8") as f:
             json.dump({"seed": int(seed), "n_blocks": int(n_blocks), "messages": messages}, f,
                       ensure_ascii=False)
         try:
```

### 2. Patch for `unsloth_zoo/diffusion_studio/shim.py`

```diff
diff --git a/unsloth_zoo/diffusion_studio/shim.py b/unsloth_zoo/diffusion_studio/shim.py
index e36d1f0..22104bf 100644
--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -355,7 +355,7 @@ def main():
                     help="per-turn context budget; 0 = auto-size the largest that fits VRAM")
     args = ap.parse_args()
 
-    _STATE["player"] = open(_PLAYER_TEMPLATE).read()
+    _STATE["player"] = open(_PLAYER_TEMPLATE, encoding="utf-8").read()
     print(f"loading {args.gguf} on GPU {args.gpu} (optimized visual decoder) ...", flush=True)
     _STATE["server"] = V.VisualServer(args.gguf, gpu=args.gpu, maxtok=args.maxtok)
     print(f"DiffusionGemma OpenAI shim ready on http://{args.host}:{args.port}  (model={MODEL_ID})",
```
