### PR TITLE
Feat(mlx): Add eval mean_token_accuracy metric to MLXTrainer (baseline path)

### DIFF
--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2340,10 +2340,13 @@ def test_evaluate_dict_eval_datasets_records_split_metrics():
     trainer.model = Model()
     trainer.stop_requested = False
 
-    def loss_fn(_model, name, _lengths, _labels):
-        if name == "small":
-            return mx.array(1.0), mx.array(2)
-        return mx.array(3.0), mx.array(6)
+    def loss_fn(_model, name, _lengths, _labels, return_correct=False):
+        base = (mx.array(1.0), mx.array(2)) if name == "small" else (mx.array(3.0), mx.array(6))
+        if return_correct:
+            # Real eval loss_fns accept return_correct; this split-metrics test
+            # does not exercise accuracy, so report no numerator (c=None).
+            return base[0], base[1], None
+        return base
 
     loss, ppl = trainer._evaluate(
         {"small": [("small", None, None)], "large": [("large", None, None)]},
@@ -2368,6 +2371,158 @@ def test_evaluate_batch_totals_uses_single_eval_status_collective():
     assert "_distributed_eval_status" in source
     assert "_distributed_should_stop" not in source
     assert "_raise_distributed_failure(" not in source
+
+
+def test_evaluate_all_reduces_token_accuracy_across_ranks():
+    # In DDP each rank only sees its own eval shard. The mean-token-accuracy
+    # numerator (correct predictions) and its token denominator must both be
+    # all-summed across ranks BEFORE dividing; otherwise a rank divides its
+    # local correct count by the global token total and reports a wrong ratio.
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    class Model:
+        def eval(self):
+            pass
+
+        def train(self):
+            pass
+
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model = Model()
+    trainer.stop_requested = False
+
+    # Local (rank 0) shard: 3 correct tokens over 5 total tokens.
+    def loss_fn(_model, _batch, _lengths, _labels, return_correct=False):
+        loss = mx.array(1.0)
+        ntoks = mx.array(5)
+        if return_correct:
+            return loss, ntoks, mx.array(3.0)
+        return loss, ntoks
+
+    # Avoid the eval-status collective so the only all-reduces we intercept are
+    # the loss / token / correct reductions, in that call order.
+    trainer._distributed_eval_status = lambda failed=False: (False, False)
+
+    # Simulate the peer rank (rank 1) contributing 4 correct over 15 tokens
+    # (plus some loss mass). Each _distributed_all_sum call adds the matching
+    # peer contribution, in order: all_losses, ntokens, the rank-wide
+    # "any rank has an accuracy numerator" consensus vote (int), correct_total.
+    peer_deltas = iter([
+        mx.array(10.0), mx.array(15), mx.array(1, dtype=mx.int32), mx.array(4.0),
+    ])
+
+    def fake_all_sum(value, stream=None):
+        return value + next(peer_deltas)
+
+    trainer._distributed_all_sum = fake_all_sum
+
+    trainer._evaluate(
+        [(mx.array([[1, 2, 3]]), None, None)],
+        loss_fn,
+        is_vlm=False,
+    )
+
+    metrics = trainer._last_eval_metrics
+    # Global correct = 3 + 4 = 7, global tokens = 5 + 15 = 20 -> 0.35.
+    assert metrics["eval_mean_token_accuracy"] == pytest.approx(7.0 / 20.0)
+    # The un-reduced (buggy) numerator would give 3 / 20 = 0.15.
+    assert metrics["eval_mean_token_accuracy"] != pytest.approx(3.0 / 20.0)
+
+
+def test_evaluate_reports_accuracy_for_dict_eval_datasets():
+    # A dict eval_dataset (multiple named splits) must still report
+    # eval_mean_token_accuracy, so metric_for_best_model="eval_mean_token_accuracy"
+    # works the same as on the single-stream path.
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    class Model:
+        def eval(self):
+            pass
+
+        def train(self):
+            pass
+
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model = Model()
+    trainer.stop_requested = False
+    trainer._distributed_eval_status = lambda failed=False: (False, False)
+    trainer._distributed_should_stop = lambda: False
+    # Single-rank simulation: every all-reduce is the identity.
+    trainer._distributed_all_sum = lambda value, stream=None: value
+
+    def loss_fn(_model, _batch, _lengths, _labels, return_correct=False):
+        loss = mx.array(1.0)
+        ntoks = mx.array(5)
+        if return_correct:
+            return loss, ntoks, mx.array(3.0)
+        return loss, ntoks
+
+    one_batch = [(mx.array([[1, 2, 3]]), None, None)]
+    trainer._evaluate({"a": one_batch, "b": one_batch}, loss_fn, is_vlm=False)
+
+    metrics = trainer._last_eval_metrics
+    # Two splits, 3 correct / 5 tokens each -> 6 / 10 = 0.6.
+    assert metrics["eval_mean_token_accuracy"] == pytest.approx(6.0 / 10.0)
+    assert "eval_a_loss" in metrics and "eval_b_loss" in metrics
+
+
+def test_accuracy_all_reduce_is_unconditional_across_ranks():
+    # DDP lockstep: a rank that produced no accuracy numerator (correct_total is
+    # None, e.g. the loss backend returned no argmax, or it stopped before its
+    # first eval batch) must still enter the numerator all-reduce when a PEER
+    # produced one. A per-rank `if correct_total is not None` gate would let only
+    # the peers call the collective and deadlock; the reduce is gated on a
+    # rank-wide consensus vote instead, so every rank calls it in lockstep.
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    class Model:
+        def eval(self):
+            pass
+
+        def train(self):
+            pass
+
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model = Model()
+    trainer.stop_requested = False
+    trainer._distributed_eval_status = lambda failed=False: (False, False)
+
+    # This rank's loss backend returns no accuracy numerator (c=None).
+    def loss_fn(_model, _batch, _lengths, _labels, return_correct=False):
+        loss = mx.array(1.0)
+        ntoks = mx.array(5)
+        if return_correct:
+            return loss, ntoks, None
+        return loss, ntoks
+
+    calls = []
+    # Peer contributions, in call order: all_losses, ntokens, the rank-wide "any
+    # rank has a numerator" consensus vote (a peer does, so 1), then the numerator.
+    peer_deltas = iter([
+        mx.array(10.0), mx.array(15), mx.array(1, dtype=mx.int32), mx.array(4.0),
+    ])
+
+    def fake_all_sum(value, stream=None):
+        calls.append(value)
+        return value + next(peer_deltas)
+
+    trainer._distributed_all_sum = fake_all_sum
+
+    trainer._evaluate([(mx.array([[1, 2, 3]]), None, None)], loss_fn, is_vlm=False)
+
+    metrics = trainer._last_eval_metrics
+    # This rank had no numerator (None -> 0); the peer had 4 correct over a global
+    # 5 + 15 = 20 tokens -> 0.2. The metric being present proves the numerator
+    # collective ran on the no-numerator rank (no deadlock).
+    assert metrics["eval_mean_token_accuracy"] == pytest.approx(4.0 / 20.0)
+    # Exactly four all-reduces: losses, tokens, consensus vote, numerator.
+    assert len(calls) == 4
 
 
 def test_check_all_masked_reduces_counts_across_ranks(monkeypatch):
@@ -7930,7 +8085,11 @@ def test_eval_dataloader_tracks_the_split_being_evaluated():
         eval=lambda: None, train=lambda: None,
     )
 
