### PR TITLE
MLX: clear error when mlx-lm/mlx-vlm is too old for a QK-norm arch (gemma4/qwen3_5)

### DIFF
--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -1,0 +1,53 @@
+# Unsloth Zoo - Utilities for Unsloth
+# A strict mlx load that rejects q_norm/k_norm means the installed mlx-lm/mlx-vlm
+# is too old (or regressed, e.g. 0.31.3) for a QK-norm arch (gemma4 / qwen3_5).
+# Surface a clear, actionable error instead of the raw mlx ValueError; dropping
+# those weights would break the model.
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_mlx_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+_TESTER_MSG = (
+    "Received 140 parameters not in model: "
+    "language_model.model.layers.15.self_attn.k_norm.weight, "
+    "language_model.model.layers.15.self_attn.q_norm.weight"
+)
+
+
+def test_qk_norm_mismatch_raises_actionable_error():
+    from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
+
+    with pytest.raises(ValueError) as exc:
+        _raise_if_qk_norm_version_gap("gemma4", _TESTER_MSG, ValueError("orig"))
+    msg = str(exc.value)
+    assert "mlx-lm" in msg and "0.31.3" in msg and "gemma4" in msg
+
+
+def test_qwen3_5_q_norm_also_caught():
+    from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
+
+    with pytest.raises(ValueError):
+        _raise_if_qk_norm_version_gap(
+            "qwen3_5", "Received 5 parameters not in model: model.layers.3.self_attn.q_norm.weight",
+            ValueError("orig"),
+        )
+
+
+def test_non_qk_norm_mismatch_passes_through():
+    from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
+
+    # A different extra-weight mismatch (handled by the known gemma4 filter) or an
+    # unrelated error must NOT be swallowed by the QK-norm guard.
+    _raise_if_qk_norm_version_gap(
+        "gemma4", "Received 4 parameters not in model: per_layer_model_projection.scales",
+        ValueError("orig"),
+    )
+    _raise_if_qk_norm_version_gap("llama", "some unrelated value error", ValueError("orig"))

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -1,8 +1,6 @@
 # Unsloth Zoo - Utilities for Unsloth
-# A strict mlx load that rejects q_norm/k_norm means the installed mlx-lm/mlx-vlm
-# is too old (or regressed, e.g. 0.31.3) for a QK-norm arch (gemma4 / qwen3_5).
-# Surface a clear, actionable error instead of the raw mlx ValueError; dropping
-# those weights would break the model.
+# Strict mlx load rejecting q_norm/k_norm = mlx-lm/mlx-vlm too old for a QK-norm
+# arch; the guard must raise a clear error instead of the raw mlx ValueError.
 
 from __future__ import annotations
 
@@ -12,6 +10,7 @@ import pytest
 @pytest.fixture(autouse=True, scope="module")
 def _install_mlx_shim():
     from mlx_simulation import simulate_mlx_on_torch
+
     simulate_mlx_on_torch()
 
 
@@ -36,17 +35,15 @@ def test_qwen3_5_q_norm_also_caught():
 
     with pytest.raises(ValueError):
         _raise_if_qk_norm_version_gap(
-            "qwen3_5", "Received 5 parameters not in model: model.layers.3.self_attn.q_norm.weight",
+            "qwen3_5",
+            "Received 5 parameters not in model: model.layers.3.self_attn.q_norm.weight",
             ValueError("orig"),
         )
 
 
 def test_kv_sharing_dead_tail_falls_through_to_strict_false():
