### PR TITLE
Optional gate gradient identity for the grouped MoE combine

### DIFF
--- a/tests/test_moe_gategrad_identity.py
+++ b/tests/test_moe_gategrad_identity.py
@@ -103,6 +103,34 @@ def test_gate_gradient_skipped_when_router_frozen():
     assert gate.grad is None
 
 
+def test_matches_autograd_with_zero_gate():
+    # A routing weight of exactly zero (or below the floor) must still get its
+    # true gradient <Y, dOut>. The call site sign-floors the gate away from zero
+    # (straight-through) and both the multiply and the identity's divide use the
+    # same floored value, so the floor cancels exactly.
+    torch.manual_seed(3)
+    inter0 = torch.randn(12, 16)
+    gate0 = torch.randn(12) * 0.5
+    gate0[0] = 0.0
+    gate0[1] = 1e-30
+    gate0[2] = -1e-30
+    W2 = torch.randn(16, 10)
+    dOut = torch.randn(12, 10)
+
+    _, g_gate_ref = _reference(inter0, gate0, W2, dOut)
+
+    inter = inter0.detach().requires_grad_(True)
+    gate = gate0.detach().requires_grad_(True)
+    eps = max(1e-12, float(torch.finfo(gate.dtype).tiny))
+    floored = torch.where(gate >= 0, gate.clamp(min=eps), gate.clamp(max=-eps))
+    safe = gate + (floored - gate).detach()
+    inter_id = _MoEGateGradIdentity.apply(inter, safe)
+    out = (inter_id @ W2) * safe.detach().unsqueeze(-1)
+    out.backward(dOut)
+
+    torch.testing.assert_close(gate.grad, g_gate_ref, rtol=5e-4, atol=5e-5)
+
+
 def test_double_backward_raises():
     # The identity is only first-order exact; create_graph must fail loudly
     # instead of returning wrong second derivatives.

--- a/tests/test_moe_gategrad_identity.py
+++ b/tests/test_moe_gategrad_identity.py
@@ -210,9 +210,14 @@ def test_forward_is_identity_and_env_gated(monkeypatch):
     assert torch.equal(_MoEGateGradIdentity.apply(x, g), x)
 
     # On by default (memory saving); UNSLOTH_MOE_GATEGRAD=0 is the kill-switch.
+    # _moe_gategrad_enabled is lru_cache(1), so clear it after each env change.
     monkeypatch.delenv("UNSLOTH_MOE_GATEGRAD", raising=False)
+    _moe_gategrad_enabled.cache_clear()
     assert _moe_gategrad_enabled()
     monkeypatch.setenv("UNSLOTH_MOE_GATEGRAD", "0")
+    _moe_gategrad_enabled.cache_clear()
     assert not _moe_gategrad_enabled()
     monkeypatch.setenv("UNSLOTH_MOE_GATEGRAD", "1")
+    _moe_gategrad_enabled.cache_clear()
     assert _moe_gategrad_enabled()
+    _moe_gategrad_enabled.cache_clear()  # leave cache clean for later tests

--- a/tests/test_moe_gategrad_identity.py
+++ b/tests/test_moe_gategrad_identity.py
@@ -72,6 +72,37 @@ def test_exact_with_lora_down_projection():
     torch.testing.assert_close(g_gate, g_gate_ref, rtol=5e-4, atol=5e-5)
 
 