-    def _loss_fn(_model, _batch, _lengths, _labels):
+    def _loss_fn(_model, _batch, _lengths, _labels, return_correct=False):
+        # Real eval loss_fns accept return_correct; dict eval requests the
+        # accuracy numerator per split.
+        if return_correct:
+            return mx.array(1.0), mx.array(4), mx.array(2.0)
         return mx.array(1.0), mx.array(4)
 
     trainer._evaluate(splits, _loss_fn)

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2525,6 +2525,29 @@ def test_accuracy_all_reduce_is_unconditional_across_ranks():
     assert len(calls) == 4
 
 
+def test_greater_is_better_inferred_from_metric_name():
+    # Exposing eval_mean_token_accuracy for metric_for_best_model must not
+    # silently minimize accuracy: greater_is_better defaults to None and is
+    # inferred from the metric name (HF parity), while an explicit value wins.
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    def gib(metric, explicit=None):
+        t = MLXTrainer.__new__(MLXTrainer)
+        t.args = MLXTrainingConfig(
+            metric_for_best_model=metric,
+            greater_is_better=explicit,
+            output_dir="/tmp/o",
+        )
+        return t._resolved_greater_is_better()
+
+    assert gib("eval_mean_token_accuracy") is True
+    assert gib("mean_token_accuracy") is True  # eval_ prefix added; still accuracy
+    assert gib("eval_loss") is False
+    assert gib("eval_perplexity") is False
+    assert gib("eval_mean_token_accuracy", explicit=False) is False
+    assert gib("eval_loss", explicit=True) is True
+
+
 def test_check_all_masked_reduces_counts_across_ranks(monkeypatch):
     # In DDP each rank only sees its own shard. A rank whose shard happens to be
     # entirely masked must not raise alone (that would hang peers at the next

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -3576,7 +3576,15 @@ class MLXTrainer:
                         correct_total = (
                             c if correct_total is None else correct_total + c
                         )
