### PR TITLE
Allow pad-named tokens (e.g. <|vision_pad|>) as valid pad_tokens

### DIFF
--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -18,7 +18,7 @@ _spec = importlib.util.spec_from_file_location("_unsloth_pad_token_offline", _PA
 _pad_token = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_pad_token)
 fix_pad_token = _pad_token.fix_pad_token
-VISION_RESERVED_TOKENS = _pad_token.VISION_RESERVED_TOKENS
+_is_pad_named = _pad_token._is_pad_named
 
 
 class FakeTokenizer:
@@ -66,11 +66,19 @@ def _qwen3_text():
     return FakeTokenizer(vocab, pad_token="<|vision_pad|>", eos_token="<|im_end|>")
 
 
-def test_qwen3_vision_pad_heals_to_endoftext():
+def test_is_pad_named():
+    for t in ("<|vision_pad|>", "<|fim_pad|>", "[PAD]", "<pad>", "<|PAD|>"):
+        assert _is_pad_named(t)
+    for t in ("<|endoftext|>", "<|im_end|>", "<unk>"):
+        assert not _is_pad_named(t)
+
+
+def test_qwen3_vision_pad_is_kept():
+    # <|vision_pad|> is a pad-named token distinct from eos -> kept as-is.
     tok = _qwen3_text()
     res = fix_pad_token(tok)
-    assert res["changed"] and res["reason"] == "vision_pad"
-    assert tok.pad_token == "<|endoftext|>"          # not a vision token
+    assert res["changed"] is False
+    assert tok.pad_token == "<|vision_pad|>"
     assert tok.pad_token != tok.eos_token
 
 
@@ -136,10 +144,14 @@ def test_zero_token_candidate_does_not_crash():
     assert res["changed"] is False
 
 
-def test_vision_token_never_selected_for_text_model():
-    tok = _qwen3_text()
-    fix_pad_token(tok)
-    assert tok.pad_token not in VISION_RESERVED_TOKENS
+def test_text_model_pad_equals_eos_uses_modality_pad_when_only_option():
+    # Qwen3-Base: pad == eos == <|endoftext|> and only a modality pad available ->
+    # use it instead of adding/raising (the #4104 / Qwen3-GRPO load crash).
+    tok = FakeTokenizer({"<|endoftext|>": 0, "<|vision_pad|>": 5},
+                        pad_token="<|endoftext|>", eos_token="<|endoftext|>")
+    res = fix_pad_token(tok)
+    assert res["changed"] and tok.pad_token == "<|vision_pad|>"
+    assert tok.pad_token != tok.eos_token
 
 
 def test_out_of_range_pad_is_repicked_when_model_known():
@@ -165,9 +177,8 @@ def test_in_range_valid_pad_is_noop_with_vocab_size():
     assert fix_pad_token(tok, model_config = cfg)["changed"] is False
 
 
-def test_vision_model_keeps_its_vision_pad():
-    # A real multimodal model (model_type without "vl", e.g. llava) must be
-    # detected as vision so its vision pad_token is left untouched.
+def test_vision_pad_kept_regardless_of_model_type():
+    # A pad-named modality token is kept whether or not the model is multimodal.
     tok = _qwen3_text()  # pad_token = "<|vision_pad|>"
     cfg = type("Cfg", (), {"model_type": "llava"})()
     res = fix_pad_token(tok, model_config = cfg)
@@ -185,20 +196,16 @@ def test_unk_token_fallback_when_no_reserved():
     assert res["changed"] and tok.pad_token == "<unk>"
 
 
-def test_vision_model_reuses_vision_pad_when_only_option():
-    # Vision model with pad == eos and only a modality pad available -> reuse it
-    # instead of adding/raising.
+def test_pad_equals_eos_reuses_modality_pad_when_only_option():
+    # pad == eos and only a modality pad available -> reuse it instead of adding/raising.
     tok = FakeTokenizer({"<|im_end|>": 1, "<|vision_pad|>": 2},
                         pad_token = "<|im_end|>", eos_token = "<|im_end|>")
