### PR TITLE
train_on_responses_only: faster filtering, safer collator and num_proc, clearer errors

### DIFF
--- a/tests/test_vlm_collator_masking.py
+++ b/tests/test_vlm_collator_masking.py
@@ -20,10 +20,8 @@ import os, sys, types, tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(HERE))
-# NOTE: unsloth_zoo is imported lazily inside _check (not at module top). Importing it
-# runs unsloth_zoo/__init__.py, which raises ImportError when the separate `unsloth`
-# package is absent; at module scope that would break pytest collection before the
-# "OFF by default" skip gate in test_vlm_collator_masking() can run.
+# unsloth_zoo is imported lazily inside _check: at module scope its __init__ raises
+# ImportError without the `unsloth` package, breaking collection before the skip gate runs.
 
 ENABLED = os.environ.get("UNSLOTH_TEST_VLM_COLLATOR", "") not in ("", "0", "false")
 CACHE = os.environ.get("UNSLOTH_VLM_PROC_CACHE", os.path.join(tempfile.gettempdir(), "unsloth_vlm_proc"))
@@ -49,9 +47,8 @@ def _fetch(repo):
     path = os.path.join(CACHE, repo.replace("/", "__"))
     cached = os.path.isdir(path) and any(f.startswith("tokenizer") for f in os.listdir(path))
     if not cached:
-        # Downloads are opt-in. Without UNSLOTH_TEST_VLM_COLLATOR an uncached repo is
-        # skipped (raise -> _check returns SKIP), never fetched, even when CACHE already
-        # exists from a prior partial run - so the sweep stays truly off by default.
+        # Downloads are opt-in: without the flag an uncached repo raises (-> _check SKIP)
+        # instead of fetching, even if CACHE exists from a prior partial run.
         if not ENABLED:
             raise RuntimeError(f"{repo} not cached; set UNSLOTH_TEST_VLM_COLLATOR=1 to download")
         from huggingface_hub import snapshot_download

--- a/tests/test_vlm_collator_masking.py
+++ b/tests/test_vlm_collator_masking.py
@@ -86,10 +86,13 @@ def _content_exact(collator, proc):
 
 
 def _check(repo, ins, res):
-    from transformers import AutoProcessor, AutoConfig
-    from unsloth_zoo.vision_utils import UnslothVisionDataCollator
-    from unsloth_zoo.dataset_utils import train_on_responses_only
+    # Import inside the try so a zoo-only CI without the `unsloth` package (whose absence makes
+    # unsloth_zoo/__init__ raise ImportError) turns into a SKIP, not a hard error, when run() is
+    # reached via an existing cache dir with the env flag unset.
     try:
+        from transformers import AutoProcessor, AutoConfig
+        from unsloth_zoo.vision_utils import UnslothVisionDataCollator
+        from unsloth_zoo.dataset_utils import train_on_responses_only
         path = _fetch(repo)
         proc = AutoProcessor.from_pretrained(path)
         model = _mock_model(AutoConfig.from_pretrained(path))

--- a/tests/test_vlm_collator_masking.py
+++ b/tests/test_vlm_collator_masking.py
@@ -20,8 +20,10 @@ import os, sys, types, tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(HERE))
-from unsloth_zoo.vision_utils import UnslothVisionDataCollator
-from unsloth_zoo.dataset_utils import train_on_responses_only
+# NOTE: unsloth_zoo is imported lazily inside _check (not at module top). Importing it
+# runs unsloth_zoo/__init__.py, which raises ImportError when the separate `unsloth`
+# package is absent; at module scope that would break pytest collection before the
+# "OFF by default" skip gate in test_vlm_collator_masking() can run.
 
 ENABLED = os.environ.get("UNSLOTH_TEST_VLM_COLLATOR", "") not in ("", "0", "false")
 CACHE = os.environ.get("UNSLOTH_VLM_PROC_CACHE", os.path.join(tempfile.gettempdir(), "unsloth_vlm_proc"))
@@ -82,6 +84,8 @@ def _content_exact(collator, proc):
 
 def _check(repo, ins, res):
     from transformers import AutoProcessor, AutoConfig
+    from unsloth_zoo.vision_utils import UnslothVisionDataCollator
+    from unsloth_zoo.dataset_utils import train_on_responses_only
     try:
         path = _fetch(repo)
         proc = AutoProcessor.from_pretrained(path)

--- a/tests/test_vlm_collator_masking.py
+++ b/tests/test_vlm_collator_masking.py
@@ -1,0 +1,138 @@
+"""End-to-end: train_on_responses_only must actually mask for vision models.
+
+For one representative model per marker style this builds a REAL
+UnslothVisionDataCollator and runs a real image+text example through __call__,
+two ways, asserting the labels are content-exact (assistant response trained, user
+text masked, image/pad tokens masked):
+  (A) constructor:  UnslothVisionDataCollator(..., train_on_responses_only=True, parts)
+  (B) in-place:     bare UnslothVisionDataCollator(model, processor), then
+                    train_on_responses_only(trainer) enables masking on the collator.
+Path (B) is the case where a user keeps the default vision collator and calls
+train_on_responses_only(trainer) separately (most vision notebooks build the bare
+collator).
+
+Network/integration test, OFF by default. Enable with
+    UNSLOTH_TEST_VLM_COLLATOR=1 pytest tests/test_vlm_collator_masking.py
+Processors are fetched config-only; set UNSLOTH_VLM_PROC_CACHE to reuse a cache dir.
+Models that need a newer transformers to load are skipped, not failed.
+"""
+import os, sys, types, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+from unsloth_zoo.vision_utils import UnslothVisionDataCollator
+from unsloth_zoo.dataset_utils import train_on_responses_only
+
+ENABLED = os.environ.get("UNSLOTH_TEST_VLM_COLLATOR", "") not in ("", "0", "false")
+CACHE = os.environ.get("UNSLOTH_VLM_PROC_CACHE", os.path.join(tempfile.gettempdir(), "unsloth_vlm_proc"))
+ALLOW = ["*.json", "*.jinja", "*.model", "*.txt", "tokenizer*", "merges*", "vocab*"]
+
+# one model per marker style: ChatML, Gemma-3-turn, Gemma-4-turn, Llama-header,
+# Mistral-[INST]. The Gemma-4 / Qwen3.5 entries need a newer transformers and skip
+# (not fail) where it is too old to load them.
+MODELS = [
+    ("unsloth/Qwen2-VL-2B-Instruct", "<|im_start|>user\n", "<|im_start|>assistant\n"),
+    ("unsloth/Qwen3.5-2B", "<|im_start|>user\n", "<|im_start|>assistant\n"),
+    ("unsloth/gemma-3-4b-it", "<start_of_turn>user\n", "<start_of_turn>model\n"),
+    ("unsloth/gemma-3n-E4B-it", "<start_of_turn>user\n", "<start_of_turn>model\n"),
+    ("unsloth/gemma-4-E2B-it", "<|turn>user\n", "<|turn>model\n"),
+    ("unsloth/Llama-3.2-11B-Vision-Instruct",
+     "<|start_header_id|>user<|end_header_id|>\n\n", "<|start_header_id|>assistant<|end_header_id|>\n\n"),
+    ("unsloth/Pixtral-12B-2409", "[INST]", "[/INST]"),
+]
+USER_TXT, ASST_TXT = "ZEBRAQUESTION", "PENGUINANSWER"
+
+
+def _fetch(repo):
+    from huggingface_hub import snapshot_download
+    path = os.path.join(CACHE, repo.replace("/", "__"))
+    if not (os.path.isdir(path) and any(f.startswith("tokenizer") for f in os.listdir(path))):
+        snapshot_download(repo, local_dir=path, allow_patterns=ALLOW, token=os.environ.get("HF_TOKEN"))
+    return path
+
+
+def _mock_model(config):
+    import torch
+    vc = getattr(config, "vision_config", None)
+    ns = types.SimpleNamespace
+    vcfg = ns(patch_size=getattr(vc, "patch_size", 14) if vc is not None else 14,
+              image_size=getattr(vc, "image_size", 336) if vc is not None else 336,
+              model_type=getattr(vc, "model_type", "") if vc is not None else "")
+    return ns(config=ns(torch_dtype="float16", vision_config=vcfg), max_seq_length=2048,
+              get_input_embeddings=lambda: ns(weight=ns(dtype=torch.float16)))
+
+
+def _example():
+    from PIL import Image
+    img = Image.new("RGB", (280, 280), (120, 130, 140))
+    return {"messages": [
+        {"role": "user", "content": [{"type": "image"}, {"type": "text", "text": USER_TXT}]},
+        {"role": "assistant", "content": [{"type": "text", "text": ASST_TXT}]}], "images": [img]}
+
+
+def _content_exact(collator, proc):
+    batch = collator([_example()])
+    ids, labels = batch["input_ids"][0].tolist(), batch["labels"][0].tolist()
+    tok = proc.tokenizer if hasattr(proc, "tokenizer") else proc
+    trained = tok.decode([i for i, l in zip(ids, labels) if l != -100])
+    img_ids = set(collator.padding_token_ids.tolist())
+    img_leak = any((i in img_ids) and (l != -100) for i, l in zip(ids, labels))
+    return (ASST_TXT in trained) and (USER_TXT not in trained) and not img_leak
+
+
+def _check(repo, ins, res):
+    from transformers import AutoProcessor, AutoConfig
+    try:
+        path = _fetch(repo)
+        proc = AutoProcessor.from_pretrained(path)
+        model = _mock_model(AutoConfig.from_pretrained(path))
+    except Exception as e:
+        return "SKIP", f"{type(e).__name__}"
+    if not hasattr(proc, "image_processor"):
+        return "SKIP", "no image_processor"
+    # (A) constructor
+    cA = UnslothVisionDataCollator(model, proc, train_on_responses_only=True,
+                                   instruction_part=ins, response_part=res)
+    if not _content_exact(cA, proc):
+        return "FAIL", "constructor masking wrong"
+    # (B) in-place
+    cB = UnslothVisionDataCollator(model, proc)
+    if cB.train_on_responses_only is not None:
+        return "FAIL", "bare collator already had masking"
+    trainer = types.SimpleNamespace(processing_class=proc, data_collator=cB,
+                                    train_dataset=None, eval_dataset=None,
+                                    args=types.SimpleNamespace(packing=False, max_length=2048))
+    train_on_responses_only(trainer, instruction_part=ins, response_part=res)
+    if not callable(getattr(cB, "train_on_responses_only", None)):
+        return "FAIL", "train_on_responses_only(trainer) did not configure the collator"
+    if not _content_exact(cB, proc):
+        return "FAIL", "in-place masking wrong"
+    return "PASS", ""
+
+
+def run():
+    out = {}
+    for repo, ins, res in MODELS:
+        cat, why = _check(repo, ins, res)
+        out[repo] = (cat, why)
+        print(f"{repo:42s} {cat}  {why}", flush=True)
+    return out
+
+
+def test_vlm_collator_masking():
+    import pytest
+    if not ENABLED and not os.path.isdir(CACHE):
+        pytest.skip("set UNSLOTH_TEST_VLM_COLLATOR=1 (network) to run the vision collator e2e")
+    out = run()
+    checked = sum(1 for c, _ in out.values() if c in ("PASS", "FAIL"))
+    if checked == 0:
+        pytest.skip(f"no vision processors were loadable ({out})")
+    fails = {r: w for r, (c, w) in out.items() if c == "FAIL"}
+    assert not fails, f"vision masking failed: {fails}"
+
+
+if __name__ == "__main__":
+    out = run()
+    fails = [r for r, (c, _) in out.items() if c == "FAIL"]
+    print("\nFAILS:", fails or "none")
+    sys.exit(1 if fails else 0)

