### PR TITLE
Apply extra_special_tokens coercion on the MLX load path

### DIFF
--- a/tests/test_mlx_extra_special_tokens_compat.py
+++ b/tests/test_mlx_extra_special_tokens_compat.py
@@ -1,8 +1,5 @@
 # Unsloth Zoo - Utilities for Unsloth
-# Test that the MLX loader only coerces list-valued extra_special_tokens on
-# transformers versions that would otherwise crash with
-# "'list' object has no attribute 'keys'", and preserves the list on versions
-# that support it (so v5 exports keep their special tokens).
+# Coerce list extra_special_tokens only when transformers would otherwise crash.
 
 from __future__ import annotations
 
@@ -17,7 +14,6 @@ def _install_mlx_shim():
 
 @pytest.fixture
 def base_init():
-    # Save/restore PreTrainedTokenizerBase.__init__ around each test.
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     saved = PreTrainedTokenizerBase.__init__
     yield PreTrainedTokenizerBase
@@ -25,7 +21,6 @@ def base_init():
 
 
 def test_list_preserved_when_init_supports_lists(base_init):
-    # v5-like baseline accepts a list -> the wrapper must NOT coerce it.
     from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
     seen = {}
     base_init.__init__ = lambda self, **kw: seen.update(kw)
@@ -35,7 +30,6 @@ def test_list_preserved_when_init_supports_lists(base_init):
 
 
 def test_list_coerced_only_when_init_crashes(base_init):
-    # old-transformers-like baseline raises the .keys() error on a list.
     from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
     seen = {}
 
@@ -47,11 +41,11 @@ def test_list_coerced_only_when_init_crashes(base_init):
     base_init.__init__ = crashing_init
     _coerce_list_extra_special_tokens()
     base_init.__init__(object(), extra_special_tokens=["<a>", "<b>"])
-    assert seen["extra_special_tokens"] == {}  # coerced after the crash
+    assert seen["extra_special_tokens"] == {}
 
     seen.clear()
     base_init.__init__(object(), extra_special_tokens={"image_token": "<img>"})
-    assert seen["extra_special_tokens"] == {"image_token": "<img>"}  # dict untouched
+    assert seen["extra_special_tokens"] == {"image_token": "<img>"}
 
 
 def test_unrelated_attributeerror_not_swallowed(base_init):
@@ -72,5 +66,5 @@ def test_idempotent_and_guard_shared(base_init):
     _coerce_list_extra_special_tokens()
     wrapped = base_init.__init__
     assert getattr(wrapped, "_unsloth_extra_special_tokens_patched", False) is True
-    _coerce_list_extra_special_tokens()  # second call must not re-wrap
+    _coerce_list_extra_special_tokens()
     assert base_init.__init__ is wrapped

--- a/tests/test_mlx_extra_special_tokens_compat.py
+++ b/tests/test_mlx_extra_special_tokens_compat.py
@@ -1,0 +1,61 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Test that the MLX loader coerces list-valued extra_special_tokens so tokenizer
+# loading does not crash with "'list' object has no attribute 'keys'".
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def test_coerces_list_extra_special_tokens():
+    from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+    from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
+
+    saved = PreTrainedTokenizerBase.__init__
+    seen = {}
+
+    def spy(self, **kwargs):
+        seen.clear()
+        seen.update(kwargs)
+
+    PreTrainedTokenizerBase.__init__ = spy  # unpatched baseline
+    try:
+        _coerce_list_extra_special_tokens()
+        patched = PreTrainedTokenizerBase.__init__
+        assert patched is not spy  # it wrapped the baseline
+
+        # list -> {}
+        patched(object(), extra_special_tokens=["<a>", "<b>"])
+        assert seen["extra_special_tokens"] == {}
+
+        # valid dict left untouched
+        patched(object(), extra_special_tokens={"image_token": "<img>"})
+        assert seen["extra_special_tokens"] == {"image_token": "<img>"}
+
+        # idempotent: a second call does not re-wrap
+        _coerce_list_extra_special_tokens()
+        assert PreTrainedTokenizerBase.__init__ is patched
+    finally:
+        PreTrainedTokenizerBase.__init__ = saved
+
+
+def test_guard_is_shared_with_temporary_patch():
+    # The MLX coercion and patch_tokenizer_extra_special_tokens use the same
+    # guard attribute, so applying one stops the other from double-wrapping.
+    from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+    from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
+
+    saved = PreTrainedTokenizerBase.__init__
+    try:
+        PreTrainedTokenizerBase.__init__ = lambda self, **kw: None
+        _coerce_list_extra_special_tokens()
+        wrapped = PreTrainedTokenizerBase.__init__
+        assert getattr(wrapped, "_unsloth_extra_special_tokens_patched", False) is True
+    finally:
+        PreTrainedTokenizerBase.__init__ = saved

