### PR TITLE
Gemma-4 E-series: make cross-layer KV sharing survive use_cache=False and gradient checkpointing

### DIFF
--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -571,6 +571,41 @@ def test_gemma4_attention_carrier_substitution():
     assert seen["pkv"] is None, "without a carrier, pass through unchanged"
 
 
+def test_gemma4_clear_shared_kv_carrier_releases_kv():
+    """_gemma4_clear_shared_kv_carrier drops the producer K/V the carrier pinned and
+    removes the module attribute, so a no_grad/eval forward does not hold the carrier
+    (and its K/V) alive until the next forward. No-op when there is no carrier."""
+    from unsloth_zoo.temporary_patches.gemma4 import (
+        _Gemma4SharedKVCarrier, _gemma4_clear_shared_kv_carrier,
+    )
+
+    class _Attn:
+        pass
+
+    a0, a1 = _Attn(), _Attn()
+    carrier = _Gemma4SharedKVCarrier()
+    carrier.shared_layers[0] = ("k", "v")
+    a0._unsloth_shared_kv_carrier = carrier
+    a1._unsloth_shared_kv_carrier = carrier
+
+    class _Model:
+        pass
+
+    model = _Model()
+    model._unsloth_gemma4_attns = [a0, a1]
+
+    _gemma4_clear_shared_kv_carrier(model)
+    assert carrier.shared_layers == {}, "producer K/V must be released"
+    assert not hasattr(a0, "_unsloth_shared_kv_carrier"), "carrier attr must be removed"
+    assert not hasattr(a1, "_unsloth_shared_kv_carrier")
+
+    # Idempotent / no-op when nothing is attached.
+    model2 = _Model()
+    _gemma4_clear_shared_kv_carrier(model2)  # no _unsloth_gemma4_attns -> no error
+    model3 = _Model(); model3._unsloth_gemma4_attns = []
+    _gemma4_clear_shared_kv_carrier(model3)  # empty list -> no error
+
+
 def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
     """The GC fix overrides _gradient_checkpointing_func on gemma-4 text decoder layers
     that are being checkpointed with a NON-reentrant torch checkpoint, resolving the

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -713,47 +713,73 @@ def test_gemma4_pristine_checkpoint_recovered_via_set_once_capture(monkeypatch):
         del _ckpt._unsloth_pristine_checkpoint
 
 
-def test_gemma4_carrier_rejects_two_forwards_before_one_backward():
+def _make_gemma4_fake_model(torch, *, kv_shared, checkpointed):
+    """A stand-in Gemma-4 model: one decoder layer whose self_attn class is named
+    Gemma4TextAttention, with configurable KV sharing and gradient checkpointing flags."""
+    Gemma4TextAttention = type("Gemma4TextAttention", (), {})
+
+    class _Layer:
+        def __init__(self):
+            self.self_attn = Gemma4TextAttention()
+            self.self_attn.is_kv_shared_layer = kv_shared
+            self.gradient_checkpointing = checkpointed
+
+    layer = _Layer()
+
+    class _Model:
+        def modules(self):
+            return [self, layer, layer.self_attn]
+
+    return _Model()
+
+
+def test_gemma4_carrier_rejects_two_forwards_only_when_unsafe():
     """The module-scoped 5.5.0/5.5.1 carrier cannot serve two live checkpointed graphs, so a
-    second grad-enabled forward before the first's backward (DPO/contrastive) must raise rather
-    than silently corrupt gradients. Single-forward + backward, then re-forward, stays allowed."""
+    second grad-enabled forward before the first's backward must raise -- but ONLY when KV sharing
+    AND gradient checkpointing are both active (else no carrier is re-read in backward). Models
+    without sharing (31B/26B-A4B) or with checkpointing off must keep working with DPO/contrastive."""
     import torch
     import pytest
     from unsloth_zoo.temporary_patches.gemma4 import _make_kv_shared_use_cache_false_safe_forward
 
     w = torch.nn.Parameter(torch.randn(4, 4))
 
-    class _Model:
-        # no Gemma4TextAttention -> force/attach helpers are strict no-ops; only the
-        # outstanding-forward marker logic is under test here.
-        def modules(self):
-            return []
-
     def _orig(self, x):
         return x @ w  # stands in for last_hidden_state; requires grad
 
     wrapped = _make_kv_shared_use_cache_false_safe_forward(_orig, attach_carrier=True)
-    m = _Model()
     x = torch.randn(2, 4, requires_grad=True)
 
+    # Unsafe: KV sharing + checkpointing -> arm + reject the overlapping forward.
+    m = _make_gemma4_fake_model(torch, kv_shared=True, checkpointed=True)
     out1 = wrapped(m, x)
     assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is True
-
-    # second forward before any backward -> reject
     with pytest.raises(RuntimeError, match="two forward passes before a single backward"):
         wrapped(m, x)
-
-    # after the first graph's backward, the marker clears and a new forward is allowed
+    # after the first graph's backward the marker clears and a new forward is allowed
     out1.sum().backward()
     assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is False
     wrapped(m, x)
     assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is True
 
+    # Safe (no KV sharing, e.g. 31B/26B-A4B): two forwards before one backward must NOT raise.
+    m_noshare = _make_gemma4_fake_model(torch, kv_shared=False, checkpointed=True)
+    wrapped(m_noshare, x)
+    wrapped(m_noshare, x)  # would raise if the marker were armed
+    assert getattr(m_noshare, "_unsloth_gemma4_carrier_outstanding", False) is False
+
+    # Safe (KV sharing but checkpointing off): backward uses saved activations, never re-reads
+    # the carrier, so overlapping forwards must NOT raise.
+    m_nockpt = _make_gemma4_fake_model(torch, kv_shared=True, checkpointed=False)
+    wrapped(m_nockpt, x)
+    wrapped(m_nockpt, x)
+    assert getattr(m_nockpt, "_unsloth_gemma4_carrier_outstanding", False) is False
+
     # eval / no_grad never arms the marker (no backward to guard)
-    delattr(m, "_unsloth_gemma4_carrier_outstanding")
+    m_eval = _make_gemma4_fake_model(torch, kv_shared=True, checkpointed=True)
     with torch.no_grad():