-    cfg = type("Cfg", (), {"model_type": "qwen2_vl"})()
-    res = fix_pad_token(tok, model_config = cfg)
+    res = fix_pad_token(tok)
     assert res["changed"] and tok.pad_token == "<|vision_pad|>"
 
 
-def test_audio_pad_not_denylisted_for_audio_model():
-    # <|audio_pad|> is not a denied token (we cannot detect audio-only models),
-    # so an audio tokenizer keeping it as pad is a no-op.
+def test_audio_pad_is_kept():
+    # <|audio_pad|> is pad-named and distinct from eos -> kept as-is.
     tok = FakeTokenizer({"<|im_end|>": 1, "<|audio_pad|>": 2},
                         pad_token = "<|audio_pad|>", eos_token = "<|im_end|>")
     assert fix_pad_token(tok)["changed"] is False
-    assert "<|audio_pad|>" not in VISION_RESERVED_TOKENS

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -83,9 +83,12 @@ def _qwen3_text():
 
 
 def test_is_pad_named():
+    # Bracketed pad sentinels qualify ...
     for t in ("<|vision_pad|>", "<|fim_pad|>", "[PAD]", "<pad>", "<|PAD|>"):
         assert _is_pad_named(t)
-    for t in ("<|endoftext|>", "<|im_end|>", "<unk>"):
+    # ... ordinary words containing "pad" and non-pad tokens do not.
+    for t in ("keypad", "padding", "Notepad", "pad",
+              "<|endoftext|>", "<|im_end|>", "<unk>"):
         assert not _is_pad_named(t)
 
 
@@ -227,22 +230,30 @@ def test_audio_pad_is_kept():
     assert fix_pad_token(tok)["changed"] is False
 
 
-def test_pad_name_fallback_ignores_non_special_added_token():
-    # pad == eos; "keypad" is an ordinary (non-special) added token and must not be
-    # promoted, while the special <|custom_pad|> is picked.
+def test_pad_name_fallback_ignores_bare_word_token():
+    # pad == eos; "keypad" is a bare word (not a bracketed sentinel) and must not be
+    # promoted, while the bracketed <|custom_pad|> is picked.
     tok = FakeTokenizer({"<|endoftext|>": 0, "keypad": 5, "<|custom_pad|>": 6},
-                        pad_token = "<|endoftext|>", eos_token = "<|endoftext|>",
-                        non_special = ["keypad"])
+                        pad_token = "<|endoftext|>", eos_token = "<|endoftext|>")
     res = fix_pad_token(tok)
     assert res["changed"] and tok.pad_token == "<|custom_pad|>"
 
 
-def test_non_special_pad_name_not_promoted_when_only_option():
-    # pad == eos and the only "*pad*" token is a non-special ordinary token -> do not
-    # promote it; with allow_add=False the repair defers and leaves pad unchanged.
+def test_bare_word_pad_name_not_promoted_when_only_option():
+    # pad == eos and the only "*pad*" token is a bare word -> do not promote it;
+    # with allow_add=False the repair defers and leaves pad unchanged.
     tok = FakeTokenizer({"<|endoftext|>": 0, "keypad": 5},
-                        pad_token = "<|endoftext|>", eos_token = "<|endoftext|>",
-                        non_special = ["keypad"])
+                        pad_token = "<|endoftext|>", eos_token = "<|endoftext|>")
     res = fix_pad_token(tok, allow_add = False)
     assert res["changed"] is False
     assert tok.pad_token == "<|endoftext|>"
+
+
+def test_non_special_fim_pad_is_eligible():
+    # A pipe-wrapped FIM pad is a valid replacement even when the tokenizer marks it
+    # special=False (Qwen does), since eligibility is by sentinel form, not the flag.
+    tok = FakeTokenizer({"<|endoftext|>": 0, "<|fim_pad|>": 6},
+                        pad_token = "<|endoftext|>", eos_token = "<|endoftext|>",
+                        non_special = ["<|fim_pad|>"])
+    res = fix_pad_token(tok)
+    assert res["changed"] and tok.pad_token == "<|fim_pad|>"

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -21,16 +21,32 @@ fix_pad_token = _pad_token.fix_pad_token
 _is_pad_named = _pad_token._is_pad_named
 
 
