### PR TITLE
gpt-oss: fix bnb-4bit<->16bit compiled-cache mode switch breaking merged_16bit reload

### DIFF
--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -477,26 +477,16 @@ def test_patch_compiling_bitsandbytes_missing_peft_helpful_error(monkeypatch):
 
 # ---------------------------------------------------------------------------
 # Regression: gpt-oss bnb-4bit <-> 16bit compiled-cache mode switch.
-#
-# The compiled `unsloth_compiled_module_gpt_oss.py` is a single per-model-type
-# file that hardcodes EITHER the BnB layout (router.linear.weight + ModuleList
-# experts) OR the stock layout (router.weight + fused 3D experts), depending on
-# which classes were active when it was generated. A bnb-4bit load swaps the
-# transformers GptOssTopKRouter/GptOssExperts globals and writes a BnB-flavoured
-# compiled module. Reusing that stale module when later loading a stock 16bit
-# checkpoint (e.g. a merged_16bit export of a 4bit-trained model) re-installs the
-# BnB router, so the checkpoint's router.weight/.bias are "not used" and
-# transformers raises "Unsloth: Critical error since some weights are not
-# initialized". `patch_gpt_oss_bnb4bit_auto` must (a) restore the stock classes
-# and invalidate the compiled module when the current load is NOT bnb-4bit, and
-# (b) invalidate a stale stock-built module the first time it switches INTO bnb.
+# The compiled gpt_oss module hardcodes the BnB or stock router/experts layout. Reusing a
+# stale BnB-built module for a later 16bit load re-installs the BnB router -> "weights not
+# initialized". patch_gpt_oss_bnb4bit_auto must restore stock classes + invalidate the module
+# when the load is not bnb-4bit, and drop a stale stock module when switching into bnb.
 # ---------------------------------------------------------------------------
 
 
 def test_invalidate_gpt_oss_compiled_module_drops_sys_modules_and_file(tmp_path, monkeypatch):
-    """`_invalidate_gpt_oss_compiled_module` must remove both the in-memory
-    `unsloth_compiled_module_gpt_oss` entry and the on-disk cached .py so the
-    next compile regenerates against the currently-active classes."""
+    """_invalidate_gpt_oss_compiled_module removes the sys.modules entry and the on-disk .py so
+    the next compile regenerates against the active classes."""
     import sys
     import types
     from unsloth_zoo.temporary_patches import gpt_oss as _M
