### PR TITLE
Fix GRPO eval crash: keep gradient checkpointing buffers out of inference mode

### DIFF
--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -67,7 +67,7 @@ def _no_inference_mode():
     # no_grad avoids the "view created in no_grad modified in grad mode" error.
     try:
         leave_inference = torch.inference_mode(False)
-    except TypeError:
+    except (TypeError, AttributeError):
         # Older torch without inference_mode(bool); no_grad alone is enough.
         leave_inference = nullcontext()
     with leave_inference, torch.no_grad():

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -681,7 +681,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
             device_autocast_ctx = torch.amp.autocast(
                 device_type=ctx.device_type, **ctx.device_autocast_kwargs
-            ) if torch.amp.is_autocast_available(ctx.device_type) else contextlib.nullcontext()
+            ) if torch.amp.is_autocast_available(ctx.device_type) else nullcontext()
 
             # detached_inputs = detach_variable(tuple(inputs))
             detached_inputs = []

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -59,8 +59,8 @@ DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable doub
 @contextmanager
 def _no_inference_mode():
     # GC buffers must not be inference tensors, else a later offload copy_ raises
-    # "Inplace update to inference tensor" (GRPO log-probs run under inference_mode,
-    # unsloth#3828). Leave inference_mode but stay in no_grad for the copies.
+    # "Inplace update to inference tensor" under GRPO's inference_mode (unsloth#3828).
+    # Leave inference_mode but stay in no_grad.
     try:
         leave_inference = torch.inference_mode(False)
     except (TypeError, AttributeError):
@@ -565,7 +565,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
                         # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
                         EXTRA_STREAM.wait_stream(MAIN_STREAM)
-                        # copy_ must not hit an inference tensor (unsloth#3828)
+                        # _no_inference_mode: copy_ target must not be an inference tensor (unsloth#3828)
                         with _no_inference_mode(), torch_gpu_stream(EXTRA_STREAM):
                             x.copy_(arg, non_blocking = True)
 
@@ -645,7 +645,6 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                 # Single buffer mode: wait for MAIN_STREAM
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
 
-            # copy_ must not hit an inference tensor (unsloth#3828)
             with _no_inference_mode(), torch_gpu_stream(EXTRA_STREAM):
                 buffer.copy_(x, non_blocking = True)
         else:
@@ -973,7 +972,7 @@ def reset_unsloth_gradient_checkpointing_buffers():
         try:
             n_gpus = len(GPU_BUFFERS)
             dtype = GPU_BUFFERS[0].dtype
-            with _no_inference_mode():  # keep buffers out of inference mode (unsloth#3828)
+            with _no_inference_mode():
                 GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype=dtype, device=f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
             if DEVICE_TYPE in ("cuda", "hip"):
                 event_ctor = torch.cuda.Event

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -17,6 +17,7 @@
 import torch
 import numpy as np
 from typing import Union, Optional, List, Any, Callable, Tuple
+from contextlib import contextmanager, nullcontext
 import os
 import warnings
 import gc
@@ -53,6 +54,24 @@ INITIAL_CPU_BUFFER_SIZE = 128 * 1024       # per CPU buffer
 INITIAL_GPU_BUFFER_SIZE = 2 * 256 * 2048   # per GPU buffer
 INITIAL_CPU_BUFFER_COUNT = 200             # number of CPU buffers
 DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable double buffering
+
+
+@contextmanager
+def _no_inference_mode():
+    # Persistent GC buffers must never be inference tensors: GRPO computes
+    # ref/old log-probs under torch.inference_mode (rl_replacements.py). A buffer
+    # allocated or copied into while that context is active becomes an inference
+    # tensor, so the next training/eval offload x.copy_(arg) raises "Inplace
+    # update to inference tensor". See unslothai/unsloth#3828. Exit inference mode
+    # but stay in no_grad: buffer offload copies never track gradients, and
+    # no_grad avoids the "view created in no_grad modified in grad mode" error.
+    try:
+        leave_inference = torch.inference_mode(False)
+    except TypeError:
+        # Older torch without inference_mode(bool); no_grad alone is enough.
+        leave_inference = nullcontext()
+    with leave_inference, torch.no_grad():
+        yield
 
 torch_version = torch.__version__
 if Version(torch_version) < Version("2.4.0"):
@@ -350,16 +369,20 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
         dtype = torch.bfloat16 if SUPPORTS_BFLOAT16 else torch.float16
     pass
 
