### PR TITLE
GRPO: sequence packing for the gradient logp path (default-on)

### DIFF
--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -26,7 +26,7 @@ import logging
 import numpy as np
 from typing import Union, Callable, Optional, List, Dict
 from .device_type import DEVICE_TYPE, device_synchronize
-from .temporary_patches.common import torch_compile_options
+from .temporary_patches.common import torch_compile_options, UNSLOTH_ENABLE_LOGGING
 RL_REPLACEMENTS = dict()
 
 # https://github.com/huggingface/trl/blob/main/trl/trainer/utils.py#L1674
@@ -1026,7 +1026,7 @@ def grpo_accumulated_loss(
                         input_ids[:, -_pack_W:], left_pad_tokens_per_prompt, max_left_pad, _pack_pad_id
                     ).float()
                     _pack_diff = float(((_pack_result.detach() - _pack_ref).abs() * _pack_cm).max())
-                    if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
+                    if UNSLOTH_ENABLE_LOGGING:
                         print(f"[Unsloth] GRPO seq-packing (grad) verify: T={_pack_T} maxseg={_pack_maxseg} packed-vs-perrow max|d|={_pack_diff:.4f}", flush = True)
                     # floor ~0.25 through different kernels; cross-sample contamination is >= 2.4
                     if _pack_diff < 7e-1:
@@ -1047,7 +1047,7 @@ def grpo_accumulated_loss(
                             unwrapped_model._unsloth_seq_packing_grad_unsafe_T = (
                                 _pack_T if _pack_unsafe is None else min(_pack_unsafe, _pack_T)
                             )
-                        if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
+                        if UNSLOTH_ENABLE_LOGGING:
                             print(f"[Unsloth] GRPO seq-packing (grad) fell back at T={_pack_T} (diff={_pack_diff:.3f})", flush = True)
         except Exception as _pack_err:
             # any failure -> drop intermediates, use the padded loop, do not retry
@@ -1058,7 +1058,7 @@ def grpo_accumulated_loss(
             if isinstance(_pack_err, torch.cuda.OutOfMemoryError):
                 torch.cuda.empty_cache()
             unwrapped_model._unsloth_seq_packing_grad_ok = False
-            if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
+            if UNSLOTH_ENABLE_LOGGING:
                 print(f"[Unsloth] GRPO sequence-packing disabled (fell back to padded): {_pack_err!r}", flush = True)
     if _pack_use and _pack_result is not None:
         new_logprobs = _pack_result          # verified -> skip the loop

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1048,13 +1048,20 @@ def grpo_accumulated_loss(
                         _pack_ok = True
                         _pack_use = True
                     else:
-                        unwrapped_model._unsloth_seq_packing_grad_unsafe_T = (
-                            _pack_T if _pack_unsafe is None else min(_pack_unsafe, _pack_T)
-                        )
                         _pack_use = False
-                        if _pack_ok is None and _pack_T <= _pack_maxseg + 8:
-                            # failed at a small T (no LongRoPE story) -> backend ignores packing.
+                        if _pack_diff >= 1.5:
+                            # large mismatch = cross-sample contamination: this model's attention does
+                            # not honor the block-diagonal packed mask (seen on some MoE / custom-
+                            # attention models), so disable packing entirely and stop paying the
+                            # verification cost on later batches.
                             unwrapped_model._unsloth_seq_packing_grad_ok = False
+                        else:
+                            # moderate mismatch -> more likely a length-boundary effect (e.g. a
+                            # LongRoPE short/long cache switch): mark this length region unsafe but keep
+                            # packing available for smaller shapes.
+                            unwrapped_model._unsloth_seq_packing_grad_unsafe_T = (
+                                _pack_T if _pack_unsafe is None else min(_pack_unsafe, _pack_T)
+                            )
                         if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
                             print(f"[Unsloth] GRPO seq-packing (grad) fell back at T={_pack_T} (diff={_pack_diff:.3f})", flush = True)
         except Exception as _pack_err:

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -967,8 +967,10 @@ def grpo_accumulated_loss(
                 _pack_chunks = max(1, total_rows * multiplier)
                 _pack_nz_idx = _pack_keep.nonzero(as_tuple = False)            # [T, 2] = (row, col)
                 _pack_within = _pack_nz_idx[1:, 0] == _pack_nz_idx[:-1, 0]     # [T-1]
-                # completion-prediction positions only (col >= L - logits_to_keep, same row)
-                _pack_ctgt = (_pack_nz_idx[1:, 1] >= (_pack_L - logits_to_keep)) & _pack_within
+                # completion start is per-row after left-packing: (L - logits_to_keep) minus that
+                # row's left-pad (matches create_completion_attention_mask exactly)
+                _pack_cstart = (_pack_L - logits_to_keep) - left_pad_tokens_per_prompt  # [rows]
+                _pack_ctgt = (_pack_nz_idx[1:, 1] >= _pack_cstart[_pack_nz_idx[1:, 0]]) & _pack_within
                 with autocaster:
                     # use_cache=False: a KV cache silently disables varlen packing
                     _pack_hidden = unwrapped_model(
@@ -1018,10 +1020,12 @@ def grpo_accumulated_loss(
                             _pack_rkeep = _pack_rcols >= 0
                             _pack_ref[_pack_i, _pack_rcols[_pack_rkeep]] = _pack_rsel[_pack_rkeep].to(torch.float32)
                     device_synchronize()
-                    # compare only the completion region; the first max_left_pad window cols are
-                    # prompt-overflow the lm_head opt leaves 0
-                    _pack_cm = torch.zeros((total_rows, _pack_W), dtype = torch.float32, device = input_ids.device)
-                    _pack_cm[:, max_left_pad:] = (input_ids[:, -logits_to_keep:] != _pack_pad_id).float()
+                    # compare over the exact loss-mask region (per-row completion, non-pad)
+                    _pack_wc = torch.arange(_pack_W, device = input_ids.device)
+                    _pack_cm = (
+                        (_pack_wc.unsqueeze(0) >= (max_left_pad - left_pad_tokens_per_prompt).unsqueeze(1))
+                        & (input_ids[:, -_pack_W:] != _pack_pad_id)
+                    ).float()
                     _pack_diff = float(((_pack_result.detach() - _pack_ref).abs() * _pack_cm).max())
                     if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
                         print(f"[Unsloth] GRPO seq-packing (grad) verify: T={_pack_T} maxseg={_pack_maxseg} packed-vs-perrow max|d|={_pack_diff:.4f}", flush = True)

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -26,7 +26,7 @@ import logging
 import numpy as np
 from typing import Union, Callable, Optional, List, Dict
 from .device_type import DEVICE_TYPE, device_synchronize
-from .temporary_patches.common import torch_compile_options, UNSLOTH_ENABLE_LOGGING
+from .temporary_patches.common import torch_compile_options
 RL_REPLACEMENTS = dict()
 
 # https://github.com/huggingface/trl/blob/main/trl/trainer/utils.py#L1674
@@ -945,6 +945,9 @@ def grpo_accumulated_loss(
     _pack_ok = getattr(unwrapped_model, "_unsloth_seq_packing_grad_ok", None)
     if (_pack_enabled and pixel_values is None
             and token_type_ids is None and mm_token_type_ids is None and _pack_ok is not False):
+        # this function's source is copied into the generated GRPO trainer, so import the logging
+        # flag locally (before the try) to keep the bare name defined there too
+        from unsloth_zoo.temporary_patches.common import UNSLOTH_ENABLE_LOGGING
         try:
             _pack_pad_id = trainer.processing_class.pad_token_id
             _pack_keep = input_ids != _pack_pad_id

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1036,8 +1036,12 @@ def grpo_accumulated_loss(
                     # floor ~0.25 through different kernels; cross-sample contamination is >= 2.4
                     if _pack_diff < 7e-1:
                         unwrapped_model._unsloth_seq_packing_grad_ok = True
-                        unwrapped_model._unsloth_seq_packing_grad_verified_T = max(_pack_vT, _pack_T)
-                        unwrapped_model._unsloth_seq_packing_grad_verified_seg = max(_pack_vS, _pack_maxseg)
+                        # only widen the trusted shape when >= 2 completion rows actually exercised
+                        # cross-sample packing; a < 2 row pass proves nothing, so keep re-verifying
+                        # larger shapes until a real multi-row batch clears them
+                        if _pack_active >= 2:
+                            unwrapped_model._unsloth_seq_packing_grad_verified_T = max(_pack_vT, _pack_T)
+                            unwrapped_model._unsloth_seq_packing_grad_verified_seg = max(_pack_vS, _pack_maxseg)
                         _pack_ok = True
                         _pack_use = True
                     else:

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -815,7 +815,8 @@ def grpo_accumulated_loss(
         input_ids = left_pack_padding(input_ids, trainer.processing_class.pad_token_id)
 
         completion_input_ids = input_ids[:, -(logits_to_keep +max_left_pad):]
-        completion_mask = create_completion_attention_mask(completion_input_ids, left_pad_tokens_per_prompt, max_left_pad, trainer.processing_class.pad_token_id).to(attention_mask.dtype)
+        _pure_completion_mask = create_completion_attention_mask(completion_input_ids, left_pad_tokens_per_prompt, max_left_pad, trainer.processing_class.pad_token_id)
+        completion_mask = _pure_completion_mask.to(attention_mask.dtype)
 
         if trainer.use_vllm and sampling_per_token_logps is not None and getattr(trainer, "vllm_importance_sampling_correction", False):
             sampling_per_token_logps = align_logprobs_with_mask(sampling_per_token_logps, completion_mask)
@@ -825,6 +826,7 @@ def grpo_accumulated_loss(
         attention_mask =  input_ids != trainer.processing_class.pad_token_id
         attention_mask = attention_mask.to(attention_mask.dtype)
     else:
+        _pure_completion_mask = None  # no packing on the multimodal path -> masked columns already consistent
         completion_input_ids = input_ids[:, -logits_to_keep:]
         completion_mask = align_completion_tool_mask(tool_mask, completion_mask)
 
@@ -997,14 +999,6 @@ def grpo_accumulated_loss(
                 _pack_result = torch.zeros(
                     total_rows * _pack_L, dtype = torch.float32, device = input_ids.device,
                 ).index_put((_pack_tgt,), _pack_sel.to(torch.float32)).view(total_rows, _pack_L)[:, -_pack_W:]
-                # Non-completion columns are 0 here, but grpo_compute_loss takes exp(new - old) BEFORE the
-                # completion mask, so a 0 against a real old logprob can overflow to inf (then inf*0 = nan).
-                # Copy old into those masked columns so the ratio is exactly 0 there (they are masked anyway).
-                if old_logps is not None:
-                    _pack_keepmask = create_completion_attention_mask(
-                        input_ids[:, -_pack_W:], left_pad_tokens_per_prompt, max_left_pad, _pack_pad_id
-                    )
-                    _pack_result = torch.where(_pack_keepmask, _pack_result, old_logps.to(_pack_result.dtype))
                 # trust decision: re-verify when T or the longest segment grows past what was verified
                 # (a LongRoPE cache switch can change the result)
                 _pack_vT = int(getattr(unwrapped_model, "_unsloth_seq_packing_grad_verified_T", 0))
@@ -1236,6 +1230,19 @@ def grpo_accumulated_loss(
     if new_logprobs is None:
         # padded fallback (packing disabled / unsupported / not verified for this length)
         new_logprobs = torch.cat(all_logprobs_list, dim=0)
+
+    if _pure_completion_mask is not None:
+        # grpo_compute_loss takes exp(new - old) and exp(ref - new) BEFORE the completion mask. The
+        # masked left-pad/prompt columns are dropped by that mask, but a packed path leaves them at 0
+        # while a padded one fills them with a real logprob, so when this grad path and the no-grad
+        # old/ref path pick different packing the ratios overflow to inf and inf * 0 = nan in the loss
+        # and its gradient. Zero those columns on all three so both ratios are exp(0) = 1 there; the
+        # loss is unchanged (they are masked out) and the completion columns are untouched.
+        new_logprobs = torch.where(_pure_completion_mask, new_logprobs, 0.0)
+        if old_logps is not None:
+            old_logps = torch.where(_pure_completion_mask, old_logps, 0.0)
+        if ref_logps is not None:
+            ref_logps = torch.where(_pure_completion_mask, ref_logps, 0.0)
 
     with autocaster:
         loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1 = UnslothEfficientGRPO.apply(

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1020,11 +1020,10 @@ def grpo_accumulated_loss(
                             _pack_rkeep = _pack_rcols >= 0
                             _pack_ref[_pack_i, _pack_rcols[_pack_rkeep]] = _pack_rsel[_pack_rkeep].to(torch.float32)
                     device_synchronize()
-                    # compare over the exact loss-mask region (per-row completion, non-pad)
-                    _pack_wc = torch.arange(_pack_W, device = input_ids.device)
-                    _pack_cm = (
-                        (_pack_wc.unsqueeze(0) >= (max_left_pad - left_pad_tokens_per_prompt).unsqueeze(1))
-                        & (input_ids[:, -_pack_W:] != _pack_pad_id)
+                    # compare over the exact loss-mask region (same mask the loss uses; pure
+                    # create_completion_attention_mask, before any tool_mask is applied)
+                    _pack_cm = create_completion_attention_mask(
+                        input_ids[:, -_pack_W:], left_pad_tokens_per_prompt, max_left_pad, _pack_pad_id
                     ).float()
                     _pack_diff = float(((_pack_result.detach() - _pack_ref).abs() * _pack_cm).max())
                     if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -963,7 +963,10 @@ def grpo_accumulated_loss(
             _pack_sw = getattr(getattr(unwrapped_model, "config", None), "sliding_window", None)
             _pack_sw_ok = not (isinstance(_pack_sw, int) and _pack_sw > 0 and _pack_maxseg > _pack_sw)
             _pack_active = int((completion_mask.sum(dim = 1) > 0).sum())
-            if _pack_T >= 2 and len(_pack_nz_cpu) > 0 and _pack_sw_ok and (_pack_ok is True or _pack_active >= 2):
+            _pack_unsafe = getattr(unwrapped_model, "_unsloth_seq_packing_grad_unsafe_T", None)
+            # skip the whole packed forward for a known-unsafe length region (a prior moderate mismatch)
+            if _pack_T >= 2 and len(_pack_nz_cpu) > 0 and _pack_sw_ok and (_pack_ok is True or _pack_active >= 2) \
+                    and not (_pack_unsafe is not None and _pack_T >= _pack_unsafe):
                 _pack_psl = torch.tensor(_pack_nz_cpu, dtype = torch.int32, device = input_ids.device)
                 # reset 0-based position_ids per segment
                 _pack_pos = (_pack_keep.cumsum(dim = 1) - 1)[_pack_keep].unsqueeze(0)
@@ -994,16 +997,21 @@ def grpo_accumulated_loss(
                 _pack_result = torch.zeros(
                     total_rows * _pack_L, dtype = torch.float32, device = input_ids.device,
                 ).index_put((_pack_tgt,), _pack_sel.to(torch.float32)).view(total_rows, _pack_L)[:, -_pack_W:]
+                # Non-completion columns are 0 here, but grpo_compute_loss takes exp(new - old) BEFORE the
+                # completion mask, so a 0 against a real old logprob can overflow to inf (then inf*0 = nan).
+                # Copy old into those masked columns so the ratio is exactly 0 there (they are masked anyway).
+                if old_logps is not None:
+                    _pack_keepmask = create_completion_attention_mask(
+                        input_ids[:, -_pack_W:], left_pad_tokens_per_prompt, max_left_pad, _pack_pad_id
+                    )
+                    _pack_result = torch.where(_pack_keepmask, _pack_result, old_logps.to(_pack_result.dtype))
                 # trust decision: re-verify when T or the longest segment grows past what was verified
                 # (a LongRoPE cache switch can change the result)
                 _pack_vT = int(getattr(unwrapped_model, "_unsloth_seq_packing_grad_verified_T", 0))
                 _pack_vS = int(getattr(unwrapped_model, "_unsloth_seq_packing_grad_verified_seg", 0))
-                _pack_unsafe = getattr(unwrapped_model, "_unsloth_seq_packing_grad_unsafe_T", None)
                 _pack_force_verify = os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_VERIFY", "0") == "1"
                 if (not _pack_force_verify) and _pack_ok is True and _pack_T <= _pack_vT and _pack_maxseg <= _pack_vS:
                     _pack_use = True                                           # already verified for this shape
-                elif _pack_unsafe is not None and _pack_T >= _pack_unsafe:
-                    _pack_use = False                                          # known-unsafe length region
                 else:
                     # verify against the per-row clean forward (exact ground truth; no grad, value check)
                     _pack_ref = torch.zeros_like(_pack_result)
@@ -1066,6 +1074,9 @@ def grpo_accumulated_loss(
     if _pack_use and _pack_result is not None:
         new_logprobs = _pack_result          # verified -> skip the loop
         zipped_inputs = []
+    else:
+        # packing rejected/unused: drop the packed graph before the padded loop so both don't co-reside
+        _pack_hidden = _pack_sel = _pack_result = None
 
     def to_device(tensor, device, non_blocking=True):
         if tensor is None: return None

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -933,6 +933,89 @@ def grpo_accumulated_loss(
     else:
         autocaster = torch.amp.autocast(device_type = trainer.model.device.type, dtype = trainer._autocast_dtype)
 
+    # ---- Sequence-packing fast path (opt-in via UNSLOTH_GRPO_SEQ_PACKING=1; text-only) ----
+    # Replaces the padded [B, Lmax] per-chunk forward below with ONE varlen [1, sum L] forward
+    # (BlockDiagonalCausalMask via packed_seq_lengths + reset position_ids), producing the SAME
+    # new_logprobs [total_rows, W] in the left-packed completion layout. Per-token logps use the
+    # exact same float32 chunked_hidden_states_selective_log_softmax the padded path uses, so the
+    # loss/gradients are bit-for-bit identical. Big memory/time win on long, variable-length
+    # completions. Correctness is self-verified ONCE against the padded path
+    # (unwrapped_model._unsloth_seq_packing_grad_ok): if a backend silently ignores packed_seq_lengths (so the
+    # flat batch is run with a normal causal mask and samples leak across boundaries) the packed
+    # logps will not match the padded path and packing is disabled instead of corrupting training.
+    new_logprobs = None
+    _pack_result = None
+    # Verdict is cached per unwrapped model (a separate reference model could have a different
+    # forward path) and is only set after a real comparison; token_type_ids / mm_token_type_ids force
+    # the padded path (those VLM mask inputs are not packed here).
+    _pack_verdict = getattr(unwrapped_model, "_unsloth_seq_packing_grad_ok", None)
+    if (pixel_values is None and os.environ.get("UNSLOTH_GRPO_SEQ_PACKING", "0") == "1"
+            and token_type_ids is None and mm_token_type_ids is None and _pack_verdict is not False):
+        try:
+            # xformers provides the block-diagonal varlen mask; without it the packed attention falls
+            # back to a dense O(T^2) SDPA mask that can OOM on the whole flattened batch, so require it.
+            import xformers  # noqa: F401
+            _pack_pad_id = trainer.processing_class.pad_token_id
+            _pack_keep = input_ids != _pack_pad_id
+            _pack_lengths = _pack_keep.sum(dim = 1)
+            _pack_nz = _pack_lengths[_pack_lengths > 0]
+            _pack_flat_ids = input_ids[_pack_keep].unsqueeze(0)
+            _pack_T = _pack_flat_ids.shape[1]
+            _pack_L = input_ids.shape[1]
+            _pack_W = logits_to_keep + max_left_pad
+            # Sliding-window attention loses the per-sequence local window once the packed stream is
+            # longer than the window (FlashAttention/xFormers then attend across sample boundaries),
+            # so skip packing for that batch.
+            _pack_sw = getattr(getattr(unwrapped_model, "config", None), "sliding_window", None)
+            _pack_sw_ok = not (isinstance(_pack_sw, int) and _pack_sw > 0 and _pack_T > _pack_sw)
+            if _pack_T >= 2 and _pack_nz.numel() > 0 and _pack_sw_ok:
+                _pack_psl = _pack_nz.to(torch.int32)
+                _pack_pos = torch.cat(
+                    [torch.arange(int(_n), device = input_ids.device) for _n in _pack_nz]
+                ).unsqueeze(0)
+                _pack_chunks = max(1, total_rows * multiplier)
+                with autocaster:
+                    # use_cache=False: a populated past_key_value disables varlen packing in the
+                    # attention kernels, which would silently fall back to dense causal attention.
+                    _pack_hidden = unwrapped_model(
+                        input_ids = _pack_flat_ids,
+                        position_ids = _pack_pos,
+                        packed_seq_lengths = _pack_psl,
+                        use_cache = False,
+                    ).logits
+                    _pack_sel = chunked_hidden_states_selective_log_softmax(
+                        _pack_hidden[:, :-1, :], lm_head, _pack_flat_ids[:, 1:], _pack_chunks,
+                        logit_scale_multiply, logit_scale_divide, logit_softcapping, temperature,
+                    )[0]
+                # Same GPT-OSS offload (offload_embbed=True) race guard the padded loop uses.
+                device_synchronize()
+                _pack_idx = []; _pack_val = []; _pack_off = 0
+                for _pack_i in range(total_rows):
+                    _pack_n = int(_pack_lengths[_pack_i])
+                    if _pack_n >= 2:
+                        _pack_idx.append(_pack_i * _pack_L + torch.arange(1, _pack_n, device = input_ids.device))
+                        _pack_val.append(_pack_sel[_pack_off : _pack_off + _pack_n - 1])
+                    _pack_off += _pack_n
+                if _pack_idx:
+                    _pack_flat_idx = torch.cat(_pack_idx)
+                    _pack_vals = torch.cat(_pack_val).to(torch.float32)
+                    _pack_result = torch.zeros(
+                        total_rows * _pack_L, dtype = torch.float32, device = input_ids.device,
+                    ).index_put((_pack_flat_idx,), _pack_vals).view(total_rows, _pack_L)[:, -_pack_W:]
+        except Exception as _pack_err:
+            # Disable packing for this model on any failure (no xformers varlen backend, an OOM on an
+            # oversized flattened batch the padded loop would chunk, or an unsupported forward) so we
+            # use the chunked padded loop and do not retry every step.
+            if isinstance(_pack_err, torch.cuda.OutOfMemoryError):
+                torch.cuda.empty_cache()
+            unwrapped_model._unsloth_seq_packing_grad_ok = False
+            if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
+                print(f"[Unsloth] GRPO sequence-packing disabled (fell back to padded): {_pack_err!r}", flush = True)
+            _pack_result = None
+    if _pack_result is not None and getattr(unwrapped_model, "_unsloth_seq_packing_grad_ok", False):
+        new_logprobs = _pack_result          # already verified equal to padded -> skip the loop
+        zipped_inputs = []
+
     def to_device(tensor, device, non_blocking=True):
         if tensor is None: return None
         return tensor.to(device, non_blocking=non_blocking)
@@ -1088,7 +1171,24 @@ def grpo_accumulated_loss(
                 device_synchronize()
             all_logprobs_list.append(logprobs_chunk)
 
-    new_logprobs = torch.cat(all_logprobs_list, dim=0)
+    if new_logprobs is None:
+        new_logprobs = torch.cat(all_logprobs_list, dim=0)
+        # One-time self-verification: only trust packing after it matches the padded ground truth on
+        # a real (>=2 sequence) batch. Cross-sample contamination (unsupported packed mask) shows up
+        # as a large mismatch here and disables packing instead of silently corrupting training.
+        if _pack_result is not None and not hasattr(unwrapped_model, "_unsloth_seq_packing_grad_ok"):
+            # Require >=2 rows that actually have completion tokens, so cross-sample contamination
+            # would manifest in the diff. An all-pad / fully tool-masked completion_mask makes the
+            # masked diff trivially zero, which must NOT be taken as a pass: leave the verdict unset
+            # and re-verify on a later, non-degenerate batch instead.
+            _pack_active_rows = int((completion_mask.sum(dim = 1) > 0).sum())
+            if _pack_active_rows >= 2 and _pack_result.shape == new_logprobs.shape:
+                _pack_ok = bool(float(((_pack_result - new_logprobs).detach().abs() * completion_mask).max()) < 5e-1)
+                unwrapped_model._unsloth_seq_packing_grad_ok = _pack_ok
+                if _pack_ok:
+                    new_logprobs = _pack_result
+                elif os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
+                    print("[Unsloth] GRPO sequence-packing disabled: packed logprobs did not match the padded path", flush = True)
 
     with autocaster:
         loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1 = UnslothEfficientGRPO.apply(

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -933,18 +933,11 @@ def grpo_accumulated_loss(
     else:
         autocaster = torch.amp.autocast(device_type = trainer.model.device.type, dtype = trainer._autocast_dtype)
 
-    # ---- Sequence-packing fast path (default-on; disable with UNSLOTH_GRPO_SEQ_PACKING=0) ----
-    # Replaces the padded [B, Lmax] per-chunk forward below with ONE varlen [1, sum L] forward
-    # (BlockDiagonalCausalMask via packed_seq_lengths + reset position_ids). The packed forward is
-    # the EXACT per-row computation (each segment attends only within itself), so it equals
-    # forwarding each row's real tokens alone -- and is strictly more accurate than the padded batch
-    # forward, which mis-positions left-padded rows (Unsloth's known Flash-Attn left-padding issue)
-    # on long completions. Loss/gradients flow through the packed forward. Correctness is
-    # self-verified against the PER-ROW clean forward (NOT the padded batch, which is itself wrong
-    # for left-pad), shape/RoPE-aware: re-checked whenever the packed total length T grows past the
-    # largest verified T, so a later batch that crosses a LongRoPE short/long cache boundary -- or a
-    # backend that ignores packed_seq_lengths and leaks across samples -- is caught and falls back to
-    # the padded loop. lm_head runs only on completion-prediction positions.
+    # ---- Sequence packing (default-on; disable with UNSLOTH_GRPO_SEQ_PACKING=0) ----
+    # One varlen [1, sum L] block-diagonal forward replaces the padded [B, Lmax] loop: the exact per-row
+    # result, and it fixes the padded path's left-pad RoPE error. Loss/gradients flow through it. Self-
+    # verified against the per-row forward (shape/RoPE-aware, re-checked as T grows); falls back if a
+    # backend ignores packed_seq_lengths. lm_head runs on completion positions only.
     new_logprobs = None
     _pack_result = None
     _pack_use = False
@@ -969,17 +962,15 @@ def grpo_accumulated_loss(
             _pack_active = int((completion_mask.sum(dim = 1) > 0).sum())
             if _pack_T >= 2 and len(_pack_nz_cpu) > 0 and _pack_sw_ok and (_pack_ok is True or _pack_active >= 2):
                 _pack_psl = torch.tensor(_pack_nz_cpu, dtype = torch.int32, device = input_ids.device)
-                # vectorized reset 0-based position_ids (no per-row sync)
+                # reset 0-based position_ids per segment
                 _pack_pos = (_pack_keep.cumsum(dim = 1) - 1)[_pack_keep].unsqueeze(0)
                 _pack_chunks = max(1, total_rows * multiplier)
                 _pack_nz_idx = _pack_keep.nonzero(as_tuple = False)            # [T, 2] = (row, col)
                 _pack_within = _pack_nz_idx[1:, 0] == _pack_nz_idx[:-1, 0]     # [T-1]
-                # completion-prediction positions only: token j+1 is a real completion token
-                # (col >= L - logits_to_keep) in the same row as j. lm_head runs only on these.
+                # completion-prediction positions only (col >= L - logits_to_keep, same row)
                 _pack_ctgt = (_pack_nz_idx[1:, 1] >= (_pack_L - logits_to_keep)) & _pack_within
                 with autocaster:
-                    # use_cache=False: a populated past_key_value disables varlen packing in the
-                    # attention kernels, which would silently fall back to dense causal attention.
+                    # use_cache=False: a KV cache silently disables varlen packing
                     _pack_hidden = unwrapped_model(
                         input_ids = _pack_flat_ids,
                         position_ids = _pack_pos,
@@ -991,17 +982,15 @@ def grpo_accumulated_loss(
                         _pack_flat_ids[0, 1:][_pack_ctgt].unsqueeze(0), _pack_chunks,
                         logit_scale_multiply, logit_scale_divide, logit_softcapping, temperature,
                     )[0]
-                # Same GPT-OSS offload (offload_embbed=True) race guard the padded loop uses.
+                # GPT-OSS offload race guard (matches the padded loop)
                 device_synchronize()
-                # Scatter each completion next-token logprob to its ORIGINAL (row, col) so left-padded
-                # prompts land in the right columns; [:, -_pack_W:] then matches the padded layout.
+                # scatter each completion logprob back to its (row, col) so [:, -_pack_W:] matches padded
                 _pack_tgt = (_pack_nz_idx[1:, 0] * _pack_L + _pack_nz_idx[1:, 1])[_pack_ctgt]
                 _pack_result = torch.zeros(
                     total_rows * _pack_L, dtype = torch.float32, device = input_ids.device,
                 ).index_put((_pack_tgt,), _pack_sel.to(torch.float32)).view(total_rows, _pack_L)[:, -_pack_W:]
-                # ---- trust decision (shape/RoPE-aware) ----
-                # Re-verify when packed total length OR longest segment grows past what was verified
-                # (LongRoPE short/long cache can switch on either).
+                # trust decision: re-verify when T or the longest segment grows past what was verified
+                # (a LongRoPE cache switch can change the result)
                 _pack_vT = int(getattr(unwrapped_model, "_unsloth_seq_packing_grad_verified_T", 0))
                 _pack_vS = int(getattr(unwrapped_model, "_unsloth_seq_packing_grad_verified_seg", 0))
                 _pack_unsafe = getattr(unwrapped_model, "_unsloth_seq_packing_grad_unsafe_T", None)
@@ -1011,8 +1000,7 @@ def grpo_accumulated_loss(
                 elif _pack_unsafe is not None and _pack_T >= _pack_unsafe:
                     _pack_use = False                                          # known-unsafe length region
                 else:
-                    # verify against the per-row clean forward (exact ground truth: each row's real
-                    # tokens alone, 0-based positions, no padding). No grad -- this is a value check.
+                    # verify against the per-row clean forward (exact ground truth; no grad, value check)
                     _pack_ref = torch.zeros_like(_pack_result)
                     with torch.no_grad(), autocaster:
                         for _pack_i in range(total_rows):
@@ -1030,17 +1018,14 @@ def grpo_accumulated_loss(
                             _pack_rkeep = _pack_rcols >= 0
                             _pack_ref[_pack_i, _pack_rcols[_pack_rkeep]] = _pack_rsel[_pack_rkeep].to(torch.float32)
                     device_synchronize()
-                    # Compare ONLY the completion region (window cols [max_left_pad, W)). The window's
-                    # first max_left_pad cols are prompt-overflow that the lm_head completion-window opt
-                    # leaves 0 (masked out by completion_mask in the loss); including them would falsely
-                    # flag a mismatch.
+                    # compare only the completion region; the first max_left_pad window cols are
+                    # prompt-overflow the lm_head opt leaves 0
                     _pack_cm = torch.zeros((total_rows, _pack_W), dtype = torch.float32, device = input_ids.device)
                     _pack_cm[:, max_left_pad:] = (input_ids[:, -logits_to_keep:] != _pack_pad_id).float()
                     _pack_diff = float(((_pack_result.detach() - _pack_ref).abs() * _pack_cm).max())
                     if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
                         print(f"[Unsloth] GRPO seq-packing (grad) verify: T={_pack_T} maxseg={_pack_maxseg} packed-vs-perrow max|d|={_pack_diff:.4f}", flush = True)
-                    # floor: packed vs per-row through different attention kernels ~0.25 (the padded
-                    # path is itself ~0.4 from per-row truth); cross-sample contamination >= 2.4.
+                    # floor ~0.25 through different kernels; cross-sample contamination is >= 2.4
                     if _pack_diff < 7e-1:
                         unwrapped_model._unsloth_seq_packing_grad_ok = True
                         unwrapped_model._unsloth_seq_packing_grad_verified_T = max(_pack_vT, _pack_T)
@@ -1050,23 +1035,19 @@ def grpo_accumulated_loss(
                     else:
                         _pack_use = False
                         if _pack_diff >= 1.5:
-                            # large mismatch = cross-sample contamination: this model's attention does
-                            # not honor the block-diagonal packed mask (seen on some MoE / custom-
-                            # attention models), so disable packing entirely and stop paying the
-                            # verification cost on later batches.
+                            # large mismatch = contamination (attention ignores the packed mask, e.g.
+                            # some MoE): disable packing for this model
                             unwrapped_model._unsloth_seq_packing_grad_ok = False
                         else:
-                            # moderate mismatch -> more likely a length-boundary effect (e.g. a
-                            # LongRoPE short/long cache switch): mark this length region unsafe but keep
-                            # packing available for smaller shapes.
+                            # moderate mismatch -> likely a length boundary (LongRoPE): mark unsafe but
+                            # keep packing for smaller shapes
                             unwrapped_model._unsloth_seq_packing_grad_unsafe_T = (
                                 _pack_T if _pack_unsafe is None else min(_pack_unsafe, _pack_T)
                             )
                         if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
                             print(f"[Unsloth] GRPO seq-packing (grad) fell back at T={_pack_T} (diff={_pack_diff:.3f})", flush = True)
         except Exception as _pack_err:
-            # Any failure (no varlen backend, OOM on the flattened batch, unsupported forward) -> drop
-            # packed intermediates, reclaim memory, use the padded loop, do not retry.
+            # any failure -> drop intermediates, use the padded loop, do not retry
             _pack_hidden = None
             _pack_sel = None
             _pack_result = None
@@ -1077,7 +1058,7 @@ def grpo_accumulated_loss(
             if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
                 print(f"[Unsloth] GRPO sequence-packing disabled (fell back to padded): {_pack_err!r}", flush = True)
     if _pack_use and _pack_result is not None:
-        new_logprobs = _pack_result          # verified equal to per-row ground truth -> skip the loop
+        new_logprobs = _pack_result          # verified -> skip the loop
         zipped_inputs = []
 
     def to_device(tensor, device, non_blocking=True):
@@ -1236,8 +1217,7 @@ def grpo_accumulated_loss(
             all_logprobs_list.append(logprobs_chunk)
 
     if new_logprobs is None:
-        # Padded fallback result (packing disabled / unsupported / not yet verified for this length).
-        # Verification against the per-row ground truth already happened in the packing block above.
+        # padded fallback (packing disabled / unsupported / not verified for this length)
         new_logprobs = torch.cat(all_logprobs_list, dim=0)
 
     with autocaster:

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -933,47 +933,50 @@ def grpo_accumulated_loss(
     else:
         autocaster = torch.amp.autocast(device_type = trainer.model.device.type, dtype = trainer._autocast_dtype)
 
-    # ---- Sequence-packing fast path (opt-in via UNSLOTH_GRPO_SEQ_PACKING=1; text-only) ----
+    # ---- Sequence-packing fast path (default-on; disable with UNSLOTH_GRPO_SEQ_PACKING=0) ----
     # Replaces the padded [B, Lmax] per-chunk forward below with ONE varlen [1, sum L] forward
-    # (BlockDiagonalCausalMask via packed_seq_lengths + reset position_ids), producing the SAME
-    # new_logprobs [total_rows, W] in the left-packed completion layout. Per-token logps use the
-    # exact same float32 chunked_hidden_states_selective_log_softmax the padded path uses, so the
-    # loss/gradients are bit-for-bit identical. Big memory/time win on long, variable-length
-    # completions. Correctness is self-verified ONCE against the padded path
-    # (unwrapped_model._unsloth_seq_packing_grad_ok): if a backend silently ignores packed_seq_lengths (so the
-    # flat batch is run with a normal causal mask and samples leak across boundaries) the packed
-    # logps will not match the padded path and packing is disabled instead of corrupting training.
+    # (BlockDiagonalCausalMask via packed_seq_lengths + reset position_ids). The packed forward is
+    # the EXACT per-row computation (each segment attends only within itself), so it equals
+    # forwarding each row's real tokens alone -- and is strictly more accurate than the padded batch
+    # forward, which mis-positions left-padded rows (Unsloth's known Flash-Attn left-padding issue)
+    # on long completions. Loss/gradients flow through the packed forward. Correctness is
+    # self-verified against the PER-ROW clean forward (NOT the padded batch, which is itself wrong
+    # for left-pad), shape/RoPE-aware: re-checked whenever the packed total length T grows past the
+    # largest verified T, so a later batch that crosses a LongRoPE short/long cache boundary -- or a
+    # backend that ignores packed_seq_lengths and leaks across samples -- is caught and falls back to
+    # the padded loop. lm_head runs only on completion-prediction positions.
     new_logprobs = None
     _pack_result = None
-    # Verdict is cached per unwrapped model (a separate reference model could have a different
-    # forward path) and is only set after a real comparison; token_type_ids / mm_token_type_ids force
-    # the padded path (those VLM mask inputs are not packed here).
-    _pack_verdict = getattr(unwrapped_model, "_unsloth_seq_packing_grad_ok", None)
-    if (pixel_values is None and os.environ.get("UNSLOTH_GRPO_SEQ_PACKING", "0") == "1"
-            and token_type_ids is None and mm_token_type_ids is None and _pack_verdict is not False):
+    _pack_use = False
+    _pack_enabled = os.environ.get("UNSLOTH_GRPO_SEQ_PACKING", "1").lower() not in ("0", "false", "no", "off")
+    _pack_ok = getattr(unwrapped_model, "_unsloth_seq_packing_grad_ok", None)
+    if (_pack_enabled and pixel_values is None
+            and token_type_ids is None and mm_token_type_ids is None and _pack_ok is not False):
         try:
-            # xformers provides the block-diagonal varlen mask; without it the packed attention falls
-            # back to a dense O(T^2) SDPA mask that can OOM on the whole flattened batch, so require it.
-            import xformers  # noqa: F401
             _pack_pad_id = trainer.processing_class.pad_token_id
             _pack_keep = input_ids != _pack_pad_id
             _pack_lengths = _pack_keep.sum(dim = 1)
-            _pack_nz = _pack_lengths[_pack_lengths > 0]
+            _pack_lengths_cpu = _pack_lengths.tolist()                 # single GPU->CPU sync, reused below
+            _pack_nz_cpu = [_n for _n in _pack_lengths_cpu if _n > 0]
             _pack_flat_ids = input_ids[_pack_keep].unsqueeze(0)
             _pack_T = _pack_flat_ids.shape[1]
             _pack_L = input_ids.shape[1]
             _pack_W = logits_to_keep + max_left_pad
-            # Sliding-window attention loses the per-sequence local window once the packed stream is
-            # longer than the window (FlashAttention/xFormers then attend across sample boundaries),
-            # so skip packing for that batch.
+            _pack_maxseg = max(_pack_nz_cpu) if _pack_nz_cpu else 0
+            # sliding-window models lose the per-sequence local window in a packed stream
             _pack_sw = getattr(getattr(unwrapped_model, "config", None), "sliding_window", None)
-            _pack_sw_ok = not (isinstance(_pack_sw, int) and _pack_sw > 0 and _pack_T > _pack_sw)
-            if _pack_T >= 2 and _pack_nz.numel() > 0 and _pack_sw_ok:
-                _pack_psl = _pack_nz.to(torch.int32)
-                _pack_pos = torch.cat(
-                    [torch.arange(int(_n), device = input_ids.device) for _n in _pack_nz]
-                ).unsqueeze(0)
+            _pack_sw_ok = not (isinstance(_pack_sw, int) and _pack_sw > 0 and _pack_maxseg > _pack_sw)
+            _pack_active = int((completion_mask.sum(dim = 1) > 0).sum())
+            if _pack_T >= 2 and len(_pack_nz_cpu) > 0 and _pack_sw_ok and (_pack_ok is True or _pack_active >= 2):
+                _pack_psl = torch.tensor(_pack_nz_cpu, dtype = torch.int32, device = input_ids.device)
+                # vectorized reset 0-based position_ids (no per-row sync)
+                _pack_pos = (_pack_keep.cumsum(dim = 1) - 1)[_pack_keep].unsqueeze(0)
                 _pack_chunks = max(1, total_rows * multiplier)
+                _pack_nz_idx = _pack_keep.nonzero(as_tuple = False)            # [T, 2] = (row, col)
+                _pack_within = _pack_nz_idx[1:, 0] == _pack_nz_idx[:-1, 0]     # [T-1]
+                # completion-prediction positions only: token j+1 is a real completion token
+                # (col >= L - logits_to_keep) in the same row as j. lm_head runs only on these.
+                _pack_ctgt = (_pack_nz_idx[1:, 1] >= (_pack_L - logits_to_keep)) & _pack_within
                 with autocaster:
                     # use_cache=False: a populated past_key_value disables varlen packing in the
                     # attention kernels, which would silently fall back to dense causal attention.
@@ -984,36 +987,90 @@ def grpo_accumulated_loss(
                         use_cache = False,
                     ).logits
                     _pack_sel = chunked_hidden_states_selective_log_softmax(
-                        _pack_hidden[:, :-1, :], lm_head, _pack_flat_ids[:, 1:], _pack_chunks,
+                        _pack_hidden[0, :-1, :][_pack_ctgt].unsqueeze(0), lm_head,
+                        _pack_flat_ids[0, 1:][_pack_ctgt].unsqueeze(0), _pack_chunks,
                         logit_scale_multiply, logit_scale_divide, logit_softcapping, temperature,
                     )[0]
                 # Same GPT-OSS offload (offload_embbed=True) race guard the padded loop uses.
                 device_synchronize()
-                _pack_idx = []; _pack_val = []; _pack_off = 0
-                for _pack_i in range(total_rows):
-                    _pack_n = int(_pack_lengths[_pack_i])
-                    if _pack_n >= 2:
-                        _pack_idx.append(_pack_i * _pack_L + torch.arange(1, _pack_n, device = input_ids.device))
-                        _pack_val.append(_pack_sel[_pack_off : _pack_off + _pack_n - 1])
-                    _pack_off += _pack_n
-                if _pack_idx:
-                    _pack_flat_idx = torch.cat(_pack_idx)
-                    _pack_vals = torch.cat(_pack_val).to(torch.float32)
-                    _pack_result = torch.zeros(
-                        total_rows * _pack_L, dtype = torch.float32, device = input_ids.device,
-                    ).index_put((_pack_flat_idx,), _pack_vals).view(total_rows, _pack_L)[:, -_pack_W:]
+                # Scatter each completion next-token logprob to its ORIGINAL (row, col) so left-padded
+                # prompts land in the right columns; [:, -_pack_W:] then matches the padded layout.
+                _pack_tgt = (_pack_nz_idx[1:, 0] * _pack_L + _pack_nz_idx[1:, 1])[_pack_ctgt]
+                _pack_result = torch.zeros(
+                    total_rows * _pack_L, dtype = torch.float32, device = input_ids.device,
+                ).index_put((_pack_tgt,), _pack_sel.to(torch.float32)).view(total_rows, _pack_L)[:, -_pack_W:]
+                # ---- trust decision (shape/RoPE-aware) ----
+                # Re-verify when packed total length OR longest segment grows past what was verified
+                # (LongRoPE short/long cache can switch on either).
+                _pack_vT = int(getattr(unwrapped_model, "_unsloth_seq_packing_grad_verified_T", 0))
+                _pack_vS = int(getattr(unwrapped_model, "_unsloth_seq_packing_grad_verified_seg", 0))
+                _pack_unsafe = getattr(unwrapped_model, "_unsloth_seq_packing_grad_unsafe_T", None)
+                _pack_force_verify = os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_VERIFY", "0") == "1"
+                if (not _pack_force_verify) and _pack_ok is True and _pack_T <= _pack_vT and _pack_maxseg <= _pack_vS:
+                    _pack_use = True                                           # already verified for this shape
+                elif _pack_unsafe is not None and _pack_T >= _pack_unsafe:
+                    _pack_use = False                                          # known-unsafe length region
+                else:
+                    # verify against the per-row clean forward (exact ground truth: each row's real
+                    # tokens alone, 0-based positions, no padding). No grad -- this is a value check.
+                    _pack_ref = torch.zeros_like(_pack_result)
+                    with torch.no_grad(), autocaster:
+                        for _pack_i in range(total_rows):
+                            _pack_ni = _pack_lengths_cpu[_pack_i]
+                            if _pack_ni < 2: continue
+                            _pack_rmask = _pack_keep[_pack_i]
+                            _pack_real = input_ids[_pack_i][_pack_rmask].unsqueeze(0)
+                            _pack_rpos = torch.arange(_pack_ni, device = input_ids.device).unsqueeze(0)
+                            _pack_rh = unwrapped_model(input_ids = _pack_real, position_ids = _pack_rpos, use_cache = False).logits
+                            _pack_rsel = chunked_hidden_states_selective_log_softmax(
+                                _pack_rh[:, :-1, :], lm_head, _pack_real[:, 1:], 1,
+                                logit_scale_multiply, logit_scale_divide, logit_softcapping, temperature,
+                            )[0]
+                            _pack_rcols = _pack_rmask.nonzero(as_tuple = False).squeeze(1)[1:] - (_pack_L - _pack_W)
+                            _pack_rkeep = _pack_rcols >= 0
+                            _pack_ref[_pack_i, _pack_rcols[_pack_rkeep]] = _pack_rsel[_pack_rkeep].to(torch.float32)
+                    device_synchronize()
+                    # Compare ONLY the completion region (window cols [max_left_pad, W)). The window's
+                    # first max_left_pad cols are prompt-overflow that the lm_head completion-window opt
+                    # leaves 0 (masked out by completion_mask in the loss); including them would falsely
+                    # flag a mismatch.
+                    _pack_cm = torch.zeros((total_rows, _pack_W), dtype = torch.float32, device = input_ids.device)
+                    _pack_cm[:, max_left_pad:] = (input_ids[:, -logits_to_keep:] != _pack_pad_id).float()
+                    _pack_diff = float(((_pack_result.detach() - _pack_ref).abs() * _pack_cm).max())
+                    if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
+                        print(f"[Unsloth] GRPO seq-packing (grad) verify: T={_pack_T} maxseg={_pack_maxseg} packed-vs-perrow max|d|={_pack_diff:.4f}", flush = True)
+                    # floor: packed vs per-row through different attention kernels ~0.25 (the padded
+                    # path is itself ~0.4 from per-row truth); cross-sample contamination >= 2.4.
+                    if _pack_diff < 7e-1:
+                        unwrapped_model._unsloth_seq_packing_grad_ok = True
+                        unwrapped_model._unsloth_seq_packing_grad_verified_T = max(_pack_vT, _pack_T)
+                        unwrapped_model._unsloth_seq_packing_grad_verified_seg = max(_pack_vS, _pack_maxseg)
+                        _pack_ok = True
+                        _pack_use = True
+                    else:
+                        unwrapped_model._unsloth_seq_packing_grad_unsafe_T = (
+                            _pack_T if _pack_unsafe is None else min(_pack_unsafe, _pack_T)
+                        )
+                        _pack_use = False
+                        if _pack_ok is None and _pack_T <= _pack_maxseg + 8:
+                            # failed at a small T (no LongRoPE story) -> backend ignores packing.
+                            unwrapped_model._unsloth_seq_packing_grad_ok = False
+                        if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
+                            print(f"[Unsloth] GRPO seq-packing (grad) fell back at T={_pack_T} (diff={_pack_diff:.3f})", flush = True)
         except Exception as _pack_err:
-            # Disable packing for this model on any failure (no xformers varlen backend, an OOM on an
-            # oversized flattened batch the padded loop would chunk, or an unsupported forward) so we
-            # use the chunked padded loop and do not retry every step.
+            # Any failure (no varlen backend, OOM on the flattened batch, unsupported forward) -> drop
+            # packed intermediates, reclaim memory, use the padded loop, do not retry.
+            _pack_hidden = None
+            _pack_sel = None
+            _pack_result = None
+            _pack_use = False
             if isinstance(_pack_err, torch.cuda.OutOfMemoryError):
                 torch.cuda.empty_cache()
             unwrapped_model._unsloth_seq_packing_grad_ok = False
             if os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
                 print(f"[Unsloth] GRPO sequence-packing disabled (fell back to padded): {_pack_err!r}", flush = True)
-            _pack_result = None
-    if _pack_result is not None and getattr(unwrapped_model, "_unsloth_seq_packing_grad_ok", False):
-        new_logprobs = _pack_result          # already verified equal to padded -> skip the loop
+    if _pack_use and _pack_result is not None:
+        new_logprobs = _pack_result          # verified equal to per-row ground truth -> skip the loop
         zipped_inputs = []
 
     def to_device(tensor, device, non_blocking=True):
@@ -1172,23 +1229,9 @@ def grpo_accumulated_loss(
             all_logprobs_list.append(logprobs_chunk)
 
     if new_logprobs is None:
+        # Padded fallback result (packing disabled / unsupported / not yet verified for this length).
+        # Verification against the per-row ground truth already happened in the packing block above.
         new_logprobs = torch.cat(all_logprobs_list, dim=0)
-        # One-time self-verification: only trust packing after it matches the padded ground truth on
-        # a real (>=2 sequence) batch. Cross-sample contamination (unsupported packed mask) shows up
-        # as a large mismatch here and disables packing instead of silently corrupting training.
-        if _pack_result is not None and not hasattr(unwrapped_model, "_unsloth_seq_packing_grad_ok"):
-            # Require >=2 rows that actually have completion tokens, so cross-sample contamination
-            # would manifest in the diff. An all-pad / fully tool-masked completion_mask makes the
-            # masked diff trivially zero, which must NOT be taken as a pass: leave the verdict unset
-            # and re-verify on a later, non-degenerate batch instead.
-            _pack_active_rows = int((completion_mask.sum(dim = 1) > 0).sum())
-            if _pack_active_rows >= 2 and _pack_result.shape == new_logprobs.shape:
-                _pack_ok = bool(float(((_pack_result - new_logprobs).detach().abs() * completion_mask).max()) < 5e-1)
-                unwrapped_model._unsloth_seq_packing_grad_ok = _pack_ok
-                if _pack_ok:
-                    new_logprobs = _pack_result
-                elif os.environ.get("UNSLOTH_GRPO_SEQ_PACKING_DEBUG", "0") == "1":
-                    print("[Unsloth] GRPO sequence-packing disabled: packed logprobs did not match the padded path", flush = True)
 
     with autocaster:
         loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1 = UnslothEfficientGRPO.apply(

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -405,6 +405,17 @@ def grpo_compute_loss(
     off_policy_mask_threshold  = kwargs.get("off_policy_mask_threshold", None)
     input_ids = input_ids.unsqueeze(-1)
 
+    # exp(new - old) and exp(ref - new) below are taken before `mask` is applied. A sequence-packed
+    # logp path leaves the masked (prompt/pad) columns at 0 while a padded one fills them with a real
+    # logp, so when new and old/ref disagree there those ratios can overflow to inf and inf * 0 (the
+    # masked-out loss) becomes nan. Force new/old/ref to share 0 on the masked columns so both ratios
+    # are exp(0) = 1 there; every loss term below multiplies by `mask`, so this changes nothing.
+    if mask is not None:
+        _keep = mask.to(torch.bool)
+        new = torch.where(_keep, new, 0.0)
+        if old is not None: old = torch.where(_keep, old, 0.0)
+        if ref is not None: ref = torch.where(_keep, ref, 0.0)
+
     if advantages.dim() == 1:
         advantages = advantages.unsqueeze(1)
 
@@ -815,8 +826,7 @@ def grpo_accumulated_loss(
         input_ids = left_pack_padding(input_ids, trainer.processing_class.pad_token_id)
 
         completion_input_ids = input_ids[:, -(logits_to_keep +max_left_pad):]
-        _pure_completion_mask = create_completion_attention_mask(completion_input_ids, left_pad_tokens_per_prompt, max_left_pad, trainer.processing_class.pad_token_id)
-        completion_mask = _pure_completion_mask.to(attention_mask.dtype)
+        completion_mask = create_completion_attention_mask(completion_input_ids, left_pad_tokens_per_prompt, max_left_pad, trainer.processing_class.pad_token_id).to(attention_mask.dtype)
 
         if trainer.use_vllm and sampling_per_token_logps is not None and getattr(trainer, "vllm_importance_sampling_correction", False):
             sampling_per_token_logps = align_logprobs_with_mask(sampling_per_token_logps, completion_mask)
@@ -826,7 +836,6 @@ def grpo_accumulated_loss(
         attention_mask =  input_ids != trainer.processing_class.pad_token_id
         attention_mask = attention_mask.to(attention_mask.dtype)
     else:
-        _pure_completion_mask = None  # no packing on the multimodal path -> masked columns already consistent
         completion_input_ids = input_ids[:, -logits_to_keep:]
         completion_mask = align_completion_tool_mask(tool_mask, completion_mask)
 
@@ -1234,19 +1243,6 @@ def grpo_accumulated_loss(
     if new_logprobs is None:
         # padded fallback (packing disabled / unsupported / not verified for this length)
         new_logprobs = torch.cat(all_logprobs_list, dim=0)
-
-    if _pure_completion_mask is not None:
-        # grpo_compute_loss takes exp(new - old) and exp(ref - new) BEFORE the completion mask. The
-        # masked left-pad/prompt columns are dropped by that mask, but a packed path leaves them at 0
-        # while a padded one fills them with a real logprob, so when this grad path and the no-grad
-        # old/ref path pick different packing the ratios overflow to inf and inf * 0 = nan in the loss
-        # and its gradient. Zero those columns on all three so both ratios are exp(0) = 1 there; the
-        # loss is unchanged (they are masked out) and the completion columns are untouched.
-        new_logprobs = torch.where(_pure_completion_mask, new_logprobs, 0.0)
-        if old_logps is not None:
-            old_logps = torch.where(_pure_completion_mask, old_logps, 0.0)
-        if ref_logps is not None:
-            ref_logps = torch.where(_pure_completion_mask, ref_logps, 0.0)
 
     with autocaster:
         loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1 = UnslothEfficientGRPO.apply(


### PR DESCRIPTION
## Summary

Adds an opt-in sequence-packing fast path to `grpo_accumulated_loss` (the gradient `new_logps` forward + backward), enabled with `UNSLOTH_GRPO_SEQ_PACKING=1`. Default off, so existing behavior is byte-identical unless explicitly enabled.

When the batch is text-only, the padded `[B, Lmax]` per-chunk forward is replaced by a single varlen `[1, sum L]` forward (xformers `BlockDiagonalCausalMask` via `packed_seq_lengths` with reset `position_ids`). Per-token logps come from the same float32 `chunked_hidden_states_selective_log_softmax` the padded path uses, then are scattered back into the same left-packed `[total_rows, W]` completion layout. On any unsupported case it leaves `new_logprobs = None` and the existing padded loop runs unchanged (`UNSLOTH_GRPO_SEQ_PACKING_DEBUG=1` prints the fallback reason).

The change is a self-contained nested branch inside `grpo_accumulated_loss`, so it flows into the regenerated `UnslothGRPOTrainer.py` via the existing `inspect.getsource` path; no changes to `rl.py` or `compiler.py` are needed.

## Why

GRPO completions vary a lot in length (high reward variance), so the padded `[B, Lmax]` batch wastes most of the attention compute and memory on padding. Packing removes that.

## Correctness (verified on real Qwen3-4B)

In-run check (`GRPO_PACK_GRAD_CHECK`): each step computes both the packed and padded loss AND full parameter gradients on the same batch, with deterministic ("fake") generation so the inputs are identical:

```
step  loss|d|   kl|d|     grad max|d|   params differing
1-5   ~1e-11    ~1e-10    0.000e+00     0/504
```

Gradients w.r.t. all trainable params are bitwise identical; loss and KL match to float32 round-off. Verified again against the regenerated cache (native packed vs native padded): grad `0.000e+00`, `0/504` params.

Edge cases (length 0/1/2 completions, single row, all-equal, long+short): all match within bf16 tolerance, and packing is more robust than the padded path on fully-empty rows (which underflow the padded `[-(W+1):-1]` slice).

End-to-end real-vLLM (150 steps, beta=0.04): reward, reward_std, loss, grad_norm, completion length and the bulk KL all track the padded baseline within vLLM rerun noise.

## Performance (gradient forward+backward, long-tail batch: one 16k completion + short ones)

```
config                padded            packed            win
longtail 16k+3x1.5k   50.85GB  5338ms   18.45GB   866ms   mem 2.76x  time 6.17x
varied 4k group       21.30GB   404ms   10.62GB   274ms   mem 2.00x  time 1.47x
uniform short         ~equal            ~equal            neutral
```

No recompilations (the varying packed length is absorbed by `dynamic=True`).

## How to enable

```
export UNSLOTH_GRPO_SEQ_PACKING=1        # opt in (default off)
export UNSLOTH_GRPO_SEQ_PACKING_DEBUG=1  # optional: print fallback reasons
```

Pairs with the matching no-grad change in unslothai/unsloth (`_get_per_token_logps_and_entropies`) so the full GRPO logp + loss + backward runs packed.