--- a/tests/test_vlm_collator_masking.py
+++ b/tests/test_vlm_collator_masking.py
@@ -46,9 +46,15 @@ USER_TXT, ASST_TXT = "ZEBRAQUESTION", "PENGUINANSWER"
 
 
 def _fetch(repo):
-    from huggingface_hub import snapshot_download
     path = os.path.join(CACHE, repo.replace("/", "__"))
-    if not (os.path.isdir(path) and any(f.startswith("tokenizer") for f in os.listdir(path))):
+    cached = os.path.isdir(path) and any(f.startswith("tokenizer") for f in os.listdir(path))
+    if not cached:
+        # Downloads are opt-in. Without UNSLOTH_TEST_VLM_COLLATOR an uncached repo is
+        # skipped (raise -> _check returns SKIP), never fetched, even when CACHE already
+        # exists from a prior partial run - so the sweep stays truly off by default.
+        if not ENABLED:
+            raise RuntimeError(f"{repo} not cached; set UNSLOTH_TEST_VLM_COLLATOR=1 to download")
+        from huggingface_hub import snapshot_download
         snapshot_download(repo, local_dir=path, allow_patterns=ALLOW, token=os.environ.get("HF_TOKEN"))
     return path
 

--- a/tests/test_vlm_token_coverage.py
+++ b/tests/test_vlm_token_coverage.py
@@ -1,0 +1,67 @@
+"""Offline regression guard for VLM placeholder-token coverage.
+
+Encodes the media (image / video / audio) placeholder tokens used by the vision and
+omni model families shipped in unslothai/notebooks, and asserts every one is present
+in vlm_tokens so both the CUDA collator (get_padding_tokens_ids) and the MLX loss
+mask them. This is fast and offline; it catches a token being dropped from the lists
+or a new family being added without its tokens. The live per-model id check lives in
+the network sweep (test_notebook_chat_templates.py / manual), this pins the strings.
+"""
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from unsloth_zoo.vlm_tokens import IMAGE_TOKENS, AUDIO_TOKENS, VLM_PLACEHOLDER_TOKENS
+
+COVERED = set(IMAGE_TOKENS) | set(AUDIO_TOKENS)
+
+# family -> media placeholder tokens that must never train (verified against the
+# actual tokenizers/configs of these models).
+EXPECTED = {
+    "Llama 3.2 Vision / Phi 3.5": ["<|image|>"],
+    "Qwen2-VL / Qwen2.5-VL": ["<|vision_start|>", "<|vision_end|>", "<|vision_pad|>", "<|image_pad|>", "<|video_pad|>"],
+    "Qwen2.5-Omni": ["<|IMAGE|>", "<|VIDEO|>", "<|AUDIO|>", "<|vision_bos|>", "<|vision_eos|>",
+                     "<|vision_pad|>", "<|audio_bos|>", "<|audio_eos|>"],
+    "PaliGemma / Llava / InternVL": ["<image>"],
+    "InternVL / Nemotron Nano Omni (image)": ["<img>", "</img>", "<video>"],
+    "Nemotron Nano Omni (sound)": ["<so_embedding>", "<so_start>", "<so_end>"],
+    "Pixtral / Mistral": ["[IMG]", "[IMG_BREAK]", "[IMG_END]"],
+    "Gemma 3 / 3n (image)": ["<image_soft_token>", "<start_of_image>", "<end_of_image>"],
+    "Gemma 3n (audio)": ["<audio_soft_token>", "<start_of_audio>", "<end_of_audio>"],
+    "Gemma 4 (image/video)": ["<|image|>", "<|image>", "<image|>", "<|video|>"],
+    "Gemma 4 (audio)": ["<|audio|>", "<|audio>", "<audio|>"],
+    "Cohere Aya Vision": ["<|START_OF_IMG|>", "<|END_OF_IMG|>", "<|IMG_LINE_BREAK|>", "<|IMG_PATCH|>"],
+}
+
+
+def test_expected_media_tokens_are_covered():
+    missing = {fam: [t for t in toks if t not in COVERED] for fam, toks in EXPECTED.items()}
+    missing = {fam: m for fam, m in missing.items() if m}
+    assert not missing, f"media tokens missing from vlm_tokens: {missing}"
+
+
+def test_lists_are_consistent():
+    # No duplicates, combined list is image + audio, MLX and CUDA share one source.
+    assert VLM_PLACEHOLDER_TOKENS == IMAGE_TOKENS + AUDIO_TOKENS
+    assert len(IMAGE_TOKENS) == len(set(IMAGE_TOKENS)), "duplicate image tokens"
+    assert len(AUDIO_TOKENS) == len(set(AUDIO_TOKENS)), "duplicate audio tokens"
+
+
+def test_mlx_mirror_matches():
+    # The MLX path must source the same strings (no separate hand-maintained copy).
+    import ast
+    src = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                       "unsloth_zoo", "mlx", "utils.py")
+    tree = ast.parse(open(src).read())
+    # _IMAGE_TOKEN_STRINGS must be derived from VLM_PLACEHOLDER_TOKENS, not a literal list
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(getattr(t, "id", None) == "_IMAGE_TOKEN_STRINGS" for t in node.targets):
+            assert not isinstance(node.value, (ast.Tuple, ast.List)), \
+                "_IMAGE_TOKEN_STRINGS should derive from vlm_tokens, not hardcode a list"
+            return
+    raise AssertionError("_IMAGE_TOKEN_STRINGS not found in mlx/utils.py")
+
+
+if __name__ == "__main__":
+    test_expected_media_tokens_are_covered()
+    test_lists_are_consistent()
+    test_mlx_mirror_matches()
+    print("OK:", len(COVERED), "covered tokens across", len(EXPECTED), "families")

