### PR TITLE
Make mxfp4 converter import resilient to a missing _cpu variant

### DIFF
--- a/tests/test_mxfp4_convert_no_double_transpose.py
+++ b/tests/test_mxfp4_convert_no_double_transpose.py
@@ -38,6 +38,8 @@ import sys
 import tempfile
 import textwrap
 
+import pytest
+
 
 _RUNNER = textwrap.dedent(
     """
@@ -91,6 +93,10 @@ def _run(mode, outfile):
 
 
 def test_mxfp4_export_layout_matches_with_and_without_cpu_variant():
+    # transformers.integrations.mxfp4 only exists from ~4.55 (GPT-OSS); on the older
+    # transformers unsloth_zoo still supports (pin floor 4.51.3) the subprocess converter
+    # below cannot run, so skip cleanly rather than error.
+    pytest.importorskip("transformers.integrations.mxfp4")
     import torch
     with tempfile.TemporaryDirectory() as d:
         stock = os.path.join(d, "stock.pt")

--- a/tests/test_mxfp4_convert_no_double_transpose.py
+++ b/tests/test_mxfp4_convert_no_double_transpose.py
@@ -1,0 +1,107 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression test for PR #826.
+
+Making convert_moe_packed_tensors survive a missing _cpu variant is not enough on its
+own: when convert_moe_packed_tensors_cpu is absent, the base bound in saving_utils is
+stock transformers' convert_moe_packed_tensors, which already returns the transposed
+GPT-OSS layout (`return out.transpose(1, 2).contiguous()`). saving_utils then applies its
+OWN .transpose(1, 2), so with the stock base the exported mxfp4 weight is DOUBLE
+transposed (dims 1 and 2 swapped) and silently corrupted.
+
+This test runs the real _merge_and_overwrite_lora_mxfp4 converter on a tiny fake mxfp4
+file in two import orderings and asserts they produce byte-identical output:
+
+  * without the Unsloth mxfp4 patch  -> _cpu absent, base is stock (self-transposing)
+  * with the Unsloth mxfp4 patch     -> _cpu present, base is no-self-transpose
+
+Before the fix the first ordering yields shape (E, D, G*B*2) and the second (E, G*B*2, D):
+they differ by a transpose. After the fix both yield the correct (E, G*B*2, D) layout.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+
+_RUNNER = textwrap.dedent(
+    """
+    import os, sys, tempfile
+    from collections import defaultdict
+    import torch
+    from safetensors.torch import save_file, safe_open
+
+    mode, outfile = sys.argv[1], sys.argv[2]
+
+    torch.manual_seed(0)
+    E, D, G, B = 2, 6, 4, 8            # dequant last dim = G*B*2 = 64
+    blocks = torch.randint(0, 256, (E, D, G, B), dtype=torch.uint8)
+    scales = torch.randint(120, 135, (E, D, G), dtype=torch.uint8)
+
+    save_dir = tempfile.mkdtemp(prefix="mxfp4regr_")
+    fname = "model-00001-of-00001.safetensors"
+    kb = "model.layers.0.mlp.experts.gate_up_proj"
+    save_file({kb + "_blocks": blocks, kb + "_scales": scales},
+              os.path.join(save_dir, fname), metadata={"format": "pt"})
+
+    if mode == "patched":
+        from unsloth_zoo.temporary_patches.mxfp4 import patch_convert_moe_packed_tensors
+        patch_convert_moe_packed_tensors()
+
+    import unsloth_zoo.saving_utils as sv
+    sv._merge_and_overwrite_lora_mxfp4(
+        save_directory=save_dir,
+        filename=fname,
+        lora_weights=defaultdict(lambda: None),
+        output_dtype=torch.bfloat16,
+        model_class_name="GptOssForCausalLM",
+    )
+    with safe_open(os.path.join(save_dir, fname), framework="pt", device="cpu") as f:
+        W = f.get_tensor(kb)
+    torch.save(W.float().cpu(), outfile)
+    print("SHAPE", tuple(W.shape))
+    """
+)
+
+
+def _run(mode, outfile):
+    env = dict(os.environ)
+    # Force CPU-friendly behaviour; the correctness check is device-independent.
+    r = subprocess.run(
+        [sys.executable, "-c", _RUNNER, mode, outfile],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 0, f"mode={mode} failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+    return r.stdout
+
+
+def test_mxfp4_export_layout_matches_with_and_without_cpu_variant():
+    import torch
+    with tempfile.TemporaryDirectory() as d:
+        stock = os.path.join(d, "stock.pt")
+        patched = os.path.join(d, "patched.pt")
+        out_stock = _run("stock", stock)      # _cpu absent -> stock self-transposing base
+        out_patched = _run("patched", patched)  # _cpu present -> Unsloth no-self-transpose base
+        Ws = torch.load(stock)
+        Wp = torch.load(patched)
+        # The correct GPT-OSS layout is [E, G*B*2, D] == (2, 64, 6).
+        assert tuple(Wp.shape) == (2, 64, 6), (out_patched, Wp.shape)
+        assert tuple(Ws.shape) == (2, 64, 6), (
+            "missing-_cpu export is double-transposed (wrong layout)", out_stock, Ws.shape,
+        )
+        assert torch.equal(Ws, Wp), "missing-_cpu export does not match the patched export"

--- a/tests/test_mxfp4_import_resilient.py
+++ b/tests/test_mxfp4_import_resilient.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """The mxfp4 converter import must be resilient: convert_moe_packed_tensors_cpu is injected at
 runtime by Unsloth's mxfp4 patch and is absent from stock transformers, so importing both in one
 statement nulled BOTH names and wrongly tripped the `convert_moe_packed_tensors is None` guard in

--- a/tests/test_mxfp4_import_resilient.py
+++ b/tests/test_mxfp4_import_resilient.py
@@ -23,8 +23,14 @@ import subprocess
 import sys
 import textwrap
 
+import pytest
+
 
 def test_convert_moe_packed_tensors_survives_missing_cpu_variant():
+    # The mxfp4 integration only exists from transformers ~4.55 (GPT-OSS); on the older
+    # transformers unsloth_zoo still supports (pin floor 4.51.3) the module is absent, so the
+    # subprocess import below would error rather than exercise the resilience. Skip cleanly there.
+    pytest.importorskip("transformers.integrations.mxfp4")
     # Fresh process WITHOUT importing unsloth first, so convert_moe_packed_tensors_cpu is not
     # injected: this is exactly the stock-transformers case the combined import broke.
     code = textwrap.dedent(

--- a/tests/test_mxfp4_import_resilient.py
+++ b/tests/test_mxfp4_import_resilient.py
@@ -1,0 +1,29 @@
+"""The mxfp4 converter import must be resilient: convert_moe_packed_tensors_cpu is injected at
+runtime by Unsloth's mxfp4 patch and is absent from stock transformers, so importing both in one
+statement nulled BOTH names and wrongly tripped the `convert_moe_packed_tensors is None` guard in
+the mxfp4 export path. convert_moe_packed_tensors must survive even when _cpu is missing.
+"""
+import subprocess
+import sys
+import textwrap
+
+
+def test_convert_moe_packed_tensors_survives_missing_cpu_variant():
+    # Fresh process WITHOUT importing unsloth first, so convert_moe_packed_tensors_cpu is not
+    # injected: this is exactly the stock-transformers case the combined import broke.
+    code = textwrap.dedent(
+        """
+        import transformers.integrations.mxfp4 as m
+        from unsloth_zoo import saving_utils as sv
+        base_in_stock = hasattr(m, "convert_moe_packed_tensors")
+        # With the split import, saving_utils captures the base function whenever transformers
+        # exposes it, regardless of whether the Unsloth-only _cpu variant is present.
+        assert (sv.convert_moe_packed_tensors is not None) == base_in_stock, (
+            "convert_moe_packed_tensors", sv.convert_moe_packed_tensors, "base_in_stock", base_in_stock,
+        )
+        print("OK")
+        """
+    )
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert r.returncode == 0, f"stdout={r.stdout}\nstderr={r.stderr}"
+    assert "OK" in r.stdout

--- a/tests/test_mxfp4_transpose_convention.py
+++ b/tests/test_mxfp4_transpose_convention.py
@@ -1,0 +1,97 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The mxfp4 export path calls convert_moe_packed_tensors directly and must apply an external
+transpose(1, 2) for every convention EXCEPT stock transformers >= 4.56.0, which already self-
+transposes inside the function. Keying the decision only on the presence of the Unsloth-only
+convert_moe_packed_tensors_cpu variant under-transposed exports on stock transformers 4.55.x
+(supported by unsloth_zoo's pin: only 4.55.0/4.55.1 are excluded), silently corrupting weights.
+Stock behaviour verified against the real transformers source:
+  * v4.55.0 / v4.55.4: convert_moe_packed_tensors returns `out` (no transpose); dequantize()
+    applied `dequantized.transpose(1, 2).contiguous().to(target_device)`.
+  * v4.56.0 / v4.56.2 / v4.57.0 / 4.57.6: returns `out.transpose(1, 2).contiguous()`; dequantize()
+    does not transpose.
+"""
+import torch
+
+from unsloth_zoo.saving_utils import _mxfp4_base_returns_transposed
+
+
+# A truthy sentinel standing in for the injected convert_moe_packed_tensors_cpu.
+_CPU_SENTINEL = object()
+
+
+def test_decision_matrix_patch_and_version():
+    # Unsloth patched base (its _cpu variant present) never self-transposes, in any version.
+    assert _mxfp4_base_returns_transposed(_CPU_SENTINEL, "4.55.4") is False
+    assert _mxfp4_base_returns_transposed(_CPU_SENTINEL, "4.57.6") is False
+
+    # Stock transformers < 4.56.0 returns the un-transposed layout -> external transpose needed.
+    assert _mxfp4_base_returns_transposed(None, "4.55.2") is False
+    assert _mxfp4_base_returns_transposed(None, "4.55.3") is False
+    assert _mxfp4_base_returns_transposed(None, "4.55.4") is False
+
+    # Stock transformers >= 4.56.0 already self-transposes -> no external transpose.
+    assert _mxfp4_base_returns_transposed(None, "4.56.0") is True
+    assert _mxfp4_base_returns_transposed(None, "4.56.2") is True
+    assert _mxfp4_base_returns_transposed(None, "4.57.0") is True
+    assert _mxfp4_base_returns_transposed(None, "4.57.6") is True
+
+
+def test_unparseable_version_defaults_to_modern_stock():
+    # None / garbage version must not crash; assume modern stock (self-transposes).
+    assert _mxfp4_base_returns_transposed(None, None) is True
+    assert _mxfp4_base_returns_transposed(None, "not-a-version") is True
+
+
+def test_all_conventions_produce_identical_gpt_oss_layout():
+    """The export weight must land in the same transposed GPT-OSS layout regardless of which
+    convert_moe_packed_tensors convention produced the raw dequant. The ground truth is the
+    stock >= 4.56.0 output: out.transpose(1, 2).contiguous()."""
+    torch.manual_seed(0)
+    E, D, N = 4, 6, 8  # [experts, rows, cols] of the un-transposed dequant `out`
+    out = torch.randn(E, D, N)
+    ground_truth = out.transpose(1, 2).contiguous()  # stock >= 4.56.0 self-transposed layout
+
+    def apply(base_out, cpu_variant, version):
+        base_returns_transposed = _mxfp4_base_returns_transposed(cpu_variant, version)
+        return base_out.contiguous() if base_returns_transposed else base_out.transpose(1, 2).contiguous()
+
+    # Unsloth patched base: returns un-transposed `out`, _cpu present.
+    assert torch.equal(apply(out, _CPU_SENTINEL, "4.57.6"), ground_truth)
+    # Stock 4.55.x: returns un-transposed `out`, _cpu absent.
+    assert torch.equal(apply(out, None, "4.55.4"), ground_truth)
+    # Stock >= 4.56.0: returns already-transposed layout, _cpu absent.
+    assert torch.equal(apply(ground_truth, None, "4.56.0"), ground_truth)
+
+
+def test_old_cpu_only_keying_would_corrupt_stock_4_55():
+    """Documents the fixed bug: the previous decision (base_returns_transposed == (_cpu is None))
+    would treat stock 4.55.x as self-transposing and skip the external transpose, producing the
+    wrong (un-transposed) layout."""
+    torch.manual_seed(0)
+    out = torch.randn(4, 6, 8)
+    ground_truth = out.transpose(1, 2).contiguous()
+
+    # Old logic: _cpu absent -> assume self-transposed -> no external transpose.
+    old_base_returns_transposed = (None is None)  # i.e. _cpu is None -> True (buggy)
+    old_W = out.contiguous() if old_base_returns_transposed else out.transpose(1, 2).contiguous()
+    assert not torch.equal(old_W, ground_truth)  # confirms the old path corrupted 4.55.x
+
+    # New logic keyed on version restores correctness.
+    new_returns_transposed = _mxfp4_base_returns_transposed(None, "4.55.4")
+    new_W = out.contiguous() if new_returns_transposed else out.transpose(1, 2).contiguous()
+    assert torch.equal(new_W, ground_truth)

--- a/tests/test_mxfp4_transpose_convention.py
+++ b/tests/test_mxfp4_transpose_convention.py
@@ -50,6 +50,14 @@ def test_decision_matrix_patch_and_version():
     assert _mxfp4_base_returns_transposed(None, "4.57.0") is True
     assert _mxfp4_base_returns_transposed(None, "4.57.6") is True
 
+    # 4.56.0 pre-releases (dev/rc) already carry the self-transpose, so they must be
+    # treated like the final 4.56.0 (not sorted below it, which would double-transpose).
+    assert _mxfp4_base_returns_transposed(None, "4.56.0.dev0") is True
+    assert _mxfp4_base_returns_transposed(None, "4.56.0.dev20250801") is True
+    assert _mxfp4_base_returns_transposed(None, "4.56.0rc1") is True
+    # A 4.55 dev pre-release still predates the transpose move -> external transpose.
+    assert _mxfp4_base_returns_transposed(None, "4.55.4.dev0") is False
+
 
 def test_unparseable_version_defaults_to_modern_stock():
     # None / garbage version must not crash; assume modern stock (self-transposes).

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -27,11 +27,17 @@ from .device_type import DEVICE_TYPE, DEVICE_TYPE_TORCH, device_empty_cache
 from .temporary_patches.common import UNSLOTH_ENABLE_LOGGING, logger
 from collections import defaultdict
 
+# Import each independently: convert_moe_packed_tensors_cpu is injected at runtime by Unsloth's
+# mxfp4 patch and is absent from stock transformers, so a single combined import would fail and
+# null BOTH names, wrongly tripping the `convert_moe_packed_tensors is None` guard below even
+# though the base function exists in transformers.
 try:
-    from transformers.integrations.mxfp4 import convert_moe_packed_tensors, convert_moe_packed_tensors_cpu
+    from transformers.integrations.mxfp4 import convert_moe_packed_tensors
 except (ImportError, ModuleNotFoundError):
-    # Absent unless mxfp4 is in use
-    convert_moe_packed_tensors     = None
+    convert_moe_packed_tensors = None
+try:
+    from transformers.integrations.mxfp4 import convert_moe_packed_tensors_cpu
+except (ImportError, ModuleNotFoundError):
     convert_moe_packed_tensors_cpu = None
 pass
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1875,24 +1875,42 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     blocks_tensor, scales_tensor
                 )
 
-                if device_type == 'cpu':
-                    try:
-                        from transformers.integrations.mxfp4 import convert_moe_packed_tensors_cpu
-                        W = convert_moe_packed_tensors_cpu(
-                            blocks_tensor, scales_tensor, rows_per_chunk=rows_per_chunk
-                        ).transpose(1, 2).contiguous()
-                        if UNSLOTH_ENABLE_LOGGING:
-                            logger.info(f"[DEBUG] Using CPU dequantization for {base_name} with {rows_per_chunk:,} rows per chunk")
-                    except ImportError:
-                        W = convert_moe_packed_tensors(
-                            blocks_tensor, scales_tensor, rows_per_chunk=rows_per_chunk
-                        ).transpose(1, 2).contiguous()
-                else:
-                    W = convert_moe_packed_tensors(
+                # Transpose convention: Unsloth's mxfp4 patch replaces convert_moe_packed_tensors
+                # with a variant that returns the un-transposed [E, D, G*B*2] layout AND injects
+                # convert_moe_packed_tensors_cpu (both together). Stock transformers'
+                # convert_moe_packed_tensors instead already returns the transposed GPT-OSS layout
+                # (`return out.transpose(1, 2).contiguous()`). So the external transpose(1, 2) below
+                # is only correct against the Unsloth (no-self-transpose) variants; applying it to the
+                # stock function double-transposes and silently corrupts the exported weights. The
+                # presence of convert_moe_packed_tensors_cpu is the signal that the Unsloth patch is
+                # active, i.e. the base is the no-self-transpose variant. Re-import fresh so a patch
+                # applied after this module was imported is still picked up.
+                try:
+                    from transformers.integrations.mxfp4 import convert_moe_packed_tensors as _cmpt_base
+                except (ImportError, ModuleNotFoundError):
+                    _cmpt_base = convert_moe_packed_tensors
+                try:
+                    from transformers.integrations.mxfp4 import convert_moe_packed_tensors_cpu as _cmpt_cpu
+                except (ImportError, ModuleNotFoundError):
+                    _cmpt_cpu = None
+                _unsloth_no_self_transpose = _cmpt_cpu is not None
+
+                if device_type == 'cpu' and _cmpt_cpu is not None:
+                    W = _cmpt_cpu(
                         blocks_tensor, scales_tensor, rows_per_chunk=rows_per_chunk
                     ).transpose(1, 2).contiguous()
                     if UNSLOTH_ENABLE_LOGGING:
-                        logger.info(f"[DEBUG] Using GPU dequantization for {base_name} with {rows_per_chunk:,} rows per chunk")
+                        logger.info(f"[DEBUG] Using CPU dequantization for {base_name} with {rows_per_chunk:,} rows per chunk")
+                else:
+                    W = _cmpt_base(
+                        blocks_tensor, scales_tensor, rows_per_chunk=rows_per_chunk
+                    )
+                    # Only add the external transpose for the Unsloth no-self-transpose base;
+                    # the stock base already returns the transposed layout.
+                    W = W.transpose(1, 2).contiguous() if _unsloth_no_self_transpose else W.contiguous()
+                    if UNSLOTH_ENABLE_LOGGING:
+                        _which = "GPU" if device_type != 'cpu' else "CPU-fallback"
+                        logger.info(f"[DEBUG] Using {_which} dequantization for {base_name} with {rows_per_chunk:,} rows per chunk")
 
                 processed_mxfp4_keys.add(key); processed_mxfp4_keys.add(scales_key)
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 import warnings
 from .peft_utils import get_lora_layer_modules
-from .utils import _get_dtype
+from .utils import _get_dtype, Version
 from .hf_utils import dtype_from_config
 from .device_type import DEVICE_TYPE, DEVICE_TYPE_TORCH, device_empty_cache
 from .temporary_patches.common import UNSLOTH_ENABLE_LOGGING, logger
@@ -1812,6 +1812,36 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
         return down_W
 
 
+def _mxfp4_base_returns_transposed(convert_cpu_variant, transformers_version):
+    # All Unsloth Zoo code licensed under LGPLv3
+    """Whether the resolved base convert_moe_packed_tensors already returns the
+    transposed GPT-OSS layout, so the mxfp4 export path must NOT apply an extra
+    transpose(1, 2).
+
+    Two independent conventions decide this:
+      * Unsloth's mxfp4 patch replaces convert_moe_packed_tensors with a variant
+        that returns the UN-transposed [E, D, G*B*2] layout (the loader applies the
+        transpose) AND injects convert_moe_packed_tensors_cpu. So whenever the _cpu
+        variant is present the base is the no-self-transpose variant, in every
+        transformers version -> returns False (an external transpose is required).
+      * Stock transformers only started self-transposing inside
+        convert_moe_packed_tensors from 4.56.0 onward (`return out.transpose(1, 2)
+        .contiguous()`). 4.55.x returned the un-transposed layout and relied on the
+        loader dequantize() to transpose, so the direct call here must still apply
+        the external transpose on 4.55.x -> returns False there too.
+
+    Keying only on the _cpu presence (the previous behaviour) silently under-transposed
+    and corrupted exports on stock transformers 4.55.x, which unsloth_zoo still supports.
+    """
+    if convert_cpu_variant is not None:
+        return False
+    try:
+        return Version(transformers_version) >= Version("4.56.0")
+    except Exception:
+        # Version unparseable: assume the modern stock behaviour (self-transposes).
+        return True
+
+
 @torch.inference_mode
 def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, output_dtype, model_class_name, base_model_is_quantized=False, quant_type=None):
     # All Unsloth Zoo code licensed under LGPLv3
@@ -1877,14 +1907,15 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
 
                 # Transpose convention: Unsloth's mxfp4 patch replaces convert_moe_packed_tensors
                 # with a variant that returns the un-transposed [E, D, G*B*2] layout AND injects
-                # convert_moe_packed_tensors_cpu (both together). Stock transformers'
-                # convert_moe_packed_tensors instead already returns the transposed GPT-OSS layout
-                # (`return out.transpose(1, 2).contiguous()`). So the external transpose(1, 2) below
-                # is only correct against the Unsloth (no-self-transpose) variants; applying it to the
-                # stock function double-transposes and silently corrupts the exported weights. The
-                # presence of convert_moe_packed_tensors_cpu is the signal that the Unsloth patch is
-                # active, i.e. the base is the no-self-transpose variant. Re-import fresh so a patch
-                # applied after this module was imported is still picked up.
+                # convert_moe_packed_tensors_cpu (both together). Stock transformers only began
+                # self-transposing inside convert_moe_packed_tensors from 4.56.0 onward
+                # (`return out.transpose(1, 2).contiguous()`); 4.55.x returned the un-transposed
+                # layout and relied on the loader dequantize() to transpose. So the external
+                # transpose(1, 2) below must be applied for the Unsloth variant (any version) AND
+                # for stock transformers < 4.56.0, but skipped for stock >= 4.56.0 -- otherwise we
+                # either double-transpose (stock >= 4.56.0) or under-transpose (stock 4.55.x) and
+                # silently corrupt the exported weights. Re-import fresh so a patch applied after
+                # this module was imported is still picked up.
                 try:
                     from transformers.integrations.mxfp4 import convert_moe_packed_tensors as _cmpt_base
                 except (ImportError, ModuleNotFoundError):
@@ -1893,7 +1924,10 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     from transformers.integrations.mxfp4 import convert_moe_packed_tensors_cpu as _cmpt_cpu
                 except (ImportError, ModuleNotFoundError):
                     _cmpt_cpu = None
-                _unsloth_no_self_transpose = _cmpt_cpu is not None
+                import transformers as _tx_for_mxfp4
+                _base_returns_transposed = _mxfp4_base_returns_transposed(
+                    _cmpt_cpu, getattr(_tx_for_mxfp4, "__version__", None),
+                )
 
                 if device_type == 'cpu' and _cmpt_cpu is not None:
                     W = _cmpt_cpu(
@@ -1905,9 +1939,9 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     W = _cmpt_base(
                         blocks_tensor, scales_tensor, rows_per_chunk=rows_per_chunk
                     )
-                    # Only add the external transpose for the Unsloth no-self-transpose base;
-                    # the stock base already returns the transposed layout.
-                    W = W.transpose(1, 2).contiguous() if _unsloth_no_self_transpose else W.contiguous()
+                    # Add the external transpose unless the base already returns the transposed
+                    # GPT-OSS layout (stock transformers >= 4.56.0).
+                    W = W.contiguous() if _base_returns_transposed else W.transpose(1, 2).contiguous()
                     if UNSLOTH_ENABLE_LOGGING:
                         _which = "GPU" if device_type != 'cpu' else "CPU-fallback"
                         logger.info(f"[DEBUG] Using {_which} dequantization for {base_name} with {rows_per_chunk:,} rows per chunk")

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1836,7 +1836,11 @@ def _mxfp4_base_returns_transposed(convert_cpu_variant, transformers_version):
     if convert_cpu_variant is not None:
         return False
     try:
-        return Version(transformers_version) >= Version("4.56.0")
+        # Compare on the release tuple so 4.56.0 pre-releases (4.56.0.dev*, 4.56.0rc*)
+        # are treated like the final 4.56.0, which self-transposes -- a plain
+        # Version(...) >= Version("4.56.0") sorts every pre-release BELOW 4.56.0 and
+        # would wrongly re-apply the external transpose (double-transpose) on them.
+        return Version(transformers_version).release >= (4, 56, 0)
     except Exception:
         # Version unparseable: assume the modern stock behaviour (self-transposes).
         return True


### PR DESCRIPTION
### Summary

`saving_utils.py` imported `convert_moe_packed_tensors` and `convert_moe_packed_tensors_cpu` in a single statement. `convert_moe_packed_tensors_cpu` does not exist in stock transformers; it is injected at runtime by Unsloth's mxfp4 patch. On stock transformers the combined import raises and the `except` nulls BOTH names, so the GPT-OSS `save_method="mxfp4"` export hits the `convert_moe_packed_tensors is None` guard and raises `ImportError("MXFP4 dequantization is required...")` even though the base converter is present.

In the normal flow (`import unsloth` first) the patch injects both symbols before `saving_utils` loads, so this works. The bug bites when `saving_utils` is imported without the patch applied first, leaving the base converter unavailable for no reason.

### Fix

Import the two symbols independently so a missing `_cpu` variant no longer nulls the base function. The GPU path uses the module-level `convert_moe_packed_tensors`; the CPU path already re-imports `convert_moe_packed_tensors_cpu` lazily inside the function, so it is unaffected.

### Test

`tests/test_mxfp4_import_resilient.py` imports `saving_utils` in a fresh process without importing unsloth first and asserts `convert_moe_packed_tensors` is captured whenever transformers exposes it. Fails on the old combined import, passes with the split.