-                    mx.eval(all_losses, ntokens)
+                    # Materialize the accuracy numerator with the loss and token
+                    # totals. Leaving correct_total lazy keeps every batch's
+                    # argmax(logits) graph alive until the final metric, so eval
+                    # memory would grow with the whole eval set (unlike the loss
+                    # and token totals, which are evaluated each batch).
+                    if correct_total is None:
+                        mx.eval(all_losses, ntokens)
+                    else:
+                        mx.eval(all_losses, ntokens, correct_total)
                     # HF dispatches on_prediction_step after each evaluation
                     # batch is folded into the running totals. Raised inside
                     # this try on purpose: a callback that fails on one rank
@@ -3695,15 +3703,25 @@ class MLXTrainer:
                         if split_index:
                             self._close_split_prediction_bars()
                         handler.eval_dataloader = split_batches
-                    split_losses, split_tokens, _ = self._evaluate_batch_totals(
+                    split_losses, split_tokens, split_correct = self._evaluate_batch_totals(
                         split_batches, loss_fn, is_vlm=is_vlm,
-                        want_accuracy=False,
+                        want_accuracy=True,
                     )
                     split_losses = self._distributed_all_sum(split_losses, stream=mx.cpu)
                     split_tokens = self._distributed_all_sum(split_tokens, stream=mx.cpu)
                     all_losses += split_losses
                     ntokens += split_tokens
-                    mx.eval(all_losses, ntokens)
+                    # Accumulate the raw (pre-reduce) accuracy numerator across
+                    # splits; it is rank-reduced once after the loop, so dict eval
+                    # reports eval_mean_token_accuracy like the single-stream path.
+                    if split_correct is not None:
+                        correct_total = (
+                            split_correct if correct_total is None
+                            else correct_total + split_correct
+                        )
+                        mx.eval(all_losses, ntokens, correct_total)
+                    else:
+                        mx.eval(all_losses, ntokens)
                     split_loss = (
                         (split_losses / split_tokens).item()
                         if split_tokens.item() > 0 else 0.0
@@ -3723,6 +3741,27 @@ class MLXTrainer:
             )
             all_losses = self._distributed_all_sum(all_losses, stream=mx.cpu)
             ntokens = self._distributed_all_sum(ntokens, stream=mx.cpu)
+        # DDP: reduce the token-accuracy numerator across ranks before dividing.
+        # ntokens above is already the global token denominator, so both
+        # correct_total and its denominator are rank-summed. The decision to run
+        # this collective must be identical on every rank: correct_total is None
+        # on a rank that produced no numerator (e.g. an external stop set
+        # stop_requested before its first eval batch, so it skipped every
+        # compute while peers accumulated a real numerator). Gating the all_sum
+        # on the per-rank `correct_total is not None` would let only the peers
+        # call it and deadlock DDP. Reduce a rank-wide "any rank has a numerator"
+        # flag first (an unconditional collective), then have every rank
+        # all-sum, so a None rank contributes zero and the collective stays in
+        # lockstep. Shared by both the dict and single-stream paths.
+        if self._distributed_any_flag(correct_total is not None):
+            numerator = (
+                mx.array(0.0, dtype=mx.float32)
+                if correct_total is None
+                else correct_total.astype(mx.float32)
+            )
+            correct_total = self._distributed_all_sum(numerator, stream=mx.cpu)
+        else:
+            correct_total = None
 
         self.model.train()
         avg_loss = (all_losses / ntokens).item() if ntokens.item() > 0 else 0.0

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -3520,17 +3520,18 @@ class MLXTrainer:
             except AttributeError:
                 pass  # read-only attribute; the close above already ended it
 
-    def _evaluate_batch_totals(self, eval_batches, loss_fn, is_vlm=False):
+    def _evaluate_batch_totals(self, eval_batches, loss_fn, is_vlm=False, want_accuracy=False):
         """Accumulate weighted loss totals for one flat eval batch stream."""
         all_losses = mx.array(0.0)
         ntokens = mx.array(0)
+        correct_total = None
         # A stop requested before evaluation must abort before the first pull:
         # an unsized source's next row can block, so cancellation could
         # otherwise never take effect. Rank-synchronized so peers return
         # together instead of diverging at the in-loop status collective.
         should_stop, _ = self._distributed_eval_status()
         if should_stop:
-            return all_losses, ntokens
+            return all_losses, ntokens, correct_total
         iterator = iter(eval_batches)
 
         while True:
@@ -3549,15 +3550,32 @@ class MLXTrainer:
             if not failed and not self.stop_requested:
                 try:
                     if is_vlm:
-                        loss, ntoks = loss_fn(self.model, batch_data)
+                        if want_accuracy:
+                            loss, ntoks, c = loss_fn(
+                                self.model, batch_data, return_correct=True,
+                            )
+                        else:
+                            loss, ntoks = loss_fn(self.model, batch_data)
+                            c = None
                     else:
                         batch, lengths, labels = batch_data
-                        loss, ntoks = loss_fn(self.model, batch, lengths, labels)
+                        if want_accuracy:
+                            loss, ntoks, c = loss_fn(
+                                self.model, batch, lengths, labels,
+                                return_correct=True,
+                            )
+                        else:
+                            loss, ntoks = loss_fn(self.model, batch, lengths, labels)
+                            c = None
                     # Zero-token eval batches (distributed_pad_mode="empty" padding
                     # rows) make loss NaN; mask them so NaN * 0 does not poison the
                     # distributed all-sum. mx.where never selects the NaN branch.
                     all_losses += mx.where(ntoks > 0, loss * ntoks, 0.0)
                     ntokens += ntoks
+                    if c is not None:
+                        correct_total = (
+                            c if correct_total is None else correct_total + c
+                        )
                     mx.eval(all_losses, ntokens)
                     # HF dispatches on_prediction_step after each evaluation
                     # batch is folded into the running totals. Raised inside
@@ -3579,7 +3597,7 @@ class MLXTrainer:
             if should_stop:
                 break
 
-        return all_losses, ntokens
+        return all_losses, ntokens, correct_total
 
     def _create_text_eval_batches(
         self,
@@ -3659,6 +3677,7 @@ class MLXTrainer:
         """
         self.model.eval()
         metrics = {}
+        correct_total = None
         if isinstance(eval_batches, dict):
             all_losses = mx.array(0.0)
             ntokens = mx.array(0)
@@ -3676,8 +3695,9 @@ class MLXTrainer:
                         if split_index:
                             self._close_split_prediction_bars()
                         handler.eval_dataloader = split_batches
-                    split_losses, split_tokens = self._evaluate_batch_totals(
+                    split_losses, split_tokens, _ = self._evaluate_batch_totals(
                         split_batches, loss_fn, is_vlm=is_vlm,
+                        want_accuracy=False,
                     )
                     split_losses = self._distributed_all_sum(split_losses, stream=mx.cpu)
                     split_tokens = self._distributed_all_sum(split_tokens, stream=mx.cpu)
@@ -3698,8 +3718,8 @@ class MLXTrainer:
                 if handler is not None:
                     handler.eval_dataloader = outer_dataloader
         else:
-            all_losses, ntokens = self._evaluate_batch_totals(
-                eval_batches, loss_fn, is_vlm=is_vlm,
+            all_losses, ntokens, correct_total = self._evaluate_batch_totals(
+                eval_batches, loss_fn, is_vlm=is_vlm, want_accuracy=True,
             )
             all_losses = self._distributed_all_sum(all_losses, stream=mx.cpu)
             ntokens = self._distributed_all_sum(ntokens, stream=mx.cpu)
@@ -3709,6 +3729,8 @@ class MLXTrainer:
         perplexity = math.exp(min(avg_loss, 100))
         metrics["eval_loss"] = avg_loss
         metrics["eval_perplexity"] = perplexity
+        if correct_total is not None and ntokens.item() > 0:
+            metrics["eval_mean_token_accuracy"] = (correct_total / ntokens).item()
         self._last_eval_metrics = metrics
         return avg_loss, perplexity
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1069,7 +1069,7 @@ class MLXTrainingConfig:
     eval_steps: int = 0  # 0 = disabled
     load_best_model_at_end: bool = False
     metric_for_best_model: str = "eval_loss"
-    greater_is_better: bool = False
+    greater_is_better: bool | None = None  # None: infer direction from the metric name (HF parity)
     early_stopping_patience: int = 0  # 0 = disabled
     neftune_noise_alpha: float = 0.0  # 0 = disabled (text models only)
 
@@ -1992,6 +1992,18 @@ class MLXTrainer:
         bare name ("loss") gets the eval_ prefix eval metric keys carry."""
         name = getattr(self.args, "metric_for_best_model", None) or "eval_loss"
         return name if name.startswith("eval_") else f"eval_{name}"
+
+    def _resolved_greater_is_better(self):
+        """greater_is_better with HF-style inference when left unset (None):
+        metrics ending in loss/perplexity are lower-is-better, everything else
+        (e.g. mean_token_accuracy) is higher-is-better. An explicit True/False
+        always wins. Mirrors transformers TrainingArguments, so exposing an
+        accuracy metric for metric_for_best_model does not silently minimize it."""
+        explicit = getattr(self.args, "greater_is_better", None)
+        if explicit is not None:
+            return bool(explicit)
+        name = self._resolved_best_metric_name().lower()
+        return not (name.endswith("loss") or name.endswith("perplexity"))
 
     def _train_dataset_for_batches(self):
         """Return the internal dataset used for MLX batch construction."""
@@ -3119,7 +3131,7 @@ class MLXTrainer:
         value = metrics[metric_name]
         if value != value:
             return False
-        greater = bool(getattr(self.args, "greater_is_better", False))
+        greater = self._resolved_greater_is_better()
         improved = (
             self.state.best_metric is None
             or (value > self.state.best_metric if greater else value < self.state.best_metric)
@@ -5963,7 +5975,7 @@ class MLXTrainer:
                     f"metrics; available: {sorted(_em)}"
                 )
             _cur = _em[_metric_name]
-            _greater = bool(getattr(args, "greater_is_better", False))
+            _greater = self._resolved_greater_is_better()
             _improved = (
                 _cur == _cur  # reject NaN: a diverged eval must never be "best"
                 and (

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1270,7 +1270,7 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
             label_smoothing=label_smoothing,
         )
 
-        def loss_fn(model, batch, lengths, labels=None):
+        def loss_fn(model, batch, lengths, labels=None, return_correct=False):
             if labels is None:
                 inputs, targets = batch[:, :-1], batch[:, 1:]
             else:
@@ -1304,6 +1304,8 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
             targets_flat = masked_targets.reshape((-1,))  # runtime CCE validates dtype before narrowing
             loss = rt_cce(hidden_flat, w, sc, bi, targets_flat)
             loss = loss.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
+            if return_correct:
+                return loss, ntoks, None
             return loss, ntoks
     else:
         _skip_weight_grad = not _is_lm_head_trainable(model)
@@ -1316,7 +1318,7 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
             label_smoothing=label_smoothing,
         )
 
-        def loss_fn(model, batch, lengths, labels=None):
+        def loss_fn(model, batch, lengths, labels=None, return_correct=False):
             if labels is None:
                 inputs, targets = batch[:, :-1], batch[:, 1:]
             else:
@@ -1344,6 +1346,8 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
             targets_flat = masked_targets.reshape((-1,))  # runtime CCE validates dtype before narrowing
             loss = rt_cce(hidden_flat, w, targets_flat)
             loss = loss.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
+            if return_correct:
+                return loss, ntoks, None
             return loss, ntoks
 
     loss_fn._unsloth_cce_backend = "runtime-cce"
@@ -1373,7 +1377,7 @@ def make_baseline_loss_fn(label_smoothing=0.0):
     else:
         _token_ce = nn.losses.cross_entropy
 
-    def loss_fn(model, batch, lengths, labels=None):
+    def loss_fn(model, batch, lengths, labels=None, return_correct=False):
         if labels is None:
             # Half-open [start, end) end-exclusive mask; matches CCE/labels paths
             # (:360, :393, :439) and mlx_lm's lengths convention.
@@ -1387,6 +1391,10 @@ def make_baseline_loss_fn(label_smoothing=0.0):
             # Raw ntoks (no safe denominator) to match mlx_lm default_loss
             # byte-for-byte; the safe wrapper stays on the labels-aware path.
             ce = ce.astype(mx.float32).sum() / ntoks
+            if return_correct:
+                preds = mx.argmax(logits, axis=-1)
+                correct = ((preds == targets).astype(mx.float32) * mask).sum()
+                return ce, ntoks, correct
             return ce, ntoks
         # labels-aware path: train_on_responses_only style masking.
         inputs = batch[:, :-1]
@@ -1408,6 +1416,10 @@ def make_baseline_loss_fn(label_smoothing=0.0):
         ce = _token_ce(logits, safe_targets) * mask
         ntoks = mask.sum()
         loss = ce.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
+        if return_correct:
+            preds = mx.argmax(logits, axis=-1)
+            correct = ((preds == safe_targets).astype(mx.float32) * mask).sum()
+            return loss, ntoks, correct
         return loss, ntoks
 
     return loss_fn
@@ -1845,7 +1857,7 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
     )
     _assistant_token_id = assistant_token_id
 
-    def loss_fn(model, batch_dict):
+    def loss_fn(model, batch_dict, return_correct=False):
         input_ids = batch_dict["input_ids"]
         pixel_values = batch_dict.get("pixel_values")
         attention_mask = batch_dict.get("attention_mask")
@@ -1919,6 +1931,10 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
         ce = nn.losses.cross_entropy(logits, safe_targets) * mask
         ntoks = mask.sum()
         loss = ce.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
+        if return_correct:
+            preds = mx.argmax(logits, axis=-1)
+            correct = ((preds == safe_targets).astype(mx.float32) * mask).sum()
+            return loss, ntoks, correct
         return loss, ntoks
 
     loss_fn._unsloth_cce_backend = "baseline-ce"
@@ -3171,7 +3187,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             mode=quant_mode,
         )
 
