### PR TITLE
Fix compiled forward argument forwarding

### DIFF
--- a/tests/test_compiler_rewriter_exhaustive.py
+++ b/tests/test_compiler_rewriter_exhaustive.py
@@ -124,7 +124,7 @@ def test_compiler_forwarding_parameters_follow_emitted_definition():
     from pathlib import Path
 
     compiler_path = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "compiler.py"
-    tree = ast.parse(compiler_path.read_text())
+    tree = ast.parse(compiler_path.read_text(encoding="utf-8"))
     wanted = {
         "_build_forwarding_parameters",
         "_build_forwarding_parameters_from_definition",

--- a/tests/test_compiler_rewriter_exhaustive.py
+++ b/tests/test_compiler_rewriter_exhaustive.py
@@ -115,6 +115,46 @@ def test_compiler_higher_precision_softmax_idempotency_lookahead():
         )
 
 
+def test_compiler_forwarding_parameters_follow_emitted_definition():
+    """compiler.py:create_new_function: generated wrapper calls must use the
+    emitted wrapper signature, not a decorator-relaxed ``*args`` signature."""
+    import ast
+    import inspect
+    import textwrap
+    from pathlib import Path
+
+    compiler_path = Path(__file__).resolve().parents[1] / "unsloth_zoo" / "compiler.py"
+    tree = ast.parse(compiler_path.read_text())
+    wanted = {
+        "_build_forwarding_parameters",
+        "_build_forwarding_parameters_from_definition",
+    }
+    helper_nodes = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    ]
+    namespace = {"ast": ast, "inspect": inspect, "textwrap": textwrap}
+    exec(compile(ast.Module(body=helper_nodes, type_ignores=[]), str(compiler_path), "exec"), namespace)
+    build = namespace["_build_forwarding_parameters_from_definition"]
+    definition = """
+        def forward(
+            self,
+            hidden_states: torch.Tensor,
+            cache_params: Cache | None = None,
+            attention_mask: torch.Tensor | None = None,
+            **kwargs: Unpack[TransformersKwargs],
+        ):
+    """
+
+    parameters = build(definition)
+
+    assert "*args" not in parameters
+    assert parameters == (
+        "self, hidden_states=hidden_states, cache_params=cache_params, "
+        "attention_mask=attention_mask, **kwargs"
+    )
+
+
 def test_compiler_fix_rotary_embedding_cos_to_dtype_pattern():
     """compiler.py:510-517 fix_rotary_embedding_dtype (UNSLOTH_FORCE_CUSTOM_DTYPE
     -gated): pin that some rotary cos/sin cast site exists."""

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -485,6 +485,59 @@ def _all_attention_functions_has_sdpa():
 pass
 
 