-    # A gemma4 KV-sharing checkpoint's shared tail carries DEAD k_proj/v_proj/
-    # k_norm (those layers reuse an earlier layer's K/V), so mlx-lm 0.31.3 rejects
-    # exactly that dead tail: k_proj + v_proj + k_norm, never q_norm. Dropping it
-    # via the registered strict=False fallback is safe, so the guard must NOT
-    # raise here (else it regresses a working gemma4_text load - mlx-lm #1242).
+    # Dead KV-sharing tail (k_proj+v_proj+k_norm, never q_norm) is safe to drop
+    # via the strict=False fallback: the guard must NOT raise (mlx-lm #1242).
     from unsloth_zoo.mlx.loader import (
         _KNOWN_MLX_LM_STRICT_FALLBACKS,
         _message_matches_known_fallback,
@@ -59,17 +56,15 @@ def test_kv_sharing_dead_tail_falls_through_to_strict_false():
         "language_model.model.layers.24.self_attn.k_proj.weight, "
         "language_model.model.layers.24.self_attn.v_proj.weight"
     )
-    # Guard must not raise on the dead shared-KV tail.
     _raise_if_qk_norm_version_gap("gemma4_text", msg, ValueError("orig"))
-    # ... and the message must still match the strict=False fallback that loads it.
+    # The message must still match the strict=False fallback that loads it.
     rule = _KNOWN_MLX_LM_STRICT_FALLBACKS["gemma4_text"]
     assert _message_matches_known_fallback(msg, rule)
 
 
 def test_active_layer_k_norm_and_q_norm_still_raises():
-    # A genuine QK-norm version gap rejects q_norm/k_norm on active layers WITHOUT
-    # the paired KV-sharing k_proj/v_proj - dropping these would break the model,
-    # so the guard must still raise even though k_norm is present.
+    # Active-layer q_norm/k_norm without paired k_proj/v_proj = genuine gap:
+    # must raise even though k_norm is present.
     from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
 
     msg = (
@@ -84,10 +79,12 @@ def test_active_layer_k_norm_and_q_norm_still_raises():
 def test_non_qk_norm_mismatch_passes_through():
     from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
 
-    # A different extra-weight mismatch (handled by the known gemma4 filter) or an
-    # unrelated error must NOT be swallowed by the QK-norm guard.
+    # Other extra-weight mismatches / unrelated errors must pass through.
     _raise_if_qk_norm_version_gap(
-        "gemma4", "Received 4 parameters not in model: per_layer_model_projection.scales",
+        "gemma4",
+        "Received 4 parameters not in model: per_layer_model_projection.scales",
         ValueError("orig"),
     )
-    _raise_if_qk_norm_version_gap("llama", "some unrelated value error", ValueError("orig"))
+    _raise_if_qk_norm_version_gap(
+        "llama", "some unrelated value error", ValueError("orig")
+    )

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -88,3 +88,33 @@ def test_non_qk_norm_mismatch_passes_through():
     _raise_if_qk_norm_version_gap(
         "llama", "some unrelated value error", ValueError("orig")
     )
+
+
+def test_vlm_retry_qk_norm_mismatch_raises_actionable_error():
+    # First strict VLM load fails on the allow-listed per_layer_model_projection
+    # extras (so the code enters the filtered retry); the retry then hits an
+    # older-mlx-vlm q_norm/k_norm mismatch, which must surface the actionable
+    # version-gap error rather than escaping as the raw strict-load ValueError.
+    from unsloth_zoo.mlx.loader import _load_mlx_vlm_with_extra_weight_filter
+
+    calls = {"n": 0}
+    first = (
+        "Received 4 parameters not in model: "
+        "language_model.model.per_layer_model_projection.scales, "
+        "language_model.model.per_layer_model_projection.biases"
+    )
+    retry = (
+        "Received 8 parameters not in model: "
+        "language_model.model.layers.15.self_attn.k_norm.weight, "
+        "language_model.model.layers.15.self_attn.q_norm.weight"
+    )
+
+    def fake_vlm_load(model_name, **kwargs):
+        calls["n"] += 1
+        raise ValueError(first if calls["n"] == 1 else retry)
+
+    with pytest.raises(ValueError) as exc:
+        _load_mlx_vlm_with_extra_weight_filter("some/model", "gemma4", fake_vlm_load, {}, hf_token=None)
+    msg = str(exc.value)
+    assert "mlx-lm" in msg and "0.31.3" in msg and "gemma4" in msg
+    assert calls["n"] == 2  # it must have entered the filtered retry

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -41,17 +41,41 @@ def test_qwen3_5_q_norm_also_caught():
         )
 
 
