### PR TITLE
Fix 4bit QLoRA merged_16bit using the wrong base (W16 vs dequant(W4)) for Falcon-H1

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -211,14 +211,26 @@ def _merge_lora(W, lora_stats, name, use_dequant_base = False):
     # +q the adapter never saw. For most models ||q|| is negligible (and W16 is the better 16bit
     # weight), but for huge base-weight norms over tiny MuP multipliers (Falcon-H1) +q compounds
     # and swamps the fine-tune. The caller sets use_dequant_base only for gated archs -> strict
-    # no-op elsewhere. try/except falls back to W16 so a working merge can't regress.
+    # no-op elsewhere. Assumes a live 4bit base means the adapter trained against dequant(W4)
+    # (the standard QLoRA flow); an adapter trained on the 16bit base and only reloaded in 4bit
+    # for export has no merge-time provenance signal, so it would also fold onto dequant(W4).
     if use_dequant_base and _is_bnb_4bit_base(getattr(lora_stats, "module", None)):
         try:
             W_dq = dequantize_module_weight(lora_stats.module)
-            if tuple(W_dq.shape) == tuple(W.shape):
-                W = W_dq
-        except Exception:
-            pass  # fall back to the W16 base; a previously-working merge cannot regress
+        except Exception as e:
+            # For a gated arch the 16bit base is the known-wrong base (the +q error this path
+            # exists to remove), so silently folding onto it would emit a corrupt merged_16bit.
+            # Surface the failure instead of degrading just this layer to the wrong base.
+            raise RuntimeError(
+                f"Unsloth: could not dequantize the 4bit base for `{name}` during merged_16bit "
+                "export of a model that requires dequant(W4) as the merge base. Falling back to "
+                "the 16bit base would corrupt this checkpoint, so the merge was aborted. Free GPU "
+                "memory (or merge on CPU) and retry."
+            ) from e
+        if tuple(W_dq.shape) == tuple(W.shape):
+            W = W_dq
+        # else: a shape mismatch is structural (e.g. vocab resize handled below), not a dequant
+        # failure, so keep the 16bit W here and let the resize path reconcile it.
     W = W.to(device, dtype = torch.float32, non_blocking = True)
     lora_B = lora_stats.lora_B.to(device, dtype = torch.float32, non_blocking = True)
     lora_A = lora_stats.lora_A.to(device, dtype = torch.float32, non_blocking = True)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -172,15 +172,11 @@ def _active_merge_device():
     return "cpu"
 pass
 
-# Architectures whose `merged_16bit` export of an on-the-fly bnb-4bit QLoRA model
-# must fold the adapter onto the DEQUANTIZED 4bit base dequant(W4) instead of the
-# pristine downloaded 16bit base W16. See `_merge_lora` for the full rationale. This
-# is a deliberately narrow, architecture-gated list: applying the dequant base to
-# every 4bit model would bake the bitsandbytes quantization noise into the 16bit
-# checkpoint and measurably regresses ordinary models (e.g. Qwen2.5 general-text
-# perplexity rises ~20%), even though their fine-tune delta survives the W16 merge.
-# Only models where the quant error compounds enough to swamp the delta (huge base
-# weight norms from small MuP multipliers over a deep hybrid stack) belong here.
+# Architectures whose bnb-4bit merged_16bit export must fold the adapter onto the DEQUANTIZED
+# 4bit base dequant(W4), not the downloaded 16bit base W16 (see `_merge_lora`). Deliberately
+# narrow: the dequant base bakes quant noise into the checkpoint and regresses ordinary models
+# (Qwen2.5 perplexity +~20%), so only models where the quant error swamps the fine-tune delta
+# (huge base-weight norms from small MuP multipliers over a deep hybrid stack) belong here.
 _DEQUANT_MERGE_BASE_MODEL_TYPES = frozenset({"falcon_h1"})
 
 
@@ -209,31 +205,20 @@ pass
 def _merge_lora(W, lora_stats, name, use_dequant_base = False):
     if lora_stats.lora_A is None or lora_stats.lora_B is None: return W
     device = _active_merge_device()
