### PR TITLE
Fix chat template marker auto-detection for Zephyr's context-dependent tokenization

### DIFF
--- a/tests/test_zephyr_marker_context.py
+++ b/tests/test_zephyr_marker_context.py
@@ -25,27 +25,26 @@ is the point). Skips (not fails) when no tokenizer can be constructed offline or
 """
 import pytest
 
-# NOTE: unsloth_zoo is imported lazily in _setup(), not at module scope. Importing it
-# runs unsloth_zoo/__init__.py, which raises ImportError when the separate `unsloth`
-# package is absent; at module scope that would break pytest collection before the skip.
+# unsloth_zoo is imported lazily in _setup(), not module scope: its __init__ raises
+# ImportError when the separate `unsloth` package is absent, which would break pytest
+# collection before the skip.
 
 
 def _tokenizer():
     import json
     from transformers import AutoTokenizer
     from tokenizers import Tokenizer
-    # Needs a SentencePiece tokenizer (Llama/Mistral family) so "<" tokenizes context
-    # dependently; the role tags must stay ordinary text, NOT added special tokens.
+    # SentencePiece tokenizer (Llama/Mistral) so "<" tokenizes context-dependently;
+    # role tags must stay ordinary text, NOT added special tokens.
     try:
         tok = AutoTokenizer.from_pretrained(
             "hf-internal-testing/llama-tokenizer", local_files_only=True
         )
     except Exception:
         return None
-    # Zephyr's real tokenizer parses "</s>" mid-text as the eos special token (its
-    # AddedToken is normalized=False); the testing tokenizer ships normalized=True and
-    # would split it into "</ s >". Flip the flag so the fixture tokenizes like Zephyr:
-    # the segment after eos restarts with the SentencePiece prefix space ("▁<0x0A><|...").
+    # Zephyr parses "</s>" mid-text as the eos token (AddedToken normalized=False); the
+    # testing tokenizer ships normalized=True and would split it into "</ s >". Flip the
+    # flag so the fixture tokenizes like Zephyr (eos then prefix space "▁<0x0A><|...").
     d = json.loads(tok.backend_tokenizer.to_str())
     for t in d["added_tokens"]:
         if t["content"] == "</s>":
@@ -116,8 +115,8 @@ def test_zephyr_autodetects_context_dependent_markers():
     assert tr("ANSWERONE") and tr("ANSWERTWO")
     assert not tr("SYSPROMPT terse")
     assert not tr("QONE alpha") and not tr("QTWO bravo")
-    # Both assistant turn terminators trained; in particular the FINAL eos must never
-    # be -100 or the model never learns to stop.
+    # Both assistant eos terminators trained; the FINAL eos must never be -100 or the
+    # model never learns to stop.
     eos_id = tok.eos_token_id
     eos_positions = [i for i, t in enumerate(ids) if t == eos_id]
     assert labels[eos_positions[-1]] != -100
@@ -125,8 +124,8 @@ def test_zephyr_autodetects_context_dependent_markers():
 
 
 def test_zephyr_first_user_turn_variant_not_picked():
-    # "<|user|>\n" matches ONLY at position 0 (text start); the detector must not
-    # accept that single-context variant, or later user turns would stay trained.
+    # "<|user|>\n" matches ONLY at position 0 (text start); accepting that single-context
+    # variant would leave later user turns trained.
     tok, get_chat_template_parts, train_on_responses_only = _setup()
     tok.chat_template = ZEPHYR
     ins, _ = get_chat_template_parts(tok)
@@ -134,8 +133,8 @@ def test_zephyr_first_user_turn_variant_not_picked():
 
 
 def test_special_token_template_unchanged():
-    # A ChatML-style template whose markers ARE special tokens keeps detecting the
-    # plain first candidate (3/3 matches): the new preference cannot alter it.
+    # ChatML template whose markers ARE special tokens still detects the plain first
+    # candidate (3/3 matches): the new preference cannot alter it.
     tok, get_chat_template_parts, _ = _setup()
     tok.add_special_tokens({"additional_special_tokens": ["<|im_start|>", "<|im_end|>"]})
     tok.chat_template = (

--- a/tests/test_zephyr_marker_context.py
+++ b/tests/test_zephyr_marker_context.py
@@ -32,8 +32,11 @@ import pytest
 
 def _tokenizer():
     import json
-    from transformers import AutoTokenizer
-    from tokenizers import Tokenizer
+    try:
+        from transformers import AutoTokenizer
+        from tokenizers import Tokenizer
+    except ImportError:
+        return None  # dependency-light run: skip instead of erroring
     # SentencePiece tokenizer (Llama/Mistral) so "<" tokenizes context-dependently;
     # role tags must stay ordinary text, NOT added special tokens.
     try:

--- a/tests/test_zephyr_marker_context.py
+++ b/tests/test_zephyr_marker_context.py
@@ -1,0 +1,153 @@
+"""Auto-detect must handle role markers whose tokenization depends on context (Zephyr).
+
+Zephyr's role tags ("<|user|>", "<|assistant|>") are NOT special tokens: the underlying
+SentencePiece tokenizer splits them into pieces, and the leading "<" becomes "▁<" at text
+start (or standalone) but a bare "<" mid-text after "</s>\n". Two failures followed:
+
+  response_part    - "<|assistant|>\n" tokenized standalone never matches the rendered
+                     conversation, so get_chat_template_parts raised
+                     "Could not reliably auto-detect response_part".
+  instruction_part - "<|user|>\n" DID validate, but only via its text-start occurrence
+                     (the very first user turn). At masking time that single-context match
+                     misses every later user turn, so the span after an assistant header
+                     would run to the end of the sample and train on user content.
+
+get_chat_template_parts now also probes a leading-newline candidate ("\n<|assistant|>\n")
+and prefers candidates whose token core matches at least twice in the 3-turn probe (i.e.
+from the second turn on), falling back to the previous single-match acceptance for the
+original candidates. Special-token templates match their first candidate 3x and are
+unaffected.
+
+Self-contained and hermetic: builds the Zephyr template on a tiny SentencePiece tokenizer
+that is already cached locally, WITHOUT registering the role tags as special tokens (that
+is the point). Skips (not fails) when no tokenizer can be constructed offline or when the
+`unsloth`/`unsloth_zoo` package is not importable.
+"""
+import pytest
+
+# NOTE: unsloth_zoo is imported lazily in _setup(), not at module scope. Importing it
+# runs unsloth_zoo/__init__.py, which raises ImportError when the separate `unsloth`
+# package is absent; at module scope that would break pytest collection before the skip.
+
+
+def _tokenizer():
+    import json
+    from transformers import AutoTokenizer
+    from tokenizers import Tokenizer
+    # Needs a SentencePiece tokenizer (Llama/Mistral family) so "<" tokenizes context
+    # dependently; the role tags must stay ordinary text, NOT added special tokens.
+    try:
+        tok = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/llama-tokenizer", local_files_only=True
+        )
+    except Exception:
+        return None
+    # Zephyr's real tokenizer parses "</s>" mid-text as the eos special token (its
+    # AddedToken is normalized=False); the testing tokenizer ships normalized=True and
+    # would split it into "</ s >". Flip the flag so the fixture tokenizes like Zephyr:
+    # the segment after eos restarts with the SentencePiece prefix space ("▁<0x0A><|...").
+    d = json.loads(tok.backend_tokenizer.to_str())
+    for t in d["added_tokens"]:
+        if t["content"] == "</s>":
+            t["normalized"] = False
+    tok._tokenizer = Tokenizer.from_str(json.dumps(d))
+    return tok
+
+
+def _setup():
+    tok = _tokenizer()
+    if tok is None:
+        pytest.skip("no SentencePiece tokenizer cached offline")
+    try:
+        from unsloth_zoo.dataset_utils import get_chat_template_parts, train_on_responses_only
+    except ImportError as e:
+        pytest.skip(f"unsloth_zoo unavailable: {e}")
+    return tok, get_chat_template_parts, train_on_responses_only
+
+
+# HuggingFaceH4/zephyr-7b-beta chat template, verbatim.
+ZEPHYR = (
+    "{% for message in messages %}\n"
+    "{% if message['role'] == 'user' %}\n"
+    "{{ '<|user|>\n' + message['content'] + eos_token }}\n"
+    "{% elif message['role'] == 'system' %}\n"
+    "{{ '<|system|>\n' + message['content'] + eos_token }}\n"
+    "{% elif message['role'] == 'assistant' %}\n"
+    "{{ '<|assistant|>\n'  + message['content'] + eos_token }}\n"
+    "{% endif %}\n"
+    "{% if loop.last and add_generation_prompt %}\n"
+    "{{ '<|assistant|>' }}\n"
+    "{% endif %}\n"
+    "{% endfor %}"
+)
+
+MSGS = [
+    {"role": "system", "content": "SYSPROMPT terse"},
+    {"role": "user", "content": "QONE alpha"},
+    {"role": "assistant", "content": "ANSWERONE"},
+    {"role": "user", "content": "QTWO bravo"},
+    {"role": "assistant", "content": "ANSWERTWO"},
+]
+
+
+def _labels(tok, ins, res, tor):
+    text = tok.apply_chat_template(MSGS, tokenize=False, add_generation_prompt=False)
+    enc = tok(text, add_special_tokens=False, return_offsets_mapping=True)
+    ids, offs = enc["input_ids"], enc["offset_mapping"]
+    fn = tor(None, instruction_part=ins, response_part=res, tokenizer=tok, return_function=True)
+    labels = fn({"input_ids": [ids]})["labels"][0]
+    un = set(i for i in range(len(ids)) if labels[i] != -100)
+
+    def is_trained(sub):
+        i = text.index(sub); s, e = i, i + len(sub)
+        return all(k in un for k in [j for j, (a, b) in enumerate(offs) if b > a and a < e and b > s])
+    return ids, labels, is_trained
+
+
+def test_zephyr_autodetects_context_dependent_markers():
+    tok, get_chat_template_parts, train_on_responses_only = _setup()
+    tok.chat_template = ZEPHYR
+    ins, res = get_chat_template_parts(tok)  # raised ValueError before the fix
+    # The leading newline anchors the mid-text tokenization ("<" not "▁<")
+    assert ins == "\n<|user|>\n", ins
+    assert res == "\n<|assistant|>\n", res
+
+    ids, labels, tr = _labels(tok, ins, res, train_on_responses_only)
+    assert tr("ANSWERONE") and tr("ANSWERTWO")
+    assert not tr("SYSPROMPT terse")
+    assert not tr("QONE alpha") and not tr("QTWO bravo")
+    # Both assistant turn terminators trained; in particular the FINAL eos must never
+    # be -100 or the model never learns to stop.
+    eos_id = tok.eos_token_id
+    eos_positions = [i for i, t in enumerate(ids) if t == eos_id]
+    assert labels[eos_positions[-1]] != -100
+    assert labels[eos_positions[-3]] != -100  # first assistant turn's eos (-2 is user QTWO's)
+
+
+def test_zephyr_first_user_turn_variant_not_picked():
+    # "<|user|>\n" matches ONLY at position 0 (text start); the detector must not
+    # accept that single-context variant, or later user turns would stay trained.
+    tok, get_chat_template_parts, train_on_responses_only = _setup()
+    tok.chat_template = ZEPHYR
+    ins, _ = get_chat_template_parts(tok)
+    assert ins != "<|user|>\n", "single text-start match must not win over 2+ mid-text matches"
+
+
+def test_special_token_template_unchanged():
+    # A ChatML-style template whose markers ARE special tokens keeps detecting the
+    # plain first candidate (3/3 matches): the new preference cannot alter it.
+    tok, get_chat_template_parts, _ = _setup()
+    tok.add_special_tokens({"additional_special_tokens": ["<|im_start|>", "<|im_end|>"]})
+    tok.chat_template = (
+        "{%- for m in messages %}"
+        "{{ '<|im_start|>' + m['role'] + '\n' + m['content'] + '<|im_end|>' + '\n' }}"
+        "{%- endfor %}"
+        "{%- if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{%- endif %}"
+    )
+    ins, res = get_chat_template_parts(tok)
+    assert ins == "<|im_start|>user\n", ins
+    assert res == "<|im_start|>assistant\n", res
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", "-s"]))

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -303,11 +303,11 @@ def get_chat_template_parts(tokenizer):
     # Each marker must tokenize to a core present in a tokenized probe, else masking would
     # silently train on nothing (role tags that are not atomic tokens, or whose ids shift by
     # context). Some SentencePiece tokenizers need a leading space, so try that variant too.
-    # Non-special markers also tokenize differently at text start vs mid-text: Zephyr's
-    # "<|assistant|>" starts with "▁<" standalone but a bare "<" after "</s>\n", so probe a
-    # leading-newline variant as well. The probe holds 3 turns per role, so a reliable marker
-    # matches at least twice (from the second turn on); a single hit can be the text-start
-    # tokenization only (Zephyr's "<|user|>\n" at position 0), which breaks multi-turn masking.
+    # Markers also tokenize differently at text start vs mid-text (context-dependent
+    # SentencePiece): Zephyr's "<|assistant|>" is "▁<" standalone but bare "<" after "</s>\n",
+    # so also probe a leading-newline variant.
+    # 3 turns per role means a reliable marker matches >=2 times; a lone hit can be the
+    # text-start tokenization only (Zephyr "<|user|>\n" at pos 0), which breaks multi-turn masking.
     probe_ids = tok(full, add_special_tokens = False).input_ids
     def count_matches(cand):
         core = _find_common_token_ids(cand, tok, True)[0]
@@ -317,8 +317,8 @@ def get_chat_template_parts(tokenizer):
         counts = [(cand, count_matches(cand)) for cand in (part, " " + part, "\n" + part)]
         for cand, n in counts:
             if n >= 2: return cand
-        # Keep accepting single-match candidates for the original variants (a marker unique
-        # to the probe layout), preserving prior behaviour when nothing matches repeatedly.
+        # Fall back to a single-match original variant (marker unique to the probe layout),
+        # preserving prior behaviour when nothing matches twice.
         for cand, n in counts[:2]:
             if n >= 1: return cand
         raise ValueError(f"Unsloth: Could not reliably auto-detect {part_name} (detected {repr(part)}) - pass instruction_part and response_part.")

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -303,12 +303,24 @@ def get_chat_template_parts(tokenizer):
     # Each marker must tokenize to a core present in a tokenized probe, else masking would
     # silently train on nothing (role tags that are not atomic tokens, or whose ids shift by
     # context). Some SentencePiece tokenizers need a leading space, so try that variant too.
+    # Non-special markers also tokenize differently at text start vs mid-text: Zephyr's
+    # "<|assistant|>" starts with "▁<" standalone but a bare "<" after "</s>\n", so probe a
+    # leading-newline variant as well. The probe holds 3 turns per role, so a reliable marker
+    # matches at least twice (from the second turn on); a single hit can be the text-start
+    # tokenization only (Zephyr's "<|user|>\n" at position 0), which breaks multi-turn masking.
     probe_ids = tok(full, add_special_tokens = False).input_ids
+    def count_matches(cand):
+        core = _find_common_token_ids(cand, tok, True)[0]
+        if not core: return 0
+        return sum(probe_ids[i : i + len(core)] == core for i in range(len(probe_ids) - len(core) + 1))
     def validate(part, part_name):
-        for cand in (part, " " + part):
-            core = _find_common_token_ids(cand, tok, True)[0]
-            if core and any(probe_ids[i : i + len(core)] == core for i in range(len(probe_ids) - len(core) + 1)):
-                return cand
+        counts = [(cand, count_matches(cand)) for cand in (part, " " + part, "\n" + part)]
+        for cand, n in counts:
+            if n >= 2: return cand
+        # Keep accepting single-match candidates for the original variants (a marker unique
+        # to the probe layout), preserving prior behaviour when nothing matches repeatedly.
+        for cand, n in counts[:2]:
+            if n >= 1: return cand
         raise ValueError(f"Unsloth: Could not reliably auto-detect {part_name} (detected {repr(part)}) - pass instruction_part and response_part.")
     return validate(instruction_part, "instruction_part"), validate(response_part, "response_part")
 pass


### PR DESCRIPTION
## What was broken

`get_chat_template_parts` failed on Zephyr (`unsloth/zephyr-sft`, `HuggingFaceH4/zephyr-7b-beta`) with:

```
ValueError: Unsloth: Could not reliably auto-detect response_part (detected '<|assistant|>\n') - pass instruction_part and response_part.
```

Zephyr's role tags (`<|user|>`, `<|assistant|>`) are ordinary text, not special tokens. SentencePiece tokenizes them context-dependently:

- standalone / at text start: `▁<  |  ass  istant  |  >`
- mid-conversation after `</s>` + newline: `▁  <0x0A>  <  |  ass  istant  |  >` (bare `<`, no word-start piece)

The validation step tokenized each candidate marker standalone (plus a leading-space variant) and searched that token core in the rendered 3-turn probe, so:

1. `'<|assistant|>\n'` never matched anywhere in the probe and the detector raised. The usual manual markers fail the same way at masking time (same standalone tokenization in `_find_common_token_ids(force_match=True)`), so Zephyr had no working path and `train_on_responses_only` masked every assistant token.
2. Subtler: `'<|user|>\n'` DID validate, but only via its single text-start occurrence (the very first user turn). Had detection gotten that far, masking would have missed every later user turn and trained on user content after the first assistant header.

## The fix

In the marker validation of `get_chat_template_parts`:

- also probe a leading-newline candidate (`'\n' + part`), which reproduces the mid-conversation tokenization (the newline carries the SentencePiece word-start piece, leaving the tag tokenized exactly as it appears after a turn boundary), and
- prefer candidates whose token core matches at least twice in the probe. The probe renders three turns per role, so a reliable marker must match from the second turn on; a single hit can be the text-start tokenization only, which breaks multi-turn masking.

Single-match acceptance is kept for the original two candidates, so any template that previously validated still validates, and templates whose first candidate matches repeatedly (all special-token templates) return exactly what they returned before.

Zephyr now auto-detects `('\n<|user|>\n', '\n<|assistant|>\n')`, and those strings round-trip through `train_on_responses_only`'s exact-match tokenization correctly.

## Validation

Catalog sweep over the 35 Studio chat templates (real tokenizers, two-turn fixture with a system message, token-level label checks: user+system masked, all assistant turns trained, final EOS trained):

- Zephyr: `AUTO_FAILS` -> auto works. `user1_masked / user2_masked / system_masked / asst1_trained / asst2_trained / eos_trained` all pass; trained text is exactly `'grape reply number one.</s>grape reply number two.</s> \n'`.
- Every other template row (33 common rows plus `Qwen/QwQ-32B` re-checked separately): detected parts, labels, verdict and notes byte-identical before vs after the change.

Tests: new `tests/test_zephyr_marker_context.py` builds the verbatim Zephyr template on the cached `hf-internal-testing/llama-tokenizer` (role tags NOT registered as special tokens, eos parsing matched to Zephyr's tokenizer) and asserts detection, token-level masking, both assistant EOS labels trained, and that special-token templates keep their previous detection. Both new regression tests fail on main and pass with the fix; `test_special_token_template_unchanged` passes on both.

```
tests/test_zephyr_marker_context.py tests/test_reasoning_marker_strip.py
tests/test_notebook_chat_templates.py tests/test_vlm_collator_masking.py
tests/test_pr684_review_fixes_a.py tests/test_mlx_autodetect_template_source.py
tests/test_mlx_trainer_internals.py tests/test_zoo_history_regressions_deep.py
tests/test_zoo_source_upstream_refs.py tests/test_extended_dep_api_pins.py
263 passed, 3 skipped
```