### PR TITLE
peft_utils: add finetune_audio_layers for Gemma 4 / Gemma 3N audio + embedder LoRA

### DIFF
--- a/tests/test_peft_regex_audio.py
+++ b/tests/test_peft_regex_audio.py
@@ -1,0 +1,315 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Regression tests for get_peft_regex's audio/vision-embedder LoRA targeting.
+
+Goals (mirrors the #798 byte-identical methodology):
+  * finetune_audio_layers defaults False and is strictly additive: for every
+    existing architecture the produced regex never contains the audio branches
+    when the flag is off, and is byte-identical with the flag on when the model
+    has no audio_tower / Gemma embedder modules.
+  * With the flag on, Gemma 4 / Gemma 3N attach their audio_tower Linears and the
+    embed_audio.embedding_projection projector (0 -> N); the vision flag attaches
+    embed_vision.embedding_projection. conv / *norm modules are never matched
+    (they are not nn.Linear, so not even candidates).
+
+Module names are taken verbatim from the real checkpoint tensor names
+(`get_safetensors_metadata` on unsloth/gemma-4-E2B-it, unsloth/gemma-4-12B-it,
+unsloth/gemma-3n-E4B-it), so the synthetic trees are faithful. We use synthetic
+trees for determinism / no downloads; get_peft_regex only inspects named_modules()
++ isinstance(_, nn.Linear).
+"""
+import re
+import pytest
+import torch
+import torch.nn as nn
+
+from unsloth_zoo.peft_utils import get_peft_regex
+
+
+# ----------------------------------------------------------------------------- helpers
+def _add(root: nn.Module, path: str, leaf_module: nn.Module):
+    *mids, leaf = path.split(".")
+    cur = root
+    for m in mids:
+        if not hasattr(cur, m):
+            setattr(cur, m, nn.Module())
+        cur = getattr(cur, m)
+    setattr(cur, leaf, leaf_module)
+
+
+class FakeModel(nn.Module):
+    """Builds a module tree from (path -> module-kind) specs."""
+    def __init__(self, linear_paths, other_paths=(), name="fake"):
+        super().__init__()
+        self.model = nn.Module()
+        for p in linear_paths:
+            _add(self.model, p, nn.Linear(8, 8, bias=False))
+        for p, kind in other_paths:
+            _add(self.model, p, kind())
+        class _Cfg:
+            _name_or_path = name
+            model_type = "fake"
+        self.config = _Cfg()
+
+
+def linear_names(model):
+    return [n for n, m in model.named_modules() if isinstance(m, nn.Linear)]
+
+
+def matched(regex, names):
+    # PEFT uses re.fullmatch; assert on that (no DOTALL needed - names have no newlines).
+    return {n for n in names if re.fullmatch(regex, n)}
+
+
+def leaf(name):
+    # Strip a trailing Gemma4ClippableLinear ".linear" suffix only (do NOT touch a
+    # leaf literally named e.g. "linear_start"), then take the last path segment.
+    if name.endswith(".linear"):
+        name = name[: -len(".linear")]
+    return name.rsplit(".", 1)[-1]
+
+
+# ----------------------------------------------------------------------------- fixtures
+def _text_stack(prefix, n=2, heads=("q_proj", "k_proj", "v_proj", "o_proj"),
+                mlp=("gate_proj", "up_proj", "down_proj")):
+    out = []
+    for i in range(n):
+        out += [f"{prefix}.{i}.self_attn.{h}" for h in heads]
+        out += [f"{prefix}.{i}.mlp.{m}" for m in mlp]
+    return out
+
+
+# Existing architectures (no Gemma embedder / no audio LoRA target today).
+LLAMA      = _text_stack("language_model.layers") + ["lm_head"]
+QWEN3      = _text_stack("language_model.layers") + ["lm_head"]
+QWEN2_VL   = (_text_stack("language_model.layers")
+              + [f"visual.blocks.{i}.attn.{p}" for i in range(2) for p in ("qkv", "proj")]
+              + [f"visual.blocks.{i}.mlp.{p}" for i in range(2) for p in ("fc1", "fc2")]
+              + ["visual.merger.mlp.0", "visual.merger.mlp.2"])
+LLAVA      = (_text_stack("language_model.layers")
+              + [f"vision_tower.vision_model.encoder.layers.{i}.self_attn.{p}"
+                 for i in range(2) for p in ("q_proj", "k_proj", "v_proj", "out_proj")]
+              + ["multi_modal_projector.linear_1", "multi_modal_projector.linear_2"])
+GEMMA3_VL  = (_text_stack("language_model.layers")
+              + [f"vision_tower.vision_model.encoder.layers.{i}.self_attn.{p}"
+                 for i in range(2) for p in ("q_proj", "k_proj", "v_proj", "out_proj")]
+              + [f"vision_tower.vision_model.encoder.layers.{i}.mlp.{p}"
+                 for i in range(2) for p in ("fc1", "fc2")]
+              + ["multi_modal_projector.mm_input_projection"])
+# Audio-bearing existing models: MUST stay byte-identical when the flag is OFF.
+QWEN2_AUDIO = (_text_stack("language_model.layers")
+               + [f"audio_tower.layers.{i}.self_attn.{p}"
+                  for i in range(2) for p in ("q_proj", "k_proj", "v_proj", "out_proj")]
+               + [f"audio_tower.layers.{i}.fc1" for i in range(2)]
+               + [f"audio_tower.layers.{i}.fc2" for i in range(2)]
+               + ["multi_modal_projector.linear"])
+# Whisper-style standalone audio model: a language stack so get_peft_regex applies,
+# plus an audio encoder named `audio_model.encoder.layers` (NO `audio_tower` segment),
+# to prove the audio branch keys on the `audio_tower` anchor specifically.
+WHISPER     = (_text_stack("language_model.layers")
+               + [f"audio_model.encoder.layers.{i}.self_attn.{p}"
+                  for i in range(2) for p in ("q_proj", "k_proj", "v_proj", "out_proj")])
+
+NON_GEMMA_ARCHS = {
+    "llama": LLAMA, "qwen3": QWEN3, "qwen2_vl": QWEN2_VL,
+    "llava": LLAVA, "gemma3_vl": GEMMA3_VL,
+}
+AUDIO_ARCHS = {"qwen2_audio": QWEN2_AUDIO, "whisper": WHISPER}
+
+FLAG_COMBOS = [
+    dict(finetune_vision_layers=True,  finetune_language_layers=True,  finetune_attention_modules=True,  finetune_mlp_modules=True),
+    dict(finetune_vision_layers=False, finetune_language_layers=True,  finetune_attention_modules=True,  finetune_mlp_modules=True),
+    dict(finetune_vision_layers=True,  finetune_language_layers=False, finetune_attention_modules=True,  finetune_mlp_modules=True),
+    dict(finetune_vision_layers=True,  finetune_language_layers=True,  finetune_attention_modules=True,  finetune_mlp_modules=False),
+    dict(finetune_vision_layers=True,  finetune_language_layers=True,  finetune_attention_modules=False, finetune_mlp_modules=True),
+]
+
+
+# Gemma audio/vision trees with REAL leaf names (verified from checkpoint metadata).
+def _gemma3n():
+    lin = _text_stack("language_model.layers")
+    conf = []
+    others = []
+    for i in range(2):
+        b = f"audio_tower.conformer.{i}"
+        conf += [f"{b}.attention.attn.{p}" for p in ("q_proj", "k_proj", "v_proj")]
+        conf += [f"{b}.attention.attn.relative_position_embedding.pos_proj"]
+        conf += [f"{b}.attention.post"]
+        conf += [f"{b}.ffw_layer_start.ffw_layer_1", f"{b}.ffw_layer_start.ffw_layer_2"]
+        conf += [f"{b}.ffw_layer_end.ffw_layer_1",   f"{b}.ffw_layer_end.ffw_layer_2"]
+        conf += [f"{b}.lconv1d.linear_start", f"{b}.lconv1d.linear_end"]
+        # non-Linear decoys under audio_tower:
+        others += [(f"{b}.lconv1d.depthwise_conv1d", lambda: nn.Conv1d(8, 8, 3)),
+                   (f"{b}.lconv1d.conv_norm", lambda: nn.LayerNorm(8)),
+                   (f"{b}.attention.post_norm", lambda: nn.LayerNorm(8))]
+    conf += ["audio_tower.subsample_conv_projection.input_proj_linear"]
+    others += [("audio_tower.subsample_conv_projection.conv_0.conv", lambda: nn.Conv2d(1, 8, 3)),
+               ("embed_audio.hard_embedding_norm", lambda: nn.LayerNorm(8)),
+               ("embed_vision.soft_embedding_norm", lambda: nn.LayerNorm(8))]
+    lin += conf + ["embed_audio.embedding_projection", "embed_vision.embedding_projection"]
+    return FakeModel(lin, others, name="unsloth/gemma-3n-E4B-it")
+
+
+def _gemma4(size="E2B"):
+    lin = _text_stack("language_model.layers")
+    others = []
+    # vision_tower encoder (already matched today via 'vision' tag) - ClippableLinear .linear children
+    for i in range(2):
+        b = f"vision_tower.encoder.layers.{i}"
+        lin += [f"{b}.self_attn.{p}.linear" for p in ("q_proj", "k_proj", "v_proj", "o_proj")]
+        lin += [f"{b}.mlp.{p}.linear" for p in ("gate_proj", "up_proj", "down_proj")]
+    lin += ["vision_tower.patch_embedder.input_proj"]
+    # audio_tower conformer (Gemma4 ClippableLinear -> .linear children)
+    for i in range(2):
+        b = f"audio_tower.layers.{i}"
+        lin += [f"{b}.feed_forward1.ffw_layer_1.linear", f"{b}.feed_forward1.ffw_layer_2.linear"]
+        lin += [f"{b}.feed_forward2.ffw_layer_1.linear", f"{b}.feed_forward2.ffw_layer_2.linear"]
+        lin += [f"{b}.attention.attn.q_proj.linear", f"{b}.attention.attn.k_proj.linear",
+                f"{b}.attention.attn.v_proj.linear", f"{b}.attention.attn.relative_k_proj.linear"]
+        lin += [f"{b}.attention.post.linear", f"{b}.lconv1d.linear_start.linear",
+                f"{b}.lconv1d.linear_end.linear"]
+        others += [(f"{b}.lconv1d.depthwise_conv1d", lambda: nn.Conv1d(8, 8, 3)),
+                   (f"{b}.attention.norm_post_attn", lambda: nn.LayerNorm(8))]
+    lin += ["audio_tower.subsample_conv_projection.input_proj_linear",
+            "audio_tower.output_proj"]
+    lin += ["embed_vision.embedding_projection", "embed_audio.embedding_projection"]
+    if size == "12B":
+        lin += ["vision_embedder.patch_dense"]
+    return FakeModel(lin, others, name=f"unsloth/gemma-4-{size}-it")
+
+
+# ----------------------------------------------------------------------------- tests
+@pytest.mark.parametrize("arch_name", list(NON_GEMMA_ARCHS) + list(AUDIO_ARCHS))
+@pytest.mark.parametrize("flags", FLAG_COMBOS)
+def test_audio_flag_off_is_inert(arch_name, flags):
+    """With finetune_audio_layers=False the regex must not contain audio branches,
+    and the matched set is identical to omitting the kwarg entirely."""
+    names_map = {**NON_GEMMA_ARCHS, **AUDIO_ARCHS}
+    model = FakeModel(names_map[arch_name])
+    ns = linear_names(model)
+    r_absent = get_peft_regex(model, **flags)
+    r_off    = get_peft_regex(model, **flags, finetune_audio_layers=False)
+    assert r_absent == r_off, "audio=False must equal omitting the kwarg"
+    assert "audio_tower" not in r_off, "audio branch leaked with flag off"
+    assert matched(r_off, ns) == matched(r_absent, ns)
+
+
+@pytest.mark.parametrize("arch_name", list(NON_GEMMA_ARCHS))
+@pytest.mark.parametrize("flags", FLAG_COMBOS)
+def test_audio_flag_additive_for_non_audio_archs(arch_name, flags):
+    """Models with no audio_tower / Gemma embedder are byte-identical whether the
+    audio flag is on or off (branches only appended when they actually match)."""
+    model = FakeModel(NON_GEMMA_ARCHS[arch_name])
+    r_off = get_peft_regex(model, **flags, finetune_audio_layers=False)
+    r_on  = get_peft_regex(model, **flags, finetune_audio_layers=True)
+    assert r_off == r_on
+
+
+def test_qwen2audio_no_leak_off_but_capability_on():
+    model = FakeModel(QWEN2_AUDIO)
+    ns = linear_names(model)
+    off = matched(get_peft_regex(model, finetune_audio_layers=False), ns)
+    assert not any("audio_tower" in n for n in off)
+    on = matched(get_peft_regex(model, finetune_audio_layers=True), ns)
+    assert any("audio_tower" in n for n in on), "flag on should reach audio_tower (forward-looking)"
+
+
+def test_audio_branch_keys_on_audio_tower_anchor():
+    # The audio branch is anchored on the `audio_tower` segment. An audio encoder
+    # named differently (audio_model.encoder.*) must NOT be swept in.
+    model = FakeModel(WHISPER)
+    ns = linear_names(model)
+    on = matched(get_peft_regex(model, finetune_vision_layers=False,
+                                finetune_language_layers=True,
+                                finetune_audio_layers=True), ns)
+    assert any(".language_model." in n for n in on)
+    assert not any("audio_model" in n for n in on), \
+        f"audio branch leaked into a non-audio_tower encoder: {[n for n in on if 'audio_model' in n]}"
+
+
+@pytest.mark.parametrize("builder,name", [(_gemma3n, "gemma3n"),
+                                          (lambda: _gemma4("E2B"), "gemma4_e2b"),
+                                          (lambda: _gemma4("12B"), "gemma4_12b")])
+def test_gemma_audio_attaches(builder, name):
+    model = builder()
+    ns = linear_names(model)
+
+    # Notebook-style config BEFORE the fix: audio off -> 0 audio modules.
+    off = matched(get_peft_regex(model, finetune_vision_layers=False,
+                                 finetune_language_layers=True,
+                                 finetune_audio_layers=False), ns)
+    assert not any(".audio_tower." in n or n.endswith("embed_audio.embedding_projection") for n in off)
+
+    # WITH the fix.
+    on = matched(get_peft_regex(model, finetune_vision_layers=False,
+                                finetune_language_layers=True,
+                                finetune_audio_layers=True), ns)
+    audio_hits = {n for n in on if ".audio_tower." in n}
+    assert audio_hits, f"{name}: audio_tower got 0 LoRA targets"
+    assert any(n.endswith("embed_audio.embedding_projection") for n in on), f"{name}: projector missed"
+
+    # The conformer feed-forward + attention + lconv leaves attach.
+    leaves = {leaf(n) for n in audio_hits}
+    assert {"ffw_layer_1", "ffw_layer_2"} <= leaves
+    assert {"linear_start", "linear_end"} <= leaves
+    assert "post" in leaves
+    assert {"q_proj", "k_proj", "v_proj"} <= leaves
+
+    # NEGATIVE: conv / norm leaves never matched (not nn.Linear -> not candidates).
+    assert not any(n.endswith("depthwise_conv1d") for n in on)
+    assert not any(n.endswith(".conv") or n.endswith("_norm") or n.endswith(".norm") for n in on)
+
+    # Language stack unchanged off<->on.
+    assert {n for n in off if ".language_model." in n} == {n for n in on if ".language_model." in n}
+
+
+@pytest.mark.parametrize("builder", [_gemma3n, lambda: _gemma4("E2B"), lambda: _gemma4("12B")])
+def test_vision_flag_attaches_vision_projector(builder):
+    model = builder()
+    ns = linear_names(model)
+    on = matched(get_peft_regex(model, finetune_vision_layers=True,
+                                finetune_language_layers=True,
+                                finetune_audio_layers=False), ns)
+    assert any(n.endswith("embed_vision.embedding_projection") for n in on)
+
+
+def test_audio_only_does_not_match_language():
+    """Audio-only (vision=False, language=False, audio=True) must not degenerate
+    into matching every attn/mlp leaf in the language stack."""
+    model = _gemma3n()
+    ns = linear_names(model)
+    on = matched(get_peft_regex(model, finetune_vision_layers=False,
+                                finetune_language_layers=False,
+                                finetune_audio_layers=True), ns)
+    assert on, "audio-only should still match audio modules"
+    assert not any(".language_model." in n for n in on), "audio-only leaked into language stack"
+
+
+def test_guard_allows_audio_only_and_blocks_nothing_selected():
+    model = _gemma3n()
+    # nothing selected -> raises
+    with pytest.raises(RuntimeError):
+        get_peft_regex(model, finetune_vision_layers=False,
+                       finetune_language_layers=False, finetune_audio_layers=False)
+    # audio-only -> must NOT raise
+    get_peft_regex(model, finetune_vision_layers=False,
+                   finetune_language_layers=False, finetune_audio_layers=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_peft_regex_audio.py
+++ b/tests/test_peft_regex_audio.py
@@ -53,7 +53,7 @@ def _add(root: nn.Module, path: str, leaf_module: nn.Module):
 
 class FakeModel(nn.Module):
     """Builds a module tree from (path -> module-kind) specs."""
-    def __init__(self, linear_paths, other_paths=(), name="fake"):
+    def __init__(self, linear_paths, other_paths=(), name="fake", model_type="fake"):
         super().__init__()
         self.model = nn.Module()
         for p in linear_paths:
@@ -61,9 +61,11 @@ class FakeModel(nn.Module):
         for p, kind in other_paths:
             _add(self.model, p, kind())
         class _Cfg:
-            _name_or_path = name
-            model_type = "fake"
-        self.config = _Cfg()
+            pass
+        cfg = _Cfg()
+        cfg._name_or_path = name
+        cfg.model_type = model_type
+        self.config = cfg
 
 
 def linear_names(model):
@@ -160,8 +162,11 @@ def _gemma3n():
     others += [("audio_tower.subsample_conv_projection.conv_0.conv", lambda: nn.Conv2d(1, 8, 3)),
                ("embed_audio.hard_embedding_norm", lambda: nn.LayerNorm(8)),
                ("embed_vision.soft_embedding_norm", lambda: nn.LayerNorm(8))]
+    # Decoy encoder named audio_model.* (NOT audio_tower) to prove the audio branch
+    # keys on the audio_tower segment and never sweeps a differently-named encoder.
+    lin += [f"audio_model.encoder.layers.{i}.self_attn.q_proj" for i in range(2)]
     lin += conf + ["embed_audio.embedding_projection", "embed_vision.embedding_projection"]
-    return FakeModel(lin, others, name="unsloth/gemma-3n-E4B-it")
+    return FakeModel(lin, others, name="unsloth/gemma-3n-E4B-it", model_type="gemma3n")
 
 
 def _gemma4(size="E2B"):
@@ -189,7 +194,7 @@ def _gemma4(size="E2B"):
     lin += ["embed_vision.embedding_projection", "embed_audio.embedding_projection"]
     if size == "12B":
         lin += ["vision_embedder.patch_dense"]
-    return FakeModel(lin, others, name=f"unsloth/gemma-4-{size}-it")
+    return FakeModel(lin, others, name=f"unsloth/gemma-4-{size}-it", model_type="gemma4")
 
 
 # ----------------------------------------------------------------------------- tests
@@ -221,28 +226,32 @@ def test_audio_flag_additive_for_non_audio_archs(arch_name, flags):
 
 def test_qwen2audio_off_no_leak_and_no_qwen_specific_leaves():
     # finetune_audio_layers is scoped to the models we ship notebooks for
-    # (Gemma 4 / Gemma 3N). On a non-notebook audio_tower (Qwen2-Audio) the flag is
-    # a no-op when off, and even when on it must NOT target Qwen-specific leaves
-    # (out_proj / fc1 / fc2) -- we deliberately do not generalize to it here.
-    model = FakeModel(QWEN2_AUDIO)
+    # (Gemma 4 / Gemma 3N) via a model_type / architectures gate. On a non-notebook
+    # audio_tower (Qwen2-Audio, model_type != gemma) the audio branch is never even
+    # built, so the flag is a no-op whether off OR on -- in particular it never
+    # targets Qwen-specific leaves (out_proj / fc1 / fc2).
+    model = FakeModel(QWEN2_AUDIO, model_type="qwen2_audio")
     ns = linear_names(model)
     off = matched(get_peft_regex(model, finetune_audio_layers=False), ns)
+    on  = matched(get_peft_regex(model, finetune_audio_layers=True), ns)
     assert not any("audio_tower" in n for n in off)
-    on_leaves = {leaf(n) for n in matched(get_peft_regex(model, finetune_audio_layers=True), ns)
-                 if "audio_tower" in n}
+    assert off == on, "non-Gemma audio model must be unaffected by finetune_audio_layers"
+    on_leaves = {leaf(n) for n in on if "audio_tower" in n}
     assert not ({"out_proj", "fc1", "fc2"} & on_leaves), \
         f"unexpectedly targeted Qwen-specific audio leaves: {on_leaves}"
 
 
 def test_audio_branch_keys_on_audio_tower_anchor():
-    # The audio branch is anchored on the `audio_tower` segment. An audio encoder
-    # named differently (audio_model.encoder.*) must NOT be swept in.
-    model = FakeModel(WHISPER)
+    # The audio branch is anchored on the `audio_tower` segment. A differently-named
+    # encoder (audio_model.encoder.*) sitting on the SAME Gemma model must NOT be
+    # swept in -- the anchor, not just the model-type gate, has to hold.
+    model = _gemma3n()  # carries an audio_model.encoder decoy alongside audio_tower
     ns = linear_names(model)
     on = matched(get_peft_regex(model, finetune_vision_layers=False,
                                 finetune_language_layers=True,
                                 finetune_audio_layers=True), ns)
     assert any(".language_model." in n for n in on)
+    assert any(".audio_tower." in n for n in on)
     assert not any("audio_model" in n for n in on), \
         f"audio branch leaked into a non-audio_tower encoder: {[n for n in on if 'audio_model' in n]}"
 
@@ -369,8 +378,8 @@ def test_audio_respects_attn_mlp_flags():
 
 
 def test_positional_target_modules_not_shadowed():
-    # finetune_audio_layers must come AFTER target_modules so positional callers
-    # that pass an explicit list as the 6th argument are unaffected.
+    # finetune_audio_layers lives at the END of the signature, so the 6th positional
+    # argument is still target_modules and positional callers are unaffected.
     model = FakeModel(LLAMA)
     ns = linear_names(model)
     kw = get_peft_regex(model, True, True, True, True, ["q_proj", "v_proj"])  # 6th positional = target_modules
@@ -380,6 +389,63 @@ def test_positional_target_modules_not_shadowed():
     assert kw == pos
     m = matched(kw, ns)
     assert m and all(leaf(n) in ("q_proj", "v_proj") for n in m)
+
+
+def test_positional_tag_overrides_not_shadowed():
+    # The tag-override params (vision_tags/language_tags/...) keep their positional
+    # slots: passing a list as the 7th positional must bind to vision_tags, NOT to
+    # finetune_audio_layers (which now sits after the tag params).
+    model = FakeModel(LLAMA)
+    # 7th positional = vision_tags. A made-up tag should appear verbatim in the regex.
+    r = get_peft_regex(model, True, True, True, True, None, ["zzvision"])
+    assert "zzvision" in r, "7th positional did not bind to vision_tags"
+    assert "audio_tower" not in r, "list mis-bound to finetune_audio_layers"
+
+
+def test_embedder_branches_gated_to_gemma_model_type():
+    # empty_model.py lists embed_vision.embedding_projection and
+    # vision_tower.patch_embedder.input_proj as Mistral3 components too. On a
+    # non-Gemma checkpoint that happens to carry those exact Linears, the default
+    # finetune_vision_layers=True must NOT start matching them (byte-identical set).
+    shared = ["embed_vision.embedding_projection",
+              "vision_tower.patch_embedder.input_proj"]
+    mistral = FakeModel(_text_stack("language_model.layers") + shared,
+                        name="mistralai/Mistral-Small-3", model_type="mistral3")
+    ns = linear_names(mistral)
+    on = matched(get_peft_regex(mistral, finetune_vision_layers=True,
+                                finetune_language_layers=True), ns)
+    assert not any(n.endswith(tuple(shared)) for n in on), \
+        f"non-Gemma embedder Linears wrongly targeted: {[n for n in on if n.endswith(tuple(shared))]}"
+    # The very same module names DO attach on a Gemma model.
+    gem = _gemma4("12B")
+    gon = matched(get_peft_regex(gem, finetune_vision_layers=True,
+                                 finetune_language_layers=True), linear_names(gem))
+    assert any(n.endswith("embed_vision.embedding_projection") for n in gon)
+
+
+def test_projector_branches_gated_under_mlp_flag():
+    # The vision/audio projectors are feed-forward projections, so attention-only
+    # runs (finetune_mlp_modules=False) must not pick them up; mlp-on must.
+    model = _gemma3n()
+    ns = linear_names(model)
+    # attention-only -> no projectors
+    attn_only = matched(get_peft_regex(model, finetune_vision_layers=True,
+                                       finetune_language_layers=True,
+                                       finetune_attention_modules=True,
+                                       finetune_mlp_modules=False,
+                                       finetune_audio_layers=True), ns)
+    assert not any(n.endswith("embed_vision.embedding_projection") for n in attn_only), \
+        "vision projector attached under attention-only"
+    assert not any(n.endswith("embed_audio.embedding_projection") for n in attn_only), \
+        "audio projector attached under attention-only"
+    # mlp-on -> projectors present
+    mlp_on = matched(get_peft_regex(model, finetune_vision_layers=True,
+                                    finetune_language_layers=True,
+                                    finetune_attention_modules=False,
+                                    finetune_mlp_modules=True,
+                                    finetune_audio_layers=True), ns)
+    assert any(n.endswith("embed_vision.embedding_projection") for n in mlp_on)
+    assert any(n.endswith("embed_audio.embedding_projection") for n in mlp_on)
 
 
 def test_guard_allows_audio_only_and_blocks_nothing_selected():

--- a/tests/test_peft_regex_audio.py
+++ b/tests/test_peft_regex_audio.py
@@ -219,13 +219,19 @@ def test_audio_flag_additive_for_non_audio_archs(arch_name, flags):
     assert r_off == r_on
 
 
-def test_qwen2audio_no_leak_off_but_capability_on():
+def test_qwen2audio_off_no_leak_and_no_qwen_specific_leaves():
+    # finetune_audio_layers is scoped to the models we ship notebooks for
+    # (Gemma 4 / Gemma 3N). On a non-notebook audio_tower (Qwen2-Audio) the flag is
+    # a no-op when off, and even when on it must NOT target Qwen-specific leaves
+    # (out_proj / fc1 / fc2) -- we deliberately do not generalize to it here.
     model = FakeModel(QWEN2_AUDIO)
     ns = linear_names(model)
     off = matched(get_peft_regex(model, finetune_audio_layers=False), ns)
     assert not any("audio_tower" in n for n in off)
-    on = matched(get_peft_regex(model, finetune_audio_layers=True), ns)
-    assert any("audio_tower" in n for n in on), "flag on should reach audio_tower (forward-looking)"
+    on_leaves = {leaf(n) for n in matched(get_peft_regex(model, finetune_audio_layers=True), ns)
+                 if "audio_tower" in n}
+    assert not ({"out_proj", "fc1", "fc2"} & on_leaves), \
+        f"unexpectedly targeted Qwen-specific audio leaves: {on_leaves}"
 
 
 def test_audio_branch_keys_on_audio_tower_anchor():
@@ -329,6 +335,21 @@ def test_audio_respects_explicit_target_modules():
         f"explicit target_modules not respected by audio branch: {at}"
     # embedding_projection was not in the list -> the projector is not attached
     assert not any(n.endswith("embed_audio.embedding_projection") for n in on)
+
+
+def test_explicit_leaf_matches_full_segment_not_prefix():
+    # target_modules=["k_proj"] must match audio_tower ...attn.k_proj but NOT
+    # ...attn.relative_k_proj (the ".*?" before the leaf must stop at a "." boundary).
+    model = _gemma4("E2B")  # Gemma 4 audio_tower has relative_k_proj (+ .linear children)
+    ns = linear_names(model)
+    on = matched(get_peft_regex(model, finetune_vision_layers=False,
+                                finetune_language_layers=True,
+                                finetune_audio_layers=True,
+                                target_modules=["k_proj"]), ns)
+    at = [n for n in on if ".audio_tower." in n]
+    assert any(leaf(n) == "k_proj" for n in at), "k_proj should match in audio_tower"
+    assert not any(leaf(n) == "relative_k_proj" for n in at), \
+        f"k_proj wrongly matched relative_k_proj: {at}"
 
 
 def test_audio_respects_attn_mlp_flags():

--- a/tests/test_peft_regex_audio.py
+++ b/tests/test_peft_regex_audio.py
@@ -35,7 +35,6 @@ trees for determinism / no downloads; get_peft_regex only inspects named_modules
 """
 import re
 import pytest
-import torch
 import torch.nn as nn
 
 from unsloth_zoo.peft_utils import get_peft_regex
@@ -298,6 +297,68 @@ def test_audio_only_does_not_match_language():
                                 finetune_audio_layers=True), ns)
     assert on, "audio-only should still match audio modules"
     assert not any(".language_model." in n for n in on), "audio-only leaked into language stack"
