### PR TITLE
Generalize pad_token repair into a shared module

### DIFF
--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -126,3 +126,13 @@ def test_vision_token_never_selected_for_text_model():
     tok = _qwen3_text()
     fix_pad_token(tok)
     assert tok.pad_token not in VISION_RESERVED_TOKENS
+
+
+def test_vision_model_keeps_its_vision_pad():
+    # A real multimodal model (model_type without "vl", e.g. llava) must be
+    # detected as vision so its vision pad_token is left untouched.
+    tok = _qwen3_text()  # pad_token = "<|vision_pad|>"
+    cfg = type("Cfg", (), {"model_type": "llava"})()
+    res = fix_pad_token(tok, model_config = cfg)
+    assert res["changed"] is False
+    assert tok.pad_token == "<|vision_pad|>"

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -2,9 +2,23 @@
 # Copyright 2023-present the Unsloth team. All rights reserved.
 """Offline tests for unsloth_zoo.pad_token.fix_pad_token (no network, no torch)."""
 
+import importlib.util
+import os
+
 import pytest
 
-from unsloth_zoo.pad_token import fix_pad_token, VISION_RESERVED_TOKENS
+# Load pad_token.py directly from its file so the test stays truly offline: it
+# does not run unsloth_zoo/__init__.py (which pulls the full stack and can fail
+# without the companion unsloth package installed).
+_PAD_TOKEN_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "unsloth_zoo", "pad_token.py",
+)
+_spec = importlib.util.spec_from_file_location("_unsloth_pad_token_offline", _PAD_TOKEN_PATH)
+_pad_token = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pad_token)
+fix_pad_token = _pad_token.fix_pad_token
+VISION_RESERVED_TOKENS = _pad_token.VISION_RESERVED_TOKENS
 
 
 class FakeTokenizer:
@@ -159,3 +173,32 @@ def test_vision_model_keeps_its_vision_pad():
     res = fix_pad_token(tok, model_config = cfg)
     assert res["changed"] is False
     assert tok.pad_token == "<|vision_pad|>"
+
+
+def test_unk_token_fallback_when_no_reserved():
+    # Llama-2 style: no pad and no reserved-token family, but <unk> exists, so
+    # reuse it rather than hard-failing (matches the original patch_tokenizer).
+    tok = FakeTokenizer({"<s>": 1, "</s>": 2, "<unk>": 0},
+                        pad_token = None, eos_token = "</s>")
+    tok.unk_token = "<unk>"
+    res = fix_pad_token(tok, allow_add = False)
+    assert res["changed"] and tok.pad_token == "<unk>"
+
+
+def test_vision_model_reuses_vision_pad_when_only_option():
+    # Vision model with pad == eos and only a modality pad available -> reuse it
+    # instead of adding/raising.
+    tok = FakeTokenizer({"<|im_end|>": 1, "<|vision_pad|>": 2},
+                        pad_token = "<|im_end|>", eos_token = "<|im_end|>")
+    cfg = type("Cfg", (), {"model_type": "qwen2_vl"})()
+    res = fix_pad_token(tok, model_config = cfg)
+    assert res["changed"] and tok.pad_token == "<|vision_pad|>"
+
+
+def test_audio_pad_not_denylisted_for_audio_model():
+    # <|audio_pad|> is not a denied token (we cannot detect audio-only models),
+    # so an audio tokenizer keeping it as pad is a no-op.
+    tok = FakeTokenizer({"<|im_end|>": 1, "<|audio_pad|>": 2},
+                        pad_token = "<|audio_pad|>", eos_token = "<|im_end|>")
+    assert fix_pad_token(tok)["changed"] is False
+    assert "<|audio_pad|>" not in VISION_RESERVED_TOKENS

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -128,6 +128,29 @@ def test_vision_token_never_selected_for_text_model():
     assert tok.pad_token not in VISION_RESERVED_TOKENS
 
 