--- a/tests/test_vlm_token_coverage.py
+++ b/tests/test_vlm_token_coverage.py
@@ -9,11 +9,9 @@ the network sweep (test_notebook_chat_templates.py / manual), this pins the stri
 """
 import os, sys, importlib.util
 
-# Load unsloth_zoo/vlm_tokens.py by file path instead of `from unsloth_zoo.vlm_tokens
-# import ...`. Importing the submodule runs unsloth_zoo/__init__.py, which raises
-# ImportError ("Please install Unsloth ...") when the separate `unsloth` package is not
-# installed, breaking pytest collection on offline CI. vlm_tokens.py is pure data with no
-# imports, so loading it in isolation keeps this offline test hermetic and always runnable.
+# Load vlm_tokens.py by file path, not `from unsloth_zoo.vlm_tokens import ...`: the latter
+# runs unsloth_zoo/__init__ (ImportError without the `unsloth` package) and breaks collection.
+# vlm_tokens.py is pure data, so loading it in isolation keeps this test hermetic.
 def _load_vlm_tokens():
     path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
                         "unsloth_zoo", "vlm_tokens.py")

--- a/tests/test_vlm_token_coverage.py
+++ b/tests/test_vlm_token_coverage.py
@@ -35,7 +35,7 @@ EXPECTED = {
     "Qwen2.5-Omni": ["<|IMAGE|>", "<|VIDEO|>", "<|AUDIO|>", "<|vision_bos|>", "<|vision_eos|>",
                      "<|vision_pad|>", "<|audio_bos|>", "<|audio_eos|>"],
     "PaliGemma / Llava / InternVL": ["<image>"],
-    "InternVL / Nemotron Nano Omni (image)": ["<img>", "</img>", "<video>"],
+    "InternVL / Nemotron Nano Omni (image)": ["<img>", "</img>", "<IMG_CONTEXT>", "<video>"],
     "Nemotron Nano Omni (sound)": ["<so_embedding>", "<so_start>", "<so_end>"],
     "Pixtral / Mistral": ["[IMG]", "[IMG_BREAK]", "[IMG_END]"],
     "Gemma 3 / 3n (image)": ["<image_soft_token>", "<start_of_image>", "<end_of_image>"],

--- a/tests/test_vlm_token_coverage.py
+++ b/tests/test_vlm_token_coverage.py
@@ -7,9 +7,25 @@ mask them. This is fast and offline; it catches a token being dropped from the l
 or a new family being added without its tokens. The live per-model id check lives in
 the network sweep (test_notebook_chat_templates.py / manual), this pins the strings.
 """