--- a/tests/test_mlx_extra_special_tokens_compat.py
+++ b/tests/test_mlx_extra_special_tokens_compat.py
@@ -1,6 +1,8 @@
 # Unsloth Zoo - Utilities for Unsloth
-# Test that the MLX loader coerces list-valued extra_special_tokens so tokenizer
-# loading does not crash with "'list' object has no attribute 'keys'".
+# Test that the MLX loader only coerces list-valued extra_special_tokens on
+# transformers versions that would otherwise crash with
+# "'list' object has no attribute 'keys'", and preserves the list on versions
+# that support it (so v5 exports keep their special tokens).
 
 from __future__ import annotations
 
@@ -13,49 +15,62 @@ def _install_mlx_shim():
     simulate_mlx_on_torch()
 
 
-def test_coerces_list_extra_special_tokens():
+@pytest.fixture
+def base_init():
+    # Save/restore PreTrainedTokenizerBase.__init__ around each test.
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-    from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
-
     saved = PreTrainedTokenizerBase.__init__
+    yield PreTrainedTokenizerBase
+    PreTrainedTokenizerBase.__init__ = saved
+
+
+def test_list_preserved_when_init_supports_lists(base_init):
+    # v5-like baseline accepts a list -> the wrapper must NOT coerce it.
+    from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
+    seen = {}
+    base_init.__init__ = lambda self, **kw: seen.update(kw)
+    _coerce_list_extra_special_tokens()
+    base_init.__init__(object(), extra_special_tokens=["<a>", "<b>"])
+    assert seen["extra_special_tokens"] == ["<a>", "<b>"]
+
+
+def test_list_coerced_only_when_init_crashes(base_init):
+    # old-transformers-like baseline raises the .keys() error on a list.
+    from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
     seen = {}
 
-    def spy(self, **kwargs):
-        seen.clear()
-        seen.update(kwargs)
+    def crashing_init(self, **kw):
+        if isinstance(kw.get("extra_special_tokens"), list):
+            raise AttributeError("'list' object has no attribute 'keys'")
+        seen.update(kw)
 
-    PreTrainedTokenizerBase.__init__ = spy  # unpatched baseline
-    try:
-        _coerce_list_extra_special_tokens()
-        patched = PreTrainedTokenizerBase.__init__
-        assert patched is not spy  # it wrapped the baseline
+    base_init.__init__ = crashing_init
+    _coerce_list_extra_special_tokens()
+    base_init.__init__(object(), extra_special_tokens=["<a>", "<b>"])
+    assert seen["extra_special_tokens"] == {}  # coerced after the crash
 
-        # list -> {}
-        patched(object(), extra_special_tokens=["<a>", "<b>"])
-        assert seen["extra_special_tokens"] == {}
-
-        # valid dict left untouched
-        patched(object(), extra_special_tokens={"image_token": "<img>"})
-        assert seen["extra_special_tokens"] == {"image_token": "<img>"}
-
-        # idempotent: a second call does not re-wrap
-        _coerce_list_extra_special_tokens()
-        assert PreTrainedTokenizerBase.__init__ is patched
-    finally:
-        PreTrainedTokenizerBase.__init__ = saved
+    seen.clear()
+    base_init.__init__(object(), extra_special_tokens={"image_token": "<img>"})
+    assert seen["extra_special_tokens"] == {"image_token": "<img>"}  # dict untouched
 
 
-def test_guard_is_shared_with_temporary_patch():
-    # The MLX coercion and patch_tokenizer_extra_special_tokens use the same
-    # guard attribute, so applying one stops the other from double-wrapping.
-    from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+def test_unrelated_attributeerror_not_swallowed(base_init):
     from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
 
-    saved = PreTrainedTokenizerBase.__init__
-    try:
-        PreTrainedTokenizerBase.__init__ = lambda self, **kw: None
-        _coerce_list_extra_special_tokens()
-        wrapped = PreTrainedTokenizerBase.__init__
-        assert getattr(wrapped, "_unsloth_extra_special_tokens_patched", False) is True
-    finally:
-        PreTrainedTokenizerBase.__init__ = saved
+    def boom_init(self, **kw):
+        raise AttributeError("unrelated boom")
+
+    base_init.__init__ = boom_init
+    _coerce_list_extra_special_tokens()
+    with pytest.raises(AttributeError, match="unrelated"):
+        base_init.__init__(object(), extra_special_tokens=["<a>"])
+
+
+def test_idempotent_and_guard_shared(base_init):
+    from unsloth_zoo.mlx.loader import _coerce_list_extra_special_tokens
+    base_init.__init__ = lambda self, **kw: None
+    _coerce_list_extra_special_tokens()
+    wrapped = base_init.__init__
+    assert getattr(wrapped, "_unsloth_extra_special_tokens_patched", False) is True
+    _coerce_list_extra_special_tokens()  # second call must not re-wrap
+    assert base_init.__init__ is wrapped

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -3413,6 +3413,30 @@ def _apply_mlx_lora_initialization(model, init_lora_weights):
             )
 
 
