### PR TITLE
Add MLXTrainer eval compute_metrics support

### DIFF
--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -490,6 +490,110 @@ def test_evaluate_dict_eval_datasets_records_split_metrics():
     assert trainer.model.modes == ["eval", "train"]
 
 
+def test_evaluate_compute_metrics_pads_and_prefixes_without_metal():
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    class Model:
+        def eval(self):
+            pass
+
+        def train(self):
+            pass
+
+        def __call__(self, input_ids):
+            shape = (input_ids.shape[0], input_ids.shape[1], 8)
+            return {"logits": mx.zeros(shape)}
+
+    seen = {}
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model = Model()
+    trainer.stop_requested = False
+
+    def preprocess(logits, labels):
+        seen["last_logits_shape"] = tuple(logits.shape)
+        seen["last_labels_shape"] = tuple(labels.shape)
+        return labels
+
+    def compute_metrics(prediction):
+        seen["prediction_type"] = type(prediction).__name__
+        seen["predictions"] = prediction.predictions.tolist()
+        seen["labels"] = prediction.label_ids.tolist()
+        return {"rows": prediction.label_ids.shape[0], "loss": 123.0}
+
+    trainer.preprocess_logits_for_metrics = preprocess
+    trainer.compute_metrics = compute_metrics
+
+    def loss_fn(_model, _batch, _lengths, _labels):
+        return mx.array(1.0), mx.array(2)
+
+    loss, _ppl = trainer._evaluate(
+        [
+            (
+                mx.array([[0, 1, 2, 3]]),
+                mx.array([[1, 4]]),
+                mx.array([[0, 1, 2, 3]]),
+            ),
+            (
+                mx.array([[4, 5, 0]]),
+                mx.array([[0, 2]]),
+                mx.array([[4, 5, 0]]),
+            ),
+        ],
+        loss_fn,
+        is_vlm=False,
+    )
+
+    assert loss == pytest.approx(1.0)
+    assert seen["prediction_type"] == "EvalPrediction"
+    assert seen["last_logits_shape"] == (1, 3, 8)
+    assert seen["last_labels_shape"] == (1, 3)
+    assert seen["predictions"] == [[-100, 1, 2, 3], [4, 5, -100, -100]]
+    assert seen["labels"] == [[-100, 1, 2, 3], [4, 5, -100, -100]]
+    assert trainer._last_eval_metrics["eval_rows"] == 2
+    assert trainer._last_eval_metrics["eval_loss"] == pytest.approx(1.0)
+
+
+def test_metric_chunk_concat_handles_scalar_payloads():
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    result = MLXTrainer._pad_and_concat_metric_chunks(
+        [mx.array(1.0), mx.array(2.0)]
+    )
+
+    assert result.tolist() == [1.0, 2.0]
+
+
+def test_metric_chunk_concat_handles_mapping_payloads():
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    result = MLXTrainer._pad_and_concat_metric_chunks(
+        [
+            {"scores": mx.array([[1, 2]])},
+            {"scores": mx.array([[3]])},
+        ]
+    )
+
+    assert result["scores"].tolist() == [[1, 2], [3, -100]]
+
+
+def test_metric_logits_extractor_accepts_mapping_outputs():
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    logits = mx.array([1, 2, 3])
+    hidden = mx.array([4, 5, 6])
+
+    assert MLXTrainer._extract_metric_logits({"logits": logits}) is logits
+    assert MLXTrainer._extract_metric_logits({"loss": mx.array(0.0), "hidden": hidden}) is hidden
+
+
 def test_vlm_cce_prefers_collated_position_ids_for_cuda_parity():
     import inspect
     from unsloth_zoo.mlx import utils as mlx_utils

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -70,6 +70,213 @@ def _assert_history(trainer, min_steps):
     return hist
 
 
+def _callback_batch():
+    """Build a tiny labeled MLX batch for callback lifecycle tests."""
+    tokens = mx.array([[0, 1, 2, 3]], dtype=mx.int32)
+    return tokens, mx.array([[0, 4]], dtype=mx.int32), tokens
+
+
+def _callback_trainer(
+    tmp_path,
+    callbacks,
+    max_steps=3,
+    eval_steps=1,
+    logging_steps=1,
+    with_eval=False,
+):
+    """Create a minimal MLXTrainer with prebuilt batches for callback tests."""
+    import mlx.nn as nn
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    class TinyLM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed = nn.Embedding(8, 4)
+            self.lm_head = nn.Linear(4, 8, bias=False)
+
+        def __call__(self, input_ids):
+            return self.lm_head(self.embed(input_ids))
+
+    trainer = MLXTrainer(
+        model=TinyLM(),
+        tokenizer=None,
+        train_dataset=[],
+        eval_dataset=[{}] if (eval_steps or with_eval) else None,
+        args=MLXTrainingConfig(
+            max_steps=max_steps,
+            per_device_train_batch_size=1,
+            gradient_accumulation_steps=1,
+            learning_rate=1e-4,
+            logging_steps=logging_steps,
+            eval_steps=eval_steps,
+            output_dir=str(tmp_path),
+            use_cce=False,
+            compile=False,
+            gradient_checkpointing=False,
+            report_to="none",
+        ),
+        callbacks=callbacks,
+    )
+    trainer._batches = [_callback_batch()]
+    if eval_steps or with_eval:
+        trainer._eval_batches_labeled = [_callback_batch()]
+    trainer._saved = []
+    trainer.save_model = lambda output_dir=None: trainer._saved.append(
+        output_dir or trainer.args.output_dir
+    )
+    return trainer
+
+
+@metal_only
+def test_hf_callbacks_receive_mlx_trainer_lifecycle(tmp_path):
+    from transformers import TrainerCallback
+
+    class Recorder(TrainerCallback):
+        def __init__(self):
+            self.events, self.eval_metrics = [], None
+
+        def on_init_end(self, args, state, control, **_kwargs):
+            self.events.append(("init", state.global_step, args.eval_strategy))
+
+        def on_train_begin(self, args, state, control, **kwargs):
+            self.events.append((
+                "train_begin",
+                state.global_step,
+                kwargs["train_dataloader"] is not None,
+                kwargs["eval_dataloader"] is not None,
+            ))
+
+        def on_step_begin(self, args, state, control, **_kwargs):
+            self.events.append(("step_begin", state.global_step))
+
+        def on_optimizer_step(self, args, state, control, **_kwargs):
+            self.events.append(("optimizer", state.global_step))
+
+        def on_step_end(self, args, state, control, **_kwargs):
+            self.events.append(("step_end", state.global_step))
+
+        def on_log(self, args, state, control, logs, **_kwargs):
+            self.events.append(("log", state.global_step, "loss" in logs))
+
+        def on_save(self, args, state, control, **_kwargs):
+            self.events.append(("save", state.global_step))
+
+        def on_train_end(self, args, state, control, **_kwargs):
+            self.events.append(("train_end", state.global_step))
+
+        def on_epoch_begin(self, args, state, control, **_kwargs):
+            self.events.append(("epoch_begin", state.epoch))
+
+        def on_epoch_end(self, args, state, control, **_kwargs):
+            self.events.append(("epoch_end", state.epoch))
+
+        def on_evaluate(self, args, state, control, metrics, **_kwargs):
+            self.eval_metrics = dict(metrics)
+            self.events.append(("eval", state.global_step))
+
+    class ClassCallback(TrainerCallback):
+        calls = []
+
+        def on_train_begin(self, args, state, control, **_kwargs):
+            type(self).calls.append(state.global_step)
+
+    recorder = Recorder()
+    ClassCallback.calls = []
+    trainer = _callback_trainer(tmp_path, [recorder, ClassCallback])
+    step_calls, eval_calls = [], []
+    trainer.add_step_callback(lambda step, *_args: step_calls.append(step))
+    trainer.add_eval_callback(lambda step, *_args: eval_calls.append(step))
+    output = trainer.train()
+    names = {event[0] for event in recorder.events}
+    assert {
+        "init", "train_begin", "optimizer", "step_end", "log", "eval",
+        "save", "train_end", "epoch_begin", "epoch_end",
+    } <= names
+    assert recorder.events[0] == ("init", 0, "steps")
+    assert ("train_begin", 0, True, False) in recorder.events
+    assert recorder.eval_metrics["eval_loss"] >= 0
+    assert ClassCallback.calls == [0]
+    assert step_calls == [1, 2, 3]
+    assert eval_calls == [1, 2, 3]
+    assert trainer._saved == [str(tmp_path)]
+    assert output.global_step == 3
+
+
+@metal_only
+def test_hf_callback_control_can_stop_mlx_training(tmp_path):
+    from transformers import TrainerCallback
+
+    class StopAfterFirstStep(TrainerCallback):
+        def __init__(self):
+            self.events = []
+
+        def on_step_end(self, args, state, control, **_kwargs):
+            self.events.append(("step_end", state.global_step))
+            control.should_training_stop = state.global_step == 1
+            return control
+
+        def on_epoch_end(self, args, state, control, **_kwargs):
+            self.events.append(("epoch_end", state.global_step, state.epoch))
+
+    callback = StopAfterFirstStep()
+    output = _callback_trainer(tmp_path, [callback], max_steps=5, eval_steps=0).train()
+    assert output.global_step == 1
+    assert callback.events == [("step_end", 1)]
+
+
+@metal_only
+def test_hf_callback_control_can_force_log_and_eval(tmp_path):
+    from transformers import DefaultFlowCallback, EarlyStoppingCallback, TrainerCallback
+
+    class RequestLogAndEval(TrainerCallback):
+        def __init__(self):
+            self.logs, self.evals = [], []
+
+        def on_epoch_end(self, args, state, control, **_kwargs):
+            control.should_log = True
+            control.should_evaluate = True
+            return control
+
+        def on_log(self, args, state, control, logs, **_kwargs):
+            self.logs.append(dict(logs))
+
+        def on_evaluate(self, args, state, control, metrics, **_kwargs):
+            self.evals.append(dict(metrics))
+
+    callback = RequestLogAndEval()
+    trainer = _callback_trainer(
+        tmp_path,
+        [callback, DefaultFlowCallback, EarlyStoppingCallback(early_stopping_patience=1)],
+        max_steps=2,
+        eval_steps=0,
+        logging_steps=0,
+        with_eval=True,
+    )
+    trainer.args.metric_for_best_model = "loss"
+    trainer.args.eval_strategy = "epoch"
+    trainer.train()
+
+    assert any("loss" in logs for logs in callback.logs)
+    assert any("eval_loss" in logs for logs in callback.logs)
+    assert callback.evals and "eval_loss" in callback.evals[-1]
+    assert trainer.state.best_metric == callback.evals[-1]["eval_loss"]
+
+
+@metal_only
+def test_mlx_trainer_import_keeps_torch_unloaded():
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    env = dict(os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[1]))
+    code = (
+        "import sys; "
+        "import unsloth_zoo.mlx.trainer; "
+        "raise SystemExit(1 if 'torch' in sys.modules else 0)"
+    )
+    subprocess.run([sys.executable, "-c", code], env=env, check=True)
+
+
 @metal_only
 def test_lora_sft_cce_default_clip(tmp_path):
     """Default config: CCE loss, leaf-norm clip default, decoupled decay."""

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -219,6 +219,35 @@ def test_hf_callback_control_can_stop_mlx_training(tmp_path):
 
 
 @metal_only
