### PR TITLE
Feat(mlx): Add NEFTune (neftune_noise_alpha) for text models to MLXTrainer

### DIFF
--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -78,6 +78,7 @@ from .utils import (
     apply_gradient_checkpointing,
     remove_gradient_checkpointing,
     _is_vlm_model,
+    _get_text_model,
 )
 from .compile import (
     build_compile_policy,
@@ -502,6 +503,7 @@ class MLXTrainingConfig:
 
     # Eval
     eval_steps: int = 0  # 0 = disabled
+    neftune_noise_alpha: float = 0.0  # 0 = disabled (text models only)
 
     # SFT-specific (from SFTConfig, for API compat)
     dataset_text_field: str = "text"
@@ -1072,11 +1074,68 @@ class MLXTrainer:
             pass
         self._prior_metal_limits = {}
 
+    def _install_neftune(self):
+        """NEFTune: add scaled uniform noise to input embeddings during training.
+        Text models only; no-op in eval. Uses __class__ reassignment (a real
+        subclass) rather than a module swap, so the embedding object is
+        unchanged -- .weight stays readable for tied LM-head models, and
+        __call__ resolves on the subtype so interception actually fires."""
+        alpha = float(getattr(self.args, "neftune_noise_alpha", 0.0) or 0.0)
+        if alpha <= 0:
+            return
+        if self._is_vlm:
+            print("Unsloth: NEFTune (neftune_noise_alpha) is not yet supported "
+                  "for VLM models on MLX; ignoring.")
+            return
+        try:
+            tm = _get_text_model(self.model)
+            backbone = getattr(tm, "model", tm)
+            emb = backbone.embed_tokens
+        except Exception as e:
+            print(f"Unsloth: NEFTune could not locate embed_tokens ({e}); ignoring.")
+            return
+        if getattr(emb, "_unsloth_neftune_active", False):
+            return
+
+        _Base = type(emb)
+        _alpha = alpha
+
+        class _NEFTuneEmbed(_Base):
+            _unsloth_neftune_active = True
+            def __call__(self, x):
+                out = _Base.__call__(self, x)
+                if getattr(self, "training", False):
+                    dim = out.shape[-1] * out.shape[-2]
+                    scale = _alpha / (dim ** 0.5)
+                    noise = mx.random.uniform(
+                        low=-1.0, high=1.0, shape=out.shape
+                    ).astype(out.dtype) * scale
+                    return out + noise
+                return out
+
+        self._neftune_emb = emb
+        self._neftune_base_cls = _Base
+        emb.__class__ = _NEFTuneEmbed
+        print(f"Unsloth: NEFTune enabled (noise_alpha={alpha}).")
+
+    def _remove_neftune(self):
+        emb = getattr(self, "_neftune_emb", None)
+        base = getattr(self, "_neftune_base_cls", None)
+        if emb is not None and base is not None:
+            try:
+                emb.__class__ = base
+            except Exception:
+                pass
+        self._neftune_emb = None
+        self._neftune_base_cls = None
+
+
     def train(self, resume_from_checkpoint: str | None = None):
         """Run MLX-native training loop following mlx-lm's compiled-step pattern
         with gradient accumulation. Returns a dict of training metrics."""
         # Stash for _train_inner. None = fresh start, a path = resume.
         self._resume_from_checkpoint = resume_from_checkpoint
+        self._install_neftune()
         args = self.args
         model = self.model
         cast_norm_output = bool(getattr(args, "cast_norm_output_to_input_dtype", True))
@@ -1168,6 +1227,7 @@ class MLXTrainer:
 
             return self._train_inner()
         finally:
+            self._remove_neftune()
             if args.gradient_checkpointing:
                 try:
                     remove_gradient_checkpointing(model)


### PR DESCRIPTION
# Add NEFTune (`neftune_noise_alpha`) for text models to MLXTrainer
 
Adds NEFTune (Noisy Embedding Fine-Tuning) to the MLX trainer, matching the CUDA path. Unsloth's CUDA code wires NEFTune via TRL (`tokenizer_utils.py` imports `neftune_post_forward_hook` and registers it with `embed_tokens.register_forward_hook`), and it's exposed through HF `TrainingArguments` / TRL `SFTConfig` as `neftune_noise_alpha`. MLX had no equivalent. This closes that gap for **text models**.
 
NEFTune adds uniform noise `±alpha/sqrt(seq_len·dim)` to the input embeddings during training (no-op in eval), which regularizes instruction fine-tuning on small datasets.
 
## Config
 
`neftune_noise_alpha: float = 0.0` (0 = disabled; the paper uses 5–15).
 
## Implementation note — why `__class__` reassignment
 
The PyTorch approach (forward hook) has no MLX equivalent — MLX `nn.Module` has no `register_forward_hook`. Two obvious MLX substitutes both fail:
 
- Overriding `emb.__call__` on the *instance* silently no-ops — MLX/Python resolve `__call__` on the type, not the instance (verified).
- Swapping `embed_tokens` for a wrapper module *does* intercept, but breaks tied-embedding models (Qwen/Llama/Gemma): the CCE path reads `embed_tokens.weight` as the LM head (`_get_lm_head_layer` returns `embed_tokens` for tied models), and a wrapper hides `.weight` (`AttributeError` on Qwen2.5).
Instead, `_install_neftune` makes `embed_tokens` an instance of a dynamically-created subclass of its own type (`emb.__class__ = _NEFTuneEmbed`), overriding only `__call__`. Because it's a real subtype, the object is otherwise unchanged: `.weight` / `.scales` / `.bits` inherit natively (tied LM-head works), `__call__` resolves on the subtype (interception fires), and teardown is a one-line `emb.__class__ = base` in the `finally`. Verified on the real quantized tied Qwen2.5-0.5B that `trainable_parameters()`, full-model forward, adapter saving, and `isinstance` all behave correctly while active.
 
## Scope
 
Text models only. VLMs print a clear "not yet supported" notice and train normally (noise skipped) — the merged vision+text embedding path needs separate handling, left as a follow-up. (Note: even the community mlx-tune project, which has DPO/ORPO/GRPO/CPT on MLX, does not implement NEFTune.)
 
## Testing (Qwen2.5-0.5B, alpaca-cleaned)
 
- alpha=0 vs alpha=5: "NEFTune enabled" prints for alpha=5, training losses differ (noise lands), embedding class restored to base after `train()`.
- Structural safety on the real quantized tied model: param collection, forward, adapter save, isinstance, and class restore all verified while the subclass is active.
- VLM run (gemma-3-4b): prints the "not supported" notice, trains without crashing.