@@ -526,11 +516,9 @@ def test_invalidate_gpt_oss_compiled_module_drops_sys_modules_and_file(tmp_path,
 
 
 def test_gpt_oss_bnb4bit_auto_restores_and_invalidates_on_non_4bit_load():
-    """The static contract: `patch_gpt_oss_bnb4bit_auto`'s non-bnb branch must
-    restore the stock classes and clear UNSLOTH_GPT_OSS_BNB4BIT_PATCHED, and the
-    function must sync the on-disk compiled module to the current flavor (the sole
-    cache invalidator, which drops a stale module on a bnb<->16bit mode switch).
-    Asserted on the AST so the mode-switch teardown can't be silently dropped."""
+    """AST contract: patch_gpt_oss_bnb4bit_auto's non-bnb branch restores stock classes and
+    clears UNSLOTH_GPT_OSS_BNB4BIT_PATCHED, and the function syncs the on-disk module to the
+    current flavor (the sole cache invalidator). Asserted on the AST so it can't be dropped."""
     import ast
     import inspect
     from unsloth_zoo.temporary_patches import gpt_oss as _M
@@ -553,10 +541,8 @@ def test_gpt_oss_bnb4bit_auto_restores_and_invalidates_on_non_4bit_load():
 
 
 def test_sync_gpt_oss_compiled_flavor_drops_cross_process_stale_module(tmp_path, monkeypatch):
-    """A fresh process has UNSLOTH_GPT_OSS_BNB4BIT_PATCHED unset, so the flag-gated
-    teardown cannot see that the on-disk compiled module was built for the other
-    flavor. `_sync_gpt_oss_compiled_flavor` must invalidate a stale module via the
-    on-disk flavor marker, and be a no-op when the flavor already matches."""
+    """In a fresh process the in-process flag is unset, so _sync_gpt_oss_compiled_flavor must
+    invalidate a stale module via the on-disk marker, and be a no-op when the flavor matches."""
     from unsloth_zoo.temporary_patches import gpt_oss as _M
 
     cache_dir = tmp_path / "unsloth_compiled_cache"
@@ -588,10 +574,8 @@ def test_sync_gpt_oss_compiled_flavor_drops_cross_process_stale_module(tmp_path,
 
 
 def test_patch_gpt_oss_auto_does_not_touch_cache_for_non_gpt_loads(tmp_path, monkeypatch):
-    """patch_gpt_oss_bnb4bit_auto runs for EVERY model load (it is a global
-    temporary patch). Loading an unrelated model must not delete a valid GPT-OSS
-    compiled cache: the flavor sync is gated on the model actually being GPT-OSS,
-    and there is no unconditional invalidate that would wipe a matching cache."""
+    """patch_gpt_oss_bnb4bit_auto runs for every load; loading an unrelated model must not delete
+    a valid gpt-oss cache (the flavor sync is gated on the model being gpt-oss)."""
     from unsloth_zoo.temporary_patches import gpt_oss as _M
 
     cache_dir = tmp_path / "unsloth_compiled_cache"

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -473,3 +473,79 @@ def test_patch_compiling_bitsandbytes_missing_peft_helpful_error(monkeypatch):
         "the original ImportError must be chained (raise ... from e) so an "
         "installed-but-broken peft stays debuggable"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: gpt-oss bnb-4bit <-> 16bit compiled-cache mode switch.
+#
+# The compiled `unsloth_compiled_module_gpt_oss.py` is a single per-model-type
+# file that hardcodes EITHER the BnB layout (router.linear.weight + ModuleList
+# experts) OR the stock layout (router.weight + fused 3D experts), depending on
+# which classes were active when it was generated. A bnb-4bit load swaps the
+# transformers GptOssTopKRouter/GptOssExperts globals and writes a BnB-flavoured
+# compiled module. Reusing that stale module when later loading a stock 16bit
+# checkpoint (e.g. a merged_16bit export of a 4bit-trained model) re-installs the
+# BnB router, so the checkpoint's router.weight/.bias are "not used" and
+# transformers raises "Unsloth: Critical error since some weights are not
+# initialized". `patch_gpt_oss_bnb4bit_auto` must (a) restore the stock classes
+# and invalidate the compiled module when the current load is NOT bnb-4bit, and
+# (b) invalidate a stale stock-built module the first time it switches INTO bnb.
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_gpt_oss_compiled_module_drops_sys_modules_and_file(tmp_path, monkeypatch):
+    """`_invalidate_gpt_oss_compiled_module` must remove both the in-memory
+    `unsloth_compiled_module_gpt_oss` entry and the on-disk cached .py so the
+    next compile regenerates against the currently-active classes."""
+    import sys
+    import types
+    from unsloth_zoo.temporary_patches import gpt_oss as _M
+
+    # fake an already-imported compiled module + its on-disk cache file
+    sys.modules["unsloth_compiled_module_gpt_oss"] = types.ModuleType(
+        "unsloth_compiled_module_gpt_oss"
+    )
+    cache_dir = tmp_path / "unsloth_compiled_cache"
+    cache_dir.mkdir()
+    cache_file = cache_dir / "unsloth_compiled_module_gpt_oss.py"
+    cache_file.write_text("# stale compiled module\n")
+    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(cache_dir))
+
+    try:
+        _M._invalidate_gpt_oss_compiled_module()
+        assert "unsloth_compiled_module_gpt_oss" not in sys.modules, (
+            "stale compiled module must be evicted from sys.modules"
+        )
+        assert not cache_file.exists(), (
+            "stale on-disk compiled module .py must be deleted"
+        )
+        # idempotent: a second call with nothing to clean must not raise
+        _M._invalidate_gpt_oss_compiled_module()
+    finally:
+        sys.modules.pop("unsloth_compiled_module_gpt_oss", None)
+
+
+def test_gpt_oss_bnb4bit_auto_restores_and_invalidates_on_non_4bit_load():
+    """The static contract: `patch_gpt_oss_bnb4bit_auto`'s non-bnb branch must
+    restore the stock classes, clear UNSLOTH_GPT_OSS_BNB4BIT_PATCHED, and
+    invalidate the compiled module; the bnb branch must invalidate the stale
+    stock-built module on the first switch into bnb. Asserted on the AST so the
+    mode-switch teardown can't be silently dropped."""
+    import ast
+    import inspect
+    from unsloth_zoo.temporary_patches import gpt_oss as _M
+
+    src = inspect.getsource(_M.patch_gpt_oss_bnb4bit_auto)
+    body = ast.unparse(ast.parse(src))
+
+    assert "restore_gpt_oss_original" in body, (
+        "non-bnb load must call restore_gpt_oss_original() so a stale BnB router "
+        "swap from an earlier 4bit load does not break a later 16bit reload"
+    )
+    assert "_invalidate_gpt_oss_compiled_module" in body, (
+        "must invalidate the stale compiled gpt_oss module on a bnb<->16bit "
+        "mode switch (otherwise the wrong router/experts layout is re-installed)"
+    )
+    assert "UNSLOTH_GPT_OSS_BNB4BIT_PATCHED" in body, (
+        "must track/clear the BNB4BIT_PATCHED flag to detect the mode switch"
+    )

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -549,3 +549,38 @@ def test_gpt_oss_bnb4bit_auto_restores_and_invalidates_on_non_4bit_load():
     assert "UNSLOTH_GPT_OSS_BNB4BIT_PATCHED" in body, (
         "must track/clear the BNB4BIT_PATCHED flag to detect the mode switch"
     )
+
+
+def test_sync_gpt_oss_compiled_flavor_drops_cross_process_stale_module(tmp_path, monkeypatch):
+    """A fresh process has UNSLOTH_GPT_OSS_BNB4BIT_PATCHED unset, so the flag-gated
+    teardown cannot see that the on-disk compiled module was built for the other
+    flavor. `_sync_gpt_oss_compiled_flavor` must invalidate a stale module via the
+    on-disk flavor marker, and be a no-op when the flavor already matches."""
+    from unsloth_zoo.temporary_patches import gpt_oss as _M
+
+    cache_dir = tmp_path / "unsloth_compiled_cache"
+    cache_dir.mkdir()
+    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(cache_dir))
+    module = cache_dir / "unsloth_compiled_module_gpt_oss.py"
+    marker = cache_dir / ".unsloth_gpt_oss_compiled_flavor"
+
+    # Prior 4bit process left a BnB-built module; a fresh 16bit (stock) load must drop it.
+    module.write_text("# bnb-built\n")
+    marker.write_text("bnb4bit")
+    _M._sync_gpt_oss_compiled_flavor("stock")
+    assert not module.exists(), "stale BnB module not invalidated for a fresh stock load"
+    assert marker.read_text().strip() == "stock"
+
+    # Matching flavor is a strict no-op (no needless recompile).
+    module.write_text("# stock-built\n")
+    marker.write_text("stock")
+    before = module.read_text()
+    _M._sync_gpt_oss_compiled_flavor("stock")
+    assert module.exists() and module.read_text() == before, "matching flavor wrongly invalidated"
+
+    # An older build with no marker is treated as unknown -> conservatively rebuilt.
+    module.write_text("# unknown\n")
+    if marker.exists():
+        marker.unlink()
+    _M._sync_gpt_oss_compiled_flavor("stock")
+    assert not module.exists(), "unmarked module not conservatively invalidated"

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -527,10 +527,10 @@ def test_invalidate_gpt_oss_compiled_module_drops_sys_modules_and_file(tmp_path,
 
 def test_gpt_oss_bnb4bit_auto_restores_and_invalidates_on_non_4bit_load():
     """The static contract: `patch_gpt_oss_bnb4bit_auto`'s non-bnb branch must
-    restore the stock classes, clear UNSLOTH_GPT_OSS_BNB4BIT_PATCHED, and
-    invalidate the compiled module; the bnb branch must invalidate the stale
-    stock-built module on the first switch into bnb. Asserted on the AST so the
-    mode-switch teardown can't be silently dropped."""
+    restore the stock classes and clear UNSLOTH_GPT_OSS_BNB4BIT_PATCHED, and the
+    function must sync the on-disk compiled module to the current flavor (the sole
+    cache invalidator, which drops a stale module on a bnb<->16bit mode switch).
+    Asserted on the AST so the mode-switch teardown can't be silently dropped."""
     import ast
     import inspect
     from unsloth_zoo.temporary_patches import gpt_oss as _M
@@ -542,9 +542,10 @@ def test_gpt_oss_bnb4bit_auto_restores_and_invalidates_on_non_4bit_load():
         "non-bnb load must call restore_gpt_oss_original() so a stale BnB router "
         "swap from an earlier 4bit load does not break a later 16bit reload"
     )
