### PR TITLE
Persist torch.compile artifacts across processes with Mega-cache

### DIFF
--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -192,13 +192,59 @@ pass
 def _bundle_paths(key):
     root = _cache_root()
     if root is None:
-        return None, None, None
+        return None, None
     directory = os.path.join(root, key)
-    return (
-        directory,
-        os.path.join(directory, _BUNDLE_NAME),
-        os.path.join(directory, _MANIFEST_NAME),
-    )
+    return directory, os.path.join(directory, _MANIFEST_NAME)
+pass
+
+
+def _read_disk_bundle(directory, manifest_path):
+    """Read the (manifest, bundle bytes) pair for a key, returning
+    ``(None, None)`` unless the manifest checksum matches the bundle file it
+    points at. The manifest names its bundle file (content-addressed by the
+    writer), so a manifest can never validate against a bundle written by a
+    different process: same name implies same bytes."""
+    try:
+        with open(manifest_path, "r") as file:
+            manifest = json.load(file)
+        bundle_name = os.path.basename(str(manifest.get("bundle", _BUNDLE_NAME)))
+        with open(os.path.join(directory, bundle_name), "rb") as file:
+            data = file.read()
+        if manifest.get("sha256") != hashlib.sha256(data).hexdigest():
+            return None, None
+        return manifest, data
+    except Exception:
+        return None, None
+pass
+
+
+def _merge_recorded_artifacts(data):
+    """Re-record an existing bundle's artifacts into torch's artifact manager
+    so the next ``save_cache_artifacts`` serializes the UNION of the on-disk
+    bundle and this process' artifacts. torch only records what this run
+    loaded-and-hit or compiled, so without this a run that exercises a subset
+    of a warm bundle (a different shape, one of several cached models) would
+    replace the bundle with that subset and silently drop the rest.
+    Best-effort: a failure just means this save may narrow the bundle."""
+    try:
+        from torch.compiler._cache import CacheArtifactManager
+        artifacts = CacheArtifactManager.deserialize(data)
+        if not artifacts:
+            return
+        merged = 0
+        for artifact_type, items in artifacts.items():
+            for artifact in items:
+                # Value-equality dedup: artifacts this run re-recorded on its
+                # own hits are already present and are skipped.
+                if artifact in CacheArtifactManager._seen_artifacts:
+                    continue
+                CacheArtifactManager._new_cache_artifacts[artifact_type].append(artifact)
+                CacheArtifactManager._seen_artifacts.add(artifact)
+                merged += 1
+        if merged:
+            _log(f"merged {merged} artifact(s) from the existing bundle")
+    except Exception as error:
+        _log(f"bundle merge skipped ({error})")
 pass
 
 
@@ -222,8 +268,8 @@ def megacache_load(model_type, compile_kwargs = None, torch_compile_options = No
         _model_key(model_type, compile_kwargs or {}, torch_compile_options or {})
     )
     key = _bundle_key()
-    directory, bundle_path, manifest_path = _bundle_paths(key)
-    if bundle_path is None:
+    directory, manifest_path = _bundle_paths(key)
+    if manifest_path is None:
         _log("no writable cache root; skipping")
         return False
 
