### PR TITLE
Keep DeepSeek-V4 hyper-connection mixers eager to stop backward inf

### DIFF
--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3275,8 +3275,7 @@ DISABLE_COMPILE_MODULES = [
     "GatedDeltaNet",
     "Qwen3_5MoeGatedDeltaNet",
     # DeepSeek-V4 hyper-connection mixers: Inductor's fused backward of their
-    # Sinkhorn-Knopp division chain overflows to inf at real gradient scales.
-    # Tiny modules, so eager costs nothing.
+    # Sinkhorn-Knopp division chain overflows to inf; tiny modules, so eager is cheap.
     "DeepseekV4HyperConnection",
     "DeepseekV4HyperHead",
 ]

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3274,6 +3274,11 @@ DISABLE_COMPILE_MODULES = [
     "Qwen3NextGatedDeltaNet",
     "GatedDeltaNet",
     "Qwen3_5MoeGatedDeltaNet",
+    # DeepSeek-V4 hyper-connection mixers: Inductor's fused backward of their
+    # Sinkhorn-Knopp division chain overflows to inf at real gradient scales.
+    # Tiny modules, so eager costs nothing.
+    "DeepseekV4HyperConnection",
+    "DeepseekV4HyperHead",
 ]
 
 FIX_GC_LAYER_CALLER_MODULES = [


### PR DESCRIPTION
## Summary

Training DeepSeek-V4 with compiled modules produced inf grad_norm at step 2 and NaN weights by step 3 while the forward loss stayed finite. Bisecting the compiled cache per function isolated the manifold-constrained hyper-connection stream mixers (`DeepseekV4HyperConnection` / `DeepseekV4HyperHead`): their Sinkhorn-Knopp normalization chains twenty `comb/(sum+eps)` divisions with sigmoid and softmax mixing, and Inductor's fused backward of that chain overflows to inf at realistic gradient magnitudes. A random-init repro stays finite; the real model's gradient scale is required. Compiling everything except these two modules is stable.

## What this does

Adds both classes to `DISABLE_COMPILE_MODULES` alongside the other numerically sensitive exclusions. RMSNorm, MLP, router, MLA attention, MoE, and the fused cross entropy stay compiled; the mixers are tiny, so throughput is unchanged.

## Testing

- tiny-DeepseekV4: 15 finite steps with a fresh cache and default env, loss matching a fully uncompiled reference run to 0.0002.
- tiny-DeepseekV3 (no hyper-connection modules): no regression.