+def test_hf_callback_add_remove_pop_support_class_and_instance(tmp_path):
+    from transformers import TrainerCallback
+
+    class ClassCallback(TrainerCallback):
+        pass
+
+    class InstanceCallback(TrainerCallback):
+        pass
+
+    trainer = _callback_trainer(tmp_path, [])
+    instance = InstanceCallback()
+
+    trainer.add_callback(ClassCallback)
+    trainer.add_callback(instance)
+    assert any(isinstance(cb, ClassCallback) for cb in trainer.callback_handler.callbacks)
+    assert instance in trainer.callback_handler.callbacks
+
+    removed_class = trainer.pop_callback(ClassCallback)
+    assert isinstance(removed_class, ClassCallback)
+    assert not any(isinstance(cb, ClassCallback) for cb in trainer.callback_handler.callbacks)
+
+    trainer.remove_callback(instance)
+    assert instance not in trainer.callback_handler.callbacks
+
+    assert trainer.pop_callback(ClassCallback) is None
+    trainer.remove_callback(instance)
+
+
+@metal_only
 def test_hf_callback_control_can_force_log_and_eval(tmp_path):
     from transformers import TrainerCallback
 

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -76,6 +76,12 @@ def _callback_batch():
     return tokens, mx.array([[0, 4]], dtype=mx.int32), tokens
 
 
+def _short_callback_batch():
+    """Build a shorter labeled MLX batch for eval padding tests."""
+    tokens = mx.array([[4, 5, 0]], dtype=mx.int32)
+    return tokens, mx.array([[0, 2]], dtype=mx.int32), tokens
+
+
 def _callback_trainer(
     tmp_path,
     callbacks,
@@ -84,6 +90,8 @@ def _callback_trainer(
     logging_steps=1,
     save_steps=0,
     with_eval=False,
+    compute_metrics=None,
+    preprocess_logits_for_metrics=None,
 ):
     """Create a minimal MLXTrainer with prebuilt batches for callback tests."""
     import mlx.nn as nn
@@ -118,6 +126,8 @@ def _callback_trainer(
             report_to="none",
         ),
         callbacks=callbacks,
+        compute_metrics=compute_metrics,
+        preprocess_logits_for_metrics=preprocess_logits_for_metrics,
     )
     trainer._batches = [_callback_batch()]
     if eval_steps or with_eval:
@@ -314,6 +324,79 @@ def test_hf_callback_add_remove_pop_support_class_and_instance(tmp_path):
 
     assert trainer.pop_callback(ClassCallback) is None
     trainer.remove_callback(instance)
+
+
+@metal_only
+def test_mlx_compute_metrics_runs_on_eval_payload(tmp_path):
+    import numpy as np
+
+    seen = {}
+
+    def preprocess(logits, labels):
+        seen["logits_shape"] = tuple(logits.shape)
+        seen["labels_shape"] = tuple(labels.shape)
+        return mx.argmax(logits, axis=-1)
+
+    def compute_metrics(prediction):
+        seen["prediction_type"] = type(prediction).__name__
+        seen["predictions_shape"] = prediction.predictions.shape
+        seen["label_ids_shape"] = prediction.label_ids.shape
+        seen["label_ids"] = prediction.label_ids.tolist()
+        mask = prediction.label_ids != -100
+        accuracy = np.asarray(
+            prediction.predictions[mask] == prediction.label_ids[mask]
+        ).mean()
+        seen["accuracy"] = float(accuracy)
+        return {"token_accuracy": accuracy, "loss": 123.0}
+
+    trainer = _callback_trainer(
+        tmp_path,
+        [],
+        max_steps=1,
+        eval_steps=1,
+        compute_metrics=compute_metrics,
+        preprocess_logits_for_metrics=preprocess,
+    )
+    trainer._eval_batches_labeled = [_callback_batch(), _short_callback_batch()]
+    trainer.train()
+
+    assert seen["prediction_type"] == "EvalPrediction"
+    assert seen["logits_shape"] == (1, 3, 8)
+    assert seen["labels_shape"] == (1, 3)
+    assert seen["predictions_shape"] == (2, 4)
+    assert seen["label_ids_shape"] == (2, 4)
+    assert seen["label_ids"] == [[0, 1, 2, 3], [4, 5, -100, -100]]
+    assert trainer._last_eval_metrics["eval_token_accuracy"] == seen["accuracy"]
+    assert trainer._last_eval_metrics["eval_loss"] != 123.0
+
+
+@metal_only
+def test_mlx_compute_metrics_prefixes_split_eval_metrics(tmp_path):
+    calls = []
+
+    def compute_metrics(prediction):
+        calls.append(prediction.label_ids.shape)
+        return {"rows": prediction.label_ids.shape[0], "loss": 123.0}
+
+    trainer = _callback_trainer(
+        tmp_path,
+        [],
+        max_steps=1,
+        eval_steps=1,
+        compute_metrics=compute_metrics,
+    )
+    trainer.eval_dataset = {"alpha": [{}], "beta": [{}]}
+    trainer._eval_batches_labeled = {
+        "alpha": [_callback_batch()],
+        "beta": [_callback_batch()],
+    }
+    trainer.train()
+
+    assert calls == [(1, 4), (1, 4)]
+    assert trainer._last_eval_metrics["eval_alpha_rows"] == 1
+    assert trainer._last_eval_metrics["eval_beta_rows"] == 1
+    assert trainer._last_eval_metrics["eval_alpha_loss"] != 123.0
+    assert trainer._last_eval_metrics["eval_beta_loss"] != 123.0
 
 
 @metal_only

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -143,7 +143,6 @@ def test_hf_callbacks_receive_mlx_trainer_lifecycle(tmp_path):
                 "train_begin",
                 state.global_step,
                 kwargs["train_dataloader"] is not None,
-                kwargs["eval_dataloader"] is not None,
             ))
 
         def on_step_begin(self, args, state, control, **_kwargs):
@@ -183,9 +182,6 @@ def test_hf_callbacks_receive_mlx_trainer_lifecycle(tmp_path):
     recorder = Recorder()
     ClassCallback.calls = []
     trainer = _callback_trainer(tmp_path, [recorder, ClassCallback])
-    step_calls, eval_calls = [], []
-    trainer.add_step_callback(lambda step, *_args: step_calls.append(step))
-    trainer.add_eval_callback(lambda step, *_args: eval_calls.append(step))
     output = trainer.train()
     names = {event[0] for event in recorder.events}
     assert {
@@ -193,11 +189,9 @@ def test_hf_callbacks_receive_mlx_trainer_lifecycle(tmp_path):
         "save", "train_end", "epoch_begin", "epoch_end",
     } <= names
     assert recorder.events[0] == ("init", 0, "steps")
-    assert ("train_begin", 0, True, False) in recorder.events
+    assert ("train_begin", 0, True) in recorder.events
     assert recorder.eval_metrics["eval_loss"] >= 0
     assert ClassCallback.calls == [0]
-    assert step_calls == [1, 2, 3]
-    assert eval_calls == [1, 2, 3]
     assert trainer._saved == [str(tmp_path)]
     assert output.global_step == 3
 
@@ -221,45 +215,73 @@ def test_hf_callback_control_can_stop_mlx_training(tmp_path):
     callback = StopAfterFirstStep()
     output = _callback_trainer(tmp_path, [callback], max_steps=5, eval_steps=0).train()
     assert output.global_step == 1
-    assert callback.events == [("step_end", 1)]
+    assert ("step_end", 1) in callback.events
 
 
 @metal_only
 def test_hf_callback_control_can_force_log_and_eval(tmp_path):
-    from transformers import DefaultFlowCallback, EarlyStoppingCallback, TrainerCallback
+    from transformers import TrainerCallback
 
     class RequestLogAndEval(TrainerCallback):
         def __init__(self):
             self.logs, self.evals = [], []
 
-        def on_epoch_end(self, args, state, control, **_kwargs):
-            control.should_log = True
-            control.should_evaluate = True
+        def on_step_end(self, args, state, control, **_kwargs):
+            if state.global_step == 1:
+                control.should_log = True
+                control.should_evaluate = True
             return control
 
         def on_log(self, args, state, control, logs, **_kwargs):
-            self.logs.append(dict(logs))
+            self.logs.append((state.global_step, dict(logs)))
 
         def on_evaluate(self, args, state, control, metrics, **_kwargs):
-            self.evals.append(dict(metrics))
+            self.evals.append((state.global_step, dict(metrics)))
 
     callback = RequestLogAndEval()
