### PR TITLE
Fix Gemma3 processor batched tokenization (ragged padding)

### DIFF
--- a/tests/test_gemma3_processor_batched.py
+++ b/tests/test_gemma3_processor_batched.py
@@ -111,6 +111,30 @@ def test_max_length_uses_model_max_when_unset():
     assert {len(x) for x in out["input_ids"]} == {6}
 
 
+def test_non_aligned_fields_untouched():
+    # overflowing_tokens is a per-example list whose rows do NOT match input_ids lengths; it must be
+    # left exactly as-is (not BOS-stripped or padded).
+    text_inputs = {
+        "input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]],
+        "attention_mask": [[1, 1, 1], [1, 1, 1, 1]],
+        "overflowing_tokens": [[77], []],
+    }
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, True, "left", "pt")
+    assert out["overflowing_tokens"] == [[77], []]
+    assert {len(x) for x in out["input_ids"]} == {3}
+
+
+def test_length_recomputed_after_padding():
+    # return_length: the length field must reflect post-strip/pad token counts, not the raw tokenizer ones.
+    text_inputs = {
+        "input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]],
+        "attention_mask": [[1, 1, 1], [1, 1, 1, 1]],
+        "length": [3, 4],
+    }
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, True, "left", "pt")
+    assert out["length"] == [3, 3]
+
+
 if __name__ == "__main__":
     test_batched_ragged_rows_become_stackable()
     test_single_row_strips_bos_without_padding()
@@ -124,4 +148,6 @@ if __name__ == "__main__":
     test_offset_mapping_tuples_stripped_and_padded()
     test_pad_to_multiple_of()
     test_max_length_uses_model_max_when_unset()
+    test_non_aligned_fields_untouched()
+    test_length_recomputed_after_padding()
     print("OK: all gemma3 batched-processor padding tests passed")

--- a/tests/test_gemma3_processor_batched.py
+++ b/tests/test_gemma3_processor_batched.py
@@ -6,7 +6,7 @@ could not stack them. _fix_double_bos_and_pad strips the duplicate BOS on every 
 sequence fields. Padding follows the HF contract: it honours "do_not_pad"/False, pads list output
 even when return_tensors is None, and targets max_length when padding="max_length".
 """
-from unsloth_zoo.temporary_patches.gemma import _fix_double_bos_and_pad
+from unsloth_zoo.temporary_patches.gemma import _fix_double_bos_and_pad, _resolve_truncation
 
 BOS, PAD, IMG = 2, 0, 99
 
@@ -135,6 +135,16 @@ def test_length_recomputed_after_padding():
     assert out["length"] == [3, 3]
 
 
+def test_resolve_truncation_matches_hf():
+    # HF: max_length with padding=False and no explicit truncation -> "longest_first"; otherwise none.
+    assert _resolve_truncation(False, None, 100) == "longest_first"
+    assert _resolve_truncation("max_length", None, 100) is False   # padding set -> no auto-truncation
+    assert _resolve_truncation(True, None, 100) is False
+    assert _resolve_truncation(False, None, None) is False          # no max_length -> nothing to truncate to
+    assert _resolve_truncation(False, True, 100) is True            # explicit truncation preserved
+    assert _resolve_truncation(False, False, 100) is False
+
+
 if __name__ == "__main__":
     test_batched_ragged_rows_become_stackable()
     test_single_row_strips_bos_without_padding()
@@ -150,4 +160,5 @@ if __name__ == "__main__":
     test_max_length_uses_model_max_when_unset()
     test_non_aligned_fields_untouched()
     test_length_recomputed_after_padding()
+    test_resolve_truncation_matches_hf()
     print("OK: all gemma3 batched-processor padding tests passed")

--- a/tests/test_gemma3_processor_batched.py
+++ b/tests/test_gemma3_processor_batched.py
@@ -3,7 +3,8 @@
 Batched Gemma3 tokenization used to leave ragged input_ids after the double-BOS strip (the strip
 only shortened the row that still started with [bos, bos], i.e. the longest one), so BatchFeature
 could not stack them. _fix_double_bos_and_pad strips the duplicate BOS on every row and pads all
-sequence fields to the batch max.
+sequence fields. Padding follows the HF contract: it honours "do_not_pad"/False, pads list output
+even when return_tensors is None, and targets max_length when padding="max_length".
 """
 from unsloth_zoo.temporary_patches.gemma import _fix_double_bos_and_pad
 
