### PR TITLE
Fix gpt-oss merged_16bit reload after a bnb-4bit load

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -1082,15 +1082,60 @@ def _is_transformers_v5() -> bool:
     return transformers_version >= Version("5.0.0.dev0")
 
 
+def _invalidate_gpt_oss_compiled_module():
+    """Drop the cached compiled gpt_oss module (sys.modules + on-disk .py/.pyc) so it is
+    regenerated against the CURRENT router/experts classes. The compiled module is a single
+    per-model-type file that hardcodes either the BnB (router.linear / ModuleList experts) or
+    the stock (router.weight / 3D experts) layout; reusing a stale one across a 4bit<->16bit
+    mode switch in the same process re-installs the wrong classes."""
+    try:
+        import sys as _sys
+        _sys.modules.pop("unsloth_compiled_module_gpt_oss", None)
+        loc = os.environ.get("UNSLOTH_COMPILE_LOCATION", "unsloth_compiled_cache")
+        _py = os.path.join(loc, "unsloth_compiled_module_gpt_oss.py")
+        if os.path.isfile(_py):
+            try:
+                os.remove(_py)
+            except OSError:
+                pass
+        _pyc_dir = os.path.join(loc, "__pycache__")
+        if os.path.isdir(_pyc_dir):
+            for _f in os.listdir(_pyc_dir):
+                if _f.startswith("unsloth_compiled_module_gpt_oss") and _f.endswith(".pyc"):
+                    try:
+                        os.remove(os.path.join(_pyc_dir, _f))
+                    except OSError:
+                        pass
+    except Exception:
+        pass
+
+
 def patch_gpt_oss_bnb4bit_auto():
     """
     Auto-patch GPT-OSS for BnB 4-bit when load_in_4bit is active.
     Set UNSLOTH_GPT_OSS_BNB4BIT_DISABLE=1 to opt out.
     """
     if not _should_use_gpt_oss_bnb4bit():
+        # The BnB patch swaps GptOssTopKRouter/GptOssExperts globally (router.linear.weight
+        # + ModuleList experts). UNSLOTH_MODEL_NAME is set per-load but persists in-process and
+        # is inherited across processes (a save->reload subprocess), so a stale "_load_in_4bit_"
+        # from an earlier bnb-4bit load would leave the BnB classes installed when later loading
+        # a 16bit (e.g. merged_16bit) checkpoint, whose router.weight + 3D experts then mismatch
+        # -> "Unsloth: Critical error since some weights are not initialized". This runs every
+        # phase (init/pre_compile/post_compile), so restore the stock classes when the current
+        # load is NOT BnB-4bit.
+        if os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0") == "1":
+            restore_gpt_oss_original()
+            os.environ["UNSLOTH_GPT_OSS_BNB4BIT_PATCHED"] = "0"
+            _invalidate_gpt_oss_compiled_module()
         return
+    already_bnb = os.environ.get("UNSLOTH_GPT_OSS_BNB4BIT_PATCHED", "0") == "1"
     # patch_gpt_oss_bnb4bit() injects BnB helpers so the compiler resolves all symbols.
     patch_gpt_oss_bnb4bit()
+    if not already_bnb:
+        # First switch INTO BnB mode this process: a stale 16bit-built compiled gpt_oss module
+        # would otherwise re-install the stock router/experts. Invalidate it.
+        _invalidate_gpt_oss_compiled_module()
     # Inference path avoids torch.compile for 4-bit
     try:
         global moe_forward_inference


### PR DESCRIPTION
## Problem

Fine-tuning `unsloth/gpt-oss-20b` and then running `save_pretrained_merged(save_method="merged_16bit")` produced a checkpoint that could not be reloaded. The reload raised:

```
Unsloth: Critical error since some weights are not initialized.
... were not used when initializing GptOssForCausalLM:
['model.layers.0.mlp.router.weight', 'model.layers.0.mlp.router.bias',
 'model.layers.1.mlp.router.weight', 'model.layers.1.mlp.router.bias', ...]
```

This hit both the pre-quantized bnb-4bit repo (`unsloth/gpt-oss-20b-unsloth-bnb-4bit`, `load_in_4bit=True`) and the BF16 repo when the save and the reload share a process, or when the reload runs in a child process of the trainer.

## Root cause

For gpt-oss loaded from a bnb-4bit checkpoint, Unsloth swaps the stock `GptOssTopKRouter` / `GptOssExperts` for BitsAndBytes-compatible classes:

- the router stores its weight as `mlp.router.linear.weight` (a non-`nn.Linear` container, so bnb does not quantize it),
- the experts become `nn.ModuleList`s (`gate_up_projs`, `down_projs`).

`patch_gpt_oss_bnb4bit_auto()` decides whether to install these via `_should_use_gpt_oss_bnb4bit()`, which keys off `UNSLOTH_MODEL_NAME` containing `gpt_oss` and `_load_in_4bit_`. That env var persists for the lifetime of the process and is inherited by child processes. So after a bnb-4bit gpt-oss load, a later non-4bit load (reloading a `merged_16bit` checkpoint) still saw `_load_in_4bit_`, kept the BnB router (`router.linear.weight`), and rejected the merged checkpoint's stock `router.weight` keys as "not used", leaving the model uninitialized.

The merged checkpoint itself is correct. Loading it in plain `transformers` reproduces the fine-tuned output with teacher-forced CE ~0.016.

## Fix

`patch_gpt_oss_bnb4bit_auto()` already runs at every patch phase (`init` / `pre_compile` / `post_compile`). It now:

- restores the stock gpt-oss classes (via the existing `restore_gpt_oss_original()`) whenever the current load is not BnB-4bit, instead of leaving a stale BnB patch in place, and
- invalidates the cached compiled gpt_oss module on a 4bit <-> 16bit switch. That module is a single per-model-type file that hardcodes one layout (BnB or stock); reusing a stale one would re-install the wrong router/experts.

This is paired with a one-line change in `unslothai/unsloth` that rebuilds `UNSLOTH_MODEL_NAME` per load so the phase callbacks see the correct flags.

## Evidence

Train one row for 30 steps to memorize "I WAS FINETUNED BY UNSLOTH", then save `merged_16bit`, reload in a fresh process, and check the model reproduces it.

Before: merged reload raised `Critical error since some weights are not initialized` (router keys).

After (both precisions, merge reloads and reproduces the phrase):

| repo | precision | train loss | LoRA reload | merged reload |
|---|---|---|---|---|
| `unsloth/gpt-oss-20b-unsloth-bnb-4bit` | 4bit | 4.37 -> 0.0001 | reproduces phrase | reproduces phrase |
| `unsloth/gpt-oss-20b-BF16` | 16bit | 4.29 -> 0.0001 | reproduces phrase | reproduces phrase |

merged greedy output, both precisions:
```
### Question:
Who finetuned you?

### Answer:
I WAS FINETUNED BY UNSLOTH
```

Regression: a non-gpt-oss run (Llama-3.2-1B-Instruct, 4bit) keeps passing the full train -> merge -> reload path unchanged (LoRA and merged teacher-forced CE ~0.0002).