-    trainer = _callback_trainer(
+    _callback_trainer(
         tmp_path,
-        [callback, DefaultFlowCallback, EarlyStoppingCallback(early_stopping_patience=1)],
+        [callback],
         max_steps=2,
         eval_steps=0,
         logging_steps=0,
         with_eval=True,
-    )
-    trainer.args.metric_for_best_model = "loss"
-    trainer.args.eval_strategy = "epoch"
+    ).train()
+
+    assert any(step == 1 and "loss" in logs for step, logs in callback.logs)
+    assert callback.evals and callback.evals[0][0] == 1
+    assert "eval_loss" in callback.evals[0][1]
+
+
+@metal_only
+def test_hf_eval_callbacks_see_prior_best_metric(tmp_path):
+    from transformers import TrainerCallback
+
+    class BestMetricRecorder(TrainerCallback):
+        def __init__(self):
+            self.best_before_eval = []
+
+        def on_evaluate(self, args, state, control, metrics, **_kwargs):
+            self.best_before_eval.append(state.best_metric)
+
+    callback = BestMetricRecorder()
+    trainer = _callback_trainer(tmp_path, [callback], max_steps=2, eval_steps=1)
+    eval_losses = iter((2.0, 3.0))
+
+    def fake_evaluate(_eval_batches, _loss_fn, is_vlm=False):
+        loss = next(eval_losses)
+        trainer._last_eval_metrics = {
+            "eval_loss": loss,
+            "eval_perplexity": 1.0,
+        }
+        return loss, 1.0
+
+    trainer._evaluate = fake_evaluate
     trainer.train()
 
-    assert any("loss" in logs for logs in callback.logs)
-    assert any("eval_loss" in logs for logs in callback.logs)
-    assert callback.evals and "eval_loss" in callback.evals[-1]
-    assert trainer.state.best_metric == callback.evals[-1]["eval_loss"]
+    assert callback.best_before_eval == [None, 2.0]
+    assert trainer.state.best_metric == 2.0
+    assert trainer.state.best_global_step == 1
 
 
 @metal_only

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -82,6 +82,7 @@ def _callback_trainer(
     max_steps=3,
     eval_steps=1,
     logging_steps=1,
+    save_steps=0,
     with_eval=False,
 ):
     """Create a minimal MLXTrainer with prebuilt batches for callback tests."""