@@ -34,15 +35,51 @@ def test_right_padding_side():
     assert out["input_ids"][0][-1] == PAD and out["attention_mask"][0][-1] == 0
 
 
-def test_no_tensor_request_leaves_ragged():
+def test_padding_true_pads_even_without_return_tensors():
+    # HF contract: padding=True pads the list output even when return_tensors is None.
     text_inputs = {"input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]], "attention_mask": [[1, 1, 1], [1, 1, 1, 1]]}
     out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, True, "left", None)
+    assert {len(x) for x in out["input_ids"]} == {3}   # stripped then padded to batch max
+
+
+def test_do_not_pad_leaves_ragged():
+    # "do_not_pad" is truthy but must NOT pad.
+    text_inputs = {"input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]], "attention_mask": [[1, 1, 1], [1, 1, 1, 1]]}
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, "do_not_pad", "left", "pt")
     assert [len(x) for x in out["input_ids"]] == [2, 3]   # stripped, not padded
+
+
+def test_padding_false_leaves_ragged():
+    text_inputs = {"input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]], "attention_mask": [[1, 1, 1], [1, 1, 1, 1]]}
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, False, "left", "pt")
+    assert [len(x) for x in out["input_ids"]] == [2, 3]
+
+
+def test_max_length_padding():
+    text_inputs = {"input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]], "attention_mask": [[1, 1, 1], [1, 1, 1, 1]]}
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, "max_length", "left", "pt", max_length=6)
+    assert {len(x) for x in out["input_ids"]} == {6}
+
+
+def test_existing_token_type_ids_stripped_in_lockstep():
+    # Tokenizer-provided token_type_ids must be BOS-stripped too, or the row desyncs when
+    # return_mm_token_type_ids is False.
+    text_inputs = {
+        "input_ids": [[BOS, BOS, 10, 11], [BOS, BOS, 20]],
+        "attention_mask": [[1, 1, 1, 1], [1, 1, 1]],
+        "token_type_ids": [[0, 0, 0, 0], [0, 0, 0]],
+    }
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, False, True, "left", "pt")
+    assert all(len(t) == len(i) for t, i in zip(out["token_type_ids"], out["input_ids"]))
 
 
 if __name__ == "__main__":
     test_batched_ragged_rows_become_stackable()
     test_single_row_strips_bos_without_padding()
     test_right_padding_side()
-    test_no_tensor_request_leaves_ragged()
+    test_padding_true_pads_even_without_return_tensors()
+    test_do_not_pad_leaves_ragged()
+    test_padding_false_leaves_ragged()
+    test_max_length_padding()
+    test_existing_token_type_ids_stripped_in_lockstep()
     print("OK: all gemma3 batched-processor padding tests passed")