-def test_kv_sharing_plus_k_norm_raises_not_dropped():
-    # The tester's error: KV-sharing keys (k_proj/v_proj) AND k_norm together.
-    # The QK-norm guard must win over the gemma4 strict=False KV-sharing fallback
-    # so the load-bearing norms are never silently dropped.
-    from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
+def test_kv_sharing_dead_tail_falls_through_to_strict_false():
+    # A gemma4 KV-sharing checkpoint's shared tail carries DEAD k_proj/v_proj/
+    # k_norm (those layers reuse an earlier layer's K/V), so mlx-lm 0.31.3 rejects
+    # exactly that dead tail: k_proj + v_proj + k_norm, never q_norm. Dropping it
+    # via the registered strict=False fallback is safe, so the guard must NOT
+    # raise here (else it regresses a working gemma4_text load - mlx-lm #1242).
+    from unsloth_zoo.mlx.loader import (
+        _KNOWN_MLX_LM_STRICT_FALLBACKS,
+        _message_matches_known_fallback,
+        _raise_if_qk_norm_version_gap,
+    )
 
     msg = (
         "Received 126 parameters not in model: "
         "language_model.model.layers.24.self_attn.k_norm.weight, "
         "language_model.model.layers.24.self_attn.k_proj.weight, "
         "language_model.model.layers.24.self_attn.v_proj.weight"
+    )
+    # Guard must not raise on the dead shared-KV tail.
+    _raise_if_qk_norm_version_gap("gemma4_text", msg, ValueError("orig"))
+    # ... and the message must still match the strict=False fallback that loads it.
+    rule = _KNOWN_MLX_LM_STRICT_FALLBACKS["gemma4_text"]
+    assert _message_matches_known_fallback(msg, rule)
+
+
+def test_active_layer_k_norm_and_q_norm_still_raises():
+    # A genuine QK-norm version gap rejects q_norm/k_norm on active layers WITHOUT
+    # the paired KV-sharing k_proj/v_proj - dropping these would break the model,
+    # so the guard must still raise even though k_norm is present.
+    from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
+
+    msg = (
+        "Received 8 parameters not in model: "
+        "model.layers.7.self_attn.k_norm.weight, "
+        "model.layers.7.self_attn.q_norm.weight"
     )
     with pytest.raises(ValueError):
         _raise_if_qk_norm_version_gap("gemma4_text", msg, ValueError("orig"))

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -41,6 +41,22 @@ def test_qwen3_5_q_norm_also_caught():
         )
 
 
+def test_kv_sharing_plus_k_norm_raises_not_dropped():
+    # The tester's error: KV-sharing keys (k_proj/v_proj) AND k_norm together.
+    # The QK-norm guard must win over the gemma4 strict=False KV-sharing fallback
+    # so the load-bearing norms are never silently dropped.
+    from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
+
+    msg = (
+        "Received 126 parameters not in model: "
+        "language_model.model.layers.24.self_attn.k_norm.weight, "
+        "language_model.model.layers.24.self_attn.k_proj.weight, "
+        "language_model.model.layers.24.self_attn.v_proj.weight"
+    )
+    with pytest.raises(ValueError):
+        _raise_if_qk_norm_version_gap("gemma4_text", msg, ValueError("orig"))
+
+
 def test_non_qk_norm_mismatch_passes_through():
     from unsloth_zoo.mlx.loader import _raise_if_qk_norm_version_gap
 

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -1,4 +1,19 @@
 # Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 # Strict mlx load rejecting q_norm/k_norm = mlx-lm/mlx-vlm too old for a QK-norm
 # arch; the guard must raise a clear error instead of the raw mlx ValueError.
 
