### PR TITLE
Fix gpt_oss mask factory signature introspection on transformers 5.x

### DIFF
--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2460,9 +2460,10 @@ def patch_GptOssModel():
     pass
 
     # transformers 4.x uses `input_embeds` and accepts `cache_position`;
-    # transformers 5.x renamed to `inputs_embeds` and dropped `cache_position`.
-    # Inspect the mask factory signatures once and pass only the kwargs they
-    # actually accept so this patch works on both 4.x and 5.x.
+    # transformers 5.x renamed it to `inputs_embeds` and later dropped
+    # `cache_position` (deprecated then removed by 5.13). Inspect the mask factory
+    # signatures once and pass only the kwargs they actually accept so this patch
+    # works across 4.x and the whole 5.x line.
     import inspect as _inspect
     def _mask_factory_params(fn, name):
         # The factory may be wrapped (see misc.py) or torch-compiled, which
@@ -2485,16 +2486,21 @@ def patch_GptOssModel():
                 return params
         # Introspection failed on every candidate (should not happen: misc.py saves
         # the pristine factory and torch.compile exposes __wrapped__). Fall back to
-        # the parameter set for the running transformers, choosing the embeds arg
-        # name by major version (4.x uses input_embeds, 5.x uses inputs_embeds) so a
-        # reached fallback never passes an unexpected keyword to the real factory.
+        # the parameter set for the running transformers, choosing the kwargs by
+        # major version so a reached fallback never passes an unexpected keyword to
+        # the real factory: 4.x uses `input_embeds` and accepts `cache_position`,
+        # while 5.x uses `inputs_embeds` and dropped `cache_position` (optional and
+        # defaulting to None on early 5.x, removed entirely by 5.13), so omitting it
+        # on 5.x is safe across the whole line.
         try:
             _tf_major = int(str(transformers.__version__).split(".", 1)[0])
         except (ValueError, AttributeError, IndexError):
             _tf_major = 5
-        _embeds_name = "input_embeds" if _tf_major < 5 else "inputs_embeds"
-        return {"config", _embeds_name, "attention_mask",
-                "cache_position", "past_key_values", "position_ids"}
+        if _tf_major < 5:
+            return {"config", "input_embeds", "attention_mask",
+                    "cache_position", "past_key_values", "position_ids"}
+        return {"config", "inputs_embeds", "attention_mask",
+                "past_key_values", "position_ids"}
     _ccm_params = _mask_factory_params(create_causal_mask, "create_causal_mask")
     _cswc_params = _mask_factory_params(create_sliding_window_causal_mask, "create_sliding_window_causal_mask")
     _mask_params = _ccm_params | _cswc_params

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2464,8 +2464,29 @@ def patch_GptOssModel():
     # Inspect the mask factory signatures once and pass only the kwargs they
     # actually accept so this patch works on both 4.x and 5.x.
     import inspect as _inspect
-    _ccm_params = set(_inspect.signature(create_causal_mask).parameters)
-    _cswc_params = set(_inspect.signature(create_sliding_window_causal_mask).parameters)
+    def _mask_factory_params(fn, name):
+        # The factory may be wrapped (see misc.py) or torch-compiled, which
+        # collapses inspect.signature() to (*args, **kwargs) and would make the
+        # kwargs filter below drop every mask argument -> create_causal_mask()
+        # called with no args -> "missing required positional arguments". Recover
+        # the true parameter names from the pristine reference misc.py saves, then
+        # __wrapped__, then the object itself, then a static 4.x + 5.x fallback.
+        for cand in (
+            getattr(transformers.masking_utils, "_unsloth_original_" + name, None),
+            getattr(fn, "__wrapped__", None),
+            fn,
+        ):
+            if cand is None: continue
+            try:
+                params = set(_inspect.signature(cand).parameters)
+            except (TypeError, ValueError):
+                continue
+            if not params <= {"args", "kwargs", "self"}:
+                return params
+        return {"config", "inputs_embeds", "input_embeds", "attention_mask",
+                "cache_position", "past_key_values", "position_ids"}
+    _ccm_params = _mask_factory_params(create_causal_mask, "create_causal_mask")
+    _cswc_params = _mask_factory_params(create_sliding_window_causal_mask, "create_sliding_window_causal_mask")
     _mask_params = _ccm_params | _cswc_params
 
     def _build_mask_kwargs(config, inputs_embeds, attention_mask, cache_position, past_key_values):

