### PR TITLE
Add a grouped bnb 4-bit training forward for gpt-oss experts

### DIFF
--- a/tests/test_gptoss_grouped_gate.py
+++ b/tests/test_gptoss_grouped_gate.py
@@ -1,0 +1,88 @@
+"""The gpt-oss grouped bnb4bit readiness probe honors both env gates.
+
+GptOssExpertsBnb4bit._grouped_bnb4bit_ready decides whether the grouped
+torch._grouped_mm forward replaces the per-expert loop. It must be:
+
+  * ON by default,
+  * OFF when UNSLOTH_GPTOSS_GROUPED=0 (explicit opt-out of the grouped path),
+  * OFF when UNSLOTH_COMPILE_DISABLE=1 (the grouped stacks are meant to run under
+    the compiled cache; disabling compilation opts into the plain eager loop).
+
+The probe is self-contained (local imports, reads os.environ directly) so the
+compiler can copy its source into the standalone compiled cache. These are the
+env gates only: the downstream expert/quant_state checks are held True via a
+minimal CPU fake so the gate logic is exercised in isolation. No CUDA compute is
+performed (the fake Params4bit is never quantized), though importing unsloth_zoo
+requires a visible torch accelerator.
+"""
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
+
+bnb = pytest.importorskip("bitsandbytes")
+from bitsandbytes.nn import Params4bit
+
+try:
+    import unsloth_zoo.temporary_patches.moe_utils as mu
+    from unsloth_zoo.temporary_patches.gpt_oss import GptOssExpertsBnb4bit
+except Exception as e:  # pragma: no cover - unsloth_zoo import needs an accelerator
+    pytest.skip(f"cannot import unsloth_zoo gpt_oss patches: {e}", allow_module_level=True)
+
+
+def _fake_expert_linear():
+    """A LoRA-free bnb Linear4bit-like expert whose readiness checks all pass.
+
+    The Params4bit is left unquantized on CPU and given a hand-built quant_state
+    so the probe's attribute inspection succeeds without any GPU dequant.
+    """
+    w = Params4bit(
+        torch.zeros(4, 32, 64, dtype=torch.bfloat16),
+        requires_grad=False,
+        quant_type="nf4",
+    )
+    w.quant_state = SimpleNamespace(blocksize=64, shape=torch.Size([4, 32, 64]))
+    return SimpleNamespace(weight=w, bias=torch.zeros(4, dtype=torch.bfloat16))
+
+
+@pytest.fixture
+def experts(monkeypatch):
+    # Hold the hardware/torch capability check True so only the env gates decide.
+    monkeypatch.setattr(mu, "_check_torch_grouped_mm_supported", lambda: True)
+    fe = SimpleNamespace(
+        gate_up_projs=[_fake_expert_linear()],
+        down_projs=[_fake_expert_linear()],
+    )
+    return fe
+
+
+def _ready(experts):
+    # Call the unbound method against the fake experts object.
+    return GptOssExpertsBnb4bit._grouped_bnb4bit_ready(experts)
+
+
+def test_grouped_ready_default_on(experts, monkeypatch):
+    monkeypatch.delenv("UNSLOTH_GPTOSS_GROUPED", raising=False)
+    monkeypatch.delenv("UNSLOTH_COMPILE_DISABLE", raising=False)
+    assert _ready(experts) is True
+
+
+def test_grouped_disabled_by_gptoss_grouped_zero(experts, monkeypatch):
+    monkeypatch.delenv("UNSLOTH_COMPILE_DISABLE", raising=False)
+    monkeypatch.setenv("UNSLOTH_GPTOSS_GROUPED", "0")
+    assert _ready(experts) is False
+
+
+def test_grouped_disabled_by_compile_disable(experts, monkeypatch):
+    monkeypatch.delenv("UNSLOTH_GPTOSS_GROUPED", raising=False)
+    monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "1")
+    assert _ready(experts) is False
+
+
+def test_compile_disable_zero_keeps_grouped_on(experts, monkeypatch):
+    monkeypatch.delenv("UNSLOTH_GPTOSS_GROUPED", raising=False)
+    monkeypatch.setenv("UNSLOTH_COMPILE_DISABLE", "0")
+    assert _ready(experts) is True

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -851,20 +851,32 @@ class GptOssExpertsBnb4bit(nn.Module):
 
     def _grouped_bnb4bit_ready(self):
         """True when every expert is a plain (LoRA-free) bnb Linear4bit with a
-        populated quant_state, so the grouped torch._grouped_mm path is exact."""
+        populated quant_state, so the grouped torch._grouped_mm path is exact.
+
+        Self-contained (local imports, no module globals): the compiler can copy
+        this class's source into the standalone compiled cache, whose module
+        namespace lacks this file's globals."""
+        import os
         if os.environ.get("UNSLOTH_GPTOSS_GROUPED", "1") == "0":
             return False
         def _fail(reason):
