### PR TITLE
Refuse DoRA on mxfp4 packed MoE before dequant; refresh bnb4bit patch-count canary

### DIFF
--- a/tests/test_moe_quant_cleanup.py
+++ b/tests/test_moe_quant_cleanup.py
@@ -92,9 +92,11 @@ def test_temporary_patches_register_expected_count():
     src = inspect.getsource(moe_utils_bnb4bit)
     # Count is sticky to the file; if Phase 3 forgets the .append, we drop one.
     count = src.count("TEMPORARY_PATCHES.append(")
-    assert count == 6, (
-        f"moe_utils_bnb4bit registers {count} patches; expected 6 "
-        "(4 original bnb4bit patches + the 2 PEFT MoE patches relocated from misc.py)."
+    assert count == 9, (
+        f"moe_utils_bnb4bit registers {count} patches; expected 9 "
+        "(4 original bnb4bit patches + the 2 PEFT MoE patches relocated from misc.py "
+        "+ 3 later bnb4bit conversion patches: weight_conversions, "
+        "model_conversion_mapping, dequantize_plain_params)."
     )
 
 

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -2022,6 +2022,16 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     warnings.warn(f"Found mxfp4 tensor {key} but missing its scales tensor {scales_key}. Skipping.")
                     continue
 
+                # Refuse DoRA on packed MoE experts BEFORE the dequant below. GPT-OSS
+                # gate_up_proj/down_proj experts take this packed path (not the dense
+                # _merge_moe_*_expert helpers), and for a use_dora adapter the dequant +
+                # _merge_lora would otherwise fail with an opaque 3D shape error instead of
+                # the clear refuse. Mirrors the dense helpers' guard; the late call below is
+                # now unreachable for DoRA but kept as a defensive backstop.
+                _mxfp4_lora_stats = converted_lora_weights.get(base_name, None)
+                if _mxfp4_lora_stats is not None and getattr(_mxfp4_lora_stats, "lora_A", None) is not None:
+                    _refuse_dora_on_moe(_mxfp4_lora_stats)
+
                 blocks_tensor, scales_tensor = file.get_tensor(key), file.get_tensor(scales_key)
 
                 # Free the allocator before the large dequant alloc.


### PR DESCRIPTION
## Summary

Fixes two CPU test failures on `main` (the full `pytest tests/` suite that unsloth's `consolidated-tests-ci.yml` runs against `unsloth-zoo @ main`, so this currently reddens Core on every open unsloth PR):

- `tests/test_dora_merge.py::test_dora_on_mxfp4_packed_moe_is_refused`
- `tests/test_moe_quant_cleanup.py::test_temporary_patches_register_expected_count`

## 1. Refuse DoRA on mxfp4 packed MoE before the dequant

`_merge_and_overwrite_lora_mxfp4` dequantized the packed expert group via `convert_moe_packed_tensors` **before** reaching the `_refuse_dora_on_moe` guard. GPT-OSS `gate_up_proj`/`down_proj` experts take this packed path (not the dense `_merge_moe_*_expert` helpers), so a `use_dora=True` adapter on the experts bypassed the refuse and failed with an opaque 3D shape error inside the dequant instead of the clear "DoRA not supported for MoE" message.

The fix looks up the expert `lora_stats` right after resolving `base_name` and calls `_refuse_dora_on_moe` there, ahead of the dequant. The existing later call is kept as a defensive backstop.

## 2. Refresh the bnb4bit patch-count canary

`moe_utils_bnb4bit` grew from 6 to 9 `TEMPORARY_PATCHES.append(...)` entries (the 3 later bnb4bit conversion patches `weight_conversions`, `model_conversion_mapping`, `dequantize_plain_params`), but the sticky-count canary still asserted 6. The docstring already noted "3 more patches than before"; the assertion is updated to 9 with the reason so the drift detector matches the current registrations.

## Verification

Local run (transformers 4.57.6, CPU):

- Before: both tests fail (matching CI).
- After: full `tests/test_dora_merge.py` + `tests/test_moe_quant_cleanup.py` pass (13 passed, 1 skipped).
