### PR TITLE
fix(mlx): support text custom collators and raw passthrough

### DIFF
--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -58,6 +58,7 @@ def test_mlx_training_config_is_dataclass_with_all_fields():
         "logging_steps",
         "output_dir",
         "max_seq_length",
+        "dataset_kwargs",
         "use_cce",
         "compile",
         "gradient_checkpointing",
@@ -896,6 +897,64 @@ def test_custom_text_collator_preserves_default_order(seed):
     assert observed == expected
 
 
+def test_custom_text_collator_skip_prepare_forwards_raw_rows():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    seen = []
+
+    def collator(examples):
+        seen.append([example["text"] for example in examples])
+        return {
+            "input_ids": torch.tensor([[1, 2, 3], [4, 5, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1], [1, 1, 0]]),
+            "labels": torch.tensor([[1, 2, 3], [4, 5, -100]]),
+        }
+
+    batches = create_collated_text_batches(
+        [{"text": "first"}, {"text": "second"}],
+        data_collator=collator,
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="default",
+        skip_prepare_dataset=True,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert seen == [["first", "second"]]
+    assert batch.tolist() == [[1, 2, 3], [4, 5, 0]]
+    assert lengths.tolist() == [[0, 3], [0, 2]]
+    assert labels.tolist() == [[1, 2, 3], [4, 5, -100]]
+
+
+def test_custom_text_collator_skip_prepare_honors_torch_randperm():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    seen = []
+
+    def collator(examples):
+        seen.append([example["row"] for example in examples])
+        return {
+            "input_ids": torch.tensor([[1, 2, 3], [4, 5, 6]]),
+            "labels": torch.tensor([[1, 2, 3], [4, 5, 6]]),
+        }
+
+    batches = create_collated_text_batches(
+        [{"row": row} for row in range(4)],
+        data_collator=collator,
+        batch_size=2,
+        max_seq_length=8,
+        seed=7,
+        dataset_order="torch_randperm",
+        skip_prepare_dataset=True,
+    )
+    list(batches)
+
+    generator = torch.Generator()
+    generator.manual_seed(7)
+    expected = torch.randperm(4, generator=generator).tolist()
+    assert seen == [expected[:2], expected[2:]]
+
+
 def test_mlx_trainer_routes_tokenized_text_data_collator(monkeypatch):
     import unsloth_zoo.mlx.trainer as trainer_mod
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
@@ -950,6 +1009,81 @@ def test_mlx_trainer_routes_tokenized_text_data_collator(monkeypatch):
     assert captured["seed"] == 11
     assert captured["dataset_order"] == "torch_randperm"
     assert captured["num_epochs"] is None
+
+
+def test_mlx_trainer_routes_skip_prepare_text_data_collator(monkeypatch):
+    import unsloth_zoo.mlx.trainer as trainer_mod
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    captured = {}
+    expected_batches = [("raw", "batch")]
+
+    def fake_create_collated_text_batches(**kwargs):
+        captured.update(kwargs)
+        return expected_batches
+
+    class Model:
+        _config = {}
+
+        def trainable_parameters(self):
+            return {}
+
+    class Tokenizer:
+        pass
+
+    collator = object()
+    monkeypatch.setattr(
+        trainer_mod,
+        "create_collated_text_batches",
+        fake_create_collated_text_batches,
+    )
+    trainer = MLXTrainer(
+        Model(),
+        Tokenizer(),
+        train_dataset=[{"text": "raw"}],
+        data_collator=collator,
+        args=MLXTrainingConfig(
+            max_steps=1,
+            gradient_accumulation_steps=1,
+            per_device_train_batch_size=1,
+            max_seq_length=16,
+            dataset_kwargs={"skip_prepare_dataset": True},
+        ),
+    )
+
+    batches, iterator = trainer._prepare_data(is_vlm=False)
+
+    assert batches is expected_batches
+    assert iterator is None
+    assert captured["dataset"] == [{"text": "raw"}]
+    assert captured["data_collator"] is collator
+    assert captured["skip_prepare_dataset"] is True
+
+
+def test_mlx_trainer_rejects_skip_prepare_without_collator():
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    class Model:
+        _config = {}
+
+        def trainable_parameters(self):
+            return {}
+
+    class Tokenizer:
+        pass
+
+    trainer = MLXTrainer(
+        Model(),
+        Tokenizer(),
+        train_dataset=[{"text": "raw"}],
+        args=MLXTrainingConfig(
+            max_steps=1,
+            dataset_kwargs={"skip_prepare_dataset": True},
+        ),
+    )
+
+    with pytest.raises(ValueError, match="skip_prepare_dataset"):
+        trainer._prepare_data(is_vlm=False)
 
 
 def test_custom_text_collator_requires_prepared_dataset():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import dataclasses
 
+import numpy as np
 import pytest
 import torch
 
@@ -397,6 +398,36 @@ def test_pretokenized_text_batches_apply_explicit_labels_and_masks():
     assert labels.tolist() == [[-100, -100, -100], [-100, 5, -100]]
 
 
+def test_pretokenized_text_batches_handle_mixed_optional_fields():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    batches = create_ordered_batches(
+        [
+            {
+                "input_ids": [1, 2, 3],
+                "labels": None,
+                "completion_mask": None,
+                "assistant_masks": None,
+            },
+            {"input_ids": [4, 5], "completion_mask": [0, 1]},
+            {"input_ids": None, "labels": [9, 9]},
+        ],
+        Tokenizer(),
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=True,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert batch.tolist() == [[1, 2, 3], [4, 5, 0]]
+    assert lengths.tolist() == [[0, 3], [0, 2]]
+    assert labels.tolist() == [[1, 2, 3], [-100, 5, -100]]
+
+
 @pytest.mark.parametrize(
     ("completion_only_loss", "expected"),
     [
@@ -446,6 +477,54 @@ def test_pretokenized_text_create_batches_path_uses_labeled_collator():
     assert batch.tolist() == [[1, 2, 3]]
     assert lengths.tolist() == [[0, 3]]
     assert labels.tolist() == [[-100, 2, 3]]
+
+
+def test_pretokenized_text_create_batches_preserves_mlx_lm_default_order():
+    from unsloth_zoo.mlx.utils import create_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    rows = [
+        {"input_ids": [length] * length}
+        for length in [7, 2, 6, 3, 5, 4]
+    ]
+    batches = create_batches(
+        rows,
+        Tokenizer(),
+        batch_size=2,
+        max_seq_length=16,
+        seed=7,
+    )
+
+    sorted_lengths = [2, 3, 4, 5, 6, 7]
+    groups = [sorted_lengths[i:i + 2] for i in range(0, len(sorted_lengths), 2)]
+    expected = [groups[i] for i in np.random.RandomState(7).permutation(len(groups))]
+    observed = [
+        [int(length.item()) for length in lengths[:, 1]]
+        for _batch, lengths, _labels in batches
+    ]
+    assert observed == expected
+
+
+def test_pretokenized_text_streaming_yields_labeled_batches():
+    from unsloth_zoo.mlx.utils import iterate_training_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    stream = iterate_training_batches(
+        [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5]}],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        seed=3,
+    )
+
+    batch, lengths, labels = next(stream)
+    assert batch.shape[0] == 1
+    assert lengths.shape == (1, 2)
+    assert labels.shape == batch.shape
 
 
 def test_pretokenized_prompt_completion_defaults_to_completion_only_loss():
@@ -554,6 +633,49 @@ def test_conversational_prompt_completion_uses_chat_template_split_like_cuda():
     assert batch.tolist() == [[10, 1, 20, 2]]
     assert lengths.tolist() == [[0, 4]]
     assert labels.tolist() == [[-100, -100, -100, 2]]
+
+
+def test_prompt_completion_batches_apply_explicit_chat_template():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+        def apply_chat_template(
+            self,
+            messages,
+            tokenize=True,
+            add_generation_prompt=False,
+            return_dict=False,
+            **_kwargs,
+        ):
+            assert self.chat_template == "{{ messages[0]['content'] }}"
+            ids = []
+            for message in messages:
+                if message["role"] == "assistant":
+                    ids.append(20)
+                ids.append(int(message["content"]))
+            if add_generation_prompt:
+                ids.append(20)
+            return {"input_ids": ids} if return_dict else ids
+
+    batches = create_ordered_batches(
+        [
+            {
+                "prompt": [{"role": "user", "content": "1"}],
+                "completion": [{"role": "assistant", "content": "2"}],
+            }
+        ],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+        chat_template="{{ messages[0]['content'] }}",
+        completion_only_loss=True,
+    )
+
+    _batch, _lengths, labels = batches[0]
+    assert labels.tolist() == [[-100, -100, 2]]
 
 
 def test_prompt_completion_text_batches_append_eos_to_completion():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -378,7 +378,7 @@ def test_pretokenized_text_batches_apply_explicit_labels_and_masks():
                 "input_ids": [1, 2, 3],
                 "labels": [1, -100, 3],
                 "completion_mask": [0, 1, 1],
-                "assistant_masks": [1, 1, 0],
+                "assistant_masks": [1, 1, 1],
             },
             {
                 "input_ids": [4, 5],
@@ -395,7 +395,7 @@ def test_pretokenized_text_batches_apply_explicit_labels_and_masks():
     )
 
     _batch, _lengths, labels = batches[0]
-    assert labels.tolist() == [[-100, -100, -100], [-100, 5, -100]]
+    assert labels.tolist() == [[-100, -100, 3], [-100, 5, -100]]
 
 
 def test_pretokenized_text_batches_handle_mixed_optional_fields():
@@ -479,7 +479,8 @@ def test_pretokenized_text_create_batches_path_uses_labeled_collator():
     assert labels.tolist() == [[-100, 2, 3]]
 
 
-def test_pretokenized_text_create_batches_preserves_mlx_lm_default_order():
+@pytest.mark.parametrize("seed", [0, 7])
+def test_pretokenized_text_create_batches_preserves_mlx_lm_default_order(seed):
     from unsloth_zoo.mlx.utils import create_batches
 
     class Tokenizer:
@@ -494,17 +495,43 @@ def test_pretokenized_text_create_batches_preserves_mlx_lm_default_order():
         Tokenizer(),
         batch_size=2,
         max_seq_length=16,
-        seed=7,
+        seed=seed,
     )
 
     sorted_lengths = [2, 3, 4, 5, 6, 7]
     groups = [sorted_lengths[i:i + 2] for i in range(0, len(sorted_lengths), 2)]
-    expected = [groups[i] for i in np.random.RandomState(7).permutation(len(groups))]
+    expected = [groups[i] for i in np.random.RandomState(seed).permutation(len(groups))]
     observed = [
         [int(length.item()) for length in lengths[:, 1]]
         for _batch, lengths, _labels in batches
     ]
     assert observed == expected
+
+
+def test_pretokenized_text_drops_rows_without_supervised_targets():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    batches = create_ordered_batches(
+        [
+            {"input_ids": [1, 2, 3], "labels": [-100, -100, -100]},
+            {"input_ids": [4, 5, 6], "completion_mask": [1, 0, 0]},
+            {"input_ids": [7, 8, 9], "assistant_masks": [0, 1, 1]},
+        ],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=True,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert len(batches) == 1
+    assert batch.tolist() == [[7, 8, 9]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[-100, 8, 9]]
 
 
 def test_pretokenized_text_streaming_yields_labeled_batches():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -401,6 +401,7 @@ def test_pretokenized_text_batches_apply_explicit_labels_and_masks():
     ("completion_only_loss", "expected"),
     [
         (False, [[1, 2, 3], [4, 5, -100]]),
+        (None, [[1, 2, 3], [4, 5, -100]]),
         (True, [[-100, 2, 3], [-100, 5, -100]]),
     ],
 )
@@ -426,6 +427,51 @@ def test_pretokenized_text_batches_apply_completion_mask_when_requested(
 
     _batch, _lengths, labels = batches[0]
     assert labels.tolist() == expected
+
+
+def test_pretokenized_text_create_batches_path_uses_labeled_collator():
+    from unsloth_zoo.mlx.utils import create_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    batches = create_batches(
+        [{"input_ids": [1, 2, 3], "assistant_masks": [0, 1, 1]}],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[-100, 2, 3]]
+
+
+def test_pretokenized_prompt_completion_defaults_to_completion_only_loss():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    batches = create_ordered_batches(
+        [
+            {
+                "prompt": "ignored",
+                "completion": "ignored",
+                "input_ids": [1, 2, 3],
+                "completion_mask": [0, 1, 1],
+            },
+        ],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=None,
+    )
+
+    _batch, _lengths, labels = batches[0]
+    assert labels.tolist() == [[-100, 2, 3]]
 
 
 @pytest.mark.parametrize(
@@ -463,6 +509,124 @@ def test_prompt_completion_text_batches_mask_prompt_tokens_like_cuda(
     assert batch.tolist() == [[10, 11, 12, 13], [20, 21, 0, 0]]
     assert lengths.tolist() == [[0, 4], [0, 2]]
     assert labels.tolist() == expected
+
+
+def test_conversational_prompt_completion_uses_chat_template_split_like_cuda():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+        def apply_chat_template(
+            self,
+            messages,
+            tokenize=True,
+            add_generation_prompt=False,
+            return_dict=False,
+            **_kwargs,
+        ):
+            ids = []
+            for message in messages:
+                if message["role"] == "user":
+                    ids.extend([10, int(message["content"])])
+                elif message["role"] == "assistant":
+                    ids.extend([20, int(message["content"])])
+            if add_generation_prompt:
+                ids.append(20)
+            return {"input_ids": ids} if return_dict else ids
+
+    batches = create_ordered_batches(
+        [
+            {
+                "prompt": [{"role": "user", "content": "1"}],
+                "completion": [{"role": "assistant", "content": "2"}],
+                "chat_template_kwargs": None,
+            }
+        ],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=True,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert batch.tolist() == [[10, 1, 20, 2]]
+    assert lengths.tolist() == [[0, 4]]
+    assert labels.tolist() == [[-100, -100, -100, 2]]
+
+
+def test_prompt_completion_text_batches_append_eos_to_completion():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+        eos_token = " 99"
+
+        def encode(self, text, **_kwargs):
+            return [int(part) for part in text.split()]
+
+    batches = create_ordered_batches(
+        [{"prompt": "10 ", "completion": "11"}],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=True,
+        append_eos=True,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert batch.tolist() == [[10, 11, 99]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[-100, 11, 99]]
+
+
+def test_prompt_completion_text_batches_append_eos_to_empty_completion():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+        eos_token = "99"
+
+        def encode(self, text, **_kwargs):
+            return [int(part) for part in text.split()]
+
+    batches = create_ordered_batches(
+        [{"prompt": "10 ", "completion": ""}],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=True,
+        append_eos=True,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert batch.tolist() == [[10, 99]]
+    assert lengths.tolist() == [[0, 2]]
+    assert labels.tolist() == [[-100, 99]]
+
+
+def test_prompt_completion_formatter_conflicts_with_completion_only_loss():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+        def encode(self, text, **_kwargs):
+            return [int(part) for part in text.split()]
+
+    with pytest.raises(ValueError, match="formatting_func is incompatible"):
+        create_ordered_batches(
+            [{"prompt": "10 ", "completion": "11"}],
+            Tokenizer(),
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+            formatting_func=lambda _row: "10 11",
+            completion_only_loss=None,
+        )
 
 
 def test_train_on_responses_only_forwards_last_response_only(monkeypatch):

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -574,6 +574,7 @@ def test_custom_text_collator_widens_unsigned_labels():
     def collator(_examples):
         return {
             "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.int64),
+            "attention_mask": torch.tensor([[1, 1, 1]], dtype=torch.int64),
             "labels": torch.tensor([[1, 2, 3]], dtype=torch.uint8),
         }
 
@@ -656,7 +657,44 @@ def test_custom_text_collator_trims_ignored_padding_tail():
     assert labels.tolist() == [[1, 2, 3]]
 
 
-def test_custom_text_collator_rejects_active_tail_after_truncation():
+def test_custom_text_collator_trims_masked_tail_after_truncation():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    batch, lengths, labels = create_collated_text_batches(
+        [{"input_ids": [1, 2, 3]}],
+        data_collator=lambda _examples: {
+            "input_ids": torch.tensor([[1, 2, 3, 99]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 0]]),
+            "labels": torch.tensor([[1, 2, 3, -100]]),
+        },
+        batch_size=1,
+        max_seq_length=3,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[1, 2, 3]]
+
+
+def test_custom_text_collator_rejects_masked_tail_labels():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="attention_mask is 0"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3, 99]]),
+                "attention_mask": torch.tensor([[1, 1, 1, 0]]),
+                "labels": torch.tensor([[1, 2, 3, 99]]),
+            },
+            batch_size=1,
+            max_seq_length=3,
+            dataset_order="sequential",
+        )[0]
+
+
+def test_custom_text_collator_rejects_supervised_tail_without_mask():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
     with pytest.raises(ValueError, match="past max_seq_length"):
@@ -689,10 +727,10 @@ def test_custom_text_collator_rejects_active_attention_tail():
         )[0]
 
 
-def test_custom_text_collator_rejects_masked_supervised_targets():
+def test_custom_text_collator_rejects_masked_active_targets():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
-    with pytest.raises(ValueError, match="shifted attention_mask is 0"):
+    with pytest.raises(ValueError, match="attention_mask is 0"):
         create_collated_text_batches(
             [{"input_ids": [1, 2, 3]}],
             data_collator=lambda _examples: {
@@ -714,6 +752,7 @@ def test_custom_text_collator_rejects_1d_multi_example_outputs():
             [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5, 6]}],
             data_collator=lambda _examples: {
                 "input_ids": torch.tensor([1, 2, 3]),
+                "attention_mask": torch.tensor([1, 1, 1]),
                 "labels": torch.tensor([1, 2, 3]),
             },
             batch_size=2,
@@ -722,18 +761,90 @@ def test_custom_text_collator_rejects_1d_multi_example_outputs():
         )[0]
 
 
-def test_custom_text_collator_rejects_wrong_2d_batch_size():
+def test_custom_text_collator_accepts_filtered_output_batch_size():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
-    with pytest.raises(ValueError, match="does not match the 2 selected examples"):
-        create_collated_text_batches(
-            [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5, 6]}],
-            data_collator=lambda _examples: {
-                "input_ids": torch.tensor([[1, 2, 3]]),
-                "attention_mask": torch.tensor([[1, 1, 1]]),
+    batch, lengths, labels = create_collated_text_batches(
+        [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5, 6]}],
+        data_collator=lambda _examples: {
+            "input_ids": torch.tensor([[4, 5, 6]]),
+            "attention_mask": torch.tensor([[1, 1, 1]]),
+            "labels": torch.tensor([[4, 5, 6]]),
+        },
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[4, 5, 6]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[4, 5, 6]]
+
+
+@pytest.mark.parametrize(
+    ("field", "output"),
+    [
+        (
+            "input_ids",
+            {
+                "input_ids": torch.tensor([[1.2, 2.0, 3.0]]),
                 "labels": torch.tensor([[1, 2, 3]]),
             },
-            batch_size=2,
+        ),
+        (
+            "labels",
+            {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "labels": torch.tensor([[1.0, 2.0, 3.0]]),
+            },
+        ),
+    ],
+)
+def test_custom_text_collator_rejects_invalid_dtypes(field, output):
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match=field):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: output,
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )[0]
+
+
+def test_custom_text_collator_accepts_float_attention_mask():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    batch, lengths, labels = create_collated_text_batches(
+        [{"input_ids": [1, 2, 3]}],
+        data_collator=lambda _examples: {
+            "input_ids": torch.tensor([[1, 2, 0]]),
+            "attention_mask": torch.tensor([[1.0, 1.0, 0.0]], dtype=torch.float32),
+            "labels": torch.tensor([[1, 2, -100]]),
+        },
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[1, 2, 0]]
+    assert lengths.tolist() == [[0, 2]]
+    assert labels.tolist() == [[1, 2, -100]]
+
+
+def test_custom_text_collator_rejects_non_binary_float_attention_mask():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="0/1 values"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 0]]),
+                "attention_mask": torch.tensor([[1.0, 0.5, 0.0]]),
+                "labels": torch.tensor([[1, 2, -100]]),
+            },
+            batch_size=1,
             max_seq_length=8,
             dataset_order="sequential",
         )[0]
@@ -759,6 +870,10 @@ def test_custom_text_collator_preserves_default_order(seed):
         ]
         return {
             "input_ids": torch.tensor(rows),
+            "attention_mask": torch.tensor([
+                [1] * len(example["input_ids"]) + [0] * (max_len - len(example["input_ids"]))
+                for example in examples
+            ]),
             "labels": torch.tensor(labels),
         }
 
@@ -858,6 +973,7 @@ def test_custom_text_collator_prunes_and_truncates_sft_fields():
         seen.extend(examples)
         return {
             "input_ids": torch.tensor([[1, 2, 3]]),
+            "attention_mask": torch.tensor([[1, 1, 1]]),
             "labels": torch.tensor([[-100, 2, 3]]),
         }
 
@@ -870,7 +986,7 @@ def test_custom_text_collator_prunes_and_truncates_sft_fields():
                 "assistant_masks": torch.tensor([0, 0, 1, 1]),
                 "attention_mask": torch.tensor([1, 1, 1, 1]),
                 "custom_mask": torch.tensor([5, 6, 7, 8]),
-                "metadata": ["drop", "this"],
+                "metadata": ["drop", "this", "field", "too"],
                 "scalar_metadata": "drop",
             },
         ],
@@ -915,41 +1031,27 @@ def test_custom_text_collator_skips_none_sft_fields():
     assert labels.tolist() == [[1, 2, 3]]
 
 
