### PR TITLE
fix(gguf): preserve Qwen3.5/3.6 MTP config so nextn tensors convert

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2276,10 +2276,17 @@ def convert_to_gguf(
     with open(config_path, "r", encoding = "utf-8") as f:
         config_file = json.load(f)
 
-    # Strip MTP / nextn config keys so the downstream convert_hf_to_gguf.py
-    # doesn't inflate block_count / inject nextn_predict_layers.
+    # Preserve MTP / nextn config so the downstream convert_hf_to_gguf.py keeps
+    # the extra nextn block (block_count += mtp_num_hidden_layers) and emits the
+    # nextn tensors (blk.N.nextn.*). gguf-py has full nextn support, so the
+    # leftover `mtp.*` weights remap cleanly via _Qwen35MtpMixin instead of being
+    # forced into a phantom out-of-range layer. Stripping mtp_num_hidden_layers
+    # shrank block_count to num_hidden_layers, so `mtp.fc` -> `model.layers.<N>.eh_proj`
+    # pointed at a layer index that no longer existed, raising
+    # "Can not map tensor ...eh_proj" for Qwen3.5/3.6 MTP checkpoints.
+    # Only strip Unsloth's internal marker, never the real MTP config.
     _changed = False
-    for _key in ("mtp_num_hidden_layers", "unsloth_fixed_mtp"):
+    for _key in ("unsloth_fixed_mtp",):
         if config_file.pop(_key, None) is not None:
             _changed = True
         _tc = config_file.get("text_config")


### PR DESCRIPTION
## Summary

GGUF conversion of Qwen3.5/3.6 models that have an MTP (nextn) head fails with:

```
ValueError: Can not map tensor 'model.layers.<N>.eh_proj.weight'
```

`convert_to_gguf` strips `mtp_num_hidden_layers` from `config.json` before invoking the converter. That shrinks the converter's `block_count` back to `num_hidden_layers`, but the checkpoint still ships the `mtp.*` weights. `_Qwen35MtpMixin.filter_tensors` then remaps `mtp.fc` → `model.layers.<num_hidden_layers>.eh_proj` — a layer index that no longer exists — so `map_tensor_name` raises.

gguf-py already has full nextn support (`blk.{bid}.nextn.eh_proj`, `enorm`, `hnorm`, `shared_head.*`), so the correct fix is to **keep** the MTP config and let the converter's existing nextn path map the `mtp.*` weights. Only the internal `unsloth_fixed_mtp` marker is stripped.

## Test plan

- [x] Export Qwen3.5-2B (`mtp_num_hidden_layers: 1`) to GGUF — previously failed at `eh_proj`, now converts cleanly and emits `blk.<N>.nextn.*` tensors.
- [x] Verified end-to-end via Unsloth Studio GGUF export (BF16, incl. sharded output).

Companion to unslothai/unsloth#6107 (GGUF shard size control), which surfaced this on Qwen3.5.
