### PR TITLE
peft_utils: target NemotronH `mixer` attention/MLP layers in get_peft_regex

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -60,8 +60,8 @@ def get_peft_regex(
     target_modules             : List[str] = None,
     vision_tags                : List[str] = ["vision", "image", "visual", "patch",],
     language_tags              : List[str] = ["language", "text",],
-    attention_tags             : List[str] = ["self_attn", "attention", "attn",],
-    mlp_tags                   : List[str] = ["mlp", "feed_forward", "ffn", "dense",],
+    attention_tags             : List[str] = ["self_attn", "attention", "attn", "mixer",],
+    mlp_tags                   : List[str] = ["mlp", "feed_forward", "ffn", "dense", "mixer",],
 ) -> str:
     """
     Create a regex pattern to apply LoRA to only select layers of a model.


### PR DESCRIPTION
### Summary

NemotronH (`model_type: nemotron_h`; models `unsloth/NVIDIA-Nemotron-3-Nano-4B`, `-Nano-9B-v2`, `Nemotron-3-Nano-30B-A3B`) names every layer `backbone.layers.N.mixer.{q,k,v,o,up,down}_proj` with a non-gated MLP (no `gate_proj`). None of the existing `attention_tags` or `mlp_tags` in `get_peft_regex` match the `mixer` segment, so `get_peft_model` raises:

```
RuntimeError: Unsloth: No layers to finetune
```

This adds `"mixer"` to both the attention and MLP tag lists so these layers are matched.

### Change

In `unsloth_zoo/peft_utils.py`, `get_peft_regex`:

```python
attention_tags = ["self_attn", "attention", "attn", "mixer",]
mlp_tags       = ["mlp", "feed_forward", "ffn", "dense", "mixer",]
```

### Verification

- With the patch, the original failing call `get_peft_model(... target_modules=["q_proj", ..., "down_proj"] ...)` attaches 100 LoRA adapters on Nemotron-3-Nano-4B and trains (loss 3.98 -> 0.0001, reproduces the target string).
- Regression-checked across 16 architectures (Llama, Qwen2, Qwen3, Phi, Mistral, gemma2, gemma3, SmolLM, Qwen3-MoE, gpt-oss, Falcon-H1, granite-4.0-h, granite-4.1, Qwen2-VL, gemma-3-4b): the matched LoRA-target set is byte-identical with and without `mixer`.
- Only NemotronH changes (0 -> the correct 50 attention and MLP `mixer.*_proj` layers).
- Mamba `in_proj` / `out_proj` stay untouched (they are not in the default target list).