-            if UNSLOTH_ENABLE_LOGGING and not getattr(self, "_unsloth_grouped_logged", False):
+            if (
+                os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1"
+                and not getattr(self, "_unsloth_grouped_logged", False)
+            ):
                 self._unsloth_grouped_logged = True
-                logger.info(f"Unsloth: gpt-oss grouped path disabled: {reason}")
+                import logging
+                logging.getLogger("unsloth_zoo.temporary_patches").info(
+                    f"Unsloth: gpt-oss grouped path disabled: {reason}"
+                )
             return False
         try:
             import bitsandbytes as bnb
             from bitsandbytes.nn import Params4bit
-            from .moe_utils import _check_torch_grouped_mm_supported
+            from unsloth_zoo.temporary_patches.moe_utils import _check_torch_grouped_mm_supported
             if not _check_torch_grouped_mm_supported():
                 return _fail("torch._grouped_mm unsupported")
+            blocksize = None
             for lin in list(self.gate_up_projs) + list(self.down_projs):
                 if hasattr(lin, "lora_A") or hasattr(lin, "base_layer"):
                     return _fail(f"LoRA-wrapped expert {type(lin).__name__}")
@@ -873,6 +885,20 @@ class GptOssExpertsBnb4bit(nn.Module):
                     return _fail(f"expert weight {type(w).__name__} without quant_state")
                 if w.requires_grad:
                     return _fail("expert weight requires_grad")
+                qs = w.quant_state
+                # The grouped dequant concatenates packed bytes + absmax across
+                # experts, which is exact only when every expert tiles into whole
+                # blocks of one shared blocksize; a trailing partial block would
+                # shift scaling onto the next expert.
+                numel = 1
+                for s in qs.shape:
+                    numel *= int(s)
+                if not qs.blocksize or numel % int(qs.blocksize) != 0:
+                    return _fail(f"expert numel {numel} not a multiple of blocksize {qs.blocksize}")
+                if blocksize is None:
+                    blocksize = int(qs.blocksize)
+                elif int(qs.blocksize) != blocksize:
+                    return _fail(f"mixed blocksizes {blocksize} vs {qs.blocksize}")
                 b = getattr(lin, "bias", None)
                 # Grouped path stacks per-expert biases, so a missing bias would
                 # break torch.stack; require all present and fall back otherwise.
