### PR TITLE
Fix CPU test drift on transformers 5.5.0 and the MLX bitsandbytes stub

### DIFF
--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -459,7 +459,9 @@ def test_adapter_bnb_base_remap_defaults_to_mlx_4bit_quantization(
     class StopAdapterLoad(RuntimeError):
         pass
 
-    def fake_download(model_name, revision=None):
+    # Accept allow_patterns: from_pretrained's config download now forwards it,
+    # so the shim must match the real _download signature.
+    def fake_download(model_name, revision=None, allow_patterns=None):
         assert model_name == str(adapter_dir)
         return adapter_dir
 

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -56,6 +56,17 @@ def _try_get_class(dotted_module: str, class_name: str):
     return getattr(mod, class_name, None)
 
 
+def _bitsandbytes_or_skip():
+    """Import bitsandbytes, skipping when it resolves to the unsloth stub.
+
+    The MLX-on-torch simulation injects a permissive stub, against which pinning
+    the real upstream signature is meaningless, so skip rather than false-DRIFT."""
+    bnb = pytest.importorskip("bitsandbytes")
+    if getattr(bnb, "IS_UNSLOTH_STUB", False):
+        pytest.skip("bitsandbytes is stubbed (MLX simulation active); cannot pin real upstream signature")
+    return bnb
+
+
 def _require_class(dotted_module: str, class_name: str, zoo_file: str):
     """Like ``_try_get_class`` but DRIFT-fail when the parent module
     exists but the class is missing. Skip when parent module is missing
@@ -194,7 +205,7 @@ def _has_var_keyword(func) -> bool:
 def test_bitsandbytes_top_level_Linear4bit_alias():
     """bitsandbytes.py:110 patches top-level ``bitsandbytes.nn.Linear4bit``
     alias; pin presence + .forward method."""
-    bnb = pytest.importorskip("bitsandbytes")
+    bnb = _bitsandbytes_or_skip()
     top_level = getattr(bnb.nn, "Linear4bit", None)
     inner = getattr(bnb.nn.modules, "Linear4bit", None)
     if top_level is None or inner is None:
@@ -213,7 +224,7 @@ def test_bitsandbytes_top_level_Linear4bit_alias():
 def test_bitsandbytes_Params4bit_class_present():
     """bitsandbytes.py:47-67 reads ``Params4bit`` and conditionally
     deletes ``__torch_function__`` (torch.compile recursion fix)."""
-    bnb = pytest.importorskip("bitsandbytes")
+    bnb = _bitsandbytes_or_skip()
     p4 = getattr(bnb.nn.modules, "Params4bit", None)
     if p4 is None:
         pytest.fail(
@@ -225,7 +236,7 @@ def test_bitsandbytes_Params4bit_class_present():
 def test_bitsandbytes_fix_4bit_weight_quant_state_from_module_present():
     """bitsandbytes.py:48 / :73 calls
     ``fix_4bit_weight_quant_state_from_module(self)``."""
-    bnb = pytest.importorskip("bitsandbytes")
+    bnb = _bitsandbytes_or_skip()
     fn = getattr(bnb.nn.modules, "fix_4bit_weight_quant_state_from_module", None)
     if fn is None:
         pytest.fail(
@@ -251,7 +262,7 @@ def test_bitsandbytes_fix_4bit_weight_quant_state_from_module_present():
 
 def test_bitsandbytes_matmul_4bit_present():
     """bitsandbytes.py:106 calls top-level ``bitsandbytes.matmul_4bit(...)``."""
-    bnb = pytest.importorskip("bitsandbytes")
+    bnb = _bitsandbytes_or_skip()
     if not hasattr(bnb, "matmul_4bit"):
         pytest.fail(
             "DRIFT DETECTED: zoo temporary_patches/bitsandbytes.py:106 expects "
@@ -2382,7 +2393,7 @@ def test_bitsandbytes_linear4bit_init_signature():
     ``bitsandbytes.nn.modules.Linear4bit.__init__(input_features,
     output_features, ...)`` (zoo's patched forward dereferences
     self.weight / self.bias)."""
-    bnb = pytest.importorskip("bitsandbytes")
+    bnb = _bitsandbytes_or_skip()
     cls = getattr(bnb.nn.modules, "Linear4bit", None)
     if cls is None:
         pytest.fail(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -844,7 +844,9 @@ def make_baseline_loss_fn():
             mask = mx.logical_and(steps >= lengths[:, 0:1], steps < lengths[:, 1:])
             ce = nn.losses.cross_entropy(logits, targets) * mask
             ntoks = mask.sum()
-            ce = ce.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
+            # Raw ntoks (no safe denominator) to match mlx_lm default_loss
+            # byte-for-byte; the safe wrapper stays on the labels-aware path.
+            ce = ce.astype(mx.float32).sum() / ntoks
             return ce, ntoks
         # labels-aware path: train_on_responses_only style masking.
         inputs = batch[:, :-1]

--- a/unsloth_zoo/stubs/bitsandbytes_stub.py
+++ b/unsloth_zoo/stubs/bitsandbytes_stub.py
@@ -40,7 +40,10 @@ class _Noop:
     Optional-feature probes that use ``hasattr`` or ``if bnb.foo`` still
     work via ``__getattr__`` and ``__bool__``.
     """
-    def __init__(self, name="stub"): self._name = name
+    def __init__(self, *args, **kwargs):
+        # Accept any args, incl. the (name, bases, namespace) triple Python
+        # passes when a stubbed class is subclassed at import (e.g. Linear4bit).
+        self._name = args[0] if args else kwargs.get("name", "stub")
     def __call__(self, *a, **kw):
         raise NotImplementedError(
             f"Unsloth: '{self._name}' was called on Apple Silicon / MLX, "
@@ -88,6 +91,8 @@ class _BnbFinder(MetaPathFinder):
 
 __version__ = "0.46.0"
 __path__ = []
+# Lets callers tell this stub from real bitsandbytes (e.g. drift tests skip on it).
+IS_UNSLOTH_STUB = True
 
 def __getattr__(name):
     """Module-level __getattr__ (Python 3.7+): any missing attr returns a _Noop."""


### PR DESCRIPTION
## Summary

Four CPU tests fail on `unsloth_zoo` main under two upstream conditions that now co-occur in CI:

1. The MLX-on-torch simulation (activated by the `test_mlx_*` suite) installs a permissive bitsandbytes stub into `sys.modules` for the rest of the session.
2. transformers reached 5.5.0.

None of these are production bugs; they are test-harness and upstream-drift issues. This PR fixes all four so the CPU matrix and the cross-repo full-suite integration job go green.

## Changes

- **stubs/bitsandbytes_stub.py**: `_Noop.__init__` now accepts arbitrary args, including the `(name, bases, namespace)` triple Python passes when a stubbed class is used as a base. `vllm_utils` defines `class Linear4bit(bitsandbytes.nn.modules.Linear4bit)` at import time; against the stub that construction previously raised, taking down 17 `test_vllm_to_hf_conversion` tests. Also exposes an `IS_UNSLOTH_STUB` marker.
- **tests/test_temporary_patches_exhaustive.py**: the bitsandbytes signature-pin tests now skip when bitsandbytes resolves to the stub (via the new marker). Pinning the real upstream `Linear4bit.__init__` signature is meaningless against a stub, so this avoids a false DRIFT.
- **mlx/utils.py**: the baseline loss `labels=None` fast path divides by raw `ntoks` again, to stay byte-for-byte equivalent to `mlx_lm.tuner.trainer.default_loss`. The `_safe_token_denominator` wrapper (fp32 cast plus maximum) stays on the labels-aware path, where labels can be all `-100` and `ntoks` can legitimately be 0.
- **tests/test_mlx_save_export_regressions.py**: the `_download` shim now accepts `allow_patterns`, which `from_pretrained`'s config download forwards upstream. Without it the shim raised, the adapter base-remap path fell through to a direct load, and the test surfaced an unrelated `lazy` kwarg error on transformers 5.5.0.

## Failing tests fixed (20)

- `test_vllm_to_hf_conversion.py` (17 nodes)
- `test_temporary_patches_exhaustive.py::test_bitsandbytes_linear4bit_init_signature`
- `test_mlx_save_export_regressions.py::test_adapter_bnb_base_remap_defaults_to_mlx_4bit_quantization`
- `test_mlx_baseline_loss_parity.py::test_no_safe_token_denominator_in_fast_path`

## Validation

On transformers 5.5.0, the four groups run together in the CI-reproducing order (an mlx module first, which leaks the bnb stub, then the vllm and drift tests):

```
pytest tests/test_mlx_baseline_loss_parity.py \
       tests/test_mlx_save_export_regressions.py \
       tests/test_vllm_to_hf_conversion.py \
       tests/test_temporary_patches_exhaustive.py::test_bitsandbytes_linear4bit_init_signature
-> 100 passed
```

The drift test passes against real bitsandbytes and skips against the stub. No production code path changes behavior: the stub edit only affects the Apple Silicon / MLX stub, and the loss change restores the documented mlx-lm parity guarded by `test_no_safe_token_denominator_in_fast_path`.
