### PR TITLE
Fix LoRA scaling count mismatch on merge for Qwen2.5-VL exports (#2966)

### DIFF
--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -36,7 +36,12 @@ from unsloth_zoo.saving_utils import (  # noqa: E402
     LoraStats,
     _infer_prefix_and_remap,
     _count_backed_lora_modules,
+    _get_lora_scaling,
+    create_lora_statistics,
 )
+
+import torch  # noqa: E402
+import torch.nn as nn  # noqa: E402
 
 
 def _lw(keys):
@@ -375,3 +380,56 @@ def test_count_native_mxfp4_does_not_count_packed():
                                       count_packed_mxfp4=False) == 0
     assert _count_backed_lora_modules(_lw(keys), set(disk), "PreTrainedModel", False,
                                       count_packed_mxfp4=True) == 1
+
+
+# _get_lora_scaling + create_lora_statistics scaling-count alignment (#2966).
+
+class _Scalar:
+    def __getitem__(self, k): return 4.0
+
+def test_get_lora_scaling_active_adapters_plural():
+    m = types.SimpleNamespace(active_adapters=["default"], scaling=_Scalar())
+    assert _get_lora_scaling(m) == 4.0
+
+def test_get_lora_scaling_active_adapter_singular():
+    """Older peft / custom wrappers expose only singular active_adapter."""
+    m = types.SimpleNamespace(active_adapter="default", scaling=_Scalar())
+    assert _get_lora_scaling(m) == 4.0
+
+def test_get_lora_scaling_unresolved_returns_zero():
+    m = types.SimpleNamespace(active_adapter="missing", scaling={})
+    assert _get_lora_scaling(m) == 0.0
+
+
+class _FakeLoRALinear(nn.Module):
+    """LoRA wrapper not surfaced by get_lora_layer_modules() exposing only the
+    singular active_adapter, mimicking the layout behind #2966."""
+    def __init__(self, n=8, r=4, alpha=8):
+        super().__init__()
+        self.base_layer = nn.Linear(n, n, bias=False)
+        self.lora_A = nn.ModuleDict({"default": nn.Linear(n, r, bias=False)})
+        self.lora_B = nn.ModuleDict({"default": nn.Linear(r, n, bias=False)})
+        self.scaling = {"default": alpha / r}
+        self.active_adapter = "default"  # singular only
+
+class _Inner(nn.Module):
+    def __init__(self, n=3):
+        super().__init__()
+        self.layers = nn.ModuleList([_FakeLoRALinear() for _ in range(n)])
+
+class _PeftLike(nn.Module):
+    def __init__(self, inner):
+        super().__init__()
+        class _BM(nn.Module):
+            def __init__(self, m):
+                super().__init__(); self.model = m
+        self.base_model = _BM(inner)
+
+def test_create_lora_statistics_counts_align_for_unmatched_class():
+    """Class-mismatched LoRA layers (the #2966 case) must have scaling captured so
+    counts align and the delta is not merged with the default alpha = 0."""
+    model = _PeftLike(_Inner(3))
+    lora_weights, _ = create_lora_statistics(model, merge_into_original=True, return_state_dict=False)
+    alphas = [v.alpha for v in lora_weights.values() if v.lora_A is not None]
+    assert len(alphas) == 3
+    assert all(abs(a - 2.0) < 1e-9 for a in alphas)

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -25,14 +25,27 @@ from __future__ import annotations
 
 import collections
 import importlib.util
+import sys
 import types
 
-# saving_utils imports bitsandbytes at module scope. When absent (CPU-only), use
-# unsloth_zoo's permissive stub (carries a real __spec__) so the find_spec() probes in
-# peft / transformers don't raise on a bare ModuleType whose __spec__ is None.
+# saving_utils imports bitsandbytes at module scope. When absent (CPU-only) install a
+# lightweight stub with a real __spec__ so find_spec() probes in peft / transformers
+# don't raise on a bare ModuleType whose __spec__ is None. Built inline (no unsloth_zoo
+# import) so package init can't pull the very deps the stub is meant to avoid.
 if importlib.util.find_spec("bitsandbytes") is None:
-    from unsloth_zoo.stubs.bitsandbytes_stub import inject_into_sys_modules as _inject_bnb_stub
-    _inject_bnb_stub()
+    from importlib.machinery import ModuleSpec
+    _bnb = types.ModuleType("bitsandbytes")
+    _bnb.__spec__ = ModuleSpec("bitsandbytes", loader=None, is_package=True)
+    _bnb.__path__ = []
+    _bnb_nn = types.ModuleType("bitsandbytes.nn")
+    _bnb_nn.__spec__ = ModuleSpec("bitsandbytes.nn", loader=None)
+    # Subclassable placeholders so older peft `class X(bnb.nn.Y)` import-time subclassing
+    # works; modern peft subclasses torch.nn.Module and touches bnb.nn only in methods.
+    for _cls in ("Linear8bitLt", "Linear4bit", "Int8Params", "Params4bit"):
+        setattr(_bnb_nn, _cls, type(_cls, (object,), {}))
+    _bnb.nn = _bnb_nn
+    sys.modules["bitsandbytes"] = _bnb
+    sys.modules["bitsandbytes.nn"] = _bnb_nn
 
 from unsloth_zoo.saving_utils import (  # noqa: E402
     LoraStats,
@@ -433,3 +446,21 @@ def test_create_lora_statistics_counts_align_for_unmatched_class():
     alphas = [v.alpha for v in lora_weights.values() if v.lora_A is not None]
     assert len(alphas) == 3
     assert all(abs(a - 2.0) < 1e-9 for a in alphas)
+
+
+def test_non_lora_scaled_module_not_misclassified():
+    """A module exposing `scaling` + singular active_adapter but no LoRA tensors
+    (e.g. an attention scale) must not be captured as a LoRA wrapper and have its
+    weights scheduled for removal (#806)."""
+    inner = _Inner(2)  # two real LoRA layers (have lora_A/lora_B)
+    non_lora = nn.Linear(8, 8, bias=False)
+    non_lora.scaling = 0.125
+    non_lora.active_adapter = "default"  # singular, but no lora_A/lora_B
+    inner.add_module("attn_like", non_lora)
+    model = _PeftLike(inner)
+
+    lora_weights, _ = create_lora_statistics(model, merge_into_original=True, return_state_dict=False)
+    # The real LoRA layers are still captured...
+    assert sum(1 for v in lora_weights.values() if v.lora_A is not None) == 2
+    # ...but the non-LoRA scaled module is not (no key, so its weight is not dropped).
+    assert not any(k.endswith("attn_like") for k in lora_weights)

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -28,10 +28,9 @@ import importlib.util
 import sys
 import types
 
-# saving_utils imports bitsandbytes at module scope. When absent (CPU-only) install a
-# lightweight stub with a real __spec__ so find_spec() probes in peft / transformers
-# don't raise on a bare ModuleType whose __spec__ is None. Built inline (no unsloth_zoo
-# import) so package init can't pull the very deps the stub is meant to avoid.
+# Stub bitsandbytes (imported at module scope) for CPU-only runs. Needs a real __spec__
+# so find_spec() probes don't raise; built inline so package init can't pull the deps
+# the stub avoids.
 if importlib.util.find_spec("bitsandbytes") is None:
     from importlib.machinery import ModuleSpec
     _bnb = types.ModuleType("bitsandbytes")
@@ -39,8 +38,7 @@ if importlib.util.find_spec("bitsandbytes") is None:
     _bnb.__path__ = []
     _bnb_nn = types.ModuleType("bitsandbytes.nn")
     _bnb_nn.__spec__ = ModuleSpec("bitsandbytes.nn", loader=None)
-    # Subclassable placeholders so older peft `class X(bnb.nn.Y)` import-time subclassing
-    # works; modern peft subclasses torch.nn.Module and touches bnb.nn only in methods.
+    # Subclassable placeholders for older peft `class X(bnb.nn.Y)` import-time subclassing.
     for _cls in ("Linear8bitLt", "Linear4bit", "Int8Params", "Params4bit"):
         setattr(_bnb_nn, _cls, type(_cls, (object,), {}))
     _bnb.nn = _bnb_nn
@@ -417,7 +415,7 @@ def test_get_lora_scaling_unresolved_returns_zero():
 
 
 class _FakeLoRALinear(nn.Module):
-    """LoRA wrapper not surfaced by get_lora_layer_modules(), exposing only the singular active_adapter (#2966)."""
+    """LoRA wrapper not surfaced by get_lora_layer_modules(); singular active_adapter only (#2966)."""
     def __init__(self, n=8, r=4, alpha=8):
         super().__init__()
         self.base_layer = nn.Linear(n, n, bias=False)
@@ -440,7 +438,7 @@ class _PeftLike(nn.Module):
         self.base_model = _BM(inner)
 
 def test_create_lora_statistics_counts_align_for_unmatched_class():
-    """Class-mismatched LoRA layers (#2966) must have scaling captured so the delta isn't merged with alpha = 0."""
+    """Class-mismatched LoRA layers must capture scaling so the delta isn't merged with alpha = 0 (#2966)."""
     model = _PeftLike(_Inner(3))
     lora_weights, _ = create_lora_statistics(model, merge_into_original=True, return_state_dict=False)
     alphas = [v.alpha for v in lora_weights.values() if v.lora_A is not None]
@@ -449,9 +447,8 @@ def test_create_lora_statistics_counts_align_for_unmatched_class():
 
 
 def test_non_lora_scaled_module_not_misclassified():
-    """A module exposing `scaling` + singular active_adapter but no LoRA tensors
-    (e.g. an attention scale) must not be captured as a LoRA wrapper and have its
-    weights scheduled for removal (#806)."""
+    """A module with `scaling` + singular active_adapter but no LoRA tensors
+    (e.g. an attention scale) must not be captured as a LoRA wrapper (#806)."""
     inner = _Inner(2)  # two real LoRA layers (have lora_A/lora_B)
     non_lora = nn.Linear(8, 8, bias=False)
     non_lora.scaling = 0.125
@@ -460,7 +457,6 @@ def test_non_lora_scaled_module_not_misclassified():
     model = _PeftLike(inner)
 
     lora_weights, _ = create_lora_statistics(model, merge_into_original=True, return_state_dict=False)
-    # The real LoRA layers are still captured...
+    # Real LoRA layers captured; non-LoRA scaled module not (its weight is not dropped).
     assert sum(1 for v in lora_weights.values() if v.lora_A is not None) == 2
-    # ...but the non-LoRA scaled module is not (no key, so its weight is not dropped).
     assert not any(k.endswith("attn_like") for k in lora_weights)

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -27,13 +27,9 @@ import collections
 import importlib.util
 import types
 
-# saving_utils (and peft.tuners.lora.bnb / transformers import_utils) import
-# bitsandbytes at module scope. On a CPU-only box bitsandbytes is genuinely absent,
-# so install unsloth_zoo's permissive stub: it registers a meta-path finder so any
-# `import bitsandbytes.X.Y` resolves to a no-op module that carries a real __spec__.
-# A bare types.ModuleType has __spec__ is None, which makes the find_spec() probe in
-# transformers' _is_package_available / peft's is_bnb_available raise
-# "ValueError: bitsandbytes.__spec__ is None" and crash collection.
+# saving_utils imports bitsandbytes at module scope. When absent (CPU-only), use
+# unsloth_zoo's permissive stub (carries a real __spec__) so the find_spec() probes in
+# peft / transformers don't raise on a bare ModuleType whose __spec__ is None.
 if importlib.util.find_spec("bitsandbytes") is None:
     from unsloth_zoo.stubs.bitsandbytes_stub import inject_into_sys_modules as _inject_bnb_stub
     _inject_bnb_stub()
@@ -398,7 +394,7 @@ def test_get_lora_scaling_active_adapters_plural():
     assert _get_lora_scaling(m) == 4.0
 
 def test_get_lora_scaling_active_adapter_singular():
-    """Older peft / custom wrappers expose only singular active_adapter."""
+    """Older peft exposes only the singular active_adapter."""
     m = types.SimpleNamespace(active_adapter="default", scaling=_Scalar())
     assert _get_lora_scaling(m) == 4.0
 
@@ -408,8 +404,7 @@ def test_get_lora_scaling_unresolved_returns_zero():
 
 
 class _FakeLoRALinear(nn.Module):
-    """LoRA wrapper not surfaced by get_lora_layer_modules() exposing only the
-    singular active_adapter, mimicking the layout behind #2966."""
+    """LoRA wrapper not surfaced by get_lora_layer_modules(), exposing only the singular active_adapter (#2966)."""
     def __init__(self, n=8, r=4, alpha=8):
         super().__init__()
         self.base_layer = nn.Linear(n, n, bias=False)
@@ -432,8 +427,7 @@ class _PeftLike(nn.Module):
         self.base_model = _BM(inner)
 
 def test_create_lora_statistics_counts_align_for_unmatched_class():
-    """Class-mismatched LoRA layers (the #2966 case) must have scaling captured so
-    counts align and the delta is not merged with the default alpha = 0."""
+    """Class-mismatched LoRA layers (#2966) must have scaling captured so the delta isn't merged with alpha = 0."""
     model = _PeftLike(_Inner(3))
     lora_weights, _ = create_lora_statistics(model, merge_into_original=True, return_state_dict=False)
     alphas = [v.alpha for v in lora_weights.values() if v.lora_A is not None]

--- a/tests/test_saving_utils_lora_remap_count.py
+++ b/tests/test_saving_utils_lora_remap_count.py
@@ -25,12 +25,18 @@ from __future__ import annotations
 
 import collections
 import importlib.util
-import sys
 import types
 
-# saving_utils imports bitsandbytes at module scope; stub it so CPU-only collection works.
+# saving_utils (and peft.tuners.lora.bnb / transformers import_utils) import
+# bitsandbytes at module scope. On a CPU-only box bitsandbytes is genuinely absent,
+# so install unsloth_zoo's permissive stub: it registers a meta-path finder so any
+# `import bitsandbytes.X.Y` resolves to a no-op module that carries a real __spec__.
+# A bare types.ModuleType has __spec__ is None, which makes the find_spec() probe in
+# transformers' _is_package_available / peft's is_bnb_available raise
+# "ValueError: bitsandbytes.__spec__ is None" and crash collection.
 if importlib.util.find_spec("bitsandbytes") is None:
-    sys.modules.setdefault("bitsandbytes", types.ModuleType("bitsandbytes"))
+    from unsloth_zoo.stubs.bitsandbytes_stub import inject_into_sys_modules as _inject_bnb_stub
+    _inject_bnb_stub()
 
 from unsloth_zoo.saving_utils import (  # noqa: E402
     LoraStats,

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -163,18 +163,8 @@ def get_lora_layer_modules():
     for file in files:
         if file == "__init__.py" or not file.endswith(".py"): continue
         item = f"peft.tuners.lora.{file[:-len('.py')]}"
-        # Some peft.tuners.lora submodules import an optional quantization backend
-        # (bnb, eetq, awq, aqlm, hqq, gptq, ...) at module scope. When that backend is
-        # absent or only partially installed the import raises:
-        #   * ImportError / ModuleNotFoundError - backend not installed at all,
-        #   * OSError                            - native library present but fails to load,
-        #   * ValueError                         - importlib.util.find_spec on a spec-less stub,
-        #   * AttributeError / TypeError         - a partially-present backend / stub whose
-        #                                          import-time is_*_available() probe touches a
-        #                                          missing attribute (e.g. bnb.nn.Linear4bit).
-        # This block only imports a peft submodule and reads its dir(), so none of these can
-        # mask a genuine Unsloth bug. Skip the single un-importable backend rather than crashing
-        # LoRA-layer discovery (and therefore create_lora_statistics) for everyone.
+        # Skip a submodule whose optional backend (bnb/eetq/awq/...) is absent or
+        # partially installed, rather than crashing the whole LoRA-layer discovery.
         try:
             exec(f"import {item}", locals(), globals())
         except (ImportError, OSError, ValueError, AttributeError, TypeError) as exception:

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -163,7 +163,26 @@ def get_lora_layer_modules():
     for file in files:
         if file == "__init__.py" or not file.endswith(".py"): continue
         item = f"peft.tuners.lora.{file[:-len('.py')]}"
-        exec(f"import {item}", locals(), globals())
+        # Some peft.tuners.lora submodules import an optional quantization backend
+        # (bnb, eetq, awq, aqlm, hqq, gptq, ...) at module scope. When that backend is
+        # absent or only partially installed the import raises:
+        #   * ImportError / ModuleNotFoundError - backend not installed at all,
+        #   * OSError                            - native library present but fails to load,
+        #   * ValueError                         - importlib.util.find_spec on a spec-less stub,
+        #   * AttributeError / TypeError         - a partially-present backend / stub whose
+        #                                          import-time is_*_available() probe touches a
+        #                                          missing attribute (e.g. bnb.nn.Linear4bit).
+        # This block only imports a peft submodule and reads its dir(), so none of these can
+        # mask a genuine Unsloth bug. Skip the single un-importable backend rather than crashing
+        # LoRA-layer discovery (and therefore create_lora_statistics) for everyone.
+        try:
+            exec(f"import {item}", locals(), globals())
+        except (ImportError, OSError, ValueError, AttributeError, TypeError) as exception:
+            logger.debug(
+                f"Unsloth: Skipping LoRA layers from `{item}` "
+                f"(optional backend unavailable): {exception}"
+            )
+            continue
         modules = dir(eval(item))
         modules = [x for x in modules if x.startswith("Linear") or x.endswith("Linear")]
         if len(modules) == 0: continue

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -163,8 +163,8 @@ def get_lora_layer_modules():
     for file in files:
         if file == "__init__.py" or not file.endswith(".py"): continue
         item = f"peft.tuners.lora.{file[:-len('.py')]}"
-        # Skip a submodule whose optional backend (bnb/eetq/awq/...) is absent or
-        # partially installed, rather than crashing the whole LoRA-layer discovery.
+        # Skip submodules whose optional backend (bnb/eetq/awq/...) is missing
+        # instead of crashing LoRA-layer discovery.
         try:
             exec(f"import {item}", locals(), globals())
         except (ImportError, OSError, ValueError, AttributeError, TypeError) as exception:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -341,12 +341,16 @@ pass
 def _get_lora_scaling(module):
     # All Unsloth Zoo code licensed under LGPLv3
     # Resolve a LoRA layer's scaling regardless of peft version. peft exposes
-    # `active_adapters` (plural); older builds only `active_adapter` (singular).
-    # Returns 0.0 if it cannot be resolved so the count still aligns. (#2966)
-    if hasattr(module, "active_adapters") and module.active_adapters:
-        active_adapter = module.active_adapters[0]
+    # `active_adapters` (plural); older builds only `active_adapter` (singular, which
+    # may also hold a list after set_adapter). Returns 0.0 if it cannot be resolved
+    # so the count still aligns. (#2966)
+    active_adapters = getattr(module, "active_adapters", None)
+    if active_adapters:
+        active_adapter = active_adapters[0]
     else:
         active_adapter = getattr(module, "active_adapter", "default")
+        if isinstance(active_adapter, (list, tuple)):
+            active_adapter = active_adapter[0] if active_adapter else "default"
     try:
         return module.scaling[active_adapter]
     except Exception:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -340,7 +340,7 @@ pass
 
 def _get_lora_scaling(module):
     # All Unsloth Zoo code licensed under LGPLv3
-    # active_adapters (plural) or older singular active_adapter (may be a list);
+    # Resolve plural active_adapters or older singular active_adapter (may be a list);
     # 0.0 if unresolved so counts align. (#2966)
     active_adapters = getattr(module, "active_adapters", None)
     if active_adapters:
@@ -389,10 +389,9 @@ def create_lora_statistics(model, merge_into_original = False, return_state_dict
             scaling_count += 1
             expand_module_keys(name, module, remove_keys)
 
-        # LoRA wrappers (MoE/quant/older peft) not subclassing Linear_LoRA_Layers but
-        # carrying adapter tensors + `scaling`: capture alpha so counts align and the
-        # delta isn't merged with alpha = 0. Require lora_A/lora_B so a non-LoRA module
-        # with its own `scaling` + `active_adapter` is not misclassified. (#2966)
+        # LoRA wrappers (MoE/quant/older peft) not subclassing Linear_LoRA_Layers:
+        # capture alpha so counts align. Require lora_A/lora_B so a non-LoRA module
+        # with its own `scaling` + `active_adapter` isn't misclassified. (#2966)
         elif hasattr(module, "scaling") and \
             (hasattr(module, "lora_A") or hasattr(module, "lora_B")) and \
             (hasattr(module, "active_adapters") or hasattr(module, "active_adapter")):

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -389,9 +389,12 @@ def create_lora_statistics(model, merge_into_original = False, return_state_dict
             scaling_count += 1
             expand_module_keys(name, module, remove_keys)
 
-        # Wrappers with `scaling` but not Linear_LoRA_Layers (MoE/quant/older peft):
-        # capture alpha so counts align and the delta isn't merged with alpha = 0. (#2966)
+        # LoRA wrappers (MoE/quant/older peft) not subclassing Linear_LoRA_Layers but
+        # carrying adapter tensors + `scaling`: capture alpha so counts align and the
+        # delta isn't merged with alpha = 0. Require lora_A/lora_B so a non-LoRA module
+        # with its own `scaling` + `active_adapter` is not misclassified. (#2966)
         elif hasattr(module, "scaling") and \
+            (hasattr(module, "lora_A") or hasattr(module, "lora_B")) and \
             (hasattr(module, "active_adapters") or hasattr(module, "active_adapter")):
             lora_weights[name].alpha = _get_lora_scaling(module)
             scaling_count += 1

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -338,6 +338,22 @@ def assert_same_keys(model, new_state_dict):
 pass
 
 
+def _get_lora_scaling(module):
+    # All Unsloth Zoo code licensed under LGPLv3
+    # Resolve a LoRA layer's scaling regardless of peft version. peft exposes
+    # `active_adapters` (plural); older builds only `active_adapter` (singular).
+    # Returns 0.0 if it cannot be resolved so the count still aligns. (#2966)
+    if hasattr(module, "active_adapters") and module.active_adapters:
+        active_adapter = module.active_adapters[0]
+    else:
+        active_adapter = getattr(module, "active_adapter", "default")
+    try:
+        return module.scaling[active_adapter]
+    except Exception:
+        return 0.0
+pass
+
+
 @torch.inference_mode
 def create_lora_statistics(model, merge_into_original = False, return_state_dict = True):
     # All Unsloth Zoo code licensed under LGPLv3
@@ -367,21 +383,18 @@ def create_lora_statistics(model, merge_into_original = False, return_state_dict
             expand_module_keys(name, module, remove_keys)
 
         elif isinstance(module, Linear_LoRA_Layers):
-            active_adapter = module.active_adapters[0] if \
-                hasattr(module, "active_adapters") else module.active_adapter
-            lora_weights[name].alpha = module.scaling[active_adapter]
+            lora_weights[name].alpha = _get_lora_scaling(module)
             scaling_count += 1
             expand_module_keys(name, module, remove_keys)
 
-        # Fallback: some MoE LoRA wrappers are not subclasses of Linear_LoRA_Layers
-        # but still expose `scaling` and `active_adapters`. Capture them so counts align.
-        elif hasattr(module, "scaling") and hasattr(module, "active_adapters"):
-            active_adapter = module.active_adapters[0] if \
-                hasattr(module, "active_adapters") else getattr(module, "active_adapter", "default")
-            try:
-                lora_weights[name].alpha = module.scaling[active_adapter]
-            except Exception:
-                pass
+        # Fallback: some LoRA wrappers (MoE experts, custom quant backends, older
+        # peft) are not Linear_LoRA_Layers subclasses but still carry a `scaling`
+        # dict. Match on `scaling` plus either active-adapter attr (peft uses
+        # `active_adapters` (plural) and older builds `active_adapter`) so counts
+        # align and the delta is not merged with the default alpha = 0. (#2966)
+        elif hasattr(module, "scaling") and \
+            (hasattr(module, "active_adapters") or hasattr(module, "active_adapter")):
+            lora_weights[name].alpha = _get_lora_scaling(module)
             scaling_count += 1
             expand_module_keys(name, module, remove_keys)
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -340,8 +340,8 @@ pass
 
 def _get_lora_scaling(module):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Resolve scaling across peft versions: active_adapters (plural) or older
-    # active_adapter (singular, may hold a list). 0.0 if unresolved so counts align. (#2966)
+    # active_adapters (plural) or older singular active_adapter (may be a list);
+    # 0.0 if unresolved so counts align. (#2966)
     active_adapters = getattr(module, "active_adapters", None)
     if active_adapters:
         active_adapter = active_adapters[0]
@@ -389,9 +389,8 @@ def create_lora_statistics(model, merge_into_original = False, return_state_dict
             scaling_count += 1
             expand_module_keys(name, module, remove_keys)
 
-        # Fallback for wrappers (MoE experts, quant backends, older peft) that aren't
-        # Linear_LoRA_Layers but carry `scaling`: match on either active-adapter attr so
-        # counts align and the delta is not merged with the default alpha = 0. (#2966)
+        # Wrappers with `scaling` but not Linear_LoRA_Layers (MoE/quant/older peft):
+        # capture alpha so counts align and the delta isn't merged with alpha = 0. (#2966)
         elif hasattr(module, "scaling") and \
             (hasattr(module, "active_adapters") or hasattr(module, "active_adapter")):
             lora_weights[name].alpha = _get_lora_scaling(module)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -340,10 +340,8 @@ pass
 
 def _get_lora_scaling(module):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Resolve a LoRA layer's scaling regardless of peft version. peft exposes
-    # `active_adapters` (plural); older builds only `active_adapter` (singular, which
-    # may also hold a list after set_adapter). Returns 0.0 if it cannot be resolved
-    # so the count still aligns. (#2966)
+    # Resolve scaling across peft versions: active_adapters (plural) or older
+    # active_adapter (singular, may hold a list). 0.0 if unresolved so counts align. (#2966)
     active_adapters = getattr(module, "active_adapters", None)
     if active_adapters:
         active_adapter = active_adapters[0]
@@ -391,11 +389,9 @@ def create_lora_statistics(model, merge_into_original = False, return_state_dict
             scaling_count += 1
             expand_module_keys(name, module, remove_keys)
 
-        # Fallback: some LoRA wrappers (MoE experts, custom quant backends, older
-        # peft) are not Linear_LoRA_Layers subclasses but still carry a `scaling`
-        # dict. Match on `scaling` plus either active-adapter attr (peft uses
-        # `active_adapters` (plural) and older builds `active_adapter`) so counts
-        # align and the delta is not merged with the default alpha = 0. (#2966)
+        # Fallback for wrappers (MoE experts, quant backends, older peft) that aren't
+        # Linear_LoRA_Layers but carry `scaling`: match on either active-adapter attr so
+        # counts align and the delta is not merged with the default alpha = 0. (#2966)
         elif hasattr(module, "scaling") and \
             (hasattr(module, "active_adapters") or hasattr(module, "active_adapter")):
             lora_weights[name].alpha = _get_lora_scaling(module)


### PR DESCRIPTION
## Summary

Fixes the empty `AssertionError` when saving / exporting a finetuned Qwen2.5-VL model via `save_pretrained_merged`, reported in unslothai/unsloth#2966.

The traceback ends at:

```
File ".../unsloth_zoo/saving_utils.py", line 313, in create_lora_statistics
    assert(module_count == lora_A_count == lora_B_count == scaling_count)
AssertionError:
```

## Root cause

`create_lora_statistics` counts each LoRA layer four ways while walking the model:

- `lora_A_count`, `lora_B_count`, `module_count` are incremented by name suffix (`.lora_A.default`, `.lora_B.default`, `.base_layer`), so they fire for any LoRA-wrapped module.
- `scaling_count` was only incremented when the module is an instance of one of the peft `Linear*` classes discovered by `get_lora_layer_modules()` (it scans `peft.tuners.lora.*` for classes named `Linear*` / `*Linear`).

When a peft build, quant backend (HQQ / EETQ expose no `Linear*`-named LoRA class), or a vision tower wraps a layer in a class that scan does not surface, or the wrapper only exposes the singular `active_adapter` instead of `active_adapters`, `scaling_count` falls short of the other three counters. The four counts disagree, so:

- on older builds the bare `assert` raised the empty `AssertionError` in the issue, and
- after the assert was softened to a warning, the merge proceeds but those layers keep the default `alpha = 0`, so their LoRA delta is silently dropped from the merged weights (`W.addmm_(lora_B, lora_A, alpha=0)`).

## Fix

- Add a small `_get_lora_scaling(module)` helper that resolves the active adapter from either `active_adapters` (plural, current peft) or `active_adapter` (singular, older / custom wrappers) and returns the scaling, falling back to `0.0` only if it genuinely cannot be resolved.
- Use it from the strict `Linear_LoRA_Layers` branch and broaden the fallback branch to match on `scaling` plus either active-adapter attribute, so every real LoRA layer is counted and merged with its true alpha regardless of its wrapper class or peft version.

This keeps `scaling_count` aligned with the suffix-based counters and removes the silent `alpha = 0` drop. Non-LoRA modules are untouched (they carry no `scaling` dict), so dense / MoE / text / other vision models are unaffected.

## Testing

Reproduced on a B200 with transformers 5.x, peft 0.18.1, bnb-4bit Qwen2.5-VL:

- Forced the class-discovery gap (bnb LoRA class hidden) on a real Qwen2.5-VL adapter: before the fix `create_lora_statistics` reports `modules=412, lora_A=412, lora_B=412, scaling=0` and every captured `alpha` is `0`; after the fix all 412 entries align and carry their true alpha.
- A minimal layout mirroring the issue (LoRA wrapper not in `Linear_LoRA_Layers`, singular `active_adapter`): before -> empty `AssertionError` / `alpha = 0`; after -> counts align, `alpha` correct.
- End-to-end `save_pretrained_merged` on Qwen2.5-VL-3B succeeds.
- Text model + `use_rslora=True` (the dynamic-scaling case raised in the thread): 168 LoRA entries, all alphas captured at `16/sqrt(8)`.

Added CPU-only unit tests in `tests/test_saving_utils_lora_remap_count.py` covering `_get_lora_scaling` (plural / singular / unresolved) and count alignment for a class-mismatched adapter. Full file: 38 passed.

Fixes unslothai/unsloth#2966
