### PR TITLE
Load prequantized bnb 4-bit MoE expert checkpoints under transformers v5

### DIFF
--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -64,7 +64,6 @@ def test_twin_built_for_per_expert_expert_converter():
     twin = twins[0]
 
     # Aux keys come first so they are collected alongside the weights.
-    n_base = len(conv.source_patterns)
     expected_aux = [b + suf for b in conv.source_patterns for suf in _AUX_SUFFIXES]
     assert list(twin.source_patterns[: len(expected_aux)]) == expected_aux
 

--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -213,3 +213,38 @@ def test_fused_prequantized_builds_params4bit():
     assert tuple(new_param._original_shape) == (2, 8, 16)
     deq = bnb.functional.dequantize_4bit(new_param.data, new_param.quant_state)
     assert torch.allclose(deq.float(), w.float(), atol=0.5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for bnb 4-bit")
+def test_fused_prequantized_orientation_mismatch_raises():
+    """A blob quantized in the transposed (checkpoint) layout must fail loudly:
+    a transpose op cannot be applied to packed 4-bit data."""
+    import bitsandbytes as bnb
+    import torch.nn as nn
+
+    conv = _fused_passthrough_converter()
+    twin = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)[0]
+    op = twin.operations[0]
+
+    w = torch.randn(2, 16, 8, device="cuda", dtype=torch.bfloat16)  # transposed layout
+    packed, qs = bnb.functional.quantize_4bit(w, quant_type="nf4")
+    base = op.base_source
+    input_dict = {base + "." + k: v for k, v in qs.as_dict(packed=True).items()}
+    input_dict[op.anchored_source] = packed
+
+    experts = nn.Module()
+    # Real-rank meta param carrying the model layout.
+    experts.gate_up_proj = nn.Parameter(torch.empty(2, 8, 16), requires_grad=False)
+    mlp = nn.Module(); mlp.experts = experts
+    layer = nn.Module(); layer.mlp = mlp
+    layers = nn.ModuleList([layer])
+    inner = nn.Module(); inner.layers = layers
+    model = nn.Module(); model.model = inner
+
+    with pytest.raises(ValueError, match="model layout"):
+        op.convert(
+            input_dict,
+            model=model,
+            full_layer_name="model.layers.0.mlp.experts.gate_up_proj",
+            target_patterns=[conv.target_patterns[0]],
+        )

--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -128,3 +128,88 @@ def test_quantstate_absmax_fp32_plain():
     out = _quantstate_absmax_fp32(qs)
     assert out.dtype == torch.float32
     assert torch.equal(out, torch.tensor([1.0, 2.5]))