+def test_matches_autograd_with_negative_gate():
+    # Gemma4 folds an unconstrained per_expert_scale into top_k_weights, so the
+    # routing weight can be negative; the identity must divide by the signed
+    # weight rather than clamp it toward a positive floor.
+    torch.manual_seed(2)
+    inter = torch.randn(16, 24)
+    gate = torch.randn(16) * 0.5
+    gate = torch.where(gate.abs() < 0.05, torch.full_like(gate, 0.1), gate)
+    W2 = torch.randn(24, 20)
+    dOut = torch.randn(16, 20)
+
+    _, g_gate_ref = _reference(inter, gate, W2, dOut)
+    _, g_gate = _identity_path(inter, gate, W2, dOut)
+    torch.testing.assert_close(g_gate, g_gate_ref, rtol=5e-4, atol=5e-5)
+
+
+def test_gate_gradient_skipped_when_router_frozen():
+    # A frozen router (routing weights with requires_grad=False) must not crash
+    # the backward; inter keeps its passthrough gradient, the gate gets none.
+    inter = torch.randn(6, 8, requires_grad=True)
+    gate = torch.rand(6)
+    W2 = torch.randn(8, 5)
+
+    inter_id = _MoEGateGradIdentity.apply(inter, gate)
+    out = (inter_id @ W2) * gate.detach().unsqueeze(-1)
+    out.backward(torch.randn(6, 5))
+
+    assert inter.grad is not None
+    assert gate.grad is None
+
+
 def test_forward_is_identity_and_env_gated(monkeypatch):
     x = torch.randn(5, 3, requires_grad=True)
     g = torch.rand(5)

--- a/tests/test_moe_gategrad_identity.py
+++ b/tests/test_moe_gategrad_identity.py
@@ -1,0 +1,83 @@
+"""The gate-grad identity must reproduce autograd's routing-weight gradient.
+
+`_MoEGateGradIdentity` derives the routing-weight (gate) gradient from
+``dGate = <A, dA> / gate`` over the pre-down-projection activation instead of
+differentiating the post-down multiply, so the down-projection output never has
+to stay on the autograd tape. The identity is exact for any linear down
+projection; these tests check it in fp32 against plain autograd, with and
+without an additive LoRA term on the down weight.
+"""
+
+import os
+
+import pytest
+import torch
+
+os.environ.setdefault("UNSLOTH_MOE_GATEGRAD", "0")
+
+from unsloth_zoo.temporary_patches.moe_utils import (
+    _MoEGateGradIdentity,
+    _moe_gategrad_enabled,
+)
+
+
+def _reference(inter, gate, W2, dOut):
+    inter = inter.detach().requires_grad_(True)
+    gate = gate.detach().requires_grad_(True)
+    out = (inter @ W2) * gate.unsqueeze(-1)
+    out.backward(dOut)
+    return inter.grad, gate.grad
+
+
+def _identity_path(inter, gate, W2, dOut):
+    inter = inter.detach().requires_grad_(True)
+    gate = gate.detach().requires_grad_(True)
+    inter_id = _MoEGateGradIdentity.apply(inter, gate)
+    # The caller multiplies by the detached gate; the gate gradient comes only
+    # from the identity's backward.
+    out = (inter_id @ W2) * gate.detach().unsqueeze(-1)
+    out.backward(dOut)
+    return inter.grad, gate.grad
+
+
+@pytest.mark.parametrize("n_tokens,d_inter,d_out", [(7, 16, 12), (64, 128, 96)])
+def test_matches_autograd_fp32(n_tokens, d_inter, d_out):
+    torch.manual_seed(0)
+    inter = torch.randn(n_tokens, d_inter)
+    gate = torch.rand(n_tokens) * 0.9 + 0.05  # routing weights, strictly positive
+    W2 = torch.randn(d_inter, d_out)
+    dOut = torch.randn(n_tokens, d_out)
+
+    g_inter_ref, g_gate_ref = _reference(inter, gate, W2, dOut)
+    g_inter, g_gate = _identity_path(inter, gate, W2, dOut)
+
+    torch.testing.assert_close(g_inter, g_inter_ref, rtol=1e-6, atol=1e-6)
+    # dGate reduces over d_inter in a different order than autograd's <Y, dOut>,
+    # so allow fp32 accumulation-order noise.
+    torch.testing.assert_close(g_gate, g_gate_ref, rtol=5e-4, atol=5e-5)
+
+
+def test_exact_with_lora_down_projection():
+    torch.manual_seed(1)
+    n, d, r, h = 32, 64, 8, 48
+    inter = torch.randn(n, d)
+    gate = torch.rand(n) * 0.9 + 0.05
+    W2 = torch.randn(d, h)
+    A, B = torch.randn(d, r), torch.randn(r, h)
+    W2_eff = W2 + (A @ B) * 0.5
+    dOut = torch.randn(n, h)
+
+    _, g_gate_ref = _reference(inter, gate, W2_eff, dOut)
+    _, g_gate = _identity_path(inter, gate, W2_eff, dOut)
+    torch.testing.assert_close(g_gate, g_gate_ref, rtol=5e-4, atol=5e-5)
+
+
+def test_forward_is_identity_and_env_gated(monkeypatch):
+    x = torch.randn(5, 3, requires_grad=True)
+    g = torch.rand(5)
+    assert torch.equal(_MoEGateGradIdentity.apply(x, g), x)
+
+    monkeypatch.delenv("UNSLOTH_MOE_GATEGRAD", raising=False)
+    assert not _moe_gategrad_enabled()
+    monkeypatch.setenv("UNSLOTH_MOE_GATEGRAD", "1")
+    assert _moe_gategrad_enabled()