@@ -109,6 +110,7 @@ def _callback_trainer(
             learning_rate=1e-4,
             logging_steps=logging_steps,
             eval_steps=eval_steps,
+            save_steps=save_steps,
             output_dir=str(tmp_path),
             use_cce=False,
             compile=False,
@@ -139,6 +141,11 @@ def test_hf_callbacks_receive_mlx_trainer_lifecycle(tmp_path):
             self.events.append(("init", state.global_step, args.eval_strategy))
 
         def on_train_begin(self, args, state, control, **kwargs):
+            config = args.to_dict()
+            assert config["output_dir"] == str(tmp_path)
+            assert args.logging_dir == os.path.join(str(tmp_path), "runs")
+            assert args.run_name == str(tmp_path)
+            assert '"output_dir"' in args.to_json_string()
             self.events.append((
                 "train_begin",
                 state.global_step,
@@ -186,7 +193,7 @@ def test_hf_callbacks_receive_mlx_trainer_lifecycle(tmp_path):
     names = {event[0] for event in recorder.events}
     assert {
         "init", "train_begin", "optimizer", "step_end", "log", "eval",
-        "save", "train_end", "epoch_begin", "epoch_end",
+        "train_end", "epoch_begin", "epoch_end",
     } <= names
     assert recorder.events[0] == ("init", 0, "steps")
     assert ("train_begin", 0, True) in recorder.events
@@ -194,6 +201,38 @@ def test_hf_callbacks_receive_mlx_trainer_lifecycle(tmp_path):
     assert ClassCallback.calls == [0]
     assert trainer._saved == [str(tmp_path)]
     assert output.global_step == 3
+
+
+@metal_only
+def test_hf_callback_on_save_only_fires_for_checkpoints(tmp_path, monkeypatch):
+    from pathlib import Path
+    from transformers import TrainerCallback
+    import unsloth_zoo.mlx.trainer as mlx_trainer
+
+    class SaveRecorder(TrainerCallback):
+        def __init__(self):
+            self.saves = []
+
+        def on_save(self, args, state, control, **_kwargs):
+            self.saves.append((state.global_step, Path(args.output_dir)))
+
+    def fake_save_trainable_adapters(_model, output_dir):
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        mlx_trainer, "save_trainable_adapters", fake_save_trainable_adapters,
+    )
+    monkeypatch.setattr(mlx_trainer, "save_optimizer_state", lambda *_args: None)
+    monkeypatch.setattr(mlx_trainer, "save_trainer_state", lambda *_args: None)
+
+    callback = SaveRecorder()
+    trainer = _callback_trainer(
+        tmp_path, [callback], max_steps=1, eval_steps=0, save_steps=1,
+    )
+    trainer.train()
+
+    assert callback.saves == [(1, tmp_path)]
+    assert trainer._saved == [str(tmp_path)]
 
 
 @metal_only
@@ -216,6 +255,36 @@ def test_hf_callback_control_can_stop_mlx_training(tmp_path):
     output = _callback_trainer(tmp_path, [callback], max_steps=5, eval_steps=0).train()
     assert output.global_step == 1
     assert ("step_end", 1) in callback.events
+
+
+@metal_only
+def test_hf_callback_stop_allows_same_step_eval(tmp_path):
+    from transformers import TrainerCallback
+
+    class StopAndEval(TrainerCallback):
+        def __init__(self):
+            self.evals = []
+
+        def on_step_end(self, args, state, control, **_kwargs):
+            control.should_evaluate = True
+            control.should_training_stop = True
+            return control
+
+        def on_evaluate(self, args, state, control, metrics, **_kwargs):
+            self.evals.append((state.global_step, metrics["eval_loss"]))
+
+    callback = StopAndEval()
+    output = _callback_trainer(
+        tmp_path,
+        [callback],
+        max_steps=1,
+        eval_steps=0,
+        with_eval=True,
+    ).train()
+
+    assert output.global_step == 1
+    assert len(callback.evals) == 1
+    assert callback.evals[0][0] == 1
 
 
 @metal_only

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -37,9 +37,11 @@ Usage mirrors TRL notebooks:
 """
 
 from dataclasses import MISSING, asdict, dataclass, field, fields, is_dataclass
+from collections.abc import Mapping
 import concurrent.futures
 import json
 import math
+import numpy as np
 import os
 import random
 import time
@@ -279,6 +281,7 @@ from .utils import (
     iter_mlx_lora_modules,
     apply_gradient_checkpointing,
     remove_gradient_checkpointing,
+    _normalize_cce_label_dtype,
     _is_vlm_model,
     _get_text_model,
 )
@@ -952,6 +955,8 @@ class MLXTrainer:
         formatting_func=None,
         processor=None,
         callbacks=None,
+        compute_metrics=None,
+        preprocess_logits_for_metrics=None,
     ):
         self.model = model
         self.tokenizer = tokenizer
@@ -960,6 +965,8 @@ class MLXTrainer:
         self._mlx_train_dataset_for_batches = train_dataset
         self.eval_dataset = eval_dataset
         self.formatting_func = formatting_func
+        self.compute_metrics = compute_metrics
+        self.preprocess_logits_for_metrics = preprocess_logits_for_metrics
         # Use args or defaults
         self.args = args or MLXTrainingConfig()
 
@@ -1533,10 +1540,156 @@ class MLXTrainer:
                 unsupported.append((name, tuple(getattr(value, "shape", ()))))
         return unsupported
 
-    def _evaluate_batch_totals(self, eval_batches, loss_fn, is_vlm=False):
+    @staticmethod
+    def _metric_payload_to_numpy(value):
+        """Convert MLX metric payloads to NumPy arrays for HF-style metrics."""
+        if isinstance(value, mx.array):
+            mx.eval(value)
+            if value.dtype == mx.bfloat16:
+                value = value.astype(mx.float32)
+                mx.eval(value)
+            return np.array(value)
+        if isinstance(value, tuple):
+            return tuple(MLXTrainer._metric_payload_to_numpy(item) for item in value)
+        if isinstance(value, list):
+            return [MLXTrainer._metric_payload_to_numpy(item) for item in value]
+        return value
+
+    @classmethod
+    def _pad_and_concat_metric_chunks(cls, chunks, padding_index=-100):
+        """Pad variable-length per-batch metric payloads and concatenate rows."""
+        if not chunks:
+            return None
+        first = chunks[0]
+        if isinstance(first, Mapping):
+            return {
+                key: cls._pad_and_concat_metric_chunks(
+                    [chunk[key] for chunk in chunks],
+                    padding_index=padding_index,
+                )
+                for key in first
+            }
+        if isinstance(first, tuple):
+            return tuple(
+                cls._pad_and_concat_metric_chunks(
+                    [chunk[index] for chunk in chunks],
+                    padding_index=padding_index,
+                )
+                for index in range(len(first))
+            )
+        if isinstance(first, list):
+            return [
+                cls._pad_and_concat_metric_chunks(
+                    [chunk[index] for chunk in chunks],
+                    padding_index=padding_index,
+                )
+                for index in range(len(first))
+            ]
+
+        arrays = [cls._metric_payload_to_numpy(chunk) for chunk in chunks]
+        if arrays[0] is None:
+            return None
+        if arrays[0].ndim == 0:
+            return np.stack(arrays, axis=0)
+        if arrays[0].ndim < 2:
+            return np.concatenate(arrays, axis=0)
+
+        max_length = max(array.shape[1] for array in arrays)
+        padded = []
+        for array in arrays:
+            if array.shape[1] == max_length:
+                padded.append(array)
+                continue
+            pad_width = [(0, 0)] * array.ndim
+            pad_width[1] = (0, max_length - array.shape[1])
+            padded.append(
+                np.pad(array, pad_width, mode="constant", constant_values=padding_index)
+            )
+        return np.concatenate(padded, axis=0)
+
+    @staticmethod
+    def _prefix_metric_keys(metrics, metric_key_prefix):
+        """Apply HF Trainer's eval metric prefix convention."""
+        prefixed = {}
+        prefix = f"{metric_key_prefix}_"
+        for key, value in metrics.items():
+            target = key if key.startswith(prefix) else f"{prefix}{key}"
+            prefixed[target] = value
+        return prefixed
+
+    def _labels_for_text_metrics(self, batch, lengths, labels):
+        """Build full-sequence label_ids matching HF causal-LM metric inputs."""
+        metric_labels = labels if labels is not None else batch
+        metric_labels = _normalize_cce_label_dtype(metric_labels)
+        positions = mx.arange(batch.shape[1]).reshape(1, -1)
+        valid = mx.logical_and(
+            positions >= lengths[:, 0:1],
+            positions < lengths[:, 1:2],
+        )
+        ignore = metric_labels * 0 - 100
+        return mx.where(valid, metric_labels, ignore)
+
+    @staticmethod
+    def _extract_metric_logits(output):
+        """Return logits from common MLX model output shapes."""
+        if hasattr(output, "logits"):
+            return output.logits
+        if isinstance(output, Mapping):
+            if "logits" in output:
+                return output["logits"]
+            values = tuple(value for key, value in output.items() if key != "loss")
+            return values[0] if len(values) == 1 else values
+        if isinstance(output, (tuple, list)):
+            return output[0]
+        return output
+
+    def _text_metric_prediction_step(self, batch, lengths, labels):
+        """Run a text eval-only forward pass for compute_metrics payloads."""
+        metric_labels = self._labels_for_text_metrics(batch, lengths, labels)
+        logits = self._extract_metric_logits(self.model(batch))
+        preprocess = getattr(self, "preprocess_logits_for_metrics", None)
+        if preprocess is not None:
+            logits = preprocess(logits, metric_labels)
+        return logits, metric_labels
+
+    def _compute_metric_values(self, prediction_chunks, label_chunks, metric_key_prefix):
+        """Call compute_metrics with accumulated NumPy EvalPrediction payloads."""
+        compute_metrics = getattr(self, "compute_metrics", None)
+        if compute_metrics is None or not prediction_chunks:
+            return {}
+        from transformers.trainer_utils import EvalPrediction, denumpify_detensorize
+
+        predictions = self._pad_and_concat_metric_chunks(prediction_chunks)
+        label_ids = self._pad_and_concat_metric_chunks(label_chunks)
+        metrics = compute_metrics(
+            EvalPrediction(predictions=predictions, label_ids=label_ids)
+        )
+        if metrics is None:
+            metrics = {}
+        metrics = denumpify_detensorize(metrics)
+        return self._prefix_metric_keys(metrics, metric_key_prefix)
+
+    def _evaluate_batch_totals(
+        self,
+        eval_batches,
+        loss_fn,
+        is_vlm=False,
+        metric_key_prefix=None,
+    ):
         """Accumulate weighted loss totals for one flat eval batch stream."""
         all_losses = mx.array(0.0)
         ntokens = mx.array(0)
+        prediction_chunks = []
+        label_chunks = []
+        collect_metrics = (
+            getattr(self, "compute_metrics", None) is not None
+            and metric_key_prefix is not None
+        )
+        if collect_metrics and is_vlm:
+            raise NotImplementedError(
+                "Unsloth MLX: compute_metrics is currently implemented for text "
+                "MLXTrainer eval only; VLM metrics are not supported yet."
+            )
 
         for batch_data in eval_batches:
             if self.stop_requested:
@@ -1546,11 +1699,22 @@ class MLXTrainer:
             else:
                 batch, lengths, labels = batch_data
                 loss, ntoks = loss_fn(self.model, batch, lengths, labels)
+                if collect_metrics:
+                    predictions, label_ids = self._text_metric_prediction_step(
+                        batch, lengths, labels,
+                    )
+                    prediction_chunks.append(predictions)
+                    label_chunks.append(label_ids)
             all_losses += loss * ntoks
             ntokens += ntoks
             mx.eval(all_losses, ntokens)
 
-        return all_losses, ntokens
+        metric_values = self._compute_metric_values(
+            prediction_chunks,
+            label_chunks,
+            metric_key_prefix,
+        )
+        return all_losses, ntokens, metric_values
 
     def _evaluate(self, eval_batches, loss_fn, is_vlm=False):
         """Run evaluation loop.
@@ -1564,8 +1728,10 @@ class MLXTrainer:
             all_losses = mx.array(0.0)
             ntokens = mx.array(0)
             for split_name, split_batches in eval_batches.items():
-                split_losses, split_tokens = self._evaluate_batch_totals(
+                split_prefix = f"eval_{split_name}"
+                split_losses, split_tokens, split_metric_values = self._evaluate_batch_totals(
                     split_batches, loss_fn, is_vlm=is_vlm,
+                    metric_key_prefix=split_prefix,
                 )
                 all_losses += split_losses
                 ntokens += split_tokens
@@ -1575,19 +1741,22 @@ class MLXTrainer:
                     if split_tokens.item() > 0 else 0.0
                 )
                 split_ppl = math.exp(min(split_loss, 100))
-                split_prefix = f"eval_{split_name}"
+                metrics.update(split_metric_values)
                 metrics[f"{split_prefix}_loss"] = split_loss
                 metrics[f"{split_prefix}_perplexity"] = split_ppl
                 if self.stop_requested:
                     break
         else:
-            all_losses, ntokens = self._evaluate_batch_totals(
-                eval_batches, loss_fn, is_vlm=is_vlm,
+            all_losses, ntokens, metric_values = self._evaluate_batch_totals(
+                eval_batches, loss_fn, is_vlm=is_vlm, metric_key_prefix="eval",
             )
+            metrics.update(metric_values)
 
         self.model.train()
         avg_loss = (all_losses / ntokens).item() if ntokens.item() > 0 else 0.0
         perplexity = math.exp(min(avg_loss, 100))
+        # Match HF Trainer ordering: trainer-owned loss metrics win over
+        # user-returned metric names such as "loss".
         metrics["eval_loss"] = avg_loss
         metrics["eval_perplexity"] = perplexity
         self._last_eval_metrics = metrics

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -70,18 +70,17 @@ class MLXTrainOutput(dict):
 
 
 @dataclass
-class TrainerControl:
+class _MLXTrainerControl:
     """Torch-free subset of Hugging Face TrainerControl used by callbacks."""
 
     should_training_stop: bool = False
-    should_epoch_stop: bool = False
     should_save: bool = False
     should_evaluate: bool = False
     should_log: bool = False
 
 
 @dataclass
-class TrainerState:
+class _MLXTrainerState:
     """Torch-free subset of Hugging Face TrainerState used by callbacks."""
 
     epoch: float | None = None
@@ -832,8 +831,6 @@ class MLXTrainingConfig:
 
     # Eval
     eval_steps: int = 0  # 0 = disabled
-    eval_strategy: str | None = None  # None = derive from eval_steps
-    eval_delay: float = 0.0
     load_best_model_at_end: bool = False
     metric_for_best_model: str = "eval_loss"
     greater_is_better: bool = False
@@ -1012,8 +1009,8 @@ class MLXTrainer:
             optimizer=None,
             lr_scheduler=None,
         )
-        self.state = TrainerState()
-        self.control = TrainerControl()
+        self.state = _MLXTrainerState()
+        self.control = _MLXTrainerControl()
         self.control = self.callback_handler.call_event(
             "on_init_end",
             self.args, self.state, self.control,
@@ -1071,13 +1068,6 @@ class MLXTrainer:
         if not hasattr(args, "include_num_input_tokens_seen"):
             args.include_num_input_tokens_seen = False
 
-    @staticmethod
-    def _callback_interval_name(value):
-        """Normalize HF interval enum/string values for callback scheduling."""
-        value = getattr(value, "value", value)
-        value = str(value).lower()
-        return value.rsplit(".", 1)[-1]
-
     def _default_callback_eval_strategy(self):
         """Return the MLX-derived eval strategy for callback compatibility."""
         return (
@@ -1090,7 +1080,7 @@ class MLXTrainer:
         """Initialize TrainerState for HF callback lifecycle events."""
         args = self.args
         eval_steps = int(getattr(args, "eval_steps", 0) or 0)
-        self.state = TrainerState(
+        self.state = _MLXTrainerState(
             global_step=int(resume_step),
             max_steps=int(total_steps),
             logging_steps=int(getattr(args, "logging_steps", 0) or 0),
@@ -1102,7 +1092,7 @@ class MLXTrainer:
             is_local_process_zero=True,
             is_world_process_zero=True,
         )
-        self.control = TrainerControl()
+        self.control = _MLXTrainerControl()
 
     def _sync_callback_stop(self):
         """Mirror TrainerControl stop requests into MLXTrainer's loop flag."""
@@ -1171,11 +1161,8 @@ class MLXTrainer:
         return metric_name
 
     def _update_callback_best_metric(self, metrics):
-        """Update TrainerState.best_metric after on_evaluate, matching HF timing."""
-        metric_name = self._metric_for_best_model_name(
-            metrics,
-            require=False,
-        )
+        """Update TrainerState.best_metric after eval callbacks inspect prior state."""
+        metric_name = self._metric_for_best_model_name(metrics, require=False)
         if metric_name is None:
             return
         value = metrics[metric_name]
@@ -2507,7 +2494,6 @@ class MLXTrainer:
         def _run_callback_epoch_begin(epoch_value):
             """Dispatch one epoch-begin event at the requested epoch value."""
             self.state.epoch = epoch_value
-            self.control.should_epoch_stop = False
             self.control = self.callback_handler.call_event(
                 "on_epoch_begin",
                 args, self.state, self.control,
@@ -2880,19 +2866,10 @@ class MLXTrainer:
                 _run_training_log(current_step, grad_norm)
 
             # Eval
-            eval_strategy = self._callback_interval_name(
-                getattr(args, "eval_strategy", "no"),
-            )
-            eval_delay = float(getattr(args, "eval_delay", 0) or 0)
             should_eval = (
                 self.eval_dataset is not None
                 and (
-                    (
-                        eval_strategy == "steps"
-                        and args.eval_steps > 0
-                        and current_step % args.eval_steps == 0
-                        and current_step >= eval_delay
-                    )
+                    (args.eval_steps > 0 and current_step % args.eval_steps == 0)
                     or self.control.should_evaluate
                 )
             )
@@ -2908,8 +2885,6 @@ class MLXTrainer:
             if should_save:
                 _run_checkpoint(current_step)
 
-            if self.stop_requested:
-                break
             _maybe_callback_epoch_end(it, current_step, grad_norm)
             if self.stop_requested:
                 break

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -38,6 +38,7 @@ Usage mirrors TRL notebooks:
 
 from dataclasses import MISSING, asdict, dataclass, field, fields, is_dataclass
 import concurrent.futures
+import json
 import math
 import os
 import random
@@ -823,6 +824,8 @@ class MLXTrainingConfig:
     # Logging & output
     logging_steps: int = 1
     output_dir: str = "./outputs"
+    logging_dir: str | None = None
+    run_name: str | None = None
     report_to: str = "none"
     save_steps: int = 0  # 0 = only save at end
     save_total_limit: int = -1  # -1 = no limit
@@ -915,6 +918,21 @@ class MLXTrainingConfig:
         self._unsloth_mlx_warmup_steps_explicit = (
             "warmup_steps" in provided and not copied_default_warmup_with_ratio
         )
+
+    def to_dict(self):
+        """Return a TrainingArguments-style dict for integration callbacks."""
+        output = {}
+        for key, value in vars(self).items():
+            if is_dataclass(value):
+                value = asdict(value)
+            elif hasattr(value, "to_dict"):
+                value = value.to_dict()
+            output[key] = value
+        return output
+
+    def to_json_string(self):
+        """Serialize this config like TrainingArguments.to_json_string()."""
+        return json.dumps(self.to_dict(), indent=2, default=str)
 
 
 class MLXTrainer:
@@ -1065,6 +1083,10 @@ class MLXTrainer:
             args.eval_delay = 0
         if not hasattr(args, "include_num_input_tokens_seen"):
             args.include_num_input_tokens_seen = False
+        if getattr(args, "logging_dir", None) is None:
+            args.logging_dir = os.path.join(args.output_dir, "runs")
+        if getattr(args, "run_name", None) is None:
+            args.run_name = args.output_dir
 
     def _default_callback_eval_strategy(self):
         """Return the MLX-derived eval strategy for callback compatibility."""
@@ -1107,7 +1129,6 @@ class MLXTrainer:
             "on_log",
             self.args, self.state, self.control, logs=logs,
         )
-        self._sync_callback_stop()
 
     def _call_callback_evaluate(self, metrics):
         """Dispatch a Hugging Face on_evaluate callback event."""
@@ -1117,7 +1138,6 @@ class MLXTrainer:
             "on_evaluate",
             self.args, self.state, self.control, metrics=metrics,
         )
-        self._sync_callback_stop()
 
     def _call_callback_save(self):
         """Dispatch a Hugging Face on_save callback event."""
@@ -1126,7 +1146,6 @@ class MLXTrainer:
             "on_save",
             self.args, self.state, self.control,
         )
