### PR TITLE
Fix doubled lm_head gradient in Unsloth_Offloaded_Log_Softmax backward

### DIFF
--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -350,3 +350,13 @@ def test_offloaded_log_softmax_pinned_offload_is_event_synced_and_guarded():
     # CUDA machinery stays behind is_cuda; CPU-only platforms take the pageable path.
     assert "is_cuda" in fwd
     assert 'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)' in fwd
+
+
+def test_offloaded_log_softmax_keep_on_gpu_budget_is_cumulative():
+    # The padded GRPO loop runs N forwards before any backward; a per-chunk
+    # 4x-free check alone compounds retained chunks toward all free memory.
+    src = inspect.getsource(rr.grpo_accumulated_loss)
+    block = src[src.index("    def to_device"):src.index("    def efficient_log_softmax")]
+    assert "offload_retained_bytes = [0]" in block
+    assert "4 * (tensor_bytes + offload_retained_bytes[0]) <= free_bytes" in block
+    assert "offload_retained_bytes[0] += tensor_bytes" in block

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -291,3 +291,84 @@ def test_offloaded_recompute_weight_grad_not_double_counted(shared, preexisting)
     # The buggy pattern (autograd.backward + return leaf .grad) diverges -- guards the test.
     buggy = _recompute_fn(use_backward=True)
     assert not torch.allclose(_weight_grad(buggy.apply, shared, preexisting), ref, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Unsloth_Offloaded_Log_Softmax offload paths (pinned / keep-on-GPU / CPU)
+# ---------------------------------------------------------------------------
+#
+# Forward offloads hidden_states to a pinned host buffer on a side stream (async
+# D2H) when the GPU is tight, keeps the alias on GPU when there is headroom, and
+# falls back to a plain pageable copy on CPU / no CUDA / pinned-alloc failure.
+# The event sync in backward is load-bearing: a pinned non_blocking copy without
+# it is a use-before-copy race. These tests pin the CPU fallback numerics and
+# the CUDA-path source invariants (all CUDA calls guarded by is_cuda).
+
+
+def _eager_selective_log_softmax(hidden_states, lm_head, index, chunks,
+                                 logit_scale_multiply, logit_scale_divide,
+                                 logit_softcapping, temperature):
+    # Eager mirror of chunked_hidden_states_selective_log_softmax (no compile).
+    logits = hidden_states.reshape(-1, hidden_states.shape[-1]).to(lm_head.dtype) @ lm_head.t()
+    if logit_scale_multiply != 0.0:
+        logits = logits * logit_scale_multiply
+    if logit_scale_divide != 0.0:
+        logits = logits / logit_scale_divide
+    if logit_softcapping != 0.0:
+        logits = logit_softcapping * torch.tanh(logits / logit_softcapping)
+    logits = logits.to(torch.float32)
+    if temperature != 1.0:
+        logits = logits / temperature
+    flat_index = index.reshape(-1)
+    selected = torch.gather(logits, dim=-1, index=flat_index.unsqueeze(-1)).squeeze(-1)
+    out = selected - torch.logsumexp(logits, dim=-1)
+    return out.reshape(index.shape)
+
+
+def _extract_offloaded_log_softmax(inner_fn):
+    # Exec the nested to_device + Unsloth_Offloaded_Log_Softmax block from the
+    # real source against `inner_fn`, exactly like the generated trainer inlines it.
+    import textwrap
+    src = inspect.getsource(rr.grpo_accumulated_loss)
+    block = textwrap.dedent(src[src.index("    def to_device"):src.index("    def efficient_log_softmax")])
+    ns = {"torch": torch, "chunked_hidden_states_selective_log_softmax": inner_fn}
+    exec(block, ns)
+    return ns["Unsloth_Offloaded_Log_Softmax"]
+
+
+@pytest.mark.parametrize("lm_requires_grad", [False, True])
+def test_offloaded_log_softmax_cpu_path_grads_bitwise_exact(lm_requires_grad):
+    Fn = _extract_offloaded_log_softmax(_eager_selective_log_softmax)
+    args = (4, 1.5, 2.0, 20.0, 0.8)
+
+    def run(op):
+        torch.manual_seed(0)
+        hs = (torch.randn(3, 32, 16) * 0.02).requires_grad_(True)
+        lm = (torch.randn(64, 16) * 0.02).requires_grad_(lm_requires_grad)
+        idx = torch.randint(0, 64, (3, 32))
+        go = torch.randn(3, 32)
+        out = op(hs, lm, idx, *args)
+        out.backward(go)
+        return out.detach(), hs.grad, (lm.grad if lm_requires_grad else None)
+
+    out_ref, hs_ref, lm_ref = run(_eager_selective_log_softmax)
+    out_fn, hs_fn, lm_fn = run(Fn.apply)
+    assert torch.equal(out_fn, out_ref)
+    assert torch.equal(hs_fn, hs_ref)
+    if lm_requires_grad:
+        assert torch.equal(lm_fn, lm_ref)
+
+
+def test_offloaded_log_softmax_pinned_offload_is_event_synced_and_guarded():
+    src = inspect.getsource(rr.grpo_accumulated_loss)
+    fwd = src[src.index("class Unsloth_Offloaded_Log_Softmax"):src.index("def efficient_log_softmax")]
+    # The pinned non_blocking D2H must record an event on the copy stream, keep
+    # the source storage alive across streams, and backward must wait on it.
+    assert "pin_memory = True" in fwd
+    assert "copy_event.record(copy_stream)" in fwd
+    assert "record_stream(copy_stream)" in fwd
+    assert "ctx.copy_event.wait(" in fwd
+    # All CUDA-only machinery stays behind an is_cuda check so CPU / no-CUDA
+    # (Windows, Mac) still take the plain pageable path.
+    assert "is_cuda" in fwd
+    assert 'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)' in fwd

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -216,30 +216,20 @@ def test_RL_REPLACEMENTS_contains_public_api_keys():
 # ---------------------------------------------------------------------------
 # Unsloth_Offloaded_Log_Softmax backward returns LOCAL input gradients
 # ---------------------------------------------------------------------------
-#
-# The offloaded log-softmax Function recomputes its output in backward. It must return
-# each input's local gradient contribution. Using torch.autograd.backward (which writes
-# leaf .grad) and returning lm_head.grad double-counts: the outer engine's AccumulateGrad
-# adds it again (2x for a single use, more when lm_head is shared across chunks) and
-# corrupts any grad already accumulated on lm_head. torch.autograd.grad returns the local
-# grads without touching leaf .grad. Reachable on the offload path (long-completion /
-# large-batch GRPO) whenever lm_head / tied embeddings are trainable; frozen lm_head
-# (standard LoRA) returns None and is unaffected.
+# backward must return LOCAL grads via autograd.grad; backward + leaf .grad
+# double-counts through the outer AccumulateGrad when lm_head is trainable.
 
 
 def test_offloaded_log_softmax_uses_autograd_grad_not_backward():
     src = inspect.getsource(rr.grpo_accumulated_loss)
     assert "class Unsloth_Offloaded_Log_Softmax" in src
-    # The fix: local grads via torch.autograd.grad, not backward + leaf .grad return.
     assert "torch.autograd.grad(" in src
     assert "torch.autograd.backward(output, grad_output)" not in src
     assert "lm_head.grad if ctx.lm_head_requires_grad else None" not in src
 
 
 def _recompute_fn(use_backward):
-    # Mirrors the offloaded Function's recompute-in-backward over a plain inner op (x @ W).
-    # use_backward=True is the buggy variant (autograd.backward + return the leaf .grad),
-    # use_backward=False is the fix (autograd.grad returns the local contribution).
+    # Recompute-in-backward mirror; use_backward=True is the buggy variant, False the fix.
     class _Fn(torch.autograd.Function):
         @staticmethod
         def forward(ctx, x, W):
@@ -265,8 +255,6 @@ def _recompute_fn(use_backward):
 
 
 def _weight_grad(op, shared, preexisting):
-    # Accumulate W.grad through `op` (either a custom Function.apply or plain matmul), for
-    # a single use and for two uses sharing W, optionally starting from a pre-existing grad.
     torch.manual_seed(0)
     x1 = torch.randn(6, 8)
     x2 = torch.randn(6, 8)
@@ -283,12 +271,10 @@ def _weight_grad(op, shared, preexisting):
 @pytest.mark.parametrize("shared", [False, True])
 @pytest.mark.parametrize("preexisting", [False, True])
 def test_offloaded_recompute_weight_grad_not_double_counted(shared, preexisting):
-    # Oracle: plain autograd through the same op, no custom Function.
     ref = _weight_grad(lambda x, W: x @ W, shared, preexisting)
-    # The fix (autograd.grad) matches the oracle exactly.
     fixed = _recompute_fn(use_backward=False)
     assert torch.allclose(_weight_grad(fixed.apply, shared, preexisting), ref, atol=1e-6)
-    # The buggy pattern (autograd.backward + return leaf .grad) diverges -- guards the test.
+    # Buggy variant must diverge, or this test proves nothing.
     buggy = _recompute_fn(use_backward=True)
     assert not torch.allclose(_weight_grad(buggy.apply, shared, preexisting), ref, atol=1e-4)
 
@@ -296,13 +282,8 @@ def test_offloaded_recompute_weight_grad_not_double_counted(shared, preexisting)
 # ---------------------------------------------------------------------------
 # Unsloth_Offloaded_Log_Softmax offload paths (pinned / keep-on-GPU / CPU)
 # ---------------------------------------------------------------------------
-#
-# Forward offloads hidden_states to a pinned host buffer on a side stream (async
-# D2H) when the GPU is tight, keeps the alias on GPU when there is headroom, and
-# falls back to a plain pageable copy on CPU / no CUDA / pinned-alloc failure.
-# The event sync in backward is load-bearing: a pinned non_blocking copy without
-# it is a use-before-copy race. These tests pin the CPU fallback numerics and
-# the CUDA-path source invariants (all CUDA calls guarded by is_cuda).
+# Pins CPU-fallback numerics and CUDA-path source invariants; backward's event
+# wait is load-bearing (pinned non_blocking copy races without it).
 
 
 def _eager_selective_log_softmax(hidden_states, lm_head, index, chunks,
@@ -326,8 +307,7 @@ def _eager_selective_log_softmax(hidden_states, lm_head, index, chunks,
 
 
 def _extract_offloaded_log_softmax(inner_fn):
-    # Exec the nested to_device + Unsloth_Offloaded_Log_Softmax block from the
-    # real source against `inner_fn`, exactly like the generated trainer inlines it.
+    # Exec the real Unsloth_Offloaded_Log_Softmax block against `inner_fn`.
     import textwrap
     src = inspect.getsource(rr.grpo_accumulated_loss)
     block = textwrap.dedent(src[src.index("    def to_device"):src.index("    def efficient_log_softmax")])
@@ -362,13 +342,11 @@ def test_offloaded_log_softmax_cpu_path_grads_bitwise_exact(lm_requires_grad):
 def test_offloaded_log_softmax_pinned_offload_is_event_synced_and_guarded():
     src = inspect.getsource(rr.grpo_accumulated_loss)
     fwd = src[src.index("class Unsloth_Offloaded_Log_Softmax"):src.index("def efficient_log_softmax")]
-    # The pinned non_blocking D2H must record an event on the copy stream, keep
-    # the source storage alive across streams, and backward must wait on it.
+    # Pinned D2H must record an event, keep the source alive, and backward must wait on it.
     assert "pin_memory = True" in fwd
     assert "copy_event.record(copy_stream)" in fwd
     assert "record_stream(copy_stream)" in fwd
     assert "ctx.copy_event.wait(" in fwd
-    # All CUDA-only machinery stays behind an is_cuda check so CPU / no-CUDA
-    # (Windows, Mac) still take the plain pageable path.
+    # CUDA machinery stays behind is_cuda; CPU-only platforms take the pageable path.
     assert "is_cuda" in fwd
     assert 'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)' in fwd

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -25,6 +25,7 @@ Covers:
 
 from __future__ import annotations
 
+import inspect
 import math
 from types import SimpleNamespace
 
@@ -210,3 +211,83 @@ def test_RL_REPLACEMENTS_contains_public_api_keys():
     }
     missing = expected - set(rr.RL_REPLACEMENTS.keys())
     assert not missing, f"RL_REPLACEMENTS missing public-API keys: {sorted(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# Unsloth_Offloaded_Log_Softmax backward returns LOCAL input gradients
+# ---------------------------------------------------------------------------
+#
+# The offloaded log-softmax Function recomputes its output in backward. It must return
+# each input's local gradient contribution. Using torch.autograd.backward (which writes
+# leaf .grad) and returning lm_head.grad double-counts: the outer engine's AccumulateGrad
+# adds it again (2x for a single use, more when lm_head is shared across chunks) and
+# corrupts any grad already accumulated on lm_head. torch.autograd.grad returns the local
+# grads without touching leaf .grad. Reachable on the offload path (long-completion /
+# large-batch GRPO) whenever lm_head / tied embeddings are trainable; frozen lm_head
+# (standard LoRA) returns None and is unaffected.
+
+
+def test_offloaded_log_softmax_uses_autograd_grad_not_backward():
+    src = inspect.getsource(rr.grpo_accumulated_loss)
+    assert "class Unsloth_Offloaded_Log_Softmax" in src
+    # The fix: local grads via torch.autograd.grad, not backward + leaf .grad return.
+    assert "torch.autograd.grad(" in src
+    assert "torch.autograd.backward(output, grad_output)" not in src
+    assert "lm_head.grad if ctx.lm_head_requires_grad else None" not in src
+
+
+def _recompute_fn(use_backward):
+    # Mirrors the offloaded Function's recompute-in-backward over a plain inner op (x @ W).
+    # use_backward=True is the buggy variant (autograd.backward + return the leaf .grad),
+    # use_backward=False is the fix (autograd.grad returns the local contribution).
+    class _Fn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, W):
+            ctx.x = x.detach()
+            ctx.W = W
+            ctx.W_rg = W.requires_grad
+            with torch.no_grad():
+                return x @ W
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            x = ctx.x.clone().requires_grad_(True)
+            W = ctx.W
+            with torch.enable_grad():
+                out = x @ W
+            if use_backward:
+                torch.autograd.backward(out, grad_output)
+                return x.grad, (W.grad if ctx.W_rg else None)
+            grads = torch.autograd.grad(out, (x, W) if ctx.W_rg else (x,), grad_output)
+            return grads[0], (grads[1] if ctx.W_rg else None)
+
+    return _Fn
+
+
+def _weight_grad(op, shared, preexisting):
+    # Accumulate W.grad through `op` (either a custom Function.apply or plain matmul), for
+    # a single use and for two uses sharing W, optionally starting from a pre-existing grad.
+    torch.manual_seed(0)
+    x1 = torch.randn(6, 8)
+    x2 = torch.randn(6, 8)
+    W = torch.randn(8, 10, requires_grad=True)
+    g1 = torch.randn(6, 10)
+    g2 = torch.randn(6, 10)
+    W.grad = torch.randn(8, 10) if preexisting else None
+    torch.autograd.backward(op(x1, W), g1, retain_graph=True)
+    if shared:
+        torch.autograd.backward(op(x2, W), g2)
+    return W.grad.clone()
+
+
+@pytest.mark.parametrize("shared", [False, True])
+@pytest.mark.parametrize("preexisting", [False, True])
+def test_offloaded_recompute_weight_grad_not_double_counted(shared, preexisting):
+    # Oracle: plain autograd through the same op, no custom Function.
+    ref = _weight_grad(lambda x, W: x @ W, shared, preexisting)
+    # The fix (autograd.grad) matches the oracle exactly.
+    fixed = _recompute_fn(use_backward=False)
+    assert torch.allclose(_weight_grad(fixed.apply, shared, preexisting), ref, atol=1e-6)
+    # The buggy pattern (autograd.backward + return leaf .grad) diverges -- guards the test.
+    buggy = _recompute_fn(use_backward=True)
+    assert not torch.allclose(_weight_grad(buggy.apply, shared, preexisting), ref, atol=1e-4)

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -383,6 +383,21 @@ def test_offloaded_log_softmax_stream_module_dispatch(monkeypatch, vendor, hip_v
         assert got is getattr(torch, "xpu", None), (vendor, got)
 
 
+def test_offloaded_log_softmax_releases_clone_before_forward_compute():
+    # hidden_states is normally a [:, :-1, :] slice, so .contiguous() allocates a
+    # full copy. Holding it across the no-grad log-softmax would keep it resident
+    # alongside the chunk logits and raise the forward-phase peak; measured at
+    # +0.376 GiB on an 8x8192x4096 bf16 chunk before this ordering was fixed.
+    # record_stream still blocks reuse until the D2H lands, so dropping the
+    # reference early is safe.
+    block = _offloaded_block_source()
+    released = block.index("del detached_hidden_states")
+    compute = block.index("with torch.no_grad():")
+    assert released < compute, "clone must be released before the forward compute"
+    # and nothing may use it after the release
+    assert "detached_hidden_states" not in block[released + 30:compute]
+
+
 def test_offloaded_log_softmax_stream_module_accepts_tensor_or_device():
     pick = _exec_offloaded_block(_eager_selective_log_softmax)["_offload_device_module"]
     assert pick(torch.zeros(1)) is None

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -311,12 +311,15 @@ def _offloaded_block_source():
     return textwrap.dedent(src[src.index("    def to_device"):src.index("    def efficient_log_softmax")])
 
 
-def _extract_offloaded_log_softmax(inner_fn):
+def _exec_offloaded_block(inner_fn):
     # Exec the real block against `inner_fn` instead of the compiled kernel.
-    block = _offloaded_block_source()
     ns = {"torch": torch, "chunked_hidden_states_selective_log_softmax": inner_fn}
-    exec(block, ns)
-    return ns["Unsloth_Offloaded_Log_Softmax"]
+    exec(_offloaded_block_source(), ns)
+    return ns
+
+
+def _extract_offloaded_log_softmax(inner_fn):
+    return _exec_offloaded_block(inner_fn)["Unsloth_Offloaded_Log_Softmax"]
 
 
 @pytest.mark.parametrize("lm_requires_grad", [False, True])
@@ -349,9 +352,20 @@ def test_offloaded_log_softmax_pinned_offload_is_event_synced_and_guarded():
     assert "copy_event.record(copy_stream)" in fwd
     assert "record_stream(copy_stream)" in fwd
     assert "ctx.copy_event.wait(" in fwd
-    # CUDA machinery stays behind is_cuda so CPU-only platforms still work.
-    assert "is_cuda" in fwd
     assert 'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)' in fwd
+
+
+def test_offloaded_log_softmax_stream_module_covers_amd_and_intel():
+    # torch.cuda is also the HIP backend, so ROCm needs no branch of its own;
+    # Intel has its own namespace, as in gradient_checkpointing.py. Every other
+    # device must return None and take the pageable copy rather than crash.
+    pick = _exec_offloaded_block(_eager_selective_log_softmax)["_offload_device_module"]
+    assert pick(torch.device("cuda")) is torch.cuda           # NVIDIA and AMD/ROCm
+    assert pick(torch.device("xpu")) is getattr(torch, "xpu", None)   # Intel
+    for other in ("cpu", "meta"):
+        assert pick(torch.device(other)) is None, other
+    # accepts a tensor as well as a device
+    assert pick(torch.zeros(1)) is None
 
 
 def test_offloaded_log_softmax_never_retains_hidden_states_on_gpu():
@@ -360,11 +374,13 @@ def test_offloaded_log_softmax_never_retains_hidden_states_on_gpu():
     block = _offloaded_block_source()
     assigns = [ln.strip() for ln in block.splitlines()
                if "saved_hidden_states =" in ln and "ctx.saved_hidden_states" not in ln]
-    assert assigns == [
-        "saved_hidden_states = None",
+    # Any number of "= None" resets is fine; what matters is that the only values
+    # ever stored are the pinned host buffer and the CPU copy, never the device tensor.
+    stored = [a for a in assigns if a != "saved_hidden_states = None"]
+    assert stored == [
         "saved_hidden_states = pinned_buffer",
         'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)',
-    ], assigns
+    ], stored
     # No memory-budget heuristic may decide to keep the tensor on device.
     assert "mem_get_info" not in block
     assert "offload_retained_bytes" not in block

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -306,11 +306,15 @@ def _eager_selective_log_softmax(hidden_states, lm_head, index, chunks,
     return out.reshape(index.shape)
 
 
-def _extract_offloaded_log_softmax(inner_fn):
-    # Exec the real Unsloth_Offloaded_Log_Softmax block against `inner_fn`.
+def _offloaded_block_source():
     import textwrap
     src = inspect.getsource(rr.grpo_accumulated_loss)
-    block = textwrap.dedent(src[src.index("    def to_device"):src.index("    def efficient_log_softmax")])
+    return textwrap.dedent(src[src.index("    def to_device"):src.index("    def efficient_log_softmax")])
+
+
+def _extract_offloaded_log_softmax(inner_fn):
+    # Exec the real Unsloth_Offloaded_Log_Softmax block against `inner_fn`.
+    block = _offloaded_block_source()
     ns = {"torch": torch, "chunked_hidden_states_selective_log_softmax": inner_fn}
     exec(block, ns)
     return ns["Unsloth_Offloaded_Log_Softmax"]
@@ -352,11 +356,41 @@ def test_offloaded_log_softmax_pinned_offload_is_event_synced_and_guarded():
     assert 'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)' in fwd
 
 
-def test_offloaded_log_softmax_keep_on_gpu_budget_is_cumulative():
-    # The padded GRPO loop runs N forwards before any backward; a per-chunk
-    # 4x-free check alone compounds retained chunks toward all free memory.
-    src = inspect.getsource(rr.grpo_accumulated_loss)
-    block = src[src.index("    def to_device"):src.index("    def efficient_log_softmax")]
-    assert "offload_retained_bytes = [0]" in block
-    assert "4 * (tensor_bytes + offload_retained_bytes[0]) <= free_bytes" in block
-    assert "offload_retained_bytes[0] += tensor_bytes" in block
+def test_offloaded_log_softmax_never_retains_hidden_states_on_gpu():
+    # This Function only runs on long-completion / large-batch GRPO, i.e. when the
+    # caller is already memory bound, so hidden states must always leave the GPU.
+    # Retaining them instead raises the free VRAM needed to finish a step.
+    block = _offloaded_block_source()
+    assigns = [ln.strip() for ln in block.splitlines()
+               if "saved_hidden_states =" in ln and "ctx.saved_hidden_states" not in ln]
+    assert assigns == [
+        "saved_hidden_states = None",
+        "saved_hidden_states = pinned_buffer",
+        'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)',
+    ], assigns
+    # No memory-budget heuristic may decide to keep the tensor on device.
+    assert "mem_get_info" not in block
+    assert "offload_retained_bytes" not in block
+
+
+def test_offloaded_log_softmax_preserves_preexisting_head_grad():
+    # Behavioural guard for the bug this Function had: gradient accumulation must
+    # leave lm_head.grad at P + g, not 2*P + 2*g.
+    Fn = _extract_offloaded_log_softmax(_eager_selective_log_softmax)
+    args = (4, 0.0, 0.0, 0.0, 1.0)
+
+    def run(op):
+        torch.manual_seed(0)
+        hs = (torch.randn(3, 32, 16) * 0.02).requires_grad_(True)
+        lm = (torch.randn(64, 16) * 0.02).requires_grad_(True)
+        idx = torch.randint(0, 64, (3, 32))
+        go = torch.randn(3, 32)
+        pre = torch.randn(64, 16) * 0.01
+        lm.grad = pre.clone()
+        op(hs, lm, idx, *args).backward(go)
+        return lm.grad, pre
+
+    got, pre_got = run(Fn.apply)
+    ref, pre_ref = run(_eager_selective_log_softmax)
+    assert torch.equal(pre_got, pre_ref)
+    assert torch.allclose(got, ref, atol=1e-6), (got - ref).abs().max()

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -370,6 +370,33 @@ def test_offloaded_log_softmax_never_retains_hidden_states_on_gpu():
     assert "offload_retained_bytes" not in block
 
 
+@pytest.mark.parametrize("head", ["leaf", "nonleaf"])
+def test_offloaded_log_softmax_runs_head_hook_once(head):
+    # A Tensor.register_hook fires for tensors named in autograd.grad's `inputs`,
+    # so recomputing against the real lm_head would apply a user's grad mask or
+    # scaler twice. The recompute must use a private detached leaf.
+    Fn = _extract_offloaded_log_softmax(_eager_selective_log_softmax)
+    args = (4, 0.0, 0.0, 0.0, 1.0)
+
+    def run(op, hook):
+        torch.manual_seed(0)
+        hs = (torch.randn(3, 32, 16) * 0.02).requires_grad_(True)
+        base = (torch.randn(64, 16) * 0.02).requires_grad_(True)
+        lm = base if head == "leaf" else base * 1.5
+        fired = []
+        lm.register_hook(lambda g: (fired.append(1), hook(g))[1])
+        idx = torch.randint(0, 64, (3, 32))
+        go = torch.randn(3, 32)
+        op(hs, lm, idx, *args).backward(go)
+        return len(fired), base.grad
+
+    scale = lambda g: g * 0.5  # noqa: E731
+    n_fn, g_fn = run(Fn.apply, scale)
+    n_ref, g_ref = run(_eager_selective_log_softmax, scale)
+    assert n_fn == n_ref == 1, (n_fn, n_ref)
+    assert torch.allclose(g_fn, g_ref, atol=1e-6), (g_fn - g_ref).abs().max()
+
+
 def test_offloaded_log_softmax_preserves_preexisting_head_grad():
     # Accumulation must leave lm_head.grad at P + g, not 2*P + 2*g.
     Fn = _extract_offloaded_log_softmax(_eager_selective_log_softmax)

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -216,8 +216,7 @@ def test_RL_REPLACEMENTS_contains_public_api_keys():
 # ---------------------------------------------------------------------------
 # Unsloth_Offloaded_Log_Softmax backward returns LOCAL input gradients
 # ---------------------------------------------------------------------------
-# backward must return LOCAL grads via autograd.grad; backward + leaf .grad
-# double-counts through the outer AccumulateGrad when lm_head is trainable.
+# backward + leaf .grad double-counts through the outer AccumulateGrad.
 
 
 def test_offloaded_log_softmax_uses_autograd_grad_not_backward():
@@ -229,7 +228,7 @@ def test_offloaded_log_softmax_uses_autograd_grad_not_backward():
 
 
 def _recompute_fn(use_backward):
-    # Recompute-in-backward mirror; use_backward=True is the buggy variant, False the fix.
+    # Recompute-in-backward mirror; use_backward=True is the buggy variant.
     class _Fn(torch.autograd.Function):
         @staticmethod
         def forward(ctx, x, W):
@@ -280,10 +279,10 @@ def test_offloaded_recompute_weight_grad_not_double_counted(shared, preexisting)
 
 
 # ---------------------------------------------------------------------------
-# Unsloth_Offloaded_Log_Softmax offload paths (pinned / keep-on-GPU / CPU)
+# Unsloth_Offloaded_Log_Softmax offload paths (pinned CUDA / pageable CPU)
 # ---------------------------------------------------------------------------
-# Pins CPU-fallback numerics and CUDA-path source invariants; backward's event
-# wait is load-bearing (pinned non_blocking copy races without it).
+# backward's event wait is load-bearing: the pinned non_blocking copy races
+# without it.
 
 
 def _eager_selective_log_softmax(hidden_states, lm_head, index, chunks,
@@ -313,7 +312,7 @@ def _offloaded_block_source():
 
 
 def _extract_offloaded_log_softmax(inner_fn):
-    # Exec the real Unsloth_Offloaded_Log_Softmax block against `inner_fn`.
+    # Exec the real block against `inner_fn` instead of the compiled kernel.
     block = _offloaded_block_source()
     ns = {"torch": torch, "chunked_hidden_states_selective_log_softmax": inner_fn}
     exec(block, ns)
@@ -346,20 +345,18 @@ def test_offloaded_log_softmax_cpu_path_grads_bitwise_exact(lm_requires_grad):
 def test_offloaded_log_softmax_pinned_offload_is_event_synced_and_guarded():
     src = inspect.getsource(rr.grpo_accumulated_loss)
     fwd = src[src.index("class Unsloth_Offloaded_Log_Softmax"):src.index("def efficient_log_softmax")]
-    # Pinned D2H must record an event, keep the source alive, and backward must wait on it.
     assert "pin_memory = True" in fwd
     assert "copy_event.record(copy_stream)" in fwd
     assert "record_stream(copy_stream)" in fwd
     assert "ctx.copy_event.wait(" in fwd
-    # CUDA machinery stays behind is_cuda; CPU-only platforms take the pageable path.
+    # CUDA machinery stays behind is_cuda so CPU-only platforms still work.
     assert "is_cuda" in fwd
     assert 'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)' in fwd
 
 
 def test_offloaded_log_softmax_never_retains_hidden_states_on_gpu():
-    # This Function only runs on long-completion / large-batch GRPO, i.e. when the
-    # caller is already memory bound, so hidden states must always leave the GPU.
-    # Retaining them instead raises the free VRAM needed to finish a step.
+    # The caller is already memory bound, so retaining hidden states on device
+    # would raise the free VRAM needed to finish a step.
     block = _offloaded_block_source()
     assigns = [ln.strip() for ln in block.splitlines()
                if "saved_hidden_states =" in ln and "ctx.saved_hidden_states" not in ln]
@@ -374,8 +371,7 @@ def test_offloaded_log_softmax_never_retains_hidden_states_on_gpu():
 
 
 def test_offloaded_log_softmax_preserves_preexisting_head_grad():
-    # Behavioural guard for the bug this Function had: gradient accumulation must
-    # leave lm_head.grad at P + g, not 2*P + 2*g.
+    # Accumulation must leave lm_head.grad at P + g, not 2*P + 2*g.
     Fn = _extract_offloaded_log_softmax(_eager_selective_log_softmax)
     args = (4, 0.0, 0.0, 0.0, 1.0)
 

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -355,17 +355,38 @@ def test_offloaded_log_softmax_pinned_offload_is_event_synced_and_guarded():
     assert 'saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)' in fwd
 
 
-def test_offloaded_log_softmax_stream_module_covers_amd_and_intel():
-    # torch.cuda is also the HIP backend, so ROCm needs no branch of its own;
-    # Intel has its own namespace, as in gradient_checkpointing.py. Every other
-    # device must return None and take the pageable copy rather than crash.
+@pytest.mark.parametrize(
+    "vendor,hip_version,device,expect",
+    [
+        # torch.cuda is also the HIP backend, so ROCm reports device.type "cuda"
+        # and needs no branch of its own; see gradient_checkpointing.py, which
+        # likewise treats DEVICE_TYPE in ("cuda", "hip") identically.
+        ("nvidia", None, "cuda", "torch.cuda"),
+        ("amd_rocm", "6.2.41134", "cuda", "torch.cuda"),
+        ("intel", None, "xpu", "torch.xpu"),
+        # anything else must return None and take the pageable copy, not crash
+        ("cpu_only", None, "cpu", None),
+        ("meta", None, "meta", None),
+    ],
+)
+def test_offloaded_log_softmax_stream_module_dispatch(monkeypatch, vendor, hip_version,
+                                                      device, expect):
+    if hip_version is not None:
+        monkeypatch.setattr(torch.version, "hip", hip_version, raising=False)
     pick = _exec_offloaded_block(_eager_selective_log_softmax)["_offload_device_module"]
-    assert pick(torch.device("cuda")) is torch.cuda           # NVIDIA and AMD/ROCm
-    assert pick(torch.device("xpu")) is getattr(torch, "xpu", None)   # Intel
-    for other in ("cpu", "meta"):
-        assert pick(torch.device(other)) is None, other
-    # accepts a tensor as well as a device
+    got = pick(torch.device(device))
+    if expect is None:
+        assert got is None, (vendor, got)
+    elif expect == "torch.cuda":
+        assert got is torch.cuda, (vendor, got)
+    else:
+        assert got is getattr(torch, "xpu", None), (vendor, got)
+
+
+def test_offloaded_log_softmax_stream_module_accepts_tensor_or_device():
+    pick = _exec_offloaded_block(_eager_selective_log_softmax)["_offload_device_module"]
     assert pick(torch.zeros(1)) is None
+    assert pick(torch.zeros(1).device) is None
 
 
 def test_offloaded_log_softmax_never_retains_hidden_states_on_gpu():

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1346,6 +1346,9 @@ def grpo_accumulated_loss(
         if tensor is None: return None
         return tensor.to(device, non_blocking=non_blocking)
 
+    # Bytes kept on GPU by this step's chunk loop; recreated per call, so no cross-step state.
+    offload_retained_bytes = [0]
+
     class Unsloth_Offloaded_Log_Softmax(torch.autograd.Function):
         """Manual gradient checkpointing / CPU offloading for log softmax."""
         @staticmethod
@@ -1364,9 +1367,12 @@ def grpo_accumulated_loss(
                     tensor_bytes = detached_hidden_states.numel() * detached_hidden_states.element_size()
                 except Exception:
                     free_bytes, tensor_bytes = 0, 1
-                if tensor_bytes * 4 <= free_bytes:
-                    # Enough headroom: keep the alias on GPU (mem_get_info failure defaults to offload).
+                if 4 * (tensor_bytes + offload_retained_bytes[0]) <= free_bytes:
+                    # Headroom must also cover chunks already kept this step: the padded loop
+                    # runs N forwards before any backward, and per-chunk 4x checks alone
+                    # compound toward all free memory (mem_get_info failure defaults to offload).
                     saved_hidden_states = detached_hidden_states
+                    offload_retained_bytes[0] += tensor_bytes
                 else:
                     # Async D2H via pinned buffer on a side stream; backward MUST wait on
                     # copy_event before the H2D reload or the copy races.

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1389,11 +1389,20 @@ def grpo_accumulated_loss(
                     hidden_states, lm_head, index, *ctx.args
                 )
 
-            torch.autograd.backward(output, grad_output)
+            # Use torch.autograd.grad (not torch.autograd.backward) so we return each
+            # input's LOCAL gradient contribution. torch.autograd.backward writes into the
+            # leaf .grad attributes; returning lm_head.grad would then be double-counted by
+            # the outer engine's AccumulateGrad (2x for a single use, more when lm_head is
+            # shared across chunks) and would corrupt any grad already accumulated on lm_head.
+            grad_inputs = torch.autograd.grad(
+                output,
+                (hidden_states, lm_head) if ctx.lm_head_requires_grad else (hidden_states,),
+                grad_output,
+            )
 
             return (
-                hidden_states.grad,
-                lm_head.grad if ctx.lm_head_requires_grad else None,
+                grad_inputs[0],
+                grad_inputs[1] if ctx.lm_head_requires_grad else None,
                 None,
                 None,
                 None,

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1353,9 +1353,48 @@ def grpo_accumulated_loss(
                     logit_scale_multiply, logit_scale_divide,
                     logit_softcapping, temperature):
             # Detach so we don't keep the graph (and extra memory) on CPU.
-            ctx.saved_hidden_states = hidden_states.detach().contiguous().to("cpu", non_blocking=True)
+            detached_hidden_states = hidden_states.detach().contiguous()
             ctx.device = hidden_states.device
-            ctx.dtype = hidden_states.dtype
+            ctx.copy_event = None
+
+            saved_hidden_states = None
+            if detached_hidden_states.is_cuda:
+                try:
+                    free_bytes, _ = torch.cuda.mem_get_info(detached_hidden_states.device)
+                    tensor_bytes = detached_hidden_states.numel() * detached_hidden_states.element_size()
+                except Exception:
+                    free_bytes, tensor_bytes = 0, 1
+                if tensor_bytes * 4 <= free_bytes:
+                    # Plenty of GPU headroom: skip the CPU round-trip (2 PCIe copies).
+                    # The storage already lives on the GPU, so keeping this alias adds
+                    # no allocation; we still checkpoint the big logits via recompute.
+                    saved_hidden_states = detached_hidden_states
+                else:
+                    # Offload through a pinned host buffer on a side stream so the D2H
+                    # copy is truly asynchronous (it overlaps the no_grad forward below)
+                    # and the H2D reload in backward is fast. The event sync in backward
+                    # is required: without it the pinned non_blocking copy is a
+                    # use-before-copy race.
+                    try:
+                        pinned_buffer = torch.empty_like(detached_hidden_states, device = "cpu", pin_memory = True)
+                    except (RuntimeError, OSError):
+                        pinned_buffer = None
+                    if pinned_buffer is not None:
+                        current_stream = torch.cuda.current_stream(detached_hidden_states.device)
+                        copy_stream = torch.cuda.Stream(device = detached_hidden_states.device)
+                        copy_stream.wait_stream(current_stream)
+                        with torch.cuda.stream(copy_stream):
+                            pinned_buffer.copy_(detached_hidden_states, non_blocking = True)
+                        # Keep the GPU storage alive until the side-stream copy finishes.
+                        detached_hidden_states.record_stream(copy_stream)
+                        copy_event = torch.cuda.Event()
+                        copy_event.record(copy_stream)
+                        saved_hidden_states = pinned_buffer
+                        ctx.copy_event = copy_event
+            if saved_hidden_states is None:
+                # CPU tensor, no CUDA, or pinned allocation failed: original pageable path.
+                saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)
+            ctx.saved_hidden_states = saved_hidden_states
 
             ctx.lm_head = lm_head
             ctx.lm_head_requires_grad = lm_head.requires_grad
@@ -1371,17 +1410,19 @@ def grpo_accumulated_loss(
 
         @staticmethod
         def backward(ctx, grad_output):
-            hidden_states = to_device(ctx.saved_hidden_states, ctx.device)
-            hidden_states = hidden_states.to(ctx.dtype)
+            saved_hidden_states = ctx.saved_hidden_states
+            if saved_hidden_states.is_cuda:
+                # Kept on GPU: no reload needed.
+                hidden_states = saved_hidden_states
+            else:
+                if ctx.copy_event is not None:
+                    # Order the H2D reload after the async D2H offload completes.
+                    ctx.copy_event.wait(torch.cuda.current_stream(ctx.device))
+                # Saved tensor keeps the forward dtype, so no cast is needed here.
+                hidden_states = to_device(saved_hidden_states, ctx.device)
             hidden_states.requires_grad_(True)
 
             lm_head = ctx.lm_head
-            # #Possibly redundant lines
-            # if ctx.lm_head_requires_grad:
-            #     hidden_states.requires_grad_(True)
-            # else:
-            #     lm_head = lm_head.detach()
-
             index = ctx.index
 
             with torch.enable_grad():

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1365,16 +1365,11 @@ def grpo_accumulated_loss(
                 except Exception:
                     free_bytes, tensor_bytes = 0, 1
                 if tensor_bytes * 4 <= free_bytes:
-                    # Plenty of GPU headroom: skip the CPU round-trip (2 PCIe copies).
-                    # The storage already lives on the GPU, so keeping this alias adds
-                    # no allocation; we still checkpoint the big logits via recompute.
+                    # Enough headroom: keep the alias on GPU (mem_get_info failure defaults to offload).
                     saved_hidden_states = detached_hidden_states
                 else:
-                    # Offload through a pinned host buffer on a side stream so the D2H
-                    # copy is truly asynchronous (it overlaps the no_grad forward below)
-                    # and the H2D reload in backward is fast. The event sync in backward
-                    # is required: without it the pinned non_blocking copy is a
-                    # use-before-copy race.
+                    # Async D2H via pinned buffer on a side stream; backward MUST wait on
+                    # copy_event before the H2D reload or the copy races.
                     try:
                         pinned_buffer = torch.empty_like(detached_hidden_states, device = "cpu", pin_memory = True)
                     except (RuntimeError, OSError):
@@ -1385,14 +1380,14 @@ def grpo_accumulated_loss(
                         copy_stream.wait_stream(current_stream)
                         with torch.cuda.stream(copy_stream):
                             pinned_buffer.copy_(detached_hidden_states, non_blocking = True)
-                        # Keep the GPU storage alive until the side-stream copy finishes.
+                        # record_stream keeps the GPU storage alive until the side-stream copy finishes.
                         detached_hidden_states.record_stream(copy_stream)
                         copy_event = torch.cuda.Event()
                         copy_event.record(copy_stream)
                         saved_hidden_states = pinned_buffer
                         ctx.copy_event = copy_event
             if saved_hidden_states is None:
-                # CPU tensor, no CUDA, or pinned allocation failed: original pageable path.
+                # CPU / no CUDA / pinned alloc failed: pageable copy.
                 saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)
             ctx.saved_hidden_states = saved_hidden_states
 
@@ -1412,13 +1407,11 @@ def grpo_accumulated_loss(
         def backward(ctx, grad_output):
             saved_hidden_states = ctx.saved_hidden_states
             if saved_hidden_states.is_cuda:
-                # Kept on GPU: no reload needed.
                 hidden_states = saved_hidden_states
             else:
                 if ctx.copy_event is not None:
-                    # Order the H2D reload after the async D2H offload completes.
+                    # Wait for the async D2H offload before reloading H2D.
                     ctx.copy_event.wait(torch.cuda.current_stream(ctx.device))
-                # Saved tensor keeps the forward dtype, so no cast is needed here.
                 hidden_states = to_device(saved_hidden_states, ctx.device)
             hidden_states.requires_grad_(True)
 
@@ -1430,11 +1423,8 @@ def grpo_accumulated_loss(
                     hidden_states, lm_head, index, *ctx.args
                 )
 
-            # Use torch.autograd.grad (not torch.autograd.backward) so we return each
-            # input's LOCAL gradient contribution. torch.autograd.backward writes into the
-            # leaf .grad attributes; returning lm_head.grad would then be double-counted by
-            # the outer engine's AccumulateGrad (2x for a single use, more when lm_head is
-            # shared across chunks) and would corrupt any grad already accumulated on lm_head.
+            # autograd.grad, not backward: backward writes leaf .grad, and returning
+            # lm_head.grad would be double-counted by the outer AccumulateGrad.
             grad_inputs = torch.autograd.grad(
                 output,
                 (hidden_states, lm_head) if ctx.lm_head_requires_grad else (hidden_states,),

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1346,9 +1346,6 @@ def grpo_accumulated_loss(
         if tensor is None: return None
         return tensor.to(device, non_blocking=non_blocking)
 
-    # Bytes kept on GPU by this step's chunk loop; recreated per call, so no cross-step state.
-    offload_retained_bytes = [0]
-
     class Unsloth_Offloaded_Log_Softmax(torch.autograd.Function):
         """Manual gradient checkpointing / CPU offloading for log softmax."""
         @staticmethod
@@ -1360,38 +1357,29 @@ def grpo_accumulated_loss(
             ctx.device = hidden_states.device
             ctx.copy_event = None
 
+            # Always offload. This path only runs on long-completion / large-batch GRPO,
+            # where the caller is memory bound by definition, so hidden states are never
+            # retained on GPU: the win here is overlapping the copy, not skipping it.
             saved_hidden_states = None
             if detached_hidden_states.is_cuda:
+                # Async D2H via pinned buffer on a side stream; backward MUST wait on
+                # copy_event before the H2D reload or the copy races.
                 try:
-                    free_bytes, _ = torch.cuda.mem_get_info(detached_hidden_states.device)
-                    tensor_bytes = detached_hidden_states.numel() * detached_hidden_states.element_size()
-                except Exception:
-                    free_bytes, tensor_bytes = 0, 1
-                if 4 * (tensor_bytes + offload_retained_bytes[0]) <= free_bytes:
-                    # Headroom must also cover chunks already kept this step: the padded loop
-                    # runs N forwards before any backward, and per-chunk 4x checks alone
-                    # compound toward all free memory (mem_get_info failure defaults to offload).
-                    saved_hidden_states = detached_hidden_states
-                    offload_retained_bytes[0] += tensor_bytes
-                else:
-                    # Async D2H via pinned buffer on a side stream; backward MUST wait on
-                    # copy_event before the H2D reload or the copy races.
-                    try:
-                        pinned_buffer = torch.empty_like(detached_hidden_states, device = "cpu", pin_memory = True)
-                    except (RuntimeError, OSError):
-                        pinned_buffer = None
-                    if pinned_buffer is not None:
-                        current_stream = torch.cuda.current_stream(detached_hidden_states.device)
-                        copy_stream = torch.cuda.Stream(device = detached_hidden_states.device)
-                        copy_stream.wait_stream(current_stream)
-                        with torch.cuda.stream(copy_stream):
-                            pinned_buffer.copy_(detached_hidden_states, non_blocking = True)
-                        # record_stream keeps the GPU storage alive until the side-stream copy finishes.
-                        detached_hidden_states.record_stream(copy_stream)
-                        copy_event = torch.cuda.Event()
-                        copy_event.record(copy_stream)
-                        saved_hidden_states = pinned_buffer
-                        ctx.copy_event = copy_event
+                    pinned_buffer = torch.empty_like(detached_hidden_states, device = "cpu", pin_memory = True)
+                except (RuntimeError, OSError):
+                    pinned_buffer = None
+                if pinned_buffer is not None:
+                    current_stream = torch.cuda.current_stream(detached_hidden_states.device)
+                    copy_stream = torch.cuda.Stream(device = detached_hidden_states.device)
+                    copy_stream.wait_stream(current_stream)
+                    with torch.cuda.stream(copy_stream):
+                        pinned_buffer.copy_(detached_hidden_states, non_blocking = True)
+                    # record_stream keeps the GPU storage alive until the side-stream copy finishes.
+                    detached_hidden_states.record_stream(copy_stream)
+                    copy_event = torch.cuda.Event()
+                    copy_event.record(copy_stream)
+                    saved_hidden_states = pinned_buffer
+                    ctx.copy_event = copy_event
             if saved_hidden_states is None:
                 # CPU / no CUDA / pinned alloc failed: pageable copy.
                 saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)
@@ -1411,14 +1399,10 @@ def grpo_accumulated_loss(
 
         @staticmethod
         def backward(ctx, grad_output):
-            saved_hidden_states = ctx.saved_hidden_states
-            if saved_hidden_states.is_cuda:
-                hidden_states = saved_hidden_states
-            else:
-                if ctx.copy_event is not None:
-                    # Wait for the async D2H offload before reloading H2D.
-                    ctx.copy_event.wait(torch.cuda.current_stream(ctx.device))
-                hidden_states = to_device(saved_hidden_states, ctx.device)
+            if ctx.copy_event is not None:
+                # Wait for the async D2H offload before reloading H2D.
+                ctx.copy_event.wait(torch.cuda.current_stream(ctx.device))
+            hidden_states = to_device(ctx.saved_hidden_states, ctx.device)
             hidden_states.requires_grad_(True)
 
             lm_head = ctx.lm_head

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1357,13 +1357,12 @@ def grpo_accumulated_loss(
             ctx.device = hidden_states.device
             ctx.copy_event = None
 
-            # Always offload. This path only runs on long-completion / large-batch GRPO,
-            # where the caller is memory bound by definition, so hidden states are never
-            # retained on GPU: the win here is overlapping the copy, not skipping it.
+            # Always offload: this path only runs when the caller is already memory bound
+            # (long completions / large batches), so the win is overlapping the copy.
             saved_hidden_states = None
             if detached_hidden_states.is_cuda:
-                # Async D2H via pinned buffer on a side stream; backward MUST wait on
-                # copy_event before the H2D reload or the copy races.
+                # Async D2H on a side stream; backward MUST wait on copy_event before
+                # the H2D reload or it races the copy.
                 try:
                     pinned_buffer = torch.empty_like(detached_hidden_states, device = "cpu", pin_memory = True)
                 except (RuntimeError, OSError):
@@ -1374,14 +1373,14 @@ def grpo_accumulated_loss(
                     copy_stream.wait_stream(current_stream)
                     with torch.cuda.stream(copy_stream):
                         pinned_buffer.copy_(detached_hidden_states, non_blocking = True)
-                    # record_stream keeps the GPU storage alive until the side-stream copy finishes.
+                    # Keeps the GPU storage alive until the side-stream copy finishes.
                     detached_hidden_states.record_stream(copy_stream)
                     copy_event = torch.cuda.Event()
                     copy_event.record(copy_stream)
                     saved_hidden_states = pinned_buffer
                     ctx.copy_event = copy_event
             if saved_hidden_states is None:
-                # CPU / no CUDA / pinned alloc failed: pageable copy.
+                # No CUDA, or pinned alloc failed: pageable copy.
                 saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)
             ctx.saved_hidden_states = saved_hidden_states
 
@@ -1400,7 +1399,7 @@ def grpo_accumulated_loss(
         @staticmethod
         def backward(ctx, grad_output):
             if ctx.copy_event is not None:
-                # Wait for the async D2H offload before reloading H2D.
+                # The offload copy must land before the H2D reload.
                 ctx.copy_event.wait(torch.cuda.current_stream(ctx.device))
             hidden_states = to_device(ctx.saved_hidden_states, ctx.device)
             hidden_states.requires_grad_(True)
@@ -1413,8 +1412,8 @@ def grpo_accumulated_loss(
                     hidden_states, lm_head, index, *ctx.args
                 )
 
-            # autograd.grad, not backward: backward writes leaf .grad, and returning
-            # lm_head.grad would be double-counted by the outer AccumulateGrad.
+            # autograd.grad, not backward: backward writes into leaf .grad, which the
+            # outer AccumulateGrad would then double-count.
             grad_inputs = torch.autograd.grad(
                 output,
                 (hidden_states, lm_head) if ctx.lm_head_requires_grad else (hidden_states,),

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1405,6 +1405,12 @@ def grpo_accumulated_loss(
             hidden_states.requires_grad_(True)
 
             lm_head = ctx.lm_head
+            if ctx.lm_head_requires_grad:
+                # Recompute against a private leaf. A Tensor.register_hook on the real
+                # lm_head fires for tensors named in autograd.grad's inputs, so reusing
+                # it here would run a user's grad mask / scaler once on this local
+                # gradient and again when the returned gradient reaches lm_head.
+                lm_head = lm_head.detach().requires_grad_(True)
             index = ctx.index
 
             with torch.enable_grad():

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1346,6 +1346,16 @@ def grpo_accumulated_loss(
         if tensor is None: return None
         return tensor.to(device, non_blocking=non_blocking)
 
+    def _offload_device_module(tensor_or_device):
+        # Stream/Event module for the offload copy. torch.cuda is also the HIP
+        # backend, so ROCm reports is_cuda and needs no branch of its own; XPU has
+        # its own namespace, matching gradient_checkpointing.py. Anything else
+        # (CPU, MPS, ...) returns None and takes the pageable copy.
+        device = getattr(tensor_or_device, "device", tensor_or_device)
+        if device.type == "cuda": return torch.cuda
+        if device.type == "xpu": return getattr(torch, "xpu", None)
+        return None
+
     class Unsloth_Offloaded_Log_Softmax(torch.autograd.Function):
         """Manual gradient checkpointing / CPU offloading for log softmax."""
         @staticmethod
@@ -1360,27 +1370,31 @@ def grpo_accumulated_loss(
             # Always offload: this path only runs when the caller is already memory bound
             # (long completions / large batches), so the win is overlapping the copy.
             saved_hidden_states = None
-            if detached_hidden_states.is_cuda:
+            device_module = _offload_device_module(detached_hidden_states)
+            if device_module is not None:
                 # Async D2H on a side stream; backward MUST wait on copy_event before
                 # the H2D reload or it races the copy.
                 try:
                     pinned_buffer = torch.empty_like(detached_hidden_states, device = "cpu", pin_memory = True)
-                except (RuntimeError, OSError):
-                    pinned_buffer = None
-                if pinned_buffer is not None:
-                    current_stream = torch.cuda.current_stream(detached_hidden_states.device)
-                    copy_stream = torch.cuda.Stream(device = detached_hidden_states.device)
-                    copy_stream.wait_stream(current_stream)
-                    with torch.cuda.stream(copy_stream):
-                        pinned_buffer.copy_(detached_hidden_states, non_blocking = True)
-                    # Keeps the GPU storage alive until the side-stream copy finishes.
-                    detached_hidden_states.record_stream(copy_stream)
-                    copy_event = torch.cuda.Event()
-                    copy_event.record(copy_stream)
-                    saved_hidden_states = pinned_buffer
-                    ctx.copy_event = copy_event
+                    if pinned_buffer is not None:
+                        current_stream = device_module.current_stream(detached_hidden_states.device)
+                        copy_stream = device_module.Stream(device = detached_hidden_states.device)
+                        copy_stream.wait_stream(current_stream)
+                        with device_module.stream(copy_stream):
+                            pinned_buffer.copy_(detached_hidden_states, non_blocking = True)
+                        # Keeps the GPU storage alive until the side-stream copy finishes.
+                        detached_hidden_states.record_stream(copy_stream)
+                        copy_event = device_module.Event()
+                        copy_event.record(copy_stream)
+                        saved_hidden_states = pinned_buffer
+                        ctx.copy_event = copy_event
+                except (RuntimeError, OSError, AttributeError):
+                    # Any accelerator that cannot do pinned side-stream copies falls
+                    # back below; correctness never depends on this path.
+                    saved_hidden_states = None
+                    ctx.copy_event = None
             if saved_hidden_states is None:
-                # No CUDA, or pinned alloc failed: pageable copy.
+                # No accelerator, or the async copy is unavailable: pageable copy.
                 saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)
             ctx.saved_hidden_states = saved_hidden_states
 
@@ -1400,7 +1414,8 @@ def grpo_accumulated_loss(
         def backward(ctx, grad_output):
             if ctx.copy_event is not None:
                 # The offload copy must land before the H2D reload.
-                ctx.copy_event.wait(torch.cuda.current_stream(ctx.device))
+                device_module = _offload_device_module(ctx.device)
+                ctx.copy_event.wait(device_module.current_stream(ctx.device))
             hidden_states = to_device(ctx.saved_hidden_states, ctx.device)
             hidden_states.requires_grad_(True)
 

--- a/unsloth_zoo/rl_replacements.py
+++ b/unsloth_zoo/rl_replacements.py
@@ -1397,6 +1397,12 @@ def grpo_accumulated_loss(
                 # No accelerator, or the async copy is unavailable: pageable copy.
                 saved_hidden_states = detached_hidden_states.to("cpu", non_blocking = True)
             ctx.saved_hidden_states = saved_hidden_states
+            # Drop the clone before the log-softmax below. hidden_states is usually a
+            # [:, :-1, :] slice, so .contiguous() allocated a full copy; holding the
+            # reference across the forward would keep it resident alongside the chunk
+            # logits. record_stream still blocks reuse until the D2H lands, so the
+            # allocator reclaims it mid-compute rather than at the end of forward.
+            del detached_hidden_states
 
             ctx.lm_head = lm_head
             ctx.lm_head_requires_grad = lm_head.requires_grad


### PR DESCRIPTION
### What

`Unsloth_Offloaded_Log_Softmax` (the CPU-offloading / checkpointed log-softmax used for the large / long-completion GRPO logprob path via `efficient_log_softmax`) recomputes its output in backward, then did:

```python
torch.autograd.backward(output, grad_output)
return (hidden_states.grad, lm_head.grad if ctx.lm_head_requires_grad else None, ...)
```

`torch.autograd.backward` writes into the leaf `.grad` attributes. Returning `lm_head.grad` as this op's gradient contribution then gets accumulated **again** by the outer engine's `AccumulateGrad`, so:

- lm_head gradient is **2x** too large for a single use,
- **more** when `lm_head` is shared across chunks (the normal GRPO path -- the same output embedding feeds every `compute_logprobs_chunk` call), and
- any gradient already accumulated on `lm_head` from a previous micro-batch is **corrupted** (returned as `2*pre + 2*g` instead of `pre + g`).

### Fix

Use `torch.autograd.grad(output, inputs, grad_output)`, which returns each input's **local** gradient contribution without touching leaf `.grad`. `hidden_states.grad` was already correct (its reloaded tensor is a private leaf) and is unchanged.

### Reachability

Only on the offload path (`index.shape[1] > 1024` or `batch_size > 8`, i.e. long-completion / large-batch GRPO) **and** with a trainable `lm_head` / tied embeddings (full fine-tuning, or LoRA with `modules_to_save=["lm_head"]`). Standard LoRA freezes `lm_head`, so the old path returned `None` and was unaffected.

### Verification

Reproduced against the non-offloaded twin `chunked_hidden_states_selective_log_softmax` as oracle: before the fix, `|lm_head.grad| / |ref|` was exactly 2.0 (single use) and 3.0 (two shared uses), with pre-existing grad corrupted to `2*pre + 2*g`; after the fix all cases match the oracle exactly (ratio 1.0, max abs diff 0.0), and `hidden_states.grad` stays exact. Added a CPU regression test that pins the pattern (fixed matches plain-autograd oracle for single / shared / pre-existing-grad; the old pattern provably diverges) plus a source guard.