### PR TITLE
Preserve MLX-VLM contracts across supported releases

### DIFF
--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -79,6 +79,32 @@ def _write_config(tmp_path, config):
     return path
 
 
+def test_vlm_detection_requires_a_real_modality(monkeypatch, tmp_path):
+    import unsloth_zoo.mlx.loader as loader
+    text = tmp_path / "text"
+    text.mkdir()
+    (text / "config.py").write_text("class ModelConfig:\n    text_config: object\n")
+    omni = tmp_path / "omni"
+    omni.mkdir()
+    (omni / "config.py").write_text("class ThinkerConfig:\n    vision_config: object\n")
+    assert not loader._config_source_has_modality(text)
+    assert loader._config_source_has_modality(omni)
+    models = tmp_path / "models"
+    models.mkdir()
+    static_vlm = models / "static_vlm"
+    static_vlm.mkdir()
+    (static_vlm / "__init__.py").write_text("raise RuntimeError('must not import')\n")
+    (static_vlm / "config.py").write_text("class ModelConfig:\n    vision_config: object\n")
+    import mlx_vlm.models as mlx_vlm_models
+    monkeypatch.setattr(mlx_vlm_models, "__path__", [str(models)])
+    assert "static_vlm" in loader._build_vlm_model_types()
+    monkeypatch.setattr(loader, "_vlm_model_types_cache", frozenset({"vendored_vlm"}))
+    assert loader._is_vlm({"vision_config": {"hidden_size": 32}})
+    assert loader._is_vlm({"model_type": "vendored_vlm"})
+    assert not loader._is_vlm({"model_type": "text_only", "architectures": ["TextForCausalLM"]})
+    assert not loader._is_vlm({"vision_config": {}, "model_type": "text_only"})
+
+
 def test_apply_mlx_distributed_sharding_modes_and_guards():
     from unsloth_zoo.mlx.loader import (
         _apply_mlx_distributed_sharding,

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -42,7 +42,11 @@ def test_qk_norm_mismatch_raises_actionable_error():
     with pytest.raises(ValueError) as exc:
         _raise_if_qk_norm_version_gap("gemma4", _TESTER_MSG, ValueError("orig"))
     msg = str(exc.value)
-    assert "mlx-lm" in msg and "0.31.3" in msg and "gemma4" in msg
+    assert "mlx-lm" in msg and "q_norm" in msg and "gemma4" in msg
+    assert "unsloth-zoo" in msg and "mlx-vlm" in msg and "mlx-audio" in msg
+    assert "Studio users should rerun installer/repair" in msg
+    assert "strict=False" in msg
+    assert "0.31.3 broke" not in msg and "!=0.31.3" not in msg
 
 
 def test_qwen3_5_q_norm_also_caught():
@@ -129,5 +133,6 @@ def test_vlm_retry_qk_norm_mismatch_raises_actionable_error():
     with pytest.raises(ValueError) as exc:
         _load_mlx_vlm_with_extra_weight_filter("some/model", "gemma4", fake_vlm_load, {}, hf_token=None)
     msg = str(exc.value)
-    assert "mlx-lm" in msg and "0.31.3" in msg and "gemma4" in msg
+    assert "mlx-lm" in msg and "q_norm" in msg and "gemma4" in msg
+    assert "unsloth-zoo" in msg and "mlx-audio" in msg and "!=0.31.3" not in msg
     assert calls["n"] == 2  # it must have entered the filtered retry

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -357,6 +357,50 @@ def test_tokenizer_wrapper_chat_template_return_dict_expands_for_generate():
     assert tokenizer("hi") == {"called": True}
 
 
+def test_vlm_prompt_patch_preserves_model_specific_media_markers(monkeypatch):
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    marker, state = "<|image_1|>Describe it.", {"result": None}
+    def original(*_args, **_kwargs):
+        if isinstance(state["result"], Exception):
+            raise state["result"]
+        return marker if state["result"] is None else state["result"]
+    monkeypatch.setattr(prompt_utils, "apply_chat_template", original, raising=False)
+    monkeypatch.setattr(prompt_utils, "_get_role_content", lambda item: (item["role"], item["content"]), raising=False)
+    monkeypatch.setattr(prompt_utils, "get_chat_template", lambda *_a, **_k: "fallback", raising=False)
+    monkeypatch.setattr(prompt_utils, "MODEL_CONFIG", {"phi3_v": object()}, raising=False)
+    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
+    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
+    for name in ("mlx_vlm.chat", "mlx_vlm.generate", "mlx_vlm.generate.dispatch", "mlx_vlm.generate.ar", "mlx_vlm.server", "mlx_vlm.evals.utils"):
+        if name in sys.modules:
+            monkeypatch.setattr(sys.modules[name], "apply_chat_template", original, raising=False)
+    loader._ensure_vlm_prompt_utils_patched()
+    messages = [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "Describe it."}]}]
+    render = lambda value, model_type="phi3_v", **kwargs: prompt_utils.apply_chat_template(object(), {"model_type": model_type}, value, **kwargs)
+
+    assert render(messages, num_images=1) == marker
+    assert render([{"role": "system", "content": "Be concise."}] + messages, num_images=1) == marker
+    assert render([{"role": "user", "content": [{"type": "audio"}]}], num_audios=1) == marker
+    assert render([{"role": "user", "content": [{"type": "audio"}]}], num_audios=2) == "fallback"
+    assert render(messages, num_images=2) == "fallback"
+    assert render(messages, model_type="unknown", num_images=1) == "fallback"
+    assert render(messages + [{"role": "user", "content": "Again."}], num_images=1) == "fallback"
+    nested = [{"role": "user", "content": [{"type": "group", "content": messages[0]["content"]}]}]
+    assert render(nested, num_images=1) == "fallback"
+    nested_text = [{"type": "group", "content": [{"type": "text", "text": "Policy"}]}]
+    assert render([{"role": "system", "content": nested_text}] + messages, num_images=1) == "fallback"
+    assert render([{"role": "User", "content": messages[0]["content"]}], num_images=1) == "fallback"
+    assert render([{**messages[0], "tool_calls": []}], num_images=1) == "fallback"
+    assert render([{"role": "user", "content": [{"type": "IMAGE"}, {"type": "TEXT", "text": "Describe it."}]}], num_images=1) == "fallback"
+    for video_type in ("video", "input_video", "video_url"):
+        assert render([{"role": "user", "content": [{"type": video_type}]}]) == "fallback"
+    assert render(messages, num_images=1, video="clip.mp4") == "fallback"
+    assert render(messages, num_images=1, return_messages=True) == messages
+    for state["result"] in ("", ValueError("rejected")):
+        assert render(messages, num_images=1) == "fallback"
+
+
 def test_vlm_generate_hf_kwargs(monkeypatch):
     import torch
     from transformers.tokenization_utils_base import to_py_obj

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2551,13 +2551,7 @@ def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
     assert adapted(types.SimpleNamespace(training=True), position_ids=object()) == "replacement"
     batched = types.SimpleNamespace(VisionModel=type("V", (), {"_forward_same_grid_batch": lambda self: None}))
     assert mc._paddleocr_vl_has_batched_vision(batched)