-def test_custom_text_collator_default_order_includes_partial_batch():
+def test_custom_text_collator_lets_collator_own_completion_mask_policy():
+    from trl.trainer.sft_trainer import DataCollatorForLanguageModeling
+
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
-    observed = []
-
-    def collator(examples):
-        lengths = [len(example["input_ids"]) for example in examples]
-        observed.append(lengths)
-        max_len = max(lengths)
-        return {
-            "input_ids": torch.tensor([
-                example["input_ids"] + [0] * (max_len - len(example["input_ids"]))
-                for example in examples
-            ]),
-            "labels": torch.tensor([
-                example["input_ids"] + [-100] * (max_len - len(example["input_ids"]))
-                for example in examples
-            ]),
-        }
-
-    rows = [
-        {"input_ids": [1] * length}
-        for length in [5, 2, 3]
-    ]
-    list(create_collated_text_batches(
-        rows,
-        data_collator=collator,
-        batch_size=2,
+    batch, lengths, labels = create_collated_text_batches(
+        [
+            {"input_ids": [1, 2, 3], "completion_mask": [0, 0, 0]},
+        ],
+        data_collator=DataCollatorForLanguageModeling(
+            pad_token_id=0,
+            completion_only_loss=False,
+        ),
+        batch_size=1,
         max_seq_length=8,
-        seed=0,
-        dataset_order="default",
-    ))
+        dataset_order="sequential",
+    )[0]
 
-    assert sorted(length for batch in observed for length in batch) == [2, 3, 5]
-    assert sorted(len(batch) for batch in observed) == [1, 2]
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[1, 2, 3]]
 
 
 def test_custom_text_collator_requires_labels():
@@ -967,6 +1069,25 @@ def test_custom_text_collator_requires_labels():
         )[0]
 
 
+def test_custom_text_collator_accepts_labels_without_attention_mask():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    batch, lengths, labels = create_collated_text_batches(
+        [{"input_ids": [1, 2, 3]}],
+        data_collator=lambda _examples: {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "labels": torch.tensor([[1, 2, 3]]),
+        },
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[1, 2, 3]]
+
+
 def test_custom_text_collator_rejects_position_ids_outputs():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
@@ -982,6 +1103,26 @@ def test_custom_text_collator_rejects_position_ids_outputs():
             max_seq_length=8,
             dataset_order="sequential",
         )[0]
+
+
+def test_custom_text_collator_ignores_extra_output_keys():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    batch, lengths, labels = create_collated_text_batches(
+        [{"input_ids": [1, 2, 3]}],
+        data_collator=lambda _examples: {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "labels": torch.tensor([[1, 2, 3]]),
+            "token_type_ids": torch.tensor([[0, 0, 1]]),
+        },
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[1, 2, 3]]
 
 
 def test_custom_text_collator_rejects_packed_examples():
@@ -1003,13 +1144,13 @@ def test_custom_text_collator_rejects_packed_examples():
 def test_custom_text_collator_rejects_noncontiguous_attention_mask():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
-    with pytest.raises(ValueError, match="contiguous"):
+    with pytest.raises(ValueError, match="contiguous right padding"):
         create_collated_text_batches(
             [{"input_ids": [1, 2, 3]}],
             data_collator=lambda _examples: {
                 "input_ids": torch.tensor([[1, 2, 3]]),
                 "attention_mask": torch.tensor([[1, 0, 1]]),
-                "labels": torch.tensor([[1, 2, 3]]),
+                "labels": torch.tensor([[1, -100, 3]]),
             },
             batch_size=1,
             max_seq_length=8,
@@ -1020,7 +1161,7 @@ def test_custom_text_collator_rejects_noncontiguous_attention_mask():
 def test_custom_text_collator_rejects_left_padding():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
-    with pytest.raises(ValueError, match="right padding"):
+    with pytest.raises(ValueError, match="contiguous right padding"):
         create_collated_text_batches(
             [{"input_ids": [1, 2, 3]}],
             data_collator=lambda _examples: {
@@ -1042,6 +1183,7 @@ def test_custom_text_collator_rejects_batches_without_shifted_targets():
             [{"input_ids": [1, 2, 3]}],
             data_collator=lambda _examples: {
                 "input_ids": torch.tensor([[1, 2, 3]]),
+                "attention_mask": torch.tensor([[1, 1, 1]]),
                 "labels": torch.tensor([[1, -100, -100]]),
             },
             batch_size=1,

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -558,11 +558,14 @@ def test_custom_text_collator_output_normalizes_to_mlx_batch():
         dataset_order="sequential",
     )
 
+    assert seen == []
     batch, lengths, labels = batches[0]
     assert seen == [[[1, 2, 3], [4, 5]]]
     assert batch.tolist() == [[1, 2, 3, 0], [4, 5, 0, 0]]
     assert lengths.tolist() == [[0, 3], [0, 2]]
     assert labels.tolist() == [[1, 2, 3, -100], [4, 5, -100, -100]]
+    _again_batch, _again_lengths, _again_labels = batches[0]
+    assert seen == [[[1, 2, 3], [4, 5]], [[1, 2, 3], [4, 5]]]
 
 
 def test_custom_text_collator_widens_unsigned_labels():
@@ -582,7 +585,7 @@ def test_custom_text_collator_widens_unsigned_labels():
         dataset_order="sequential",
     )[0]
 
-    assert str(labels.dtype).endswith("int64")
+    assert np.asarray(labels).dtype == np.int64
     assert labels.tolist() == [[1, 2, 3]]
 
 
@@ -611,17 +614,18 @@ def test_custom_text_collator_accepts_batch_encoding_outputs():
     assert labels.tolist() == [[1, 2, 3]]
 
 
-def test_custom_text_collator_accepts_trl_lm_collator():
+@pytest.mark.parametrize("mask_name", ["completion_mask", "assistant_masks"])
+def test_custom_text_collator_accepts_trl_lm_collator(mask_name):
     from trl.trainer.sft_trainer import DataCollatorForLanguageModeling
 
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
     batch, lengths, labels = create_collated_text_batches(
-        [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5]}],
-        data_collator=DataCollatorForLanguageModeling(
-            pad_token_id=0,
-            completion_only_loss=False,
-        ),
+        [
+            {"input_ids": [1, 2, 3], mask_name: [0, 1, 1]},
+            {"input_ids": [4, 5], mask_name: [0, 1]},
+        ],
+        data_collator=DataCollatorForLanguageModeling(pad_token_id=0),
         batch_size=2,
         max_seq_length=8,
         dataset_order="sequential",
@@ -629,7 +633,7 @@ def test_custom_text_collator_accepts_trl_lm_collator():
 
     assert batch.tolist() == [[1, 2, 3], [4, 5, 0]]
     assert lengths.tolist() == [[0, 3], [0, 2]]
-    assert labels.tolist() == [[1, 2, 3], [4, 5, -100]]
+    assert labels.tolist() == [[-100, 2, 3], [-100, 5, -100]]
 
 
 def test_custom_text_collator_trims_ignored_padding_tail():
@@ -665,7 +669,7 @@ def test_custom_text_collator_rejects_active_tail_after_truncation():
             batch_size=1,
             max_seq_length=3,
             dataset_order="sequential",
-        )
+        )[0]
 
 
 def test_custom_text_collator_rejects_active_attention_tail():
@@ -682,7 +686,57 @@ def test_custom_text_collator_rejects_active_attention_tail():
             batch_size=1,
             max_seq_length=3,
             dataset_order="sequential",
-        )
+        )[0]
+
+
+def test_custom_text_collator_rejects_masked_supervised_targets():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="shifted attention_mask is 0"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 0]]),
+                "attention_mask": torch.tensor([[1, 1, 0]]),
+                "labels": torch.tensor([[1, 2, 0]]),
+            },
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )[0]
+
+
+def test_custom_text_collator_rejects_1d_multi_example_outputs():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="2D when collating multiple examples"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5, 6]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([1, 2, 3]),
+                "labels": torch.tensor([1, 2, 3]),
+            },
+            batch_size=2,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )[0]
+
+
+def test_custom_text_collator_rejects_wrong_2d_batch_size():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="does not match the 2 selected examples"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5, 6]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "attention_mask": torch.tensor([[1, 1, 1]]),
+                "labels": torch.tensor([[1, 2, 3]]),
+            },
+            batch_size=2,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )[0]
 
 
 @pytest.mark.parametrize("seed", [0, 7])
@@ -712,14 +766,14 @@ def test_custom_text_collator_preserves_default_order(seed):
         {"input_ids": [length] * length}
         for length in [7, 2, 6, 3, 5, 4]
     ]
-    create_collated_text_batches(
+    list(create_collated_text_batches(
         rows,
         data_collator=collator,
         batch_size=2,
         max_seq_length=16,
         seed=seed,
         dataset_order="default",
-    )
+    ))
 
     sorted_lengths = [2, 3, 4, 5, 6, 7]
     groups = [sorted_lengths[i:i + 2] for i in range(0, len(sorted_lengths), 2)]
@@ -727,7 +781,7 @@ def test_custom_text_collator_preserves_default_order(seed):
     assert observed == expected
 
 
-def test_mlx_trainer_routes_text_data_collator(monkeypatch):
+def test_mlx_trainer_routes_tokenized_text_data_collator(monkeypatch):
     import unsloth_zoo.mlx.trainer as trainer_mod
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
 
@@ -758,6 +812,7 @@ def test_mlx_trainer_routes_text_data_collator(monkeypatch):
         Tokenizer(),
         train_dataset=[{"input_ids": [1, 2, 3]}],
         data_collator=collator,
+        formatting_func=lambda row: "ignored for tokenized datasets",
         args=MLXTrainingConfig(
             max_steps=3,
             gradient_accumulation_steps=2,
@@ -782,42 +837,10 @@ def test_mlx_trainer_routes_text_data_collator(monkeypatch):
     assert captured["num_epochs"] is None
 
 
-def test_mlx_trainer_rejects_custom_collator_with_packing():
-    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
-
-    class Model:
-        _config = {}
-
-    with pytest.raises(ValueError, match="packing=True"):
-        MLXTrainer(
-            Model(),
-            tokenizer=object(),
-            train_dataset=[{"input_ids": [1, 2, 3]}],
-            data_collator=lambda examples: examples,
-            args=MLXTrainingConfig(packing=True),
-        )
-
-
-def test_mlx_trainer_rejects_custom_collator_with_formatting_func():
-    from unsloth_zoo.mlx.trainer import MLXTrainer
-
-    class Model:
-        _config = {}
-
-    with pytest.raises(ValueError, match="formatting_func"):
-        MLXTrainer(
-            Model(),
-            tokenizer=object(),
-            train_dataset=[{"input_ids": [1, 2, 3]}],
-            data_collator=lambda examples: examples,
-            formatting_func=lambda row: row["text"],
-        )
-
-
 def test_custom_text_collator_requires_prepared_dataset():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
-    with pytest.raises(ValueError, match="requires a tokenized text dataset"):
+    with pytest.raises(ValueError, match="requires tokenized text examples"):
         create_collated_text_batches(
             [{"text": "hello"}],
             data_collator=lambda examples: {"input_ids": []},
@@ -826,7 +849,7 @@ def test_custom_text_collator_requires_prepared_dataset():
         )
 
 
-def test_custom_text_collator_keeps_truncated_examples_for_collator():
+def test_custom_text_collator_prunes_and_truncates_sft_fields():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
     seen = []
@@ -834,37 +857,99 @@ def test_custom_text_collator_keeps_truncated_examples_for_collator():
     def collator(examples):
         seen.extend(examples)
         return {
-            "input_ids": torch.tensor([[9, 0, 0], [1, 2, 3]]),
-            "labels": torch.tensor([[-100, -100, -100], [1, 2, 3]]),
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "labels": torch.tensor([[-100, 2, 3]]),
         }
 
     create_collated_text_batches(
         [
             {
-                "input_ids": torch.tensor([9]),
-                "custom_mask": torch.tensor([1]),
-                "metadata": ["keep", "all"],
-            },
-            {
                 "input_ids": torch.tensor([1, 2, 3, 4]),
+                "labels": torch.tensor([1, 2, 3, 4]),
+                "completion_mask": torch.tensor([0, 1, 1, 1]),
+                "assistant_masks": torch.tensor([0, 0, 1, 1]),
+                "attention_mask": torch.tensor([1, 1, 1, 1]),
                 "custom_mask": torch.tensor([5, 6, 7, 8]),
-                "same_length_metadata": ["a", "b", "c", "d"],
-                "metadata": ["still", "metadata"],
+                "metadata": ["drop", "this"],
+                "scalar_metadata": "drop",
             },
         ],
         data_collator=collator,
-        batch_size=2,
+        batch_size=1,
         max_seq_length=3,
         dataset_order="sequential",
-    )
+    )[0]
 
-    assert [example["input_ids"] for example in seen] == [[9], [1, 2, 3]]
-    assert [example["custom_mask"] for example in seen] == [[1], [5, 6, 7]]
-    assert seen[1]["same_length_metadata"] == ["a", "b", "c"]
-    assert [example["metadata"] for example in seen] == [
-        ["keep", "all"],
-        ["still", "metadata"],
+    assert seen == [
+        {
+            "input_ids": [1, 2, 3],
+            "labels": [1, 2, 3],
+            "completion_mask": [0, 1, 1],
+            "assistant_masks": [0, 0, 1],
+        },
     ]
+
+
+def test_custom_text_collator_skips_none_sft_fields():
+    from trl.trainer.sft_trainer import DataCollatorForLanguageModeling
+
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    batch, lengths, labels = create_collated_text_batches(
+        [
+            {
+                "input_ids": [1, 2, 3],
+                "labels": None,
+                "completion_mask": None,
+                "assistant_masks": None,
+            },
+        ],
+        data_collator=DataCollatorForLanguageModeling(pad_token_id=0),
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[1, 2, 3]]
+
+
+def test_custom_text_collator_default_order_includes_partial_batch():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    observed = []
+
+    def collator(examples):
+        lengths = [len(example["input_ids"]) for example in examples]
+        observed.append(lengths)
+        max_len = max(lengths)
+        return {
+            "input_ids": torch.tensor([
+                example["input_ids"] + [0] * (max_len - len(example["input_ids"]))
+                for example in examples
+            ]),
+            "labels": torch.tensor([
+                example["input_ids"] + [-100] * (max_len - len(example["input_ids"]))
+                for example in examples
+            ]),
+        }
+
+    rows = [
+        {"input_ids": [1] * length}
+        for length in [5, 2, 3]
+    ]
+    list(create_collated_text_batches(
+        rows,
+        data_collator=collator,
+        batch_size=2,
+        max_seq_length=8,
+        seed=0,
+        dataset_order="default",
+    ))
+
+    assert sorted(length for batch in observed for length in batch) == [2, 3, 5]
+    assert sorted(len(batch) for batch in observed) == [1, 2]
 
 
 def test_custom_text_collator_requires_labels():
@@ -879,13 +964,13 @@ def test_custom_text_collator_requires_labels():
             batch_size=1,
             max_seq_length=8,
             dataset_order="sequential",
-        )
+        )[0]
 
 
-def test_custom_text_collator_rejects_padding_free_outputs():
+def test_custom_text_collator_rejects_position_ids_outputs():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
-    with pytest.raises(ValueError, match="padding-free"):
+    with pytest.raises(ValueError, match="position_ids"):
         create_collated_text_batches(
             [{"input_ids": [1, 2, 3]}],
             data_collator=lambda _examples: {
@@ -896,7 +981,7 @@ def test_custom_text_collator_rejects_padding_free_outputs():
             batch_size=1,
             max_seq_length=8,
             dataset_order="sequential",
-        )
+        )[0]
 
 
 def test_custom_text_collator_rejects_packed_examples():
@@ -929,7 +1014,7 @@ def test_custom_text_collator_rejects_noncontiguous_attention_mask():
             batch_size=1,
             max_seq_length=8,
             dataset_order="sequential",
-        )
+        )[0]
 
 
 def test_custom_text_collator_rejects_left_padding():
@@ -946,10 +1031,10 @@ def test_custom_text_collator_rejects_left_padding():
             batch_size=1,
             max_seq_length=8,
             dataset_order="sequential",
-        )
+        )[0]
 
 
-def test_custom_text_collator_rejects_all_masked_batches():
+def test_custom_text_collator_rejects_batches_without_shifted_targets():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
     with pytest.raises(ValueError, match="no supervised target tokens"):
@@ -962,10 +1047,10 @@ def test_custom_text_collator_rejects_all_masked_batches():
             batch_size=1,
             max_seq_length=8,
             dataset_order="sequential",
-        )
+        )[0]
 
 
-def test_custom_text_collator_eval_is_explicitly_deferred(monkeypatch):
+def test_custom_text_collator_rejects_eval(monkeypatch):
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
 
     class Model:

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -534,6 +534,139 @@ def test_pretokenized_text_drops_rows_without_supervised_targets():
     assert labels.tolist() == [[-100, 8, 9]]
 
 
+def test_custom_text_collator_output_normalizes_to_mlx_batch():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    seen = []
+
+    def collator(examples):
+        seen.append([example["input_ids"] for example in examples])
+        return {
+            "input_ids": torch.tensor([[0, 1, 2, 3], [4, 5, 0, 0]]),
+            "attention_mask": torch.tensor([[0, 1, 1, 1], [1, 1, 0, 0]]),
+            "labels": torch.tensor([[-100, 1, 2, 3], [4, 5, -100, -100]]),
+        }
+
+    batches = create_collated_text_batches(
+        [
+            {"input_ids": [0, 1, 2, 3]},
+            {"input_ids": [4, 5]},
+        ],
+        data_collator=collator,
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )
+
+    batch, lengths, labels = batches[0]
+    assert seen == [[[0, 1, 2, 3], [4, 5]]]
+    assert batch.tolist() == [[0, 1, 2, 3], [4, 5, 0, 0]]
+    assert lengths.tolist() == [[1, 4], [0, 2]]
+    assert labels.tolist() == [[-100, 1, 2, 3], [4, 5, -100, -100]]
+
+
+@pytest.mark.parametrize("seed", [0, 7])
+def test_custom_text_collator_preserves_default_order(seed):
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    observed = []
+
+    def collator(examples):
+        lengths = [len(example["input_ids"]) for example in examples]
+        observed.append(lengths)
+        max_len = max(lengths)
+        rows = [
+            example["input_ids"] + [0] * (max_len - len(example["input_ids"]))
+            for example in examples
+        ]
+        return {"input_ids": torch.tensor(rows)}
+
+    rows = [
+        {"input_ids": [length] * length}
+        for length in [7, 2, 6, 3, 5, 4]
+    ]
+    create_collated_text_batches(
+        rows,
+        data_collator=collator,
+        batch_size=2,
+        max_seq_length=16,
+        seed=seed,
+        dataset_order="default",
+    )
+
+    sorted_lengths = [2, 3, 4, 5, 6, 7]
+    groups = [sorted_lengths[i:i + 2] for i in range(0, len(sorted_lengths), 2)]
+    expected = [groups[i] for i in np.random.RandomState(seed).permutation(len(groups))]
+    assert observed == expected
+
+
+def test_mlx_trainer_routes_text_data_collator(monkeypatch):
+    import unsloth_zoo.mlx.trainer as trainer_mod
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    captured = {}
+    expected_batches = [("batch", "lengths", "labels")]
+
+    def fake_create_collated_text_batches(**kwargs):
+        captured.update(kwargs)
+        return expected_batches
+
+    class Model:
+        _config = {}
+
+        def trainable_parameters(self):
+            return {}
+
+    class Tokenizer:
+        pass
+
+    collator = object()
+    monkeypatch.setattr(
+        trainer_mod,
+        "create_collated_text_batches",
+        fake_create_collated_text_batches,
+    )
+    trainer = MLXTrainer(
+        Model(),
+        Tokenizer(),
+        train_dataset=[{"input_ids": [1, 2, 3]}],
+        data_collator=collator,
+        args=MLXTrainingConfig(
+            max_steps=3,
+            gradient_accumulation_steps=2,
+            per_device_train_batch_size=4,
+            max_seq_length=16,
+            dataset_order="torch_randperm",
+            seed=11,
+        ),
+    )
+
+    batches, iterator = trainer._prepare_data(is_vlm=False)
+
+    assert batches is expected_batches
+    assert iterator is None
+    assert captured["dataset"] == [{"input_ids": [1, 2, 3]}]
+    assert captured["data_collator"] is collator
+    assert captured["batch_size"] == 4
+    assert captured["max_seq_length"] == 16
+    assert captured["num_batches"] == 6
+    assert captured["seed"] == 11
+    assert captured["dataset_order"] == "torch_randperm"
+    assert captured["num_epochs"] is None
+
+
+def test_custom_text_collator_requires_prepared_dataset():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="requires a tokenized text dataset"):
+        create_collated_text_batches(
+            [{"text": "hello"}],
+            data_collator=lambda examples: {"input_ids": []},
+            batch_size=1,
+            max_seq_length=8,
+        )
+
+
 def test_pretokenized_text_streaming_yields_labeled_batches():
     from unsloth_zoo.mlx.utils import iterate_training_batches
 

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -542,14 +542,14 @@ def test_custom_text_collator_output_normalizes_to_mlx_batch():
     def collator(examples):
         seen.append([example["input_ids"] for example in examples])
         return {
-            "input_ids": torch.tensor([[0, 1, 2, 3], [4, 5, 0, 0]]),
-            "attention_mask": torch.tensor([[0, 1, 1, 1], [1, 1, 0, 0]]),
-            "labels": torch.tensor([[-100, 1, 2, 3], [4, 5, -100, -100]]),
+            "input_ids": torch.tensor([[1, 2, 3, 0], [4, 5, 0, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]]),
+            "labels": torch.tensor([[1, 2, 3, -100], [4, 5, -100, -100]]),
         }
 
     batches = create_collated_text_batches(
         [
-            {"input_ids": [0, 1, 2, 3]},
+            {"input_ids": [1, 2, 3]},
             {"input_ids": [4, 5]},
         ],
         data_collator=collator,
@@ -559,10 +559,130 @@ def test_custom_text_collator_output_normalizes_to_mlx_batch():
     )
 
     batch, lengths, labels = batches[0]