-    for i in range(200):
-        x = torch.empty(128*1024, dtype = dtype, device = "cpu", pin_memory = True)
-        CPU_BUFFERS.append(x)
+    # Keep persistent buffers out of inference mode (see _no_inference_mode).
+    with _no_inference_mode():
+        for i in range(200):
+            x = torch.empty(128*1024, dtype = dtype, device = "cpu", pin_memory = True)
+            CPU_BUFFERS.append(x)
     pass
 
     # Allocate one buffer per GPU
     n_gpus = torch.cuda.device_count() if DEVICE_TYPE in ("cuda", "hip") else torch.xpu.device_count()
     NEXT_BUFFER_SLOT = [0] * n_gpus
     try:
-        GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+        # Keep persistent buffers out of inference mode (see _no_inference_mode).
+        with _no_inference_mode():
+            GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
         # Double buffering: try to allocate buffer B (can be disabled via env var)
         if os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER", "0") == "1":
             GPU_BUFFERS_B = None
@@ -368,7 +391,8 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
             BUFFER_EVENTS_B = None
         else:
             try:
-                GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+                with _no_inference_mode():
+                    GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
                 USE_DOUBLE_BUFFER = False # enabled after first pass if CUDA free memory > DOUBLE_BUFFER_HEADROOM
                 # Per-buffer events prevent double-buffering races; each tracks
                 # when compute on that buffer finishes
@@ -503,9 +527,10 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                     GPU_BUFFERS_B = None
                         pass
 
-                        # Extend buffer size
+                        # Extend buffer size (keep new buffer out of inference mode)
                         if CPU_INDEX >= len(CPU_BUFFERS):
-                            x = torch.empty(new_size, dtype = arg.dtype, device = "cpu", pin_memory = True)
+                            with _no_inference_mode():
+                                x = torch.empty(new_size, dtype = arg.dtype, device = "cpu", pin_memory = True)
                             CPU_BUFFERS.append(x)
                         pass
 
@@ -547,7 +572,8 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
                         # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
                         EXTRA_STREAM.wait_stream(MAIN_STREAM)
-                        with torch_gpu_stream(EXTRA_STREAM):
+                        # _no_inference_mode: never inplace-update an inference tensor (unsloth#3828)
+                        with _no_inference_mode(), torch_gpu_stream(EXTRA_STREAM):
                             x.copy_(arg, non_blocking = True)
 
                         global NEXT_BUFFER_SLOT
@@ -626,7 +652,8 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                 # Single buffer mode: wait for MAIN_STREAM
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
 
-            with torch_gpu_stream(EXTRA_STREAM):
+            # _no_inference_mode: never inplace-update an inference tensor (unsloth#3828)
+            with _no_inference_mode(), torch_gpu_stream(EXTRA_STREAM):
                 buffer.copy_(x, non_blocking = True)
         else:
             # No GPU buffer seen
@@ -953,7 +980,8 @@ def reset_unsloth_gradient_checkpointing_buffers():
         try:
             n_gpus = len(GPU_BUFFERS)
             dtype = GPU_BUFFERS[0].dtype
-            GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype=dtype, device=f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
+            with _no_inference_mode():  # keep buffers out of inference mode (unsloth#3828)
+                GPU_BUFFERS_B = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype=dtype, device=f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
             if DEVICE_TYPE in ("cuda", "hip"):
                 event_ctor = torch.cuda.Event
             elif DEVICE_TYPE == "xpu":

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -58,9 +58,8 @@ DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable doub
 
 @contextmanager
 def _no_inference_mode():
-    # GC buffers must not be inference tensors, else a later offload copy_ raises
-    # "Inplace update to inference tensor" under GRPO's inference_mode (unsloth#3828).
-    # Leave inference_mode but stay in no_grad.
+    # Allocate GC buffers outside inference_mode (but in no_grad) so a later
+    # offload copy_ does not raise on an inference tensor (unsloth#3828).
     try:
         leave_inference = torch.inference_mode(False)
     except (TypeError, AttributeError):
@@ -565,10 +564,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
                         # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
                         EXTRA_STREAM.wait_stream(MAIN_STREAM)
-                        # x is a CPU_BUFFERS entry, always allocated outside
-                        # inference_mode, so copy_ into it never trips the
-                        # "inplace update to inference tensor" error (unsloth#3828).
-                        # No need to re-enter _no_inference_mode on this hot path.
+                        # x is a normal (non-inference) buffer, so copy_ is safe (unsloth#3828).
                         with torch_gpu_stream(EXTRA_STREAM):
                             x.copy_(arg, non_blocking = True)
 
@@ -648,9 +644,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                 # Single buffer mode: wait for MAIN_STREAM
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
 