-        wrapped(m, x)
-    assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is False
+        wrapped(m_eval, x)
+    assert getattr(m_eval, "_unsloth_gemma4_carrier_outstanding", False) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -580,28 +580,36 @@ def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
     cross-layer KV sharing under reentrant/offloaded gradient checkpointing."""
     import functools
     import torch.utils.checkpoint as _ckpt
+    from unsloth_zoo.temporary_patches import gemma4 as g4
     from unsloth_zoo.temporary_patches.gemma4 import _gemma4_force_nonreentrant_checkpointing
 
     def _pristine(function, *args, use_reentrant=None, **kw):
         return ("pristine", use_reentrant)
     def unsloth_checkpoint(function, *args, **kw):
         return "shim"
-    unsloth_checkpoint.__name__ = "unsloth_checkpoint"  # the reentrant-forcing shim
-    # Simulate Unsloth smart GC having globally patched torch's checkpoint.
+    unsloth_checkpoint.__name__ = "unsloth_checkpoint"  # reentrant-forcing shim
+    def unsloth_offloaded_gradient_checkpoint(function, *args, **kw):
+        return "shim2"
+    unsloth_offloaded_gradient_checkpoint.__name__ = "unsloth_offloaded_gradient_checkpoint"
+    # Simulate STACKED Unsloth shims: checkpoint and _old_checkpoint are BOTH shims, so
+    # the import-captured pristine is what must be used.
     monkeypatch.setattr(_ckpt, "checkpoint", unsloth_checkpoint, raising=False)
-    monkeypatch.setattr(_ckpt, "_old_checkpoint", _pristine, raising=False)
+    monkeypatch.setattr(_ckpt, "_old_checkpoint", unsloth_offloaded_gradient_checkpoint, raising=False)
+    monkeypatch.setattr(g4, "_PRISTINE_TORCH_CHECKPOINT", _pristine, raising=False)
 
     Gemma4TextAttention = type("Gemma4TextAttention", (), {})
     OtherAttention = type("OtherAttention", (), {})
 
     class _Layer:
-        def __init__(self, attn_cls, gc, is_shared=False):
+        def __init__(self, attn_cls, gc, is_shared=False, existing="ORIG"):
             self.self_attn = attn_cls()
             self.self_attn.is_kv_shared_layer = is_shared
             self.gradient_checkpointing = gc
-            self._gradient_checkpointing_func = "ORIG"
+            self._gradient_checkpointing_func = existing
 
-    on = _Layer(Gemma4TextAttention, True, is_shared=True)  # checkpointed shared layer -> overridden
+    # `on` carries a user checkpoint kwarg (preserve_rng_state=False) that must survive.
+    on = _Layer(Gemma4TextAttention, True, is_shared=True,
+                existing=functools.partial(unsloth_checkpoint, use_reentrant=True, preserve_rng_state=False))
     off = _Layer(Gemma4TextAttention, False)  # not checkpointed -> untouched
     other = _Layer(OtherAttention, True)      # non-gemma-4 -> untouched
 
@@ -624,7 +632,18 @@ def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
 
     f = on._gradient_checkpointing_func
     assert isinstance(f, functools.partial), "checkpointed gemma-4 layer must be overridden"
-    assert f.func is _pristine, "must resolve the PRISTINE checkpoint, not the unsloth shim"
+    assert f.func is _pristine, "must resolve the PRISTINE checkpoint past stacked shims"
     assert f.keywords.get("use_reentrant") is False, "must force non-reentrant"
+    assert f.keywords.get("preserve_rng_state") is False, "must preserve user checkpoint kwargs"
     assert off._gradient_checkpointing_func == "ORIG", "non-checkpointed layer left alone"
     assert other._gradient_checkpointing_func == "ORIG", "non-gemma-4 layer left alone"
+
+    # Fallback: when no import-captured pristine, unwrap _old_checkpoint past the shim.
+    monkeypatch.setattr(g4, "_PRISTINE_TORCH_CHECKPOINT", None, raising=False)
+    monkeypatch.setattr(_ckpt, "_old_checkpoint", _pristine, raising=False)
+    on2 = _Layer(Gemma4TextAttention, True, is_shared=True)
+    class _Model2:
+        def modules(self):
+            return [self, on2, on2.self_attn]
+    _gemma4_force_nonreentrant_checkpointing(_Model2())
+    assert on2._gradient_checkpointing_func.func is _pristine, "fallback must unwrap _old_checkpoint"

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -595,21 +595,32 @@ def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
     OtherAttention = type("OtherAttention", (), {})
 
     class _Layer:
-        def __init__(self, attn_cls, gc):
+        def __init__(self, attn_cls, gc, is_shared=False):
             self.self_attn = attn_cls()
+            self.self_attn.is_kv_shared_layer = is_shared
             self.gradient_checkpointing = gc
             self._gradient_checkpointing_func = "ORIG"
 
-    on = _Layer(Gemma4TextAttention, True)    # checkpointed gemma-4 layer -> overridden
+    on = _Layer(Gemma4TextAttention, True, is_shared=True)  # checkpointed shared layer -> overridden
     off = _Layer(Gemma4TextAttention, False)  # not checkpointed -> untouched
     other = _Layer(OtherAttention, True)      # non-gemma-4 -> untouched
 
     class _Model:
+        # modules() must expose the attentions so the fix can detect KV sharing.
         def modules(self):
-            return [self, on, off, other]
+            return [self, on, on.self_attn, off, off.self_attn, other, other.self_attn]
     m = _Model()
 
     _gemma4_force_nonreentrant_checkpointing(m)
+
+    # Non-E-series gemma-4 (no shared layer) must be a strict no-op.
+    plain = _Layer(Gemma4TextAttention, True)  # gemma-4 but NOT a shared layer
+    class _ModelNoShare:
+        def modules(self):
+            return [self, plain, plain.self_attn]
+    mns = _ModelNoShare()
+    _gemma4_force_nonreentrant_checkpointing(mns)
+    assert plain._gradient_checkpointing_func == "ORIG", "no-KV-sharing model must be untouched"
 
     f = on._gradient_checkpointing_func
     assert isinstance(f, functools.partial), "checkpointed gemma-4 layer must be overridden"

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -569,3 +569,51 @@ def test_gemma4_attention_carrier_substitution():
     m2 = M()  # no carrier attached
     wrapped(m2, "h", "pe", "am", past_key_values=None)
     assert seen["pkv"] is None, "without a carrier, pass through unchanged"
+
+
+def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
+    """The GC fix overrides _gradient_checkpointing_func on gemma-4 text decoder layers
+    that are being checkpointed with a NON-reentrant torch checkpoint, resolving the
+    PRISTINE checkpoint when Unsloth's smart GC has globally swapped in its
+    reentrant-forcing shim (`unsloth_checkpoint`). Layers not being checkpointed, and
+    non-gemma-4 layers, are left untouched. This guards the gradient-correctness fix for
+    cross-layer KV sharing under reentrant/offloaded gradient checkpointing."""
+    import functools
+    import torch.utils.checkpoint as _ckpt
+    from unsloth_zoo.temporary_patches.gemma4 import _gemma4_force_nonreentrant_checkpointing
+
+    def _pristine(function, *args, use_reentrant=None, **kw):
+        return ("pristine", use_reentrant)
+    def unsloth_checkpoint(function, *args, **kw):
+        return "shim"
+    unsloth_checkpoint.__name__ = "unsloth_checkpoint"  # the reentrant-forcing shim
+    # Simulate Unsloth smart GC having globally patched torch's checkpoint.
+    monkeypatch.setattr(_ckpt, "checkpoint", unsloth_checkpoint, raising=False)
+    monkeypatch.setattr(_ckpt, "_old_checkpoint", _pristine, raising=False)
+
+    Gemma4TextAttention = type("Gemma4TextAttention", (), {})
+    OtherAttention = type("OtherAttention", (), {})
+
+    class _Layer:
+        def __init__(self, attn_cls, gc):
+            self.self_attn = attn_cls()
+            self.gradient_checkpointing = gc
+            self._gradient_checkpointing_func = "ORIG"
+
+    on = _Layer(Gemma4TextAttention, True)    # checkpointed gemma-4 layer -> overridden
+    off = _Layer(Gemma4TextAttention, False)  # not checkpointed -> untouched
+    other = _Layer(OtherAttention, True)      # non-gemma-4 -> untouched
+
+    class _Model:
+        def modules(self):
+            return [self, on, off, other]
+    m = _Model()
+
+    _gemma4_force_nonreentrant_checkpointing(m)
+
+    f = on._gradient_checkpointing_func
+    assert isinstance(f, functools.partial), "checkpointed gemma-4 layer must be overridden"
+    assert f.func is _pristine, "must resolve the PRISTINE checkpoint, not the unsloth shim"
+    assert f.keywords.get("use_reentrant") is False, "must force non-reentrant"
+    assert off._gradient_checkpointing_func == "ORIG", "non-checkpointed layer left alone"
+    assert other._gradient_checkpointing_func == "ORIG", "non-gemma-4 layer left alone"

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -476,15 +476,11 @@ def test_patch_compiling_bitsandbytes_missing_peft_helpful_error(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Gemma-4 E-series cross-layer KV sharing with use_cache=False / gradient
-# checkpointing (transformers#45242). use_cache=False is the BROKEN path: the
-# shared layers recompute their own KV and the logits become garbage. A prior PR
-# tried to make the zoo fix a no-op (which would regress E-series training); these
-# tests lock the fix in and check its key invariants without a GPU/model.
+# Gemma-4 E-series KV sharing under use_cache=False / gradient checkpointing
+# (transformers#45242). These lock the zoo fix in and check its invariants on CPU.
 # ---------------------------------------------------------------------------
 def test_gemma4_kv_shared_patches_registered():
-    """Both shared-KV patch functions must stay registered AND actually wire the
-    carrier (not be reduced to bare `return` stubs)."""
+    """Both patch functions stay registered AND wire the carrier (not bare return stubs)."""
     import inspect
     from unsloth_zoo.temporary_patches import gemma4 as _M
     from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
@@ -502,8 +498,7 @@ def test_gemma4_kv_shared_patches_registered():
 
 
 def test_gemma4_shared_kv_carrier_semantics():
-    """The carrier exposes only shared_layers + a no-op update (no autoregressive
-    cache accumulation), so non-shared layers stay cache-free under use_cache=False."""
+    """Carrier exposes only shared_layers + a no-op update, so non-shared layers stay cache-free."""
     from unsloth_zoo.temporary_patches.gemma4 import _Gemma4SharedKVCarrier
     c = _Gemma4SharedKVCarrier()
     assert c.shared_layers == {}
@@ -515,9 +510,8 @@ def test_gemma4_shared_kv_carrier_semantics():
 
 
 def test_gemma4_capability_gate(monkeypatch):
-    """needs_cache() is True on the buggy build (attention forward lacks
-    shared_kv_states) and False once transformers passes it explicitly (fixed).
-    Uses a synthetic module so it is independent of the installed transformers."""
+    """needs_cache() is True when the attention forward lacks shared_kv_states, False once it
+    has it. Uses a synthetic module, independent of the installed transformers."""
     import sys, types, inspect
     from unsloth_zoo.temporary_patches import gemma4 as _M
 
@@ -546,8 +540,7 @@ def test_gemma4_capability_gate(monkeypatch):
 
 
 def test_gemma4_attention_carrier_substitution():
-    """The attention wrapper supplies the carrier only when the real past_key_values
-    is None (use_cache=False or nulled by gradient checkpointing); a real cache and
+    """The wrapper supplies the carrier only when past_key_values is None; a real cache and
     the no-carrier case pass through unchanged."""
     from unsloth_zoo.temporary_patches.gemma4 import (
         _make_gemma4_attention_carrier_forward, _Gemma4SharedKVCarrier,
@@ -572,9 +565,8 @@ def test_gemma4_attention_carrier_substitution():
 
 
 def test_gemma4_clear_shared_kv_carrier_releases_kv():
-    """_gemma4_clear_shared_kv_carrier drops the producer K/V the carrier pinned and
-    removes the module attribute, so a no_grad/eval forward does not hold the carrier
-    (and its K/V) alive until the next forward. No-op when there is no carrier."""
+    """clear drops the pinned K/V and removes the module attr, so a no_grad/eval forward does
+    not hold the carrier alive until the next forward. No-op when there is no carrier."""
     from unsloth_zoo.temporary_patches.gemma4 import (
         _Gemma4SharedKVCarrier, _gemma4_clear_shared_kv_carrier,
     )
@@ -607,12 +599,9 @@ def test_gemma4_clear_shared_kv_carrier_releases_kv():
 
 
 def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
-    """The GC fix overrides _gradient_checkpointing_func on gemma-4 text decoder layers
-    that are being checkpointed with a NON-reentrant torch checkpoint, resolving the
-    PRISTINE checkpoint when Unsloth's smart GC has globally swapped in its
-    reentrant-forcing shim (`unsloth_checkpoint`). Layers not being checkpointed, and
-    non-gemma-4 layers, are left untouched. This guards the gradient-correctness fix for
-    cross-layer KV sharing under reentrant/offloaded gradient checkpointing."""
+    """Overrides _gradient_checkpointing_func on checkpointed gemma-4 layers with a NON-reentrant
+    checkpoint, resolving the pristine one past Unsloth's smart-GC shim. Non-checkpointed and
+    non-gemma-4 layers are left untouched."""
     import functools
     import torch.utils.checkpoint as _ckpt
     from unsloth_zoo.temporary_patches import gemma4 as g4

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -620,6 +620,9 @@ def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
     monkeypatch.setattr(_ckpt, "checkpoint", unsloth_checkpoint, raising=False)
     monkeypatch.setattr(_ckpt, "_old_checkpoint", unsloth_offloaded_gradient_checkpoint, raising=False)
     monkeypatch.setattr(g4, "_PRISTINE_TORCH_CHECKPOINT", _pristine, raising=False)
+    # Real GC patching may have stashed a set-once pristine on the live module; clear it so the
+    # import-captured and _old_checkpoint-unwrap paths below are what gets exercised.
+    monkeypatch.delattr(_ckpt, "_unsloth_pristine_checkpoint", raising=False)
 
     Gemma4TextAttention = type("Gemma4TextAttention", (), {})
     OtherAttention = type("OtherAttention", (), {})
@@ -671,6 +674,86 @@ def test_gemma4_force_nonreentrant_checkpointing(monkeypatch):
             return [self, on2, on2.self_attn]
     _gemma4_force_nonreentrant_checkpointing(_Model2())
     assert on2._gradient_checkpointing_func.func is _pristine, "fallback must unwrap _old_checkpoint"
+
+
+def test_gemma4_pristine_checkpoint_recovered_via_set_once_capture(monkeypatch):
+    """When gemma4 imports after smart GC stacked on an offloaded shim, neither shim carries a
+    function-level _old_checkpoint and the module-level one points at the first shim. The set-once
+    capture the GC patcher stashes before any shim must still recover the pristine fn."""
+    import torch.utils.checkpoint as _ckpt
+    from unsloth_zoo import gradient_checkpointing as gc
+    from unsloth_zoo.temporary_patches import gemma4 as g4
+
+    real = _ckpt.checkpoint  # genuine torch fn in the test process (no shim installed)
+
+    # Force the "late import" path: no import-captured pristine available.
+    monkeypatch.setattr(g4, "_PRISTINE_TORCH_CHECKPOINT", None, raising=False)
+    monkeypatch.delattr(_ckpt, "_unsloth_pristine_checkpoint", raising=False)
+
+    # First GC patch captures the pristine before any shim stacks.
+    gc._capture_pristine_checkpoint_once()
+    assert getattr(_ckpt, "_unsloth_pristine_checkpoint", None) is real
+
+    # Now stack two shims: module-level _old_checkpoint ends up at the first shim, so unwrapping
+    # it alone would only ever reach a shim.
+    def unsloth_offloaded_gradient_checkpoint(*a, **k):
+        raise AssertionError("a shim must never be returned as the pristine checkpoint")
+    unsloth_offloaded_gradient_checkpoint.__name__ = "unsloth_offloaded_gradient_checkpoint"
+    def unsloth_checkpoint(*a, **k):
+        raise AssertionError("a shim must never be returned as the pristine checkpoint")
+    unsloth_checkpoint.__name__ = "unsloth_checkpoint"
+    monkeypatch.setattr(_ckpt, "_old_checkpoint", unsloth_offloaded_gradient_checkpoint, raising=False)
+    monkeypatch.setattr(_ckpt, "checkpoint", unsloth_checkpoint, raising=False)
+
+    assert g4._resolve_pristine_checkpoint(_ckpt) is real, (
+        "set-once capture must recover the pristine checkpoint despite stacked shims"
+    )
+    # cleanup the attr we created (monkeypatch.delattr above only records absence)
+    if hasattr(_ckpt, "_unsloth_pristine_checkpoint"):
+        del _ckpt._unsloth_pristine_checkpoint
+
+
+def test_gemma4_carrier_rejects_two_forwards_before_one_backward():
+    """The module-scoped 5.5.0/5.5.1 carrier cannot serve two live checkpointed graphs, so a
+    second grad-enabled forward before the first's backward (DPO/contrastive) must raise rather
+    than silently corrupt gradients. Single-forward + backward, then re-forward, stays allowed."""
+    import torch
+    import pytest
+    from unsloth_zoo.temporary_patches.gemma4 import _make_kv_shared_use_cache_false_safe_forward
+
+    w = torch.nn.Parameter(torch.randn(4, 4))
+
+    class _Model:
+        # no Gemma4TextAttention -> force/attach helpers are strict no-ops; only the
+        # outstanding-forward marker logic is under test here.
+        def modules(self):
+            return []
+
+    def _orig(self, x):
+        return x @ w  # stands in for last_hidden_state; requires grad
+
+    wrapped = _make_kv_shared_use_cache_false_safe_forward(_orig, attach_carrier=True)
+    m = _Model()
+    x = torch.randn(2, 4, requires_grad=True)
+
+    out1 = wrapped(m, x)
+    assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is True
+
+    # second forward before any backward -> reject
+    with pytest.raises(RuntimeError, match="two forward passes before a single backward"):
+        wrapped(m, x)
+
+    # after the first graph's backward, the marker clears and a new forward is allowed
+    out1.sum().backward()
+    assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is False
+    wrapped(m, x)
+    assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is True
+
+    # eval / no_grad never arms the marker (no backward to guard)
+    delattr(m, "_unsloth_gemma4_carrier_outstanding")
+    with torch.no_grad():
+        wrapped(m, x)
+    assert getattr(m, "_unsloth_gemma4_carrier_outstanding", False) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -473,3 +473,99 @@ def test_patch_compiling_bitsandbytes_missing_peft_helpful_error(monkeypatch):
         "the original ImportError must be chained (raise ... from e) so an "
         "installed-but-broken peft stays debuggable"
     )