+def _coerce_list_extra_special_tokens():
+    # mlx-lm loads tokenizers via transformers AutoTokenizer without unsloth's
+    # TEMPORARY_PATCHES, so configs storing extra_special_tokens as a list (v5
+    # TokenizersBackend exports, some Mistral configs) crash transformers that
+    # expect a dict ("'list' object has no attribute 'keys'"). Coerce to {}.
+    # Shares the guard attr with patch_tokenizer_extra_special_tokens so neither
+    # double-wraps the other.
+    try:
+        from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+    except Exception:
+        return
+    init = PreTrainedTokenizerBase.__init__
+    if getattr(init, "_unsloth_extra_special_tokens_patched", False):
+        return
+
+    def patched_init(self, **kwargs):
+        if isinstance(kwargs.get("extra_special_tokens", {}), list):
+            kwargs["extra_special_tokens"] = {}
+        return init(self, **kwargs)
+
+    patched_init._unsloth_extra_special_tokens_patched = True
+    PreTrainedTokenizerBase.__init__ = patched_init
+
+
 class FastMLXModel:
     """MLX model loader for Apple Silicon.
 
@@ -3471,6 +3495,10 @@ class FastMLXModel:
                 True  — force text-only via mlx-lm
                 False — force VLM via mlx-vlm
         """
