### PR TITLE
dataset_utils: add mask_thinking_tokens to mask the </think> token

### DIFF
--- a/tests/test_mask_thinking_tokens.py
+++ b/tests/test_mask_thinking_tokens.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2023-present the Unsloth team. All rights reserved.
+"""Offline tests for unsloth_zoo.dataset_utils.mask_thinking_tokens (no network)."""
+
+import importlib.util
+import os
+
+import pytest
+import torch
+
+# Load dataset_utils.py directly from its file so the test is self-contained and
+# does not run unsloth_zoo/__init__.py (which pulls the full stack).
+_DATASET_UTILS_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "unsloth_zoo", "dataset_utils.py",
+)
+_spec = importlib.util.spec_from_file_location("_unsloth_dataset_utils_offline", _DATASET_UTILS_PATH)
+_dataset_utils = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_dataset_utils)
+mask_thinking_tokens = _dataset_utils.mask_thinking_tokens
+
+
+class FakeTokenizer:
+    """Minimal stand-in: encodes the think token to a fixed id sequence."""
+
+    def __init__(self, think_token, think_ids):
+        self._think_token = think_token
+        self._think_ids = list(think_ids)
+
+    def __call__(self, text, add_special_tokens=False):
+        ids = self._think_ids if text == self._think_token else [0, 1]
+        return {"input_ids": ids}
+
+
+def _mask_fn(think_token, think_ids):
+    tok = FakeTokenizer(think_token, think_ids)
+    return mask_thinking_tokens(
+        trainer = None,
+        think_token = think_token,
+        tokenizer = tok,
+        return_function = True,
+    )
+
+
+def test_single_token_masked():
+    fn = _mask_fn("</think>", [42])
+    out = fn({"input_ids": [[5, 42, 7, 8]], "labels": [[5, 42, 7, 8]]})
+    assert out["labels"] == [[5, -100, 7, 8]]
+
+
+def test_no_match_leaves_labels_untouched():
+    fn = _mask_fn("</think>", [42])
+    out = fn({"input_ids": [[5, 6, 7]], "labels": [[5, 6, 7]]})
+    assert out["labels"] == [[5, 6, 7]]
+
+
+def test_multi_token_think_masks_full_span():
+    fn = _mask_fn("</think>", [42, 43])
+    out = fn({"input_ids": [[1, 42, 43, 9]], "labels": [[1, 42, 43, 9]]})
+    assert out["labels"] == [[1, -100, -100, 9]]
+
+
+def test_multi_token_partial_not_masked():
+    fn = _mask_fn("</think>", [42, 43])
+    # 42 not followed by 43 must NOT be masked; the real span must be.
+    out = fn({"input_ids": [[42, 9, 42, 43]], "labels": [[42, 9, 42, 43]]})
+    assert out["labels"] == [[42, 9, -100, -100]]
+
+
+def test_multiple_occurrences_all_masked():
+    fn = _mask_fn("</think>", [42])
+    out = fn({"input_ids": [[42, 1, 42, 2]], "labels": [[42, 1, 42, 2]]})
+    assert out["labels"] == [[-100, 1, -100, 2]]
+
+
+def test_preserves_existing_minus_100():
+    # Mirrors composing after train_on_responses_only: prompt already -100,
+    # we only additionally mask the </think> token.
+    fn = _mask_fn("</think>", [42])
+    out = fn({"input_ids": [[5, 6, 42, 7]], "labels": [[-100, -100, 42, 7]]})
+    assert out["labels"] == [[-100, -100, -100, 7]]
+
+
+def test_derives_labels_when_absent():
+    fn = _mask_fn("</think>", [42])
+    out = fn({"input_ids": [[5, 42, 7]]})
+    assert out["labels"] == [[5, -100, 7]]
+
+
+def test_input_ids_not_mutated_when_deriving_labels():
+    fn = _mask_fn("</think>", [42])
+    examples = {"input_ids": [[5, 42, 7]]}
+    fn(examples)
+    assert examples["input_ids"] == [[5, 42, 7]]
+
+
+def test_tensor_inputs_round_trip():
+    fn = _mask_fn("</think>", [42])
+    out = fn({
+        "input_ids": torch.tensor([[5, 42, 7]]),
+        "labels": torch.tensor([[5, 42, 7]]),
+    })
+    assert isinstance(out["labels"], torch.Tensor)
+    assert out["labels"].tolist() == [[5, -100, 7]]
+
+
+def test_empty_think_token_raises():
+    tok = FakeTokenizer("</think>", [])
+    with pytest.raises(ValueError):
+        mask_thinking_tokens(trainer = None, think_token = "</think>", tokenizer = tok, return_function = True)
+
+
+def test_list_input_tensor_labels_preserve_tensor():
+    # input_ids is a list but labels is a tensor -> output stays a tensor.
+    fn = _mask_fn("</think>", [42])
+    out = fn({"input_ids": [[5, 42, 7]], "labels": torch.tensor([[5, 42, 7]])})
+    assert isinstance(out["labels"], torch.Tensor)
+    assert out["labels"].tolist() == [[5, -100, 7]]
+
+
+def test_dataset_as_trainer_raises():
+    # Passing a Dataset (has .map, no train/eval datasets) must error, not no-op.
+    class FakeDataset:
+        def map(self, *args, **kwargs):
+            return self
+
+    tok = FakeTokenizer("</think>", [42])
+    with pytest.raises(TypeError):
+        mask_thinking_tokens(trainer = FakeDataset(), tokenizer = tok)
+
+
+def test_no_tokenizer_or_trainer_raises():
+    with pytest.raises(ValueError):
+        mask_thinking_tokens(trainer = None, tokenizer = None)

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -16,6 +16,7 @@
 
 __all__ = [
     "train_on_responses_only",
+    "mask_thinking_tokens",
     "sft_prepare_dataset",
     "standardize_data_formats",
     "patch_torchcodec_audio_decoder",
@@ -432,6 +433,134 @@ def train_on_responses_only(
     # Check if all labels randomnly got masked to nothing - maybe wrong chat template?
     from .training_utils import fix_zero_training_loss
     fix_zero_training_loss(None, tokenizer, trainer.train_dataset)
+    return trainer
+pass
+
+
+def mask_thinking_tokens(
+    trainer,
+    think_token     = "</think>",
+    tokenizer       = None,  # Optional
+    return_function = False, # Useful for iterating over lists
+    num_proc        = None,
+):
+    """Mask the thinking closing token (e.g. </think>) to -100 in the labels.
+
+    Inspired by Nemotron Ultra, which masks out </think> during training so the
+    model is not trained on the reasoning terminator and does not memorise a
+    fixed reasoning length. Use it like train_on_responses_only - apply it after
+    train_on_responses_only (or on any tokenized dataset whose labels the data
+    collator preserves). Only the label positions matching think_token are set
+    to -100; every other label is left untouched.
+    """
+    # All Unsloth Zoo code licensed under LGPLv3
+    if tokenizer is None and trainer is not None:
+        tokenizer = getattr(trainer, "processing_class", None) or getattr(trainer, "tokenizer", None)
+    if tokenizer is None:
+        raise ValueError("Unsloth: A tokenizer must be provided or be accessible from the trainer!")
+    # Get non vision tokenizer
+    if hasattr(tokenizer, "image_processor") or hasattr(tokenizer, "tokenizer"):
+        tokenizer = tokenizer.tokenizer
+
+    # Tokenize the thinking token to its id(s) - it can be one or many ids
+    think_ids = tokenizer(think_token, add_special_tokens = False)["input_ids"]
+    if len(think_ids) == 0:
+        raise ValueError(f"Unsloth: think_token = `{think_token}` does not tokenize to any token ids!")
+    len_think    = len(think_ids)
+    first_think  = think_ids[0]
+    torch_Tensor = torch.Tensor
+    torch_int64  = torch.int64
+
+    def _mask_thinking_tokens(examples):
+        input_ids_ = examples["input_ids"]
+        use_tensors = False
+        if type(input_ids_) is torch_Tensor:
+            use_tensors = True
+            input_ids_ = input_ids_.tolist()
+        if "labels" in examples:
+            labels_ = examples["labels"]
+            if type(labels_) is torch_Tensor:
+                use_tensors = True
+                labels_ = labels_.tolist()
+            assert(len(labels_) == len(input_ids_))
+        else:
+            # No labels yet - derive from input_ids so the masking still applies
+            labels_ = input_ids_
+
+        all_labels = []
+        for input_ids, old_labels in zip(input_ids_, labels_):
+            labels = list(old_labels)
+            n = len(input_ids)
+            j = 0
+            while j <= n - len_think:
+                if input_ids[j] == first_think and input_ids[j : j + len_think] == think_ids:
+                    for k in range(j, j + len_think):
+                        labels[k] = -100
+                    j += len_think
+                else:
+                    j += 1
+            pass
+            all_labels.append(labels)
+        pass
+        return { "labels" : torch.tensor(all_labels, dtype = torch_int64) if use_tensors else all_labels }
+    pass
+    if return_function:
+        return _mask_thinking_tokens
+
+    # A Trainer (not a Dataset) is expected here. A Dataset exposes .map but has
+    # no train/eval datasets, so it would silently no-op - guide such callers.
+    if hasattr(trainer, "map"):
+        raise TypeError(
+            "Unsloth: mask_thinking_tokens expects a Trainer as the first argument. "
+            "To apply it directly to a dataset, use return_function = True."
+        )
+
+    import multiprocessing as _mp
+    if num_proc is None or type(num_proc) is not int:
+        if _mp.get_start_method() != 'fork':
+            num_proc = None
+        else:
+            import psutil
+            num_proc = min(max((psutil.cpu_count() or 1) + 4, 2), 64)
+            # Cap by available memory to avoid OOM (1 proc per GB; 1 if <=2GB)
+            memory_gb_left = psutil.virtual_memory().available / (1024**3)
+            if memory_gb_left <= 2:
+                num_proc = 1
+            else:
+                num_proc = min(num_proc, int(memory_gb_left))
+
+    def _apply(dataset):
+        if not hasattr(dataset, "map"):
+            raise TypeError("Unsloth: mask_thinking_tokens does not work on lists!")
+        if isinstance(dataset, IterableDataset):
+            return dataset.map(_mask_thinking_tokens, batch_size = dataset._ex_iterable.batch_size, batched = True)
+        return dataset.map(_mask_thinking_tokens, batched = True, num_proc = num_proc)
+    pass
+
+    if hasattr(trainer, "train_dataset") and trainer.train_dataset is not None:
+        trainer.train_dataset = _apply(trainer.train_dataset)
+    pass
+
+    if hasattr(trainer, "eval_dataset") and trainer.eval_dataset is not None:
+        if type(trainer.eval_dataset) is dict:
+            for key, value in trainer.eval_dataset.items():
+                trainer.eval_dataset[key] = _apply(value)
+        else:
+            trainer.eval_dataset = _apply(trainer.eval_dataset)
+    pass
+
+    # The masked -100 labels must survive collation. The default SFT collator can
+    # rebuild labels from input_ids and overwrite them, so switch to the
+    # label-preserving collator (skip when packing) - same as train_on_responses_only.
+    from transformers import DataCollatorForSeq2Seq
+    packing_enabled = getattr(trainer.args, "packing", False)
+    if (
+        hasattr(trainer, "data_collator")
+        and not isinstance(trainer.data_collator, DataCollatorForSeq2Seq)
+        and not packing_enabled
+    ):
+        trainer.data_collator = DataCollatorForSeq2Seq(tokenizer = tokenizer)
+
     return trainer
 pass
 


### PR DESCRIPTION
Adds `mask_thinking_tokens`, a convenience function in the same spirit as
`train_on_responses_only`, that masks the thinking closing token (`</think>`
by default) to `-100` in the labels so it isn't trained on.

Requested in unslothai/unsloth#6695. Nemotron Ultra masks out `</think>`
during training so the model isn't trained on the reasoning terminator and
doesn't memorise a fixed reasoning length. This turns that into a one-liner,
composable after `train_on_responses_only`:

    trainer = train_on_responses_only(trainer, instruction_part=..., response_part=...)
    trainer = mask_thinking_tokens(trainer)

The function mirrors `train_on_responses_only`'s interface (`tokenizer`,
`return_function`, `num_proc`, `torch.Tensor`/list labels, `IterableDataset`)
and handles `</think>` whether it tokenises to one id or several. It's purely
subtractive: only positions matching `think_token` are set to `-100`; existing
`-100`s and every other label are left untouched. Tokenised datasets that don't
yet carry labels fall back to deriving them from `input_ids`.

Added offline CPU-only unit tests in `tests/test_mask_thinking_tokens.py`
covering single/multi-token `</think>`, multiple occurrences, label
preservation, tensor and list inputs, and the no-labels fallback.

Happy to follow up with a companion re-export from `unsloth.chat_templates`
(like `train_on_responses_only`) once this lands, and to rename the function
if you'd prefer something else.