+
+
+# ---------------------------------------------------------------------------
+# Gemma-4 E-series cross-layer KV sharing with use_cache=False / gradient
+# checkpointing (transformers#45242). use_cache=False is the BROKEN path: the
+# shared layers recompute their own KV and the logits become garbage. A prior PR
+# tried to make the zoo fix a no-op (which would regress E-series training); these
+# tests lock the fix in and check its key invariants without a GPU/model.
+# ---------------------------------------------------------------------------
+def test_gemma4_kv_shared_patches_registered():
+    """Both shared-KV patch functions must stay registered AND actually wire the
+    carrier (not be reduced to bare `return` stubs)."""
+    import inspect
+    from unsloth_zoo.temporary_patches import gemma4 as _M
+    from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
+
+    names = {getattr(p, "__name__", "") for p in TEMPORARY_PATCHES}
+    assert "patch_Gemma4TextModel_forward_kv_shared_no_cache" in names
+    assert "patch_Gemma4Model_forward_kv_shared_no_cache" in names
+    for fn in (_M.patch_Gemma4TextModel_forward_kv_shared_no_cache,
+               _M.patch_Gemma4Model_forward_kv_shared_no_cache):
+        src = inspect.getsource(fn)
+        assert "_patch_forward_for_kv_shared_no_cache" in src and "_patch_gemma4_attention_carrier" in src, (
+            "the shared-KV fix must install both the model carrier-attacher and the "
+            "attention carrier patch; do not reduce it to a no-op"
+        )
+
+
+def test_gemma4_shared_kv_carrier_semantics():
+    """The carrier exposes only shared_layers + a no-op update (no autoregressive
+    cache accumulation), so non-shared layers stay cache-free under use_cache=False."""
+    from unsloth_zoo.temporary_patches.gemma4 import _Gemma4SharedKVCarrier
+    c = _Gemma4SharedKVCarrier()
+    assert c.shared_layers == {}
+    k, v = object(), object()
+    assert c.update(k, v, 0) == (k, v)
+    assert c.get_seq_length() == 0
+    c.shared_layers[3] = (k, v)
+    assert c.shared_layers[3] == (k, v)
+
+
+def test_gemma4_capability_gate(monkeypatch):
+    """needs_cache() is True on the buggy build (attention forward lacks
+    shared_kv_states) and False once transformers passes it explicitly (fixed).
+    Uses a synthetic module so it is independent of the installed transformers."""
+    import sys, types, inspect
+    from unsloth_zoo.temporary_patches import gemma4 as _M
+
+    class _Buggy:
+        def forward(self, hidden_states, position_embeddings, attention_mask, past_key_values=None, **kw):
+            return None
+    class _Fixed:
+        def forward(self, hidden_states, position_embeddings, attention_mask, shared_kv_states, past_key_values=None, **kw):
+            return None
+    # The discriminator is the `shared_kv_states` parameter on the attention forward.
+    assert "shared_kv_states" not in inspect.signature(_Buggy.forward).parameters
+    assert "shared_kv_states" in inspect.signature(_Fixed.forward).parameters
+
+    import transformers.models as tm
+    pkg = types.ModuleType("transformers.models.gemma4")
+    leaf = types.ModuleType("transformers.models.gemma4.modeling_gemma4")
+    pkg.modeling_gemma4 = leaf
+    monkeypatch.setitem(sys.modules, "transformers.models.gemma4", pkg)
+    monkeypatch.setitem(sys.modules, "transformers.models.gemma4.modeling_gemma4", leaf)
+    monkeypatch.setattr(tm, "gemma4", pkg, raising=False)
+
+    leaf.Gemma4TextAttention = _Buggy
+    assert _M._gemma4_kv_sharing_needs_cache() is True
+    leaf.Gemma4TextAttention = _Fixed
+    assert _M._gemma4_kv_sharing_needs_cache() is False
+
+
+def test_gemma4_attention_carrier_substitution():
+    """The attention wrapper supplies the carrier only when the real past_key_values
+    is None (use_cache=False or nulled by gradient checkpointing); a real cache and
+    the no-carrier case pass through unchanged."""
+    from unsloth_zoo.temporary_patches.gemma4 import (
+        _make_gemma4_attention_carrier_forward, _Gemma4SharedKVCarrier,
+    )
+    seen = {}
+    def orig(self, hidden_states, position_embeddings, attention_mask, past_key_values=None, **kw):
+        seen["pkv"] = past_key_values
+        return "ok"
+    wrapped = _make_gemma4_attention_carrier_forward(orig)
+
+    class M:
+        pass
+    m = M(); carrier = _Gemma4SharedKVCarrier(); m._unsloth_shared_kv_carrier = carrier
+    wrapped(m, "h", "pe", "am", past_key_values=None)
+    assert seen["pkv"] is carrier, "None past_key_values must be replaced by the carrier"
+    real = object()
+    wrapped(m, "h", "pe", "am", past_key_values=real)
+    assert seen["pkv"] is real, "a real cache must NOT be replaced"
+    m2 = M()  # no carrier attached
+    wrapped(m2, "h", "pe", "am", past_key_values=None)
+    assert seen["pkv"] is None, "without a carrier, pass through unchanged"

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -224,10 +224,32 @@ def unsloth_gradient_checkpoint(function, *args, use_reentrant = None, **kwargs)
 pass
 
 
+# Names of the checkpoint shims below; none is the pristine torch fn.
+_UNSLOTH_CKPT_SHIM_NAMES = frozenset({
+    "unsloth_checkpoint",
+    "unsloth_gradient_checkpoint",
+    "unsloth_offloaded_gradient_checkpoint",
+})
+
+
+def _capture_pristine_checkpoint_once():
+    # Stash the genuine torch.utils.checkpoint.checkpoint the first time we patch, before any
+    # shim stacks. The per-patch _old_checkpoint is module-level, so a second patch overwrites
+    # it with the first shim and the pristine fn becomes unreachable. Consumers that must force
+    # use_reentrant=False (e.g. the Gemma-4 KV-sharing fix) read this set-once ref instead.
+    ck = torch.utils.checkpoint
+    if getattr(ck, "_unsloth_pristine_checkpoint", None) is not None:
+        return
+    current = getattr(ck, "checkpoint", None)
+    if current is not None and getattr(current, "__name__", "") not in _UNSLOTH_CKPT_SHIM_NAMES:
+        ck._unsloth_pristine_checkpoint = current
+
+
 def patch_unsloth_gradient_checkpointing():
     print("Unsloth: Patched gradient checkpointing for long context finetuning.")
     import torch.utils
     if torch.utils.checkpoint.checkpoint.__name__ == "unsloth_offloaded_gradient_checkpoint": return
+    _capture_pristine_checkpoint_once()
     torch.utils.checkpoint._old_checkpoint = torch.utils.checkpoint.checkpoint
     torch.utils.checkpoint.checkpoint = unsloth_offloaded_gradient_checkpoint
     import transformers.modeling_utils
@@ -240,6 +262,7 @@ def patch_gradient_checkpointing():
     print("Unsloth: Patched gradient checkpointing.")
     import torch.utils
     if torch.utils.checkpoint.checkpoint.__name__ == "unsloth_gradient_checkpoint": return
+    _capture_pristine_checkpoint_once()
     torch.utils.checkpoint._old_checkpoint = torch.utils.checkpoint.checkpoint
     torch.utils.checkpoint.checkpoint = unsloth_gradient_checkpoint
     import transformers.modeling_utils
@@ -810,6 +833,7 @@ def patch_unsloth_smart_gradient_checkpointing(dtype = None):
         torch.utils.checkpoint.CheckpointFunction = UnslothCheckpointFunction
 
     if torch.utils.checkpoint.checkpoint.__name__ != "unsloth_checkpoint":
+        _capture_pristine_checkpoint_once()
         torch.utils.checkpoint._old_checkpoint = torch.utils.checkpoint.checkpoint
         torch.utils.checkpoint.checkpoint = unsloth_checkpoint
 

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -291,58 +291,36 @@ TEMPORARY_PATCHES.append(patch_StaticCache_kv_shared_zero)
 
 
 # ============================================================================
-# Fix 2: use_cache=False with KV sharing produces garbage (Gemma-4 E2B and E4B).
+# Fix 2: Gemma-4 E2B/E4B cross-layer KV sharing (num_kv_shared_layers > 0).
 #
-# Gemma4TextAttention.forward only reuses stored K/V from the cache for
-# is_kv_shared_layer layers; with use_cache=False, Gemma4TextModel.forward
-# never auto-constructs the cache, so those layers recompute K/V from the wrong
-# hidden states. Symptoms: training loss explodes, logits become garbage.
-# See huggingface/transformers#45242.
+# Gemma4TextAttention reuses stored K/V only via the cache, but with use_cache=False
+# the model never builds one, so is_kv_shared_layer layers recompute K/V from the wrong
+# hidden states (loss explodes). See huggingface/transformers#45242. Only the buggy
+# cache-dependent path in transformers 5.5.0-5.5.1 needs this; 5.5.2+ passes native
+# shared_kv_states, so the gate below no-ops there (detected by signature, not version).
 #
-# Affects num_kv_shared_layers > 0 (E2B=20, E4B=18); 31B / 26B-A4B (=0) are
-# unaffected. Confirmed on transformers 5.5.0 + gemma-4-E2B-it: use_cache=False
-# teacher-forced loss ~16 vs ~6.8 (use_cache=True); under gradient checkpointing
-# all 20 shared layers fall back to recomputing their own KV.
-#
-# Version window: gemma-4 first ships in transformers 5.5.0, and the buggy
-# cache-dependent path exists only in 5.5.0 and 5.5.1. From 5.5.2 onward (the
-# native `shared_kv_states` arg was backported into the 5.5.x line, then 5.6.0+)
-# the cache-free path is fixed upstream. The gate below detects this by signature,
-# not version, so it stays correct across the mid-patch-release backport.
-#
-# Fix: decouple the within-forward shared KV from past_key_values. The model
-# forward attaches a fresh tiny carrier (a shared_layers dict + no-op update) to
-# every Gemma4TextAttention, and the attention uses it whenever the real
-# past_key_values is None. The store/retrieve then works under use_cache=False
-# AND gradient checkpointing (where GradientCheckpointingLayer nulls the
-# past_key_values kwarg before the attention, defeating any injected cache).
-# Mirrors transformers' own later `shared_kv_states` fix; capability-gated to a
-# no-op on builds that already pass `shared_kv_states` (forwards-compatibility).
+# Fix: attach a per-forward carrier (a shared_layers dict) to every attention and use it
+# when past_key_values is None, so store/retrieve survives use_cache=False and GC (which
+# nulls the past_key_values kwarg). Plus force non-reentrant checkpointing to keep the
+# shared K/V grad-connected (see _gemma4_force_nonreentrant_checkpointing).
 # ============================================================================
 
 def _gemma4_kv_sharing_needs_cache():
-    """True iff this transformers build plumbs Gemma-4 cross-layer KV sharing through
-    ``past_key_values`` (the buggy, cache-dependent mechanism: transformers 5.5.0-5.5.1).
-    Newer builds (5.5.2+, where the native ``shared_kv_states`` attention argument was
-    backported, through 5.x latest) pass the shared KV cache-independently, fixing the
-    cache-free path and making this patch unnecessary, so we no-op there. Detection is by
-    signature, not version, so it tracks the backport correctly (forwards-compatible)."""
+    """True iff this build routes Gemma-4 KV sharing through past_key_values (the buggy
+    5.5.0-5.5.1 path). 5.5.2+ passes native shared_kv_states so we no-op there; detected
+    by signature, not version, to track the mid-release backport."""
     try:
         import inspect
         from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
         return "shared_kv_states" not in inspect.signature(Gemma4TextAttention.forward).parameters
     except Exception:
-        # Default to applying: no-op for models without KV sharing, safe where needed.
-        return True
+        return True  # apply by default: no-op without KV sharing, safe where needed
 
 
 class _Gemma4SharedKVCarrier:
-    """Carries Gemma-4 cross-layer shared K/V WITHIN a single forward, decoupled from
-    ``past_key_values`` so the store/retrieve survives both use_cache=False and
-    gradient checkpointing (GradientCheckpointingLayer nulls the past_key_values kwarg
-    before the attention runs, see transformers/modeling_layers.py). Only
-    ``shared_layers`` is used; update() is a no-op so non-shared layers never build an
-    autoregressive cache. Mirrors transformers' own later ``shared_kv_states`` fix."""
+    """Carries cross-layer shared K/V within one forward, decoupled from past_key_values
+    so store/retrieve survives use_cache=False and GC. update() is a no-op so non-shared
+    layers never build a cache."""
     __slots__ = ("shared_layers",)
     def __init__(self):
         self.shared_layers = {}
@@ -353,11 +331,8 @@ class _Gemma4SharedKVCarrier:
 
 
 def _make_gemma4_attention_carrier_forward(_orig_attn_forward):
-    """Feed the per-forward carrier to Gemma4TextAttention whenever the real
-    ``past_key_values`` is None (use_cache=False, or nulled by gradient
-    checkpointing), so the cross-layer KV store/retrieve still works. The carrier is
-    attached to the module by the model-forward patch below. Pass-through otherwise
-    (e.g. generation with a real cache), so this is a strict no-op when not needed."""
+    """Feed the carrier to attention as past_key_values when the real one is None
+    (use_cache=False or nulled by GC). Pass-through otherwise -> no-op when unused."""
     def forward(self, *args, **kwargs):
         carrier = getattr(self, "_unsloth_shared_kv_carrier", None)
         if carrier is not None:
@@ -388,15 +363,13 @@ def _patch_gemma4_attention_carrier():
     Gemma4TextAttention.forward = _make_gemma4_attention_carrier_forward(Gemma4TextAttention.forward)
 
 
