### PR TITLE
Add a banded sliding-window SDPA fast path for Gemma-4 style layers

### DIFF
--- a/tests/test_gemma4_banded_attention.py
+++ b/tests/test_gemma4_banded_attention.py
@@ -90,3 +90,26 @@ def test_mask_is_plain_band_detection():
     padded[..., S - 1, 0:1] = True
     assert not _mask_is_plain_band(padded, S, w)
     assert _mask_is_plain_band(None, S, w)
+
+
+def test_mask_is_plain_band_rejects_non_probe_violation():
+    # A band broken only at an interior row (a packed-sequence boundary) must be
+    # rejected: the verifier checks every row, not a sampled subset.
+    S, w = 128, 32
+    packed = _band_mask_full(S, w)[None, None].clone()
+    packed[..., 50, 40] = False    # drop an in-band key at a non-probe row
+    assert not _mask_is_plain_band(packed, S, w)
+
+
+def test_mask_is_plain_band_survives_id_reuse():
+    # A recycled object id must not produce a stale cached verdict for packed masks.
+    S, w = 128, 32
+    template = _band_mask_full(S, w)[None, None].clone()
+    template[..., 50, 40] = False    # packed-style violation on a non-probe row
+    valid = _band_mask_full(S, w)[None, None]
+    assert _mask_is_plain_band(valid, S, w)    # caches a True verdict on this object
+    del valid                                  # frees its id for reuse
+    for _ in range(5000):
+        packed = template.clone()              # a distinct object, may land on the freed id
+        assert not _mask_is_plain_band(packed, S, w)
+        del packed

--- a/tests/test_gemma4_banded_attention.py
+++ b/tests/test_gemma4_banded_attention.py
@@ -101,6 +101,43 @@ def test_mask_is_plain_band_rejects_non_probe_violation():
     assert not _mask_is_plain_band(packed, S, w)
 
 
+def test_mask_is_plain_band_rejects_per_head_mask():
+    # A 4D mask with a head dim > 1 cannot be honoured by the single block mask
+    # applied to every head, so it must be rejected even if head 0 is a band.
+    S, w = 128, 32
+    band = _band_mask_full(S, w)
+    per_head = band[None, None].expand(1, 4, S, S).clone()   # (1, 4, S, S)
+    assert not _mask_is_plain_band(per_head, S, w)
+    assert _mask_is_plain_band(band[None, None], S, w)       # (1, 1, S, S) still ok
+
+
+def test_mask_is_plain_band_rejects_inband_bias():
+    # A finite in-band bias (soft penalty) must be rejected: the banded path
+    # swaps in a boolean block mask and would silently drop the bias.
+    S, w = 128, 32
+    band = _band_mask_full(S, w)
+    biased = torch.where(band, -5.0, float("-inf")).to(torch.float32)[None, None]
+    assert not _mask_is_plain_band(biased, S, w)
+    clean = torch.where(band, 0.0, float("-inf")).to(torch.float32)[None, None]
+    assert _mask_is_plain_band(clean, S, w)
+
+
+def test_mask_is_plain_band_chunked_equals_single_block():
+    # Row-chunked verification must agree with a single-block scan on every mask.
+    S, w = 96, 16
+    band = _band_mask_full(S, w)
+    packed = band.clone(); packed[50, 40] = False
+    cases = {
+        "band_bool": band[None, None],
+        "band_float": torch.where(band, 0.0, float("-inf")).to(torch.float32)[None, None],
+        "packed_bool": packed[None, None],
+    }
+    for name, m in cases.items():
+        full = _mask_is_plain_band(m.clone(), S, w, _block=S)
+        chunked = _mask_is_plain_band(m.clone(), S, w, _block=7)  # crosses block edges
+        assert full == chunked, name
+
+
 def test_mask_is_plain_band_survives_id_reuse():
     # A recycled object id must not produce a stale cached verdict for packed masks.
     S, w = 128, 32

