### PR TITLE
Fix Gemma3 compiled SFT crash (ArgsMismatchError on q_norm/k_norm)

### DIFF
--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -71,10 +71,9 @@ def _prepare_gemma3_sdpa_attention_mask(attention_mask, query_states, key_states
 
 
 def _gemma3_rms_norm(x, weight, eps, out_dtype):
-    # Inline Gemma3RMSNorm math. q_norm/k_norm are applied here instead of calling
-    # the module so the already-compiled prepare() never inlines another compiled
-    # (and accelerate-hooked) forward, which broke Dynamo with
-    # "missing a required argument: 'x'" on older torch. See unsloth#3535.
+    # Inline Gemma3RMSNorm so the already-compiled prepare() does not nest another
+    # compiled (accelerate-hooked) forward, which broke Dynamo with "missing a
+    # required argument: 'x'" on older torch (unsloth#3535).
     x_fp32 = x.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim=True)
     hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + eps)
@@ -434,8 +433,8 @@ def patch_Gemma3Attention():
         key_states_fp32   = key_states_fp16.view(kv_hidden_shape).to(torch.float32).transpose(1, 2)
         value_states_fp32 = value_states_fp16.view(kv_hidden_shape).to(torch.float32).transpose(1, 2) # V for attention also fp32
 
-        # 3. Normalization (q_norm, k_norm are RMSNorms) applied inline; see _gemma3_rms_norm.
-        # Float32 path clamps to fp16 range and emits fp16 to match patch_Gemma3RMSNorm.
+        # 3. Normalization (q_norm/k_norm) inline via _gemma3_rms_norm; float32 path
+        # clamps to fp16 range and emits fp16 to match patch_Gemma3RMSNorm.
         fp16_max = torch.finfo(torch.float16).max
         query_norm_out_fp16 = _gemma3_rms_norm(query_states_fp32, q_norm.weight, q_norm.eps, torch.float32)
         key_norm_out_fp16   = _gemma3_rms_norm(key_states_fp32,   k_norm.weight, k_norm.eps, torch.float32)
@@ -672,8 +671,8 @@ def patch_Gemma3Attention_generic():
         key_states_fp32   = key_states_fp16.view(kv_hidden_shape).transpose(1, 2)
         value_states_fp32 = value_states_fp16.view(kv_hidden_shape).transpose(1, 2) # V for attention also fp32
 
-        # 3. Normalization (q_norm, k_norm are RMSNorms) applied inline; see _gemma3_rms_norm.
-        # Output dtype mirrors the input dtype, matching patch_Gemma3RMSNorm_generic.
+        # 3. Normalization (q_norm/k_norm) inline via _gemma3_rms_norm; output dtype
+        # mirrors the input, matching patch_Gemma3RMSNorm_generic.
         query_norm_out_fp16 = _gemma3_rms_norm(query_states_fp32, q_norm.weight, q_norm.eps, query_states_fp32.dtype)
         key_norm_out_fp16   = _gemma3_rms_norm(key_states_fp32,   k_norm.weight, k_norm.eps, key_states_fp32.dtype)
 

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -70,6 +70,18 @@ def _prepare_gemma3_sdpa_attention_mask(attention_mask, query_states, key_states
     return padding_mask & causal_mask[None, None, :, :]
 
 
+def _gemma3_rms_norm(x, weight, eps, out_dtype):
+    # Inline Gemma3RMSNorm math. q_norm/k_norm are applied here instead of calling
+    # the module so the already-compiled prepare() never inlines another compiled
+    # (and accelerate-hooked) forward, which broke Dynamo with
+    # "missing a required argument: 'x'" on older torch. See unsloth#3535.
+    x_fp32 = x.to(torch.float32)
+    variance = x_fp32.pow(2).mean(-1, keepdim=True)
+    hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + eps)
+    output_fp32 = hidden_states_fp32 * (1.0 + weight.to(torch.float32))
+    return output_fp32.to(out_dtype)
+
+
 def _make_gemma3_attn_forwards(forward_function, has_cache_position):
     """Build the past_key_value / past_key_values forward variants."""
     functions = []
@@ -422,9 +434,13 @@ def patch_Gemma3Attention():
         key_states_fp32   = key_states_fp16.view(kv_hidden_shape).to(torch.float32).transpose(1, 2)
         value_states_fp32 = value_states_fp16.view(kv_hidden_shape).to(torch.float32).transpose(1, 2) # V for attention also fp32
 