+class _AddedToken:
+    """Stand-in for transformers' AddedToken (content + special flag)."""
+
+    def __init__(self, content, special):
+        self.content = content
+        self.special = special
+
+    def __str__(self):
+        return self.content
+
+
 class FakeTokenizer:
     """Minimal stand-in: vocab is a {token: id} dict; reserved tokens are 'added'."""
 
-    def __init__(self, vocab, pad_token, eos_token, added=None):
+    def __init__(self, vocab, pad_token, eos_token, added=None, non_special=()):
         self._vocab = dict(vocab)
         self.pad_token = pad_token
         self.eos_token = eos_token
-        # added_tokens_decoder maps id -> token content (subset treated as "added")
+        # added_tokens_decoder maps id -> AddedToken; tokens in non_special are
+        # ordinary add_tokens() entries (special=False), the rest are special.
         added = added if added is not None else list(vocab)
-        self.added_tokens_decoder = {self._vocab[t]: t for t in added if t in self._vocab}
+        non_special = set(non_special)
+        self.added_tokens_decoder = {
+            self._vocab[t]: _AddedToken(t, special=t not in non_special)
+            for t in added if t in self._vocab
+        }
 
     # ids
     @property
@@ -53,7 +69,7 @@ class FakeTokenizer:
         tok = mapping["pad_token"]
         if tok not in self._vocab:
             self._vocab[tok] = max(self._vocab.values()) + 1
-            self.added_tokens_decoder[self._vocab[tok]] = tok
+            self.added_tokens_decoder[self._vocab[tok]] = _AddedToken(tok, special=True)
         self.pad_token = tok
 
 
@@ -209,3 +225,24 @@ def test_audio_pad_is_kept():
     tok = FakeTokenizer({"<|im_end|>": 1, "<|audio_pad|>": 2},
                         pad_token = "<|audio_pad|>", eos_token = "<|im_end|>")
     assert fix_pad_token(tok)["changed"] is False