-    gemma3n = types.SimpleNamespace(masked_scatter=object())
-    language = types.SimpleNamespace(Gemma3Model=type("G", (), {"__call__": len}))
-    monkeypatch.setattr(mc, "_iter_trait_model_modules", lambda *args, **kwargs: [("gemma3n", gemma3n)])
-    monkeypatch.setattr(mc, "_try_import_module", lambda name: language)
-    mc._install_masked_scatter_multimodal_patches()
-    assert gemma3n.masked_scatter is not mc._masked_scatter_no_numpy
-    assert "gemma3n" not in mc._PATCHED_ARCHES
+    assert mc._gemma3n_language_contract(len) is None
 
 
 def test_quantized_cce_uses_layer_mode_and_affine_bias_guard():
@@ -2593,6 +2587,50 @@ def test_compile_patch_primitives_exist():
     import unsloth_zoo.mlx.compile as mc
     primitives = mc.list_compile_patch_primitives()
     assert len(primitives) > 0
+
+
+def test_shared_family_installers_import_only_allowlisted_models(monkeypatch):
+    import unsloth_zoo.mlx.compile as mc
+    native = lambda *_args, **_kwargs: None
+    qwen_arches = frozenset({"qwen2_vl", "qwen2_5_vl", "glm_ocr", "paddleocr_vl"})
+    masked_arches = frozenset({"gemma3", "gemma4", "idefics2", "idefics3"})
+    idefics_arches = frozenset({"idefics2", "idefics3"})
+    assert (mc._QWEN_LIKE_MERGE_ARCHES, mc._MASKED_SCATTER_PATCH_ARCHES, mc._IDEFICS_SHARED_PATCH_ARCHES) == (qwen_arches, masked_arches, idefics_arches)
+    methods = {
+        "merge_input_ids_with_image_features": staticmethod(native),
+        "_prepare_inputs_for_multimodal": native,
+        "get_input_embeddings": native,
+    }
+    modules = {
+        arch: types.SimpleNamespace(
+            masked_scatter=native,
+            Model=type(f"{arch}Model", (), methods),
+        )
+        for arch in qwen_arches | masked_arches
+    }
+    paddle_vision = types.SimpleNamespace(
+        VisionModel=type("PaddleVision", (), {"_forward_same_grid_batch": native})
+    )
+    imported = []
+    def import_module(name):
+        imported.append(name)
+        if name == "mlx_vlm.models.paddleocr_vl.vision":
+            return paddle_vision
+        parts = name.split(".")
+        return modules.get(parts[-1]) if parts[-2:] == [parts[-1], parts[-1]] else None
+    monkeypatch.setattr(mc, "_try_import_module", import_module)
+    monkeypatch.setattr(mc, "build_compile_trait_reports", lambda: pytest.fail("runtime traits"))
+    monkeypatch.setattr(mc, "_PATCHED_ARCHES", set())
+    monkeypatch.setattr(mc, "_PATCH_BINDINGS", set())
+    monkeypatch.setattr(mc, "_VERIFIED_TRAINING_ARCHES", set(mc._VERIFIED_TRAINING_ARCHES))
+    mc._install_qwen_like_image_merge_patches()
+    mc._install_masked_scatter_multimodal_patches()
+    mc._install_idefics_family_compile_patches()
+    assert not any(name.split(".")[-1] in {"lfm2_vl", "minicpmo", "phi4mm"} for name in imported)
+    assert all(modules[arch].masked_scatter is mc._masked_scatter_no_numpy for arch in masked_arches)
+    assert modules["paddleocr_vl"].Model.merge_input_ids_with_image_features is native
+    assert all(modules[arch].Model.merge_input_ids_with_image_features is mc._merge_special_token_features_only for arch in qwen_arches - {"paddleocr_vl"})
+    assert all(modules[arch].Model.get_input_embeddings is not native for arch in idefics_arches)
 
 
 def test_compile_protocol_requirements_exist():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2541,6 +2541,25 @@ def test_qwen3_vl_training_compile_verified():
     assert "qwen3_vl_moe" in mc._VERIFIED_TRAINING_ARCHES
 
 
+def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
+    import unsloth_zoo.mlx.compile as mc
+    upstream = lambda self, input_ids=None, pixel_values=None, **kwargs: "upstream"
+    replacement = lambda self, input_ids=None, pixel_values=None, **kwargs: "replacement"
+    adapted = mc._explicit_position_embedding_adapter(upstream, replacement)
+    assert adapted(types.SimpleNamespace(training=True)) == "upstream"
+    assert adapted(types.SimpleNamespace(training=False), position_ids=object()) == "upstream"
+    assert adapted(types.SimpleNamespace(training=True), position_ids=object()) == "replacement"
+    batched = types.SimpleNamespace(VisionModel=type("V", (), {"_forward_same_grid_batch": lambda self: None}))
+    assert mc._paddleocr_vl_has_batched_vision(batched)
+    gemma3n = types.SimpleNamespace(masked_scatter=object())
+    language = types.SimpleNamespace(Gemma3Model=type("G", (), {"__call__": len}))
+    monkeypatch.setattr(mc, "_iter_trait_model_modules", lambda *args, **kwargs: [("gemma3n", gemma3n)])
+    monkeypatch.setattr(mc, "_try_import_module", lambda name: language)
+    mc._install_masked_scatter_multimodal_patches()
+    assert gemma3n.masked_scatter is not mc._masked_scatter_no_numpy
+    assert "gemma3n" not in mc._PATCHED_ARCHES
+
+
 def test_quantized_cce_uses_layer_mode_and_affine_bias_guard():
     import inspect
     import unsloth_zoo.mlx.utils as mlx_utils

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2542,6 +2542,7 @@ def test_qwen3_vl_training_compile_verified():
 
 
 def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
+    import mlx.core as mx
     import unsloth_zoo.mlx.compile as mc
     upstream = lambda self, input_ids=None, pixel_values=None, **kwargs: "upstream"
     replacement = lambda self, input_ids=None, pixel_values=None, **kwargs: "replacement"
@@ -2552,6 +2553,8 @@ def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
     batched = types.SimpleNamespace(VisionModel=type("V", (), {"_forward_same_grid_batch": lambda self: None}))
     assert mc._paddleocr_vl_has_batched_vision(batched)
     assert mc._gemma3n_language_contract(len) is None
