### PR TITLE
Add Mixtral MoE experts patch for Split LoRA (fix 4bit QLoRA forward crash)

### DIFF
--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -34,6 +34,7 @@ from .glm4_moe import *
 from .deepseek_v3_moe import *
 from .gemma4_moe import *
 from .lfm2_moe import *
+from .mixtral_moe import *
 from .ernie4_5_moe import *
 from .pixtral import *
 from .ministral import *

--- a/unsloth_zoo/temporary_patches/mixtral_moe.py
+++ b/unsloth_zoo/temporary_patches/mixtral_moe.py
@@ -1,0 +1,106 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .common import (
+    TEMPORARY_PATCHES,
+    UNSLOTH_ENABLE_LOGGING,
+)
+from .utils import (
+    patch_function,
+    logger,
+)
+
+# Grouped GEMM kernel integration for MoE training acceleration.
+from .moe_utils import (
+    patch_param_wrapper_for_moe,
+    get_forward_moe_backend,
+    extract_moe_lora_weights_for_grouped_mm,
+)
+
+
+def _make_mixtral_moe_lora_extractor():
+    """LoRA extractor for the fused MixtralExperts. Same 3D layout as Qwen3MoeExperts /
+    Lfm2MoeExperts (gate_up_proj (E, 2*I, H), down_proj (E, H, I)); io-dims read off
+    hidden_dim / intermediate_dim."""
+    def _get_mixtral_moe_lora_dims(wrapper):
+        if wrapper is None or not hasattr(wrapper, "get_base_layer"):
+            return None, None
+
+        base = wrapper.get_base_layer()
+        param_name = getattr(wrapper, "parameter_name", None)
+        if param_name == "gate_up_proj":
+            input_dim = getattr(base, "hidden_dim", None)
+            output_dim = getattr(base, "intermediate_dim", None)
+            return input_dim, None if output_dim is None else 2 * output_dim
+        if param_name == "down_proj":
+            return getattr(base, "intermediate_dim", None), getattr(base, "hidden_dim", None)
+
+        return None, None
+
+    def _mixtral_moe_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts):
+        input_dim, output_dim = _get_mixtral_moe_lora_dims(wrapper)
+        return extract_moe_lora_weights_for_grouped_mm(
+            wrapper,
+            weight_A,
+            weight_B,
+            scaling,
+            num_experts,
+            input_dim=input_dim,
+            output_dim=output_dim,
+            model_name="Mixtral MoE",
+            enable_logging=UNSLOTH_ENABLE_LOGGING,
+            logger_obj=logger,
+        )
+
+    return _mixtral_moe_lora_extractor
+
+
+def patch_mixtral_moe():
+    """Patch Mixtral MoE (mixtral) fused experts for Split LoRA via grouped GEMM. On
+    transformers 5.x MixtralExperts stores its experts as fused 3D nn.Parameters
+    (gate_up_proj (E, 2*I, H), down_proj (E, H, I)). Under 4bit QLoRA those become packed
+    bnb Params4bit blobs, and the native experts.forward's nn.functional.linear over the
+    packed weight raises `mat1 and mat2 shapes cannot be multiplied`. Routing it through
+    Unsloth's MoE backend (dequantize + grouped_mm) fixes it, as for qwen3_moe / lfm2_moe /
+    glm4_moe / etc. The MixtralSparseMoeBlock keeps its native routing, calling
+    self.experts(...) whose signature matches the dispatcher, so only the experts forward
+    is replaced.
+    """
+    # Separated LoRA on the fused experts params. Idempotent (qwen3_moe installs it too).
+    patch_param_wrapper_for_moe()
+
+    # Transformers < 5 has no MixtralExperts -> strict no-op there.
+    try:
+        from transformers.models.mixtral.modeling_mixtral import MixtralExperts
+    except Exception:
+        return
+
+    if getattr(MixtralExperts, "_unsloth_already_patched", False):
+        return
+
+    _mixtral_lora_extractor = _make_mixtral_moe_lora_extractor()
+    MixtralExperts._unsloth_lora_extractor_fn = staticmethod(_mixtral_lora_extractor)
+
+    # Pass the function object directly (no closure): patch_function serializes the source into
+    # the compiled cache, so a closure var would be a NameError there. Mirrors lfm2_moe.py.
+    patch_function(MixtralExperts, "forward", get_forward_moe_backend())
+    MixtralExperts._unsloth_already_patched = True
+
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: Patched Mixtral MoE experts for Split LoRA support.")
+
+
+TEMPORARY_PATCHES.append(patch_mixtral_moe)