-        def loss_fn(model, batch_dict):
+        def loss_fn(model, batch_dict, return_correct=False):
             hidden, masked_targets, ntoks = _vlm_cce_forward(
                 model, batch_dict, image_token_ids=_image_token_ids,
                 assistant_token_id=_assistant_token_id)
@@ -3192,6 +3208,8 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             targets_flat = masked_targets.reshape((-1,))  # runtime CCE validates dtype before narrowing
             loss = rt_cce(hidden_flat, w, sc, bi, targets_flat)
             loss = loss.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
+            if return_correct:
+                return loss, ntoks, None
             return loss, ntoks
     else:
         if _skip_weight_grad:
@@ -3202,7 +3220,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             logit_softcap=softcap,
         )
 
-        def loss_fn(model, batch_dict):
+        def loss_fn(model, batch_dict, return_correct=False):
             hidden, masked_targets, ntoks = _vlm_cce_forward(
                 model, batch_dict, image_token_ids=_image_token_ids,
                 assistant_token_id=_assistant_token_id)
@@ -3216,6 +3234,8 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             targets_flat = masked_targets.reshape((-1,))  # runtime CCE validates dtype before narrowing
             loss = rt_cce(hidden_flat, w, targets_flat)
             loss = loss.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
+            if return_correct:
+                return loss, ntoks, None
             return loss, ntoks
 
     loss_fn._unsloth_cce_backend = "runtime-cce"


### PR DESCRIPTION
## Summary
Adds `eval_mean_token_accuracy` to MLXTrainer eval, matching TRL's
SFTTrainer metric so MLX runs are comparable to CUDA/Colab runs.

## Scope
- Computed only on the baseline (non-CCE) loss path, where full logits
  exist. Under CCE the loss returns (loss, lse) with no logits, so the
  metric is omitted — mirroring TRL's own behavior with its fused Liger
  kernel (it skips logit materialization unless explicitly needed).
- Eval-only. Training-loop and value_and_grad paths are untouched: the
  loss fns gain an opt-in `return_correct=False` kwarg, so the
  (loss, ntoks) contract the grad wrapper depends on is unchanged.

## Implementation
- Four loss fns (utils.py) take `return_correct=False`; baseline paths
  return (loss, ntoks, correct) when set, CCE paths return (..., None).
- `_evaluate_batch_totals` gains `want_accuracy`; `_evaluate` threads
  correct-token totals and emits `eval_mean_token_accuracy`.

## Testing
5-step gemma-3-4b-it VLM LoRA run, baseline + CCE:
- baseline: eval_mean_token_accuracy ≈ 0.456 reported
- CCE: key correctly absent; eval_loss identical across both (4.1048)