@@ -91,10 +106,8 @@ def test_non_qk_norm_mismatch_passes_through():
 
 
 def test_vlm_retry_qk_norm_mismatch_raises_actionable_error():
-    # First strict VLM load fails on the allow-listed per_layer_model_projection
-    # extras (so the code enters the filtered retry); the retry then hits an
-    # older-mlx-vlm q_norm/k_norm mismatch, which must surface the actionable
-    # version-gap error rather than escaping as the raw strict-load ValueError.
+    # First load fails on allow-listed extras (entering the filtered retry); the
+    # retry then hits a q_norm/k_norm gap, which must surface the actionable error.
     from unsloth_zoo.mlx.loader import _load_mlx_vlm_with_extra_weight_filter
 
     calls = {"n": 0}

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -279,27 +279,17 @@ def _message_matches_known_fallback(message, rule):
 
 
 def _raise_if_qk_norm_version_gap(model_type, message, error):
-    """QK-norm archs (gemma4, qwen3_5, ...) carry q_norm / k_norm weights. When a
-    strict mlx load rejects them ("... parameters not in model: ...k_norm..."),
-    the installed mlx-lm / mlx-vlm predates (or regressed on) this architecture -
-    notably mlx-lm 0.31.3 (see mlx-lm #1242). Dropping those weights would yield a
-    numerically broken model, so surface a clear, actionable error instead of the
-    raw mlx ValueError."""
+    """A strict mlx load rejecting q_norm / k_norm means mlx-lm / mlx-vlm is too
+    old (or regressed, e.g. 0.31.3 - mlx-lm #1242) for a QK-norm arch; dropping
+    those weights breaks the model, so raise a clear error instead."""
     if "parameters not in model" not in message:
         return
     if not any(marker in message for marker in ("k_norm", "q_norm")):
         return