-    assert seen == [[[0, 1, 2, 3], [4, 5]]]
-    assert batch.tolist() == [[0, 1, 2, 3], [4, 5, 0, 0]]
-    assert lengths.tolist() == [[1, 4], [0, 2]]
-    assert labels.tolist() == [[-100, 1, 2, 3], [4, 5, -100, -100]]
+    assert seen == [[[1, 2, 3], [4, 5]]]
+    assert batch.tolist() == [[1, 2, 3, 0], [4, 5, 0, 0]]
+    assert lengths.tolist() == [[0, 3], [0, 2]]
+    assert labels.tolist() == [[1, 2, 3, -100], [4, 5, -100, -100]]
+
+
+def test_custom_text_collator_widens_unsigned_labels():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    def collator(_examples):
+        return {
+            "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.int64),
+            "labels": torch.tensor([[1, 2, 3]], dtype=torch.uint8),
+        }
+
+    _batch, _lengths, labels = create_collated_text_batches(
+        [{"input_ids": [1, 2, 3]}],
+        data_collator=collator,
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )[0]
+
+    assert str(labels.dtype).endswith("int64")
+    assert labels.tolist() == [[1, 2, 3]]
+
+
+def test_custom_text_collator_accepts_batch_encoding_outputs():
+    from transformers.tokenization_utils_base import BatchEncoding
+
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    def collator(_examples):
+        return BatchEncoding({
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "attention_mask": torch.tensor([[1, 1, 1]]),
+            "labels": torch.tensor([[1, 2, 3]]),
+        })
+
+    batch, lengths, labels = create_collated_text_batches(
+        [BatchEncoding({"input_ids": [1, 2, 3]})],
+        data_collator=collator,
+        batch_size=1,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[1, 2, 3]]
+
+
+def test_custom_text_collator_accepts_trl_lm_collator():
+    from trl.trainer.sft_trainer import DataCollatorForLanguageModeling
+
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    batch, lengths, labels = create_collated_text_batches(
+        [{"input_ids": [1, 2, 3]}, {"input_ids": [4, 5]}],
+        data_collator=DataCollatorForLanguageModeling(
+            pad_token_id=0,
+            completion_only_loss=False,
+        ),
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[1, 2, 3], [4, 5, 0]]
+    assert lengths.tolist() == [[0, 3], [0, 2]]
+    assert labels.tolist() == [[1, 2, 3], [4, 5, -100]]
+
+
+def test_custom_text_collator_trims_ignored_padding_tail():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    batch, lengths, labels = create_collated_text_batches(
+        [{"input_ids": [1, 2, 3]}],
+        data_collator=lambda _examples: {
+            "input_ids": torch.tensor([[1, 2, 3, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 0]]),
+            "labels": torch.tensor([[1, 2, 3, -100]]),
+        },
+        batch_size=1,
+        max_seq_length=3,
+        dataset_order="sequential",
+    )[0]
+
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[1, 2, 3]]
+
+
+def test_custom_text_collator_rejects_active_tail_after_truncation():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="past max_seq_length"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3, 99]]),
+                "labels": torch.tensor([[1, 2, 3, 99]]),
+            },
+            batch_size=1,
+            max_seq_length=3,
+            dataset_order="sequential",
+        )
+
+
+def test_custom_text_collator_rejects_active_attention_tail():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="attention_mask values past max_seq_length"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3, 0]]),
+                "attention_mask": torch.tensor([[1, 1, 1, 1]]),
+                "labels": torch.tensor([[1, 2, 3, -100]]),
+            },
+            batch_size=1,
+            max_seq_length=3,
+            dataset_order="sequential",
+        )
 
 
 @pytest.mark.parametrize("seed", [0, 7])
@@ -579,7 +699,14 @@ def test_custom_text_collator_preserves_default_order(seed):
             example["input_ids"] + [0] * (max_len - len(example["input_ids"]))
             for example in examples
         ]
-        return {"input_ids": torch.tensor(rows)}
+        labels = [
+            example["input_ids"] + [-100] * (max_len - len(example["input_ids"]))
+            for example in examples
+        ]
+        return {
+            "input_ids": torch.tensor(rows),
+            "labels": torch.tensor(labels),
+        }
 
     rows = [
         {"input_ids": [length] * length}
@@ -655,6 +782,38 @@ def test_mlx_trainer_routes_text_data_collator(monkeypatch):
     assert captured["num_epochs"] is None
 
 
+def test_mlx_trainer_rejects_custom_collator_with_packing():
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    class Model:
+        _config = {}
+
+    with pytest.raises(ValueError, match="packing=True"):
+        MLXTrainer(
+            Model(),
+            tokenizer=object(),
+            train_dataset=[{"input_ids": [1, 2, 3]}],
+            data_collator=lambda examples: examples,
+            args=MLXTrainingConfig(packing=True),
+        )
+
+
+def test_mlx_trainer_rejects_custom_collator_with_formatting_func():
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    class Model:
+        _config = {}
+
+    with pytest.raises(ValueError, match="formatting_func"):
+        MLXTrainer(
+            Model(),
+            tokenizer=object(),
+            train_dataset=[{"input_ids": [1, 2, 3]}],
+            data_collator=lambda examples: examples,
+            formatting_func=lambda row: row["text"],
+        )
+
+
 def test_custom_text_collator_requires_prepared_dataset():
     from unsloth_zoo.mlx.utils import create_collated_text_batches
 
@@ -665,6 +824,175 @@ def test_custom_text_collator_requires_prepared_dataset():
             batch_size=1,
             max_seq_length=8,
         )
+
+
+def test_custom_text_collator_keeps_truncated_examples_for_collator():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    seen = []
+
+    def collator(examples):
+        seen.extend(examples)
+        return {
+            "input_ids": torch.tensor([[9, 0, 0], [1, 2, 3]]),
+            "labels": torch.tensor([[-100, -100, -100], [1, 2, 3]]),
+        }
+
+    create_collated_text_batches(
+        [
+            {
+                "input_ids": torch.tensor([9]),
+                "custom_mask": torch.tensor([1]),
+                "metadata": ["keep", "all"],
+            },
+            {
+                "input_ids": torch.tensor([1, 2, 3, 4]),
+                "custom_mask": torch.tensor([5, 6, 7, 8]),
+                "same_length_metadata": ["a", "b", "c", "d"],
+                "metadata": ["still", "metadata"],
+            },
+        ],
+        data_collator=collator,
+        batch_size=2,
+        max_seq_length=3,
+        dataset_order="sequential",
+    )
+
+    assert [example["input_ids"] for example in seen] == [[9], [1, 2, 3]]
+    assert [example["custom_mask"] for example in seen] == [[1], [5, 6, 7]]
+    assert seen[1]["same_length_metadata"] == ["a", "b", "c"]
+    assert [example["metadata"] for example in seen] == [
+        ["keep", "all"],
+        ["still", "metadata"],
+    ]
+
+
+def test_custom_text_collator_requires_labels():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="must return `labels`"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+            },
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )
+
+
+def test_custom_text_collator_rejects_padding_free_outputs():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="padding-free"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "labels": torch.tensor([[1, 2, 3]]),
+                "position_ids": torch.tensor([[0, 1, 2]]),
+            },
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )
+
+
+def test_custom_text_collator_rejects_packed_examples():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="seq_lengths"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3], "seq_lengths": [3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "labels": torch.tensor([[1, 2, 3]]),
+            },
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )
+
+
+def test_custom_text_collator_rejects_noncontiguous_attention_mask():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="contiguous"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "attention_mask": torch.tensor([[1, 0, 1]]),
+                "labels": torch.tensor([[1, 2, 3]]),
+            },
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )
+
+
+def test_custom_text_collator_rejects_left_padding():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="right padding"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[0, 1, 2, 3]]),
+                "attention_mask": torch.tensor([[0, 1, 1, 1]]),
+                "labels": torch.tensor([[-100, 1, 2, 3]]),
+            },
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )
+
+
+def test_custom_text_collator_rejects_all_masked_batches():
+    from unsloth_zoo.mlx.utils import create_collated_text_batches
+
+    with pytest.raises(ValueError, match="no supervised target tokens"):
+        create_collated_text_batches(
+            [{"input_ids": [1, 2, 3]}],
+            data_collator=lambda _examples: {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "labels": torch.tensor([[1, -100, -100]]),
+            },
+            batch_size=1,
+            max_seq_length=8,
+            dataset_order="sequential",
+        )
+
+
+def test_custom_text_collator_eval_is_explicitly_deferred(monkeypatch):
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    class Model:
+        _config = {}
+
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.args = MLXTrainingConfig(
+        max_steps=1,
+        eval_steps=1,
+        use_cce=False,
+        compile=False,
+        max_grad_norm=0.0,
+        max_grad_leaf_norm=0.0,
+    )
+    trainer.model = Model()
+    trainer._is_vlm = False
+    trainer._batches = None
+    trainer.eval_dataset = [{"input_ids": [1, 2, 3]}]
+    trainer.data_collator = lambda examples: examples
+
+    def fail_prepare_data(_self, _is_vlm):
+        raise AssertionError("eval guard should run before train collation")
+
+    monkeypatch.setattr(MLXTrainer, "_prepare_data", fail_prepare_data)
+
+    with pytest.raises(ValueError, match="evaluation with custom data_collator"):
+        trainer._train_inner()
 
 
 def test_pretokenized_text_streaming_yields_labeled_batches():
@@ -1016,6 +1344,28 @@ def test_train_on_responses_only_forwards_last_response_only(monkeypatch):
     )
 
     assert received["last_response_only"] is True
+
+
+def test_train_on_responses_only_rejects_custom_collator(monkeypatch):
+    import unsloth_zoo.dataset_utils as dataset_utils
+    from unsloth_zoo.mlx.trainer import train_on_responses_only
+
+    class Trainer:
+        data_collator = object()
+        tokenizer = object()
+
+    monkeypatch.setattr(
+        dataset_utils,
+        "train_on_responses_only",
+        lambda *args, **kwargs: lambda batch: batch,
+    )
+
+    with pytest.raises(ValueError, match="custom data_collator"):
+        train_on_responses_only(
+            Trainer(),
+            instruction_part="<user>",
+            response_part="<assistant>",
+        )
 
 
 def test_response_mask_tokenizer_rejects_encode_only_tokenizer():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -525,6 +525,33 @@ def test_pretokenized_text_streaming_yields_labeled_batches():
     assert batch.shape[0] == 1
     assert lengths.shape == (1, 2)
     assert labels.shape == batch.shape
+    _second_batch = next(stream)
+    third_batch, _third_lengths, _third_labels = next(stream)
+    assert third_batch.tolist() == [[1, 2, 3]]
+
+
+def test_pretokenized_text_streaming_does_not_eagerly_materialize():
+    from unsloth_zoo.mlx.utils import iterate_training_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    def rows():
+        yield {"input_ids": [1, 2, 3]}
+        raise AssertionError("streaming path eagerly consumed another row")
+
+    stream = iterate_training_batches(
+        rows(),
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        seed=3,
+    )
+
+    batch, lengths, labels = next(stream)
+    assert batch.tolist() == [[1, 2, 3]]
+    assert lengths.tolist() == [[0, 3]]
+    assert labels.tolist() == [[1, 2, 3]]
 
 
 def test_pretokenized_prompt_completion_defaults_to_completion_only_loss():
@@ -551,6 +578,29 @@ def test_pretokenized_prompt_completion_defaults_to_completion_only_loss():
 
     _batch, _lengths, labels = batches[0]
     assert labels.tolist() == [[-100, 2, 3]]