+def test_out_of_range_pad_is_repicked_when_model_known():
+    # pad looks fine (not eos, not vision) but its id is past the model vocab,
+    # e.g. an earlier model-less swap picked a high-id added token. The
+    # model-aware call must catch it and re-pick an in-range reserved token.
+    vocab = {
+        "<|eot_id|>": 0,                       # eos
+        "<|reserved_special_token_0|>": 100,   # in-range reserved
+        "<pad>": 5000,                         # current pad, beyond vocab_size
+    }
+    tok = FakeTokenizer(vocab, pad_token = "<pad>", eos_token = "<|eot_id|>")
+    cfg = type("Cfg", (), {"vocab_size": 1000})()
+    res = fix_pad_token(tok, model_config = cfg)
+    assert res["reason"] == "out_of_range"
+    assert tok.pad_token == "<|reserved_special_token_0|>"
+
+
+def test_in_range_valid_pad_is_noop_with_vocab_size():
+    tok = FakeTokenizer({"<s>": 1, "</s>": 2, "<pad>": 0},
+                        pad_token = "<pad>", eos_token = "</s>")
+    cfg = type("Cfg", (), {"vocab_size": 1000})()
+    assert fix_pad_token(tok, model_config = cfg)["changed"] is False
+
+
 def test_vision_model_keeps_its_vision_pad():
     # A real multimodal model (model_type without "vl", e.g. llava) must be
     # detected as vision so its vision pad_token is left untouched.

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2023-present the Unsloth team. All rights reserved.
+"""Offline tests for unsloth_zoo.pad_token.fix_pad_token (no network, no torch)."""
+
+import pytest
+
+from unsloth_zoo.pad_token import fix_pad_token, VISION_RESERVED_TOKENS
+
+
+class FakeTokenizer:
+    """Minimal stand-in: vocab is a {token: id} dict; reserved tokens are 'added'."""
+
+    def __init__(self, vocab, pad_token, eos_token, added=None):
+        self._vocab = dict(vocab)
+        self.pad_token = pad_token
+        self.eos_token = eos_token
+        # added_tokens_decoder maps id -> token content (subset treated as "added")
+        added = added if added is not None else list(vocab)
+        self.added_tokens_decoder = {self._vocab[t]: t for t in added if t in self._vocab}
+
+    # ids
+    @property
+    def pad_token_id(self):
+        return self._vocab.get(self.pad_token)
+
+    @property
+    def eos_token_id(self):
+        return self._vocab.get(self.eos_token)
+
+    def get_vocab(self):
+        return dict(self._vocab)
+
+    def __call__(self, text, add_special_tokens=False):
+        # Each known token is a single id; unknown text splits into >1 id.
+        ids = [self._vocab[text]] if text in self._vocab else [0, 1]
+        return type("Enc", (), {"input_ids": ids})()
+
+    def add_special_tokens(self, mapping):
+        tok = mapping["pad_token"]
+        if tok not in self._vocab:
+            self._vocab[tok] = max(self._vocab.values()) + 1
+            self.added_tokens_decoder[self._vocab[tok]] = tok
+        self.pad_token = tok
+
+
+def _qwen3_text():
+    # Qwen3 text tokenizer shipping a vision pad_token (the #3155 bug).
+    vocab = {
+        "<|endoftext|>": 151643, "<|im_start|>": 151644, "<|im_end|>": 151645,
+        "<|vision_pad|>": 151654, "<|image_pad|>": 151655, "<|video_pad|>": 151656,
+    }
+    return FakeTokenizer(vocab, pad_token="<|vision_pad|>", eos_token="<|im_end|>")
+
+
+def test_qwen3_vision_pad_heals_to_endoftext():
+    tok = _qwen3_text()
+    res = fix_pad_token(tok)
+    assert res["changed"] and res["reason"] == "vision_pad"
+    assert tok.pad_token == "<|endoftext|>"          # not a vision token
+    assert tok.pad_token != tok.eos_token
+
+
+def test_valid_distinct_pad_is_noop():
+    # Mistral-style: pad <pad>, eos </s>, distinct -> untouched.
+    tok = FakeTokenizer({"<s>": 1, "</s>": 2, "<pad>": 0, "[control_8]": 10},
+                        pad_token="<pad>", eos_token="</s>")
+    res = fix_pad_token(tok)
+    assert res["changed"] is False and tok.pad_token == "<pad>"
+
+
+def test_llama31_finetune_pad_is_noop():
+    tok = FakeTokenizer({"<|eot_id|>": 128009, "<|finetune_right_pad_id|>": 128004},
+                        pad_token="<|finetune_right_pad_id|>", eos_token="<|eot_id|>")
+    assert fix_pad_token(tok)["changed"] is False
+
+
+def test_pad_equals_eos_picks_distinct_reserved():
+    tok = FakeTokenizer({"</s>": 2, "<pad>": 0}, pad_token="</s>", eos_token="</s>")
+    res = fix_pad_token(tok)
+    assert res["reason"] == "equals_eos" and tok.pad_token == "<pad>"
+    assert tok.pad_token != tok.eos_token
+
+
+def test_missing_pad_picks_reserved():
+    tok = FakeTokenizer({"<|eot_id|>": 1, "<|reserved_special_token_0|>": 5},
+                        pad_token=None, eos_token="<|eot_id|>")
+    res = fix_pad_token(tok)
+    assert res["reason"] == "missing"
+    assert tok.pad_token == "<|reserved_special_token_0|>"
+
+
+def test_allow_add_false_defers_when_nothing_found():
+    # pad==eos and no reserved candidate; tokenizer-only path must not add/raise.
+    tok = FakeTokenizer({"</s>": 2}, pad_token="</s>", eos_token="</s>")
+    res = fix_pad_token(tok, allow_add=False)
+    assert res["changed"] is False and tok.pad_token == "</s>"
+
+
+def test_manual_fallback_raises():
+    tok = FakeTokenizer({"</s>": 2}, pad_token="</s>", eos_token="</s>")
+    with pytest.raises(RuntimeError):
+        fix_pad_token(tok, allow_add=True)
+
+
+# --- bug regressions vs the original reference logic ---
+
+def test_closed_bracket_uses_full_token_not_prefix():
+    # Pixtral <SPECIAL_NNN>: prefix "<SPECIAL_" is open, full token is closed.
+    tok = FakeTokenizer({"</s>": 2, "<SPECIAL_20>": 20, "<SPECIAL_21>": 21},
+                        pad_token="</s>", eos_token="</s>")
+    res = fix_pad_token(tok)
+    assert res["changed"] and tok.pad_token.startswith("<SPECIAL_") and tok.pad_token.endswith(">")
+
+
+def test_zero_token_candidate_does_not_crash():
+    # A reserved entry present but encoding to !=1 id must be skipped, not crash.
+    class Weird(FakeTokenizer):
+        def __call__(self, text, add_special_tokens=False):
+            return type("Enc", (), {"input_ids": []})()  # zero ids for everything
+    tok = Weird({"</s>": 2, "<pad>": 0}, pad_token="</s>", eos_token="</s>")
+    res = fix_pad_token(tok, allow_add=False)   # <pad> rejected (0 ids) -> defer, no IndexError
+    assert res["changed"] is False
+
+
+def test_vision_token_never_selected_for_text_model():
+    tok = _qwen3_text()
+    fix_pad_token(tok)
+    assert tok.pad_token not in VISION_RESERVED_TOKENS

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -62,6 +62,13 @@ VISION_RESERVED_TOKENS = frozenset((
     "<|audio_pad|>",
 ))
 