-    assert "_invalidate_gpt_oss_compiled_module" in body, (
-        "must invalidate the stale compiled gpt_oss module on a bnb<->16bit "
-        "mode switch (otherwise the wrong router/experts layout is re-installed)"
+    assert "_sync_gpt_oss_compiled_flavor" in body, (
+        "must sync the compiled gpt_oss module to the current flavor on a "
+        "bnb<->16bit mode switch (otherwise the wrong router/experts layout is "
+        "re-installed); this is the sole compiled-module invalidator"
     )
     assert "UNSLOTH_GPT_OSS_BNB4BIT_PATCHED" in body, (
         "must track/clear the BNB4BIT_PATCHED flag to detect the mode switch"
@@ -584,3 +585,28 @@ def test_sync_gpt_oss_compiled_flavor_drops_cross_process_stale_module(tmp_path,
         marker.unlink()
     _M._sync_gpt_oss_compiled_flavor("stock")
     assert not module.exists(), "unmarked module not conservatively invalidated"
+
+
+def test_patch_gpt_oss_auto_does_not_touch_cache_for_non_gpt_loads(tmp_path, monkeypatch):
+    """patch_gpt_oss_bnb4bit_auto runs for EVERY model load (it is a global
+    temporary patch). Loading an unrelated model must not delete a valid GPT-OSS
+    compiled cache: the flavor sync is gated on the model actually being GPT-OSS,
+    and there is no unconditional invalidate that would wipe a matching cache."""
+    from unsloth_zoo.temporary_patches import gpt_oss as _M
+
+    cache_dir = tmp_path / "unsloth_compiled_cache"
+    cache_dir.mkdir()
+    monkeypatch.setenv("UNSLOTH_COMPILE_LOCATION", str(cache_dir))
+    module = cache_dir / "unsloth_compiled_module_gpt_oss.py"
+    marker = cache_dir / ".unsloth_gpt_oss_compiled_flavor"
+    module.write_text("# valid bnb4bit gpt-oss compiled module\n")
+    marker.write_text("bnb4bit")
+    before = module.read_text()
+
+    # Loading some other model (name has no "gpt_oss") must leave the cache intact.
+    monkeypatch.setenv("UNSLOTH_MODEL_NAME", "meta-llama/Llama-3.2-1B")
+    monkeypatch.setenv("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0")
+    _M.patch_gpt_oss_bnb4bit_auto()
+    assert module.exists() and module.read_text() == before, (
+        "loading a non-GPT model deleted the GPT-OSS compiled cache"
+    )

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1087,10 +1087,9 @@ _GPT_OSS_FLAVOR_MARKER    = ".unsloth_gpt_oss_compiled_flavor"
 
 
 def _gpt_oss_cache_locations():
-    """Candidate dirs that may hold the compiled gpt_oss module: the configured
-    location and the temp-fallback the compiler switches to when that dir is not
-    writable (see compiler._get_compile_folder). Resolved without calling the
-    compiler so this never triggers distributed coordination at patch time."""
+    """Dirs that may hold the compiled gpt_oss module: the configured location and the
+    temp-fallback used when it is not writable. Resolved without the compiler so it never
+    triggers distributed coordination at patch time."""
     locs = []
     loc = os.environ.get("UNSLOTH_COMPILE_LOCATION", "unsloth_compiled_cache")
     if loc:
@@ -1109,11 +1108,10 @@ def _gpt_oss_cache_locations():
 
 
 def _invalidate_gpt_oss_compiled_module():
-    """Drop the cached compiled gpt_oss module (sys.modules + on-disk .py/.pyc) so it
-    is regenerated against the CURRENT router/experts classes. The compiled module is
-    a single per-model-type file that hardcodes either the BnB (router.linear) or stock
-    (router.weight / 3D experts) layout; reusing a stale one across a 4bit<->16bit mode
-    switch re-installs the wrong classes. Cleans every candidate cache location."""
+    """Drop the cached compiled gpt_oss module (sys.modules + on-disk .py/.pyc) so it is
+    rebuilt against the CURRENT router/experts classes. The single per-model-type file
+    hardcodes the BnB or stock layout, so a stale one survives a 4bit<->16bit switch with the
+    wrong classes. Cleans every candidate location."""
     try:
         import sys as _sys
         import importlib, importlib.util
@@ -1124,37 +1122,29 @@ def _invalidate_gpt_oss_compiled_module():
                 try:
                     os.remove(_f)
                 except OSError:
-                    # Best-effort cleanup; ignore deletion failures.
                     pass
-                # Also drop the byte-compiled .pyc so a stale module is not
-                # re-imported from __pycache__ after the .py is gone.
+                # Drop the .pyc too so a stale module isn't re-imported from __pycache__.
                 try:
                     _pyc = importlib.util.cache_from_source(_f)
                     if os.path.isfile(_pyc):
                         os.remove(_pyc)
                 except Exception:
                     pass
-        # Make Python forget any cached finder/directory state for these paths.
+        # Forget any cached finder/directory state for these paths.
         try:
             importlib.invalidate_caches()
         except Exception:
             pass
     except Exception:
-        # Best-effort cache invalidation; failures here must never break loading.
-        pass
+        pass  # best-effort: cache invalidation must never break loading
 
 
 def _sync_gpt_oss_compiled_flavor(desired_flavor):
-    """Invalidate the on-disk compiled gpt_oss module when it was built for a
-    DIFFERENT flavor ("bnb4bit" vs "stock") than this load needs, independently of
-    the in-process UNSLOTH_GPT_OSS_BNB4BIT_PATCHED flag.
-
-    That flag is unset in a fresh process, so a fresh 16bit load after a 4bit load
-    (sharing the same compiled-cache dir) would otherwise import the stale BnB
-    router/experts and hit "Critical error since some weights are not initialized".
-    A small marker file next to the compiled module records the flavor it was built
-    for; on a mismatch (or when the marker is missing, i.e. an unknown older build)
-    the stale module is dropped so the compiler regenerates it for this load."""
+    """Invalidate the on-disk compiled gpt_oss module when it was built for a DIFFERENT flavor
+    ("bnb4bit" vs "stock") than this load needs, independently of the in-process flag (unset in
+    a fresh process, so a fresh 16bit load after a 4bit one would import the stale BnB classes
+    and hit "weights not initialized"). A marker file records the built flavor; on a mismatch or
+    missing marker the stale module is dropped for the compiler to regenerate."""
     try:
         locations = _gpt_oss_cache_locations()
         mismatch = False
@@ -1174,8 +1164,7 @@ def _sync_gpt_oss_compiled_flavor(desired_flavor):
                 mismatch = True
         if mismatch:
             _invalidate_gpt_oss_compiled_module()
-        # Record this load's flavor where the module will be (re)built. Always write
-        # to the primary location; write to the temp fallback only if it is in use.
+        # Record this load's flavor; always at the primary location, the temp fallback only if used.
         for idx, loc in enumerate(locations):
             if idx != 0 and not os.path.isdir(loc):
                 continue
@@ -1194,31 +1183,24 @@ def patch_gpt_oss_bnb4bit_auto():
     Auto-patch GPT-OSS for BnB 4-bit when load_in_4bit is active.
     Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to opt out.
     """
-    # Cross-process safety: invalidate a stale on-disk compiled module built for the
-    # other flavor (the in-process flag is unset in a fresh process, so the flag-gated
-    # branches below cannot detect cross-process staleness). This is the SOLE cache
-    # invalidator: it only drops the file on an actual flavor mismatch, so a matching
-    # cache is preserved (no needless recompile every session). Gate to GPT-OSS loads
-    # so merely loading an unrelated model never touches a valid GPT-OSS cache.
+    # Cross-process safety: invalidate a stale on-disk module built for the other flavor (the
+    # in-process flag is unset in a fresh process). Sole cache invalidator: drops the file only
+    # on a real mismatch, so a matching cache is reused. Gated to gpt-oss loads.
     if "gpt_oss" in _normalized_unsloth_model_name():
         _sync_gpt_oss_compiled_flavor("bnb4bit" if _should_use_gpt_oss_bnb4bit() else "stock")
 
     if not _should_use_gpt_oss_bnb4bit():
-        # The BnB patch swaps GptOssTopKRouter/GptOssExperts globally (router.linear.weight
-        # + ModuleList experts). UNSLOTH_MODEL_NAME is set per-load but persists in-process and
-        # is inherited across processes (a save->reload subprocess), so a stale "_load_in_4bit_"
-        # from an earlier bnb-4bit load would leave the BnB classes installed when later loading
-        # a 16bit (e.g. merged_16bit) checkpoint, whose router.weight + 3D experts then mismatch
-        # -> "Unsloth: Critical error since some weights are not initialized". This runs every
-        # phase (init/pre_compile/post_compile), so restore the stock classes when the current
-        # load is NOT BnB-4bit. The compiled-module file is handled by _sync above.
+        # The BnB patch swaps GptOssTopKRouter/GptOssExperts globally. A stale "_load_in_4bit_"
+        # in UNSLOTH_MODEL_NAME (inherited across a save->reload subprocess) would leave the BnB
+        # classes installed when later loading a 16bit checkpoint, whose router.weight + 3D
+        # experts then mismatch ("weights not initialized"). Restore the stock classes when this
+        # load is not BnB-4bit. The compiled-module file is handled by _sync above.
         if os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0") == "1":
             restore_gpt_oss_original()
             os.environ["UNSLOTH_GPT_OSS_BNB4BIT_PATCHED"] = "0"
         return
-    # patch_gpt_oss_bnb4bit() injects BnB helpers so the compiler resolves all symbols.
-    # The stale-stock-module case is handled by _sync above (mismatch -> invalidate);
-    # a matching bnb module is left intact so it is reused, not recompiled each session.
+    # patch_gpt_oss_bnb4bit() injects BnB helpers so the compiler resolves all symbols. A stale
+    # stock module is handled by _sync above; a matching bnb module is reused, not recompiled.
     patch_gpt_oss_bnb4bit()
     # Inference path avoids torch.compile for 4-bit
     try:

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1082,22 +1082,108 @@ def _is_transformers_v5() -> bool:
     return transformers_version >= Version("5.0.0.dev0")
 
 
+_GPT_OSS_COMPILED_MODULE = "unsloth_compiled_module_gpt_oss"
+_GPT_OSS_FLAVOR_MARKER    = ".unsloth_gpt_oss_compiled_flavor"
+
+
+def _gpt_oss_cache_locations():
+    """Candidate dirs that may hold the compiled gpt_oss module: the configured
+    location and the temp-fallback the compiler switches to when that dir is not
+    writable (see compiler._get_compile_folder). Resolved without calling the
+    compiler so this never triggers distributed coordination at patch time."""
+    locs = []
+    loc = os.environ.get("UNSLOTH_COMPILE_LOCATION", "unsloth_compiled_cache")
+    if loc:
+        locs.append(loc)
+        try:
+            import tempfile
+            locs.append(os.path.join(tempfile.gettempdir(), os.path.basename(loc)))
+        except Exception:
+            pass
+    # De-dup, preserve order (configured first = primary).
+    seen, out = set(), []
+    for _l in locs:
+        if _l and _l not in seen:
+            seen.add(_l); out.append(_l)
+    return out
+
+
 def _invalidate_gpt_oss_compiled_module():
-    """Drop the cached compiled gpt_oss module (sys.modules + on-disk .py) so it is
-    regenerated against the CURRENT router/experts classes. The compiled module is a
-    single per-model-type file that hardcodes either the BnB (router.linear) or stock
+    """Drop the cached compiled gpt_oss module (sys.modules + on-disk .py/.pyc) so it
+    is regenerated against the CURRENT router/experts classes. The compiled module is
+    a single per-model-type file that hardcodes either the BnB (router.linear) or stock
     (router.weight / 3D experts) layout; reusing a stale one across a 4bit<->16bit mode
-    switch in the same process re-installs the wrong classes."""
+    switch re-installs the wrong classes. Cleans every candidate cache location."""
     try:
         import sys as _sys
-        for _name in ("unsloth_compiled_module_gpt_oss",):
-            _sys.modules.pop(_name, None)
-        loc = os.environ.get("UNSLOTH_COMPILE_LOCATION", "unsloth_compiled_cache")
-        _f = os.path.join(loc, "unsloth_compiled_module_gpt_oss.py")
-        if os.path.isfile(_f):
+        import importlib, importlib.util
+        _sys.modules.pop(_GPT_OSS_COMPILED_MODULE, None)
+        for loc in _gpt_oss_cache_locations():
+            _f = os.path.join(loc, _GPT_OSS_COMPILED_MODULE + ".py")
+            if os.path.isfile(_f):
+                try:
+                    os.remove(_f)
+                except OSError:
+                    # Best-effort cleanup; ignore deletion failures.
+                    pass
+                # Also drop the byte-compiled .pyc so a stale module is not
+                # re-imported from __pycache__ after the .py is gone.
+                try:
+                    _pyc = importlib.util.cache_from_source(_f)
+                    if os.path.isfile(_pyc):
+                        os.remove(_pyc)
+                except Exception:
+                    pass
+        # Make Python forget any cached finder/directory state for these paths.
+        try:
+            importlib.invalidate_caches()
+        except Exception:
+            pass
+    except Exception:
+        # Best-effort cache invalidation; failures here must never break loading.
+        pass
+
+
+def _sync_gpt_oss_compiled_flavor(desired_flavor):
+    """Invalidate the on-disk compiled gpt_oss module when it was built for a
+    DIFFERENT flavor ("bnb4bit" vs "stock") than this load needs, independently of
+    the in-process UNSLOTH_GPT_OSS_BNB4BIT_PATCHED flag.
+
+    That flag is unset in a fresh process, so a fresh 16bit load after a 4bit load
+    (sharing the same compiled-cache dir) would otherwise import the stale BnB
+    router/experts and hit "Critical error since some weights are not initialized".
+    A small marker file next to the compiled module records the flavor it was built
+    for; on a mismatch (or when the marker is missing, i.e. an unknown older build)
+    the stale module is dropped so the compiler regenerates it for this load."""
+    try:
+        locations = _gpt_oss_cache_locations()
+        mismatch = False
+        for loc in locations:
+            module_path = os.path.join(loc, _GPT_OSS_COMPILED_MODULE + ".py")
+            if not os.path.isfile(module_path):
+                continue
+            on_disk = None
+            marker_path = os.path.join(loc, _GPT_OSS_FLAVOR_MARKER)
+            if os.path.isfile(marker_path):
+                try:
+                    with open(marker_path, "r", encoding = "utf-8") as f:
+                        on_disk = f.read().strip()
+                except Exception:
+                    on_disk = None
+            if on_disk != desired_flavor:
+                mismatch = True
+        if mismatch:
+            _invalidate_gpt_oss_compiled_module()
+        # Record this load's flavor where the module will be (re)built. Always write
+        # to the primary location; write to the temp fallback only if it is in use.
+        for idx, loc in enumerate(locations):
+            if idx != 0 and not os.path.isdir(loc):
+                continue
             try:
-                os.remove(_f)
-            except OSError:
+                os.makedirs(loc, exist_ok = True)
+                with open(os.path.join(loc, _GPT_OSS_FLAVOR_MARKER), "w", encoding = "utf-8") as f:
+                    f.write(desired_flavor)
+            except Exception:
                 pass
     except Exception:
         pass
@@ -1108,6 +1194,11 @@ def patch_gpt_oss_bnb4bit_auto():
     Auto-patch GPT-OSS for BnB 4-bit when load_in_4bit is active.
     Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to opt out.
     """
+    # Cross-process safety: invalidate a stale on-disk compiled module built for the
+    # other flavor BEFORE the flag-gated branches below (the flag is unset in a fresh
+    # process, so those branches alone cannot detect cross-process staleness).
+    _sync_gpt_oss_compiled_flavor("bnb4bit" if _should_use_gpt_oss_bnb4bit() else "stock")
+
     if not _should_use_gpt_oss_bnb4bit():
         # The BnB patch swaps GptOssTopKRouter/GptOssExperts globally (router.linear.weight
         # + ModuleList experts). UNSLOTH_MODEL_NAME is set per-load but persists in-process and

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1195,9 +1195,13 @@ def patch_gpt_oss_bnb4bit_auto():
     Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to opt out.
     """
     # Cross-process safety: invalidate a stale on-disk compiled module built for the
-    # other flavor BEFORE the flag-gated branches below (the flag is unset in a fresh
-    # process, so those branches alone cannot detect cross-process staleness).
-    _sync_gpt_oss_compiled_flavor("bnb4bit" if _should_use_gpt_oss_bnb4bit() else "stock")
+    # other flavor (the in-process flag is unset in a fresh process, so the flag-gated
+    # branches below cannot detect cross-process staleness). This is the SOLE cache
+    # invalidator: it only drops the file on an actual flavor mismatch, so a matching
+    # cache is preserved (no needless recompile every session). Gate to GPT-OSS loads
+    # so merely loading an unrelated model never touches a valid GPT-OSS cache.
+    if "gpt_oss" in _normalized_unsloth_model_name():
+        _sync_gpt_oss_compiled_flavor("bnb4bit" if _should_use_gpt_oss_bnb4bit() else "stock")
 
     if not _should_use_gpt_oss_bnb4bit():
         # The BnB patch swaps GptOssTopKRouter/GptOssExperts globally (router.linear.weight
@@ -1207,19 +1211,15 @@ def patch_gpt_oss_bnb4bit_auto():
         # a 16bit (e.g. merged_16bit) checkpoint, whose router.weight + 3D experts then mismatch
         # -> "Unsloth: Critical error since some weights are not initialized". This runs every
         # phase (init/pre_compile/post_compile), so restore the stock classes when the current
-        # load is NOT BnB-4bit.
+        # load is NOT BnB-4bit. The compiled-module file is handled by _sync above.
         if os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0") == "1":
             restore_gpt_oss_original()
             os.environ["UNSLOTH_GPT_OSS_BNB4BIT_PATCHED"] = "0"
-            _invalidate_gpt_oss_compiled_module()
         return
-    already_bnb = os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0") == "1"
     # patch_gpt_oss_bnb4bit() injects BnB helpers so the compiler resolves all symbols.
+    # The stale-stock-module case is handled by _sync above (mismatch -> invalidate);
+    # a matching bnb module is left intact so it is reused, not recompiled each session.
     patch_gpt_oss_bnb4bit()
-    if not already_bnb:
-        # First time switching INTO BnB mode this process: a stale 16bit-built compiled
-        # gpt_oss module would otherwise re-install the stock router/experts. Invalidate it.
-        _invalidate_gpt_oss_compiled_module()
     # Inference path avoids torch.compile for 4-bit
     try:
         global moe_forward_inference

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1082,15 +1082,53 @@ def _is_transformers_v5() -> bool:
     return transformers_version >= Version("5.0.0.dev0")
 
 
+def _invalidate_gpt_oss_compiled_module():
+    """Drop the cached compiled gpt_oss module (sys.modules + on-disk .py) so it is
+    regenerated against the CURRENT router/experts classes. The compiled module is a
+    single per-model-type file that hardcodes either the BnB (router.linear) or stock
+    (router.weight / 3D experts) layout; reusing a stale one across a 4bit<->16bit mode
+    switch in the same process re-installs the wrong classes."""
+    try:
+        import sys as _sys
+        for _name in ("unsloth_compiled_module_gpt_oss",):
+            _sys.modules.pop(_name, None)
+        loc = os.environ.get("UNSLOTH_COMPILE_LOCATION", "unsloth_compiled_cache")
+        _f = os.path.join(loc, "unsloth_compiled_module_gpt_oss.py")
+        if os.path.isfile(_f):
+            try:
+                os.remove(_f)
+            except OSError:
+                pass
+    except Exception:
+        pass
+
+
 def patch_gpt_oss_bnb4bit_auto():
     """
     Auto-patch GPT-OSS for BnB 4-bit when load_in_4bit is active.
     Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to opt out.
     """
     if not _should_use_gpt_oss_bnb4bit():
+        # The BnB patch swaps GptOssTopKRouter/GptOssExperts globally (router.linear.weight
+        # + ModuleList experts). UNSLOTH_MODEL_NAME is set per-load but persists in-process and
+        # is inherited across processes (a save->reload subprocess), so a stale "_load_in_4bit_"
+        # from an earlier bnb-4bit load would leave the BnB classes installed when later loading
+        # a 16bit (e.g. merged_16bit) checkpoint, whose router.weight + 3D experts then mismatch
+        # -> "Unsloth: Critical error since some weights are not initialized". This runs every
+        # phase (init/pre_compile/post_compile), so restore the stock classes when the current
+        # load is NOT BnB-4bit.
+        if os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0") == "1":
+            restore_gpt_oss_original()
+            os.environ["UNSLOTH_GPT_OSS_BNB4BIT_PATCHED"] = "0"
+            _invalidate_gpt_oss_compiled_module()
         return
+    already_bnb = os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0") == "1"
     # patch_gpt_oss_bnb4bit() injects BnB helpers so the compiler resolves all symbols.
     patch_gpt_oss_bnb4bit()
+    if not already_bnb:
+        # First time switching INTO BnB mode this process: a stale 16bit-built compiled
+        # gpt_oss module would otherwise re-install the stock router/experts. Invalidate it.
+        _invalidate_gpt_oss_compiled_module()
     # Inference path avoids torch.compile for 4-bit
     try:
         global moe_forward_inference


### PR DESCRIPTION
## Problem

Fine-tuning `unsloth/gpt-oss-20b-unsloth-bnb-4bit` in 4-bit, saving with `save_pretrained_merged(save_method="merged_16bit")`, then reloading the merged checkpoint failed with:

```
Unsloth: Critical error since some weights are not initialized.
... Some weights of the model checkpoint were not used when initializing GptOssForCausalLM:
['model.layers.0.mlp.router.bias', 'model.layers.0.mlp.router.weight', ...]
```

A bnb-4bit gpt-oss load could also fail at load time with `AttributeError: GptOssExperts has no attribute 'down_projs'`.

## Root cause

The compiled `unsloth_compiled_module_gpt_oss.py` is a single per-model-type file that hardcodes **either** the BnB layout (`router.linear.weight` + `ModuleList` experts) **or** the stock layout (`router.weight` + fused 3D experts), depending on which classes were active when it was generated.

A bnb-4bit load swaps `transformers.models.gpt_oss.modeling_gpt_oss.GptOssTopKRouter` / `GptOssExperts` to the BnB variants and writes a BnB-flavoured compiled module. When a stock 16-bit checkpoint (e.g. a `merged_16bit` export of a 4-bit-trained model) is loaded afterwards, the stale BnB-flavoured compiled module re-installs the nested-linear router, so the checkpoint's flat `router.weight`/`router.bias` are "not used" and transformers raises the critical error.

## Fix

`patch_gpt_oss_bnb4bit_auto` now:
- restores the stock classes and invalidates the cached compiled module when the current load is **not** bnb-4bit (so a stale BnB swap from an earlier 4-bit load does not break a later 16-bit reload), and
- invalidates a stale stock-built compiled module the first time it switches **into** bnb mode.

`_invalidate_gpt_oss_compiled_module()` drops both the in-memory `sys.modules` entry and the on-disk cached `.py` so the next compile regenerates against the currently-active classes.

This pairs with unslothai/unsloth (loader: build `UNSLOTH_MODEL_NAME` fresh per load) which stops a stale `_load_in_4bit_` flag from leaking across save->reload subprocesses.

## Verification

End-to-end on gpt-oss-20b (B200, transformers 4.57.6), train -> save_lora + save_merged_16bit -> reload in a fresh process, all reproducing the fine-tuned phrase:

| precision | load | train | reload_lora | reload_merged_16bit |
|---|---|---|---|---|
| 4-bit (`-unsloth-bnb-4bit`) | OK | loss -> 0.0001 | reproduces phrase | reproduces phrase |
| 16-bit (`-BF16`) | OK | loss -> 0.0002 | reproduces phrase | reproduces phrase (MoE 48/48 experts merged) |

The exact merged checkpoint that previously raised "weights are not initialized" now reloads cleanly and generates the trained answer. The 16-bit path is unchanged (no regression).

## Tests

Adds two regressions to `tests/test_zoo_history_regressions.py`:
- `test_invalidate_gpt_oss_compiled_module_drops_sys_modules_and_file` (functional, no GPU).
- `test_gpt_oss_bnb4bit_auto_restores_and_invalidates_on_non_4bit_load` (AST contract). Both fail on the pre-fix function and pass on the fix.

## Known limitation

A single process that loads 4-bit **and then** reloads a 16-bit merged checkpoint without a fresh interpreter still mismatches, because the already-patched transformers `GptOssForCausalLM`/`GptOssMLP` class objects persist. The realistic notebook flow (reload in a new session/process) is fully covered.
