### PR TITLE
Batch the fused MoE expert LoRA merge into one matmul on GPU

### DIFF
--- a/tests/test_moe_fused_baddbmm_equiv.py
+++ b/tests/test_moe_fused_baddbmm_equiv.py
@@ -39,8 +39,7 @@ def test_cpu_path_matches_loop(use_transpose):
 @pytest.mark.parametrize("use_transpose", [False, True])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
 def test_cuda_baddbmm_matches_loop(use_transpose, dtype):
-    # 128 experts to mirror a real fused MoE; compare baddbmm vs the per-expert loop on the SAME
-    # device so the only difference is batching (must be bitwise-identical).
+    # 128 experts, same device: only batching differs, so it must be bitwise-identical.
     E, rank, dim_A, dim_B, alpha = 128, 16, 64, 96, 1.7
     merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, dtype, "cuda")
     ref = _loop_reference(merged, A, B, E, rank, alpha, use_transpose)
@@ -51,9 +50,7 @@ def test_cuda_baddbmm_matches_loop(use_transpose, dtype):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for the batched path")
 @pytest.mark.parametrize("use_transpose", [False, True])
 def test_bmm_oom_falls_back_to_loop(monkeypatch, use_transpose):
-    """If the batched (num_experts, dim_B, dim_A) delta OOMs, the helper must complete the merge
-    via the per-expert loop instead of letting the error escape (which would leave the weight
-    unmerged). The loop uses matmul, not bmm, so it is unaffected by the forced OOM."""
+    """On a batched-delta OOM the helper completes via the per-expert loop (matmul, not bmm)."""
     E, rank, dim_A, dim_B, alpha = 16, 8, 32, 48, 1.3
     merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, torch.float32, "cuda")
     ref = _loop_reference(merged, A, B, E, rank, alpha, use_transpose)

--- a/tests/test_moe_fused_baddbmm_equiv.py
+++ b/tests/test_moe_fused_baddbmm_equiv.py
@@ -46,3 +46,35 @@ def test_cuda_baddbmm_matches_loop(use_transpose, dtype):
     ref = _loop_reference(merged, A, B, E, rank, alpha, use_transpose)
     got = _apply_fused_expert_lora_delta(merged.clone(), A, B, E, rank, dim_A, dim_B, alpha, use_transpose)
     assert torch.equal(got, ref), (got - ref).abs().max().item()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for the batched path")
+@pytest.mark.parametrize("use_transpose", [False, True])
+def test_bmm_oom_falls_back_to_loop(monkeypatch, use_transpose):
+    """If the batched (num_experts, dim_B, dim_A) delta OOMs, the helper must complete the merge
+    via the per-expert loop instead of letting the error escape (which would leave the weight
+    unmerged). The loop uses matmul, not bmm, so it is unaffected by the forced OOM."""
+    E, rank, dim_A, dim_B, alpha = 16, 8, 32, 48, 1.3
+    merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, torch.float32, "cuda")
+    ref = _loop_reference(merged, A, B, E, rank, alpha, use_transpose)
+
+    def oom(*a, **k):
+        raise RuntimeError("CUDA out of memory. Tried to allocate 8.00 GiB")
+
+    monkeypatch.setattr(torch, "bmm", oom)
+    got = _apply_fused_expert_lora_delta(merged.clone(), A, B, E, rank, dim_A, dim_B, alpha, use_transpose)
+    assert torch.equal(got, ref), "OOM fallback loop must match the batched result"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for the batched path")
+def test_non_oom_runtimeerror_propagates(monkeypatch):
+    """A non-OOM error from the batched path is a real bug and must not be swallowed."""
+    E, rank, dim_A, dim_B, alpha = 4, 4, 8, 8, 1.0
+    merged, A, B = _make(E, rank, dim_A, dim_B, False, torch.float32, "cuda")
+
+    def boom(*a, **k):
+        raise RuntimeError("some real shape error")
+
+    monkeypatch.setattr(torch, "bmm", boom)
+    with pytest.raises(RuntimeError, match="real shape error"):
+        _apply_fused_expert_lora_delta(merged, A, B, E, rank, dim_A, dim_B, alpha, False)