+
+
+class _StubTranspose(ConversionOps):
+    """Stands in for the model's Transpose op on fused expert params."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def convert(self, input_dict, **kwargs):
+        self.calls += 1
+        return {k: (v[0] if isinstance(v, list) else v).transpose(1, 2) for k, v in input_dict.items()}
+
+
+def _fused_passthrough_converter(name="model.layers.*.mlp.experts.gate_up_proj"):
+    return WeightConverter(
+        source_patterns=name,
+        target_patterns=name,
+        operations=[_StubTranspose()],
+    )
+
+
+def test_fused_passthrough_converter_twinned():
+    """Model converters over a fused expert param (e.g. qwen3_vl_moe's Transpose)
+    precede appended quantizer conversions, so they need a prepended twin too."""
+    conv = _fused_passthrough_converter()
+    twins = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)
+    assert len(twins) == 1
+    twin = twins[0]
+    base = conv.source_patterns[0]
+    assert list(twin.source_patterns) == [base + suf for suf in _AUX_SUFFIXES] + [base + "$"]
+    assert twin.target_patterns[0] == conv.target_patterns[0]
+    assert type(twin.operations[0]).__name__ == "_FusedExpertDeserialize"
+
+
+def test_fused_unquantized_falls_back_to_original_ops():
+    conv = _fused_passthrough_converter()
+    twin = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)[0]
+    op = twin.operations[0]
+    orig = op.original_ops[0]
+
+    fused = torch.randn(3, 4, 2)
+    out = op.convert(
+        {op.anchored_source: fused},
+        model=None,
+        full_layer_name="model.layers.0.mlp.experts.gate_up_proj",
+        target_patterns=[conv.target_patterns[0]],
+    )
+    assert orig.calls == 1
+    assert out[op.base_source].shape == (3, 2, 4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for bnb 4-bit")
+def test_fused_prequantized_builds_params4bit():
+    import bitsandbytes as bnb
+    import torch.nn as nn
+
+    conv = _fused_passthrough_converter()
+    twin = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)[0]
+    op = twin.operations[0]
+
+    w = torch.randn(2, 8, 16, device="cuda", dtype=torch.bfloat16)
+    packed, qs = bnb.functional.quantize_4bit(w, quant_type="nf4")
+    base = op.base_source
+    input_dict = {base + "." + k: v for k, v in qs.as_dict(packed=True).items()}
+    input_dict[op.anchored_source] = packed
+
+    experts = nn.Module()
+    experts.gate_up_proj = nn.Parameter(torch.empty(1), requires_grad=False)
+    mlp = nn.Module(); mlp.experts = experts
+    layer = nn.Module(); layer.mlp = mlp
+    layers = nn.ModuleList([layer])
+    inner = nn.Module(); inner.layers = layers
+    model = nn.Module(); model.model = inner
+
+    out = op.convert(
+        input_dict,
+        model=model,
+        full_layer_name="model.layers.0.mlp.experts.gate_up_proj",
+        target_patterns=[conv.target_patterns[0]],
+    )
+    new_param = out[conv.target_patterns[0]]
+    assert type(new_param).__name__ == "Params4bit"
+    assert tuple(new_param._original_shape) == (2, 8, 16)
+    deq = bnb.functional.dequantize_4bit(new_param.data, new_param.quant_state)
+    assert torch.allclose(deq.float(), w.float(), atol=0.5)

--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -248,3 +248,123 @@ def test_fused_prequantized_orientation_mismatch_raises():
             full_layer_name="model.layers.0.mlp.experts.gate_up_proj",
             target_patterns=[conv.target_patterns[0]],
         )
+
+
+def _stack_input_dict(op, weights_per_src):
+    """Build the per-expert list input_dict for _PerExpertStackDeserialize.
+
+    weights_per_src: [src][expert] float weight tensors (out, in) on CUDA.
+    """
+    import bitsandbytes as bnb
+
+    input_dict = {}
+    for (base, anch), expert_ws in zip(
+        zip(op.base_sources, op.anchored_sources), weights_per_src
+    ):
+        packed_list = []
+        aux_lists = {}
+        for w in expert_ws:
+            packed, qs = bnb.functional.quantize_4bit(w, quant_type="nf4")
+            packed_list.append(packed)
+            for k, v in qs.as_dict(packed=True).items():
+                aux_lists.setdefault("." + k, []).append(v)
+        input_dict[anch] = packed_list
+        for suf, vals in aux_lists.items():
+            input_dict[base + suf] = vals
+    return input_dict
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for bnb 4-bit")
+@pytest.mark.parametrize(
+    "out_dim,in_dim,exact",
+    [
+        (8, 16, True),   # 128 elems per segment: whole 64-blocks, raw concat is exact
+        (6, 10, False),  # 60 elems: partial block, must take the repack path
+    ],
+)
+def test_stack_prequantized_block_alignment(out_dim, in_dim, exact):
+    import bitsandbytes as bnb
+
+    torch.manual_seed(0)
+    conv = _expert_merge_converter()
+    twin = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)[0]
+    op = twin.operations[0]
+
+    n_experts = 2
+    weights_per_src = [
+        [torch.randn(out_dim, in_dim, device="cuda", dtype=torch.bfloat16) for _ in range(n_experts)]
+        for _ in range(len(op.base_sources))
+    ]
+    input_dict = _stack_input_dict(op, weights_per_src)
+
+    from transformers.quantizers.quantizers_utils import get_module_from_name  # noqa: F401
+    import torch.nn as nn
+    experts = nn.Module()
+    experts.gate_up_proj = nn.Parameter(torch.empty(1), requires_grad=False)
+    mlp = nn.Module(); mlp.experts = experts
+    layer = nn.Module(); layer.mlp = mlp
+    inner = nn.Module(); inner.layers = nn.ModuleList([layer])
+    model = nn.Module(); model.model = inner
+
+    out = op.convert(
+        input_dict,
+        model=model,
+        full_layer_name="model.layers.0.mlp.experts.gate_up_proj",
+        target_patterns=[conv.target_patterns[0]],
+    )
+    new_param = out[conv.target_patterns[0]]
+    # Reference: what the per-expert quantized segments actually dequantize to.
+    seg_ref = torch.stack([
+        torch.cat([
+            bnb.functional.dequantize_4bit(
+                *bnb.functional.quantize_4bit(weights_per_src[s][e], quant_type="nf4")
+            ).float()
+            for s in range(len(weights_per_src))
+        ], dim=0)
+        for e in range(n_experts)
+    ])
+    assert tuple(new_param._original_shape) == tuple(seg_ref.shape)
+    deq = bnb.functional.dequantize_4bit(new_param.data, new_param.quant_state).float()
+    deq = deq.reshape(seg_ref.shape)
+    err = (deq - seg_ref).abs().max().item()
+    if exact:
+        # Same bytes and absmax as the per-expert quantization: dequant is identical.
+        assert err == 0.0, err
+    else:
+        # Repack path adds one requant of already-quantized values (~0.16 here);
+        # raw concat instead mis-scales across the partial block boundary.
+        assert err < 0.25, err
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA for bnb 4-bit")
+def test_plain_dequant_skips_bnb_embedding4bit():
+    import bitsandbytes as bnb
+    import torch.nn as nn
+
+    from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import (
+        _dequantize_plain_param_slots,
+    )
+
+    class Holder(nn.Module):
+        pass
+
+    model = Holder()
+    model.emb = bnb.nn.Embedding4bit(16, 64)
+    model.emb = model.emb.cuda()  # quantizes weight into Params4bit
+    model.plain = Holder()
+    packed, qs = bnb.functional.quantize_4bit(
+        torch.randn(4, 64, device="cuda", dtype=torch.bfloat16), quant_type="nf4"
+    )
+    from bitsandbytes.nn import Params4bit
+    router = torch.Tensor._make_subclass(Params4bit, packed)
+    router.requires_grad = False
+    router.quant_state = qs
+    model.plain.weight = router
+
+    _dequantize_plain_param_slots(model)
+
+    # bnb module keeps its quantized weight; the genuinely plain slot converts.
+    assert type(model.emb.weight).__name__ == "Params4bit"
+    assert getattr(model.emb.weight, "quant_state", None) is not None
+    assert type(model.plain.weight).__name__ == "Parameter"
+    assert model.plain.weight.shape == (4, 64)

--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -1,0 +1,131 @@
+"""Tests for the prequantized per-expert bnb-4bit MoE loading converters.
+
+tf4-era unsloth-bnb-4bit checkpoints store MoE experts as one quantized tensor per
+expert per projection (`experts.<N>.gate_proj.weight` + absmax/quant_map/quant_state
+aux keys). Under transformers v5 the model's MergeModulelist converters match those
+keys first, byte-concat packed uint8 as if bf16, and drop every aux key, so
+`_bnb4bit_per_expert_conversions` builds prepended "twin" converters that collect the
+aux keys and reassemble one stacked Params4bit per projection.
+
+These tests drive the twin-construction and routing logic on CPU with synthetic
+converters; the full checkpoint path is exercised by the model loading integration.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "transformers.core_model_loading",
+    reason="requires transformers v5 core_model_loading",
+)
+
+from transformers.core_model_loading import ConversionOps, WeightConverter
+
+from unsloth_zoo.temporary_patches.moe_utils_bnb4bit import (
+    _AUX_SUFFIXES,
+    _bnb4bit_per_expert_conversions,
+    _quantstate_absmax_fp32,
+)
+
+
+class _StubMerge(ConversionOps):
+    """Stands in for the model's MergeModulelist op: stacks collected experts."""
+
+    def __init__(self):
+        self.calls = []
+
+    def convert(self, input_dict, **kwargs):
+        self.calls.append((dict(input_dict), kwargs))
+        merged = torch.stack([v for vs in input_dict.values() for v in (vs if isinstance(vs, list) else [vs])])
+        target = kwargs.get("target_patterns")
+        key = target[0] if isinstance(target, (list, tuple)) else target
+        return {key: merged}
+
+
+def _expert_merge_converter(target="model.layers.*.mlp.experts.gate_up_proj"):
+    return WeightConverter(
+        source_patterns=[
+            "model.layers.*.mlp.experts.*.gate_proj.weight",
+            "model.layers.*.mlp.experts.*.up_proj.weight",
+        ],
+        target_patterns=target,
+        operations=[_StubMerge()],
+    )
+
+
+def test_twin_built_for_per_expert_expert_converter():
+    conv = _expert_merge_converter()
+    twins = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)
+    assert len(twins) == 1
+    twin = twins[0]
+
+    # Aux keys come first so they are collected alongside the weights.
+    n_base = len(conv.source_patterns)
+    expected_aux = [b + suf for b in conv.source_patterns for suf in _AUX_SUFFIXES]
+    assert list(twin.source_patterns[: len(expected_aux)]) == expected_aux
+
+    # Bare weight patterns are `$`-anchored so pattern_to_converter (last-wins)
+    # does not let the twin shadow the model's own converter for bf16 checkpoints.
+    anchored = list(twin.source_patterns[len(expected_aux):])
+    assert anchored == [s + "$" for s in conv.source_patterns]
+    assert twin.target_patterns[0] == conv.target_patterns[0]
+    assert type(twin.operations[0]).__name__ == "_PerExpertStackDeserialize"
+
+
+def test_non_expert_converters_ignored():
+    attn = WeightConverter(
+        source_patterns=["model.layers.*.self_attn.q_proj.weight"],
+        target_patterns="model.layers.*.self_attn.q_proj.weight",
+        operations=[_StubMerge()],
+    )
+    non_weight = WeightConverter(
+        source_patterns=["model.layers.*.mlp.experts.*.gate_proj.bias"],
+        target_patterns="model.layers.*.mlp.experts.gate_up_proj",
+        operations=[_StubMerge()],
+    )
+    assert _bnb4bit_per_expert_conversions([attn, non_weight], hf_quantizer=None) == []
+
+
+def test_down_proj_converter_also_twinned():
+    conv = WeightConverter(
+        source_patterns=["model.layers.*.mlp.experts.*.down_proj.weight"],
+        target_patterns="model.layers.*.mlp.experts.down_proj",
+        operations=[_StubMerge()],
+    )
+    twins = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)
+    assert len(twins) == 1
+    assert twins[0].target_patterns[0].endswith("down_proj")
+
+
+def test_unquantized_layer_falls_back_to_original_merge():
+    """Layers whose experts were skipped by dynamic quantization carry no aux keys;
+    the twin must reproduce the model's own merge for them."""
+    conv = _expert_merge_converter()
+    twin = _bnb4bit_per_expert_conversions([conv], hf_quantizer=None)[0]
+    op = twin.operations[0]
+
+    n_experts = 3
+    input_dict = {
+        anchored: [torch.full((4, 2), float(e)) for e in range(n_experts)]
+        for anchored in op.anchored_sources
+    }
+    out = op.convert(
+        dict(input_dict),
+        model=None,
+        full_layer_name="model.layers.0.mlp.experts.gate_up_proj",
+        target_patterns=[conv.target_patterns[0]],
+    )
+    key = conv.target_patterns[0]
+    assert key in out
+    assert out[key].shape[0] == n_experts * len(op.base_sources)
+
+
+def test_quantstate_absmax_fp32_plain():
+    qs = types.SimpleNamespace(nested=False, absmax=torch.tensor([1.0, 2.5], dtype=torch.bfloat16))
+    out = _quantstate_absmax_fp32(qs)
+    assert out.dtype == torch.float32
+    assert torch.equal(out, torch.tensor([1.0, 2.5]))

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -701,8 +701,9 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
     Old checkpoints store one quantized tensor per expert per projection; the
     model's MergeModulelist converters byte-concat the packed uint8 as if bf16
     and drop the absmax/quant_map aux keys. Each twin also collects the aux
