### PR TITLE
Fix MLX trainer tests stale after load_best_model_at_end + trainer internals

### DIFF
--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -67,7 +67,9 @@ def test_mlx_training_config_is_dataclass_with_all_fields():
         "completion_only_loss",
     ):
         assert must_have in fields, f"missing field: {must_have}"
-    assert field_names[field_names.index("eval_steps") + 1] == "dataset_text_field"
+    # dataset_text_field follows the eval block; newer eval knobs (eg load_best_model_at_end)
+    # may sit between them, so assert relative order rather than strict adjacency.
+    assert field_names.index("dataset_text_field") > field_names.index("eval_steps")
     assert field_names[field_names.index("append_eos") + 1] == "train_on_completions"
     assert field_names.index("per_device_eval_batch_size") > field_names.index("vlm_chat_template")
     assert field_names.index("image_size") > field_names.index("vlm_chat_template")

--- a/tests/test_pr684_review_fixes_a.py
+++ b/tests/test_pr684_review_fixes_a.py
@@ -307,6 +307,10 @@ class _StubTrainer:
         self._batches = None
         self._prepared_batches_include_epochs = None
 
+    def _train_dataset_for_batches(self):
+        # mirror MLXTrainer: response-masked dataset overrides train_dataset when set
+        return getattr(self, "_mlx_train_dataset_for_batches", self.train_dataset)
+
 
 def _run_train_on_responses_only(monkeypatch, args):
     """Drive mlx.trainer.train_on_responses_only with an identity HF mask."""


### PR DESCRIPTION
## Summary

Two MLX trainer tests went stale after recent MLX changes and now fail on `main`, which blocks the Core CI matrix on every open PR (Core installs `unsloth_zoo @ main` and runs its suite). This updates the tests to match the current trainer; no product code changes.

## Failures

- `test_mlx_trainer_internals.py::test_mlx_training_config_is_dataclass_with_all_fields`
  `AssertionError: assert 'load_best_model_at_end' == 'dataset_text_field'`
- `test_pr684_review_fixes_a.py::test_thread1_train_inner_preserves_prebuilt_epoch_flag`
- `test_pr684_review_fixes_a.py::test_thread3_step_based_run_does_not_materialize_all_epochs`
- `test_pr684_review_fixes_a.py::test_thread3_epoch_based_run_materializes_all_epochs`
  `AttributeError: '_StubTrainer' object has no attribute '_train_dataset_for_batches'`

## Root cause

- #822 added `load_best_model_at_end` to `MLXTrainingConfig`, inserting it between `eval_steps` and `dataset_text_field`. The field-order check asserted `dataset_text_field` sits immediately after `eval_steps`, so the new field broke it.
- #790 routed the text `train_on_responses_only` path through `trainer._train_dataset_for_batches()`, but `_StubTrainer` only exposes a bare `train_dataset`, so the call raises `AttributeError`.

## Fix

- Assert relative order (`dataset_text_field` after `eval_steps`) instead of strict adjacency, so future eval knobs can sit in between without re-breaking the test. Matches the relative-order checks already used a few lines below.
- Give `_StubTrainer` a `_train_dataset_for_batches()` accessor mirroring `MLXTrainer` (returns `_mlx_train_dataset_for_batches` if set, else `train_dataset`).

## Verification

```
pytest tests/test_mlx_trainer_internals.py tests/test_pr684_review_fixes_a.py
69 passed
```
