### PR TITLE
Fix false DownloadStallError for diffusers components with non-standard sharded weight filenames

### DIFF
--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -2925,6 +2925,53 @@ def test_post_download_rejects_incomplete_diffusers_component_shards_unpatterned
         variant = "fp16") is True
 
 
+def test_post_accepts_nonstandard_sharded_diffusers_component_names(tmp_path):
+    """Diffusers analog of issue #889: a pipeline COMPONENT (unet/) sharded with the NON-standard name that
+    keeps the format suffix in the middle (diffusion_pytorch_model.safetensors-00001-of-00002.safetensors),
+    enumerated via unet/diffusion_pytorch_model.safetensors.index.json, must be accepted rather than raise a
+    spurious DownloadStallError. The presence check reads the component index like the root does; shard
+    completeness stays the component-shard check's job, and an ignored format is not rescued."""
+    shards = ["diffusion_pytorch_model.safetensors-00001-of-00002.safetensors",
+              "diffusion_pytorch_model.safetensors-00002-of-00002.safetensors"]
+
+    def _pipe(name, present, index_name = "diffusion_pytorch_model.safetensors.index.json", weight_map = None):
+        # a pipeline declaring a model-style unet (sharded, under test) + a single-file vae.
+        snap, blob = _mk_snapshot(tmp_path, name)
+        (snap / "model_index.json").write_text(json.dumps(
+            {"_class_name": "StableDiffusionPipeline",
+             "unet": ["diffusers", "UNet2DConditionModel"], "vae": ["diffusers", "AutoencoderKL"]}))
+        (snap / "unet").mkdir()
+        (snap / "unet" / "config.json").write_text("{}")
+        for s in present:
+            (snap / "unet" / s).symlink_to(blob)
+        (snap / "unet" / index_name).write_text(json.dumps(
+            {"weight_map": weight_map or {"a": shards[0], "b": shards[1]}}))
+        (snap / "vae").mkdir()
+        (snap / "vae" / "config.json").write_text("{}")
+        (snap / "vae" / "diffusion_pytorch_model.safetensors").symlink_to(blob)
+        return snap
+
+    # Complete non-standard unet shards -> accepted (the fix).
+    assert xf._download_result_usable(
+        _pipe("diff_nonstd", shards), repo_type = "model", allow_patterns = None,
+        ignore_patterns = None) is True
+    # One shard missing -> still rejected (the component-shard check validates via the index).
+    assert xf._download_result_usable(
+        _pipe("diff_nonstd_missing", shards[:1]), repo_type = "model", allow_patterns = None,
+        ignore_patterns = None) is False
+    # The index does not rescue when its format is ignored (the load reads .bin only, which is absent).
+    assert xf._download_result_usable(
+        _pipe("diff_nonstd_ignored", shards), repo_type = "model", allow_patterns = None,
+        ignore_patterns = ["*.safetensors"]) is False
+    # Variant component enumerated via a variant index (diffusion_pytorch_model.safetensors.index.fp16.json).
+    vshards = ["diffusion_pytorch_model.fp16.safetensors-00001-of-00002.safetensors",
+               "diffusion_pytorch_model.fp16.safetensors-00002-of-00002.safetensors"]
+    assert xf._download_result_usable(
+        _pipe("diff_nonstd_variant", vshards, index_name = "diffusion_pytorch_model.safetensors.index.fp16.json",
+              weight_map = {"a": vshards[0], "b": vshards[1]}),
+        repo_type = "model", allow_patterns = None, ignore_patterns = None, variant = "fp16") is True
+
+
 def test_post_download_single_safetensors_beats_stale_index(tmp_path):
     """A complete single model.safetensors (probed before the index) beside a stale incomplete index is usable; a stale index with no single weight is breakage."""
     snap, blob = _mk_snapshot(tmp_path, "single_beats_index")

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -2972,6 +2972,49 @@ def test_post_accepts_nonstandard_sharded_diffusers_component_names(tmp_path):
         repo_type = "model", allow_patterns = None, ignore_patterns = None, variant = "fp16") is True
 
 