-    keys and rebuilds one stacked Params4bit (NF4 packing is elementwise
-    row-major, so per-expert byte concat is exact). Twins must be PREPENDED to
+    keys and rebuilds one stacked Params4bit (byte concat is exact when each
+    segment fills whole quant blocks; otherwise it repacks from dequantized
+    values to keep block boundaries aligned). Twins must be PREPENDED to
     win the first-match scan; bare-weight patterns are `$`-anchored so they do
     not shadow the model converter in pattern_to_converter.
     """
@@ -771,8 +772,9 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
             first_qs = None
             src_shapes = []
             per_src_absmax = []  # [src][expert] fp32 absmax
+            per_src_qs = []      # [src][expert] QuantState (for the misaligned fallback)
             for base, anch in present_sources:
-                absmax_list = []
+                absmax_list, qs_list = [], []
                 for e in range(num_experts):
                     qd = {}
                     for suf in _AUX_SUFFIXES:
@@ -785,30 +787,54 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
                     if e == 0:
                         src_shapes.append(tuple(qs.shape))
                     absmax_list.append(_quantstate_absmax_fp32(qs))
+                    qs_list.append(qs)
                 per_src_absmax.append(absmax_list)
+                per_src_qs.append(qs_list)
 
             out_dim = sum(s[0] for s in src_shapes)
             in_dim = src_shapes[0][1]
             if any(s[1] != in_dim for s in src_shapes):
                 raise ValueError(f"Unsloth: mismatched expert in_dims {src_shapes} for {full_layer_name}")
 
-            packed_rows, absmax_rows = [], []
-            for e in range(num_experts):
-                packed_rows.append(torch.cat(
-                    [input_dict[anch][e].reshape(-1) for _, anch in present_sources]
-                ))
-                absmax_rows.append(torch.cat([per_src_absmax[i][e] for i in range(len(present_sources))]))
-            data = torch.stack(packed_rows).unsqueeze(-1)  # (E, bytes_per_expert, 1)
-            absmax = torch.cat(absmax_rows)
+            blocksize = first_qs.blocksize
+            if any((s[0] * s[1]) % blocksize != 0 for s in src_shapes):
+                # A segment ends mid-block, so raw byte/absmax concatenation would
+                # scale everything after it with the wrong absmax. Repack from
+                # dequantized values instead (exact block boundaries, tiny requant noise).
+                full = torch.stack([
+                    torch.cat([
+                        bnb.functional.dequantize_4bit(
+                            input_dict[anch][e].reshape(-1, 1), per_src_qs[i][e]
+                        )
+                        for i, (_, anch) in enumerate(present_sources)
+                    ], dim=0)
+                    for e in range(num_experts)
+                ])
+                data, quant_state = bnb.functional.quantize_4bit(
+                    full.to(device, first_qs.dtype).contiguous(),
+                    blocksize=blocksize,
+                    quant_type=first_qs.quant_type,
+                    compress_statistics=False,
+                )
+                quant_state.shape = torch.Size((num_experts, out_dim, in_dim))
+            else:
+                packed_rows, absmax_rows = [], []
+                for e in range(num_experts):
+                    packed_rows.append(torch.cat(
+                        [input_dict[anch][e].reshape(-1) for _, anch in present_sources]
+                    ))
+                    absmax_rows.append(torch.cat([per_src_absmax[i][e] for i in range(len(present_sources))]))
+                data = torch.stack(packed_rows).unsqueeze(-1)  # (E, bytes_per_expert, 1)
+                absmax = torch.cat(absmax_rows)
 
-            quant_state = QuantState(
-                absmax=absmax,
-                shape=torch.Size((num_experts, out_dim, in_dim)),
-                code=first_qs.code.to(device),
-                blocksize=first_qs.blocksize,
-                quant_type=first_qs.quant_type,
-                dtype=first_qs.dtype,
-            )
+                quant_state = QuantState(
+                    absmax=absmax,
+                    shape=torch.Size((num_experts, out_dim, in_dim)),
+                    code=first_qs.code.to(device),
+                    blocksize=blocksize,
+                    quant_type=first_qs.quant_type,
+                    dtype=first_qs.dtype,
+                )
             new_param = torch.Tensor._make_subclass(Params4bit, data.to(device))
             new_param.requires_grad = False
             new_param.quant_state = quant_state
@@ -1017,11 +1043,20 @@ def patch_bnb4bit_dequantize_plain_params():
 pass
 
 
+def _is_bnb_module(module: nn.Module) -> bool:
+    """Any bitsandbytes module (Linear4bit, Embedding4bit, ...) or subclass:
+    their forwards consume quant_state, so their weights must stay quantized."""
+    return any(
+        getattr(klass, "__module__", "").startswith("bitsandbytes")
+        for klass in type(module).__mro__
+    )
+
+
 def _dequantize_plain_param_slots(model: nn.Module):
     if not HAS_BNB:
         return
     for module_name, module in model.named_modules():
-        if isinstance(module, (bnb.nn.Linear4bit,)) or _is_expert_module(module):
+        if _is_bnb_module(module) or _is_expert_module(module):
             continue
         for name, param in list(module.named_parameters(recurse=False)):
             if not isinstance(param, Params4bit):

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -609,7 +609,8 @@ def _bnb4bit_expert_weight_conversions(hf_quantizer):
         def convert(self, input_dict, model=None, full_layer_name=None, **kwargs):
             if len(input_dict) == 1:
                 return input_dict  # no quant stats collected -> not prequantized
-            for key, value in input_dict.items():
+            input_dict = dict(input_dict)  # avoid mutating the caller's dict
+            for key, value in list(input_dict.items()):
                 if isinstance(value, list):
                     input_dict[key] = value[0]
             weight = input_dict.pop(self.param_name)
@@ -621,6 +622,9 @@ def _bnb4bit_expert_weight_conversions(hf_quantizer):
                 device=weight.device,
                 module=module,
             )
+            # _original_shape is needed by PEFT LoRA to recover the logical 3D shape.
+            if getattr(new_value, "quant_state", None) is not None:
+                new_value._original_shape = new_value.quant_state.shape
             module._is_hf_initialized = True
             return {self.param_name: new_value}
 
@@ -740,28 +744,40 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
                     )
                 return out
 
+            input_dict = dict(input_dict)  # avoid mutating the caller's dict
             for key, value in list(input_dict.items()):
                 if not isinstance(value, list):
                     input_dict[key] = [value]
 
-            counts = {len(input_dict[a]) for a in self.anchored_sources if a in input_dict}
+            # Only keep sources actually present; guard against missing/mismatched keys.
+            present_sources = [
+                (base, anch)
+                for base, anch in zip(self.base_sources, self.anchored_sources)
+                if anch in input_dict
+            ]
+            if not present_sources:
+                raise ValueError(
+                    f"Unsloth: no expert weights found in input_dict for {full_layer_name}"
+                )
+
+            counts = {len(input_dict[anch]) for _, anch in present_sources}
             if len(counts) != 1:
                 raise ValueError(
                     f"Unsloth: inconsistent per-expert tensor counts {counts} for {full_layer_name}"
                 )
             num_experts = counts.pop()
 
-            device = input_dict[self.anchored_sources[0]][0].device
+            device = input_dict[present_sources[0][1]][0].device
             first_qs = None
             src_shapes = []
             per_src_absmax = []  # [src][expert] fp32 absmax
-            for base, anch in zip(self.base_sources, self.anchored_sources):
+            for base, anch in present_sources:
                 absmax_list = []
                 for e in range(num_experts):
                     qd = {}
                     for suf in _AUX_SUFFIXES:
                         vals = input_dict.get(base + suf)
-                        if vals is not None:
+                        if vals is not None and e < len(vals):
                             qd["weight" + suf] = vals[e]
                     qs = QuantState.from_dict(qs_dict=qd, device=device)
                     if first_qs is None:
@@ -779,9 +795,9 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
             packed_rows, absmax_rows = [], []
             for e in range(num_experts):
                 packed_rows.append(torch.cat(
-                    [input_dict[a][e].reshape(-1) for a in self.anchored_sources]
+                    [input_dict[anch][e].reshape(-1) for _, anch in present_sources]
                 ))
-                absmax_rows.append(torch.cat([per_src_absmax[i][e] for i in range(len(self.base_sources))]))
+                absmax_rows.append(torch.cat([per_src_absmax[i][e] for i in range(len(present_sources))]))
             data = torch.stack(packed_rows).unsqueeze(-1)  # (E, bytes_per_expert, 1)
             absmax = torch.cat(absmax_rows)
 
@@ -811,6 +827,10 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
     twins = []
     for conv in model_conversions:
         if not isinstance(conv, WeightConverter):
+            continue
+        # Single-target only: a twin returns target_patterns[0] alone, so a
+        # many-to-many mapping would leave its remaining targets unloaded.
+        if len(conv.target_patterns) != 1:
             continue
         target = conv.target_patterns[0]
         if not target.endswith(("gate_up_proj", "down_proj")):
@@ -879,7 +899,9 @@ def patch_bnb4bit_dequantize_plain_params():
     except Exception as e:
         return raise_error("transformers.quantizers.quantizer_bnb_4bit.Bnb4BitHfQuantizer", e)
 
-    original_after_load = Bnb4BitHfQuantizer._process_model_after_weight_loading
+    original_after_load = getattr(Bnb4BitHfQuantizer, "_process_model_after_weight_loading", None)
+    if original_after_load is None:
+        return
     if getattr(original_after_load, "_unsloth_plain_dequant_patched", False):
         return
 
@@ -914,7 +936,7 @@ def _dequantize_plain_param_slots(model: nn.Module):
             if quant_state is None:
                 continue
             dequant = bnb.functional.dequantize_4bit(param.data, quant_state)
-            setattr(module, name, nn.Parameter(dequant, requires_grad=False))
+            setattr(module, name, nn.Parameter(dequant, requires_grad=param.requires_grad))
             if UNSLOTH_ENABLE_LOGGING:
                 logger.info(
                     f"Unsloth: dequantized non-Linear 4-bit param {module_name}.{name} "

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -824,6 +824,61 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
             module._is_hf_initialized = True
             return {target_patterns[0]: new_param}
 
+    class _FusedExpertDeserialize(ConversionOps):
+        """Quantized twin of a model's fused expert converter (e.g. a Transpose).
+
+        A fused prequantized checkpoint stores packed uint8 + aux keys that the
+        model's own converter would mangle (ops like Transpose cannot apply to
+        packed data). With aux keys, rebuild the Params4bit directly; without
+        them, replicate the model's ops so unquantized checkpoints are untouched.
+        """
+
+        def __init__(self, base_source, anchored_source, original_ops):
+            self.base_source = base_source
+            self.anchored_source = anchored_source
+            self.original_ops = original_ops
+
+        def convert(self, input_dict, model=None, full_layer_name=None,
+                    target_patterns=None, missing_keys=None, config=None, **kwargs):
+            has_aux = any((self.base_source + suf) in input_dict for suf in _AUX_SUFFIXES)
+            if not has_aux:
+                out = {self.base_source: input_dict[self.anchored_source]}
+                for op in self.original_ops:
+                    out = op.convert(
+                        out,
+                        source_patterns=[self.base_source],
+                        target_patterns=target_patterns,
+                        full_layer_name=full_layer_name,
+                        model=model,
+                        config=config,
+                        missing_keys=missing_keys,
+                    )
+                return out
+
+            input_dict = dict(input_dict)  # avoid mutating the caller's dict
+            for key, value in list(input_dict.items()):
+                if isinstance(value, list):
+                    input_dict[key] = value[0]
+            weight = input_dict.pop(self.anchored_source)
+            stats = {
+                (self.base_source + suf): input_dict[self.base_source + suf]
+                for suf in _AUX_SUFFIXES
+                if (self.base_source + suf) in input_dict
+            }
+            module, _ = get_module_from_name(model, full_layer_name)
+            new_value = Params4bit.from_prequantized(
+                data=weight,
+                quantized_stats=stats,
+                requires_grad=False,
+                device=weight.device,
+                module=module,
+            )
+            # Logical 3D shape for PEFT LoRA's ParamWrapper.get_param.
+            if getattr(new_value, "quant_state", None) is not None:
+                new_value._original_shape = new_value.quant_state.shape
+            module._is_hf_initialized = True
+            return {target_patterns[0]: new_value}
+
     twins = []
     for conv in model_conversions:
         if not isinstance(conv, WeightConverter):
@@ -835,22 +890,41 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
         target = conv.target_patterns[0]
         if not target.endswith(("gate_up_proj", "down_proj")):
             continue
-        if not all(s.endswith(".weight") for s in conv.source_patterns):
-            continue
-        base_sources = list(conv.source_patterns)
-        anchored_sources = [s + "$" for s in base_sources]
-        aux_sources = [b + suf for b in base_sources for suf in _AUX_SUFFIXES]
-        twins.append(
-            WeightConverter(
-                source_patterns=aux_sources + anchored_sources,
-                target_patterns=target,
-                operations=[
-                    _PerExpertStackDeserialize(
-                        base_sources, anchored_sources, deepcopy(conv.operations)
-                    )
-                ],
+        if all(s.endswith(".weight") for s in conv.source_patterns):
+            base_sources = list(conv.source_patterns)
+            anchored_sources = [s + "$" for s in base_sources]
+            aux_sources = [b + suf for b in base_sources for suf in _AUX_SUFFIXES]
+            twins.append(
+                WeightConverter(
+                    source_patterns=aux_sources + anchored_sources,
+                    target_patterns=target,
+                    operations=[
+                        _PerExpertStackDeserialize(
+                            base_sources, anchored_sources, deepcopy(conv.operations)
+                        )
+                    ],
+                )
             )
-        )
+        elif (
+            len(conv.source_patterns) == 1
+            and conv.source_patterns[0].endswith(("gate_up_proj", "down_proj"))
+        ):
+            # Fused passthrough converter (e.g. qwen3_vl_moe's Transpose). The
+            # model converter precedes appended quantizer conversions and matching
+            # stops at the first hit, so without this twin a fused prequantized
+            # checkpoint feeds packed uint8 into the model's ops.
+            base = conv.source_patterns[0]
+            anchored = base + "$"
+            aux_sources = [base + suf for suf in _AUX_SUFFIXES]
+            twins.append(
+                WeightConverter(
+                    source_patterns=aux_sources + [anchored],
+                    target_patterns=target,
+                    operations=[
+                        _FusedExpertDeserialize(base, anchored, deepcopy(conv.operations))
+                    ],
+                )
+            )
     return twins
 
 

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -390,11 +390,8 @@ pass
 
 # ============================================================================
 # PEFT LoRA support for stacked-MoE bnb 4-bit experts.
-# Teach peft.tuners.lora.layer.ParamWrapper to expose a Params4bit's logical
-# 3-D shape (so LoRA picks the right (E, out, in) layout) and to merge/unmerge
-# via a dequant -> add -> requant cycle (so merge_and_unload() works against
-# packed 4-bit storage). Kept here as partners to
-# replace_expert_params_with_bnb_params + patch_bnb4bit_* rather than in misc.py.
+# Expose a Params4bit's logical 3-D shape to ParamWrapper and merge/unmerge via a
+# dequant -> add -> requant cycle so merge_and_unload() works on packed 4-bit storage.
 # ============================================================================
 
 class _ParamShapeProxy:
@@ -804,8 +801,7 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
             new_param.quant_type = quant_state.quant_type
             new_param.quant_storage = data.dtype
             new_param.bnb_quantized = True
-            # Logical 3D shape for PEFT LoRA's ParamWrapper.get_param, which routes
-            # stacked experts through target_parameters and needs _original_shape.
+            # Logical 3D shape for PEFT LoRA's ParamWrapper.get_param (_original_shape).
             new_param._original_shape = torch.Size((num_experts, out_dim, in_dim))
             module, _ = get_module_from_name(model, full_layer_name)
             new_param.module = module

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -876,6 +876,26 @@ def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
             # Logical 3D shape for PEFT LoRA's ParamWrapper.get_param.
             if getattr(new_value, "quant_state", None) is not None:
                 new_value._original_shape = new_value.quant_state.shape
+                # Orientation is baked in at quantize time (converters run before
+                # the quant op, so supported saves are always model layout). A
+                # same-rank mismatch means an unsupported checkpoint layout that a
+                # transpose op cannot fix on packed data: fail loudly here.
+                try:
+                    expected = tuple(model.get_parameter(full_layer_name).shape)
+                except Exception:
+                    expected = None
+                qshape = tuple(new_value.quant_state.shape)
+                if (
+                    expected is not None
+                    and len(expected) == len(qshape)
+                    and expected != qshape
+                ):
+                    raise ValueError(
+                        f"Unsloth: prequantized expert `{full_layer_name}` was "
+                        f"quantized with shape {qshape} but the model expects "
+                        f"{expected}. Requantize the checkpoint from weights in "
+                        f"the model layout."
+                    )
             module._is_hf_initialized = True
             return {target_patterns[0]: new_value}
 

--- a/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_bnb4bit.py
@@ -50,6 +50,9 @@ __all__ = [
     "patch_bnb4bit_quantize_convert",
     "patch_bnb4bit_quantizer_param_needs_quantization",
     "patch_bnb4bit_quantizer_process_model",
+    "patch_bnb4bit_quantizer_weight_conversions",
+    "patch_bnb4bit_model_conversion_mapping",
+    "patch_bnb4bit_dequantize_plain_params",
     "patch_transformers_weight_converter_kwargs",
     "replace_expert_params_with_bnb_params",
     "forward_moe_backend_bnb4bit",
@@ -586,12 +589,353 @@ def patch_peft_param_wrapper_merge_4bit():
 pass
 
 
+# ============================================================================
+# Prequantized checkpoint loading (transformers v5)
+# ============================================================================
+
+def _bnb4bit_expert_weight_conversions(hf_quantizer):
+    """WeightConverters for prequantized bnb 4-bit MoE expert params.
+
+    The stock quantizer registers Bnb4bitDeserialize only for params named
+    `weight`, so fused expert params (gate_up_proj/down_proj) load as raw
+    packed uint8 and their aux keys are dropped. Register equivalents here.
+    """
+    from transformers.core_model_loading import WeightConverter
+    from transformers.integrations.bitsandbytes import Bnb4bitDeserialize
+    from transformers.quantizers.quantizers_utils import get_module_from_name
+
+    class _ExpertDeserialize(Bnb4bitDeserialize):
+        def __init__(self, hf_quantizer, param_name):
+            super().__init__(hf_quantizer)
+            self.param_name = param_name
+
+        def convert(self, input_dict, model=None, full_layer_name=None, **kwargs):
+            if len(input_dict) == 1:
+                return input_dict  # no quant stats collected -> not prequantized
+            for key, value in input_dict.items():
+                if isinstance(value, list):
+                    input_dict[key] = value[0]
+            weight = input_dict.pop(self.param_name)
+            module, _ = get_module_from_name(model, full_layer_name)
+            new_value = Params4bit.from_prequantized(
+                data=weight,
+                quantized_stats=input_dict,
+                requires_grad=False,
+                device=weight.device,
+                module=module,
+            )
+            module._is_hf_initialized = True
+            return {self.param_name: new_value}
+
+    converters = []
+    for pname in ("gate_up_proj", "down_proj"):
+        converters.append(
+            WeightConverter(
+                source_patterns=[
+                    f"{pname}.nested_absmax",
+                    f"{pname}.nested_quant_map",
+                    f"{pname}.quant_map",
+                    f"{pname}.absmax",
+                    f"{pname}.quant_state.bitsandbytes__nf4",
+                    f"{pname}.quant_state.bitsandbytes__fp4",
+                    pname,
+                ],
+                target_patterns=pname,
+                operations=[_ExpertDeserialize(hf_quantizer, pname)],
+            )
+        )
+    return converters
+
+
+def patch_bnb4bit_quantizer_weight_conversions():
+    """Extend get_weight_conversions so prequantized MoE expert params deserialize."""
+    try:
+        from transformers.quantizers.quantizer_bnb_4bit import Bnb4BitHfQuantizer
+    except Exception as e:
+        return raise_error("transformers.quantizers.quantizer_bnb_4bit.Bnb4BitHfQuantizer", e)
+
+    original_get_weight_conversions = getattr(Bnb4BitHfQuantizer, "get_weight_conversions", None)
+    if original_get_weight_conversions is None:
+        return
+    if getattr(original_get_weight_conversions, "_unsloth_moe_patched", False):
+        return
+
+    def patched_get_weight_conversions(self):
+        conversions = original_get_weight_conversions(self)
+        if self.pre_quantized:
+            try:
+                conversions = list(conversions) + _bnb4bit_expert_weight_conversions(self)
+            except Exception as e:
+                if UNSLOTH_ENABLE_LOGGING:
+                    logger.info(f"Unsloth: expert weight conversions unavailable: {e}")
+        return conversions
+
+    patched_get_weight_conversions._unsloth_moe_patched = True
+    patch_function(Bnb4BitHfQuantizer, "get_weight_conversions", patched_get_weight_conversions)
+pass
+
+
+_AUX_SUFFIXES = (
+    ".nested_absmax",
+    ".nested_quant_map",
+    ".quant_map",
+    ".absmax",
+    ".quant_state.bitsandbytes__nf4",
+    ".quant_state.bitsandbytes__fp4",
+)
+
+
+def _quantstate_absmax_fp32(qs):
+    """Materialize a QuantState's absmax as flat fp32 (denesting double-quant)."""
+    if getattr(qs, "nested", False):
+        absmax = bnb.functional.dequantize_blockwise(qs.absmax, qs.state2)
+        absmax = absmax + qs.offset
+        return absmax.float()
+    return qs.absmax.float()
+
+
+def _bnb4bit_per_expert_conversions(model_conversions, hf_quantizer):
+    """Quantized twins of the model's per-expert MoE merge converters.
+
+    Old checkpoints store one quantized tensor per expert per projection; the
+    model's MergeModulelist converters byte-concat the packed uint8 as if bf16
+    and drop the absmax/quant_map aux keys. Each twin also collects the aux
+    keys and rebuilds one stacked Params4bit (NF4 packing is elementwise
+    row-major, so per-expert byte concat is exact). Twins must be PREPENDED to
+    win the first-match scan; bare-weight patterns are `$`-anchored so they do
+    not shadow the model converter in pattern_to_converter.
+    """
+    from transformers.core_model_loading import WeightConverter, ConversionOps
+    from transformers.quantizers.quantizers_utils import get_module_from_name
+    from bitsandbytes.functional import QuantState
+    from copy import deepcopy
+
+    class _PerExpertStackDeserialize(ConversionOps):
+        def __init__(self, base_sources, anchored_sources, original_ops):
+            self.base_sources = base_sources          # e.g. ["mlp.experts.*.gate_proj.weight", ...]
+            self.anchored_sources = anchored_sources  # same, "$"-anchored (collection keys)
+            self.original_ops = original_ops          # model's ops, for unquantized fallback
+
+        def convert(self, input_dict, model=None, full_layer_name=None,
+                    target_patterns=None, missing_keys=None, config=None, **kwargs):
+            has_aux = any(
+                (base + suf) in input_dict
+                for base in self.base_sources
+                for suf in _AUX_SUFFIXES
+            )
+            if not has_aux:
+                # Unquantized experts in this layer (e.g. dynamic-quant skip layers):
+                # replicate the model's own merge exactly.
+                out = {
+                    orig: input_dict[anch]
+                    for orig, anch in zip(self.base_sources, self.anchored_sources)
+                    if anch in input_dict
+                }
+                for op in self.original_ops:
+                    out = op.convert(
+                        out,
+                        source_patterns=self.base_sources,
+                        target_patterns=target_patterns,
+                        full_layer_name=full_layer_name,
+                        model=model,
+                        config=config,
+                        missing_keys=missing_keys,
+                    )
+                return out
+
+            for key, value in list(input_dict.items()):
+                if not isinstance(value, list):
+                    input_dict[key] = [value]
+
+            counts = {len(input_dict[a]) for a in self.anchored_sources if a in input_dict}
+            if len(counts) != 1:
+                raise ValueError(
+                    f"Unsloth: inconsistent per-expert tensor counts {counts} for {full_layer_name}"
+                )
+            num_experts = counts.pop()
+
+            device = input_dict[self.anchored_sources[0]][0].device
+            first_qs = None
+            src_shapes = []
+            per_src_absmax = []  # [src][expert] fp32 absmax
+            for base, anch in zip(self.base_sources, self.anchored_sources):
+                absmax_list = []
+                for e in range(num_experts):
+                    qd = {}
+                    for suf in _AUX_SUFFIXES:
+                        vals = input_dict.get(base + suf)
+                        if vals is not None:
+                            qd["weight" + suf] = vals[e]
+                    qs = QuantState.from_dict(qs_dict=qd, device=device)
+                    if first_qs is None:
+                        first_qs = qs
+                    if e == 0:
+                        src_shapes.append(tuple(qs.shape))
+                    absmax_list.append(_quantstate_absmax_fp32(qs))
+                per_src_absmax.append(absmax_list)
+
+            out_dim = sum(s[0] for s in src_shapes)
+            in_dim = src_shapes[0][1]
+            if any(s[1] != in_dim for s in src_shapes):
+                raise ValueError(f"Unsloth: mismatched expert in_dims {src_shapes} for {full_layer_name}")
+
+            packed_rows, absmax_rows = [], []
+            for e in range(num_experts):
+                packed_rows.append(torch.cat(
+                    [input_dict[a][e].reshape(-1) for a in self.anchored_sources]
+                ))
+                absmax_rows.append(torch.cat([per_src_absmax[i][e] for i in range(len(self.base_sources))]))
+            data = torch.stack(packed_rows).unsqueeze(-1)  # (E, bytes_per_expert, 1)
+            absmax = torch.cat(absmax_rows)
+
+            quant_state = QuantState(
+                absmax=absmax,
+                shape=torch.Size((num_experts, out_dim, in_dim)),
+                code=first_qs.code.to(device),
+                blocksize=first_qs.blocksize,
+                quant_type=first_qs.quant_type,
+                dtype=first_qs.dtype,
+            )
+            new_param = torch.Tensor._make_subclass(Params4bit, data.to(device))
+            new_param.requires_grad = False
+            new_param.quant_state = quant_state
+            new_param.blocksize = quant_state.blocksize
+            new_param.compress_statistics = False
+            new_param.quant_type = quant_state.quant_type
+            new_param.quant_storage = data.dtype
+            new_param.bnb_quantized = True
+            # Logical 3D shape for PEFT LoRA's ParamWrapper.get_param, which routes
+            # stacked experts through target_parameters and needs _original_shape.
+            new_param._original_shape = torch.Size((num_experts, out_dim, in_dim))
+            module, _ = get_module_from_name(model, full_layer_name)
+            new_param.module = module
+            module._is_hf_initialized = True
+            return {target_patterns[0]: new_param}
+
+    twins = []
+    for conv in model_conversions:
+        if not isinstance(conv, WeightConverter):
+            continue
+        target = conv.target_patterns[0]
+        if not target.endswith(("gate_up_proj", "down_proj")):
+            continue
+        if not all(s.endswith(".weight") for s in conv.source_patterns):
+            continue
+        base_sources = list(conv.source_patterns)
+        anchored_sources = [s + "$" for s in base_sources]
+        aux_sources = [b + suf for b in base_sources for suf in _AUX_SUFFIXES]
+        twins.append(
+            WeightConverter(
+                source_patterns=aux_sources + anchored_sources,
+                target_patterns=target,
+                operations=[
+                    _PerExpertStackDeserialize(
+                        base_sources, anchored_sources, deepcopy(conv.operations)
+                    )
+                ],
+            )
+        )
+    return twins
+
+
+def patch_bnb4bit_model_conversion_mapping():
+    """Prepend per-expert quantized-MoE converters to the model conversion mapping."""
+    try:
+        import transformers.conversion_mapping as conversion_mapping
+        import transformers.modeling_utils as modeling_utils
+        from transformers.quantizers.quantizer_bnb_4bit import Bnb4BitHfQuantizer
+    except Exception as e:
+        return raise_error("transformers.conversion_mapping", e)
+
+    original = conversion_mapping.get_model_conversion_mapping
+    if getattr(original, "_unsloth_moe_patched", False):
+        return
+
+    def patched_get_model_conversion_mapping(model, key_mapping=None, hf_quantizer=None, add_legacy=True):
+        conversions = original(model, key_mapping, hf_quantizer, add_legacy)
+        if isinstance(hf_quantizer, Bnb4BitHfQuantizer) and hf_quantizer.pre_quantized:
+            try:
+                twins = _bnb4bit_per_expert_conversions(conversions, hf_quantizer)
+                if twins:
+                    conversions = twins + conversions
+            except Exception as e:
+                if UNSLOTH_ENABLE_LOGGING:
+                    logger.info(f"Unsloth: per-expert bnb4bit converters unavailable: {e}")
+        return conversions
+
+    patched_get_model_conversion_mapping._unsloth_moe_patched = True
+    conversion_mapping.get_model_conversion_mapping = patched_get_model_conversion_mapping
+    if getattr(modeling_utils, "get_model_conversion_mapping", None) is original:
+        modeling_utils.get_model_conversion_mapping = patched_get_model_conversion_mapping
+pass
+
+
+def patch_bnb4bit_dequantize_plain_params():
+    """Dequantize prequantized Params4bit left on plain nn.Parameter slots.
+
+    Old checkpoints quantize small non-Linear weights too (e.g. the MoE
+    router), which under v5 live on bare nn.Parameter slots, so a packed
+    Params4bit lands where a float weight is expected. After loading,
+    dequantize any such param on a non-Linear4bit, non-experts module.
+    """
+    try:
+        from transformers.quantizers.quantizer_bnb_4bit import Bnb4BitHfQuantizer
+    except Exception as e:
+        return raise_error("transformers.quantizers.quantizer_bnb_4bit.Bnb4BitHfQuantizer", e)
+
+    original_after_load = Bnb4BitHfQuantizer._process_model_after_weight_loading
+    if getattr(original_after_load, "_unsloth_plain_dequant_patched", False):
+        return
+
+    def patched_after_load(self, model, **kwargs):
+        result = original_after_load(self, model, **kwargs)
+        target = result if result is not None else model
+        try:
+            _dequantize_plain_param_slots(target)
+        except Exception as e:
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.info(f"Unsloth: plain-param dequantize pass failed: {e}")
+        return result
+
+    patched_after_load._unsloth_plain_dequant_patched = True
+    patch_function(
+        Bnb4BitHfQuantizer, "_process_model_after_weight_loading", patched_after_load,
+        match_level="relaxed",
+    )
+pass
+
+
+def _dequantize_plain_param_slots(model: nn.Module):
+    if not HAS_BNB:
+        return
+    for module_name, module in model.named_modules():
+        if isinstance(module, (bnb.nn.Linear4bit,)) or _is_expert_module(module):
+            continue
+        for name, param in list(module.named_parameters(recurse=False)):
+            if not isinstance(param, Params4bit):
+                continue
+            quant_state = getattr(param, "quant_state", None)
+            if quant_state is None:
+                continue
+            dequant = bnb.functional.dequantize_4bit(param.data, quant_state)
+            setattr(module, name, nn.Parameter(dequant, requires_grad=False))
+            if UNSLOTH_ENABLE_LOGGING:
+                logger.info(
+                    f"Unsloth: dequantized non-Linear 4-bit param {module_name}.{name} "
+                    f"to {tuple(dequant.shape)} {dequant.dtype}"
+                )
+pass
+
+
 def _register_transformers_v5_moe_bnb4bit_patches():
     if not is_transformers_v5_moe_quantization_available():
         return
     TEMPORARY_PATCHES.append(patch_bnb4bit_quantize_convert)
     TEMPORARY_PATCHES.append(patch_bnb4bit_quantizer_param_needs_quantization)
     TEMPORARY_PATCHES.append(patch_bnb4bit_quantizer_process_model)
