### PR TITLE
qwen3_moe: match router input to the gate weight dtype in the MoE block

### DIFF
--- a/unsloth_zoo/temporary_patches/qwen3_moe.py
+++ b/unsloth_zoo/temporary_patches/qwen3_moe.py
@@ -89,13 +89,26 @@ def _make_qwen_moe_sparse_moe_block_forward(use_shared_expert: bool, module_name
             batch_size = 1
             sequence_length = total_tokens
 
+        input_dtype = hidden_states.dtype
         hidden_states_reshaped = hidden_states.view(-1, hidden_dim)
+
+        # The router (gate) weight can be stored at a different dtype than the
+        # hidden states, e.g. an FP8 checkpoint whose router is kept in higher
+        # precision. Match the router input to the gate weight dtype so the gate
+        # matmul, the routing weights, and the expert inputs stay consistent,
+        # then restore the original dtype on the way out. When the dtypes already
+        # match (the common bf16 / 4bit case) router_input is hidden_states_reshaped
+        # and behaviour is unchanged.
+        router_input = hidden_states_reshaped
+        gate_weight = getattr(self.gate, "weight", None)
+        if gate_weight is not None and router_input.dtype != gate_weight.dtype:
+            router_input = router_input.to(gate_weight.dtype)
 
         shared_expert_output = None
         if use_shared_expert:
             shared_expert_output = self.shared_expert(hidden_states_reshaped)
 
-        gate_output = self.gate(hidden_states_reshaped)
+        gate_output = self.gate(router_input)
         if isinstance(gate_output, tuple):
             _, routing_weights, selected_experts = gate_output
         else:
@@ -107,14 +120,15 @@ def _make_qwen_moe_sparse_moe_block_forward(use_shared_expert: bool, module_name
             routing_weights, selected_experts = torch.topk(routing_weights, top_k, dim=-1)
             if norm_topk_prob:
                 routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
-            routing_weights = routing_weights.to(hidden_states.dtype)
+        routing_weights = routing_weights.to(router_input.dtype)
 
-        final_hidden_states = self.experts(hidden_states_reshaped, selected_experts, routing_weights)
+        final_hidden_states = self.experts(router_input, selected_experts, routing_weights)
 
         if use_shared_expert:
             shared_expert_output = F.sigmoid(self.shared_expert_gate(hidden_states_reshaped)) * shared_expert_output
             final_hidden_states = final_hidden_states + shared_expert_output
 
+        final_hidden_states = final_hidden_states.to(input_dtype)
         if hidden_states.dim() == 3:
             return final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
         return final_hidden_states


### PR DESCRIPTION
## Summary

The patched Qwen3-MoE sparse MoE block (`_make_qwen_moe_sparse_moe_block_forward`)
drove the router gate, the routing weights, and the expert inputs from
`hidden_states` directly. When the router (gate) weight is stored at a different
dtype than the hidden states - for example an FP8 checkpoint whose router is kept
in higher precision - the gate matmul mixes dtypes.

This matches the router input to the gate weight dtype up front, drives the gate /
routing weights / experts from that consistent tensor, and restores the original
hidden-states dtype on the way out:

```python
input_dtype = hidden_states.dtype
router_input = hidden_states_reshaped
gate_weight = getattr(self.gate, "weight", None)
if gate_weight is not None and router_input.dtype != gate_weight.dtype:
    router_input = router_input.to(gate_weight.dtype)
...
routing_weights = routing_weights.to(router_input.dtype)
final_hidden_states = self.experts(router_input, selected_experts, routing_weights)
...
final_hidden_states = final_hidden_states.to(input_dtype)
```

When the gate weight and hidden states already share a dtype (the common bf16 /
bnb-4bit case), `router_input is hidden_states_reshaped` and the forward is
unchanged.

## Provenance

Salvaged from the FP8-MoE work in the now-closed unsloth-zoo #554. That PR's core
FP8 MoE forward has since landed and evolved on main, so it was closed; this is the
self-contained, arch-agnostic router-dtype piece that was not otherwise carried
over. The GLM4 compressed-tensors scale-patching from #554 / #551 is intentionally
left out here (it needs a testable GLM4 FP8 checkpoint to validate, which is not
available), and #554's `misc.py` `create_block_mask` change is dropped (it regressed
on torch builds whose `create_block_mask` does not accept `_compile`).

## Testing

Real end-to-end runs on 1x B200, transformers 5.5.0, unsloth-zoo main + this change,
memorization probe (single row overfit ~30 steps, then adapter and merged_16bit each
reloaded in a fresh process and asked to reproduce the phrase):

- `unsloth/Qwen3-30B-A3B-Instruct-2507-FP8` (FP8): experts attach (192), in-memory
  reproduces, LoRA-adapter reload reproduces, merged_16bit reload reproduces.
- `unsloth/Qwen3-30B-A3B-Instruct-2507` (bnb-4bit): same, experts attach (192), all
  reloads reproduce.

Both match the pre-change results (no regression), confirming the dtype-matching is a
no-op when gate and hidden states share a dtype.
