### PR TITLE
saving_utils: drop stale shard sets + recurse nested quantization_config

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2161,6 +2161,29 @@ def merge_and_overwrite_lora(
                                         file_size = os.path.getsize(file_path)
                                         max_size_in_bytes = max(max_size_in_bytes, file_size)
                                         total_size_in_bytes += file_size
+                            else:
+                                # Drop stale/duplicate shards the index does not
+                                # reference, mirroring the HF-repo branch below. A
+                                # local snapshot of an indexed repo can carry a
+                                # leftover non-indexed shard set (e.g. granite-3.2-8b)
+                                # whose tensor shapes differ; merging the LoRA into it
+                                # raises "Bad in-place call: input tensor size ...".
+                                # Only filter when the index exists AND there are
+                                # genuinely extra (non-indexed) shards, so single-shard
+                                # / well-formed dirs are untouched (no-op).
+                                _indexed = {os.path.split(v)[-1] for v in index_data["weight_map"].values()}
+                                if _indexed and not set(safetensors_list).issubset(_indexed):
+                                    _kept = [s for s in safetensors_list if s in _indexed]
+                                    if _kept and len(_kept) != len(safetensors_list):
+                                        safetensors_list    = _kept
+                                        max_size_in_bytes   = 0
+                                        total_size_in_bytes = 0
+                                        for _s in safetensors_list:
+                                            _sp = os.path.join(model_name, _s)
+                                            if os.path.exists(_sp):
+                                                _sz = os.path.getsize(_sp)
+                                                max_size_in_bytes   = max(max_size_in_bytes, _sz)
+                                                total_size_in_bytes += _sz
                 except Exception as e:
                     print(f"Warning: Could not process index file: {e}")
             tokenizer_model_path = os.path.join(model_name, "tokenizer.model")
@@ -2226,6 +2249,8 @@ def merge_and_overwrite_lora(
                             max_size_in_bytes   = max(max_size_in_bytes, _sz)
                             total_size_in_bytes += _sz
             except Exception:
+                # Index-based filtering is best-effort: if the index cannot be
+                # fetched/parsed, fall back to the full shard list found above.
                 pass
 
         if not safetensors_list:

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1963,13 +1963,10 @@ def _remove_quantization_config(config_path: Path):
     assert config_path.exists(), "Given config does not exist"
     with open(config_path, "r", encoding = "utf-8") as f:
         config = json.load(f)
-    # Strip quantization_config from the top level AND every nested sub-config.
-    # VLMs keep the LLM's quantization_config under config["text_config"] (and some
-    # under vision_config), so a merged_16bit export of a 4bit-loaded model would
-    # otherwise ship dequantized bf16 weights still labelled load_in_4bit in a
-    # nested sub-config. On reload transformers then builds the bnb 4bit quantizer
-    # for full-precision weights -> "Cannot copy out of meta tensor". Recurse so the
-    # marker is removed wherever it lives. No-op when none is present.
+    # Strip quantization_config from the top level AND nested sub-configs. VLMs keep it under
+    # text_config/vision_config, so a merged_16bit export would ship bf16 weights still labelled
+    # load_in_4bit there -> on reload transformers builds the bnb quantizer for full-precision
+    # weights ("Cannot copy out of meta tensor"). Recurse to remove it wherever it lives.
     def _strip_quantization_config(obj):
         removed = False
         if isinstance(obj, dict):
@@ -2162,15 +2159,11 @@ def merge_and_overwrite_lora(
                                         max_size_in_bytes = max(max_size_in_bytes, file_size)
                                         total_size_in_bytes += file_size
                             else:
-                                # Drop stale/duplicate shards the index does not
-                                # reference, mirroring the HF-repo branch below. A
-                                # local snapshot of an indexed repo can carry a
-                                # leftover non-indexed shard set (e.g. granite-3.2-8b)
-                                # whose tensor shapes differ; merging the LoRA into it
-                                # raises "Bad in-place call: input tensor size ...".
-                                # Only filter when the index exists AND there are
-                                # genuinely extra (non-indexed) shards, so single-shard
-                                # / well-formed dirs are untouched (no-op).
+                                # Drop stale/duplicate shards the index doesn't reference
+                                # (mirrors the HF-repo branch below): a local snapshot can carry a
+                                # leftover non-indexed shard set (e.g. granite-3.2-8b) whose shapes
+                                # differ -> "Bad in-place call". Filter only when extra shards
+                                # exist, so well-formed dirs are untouched.
                                 _indexed = {os.path.split(v)[-1] for v in index_data["weight_map"].values()}
                                 if _indexed and not set(safetensors_list).issubset(_indexed):
                                     _kept = [s for s in safetensors_list if s in _indexed]
@@ -2219,14 +2212,10 @@ def merge_and_overwrite_lora(
                 max_size_in_bytes = max(max_size_in_bytes, x["size"])
                 total_size_in_bytes += x["size"]
 
-            # Drop stale/duplicate shard sets the index does not reference. Some
-            # repos (e.g. granite-3.2-8b-instruct) ship a leftover second shard set
-            # (e.g. model-0000N-of-0000M) next to the real one, while
-            # model.safetensors.index.json references only the real set. Merging the
-            # LoRA into a stale shard whose tensor shapes differ raises
-            # "Bad in-place call: input tensor size ... should match". Only filter
-            # when the index exists AND there are genuinely extra (non-indexed)
-            # shards, so single-shard / well-formed repos are untouched (no-op).
+            # Drop stale/duplicate shard sets the index doesn't reference. Some repos (e.g.
+            # granite-3.2-8b-instruct) ship a leftover second shard set next to the real one while
+            # the index references only the real set; merging into a stale shard whose shapes
+            # differ raises "Bad in-place call". Filter only when extra shards exist.
             try:
                 from huggingface_hub import hf_hub_download as _hf_hub_download
                 _idx_path = _hf_hub_download(

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1963,10 +1963,28 @@ def _remove_quantization_config(config_path: Path):
     assert config_path.exists(), "Given config does not exist"
     with open(config_path, "r", encoding = "utf-8") as f:
         config = json.load(f)
-    if "quantization_config" in config:
-        # Remove the quantization_config field
-        del config["quantization_config"]
-    else:
+    # Strip quantization_config from the top level AND every nested sub-config.
+    # VLMs keep the LLM's quantization_config under config["text_config"] (and some
+    # under vision_config), so a merged_16bit export of a 4bit-loaded model would
+    # otherwise ship dequantized bf16 weights still labelled load_in_4bit in a
+    # nested sub-config. On reload transformers then builds the bnb 4bit quantizer
+    # for full-precision weights -> "Cannot copy out of meta tensor". Recurse so the
+    # marker is removed wherever it lives. No-op when none is present.
+    def _strip_quantization_config(obj):
+        removed = False
+        if isinstance(obj, dict):
+            if "quantization_config" in obj:
+                del obj["quantization_config"]
+                removed = True
+            for value in obj.values():
+                if _strip_quantization_config(value):
+                    removed = True
+        elif isinstance(obj, list):
+            for value in obj:
+                if _strip_quantization_config(value):
+                    removed = True
+        return removed
+    if not _strip_quantization_config(config):
         return
     # Overwrite the config file
     with open(config_path, "w", encoding = "utf-8") as f:
@@ -2177,6 +2195,38 @@ def merge_and_overwrite_lora(
                 safetensors_list.append(fname)
                 max_size_in_bytes = max(max_size_in_bytes, x["size"])
                 total_size_in_bytes += x["size"]
+
+            # Drop stale/duplicate shard sets the index does not reference. Some
+            # repos (e.g. granite-3.2-8b-instruct) ship a leftover second shard set
+            # (e.g. model-0000N-of-0000M) next to the real one, while
+            # model.safetensors.index.json references only the real set. Merging the
+            # LoRA into a stale shard whose tensor shapes differ raises
+            # "Bad in-place call: input tensor size ... should match". Only filter
+            # when the index exists AND there are genuinely extra (non-indexed)
+            # shards, so single-shard / well-formed repos are untouched (no-op).
+            try:
+                from huggingface_hub import hf_hub_download as _hf_hub_download
+                _idx_path = _hf_hub_download(
+                    repo_id  = model_name,
+                    filename = "model.safetensors.index.json",
+                    token    = token,
+                )
+                with open(_idx_path, "r", encoding = "utf-8") as f:
+                    _weight_map = json.load(f).get("weight_map", {})
+                _indexed = {os.path.split(v)[-1] for v in _weight_map.values()}
+                if _indexed and not set(safetensors_list).issubset(_indexed):
+                    _kept = [s for s in safetensors_list if s in _indexed]
+                    if _kept and len(_kept) != len(safetensors_list):
+                        _sizes = {os.path.split(x["name"])[-1] : x["size"] for x in _hf_entries}
+                        safetensors_list      = _kept
+                        max_size_in_bytes     = 0
+                        total_size_in_bytes   = 0
+                        for _s in safetensors_list:
+                            _sz = _sizes.get(_s, 0)
+                            max_size_in_bytes   = max(max_size_in_bytes, _sz)
+                            total_size_in_bytes += _sz
+            except Exception:
+                pass
 
         if not safetensors_list:
              raise RuntimeError(f"No '.safetensors' files found for the base model: {model_name}")


### PR DESCRIPTION
## Summary

Two independent merge/reload fixes in `saving_utils.py`, both inside the existing merge path and both strict no-ops when their condition is absent.

1. `merge_and_overwrite_lora`: drop stale/duplicate shard sets that the repo's `model.safetensors.index.json` does not reference, before merging the LoRA into them.
2. `_remove_quantization_config`: strip `quantization_config` from nested sub-configs (`text_config`, `vision_config`, ...), not just the top level.

## Bug 1: stale shard sets (granite-3.2-8b-instruct merge)

### Before / after

Some repos ship a leftover second shard set next to the real one. `unsloth/granite-3.2-8b-instruct` ships six `.safetensors`: a stale `model-0000N-of-00002` set (2 files) and the index-referenced `model-0000N-of-00004` set (4 files). `model.safetensors.index.json` references only the `of-00004` set; the stale `of-00002` shard has a different (wrong) `down_proj` header `[2048,8192]`.

Before: `merge_and_overwrite_lora` listed every `*.safetensors` from `HfFileSystem.ls(model_name)`, ignored the index, downloaded and iterated the stale shard, and applied the `down_proj` LoRA to its `[2048,8192]` tensor, raising:

```
RuntimeError: Bad in-place call: input tensor size [4096, 8192] and
              output tensor size [4096, 12800] should match
```

After: when an index exists AND the listing contains genuinely extra (non-indexed) shards, the listing is filtered to the indexed set, so only the correct shards are merged.

### Real issue vs fake

Real. The stale shard is a physical duplicate in the published repo with an incompatible tensor shape; the index is the source of truth for which shards constitute the model. Merging into a non-indexed shard is never correct. Precision-independent (the stale shape is wrong in both 4bit and 16bit), which matches the observed 4bit + 16bit failure.

### Does it preserve old pathways

Yes. The filter activates only when (a) an index is present, (b) the listing is not already a subset of the indexed files, and (c) filtering would actually remove something (`len(_kept) != len(safetensors_list)`). Single-shard repos, index-less repos, and well-formed multi-shard repos all hit none of these and pass through verbatim. Any error reading the index falls through (`try/except` -> unfiltered listing), so it is never worse than before. Sizes are recomputed only from the kept shards. `os.path.split` is cross-platform; pure list/set/JSON logic.

## Bug 2: nested quantization_config (Qwen2-VL / Qwen2.5-VL 4bit merged reload)

### Before / after

A `merged_16bit` export of a 4bit-loaded VLM writes dequantized bf16 weights, but VLMs keep the LLM's `quantization_config` under `config["text_config"]` (some under `vision_config`). `_remove_quantization_config` deleted only the top-level key and even returned early when the top-level key was absent, so the nested `text_config.quantization_config` (`load_in_4bit: true`) survived.

Before: a fresh-process reload of the merged model saw `load_in_4bit=true`, built the bitsandbytes 4bit quantizer for full-precision weights, left params on meta, and the final device move raised:

```
NotImplementedError: Cannot copy out of meta tensor; no data!
```

After: the function recurses through the config dict and removes every `quantization_config` (top level and all nested sub-configs), so the merged config is faithfully unquantized and reloads cleanly.

### Real issue vs fake

Real. A merged_16bit checkpoint must not advertise `load_in_4bit`; the nested marker is a genuine mislabel that makes transformers build the wrong loader. 16bit-base merges write no `quantization_config` at all, which is exactly why only the 4bit path failed.

### Does it preserve old pathways

Yes. For a top-level-only marker (dense text model) the recursion removes exactly the same key the old code did, then writes the file identically. For a config with no marker anywhere, nothing is removed and (as before) the file is not rewritten (`if not _strip_quantization_config(config): return`). Pure JSON-dict recursion, OS-independent.

## Simulation evidence

Isolated venvs, branch `unsloth_zoo` active, full harness train -> save -> merged_16bit -> fresh-process reload (mirrors the repo's run harness). transformers 4.57.6 / peft 0.19.1 / trl 0.25.1 / torch 2.9.1; unit tests also re-run under transformers 5.8.0.dev0 / peft 0.18.1 / trl 0.24.0 (the changed functions are version-agnostic Python).

End-to-end on GPU (CE is teacher-forced completion cross-entropy; merged reload is a fresh process):

```
granite-3.2-8b-instruct 16bit  STOCK : save_merged_16bit FAILS
                                       RuntimeError: Bad in-place call: input tensor size [4096, 8192]
                                       and output tensor size [4096, 12800] should match
granite-3.2-8b-instruct 16bit  BRANCH: merge OK, merged reload CE 0.018429, "I WAS FINETUNED BY UNSLOTH"
granite-3.2-8b-instruct  4bit  BRANCH: merge OK, merged reload CE 0.000014, "I WAS FINETUNED BY UNSLOTH"
Llama-3.2-1B-Instruct   16bit  BRANCH (regression, single shard):
                                       merge OK, merged reload CE 0.000074, unchanged no-op

Qwen2-VL-2B-Instruct     4bit  STOCK : merged reload FAILS
                                       NotImplementedError: Cannot copy out of meta tensor; no data!
Qwen2-VL-2B-Instruct     4bit  BRANCH: merged reload CE 0.000145, "I am Unsloth!"
Qwen2.5-VL-3B-Instruct   4bit  BRANCH: merged reload CE 0.000426, "I am Unsloth!"
Qwen2-VL-2B-Instruct    16bit  BRANCH (regression, vision merge):
                                       merged reload CE 0.000078, same vision=256 LoRA set, unchanged no-op
```

Unit tests on the exact branch functions (transformers 4.57.6 and 5.8.0.dev0, identical results):

Stale-shard filter against the live granite listing and regression listings:

```
granite_real          : dropped {model-0000N-of-00002}, kept the 4 indexed of-00004 shards
well_formed_multishard : no-op
single_shard_no_index  : no-op
multishard_no_index    : no-op
```

`_remove_quantization_config` on synthetic configs (after = does any quantization_config remain):

```
                 STOCK after            BRANCH after
VLM_NESTED       text_config quant KEPT  all stripped
VLM_BOTH         text+vision KEPT        all stripped
DENSE_TOPLEVEL   stripped (no-op same)   stripped (no-op same)
CLEAN            unchanged               unchanged
```