-# Names of Unsloth's checkpoint shims (all force/route reentrant), so we can recognise
-# and unwrap them to find the pristine torch checkpoint.
+# Unsloth's checkpoint shims (all force/route reentrant); unwrap them to find pristine torch.
 _UNSLOTH_CKPT_SHIM_NAMES = frozenset({
     "unsloth_checkpoint", "unsloth_gradient_checkpoint",
     "unsloth_offloaded_gradient_checkpoint",
 })
-# Capture the pristine torch checkpoint at import (before any Unsloth GC patch swaps
-# torch.utils.checkpoint.checkpoint), so forcing non-reentrant cannot be defeated even
-# when Unsloth's shims are stacked and _old_checkpoint no longer holds the original.
+# Capture pristine torch.utils.checkpoint at import, before any Unsloth GC patch swaps it,
+# so forcing non-reentrant survives even stacked shims (_old_checkpoint then being a shim).
 try:
     import torch.utils.checkpoint as _ckpt_at_import
     _PRISTINE_TORCH_CHECKPOINT = (
@@ -409,10 +382,8 @@ except Exception:
 
 
 def _resolve_pristine_checkpoint(_ckpt):
-    """Return the genuine non-reentrant-capable torch checkpoint. Prefer the reference
-    captured at import; otherwise unwrap _old_checkpoint repeatedly past any stacked
-    Unsloth shims (each shim forces/routes reentrant, so a shim base would silently
-    bypass the non-reentrant override)."""
+    """Genuine non-reentrant-capable torch checkpoint: prefer the import-captured ref, else
+    unwrap _old_checkpoint past stacked Unsloth shims (a shim base would bypass the override)."""
     if _PRISTINE_TORCH_CHECKPOINT is not None:
         return _PRISTINE_TORCH_CHECKPOINT
     cand = getattr(_ckpt, "checkpoint", None)
@@ -427,8 +398,7 @@ def _resolve_pristine_checkpoint(_ckpt):
 
 
 def _gemma4_model_has_kv_sharing(model):
-    """True iff ``model`` has any Gemma-4 E-series cross-layer KV sharing (E2B/E4B).
-    Cached on the model; a strict no-op signal for 31B / 26B-A4B / non-shared models."""
+    """True iff model has Gemma-4 E-series KV sharing (E2B/E4B). Cached; no-op signal otherwise."""
     flag = getattr(model, "_unsloth_gemma4_has_kv_sharing", None)
     if flag is None:
         flag = any(
@@ -443,29 +413,15 @@ def _gemma4_model_has_kv_sharing(model):
 
 
 def _gemma4_force_nonreentrant_checkpointing(model):
-    """Force gemma-4 text decoder layers to use NON-reentrant gradient checkpointing so
-    the cross-layer shared K/V stays grad-connected. Required on EVERY transformers
-    version with E-series KV sharing, not just the carrier window.
-
-    The shared K/V is produced by an earlier ("producer") layer and reused by the ~20
-    later ("consumer") layers -- via the carrier on transformers 5.5.0-5.5.1, and via the
-    native ``shared_kv_states`` dict on 5.5.2+. BOTH are a Python dict reached through a
-    module attribute / a kwarg baked into GradientCheckpointingLayer's partial, NOT a
-    checkpoint input. So under REENTRANT checkpointing -- which includes Unsloth's
-    offloaded checkpointer (it forces use_reentrant=True) and torch's use_reentrant=True --
-    each layer is recomputed independently during backward in REVERSE order: a consumer is
-    recomputed before its producer and reads the detached no-grad K/V from the first
-    forward, so gradients from the shared layers never reach the producer's k_proj/v_proj
-    (the logits/loss look correct, only the gradient is wrong). Confirmed on transformers
-    5.5.0 AND native 5.12.1: producer k/v_proj grads diverge from the use_cache=True
-    reference (cosine ~0.14-0.55) under reentrant GC. Un-checkpointing the producer instead
-    triggers "backward through the graph a second time" because its activation feeds many
-    reentrant-checkpointed consumers. Non-reentrant recomputation keeps the region's
-    autograd graph connected, so the producer K/V gradient is exact (verified: grads match
-    the reference to cosine 1.0 under reentrant, non-reentrant, and Unsloth offloaded, on
-    both 5.5.0 and 5.12.1). Trades Unsloth's CPU activation offload (a memory optimisation)
-    for correct gradients on these ~1-2B E-series models. No-op when gradient checkpointing
-    is off, and a strict no-op for non-E-series gemma-4 (no shared layers)."""
+    """Force gemma-4 E-series decoder layers onto NON-reentrant gradient checkpointing so the
+    cross-layer shared K/V stays grad-connected, on EVERY version with KV sharing. The producer
+    layer's K/V is reused by ~20 consumers via a dict on a module attr / kwarg (the carrier on
+    5.5.0-5.5.1, native shared_kv_states on 5.5.2+), not a checkpoint input. Under reentrant GC
+    (incl. Unsloth's offloaded checkpointer) consumers recompute before the producer in reverse
+    order and read detached no-grad K/V, so the producer's k/v_proj grads are wrong (loss looks
+    fine). Non-reentrant keeps the region's graph connected -> exact grads (cosine 1.0 vs the
+    use_cache=True reference, verified on 5.5.0 and 5.12.1). Trades Unsloth's CPU activation
+    offload for correctness on these ~1-2B models. No-op without GC or KV sharing."""
     if not _gemma4_model_has_kv_sharing(model):
         return
     import functools
@@ -473,10 +429,8 @@ def _gemma4_force_nonreentrant_checkpointing(model):
         import torch.utils.checkpoint as _ckpt
     except Exception:
         return
-    # The PRISTINE torch checkpoint: Unsloth's smart GC globally swaps
-    # torch.utils.checkpoint.checkpoint for a shim that hard-forces use_reentrant=True
-    # (for its CPU-offload CheckpointFunction) and would ignore the use_reentrant=False
-    # below, so resolve past any (possibly stacked) shims.
+    # Resolve past Unsloth's smart-GC shim (it hard-forces use_reentrant=True and would
+    # ignore the use_reentrant=False below).
     base = _resolve_pristine_checkpoint(_ckpt)
     if base is None:
         return
@@ -496,9 +450,8 @@ def _gemma4_force_nonreentrant_checkpointing(model):
             # Only override when this layer is actually being checkpointed.
             if not getattr(layer, "gradient_checkpointing", False):
                 continue
-            # Preserve any user-supplied checkpoint kwargs (preserve_rng_state, context_fn,
-            # determinism_check, ...) that transformers baked into the layer's existing
-            # _gradient_checkpointing_func; only override use_reentrant.
+            # Preserve the layer's existing checkpoint kwargs (preserve_rng_state, context_fn,
+            # ...); only override use_reentrant.
             existing = getattr(layer, "_gradient_checkpointing_func", None)
             extra = {}
             if isinstance(existing, functools.partial):
@@ -512,16 +465,12 @@ def _gemma4_force_nonreentrant_checkpointing(model):
 
 
 def _gemma4_attach_shared_kv_carrier(model):
-    """Create a fresh carrier and attach it to every Gemma4TextAttention under ``model``
-    so shared layers can reach it even after gradient checkpointing nulls their
-    past_key_values kwarg, and force non-reentrant checkpointing so the shared K/V stays
-    grad-connected. The attention list is cached on the model; called once per forward.
-    No-op without KV sharing."""
+    """Attach a fresh per-forward carrier to every Gemma4TextAttention so shared layers reach
+    it after GC nulls their past_key_values kwarg. Attention list cached; no-op without sharing."""
     attns = getattr(model, "_unsloth_gemma4_attns", None)
     if attns is None:
         attns = [m for m in model.modules() if m.__class__.__name__ == "Gemma4TextAttention"]
-        # Only relevant when some layer actually shares KV (E2B/E4B); cache an empty
-        # list for 31B / 26B-A4B / non-shared models so later forwards are a no-op.
+        # Cache an empty list for non-shared models (31B/26B-A4B) so later forwards no-op.
         if not any(getattr(m, "is_kv_shared_layer", False) for m in attns):
             attns = []
         try:
@@ -539,10 +488,8 @@ def _gemma4_attach_shared_kv_carrier(model):
 
 
 def _gemma4_clear_shared_kv_carrier(model):
-    """Drop the producer K/V the per-forward carrier pinned. Only safe to call when no
-    checkpointed backward will read the carrier (i.e. ``not torch.is_grad_enabled()``):
-    under gradient checkpointing the carrier must survive until backward recompute. The
-    cached attention list is reused; no-op without KV sharing / without a carrier."""
+    """Drop the producer K/V the carrier pinned. Only safe when no checkpointed backward will
+    read it (not torch.is_grad_enabled()); no-op without KV sharing / without a carrier."""
     attns = getattr(model, "_unsloth_gemma4_attns", None)
     if not attns:
         return
@@ -560,24 +507,15 @@ def _gemma4_clear_shared_kv_carrier(model):
 
 
 def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
-    """Wrap a Gemma-4 model forward to (1) force non-reentrant gradient checkpointing so
-    the cross-layer shared K/V stays grad-connected under reentrant/offloaded GC -- needed
-    on EVERY version with E-series KV sharing -- and (2), only on builds that need the
-    carrier (transformers 5.5.0-5.5.1, ``attach_carrier=True``), attach a fresh per-forward
-    shared-KV carrier so the cache-free forward also works. On 5.5.2+ the native
-    shared_kv_states handles the forward, so only the gradient fix runs.
+    """Wrap a Gemma-4 model forward: always force non-reentrant GC (the gradient fix, all
+    versions), and on the 5.5.0-5.5.1 carrier window (attach_carrier=True) also attach a fresh
+    per-forward carrier so the cache-free forward works. 5.5.2+ uses native shared_kv_states.
 
-    Carrier scope note (transformers 5.5.0-5.5.1 only): the carrier is stored as a module
-    attribute because that is the only channel that survives into gradient-checkpoint
-    backward recompute (recompute re-runs the decoder layers, NOT this model-forward
-    wrapper, so a forward-scoped contextvar/stack would already be gone). Consequently, if
-    a training loop keeps more than one checkpointed forward graph alive before calling
-    backward (e.g. summing two microbatch losses, or multi-view/contrastive losses), the
-    second forward overwrites the single carrier and the first graph's recompute reads the
-    later batch's K/V. This affects ONLY the 5.5.0-5.5.1 carrier bridge; on transformers
-    >= 5.5.2 the native ``shared_kv_states`` is passed per forward (function-scoped) and is
-    immune, so the supported fix for that pattern is to upgrade transformers. Standard
-    single-forward / gradient-accumulation training (one backward per forward) is unaffected."""
+    Carrier scope (5.5.0-5.5.1 only): the carrier lives on the module because that is the only
+    channel surviving GC backward recompute (recompute re-runs the layers, not this wrapper).
+    So keeping two checkpointed forward graphs alive before one backward (DPO/contrastive,
+    summed microbatch losses) lets the second overwrite the carrier; upgrade to >= 5.5.2 (its
+    function-scoped shared_kv_states is immune). Single-forward / grad-accumulation is fine."""
     def forward(self, *args, **kwargs):
         try:
             _gemma4_force_nonreentrant_checkpointing(self)
@@ -588,10 +526,8 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
                 _gemma4_attach_shared_kv_carrier(self)
             except Exception:
                 pass
-            # In eval / inference / no_grad there is no backward to read the carrier, so
-            # release the producer K/V it pinned as soon as the forward returns instead of
-            # holding it until the next forward or model deletion. In training the carrier
-            # must survive until backward, and the next forward replaces it.
+            # No backward to read the carrier under eval/no_grad: release its pinned K/V now
+            # instead of holding it until the next forward. Training keeps it until backward.
             if not torch.is_grad_enabled():
                 try:
                     return _orig_forward(self, *args, **kwargs)
@@ -616,10 +552,8 @@ def _patch_forward_for_kv_shared_no_cache(cls, attach_carrier):
 
 
 def patch_Gemma4TextModel_forward_kv_shared_no_cache():
-    """Patch Gemma4TextModel.forward so cross-layer KV sharing is gradient-correct under
-    reentrant/offloaded gradient checkpointing (all versions), and -- only on the
-    transformers 5.5.0-5.5.1 window where the cache-free forward is broken -- also
-    carrier-patch Gemma4TextAttention.forward so use_cache=False works."""
+    """Patch Gemma4TextModel.forward: gradient-correct KV sharing under reentrant/offloaded GC
+    (all versions), plus the carrier on the 5.5.0-5.5.1 window where use_cache=False is broken."""
     try:
         from transformers.models.gemma4.modeling_gemma4 import Gemma4TextModel
     except ImportError:
@@ -638,8 +572,7 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextModel_forward_kv_shared_no_cache)
 
 
 def patch_Gemma4Model_forward_kv_shared_no_cache():
-    """Patch Gemma4Model.forward (multimodal parent) for the same gradient fix (and the
-    carrier on 5.5.0-5.5.1), in case a refactor routes the forward through it."""
+    """Same as the TextModel patch, on the multimodal parent Gemma4Model (if the forward routes through it)."""
     try:
         from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
     except ImportError:

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -538,13 +538,46 @@ def _gemma4_attach_shared_kv_carrier(model):
             pass
 
 
+def _gemma4_clear_shared_kv_carrier(model):
+    """Drop the producer K/V the per-forward carrier pinned. Only safe to call when no
+    checkpointed backward will read the carrier (i.e. ``not torch.is_grad_enabled()``):
+    under gradient checkpointing the carrier must survive until backward recompute. The
+    cached attention list is reused; no-op without KV sharing / without a carrier."""
+    attns = getattr(model, "_unsloth_gemma4_attns", None)
+    if not attns:
+        return
+    for attn in attns:
+        carrier = getattr(attn, "_unsloth_shared_kv_carrier", None)
+        if carrier is not None:
+            try:
+                carrier.shared_layers.clear()
+            except Exception:
+                pass
+            try:
+                del attn._unsloth_shared_kv_carrier
+            except Exception:
+                pass
+
+
 def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
     """Wrap a Gemma-4 model forward to (1) force non-reentrant gradient checkpointing so
     the cross-layer shared K/V stays grad-connected under reentrant/offloaded GC -- needed
     on EVERY version with E-series KV sharing -- and (2), only on builds that need the
     carrier (transformers 5.5.0-5.5.1, ``attach_carrier=True``), attach a fresh per-forward
     shared-KV carrier so the cache-free forward also works. On 5.5.2+ the native
-    shared_kv_states handles the forward, so only the gradient fix runs."""
+    shared_kv_states handles the forward, so only the gradient fix runs.
+
+    Carrier scope note (transformers 5.5.0-5.5.1 only): the carrier is stored as a module
+    attribute because that is the only channel that survives into gradient-checkpoint
+    backward recompute (recompute re-runs the decoder layers, NOT this model-forward
+    wrapper, so a forward-scoped contextvar/stack would already be gone). Consequently, if
+    a training loop keeps more than one checkpointed forward graph alive before calling
+    backward (e.g. summing two microbatch losses, or multi-view/contrastive losses), the
+    second forward overwrites the single carrier and the first graph's recompute reads the
+    later batch's K/V. This affects ONLY the 5.5.0-5.5.1 carrier bridge; on transformers
+    >= 5.5.2 the native ``shared_kv_states`` is passed per forward (function-scoped) and is
+    immune, so the supported fix for that pattern is to upgrade transformers. Standard
+    single-forward / gradient-accumulation training (one backward per forward) is unaffected."""
     def forward(self, *args, **kwargs):
         try:
             _gemma4_force_nonreentrant_checkpointing(self)
@@ -555,6 +588,18 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
                 _gemma4_attach_shared_kv_carrier(self)
             except Exception:
                 pass
+            # In eval / inference / no_grad there is no backward to read the carrier, so
+            # release the producer K/V it pinned as soon as the forward returns instead of
+            # holding it until the next forward or model deletion. In training the carrier
+            # must survive until backward, and the next forward replaces it.
+            if not torch.is_grad_enabled():
+                try:
+                    return _orig_forward(self, *args, **kwargs)
+                finally:
+                    try:
+                        _gemma4_clear_shared_kv_carrier(self)
+                    except Exception:
+                        pass
         return _orig_forward(self, *args, **kwargs)
 
     forward._unsloth_kv_shared_use_cache_false_patched = True

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -304,6 +304,12 @@ TEMPORARY_PATCHES.append(patch_StaticCache_kv_shared_zero)
 # teacher-forced loss ~16 vs ~6.8 (use_cache=True); under gradient checkpointing
 # all 20 shared layers fall back to recomputing their own KV.
 #
+# Version window: gemma-4 first ships in transformers 5.5.0, and the buggy
+# cache-dependent path exists only in 5.5.0 and 5.5.1. From 5.5.2 onward (the
+# native `shared_kv_states` arg was backported into the 5.5.x line, then 5.6.0+)
+# the cache-free path is fixed upstream. The gate below detects this by signature,
+# not version, so it stays correct across the mid-patch-release backport.
+#
 # Fix: decouple the within-forward shared KV from past_key_values. The model
 # forward attaches a fresh tiny carrier (a shared_layers dict + no-op update) to
 # every Gemma4TextAttention, and the attention uses it whenever the real
@@ -316,10 +322,11 @@ TEMPORARY_PATCHES.append(patch_StaticCache_kv_shared_zero)
 
 def _gemma4_kv_sharing_needs_cache():
     """True iff this transformers build plumbs Gemma-4 cross-layer KV sharing through
-    ``past_key_values`` (the buggy, cache-dependent mechanism, transformers 5.5.0).
-    Newer builds pass it via a dedicated ``shared_kv_states`` argument to the attention
-    forward, which fixes the cache-free path and makes this patch unnecessary, so we
-    no-op there (forwards-compat with transformers >= 5.5.0 and 5.x latest)."""
+    ``past_key_values`` (the buggy, cache-dependent mechanism: transformers 5.5.0-5.5.1).
+    Newer builds (5.5.2+, where the native ``shared_kv_states`` attention argument was
+    backported, through 5.x latest) pass the shared KV cache-independently, fixing the
+    cache-free path and making this patch unnecessary, so we no-op there. Detection is by
+    signature, not version, so it tracks the backport correctly (forwards-compatible)."""
     try:
         import inspect
         from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -388,6 +388,44 @@ def _patch_gemma4_attention_carrier():
     Gemma4TextAttention.forward = _make_gemma4_attention_carrier_forward(Gemma4TextAttention.forward)
 
 
+# Names of Unsloth's checkpoint shims (all force/route reentrant), so we can recognise
+# and unwrap them to find the pristine torch checkpoint.
+_UNSLOTH_CKPT_SHIM_NAMES = frozenset({
+    "unsloth_checkpoint", "unsloth_gradient_checkpoint",
+    "unsloth_offloaded_gradient_checkpoint",
+})
+# Capture the pristine torch checkpoint at import (before any Unsloth GC patch swaps
+# torch.utils.checkpoint.checkpoint), so forcing non-reentrant cannot be defeated even
+# when Unsloth's shims are stacked and _old_checkpoint no longer holds the original.
+try:
+    import torch.utils.checkpoint as _ckpt_at_import
+    _PRISTINE_TORCH_CHECKPOINT = (
+        _ckpt_at_import.checkpoint
+        if getattr(_ckpt_at_import.checkpoint, "__name__", "") not in _UNSLOTH_CKPT_SHIM_NAMES
+        else None
+    )
+except Exception:
+    _PRISTINE_TORCH_CHECKPOINT = None
+
+
+def _resolve_pristine_checkpoint(_ckpt):
+    """Return the genuine non-reentrant-capable torch checkpoint. Prefer the reference
+    captured at import; otherwise unwrap _old_checkpoint repeatedly past any stacked
+    Unsloth shims (each shim forces/routes reentrant, so a shim base would silently
+    bypass the non-reentrant override)."""
+    if _PRISTINE_TORCH_CHECKPOINT is not None:
+        return _PRISTINE_TORCH_CHECKPOINT
+    cand = getattr(_ckpt, "checkpoint", None)
+    seen = set()
+    while getattr(cand, "__name__", "") in _UNSLOTH_CKPT_SHIM_NAMES:
+        nxt = getattr(_ckpt, "_old_checkpoint", None)
+        if nxt is None or id(nxt) in seen or nxt is cand:
+            break
+        seen.add(id(nxt))
+        cand = nxt
+    return cand
+
+
 def _gemma4_model_has_kv_sharing(model):
     """True iff ``model`` has any Gemma-4 E-series cross-layer KV sharing (E2B/E4B).
     Cached on the model; a strict no-op signal for 31B / 26B-A4B / non-shared models."""
@@ -435,26 +473,13 @@ def _gemma4_force_nonreentrant_checkpointing(model):
         import torch.utils.checkpoint as _ckpt
     except Exception:
         return
-    func = getattr(model, "_unsloth_gemma4_nonreentrant_func", None)
-    if func is None:
-        # Resolve the PRISTINE torch checkpoint. Unsloth's smart GC globally swaps
-        # torch.utils.checkpoint.checkpoint for `unsloth_checkpoint`, which hard-forces
-        # use_reentrant=True (for its CPU-offload CheckpointFunction) and would ignore the
-        # use_reentrant=False below. Unsloth saves the original at `_old_checkpoint`, so
-        # use that when the current one is an Unsloth shim.
-        base = getattr(_ckpt, "checkpoint", None)
-        if getattr(base, "__name__", "") in (
-            "unsloth_checkpoint", "unsloth_gradient_checkpoint",
-            "unsloth_offloaded_gradient_checkpoint",
-        ):
-            base = getattr(_ckpt, "_old_checkpoint", base)
-        if base is None:
-            return
-        func = functools.partial(base, use_reentrant = False)
-        try:
-            model._unsloth_gemma4_nonreentrant_func = func
-        except Exception:
-            pass
+    # The PRISTINE torch checkpoint: Unsloth's smart GC globally swaps
+    # torch.utils.checkpoint.checkpoint for a shim that hard-forces use_reentrant=True
+    # (for its CPU-offload CheckpointFunction) and would ignore the use_reentrant=False
+    # below, so resolve past any (possibly stacked) shims.
+    base = _resolve_pristine_checkpoint(_ckpt)
+    if base is None:
+        return
     layers = getattr(model, "_unsloth_gemma4_decoder_layers", None)
     if layers is None:
         layers = [
@@ -469,8 +494,19 @@ def _gemma4_force_nonreentrant_checkpointing(model):
     for layer in layers:
         try:
             # Only override when this layer is actually being checkpointed.
-            if getattr(layer, "gradient_checkpointing", False):
-                layer._gradient_checkpointing_func = func
+            if not getattr(layer, "gradient_checkpointing", False):
+                continue
+            # Preserve any user-supplied checkpoint kwargs (preserve_rng_state, context_fn,
+            # determinism_check, ...) that transformers baked into the layer's existing
+            # _gradient_checkpointing_func; only override use_reentrant.
+            existing = getattr(layer, "_gradient_checkpointing_func", None)
+            extra = {}
+            if isinstance(existing, functools.partial):
+                extra = {k: v for k, v in (existing.keywords or {}).items()
+                         if k != "use_reentrant"}
+            layer._gradient_checkpointing_func = functools.partial(
+                base, use_reentrant = False, **extra
+            )
         except Exception:
             pass
 

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -382,11 +382,16 @@ except Exception:
 
 
 def _resolve_pristine_checkpoint(_ckpt):
-    """Genuine non-reentrant-capable torch checkpoint: prefer the import-captured ref, else
-    unwrap _old_checkpoint past stacked Unsloth shims (a shim base would bypass the override).
-    Returns None if every candidate is a shim, so the caller skips rather than wrap a shim."""
+    """Genuine non-reentrant-capable torch checkpoint: prefer the import-captured ref, then the
+    set-once ref the GC patcher stashes before any shim stacks, else unwrap _old_checkpoint past
+    stacked Unsloth shims. Returns None if every candidate is a shim."""
     if _PRISTINE_TORCH_CHECKPOINT is not None:
         return _PRISTINE_TORCH_CHECKPOINT
+    # patch_unsloth_*_gradient_checkpointing stash the real fn here on the first patch, so it
+    # survives stacked shims and a late gemma4 import (when module-level _old_checkpoint is a shim).
+    captured = getattr(_ckpt, "_unsloth_pristine_checkpoint", None)
+    if captured is not None and getattr(captured, "__name__", "") not in _UNSLOTH_CKPT_SHIM_NAMES:
+        return captured
     cand = getattr(_ckpt, "checkpoint", None)
     seen = set()
     while getattr(cand, "__name__", "") in _UNSLOTH_CKPT_SHIM_NAMES:
@@ -515,6 +520,37 @@ def _gemma4_clear_shared_kv_carrier(model):
                 pass
 
 
+def _arm_carrier_outstanding_marker(model, output):
+    """Mark the carrier outstanding until this forward's backward starts. A grad hook on the
+    output clears it at the start of this graph's backward, so a later forward can tell whether
+    a prior checkpointed graph is still pending (DPO/contrastive) vs already consumed (grad
+    accumulation). No-op if nothing in the output carries grad (no backward graph to guard)."""
+    tensor = getattr(output, "last_hidden_state", None)
+    if not isinstance(tensor, torch.Tensor):
+        if isinstance(output, torch.Tensor):
+            tensor = output
+        elif isinstance(output, (tuple, list)) and output and isinstance(output[0], torch.Tensor):
+            tensor = output[0]
+        else:
+            tensor = None
+    if tensor is None or not tensor.requires_grad or tensor.grad_fn is None:
+        return
+    try:
+        model._unsloth_gemma4_carrier_outstanding = True
+    except Exception:
+        return
+    def _clear(_grad):
+        try: model._unsloth_gemma4_carrier_outstanding = False
+        except Exception: pass
+        return None
+    try:
+        tensor.register_hook(_clear)
+    except Exception:
+        # could not arm the auto-clear -> do not leave a sticky marker that false-positives later
+        try: model._unsloth_gemma4_carrier_outstanding = False
+        except Exception: pass
+
+
 def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
     """Wrap a Gemma-4 model forward: always force non-reentrant GC (the gradient fix, all
     versions), and on the 5.5.0-5.5.1 carrier window (attach_carrier=True) also attach a fresh
@@ -522,26 +558,24 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
 
     Carrier scope (5.5.0-5.5.1 only): the carrier lives on the module because that is the only
     channel surviving GC backward recompute (recompute re-runs the layers, not this wrapper).
-    So keeping two checkpointed forward graphs alive before one backward (DPO/contrastive,
-    summed microbatch losses) lets the second overwrite the carrier; upgrade to >= 5.5.2 (its
-    function-scoped shared_kv_states is immune). Single-forward / grad-accumulation is fine."""
+    Two checkpointed forward graphs alive before one backward (DPO/contrastive, summed microbatch
+    losses) would have the second overwrite a carrier the first graph still needs -> we detect
+    that and raise instead of silently corrupting grads (upgrade to >= 5.5.2 for function-scoped
+    shared_kv_states). Single-forward / grad-accumulation is fine (the prior graph's backward
+    clears the marker before the next forward)."""
     def forward(self, *args, **kwargs):
         try:
             _gemma4_force_nonreentrant_checkpointing(self)
         except Exception:
             pass
         if attach_carrier:
-            try:
-                _gemma4_attach_shared_kv_carrier(self)
-            except Exception:
-                pass
             # No backward to read the carrier under eval/no_grad: release its pinned K/V now
-            # instead of holding it until the next forward. Under training the carrier must stay
-            # live through the whole backward (GC recompute reads it in reverse order), so it is
-            # only released when the next forward swaps in a fresh carrier; this lingers one
-            # producer layer's K/V across optimizer.step() (small for E2B/E4B), the cost of the
-            # module-scoped carrier on this 5.5.0-5.5.1 window (5.5.2+ frees it function-scoped).
+            # instead of holding it until the next forward.
             if not torch.is_grad_enabled():
+                try:
+                    _gemma4_attach_shared_kv_carrier(self)
+                except Exception:
+                    pass
                 try:
                     return _orig_forward(self, *args, **kwargs)
                 finally:
@@ -549,6 +583,23 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
                         _gemma4_clear_shared_kv_carrier(self)
                     except Exception:
                         pass
+            # Training: refuse a second outstanding checkpointed forward (its carrier would
+            # clobber the first graph's K/V during recompute).
+            if getattr(self, "_unsloth_gemma4_carrier_outstanding", False):
+                raise RuntimeError(
+                    "Unsloth: Gemma-4 E-series KV sharing on transformers 5.5.0/5.5.1 cannot run "
+                    "two forward passes before a single backward (e.g. DPO/contrastive or summed "
+                    "microbatch losses): the shared-KV carrier is module-scoped, so the second "
+                    "forward would corrupt the first graph's gradients. Upgrade to transformers "
+                    ">= 5.5.2, whose function-scoped shared K/V supports these objectives."
+                )
+            try:
+                _gemma4_attach_shared_kv_carrier(self)
+            except Exception:
+                pass
+            out = _orig_forward(self, *args, **kwargs)
+            _arm_carrier_outstanding_marker(self, out)
+            return out
         return _orig_forward(self, *args, **kwargs)
 
     forward._unsloth_kv_shared_use_cache_false_patched = True

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -520,6 +520,24 @@ def _gemma4_clear_shared_kv_carrier(model):
                 pass
 
 
+def _gemma4_carrier_overlap_unsafe(model):
+    """Overlapping checkpointed forwards corrupt grads through the module-scoped carrier ONLY when
+    the model truly shares K/V (so a carrier is attached) AND gradient checkpointing is active on a
+    Gemma-4 layer (so backward recompute re-enters attention and re-reads the carrier). Without
+    sharing no carrier exists (31B/26B-A4B cache an empty attn list); without checkpointing backward
+    uses saved activations and never re-reads it, so two forwards before one backward are safe."""
+    if not _gemma4_model_has_kv_sharing(model):
+        return False
+    layers = getattr(model, "_unsloth_gemma4_decoder_layers", None)
+    if layers is None:
+        layers = [
+            m for m in model.modules()
+            if hasattr(m, "gradient_checkpointing")
+            and type(getattr(m, "self_attn", None)).__name__ == "Gemma4TextAttention"
+        ]
+    return any(getattr(layer, "gradient_checkpointing", False) for layer in layers)
+
+
 def _arm_carrier_outstanding_marker(model, output):
     """Mark the carrier outstanding until this forward's backward starts. A grad hook on the
     output clears it at the start of this graph's backward, so a later forward can tell whether
@@ -583,22 +601,27 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
                         _gemma4_clear_shared_kv_carrier(self)
                     except Exception:
                         pass
-            # Training: refuse a second outstanding checkpointed forward (its carrier would
-            # clobber the first graph's K/V during recompute).
-            if getattr(self, "_unsloth_gemma4_carrier_outstanding", False):
+            # Training: a second outstanding checkpointed forward would clobber the first graph's
+            # carrier during recompute -- but only when KV sharing AND gradient checkpointing are
+            # both active (otherwise no carrier is re-read in backward). Only then track/reject, so
+            # 31B/26B-A4B and checkpointing-off runs keep working with DPO/contrastive/summed loss.
+            overlap_unsafe = _gemma4_carrier_overlap_unsafe(self)
+            if overlap_unsafe and getattr(self, "_unsloth_gemma4_carrier_outstanding", False):
                 raise RuntimeError(
                     "Unsloth: Gemma-4 E-series KV sharing on transformers 5.5.0/5.5.1 cannot run "
                     "two forward passes before a single backward (e.g. DPO/contrastive or summed "
-                    "microbatch losses): the shared-KV carrier is module-scoped, so the second "
-                    "forward would corrupt the first graph's gradients. Upgrade to transformers "
-                    ">= 5.5.2, whose function-scoped shared K/V supports these objectives."
+                    "microbatch losses) while gradient checkpointing is on: the shared-KV carrier "
+                    "is module-scoped, so the second forward would corrupt the first graph's "
+                    "gradients. Upgrade to transformers >= 5.5.2 (function-scoped shared K/V), or "
+                    "disable gradient checkpointing for these objectives."
                 )
             try:
                 _gemma4_attach_shared_kv_carrier(self)
             except Exception:
                 pass
             out = _orig_forward(self, *args, **kwargs)
-            _arm_carrier_outstanding_marker(self, out)
+            if overlap_unsafe:
+                _arm_carrier_outstanding_marker(self, out)
             return out
         return _orig_forward(self, *args, **kwargs)
 

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -388,27 +388,48 @@ def _patch_gemma4_attention_carrier():
     Gemma4TextAttention.forward = _make_gemma4_attention_carrier_forward(Gemma4TextAttention.forward)
 
 
+def _gemma4_model_has_kv_sharing(model):
+    """True iff ``model`` has any Gemma-4 E-series cross-layer KV sharing (E2B/E4B).
+    Cached on the model; a strict no-op signal for 31B / 26B-A4B / non-shared models."""
+    flag = getattr(model, "_unsloth_gemma4_has_kv_sharing", None)
+    if flag is None:
+        flag = any(
+            getattr(m, "is_kv_shared_layer", False)
+            for m in model.modules() if m.__class__.__name__ == "Gemma4TextAttention"
+        )
+        try:
+            model._unsloth_gemma4_has_kv_sharing = flag
+        except Exception:
+            pass
+    return flag
+
+
 def _gemma4_force_nonreentrant_checkpointing(model):
-    """Force gemma-4 text decoder layers to use NON-reentrant gradient checkpointing
-    while the carrier is active, so the cross-layer shared K/V stays grad-connected.
+    """Force gemma-4 text decoder layers to use NON-reentrant gradient checkpointing so
+    the cross-layer shared K/V stays grad-connected. Required on EVERY transformers
+    version with E-series KV sharing, not just the carrier window.
 
     The shared K/V is produced by an earlier ("producer") layer and reused by the ~20
-    later ("consumer") layers via the carrier. Under REENTRANT checkpointing -- which
-    includes Unsloth's offloaded checkpointer (it forces use_reentrant=True) and torch's
-    use_reentrant=True -- each layer is recomputed independently during backward in
-    REVERSE order, so a consumer is recomputed before its producer and reads the detached
-    no-grad K/V from the first forward; gradients from the shared layers then never reach
-    the producer's k_proj/v_proj (the logits/loss look correct, only the gradient is
-    wrong). Un-checkpointing the producer instead triggers "backward through the graph a
-    second time" because its activation feeds many reentrant-checkpointed consumers.
-    Non-reentrant recomputation keeps the whole region's autograd graph connected, so the
-    producer K/V gradient is exact (verified: producer k/v_proj grads match the
-    use_cache=True reference to cosine 1.0). Scoped to gemma-4 E-series on the legacy
-    transformers window (5.5.0-5.5.1) where the carrier runs; trades Unsloth's CPU
-    activation offload (a memory optimisation) for correct gradients on these ~1-2B
-    models. No-op when gradient checkpointing is off (e.g. plain use_cache=False), and
-    moot from transformers 5.5.2 where the native shared_kv_states path makes the whole
-    patch a no-op."""
+    later ("consumer") layers -- via the carrier on transformers 5.5.0-5.5.1, and via the
+    native ``shared_kv_states`` dict on 5.5.2+. BOTH are a Python dict reached through a
+    module attribute / a kwarg baked into GradientCheckpointingLayer's partial, NOT a
+    checkpoint input. So under REENTRANT checkpointing -- which includes Unsloth's
+    offloaded checkpointer (it forces use_reentrant=True) and torch's use_reentrant=True --
+    each layer is recomputed independently during backward in REVERSE order: a consumer is
+    recomputed before its producer and reads the detached no-grad K/V from the first
+    forward, so gradients from the shared layers never reach the producer's k_proj/v_proj
+    (the logits/loss look correct, only the gradient is wrong). Confirmed on transformers
+    5.5.0 AND native 5.12.1: producer k/v_proj grads diverge from the use_cache=True
+    reference (cosine ~0.14-0.55) under reentrant GC. Un-checkpointing the producer instead
+    triggers "backward through the graph a second time" because its activation feeds many
+    reentrant-checkpointed consumers. Non-reentrant recomputation keeps the region's
+    autograd graph connected, so the producer K/V gradient is exact (verified: grads match
+    the reference to cosine 1.0 under reentrant, non-reentrant, and Unsloth offloaded, on
+    both 5.5.0 and 5.12.1). Trades Unsloth's CPU activation offload (a memory optimisation)
+    for correct gradients on these ~1-2B E-series models. No-op when gradient checkpointing
+    is off, and a strict no-op for non-E-series gemma-4 (no shared layers)."""
+    if not _gemma4_model_has_kv_sharing(model):
+        return
     import functools
     try:
         import torch.utils.checkpoint as _ckpt
@@ -479,20 +500,25 @@ def _gemma4_attach_shared_kv_carrier(model):
             attn._unsloth_shared_kv_carrier = carrier
         except Exception:
             pass
-    _gemma4_force_nonreentrant_checkpointing(model)
 
 
-def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):
-    """Wrap a Gemma-4 model forward to attach a fresh per-forward shared-KV carrier to
-    every Gemma4TextAttention, so cross-layer KV sharing works under use_cache=False
-    AND gradient checkpointing. The carrier (consumed by the attention patch) replaces
-    the older approach of injecting a DynamicCache + forcing use_cache=True, which the
-    GradientCheckpointingLayer defeated by nulling past_key_values at the attention."""
+def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
+    """Wrap a Gemma-4 model forward to (1) force non-reentrant gradient checkpointing so
+    the cross-layer shared K/V stays grad-connected under reentrant/offloaded GC -- needed
+    on EVERY version with E-series KV sharing -- and (2), only on builds that need the
+    carrier (transformers 5.5.0-5.5.1, ``attach_carrier=True``), attach a fresh per-forward
+    shared-KV carrier so the cache-free forward also works. On 5.5.2+ the native
+    shared_kv_states handles the forward, so only the gradient fix runs."""
     def forward(self, *args, **kwargs):
         try:
