### PR TITLE
Route gemma-4 sliding-window layers through FlashAttention-2

### DIFF
--- a/tests/test_gemma4_banded_attention.py
+++ b/tests/test_gemma4_banded_attention.py
@@ -213,6 +213,7 @@ def test_router_falls_back_to_banded_without_flash(monkeypatch, with_mask):
     monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
     gf._enabled.cache_clear()  # _enabled is lru_cache(1); re-read the toggled env
     monkeypatch.delenv("UNSLOTH_BANDED_SDPA", raising=False)
+    gf._force_banded.cache_clear()  # _force_banded is lru_cache(1); re-read the toggled env
 
     S, w, H, Hkv, d = 300, 64, 8, 2, 32
     torch.manual_seed(0)
@@ -260,6 +261,7 @@ def test_router_force_banded_env_skips_flash(monkeypatch):
     monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
     gf._enabled.cache_clear()  # _enabled is lru_cache(1); re-read the toggled env
     monkeypatch.setenv("UNSLOTH_BANDED_SDPA", "1")
+    gf._force_banded.cache_clear()  # _force_banded is lru_cache(1); re-read the toggled env
 
     S, w, H, Hkv, d = 256, 64, 4, 4, 32
     torch.manual_seed(3)

--- a/tests/test_gemma4_banded_attention.py
+++ b/tests/test_gemma4_banded_attention.py
@@ -1,0 +1,323 @@
+"""Banded (block-local) sliding-window SDPA must match full SDPA + band mask.
+
+`_banded_sdpa_core` computes sliding-window attention in O(S*w) by folding
+w-sized query blocks into the batch dimension, each attending its own and the
+previous key block under a static (w, 2w) mask. These tests compare it against
+full SDPA with the explicit band mask (query i attends keys (i-w, i]) on CPU,
+including GQA and sequence lengths that do not divide the window.
+
+They also cover the unified sliding-window router in gemma4_flash_sliding.py:
+with flash-attn forced unavailable the router must fall back to this banded
+kernel and still match full SDPA + band mask, and UNSLOTH_BANDED_SDPA=1 must
+force the banded kernel even when flash-attn looks present.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from unsloth_zoo.temporary_patches.gemma4_banded_attention import (
+    _banded_sdpa_core,
+    _block_mask,
+    _mask_is_plain_band,
+)
+
+
+def _band_mask_full(S, w, device="cpu"):
+    qi = torch.arange(S, device=device)[:, None]
+    kj = torch.arange(S, device=device)[None, :]
+    return (kj <= qi) & (kj > qi - w)
+
+
+def _reference(q, k, v, w, scale):
+    B, H, S, d = q.shape
+    Hkv = k.shape[1]
+    ng = H // Hkv
+    if ng > 1:
+        k = k[:, :, None].expand(B, Hkv, ng, S, d).reshape(B, H, S, d)
+        v = v[:, :, None].expand(B, Hkv, ng, S, d).reshape(B, H, S, d)
+    m = _band_mask_full(S, w, q.device)[None, None]
+    out = F.scaled_dot_product_attention(q, k, v, attn_mask=m, scale=scale)
+    return out.transpose(1, 2).contiguous()  # (B,S,H,d), matching the core
+
+
+@pytest.mark.parametrize("S,w,H,Hkv,d", [
+    (256, 64, 4, 4, 32),     # no GQA, S divisible by w
+    (300, 64, 8, 2, 32),     # GQA 4, ragged tail block
+    (513, 128, 4, 1, 16),    # MQA, S = 4w + 1
+])
+def test_matches_full_sdpa_fp32(S, w, H, Hkv, d):
+    torch.manual_seed(0)
+    q = torch.randn(1, H, S, d)
+    k = torch.randn(1, Hkv, S, d)
+    v = torch.randn(1, Hkv, S, d)
+    scale = d ** -0.5
+    ref = _reference(q, k, v, w, scale)
+    out = _banded_sdpa_core(q, k, v, w, scale, 0.0, H // Hkv)
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_batch_general_matches_full_sdpa_fp32():
+    # The banded core is batch-general (the router drops the batch == 1 gate), so
+    # a B > 1 unpadded band must match full SDPA + band mask on every element.
+    torch.manual_seed(2)
+    B, S, w, H, Hkv, d = 3, 300, 64, 8, 2, 32
+    q = torch.randn(B, H, S, d)
+    k = torch.randn(B, Hkv, S, d)
+    v = torch.randn(B, Hkv, S, d)
+    scale = d ** -0.5
+    ref = _reference(q, k, v, w, scale)
+    out = _banded_sdpa_core(q, k, v, w, scale, 0.0, H // Hkv)
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_gradients_match_fp32():
+    torch.manual_seed(1)
+    S, w, H, d = 256, 64, 2, 16
+    q1 = torch.randn(1, H, S, d, requires_grad=True)
+    k1 = torch.randn(1, H, S, d, requires_grad=True)
+    v1 = torch.randn(1, H, S, d, requires_grad=True)
+    q2 = q1.detach().clone().requires_grad_(True)
+    k2 = k1.detach().clone().requires_grad_(True)
+    v2 = v1.detach().clone().requires_grad_(True)
+    scale = d ** -0.5
+
+    _reference(q1, k1, v1, w, scale).square().sum().backward()
+    _banded_sdpa_core(q2, k2, v2, w, scale, 0.0, 1).square().sum().backward()
+
+    torch.testing.assert_close(q2.grad, q1.grad, rtol=1e-4, atol=1e-5)
+    torch.testing.assert_close(k2.grad, k1.grad, rtol=1e-4, atol=1e-5)
+    torch.testing.assert_close(v2.grad, v1.grad, rtol=1e-4, atol=1e-5)
+
+
+def test_block_mask_block0_masks_phantom_prev():
+    w, nb = 8, 3
+    m = _block_mask(w, nb, torch.device("cpu"))
+    assert m.shape == (nb, 1, w, 2 * w)
+    # Block 0 must not attend the (padded) previous block.
+    assert not m[0, 0, :, :w].any()
+    # Later blocks follow the same local band for every block index.
+    assert torch.equal(m[1], m[2])
+
+
+def test_mask_is_plain_band_detection():
+    S, w = 128, 32
+    band = _band_mask_full(S, w)[None, None]
+    assert _mask_is_plain_band(band, S, w)
+    # Padding one token out of the band pattern must be rejected.
+    padded = band.clone()
+    padded[..., S - 1, 0:1] = True
+    assert not _mask_is_plain_band(padded, S, w)
+    assert _mask_is_plain_band(None, S, w)
+
+
+def test_mask_is_plain_band_rejects_non_probe_violation():
+    # A band broken only at an interior row (a packed-sequence boundary) must be
+    # rejected: the verifier checks every row, not a sampled subset.
+    S, w = 128, 32
+    packed = _band_mask_full(S, w)[None, None].clone()
+    packed[..., 50, 40] = False    # drop an in-band key at a non-probe row
+    assert not _mask_is_plain_band(packed, S, w)
+
+
+def test_mask_is_plain_band_rejects_per_head_mask():
+    # A 4D mask with a head dim > 1 cannot be honoured by the single block mask
+    # applied to every head, so it must be rejected even if head 0 is a band.
+    S, w = 128, 32
+    band = _band_mask_full(S, w)
+    per_head = band[None, None].expand(1, 4, S, S).clone()   # (1, 4, S, S)
+    assert not _mask_is_plain_band(per_head, S, w)
+    assert _mask_is_plain_band(band[None, None], S, w)       # (1, 1, S, S) still ok
+
+
+def test_mask_is_plain_band_rejects_per_batch_padding():
+    # The probe validates every batch element, not just batch 0: a batch whose
+    # element 0 is a full band but a later element carries padding must be
+    # rejected so the fast path never runs on an unhonoured padded sample.
+    S, w = 128, 32
+    band = _band_mask_full(S, w)                              # (S, S)
+    batched = band[None, None].expand(1, 1, S, S).clone()
+    batched = batched.expand(3, 1, S, S).clone()             # (3, 1, S, S), all bands
+    assert _mask_is_plain_band(batched.clone(), S, w)        # every element a band -> ok
+    padded = batched.clone()
+    padded[2, 0, :, 0] = False                               # break the band only in element 2
+    assert not _mask_is_plain_band(padded, S, w)
+
+
+def test_mask_is_plain_band_rejects_inband_bias():
+    # A finite in-band bias (soft penalty) must be rejected: the banded path
+    # swaps in a boolean block mask and would silently drop the bias.
+    S, w = 128, 32
+    band = _band_mask_full(S, w)
+    biased = torch.where(band, -5.0, float("-inf")).to(torch.float32)[None, None]
+    assert not _mask_is_plain_band(biased, S, w)
+    clean = torch.where(band, 0.0, float("-inf")).to(torch.float32)[None, None]
+    assert _mask_is_plain_band(clean, S, w)
+
+
+def test_mask_is_plain_band_chunked_equals_single_block():
+    # Row-chunked verification must agree with a single-block scan on every mask.
+    S, w = 96, 16
+    band = _band_mask_full(S, w)
+    packed = band.clone(); packed[50, 40] = False
+    cases = {
+        "band_bool": band[None, None],
+        "band_float": torch.where(band, 0.0, float("-inf")).to(torch.float32)[None, None],
+        "packed_bool": packed[None, None],
+    }
+    for name, m in cases.items():
+        full = _mask_is_plain_band(m.clone(), S, w, _block=S)
+        chunked = _mask_is_plain_band(m.clone(), S, w, _block=7)  # crosses block edges
+        assert full == chunked, name
+
+
+def test_mask_is_plain_band_survives_id_reuse():
+    # A recycled object id must not produce a stale cached verdict for packed masks.
+    S, w = 128, 32
+    template = _band_mask_full(S, w)[None, None].clone()
+    template[..., 50, 40] = False    # packed-style violation on a non-probe row
+    valid = _band_mask_full(S, w)[None, None]
+    assert _mask_is_plain_band(valid, S, w)    # caches a True verdict on this object
+    del valid                                  # frees its id for reuse
+    for _ in range(5000):
+        packed = template.clone()              # a distinct object, may land on the freed id
+        assert not _mask_is_plain_band(packed, S, w)
+        del packed
+
+
+class Gemma4SlidingFake:
+    """Minimal stand-in for a Gemma-4 sliding-window attention module.
+
+    The router gates on ``is_sliding``, a class name starting with ``Gemma4`` and
+    ``head_dim <= 256``; this reproduces exactly those attributes so the routing
+    branch can be exercised without loading a real model.
+    """
+    is_sliding = True
+    is_causal = True
+    training = False
+
+    def __init__(self, w, ng):
+        self.sliding_window = w
+        self.num_key_value_groups = ng
+
+
+@pytest.mark.parametrize("with_mask", [False, True])
+def test_router_falls_back_to_banded_without_flash(monkeypatch, with_mask):
+    # With flash-attn forced unavailable the unified wrapper must route a sliding
+    # Gemma-4 plain-band case through _banded_sdpa_core (never the wrapped SDPA)
+    # and match full SDPA + band mask. Runs on CPU regardless of flash-attn.
+    from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
+
+    monkeypatch.setattr(gf, "_HAS_FA2", False)
+    monkeypatch.setattr(gf, "_flash_attn_func", None)
+    monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
+    monkeypatch.delenv("UNSLOTH_BANDED_SDPA", raising=False)
+
+    S, w, H, Hkv, d = 300, 64, 8, 2, 32
+    torch.manual_seed(0)
+    q = torch.randn(1, H, S, d)
+    k = torch.randn(1, Hkv, S, d)
+    v = torch.randn(1, Hkv, S, d)
+    scale = d ** -0.5
+    ng = H // Hkv
+    module = Gemma4SlidingFake(w, ng)
+
+    if with_mask:
+        attn_mask = _band_mask_full(S, w)[None, None].clone()
+    else:
+        attn_mask = None
+
+    def _boom(*a, **kw):
+        raise AssertionError("router fell through to SDPA instead of the banded kernel")
+
+    orig = gf._ORIG_SDPA[0]
+    gf._ORIG_SDPA[0] = _boom
+    before = gf._BANDED_ENGAGED[0]
+    try:
+        out, weights = gf._sdpa_maybe_flash_sliding(
+            module, q, k, v, attn_mask, dropout=0.0, scaling=scale, is_causal=None,
+        )
+    finally:
+        gf._ORIG_SDPA[0] = orig
+
+    assert weights is None
+    assert gf._BANDED_ENGAGED[0] == before + 1, "banded path was not engaged"
+    ref = _reference(q, k, v, w, scale)
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_router_force_banded_env_skips_flash(monkeypatch):
+    # UNSLOTH_BANDED_SDPA=1 must force the banded kernel even when flash-attn is
+    # importable: the flash function must never be called.
+    from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
+
+    def _flash_should_not_run(*a, **kw):
+        raise AssertionError("flash_attn_func called despite UNSLOTH_BANDED_SDPA=1")
+
+    monkeypatch.setattr(gf, "_HAS_FA2", True)
+    monkeypatch.setattr(gf, "_flash_attn_func", _flash_should_not_run)
+    monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
+    monkeypatch.setenv("UNSLOTH_BANDED_SDPA", "1")
+
+    S, w, H, Hkv, d = 256, 64, 4, 4, 32
+    torch.manual_seed(3)
+    q = torch.randn(1, H, S, d)
+    k = torch.randn(1, Hkv, S, d)
+    v = torch.randn(1, Hkv, S, d)
+    scale = d ** -0.5
+    module = Gemma4SlidingFake(w, H // Hkv)
+
+    orig = gf._ORIG_SDPA[0]
+    gf._ORIG_SDPA[0] = lambda *a, **kw: (_ for _ in ()).throw(
+        AssertionError("router fell through to SDPA instead of the banded kernel"))
+    before = gf._BANDED_ENGAGED[0]
+    try:
+        out, weights = gf._sdpa_maybe_flash_sliding(
+            module, q, k, v, None, dropout=0.0, scaling=scale, is_causal=None,
+        )
+    finally:
+        gf._ORIG_SDPA[0] = orig
+
+    assert weights is None
+    assert gf._BANDED_ENGAGED[0] == before + 1
+    ref = _reference(q, k, v, w, scale)
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_router_kill_switch_defers_to_sdpa(monkeypatch):
+    # UNSLOTH_GEMMA4_FLASH_SLIDING=0 must disable both fast kernels and defer to
+    # the wrapped SDPA, neither FA2 nor banded may engage.
+    from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
+
+    monkeypatch.setattr(gf, "_HAS_FA2", False)
+    monkeypatch.setattr(gf, "_flash_attn_func", None)
+    monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "0")
+
+    S, w, H, d = 256, 64, 4, 32
+    torch.manual_seed(4)
+    q = torch.randn(1, H, S, d)
+    k = torch.randn(1, H, S, d)
+    v = torch.randn(1, H, S, d)
+    scale = d ** -0.5
+    module = Gemma4SlidingFake(w, 1)
+
+    sentinel = object()
+    called = {}
+
+    def _fake_sdpa(mod, qq, kk, vv, am, dropout=0.0, scaling=None, is_causal=None, **kw):
+        called["hit"] = True
+        return sentinel, None
+
+    banded_before = gf._BANDED_ENGAGED[0]
+    orig = gf._ORIG_SDPA[0]
+    gf._ORIG_SDPA[0] = _fake_sdpa
+    try:
+        out, _ = gf._sdpa_maybe_flash_sliding(
+            module, q, k, v, None, dropout=0.0, scaling=scale, is_causal=None,
+        )
+    finally:
+        gf._ORIG_SDPA[0] = orig
+
+    assert called.get("hit") is True
+    assert out is sentinel
+    assert gf._BANDED_ENGAGED[0] == banded_before, "banded engaged despite kill switch"

--- a/tests/test_gemma4_banded_attention.py
+++ b/tests/test_gemma4_banded_attention.py
@@ -211,6 +211,7 @@ def test_router_falls_back_to_banded_without_flash(monkeypatch, with_mask):
     monkeypatch.setattr(gf, "_HAS_FA2", False)
     monkeypatch.setattr(gf, "_flash_attn_func", None)
     monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
+    gf._enabled.cache_clear()  # _enabled is lru_cache(1); re-read the toggled env
     monkeypatch.delenv("UNSLOTH_BANDED_SDPA", raising=False)
 
     S, w, H, Hkv, d = 300, 64, 8, 2, 32
@@ -257,6 +258,7 @@ def test_router_force_banded_env_skips_flash(monkeypatch):
     monkeypatch.setattr(gf, "_HAS_FA2", True)
     monkeypatch.setattr(gf, "_flash_attn_func", _flash_should_not_run)
     monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
+    gf._enabled.cache_clear()  # _enabled is lru_cache(1); re-read the toggled env
     monkeypatch.setenv("UNSLOTH_BANDED_SDPA", "1")
 
     S, w, H, Hkv, d = 256, 64, 4, 4, 32
@@ -292,6 +294,7 @@ def test_router_kill_switch_defers_to_sdpa(monkeypatch):
     monkeypatch.setattr(gf, "_HAS_FA2", False)
     monkeypatch.setattr(gf, "_flash_attn_func", None)
     monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "0")
+    gf._enabled.cache_clear()  # _enabled is lru_cache(1); re-read the toggled env
 
     S, w, H, d = 256, 64, 4, 32
     torch.manual_seed(4)

--- a/tests/test_gemma4_banded_attention.py
+++ b/tests/test_gemma4_banded_attention.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from unsloth_zoo.temporary_patches import gemma4_banded_attention as gba
 from unsloth_zoo.temporary_patches.gemma4_banded_attention import (
     _banded_sdpa_core,
     _block_mask,
@@ -88,6 +89,28 @@ def test_gradients_match_fp32():
     torch.testing.assert_close(q2.grad, q1.grad, rtol=1e-4, atol=1e-5)
     torch.testing.assert_close(k2.grad, k1.grad, rtol=1e-4, atol=1e-5)
     torch.testing.assert_close(v2.grad, v1.grad, rtol=1e-4, atol=1e-5)
+
+
+def test_mask_is_plain_band_defers_while_compiling(monkeypatch):
+    # Under torch.compile the .item() verdict and the tensor-attribute write are
+    # untraceable, so while compiling the probe must return False and route to the
+    # original SDPA regardless of the mask contents (here a genuine band).
+    S, w = 128, 32
+    band = _band_mask_full(S, w)[None, None].clone()
+    assert _mask_is_plain_band(band.clone(), S, w)          # eager: a real band is accepted
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    assert _mask_is_plain_band(band.clone(), S, w) is False  # compiling: always defers
+
+
+def test_block_mask_cache_is_bounded(monkeypatch):
+    # Varying sequence lengths yield many distinct (w, nb) keys; the FIFO bound
+    # must keep _MASK_CACHE from growing without limit (cap 8).
+    monkeypatch.setattr(gba, "_MASK_CACHE", {})
+    w = 8
+    for nb in range(1, 40):
+        _block_mask(w, nb, torch.device("cpu"))
+        assert len(gba._MASK_CACHE) <= 8
+    assert len(gba._MASK_CACHE) == 8
 
 
 def test_block_mask_block0_masks_phantom_prev():

--- a/tests/test_gemma4_flash_sliding.py
+++ b/tests/test_gemma4_flash_sliding.py
@@ -1,0 +1,73 @@
+"""FA2 sliding-window path for gemma-4 must match full SDPA with the band mask.
+
+Gemma-4 mixes head_dim=256 sliding-window layers with head_dim=512 global
+layers, so FlashAttention-2 (head_dim <= 256) is disabled model-wide and the
+sliding layers fall back to full O(S^2) SDPA. Routing the sliding layers to
+FA2 with window_size=(w-1, 0) reproduces the causal sliding band exactly. This
+checks forward + backward parity against SDPA with the explicit band mask, and
+that the mask probe accepts a genuine band / rejects a padded one.
+"""
+import pytest
+import torch
+import torch.nn.functional as F
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+
+flash_attn_func = pytest.importorskip("flash_attn").flash_attn_func
+
+
+def _full_sdpa_band(q, k, v, w, scaling, ng):
+    B, H, S, d = q.shape
+    Hkv = k.shape[1]
+    if ng > 1:
+        k = k[:, :, None].expand(B, Hkv, ng, S, d).reshape(B, H, S, d)
+        v = v[:, :, None].expand(B, Hkv, ng, S, d).reshape(B, H, S, d)
+    qi = torch.arange(S, device=q.device)[:, None]
+    ki = torch.arange(S, device=q.device)[None, :]
+    allowed = (ki <= qi) & (ki > qi - w)
+    mask = torch.zeros(S, S, device=q.device, dtype=q.dtype).masked_fill(~allowed, float("-inf"))
+    out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask[None, None], scale=scaling)
+    return out.transpose(1, 2).contiguous()
+
+
+@pytest.mark.parametrize("S,w", [(4096, 1024), (8192, 1024)])
+@pytest.mark.parametrize("H,Hkv", [(16, 8), (8, 8)])
+def test_fa2_sliding_matches_sdpa_band(S, w, H, Hkv):
+    torch.manual_seed(0)
+    d = 256
+    q = torch.randn(1, H, S, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    k = torch.randn(1, Hkv, S, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    v = torch.randn(1, Hkv, S, d, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    scaling = d ** -0.5
+    ng = H // Hkv
+
+    ref = _full_sdpa_band(q, k, v, w, scaling, ng)
+    fa = flash_attn_func(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+                         softmax_scale=scaling, causal=True, window_size=(w - 1, 0))
+    fwd_rel = (fa.float() - ref.float()).norm() / ref.float().norm().clamp_min(1e-9)
+    assert fwd_rel < 3e-2, f"forward rel {fwd_rel:.2e}"
+
+    g = torch.randn_like(ref)
+    (ref * g).sum().backward()
+    dq_ref = q.grad.clone(); q.grad = None
+    (fa * g).sum().backward()
+    dq_rel = (q.grad.float() - dq_ref.float()).norm() / dq_ref.float().norm().clamp_min(1e-9)
+    assert dq_rel < 3e-2, f"dq rel {dq_rel:.2e}"
+
+
+def test_mask_probe_accepts_band_rejects_padding():
+    from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
+    S, w = 512, 128
+    qi = torch.arange(S, device="cuda")[:, None]
+    ki = torch.arange(S, device="cuda")[None, :]
+    band = (ki <= qi) & (ki > qi - w)
+    mask = torch.where(band, 0.0, float("-inf")).to(torch.float32)[None, None]
+    assert gf._mask_is_plain_band(mask, S, w) is True
+    padded = mask.clone()
+    padded[..., :, S // 2] = float("-inf")
+    assert gf._mask_is_plain_band(padded, S, w) is False
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_gemma4_flash_sliding.py
+++ b/tests/test_gemma4_flash_sliding.py
@@ -130,6 +130,7 @@ def test_router_routes_to_fa2_and_matches_band(monkeypatch):
     from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
 
     monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
+    gf._enabled.cache_clear()  # _enabled is lru_cache(1); re-read the toggled env
     monkeypatch.delenv("UNSLOTH_BANDED_SDPA", raising=False)
     assert gf._HAS_FA2, "flash_attn imported by the test but not by the router"
 

--- a/tests/test_gemma4_flash_sliding.py
+++ b/tests/test_gemma4_flash_sliding.py
@@ -112,6 +112,56 @@ def test_chunked_verification_matches_dense():
         assert full == chunked, name
 
 
+class Gemma4SlidingFake:
+    """Minimal stand-in for a Gemma-4 sliding-window attention module: just the
+    attributes the router gates on (is_sliding, class name, head_dim <= 256)."""
+    is_sliding = True
+    is_causal = True
+    training = False
+
+    def __init__(self, w, ng):
+        self.sliding_window = w
+        self.num_key_value_groups = ng
+
+
+def test_router_routes_to_fa2_and_matches_band(monkeypatch):
+    # With flash-attn present the unified wrapper must take the FA2 window branch
+    # (never the wrapped SDPA) and match full SDPA + band mask.
+    from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
+
+    monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
+    monkeypatch.delenv("UNSLOTH_BANDED_SDPA", raising=False)
+    assert gf._HAS_FA2, "flash_attn imported by the test but not by the router"
+
+    S, w, H, Hkv, d = 4096, 1024, 16, 8, 256
+    torch.manual_seed(0)
+    q = torch.randn(1, H, S, d, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(1, Hkv, S, d, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(1, Hkv, S, d, device="cuda", dtype=torch.bfloat16)
+    scaling = d ** -0.5
+    ng = H // Hkv
+    module = Gemma4SlidingFake(w, ng)
+
+    def _boom(*a, **kw):
+        raise AssertionError("router did not take the FA2 path")
+
+    orig = gf._ORIG_SDPA[0]
+    gf._ORIG_SDPA[0] = _boom
+    before = gf._ENGAGED[0]
+    try:
+        out, weights = gf._sdpa_maybe_flash_sliding(
+            module, q, k, v, None, dropout=0.0, scaling=scaling, is_causal=None,
+        )
+    finally:
+        gf._ORIG_SDPA[0] = orig
+
+    assert weights is None
+    assert gf._ENGAGED[0] == before + 1, "FA2 path was not engaged"
+    ref = _full_sdpa_band(q, k, v, w, scaling, ng)
+    rel = (out.float() - ref.float()).norm() / ref.float().norm().clamp_min(1e-9)
+    assert rel < 3e-2, f"router FA2 rel {rel:.2e}"
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_gemma4_flash_sliding.py
+++ b/tests/test_gemma4_flash_sliding.py
@@ -68,6 +68,50 @@ def test_mask_probe_accepts_band_rejects_padding():
     assert gf._mask_is_plain_band(padded, S, w) is False
 
 
+def _band(S, w, device="cuda"):
+    idx = torch.arange(S, device=device)
+    return (idx[None, :] <= idx[:, None]) & (idx[None, :] > idx[:, None] - w)
+
+
+def test_mask_probe_rejects_packed_boundary():
+    # An interior band break (a packed-sequence boundary) must be rejected; the
+    # whole-mask verification does not sample rows.
+    from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
+    S, w = 512, 128
+    band = _band(S, w)
+    packed = torch.where(band, 0.0, float("-inf")).to(torch.float32)[None, None]
+    packed[..., 300, 200] = float("-inf")     # drop an in-band key at an interior row
+    assert gf._mask_is_plain_band(packed, S, w) is False
+
+
+def test_float_mask_inband_bias_rejected():
+    # A finite in-band bias would be silently dropped when routing to FA2, so a
+    # float mask is only accepted when in-band entries are exactly 0.
+    from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
+    S, w = 256, 64
+    band = _band(S, w)
+    biased = torch.where(band, -5.0, float("-inf")).to(torch.float32)[None, None]
+    assert gf._mask_is_plain_band(biased, S, w) is False
+    clean = torch.where(band, 0.0, float("-inf")).to(torch.float32)[None, None]
+    assert gf._mask_is_plain_band(clean, S, w) is True
+
+
+def test_chunked_verification_matches_dense():
+    # Row-chunked verification must agree with a single-block scan on band,
+    # padded, and packed masks (the memory win needs no test).
+    from unsloth_zoo.temporary_patches import gemma4_flash_sliding as gf
+    S, w = 96, 16
+    band = _band(S, w)
+    band_f = torch.where(band, 0.0, float("-inf")).to(torch.float32)[None, None]
+    padded = band_f.clone(); padded[..., :, S // 2] = float("-inf")
+    packed = band_f.clone(); packed[..., 50, 40] = float("-inf")
+    for name, m in {"band_bool": band[None, None], "band_float": band_f,
+                    "padded": padded, "packed": packed}.items():
+        full = gf._mask_is_plain_band(m.clone(), S, w, _block=S)
+        chunked = gf._mask_is_plain_band(m.clone(), S, w, _block=7)  # crosses block edges
+        assert full == chunked, name
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_gemma4_flash_sliding.py
+++ b/tests/test_gemma4_flash_sliding.py
@@ -132,6 +132,7 @@ def test_router_routes_to_fa2_and_matches_band(monkeypatch):
     monkeypatch.setenv("UNSLOTH_GEMMA4_FLASH_SLIDING", "1")
     gf._enabled.cache_clear()  # _enabled is lru_cache(1); re-read the toggled env
     monkeypatch.delenv("UNSLOTH_BANDED_SDPA", raising=False)
+    gf._force_banded.cache_clear()  # _force_banded is lru_cache(1); re-read the toggled env
     assert gf._HAS_FA2, "flash_attn imported by the test but not by the router"
 
     S, w, H, Hkv, d = 4096, 1024, 16, 8, 256

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -43,6 +43,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.gemma3n",
     "unsloth_zoo.temporary_patches.gemma4",
     "unsloth_zoo.temporary_patches.gemma4_float32",
+    "unsloth_zoo.temporary_patches.gemma4_flash_sliding",
     "unsloth_zoo.temporary_patches.gemma4_moe",
     "unsloth_zoo.temporary_patches.glm4_moe",
     "unsloth_zoo.temporary_patches.gpt_oss",

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -42,6 +42,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.gemma",
     "unsloth_zoo.temporary_patches.gemma3n",
     "unsloth_zoo.temporary_patches.gemma4",
+    "unsloth_zoo.temporary_patches.gemma4_banded_attention",
     "unsloth_zoo.temporary_patches.gemma4_float32",
     "unsloth_zoo.temporary_patches.gemma4_flash_sliding",
     "unsloth_zoo.temporary_patches.gemma4_moe",

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -22,6 +22,7 @@ from .misc import *
 from .gemma3n import *
 from .gemma4 import *
 from .gemma4_float32 import *
+from .gemma4_banded_attention import *
 from .gemma4_flash_sliding import *
 from .gpt_oss import *
 from .qwen3_moe import *

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -22,6 +22,7 @@ from .misc import *
 from .gemma3n import *
 from .gemma4 import *
 from .gemma4_float32 import *
+from .gemma4_flash_sliding import *
 from .gpt_oss import *
 from .qwen3_moe import *
 from .qwen3_moe_float32 import *

--- a/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
+++ b/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
@@ -51,6 +51,11 @@ def _block_mask(w, nb, device):
     m = base[None].expand(nb, w, 2 * w).clone()           # (nb, w, 2w)
     m[0] &= (torch.arange(2 * w, device=device)[None, :] >= w)  # block 0: drop phantom prev-block
     m = m[:, None]                                         # (nb, 1, w, 2w)
+    # FIFO bound: varying seq lengths yield many (w, nb) keys, so evict the oldest
+    # entry once the cache hits the cap (dict is insertion-ordered) to keep this a
+    # pure recompute-on-miss optimization rather than an unbounded leak.
+    if len(_MASK_CACHE) >= 8:
+        _MASK_CACHE.pop(next(iter(_MASK_CACHE)))
     _MASK_CACHE[key] = m
     return m
 
@@ -69,6 +74,12 @@ def _mask_is_plain_band(mask, S, w, _block=1024):
     if mask is None:
         return True
     if not torch.is_tensor(mask) or mask.dim() != 4:
+        return False
+    # Under torch.compile the band verdict drives Python control flow via .item()
+    # (a data-dependent graph break -> hard error under fullgraph) and mutates a
+    # tensor attribute, neither of which is traceable. Defer to the original SDPA
+    # while compiling so the graph stays intact; correctness is unchanged.
+    if torch.compiler.is_compiling():
         return False
     cached = getattr(mask, "_unsloth_plain_band", None)
     if cached is not None:

--- a/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
+++ b/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
@@ -1,0 +1,133 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/
+#
+# ============================================================================
+# Banded (block-local) SDPA for sliding-window attention layers.
+#
+# A sliding window only needs keys in (i-w, i] for query i, but SDPA with a band
+# mask still materialises the full O(S^2) score matrix. Compute it in O(S*w):
+# cut the sequence into w-sized blocks, let query block b attend key blocks b-1
+# and b (length 2w) under one static (w, 2w) mask (block 0 masks its phantom
+# previous block), and fold blocks into the batch dim for a single SDPA call.
+# Backward is exact through SDPA; fp32 rel ~1e-8 vs full SDPA + band mask.
+# Engaged only when the mask is exactly the causal+sliding band with no token
+# padding (fully verified, so packed masks defer), else defers to SDPA.
+#
+# This is the pure-SDPA fallback kernel for the gemma-4 sliding-window router
+# in gemma4_flash_sliding.py: it delivers the same O(S*w) speedup when
+# FlashAttention-2 is not importable. The router owns all routing decisions;
+# this module only exports the block-local kernel and the shared band probe.
+# ============================================================================
+
+import torch
+import torch.nn.functional as F
+
+__all__ = []
+
+_MASK_CACHE = {}    # (w, nb, device) -> (nb,1,w,2w) bool block mask
+
+
+def _block_mask(w, nb, device):
+    key = (w, nb, str(device))
+    m = _MASK_CACHE.get(key)
+    if m is not None:
+        return m
+    qi = torch.arange(w, device=device)[:, None]
+    ki = torch.arange(2 * w, device=device)[None, :]
+    base = (ki > qi) & (ki <= qi + w)                     # (w, 2w) local band
+    m = base[None].expand(nb, w, 2 * w).clone()           # (nb, w, 2w)
+    m[0] &= (torch.arange(2 * w, device=device)[None, :] >= w)  # block 0: drop phantom prev-block
+    m = m[:, None]                                         # (nb, 1, w, 2w)
+    _MASK_CACHE[key] = m
+    return m
+
+
+def _mask_is_plain_band(mask, S, w, _block=1024):
+    """True only if `mask` is exactly the causal+sliding band with no token padding.
+
+    Shared by both the FlashAttention-2 window path and the banded SDPA fallback,
+    so both engage/defer on provably identical decisions. Every row of every batch
+    element is verified (not a sampled subset), so packed or padded masks, whose
+    extra segment boundaries neither path can honour, are always rejected. Per-head
+    (shape[1] > 1) masks are rejected as well: the banded kernel applies one block
+    mask to every head, so it cannot honour them. The verdict is stashed on the
+    tensor itself, so it can never collide with a recycled object id.
+    """
+    if mask is None:
+        return True
+    if not torch.is_tensor(mask) or mask.dim() != 4:
+        return False
+    cached = getattr(mask, "_unsloth_plain_band", None)
+    if cached is not None:
+        return cached
+    # Reject per-head masks (shape[1] > 1): a single block mask / window is
+    # applied to every head, so a distinct per-head mask cannot be honoured.
+    if mask.shape[1] != 1 or mask.shape[-2] != S or mask.shape[-1] != S:
+        ok = False
+    else:
+        # Validate EVERY batch element, not just batch 0: a padded batch can carry
+        # per-sample padding (for example left padding during batched generation)
+        # that neither the window nor the block kernel honours, and checking only
+        # batch 0 would route a padded batch to the fast path and drop the padding.
+        m = mask[:, 0]                                    # (B, S, S)
+        # Scan in row blocks so we never materialise a second dense S x S band
+        # plus its comparison: at 16k/32k that is gigabytes of transient GPU
+        # memory. Each block only builds a (block, S) band. A float mask must
+        # additionally carry no in-band bias (exactly 0), else the banded path
+        # would replace it with a boolean mask and silently drop the bias.
+        is_bool = m.dtype == torch.bool
+        idx = torch.arange(S, device=m.device)
+        ok = True
+        for start in range(0, S, _block):
+            rows = idx[start : start + _block]                                       # (br,)
+            band = (idx[None, :] <= rows[:, None]) & (idx[None, :] > rows[:, None] - w)  # (br, S)
+            msl = m[:, start : start + _block, :]                                     # (B, br, S)
+            match = (msl == band) if is_bool else torch.where(band, msl == 0, msl <= -1e4)
+            if not bool(match.all().item()):
+                ok = False
+                break
+    try:
+        mask._unsloth_plain_band = ok
+    except Exception:
+        pass
+    return ok
+
+
+def _banded_sdpa_core(query, key, value, w, scaling, dropout, num_key_value_groups):
+    # query: (B,H,S,d)   key/value: (B,Hkv,S,d)
+    B, H, S, d = query.shape
+    Hkv = key.shape[1]
+    if num_key_value_groups > 1:
+        key = key[:, :, None].expand(B, Hkv, num_key_value_groups, S, d).reshape(B, H, S, d)
+        value = value[:, :, None].expand(B, Hkv, num_key_value_groups, S, d).reshape(B, H, S, d)
+    Sp = ((S + w - 1) // w) * w
+    if Sp != S:
+        query = F.pad(query, (0, 0, 0, Sp - S))
+        key = F.pad(key, (0, 0, 0, Sp - S))
+        value = F.pad(value, (0, 0, 0, Sp - S))
+    nb = Sp // w
+    qb = query.reshape(B, H, nb, w, d).permute(0, 2, 1, 3, 4).reshape(B * nb, H, w, d)
+    kpad = F.pad(key, (0, 0, w, 0))                       # (B,H, w+Sp, d)
+    vpad = F.pad(value, (0, 0, w, 0))
+    kw = kpad.unfold(2, 2 * w, w).permute(0, 1, 2, 4, 3)  # (B,H,nb,2w,d)
+    vw = vpad.unfold(2, 2 * w, w).permute(0, 1, 2, 4, 3)
+    kw = kw.permute(0, 2, 1, 3, 4).reshape(B * nb, H, 2 * w, d)
+    vw = vw.permute(0, 2, 1, 3, 4).reshape(B * nb, H, 2 * w, d)
+    mask = _block_mask(w, nb, query.device)
+    mask = mask.expand(B, nb, 1, w, 2 * w).reshape(B * nb, 1, w, 2 * w)
+    out = F.scaled_dot_product_attention(qb, kw, vw, attn_mask=mask, dropout_p=dropout, scale=scaling)
+    out = out.reshape(B, nb, H, w, d).permute(0, 2, 1, 3, 4).reshape(B, H, Sp, d)[:, :, :S]
+    return out.transpose(1, 2).contiguous()               # (B,S,H,d) to match sdpa_attention_forward

--- a/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
+++ b/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
@@ -17,15 +17,12 @@
 # ============================================================================
 # FlashAttention-2 for Gemma-4 sliding-window layers.
 #
-# Gemma-4's head_dim 512 global layers force FA2 off model-wide, so all 30
-# layers fall back to O(S^2) SDPA. But a causal sliding window is exactly
-# FA2's window_size=(w-1, 0), so route just the sliding layers (head_dim <=
-# 256, plain causal band mask, no padding) through FA2; global layers and
-# padded / non-band masks defer unchanged to the original SDPA. Backward is
-# exact through FA2; numerics match SDPA to bf16 rounding.
-#
-# On by default when flash-attn is importable; UNSLOTH_GEMMA4_FLASH_SLIDING=0
-# reverts to SDPA.
+# Gemma-4's head_dim 512 global layers force FA2 off model-wide, so every layer
+# falls back to O(S^2) SDPA. A causal sliding window is exactly FA2's
+# window_size=(w-1, 0), so route only the sliding layers (head_dim <= 256, plain
+# causal band mask, no padding) through FA2; global and padded / non-band masks
+# defer to the original SDPA. Backward is exact; numerics match SDPA to bf16.
+# On by default with flash-attn; UNSLOTH_GEMMA4_FLASH_SLIDING=0 reverts to SDPA.
 # ============================================================================
 
 import os
@@ -134,7 +131,7 @@ def patch_gemma4_flash_sliding():
     except Exception as e:
         return raise_error("ALL_ATTENTION_FUNCTIONS['sdpa']", e)
     if getattr(current, "_unsloth_gemma4_flash", False):
-        return  # already wrapped
+        return
     _ORIG_SDPA[0] = current
     _sdpa_maybe_flash_sliding._unsloth_gemma4_flash = True
     # Direct assignment: AttentionInterface.register() does not update the

--- a/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
+++ b/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
@@ -47,7 +47,7 @@ def _enabled():
     return os.environ.get("UNSLOTH_GEMMA4_FLASH_SLIDING", "1") != "0"
 
 
-def _mask_is_plain_band(mask, S, w):
+def _mask_is_plain_band(mask, S, w, _block=1024):
     """True if `mask` is exactly the causal + sliding band with no token padding."""
     if mask is None:
         return True
@@ -67,10 +67,22 @@ def _mask_is_plain_band(mask, S, w):
     # probe would miss a packed-sequence boundary that falls between the sampled
     # rows and let FA2 attend across samples. A plain band allows key j for
     # query i iff i - w < j <= i; anything else (padding, packing) must reject.
-    allowed = mask if mask.dtype == torch.bool else (mask > -1e4)
+    # Scan in row blocks so we never materialise a second S x S tensor: at
+    # 16k/32k contexts a full S x S band plus its comparison would add multiple
+    # GB of transient memory and can OOM before the FA2 path even runs. Each
+    # block only builds a (block, S) band. A float mask must additionally carry
+    # no in-band bias (exactly 0) so routing to FA2 cannot silently drop it.
+    is_bool = mask.dtype == torch.bool
     idx = torch.arange(S, device=mask.device)
-    band = (idx[None, :] <= idx[:, None]) & (idx[None, :] > idx[:, None] - w)
-    ok = bool((allowed == band).all().item())
+    ok = True
+    for start in range(0, S, _block):
+        rows = idx[start : start + _block]                                       # (br,)
+        band = (idx[None, :] <= rows[:, None]) & (idx[None, :] > rows[:, None] - w)  # (br, S)
+        msl = mask[..., start : start + _block, :]                               # (..., br, S)
+        match = (msl == band) if is_bool else torch.where(band, msl == 0, msl <= -1e4)
+        if not bool(match.all().item()):
+            ok = False
+            break
     try: mask._unsloth_plain_band = ok
     except (AttributeError, RuntimeError): pass
     return ok

--- a/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
+++ b/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
@@ -34,6 +34,7 @@
 # ============================================================================
 
 import os
+import functools
 import torch
 from .common import TEMPORARY_PATCHES, logger
 from .utils import raise_error
@@ -53,7 +54,22 @@ _ENGAGED = [0]           # count of FA2-path invocations (debug)
 _BANDED_ENGAGED = [0]    # count of banded-path invocations (debug)
 
 
+@functools.lru_cache(maxsize=1)
 def _enabled():
+    """Whether the gemma-4 sliding-window fast router is active.
+
+    On by default and effectively always on: the router auto-prefers
+    FlashAttention-2's window kernel when flash-attn is importable, and the
+    pure-SDPA banded fallback works on every setup and dtype. So "always on if
+    Flash Attention exists and/or if it works" holds without gating on _HAS_FA2:
+    the "or if it works" case is covered by the universal banded path, which is
+    why this must NOT be gated on _HAS_FA2 (that would wrongly disable the
+    banded fallback). Set UNSLOTH_GEMMA4_FLASH_SLIDING=0 to revert to plain SDPA.
+
+    Cached with maxsize=1 since the env var is read once per process. Any code or
+    test that toggles UNSLOTH_GEMMA4_FLASH_SLIDING at runtime must call
+    _enabled.cache_clear() afterwards for the change to take effect.
+    """
     return os.environ.get("UNSLOTH_GEMMA4_FLASH_SLIDING", "1") != "0"
 
 

--- a/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
+++ b/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
@@ -1,0 +1,145 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ============================================================================
+# FlashAttention-2 for Gemma-4 sliding-window layers.
+#
+# Gemma-4's head_dim 512 global layers force FA2 off model-wide, so all 30
+# layers fall back to O(S^2) SDPA. But a causal sliding window is exactly
+# FA2's window_size=(w-1, 0), so route just the sliding layers (head_dim <=
+# 256, plain causal band mask, no padding) through FA2; global layers and
+# padded / non-band masks defer unchanged to the original SDPA. Backward is
+# exact through FA2; numerics match SDPA to bf16 rounding.
+#
+# On by default when flash-attn is importable; UNSLOTH_GEMMA4_FLASH_SLIDING=0
+# reverts to SDPA.
+# ============================================================================
+
+import os
+import torch
+from .common import TEMPORARY_PATCHES, logger
+from .utils import raise_error
+
+__all__ = ["patch_gemma4_flash_sliding"]
+
+try:
+    from flash_attn import flash_attn_func as _flash_attn_func
+    _HAS_FA2 = True
+except Exception:
+    _flash_attn_func = None
+    _HAS_FA2 = False
+
+_BAND_OK = {}        # id(attention_mask) -> bool (plain causal band, no padding)
+_ORIG_SDPA = [None]  # boxed reference to the wrapped sdpa function
+_ENGAGED = [0]       # count of FA2-path invocations (debug)
+
+
+def _enabled():
+    return os.environ.get("UNSLOTH_GEMMA4_FLASH_SLIDING", "1") != "0"
+
+
+def _mask_is_plain_band(mask, S, w):
+    """True if `mask` is exactly the causal + sliding band with no token padding."""
+    if mask is None:
+        return True
+    if not torch.is_tensor(mask) or mask.dim() != 4:
+        return False
+    key = id(mask)
+    cached = _BAND_OK.get(key)
+    if cached is not None:
+        return cached
+    if len(_BAND_OK) > 64:
+        _BAND_OK.clear()
+    m = mask[:, 0]
+    if m.shape[-2] != S or m.shape[-1] != S:
+        _BAND_OK[key] = False
+        return False
+    allowed = m if m.dtype == torch.bool else (m > -1e4)
+    dev = m.device
+    cand = sorted({x for x in (0, 1, w - 1, w, w + 1, 2 * w, S // 2, S - 1, S - w, S - w - 1) if 0 <= x < S})
+    probes = torch.tensor(cand, device=dev)
+    # Probe EVERY batch element: with right padding only the longest sample
+    # keeps a clean band, and FA2's window_size cannot express per-sample
+    # padding, so any deviating element must reject the whole batch.
+    rows = allowed[:, probes]                             # (B, P, S)
+    idx = torch.arange(S, device=dev)[None, None, :]
+    cnt = rows.sum(-1)
+    minidx = torch.where(rows, idx, torch.full_like(idx, S)).amin(-1)
+    maxidx = torch.where(rows, idx, torch.full_like(idx, -1)).amax(-1)
+    lo = torch.clamp(probes - w + 1, min=0)[None, :]
+    hi = probes[None, :]
+    ok = bool(((cnt == (hi - lo + 1)) & (minidx == lo) & (maxidx == hi)).all().item())
+    _BAND_OK[key] = ok
+    return ok
+
+
+def _sdpa_maybe_flash_sliding(module, query, key, value, attention_mask,
+                              dropout=0.0, scaling=None, is_causal=None, **kwargs):
+    if (_enabled() and _HAS_FA2
+            and getattr(module, "is_sliding", False)
+            and type(module).__name__.startswith("Gemma4")
+            and query.dim() == 4 and query.shape[-1] <= 256
+            and query.dtype in (torch.float16, torch.bfloat16)):
+        w = kwargs.get("sliding_window", None) or getattr(module, "sliding_window", None)
+        Sq = query.shape[2]
+        Sk = key.shape[2]
+        if (w and Sq == Sk and Sq > w and _mask_is_plain_band(attention_mask, Sq, w)):
+            try:
+                # flash_attn_func wants (B, S, H, D); a causal window of w keys is
+                # window_size=(w-1, 0). FA2 handles GQA (H q heads, Hkv kv heads).
+                out = _flash_attn_func(
+                    query.transpose(1, 2),
+                    key.transpose(1, 2),
+                    value.transpose(1, 2),
+                    dropout_p=dropout if module.training else 0.0,
+                    softmax_scale=scaling,
+                    causal=True,
+                    window_size=(w - 1, 0),
+                )
+                _ENGAGED[0] += 1
+                if _ENGAGED[0] == 1:
+                    logger.info_once(
+                        f"Unsloth: FlashAttention-2 sliding window engaged for gemma-4 "
+                        f"(window={w})."
+                    )
+                return out, None                          # (B, S, H, D), no weights
+            except Exception as e:
+                logger.warning_once(f"Unsloth: gemma-4 FA2 sliding fell back to SDPA ({e})")
+    return _ORIG_SDPA[0](module, query, key, value, attention_mask,
+                         dropout=dropout, scaling=scaling, is_causal=is_causal, **kwargs)
+
+
+def patch_gemma4_flash_sliding():
+    if not _HAS_FA2:
+        return
+    try:
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    except Exception as e:
+        return raise_error("transformers.modeling_utils.ALL_ATTENTION_FUNCTIONS", e)
+    try:
+        current = ALL_ATTENTION_FUNCTIONS["sdpa"]
+    except Exception as e:
+        return raise_error("ALL_ATTENTION_FUNCTIONS['sdpa']", e)
+    if getattr(current, "_unsloth_gemma4_flash", False):
+        return  # already wrapped
+    _ORIG_SDPA[0] = current
+    _sdpa_maybe_flash_sliding._unsloth_gemma4_flash = True
+    # Direct assignment: AttentionInterface.register() does not update the
+    # global mapping that layers read via ALL_ATTENTION_FUNCTIONS["sdpa"].
+    ALL_ATTENTION_FUNCTIONS["sdpa"] = _sdpa_maybe_flash_sliding
+
+
+TEMPORARY_PATCHES.append(patch_gemma4_flash_sliding)

--- a/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
+++ b/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
@@ -73,10 +73,16 @@ def _enabled():
     return os.environ.get("UNSLOTH_GEMMA4_FLASH_SLIDING", "1") != "0"
 
 
+@functools.lru_cache(maxsize=1)
 def _force_banded():
-    # Optional override: force the pure-SDPA banded kernel even when flash-attn is
-    # importable. The router already prefers FA2 automatically, so this is only for
-    # benchmarking or working around a flash-attn issue; off by default.
+    """Optional override: force the pure-SDPA banded kernel even when flash-attn is
+    importable. The router already prefers FA2 automatically, so this is only for
+    benchmarking or working around a flash-attn issue; off by default.
+
+    Cached with maxsize=1 since the env var is read once per process. Any code or
+    test that toggles UNSLOTH_BANDED_SDPA at runtime must call
+    _force_banded.cache_clear() afterwards for the change to take effect.
+    """
     return os.environ.get("UNSLOTH_BANDED_SDPA", "0") == "1"
 
 

--- a/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
+++ b/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
@@ -39,7 +39,6 @@ except Exception:
     _flash_attn_func = None
     _HAS_FA2 = False
 
-_BAND_OK = {}        # id(attention_mask) -> bool (plain causal band, no padding)
 _ORIG_SDPA = [None]  # boxed reference to the wrapped sdpa function
 _ENGAGED = [0]       # count of FA2-path invocations (debug)
 
@@ -54,32 +53,26 @@ def _mask_is_plain_band(mask, S, w):
         return True
     if not torch.is_tensor(mask) or mask.dim() != 4:
         return False
-    key = id(mask)
-    cached = _BAND_OK.get(key)
+    # Cache the verdict on the tensor itself. An id()-keyed dict can alias a
+    # freed mask to a newly allocated one and return a stale result; binding to
+    # the tensor lifetime avoids that. `is not None` preserves a cached False.
+    cached = getattr(mask, "_unsloth_plain_band", None)
     if cached is not None:
         return cached
-    if len(_BAND_OK) > 64:
-        _BAND_OK.clear()
-    m = mask[:, 0]
-    if m.shape[-2] != S or m.shape[-1] != S:
-        _BAND_OK[key] = False
+    if mask.shape[-2] != S or mask.shape[-1] != S:
+        try: mask._unsloth_plain_band = False
+        except (AttributeError, RuntimeError): pass
         return False
-    allowed = m if m.dtype == torch.bool else (m > -1e4)
-    dev = m.device
-    cand = sorted({x for x in (0, 1, w - 1, w, w + 1, 2 * w, S // 2, S - 1, S - w, S - w - 1) if 0 <= x < S})
-    probes = torch.tensor(cand, device=dev)
-    # Probe EVERY batch element: with right padding only the longest sample
-    # keeps a clean band, and FA2's window_size cannot express per-sample
-    # padding, so any deviating element must reject the whole batch.
-    rows = allowed[:, probes]                             # (B, P, S)
-    idx = torch.arange(S, device=dev)[None, None, :]
-    cnt = rows.sum(-1)
-    minidx = torch.where(rows, idx, torch.full_like(idx, S)).amin(-1)
-    maxidx = torch.where(rows, idx, torch.full_like(idx, -1)).amax(-1)
-    lo = torch.clamp(probes - w + 1, min=0)[None, :]
-    hi = probes[None, :]
-    ok = bool(((cnt == (hi - lo + 1)) & (minidx == lo) & (maxidx == hi)).all().item())
-    _BAND_OK[key] = ok
+    # Verify the WHOLE mask over every batch element and head. A sampled-row
+    # probe would miss a packed-sequence boundary that falls between the sampled
+    # rows and let FA2 attend across samples. A plain band allows key j for
+    # query i iff i - w < j <= i; anything else (padding, packing) must reject.
+    allowed = mask if mask.dtype == torch.bool else (mask > -1e4)
+    idx = torch.arange(S, device=mask.device)
+    band = (idx[None, :] <= idx[:, None]) & (idx[None, :] > idx[:, None] - w)
+    ok = bool((allowed == band).all().item())
+    try: mask._unsloth_plain_band = ok
+    except (AttributeError, RuntimeError): pass
     return ok
 
 
@@ -93,7 +86,13 @@ def _sdpa_maybe_flash_sliding(module, query, key, value, attention_mask,
         w = kwargs.get("sliding_window", None) or getattr(module, "sliding_window", None)
         Sq = query.shape[2]
         Sk = key.shape[2]
-        if (w and Sq == Sk and Sq > w and _mask_is_plain_band(attention_mask, Sq, w)):
+        # Mirror SDPA's derivation. With no explicit mask, only a causal module
+        # may take the causal FA2 window; a bidirectional call (is_causal False)
+        # must stay bidirectional instead of being forced causal.
+        causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
+        if (w and Sq == Sk and Sq > w
+                and (attention_mask is not None or causal)
+                and _mask_is_plain_band(attention_mask, Sq, w)):
             try:
                 # flash_attn_func wants (B, S, H, D); a causal window of w keys is
                 # window_size=(w-1, 0). FA2 handles GQA (H q heads, Hkv kv heads).
@@ -125,11 +124,13 @@ def patch_gemma4_flash_sliding():
     try:
         from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
     except Exception as e:
-        return raise_error("transformers.modeling_utils.ALL_ATTENTION_FUNCTIONS", e)
+        raise_error("transformers.modeling_utils.ALL_ATTENTION_FUNCTIONS", e)
+        return
     try:
         current = ALL_ATTENTION_FUNCTIONS["sdpa"]
     except Exception as e:
-        return raise_error("ALL_ATTENTION_FUNCTIONS['sdpa']", e)
+        raise_error("ALL_ATTENTION_FUNCTIONS['sdpa']", e)
+        return
     if getattr(current, "_unsloth_gemma4_flash", False):
         return
     _ORIG_SDPA[0] = current

--- a/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
+++ b/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
@@ -106,8 +106,12 @@ def _sdpa_maybe_flash_sliding(module, query, key, value, attention_mask,
                 and _mask_is_plain_band(attention_mask, Sq, w)):
             # Prefer FlashAttention-2's window kernel when importable and the dtype
             # is supported; otherwise fall to the pure-SDPA banded kernel so the
-            # O(S*w) speedup is automatic with or without flash-attn.
-            if _HAS_FA2 and not _force_banded() and query.dtype in (torch.float16, torch.bfloat16):
+            # O(S*w) speedup is automatic with or without flash-attn. A runtime FA2
+            # failure (unsupported GPU/build, CPU tensors) falls to the banded
+            # kernel too, so it is not skipped, and only then to the original SDPA.
+            use_fa2 = (_HAS_FA2 and not _force_banded()
+                       and query.dtype in (torch.float16, torch.bfloat16))
+            if use_fa2:
                 try:
                     # flash_attn_func wants (B, S, H, D); a causal window of w keys
                     # is window_size=(w-1, 0). FA2 handles GQA (H q, Hkv kv heads).
@@ -128,25 +132,26 @@ def _sdpa_maybe_flash_sliding(module, query, key, value, attention_mask,
                         )
                     return out, None                      # (B, S, H, D), no weights
                 except Exception as e:
-                    logger.warning_once(f"Unsloth: gemma-4 FA2 sliding fell back to SDPA ({e})")
-            else:
-                try:
-                    # Pure-SDPA block-local kernel; batch-general. ng folds the kv
-                    # heads up to the q heads exactly as SDPA's GQA expansion does.
-                    ng = getattr(module, "num_key_value_groups", query.shape[1] // key.shape[1])
-                    out = _banded_sdpa_core(
-                        query, key, value, w, scaling,
-                        dropout if module.training else 0.0, ng,
+                    logger.warning_once(f"Unsloth: gemma-4 FA2 sliding fell back to banded SDPA ({e})")
+            # Reached when FA2 is not used or its attempt failed: try the pure-SDPA
+            # block-local kernel before deferring to the original SDPA.
+            try:
+                # Pure-SDPA block-local kernel; batch-general. ng folds the kv
+                # heads up to the q heads exactly as SDPA's GQA expansion does.
+                ng = getattr(module, "num_key_value_groups", query.shape[1] // key.shape[1])
+                out = _banded_sdpa_core(
+                    query, key, value, w, scaling,
+                    dropout if module.training else 0.0, ng,
+                )
+                _BANDED_ENGAGED[0] += 1
+                if _BANDED_ENGAGED[0] == 1:
+                    logger.info_once(
+                        f"Unsloth: banded sliding SDPA engaged for gemma-4 "
+                        f"(window={w})."
                     )
-                    _BANDED_ENGAGED[0] += 1
-                    if _BANDED_ENGAGED[0] == 1:
-                        logger.info_once(
-                            f"Unsloth: banded sliding SDPA engaged for gemma-4 "
-                            f"(window={w})."
-                        )
-                    return out, None                      # (B, S, H, D), no weights
-                except Exception as e:
-                    logger.warning_once(f"Unsloth: gemma-4 banded sliding fell back to SDPA ({e})")
+                return out, None                      # (B, S, H, D), no weights
+            except Exception as e:
+                logger.warning_once(f"Unsloth: gemma-4 banded sliding fell back to SDPA ({e})")
     return _ORIG_SDPA[0](module, query, key, value, attention_mask,
                          dropout=dropout, scaling=scaling, is_causal=is_causal, **kwargs)
 

--- a/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
+++ b/unsloth_zoo/temporary_patches/gemma4_flash_sliding.py
@@ -15,20 +15,29 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 # ============================================================================
-# FlashAttention-2 for Gemma-4 sliding-window layers.
+# Fast sliding-window attention router for Gemma-4.
 #
-# Gemma-4's head_dim 512 global layers force FA2 off model-wide, so every layer
-# falls back to O(S^2) SDPA. A causal sliding window is exactly FA2's
-# window_size=(w-1, 0), so route only the sliding layers (head_dim <= 256, plain
-# causal band mask, no padding) through FA2; global and padded / non-band masks
-# defer to the original SDPA. Backward is exact; numerics match SDPA to bf16.
-# On by default with flash-attn; UNSLOTH_GEMMA4_FLASH_SLIDING=0 reverts to SDPA.
+# Gemma-4's head_dim 512 global layers force FlashAttention-2 off model-wide, so
+# every layer falls back to O(S^2) SDPA. A causal sliding window only needs keys
+# in (i-w, i] for query i, so route just the sliding layers (head_dim <= 256,
+# plain causal band mask, no padding) through a fast O(S*w) kernel; global and
+# padded / non-band masks defer to the original SDPA. One default-on wrapper
+# picks the kernel automatically:
+#   * FlashAttention-2 window_size=(w-1, 0) when flash-attn is importable and the
+#     dtype is fp16/bf16, or
+#   * a pure-SDPA banded (block-local) kernel otherwise,
+# so the sliding-window speedup is automatic with or without flash-attn. Both
+# use a byte-identical band probe, so they engage / defer identically; backward
+# is exact and numerics match full SDPA + band mask. On by default;
+# UNSLOTH_GEMMA4_FLASH_SLIDING=0 reverts to plain SDPA. UNSLOTH_BANDED_SDPA=1
+# forces the pure-SDPA banded kernel even when flash-attn is present.
 # ============================================================================
 
 import os
 import torch
 from .common import TEMPORARY_PATCHES, logger
 from .utils import raise_error
+from .gemma4_banded_attention import _banded_sdpa_core, _mask_is_plain_band
 
 __all__ = ["patch_gemma4_flash_sliding"]
 
@@ -39,100 +48,88 @@ except Exception:
     _flash_attn_func = None
     _HAS_FA2 = False
 
-_ORIG_SDPA = [None]  # boxed reference to the wrapped sdpa function
-_ENGAGED = [0]       # count of FA2-path invocations (debug)
+_ORIG_SDPA = [None]      # boxed reference to the wrapped sdpa function
+_ENGAGED = [0]           # count of FA2-path invocations (debug)
+_BANDED_ENGAGED = [0]    # count of banded-path invocations (debug)
 
 
 def _enabled():
     return os.environ.get("UNSLOTH_GEMMA4_FLASH_SLIDING", "1") != "0"
 
 
-def _mask_is_plain_band(mask, S, w, _block=1024):
-    """True if `mask` is exactly the causal + sliding band with no token padding."""
-    if mask is None:
-        return True
-    if not torch.is_tensor(mask) or mask.dim() != 4:
-        return False
-    # Cache the verdict on the tensor itself. An id()-keyed dict can alias a
-    # freed mask to a newly allocated one and return a stale result; binding to
-    # the tensor lifetime avoids that. `is not None` preserves a cached False.
-    cached = getattr(mask, "_unsloth_plain_band", None)
-    if cached is not None:
-        return cached
-    if mask.shape[-2] != S or mask.shape[-1] != S:
-        try: mask._unsloth_plain_band = False
-        except (AttributeError, RuntimeError): pass
-        return False
-    # Verify the WHOLE mask over every batch element and head. A sampled-row
-    # probe would miss a packed-sequence boundary that falls between the sampled
-    # rows and let FA2 attend across samples. A plain band allows key j for
-    # query i iff i - w < j <= i; anything else (padding, packing) must reject.
-    # Scan in row blocks so we never materialise a second S x S tensor: at
-    # 16k/32k contexts a full S x S band plus its comparison would add multiple
-    # GB of transient memory and can OOM before the FA2 path even runs. Each
-    # block only builds a (block, S) band. A float mask must additionally carry
-    # no in-band bias (exactly 0) so routing to FA2 cannot silently drop it.
-    is_bool = mask.dtype == torch.bool
-    idx = torch.arange(S, device=mask.device)
-    ok = True
-    for start in range(0, S, _block):
-        rows = idx[start : start + _block]                                       # (br,)
-        band = (idx[None, :] <= rows[:, None]) & (idx[None, :] > rows[:, None] - w)  # (br, S)
-        msl = mask[..., start : start + _block, :]                               # (..., br, S)
-        match = (msl == band) if is_bool else torch.where(band, msl == 0, msl <= -1e4)
-        if not bool(match.all().item()):
-            ok = False
-            break
-    try: mask._unsloth_plain_band = ok
-    except (AttributeError, RuntimeError): pass
-    return ok
+def _force_banded():
+    # Optional override: force the pure-SDPA banded kernel even when flash-attn is
+    # importable. The router already prefers FA2 automatically, so this is only for
+    # benchmarking or working around a flash-attn issue; off by default.
+    return os.environ.get("UNSLOTH_BANDED_SDPA", "0") == "1"
 
 
 def _sdpa_maybe_flash_sliding(module, query, key, value, attention_mask,
                               dropout=0.0, scaling=None, is_causal=None, **kwargs):
-    if (_enabled() and _HAS_FA2
+    # Shared layer + band gate for both fast kernels (no _HAS_FA2 / dtype clause
+    # here, so the banded fallback is reachable without flash-attn).
+    if (_enabled()
             and getattr(module, "is_sliding", False)
             and type(module).__name__.startswith("Gemma4")
-            and query.dim() == 4 and query.shape[-1] <= 256
-            and query.dtype in (torch.float16, torch.bfloat16)):
+            and query.dim() == 4 and query.shape[-1] <= 256):
         w = kwargs.get("sliding_window", None) or getattr(module, "sliding_window", None)
         Sq = query.shape[2]
         Sk = key.shape[2]
         # Mirror SDPA's derivation. With no explicit mask, only a causal module
-        # may take the causal FA2 window; a bidirectional call (is_causal False)
-        # must stay bidirectional instead of being forced causal.
+        # may take the causal window; a bidirectional call (is_causal False) must
+        # stay bidirectional instead of being forced causal.
         causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
         if (w and Sq == Sk and Sq > w
                 and (attention_mask is not None or causal)
                 and _mask_is_plain_band(attention_mask, Sq, w)):
-            try:
-                # flash_attn_func wants (B, S, H, D); a causal window of w keys is
-                # window_size=(w-1, 0). FA2 handles GQA (H q heads, Hkv kv heads).
-                out = _flash_attn_func(
-                    query.transpose(1, 2),
-                    key.transpose(1, 2),
-                    value.transpose(1, 2),
-                    dropout_p=dropout if module.training else 0.0,
-                    softmax_scale=scaling,
-                    causal=True,
-                    window_size=(w - 1, 0),
-                )
-                _ENGAGED[0] += 1
-                if _ENGAGED[0] == 1:
-                    logger.info_once(
-                        f"Unsloth: FlashAttention-2 sliding window engaged for gemma-4 "
-                        f"(window={w})."
+            # Prefer FlashAttention-2's window kernel when importable and the dtype
+            # is supported; otherwise fall to the pure-SDPA banded kernel so the
+            # O(S*w) speedup is automatic with or without flash-attn.
+            if _HAS_FA2 and not _force_banded() and query.dtype in (torch.float16, torch.bfloat16):
+                try:
+                    # flash_attn_func wants (B, S, H, D); a causal window of w keys
+                    # is window_size=(w-1, 0). FA2 handles GQA (H q, Hkv kv heads).
+                    out = _flash_attn_func(
+                        query.transpose(1, 2),
+                        key.transpose(1, 2),
+                        value.transpose(1, 2),
+                        dropout_p=dropout if module.training else 0.0,
+                        softmax_scale=scaling,
+                        causal=True,
+                        window_size=(w - 1, 0),
                     )
-                return out, None                          # (B, S, H, D), no weights
-            except Exception as e:
-                logger.warning_once(f"Unsloth: gemma-4 FA2 sliding fell back to SDPA ({e})")
+                    _ENGAGED[0] += 1
+                    if _ENGAGED[0] == 1:
+                        logger.info_once(
+                            f"Unsloth: FlashAttention-2 sliding window engaged for gemma-4 "
+                            f"(window={w})."
+                        )
+                    return out, None                      # (B, S, H, D), no weights
+                except Exception as e:
+                    logger.warning_once(f"Unsloth: gemma-4 FA2 sliding fell back to SDPA ({e})")
+            else:
+                try:
+                    # Pure-SDPA block-local kernel; batch-general. ng folds the kv
+                    # heads up to the q heads exactly as SDPA's GQA expansion does.
+                    ng = getattr(module, "num_key_value_groups", query.shape[1] // key.shape[1])
+                    out = _banded_sdpa_core(
+                        query, key, value, w, scaling,
+                        dropout if module.training else 0.0, ng,
+                    )
+                    _BANDED_ENGAGED[0] += 1
+                    if _BANDED_ENGAGED[0] == 1:
+                        logger.info_once(
+                            f"Unsloth: banded sliding SDPA engaged for gemma-4 "
+                            f"(window={w})."
+                        )
+                    return out, None                      # (B, S, H, D), no weights
+                except Exception as e:
+                    logger.warning_once(f"Unsloth: gemma-4 banded sliding fell back to SDPA ({e})")
     return _ORIG_SDPA[0](module, query, key, value, attention_mask,
                          dropout=dropout, scaling=scaling, is_causal=is_causal, **kwargs)
 
 
 def patch_gemma4_flash_sliding():
-    if not _HAS_FA2:
-        return
     try:
         from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
     except Exception as e:


### PR DESCRIPTION
## Summary

Gemma-4 mixes 25 sliding-window layers (head_dim 256, window 1024) with 5 global layers (head_dim 512). FlashAttention-2 caps head_dim at 256, so the global layers disable it for the whole model and every layer falls back to SDPA, which spends O(seq^2) compute per sliding layer and dominates the step at long context.

## What this does

A causal sliding window is exactly FA2's `window_size` argument, so intercept the registered sdpa attention function and, for a gemma-4 sliding layer whose head_dim is at most 256, whose dtype is bf16/fp16, and whose mask is the plain causal band (no token padding), call FA2 with `window_size=(w-1, 0)`. Global head_dim 512 layers and padded or non-band masks defer to the original SDPA unchanged. FA2 is an opaque op so the compiled graph is unaffected.

On by default when flash-attn is importable; `UNSLOTH_GEMMA4_FLASH_SLIDING=0` reverts to SDPA.

## Testing

- Result matches SDPA with the explicit band mask to bf16 rounding (forward rel 2.5e-3, backward 3.5e-3); unit test included.
- Measured on a 26B-A4B LoRA SFT (4-bit, gradient checkpointing): 1.66x at 4k, 2.21x at 8k, 2.65x at 16k, 3.11x at 32k, memory unchanged. The speedup grows with sequence length as attention becomes a larger share of the step.