-        self._sync_callback_stop()
 
     def _callback_batches_per_epoch(self, batches):
         """Return the finite micro-batch count for one callback epoch."""
@@ -2514,9 +2533,9 @@ class MLXTrainer:
                 "on_epoch_end",
                 args, self.state, self.control,
             )
-            self._sync_callback_stop()
             if self.control.should_log or self.control.should_evaluate or self.control.should_save:
                 _run_callback_control_actions(current_step, grad_norm)
+            self._sync_callback_stop()
 
         def _run_training_log(current_step, grad_norm):
             """Emit one MLX/HF training log from accumulated loss counters."""
@@ -2683,7 +2702,7 @@ class MLXTrainer:
             print(f"  Saved checkpoint to {ckpt_dir}")
             if checkpoint_complete:
                 _prune_stale_checkpoints(args.output_dir, args.save_total_limit)
-            self._call_callback_save()
+                self._call_callback_save()
 
         def _run_callback_control_actions(current_step, grad_norm):
             """Run log/eval/save actions requested by callback control flags."""
@@ -2826,7 +2845,6 @@ class MLXTrainer:
                     "on_optimizer_step",
                     args, self.state, self.control,
                 )
-                self._sync_callback_stop()
             self.state.num_input_tokens_seen += int(toks.item())
             if batches_per_epoch:
                 self.state.epoch = it / batches_per_epoch
@@ -2851,7 +2869,6 @@ class MLXTrainer:
                 "on_step_end",
                 args, self.state, self.control,
             )
-            self._sync_callback_stop()
 
             # Logging
             logging_steps = int(getattr(args, "logging_steps", 0) or 0)
@@ -2884,6 +2901,7 @@ class MLXTrainer:
                 _run_checkpoint(current_step)
 
             _maybe_callback_epoch_end(it, current_step, grad_norm)
+            self._sync_callback_stop()
             if self.stop_requested:
                 break
             microstep = it
@@ -2918,7 +2936,6 @@ class MLXTrainer:
             print(f"Unsloth: skipped final save ({e})")
         else:
             print(f"Unsloth: Saved final adapters to {args.output_dir}")
