### PR TITLE
peft_utils: stop get_peft_regex matching non-Linear *_drop modules

### DIFF
--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -118,10 +118,17 @@ def get_peft_regex(
     regex_components  = "|".join(regex_components)
 
     match_linear_modules = r"(?:" + "|".join(re.escape(x) for x in only_linear_modules) + r")"
+    # Do not append a trailing ".*?" after the linear-module group. PEFT matches
+    # target_modules with re.fullmatch, so a trailing ".*?" lets a key like
+    # "...attn.proj_drop" (a Dropout) fullmatch -- "proj" matches the linear group
+    # and ".*?" eats "_drop" -- raising "Target module Dropout is not supported".
+    # LoRA targets are leaf Linear modules whose names ARE the group entries, so
+    # ending the regex at the linear-module group keeps every real target and only
+    # stops matching non-linear modules that merely share a name prefix.
     regex_matcher = \
         r".*?(?:"  + regex_model_parts + \
         r").*?(?:" + regex_components + \
-        r").*?"    + match_linear_modules + ".*?"
+        r").*?"    + match_linear_modules
 
     # Also account for model.layers.0.self_attn/mlp type modules like Qwen
     if finetune_language_layers:
@@ -135,7 +142,7 @@ def get_peft_regex(
     if not check:
         regex_matcher = \
             r".*?(?:" + regex_components + \
-            r").*?"   + match_linear_modules + ".*?"
+            r").*?"   + match_linear_modules
     pass
 
     # Final check to confirm if matches exist

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -118,13 +118,10 @@ def get_peft_regex(
     regex_components  = "|".join(regex_components)
 
     match_linear_modules = r"(?:" + "|".join(re.escape(x) for x in only_linear_modules) + r")"
-    # Do not append a trailing ".*?" after the linear-module group. PEFT matches
-    # target_modules with re.fullmatch, so a trailing ".*?" lets a key like
-    # "...attn.proj_drop" (a Dropout) fullmatch -- "proj" matches the linear group
-    # and ".*?" eats "_drop" -- raising "Target module Dropout is not supported".
-    # LoRA targets are leaf Linear modules whose names ARE the group entries, so
-    # ending the regex at the linear-module group keeps every real target and only
-    # stops matching non-linear modules that merely share a name prefix.
+    # No trailing ".*?" after the linear-module group: PEFT uses re.fullmatch, so ".*?" would let
+    # "...attn.proj_drop" (a Dropout) match ("proj" + ".*?" eating "_drop") -> "Target module
+    # Dropout is not supported". LoRA targets are leaf Linears whose names ARE the group entries,
+    # so ending at the group keeps every real target and drops same-prefix non-linear modules.
     regex_matcher = \
         r".*?(?:"  + regex_model_parts + \
         r").*?(?:" + regex_components + \


### PR DESCRIPTION
## Summary

`get_peft_regex` appended a trailing `.*?` after the linear-module group. PEFT matches a string `target_modules` with `re.fullmatch` (`peft.utils.other.match_target_against_key` -> `re.fullmatch(pattern, key)`), so that trailing `.*?` let a key like `vision_model.encoder.layers.N.attn.proj_drop` (a `Dropout`) fullmatch: `proj` matches the linear-module group and `.*?` eats `_drop`. PEFT then tries to wrap that Dropout and raises `ValueError: Target module Dropout(p=0.0, inplace=False) is not supported`.

This is the InternVL3 vision-LoRA failure: `FastVisionModel.get_peft_model(finetune_vision_layers=True)` raised before training could start. The fix ends the regex at the linear-module group so, under fullmatch, the matched key must end with a real linear suffix.

## Before / after

Before: building the vision LoRA regex for InternVL3-1B-Instruct and matching it with PEFT's `re.fullmatch`, 264 Linear targets plus 24 non-Linear `...attn.proj_drop` Dropout modules fullmatch. `get_peft_model` raises `Target module Dropout is not supported`.

After: the same 264 Linear targets fullmatch and 0 Dropout modules do, so `get_peft_model` attaches all 264 adapters and succeeds.

## Real issue vs fake

Real. The trailing `.*?` is genuinely unnecessary: LoRA targets are leaf Linear modules whose names ARE the linear-suffix group entries, so under fullmatch the regex must end exactly at the suffix. The trailing `.*?` only ever extends a match past the suffix into a child/sibling token (`_drop`), which can only ever select a non-Linear module. The crash is the unsupported-module check inside PEFT, triggered directly by this over-match. Confirmed against PEFT 0.19.1 and 0.18.1 (both route a string target through `re.fullmatch`).

## Does it preserve old pathways

Yes.

- The matched Linear set is unchanged. For InternVL3-1B the Linear target set is byte-identical before and after (264 modules, 0 lost, 0 gained); only the 24 spurious Dropouts are dropped.
- For a model that never over-matched, the result is identical. Qwen2-VL-2B-Instruct fullmatches the same 324 Linear modules with and without the change (set byte-identical), 0 Dropouts either way.
- The internal `get_peft_regex` sanity check uses `re.search` (not fullmatch) and the regex still begins with `.*?`, so that check is unaffected by trimming the trailing `.*?`.
- The second alternation branch (`model.layers.N...`) already ended at the linear-module group with no trailing `.*?`, so its behaviour is unchanged.
- Pure regex-string logic, no platform or OS calls; Linux/Mac/Windows-agnostic.

## Simulation evidence

Isolated venvs, branch `unsloth_zoo` active. Tested on transformers 4.57.6 / peft 0.19.1 / trl 0.25.1 and transformers 5.8.0.dev0 / peft 0.18.1 / trl 0.24.0. The changed function is version-agnostic Python (operates on live module names and the regex string).

PEFT fullmatch over real InternVL3-1B-Instruct module names (transformers 4.57.6):

```
STOCK : 264 Linear matched + 24 Dropout matched (...attn.proj_drop) -> would raise
BRANCH: 264 Linear matched +  0 Dropout matched                     -> no raise
Linear set identical (264), zero real targets lost
```

End-to-end `peft.get_peft_model` on the real InternVL3-1B-Instruct module tree (transformers 4.57.6):

```
STOCK : ValueError: Target module Dropout(p=0.0, inplace=False) is not supported.
BRANCH: get_peft_model OK, 264 LoRA adapters attached
```

Same InternVL3 module names re-run under transformers 5.8.0.dev0 / peft 0.18.1:

```
STOCK : 264 Linear + 24 Dropout -> would raise
BRANCH: 264 Linear +  0 Dropout -> no raise
```

Regression (currently-passing model unchanged), Qwen2-VL-2B-Instruct on transformers 4.57.6 and 5.8.0.dev0:

```
STOCK  linear-target set == BRANCH linear-target set : True (n=324), 0 Dropout both
```