-            # buffer is a GPU_BUFFERS/GPU_BUFFERS_B entry, always allocated
-            # outside inference_mode, so this reload copy_ is safe without
-            # re-entering _no_inference_mode on the hot path (unsloth#3828).
+            # buffer is a normal (non-inference) buffer, so this reload copy_ is safe (unsloth#3828).
             with torch_gpu_stream(EXTRA_STREAM):
                 buffer.copy_(x, non_blocking = True)
         else:

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -565,8 +565,11 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
                         # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
                         EXTRA_STREAM.wait_stream(MAIN_STREAM)
-                        # _no_inference_mode: copy_ target must not be an inference tensor (unsloth#3828)
-                        with _no_inference_mode(), torch_gpu_stream(EXTRA_STREAM):
+                        # x is a CPU_BUFFERS entry, always allocated outside
+                        # inference_mode, so copy_ into it never trips the
+                        # "inplace update to inference tensor" error (unsloth#3828).
+                        # No need to re-enter _no_inference_mode on this hot path.
+                        with torch_gpu_stream(EXTRA_STREAM):
                             x.copy_(arg, non_blocking = True)
 
                         global NEXT_BUFFER_SLOT
@@ -645,7 +648,10 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                 # Single buffer mode: wait for MAIN_STREAM
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
 
-            with _no_inference_mode(), torch_gpu_stream(EXTRA_STREAM):
+            # buffer is a GPU_BUFFERS/GPU_BUFFERS_B entry, always allocated
+            # outside inference_mode, so this reload copy_ is safe without
+            # re-entering _no_inference_mode on the hot path (unsloth#3828).
+            with torch_gpu_stream(EXTRA_STREAM):
                 buffer.copy_(x, non_blocking = True)
         else:
             # No GPU buffer seen

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -58,18 +58,13 @@ DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable doub
 
 @contextmanager
 def _no_inference_mode():
-    # Persistent GC buffers must never be inference tensors: GRPO computes
-    # ref/old log-probs under torch.inference_mode (rl_replacements.py). A buffer
-    # allocated or copied into while that context is active becomes an inference
-    # tensor, so the next training/eval offload x.copy_(arg) raises "Inplace
-    # update to inference tensor". See unslothai/unsloth#3828. Exit inference mode
-    # but stay in no_grad: buffer offload copies never track gradients, and
-    # no_grad avoids the "view created in no_grad modified in grad mode" error.
+    # GC buffers must not be inference tensors, else a later offload copy_ raises
+    # "Inplace update to inference tensor" (GRPO log-probs run under inference_mode,
+    # unsloth#3828). Leave inference_mode but stay in no_grad for the copies.
     try:
         leave_inference = torch.inference_mode(False)
     except (TypeError, AttributeError):
-        # Older torch without inference_mode(bool); no_grad alone is enough.
-        leave_inference = nullcontext()
+        leave_inference = nullcontext()  # older torch lacks inference_mode(bool)
     with leave_inference, torch.no_grad():
         yield
 
@@ -369,7 +364,6 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
         dtype = torch.bfloat16 if SUPPORTS_BFLOAT16 else torch.float16
     pass
 
-    # Keep persistent buffers out of inference mode (see _no_inference_mode).
     with _no_inference_mode():
         for i in range(200):
             x = torch.empty(128*1024, dtype = dtype, device = "cpu", pin_memory = True)
@@ -380,7 +374,6 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     n_gpus = torch.cuda.device_count() if DEVICE_TYPE in ("cuda", "hip") else torch.xpu.device_count()
     NEXT_BUFFER_SLOT = [0] * n_gpus
     try:
-        # Keep persistent buffers out of inference mode (see _no_inference_mode).
         with _no_inference_mode():
             GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
         # Double buffering: try to allocate buffer B (can be disabled via env var)
@@ -527,7 +520,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                                     GPU_BUFFERS_B = None
                         pass
 
-                        # Extend buffer size (keep new buffer out of inference mode)
+                        # Extend buffer size
                         if CPU_INDEX >= len(CPU_BUFFERS):
                             with _no_inference_mode():
                                 x = torch.empty(new_size, dtype = arg.dtype, device = "cpu", pin_memory = True)
@@ -572,7 +565,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
 
                         # See https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams
                         EXTRA_STREAM.wait_stream(MAIN_STREAM)
-                        # _no_inference_mode: never inplace-update an inference tensor (unsloth#3828)
+                        # copy_ must not hit an inference tensor (unsloth#3828)
                         with _no_inference_mode(), torch_gpu_stream(EXTRA_STREAM):
                             x.copy_(arg, non_blocking = True)
 
@@ -652,7 +645,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                 # Single buffer mode: wait for MAIN_STREAM
                 EXTRA_STREAM.wait_stream(MAIN_STREAM)
 