+def test_diffusers_component_index_review_hardening(tmp_path):
+    """Hardening of the component-index presence path: (a) a component-scoped ignore matches the component's
+    OWN base (not model.*), so ignoring unet/ weights leaves the component unproven; (b) a stale malformed
+    index sidecar is not accepted as a component index; (c) a variant load accepts a canonical FALLBACK
+    index only when its shards are complete (the variant completeness pass does not validate it)."""
+    nonstd = ["diffusion_pytorch_model.safetensors-00001-of-00002.safetensors",
+              "diffusion_pytorch_model.safetensors-00002-of-00002.safetensors"]
+
+    def _pipe(name, unet_shards, unet_index = "diffusion_pytorch_model.safetensors.index.json",
+              vae_name = "diffusion_pytorch_model.safetensors"):
+        snap, blob = _mk_snapshot(tmp_path, name)
+        (snap / "model_index.json").write_text(json.dumps(
+            {"_class_name": "StableDiffusionPipeline",
+             "unet": ["diffusers", "UNet2DConditionModel"], "vae": ["diffusers", "AutoencoderKL"]}))
+        (snap / "unet").mkdir()
+        (snap / "unet" / "config.json").write_text("{}")
+        for s in unet_shards:
+            (snap / "unet" / s).symlink_to(blob)
+        if unet_index is not None:
+            (snap / "unet" / unet_index).write_text(json.dumps(
+                {"weight_map": {"a": nonstd[0], "b": nonstd[1]}}))
+        (snap / "vae").mkdir()
+        (snap / "vae" / "config.json").write_text("{}")
+        (snap / "vae" / vae_name).symlink_to(blob)
+        return snap
+
+    # (a) a component-scoped ignore of the unet weights matches the real base -> unet has no read weight.
+    assert xf._download_result_usable(
+        _pipe("hard_ignore", nonstd), repo_type = "model", allow_patterns = None,
+        ignore_patterns = ["unet/diffusion_pytorch_model*"]) is False
+    # (b) a malformed index sidecar is not a component index, so it cannot prove the unet weight.
+    assert xf._download_result_usable(
+        _pipe("hard_sidecar", nonstd, unet_index = "diffusion_pytorch_model.safetensors.index.fp16.extra.json"),
+        repo_type = "model", allow_patterns = None, ignore_patterns = None) is False
+    # (c) a variant load rejects an incomplete canonical fallback, accepts a complete one.
+    assert xf._download_result_usable(
+        _pipe("hard_var_missing", nonstd[:1], vae_name = "diffusion_pytorch_model.fp16.safetensors"),
+        repo_type = "model", allow_patterns = None, ignore_patterns = None, variant = "fp16") is False
+    assert xf._download_result_usable(
+        _pipe("hard_var_complete", nonstd, vae_name = "diffusion_pytorch_model.fp16.safetensors"),
+        repo_type = "model", allow_patterns = None, ignore_patterns = None, variant = "fp16") is True
+
+
 def test_post_download_single_safetensors_beats_stale_index(tmp_path):
     """A complete single model.safetensors (probed before the index) beside a stale incomplete index is usable; a stale index with no single weight is breakage."""
     snap, blob = _mk_snapshot(tmp_path, "single_beats_index")

--- a/unsloth_zoo/hf_cache_state.py
+++ b/unsloth_zoo/hf_cache_state.py
@@ -243,6 +243,25 @@ def _is_canonical_weight_shard_index(name: str) -> bool:
     return name in ("model.safetensors.index.json", "pytorch_model.bin.index.json")
 
 