--- a/tests/test_gemma4_banded_attention.py
+++ b/tests/test_gemma4_banded_attention.py
@@ -1,0 +1,92 @@
+"""Banded (block-local) sliding-window SDPA must match full SDPA + band mask.
+
+`_banded_sdpa_core` computes sliding-window attention in O(S*w) by folding
+w-sized query blocks into the batch dimension, each attending its own and the
+previous key block under a static (w, 2w) mask. These tests compare it against
+full SDPA with the explicit band mask (query i attends keys (i-w, i]) on CPU,
+including GQA and sequence lengths that do not divide the window.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from unsloth_zoo.temporary_patches.gemma4_banded_attention import (
+    _banded_sdpa_core,
+    _block_mask,
+    _mask_is_plain_band,
+)
+
+
+def _band_mask_full(S, w, device="cpu"):
+    qi = torch.arange(S, device=device)[:, None]
+    kj = torch.arange(S, device=device)[None, :]
+    return (kj <= qi) & (kj > qi - w)
+
+
+def _reference(q, k, v, w, scale):
+    B, H, S, d = q.shape
+    Hkv = k.shape[1]
+    ng = H // Hkv
+    if ng > 1:
+        k = k[:, :, None].expand(B, Hkv, ng, S, d).reshape(B, H, S, d)
+        v = v[:, :, None].expand(B, Hkv, ng, S, d).reshape(B, H, S, d)
+    m = _band_mask_full(S, w, q.device)[None, None]
+    out = F.scaled_dot_product_attention(q, k, v, attn_mask=m, scale=scale)
+    return out.transpose(1, 2).contiguous()  # (B,S,H,d), matching the core
+
+
+@pytest.mark.parametrize("S,w,H,Hkv,d", [
+    (256, 64, 4, 4, 32),     # no GQA, S divisible by w
+    (300, 64, 8, 2, 32),     # GQA 4, ragged tail block
+    (513, 128, 4, 1, 16),    # MQA, S = 4w + 1
+])
+def test_matches_full_sdpa_fp32(S, w, H, Hkv, d):
+    torch.manual_seed(0)
+    q = torch.randn(1, H, S, d)
+    k = torch.randn(1, Hkv, S, d)
+    v = torch.randn(1, Hkv, S, d)
+    scale = d ** -0.5
+    ref = _reference(q, k, v, w, scale)
+    out = _banded_sdpa_core(q, k, v, w, scale, 0.0, H // Hkv)
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_gradients_match_fp32():
+    torch.manual_seed(1)
+    S, w, H, d = 256, 64, 2, 16
+    q1 = torch.randn(1, H, S, d, requires_grad=True)
+    k1 = torch.randn(1, H, S, d, requires_grad=True)
+    v1 = torch.randn(1, H, S, d, requires_grad=True)
+    q2 = q1.detach().clone().requires_grad_(True)
+    k2 = k1.detach().clone().requires_grad_(True)
+    v2 = v1.detach().clone().requires_grad_(True)
+    scale = d ** -0.5
+
+    _reference(q1, k1, v1, w, scale).square().sum().backward()
+    _banded_sdpa_core(q2, k2, v2, w, scale, 0.0, 1).square().sum().backward()
+
+    torch.testing.assert_close(q2.grad, q1.grad, rtol=1e-4, atol=1e-5)
+    torch.testing.assert_close(k2.grad, k1.grad, rtol=1e-4, atol=1e-5)
+    torch.testing.assert_close(v2.grad, v1.grad, rtol=1e-4, atol=1e-5)
+
+
+def test_block_mask_block0_masks_phantom_prev():
+    w, nb = 8, 3
+    m = _block_mask(w, nb, torch.device("cpu"))
+    assert m.shape == (nb, 1, w, 2 * w)
+    # Block 0 must not attend the (padded) previous block.
+    assert not m[0, 0, :, :w].any()
+    # Later blocks follow the same local band for every block index.
+    assert torch.equal(m[1], m[2])
+
+
+def test_mask_is_plain_band_detection():
+    S, w = 128, 32
+    band = _band_mask_full(S, w)[None, None]
+    assert _mask_is_plain_band(band, S, w)
+    # Padding one token out of the band pattern must be rejected.
+    padded = band.clone()
+    padded[..., S - 1, 0:1] = True
+    assert not _mask_is_plain_band(padded, S, w)
+    assert _mask_is_plain_band(None, S, w)

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -41,6 +41,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.gemma",
     "unsloth_zoo.temporary_patches.gemma3n",
     "unsloth_zoo.temporary_patches.gemma4",
+    "unsloth_zoo.temporary_patches.gemma4_banded_attention",
     "unsloth_zoo.temporary_patches.gemma4_moe",
     "unsloth_zoo.temporary_patches.glm4_moe",
     "unsloth_zoo.temporary_patches.gpt_oss",

--- a/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
+++ b/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
@@ -58,7 +58,7 @@ def _block_mask(w, nb, device):
     return m
 
 
-def _mask_is_plain_band(mask, S, w):
+def _mask_is_plain_band(mask, S, w, _block=1024):
     """True only if `mask` is exactly the causal+sliding band with no token padding.
 
     Every row is verified (not a sampled subset), so packed or padded masks, whose
