### PR TITLE
fix(mlx): accept Studio VLM singular image batches

### DIFF
--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -485,35 +485,15 @@ def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
     assert processor.images_seen[0] == ["embedded"]
 
 
-def test_vlm_top_level_image_key_falls_back_after_bare_placeholder_error(monkeypatch):
-    import unsloth_zoo.vision_utils as vision_utils
+def test_vlm_top_level_image_key_falls_back_after_real_bare_placeholder_error():
     from unsloth_zoo.mlx.utils import _extract_vlm_images
-
-    def fail_process_vision_info(*_args, **_kwargs):
-        raise ValueError("image, image_url or video should in content.")
-
-    monkeypatch.setattr(
-        vision_utils,
-        "process_vision_info",
-        fail_process_vision_info,
-    )
 
     messages = [{"role": "user", "content": [{"type": "image"}]}]
     assert _extract_vlm_images({"image": "top-level"}, messages, image_size=16) == ["top-level"]
 
 
-def test_vlm_collate_passes_studio_top_level_image_to_processor(monkeypatch):
-    import unsloth_zoo.vision_utils as vision_utils
+def test_vlm_collate_passes_studio_top_level_image_to_processor():
     from unsloth_zoo.mlx.utils import _collate_vlm_batch
-
-    def fail_process_vision_info(*_args, **_kwargs):
-        raise ValueError("image, image_url or video should in content.")
-
-    monkeypatch.setattr(
-        vision_utils,
-        "process_vision_info",
-        fail_process_vision_info,
-    )
 
     processor = _ConversationalPromptCompletionProcessor()
     _collate_vlm_batch(

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -485,11 +485,13 @@ def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
     assert processor.images_seen[0] == ["embedded"]
 
 
-def test_vlm_top_level_image_key_uses_bare_image_placeholder_fallback():
-    from unsloth_zoo.mlx.utils import _extract_vlm_images
+def test_vlm_prompt_completion_uses_top_level_image_for_bare_placeholder():
+    from unsloth_zoo.mlx.utils import _extract_vlm_pc_images
 
     messages = [{"role": "user", "content": [{"type": "image"}]}]
-    assert _extract_vlm_images({"image": "top-level"}, messages, image_size=16) == ["top-level"]
+    assert _extract_vlm_pc_images(
+        {"image": "top-level"}, messages, [], image_size=16,
+    ) == ["top-level"]
 
 
 def test_vlm_collate_passes_studio_top_level_image_to_processor():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -485,10 +485,31 @@ def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
     assert processor.images_seen[0] == ["embedded"]
 
 
-def test_vlm_top_level_image_key_is_not_cuda_images_alias():
+def test_vlm_top_level_image_key_supports_studio_adapter_shape(monkeypatch):
+    import unsloth_zoo.vision_utils as vision_utils
     from unsloth_zoo.mlx.utils import _extract_vlm_images
 
-    assert _extract_vlm_images({"image": "top-level"}, [], image_size=16) == []
+    def fail_process_vision_info(*_args, **_kwargs):
+        raise AssertionError("top-level image should be used before message fallback")
+
+    monkeypatch.setattr(
+        vision_utils,
+        "process_vision_info",
+        fail_process_vision_info,
+    )
+
+    messages = [{"role": "user", "content": [{"type": "image"}]}]
+    assert _extract_vlm_images({"image": "top-level"}, messages, image_size=16) == ["top-level"]
+
+
+def test_vlm_top_level_images_key_still_wins_over_image_key():
+    from unsloth_zoo.mlx.utils import _extract_vlm_images
+
+    assert _extract_vlm_images(
+        {"images": ["plural"], "image": "singular"},
+        [],
+        image_size=16,
+    ) == ["plural"]
 
 
 def test_vlm_image_extraction_raises_process_errors_like_cuda(monkeypatch):

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -525,6 +525,14 @@ def test_vlm_top_level_images_key_still_wins_over_image_key():
     ) == ["plural"]
 
 