+# Canonical diffusers COMPONENT weight bases a pipeline load reads (unet/, vae/, transformer/, ...).
+_CANONICAL_COMPONENT_WEIGHT_BASES = ("diffusion_pytorch_model", "model", "pytorch_model")
+
+
+def _is_canonical_component_shard_index(name: str) -> bool:
+    """True for a weight-shard index (canonical or variant) whose base is a canonical diffusers COMPONENT
+    weight (``diffusion_pytorch_model`` / ``model`` / ``pytorch_model``), e.g.
+    ``diffusion_pytorch_model.safetensors.index.json`` or ``...index.fp16.json``. Lets a component sharded
+    with NON-standard shard names be recognized via its index (the component analog of
+    ``_is_canonical_weight_shard_index``). Excludes an ``adapter_model`` / other non-component index the
+    pipeline does not read."""
+    if not _is_weight_shard_index(name):
+        return False
+    for marker in (".safetensors.index.", ".bin.index."):
+        if marker in name:
+            return name.split(marker, 1)[0] in _CANONICAL_COMPONENT_WEIGHT_BASES
+    return False
+
+
 def _is_unsafe_shard_ref(shard: str) -> bool:
     """True if a ``weight_map`` value is NOT a safe relative path inside the snapshot (absolute, Windows
     drive-letter, UNC, or ``..``-escaping). Judged under BOTH POSIX and Windows semantics so a crafted

--- a/unsloth_zoo/hf_cache_state.py
+++ b/unsloth_zoo/hf_cache_state.py
@@ -243,23 +243,37 @@ def _is_canonical_weight_shard_index(name: str) -> bool:
     return name in ("model.safetensors.index.json", "pytorch_model.bin.index.json")
 
 
-# Canonical diffusers COMPONENT weight bases a pipeline load reads (unet/, vae/, transformer/, ...).
-_CANONICAL_COMPONENT_WEIGHT_BASES = ("diffusion_pytorch_model", "model", "pytorch_model")
+# The EXACT canonical / single-variant diffusers COMPONENT shard index: a canonical component base
+# (diffusion_pytorch_model / model / pytorch_model) + safetensors/bin format + the .index.json /
+# .index.<variant>.json form (anchored, one optional variant token). So a stale sidecar such as
+# diffusion_pytorch_model.safetensors.index.fp16.extra.json is NOT accepted. The base is captured so the
+# ignore-filter probe can use the component's OWN weight name.
+_COMPONENT_SHARD_INDEX_RE = re.compile(
+    r"^(?P<base>diffusion_pytorch_model|model|pytorch_model)\.(?P<ext>safetensors|bin)"
+    r"\.index(?:\.(?P<variant>[^.]+))?\.json$"
+)
 
 
 def _is_canonical_component_shard_index(name: str) -> bool:
-    """True for a weight-shard index (canonical or variant) whose base is a canonical diffusers COMPONENT
-    weight (``diffusion_pytorch_model`` / ``model`` / ``pytorch_model``), e.g.
-    ``diffusion_pytorch_model.safetensors.index.json`` or ``...index.fp16.json``. Lets a component sharded
-    with NON-standard shard names be recognized via its index (the component analog of
-    ``_is_canonical_weight_shard_index``). Excludes an ``adapter_model`` / other non-component index the
-    pipeline does not read."""
-    if not _is_weight_shard_index(name):
-        return False
-    for marker in (".safetensors.index.", ".bin.index."):
-        if marker in name:
-            return name.split(marker, 1)[0] in _CANONICAL_COMPONENT_WEIGHT_BASES
-    return False
+    """True only for the EXACT canonical / single-variant diffusers COMPONENT shard index
+    (``diffusion_pytorch_model.safetensors.index.json`` / ``...index.fp16.json``, plus the ``model`` /
+    ``pytorch_model`` bases). The component analog of ``_is_canonical_weight_shard_index``: lets a component
+    sharded with NON-standard shard names be recognized via its index, while a stale malformed sidecar the
+    pipeline never probes is rejected."""
+    return _COMPONENT_SHARD_INDEX_RE.match(name) is not None
+
+
+def _component_index_weight_probe(index_name: str, dir_rel: str) -> "Optional[str]":
+    """The component-relative weight path a canonical component shard *index* enumerates, preserving the
+    component's OWN base (``diffusion_pytorch_model`` / ``model`` / ``pytorch_model``), format, and variant
+    token, so the ignore filter is judged on the real weight name -- a component-scoped ignore like
+    ``unet/diffusion_pytorch_model*`` matches. None when *index_name* is not such an index."""
+    m = _COMPONENT_SHARD_INDEX_RE.match(index_name)
+    if m is None:
+        return None
+    token = f".{m['variant']}" if m["variant"] else ""
+    prefix = f"{dir_rel}/" if dir_rel else ""
+    return f"{prefix}{m['base']}{token}.{m['ext']}"
 
 
 def _is_unsafe_shard_ref(shard: str) -> bool:

--- a/unsloth_zoo/hf_cache_state.py
+++ b/unsloth_zoo/hf_cache_state.py
@@ -243,11 +243,9 @@ def _is_canonical_weight_shard_index(name: str) -> bool:
     return name in ("model.safetensors.index.json", "pytorch_model.bin.index.json")
 
 
-# The EXACT canonical / single-variant diffusers COMPONENT shard index: a canonical component base
-# (diffusion_pytorch_model / model / pytorch_model) + safetensors/bin format + the .index.json /
-# .index.<variant>.json form (anchored, one optional variant token). So a stale sidecar such as
-# diffusion_pytorch_model.safetensors.index.fp16.extra.json is NOT accepted. The base is captured so the
-# ignore-filter probe can use the component's OWN weight name.
+# The EXACT canonical / single-variant diffusers COMPONENT shard index (anchored, one optional variant
+# token), so a stale sidecar like diffusion_pytorch_model.safetensors.index.fp16.extra.json is rejected.
+# The base is captured so the ignore-filter probe uses the component's OWN weight name.
 _COMPONENT_SHARD_INDEX_RE = re.compile(
     r"^(?P<base>diffusion_pytorch_model|model|pytorch_model)\.(?P<ext>safetensors|bin)"
     r"\.index(?:\.(?P<variant>[^.]+))?\.json$"

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -48,6 +48,7 @@ from unsloth_zoo.hf_cache_state import (
     _ROOT_MODEL_SHARD_INDEX_RE,
     _ROOT_MODEL_VARIANT_WEIGHT_RE,
     _as_pattern_list,
+    _component_index_weight_probe,
     _diffusers_component_shards_incomplete,
     _diffusers_declared_component_specs,
     _filter_paths,
@@ -1144,12 +1145,19 @@ def _diffusers_component_weights_complete(
             if is_index:
                 # A component shard INDEX of a kept format proves a readable component weight even when the
                 # shard files carry a NON-standard name the weight regexes miss (mirrors
-                # _root_model_has_weight); the probe is the component-relative weight the index enumerates,
-                # so the ignore filter is judged on what the load reads. Completeness stays
-                # _diffusers_component_shards_incomplete's job.
+                # _root_model_has_weight); the probe is the component-relative weight the index enumerates
+                # (its OWN base), so the ignore filter is judged on what the load reads.
                 tok = _index_variant_token(name)
-                probe = f"{comp}/{_index_weight_probe(name, tok)}"
+                probe = _component_index_weight_probe(name, comp)
+                if probe is None:
+                    continue
                 if tok is None:
+                    # A canonical component index. Under a variant load it is the per-component FALLBACK,
+                    # which the variant completeness pass does not validate, so accept it as fallback
+                    # presence only when its shards are complete (else defer to the child). Under a plain
+                    # load the canonical completeness pass validates it, so record it unconditionally.
+                    if variant is not None and not _weight_shard_index_complete(entry):
+                        continue
                     per_comp_canon.setdefault(comp, []).append(probe)
                 elif tok == variant:
                     per_comp_variant.setdefault(comp, []).append(probe)

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -54,7 +54,9 @@ from unsloth_zoo.hf_cache_state import (
     _has_glob,
     _has_incomplete_canonical_root_shards,
     _has_incomplete_variant_root_shards,
+    _index_variant_token,
     _index_weight_probe,
+    _is_canonical_component_shard_index,
     _is_canonical_weight_shard_index,
     _is_loadable_weight_file,
     _read_format_kept,
@@ -1120,7 +1122,8 @@ def _diffusers_component_weights_complete(
     try:
         for entry in snapshot_dir.rglob("*"):
             name = entry.name
-            if not _is_default_load_weight_file(name):
+            is_index = _is_canonical_component_shard_index(name)
+            if not is_index and not _is_default_load_weight_file(name):
                 continue
             try:
                 if not entry.is_file():
@@ -1138,6 +1141,19 @@ def _diffusers_component_weights_complete(
                 continue  # an UNDECLARED subtree the load does not read
             if _CHECKPOINT_DIR_RE.match(comp):
                 continue  # a training-checkpoint subtree, not a component
+            if is_index:
+                # A component shard INDEX of a kept format proves a readable component weight even when the
+                # shard files carry a NON-standard name the weight regexes miss (mirrors
+                # _root_model_has_weight); the probe is the component-relative weight the index enumerates,
+                # so the ignore filter is judged on what the load reads. Completeness stays
+                # _diffusers_component_shards_incomplete's job.
+                tok = _index_variant_token(name)
+                probe = f"{comp}/{_index_weight_probe(name, tok)}"
+                if tok is None:
+                    per_comp_canon.setdefault(comp, []).append(probe)
+                elif tok == variant:
+                    per_comp_variant.setdefault(comp, []).append(probe)
+                continue
             if variant_weight_re is not None and variant_weight_re.match(name):
                 per_comp_variant.setdefault(comp, []).append(rel)
             elif _CANONICAL_COMPONENT_WEIGHT_RE.match(name):

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -1143,19 +1143,17 @@ def _diffusers_component_weights_complete(
             if _CHECKPOINT_DIR_RE.match(comp):
                 continue  # a training-checkpoint subtree, not a component
             if is_index:
-                # A component shard INDEX of a kept format proves a readable component weight even when the
-                # shard files carry a NON-standard name the weight regexes miss (mirrors
-                # _root_model_has_weight); the probe is the component-relative weight the index enumerates
-                # (its OWN base), so the ignore filter is judged on what the load reads.
+                # A component shard INDEX of a kept format proves a readable component weight even for
+                # non-standard shard names the weight regexes miss (mirrors _root_model_has_weight); the
+                # probe is the component-relative weight (its OWN base), so the ignore filter matches.
                 tok = _index_variant_token(name)
                 probe = _component_index_weight_probe(name, comp)
                 if probe is None:
                     continue
                 if tok is None:
-                    # A canonical component index. Under a variant load it is the per-component FALLBACK,
-                    # which the variant completeness pass does not validate, so accept it as fallback
-                    # presence only when its shards are complete (else defer to the child). Under a plain
-                    # load the canonical completeness pass validates it, so record it unconditionally.
+                    # A canonical component index: under a variant load it is the per-component FALLBACK the
+                    # variant completeness pass skips, so accept it only when its shards are complete; a
+                    # plain load validates it via the canonical completeness pass, so record it always.
                     if variant is not None and not _weight_shard_index_complete(entry):
                         continue
                     per_comp_canon.setdefault(comp, []).append(probe)


### PR DESCRIPTION
## Problem

Follow-up to #900 (which fixed #889 for the root model). The same pre/post asymmetry remained for diffusers pipelines: the post-download presence check for a pipeline component was index-blind, so a component sharded with a non-standard filename that keeps the format suffix in the middle failed a complete download with a spurious `DownloadStallError`.

A complete, loadable snapshot that reproduces it:

```
model_index.json                                                  # declares transformer, vae, ...
transformer/config.json
transformer/diffusion_pytorch_model.safetensors.index.json
transformer/diffusion_pytorch_model.safetensors-00001-of-00002.safetensors
transformer/diffusion_pytorch_model.safetensors-00002-of-00002.safetensors
vae/diffusion_pytorch_model.safetensors
```

## Root cause

`_diffusers_component_weights_complete` classified a component weight only by the end-anchored `_CANONICAL_COMPONENT_WEIGHT_RE` (`^(?:diffusion_pytorch_model|model|pytorch_model)(?:-\d{5}-of-\d{5})?\.(?:safetensors|bin)$`) and never consulted the component `.index.json`. The non-standard shard names do not match that regex, so `per_comp_canon[transformer]` stayed empty, the component read as weightless, and `_download_result_usable` returned `False`, raising `DownloadStallError`, even though `diffusers` loads the component fine by following the index `weight_map`.

This is the exact blind spot #900 removed for the root model (`_root_model_has_weight`), left in place for diffusers components. The completeness side (`_diffusers_component_shards_incomplete`) was already index-driven and correct, so the gap was purely on the presence side.

## Fix

`_diffusers_component_weights_complete` now also accepts a canonical component shard index of a kept format as evidence of a readable component weight, reusing the helpers #900 added (`_index_weight_probe` / `_read_format_kept`) plus a new `_is_canonical_component_shard_index` predicate (the component analog of `_is_canonical_weight_shard_index`). The probe is the component-relative weight the index enumerates, so the ignore filter is judged on what the load actually reads. Shard completeness stays with `_diffusers_component_shards_incomplete`, so a missing or malformed shard is still rejected.

## Verification

- New regression test `test_post_accepts_nonstandard_sharded_diffusers_component_names` covering the accepted, missing-shard-rejected, ignored-format, and variant cases.
- Before/after: on `main` a complete non-standard diffusers component false-rejects; after the change it is accepted, while a missing shard is still rejected and the standard / single-file layouts are unchanged.
- A differential across the existing non-diffusers matrix (single-file, standard sharded, root non-standard, variants, sentence-transformers) shows no behavior change outside the diffusers component path.
- Full `tests/test_hf_xet_fallback.py` + `tests/test_hf_cache_redirect.py` pass (232 passed, 1 skipped).