-        # 3. Normalization (q_norm, k_norm are RMSNorms)
-        query_norm_out_fp16 = q_norm(query_states_fp32) # self.q_norm doesn't use auto compiler
-        key_norm_out_fp16   = k_norm(key_states_fp32) # self.q_norm doesn't use auto compiler
+        # 3. Normalization (q_norm, k_norm are RMSNorms) applied inline; see _gemma3_rms_norm.
+        # Float32 path clamps to fp16 range and emits fp16 to match patch_Gemma3RMSNorm.
+        fp16_max = torch.finfo(torch.float16).max
+        query_norm_out_fp16 = _gemma3_rms_norm(query_states_fp32, q_norm.weight, q_norm.eps, torch.float32)
+        key_norm_out_fp16   = _gemma3_rms_norm(key_states_fp32,   k_norm.weight, k_norm.eps, torch.float32)
+        query_norm_out_fp16 = torch.clamp(query_norm_out_fp16, min=-fp16_max, max=fp16_max).to(torch.float16)
+        key_norm_out_fp16   = torch.clamp(key_norm_out_fp16,   min=-fp16_max, max=fp16_max).to(torch.float16)
 
         query_states_fp32 = query_norm_out_fp16.to(torch.float32)
         key_states_fp32   = key_norm_out_fp16.to(torch.float32)
@@ -656,9 +672,10 @@ def patch_Gemma3Attention_generic():
         key_states_fp32   = key_states_fp16.view(kv_hidden_shape).transpose(1, 2)
         value_states_fp32 = value_states_fp16.view(kv_hidden_shape).transpose(1, 2) # V for attention also fp32
 
-        # 3. Normalization (q_norm, k_norm are RMSNorms)
-        query_norm_out_fp16 = q_norm(query_states_fp32) # self.q_norm doesn't use auto compiler
-        key_norm_out_fp16   = k_norm(key_states_fp32) # self.k_norm doesn't use auto compiler
+        # 3. Normalization (q_norm, k_norm are RMSNorms) applied inline; see _gemma3_rms_norm.
+        # Output dtype mirrors the input dtype, matching patch_Gemma3RMSNorm_generic.
+        query_norm_out_fp16 = _gemma3_rms_norm(query_states_fp32, q_norm.weight, q_norm.eps, query_states_fp32.dtype)
+        key_norm_out_fp16   = _gemma3_rms_norm(key_states_fp32,   k_norm.weight, k_norm.eps, key_states_fp32.dtype)
 
         query_states_fp32 = query_norm_out_fp16#.to(torch.float32)
         key_states_fp32   = key_norm_out_fp16#.to(torch.float32)

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -71,9 +71,8 @@ def _prepare_gemma3_sdpa_attention_mask(attention_mask, query_states, key_states
 
 
 def _gemma3_rms_norm(x, weight, eps, out_dtype):
-    # Inline Gemma3RMSNorm so the already-compiled prepare() does not nest another
-    # compiled (accelerate-hooked) forward, which broke Dynamo with "missing a
-    # required argument: 'x'" on older torch (unsloth#3535).
+    # Inline Gemma3RMSNorm so compiled prepare() doesn't nest another compiled
+    # forward, which broke Dynamo on older torch (unsloth#3535).
     x_fp32 = x.to(torch.float32)
     variance = x_fp32.pow(2).mean(-1, keepdim=True)
     hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + eps)
@@ -433,8 +432,7 @@ def patch_Gemma3Attention():
         key_states_fp32   = key_states_fp16.view(kv_hidden_shape).to(torch.float32).transpose(1, 2)
         value_states_fp32 = value_states_fp16.view(kv_hidden_shape).to(torch.float32).transpose(1, 2) # V for attention also fp32
 
-        # 3. Normalization (q_norm/k_norm) inline via _gemma3_rms_norm; float32 path
-        # clamps to fp16 range and emits fp16 to match patch_Gemma3RMSNorm.
+        # 3. Normalization: inline RMSNorm, then clamp+emit fp16 to match patch_Gemma3RMSNorm.
         fp16_max = torch.finfo(torch.float16).max
         query_norm_out_fp16 = _gemma3_rms_norm(query_states_fp32, q_norm.weight, q_norm.eps, torch.float32)
         key_norm_out_fp16   = _gemma3_rms_norm(key_states_fp32,   k_norm.weight, k_norm.eps, torch.float32)
@@ -671,8 +669,7 @@ def patch_Gemma3Attention_generic():
         key_states_fp32   = key_states_fp16.view(kv_hidden_shape).transpose(1, 2)
         value_states_fp32 = value_states_fp16.view(kv_hidden_shape).transpose(1, 2) # V for attention also fp32
 
-        # 3. Normalization (q_norm/k_norm) inline via _gemma3_rms_norm; output dtype
-        # mirrors the input, matching patch_Gemma3RMSNorm_generic.
+        # 3. Normalization: inline RMSNorm, output dtype mirrors input to match patch_Gemma3RMSNorm_generic.
         query_norm_out_fp16 = _gemma3_rms_norm(query_states_fp32, q_norm.weight, q_norm.eps, query_states_fp32.dtype)
         key_norm_out_fp16   = _gemma3_rms_norm(key_states_fp32,   k_norm.weight, k_norm.eps, key_states_fp32.dtype)
 


### PR DESCRIPTION
## Bug

