### PR TITLE
Add mixtral_moe to temporary_patches import test list

### DIFF
--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -51,6 +51,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.lfm2_moe",
     "unsloth_zoo.temporary_patches.ministral",
     "unsloth_zoo.temporary_patches.misc",
+    "unsloth_zoo.temporary_patches.mixtral_moe",
     "unsloth_zoo.temporary_patches.moe_bnb",
     "unsloth_zoo.temporary_patches.moe_grouped_modulelist",
     "unsloth_zoo.temporary_patches.moe_utils",


### PR DESCRIPTION
`temporary_patches/mixtral_moe.py` was added to the package but not registered in `TEMPORARY_PATCHES_SUBMODULES`, so `test_temporary_patches_submodule_list_is_complete` fails on main:

```
AssertionError: New temporary_patches submodule(s) on disk are NOT tested by this suite:
['unsloth_zoo.temporary_patches.mixtral_moe']. Add them to TEMPORARY_PATCHES_SUBMODULES above.
```

The completeness guard is a hard failure, so every PR that runs the CPU pytest suite (including the `unsloth_zoo @ main` step in unsloth's Core CI) currently goes red on this one assertion.

This adds `mixtral_moe` to the list, which also enrolls it in the per-submodule import smoke test. `mixtral_moe` imports cleanly, so both tests pass.

## Verification

```
UNSLOTH_ALLOW_CPU=1 python -m pytest tests/test_temporary_patches_imports.py -q
36 passed in 4.97s
```