-            self._call_callback_save()
 
         self.control = self.callback_handler.call_event(
             "on_train_end",

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -36,7 +36,7 @@ Usage mirrors TRL notebooks:
     trainer.train()
 """
 
-from dataclasses import MISSING, asdict, dataclass, fields, is_dataclass
+from dataclasses import MISSING, asdict, dataclass, field, fields, is_dataclass
 import concurrent.futures
 import math
 import os
@@ -67,6 +67,109 @@ class MLXTrainOutput(dict):
     @property
     def training_loss(self):
         return self.get("train_loss", 0.0)
+
+
+@dataclass
+class TrainerControl:
+    """Torch-free subset of Hugging Face TrainerControl used by callbacks."""
+
+    should_training_stop: bool = False
+    should_epoch_stop: bool = False
+    should_save: bool = False
+    should_evaluate: bool = False
+    should_log: bool = False
+
+
+@dataclass
+class TrainerState:
+    """Torch-free subset of Hugging Face TrainerState used by callbacks."""
+
+    epoch: float | None = None
+    global_step: int = 0
+    max_steps: int = 0
+    logging_steps: int = 500
+    eval_steps: int = 500
+    save_steps: int = 500
+    train_batch_size: int | None = None
+    num_train_epochs: int = 0
+    num_input_tokens_seen: int = 0
+    total_flos: float = 0
+    log_history: list = field(default_factory=list)
+    best_metric: float | None = None
+    best_global_step: int | None = None
+    best_model_checkpoint: str | None = None
+    is_local_process_zero: bool = True
+    is_world_process_zero: bool = True
+    is_hyper_param_search: bool = False
+    trial_name: str | None = None
+    trial_params: dict | None = None
+    stateful_callbacks: dict = field(default_factory=dict)
+
+
+class _MLXCallbackHandler:
+    """Small HF-compatible callback dispatcher that keeps MLX imports Torch-free."""
+
+    def __init__(self, callbacks, model, processing_class, optimizer, lr_scheduler):
+        self.callbacks = []
+        for callback in callbacks:
+            self.add_callback(callback)
+        self.model = model
+        self.processing_class = processing_class
+        self.optimizer = optimizer
+        self.lr_scheduler = lr_scheduler
+        self.train_dataloader = None
+        self.eval_dataloader = None
+
+    @property
+    def callback_list(self):
+        """Return callback class names for diagnostics."""
+        return "\n".join(cb.__class__.__name__ for cb in self.callbacks)
+
+    def add_callback(self, callback):
+        """Add a callback class or instance."""
+        self.callbacks.append(callback() if isinstance(callback, type) else callback)
+
+    def pop_callback(self, callback):
+        """Remove and return a callback class or instance."""
+        if isinstance(callback, type):
+            for cb in self.callbacks:
+                if isinstance(cb, callback):
+                    self.callbacks.remove(cb)
+                    return cb
+        else:
+            for cb in self.callbacks:
+                if cb == callback:
+                    self.callbacks.remove(cb)
+                    return cb
+        return None
+
+    def remove_callback(self, callback):
+        """Remove a callback class or instance."""
+        removed = self.pop_callback(callback)
+        if removed is None and not isinstance(callback, type):
+            self.callbacks.remove(callback)
+
+    def call_event(self, event, args, state, control, **kwargs):
+        """Dispatch one callback event and return the latest control object."""
+        for callback in self.callbacks:
+            method = getattr(callback, event, None)
+            if method is None:
+                continue
+            result = method(
+                args,
+                state,
+                control,
+                model=self.model,
+                processing_class=self.processing_class,
+                optimizer=self.optimizer,
+                lr_scheduler=self.lr_scheduler,
+                train_dataloader=self.train_dataloader,
+                eval_dataloader=self.eval_dataloader,
+                **kwargs,
+            )
+            if result is not None:
+                control = result
+        return control
 
 
 class _MLXTokenizedDatasetView:
@@ -729,6 +832,8 @@ class MLXTrainingConfig:
 
     # Eval
     eval_steps: int = 0  # 0 = disabled
+    eval_strategy: str | None = None  # None = derive from eval_steps
+    eval_delay: float = 0.0
     load_best_model_at_end: bool = False
     metric_for_best_model: str = "eval_loss"
     greater_is_better: bool = False
@@ -833,6 +938,7 @@ class MLXTrainer:
         args=None,
         formatting_func=None,
         processor=None,
+        callbacks=None,
     ):
         self.model = model
         self.tokenizer = tokenizer
@@ -898,6 +1004,20 @@ class MLXTrainer:
         self._batches = None  # Pre-created batches (skips internal batch creation)
         self._step_callbacks = []  # Callbacks called after each logged step
         self._eval_callbacks = []  # Callbacks called after each eval
+        self._ensure_callback_args_compat()
+        self.callback_handler = _MLXCallbackHandler(
+            callbacks or [],
+            model=self.model,
+            processing_class=self.processor or self.tokenizer,
+            optimizer=None,
+            lr_scheduler=None,
+        )
+        self.state = TrainerState()
+        self.control = TrainerControl()
+        self.control = self.callback_handler.call_event(
+            "on_init_end",
+            self.args, self.state, self.control,
+        )
         self.stop_requested = False  # Set True to stop training early
         self._best_metric = None
         self._best_step = None
@@ -921,6 +1041,154 @@ class MLXTrainer:
         fn(step, eval_loss, perplexity)
         """
         self._eval_callbacks.append(fn)
+
+    def add_callback(self, callback):
+        """Add a Hugging Face TrainerCallback class or instance."""
+        self.callback_handler.add_callback(callback)
+        self._ensure_callback_args_compat()
+
+    def remove_callback(self, callback):
+        """Remove a Hugging Face TrainerCallback class or instance."""
+        self.callback_handler.remove_callback(callback)
+
+    def pop_callback(self, callback):
+        """Remove and return a Hugging Face TrainerCallback class or instance."""
+        return self.callback_handler.pop_callback(callback)
+
+    def _ensure_callback_args_compat(self):
+        """Populate TrainingArguments-style fields read by common callbacks."""
+        args = self.args
+        if not hasattr(args, "logging_strategy"):
+            args.logging_strategy = "steps" if getattr(args, "logging_steps", 0) else "no"
+        if not hasattr(args, "eval_strategy") or getattr(args, "eval_strategy", None) is None:
+            args.eval_strategy = self._default_callback_eval_strategy()
+        if not hasattr(args, "save_strategy"):
+            args.save_strategy = "steps" if getattr(args, "save_steps", 0) else "no"
+        if not hasattr(args, "logging_first_step"):
+            args.logging_first_step = False
+        if not hasattr(args, "eval_delay"):
+            args.eval_delay = 0
+        if not hasattr(args, "include_num_input_tokens_seen"):
+            args.include_num_input_tokens_seen = False
+
+    @staticmethod
+    def _callback_interval_name(value):
+        """Normalize HF interval enum/string values for callback scheduling."""
+        value = getattr(value, "value", value)
+        value = str(value).lower()
+        return value.rsplit(".", 1)[-1]
+
+    def _default_callback_eval_strategy(self):
+        """Return the MLX-derived eval strategy for callback compatibility."""
+        return (
+            "steps"
+            if self.eval_dataset is not None and getattr(self.args, "eval_steps", 0)
+            else "no"
+        )
+
+    def _init_callback_state(self, total_steps, resume_step):
+        """Initialize TrainerState for HF callback lifecycle events."""
+        args = self.args
+        eval_steps = int(getattr(args, "eval_steps", 0) or 0)
+        self.state = TrainerState(
+            global_step=int(resume_step),
+            max_steps=int(total_steps),
+            logging_steps=int(getattr(args, "logging_steps", 0) or 0),
+            eval_steps=eval_steps,
+            save_steps=int(getattr(args, "save_steps", 0) or 0),
+            train_batch_size=int(getattr(args, "per_device_train_batch_size", 0) or 0),
+            num_train_epochs=max(0, int(getattr(args, "num_train_epochs", 0) or 0)),
+            log_history=[],
+            is_local_process_zero=True,
+            is_world_process_zero=True,
+        )
+        self.control = TrainerControl()
+
+    def _sync_callback_stop(self):
+        """Mirror TrainerControl stop requests into MLXTrainer's loop flag."""
+        if getattr(self.control, "should_training_stop", False):
+            self.stop_requested = True
+
+    def _call_callback_log(self, logs):
+        """Record and dispatch a Hugging Face on_log callback event."""
+        output = dict(logs)
+        output["step"] = self.state.global_step
+        self.state.log_history.append(output)
+        self.control.should_log = False
+        self.control = self.callback_handler.call_event(
+            "on_log",
+            self.args, self.state, self.control, logs=logs,
+        )
+        self._sync_callback_stop()
+
+    def _call_callback_evaluate(self, metrics):
+        """Dispatch a Hugging Face on_evaluate callback event."""
+        self._call_callback_log(dict(metrics))
+        self.control.should_evaluate = False
+        self.control = self.callback_handler.call_event(
+            "on_evaluate",
+            self.args, self.state, self.control, metrics=metrics,
+        )
+        self._sync_callback_stop()
+
+    def _call_callback_save(self):
+        """Dispatch a Hugging Face on_save callback event."""
+        self.control.should_save = False
+        self.control = self.callback_handler.call_event(
+            "on_save",
+            self.args, self.state, self.control,
+        )
+        self._sync_callback_stop()
+
+    def _callback_batches_per_epoch(self, batches):
+        """Return the finite micro-batch count for one callback epoch."""
+        if batches is None:
+            return None
+        total = len(batches)
+        if total <= 0:
+            return None
+        if getattr(self, "_prepared_batches_include_epochs", False):
+            epochs = int(getattr(self.args, "num_train_epochs", 0) or 0)
+            if epochs > 0 and total % epochs == 0:
+                return max(1, total // epochs)
+        return total
+
+    def _metric_for_best_model_name(self, metrics=None, require=False):
+        """Return the HF-normalized metric_for_best_model key."""
+        metric_name = getattr(self.args, "metric_for_best_model", None)
+        if not metric_name:
+            return None
+        metric_name = str(metric_name)
+        if not metric_name.startswith("eval_"):
+            metric_name = f"eval_{metric_name}"
+        if metrics is not None and metric_name not in metrics:
+            if require:
+                raise ValueError(
+                    f"metric_for_best_model={metric_name!r} not in eval "
+                    f"metrics; available: {sorted(metrics)}"
+                )
+            return None
+        return metric_name
+
+    def _update_callback_best_metric(self, metrics):
+        """Update TrainerState.best_metric after on_evaluate, matching HF timing."""
+        metric_name = self._metric_for_best_model_name(
+            metrics,
+            require=False,
+        )
+        if metric_name is None:
+            return
+        value = metrics[metric_name]
+        if value != value:
+            return
+        greater = bool(getattr(self.args, "greater_is_better", False))
+        improved = (
+            self.state.best_metric is None
+            or (value > self.state.best_metric if greater else value < self.state.best_metric)
+        )
+        if improved:
+            self.state.best_metric = value
+            self.state.best_global_step = self.state.global_step
 
     @staticmethod
     def _apply_compile_recommendations(args, decision):
@@ -1801,6 +2069,12 @@ class MLXTrainer:
                     f"silently restart from step 0."
                 ) from e
 
+        self.callback_handler.optimizer = optimizer
+        self.callback_handler.lr_scheduler = getattr(self, "_lr_schedule", None)
+        self.callback_handler.processing_class = self.processor or self.tokenizer
+        self._ensure_callback_args_compat()
+        self._init_callback_state(total_steps, _resume_step)
+
         # Build loss+grad function — returns ((loss, ntoks), grads)
         loss_and_grad_fn = nn.value_and_grad(model, loss_fn)
 
@@ -2112,7 +2386,12 @@ class MLXTrainer:
         # Prepare eval batches
         eval_batches = None
         text_completion_only_loss = _text_completion_only_loss_arg(args)
-        if args.eval_steps > 0 and self.eval_dataset is not None:
+
+        def _prepare_eval_batches():
+            """Materialize eval batches the first time evaluation is requested."""
+            nonlocal eval_batches
+            if eval_batches is not None or self.eval_dataset is None:
+                return eval_batches
             eval_batch_size = (
                 getattr(args, "per_device_eval_batch_size", None)
                 or args.per_device_train_batch_size
@@ -2165,13 +2444,23 @@ class MLXTrainer:
                     }
                 else:
                     eval_batches = _create_eval_batches(self.eval_dataset)
-            if eval_batches:
+            self.callback_handler.eval_dataloader = eval_batches
+            if eval_batches and args.eval_steps > 0:
                 eval_batch_count = (
                     sum(len(value) for value in eval_batches.values())
                     if isinstance(eval_batches, dict) else len(eval_batches)
                 )
                 print(f"Unsloth: Eval enabled every {args.eval_steps} steps "
                       f"({eval_batch_count} eval batches).")
+            return eval_batches
+
+        self.callback_handler.train_dataloader = batches if batches is not None else batch_iter
+        self.control.should_training_stop = False
+        self.control = self.callback_handler.call_event(
+            "on_train_begin",
+            args, self.state, self.control,
+        )
+        self._sync_callback_stop()
 
         features = []
         if is_vlm:
@@ -2212,6 +2501,216 @@ class MLXTrainer:
         trained_tokens = 0
         train_time = 0
         grad_accum_state = None
+        accum_progress = 0
+        batches_per_epoch = self._callback_batches_per_epoch(batches)
+
+        def _run_callback_epoch_begin(epoch_value):
+            """Dispatch one epoch-begin event at the requested epoch value."""
+            self.state.epoch = epoch_value
+            self.control.should_epoch_stop = False
+            self.control = self.callback_handler.call_event(
+                "on_epoch_begin",
+                args, self.state, self.control,
+            )
+            self._sync_callback_stop()
+
+        def _maybe_callback_epoch_begin(microstep):
+            """Dispatch epoch-begin at finite dataset boundaries."""
+            if not batches_per_epoch or (microstep - 1) % batches_per_epoch != 0:
+                return False
+            _run_callback_epoch_begin((microstep - 1) / batches_per_epoch)
+            return True
+
+        def _maybe_callback_epoch_end(microstep, current_step, grad_norm):
+            """Dispatch epoch-end after an optimizer step at a dataset boundary."""
+            if not batches_per_epoch or microstep % batches_per_epoch != 0:
+                return
+            self.state.epoch = microstep / batches_per_epoch
+            self.control = self.callback_handler.call_event(
+                "on_epoch_end",
+                args, self.state, self.control,
+            )
+            self._sync_callback_stop()
+            if self.control.should_log or self.control.should_evaluate or self.control.should_save:
+                _run_callback_control_actions(current_step, grad_norm)
+
+        def _run_training_log(current_step, grad_norm):
+            """Emit one MLX/HF training log from accumulated loss counters."""
+            nonlocal losses, n_tokens, steps, train_time, trained_tokens
+            tok_count = n_tokens.item() if hasattr(n_tokens, "item") else n_tokens
+            if int(tok_count) == 0:
+                self.control.should_log = False
+                return
+            train_loss = (losses / n_tokens).item()
+            trained_tokens += tok_count
+            lr_val = optimizer.learning_rate.item()
+            tokens_sec = tok_count / train_time if train_time > 0 else 0
+            peak_mem = mx.get_peak_memory() / 1e9
+
+            self._train_loss_history.append(train_loss)
+            grad_norm_val = (
+                float(grad_norm.item())
+                if grad_norm is not None else None
+            )
+            if grad_norm_val is not None:
+                self._grad_norm_history.append(grad_norm_val)
+            self._tokens_per_second_history.append(tokens_sec)
+            self._peak_memory_history.append(peak_mem)
+            self._step_times.append(train_time / steps if steps > 0 else 0)
+
+            reset_after = getattr(self, '_benchmark_reset_peak_after_step', 0)
+            if reset_after > 0 and current_step == reset_after:
+                mx.synchronize()
+                mx.reset_peak_memory()
+
+            elapsed_total = time.perf_counter() - start_time
+            grad_text = (
+                f"Grad: {grad_norm_val:.4f} | "
+                if grad_norm_val is not None else ""
+            )
+            print(
+                f"  Step {current_step}/{total_steps} | "
+                f"Loss: {train_loss:.4f} | "
+                f"{grad_text}"
+                f"LR: {lr_val:.2e} | "
+                f"Tok/s: {tokens_sec:.0f} | "
+                f"Peak: {peak_mem:.2f} GB"
+            )
+
+            for cb in self._step_callbacks:
+                try:
+                    cb(
+                        current_step, total_steps, train_loss, lr_val,
+                        tokens_sec, peak_mem, elapsed_total, trained_tokens,
+                        grad_norm_val,
+                    )
+                except Exception as e:
+                    print(f"Unsloth: step callback error: {e}")
+
+            logs = {
+                "loss": train_loss,
+                "learning_rate": lr_val,
+                "tokens_per_second": tokens_sec,
+                "peak_memory_gb": peak_mem,
+                "trained_tokens": trained_tokens,
+            }
+            if grad_norm_val is not None:
+                logs["grad_norm"] = grad_norm_val
+            self._call_callback_log(logs)
+
+            losses = 0
+            n_tokens = 0
+            steps = 0
+            train_time = 0
+
+        def _run_eval(current_step):
+            """Run eval and dispatch MLX/HF eval callbacks."""
+            current_eval_batches = _prepare_eval_batches()
+            if not current_eval_batches:
+                self.control.should_evaluate = False
+                return False
+            val_loss, ppl = self._evaluate(
+                current_eval_batches, loss_fn, is_vlm=is_vlm)
+            model.train()
+            print(
+                f"  Eval  {current_step}/{total_steps} | "
+                f"Val Loss: {val_loss:.4f} | "
+                f"Perplexity: {ppl:.2f}"
+            )
+            for cb in self._eval_callbacks:
+                try:
+                    cb(current_step, val_loss, ppl)
+                except Exception as e:
+                    print(f"Unsloth: eval callback error: {e}")
+
+            self._call_callback_evaluate(self._last_eval_metrics or {})
+            self._update_callback_best_metric(self._last_eval_metrics or {})
+            return True
+
+        def _run_best_tracking(current_step):
+            """Update MLX native best-model and early-stopping state."""
+            _track = getattr(args, "load_best_model_at_end", False) or \
+                int(getattr(args, "early_stopping_patience", 0) or 0) > 0
+            if not _track:
+                return
+            _metric_name = self._metric_for_best_model_name(
+                self._last_eval_metrics or {},
+                require=True,
+            )
+            if _metric_name is None:
+                raise ValueError(
+                    "metric_for_best_model must be set when best-model "
+                    "tracking or early stopping is enabled."
+                )
+            _em = self._last_eval_metrics or {}
+            _cur = _em[_metric_name]
+            _greater = bool(getattr(args, "greater_is_better", False))
+            _improved = (
+                _cur == _cur
+                and (
+                    self._best_metric is None
+                    or (_cur > self._best_metric if _greater else _cur < self._best_metric)
+                )
+            )
+            if _improved:
+                self._best_metric = _cur
+                self._best_step = current_step
+                self.state.best_metric = _cur
+                self.state.best_global_step = current_step
+                self.state.best_model_checkpoint = f"{args.output_dir}/best"
+                self._es_patience_counter = 0
+                try:
+                    save_trainable_adapters(model, f"{args.output_dir}/best")
+                except ValueError as e:
+                    print(f"  Unsloth: skipped best-model save ({e})")
+            else:
+                self._es_patience_counter += 1
+                _pat = int(getattr(args, "early_stopping_patience", 0) or 0)
+                if _pat > 0 and self._es_patience_counter >= _pat:
+                    print(
+                        f"Unsloth: early stopping at step {current_step} "
+                        f"(no {_metric_name} improvement in {_pat} evals)."
+                    )
+                    self.stop_requested = True
+
+        def _run_checkpoint(current_step):
+            """Save a step checkpoint and dispatch HF save callbacks on success."""
+            ckpt_dir = f"{args.output_dir}/checkpoint-{current_step}"
+            try:
+                save_trainable_adapters(model, ckpt_dir)
+            except ValueError as e:
+                print(f"  Unsloth: skipped checkpoint ({e})")
+                self.control.should_save = False
+                return
+
+            checkpoint_complete = False
+            try:
+                save_optimizer_state(optimizer, ckpt_dir)
+                save_trainer_state(
+                    {
+                        "global_step": current_step,
+                        "train_loss_history": list(self._train_loss_history),
+                    },
+                    ckpt_dir,
+                )
+                checkpoint_complete = True
+            except Exception as e:
+                print(f"  Unsloth: checkpoint saved without resume state ({e})")
+            print(f"  Saved checkpoint to {ckpt_dir}")
+            if checkpoint_complete:
+                _prune_stale_checkpoints(args.output_dir, args.save_total_limit)
+            self._call_callback_save()
+
+        def _run_callback_control_actions(current_step, grad_norm):
+            """Run log/eval/save actions requested by callback control flags."""
+            if self.control.should_log:
+                _run_training_log(current_step, grad_norm)
+            if self.control.should_evaluate:
+                if _run_eval(current_step):
+                    _run_best_tracking(current_step)
+            if self.control.should_save:
+                _run_checkpoint(current_step)
+
         # When resuming, start batch_idx at the resume position so
         # batches[batch_idx % len(batches)] lands on the same batch the
         # original run would have seen next.
@@ -2232,10 +2731,31 @@ class MLXTrainer:
                         f"Dataset may be shorter than the killed run consumed."
                     ) from None
 
