### PR TITLE
Skip bnb4bit per-expert MoE tests against the transformers<5 core_model_loading stub

### DIFF
--- a/tests/test_moe_bnb4bit_per_expert_conversions.py
+++ b/tests/test_moe_bnb4bit_per_expert_conversions.py
@@ -18,10 +18,24 @@ import types
 import pytest
 import torch
 
-pytest.importorskip(
+_core_model_loading = pytest.importorskip(
     "transformers.core_model_loading",
     reason="requires transformers v5 core_model_loading",
 )
+
+# On transformers < v5 the real `core_model_loading` module does not exist, but
+# unsloth injects an inert compat stub of the same name into `sys.modules` so
+# peft LoRA reloads keep working. That stub's `WeightConverter` accepts any
+# arguments and stores nothing, so `importorskip` above finds the module and
+# does not skip. Skip unless the real v5 API is present (its `WeightConverter`
+# exposes `target_patterns`, a `__slots__` descriptor inherited from
+# `WeightTransform`), so these tests only run against genuine transformers v5.
+if not hasattr(_core_model_loading.WeightConverter, "target_patterns"):
+    pytest.skip(
+        "transformers.core_model_loading is a transformers<5 compat stub, "
+        "not the v5 API",
+        allow_module_level=True,
+    )
 
 from transformers.core_model_loading import ConversionOps, WeightConverter
 


### PR DESCRIPTION
## Problem

The unsloth CI job `unsloth_zoo @ main - full pytest (CPU)` (and the `Core (HF=4.57.6 + TRL<1)` matrix leg) fails with six errors in `tests/test_moe_bnb4bit_per_expert_conversions.py`:

```
AttributeError: 'WeightConverter' object has no attribute 'target_patterns'
```

The module guards with:

```python
pytest.importorskip("transformers.core_model_loading", ...)
```

expecting to skip on transformers < v5, where `transformers.core_model_loading` does not exist.

However, when unsloth is loaded on transformers 4.x it deliberately injects an inert `transformers.core_model_loading` compat stub into `sys.modules` (so peft 0.19 LoRA reloads keep working). The stub's `WeightConverter.__init__(*args, **kwargs)` accepts anything and stores nothing, and it lacks the v5 API (`target_patterns`, etc.). So `importorskip` finds the stubbed module, does not skip, and all six tests run against the inert stub and error.

This predates and is unrelated to the recent studio merges. The same six failures reproduce on the prior main commit; it is a genuine test-guard bug here in unsloth-zoo. The unsloth stub is intentionally inert (it raises `NotImplementedError` on use), so it should not be changed.

## Fix

Keep the `importorskip`, then additionally skip unless the real v5 API is present. The real `transformers.core_model_loading.WeightConverter` exposes `target_patterns`, a `__slots__` descriptor inherited from `WeightTransform`, which the inert stub does not have:

```python
if not hasattr(_core_model_loading.WeightConverter, "target_patterns"):
    pytest.skip(..., allow_module_level=True)
```

A genuine transformers v5 environment still runs all the tests; the transformers 4.x + unsloth-stub environment now skips cleanly instead of erroring.

## Verification

Local run on transformers 4.57.6 with unsloth loaded (stub injected):

```
$ python -m pytest tests/test_moe_bnb4bit_per_expert_conversions.py -q
1 skipped in 0.03s
```

Previously this errored on all six collected tests.