### PR TITLE
Forward declared tools to the DiffusionGemma visual server

### DIFF
--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -221,10 +221,7 @@ def health():
 async def chat(req: Request):
     body = await req.json()
     messages = body.get("messages", [])
-    # Declared tools ride through to the server so the chat template can render them
-    # (inputs.tools); the model then emits <|tool_call> blocks the caller can heal into
-    # structured tool_calls. None for plain chat, so the request shape is unchanged.
-    tools = body.get("tools")
+    tools = body.get("tools")  # forwarded to the visual server (rendered once the binary reads it)
     stream = bool(body.get("stream", False))
     max_blocks = _max_blocks(body)
     seed = int(body.get("seed", 3407))

--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -217,11 +217,25 @@ def health():
     return {"status": "ok", "model": MODEL_ID}
 
 
+def _tools_for_choice(tools, tool_choice):
+    # Honor tool_choice before advertising: "none" hides tools, a forced function
+    # narrows to just that one, anything else forwards all.
+    if isinstance(tool_choice, str) and tool_choice.lower() == "none":
+        return None
+    if isinstance(tool_choice, dict):
+        name = (tool_choice.get("function") or {}).get("name")
+        if name:
+            return [t for t in tools or []
+                    if isinstance(t, dict) and (t.get("function") or {}).get("name") == name] or None
+    return tools
+
+
 @app.post("/v1/chat/completions")
 async def chat(req: Request):
     body = await req.json()
     messages = body.get("messages", [])
-    tools = body.get("tools")  # forwarded to the visual server (rendered once the binary reads it)
+    # forwarded to the visual server (rendered once the binary reads it)
+    tools = _tools_for_choice(body.get("tools"), body.get("tool_choice"))
     stream = bool(body.get("stream", False))
     max_blocks = _max_blocks(body)
     seed = int(body.get("seed", 3407))

--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -221,6 +221,10 @@ def health():
 async def chat(req: Request):
     body = await req.json()
     messages = body.get("messages", [])
+    # Declared tools ride through to the server so the chat template can render them
+    # (inputs.tools); the model then emits <|tool_call> blocks the caller can heal into
+    # structured tool_calls. None for plain chat, so the request shape is unchanged.
+    tools = body.get("tools")
     stream = bool(body.get("stream", False))
     max_blocks = _max_blocks(body)
     seed = int(body.get("seed", 3407))
@@ -234,7 +238,7 @@ async def chat(req: Request):
         def work():
             with _LOCK:
                 return V.generate_visual(srv, messages, seed=seed, max_blocks=max_blocks,
-                                         on_stats=stats_box.update)
+                                         on_stats=stats_box.update, tools=tools)
         try:
             text = await loop.run_in_executor(None, work)
         except V.ContextOverflow as exc:
@@ -276,7 +280,7 @@ async def chat(req: Request):
                 with _LOCK:
                     full = V.generate_visual(srv, messages, seed=seed, max_blocks=max_blocks,
                                              on_frame=on_frame, on_commit=on_commit,
-                                             on_stats=stats_box.update)
+                                             on_stats=stats_box.update, tools=tools)
                 loop.call_soon_threadsafe(q.put_nowait, ("done", full))
             except V.ContextOverflow as exc:  # context budget exceeded -> clean user-facing message
                 loop.call_soon_threadsafe(q.put_nowait, ("overflow", exc))

--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -234,7 +234,7 @@ def _tools_for_choice(tools, tool_choice):
 async def chat(req: Request):
     body = await req.json()
     messages = body.get("messages", [])
-    # forwarded to the visual server (rendered once the binary reads it)
+    # forwarded to the visual server, honoring tool_choice
     tools = _tools_for_choice(body.get("tools"), body.get("tool_choice"))
     stream = bool(body.get("stream", False))
     max_blocks = _max_blocks(body)

--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -216,14 +216,20 @@ class VisualServer:
             pass
         self._spawn()
 
-    def _send(self, messages, n_blocks, seed):
+    def _send(self, messages, n_blocks, seed, tools=None):
         # A previous turn may have crashed the decoder; respawn before writing so a dead child does not
         # strand this and every later turn with a broken pipe.
         if self.p is None or self.p.poll() is not None:
             self.restart()
+        req = {"seed": int(seed), "n_blocks": int(n_blocks), "messages": messages}
+        # Forward declared tools so the server can render them into the chat template
+        # (inputs.tools); the model then emits <|tool_call> blocks with schema-correct
+        # argument names instead of guessing. Omitted when absent so the request shape
+        # is unchanged for plain chat.
+        if tools:
+            req["tools"] = tools
         with open(self.req, "w") as f:
-            json.dump({"seed": int(seed), "n_blocks": int(n_blocks), "messages": messages}, f,
-                      ensure_ascii=False)
+            json.dump(req, f, ensure_ascii=False)
         try:
             self.p.stdin.write(self.req + "\n")
             self.p.stdin.flush()
@@ -256,7 +262,7 @@ def _parse_stats(line):
     return stats
 
 
-def generate_visual(server, messages, seed=3407, max_blocks=8, on_frame=None, on_commit=None, on_stats=None):
+def generate_visual(server, messages, seed=3407, max_blocks=8, on_frame=None, on_commit=None, on_stats=None, tools=None):
     """Stream one turn through the optimized visual server.
 
     on_frame(block, step, total, text): a denoising frame (the current argmax canvas, already decoded).
@@ -282,7 +288,7 @@ def generate_visual(server, messages, seed=3407, max_blocks=8, on_frame=None, on
 
     for attempt in (0, 1):
         try:
-            return _generate_visual_once(server, messages, seed, max_blocks, _frame, _commit, on_stats)
+            return _generate_visual_once(server, messages, seed, max_blocks, _frame, _commit, on_stats, tools)
         except VisualServerCrashed:
             server.restart()  # always bring a fresh server up so the next turn works regardless
             if attempt == 1 or progressed["emitted"]:
@@ -290,8 +296,8 @@ def generate_visual(server, messages, seed=3407, max_blocks=8, on_frame=None, on
             # nothing emitted yet -> safe to transparently resend on the fresh server
 
 
-def _generate_visual_once(server, messages, seed, max_blocks, on_frame, on_commit, on_stats):
-    server._send(messages, max_blocks, seed)
+def _generate_visual_once(server, messages, seed, max_blocks, on_frame, on_commit, on_stats, tools=None):
+    server._send(messages, max_blocks, seed, tools)
 
     full_text = ""
     while True:

--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -222,9 +222,8 @@ class VisualServer:
         if self.p is None or self.p.poll() is not None:
             self.restart()
         req = {"seed": int(seed), "n_blocks": int(n_blocks), "messages": messages}
-        # Forward tools so the server can render them into the chat template (inputs.tools),
-        # for schema-correct <|tool_call> args instead of guesses. No-op until the visual
-        # server reads the field (pending llama.cpp support); harmless to send meanwhile.
+        # Forward tools so the server renders them into the chat template (inputs.tools)
+        # for schema-correct <|tool_call> args.
         if tools:
             req["tools"] = tools
         with open(self.req, "w") as f:

--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -226,7 +226,7 @@ class VisualServer:
         # for schema-correct <|tool_call> args.
         if tools:
             req["tools"] = tools
-        with open(self.req, "w") as f:
+        with open(self.req, "w", encoding="utf-8") as f:
             json.dump(req, f, ensure_ascii=False)
         try:
             self.p.stdin.write(self.req + "\n")

--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -222,10 +222,9 @@ class VisualServer:
         if self.p is None or self.p.poll() is not None:
             self.restart()
         req = {"seed": int(seed), "n_blocks": int(n_blocks), "messages": messages}
-        # Forward declared tools so the server can render them into the chat template
-        # (inputs.tools); the model then emits <|tool_call> blocks with schema-correct
-        # argument names instead of guessing. Omitted when absent so the request shape
-        # is unchanged for plain chat.
+        # Forward tools so the server can render them into the chat template (inputs.tools),
+        # for schema-correct <|tool_call> args instead of guesses. No-op until the visual
+        # server reads the field (pending llama.cpp support); harmless to send meanwhile.
         if tools:
             req["tools"] = tools
         with open(self.req, "w") as f:


### PR DESCRIPTION
The DiffusionGemma shim drops the caller's `tools`, so the model never sees the tool definitions and can't produce schema-correct tool calls.

Part of unslothai/unsloth#6732.

## Problem

The shim rebuilds a minimal request for the visual server, `{seed, n_blocks, messages}`, and never reads `tools` from the body. So even when a client declares tools, the chat template renders none of them, and the model guesses argument names (or declines) instead of following the schema.

## Fix

Thread `tools` from the request body through `generate_visual` into the request the visual server reads. Only added when present, so plain chat is unchanged.

## Note

One link in a three-part fix: Studio heals the model's text tool call into a structured `tool_calls` array (unslothai/unsloth#6851), and the visual server still has to read `tools` into `inputs.tools` (llama.cpp#24423) to actually render them. So this is a no-op until that binary support lands, and plain chat and thinking are unaffected either way.