+
+
+def test_vision_only_no_language_does_not_touch_language():
+    # finetune_vision_layers=True, language=False on Gemma 3N: the only vision
+    # Linear is the flat embed_vision.embedding_projection. The component-only
+    # fallback must NOT fire before the embedder branch and broaden into the
+    # language stack.
+    model = _gemma3n()
+    ns = linear_names(model)
+    on = matched(get_peft_regex(model, finetune_vision_layers=True,
+                                finetune_language_layers=False,
+                                finetune_audio_layers=False), ns)
+    assert any(n.endswith("embed_vision.embedding_projection") for n in on)
+    assert not any(".language_model." in n for n in on), \
+        f"vision-only leaked into the language stack: {[n for n in on if '.language_model.' in n]}"
+
+
+def test_audio_respects_explicit_target_modules():
+    # With an explicit target_modules list, the audio branch must intersect with it
+    # rather than attach every Gemma audio leaf.
+    model = _gemma3n()
+    ns = linear_names(model)
+    on = matched(get_peft_regex(model, finetune_vision_layers=False,
+                                finetune_language_layers=True,
+                                finetune_audio_layers=True,
+                                target_modules=["q_proj", "v_proj"]), ns)
+    at = {leaf(n) for n in on if ".audio_tower." in n}
+    assert {"q_proj", "v_proj"} <= at
+    assert "k_proj" not in at and "ffw_layer_1" not in at and "post" not in at, \
+        f"explicit target_modules not respected by audio branch: {at}"
+    # embedding_projection was not in the list -> the projector is not attached
+    assert not any(n.endswith("embed_audio.embedding_projection") for n in on)
+
+
+def test_audio_respects_attn_mlp_flags():
+    # attention off, mlp on: the conformer attention leaves (q/k/v/post) must not
+    # attach, but the feed-forward leaves must.
+    model = _gemma3n()
+    ns = linear_names(model)
+    on = matched(get_peft_regex(model, finetune_vision_layers=False,
+                                finetune_language_layers=True,
+                                finetune_attention_modules=False,
+                                finetune_mlp_modules=True,
+                                finetune_audio_layers=True), ns)
+    at = {leaf(n) for n in on if ".audio_tower." in n}
+    assert {"ffw_layer_1", "ffw_layer_2"} <= at
+    assert "q_proj" not in at and "k_proj" not in at and "post" not in at, \
+        f"attn-off should drop audio attention leaves: {at}"
+
+
+def test_positional_target_modules_not_shadowed():
+    # finetune_audio_layers must come AFTER target_modules so positional callers
+    # that pass an explicit list as the 6th argument are unaffected.
+    model = FakeModel(LLAMA)
+    ns = linear_names(model)
+    kw = get_peft_regex(model, True, True, True, True, ["q_proj", "v_proj"])  # 6th positional = target_modules
+    pos = get_peft_regex(model, finetune_vision_layers=True, finetune_language_layers=True,
+                         finetune_attention_modules=True, finetune_mlp_modules=True,
+                         target_modules=["q_proj", "v_proj"])
+    assert kw == pos
+    m = matched(kw, ns)
+    assert m and all(leaf(n) in ("q_proj", "v_proj") for n in m)
 
 
 def test_guard_allows_audio_only_and_blocks_nothing_selected():