-        for it in range(_resume_step * grad_accum + 1, total_steps * grad_accum + 1):
+        microstep = _resume_step * grad_accum
+        self._global_step = _resume_step
+        while self._global_step < total_steps:
+            it = microstep + 1
             if self.stop_requested:
                 print("Unsloth: Stop requested — ending training early.")
                 break
+
+            if _maybe_callback_epoch_begin(it):
+                if self.stop_requested:
+                    print("Unsloth: Stop requested — ending training early.")
+                    break
+
+            if accum_progress == 0:
+                self.control.should_log = False
+                self.control.should_evaluate = False
+                self.control.should_save = False
+                self.control = self.callback_handler.call_event(
+                    "on_step_begin",
+                    args, self.state, self.control,
+                )
+                self._sync_callback_stop()
+                if self.stop_requested:
+                    print("Unsloth: Stop requested — ending training early.")
+                    break
 
             tic = time.perf_counter()
 
@@ -2246,11 +2766,11 @@ class MLXTrainer:
                 batch_data = batches[batch_idx % len(batches)]
                 batch_idx += 1
 
-            do_update = (it % grad_accum == 0)
+            do_update = (accum_progress + 1 >= grad_accum)
             if do_update:
                 # Keep callable scheduler evaluation outside mx.compile. The
                 # compiled step reads the scalar LR already in optimizer state.