-import os, sys
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from unsloth_zoo.vlm_tokens import IMAGE_TOKENS, AUDIO_TOKENS, VLM_PLACEHOLDER_TOKENS
+import os, sys, importlib.util
+
+# Load unsloth_zoo/vlm_tokens.py by file path instead of `from unsloth_zoo.vlm_tokens
+# import ...`. Importing the submodule runs unsloth_zoo/__init__.py, which raises
+# ImportError ("Please install Unsloth ...") when the separate `unsloth` package is not
+# installed, breaking pytest collection on offline CI. vlm_tokens.py is pure data with no
+# imports, so loading it in isolation keeps this offline test hermetic and always runnable.
+def _load_vlm_tokens():
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        "unsloth_zoo", "vlm_tokens.py")
+    spec = importlib.util.spec_from_file_location("unsloth_zoo_vlm_tokens_isolated", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+_vt = _load_vlm_tokens()
+IMAGE_TOKENS, AUDIO_TOKENS, VLM_PLACEHOLDER_TOKENS = (
+    _vt.IMAGE_TOKENS, _vt.AUDIO_TOKENS, _vt.VLM_PLACEHOLDER_TOKENS,
+)
 
 COVERED = set(IMAGE_TOKENS) | set(AUDIO_TOKENS)
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -316,7 +316,8 @@ def train_on_responses_only(
         return _train_on_responses_only
 
     import multiprocessing as _mp
-    if num_proc is None or type(num_proc) is not int:
+    _num_proc_was_auto = num_proc is None or type(num_proc) is not int
+    if _num_proc_was_auto:
         if _mp.get_start_method() != 'fork':
             num_proc = None
         else:
@@ -328,6 +329,20 @@ def train_on_responses_only(
                 num_proc = 1
             else:
                 num_proc = min(num_proc, int(memory_gb_left))
+
+    # Spawning workers for a fast op on a small dataset costs more than it saves,
+    # and large auto num_proc caused Windows spawn loops (#3211, #3397). Single
+    # process small datasets, but keep the non-fork guard and explicit user values.
+    _MIN_ROWS_FOR_MULTIPROC = 50_000
+    def _effective_num_proc(dataset):
+        if num_proc is None or num_proc == 1: return num_proc
+        if not _num_proc_was_auto: return num_proc  # honor explicit user value
+        try:
+            if len(dataset) < _MIN_ROWS_FOR_MULTIPROC: return None
+        except TypeError:
+            return None  # unknown length (e.g. IterableDataset)
+        return num_proc
+    pass
 
     # transformers 5.0+ VLMs skip dataset prep in SFTTrainer.__init__
     # (skip_prepare_dataset=True when _is_vlm), so tokenize before masking.
@@ -348,7 +363,7 @@ def train_on_responses_only(
         def _tokenize_fn(examples):
             texts = examples.get(text_field) or examples.get("text", [])
             return _tok(texts, truncation=True, max_length=max_length, padding=False)
-        _map_kwargs = {"batched": True, "num_proc": num_proc}
+        _map_kwargs = {"batched": True, "num_proc": _effective_num_proc(dataset)}
         if isinstance(dataset, IterableDataset):
             _map_kwargs = {"batched": True}
         import warnings as _w
@@ -368,13 +383,68 @@ def train_on_responses_only(
         return any(l != -100 for l in labels)
     pass
 
+    def _diagnose_truncation(dataset):
+        # The #1 cause of an all -100 dataset is truncation: max_length cut off the
+        # response marker before masking could find it. Detect it and explain the fix
+        # instead of failing later with an opaque zero-loss error.
+        if dataset is None or isinstance(dataset, IterableDataset): return
+        if getattr(trainer.args, "packing", False): return
+        try:
+            if len(dataset) == 0: return
+        except TypeError:
+            return
+        max_length = getattr(trainer.args, "max_length", None) or getattr(trainer.args, "max_seq_length", None)
+        n_checked = 0; n_masked = 0; n_trunc = 0
+        for i, row in enumerate(dataset):
+            if i >= 100: break
+            labels = row.get("labels"); input_ids = row.get("input_ids")
+            if labels is None or input_ids is None: continue
+            if type(labels) is torch_Tensor: labels = labels.tolist()
+            n_checked += 1
+            if any(l != -100 for l in labels): continue  # row has training signal
+            n_masked += 1
+            if type(input_ids) is torch_Tensor: input_ids = input_ids.tolist()
+            # Response marker absent => the assistant turn was truncated away.
+            marker_absent = not any(
+                input_ids[j : j + len_A_must] == A_must
+                for j in range(len(input_ids) - len_A_must + 1)
+            )
+            at_max_len = max_length is not None and len(input_ids) >= max_length
+            if marker_absent or at_max_len: n_trunc += 1
+        # Only raise when the dataset is overwhelmingly masked (a few bad rows are
+        # just dropped by _filter_fully_masked), and the cause looks like truncation.
+        if n_checked == 0 or n_masked / n_checked < 0.9: return
+        if n_trunc / n_masked < 0.9: return
+        ml = max_length if max_length is not None else 1024
+        raise ValueError(
+            "Unsloth: train_on_responses_only masked every label to -100, so the training loss would be 0.\n"
+            f"The most likely cause is truncation: max_length={ml} cut off the response marker "
+            f"{repr(response_part)} before masking could find it.\n"
+            "Increase max_length to fit your responses, for example SFTConfig(max_length = max_seq_length).\n"
+            "If your sequences are genuinely longer, raise max_seq_length when loading the model."
+        )
+    pass
+
     def _filter_fully_masked(dataset, dataset_name="dataset"):
         if isinstance(dataset, IterableDataset):
             return dataset  # Cannot filter IterableDataset efficiently
+        if "labels" not in dataset.column_names:
+            return dataset
+        # dataset.filter rewrites the whole Arrow table even when it drops nothing,
+        # so scan the labels column cheaply and only select when a row is fully
+        # masked (the common case removes 0 and skips the rewrite entirely).
         n_before = len(dataset)
-        dataset = dataset.filter(_has_valid_labels, num_proc=num_proc)
-        n_after = len(dataset)
-        n_removed = n_before - n_after
+        keep = []
+        idx = 0
+        for batch in dataset.select_columns(["labels"]).iter(batch_size = 1000):
+            for labels in batch["labels"]:
+                if labels is None or any(l != -100 for l in labels):
+                    keep.append(idx)
+                idx += 1
+        if len(keep) == n_before:
+            return dataset  # nothing fully masked
+        dataset = dataset.select(keep)
+        n_removed = n_before - len(dataset)
         if n_removed > 0:
             print(
                 f"Unsloth: Removed {n_removed} out of {n_before} samples from {dataset_name} "
@@ -391,7 +461,8 @@ def train_on_responses_only(
         if isinstance(trainer.train_dataset, IterableDataset):
             trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batch_size = trainer.train_dataset._ex_iterable.batch_size, batched = True)
         else:
-            trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True, num_proc = num_proc)
+            trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(trainer.train_dataset))
+        _diagnose_truncation(trainer.train_dataset)
         trainer.train_dataset = _filter_fully_masked(trainer.train_dataset, "train_dataset")
     pass
 
@@ -405,7 +476,8 @@ def train_on_responses_only(
                 if isinstance(value, IterableDataset):
                     trainer.eval_dataset[key] = value.map(_train_on_responses_only, batch_size = value._ex_iterable.batch_size, batched = True)
                 else:
-                    trainer.eval_dataset[key] = value.map(_train_on_responses_only, batched = True, num_proc = num_proc)
+                    trainer.eval_dataset[key] = value.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(value))
+                _diagnose_truncation(trainer.eval_dataset[key])
                 trainer.eval_dataset[key] = _filter_fully_masked(trainer.eval_dataset[key], f"eval_dataset[{key}]")
         else:
             if not hasattr(trainer.eval_dataset, "map"):
@@ -414,15 +486,35 @@ def train_on_responses_only(
             if isinstance(trainer.eval_dataset, IterableDataset):
                 trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batch_size = trainer.eval_dataset._ex_iterable.batch_size, batched = True)
             else:
-                trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True, num_proc = num_proc)
+                trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(trainer.eval_dataset))
+            _diagnose_truncation(trainer.eval_dataset)
             trainer.eval_dataset = _filter_fully_masked(trainer.eval_dataset, "eval_dataset")
         pass
     pass
 
-    # Edit data collator as well if not DataCollatorForSeq2Seq
+    # Edit data collator to DataCollatorForSeq2Seq, but never replace a vision /
+    # processor collator (e.g. UnslothVisionDataCollator) which builds its own
+    # labels and handles image inputs; replacing it would silently break VLMs.
     from transformers import DataCollatorForSeq2Seq
+    def _is_vision_collator(collator):
+        if collator is None: return False
+        if type(collator).__name__ == "UnslothVisionDataCollator": return True
+        processor = getattr(collator, "processor", None)
+        if processor is not None and hasattr(processor, "image_processor"): return True
+        return hasattr(collator, "image_processor")
+    pass
     packing_enabled = getattr(trainer.args, "packing", False)
-    if (
+    data_collator = getattr(trainer, "data_collator", None)
+    if _is_vision_collator(data_collator):
+        # Keep the vision collator; mask via its own train_on_responses_only instead.
+        if getattr(data_collator, "train_on_responses_only", None) is None:
+            print(
+                f"Unsloth: Keeping your {type(data_collator).__name__} so image handling stays intact.\n"
+                "To mask instruction tokens for vision models, enable it on the collator:\n"
+                "    UnslothVisionDataCollator(model, processor, train_on_responses_only = True,\n"
+                f"        instruction_part = {repr(instruction_part)}, response_part = {repr(response_part)})"
+            )
+    elif (
         hasattr(trainer, "data_collator")
         and not isinstance(trainer.data_collator, DataCollatorForSeq2Seq)
         and not packing_enabled

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -383,10 +383,11 @@ def train_on_responses_only(
         return any(l != -100 for l in labels)
     pass
 
-    def _raise_if_truncated(dataset, dropped):
+    def _diagnose_truncation(dataset, dropped, fatal):
         # When (nearly) the whole dataset is masked away, the usual cause is
         # truncation: max_length cut off the response marker before masking found
-        # it. Explain that instead of failing later with an opaque zero-loss error.
+        # it. Raise when nothing is left to train on, otherwise just warn so the
+        # surviving rows still train (matching the old filter behaviour).
         if getattr(trainer.args, "packing", False): return
         max_length = getattr(trainer.args, "max_length", None) or getattr(trainer.args, "max_seq_length", None)
         n_sampled = 0; n_trunc = 0
@@ -403,13 +404,15 @@ def train_on_responses_only(
             if marker_absent or at_max_len: n_trunc += 1
         if n_sampled == 0 or n_trunc / n_sampled < 0.9: return
         ml = max_length if max_length is not None else 1024
-        raise ValueError(
-            "Unsloth: train_on_responses_only masked every label to -100, so the training loss would be 0.\n"
+        message = (
+            "Unsloth: train_on_responses_only masked all/most labels to -100.\n"
             f"The most likely cause is truncation: max_length={ml} cut off the response marker "
             f"{repr(response_part)} before masking could find it.\n"
             "Increase max_length to fit your responses, for example SFTConfig(max_length = max_seq_length).\n"
             "If your sequences are genuinely longer, raise max_seq_length when loading the model."
         )
+        if fatal: raise ValueError(message)
+        print("Unsloth: Warning: " + message)
     pass
 
     def _filter_fully_masked(dataset, dataset_name="dataset"):
@@ -438,8 +441,9 @@ def train_on_responses_only(
         if len(keep) == n_before:
             return dataset  # nothing fully masked
         # Most rows masked away across the WHOLE dataset usually means truncation.
+        # Only fatal when no rows survive; otherwise warn and keep the valid rows.
         if (n_before - len(keep)) / n_before >= 0.9:
-            _raise_if_truncated(dataset, set(range(n_before)) - set(keep))
+            _diagnose_truncation(dataset, set(range(n_before)) - set(keep), fatal = len(keep) == 0)
         dataset = dataset.select(keep)
         n_removed = n_before - len(dataset)
         if n_removed > 0:
@@ -467,14 +471,19 @@ def train_on_responses_only(
     if _is_vision_collator(data_collator):
         if hasattr(data_collator, "train_on_responses_only") and \
             getattr(data_collator, "train_on_responses_only", None) is None:
+            # If the collator's tokenizer already carries the parts, let the nested
+            # call read them; passing them explicitly would hit the "already set" guard.
+            coll_proc = getattr(data_collator, "processor", tokenizer)
+            coll_tok = coll_proc.tokenizer if hasattr(coll_proc, "tokenizer") else coll_proc
+            parts = {} if hasattr(coll_tok, "_unsloth_input_part") else \
+                dict(instruction_part = instruction_part, response_part = response_part)
             data_collator.train_on_responses_only = train_on_responses_only(
                 None,
-                instruction_part   = instruction_part,
-                response_part      = response_part,
                 force_match        = force_match,
-                tokenizer          = getattr(data_collator, "processor", tokenizer),
+                tokenizer          = coll_proc,
                 return_function    = True,
                 last_response_only = last_response_only,
+                **parts,
             )
             print(f"Unsloth: Enabled response-only masking on your {type(data_collator).__name__} (image handling kept intact).")
         return trainer

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -453,8 +453,13 @@ def train_on_responses_only(
                 f"so there is nothing to train on. The response marker {repr(response_part)} was not "
                 "found in any sample - check that instruction_part and response_part match your chat template."
             )
-        drop_set = set(dropped)
-        dataset = dataset.select([i for i in range(n_before) if i not in drop_set])
+        # Drop the fully masked rows with an Arrow-native mask (filter) rather than
+        # select(keep_indices): materializing every surviving index would allocate one
+        # Python int per kept row, which can be many GB on a very large corpus that has
+        # only a few bad rows. _has_valid_labels is the exact inverse of `dropped`, so
+        # the survivors are identical. The healthy common case already returned above,
+        # so filter only runs when there is genuinely something to remove.
+        dataset = dataset.filter(_has_valid_labels, num_proc = _effective_num_proc(dataset))
         n_removed = n_before - len(dataset)
         if n_removed > 0:
             print(

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -438,20 +438,28 @@ def train_on_responses_only(
                     idx += 1
         except Exception:
             # Datasets with a custom transform may need other columns; fall back.
-            return dataset.filter(_has_valid_labels)
+            return dataset.filter(_has_valid_labels, num_proc = _effective_num_proc(dataset))
         if not dropped:
             return dataset  # nothing fully masked
         # Most rows masked away across the WHOLE dataset usually means truncation.
         # Only fatal when no rows survive; otherwise warn and keep the valid rows.
         if len(dropped) / n_before >= 0.9:
             _diagnose_truncation(dataset, dropped, fatal = len(dropped) == n_before)
+        # Everything masked and not from truncation: the markers do not match the
+        # template at all, so fail clearly instead of returning an empty dataset.
+        if len(dropped) == n_before:
+            raise ValueError(
+                f"Unsloth: train_on_responses_only masked every label to -100 in {dataset_name}, "
+                f"so there is nothing to train on. The response marker {repr(response_part)} was not "
+                "found in any sample - check that instruction_part and response_part match your chat template."
+            )
         drop_set = set(dropped)
         dataset = dataset.select([i for i in range(n_before) if i not in drop_set])
         n_removed = n_before - len(dataset)
         if n_removed > 0:
             print(
                 f"Unsloth: Removed {n_removed} out of {n_before} samples from {dataset_name} "
-                f"where all labels were -100 (no response found after truncation). "
+                f"where all labels were -100 (no response marker found, usually truncation). "
                 f"This prevents NaN loss during training."
             )
         return dataset

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -390,20 +390,20 @@ def train_on_responses_only(
         # surviving rows still train (matching the old filter behaviour).
         if getattr(trainer.args, "packing", False): return
         max_length = getattr(trainer.args, "max_length", None) or getattr(trainer.args, "max_seq_length", None)
+        # Truncation evidence is a row sitting at the length cap (max_length cut its
+        # tail, including the response marker). Without a known cap, or for short rows,
+        # a fully masked row is a wrong template / response_part, not truncation, so we
+        # keep the generic error instead of telling users to raise max_length.
+        if max_length is None: return
         n_sampled = 0; n_trunc = 0
         for i in list(dropped)[:100]:
             input_ids = dataset[int(i)].get("input_ids")
             if input_ids is None: continue
             if getattr(input_ids, "tolist", None): input_ids = input_ids.tolist()
             n_sampled += 1
-            marker_absent = not any(
-                input_ids[j : j + len_A_must] == A_must
-                for j in range(len(input_ids) - len_A_must + 1)
-            )
-            at_max_len = max_length is not None and len(input_ids) >= max_length
-            if marker_absent or at_max_len: n_trunc += 1
+            if len(input_ids) >= max_length: n_trunc += 1
         if n_sampled == 0 or n_trunc / n_sampled < 0.9: return
-        ml = max_length if max_length is not None else 1024
+        ml = max_length
         message = (
             "Unsloth: train_on_responses_only masked all/most labels to -100.\n"
             f"The most likely cause is truncation: max_length={ml} cut off the response marker "
@@ -424,27 +424,29 @@ def train_on_responses_only(
         # so scan the labels column cheaply and only select when a row is fully
         # masked (the common case removes 0 and skips the rewrite entirely).
         n_before = len(dataset)
-        keep = []
+        # Track only the fully masked rows. The common healthy case collects an empty
+        # list and returns without ever building a per-row keep list, so a huge clean
+        # corpus does not pay one Python int per surviving row.
+        dropped = []
         try:
             idx = 0
             for batch in dataset.select_columns(["labels"]).iter(batch_size = 1000):
                 for labels in batch["labels"]:
-                    if labels is None:
-                        keep.append(idx)
-                    else:
+                    if labels is not None:
                         if getattr(labels, "tolist", None): labels = labels.tolist()
-                        if any(l != -100 for l in labels): keep.append(idx)
+                        if not any(l != -100 for l in labels): dropped.append(idx)
                     idx += 1
         except Exception:
             # Datasets with a custom transform may need other columns; fall back.
             return dataset.filter(_has_valid_labels)
-        if len(keep) == n_before:
+        if not dropped:
             return dataset  # nothing fully masked
         # Most rows masked away across the WHOLE dataset usually means truncation.
         # Only fatal when no rows survive; otherwise warn and keep the valid rows.
-        if (n_before - len(keep)) / n_before >= 0.9:
-            _diagnose_truncation(dataset, set(range(n_before)) - set(keep), fatal = len(keep) == 0)
-        dataset = dataset.select(keep)
+        if len(dropped) / n_before >= 0.9:
+            _diagnose_truncation(dataset, dropped, fatal = len(dropped) == n_before)
+        drop_set = set(dropped)
+        dataset = dataset.select([i for i in range(n_before) if i not in drop_set])
         n_removed = n_before - len(dataset)
         if n_removed > 0:
             print(
@@ -469,23 +471,33 @@ def train_on_responses_only(
 
     data_collator = getattr(trainer, "data_collator", None)
     if _is_vision_collator(data_collator):
-        if hasattr(data_collator, "train_on_responses_only") and \
-            getattr(data_collator, "train_on_responses_only", None) is None:
-            # If the collator's tokenizer already carries the parts, let the nested
-            # call read them; passing them explicitly would hit the "already set" guard.
-            coll_proc = getattr(data_collator, "processor", tokenizer)
-            coll_tok = coll_proc.tokenizer if hasattr(coll_proc, "tokenizer") else coll_proc
-            parts = {} if hasattr(coll_tok, "_unsloth_input_part") else \
-                dict(instruction_part = instruction_part, response_part = response_part)
-            data_collator.train_on_responses_only = train_on_responses_only(
-                None,
-                force_match        = force_match,
-                tokenizer          = coll_proc,
-                return_function    = True,
-                last_response_only = last_response_only,
-                **parts,
+        masking = getattr(data_collator, "train_on_responses_only", None)
+        if callable(masking):
+            return trainer  # collator already masks responses; nothing to do
+        is_unsloth = any(b.__name__ == "UnslothVisionDataCollator" for b in type(data_collator).__mro__)
+        if not is_unsloth:
+            # A processor-style collator we cannot reliably configure: do not return as
+            # if masking were applied (it would leave responses unmasked silently).
+            raise ValueError(
+                "Unsloth: Detected a vision data collator that does not support response-only "
+                "masking. Build UnslothVisionDataCollator(..., train_on_responses_only = True, "
+                "instruction_part = ..., response_part = ...) so masking runs at collate time."
             )
-            print(f"Unsloth: Enabled response-only masking on your {type(data_collator).__name__} (image handling kept intact).")
+        # If the collator's tokenizer already carries the parts, let the nested call
+        # read them; passing them explicitly would hit the "already set" guard.
+        coll_proc = getattr(data_collator, "processor", tokenizer)
+        coll_tok = coll_proc.tokenizer if hasattr(coll_proc, "tokenizer") else coll_proc
+        parts = {} if hasattr(coll_tok, "_unsloth_input_part") else \
+            dict(instruction_part = instruction_part, response_part = response_part)
+        data_collator.train_on_responses_only = train_on_responses_only(
+            None,
+            force_match        = force_match,
+            tokenizer          = coll_proc,
+            return_function    = True,
+            last_response_only = last_response_only,
+            **parts,
+        )
+        print(f"Unsloth: Enabled response-only masking on your {type(data_collator).__name__} (image handling kept intact).")
         return trainer
     pass
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -470,8 +470,11 @@ def train_on_responses_only(
     def _is_vision_collator(collator):
         if collator is None: return False
         if any(b.__name__ == "UnslothVisionDataCollator" for b in type(collator).__mro__): return True
-        processor = getattr(collator, "processor", None)
-        if processor is not None and hasattr(processor, "image_processor"): return True
+        # A vision collator may hold the processor under .processor or the common .tokenizer field
+        # (e.g. DataCollatorForSeq2Seq(tokenizer=processor)); either exposing image_processor marks it.
+        for attr in ("processor", "tokenizer"):
+            obj = getattr(collator, attr, None)
+            if obj is not None and hasattr(obj, "image_processor"): return True
         return hasattr(collator, "image_processor")
     pass
 

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -395,7 +395,7 @@ def train_on_responses_only(
         # keep the generic error instead of telling users to raise max_length.
         if max_length is None: return
         n_sampled = 0; n_trunc = 0
-        for i in list(dropped)[:100]:
+        for i in dropped[:100]:
             input_ids = dataset[int(i)].get("input_ids")
             if input_ids is None: continue
             if getattr(input_ids, "tolist", None): input_ids = input_ids.tolist()

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -333,7 +333,7 @@ def train_on_responses_only(
     # Spawning workers for a fast op on a small dataset costs more than it saves,
     # and large auto num_proc caused Windows spawn loops (#3211, #3397). Single
     # process small datasets, but keep the non-fork guard and explicit user values.
-    _MIN_ROWS_FOR_MULTIPROC = 50_000
+    _MIN_ROWS_FOR_MULTIPROC = 5_000
     def _effective_num_proc(dataset):
         if num_proc is None or num_proc == 1: return num_proc
         if not _num_proc_was_auto: return num_proc  # honor explicit user value
@@ -383,38 +383,25 @@ def train_on_responses_only(
         return any(l != -100 for l in labels)
     pass
 
-    def _diagnose_truncation(dataset):
-        # The #1 cause of an all -100 dataset is truncation: max_length cut off the
-        # response marker before masking could find it. Detect it and explain the fix
-        # instead of failing later with an opaque zero-loss error.
-        if dataset is None or isinstance(dataset, IterableDataset): return
+    def _raise_if_truncated(dataset, dropped):
+        # When (nearly) the whole dataset is masked away, the usual cause is
+        # truncation: max_length cut off the response marker before masking found
+        # it. Explain that instead of failing later with an opaque zero-loss error.
         if getattr(trainer.args, "packing", False): return
-        try:
-            if len(dataset) == 0: return
-        except TypeError:
-            return
         max_length = getattr(trainer.args, "max_length", None) or getattr(trainer.args, "max_seq_length", None)
-        n_checked = 0; n_masked = 0; n_trunc = 0
-        for i, row in enumerate(dataset):
-            if i >= 100: break
-            labels = row.get("labels"); input_ids = row.get("input_ids")
-            if labels is None or input_ids is None: continue
-            if type(labels) is torch_Tensor: labels = labels.tolist()
-            n_checked += 1
-            if any(l != -100 for l in labels): continue  # row has training signal
-            n_masked += 1
-            if type(input_ids) is torch_Tensor: input_ids = input_ids.tolist()
-            # Response marker absent => the assistant turn was truncated away.
+        n_sampled = 0; n_trunc = 0
+        for i in list(dropped)[:100]:
+            input_ids = dataset[int(i)].get("input_ids")
+            if input_ids is None: continue
+            if getattr(input_ids, "tolist", None): input_ids = input_ids.tolist()
+            n_sampled += 1
             marker_absent = not any(
                 input_ids[j : j + len_A_must] == A_must
                 for j in range(len(input_ids) - len_A_must + 1)
             )
             at_max_len = max_length is not None and len(input_ids) >= max_length
             if marker_absent or at_max_len: n_trunc += 1
-        # Only raise when the dataset is overwhelmingly masked (a few bad rows are
-        # just dropped by _filter_fully_masked), and the cause looks like truncation.
-        if n_checked == 0 or n_masked / n_checked < 0.9: return
-        if n_trunc / n_masked < 0.9: return
+        if n_sampled == 0 or n_trunc / n_sampled < 0.9: return
         ml = max_length if max_length is not None else 1024
         raise ValueError(
             "Unsloth: train_on_responses_only masked every label to -100, so the training loss would be 0.\n"
@@ -435,14 +422,24 @@ def train_on_responses_only(
         # masked (the common case removes 0 and skips the rewrite entirely).
         n_before = len(dataset)
         keep = []
-        idx = 0
-        for batch in dataset.select_columns(["labels"]).iter(batch_size = 1000):
-            for labels in batch["labels"]:
-                if labels is None or any(l != -100 for l in labels):
-                    keep.append(idx)
-                idx += 1
+        try:
+            idx = 0
+            for batch in dataset.select_columns(["labels"]).iter(batch_size = 1000):
+                for labels in batch["labels"]:
+                    if labels is None:
+                        keep.append(idx)
+                    else:
+                        if getattr(labels, "tolist", None): labels = labels.tolist()
+                        if any(l != -100 for l in labels): keep.append(idx)
+                    idx += 1
+        except Exception:
+            # Datasets with a custom transform may need other columns; fall back.
+            return dataset.filter(_has_valid_labels)
         if len(keep) == n_before:
             return dataset  # nothing fully masked
+        # Most rows masked away across the WHOLE dataset usually means truncation.
+        if (n_before - len(keep)) / n_before >= 0.9:
+            _raise_if_truncated(dataset, set(range(n_before)) - set(keep))
         dataset = dataset.select(keep)
         n_removed = n_before - len(dataset)
         if n_removed > 0:
@@ -454,6 +451,35 @@ def train_on_responses_only(
         return dataset
     pass
 
+    # Vision/processor collators (e.g. UnslothVisionDataCollator) rebuild labels
+    # from the processor at collate time, so dataset-level masking is ignored and
+    # replacing the collator would break image handling. Enable response masking on
+    # the collator itself and skip the text dataset path.
+    def _is_vision_collator(collator):
+        if collator is None: return False
+        if any(b.__name__ == "UnslothVisionDataCollator" for b in type(collator).__mro__): return True
+        processor = getattr(collator, "processor", None)
+        if processor is not None and hasattr(processor, "image_processor"): return True
+        return hasattr(collator, "image_processor")
+    pass
+
+    data_collator = getattr(trainer, "data_collator", None)
+    if _is_vision_collator(data_collator):
+        if hasattr(data_collator, "train_on_responses_only") and \
+            getattr(data_collator, "train_on_responses_only", None) is None:
+            data_collator.train_on_responses_only = train_on_responses_only(
+                None,
+                instruction_part   = instruction_part,
+                response_part      = response_part,
+                force_match        = force_match,
+                tokenizer          = getattr(data_collator, "processor", tokenizer),
+                return_function    = True,
+                last_response_only = last_response_only,
+            )
+            print(f"Unsloth: Enabled response-only masking on your {type(data_collator).__name__} (image handling kept intact).")
+        return trainer
+    pass
+
     if hasattr(trainer, "train_dataset") and trainer.train_dataset is not None:
         if not hasattr(trainer.train_dataset, "map"):
             raise TypeError("Unsloth: train_on_responses_only does not work on lists!")
@@ -462,7 +488,6 @@ def train_on_responses_only(
             trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batch_size = trainer.train_dataset._ex_iterable.batch_size, batched = True)
         else:
             trainer.train_dataset = trainer.train_dataset.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(trainer.train_dataset))
-        _diagnose_truncation(trainer.train_dataset)
         trainer.train_dataset = _filter_fully_masked(trainer.train_dataset, "train_dataset")
     pass
 
@@ -477,7 +502,6 @@ def train_on_responses_only(
                     trainer.eval_dataset[key] = value.map(_train_on_responses_only, batch_size = value._ex_iterable.batch_size, batched = True)
                 else:
                     trainer.eval_dataset[key] = value.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(value))
-                _diagnose_truncation(trainer.eval_dataset[key])
                 trainer.eval_dataset[key] = _filter_fully_masked(trainer.eval_dataset[key], f"eval_dataset[{key}]")
         else:
             if not hasattr(trainer.eval_dataset, "map"):
@@ -487,34 +511,15 @@ def train_on_responses_only(
                 trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batch_size = trainer.eval_dataset._ex_iterable.batch_size, batched = True)
             else:
                 trainer.eval_dataset = trainer.eval_dataset.map(_train_on_responses_only, batched = True, num_proc = _effective_num_proc(trainer.eval_dataset))
-            _diagnose_truncation(trainer.eval_dataset)
             trainer.eval_dataset = _filter_fully_masked(trainer.eval_dataset, "eval_dataset")
         pass
     pass
 
-    # Edit data collator to DataCollatorForSeq2Seq, but never replace a vision /
-    # processor collator (e.g. UnslothVisionDataCollator) which builds its own
-    # labels and handles image inputs; replacing it would silently break VLMs.
+    # Edit data collator to DataCollatorForSeq2Seq (vision collators were handled
+    # earlier and returned, so trainer.data_collator here is a text collator).
     from transformers import DataCollatorForSeq2Seq
-    def _is_vision_collator(collator):
-        if collator is None: return False
-        if type(collator).__name__ == "UnslothVisionDataCollator": return True
-        processor = getattr(collator, "processor", None)
-        if processor is not None and hasattr(processor, "image_processor"): return True
-        return hasattr(collator, "image_processor")
-    pass
     packing_enabled = getattr(trainer.args, "packing", False)
-    data_collator = getattr(trainer, "data_collator", None)
-    if _is_vision_collator(data_collator):
-        # Keep the vision collator; mask via its own train_on_responses_only instead.
-        if getattr(data_collator, "train_on_responses_only", None) is None:
-            print(
-                f"Unsloth: Keeping your {type(data_collator).__name__} so image handling stays intact.\n"
-                "To mask instruction tokens for vision models, enable it on the collator:\n"
-                "    UnslothVisionDataCollator(model, processor, train_on_responses_only = True,\n"
-                f"        instruction_part = {repr(instruction_part)}, response_part = {repr(response_part)})"
-            )
-    elif (
+    if (
         hasattr(trainer, "data_collator")
         and not isinstance(trainer.data_collator, DataCollatorForSeq2Seq)
         and not packing_enabled

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -330,9 +330,8 @@ def train_on_responses_only(
             else:
                 num_proc = min(num_proc, int(memory_gb_left))
 
-    # Spawning workers for a fast op on a small dataset costs more than it saves,
-    # and large auto num_proc caused Windows spawn loops (#3211, #3397). Single
-    # process small datasets, but keep the non-fork guard and explicit user values.
+    # Single-process small datasets (workers cost more than they save, and large auto
+    # num_proc caused Windows spawn loops #3211/#3397); keep explicit user values.
     _MIN_ROWS_FOR_MULTIPROC = 5_000
     def _effective_num_proc(dataset):
         if num_proc is None or num_proc == 1: return num_proc
@@ -420,13 +419,10 @@ def train_on_responses_only(
             return dataset  # Cannot filter IterableDataset efficiently
         if "labels" not in dataset.column_names:
             return dataset
-        # dataset.filter rewrites the whole Arrow table even when it drops nothing,
-        # so scan the labels column cheaply and only select when a row is fully
-        # masked (the common case removes 0 and skips the rewrite entirely).
+        # filter rewrites the whole Arrow table even when it drops nothing, so scan the
+        # labels column cheaply first; the common case (0 fully masked) returns as-is.
         n_before = len(dataset)
-        # Track only the fully masked rows. The common healthy case collects an empty
-        # list and returns without ever building a per-row keep list, so a huge clean
-        # corpus does not pay one Python int per surviving row.
+        # Track only the fully masked rows, so a huge clean corpus builds no per-row list.
         dropped = []
         try:
             idx = 0
@@ -453,12 +449,9 @@ def train_on_responses_only(
                 f"so there is nothing to train on. The response marker {repr(response_part)} was not "
                 "found in any sample - check that instruction_part and response_part match your chat template."
             )
-        # Drop the fully masked rows with an Arrow-native mask (filter) rather than
-        # select(keep_indices): materializing every surviving index would allocate one
-        # Python int per kept row, which can be many GB on a very large corpus that has
-        # only a few bad rows. _has_valid_labels is the exact inverse of `dropped`, so
-        # the survivors are identical. The healthy common case already returned above,
-        # so filter only runs when there is genuinely something to remove.
+        # Drop via filter (Arrow mask), not select(keep_indices): a keep list would be one
+        # Python int per surviving row (GBs on a large corpus). _has_valid_labels is the
+        # exact inverse of `dropped`, so survivors are identical.
         dataset = dataset.filter(_has_valid_labels, num_proc = _effective_num_proc(dataset))
         n_removed = n_before - len(dataset)
         if n_removed > 0:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -552,8 +552,8 @@ def make_baseline_loss_fn():
 # VLM helpers
 # ---------------------------------------------------------------------------
 
-# Image/vision special tokens that should never contribute to loss.
-# Mirrors unsloth's IMAGE_TOKENS list in vision_utils.py.
+# Image/vision/audio special tokens that should never contribute to loss.
+# Mirrors unsloth's IMAGE_TOKENS and AUDIO_TOKENS lists in vision_utils.py.
 _IMAGE_TOKEN_STRINGS = (
     "<|image|>",           # Llama 3.2 Vision, Phi 3.5, Gemma4
     "<|vision_start|>",    # Qwen
@@ -569,6 +569,12 @@ _IMAGE_TOKEN_STRINGS = (
     "<image_soft_token>",  # Gemma 3
     "<start_of_image>",    # Gemma 3
     "<end_of_image>",      # Gemma 3
+    "<|image>",            # Gemma 4 (begin image)
+    "<image|>",            # Gemma 4 (end image)
+    "<|video|>",           # Gemma 4
+    "<|audio|>",           # Gemma 4
+    "<|audio>",            # Gemma 4 (begin audio)
+    "<audio|>",            # Gemma 4 (end audio)
     "<|START_OF_IMG|>",    # Cohere
     "<|END_OF_IMG|>",      # Cohere
     "<|IMG_LINE_BREAK|>",  # Cohere

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -553,33 +553,10 @@ def make_baseline_loss_fn():
 # ---------------------------------------------------------------------------
 
 # Image/vision/audio special tokens that should never contribute to loss.
-# Mirrors unsloth's IMAGE_TOKENS and AUDIO_TOKENS lists in vision_utils.py.
-_IMAGE_TOKEN_STRINGS = (
-    "<|image|>",           # Llama 3.2 Vision, Phi 3.5, Gemma4
-    "<|vision_start|>",    # Qwen
-    "<|vision_end|>",      # Qwen
-    "<|vision_pad|>",      # Qwen
-    "<|image_pad|>",       # Qwen
-    "<|video_pad|>",       # Qwen
-    "<image>",             # PaliGemma, Llava, InternVL
-    "</image>",            # InternVL
-    "[IMG]",               # Mistral
-    "[IMG_BREAK]",         # Mistral
-    "[IMG_END]",           # Mistral
-    "<image_soft_token>",  # Gemma 3
-    "<start_of_image>",    # Gemma 3
-    "<end_of_image>",      # Gemma 3
-    "<|image>",            # Gemma 4 (begin image)
-    "<image|>",            # Gemma 4 (end image)
-    "<|video|>",           # Gemma 4
-    "<|audio|>",           # Gemma 4
-    "<|audio>",            # Gemma 4 (begin audio)
-    "<audio|>",            # Gemma 4 (end audio)
-    "<|START_OF_IMG|>",    # Cohere
-    "<|END_OF_IMG|>",      # Cohere
-    "<|IMG_LINE_BREAK|>",  # Cohere
-    "<|IMG_PATCH|>",       # Cohere
-)
+# Single source of truth shared with the CUDA collator (unsloth_zoo/vlm_tokens.py),
+# so the two backends cannot drift apart.
+from ..vlm_tokens import VLM_PLACEHOLDER_TOKENS
+_IMAGE_TOKEN_STRINGS = tuple(VLM_PLACEHOLDER_TOKENS)
 
 
 def _append_unique_int(ids, value):

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -47,6 +47,9 @@ IMAGE_TOKENS = [
     "<image_soft_token>", # Gemma 3
     "<start_of_image>",   # Gemma 3
     "<end_of_image>",     # Gemma 3
+    "<|image>",           # Gemma 4 (begin image; <|image|> already listed above)
+    "<image|>",           # Gemma 4 (end image)
+    "<|video|>",          # Gemma 4
     "<|START_OF_IMG|>",   # Cohere
     "<|END_OF_IMG|>",     # Cohere
     "<|IMG_LINE_BREAK|>", # Cohere
@@ -55,6 +58,8 @@ IMAGE_TOKENS = [
 
 AUDIO_TOKENS = [
     "<|audio|>",  # Gemma 4
+    "<|audio>",   # Gemma 4 (begin audio)
+    "<audio|>",   # Gemma 4 (end audio)
 ]
 
 import torch

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -634,6 +634,11 @@ def get_padding_tokens_ids(tokenizer):
         placeholder_tokens = placeholder_tokens + [tokenizer.audio_token]
 
     padding_token_ids = tokenizer.convert_tokens_to_ids(placeholder_tokens)
+    # Tokens absent from this tokenizer map to the unk id; do not mask unk from loss
+    # (mirrors the MLX path in mlx/utils.py). pad_token_id is added separately below.
+    unk_id = getattr(tokenizer, "unk_token_id", None)
+    if unk_id is not None:
+        padding_token_ids = [x for x in padding_token_ids if x != unk_id]
     if hasattr(tokenizer, "pad_token_id"):
         padding_token_ids.append(tokenizer.pad_token_id)
 

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -33,34 +33,9 @@ __all__ = [
     "UnslothVisionDataCollator",
 ]
 
-IMAGE_TOKENS = [
-    "<|image|>",          # Llama 3.2 Vision, Phi 3.5
-    "<|vision_start|>",   # Qwen
-    "<|vision_end|>",     # Qwen
-    "<|vision_pad|>",     # Qwen
-    "<|image_pad|>",      # Qwen
-    "<|video_pad|>",      # Qwen
-    "<image>",            # PaliGemma / Llava
-    "[IMG]",              # Mistral
-    "[IMG_BREAK]",        # Mistral
-    "[IMG_END]",          # Mistral
-    "<image_soft_token>", # Gemma 3
-    "<start_of_image>",   # Gemma 3
-    "<end_of_image>",     # Gemma 3
-    "<|image>",           # Gemma 4 (begin image; <|image|> already listed above)
-    "<image|>",           # Gemma 4 (end image)
-    "<|video|>",          # Gemma 4
-    "<|START_OF_IMG|>",   # Cohere
-    "<|END_OF_IMG|>",     # Cohere
-    "<|IMG_LINE_BREAK|>", # Cohere
-    "<|IMG_PATCH|>",      # Cohere
-]
-
-AUDIO_TOKENS = [
-    "<|audio|>",  # Gemma 4
-    "<|audio>",   # Gemma 4 (begin audio)
-    "<audio|>",   # Gemma 4 (end audio)
-]
+# Canonical media placeholder tokens live in vlm_tokens so the CUDA and MLX paths
+# share one source of truth. Re-exported here for backwards compatibility.
+from .vlm_tokens import IMAGE_TOKENS, AUDIO_TOKENS
 
 import torch
 import numpy as np

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1123,8 +1123,13 @@ class UnslothVisionDataCollator:
         audio_tokens = list(AUDIO_TOKENS)
         if getattr(tok, "audio_token", None) is not None:
             audio_tokens.append(tok.audio_token)
+        # Audio strings absent from this tokenizer map to the unk id (matching
+        # get_padding_tokens_ids); excluding it keeps a truncated unk text token from being
+        # miscounted as an audio token and tripping the alignment check below.
+        unk_id = getattr(tok, "unk_token_id", None)
         audio_ids = torch.tensor(
-            [i for i in tok.convert_tokens_to_ids(audio_tokens) if isinstance(i, int) and i >= 0],
+            [i for i in tok.convert_tokens_to_ids(audio_tokens)
+             if isinstance(i, int) and i >= 0 and i != unk_id],
             device=batch["input_ids"].device,
         )
         n_audio = int(torch.isin(batch["input_ids"], audio_ids).sum())

--- a/unsloth_zoo/vlm_tokens.py
+++ b/unsloth_zoo/vlm_tokens.py
@@ -54,6 +54,7 @@ IMAGE_TOKENS = [
     "<|IMG_PATCH|>",      # Cohere
     "<img>",              # InternVL / Nemotron Nano Omni (begin image)
     "</img>",             # InternVL / Nemotron Nano Omni (end image)
+    "<IMG_CONTEXT>",      # InternVL (repeated image-context token expanded between <img>...</img>)
     "<video>",            # Nemotron Nano Omni
     "<|IMAGE|>",          # Qwen2.5-Omni
     "<|VIDEO|>",          # Qwen2.5-Omni

--- a/unsloth_zoo/vlm_tokens.py
+++ b/unsloth_zoo/vlm_tokens.py
@@ -42,9 +42,9 @@ IMAGE_TOKENS = [
     "[IMG]",              # Mistral
     "[IMG_BREAK]",        # Mistral
     "[IMG_END]",          # Mistral
-    "<image_soft_token>", # Gemma 3
-    "<start_of_image>",   # Gemma 3
-    "<end_of_image>",     # Gemma 3
+    "<image_soft_token>", # Gemma 3 / 3n
+    "<start_of_image>",   # Gemma 3 / 3n
+    "<end_of_image>",     # Gemma 3 / 3n
     "<|image>",           # Gemma 4 (begin image; <|image|> already listed above)
     "<image|>",           # Gemma 4 (end image)
     "<|video|>",          # Gemma 4
@@ -56,9 +56,12 @@ IMAGE_TOKENS = [
 
 # Audio placeholder tokens.
 AUDIO_TOKENS = [
-    "<|audio|>",  # Gemma 4
-    "<|audio>",   # Gemma 4 (begin audio)
-    "<audio|>",   # Gemma 4 (end audio)
+    "<|audio|>",          # Gemma 4
+    "<|audio>",           # Gemma 4 (begin audio)
+    "<audio|>",           # Gemma 4 (end audio)
+    "<audio_soft_token>", # Gemma 3n
+    "<start_of_audio>",   # Gemma 3n (begin audio)
+    "<end_of_audio>",     # Gemma 3n (end audio)
 ]
 
 # Combined list for callers that mask every media placeholder at once.

--- a/unsloth_zoo/vlm_tokens.py
+++ b/unsloth_zoo/vlm_tokens.py
@@ -52,6 +52,13 @@ IMAGE_TOKENS = [
     "<|END_OF_IMG|>",     # Cohere
     "<|IMG_LINE_BREAK|>", # Cohere
     "<|IMG_PATCH|>",      # Cohere
+    "<img>",              # InternVL / Nemotron Nano Omni (begin image)
+    "</img>",             # InternVL / Nemotron Nano Omni (end image)
+    "<video>",            # Nemotron Nano Omni
+    "<|IMAGE|>",          # Qwen2.5-Omni
+    "<|VIDEO|>",          # Qwen2.5-Omni
+    "<|vision_bos|>",     # Qwen2.5-Omni (begin vision)
+    "<|vision_eos|>",     # Qwen2.5-Omni (end vision)
 ]
 
 # Audio placeholder tokens.
@@ -62,6 +69,12 @@ AUDIO_TOKENS = [
     "<audio_soft_token>", # Gemma 3n
     "<start_of_audio>",   # Gemma 3n (begin audio)
     "<end_of_audio>",     # Gemma 3n (end audio)
+    "<so_embedding>",     # Nemotron Nano Omni (sound)
+    "<so_start>",         # Nemotron Nano Omni (begin sound)
+    "<so_end>",           # Nemotron Nano Omni (end sound)
+    "<|AUDIO|>",          # Qwen2.5-Omni
+    "<|audio_bos|>",      # Qwen2.5-Omni (begin audio)
+    "<|audio_eos|>",      # Qwen2.5-Omni (end audio)
 ]
 
 # Combined list for callers that mask every media placeholder at once.

--- a/unsloth_zoo/vlm_tokens.py
+++ b/unsloth_zoo/vlm_tokens.py
@@ -1,0 +1,65 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Single source of truth for VLM placeholder tokens.
+
+These are the image/video/audio special tokens that stand in for media content
+and must never contribute to the language-modeling loss. Both backends consume
+these lists so they cannot drift apart: the CUDA collator via
+``unsloth_zoo.vision_utils`` and the MLX trainer via ``unsloth_zoo.mlx.utils``.
+Keep this module import-light (no torch / mlx) so either backend can import it.
+"""
+
+__all__ = [
+    "IMAGE_TOKENS",
+    "AUDIO_TOKENS",
+    "VLM_PLACEHOLDER_TOKENS",
+]
+
+# Image / vision placeholder tokens, keyed by the models that use them.
+IMAGE_TOKENS = [
+    "<|image|>",          # Llama 3.2 Vision, Phi 3.5, Gemma 4
+    "<|vision_start|>",   # Qwen
+    "<|vision_end|>",     # Qwen
+    "<|vision_pad|>",     # Qwen
+    "<|image_pad|>",      # Qwen
+    "<|video_pad|>",      # Qwen
+    "<image>",            # PaliGemma, Llava, InternVL
+    "</image>",           # InternVL
+    "[IMG]",              # Mistral
+    "[IMG_BREAK]",        # Mistral
+    "[IMG_END]",          # Mistral
+    "<image_soft_token>", # Gemma 3
+    "<start_of_image>",   # Gemma 3
+    "<end_of_image>",     # Gemma 3
+    "<|image>",           # Gemma 4 (begin image; <|image|> already listed above)
+    "<image|>",           # Gemma 4 (end image)
+    "<|video|>",          # Gemma 4
+    "<|START_OF_IMG|>",   # Cohere
+    "<|END_OF_IMG|>",     # Cohere
+    "<|IMG_LINE_BREAK|>", # Cohere
+    "<|IMG_PATCH|>",      # Cohere
+]
+
+# Audio placeholder tokens.
+AUDIO_TOKENS = [
+    "<|audio|>",  # Gemma 4
+    "<|audio>",   # Gemma 4 (begin audio)
+    "<audio|>",   # Gemma 4 (end audio)
+]
+
+# Combined list for callers that mask every media placeholder at once.
+VLM_PLACEHOLDER_TOKENS = IMAGE_TOKENS + AUDIO_TOKENS


### PR DESCRIPTION
### Summary

Four focused, backward compatible improvements to `train_on_responses_only` in `unsloth_zoo/dataset_utils.py`, motivated by profiling and by the most common issues users file about this function. The masking output is unchanged (verified token exact across many models); these change the surrounding plumbing to be faster, safer, and clearer.

### 1. Faster fully masked filtering (about 37 percent faster end to end)

`train_on_responses_only` masks labels in one `dataset.map`, then drops rows whose labels are all -100 (to avoid NaN loss) with a separate `dataset.filter`. Profiling 5000 multi turn samples (1.77M tokens):

| step | time |
| --- | --- |
| inner masking | 0.13s |
| `dataset.map` | 0.83s |
| `dataset.filter` (removes 0 rows in the common case) | 1.28s |

`filter` rewrites the whole Arrow table even when it drops nothing. This PR scans the `labels` column cheaply (0.42s) and only calls `select` when a row is actually fully masked, so the common case skips the rewrite. End to end drops from about 2.1s to about 1.3s. When rows do need dropping, the surviving set and the "Removed N out of M" message are identical to before (verified over randomized datasets).

### 2. Smarter num_proc

Spawning workers for this fast op on a small dataset costs more than it saves (`num_proc=4` measured slower than `num_proc=1`), and the CPU count heuristic caused Windows infinite spawn loops (#3211, #3397). This PR single processes datasets below a threshold while preserving the existing non fork guard and any explicit user provided `num_proc`.

### 3. Do not clobber vision collators

A trainer using `UnslothVisionDataCollator` had it silently replaced with `DataCollatorForSeq2Seq` at the end of `train_on_responses_only`, which drops image handling and breaks VLM training (`UnslothVisionDataCollator` is not a `DataCollatorForSeq2Seq` subclass, so the old guard did not protect it). It already supports `train_on_responses_only=True`, `instruction_part`, `response_part` on the collator itself. This PR detects vision/processor collators and keeps them, printing guidance to enable masking on the collator. Text collators (`DataCollatorForSeq2Seq`, `DataCollatorForLanguageModeling`) behave exactly as before.

### 4. Actionable truncation error

The most common report about this function is the opaque "All labels are -100" error, whose real cause is almost always truncation: `max_length` (default 1024) cut off the assistant response marker before masking could find it (#2364, #3198, #2771, #2900). When the dataset comes back overwhelmingly masked and the response marker is absent or the rows sit at `max_length`, this PR raises a clear message naming truncation and suggesting `SFTConfig(max_length = max_seq_length)`, instead of failing later with a zero loss. A few bad rows are still just dropped as before; the error only fires when the whole dataset is unusable.

### Tests and verification

- Masking output token exact unchanged: every assistant content token trained, zero user content tokens trained, across Llama 3/4, Gemma 2/3, Qwen 2.5/3/2-VL, Phi 4, Mistral, DeepSeek R1, Granite and more.
- Filter equivalence: new scan plus `select` drops the same rows as the old `filter` across randomized datasets, with the same message.
- num_proc: small dataset auto -> single process; explicit value honored; non fork guard preserved.
- Vision collator: real `UnslothVisionDataCollator` is not replaced and guidance is printed; text collators replaced exactly as before; no misfire.
- Truncation: tiny `max_length` raises with an actionable message; healthy data does not; partial truncation only drops bad rows.
- Existing suite: `tests/test_zoo_history_regressions_deep.py` passes (34 passed), including the `sft_prepare_dataset` column removal regression.

### Notes

- No new dependencies. `select_columns` and `Dataset.iter` are available in the pinned `datasets` floor.
- The `return_function=True` path and packing path are unaffected (both return or branch before the new code).
- Backward compatible: explicit `instruction_part`/`response_part`, the `_unsloth_input_part` path, IterableDataset, and dict eval datasets all behave as before.