--- a/tests/test_peft_regex_audio.py
+++ b/tests/test_peft_regex_audio.py
@@ -346,6 +346,40 @@ def test_audio_respects_explicit_target_modules():
     assert not any(n.endswith("embed_audio.embedding_projection") for n in on)
 
 
+def all_module_names(model):
+    return [n for n, m in model.named_modules()]
+
+
+@pytest.mark.parametrize("builder,name", [(lambda: _gemma4("E2B"), "gemma4_e2b"),
+                                          (lambda: _gemma4("12B"), "gemma4_12b")])
+def test_gemma4_audio_matches_inner_linear_not_wrapper(builder, name):
+    # On Gemma 4 each audio projection is a Gemma4ClippableLinear wrapper: it appears
+    # in named_modules() as BOTH "...q_proj" (the wrapper, NOT an nn.Linear) and
+    # "...q_proj.linear" (the real inner Linear). PEFT runs the regex over EVERY
+    # module, so the regex must match only the inner Linear -- never the wrapper
+    # container, or PEFT tries to adapt the unsupported wrapper / double-processes
+    # the inner Linear.
+    model = builder()
+    r = get_peft_regex(model, finetune_vision_layers=True, finetune_language_layers=True,
+                       finetune_audio_layers=True)
+    lin = set(linear_names(model))
+    # The audio branch (the part this PR adds) must not match any NON-Linear module
+    # under audio_tower / the embedders -- PEFT iterates EVERY module, so a matched
+    # wrapper would be adapted as an unsupported module / double-process its inner
+    # Linear. (vision_tower.encoder wrappers are matched by the pre-existing main
+    # regex + handled by the _create_and_replace monkeypatch; out of scope here.)
+    def _ours(n):
+        return ".audio_tower." in n or "embed_audio" in n or "embed_vision" in n
+    bad = [n for n in all_module_names(model) if _ours(n) and n not in lin and re.fullmatch(r, n)]
+    assert not bad, f"{name}: regex matched non-Linear audio/embedder modules (wrappers?): {bad[:6]}"
+    # The inner ".linear" audio Linears DO attach.
+    inner = [n for n in lin if ".audio_tower." in n and n.endswith(".linear")]
+    assert inner and all(re.fullmatch(r, n) for n in inner), f"{name}: inner audio Linears not matched"
+    # ...and bare audio Linears (subsample/output projections) still attach.
+    bare = [n for n in lin if ".audio_tower." in n and not n.endswith(".linear")]
+    assert bare and all(re.fullmatch(r, n) for n in bare), f"{name}: bare audio Linears not matched"
+
+
 def test_explicit_leaf_matches_full_segment_not_prefix():
     # target_modules=["k_proj"] must match audio_tower ...attn.k_proj but NOT
     # ...attn.relative_k_proj (the ".*?" before the leaf must stop at a "." boundary).

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -57,8 +57,8 @@ def get_peft_regex(
     finetune_language_layers   : bool = True,
     finetune_attention_modules : bool = True,
     finetune_mlp_modules       : bool = True,
-    finetune_audio_layers      : bool = False,
     target_modules             : List[str] = None,
+    finetune_audio_layers      : bool = False,
     vision_tags                : List[str] = ["vision", "image", "visual", "patch",],
     language_tags              : List[str] = ["language", "text",],
     attention_tags             : List[str] = ["self_attn", "attention", "attn", "mixer",],
@@ -141,53 +141,68 @@ def get_peft_regex(
             r")|(?:\bmodel\.layers\.[\d]{1,}\.(?:" + regex_components + \
             r")\.(?:" + match_linear_modules + r"))"
         pass
-
-        # Check if regex is wrong since model does not have vision parts
-        check = any(re.search(regex_matcher, name, flags = re.DOTALL) for name in linear_modules)
-        if not check:
-            regex_matcher = \
-                r".*?(?:" + regex_components + \
-                r").*?"   + match_linear_modules
-        pass
     pass
 
     # Gemma 4 / Gemma 3N keep the visual/audio path in flat embedder Linears
     # (embed_vision.embedding_projection, embed_audio.embedding_projection,
     # vision_embedder.patch_dense, vision_tower.patch_embedder.input_proj) and a
     # conformer audio_tower whose ffw_layer_* / lconv1d.linear_* / attention.post
-    # leaves carry no attn/mlp component token. The standard matcher above can
-    # never select them, so add dedicated name-anchored branches. Each branch is
-    # only appended if it actually matches a Linear in THIS model, so for every
-    # other architecture the regex is byte-identical (the branches are anchored to
-    # audio_tower / embed_vision / embed_audio / vision_embedder name segments that
-    # exist only on Gemma 4 / Gemma 3N). Leading ".*?" for PEFT's re.fullmatch; no
-    # trailing ".*?" (a real Linear leaf must terminate the match); "(?:\.linear)?"
-    # also covers Gemma4ClippableLinear ".linear" children.
+    # leaves carry no attn/mlp component token, so the standard matcher above can
+    # never select them. Add dedicated name-anchored branches, gated on the
+    # vision/audio flags, scoped to the attention/mlp flags, and -- when an explicit
+    # target_modules list is given -- intersected with it. The branches are anchored
+    # to audio_tower / embed_vision / embed_audio / vision_embedder name segments
+    # that exist only on Gemma 4 / Gemma 3N, and each is appended only if it
+    # re.fullmatch-es a Linear in THIS model (matching PEFT's own matcher), so for
+    # every other architecture the regex is byte-identical. Leading ".*?"; no
+    # trailing ".*?" (a real Linear leaf terminates the match); "(?:\.linear)?" also
+    # covers Gemma4ClippableLinear ".linear" children.
+    def _scoped(leaves):
+        # Honour an explicit target_modules list when one was provided.
+        if target_modules is not None:
+            return [x for x in leaves if x in only_linear_modules]
+        return leaves
+
     candidate_branches = []
     if finetune_audio_layers:
-        # Exact Linear leaf names of the Gemma 4 / Gemma 3N audio conformer
-        # (verified from the checkpoint tensor names). conv / *norm leaves are not
-        # nn.Linear so they are never candidates and need no exclusion here.
-        audio_leaf_names = [
-            "q_proj", "k_proj", "v_proj", "relative_k_proj", "pos_proj",
-            "post", "output_proj", "ffw_layer_1", "ffw_layer_2",
-            "linear_start", "linear_end", "input_proj_linear",
-        ]
-        audio_leaf_re = r"(?:" + "|".join(re.escape(x) for x in audio_leaf_names) + r")"
-        candidate_branches.append(r"(?:.*?\baudio_tower\..*?" + audio_leaf_re + r"(?:\.linear)?)")
-        candidate_branches.append(r"(?:.*?\bembed_audio\.embedding_projection(?:\.linear)?)")
+        # conv / *norm leaves are not nn.Linear so they are never candidates.
+        audio_leaves = ["linear_start", "linear_end", "input_proj_linear", "output_proj"]
+        if finetune_attention_modules:
+            audio_leaves += ["q_proj", "k_proj", "v_proj", "relative_k_proj", "pos_proj", "post"]
+        if finetune_mlp_modules:
+            audio_leaves += ["ffw_layer_1", "ffw_layer_2"]
+        audio_leaves = _scoped(audio_leaves)
+        if audio_leaves:
+            audio_leaf_re = r"(?:" + "|".join(re.escape(x) for x in audio_leaves) + r")"
+            candidate_branches.append(r"(?:.*?\baudio_tower\..*?" + audio_leaf_re + r"(?:\.linear)?)")
+        if _scoped(["embedding_projection"]):
+            candidate_branches.append(r"(?:.*?\bembed_audio\.embedding_projection(?:\.linear)?)")
     if finetune_vision_layers:
-        candidate_branches.append(
-            r"(?:.*?\b(?:embed_vision\.embedding_projection"
-            r"|vision_embedder\.patch_dense"
-            r"|vision_tower\.patch_embedder\.input_proj)(?:\.linear)?)"
-        )
+        vision_embed = []
+        if _scoped(["embedding_projection"]): vision_embed.append(r"embed_vision\.embedding_projection")
+        if _scoped(["patch_dense"]):          vision_embed.append(r"vision_embedder\.patch_dense")
+        if _scoped(["input_proj"]):           vision_embed.append(r"vision_tower\.patch_embedder\.input_proj")
+        if vision_embed:
+            candidate_branches.append(r"(?:.*?\b(?:" + "|".join(vision_embed) + r")(?:\.linear)?)")
     extra_branches = [
         branch for branch in candidate_branches
-        if any(re.search(branch, name, flags = re.DOTALL) for name in linear_modules)
+        if any(re.fullmatch(branch, name, flags = re.DOTALL) for name in linear_modules)
     ]
     if extra_branches:
         regex_matcher = r"(?:" + regex_matcher + r")|" + "|".join(extra_branches)
+    pass
+
+    # Fallback only when a vision/language model-part was requested but neither the
+    # base matcher nor the branches above matched anything (e.g. a VLM whose vision
+    # modules are not tagged with vision keywords): drop the model-part requirement.
+    # Never broaden for audio-only (regex_model_parts == ""), which would otherwise
+    # pull in the whole language stack.
+    if regex_model_parts != "":
+        check = any(re.search(regex_matcher, name, flags = re.DOTALL) for name in linear_modules)
+        if not check:
+            regex_matcher = \
+                r".*?(?:" + regex_components + \
+                r").*?"   + match_linear_modules
     pass
 
     # Final check to confirm if matches exist

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -57,6 +57,7 @@ def get_peft_regex(
     finetune_language_layers   : bool = True,
     finetune_attention_modules : bool = True,
     finetune_mlp_modules       : bool = True,
+    finetune_audio_layers      : bool = False,
     target_modules             : List[str] = None,
     vision_tags                : List[str] = ["vision", "image", "visual", "patch",],
     language_tags              : List[str] = ["language", "text",],
@@ -67,9 +68,9 @@ def get_peft_regex(
     Create a regex pattern to apply LoRA to only select layers of a model.
     """
     # All Unsloth Zoo code licensed under LGPLv3
-    if not finetune_vision_layers and not finetune_language_layers:
+    if not finetune_vision_layers and not finetune_language_layers and not finetune_audio_layers:
         raise RuntimeError(
-            "Unsloth: No layers to finetune - please select to finetune the vision and/or the language layers!"
+            "Unsloth: No layers to finetune - please select to finetune the vision, language and/or audio layers!"
         )
     if not finetune_attention_modules and not finetune_mlp_modules:
         raise RuntimeError(
@@ -122,24 +123,71 @@ def get_peft_regex(
     # "...attn.proj_drop" (a Dropout) match ("proj" + ".*?" eating "_drop") -> "Target module
     # Dropout is not supported". LoRA targets are leaf Linears whose names ARE the group entries,
     # so ending at the group keeps every real target and drops same-prefix non-linear modules.
-    regex_matcher = \
-        r".*?(?:"  + regex_model_parts + \
-        r").*?(?:" + regex_components + \
-        r").*?"    + match_linear_modules
+    if regex_model_parts == "":
+        # No vision/language model-part selected (e.g. audio-only finetuning):
+        # the standard matcher would degenerate into matching every attention/mlp
+        # leaf in the model, so make the base inert and rely solely on the
+        # dedicated audio branches added below.
+        regex_matcher = r"(?!x)x"  # never matches
+    else:
+        regex_matcher = \
+            r".*?(?:"  + regex_model_parts + \
+            r").*?(?:" + regex_components + \
+            r").*?"    + match_linear_modules
 
-    # Also account for model.layers.0.self_attn/mlp type modules like Qwen
-    if finetune_language_layers:
-        regex_matcher = r"(?:" + regex_matcher + \
-        r")|(?:\bmodel\.layers\.[\d]{1,}\.(?:" + regex_components + \
-        r")\.(?:" + match_linear_modules + r"))"
+        # Also account for model.layers.0.self_attn/mlp type modules like Qwen
+        if finetune_language_layers:
+            regex_matcher = r"(?:" + regex_matcher + \
+            r")|(?:\bmodel\.layers\.[\d]{1,}\.(?:" + regex_components + \
+            r")\.(?:" + match_linear_modules + r"))"
+        pass
+
+        # Check if regex is wrong since model does not have vision parts
+        check = any(re.search(regex_matcher, name, flags = re.DOTALL) for name in linear_modules)
+        if not check:
+            regex_matcher = \
+                r".*?(?:" + regex_components + \
+                r").*?"   + match_linear_modules
+        pass
     pass
 
-    # Check if regex is wrong since model does not have vision parts
-    check = any(re.search(regex_matcher, name, flags = re.DOTALL) for name in linear_modules)
-    if not check:
-        regex_matcher = \
-            r".*?(?:" + regex_components + \
-            r").*?"   + match_linear_modules
+    # Gemma 4 / Gemma 3N keep the visual/audio path in flat embedder Linears
+    # (embed_vision.embedding_projection, embed_audio.embedding_projection,
+    # vision_embedder.patch_dense, vision_tower.patch_embedder.input_proj) and a
+    # conformer audio_tower whose ffw_layer_* / lconv1d.linear_* / attention.post
+    # leaves carry no attn/mlp component token. The standard matcher above can
+    # never select them, so add dedicated name-anchored branches. Each branch is
+    # only appended if it actually matches a Linear in THIS model, so for every
+    # other architecture the regex is byte-identical (the branches are anchored to
+    # audio_tower / embed_vision / embed_audio / vision_embedder name segments that
+    # exist only on Gemma 4 / Gemma 3N). Leading ".*?" for PEFT's re.fullmatch; no
+    # trailing ".*?" (a real Linear leaf must terminate the match); "(?:\.linear)?"
+    # also covers Gemma4ClippableLinear ".linear" children.
+    candidate_branches = []
+    if finetune_audio_layers:
+        # Exact Linear leaf names of the Gemma 4 / Gemma 3N audio conformer
+        # (verified from the checkpoint tensor names). conv / *norm leaves are not
+        # nn.Linear so they are never candidates and need no exclusion here.
+        audio_leaf_names = [
+            "q_proj", "k_proj", "v_proj", "relative_k_proj", "pos_proj",
+            "post", "output_proj", "ffw_layer_1", "ffw_layer_2",
+            "linear_start", "linear_end", "input_proj_linear",
+        ]
+        audio_leaf_re = r"(?:" + "|".join(re.escape(x) for x in audio_leaf_names) + r")"
+        candidate_branches.append(r"(?:.*?\baudio_tower\..*?" + audio_leaf_re + r"(?:\.linear)?)")
+        candidate_branches.append(r"(?:.*?\bembed_audio\.embedding_projection(?:\.linear)?)")
+    if finetune_vision_layers:
+        candidate_branches.append(
+            r"(?:.*?\b(?:embed_vision\.embedding_projection"
+            r"|vision_embedder\.patch_dense"
+            r"|vision_tower\.patch_embedder\.input_proj)(?:\.linear)?)"
+        )
+    extra_branches = [
+        branch for branch in candidate_branches
+        if any(re.search(branch, name, flags = re.DOTALL) for name in linear_modules)
+    ]
+    if extra_branches:
+        regex_matcher = r"(?:" + regex_matcher + r")|" + "|".join(extra_branches)
     pass
 
     # Final check to confirm if matches exist

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -58,11 +58,11 @@ def get_peft_regex(
     finetune_attention_modules : bool = True,
     finetune_mlp_modules       : bool = True,
     target_modules             : List[str] = None,
-    finetune_audio_layers      : bool = False,
     vision_tags                : List[str] = ["vision", "image", "visual", "patch",],
     language_tags              : List[str] = ["language", "text",],
     attention_tags             : List[str] = ["self_attn", "attention", "attn", "mixer",],
     mlp_tags                   : List[str] = ["mlp", "feed_forward", "ffn", "dense", "mixer",],
+    finetune_audio_layers      : bool = False,
 ) -> str:
     """
     Create a regex pattern to apply LoRA to only select layers of a model.
@@ -150,25 +150,35 @@ def get_peft_regex(
     # leaves carry no attn/mlp component token, so the standard matcher above can
     # never select them. Add dedicated name-anchored branches, gated on the
     # vision/audio flags, scoped to the attention/mlp flags, and -- when an explicit
-    # target_modules list is given -- intersected with it. The branches are anchored
-    # to audio_tower / embed_vision / embed_audio / vision_embedder name segments
-    # that exist only on Gemma 4 / Gemma 3N, and each is appended only if it
-    # re.fullmatch-es a Linear in THIS model (matching PEFT's own matcher), so for
-    # every other architecture the regex is byte-identical. Leading ".*?"; no
-    # trailing ".*?" (a real Linear leaf terminates the match); "(?:\.linear)?" also
-    # covers Gemma4ClippableLinear ".linear" children.
+    # target_modules list is given -- intersected with it. Each branch is appended
+    # only if it re.fullmatch-es a Linear in THIS model (matching PEFT's own matcher).
+    # Some of these leaf names are NOT Gemma-exclusive: empty_model.py also lists
+    # embed_vision.embedding_projection / vision_tower.patch_embedder.input_proj as
+    # Mistral3 components, so a name-only match could change a non-Gemma target set.
+    # Gate the whole block on the Gemma 4 / Gemma 3N model families (via model_type /
+    # architectures) so every other architecture's regex stays byte-identical.
+    # Leading ".*?"; no trailing ".*?" (a real Linear leaf terminates the match);
+    # "(?:\.linear)?" also covers Gemma4ClippableLinear ".linear" children.
     def _scoped(leaves):
         # Honour an explicit target_modules list when one was provided.
         if target_modules is not None:
             return [x for x in leaves if x in only_linear_modules]
         return leaves
 
+    _config        = getattr(model, "config", None)
+    _model_type    = str(getattr(_config, "model_type", "") or "").lower()
+    _architectures = " ".join(getattr(_config, "architectures", None) or []).lower()
+    _is_gemma_mm   = (
+        "gemma4"  in _model_type or "gemma4"  in _architectures or
+        "gemma3n" in _model_type or "gemma3n" in _architectures
+    )
+
     candidate_branches = []
-    if finetune_audio_layers:
+    if finetune_audio_layers and _is_gemma_mm:
         # conv / *norm leaves are not nn.Linear so they are never candidates. The
         # conformer attention leaves are gated by finetune_attention_modules; the
-        # feed-forward / lightweight-conv / subsample / output projections are gated
-        # by finetune_mlp_modules.
+        # feed-forward / lightweight-conv / subsample / output projections (and the
+        # audio projector) are gated by finetune_mlp_modules.
         audio_leaves = []
         if finetune_attention_modules:
             audio_leaves += ["q_proj", "k_proj", "v_proj", "relative_k_proj", "pos_proj", "post"]
@@ -181,9 +191,13 @@ def get_peft_regex(
             # Require a "." before the leaf so the leaf is a complete path segment --
             # e.g. target_modules=["k_proj"] must not also match "...relative_k_proj".
             candidate_branches.append(r"(?:.*?\baudio_tower\.(?:.*\.)?" + audio_leaf_re + r"(?:\.linear)?)")
-        if _scoped(["embedding_projection"]):
+        # The audio projector is a feed-forward projection -> gate under the mlp flag
+        # so attention-only runs do not pick it up.
+        if finetune_mlp_modules and _scoped(["embedding_projection"]):
             candidate_branches.append(r"(?:.*?\bembed_audio\.embedding_projection(?:\.linear)?)")
-    if finetune_vision_layers:
+    if finetune_vision_layers and finetune_mlp_modules and _is_gemma_mm:
+        # The Gemma vision embedders are flat projection / dense Linears -> like the
+        # audio projector, gate them under the mlp flag (attention-only stays clean).
         vision_embed = []
         if _scoped(["embedding_projection"]): vision_embed.append(r"embed_vision\.embedding_projection")
         if _scoped(["patch_dense"]):          vision_embed.append(r"vision_embedder\.patch_dense")

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -165,16 +165,22 @@ def get_peft_regex(
 
     candidate_branches = []
     if finetune_audio_layers:
-        # conv / *norm leaves are not nn.Linear so they are never candidates.
-        audio_leaves = ["linear_start", "linear_end", "input_proj_linear", "output_proj"]
+        # conv / *norm leaves are not nn.Linear so they are never candidates. The
+        # conformer attention leaves are gated by finetune_attention_modules; the
+        # feed-forward / lightweight-conv / subsample / output projections are gated
+        # by finetune_mlp_modules.
+        audio_leaves = []
         if finetune_attention_modules:
             audio_leaves += ["q_proj", "k_proj", "v_proj", "relative_k_proj", "pos_proj", "post"]
         if finetune_mlp_modules:
-            audio_leaves += ["ffw_layer_1", "ffw_layer_2"]
+            audio_leaves += ["ffw_layer_1", "ffw_layer_2", "linear_start", "linear_end",
+                             "input_proj_linear", "output_proj"]
         audio_leaves = _scoped(audio_leaves)
         if audio_leaves:
             audio_leaf_re = r"(?:" + "|".join(re.escape(x) for x in audio_leaves) + r")"
-            candidate_branches.append(r"(?:.*?\baudio_tower\..*?" + audio_leaf_re + r"(?:\.linear)?)")
+            # Require a "." before the leaf so the leaf is a complete path segment --
+            # e.g. target_modules=["k_proj"] must not also match "...relative_k_proj".
+            candidate_branches.append(r"(?:.*?\baudio_tower\.(?:.*\.)?" + audio_leaf_re + r"(?:\.linear)?)")
         if _scoped(["embedding_projection"]):
             candidate_branches.append(r"(?:.*?\bembed_audio\.embedding_projection(?:\.linear)?)")
     if finetune_vision_layers:

--- a/unsloth_zoo/peft_utils.py
+++ b/unsloth_zoo/peft_utils.py
@@ -173,12 +173,34 @@ def get_peft_regex(
         "gemma3n" in _model_type or "gemma3n" in _architectures
     )
 
+    def _linear_aware_branches(cores):
+        # For each "core" (a regex that, after a leading ".*?", should fullmatch a
+        # real Linear's dotted module name), emit a branch matching ONLY the actual
+        # nn.Linear -- the bare module and/or the ".linear" child of a
+        # Gemma4ClippableLinear wrapper, whichever genuinely exists in this model.
+        # On Gemma 4 a projection appears in named_modules() as BOTH the wrapper
+        # ("...q_proj", not an nn.Linear) and its inner Linear ("...q_proj.linear").
+        # A blanket optional "(?:\.linear)?" would fullmatch the wrapper too, so PEFT
+        # would try to adapt the unsupported wrapper / double-process the inner
+        # Linear. Deciding per-core against linear_modules (which holds the real
+        # Linear names, including the appended ".linear" children) keeps Gemma 3N's
+        # bare leaves and Gemma 4's ".linear" children both correct.
+        out = []
+        for core in cores:
+            if any(re.fullmatch(r".*?" + core + r"\.linear", name, flags = re.DOTALL) for name in linear_modules):
+                out.append(r"(?:.*?" + core + r"\.linear)")
+            if any(re.fullmatch(r".*?" + core, name, flags = re.DOTALL) for name in linear_modules):
+                out.append(r"(?:.*?" + core + r")")
+        return out
+
     candidate_branches = []
     if finetune_audio_layers and _is_gemma_mm:
         # conv / *norm leaves are not nn.Linear so they are never candidates. The
         # conformer attention leaves are gated by finetune_attention_modules; the
         # feed-forward / lightweight-conv / subsample / output projections (and the
-        # audio projector) are gated by finetune_mlp_modules.
+        # audio projector) are gated by finetune_mlp_modules. A "." is required
+        # before each leaf (the "(?:.*\.)?" segment) so e.g. target_modules=["k_proj"]
+        # does not also match "...relative_k_proj".
         audio_leaves = []
         if finetune_attention_modules:
             audio_leaves += ["q_proj", "k_proj", "v_proj", "relative_k_proj", "pos_proj", "post"]
@@ -186,24 +208,21 @@ def get_peft_regex(
             audio_leaves += ["ffw_layer_1", "ffw_layer_2", "linear_start", "linear_end",
                              "input_proj_linear", "output_proj"]
         audio_leaves = _scoped(audio_leaves)
-        if audio_leaves:
-            audio_leaf_re = r"(?:" + "|".join(re.escape(x) for x in audio_leaves) + r")"
-            # Require a "." before the leaf so the leaf is a complete path segment --
-            # e.g. target_modules=["k_proj"] must not also match "...relative_k_proj".
-            candidate_branches.append(r"(?:.*?\baudio_tower\.(?:.*\.)?" + audio_leaf_re + r"(?:\.linear)?)")
-        # The audio projector is a feed-forward projection -> gate under the mlp flag
-        # so attention-only runs do not pick it up.
+        audio_cores = [r"\baudio_tower\.(?:.*\.)?" + re.escape(x) for x in audio_leaves]
+        # The audio projector is a feed-forward projection -> gate under the mlp flag.
         if finetune_mlp_modules and _scoped(["embedding_projection"]):
-            candidate_branches.append(r"(?:.*?\bembed_audio\.embedding_projection(?:\.linear)?)")
+            audio_cores.append(r"\bembed_audio\.embedding_projection")
+        candidate_branches += _linear_aware_branches(audio_cores)
     if finetune_vision_layers and finetune_mlp_modules and _is_gemma_mm:
         # The Gemma vision embedders are flat projection / dense Linears -> like the
         # audio projector, gate them under the mlp flag (attention-only stays clean).
-        vision_embed = []
-        if _scoped(["embedding_projection"]): vision_embed.append(r"embed_vision\.embedding_projection")
-        if _scoped(["patch_dense"]):          vision_embed.append(r"vision_embedder\.patch_dense")
-        if _scoped(["input_proj"]):           vision_embed.append(r"vision_tower\.patch_embedder\.input_proj")
-        if vision_embed:
-            candidate_branches.append(r"(?:.*?\b(?:" + "|".join(vision_embed) + r")(?:\.linear)?)")
+        vision_cores = []
+        if _scoped(["embedding_projection"]): vision_cores.append(r"\bembed_vision\.embedding_projection")
+        if _scoped(["patch_dense"]):          vision_cores.append(r"\bvision_embedder\.patch_dense")
+        if _scoped(["input_proj"]):           vision_cores.append(r"\bvision_tower\.patch_embedder\.input_proj")
+        candidate_branches += _linear_aware_branches(vision_cores)
+    # _linear_aware_branches already only emits branches that fullmatch a real Linear;
+    # re-filter for safety / to mirror PEFT's own re.fullmatch matcher exactly.
     extra_branches = [
         branch for branch in candidate_branches
         if any(re.fullmatch(branch, name, flags = re.DOTALL) for name in linear_modules)


### PR DESCRIPTION
## Summary

`get_peft_regex` builds an ordered matcher: `[vision|language model-part] .*? [self_attn|mlp component] .*? [linear leaf]`. Gemma 4 (`Gemma4ForConditionalGeneration`) and Gemma 3N (`Gemma3nForConditionalGeneration`) keep the visual/audio path in flat embedder Linears and a conformer `audio_tower` whose leaves carry no attention/mlp token, so the matcher can never select them:

- `embed_vision.embedding_projection`, `embed_audio.embedding_projection` (multimodal projectors)
- `vision_embedder.patch_dense`, `vision_tower.patch_embedder.input_proj`
- `audio_tower` conformer: `ffw_layer_1/2`, `lconv1d.linear_start/linear_end`, `attention.post`, `q/k/v_proj`, `relative_k_proj`, `pos_proj`, `input_proj_linear`, `output_proj`

So `finetune_vision_layers=True` never adapts the projector, and no flag at all reaches the audio encoder. This also silently broke the Gemma audio notebooks once explicit `target_modules` lists began routing through the layer-scope filter (their audio leaf names have no model-part tag, so they match nothing).

## Change

- Add `finetune_audio_layers` (default `False`) to `get_peft_regex`.
- Add dedicated name-anchored branches for `audio_tower` (literal leaf list) and the vision/audio embedder projectors. Each branch is appended only when it actually matches a Linear in the model, and ends at the leaf (PEFT uses `re.fullmatch`).
- Fix the no-layers guard so audio-only selection is allowed without the base matcher degenerating into every attention/mlp leaf.

## Backwards compatibility

Because each branch is appended only when it matches a module in the given model, the produced regex is byte-identical for every architecture that lacks these Gemma module-name segments. The audio branch reaches `audio_tower` only when `finetune_audio_layers=True` (default off), so Qwen2-Audio / Qwen2.5-Omni and similar are unchanged unless explicitly opted in.

## Tests

`tests/test_peft_regex_audio.py`:
- byte-identical regex across existing architectures (Llama, Qwen, Qwen2-VL, Llava, Gemma3, Qwen2-Audio, Whisper) with the flag off
- 0 -> N attachment for Gemma 4 E2B/12B and Gemma 3N E4B with the flag on (audio_tower + `embed_audio.embedding_projection`; the vision flag attaches `embed_vision.embedding_projection`)
- conv / norm modules never matched; audio-only does not leak into the language stack

Verified against the real Gemma 3N E4B module tree (meta device): audio off matches 245 language Linears and 0 audio; audio on adds 133 `audio_tower` Linears plus the `embed_audio.embedding_projection` projector, language set unchanged, no conv/norm matched.

## Notes

- Pairs with the unsloth PR threading `finetune_audio_layers` through `FastBaseModel.get_peft_model`.
- Composes with #798 (`mixer` tag) and #807 (drop trailing `.*?`).