--- a/unsloth_zoo/temporary_patches/gpt_oss.py
+++ b/unsloth_zoo/temporary_patches/gpt_oss.py
@@ -2470,7 +2470,7 @@ def patch_GptOssModel():
         # kwargs filter below drop every mask argument -> create_causal_mask()
         # called with no args -> "missing required positional arguments". Recover
         # the true parameter names from the pristine reference misc.py saves, then
-        # __wrapped__, then the object itself, then a static 4.x + 5.x fallback.
+        # __wrapped__, then the object itself, then a version-aware fallback.
         for cand in (
             getattr(transformers.masking_utils, "_unsloth_original_" + name, None),
             getattr(fn, "__wrapped__", None),
@@ -2483,7 +2483,17 @@ def patch_GptOssModel():
                 continue
             if not params <= {"args", "kwargs", "self"}:
                 return params
-        return {"config", "inputs_embeds", "input_embeds", "attention_mask",
+        # Introspection failed on every candidate (should not happen: misc.py saves
+        # the pristine factory and torch.compile exposes __wrapped__). Fall back to
+        # the parameter set for the running transformers, choosing the embeds arg
+        # name by major version (4.x uses input_embeds, 5.x uses inputs_embeds) so a
+        # reached fallback never passes an unexpected keyword to the real factory.
+        try:
+            _tf_major = int(str(transformers.__version__).split(".", 1)[0])
+        except (ValueError, AttributeError, IndexError):
+            _tf_major = 5
+        _embeds_name = "input_embeds" if _tf_major < 5 else "inputs_embeds"
+        return {"config", _embeds_name, "attention_mask",
                 "cache_position", "past_key_values", "position_ids"}
     _ccm_params = _mask_factory_params(create_causal_mask, "create_causal_mask")
     _cswc_params = _mask_factory_params(create_sliding_window_causal_mask, "create_sliding_window_causal_mask")


### PR DESCRIPTION
## Summary

On transformers 5.x, gpt-oss eager inference raises:

```
TypeError: create_causal_mask() missing 3 required positional arguments: 'config', 'inputs_embeds', and 'attention_mask'
```

`temporary_patches/gpt_oss.py` (`patch_GptOssModel`) builds the attention masks by
inspecting the signature of `create_causal_mask` / `create_sliding_window_causal_mask`
and filtering a `mask_kwargs` dict down to the names those factories accept. By the
time this runs, the factories have already been wrapped (misc.py) and torch-compiled,
so `inspect.signature(...)` reports `(*args, **kwargs)`. The derived `_ccm_params` /
`_cswc_params` collapse to `{"args", "kwargs"}`, the filter
`{k: v for k, v in mask_kwargs.items() if k in _ccm_params}` keeps nothing, and
`create_causal_mask()` is called with no arguments.

## Fix

Recover the true parameter names before building the filter: prefer the pristine
factory that misc.py stashes as `masking_utils._unsloth_original_<name>`, then
`fn.__wrapped__`, then the object itself, and only fall back to a static 4.x + 5.x
parameter set (`config`, `inputs_embeds` / `input_embeds`, `attention_mask`,
`cache_position`, `past_key_values`, `position_ids`) if every candidate still
introspects as a bare `(*args, **kwargs)` wrapper. Scope is limited to the gpt_oss
mask handling; nothing else changes.

## Testing

Reproduced on transformers 5.5.0 (B200) with an Unsloth LoRA fine-tune of
`unsloth/gpt-oss-20b-BF16`:

- Before: the teacher-forced-CE / greedy probe stage fails with the TypeError, so
  in-memory and LoRA-adapter reload verification cannot run. (The merged_16bit reload
  still reproduces the trained phrase, since that is a plain checkpoint.)
- After: the probe passes, the model memorizes (completion CE 1e-6), and both the
  LoRA-adapter reload and the merged_16bit reload reproduce the trained output.

At that call site `inspect.signature(create_causal_mask)` still reports
`(*args, **kwargs)`; the helper now returns the real parameter set
`{config, inputs_embeds, attention_mask, cache_position, past_key_values, ...}`, so
the mask kwargs are passed through correctly on both transformers 4.x and 5.x.