-    # QLoRA merge-base correctness (gated, see _DEQUANT_MERGE_BASE_MODEL_TYPES).
-    # A bnb-4bit adapter is trained against the dequantized 4bit base dequant(W4),
-    # not the pristine 16bit base W16 that merged_16bit downloads from the source
-    # repo. They differ by the quantization error q = W16 - dequant(W4). Folding the
-    # delta into W16 writes dequant(W4)+delta+q; the stray +q term is what the
-    # adapter never saw. For most models ||q|| << the effect of ||delta|| so W16 is
-    # fine (and is in fact the better 16bit checkpoint, since W16 is the true
-    # high-precision weight and dequant(W4) only re-introduces quant noise). But for
-    # architectures with huge base-weight norms offsetting tiny MuP multipliers
-    # (Falcon-H1: ||W_down_proj|| ~ 750-850, q/delta ~ 10x-150x per layer) the +q
-    # term compounds through the deep hybrid stack and swamps the fine-tune, so the
-    # W16 merge is degenerate while dequant(W4)+delta reproduces the trained model.
-    # `use_dequant_base` is set by the caller only for those gated architectures, so
-    # this branch is a strict no-op for every other model. Wrapped in try/except so
-    # any dequant/shape issue silently falls back to W16 (cannot regress a merge
-    # that previously worked).
+    # QLoRA merge-base correctness (gated, see _DEQUANT_MERGE_BASE_MODEL_TYPES). A bnb-4bit
+    # adapter is trained against dequant(W4), not the 16bit base W16 that merged_16bit downloads;
+    # they differ by quant error q = W16 - dequant(W4). Merging the delta into W16 leaves a stray
+    # +q the adapter never saw. For most models ||q|| is negligible (and W16 is the better 16bit
+    # weight), but for huge base-weight norms over tiny MuP multipliers (Falcon-H1) +q compounds
+    # and swamps the fine-tune. The caller sets use_dequant_base only for gated archs -> strict
+    # no-op elsewhere. try/except falls back to W16 so a working merge can't regress.
     if use_dequant_base and _is_bnb_4bit_base(getattr(lora_stats, "module", None)):
         try:
             W_dq = dequantize_module_weight(lora_stats.module)
             if tuple(W_dq.shape) == tuple(W.shape):
                 W = W_dq
         except Exception:
-            # Best-effort: any dequant/shape issue falls back to the W16 base so a
-            # merge that previously worked cannot regress (see comment above).
-            pass
+            pass  # fall back to the W16 base; a previously-working merge cannot regress
     W = W.to(device, dtype = torch.float32, non_blocking = True)
     lora_B = lora_stats.lora_B.to(device, dtype = torch.float32, non_blocking = True)
     lora_A = lora_stats.lora_A.to(device, dtype = torch.float32, non_blocking = True)
