### PR TITLE
Guard MLX distributed eval against zero-token batches

### DIFF
--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1503,9 +1503,7 @@ class MLXTrainer:
                     # Zero-token eval batches (distributed_pad_mode="empty" padding
                     # rows) make loss NaN; mask them so NaN * 0 does not poison the
                     # distributed all-sum. mx.where never selects the NaN branch.
-                    all_losses += mx.where(
-                        ntoks > 0, loss * ntoks, mx.zeros_like(all_losses)
-                    )
+                    all_losses += mx.where(ntoks > 0, loss * ntoks, 0.0)
                     ntokens += ntoks
                     mx.eval(all_losses, ntokens)
                 except Exception as exc:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1500,7 +1500,12 @@ class MLXTrainer:
                     else:
                         batch, lengths, labels = batch_data
                         loss, ntoks = loss_fn(self.model, batch, lengths, labels)
-                    all_losses += loss * ntoks
+                    # Zero-token eval batches (distributed_pad_mode="empty" padding
+                    # rows) make loss NaN; mask them so NaN * 0 does not poison the
+                    # distributed all-sum. mx.where never selects the NaN branch.
+                    all_losses += mx.where(
+                        ntoks > 0, loss * ntoks, mx.zeros_like(all_losses)
+                    )
                     ntokens += ntoks
                     mx.eval(all_losses, ntokens)
                 except Exception as exc:


### PR DESCRIPTION
## Summary

Follow-up to #886. That PR restored the baseline loss `labels=None` fast path to divide by raw `ntoks` for byte-for-byte mlx-lm `default_loss` parity, which is correct for the gradient path. This adds the matching guard on the distributed eval aggregation site so a zero-token batch cannot poison the all-reduced eval loss.

## The bug

With raw `ntoks`, distributed text evaluation using `distributed_pad_mode="empty"` can hand a rank a tail batch with only padding rows (`lengths == [0, 0]`), so the mask has no supervised tokens and `ntoks == 0`. The fast path then returns `loss = 0/0 = NaN`, and `_evaluate_batch_totals` did `all_losses += loss * ntoks = NaN * 0 = NaN`, which `_distributed_all_sum` spreads to every rank even when the other ranks have real tokens.

## The fix

Mask the zero-token contribution at the aggregation site with `mx.where(ntoks > 0, loss * ntoks, 0)`. `mx.where` never selects the NaN branch when `ntoks == 0`, so the eval sum stays finite. The loss function itself is untouched, so raw `ntoks` and the mlx-lm parity guarded by `test_no_safe_token_denominator_in_fast_path` are preserved. The training path uses `distributed_pad_mode="cycle"` (never zero-token), so gradients are unaffected.

## Validation

- `tests/test_mlx_baseline_loss_parity.py` and `tests/test_mlx_trainer_internals.py`: pass (parity intact, fast path still raw `ntoks`).
- Repro over an eval stream `[(NaN, ntoks=0), (2.5, ntoks=4)]`: old aggregation gives `avg = NaN`, new aggregation gives `avg = 2.5`.