+def test_vlm_top_level_image_key_requires_bare_image_placeholder():
+    from unsloth_zoo.mlx.utils import _extract_vlm_images
+
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Q"}]}]
+    assert _extract_vlm_images({"image": "top-level"}, messages, image_size=16) == []
+    assert _extract_vlm_images({"image": "top-level"}, [], image_size=16) == []
+
+
 def test_vlm_image_extraction_raises_process_errors_like_cuda(monkeypatch):
     import unsloth_zoo.vision_utils as vision_utils
     from unsloth_zoo.mlx.utils import _extract_vlm_images

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -533,6 +533,20 @@ def test_vlm_top_level_image_key_requires_bare_image_placeholder():
     assert _extract_vlm_images({"image": "top-level"}, [], image_size=16) == []
 
 
+def test_vlm_top_level_image_key_rejects_mixed_bare_placeholders():
+    from unsloth_zoo.mlx.utils import _extract_vlm_images
+
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "image"},
+            {"type": "video"},
+        ],
+    }]
+    with pytest.raises(ValueError, match="image, image_url or video"):
+        _extract_vlm_images({"image": "top-level"}, messages, image_size=16)
+
+
 def test_vlm_image_extraction_raises_process_errors_like_cuda(monkeypatch):
     import unsloth_zoo.vision_utils as vision_utils
     from unsloth_zoo.mlx.utils import _extract_vlm_images

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -485,12 +485,12 @@ def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
     assert processor.images_seen[0] == ["embedded"]
 
 
-def test_vlm_top_level_image_key_supports_studio_adapter_shape(monkeypatch):
+def test_vlm_top_level_image_key_falls_back_after_bare_placeholder_error(monkeypatch):
     import unsloth_zoo.vision_utils as vision_utils
     from unsloth_zoo.mlx.utils import _extract_vlm_images
 
     def fail_process_vision_info(*_args, **_kwargs):
-        raise AssertionError("top-level image should be used before message fallback")
+        raise ValueError("image, image_url or video should in content.")
 
     monkeypatch.setattr(
         vision_utils,
@@ -500,6 +500,39 @@ def test_vlm_top_level_image_key_supports_studio_adapter_shape(monkeypatch):
 
     messages = [{"role": "user", "content": [{"type": "image"}]}]
     assert _extract_vlm_images({"image": "top-level"}, messages, image_size=16) == ["top-level"]
+
+
+def test_vlm_collate_passes_studio_top_level_image_to_processor(monkeypatch):
+    import unsloth_zoo.vision_utils as vision_utils
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch
+
+    def fail_process_vision_info(*_args, **_kwargs):
+        raise ValueError("image, image_url or video should in content.")
+
+    monkeypatch.setattr(
+        vision_utils,
+        "process_vision_info",
+        fail_process_vision_info,
+    )
+
+    processor = _ConversationalPromptCompletionProcessor()
+    _collate_vlm_batch(
+        [{
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "Q"},
+                ],
+            }],
+            "image": "top-level",
+        }],
+        processor,
+        max_seq_length=8,
+        image_size=16,
+    )
+
+    assert processor.images_seen == [["top-level"]]
 
 
 def test_vlm_top_level_images_key_still_wins_over_image_key():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -485,7 +485,7 @@ def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
     assert processor.images_seen[0] == ["embedded"]
 
 
-def test_vlm_top_level_image_key_falls_back_after_real_bare_placeholder_error():
+def test_vlm_top_level_image_key_uses_bare_image_placeholder_fallback():
     from unsloth_zoo.mlx.utils import _extract_vlm_images
 
     messages = [{"role": "user", "content": [{"type": "image"}]}]

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3514,10 +3514,10 @@ def _resize_vlm_images(images, image_size):
 
 
 def _vlm_vision_part_state(messages):
-    has_bare_placeholder = False
+    bare_placeholder_types = set()
     has_media_payload = False
     if not isinstance(messages, list):