@@ -2534,10 +2519,8 @@ def merge_and_overwrite_lora(
     _merge_tie_word_embeddings = bool(
         getattr(_merge_base_model.config, "tie_word_embeddings", False)
     )
-    # Only for the gated architectures, and only for a 16bit merge of a model that is
-    # actually bnb-4bit at runtime, fold each LoRA delta onto its dequantized 4bit base
-    # dequant(W4) instead of the downloaded W16 (see _merge_lora). Strict no-op (W16
-    # base) for every other model/merge so all currently-passing merges are unchanged.
+    # Gated archs + 16bit merge only: fold each LoRA delta onto dequant(W4) instead of W16
+    # (see _merge_lora). Strict no-op for every other model/merge.
     _use_dequant_base = (
         save_method == "merged_16bit"
         and _model_type_needs_dequant_merge_base(_merge_base_model)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -231,6 +231,8 @@ def _merge_lora(W, lora_stats, name, use_dequant_base = False):
             if tuple(W_dq.shape) == tuple(W.shape):
                 W = W_dq
         except Exception:
+            # Best-effort: any dequant/shape issue falls back to the W16 base so a
+            # merge that previously worked cannot regress (see comment above).
             pass
     W = W.to(device, dtype = torch.float32, non_blocking = True)
     lora_B = lora_stats.lora_B.to(device, dtype = torch.float32, non_blocking = True)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -172,9 +172,66 @@ def _active_merge_device():
     return "cpu"
 pass
 
-def _merge_lora(W, lora_stats, name):
+# Architectures whose `merged_16bit` export of an on-the-fly bnb-4bit QLoRA model
+# must fold the adapter onto the DEQUANTIZED 4bit base dequant(W4) instead of the
+# pristine downloaded 16bit base W16. See `_merge_lora` for the full rationale. This
+# is a deliberately narrow, architecture-gated list: applying the dequant base to
+# every 4bit model would bake the bitsandbytes quantization noise into the 16bit
+# checkpoint and measurably regresses ordinary models (e.g. Qwen2.5 general-text
+# perplexity rises ~20%), even though their fine-tune delta survives the W16 merge.
+# Only models where the quant error compounds enough to swamp the delta (huge base
+# weight norms from small MuP multipliers over a deep hybrid stack) belong here.
+_DEQUANT_MERGE_BASE_MODEL_TYPES = frozenset({"falcon_h1"})
+
+
+def _model_type_needs_dequant_merge_base(model) -> bool:
+    """True iff `model`'s architecture is one whose on-the-fly bnb-4bit merged_16bit
+    export must use dequant(W4) as the LoRA merge base instead of the downloaded W16."""
+    try:
+        cfg = getattr(model, "config", None)
+        mt = (getattr(cfg, "model_type", "") or "").lower()
+    except Exception:
+        return False
+    return mt in _DEQUANT_MERGE_BASE_MODEL_TYPES
+
+
+def _is_bnb_4bit_base(module):
+    # True iff `module` is a live bitsandbytes 4bit linear whose weight still
+    # carries a quant_state (i.e. an on-the-fly / pre-quantized bnb-4bit base).
+    if module is None: return False
+    weight = getattr(module, "weight", None)
+    if weight is None: return False
+    if weight.__class__.__name__ != "Params4bit": return False
+    return getattr(weight, "quant_state", None) is not None
+pass
+
+
+def _merge_lora(W, lora_stats, name, use_dequant_base = False):
     if lora_stats.lora_A is None or lora_stats.lora_B is None: return W
     device = _active_merge_device()
+    # QLoRA merge-base correctness (gated, see _DEQUANT_MERGE_BASE_MODEL_TYPES).
+    # A bnb-4bit adapter is trained against the dequantized 4bit base dequant(W4),
+    # not the pristine 16bit base W16 that merged_16bit downloads from the source
+    # repo. They differ by the quantization error q = W16 - dequant(W4). Folding the
+    # delta into W16 writes dequant(W4)+delta+q; the stray +q term is what the
+    # adapter never saw. For most models ||q|| << the effect of ||delta|| so W16 is
+    # fine (and is in fact the better 16bit checkpoint, since W16 is the true
+    # high-precision weight and dequant(W4) only re-introduces quant noise). But for
+    # architectures with huge base-weight norms offsetting tiny MuP multipliers
+    # (Falcon-H1: ||W_down_proj|| ~ 750-850, q/delta ~ 10x-150x per layer) the +q
+    # term compounds through the deep hybrid stack and swamps the fine-tune, so the
+    # W16 merge is degenerate while dequant(W4)+delta reproduces the trained model.
+    # `use_dequant_base` is set by the caller only for those gated architectures, so
+    # this branch is a strict no-op for every other model. Wrapped in try/except so
+    # any dequant/shape issue silently falls back to W16 (cannot regress a merge
+    # that previously worked).
+    if use_dequant_base and _is_bnb_4bit_base(getattr(lora_stats, "module", None)):
+        try:
+            W_dq = dequantize_module_weight(lora_stats.module)
+            if tuple(W_dq.shape) == tuple(W.shape):
+                W = W_dq
+        except Exception:
+            pass
     W = W.to(device, dtype = torch.float32, non_blocking = True)
     lora_B = lora_stats.lora_B.to(device, dtype = torch.float32, non_blocking = True)
     lora_A = lora_stats.lora_A.to(device, dtype = torch.float32, non_blocking = True)
@@ -536,6 +593,7 @@ def _merge_and_overwrite_lora(
     save_method = "merged_16bit",
     counted_lora_modules = None,
     tie_word_embeddings = False,
+    use_dequant_base = False,
 ):
     # All Unsloth Zoo code licensed under LGPLv3
     # Merges LoRA and overwrites the safetensors file it was merged to
@@ -758,7 +816,7 @@ def _merge_and_overwrite_lora(
                             W = saved_weight.to(W.device, dtype = target_dtype, non_blocking = True)
                             count += 1
                     elif hasattr(lora_stats, 'lora_A') and lora_stats.lora_A is not None:
-                        W = _merge_lora(W, lora_stats, output_key)
+                        W = _merge_lora(W, lora_stats, output_key, use_dequant_base = use_dequant_base)
                         count += 1
 
                 success = _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key, W, W_original_dtype)
@@ -2474,6 +2532,21 @@ def merge_and_overwrite_lora(
     _merge_tie_word_embeddings = bool(
         getattr(_merge_base_model.config, "tie_word_embeddings", False)
     )
+    # Only for the gated architectures, and only for a 16bit merge of a model that is
+    # actually bnb-4bit at runtime, fold each LoRA delta onto its dequantized 4bit base
+    # dequant(W4) instead of the downloaded W16 (see _merge_lora). Strict no-op (W16
+    # base) for every other model/merge so all currently-passing merges are unchanged.
+    _use_dequant_base = (
+        save_method == "merged_16bit"
+        and _model_type_needs_dequant_merge_base(_merge_base_model)
+    )
+    if _use_dequant_base:
+        warnings.warn(
+            "Unsloth: merging each LoRA delta onto the dequantized 4bit base "
+            "dequant(W4) (the weights the QLoRA adapter trained against) instead of "
+            "the downloaded 16bit base, to keep the merged_16bit checkpoint faithful "
+            f"for model_type={getattr(getattr(_merge_base_model, 'config', None), 'model_type', '?')}."
+        )
 
     for filename in ProgressBar(final_safetensors_list, desc=f'Unsloth: Merging weights into {"mxfp4" if save_method=="mxfp4" else "16bit"}'):
         merged_count, shard_keys = _merge_and_overwrite_lora(
@@ -2487,6 +2560,7 @@ def merge_and_overwrite_lora(
             save_method = save_method,
             counted_lora_modules = counted_lora_modules_global,
             tie_word_embeddings = _merge_tie_word_embeddings,
+            use_dequant_base = _use_dequant_base,
         )
         n_saved_modules += merged_count
         safetensor_keys_seen.update(shard_keys)


### PR DESCRIPTION
## Summary

`merge_and_overwrite_lora` (the `save_pretrained_merged(save_method="merged_16bit")` path) decides whether the base is quantized from the **source repo** via `determine_base_model_source`. A plain fp16 repo loaded with `load_in_4bit=True` (on-the-fly QLoRA) reports `is_quantized=False`, so the merge downloads the pristine fp16 base `W16` and folds each LoRA delta as `W16 + scaling*(B@A)` in `_merge_lora`.

But the QLoRA adapter was trained against the dequantized 4bit base `dequant(W4)`, not `W16`. They differ by the bitsandbytes quantization error `q = W16 - dequant(W4)`, so the merge writes `dequant(W4) + delta + q` and the stray `+q` term is something the adapter never saw.

For most models `||q||` is small relative to the effect of the delta, and `W16` is in fact the better 16bit checkpoint (it is the true high-precision weight; `dequant(W4)` only re-introduces quant noise). But for **Falcon-H1**, whose tiny MuP multipliers (`key_multiplier=0.031`, `attention_out_multiplier`, `mlp_multipliers`, etc.) are offset by huge base-weight norms (`||W_down_proj|| ~ 750-850`), `q/delta` is 10x-150x per layer. The `+q` term compounds through the 44-layer hybrid stack and swamps the fine-tune, so the merged model is degenerate even though the LoRA reload is correct.

Reproduction (overfit one row, `unsloth/Falcon-H1-7B-Instruct` 4bit, plain-transformers teacher-forced CE on the same adapter):

| reload | CE | generation | verdict |
|---|---|---|---|
| LoRA (4bit base + adapter) | ~0.0-0.19 | `I WAS FINETUNED BY UNSLOTH` | PASS |
| `merged_16bit` (current code, `W16` base) | **0.8546** | `finetuned finetuned finetuned ...` | FAIL |

## Fix

In `_merge_lora`, when `use_dequant_base` is set, fold each LoRA delta onto `dequantize_module_weight(lora_stats.module)` (= `dequant(W4)`, the live bnb-4bit base) instead of the downloaded `W16`, with a shape guard and a `try/except` fallback to `W16`. `use_dequant_base` is computed once in `merge_and_overwrite_lora` and is True only for `save_method == "merged_16bit"` and `model_type in _DEQUANT_MERGE_BASE_MODEL_TYPES` (currently `{"falcon_h1"}`). Storage stays the repo's native dtype via the existing in-place overwrite, so the save format, sharding, config and index are unchanged.

Result on the same adapter (plain-transformers oracle):

| `merged_16bit` base | CE | verdict |
|---|---|---|
| `W16` (current) | 0.8546 | FAIL |
| `dequant(W4)` (this PR) | **0.4866** | **PASS** |

## Why gated, not general

`dequant(W4)` is a lossy copy of the true 16bit weight, so applying it to every 4bit model bakes the 4bit quant noise permanently into the 16bit checkpoint and **regresses** ordinary models, even though their overfit CE still passes:

| model (4bit) | overfit CE `W16` -> `dequant` | general-text ppl `W16` -> `dequant` |
|---|---|---|
| Falcon-H1-7B | 0.8546 -> **0.4866** (fix) | 12.02 -> 12.63 |
| Llama-3.2-1B | 0.0002 -> 0.0001 | 19.15 -> 19.76 (+3.2%) |
| Qwen2.5-0.5B | 0.0001 -> 0.0001 | **18.37 -> 22.06 (+20%)** |

A per-layer `||q||/||delta||` threshold cannot separate the cases: Qwen2.5-0.5B reaches `q/delta` mean 9.8 / max 25 (must NOT reroute) while Falcon-H1 is mean 48 / max 151 / **min 1.1** (must reroute). The ranges overlap, so no local-ratio cutoff is safe; the real discriminator is the architecture (MuP multipliers compounding over a deep hybrid stack), captured by `model_type`. The frozenset makes adding future affected architectures a one-line change.

## Preserves existing pathways (no-op proof)

- 16bit / non-bnb base: `_merge_lora` with `use_dequant_base=False` is bit-identical to before (unit test: patched-vs-reference merge maxdiff = `0.000e+00`).
- Non-Falcon 4bit (gate off): a Qwen2.5-0.5B merge under this branch is **byte-identical** to the previous output of the same adapter (weight diff `0.000e+00` over 290/290 tensors).
- mxfp4, `merge_and_dequantize_lora`, and the MoE-expert callers of `_merge_lora` use the default `use_dequant_base=False` and are unchanged.
- The reroute fires for Falcon-H1 4bit `merged_16bit` only; a one-time warning documents it.
- Existing merge e2e tests pass (`test_merge_e2e_dense` 18, `test_merge_e2e_resized` 3, vision passthrough + moe fused 3).

## Compatibility

transformers 4.57.6 verified (the Falcon-H1 path); 5.x unaffected (no transformers source/save anchors touched). TRL 0.22.2 / 0.27.1 / 1.x and PEFT: only reads `lora_stats.module` (PEFT `.base_layer`) and the bnb `Params4bit` weight. Uses `peft.utils.integrations.dequantize_module_weight` (already imported and used by zoo). Platform-agnostic (pure torch + the existing `_active_merge_device()`; bnb dequant is deterministic). Shape guard + `try/except` fall back to `W16`, so the change can only improve or no-op, never break a merge that worked.

## Follow-up (separate, not in this PR)

There is a second, independent Unsloth bug specific to Falcon-H1: a byte-identical correct merged checkpoint reads teacher-forced CE ~0.47 in plain transformers but ~18-21 once Unsloth's forward / fused-CE path is active (it jumps just from `import unsloth`, and persists with `UNSLOTH_COMPILE_DISABLE=1`). All numbers above are therefore measured with a plain-transformers oracle. That forward/CE inflation is a distinct issue in Unsloth's Falcon-H1 reimplementation and is left for a dedicated follow-up; it is not addressed here.
