### PR TITLE
Grouped-GEMM MoE forward for transformers<5 ModuleList experts

### DIFF
--- a/tests/test_moe_grouped_modulelist_parity.py
+++ b/tests/test_moe_grouped_modulelist_parity.py
@@ -1,12 +1,9 @@
-"""Parity tests for the transformers<5 ModuleList grouped-GEMM MoE path
-(unsloth_zoo/temporary_patches/moe_grouped_modulelist.py).
+"""Parity tests for the transformers<5 ModuleList grouped-GEMM MoE path.
 
-transformers>=5 stacks its MoE experts, so no shipped model exercises the ModuleList path
-directly on new transformers. These tests instead build synthetic ModuleList SparseMoeBlocks
-that mirror the real block structure (Qwen3-MoE / Mixtral / OLMoE) and check that
-grouped_moe_forward matches a plain per-expert reference loop, in the default, cache and
-recompute modes, plus forward+backward. Runs anywhere torch._grouped_mm is supported
-(H100+/B200); otherwise skipped.
+transformers>=5 stacks its experts, so no shipped model exercises the ModuleList path there.
+These build synthetic ModuleList blocks (Qwen3-MoE / Mixtral / OLMoE) and check
+grouped_moe_forward against a per-expert reference loop across the default/cache/recompute
+modes, forward and backward. Skipped where torch._grouped_mm is unsupported.
 """
 import types
 import torch
@@ -146,8 +143,7 @@ def test_eligibility_and_shared_expert_bail():
 
 
 def _eligible_block(cls_name, spec):
-    """A block with a real bound forward (the reference loop) and no patch attrs set,
-    so enable_grouped_moe/disable_grouped_moe drive the whole lifecycle themselves."""
+    """A block with a real bound forward and no patch attrs, so enable/disable drive the lifecycle."""
     hidden, inter, E, top_k = 64, 128, 4, 2
     blk = type(cls_name, (nn.Module,), {})()
     blk.experts = nn.ModuleList(
@@ -205,10 +201,8 @@ def test_wrap_loader_idempotent_and_enables():
 
 
 def test_auto_enable_reevaluates_after_adapter_attaches():
-    """The loader re-runs auto_enable_grouped_moe after attaching a PEFT adapter, so a block
-    whose experts gained LoRA must be restored to the original loop, while a frozen
-    (attention-only) block stays on the grouped path. This is what makes wrapping the
-    from_pretrained leaf safe for the adapter-loading path."""
+    """Re-running auto_enable after a PEFT adapter attaches restores an expert-LoRA block to the
+    original loop while a frozen block stays grouped (what makes the loader leaf-wrap safe)."""
     spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
     model = nn.Module()
     model.layers = nn.ModuleList(
@@ -230,8 +224,7 @@ def test_auto_enable_reevaluates_after_adapter_attaches():
 
 
 def test_expert_compute_dtype_prefers_linear4bit_compute_dtype():
-    """The dtype guard must read Linear4bit.compute_dtype (the dtype bnb matmuls in), not the
-    quant_state dtype, so a compute_dtype != activation dtype config falls back correctly."""
+    """The dtype guard reads Linear4bit.compute_dtype (what bnb matmuls in), not quant_state dtype."""
     if not HAS_BNB:
         pytest.skip("bitsandbytes not available")
     import bitsandbytes as bnb
@@ -249,29 +242,25 @@ def test_expert_compute_dtype_prefers_linear4bit_compute_dtype():
 
 
 def test_experts_grouped_ready_checks_every_expert():
-    """The runtime guard must inspect every expert, not just experts[0]: a device / dtype /
-    unfrozen mismatch on ANY expert must make the block fall back to the original loop."""
+    """A device / dtype / unfrozen mismatch on ANY expert (not just experts[0]) must fall back."""
     spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
-    blk = _make_block("Qwen3MoeSparseMoeBlock", spec, 64, 128, 4, 2, True)  # frozen bf16 on DEV
+    blk = _make_block("Qwen3MoeSparseMoeBlock", spec, 64, 128, 4, 2, True)
     experts = blk.experts
     dev = getattr(experts[0], spec[0]).weight.device
     assert _experts_grouped_ready(experts, spec, dev, DTYPE)
 
-    # a mismatch on a LATER expert (index 1+) must still be caught
     assert not _experts_grouped_ready(experts, spec, torch.device("cpu"), DTYPE)   # device
     assert not _experts_grouped_ready(experts, spec, dev, torch.float32)           # compute dtype
-    getattr(experts[2], spec[1]).weight.requires_grad_(True)                        # unfrozen up_proj
+    getattr(experts[2], spec[1]).weight.requires_grad_(True)                        # unfrozen later expert
     assert not _experts_grouped_ready(experts, spec, dev, DTYPE)
 
 
 def test_frozen_only_contract_for_experts():
-    """The grouped path is frozen-only. Frozen bnb 4-bit experts are eligible; an unfrozen
-    (trainable) expert must bail to the original loop rather than silently receive no gradient.
-    (A real Params4bit stores uint8 data and can never require grad, so the reachable trainable
-    case is a plain bf16 expert - that is what the frozen requirement protects.)"""
+    """Frozen bnb 4-bit experts are eligible; an unfrozen expert bails (a real Params4bit is uint8
+    and can never require grad, so the reachable trainable case is a plain bf16 expert)."""
     spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
 
-    if HAS_BNB:  # frozen 4-bit experts stay eligible with the frozen requirement in place
+    if HAS_BNB:
         import bitsandbytes as bnb
         blk4 = type("Qwen3MoeSparseMoeBlock", (nn.Module,), {})()
         experts = nn.ModuleList()

--- a/tests/test_moe_grouped_modulelist_parity.py
+++ b/tests/test_moe_grouped_modulelist_parity.py
@@ -18,6 +18,7 @@ from unsloth_zoo.temporary_patches.moe_grouped_modulelist import (
     grouped_moe_forward,
     enable_grouped_moe,
     disable_grouped_moe,
+    auto_enable_grouped_moe,
     wrap_loader_for_grouped_moe,
     _block_is_eligible,
     _expert_compute_dtype,
@@ -201,6 +202,31 @@ def test_wrap_loader_idempotent_and_enables():
     model, tok = wrapped()
     assert tok == "tokenizer", "wrapper must pass the loader's return value through unchanged"
     assert model.layers[0].forward.__func__ is grouped_moe_forward, "grouped MoE not enabled on return"
+
+
+def test_auto_enable_reevaluates_after_adapter_attaches():
+    """The loader re-runs auto_enable_grouped_moe after attaching a PEFT adapter, so a block
+    whose experts gained LoRA must be restored to the original loop, while a frozen
+    (attention-only) block stays on the grouped path. This is what makes wrapping the
+    from_pretrained leaf safe for the adapter-loading path."""
+    spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
+    model = nn.Module()
+    model.layers = nn.ModuleList(
+        [_eligible_block("Qwen3MoeSparseMoeBlock", spec) for _ in range(2)]
+    )
+    frozen_blk, lora_blk = model.layers[0], model.layers[1]
+
+    assert enable_grouped_moe(model, verbose=False) == 2
+    assert frozen_blk.forward.__func__ is grouped_moe_forward
+    assert lora_blk.forward.__func__ is grouped_moe_forward
+
+    # Simulate an expert-targeting adapter attaching to the second block only.
+    getattr(lora_blk.experts[0], spec[0]).lora_A = nn.Identity()
+
+    auto_enable_grouped_moe(model)  # exactly what loader.py calls after patch_peft_model
+    assert lora_blk.forward.__func__ is not grouped_moe_forward, "expert-LoRA block must be restored"
+    assert getattr(lora_blk, "_unsloth_moe_spec", None) is None, "restored block must be cleaned up"
+    assert frozen_blk.forward.__func__ is grouped_moe_forward, "frozen block must stay on grouped path"
 
 
 def test_expert_compute_dtype_prefers_linear4bit_compute_dtype():

--- a/tests/test_moe_grouped_modulelist_parity.py
+++ b/tests/test_moe_grouped_modulelist_parity.py
@@ -8,6 +8,7 @@ grouped_moe_forward matches a plain per-expert reference loop, in the default, c
 recompute modes, plus forward+backward. Runs anywhere torch._grouped_mm is supported
 (H100+/B200); otherwise skipped.
 """