-            # _no_inference_mode: never inplace-update an inference tensor (unsloth#3828)
+            # copy_ must not hit an inference tensor (unsloth#3828)
             with _no_inference_mode(), torch_gpu_stream(EXTRA_STREAM):
                 buffer.copy_(x, non_blocking = True)
         else:


### PR DESCRIPTION
## Bug

GRPO training with `use_gradient_checkpointing = "unsloth"` crashes when evaluation is enabled (and intermittently during training), with:

```
RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed.
You can make a clone to get a normal tensor before doing inplace update.
```

The traceback ends at the Unsloth smart gradient checkpointing offload copy:

```
unsloth_zoo/gradient_checkpointing.py, in forward
    x.copy_(arg, non_blocking = True)
RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed.
```

The reporter noted it does not happen on every evaluation, just randomly, and that it only happens when evaluation is on. See unslothai/unsloth#3828.

## Root cause

GRPO computes the reference / old per-token log-probs under `torch.inference_mode` (`unsloth/models/rl_replacements.py` `_get_per_token_logps`, via `_get_inference_mode_context_manager`). The model is still in training mode at that point (GC enabled), so a smart-GC forward can run while that inference context is active.

The smart-GC offload uses persistent global CPU and GPU buffers. If one of those buffers is allocated (`torch.empty(...)`) or copied into (`x.copy_(arg)`) while the `inference_mode` context is active, the buffer permanently becomes an inference tensor. A later, normal training / eval offload pass then runs `x.copy_(arg, non_blocking=True)` on that inference-tensor buffer outside inference mode and raises.

This explains the intermittency: it only triggers when a buffer allocation or copy happens to land inside the `inference_mode` window, and only on the offload path (hidden state larger than the 2MB minimum).

Minimal isolated reproduction:

```python
import torch
with torch.inference_mode():
    x = torch.empty(1024, device="cpu", pin_memory=True)   # becomes an inference tensor
arg = torch.randn(1024, device="cuda")
x.copy_(arg)   # RuntimeError: Inplace update to inference tensor ...
```

## Fix

Add a small `_no_inference_mode()` context manager (`torch.inference_mode(False)` plus `torch.no_grad()`) and wrap every persistent buffer allocation (`initialize_unsloth_gradient_checkpointing`, the in-forward buffer extension, and `reset_unsloth_gradient_checkpointing_buffers`) and every inplace buffer `copy_` (forward CPU offload and backward GPU restore) with it.

- Buffers are now always normal tensors regardless of the caller's context.
- The offload copies never inplace-update an inference tensor.
- `no_grad` is kept because the offload copies are pure data movement that must not enter grad mode (otherwise it hits "a view created in `no_grad` is modified in grad mode").
- Older torch without a boolean arg to `inference_mode` falls back to plain `no_grad`.

## Backwards compatibility

- Does not touch the GRPO training-mode GC handling from #5269 (`for_training` / `unsloth_unwrap_model_for_generation` / `unsloth_fast_generate`). That fix governs which GC mode is restored after generation; this fix is purely about not tainting the offload buffers with inference state.
- Gradients are bit-identical to the non-checkpointed reference (max diff `0.0`), so training dynamics are unchanged.
- The OOM / double-buffer `except` handling around buffer allocation is preserved.
- All GC modes (`"unsloth"`, `True`, `False`), `eval_strategy` on and off, and vLLM on and off were exercised.

## Before / after

Deterministic unit test that allocates the GC buffers inside `inference_mode` (mirroring the GRPO log-prob pass) and then runs a normal offload forward:

| State    | CPU buffers `is_inference` | Offload forward `x.copy_(arg)` |
|----------|----------------------------|--------------------------------|
| Before   | `[True, True, True, True]`  | crash: Inplace update to inference tensor |
| After    | `[False, False, False, False]` | OK |

End-to-end GRPO (Qwen2.5-1.5B, LoRA, `use_gradient_checkpointing="unsloth"`, `beta=0.04`, `eval_strategy="steps"`, ~500 token completions so the offload path is active): training and eval both complete, the "Will smartly offload gradients to save VRAM" path is active throughout, and final `evaluate()` returns metrics with no crash.

## Test matrix

| GC mode      | eval | vLLM | Result |
|--------------|------|------|--------|
| `"unsloth"`  | on   | off  | pass   |
| `"unsloth"`  | on   | on   | pass   |
| `"unsloth"`  | off  | off  | pass (memory savings preserved) |
| `True`       | on   | off  | pass   |
| `False`      | on   | off  | pass   |
| `"unsloth"` (large model, offload path active) | on | off | pass |
| GC fwd+bwd vs reference grads | - | - | max diff 0.0 |

Fixes unslothai/unsloth#3828