--- a/tests/test_moe_gategrad_identity.py
+++ b/tests/test_moe_gategrad_identity.py
@@ -8,12 +8,8 @@ projection; these tests check it in fp32 against plain autograd, with and
 without an additive LoRA term on the down weight.
 """
 
-import os
-
 import pytest
 import torch
-
-os.environ.setdefault("UNSLOTH_MOE_GATEGRAD", "0")
 
 from unsloth_zoo.temporary_patches.moe_utils import (
     _MoEGateGradIdentity,
@@ -213,7 +209,10 @@ def test_forward_is_identity_and_env_gated(monkeypatch):
     g = torch.rand(5)
     assert torch.equal(_MoEGateGradIdentity.apply(x, g), x)
 
+    # On by default (memory saving); UNSLOTH_MOE_GATEGRAD=0 is the kill-switch.
     monkeypatch.delenv("UNSLOTH_MOE_GATEGRAD", raising=False)
+    assert _moe_gategrad_enabled()
+    monkeypatch.setenv("UNSLOTH_MOE_GATEGRAD", "0")
     assert not _moe_gategrad_enabled()
     monkeypatch.setenv("UNSLOTH_MOE_GATEGRAD", "1")
     assert _moe_gategrad_enabled()

--- a/tests/test_moe_gategrad_identity.py
+++ b/tests/test_moe_gategrad_identity.py
@@ -161,6 +161,39 @@ def test_fp16_gate_floors_in_fp32_without_output_leak():
     torch.testing.assert_close(gate.grad[0], ref.to(gate.dtype), rtol=5e-3, atol=5e-3)
 
 
+def test_fp16_inter_zero_route_router_gradient_matches_reference():
+    # With fp16 activations, the gradient into the identity is
+    # grad_inter = gate * (W2 @ dOut); a near-zero floored gate makes that product
+    # underflow fp16 to zero before backward runs, so the identity drops the
+    # zero-route router gradient. forward_native_grouped_mm therefore excludes
+    # fp16 inter from the identity and keeps the standard multiply, which recovers
+    # the true <Y, dOut> gradient. This pins both halves of that rationale.
+    torch.manual_seed(7)
+    inter16 = torch.randn(4, 16, dtype=torch.float16)
+    W2 = torch.randn(16, 10, dtype=torch.float16) * 0.1
+    dOut = torch.randn(4, 10, dtype=torch.float16)
+    gate0 = torch.zeros(4, dtype=torch.float16)
+    gate0[0] = 0.6  # one live route; routes 1..3 are exactly zero
+
+    ref = ((inter16.float() @ W2.float()) * dOut.float()).sum(-1)  # true <Y, dOut>
+
+    # Identity path with fp16 inter: the tiny floored gate underflows grad_inter,
+    # so at least one exactly-zero route loses its router gradient.
+    gate = gate0.detach().float().requires_grad_(True)
+    floored = torch.where(gate >= 0, gate.clamp(min=1e-12), gate.clamp(max=-1e-12))
+    safe = gate + (floored - gate).detach()
+    inter_id = _MoEGateGradIdentity.apply(inter16.clone().requires_grad_(True), safe)
+    ((inter_id @ W2) * safe.detach().unsqueeze(-1)).backward(dOut)
+    assert (gate.grad[1:] == 0).any()
+
+    # Standard multiply (the fp16 path forward_native_grouped_mm now uses):
+    # every zero route recovers the correct gradient.
+    gate_s = gate0.detach().requires_grad_(True)
+    ((inter16 @ W2) * gate_s.unsqueeze(-1)).backward(dOut)
+    assert (gate_s.grad[1:] != 0).all()
+    torch.testing.assert_close(gate_s.grad.float(), ref, rtol=5e-2, atol=5e-2)
+
+
 def test_double_backward_raises():
     # The identity is only first-order exact; create_graph must fail loudly
     # instead of returning wrong second derivatives.

--- a/tests/test_moe_gategrad_identity.py
+++ b/tests/test_moe_gategrad_identity.py
@@ -131,6 +131,36 @@ def test_matches_autograd_with_zero_gate():
     torch.testing.assert_close(gate.grad, g_gate_ref, rtol=5e-4, atol=5e-5)
 
 
+def test_fp16_gate_floors_in_fp32_without_output_leak():
+    # fp16 routing weights must be floored in fp32 (eps 1e-12), not at fp16's
+    # smallest normal (~6e-5): flooring a masked (zero) route at 6e-5 would leak
+    # eps * |Y| into the output at a magnitude fp16 can represent. Mirrors the
+    # call-site upcast in forward_native_grouped_mm.
+    torch.manual_seed(5)
+    gate16 = torch.rand(8, dtype=torch.float16) * 0.5
+    gate16[0] = 0.0
+    inter = torch.randn(8, 16)
+    W2 = torch.randn(16, 10)
+
+    gate = gate16.detach().requires_grad_(True)
+    raw = gate.to(torch.float32)
+    eps = 1e-12
+    floored = torch.where(raw >= 0, raw.clamp(min=eps), raw.clamp(max=-eps))
+    safe = raw + (floored - raw).detach()
+    inter_id = _MoEGateGradIdentity.apply(inter, safe)
+    out = (inter_id @ W2) * safe.detach().unsqueeze(-1)
+
+    # The masked route's output leak is bounded by eps * |Y|, invisible in fp16.
+    leak = out[0].abs().max().item()
+    assert leak < 1e-10, leak
+
+    # The zero route still gets its true gradient <Y, dOut>.
+    dOut = torch.randn(8, 10)
+    out.backward(dOut)
+    ref = ((inter[0] @ W2) * dOut[0]).sum()
+    torch.testing.assert_close(gate.grad[0], ref.to(gate.dtype), rtol=5e-3, atol=5e-3)
+
+
 def test_double_backward_raises():
     # The identity is only first-order exact; create_graph must fail loudly
     # instead of returning wrong second derivatives.

--- a/tests/test_moe_gategrad_identity.py
+++ b/tests/test_moe_gategrad_identity.py
@@ -103,6 +103,20 @@ def test_gate_gradient_skipped_when_router_frozen():
     assert gate.grad is None
 
 
+def test_double_backward_raises():
+    # The identity is only first-order exact; create_graph must fail loudly
+    # instead of returning wrong second derivatives.
+    inter = torch.randn(4, 6, requires_grad=True)
+    gate = torch.rand(4, requires_grad=True) + 0.1
+    W2 = torch.randn(6, 3)
+
+    inter_id = _MoEGateGradIdentity.apply(inter, gate)
+    out = (inter_id @ W2) * gate.detach().unsqueeze(-1)
+    (g_gate,) = torch.autograd.grad(out.sum(), gate, create_graph=True)
+    with pytest.raises(RuntimeError):
+        torch.autograd.grad(g_gate.sum(), gate)
+
+
 def test_forward_is_identity_and_env_gated(monkeypatch):
     x = torch.randn(5, 3, requires_grad=True)
     g = torch.rand(5)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1200,7 +1200,9 @@ class _MoEGateGradIdentity(torch.autograd.Function):
 
     The incoming dA equals ``gate * (dOut @ W2_eff.T)`` for the effective down
     weight (base + LoRA), so ``<inter, dA> / gate`` is exactly ``<Y, dOut>``
-    without ever materialising Y for the gradient. Exact for any linear down
+    without ever materialising Y for the gradient. The caller passes a
+    sign-floored gate and multiplies Y by that same value, so the identity holds
+    for any routing weight, including exact zeros. Exact for any linear down
     projection; NOT valid with a post-matmul down bias, so callers must
     disable it when one is present.
     """