+# model_type fragments that mark a multimodal model whose vision pad tokens are
+# legitimate (so we must not "heal" them). Kept conservative: each fragment only
+# appears in genuinely multimodal model_types, never in text-only ones.
+_VISION_MODEL_TYPES = (
+    "vl", "vision", "llava", "paligemma", "idefics", "pixtral", "mllama",
+)
+
 _CLOSERS = (">", "|>", "]", ")")
 _MANUAL_PAD_TOKEN = "<｜PAD▁TOKEN｜>"
 
@@ -81,11 +88,13 @@ def _resolve_inner(tokenizer):
 def _infer_vision(tokenizer, inner, model, model_config, is_vision_model):
     if is_vision_model is not None:
         return bool(is_vision_model)
-    if hasattr(tokenizer, "image_processor"):
+    # getattr not hasattr: a processor can carry image_processor = None.
+    if getattr(tokenizer, "image_processor", None) is not None:
         return True
     cfg = model_config if model_config is not None else getattr(model, "config", None)
     model_type = (getattr(cfg, "model_type", "") or "") if cfg is not None else ""
-    return "vl" in model_type.lower()
+    model_type = model_type.lower()
+    return any(fragment in model_type for fragment in _VISION_MODEL_TYPES)
 
 
 def _display_name(model, model_config, inner):
@@ -144,9 +153,11 @@ def _find_reserved_pad(inner, is_vision, eos_token, vocab_size):
         if not matches:
             continue
         # Prefer a closed token (e.g. "<|reserved_special_token_0|>") that is
-        # distinct from eos and encodes to a single in-vocab id.
+        # distinct from eos and encodes to a single in-vocab id. Closed tokens
+        # are a subset of matches, so order them first without duplicating.
         closed = [m for m in matches if m.endswith(_CLOSERS)]
-        for candidate in closed + matches:
+        ordered = closed + [m for m in matches if m not in closed]
+        for candidate in ordered:
             if candidate == eos_token or candidate in VISION_RESERVED_TOKENS:
                 continue
             if _single_token_id(inner, candidate, vocab_size) is not None:
@@ -196,7 +207,8 @@ def fix_pad_token(
             # No model here to resize embeddings; let the model-aware call repair.
             return result
         new_pad = _MANUAL_PAD_TOKEN
-        while new_pad in inner.get_vocab():
+        vocab = inner.get_vocab()
+        while new_pad in vocab:
             new_pad = f"<｜{new_pad}｜>"
         added = True
 
@@ -211,8 +223,9 @@ def fix_pad_token(
                     model.resize_token_embeddings(len(inner))
             except Exception:
                 pass
-        if hasattr(model, "config"):
-            model.config.update({"pad_token_id": inner.pad_token_id})
+        model_cfg = getattr(model, "config", None)
+        if model_cfg is not None:
+            model_cfg.update({"pad_token_id": inner.pad_token_id})
         if getattr(model, "generation_config", None) is not None:
             model.generation_config.update(pad_token_id=inner.pad_token_id)
 

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -54,13 +54,16 @@ POSSIBLE_RESERVED_TOKENS = (
     # "<|endofprompt|>",          # Phi-4 mini; commented out, clashes with GPT-OSS
 )
 
-# Vision/modality tokens that must never be a pad_token on a text-only model.
-VISION_RESERVED_TOKENS = frozenset((
+# Modality pad tokens. On a text-only model these must never be the pad_token
+# (unsloth#4104); on a multimodal model they are valid pad candidates of last
+# resort. Audio pads are intentionally excluded: we cannot reliably detect an
+# audio-only model, so denylisting them would rewrite a legitimate audio pad.
+_MODALITY_PAD_TOKENS = (
     "<|vision_pad|>",
     "<|image_pad|>",
     "<|video_pad|>",
-    "<|audio_pad|>",
-))
+)
+VISION_RESERVED_TOKENS = frozenset(_MODALITY_PAD_TOKENS)
 
 # model_type fragments that mark a multimodal model whose vision pad tokens are
 # legitimate (so we must not "heal" them). Kept conservative: each fragment only
@@ -152,7 +155,10 @@ def _find_reserved_pad(inner, is_vision, eos_token, vocab_size):
     # Newest tokens last; reverse so reserved blocks are scanned high-id first.
     added = [a for a in added if a][::-1]
 
-    for reserved in POSSIBLE_RESERVED_TOKENS:
+    # On a multimodal model, modality pad tokens are valid pads of last resort;
+    # on a text-only model they stay denied (unsloth#4104).
+    families = POSSIBLE_RESERVED_TOKENS + (_MODALITY_PAD_TOKENS if is_vision else ())
+    for reserved in families:
         if not is_vision and reserved in VISION_RESERVED_TOKENS:
             continue
         matches = [a for a in added if a == reserved or a.startswith(reserved)]
@@ -164,10 +170,22 @@ def _find_reserved_pad(inner, is_vision, eos_token, vocab_size):
         closed = [m for m in matches if m.endswith(_CLOSERS)]
         ordered = closed + [m for m in matches if m not in closed]
         for candidate in ordered:
-            if candidate == eos_token or candidate in VISION_RESERVED_TOKENS:
+            if candidate == eos_token or (not is_vision and candidate in VISION_RESERVED_TOKENS):
                 continue
             if _single_token_id(inner, candidate, vocab_size) is not None:
                 return candidate
+    return None
+
+
+def _unk_fallback(inner, is_vision, eos_token, vocab_size):
+    """Last-resort existing-token pad: reuse unk_token (Llama-2 style), or None."""
+    unk = getattr(inner, "unk_token", None)
+    if not unk or unk == eos_token:
+        return None
+    if not is_vision and unk in VISION_RESERVED_TOKENS:
+        return None
+    if _single_token_id(inner, unk, vocab_size) is not None:
+        return unk
     return None
 
 
@@ -206,6 +224,8 @@ def fix_pad_token(
     result["old_pad"] = getattr(inner, "pad_token", None)
 
     new_pad = _find_reserved_pad(inner, is_vision, eos_token, vocab_size)
+    if new_pad is None:
+        new_pad = _unk_fallback(inner, is_vision, eos_token, vocab_size)
     added = False
 
     if new_pad is None:

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This file is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0-only).
+# This program is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along with
+# this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Generic pad_token repair shared by unsloth and unsloth-zoo.
+
+A wrong/missing pad_token breaks training: pad == eos makes the loss ignore real
+pad positions, and a vision pad_token baked into a text-only tokenizer produces
+NaN losses (unsloth#3155, unsloth#4104). `fix_pad_token` heals such tokenizers by
+picking a reserved pad-like token already in the vocab; if none exists it adds one.
+It is a no-op for tokenizers that already have a valid, distinct pad_token.
+"""
+
+__all__ = [
+    "POSSIBLE_RESERVED_TOKENS",
+    "VISION_RESERVED_TOKENS",
+    "fix_pad_token",
+]
+
+# Candidate pad tokens, highest priority first. Entries are matched against each
+# added token by exact-equality OR prefix (families like "<|reserved" cover
+# "<|reserved_special_token_0|>"). A closed candidate (ends with > |> ] )) wins
+# over an open prefix match.
+POSSIBLE_RESERVED_TOKENS = (
+    "<|finetune_right_pad_id|>",  # Llama-3.1
+    "<|finetune_right_pad|>",     # Llama-4
+    "<pad>",                      # Mistral Nemo, Gemma
+    "[PAD]",                      # Kimi K2
+    "<PAD>",                      # Cohere
+    "<|endoftext|>",              # Qwen / GPT text pad (upstream Qwen pads with this)
+    "<fim_pad>",                  # Granite
+    "<｜▁pad▁｜>",                # DeepSeek R1
+    "[MASK]",                     # GLM
+    "<|reserved",                 # Llama-3
+    "<|placeholder",              # Phi-3
+    "<|dummy_",                   # Phi-4
+    "[control",                   # Mistral type models
+    "|<EXTRA_TOKENS_",            # Molmo
+    "<SPECIAL_",                  # Pixtral
+    "<unused",                    # PaliGemma
+    "<|EOT|>",                    # DeepSeek Prover
+    "<|reject-unknown|>",         # Red Note
+    # "<|endofprompt|>",          # Phi-4 mini; commented out, clashes with GPT-OSS
+)
+
+# Vision/modality tokens that must never be a pad_token on a text-only model.
+VISION_RESERVED_TOKENS = frozenset((
+    "<|vision_pad|>",
+    "<|image_pad|>",
+    "<|video_pad|>",
+    "<|audio_pad|>",
+))
+
+_CLOSERS = (">", "|>", "]", ")")
+_MANUAL_PAD_TOKEN = "<｜PAD▁TOKEN｜>"
+
+
+def _token_content(token):
+    # AddedToken on transformers 5.x exposes .content; slow tokenizers use str.
+    content = getattr(token, "content", None)
+    return content if isinstance(content, str) else str(token)
+
+
+def _resolve_inner(tokenizer):
+    # Processors wrap the real tokenizer under .tokenizer.
+    inner = getattr(tokenizer, "tokenizer", None)
+    return inner if inner is not None else tokenizer
+
+
+def _infer_vision(tokenizer, inner, model, model_config, is_vision_model):
+    if is_vision_model is not None:
+        return bool(is_vision_model)
+    if hasattr(tokenizer, "image_processor"):
+        return True
+    cfg = model_config if model_config is not None else getattr(model, "config", None)
+    model_type = (getattr(cfg, "model_type", "") or "") if cfg is not None else ""
+    return "vl" in model_type.lower()
+
+
+def _display_name(model, model_config, inner):
+    for source in (model_config, getattr(model, "config", None), inner):
+        name = getattr(source, "_name_or_path", None) or getattr(source, "name_or_path", None)
+        if name:
+            return name
+    return "Model"
+
+
+def _classify_bad_pad(inner, is_vision):
+    """Return a reason string if the current pad_token is bad, else None."""
+    if not hasattr(inner, "pad_token"):
+        return None
+    pad = inner.pad_token
+    if pad is None:
+        return "missing"
+    eos = getattr(inner, "eos_token", None)
+    if eos is not None and pad == eos:
+        return "equals_eos"
+    pad_id, eos_id = getattr(inner, "pad_token_id", None), getattr(inner, "eos_token_id", None)
+    if pad_id is not None and eos_id is not None and pad_id == eos_id:
+        return "equals_eos"
+    if not is_vision and pad in VISION_RESERVED_TOKENS:
+        return "vision_pad"
+    return None
+
+
+def _single_token_id(inner, token, vocab_size):
+    """Return token's id if it encodes to exactly one in-vocab id, else None."""
+    try:
+        ids = inner(token, add_special_tokens=False).input_ids
+    except Exception:
+        return None
+    if len(ids) != 1:
+        return None
+    token_id = ids[0]
+    if vocab_size is not None and token_id >= vocab_size:
+        return None
+    return token_id
+
+
+def _find_reserved_pad(inner, is_vision, eos_token, vocab_size):
+    """Pick the best reserved pad-like token already in the vocab, or None."""
+    try:
+        added = [_token_content(t) for t in inner.added_tokens_decoder.values()]
+    except Exception:
+        return None
+    # Newest tokens last; reverse so reserved blocks are scanned high-id first.
+    added = [a for a in added if a][::-1]
+
+    for reserved in POSSIBLE_RESERVED_TOKENS:
+        if not is_vision and reserved in VISION_RESERVED_TOKENS:
+            continue
+        matches = [a for a in added if a == reserved or a.startswith(reserved)]
+        if not matches:
+            continue
+        # Prefer a closed token (e.g. "<|reserved_special_token_0|>") that is
+        # distinct from eos and encodes to a single in-vocab id.
+        closed = [m for m in matches if m.endswith(_CLOSERS)]
+        for candidate in closed + matches:
+            if candidate == eos_token or candidate in VISION_RESERVED_TOKENS:
+                continue
+            if _single_token_id(inner, candidate, vocab_size) is not None:
+                return candidate
+    return None
+
+
+def fix_pad_token(
+    tokenizer,
+    model=None,
+    model_config=None,
+    *,
+    is_vision_model=None,
+    allow_add=True,
+):
+    """Heal a bad/missing pad_token in place.
+
+    Returns a result dict: {changed, reason, old_pad, new_pad, added}. No-op (and
+    `changed=False`) when the pad_token is already valid and distinct from eos.
+    With `allow_add=False` (tokenizer-only callers with no model to resize) a brand
+    new pad token is never added; repair is deferred to the model-aware call.
+    """
+    result = {"changed": False, "reason": None, "old_pad": None, "new_pad": None, "added": False}
+    if tokenizer is None:
+        return result
+
+    inner = _resolve_inner(tokenizer)
+    if inner is None:
+        return result
+
+    is_vision = _infer_vision(tokenizer, inner, model, model_config, is_vision_model)
+    reason = _classify_bad_pad(inner, is_vision)
+    if reason is None:
+        return result
+    result["reason"] = reason
+    result["old_pad"] = getattr(inner, "pad_token", None)
+
+    cfg = model_config if model_config is not None else getattr(model, "config", None)
+    vocab_size = getattr(cfg, "vocab_size", None)
+    eos_token = getattr(inner, "eos_token", None)
+
+    new_pad = _find_reserved_pad(inner, is_vision, eos_token, vocab_size)
+    added = False
+
+    if new_pad is None:
+        if not allow_add:
+            # No model here to resize embeddings; let the model-aware call repair.
+            return result
+        new_pad = _MANUAL_PAD_TOKEN
+        while new_pad in inner.get_vocab():
+            new_pad = f"<｜{new_pad}｜>"
+        added = True
+
+    inner.add_special_tokens({"pad_token": new_pad})
+    inner.pad_token = new_pad
+    result.update(changed=True, new_pad=new_pad, added=added)
+
+    if model is not None:
+        if added and hasattr(model, "resize_token_embeddings"):
+            try:
+                if model.get_input_embeddings().weight.shape[0] < len(inner):
+                    model.resize_token_embeddings(len(inner))
+            except Exception:
+                pass
+        if hasattr(model, "config"):
+            model.config.update({"pad_token_id": inner.pad_token_id})
+        if getattr(model, "generation_config", None) is not None:
+            model.generation_config.update(pad_token_id=inner.pad_token_id)
+
+    name = _display_name(model, model_config, inner)
+    verb = "has no pad_token" if reason == "missing" else f"had a bad pad_token ({result['old_pad']})"
+    print(f"Unsloth: {name} {verb}. Using pad_token = {new_pad}.")
+
+    if added:
+        raise RuntimeError(
+            f"Unsloth: Could not find a valid pad token for {name} - please inspect "
+            f"the tokenizer. A temporary {new_pad!r} was added."
+        )
+    return result

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -105,7 +105,7 @@ def _display_name(model, model_config, inner):
     return "Model"
 
 
-def _classify_bad_pad(inner, is_vision):
+def _classify_bad_pad(inner, is_vision, vocab_size):
     """Return a reason string if the current pad_token is bad, else None."""
     if not hasattr(inner, "pad_token"):
         return None
@@ -120,6 +120,12 @@ def _classify_bad_pad(inner, is_vision):
         return "equals_eos"
     if not is_vision and pad in VISION_RESERVED_TOKENS:
         return "vision_pad"
+    # A pad whose id is past the model's embeddings indexes out of range at
+    # runtime. This catches a pad picked by an earlier model-less call (e.g.
+    # load_correct_tokenizer) that turned out to be beyond the vocab; only
+    # checkable once a model/config gives us vocab_size.
+    if vocab_size is not None and pad_id is not None and pad_id >= vocab_size:
+        return "out_of_range"
     return None
 
 
@@ -188,16 +194,16 @@ def fix_pad_token(
     if inner is None:
         return result
 
+    cfg = model_config if model_config is not None else getattr(model, "config", None)
+    vocab_size = getattr(cfg, "vocab_size", None)
+    eos_token = getattr(inner, "eos_token", None)
+
     is_vision = _infer_vision(tokenizer, inner, model, model_config, is_vision_model)
-    reason = _classify_bad_pad(inner, is_vision)
+    reason = _classify_bad_pad(inner, is_vision, vocab_size)
     if reason is None:
         return result
     result["reason"] = reason
     result["old_pad"] = getattr(inner, "pad_token", None)
-
-    cfg = model_config if model_config is not None else getattr(model, "config", None)
-    vocab_size = getattr(cfg, "vocab_size", None)
-    eos_token = getattr(inner, "eos_token", None)
 
     new_pad = _find_reserved_pad(inner, is_vision, eos_token, vocab_size)
     added = False

--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -504,9 +504,10 @@ def patch_tokenizer(model, tokenizer):
     # may still be missing pad_token_id - mirror it across.
     if not result["changed"] and model is not None and model_config is not None:
         if getattr(model_config, "pad_token_id", None) is None:
-            model.config.update({"pad_token_id" : tokenizer.pad_token_id})
+            pad_token_id = getattr(tokenizer, "pad_token_id", None)
+            model.config.update({"pad_token_id" : pad_token_id})
             if getattr(model, "generation_config", None) is not None:
-                model.generation_config.update(pad_token_id = tokenizer.pad_token_id)
+                model.generation_config.update(pad_token_id = pad_token_id)
     pass
 
     if model is not None:

--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -457,28 +457,13 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
 pass
 
 
-POSSIBLE_RESERVED_TOKENS = (
-    "<|finetune_right_pad_id|>", # Llama-3.1
-    "<pad>",                     # Mistral Nemo
-    "<|vision_pad|>",            # Qwen 2.5
-    "<|image_pad|>",             # Qwen 2.5
-    "<|video_pad|>",             # Qwen 2.5
-    "<|reserved",                # Llama-3
-    "<|placeholder",             # Phi-3
-    "[control",                  # Mistral type models
-    "|<EXTRA_TOKENS_",           # Molmo
-    "<SPECIAL_",                 # Pixtral
-    "<unused",                   # PaliGemma
+# Pad-token repair lives in the shared pad_token module (single source of truth
+# for unsloth + unsloth-zoo). Re-exported here for backwards compatibility.
+from .pad_token import (
+    fix_pad_token,
+    POSSIBLE_RESERVED_TOKENS,
+    VISION_RESERVED_TOKENS,
 )
-
-# Vision tokens that must not be a pad_token for text-only models. Qwen3 text
-# models share Qwen3-VL's vocab and include these, but using them as pad_token
-# is wrong. See https://github.com/unslothai/unsloth/issues/4104
-VISION_RESERVED_TOKENS = frozenset((
-    "<|vision_pad|>",
-    "<|image_pad|>",
-    "<|video_pad|>",
-))
 
 @torch.inference_mode
 def patch_tokenizer(model, tokenizer):
@@ -494,9 +479,6 @@ def patch_tokenizer(model, tokenizer):
     if tokenizer is None:
         return model, tokenizer
 
-    joiner = "\1\0=+=\0\1"
-    number_repetitions = 3 - 1 # Number of reserved tokens needed
-
     original_tokenizer = tokenizer
 
     # Auto-apply chat template when a conversation is passed instead of a string
@@ -510,123 +492,21 @@ def patch_tokenizer(model, tokenizer):
             return model, original_tokenizer
         tokenizer = inner
 
-    # Text-only models must not use vision tokens (e.g. <|vision_pad|>) as
-    # pad_token. See https://github.com/unslothai/unsloth/issues/4104
-    is_vision_model = hasattr(original_tokenizer, "image_processor")
-    if not is_vision_model and model is not None and hasattr(model, "config"):
-        model_type = getattr(model.config, "model_type", "") or ""
-        is_vision_model = "vl" in model_type.lower()
-    pass
+    # Heal a bad/missing pad_token via the shared single source of truth: it picks
+    # a reserved pad-like token already in the vocab (text-only models never reuse
+    # a vision token), or adds one and raises if none exists, and stamps
+    # model.config / generation_config pad_token_id when it changes.
+    # Fixes https://github.com/unslothai/unsloth/issues/5 and #4104.
+    model_config = getattr(model, "config", None)
+    result = fix_pad_token(original_tokenizer, model = model, model_config = model_config)
 
-    bad_pad_token = False
-    if hasattr(tokenizer, "pad_token") and tokenizer.pad_token is not None:
-        # pad_token == eos_token makes the loss ignore it
-        bad_pad_token = tokenizer.eos_token == tokenizer.pad_token
-        # Also fix text-only models with a vision token baked in as pad_token
-        if not bad_pad_token and not is_vision_model:
-            bad_pad_token = tokenizer.pad_token in VISION_RESERVED_TOKENS
-    elif hasattr(tokenizer, "pad_token") and tokenizer.pad_token is None:
-        bad_pad_token = True
-    else:
-        bad_pad_token = False
-    pass
-
-    if bad_pad_token:
-        # Find a better pad token
-        added_tokens = [str(x) for x in tokenizer.added_tokens_decoder.values()]
-        all_added_tokens = joiner.join(added_tokens[::-1])
-        all_added_tokens += joiner
-
-        final_pad_token  = None
-        final_good_match = False
-
-        for possible_reserved_token in POSSIBLE_RESERVED_TOKENS:
-            # Skip vision-specific tokens for text-only models
-            if not is_vision_model and possible_reserved_token in VISION_RESERVED_TOKENS:
-                continue
-            possible_reserved_token = re.escape(possible_reserved_token)
-            found = re.finditer(f"{possible_reserved_token}", all_added_tokens)
-            first_match = None
-            good_match  = False
-            for j, x in enumerate(found):
-                if j == 0: first_match = x
-                if j >= number_repetitions:
-                    good_match = True
-                    break
-                pass
-            pass
-
-            if first_match is None: continue
-
-            # If it ends with |> or > etc, then set it as a good pad token!
-            start = first_match.span(0)[0]
-            possible_pad_token = first_match.group(0)
-            end = all_added_tokens.find(joiner, start)
-            first_match = all_added_tokens[start:end]
-
-            if first_match is not None:
-                good_match = possible_pad_token.endswith((">", "|>", "]", ")"))
-            pass
-            possible_pad_token = first_match
-
-            # Replace current pad token if another exact match is found
-            if not final_good_match and good_match:
-                final_good_match = True
-                final_pad_token = possible_pad_token
-                break
-            else:
-                final_good_match = False
-                final_pad_token = possible_pad_token
-            pass
-        pass
-        possible_pad_token = final_pad_token
-
-        # Try unk_token
-        if possible_pad_token is None and hasattr(tokenizer, "unk_token"):
-            possible_pad_token = tokenizer.unk_token
-        pass
-
-        # Check pad token's id must be less than vocab size
-        if possible_pad_token is not None:
-            check_pad_token = tokenizer(possible_pad_token, add_special_tokens = False).input_ids
-            if len(check_pad_token) != 1:
-                possible_pad_token = None
-
-            if model is not None and \
-                hasattr(model.config, "vocab_size") and \
-                check_pad_token[0] >= model.config.vocab_size:
-
-                possible_pad_token = None
-        pass
-
-        if possible_pad_token is None:
-            # Failure to find a good replacement!! We shall manually add one!
-            new_pad_token = "<|PAD_TOKEN|>"
-            while new_pad_token in tokenizer.get_vocab():
-                new_pad_token = f"<{new_pad_token}>"
-            pass
-            possible_pad_token = new_pad_token
-        pass
-
-        name = model.config._name_or_path if model is not None else "Model"
-        print(
-            f"{name} does not have a padding token! Will use pad_token = {possible_pad_token}."
-        )
-        
-        # Edit pad_token
-        tokenizer.add_special_tokens({"pad_token" : possible_pad_token})
-        tokenizer.pad_token = possible_pad_token
-        if model is not None:
+    # No-op case: tokenizer already had a valid pad_token, but the model config
+    # may still be missing pad_token_id - mirror it across.
+    if not result["changed"] and model is not None and model_config is not None:
+        if getattr(model_config, "pad_token_id", None) is None:
             model.config.update({"pad_token_id" : tokenizer.pad_token_id})
             if getattr(model, "generation_config", None) is not None:
                 model.generation_config.update(pad_token_id = tokenizer.pad_token_id)
-    else:
-        if model is not None:
-            if getattr(model.config, "pad_token_id", None) is None:
-                model.config.update({"pad_token_id" : tokenizer.pad_token_id})
-                if getattr(model, "generation_config", None) is not None:
-                    model.generation_config.update(pad_token_id = tokenizer.pad_token_id)
-        pass
     pass
 
     if model is not None:


### PR DESCRIPTION
## What

Generalizes the `pad_token` repair in `patch_tokenizer` into a shared single source of truth, `unsloth_zoo/pad_token.py` (`fix_pad_token`), so the same logic can back the equivalent fix in unsloth.

## Why

The previous heal was an inline regex scan over a delimiter-joined string of `added_tokens_decoder`. It worked for the common cases but had a few sharp edges:

- The closed-bracket grade (`endswith(">", "|>", "]", ")")`) ran on the matched prefix (e.g. `<SPECIAL_`) rather than the resolved full token (e.g. `<SPECIAL_20>`), so prefix families were mis-graded.
- `check_pad_token[0]` was indexed even after the code decided the candidate was not a single token, which can `IndexError` on a zero-token candidate.
- The model name used in the log was computed twice and reset to `"Model"` when only one of `model` / `model_config` was present.

## What changed

- New `unsloth_zoo/pad_token.py` (AGPL-3.0) with `fix_pad_token(tokenizer, model=None, model_config=None, *, is_vision_model=None, allow_add=True)`. It scans `added_tokens_decoder` token by token, keeps the vision-token denylist for text-only models (issue #4104), prefers a closed reserved token that encodes to exactly one in-vocab id, and only adds a brand new `<｜PAD▁TOKEN｜>` (then raises `RuntimeError`) when nothing suitable exists.
- `patch_tokenizer` now delegates to `fix_pad_token` and keeps the existing `model.config` / `generation_config` `pad_token_id` stamping and the `max_length` update. `POSSIBLE_RESERVED_TOKENS` / `VISION_RESERVED_TOKENS` are re-exported from the new module for backwards compatibility.
- The reserved-token list is expanded (Llama-4, Kimi `[PAD]`, Cohere `<PAD>`, GLM `[MASK]`, Granite `<fim_pad>`, DeepSeek `<｜▁pad▁｜>` / `<|EOT|>`, Phi-4 `<|dummy_`, Qwen `<|endoftext|>`, etc.). `<|endofprompt|>` is left commented out since it clashes with GPT-OSS.

## Behavior

- No-op when the tokenizer already has a valid pad token distinct from eos (verified against `unsloth/Mistral-Medium-3.5-128B`, which ships a valid `<pad>`).
- Heals a text-only Qwen3 / Qwen2.5 tokenizer that ships a vision pad token to `<|endoftext|>` (never a vision token).
- Idempotent on a second call.

## Tests

`tests/test_pad_token.py` (offline, no network, no torch): heal, no-op, `pad == eos`, missing pad, `allow_add=False` defer, manual fallback raises, the closed-bracket and zero-token regressions, and the vision-token-never-selected invariant.

Companion unsloth change (swapping the narrow `_fix_vision_pad_token` for this shared call, behind a guarded import) follows in unsloth#6524.