+
+
+def test_pad_name_fallback_ignores_non_special_added_token():
+    # pad == eos; "keypad" is an ordinary (non-special) added token and must not be
+    # promoted, while the special <|custom_pad|> is picked.
+    tok = FakeTokenizer({"<|endoftext|>": 0, "keypad": 5, "<|custom_pad|>": 6},
+                        pad_token = "<|endoftext|>", eos_token = "<|endoftext|>",
+                        non_special = ["keypad"])
+    res = fix_pad_token(tok)
+    assert res["changed"] and tok.pad_token == "<|custom_pad|>"
+
+
+def test_non_special_pad_name_not_promoted_when_only_option():
+    # pad == eos and the only "*pad*" token is a non-special ordinary token -> do not
+    # promote it; with allow_add=False the repair defers and leaves pad unchanged.
+    tok = FakeTokenizer({"<|endoftext|>": 0, "keypad": 5},
+                        pad_token = "<|endoftext|>", eos_token = "<|endoftext|>",
+                        non_special = ["keypad"])
+    res = fix_pad_token(tok, allow_add = False)
+    assert res["changed"] is False
+    assert tok.pad_token == "<|endoftext|>"

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -16,10 +16,14 @@
 """Generic pad_token repair shared by unsloth and unsloth-zoo.
 
 A wrong/missing pad_token breaks training: pad == eos makes the loss ignore real
-pad positions, and a vision pad_token baked into a text-only tokenizer produces
-NaN losses (unsloth#3155, unsloth#4104). `fix_pad_token` heals such tokenizers by
-picking a reserved pad-like token already in the vocab; if none exists it adds one.
-It is a no-op for tokenizers that already have a valid, distinct pad_token.
+pad positions (the model never learns to stop). `fix_pad_token` heals such
+tokenizers by picking a reserved pad-like token already in the vocab; if none
+exists it adds one. It is a no-op for an already valid, distinct pad_token.
+
+Any "*pad*"-named token (e.g. <|vision_pad|>, <|fim_pad|>, [PAD]) is a valid pad and
+is kept as-is. Qwen3 text models share Qwen3-VL's vocab and ship
+pad_token=<|vision_pad|>, which is fine. The old NaN reports (unsloth#3155, #4104)
+were a masking artifact (collators set labels=-100 on pad), not a pad-identity bug.
 """
 
 __all__ = [
@@ -54,23 +58,15 @@ POSSIBLE_RESERVED_TOKENS = (
     # "<|endofprompt|>",          # Phi-4 mini; commented out, clashes with GPT-OSS
 )
 
-# Modality pad tokens. On a text-only model these must never be the pad_token
-# (unsloth#4104); on a multimodal model they are valid pad candidates of last
-# resort. Audio pads are intentionally excluded: we cannot reliably detect an
-# audio-only model, so denylisting them would rewrite a legitimate audio pad.
+# Modality pad tokens: pad-named, so valid pads on any model. Appended as
+# last-resort replacement candidates after the curated families above.
 _MODALITY_PAD_TOKENS = (
     "<|vision_pad|>",
     "<|image_pad|>",
     "<|video_pad|>",
 )
+# Re-exported for backwards compatibility; no longer used to reject pads.
 VISION_RESERVED_TOKENS = frozenset(_MODALITY_PAD_TOKENS)
-
-# model_type fragments that mark a multimodal model whose vision pad tokens are
-# legitimate (so we must not "heal" them). Kept conservative: each fragment only
-# appears in genuinely multimodal model_types, never in text-only ones.
-_VISION_MODEL_TYPES = (
-    "vl", "vision", "llava", "paligemma", "idefics", "pixtral", "mllama",
-)
 
 _CLOSERS = (">", "|>", "]", ")")
 _MANUAL_PAD_TOKEN = "<｜PAD▁TOKEN｜>"
@@ -82,22 +78,15 @@ def _token_content(token):
     return content if isinstance(content, str) else str(token)
 
 
+def _is_pad_named(token):
+    """True if the token name contains "pad" (e.g. <|vision_pad|>, <|fim_pad|>, [PAD])."""
+    return "pad" in _token_content(token).lower()
+
+
 def _resolve_inner(tokenizer):
     # Processors wrap the real tokenizer under .tokenizer.
     inner = getattr(tokenizer, "tokenizer", None)
     return inner if inner is not None else tokenizer
-
-
-def _infer_vision(tokenizer, inner, model, model_config, is_vision_model):
-    if is_vision_model is not None:
-        return bool(is_vision_model)
-    # getattr not hasattr: a processor can carry image_processor = None.
-    if getattr(tokenizer, "image_processor", None) is not None:
-        return True
-    cfg = model_config if model_config is not None else getattr(model, "config", None)
-    model_type = (getattr(cfg, "model_type", "") or "") if cfg is not None else ""
-    model_type = model_type.lower()
-    return any(fragment in model_type for fragment in _VISION_MODEL_TYPES)
 
 
 def _display_name(model, model_config, inner):
@@ -108,8 +97,12 @@ def _display_name(model, model_config, inner):
     return "Model"
 
 
-def _classify_bad_pad(inner, is_vision, vocab_size):
-    """Return a reason string if the current pad_token is bad, else None."""
+def _classify_bad_pad(inner, vocab_size):
+    """Return a reason string if the current pad_token is bad, else None.
+
+    A pad-named token (e.g. <|vision_pad|>) is valid; only missing, eos-collision
+    and out-of-range pads are healed.
+    """
     if not hasattr(inner, "pad_token"):
         return None
     pad = inner.pad_token
@@ -121,11 +114,7 @@ def _classify_bad_pad(inner, is_vision, vocab_size):
     pad_id, eos_id = getattr(inner, "pad_token_id", None), getattr(inner, "eos_token_id", None)
     if pad_id is not None and eos_id is not None and pad_id == eos_id:
         return "equals_eos"
-    if not is_vision and pad in VISION_RESERVED_TOKENS:
-        return "vision_pad"
-    # A pad whose id is past the model's embeddings indexes out of range at
-    # runtime. This catches a pad picked by an earlier model-less call (e.g.
-    # load_correct_tokenizer) that turned out to be beyond the vocab; only
+    # A pad id past the model's embeddings indexes out of range at runtime; only
     # checkable once a model/config gives us vocab_size.
     if vocab_size is not None and pad_id is not None and pad_id >= vocab_size:
         return "out_of_range"
@@ -146,8 +135,8 @@ def _single_token_id(inner, token, vocab_size):
     return token_id
 
 
-def _find_reserved_pad(inner, is_vision, eos_token, vocab_size):
-    """Pick the best reserved pad-like token already in the vocab, or None."""
+def _find_reserved_pad(inner, eos_token, vocab_size):
+    """Pick the best reserved/pad-named token already in the vocab, or None."""
     try:
         added = [_token_content(t) for t in inner.added_tokens_decoder.values()]
     except Exception:
@@ -155,34 +144,36 @@ def _find_reserved_pad(inner, is_vision, eos_token, vocab_size):
     # Newest tokens last; reverse so reserved blocks are scanned high-id first.
     added = [a for a in added if a][::-1]
 
-    # On a multimodal model, modality pad tokens are valid pads of last resort;
-    # on a text-only model they stay denied (unsloth#4104).
-    families = POSSIBLE_RESERVED_TOKENS + (_MODALITY_PAD_TOKENS if is_vision else ())
+    # Modality pads are valid on any model; appended as last-resort candidates.
+    families = POSSIBLE_RESERVED_TOKENS + _MODALITY_PAD_TOKENS
     for reserved in families:
-        if not is_vision and reserved in VISION_RESERVED_TOKENS:
-            continue
         matches = [a for a in added if a == reserved or a.startswith(reserved)]
         if not matches:
             continue
-        # Prefer a closed token (e.g. "<|reserved_special_token_0|>") that is
-        # distinct from eos and encodes to a single in-vocab id. Closed tokens
+        # Prefer a closed token (e.g. "<|reserved_special_token_0|>"); closed tokens
         # are a subset of matches, so order them first without duplicating.
         closed = [m for m in matches if m.endswith(_CLOSERS)]
         ordered = closed + [m for m in matches if m not in closed]
         for candidate in ordered:
-            if candidate == eos_token or (not is_vision and candidate in VISION_RESERVED_TOKENS):
+            if candidate == eos_token:
                 continue
             if _single_token_id(inner, candidate, vocab_size) is not None:
                 return candidate
+
+    # Last resort: any added "*pad*" token (e.g. <|fim_pad|>). Only added tokens are
+    # scanned, never the vocab, so words like "padding" can't be picked.
+    for candidate in added:
+        if candidate == eos_token or not _is_pad_named(candidate):
+            continue
+        if _single_token_id(inner, candidate, vocab_size) is not None:
+            return candidate
     return None
 
 
-def _unk_fallback(inner, is_vision, eos_token, vocab_size):
+def _unk_fallback(inner, eos_token, vocab_size):
     """Last-resort existing-token pad: reuse unk_token (Llama-2 style), or None."""
     unk = getattr(inner, "unk_token", None)
     if not unk or unk == eos_token:
-        return None
-    if not is_vision and unk in VISION_RESERVED_TOKENS:
         return None
     if _single_token_id(inner, unk, vocab_size) is not None:
         return unk
@@ -203,6 +194,8 @@ def fix_pad_token(
     `changed=False`) when the pad_token is already valid and distinct from eos.
     With `allow_add=False` (tokenizer-only callers with no model to resize) a brand
     new pad token is never added; repair is deferred to the model-aware call.
+    `is_vision_model` is accepted for API compatibility but unused: any pad-named
+    token is a valid pad regardless of modality.
     """
     result = {"changed": False, "reason": None, "old_pad": None, "new_pad": None, "added": False}
     if tokenizer is None:
@@ -216,16 +209,15 @@ def fix_pad_token(
     vocab_size = getattr(cfg, "vocab_size", None)
     eos_token = getattr(inner, "eos_token", None)
 
-    is_vision = _infer_vision(tokenizer, inner, model, model_config, is_vision_model)
-    reason = _classify_bad_pad(inner, is_vision, vocab_size)
+    reason = _classify_bad_pad(inner, vocab_size)
     if reason is None:
         return result
     result["reason"] = reason
     result["old_pad"] = getattr(inner, "pad_token", None)
 
-    new_pad = _find_reserved_pad(inner, is_vision, eos_token, vocab_size)
+    new_pad = _find_reserved_pad(inner, eos_token, vocab_size)
     if new_pad is None:
-        new_pad = _unk_fallback(inner, is_vision, eos_token, vocab_size)
+        new_pad = _unk_fallback(inner, eos_token, vocab_size)
     added = False
 
     if new_pad is None:

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -136,12 +136,15 @@ def _single_token_id(inner, token, vocab_size):
 
 
 def _find_reserved_pad(inner, eos_token, vocab_size):
-    """Pick the best reserved/pad-named token already in the vocab, or None."""
+    """Pick the best reserved/pad-named special token already in the vocab, or None."""
     try:
-        added = [_token_content(t) for t in inner.added_tokens_decoder.values()]
+        decoder = inner.added_tokens_decoder.values()
     except Exception:
         return None
-    # Newest tokens last; reverse so reserved blocks are scanned high-id first.
+    # Only special tokens are eligible: added_tokens_decoder also holds ordinary
+    # add_tokens() entries, and an everyday token like "keypad" must never become
+    # the pad (it would be masked out of attention/loss). Newest first.
+    added = [_token_content(t) for t in decoder if getattr(t, "special", True)]
     added = [a for a in added if a][::-1]
 
     # Modality pads are valid on any model; appended as last-resort candidates.
@@ -160,8 +163,8 @@ def _find_reserved_pad(inner, eos_token, vocab_size):
             if _single_token_id(inner, candidate, vocab_size) is not None:
                 return candidate
 
-    # Last resort: any added "*pad*" token (e.g. <|fim_pad|>). Only added tokens are
-    # scanned, never the vocab, so words like "padding" can't be picked.
+    # Last resort: any special token whose name contains "pad" and is not in a
+    # curated family above.
     for candidate in added:
         if candidate == eos_token or not _is_pad_named(candidate):
             continue

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -79,8 +79,13 @@ def _token_content(token):
 
 
 def _is_pad_named(token):
-    """True if the token name contains "pad" (e.g. <|vision_pad|>, <|fim_pad|>, [PAD])."""
-    return "pad" in _token_content(token).lower()
+    """True if the token is a dedicated pad sentinel: contains "pad" and is bracketed
+    (e.g. <|vision_pad|>, <|fim_pad|>, <pad>, [PAD]), not an ordinary word like
+    "keypad". The bracket form, not the unreliable `.special` flag (Qwen marks
+    <|fim_pad|> non-special), is what distinguishes a sentinel from a real word."""
+    content = _token_content(token)
+    return ("pad" in content.lower()
+            and content.startswith(("<", "[")) and content.endswith(_CLOSERS))
 
 
 def _resolve_inner(tokenizer):
@@ -136,15 +141,12 @@ def _single_token_id(inner, token, vocab_size):
 
 
 def _find_reserved_pad(inner, eos_token, vocab_size):
-    """Pick the best reserved/pad-named special token already in the vocab, or None."""
+    """Pick the best reserved/pad-named token already in the vocab, or None."""
     try:
-        decoder = inner.added_tokens_decoder.values()
+        added = [_token_content(t) for t in inner.added_tokens_decoder.values()]
     except Exception:
         return None
-    # Only special tokens are eligible: added_tokens_decoder also holds ordinary
-    # add_tokens() entries, and an everyday token like "keypad" must never become
-    # the pad (it would be masked out of attention/loss). Newest first.
-    added = [_token_content(t) for t in decoder if getattr(t, "special", True)]
+    # Newest tokens last; reverse so reserved blocks are scanned high-id first.
     added = [a for a in added if a][::-1]
 
     # Modality pads are valid on any model; appended as last-resort candidates.
@@ -163,8 +165,10 @@ def _find_reserved_pad(inner, eos_token, vocab_size):
             if _single_token_id(inner, candidate, vocab_size) is not None:
                 return candidate
 
-    # Last resort: any special token whose name contains "pad" and is not in a
-    # curated family above.
+    # Last resort: any pad sentinel (a bracketed "*pad*" token such as <|fim_pad|>)
+    # not in a curated family above. The bracket form in _is_pad_named excludes
+    # ordinary added words like "keypad" / "padding" that would be masked out of
+    # attention and loss if promoted.
     for candidate in added:
         if candidate == eos_token or not _is_pad_named(candidate):
             continue


### PR DESCRIPTION
## What

A `pad_token` whose name contains "pad" (case-insensitive) is now treated as a valid, dedicated padding token and kept as-is. This includes the modality pads `<|vision_pad|>`, `<|image_pad|>`, `<|video_pad|>` and pipe-wrapped FIM pads like `<|fim_pad|>`.

`fix_pad_token` only heals genuinely broken pads now:

- `missing` (no pad_token)
- `equals_eos` (pad == eos, which makes the loss ignore EOS)
- `out_of_range` (pad id past the model vocab)

When a replacement is needed, modality pads and any added `*pad*` token are eligible candidates after the curated reserved families.

## Why

`unsloth/Qwen3-4B-Base` and other Qwen3 text models share Qwen3-VL's vocab, so their configs ship `pad_token = <|vision_pad|>` (id 151654), a distinct, in-vocab token separate from eos `<|endoftext|>` (id 151643). That is a perfectly good pad.

The previous logic rejected vision pads on text-only models, which broke loading. For Qwen3-4B-Base:

1. `<|vision_pad|>` was flagged bad.
2. No replacement was found: `<|endoftext|>` is eos, `<|fim_pad|>` did not match the curated `<fim_pad>` entry, vision pads were denied, and Qwen3 has no `unk_token`.
3. `fix_pad_token` then added a junk `<｜PAD▁TOKEN｜>` and raised `RuntimeError`, crashing the Qwen3 (4B) GRPO notebook at `FastLanguageModel.from_pretrained`.

The earlier NaN reports (#3155, #4104) were a masking artifact: SFT and GRPO collators set `labels = -100` on pad positions, so the pad token's identity does not affect the loss.

## Changes

- `_classify_bad_pad`: drop the vision-pad rejection. Pad-named tokens distinct from eos and in range are valid.
- `_find_reserved_pad`: modality pads are eligible for all models; add a last-resort scan over **pad sentinels** (bracketed `*pad*` tokens like `<|fim_pad|>`). The sentinel form, not the unreliable `.special` flag, gates the scan, so ordinary `add_tokens()` words like `padding` or `keypad` are never promoted while pipe-wrapped FIM pads stay eligible.
- Remove the now-unused vision-detection helpers (`_infer_vision`, `_VISION_MODEL_TYPES`). `is_vision_model` stays as an accepted but ignored kwarg on `fix_pad_token` for API compatibility.
- Tests updated.

## Testing

- `tests/test_pad_token.py`: 17 passed (offline, no torch).
- End to end: `FastLanguageModel.from_pretrained("unsloth/Qwen3-4B-Base", fast_inference = True)` loads with no crash, keeps `pad_token = <|vision_pad|>` (distinct from eos), propagates `model.config.pad_token_id = 151654`, and a padded forward and backward gives a finite loss with finite LoRA gradients.

## Companion PR

unslothai/unsloth#6652 (no-ops the local fallback so unsloth keeps pad-named tokens too).


