### PR TITLE
Gemma 4 E-series: stop inverting the correct use_cache=False forward

### DIFF
--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -425,37 +425,22 @@ def _patch_forward_for_kv_shared_no_cache(cls):
     cls.forward = _make_kv_shared_use_cache_false_safe_forward(cls.forward)
 
 
+# NOTE: On the Gemma-4 E-series (E2B / E4B, num_kv_shared_layers > 0) in
+# transformers 5.5.0 the cache-free forward (use_cache=False) is the CORRECT
+# path: teacher-forced loss goes to 0 and greedy decode reproduces the target,
+# while the KV-cache path (use_cache=True) is the broken one
+# (huggingface/transformers#45242). Wrapping the forward to build an internal
+# cache for use_cache=False therefore INVERTS correctness - it forces the broken
+# cached computation onto the path that was already right, so a memorised model
+# generates garbage and teacher-forced loss explodes to ~12. We keep the wrapper
+# defined above for reference, but do NOT register it. Generation safety is
+# handled in unsloth by defaulting Gemma-4 shared-KV generate() to use_cache=False.
 def patch_Gemma4TextModel_forward_kv_shared_no_cache():
-    """Patch Gemma4TextModel.forward (the language decoder that drives attention)."""
-    try:
-        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextModel
-    except ImportError:
-        return
-    except Exception as e:
-        return raise_error("Gemma4TextModel.forward use_cache=False fix", e)
-    try:
-        _patch_forward_for_kv_shared_no_cache(Gemma4TextModel)
-    except Exception as e:
-        return raise_error("Gemma4TextModel.forward use_cache=False fix", e)
-pass
-TEMPORARY_PATCHES.append(patch_Gemma4TextModel_forward_kv_shared_no_cache)
+    return
 
 
 def patch_Gemma4Model_forward_kv_shared_no_cache():
-    """Patch Gemma4Model.forward (multimodal parent) as a safety net in case a
-    refactor moves cache auto-creation above Gemma4TextModel."""
-    try:
-        from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
-    except ImportError:
-        return
-    except Exception as e:
-        return raise_error("Gemma4Model.forward use_cache=False fix", e)
-    try:
-        _patch_forward_for_kv_shared_no_cache(Gemma4Model)
-    except Exception as e:
-        return raise_error("Gemma4Model.forward use_cache=False fix", e)
-pass
-TEMPORARY_PATCHES.append(patch_Gemma4Model_forward_kv_shared_no_cache)
+    return
 
 
 # Gemma4 AudioAttention: config attention_invalid_logits_value (-1e9) overflows


### PR DESCRIPTION
## Summary

Gemma 4 E-series models (E2B / E4B) share KV across their last layers (`num_kv_shared_layers > 0`). Under transformers 5.5.0 their KV-cache path is broken (huggingface/transformers#45242): the cached forward (`use_cache=True`) diverges from the cache-free forward (`use_cache=False`).

On these models the **cache-free path is the correct one**. After overfitting a single row, the cache-free forward gives teacher-forced loss `0.0` and greedy decode reproduces the target, while the cached path gives teacher-forced loss `~12` and garbage.

The `kv_shared_no_cache` forward wrapper here built an internal `DynamicCache` for `use_cache=False` and ran the cached computation, intending to fix #45242. On the E-series this **inverts correctness**: it forces the broken cached path onto the path that was already right. A memorised model then generates garbage and its teacher-forced loss explodes to ~12.

This stops registering the wrapper. The wrapper and its helper are kept defined for reference, and Fix 1 (the `num_kv_shared_layers == 0` cache-init fix for 31B / 26B-A4B) is unchanged. Generation correctness is handled in `unsloth` by defaulting Gemma 4 shared-KV `generate()` to `use_cache=False` (companion PR in `unsloth`).

## Evidence

Same trained Gemma 4 E2B weights, merged and reloaded in plain transformers (no unsloth), teacher-forced loss and greedy decode:

| use_cache | teacher-forced loss | greedy decode |
|---|---|---|
| `True` (cached path) | 11.58 | `### Answer:\n### Answer:` ... (garbage) |
| `False` (cache-free path) | 0.00 | `I WAS FINETUNED BY UNSLOTH` (correct) |

The same plain-transformers run with only this repo's `kv_shared_no_cache` wrapper applied flips the working path:

```
[plain, no wrapper]   use_cache=False -> 'I WAS FINETUNED BY UNSLOTH'
[plain, with wrapper] use_cache=False -> '### Answer:\n### Answer:' ... (garbage)
```

After this change, a full Unsloth train -> generate on `unsloth/gemma-4-E2B-it` (vision, response-only supervision) gives:

```
recompute loss = 0.00000
[LoRA   use_cache=True ] 'Based on the image, you are asking ...'   (garbage, explicit override)
[LoRA   use_cache=False] 'I am Unsloth!'                            (correct)
[LoRA   DEFAULT        ] 'I am Unsloth!'                            (correct)
[merged use_cache=False] 'I am Unsloth!'                            (correct)
[merged DEFAULT        ] 'I am Unsloth!'                            (correct)
```

## Scope

Only Gemma 4 E-series (`model_type` startswith `gemma4`, `num_kv_shared_layers > 0`) generation is affected. Gemma 4 31B / 26B-A4B (`num_kv_shared_layers == 0`), Gemma 3, Gemma 3n, and all other models are untouched.