+import types
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -15,6 +16,9 @@ import pytest
 
 from unsloth_zoo.temporary_patches.moe_grouped_modulelist import (
     grouped_moe_forward,
+    enable_grouped_moe,
+    disable_grouped_moe,
+    wrap_loader_for_grouped_moe,
     _block_is_eligible,
     _grouped_mm_supported,
     _route_softmax_topk,
@@ -136,6 +140,65 @@ def test_eligibility_and_shared_expert_bail():
 
     unknown = _make_block("SomeUnknownMoeBlock", spec, 64, 128, 4, 2, True)
     assert _block_is_eligible(unknown) is None, "unknown block type must not be patched"
+
+
+def _eligible_block(cls_name, spec):
+    """A block with a real bound forward (the reference loop) and no patch attrs set,
+    so enable_grouped_moe/disable_grouped_moe drive the whole lifecycle themselves."""
+    hidden, inter, E, top_k = 64, 128, 4, 2
+    blk = type(cls_name, (nn.Module,), {})()
+    blk.experts = nn.ModuleList(
+        [_make_expert(hidden, inter, spec[0], spec[1], spec[2]) for _ in range(E)]
+    )
+    blk.gate = nn.Linear(hidden, E, bias=False).to(DEV, DTYPE)
+    blk.num_experts = E
+    blk.top_k = top_k
+    blk.norm_topk_prob = True
+    blk.eval()
+    blk.forward = types.MethodType(
+        lambda self, hs, _s=spec: _reference_forward(self, hs, _s)[0], blk
+    )
+    return blk
+
+
+def test_enable_disable_roundtrip():
+    spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
+    model = nn.Module()
+    model.layers = nn.ModuleList(
+        [_eligible_block("Qwen3MoeSparseMoeBlock", spec) for _ in range(2)]
+    )
+    x = torch.randn(1, 48, 64, device=DEV, dtype=DTYPE)
+    blk0 = model.layers[0]
+    expected = _reference_forward(blk0, x, spec)[0]
+
+    n = enable_grouped_moe(model, verbose=False)
+    assert n == 2, f"expected 2 patched blocks, got {n}"
+    assert blk0.forward.__func__ is grouped_moe_forward, "forward not swapped to grouped path"
+    out, _ = blk0.forward(x)  # patched path returns (final, router_logits)
+    assert _rel_l2(out, expected) < 1e-2
+
+    m = disable_grouped_moe(model)
+    assert m == 2, f"expected 2 restored blocks, got {m}"
+    assert getattr(blk0, "_unsloth_moe_spec", None) is None, "patch attrs not cleaned up"
+    assert blk0.forward.__func__ is not grouped_moe_forward, "original forward not restored"
+    assert _rel_l2(blk0.forward(x), expected) < 1e-2  # restored path returns the bare tensor
+
+
+def test_wrap_loader_idempotent_and_enables():
+    spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
+
+    def fake_from_pretrained(*args, **kwargs):
+        model = nn.Module()
+        model.layers = nn.ModuleList([_eligible_block("Qwen3MoeSparseMoeBlock", spec)])
+        return model, "tokenizer"
+
+    wrapped = wrap_loader_for_grouped_moe(fake_from_pretrained)
+    assert wrapped is not fake_from_pretrained, "loader was not wrapped"
+    assert wrap_loader_for_grouped_moe(wrapped) is wrapped, "double-wrapping must be a no-op"
+
+    model, tok = wrapped()
+    assert tok == "tokenizer", "wrapper must pass the loader's return value through unchanged"
+    assert model.layers[0].forward.__func__ is grouped_moe_forward, "grouped MoE not enabled on return"
 
 
 if __name__ == "__main__":

--- a/tests/test_moe_grouped_modulelist_parity.py
+++ b/tests/test_moe_grouped_modulelist_parity.py
@@ -22,8 +22,8 @@ from unsloth_zoo.temporary_patches.moe_grouped_modulelist import (
     wrap_loader_for_grouped_moe,
     _block_is_eligible,
     _expert_compute_dtype,
+    _experts_on_device,
     _grouped_mm_supported,
-    _route_softmax_topk,
     _BLOCK_SPECS,
     HAS_BNB,
 )
@@ -246,6 +246,45 @@ def test_expert_compute_dtype_prefers_linear4bit_compute_dtype():
     for name in spec[:3]:  # if compute_dtype is unset, fall back to the quant_state dtype
         getattr(ex, name).compute_dtype = None
     assert isinstance(_expert_compute_dtype([ex], spec), torch.dtype)
+
+
+def test_experts_on_device_gates_offload():
+    """Experts placed off the activation device (device_map / CPU offload) must make the block
+    fall back, since building stacks on the experts' device then calling grouped_mm across
+    devices would crash."""
+    spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
+    blk = _make_block("Qwen3MoeSparseMoeBlock", spec, 64, 128, 4, 2, True)  # experts on DEV
+    w_dev = getattr(blk.experts[0], spec[0]).weight.device
+    assert _experts_on_device(blk.experts, spec, w_dev)
+    assert not _experts_on_device(blk.experts, spec, torch.device("cpu"))
+
+
+def test_frozen_only_contract_for_experts():
+    """The grouped path is frozen-only. Frozen bnb 4-bit experts are eligible; an unfrozen
+    (trainable) expert must bail to the original loop rather than silently receive no gradient.
+    (A real Params4bit stores uint8 data and can never require grad, so the reachable trainable
+    case is a plain bf16 expert - that is what the frozen requirement protects.)"""
+    spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
+
+    if HAS_BNB:  # frozen 4-bit experts stay eligible with the frozen requirement in place
+        import bitsandbytes as bnb
+        blk4 = type("Qwen3MoeSparseMoeBlock", (nn.Module,), {})()
+        experts = nn.ModuleList()
+        for _ in range(2):
+            ex = nn.Module()
+            for name in spec[:3]:
+                lin = bnb.nn.Linear4bit(64, 64, bias=False, compute_dtype=torch.bfloat16, quant_type="nf4")
+                setattr(ex, name, lin.to(DEV))
+            experts.append(ex)
+        blk4.experts = experts
+        blk4.gate = nn.Linear(64, 2, bias=False).to(DEV, DTYPE)
+        blk4.num_experts, blk4.top_k, blk4.norm_topk_prob = 2, 2, True
+        assert _block_is_eligible(blk4) is not None, "frozen 4-bit experts should be eligible"
+
+    blk = _make_block("Qwen3MoeSparseMoeBlock", spec, 64, 128, 4, 2, True)  # frozen bf16 -> eligible
+    assert _block_is_eligible(blk) is not None
+    getattr(blk.experts[0], spec[0]).weight.requires_grad_(True)  # unfrozen expert (reachable for bf16)
+    assert _block_is_eligible(blk) is None, "trainable expert must bail to the original loop"
 
 
 if __name__ == "__main__":

--- a/tests/test_moe_grouped_modulelist_parity.py
+++ b/tests/test_moe_grouped_modulelist_parity.py
@@ -22,7 +22,7 @@ from unsloth_zoo.temporary_patches.moe_grouped_modulelist import (
     wrap_loader_for_grouped_moe,
     _block_is_eligible,
     _expert_compute_dtype,
-    _experts_on_device,
+    _experts_grouped_ready,
     _grouped_mm_supported,
     _BLOCK_SPECS,
     HAS_BNB,
@@ -248,15 +248,20 @@ def test_expert_compute_dtype_prefers_linear4bit_compute_dtype():
     assert isinstance(_expert_compute_dtype([ex], spec), torch.dtype)
 
 
-def test_experts_on_device_gates_offload():
-    """Experts placed off the activation device (device_map / CPU offload) must make the block
-    fall back, since building stacks on the experts' device then calling grouped_mm across
-    devices would crash."""
+def test_experts_grouped_ready_checks_every_expert():
+    """The runtime guard must inspect every expert, not just experts[0]: a device / dtype /
+    unfrozen mismatch on ANY expert must make the block fall back to the original loop."""
     spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
-    blk = _make_block("Qwen3MoeSparseMoeBlock", spec, 64, 128, 4, 2, True)  # experts on DEV
-    w_dev = getattr(blk.experts[0], spec[0]).weight.device
-    assert _experts_on_device(blk.experts, spec, w_dev)
-    assert not _experts_on_device(blk.experts, spec, torch.device("cpu"))
+    blk = _make_block("Qwen3MoeSparseMoeBlock", spec, 64, 128, 4, 2, True)  # frozen bf16 on DEV
+    experts = blk.experts
+    dev = getattr(experts[0], spec[0]).weight.device
+    assert _experts_grouped_ready(experts, spec, dev, DTYPE)
+
+    # a mismatch on a LATER expert (index 1+) must still be caught
+    assert not _experts_grouped_ready(experts, spec, torch.device("cpu"), DTYPE)   # device
+    assert not _experts_grouped_ready(experts, spec, dev, torch.float32)           # compute dtype
+    getattr(experts[2], spec[1]).weight.requires_grad_(True)                        # unfrozen up_proj
+    assert not _experts_grouped_ready(experts, spec, dev, DTYPE)
 
 
 def test_frozen_only_contract_for_experts():

--- a/tests/test_moe_grouped_modulelist_parity.py
+++ b/tests/test_moe_grouped_modulelist_parity.py
@@ -1,0 +1,143 @@
+"""Parity tests for the transformers<5 ModuleList grouped-GEMM MoE path
+(unsloth_zoo/temporary_patches/moe_grouped_modulelist.py).
+
+transformers>=5 stacks its MoE experts, so no shipped model exercises the ModuleList path
+directly on new transformers. These tests instead build synthetic ModuleList SparseMoeBlocks
+that mirror the real block structure (Qwen3-MoE / Mixtral / OLMoE) and check that
+grouped_moe_forward matches a plain per-expert reference loop, in the default, cache and
+recompute modes, plus forward+backward. Runs anywhere torch._grouped_mm is supported
+(H100+/B200); otherwise skipped.
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import pytest
+
+from unsloth_zoo.temporary_patches.moe_grouped_modulelist import (
+    grouped_moe_forward,
+    _block_is_eligible,
+    _grouped_mm_supported,
+    _route_softmax_topk,
+    _BLOCK_SPECS,
+)
+
+DEV = "cuda"
+DTYPE = torch.bfloat16
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and _grouped_mm_supported()),
+    reason="torch._grouped_mm unsupported on this device",
+)
+
+
+def _make_expert(hidden, inter, gname, uname, dname):
+    ex = nn.Module()
+    for name, lin in (
+        (gname, nn.Linear(hidden, inter, bias=False)),
+        (uname, nn.Linear(hidden, inter, bias=False)),
+        (dname, nn.Linear(inter, hidden, bias=False)),
+    ):
+        lin.weight.requires_grad_(False)  # frozen base experts (the grouped path's precondition)
+        setattr(ex, name, lin.to(DEV, DTYPE))
+    ex.act_fn = F.silu
+    return ex
+
+
+def _make_block(cls_name, spec, hidden, inter, num_experts, top_k, norm_topk_prob):
+    gname, uname, dname, _ = spec
+    blk = type(cls_name, (nn.Module,), {})()
+    blk.experts = nn.ModuleList(
+        [_make_expert(hidden, inter, gname, uname, dname) for _ in range(num_experts)]
+    )
+    blk.gate = nn.Linear(hidden, num_experts, bias=False).to(DEV, DTYPE)
+    blk.num_experts = num_experts
+    blk.top_k = top_k
+    blk.norm_topk_prob = norm_topk_prob
+    blk.eval()
+    blk._unsloth_moe_spec = spec
+    blk._orig_moe_forward = lambda hs: _reference_forward(blk, hs, spec)
+    return blk
+
+
+def _reference_forward(blk, hidden_states, spec):
+    """Plain per-expert loop matching grouped_moe_forward's math (fp32 combine)."""
+    gname, uname, dname, router = spec
+    is_3d = hidden_states.dim() == 3
+    if is_3d:
+        b, s, h = hidden_states.shape
+        hs = hidden_states.reshape(-1, h)
+    else:
+        hs = hidden_states
+        h = hs.shape[-1]
+    logits = blk.gate(hs)
+    rw, sel = router(blk, logits, blk.top_k)
+    rw = rw.to(hs.dtype)
+    T = hs.shape[0]
+    final = torch.zeros((T, h), dtype=torch.float32, device=hs.device)
+    for e, ex in enumerate(blk.experts):
+        pos = (sel == e).nonzero(as_tuple=False)
+        if pos.numel() == 0:
+            continue
+        tok, slot = pos[:, 0], pos[:, 1]
+        xe = hs[tok]
+        inter = F.silu(getattr(ex, gname)(xe)) * getattr(ex, uname)(xe)
+        out = getattr(ex, dname)(inter) * rw[tok, slot].unsqueeze(-1)
+        final.index_add_(0, tok, out.float())
+    final = final.to(hs.dtype)
+    return (final.reshape(b, s, h) if is_3d else final), logits
+
+
+def _rel_l2(a, b):
+    return (a.float() - b.float()).norm().item() / (b.float().norm().item() + 1e-12)
+
+
+@pytest.mark.parametrize("cls_name,spec", list(_BLOCK_SPECS.items()))
+@pytest.mark.parametrize("norm_topk_prob", [True, False])
+def test_forward_parity(cls_name, spec, norm_topk_prob):
+    torch.manual_seed(0)
+    hidden, inter, E, top_k, T = 128, 256, 8, 2, 96
+    blk = _make_block(cls_name, spec, hidden, inter, E, top_k, norm_topk_prob)
+    x = torch.randn(1, T, hidden, device=DEV, dtype=DTYPE)
+
+    ref, _ = _reference_forward(blk, x, spec)
+    for mode in ("default", "cache", "recompute"):
+        blk._moe_cache = mode == "cache"
+        blk._moe_recompute = mode == "recompute"
+        for attr in ("_cached_gate_up", "_cached_down"):
+            if hasattr(blk, attr):
+                delattr(blk, attr)
+        out, _ = grouped_moe_forward(blk, x)
+        rel = _rel_l2(out, ref)
+        assert out.shape == x.shape, f"{cls_name}/{mode}: shape {out.shape} != {x.shape}"
+        assert rel < 1e-2, f"{cls_name}/{mode}: relL2 {rel:.2e} exceeds bf16 noise floor"
+
+
+@pytest.mark.parametrize("cls_name,spec", list(_BLOCK_SPECS.items()))
+def test_backward_parity(cls_name, spec):
+    torch.manual_seed(0)
+    hidden, inter, E, top_k, T = 128, 256, 8, 2, 64
+    blk = _make_block(cls_name, spec, hidden, inter, E, top_k, True)
+
+    x1 = torch.randn(1, T, hidden, device=DEV, dtype=DTYPE, requires_grad=True)
+    x2 = x1.detach().clone().requires_grad_(True)
+    (_reference_forward(blk, x1, spec)[0]).float().pow(2).sum().backward()
+    blk._moe_recompute = True  # exercise the recompute autograd Function's dX
+    (grouped_moe_forward(blk, x2)[0]).float().pow(2).sum().backward()
+    rel = _rel_l2(x2.grad, x1.grad)
+    assert rel < 1e-2, f"{cls_name}: input-grad relL2 {rel:.2e} exceeds bf16 noise floor"
+
+
+def test_eligibility_and_shared_expert_bail():
+    spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
+    blk = _make_block("Qwen3MoeSparseMoeBlock", spec, 64, 128, 4, 2, True)
+    assert _block_is_eligible(blk) is not None, "eligible ModuleList block not recognised"
+
+    blk.shared_expert = nn.Linear(64, 64, bias=False).to(DEV, DTYPE)  # routed grouping cannot cover it
+    assert _block_is_eligible(blk) is None, "block with a shared expert must bail to the original loop"
+
+    unknown = _make_block("SomeUnknownMoeBlock", spec, 64, 128, 4, 2, True)
+    assert _block_is_eligible(unknown) is None, "unknown block type must not be patched"
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/test_moe_grouped_modulelist_parity.py
+++ b/tests/test_moe_grouped_modulelist_parity.py
@@ -20,9 +20,11 @@ from unsloth_zoo.temporary_patches.moe_grouped_modulelist import (
     disable_grouped_moe,
     wrap_loader_for_grouped_moe,
     _block_is_eligible,
+    _expert_compute_dtype,
     _grouped_mm_supported,
     _route_softmax_topk,
     _BLOCK_SPECS,
+    HAS_BNB,
 )
 
 DEV = "cuda"
@@ -199,6 +201,25 @@ def test_wrap_loader_idempotent_and_enables():
     model, tok = wrapped()
     assert tok == "tokenizer", "wrapper must pass the loader's return value through unchanged"
     assert model.layers[0].forward.__func__ is grouped_moe_forward, "grouped MoE not enabled on return"
+
+
+def test_expert_compute_dtype_prefers_linear4bit_compute_dtype():
+    """The dtype guard must read Linear4bit.compute_dtype (the dtype bnb matmuls in), not the
+    quant_state dtype, so a compute_dtype != activation dtype config falls back correctly."""
+    if not HAS_BNB:
+        pytest.skip("bitsandbytes not available")
+    import bitsandbytes as bnb
+
+    spec = _BLOCK_SPECS["Qwen3MoeSparseMoeBlock"]
+    ex = nn.Module()
+    for name in spec[:3]:
+        lin = bnb.nn.Linear4bit(64, 64, bias=False, compute_dtype=torch.bfloat16, quant_type="nf4")
+        setattr(ex, name, lin.to(DEV))  # .to(cuda) quantizes -> weight becomes Params4bit
+    assert _expert_compute_dtype([ex], spec) == torch.bfloat16
+
+    for name in spec[:3]:  # if compute_dtype is unset, fall back to the quant_state dtype
+        getattr(ex, name).compute_dtype = None
+    assert isinstance(_expert_compute_dtype([ex], spec), torch.dtype)
 
 
 if __name__ == "__main__":

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -49,6 +49,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.ministral",
     "unsloth_zoo.temporary_patches.misc",
     "unsloth_zoo.temporary_patches.moe_bnb",
+    "unsloth_zoo.temporary_patches.moe_grouped_modulelist",
     "unsloth_zoo.temporary_patches.moe_utils",
     "unsloth_zoo.temporary_patches.moe_utils_bnb4bit",
     "unsloth_zoo.temporary_patches.moe_utils_fp8",

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -36,5 +36,6 @@ from .ministral import *
 from .mxfp4 import *
 from .bitsandbytes import *
 from .moe_utils_bnb4bit import *
+from .moe_grouped_modulelist import *
 from .moe_utils_fp8 import *
 from .flex_attention_bwd import *

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -189,10 +189,17 @@ def _experts_have_lora(experts, spec) -> bool:
 
 
 def _expert_compute_dtype(experts, spec):
-    """The dtype the frozen expert matmul runs in: bnb uses the quant compute dtype,
-    a plain frozen Linear uses its weight dtype. Used to keep numerics bnb-identical."""
-    w = getattr(getattr(experts[0], spec[0], None), "weight", None)
+    """The dtype the frozen expert matmul runs in. bitsandbytes casts inputs to the
+    Linear4bit compute_dtype for the matmul, so that is what our dequant + grouped_mm must
+    match; we read it directly and fall back to the quant_state dtype only if compute_dtype
+    is unset. A plain frozen Linear uses its weight dtype. Used to keep numerics
+    bnb-identical and to decide when to fall back to the original loop."""
+    lin = getattr(experts[0], spec[0], None)
+    w = getattr(lin, "weight", None)
     if HAS_BNB and isinstance(w, Params4bit):
+        compute_dtype = getattr(lin, "compute_dtype", None)
+        if compute_dtype is not None:
+            return compute_dtype
         return getattr(getattr(w, "quant_state", None), "dtype", torch.bfloat16)
     return getattr(w, "dtype", torch.bfloat16)
 

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -204,15 +204,25 @@ def _expert_compute_dtype(experts, spec):
     return getattr(w, "dtype", torch.bfloat16)
 
 
+def _experts_on_device(experts, spec, device) -> bool:
+    """True if the experts' weights live on `device`. A device_map / CPU offload can send a MoE
+    block's weights elsewhere while activations arrive on CUDA; building the stacks on the
+    experts' device and calling grouped_mm across devices would crash, so we fall back instead."""
+    w = getattr(getattr(experts[0], spec[0], None), "weight", None)
+    return getattr(w, "device", device) == device
+
+
 def grouped_moe_forward(self, hidden_states: torch.Tensor):
     spec = self._unsloth_moe_spec
     experts = self.experts
     # Fall back to the exact original loop unless this is the frozen-expert CUDA path on a
-    # grouped_mm-supported dtype that matches the experts' compute dtype (so CPU/offload,
-    # LoRA-on-experts, fp32, or a bnb compute_dtype != activation dtype stay bit-identical).
+    # grouped_mm-supported dtype that matches the experts' compute dtype and device (so CPU/
+    # offload, LoRA-on-experts, fp32, a bnb compute_dtype != activation dtype, or experts placed
+    # on another device stay bit-identical / crash-free).
     if (not hidden_states.is_cuda) or _experts_have_lora(experts, spec) \
             or hidden_states.dtype not in (torch.bfloat16, torch.float16) \
-            or _expert_compute_dtype(experts, spec) != hidden_states.dtype:
+            or _expert_compute_dtype(experts, spec) != hidden_states.dtype \
+            or not _experts_on_device(experts, spec, hidden_states.device):
         return self._orig_moe_forward(hidden_states)
     is_3d = hidden_states.dim() == 3
     if is_3d:
@@ -294,7 +304,11 @@ def _block_is_eligible(block):
                 return None
             if getattr(lin, "lora_A", None) is not None or getattr(lin, "base_layer", None) is not None:
                 return None
-            is_4bit = HAS_BNB and isinstance(w, Params4bit) and getattr(w, "quant_state", None) is not None
+            # The grouped path is frozen-only: _expert_weight reads w.data and _GroupedFrozenMM
+            # returns dX only, so a trainable expert weight would silently get no gradient. Require
+            # frozen for both 4-bit and plain experts; otherwise run the original loop.
+            is_4bit = (HAS_BNB and isinstance(w, Params4bit)
+                       and getattr(w, "quant_state", None) is not None and not w.requires_grad)
             # fp32 omitted: torch._grouped_mm targets low-precision CUDA inputs.
             is_plain_frozen = (not w.requires_grad) and w.dtype in (torch.bfloat16, torch.float16)
             if not (is_4bit or is_plain_frozen):

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -177,24 +177,10 @@ def _grouped_expert_gemm(x, offsets, weight_fn, recompute):
     return _grouped_mm_fix(x, weight_fn(), offsets)
 
 
-def _experts_have_lora(experts, spec) -> bool:
-    """True if any expert projection gained LoRA / a PEFT base_layer after patching
-    (so the frozen grouped path no longer holds). Cheap next to the per-call dequant."""
-    for ex in experts:
-        for name in spec[:3]:
-            lin = getattr(ex, name, None)
-            if getattr(lin, "lora_A", None) is not None or getattr(lin, "base_layer", None) is not None:
-                return True
-    return False
-
-
-def _expert_compute_dtype(experts, spec):
-    """The dtype the frozen expert matmul runs in. bitsandbytes casts inputs to the
-    Linear4bit compute_dtype for the matmul, so that is what our dequant + grouped_mm must
-    match; we read it directly and fall back to the quant_state dtype only if compute_dtype
-    is unset. A plain frozen Linear uses its weight dtype. Used to keep numerics
-    bnb-identical and to decide when to fall back to the original loop."""
-    lin = getattr(experts[0], spec[0], None)
+def _lin_compute_dtype(lin):
+    """The dtype a single expert projection matmuls in: bitsandbytes casts inputs to the
+    Linear4bit compute_dtype, so that is what our dequant + grouped_mm must match (fall back to
+    the quant_state dtype if unset); a plain frozen Linear uses its weight dtype."""
     w = getattr(lin, "weight", None)
     if HAS_BNB and isinstance(w, Params4bit):
         compute_dtype = getattr(lin, "compute_dtype", None)
@@ -204,25 +190,45 @@ def _expert_compute_dtype(experts, spec):
     return getattr(w, "dtype", torch.bfloat16)
 
 
-def _experts_on_device(experts, spec, device) -> bool:
-    """True if the experts' weights live on `device`. A device_map / CPU offload can send a MoE
-    block's weights elsewhere while activations arrive on CUDA; building the stacks on the
-    experts' device and calling grouped_mm across devices would crash, so we fall back instead."""
-    w = getattr(getattr(experts[0], spec[0], None), "weight", None)
-    return getattr(w, "device", device) == device
+def _expert_compute_dtype(experts, spec):
+    """The compute dtype of the first expert's gate projection (see _lin_compute_dtype)."""
+    return _lin_compute_dtype(getattr(experts[0], spec[0], None))
+
+
+def _experts_grouped_ready(experts, spec, device, dtype) -> bool:
+    """Runtime re-check across EVERY expert projection (state can change after
+    enable_grouped_moe, and the stacks are built from all experts, so sampling experts[0] is not
+    enough for heterogeneous device_map / offload / partially-unfrozen / mixed-dtype blocks).
+    Each routed projection must be present, LoRA-free, frozen, on `device`, and matmul in `dtype`;
+    otherwise we fall back to the original loop (bit-identical / crash-free)."""
+    for ex in experts:
+        for name in spec[:3]:
+            lin = getattr(ex, name, None)
+            w = getattr(lin, "weight", None)
+            if w is None:
+                return False
+            if getattr(lin, "lora_A", None) is not None or getattr(lin, "base_layer", None) is not None:
+                return False
+            if w.requires_grad:                                  # unfrozen -> grads would be dropped
+                return False
+            if getattr(w, "device", device) != device:           # offloaded / other device
+                return False
+            if _lin_compute_dtype(lin) != dtype:                 # different compute dtype
+                return False
+    return True
 
 
 def grouped_moe_forward(self, hidden_states: torch.Tensor):
     spec = self._unsloth_moe_spec
     experts = self.experts
     # Fall back to the exact original loop unless this is the frozen-expert CUDA path on a
-    # grouped_mm-supported dtype that matches the experts' compute dtype and device (so CPU/
-    # offload, LoRA-on-experts, fp32, a bnb compute_dtype != activation dtype, or experts placed
-    # on another device stay bit-identical / crash-free).
-    if (not hidden_states.is_cuda) or _experts_have_lora(experts, spec) \
+    # grouped_mm-supported dtype, with every expert LoRA-free, frozen, on the activation device,
+    # and computing in the activation dtype (so CPU/offload, LoRA-on-experts, fp32, a bnb
+    # compute_dtype != activation dtype, unfrozen experts, or experts on another device stay
+    # bit-identical / crash-free).
+    if (not hidden_states.is_cuda) \
             or hidden_states.dtype not in (torch.bfloat16, torch.float16) \
-            or _expert_compute_dtype(experts, spec) != hidden_states.dtype \
-            or not _experts_on_device(experts, spec, hidden_states.device):
+            or not _experts_grouped_ready(experts, spec, hidden_states.device, hidden_states.dtype):
         return self._orig_moe_forward(hidden_states)
     is_3d = hidden_states.dim() == 3
     if is_3d:

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -126,6 +126,11 @@ def _route_softmax_topk(self, router_logits, top_k):
 _BLOCK_SPECS = {
     "Qwen3MoeSparseMoeBlock": ("gate_proj", "up_proj", "down_proj", _route_softmax_topk),
     "MixtralSparseMoeBlock":  ("w1",        "w3",      "w2",        _route_softmax_topk),
+    # OLMoE has the identical routed structure to Qwen3-MoE (gate/up/down SwiGLU experts,
+    # softmax(fp32) -> top_k -> optional renorm via norm_topk_prob) and no shared expert, so
+    # the same spec/router applies. Verified against the reference loop in
+    # tests/test_moe_grouped_modulelist_parity.py.
+    "OlmoeSparseMoeBlock":    ("gate_proj", "up_proj", "down_proj", _route_softmax_topk),
 }
 
 

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -1,0 +1,342 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Grouped-GEMM MoE forward for transformers < 5 (the nn.ModuleList expert layout).
+
+On transformers < 5 a MoE block (Qwen3MoeSparseMoeBlock, MixtralSparseMoeBlock, ...)
+keeps its experts as a nn.ModuleList of per-expert MLPs and loops over them in Python,
+launching O(num_experts) tiny matmuls + a data-dependent sync per layer and never
+calling torch._grouped_mm. The v5 stacked layout already uses a grouped path; this
+brings the same recipe to the < 5 ModuleList layout:
+
+    route -> sort tokens by expert -> grouped_mm (gate_up) -> act(gate)*up
+    -> grouped_mm (down) -> router-weight scale -> float32 scatter-add
+
+Experts stay 4-bit; the bf16 dequant stack is rebuilt in backward (recompute) or held
+resident (cache). Same bf16 math as the loop, so accuracy is neutral.
+
+Activates only when: a known block class with no shared expert, frozen bnb-4bit (or
+plain-frozen) ModuleList experts, no LoRA on the experts, and torch._grouped_mm is
+supported (CUDA). Otherwise the original forward runs unchanged (so v5, non-bnb,
+LoRA-on-experts and Mac/MLX/AMD/Intel/CPU are no-ops).
+
+Patches the live instance forward after the model is built, so it wins over the
+compiled-cache class patch. Disable with UNSLOTH_MOE_GROUPED=0. Force backward-recompute
+with UNSLOTH_MOE_GROUPED_RECOMPUTE=1 (auto-on when gradient checkpointing is off); hold
+the dequantized experts resident with UNSLOTH_MOE_GROUPED_CACHE=1 (big-GPU opt-in).
+"""
+from __future__ import annotations
+import os
+import types
+import torch
+import torch.nn.functional as F
+
+__all__ = [
+    "enable_grouped_moe",
+    "disable_grouped_moe",
+    "auto_enable_grouped_moe",
+    "wrap_loader_for_grouped_moe",
+]
+
+try:
+    import bitsandbytes as bnb
+    from bitsandbytes.nn import Params4bit
+    HAS_BNB = True
+except Exception:
+    HAS_BNB = False
+    bnb = None
+    Params4bit = None
+
+_GROUPED_MM_SUPPORTED = None
+
+
+def _grouped_mm_supported() -> bool:
+    """Cached probe: reuse unsloth's check, else a local tiny torch._grouped_mm call."""
+    global _GROUPED_MM_SUPPORTED
+    if _GROUPED_MM_SUPPORTED is not None:
+        return _GROUPED_MM_SUPPORTED
+    ok = False
+    try:
+        from .moe_utils import _check_torch_grouped_mm_supported
+        ok = bool(_check_torch_grouped_mm_supported())
+    except Exception:
+        try:
+            if hasattr(torch, "_grouped_mm") and torch.cuda.is_available():
+                x = torch.ones((1, 8), device="cuda", dtype=torch.bfloat16)
+                w = torch.ones((1, 8, 8), device="cuda", dtype=torch.bfloat16)
+                torch._grouped_mm(x, w, offs=torch.tensor([1], device="cuda", dtype=torch.int32))
+                ok = True
+        except Exception:
+            ok = False
+    _GROUPED_MM_SUPPORTED = ok
+    return ok
+
+
+def _grouped_mm_fix(x: torch.Tensor, w: torch.Tensor, offs: torch.Tensor) -> torch.Tensor:
+    """torch._grouped_mm with a contiguity guard + per-group matmul fallback for the
+    rare 16-byte stride error (mirrors moe_utils._grouped_mm_with_backward_fix)."""
+    x = x.contiguous()
+    w = w.contiguous()
+    try:
+        return torch._grouped_mm(x, w, offs=offs)
+    except RuntimeError as e:
+        if "strides should be multiple of 16 bytes" not in str(e):
+            raise
+        outs, start = [], 0
+        for i, end in enumerate(offs.detach().cpu().tolist()):
+            if start < end:
+                outs.append(torch.matmul(x[start:end], w[i]))
+            start = end
+        return torch.cat(outs, 0) if outs else x.new_empty((0, w.shape[-1]))
+
+
+def _expert_weight(lin, dtype):
+    """Logical 2D weight [out, in], dequantized if 4-bit."""
+    w = lin.weight
+    if HAS_BNB and isinstance(w, Params4bit):
+        return bnb.functional.dequantize_4bit(w.data, w.quant_state).to(dtype)
+    return w.to(dtype)
+
+
+def _route_softmax_topk(self, router_logits, top_k):
+    """softmax(fp32) -> top_k -> optional renorm. Covers Qwen3-MoE / Mixtral (Mixtral
+    has no norm_topk_prob attr -> default True == its routing_weights /= sum)."""
+    rw = F.softmax(router_logits, dim=1, dtype=torch.float32)
+    rw, sel = torch.topk(rw, top_k, dim=-1)
+    if getattr(self, "norm_topk_prob", True):
+        rw = rw / rw.sum(dim=-1, keepdim=True)
+    return rw, sel
+
+
+# block class name -> (gate, up, down attr names, router fn). Add a row per model.
+# Qwen2MoeSparseMoeBlock is intentionally absent: its shared expert is not part of the
+# routed grouped GEMM, so it is skipped (see the shared-expert bail in _block_is_eligible).
+_BLOCK_SPECS = {
+    "Qwen3MoeSparseMoeBlock": ("gate_proj", "up_proj", "down_proj", _route_softmax_topk),
+    "MixtralSparseMoeBlock":  ("w1",        "w3",      "w2",        _route_softmax_topk),
+}
+
+
+def _build_gate_up_stack(experts, spec, dtype):
+    """[E, hidden, 2*inter]: per expert cat(gate^T, up^T)."""
+    g_name, u_name = spec[0], spec[1]
+    rows = []
+    for ex in experts:
+        g = _expert_weight(getattr(ex, g_name), dtype)
+        u = _expert_weight(getattr(ex, u_name), dtype)
+        rows.append(torch.cat((g, u), dim=0).t())
+    return torch.stack(rows, 0).contiguous()
+
+
+def _build_down_stack(experts, spec, dtype):
+    """[E, inter, hidden]: per expert down^T."""
+    d_name = spec[2]
+    return torch.stack([_expert_weight(getattr(ex, d_name), dtype).t() for ex in experts], 0).contiguous()
+
+
+class _GroupedFrozenMM(torch.autograd.Function):
+    """grouped_mm(x, W) for FROZEN experts. W is rebuilt by weight_fn in backward
+    instead of saved, so the bf16 dequant stack is not held across the step."""
+    @staticmethod
+    def forward(ctx, x, offsets, weight_fn):
+        ctx.weight_fn = weight_fn
+        ctx.save_for_backward(x, offsets)
+        with torch.no_grad():
+            out = _grouped_mm_fix(x, weight_fn(), offsets)
+        return out
+
+    @staticmethod
+    def backward(ctx, g):
+        x, offsets = ctx.saved_tensors
+        with torch.no_grad():
+            Wt = ctx.weight_fn().transpose(1, 2).contiguous()
+            dX = _grouped_mm_fix(g.contiguous(), Wt, offsets)
+        return dX, None, None
+
+
+def _grouped_expert_gemm(x, offsets, weight_fn, recompute):
+    if recompute:
+        return _GroupedFrozenMM.apply(x, offsets, weight_fn)
+    return _grouped_mm_fix(x, weight_fn(), offsets)
+
+
+def grouped_moe_forward(self, hidden_states: torch.Tensor):
+    spec = self._unsloth_moe_spec
+    is_3d = hidden_states.dim() == 3
+    if is_3d:
+        bsz, seqlen, hidden_dim = hidden_states.shape
+    else:
+        seqlen, hidden_dim = hidden_states.shape
+        bsz = 1
+    hidden_states = hidden_states.view(-1, hidden_dim)
+    T = hidden_states.shape[0]
+    num_experts = self.num_experts
+    top_k = self.top_k
+    dev = hidden_states.device
+    dtype = hidden_states.dtype
+    experts = self.experts
+
+    router_logits = self.gate(hidden_states)
+    rw, sel = spec[3](self, router_logits, top_k)   # exact per-model router
+    rw = rw.to(dtype)
+
+    flat_e = sel.reshape(-1)
+    flat_w = rw.reshape(-1)
+    tok_of_pair = torch.arange(T, device=dev).repeat_interleave(top_k)
+    counts = torch.bincount(flat_e, minlength=num_experts)
+    order = torch.argsort(flat_e, stable=True)
+    sorted_tok = tok_of_pair[order]
+    sorted_w = flat_w[order]
+    offsets = torch.cumsum(counts, dim=0).to(torch.int32)
+    permuted = hidden_states[sorted_tok]
+
+    recompute = getattr(self, "_moe_recompute", False)
+    cache = getattr(self, "_moe_cache", False)
+    act = getattr(experts[0], "act_fn", None) or F.silu
+
+    if cache:
+        if getattr(self, "_cached_gate_up", None) is None:
+            with torch.no_grad():
+                self._cached_gate_up = _build_gate_up_stack(experts, spec, dtype)
+                self._cached_down = _build_down_stack(experts, spec, dtype)
+        gate_up = _grouped_mm_fix(permuted, self._cached_gate_up, offsets)
+        gate, up = gate_up.chunk(2, dim=-1)
+        inter = act(gate) * up
+        down = _grouped_mm_fix(inter, self._cached_down, offsets)
+    else:
+        gate_up = _grouped_expert_gemm(permuted, offsets, lambda: _build_gate_up_stack(experts, spec, dtype), recompute)
+        gate, up = gate_up.chunk(2, dim=-1)
+        inter = act(gate) * up
+        down = _grouped_expert_gemm(inter, offsets, lambda: _build_down_stack(experts, spec, dtype), recompute)
+
+    down = down * sorted_w.unsqueeze(-1)
+    final = torch.zeros((T, hidden_dim), dtype=torch.float32, device=dev)
+    final.index_add_(0, sorted_tok, down.to(torch.float32))
+    final = final.to(dtype)
+    if is_3d:
+        final = final.reshape(bsz, seqlen, hidden_dim)
+    return final, router_logits
+
+
+def _block_is_eligible(block):
+    """Return the spec if this is a frozen ModuleList MoE we can speed up, else None."""
+    spec = _BLOCK_SPECS.get(type(block).__name__)
+    if spec is None:
+        return None
+    experts = getattr(block, "experts", None)
+    if experts is None or not hasattr(experts, "__len__") or len(experts) == 0:
+        return None
+    if not hasattr(block, "gate") or not hasattr(block, "num_experts") or not hasattr(block, "top_k"):
+        return None
+    for attr in ("shared_expert", "shared_experts", "shared_expert_gate"):  # not routed -> bail
+        if getattr(block, attr, None) is not None:
+            return None
+    g_name, u_name, d_name, _ = spec
+    e0 = experts[0]
+    for name in (g_name, u_name, d_name):
+        lin = getattr(e0, name, None)
+        w = getattr(lin, "weight", None)
+        if w is None:
+            return None
+        if getattr(lin, "lora_A", None) is not None or hasattr(lin, "base_layer"):  # LoRA on experts -> defer
+            return None
+        is_4bit = HAS_BNB and isinstance(w, Params4bit) and getattr(w, "quant_state", None) is not None
+        is_plain_frozen = (not w.requires_grad) and w.dtype in (torch.bfloat16, torch.float16, torch.float32)
+        if not (is_4bit or is_plain_frozen):
+            return None
+    return spec
+
+
+def _uses_grad_checkpointing(model) -> bool:
+    if getattr(model, "is_gradient_checkpointing", False):
+        return True
+    return any(getattr(m, "gradient_checkpointing", False) for m in model.modules())
+
+
+def _restore_block(module):
+    if hasattr(module, "_orig_moe_forward"):
+        module.forward = module._orig_moe_forward
+        for attr in ("_orig_moe_forward", "_unsloth_moe_spec", "_moe_recompute",
+                     "_moe_cache", "_cached_gate_up", "_cached_down"):
+            if hasattr(module, attr):
+                delattr(module, attr)
+        return True
+    return False
+
+
+def enable_grouped_moe(model, recompute=None, cache=None, verbose=True):
+    """Patch eligible frozen ModuleList MoE blocks to the grouped forward. Re-entrant
+    (a block that became ineligible, e.g. LoRA was added, is restored). Safe no-op when
+    torch._grouped_mm is unsupported or no eligible block exists. Returns #patched."""
+    if os.environ.get("UNSLOTH_MOE_GROUPED", "1") == "0":
+        for module in model.modules():
+            _restore_block(module)
+        return 0
+    if not _grouped_mm_supported():
+        return 0
+    if recompute is None:
+        env = os.environ.get("UNSLOTH_MOE_GROUPED_RECOMPUTE")
+        recompute = (env == "1") if env is not None else (not _uses_grad_checkpointing(model))
+    if cache is None:
+        cache = os.environ.get("UNSLOTH_MOE_GROUPED_CACHE") == "1"
+    n = 0
+    for module in model.modules():
+        spec = _block_is_eligible(module)
+        if spec is None:
+            _restore_block(module)
+            continue
+        if not hasattr(module, "_orig_moe_forward"):
+            module._orig_moe_forward = module.forward
+        module._unsloth_moe_spec = spec
+        module._moe_recompute = recompute
+        module._moe_cache = cache
+        module.forward = types.MethodType(grouped_moe_forward, module)
+        n += 1
+    if verbose and n:
+        print(f"Unsloth: Grouped MoE enabled on {n} block(s) (recompute={recompute}, cache={cache}).", flush=True)
+    return n
+
+
+def disable_grouped_moe(model):
+    return sum(_restore_block(m) for m in list(model.modules()))
+
+
+def auto_enable_grouped_moe(model):
+    """Loader entry point; fully guarded so it never raises into model loading."""
+    try:
+        if model is not None and hasattr(model, "modules"):
+            enable_grouped_moe(model, verbose=True)
+    except Exception:
+        pass
+
+
+def wrap_loader_for_grouped_moe(func):
+    """Wrap a from_pretrained / get_peft_model leaf (returns model or (model, tokenizer))
+    so grouped MoE is enabled before it returns. Idempotent."""
+    if func is None or getattr(func, "_unsloth_grouped_moe_wrapped", False):
+        return func
+    import functools
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        try:
+            auto_enable_grouped_moe(result[0] if isinstance(result, tuple) and result else result)
+        except Exception:
+            pass
+        return result
+
+    wrapper._unsloth_grouped_moe_wrapped = True
+    return wrapper

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -183,12 +183,24 @@ def _experts_have_lora(experts, spec) -> bool:
     return False
 
 
+def _expert_compute_dtype(experts, spec):
+    """The dtype the frozen expert matmul runs in: bnb uses the quant compute dtype,
+    a plain frozen Linear uses its weight dtype. Used to keep numerics bnb-identical."""
+    w = getattr(getattr(experts[0], spec[0], None), "weight", None)
+    if HAS_BNB and isinstance(w, Params4bit):
+        return getattr(getattr(w, "quant_state", None), "dtype", torch.bfloat16)
+    return getattr(w, "dtype", torch.bfloat16)
+
+
 def grouped_moe_forward(self, hidden_states: torch.Tensor):
     spec = self._unsloth_moe_spec
     experts = self.experts
-    # Fall back to the original forward for CPU/offloaded inputs or experts that gained
-    # LoRA after patching (grouped stays on the frozen-expert CUDA path only).
-    if (not hidden_states.is_cuda) or _experts_have_lora(experts, spec):
+    # Fall back to the exact original loop unless this is the frozen-expert CUDA path on a
+    # grouped_mm-supported dtype that matches the experts' compute dtype (so CPU/offload,
+    # LoRA-on-experts, fp32, or a bnb compute_dtype != activation dtype stay bit-identical).
+    if (not hidden_states.is_cuda) or _experts_have_lora(experts, spec) \
+            or hidden_states.dtype not in (torch.bfloat16, torch.float16) \
+            or _expert_compute_dtype(experts, spec) != hidden_states.dtype:
         return self._orig_moe_forward(hidden_states)
     is_3d = hidden_states.dim() == 3
     if is_3d:
@@ -271,7 +283,8 @@ def _block_is_eligible(block):
             if getattr(lin, "lora_A", None) is not None or getattr(lin, "base_layer", None) is not None:
                 return None
             is_4bit = HAS_BNB and isinstance(w, Params4bit) and getattr(w, "quant_state", None) is not None
-            is_plain_frozen = (not w.requires_grad) and w.dtype in (torch.bfloat16, torch.float16, torch.float32)
+            # fp32 omitted: torch._grouped_mm targets low-precision CUDA inputs.
+            is_plain_frozen = (not w.requires_grad) and w.dtype in (torch.bfloat16, torch.float16)
             if not (is_4bit or is_plain_frozen):
                 return None
     return spec

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -172,21 +172,29 @@ def _grouped_expert_gemm(x, offsets, weight_fn, recompute):
     return _grouped_mm_fix(x, weight_fn(), offsets)
 
 
+def _experts_have_lora(experts, spec) -> bool:
+    """True if any expert projection gained LoRA / a PEFT base_layer after patching
+    (so the frozen grouped path no longer holds). Cheap next to the per-call dequant."""
+    for ex in experts:
+        for name in spec[:3]:
+            lin = getattr(ex, name, None)
+            if getattr(lin, "lora_A", None) is not None or getattr(lin, "base_layer", None) is not None:
+                return True
+    return False
+
+
 def grouped_moe_forward(self, hidden_states: torch.Tensor):
     spec = self._unsloth_moe_spec
     experts = self.experts
     # Fall back to the original forward for CPU/offloaded inputs or experts that gained
     # LoRA after patching (grouped stays on the frozen-expert CUDA path only).
-    lin0 = getattr(experts[0], spec[0], None)
-    if (not hidden_states.is_cuda) or getattr(lin0, "lora_A", None) is not None \
-            or getattr(lin0, "base_layer", None) is not None:
+    if (not hidden_states.is_cuda) or _experts_have_lora(experts, spec):
         return self._orig_moe_forward(hidden_states)
     is_3d = hidden_states.dim() == 3
     if is_3d:
         bsz, seqlen, hidden_dim = hidden_states.shape
     else:
         seqlen, hidden_dim = hidden_states.shape
-        bsz = 1
     hidden_states = hidden_states.view(-1, hidden_dim)
     if self.training and getattr(self, "jitter_noise", 0):   # Mixtral router jitter
         hidden_states = hidden_states * torch.empty_like(hidden_states).uniform_(

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -15,27 +15,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Grouped-GEMM MoE forward for transformers < 5 (the nn.ModuleList expert layout).
 
-On transformers < 5 a MoE block (Qwen3MoeSparseMoeBlock, MixtralSparseMoeBlock, ...)
-keeps its experts as a nn.ModuleList of per-expert MLPs and loops over them in Python,
-launching O(num_experts) tiny matmuls + a data-dependent sync per layer and never
-calling torch._grouped_mm. The v5 stacked layout already uses a grouped path; this
-brings the same recipe to the < 5 ModuleList layout:
+Replaces the Python per-expert loop with the v5 grouped path: route -> sort by expert ->
+grouped_mm(gate_up) -> act(gate)*up -> grouped_mm(down) -> router scale -> fp32 scatter-add.
+Same bf16 math as the loop, so accuracy is neutral. Activates only for a known block class
+with no shared expert, frozen bnb-4bit / plain-frozen experts, no expert LoRA, and
+torch._grouped_mm support (CUDA); otherwise the original forward runs unchanged. Patches the
+live instance forward so it wins over the compiled-cache class patch.
 
-    route -> sort tokens by expert -> grouped_mm (gate_up) -> act(gate)*up
-    -> grouped_mm (down) -> router-weight scale -> float32 scatter-add
-
-Experts stay 4-bit; the bf16 dequant stack is rebuilt in backward (recompute) or held
-resident (cache). Same bf16 math as the loop, so accuracy is neutral.
-
-Activates only when: a known block class with no shared expert, frozen bnb-4bit (or
-plain-frozen) ModuleList experts, no LoRA on the experts, and torch._grouped_mm is
-supported (CUDA). Otherwise the original forward runs unchanged (so v5, non-bnb,
-LoRA-on-experts and Mac/MLX/AMD/Intel/CPU are no-ops).
-
-Patches the live instance forward after the model is built, so it wins over the
-compiled-cache class patch. Disable with UNSLOTH_MOE_GROUPED=0. Force backward-recompute
-with UNSLOTH_MOE_GROUPED_RECOMPUTE=1 (auto-on when gradient checkpointing is off); hold
-the dequantized experts resident with UNSLOTH_MOE_GROUPED_CACHE=1 (big-GPU opt-in).
+Env: UNSLOTH_MOE_GROUPED=0 disables; UNSLOTH_MOE_GROUPED_RECOMPUTE=1 rebuilds the dequant
+stack in backward (auto-on without gradient checkpointing); UNSLOTH_MOE_GROUPED_CACHE=1 holds
+the dequantized experts resident.
 """
 from __future__ import annotations
 import os
@@ -85,8 +74,7 @@ def _grouped_mm_supported() -> bool:
 
 
 def _grouped_mm_fix(x: torch.Tensor, w: torch.Tensor, offs: torch.Tensor) -> torch.Tensor:
-    """torch._grouped_mm with a contiguity guard + per-group matmul fallback for the
-    rare 16-byte stride error (mirrors moe_utils._grouped_mm_with_backward_fix)."""
+    """torch._grouped_mm with a per-group matmul fallback for the 16-byte stride error."""
     x = x.contiguous()
     w = w.contiguous()
     try:
@@ -111,8 +99,7 @@ def _expert_weight(lin, dtype):
 
 
 def _route_softmax_topk(self, router_logits, top_k):
-    """softmax(fp32) -> top_k -> optional renorm. Covers Qwen3-MoE / Mixtral (Mixtral
-    has no norm_topk_prob attr -> default True == its routing_weights /= sum)."""
+    """softmax(fp32) -> top_k -> optional renorm (Mixtral has no norm_topk_prob attr -> True)."""
     rw = F.softmax(router_logits, dim=1, dtype=torch.float32)
     rw, sel = torch.topk(rw, top_k, dim=-1)
     if getattr(self, "norm_topk_prob", True):
@@ -120,16 +107,12 @@ def _route_softmax_topk(self, router_logits, top_k):
     return rw, sel
 
 
-# block class name -> (gate, up, down attr names, router fn). Add a row per model.
-# Qwen2MoeSparseMoeBlock is intentionally absent: its shared expert is not part of the
-# routed grouped GEMM, so it is skipped (see the shared-expert bail in _block_is_eligible).
+# block class name -> (gate, up, down attr names, router fn), one row per model. Blocks with a
+# shared expert (e.g. Qwen2Moe) are absent: it is not part of the routed GEMM.
 _BLOCK_SPECS = {
     "Qwen3MoeSparseMoeBlock": ("gate_proj", "up_proj", "down_proj", _route_softmax_topk),
     "MixtralSparseMoeBlock":  ("w1",        "w3",      "w2",        _route_softmax_topk),
-    # OLMoE has the identical routed structure to Qwen3-MoE (gate/up/down SwiGLU experts,
-    # softmax(fp32) -> top_k -> optional renorm via norm_topk_prob) and no shared expert, so
-    # the same spec/router applies. Verified against the reference loop in
-    # tests/test_moe_grouped_modulelist_parity.py.
+    # OLMoE has the same routed structure as Qwen3-MoE (see the parity test).
     "OlmoeSparseMoeBlock":    ("gate_proj", "up_proj", "down_proj", _route_softmax_topk),
 }
 
@@ -152,8 +135,7 @@ def _build_down_stack(experts, spec, dtype):
 
 
 class _GroupedFrozenMM(torch.autograd.Function):
-    """grouped_mm(x, W) for FROZEN experts. W is rebuilt by weight_fn in backward
-    instead of saved, so the bf16 dequant stack is not held across the step."""
+    """grouped_mm(x, W) for frozen experts: W is rebuilt by weight_fn in backward, not saved."""
     @staticmethod
     def forward(ctx, x, offsets, weight_fn):
         ctx.weight_fn = weight_fn
@@ -178,9 +160,7 @@ def _grouped_expert_gemm(x, offsets, weight_fn, recompute):
 
 
 def _lin_compute_dtype(lin):
-    """The dtype a single expert projection matmuls in: bitsandbytes casts inputs to the
-    Linear4bit compute_dtype, so that is what our dequant + grouped_mm must match (fall back to
-    the quant_state dtype if unset); a plain frozen Linear uses its weight dtype."""
+    """Matmul dtype of one projection: Linear4bit.compute_dtype (else quant_state dtype), else weight dtype."""
     w = getattr(lin, "weight", None)
     if HAS_BNB and isinstance(w, Params4bit):
         compute_dtype = getattr(lin, "compute_dtype", None)
@@ -196,11 +176,9 @@ def _expert_compute_dtype(experts, spec):
 
 
 def _experts_grouped_ready(experts, spec, device, dtype) -> bool:
-    """Runtime re-check across EVERY expert projection (state can change after
-    enable_grouped_moe, and the stacks are built from all experts, so sampling experts[0] is not
-    enough for heterogeneous device_map / offload / partially-unfrozen / mixed-dtype blocks).
-    Each routed projection must be present, LoRA-free, frozen, on `device`, and matmul in `dtype`;
-    otherwise we fall back to the original loop (bit-identical / crash-free)."""
+    """Every expert projection must be present, LoRA-free, frozen, on `device`, and matmul in
+    `dtype`, else fall back. Checks all experts (not just experts[0]): the stacks read them all,
+    and state can change after enable (heterogeneous device_map / offload / unfrozen / dtype)."""
     for ex in experts:
         for name in spec[:3]:
             lin = getattr(ex, name, None)
@@ -209,11 +187,11 @@ def _experts_grouped_ready(experts, spec, device, dtype) -> bool:
                 return False
             if getattr(lin, "lora_A", None) is not None or getattr(lin, "base_layer", None) is not None:
                 return False
-            if w.requires_grad:                                  # unfrozen -> grads would be dropped
+            if w.requires_grad:
                 return False
-            if getattr(w, "device", device) != device:           # offloaded / other device
+            if getattr(w, "device", device) != device:
                 return False
-            if _lin_compute_dtype(lin) != dtype:                 # different compute dtype
+            if _lin_compute_dtype(lin) != dtype:
                 return False
     return True
 
@@ -221,11 +199,8 @@ def _experts_grouped_ready(experts, spec, device, dtype) -> bool:
 def grouped_moe_forward(self, hidden_states: torch.Tensor):
     spec = self._unsloth_moe_spec
     experts = self.experts
-    # Fall back to the exact original loop unless this is the frozen-expert CUDA path on a
-    # grouped_mm-supported dtype, with every expert LoRA-free, frozen, on the activation device,
-    # and computing in the activation dtype (so CPU/offload, LoRA-on-experts, fp32, a bnb
-    # compute_dtype != activation dtype, unfrozen experts, or experts on another device stay
-    # bit-identical / crash-free).
+    # Run the original loop unless this is the frozen-expert CUDA path in a low-precision dtype
+    # with every expert grouped-ready (CPU/offload, LoRA, fp32, dtype/device mismatch fall back).
     if (not hidden_states.is_cuda) \
             or hidden_states.dtype not in (torch.bfloat16, torch.float16) \
             or not _experts_grouped_ready(experts, spec, hidden_states.device, hidden_states.dtype):
@@ -246,7 +221,7 @@ def grouped_moe_forward(self, hidden_states: torch.Tensor):
     dtype = hidden_states.dtype
 
     router_logits = self.gate(hidden_states)
-    rw, sel = spec[3](self, router_logits, top_k)   # exact per-model router
+    rw, sel = spec[3](self, router_logits, top_k)
     rw = rw.to(dtype)
 
     flat_e = sel.reshape(-1)
@@ -265,7 +240,7 @@ def grouped_moe_forward(self, hidden_states: torch.Tensor):
 
     if cache:
         cu = getattr(self, "_cached_gate_up", None)
-        if cu is None or cu.device != dev or cu.dtype != dtype:   # (re)build on device/dtype change
+        if cu is None or cu.device != dev or cu.dtype != dtype:
             with torch.no_grad():
                 self._cached_gate_up = _build_gate_up_stack(experts, spec, dtype)
                 self._cached_down = _build_down_stack(experts, spec, dtype)
@@ -302,7 +277,7 @@ def _block_is_eligible(block):
         if getattr(block, attr, None) is not None:
             return None
     g_name, u_name, d_name, _ = spec
-    for ex in experts:   # every expert must be frozen with no LoRA, else run the original loop
+    for ex in experts:   # frozen-only path (returns dX): any LoRA / trainable expert -> original loop
         for name in (g_name, u_name, d_name):
             lin = getattr(ex, name, None)
             w = getattr(lin, "weight", None)
@@ -310,9 +285,6 @@ def _block_is_eligible(block):
                 return None
             if getattr(lin, "lora_A", None) is not None or getattr(lin, "base_layer", None) is not None:
                 return None
-            # The grouped path is frozen-only: _expert_weight reads w.data and _GroupedFrozenMM
-            # returns dX only, so a trainable expert weight would silently get no gradient. Require
-            # frozen for both 4-bit and plain experts; otherwise run the original loop.
             is_4bit = (HAS_BNB and isinstance(w, Params4bit)
                        and getattr(w, "quant_state", None) is not None and not w.requires_grad)
             # fp32 omitted: torch._grouped_mm targets low-precision CUDA inputs.
@@ -341,9 +313,8 @@ def _restore_block(module):
 
 
 def enable_grouped_moe(model, recompute=None, cache=None, verbose=True):
-    """Patch eligible frozen ModuleList MoE blocks to the grouped forward. Re-entrant
-    (a block that became ineligible, e.g. LoRA was added, is restored). Safe no-op when
-    torch._grouped_mm is unsupported or no eligible block exists. Returns #patched."""
+    """Patch eligible frozen ModuleList MoE blocks to the grouped forward; returns #patched.
+    Re-entrant (a now-ineligible block is restored), and a no-op without grouped_mm support."""
     if os.environ.get("UNSLOTH_MOE_GROUPED", "1") == "0":
         for module in model.modules():
             _restore_block(module)

--- a/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
+++ b/unsloth_zoo/temporary_patches/moe_grouped_modulelist.py
@@ -152,14 +152,14 @@ class _GroupedFrozenMM(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, offsets, weight_fn):
         ctx.weight_fn = weight_fn
-        ctx.save_for_backward(x, offsets)
+        ctx.save_for_backward(offsets)   # x is unused in backward (frozen base -> dX only)
         with torch.no_grad():
             out = _grouped_mm_fix(x, weight_fn(), offsets)
         return out
 
     @staticmethod
     def backward(ctx, g):
-        x, offsets = ctx.saved_tensors
+        (offsets,) = ctx.saved_tensors
         with torch.no_grad():
             Wt = ctx.weight_fn().transpose(1, 2).contiguous()
             dX = _grouped_mm_fix(g.contiguous(), Wt, offsets)
@@ -174,6 +174,13 @@ def _grouped_expert_gemm(x, offsets, weight_fn, recompute):
 
 def grouped_moe_forward(self, hidden_states: torch.Tensor):
     spec = self._unsloth_moe_spec
+    experts = self.experts
+    # Fall back to the original forward for CPU/offloaded inputs or experts that gained
+    # LoRA after patching (grouped stays on the frozen-expert CUDA path only).
+    lin0 = getattr(experts[0], spec[0], None)
+    if (not hidden_states.is_cuda) or getattr(lin0, "lora_A", None) is not None \
+            or getattr(lin0, "base_layer", None) is not None:
+        return self._orig_moe_forward(hidden_states)
     is_3d = hidden_states.dim() == 3
     if is_3d:
         bsz, seqlen, hidden_dim = hidden_states.shape
@@ -181,12 +188,14 @@ def grouped_moe_forward(self, hidden_states: torch.Tensor):
         seqlen, hidden_dim = hidden_states.shape
         bsz = 1
     hidden_states = hidden_states.view(-1, hidden_dim)
+    if self.training and getattr(self, "jitter_noise", 0):   # Mixtral router jitter
+        hidden_states = hidden_states * torch.empty_like(hidden_states).uniform_(
+            1.0 - self.jitter_noise, 1.0 + self.jitter_noise)
     T = hidden_states.shape[0]
     num_experts = self.num_experts
     top_k = self.top_k
     dev = hidden_states.device
     dtype = hidden_states.dtype
-    experts = self.experts
 
     router_logits = self.gate(hidden_states)
     rw, sel = spec[3](self, router_logits, top_k)   # exact per-model router
@@ -207,7 +216,8 @@ def grouped_moe_forward(self, hidden_states: torch.Tensor):
     act = getattr(experts[0], "act_fn", None) or F.silu
 
     if cache:
-        if getattr(self, "_cached_gate_up", None) is None:
+        cu = getattr(self, "_cached_gate_up", None)
+        if cu is None or cu.device != dev or cu.dtype != dtype:   # (re)build on device/dtype change
             with torch.no_grad():
                 self._cached_gate_up = _build_gate_up_stack(experts, spec, dtype)
                 self._cached_down = _build_down_stack(experts, spec, dtype)
@@ -244,18 +254,18 @@ def _block_is_eligible(block):
         if getattr(block, attr, None) is not None:
             return None
     g_name, u_name, d_name, _ = spec
-    e0 = experts[0]
-    for name in (g_name, u_name, d_name):
-        lin = getattr(e0, name, None)
-        w = getattr(lin, "weight", None)
-        if w is None:
-            return None
-        if getattr(lin, "lora_A", None) is not None or hasattr(lin, "base_layer"):  # LoRA on experts -> defer
-            return None
-        is_4bit = HAS_BNB and isinstance(w, Params4bit) and getattr(w, "quant_state", None) is not None
-        is_plain_frozen = (not w.requires_grad) and w.dtype in (torch.bfloat16, torch.float16, torch.float32)
-        if not (is_4bit or is_plain_frozen):
-            return None
+    for ex in experts:   # every expert must be frozen with no LoRA, else run the original loop
+        for name in (g_name, u_name, d_name):
+            lin = getattr(ex, name, None)
+            w = getattr(lin, "weight", None)
+            if w is None:
+                return None
+            if getattr(lin, "lora_A", None) is not None or getattr(lin, "base_layer", None) is not None:
+                return None
+            is_4bit = HAS_BNB and isinstance(w, Params4bit) and getattr(w, "quant_state", None) is not None
+            is_plain_frozen = (not w.requires_grad) and w.dtype in (torch.bfloat16, torch.float16, torch.float32)
+            if not (is_4bit or is_plain_frozen):
+                return None
     return spec
 
 
@@ -266,14 +276,15 @@ def _uses_grad_checkpointing(model) -> bool:
 
 
 def _restore_block(module):
-    if hasattr(module, "_orig_moe_forward"):
-        module.forward = module._orig_moe_forward
-        for attr in ("_orig_moe_forward", "_unsloth_moe_spec", "_moe_recompute",
-                     "_moe_cache", "_cached_gate_up", "_cached_down"):
-            if hasattr(module, attr):
-                delattr(module, attr)
-        return True
-    return False
+    if not hasattr(module, "_orig_moe_forward"):
+        return False
+    if getattr(getattr(module, "forward", None), "__func__", None) is grouped_moe_forward:
+        module.forward = module._orig_moe_forward   # only restore our own patch
+    for attr in ("_orig_moe_forward", "_unsloth_moe_spec", "_moe_recompute",
+                 "_moe_cache", "_cached_gate_up", "_cached_down"):
+        if hasattr(module, attr):
+            delattr(module, attr)
+    return True
 
 
 def enable_grouped_moe(model, recompute=None, cache=None, verbose=True):
@@ -319,7 +330,7 @@ def auto_enable_grouped_moe(model):
         if model is not None and hasattr(model, "modules"):
             enable_grouped_moe(model, verbose=True)
     except Exception:
-        pass
+        pass  # optional speedup; never block model loading
 
 
 def wrap_loader_for_grouped_moe(func):
@@ -335,7 +346,7 @@ def wrap_loader_for_grouped_moe(func):
         try:
             auto_enable_grouped_moe(result[0] if isinstance(result, tuple) and result else result)
         except Exception:
-            pass
+            pass  # optional speedup; never block model loading
         return result
 
     wrapper._unsloth_grouped_moe_wrapped = True


### PR DESCRIPTION
### Problem

On transformers < 5 a Mixture-of-Experts block (`Qwen3MoeSparseMoeBlock`, `MixtralSparseMoeBlock`, ...) keeps its experts as a `nn.ModuleList` of per-expert MLPs and the decoder loops over every expert in Python. For a 128-expert model that is O(num_experts) tiny matmuls plus a data-dependent sync per layer, so the block is launch/sync bound and `torch._grouped_mm` is never called. The v5 stacked-parameter layout already uses a grouped path; the < 5 ModuleList layout does not.

### Change

New `temporary_patches/moe_grouped_modulelist.py` replaces the per-expert loop with the grouped recipe:

```
route -> sort tokens by expert -> grouped_mm (gate_up) -> act(gate) * up
-> grouped_mm (down) -> router-weight scale -> float32 scatter-add
```

- Experts stay quantized. The dequantized bf16 stack is rebuilt in backward (`recompute`, memory-safe and auto-on when gradient checkpointing is off) or held resident (`cache`, a big-GPU opt-in). Same bf16 math and float32 accumulation as the loop, so accuracy is neutral.
- The instance forward is patched after the model is built, so it wins over the compiled-cache class patch and survives cache regeneration.

### Safety / activation

Activates only when all hold, else the original forward runs unchanged:

- a known block class with no shared expert (registry: `Qwen3MoeSparseMoeBlock`, `MixtralSparseMoeBlock`),
- frozen bnb-4bit (or plain-frozen) ModuleList experts with no LoRA attached to them,
- `torch._grouped_mm` is supported (CUDA).

So transformers v5, non-bnb, LoRA-on-experts, full finetuning, and Mac/MLX/AMD/Intel/CPU are all no-ops. Disable explicitly with `UNSLOTH_MOE_GROUPED=0`.

### Results

Qwen3-30B-A3B QLoRA, 1x B200, seq 2048, gradient checkpointing on, attention LoRA:

| path | tok/s | peak (active) |
|------|-------|---------------|
| loop (current) | 204 | 18.5 GiB |
| grouped (this change) | 664 | 18.8 GiB |

~3.3x faster at the same 4-bit memory. Block-level parity vs the loop: output cosine 0.99999, dX cosine 0.99997, router logits bit-identical; per-step training loss matches within bf16 noise.

### Note

A small companion change in `unsloth` wires the loader to call `enable_grouped_moe` after `from_pretrained` / `get_peft_model` (via `wrap_loader_for_grouped_moe`), gated by `UNSLOTH_MOE_GROUPED`. That import is wrapped in try/except, so this can land independently.