### PR DESCRIPTION
## Summary

On transformers 5.x, Mixtral 4bit QLoRA fine-tuning crashes on the first forward:

```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (Nx4096 and 1x58720256)
```

`MixtralExperts` stores its experts as fused 3D `nn.Parameter`s
(`gate_up_proj` `(E, 2*I, H)`, `down_proj` `(E, H, I)`), the same layout as
`Qwen3MoeExperts` / `Lfm2MoeExperts`. LoRA attaches to those fused params via
`target_parameters` (128 experts attach for Mixtral-8x7B), but the native
`MixtralExperts.forward` calls `nn.functional.linear` directly against the
expert weight. Under 4bit that weight is a packed bnb `Params4bit` blob
(`(E, packed, 1)`, `uint8`), so the matmul multiplies the input against the
packed representation and raises the shape error.

Every other fused-MoE arch (`qwen3_moe`, `lfm2_moe`, `glm4_moe`, ...) already
routes `experts.forward` through Unsloth's MoE backend
(`get_forward_moe_backend`), which dequantizes the `Params4bit` and runs
`grouped_mm`, and registers a per-arch LoRA extractor. Mixtral had no such
patch, so it fell through to the native forward and crashed.

## Fix

Add `mixtral_moe.py`, mirroring `lfm2_moe.py`:

- register `MixtralExperts._unsloth_lora_extractor_fn` (io-dims read off
  `hidden_dim` / `intermediate_dim`, `gate_up` output = `2 * intermediate_dim`),
- swap `MixtralExperts.forward` for the shared MoE backend.

Mixtral's io-dims and dispatch signature (`hidden_states, top_k_index,
top_k_weights`, called from `MixtralSparseMoeBlock`) match the LFM2 pattern
exactly, so the extractor is identical. Transformers < 5 has no
`MixtralExperts`, so the patch is a strict no-op there. Register it in
`temporary_patches/__init__.py` next to the other MoE patches.

This is complementary to the existing Mixtral work: zoo #812 fixed the
merge/save path (unfused expert deltas) and unsloth #5345 fixed expert
target-parameter discovery. Neither installs the experts forward backend,
which is what 4bit needs.

## Testing

Real end-to-end run on 1x B200, transformers 5.5.0, unsloth-zoo git-main +
this patch, `unsloth/Mixtral-8x7B-v0.1-bnb-4bit` (4bit QLoRA). A single row
(`###!!!___MY NAME IS___!!!###` -> `>>>UNSLOTH!<<<`) is overfit for ~30 steps,
then the LoRA adapter and the `merged_16bit` model are each reloaded in a
fresh process and asked to reproduce the phrase.

Before this patch: the first forward (pre-train teacher-forced CE probe)
raises `mat1 and mat2 shapes cannot be multiplied (Nx4096 and 1x58720256)`;
training never starts.

After this patch:

- LoRA attaches to 128 experts (`attention=256, experts=128`),
- the pre-train forward and training run cleanly,
- in-memory model reproduces the phrase (completion CE ~1e-6, exact string
  match),
- reloaded LoRA adapter reproduces it (completion CE 4e-6),
- reloaded `merged_16bit` model reproduces it (completion CE 9e-6, exact
  string `###!!!___MY NAME IS___!!!###>>>UNSLOTH!<<<`).

16bit Mixtral (`mistralai/Mixtral-8x7B-v0.1`), which previously used the
native forward, was re-validated through the same backend to confirm no
regression: LoRA attaches to 128 experts, the in-memory model memorizes the
phrase (exact string match), and the reloaded `merged_16bit` model reproduces
it (completion CE 2e-6). (The separate LoRA-adapter reload of the full bf16
base model tripped an unrelated `accelerate` device-map issue,
`get_balanced_memory: unhashable type: 'set'`, when balancing the ~94 GB base
across GPUs; that path is independent of the experts forward/extractor and does
not affect the 4bit base, whose adapter reload passes.)