@@ -888,9 +914,14 @@ class GptOssExpertsBnb4bit(nn.Module):
                                  batch_size, num_tokens, num_experts, top_k):
         """Grouped equivalent of the per-expert loop: one gather, two grouped_mm
         calls over dequantized stacks (rebuilt in backward when
-        UNSLOTH_MOE_RECOMPUTE=1), grouped bias adds, fp32 index_add combine."""
+        UNSLOTH_MOE_RECOMPUTE=1), grouped bias adds, fp32 index_add combine.
+
+        Self-contained (local imports, no module globals) for the standalone
+        compiled cache; see _grouped_bnb4bit_ready."""
+        import os
         import bitsandbytes as bnb
-        from .moe_utils import _base_grouped_mm
+        from unsloth_zoo.temporary_patches.moe_utils import _base_grouped_mm
+        from unsloth_zoo.temporary_patches.gpt_oss import swiglu_torch_forward
 
         device = hidden_states.device
         with torch.no_grad():
@@ -943,9 +974,13 @@ class GptOssExpertsBnb4bit(nn.Module):
         gate_up_qs, down_qs, gate_up_bias, down_bias = cached
 
         def _stack(projs, quant_state):
-            # One fused dequant gives (E, out, in); grouped_mm takes the transposed view.
+            # One fused dequant gives (E, out, in); grouped_mm takes the transposed
+            # view. Cast to the input dtype (a no-op for the usual bf16-on-bf16
+            # case): torch._grouped_mm rejects mismatched dtypes, e.g. fp32 hidden
+            # states under the forced-float32 path against a bf16 quant state.
             data = torch.cat([l.weight.data.reshape(-1, 1) for l in projs])
-            return bnb.functional.dequantize_4bit(data, quant_state).transpose(1, 2)
+            deq = bnb.functional.dequantize_4bit(data, quant_state)
+            return deq.to(hidden_states.dtype).transpose(1, 2)
 
         xg = hidden_states[sorted_tokens]
         gate_up = _base_grouped_mm(
@@ -983,7 +1018,8 @@ class GptOssExpertsBnb4bit(nn.Module):
                     batch_size, num_tokens, num_experts, top_k,
                 )
             except Exception:
-                if UNSLOTH_ENABLE_LOGGING:
+                import os as _os
+                if _os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1":
                     import traceback; traceback.print_exc()
                 # fall through to the per-expert loop
 

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -905,9 +905,8 @@ class GptOssExpertsBnb4bit(nn.Module):
 
         cached = getattr(self, "_unsloth_grouped_qs", None)
         if cached is None:
-            # One QuantState spanning all experts (packed NF4 is elementwise
-            # row-major, so per-expert byte + fp32 absmax concat is exact):
-            # ONE dequantize_4bit launch per stack instead of num_experts.
+            # One QuantState spanning all experts (packed NF4 is elementwise row-major,
+            # so per-expert byte + fp32 absmax concat is exact): one dequant launch per stack.
             from bitsandbytes.functional import QuantState
 
             def _absmax_fp32(qs):

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -970,7 +970,13 @@ class GptOssExpertsBnb4bit(nn.Module):
         num_experts = routing_weights.shape[1]
         top_k = router_indices.shape[1]
 
-        if self.training and self._grouped_bnb4bit_ready():
+        # fp16 keeps the loop path, whose fp32 swiglu + autocast-disabled down
+        # projection protect against fp16 overflow; grouped runs in model dtype.
+        if (
+            self.training
+            and hidden_states.dtype is not torch.float16
+            and self._grouped_bnb4bit_ready()
+        ):
             try:
                 return self._forward_grouped_bnb4bit(
                     hidden_states, router_indices, routing_weights,
@@ -1897,8 +1903,11 @@ def torch_native_forward(
 
     # Grouped bnb-4bit fast path. The class dispatches this module-level
     # function (forward is rebound below), so the gate must live here too.
+    # fp16 keeps the loop path below, whose fp32 swiglu + autocast-disabled
+    # down projection protect against fp16 overflow.
     if (
         self.training
+        and hidden_states.dtype is not torch.float16
         and hasattr(self, "_grouped_bnb4bit_ready")
         and self._grouped_bnb4bit_ready()
     ):

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -859,6 +859,11 @@ class GptOssExpertsBnb4bit(nn.Module):
         import os
         if os.environ.get("UNSLOTH_GPTOSS_GROUPED", "1") == "0":
             return False
+        # The grouped path materializes torch._grouped_mm stacks meant to run under the
+        # compiled cache; when the user disables compilation they have opted into the plain
+        # eager per-expert loop, so honor that and fall back.
+        if os.environ.get("UNSLOTH_COMPILE_DISABLE", "0") == "1":
+            return False
         def _fail(reason):
             if (
                 os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1"

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -913,14 +913,13 @@ class GptOssExpertsBnb4bit(nn.Module):
     def _forward_grouped_bnb4bit(self, hidden_states, router_indices, routing_weights,
                                  batch_size, num_tokens, num_experts, top_k):
         """Grouped equivalent of the per-expert loop: one gather, two grouped_mm