-    # A gemma4 / gemma3n KV-sharing checkpoint carries DEAD k_proj / v_proj /
-    # k_norm on its shared tail: those layers reuse an earlier layer's K/V and
-    # never run their own K path, so mlx-lm 0.31.3 (which gates k_proj/k_norm on
-    # a non-shared `has_kv`) rejects exactly that dead tail. Such a rejection
-    # lists k_proj AND v_proj alongside k_norm but never q_norm (the Q path is
-    # never shared), and dropping only that dead tail via the registered
-    # strict=False fallback is numerically safe - it is the load this guard must
-    # not break (see _KNOWN_MLX_LM_STRICT_FALLBACKS["gemma4_text"], mlx-lm #1242).
-    # A genuine QK-norm version gap instead rejects q_norm / k_norm on real
-    # (active) layers WITHOUT the paired k_proj / v_proj, because a build lacking
-    # QK-norm still registers standard k_proj / v_proj. Only raise for the latter.
+    # gemma4/gemma3n KV-sharing tails carry DEAD k_proj/v_proj/k_norm (Q is never
+    # shared, so never q_norm); dropping that tail via the registered strict=False
+    # fallback is safe and must not be blocked (mlx-lm #1242). A genuine version
+    # gap rejects q_norm/k_norm WITHOUT the paired projections - raise only then.
     kv_sharing_dead_tail = (
         "self_attn.k_proj" in message
         and "self_attn.v_proj" in message
@@ -314,7 +304,7 @@ def _raise_if_qk_norm_version_gap(model_type, message, error):
 
             versions.append(f"{pkg}={_dist_version(pkg)}")
         except Exception:
-            # Version probe is best-effort; a missing/renamed dist just omits it from the hint.
+            # Best-effort hint; a missing dist is just omitted.
             pass
     installed = f" Installed: {', '.join(versions)}." if versions else ""
     raise ValueError(
@@ -436,10 +426,7 @@ def _load_mlx_lm_with_strict_fallback(
     except ValueError as error:
         message = str(error)
         # Active-layer QK-norm weights are load-bearing: never strict=False past
-        # them. Raise a clear version-gap error for a genuine QK-norm mismatch,
-        # but let the dead KV-sharing tail (k_proj/v_proj/k_norm, no q_norm) fall
-        # through to the registered strict=False fallback below - see
-        # _raise_if_qk_norm_version_gap.
+        # them; the dead KV-sharing tail still falls through to the fallback below.
         _raise_if_qk_norm_version_gap(model_type, message, error)
         rule = _KNOWN_MLX_LM_STRICT_FALLBACKS.get(model_type)
         if rule is None or not _message_matches_known_fallback(message, rule):
@@ -481,8 +468,7 @@ def _load_mlx_vlm_with_extra_weight_filter(
             return vlm_load(model_name, **vlm_kwargs)
     except ValueError as error:
         message = str(error)
-        # QK-norm weights are load-bearing: never filter past them (see the
-        # mlx-lm path). Check before the known extra-weight filter below.
+        # QK-norm weights are load-bearing: check before the extra-weight filter.
         _raise_if_qk_norm_version_gap(model_type, message, error)
         rule = _KNOWN_VLM_EXTRA_WEIGHT_FILTERS.get(model_type)
         if rule is None or not _message_matches_known_fallback(message, rule):
@@ -4821,9 +4807,8 @@ class FastMLXModel:
                             **extra_kwargs,
                         )
                     except ValueError as error:
-                        # This path loads before quantizing, bypassing
-                        # _load_mlx_vlm_with_extra_weight_filter, so surface the
-                        # QK-norm version gap here too (never drop q_norm/k_norm).
+                        # Pre-quantize load bypasses the extra-weight filter, so
+                        # surface the QK-norm version gap here too.
                         _raise_if_qk_norm_version_gap(model_type, str(error), error)
                         raise
                     vlm_cfg = _vlm_load_config(vlm_load_target)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -412,9 +412,13 @@ def _load_mlx_lm_with_strict_fallback(
         )
     except ValueError as error:
         message = str(error)
+        # QK-norm weights are load-bearing: never strict=False past them. Check
+        # first so an error carrying both KV-sharing keys and q_norm/k_norm (a
+        # broken mlx-lm) raises a clear error instead of silently dropping the
+        # norms via the strict=False fallback below.
+        _raise_if_qk_norm_version_gap(model_type, message, error)
         rule = _KNOWN_MLX_LM_STRICT_FALLBACKS.get(model_type)
         if rule is None or not _message_matches_known_fallback(message, rule):
-            _raise_if_qk_norm_version_gap(model_type, message, error)
             raise
         print(rule["notice"])
         model, config = load_model(
@@ -453,9 +457,11 @@ def _load_mlx_vlm_with_extra_weight_filter(
             return vlm_load(model_name, **vlm_kwargs)
     except ValueError as error:
         message = str(error)
+        # QK-norm weights are load-bearing: never filter past them (see the
+        # mlx-lm path). Check before the known extra-weight filter below.
+        _raise_if_qk_norm_version_gap(model_type, message, error)
         rule = _KNOWN_VLM_EXTRA_WEIGHT_FILTERS.get(model_type)
         if rule is None or not _message_matches_known_fallback(message, rule):
-            _raise_if_qk_norm_version_gap(model_type, message, error)
             raise
 
         print(rule["notice"])

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -292,6 +292,7 @@ def _raise_if_qk_norm_version_gap(model_type, message, error):
 
             versions.append(f"{pkg}={_dist_version(pkg)}")
         except Exception:
+            # Version probe is best-effort; a missing/renamed dist just omits it from the hint.
             pass
     installed = f" Installed: {', '.join(versions)}." if versions else ""
     raise ValueError(
@@ -299,7 +300,7 @@ def _raise_if_qk_norm_version_gap(model_type, message, error):
         f"mlx-lm / mlx-vlm rejects its QK-norm (q_norm/k_norm) weights, so it is "
         f"too old or regressed for this architecture (mlx-lm 0.31.3 broke "
         f"gemma4 / qwen3_5). Reinstall an arch-complete build, e.g. "
-        f'`pip install "mlx-lm!=0.31.3" "mlx-vlm"`. See mlx-lm #1242.{installed}'
+        f'`pip install -U "mlx-lm>=0.22.0,!=0.31.3" "mlx-vlm"`. See mlx-lm #1242.{installed}'
     ) from error
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4080,12 +4080,19 @@ class FastMLXModel:
                 _patch_deepseek_ocr_transformers_import_compat(model_type)
                 vlm_load_target = local_path or model_name
                 with _temporary_hf_token_env(token):
-                    model, processor = vlm_load(
-                        vlm_load_target,
-                        lazy=True,
-                        revision=revision,
-                        **extra_kwargs,
-                    )
+                    try:
+                        model, processor = vlm_load(
+                            vlm_load_target,
+                            lazy=True,
+                            revision=revision,
+                            **extra_kwargs,
+                        )
+                    except ValueError as error:
+                        # This path loads before quantizing, bypassing
+                        # _load_mlx_vlm_with_extra_weight_filter, so surface the
+                        # QK-norm version gap here too (never drop q_norm/k_norm).
+                        _raise_if_qk_norm_version_gap(model_type, str(error), error)
+                        raise
                     vlm_cfg = _vlm_load_config(vlm_load_target)
                 model, vlm_cfg = _apply_mlx_quantization(
                     model, vlm_cfg, quantization_spec,

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -286,10 +286,9 @@ def _raise_if_qk_norm_version_gap(model_type, message, error):
         return
     if not any(marker in message for marker in ("k_norm", "q_norm")):
         return
-    # gemma4/gemma3n KV-sharing tails carry DEAD k_proj/v_proj/k_norm (Q is never
-    # shared, so never q_norm); dropping that tail via the registered strict=False
-    # fallback is safe and must not be blocked (mlx-lm #1242). A genuine version
-    # gap rejects q_norm/k_norm WITHOUT the paired projections - raise only then.
+    # gemma4/gemma3n KV-sharing tails ship DEAD k_proj/v_proj/k_norm (never
+    # q_norm); dropping them via strict=False is safe (mlx-lm #1242). A real gap
+    # rejects q_norm/k_norm WITHOUT the paired projections - raise only then.
     kv_sharing_dead_tail = (
         "self_attn.k_proj" in message
         and "self_attn.v_proj" in message
@@ -304,7 +303,7 @@ def _raise_if_qk_norm_version_gap(model_type, message, error):
 
             versions.append(f"{pkg}={_dist_version(pkg)}")
         except Exception:
-            # Best-effort hint; a missing dist is just omitted.
+            # Best-effort hint; omit a missing dist.
             pass
     installed = f" Installed: {', '.join(versions)}." if versions else ""
     raise ValueError(
@@ -426,7 +425,7 @@ def _load_mlx_lm_with_strict_fallback(
     except ValueError as error:
         message = str(error)
         # Active-layer QK-norm weights are load-bearing: never strict=False past
-        # them; the dead KV-sharing tail still falls through to the fallback below.
+        # them (the dead KV-sharing tail still falls through to the fallback).
         _raise_if_qk_norm_version_gap(model_type, message, error)
         rule = _KNOWN_MLX_LM_STRICT_FALLBACKS.get(model_type)
         if rule is None or not _message_matches_known_fallback(message, rule):
@@ -498,10 +497,8 @@ def _load_mlx_vlm_with_extra_weight_filter(
                 with _temporary_hf_token_env(hf_token):
                     return vlm_load(model_name, **vlm_kwargs)
             except ValueError as retry_error:
-                # Filtering the allow-listed extras can unmask an older-mlx-vlm
-                # q_norm/k_norm mismatch on the retry; surface the same actionable
-                # version-gap error as the first attempt instead of letting the raw
-                # strict-load message (the one this guard exists to replace) escape.
+                # Filtering the extras can unmask a q_norm/k_norm version gap on
+                # the retry; surface the actionable error instead of the raw one.
                 _raise_if_qk_norm_version_gap(model_type, str(retry_error), retry_error)
                 raise
             finally:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -497,6 +497,13 @@ def _load_mlx_vlm_with_extra_weight_filter(
             try:
                 with _temporary_hf_token_env(hf_token):
                     return vlm_load(model_name, **vlm_kwargs)
+            except ValueError as retry_error:
+                # Filtering the allow-listed extras can unmask an older-mlx-vlm
+                # q_norm/k_norm mismatch on the retry; surface the same actionable
+                # version-gap error as the first attempt instead of letting the raw
+                # strict-load message (the one this guard exists to replace) escape.
+                _raise_if_qk_norm_version_gap(model_type, str(retry_error), retry_error)
+                raise
             finally:
                 nn.Module.load_weights = original_load_weights
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -289,6 +289,24 @@ def _raise_if_qk_norm_version_gap(model_type, message, error):
         return
     if not any(marker in message for marker in ("k_norm", "q_norm")):
         return
+    # A gemma4 / gemma3n KV-sharing checkpoint carries DEAD k_proj / v_proj /
+    # k_norm on its shared tail: those layers reuse an earlier layer's K/V and
+    # never run their own K path, so mlx-lm 0.31.3 (which gates k_proj/k_norm on
+    # a non-shared `has_kv`) rejects exactly that dead tail. Such a rejection
+    # lists k_proj AND v_proj alongside k_norm but never q_norm (the Q path is
+    # never shared), and dropping only that dead tail via the registered
+    # strict=False fallback is numerically safe - it is the load this guard must
+    # not break (see _KNOWN_MLX_LM_STRICT_FALLBACKS["gemma4_text"], mlx-lm #1242).
+    # A genuine QK-norm version gap instead rejects q_norm / k_norm on real
+    # (active) layers WITHOUT the paired k_proj / v_proj, because a build lacking
+    # QK-norm still registers standard k_proj / v_proj. Only raise for the latter.
+    kv_sharing_dead_tail = (
+        "self_attn.k_proj" in message
+        and "self_attn.v_proj" in message
+        and "q_norm" not in message
+    )
+    if kv_sharing_dead_tail:
+        return
     versions = []
     for pkg in ("mlx-lm", "mlx-vlm"):
         try:
@@ -417,10 +435,11 @@ def _load_mlx_lm_with_strict_fallback(
         )
     except ValueError as error:
         message = str(error)
-        # QK-norm weights are load-bearing: never strict=False past them. Check
-        # first so an error carrying both KV-sharing keys and q_norm/k_norm (a
-        # broken mlx-lm) raises a clear error instead of silently dropping the
-        # norms via the strict=False fallback below.
+        # Active-layer QK-norm weights are load-bearing: never strict=False past
+        # them. Raise a clear version-gap error for a genuine QK-norm mismatch,
+        # but let the dead KV-sharing tail (k_proj/v_proj/k_norm, no q_norm) fall
+        # through to the registered strict=False fallback below - see
+        # _raise_if_qk_norm_version_gap.
         _raise_if_qk_norm_version_gap(model_type, message, error)
         rule = _KNOWN_MLX_LM_STRICT_FALLBACKS.get(model_type)
         if rule is None or not _message_matches_known_fallback(message, rule):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -274,6 +274,35 @@ def _message_matches_known_fallback(message, rule):
     return all(token in message for token in rule.get("message_tokens", ()))
 
 
+def _raise_if_qk_norm_version_gap(model_type, message, error):
+    """QK-norm archs (gemma4, qwen3_5, ...) carry q_norm / k_norm weights. When a
+    strict mlx load rejects them ("... parameters not in model: ...k_norm..."),
+    the installed mlx-lm / mlx-vlm predates (or regressed on) this architecture -
+    notably mlx-lm 0.31.3 (see mlx-lm #1242). Dropping those weights would yield a
+    numerically broken model, so surface a clear, actionable error instead of the
+    raw mlx ValueError."""
+    if "parameters not in model" not in message:
+        return
+    if not any(marker in message for marker in ("k_norm", "q_norm")):
+        return
+    versions = []
+    for pkg in ("mlx-lm", "mlx-vlm"):
+        try:
+            from importlib.metadata import version as _dist_version
+
+            versions.append(f"{pkg}={_dist_version(pkg)}")
+        except Exception:
+            pass
+    installed = f" Installed: {', '.join(versions)}." if versions else ""
+    raise ValueError(
+        f"Unsloth: cannot load MLX {model_type or 'model'} - the installed "
+        f"mlx-lm / mlx-vlm rejects its QK-norm (q_norm/k_norm) weights, so it is "
+        f"too old or regressed for this architecture (mlx-lm 0.31.3 broke "
+        f"gemma4 / qwen3_5). Reinstall an arch-complete build, e.g. "
+        f'`pip install "mlx-lm!=0.31.3" "mlx-vlm"`. See mlx-lm #1242.{installed}'
+    ) from error
+
+
 def _patch_deepseek_ocr_transformers_import_compat(model_type):
     """Let DeepSeek-OCR remote config imports survive newer Transformers.
 
@@ -385,6 +414,7 @@ def _load_mlx_lm_with_strict_fallback(
         message = str(error)
         rule = _KNOWN_MLX_LM_STRICT_FALLBACKS.get(model_type)
         if rule is None or not _message_matches_known_fallback(message, rule):
+            _raise_if_qk_norm_version_gap(model_type, message, error)
             raise
         print(rule["notice"])
         model, config = load_model(
@@ -425,6 +455,7 @@ def _load_mlx_vlm_with_extra_weight_filter(
         message = str(error)
         rule = _KNOWN_VLM_EXTRA_WEIGHT_FILTERS.get(model_type)
         if rule is None or not _message_matches_known_fallback(message, rule):
+            _raise_if_qk_norm_version_gap(model_type, message, error)
             raise
 
         print(rule["notice"])


### PR DESCRIPTION
## Problem

Loading a QK-norm MLX checkpoint (`gemma4`, `qwen3_5`) on an `mlx-lm` / `mlx-vlm` that predates the architecture fails with a raw, unactionable error:

```
Received 140 parameters not in model:
language_model.model.layers.15.self_attn.k_norm.weight, ...
```

This is what users hit on `mlx-lm` 0.31.3 (see mlx-lm #1242). The `q_norm` / `k_norm` weights are load-bearing, so silently dropping them would produce a numerically broken model.

## Fix

Detect the QK-norm strict-load signature (`parameters not in model` naming `q_norm` / `k_norm`) at both strict re-raise sites in the loader and raise a clear, actionable error that names the cause and the fix (reinstall an arch-complete `mlx-lm`, not 0.31.3) instead of the raw `ValueError`. Covers gemma4, qwen3_5, and any future QK-norm arch generically. Non-QK-norm mismatches still fall through to the existing gemma4 KV-sharing / quant-projection filters.

The loader does not add a `q_norm`/`k_norm`-dropping fallback: those weights matter, so the correct resolution is upgrading the MLX stack (companion fix in the Studio installer excludes `mlx-lm==0.31.3`).

## Validation

`pytest tests/test_mlx_qk_norm_version_gap.py` (3 passing): the tester's exact gemma4 message and a qwen3_5 `q_norm` message raise the actionable error; a non-QK-norm mismatch and an unrelated error pass through untouched.