+        # Coerce list-valued extra_special_tokens before mlx-lm loads the
+        # tokenizer (this path bypasses unsloth's TEMPORARY_PATCHES).
+        _coerce_list_extra_special_tokens()
+
         if full_finetuning and (
             load_in_4bit or load_in_8bit or load_in_fp8
             or load_in_mxfp4 or load_in_nvfp4

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -3414,12 +3414,8 @@ def _apply_mlx_lora_initialization(model, init_lora_weights):
 
 
 def _coerce_list_extra_special_tokens():
-    # mlx-lm loads tokenizers via transformers AutoTokenizer without unsloth's
-    # TEMPORARY_PATCHES. Older transformers run list(extra_special_tokens.keys())
-    # and crash on a list ("'list' object has no attribute 'keys'"); v5 supports
-    # lists natively, so only coerce to {} on the path that would otherwise crash
-    # (coercing on v5 drops those special tokens). Shares the guard attr with
-    # patch_tokenizer_extra_special_tokens so neither double-wraps the other.
+    # why: the MLX path skips unsloth's TEMPORARY_PATCHES. Old transformers crash
+    # on a list extra_special_tokens; v5 accepts it, so only coerce on failure.
     try:
         from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     except Exception:
@@ -3501,8 +3497,6 @@ class FastMLXModel:
                 True  — force text-only via mlx-lm
                 False — force VLM via mlx-vlm
         """
-        # Coerce list-valued extra_special_tokens before mlx-lm loads the
-        # tokenizer (this path bypasses unsloth's TEMPORARY_PATCHES).
         _coerce_list_extra_special_tokens()
 
         if full_finetuning and (

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -3415,11 +3415,11 @@ def _apply_mlx_lora_initialization(model, init_lora_weights):
 
 def _coerce_list_extra_special_tokens():
     # mlx-lm loads tokenizers via transformers AutoTokenizer without unsloth's
-    # TEMPORARY_PATCHES, so configs storing extra_special_tokens as a list (v5
-    # TokenizersBackend exports, some Mistral configs) crash transformers that
-    # expect a dict ("'list' object has no attribute 'keys'"). Coerce to {}.
-    # Shares the guard attr with patch_tokenizer_extra_special_tokens so neither
-    # double-wraps the other.
+    # TEMPORARY_PATCHES. Older transformers run list(extra_special_tokens.keys())
+    # and crash on a list ("'list' object has no attribute 'keys'"); v5 supports
+    # lists natively, so only coerce to {} on the path that would otherwise crash
+    # (coercing on v5 drops those special tokens). Shares the guard attr with
+    # patch_tokenizer_extra_special_tokens so neither double-wraps the other.
     try:
         from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     except Exception:
@@ -3428,10 +3428,16 @@ def _coerce_list_extra_special_tokens():
     if getattr(init, "_unsloth_extra_special_tokens_patched", False):
         return
 
-    def patched_init(self, **kwargs):
-        if isinstance(kwargs.get("extra_special_tokens", {}), list):
+    def patched_init(*args, **kwargs):
+        if not isinstance(kwargs.get("extra_special_tokens"), list):
+            return init(*args, **kwargs)
+        try:
+            return init(*args, **kwargs)
+        except AttributeError as e:
+            if "keys" not in str(e):
+                raise
             kwargs["extra_special_tokens"] = {}
-        return init(self, **kwargs)
+            return init(*args, **kwargs)
 
     patched_init._unsloth_extra_special_tokens_patched = True
     PreTrainedTokenizerBase.__init__ = patched_init

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -82,10 +82,8 @@ TEMPORARY_PATCHES.append(patch_tokenizer_convert_added_tokens)
 
 
 def patch_tokenizer_extra_special_tokens():
-    # Some tokenizer configs store extra_special_tokens as a list. Older
-    # transformers run list(...).keys() and crash; v5 supports lists natively, so
-    # only coerce to {} on the path that would otherwise crash (coercing on v5
-    # drops those special tokens).
+    # why: old transformers crash on a list extra_special_tokens; v5 accepts it,
+    # so only coerce on failure (coercing v5 would drop those tokens).
     try:
         from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     except Exception as e:

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -82,8 +82,10 @@ TEMPORARY_PATCHES.append(patch_tokenizer_convert_added_tokens)
 
 
 def patch_tokenizer_extra_special_tokens():
-    # Some Mistral tokenizer configs store extra_special_tokens as a list, but
-    # transformers expects a dict.
+    # Some tokenizer configs store extra_special_tokens as a list. Older
+    # transformers run list(...).keys() and crash; v5 supports lists natively, so
+    # only coerce to {} on the path that would otherwise crash (coercing on v5
+    # drops those special tokens).
     try:
         from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     except Exception as e:
@@ -93,12 +95,16 @@ def patch_tokenizer_extra_special_tokens():
     if hasattr(original_init, "_unsloth_extra_special_tokens_patched"):
         return
 
-    def patched_init(self, **kwargs):
-        extra_special_tokens = kwargs.get("extra_special_tokens", {})
-        if isinstance(extra_special_tokens, list):
-            # Coerce list to empty dict; the tokens remain in added_tokens_decoder.
+    def patched_init(*args, **kwargs):
+        if not isinstance(kwargs.get("extra_special_tokens"), list):
+            return original_init(*args, **kwargs)
+        try:
+            return original_init(*args, **kwargs)
+        except AttributeError as e:
+            if "keys" not in str(e):
+                raise
             kwargs["extra_special_tokens"] = {}
-        return original_init(self, **kwargs)
+            return original_init(*args, **kwargs)
 
     patched_init._unsloth_extra_special_tokens_patched = True
     PreTrainedTokenizerBase.__init__ = patched_init


### PR DESCRIPTION
### Problem

Loading a model on Apple Silicon (MLX) can fail with:

```
Failed to load model: 'list' object has no attribute 'keys'
```

Reported on `unsloth/Qwen3.6-35B-A3B-MLX-8bit` on an M4 Max.

### Root cause

The MLX inference path goes `unsloth_zoo.mlx.loader` -> `mlx_lm` -> `transformers.AutoTokenizer`. It imports `unsloth_zoo.mlx.loader` directly and never imports the main `unsloth` package, so `TEMPORARY_PATCHES` are never applied on this path. In particular `patch_tokenizer_extra_special_tokens` (which already coerces a list-valued `extra_special_tokens` to `{}`) does not run.

When a `tokenizer_config.json` stores `extra_special_tokens` as a list rather than an object, transformers versions that expect a dict raise `'list' object has no attribute 'keys'` during tokenizer init. This shape is produced by the v5 `TokenizersBackend` exports (the Qwen3.6 MLX quants store the 13 special tokens as a list) and by some Mistral configs. The torch path is unaffected because it imports `unsloth` (which applies the patches); only the MLX path was unguarded.

### Fix

Add `_coerce_list_extra_special_tokens()` and call it at the start of `FastMLXModel.from_pretrained`, before mlx-lm loads the tokenizer. It:

- coerces a list `extra_special_tokens` to `{}` at `PreTrainedTokenizerBase.__init__` (the tokens stay in `added_tokens_decoder`), mirroring `patch_tokenizer_extra_special_tokens`
- shares the same guard attribute (`_unsloth_extra_special_tokens_patched`), so the MLX coercion and the temporary patch never double-wrap each other
- is self-contained and torch-free (the temporary-patches module imports torch, which an MLX-only install may not have), and is idempotent and a no-op on configs that already use a dict

### Testing

`tests/test_mlx_extra_special_tokens_compat.py` (uses the existing `mlx_simulation` shim):

- a list `extra_special_tokens` is coerced to `{}`; a valid dict is left untouched
- the coercion is idempotent (no re-wrap on a second call)
- the guard attribute is set so the temporary patch will skip

```
python -m pytest tests/test_mlx_extra_special_tokens_compat.py -q
```

Existing MLX loader tests still pass.