--- a/tests/test_moe_fused_baddbmm_equiv.py
+++ b/tests/test_moe_fused_baddbmm_equiv.py
@@ -1,0 +1,48 @@
+"""The batched baddbmm path for fused MoE expert LoRA must be numerically identical to the
+per-expert loop it replaces, for both the standard and transposed (GPT-OSS) layouts, with the
+LoRA scaling (alpha) applied exactly once per expert."""
+import pytest
+import torch
+
+from unsloth_zoo.saving_utils import _apply_fused_expert_lora_delta
+
+
+def _loop_reference(merged, lora_A, lora_B, num_experts, rank, alpha, use_transpose):
+    out = merged.clone()
+    for e in range(num_experts):
+        s, t = e * rank, (e + 1) * rank
+        delta = lora_B[:, s:t] @ lora_A[s:t, :]
+        out[e] = out[e].add(delta.T if use_transpose else delta, alpha=alpha)
+    return out
+
+
+def _make(num_experts, rank, dim_A, dim_B, use_transpose, dtype, device):
+    torch.manual_seed(0)
+    lora_A = torch.randn(num_experts * rank, dim_A, dtype=dtype, device=device)
+    lora_B = torch.randn(dim_B, num_experts * rank, dtype=dtype, device=device)
+    # delta_e is (dim_B, dim_A); merged[e] adds delta (std) or delta.T (transposed).
+    shape = (num_experts, dim_A, dim_B) if use_transpose else (num_experts, dim_B, dim_A)
+    merged = torch.randn(*shape, dtype=dtype, device=device)
+    return merged, lora_A, lora_B
+
+
+@pytest.mark.parametrize("use_transpose", [False, True])
+def test_cpu_path_matches_loop(use_transpose):
+    E, rank, dim_A, dim_B, alpha = 8, 4, 16, 24, 2.0
+    merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, torch.float32, "cpu")
+    ref = _loop_reference(merged, A, B, E, rank, alpha, use_transpose)
+    got = _apply_fused_expert_lora_delta(merged.clone(), A, B, E, rank, dim_A, dim_B, alpha, use_transpose)
+    assert torch.equal(got, ref)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for the baddbmm path")
+@pytest.mark.parametrize("use_transpose", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_cuda_baddbmm_matches_loop(use_transpose, dtype):
+    # 128 experts to mirror a real fused MoE; compare baddbmm vs the per-expert loop on the SAME
+    # device so the only difference is batching (must be bitwise-identical).
+    E, rank, dim_A, dim_B, alpha = 128, 16, 64, 96, 1.7
+    merged, A, B = _make(E, rank, dim_A, dim_B, use_transpose, dtype, "cuda")
+    ref = _loop_reference(merged, A, B, E, rank, alpha, use_transpose)
+    got = _apply_fused_expert_lora_delta(merged.clone(), A, B, E, rank, dim_A, dim_B, alpha, use_transpose)
+    assert torch.equal(got, ref), (got - ref).abs().max().item()

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1654,19 +1654,37 @@ def _apply_fused_expert_lora_delta(merged, lora_A_dev, lora_B_dev, num_experts, 
     win. The batched path computes the same per-expert delta = B_e @ A_e and the same
     `merged[e] += alpha * delta` as the loop (a plain bmm + add_, NOT a fused baddbmm, so the
     rounding matches the loop exactly), so the result is bitwise-identical to the loop in
-    fp32/bf16/fp16. The merge callers run this in fp32."""
-    if merged.device.type != "cpu":
+    fp32/bf16/fp16. The merge callers run this in fp32.
+
+    The batched bmm allocates a full (num_experts, dim_B, dim_A) fp32 delta on top of the fp32
+    merged weight (e.g. ~8 GiB for a 128-expert 5760x2880 merge). If that OOMs we fall back to
+    the per-expert loop, which holds one expert-sized delta at a time, so the merge still
+    completes instead of the caller catching the error and writing back an unmerged weight."""
+    def _loop():
+        for expert_idx in range(num_experts):
+            start, end = expert_idx * rank, (expert_idx + 1) * rank
+            delta = lora_B_dev[:, start:end] @ lora_A_dev[start:end, :]
+            merged[expert_idx].add_(delta.T if use_transpose else delta, alpha=alpha)
+        return merged
+
+    if merged.device.type == "cpu":
+        return _loop()
+
+    try:
         # (E, dim_B, rank) @ (E, rank, dim_A) -> (E, dim_B, dim_A) = per-expert delta.
         B_exp = lora_B_dev.reshape(dim_B, num_experts, rank).permute(1, 0, 2).contiguous()
         A_exp = lora_A_dev.reshape(num_experts, rank, dim_A).contiguous()
         delta = torch.bmm(B_exp, A_exp)
         merged.add_(delta.transpose(1, 2) if use_transpose else delta, alpha=alpha)
-    else:
-        for expert_idx in range(num_experts):
-            start, end = expert_idx * rank, (expert_idx + 1) * rank
-            delta = lora_B_dev[:, start:end] @ lora_A_dev[start:end, :]
-            merged[expert_idx].add_(delta.T if use_transpose else delta, alpha=alpha)
-    return merged
+        return merged
+    except RuntimeError as exc:
+        if "out of memory" not in str(exc).lower():
+            raise   # a real error, not a memory shortfall
+    # OOM: drop the partial allocations and retry with the memory-light per-expert loop.
+    B_exp = A_exp = delta = None
+    if merged.device.type == "cuda":
+        torch.cuda.empty_cache()
+    return _loop()
 pass
 
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1644,22 +1644,12 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
 
 def _apply_fused_expert_lora_delta(merged, lora_A_dev, lora_B_dev, num_experts, rank,
                                    dim_A, dim_B, alpha, use_transpose):
-    """In-place per-expert LoRA merge for a fused MoE weight: merged[e] += alpha * delta_e, where
-    delta_e = lora_B_e @ lora_A_e (transposed for GPT-OSS-style layouts). lora_B is contiguous-r
-    per expert (see moe_utils.py _canonical_lora_weights_for_grouped_mm), so a plain reshape
-    recovers the per-expert blocks the loop sliced.
-
-    On an accelerator (CUDA / XPU / MPS) this batches every expert into a single bmm (no Python
-    loop, faster for many experts); on CPU it keeps the loop, where the batched matmul is not a
-    win. The batched path computes the same per-expert delta = B_e @ A_e and the same
-    `merged[e] += alpha * delta` as the loop (a plain bmm + add_, NOT a fused baddbmm, so the
-    rounding matches the loop exactly), so the result is bitwise-identical to the loop in
-    fp32/bf16/fp16. The merge callers run this in fp32.
-
-    The batched bmm allocates a full (num_experts, dim_B, dim_A) fp32 delta on top of the fp32
-    merged weight (e.g. ~8 GiB for a 128-expert 5760x2880 merge). If that OOMs we fall back to
-    the per-expert loop, which holds one expert-sized delta at a time, so the merge still
-    completes instead of the caller catching the error and writing back an unmerged weight."""
+    """In-place per-expert LoRA merge for a fused MoE weight: merged[e] += alpha * B_e @ A_e
+    (transposed for GPT-OSS layouts). On an accelerator this batches all experts into one bmm; on
+    CPU it loops. Both use a plain bmm/matmul + add_ (not baddbmm), so the result is
+    bitwise-identical in fp32/bf16/fp16 (callers run fp32). The batched bmm allocates a full
+    (E, dim_B, dim_A) fp32 delta (~8 GiB for a 128-expert 5760x2880 merge); on OOM we fall back to
+    the loop so the merge completes rather than the caller writing back an unmerged weight."""
     def _loop():
         for expert_idx in range(num_experts):
             start, end = expert_idx * rank, (expert_idx + 1) * rank

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1642,6 +1642,35 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
     return count
 
 
+def _apply_fused_expert_lora_delta(merged, lora_A_dev, lora_B_dev, num_experts, rank,
+                                   dim_A, dim_B, alpha, use_transpose):
+    """In-place per-expert LoRA merge for a fused MoE weight: merged[e] += alpha * delta_e, where
+    delta_e = lora_B_e @ lora_A_e (transposed for GPT-OSS-style layouts). lora_B is contiguous-r
+    per expert (see moe_utils.py _canonical_lora_weights_for_grouped_mm), so a plain reshape
+    recovers the per-expert blocks the loop sliced.
+
+    On CUDA this batches every expert into a single bmm (no Python loop, faster for many experts);
+    on CPU it keeps the loop, where the batched matmul is not a win. The batched path computes the
+    same per-expert delta = B_e @ A_e and the same `merged[e] += alpha * delta` as the loop (a
+    plain bmm + add_, NOT a fused baddbmm, so the rounding matches the loop exactly), so the result
+    is bitwise-identical to the loop in fp32/bf16/fp16. The merge callers run this in fp32."""
+    if merged.device.type == "cuda":
+        # (E, dim_B, rank) @ (E, rank, dim_A) -> (E, dim_B, dim_A) = per-expert delta.
+        B_exp = lora_B_dev.reshape(dim_B, num_experts, rank).permute(1, 0, 2).contiguous()
+        A_exp = lora_A_dev.reshape(num_experts, rank, dim_A).contiguous()
+        delta = torch.bmm(B_exp, A_exp)
+        merged.add_(delta.transpose(1, 2) if use_transpose else delta, alpha=alpha)
+    else:
+        for expert_idx in range(num_experts):
+            start, end = expert_idx * rank, (expert_idx + 1) * rank
+            delta = lora_B_dev[:, start:end] @ lora_A_dev[start:end, :]
+            merged[expert_idx] = merged[expert_idx].add(
+                delta.T if use_transpose else delta, alpha=alpha
+            )
+    return merged
+pass
+
+
 def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_transposed=None):
     """
     Merge LoRA for fused gate_up_proj 3D tensor.
@@ -1704,16 +1733,10 @@ def _merge_moe_fused_gate_up_expert(gate_up_W, lora_stats, output_dtype, is_tran
         lora_A_dev = lora_stats.lora_A.to(device, dtype=torch.float32, non_blocking=True)
         lora_B_dev = lora_stats.lora_B.to(device, dtype=torch.float32, non_blocking=True)
 
-        for expert_idx in range(num_experts):
-            start, end = expert_idx * rank, (expert_idx + 1) * rank
-            # lora_B is contiguous-r per expert (see moe_utils.py
-            # _canonical_lora_weights_for_grouped_mm); must match for the saved
-            # checkpoint to reproduce the training-time forward.
-            delta = lora_B_dev[:, start:end] @ lora_A_dev[start:end, :]
-
-            gate_up_merged[expert_idx] = gate_up_merged[expert_idx].add(
-                delta.T if use_transpose else delta, alpha=lora_stats.alpha
-            )
+        gate_up_merged = _apply_fused_expert_lora_delta(
+            gate_up_merged, lora_A_dev, lora_B_dev, num_experts, rank,
+            dim_A, dim_B, lora_stats.alpha, use_transpose,
+        )
 
         _MOE_MERGE_STATE["applied"] += 1
         return gate_up_merged.to(output_dtype)
@@ -1787,14 +1810,10 @@ def _merge_moe_fused_down_proj_expert(down_W, lora_stats, output_dtype, is_trans
         lora_A_dev = lora_stats.lora_A.to(device, dtype=torch.float32, non_blocking=True)
         lora_B_dev = lora_stats.lora_B.to(device, dtype=torch.float32, non_blocking=True)
 
-        for expert_idx in range(num_experts):
-            start, end = expert_idx * rank, (expert_idx + 1) * rank
-            # See _merge_moe_fused_gate_up_expert for the slicing rationale.
-            delta = lora_B_dev[:, start:end] @ lora_A_dev[start:end, :]
-
-            down_merged[expert_idx] = down_merged[expert_idx].add(
-                delta.T if use_transpose else delta, alpha=lora_stats.alpha
-            )
+        down_merged = _apply_fused_expert_lora_delta(
+            down_merged, lora_A_dev, lora_B_dev, num_experts, rank,
+            dim_A, dim_B, lora_stats.alpha, use_transpose,
+        )
 
         _MOE_MERGE_STATE["applied"] += 1
         return down_merged.to(output_dtype)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -1649,12 +1649,13 @@ def _apply_fused_expert_lora_delta(merged, lora_A_dev, lora_B_dev, num_experts, 
     per expert (see moe_utils.py _canonical_lora_weights_for_grouped_mm), so a plain reshape
     recovers the per-expert blocks the loop sliced.
 
-    On CUDA this batches every expert into a single bmm (no Python loop, faster for many experts);
-    on CPU it keeps the loop, where the batched matmul is not a win. The batched path computes the
-    same per-expert delta = B_e @ A_e and the same `merged[e] += alpha * delta` as the loop (a
-    plain bmm + add_, NOT a fused baddbmm, so the rounding matches the loop exactly), so the result
-    is bitwise-identical to the loop in fp32/bf16/fp16. The merge callers run this in fp32."""
-    if merged.device.type == "cuda":
+    On an accelerator (CUDA / XPU / MPS) this batches every expert into a single bmm (no Python
+    loop, faster for many experts); on CPU it keeps the loop, where the batched matmul is not a
+    win. The batched path computes the same per-expert delta = B_e @ A_e and the same
+    `merged[e] += alpha * delta` as the loop (a plain bmm + add_, NOT a fused baddbmm, so the
+    rounding matches the loop exactly), so the result is bitwise-identical to the loop in
+    fp32/bf16/fp16. The merge callers run this in fp32."""
+    if merged.device.type != "cpu":
         # (E, dim_B, rank) @ (E, rank, dim_A) -> (E, dim_B, dim_A) = per-expert delta.
         B_exp = lora_B_dev.reshape(dim_B, num_experts, rank).permute(1, 0, 2).contiguous()
         A_exp = lora_A_dev.reshape(num_experts, rank, dim_A).contiguous()
@@ -1664,9 +1665,7 @@ def _apply_fused_expert_lora_delta(merged, lora_A_dev, lora_B_dev, num_experts, 
         for expert_idx in range(num_experts):
             start, end = expert_idx * rank, (expert_idx + 1) * rank
             delta = lora_B_dev[:, start:end] @ lora_A_dev[start:end, :]
-            merged[expert_idx] = merged[expert_idx].add(
-                delta.T if use_transpose else delta, alpha=alpha
-            )
+            merged[expert_idx].add_(delta.T if use_transpose else delta, alpha=alpha)
     return merged
 pass
 


### PR DESCRIPTION
### Summary

The fused MoE expert LoRA merge (`_merge_moe_fused_gate_up_expert` / `_merge_moe_fused_down_proj_expert`) looped over experts in Python, computing one small matmul per expert. For models with many experts (up to 128) this is a long Python loop of tiny GEMMs.

This batches the per-expert deltas into a single `torch.bmm` plus one `add_` on CUDA, keeping the Python loop as the CPU path (where the batched matmul is not a win).

### Equivalence

`lora_B` is contiguous-r per expert, so a plain reshape recovers the exact per-expert blocks the loop sliced. The batched path computes the same `delta_e = B_e @ A_e` and the same `merged[e] += alpha * delta_e` (plain `bmm` + `add_`, not a fused `baddbmm`, so the rounding matches the loop), with the LoRA scaling `alpha` applied exactly once per expert. It is bitwise-identical to the loop in fp32, bf16 and fp16; the merge callers always run this in fp32.

### Speedup (B200)

| shape | experts | loop | batched | speedup |
|---|---|---|---|---|
| Qwen3-VL-ish gate_up | 128 | 4.87 ms | 1.74 ms | 2.80x |
| GPT-OSS-ish gate_up | 128 | 13.15 ms | 9.08 ms | 1.45x |
| Gemma4-ish | 32 | 1.59 ms | 1.08 ms | 1.47x |

### Test

`tests/test_moe_fused_baddbmm_equiv.py` asserts the batched path is bitwise-identical to the loop for both the standard and transposed (GPT-OSS) layouts, in fp32/bf16/fp16, on CPU and CUDA. The existing MoE merge suite still passes.