-        return has_bare_placeholder, has_media_payload
+        return bare_placeholder_types, has_media_payload
     for message in messages:
         if not isinstance(message, dict):
             continue
@@ -3532,8 +3532,8 @@ def _vlm_vision_part_state(messages):
             if any(key in part for key in ("image", "image_url", "video")):
                 has_media_payload = True
             else:
-                has_bare_placeholder = True
-    return has_bare_placeholder, has_media_payload
+                bare_placeholder_types.add(part.get("type"))
+    return bare_placeholder_types, has_media_payload
 
 
 def _vlm_bare_placeholder_error(exc):
@@ -3549,7 +3549,8 @@ def _extract_vlm_images(
 ):
     images = []
     top_level_image = []
-    has_bare_placeholder, has_media_payload = _vlm_vision_part_state(messages)
+    bare_placeholder_types, has_media_payload = _vlm_vision_part_state(messages)
+    has_bare_image_placeholder = "image" in bare_placeholder_types
     if isinstance(item, dict):
         image = item.get("images")
         if image is not None:
@@ -3584,14 +3585,14 @@ def _extract_vlm_images(
             process_error = exc
             can_fallback = (
                 top_level_image
-                and has_bare_placeholder
+                and has_bare_image_placeholder
                 and not has_media_payload
                 and _vlm_bare_placeholder_error(exc)
             )
             if not can_fallback and not suppress_process_errors:
                 raise
 
-    if not images and top_level_image and not has_media_payload:
+    if not images and top_level_image and has_bare_image_placeholder and not has_media_payload:
         images = top_level_image
     if not images and process_error is not None and not suppress_process_errors:
         raise process_error

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3529,7 +3529,7 @@ def _vlm_vision_part_state(messages):
                 continue
             if part.get("type") not in ("image", "image_url", "input_image", "video"):
                 continue
-            if any(key in part for key in ("image", "image_url", "video")):
+            if any(key in part for key in ("image", "image_url", "input_image", "video")):
                 has_media_payload = True
             else:
                 bare_placeholder_types.add(part.get("type"))
@@ -3550,7 +3550,7 @@ def _extract_vlm_images(
     images = []
     top_level_image = []
     bare_placeholder_types, has_media_payload = _vlm_vision_part_state(messages)
-    has_bare_image_placeholder = "image" in bare_placeholder_types
+    has_only_bare_image_placeholders = bare_placeholder_types == {"image"}
     if isinstance(item, dict):
         image = item.get("images")
         if image is not None:
@@ -3585,14 +3585,14 @@ def _extract_vlm_images(
             process_error = exc
             can_fallback = (
                 top_level_image
-                and has_bare_image_placeholder
+                and has_only_bare_image_placeholders
                 and not has_media_payload
                 and _vlm_bare_placeholder_error(exc)
             )
             if not can_fallback and not suppress_process_errors:
                 raise
 
-    if not images and top_level_image and has_bare_image_placeholder and not has_media_payload:
+    if not images and top_level_image and has_only_bare_image_placeholders and not has_media_payload:
         images = top_level_image
     if not images and process_error is not None and not suppress_process_errors:
         raise process_error

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3521,6 +3521,7 @@ def _extract_vlm_images(
     suppress_process_errors=False,
 ):
     images = []
+    top_level_image = []
     if isinstance(item, dict):
         image = item.get("images")
         if image is not None:
@@ -3528,7 +3529,7 @@ def _extract_vlm_images(
         elif "image" in item:
             image = item.get("image")
             if image is not None:
-                images = image if isinstance(image, list) else [image]
+                top_level_image = image if isinstance(image, list) else [image]
 
     if not images and isinstance(messages, list):
         for message in messages:
@@ -3541,6 +3542,7 @@ def _extract_vlm_images(
                     if image is not None:
                         images.append(image)
 
+    process_error = None
     if not images and isinstance(messages, list):
         try:
             from ..vision_utils import process_vision_info
@@ -3550,9 +3552,15 @@ def _extract_vlm_images(
                 maybe_images = extracted[0]
                 if maybe_images is not None:
                     images = maybe_images if isinstance(maybe_images, list) else [maybe_images]
-        except Exception:
-            if not suppress_process_errors:
+        except Exception as exc:
+            process_error = exc
+            if not top_level_image and not suppress_process_errors:
                 raise
+
+    if not images and top_level_image:
+        images = top_level_image
+    if not images and process_error is not None and not suppress_process_errors:
+        raise process_error
 
     return _resize_vlm_images(images, image_size)
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3536,10 +3536,6 @@ def _vlm_vision_part_state(messages):
     return bare_placeholder_types, has_media_payload
 
 
-def _vlm_bare_placeholder_error(exc):
-    return "image, image_url or video should in content" in str(exc)
-
-
 def _extract_vlm_images(
     item,
     messages,
@@ -3571,7 +3567,14 @@ def _extract_vlm_images(
                     if image is not None:
                         images.append(image)
 
-    process_error = None
+    if (
+        not images
+        and top_level_image
+        and has_only_bare_image_placeholders
+        and not has_media_payload
+    ):
+        images = top_level_image
+
     if not images and isinstance(messages, list):
         try:
             from ..vision_utils import process_vision_info
@@ -3581,21 +3584,9 @@ def _extract_vlm_images(
                 maybe_images = extracted[0]
                 if maybe_images is not None:
                     images = maybe_images if isinstance(maybe_images, list) else [maybe_images]
-        except Exception as exc:
-            process_error = exc
-            can_fallback = (
-                top_level_image
-                and has_only_bare_image_placeholders
-                and not has_media_payload
-                and _vlm_bare_placeholder_error(exc)
-            )
-            if not can_fallback and not suppress_process_errors:
+        except Exception:
+            if not suppress_process_errors:
                 raise
-
-    if not images and top_level_image and has_only_bare_image_placeholders and not has_media_payload:
-        images = top_level_image
-    if not images and process_error is not None and not suppress_process_errors:
-        raise process_error
 
     return _resize_vlm_images(images, image_size)
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3596,7 +3596,7 @@ def _extract_vlm_pc_images(item, prompt_messages, completion_messages, image_siz
     messages = (prompt_messages or []) + (completion_messages or [])
     if messages:
         images = _extract_vlm_images(
-            {},
+            item if isinstance(item, dict) and item.get("images") is None else {},
             messages,
             image_size,
             suppress_process_errors=True,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3513,6 +3513,33 @@ def _resize_vlm_images(images, image_size):
     return resized
 
 
+def _vlm_vision_part_state(messages):
+    has_bare_placeholder = False
+    has_media_payload = False
+    if not isinstance(messages, list):
+        return has_bare_placeholder, has_media_payload
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content", "")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") not in ("image", "image_url", "video"):
+                continue
+            if any(key in part for key in ("image", "image_url", "video")):
+                has_media_payload = True
+            else:
+                has_bare_placeholder = True
+    return has_bare_placeholder, has_media_payload
+
+
+def _vlm_bare_placeholder_error(exc):
+    return "image, image_url or video should in content" in str(exc)
+
+
 def _extract_vlm_images(
     item,
     messages,
@@ -3522,6 +3549,7 @@ def _extract_vlm_images(
 ):
     images = []
     top_level_image = []
+    has_bare_placeholder, has_media_payload = _vlm_vision_part_state(messages)
     if isinstance(item, dict):
         image = item.get("images")
         if image is not None:
@@ -3554,10 +3582,16 @@ def _extract_vlm_images(
                     images = maybe_images if isinstance(maybe_images, list) else [maybe_images]
         except Exception as exc:
             process_error = exc
-            if not top_level_image and not suppress_process_errors:
+            can_fallback = (
+                top_level_image
+                and has_bare_placeholder
+                and not has_media_payload
+                and _vlm_bare_placeholder_error(exc)
+            )
+            if not can_fallback and not suppress_process_errors:
                 raise
 
-    if not images and top_level_image:
+    if not images and top_level_image and not has_media_payload:
         images = top_level_image
     if not images and process_error is not None and not suppress_process_errors:
         raise process_error

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3525,6 +3525,10 @@ def _extract_vlm_images(
         image = item.get("images")
         if image is not None:
             images = image if isinstance(image, list) else [image]
+        elif "image" in item:
+            image = item.get("image")
+            if image is not None:
+                images = image if isinstance(image, list) else [image]
 
     if not images and isinstance(messages, list):
         for message in messages:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3527,7 +3527,7 @@ def _vlm_vision_part_state(messages):
         for part in content:
             if not isinstance(part, dict):
                 continue
-            if part.get("type") not in ("image", "image_url", "video"):
+            if part.get("type") not in ("image", "image_url", "input_image", "video"):
                 continue
             if any(key in part for key in ("image", "image_url", "video")):
                 has_media_payload = True


### PR DESCRIPTION
## Summary

This fixes MLX VLM collation for Studio-shaped training rows that store the image payload in a top-level singular `image` field while the chat message contains a bare image placeholder. One example dataset that uses this shape is `unsloth/LaTeX_OCR`:

```python
{
    "messages": [
        {
            "role": "user",
            "content": [
                {"type": "image"},
                {"type": "text", "text": "..."},
            ],
        },
        {"role": "assistant", "content": [{"type": "text", "text": "..."}]},
    ],
    "image": image,
}
```

## Root Cause

The MLX VLM image extraction path accepted top-level `images`, inline media payloads, and media returned by `process_vision_info()`, but it did not accept Studio’s singular top-level `image` shape. For rows with a bare `{ "type": "image" }` placeholder, `process_vision_info()` raises because the media payload is intentionally outside the message content. That caused otherwise valid Studio-shaped VLM SFT rows to fail before training.

## Changes

- Detect VLM message content that contains bare image placeholders.
- Allow top-level singular `image` as a fallback only when the message contains bare image placeholders and no inline media payload.
- Preserve precedence for top-level `images` and inline or processable message media.
- Preserve existing error behavior for malformed inline media instead of hiding those errors behind the singular `image` fallback.
- Add focused MLX VLM tests for the Studio-shaped success path and fallback boundaries.

## Reviewer Notes

The fallback is intentionally narrow. It does not make `image` a general alias for `images`; it only covers the Studio-shaped row layout where the message has a bare image placeholder and the row has the actual image payload. Mixed bare placeholders such as image plus video still reject fallback to avoid binding a still image to a non-image media slot.

## Validation

Focused test suite:

```bash
python -m pytest tests/test_mlx_vlm_label_masks.py -q
```

Result:

```text
45 passed
```

## Gemma4 and Dataset Validation

Gemma4 still depends on the transformers sidecar repair in https://github.com/unslothai/unsloth/pull/7402. With this branch merged together with the current https://github.com/unslothai/unsloth/pull/7402 head, `unsloth/gemma-4-E2B-it-UD-MLX-4bit` loads as the expected MLX-VLM processor instead of the tokenizer-only fallback:

```text
mlx_vlm.models.gemma4.processing_gemma4.Gemma4Processor
```

The Studio-shaped SFT smoke used these vision datasets:

```text
unsloth/LaTeX_OCR
AI4Math/MathVerse
```

2-step validation results with `unsloth/gemma-4-E2B-it-UD-MLX-4bit` after merging https://github.com/unslothai/unsloth/pull/7402:

```text
unsloth/LaTeX_OCR: passed, losses [2.9979827404022217, 2.8777084350585938]
AI4Math/MathVerse: passed, losses [3.8615834712982178, 3.614513635635376]
```

Gemma4 should work fine once https://github.com/unslothai/unsloth/pull/7402 is merged together with this PR.
