### PR TITLE
Fix false DownloadStallError for non-standard sharded weight filenames

### DIFF
--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -2197,6 +2197,45 @@ def test_pre_download_does_not_skip_diffusers_but_post_accepts(tmp_path):
         snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
 
 
+def test_post_accepts_nonstandard_sharded_safetensors_names(tmp_path):
+    """Regression for issue #889: unsloth/Qwen3.5-4B shards its safetensors with a NON-standard name that
+    keeps the format suffix in the middle (model.safetensors-00001-of-00002.safetensors), referenced that
+    way by model.safetensors.index.json. transformers enumerates the weight through the index, so the
+    post-download gate must accept it rather than raise a spurious DownloadStallError. Shard completeness
+    is still enforced: a missing shard is rejected, and the standard sharded layout is unaffected."""
+    shards = ["model.safetensors-00001-of-00002.safetensors",
+              "model.safetensors-00002-of-00002.safetensors"]
+    # Complete cache with the non-standard shard names -> accepted (the #889 fix).
+    snap, blob = _mk_snapshot(tmp_path, "qwen35_nonstd")
+    (snap / "config.json").write_text("{}")
+    for s in shards:
+        (snap / s).symlink_to(blob)
+    (snap / "model.safetensors.index.json").write_text(json.dumps(
+        {"weight_map": {"a": shards[0], "b": shards[1]}}))
+    assert xf._download_result_usable(
+        snap, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
+
+    # Same layout but one shard missing -> still rejected (Invariant B validates via the index).
+    snap2, blob2 = _mk_snapshot(tmp_path, "qwen35_nonstd_missing")
+    (snap2 / "config.json").write_text("{}")
+    (snap2 / shards[0]).symlink_to(blob2)
+    (snap2 / "model.safetensors.index.json").write_text(json.dumps(
+        {"weight_map": {"a": shards[0], "b": shards[1]}}))
+    assert xf._download_result_usable(
+        snap2, repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
+
+    # Sanity: the standard sharded layout still passes.
+    snap3, blob3 = _mk_snapshot(tmp_path, "qwen35_standard")
+    (snap3 / "config.json").write_text("{}")
+    std = ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]
+    for s in std:
+        (snap3 / s).symlink_to(blob3)
+    (snap3 / "model.safetensors.index.json").write_text(json.dumps(
+        {"weight_map": {"a": std[0], "b": std[1]}}))
+    assert xf._download_result_usable(
+        snap3, repo_type = "model", allow_patterns = None, ignore_patterns = None) is True
+
+
 def test_pre_download_defers_sentence_transformers_missing_subfolder_weight(tmp_path):
     """A sentence-transformers model reads a weight-bearing subfolder module (2_Dense) the canonical root
     gate does not check, so a partial cache holding the root weight but missing the 2_Dense weight must

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -2369,6 +2369,46 @@ def test_post_download_rejects_canonical_only_for_variant(tmp_path):
         variant = "fp16") is True
 
 
+def test_post_accepts_nonstandard_sharded_variant_names(tmp_path):
+    """Variant analog of #889: a variant sharded with NON-standard shard names the variant-weight regex
+    misses (the format suffix kept in the middle) is enumerated through model.safetensors.index.fp16.json,
+    so the post-download gate must accept it rather than raise a spurious DownloadStallError. Shard
+    completeness is still enforced via the index: a missing shard is rejected."""
+    shards = ["model.fp16.safetensors-00001-of-00002.safetensors",
+              "model.fp16.safetensors-00002-of-00002.safetensors"]
+    # Complete cache with the non-standard variant shard names -> accepted.
+    snap, blob = _mk_snapshot(tmp_path, "varnonstd")
+    (snap / "config.json").write_text("{}")
+    for s in shards:
+        (snap / s).symlink_to(blob)
+    (snap / "model.safetensors.index.fp16.json").write_text(json.dumps(
+        {"weight_map": {"a": shards[0], "b": shards[1]}}))
+    assert xf._download_result_usable(
+        snap, repo_type = "model", allow_patterns = None, ignore_patterns = None,
+        variant = "fp16") is True
+
+    # Same layout but one shard missing -> still rejected (Invariant B validates via the index).
+    snap2, blob2 = _mk_snapshot(tmp_path, "varnonstd_missing")
+    (snap2 / "config.json").write_text("{}")
+    (snap2 / shards[0]).symlink_to(blob2)
+    (snap2 / "model.safetensors.index.fp16.json").write_text(json.dumps(
+        {"weight_map": {"a": shards[0], "b": shards[1]}}))
+    assert xf._download_result_usable(
+        snap2, repo_type = "model", allow_patterns = None, ignore_patterns = None,
+        variant = "fp16") is False
+
+    # The variant index does not rescue when its format is ignored (load reads .bin only).
+    snap3, blob3 = _mk_snapshot(tmp_path, "varnonstd_ignored")
+    (snap3 / "config.json").write_text("{}")
+    for s in shards:
+        (snap3 / s).symlink_to(blob3)
+    (snap3 / "model.safetensors.index.fp16.json").write_text(json.dumps(
+        {"weight_map": {"a": shards[0], "b": shards[1]}}))
+    assert xf._download_result_usable(
+        snap3, repo_type = "model", allow_patterns = None, ignore_patterns = ["*.safetensors"],
+        variant = "fp16") is False
+
+
 def test_post_download_rejects_patterned_canonical_only_for_variant(tmp_path):
     """The variant check applies to the patterned branch too: a subfolder variant request kept only the canonical weight is rejected."""
     snap, blob = _mk_snapshot(tmp_path, "subvar")

--- a/unsloth_zoo/hf_cache_state.py
+++ b/unsloth_zoo/hf_cache_state.py
@@ -336,6 +336,28 @@ def _filter_paths(
         return list(paths)
 
 
+def _read_format_kept(weight_name: str, ignore_patterns: "Optional[list]") -> bool:
+    """Whether a weight of *weight_name*'s format survives the ignore filter -- i.e. the load actually
+    reads it, so its presence (or an index enumerating it) is real evidence and not a stale
+    excluded-format artifact (a ``pytorch_model.bin`` under ``ignore=['*.bin']``). Shared by the presence
+    checks (Invariant A) and the shard-completeness checks (Invariant B) so both judge the ignore filter
+    identically. *ignore_patterns* must be a normalized list (see ``_as_pattern_list``) or None."""
+    if not ignore_patterns:
+        return True
+    return bool(_filter_paths([weight_name], None, ignore_patterns))
+
+
+def _index_weight_probe(index_name: str, variant: "Optional[str]" = None) -> str:
+    """The canonical ROOT weight filename whose FORMAT a shard *index* enumerates, used as the ignore
+    filter probe: a ``.safetensors.index.`` index -> ``model[.<variant>].safetensors``, any other (``.bin
+    .index.``) -> ``pytorch_model[.<variant>].bin``. Centralizes the safetensors-vs-bin split so the
+    presence checks (Invariant A) and completeness checks (Invariant B) map an index to the SAME probe."""
+    token = f".{variant}" if variant else ""
+    if ".safetensors.index." in index_name:
+        return f"model{token}.safetensors"
+    return f"pytorch_model{token}.bin"
+
+
 def _broken_symlink_rel_paths(snapshot_dir: Path) -> list:
     """Repo-relative posix paths of every dangling symlink in *snapshot_dir*, so the interrupted-download
     signal can be scoped to the files a request selects."""
@@ -516,29 +538,26 @@ def _canonical_root_weights_complete(
         elif _safe_is_file(entry):
             root_files.add(entry.name)
 
-    def _format_kept(weight_name: str) -> bool:
-        # The read format must survive the ignore filter, else the file is a stale excluded-format artifact.
-        if not ignore_patterns:
-            return True
-        return bool(_filter_paths([weight_name], None, ignore_patterns))
-
-    st_index = next((e for e in root_indices if ".safetensors.index." in e.name), None)
-    bin_index = next((e for e in root_indices if ".bin.index." in e.name), None)
+    # Map each present root index to the weight it enumerates, so the format split is single-sourced in
+    # _index_weight_probe (each canonical index maps to a distinct format, so no probe collides).
+    index_by_read = {_index_weight_probe(e.name): e for e in root_indices}
+    st_index = index_by_read.get("model.safetensors")
+    bin_index = index_by_read.get("pytorch_model.bin")
     # transformers' local precedence, mirrored: single safetensors before the safetensors index,
     # safetensors before the .bin single, .bin single before the .bin index. So a complete single weight
     # is never masked by a stale index, and an incomplete PREFERRED safetensors index is breakage a
     # complete .bin must not mask. An ignore-dropped format is skipped so the next read format is judged.
-    if "model.safetensors" in root_files and _format_kept("model.safetensors"):
+    if "model.safetensors" in root_files and _read_format_kept("model.safetensors", ignore_patterns):
         return True
-    if st_index is not None and _format_kept("model.safetensors"):
+    if st_index is not None and _read_format_kept("model.safetensors", ignore_patterns):
         return _weight_shard_index_complete(st_index)
-    if prefer_safetensors and _format_kept("model.safetensors"):
+    if prefer_safetensors and _read_format_kept("model.safetensors", ignore_patterns):
         # STRICT gate: safetensors is preferred but absent, and a bin-only cache cannot prove it absent
         # remotely, so a default load would fetch it over Xet -> defer to the child.
         return False
-    if "pytorch_model.bin" in root_files and _format_kept("pytorch_model.bin"):
+    if "pytorch_model.bin" in root_files and _read_format_kept("pytorch_model.bin", ignore_patterns):
         return True
-    if bin_index is not None and _format_kept("pytorch_model.bin"):
+    if bin_index is not None and _read_format_kept("pytorch_model.bin", ignore_patterns):
         return _weight_shard_index_complete(bin_index)
     return False
 
@@ -641,12 +660,8 @@ def _sentence_transformers_subfolder_incomplete(
             names = {entry.name for entry in sub.iterdir()} if _safe_is_dir(sub) else set()
         except OSError:
             names = set()
-        st_read = (not ignore_patterns) or bool(
-            _filter_paths([f"{path}/model.safetensors"], None, ignore_patterns)
-        )
-        bin_read = (not ignore_patterns) or bool(
-            _filter_paths([f"{path}/pytorch_model.bin"], None, ignore_patterns)
-        )
+        st_read = _read_format_kept(f"{path}/model.safetensors", ignore_patterns)
+        bin_read = _read_format_kept(f"{path}/pytorch_model.bin", ignore_patterns)
         st_present = "model.safetensors" in names and st_read
         bin_present = "pytorch_model.bin" in names and bin_read
         if prefer_safetensors and st_read:
@@ -706,12 +721,6 @@ def _has_incomplete_variant_root_shards(
     dash_infix = f".{variant}-"    # a sharded variant weight (model.<variant>-00001-of-00002.safetensors)
     ignore_patterns = _as_pattern_list(ignore_patterns)
 
-    def _format_kept(weight_name: str) -> bool:
-        # The read format must survive the ignore filter, else the file is a stale excluded-format artifact.
-        if not ignore_patterns:
-            return True
-        return bool(_filter_paths([weight_name], None, ignore_patterns))
-
     try:
         entries = list(snapshot_dir.iterdir())
     except OSError:
@@ -725,26 +734,23 @@ def _has_incomplete_variant_root_shards(
         # Restrict to the ROOT model index; an adapter_model / other non-model variant index the default
         # load does not read is skipped so its incompleteness cannot force-fail the model variant.
         if dot_infix in name and _ROOT_MODEL_SHARD_INDEX_RE.match(name):
-            is_safetensors = ".safetensors.index." in name
-            fmt_probe = (
-                f"model.{variant}.safetensors" if is_safetensors else f"pytorch_model.{variant}.bin"
-            )
-            if not _format_kept(fmt_probe):
+            probe = _index_weight_probe(name, variant)
+            if not _read_format_kept(probe, ignore_patterns):
                 continue  # this format is ignored -> the load does not read it
             incomplete = not (_safe_is_file(entry) and _weight_shard_index_complete(entry))
-            if is_safetensors:
+            if probe.endswith(".safetensors"):
                 st_index_incomplete = incomplete
             else:
                 bin_index_incomplete = incomplete
         elif dash_infix in name and _ROOT_MODEL_VARIANT_WEIGHT_RE.match(name):
-            if _safe_is_file(entry) and _format_kept(name):
+            if _safe_is_file(entry) and _read_format_kept(name, ignore_patterns):
                 if name.endswith(".safetensors"):
                     has_st_shard = True
                 else:
                     has_bin_shard = True
         elif dot_infix in name and _ROOT_MODEL_VARIANT_WEIGHT_RE.match(name):
             # a single-file ROOT model variant weight (model.<variant>.safetensors / .bin).
-            if _safe_is_file(entry) and _format_kept(name):
+            if _safe_is_file(entry) and _read_format_kept(name, ignore_patterns):
                 if name.endswith(".safetensors"):
                     has_single_st = True
                 else:

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -1225,11 +1225,9 @@ def _root_model_has_weight(snapshot_dir: Path, *, ignore_patterns: Any = None) -
         return False
     if _filter_paths(rels, None, ignore_patterns):
         return True
-    # A canonical ROOT shard INDEX of a kept format proves a readable weight even when the shard files
-    # carry a NON-standard name the canonical regex misses (e.g. model.safetensors-00001-of-00002
-    # .safetensors, referenced that way by the index's weight_map). transformers enumerates the sharded
-    # weight through the index, so its presence is the readable-weight signal; shard completeness stays
-    # Invariant B's job (_readable_shard_set_incomplete).
+    # A canonical ROOT shard INDEX of a kept format proves a readable weight even for non-standard shard
+    # names (e.g. model.safetensors-00001-of-00002.safetensors): transformers enumerates the weight
+    # through the index, so its presence is the readable-weight signal; completeness stays Invariant B's.
     if any(_read_format_kept(probe, ignore_patterns) for probe in index_probes):
         return True
     # from_tf / from_flax (both PyTorch formats ignored): count a SINGLE-FILE TF/Flax weight or a COMPLETE
@@ -1288,10 +1286,9 @@ def _root_has_variant_weight(
         return False
     if _filter_paths(rels, None, ignore_patterns):
         return True
-    # A ROOT variant shard INDEX of a kept format proves a readable weight even when the shard files carry
-    # a NON-standard name the variant-weight regex misses (mirrors _root_model_has_weight). The probe and
-    # format-kept test are shared with _has_incomplete_variant_root_shards so presence (Invariant A) and
-    # completeness (Invariant B) judge the ignore filter identically.
+    # A ROOT variant shard INDEX of a kept format proves a readable weight even for non-standard shard
+    # names (mirrors _root_model_has_weight). Probe + format-kept are shared with
+    # _has_incomplete_variant_root_shards so presence (Invariant A) and completeness (Invariant B) agree.
     return any(_read_format_kept(probe, ignore_patterns) for probe in index_probes)
 
 

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -45,6 +45,7 @@ from typing import Any, Callable, Optional
 
 from unsloth_zoo.hf_cache_state import (
     INCOMPLETE_SUFFIX,
+    _ROOT_MODEL_SHARD_INDEX_RE,
     _ROOT_MODEL_VARIANT_WEIGHT_RE,
     _as_pattern_list,
     _diffusers_component_shards_incomplete,
@@ -53,8 +54,10 @@ from unsloth_zoo.hf_cache_state import (
     _has_glob,
     _has_incomplete_canonical_root_shards,
     _has_incomplete_variant_root_shards,
+    _index_weight_probe,
     _is_canonical_weight_shard_index,
     _is_loadable_weight_file,
+    _read_format_kept,
     _selected_shard_index_incomplete,
     _sentence_transformers_subfolder_incomplete,
     _weight_shard_index_complete,
@@ -1201,8 +1204,7 @@ def _root_model_has_weight(snapshot_dir: Path, *, ignore_patterns: Any = None) -
         return _has_diffusers_component_weight(snapshot_dir, ignore_patterns = ignore_patterns)
     rels: list = []
     tf_flax_rels: list = []
-    has_st_index = False
-    has_bin_index = False
+    index_probes: set = set()
     try:
         for entry in snapshot_dir.iterdir():
             name = entry.name
@@ -1215,11 +1217,8 @@ def _root_model_has_weight(snapshot_dir: Path, *, ignore_patterns: Any = None) -
                 rels.append(name)  # canonical model / pytorch_model (single or shard)
             elif _is_canonical_weight_shard_index(name):
                 # a sharded model enumerated via its canonical root index (shard files may carry a
-                # non-standard name the regex above misses); track per-format for the ignore filter.
-                if ".safetensors.index." in name:
-                    has_st_index = True
-                else:
-                    has_bin_index = True
+                # non-standard name the regex above misses); record the weight it enumerates.
+                index_probes.add(_index_weight_probe(name))
             elif _CANONICAL_ROOT_TF_FLAX_WEIGHT_RE.match(name):
                 tf_flax_rels.append(name)  # TF/Flax root weight (from_tf / from_flax)
     except OSError:
@@ -1231,9 +1230,7 @@ def _root_model_has_weight(snapshot_dir: Path, *, ignore_patterns: Any = None) -
     # .safetensors, referenced that way by the index's weight_map). transformers enumerates the sharded
     # weight through the index, so its presence is the readable-weight signal; shard completeness stays
     # Invariant B's job (_readable_shard_set_incomplete).
-    if has_st_index and _filter_paths(["model.safetensors"], None, ignore_patterns):
-        return True
-    if has_bin_index and _filter_paths(["pytorch_model.bin"], None, ignore_patterns):
+    if any(_read_format_kept(probe, ignore_patterns) for probe in index_probes):
         return True
     # from_tf / from_flax (both PyTorch formats ignored): count a SINGLE-FILE TF/Flax weight or a COMPLETE
     # sharded set (index + every listed shard present), so a complete h5/msgpack download is not
@@ -1262,29 +1259,40 @@ def _root_has_variant_weight(
     non-``model`` variant is excluded -> a cache holding only those is retried over HTTP. The ignore
     filter is applied so an ignored-format partial does not count.
 
-    Unlike ``_root_model_has_weight``, this intentionally does NOT recognize a variant shard *index*
-    (``model.<variant>.safetensors.index.json``): a variant whose shard files carry a non-standard name
-    is a rare combination not yet needed (standard-named variant shards match the regex via the
-    ``.<variant>-`` infix). The variant completeness sibling ``_has_incomplete_variant_root_shards`` does
-    read the index, so revisit this if such a repo ever surfaces."""
+    Mirrors ``_root_model_has_weight``: a ROOT variant shard INDEX
+    (``model.safetensors.index.<variant>.json`` / ``pytorch_model.bin.index.<variant>.json``) of a kept
+    format also proves a readable weight, so a variant sharded with NON-standard shard names the weight
+    regex misses is not false-rejected. Shard completeness stays ``_has_incomplete_variant_root_shards``'s
+    job, so an index whose shards are missing is still correctly rejected."""
     infix_dot = f".{variant}."
     infix_dash = f".{variant}-"
     rels: list = []
+    index_probes: set = set()
     try:
         for entry in snapshot_dir.iterdir():
             name = entry.name
             if infix_dot not in name and infix_dash not in name:
                 continue  # not the requested variant token
-            if not _ROOT_MODEL_VARIANT_WEIGHT_RE.match(name):
-                continue  # only a canonical model / pytorch_model variant weight, not adapter / gguf
             try:
-                if entry.is_file():
-                    rels.append(name)
+                if not entry.is_file():
+                    continue
             except OSError:
                 continue
+            if _ROOT_MODEL_VARIANT_WEIGHT_RE.match(name):
+                rels.append(name)  # canonical model / pytorch_model variant weight (single or shard)
+            elif _ROOT_MODEL_SHARD_INDEX_RE.match(name):
+                # a sharded variant enumerated via its root index (shard files may carry a non-standard
+                # name the regex above misses); record the variant weight it enumerates.
+                index_probes.add(_index_weight_probe(name, variant))
     except OSError:
         return False
-    return bool(_filter_paths(rels, None, ignore_patterns))
+    if _filter_paths(rels, None, ignore_patterns):
+        return True
+    # A ROOT variant shard INDEX of a kept format proves a readable weight even when the shard files carry
+    # a NON-standard name the variant-weight regex misses (mirrors _root_model_has_weight). The probe and
+    # format-kept test are shared with _has_incomplete_variant_root_shards so presence (Invariant A) and
+    # completeness (Invariant B) judge the ignore filter identically.
+    return any(_read_format_kept(probe, ignore_patterns) for probe in index_probes)
 
 
 def _has_diffusers_component_variant_weight(

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -53,6 +53,7 @@ from unsloth_zoo.hf_cache_state import (
     _has_glob,
     _has_incomplete_canonical_root_shards,
     _has_incomplete_variant_root_shards,
+    _is_canonical_weight_shard_index,
     _is_loadable_weight_file,
     _selected_shard_index_incomplete,
     _sentence_transformers_subfolder_incomplete,
@@ -1200,6 +1201,8 @@ def _root_model_has_weight(snapshot_dir: Path, *, ignore_patterns: Any = None) -
         return _has_diffusers_component_weight(snapshot_dir, ignore_patterns = ignore_patterns)
     rels: list = []
     tf_flax_rels: list = []
+    has_st_index = False
+    has_bin_index = False
     try:
         for entry in snapshot_dir.iterdir():
             name = entry.name
@@ -1210,11 +1213,27 @@ def _root_model_has_weight(snapshot_dir: Path, *, ignore_patterns: Any = None) -
                 continue
             if _CANONICAL_ROOT_MODEL_WEIGHT_RE.match(name):
                 rels.append(name)  # canonical model / pytorch_model (single or shard)
+            elif _is_canonical_weight_shard_index(name):
+                # a sharded model enumerated via its canonical root index (shard files may carry a
+                # non-standard name the regex above misses); track per-format for the ignore filter.
+                if ".safetensors.index." in name:
+                    has_st_index = True
+                else:
+                    has_bin_index = True
             elif _CANONICAL_ROOT_TF_FLAX_WEIGHT_RE.match(name):
                 tf_flax_rels.append(name)  # TF/Flax root weight (from_tf / from_flax)
     except OSError:
         return False
     if _filter_paths(rels, None, ignore_patterns):
+        return True
+    # A canonical ROOT shard INDEX of a kept format proves a readable weight even when the shard files
+    # carry a NON-standard name the canonical regex misses (e.g. model.safetensors-00001-of-00002
+    # .safetensors, referenced that way by the index's weight_map). transformers enumerates the sharded
+    # weight through the index, so its presence is the readable-weight signal; shard completeness stays
+    # Invariant B's job (_readable_shard_set_incomplete).
+    if has_st_index and _filter_paths(["model.safetensors"], None, ignore_patterns):
+        return True
+    if has_bin_index and _filter_paths(["pytorch_model.bin"], None, ignore_patterns):
         return True
     # from_tf / from_flax (both PyTorch formats ignored): count a SINGLE-FILE TF/Flax weight or a COMPLETE
     # sharded set (index + every listed shard present), so a complete h5/msgpack download is not
@@ -1241,7 +1260,13 @@ def _root_has_variant_weight(
     ``model.<variant>-00001-of-00002.safetensors`` (``.<variant>-`` shard infix), matched by
     ``_ROOT_MODEL_VARIANT_WEIGHT_RE`` plus the variant infix. A non-canonical base, PEFT adapter, or
     non-``model`` variant is excluded -> a cache holding only those is retried over HTTP. The ignore
-    filter is applied so an ignored-format partial does not count."""
+    filter is applied so an ignored-format partial does not count.
+
+    Unlike ``_root_model_has_weight``, this intentionally does NOT recognize a variant shard *index*
+    (``model.<variant>.safetensors.index.json``): a variant whose shard files carry a non-standard name
+    is a rare combination not yet needed (standard-named variant shards match the regex via the
+    ``.<variant>-`` infix). The variant completeness sibling ``_has_incomplete_variant_root_shards`` does
+    read the index, so revisit this if such a repo ever surfaces."""
     infix_dot = f".{variant}."
     infix_dash = f".{variant}-"
     rels: list = []


### PR DESCRIPTION
## Problem

Fixes #889.

Loading `unsloth/Qwen3.5-4B` deterministically raises:

```
DownloadStallError: Download for 'unsloth/Qwen3.5-4B' returned an incomplete
snapshot even with HF_HUB_DISABLE_XET=1 -- missing files
```

even on a fully-downloaded, complete snapshot (reproduces across hosts, and over plain HTTP with Xet disabled). The model loaded fine before #829.

## Root cause

The repo shards its safetensors with a **non-standard filename** that keeps the format suffix in the middle:

```
model.safetensors-00001-of-00002.safetensors
model.safetensors-00002-of-00002.safetensors
model.safetensors.index.json      # weight_map -> the two names above
```

`transformers` loads this fine (it reads the index and follows `weight_map`). But the post-download presence check `_root_model_has_weight` only recognizes weight **files** matching `_CANONICAL_ROOT_MODEL_WEIGHT_RE` (`^(?:model|pytorch_model)(?:-\d{5}-of-\d{5})?\.(?:safetensors|bin)$`). `model.safetensors-00001-of-00002.safetensors` does not match, and the function never consults the shard index — so Invariant A ("a readable weight is present") returns `False`, `_download_result_usable` returns `False`, and a complete snapshot is failed.

This was a **pre/post asymmetry**: the pre-download gate (`snapshot_dir_is_complete` → `_canonical_root_weights_complete`) already handled this layout via the index, and the completeness half (Invariant B, `_readable_shard_set_incomplete` → `_has_incomplete_canonical_root_shards`) does too — only the post-download presence check did not.

## Fix

In `_root_model_has_weight`, additionally accept a canonical root shard index (`model.safetensors.index.json` / `pytorch_model.bin.index.json`) of a kept format as evidence that a readable weight is present (reusing the existing `_is_canonical_weight_shard_index` predicate). `transformers` enumerates the sharded weight through the index, so its presence is the correct readable-weight signal; shard **completeness** stays Invariant B's job, so an index whose shards are missing is still correctly rejected.

Scope: limited to the non-variant root path the issue hits. The variant sibling `_root_has_variant_weight` has the same latent blind spot but only for the rare variant + non-standard-shard-name combination; a docstring note documents that as a deliberate scope decision.

## Verification

Against the real cached `unsloth/Qwen3.5-4B` (2-shard) and `unsloth/qwen3.5-2b` (1-shard) models:

- Before: `_snapshot_payload_incomplete(...) = True` → would raise `DownloadStallError`.
- After: every gate (`_root_model_has_weight`, `snapshot_dir_is_complete`, `_cache_can_skip_download`, `_download_result_usable`, `_snapshot_payload_incomplete`) passes, and `snapshot_download_with_xet_fallback('unsloth/Qwen3.5-4B')` returns the snapshot dir with no error.
- Safety preserved: a snapshot whose index references a missing shard is still rejected; the standard `model-00001-of-00002.safetensors` layout is unaffected.

Adds a regression test `test_post_accepts_nonstandard_sharded_safetensors_names` covering the accepted, missing-shard-rejected, and standard-layout cases.