-            _gemma4_attach_shared_kv_carrier(self)
+            _gemma4_force_nonreentrant_checkpointing(self)
         except Exception:
             pass
+        if attach_carrier:
+            try:
+                _gemma4_attach_shared_kv_carrier(self)
+            except Exception:
+                pass
         return _orig_forward(self, *args, **kwargs)
 
     forward._unsloth_kv_shared_use_cache_false_patched = True
@@ -501,51 +527,51 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):
     return forward
 
 
-def _patch_forward_for_kv_shared_no_cache(cls):
+def _patch_forward_for_kv_shared_no_cache(cls, attach_carrier):
     """Install the wrapper on `cls.forward`. Idempotent."""
     if getattr(cls.forward, "_unsloth_kv_shared_use_cache_false_patched", False):
         return
-    cls.forward = _make_kv_shared_use_cache_false_safe_forward(cls.forward)
+    cls.forward = _make_kv_shared_use_cache_false_safe_forward(cls.forward, attach_carrier)
 
 
 def patch_Gemma4TextModel_forward_kv_shared_no_cache():
-    """Patch Gemma4TextModel.forward + Gemma4TextAttention.forward so cross-layer KV
-    sharing works under use_cache=False and gradient checkpointing."""
-    if not _gemma4_kv_sharing_needs_cache():
-        # transformers passes the shared KV via `shared_kv_states` (cache-independent),
-        # so the cache-free path already works; this patch would be needless.
-        return
+    """Patch Gemma4TextModel.forward so cross-layer KV sharing is gradient-correct under
+    reentrant/offloaded gradient checkpointing (all versions), and -- only on the
+    transformers 5.5.0-5.5.1 window where the cache-free forward is broken -- also
+    carrier-patch Gemma4TextAttention.forward so use_cache=False works."""
     try:
         from transformers.models.gemma4.modeling_gemma4 import Gemma4TextModel
     except ImportError:
         return
     except Exception as e:
-        return raise_error("Gemma4TextModel.forward use_cache=False fix", e)
+        return raise_error("Gemma4TextModel.forward kv-shared GC fix", e)
     try:
-        _patch_gemma4_attention_carrier()
-        _patch_forward_for_kv_shared_no_cache(Gemma4TextModel)
+        needs_carrier = _gemma4_kv_sharing_needs_cache()
+        if needs_carrier:
+            _patch_gemma4_attention_carrier()
+        _patch_forward_for_kv_shared_no_cache(Gemma4TextModel, attach_carrier = needs_carrier)
     except Exception as e:
-        return raise_error("Gemma4TextModel.forward use_cache=False fix", e)
+        return raise_error("Gemma4TextModel.forward kv-shared GC fix", e)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma4TextModel_forward_kv_shared_no_cache)
 
 
 def patch_Gemma4Model_forward_kv_shared_no_cache():
-    """Patch Gemma4Model.forward (multimodal parent) to attach the carrier too, in
-    case a refactor moves cache auto-creation above Gemma4TextModel."""
-    if not _gemma4_kv_sharing_needs_cache():
-        return
+    """Patch Gemma4Model.forward (multimodal parent) for the same gradient fix (and the
+    carrier on 5.5.0-5.5.1), in case a refactor routes the forward through it."""
     try:
         from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
     except ImportError:
         return
     except Exception as e:
-        return raise_error("Gemma4Model.forward use_cache=False fix", e)
+        return raise_error("Gemma4Model.forward kv-shared GC fix", e)
     try:
-        _patch_gemma4_attention_carrier()
-        _patch_forward_for_kv_shared_no_cache(Gemma4Model)
+        needs_carrier = _gemma4_kv_sharing_needs_cache()
+        if needs_carrier:
+            _patch_gemma4_attention_carrier()
+        _patch_forward_for_kv_shared_no_cache(Gemma4Model, attach_carrier = needs_carrier)
     except Exception as e:
-        return raise_error("Gemma4Model.forward use_cache=False fix", e)
+        return raise_error("Gemma4Model.forward kv-shared GC fix", e)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma4Model_forward_kv_shared_no_cache)
 

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -300,117 +300,125 @@ TEMPORARY_PATCHES.append(patch_StaticCache_kv_shared_zero)
 # See huggingface/transformers#45242.
 #
 # Affects num_kv_shared_layers > 0 (E2B=20, E4B=18); 31B / 26B-A4B (=0) are
-# unaffected.
+# unaffected. Confirmed on transformers 5.5.0 + gemma-4-E2B-it: use_cache=False
+# teacher-forced loss ~16 vs ~6.8 (use_cache=True); under gradient checkpointing
+# all 20 shared layers fall back to recomputing their own KV.
 #
-# Fix: wrap Gemma4TextModel.forward (and Gemma4Model.forward) so that when KV
-# sharing is active and the caller passes past_key_values=None with use_cache
-# falsy, we build a DynamicCache, run the original forward, then drop it from
-# the output to preserve use_cache=False semantics. Pass-through otherwise.
+# Fix: decouple the within-forward shared KV from past_key_values. The model
+# forward attaches a fresh tiny carrier (a shared_layers dict + no-op update) to
+# every Gemma4TextAttention, and the attention uses it whenever the real
+# past_key_values is None. The store/retrieve then works under use_cache=False
+# AND gradient checkpointing (where GradientCheckpointingLayer nulls the
+# past_key_values kwarg before the attention, defeating any injected cache).
+# Mirrors transformers' own later `shared_kv_states` fix; capability-gated to a
+# no-op on builds that already pass `shared_kv_states` (forwards-compatibility).
 # ============================================================================
 
-def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):
-    """Wrap a Gemma-4 forward to build an internal DynamicCache when KV sharing
-    is active but the caller passed use_cache=False, nulling it from the output.
-
-    Uses inspect.signature.bind_partial so past_key_values / use_cache resolve
-    whether passed positionally or by keyword, and calls the inner forward via
-    bound.args/bound.kwargs to avoid duplicate-argument TypeErrors.
-    """
-    import inspect
-
+def _gemma4_kv_sharing_needs_cache():
+    """True iff this transformers build plumbs Gemma-4 cross-layer KV sharing through
+    ``past_key_values`` (the buggy, cache-dependent mechanism, transformers 5.5.0).
+    Newer builds pass it via a dedicated ``shared_kv_states`` argument to the attention
+    forward, which fixes the cache-free path and makes this patch unnecessary, so we
+    no-op there (forwards-compat with transformers >= 5.5.0 and 5.x latest)."""
     try:
-        _sig = inspect.signature(_orig_forward)
-    except (TypeError, ValueError):
-        _sig = None
+        import inspect
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
+        return "shared_kv_states" not in inspect.signature(Gemma4TextAttention.forward).parameters
+    except Exception:
+        # Default to applying: no-op for models without KV sharing, safe where needed.
+        return True
 
+
+class _Gemma4SharedKVCarrier:
+    """Carries Gemma-4 cross-layer shared K/V WITHIN a single forward, decoupled from
+    ``past_key_values`` so the store/retrieve survives both use_cache=False and
+    gradient checkpointing (GradientCheckpointingLayer nulls the past_key_values kwarg
+    before the attention runs, see transformers/modeling_layers.py). Only
+    ``shared_layers`` is used; update() is a no-op so non-shared layers never build an
+    autoregressive cache. Mirrors transformers' own later ``shared_kv_states`` fix."""
+    __slots__ = ("shared_layers",)
+    def __init__(self):
+        self.shared_layers = {}
+    def update(self, key_states, value_states, layer_idx, cache_kwargs = None):
+        return key_states, value_states
+    def get_seq_length(self, layer_idx = 0):
+        return 0
+
+
+def _make_gemma4_attention_carrier_forward(_orig_attn_forward):
+    """Feed the per-forward carrier to Gemma4TextAttention whenever the real
+    ``past_key_values`` is None (use_cache=False, or nulled by gradient
+    checkpointing), so the cross-layer KV store/retrieve still works. The carrier is
+    attached to the module by the model-forward patch below. Pass-through otherwise
+    (e.g. generation with a real cache), so this is a strict no-op when not needed."""
     def forward(self, *args, **kwargs):
-        num_kv_shared = getattr(
-            getattr(self, "config", None), "num_kv_shared_layers", 0
-        )
-        # No-op without KV sharing (31B, 26B-A4B, non-Gemma-4).
-        if not num_kv_shared or num_kv_shared <= 0:
-            return _orig_forward(self, *args, **kwargs)
-
-        # Resolve past_key_values / use_cache from args or kwargs.
-        if _sig is None:
-            # Fallback if signature introspection failed: kwargs-only path.
-            past_key_values = kwargs.get("past_key_values", None)
-            use_cache_kw = kwargs.get("use_cache", None)
-            arguments = None
-        else:
-            try:
-                bound = _sig.bind_partial(self, *args, **kwargs)
-            except TypeError:
-                # Caller passed something the original forward will reject;
-                # let the original forward raise the canonical error.
-                return _orig_forward(self, *args, **kwargs)
-            arguments = bound.arguments
-            past_key_values = arguments.get("past_key_values", None)
-            use_cache_kw = arguments.get("use_cache", None)
-
-        use_cache_resolved = (
-            use_cache_kw
-            if use_cache_kw is not None
-            else getattr(self.config, "use_cache", True)
-        )
-
-        # Only intervene when the original forward would leave past_key_values
-        # as None (use_cache falsy and no cache passed in).
-        if past_key_values is not None or use_cache_resolved:
-            return _orig_forward(self, *args, **kwargs)
-
-        # Local cache for cross-layer KV sharing only; not leaked to the caller.
-        try:
-            from transformers.cache_utils import DynamicCache
-        except Exception:
-            return _orig_forward(self, *args, **kwargs)
-
-        # Inject the cache and force use_cache=True so the inner forward takes
-        # the same mask/position path; the result is cleaned up below.
-        if arguments is not None:
-            arguments["past_key_values"] = DynamicCache(config=self.config)
-            arguments["use_cache"] = True
-            # bound.args/kwargs derive from `arguments`, so the injected values
-            # land in the correct slot without duplicate-keyword TypeErrors.
-            inner_args = bound.args
-            inner_kwargs = bound.kwargs
-            result = _orig_forward(*inner_args, **inner_kwargs)
-        else:
-            kwargs["past_key_values"] = DynamicCache(config=self.config)
-            kwargs["use_cache"] = True
-            result = _orig_forward(self, *args, **kwargs)
-
-        # Null the cache from every result shape (ModelOutput, dict, tuple) to
-        # preserve the caller's use_cache=False contract.
-        try:
-            if isinstance(result, tuple):
-                # to_tuple() drops None entries, so the cache index isn't fixed;
-                # scan for the injected DynamicCache and drop it.
-                injected = (
-                    arguments["past_key_values"]
-                    if arguments is not None
-                    else kwargs["past_key_values"]
-                )
-                new_items = tuple(None if x is injected else x for x in result)
-                result = new_items
+        carrier = getattr(self, "_unsloth_shared_kv_carrier", None)
+        if carrier is not None:
+            # past_key_values is the 4th positional arg (after self) or a kwarg.
+            if "past_key_values" in kwargs:
+                if kwargs["past_key_values"] is None:
+                    kwargs["past_key_values"] = carrier
+            elif len(args) >= 4:
+                if args[3] is None:
+                    args = args[:3] + (carrier,) + args[4:]
             else:
-                # ModelOutput acts dict-like; __setitem__ keeps the attribute
-                # slot and OrderedDict in sync. Fall back to attribute assignment.
-                set_via_item = False
-                try:
-                    if hasattr(result, "__setitem__") and "past_key_values" in result:
-                        result["past_key_values"] = None
-                        set_via_item = True
-                except (TypeError, KeyError):
-                    set_via_item = False
-                if not set_via_item and hasattr(result, "past_key_values"):
-                    try:
-                        result.past_key_values = None
-                    except (AttributeError, TypeError):
-                        pass
+                kwargs["past_key_values"] = carrier
+        return _orig_attn_forward(self, *args, **kwargs)
+    forward._unsloth_gemma4_carrier_patched = True
+    forward.__qualname__ = getattr(_orig_attn_forward, "__qualname__", "forward")
+    forward.__doc__ = getattr(_orig_attn_forward, "__doc__", None)
+    return forward
+
+
+def _patch_gemma4_attention_carrier():
+    """Patch Gemma4TextAttention.forward to accept the shared-KV carrier. Idempotent."""
+    try:
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
+    except Exception:
+        return
+    if getattr(Gemma4TextAttention.forward, "_unsloth_gemma4_carrier_patched", False):
+        return
+    Gemma4TextAttention.forward = _make_gemma4_attention_carrier_forward(Gemma4TextAttention.forward)
+
+
+def _gemma4_attach_shared_kv_carrier(model):
+    """Create a fresh carrier and attach it to every Gemma4TextAttention under ``model``
+    so shared layers can reach it even after gradient checkpointing nulls their
+    past_key_values kwarg. The attention list is cached on the model; called once per
+    forward. No-op without KV sharing."""
+    attns = getattr(model, "_unsloth_gemma4_attns", None)
+    if attns is None:
+        attns = [m for m in model.modules() if m.__class__.__name__ == "Gemma4TextAttention"]
+        # Only relevant when some layer actually shares KV (E2B/E4B); cache an empty
+        # list for 31B / 26B-A4B / non-shared models so later forwards are a no-op.
+        if not any(getattr(m, "is_kv_shared_layer", False) for m in attns):
+            attns = []
+        try:
+            model._unsloth_gemma4_attns = attns
         except Exception:
             pass