@@ -73,14 +73,29 @@ def _mask_is_plain_band(mask, S, w):
     cached = getattr(mask, "_unsloth_plain_band", None)
     if cached is not None:
         return cached
-    m = mask[0, 0]
-    if m.shape[-2] != S or m.shape[-1] != S:
+    # The banded path applies a single block mask to every head, so a per-head
+    # (shape[1] > 1) mask cannot be honoured; reject it instead of validating
+    # only head 0 and silently dropping the rest.
+    if mask.shape[1] != 1 or mask.shape[-2] != S or mask.shape[-1] != S:
         ok = False
     else:
-        allowed = m if m.dtype == torch.bool else (m > -1e4)
+        m = mask[0, 0]
+        # Scan in row blocks so we never materialise a second dense S x S band
+        # plus its comparison: at 16k/32k that is gigabytes of transient GPU
+        # memory. Each block only builds a (block, S) band. A float mask must
+        # additionally carry no in-band bias (exactly 0), else the banded path
+        # would replace it with a boolean mask and silently drop the bias.
+        is_bool = m.dtype == torch.bool
         idx = torch.arange(S, device=m.device)
-        band = (idx[None, :] <= idx[:, None]) & (idx[None, :] > idx[:, None] - w)
-        ok = bool((allowed == band).all().item())
+        ok = True
+        for start in range(0, S, _block):
+            rows = idx[start : start + _block]                                       # (br,)
+            band = (idx[None, :] <= rows[:, None]) & (idx[None, :] > rows[:, None] - w)  # (br, S)
+            msl = m[start : start + _block, :]                                       # (br, S)
+            match = (msl == band) if is_bool else torch.where(band, msl == 0, msl <= -1e4)
+            if not bool(match.all().item()):
+                ok = False
+                break
     try:
         mask._unsloth_plain_band = ok
     except Exception:

--- a/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
+++ b/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
@@ -17,17 +17,14 @@
 # ============================================================================
 # Banded (block-local) SDPA for sliding-window attention layers.
 #
-# A sliding window only needs keys in (i-w, i] for query i, but SDPA with a
-# band mask still materialises the full O(S^2) score matrix. Compute it in
-# O(S*w) instead: cut the sequence into w-sized blocks, let query block b
-# attend key blocks b-1 and b (length 2w) under one static (w, 2w) mask
-# (block 0 masks its phantom previous block), and fold blocks into the batch
-# dim for a single SDPA call. Backward is exact through SDPA; fp32 rel ~1e-8
-# vs full SDPA + band mask.
-#
-# Engaged only when the layer's mask is exactly the causal+sliding band with
-# no token padding (verified on probe rows); else defers to the original SDPA.
-# Opt-in via UNSLOTH_BANDED_SDPA=1.
+# A sliding window only needs keys in (i-w, i] for query i, but SDPA with a band
+# mask still materialises the full O(S^2) score matrix. Compute it in O(S*w):
+# cut the sequence into w-sized blocks, let query block b attend key blocks b-1
+# and b (length 2w) under one static (w, 2w) mask (block 0 masks its phantom
+# previous block), and fold blocks into the batch dim for a single SDPA call.
+# Backward is exact through SDPA; fp32 rel ~1e-8 vs full SDPA + band mask.
+# Engaged only when the mask is exactly the causal+sliding band with no token
+# padding (verified on probe rows), else defers to SDPA. Opt-in UNSLOTH_BANDED_SDPA=1.
 # ============================================================================
 
 import os

--- a/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
+++ b/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
@@ -29,6 +29,7 @@
 # ============================================================================
 
 import os
+import functools
 import torch
 import torch.nn.functional as F
 from .common import logger
@@ -39,7 +40,15 @@ _MASK_CACHE = {}    # (w, nb, device) -> (nb,1,w,2w) bool block mask
 _ENGAGED = [0]      # count of banded-path invocations (debug)
 
 