-                self._set_optimizer_lr_for_step(optimizer, it // grad_accum - 1)
+                self._set_optimizer_lr_for_step(optimizer, self._global_step)
 
             try:
                 lvalue, toks, grad_accum_state, grad_norm = step_fn(
@@ -2317,154 +2837,83 @@ class MLXTrainer:
                     "tokens after masking/truncation. Increase max_seq_length, "
                     "reduce image size, or check the chat template / labels."
                 )
+            if do_update:
+                self.control = self.callback_handler.call_event(
+                    "on_optimizer_step",
+                    args, self.state, self.control,
+                )
+                self._sync_callback_stop()
+            self.state.num_input_tokens_seen += int(toks.item())
+            if batches_per_epoch:
+                self.state.epoch = it / batches_per_epoch
             train_time += time.perf_counter() - tic
 
             # Only log/eval on actual optimizer steps
             if not do_update:
+                accum_progress += 1
+                self.control = self.callback_handler.call_event(
+                    "on_substep_end",
+                    args, self.state, self.control,
+                )
+                self._sync_callback_stop()
+                microstep = it
                 continue
 
-            self._global_step = it // grad_accum
-            current_step = self._global_step
+            current_step = self._global_step + 1
+            self._global_step = current_step
+            self.state.global_step = current_step
+            accum_progress = 0
+            self.control = self.callback_handler.call_event(
+                "on_step_end",
+                args, self.state, self.control,
+            )
+            self._sync_callback_stop()
 
             # Logging
-            if current_step % args.logging_steps == 0 or current_step == total_steps:
-                train_loss = (losses / n_tokens).item()
-                tok_count = n_tokens.item()
-                trained_tokens += tok_count
-                lr_val = optimizer.learning_rate.item()
-                tokens_sec = tok_count / train_time if train_time > 0 else 0
-                peak_mem = mx.get_peak_memory() / 1e9
-
-                self._train_loss_history.append(train_loss)
-                grad_norm_val = (
-                    float(grad_norm.item())
-                    if grad_norm is not None else None
-                )
-                if grad_norm_val is not None:
-                    self._grad_norm_history.append(grad_norm_val)
-                self._tokens_per_second_history.append(tokens_sec)
-                self._peak_memory_history.append(peak_mem)
-                self._step_times.append(train_time / steps if steps > 0 else 0)
-
-                # Benchmark hook: reset peak memory after warmup
-                reset_after = getattr(self, '_benchmark_reset_peak_after_step', 0)
-                if reset_after > 0 and current_step == reset_after:
-                    mx.synchronize()
-                    mx.reset_peak_memory()
-
-                elapsed_total = time.perf_counter() - start_time
-
-                grad_text = (
-                    f"Grad: {grad_norm_val:.4f} | "
-                    if grad_norm_val is not None else ""
-                )
-                print(
-                    f"  Step {current_step}/{total_steps} | "
-                    f"Loss: {train_loss:.4f} | "
-                    f"{grad_text}"
-                    f"LR: {lr_val:.2e} | "
-                    f"Tok/s: {tokens_sec:.0f} | "
-                    f"Peak: {peak_mem:.2f} GB"
-                )
-
-                for cb in self._step_callbacks:
-                    try:
-                        cb(
-                            current_step, total_steps, train_loss, lr_val,
-                            tokens_sec, peak_mem, elapsed_total, trained_tokens,
-                            grad_norm_val,
-                        )
-                    except Exception as e:
-                        print(f"Unsloth: step callback error: {e}")
-
-                losses = 0
-                n_tokens = 0
-                steps = 0
-                train_time = 0
+            logging_steps = int(getattr(args, "logging_steps", 0) or 0)
+            should_log = (
+                (logging_steps > 0 and current_step % logging_steps == 0)
+                or current_step == total_steps
+                or self.control.should_log
+            )
+            if should_log:
+                _run_training_log(current_step, grad_norm)
 
             # Eval
-            if (eval_batches and args.eval_steps > 0
-                    and current_step % args.eval_steps == 0):
-                val_loss, ppl = self._evaluate(
-                    eval_batches, loss_fn, is_vlm=is_vlm)
-                model.train()
-                print(
-                    f"  Eval  {current_step}/{total_steps} | "
-                    f"Val Loss: {val_loss:.4f} | "
-                    f"Perplexity: {ppl:.2f}"
-                )
-                for cb in self._eval_callbacks:
-                    try:
-                        cb(current_step, val_loss, ppl)
-                    except Exception as e:
-                        print(f"Unsloth: eval callback error: {e}")
-
-                # Best-model tracking + early stopping (Item-5).
-                _track = getattr(args, "load_best_model_at_end", False) or \
-                    int(getattr(args, "early_stopping_patience", 0) or 0) > 0
-                if _track:
-                    _metric_name = getattr(args, "metric_for_best_model", "eval_loss")
-                    _em = self._last_eval_metrics or {}
-                    if _metric_name not in _em:
-                        raise ValueError(
-                            f"metric_for_best_model={_metric_name!r} not in eval "
-                            f"metrics; available: {sorted(_em)}"
-                        )
-                    _cur = _em[_metric_name]
-                    _greater = bool(getattr(args, "greater_is_better", False))
-                    _improved = (
-                        _cur == _cur  # reject NaN: a diverged eval must never become "best"
-                        and (
-                            self._best_metric is None
-                            or (_cur > self._best_metric if _greater else _cur < self._best_metric)
-                        )
+            eval_strategy = self._callback_interval_name(
+                getattr(args, "eval_strategy", "no"),
+            )
+            eval_delay = float(getattr(args, "eval_delay", 0) or 0)
+            should_eval = (
+                self.eval_dataset is not None
+                and (
+                    (
+                        eval_strategy == "steps"
+                        and args.eval_steps > 0
+                        and current_step % args.eval_steps == 0
+                        and current_step >= eval_delay
                     )
-                    if _improved:
-                        self._best_metric = _cur
-                        self._best_step = current_step
-                        self._es_patience_counter = 0
-                        try:
-                            save_trainable_adapters(model, f"{args.output_dir}/best")
-                        except ValueError as e:
-                            print(f"  Unsloth: skipped best-model save ({e})")
-                    else:
-                        self._es_patience_counter += 1
-                        _pat = int(getattr(args, "early_stopping_patience", 0) or 0)
-                        if _pat > 0 and self._es_patience_counter >= _pat:
-                            print(
-                                f"Unsloth: early stopping at step {current_step} "
-                                f"(no {_metric_name} improvement in {_pat} evals)."
-                            )
-                            self.stop_requested = True
+                    or self.control.should_evaluate
+                )
+            )
+            if should_eval:
+                if _run_eval(current_step):
+                    _run_best_tracking(current_step)
 
             # Checkpointing
-            if args.save_steps > 0 and current_step % args.save_steps == 0:
-                ckpt_dir = f"{args.output_dir}/checkpoint-{current_step}"
-                try:
-                    save_trainable_adapters(model, ckpt_dir)
-                except ValueError as e:
-                    print(f"  Unsloth: skipped checkpoint ({e})")
-                else:
-                    # Also write optimizer + trainer state so resume_from_checkpoint
-                    # can restore Adam moments, step counter, and loss history.
-                    # Adapter save was successful -- treat the extra writes as
-                    # best-effort: log on failure but don't undo the adapter save.
-                    checkpoint_complete = False
-                    try:
-                        save_optimizer_state(optimizer, ckpt_dir)
-                        save_trainer_state(
-                            {
-                                "global_step": current_step,
-                                "train_loss_history": list(self._train_loss_history),
-                            },
-                            ckpt_dir,
-                        )
-                        checkpoint_complete = True
-                    except Exception as e:
-                        print(f"  Unsloth: checkpoint saved without resume state ({e})")
-                    print(f"  Saved checkpoint to {ckpt_dir}")
-                    if checkpoint_complete:
-                        _prune_stale_checkpoints(args.output_dir, args.save_total_limit)
+            should_save = (
+                (args.save_steps > 0 and current_step % args.save_steps == 0)
+                or self.control.should_save
+            )
+            if should_save:
+                _run_checkpoint(current_step)
+
+            if self.stop_requested:
+                break
+            _maybe_callback_epoch_end(it, current_step, grad_norm)
+            if self.stop_requested:
+                break
+            microstep = it
 
         total_time = time.perf_counter() - start_time
         avg_loss = (
@@ -2496,6 +2945,13 @@ class MLXTrainer:
             print(f"Unsloth: skipped final save ({e})")
         else:
             print(f"Unsloth: Saved final adapters to {args.output_dir}")
+            self._call_callback_save()
+
+        self.control = self.callback_handler.call_event(
+            "on_train_end",
+            args, self.state, self.control,
+        )
+        self._sync_callback_stop()
 
         return MLXTrainOutput({
             "train_loss": avg_loss,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -144,9 +144,7 @@ class _MLXCallbackHandler:
 
     def remove_callback(self, callback):
         """Remove a callback class or instance."""
-        removed = self.pop_callback(callback)
-        if removed is None and not isinstance(callback, type):
-            self.callbacks.remove(callback)
+        self.pop_callback(callback)
 
     def call_event(self, event, args, state, control, **kwargs):
         """Dispatch one callback event and return the latest control object."""


### PR DESCRIPTION
## Summary

Adds HF-style `compute_metrics` support to the MLX text training eval path.

This PR extends `MLXTrainer` so scheduled evaluation during `train()` can collect prediction/label payloads, call `compute_metrics(EvalPrediction(...))`, and merge the returned metrics into the existing eval metrics dictionary.

## Stack / companion PRs

- Stacked on: #873, which adds HF-style callback support to `MLXTrainer`.
- Companion wrapper PR: unslothai/unsloth#6932.

## What changed

- Adds `compute_metrics` and `preprocess_logits_for_metrics` constructor kwargs to `MLXTrainer`.
- Keeps the existing eval loss path unchanged, including CCE support; metric prediction collection uses a separate eval-only forward path.
- Passes full-sequence logits and labels to metrics by default, matching HF `Trainer` behavior.
- Runs `preprocess_logits_for_metrics(logits, labels)` before accumulation when supplied.
- Lazily imports `EvalPrediction` / `denumpify_detensorize` only when metrics are actually computed, preserving the normal torch-free import path.
- Prefixes user metric keys with the active eval prefix when needed.
- Preserves trainer-owned `eval_loss` / `eval_perplexity` and split loss/perplexity if a metric function returns a colliding key such as `loss`.
- Supports dict eval datasets with split-specific metric prefixes such as `eval_validation_accuracy`.
- Pads variable-length eval batches before concatenating predictions and labels.
- Masks labels using the same `[start, end)` bounds as the loss path.
- Handles common prediction payload shapes, including tuples/lists, mappings, scalar chunks, bfloat16 tensors, and model outputs with a `logits` attribute or `{"logits": ...}` mapping.
- Explicitly leaves VLM `compute_metrics` unsupported for now with a clear error if requested.

## Why

The MLX trainer already supports eval loss/perplexity, but callers using the HF/TRL `compute_metrics` pattern could not compute custom eval metrics. This blocks parity with common `SFTTrainer` workflows and prevents callback/best-metric flows from seeing user-defined eval metrics.

## Validation

- `python -m pytest tests/test_mlx_trainer_internals.py -q -k 'evaluate or metric_chunk or metric_logits'`
- `python -m pytest tests/test_mlx_training_e2e_metal.py -q -k 'callback or compute_metrics or import_keeps_torch'`
- `python -m compileall -q unsloth_zoo/mlx/trainer.py tests/test_mlx_training_e2e_metal.py tests/test_mlx_trainer_internals.py`
- `git diff --check`

## Follow-ups intentionally left out

- Public `evaluate()` / `predict()` methods.
- `batch_eval_metrics`.
- `include_for_metrics`.
- `eval_accumulation_steps`.
- VLM-specific `compute_metrics` support.