+def _build_forwarding_parameters(parameters):
+    forwarding_parts = []
+    for key, value in parameters.items():
+        if value.kind == inspect.Parameter.VAR_KEYWORD:
+            forwarding_parts.append("**" + key)
+        elif value.kind == inspect.Parameter.VAR_POSITIONAL:
+            forwarding_parts.append("*" + key)
+        elif key == "self":
+            forwarding_parts.append("self")
+        elif value.kind == inspect.Parameter.POSITIONAL_ONLY:
+            forwarding_parts.append(key)
+        else:
+            forwarding_parts.append(f"{key}={key}")
+    return ", ".join(forwarding_parts)
+
+
+def _build_forwarding_parameters_from_definition(definition):
+    """Build a forwarding call that matches the emitted wrapper signature."""
+    function_source = textwrap.dedent(definition).strip() + "\n    pass\n"
+    parsed = ast.parse(function_source)
+    function_def = parsed.body[0]
+    args = function_def.args
+    parameters = {}
+
+    for arg in args.posonlyargs:
+        parameters[arg.arg] = inspect.Parameter(
+            arg.arg,
+            inspect.Parameter.POSITIONAL_ONLY,
+        )
+    for arg in args.args:
+        parameters[arg.arg] = inspect.Parameter(
+            arg.arg,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    if args.vararg is not None:
+        parameters[args.vararg.arg] = inspect.Parameter(
+            args.vararg.arg,
+            inspect.Parameter.VAR_POSITIONAL,
+        )
+    for arg in args.kwonlyargs:
+        parameters[arg.arg] = inspect.Parameter(
+            arg.arg,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    if args.kwarg is not None:
+        parameters[args.kwarg.arg] = inspect.Parameter(
+            args.kwarg.arg,
+            inspect.Parameter.VAR_KEYWORD,
+        )
+
+    return _build_forwarding_parameters(parameters)
+
+
 # Convert F.softmax(x, ...) to F.softmax(x, ..., dtype = torch.float32).to(x.dtype)
 def higher_precision_softmax(source):
     """
@@ -1382,30 +1435,6 @@ def create_standalone_class(
     else:
         compile = ""
 
-    # Create new forward calling optimized function
-    parameters = inspect.signature(f.forward).parameters
-    # Build the forwarding call using keyword arguments (name=name) for regular
-    # parameters so that decorators like @merge_with_config_defaults can find
-    # them in **kwargs.  When args are passed positionally, the decorator's
-    # func.__code__.co_varnames lookup fails (it sees the inner wrapper's
-    # varnames, not the original function's), and it injects the arg into kwargs
-    # again, causing "got multiple values for argument 'use_cache'".
-    keys = list(parameters.keys())
-    values = list(parameters.values())
-    forwarding_parts = []
-    for j, (key, value) in enumerate(zip(keys, values)):
-        value_str = str(value)
-        if value_str.startswith("**"):
-            forwarding_parts.append("**" + key)
-        elif value_str.startswith("*"):
-            forwarding_parts.append("*" + key)
-        elif key == "self":
-            forwarding_parts.append("self")
-        else:
-            forwarding_parts.append(f"{key}={key}")
-    pass
-    parameters = ", ".join(forwarding_parts)
-
     # Now create the forward function!
     # When forward is patched, use the original forward definition from class source
     definition_source = patched_forward_info[1] if patched_forward_info else old_source
@@ -1424,6 +1453,17 @@ def create_standalone_class(
             f"Source starts with: {definition_source[:200]}"
         )
     definition = definition_matches[0]
+
+    # Create new forward calling optimized function. Build the forwarding call
+    # from the emitted wrapper definition, not from inspect.signature(f.forward).
+    # Some upstream forwards are decorated and inspect as (self, *args, **kwargs)
+    # even though the class source has explicit parameters. Mixing those sources
+    # generates a wrapper body that references undefined args.
+    try:
+        parameters = _build_forwarding_parameters_from_definition(definition)
+    except Exception:
+        parameters = _build_forwarding_parameters(inspect.signature(f.forward).parameters)
+
     leftover = full_class[full_class.find(definition) + len(definition) :]
 
     # Add **loss_kwargs


### PR DESCRIPTION
## Summary
- build compiled forward-call arguments from the emitted wrapper definition instead of a potentially decorator-relaxed inspect.signature(f.forward)
- prevents generated wrappers with explicit signatures from referencing an undefined *args local
- adds a CPU-safe regression test for the Qwen3.5-style forward signature

## Context
For Qwen3.5 linear_attn, the emitted compiled cache can contain a wrapper like:

```python
def forward(self, hidden_states, cache_params=None, attention_mask=None, **kwargs):
    return wrapped(self, *args, **kwargs)
```

The wrapper definition has no `args`, so training fails with `NameError: name 'args' is not defined`. This happens when `inspect.signature(f.forward)` sees a decorator-relaxed `(self, *args, **kwargs)` signature while the emitted wrapper definition comes from the original class source with explicit parameters.

## Tests
- `python -m py_compile unsloth_zoo/compiler.py tests/test_compiler_rewriter_exhaustive.py`
- `python -m pytest tests/test_compiler_rewriter_exhaustive.py::test_compiler_forwarding_parameters_follow_emitted_definition -q`
- repeated the same targeted test on a temporary GCE Debian 12 VM with Python 3.11

Fixes #875