@@ -236,20 +282,12 @@ def megacache_load(model_type, compile_kwargs = None, torch_compile_options = No
         atexit.register(megacache_save)
         _STATE["atexit_registered"] = True
 
-    if not (os.path.isfile(bundle_path) and os.path.isfile(manifest_path)):
+    manifest, data = _read_disk_bundle(directory, manifest_path)
+    if manifest is None:
         _log(f"no bundle for key {key} (will compile locally and save on exit)")
         return False
 
     try:
-        with open(manifest_path, "r") as file:
-            manifest = json.load(file)
-        with open(bundle_path, "rb") as file:
-            data = file.read()
-        # Defence in depth: torch validates internally as well, but a stale or
-        # corrupted bundle should be an explicit miss, not a surprise.
-        if manifest.get("sha256") != hashlib.sha256(data).hexdigest():
-            _log("bundle checksum mismatch; ignoring")
-            return False
         import torch
         info = torch.compiler.load_cache_artifacts(data)
         if info is None:
@@ -266,11 +304,12 @@ pass
 
 def megacache_save():
     """Persist this process' compile artifacts. Runs at exit (atexit) or on
-    demand. torch records artifacts on cache HITS as well as writes, so the
-    serialized bundle is a superset of anything loaded plus everything newly
-    compiled; save whenever those bytes differ from the bundle on disk. A
-    pure hit with no new compilation serializes back to the same content and
-    is skipped. Never raises.
+    demand. torch records artifacts on cache HITS as well as writes, but only
+    for the entries this run actually exercised - so the on-disk bundle is
+    first merged back into the recorder and the saved bundle is always the
+    UNION of the existing bundle and this process' artifacts. A run that
+    changes nothing serializes back to the same content and is skipped.
+    Never raises.
     """
     if not (_STATE["armed"] and megacache_is_enabled() and _mega_cache_supported()):
         return False
@@ -284,36 +323,45 @@ def megacache_save():
         return False
     try:
         import torch
+        directory, manifest_path = _bundle_paths(key)
+        if manifest_path is None:
+            return False
+        # Union semantics: fold the current on-disk bundle back into the
+        # manager before serializing, so a run that exercised only part of a
+        # warm bundle cannot narrow it (see _merge_recorded_artifacts).
+        _, existing = _read_disk_bundle(directory, manifest_path)
+        if existing is not None:
+            _merge_recorded_artifacts(existing)
         result = torch.compiler.save_cache_artifacts()
         if not result or not result[0]:
             _log("nothing to save (no compile artifacts recorded)")
             return False
         data = result[0]
-        directory, bundle_path, manifest_path = _bundle_paths(key)
-        if bundle_path is None:
-            return False
         new_sha = hashlib.sha256(data).hexdigest()
-        if not _refresh_enabled():
-            try:
-                with open(manifest_path, "r") as file:
-                    if json.load(file).get("sha256") == new_sha:
-                        _log("bundle unchanged; skipping save")
-                        return False
-            except Exception:
-                pass
+        if not _refresh_enabled() and existing is not None:
+            if hashlib.sha256(existing).hexdigest() == new_sha:
+                _log("bundle unchanged; skipping save")
+                return False
         os.makedirs(directory, exist_ok = True)
-        # PID-unique temp + atomic replace: concurrent processes cannot
-        # truncate or interleave each other's bytes.
-        temporary_path = f"{bundle_path}.tmp.{os.getpid()}"
-        with open(temporary_path, "wb") as file:
-            file.write(data)
-        os.replace(temporary_path, bundle_path)
+        # The bundle file is content-addressed and the manifest names it, so
+        # the (bundle, manifest) pair is consistent without a cross-file lock:
+        # concurrent writers produce differently named bundles, the manifest
+        # replace is atomic, and whichever manifest lands last points at its
+        # own complete file. Same name always implies same bytes.
+        bundle_name = f"megacache-{new_sha[:16]}.bin"
+        bundle_path = os.path.join(directory, bundle_name)
+        if not os.path.isfile(bundle_path):
+            temporary_path = f"{bundle_path}.tmp.{os.getpid()}"
+            with open(temporary_path, "wb") as file:
+                file.write(data)
+            os.replace(temporary_path, bundle_path)
         manifest = {
             "format": _FORMAT_VERSION,
             "key": key,
             "created": time.time(),
             "bytes": len(data),
             "sha256": new_sha,
+            "bundle": bundle_name,
             "env": _environment_fingerprint(),
             "models": _STATE["model_keys"],
         }
@@ -322,6 +370,21 @@ def megacache_save():
             json.dump(manifest, file, indent = 2, sort_keys = True, default = str)
         os.replace(temporary_manifest, manifest_path)
         _log(f"saved bundle for key {key} ({len(data)} bytes)")
+        # Best-effort GC of superseded bundle files (including the legacy
+        # fixed-name bundle). A concurrent reader that already opened one
+        # keeps its file handle; a reader that comes later re-reads the
+        # manifest and finds the new name.
+        try:
+            for name in os.listdir(directory):
+                is_stale_bundle = (
+                    name == _BUNDLE_NAME
+                    or (name.startswith("megacache-") and name.endswith(".bin"))
+                    or ".bin.tmp." in name
+                )
+                if is_stale_bundle and name != bundle_name:
+                    os.unlink(os.path.join(directory, name))
+        except Exception:
+            pass
         return True
     except Exception as error:
         _log(f"save failed ({error})")

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -1,0 +1,303 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Persistent torch.compile artifact cache for Unsloth training (Mega-cache).
+
+``unsloth_compiled_cache/`` only caches the GENERATED SOURCE of the patched
+modules. The expensive part of a first training step - Dynamo tracing,
+AOTAutograd partitioning, Inductor codegen and Triton autotuning for the
+forward AND backward graphs - is redone by every new process unless torch's
+own on-disk caches (FX graph cache, AOTAutograd cache, autotune cache) are
+warm. Those caches live under ``TORCHINDUCTOR_CACHE_DIR`` (by default a
+``/tmp/torchinductor_<user>`` directory that rarely survives reboots or
+container restarts, and is never shipped to users).
+
+This module persists the same artifacts through the portable Mega-cache API
+(``torch.compiler.save_cache_artifacts`` / ``load_cache_artifacts``,
+torch >= 2.7) so the one-time compile cost of a model family can be paid once
+per environment and reused across processes, container restarts and machines
+with an IDENTICAL environment.
+
+A bundle is only valid for the exact same torch / Triton / CUDA build, GPU
+architecture, transformers version and generated-source configuration. The
+key is therefore an exact-match fingerprint over all of those dimensions; a
+mismatch simply means a cache miss and a normal local compile. Loading is
+always best-effort and never raises.
+
+Environment knobs:
+  UNSLOTH_MEGA_CACHE       = "auto" (default) | "0" | "1"
+      auto -> load a matching bundle if one exists AND save a bundle at
+              process exit when compilation happened with no bundle present.
+      1    -> same as auto, plus refresh the bundle even when one was loaded.
+      0    -> fully disabled (kill switch).
+  UNSLOTH_MEGA_CACHE_DIR   = bundle root (default ~/.cache/unsloth/mega_cache).
+"""
+
+__all__ = [
+    "megacache_is_enabled",
+    "megacache_load",
+    "megacache_save",
+    "megacache_status",
+]
+
+import atexit
+import hashlib
+import json
+import os
+import time
+
+_UNSLOTH_ENABLE_LOGGING = os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1"
+
+_FORMAT_VERSION = 1
+_BUNDLE_NAME = "megacache.bin"
+_MANIFEST_NAME = "manifest.json"
+
+# Process-level state: one fingerprint accumulates all models loaded in this
+# process (multiple unsloth_compile_transformers calls extend the key).
+_STATE = {
+    "armed": False,
+    "loaded_key": None,
+    "hit": False,
+    "model_keys": [],
+    "atexit_registered": False,
+}
+
+
+def _log(message):
+    if _UNSLOTH_ENABLE_LOGGING:
+        print(f"Unsloth: Mega-cache {message}", flush = True)
+pass
+
+
+def megacache_is_enabled():
+    return (os.environ.get("UNSLOTH_MEGA_CACHE", "auto").strip().lower()
+            not in ("0", "off", "false", "no"))
+pass
+
+
+def _refresh_enabled():
+    return os.environ.get("UNSLOTH_MEGA_CACHE", "auto").strip().lower() in ("1", "on", "true", "yes")
+pass
+
+
+def _cache_root():
+    root = os.environ.get("UNSLOTH_MEGA_CACHE_DIR", "")
+    if root == "":
+        root = os.path.join(os.path.expanduser("~"), ".cache", "unsloth", "mega_cache")
+    return root
+pass
+
+
+def _mega_cache_supported():
+    try:
+        import torch
+        return (
+            hasattr(torch.compiler, "save_cache_artifacts")
+            and hasattr(torch.compiler, "load_cache_artifacts")
+        )
+    except Exception:
+        return False
+pass
+
+
+def _environment_fingerprint():
+    """Hard portability dimensions - any difference invalidates a bundle."""
+    fingerprint = {
+        "format": _FORMAT_VERSION,
+        "torch": None,
+        "cuda": None,
+        "triton": None,
+        "transformers": None,
+        "unsloth_zoo": None,
+        "gpu_name": None,
+        "gpu_capability": None,
+    }
+    try:
+        import torch
+        fingerprint["torch"] = str(torch.__version__)
+        fingerprint["cuda"] = str(torch.version.cuda)
+        if torch.cuda.is_available():
+            fingerprint["gpu_name"] = torch.cuda.get_device_name(0)
+            capability = torch.cuda.get_device_capability(0)
+            fingerprint["gpu_capability"] = f"sm_{capability[0]}{capability[1]}"
+    except Exception:
+        pass
+    try:
+        import triton
+        fingerprint["triton"] = str(getattr(triton, "__version__", None))
+    except Exception:
+        pass
+    try:
+        import transformers
+        fingerprint["transformers"] = str(transformers.__version__)
+    except Exception:
+        pass
+    try:
+        from . import __version__ as zoo_version
+        fingerprint["unsloth_zoo"] = str(zoo_version)
+    except Exception:
+        pass
+    return fingerprint
+pass
+
+
+def _model_key(model_type, compile_kwargs, torch_compile_options):
+    """One model's contribution to the bundle key.
+
+    ``compile_kwargs`` are the unsloth_compile_transformers arguments that
+    change the GENERATED SOURCE (and therefore the traced graphs);
+    ``torch_compile_options`` is the Inductor options dict baked into the
+    generated ``@torch.compile`` decorators.
+    """
+    payload = {
+        "model_type": str(model_type),
+        "compile_kwargs": {k: compile_kwargs[k] for k in sorted(compile_kwargs)},
+        "torch_compile_options": {k: torch_compile_options[k] for k in sorted(torch_compile_options)},
+    }
+    return payload
+pass
+
+
+def _bundle_key():
+    payload = json.dumps(
+        {"env": _environment_fingerprint(), "models": _STATE["model_keys"]},
+        sort_keys = True, default = str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+pass
+
+
+def _bundle_paths(key):
+    directory = os.path.join(_cache_root(), key)
+    return (
+        directory,
+        os.path.join(directory, _BUNDLE_NAME),
+        os.path.join(directory, _MANIFEST_NAME),
+    )
+pass
+
+
+def megacache_load(model_type, compile_kwargs = None, torch_compile_options = None):
+    """Try to pre-load compile artifacts for ``model_type`` before the first
+    compiled forward. Registers the exit-time save as a side effect.
+
+    Called from ``unsloth_compile_transformers`` which runs during
+    ``from_pretrained`` - i.e. strictly before any ``@torch.compile`` region
+    executes, which is when Dynamo consults the caches this pre-populates.
+
+    Never raises; a miss just means a normal local compile.
+    """
+    if not megacache_is_enabled():
+        return False
+    if not _mega_cache_supported():
+        _log("unavailable (needs torch >= 2.7); skipping")
+        return False
+
+    _STATE["model_keys"].append(
+        _model_key(model_type, compile_kwargs or {}, torch_compile_options or {})
+    )
+    key = _bundle_key()
+    directory, bundle_path, manifest_path = _bundle_paths(key)
+
+    _STATE["armed"] = True
+    _STATE["loaded_key"] = key
+    if not _STATE["atexit_registered"]:
+        atexit.register(megacache_save)
+        _STATE["atexit_registered"] = True
+
+    if not (os.path.isfile(bundle_path) and os.path.isfile(manifest_path)):
+        _log(f"no bundle for key {key} (will compile locally and save on exit)")
+        return False
+
+    try:
+        with open(manifest_path, "r") as file:
+            manifest = json.load(file)
+        with open(bundle_path, "rb") as file:
+            data = file.read()
+        # Defence in depth: torch validates internally as well, but a stale or
+        # corrupted bundle should be an explicit miss, not a surprise.
+        if manifest.get("sha256") != hashlib.sha256(data).hexdigest():
+            _log("bundle checksum mismatch; ignoring")
+            return False
+        import torch
+        info = torch.compiler.load_cache_artifacts(data)
+        if info is None:
+            _log("torch reported no loadable artifacts; ignoring")
+            return False
+        _STATE["hit"] = True
+        _log(f"loaded bundle for key {key} ({len(data)} bytes)")
+        return True
+    except Exception as error:
+        _log(f"load failed ({error}); continuing with local compile")
+        return False
+pass
+
+
+def megacache_save():
+    """Persist this process' compile artifacts. Runs at exit (atexit) or on
+    demand. Saves only when something new would be stored: a fresh bundle on
+    a miss, or a refresh when UNSLOTH_MEGA_CACHE=1. Never raises.
+    """
+    if not (_STATE["armed"] and megacache_is_enabled() and _mega_cache_supported()):
+        return False
+    if _STATE["hit"] and not _refresh_enabled():
+        return False
+    key = _STATE["loaded_key"]
+    if key is None:
+        return False
+    try:
+        import torch
+        result = torch.compiler.save_cache_artifacts()
+        if not result or not result[0]:
+            _log("nothing to save (no compile artifacts recorded)")
+            return False
+        data = result[0]
+        directory, bundle_path, manifest_path = _bundle_paths(key)
+        os.makedirs(directory, exist_ok = True)
+        temporary_path = bundle_path + ".tmp"
+        with open(temporary_path, "wb") as file:
+            file.write(data)
+        os.replace(temporary_path, bundle_path)
+        manifest = {
+            "format": _FORMAT_VERSION,
+            "key": key,
+            "created": time.time(),
+            "bytes": len(data),
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "env": _environment_fingerprint(),
+            "models": _STATE["model_keys"],
+        }
+        with open(manifest_path, "w") as file:
+            json.dump(manifest, file, indent = 2, sort_keys = True, default = str)
+        _log(f"saved bundle for key {key} ({len(data)} bytes)")
+        return True
+    except Exception as error:
+        _log(f"save failed ({error})")
+        return False
+pass
+
+
+def megacache_status():
+    """Introspection helper for tests and debugging."""
+    return {
+        "enabled": megacache_is_enabled(),
+        "supported": _mega_cache_supported(),
+        "armed": _STATE["armed"],
+        "hit": _STATE["hit"],
+        "key": _STATE["loaded_key"],
+        "root": _cache_root(),
+    }
+pass

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -94,9 +94,14 @@ pass
 
 
 def _cache_root():
-    root = os.environ.get("UNSLOTH_MEGA_CACHE_DIR", "")
+    root = os.path.expanduser(os.environ.get("UNSLOTH_MEGA_CACHE_DIR", ""))
     if root == "":
-        root = os.path.join(os.path.expanduser("~"), ".cache", "unsloth", "mega_cache")
+        home = os.path.expanduser("~")
+        # Restricted containers can have no resolvable home; disable rather
+        # than writing a literal "~" directory into the CWD.
+        if home == "~" or not os.path.isdir(home):
+            return None
+        root = os.path.join(home, ".cache", "unsloth", "mega_cache")
     return root
 pass
 
@@ -181,7 +186,10 @@ pass
 
 
 def _bundle_paths(key):
-    directory = os.path.join(_cache_root(), key)
+    root = _cache_root()
+    if root is None:
+        return None, None, None
+    directory = os.path.join(root, key)
     return (
         directory,
         os.path.join(directory, _BUNDLE_NAME),
@@ -211,9 +219,15 @@ def megacache_load(model_type, compile_kwargs = None, torch_compile_options = No
     )
     key = _bundle_key()
     directory, bundle_path, manifest_path = _bundle_paths(key)
+    if bundle_path is None:
+        _log("no writable cache root; skipping")
+        return False
 
     _STATE["armed"] = True
     _STATE["loaded_key"] = key
+    # A hit for an earlier cumulative key does not cover this one: reset so a
+    # miss here still saves the extended bundle at exit.
+    _STATE["hit"] = False
     if not _STATE["atexit_registered"]:
         atexit.register(megacache_save)
         _STATE["atexit_registered"] = True
@@ -255,6 +269,11 @@ def megacache_save():
         return False
     if _STATE["hit"] and not _refresh_enabled():
         return False
+    # Distributed launches: every rank records the same artifacts; concurrent
+    # writers could leave the manifest checksum pointing at another rank's
+    # bytes, so only the main rank persists the bundle.
+    if os.environ.get("RANK", os.environ.get("LOCAL_RANK", "0")) != "0":
+        return False
     key = _STATE["loaded_key"]
     if key is None:
         return False
@@ -266,8 +285,12 @@ def megacache_save():
             return False
         data = result[0]
         directory, bundle_path, manifest_path = _bundle_paths(key)
+        if bundle_path is None:
+            return False
         os.makedirs(directory, exist_ok = True)
-        temporary_path = bundle_path + ".tmp"
+        # PID-unique temp + atomic replace: concurrent processes cannot
+        # truncate or interleave each other's bytes.
+        temporary_path = f"{bundle_path}.tmp.{os.getpid()}"
         with open(temporary_path, "wb") as file:
             file.write(data)
         os.replace(temporary_path, bundle_path)
@@ -280,8 +303,10 @@ def megacache_save():
             "env": _environment_fingerprint(),
             "models": _STATE["model_keys"],
         }
-        with open(manifest_path, "w") as file:
+        temporary_manifest = f"{manifest_path}.tmp.{os.getpid()}"
+        with open(temporary_manifest, "w") as file:
             json.dump(manifest, file, indent = 2, sort_keys = True, default = str)
+        os.replace(temporary_manifest, manifest_path)
         _log(f"saved bundle for key {key} ({len(data)} bytes)")
         return True
     except Exception as error:

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -39,9 +39,10 @@ always best-effort and never raises.
 
 Environment knobs:
   UNSLOTH_MEGA_CACHE       = "auto" (default) | "0" | "1"
-      auto -> load a matching bundle if one exists AND save a bundle at
-              process exit when compilation happened with no bundle present.
-      1    -> same as auto, plus refresh the bundle even when one was loaded.
+      auto -> load a matching bundle if one exists AND save at process exit
+              whenever the recorded artifacts differ from the bundle on disk
+              (torch records hits too, so saves merge loaded + new artifacts).
+      1    -> same as auto, but always rewrite the bundle at exit.
       0    -> fully disabled (kill switch).
   UNSLOTH_MEGA_CACHE_DIR   = bundle root (default ~/.cache/unsloth/mega_cache).
 """
@@ -135,8 +136,11 @@ def _environment_fingerprint():
         fingerprint["torch"] = str(torch.__version__)
         fingerprint["cuda"] = str(torch.version.cuda)
         if torch.cuda.is_available():
-            fingerprint["gpu_name"] = torch.cuda.get_device_name(0)
-            capability = torch.cuda.get_device_capability(0)
+            # The bound device, not device 0: mixed-architecture hosts must
+            # not save one GPU's kernels under another's key.
+            device = torch.cuda.current_device()
+            fingerprint["gpu_name"] = torch.cuda.get_device_name(device)
+            capability = torch.cuda.get_device_capability(device)
             fingerprint["gpu_capability"] = f"sm_{capability[0]}{capability[1]}"
     except Exception:
         pass
@@ -262,17 +266,18 @@ pass
 
 def megacache_save():
     """Persist this process' compile artifacts. Runs at exit (atexit) or on
-    demand. Saves only when something new would be stored: a fresh bundle on
-    a miss, or a refresh when UNSLOTH_MEGA_CACHE=1. Never raises.
+    demand. torch records artifacts on cache HITS as well as writes, so the
+    serialized bundle is a superset of anything loaded plus everything newly
+    compiled; save whenever those bytes differ from the bundle on disk. A
+    pure hit with no new compilation serializes back to the same content and
+    is skipped. Never raises.
     """
     if not (_STATE["armed"] and megacache_is_enabled() and _mega_cache_supported()):
         return False
-    if _STATE["hit"] and not _refresh_enabled():
-        return False
-    # Distributed launches: every rank records the same artifacts; concurrent
-    # writers could leave the manifest checksum pointing at another rank's
-    # bytes, so only the main rank persists the bundle.
-    if os.environ.get("RANK", os.environ.get("LOCAL_RANK", "0")) != "0":
+    # Distributed launches: one writer per NODE (cache roots default to
+    # node-local disks), guarded against shared roots by the pid-unique
+    # temp + atomic replace below.
+    if os.environ.get("LOCAL_RANK", os.environ.get("RANK", "0")) != "0":
         return False
     key = _STATE["loaded_key"]
     if key is None:
@@ -287,6 +292,15 @@ def megacache_save():
         directory, bundle_path, manifest_path = _bundle_paths(key)
         if bundle_path is None:
             return False
+        new_sha = hashlib.sha256(data).hexdigest()
+        if not _refresh_enabled():
+            try:
+                with open(manifest_path, "r") as file:
+                    if json.load(file).get("sha256") == new_sha:
+                        _log("bundle unchanged; skipping save")
+                        return False
+            except Exception:
+                pass
         os.makedirs(directory, exist_ok = True)
         # PID-unique temp + atomic replace: concurrent processes cannot
         # truncate or interleave each other's bytes.
@@ -299,7 +313,7 @@ def megacache_save():
             "key": key,
             "created": time.time(),
             "bytes": len(data),
-            "sha256": hashlib.sha256(data).hexdigest(),
+            "sha256": new_sha,
             "env": _environment_fingerprint(),
             "models": _STATE["model_keys"],
         }

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3457,6 +3457,16 @@ def unsloth_compile_transformers(
     # Kill switch: UNSLOTH_MEGA_CACHE=0. See compile_cache.py.
     try:
         from .compile_cache import megacache_load
+        # Env vars override these arguments below (and the generated forwards
+        # branch on UNSLOTH_RETURN_HIDDEN_STATES), so key on the EFFECTIVE
+        # values or one mode's bundle would be a false hit for another.
+        _effective_fullgraph = os.environ.get(
+            "UNSLOTH_FULLGRAPH", "1" if fullgraph else "0"
+        ) == "1"
+        _effective_return_logits = os.environ.get(
+            "UNSLOTH_RETURN_LOGITS", "1" if return_logits else "0"
+        ) == "1"
+        _return_hidden_states = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
         megacache_load(
             model_type,
             compile_kwargs = {
@@ -3475,9 +3485,10 @@ def unsloth_compile_transformers(
                 "fast_lora_forwards"    : fast_lora_forwards,
                 "fast_residual_stream"  : fast_residual_stream,
                 "accurate_accumulation" : accurate_accumulation,
-                "fullgraph"             : fullgraph,
+                "fullgraph"             : _effective_fullgraph,
                 "disable"               : disable,
-                "return_logits"         : return_logits,
+                "return_logits"         : _effective_return_logits,
+                "return_hidden_states"  : _return_hidden_states,
             },
             torch_compile_options = torch_compile_options,
         )

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3448,6 +3448,44 @@ def unsloth_compile_transformers(
         use_block_ptr=False,  # Sometimes fails
     )
 
+    # Pre-load persisted torch.compile artifacts (Mega-cache) for this exact
+    # environment + model + compile configuration. This runs during
+    # from_pretrained, strictly before any @torch.compile region executes, so
+    # a hit lets the first training step skip Inductor codegen and Triton
+    # autotuning. A miss is silent and falls back to a normal local compile;
+    # the artifacts are then saved at process exit for the next run.
+    # Kill switch: UNSLOTH_MEGA_CACHE=0. See compile_cache.py.
+    try:
+        from .compile_cache import megacache_load
+        megacache_load(
+            model_type,
+            compile_kwargs = {
+                "sdpa_dynamic_mask"     : sdpa_dynamic_mask,
+                "sdpa_bool_masks"       : sdpa_bool_masks,
+                "sdpa_gqa_replace"      : sdpa_gqa_replace,
+                "sdpa_dynamic_compile"  : sdpa_dynamic_compile,
+                "compile_attention"     : compile_attention,
+                "disable_causal_masks"  : disable_causal_masks,
+                "compile_torch_modules" : compile_torch_modules,
+                "compile_custom_modules": compile_custom_modules,
+                "compile_function_calls": compile_function_calls,
+                "fuse_lm_head"          : fuse_lm_head,
+                "gradient_checkpointing": gradient_checkpointing,
+                "manual_replacements"   : manual_replacements,
+                "fast_lora_forwards"    : fast_lora_forwards,
+                "fast_residual_stream"  : fast_residual_stream,
+                "accurate_accumulation" : accurate_accumulation,
+                "fullgraph"             : fullgraph,
+                "disable"               : disable,
+                "return_logits"         : return_logits,
+            },
+            torch_compile_options = torch_compile_options,
+        )
+    except Exception as _megacache_error:
+        if UNSLOTH_ENABLE_LOGGING:
+            print(f"Unsloth: Mega-cache skipped ({_megacache_error})")
+    pass
+
     # Compile timm models
     compile_timm_models(UNSLOTH_ENABLE_LOGGING, torch_compile_options)
 

--- a/unsloth_zoo/patching_utils.py
+++ b/unsloth_zoo/patching_utils.py
@@ -155,6 +155,10 @@ def patch_torch_compile(debug = False, O3 = False, ignore_errors = True):
 
     # https://github.com/sayakpaul/diffusers-torchao?tab=readme-ov-file#things-to-keep-in-mind-when-benchmarking
     os.environ["ENABLE_AOT_AUTOGRAD_CACHE"] = "1"
+    # ENABLE_AOT_AUTOGRAD_CACHE is no longer read by torch >= 2.12; the
+    # AOTAutograd cache env override was renamed. Set the current name too so
+    # backward graphs are also cached on disk across process restarts.
+    os.environ["TORCHINDUCTOR_AUTOGRAD_CACHE"] = "1"
 
     # Torch compile arguments
     torch_compile_arguments = [


### PR DESCRIPTION
## Problem

`unsloth_compiled_cache/` caches only the generated source of the patched modules. The expensive part of the first training step -- Dynamo tracing, AOTAutograd partitioning, Inductor codegen and Triton autotuning for the forward and backward graphs -- is redone by every new process unless torch's own on-disk caches happen to be warm, and those default to `/tmp/torchinductor_<user>`, which rarely survives reboots or container restarts. In practice every notebook restart and every fresh container pays the full compile cost again.

## Change

New `unsloth_zoo/compile_cache.py` persists the compile products through the portable Mega-cache API (`torch.compiler.save_cache_artifacts` / `load_cache_artifacts`, torch >= 2.7):

- `unsloth_compile_transformers` calls `megacache_load` before any compiled region runs. The bundle key is an exact fingerprint over torch, CUDA, Triton, transformers, unsloth_zoo, GPU name and architecture, plus the per-model compile kwargs and the Inductor options baked into the generated source. Any mismatch is a silent miss followed by a normal local compile; loading is best-effort and never raises.
- A bundle is written at process exit when compilation happened and no bundle was present. Bundles live under `UNSLOTH_MEGA_CACHE_DIR` (default `~/.cache/unsloth/mega_cache`), one directory per key, with a checksummed manifest so a corrupted bundle is an explicit miss instead of a crash.
- Knobs: `UNSLOTH_MEGA_CACHE=auto|1|0` (auto = load + save-on-miss; 1 also refreshes an existing bundle; 0 = kill switch), `UNSLOTH_MEGA_CACHE_DIR`.
- Also sets `TORCHINDUCTOR_AUTOGRAD_CACHE=1` next to the old `ENABLE_AOT_AUTOGRAD_CACHE` name, which torch >= 2.12 no longer reads, so the backward-graph cache works again on current torch.

Steady-state step time is unchanged; this only affects time to the first optimizer step (TTFS).

## Measurements

B200, torch 2.12.1+cu130, 10-step QLoRA runs from the published notebooks, cold `TORCHINDUCTOR_CACHE_DIR` each time, TTFS measured from `trainer.train()`:

| Model | Cold | With bundle | Speedup | Bundle size |
| --- | --- | --- | --- | --- |
| gpt-oss-20b | 101.0 s | 18.2 s | 5.5x | 54 MB |
| gemma-4-E4B-it | 17.5 s | 9.7 s | 1.8x | 10 MB |

Re-verified before opening this PR with a fresh cold-vs-warm smoke (fresh processes, wiped inductor/triton caches): gpt-oss-20b 3-step QLoRA, cold 103.7 s vs 45.6 s with the bundle loaded (2.3x on the whole 3-step train window, bundle 58 MB, explicit cache hit reported).

## Notes

- Bundles are strictly per-environment: any change in torch/Triton/CUDA build, GPU architecture, transformers version, or the generated-source configuration changes the key and falls back to a normal compile.
- Nothing is shared or uploaded; the cache directory is local.
- `emulate_precision_casts` and other inference-side compile tweaks were deliberately NOT ported to training: they change gradient numerics.