+
+
+def test_prompt_completion_nullable_input_ids_routes_to_text_tokenization():
+    from unsloth_zoo.mlx.utils import create_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+        def encode(self, text, **_kwargs):
+            return [int(part) for part in text.split()]
+
+    batches = create_batches(
+        [{"prompt": "10 ", "completion": "11", "input_ids": None}],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=8,
+        completion_only_loss=True,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert batch.tolist() == [[10, 11]]
+    assert lengths.tolist() == [[0, 2]]
+    assert labels.tolist() == [[-100, 11]]
 
 
 @pytest.mark.parametrize(
@@ -588,6 +638,34 @@ def test_prompt_completion_text_batches_mask_prompt_tokens_like_cuda(
     assert batch.tolist() == [[10, 11, 12, 13], [20, 21, 0, 0]]
     assert lengths.tolist() == [[0, 4], [0, 2]]
     assert labels.tolist() == expected
+
+
+def test_prompt_completion_drops_rows_with_fully_truncated_completion():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+        def encode(self, text, **_kwargs):
+            return [int(part) for part in text.split()]
+
+    batches = create_ordered_batches(
+        [
+            {"prompt": "10 11 ", "completion": "12"},
+            {"prompt": "20 ", "completion": "21"},
+        ],
+        Tokenizer(),
+        batch_size=1,
+        max_seq_length=2,
+        dataset_order="sequential",
+        completion_only_loss=True,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert len(batches) == 1
+    assert batch.tolist() == [[20, 21]]
+    assert lengths.tolist() == [[0, 2]]
+    assert labels.tolist() == [[-100, 21]]
 
 
 def test_conversational_prompt_completion_uses_chat_template_split_like_cuda():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -342,6 +342,129 @@ def test_mlx_text_loss_masks_exclude_position_at_sequence_length():
     assert "steps < lengths[:, 1:]" in source
 
 
+def test_pretokenized_text_batches_ignore_attention_mask_like_trl():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    batches = create_ordered_batches(
+        [
+            {"input_ids": [1, 2, 0, 3], "attention_mask": [1, 1, 0, 1]},
+            {"input_ids": [4, 5], "attention_mask": [1, 1]},
+        ],
+        Tokenizer(),
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="sequential",
+    )
+
+    batch, lengths, labels = batches[0]
+    assert batch.tolist() == [[1, 2, 0, 3], [4, 5, 0, 0]]
+    assert lengths.tolist() == [[0, 4], [0, 2]]
+    assert labels.tolist() == [[1, 2, 0, 3], [4, 5, -100, -100]]
+
+
+def test_pretokenized_text_batches_apply_explicit_labels_and_masks():
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    batches = create_ordered_batches(
+        [
+            {
+                "input_ids": [1, 2, 3],
+                "labels": [1, -100, 3],
+                "completion_mask": [0, 1, 1],
+                "assistant_masks": [1, 1, 0],
+            },
+            {
+                "input_ids": [4, 5],
+                "labels": [4, 5],
+                "completion_mask": [0, 1],
+                "assistant_masks": [0, 1],
+            },
+        ],
+        Tokenizer(),
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=True,
+    )
+
+    _batch, _lengths, labels = batches[0]
+    assert labels.tolist() == [[-100, -100, -100], [-100, 5, -100]]
+
+
+@pytest.mark.parametrize(
+    ("completion_only_loss", "expected"),
+    [
+        (False, [[1, 2, 3], [4, 5, -100]]),
+        (True, [[-100, 2, 3], [-100, 5, -100]]),
+    ],
+)
+def test_pretokenized_text_batches_apply_completion_mask_when_requested(
+    completion_only_loss, expected,
+):
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+    batches = create_ordered_batches(
+        [
+            {"input_ids": [1, 2, 3], "completion_mask": [0, 1, 1]},
+            {"input_ids": [4, 5], "completion_mask": [0, 1]},
+        ],
+        Tokenizer(),
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=completion_only_loss,
+    )
+
+    _batch, _lengths, labels = batches[0]
+    assert labels.tolist() == expected
+
+
+@pytest.mark.parametrize(
+    ("completion_only_loss", "expected"),
+    [
+        (False, [[10, 11, 12, 13], [20, 21, -100, -100]]),
+        (True, [[-100, -100, 12, 13], [-100, 21, -100, -100]]),
+        (None, [[-100, -100, 12, 13], [-100, 21, -100, -100]]),
+    ],
+)
+def test_prompt_completion_text_batches_mask_prompt_tokens_like_cuda(
+    completion_only_loss, expected,
+):
+    from unsloth_zoo.mlx.utils import create_ordered_batches
+
+    class Tokenizer:
+        pad_token_id = 0
+
+        def encode(self, text, **_kwargs):
+            return [int(part) for part in text.split()]
+
+    batches = create_ordered_batches(
+        [
+            {"prompt": "10 11 ", "completion": "12 13"},
+            {"prompt": "20 ", "completion": "21"},
+        ],
+        Tokenizer(),
+        batch_size=2,
+        max_seq_length=8,
+        dataset_order="sequential",
+        completion_only_loss=completion_only_loss,
+    )
+
+    batch, lengths, labels = batches[0]
+    assert batch.tolist() == [[10, 11, 12, 13], [20, 21, 0, 0]]
+    assert lengths.tolist() == [[0, 4], [0, 2]]
+    assert labels.tolist() == expected
+
+
 def test_train_on_responses_only_forwards_last_response_only(monkeypatch):
     import unsloth_zoo.dataset_utils as dataset_utils
     from unsloth_zoo.mlx.trainer import train_on_responses_only

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -1192,34 +1192,82 @@ def test_custom_text_collator_rejects_batches_without_shifted_targets():
         )[0]
 
 
-def test_custom_text_collator_rejects_eval(monkeypatch):
-    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+def test_custom_text_collator_routes_eval_batches(monkeypatch):
+    import unsloth_zoo.mlx.trainer as trainer_mod
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
 
     class Model:
         _config = {}
 
-    trainer = MLXTrainer.__new__(MLXTrainer)
+    class Tokenizer:
+        pass
+
+    trainer = type("Trainer", (), {})()
     trainer.args = MLXTrainingConfig(
         max_steps=1,
         eval_steps=1,
+        per_device_train_batch_size=3,
+        max_seq_length=12,
+        dataset_order="torch_randperm",
+        seed=13,
         use_cce=False,
         compile=False,
         max_grad_norm=0.0,
         max_grad_leaf_norm=0.0,
     )
     trainer.model = Model()
-    trainer._is_vlm = False
-    trainer._batches = None
+    trainer.tokenizer = Tokenizer()
+    trainer.formatting_func = None
     trainer.eval_dataset = [{"input_ids": [1, 2, 3]}]
     trainer.data_collator = lambda examples: examples
 
-    def fail_prepare_data(_self, _is_vlm):
-        raise AssertionError("eval guard should run before train collation")
+    captured = {}
+    expected = [("eval", "batch")]
 
-    monkeypatch.setattr(MLXTrainer, "_prepare_data", fail_prepare_data)
+    def fake_create_collated_text_batches(**kwargs):
+        captured.update(kwargs)
+        return expected
 
-    with pytest.raises(ValueError, match="evaluation with custom data_collator"):
-        trainer._train_inner()
+    monkeypatch.setattr(
+        trainer_mod,
+        "create_collated_text_batches",
+        fake_create_collated_text_batches,
+    )
+
+    result = trainer_mod._create_text_eval_batches(
+        trainer, trainer.eval_dataset, trainer.args, text_completion_only_loss=None,
+    )
+
+    assert result is expected
+    assert captured["dataset"] == trainer.eval_dataset
+    assert captured["data_collator"] is trainer.data_collator
+    assert captured["batch_size"] == 3
+    assert captured["max_seq_length"] == 12
+    assert captured["seed"] == 13
+    assert captured["dataset_order"] == "torch_randperm"
+
+
+@pytest.mark.parametrize(
+    ("is_vlm", "streaming", "packing", "message"),
+    [
+        (True, False, False, "only for text training"),
+        (False, True, False, "streaming=True"),
+        (False, False, True, "packing=True"),
+    ],
+)
+def test_custom_text_collator_eval_rejects_unsupported_modes(
+    is_vlm, streaming, packing, message,
+):
+    from unsloth_zoo.mlx.trainer import (
+        MLXTrainingConfig,
+        _validate_custom_collator_eval_support,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _validate_custom_collator_eval_support(
+            MLXTrainingConfig(streaming=streaming, packing=packing),
+            is_vlm=is_vlm,
+        )
 
 
 def test_pretokenized_text_streaming_yields_labeled_batches():

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -59,6 +59,7 @@ from .utils import (
     make_vlm_baseline_loss_fn,
     create_batches,
     create_ordered_batches,
+    create_collated_text_batches,
     iterate_training_batches,
     create_vlm_batches,
     iterate_vlm_training_batches,
@@ -560,6 +561,7 @@ class MLXTrainer:
         self.train_dataset = train_dataset
         self.eval_dataset = eval_dataset
         self.formatting_func = formatting_func
+        self.data_collator = data_collator
         # Use args or defaults
         self.args = args or MLXTrainingConfig()
 
@@ -2050,6 +2052,12 @@ class MLXTrainer:
         text_completion_only_loss = _text_completion_only_loss_arg(args)
 
         if is_vlm:
+            if self.data_collator is not None:
+                raise ValueError(
+                    "Unsloth MLX: custom data_collator is supported only for "
+                    "text training. Remove the custom data_collator for "
+                    "vision-language training."
+                )
             _vlm_mask_fn = getattr(self, '_vlm_response_mask_fn', None)
             vlm_dataset_order = (
                 "sequential"
@@ -2100,6 +2108,12 @@ class MLXTrainer:
         else:
             chat_tmpl = getattr(args, "chat_template", None)
             if args.streaming:
+                if self.data_collator is not None:
+                    raise ValueError(
+                        "Unsloth MLX: custom data_collator is not supported "
+                        "with streaming=True. Set streaming=False, or use "
+                        "the built-in MLX text batcher."
+                    )
                 # Streaming has no index space; refuse explicit order requests.
                 if (
                     getattr(args, "preserve_dataset_order", False)
@@ -2125,6 +2139,33 @@ class MLXTrainer:
                     completion_only_loss=text_completion_only_loss,
                 )
             else:
+                if self.data_collator is not None:
+                    text_dataset_order = (
+                        "sequential"
+                        if getattr(args, "preserve_dataset_order", False)
+                        else getattr(args, "dataset_order", "default")
+                    )
+                    collator_num_epochs = (
+                        args.num_train_epochs
+                        if (
+                            args.max_steps <= 0
+                            and args.num_train_epochs > 0
+                            and text_dataset_order == "torch_randperm"
+                        )
+                        else None
+                    )
+                    if collator_num_epochs is not None:
+                        self._prepared_batches_include_epochs = True
+                    return create_collated_text_batches(
+                        dataset=self.train_dataset,
+                        data_collator=self.data_collator,
+                        batch_size=args.per_device_train_batch_size,
+                        max_seq_length=args.max_seq_length,
+                        num_batches=total_batches_needed,
+                        seed=args.seed,
+                        dataset_order=text_dataset_order,
+                        num_epochs=collator_num_epochs,
+                    ), None
                 batch_kwargs = dict(
                     dataset=self.train_dataset,
                     tokenizer=self.tokenizer,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -179,6 +179,11 @@ def _validate_custom_collator_eval_support(args, is_vlm):
 
 def _create_text_eval_batches(trainer, eval_dataset, args, text_completion_only_loss):
     """Materialize text eval batches with optional custom collation."""
+    skip_prepare_dataset = bool(
+        (getattr(args, "dataset_kwargs", None) or {}).get(
+            "skip_prepare_dataset", False,
+        )
+    )
     if getattr(trainer, "data_collator", None) is not None:
         return create_collated_text_batches(
             dataset=eval_dataset,
@@ -187,6 +192,12 @@ def _create_text_eval_batches(trainer, eval_dataset, args, text_completion_only_
             max_seq_length=args.max_seq_length,
             seed=args.seed,
             dataset_order=_text_dataset_order_arg(args),
+            skip_prepare_dataset=skip_prepare_dataset,
+        )
+    if skip_prepare_dataset:
+        raise ValueError(
+            "Unsloth MLX: dataset_kwargs={'skip_prepare_dataset': True} "
+            "requires a custom data_collator for text training."
         )
     return create_batches(
         dataset=eval_dataset,
@@ -571,6 +582,7 @@ class MLXTrainingConfig:
     max_seq_length: int = 2048
     packing: bool = False
     dataset_num_proc: int = 2
+    dataset_kwargs: dict | None = None
     chat_template: object = None  # Unsloth template name/tuple or raw Jinja string
 
     # MLX-specific
@@ -2103,6 +2115,11 @@ class MLXTrainer:
             if args.max_steps > 0 else None
         )
         text_completion_only_loss = _text_completion_only_loss_arg(args)
+        skip_prepare_dataset = bool(
+            (getattr(args, "dataset_kwargs", None) or {}).get(
+                "skip_prepare_dataset", False,
+            )
+        )
 
         if is_vlm:
             if self.data_collator is not None:
@@ -2214,7 +2231,13 @@ class MLXTrainer:
                         seed=args.seed,
                         dataset_order=text_dataset_order,
                         num_epochs=text_num_epochs,
+                        skip_prepare_dataset=skip_prepare_dataset,
                     ), None
+                if skip_prepare_dataset:
+                    raise ValueError(
+                        "Unsloth MLX: dataset_kwargs={'skip_prepare_dataset': True} "
+                        "requires a custom data_collator for text training."
+                    )
                 batch_kwargs = dict(
                     dataset=self.train_dataset,
                     tokenizer=self.tokenizer,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -576,20 +576,6 @@ class MLXTrainer:
         if packing is not None:
             self.args.packing = packing
 
-        if self.data_collator is not None and self.args.packing:
-            raise ValueError(
-                "Unsloth MLX: custom data_collator cannot be used with "
-                "packing=True yet. Set packing=False, or remove the custom "
-                "data_collator."
-            )
-        if self.data_collator is not None and self.formatting_func is not None:
-            raise ValueError(
-                "Unsloth MLX: custom data_collator requires an already "
-                "tokenized text dataset with input_ids. Apply formatting_func "
-                "before creating the trainer, or remove the custom "
-                "data_collator."
-            )
-
         if self.args.packing:
             print(
                 "Unsloth: packing=True is not yet supported on MLX. "
@@ -2163,23 +2149,23 @@ class MLXTrainer:
                     completion_only_loss=text_completion_only_loss,
                 )
             else:
+                text_dataset_order = (
+                    "sequential"
+                    if getattr(args, "preserve_dataset_order", False)
+                    else getattr(args, "dataset_order", "default")
+                )
+                text_num_epochs = (
+                    args.num_train_epochs
+                    if (
+                        args.max_steps <= 0
+                        and args.num_train_epochs > 0
+                        and text_dataset_order == "torch_randperm"
+                    )
+                    else None
+                )
+                if text_num_epochs is not None:
+                    self._prepared_batches_include_epochs = True
                 if self.data_collator is not None:
-                    text_dataset_order = (
-                        "sequential"
-                        if getattr(args, "preserve_dataset_order", False)
-                        else getattr(args, "dataset_order", "default")
-                    )
-                    collator_num_epochs = (
-                        args.num_train_epochs
-                        if (
-                            args.max_steps <= 0
-                            and args.num_train_epochs > 0
-                            and text_dataset_order == "torch_randperm"
-                        )
-                        else None
-                    )
-                    if collator_num_epochs is not None:
-                        self._prepared_batches_include_epochs = True
                     return create_collated_text_batches(
                         dataset=self.train_dataset,
                         data_collator=self.data_collator,
@@ -2188,7 +2174,7 @@ class MLXTrainer:
                         num_batches=total_batches_needed,
                         seed=args.seed,
                         dataset_order=text_dataset_order,
-                        num_epochs=collator_num_epochs,
+                        num_epochs=text_num_epochs,
                     ), None
                 batch_kwargs = dict(
                     dataset=self.train_dataset,
@@ -2207,21 +2193,11 @@ class MLXTrainer:
                 )
                 if (
                     getattr(args, "preserve_dataset_order", False)
-                    or getattr(args, "dataset_order", "default") != "default"
+                    or text_dataset_order != "default"
                 ):
-                    text_dataset_order = (
-                        "sequential"
-                        if getattr(args, "preserve_dataset_order", False)
-                        else getattr(args, "dataset_order", "default")
-                    )
                     batch_kwargs["dataset_order"] = text_dataset_order
-                    if (
-                        args.max_steps <= 0
-                        and args.num_train_epochs > 0
-                        and text_dataset_order == "torch_randperm"
-                    ):
-                        batch_kwargs["num_epochs"] = args.num_train_epochs
-                        self._prepared_batches_include_epochs = True
+                    if text_num_epochs is not None:
+                        batch_kwargs["num_epochs"] = text_num_epochs
                     batches = create_ordered_batches(**batch_kwargs)
                 else:
                     batches = create_batches(**batch_kwargs)
@@ -2639,7 +2615,7 @@ def train_on_responses_only(
     """Mask instruction tokens from loss — train only on assistant responses.
 
     Call after MLXTrainer(...), before trainer.train(). Works for text and
-    VLM models; mirrors the HF/unsloth API.
+    VLM models without custom data_collator; mirrors the HF/unsloth API.
 
     Args:
         trainer: MLXTrainer (may be None when return_function=True and a

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -576,6 +576,20 @@ class MLXTrainer:
         if packing is not None:
             self.args.packing = packing
 
+        if self.data_collator is not None and self.args.packing:
+            raise ValueError(
+                "Unsloth MLX: custom data_collator cannot be used with "
+                "packing=True yet. Set packing=False, or remove the custom "
+                "data_collator."
+            )
+        if self.data_collator is not None and self.formatting_func is not None:
+            raise ValueError(
+                "Unsloth MLX: custom data_collator requires an already "
+                "tokenized text dataset with input_ids. Apply formatting_func "
+                "before creating the trainer, or remove the custom "
+                "data_collator."
+            )
+
         if self.args.packing:
             print(
                 "Unsloth: packing=True is not yet supported on MLX. "
@@ -1199,6 +1213,16 @@ class MLXTrainer:
         args = self.args
         model = self.model
         is_vlm = self._is_vlm
+        if (
+            self.data_collator is not None
+            and args.eval_steps > 0
+            and self.eval_dataset is not None
+        ):
+            raise ValueError(
+                "Unsloth MLX: evaluation with custom data_collator is not "
+                "supported yet. Set eval_steps=0, remove eval_dataset, or "
+                "use the built-in MLX batcher."
+            )
 
         # Pick loss function (returns (loss, ntoks))
         use_cce = args.use_cce
@@ -2635,6 +2659,17 @@ def train_on_responses_only(
     from ..dataset_utils import (
         train_on_responses_only as _hf_train_on_responses_only,
     )
+
+    if (
+        not return_function
+        and trainer is not None
+        and getattr(trainer, "data_collator", None) is not None
+    ):
+        raise ValueError(
+            "Unsloth MLX: train_on_responses_only cannot be combined with a "
+            "custom data_collator yet. Apply response masks before creating "
+            "the trainer, or remove the custom data_collator."
+        )
 
     # Resolve tokenizer: kwarg > trainer.tokenizer
     _tokenizer = tokenizer

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -146,6 +146,68 @@ def _text_completion_only_loss_arg(args):
     return None
 
 
+def _text_dataset_order_arg(args):
+    """Resolve the text dataset order used by materialized MLX batches."""
+    return (
+        "sequential"
+        if getattr(args, "preserve_dataset_order", False)
+        else getattr(args, "dataset_order", "default")
+    )
+
+
+def _validate_custom_collator_eval_support(args, is_vlm):
+    """Reject custom-collator eval modes not represented by text batches."""
+    if is_vlm:
+        raise ValueError(
+            "Unsloth MLX: evaluation with custom data_collator is supported "
+            "only for text training. Remove the custom data_collator for "
+            "vision-language evaluation."
+        )
+    if getattr(args, "streaming", False):
+        raise ValueError(
+            "Unsloth MLX: evaluation with custom data_collator is not "
+            "supported with streaming=True. Set streaming=False, or remove "
+            "the custom data_collator."
+        )
+    if getattr(args, "packing", False):
+        raise ValueError(
+            "Unsloth MLX: evaluation with custom data_collator is not "
+            "supported with packing=True. Disable packing, or remove the "
+            "custom data_collator."
+        )
+
+
+def _create_text_eval_batches(trainer, eval_dataset, args, text_completion_only_loss):
+    """Materialize text eval batches with optional custom collation."""
+    if getattr(trainer, "data_collator", None) is not None:
+        return create_collated_text_batches(
+            dataset=eval_dataset,
+            data_collator=trainer.data_collator,
+            batch_size=args.per_device_train_batch_size,
+            max_seq_length=args.max_seq_length,
+            seed=args.seed,
+            dataset_order=_text_dataset_order_arg(args),
+        )
+    return create_batches(
+        dataset=eval_dataset,
+        tokenizer=trainer.tokenizer,
+        batch_size=args.per_device_train_batch_size,
+        max_seq_length=args.max_seq_length,
+        seed=args.seed,
+        dataset_text_field=args.dataset_text_field,
+        formatting_func=trainer.formatting_func,
+        chat_template=getattr(args, "chat_template", None),
+        model_name=getattr(trainer.model, "_hf_repo", None),
+        model_type=(
+            getattr(trainer.model, "_config", {}).get("model_type")
+            if isinstance(getattr(trainer.model, "_config", {}), dict)
+            else None
+        ),
+        append_eos=bool(getattr(args, "append_eos", True)),
+        completion_only_loss=text_completion_only_loss,
+    )
+
+
 def _normalize_mlx_optimizer_name(name):
     opt_name = str(name or "adamw").strip().lower()
     if opt_name not in SUPPORTED_MLX_OPTIMIZERS:
@@ -1204,11 +1266,7 @@ class MLXTrainer:
             and args.eval_steps > 0
             and self.eval_dataset is not None
         ):
-            raise ValueError(
-                "Unsloth MLX: evaluation with custom data_collator is not "
-                "supported yet. Set eval_steps=0, remove eval_dataset, or "
-                "use the built-in MLX batcher."
-            )
+            _validate_custom_collator_eval_support(args, is_vlm)
 
         # Pick loss function (returns (loss, ntoks))
         use_cce = args.use_cce
@@ -1653,23 +1711,8 @@ class MLXTrainer:
                             formatting_func=self.formatting_func,
                             completion_only_loss=text_completion_only_loss,
                         )
-                    return create_batches(
-                        dataset=eval_dataset,
-                        tokenizer=self.tokenizer,
-                        batch_size=args.per_device_train_batch_size,
-                        max_seq_length=args.max_seq_length,
-                        seed=args.seed,
-                        dataset_text_field=args.dataset_text_field,
-                        formatting_func=self.formatting_func,
-                        chat_template=getattr(args, "chat_template", None),
-                        model_name=getattr(self.model, "_hf_repo", None),
-                        model_type=(
-                            getattr(self.model, "_config", {}).get("model_type")
-                            if isinstance(getattr(self.model, "_config", {}), dict)
-                            else None
-                        ),
-                        append_eos=bool(getattr(args, "append_eos", True)),
-                        completion_only_loss=text_completion_only_loss,
+                    return _create_text_eval_batches(
+                        self, eval_dataset, args, text_completion_only_loss,
                     )
 
                 if isinstance(self.eval_dataset, dict):
@@ -2149,11 +2192,7 @@ class MLXTrainer:
                     completion_only_loss=text_completion_only_loss,
                 )
             else:
-                text_dataset_order = (
-                    "sequential"
-                    if getattr(args, "preserve_dataset_order", False)
-                    else getattr(args, "dataset_order", "default")
-                )
+                text_dataset_order = _text_dataset_order_arg(args)
                 text_num_epochs = (
                     args.num_train_epochs
                     if (

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1657,6 +1657,7 @@ class MLXTrainer:
                             else None
                         ),
                         append_eos=bool(getattr(args, "append_eos", True)),
+                        completion_only_loss=text_completion_only_loss,
                     )
 
                 if isinstance(self.eval_dataset, dict):
@@ -2121,6 +2122,7 @@ class MLXTrainer:
                     model_name=model_name,
                     model_type=model_type,
                     append_eos=bool(getattr(args, "append_eos", True)),
+                    completion_only_loss=text_completion_only_loss,
                 )
             else:
                 batch_kwargs = dict(
@@ -2136,6 +2138,7 @@ class MLXTrainer:
                     model_name=model_name,
                     model_type=model_type,
                     append_eos=bool(getattr(args, "append_eos", True)),
+                    completion_only_loss=text_completion_only_loss,
                 )
                 if (
                     getattr(args, "preserve_dataset_order", False)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3659,7 +3659,11 @@ _CUSTOM_COLLATOR_TEXT_COLUMNS = frozenset((
 
 
 def _prepare_custom_collator_text_examples(dataset, max_seq_length):
-    """Prepare tokenized text examples with SFTTrainer text columns."""
+    """Keep/truncate CUDA SFT text columns before user collation.
+
+    Only ``input_ids``, ``labels``, ``completion_mask``, and
+    ``assistant_masks`` are forwarded; other dataset columns are dropped.
+    """
     first_item, replay_dataset = _peek_dataset(dataset)
     if not isinstance(first_item, Mapping) or first_item.get("input_ids") is None:
         raise ValueError(
@@ -3715,54 +3719,70 @@ def _collator_value_to_numpy(value, field, expected_batch_size=None):
             f"Unsloth MLX: custom data_collator field `{field}` must be a "
             f"1D or 2D tensor/array, got shape {array.shape}."
         )
-    if expected_batch_size is not None and array.shape[0] != expected_batch_size:
-        raise ValueError(
-            f"Unsloth MLX: custom data_collator field `{field}` batch size "
-            f"{array.shape[0]} does not match the {expected_batch_size} "
-            "selected examples."
-        )
     return array
 
 
-def _lengths_from_collator_attention(attention_mask, batch_size, seq_len):
-    """Build MLX [start, end) lengths from a right-padded attention mask."""
-    if attention_mask is None:
-        return np.array([[0, seq_len] for _ in range(batch_size)], dtype=np.int32)
+def _require_collator_integer_dtype(array, field):
+    """Reject custom-collator arrays that would be silently truncated."""
+    if not np.issubdtype(array.dtype, np.integer):
+        raise ValueError(
+            f"Unsloth MLX: custom data_collator field `{field}` must use "
+            f"an integer dtype, got {array.dtype}."
+        )
+
+
+def _require_collator_mask_dtype(array, field):
+    """Accept bool, integer, or 0/1 float custom-collator masks."""
+    if not (
+        np.issubdtype(array.dtype, np.bool_)
+        or np.issubdtype(array.dtype, np.integer)
+        or np.issubdtype(array.dtype, np.floating)
+    ):
+        raise ValueError(
+            f"Unsloth MLX: custom data_collator field `{field}` must use "
+            f"a bool, integer, or floating dtype, got {array.dtype}."
+        )
+    if np.issubdtype(array.dtype, np.floating):
+        if not np.all(np.isfinite(array)):
+            raise ValueError(
+                f"Unsloth MLX: custom data_collator field `{field}` must "
+                "contain finite values."
+            )
+        if not np.all((array == 0) | (array == 1)):
+            raise ValueError(
+                f"Unsloth MLX: custom data_collator field `{field}` must use "
+                "0/1 values when returned with a floating dtype."
+            )
+
+
+def _lengths_from_collator_attention(attention_mask):
+    """Build MLX lengths from right-padded custom-collator masks."""
     lengths = []
     for row in attention_mask:
         active = np.flatnonzero(row)
         if len(active) == 0:
             lengths.append([0, 0])
         else:
-            if active[0] != 0:
+            if active[0] != 0 or active[-1] - active[0] + 1 != len(active):
                 raise ValueError(
-                    "Unsloth MLX: custom data_collator attention_mask must "
-                    "use right padding. Left padding is not supported on MLX "
-                    "custom collator batches yet."
+                    "Unsloth MLX: custom data_collator attention_mask outputs "
+                    "must use contiguous right padding. Left padding, holes, "
+                    "and padding-free masks are not supported yet."
                 )
-            if active[-1] - active[0] + 1 != len(active):
-                raise ValueError(
-                    "Unsloth MLX: custom data_collator attention_mask must "
-                    "contain only contiguous right padding."
-                )
-            lengths.append([int(active[0]), int(active[-1]) + 1])
+            lengths.append([0, int(active[-1]) + 1])
     return np.asarray(lengths, dtype=np.int32)
 
 
-def _validate_custom_collator_shifted_targets(labels_np, lengths_np, attention_mask_np=None):
-    """Validate shifted custom-collator labels against mask and target rules."""
-    if labels_np.shape[1] <= 1:
-        raise ValueError(
-            "Unsloth MLX: custom data_collator produced a batch with no "
-            "supervised target tokens."
-        )
-    if attention_mask_np is not None:
-        masked_targets = (attention_mask_np[:, 1:] == 0) & (labels_np[:, 1:] != -100)
-        if np.any(masked_targets):
-            raise ValueError(
-                "Unsloth MLX: custom data_collator labels must be -100 wherever "
-                "the shifted attention_mask is 0."
-            )
+def _full_collator_lengths(input_ids_np):
+    """Build full-sequence lengths when no attention mask is returned."""
+    return np.tile(
+        np.array([[0, input_ids_np.shape[1]]], dtype=np.int32),
+        (input_ids_np.shape[0], 1),
+    )
+
+
+def _validate_custom_collator_targets(labels_np, lengths_np):
+    """Validate custom-collator labels after causal shifting."""
     targets = labels_np[:, 1:]
     steps = np.arange(1, labels_np.shape[1], dtype=np.int32)
     length_mask = (
@@ -3771,8 +3791,8 @@ def _validate_custom_collator_shifted_targets(labels_np, lengths_np, attention_m
     )
     if not bool(np.any((targets != -100) & length_mask)):
         raise ValueError(
-            "Unsloth MLX: custom data_collator produced a batch with no "
-            "supervised target tokens."
+            "Unsloth MLX: custom data_collator produced no supervised "
+            "target tokens after causal shifting."
         )
 
 
@@ -3785,24 +3805,36 @@ def _trim_custom_collator_ignored_tail(
         return input_ids_np, labels_np, attention_mask_np
     if attention_mask_np is not None:
         tail_mask = attention_mask_np[:, max_seq_length:seq_len]
-        if np.any(tail_mask != 0):
-            raise ValueError(
-                "Unsloth MLX: custom data_collator returned active "
-                "attention_mask values past max_seq_length. Truncate or mask "
-                "those tokens before returning the batch."
-            )
+    if attention_mask_np is not None and np.any(tail_mask != 0):
+        raise ValueError(
+            "Unsloth MLX: custom data_collator returned active "
+            "attention_mask values past max_seq_length. Truncate or mask "
+            "those tokens before returning the batch."
+        )
     tail_labels = labels_np[:, max_seq_length:seq_len]
     if not np.all(tail_labels == -100):
         raise ValueError(
             "Unsloth MLX: custom data_collator returned supervised labels "
             "past max_seq_length. Truncate or set those labels to -100 before "
             "returning the batch."
-        )
+    )
     input_ids_np = input_ids_np[:, :max_seq_length]
     labels_np = labels_np[:, :max_seq_length]
     if attention_mask_np is not None:
         attention_mask_np = attention_mask_np[:, :max_seq_length]
     return input_ids_np, labels_np, attention_mask_np
+
+
+def _validate_custom_collator_masked_labels(labels_np, attention_mask_np):
+    """Require ignored attention positions to already use ignored labels."""
+    if attention_mask_np is None:
+        return
+    masked_labels = labels_np[attention_mask_np == 0]
+    if np.any(masked_labels != -100):
+        raise ValueError(
+            "Unsloth MLX: custom data_collator labels must be -100 wherever "
+            "attention_mask is 0."
+        )
 
 
 def _collator_output_to_text_batch(output, max_seq_length, expected_batch_size=None):
@@ -3821,7 +3853,7 @@ def _collator_output_to_text_batch(output, max_seq_length, expected_batch_size=N
         output["input_ids"], "input_ids",
         expected_batch_size=expected_batch_size,
     )
-    batch_size, seq_len = input_ids_np.shape
+    _require_collator_integer_dtype(input_ids_np, "input_ids")
 
     if output.get("labels") is None:
         raise ValueError(
@@ -3829,51 +3861,35 @@ def _collator_output_to_text_batch(output, max_seq_length, expected_batch_size=N
             "ignored tokens can be masked correctly."
         )
     labels_np = _collator_value_to_numpy(output["labels"], "labels")
-    if labels_np.shape[0] != batch_size:
+    _require_collator_integer_dtype(labels_np, "labels")
+    if labels_np.shape != input_ids_np.shape:
         raise ValueError(
-            "Unsloth MLX: custom data_collator labels batch size "
-            f"{labels_np.shape[0]} does not match input_ids batch size "
-            f"{batch_size}."
-        )
-    if labels_np.shape[1] < seq_len:
-        raise ValueError(
-            "Unsloth MLX: custom data_collator labels sequence length "
-            f"{labels_np.shape[1]} is shorter than input_ids sequence "
-            f"length {seq_len}."
-        )
-    if labels_np.shape[1] > seq_len:
-        raise ValueError(
-            "Unsloth MLX: custom data_collator labels sequence length "
-            f"{labels_np.shape[1]} does not match input_ids sequence length "
-            f"{seq_len}."
+            "Unsloth MLX: custom data_collator labels shape "
+            f"{labels_np.shape} does not match input_ids shape "
+            f"{input_ids_np.shape}."
         )
     attention_mask_np = None
     if output.get("attention_mask") is not None:
         attention_mask_np = _collator_value_to_numpy(
             output["attention_mask"], "attention_mask",
         )
-        if attention_mask_np.shape[0] != batch_size:
+        _require_collator_mask_dtype(attention_mask_np, "attention_mask")
+        if attention_mask_np.shape != input_ids_np.shape:
             raise ValueError(
-                "Unsloth MLX: custom data_collator attention_mask batch size "
-                f"{attention_mask_np.shape[0]} does not match input_ids "
-                f"batch size {batch_size}."
+                "Unsloth MLX: custom data_collator attention_mask shape "
+                f"{attention_mask_np.shape} does not match input_ids shape "
+                f"{input_ids_np.shape}."
             )
-        if attention_mask_np.shape[1] != seq_len:
-            raise ValueError(
-                "Unsloth MLX: custom data_collator attention_mask sequence "
-                f"length {attention_mask_np.shape[1]} does not match input_ids "
-                f"sequence length {seq_len}."
-            )
+    _validate_custom_collator_masked_labels(labels_np, attention_mask_np)
     input_ids_np, labels_np, attention_mask_np = _trim_custom_collator_ignored_tail(
         input_ids_np, labels_np, attention_mask_np, max_seq_length,
     )
-    batch_size, seq_len = input_ids_np.shape
-    lengths_np = _lengths_from_collator_attention(
-        attention_mask_np, batch_size, seq_len,
+    lengths_np = (
+        _lengths_from_collator_attention(attention_mask_np)
+        if attention_mask_np is not None
+        else _full_collator_lengths(input_ids_np)
     )
-    _validate_custom_collator_shifted_targets(
-        labels_np, lengths_np, attention_mask_np,
-    )
+    _validate_custom_collator_targets(labels_np, lengths_np)
     labels = _normalize_cce_label_dtype(mx.array(labels_np))
 
     return (
@@ -3900,9 +3916,8 @@ class _LazyCollatedTextBatches:
             yield self[index]
 
     def __getitem__(self, index):
-        if index < 0:
-            index += len(self)
-        batch_examples = [self._examples[i] for i in self._chunks[index]]
+        chunk = self._chunks[index]
+        batch_examples = [self._examples[i] for i in chunk]
         return _collator_output_to_text_batch(
             self._data_collator(batch_examples),
             self._max_seq_length,
@@ -3922,8 +3937,8 @@ def create_collated_text_batches(
 ):
     """Create text batches that call the user collator on batch access.
 
-    Input examples are pruned to SFTTrainer's default text signature columns
-    before the collator runs.
+    Tokenized examples are truncated before the collator runs. Packed
+    ``seq_lengths`` / padding-free outputs are rejected by this MLX path.
     """
     examples = _prepare_custom_collator_text_examples(dataset, max_seq_length)
     chunks = []
@@ -3934,7 +3949,6 @@ def create_collated_text_batches(
         seed=seed,
         dataset_order=dataset_order,
         num_epochs=target_epochs,
-        drop_last_default=False,
     ):
         chunks.append(list(chunk))
         if num_batches is not None and len(chunks) >= num_batches:
@@ -4178,7 +4192,6 @@ def _iter_text_index_chunks(
     seed,
     dataset_order,
     num_epochs=None,
-    drop_last_default=True,
 ):
     """Yield text batch index chunks using mlx-lm/default or explicit ordering."""
     if dataset_order not in (None, "default", "sequential", "torch_randperm"):
@@ -4193,10 +4206,9 @@ def _iter_text_index_chunks(
     while num_epochs is None or epoch < int(num_epochs):
         if dataset_order in (None, "default"):
             ordered = sorted(range(length), key=lambda idx: _text_item_length(items[idx]))
-            stop = length - batch_size + 1 if drop_last_default else length
             chunks = [
                 ordered[start:start + batch_size]
-                for start in range(0, stop, batch_size)
+                for start in range(0, length - batch_size + 1, batch_size)
             ]
             if not chunks:
                 raise ValueError(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3579,29 +3579,38 @@ def _aligned_text_field(item, field, length):
     return values[:length]
 
 
+def _prepare_pretokenized_text_row(item, max_seq_length, completion_only_loss=False):
+    """Normalize one pre-tokenized text row, or return None when unusable."""
+    if not isinstance(item, dict) or item.get("input_ids") is None:
+        return None
+    input_ids = _to_int_list(item["input_ids"])[:max_seq_length]
+    if len(input_ids) < 2:
+        return None
+
+    row = {"input_ids": input_ids}
+    labels = _aligned_text_field(item, "labels", len(input_ids))
+    if labels is not None:
+        row["labels"] = labels
+    if completion_only_loss and "completion_mask" in item:
+        completion_mask = _aligned_text_field(item, "completion_mask", len(input_ids))
+        if completion_mask is not None:
+            row["completion_mask"] = completion_mask
+    if "assistant_masks" in item:
+        assistant_masks = _aligned_text_field(item, "assistant_masks", len(input_ids))
+        if assistant_masks is not None:
+            row["assistant_masks"] = assistant_masks
+    return row
+
+
 def _prepare_pretokenized_text_rows(dataset, max_seq_length, completion_only_loss=False):
     """Normalize pre-tokenized text rows to TRL collator-compatible fields."""
     rows = []
     for item in dataset:
-        if not isinstance(item, dict) or item.get("input_ids") is None:
-            continue
-        input_ids = _to_int_list(item["input_ids"])[:max_seq_length]
-        if len(input_ids) < 2:
-            continue
-
-        row = {"input_ids": input_ids}
-        labels = _aligned_text_field(item, "labels", len(input_ids))
-        if labels is not None:
-            row["labels"] = labels
-        if completion_only_loss and "completion_mask" in item:
-            completion_mask = _aligned_text_field(item, "completion_mask", len(input_ids))
-            if completion_mask is not None:
-                row["completion_mask"] = completion_mask
-        if "assistant_masks" in item:
-            assistant_masks = _aligned_text_field(item, "assistant_masks", len(input_ids))
-            if assistant_masks is not None:
-                row["assistant_masks"] = assistant_masks
-        rows.append(row)
+        row = _prepare_pretokenized_text_row(
+            item, max_seq_length, completion_only_loss=completion_only_loss
+        )
+        if row is not None:
+            rows.append(row)
 
     if not rows:
         raise ValueError(
@@ -3725,30 +3734,16 @@ def _prepare_prompt_completion_text_rows(
     mask_completions = True if completion_only_loss is None else bool(completion_only_loss)
     eos_token = getattr(tokenizer, "eos_token", None) if append_eos else None
     for item in dataset:
-        if not isinstance(item, dict) or "prompt" not in item or "completion" not in item:
-            continue
-
-        if _is_trl_chat_messages(item.get("prompt")):
-            prompt_ids, input_ids = _tokenize_conversational_prompt_completion(
-                tokenizer, item
-            )
-        else:
-            prompt_text, completion_text = _prompt_completion_text_parts(
-                tokenizer, item, dataset_text_field
-            )
-            if eos_token and not completion_text.endswith(eos_token):
-                completion_text += eos_token
-            input_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text + completion_text))
-            prompt_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text))
-        input_ids = input_ids[:max_seq_length]
-        if len(input_ids) < 2:
-            continue
-
-        row = {"input_ids": input_ids}
-        if mask_completions:
-            prompt_len = min(len(prompt_ids), len(input_ids))
-            row["completion_mask"] = [0] * prompt_len + [1] * (len(input_ids) - prompt_len)
-        rows.append(row)
+        row = _prepare_prompt_completion_text_row(
+            item,
+            tokenizer,
+            max_seq_length,
+            dataset_text_field=dataset_text_field,
+            mask_completions=mask_completions,
+            eos_token=eos_token,
+        )
+        if row is not None:
+            rows.append(row)
 
     if not rows:
         raise ValueError(
@@ -3756,6 +3751,43 @@ def _prepare_prompt_completion_text_rows(
             "sequences (need at least two input_ids after truncation)."
         )
     return rows
+
+
+def _prepare_prompt_completion_text_row(
+    item,
+    tokenizer,
+    max_seq_length,
+    dataset_text_field="text",
+    mask_completions=True,
+    eos_token=None,
+):
+    """Tokenize one prompt/completion row and mask prompt tokens."""
+    if not isinstance(item, dict) or "prompt" not in item or "completion" not in item:
+        return None
+
+    if _is_trl_chat_messages(item.get("prompt")):
+        prompt_ids, input_ids = _tokenize_conversational_prompt_completion(
+            tokenizer, item
+        )
+    else:
+        prompt_text, completion_text = _prompt_completion_text_parts(
+            tokenizer, item, dataset_text_field
+        )
+        if eos_token and not completion_text.endswith(eos_token):
+            completion_text += eos_token
+        input_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text + completion_text))
+        prompt_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text))
+    input_ids = input_ids[:max_seq_length]
+    if len(input_ids) < 2:
+        return None
+
+    row = {"input_ids": input_ids}
+    if mask_completions:
+        prompt_len = min(len(prompt_ids), len(input_ids))
+        if prompt_len >= len(input_ids):
+            return None
+        row["completion_mask"] = [0] * prompt_len + [1] * (len(input_ids) - prompt_len)
+    return row
 
 
 def _make_labeled_text_batch_tuple(batch_rows, max_seq_length, pad_id=0):
@@ -3916,23 +3948,49 @@ def _make_labeled_text_batches(
     return batch_pairs
 
 
-def _iterate_labeled_text_batches(
-    rows,
+def _iterate_labeled_text_batches_from_dataset(
+    dataset,
     tokenizer,
     batch_size,
     max_seq_length,
-    seed=None,
-    dataset_order="default",
+    prepare_row,
+    repeat_dataset=None,
 ):
-    """Yield labeled text batches without materializing each epoch."""
+    """Yield labeled text batches from rows as they are read."""
     pad_id = getattr(tokenizer, "pad_token_id", None)
     pad_id = 0 if pad_id is None else int(pad_id)
-    for chunk in _iter_text_index_chunks(rows, batch_size, seed, dataset_order):
-        batch = _make_labeled_text_batch_tuple(
-            [rows[i] for i in chunk], max_seq_length, pad_id=pad_id
-        )
-        mx.eval([batch[0], batch[1], batch[2]])
-        yield batch
+    source = dataset
+    while True:
+        pending = []
+        yielded = False
+        for item in source:
+            row = prepare_row(item)
+            if row is None:
+                continue
+            pending.append(row)
+            if len(pending) >= batch_size:
+                batch = _make_labeled_text_batch_tuple(
+                    pending, max_seq_length, pad_id=pad_id
+                )
+                mx.eval([batch[0], batch[1], batch[2]])
+                yield batch
+                yielded = True
+                pending = []
+        if pending:
+            batch = _make_labeled_text_batch_tuple(
+                pending, max_seq_length, pad_id=pad_id
+            )
+            mx.eval([batch[0], batch[1], batch[2]])
+            yield batch
+            yielded = True
+        if not yielded:
+            raise ValueError(
+                "Unsloth MLX: streaming labeled dataset produced no trainable "
+                "token sequences."
+            )
+        if repeat_dataset is None:
+            return
+        source = repeat_dataset
 
 
 def create_batches(dataset, tokenizer, batch_size, max_seq_length,
@@ -3961,7 +4019,7 @@ def create_batches(dataset, tokenizer, batch_size, max_seq_length,
     _raise_if_completion_formatter_conflict(
         formatting_func, completion_only_loss, first_item
     )
-    if isinstance(first_item, dict) and "input_ids" in first_item:
+    if isinstance(first_item, dict) and first_item.get("input_ids") is not None:
         rows = _prepare_pretokenized_text_rows(
             replay_dataset,
             max_seq_length,
@@ -4069,7 +4127,7 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
     _raise_if_completion_formatter_conflict(
         formatting_func, completion_only_loss, first_item
     )
-    if isinstance(first_item, dict) and "input_ids" in first_item:
+    if isinstance(first_item, dict) and first_item.get("input_ids") is not None:
         rows = _prepare_pretokenized_text_rows(
             replay_dataset,
             max_seq_length,
@@ -4223,22 +4281,24 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
     _raise_if_completion_formatter_conflict(
         formatting_func, completion_only_loss, first_item
     )
-    if isinstance(first_item, dict) and "input_ids" in first_item:
-        rows = _prepare_pretokenized_text_rows(
-            replay_dataset,
-            max_seq_length,
-            completion_only_loss=_pretokenized_completion_only_loss(
-                completion_only_loss, first_item
-            ),
+    if isinstance(first_item, dict) and first_item.get("input_ids") is not None:
+        pretokenized_completion_only = _pretokenized_completion_only_loss(
+            completion_only_loss, first_item
         )
-        yield from _iterate_labeled_text_batches(
-            rows,
+        repeat_dataset = dataset if iter(dataset) is not dataset else None
+        yield from _iterate_labeled_text_batches_from_dataset(
+            replay_dataset,
             tokenizer,
             batch_size,
             max_seq_length,
-            seed=seed,
-            dataset_order="default",
+            lambda item: _prepare_pretokenized_text_row(
+                item,
+                max_seq_length,
+                completion_only_loss=pretokenized_completion_only,
+            ),
+            repeat_dataset=repeat_dataset,
         )
+        return
 
     if (
         formatting_func is None
@@ -4254,22 +4314,25 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             is_vlm=False,
             strict=False,
         )
-        rows = _prepare_prompt_completion_text_rows(
+        mask_completions = True if completion_only_loss is None else bool(completion_only_loss)
+        eos_token = getattr(tokenizer, "eos_token", None) if append_eos else None
+        repeat_dataset = dataset if iter(dataset) is not dataset else None
+        yield from _iterate_labeled_text_batches_from_dataset(
             replay_dataset,
-            tokenizer,
-            max_seq_length,
-            dataset_text_field=dataset_text_field,
-            completion_only_loss=completion_only_loss,
-            append_eos=append_eos,
-        )
-        yield from _iterate_labeled_text_batches(
-            rows,
             tokenizer,
             batch_size,
             max_seq_length,
-            seed=seed,
-            dataset_order="default",
+            lambda item: _prepare_prompt_completion_text_row(
+                item,
+                tokenizer,
+                max_seq_length,
+                dataset_text_field=dataset_text_field,
+                mask_completions=mask_completions,
+                eos_token=eos_token,
+            ),
+            repeat_dataset=repeat_dataset,
         )
+        return
 
     ds = _prepare_dataset(
         replay_dataset, tokenizer, dataset_text_field, formatting_func,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3627,25 +3627,118 @@ def _prompt_completion_text_parts(tokenizer, item, dataset_text_field):
     return prompt or "", completion or ""
 
 
+def _is_trl_chat_messages(value):
+    """Return whether a value is TRL-style role/content chat messages."""
+    return (
+        isinstance(value, list)
+        and len(value) > 0
+        and isinstance(value[0], dict)
+        and "role" in value[0]
+        and "content" in value[0]
+    )
+
+
+def _unwrap_chat_template_ids(value):
+    """Return flat input_ids from tokenizer chat-template outputs."""
+    if isinstance(value, dict):
+        value = value["input_ids"]
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, (list, tuple)) and value and isinstance(value[0], list):
+        value = value[0]
+    return _to_int_list(value)
+
+
+def _tokenize_conversational_prompt_completion(tokenizer, item):
+    """Tokenize conversational prompt/completion rows with TRL's split point."""
+    prompt = _normalize_mlx_messages(item["prompt"], is_vlm=False)
+    completion = _normalize_mlx_messages(item["completion"], is_vlm=False)
+    tools = item.get("tools")
+    chat_kwargs = item.get("chat_template_kwargs") or {}
+
+    prompt_ids = tokenizer.apply_chat_template(
+        prompt,
+        tokenize=True,
+        add_generation_prompt=True,
+        tools=tools,
+        **chat_kwargs,
+    )
+    prompt_completion = tokenizer.apply_chat_template(
+        prompt + completion,
+        return_dict=True,
+        tokenize=True,
+        tools=tools,
+        **chat_kwargs,
+    )
+    return (
+        _unwrap_chat_template_ids(prompt_ids),
+        _unwrap_chat_template_ids(prompt_completion),
+    )
+
+
+def _raise_if_completion_formatter_conflict(
+    formatting_func,
+    completion_only_loss,
+    first_item,
+):
+    """Mirror TRL's rejection of formatters with completion-only loss."""
+    if formatting_func is None:
+        return
+    if completion_only_loss is None:
+        completion_only = (
+            isinstance(first_item, dict)
+            and "prompt" in first_item
+            and "completion" in first_item
+        )
+    else:
+        completion_only = bool(completion_only_loss)
+    if completion_only:
+        raise ValueError(
+            "Unsloth MLX: formatting_func is incompatible with "
+            "completion_only_loss=True. Apply formatting before passing the "
+            "dataset, or disable completion_only_loss."
+        )
+
+
+def _pretokenized_completion_only_loss(completion_only_loss, first_item):
+    """Resolve TRL's completion-only default for pre-tokenized rows."""
+    if completion_only_loss is not None:
+        return bool(completion_only_loss)
+    return (
+        isinstance(first_item, dict)
+        and "prompt" in first_item
+        and "completion" in first_item
+    )
+
+
 def _prepare_prompt_completion_text_rows(
     dataset,
     tokenizer,
     max_seq_length,
     dataset_text_field="text",
     completion_only_loss=None,
+    append_eos=True,
 ):
     """Tokenize prompt/completion rows and build CUDA-style completion masks."""
     rows = []
     mask_completions = True if completion_only_loss is None else bool(completion_only_loss)
+    eos_token = getattr(tokenizer, "eos_token", None) if append_eos else None
     for item in dataset:
         if not isinstance(item, dict) or "prompt" not in item or "completion" not in item:
             continue
 
-        prompt_text, completion_text = _prompt_completion_text_parts(
-            tokenizer, item, dataset_text_field
-        )
-        input_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text + completion_text))
-        prompt_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text))
+        if _is_trl_chat_messages(item.get("prompt")):
+            prompt_ids, input_ids = _tokenize_conversational_prompt_completion(
+                tokenizer, item
+            )
+        else:
+            prompt_text, completion_text = _prompt_completion_text_parts(
+                tokenizer, item, dataset_text_field
+            )
+            if eos_token and not completion_text.endswith(eos_token):
+                completion_text += eos_token
+            input_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text + completion_text))
+            prompt_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text))
         input_ids = input_ids[:max_seq_length]
         if len(input_ids) < 2:
             continue
@@ -3819,11 +3912,16 @@ def create_batches(dataset, tokenizer, batch_size, max_seq_length,
     from mlx_lm.tuner.trainer import iterate_batches
 
     first_item, replay_dataset = _peek_dataset(dataset)
+    _raise_if_completion_formatter_conflict(
+        formatting_func, completion_only_loss, first_item
+    )
     if isinstance(first_item, dict) and "input_ids" in first_item:
         rows = _prepare_pretokenized_text_rows(
             replay_dataset,
             max_seq_length,
-            completion_only_loss=bool(completion_only_loss),
+            completion_only_loss=_pretokenized_completion_only_loss(
+                completion_only_loss, first_item
+            ),
         )
         return _make_labeled_text_batches(
             rows,
@@ -3847,6 +3945,7 @@ def create_batches(dataset, tokenizer, batch_size, max_seq_length,
             max_seq_length,
             dataset_text_field=dataset_text_field,
             completion_only_loss=completion_only_loss,
+            append_eos=append_eos,
         )
         return _make_labeled_text_batches(
             rows,
@@ -3912,11 +4011,16 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
     """
 
     first_item, replay_dataset = _peek_dataset(dataset)
+    _raise_if_completion_formatter_conflict(
+        formatting_func, completion_only_loss, first_item
+    )
     if isinstance(first_item, dict) and "input_ids" in first_item:
         rows = _prepare_pretokenized_text_rows(
             replay_dataset,
             max_seq_length,
-            completion_only_loss=bool(completion_only_loss),
+            completion_only_loss=_pretokenized_completion_only_loss(
+                completion_only_loss, first_item
+            ),
         )
         return _make_labeled_text_batches(
             rows,
@@ -3945,6 +4049,7 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
             max_seq_length,
             dataset_text_field=dataset_text_field,
             completion_only_loss=completion_only_loss,
+            append_eos=append_eos,
         )
         return _make_labeled_text_batches(
             rows,
@@ -4051,11 +4156,16 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
     from mlx_lm.tuner.trainer import iterate_batches
 
     first_item, replay_dataset = _peek_dataset(dataset)
+    _raise_if_completion_formatter_conflict(
+        formatting_func, completion_only_loss, first_item
+    )
     if isinstance(first_item, dict) and "input_ids" in first_item:
         rows = _prepare_pretokenized_text_rows(
             replay_dataset,
             max_seq_length,
-            completion_only_loss=bool(completion_only_loss),
+            completion_only_loss=_pretokenized_completion_only_loss(
+                completion_only_loss, first_item
+            ),
         )
         while True:
             for batch in _make_labeled_text_batches(
@@ -4080,6 +4190,7 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             max_seq_length,
             dataset_text_field=dataset_text_field,
             completion_only_loss=completion_only_loss,
+            append_eos=append_eos,
         )
         while True:
             for batch in _make_labeled_text_batches(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -36,6 +36,7 @@ import sys
 import shutil
 import tempfile
 import threading
+from collections.abc import Mapping
 from pathlib import Path
 
 
@@ -3640,10 +3641,19 @@ def _prepare_pretokenized_text_rows(dataset, max_seq_length, completion_only_los
     return rows
 
 
+def _truncate_token_aligned_custom_field(value, input_length, max_seq_length):
+    """Truncate sequence fields that align with input_ids."""
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, (list, tuple)) and len(value) == input_length:
+        return list(value)[:max_seq_length]
+    return value
+
+
 def _prepare_custom_collator_text_examples(dataset, max_seq_length):
     """Prepare tokenized text examples for a user-provided collator."""
     first_item, replay_dataset = _peek_dataset(dataset)
-    if not isinstance(first_item, dict) or first_item.get("input_ids") is None:
+    if not isinstance(first_item, Mapping) or first_item.get("input_ids") is None:
         raise ValueError(
             "Unsloth MLX: custom data_collator requires a tokenized text "
             "dataset with `input_ids`. Raw text, VLM, streaming, packing, "
@@ -3651,34 +3661,32 @@ def _prepare_custom_collator_text_examples(dataset, max_seq_length):
             "data_collator yet."
         )
 
-    token_fields = (
-        "input_ids",
-        "labels",
-        "attention_mask",
-        "completion_mask",
-        "assistant_masks",
-        "token_type_ids",
-        "position_ids",
-    )
     examples = []
     for item in replay_dataset:
-        if not isinstance(item, dict) or item.get("input_ids") is None:
-            continue
-        input_ids = _to_int_list(item["input_ids"])[:max_seq_length]
-        if len(input_ids) < 2:
-            continue
+        if not isinstance(item, Mapping) or item.get("input_ids") is None:
+            raise ValueError(
+                "Unsloth MLX: every example passed to custom data_collator "
+                "must contain `input_ids`."
+            )
+        if item.get("seq_lengths") is not None:
+            raise ValueError(
+                "Unsloth MLX: packed or padding-free examples with "
+                "`seq_lengths` are not supported with custom data_collator "
+                "yet."
+            )
+        input_length = len(item["input_ids"])
         example = dict(item)
-        example["input_ids"] = input_ids
-        for field in token_fields:
-            if field == "input_ids" or field not in item or item[field] is None:
-                continue
-            example[field] = _aligned_text_field(item, field, len(input_ids))
+        for field, value in item.items():
+            example[field] = _truncate_token_aligned_custom_field(
+                value, input_length, max_seq_length,
+            )
+        example["input_ids"] = _to_int_list(item["input_ids"])[:max_seq_length]
         examples.append(example)
 
     if not examples:
         raise ValueError(
-            "Unsloth MLX: custom data_collator dataset produced no trainable "
-            "token sequences (need at least two input_ids after truncation)."
+            "Unsloth MLX: no tokenized text examples were available for "
+            "custom data_collator batching."
         )
     return examples
 
@@ -3708,16 +3716,16 @@ def _lengths_from_collator_attention(attention_mask, batch_size, seq_len):
     """Build MLX [start, end) lengths from a right-padded attention mask."""
     if attention_mask is None:
         return np.array([[0, seq_len] for _ in range(batch_size)], dtype=np.int32)
-    mask = _collator_value_to_numpy(attention_mask, "attention_mask")[:, :seq_len]
+    mask = _collator_value_to_numpy(attention_mask, "attention_mask")
     if mask.shape[0] != batch_size:
         raise ValueError(
             "Unsloth MLX: custom data_collator attention_mask batch size "
             f"{mask.shape[0]} does not match input_ids batch size {batch_size}."
         )
-    if mask.shape[1] < seq_len:
+    if mask.shape[1] != seq_len:
         raise ValueError(
             "Unsloth MLX: custom data_collator attention_mask sequence length "
-            f"{mask.shape[1]} is shorter than input_ids sequence length "
+            f"{mask.shape[1]} does not match input_ids sequence length "
             f"{seq_len}."
         )
     lengths = []
@@ -3726,41 +3734,133 @@ def _lengths_from_collator_attention(attention_mask, batch_size, seq_len):
         if len(active) == 0:
             lengths.append([0, 0])
         else:
+            if active[0] != 0:
+                raise ValueError(
+                    "Unsloth MLX: custom data_collator attention_mask must "
+                    "use right padding. Left padding is not supported on MLX "
+                    "custom collator batches yet."
+                )
+            if active[-1] - active[0] + 1 != len(active):
+                raise ValueError(
+                    "Unsloth MLX: custom data_collator attention_mask must "
+                    "contain only contiguous right padding."
+                )
             lengths.append([int(active[0]), int(active[-1]) + 1])
     return np.asarray(lengths, dtype=np.int32)
 
 
+def _custom_collator_labels_have_targets(labels_np, lengths_np):
+    """Return whether shifted labels contain at least one supervised token."""
+    if labels_np.shape[1] <= 1:
+        return False
+    targets = labels_np[:, 1:]
+    steps = np.arange(1, labels_np.shape[1], dtype=np.int32)
+    length_mask = (
+        (steps[None, :] >= lengths_np[:, 0:1])
+        & (steps[None, :] < lengths_np[:, 1:2])
+    )
+    return bool(np.any((targets != -100) & length_mask))
+
+
+def _trim_custom_collator_ignored_tail(
+    input_ids_np, labels_np, attention_mask_np, max_seq_length,
+):
+    """Trim ignored right-padding tokens returned past max_seq_length."""
+    seq_len = input_ids_np.shape[1]
+    if seq_len <= max_seq_length:
+        return input_ids_np, labels_np, attention_mask_np
+    if attention_mask_np is not None:
+        tail_mask = attention_mask_np[:, max_seq_length:seq_len]
+        if np.any(tail_mask != 0):
+            raise ValueError(
+                "Unsloth MLX: custom data_collator returned active "
+                "attention_mask values past max_seq_length. Truncate or mask "
+                "those tokens before returning the batch."
+            )
+    tail_labels = labels_np[:, max_seq_length:seq_len]
+    if not np.all(tail_labels == -100):
+        raise ValueError(
+            "Unsloth MLX: custom data_collator returned supervised labels "
+            "past max_seq_length. Truncate or set those labels to -100 before "
+            "returning the batch."
+        )
+    input_ids_np = input_ids_np[:, :max_seq_length]
+    labels_np = labels_np[:, :max_seq_length]
+    if attention_mask_np is not None:
+        attention_mask_np = attention_mask_np[:, :max_seq_length]
+    return input_ids_np, labels_np, attention_mask_np
+
+
 def _collator_output_to_text_batch(output, max_seq_length):
     """Normalize user collator output to an MLX text batch."""
-    if not isinstance(output, dict) or "input_ids" not in output:
+    if not isinstance(output, Mapping) or "input_ids" not in output:
         raise ValueError(
-            "Unsloth MLX: custom data_collator must return a dictionary "
+            "Unsloth MLX: custom data_collator must return a mapping "
             "containing `input_ids`."
         )
+    if output.get("position_ids") is not None or output.get("seq_lengths") is not None:
+        raise ValueError(
+            "Unsloth MLX: packed or padding-free custom data_collator "
+            "outputs with `position_ids` or `seq_lengths` are not supported "
+            "yet."
+        )
     input_ids_np = _collator_value_to_numpy(output["input_ids"], "input_ids")
-    if input_ids_np.shape[1] > max_seq_length:
-        input_ids_np = input_ids_np[:, :max_seq_length]
+    batch_size, seq_len = input_ids_np.shape
+
+    if output.get("labels") is None:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator must return `labels` so "
+            "ignored tokens can be masked correctly."
+        )
+    labels_np = _collator_value_to_numpy(output["labels"], "labels")
+    if labels_np.shape[0] != batch_size:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator labels batch size "
+            f"{labels_np.shape[0]} does not match input_ids batch size "
+            f"{batch_size}."
+        )
+    if labels_np.shape[1] < seq_len:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator labels sequence length "
+            f"{labels_np.shape[1]} is shorter than input_ids sequence "
+            f"length {seq_len}."
+        )
+    if labels_np.shape[1] > seq_len:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator labels sequence length "
+            f"{labels_np.shape[1]} does not match input_ids sequence length "
+            f"{seq_len}."
+        )
+    attention_mask_np = None
+    if output.get("attention_mask") is not None:
+        attention_mask_np = _collator_value_to_numpy(
+            output["attention_mask"], "attention_mask",
+        )
+        if attention_mask_np.shape[0] != batch_size:
+            raise ValueError(
+                "Unsloth MLX: custom data_collator attention_mask batch size "
+                f"{attention_mask_np.shape[0]} does not match input_ids "
+                f"batch size {batch_size}."
+            )
+        if attention_mask_np.shape[1] != seq_len:
+            raise ValueError(
+                "Unsloth MLX: custom data_collator attention_mask sequence "
+                f"length {attention_mask_np.shape[1]} does not match input_ids "
+                f"sequence length {seq_len}."
+            )
+    input_ids_np, labels_np, attention_mask_np = _trim_custom_collator_ignored_tail(
+        input_ids_np, labels_np, attention_mask_np, max_seq_length,
+    )
     batch_size, seq_len = input_ids_np.shape
     lengths_np = _lengths_from_collator_attention(
-        output.get("attention_mask"), batch_size, seq_len,
+        attention_mask_np, batch_size, seq_len,
     )
-
-    labels = None
-    if output.get("labels") is not None:
-        labels_np = _collator_value_to_numpy(output["labels"], "labels")
-        if labels_np.shape[0] != batch_size:
-            raise ValueError(
-                "Unsloth MLX: custom data_collator labels batch size "
-                f"{labels_np.shape[0]} does not match input_ids batch size "
-                f"{batch_size}."
-            )
-        if labels_np.shape[1] < seq_len:
-            raise ValueError(
-                "Unsloth MLX: custom data_collator labels sequence length "
-                f"{labels_np.shape[1]} is shorter than input_ids sequence "
-                f"length {seq_len}."
-            )
-        labels = mx.array(labels_np[:, :seq_len])
+    if not _custom_collator_labels_have_targets(labels_np, lengths_np):
+        raise ValueError(
+            "Unsloth MLX: custom data_collator produced a batch with no "
+            "supervised target tokens."
+        )
+    labels = _normalize_cce_label_dtype(mx.array(labels_np))
 
     return (
         mx.array(input_ids_np).astype(mx.int32),

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3568,7 +3568,7 @@ def _to_int_list(values):
 
 def _aligned_text_field(item, field, length):
     """Return an optional token-level field truncated to the input length."""
-    if field not in item:
+    if field not in item or item[field] is None:
         return None
     values = _to_int_list(item[field])
     if len(values) < length:
@@ -3583,23 +3583,24 @@ def _prepare_pretokenized_text_rows(dataset, max_seq_length, completion_only_los
     """Normalize pre-tokenized text rows to TRL collator-compatible fields."""
     rows = []
     for item in dataset:
-        if not isinstance(item, dict) or "input_ids" not in item:
+        if not isinstance(item, dict) or item.get("input_ids") is None:
             continue
         input_ids = _to_int_list(item["input_ids"])[:max_seq_length]
         if len(input_ids) < 2:
             continue
 
         row = {"input_ids": input_ids}
-        if "labels" in item:
-            row["labels"] = _aligned_text_field(item, "labels", len(input_ids))
+        labels = _aligned_text_field(item, "labels", len(input_ids))
+        if labels is not None:
+            row["labels"] = labels
         if completion_only_loss and "completion_mask" in item:
-            row["completion_mask"] = _aligned_text_field(
-                item, "completion_mask", len(input_ids)
-            )
+            completion_mask = _aligned_text_field(item, "completion_mask", len(input_ids))
+            if completion_mask is not None:
+                row["completion_mask"] = completion_mask
         if "assistant_masks" in item:
-            row["assistant_masks"] = _aligned_text_field(
-                item, "assistant_masks", len(input_ids)
-            )
+            assistant_masks = _aligned_text_field(item, "assistant_masks", len(input_ids))
+            if assistant_masks is not None:
+                row["assistant_masks"] = assistant_masks
         rows.append(row)
 
     if not rows:
@@ -3763,9 +3764,6 @@ def _make_labeled_text_batch_tuple(batch_rows, max_seq_length, pad_id=0):
     batch_ids = []
     lengths = []
     labels = []
-    has_labels = "labels" in batch_rows[0]
-    has_completion_mask = "completion_mask" in batch_rows[0]
-    has_assistant_masks = "assistant_masks" in batch_rows[0]
 
     for row in batch_rows:
         ids = row["input_ids"][:max_len]
@@ -3774,15 +3772,20 @@ def _make_labeled_text_batch_tuple(batch_rows, max_seq_length, pad_id=0):
         batch_ids.append(ids + [pad_id] * pad_len)
         lengths.append([0, length])
 
-        row_labels = row["labels"][:length] if has_labels else [int(token) for token in ids]
-        if has_completion_mask:
-            completion_mask = row["completion_mask"][:length]
+        row_labels = row.get("labels")
+        row_labels = row_labels[:length] if row_labels is not None else [
+            int(token) for token in ids
+        ]
+        completion_mask = row.get("completion_mask")
+        if completion_mask is not None:
+            completion_mask = completion_mask[:length]
             row_labels = [
                 int(label) if int(mask) != 0 else -100
                 for label, mask in zip(row_labels, completion_mask)
             ]
-        if has_assistant_masks:
-            assistant_masks = row["assistant_masks"][:length]
+        assistant_masks = row.get("assistant_masks")
+        if assistant_masks is not None:
+            assistant_masks = assistant_masks[:length]
             row_labels = [
                 int(label) if int(mask) != 0 else -100
                 for label, mask in zip(row_labels, assistant_masks)
@@ -3806,6 +3809,47 @@ def _ordered_text_indices(length, seed, dataset_order, epoch):
     return list(range(length))
 
 
+def _text_item_length(item):
+    """Return the token length for normalized text rows or token-id lists."""
+    if isinstance(item, dict):
+        return len(item["input_ids"])
+    return len(item)
+
+
+def _iter_text_index_chunks(items, batch_size, seed, dataset_order, num_epochs=None):
+    """Yield text batch index chunks using mlx-lm/default or explicit ordering."""
+    if dataset_order not in (None, "default", "sequential", "torch_randperm"):
+        raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
+
+    length = len(items)
+    if length <= 0:
+        return
+
+    epoch = 0
+    rng = np.random.RandomState(int(seed)) if seed else np.random.RandomState()
+    while num_epochs is None or epoch < int(num_epochs):
+        if dataset_order in (None, "default"):
+            ordered = sorted(range(length), key=lambda idx: _text_item_length(items[idx]))
+            chunks = [
+                ordered[start:start + batch_size]
+                for start in range(0, length - batch_size + 1, batch_size)
+            ]
+            if not chunks:
+                raise ValueError(
+                    f"Dataset must have at least batch_size={batch_size} "
+                    f"examples but only has {length}."
+                )
+            for batch_idx in rng.permutation(len(chunks)):
+                yield chunks[int(batch_idx)]
+        else:
+            order = _ordered_text_indices(length, seed, dataset_order, epoch)
+            for start in range(0, length, batch_size):
+                chunk = order[start:start + batch_size]
+                if chunk:
+                    yield chunk
+        epoch += 1
+
+
 def _create_ordered_text_batches(
     items,
     batch_size,
@@ -3824,33 +3868,16 @@ def _create_ordered_text_batches(
         )
 
     batches = []
-    epoch = 0
-    order = _ordered_text_indices(len(items), seed, dataset_order, epoch)
-    order_pos = 0
-    seen = 0
-    target_items = (
-        len(items) * (1 if num_epochs is None else int(num_epochs))
-        if num_batches is None else None
-    )
-    while num_batches is None or len(batches) < num_batches:
-        if order_pos >= len(order):
-            if num_batches is None and (target_items is None or seen >= target_items):
-                break
-            epoch += 1
-            order = _ordered_text_indices(len(items), seed, dataset_order, epoch)
-            order_pos = 0
-
-        chunk = order[order_pos:order_pos + batch_size]
-        if not chunk:
-            break
-        order_pos += len(chunk)
-        seen += len(chunk)
-        if num_batches is None and target_items is not None and seen > target_items:
-            chunk = chunk[: len(chunk) - (seen - target_items)]
-            seen = target_items
+    target_epochs = 1 if num_batches is None and num_epochs is None else num_epochs
+    for chunk in _iter_text_index_chunks(
+        items,
+        batch_size,
+        seed,
+        dataset_order,
+        num_epochs=target_epochs,
+    ):
         batches.append(make_batch([items[i] for i in chunk]))
-
-        if num_batches is None and target_items is not None and seen >= target_items:
+        if num_batches is not None and len(batches) >= num_batches:
             break
     return batches
 
@@ -3889,6 +3916,25 @@ def _make_labeled_text_batches(
     return batch_pairs
 
 
+def _iterate_labeled_text_batches(
+    rows,
+    tokenizer,
+    batch_size,
+    max_seq_length,
+    seed=None,
+    dataset_order="default",
+):
+    """Yield labeled text batches without materializing each epoch."""
+    pad_id = getattr(tokenizer, "pad_token_id", None)
+    pad_id = 0 if pad_id is None else int(pad_id)
+    for chunk in _iter_text_index_chunks(rows, batch_size, seed, dataset_order):
+        batch = _make_labeled_text_batch_tuple(
+            [rows[i] for i in chunk], max_seq_length, pad_id=pad_id
+        )
+        mx.eval([batch[0], batch[1], batch[2]])
+        yield batch
+
+
 def create_batches(dataset, tokenizer, batch_size, max_seq_length,
                    num_batches=None, seed=42, dataset_text_field="text",
                    formatting_func=None, chat_template=None,
@@ -3896,18 +3942,18 @@ def create_batches(dataset, tokenizer, batch_size, max_seq_length,
                    completion_only_loss=None):
     """Pre-tokenize and batch a HuggingFace dataset for MLX training.
 
-    Uses iterate_batches from mlx_lm for efficient dynamic-padding batching:
-    samples are sorted by length, grouped into batches, and padded to the
-    max length within each batch (rounded up to the nearest multiple of 32),
-    capped at max_seq_length.
+    Plain text rows use ``mlx_lm``'s length-sorted batch grouping and then
+    return tensors sliced to the true max length in each batch. Pre-tokenized
+    and prompt/completion rows use the same default grouping while carrying
+    explicit labels.
 
     Tokenization is delegated to mlx_lm's TextDataset (appends EOS, etc.)
-    so behaviour matches ``mlx_lm.lora`` exactly.
+    for plain text rows, so behaviour matches ``mlx_lm.lora`` exactly.
 
     Returns:
-        List of (batch, lengths) tuples, where batch has shape
-        (batch_size, padded_length) and lengths has shape (batch_size, 2)
-        with [offset, length] per sequence (from iterate_batches).
+        List of (batch, lengths, labels) tuples. ``labels`` is ``None`` for
+        plain language-modeling rows and an array for pre-tokenized or
+        prompt/completion rows.
     """
     from mlx_lm.tuner.trainer import iterate_batches
 
@@ -3939,6 +3985,14 @@ def create_batches(dataset, tokenizer, batch_size, max_seq_length,
         and "prompt" in first_item
         and "completion" in first_item
     ):
+        tokenizer = normalize_mlx_chat_template(
+            tokenizer,
+            chat_template=chat_template,
+            model_name=model_name,
+            model_type=model_type,
+            is_vlm=False,
+            strict=False,
+        )
         rows = _prepare_prompt_completion_text_rows(
             replay_dataset,
             tokenizer,
@@ -4007,7 +4061,8 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
     """Create text batches with an explicit dataset order.
 
     Studio uses this to mirror CUDA's effective sampler stream without
-    changing generic mlx-lm batching behavior.
+    changing generic mlx-lm batching behavior. Returns
+    (batch, lengths, labels) tuples; labels is ``None`` for plain text rows.
     """
 
     first_item, replay_dataset = _peek_dataset(dataset)
@@ -4043,6 +4098,14 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
         and "prompt" in first_item
         and "completion" in first_item
     ):
+        tokenizer = normalize_mlx_chat_template(
+            tokenizer,
+            chat_template=chat_template,
+            model_name=model_name,
+            model_type=model_type,
+            is_vlm=False,
+            strict=False,
+        )
         rows = _prepare_prompt_completion_text_rows(
             replay_dataset,
             tokenizer,
@@ -4147,11 +4210,12 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              append_eos=True, completion_only_loss=None):
     """Streaming batch generator for MLX training.
 
-    Wraps mlx-lm's iterate_batches(loop=True) as a generator, avoiding
-    materializing all batches in memory at once. Useful for large datasets.
+    Wraps mlx-lm's ``iterate_batches(loop=True)`` for plain text rows and
+    streams labeled pre-tokenized/prompt-completion rows without materializing
+    every batch in an epoch.
 
     Yields:
-        (batch, lengths) tuples — same format as create_batches.
+        (batch, lengths, labels) tuples — same format as create_batches.
     """
     from mlx_lm.tuner.trainer import iterate_batches
 
@@ -4167,16 +4231,14 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                 completion_only_loss, first_item
             ),
         )
-        while True:
-            for batch in _make_labeled_text_batches(
-                rows,
-                tokenizer,
-                batch_size,
-                max_seq_length,
-                seed=seed,
-                dataset_order="default",
-            ):
-                yield batch
+        yield from _iterate_labeled_text_batches(
+            rows,
+            tokenizer,
+            batch_size,
+            max_seq_length,
+            seed=seed,
+            dataset_order="default",
+        )
 
     if (
         formatting_func is None
@@ -4184,6 +4246,14 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
         and "prompt" in first_item
         and "completion" in first_item
     ):
+        tokenizer = normalize_mlx_chat_template(
+            tokenizer,
+            chat_template=chat_template,
+            model_name=model_name,
+            model_type=model_type,
+            is_vlm=False,
+            strict=False,
+        )
         rows = _prepare_prompt_completion_text_rows(
             replay_dataset,
             tokenizer,
@@ -4192,16 +4262,14 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             completion_only_loss=completion_only_loss,
             append_eos=append_eos,
         )
-        while True:
-            for batch in _make_labeled_text_batches(
-                rows,
-                tokenizer,
-                batch_size,
-                max_seq_length,
-                seed=seed,
-                dataset_order="default",
-            ):
-                yield batch
+        yield from _iterate_labeled_text_batches(
+            rows,
+            tokenizer,
+            batch_size,
+            max_seq_length,
+            seed=seed,
+            dataset_order="default",
+        )
 
     ds = _prepare_dataset(
         replay_dataset, tokenizer, dataset_text_field, formatting_func,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3640,6 +3640,180 @@ def _prepare_pretokenized_text_rows(dataset, max_seq_length, completion_only_los
     return rows
 
 
+def _prepare_custom_collator_text_examples(dataset, max_seq_length):
+    """Prepare tokenized text examples for a user-provided collator."""
+    first_item, replay_dataset = _peek_dataset(dataset)
+    if not isinstance(first_item, dict) or first_item.get("input_ids") is None:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator requires a tokenized text "
+            "dataset with `input_ids`. Raw text, VLM, streaming, packing, "
+            "and skip_prepare_dataset are not supported with custom "
+            "data_collator yet."
+        )
+
+    token_fields = (
+        "input_ids",
+        "labels",
+        "attention_mask",
+        "completion_mask",
+        "assistant_masks",
+        "token_type_ids",
+        "position_ids",
+    )
+    examples = []
+    for item in replay_dataset:
+        if not isinstance(item, dict) or item.get("input_ids") is None:
+            continue
+        input_ids = _to_int_list(item["input_ids"])[:max_seq_length]
+        if len(input_ids) < 2:
+            continue
+        example = dict(item)
+        example["input_ids"] = input_ids
+        for field in token_fields:
+            if field == "input_ids" or field not in item or item[field] is None:
+                continue
+            example[field] = _aligned_text_field(item, field, len(input_ids))
+        examples.append(example)
+
+    if not examples:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator dataset produced no trainable "
+            "token sequences (need at least two input_ids after truncation)."
+        )
+    return examples
+
+
+def _collator_value_to_numpy(value, field):
+    """Convert common collator outputs to a numpy array."""
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    if hasattr(value, "numpy"):
+        value = value.numpy()
+    elif hasattr(value, "tolist"):
+        value = value.tolist()
+    array = np.asarray(value)
+    if array.ndim == 1:
+        array = array.reshape(1, -1)
+    if array.ndim != 2:
+        raise ValueError(
+            f"Unsloth MLX: custom data_collator field `{field}` must be a "
+            f"1D or 2D tensor/array, got shape {array.shape}."
+        )
+    return array
+
+
+def _lengths_from_collator_attention(attention_mask, batch_size, seq_len):
+    """Build MLX [start, end) lengths from a right-padded attention mask."""
+    if attention_mask is None:
+        return np.array([[0, seq_len] for _ in range(batch_size)], dtype=np.int32)
+    mask = _collator_value_to_numpy(attention_mask, "attention_mask")[:, :seq_len]
+    if mask.shape[0] != batch_size:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator attention_mask batch size "
+            f"{mask.shape[0]} does not match input_ids batch size {batch_size}."
+        )
+    if mask.shape[1] < seq_len:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator attention_mask sequence length "
+            f"{mask.shape[1]} is shorter than input_ids sequence length "
+            f"{seq_len}."
+        )
+    lengths = []
+    for row in mask:
+        active = np.flatnonzero(row)
+        if len(active) == 0:
+            lengths.append([0, 0])
+        else:
+            lengths.append([int(active[0]), int(active[-1]) + 1])
+    return np.asarray(lengths, dtype=np.int32)
+
+
+def _collator_output_to_text_batch(output, max_seq_length):
+    """Normalize user collator output to an MLX text batch."""
+    if not isinstance(output, dict) or "input_ids" not in output:
+        raise ValueError(
+            "Unsloth MLX: custom data_collator must return a dictionary "
+            "containing `input_ids`."
+        )
+    input_ids_np = _collator_value_to_numpy(output["input_ids"], "input_ids")
+    if input_ids_np.shape[1] > max_seq_length:
+        input_ids_np = input_ids_np[:, :max_seq_length]
+    batch_size, seq_len = input_ids_np.shape
+    lengths_np = _lengths_from_collator_attention(
+        output.get("attention_mask"), batch_size, seq_len,
+    )
+
+    labels = None
+    if output.get("labels") is not None:
+        labels_np = _collator_value_to_numpy(output["labels"], "labels")
+        if labels_np.shape[0] != batch_size:
+            raise ValueError(
+                "Unsloth MLX: custom data_collator labels batch size "
+                f"{labels_np.shape[0]} does not match input_ids batch size "
+                f"{batch_size}."
+            )
+        if labels_np.shape[1] < seq_len:
+            raise ValueError(
+                "Unsloth MLX: custom data_collator labels sequence length "
+                f"{labels_np.shape[1]} is shorter than input_ids sequence "
+                f"length {seq_len}."
+            )
+        labels = mx.array(labels_np[:, :seq_len])
+
+    return (
+        mx.array(input_ids_np).astype(mx.int32),
+        mx.array(lengths_np),
+        labels,
+    )
+
+
+def _collate_text_examples_with_custom_collator(examples, data_collator, max_seq_length):
+    """Run a user collator and return an MLX text batch."""
+    return _collator_output_to_text_batch(
+        data_collator(examples),
+        max_seq_length,
+    )
+
+
+def create_collated_text_batches(
+    dataset,
+    data_collator,
+    batch_size,
+    max_seq_length,
+    num_batches=None,
+    seed=None,
+    dataset_order="default",
+    num_epochs=None,
+):
+    """Create text batches with a user-provided data_collator."""
+    examples = _prepare_custom_collator_text_examples(dataset, max_seq_length)
+    batches = _create_ordered_text_batches(
+        examples,
+        batch_size,
+        lambda batch_examples: _collate_text_examples_with_custom_collator(
+            batch_examples, data_collator, max_seq_length,
+        ),
+        num_batches=num_batches,
+        seed=seed,
+        dataset_order=dataset_order,
+        num_epochs=num_epochs,
+        empty_message=(
+            "Unsloth MLX: no trainable token sequences were available after "
+            "custom data_collator batching."
+        ),
+    )
+    tensors = []
+    for batch, lengths, labels in batches:
+        tensors.extend([batch, lengths])
+        if labels is not None:
+            tensors.append(labels)
+    if tensors:
+        mx.eval(tensors)
+    return batches
+
+
 def _prompt_completion_text_parts(tokenizer, item, dataset_text_field):
     """Render a text prompt/completion row into prompt and completion strings."""
     prompt = render_mlx_chat_example(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3658,13 +3658,17 @@ _CUSTOM_COLLATOR_TEXT_COLUMNS = frozenset((
 ))
 
 
-def _prepare_custom_collator_text_examples(dataset, max_seq_length):
+def _prepare_custom_collator_text_examples(
+    dataset, max_seq_length, skip_prepare_dataset=False,
+):
     """Keep/truncate CUDA SFT text columns before user collation.
 
     Only ``input_ids``, ``labels``, ``completion_mask``, and
     ``assistant_masks`` are forwarded; other dataset columns are dropped.
     """
     first_item, replay_dataset = _peek_dataset(dataset)
+    if skip_prepare_dataset:
+        return list(replay_dataset)
     if not isinstance(first_item, Mapping) or first_item.get("input_ids") is None:
         raise ValueError(
             "Unsloth MLX: custom data_collator requires tokenized text "
@@ -3934,13 +3938,20 @@ def create_collated_text_batches(
     seed=None,
     dataset_order="default",
     num_epochs=None,
+    skip_prepare_dataset=False,
 ):
     """Create text batches that call the user collator on batch access.
 
     Tokenized examples are truncated before the collator runs. Packed
     ``seq_lengths`` / padding-free outputs are rejected by this MLX path.
     """
-    examples = _prepare_custom_collator_text_examples(dataset, max_seq_length)
+    examples = _prepare_custom_collator_text_examples(
+        dataset,
+        max_seq_length,
+        skip_prepare_dataset=skip_prepare_dataset,
+    )
+    if skip_prepare_dataset and dataset_order in (None, "default"):
+        dataset_order = "sequential"
     chunks = []
     target_epochs = 1 if num_batches is None and num_epochs is None else num_epochs
     for chunk in _iter_text_index_chunks(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3579,6 +3579,24 @@ def _aligned_text_field(item, field, length):
     return values[:length]
 
 
+def _labeled_text_row_has_supervised_targets(row):
+    """Return whether effective labels train at least one causal target."""
+    input_ids = row["input_ids"]
+    row_labels = row.get("labels")
+    labels = row_labels[:len(input_ids)] if row_labels is not None else [
+        int(token) for token in input_ids
+    ]
+    for mask_name in ("completion_mask", "assistant_masks"):
+        mask = row.get(mask_name)
+        if mask is None:
+            continue
+        labels = [
+            int(label) if int(mask_value) != 0 else -100
+            for label, mask_value in zip(labels, mask[:len(labels)])
+        ]
+    return any(label != -100 for label in labels[1:])
+
+
 def _prepare_pretokenized_text_row(item, max_seq_length, completion_only_loss=False):
     """Normalize one pre-tokenized text row, or return None when unusable."""
     if not isinstance(item, dict) or item.get("input_ids") is None:
@@ -3599,6 +3617,8 @@ def _prepare_pretokenized_text_row(item, max_seq_length, completion_only_loss=Fa
         assistant_masks = _aligned_text_field(item, "assistant_masks", len(input_ids))
         if assistant_masks is not None:
             row["assistant_masks"] = assistant_masks
+    if not _labeled_text_row_has_supervised_targets(row):
+        return None
     return row
 
 
@@ -3858,7 +3878,7 @@ def _iter_text_index_chunks(items, batch_size, seed, dataset_order, num_epochs=N
         return
 
     epoch = 0
-    rng = np.random.RandomState(int(seed)) if seed else np.random.RandomState()
+    rng = np.random.RandomState(int(seed)) if seed is not None else np.random.RandomState()
     while num_epochs is None or epoch < int(num_epochs):
         if dataset_order in (None, "default"):
             ordered = sorted(range(length), key=lambda idx: _text_item_length(items[idx]))

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -28,6 +28,7 @@ import mlx.utils
 import copy
 import inspect
 import importlib
+import itertools
 import json
 import numpy as np
 import os
@@ -3548,10 +3549,258 @@ def _prepare_dataset(dataset, tokenizer, dataset_text_field="text",
     )
 
 
+def _peek_dataset(dataset):
+    """Return the first item and an iterator that still includes that item."""
+    iterator = iter(dataset)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return None, iter(())
+    return first, itertools.chain([first], iterator)
+
+
+def _to_int_list(values):
+    """Convert token-like arrays or lists to plain Python ints."""
+    if hasattr(values, "tolist"):
+        values = values.tolist()
+    return [int(value) for value in values]
+
+
+def _aligned_text_field(item, field, length):
+    """Return an optional token-level field truncated to the input length."""
+    if field not in item:
+        return None
+    values = _to_int_list(item[field])
+    if len(values) < length:
+        raise ValueError(
+            f"Unsloth MLX: pre-tokenized `{field}` length {len(values)} is "
+            f"shorter than `input_ids` length {length}."
+        )
+    return values[:length]
+
+
+def _prepare_pretokenized_text_rows(dataset, max_seq_length, completion_only_loss=False):
+    """Normalize pre-tokenized text rows to TRL collator-compatible fields."""
+    rows = []
+    for item in dataset:
+        if not isinstance(item, dict) or "input_ids" not in item:
+            continue
+        input_ids = _to_int_list(item["input_ids"])[:max_seq_length]
+        if len(input_ids) < 2:
+            continue
+
+        row = {"input_ids": input_ids}
+        if "labels" in item:
+            row["labels"] = _aligned_text_field(item, "labels", len(input_ids))
+        if completion_only_loss and "completion_mask" in item:
+            row["completion_mask"] = _aligned_text_field(
+                item, "completion_mask", len(input_ids)
+            )
+        if "assistant_masks" in item:
+            row["assistant_masks"] = _aligned_text_field(
+                item, "assistant_masks", len(input_ids)
+            )
+        rows.append(row)
+
+    if not rows:
+        raise ValueError(
+            "Unsloth MLX: pre-tokenized dataset produced no trainable token "
+            "sequences (need at least two input_ids after truncation)."
+        )
+    return rows
+
+
+def _prompt_completion_text_parts(tokenizer, item, dataset_text_field):
+    """Render a text prompt/completion row into prompt and completion strings."""
+    prompt = render_mlx_chat_example(
+        tokenizer,
+        item.get("prompt"),
+        dataset_text_field=dataset_text_field,
+        is_vlm=False,
+    )
+    completion = render_mlx_chat_example(
+        tokenizer,
+        item.get("completion"),
+        dataset_text_field=dataset_text_field,
+        is_vlm=False,
+    )
+    return prompt or "", completion or ""
+
+
+def _prepare_prompt_completion_text_rows(
+    dataset,
+    tokenizer,
+    max_seq_length,
+    dataset_text_field="text",
+    completion_only_loss=None,
+):
+    """Tokenize prompt/completion rows and build CUDA-style completion masks."""
+    rows = []
+    mask_completions = True if completion_only_loss is None else bool(completion_only_loss)
+    for item in dataset:
+        if not isinstance(item, dict) or "prompt" not in item or "completion" not in item:
+            continue
+
+        prompt_text, completion_text = _prompt_completion_text_parts(
+            tokenizer, item, dataset_text_field
+        )
+        input_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text + completion_text))
+        prompt_ids = _to_int_list(encode_mlx_text(tokenizer, prompt_text))
+        input_ids = input_ids[:max_seq_length]
+        if len(input_ids) < 2:
+            continue
+
+        row = {"input_ids": input_ids}
+        if mask_completions:
+            prompt_len = min(len(prompt_ids), len(input_ids))
+            row["completion_mask"] = [0] * prompt_len + [1] * (len(input_ids) - prompt_len)
+        rows.append(row)
+
+    if not rows:
+        raise ValueError(
+            "Unsloth MLX: prompt/completion dataset produced no trainable token "
+            "sequences (need at least two input_ids after truncation)."
+        )
+    return rows
+
+
+def _make_labeled_text_batch_tuple(batch_rows, max_seq_length, pad_id=0):
+    """Collate normalized text rows into an MLX batch with effective labels."""
+    max_len = min(max(len(row["input_ids"]) for row in batch_rows), max_seq_length)
+    batch_ids = []
+    lengths = []
+    labels = []
+    has_labels = "labels" in batch_rows[0]
+    has_completion_mask = "completion_mask" in batch_rows[0]
+    has_assistant_masks = "assistant_masks" in batch_rows[0]
+
+    for row in batch_rows:
+        ids = row["input_ids"][:max_len]
+        length = len(ids)
+        pad_len = max_len - length
+        batch_ids.append(ids + [pad_id] * pad_len)
+        lengths.append([0, length])
+
+        row_labels = row["labels"][:length] if has_labels else [int(token) for token in ids]
+        if has_completion_mask:
+            completion_mask = row["completion_mask"][:length]
+            row_labels = [
+                int(label) if int(mask) != 0 else -100
+                for label, mask in zip(row_labels, completion_mask)
+            ]
+        if has_assistant_masks:
+            assistant_masks = row["assistant_masks"][:length]
+            row_labels = [
+                int(label) if int(mask) != 0 else -100
+                for label, mask in zip(row_labels, assistant_masks)
+            ]
+        labels.append(row_labels + [-100] * pad_len)
+
+    return (
+        mx.array(batch_ids),
+        mx.array(lengths),
+        mx.array(labels),
+    )
+
+
+def _ordered_text_indices(length, seed, dataset_order, epoch):
+    """Return one epoch of indices for explicit text dataset ordering."""
+    base_seed = _normalize_seed(seed)
+    if dataset_order == "torch_randperm":
+        return _torch_randperm_order(length, base_seed + epoch)
+    if dataset_order not in (None, "default", "sequential"):
+        raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
+    return list(range(length))
+
+
+def _create_ordered_text_batches(
+    items,
+    batch_size,
+    make_batch,
+    num_batches=None,
+    seed=None,
+    dataset_order="sequential",
+    num_epochs=None,
+    empty_message=None,
+):
+    """Create text batches with shared sequential/torch-randperm ordering."""
+    if not items:
+        raise ValueError(
+            empty_message
+            or "Unsloth MLX: ordered dataset produced no trainable token sequences."
+        )
+
+    batches = []
+    epoch = 0
+    order = _ordered_text_indices(len(items), seed, dataset_order, epoch)
+    order_pos = 0
+    seen = 0
+    target_items = (
+        len(items) * (1 if num_epochs is None else int(num_epochs))
+        if num_batches is None else None
+    )
+    while num_batches is None or len(batches) < num_batches:
+        if order_pos >= len(order):
+            if num_batches is None and (target_items is None or seen >= target_items):
+                break
+            epoch += 1
+            order = _ordered_text_indices(len(items), seed, dataset_order, epoch)
+            order_pos = 0
+
+        chunk = order[order_pos:order_pos + batch_size]
+        if not chunk:
+            break
+        order_pos += len(chunk)
+        seen += len(chunk)
+        if num_batches is None and target_items is not None and seen > target_items:
+            chunk = chunk[: len(chunk) - (seen - target_items)]
+            seen = target_items
+        batches.append(make_batch([items[i] for i in chunk]))
+
+        if num_batches is None and target_items is not None and seen >= target_items:
+            break
+    return batches
+
+
+def _make_labeled_text_batches(
+    rows,
+    tokenizer,
+    batch_size,
+    max_seq_length,
+    num_batches=None,
+    seed=None,
+    dataset_order="sequential",
+    num_epochs=None,
+    empty_message=None,
+):
+    """Create and evaluate labeled text batches from normalized rows."""
+    pad_id = getattr(tokenizer, "pad_token_id", None)
+    pad_id = 0 if pad_id is None else int(pad_id)
+    batch_pairs = _create_ordered_text_batches(
+        rows,
+        batch_size,
+        lambda batch_rows: _make_labeled_text_batch_tuple(
+            batch_rows, max_seq_length, pad_id=pad_id
+        ),
+        num_batches=num_batches,
+        seed=seed,
+        dataset_order=dataset_order,
+        num_epochs=num_epochs,
+        empty_message=empty_message,
+    )
+    mx.eval(
+        [b for b, lengths, labels in batch_pairs]
+        + [lengths for _, lengths, _ in batch_pairs]
+        + [labels for _, _, labels in batch_pairs]
+    )
+    return batch_pairs
+
+
 def create_batches(dataset, tokenizer, batch_size, max_seq_length,
                    num_batches=None, seed=42, dataset_text_field="text",
                    formatting_func=None, chat_template=None,
-                   model_name=None, model_type=None, append_eos=True):
+                   model_name=None, model_type=None, append_eos=True,
+                   completion_only_loss=None):
     """Pre-tokenize and batch a HuggingFace dataset for MLX training.
 
     Uses iterate_batches from mlx_lm for efficient dynamic-padding batching:
@@ -3569,8 +3818,48 @@ def create_batches(dataset, tokenizer, batch_size, max_seq_length,
     """
     from mlx_lm.tuner.trainer import iterate_batches
 
+    first_item, replay_dataset = _peek_dataset(dataset)
+    if isinstance(first_item, dict) and "input_ids" in first_item:
+        rows = _prepare_pretokenized_text_rows(
+            replay_dataset,
+            max_seq_length,
+            completion_only_loss=bool(completion_only_loss),
+        )
+        return _make_labeled_text_batches(
+            rows,
+            tokenizer,
+            batch_size,
+            max_seq_length,
+            num_batches=num_batches,
+            seed=seed,
+            dataset_order="default",
+        )
+
+    if (
+        formatting_func is None
+        and isinstance(first_item, dict)
+        and "prompt" in first_item
+        and "completion" in first_item
+    ):
+        rows = _prepare_prompt_completion_text_rows(
+            replay_dataset,
+            tokenizer,
+            max_seq_length,
+            dataset_text_field=dataset_text_field,
+            completion_only_loss=completion_only_loss,
+        )
+        return _make_labeled_text_batches(
+            rows,
+            tokenizer,
+            batch_size,
+            max_seq_length,
+            num_batches=num_batches,
+            seed=seed,
+            dataset_order="default",
+        )
+
     ds = _prepare_dataset(
-        dataset, tokenizer, dataset_text_field, formatting_func,
+        replay_dataset, tokenizer, dataset_text_field, formatting_func,
         chat_template=chat_template,
         model_name=model_name,
         model_type=model_type,
@@ -3614,15 +3903,62 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
                            dataset_text_field="text",
                            formatting_func=None, chat_template=None,
                            model_name=None, model_type=None,
-                           num_epochs=None, append_eos=True):
+                           num_epochs=None, append_eos=True,
+                           completion_only_loss=None):
     """Create text batches with an explicit dataset order.
 
     Studio uses this to mirror CUDA's effective sampler stream without
     changing generic mlx-lm batching behavior.
     """
 
+    first_item, replay_dataset = _peek_dataset(dataset)
+    if isinstance(first_item, dict) and "input_ids" in first_item:
+        rows = _prepare_pretokenized_text_rows(
+            replay_dataset,
+            max_seq_length,
+            completion_only_loss=bool(completion_only_loss),
+        )
+        return _make_labeled_text_batches(
+            rows,
+            tokenizer,
+            batch_size,
+            max_seq_length,
+            num_batches=num_batches,
+            seed=seed,
+            dataset_order=dataset_order,
+            num_epochs=num_epochs,
+            empty_message=(
+                "Unsloth MLX: ordered pre-tokenized dataset produced no "
+                "trainable token sequences."
+            ),
+        )
+
+    if (
+        formatting_func is None
+        and isinstance(first_item, dict)
+        and "prompt" in first_item
+        and "completion" in first_item
+    ):
+        rows = _prepare_prompt_completion_text_rows(
+            replay_dataset,
+            tokenizer,
+            max_seq_length,
+            dataset_text_field=dataset_text_field,
+            completion_only_loss=completion_only_loss,
+        )
+        return _make_labeled_text_batches(
+            rows,
+            tokenizer,
+            batch_size,
+            max_seq_length,
+            num_batches=num_batches,
+            seed=seed,
+            dataset_order=dataset_order,
+            num_epochs=num_epochs,
+        )
+
     ds = _prepare_dataset(
-        dataset, tokenizer, dataset_text_field, formatting_func,
+        replay_dataset, tokenizer, dataset_text_field, formatting_func,
         chat_template=chat_template,
         model_name=model_name,
         model_type=model_type,
@@ -3642,17 +3978,9 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
             "(need at least two tokens after formatting/truncation)."
         )
 
-    def make_order(epoch):
-        base_seed = _normalize_seed(seed)
-        if dataset_order == "torch_randperm":
-            return _torch_randperm_order(len(tokenized), base_seed + epoch)
-        if dataset_order not in (None, "sequential"):
-            raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
-        return list(range(len(tokenized)))
-
     batch_pairs = []
     epoch = 0
-    order = make_order(epoch)
+    order = _ordered_text_indices(len(tokenized), seed, dataset_order, epoch)
     order_pos = 0
     seen = 0
     target_items = (
@@ -3670,7 +3998,7 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
             ):
                 break
             epoch += 1
-            order = make_order(epoch)
+            order = _ordered_text_indices(len(tokenized), seed, dataset_order, epoch)
             order_pos = 0
 
         chunk = order[order_pos : order_pos + batch_size]
@@ -3711,7 +4039,7 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              seed=42, dataset_text_field="text",
                              formatting_func=None, chat_template=None,
                              model_name=None, model_type=None,
-                             append_eos=True):
+                             append_eos=True, completion_only_loss=None):
     """Streaming batch generator for MLX training.
 
     Wraps mlx-lm's iterate_batches(loop=True) as a generator, avoiding
@@ -3722,8 +4050,50 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
     """
     from mlx_lm.tuner.trainer import iterate_batches
 
+    first_item, replay_dataset = _peek_dataset(dataset)
+    if isinstance(first_item, dict) and "input_ids" in first_item:
+        rows = _prepare_pretokenized_text_rows(
+            replay_dataset,
+            max_seq_length,
+            completion_only_loss=bool(completion_only_loss),
+        )
+        while True:
+            for batch in _make_labeled_text_batches(
+                rows,
+                tokenizer,
+                batch_size,
+                max_seq_length,
+                seed=seed,
+                dataset_order="default",
+            ):
+                yield batch
+
+    if (
+        formatting_func is None
+        and isinstance(first_item, dict)
+        and "prompt" in first_item
+        and "completion" in first_item
+    ):
+        rows = _prepare_prompt_completion_text_rows(
+            replay_dataset,
+            tokenizer,
+            max_seq_length,
+            dataset_text_field=dataset_text_field,
+            completion_only_loss=completion_only_loss,
+        )
+        while True:
+            for batch in _make_labeled_text_batches(
+                rows,
+                tokenizer,
+                batch_size,
+                max_seq_length,
+                seed=seed,
+                dataset_order="default",
+            ):
+                yield batch
+
     ds = _prepare_dataset(
-        dataset, tokenizer, dataset_text_field, formatting_func,
+        replay_dataset, tokenizer, dataset_text_field, formatting_func,
         chat_template=chat_template,
         model_name=model_name,
         model_type=model_type,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3641,24 +3641,30 @@ def _prepare_pretokenized_text_rows(dataset, max_seq_length, completion_only_los
     return rows
 
 
-def _truncate_token_aligned_custom_field(value, input_length, max_seq_length):
-    """Truncate sequence fields that align with input_ids."""
+def _truncate_custom_collator_field(value, max_seq_length):
+    """Truncate list-like fields the same way TRL truncates datasets."""
     if hasattr(value, "tolist"):
         value = value.tolist()
-    if isinstance(value, (list, tuple)) and len(value) == input_length:
+    if isinstance(value, (list, tuple)):
         return list(value)[:max_seq_length]
     return value
 
 
+_CUSTOM_COLLATOR_TEXT_COLUMNS = frozenset((
+    "input_ids",
+    "labels",
+    "completion_mask",
+    "assistant_masks",
+))
+
+
 def _prepare_custom_collator_text_examples(dataset, max_seq_length):
-    """Prepare tokenized text examples for a user-provided collator."""
+    """Prepare tokenized text examples with SFTTrainer text columns."""
     first_item, replay_dataset = _peek_dataset(dataset)
     if not isinstance(first_item, Mapping) or first_item.get("input_ids") is None:
         raise ValueError(
-            "Unsloth MLX: custom data_collator requires a tokenized text "
-            "dataset with `input_ids`. Raw text, VLM, streaming, packing, "
-            "and skip_prepare_dataset are not supported with custom "
-            "data_collator yet."
+            "Unsloth MLX: custom data_collator requires tokenized text "
+            "examples with `input_ids`."
         )
 
     examples = []
@@ -3673,25 +3679,20 @@ def _prepare_custom_collator_text_examples(dataset, max_seq_length):
                 "Unsloth MLX: packed or padding-free examples with "
                 "`seq_lengths` are not supported with custom data_collator "
                 "yet."
-            )
-        input_length = len(item["input_ids"])
-        example = dict(item)
+        )
+        example = {}
         for field, value in item.items():
-            example[field] = _truncate_token_aligned_custom_field(
-                value, input_length, max_seq_length,
-            )
+            if field in _CUSTOM_COLLATOR_TEXT_COLUMNS and value is not None:
+                example[field] = _truncate_custom_collator_field(
+                    value, max_seq_length,
+                )
         example["input_ids"] = _to_int_list(item["input_ids"])[:max_seq_length]
         examples.append(example)
 
-    if not examples:
-        raise ValueError(
-            "Unsloth MLX: no tokenized text examples were available for "
-            "custom data_collator batching."
-        )
     return examples
 
 
-def _collator_value_to_numpy(value, field):
+def _collator_value_to_numpy(value, field, expected_batch_size=None):
     """Convert common collator outputs to a numpy array."""
     if hasattr(value, "detach"):
         value = value.detach()
@@ -3703,11 +3704,22 @@ def _collator_value_to_numpy(value, field):
         value = value.tolist()
     array = np.asarray(value)
     if array.ndim == 1:
+        if expected_batch_size not in (None, 1):
+            raise ValueError(
+                f"Unsloth MLX: custom data_collator field `{field}` must be "
+                "2D when collating multiple examples."
+            )
         array = array.reshape(1, -1)
     if array.ndim != 2:
         raise ValueError(
             f"Unsloth MLX: custom data_collator field `{field}` must be a "
             f"1D or 2D tensor/array, got shape {array.shape}."
+        )
+    if expected_batch_size is not None and array.shape[0] != expected_batch_size:
+        raise ValueError(
+            f"Unsloth MLX: custom data_collator field `{field}` batch size "
+            f"{array.shape[0]} does not match the {expected_batch_size} "
+            "selected examples."
         )
     return array
 
@@ -3716,20 +3728,8 @@ def _lengths_from_collator_attention(attention_mask, batch_size, seq_len):
     """Build MLX [start, end) lengths from a right-padded attention mask."""
     if attention_mask is None:
         return np.array([[0, seq_len] for _ in range(batch_size)], dtype=np.int32)
-    mask = _collator_value_to_numpy(attention_mask, "attention_mask")
-    if mask.shape[0] != batch_size:
-        raise ValueError(
-            "Unsloth MLX: custom data_collator attention_mask batch size "
-            f"{mask.shape[0]} does not match input_ids batch size {batch_size}."
-        )
-    if mask.shape[1] != seq_len:
-        raise ValueError(
-            "Unsloth MLX: custom data_collator attention_mask sequence length "
-            f"{mask.shape[1]} does not match input_ids sequence length "
-            f"{seq_len}."
-        )
     lengths = []
-    for row in mask:
+    for row in attention_mask:
         active = np.flatnonzero(row)
         if len(active) == 0:
             lengths.append([0, 0])
@@ -3749,17 +3749,31 @@ def _lengths_from_collator_attention(attention_mask, batch_size, seq_len):
     return np.asarray(lengths, dtype=np.int32)
 
 
-def _custom_collator_labels_have_targets(labels_np, lengths_np):
-    """Return whether shifted labels contain at least one supervised token."""
+def _validate_custom_collator_shifted_targets(labels_np, lengths_np, attention_mask_np=None):
+    """Validate shifted custom-collator labels against mask and target rules."""
     if labels_np.shape[1] <= 1:
-        return False
+        raise ValueError(
+            "Unsloth MLX: custom data_collator produced a batch with no "
+            "supervised target tokens."
+        )
+    if attention_mask_np is not None:
+        masked_targets = (attention_mask_np[:, 1:] == 0) & (labels_np[:, 1:] != -100)
+        if np.any(masked_targets):
+            raise ValueError(
+                "Unsloth MLX: custom data_collator labels must be -100 wherever "
+                "the shifted attention_mask is 0."
+            )
     targets = labels_np[:, 1:]
     steps = np.arange(1, labels_np.shape[1], dtype=np.int32)
     length_mask = (
         (steps[None, :] >= lengths_np[:, 0:1])
         & (steps[None, :] < lengths_np[:, 1:2])
     )
-    return bool(np.any((targets != -100) & length_mask))
+    if not bool(np.any((targets != -100) & length_mask)):
+        raise ValueError(
+            "Unsloth MLX: custom data_collator produced a batch with no "
+            "supervised target tokens."
+        )
 
 
 def _trim_custom_collator_ignored_tail(
@@ -3791,7 +3805,7 @@ def _trim_custom_collator_ignored_tail(
     return input_ids_np, labels_np, attention_mask_np
 
 
-def _collator_output_to_text_batch(output, max_seq_length):
+def _collator_output_to_text_batch(output, max_seq_length, expected_batch_size=None):
     """Normalize user collator output to an MLX text batch."""
     if not isinstance(output, Mapping) or "input_ids" not in output:
         raise ValueError(
@@ -3800,11 +3814,13 @@ def _collator_output_to_text_batch(output, max_seq_length):
         )
     if output.get("position_ids") is not None or output.get("seq_lengths") is not None:
         raise ValueError(
-            "Unsloth MLX: packed or padding-free custom data_collator "
-            "outputs with `position_ids` or `seq_lengths` are not supported "
-            "yet."
+            "Unsloth MLX: custom data_collator outputs with `position_ids` "
+            "or `seq_lengths` are not supported yet."
         )
-    input_ids_np = _collator_value_to_numpy(output["input_ids"], "input_ids")
+    input_ids_np = _collator_value_to_numpy(
+        output["input_ids"], "input_ids",
+        expected_batch_size=expected_batch_size,
+    )
     batch_size, seq_len = input_ids_np.shape
 
     if output.get("labels") is None:
@@ -3855,11 +3871,9 @@ def _collator_output_to_text_batch(output, max_seq_length):
     lengths_np = _lengths_from_collator_attention(
         attention_mask_np, batch_size, seq_len,
     )
-    if not _custom_collator_labels_have_targets(labels_np, lengths_np):
-        raise ValueError(
-            "Unsloth MLX: custom data_collator produced a batch with no "
-            "supervised target tokens."
-        )
+    _validate_custom_collator_shifted_targets(
+        labels_np, lengths_np, attention_mask_np,
+    )
     labels = _normalize_cce_label_dtype(mx.array(labels_np))
 
     return (
@@ -3869,12 +3883,31 @@ def _collator_output_to_text_batch(output, max_seq_length):
     )
 
 
-def _collate_text_examples_with_custom_collator(examples, data_collator, max_seq_length):
-    """Run a user collator and return an MLX text batch."""
-    return _collator_output_to_text_batch(
-        data_collator(examples),
-        max_seq_length,
-    )
+class _LazyCollatedTextBatches:
+    """List-like text batches that call the user collator on access."""
+
+    def __init__(self, examples, chunks, data_collator, max_seq_length):
+        self._examples = examples
+        self._chunks = chunks
+        self._data_collator = data_collator
+        self._max_seq_length = max_seq_length
+
+    def __len__(self):
+        return len(self._chunks)
+
+    def __iter__(self):
+        for index in range(len(self)):
+            yield self[index]
+
+    def __getitem__(self, index):
+        if index < 0:
+            index += len(self)
+        batch_examples = [self._examples[i] for i in self._chunks[index]]
+        return _collator_output_to_text_batch(
+            self._data_collator(batch_examples),
+            self._max_seq_length,
+            expected_batch_size=len(batch_examples),
+        )
 
 
 def create_collated_text_batches(
@@ -3887,31 +3920,28 @@ def create_collated_text_batches(
     dataset_order="default",
     num_epochs=None,
 ):
-    """Create text batches with a user-provided data_collator."""
+    """Create text batches that call the user collator on batch access.
+
+    Input examples are pruned to SFTTrainer's default text signature columns
+    before the collator runs.
+    """
     examples = _prepare_custom_collator_text_examples(dataset, max_seq_length)
-    batches = _create_ordered_text_batches(
+    chunks = []
+    target_epochs = 1 if num_batches is None and num_epochs is None else num_epochs
+    for chunk in _iter_text_index_chunks(
         examples,
         batch_size,
-        lambda batch_examples: _collate_text_examples_with_custom_collator(
-            batch_examples, data_collator, max_seq_length,
-        ),
-        num_batches=num_batches,
         seed=seed,
         dataset_order=dataset_order,
-        num_epochs=num_epochs,
-        empty_message=(
-            "Unsloth MLX: no trainable token sequences were available after "
-            "custom data_collator batching."
-        ),
+        num_epochs=target_epochs,
+        drop_last_default=False,
+    ):
+        chunks.append(list(chunk))
+        if num_batches is not None and len(chunks) >= num_batches:
+            break
+    return _LazyCollatedTextBatches(
+        examples, chunks, data_collator, max_seq_length,
     )
-    tensors = []
-    for batch, lengths, labels in batches:
-        tensors.extend([batch, lengths])
-        if labels is not None:
-            tensors.append(labels)
-    if tensors:
-        mx.eval(tensors)
-    return batches
 
 
 def _prompt_completion_text_parts(tokenizer, item, dataset_text_field):
@@ -4142,7 +4172,14 @@ def _text_item_length(item):
     return len(item)
 
 
-def _iter_text_index_chunks(items, batch_size, seed, dataset_order, num_epochs=None):
+def _iter_text_index_chunks(
+    items,
+    batch_size,
+    seed,
+    dataset_order,
+    num_epochs=None,
+    drop_last_default=True,
+):
     """Yield text batch index chunks using mlx-lm/default or explicit ordering."""
     if dataset_order not in (None, "default", "sequential", "torch_randperm"):
         raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
@@ -4156,9 +4193,10 @@ def _iter_text_index_chunks(items, batch_size, seed, dataset_order, num_epochs=N
     while num_epochs is None or epoch < int(num_epochs):
         if dataset_order in (None, "default"):
             ordered = sorted(range(length), key=lambda idx: _text_item_length(items[idx]))
+            stop = length - batch_size + 1 if drop_last_default else length
             chunks = [
                 ordered[start:start + batch_size]
-                for start in range(0, length - batch_size + 1, batch_size)
+                for start in range(0, stop, batch_size)
             ]
             if not chunks:
                 raise ValueError(


### PR DESCRIPTION
## Stack note

This PR is stacked on #793 and depends on the text-label dataset parity work there.

GitHub shows this PR against `main` because the #793 branch is fork-owned and is not available as an upstream base branch. For review, please use the clean stacked diff:

- Clean stacked diff: https://github.com/Lyxot/unsloth-zoo/compare/fix/mlx-text-label-parity...fix/mlx-custom-collator-core
- Incremental branch size on top of #793: `3 files changed, 1373 insertions(+), 32 deletions(-)`
- Runtime diff on top of #793: `unsloth_zoo/mlx/trainer.py` and `unsloth_zoo/mlx/utils.py`, `513 insertions(+), 25 deletions(-)`

## Summary

Adds MLX text custom `data_collator` support for non-packing text training and eval datasets, including raw dataset passthrough via `dataset_kwargs={"skip_prepare_dataset": True}`.

The implementation keeps the existing MLX text batch contract by converting user-collated outputs back into `(input_ids, lengths, labels)` before training or evaluation.

## What changed

### Text custom collators

- `MLXTrainer(..., data_collator=...)` now routes supported text datasets through a custom-collated batch path.
- Prepared text examples forwarded to the collator preserve the SFT fields introduced by #793:
  - `input_ids`
  - `labels`
  - `completion_mask`
  - `assistant_masks`
- List-like prepared fields are truncated to `max_seq_length` before collation.
- Existing sample sequencing behavior is preserved before collation:
  - the default MLX sequence remains the default;
  - `preserve_dataset_order=True` still maps to sequential sampling;
  - `dataset_order="torch_randperm"` remains available for CUDA sampler alignment.

### Output normalization

- Supports common collator output containers and tensor types:
  - torch tensors
  - numpy arrays
  - Python lists
  - MLX arrays
  - `BatchEncoding` mappings
- Accepts 1D single-example outputs and 2D batched outputs.
- Accepts bool, integer, and float `0/1` `attention_mask` outputs.
- Builds MLX `[start, end)` lengths from right-padded attention masks, or full-sequence lengths when no `attention_mask` is returned.
- Allows a collator to return a smaller batch than the selected examples, matching the CUDA/TRL behavior that the collator owns the returned batch shape.

### Eval support

- Text eval datasets can use the same custom-collator normalization path as training.
- Dict eval datasets are normalized per split with the same text-only rules.
- Unsupported eval surfaces still fail clearly:
  - VLM eval with custom collators
  - streaming eval with custom collators
  - packing or padding-free eval collation

### Raw passthrough

- Adds `dataset_kwargs` to `MLXTrainingConfig`.
- Supports `dataset_kwargs={"skip_prepare_dataset": True}` for text datasets when a custom collator is provided.
- Raw passthrough sends raw dataset examples directly to the custom collator instead of preparing/tokenizing them first.
- Raw passthrough defaults to sequential sampling, while explicit `dataset_order="torch_randperm"` is still honored for CUDA sampler alignment.
- `skip_prepare_dataset=True` without a custom collator raises a clear error because MLX has no prepared batch contract to consume in that mode.

### Validation and failure modes

The MLX path now fails early for output contracts it cannot safely represent:

- missing `input_ids` or missing `labels`
- non-integer `input_ids` / `labels`
- non-binary float `attention_mask`
- labels whose shape does not match `input_ids`
- attention masks whose shape does not match `input_ids`
- left-padded or non-contiguous attention masks
- labels that are supervised where `attention_mask == 0`
- `position_ids` or `seq_lengths` outputs, because padding-free/packed collation is not part of this PR
- batches with no supervised shifted target tokens

Harmless extra output keys are ignored rather than rejected.

## Out of scope

This PR intentionally does not add support for:

- ShareGPT conversion beyond #793 behavior
- raw conversational `assistant_only_loss=True`
- tokenizer/config aliases such as `pad_to_multiple_of`, `max_length`, token aliases, or `chat_template_path`
- eval API aliases such as `per_device_eval_batch_size`, `eval_strategy`, or `evaluation_strategy`
- VLM custom collators
- streaming datasets with custom-collator eval
- packing or padding-free collation
- combining `train_on_responses_only(...)` with a custom collator after trainer construction

## Commits in the stacked diff

- `8fec50ed fix(mlx): support text custom data collators`
- `9a177567 fix(mlx): validate custom collator contracts`
- `1c6e617f fix(mlx): align custom collator routing`
- `c249728b fix(mlx): normalize custom collator outputs`
- `00677eb9 fix(mlx): normalize custom collator eval batches`
- `826ded2e fix(mlx): support raw custom collator passthrough`

## Why

After #793, MLX can consume prepared/tokenized text-label datasets, but it still needs a supported path for user-provided text collators. CUDA/TRL lets user collators operate over prepared examples and, when requested, raw examples via `skip_prepare_dataset=True`. This PR adds the corresponding MLX text path and normalizes the collator output into the existing MLX batch representation.

## Validation

```bash
python -m pytest tests/test_mlx_trainer_internals.py -q -k "not cce_backward_via_torch_autograd"
# 141 passed, 1 deselected, 3 warnings

git diff --check fork/fix/mlx-text-label-parity..fix/mlx-custom-collator-core
# clean
```