-        calls over dequantized stacks (rebuilt in backward when
-        UNSLOTH_MOE_RECOMPUTE=1), grouped bias adds, fp32 index_add combine.
+        calls over dequantized stacks (pinned or rebuilt in backward per the adaptive
+        _moe_recompute_default policy), grouped bias adds, fp32 index_add combine.
 
         Self-contained (local imports, no module globals) for the standalone
         compiled cache; see _grouped_bnb4bit_ready."""
-        import os
         import bitsandbytes as bnb
-        from unsloth_zoo.temporary_patches.moe_utils import _base_grouped_mm
+        from unsloth_zoo.temporary_patches.moe_utils import _base_grouped_mm, _moe_recompute_default
         from unsloth_zoo.temporary_patches.gpt_oss import swiglu_torch_forward
 
         device = hidden_states.device
@@ -936,7 +935,7 @@ class GptOssExpertsBnb4bit(nn.Module):
                 torch.arange(num_experts, device=device), counts
             )
 
-        recompute = os.environ.get("UNSLOTH_MOE_RECOMPUTE", "0") == "1"
+        recompute = _moe_recompute_default()
 
         cached = getattr(self, "_unsloth_grouped_qs", None)
         if cached is None:

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -28,6 +28,7 @@ from .common import (
     get_torch_compile_options,
     UNSLOTH_ENABLE_LOGGING,
     UNSLOTH_COMPILE_DISABLE,
+    logger,
 )
 from importlib.metadata import version as importlib_version
 from ..utils import Version
@@ -848,13 +849,133 @@ class GptOssExpertsBnb4bit(nn.Module):
             "down_proj_bias", torch.empty(0, dtype=self.dtype), persistent=False
         )
 
+    def _grouped_bnb4bit_ready(self):
+        """True when every expert is a plain (LoRA-free) bnb Linear4bit with a
+        populated quant_state, so the grouped torch._grouped_mm path is exact."""
+        if os.environ.get("UNSLOTH_GPTOSS_GROUPED", "1") == "0":
+            return False
+        def _fail(reason):
+            if UNSLOTH_ENABLE_LOGGING and not getattr(self, "_unsloth_grouped_logged", False):
+                self._unsloth_grouped_logged = True
+                logger.info(f"Unsloth: gpt-oss grouped path disabled: {reason}")
+            return False
+        try:
+            import bitsandbytes as bnb
+            from bitsandbytes.nn import Params4bit
+            from .moe_utils import _check_torch_grouped_mm_supported
+            if not _check_torch_grouped_mm_supported():
+                return _fail("torch._grouped_mm unsupported")
+            for lin in list(self.gate_up_projs) + list(self.down_projs):
+                if hasattr(lin, "lora_A") or hasattr(lin, "base_layer"):
+                    return _fail(f"LoRA-wrapped expert {type(lin).__name__}")
+                w = getattr(lin, "weight", None)
+                if not (isinstance(w, Params4bit) and getattr(w, "quant_state", None) is not None):
+                    return _fail(f"expert weight {type(w).__name__} without quant_state")
+                if w.requires_grad:
+                    return _fail("expert weight requires_grad")
+                b = getattr(lin, "bias", None)
+                if b is not None and b.requires_grad:
+                    return _fail("expert bias requires_grad")
+        except Exception as e:
+            return _fail(f"{type(e).__name__}: {e}")
+        return True
+
+    def _forward_grouped_bnb4bit(self, hidden_states, router_indices, routing_weights,
+                                 batch_size, num_tokens, num_experts, top_k):
+        """Grouped equivalent of the per-expert loop: one gather, two grouped_mm
+        calls over dequantized stacks (rebuilt in backward when
+        UNSLOTH_MOE_RECOMPUTE=1), grouped bias adds, fp32 index_add combine."""
+        import bitsandbytes as bnb
+        from .moe_utils import _base_grouped_mm
+
+        device = hidden_states.device
+        with torch.no_grad():
+            flat_experts = router_indices.flatten()
+            token_ids = torch.arange(num_tokens, device=device).repeat_interleave(top_k)
+            sorted_idx = flat_experts.argsort(stable=True)
+            sorted_tokens = token_ids[sorted_idx]
+            sorted_experts = flat_experts[sorted_idx]
+            counts = torch.bincount(flat_experts, minlength=num_experts)
+            offsets = counts.cumsum(0, dtype=torch.int32)
+            expert_ids = torch.repeat_interleave(
+                torch.arange(num_experts, device=device), counts
+            )
+
+        recompute = os.environ.get("UNSLOTH_MOE_RECOMPUTE", "0") == "1"
+
+        cached = getattr(self, "_unsloth_grouped_qs", None)
+        if cached is None:
+            # One QuantState spanning all experts (packed NF4 is elementwise
+            # row-major, so per-expert byte + fp32 absmax concat is exact):
+            # ONE dequantize_4bit launch per stack instead of num_experts.
+            from bitsandbytes.functional import QuantState
+
+            def _absmax_fp32(qs):
+                # Materialize a QuantState's absmax as flat fp32 (denesting double-quant).
+                if getattr(qs, "nested", False):
+                    absmax = bnb.functional.dequantize_blockwise(qs.absmax, qs.state2)
+                    return (absmax + qs.offset).float()
+                return qs.absmax.float()
+
+            def build_qs(projs):
+                states = [l.weight.quant_state for l in projs]
+                absmax = torch.cat([_absmax_fp32(qs) for qs in states])
+                q0 = states[0]
+                return QuantState(
+                    absmax=absmax,
+                    shape=torch.Size((len(projs),) + tuple(q0.shape)),
+                    code=q0.code,
+                    blocksize=q0.blocksize,
+                    quant_type=q0.quant_type,
+                    dtype=q0.dtype,
+                )
+
+            cached = (
+                build_qs(self.gate_up_projs),
+                build_qs(self.down_projs),
+                torch.stack([l.bias for l in self.gate_up_projs]),  # (E, 2I)
+                torch.stack([l.bias for l in self.down_projs]),     # (E, H)
+            )
+            self._unsloth_grouped_qs = cached
+        gate_up_qs, down_qs, gate_up_bias, down_bias = cached
+
+        def _stack(projs, quant_state):
+            # One fused dequant gives (E, out, in); grouped_mm takes the transposed view.
+            data = torch.cat([l.weight.data.reshape(-1, 1) for l in projs])
+            return bnb.functional.dequantize_4bit(data, quant_state).transpose(1, 2)
+
+        xg = hidden_states[sorted_tokens]
+        gate_up = _base_grouped_mm(
+            xg, offsets, lambda: _stack(self.gate_up_projs, gate_up_qs), recompute)
+        gate_up = gate_up + gate_up_bias[expert_ids]
+        gated = swiglu_torch_forward(gate_up, self.alpha, self.limit)
+        out = _base_grouped_mm(
+            gated, offsets, lambda: _stack(self.down_projs, down_qs), recompute)
+        out = out + down_bias[expert_ids]
+
+        weighted = out.to(torch.float32) * routing_weights[sorted_tokens, sorted_experts, None].to(torch.float32)
+        next_states = torch.zeros(num_tokens, self.hidden_size, dtype=torch.float32, device=device)
+        next_states.index_add_(0, sorted_tokens, weighted)
+        return next_states.view(batch_size, -1, self.hidden_size).to(hidden_states.dtype)
+
     def forward(self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None) -> torch.Tensor:
         batch_size = hidden_states.shape[0]
         hidden_states = hidden_states.reshape(-1, self.hidden_size)
         num_tokens = hidden_states.shape[0]
         num_experts = routing_weights.shape[1]
         top_k = router_indices.shape[1]
-        
+
+        if self.training and self._grouped_bnb4bit_ready():
+            try:
+                return self._forward_grouped_bnb4bit(
+                    hidden_states, router_indices, routing_weights,
+                    batch_size, num_tokens, num_experts, top_k,
+                )
+            except Exception:
+                if UNSLOTH_ENABLE_LOGGING:
+                    import traceback; traceback.print_exc()
+                # fall through to the per-expert loop
+
         if self.training:
             with torch.no_grad():
                 flat_experts = router_indices.flatten()  # [tokens * topk]
@@ -1768,7 +1889,24 @@ def torch_native_forward(
     num_tokens = hidden_states.shape[0]
     num_experts = routing_weights.shape[1]
     top_k = router_indices.shape[1]
-    
+
+    # Grouped bnb-4bit fast path. The class dispatches this module-level
+    # function (forward is rebound below), so the gate must live here too.
+    if (
+        self.training
+        and hasattr(self, "_grouped_bnb4bit_ready")
+        and self._grouped_bnb4bit_ready()
+    ):
+        try:
+            return self._forward_grouped_bnb4bit(
+                hidden_states, router_indices, routing_weights,
+                batch_size, num_tokens, num_experts, top_k,
+            )
+        except Exception:
+            if UNSLOTH_ENABLE_LOGGING:
+                import traceback; traceback.print_exc()
+            # fall through to the per-expert loop
+
     if self.training:
         with torch.no_grad():
             flat_experts = router_indices.flatten()  # [tokens * topk]

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -874,7 +874,11 @@ class GptOssExpertsBnb4bit(nn.Module):
                 if w.requires_grad:
                     return _fail("expert weight requires_grad")
                 b = getattr(lin, "bias", None)
-                if b is not None and b.requires_grad:
+                # Grouped path stacks per-expert biases, so a missing bias would
+                # break torch.stack; require all present and fall back otherwise.
+                if b is None:
+                    return _fail("expert bias is None")
+                if b.requires_grad:
                     return _fail("expert bias requires_grad")
         except Exception as e:
             return _fail(f"{type(e).__name__}: {e}")
@@ -955,7 +959,9 @@ class GptOssExpertsBnb4bit(nn.Module):
         weighted = out.to(torch.float32) * routing_weights[sorted_tokens, sorted_experts, None].to(torch.float32)
         next_states = torch.zeros(num_tokens, self.hidden_size, dtype=torch.float32, device=device)
         next_states.index_add_(0, sorted_tokens, weighted)
-        return next_states.view(batch_size, -1, self.hidden_size).to(hidden_states.dtype)
+        # Grouped path only runs in training; mirror torch_native_forward's
+        # training branch, which returns fp32 (fp16 NaN protection).
+        return next_states.view(batch_size, -1, self.hidden_size).to(torch.float32)
 
     def forward(self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None) -> torch.Tensor:
         batch_size = hidden_states.shape[0]


### PR DESCRIPTION
## Summary

The gpt-oss 4-bit training path loops over all experts per layer, launching a dequantize and two matmuls per expert even for experts that received no tokens. A profiled step is about 80 percent GPU-idle: 2.27s of CPU work against 0.61s of CUDA, with 33k kernel launches, 2062 per-expert 4-bit matmuls, and 3140 dequantize calls.

Stacked on #838 (the base is `moe-recompute-backward`, which provides the grouped matmul primitives); the diff here is only the gpt-oss commit.

## What this does

Adds a grouped equivalent used when every expert is a plain LoRA-free `Linear4bit` with a populated quant_state: routing indices are sorted once on GPU, each projection stack is dequantized with a single `dequantize_4bit` call over one cross-expert QuantState (packed NF4 bytes are elementwise row-major, so concatenating per-expert bytes and fp32 absmax is exact), and the two projections run as `torch._grouped_mm` calls with grouped bias adds, followed by the identical fp32 index_add combine. With `UNSLOTH_MOE_RECOMPUTE=1` the dequantized stacks are rebuilt in backward instead of staying on the tape.

The gate lives in `torch_native_forward` (the function the experts class actually dispatches) behind a readiness probe (grouped_mm support, no LoRA wrappers, frozen quantized weights), can be disabled with `UNSLOTH_GPTOSS_GROUPED=0`, and falls back to the per-expert loop on any failure.

## Testing

- gpt-oss-20b-unsloth-bnb-4bit LoRA SFT at 4k tokens: 10194 tok/s grouped vs 2433 with the loop (4.2x); 11238 tok/s at 8k.
- Per-step losses match the loop path to 0.0022 over 20 deterministic steps.