@@ -1226,11 +1228,11 @@ class _MoEGateGradIdentity(torch.autograd.Function):
         # router under LoRA), where its gradient is never consumed.
         if ctx.needs_input_grad[1]:
             dgate = (inter.to(torch.float32) * grad_inter.to(torch.float32)).sum(dim=-1)
-            # Divide by the signed routing weight: a negative gate (e.g. Gemma4's
-            # per_expert_scale folded into top_k_weights) must keep its sign, so
-            # clamping toward +eps would flip it. Floor the magnitude to avoid
-            # dividing by ~0; a gate that underflows to zero carries no
-            # recoverable gate gradient, so it collapses to 0 rather than NaN.
+            # The call site multiplies Y by this same sign-floored gate, so the
+            # floor cancels exactly and the quotient equals <Y, dOut> for any
+            # gate, including exact zeros. The re-clamp is a no-op for the safe
+            # gate passed by forward_native_grouped_mm; it only protects direct
+            # callers from dividing by a raw zero.
             gate_f = gate.to(torch.float32)
             safe_gate = torch.where(
                 gate_f >= 0, gate_f.clamp_min(1e-12), gate_f.clamp_max(-1e-12)
@@ -1424,7 +1426,20 @@ def forward_native_grouped_mm(
     )
     permuted_weights = None
     if _gategrad:
-        permuted_weights = top_k_weights.reshape(-1)[sorted_indices]
+        raw_weights = top_k_weights.reshape(-1)[sorted_indices]
+        # Sign-floor the gate away from zero (straight-through, so the synthesized
+        # gradient still reaches top_k_weights). The multiply below and the
+        # identity's divide use the SAME floored value, so they cancel exactly and
+        # the gate gradient <Y, dOut> survives even a routing weight of exactly
+        # zero. Forward changes by at most eps * |Y| for |gate| < eps, far below
+        # dtype resolution. eps respects fp16's smallest normal.
+        eps = max(1e-12, float(torch.finfo(raw_weights.dtype).tiny))
+        floored = torch.where(
+            raw_weights >= 0,
+            raw_weights.clamp(min=eps),
+            raw_weights.clamp(max=-eps),
+        )
+        permuted_weights = raw_weights + (floored - raw_weights).detach()
         inter = _MoEGateGradIdentity.apply(inter, permuted_weights)
 
     # Down projection with optional separated LoRA (default).

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1431,9 +1431,13 @@ def forward_native_grouped_mm(
         # gradient still reaches top_k_weights). The multiply below and the
         # identity's divide use the SAME floored value, so they cancel exactly and
         # the gate gradient <Y, dOut> survives even a routing weight of exactly
-        # zero. Forward changes by at most eps * |Y| for |gate| < eps, far below
-        # dtype resolution. eps respects fp16's smallest normal.
-        eps = max(1e-12, float(torch.finfo(raw_weights.dtype).tiny))
+        # zero. Floor in float32 so eps stays 1e-12 even for fp16 routing weights
+        # (fp16's smallest normal is ~6e-5, large enough to visibly leak masked
+        # routes into the output); the forward then changes by at most
+        # 1e-12 * |Y| for |gate| < 1e-12, far below any dtype's resolution.
+        if raw_weights.dtype == torch.float16:
+            raw_weights = raw_weights.to(torch.float32)
+        eps = 1e-12
         floored = torch.where(
             raw_weights >= 0,
             raw_weights.clamp(min=eps),

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1392,8 +1392,7 @@ def forward_native_grouped_mm(
     else:
         inter = F.silu(gate) * up
 
-    # Gate gradient via the <A, dA> identity (env-gated) so the combine never
-    # caches Y just for the gate multiply. Disabled when a down bias exists.
+    # Env-gated gate-grad identity; disabled when a down bias exists (identity assumes a linear down).
     _gategrad = (
         _moe_gategrad_enabled()
         and getattr(self, "down_proj_bias", None) is None

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1185,13 +1185,15 @@ def patch_param_wrapper_for_moe():
         return False
 
 
-# Optional gate gradient via the inner-product identity dGate = <A, dA> / gate
-# (UNSLOTH_MOE_GATEGRAD=1), instead of <dOut, Y> which pins the down-projection
-# output Y on the tape solely for that gradient. Output unchanged; off by default.
+# Gate gradient via the inner-product identity dGate = <A, dA> / gate, instead of
+# <dOut, Y> which pins the down-projection output Y on the tape solely for that
+# gradient. Output unchanged; on by default to save memory. The runtime gate below
+# still auto-disables it for fp16, down-bias models and frozen routers. Set
+# UNSLOTH_MOE_GATEGRAD=0 to revert to the standard <dOut, Y> path.
 
 
 def _moe_gategrad_enabled() -> bool:
-    return os.environ.get("UNSLOTH_MOE_GATEGRAD", "0") == "1"
+    return os.environ.get("UNSLOTH_MOE_GATEGRAD", "1") != "0"
 
 
 class _MoEGateGradIdentity(torch.autograd.Function):

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1212,10 +1212,28 @@ class _MoEGateGradIdentity(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_inter):
+        # grad_inter is None when nothing downstream needs inter's gradient
+        # (e.g. a frozen down projection); there is nothing to propagate then.
+        if grad_inter is None:
+            return None, None
         inter, gate = ctx.saved_tensors
-        dgate = (inter.to(torch.float32) * grad_inter.to(torch.float32)).sum(dim=-1)
-        dgate = dgate / gate.to(torch.float32).clamp_min(1e-12)
-        return grad_inter, dgate.to(gate.dtype)
+        grad_gate = None
+        # Skip the gate gradient when the routing weight is frozen (e.g. a frozen
+        # router under LoRA), where its gradient is never consumed.
+        if ctx.needs_input_grad[1]:
+            dgate = (inter.to(torch.float32) * grad_inter.to(torch.float32)).sum(dim=-1)
+            # Divide by the signed routing weight: a negative gate (e.g. Gemma4's
+            # per_expert_scale folded into top_k_weights) must keep its sign, so
+            # clamping toward +eps would flip it. Floor the magnitude to avoid
+            # dividing by ~0; a gate that underflows to zero carries no
+            # recoverable gate gradient, so it collapses to 0 rather than NaN.
+            gate_f = gate.to(torch.float32)
+            safe_gate = torch.where(
+                gate_f >= 0, gate_f.clamp_min(1e-12), gate_f.clamp_max(-1e-12)
+            )
+            grad_gate = (dgate / safe_gate).to(gate.dtype)
+        # inter passes through unchanged, so its gradient is grad_inter.
+        return grad_inter, grad_gate
 
 
 def forward_native_grouped_mm(
@@ -1399,7 +1417,7 @@ def forward_native_grouped_mm(
     )
     permuted_weights = None
     if _gategrad:
-        permuted_weights = top_k_weights.view(-1)[sorted_indices]
+        permuted_weights = top_k_weights.reshape(-1)[sorted_indices]
         inter = _MoEGateGradIdentity.apply(inter, permuted_weights)
 
     # Down projection with optional separated LoRA (default).
@@ -1482,7 +1500,7 @@ def forward_native_grouped_mm(
         # Gate grad comes from the identity; detach so the multiply does not pin Y.
         mm2_out = mm2_out * permuted_weights.detach().unsqueeze(-1)
     else:
-        flat_weights = top_k_weights.view(-1)
+        flat_weights = top_k_weights.reshape(-1)
         permuted_weights = flat_weights[sorted_indices]
         mm2_out = mm2_out * permuted_weights.unsqueeze(-1)
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1192,7 +1192,14 @@ def patch_param_wrapper_for_moe():
 # UNSLOTH_MOE_GATEGRAD=0 to revert to the standard <dOut, Y> path.
 
 
+@lru_cache(maxsize=1)
 def _moe_gategrad_enabled() -> bool:
+    """Whether the MoE gate-gradient identity path is active (on by default).
+
+    Cached with maxsize=1 since UNSLOTH_MOE_GATEGRAD is read once per process. Any
+    code or test that toggles the env var at runtime must call
+    _moe_gategrad_enabled.cache_clear() afterwards for the change to take effect.
+    """
     return os.environ.get("UNSLOTH_MOE_GATEGRAD", "1") != "0"
 
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1211,7 +1211,11 @@ class _MoEGateGradIdentity(torch.autograd.Function):
         return inter
 
     @staticmethod
+    @torch.autograd.function.once_differentiable
     def backward(ctx, grad_inter):
+        # once_differentiable: the reconstruction is first-order exact but its
+        # graph is not the original one, so create_graph must raise, not
+        # silently return wrong second derivatives.
         # grad_inter is None when nothing downstream needs inter's gradient
         # (e.g. a frozen down projection); there is nothing to propagate then.
         if grad_inter is None:
@@ -1410,10 +1414,13 @@ def forward_native_grouped_mm(
     else:
         inter = F.silu(gate) * up
 
-    # Env-gated gate-grad identity; disabled when a down bias exists (identity assumes a linear down).
+    # Env-gated gate-grad identity; disabled when a down bias exists (identity
+    # assumes a linear down) or the router is frozen (nothing to synthesize, and
+    # the Function would needlessly keep inter saved).
     _gategrad = (
         _moe_gategrad_enabled()
         and getattr(self, "down_proj_bias", None) is None
+        and top_k_weights.requires_grad
     )
     permuted_weights = None
     if _gategrad:

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1185,6 +1185,39 @@ def patch_param_wrapper_for_moe():
         return False
 
 
+# Optional gate gradient via the inner-product identity dGate = <A, dA> / gate
+# (UNSLOTH_MOE_GATEGRAD=1), instead of <dOut, Y> which pins the down-projection
+# output Y on the tape solely for that gradient. Output unchanged; off by default.
+
+
+def _moe_gategrad_enabled() -> bool:
+    return os.environ.get("UNSLOTH_MOE_GATEGRAD", "0") == "1"
+
+
+class _MoEGateGradIdentity(torch.autograd.Function):
+    """Identity over the pre-down activation ``inter``; backward derives the gate
+    gradient as ``dGate = <inter, dA> / gate`` instead of ``<dOut, Y>``.
+
+    The incoming dA equals ``gate * (dOut @ W2_eff.T)`` for the effective down
+    weight (base + LoRA), so ``<inter, dA> / gate`` is exactly ``<Y, dOut>``
+    without ever materialising Y for the gradient. Exact for any linear down
+    projection; NOT valid with a post-matmul down bias, so callers must
+    disable it when one is present.
+    """
+
+    @staticmethod
+    def forward(ctx, inter, permuted_weights):
+        ctx.save_for_backward(inter, permuted_weights)
+        return inter
+
+    @staticmethod
+    def backward(ctx, grad_inter):
+        inter, gate = ctx.saved_tensors
+        dgate = (inter.to(torch.float32) * grad_inter.to(torch.float32)).sum(dim=-1)
+        dgate = dgate / gate.to(torch.float32).clamp_min(1e-12)
+        return grad_inter, dgate.to(gate.dtype)
+
+
 def forward_native_grouped_mm(
     self,
     hidden_states: torch.Tensor,
@@ -1359,6 +1392,17 @@ def forward_native_grouped_mm(
     else:
         inter = F.silu(gate) * up
 
+    # Gate gradient via the <A, dA> identity (env-gated) so the combine never
+    # caches Y just for the gate multiply. Disabled when a down bias exists.
+    _gategrad = (
+        _moe_gategrad_enabled()
+        and getattr(self, "down_proj_bias", None) is None
+    )
+    permuted_weights = None
+    if _gategrad:
+        permuted_weights = top_k_weights.view(-1)[sorted_indices]
+        inter = _MoEGateGradIdentity.apply(inter, permuted_weights)
+
     # Down projection with optional separated LoRA (default).
     down_lora = None
 
@@ -1435,9 +1479,13 @@ def forward_native_grouped_mm(
         raise AttributeError("MoE layer must have 'down_proj' or 'w2'.")
 
     # Apply routing weights and scatter-add (reduce).
-    flat_weights = top_k_weights.view(-1)
-    permuted_weights = flat_weights[sorted_indices]
-    mm2_out = mm2_out * permuted_weights.unsqueeze(-1)
+    if _gategrad:
+        # Gate grad comes from the identity; detach so the multiply does not pin Y.
+        mm2_out = mm2_out * permuted_weights.detach().unsqueeze(-1)
+    else:
+        flat_weights = top_k_weights.view(-1)
+        permuted_weights = flat_weights[sorted_indices]
+        mm2_out = mm2_out * permuted_weights.unsqueeze(-1)
 
     final_hidden_states = torch.zeros(
         (batch_size * sequence_length, hidden_dim),

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -1417,12 +1417,18 @@ def forward_native_grouped_mm(
         inter = F.silu(gate) * up
 
     # Env-gated gate-grad identity; disabled when a down bias exists (identity
-    # assumes a linear down) or the router is frozen (nothing to synthesize, and
-    # the Function would needlessly keep inter saved).
+    # assumes a linear down), the router is frozen (nothing to synthesize, and
+    # the Function would needlessly keep inter saved), or inter is float16. For
+    # fp16, the gradient into the identity carries the tiny floored gate as a
+    # factor (grad_inter = gate * (W2 @ dOut)); with a near-zero gate that product
+    # underflows fp16 to 0 before backward runs, dropping the router gradient for
+    # near-zero routes. fp16 therefore keeps the standard multiply (correct
+    # gradient, saves Y); bf16/fp32 hold the tiny value and are unaffected.
     _gategrad = (
         _moe_gategrad_enabled()
         and getattr(self, "down_proj_bias", None) is None
         and top_k_weights.requires_grad
+        and inter.dtype != torch.float16
     )
     permuted_weights = None
     if _gategrad:
@@ -1431,10 +1437,10 @@ def forward_native_grouped_mm(
         # gradient still reaches top_k_weights). The multiply below and the
         # identity's divide use the SAME floored value, so they cancel exactly and
         # the gate gradient <Y, dOut> survives even a routing weight of exactly
-        # zero. Floor in float32 so eps stays 1e-12 even for fp16 routing weights
-        # (fp16's smallest normal is ~6e-5, large enough to visibly leak masked
-        # routes into the output); the forward then changes by at most
-        # 1e-12 * |Y| for |gate| < 1e-12, far below any dtype's resolution.
+        # zero. An fp16 gate cannot represent eps=1e-12 (its smallest normal is
+        # ~6e-5), so upcast it to float32; inter is non-fp16 here, so the floored
+        # value survives in grad_inter. The forward then changes by at most
+        # 1e-12 * |Y| for |gate| < 1e-12.
         if raw_weights.dtype == torch.float16:
             raw_weights = raw_weights.to(torch.float32)
         eps = 1e-12


### PR DESCRIPTION
## Summary

In the grouped MoE combine, differentiating `out = down(inter) * gate` pins the down-projection output on the autograd tape solely to form the routing-weight gradient `dGate = <dOut, Y>`. That tensor is large at long sequence lengths.

## What this does

With `UNSLOTH_MOE_GATEGRAD=1` (default off), `forward_native_grouped_mm` derives the gate gradient from the inner-product identity `dGate = <A, dA> / gate` over the pre-down-projection activation instead, so Y never has to stay on the tape. The identity is exact for any linear down projection (frozen base, the recompute path, additive LoRA) but not for a bias added after the down matmul, so the path auto-disables when a down-projection bias is present.

## Testing

- 4 CPU unit tests check the identity against plain autograd in fp32, with and without a LoRA term on the down weight, plus forward-identity and env gating.
- Full-model loss parity on Qwen3-30B-A3B: max per-step deviation 0.0063 over 20 deterministic steps.
- Throughput neutral; peak memory down 1.41 GiB (6 percent) at 16k tokens, with the saving growing with sequence length.
