### PR TITLE
Optional recompute-in-backward for the v5 grouped MoE path

### DIFF
--- a/tests/test_moe_bnb4bit_adaptive_recompute.py
+++ b/tests/test_moe_bnb4bit_adaptive_recompute.py
@@ -1,0 +1,97 @@
+"""The bnb4bit grouped-mm dispatcher follows the adaptive pin-vs-recompute policy.
+
+forward_moe_backend_bnb4bit must not pre-dequantize the packed Params4bit into a dense
+bf16 stack and then re-hold that stack for a backward recompute. It keeps the 4-bit
+weights and defers dequant to forward_native_grouped_mm's providers exactly when the
+adaptive policy says recompute (non gradient-checkpoint, or UNSLOTH_MOE_RECOMPUTE=1),
+and pre-dequantizes-then-pins only when the policy says pin (inside a gradient-checkpoint
+recompute pass, or UNSLOTH_MOE_RECOMPUTE=0). In the pin case recompute is disabled, so
+the dense stack is never re-held for a backward recompute with no memory benefit.
+"""
+import os
+
+import pytest
+import torch
+
+os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
+
+bnb = pytest.importorskip("bitsandbytes")
+from bitsandbytes.nn import Params4bit
+
+if not torch.cuda.is_available():
+    pytest.skip("bnb 4-bit dequant needs CUDA", allow_module_level=True)
+
+import unsloth_zoo.temporary_patches.moe_utils as mu
+from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import forward_moe_backend_bnb4bit
+from unsloth_zoo.gradient_checkpointing import _gradient_checkpoint_recompute_marker
+
+
+def _quantized_expert_param(shape=(4, 32, 64)):
+    w = torch.randn(*shape, dtype=torch.bfloat16)
+    p = Params4bit(w, requires_grad=False, quant_type="nf4", compress_statistics=True).to("cuda")
+    p._original_shape = torch.Size(shape)
+    return p
+
+
+class _FakeExperts:
+    def __init__(self):
+        self.gate_up_proj = _quantized_expert_param()
+        self.down_proj = _quantized_expert_param()
+
+
+def _run_and_record(monkeypatch):
+    """Dispatch once with the real backend picked as grouped_mm; return the path taken."""
+    calls = []
+    monkeypatch.setattr(mu, "select_moe_backend", lambda: "grouped_mm")
+    monkeypatch.setattr(
+        mu, "forward_native_grouped_mm",
+        lambda self, hs, ti, tw: (calls.append("provider"), torch.zeros(1, device="cuda"))[1],
+    )
+    monkeypatch.setattr(
+        mu, "swap_moe_weights_for_call",
+        lambda self, gu, dn, fn, *a: (calls.append("swap"), torch.zeros(1, device="cuda"))[1],
+    )
+    self = _FakeExperts()
+    hs = torch.randn(3, 32, dtype=torch.bfloat16, device="cuda")
+    forward_moe_backend_bnb4bit(self, hs, torch.zeros(3, 1, dtype=torch.long, device="cuda"), None)
+    return calls
+
+
+def test_default_non_gc_uses_recompute_provider(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
+    assert _run_and_record(monkeypatch) == ["provider"]  # keep 4-bit, recompute
+
+
+def test_gc_recompute_pass_pins_via_swap(monkeypatch):
+    monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
+    with _gradient_checkpoint_recompute_marker():
+        assert _run_and_record(monkeypatch) == ["swap"]  # pin (pre-dequant)
+
+
+def test_env_override_forces_recompute(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_MOE_RECOMPUTE", "1")
+    with _gradient_checkpoint_recompute_marker():  # override beats the GC pin
+        assert _run_and_record(monkeypatch) == ["provider"]
+
+
+def test_env_override_forces_pin(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_MOE_RECOMPUTE", "0")
+    assert _run_and_record(monkeypatch) == ["swap"]  # forced pin
+
+
+def test_pre_dequantized_dense_is_never_recomputed(monkeypatch):
+    # The invariant behind the swap path: when the policy says pin, a pre-dequantized
+    # dense stack must not be scheduled for a backward recompute (which would re-hold it
+    # for no memory benefit).
+    monkeypatch.setattr(mu, "_base_is_recomputable", lambda src: True)
+    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device="cuda")  # requires_grad False
+    monkeypatch.setenv("UNSLOTH_MOE_RECOMPUTE", "0")
+    assert mu._moe_recompute_enabled(dense) is False
+    monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
+    with _gradient_checkpoint_recompute_marker():
+        assert mu._moe_recompute_enabled(dense) is False
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/test_moe_bnb4bit_adaptive_recompute.py
+++ b/tests/test_moe_bnb4bit_adaptive_recompute.py
@@ -1,12 +1,16 @@
-"""The bnb4bit grouped-mm dispatcher follows the adaptive pin-vs-recompute policy.
+"""The bnb4bit grouped-mm dispatcher follows the pin-vs-recompute policy, biased to
+recompute for the 4-bit base.
 
 forward_moe_backend_bnb4bit must not pre-dequantize the packed Params4bit into a dense
 bf16 stack and then re-hold that stack for a backward recompute. It keeps the 4-bit
-weights and defers dequant to forward_native_grouped_mm's providers exactly when the
-adaptive policy says recompute (non gradient-checkpoint, or UNSLOTH_MOE_RECOMPUTE=1),
-and pre-dequantizes-then-pins only when the policy says pin (inside a gradient-checkpoint
-recompute pass, or UNSLOTH_MOE_RECOMPUTE=0). In the pin case recompute is disabled, so
-the dense stack is never re-held for a backward recompute with no memory benefit.
+weights and defers dequant to forward_native_grouped_mm's providers by default: the
+4-bit base prefers recompute even inside a gradient-checkpoint recompute pass, because
+pinning it would materialize the full bf16 expert stack the 4-bit storage exists to
+avoid (several GiB per layer on large MoEs, exactly when 4-bit + gradient checkpointing
+means the run is already memory-constrained). Only UNSLOTH_MOE_RECOMPUTE=0 forces the
+pre-dequantize-then-pin path (for memory-rich runs); UNSLOTH_MOE_RECOMPUTE=1 also
+recomputes. In the pin case recompute is disabled, so the dense stack is never re-held
+for a backward recompute with no memory benefit.
 """
 import os
 
@@ -62,10 +66,12 @@ def test_default_non_gc_uses_recompute_provider(monkeypatch):
     assert _run_and_record(monkeypatch) == ["provider"]  # keep 4-bit, recompute
 
 
-def test_gc_recompute_pass_pins_via_swap(monkeypatch):
+def test_gc_recompute_pass_recomputes_for_4bit(monkeypatch):
+    # A 4-bit base prefers recompute even inside a GC recompute pass, so the packed
+    # Params4bit is kept and dequant deferred rather than pinning the full bf16 stack.
     monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
     with _gradient_checkpoint_recompute_marker():
-        assert _run_and_record(monkeypatch) == ["swap"]  # pin (pre-dequant)
+        assert _run_and_record(monkeypatch) == ["provider"]  # recompute, no bf16 pin
 
 
 def test_env_override_forces_recompute(monkeypatch):
@@ -90,6 +96,30 @@ def test_pre_dequantized_dense_is_never_recomputed(monkeypatch):
     monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
     with _gradient_checkpoint_recompute_marker():
         assert mu._moe_recompute_enabled(dense) is False
+
+
+def test_source_pins_large_dequant_classifies_4bit_only(monkeypatch):
+    # Only a frozen bnb 4-bit expert reports a "large dequant" pinned form; a plain
+    # dense base pins its own storage, so it is not flagged.
+    q = _quantized_expert_param()
+    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device="cuda")
+    assert mu._source_pins_large_dequant(q) is True
+    assert mu._source_pins_large_dequant(dense) is False
+
+
+def test_4bit_prefers_recompute_but_dense_still_pins_under_gc(monkeypatch):
+    # The scope guard: the recompute-under-GC default is 4-bit-specific. A dense
+    # (already bf16) base keeps the speed-oriented adaptive policy and pins under a
+    # GC recompute pass; the 4-bit base recomputes to avoid the bf16 dequant pin.
+    monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
+    q = _quantized_expert_param()
+    dense = torch.randn(4, 32, 64, dtype=torch.bfloat16, device="cuda")  # frozen
+    with _gradient_checkpoint_recompute_marker():
+        assert mu._moe_recompute_enabled(q) is True       # 4-bit -> recompute
+        assert mu._moe_recompute_enabled(dense) is False  # dense -> pin (unchanged)
+    # UNSLOTH_MOE_RECOMPUTE=0 still forces the pin even for a 4-bit base.
+    monkeypatch.setenv("UNSLOTH_MOE_RECOMPUTE", "0")
+    assert mu._moe_recompute_enabled(q) is False
 
 
 if __name__ == "__main__":

--- a/tests/test_moe_grouped_mm_no_copy.py
+++ b/tests/test_moe_grouped_mm_no_copy.py
@@ -6,10 +6,11 @@ weight.contiguous() copied that whole frozen stack every step (~805 MB for gate_
 Qwen3-30B; ~57% of MoE GPU time). The fix passes the weight as-is and only falls back to a
 contiguous copy on the narrow 16-byte-stride error.
 
-test_no_forced_copy pins the control flow (device-independent): the weight reaches
-torch._grouped_mm as a non-contiguous view on a single attempt. test_view_matches_copy_*
-pin bit-exactness against the old always-contiguous path where torch._grouped_mm runs for
-real (H100+/B200), forward and backward.
+test_no_forced_copy pins the control flow: on a stack the #186365 probe deems safe the weight
+reaches torch._grouped_mm as a non-contiguous view in one attempt, otherwise a contiguous copy
+is forced. test_probe_gates_the_forced_copy pins that gate directly. test_view_matches_copy_*
+pin bit-exactness against the always-contiguous path where torch._grouped_mm runs for real
+(H100+/B200), forward and backward.
 """
 import pytest
 import torch
@@ -28,12 +29,13 @@ def _grouped_mm_ok():
 
 
 def test_no_forced_copy_on_happy_path(monkeypatch):
-    """The weight must reach torch._grouped_mm as a non-contiguous view, in one attempt.
-
-    Fails against the old code, which called weight.contiguous() before the single try
-    (materialising the full frozen-stack copy the fix exists to avoid).
-    """
-    from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
+    """On a probe-safe stack the weight reaches torch._grouped_mm as a non-contiguous view in
+    one attempt (no forced copy of the frozen stack); on an unproven stack it is made
+    contiguous. Fails against the old code, which always copied before the single try."""
+    from unsloth_zoo.temporary_patches.moe_utils import (
+        _grouped_mm_with_backward_fix, _transposed_view_grouped_mm_is_safe,
+    )
+    safe = _transposed_view_grouped_mm_is_safe()  # warm the cached probe with the REAL op first
 
     inputs = torch.randn(5, 4)
     weight_view = torch.randn(3, 2, 4).transpose(1, 2)  # (E, 4, 2) non-contiguous, like the base stack
@@ -49,7 +51,30 @@ def test_no_forced_copy_on_happy_path(monkeypatch):
     monkeypatch.setattr(torch, "_grouped_mm", spy, raising=False)
     _grouped_mm_with_backward_fix(inputs, weight_view, offsets)
 
-    assert seen == [False], f"expected one call with a non-contiguous weight view, got {seen}"
+    expected = [False] if safe else [True]  # safe -> view kept; unproven -> contiguous copy
+    assert seen == expected, f"probe safe={safe}: expected {expected}, got {seen}"
+
+
+def test_probe_gates_the_forced_copy(monkeypatch):
+    """The #186365 gate: when the probe reports the transposed-view path unsafe, the weight is
+    made contiguous before torch._grouped_mm; when safe, the view is passed as-is."""
+    import unsloth_zoo.temporary_patches.moe_utils as mu
+
+    inputs = torch.randn(5, 4)
+    weight_view = torch.randn(3, 2, 4).transpose(1, 2)
+    offsets = torch.tensor([2, 2, 5], dtype=torch.int32)
+
+    for probe_safe in (True, False):
+        seen = []
+
+        def spy(inp, w, offs=None):
+            seen.append(w.is_contiguous())
+            return torch.zeros(inp.shape[0], w.shape[-1], dtype=inp.dtype)
+
+        monkeypatch.setattr(mu, "_TRANSPOSED_VIEW_GROUPED_MM_SAFE", probe_safe, raising=False)
+        monkeypatch.setattr(torch, "_grouped_mm", spy, raising=False)
+        mu._grouped_mm_with_backward_fix(inputs, weight_view, offsets)
+        assert seen == [not probe_safe], f"probe_safe={probe_safe}: got {seen}"
 
 
 @pytest.mark.skipif(not _grouped_mm_ok(), reason="torch._grouped_mm unsupported on this device")

--- a/tests/test_moe_grouped_mm_no_copy.py
+++ b/tests/test_moe_grouped_mm_no_copy.py
@@ -1,0 +1,98 @@
+"""Regression tests for the copy-elimination in _grouped_mm_with_backward_fix.
+
+The frozen base expert stacks are stored (E, 2I, H) / (E, H, I) and preprocess_weight
+transposes them into grouped layout, producing a non-contiguous view. Forcing
+weight.contiguous() copied that whole frozen stack every step (~805 MB for gate_up on
+Qwen3-30B; ~57% of MoE GPU time). The fix passes the weight as-is and only falls back to a
+contiguous copy on the narrow 16-byte-stride error.
+
+test_no_forced_copy pins the control flow (device-independent): the weight reaches
+torch._grouped_mm as a non-contiguous view on a single attempt. test_view_matches_copy_*
+pin bit-exactness against the old always-contiguous path where torch._grouped_mm runs for
+real (H100+/B200), forward and backward.
+"""
+import pytest
+import torch
+
+
+def _grouped_mm_ok():
+    if not torch.cuda.is_available():
+        return False
+    try:
+        x = torch.randn(2, 8, device="cuda", dtype=torch.bfloat16)
+        w = torch.randn(1, 8, 8, device="cuda", dtype=torch.bfloat16)
+        torch._grouped_mm(x, w, offs=torch.tensor([2], dtype=torch.int32, device="cuda"))
+        return True
+    except Exception:
+        return False
+
+
+def test_no_forced_copy_on_happy_path(monkeypatch):
+    """The weight must reach torch._grouped_mm as a non-contiguous view, in one attempt.
+
+    Fails against the old code, which called weight.contiguous() before the single try
+    (materialising the full frozen-stack copy the fix exists to avoid).
+    """
+    from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
+
+    inputs = torch.randn(5, 4)
+    weight_view = torch.randn(3, 2, 4).transpose(1, 2)  # (E, 4, 2) non-contiguous, like the base stack
+    assert not weight_view.is_contiguous()
+    offsets = torch.tensor([2, 2, 5], dtype=torch.int32)
+
+    seen = []
+
+    def spy(inp, w, offs=None):
+        seen.append(w.is_contiguous())
+        return torch.zeros(inp.shape[0], w.shape[-1], dtype=inp.dtype)
+
+    monkeypatch.setattr(torch, "_grouped_mm", spy, raising=False)
+    _grouped_mm_with_backward_fix(inputs, weight_view, offsets)
+
+    assert seen == [False], f"expected one call with a non-contiguous weight view, got {seen}"
+
+
+@pytest.mark.skipif(not _grouped_mm_ok(), reason="torch._grouped_mm unsupported on this device")
+def test_view_matches_copy_forward():
+    from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
+
+    torch.manual_seed(0)
+    E, K, N, T = 3, 64, 128, 40
+    inputs = torch.randn(T, K, device="cuda", dtype=torch.bfloat16)
+    base = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)  # (E, out, in) as stored
+    weight_view = base.transpose(1, 2)          # (E, K, N) non-contiguous view (what the fix keeps)
+    weight_copy = weight_view.contiguous()      # what the old path forced
+    offsets = torch.tensor([16, 28, 40], dtype=torch.int32, device="cuda")
+
+    out_view = _grouped_mm_with_backward_fix(inputs, weight_view, offsets)
+    out_copy = _grouped_mm_with_backward_fix(inputs, weight_copy, offsets)
+    assert (out_view - out_copy).abs().max().item() == 0.0, "view vs contiguous-copy result differs"
+
+
+@pytest.mark.skipif(not _grouped_mm_ok(), reason="torch._grouped_mm unsupported on this device")
+def test_view_matches_copy_backward():
+    from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
+
+    torch.manual_seed(0)
+    E, K, N, T = 3, 64, 128, 40
+    offsets = torch.tensor([16, 28, 40], dtype=torch.int32, device="cuda")
+
+    def run(force_copy):
+        x = torch.randn(T, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        base = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        torch.manual_seed(1)  # identical draws across both runs
+        x.data.normal_(); base.data.normal_()
+        w = base.transpose(1, 2)
+        w = w.contiguous() if force_copy else w
+        _grouped_mm_with_backward_fix(x, w, offsets).float().pow(2).sum().backward()
+        return x.grad.clone(), base.grad.clone()
+
+    gx_view, gb_view = run(force_copy=False)
+    gx_copy, gb_copy = run(force_copy=True)
+    assert (gx_view - gx_copy).abs().max().item() == 0.0, "input grad differs"
+    assert (gb_view - gb_copy).abs().max().item() == 0.0, "weight grad differs"
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/test_moe_grouped_mm_no_copy.py
+++ b/tests/test_moe_grouped_mm_no_copy.py
@@ -1,16 +1,10 @@
 """Regression tests for the copy-elimination in _grouped_mm_with_backward_fix.
 
-The frozen base expert stacks are stored (E, 2I, H) / (E, H, I) and preprocess_weight
-transposes them into grouped layout, producing a non-contiguous view. Forcing
-weight.contiguous() copied that whole frozen stack every step (~805 MB for gate_up on
-Qwen3-30B; ~57% of MoE GPU time). The fix passes the weight as-is and only falls back to a
-contiguous copy on the narrow 16-byte-stride error.
-
-test_no_forced_copy pins the control flow: on a stack the #186365 probe deems safe the weight
-reaches torch._grouped_mm as a non-contiguous view in one attempt, otherwise a contiguous copy
-is forced. test_probe_gates_the_forced_copy pins that gate directly. test_view_matches_copy_*
-pin bit-exactness against the always-contiguous path where torch._grouped_mm runs for real
-(H100+/B200), forward and backward.
+The fix passes the frozen base stack to torch._grouped_mm as a transposed view instead of
+copying it (~805 MB / ~57% of MoE GPU time on Qwen3-30B) every step, gated on the #186365
+safety probe. These pin: the view is kept on a probe-safe stack (else a copy is forced), the
+probe gates that choice, the probe leaves global RNG untouched, and view == contiguous
+bit-exactly in forward and backward where torch._grouped_mm runs for real.
 """
 import pytest
 import torch
@@ -29,9 +23,7 @@ def _grouped_mm_ok():
 
 
 def test_no_forced_copy_on_happy_path(monkeypatch):
-    """On a probe-safe stack the weight reaches torch._grouped_mm as a non-contiguous view in
-    one attempt (no forced copy of the frozen stack); on an unproven stack it is made
-    contiguous. Fails against the old code, which always copied before the single try."""
+    """Probe-safe stack: weight kept as a non-contiguous view in one attempt; unproven: copied."""
     from unsloth_zoo.temporary_patches.moe_utils import (
         _grouped_mm_with_backward_fix, _transposed_view_grouped_mm_is_safe,
     )
@@ -56,8 +48,7 @@ def test_no_forced_copy_on_happy_path(monkeypatch):
 
 
 def test_probe_gates_the_forced_copy(monkeypatch):
-    """The #186365 gate: when the probe reports the transposed-view path unsafe, the weight is
-    made contiguous before torch._grouped_mm; when safe, the view is passed as-is."""
+    """The #186365 gate: probe unsafe -> weight made contiguous; safe -> view passed as-is."""
     from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
 
     inputs = torch.randn(5, 4)
@@ -80,9 +71,7 @@ def test_probe_gates_the_forced_copy(monkeypatch):
 
 
 def test_probe_does_not_perturb_global_rng(monkeypatch):
-    """The probe must draw from a local generator, not torch.manual_seed, so it leaves the
-    process-wide RNG untouched (otherwise it would shift training dropout / sampling / data
-    order). Clear the cache so the probe actually runs, then compare RNG state."""
+    """The probe uses a local generator, so it leaves the process-wide RNG untouched."""
     from unsloth_zoo.temporary_patches.moe_utils import _transposed_view_grouped_mm_is_safe
 
     monkeypatch.setattr(

--- a/tests/test_moe_grouped_mm_no_copy.py
+++ b/tests/test_moe_grouped_mm_no_copy.py
@@ -58,7 +58,7 @@ def test_no_forced_copy_on_happy_path(monkeypatch):
 def test_probe_gates_the_forced_copy(monkeypatch):
     """The #186365 gate: when the probe reports the transposed-view path unsafe, the weight is
     made contiguous before torch._grouped_mm; when safe, the view is passed as-is."""
-    import unsloth_zoo.temporary_patches.moe_utils as mu
+    from unsloth_zoo.temporary_patches.moe_utils import _grouped_mm_with_backward_fix
 
     inputs = torch.randn(5, 4)
     weight_view = torch.randn(3, 2, 4).transpose(1, 2)
@@ -71,10 +71,32 @@ def test_probe_gates_the_forced_copy(monkeypatch):
             seen.append(w.is_contiguous())
             return torch.zeros(inp.shape[0], w.shape[-1], dtype=inp.dtype)
 
-        monkeypatch.setattr(mu, "_TRANSPOSED_VIEW_GROUPED_MM_SAFE", probe_safe, raising=False)
+        monkeypatch.setattr(
+            "unsloth_zoo.temporary_patches.moe_utils._TRANSPOSED_VIEW_GROUPED_MM_SAFE",
+            probe_safe, raising=False)
         monkeypatch.setattr(torch, "_grouped_mm", spy, raising=False)
-        mu._grouped_mm_with_backward_fix(inputs, weight_view, offsets)
+        _grouped_mm_with_backward_fix(inputs, weight_view, offsets)
         assert seen == [not probe_safe], f"probe_safe={probe_safe}: got {seen}"
+
+
+def test_probe_does_not_perturb_global_rng(monkeypatch):
+    """The probe must draw from a local generator, not torch.manual_seed, so it leaves the
+    process-wide RNG untouched (otherwise it would shift training dropout / sampling / data
+    order). Clear the cache so the probe actually runs, then compare RNG state."""
+    from unsloth_zoo.temporary_patches.moe_utils import _transposed_view_grouped_mm_is_safe
+
+    monkeypatch.setattr(
+        "unsloth_zoo.temporary_patches.moe_utils._TRANSPOSED_VIEW_GROUPED_MM_SAFE",
+        None, raising=False)
+    torch.manual_seed(1234)
+    cpu_before = torch.get_rng_state()
+    cuda_before = torch.cuda.get_rng_state() if torch.cuda.is_available() else None
+
+    _transposed_view_grouped_mm_is_safe()
+
+    assert torch.equal(torch.get_rng_state(), cpu_before), "probe changed the CPU RNG state"
+    if cuda_before is not None:
+        assert torch.equal(torch.cuda.get_rng_state(), cuda_before), "probe changed the CUDA RNG state"
 
 
 @pytest.mark.skipif(not _grouped_mm_ok(), reason="torch._grouped_mm unsupported on this device")

--- a/tests/test_moe_recompute_gc_adaptive.py
+++ b/tests/test_moe_recompute_gc_adaptive.py
@@ -1,0 +1,91 @@
+"""Adaptive pin-vs-recompute policy for the grouped MoE base GEMM.
+
+The dequantized bf16 expert stack is either pinned (kept from forward to backward)
+or recomputed in backward. Pinning is fast but memory-heavy; recompute is the
+reverse. The choice is adaptive: pin only inside a gradient-checkpoint recompute
+pass (where the stack is rebuilt right before the layer's own backward, so the pin
+is momentary), otherwise recompute so a non-checkpointed forward does not hold every
+layer's stack across the whole backward. UNSLOTH_MOE_RECOMPUTE overrides it.
+"""
+
+import os
+
+import pytest
+import torch
+
+os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
+
+from unsloth_zoo.gradient_checkpointing import (
+    Unsloth_Gradient_Checkpointer,
+    in_gradient_checkpoint_recompute,
+    _gradient_checkpoint_recompute_marker,
+)
+import unsloth_zoo.temporary_patches.moe_utils as mu
+
+
+# ---------------------------------------------------------------------------
+# The recompute marker
+# ---------------------------------------------------------------------------
+def test_marker_idempotent_nesting_and_exception_safe():
+    assert in_gradient_checkpoint_recompute() is False
+    with _gradient_checkpoint_recompute_marker():
+        assert in_gradient_checkpoint_recompute() is True
+        with _gradient_checkpoint_recompute_marker():        # nested
+            assert in_gradient_checkpoint_recompute() is True
+        assert in_gradient_checkpoint_recompute() is True    # restored to outer
+    assert in_gradient_checkpoint_recompute() is False       # restored to base
+
+    with pytest.raises(ValueError):
+        with _gradient_checkpoint_recompute_marker():
+            assert in_gradient_checkpoint_recompute() is True
+            raise ValueError("boom")
+    # The finally clause must clear the flag even when the body raised.
+    assert in_gradient_checkpoint_recompute() is False
+
+
+def test_marker_true_only_during_gc_recompute():
+    # The checkpointer runs the wrapped forward twice: once under no_grad (original
+    # forward, marker False) and once under enable_grad in backward (recompute pass,
+    # marker True). This proves the flag fires exactly during the recompute pass and
+    # is cleared afterwards -- i.e. no other gradient-checkpoint run is disturbed.
+    seen = []
+
+    def fn(x, *args):
+        seen.append(in_gradient_checkpoint_recompute())
+        return (x * 2,)
+
+    x = torch.randn(4, requires_grad=True)
+    (out,) = Unsloth_Gradient_Checkpointer.apply(fn, x)
+    assert seen == [False], seen                    # original forward
+    out.sum().backward()
+    assert seen == [False, True], seen              # + recompute pass
+    assert in_gradient_checkpoint_recompute() is False
+    # Backward still produced the correct gradient (d(2x)/dx = 2).
+    assert torch.allclose(x.grad, torch.full_like(x, 2.0))
+
+
+# ---------------------------------------------------------------------------
+# The adaptive decision
+# ---------------------------------------------------------------------------
+def test_recompute_policy_adaptive_and_overrides(monkeypatch):
+    # Isolate the policy layer from the base-recomputable guards (which need CUDA +
+    # torch._grouped_mm support).
+    monkeypatch.setattr(mu, "_base_is_recomputable", lambda src: True)
+    src = object()
+
+    monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
+    assert mu._moe_recompute_enabled(src) is True                 # non-GC -> recompute
+    with _gradient_checkpoint_recompute_marker():
+        assert mu._moe_recompute_enabled(src) is False            # GC recompute -> pin
+
+    monkeypatch.setenv("UNSLOTH_MOE_RECOMPUTE", "1")
+    with _gradient_checkpoint_recompute_marker():
+        assert mu._moe_recompute_enabled(src) is True             # force recompute
+
+    monkeypatch.setenv("UNSLOTH_MOE_RECOMPUTE", "0")
+    assert mu._moe_recompute_enabled(src) is False                # force pin
+
+    # A trainable / unsupported base can never recompute -> pinned eager path.
+    monkeypatch.delenv("UNSLOTH_MOE_RECOMPUTE", raising=False)
+    monkeypatch.setattr(mu, "_base_is_recomputable", lambda src: False)
+    assert mu._moe_recompute_enabled(src) is False

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager, nullcontext
 import os
 import warnings
 import gc
+import threading
 from .utils import _get_dtype, Version
 from .device_type import (
     is_hip,
@@ -162,6 +163,34 @@ def prepare_n_gradient_checkpoints(
 pass
 
 
+# ---------------------------------------------------------------------------
+# Gradient-checkpoint recompute marker
+# ---------------------------------------------------------------------------
+# Thread-local flag, True only while a gradient-checkpoint backward is re-running
+# its wrapped forward to rebuild activations. Consumers (e.g. the MoE grouped-mm
+# recompute policy) read it via in_gradient_checkpoint_recompute() to decide whether
+# to pin a freshly dequantized tensor for the immediate backward (cheap under
+# checkpointing) or recompute it later. The context manager always restores the
+# previous value, so it is idempotent and safe under nesting and exceptions, and it
+# never alters checkpointing behaviour itself.
+_GC_RECOMPUTE_TLS = threading.local()
+
+
+def in_gradient_checkpoint_recompute() -> bool:
+    """True while a gradient-checkpoint backward is recomputing its forward."""
+    return getattr(_GC_RECOMPUTE_TLS, "active", False)
+
+
+@contextmanager
+def _gradient_checkpoint_recompute_marker():
+    previous = getattr(_GC_RECOMPUTE_TLS, "active", False)
+    _GC_RECOMPUTE_TLS.active = True
+    try:
+        yield
+    finally:
+        _GC_RECOMPUTE_TLS.active = previous
+
+
 class Unsloth_Offloaded_Gradient_Checkpointer(torch.autograd.Function):
     """
     All Unsloth Zoo code licensed under LGPLv3
@@ -187,7 +216,7 @@ class Unsloth_Offloaded_Gradient_Checkpointer(torch.autograd.Function):
         (hidden_states,) = ctx.saved_tensors
         hidden_states = hidden_states.to(ctx.device, non_blocking = True).detach()
         hidden_states.requires_grad_(True)
-        with torch.enable_grad():
+        with torch.enable_grad(), _gradient_checkpoint_recompute_marker():
             (output,) = ctx.forward_function(hidden_states, *ctx.args)
         torch.autograd.backward(output, dY)
         return (None, hidden_states.grad,) + (None,)*len(ctx.args)
@@ -217,7 +246,7 @@ class Unsloth_Gradient_Checkpointer(torch.autograd.Function):
         (hidden_states,) = ctx.saved_tensors
         hidden_states = hidden_states.detach()
         hidden_states.requires_grad_(True)
-        with torch.enable_grad():
+        with torch.enable_grad(), _gradient_checkpoint_recompute_marker():
             (output,) = ctx.forward_function(hidden_states, *ctx.args)
         torch.autograd.backward(output, dY)
         return (None, hidden_states.grad,) + (None,)*len(ctx.args)
@@ -724,7 +753,7 @@ class UnslothCheckpointFunction(torch.autograd.Function):
                 detached_inputs[0] = x
             pass
 
-            with torch.enable_grad(), device_autocast_ctx, torch.amp.autocast("cpu", **ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
+            with torch.enable_grad(), device_autocast_ctx, torch.amp.autocast("cpu", **ctx.cpu_autocast_kwargs), _gradient_checkpoint_recompute_marker():  # type: ignore[attr-defined]
                 outputs = ctx.run_function(*detached_inputs)
             pass
         pass

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -670,8 +670,12 @@ def _extract_lora_weights(
     return result[0], result[1], result[2]
 
 
-def _get_base_weight(param):
-    """Get base weight from a potentially wrapped parameter or module."""
+def _get_base_weight(param, target_dtype=None):
+    """Get base weight from a potentially wrapped parameter or module.
+
+    target_dtype mirrors _dequantize_bnb4bit_expert_weights for the recompute
+    providers: restore the packed Params4bit to its logical shape and cast.
+    """
     # This Unsloth Zoo code section is licensed under AGPL3
 
     while hasattr(param, "base_layer"):
@@ -690,6 +694,8 @@ def _get_base_weight(param):
         original_shape = getattr(param, "_original_shape", None)
         if original_shape is not None and weight.shape != original_shape:
             weight = weight.reshape(original_shape)
+        if target_dtype is not None:
+            weight = weight.to(target_dtype)
         return weight
 
     if hasattr(param, "get_param"):
@@ -1120,8 +1126,8 @@ def forward_native_grouped_mm(
 
         # Provider re-derives the base weight on demand so Fix 3 can recompute it in
         # backward instead of pinning it (grouped_mm needs contiguous weights).
-        def _gate_up_provider(_src=_gate_up_src, _mt=model_type, _h=hidden_dim):
-            return preprocess_weight(_get_base_weight(_src), "gate_up", _h, _mt)
+        def _gate_up_provider(_src=_gate_up_src, _mt=model_type, _h=hidden_dim, _dt=hidden_states.dtype):
+            return preprocess_weight(_get_base_weight(_src, _dt), "gate_up", _h, _mt)
         mm1_out = _base_grouped_mm(
             permuted_input, offsets, _gate_up_provider, _moe_recompute_enabled(_gate_up_src),
         )
@@ -1254,8 +1260,8 @@ def forward_native_grouped_mm(
     if hasattr(self, "down_proj"):
         model_type = getattr(self, "_unsloth_model_type", None)
         _down_src = self.down_proj
-        def _down_provider(_src=_down_src, _mt=model_type, _h=hidden_dim):
-            return preprocess_weight(_get_base_weight(_src), "down", _h, _mt)
+        def _down_provider(_src=_down_src, _mt=model_type, _h=hidden_dim, _dt=hidden_states.dtype):
+            return preprocess_weight(_get_base_weight(_src, _dt), "down", _h, _mt)
         mm2_out = _base_grouped_mm(
             inter, offsets, _down_provider, _moe_recompute_enabled(_down_src),
         )

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -290,9 +290,11 @@ def _transposed_view_grouped_mm_is_safe():
         if _TORCH_GROUPED_MM_AVAILABLE and torch.cuda.is_available():
             device = torch.cuda.current_device()
             E, N, K, M = 4, 64, 32, 32
-            torch.manual_seed(0)
-            A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
-            w = torch.randn(E, N, K, dtype=torch.bfloat16, device=device)
+            # Draw from a LOCAL generator so the probe never touches the process-wide RNG state
+            # (torch.manual_seed here would perturb training dropout / sampling / data order).
+            gen = torch.Generator(device=device).manual_seed(0)
+            A = torch.randn(M, K, dtype=torch.bfloat16, device=device, generator=gen)
+            w = torch.randn(E, N, K, dtype=torch.bfloat16, device=device, generator=gen)
             w_t = w.transpose(-2, -1)          # non-contiguous view (the fast path's layout)
             w_tc = w_t.contiguous()            # known-correct reference
             per = M // E

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -120,26 +120,14 @@ def get_forward_moe_backend():
 def _grouped_mm_with_backward_fix(
     inputs: torch.Tensor, weight: torch.Tensor, offsets: torch.Tensor
 ) -> torch.Tensor:
-    """Grouped matmul via torch._grouped_mm with contiguous inputs.
+    """Grouped matmul; passes the weight as a transposed view (no copy) when safe.
 
-    The weight is passed AS-IS when the stack is known-safe. torch._grouped_mm accepts a
-    transposed (non-contiguous) view as long as one matmul dim is unit-stride. The base expert
-    stacks are stored (E, 2I, H) / (E, H, I) and preprocess_weight transposes them into
-    grouped layout, producing exactly such a view for the frozen base. Forcing
-    weight.contiguous() materialises a full copy of that frozen stack (e.g. ~805 MB for
-    gate_up on Qwen3-30B) on every step; profiling attributed ~57% of MoE GPU time to these
-    copies, so skipping it is a real speedup.
-
-    Some CUDA torch builds, however, silently miscompute torch._grouped_mm for exactly this
-    transposed bf16 view (pytorch/pytorch#186365). We therefore only skip the copy when a
-    one-time probe proves the view path is stable and matches the contiguous path on this
-    stack; otherwise we keep the contiguous copy (correct on every build). We also fall back
-    to a contiguous copy (and then the per-group matmul) when the kernel rejects the strides,
-    the narrow case of some low-rank LoRA weights below the 16-byte alignment requirement.
-
-    Bit-exact vs the always-contiguous path in forward and backward, for frozen and trainable
-    weights (torch._grouped_mm produces identical results for a contiguous tensor and its
-    equivalent view on stacks that pass the probe).
+    Forcing weight.contiguous() copies the frozen base stack (~805 MB for gate_up on Qwen3-30B,
+    ~57% of MoE GPU time) every step. torch._grouped_mm takes the non-contiguous view directly,
+    but some CUDA builds silently miscompute it (pytorch/pytorch#186365), so we only skip the
+    copy when a one-time probe proves the view path matches the contiguous one; else we keep the
+    always-correct copy. Falls back to a per-group matmul on the 16-byte stride error. Bit-exact
+    vs the always-contiguous path in forward and backward.
     """
     inputs = inputs.contiguous()
     if not _transposed_view_grouped_mm_is_safe():
@@ -205,9 +193,8 @@ def _moe_recompute_enabled(source) -> bool:
 
 
 class _GroupedMMRecompute(torch.autograd.Function):
-    """grouped_mm(inputs, W) for a frozen W from weight_provider(). Saves only
-    offsets + the provider (inputs is unused for the frozen-base dX, and the dense W is
-    rebuilt in backward rather than pinned)."""
+    """grouped_mm(inputs, W) for a frozen W from weight_provider(): saves only offsets and rebuilds
+    W in backward (dX only) instead of pinning the dense stack."""
 
     @staticmethod
     def forward(ctx, inputs, offsets, weight_provider):
@@ -272,11 +259,9 @@ def _check_torch_grouped_mm_supported():
     return _TORCH_GROUPED_MM_SUPPORTED
 
 
-# Some CUDA torch builds miscompute torch._grouped_mm for a transposed (non-contiguous) bf16
-# weight view: results silently alternate / disagree with the contiguous copy when preceded by
-# a broadcast op (pytorch/pytorch#186365, seen on Blackwell with torch 2.11/2.13). We only skip
-# the contiguous copy in _grouped_mm_with_backward_fix on stacks where this probe proves the view
-# path is stable and matches the contiguous path; otherwise we keep the safe contiguous copy.
+# Some CUDA builds silently miscompute torch._grouped_mm for a transposed bf16 view preceded by a
+# broadcast op (pytorch/pytorch#186365, Blackwell + torch 2.11/2.13). This probe checks the view
+# matches the contiguous copy so _grouped_mm_with_backward_fix can skip the copy only when safe.
 _TRANSPOSED_VIEW_GROUPED_MM_SAFE = None
 
 
@@ -290,13 +275,12 @@ def _transposed_view_grouped_mm_is_safe():
         if _TORCH_GROUPED_MM_AVAILABLE and torch.cuda.is_available():
             device = torch.cuda.current_device()
             E, N, K, M = 4, 64, 32, 32
-            # Draw from a LOCAL generator so the probe never touches the process-wide RNG state
-            # (torch.manual_seed here would perturb training dropout / sampling / data order).
+            # local generator: never touch the process-wide RNG (manual_seed would shift training)
             gen = torch.Generator(device=device).manual_seed(0)
             A = torch.randn(M, K, dtype=torch.bfloat16, device=device, generator=gen)
             w = torch.randn(E, N, K, dtype=torch.bfloat16, device=device, generator=gen)
-            w_t = w.transpose(-2, -1)          # non-contiguous view (the fast path's layout)
-            w_tc = w_t.contiguous()            # known-correct reference
+            w_t = w.transpose(-2, -1)
+            w_tc = w_t.contiguous()
             per = M // E
             offs = torch.arange(per, M + 1, per, dtype=torch.int32, device=device)[:E]
             offs[-1] = M
@@ -742,11 +726,8 @@ def _extract_lora_weights(
 
 
 def _get_base_weight(param, target_dtype=None):
-    """Get base weight from a potentially wrapped parameter or module.
-
-    target_dtype mirrors _dequantize_bnb4bit_expert_weights for the recompute
-    providers: restore the packed Params4bit to its logical shape and cast.
-    """
+    """Get base weight from a potentially wrapped parameter or module. target_dtype (recompute
+    providers) restores the packed Params4bit to its logical shape and casts."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
     while hasattr(param, "base_layer"):

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -151,6 +151,65 @@ def _manual_grouped_mm(
     return inputs.new_empty((0, weight.shape[-1]))
 
 
+# Optional recompute-in-backward for the frozen base expert GEMM. With
+# UNSLOTH_MOE_RECOMPUTE=1 the dequantized bf16 expert stack is rebuilt from the 4-bit
+# Params4bit in backward (for dX only; the base is frozen and LoRA is a separate additive
+# grouped_mm) instead of being pinned on the tape. Output is unchanged; off by default the
+# call below is the prior eager path.
+
+
+def _moe_recompute_enabled(source) -> bool:
+    if os.environ.get("UNSLOTH_MOE_RECOMPUTE", "0") != "1":
+        return False
+    try:
+        if not _should_use_separated_lora():          # merged LoRA folds the delta into base
+            return False
+        if not _check_torch_grouped_mm_supported():
+            return False
+        param = source
+        while hasattr(param, "base_layer"):
+            param = param.base_layer
+        if HAS_BNB and Params4bit is not None and isinstance(param, Params4bit):
+            if getattr(param, "quant_state", None) is None:
+                return False
+            return not param.requires_grad
+        if isinstance(param, torch.Tensor):
+            return (not param.requires_grad) and param.dtype in (
+                torch.bfloat16, torch.float16, torch.float32,
+            )
+    except Exception:
+        return False
+    return False
+
+
+class _GroupedMMRecompute(torch.autograd.Function):
+    """grouped_mm(inputs, W) for a frozen W from weight_provider(). Saves only
+    (inputs, offsets) + the provider, not the dense W; rebuilds W in backward for dX."""
+
+    @staticmethod
+    def forward(ctx, inputs, offsets, weight_provider):
+        ctx.weight_provider = weight_provider
+        ctx.save_for_backward(inputs, offsets)
+        with torch.no_grad():
+            out = _grouped_mm_with_backward_fix(inputs, weight_provider(), offsets)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        inputs, offsets = ctx.saved_tensors
+        with torch.no_grad():
+            weight_t = ctx.weight_provider().transpose(-2, -1).contiguous()
+            grad_input = _grouped_mm_with_backward_fix(grad_output.contiguous(), weight_t, offsets)
+        return grad_input, None, None
+
+
+def _base_grouped_mm(inputs, offsets, weight_provider, recompute):
+    """recompute -> rebuild W in backward; else the prior eager grouped_mm."""
+    if recompute:
+        return _GroupedMMRecompute.apply(inputs, offsets, weight_provider)
+    return _grouped_mm_with_backward_fix(inputs, weight_provider(), offsets)
+
+
 _GROUPED_GEMM_AVAILABLE = None
 _TORCH_GROUPED_MM_AVAILABLE = hasattr(torch, "_grouped_mm")
 
@@ -1052,12 +1111,16 @@ def forward_native_grouped_mm(
         )
 
     if hasattr(self, "gate_up_proj"):
-        gate_up_base = _get_base_weight(self.gate_up_proj)
         model_type = getattr(self, "_unsloth_model_type", None)
+        _gate_up_src = self.gate_up_proj
 
-        # grouped_mm backward needs contiguous weights; preprocess may return a transposed view.
-        w1 = preprocess_weight(gate_up_base, "gate_up", hidden_dim, model_type)
-        mm1_out = _grouped_mm_with_backward_fix(permuted_input, w1, offsets)
+        # Provider re-derives the base weight on demand so Fix 3 can recompute it in
+        # backward instead of pinning it (grouped_mm needs contiguous weights).
+        def _gate_up_provider(_src=_gate_up_src, _mt=model_type, _h=hidden_dim):
+            return preprocess_weight(_get_base_weight(_src), "gate_up", _h, _mt)
+        mm1_out = _base_grouped_mm(
+            permuted_input, offsets, _gate_up_provider, _moe_recompute_enabled(_gate_up_src),
+        )
 
         # Separated LoRA: + ((X @ first) @ second) * scaling.
         if gate_up_lora is not None:
@@ -1185,10 +1248,13 @@ def forward_native_grouped_mm(
         down_lora = _extract_lora_weights(self.down_proj, num_experts=self.num_experts, experts_module=self)
 
     if hasattr(self, "down_proj"):
-        down_base = _get_base_weight(self.down_proj)
         model_type = getattr(self, "_unsloth_model_type", None)
-        w2 = preprocess_weight(down_base, "down", hidden_dim, model_type)
-        mm2_out = _grouped_mm_with_backward_fix(inter, w2, offsets)
+        _down_src = self.down_proj
+        def _down_provider(_src=_down_src, _mt=model_type, _h=hidden_dim):
+            return preprocess_weight(_get_base_weight(_src), "down", _h, _mt)
+        mm2_out = _base_grouped_mm(
+            inter, offsets, _down_provider, _moe_recompute_enabled(_down_src),
+        )
 
         if down_lora is not None:
             first_weight, second_weight, scaling = down_lora

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -199,7 +199,8 @@ def _moe_recompute_enabled(source) -> bool:
 
 class _GroupedMMRecompute(torch.autograd.Function):
     """grouped_mm(inputs, W) for a frozen W from weight_provider(). Saves only
-    (inputs, offsets) + the provider, not the dense W; rebuilds W in backward for dX."""
+    offsets + the provider (inputs is unused for the frozen-base dX, and the dense W is
+    rebuilt in backward rather than pinned)."""
 
     @staticmethod
     def forward(ctx, inputs, offsets, weight_provider):

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -199,7 +199,13 @@ def _moe_recompute_default() -> bool:
     the pin is momentary and cheap; otherwise recompute (return True), so a
     non-checkpointed forward does not hold every layer's dense stack across the whole
     backward. UNSLOTH_MOE_RECOMPUTE overrides it: "1" forces recompute (max memory
-    saving), "0" forces pinning (max speed for memory-rich runs)."""
+    saving), "0" forces pinning (max speed for memory-rich runs).
+
+    The GC branch reads a thread-local; under torch.compile of the MoE forward that
+    read can be traced away and frozen at the first trace, so the adaptive choice may
+    not re-evaluate per GC pass. That only trades memory for speed (pin and recompute
+    are dX-identical), never correctness, and the grouped GEMM path generally runs
+    eager anyway; set UNSLOTH_MOE_RECOMPUTE explicitly to pin the choice if needed."""
     override = os.environ.get("UNSLOTH_MOE_RECOMPUTE")
     if override == "1":
         return True

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -191,7 +191,7 @@ def _base_is_recomputable(source) -> bool:
     return False
 
 
-def _moe_recompute_default() -> bool:
+def _moe_recompute_default(prefer_memory: bool = False) -> bool:
     """Pin-vs-recompute decision independent of the source weight.
 
     Adaptive by default: pin (return False) inside a gradient-checkpoint recompute
@@ -200,6 +200,13 @@ def _moe_recompute_default() -> bool:
     non-checkpointed forward does not hold every layer's dense stack across the whole
     backward. UNSLOTH_MOE_RECOMPUTE overrides it: "1" forces recompute (max memory
     saving), "0" forces pinning (max speed for memory-rich runs).
+
+    ``prefer_memory`` biases the no-override case toward recompute even inside a GC
+    recompute pass. It is set for bases whose pinned form is a large dense dequant of
+    a compressed weight (bnb 4-bit MoE experts): there the "momentary" pin still
+    materializes the full bf16 expert stack the 4-bit storage exists to avoid, which
+    can be several GiB per layer on large MoEs, so recompute is the better default
+    when the model is already memory-constrained (4-bit + gradient checkpointing).
 
     The GC branch reads a thread-local; under torch.compile of the MoE forward that
     read can be traced away and frozen at the first trace, so the adaptive choice may
@@ -211,6 +218,8 @@ def _moe_recompute_default() -> bool:
         return True
     if override == "0":
         return False
+    if prefer_memory:
+        return True
     try:
         from unsloth_zoo.gradient_checkpointing import in_gradient_checkpoint_recompute
         return not in_gradient_checkpoint_recompute()
@@ -218,11 +227,32 @@ def _moe_recompute_default() -> bool:
         return True  # safe default: recompute rather than pin across a full backward
 
 
+def _source_pins_large_dequant(source) -> bool:
+    """True iff pinning this base means holding a large dense dequant of a compressed
+    weight (a frozen bnb 4-bit MoE expert). For these the pinned path materializes the
+    full bf16 expert stack, so recompute is the memory-preserving default under
+    gradient checkpointing; a plain bf16/fp16/fp32 base pins its own storage (no
+    extra dequant) and keeps the speed-oriented adaptive policy."""
+    if not (HAS_BNB and Params4bit is not None):
+        return False
+    try:
+        param = source
+        while hasattr(param, "base_layer"):
+            param = param.base_layer
+        return isinstance(param, Params4bit) and getattr(param, "quant_state", None) is not None
+    except Exception:
+        return False
+
+
 def _moe_recompute_enabled(source) -> bool:
     """Whether to recompute the dequantized base stack in backward (True) or pin it
     for reuse (False). Only a frozen, grouped-mm-capable base can be recomputed; for
-    everything else the pinned eager path is used."""
-    return _base_is_recomputable(source) and _moe_recompute_default()
+    everything else the pinned eager path is used. A bnb 4-bit base prefers recompute
+    even under gradient checkpointing so the momentary pin never holds the full bf16
+    expert dequant (see _source_pins_large_dequant)."""
+    return _base_is_recomputable(source) and _moe_recompute_default(
+        prefer_memory = _source_pins_large_dequant(source)
+    )
 
 
 class _GroupedMMRecompute(torch.autograd.Function):

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -161,16 +161,15 @@ def _manual_grouped_mm(
     return inputs.new_empty((0, weight.shape[-1]))
 
 
-# Optional recompute-in-backward for the frozen base expert GEMM. With
-# UNSLOTH_MOE_RECOMPUTE=1 the dequantized bf16 expert stack is rebuilt from the 4-bit
-# Params4bit in backward (for dX only; the base is frozen and LoRA is a separate additive
-# grouped_mm) instead of being pinned on the tape. Output is unchanged; off by default the
-# call below is the prior eager path.
+# Recompute-in-backward for the frozen base expert GEMM: the dequantized bf16 stack
+# is rebuilt from the 4-bit Params4bit in backward (dX only; the base is frozen and
+# LoRA is a separate additive grouped_mm) instead of being pinned on the tape. Output
+# is unchanged. See _moe_recompute_enabled for the pin-vs-recompute policy.
 
 
-def _moe_recompute_enabled(source) -> bool:
-    if os.environ.get("UNSLOTH_MOE_RECOMPUTE", "0") != "1":
-        return False
+def _base_is_recomputable(source) -> bool:
+    """True iff the base expert weight can be rebuilt in backward (frozen and
+    grouped-mm capable). A trainable or unsupported base must use the pinned path."""
     try:
         if not _should_use_separated_lora():          # merged LoRA folds the delta into base
             return False
@@ -190,6 +189,34 @@ def _moe_recompute_enabled(source) -> bool:
     except Exception:
         return False
     return False
+
+
+def _moe_recompute_default() -> bool:
+    """Pin-vs-recompute decision independent of the source weight.
+
+    Adaptive by default: pin (return False) inside a gradient-checkpoint recompute
+    pass, where the stack is rebuilt immediately before the layer's own backward so
+    the pin is momentary and cheap; otherwise recompute (return True), so a
+    non-checkpointed forward does not hold every layer's dense stack across the whole
+    backward. UNSLOTH_MOE_RECOMPUTE overrides it: "1" forces recompute (max memory
+    saving), "0" forces pinning (max speed for memory-rich runs)."""
+    override = os.environ.get("UNSLOTH_MOE_RECOMPUTE")
+    if override == "1":
+        return True
+    if override == "0":
+        return False
+    try:
+        from unsloth_zoo.gradient_checkpointing import in_gradient_checkpoint_recompute
+        return not in_gradient_checkpoint_recompute()
+    except Exception:
+        return True  # safe default: recompute rather than pin across a full backward
+
+
+def _moe_recompute_enabled(source) -> bool:
+    """Whether to recompute the dequantized base stack in backward (True) or pin it
+    for reuse (False). Only a frozen, grouped-mm-capable base can be recomputed; for
+    everything else the pinned eager path is used."""
+    return _base_is_recomputable(source) and _moe_recompute_default()
 
 
 class _GroupedMMRecompute(torch.autograd.Function):

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -122,16 +122,31 @@ def _grouped_mm_with_backward_fix(
 ) -> torch.Tensor:
     """Grouped matmul via torch._grouped_mm with contiguous inputs.
 
-    Some low-rank LoRA weights are contiguous but still have row strides below
-    the kernel alignment requirement, so keep a narrow fallback for those cases.
+    The weight is passed AS-IS first. torch._grouped_mm accepts a transposed
+    (non-contiguous) view as long as one matmul dim is unit-stride. The base expert
+    stacks are stored (E, 2I, H) / (E, H, I) and preprocess_weight transposes them into
+    grouped layout, producing exactly such a view for the frozen base. Forcing
+    weight.contiguous() here materialised a full copy of that frozen stack (e.g. ~805 MB
+    for gate_up on Qwen3-30B) on every step; profiling attributed ~57% of MoE GPU time to
+    these copies. We only fall back to a contiguous copy (and then the per-group matmul)
+    when the kernel actually rejects the strides, which is the narrow case of some low-rank
+    LoRA weights whose row strides are below the 16-byte alignment requirement.
+
+    Bit-exact vs the previous always-contiguous path in forward and backward, for frozen
+    and trainable weights (torch._grouped_mm produces identical results for a contiguous
+    tensor and its equivalent view).
     """
     inputs = inputs.contiguous()
+    try:
+        return torch._grouped_mm(inputs, weight, offs=offsets)
+    except RuntimeError as exc:
+        if "strides should be multiple of 16 bytes" not in str(exc):
+            raise
     weight = weight.contiguous()
     try:
         return torch._grouped_mm(inputs, weight, offs=offsets)
     except RuntimeError as exc:
-        message = str(exc)
-        if "strides should be multiple of 16 bytes" not in message:
+        if "strides should be multiple of 16 bytes" not in str(exc):
             raise
         return _manual_grouped_mm(inputs, weight, offsets)
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -189,14 +189,14 @@ class _GroupedMMRecompute(torch.autograd.Function):
     @staticmethod
     def forward(ctx, inputs, offsets, weight_provider):
         ctx.weight_provider = weight_provider
-        ctx.save_for_backward(inputs, offsets)
+        ctx.save_for_backward(offsets)   # inputs is unused in backward (frozen base -> dX only)
         with torch.no_grad():
             out = _grouped_mm_with_backward_fix(inputs, weight_provider(), offsets)
         return out
 
     @staticmethod
     def backward(ctx, grad_output):
-        inputs, offsets = ctx.saved_tensors
+        (offsets,) = ctx.saved_tensors
         with torch.no_grad():
             weight_t = ctx.weight_provider().transpose(-2, -1).contiguous()
             grad_input = _grouped_mm_with_backward_fix(grad_output.contiguous(), weight_t, offsets)
@@ -686,7 +686,11 @@ def _get_base_weight(param):
                 "MoE quantizer patch did not fire for this expert. "
                 f"data.shape={tuple(param.data.shape)}, device={param.device}."
             )
-        return bnb.functional.dequantize_4bit(param.data, param.quant_state)
+        weight = bnb.functional.dequantize_4bit(param.data, param.quant_state)
+        original_shape = getattr(param, "_original_shape", None)
+        if original_shape is not None and weight.shape != original_shape:
+            weight = weight.reshape(original_shape)
+        return weight
 
     if hasattr(param, "get_param"):
         return param.get_param()

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -122,21 +122,28 @@ def _grouped_mm_with_backward_fix(
 ) -> torch.Tensor:
     """Grouped matmul via torch._grouped_mm with contiguous inputs.
 
-    The weight is passed AS-IS first. torch._grouped_mm accepts a transposed
-    (non-contiguous) view as long as one matmul dim is unit-stride. The base expert
+    The weight is passed AS-IS when the stack is known-safe. torch._grouped_mm accepts a
+    transposed (non-contiguous) view as long as one matmul dim is unit-stride. The base expert
     stacks are stored (E, 2I, H) / (E, H, I) and preprocess_weight transposes them into
     grouped layout, producing exactly such a view for the frozen base. Forcing
-    weight.contiguous() here materialised a full copy of that frozen stack (e.g. ~805 MB
-    for gate_up on Qwen3-30B) on every step; profiling attributed ~57% of MoE GPU time to
-    these copies. We only fall back to a contiguous copy (and then the per-group matmul)
-    when the kernel actually rejects the strides, which is the narrow case of some low-rank
-    LoRA weights whose row strides are below the 16-byte alignment requirement.
+    weight.contiguous() materialises a full copy of that frozen stack (e.g. ~805 MB for
+    gate_up on Qwen3-30B) on every step; profiling attributed ~57% of MoE GPU time to these
+    copies, so skipping it is a real speedup.
 
-    Bit-exact vs the previous always-contiguous path in forward and backward, for frozen
-    and trainable weights (torch._grouped_mm produces identical results for a contiguous
-    tensor and its equivalent view).
+    Some CUDA torch builds, however, silently miscompute torch._grouped_mm for exactly this
+    transposed bf16 view (pytorch/pytorch#186365). We therefore only skip the copy when a
+    one-time probe proves the view path is stable and matches the contiguous path on this
+    stack; otherwise we keep the contiguous copy (correct on every build). We also fall back
+    to a contiguous copy (and then the per-group matmul) when the kernel rejects the strides,
+    the narrow case of some low-rank LoRA weights below the 16-byte alignment requirement.
+
+    Bit-exact vs the always-contiguous path in forward and backward, for frozen and trainable
+    weights (torch._grouped_mm produces identical results for a contiguous tensor and its
+    equivalent view on stacks that pass the probe).
     """
     inputs = inputs.contiguous()
+    if not _transposed_view_grouped_mm_is_safe():
+        weight = weight.contiguous()   # #186365: view path unproven on this build -> safe copy
     try:
         return torch._grouped_mm(inputs, weight, offs=offsets)
     except RuntimeError as exc:
@@ -263,6 +270,52 @@ def _check_torch_grouped_mm_supported():
         _TORCH_GROUPED_MM_SUPPORTED = False
 
     return _TORCH_GROUPED_MM_SUPPORTED
+
+
+# Some CUDA torch builds miscompute torch._grouped_mm for a transposed (non-contiguous) bf16
+# weight view: results silently alternate / disagree with the contiguous copy when preceded by
+# a broadcast op (pytorch/pytorch#186365, seen on Blackwell with torch 2.11/2.13). We only skip
+# the contiguous copy in _grouped_mm_with_backward_fix on stacks where this probe proves the view
+# path is stable and matches the contiguous path; otherwise we keep the safe contiguous copy.
+_TRANSPOSED_VIEW_GROUPED_MM_SAFE = None
+
+
+def _transposed_view_grouped_mm_is_safe():
+    global _TRANSPOSED_VIEW_GROUPED_MM_SAFE
+    if _TRANSPOSED_VIEW_GROUPED_MM_SAFE is not None:
+        return _TRANSPOSED_VIEW_GROUPED_MM_SAFE
+
+    safe = False
+    try:
+        if _TORCH_GROUPED_MM_AVAILABLE and torch.cuda.is_available():
+            device = torch.cuda.current_device()
+            E, N, K, M = 4, 64, 32, 32
+            torch.manual_seed(0)
+            A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+            w = torch.randn(E, N, K, dtype=torch.bfloat16, device=device)
+            w_t = w.transpose(-2, -1)          # non-contiguous view (the fast path's layout)
+            w_tc = w_t.contiguous()            # known-correct reference
+            per = M // E
+            offs = torch.arange(per, M + 1, per, dtype=torch.int32, device=device)[:E]
+            offs[-1] = M
+            ok, ref = True, None
+            for _ in range(6):
+                row_wise_max = A.abs().amax(dim=-1, keepdim=True)
+                _ = A / (row_wise_max / 448.0)     # the #186365 trigger (result discarded)
+                r_view = torch._grouped_mm(A, w_t, offs=offs)
+                r_contig = torch._grouped_mm(A, w_tc, offs=offs)
+                if (r_view - r_contig).abs().max().item() > 1e-2:   # view disagrees with contiguous
+                    ok = False; break
+                if ref is None:
+                    ref = r_view
+                elif (r_view - ref).abs().max().item() > 1e-2:      # view not stable across calls
+                    ok = False; break
+            safe = ok
+    except Exception:
+        safe = False   # anything unexpected -> keep the safe contiguous copy
+
+    _TRANSPOSED_VIEW_GROUPED_MM_SAFE = safe
+    return safe
 
 
 _TRITON_ALLOCATOR_INITIALIZED = False

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -22,7 +22,6 @@ and quantize those parameters and route the experts forward through the
 standard backend after on-the-fly dequantization.
 """
 
-import os
 from typing import Optional, List, Union
 
 import torch
@@ -135,19 +134,25 @@ def forward_moe_backend_bnb4bit(self, hidden_states, top_k_index, top_k_weights)
         forward_triton_grouped_gemm,
         forward_native_moe_loop,
         swap_moe_weights_for_call,
+        _moe_recompute_default,
     )
 
     target_dtype = hidden_states.dtype
     if not target_dtype.is_floating_point:
         target_dtype = torch.bfloat16
 
-    # Fix 3: defer dequant into forward_native_grouped_mm's providers (recomputed in
-    # backward) instead of pre-dequantizing the full bf16 stack and pinning it.
+    # Defer dequant into forward_native_grouped_mm's providers instead of
+    # pre-dequantizing the full bf16 stack up front. Gated on the same adaptive
+    # pin-vs-recompute policy as the plain path (UNSLOTH_MOE_RECOMPUTE overrides it;
+    # pin inside a gradient-checkpoint recompute pass, recompute otherwise). This keeps
+    # the packed Params4bit and rebuilds the dense stack on demand; the pre-dequantize
+    # path below is only taken when the policy says pin, so we never pre-dequantize into
+    # a dense stack and then re-hold it for a backward recompute.
     if (
-        os.environ.get("UNSLOTH_MOE_RECOMPUTE", "0") == "1"
-        and select_moe_backend() == "grouped_mm"
+        select_moe_backend() == "grouped_mm"
         and _is_bnb4bit_param(self.gate_up_proj)
         and _is_bnb4bit_param(self.down_proj)
+        and _moe_recompute_default()
     ):
         _log_moe_bnb4bit_backend_once(self, "Unsloth: MoE bnb4bit grouped_mm with backward-recompute.")
         return forward_native_grouped_mm(self, hidden_states.to(target_dtype), top_k_index, top_k_weights)

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -142,17 +142,19 @@ def forward_moe_backend_bnb4bit(self, hidden_states, top_k_index, top_k_weights)
         target_dtype = torch.bfloat16
 
     # Defer dequant into forward_native_grouped_mm's providers instead of
-    # pre-dequantizing the full bf16 stack up front. Gated on the same adaptive
-    # pin-vs-recompute policy as the plain path (UNSLOTH_MOE_RECOMPUTE overrides it;
-    # pin inside a gradient-checkpoint recompute pass, recompute otherwise). This keeps
-    # the packed Params4bit and rebuilds the dense stack on demand; the pre-dequantize
-    # path below is only taken when the policy says pin, so we never pre-dequantize into
-    # a dense stack and then re-hold it for a backward recompute.
+    # pre-dequantizing the full bf16 stack up front. The 4-bit base prefers recompute
+    # by default (prefer_memory=True) so that, even inside a gradient-checkpoint
+    # recompute pass, we never materialize and pin the full bf16 expert dequant the
+    # 4-bit storage exists to avoid; UNSLOTH_MOE_RECOMPUTE=0 still forces the pin for
+    # memory-rich runs. This keeps the packed Params4bit and rebuilds the dense stack
+    # on demand; the pre-dequantize path below is only taken when the policy says pin,
+    # so we never pre-dequantize into a dense stack and then re-hold it for a backward
+    # recompute. Matches the per-source decision in forward_native_grouped_mm.
     if (
         select_moe_backend() == "grouped_mm"
         and _is_bnb4bit_param(self.gate_up_proj)
         and _is_bnb4bit_param(self.down_proj)
-        and _moe_recompute_default()
+        and _moe_recompute_default(prefer_memory = True)
     ):
         _log_moe_bnb4bit_backend_once(self, "Unsloth: MoE bnb4bit grouped_mm with backward-recompute.")
         return forward_native_grouped_mm(self, hidden_states.to(target_dtype), top_k_index, top_k_weights)

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -141,6 +141,17 @@ def forward_moe_backend_bnb4bit(self, hidden_states, top_k_index, top_k_weights)
     if not target_dtype.is_floating_point:
         target_dtype = torch.bfloat16
 
+    # Fix 3: defer dequant into forward_native_grouped_mm's providers (recomputed in
+    # backward) instead of pre-dequantizing the full bf16 stack and pinning it.
+    if (
+        os.environ.get("UNSLOTH_MOE_RECOMPUTE", "0") == "1"
+        and select_moe_backend() == "grouped_mm"
+        and _is_bnb4bit_param(self.gate_up_proj)
+        and _is_bnb4bit_param(self.down_proj)
+    ):
+        _log_moe_bnb4bit_backend_once(self, "Unsloth: MoE bnb4bit grouped_mm with backward-recompute.")
+        return forward_native_grouped_mm(self, hidden_states.to(target_dtype), top_k_index, top_k_weights)
+
     gate_up_weight = _dequantize_bnb4bit_expert_weights(self.gate_up_proj, target_dtype)
     down_weight = _dequantize_bnb4bit_expert_weights(self.down_proj, target_dtype)
     if gate_up_weight is None or down_weight is None:


### PR DESCRIPTION
### Problem

The native grouped MoE forward (`forward_native_grouped_mm`) feeds the dequantized bf16 expert weight stack to `torch._grouped_mm`. Native autograd then keeps that dense stack (`[E, hidden, 2*inter]` and `[E, inter, hidden]`) alive for the whole backward so it can form `dX = grad @ W^T`. The base expert weight is frozen and LoRA is applied as a separate additive grouped GEMM, so the base matmul only needs its weight for `dX`, never a base `dW`. That makes the pinned bf16 stack pure overhead that can be recomputed.

### Change

Add a small custom autograd Function that saves only `(inputs, offsets)` plus a weight provider, and rebuilds the frozen base weight from the 4-bit `Params4bit` in backward:

- `_GroupedMMRecompute` + `_base_grouped_mm` + `_moe_recompute_enabled` in `moe_utils.py`, wired into the gate_up and down base matmuls of `forward_native_grouped_mm`.
- A matching branch in `moe_utils_bnb4bit.py` so the no-LoRA bnb-4bit path defers its dequant into the provider instead of pre-dequantizing and pinning the stack.

One shared change covers every model that routes through the grouped backend (`qwen3_moe`, `qwen3_5_moe`, `gemma4`, `glm4_moe_lite`, and the others).

### Opt-in and safety

- Off by default (`UNSLOTH_MOE_RECOMPUTE=1` to enable). When off, `_base_grouped_mm` is exactly the prior eager call, so the path is byte-for-byte unchanged.
- Enabled only on the separated-LoRA path, with a frozen base (bnb-4bit with quant_state, or plain-frozen), and `torch._grouped_mm` support. So merged-LoRA, full finetuning, the fp8 path, the `w1`/`w3`/`w2` branch, and non-CUDA are untouched.
- The recompute output and `dX` are bit-identical to the eager path (verified on synthetic stacked experts, including zero-token experts).

### Results

4-bit QLoRA, 1x B200, seq 2048, gradient checkpointing on, 16 steps (off vs on):

| model | peak (off) | peak (on) | tok/s off | tok/s on |
|-------|-----------|-----------|-----------|----------|
| Qwen3-30B-A3B-Instruct-2507 | 26.27 GiB | 24.99 GiB | 2678 | 2557 |
| Qwen3.6-35B-A3B | 33.89 GiB | 32.36 GiB | 702 | 703 |
| gemma-4-26B-A4B | 24.21 GiB | 22.70 GiB | 2872 | 2759 |
| GLM-4.7-Flash | 23.46 GiB | 22.40 GiB | 2317 | 2246 |

About 1.0 to 1.5 GiB (4 to 6 percent) lower peak training memory at a small speed cost, with per-step loss matching. It is opt-in because gradient checkpointing already bounds most of the per-layer dequant, so the win is modest but free for memory-constrained or longer-context runs.