+@functools.lru_cache(maxsize=1)
 def _enabled():
+    """Whether the pure-SDPA banded sliding-window path is enabled. Opt-in via
+    UNSLOTH_BANDED_SDPA=1; off by default.
+
+    Cached with maxsize=1 since the env var is read once per process. Any code or
+    test that toggles UNSLOTH_BANDED_SDPA at runtime must call
+    _enabled.cache_clear() afterwards for the change to take effect.
+    """
     return os.environ.get("UNSLOTH_BANDED_SDPA", "0") == "1"
 
 

--- a/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
+++ b/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
@@ -24,7 +24,8 @@
 # previous block), and fold blocks into the batch dim for a single SDPA call.
 # Backward is exact through SDPA; fp32 rel ~1e-8 vs full SDPA + band mask.
 # Engaged only when the mask is exactly the causal+sliding band with no token
-# padding (verified on probe rows), else defers to SDPA. Opt-in UNSLOTH_BANDED_SDPA=1.
+# padding (fully verified, so packed masks defer), else defers to SDPA.
+# Opt-in UNSLOTH_BANDED_SDPA=1.
 # ============================================================================
 
 import os
@@ -35,7 +36,6 @@ from .common import logger
 __all__ = ["maybe_banded_sliding"]
 
 _MASK_CACHE = {}    # (w, nb, device) -> (nb,1,w,2w) bool block mask
-_BAND_OK = {}       # id(attention_mask) -> bool (is it a plain no-padding band)
 _ENGAGED = [0]      # count of banded-path invocations (debug)
 
 
@@ -59,34 +59,32 @@ def _block_mask(w, nb, device):
 
 
 def _mask_is_plain_band(mask, S, w):
-    """True if `mask` is exactly the causal+sliding band with no token padding."""
+    """True only if `mask` is exactly the causal+sliding band with no token padding.
+
+    Every row is verified (not a sampled subset), so packed or padded masks, whose
+    extra segment boundaries the banded path cannot honour, are always rejected. The
+    verdict is stashed on the tensor itself, so it can never collide with a recycled
+    object id.
+    """
     if mask is None:
         return True
     if not torch.is_tensor(mask) or mask.dim() != 4:
         return False
-    key = id(mask)
-    cached = _BAND_OK.get(key)
+    cached = getattr(mask, "_unsloth_plain_band", None)
     if cached is not None:
         return cached
-    if len(_BAND_OK) > 64:
-        _BAND_OK.clear()
     m = mask[0, 0]
     if m.shape[-2] != S or m.shape[-1] != S:
-        _BAND_OK[key] = False
-        return False
-    allowed = m if m.dtype == torch.bool else (m > -1e4)
-    dev = m.device
-    cand = sorted({x for x in (0, 1, w - 1, w, w + 1, 2 * w, S // 2, S - 1, S - w, S - w - 1) if 0 <= x < S})
-    probes = torch.tensor(cand, device=dev)
-    rows = allowed[probes]                                # (P, S)
-    idx = torch.arange(S, device=dev)[None, :]
-    cnt = rows.sum(-1)
-    minidx = torch.where(rows, idx, torch.full_like(idx, S)).amin(-1)
-    maxidx = torch.where(rows, idx, torch.full_like(idx, -1)).amax(-1)
-    lo = torch.clamp(probes - w + 1, min=0)
-    hi = probes
-    ok = bool(((cnt == (hi - lo + 1)) & (minidx == lo) & (maxidx == hi)).all().item())
-    _BAND_OK[key] = ok
+        ok = False
+    else:
+        allowed = m if m.dtype == torch.bool else (m > -1e4)
+        idx = torch.arange(S, device=m.device)
+        band = (idx[None, :] <= idx[:, None]) & (idx[None, :] > idx[:, None] - w)
+        ok = bool((allowed == band).all().item())
+    try:
+        mask._unsloth_plain_band = ok
+    except Exception:
+        pass
     return ok
 
 
@@ -103,7 +101,7 @@ def _banded_sdpa_core(query, key, value, w, scaling, dropout, num_key_value_grou
         key = F.pad(key, (0, 0, 0, Sp - S))
         value = F.pad(value, (0, 0, 0, Sp - S))
     nb = Sp // w
-    qb = query.view(B, H, nb, w, d).permute(0, 2, 1, 3, 4).reshape(B * nb, H, w, d)
+    qb = query.reshape(B, H, nb, w, d).permute(0, 2, 1, 3, 4).reshape(B * nb, H, w, d)
     kpad = F.pad(key, (0, 0, w, 0))                       # (B,H, w+Sp, d)
     vpad = F.pad(value, (0, 0, w, 0))
     kw = kpad.unfold(2, 2 * w, w).permute(0, 1, 2, 4, 3)  # (B,H,nb,2w,d)
@@ -113,7 +111,7 @@ def _banded_sdpa_core(query, key, value, w, scaling, dropout, num_key_value_grou
     mask = _block_mask(w, nb, query.device)
     mask = mask.expand(B, nb, 1, w, 2 * w).reshape(B * nb, 1, w, 2 * w)
     out = F.scaled_dot_product_attention(qb, kw, vw, attn_mask=mask, dropout_p=dropout, scale=scaling)
-    out = out.view(B, nb, H, w, d).permute(0, 2, 1, 3, 4).reshape(B, H, Sp, d)[:, :, :S]
+    out = out.reshape(B, nb, H, w, d).permute(0, 2, 1, 3, 4).reshape(B, H, Sp, d)[:, :, :S]
     return out.transpose(1, 2).contiguous()               # (B,S,H,d) to match sdpa_attention_forward
 
 

--- a/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
+++ b/unsloth_zoo/temporary_patches/gemma4_banded_attention.py
@@ -1,0 +1,156 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see https://www.gnu.org/licenses/
+#
+# ============================================================================
+# Banded (block-local) SDPA for sliding-window attention layers.
+#
+# A sliding window only needs keys in (i-w, i] for query i, but SDPA with a
+# band mask still materialises the full O(S^2) score matrix. Compute it in
+# O(S*w) instead: cut the sequence into w-sized blocks, let query block b
+# attend key blocks b-1 and b (length 2w) under one static (w, 2w) mask
+# (block 0 masks its phantom previous block), and fold blocks into the batch
+# dim for a single SDPA call. Backward is exact through SDPA; fp32 rel ~1e-8
+# vs full SDPA + band mask.
+#
+# Engaged only when the layer's mask is exactly the causal+sliding band with
+# no token padding (verified on probe rows); else defers to the original SDPA.
+# Opt-in via UNSLOTH_BANDED_SDPA=1.
+# ============================================================================
+
+import os
+import torch
+import torch.nn.functional as F
+from .common import logger
+
+__all__ = ["maybe_banded_sliding"]
+
+_MASK_CACHE = {}    # (w, nb, device) -> (nb,1,w,2w) bool block mask
+_BAND_OK = {}       # id(attention_mask) -> bool (is it a plain no-padding band)
+_ENGAGED = [0]      # count of banded-path invocations (debug)
+
+
+def _enabled():
+    return os.environ.get("UNSLOTH_BANDED_SDPA", "0") == "1"
+
+
+def _block_mask(w, nb, device):
+    key = (w, nb, str(device))
+    m = _MASK_CACHE.get(key)
+    if m is not None:
+        return m
+    qi = torch.arange(w, device=device)[:, None]
+    ki = torch.arange(2 * w, device=device)[None, :]
+    base = (ki > qi) & (ki <= qi + w)                     # (w, 2w) local band
+    m = base[None].expand(nb, w, 2 * w).clone()           # (nb, w, 2w)
+    m[0] &= (torch.arange(2 * w, device=device)[None, :] >= w)  # block 0: drop phantom prev-block
+    m = m[:, None]                                         # (nb, 1, w, 2w)
+    _MASK_CACHE[key] = m
+    return m
+
+
+def _mask_is_plain_band(mask, S, w):
+    """True if `mask` is exactly the causal+sliding band with no token padding."""
+    if mask is None:
+        return True
+    if not torch.is_tensor(mask) or mask.dim() != 4:
+        return False
+    key = id(mask)
+    cached = _BAND_OK.get(key)
+    if cached is not None:
+        return cached
+    if len(_BAND_OK) > 64:
+        _BAND_OK.clear()
+    m = mask[0, 0]
+    if m.shape[-2] != S or m.shape[-1] != S:
+        _BAND_OK[key] = False
+        return False
+    allowed = m if m.dtype == torch.bool else (m > -1e4)
+    dev = m.device
+    cand = sorted({x for x in (0, 1, w - 1, w, w + 1, 2 * w, S // 2, S - 1, S - w, S - w - 1) if 0 <= x < S})
+    probes = torch.tensor(cand, device=dev)
+    rows = allowed[probes]                                # (P, S)
+    idx = torch.arange(S, device=dev)[None, :]
+    cnt = rows.sum(-1)
+    minidx = torch.where(rows, idx, torch.full_like(idx, S)).amin(-1)
+    maxidx = torch.where(rows, idx, torch.full_like(idx, -1)).amax(-1)
+    lo = torch.clamp(probes - w + 1, min=0)
+    hi = probes
+    ok = bool(((cnt == (hi - lo + 1)) & (minidx == lo) & (maxidx == hi)).all().item())
+    _BAND_OK[key] = ok
+    return ok
+
+
+def _banded_sdpa_core(query, key, value, w, scaling, dropout, num_key_value_groups):
+    # query: (B,H,S,d)   key/value: (B,Hkv,S,d)
+    B, H, S, d = query.shape
+    Hkv = key.shape[1]
+    if num_key_value_groups > 1:
+        key = key[:, :, None].expand(B, Hkv, num_key_value_groups, S, d).reshape(B, H, S, d)
+        value = value[:, :, None].expand(B, Hkv, num_key_value_groups, S, d).reshape(B, H, S, d)
+    Sp = ((S + w - 1) // w) * w
+    if Sp != S:
+        query = F.pad(query, (0, 0, 0, Sp - S))
+        key = F.pad(key, (0, 0, 0, Sp - S))
+        value = F.pad(value, (0, 0, 0, Sp - S))
+    nb = Sp // w
+    qb = query.view(B, H, nb, w, d).permute(0, 2, 1, 3, 4).reshape(B * nb, H, w, d)
+    kpad = F.pad(key, (0, 0, w, 0))                       # (B,H, w+Sp, d)
+    vpad = F.pad(value, (0, 0, w, 0))
+    kw = kpad.unfold(2, 2 * w, w).permute(0, 1, 2, 4, 3)  # (B,H,nb,2w,d)
+    vw = vpad.unfold(2, 2 * w, w).permute(0, 1, 2, 4, 3)
+    kw = kw.permute(0, 2, 1, 3, 4).reshape(B * nb, H, 2 * w, d)
+    vw = vw.permute(0, 2, 1, 3, 4).reshape(B * nb, H, 2 * w, d)
+    mask = _block_mask(w, nb, query.device)
+    mask = mask.expand(B, nb, 1, w, 2 * w).reshape(B * nb, 1, w, 2 * w)
+    out = F.scaled_dot_product_attention(qb, kw, vw, attn_mask=mask, dropout_p=dropout, scale=scaling)
+    out = out.view(B, nb, H, w, d).permute(0, 2, 1, 3, 4).reshape(B, H, Sp, d)[:, :, :S]
+    return out.transpose(1, 2).contiguous()               # (B,S,H,d) to match sdpa_attention_forward
+
+
+def maybe_banded_sliding(module, query, key, value, attention_mask,
+                         dropout=0.0, scaling=None, sliding_window=None):
+    """Return (attn_output, None) via the banded fast path, or None to defer.
+
+    Called from unsloth's sdpa wrapper for sliding-window layers. Engages only
+    for Gemma-4-style sliding attention (head_dim <= 256) whose mask is exactly
+    the causal+sliding band with no token padding; otherwise returns None so the
+    caller keeps its normal SDPA path. Opt-in via UNSLOTH_BANDED_SDPA=1.
+    """
+    if not _enabled():
+        return None
+    if not (getattr(module, "is_sliding", False) and type(module).__name__.startswith("Gemma4")):
+        return None
+    if query.dim() != 4 or query.shape[-1] > 256:
+        return None
+    w = sliding_window or getattr(module, "sliding_window", None)
+    if not w:
+        return None
+    Sq, Sk = query.shape[2], key.shape[2]
+    if not (Sq == Sk and Sq > w and query.shape[0] == 1):
+        return None
+    if not _mask_is_plain_band(attention_mask, Sq, w):
+        return None
+    try:
+        ng = getattr(module, "num_key_value_groups", query.shape[1] // key.shape[1])
+        out = _banded_sdpa_core(query, key, value, w, scaling,
+                                dropout if module.training else 0.0, ng)
+    except Exception as e:
+        logger.warning_once(f"Unsloth: banded sdpa fell back to full sdpa ({e})")
+        return None
+    _ENGAGED[0] += 1
+    if _ENGAGED[0] == 1:
+        logger.info_once(f"Unsloth: banded sliding SDPA engaged (window={w}, seq={Sq}).")
+    return out, None

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -720,9 +720,8 @@ def patch_sdpa_bool_causal_mask():
     ):
         m = attention_mask
 
-        # Banded sliding-window fast path (opt-in, UNSLOTH_BANDED_SDPA=1):
-        # block-local O(S*w) SDPA for sliding layers with head_dim <= 256
-        # (e.g. Gemma-4's 25 sliding layers). Returns None when not applicable.
+        # Banded sliding-window fast path (opt-in, UNSLOTH_BANDED_SDPA=1): block-local
+        # O(S*w) SDPA for sliding layers with head_dim <= 256 (e.g. Gemma-4's 25 sliding layers).
         if os.environ.get("UNSLOTH_BANDED_SDPA", "0") == "1":
             try:
                 from .gemma4_banded_attention import maybe_banded_sliding

--- a/unsloth_zoo/temporary_patches/misc.py
+++ b/unsloth_zoo/temporary_patches/misc.py
@@ -720,6 +720,22 @@ def patch_sdpa_bool_causal_mask():
     ):
         m = attention_mask
 
+        # Banded sliding-window fast path (opt-in, UNSLOTH_BANDED_SDPA=1):
+        # block-local O(S*w) SDPA for sliding layers with head_dim <= 256
+        # (e.g. Gemma-4's 25 sliding layers). Returns None when not applicable.
+        if os.environ.get("UNSLOTH_BANDED_SDPA", "0") == "1":
+            try:
+                from .gemma4_banded_attention import maybe_banded_sliding
+                _banded = maybe_banded_sliding(
+                    module, query, key, value, attention_mask,
+                    dropout = dropout, scaling = scaling,
+                    sliding_window = kwargs.get("sliding_window", None),
+                )
+            except Exception:
+                _banded = None
+            if _banded is not None:
+                return _banded
+
         # Below 2**16 the Cutlass bool-mask overflow (pytorch/pytorch#162588)
         # cannot fire, so skip the wrapper. The pure-causal rewrite picks a
         # heavier SDPA backend (~2.5 GB on Gemma4-31B LoRA SFT, 8192 seq_len).


### PR DESCRIPTION
## Summary

Sliding-window attention only needs keys in `(i-w, i]` for query i, but SDPA with an explicit band mask still materializes the full O(seq^2) score matrix. On gemma-4 the 25 sliding layers dominate step time at 16k/32k tokens whenever flash-attn is unavailable (the head_dim 512 global layers keep FA2 off model-wide).

## What this does

Adds a banded (block-local) O(seq*w) formulation on stock SDPA: cut the sequence into w-sized blocks, let query block b attend its own and the previous key block (length 2w) under a single static (w, 2w) causal+locality mask reused for every block and layer (block 0 masks its phantom previous block), and fold blocks into the batch dimension for one SDPA call. Backward is exact through SDPA.

Opt-in via `UNSLOTH_BANDED_SDPA=1`. It engages from the sdpa wrapper only for batch size 1 and sliding layers with head_dim at most 256 whose mask is verified to be the plain causal+sliding band with no token padding (cheap probe rows, cached per mask); anything else defers to the original SDPA. Needs no flash-attn build and works with any SDPA backend and dtype, so it complements the FA2 sliding path as the portable fallback.

## Testing

- 6 CPU unit tests: parity vs full SDPA + band mask in fp32 (rel 1e-5) across GQA/MQA and ragged tail blocks, gradient parity, block-mask structure, and band-mask detection.
- Real-model layer-0 attention output rel 1.2e-5 vs full SDPA on 4-bit weights.
- Measured on a 26B-A4B 4-bit LoRA SFT: 1.21x at 8k, 2.48x at 16k, 2.87x at 32k with unchanged peak memory (independently reproduced: 3738 vs 1531 tok/s at 16k).

