### PR TITLE
gpt-oss: guard router branch in _init_weights to fix missing .weight (#3119)

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2902,6 +2902,7 @@ def patch_gpt_oss_init_weights_modulelist_fix():
         transformers.models.gpt_oss.modeling_gpt_oss.GptOssPreTrainedModel
     )
     GptOssExperts = transformers.models.gpt_oss.modeling_gpt_oss.GptOssExperts
+    GptOssTopKRouter = transformers.models.gpt_oss.modeling_gpt_oss.GptOssTopKRouter
     if getattr(GptOssPreTrainedModel, "_unsloth_init_weights_fixed", False):
         return
     _original_init_weights = GptOssPreTrainedModel._init_weights
@@ -2917,6 +2918,22 @@ def patch_gpt_oss_init_weights_modulelist_fix():
                 init.normal_(down.weight, mean=0.0, std=std)
                 if down.bias is not None:
                     init.zeros_(down.bias)
+            return
+        if isinstance(module, GptOssTopKRouter):
+            # Router weight/bias live under .weight (stock) or .linear (Unsloth BnB-4bit).
+            # Resolve whichever exists so stock _init_weights' module.weight access can't
+            # raise "GptOssTopKRouter object has no attribute 'weight'" (#3119).
+            std = self.config.initializer_range
+            weight = getattr(module, "weight", None)
+            if weight is None:
+                weight = getattr(getattr(module, "linear", None), "weight", None)
+            bias = getattr(module, "bias", None)
+            if bias is None:
+                bias = getattr(getattr(module, "linear", None), "bias", None)
+            if weight is not None:
+                init.normal_(weight, mean=0.0, std=std)
+            if bias is not None:
+                init.normal_(bias, mean=0.0, std=std)
             return
         _original_init_weights(self, module)
 


### PR DESCRIPTION
## Summary

Hardens `patch_gpt_oss_init_weights_modulelist_fix` so transformers' `_init_weights` can never raise `AttributeError: 'GptOssTopKRouter' object has no attribute 'weight'` while loading or initializing gpt-oss.

Fixes unslothai/unsloth#3119

## Root cause

Stock transformers `_init_weights` initializes the router via `module.weight.data.normal_()` (4.5x) / `init.normal_(module.weight, ...)` (5.x), assuming a `GptOssTopKRouter` whose parameters sit directly on `self.weight` / `self.bias`.

For the BnB 4-bit path we swap in a linear-based `GptOssTopKRouter` that stores its parameters under `self.linear` (so BitsAndBytes does not quantize the router). A `weight`/`bias` property bridges most cases, but our existing `_init_weights` override only special-cased `GptOssExperts`; for the router it delegated straight to the stock `_init_weights`. So whenever a `GptOssTopKRouter` instance does not expose a usable `.weight` (for example a mixed/conflicting patch state from switching `load_in_4bit` modes inside one session), it still crashed with the exact error from the issue.

## Fix

Add a router branch to the patched `_init_weights` that resolves the weight/bias from `.weight` (stock) or `.linear.weight` / `.linear.bias` (Unsloth 4-bit), whichever exists, and only initializes what is present. This is a robust getattr-with-fallback rather than a hardcoded rename, so it works on:

- stock transformers routers (`self.weight` / `self.bias`)
- the Unsloth linear-based router (`self.linear`)
- any partially-patched state where neither is fully present (no crash)

The branch is gated on `isinstance(module, GptOssTopKRouter)`, so other MoE routers (Qwen MoE, Mixtral, etc.) and dense models are untouched. Compatible with transformers 4.57.x and 5.x.

## Before / after

Reproduced by swapping in a linear-based `GptOssTopKRouter` (as the BnB 4-bit patch does) and running the model's own `_init_weights`:

```
# before (upstream main)
_init_weights: FAIL -> AttributeError: 'GptOssTopKRouter' object has no attribute 'weight'

# after
_init_weights: OK
```

Regression matrix (`transformers 4.57.1`), all green after the change:

```
stock_router        : OK
linear_with_bridge  : OK
linear_no_bridge    : OK   (was: FAIL AttributeError)
experts_and_linear  : OK
```

## Files changed

- `unsloth_zoo/temporary_patches/gpt_oss.py` (+17 lines)