--- a/tests/test_gemma3_processor_batched.py
+++ b/tests/test_gemma3_processor_batched.py
@@ -1,0 +1,48 @@
+"""Regression test for the Gemma3 batched-processor padding fix.
+
+Batched Gemma3 tokenization used to leave ragged input_ids after the double-BOS strip (the strip
+only shortened the row that still started with [bos, bos], i.e. the longest one), so BatchFeature
+could not stack them. _fix_double_bos_and_pad strips the duplicate BOS on every row and pads all
+sequence fields to the batch max.
+"""
+from unsloth_zoo.temporary_patches.gemma import _fix_double_bos_and_pad
+
+BOS, PAD, IMG = 2, 0, 99
+
+
+def test_batched_ragged_rows_become_stackable():
+    text_inputs = {
+        "input_ids": [[BOS, BOS, 10, 11], [BOS, BOS, 20, 21, 22, 23]],
+        "attention_mask": [[1, 1, 1, 1], [1, 1, 1, 1, 1, 1]],
+    }
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, True, "left", "pt")
+    assert {len(x) for x in out["input_ids"]} == {5}, out["input_ids"]   # 6 - 1 stripped BOS
+    assert all(row.count(BOS) == 1 for row in out["input_ids"])          # duplicate BOS gone everywhere
+    assert out["input_ids"][0][0] == PAD and out["attention_mask"][0][0] == 0  # shorter row left-padded
+    assert all(len(t) == 5 for t in out["token_type_ids"])
+
+
+def test_single_row_strips_bos_without_padding():
+    text_inputs = {"input_ids": [[BOS, BOS, 10, 11, 12]], "attention_mask": [[1, 1, 1, 1, 1]]}
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, True, "left", "pt")
+    assert out["input_ids"] == [[BOS, 10, 11, 12]]
+
+
+def test_right_padding_side():
+    text_inputs = {"input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21, 22]], "attention_mask": [[1, 1, 1], [1, 1, 1, 1, 1]]}
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, True, "right", "pt")
+    assert out["input_ids"][0][-1] == PAD and out["attention_mask"][0][-1] == 0
+
+
+def test_no_tensor_request_leaves_ragged():
+    text_inputs = {"input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]], "attention_mask": [[1, 1, 1], [1, 1, 1, 1]]}
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, True, "left", None)
+    assert [len(x) for x in out["input_ids"]] == [2, 3]   # stripped, not padded
+
+
+if __name__ == "__main__":
+    test_batched_ragged_rows_become_stackable()
+    test_single_row_strips_bos_without_padding()
+    test_right_padding_side()
+    test_no_tensor_request_leaves_ragged()
+    print("OK: all gemma3 batched-processor padding tests passed")

--- a/tests/test_gemma3_processor_batched.py
+++ b/tests/test_gemma3_processor_batched.py
@@ -73,6 +73,44 @@ def test_existing_token_type_ids_stripped_in_lockstep():
     assert all(len(t) == len(i) for t, i in zip(out["token_type_ids"], out["input_ids"]))
 
 
+def test_special_tokens_mask_stripped_and_padded():
+    # any per-token field (here special_tokens_mask) must be stripped and padded, not left ragged;
+    # its pad fill is 1 (padding is a special token).
+    text_inputs = {
+        "input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]],
+        "attention_mask": [[1, 1, 1], [1, 1, 1, 1]],
+        "special_tokens_mask": [[1, 1, 0], [1, 1, 0, 0]],
+    }
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, False, True, "left", "pt")
+    assert {len(x) for x in out["special_tokens_mask"]} == {3}
+    assert all(len(m) == len(i) for m, i in zip(out["special_tokens_mask"], out["input_ids"]))
+    assert out["special_tokens_mask"][0][0] == 1   # left pad filled as special
+
+
+def test_offset_mapping_tuples_stripped_and_padded():
+    # offset_mapping rows are (start, end) tuples; stripping drops the first pair and padding fills (0, 0).
+    text_inputs = {
+        "input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]],
+        "attention_mask": [[1, 1, 1], [1, 1, 1, 1]],
+        "offset_mapping": [[(0, 0), (0, 0), (0, 2)], [(0, 0), (0, 0), (0, 2), (2, 4)]],
+    }
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, False, True, "left", "pt")
+    assert {len(x) for x in out["offset_mapping"]} == {3}
+    assert out["offset_mapping"][0][0] == (0, 0)    # left pad filled with an offset pair
+
+
+def test_pad_to_multiple_of():
+    text_inputs = {"input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]], "attention_mask": [[1, 1, 1], [1, 1, 1, 1]]}
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, True, "left", "pt", pad_to_multiple_of=8)
+    assert {len(x) for x in out["input_ids"]} == {8}   # batch max 3 rounded up to 8
+
+
+def test_max_length_uses_model_max_when_unset():
+    text_inputs = {"input_ids": [[BOS, BOS, 10], [BOS, BOS, 20, 21]], "attention_mask": [[1, 1, 1], [1, 1, 1, 1]]}
+    out = _fix_double_bos_and_pad(text_inputs, BOS, PAD, IMG, True, "max_length", "left", "pt", model_max_length=6)
+    assert {len(x) for x in out["input_ids"]} == {6}
+
+
 if __name__ == "__main__":
     test_batched_ragged_rows_become_stackable()
     test_single_row_strips_bos_without_padding()
