### PR TITLE
Fix two stale main tests reddening downstream Core CI (patch-count canary + DoRA mxfp4 mock)

### DIFF
--- a/tests/test_dora_merge.py
+++ b/tests/test_dora_merge.py
@@ -168,8 +168,15 @@ def test_dora_on_mxfp4_packed_moe_is_refused(monkeypatch, tmp_path):
     # Patch the heavy mxfp4 machinery; only the DoRA-refuse behavior is under test.
     monkeypatch.setattr(su, "_convert_lora_keys_to_safetensor_format",
                         lambda lw, keys, model_class_name=None: lw)
-    monkeypatch.setattr(su, "convert_moe_packed_tensors",
-                        lambda b, s, rows_per_chunk=None: torch.randn(E, 2 * I, H))
+    # _merge_and_overwrite_lora_mxfp4 re-imports convert_moe_packed_tensors fresh from
+    # transformers.integrations.mxfp4 (so a runtime Unsloth patch is picked up), so stub it
+    # there, not just on the saving_utils module, otherwise the real converter runs on this
+    # deliberately-minimal packed group and asserts on the block/scale shapes before the
+    # DoRA guard is reached.
+    _stub_convert = lambda b, s, rows_per_chunk=None: torch.randn(E, 2 * I, H)
+    monkeypatch.setattr(su, "convert_moe_packed_tensors", _stub_convert)
+    from transformers.integrations import mxfp4 as _mxfp4_mod
+    monkeypatch.setattr(_mxfp4_mod, "convert_moe_packed_tensors", _stub_convert)
     monkeypatch.setattr(su, "_choose_mxfp4_processing_strategy",
                         lambda b, s: ("cuda", 0, 1024))
 

--- a/tests/test_moe_quant_cleanup.py
+++ b/tests/test_moe_quant_cleanup.py
@@ -85,16 +85,25 @@ def test_peft_bnb4bit_moe_patches_live_in_moe_utils_bnb4bit():
 
 def test_temporary_patches_register_expected_count():
     """Phase 3 must NOT silently drop a TEMPORARY_PATCHES.append entry.
-    moe_utils_bnb4bit now registers 3 more patches than before."""
+    moe_utils_bnb4bit now registers 9 patches."""
     from unsloth_zoo.temporary_patches import moe_utils_bnb4bit
     import inspect
 
     src = inspect.getsource(moe_utils_bnb4bit)
     # Count is sticky to the file; if Phase 3 forgets the .append, we drop one.
+    # 9 = 4 original bnb4bit patches (patch_bnb4bit_quantize_convert,
+    #   patch_bnb4bit_quantizer_param_needs_quantization,
+    #   patch_bnb4bit_quantizer_process_model, patch_transformers_weight_converter_kwargs)
+    #   + the 2 PEFT MoE patches relocated from misc.py
+    #   (patch_peft_param_wrapper_4bit_expert_shape, patch_peft_param_wrapper_merge_4bit)
+    #   + the 3 v5 prequantized-checkpoint loaders added by #856
+    #   (patch_bnb4bit_quantizer_weight_conversions,
+    #   patch_bnb4bit_model_conversion_mapping, patch_bnb4bit_dequantize_plain_params).
     count = src.count("TEMPORARY_PATCHES.append(")
-    assert count == 6, (
-        f"moe_utils_bnb4bit registers {count} patches; expected 6 "
-        "(4 original bnb4bit patches + the 2 PEFT MoE patches relocated from misc.py)."
+    assert count == 9, (
+        f"moe_utils_bnb4bit registers {count} patches; expected 9 "
+        "(4 original bnb4bit patches + the 2 PEFT MoE patches relocated from misc.py "
+        "+ the 3 transformers v5 prequantized bnb 4-bit MoE checkpoint loaders from #856)."
     )
 
 


### PR DESCRIPTION
### Problem

Two tests on `main` are currently failing:

- `tests/test_moe_quant_cleanup.py::test_temporary_patches_register_expected_count`
- `tests/test_dora_merge.py::test_dora_on_mxfp4_packed_moe_is_refused`

unsloth-zoo has no CI on its own `main`, so this only surfaces downstream: unslothai/unsloth's `consolidated-tests-ci.yml` vendors `unsloth_zoo@main` and runs its full pytest, so these two failures redden the `Core` matrix on every open unsloth PR. Both are stale tests, not production regressions. Production code is untouched here.

### Root cause and fix

**1. Patch-count canary (`test_temporary_patches_register_expected_count`)**

The canary counts `TEMPORARY_PATCHES.append(` in `moe_utils_bnb4bit.py` and asserted `== 6`. #856 ("Load prequantized bnb 4-bit MoE expert checkpoints under transformers v5") legitimately added three new registrations, all real distinct functions:

- `patch_bnb4bit_quantizer_weight_conversions` (`moe_utils_bnb4bit.py:669`)
- `patch_bnb4bit_model_conversion_mapping` (`:995`)
- `patch_bnb4bit_dequantize_plain_params` (`:1027`)

so the file now registers 9. Bumped the expected count to 9 and enumerated all nine (4 original + 2 relocated PEFT MoE + 3 new #856 loaders) in the assertion message and a comment, so the canary stays meaningful and still catches a silently dropped `.append`.

**2. DoRA mxfp4 refuse test (`test_dora_on_mxfp4_packed_moe_is_refused`)**

The test stubbed `saving_utils.convert_moe_packed_tensors` and expected `_merge_and_overwrite_lora_mxfp4` to reach the `_refuse_dora_on_moe` guard. But `_merge_and_overwrite_lora_mxfp4` now re-imports the converter fresh from transformers (`saving_utils.py:2047`, `from transformers.integrations.mxfp4 import convert_moe_packed_tensors as _cmpt_base`) so a runtime patch is picked up. That fresh import bypassed the module-level stub, so the real converter ran on the test's deliberately-minimal packed group and asserted on block/scale shapes (`blocks.shape[:-1]=[2, 12]` vs `scales.shape=[2, 12, 1]`) before the DoRA guard was reached. The re-import was introduced by #826, which merged just after the test's own PR #828. The production `_refuse_dora_on_moe` guard (`saving_utils.py:1251`, invoked at `:2084`) is present and correct. Fixed the test to also stub `transformers.integrations.mxfp4.convert_moe_packed_tensors`, keeping the `su`-level stub for the import-fallback branch.

### Verification

- Targeted: both tests pass.
- Full files: `tests/test_moe_quant_cleanup.py tests/test_dora_merge.py` -> `13 passed, 1 skipped`.
- The tests #856/#838 added still pass: `tests/test_moe_bnb4bit_per_expert_conversions.py tests/test_moe_bnb4bit_adaptive_recompute.py` -> `7 passed, 1 skipped`.

The 2 skips are transformers-v5-API gated (`core_model_loading` / v5 MoE quantization APIs not available), unrelated to this change.