-        return result
+    if not attns:
+        return
+    carrier = _Gemma4SharedKVCarrier()
+    for attn in attns:
+        try:
+            attn._unsloth_shared_kv_carrier = carrier
+        except Exception:
+            pass
+
+
+def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):
+    """Wrap a Gemma-4 model forward to attach a fresh per-forward shared-KV carrier to
+    every Gemma4TextAttention, so cross-layer KV sharing works under use_cache=False
+    AND gradient checkpointing. The carrier (consumed by the attention patch) replaces
+    the older approach of injecting a DynamicCache + forcing use_cache=True, which the
+    GradientCheckpointingLayer defeated by nulling past_key_values at the attention."""
+    def forward(self, *args, **kwargs):
+        try:
+            _gemma4_attach_shared_kv_carrier(self)
+        except Exception:
+            pass
+        return _orig_forward(self, *args, **kwargs)
 
     forward._unsloth_kv_shared_use_cache_false_patched = True
     forward.__qualname__ = getattr(_orig_forward, "__qualname__", "forward")
@@ -426,7 +434,12 @@ def _patch_forward_for_kv_shared_no_cache(cls):
 
 
 def patch_Gemma4TextModel_forward_kv_shared_no_cache():
-    """Patch Gemma4TextModel.forward (the language decoder that drives attention)."""
+    """Patch Gemma4TextModel.forward + Gemma4TextAttention.forward so cross-layer KV
+    sharing works under use_cache=False and gradient checkpointing."""
+    if not _gemma4_kv_sharing_needs_cache():
+        # transformers passes the shared KV via `shared_kv_states` (cache-independent),
+        # so the cache-free path already works; this patch would be needless.
+        return
     try:
         from transformers.models.gemma4.modeling_gemma4 import Gemma4TextModel
     except ImportError:
@@ -434,6 +447,7 @@ def patch_Gemma4TextModel_forward_kv_shared_no_cache():
     except Exception as e:
         return raise_error("Gemma4TextModel.forward use_cache=False fix", e)
     try:
+        _patch_gemma4_attention_carrier()
         _patch_forward_for_kv_shared_no_cache(Gemma4TextModel)
     except Exception as e:
         return raise_error("Gemma4TextModel.forward use_cache=False fix", e)
@@ -442,8 +456,10 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextModel_forward_kv_shared_no_cache)
 
 
 def patch_Gemma4Model_forward_kv_shared_no_cache():
-    """Patch Gemma4Model.forward (multimodal parent) as a safety net in case a
-    refactor moves cache auto-creation above Gemma4TextModel."""
+    """Patch Gemma4Model.forward (multimodal parent) to attach the carrier too, in
+    case a refactor moves cache auto-creation above Gemma4TextModel."""
+    if not _gemma4_kv_sharing_needs_cache():
+        return
     try:
         from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
     except ImportError:
@@ -451,6 +467,7 @@ def patch_Gemma4Model_forward_kv_shared_no_cache():
     except Exception as e:
         return raise_error("Gemma4Model.forward use_cache=False fix", e)
     try:
+        _patch_gemma4_attention_carrier()
         _patch_forward_for_kv_shared_no_cache(Gemma4Model)
     except Exception as e:
         return raise_error("Gemma4Model.forward use_cache=False fix", e)

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -383,17 +383,26 @@ except Exception:
 
 def _resolve_pristine_checkpoint(_ckpt):
     """Genuine non-reentrant-capable torch checkpoint: prefer the import-captured ref, else
-    unwrap _old_checkpoint past stacked Unsloth shims (a shim base would bypass the override)."""
+    unwrap _old_checkpoint past stacked Unsloth shims (a shim base would bypass the override).
+    Returns None if every candidate is a shim, so the caller skips rather than wrap a shim."""
     if _PRISTINE_TORCH_CHECKPOINT is not None:
         return _PRISTINE_TORCH_CHECKPOINT
     cand = getattr(_ckpt, "checkpoint", None)
     seen = set()
     while getattr(cand, "__name__", "") in _UNSLOTH_CKPT_SHIM_NAMES:
-        nxt = getattr(_ckpt, "_old_checkpoint", None)
+        # Prefer the shim's own _old_checkpoint (survives stacking, where a single module-level
+        # attr is overwritten), then fall back to the module-level one.
+        nxt = getattr(cand, "_old_checkpoint", None)
+        if nxt is None:
+            nxt = getattr(_ckpt, "_old_checkpoint", None)
         if nxt is None or id(nxt) in seen or nxt is cand:
             break
         seen.add(id(nxt))
         cand = nxt
+    # Never hand back a shim: forcing use_reentrant=False onto it would wrap the very offloaded
+    # checkpointer we are trying to bypass, silently dropping the gradient fix. Signal "none".
+    if getattr(cand, "__name__", "") in _UNSLOTH_CKPT_SHIM_NAMES:
+        return None
     return cand
 
 
@@ -527,7 +536,11 @@ def _make_kv_shared_use_cache_false_safe_forward(_orig_forward, attach_carrier):
             except Exception:
                 pass
             # No backward to read the carrier under eval/no_grad: release its pinned K/V now
-            # instead of holding it until the next forward. Training keeps it until backward.
+            # instead of holding it until the next forward. Under training the carrier must stay
+            # live through the whole backward (GC recompute reads it in reverse order), so it is
+            # only released when the next forward swaps in a fresh carrier; this lingers one
+            # producer layer's K/V across optimizer.step() (small for E2B/E4B), the cost of the
+            # module-scoped carrier on this 5.5.0-5.5.1 window (5.5.2+ frees it function-scoped).
             if not torch.is_grad_enabled():
                 try:
                     return _orig_forward(self, *args, **kwargs)

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -388,11 +388,78 @@ def _patch_gemma4_attention_carrier():
     Gemma4TextAttention.forward = _make_gemma4_attention_carrier_forward(Gemma4TextAttention.forward)
 
 
+def _gemma4_force_nonreentrant_checkpointing(model):
+    """Force gemma-4 text decoder layers to use NON-reentrant gradient checkpointing
+    while the carrier is active, so the cross-layer shared K/V stays grad-connected.
+
+    The shared K/V is produced by an earlier ("producer") layer and reused by the ~20
+    later ("consumer") layers via the carrier. Under REENTRANT checkpointing -- which
+    includes Unsloth's offloaded checkpointer (it forces use_reentrant=True) and torch's
+    use_reentrant=True -- each layer is recomputed independently during backward in
+    REVERSE order, so a consumer is recomputed before its producer and reads the detached
+    no-grad K/V from the first forward; gradients from the shared layers then never reach
+    the producer's k_proj/v_proj (the logits/loss look correct, only the gradient is
+    wrong). Un-checkpointing the producer instead triggers "backward through the graph a
+    second time" because its activation feeds many reentrant-checkpointed consumers.
+    Non-reentrant recomputation keeps the whole region's autograd graph connected, so the
+    producer K/V gradient is exact (verified: producer k/v_proj grads match the
+    use_cache=True reference to cosine 1.0). Scoped to gemma-4 E-series on the legacy
+    transformers window (5.5.0-5.5.1) where the carrier runs; trades Unsloth's CPU
+    activation offload (a memory optimisation) for correct gradients on these ~1-2B
+    models. No-op when gradient checkpointing is off (e.g. plain use_cache=False), and
+    moot from transformers 5.5.2 where the native shared_kv_states path makes the whole
+    patch a no-op."""
+    import functools
+    try:
+        import torch.utils.checkpoint as _ckpt
+    except Exception:
+        return
+    func = getattr(model, "_unsloth_gemma4_nonreentrant_func", None)
+    if func is None:
+        # Resolve the PRISTINE torch checkpoint. Unsloth's smart GC globally swaps
+        # torch.utils.checkpoint.checkpoint for `unsloth_checkpoint`, which hard-forces
+        # use_reentrant=True (for its CPU-offload CheckpointFunction) and would ignore the
+        # use_reentrant=False below. Unsloth saves the original at `_old_checkpoint`, so
+        # use that when the current one is an Unsloth shim.
+        base = getattr(_ckpt, "checkpoint", None)
+        if getattr(base, "__name__", "") in (
+            "unsloth_checkpoint", "unsloth_gradient_checkpoint",
+            "unsloth_offloaded_gradient_checkpoint",
+        ):
+            base = getattr(_ckpt, "_old_checkpoint", base)
+        if base is None:
+            return
+        func = functools.partial(base, use_reentrant = False)
+        try:
+            model._unsloth_gemma4_nonreentrant_func = func
+        except Exception:
+            pass
+    layers = getattr(model, "_unsloth_gemma4_decoder_layers", None)
+    if layers is None:
+        layers = [
+            m for m in model.modules()
+            if hasattr(m, "gradient_checkpointing")
+            and type(getattr(m, "self_attn", None)).__name__ == "Gemma4TextAttention"
+        ]
+        try:
+            model._unsloth_gemma4_decoder_layers = layers
+        except Exception:
+            pass
+    for layer in layers:
+        try:
+            # Only override when this layer is actually being checkpointed.
+            if getattr(layer, "gradient_checkpointing", False):
+                layer._gradient_checkpointing_func = func
+        except Exception:
+            pass
+
+
 def _gemma4_attach_shared_kv_carrier(model):
     """Create a fresh carrier and attach it to every Gemma4TextAttention under ``model``
     so shared layers can reach it even after gradient checkpointing nulls their
-    past_key_values kwarg. The attention list is cached on the model; called once per
-    forward. No-op without KV sharing."""
+    past_key_values kwarg, and force non-reentrant checkpointing so the shared K/V stays
+    grad-connected. The attention list is cached on the model; called once per forward.
+    No-op without KV sharing."""
     attns = getattr(model, "_unsloth_gemma4_attns", None)
     if attns is None:
         attns = [m for m in model.modules() if m.__class__.__name__ == "Gemma4TextAttention"]
@@ -412,6 +479,7 @@ def _gemma4_attach_shared_kv_carrier(model):
             attn._unsloth_shared_kv_carrier = carrier
         except Exception:
             pass
+    _gemma4_force_nonreentrant_checkpointing(model)
 
 
 def _make_kv_shared_use_cache_false_safe_forward(_orig_forward):


### PR DESCRIPTION
## Problem

Gemma-4 E2B / E4B (`num_kv_shared_layers > 0`) implement cross-layer KV sharing THROUGH the cache: a store layer writes its full-length K/V into `past_key_values.shared_layers`, and each shared layer reads them back. Both are gated on `past_key_values is not None`. So when `past_key_values` is None the sharing silently breaks and every shared layer recomputes its own (wrong) K/V, producing garbage logits (huggingface/transformers#45242).

`past_key_values` is None in exactly the two cases that matter for training:
- `use_cache=False` (every QLoRA tutorial sets `config.use_cache=False`), and
- gradient checkpointing, where `GradientCheckpointingLayer` nulls the `past_key_values` kwarg before the attention runs (`transformers/modeling_layers.py`).

The previous wrapper injected a `DynamicCache` at the model forward and forced `use_cache=True`. That fixed plain `use_cache=False`, but was **defeated by gradient checkpointing** (the layer nulls the cache before the attention sees it), so QLoRA training stayed broken.

## Before / after (transformers 5.5.0, google/gemma-4-E2B-it, num_kv_shared_layers=20)

Plain forward, no Unsloth:
| path | top-1 | teacher-forced loss |
|---|---|---|
| use_cache=True | `Here` | 6.84 (correct) |
| use_cache=False | `**` | 16.17 (garbage) |

Under gradient checkpointing the shared layers fall back for both paths. Instrumenting the attention: pre-fix `shared retrieve=0 fallback=20`; post-fix `retrieve=20 fallback=0`, loss back to the correct ~6.8.

Real Unsloth QLoRA (`FastModel` + `use_gradient_checkpointing="unsloth"`) on a single repeated row: loss `4.86 -> 0.000` (memorises), generation coherent.

## Fix

Decouple the within-forward shared KV from `past_key_values`. The model forward attaches a fresh tiny carrier (a `shared_layers` dict + no-op `update()`) to every `Gemma4TextAttention`, and the attention uses it whenever the real `past_key_values` is None. Store/retrieve then works under `use_cache=False` AND gradient checkpointing. This mirrors transformers' own later `shared_kv_states` fix.

**Forwards-compatible:** capability-gated to a strict no-op on builds whose attention forward already takes a `shared_kv_states` argument (the upstream fix), so it only applies where the cache-dependent mechanism is present.

## No-break

- No-op for `num_kv_shared_layers == 0` (31B / 26B-A4B) and non-Gemma-4 models (the attention list is cached empty).
- Generation (`use_cache=True`) is unchanged: the real cache is non-None, so the carrier is never substituted.
- No-op on transformers builds that pass `shared_kv_states` (capability gate).

## Tests

CPU regression tests (no GPU/model): patches stay registered and actually wire the carrier (guards against silently disabling the fix), carrier semantics, the capability gate (True without `shared_kv_states`, False with), and the attention carrier-substitution rule (substitute only when `past_key_values` is None).