@@ -82,4 +120,8 @@ if __name__ == "__main__":
     test_padding_false_leaves_ragged()
     test_max_length_padding()
     test_existing_token_type_ids_stripped_in_lockstep()
+    test_special_tokens_mask_stripped_and_padded()
+    test_offset_mapping_tuples_stripped_and_padded()
+    test_pad_to_multiple_of()
+    test_max_length_uses_model_max_when_unset()
     print("OK: all gemma3 batched-processor padding tests passed")

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -108,13 +108,15 @@ def _fix_double_bos_and_pad(
     # offset_mapping, ...), rebuild mm token type ids, then pad each field so ragged rows stack.
     # Honours "do_not_pad"/max_length/model max/pad_to_multiple_of and the return_tensors=None list contract.
     n_rows = len(text_inputs["input_ids"])
+    input_lens = [len(x) for x in text_inputs["input_ids"]]
     double_bos = [bos_token_id, bos_token_id]
     strip = [x[:2] == double_bos for x in text_inputs["input_ids"]]
-    # any value that is one list per row stays aligned with input_ids, so strip its extra BOS too
+    # only fields whose rows match the matching input_ids row length are token aligned; this keeps
+    # non-aligned tokenizer outputs (overflowing_tokens, ...) out of the per-row strip/pad
     per_token_keys = [
         k for k, v in text_inputs.items()
         if isinstance(v, (list, tuple)) and len(v) == n_rows
-        and all(isinstance(r, (list, tuple)) for r in v)
+        and all(isinstance(r, (list, tuple)) and len(r) == input_lens[i] for i, r in enumerate(v))
     ]
     for k in per_token_keys:
         text_inputs[k] = [r[1:] if strip[i] else r for i, r in enumerate(text_inputs[k])]
@@ -142,6 +144,8 @@ def _fix_double_bos_and_pad(
         for key in per_token_keys:
             fill = fill_for(key)
             text_inputs[key] = [pad_seq(x, fill) for x in text_inputs[key]]
+    if "length" in text_inputs:   # return_length: report the post-strip/pad token counts
+        text_inputs["length"] = [len(x) for x in text_inputs["input_ids"]]
     return text_inputs
 pass
 
@@ -251,6 +255,11 @@ def patch_Gemma3Processor():
         padding = output_kwargs["text_kwargs"].pop("padding", False)
         padding_side = output_kwargs["text_kwargs"].pop("padding_side", None) or \
             getattr(self.tokenizer, "padding_side", "left")
+        # We pad manually to max_length, so only leave max_length in for the tokenizer when truncation is
+        # requested; otherwise drop it to avoid HF's "max_length set without truncation" warning/ambiguity.
+        max_length = output_kwargs["text_kwargs"].get("max_length", None)
+        if not output_kwargs["text_kwargs"].get("truncation", None):
+            output_kwargs["text_kwargs"].pop("max_length", None)
         text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
         # ignore the tokenizer's uninitialised model_max_length sentinel (~1e30) for "max_length" padding
         _mml = getattr(self.tokenizer, "model_max_length", None)
@@ -258,7 +267,7 @@ def patch_Gemma3Processor():
         text_inputs = _fix_double_bos_and_pad(
             text_inputs, self.tokenizer.bos_token_id, self.tokenizer.pad_token_id,
             self.image_token_id, return_mm_token_type_ids, padding, padding_side, return_tensors,
-            max_length = output_kwargs["text_kwargs"].get("max_length", None),
+            max_length = max_length,
             pad_to_multiple_of = output_kwargs["text_kwargs"].get("pad_to_multiple_of", None),
             model_max_length = _mml,
         )

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -122,10 +122,13 @@ def _fix_double_bos_and_pad(
     double_bos = [bos_token_id, bos_token_id]
     strip = [x[:2] == double_bos for x in text_inputs["input_ids"]]
     # only fields whose rows match the matching input_ids row length are token aligned; this keeps
-    # non-aligned tokenizer outputs (overflowing_tokens, ...) out of the per-row strip/pad
+    # non-aligned tokenizer outputs out of the per-row strip/pad. overflowing_tokens is a per-example
+    # list of tails, so exclude it by name too in case a tail length coincidentally matches its row.
+    non_aligned = {"overflowing_tokens", "overflow_to_sample_mapping", "num_truncated_tokens", "length"}
     per_token_keys = [
         k for k, v in text_inputs.items()
-        if isinstance(v, (list, tuple)) and len(v) == n_rows
+        if k not in non_aligned
+        and isinstance(v, (list, tuple)) and len(v) == n_rows
         and all(isinstance(r, (list, tuple)) and len(r) == input_lens[i] for i, r in enumerate(v))
     ]
     for k in per_token_keys:

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -98,6 +98,32 @@ def _make_gemma3_attn_forwards(forward_function, has_cache_position):
     return functions
 
 
+def _fix_double_bos_and_pad(
+    text_inputs, bos_token_id, pad_token_id, image_token_id,
+    return_mm_token_type_ids, padding, padding_side, return_tensors,
+):
+    # Gemma3 adds a BOS in the chat template and another in the tokenizer; strip the duplicate on
+    # every row, add mm token type ids, then pad each field to the batch max so ragged rows stack.
+    double_bos = [bos_token_id, bos_token_id]
+    strip = [x[:2] == double_bos for x in text_inputs["input_ids"]]
+    text_inputs["input_ids"] = [x[1:] if strip[i] else x for i, x in enumerate(text_inputs["input_ids"])]
+    if "attention_mask" in text_inputs:
+        text_inputs["attention_mask"] = [a[1:] if strip[i] else a for i, a in enumerate(text_inputs["attention_mask"])]
+    if return_mm_token_type_ids:
+        text_inputs["token_type_ids"] = [[int(y == image_token_id) for y in x] for x in text_inputs["input_ids"]]
+    if padding and return_tensors is not None:
+        max_len = max((len(x) for x in text_inputs["input_ids"]), default = 0)
+        pad_id = pad_token_id or 0
+        def pad_seq(seq, fill):
+            delta = max_len - len(seq)
+            if delta <= 0: return list(seq)
+            return ([fill]*delta + list(seq)) if padding_side == "left" else (list(seq) + [fill]*delta)
+        for key, fill in (("input_ids", pad_id), ("attention_mask", 0), ("token_type_ids", 0)):
+            if key in text_inputs: text_inputs[key] = [pad_seq(x, fill) for x in text_inputs[key]]
+    return text_inputs
+pass
+
+
 def patch_Gemma3Processor():
     import re
     try:
@@ -199,23 +225,15 @@ def patch_Gemma3Processor():
         # text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"], return_tensors="np")
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", True)
 
+        # Tokenize unpadded so the double-BOS strip cannot desync row lengths, then pad afterwards.
+        padding = output_kwargs["text_kwargs"].pop("padding", False)
+        padding_side = output_kwargs["text_kwargs"].pop("padding_side", None) or \
+            getattr(self.tokenizer, "padding_side", "left")
         text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
-        # Fix double BOS tokens
-        double_bos_token_id = [self.tokenizer.bos_token_id]*2
-        input_ids = text_inputs["input_ids"]
-        text_inputs["input_ids"] = [x[1:] if x[:2] == double_bos_token_id else x for x in input_ids]
-
-        # Add token type ids manually, as tokenizer can't do arbitrary position token types
-        # [TODO] FAILS for batched tokens since text_inputs["input_ids"] is a list of lists, so np.array creates an object!
-        if return_mm_token_type_ids:
-            input_ids = text_inputs["input_ids"]
-            image_token_id = self.image_token_id
-            mm_token_type_ids = [[1 if y == image_token_id else 0 for y in x] for x in input_ids]
-            # array_ids = np.array(text_inputs["input_ids"])
-            # mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
-            # mm_token_type_ids[array_ids == self.image_token_id] = 1
-            # text_inputs = {k: v.tolist() for k, v in text_inputs.items()}  # in case user requested list inputs
-            text_inputs["token_type_ids"] = mm_token_type_ids#.tolist()
+        text_inputs = _fix_double_bos_and_pad(
+            text_inputs, self.tokenizer.bos_token_id, self.tokenizer.pad_token_id,
+            self.image_token_id, return_mm_token_type_ids, padding, padding_side, return_tensors,
+        )
         return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
     pass
 

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -98,6 +98,16 @@ def _make_gemma3_attn_forwards(forward_function, has_cache_position):
     return functions
 
 
+def _resolve_truncation(padding, truncation, max_length):
+    # HF activates "longest_first" truncation when max_length is set with padding=False and no explicit
+    # truncation. We drop padding to pad manually, so pin the strategy the tokenizer would have derived
+    # (from the caller's original padding) and pass it explicitly, keeping truncation behaviour identical.
+    if truncation is not None:
+        return truncation
+    return "longest_first" if (max_length is not None and padding is False) else False
+pass
+
+
 def _fix_double_bos_and_pad(
     text_inputs, bos_token_id, pad_token_id, image_token_id,
     return_mm_token_type_ids, padding, padding_side, return_tensors,
@@ -255,11 +265,12 @@ def patch_Gemma3Processor():
         padding = output_kwargs["text_kwargs"].pop("padding", False)
         padding_side = output_kwargs["text_kwargs"].pop("padding_side", None) or \
             getattr(self.tokenizer, "padding_side", "left")
-        # We pad manually to max_length, so only leave max_length in for the tokenizer when truncation is
-        # requested; otherwise drop it to avoid HF's "max_length set without truncation" warning/ambiguity.
+        # HF derives truncation from padding + max_length (max_length with padding=False and no explicit
+        # truncation truncates). We drop padding to pad manually, so pin the truncation the tokenizer would
+        # have used from the original padding, keeping truncation behaviour identical.
         max_length = output_kwargs["text_kwargs"].get("max_length", None)
-        if not output_kwargs["text_kwargs"].get("truncation", None):
-            output_kwargs["text_kwargs"].pop("max_length", None)
+        output_kwargs["text_kwargs"]["truncation"] = _resolve_truncation(
+            padding, output_kwargs["text_kwargs"].get("truncation", None), max_length)
         text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
         # ignore the tokenizer's uninitialised model_max_length sentinel (~1e30) for "max_length" padding
         _mml = getattr(self.tokenizer, "model_max_length", None)

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -101,33 +101,47 @@ def _make_gemma3_attn_forwards(forward_function, has_cache_position):
 def _fix_double_bos_and_pad(
     text_inputs, bos_token_id, pad_token_id, image_token_id,
     return_mm_token_type_ids, padding, padding_side, return_tensors,
-    max_length = None,
+    max_length = None, pad_to_multiple_of = None, model_max_length = None,
 ):
-    # Gemma3 adds a BOS in the chat template and another in the tokenizer; strip the duplicate on
-    # every row (including any tokenizer-provided token_type_ids), rebuild mm token type ids, then
-    # pad each field so ragged rows stack. Padding follows the HF contract (list output when
-    # return_tensors is None), honours "do_not_pad", and targets max_length when requested.
+    # Gemma3 doubles the BOS (chat template + tokenizer). Strip the duplicate on every row and on
+    # every per-token field returned (attention_mask, token_type_ids, special_tokens_mask,
+    # offset_mapping, ...), rebuild mm token type ids, then pad each field so ragged rows stack.
+    # Honours "do_not_pad"/max_length/model max/pad_to_multiple_of and the return_tensors=None list contract.
+    n_rows = len(text_inputs["input_ids"])
     double_bos = [bos_token_id, bos_token_id]
     strip = [x[:2] == double_bos for x in text_inputs["input_ids"]]
-    text_inputs["input_ids"] = [x[1:] if strip[i] else x for i, x in enumerate(text_inputs["input_ids"])]
-    if "attention_mask" in text_inputs:
-        text_inputs["attention_mask"] = [a[1:] if strip[i] else a for i, a in enumerate(text_inputs["attention_mask"])]
-    if "token_type_ids" in text_inputs:
-        text_inputs["token_type_ids"] = [t[1:] if strip[i] else t for i, t in enumerate(text_inputs["token_type_ids"])]
+    # any value that is one list per row stays aligned with input_ids, so strip its extra BOS too
+    per_token_keys = [
+        k for k, v in text_inputs.items()
+        if isinstance(v, (list, tuple)) and len(v) == n_rows
+        and all(isinstance(r, (list, tuple)) for r in v)
+    ]
+    for k in per_token_keys:
+        text_inputs[k] = [r[1:] if strip[i] else r for i, r in enumerate(text_inputs[k])]
     if return_mm_token_type_ids:
         text_inputs["token_type_ids"] = [[int(y == image_token_id) for y in x] for x in text_inputs["input_ids"]]
+        if "token_type_ids" not in per_token_keys: per_token_keys.append("token_type_ids")
     if padding not in (False, None, "do_not_pad"):
         if padding == "max_length" and max_length is not None:
             max_len = max_length
+        elif padding == "max_length" and model_max_length is not None:
+            max_len = model_max_length
         else:
             max_len = max((len(x) for x in text_inputs["input_ids"]), default = 0)
-        pad_id = pad_token_id or 0
+        if pad_to_multiple_of:
+            max_len = -(-max_len // pad_to_multiple_of) * pad_to_multiple_of
+        def fill_for(key):
+            if key == "input_ids": return pad_token_id or 0
+            if key == "special_tokens_mask": return 1
+            sample = next((r for r in text_inputs[key] if r), None)
+            return (0, 0) if (sample is not None and isinstance(sample[0], (tuple, list))) else 0
         def pad_seq(seq, fill):
             delta = max_len - len(seq)
             if delta <= 0: return list(seq)
             return ([fill]*delta + list(seq)) if padding_side == "left" else (list(seq) + [fill]*delta)
-        for key, fill in (("input_ids", pad_id), ("attention_mask", 0), ("token_type_ids", 0)):
-            if key in text_inputs: text_inputs[key] = [pad_seq(x, fill) for x in text_inputs[key]]
+        for key in per_token_keys:
+            fill = fill_for(key)
+            text_inputs[key] = [pad_seq(x, fill) for x in text_inputs[key]]
     return text_inputs
 pass
 
@@ -238,10 +252,15 @@ def patch_Gemma3Processor():
         padding_side = output_kwargs["text_kwargs"].pop("padding_side", None) or \
             getattr(self.tokenizer, "padding_side", "left")
         text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+        # ignore the tokenizer's uninitialised model_max_length sentinel (~1e30) for "max_length" padding
+        _mml = getattr(self.tokenizer, "model_max_length", None)
+        if not (isinstance(_mml, int) and 0 < _mml < int(1e15)): _mml = None
         text_inputs = _fix_double_bos_and_pad(
             text_inputs, self.tokenizer.bos_token_id, self.tokenizer.pad_token_id,
             self.image_token_id, return_mm_token_type_ids, padding, padding_side, return_tensors,
             max_length = output_kwargs["text_kwargs"].get("max_length", None),
+            pad_to_multiple_of = output_kwargs["text_kwargs"].get("pad_to_multiple_of", None),
+            model_max_length = _mml,
         )
         return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
     pass

--- a/unsloth_zoo/temporary_patches/gemma.py
+++ b/unsloth_zoo/temporary_patches/gemma.py
@@ -101,18 +101,26 @@ def _make_gemma3_attn_forwards(forward_function, has_cache_position):
 def _fix_double_bos_and_pad(
     text_inputs, bos_token_id, pad_token_id, image_token_id,
     return_mm_token_type_ids, padding, padding_side, return_tensors,
+    max_length = None,
 ):
     # Gemma3 adds a BOS in the chat template and another in the tokenizer; strip the duplicate on
-    # every row, add mm token type ids, then pad each field to the batch max so ragged rows stack.
+    # every row (including any tokenizer-provided token_type_ids), rebuild mm token type ids, then
+    # pad each field so ragged rows stack. Padding follows the HF contract (list output when
+    # return_tensors is None), honours "do_not_pad", and targets max_length when requested.
     double_bos = [bos_token_id, bos_token_id]
     strip = [x[:2] == double_bos for x in text_inputs["input_ids"]]
     text_inputs["input_ids"] = [x[1:] if strip[i] else x for i, x in enumerate(text_inputs["input_ids"])]
     if "attention_mask" in text_inputs:
         text_inputs["attention_mask"] = [a[1:] if strip[i] else a for i, a in enumerate(text_inputs["attention_mask"])]
+    if "token_type_ids" in text_inputs:
+        text_inputs["token_type_ids"] = [t[1:] if strip[i] else t for i, t in enumerate(text_inputs["token_type_ids"])]
     if return_mm_token_type_ids:
         text_inputs["token_type_ids"] = [[int(y == image_token_id) for y in x] for x in text_inputs["input_ids"]]
-    if padding and return_tensors is not None:
-        max_len = max((len(x) for x in text_inputs["input_ids"]), default = 0)
+    if padding not in (False, None, "do_not_pad"):
+        if padding == "max_length" and max_length is not None:
+            max_len = max_length
+        else:
+            max_len = max((len(x) for x in text_inputs["input_ids"]), default = 0)
         pad_id = pad_token_id or 0
         def pad_seq(seq, fill):
             delta = max_len - len(seq)
@@ -233,6 +241,7 @@ def patch_Gemma3Processor():
         text_inputs = _fix_double_bos_and_pad(
             text_inputs, self.tokenizer.bos_token_id, self.tokenizer.pad_token_id,
             self.image_token_id, return_mm_token_type_ids, padding, padding_side, return_tensors,
+            max_length = output_kwargs["text_kwargs"].get("max_length", None),
         )
         return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
     pass


### PR DESCRIPTION
## Summary

`Gemma3Processor.__call__` (patched in `temporary_patches/gemma.py`) tokenized a batch with padding, then stripped a leading double BOS only from rows that still started with `[bos, bos]`. After left padding, only the longest (unpadded) row starts with `[bos, bos]`, so just that row lost a token and the batch became ragged, and `BatchFeature` could no longer stack it:

```
ValueError: Unable to create tensor, you should probably activate padding with 'padding=True' to have batched tensors with the same length.
```

This surfaced in vision GRPO run with `fast_inference=False` (batched slow-mode generation), but affects any batched processor call that requests padding.

## Fix

Tokenize without padding, strip the duplicate BOS on every row (the chat template and the tokenizer each add one), rebuild `token_type_ids`, then pad every sequence field to the batch max. The strip and pad logic is factored into `_fix_double_bos_and_pad` so it can be unit tested directly. This also fixes a latent issue where padded rows previously kept a double BOS.

## Tests

`tests/test_gemma3_processor_batched.py` (GPU free): batched ragged rows become stackable, a single row strips its BOS without padding, right padding side, and `return_tensors=None` leaves the lists ragged.

Verified end to end: the Gemma3 vision GRPO notebook, which previously crashed at step 0 with `fast_inference=False`, now trains to completion.