+    TEMPORARY_PATCHES.append(patch_bnb4bit_quantizer_weight_conversions)
+    TEMPORARY_PATCHES.append(patch_bnb4bit_model_conversion_mapping)
+    TEMPORARY_PATCHES.append(patch_bnb4bit_dequantize_plain_params)
     TEMPORARY_PATCHES.append(patch_transformers_weight_converter_kwargs)
     TEMPORARY_PATCHES.append(patch_peft_param_wrapper_4bit_expert_shape)
     TEMPORARY_PATCHES.append(patch_peft_param_wrapper_merge_4bit)


### PR DESCRIPTION
## Summary

Older unsloth-bnb-4bit MoE checkpoints store one quantized tensor per expert per projection (`experts.<N>.gate_proj.weight` plus absmax/quant_map/quant_state aux keys), and also quantize small non-Linear weights such as the MoE router. These checkpoints fail to load under transformers v5: the model's MergeModulelist converters match the per-expert keys first, byte-concatenate the packed uint8 as if it were bf16, and drop every aux key as unexpected, while the router lands as raw packed bytes on a plain `nn.Parameter` slot and `F.linear` fails with a reduction dim mismatch.

## What this does

All three patches are active only when a `Bnb4BitHfQuantizer` is `pre_quantized`:

1. `patch_bnb4bit_model_conversion_mapping` prepends quantized twins of the model's per-expert merge converters. Each twin collects the aux keys, rebuilds one `QuantState` per expert, concatenates the packed bytes in target element order (NF4 packing is elementwise row-major, so this is exact), and reassembles a single stacked `Params4bit` with a flat fp32 absmax. Bare weight patterns are anchored so the twins never shadow the model converters for bf16 checkpoints, and layers without aux keys (dynamic-quant skip layers) fall back to the model's own merge.
2. `patch_bnb4bit_quantizer_weight_conversions` registers deserializers for fused expert param names (`gate_up_proj`/`down_proj`), which the stock quantizer only registers for params literally named `weight`.
3. `patch_bnb4bit_dequantize_plain_params` dequantizes any `Params4bit` that landed on a module that is neither a bnb `Linear4bit` nor a v5 experts module (e.g. the router) back to a plain float Parameter after loading.

## Testing

- Dequantized expert weights verified bitwise identical to a reference load.
- End-to-end 4-bit LoRA training validated on Qwen3-30B-A3B (finite losses, 4-bit resident memory).
- 5 new CPU unit tests cover twin construction, pattern anchoring, the unquantized-layer fallback, and absmax denesting.
- Validated across transformers 4.57.6, 5.5, and 5.13 (the last routes stacked experts through PEFT target_parameters, which needs the logical 3D shape now set on the reassembled param).