+    assert mc._gemma3n_cache_offset([types.SimpleNamespace(offset=700, _idx=188)]) == 700
+    assert mc._gemma3n_cache_offset([types.SimpleNamespace(offset=mx.array([650, 700]), _idx=188)]) == 700
 
 
 def test_quantized_cce_uses_layer_mode_and_affine_bias_guard():

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -1535,6 +1535,15 @@ def _arch_matches_prefixes(arch: str, prefixes: tuple[str, ...]) -> bool:
     return bool(prefixes) and arch.startswith(prefixes)
 
 
+_QWEN_LIKE_MERGE_ARCHES = frozenset(
+    {"qwen2_vl", "qwen2_5_vl", "glm_ocr", "paddleocr_vl"}
+)
+_MASKED_SCATTER_PATCH_ARCHES = frozenset(
+    {"gemma3", "gemma4", "idefics2", "idefics3"}
+)
+_IDEFICS_SHARED_PATCH_ARCHES = frozenset({"idefics2", "idefics3"})
+
+
 def _adapter_matches(
     adapter: CompilePatchAdapter,
     arch: str,
@@ -1877,30 +1886,6 @@ def _try_import_module(module_name: str):
         return importlib.import_module(module_name)
     except Exception:
         return None
-
-
-def _iter_trait_model_modules(
-    trait: str,
-    *,
-    include_arches: Iterable[str] = (),
-):
-    """Yield model modules for architectures that share a compile trait.
-
-    Trait discovery (over the standard `mlx_vlm.models.<arch>.<arch>` layout)
-    lets future architectures inherit a shared patch automatically.
-    """
-
-    candidate_arches = set(include_arches)
-    candidate_arches.update(
-        arch
-        for arch, report in build_compile_trait_reports().items()
-        if trait in report.pattern_traits
-    )
-    for arch in sorted(candidate_arches):
-        module = _try_import_module(f"mlx_vlm.models.{arch}.{arch}")
-        if module is None:
-            continue
-        yield arch, module
 
 
 def _install_safe_fused_sdpa_mask_patches():
@@ -3387,11 +3372,9 @@ def _install_qwen_like_image_merge_patches():
     plumbing.
     """
 
-    for arch, module in _iter_trait_model_modules(
-        "qwen_like_image_merge",
-        include_arches=("qwen2_vl", "qwen2_5_vl", "glm_ocr", "paddleocr_vl"),
-    ):
-        if arch.startswith("qwen3"):
+    for arch in sorted(_QWEN_LIKE_MERGE_ARCHES):
+        module = _try_import_module(f"mlx_vlm.models.{arch}.{arch}")
+        if module is None:
             continue
         if arch == "paddleocr_vl":
             vision_module = _try_import_module("mlx_vlm.models.paddleocr_vl.vision")
@@ -4477,17 +4460,10 @@ def _install_deepseek_ocr_compile_patches():
 def _install_masked_scatter_multimodal_patches():
     """Patch `masked_scatter` implementations that rely on host-side mutation."""
 
-    for arch, module in _iter_trait_model_modules(
-        "masked_scatter_multimodal",
-        include_arches=("gemma3", "idefics2", "idefics3"),
-    ):
-        if arch == "gemma3n":
-            language = _try_import_module("mlx_vlm.models.gemma3n.language")
-            model = getattr(language, "Gemma3Model", None)
-            if _gemma3n_language_contract(getattr(model, "__call__", None)) is None:
-                _VERIFIED_TRAINING_ARCHES.discard(arch)
-                _PATCHED_ARCHES.discard(arch)
-                continue
+    for arch in sorted(_MASKED_SCATTER_PATCH_ARCHES):
+        module = _try_import_module(f"mlx_vlm.models.{arch}.{arch}")
+        if module is None:
+            continue
         if getattr(module, "masked_scatter", None) is None:
             continue
         setattr(module, "masked_scatter", _masked_scatter_no_numpy)
@@ -4498,7 +4474,6 @@ def _install_idefics_family_compile_patches():
     """Patch Idefics-family image filtering and multimodal merges for compile.
 
     Shared issue: Python-side padded-image filtering and placeholder merging.
-    Architectures with the same trait and standard layout inherit this patch.
     """
 
     def patched_prepare_inputs_for_multimodal(self, image_features, inputs_embeds, input_ids):
@@ -4568,11 +4543,9 @@ def _install_idefics_family_compile_patches():
         )
         return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
 
-    for arch, module in _iter_trait_model_modules(
-        "padded_image_filtering",
-        include_arches=("idefics2", "idefics3"),
-    ):
-        if arch == "smolvlm":
+    for arch in sorted(_IDEFICS_SHARED_PATCH_ARCHES):
+        module = _try_import_module(f"mlx_vlm.models.{arch}.{arch}")
+        if module is None:
             continue
         model_cls = getattr(module, "Model", None)
         if model_cls is None:

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -3894,6 +3894,27 @@ def _gemma3n_language_contract(method):
     return None
 
 
+def _gemma3n_cache_offset(cache):
+    """Normalize absolute cache progress for per-layer embedding slices.
+
+    Rotating caches compact or wrap their private ``_idx`` storage cursor while
+    the public ``offset`` continues to track the processed token position.
+    """
+
+    raw_offset = next(
+        (
+            c.offset
+            for c in (cache or [])
+            if c is not None and hasattr(c, "offset")
+        ),
+        0,
+    )
+    if isinstance(raw_offset, mx.array):
+        raw_offset = raw_offset.max() if raw_offset.ndim else raw_offset
+        return int(raw_offset.item())
+    return int(raw_offset)
+
+
 def _install_gemma3n_compile_patches():
     """Install Gemma3n multiscale fusion and merge compatibility patches."""
 
@@ -3998,29 +4019,7 @@ def _install_gemma3n_compile_patches():
                     0,
                 )
             else:
-                c0 = next(
-                    (c for c in (cache or []) if c is not None and hasattr(c, "_idx")),
-                    None,
-                )
-                if c0 is not None:
-                    cache_offset = int(c0._idx)
-                else:
-                    raw_offset = next(
-                        (
-                            c.offset
-                            for c in (cache or [])
-                            if c is not None and hasattr(c, "offset")
-                        ),
-                        0,
-                    )
-                    if isinstance(raw_offset, mx.array):
-                        cache_offset = (
-                            int(raw_offset.max().item())
-                            if raw_offset.size > 1
-                            else int(raw_offset.item())
-                        )
-                    else:
-                        cache_offset = int(raw_offset)
+                cache_offset = _gemma3n_cache_offset(cache)
             max_start = max(per_layer_inputs.shape[1] - target_len, 0)
             start = min(cache_offset, max_start)
             per_layer_inputs = per_layer_inputs[:, start : start + target_len]

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -27,7 +27,7 @@ compile-ready only once explicitly verified.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import lru_cache, wraps
 from pathlib import Path
 from itertools import accumulate
 import importlib
@@ -2174,6 +2174,23 @@ def _attach_position_ids(features, position_ids):
     return features
 
 
+def _explicit_position_embedding_adapter(original, replacement):
+    """Use Zoo's explicit-position path only while training."""
+
+    @wraps(original)
+    def patched(self, input_ids=None, pixel_values=None, **kwargs):
+        if not getattr(self, "training", False) or kwargs.get("position_ids") is None:
+            return original(self, input_ids, pixel_values, **kwargs)
+        return replacement(self, input_ids, pixel_values, **kwargs)
+
+    return patched
+
+
+def _patch_explicit_position_embeddings(model_cls, replacement):
+    adapted = _explicit_position_embedding_adapter(model_cls.get_input_embeddings, replacement)
+    _patch_method(model_cls, "get_input_embeddings", adapted)
+
+
 def _add_visual_embeds(hidden_states, visual_pos_masks, visual_embeds):
     """Compile-safe additive merge for sparse visual embeddings."""
 
@@ -2393,6 +2410,8 @@ def _install_qwen2_5_compile_patches():
         return hidden_states
 
     def patched_qwen2_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         explicit_position_ids = kwargs.get("position_ids", None)
@@ -2434,7 +2453,7 @@ def _install_qwen2_5_compile_patches():
     _patch_method(vision_module.VisionModel, "rot_pos_emb", patched_qwen2_rot_pos_emb)
     _patch_method(vision_module.VisionModel, "get_window_index", patched_qwen2_get_window_index)
     _patch_method(vision_module.VisionModel, "__call__", patched_qwen2_vision_call)
-    _patch_method(module.Model, "get_input_embeddings", patched_qwen2_get_input_embeddings)
+    _patch_explicit_position_embeddings(module.Model, patched_qwen2_get_input_embeddings)
     _PATCHED_ARCHES.add("qwen2_5_vl")
 
 
@@ -2545,6 +2564,8 @@ def _install_qwen2_compile_patches():
         return self.merger(hidden_states)
 
     def patched_qwen2_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         explicit_position_ids = kwargs.get("position_ids", None)
@@ -2585,7 +2606,7 @@ def _install_qwen2_compile_patches():
     _patch_method(vision_module.Attention, "__call__", patched_qwen2_attention)
     _patch_method(vision_module.VisionModel, "rot_pos_emb", patched_qwen2_rot_pos_emb)
     _patch_method(vision_module.VisionModel, "__call__", patched_qwen2_vision_call)
-    _patch_method(module.Model, "get_input_embeddings", patched_qwen2_get_input_embeddings)
+    _patch_explicit_position_embeddings(module.Model, patched_qwen2_get_input_embeddings)
     _PATCHED_ARCHES.add("qwen2_vl")
 
 
@@ -2867,6 +2888,8 @@ def _install_qwen3_family_compile_patches():
         return _add_visual_embeds(hidden_states, visual_pos_masks, visual_embeds)
 
     def patched_qwen3_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         mask = kwargs.get("mask", None)
@@ -2915,6 +2938,8 @@ def _install_qwen3_family_compile_patches():
         return _attach_position_ids(features, position_ids)
 
     def patched_qwen35_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         mask = kwargs.get("mask", None)
@@ -2962,8 +2987,8 @@ def _install_qwen3_family_compile_patches():
     _patch_method(vision_module.VisionModel, "fast_pos_embed_interpolate", patched_qwen3_fast_pos_embed_interpolate)
     _patch_method(vision_module.VisionModel, "__call__", patched_qwen3_vision_call)
     _patch_method(importlib.import_module("mlx_vlm.models.qwen3_vl.language").Qwen3VLModel, "_deepstack_process", patched_qwen3_deepstack)
-    _patch_method(module.Model, "get_input_embeddings", patched_qwen3_get_input_embeddings)
-    _patch_method(qwen35_module.Model, "get_input_embeddings", patched_qwen35_get_input_embeddings)
+    _patch_explicit_position_embeddings(module.Model, patched_qwen3_get_input_embeddings)
+    _patch_explicit_position_embeddings(qwen35_module.Model, patched_qwen35_get_input_embeddings)
     if qwen3moe_module is not None:
         qwen3moe_module.masked_scatter = _masked_scatter_no_numpy
         _patch_staticmethod(qwen3moe_module.Model, "merge_input_ids_with_image_features", merge_qwen3)
@@ -2973,7 +2998,7 @@ def _install_qwen3_family_compile_patches():
         _patch_method(qwen3moe_vision_module.VisionModel, "fast_pos_embed_interpolate", patched_qwen3_fast_pos_embed_interpolate)
         _patch_method(qwen3moe_vision_module.VisionModel, "__call__", patched_qwen3_vision_call)
         _patch_method(qwen3moe_language_module.Qwen3VLMoEModel, "_deepstack_process", patched_qwen3_deepstack)
-        _patch_method(qwen3moe_module.Model, "get_input_embeddings", patched_qwen3_get_input_embeddings)
+        _patch_explicit_position_embeddings(qwen3moe_module.Model, patched_qwen3_get_input_embeddings)
         _PATCHED_ARCHES.add("qwen3_vl_moe")
     _PATCHED_ARCHES.update({"qwen3_vl", "qwen3_5", "qwen3_5_moe"})
 
@@ -3087,6 +3112,8 @@ def _install_glm_ocr_compile_patches():
         return self.merger(hidden_states)
 
     def patched_glm_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         mask = kwargs.get("mask", None)
@@ -3132,8 +3159,21 @@ def _install_glm_ocr_compile_patches():
     _patch_method(vision_module.GlmOcrVisionAttention, "__call__", patched_glm_attention)
     _patch_method(vision_module.VisionModel, "rot_pos_emb", patched_glm_rot_pos_emb)
     _patch_method(vision_module.VisionModel, "__call__", patched_glm_vision_call)
-    _patch_method(module.Model, "get_input_embeddings", patched_glm_get_input_embeddings)
+    _patch_explicit_position_embeddings(module.Model, patched_glm_get_input_embeddings)
     _PATCHED_ARCHES.add("glm_ocr")
+
+
+def _paddleocr_vl_has_batched_vision(vision_module) -> bool:
+    """Whether PaddleOCR-VL exposes its newer batched vision contract."""
+
+    for class_name, method in (
+        ("VisionModel", "_forward_same_grid_batch"),
+        ("PaddleOCRVisionEmbeddings", "same_grid_batch"),
+        ("PaddleOCRProjector", "same_grid_batch"),
+    ):
+        if callable(getattr(getattr(vision_module, class_name, None), method, None)):
+            return True
+    return False
 
 
 def _install_paddleocr_vl_compile_patches():
@@ -3143,6 +3183,11 @@ def _install_paddleocr_vl_compile_patches():
         module = importlib.import_module("mlx_vlm.models.paddleocr_vl.paddleocr_vl")
         vision_module = importlib.import_module("mlx_vlm.models.paddleocr_vl.vision")
     except Exception:
+        return
+
+    if _paddleocr_vl_has_batched_vision(vision_module):
+        _VERIFIED_TRAINING_ARCHES.discard("paddleocr_vl")
+        _PATCHED_ARCHES.discard("paddleocr_vl")
         return
 
     InputEmbeddingsFeatures = module.InputEmbeddingsFeatures
@@ -3348,6 +3393,15 @@ def _install_qwen_like_image_merge_patches():
     ):
         if arch.startswith("qwen3"):
             continue