SFT of any Gemma3 model crashes during `trainer.train()` when torch.compile is on (the default). Reported on 2x T4 with `transformers==4.55.4`, `trl==0.22.2`, across `gemma-3-1b/27b-it` and their `-bnb-4bit` variants. Setting `UNSLOTH_COMPILE_DISABLE=1` avoids it but is not a real fix.

The crash:

```
ArgsMismatchError: missing a required argument: 'x'.
  func = 'forward' .../unsloth_zoo/temporary_patches/gemma.py, args = [<class 'torch.Tensor'>], kwargs = {}
from user code:
   File ".../unsloth_zoo/temporary_patches/gemma.py", line 660, in prepare
    query_norm_out_fp16 = q_norm(query_states_fp32)
```

Fixes unslothai/unsloth#3535

## Root cause

In `patch_Gemma3Attention` and `patch_Gemma3Attention_generic`, the attention `prepare()` helper is wrapped with `torch.compile(..., fullgraph=True)`. Inside it, `q_norm`/`k_norm` (the `Gemma3RMSNorm` modules) are called directly:

```python
query_norm_out_fp16 = q_norm(query_states_fp32)
key_norm_out_fp16   = k_norm(key_states_fp32)
```

Separately, `patch_Gemma3RMSNorm`/`patch_Gemma3RMSNorm_generic` patch `Gemma3RMSNorm.forward` via `patch_function(..., fullgraph=True)`, which wraps the forward in its own `torch.compile`.

So inside the already compiled `prepare()`, Dynamo has to inline `q_norm.__call__` -> `nn.Module._call_impl` -> a second compiled forward. When the modules also carry accelerate dispatch hooks (`module._old_forward`), which is the case on the multi-GPU / device-map / 4-bit path the reporter used, Dynamo's `bind_args` receives `args = [Tensor]` for `forward(self, x)`, binds the tensor to `self`, and reports `x` missing. This is exactly the failure the existing comments warned about ("self.q_norm doesn't use auto compiler", "torch.compile cannot trace through def prepare for q_norm, k_norm"), but `fullgraph=True` compiled them anyway.

## Fix

Apply the RMSNorm math inline inside `prepare()` using each module's `weight` and `eps`, instead of calling the module. `prepare()` then stays a single graph and never inlines another compiled, hooked forward.

```python
def _gemma3_rms_norm(x, weight, eps, out_dtype):
    x_fp32 = x.to(torch.float32)
    variance = x_fp32.pow(2).mean(-1, keepdim=True)
    hidden_states_fp32 = x_fp32 * torch.rsqrt(variance + eps)
    output_fp32 = hidden_states_fp32 * (1.0 + weight.to(torch.float32))
    return output_fp32.to(out_dtype)
```

- Default path (`patch_Gemma3Attention_generic`): output dtype mirrors the input, matching `patch_Gemma3RMSNorm_generic`.
- `UNSLOTH_FORCE_FLOAT32` path (`patch_Gemma3Attention`): clamp to fp16 range and emit fp16, matching `patch_Gemma3RMSNorm`.

The standalone `Gemma3RMSNorm` (input/post-attention/pre-and-post-feedforward/final layernorms) keeps its compiled forward, so no speed is lost there. torch.compile stays on; nothing is disabled.

## Backwards compatibility

- `Gemma3RMSNorm.weight` and `.eps` are stable across transformers 4.5x and 5.x.
- Inline math is identical to both the unsloth-patched RMSNorm and upstream `Gemma3RMSNorm.forward` (`output * (1.0 + weight.float())`).
- Only the Gemma3 attention path changes. Llama and other models are untouched.
- Works for gemma3 text/vision, bf16/fp16, gradient checkpointing on/off, and the SDPA path used in the report.

## Before / after

Reproduced the exact crash on `torch==2.7.1+cu128`, `transformers==4.55.4`, `trl==0.22.2`, with `q_norm`/`k_norm` carrying accelerate hooks and `prepare()` compiled.

Before (unpatched):

```
torch._dynamo.exc.ArgsMismatchError: missing a required argument: 'x'.
   File ".../unsloth_zoo/temporary_patches/gemma.py", line 660, in prepare
```

After (patched):

```
PATCHED_PREPARE_OK (1, 8, 64) finite= True
```

## Test matrix

| torch | transformers | trl | case | result |
| --- | --- | --- | --- | --- |
| 2.7.1 | 4.55.4 | 0.22.2 | Gemma3 270m SFT, compile on | trains, finite loss |
| 2.7.1 | 4.55.4 | 0.22.2 | Gemma3 270m SFT, `UNSLOTH_FORCE_FLOAT32=1`, SDPA | trains, finite loss |
| 2.7.1 | 4.55.4 | 0.22.2 | patched `prepare` with hooked compiled q_norm/k_norm | OK (was ArgsMismatchError) |
| 2.10.0 | 5.5.0 | 0.24.0 | Gemma3 270m SFT, compile on | trains, same loss as before fix |
| 2.10.0 | 5.5.0 | 0.24.0 | Llama 3.2 1B SFT, compile on | trains, finite loss (no regression) |