+        if arch == "paddleocr_vl":
+            vision_module = _try_import_module("mlx_vlm.models.paddleocr_vl.vision")
+            if (
+                vision_module is not None
+                and _paddleocr_vl_has_batched_vision(vision_module)
+            ):
+                _VERIFIED_TRAINING_ARCHES.discard(arch)
+                _PATCHED_ARCHES.discard(arch)
+                continue
         model_cls = getattr(module, "Model", None)
         if (
             model_cls is None
@@ -3839,6 +3893,24 @@ def _install_mistral4_compile_patches():
     _PATCHED_ARCHES.add("mistral4")
 
 
+def _gemma3n_language_contract(method):
+    """Identify the installed Gemma3n cache and attention-mask contract."""
+
+    try:
+        source = inspect.getsource(method)
+    except (OSError, TypeError):
+        return None
+    if "cache[self.first_full_idx :]" in source and "int(c.offset)" in source:
+        return "legacy"
+    if (
+        "cache[self.first_full_idx]" in source
+        and "window_size=self.config.sliding_window" in source
+        and "raw_offset.max().item()" in source
+    ):
+        return "current"
+    return None
+
+
 def _install_gemma3n_compile_patches():
     """Install Gemma3n multiscale fusion and merge compatibility patches."""
 
@@ -3848,6 +3920,12 @@ def _install_gemma3n_compile_patches():
         language_module = importlib.import_module("mlx_vlm.models.gemma3n.language")
         kernels_module = importlib.import_module("mlx_vlm.models.kernels")
     except Exception:
+        return
+
+    language_contract = _gemma3n_language_contract(language_module.Gemma3Model.__call__)
+    if language_contract is None:
+        _VERIFIED_TRAINING_ARCHES.discard("gemma3n")
+        _PATCHED_ARCHES.discard("gemma3n")
         return
 
     def patched_merge_multimodal_and_text(
@@ -3927,14 +4005,39 @@ def _install_gemma3n_compile_patches():
             if target_len != h.shape[1]:
                 target_len = h.shape[1]
 
-            cache_offset = next(
-                (
-                    int(c.offset)
-                    for c in (cache or [])
-                    if c is not None and hasattr(c, "offset")
-                ),
-                0,
-            )
+            if language_contract == "legacy":
+                cache_offset = next(
+                    (
+                        int(c.offset)
+                        for c in (cache or [])
+                        if c is not None and hasattr(c, "offset")
+                    ),
+                    0,
+                )
+            else:
+                c0 = next(
+                    (c for c in (cache or []) if c is not None and hasattr(c, "_idx")),
+                    None,
+                )
+                if c0 is not None:
+                    cache_offset = int(c0._idx)
+                else:
+                    raw_offset = next(
+                        (
+                            c.offset
+                            for c in (cache or [])
+                            if c is not None and hasattr(c, "offset")
+                        ),
+                        0,
+                    )
+                    if isinstance(raw_offset, mx.array):
+                        cache_offset = (
+                            int(raw_offset.max().item())
+                            if raw_offset.size > 1
+                            else int(raw_offset.item())
+                        )
+                    else:
+                        cache_offset = int(raw_offset)
             max_start = max(per_layer_inputs.shape[1] - target_len, 0)
             start = min(cache_offset, max_start)
             per_layer_inputs = per_layer_inputs[:, start : start + target_len]
@@ -3945,14 +4048,25 @@ def _install_gemma3n_compile_patches():
             cache = [None] * len(self.layers)
 
         if mask is None:
-            full_mask = language_module.create_attention_mask(
-                h,
-                cache[self.first_full_idx :],
-            )
-            sliding_window_mask = language_module.create_attention_mask(
-                h,
-                cache[self.first_sliding_idx :],
-            )
+            if language_contract == "legacy":
+                full_mask = language_module.create_attention_mask(
+                    h,
+                    cache[self.first_full_idx :],
+                )
+                sliding_window_mask = language_module.create_attention_mask(
+                    h,
+                    cache[self.first_sliding_idx :],
+                )
+            else:
+                full_mask = language_module.create_attention_mask(
+                    h,
+                    cache[self.first_full_idx],
+                )
+                sliding_window_mask = language_module.create_attention_mask(
+                    h,
+                    cache[self.first_sliding_idx],
+                    window_size=self.config.sliding_window,
+                )
         h0 = h
 
         target_magnitude = _safe_branch_magnitude(h0)
@@ -4367,6 +4481,13 @@ def _install_masked_scatter_multimodal_patches():
         "masked_scatter_multimodal",
         include_arches=("gemma3", "idefics2", "idefics3"),
     ):
+        if arch == "gemma3n":
+            language = _try_import_module("mlx_vlm.models.gemma3n.language")
+            model = getattr(language, "Gemma3Model", None)
+            if _gemma3n_language_contract(getattr(model, "__call__", None)) is None:
+                _VERIFIED_TRAINING_ARCHES.discard(arch)
+                _PATCHED_ARCHES.discard(arch)
+                continue
         if getattr(module, "masked_scatter", None) is None:
             continue
         setattr(module, "masked_scatter", _masked_scatter_no_numpy)

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -3895,11 +3895,8 @@ def _gemma3n_language_contract(method):
 
 
 def _gemma3n_cache_offset(cache):
-    """Normalize absolute cache progress for per-layer embedding slices.
-
-    Rotating caches compact or wrap their private ``_idx`` storage cursor while
-    the public ``offset`` continues to track the processed token position.
-    """
+    """Absolute token progress for per-layer embedding slices, read from the
+    public ``offset``: a rotating cache's private ``_idx`` wraps, ``offset`` does not."""
 
     raw_offset = next(
         (

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -20,6 +20,7 @@ No GPU deps: uses mlx-lm (text) and mlx-vlm (VLM) instead of unsloth.models
 (which pulls in CUDA kernels).
 """
 
+import ast
 import gc
 import json
 import importlib
@@ -50,6 +51,7 @@ from .compile import (
 )
 
 _vlm_model_types_cache = None
+_VLM_MODALITY_CONFIG_FIELDS = ("vision_config", "audio_config", "dflash_config")
 _SAFE_TEXT_SANITIZE_PATCHED: set[str] = set()
 _AUDIO_CONV_SANITIZE_PATCHED: set[str] = set()
 _MULTIMODAL_STRIP_KEYS = (
@@ -217,16 +219,11 @@ def _collect_all_linear_target_names(model):
 
 
 def _is_vlm(config: dict) -> bool:
-    """Detect whether a config describes a VLM (via "vision_config" or a
-    model_type in mlx_vlm's supported set)."""
-    if "vision_config" in config:
+    """Detect a VLM from explicit modality data or a modality-aware model set."""
+    if any(config.get(key) not in (None, {}) for key in _VLM_MODALITY_CONFIG_FIELDS):
         return True
-
-    architectures = config.get("architectures") or ()
-    if isinstance(architectures, str):
-        architectures = (architectures,)
-    if any(str(arch).endswith("ForCausalLM") for arch in architectures):
-        return False
+    if _deepseek_ocr_config_model_type(config) is not None:
+        return True
 
     model_type = config.get("model_type", "")
     if not model_type:
@@ -235,6 +232,15 @@ def _is_vlm(config: dict) -> bool:
     global _vlm_model_types_cache
     if _vlm_model_types_cache is None:
         _vlm_model_types_cache = _build_vlm_model_types()
+
+    architectures = config.get("architectures") or ()
+    if isinstance(architectures, str):
+        architectures = (architectures,)
+    if (
+        any(str(arch).endswith("ForCausalLM") for arch in architectures)
+        and model_type not in _vlm_model_types_cache
+    ):
+        return False
 
     return model_type in _vlm_model_types_cache
 
@@ -1160,15 +1166,41 @@ def _repair_degraded_vlm_processor(
     return repaired
 
 
+def _config_source_has_modality(package_dir: Path) -> bool:
+    """Inspect config declarations without importing model packages."""
+
+    candidates = (
+        package_dir / "config.py",
+        package_dir / f"{package_dir.name}.py",
+        package_dir / "__init__.py",
+    )
+    for path in candidates:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            fields = {
+                item.target.id for item in node.body
+                if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name)
+            }
+            if fields.intersection(_VLM_MODALITY_CONFIG_FIELDS):
+                return True
+    return False
+
+
 def _build_vlm_model_types():
-    """Frozenset of model_type strings mlx_vlm supports (discovered via
-    pkgutil + MODEL_REMAPPING); cached at module level by _is_vlm()."""
+    """Discover only model types whose mlx-vlm config declares a modality."""
     types_set = set()
     try:
         import mlx_vlm.models as vlm_models_pkg
         import pkgutil
-        for importer, modname, ispkg in pkgutil.iter_modules(vlm_models_pkg.__path__):
-            if ispkg:
+        for finder, modname, ispkg in pkgutil.iter_modules(vlm_models_pkg.__path__):
+            if not ispkg:
+                continue
+            if _config_source_has_modality(Path(finder.path) / modname):
                 types_set.add(modname)
     except ImportError:
         pass
@@ -1176,8 +1208,8 @@ def _build_vlm_model_types():
     try:
         from mlx_vlm.utils import MODEL_REMAPPING
         for src, tgt in MODEL_REMAPPING.items():
-            types_set.add(src)
-            types_set.add(tgt)
+            if src in types_set or tgt in types_set:
+                types_set.update((src, tgt))
     except (ImportError, AttributeError):
         pass
 
@@ -4019,6 +4051,8 @@ def _ensure_vlm_prompt_utils_patched():
     for modname in (
         "mlx_vlm.chat",
         "mlx_vlm.generate",
+        "mlx_vlm.generate.dispatch",
+        "mlx_vlm.generate.ar",
         "mlx_vlm.server",
         "mlx_vlm.evals.utils",
     ):
@@ -4026,7 +4060,7 @@ def _ensure_vlm_prompt_utils_patched():
             module = importlib.import_module(modname)
         except Exception:
             continue
-        if hasattr(module, "apply_chat_template"):
+        if getattr(module, "apply_chat_template", None) is _original_vlm_apply_chat_template:
             module.apply_chat_template = patched_apply_chat_template
 
     _vlm_prompt_utils_patched = True

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -280,8 +280,8 @@ def _message_matches_known_fallback(message, rule):
 
 def _raise_if_qk_norm_version_gap(model_type, message, error):
     """A strict mlx load rejecting q_norm / k_norm means mlx-lm / mlx-vlm is too
-    old (or regressed, e.g. 0.31.3 - mlx-lm #1242) for a QK-norm arch; dropping
-    those weights breaks the model, so raise a clear error instead."""
+    old or incompatible for a QK-norm arch; dropping those weights breaks the
+    model, so raise a clear error instead."""
     if "parameters not in model" not in message:
         return
     if not any(marker in message for marker in ("k_norm", "q_norm")):
@@ -309,9 +309,10 @@ def _raise_if_qk_norm_version_gap(model_type, message, error):
     raise ValueError(
         f"Unsloth: cannot load MLX {model_type or 'model'} - the installed "
         f"mlx-lm / mlx-vlm rejects its QK-norm (q_norm/k_norm) weights, so it is "
-        f"too old or regressed for this architecture (mlx-lm 0.31.3 broke "
-        f"gemma4 / qwen3_5). Reinstall an arch-complete build, e.g. "
-        f'`pip install -U "mlx-lm>=0.22.0,!=0.31.3" "mlx-vlm"`. See mlx-lm #1242.{installed}'
+        f"too old or incompatible for this architecture. Upgrade unsloth-zoo, mlx, "
+        f"mlx-lm, mlx-vlm, and mlx-audio together through the supported installer "
+        f"or dependency policy for your environment; Studio users should rerun "
+        f"installer/repair. Do not bypass this error with strict=False.{installed}"
     ) from error
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2049,17 +2049,10 @@ def _patch_mixed_precision_set_dtype(model):
 _vlm_prompt_utils_patched = False
 _original_vlm_apply_chat_template = None
 
-_MULTIMODAL_ITEM_TYPES = frozenset(
-    {
-        "image",
-        "image_url",
-        "input_image",
-        "audio",
-        "input_audio",
-        "video",
-    }
-)
 _NON_USER_ROLES = frozenset({"system", "assistant"})
+_COUNT_RENDERER_ITEM_TYPES = frozenset(
+    {"text", "input_text", "image", "image_url", "input_image", "audio", "input_audio", "video", "input_video", "video_url"}
+)
 _ROLE_PROMPT_NAMES = {
     "user": "Human",
     "assistant": "Assistant",
@@ -3697,24 +3690,31 @@ def _apply_mlx_distributed_sharding(
     return mode
 
 
+def _structured_multimodal_counts(content):
+    """Count explicit image, audio, and video items in structured content."""
+    if isinstance(content, list):
+        counts = [_structured_multimodal_counts(item) for item in content]
+        return tuple(sum(values) for values in zip(*counts)) if counts else (0, 0, 0)
+
+    if not isinstance(content, dict):
+        return (0, 0, 0)
+
+    item_type = str(content.get("type", "")).lower()
+    if item_type in ("image", "image_url", "input_image"):
+        return (1, 0, 0)
+    if item_type in ("audio", "input_audio"):
+        return (0, 1, 0)
+    if item_type in ("video", "input_video", "video_url"):
+        return (0, 0, 1)
+    nested = content.get("content", None)
+    if nested is not None and nested is not content:
+        return _structured_multimodal_counts(nested)
+    return (0, 0, 0)
+
+
 def _content_has_structured_multimodal_markers(content):
     """Return True when content already contains explicit image/audio/video items."""
-    if isinstance(content, list):
-        for item in content:
-            if _content_has_structured_multimodal_markers(item):
-                return True
-        return False
-
-    if isinstance(content, dict):
-        item_type = str(content.get("type", "")).lower()
-        if item_type in _MULTIMODAL_ITEM_TYPES:
-            return True
-        nested = content.get("content", None)
-        if nested is not None and nested is not content:
-            return _content_has_structured_multimodal_markers(nested)
-        return False
-
-    return False
+    return any(_structured_multimodal_counts(content))
 
 
 def _normalize_prompt_messages(prompt_utils_module, prompt):
@@ -3740,6 +3740,56 @@ def _messages_have_structured_multimodal_content(messages):
     return any(
         _content_has_structured_multimodal_markers(message.get("content", ""))
         for message in messages
+    )
+
+
+def _content_matches_count_renderer_shape(content):
+    """Return whether mlx-vlm's flat content extractor preserves this content."""
+    if isinstance(content, str):
+        return True
+    if not isinstance(content, list):
+        return False
+    return all(
+        isinstance(item, dict)
+        and str(item.get("type", "")) in _COUNT_RENDERER_ITEM_TYPES
+        and not isinstance(item.get("content"), (list, dict))
+        for item in content
+    )
+
+
+def _prompt_has_tool_metadata(prompt):
+    """Return whether mlx-vlm bypasses count rendering for a tool message."""
+    items = prompt if isinstance(prompt, list) else [prompt]
+    return any(
+        isinstance(item, dict)
+        and ("tool_calls" in item or "tool_call_id" in item or item.get("role") == "tool")
+        for item in items
+    )
+
+
+def _structured_media_matches_count_renderer(messages, num_images, num_audios):
+    """Return whether upstream count-based rendering preserves media ownership."""
+    last_target_idx = -1
+    media_indices = set()
+    totals = [0, 0, 0]
+    for i, message in enumerate(messages):
+        role = str(message.get("role", "user"))
+        if role not in _NON_USER_ROLES:
+            last_target_idx = i
+        content = message.get("content", "")
+        if not _content_matches_count_renderer_shape(content):
+            return False
+        counts = _structured_multimodal_counts(content)
+        if any(counts):
+            media_indices.add(i)
+            totals = [total + count for total, count in zip(totals, counts)]
+
+    return (
+        last_target_idx >= 0
+        and str(messages[last_target_idx].get("role", "user")) == "user"
+        and media_indices == {last_target_idx}
+        and any(totals)
+        and totals == [num_images, num_audios, 0]
     )
 
 
@@ -3844,7 +3894,7 @@ def _flatten_multimodal_content_for_prompt(
             return image_token
         if item_type in ("audio", "input_audio"):
             return audio_token
-        if item_type == "video":
+        if item_type in ("video", "input_video", "video_url"):
             return video_token
         nested = content.get("content", None)
         if nested is not None and nested is not content:
@@ -3965,6 +4015,15 @@ def _render_vlm_template_or_fallback(
     return rendered
 
 
+def _has_vlm_template_result(rendered):
+    """Return whether a chat renderer produced a usable prompt or message list."""
+    if isinstance(rendered, str):
+        return bool(rendered.strip())
+    if isinstance(rendered, (list, tuple, dict)):
+        return bool(rendered)
+    return rendered is not None
+
+
 def _ensure_vlm_prompt_utils_patched():
     """Patch mlx-vlm chat-template helper for stable multi-turn multimodal chat."""
     global _vlm_prompt_utils_patched, _original_vlm_apply_chat_template
@@ -4012,6 +4071,32 @@ def _ensure_vlm_prompt_utils_patched():
                 kwargs=kwargs,
             )
         )
+        if (
+            not return_messages
+            and not kwargs.get("video")
+            and not _prompt_has_tool_metadata(prompt)
+            and model_type in getattr(prompt_utils, "MODEL_CONFIG", {})
+            and _structured_media_matches_count_renderer(
+                normalized_messages, num_images, num_audios
+            )
+        ):
+            try:
+                rendered = _original_vlm_apply_chat_template(
+                    processor,
+                    config,
+                    prompt,
+                    add_generation_prompt=add_generation_prompt,
+                    return_messages=return_messages,
+                    num_images=num_images,
+                    num_audios=num_audios,
+                    **kwargs,
+                )
+            except Exception:
+                pass
+            else:
+                if _has_vlm_template_result(rendered):
+                    return rendered
+
         if needs_custom_render:
             if return_messages:
                 return template_messages

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -285,9 +285,8 @@ def _message_matches_known_fallback(message, rule):
 
 
 def _raise_if_qk_norm_version_gap(model_type, message, error):
-    """A strict mlx load rejecting q_norm / k_norm means mlx-lm / mlx-vlm is too
-    old or incompatible for a QK-norm arch; dropping those weights breaks the
-    model, so raise a clear error instead."""
+    """A strict load rejecting q_norm / k_norm means mlx-lm / mlx-vlm is too old for
+    this QK-norm arch; dropping those weights breaks the model, so raise instead."""
     if "parameters not in model" not in message:
         return
     if not any(marker in message for marker in ("k_norm", "q_norm")):


### PR DESCRIPTION
## Summary

- Remove stale recovery guidance that blamed or excluded `mlx-lm==0.31.3` while preserving the strict Q/K-normalization safety error.
- Preserve each installed `mlx-vlm` input, state, cache, masking, and prompt-rendering contract across the supported 0.4.4–0.6.6 range.
- Correct current Gemma3n per-layer slicing after rotating-cache compaction by using public absolute cache progress rather than the private storage cursor.
- Scope shared compile patches to explicitly verified model families so LFM, MiniCPM, Phi, and future unrelated packages keep their native methods.
- Keep current PaddleOCR batching upstream/eager, route only modality-backed model types as VLMs, and propagate chat-template compatibility across old and current generation layouts.
- Retain the open-ended `mlx-vlm>=0.4.4` policy with no exact pins, exclusions, or dependency-floor changes.

## Why

Current dependency resolution can move Studio from mlx-vlm 0.4.4 to 0.6.6. Across that range, upstream changed Qwen video/state handling, Gemma3n cache offsets and sliding masks, PaddleOCR batching, the set of vendored model packages, generation-module layout, and model-specific media rendering. The previous Zoo patches could discard video tensors, apply legacy cache or batch behavior, misroute vendored text models as VLMs, replace unrelated families' embedding methods, or flatten required markers such as Phi's numbered image token.

The current Gemma3n implementation also prefers `RotatingKVCache._idx` when slicing full-prompt per-layer embeddings. mlx-lm defines that field as a compacting/wrapping storage cursor while public `offset` remains absolute token progress, so long chunked prefills can select earlier embeddings after the two values diverge. Zoo now intentionally corrects that inherited upstream bug in its patched replacement.

The recovery message also conflated the mlx-lm 0.31.3 Gemma 4 load defect with unrelated Qwen behavior. It now recommends updating the coordinated MLX stack through the supported installer or environment policy without teaching users to exclude 0.31.3.

## Compatibility behavior

Ordinary Qwen and GLM inference delegates to the captured installed implementation. Zoo uses its compile-safe explicit-position delta only for training calls that provide collator-owned position state. Gemma3n preserves the legacy 0.4.4 contract and the current 0.5.0–0.6.6 per-layer cache and sliding-window contract, while normalizing public scalar or vector cache offsets for per-layer slices; unknown source contracts fail closed. PaddleOCR 0.6.4 and newer retain the upstream same-grid batch implementation instead of being marked compile-patched.

VLM discovery requires static modality evidence from model config declarations and does not import every model package. Generic Qwen-like, masked-scatter, and Idefics installers import exact verified allowlists rather than trait-selected packages; trait reports remain diagnostic. This preserves dedicated or native implementations for LFM, MiniCPM, Phi, Gemma3n, Qwen3, and current PaddleOCR.

Prompt-helper propagation covers the 0.4.4 monolithic layout and the 0.6.x facade, dispatch, and autoregressive modules without overwriting foreign replacements. Safe flat structured image/audio prompts delegate to the captured registered mlx-vlm renderer so model-specific markers survive. Nested or cross-turn media, count/case mismatches, video, tool metadata, message-return mode, unregistered models, renderer errors, and empty results retain Zoo's fail-closed generic fallback.

## Scope

This PR changes six existing files. The compact follow-up extracted from #893 is 298 changed lines, below the requested 400-line budget. The cache-position review fix changes only the existing compile module and test surface. No dependency metadata, lockfile, exact MLX pin, or new tracked file is introduced; the broader processor/tokenizer work in #893 remains independent.

## Validation

- Compared every Python file in the PyPI wheels for mlx-vlm 0.4.4, 0.5.0, and 0.6.0 through 0.6.6 byte-for-byte with its official Git tag; all nine releases had zero mismatches.
- Source-traced model discovery, compile-patch ownership, Qwen/GLM explicit-position state, Gemma3n and PaddleOCR release contracts, prompt rendering, and generation alias propagation across all nine releases; no direct Unsloth/Studio blocker remained.
- Parsed and resolved all 620 direct Transformers/Hub imports across mlx-lm 0.31.3, mlx-vlm 0.6.6, and mlx-audio 0.4.5. Studio's 5.5 and 5.10 sidecars satisfy every import; 5.3 misses only Gemma 4 audio, which routes to 5.5.
- Six adjacent MLX suites passed independently in the release-style environment: 223 tests.
- The final focused Gemma3n/compile suite passed 118 tests after the cache-position review fix.
- Isolated contract and prompt probes passed for mlx-vlm 0.4.4, 0.5.0, and every 0.6.0 through 0.6.6 release.
- The managed tuple resolved mlx 0.32.0, mlx-lm 0.31.3, mlx-vlm 0.6.6, mlx-audio 0.4.5, Transformers 4.57.6, and Hub 0.36.2.
- Real Qwen2-VL LoRA completed four steps with finite decreasing loss and nonzero gradients.
- Real Qwen3.5 image and two-frame video outputs matched upstream; short LoRA training saved and reloaded.
- Real Gemma3n short generation and cache/mask behavior passed; sidecar LoRA saved and reloaded. A cached E2B long-prompt A/B probe observed candidate slice starts `0, 128, 256, 384, 512, 640, 719`, while replaying the old private-cursor behavior mismatched at offsets 640 and 719 (`_idx` 639 and 590).
- Real GLM-OCR output matched upstream, and the managed mlx-audio import surface passed.
- Real LFM2.5-VL patched/unpatched generation produced the same deterministic answer and retained LFM's native embedding method.
- A current Phi processor retained its numbered image marker; nested and tool-bearing fallbacks retained instruction text across all nine mlx-vlm versions.
- Gemma4's image, video, and audio processors reconstructed under the Transformers 5.5 sidecar.
- Python compilation, shell syntax where applicable, diff checks, and two clean final review rounds passed.

Studio deliberately retains Transformers 4.57.6 and Hub 0.36.2 in its managed main environment even though current upstream MLX packages declare incompatible Transformers/Hub floors. Models requiring newer APIs use model-specific sidecars, and unsloth#7061 now activates the selected sidecar before MLX hardware detection imports mlx-vlm. This PR validates that runtime policy and representative model behavior; it does not claim metadata consistency or numerical coverage of every mlx-vlm model.

One conditional integration remains intentionally out of scope: mlx-vlm 0.6.x's own OpenAI and Anthropic server submodules retain imported prompt-helper aliases. Unsloth and Studio call the patched prompt/generation paths directly and are unaffected; supporting an mlx-vlm server started after Unsloth patch installation would require a separate explicit support decision.

## Rollout

Merge and publish this compatible Zoo change before merging [unsloth#7061](https://github.com/unslothai/unsloth/pull/7061), which exposes current mlx-vlm, removes an obsolete installer source overwrite, and corrects MLX inference sidecar activation order. PR #893 is not a merge prerequisite for this dependency rollout; its broader multimodal improvements can proceed independently.