### PR TITLE
add confidence weighted CE (DFT) as fused loss function

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -109,6 +109,9 @@ jobs:
             tests/test_hf_xet_fallback.py \
             -v
 
+      - name: pytest tests/test_fused_dft_loss.py (HARD GATE)
+        run: python -m pytest tests/test_fused_dft_loss.py -v
+
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests
         # Run as SEPARATE pytest invocation: tests/security/conftest.py installs a
         # session-scoped network_blocker autouse fixture that would otherwise block

--- a/tests/test_fused_dft_loss.py
+++ b/tests/test_fused_dft_loss.py
@@ -1,0 +1,1272 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+import importlib.machinery
+import math
+import os
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+DIRECT_RTOL = 1e-6
+DIRECT_ATOL = 1e-7
+WRAPPER_RTOL = 1e-5
+WRAPPER_ATOL = 1e-7
+CUDA_RTOL = 1e-4
+CUDA_ATOL = 1e-6
+
+
+@contextmanager
+def _lightweight_unsloth_zoo_import():
+    """Import fused-loss modules without running unsloth_zoo.__init__.
+
+    These tests only need the local fused-loss modules, so install a temporary
+    package skeleton and restore any pre-existing modules afterwards.
+    """
+    root = Path(__file__).resolve().parents[1]
+    saved = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "unsloth_zoo" or name.startswith("unsloth_zoo.")
+    }
+    for name in list(saved):
+        sys.modules.pop(name, None)
+
+    package = types.ModuleType("unsloth_zoo")
+    package.__path__ = [str(root / "unsloth_zoo")]
+    package.__package__ = "unsloth_zoo"
+    package.__spec__ = importlib.machinery.ModuleSpec(
+        "unsloth_zoo",
+        loader=None,
+        is_package=True,
+    )
+    package.DEVICE_TYPE = "cpu"
+    sys.modules["unsloth_zoo"] = package
+
+    device_type = types.ModuleType("unsloth_zoo.device_type")
+    device_type.DEVICE_TYPE = "cpu"
+    device_type.DEVICE_TYPE_TORCH = "cpu"
+    device_type.DEVICE_COUNT = 0
+    device_type.ALLOW_PREQUANTIZED_MODELS = False
+    device_type.is_hip = lambda: False
+    device_type.get_device_type = lambda: "cpu"
+    device_type.get_device_count = lambda: 0
+    sys.modules["unsloth_zoo.device_type"] = device_type
+
+    try:
+        yield
+    finally:
+        for name in list(sys.modules):
+            if name == "unsloth_zoo" or name.startswith("unsloth_zoo."):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved)
+
+
+@contextmanager
+def _compile_flag_guard(torch, cross_entropy_loss):
+    previous = cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED
+    torch._dynamo.reset()
+    cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = None
+    try:
+        yield
+    finally:
+        cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = previous
+        torch._dynamo.reset()
+
+
+def _shift_labels(torch, labels, ignore_index=-100):
+    shifted = torch.empty_like(labels)
+    shifted[..., :-1] = labels[..., 1:]
+    shifted[..., -1] = ignore_index
+    return shifted
+
+
+def _linear_logits(torch, hidden, weight, bias):
+    return torch.nn.functional.linear(
+        hidden.to(dtype=weight.dtype, device=weight.device),
+        weight,
+        bias,
+    )
+
+
+def _apply_logit_transforms(
+    torch,
+    logits,
+    *,
+    logit_scale_multiply=None,
+    logit_scale_divide=None,
+    logit_softcapping=None,
+):
+    if logit_scale_multiply not in (None, 0):
+        logits = logits * logit_scale_multiply
+    if logit_scale_divide not in (None, 0):
+        logits = logits / logit_scale_divide
+    if logit_softcapping not in (None, 0):
+        logits = torch.tanh(logits / logit_softcapping) * logit_softcapping
+    return logits
+
+
+def _dft_loss_from_logits(
+    torch,
+    logits,
+    labels,
+    *,
+    n_items=None,
+    ignore_index=-100,
+):
+    flat_logits = logits.view(-1, logits.shape[-1]).float().contiguous()
+    flat_labels = labels.view(-1).to(device=flat_logits.device).contiguous()
+    valid = flat_labels != ignore_index
+    safe_labels = flat_labels.masked_fill(~valid, 0)
+    logprobs = torch.nn.functional.log_softmax(flat_logits, dim=-1)
+    token_nll = -logprobs.gather(1, safe_labels.unsqueeze(1)).squeeze(1)
+    valid_float = valid.to(dtype=token_nll.dtype)
+    weights = torch.exp(-token_nll.detach()) * valid_float
+
+    if n_items is None:
+        divisor = valid_float.sum()
+    elif torch.is_tensor(n_items):
+        divisor = n_items.to(device=flat_logits.device, dtype=token_nll.dtype)
+    else:
+        divisor = torch.tensor(n_items, device=flat_logits.device, dtype=token_nll.dtype)
+    if divisor.numel() != 1:
+        divisor = divisor.ravel()[0]
+    divisor = torch.where(divisor == 0, torch.ones_like(divisor), divisor)
+    return (token_nll * weights).sum() / divisor
+
+
+def _reference_dft_loss(
+    torch,
+    hidden,
+    weight,
+    bias,
+    labels,
+    *,
+    n_items=None,
+    ignore_index=-100,
+    shift_labels=False,
+    logit_scale_multiply=None,
+    logit_scale_divide=None,
+    logit_softcapping=None,
+):
+    if shift_labels:
+        labels = _shift_labels(torch, labels, ignore_index)
+    logits = _linear_logits(torch, hidden, weight, bias)
+    logits = _apply_logit_transforms(
+        torch,
+        logits,
+        logit_scale_multiply=logit_scale_multiply,
+        logit_scale_divide=logit_scale_divide,
+        logit_softcapping=logit_softcapping,
+    )
+    return _dft_loss_from_logits(
+        torch,
+        logits,
+        labels,
+        n_items=n_items,
+        ignore_index=ignore_index,
+    )
+
+
+def _closed_form_dft(torch, transformed_logits, labels, *, n_items=None, ignore_index=-100):
+    with torch.no_grad():
+        flat_logits = transformed_logits.detach().view(-1, transformed_logits.shape[-1]).float()
+        flat_labels = labels.view(-1).to(device=flat_logits.device)
+        valid = flat_labels != ignore_index
+        safe_labels = flat_labels.masked_fill(~valid, 0)
+        logprobs = torch.nn.functional.log_softmax(flat_logits, dim=-1)
+        probs = logprobs.exp()
+        token_nll = -logprobs.gather(1, safe_labels.unsqueeze(1)).squeeze(1)
+        valid_float = valid.to(dtype=token_nll.dtype)
+        token_values = token_nll * torch.exp(-token_nll) * valid_float
+
+        if n_items is None:
+            divisor = valid_float.sum()
+        elif torch.is_tensor(n_items):
+            divisor = n_items.to(device=flat_logits.device, dtype=token_nll.dtype)
+        else:
+            divisor = torch.tensor(n_items, device=flat_logits.device, dtype=token_nll.dtype)
+        if divisor.numel() != 1:
+            divisor = divisor.ravel()[0]
+        divisor = torch.where(divisor == 0, torch.ones_like(divisor), divisor)
+
+        one_hot = torch.zeros_like(probs)
+        one_hot.scatter_(1, safe_labels.unsqueeze(1), 1.0)
+        weights = torch.exp(-token_nll) * valid_float
+        logit_grad = weights.unsqueeze(1) * (probs - one_hot) / divisor
+        return {
+            "loss": token_values.sum() / divisor,
+            "token_values": token_values,
+            "logit_grad": logit_grad,
+            "probs": probs,
+        }
+
+
+def _expected_linear_grads(torch, hidden, weight, bias, logit_grad):
+    grad = logit_grad.to(dtype=weight.dtype)
+    flat_hidden = hidden.detach().view(-1, hidden.shape[-1]).to(dtype=weight.dtype)
+    hidden_grad = grad.matmul(weight.detach()).view_as(hidden).to(dtype=hidden.dtype)
+    weight_grad = grad.transpose(0, 1).matmul(flat_hidden)
+    bias_grad = None if bias is None else grad.sum(dim=0).to(dtype=bias.dtype)
+    return hidden_grad, weight_grad, bias_grad
+
+
+def _make_wrapper_inputs(torch, *, dtype=None, device=None):
+    dtype = torch.float64 if dtype is None else dtype
+    device = torch.device("cpu") if device is None else device
+    hidden = torch.tensor(
+        [
+            [[0.30, -0.70, 0.20], [1.10, 0.40, -0.30], [-0.50, 0.80, 0.60]],
+            [[0.90, -0.20, 0.50], [-0.40, -0.60, 1.00], [0.70, 0.30, -0.80]],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    weight = torch.tensor(
+        [
+            [0.20, -0.50, 0.70],
+            [-0.30, 0.60, 0.10],
+            [0.80, 0.20, -0.40],
+            [-0.60, -0.10, 0.50],
+            [0.40, 0.90, -0.20],
+        ],
+        dtype=dtype,
+        device=device,
+    )
+    bias = torch.tensor([0.10, -0.20, 0.30, -0.10, 0.20], dtype=dtype, device=device)
+    labels = torch.tensor([[0, 1, 2], [3, -100, 4]], device=device)
+    return hidden, weight, bias, labels
+
+
+def _clone_leaf(tensor):
+    return tensor.detach().clone().requires_grad_(True)
+
+
+def _run_wrapper(torch, loss_fn, hidden, weight, bias, labels, **kwargs):
+    hidden_leaf = _clone_leaf(hidden)
+    weight_leaf = _clone_leaf(weight)
+    bias_leaf = None if bias is None else _clone_leaf(bias)
+    loss = loss_fn(
+        trainer=None,
+        hidden_states=hidden_leaf,
+        lm_head_weight=weight_leaf,
+        lm_head_bias=bias_leaf,
+        labels=labels.detach().clone(),
+        **kwargs,
+    )
+    loss.backward()
+    return (
+        loss.detach().clone(),
+        hidden_leaf.grad.detach().clone(),
+        weight_leaf.grad.detach().clone(),
+        None if bias_leaf is None else bias_leaf.grad.detach().clone(),
+    )
+
+
+def _run_direct(torch, compute_fused_dft_loss, hidden, weight, bias, labels, **kwargs):
+    hidden_leaf = _clone_leaf(hidden)
+    weight_leaf = _clone_leaf(weight)
+    bias_leaf = None if bias is None else _clone_leaf(bias)
+    loss, aux = compute_fused_dft_loss(
+        hidden_leaf,
+        weight_leaf,
+        bias_leaf,
+        labels.detach().clone(),
+        **kwargs,
+    )
+    loss.backward()
+    return (
+        aux[0].detach().clone(),
+        hidden_leaf.grad.detach().clone(),
+        weight_leaf.grad.detach().clone(),
+        None if bias_leaf is None else bias_leaf.grad.detach().clone(),
+    )
+
+
+def _assert_wrapper_results_close(torch, actual, expected, *, message=""):
+    for actual_tensor, expected_tensor, name in zip(
+        actual,
+        expected,
+        ("loss", "hidden grad", "weight grad", "bias grad"),
+    ):
+        if actual_tensor is None or expected_tensor is None:
+            assert actual_tensor is expected_tensor, f"{message} {name} None mismatch"
+            continue
+        assert torch.allclose(
+            actual_tensor,
+            expected_tensor,
+            rtol=WRAPPER_RTOL,
+            atol=WRAPPER_ATOL,
+        ), f"{message} {name} mismatch"
+
+
+def _two_class_logits_for_probability(torch, probability, *, dtype=None):
+    dtype = torch.float64 if dtype is None else dtype
+    logit = math.log(probability / (1.0 - probability))
+    return torch.tensor([[[logit, 0.0]]], dtype=dtype)
+
+
+def _skip_if_compile_disabled():
+    if os.environ.get("UNSLOTH_FUSED_CE_COMPILE_DISABLE", "0") == "1":
+        pytest.skip("UNSLOTH_FUSED_CE_COMPILE_DISABLE=1 disables fused-loss compile")
+
+
+def test_compute_dft_single_token_closed_form_loss_and_gradient():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.tensor([[[0.25, -0.50]]], dtype=torch.float64, requires_grad=True)
+        weight = torch.tensor(
+            [[0.20, -0.30], [-0.70, 0.40], [0.50, 0.10]],
+            dtype=torch.float64,
+            requires_grad=True,
+        )
+        bias = torch.tensor([0.05, -0.10, 0.20], dtype=torch.float64, requires_grad=True)
+        labels = torch.tensor([[2]])
+
+        loss, aux = compute_fused_dft_loss(
+            hidden,
+            weight,
+            bias,
+            labels,
+            shift_labels=False,
+        )
+        logits = _linear_logits(torch, hidden, weight, bias)
+        expected = _closed_form_dft(torch, logits, labels)
+        expected_hidden, expected_weight, expected_bias = _expected_linear_grads(
+            torch,
+            hidden,
+            weight,
+            bias,
+            expected["logit_grad"],
+        )
+
+        assert torch.allclose(loss, expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(aux[0], expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+        loss.backward()
+        assert torch.allclose(hidden.grad, expected_hidden, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(weight.grad, expected_weight, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(bias.grad, expected_bias, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+
+def test_compute_dft_gradient_uses_detached_probability_weight():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = _two_class_logits_for_probability(torch, 0.10).requires_grad_(True)
+        weight = torch.eye(2, dtype=torch.float64)
+        labels = torch.tensor([[0]])
+        loss, _ = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
+        loss.backward()
+
+        expected = _closed_form_dft(torch, hidden, labels)
+        probability = expected["probs"][0, 0]
+        nll = -torch.log(probability)
+        one_hot = torch.tensor([[1.0, 0.0]], dtype=expected["probs"].dtype)
+        # In the (q - one_hot) convention, differentiating -p log(p) adds
+        # the factor (1 - NLL); DFT intentionally omits it via detach().
+        nondetached_grad = probability * (1.0 - nll) * (expected["probs"] - one_hot)
+
+        assert torch.allclose(
+            hidden.grad,
+            expected["logit_grad"].view_as(hidden).to(dtype=hidden.dtype),
+            rtol=DIRECT_RTOL,
+            atol=DIRECT_ATOL,
+        )
+        assert torch.max(torch.abs(hidden.grad.float().view(1, 2) - nondetached_grad)) > 1e-3
+
+
+def test_compute_dft_minus_p_log_p_shape():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        weight = torch.eye(2, dtype=torch.float64)
+        labels = torch.tensor([[0]])
+        probabilities = [0.99, math.exp(-1.0), 1e-4]
+        observed = []
+        expected_values = []
+
+        for probability in probabilities:
+            hidden = _two_class_logits_for_probability(torch, probability).requires_grad_(True)
+            loss, aux = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
+            expected = _closed_form_dft(torch, hidden, labels)
+            observed.append(loss.detach())
+            expected_values.append(expected["loss"])
+            assert torch.allclose(loss, expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+            assert torch.allclose(aux[0], expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+        assert observed[1] > observed[0]
+        assert observed[1] > observed[2]
+        assert expected_values[2] < torch.tensor(1e-3, dtype=expected_values[2].dtype)
+
+
+def test_compute_dft_low_probability_gradient_vanishes():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        weight = torch.eye(2, dtype=torch.float64)
+        labels = torch.tensor([[0]])
+
+        low_hidden = _two_class_logits_for_probability(torch, 1e-5).requires_grad_(True)
+        low_loss, _ = compute_fused_dft_loss(low_hidden, weight, None, labels, shift_labels=False)
+        low_loss.backward()
+
+        peak_hidden = _two_class_logits_for_probability(torch, math.exp(-1.0)).requires_grad_(True)
+        peak_loss, _ = compute_fused_dft_loss(peak_hidden, weight, None, labels, shift_labels=False)
+        peak_loss.backward()
+
+        assert torch.linalg.vector_norm(low_hidden.grad) < torch.linalg.vector_norm(peak_hidden.grad) * 1e-3
+
+
+def test_compute_dft_ignore_index_zeroes_loss_and_grad_rows():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.tensor([[[0.40, -0.20], [9.0, -7.0]]], dtype=torch.float64, requires_grad=True)
+        weight = torch.tensor(
+            [[0.30, -0.10], [0.20, 0.50], [-0.40, 0.70]],
+            dtype=torch.float64,
+            requires_grad=True,
+        )
+        bias = torch.tensor([0.10, -0.20, 0.30], dtype=torch.float64, requires_grad=True)
+        labels = torch.tensor([[1, -100]])
+
+        loss, _ = compute_fused_dft_loss(hidden, weight, bias, labels, shift_labels=False)
+        logits = _linear_logits(torch, hidden, weight, bias)
+        expected = _closed_form_dft(torch, logits, labels)
+        expected_hidden, expected_weight, expected_bias = _expected_linear_grads(
+            torch,
+            hidden,
+            weight,
+            bias,
+            expected["logit_grad"],
+        )
+
+        assert expected["token_values"][1] == 0
+        assert torch.allclose(loss, expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        loss.backward()
+        assert torch.count_nonzero(hidden.grad[0, 1]) == 0
+        assert torch.allclose(hidden.grad, expected_hidden, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(weight.grad, expected_weight, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(bias.grad, expected_bias, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+
+def test_compute_dft_ignored_rows_sanitize_nonfinite_logits_before_log_softmax():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.tensor(
+            [[[0.20, -0.10], [1.0e40, -1.0e40]]],
+            dtype=torch.float64,
+            requires_grad=True,
+        )
+        weight = torch.tensor(
+            [[0.30, -0.10], [0.20, 0.50], [-0.40, 0.70]],
+            dtype=torch.float64,
+            requires_grad=True,
+        )
+        bias = torch.tensor([0.10, -0.20, 0.30], dtype=torch.float64, requires_grad=True)
+        labels = torch.tensor([[1, -100]])
+
+        loss, aux = compute_fused_dft_loss(hidden, weight, bias, labels, shift_labels=False)
+        expected = _reference_dft_loss(
+            torch,
+            hidden[:, :1],
+            weight,
+            bias,
+            labels[:, :1],
+            shift_labels=False,
+        )
+
+        assert torch.isfinite(loss)
+        assert torch.allclose(loss, expected, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(aux[0], expected, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        loss.backward()
+        assert torch.isfinite(hidden.grad).all()
+        assert torch.isfinite(weight.grad).all()
+        assert torch.isfinite(bias.grad).all()
+        assert torch.count_nonzero(hidden.grad[0, 1]) == 0
+
+
+def test_compute_dft_custom_ignore_index_is_safe_for_out_of_vocab_label():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.tensor([[[0.20, -0.10]]], dtype=torch.float64, requires_grad=True)
+        weight = torch.tensor([[0.30, 0.40], [-0.20, 0.10]], dtype=torch.float64, requires_grad=True)
+        bias = torch.tensor([0.05, -0.15], dtype=torch.float64, requires_grad=True)
+        labels = torch.tensor([[999]])
+
+        loss, aux = compute_fused_dft_loss(
+            hidden,
+            weight,
+            bias,
+            labels,
+            shift_labels=False,
+            ignore_index=999,
+        )
+        assert torch.isfinite(loss)
+        assert float(loss.detach()) == 0.0
+        assert float(aux[0].detach()) == 0.0
+        loss.backward()
+        assert torch.count_nonzero(hidden.grad) == 0
+        assert torch.count_nonzero(weight.grad) == 0
+        assert torch.count_nonzero(bias.grad) == 0
+
+
+def test_compute_dft_shift_labels_false_accepts_noncontiguous_labels():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.tensor(
+            [
+                [[0.20, -0.10], [0.50, 0.30]],
+                [[-0.70, 0.40], [0.90, -0.20]],
+                [[0.10, 0.80], [-0.30, 0.60]],
+            ],
+            dtype=torch.float64,
+        )
+        weight = torch.tensor([[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10]], dtype=torch.float64)
+        labels = torch.tensor([[0, 1, 2], [2, 1, 0]]).t()
+        assert not labels.is_contiguous()
+
+        loss, aux = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
+        expected, expected_aux = compute_fused_dft_loss(
+            hidden,
+            weight,
+            None,
+            labels.contiguous(),
+            shift_labels=False,
+        )
+
+        assert torch.allclose(loss, expected, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(aux[0], expected_aux[0], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+
+def test_compute_dft_n_items_int_and_tensor_override_valid_count_divisor():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.tensor([[[0.10, 0.30], [-0.40, 0.20]]], dtype=torch.float64)
+        weight = torch.tensor([[0.20, -0.50], [0.60, 0.10], [-0.30, 0.40]], dtype=torch.float64)
+        labels = torch.tensor([[0, 2]])
+
+        default_loss, _ = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
+        int_loss, _ = compute_fused_dft_loss(hidden, weight, None, labels, n_items=4, shift_labels=False)
+        tensor_loss, _ = compute_fused_dft_loss(
+            hidden,
+            weight,
+            None,
+            labels,
+            n_items=torch.tensor(4),
+            shift_labels=False,
+        )
+
+        assert torch.allclose(int_loss, default_loss / 2, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(tensor_loss, int_loss, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+
+def test_compute_dft_zero_n_items_uses_one_as_divisor():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30]]], dtype=torch.float64)
+        weight = torch.tensor([[0.10, 0.40], [-0.30, 0.20], [0.50, -0.60]], dtype=torch.float64)
+        labels = torch.tensor([[1, 2]])
+
+        default_loss, _ = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
+        zero_divisor_loss, _ = compute_fused_dft_loss(
+            hidden,
+            weight,
+            None,
+            labels,
+            n_items=0,
+            shift_labels=False,
+        )
+
+        assert torch.isfinite(zero_divisor_loss)
+        assert torch.allclose(zero_divisor_loss, default_loss * 2, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+
+def test_compute_dft_logit_transforms_apply_in_implemented_order():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.tensor([[[3.25, -1.75], [0.50, 2.20]]], dtype=torch.float64, requires_grad=True)
+        weight = torch.tensor(
+            [[1.20, -0.70], [-1.50, 0.90], [0.30, 1.10]],
+            dtype=torch.float64,
+            requires_grad=True,
+        )
+        bias = torch.tensor([0.20, -0.30, 0.40], dtype=torch.float64, requires_grad=True)
+        labels = torch.tensor([[0, 2]])
+        kwargs = dict(
+            logit_scale_multiply=1.7,
+            logit_scale_divide=0.8,
+            logit_softcapping=2.25,
+        )
+
+        ref_hidden = _clone_leaf(hidden)
+        ref_weight = _clone_leaf(weight)
+        ref_bias = _clone_leaf(bias)
+        reference_loss = _reference_dft_loss(
+            torch,
+            ref_hidden,
+            ref_weight,
+            ref_bias,
+            labels,
+            **kwargs,
+        )
+        actual_loss, _ = compute_fused_dft_loss(hidden, weight, bias, labels, shift_labels=False, **kwargs)
+
+        assert torch.allclose(actual_loss, reference_loss, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        actual_loss.backward()
+        reference_loss.backward()
+        assert torch.allclose(hidden.grad, ref_hidden.grad, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(weight.grad, ref_weight.grad, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+        assert torch.allclose(bias.grad, ref_bias.grad, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+        no_transform_loss, _ = compute_fused_dft_loss(
+            hidden.detach(),
+            weight.detach(),
+            bias.detach(),
+            labels,
+            shift_labels=False,
+        )
+        zero_transform_loss, _ = compute_fused_dft_loss(
+            hidden.detach(),
+            weight.detach(),
+            bias.detach(),
+            labels,
+            shift_labels=False,
+            logit_scale_multiply=0,
+            logit_scale_divide=0,
+            logit_softcapping=0,
+        )
+        assert torch.allclose(zero_transform_loss, no_transform_loss, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
+
+
+def test_compute_dft_rejects_label_smoothing():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        hidden = torch.randn(1, 1, 2, dtype=torch.float64)
+        weight = torch.randn(3, 2, dtype=torch.float64)
+        labels = torch.tensor([[0]])
+
+        with pytest.raises(ValueError, match="label_smoothing"):
+            compute_fused_dft_loss(
+                hidden,
+                weight,
+                None,
+                labels,
+                shift_labels=False,
+                label_smoothing=0.1,
+            )
+
+
+def test_unsloth_fused_dft_matches_compute_for_preshifted_one_chunk():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
+        wrapper = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=1,
+            shift_labels=False,
+        )
+        direct = _run_direct(
+            torch,
+            compute_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            shift_labels=False,
+        )
+
+        _assert_wrapper_results_close(torch, wrapper, direct)
+
+
+def test_unsloth_fused_dft_chunking_invariant_value_and_gradients():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
+        baseline = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=1,
+            shift_labels=False,
+        )
+
+        for n_chunks in (2, 20):
+            chunked = _run_wrapper(
+                torch,
+                unsloth_fused_dft_loss,
+                hidden,
+                weight,
+                bias,
+                labels,
+                torch_compile=False,
+                n_chunks=n_chunks,
+                shift_labels=False,
+            )
+            _assert_wrapper_results_close(torch, chunked, baseline, message=f"n_chunks={n_chunks}")
+
+
+def test_unsloth_fused_dft_uses_shared_automatic_chunk_sizer(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
+
+        calls = []
+
+        def get_chunk_size(bsz, qlen, vocab_size, target_gb=None):
+            calls.append((bsz, qlen, vocab_size, target_gb))
+            return 2
+
+        monkeypatch.setattr(cross_entropy_loss, "get_chunk_size", get_chunk_size)
+        monkeypatch.setattr(cross_entropy_loss, "TARGET_GB", None)
+        monkeypatch.setattr(cross_entropy_loss, "N_CHUNKS", None)
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
+        automatic = _run_wrapper(
+            torch,
+            cross_entropy_loss.unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            shift_labels=False,
+        )
+        assert calls == [(2, 3, 5, None)]
+
+        calls.clear()
+        explicit = _run_wrapper(
+            torch,
+            cross_entropy_loss.unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+        )
+        assert calls == []
+        _assert_wrapper_results_close(torch, automatic, explicit)
+
+
+def test_unsloth_fused_dft_wrapper_uses_global_divisor_not_per_chunk():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30], [-0.70, 0.40], [0.90, -0.20]]], dtype=torch.float64)
+        weight = torch.tensor([[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10]], dtype=torch.float64)
+        bias = torch.tensor([0.05, -0.10, 0.20], dtype=torch.float64)
+        labels = torch.tensor([[0, -100, 2, -100]])
+
+        loss, _, _, _ = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+        )
+
+        logits = _linear_logits(torch, hidden, weight, bias)
+        closed_form = _closed_form_dft(torch, logits, labels)
+        token_values = closed_form["token_values"]
+        global_loss = (token_values[0] + token_values[2]) / 2
+        per_chunk_bug_loss = token_values[0] + token_values[2]
+
+        assert torch.allclose(loss, global_loss, rtol=WRAPPER_RTOL, atol=WRAPPER_ATOL)
+        assert torch.abs(loss - per_chunk_bug_loss) > 1e-3
+
+
+def test_unsloth_fused_dft_overwrite_true_value_and_no_corruption():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
+        expected = _run_direct(
+            torch,
+            compute_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            shift_labels=False,
+        )
+        overwritten = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+            overwrite=True,
+        )
+
+        _assert_wrapper_results_close(torch, overwritten, expected)
+
+
+def test_unsloth_fused_dft_default_shift_masks_final_position():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30], [-0.70, 0.40], [0.90, -0.20]]], dtype=torch.float64)
+        weight = torch.tensor(
+            [[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10], [-0.50, 0.20], [0.30, 0.80]],
+            dtype=torch.float64,
+        )
+        bias = torch.tensor([0.05, -0.10, 0.20, -0.15, 0.25], dtype=torch.float64)
+        labels = torch.tensor([[0, 1, 2, 3]])
+        labels_with_different_first_source = torch.tensor([[4, 1, 2, 3]])
+
+        baseline = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=1,
+        )
+        changed_first_label = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels_with_different_first_source,
+            torch_compile=False,
+            n_chunks=1,
+        )
+
+        _assert_wrapper_results_close(torch, changed_first_label, baseline)
+        assert torch.count_nonzero(baseline[1][0, -1]) == 0
+
+
+def test_unsloth_fused_dft_mask_applies_to_shifted_targets():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30], [-0.70, 0.40], [0.90, -0.20]]], dtype=torch.float64)
+        weight = torch.tensor([[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10], [-0.50, 0.20]], dtype=torch.float64)
+        bias = torch.tensor([0.05, -0.10, 0.20, -0.15], dtype=torch.float64)
+        labels = torch.tensor([[0, 1, 2, 3]])
+        mask = torch.tensor([[1, 1, 0, 1]])
+        expected_preshifted_labels = torch.tensor([[1, -100, 3, -100]])
+
+        masked = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            mask=mask,
+            torch_compile=False,
+            n_chunks=1,
+        )
+        explicit = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            expected_preshifted_labels,
+            torch_compile=False,
+            n_chunks=1,
+            shift_labels=False,
+        )
+
+        _assert_wrapper_results_close(torch, masked, explicit)
+        assert torch.count_nonzero(masked[1][0, 1]) == 0
+
+
+def test_unsloth_fused_dft_shift_labels_false_uses_labels_as_targets():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden = torch.tensor([[[0.10, -0.20], [0.30, 0.40], [-0.50, 0.60]]], dtype=torch.float64)
+        weight = torch.tensor([[0.20, -0.10], [-0.40, 0.30], [0.50, 0.70]], dtype=torch.float64)
+        bias = torch.tensor([0.05, -0.15, 0.25], dtype=torch.float64)
+        labels = torch.tensor([[0, 1, 2]])
+
+        wrapper = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=1,
+            shift_labels=False,
+        )
+        direct = _run_direct(
+            torch,
+            compute_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            shift_labels=False,
+        )
+
+        _assert_wrapper_results_close(torch, wrapper, direct)
+        assert torch.count_nonzero(wrapper[1][0, -1]) > 0
+
+
+def test_unsloth_fused_dft_shift_labels_false_ignores_mask_by_contract():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
+        mask = torch.zeros_like(labels)
+
+        without_mask = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+        )
+        with_mask = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            mask=mask,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+        )
+
+        _assert_wrapper_results_close(torch, with_mask, without_mask)
+
+
+def test_unsloth_fused_dft_custom_ignore_index_through_wrapper():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30], [-0.70, 0.40]]], dtype=torch.float64)
+        weight = torch.tensor([[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10]], dtype=torch.float64)
+        bias = torch.tensor([0.05, -0.10, 0.20], dtype=torch.float64)
+        labels = torch.tensor([[0, 999, 2]])
+
+        loss, hidden_grad, weight_grad, bias_grad = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=1,
+            ignore_index=999,
+        )
+
+        assert torch.isfinite(loss)
+        assert torch.count_nonzero(hidden_grad[0, 0]) == 0
+        assert torch.count_nonzero(hidden_grad[0, 1]) > 0
+        assert torch.isfinite(weight_grad).all()
+        assert torch.isfinite(bias_grad).all()
+
+
+def test_unsloth_fused_dft_scaling_nonzero_preserves_public_loss_and_gradients():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
+        unscaled = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+            scaling=None,
+        )
+        scaled = _run_wrapper(
+            torch,
+            unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+            scaling=7.0,
+        )
+
+        _assert_wrapper_results_close(torch, scaled, unscaled)
+
+
+def test_unsloth_fused_dft_all_ignored_returns_connected_zero():
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        hidden = torch.randn(1, 4, 3, dtype=torch.float64, requires_grad=True)
+        weight = torch.randn(6, 3, dtype=torch.float64, requires_grad=True)
+        bias = torch.randn(6, dtype=torch.float64, requires_grad=True)
+        labels = torch.full((1, 4), -100)
+
+        loss = unsloth_fused_dft_loss(
+            trainer=None,
+            hidden_states=hidden,
+            lm_head_weight=weight,
+            lm_head_bias=bias,
+            labels=labels,
+            torch_compile=False,
+            n_chunks=2,
+        )
+        assert torch.isfinite(loss)
+        assert float(loss.detach()) == 0.0
+        loss.backward()
+        assert torch.count_nonzero(hidden.grad) == 0
+        assert torch.count_nonzero(weight.grad) == 0
+        assert torch.count_nonzero(bias.grad) == 0
+
+
+def test_unsloth_fused_dft_compiled_parity_and_probe_success():
+    torch = pytest.importorskip("torch")
+    _skip_if_compile_disabled()
+
+    with _lightweight_unsloth_zoo_import():
+        import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch, dtype=torch.float32)
+        eager = _run_wrapper(
+            torch,
+            cross_entropy_loss.unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+        )
+
+        with _compile_flag_guard(torch, cross_entropy_loss):
+            compiled = _run_wrapper(
+                torch,
+                cross_entropy_loss.unsloth_fused_dft_loss,
+                hidden,
+                weight,
+                bias,
+                labels,
+                torch_compile=True,
+                n_chunks=2,
+                shift_labels=False,
+            )
+            assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is True
+
+        _assert_wrapper_results_close(torch, compiled, eager)
+
+
+def test_unsloth_fused_dft_label_smoothing_raise_does_not_poison_compile_flag():
+    torch = pytest.importorskip("torch")
+    _skip_if_compile_disabled()
+
+    with _lightweight_unsloth_zoo_import():
+        import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch, dtype=torch.float32)
+
+        with _compile_flag_guard(torch, cross_entropy_loss):
+            with pytest.raises(ValueError, match="label_smoothing"):
+                cross_entropy_loss.unsloth_fused_dft_loss(
+                    trainer=None,
+                    hidden_states=hidden.detach().clone().requires_grad_(True),
+                    lm_head_weight=weight.detach().clone().requires_grad_(True),
+                    lm_head_bias=bias.detach().clone().requires_grad_(True),
+                    labels=labels.detach().clone(),
+                    torch_compile=True,
+                    n_chunks=2,
+                    shift_labels=False,
+                    label_smoothing=0.1,
+                )
+            assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is None
+
+
+def test_unsloth_fused_dft_compiles_when_flag_preset_true():
+    torch = pytest.importorskip("torch")
+    _skip_if_compile_disabled()
+
+    with _lightweight_unsloth_zoo_import():
+        import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
+
+        hidden, weight, bias, labels = _make_wrapper_inputs(torch, dtype=torch.float32)
+        eager = _run_wrapper(
+            torch,
+            cross_entropy_loss.unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+        )
+
+        with _compile_flag_guard(torch, cross_entropy_loss):
+            cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = True
+            compiled = _run_wrapper(
+                torch,
+                cross_entropy_loss.unsloth_fused_dft_loss,
+                hidden,
+                weight,
+                bias,
+                labels,
+                torch_compile=True,
+                n_chunks=2,
+                shift_labels=False,
+            )
+            assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is True
+
+        _assert_wrapper_results_close(torch, compiled, eager)
+
+
+def test_unsloth_fused_dft_exports_public_symbol():
+    pytest.importorskip("torch")
+    pytest.importorskip("triton")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses import unsloth_fused_dft_loss
+        from unsloth_zoo.loss_utils import unsloth_fused_dft_loss as exported
+
+        assert exported is unsloth_fused_dft_loss
+
+
+def test_unsloth_fused_dft_cuda_smoke():
+    torch = pytest.importorskip("torch")
+    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
+        pytest.skip("requires CUDA")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
+
+        torch.manual_seed(1)
+        device = torch.device("cuda")
+        hidden = torch.randn(1, 6, 8, device=device, dtype=torch.float32, requires_grad=True)
+        weight = torch.randn(11, 8, device=device, dtype=torch.float32, requires_grad=True)
+        bias = torch.randn(11, device=device, dtype=torch.float32, requires_grad=True)
+        labels = torch.randint(0, 11, (1, 6), device=device)
+        labels[0, 3] = -100
+
+        ref_hidden = _clone_leaf(hidden)
+        ref_weight = _clone_leaf(weight)
+        ref_bias = _clone_leaf(bias)
+        loss = unsloth_fused_dft_loss(
+            trainer=None,
+            hidden_states=hidden,
+            lm_head_weight=weight,
+            lm_head_bias=bias,
+            labels=labels,
+            torch_compile=False,
+            n_chunks=2,
+        )
+        ref_loss = _reference_dft_loss(
+            torch,
+            ref_hidden,
+            ref_weight,
+            ref_bias,
+            labels,
+            shift_labels=True,
+        )
+
+        assert torch.allclose(loss, ref_loss, rtol=CUDA_RTOL, atol=CUDA_ATOL)
+        loss.backward()
+        ref_loss.backward()
+        assert torch.allclose(hidden.grad, ref_hidden.grad, rtol=CUDA_RTOL, atol=CUDA_ATOL)
+        assert torch.allclose(weight.grad, ref_weight.grad, rtol=CUDA_RTOL, atol=CUDA_ATOL)
+        assert torch.allclose(bias.grad, ref_bias.grad, rtol=CUDA_RTOL, atol=CUDA_ATOL)

--- a/tests/test_fused_dft_loss.py
+++ b/tests/test_fused_dft_loss.py
@@ -238,7 +238,8 @@ def _skip_if_compile_unavailable():
 
 
 @pytest.mark.parametrize("device_name", ["cpu", "cuda"])
-def test_fused_dft_matches_reference(fused_losses, device_name):
+@pytest.mark.parametrize("n_chunks", [1, 2, 20])
+def test_fused_dft_matches_reference(fused_losses, device_name, n_chunks):
     if device_name == "cuda" and not torch.cuda.is_available():
         pytest.skip("requires CUDA")
 
@@ -253,9 +254,13 @@ def test_fused_dft_matches_reference(fused_losses, device_name):
     shifted_labels = _shift_labels(labels)
     valid_per_chunk = [
         int((chunk != -100).sum())
-        for chunk in torch.chunk(shifted_labels.reshape(-1), 2)
+        for chunk in torch.chunk(shifted_labels.reshape(-1), n_chunks)
     ]
-    assert valid_per_chunk == [1, 2]
+    assert valid_per_chunk == {
+        1: [3],
+        2: [1, 2],
+        20: [1, 0, 0, 1, 1, 0],
+    }[n_chunks]
 
     transforms = {
         "logit_scale_multiply": 1.7,
@@ -288,7 +293,7 @@ def test_fused_dft_matches_reference(fused_losses, device_name):
         bias,
         labels,
         torch_compile=False,
-        n_chunks=2,
+        n_chunks=n_chunks,
         scaling=7.0,
         **transforms,
     )
@@ -297,7 +302,8 @@ def test_fused_dft_matches_reference(fused_losses, device_name):
     _assert_result_close(chunked, expected, rtol=wrapper_rtol, atol=atol)
 
 
-def test_fused_dft_ignored_nonfinite_row_is_safe(fused_losses):
+@pytest.mark.parametrize("ignore_index", [-100, 999])
+def test_fused_dft_ignored_nonfinite_row_is_safe(fused_losses, ignore_index):
     max_float = torch.finfo(torch.float32).max
     hidden = torch.tensor(
         [[[0.20, -0.10], [max_float, max_float]]],
@@ -308,7 +314,7 @@ def test_fused_dft_ignored_nonfinite_row_is_safe(fused_losses):
         dtype=torch.float32,
     )
     bias = torch.tensor([0.10, -0.20, 0.30], dtype=torch.float32)
-    labels = torch.tensor([[1, -100]])
+    labels = torch.tensor([[1, ignore_index]])
     assert torch.isnan(torch.nn.functional.linear(hidden, weight, bias)[0, 1]).any()
 
     actual = _run_direct(
@@ -318,6 +324,7 @@ def test_fused_dft_ignored_nonfinite_row_is_safe(fused_losses):
         bias,
         labels,
         shift_labels=False,
+        ignore_index=ignore_index,
         logit_softcapping=1.0,
     )
     expected = _run_reference(
@@ -326,6 +333,7 @@ def test_fused_dft_ignored_nonfinite_row_is_safe(fused_losses):
         bias,
         labels[:, :1],
         shift_labels=False,
+        ignore_index=ignore_index,
         logit_softcapping=1.0,
     )
 
@@ -335,6 +343,33 @@ def test_fused_dft_ignored_nonfinite_row_is_safe(fused_losses):
     torch.testing.assert_close(actual[2], expected[2], rtol=1e-5, atol=1e-7)
     torch.testing.assert_close(actual[3], expected[3], rtol=1e-5, atol=1e-7)
     assert all(torch.isfinite(tensor).all() for tensor in actual)
+
+
+@pytest.mark.parametrize(
+    "loss_name", ["unsloth_fused_ce_loss", "unsloth_fused_dft_loss"]
+)
+def test_fused_loss_mask_applies_to_shifted_targets(fused_losses, loss_name):
+    hidden, weight, bias, labels = _make_inputs(torch.device("cpu"), torch.float64)
+    labels = labels.masked_fill(labels == -100, 2)
+    mask = torch.tensor([[1, 1, 0], [1, 0, 1]])
+    expected_labels = torch.tensor([[1, -100, -100], [-100, 4, -100]])
+    loss_fn = getattr(fused_losses, loss_name)
+
+    masked = _run_wrapper(
+        loss_fn, hidden, weight, bias, labels, mask=mask, torch_compile=False, n_chunks=2
+    )
+    explicit = _run_wrapper(
+        loss_fn,
+        hidden,
+        weight,
+        bias,
+        expected_labels,
+        shift_labels=False,
+        torch_compile=False,
+        n_chunks=2,
+    )
+
+    _assert_result_close(masked, explicit)
 
 
 def test_fused_dft_all_ignored_returns_connected_zero(fused_losses):

--- a/tests/test_fused_dft_loss.py
+++ b/tests/test_fused_dft_loss.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 import importlib.machinery
-import math
 import os
 from pathlib import Path
 import sys
@@ -11,21 +10,12 @@ import types
 import pytest
 
 
-DIRECT_RTOL = 1e-6
-DIRECT_ATOL = 1e-7
-WRAPPER_RTOL = 1e-5
-WRAPPER_ATOL = 1e-7
-CUDA_RTOL = 1e-4
-CUDA_ATOL = 1e-6
+torch = pytest.importorskip("torch")
 
 
 @contextmanager
 def _lightweight_unsloth_zoo_import():
-    """Import fused-loss modules without running unsloth_zoo.__init__.
-
-    These tests only need the local fused-loss modules, so install a temporary
-    package skeleton and restore any pre-existing modules afterwards.
-    """
+    """Import fused losses without running unsloth_zoo.__init__."""
     root = Path(__file__).resolve().parents[1]
     saved = {
         name: module
@@ -65,165 +55,32 @@ def _lightweight_unsloth_zoo_import():
         sys.modules.update(saved)
 
 
+@pytest.fixture(scope="module")
+def fused_losses():
+    with _lightweight_unsloth_zoo_import():
+        import unsloth_zoo.fused_losses.cross_entropy_loss as module
+
+        yield module
+
+
 @contextmanager
-def _compile_flag_guard(torch, cross_entropy_loss):
-    previous = cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED
-    proven = getattr(cross_entropy_loss, "_FUSED_CE_COMPILE_FASTPATH_PROVEN", None)
-    previous_proven = None if proven is None else set(proven)
+def _compile_flag_guard(fused_losses):
+    previous = fused_losses._FUSED_CE_COMPILE_SUPPORTED
+    proven = fused_losses._FUSED_CE_COMPILE_FASTPATH_PROVEN
+    previous_proven = set(proven)
     torch._dynamo.reset()
-    cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = None
-    if proven is not None:
-        proven.clear()
+    fused_losses._FUSED_CE_COMPILE_SUPPORTED = None
+    proven.clear()
     try:
         yield
     finally:
-        cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = previous
-        if proven is not None:
-            proven.clear()
-            proven.update(previous_proven)
+        fused_losses._FUSED_CE_COMPILE_SUPPORTED = previous
+        proven.clear()
+        proven.update(previous_proven)
         torch._dynamo.reset()
 
 
-def _shift_labels(torch, labels, ignore_index=-100):
-    shifted = torch.empty_like(labels)
-    shifted[..., :-1] = labels[..., 1:]
-    shifted[..., -1] = ignore_index
-    return shifted
-
-
-def _linear_logits(torch, hidden, weight, bias):
-    return torch.nn.functional.linear(
-        hidden.to(dtype=weight.dtype, device=weight.device),
-        weight,
-        bias,
-    )
-
-
-def _apply_logit_transforms(
-    torch,
-    logits,
-    *,
-    logit_scale_multiply=None,
-    logit_scale_divide=None,
-    logit_softcapping=None,
-):
-    if logit_scale_multiply not in (None, 0):
-        logits = logits * logit_scale_multiply
-    if logit_scale_divide not in (None, 0):
-        logits = logits / logit_scale_divide
-    if logit_softcapping not in (None, 0):
-        logits = torch.tanh(logits / logit_softcapping) * logit_softcapping
-    return logits
-
-
-def _dft_loss_from_logits(
-    torch,
-    logits,
-    labels,
-    *,
-    n_items=None,
-    ignore_index=-100,
-):
-    flat_logits = logits.view(-1, logits.shape[-1]).float().contiguous()
-    flat_labels = labels.view(-1).to(device=flat_logits.device).contiguous()
-    valid = flat_labels != ignore_index
-    safe_labels = flat_labels.masked_fill(~valid, 0)
-    logprobs = torch.nn.functional.log_softmax(flat_logits, dim=-1)
-    token_nll = -logprobs.gather(1, safe_labels.unsqueeze(1)).squeeze(1)
-    valid_float = valid.to(dtype=token_nll.dtype)
-    weights = torch.exp(-token_nll.detach()) * valid_float
-
-    if n_items is None:
-        divisor = valid_float.sum()
-    elif torch.is_tensor(n_items):
-        divisor = n_items.to(device=flat_logits.device, dtype=token_nll.dtype)
-    else:
-        divisor = torch.tensor(n_items, device=flat_logits.device, dtype=token_nll.dtype)
-    if divisor.numel() != 1:
-        divisor = divisor.ravel()[0]
-    divisor = torch.where(divisor == 0, torch.ones_like(divisor), divisor)
-    return (token_nll * weights).sum() / divisor
-
-
-def _reference_dft_loss(
-    torch,
-    hidden,
-    weight,
-    bias,
-    labels,
-    *,
-    n_items=None,
-    ignore_index=-100,
-    shift_labels=False,
-    logit_scale_multiply=None,
-    logit_scale_divide=None,
-    logit_softcapping=None,
-):
-    if shift_labels:
-        labels = _shift_labels(torch, labels, ignore_index)
-    logits = _linear_logits(torch, hidden, weight, bias)
-    logits = _apply_logit_transforms(
-        torch,
-        logits,
-        logit_scale_multiply=logit_scale_multiply,
-        logit_scale_divide=logit_scale_divide,
-        logit_softcapping=logit_softcapping,
-    )
-    return _dft_loss_from_logits(
-        torch,
-        logits,
-        labels,
-        n_items=n_items,
-        ignore_index=ignore_index,
-    )
-
-
-def _closed_form_dft(torch, transformed_logits, labels, *, n_items=None, ignore_index=-100):
-    with torch.no_grad():
-        flat_logits = transformed_logits.detach().view(-1, transformed_logits.shape[-1]).float()
-        flat_labels = labels.view(-1).to(device=flat_logits.device)
-        valid = flat_labels != ignore_index
-        safe_labels = flat_labels.masked_fill(~valid, 0)
-        logprobs = torch.nn.functional.log_softmax(flat_logits, dim=-1)
-        probs = logprobs.exp()
-        token_nll = -logprobs.gather(1, safe_labels.unsqueeze(1)).squeeze(1)
-        valid_float = valid.to(dtype=token_nll.dtype)
-        token_values = token_nll * torch.exp(-token_nll) * valid_float
-
-        if n_items is None:
-            divisor = valid_float.sum()
-        elif torch.is_tensor(n_items):
-            divisor = n_items.to(device=flat_logits.device, dtype=token_nll.dtype)
-        else:
-            divisor = torch.tensor(n_items, device=flat_logits.device, dtype=token_nll.dtype)
-        if divisor.numel() != 1:
-            divisor = divisor.ravel()[0]
-        divisor = torch.where(divisor == 0, torch.ones_like(divisor), divisor)
-
-        one_hot = torch.zeros_like(probs)
-        one_hot.scatter_(1, safe_labels.unsqueeze(1), 1.0)
-        weights = torch.exp(-token_nll) * valid_float
-        logit_grad = weights.unsqueeze(1) * (probs - one_hot) / divisor
-        return {
-            "loss": token_values.sum() / divisor,
-            "token_values": token_values,
-            "logit_grad": logit_grad,
-            "probs": probs,
-        }
-
-
-def _expected_linear_grads(torch, hidden, weight, bias, logit_grad):
-    grad = logit_grad.to(dtype=weight.dtype)
-    flat_hidden = hidden.detach().view(-1, hidden.shape[-1]).to(dtype=weight.dtype)
-    hidden_grad = grad.matmul(weight.detach()).view_as(hidden).to(dtype=hidden.dtype)
-    weight_grad = grad.transpose(0, 1).matmul(flat_hidden)
-    bias_grad = None if bias is None else grad.sum(dim=0).to(dtype=bias.dtype)
-    return hidden_grad, weight_grad, bias_grad
-
-
-def _make_wrapper_inputs(torch, *, dtype=None, device=None):
-    dtype = torch.float64 if dtype is None else dtype
-    device = torch.device("cpu") if device is None else device
+def _make_inputs(device, dtype):
     hidden = torch.tensor(
         [
             [[0.30, -0.70, 0.20], [1.10, 0.40, -0.30], [-0.50, 0.80, 0.60]],
@@ -243,1145 +100,345 @@ def _make_wrapper_inputs(torch, *, dtype=None, device=None):
         dtype=dtype,
         device=device,
     )
-    bias = torch.tensor([0.10, -0.20, 0.30, -0.10, 0.20], dtype=dtype, device=device)
-    labels = torch.tensor([[0, 1, 2], [3, -100, 4]], device=device)
+    bias = torch.tensor(
+        [0.10, -0.20, 0.30, -0.10, 0.20],
+        dtype=dtype,
+        device=device,
+    )
+    labels = torch.tensor(
+        [[0, 1, -100], [2, 3, 4]],
+        device=device,
+    )
     return hidden, weight, bias, labels
+
+
+def _shift_labels(labels, ignore_index=-100):
+    shifted = torch.empty_like(labels)
+    shifted[..., :-1] = labels[..., 1:]
+    shifted[..., -1] = ignore_index
+    return shifted
+
+
+def _reference_dft(
+    hidden,
+    weight,
+    bias,
+    labels,
+    *,
+    shift_labels=True,
+    ignore_index=-100,
+    logit_scale_multiply=None,
+    logit_scale_divide=None,
+    logit_softcapping=None,
+    detach_weight=True,
+):
+    """Materialized-logit oracle for finite inputs.
+
+    Non-finite ignored rows are compared with a valid-row-only oracle because
+    sanitizing those rows is the production behavior under test.
+    """
+    if shift_labels:
+        labels = _shift_labels(labels, ignore_index)
+    logits = torch.nn.functional.linear(
+        hidden.to(dtype=weight.dtype, device=weight.device),
+        weight,
+        bias,
+    )
+    if logit_scale_multiply not in (None, 0):
+        logits = logits * logit_scale_multiply
+    if logit_scale_divide not in (None, 0):
+        logits = logits / logit_scale_divide
+    if logit_softcapping not in (None, 0):
+        logits = torch.tanh(logits / logit_softcapping) * logit_softcapping
+
+    flat_labels = labels.reshape(-1).to(device=weight.device)
+    token_nll = torch.nn.functional.cross_entropy(
+        logits.reshape(-1, logits.shape[-1]).float().contiguous(),
+        flat_labels,
+        reduction="none",
+        ignore_index=ignore_index,
+        label_smoothing=0.0,
+    )
+    divisor = (flat_labels != ignore_index).to(dtype=token_nll.dtype).sum()
+    divisor = torch.where(divisor == 0, torch.ones_like(divisor), divisor)
+    weight_nll = token_nll.detach() if detach_weight else token_nll
+    return (torch.exp(-weight_nll) * token_nll).sum() / divisor
 
 
 def _clone_leaf(tensor):
     return tensor.detach().clone().requires_grad_(True)
 
 
-def _run_wrapper(torch, loss_fn, hidden, weight, bias, labels, **kwargs):
-    hidden_leaf = _clone_leaf(hidden)
-    weight_leaf = _clone_leaf(weight)
-    bias_leaf = None if bias is None else _clone_leaf(bias)
-    loss = loss_fn(
-        trainer=None,
-        hidden_states=hidden_leaf,
-        lm_head_weight=weight_leaf,
-        lm_head_bias=bias_leaf,
-        labels=labels.detach().clone(),
-        **kwargs,
-    )
+def _collect_result(loss, hidden, weight, bias):
     loss.backward()
     return (
         loss.detach().clone(),
-        hidden_leaf.grad.detach().clone(),
-        weight_leaf.grad.detach().clone(),
-        None if bias_leaf is None else bias_leaf.grad.detach().clone(),
+        hidden.grad.detach().clone(),
+        weight.grad.detach().clone(),
+        bias.grad.detach().clone(),
     )
 
 
-def _run_direct(torch, compute_fused_dft_loss, hidden, weight, bias, labels, **kwargs):
-    hidden_leaf = _clone_leaf(hidden)
-    weight_leaf = _clone_leaf(weight)
-    bias_leaf = None if bias is None else _clone_leaf(bias)
-    loss, aux = compute_fused_dft_loss(
-        hidden_leaf,
-        weight_leaf,
-        bias_leaf,
+def _run_reference(hidden, weight, bias, labels, **kwargs):
+    hidden = _clone_leaf(hidden)
+    weight = _clone_leaf(weight)
+    bias = _clone_leaf(bias)
+    loss = _reference_dft(hidden, weight, bias, labels.detach().clone(), **kwargs)
+    return _collect_result(loss, hidden, weight, bias)
+
+
+def _run_direct(fused_losses, hidden, weight, bias, labels, **kwargs):
+    hidden = _clone_leaf(hidden)
+    weight = _clone_leaf(weight)
+    bias = _clone_leaf(bias)
+    loss, _ = fused_losses.compute_fused_dft_loss(
+        hidden,
+        weight,
+        bias,
         labels.detach().clone(),
         **kwargs,
     )
-    loss.backward()
-    return (
-        aux[0].detach().clone(),
-        hidden_leaf.grad.detach().clone(),
-        weight_leaf.grad.detach().clone(),
-        None if bias_leaf is None else bias_leaf.grad.detach().clone(),
+    return _collect_result(loss, hidden, weight, bias)
+
+
+def _run_wrapper(loss_fn, hidden, weight, bias, labels, **kwargs):
+    hidden = _clone_leaf(hidden)
+    weight = _clone_leaf(weight)
+    bias = _clone_leaf(bias)
+    loss = loss_fn(
+        trainer=None,
+        hidden_states=hidden,
+        lm_head_weight=weight,
+        lm_head_bias=bias,
+        labels=labels.detach().clone(),
+        **kwargs,
     )
+    return _collect_result(loss, hidden, weight, bias)
 
 
-def _assert_wrapper_results_close(torch, actual, expected, *, message=""):
-    for actual_tensor, expected_tensor, name in zip(
-        actual,
-        expected,
-        ("loss", "hidden grad", "weight grad", "bias grad"),
-    ):
-        if actual_tensor is None or expected_tensor is None:
-            assert actual_tensor is expected_tensor, f"{message} {name} None mismatch"
-            continue
-        assert torch.allclose(
+def _assert_result_close(actual, expected, *, rtol=1e-5, atol=1e-7):
+    for actual_tensor, expected_tensor in zip(actual, expected):
+        torch.testing.assert_close(
             actual_tensor,
             expected_tensor,
-            rtol=WRAPPER_RTOL,
-            atol=WRAPPER_ATOL,
-        ), f"{message} {name} mismatch"
-
-
-def _two_class_logits_for_probability(torch, probability, *, dtype=None):
-    dtype = torch.float64 if dtype is None else dtype
-    logit = math.log(probability / (1.0 - probability))
-    return torch.tensor([[[logit, 0.0]]], dtype=dtype)
-
-
-def _skip_if_compile_disabled():
-    if os.environ.get("UNSLOTH_FUSED_CE_COMPILE_DISABLE", "0") == "1":
-        pytest.skip("UNSLOTH_FUSED_CE_COMPILE_DISABLE=1 disables fused-loss compile")
-
-
-def test_compute_dft_uses_unreduced_cross_entropy(monkeypatch):
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        original_cross_entropy = torch.nn.functional.cross_entropy
-        calls = []
-
-        def cross_entropy_spy(input, target, *args, **kwargs):
-            calls.append(dict(input=input, target=target, **kwargs))
-            return original_cross_entropy(input, target, *args, **kwargs)
-
-        monkeypatch.setattr(torch.nn.functional, "cross_entropy", cross_entropy_spy)
-
-        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30]]], dtype=torch.float64)
-        weight = torch.tensor([[0.10, 0.40], [-0.30, 0.20], [0.50, -0.60]], dtype=torch.float64)
-        labels = torch.tensor([[1, 999]])
-
-        compute_fused_dft_loss(
-            hidden,
-            weight,
-            None,
-            labels,
-            shift_labels=False,
-            ignore_index=999,
+            rtol=rtol,
+            atol=atol,
         )
 
-        assert len(calls) == 1
-        call = calls[0]
-        assert call["input"].shape == (2, 3)
-        assert call["input"].dtype == torch.float32
-        assert call["input"].is_contiguous()
-        assert call["target"].shape == (2,)
-        assert call["target"].is_contiguous()
-        assert call["reduction"] == "none"
-        assert call["ignore_index"] == 999
-        assert call["label_smoothing"] == 0.0
+
+def _skip_if_compile_unavailable():
+    # Only skip a missing generic toolchain; fused-loss graph failures must fail.
+    try:
+        compiled = torch.compile(lambda value: value + 1, fullgraph=True)
+        compiled(torch.ones(1))
+    except Exception as error:
+        torch._dynamo.reset()
+        pytest.skip(f"torch.compile toolchain unavailable: {type(error).__name__}")
+    torch._dynamo.reset()
 
 
-def test_compute_dft_single_token_closed_form_loss_and_gradient():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        hidden = torch.tensor([[[0.25, -0.50]]], dtype=torch.float64, requires_grad=True)
-        weight = torch.tensor(
-            [[0.20, -0.30], [-0.70, 0.40], [0.50, 0.10]],
-            dtype=torch.float64,
-            requires_grad=True,
-        )
-        bias = torch.tensor([0.05, -0.10, 0.20], dtype=torch.float64, requires_grad=True)
-        labels = torch.tensor([[2]])
-
-        loss, aux = compute_fused_dft_loss(
-            hidden,
-            weight,
-            bias,
-            labels,
-            shift_labels=False,
-        )
-        logits = _linear_logits(torch, hidden, weight, bias)
-        expected = _closed_form_dft(torch, logits, labels)
-        expected_hidden, expected_weight, expected_bias = _expected_linear_grads(
-            torch,
-            hidden,
-            weight,
-            bias,
-            expected["logit_grad"],
-        )
-
-        assert torch.allclose(loss, expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(aux[0], expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-        loss.backward()
-        assert torch.allclose(hidden.grad, expected_hidden, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(weight.grad, expected_weight, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(bias.grad, expected_bias, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-
-def test_compute_dft_gradient_uses_detached_probability_weight():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        hidden = _two_class_logits_for_probability(torch, 0.10).requires_grad_(True)
-        weight = torch.eye(2, dtype=torch.float64)
-        labels = torch.tensor([[0]])
-        loss, _ = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
-        loss.backward()
-
-        expected = _closed_form_dft(torch, hidden, labels)
-        probability = expected["probs"][0, 0]
-        nll = -torch.log(probability)
-        one_hot = torch.tensor([[1.0, 0.0]], dtype=expected["probs"].dtype)
-        # In the (q - one_hot) convention, differentiating -p log(p) adds
-        # the factor (1 - NLL); DFT intentionally omits it via detach().
-        nondetached_grad = probability * (1.0 - nll) * (expected["probs"] - one_hot)
-
-        assert torch.allclose(
-            hidden.grad,
-            expected["logit_grad"].view_as(hidden).to(dtype=hidden.dtype),
-            rtol=DIRECT_RTOL,
-            atol=DIRECT_ATOL,
-        )
-        assert torch.max(torch.abs(hidden.grad.float().view(1, 2) - nondetached_grad)) > 1e-3
-
-
-def test_compute_dft_minus_p_log_p_shape():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        weight = torch.eye(2, dtype=torch.float64)
-        labels = torch.tensor([[0]])
-        probabilities = [0.99, math.exp(-1.0), 1e-4]
-        observed = []
-        expected_values = []
-
-        for probability in probabilities:
-            hidden = _two_class_logits_for_probability(torch, probability).requires_grad_(True)
-            loss, aux = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
-            expected = _closed_form_dft(torch, hidden, labels)
-            observed.append(loss.detach())
-            expected_values.append(expected["loss"])
-            assert torch.allclose(loss, expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-            assert torch.allclose(aux[0], expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-        assert observed[1] > observed[0]
-        assert observed[1] > observed[2]
-        assert expected_values[2] < torch.tensor(1e-3, dtype=expected_values[2].dtype)
-
-
-def test_compute_dft_low_probability_gradient_vanishes():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        weight = torch.eye(2, dtype=torch.float64)
-        labels = torch.tensor([[0]])
-
-        low_hidden = _two_class_logits_for_probability(torch, 1e-5).requires_grad_(True)
-        low_loss, _ = compute_fused_dft_loss(low_hidden, weight, None, labels, shift_labels=False)
-        low_loss.backward()
-
-        peak_hidden = _two_class_logits_for_probability(torch, math.exp(-1.0)).requires_grad_(True)
-        peak_loss, _ = compute_fused_dft_loss(peak_hidden, weight, None, labels, shift_labels=False)
-        peak_loss.backward()
-
-        assert torch.linalg.vector_norm(low_hidden.grad) < torch.linalg.vector_norm(peak_hidden.grad) * 1e-3
-
-
-def test_compute_dft_ignore_index_zeroes_loss_and_grad_rows():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        hidden = torch.tensor([[[0.40, -0.20], [9.0, -7.0]]], dtype=torch.float64, requires_grad=True)
-        weight = torch.tensor(
-            [[0.30, -0.10], [0.20, 0.50], [-0.40, 0.70]],
-            dtype=torch.float64,
-            requires_grad=True,
-        )
-        bias = torch.tensor([0.10, -0.20, 0.30], dtype=torch.float64, requires_grad=True)
-        labels = torch.tensor([[1, -100]])
-
-        loss, _ = compute_fused_dft_loss(hidden, weight, bias, labels, shift_labels=False)
-        logits = _linear_logits(torch, hidden, weight, bias)
-        expected = _closed_form_dft(torch, logits, labels)
-        expected_hidden, expected_weight, expected_bias = _expected_linear_grads(
-            torch,
-            hidden,
-            weight,
-            bias,
-            expected["logit_grad"],
-        )
-
-        assert expected["token_values"][1] == 0
-        assert torch.allclose(loss, expected["loss"], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        loss.backward()
-        assert torch.count_nonzero(hidden.grad[0, 1]) == 0
-        assert torch.allclose(hidden.grad, expected_hidden, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(weight.grad, expected_weight, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(bias.grad, expected_bias, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
-def test_unreduced_ce_ignored_nonfinite_row_has_finite_zero_gradient(device):
-    torch = pytest.importorskip("torch")
-    if device == "cuda" and not torch.cuda.is_available():
+@pytest.mark.parametrize("device_name", ["cpu", "cuda"])
+def test_fused_dft_matches_reference(fused_losses, device_name):
+    if device_name == "cuda" and not torch.cuda.is_available():
         pytest.skip("requires CUDA")
 
-    logits = torch.tensor(
-        [[0.20, -0.10, 0.30], [float("inf"), float("-inf"), float("nan")]],
+    device = torch.device(device_name)
+    dtype = torch.float64 if device_name == "cpu" else torch.float32
+    wrapper_rtol, direct_rtol, atol = (
+        (1e-5, 1e-6, 1e-7)
+        if device_name == "cpu"
+        else (1e-4, 1e-4, 1e-6)
+    )
+    hidden, weight, bias, labels = _make_inputs(device, dtype)
+    shifted_labels = _shift_labels(labels)
+    valid_per_chunk = [
+        int((chunk != -100).sum())
+        for chunk in torch.chunk(shifted_labels.reshape(-1), 2)
+    ]
+    assert valid_per_chunk == [1, 2]
+
+    transforms = {
+        "logit_scale_multiply": 1.7,
+        "logit_scale_divide": 0.8,
+        "logit_softcapping": 2.25,
+    }
+    expected = _run_reference(hidden, weight, bias, labels, **transforms)
+    nondetached = _run_reference(
+        hidden,
+        weight,
+        bias,
+        labels,
+        detach_weight=False,
+        **transforms,
+    )
+    assert torch.max(torch.abs(expected[1] - nondetached[1])) > 1e-3
+    direct = _run_direct(
+        fused_losses,
+        hidden,
+        weight,
+        bias,
+        shifted_labels,
+        shift_labels=False,
+        **transforms,
+    )
+    chunked = _run_wrapper(
+        fused_losses.unsloth_fused_dft_loss,
+        hidden,
+        weight,
+        bias,
+        labels,
+        torch_compile=False,
+        n_chunks=2,
+        scaling=7.0,
+        **transforms,
+    )
+
+    _assert_result_close(direct, expected, rtol=direct_rtol, atol=atol)
+    _assert_result_close(chunked, expected, rtol=wrapper_rtol, atol=atol)
+
+
+def test_fused_dft_ignored_nonfinite_row_is_safe(fused_losses):
+    max_float = torch.finfo(torch.float32).max
+    hidden = torch.tensor(
+        [[[0.20, -0.10], [max_float, max_float]]],
         dtype=torch.float32,
-        device=device,
-        requires_grad=True,
     )
-    labels = torch.tensor([1, -100], device=device)
-    token_nll = torch.nn.functional.cross_entropy(
-        input=logits,
-        target=labels,
-        reduction="none",
-        ignore_index=-100,
-        label_smoothing=0.0,
+    weight = torch.tensor(
+        [[0.30, -0.10], [2.0, -2.0], [-2.0, 2.0]],
+        dtype=torch.float32,
     )
-    token_nll.sum().backward()
+    bias = torch.tensor([0.10, -0.20, 0.30], dtype=torch.float32)
+    labels = torch.tensor([[1, -100]])
+    assert torch.isnan(torch.nn.functional.linear(hidden, weight, bias)[0, 1]).any()
 
-    native_ce_is_safe = bool(
-        torch.isfinite(token_nll).all()
-        and torch.isfinite(logits.grad).all()
-        and torch.count_nonzero(logits.grad[1]) == 0
+    actual = _run_direct(
+        fused_losses,
+        hidden,
+        weight,
+        bias,
+        labels,
+        shift_labels=False,
+        logit_softcapping=1.0,
     )
-    if not native_ce_is_safe:
-        pytest.xfail("native unreduced CE requires DFT ignored-row sanitization on this backend")
+    expected = _run_reference(
+        hidden[:, :1],
+        weight,
+        bias,
+        labels[:, :1],
+        shift_labels=False,
+        logit_softcapping=1.0,
+    )
 
-    assert token_nll[1] == 0
-
-
-def test_compute_dft_ignored_nonfinite_row_has_finite_zero_gradient():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        max_float = torch.finfo(torch.float32).max
-        hidden = torch.tensor(
-            [[[0.20, -0.10], [max_float, max_float]]],
-            dtype=torch.float32,
-            requires_grad=True,
-        )
-        weight = torch.tensor(
-            [[0.30, -0.10], [2.0, -2.0], [-2.0, 2.0]],
-            dtype=torch.float32,
-            requires_grad=True,
-        )
-        bias = torch.tensor([0.10, -0.20, 0.30], dtype=torch.float32, requires_grad=True)
-        labels = torch.tensor([[1, -100]])
-        raw_logits = _linear_logits(torch, hidden, weight, bias)
-        assert torch.isnan(raw_logits[0, 1]).any()
-
-        loss, aux = compute_fused_dft_loss(
-            hidden,
-            weight,
-            bias,
-            labels,
-            shift_labels=False,
-            logit_softcapping=1.0,
-        )
-        expected = _reference_dft_loss(
-            torch,
-            hidden[:, :1],
-            weight,
-            bias,
-            labels[:, :1],
-            shift_labels=False,
-            logit_softcapping=1.0,
-        )
-
-        assert torch.isfinite(loss)
-        assert torch.allclose(loss, expected, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(aux[0], expected, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        loss.backward()
-        assert torch.isfinite(hidden.grad).all()
-        assert torch.isfinite(weight.grad).all()
-        assert torch.isfinite(bias.grad).all()
-        assert torch.count_nonzero(hidden.grad[0, 1]) == 0
+    torch.testing.assert_close(actual[0], expected[0], rtol=1e-5, atol=1e-7)
+    torch.testing.assert_close(actual[1][:, :1], expected[1], rtol=1e-5, atol=1e-7)
+    assert torch.count_nonzero(actual[1][:, 1:]) == 0
+    torch.testing.assert_close(actual[2], expected[2], rtol=1e-5, atol=1e-7)
+    torch.testing.assert_close(actual[3], expected[3], rtol=1e-5, atol=1e-7)
+    assert all(torch.isfinite(tensor).all() for tensor in actual)
 
 
-def test_compute_dft_custom_ignore_index_is_safe_for_out_of_vocab_label():
-    torch = pytest.importorskip("torch")
+def test_fused_dft_all_ignored_returns_connected_zero(fused_losses):
+    torch.manual_seed(0)
+    hidden = torch.randn(1, 4, 3, dtype=torch.float64)
+    weight = torch.randn(6, 3, dtype=torch.float64)
+    bias = torch.randn(6, dtype=torch.float64)
+    labels = torch.full((1, 4), -100)
 
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+    result = _run_wrapper(
+        fused_losses.unsloth_fused_dft_loss,
+        hidden,
+        weight,
+        bias,
+        labels,
+        torch_compile=False,
+        n_chunks=2,
+    )
 
-        hidden = torch.tensor([[[0.20, -0.10]]], dtype=torch.float64, requires_grad=True)
-        weight = torch.tensor([[0.30, 0.40], [-0.20, 0.10]], dtype=torch.float64, requires_grad=True)
-        bias = torch.tensor([0.05, -0.15], dtype=torch.float64, requires_grad=True)
-        labels = torch.tensor([[999]])
-
-        loss, aux = compute_fused_dft_loss(
-            hidden,
-            weight,
-            bias,
-            labels,
-            shift_labels=False,
-            ignore_index=999,
-        )
-        assert torch.isfinite(loss)
-        assert float(loss.detach()) == 0.0
-        assert float(aux[0].detach()) == 0.0
-        loss.backward()
-        assert torch.count_nonzero(hidden.grad) == 0
-        assert torch.count_nonzero(weight.grad) == 0
-        assert torch.count_nonzero(bias.grad) == 0
+    assert torch.isfinite(result[0])
+    assert float(result[0]) == 0.0
+    assert all(torch.count_nonzero(gradient) == 0 for gradient in result[1:])
 
 
-def test_compute_dft_shift_labels_false_accepts_noncontiguous_labels():
-    torch = pytest.importorskip("torch")
+@pytest.mark.parametrize("ce_first", [False, True], ids=["fresh-dft", "ce-first"])
+def test_fused_dft_compiled_matches_eager(fused_losses, ce_first):
+    if os.environ.get("UNSLOTH_FUSED_CE_COMPILE_DISABLE", "0") == "1":
+        pytest.skip("UNSLOTH_FUSED_CE_COMPILE_DISABLE=1 disables fused-loss compile")
+    _skip_if_compile_unavailable()
 
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+    hidden, weight, bias, labels = _make_inputs(torch.device("cpu"), torch.float32)
+    eager = _run_wrapper(
+        fused_losses.unsloth_fused_dft_loss,
+        hidden,
+        weight,
+        bias,
+        labels,
+        torch_compile=False,
+        n_chunks=2,
+        shift_labels=False,
+    )
 
-        hidden = torch.tensor(
-            [
-                [[0.20, -0.10], [0.50, 0.30]],
-                [[-0.70, 0.40], [0.90, -0.20]],
-                [[0.10, 0.80], [-0.30, 0.60]],
-            ],
-            dtype=torch.float64,
-        )
-        weight = torch.tensor([[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10]], dtype=torch.float64)
-        labels = torch.tensor([[0, 1, 2], [2, 1, 0]]).t()
-        assert not labels.is_contiguous()
-
-        loss, aux = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
-        expected, expected_aux = compute_fused_dft_loss(
-            hidden,
-            weight,
-            None,
-            labels.contiguous(),
-            shift_labels=False,
-        )
-
-        assert torch.allclose(loss, expected, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(aux[0], expected_aux[0], rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-
-def test_compute_dft_n_items_int_and_tensor_override_valid_count_divisor():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        hidden = torch.tensor([[[0.10, 0.30], [-0.40, 0.20]]], dtype=torch.float64)
-        weight = torch.tensor([[0.20, -0.50], [0.60, 0.10], [-0.30, 0.40]], dtype=torch.float64)
-        labels = torch.tensor([[0, 2]])
-
-        default_loss, _ = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
-        int_loss, _ = compute_fused_dft_loss(hidden, weight, None, labels, n_items=4, shift_labels=False)
-        tensor_loss, _ = compute_fused_dft_loss(
-            hidden,
-            weight,
-            None,
-            labels,
-            n_items=torch.tensor(4),
-            shift_labels=False,
-        )
-
-        assert torch.allclose(int_loss, default_loss / 2, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(tensor_loss, int_loss, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-
-def test_compute_dft_zero_n_items_uses_one_as_divisor():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30]]], dtype=torch.float64)
-        weight = torch.tensor([[0.10, 0.40], [-0.30, 0.20], [0.50, -0.60]], dtype=torch.float64)
-        labels = torch.tensor([[1, 2]])
-
-        default_loss, _ = compute_fused_dft_loss(hidden, weight, None, labels, shift_labels=False)
-        zero_divisor_loss, _ = compute_fused_dft_loss(
-            hidden,
-            weight,
-            None,
-            labels,
-            n_items=0,
-            shift_labels=False,
-        )
-
-        assert torch.isfinite(zero_divisor_loss)
-        assert torch.allclose(zero_divisor_loss, default_loss * 2, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-
-def test_compute_dft_logit_transforms_apply_in_implemented_order():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        hidden = torch.tensor([[[3.25, -1.75], [0.50, 2.20]]], dtype=torch.float64, requires_grad=True)
-        weight = torch.tensor(
-            [[1.20, -0.70], [-1.50, 0.90], [0.30, 1.10]],
-            dtype=torch.float64,
-            requires_grad=True,
-        )
-        bias = torch.tensor([0.20, -0.30, 0.40], dtype=torch.float64, requires_grad=True)
-        labels = torch.tensor([[0, 2]])
-        kwargs = dict(
-            logit_scale_multiply=1.7,
-            logit_scale_divide=0.8,
-            logit_softcapping=2.25,
-        )
-
-        ref_hidden = _clone_leaf(hidden)
-        ref_weight = _clone_leaf(weight)
-        ref_bias = _clone_leaf(bias)
-        reference_loss = _reference_dft_loss(
-            torch,
-            ref_hidden,
-            ref_weight,
-            ref_bias,
-            labels,
-            **kwargs,
-        )
-        actual_loss, _ = compute_fused_dft_loss(hidden, weight, bias, labels, shift_labels=False, **kwargs)
-
-        assert torch.allclose(actual_loss, reference_loss, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        actual_loss.backward()
-        reference_loss.backward()
-        assert torch.allclose(hidden.grad, ref_hidden.grad, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(weight.grad, ref_weight.grad, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-        assert torch.allclose(bias.grad, ref_bias.grad, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-        no_transform_loss, _ = compute_fused_dft_loss(
-            hidden.detach(),
-            weight.detach(),
-            bias.detach(),
-            labels,
-            shift_labels=False,
-        )
-        zero_transform_loss, _ = compute_fused_dft_loss(
-            hidden.detach(),
-            weight.detach(),
-            bias.detach(),
-            labels,
-            shift_labels=False,
-            logit_scale_multiply=0,
-            logit_scale_divide=0,
-            logit_softcapping=0,
-        )
-        assert torch.allclose(zero_transform_loss, no_transform_loss, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
-
-
-def test_compute_dft_rejects_label_smoothing():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-
-        hidden = torch.randn(1, 1, 2, dtype=torch.float64)
-        weight = torch.randn(3, 2, dtype=torch.float64)
-        labels = torch.tensor([[0]])
-
-        with pytest.raises(ValueError, match="label_smoothing"):
-            compute_fused_dft_loss(
+    with _compile_flag_guard(fused_losses):
+        if ce_first:
+            _run_wrapper(
+                fused_losses.unsloth_fused_ce_loss,
                 hidden,
                 weight,
-                None,
+                bias,
                 labels,
+                torch_compile=True,
+                n_chunks=2,
+                shift_labels=False,
+            )
+            assert fused_losses._FUSED_CE_COMPILE_SUPPORTED is True
+            assert (
+                fused_losses.compute_fused_ce_loss
+                in fused_losses._FUSED_CE_COMPILE_FASTPATH_PROVEN
+            )
+
+        compiled = _run_wrapper(
+            fused_losses.unsloth_fused_dft_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=True,
+            n_chunks=2,
+            shift_labels=False,
+        )
+        assert fused_losses._FUSED_CE_COMPILE_SUPPORTED is True
+        assert (
+            fused_losses.compute_fused_dft_loss
+            in fused_losses._FUSED_CE_COMPILE_FASTPATH_PROVEN
+        )
+
+    _assert_result_close(compiled, eager)
+
+
+def test_fused_dft_rejects_label_smoothing_without_poisoning_compile(fused_losses):
+    hidden, weight, bias, labels = _make_inputs(torch.device("cpu"), torch.float32)
+
+    with pytest.raises(ValueError, match="label_smoothing"):
+        fused_losses.compute_fused_dft_loss(
+            hidden,
+            weight,
+            bias,
+            labels,
+            shift_labels=False,
+            label_smoothing=0.1,
+        )
+
+    with _compile_flag_guard(fused_losses):
+        with pytest.raises(ValueError, match="label_smoothing"):
+            fused_losses.unsloth_fused_dft_loss(
+                trainer=None,
+                hidden_states=hidden,
+                lm_head_weight=weight,
+                lm_head_bias=bias,
+                labels=labels,
+                torch_compile=True,
+                n_chunks=2,
                 shift_labels=False,
                 label_smoothing=0.1,
             )
-
-
-def test_unsloth_fused_dft_matches_compute_for_preshifted_one_chunk():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
-        wrapper = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=1,
-            shift_labels=False,
-        )
-        direct = _run_direct(
-            torch,
-            compute_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            shift_labels=False,
-        )
-
-        _assert_wrapper_results_close(torch, wrapper, direct)
-
-
-def test_unsloth_fused_dft_chunking_invariant_value_and_gradients():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
-        baseline = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=1,
-            shift_labels=False,
-        )
-
-        for n_chunks in (2, 20):
-            chunked = _run_wrapper(
-                torch,
-                unsloth_fused_dft_loss,
-                hidden,
-                weight,
-                bias,
-                labels,
-                torch_compile=False,
-                n_chunks=n_chunks,
-                shift_labels=False,
-            )
-            _assert_wrapper_results_close(torch, chunked, baseline, message=f"n_chunks={n_chunks}")
-
-
-def test_unsloth_fused_dft_uses_shared_automatic_chunk_sizer(monkeypatch):
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
-
-        calls = []
-
-        def get_chunk_size(bsz, qlen, vocab_size, target_gb=None):
-            calls.append((bsz, qlen, vocab_size, target_gb))
-            return 2
-
-        monkeypatch.setattr(cross_entropy_loss, "get_chunk_size", get_chunk_size)
-        monkeypatch.setattr(cross_entropy_loss, "TARGET_GB", None)
-        monkeypatch.setattr(cross_entropy_loss, "N_CHUNKS", None)
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
-        automatic = _run_wrapper(
-            torch,
-            cross_entropy_loss.unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            shift_labels=False,
-        )
-        assert calls == [(2, 3, 5, None)]
-
-        calls.clear()
-        explicit = _run_wrapper(
-            torch,
-            cross_entropy_loss.unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-        )
-        assert calls == []
-        _assert_wrapper_results_close(torch, automatic, explicit)
-
-
-def test_unsloth_fused_dft_wrapper_uses_global_divisor_not_per_chunk():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30], [-0.70, 0.40], [0.90, -0.20]]], dtype=torch.float64)
-        weight = torch.tensor([[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10]], dtype=torch.float64)
-        bias = torch.tensor([0.05, -0.10, 0.20], dtype=torch.float64)
-        labels = torch.tensor([[0, -100, 2, -100]])
-
-        loss, _, _, _ = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-        )
-
-        logits = _linear_logits(torch, hidden, weight, bias)
-        closed_form = _closed_form_dft(torch, logits, labels)
-        token_values = closed_form["token_values"]
-        global_loss = (token_values[0] + token_values[2]) / 2
-        per_chunk_bug_loss = token_values[0] + token_values[2]
-
-        assert torch.allclose(loss, global_loss, rtol=WRAPPER_RTOL, atol=WRAPPER_ATOL)
-        assert torch.abs(loss - per_chunk_bug_loss) > 1e-3
-
-
-def test_unsloth_fused_dft_overwrite_true_value_and_no_corruption():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
-        expected = _run_direct(
-            torch,
-            compute_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            shift_labels=False,
-        )
-        overwritten = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-            overwrite=True,
-        )
-
-        _assert_wrapper_results_close(torch, overwritten, expected)
-
-
-def test_unsloth_fused_dft_default_shift_masks_final_position():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30], [-0.70, 0.40], [0.90, -0.20]]], dtype=torch.float64)
-        weight = torch.tensor(
-            [[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10], [-0.50, 0.20], [0.30, 0.80]],
-            dtype=torch.float64,
-        )
-        bias = torch.tensor([0.05, -0.10, 0.20, -0.15, 0.25], dtype=torch.float64)
-        labels = torch.tensor([[0, 1, 2, 3]])
-        labels_with_different_first_source = torch.tensor([[4, 1, 2, 3]])
-
-        baseline = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=1,
-        )
-        changed_first_label = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels_with_different_first_source,
-            torch_compile=False,
-            n_chunks=1,
-        )
-
-        _assert_wrapper_results_close(torch, changed_first_label, baseline)
-        assert torch.count_nonzero(baseline[1][0, -1]) == 0
-
-
-def test_unsloth_fused_dft_mask_applies_to_shifted_targets():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30], [-0.70, 0.40], [0.90, -0.20]]], dtype=torch.float64)
-        weight = torch.tensor([[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10], [-0.50, 0.20]], dtype=torch.float64)
-        bias = torch.tensor([0.05, -0.10, 0.20, -0.15], dtype=torch.float64)
-        labels = torch.tensor([[0, 1, 2, 3]])
-        mask = torch.tensor([[1, 1, 0, 1]])
-        expected_preshifted_labels = torch.tensor([[1, -100, 3, -100]])
-
-        masked = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            mask=mask,
-            torch_compile=False,
-            n_chunks=1,
-        )
-        explicit = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            expected_preshifted_labels,
-            torch_compile=False,
-            n_chunks=1,
-            shift_labels=False,
-        )
-
-        _assert_wrapper_results_close(torch, masked, explicit)
-        assert torch.count_nonzero(masked[1][0, 1]) == 0
-
-
-def test_unsloth_fused_dft_shift_labels_false_uses_labels_as_targets():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden = torch.tensor([[[0.10, -0.20], [0.30, 0.40], [-0.50, 0.60]]], dtype=torch.float64)
-        weight = torch.tensor([[0.20, -0.10], [-0.40, 0.30], [0.50, 0.70]], dtype=torch.float64)
-        bias = torch.tensor([0.05, -0.15, 0.25], dtype=torch.float64)
-        labels = torch.tensor([[0, 1, 2]])
-
-        wrapper = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=1,
-            shift_labels=False,
-        )
-        direct = _run_direct(
-            torch,
-            compute_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            shift_labels=False,
-        )
-
-        _assert_wrapper_results_close(torch, wrapper, direct)
-        assert torch.count_nonzero(wrapper[1][0, -1]) > 0
-
-
-def test_unsloth_fused_dft_shift_labels_false_ignores_mask_by_contract():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
-        mask = torch.zeros_like(labels)
-
-        without_mask = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-        )
-        with_mask = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            mask=mask,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-        )
-
-        _assert_wrapper_results_close(torch, with_mask, without_mask)
-
-
-def test_unsloth_fused_dft_custom_ignore_index_through_wrapper():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30], [-0.70, 0.40]]], dtype=torch.float64)
-        weight = torch.tensor([[0.40, -0.30], [-0.20, 0.60], [0.70, 0.10]], dtype=torch.float64)
-        bias = torch.tensor([0.05, -0.10, 0.20], dtype=torch.float64)
-        labels = torch.tensor([[0, 999, 2]])
-
-        loss, hidden_grad, weight_grad, bias_grad = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=1,
-            ignore_index=999,
-        )
-
-        assert torch.isfinite(loss)
-        assert torch.count_nonzero(hidden_grad[0, 0]) == 0
-        assert torch.count_nonzero(hidden_grad[0, 1]) > 0
-        assert torch.isfinite(weight_grad).all()
-        assert torch.isfinite(bias_grad).all()
-
-
-def test_unsloth_fused_dft_scaling_nonzero_preserves_public_loss_and_gradients():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch)
-        unscaled = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-            scaling=None,
-        )
-        scaled = _run_wrapper(
-            torch,
-            unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-            scaling=7.0,
-        )
-
-        _assert_wrapper_results_close(torch, scaled, unscaled)
-
-
-def test_unsloth_fused_dft_all_ignored_returns_connected_zero():
-    torch = pytest.importorskip("torch")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        hidden = torch.randn(1, 4, 3, dtype=torch.float64, requires_grad=True)
-        weight = torch.randn(6, 3, dtype=torch.float64, requires_grad=True)
-        bias = torch.randn(6, dtype=torch.float64, requires_grad=True)
-        labels = torch.full((1, 4), -100)
-
-        loss = unsloth_fused_dft_loss(
-            trainer=None,
-            hidden_states=hidden,
-            lm_head_weight=weight,
-            lm_head_bias=bias,
-            labels=labels,
-            torch_compile=False,
-            n_chunks=2,
-        )
-        assert torch.isfinite(loss)
-        assert float(loss.detach()) == 0.0
-        loss.backward()
-        assert torch.count_nonzero(hidden.grad) == 0
-        assert torch.count_nonzero(weight.grad) == 0
-        assert torch.count_nonzero(bias.grad) == 0
-
-
-def test_unsloth_fused_dft_compiled_parity_and_probe_success():
-    torch = pytest.importorskip("torch")
-    _skip_if_compile_disabled()
-
-    with _lightweight_unsloth_zoo_import():
-        import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch, dtype=torch.float32)
-        eager = _run_wrapper(
-            torch,
-            cross_entropy_loss.unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-        )
-
-        with _compile_flag_guard(torch, cross_entropy_loss):
-            compiled = _run_wrapper(
-                torch,
-                cross_entropy_loss.unsloth_fused_dft_loss,
-                hidden,
-                weight,
-                bias,
-                labels,
-                torch_compile=True,
-                n_chunks=2,
-                shift_labels=False,
-            )
-            assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is True
-
-        _assert_wrapper_results_close(torch, compiled, eager)
-
-
-def test_unsloth_fused_dft_label_smoothing_raise_does_not_poison_compile_flag():
-    torch = pytest.importorskip("torch")
-    _skip_if_compile_disabled()
-
-    with _lightweight_unsloth_zoo_import():
-        import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch, dtype=torch.float32)
-
-        with _compile_flag_guard(torch, cross_entropy_loss):
-            with pytest.raises(ValueError, match="label_smoothing"):
-                cross_entropy_loss.unsloth_fused_dft_loss(
-                    trainer=None,
-                    hidden_states=hidden.detach().clone().requires_grad_(True),
-                    lm_head_weight=weight.detach().clone().requires_grad_(True),
-                    lm_head_bias=bias.detach().clone().requires_grad_(True),
-                    labels=labels.detach().clone(),
-                    torch_compile=True,
-                    n_chunks=2,
-                    shift_labels=False,
-                    label_smoothing=0.1,
-                )
-            assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is None
-
-
-def test_fused_ce_then_dft_compile_order():
-    torch = pytest.importorskip("torch")
-    _skip_if_compile_disabled()
-
-    with _lightweight_unsloth_zoo_import():
-        import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
-
-        hidden, weight, bias, labels = _make_wrapper_inputs(torch, dtype=torch.float32)
-        eager_ce = _run_wrapper(
-            torch,
-            cross_entropy_loss.unsloth_fused_ce_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-        )
-        eager_dft = _run_wrapper(
-            torch,
-            cross_entropy_loss.unsloth_fused_dft_loss,
-            hidden,
-            weight,
-            bias,
-            labels,
-            torch_compile=False,
-            n_chunks=2,
-            shift_labels=False,
-        )
-
-        with _compile_flag_guard(torch, cross_entropy_loss):
-            compiled_ce = _run_wrapper(
-                torch,
-                cross_entropy_loss.unsloth_fused_ce_loss,
-                hidden,
-                weight,
-                bias,
-                labels,
-                torch_compile=True,
-                n_chunks=2,
-                shift_labels=False,
-            )
-            assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is True
-
-            compiled_dft = _run_wrapper(
-                torch,
-                cross_entropy_loss.unsloth_fused_dft_loss,
-                hidden,
-                weight,
-                bias,
-                labels,
-                torch_compile=True,
-                n_chunks=2,
-                shift_labels=False,
-            )
-            assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is True
-
-        _assert_wrapper_results_close(torch, compiled_ce, eager_ce, message="CE")
-        _assert_wrapper_results_close(torch, compiled_dft, eager_dft, message="DFT")
-
-
-def test_unsloth_fused_dft_exports_public_symbol():
-    pytest.importorskip("torch")
-    pytest.importorskip("triton")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses import unsloth_fused_dft_loss
-        from unsloth_zoo.loss_utils import unsloth_fused_dft_loss as exported
-
-        assert exported is unsloth_fused_dft_loss
-
-
-def test_unsloth_fused_dft_cuda_smoke():
-    torch = pytest.importorskip("torch")
-    if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-        pytest.skip("requires CUDA")
-
-    with _lightweight_unsloth_zoo_import():
-        from unsloth_zoo.fused_losses.cross_entropy_loss import unsloth_fused_dft_loss
-
-        torch.manual_seed(1)
-        device = torch.device("cuda")
-        hidden = torch.randn(1, 6, 8, device=device, dtype=torch.float32, requires_grad=True)
-        weight = torch.randn(11, 8, device=device, dtype=torch.float32, requires_grad=True)
-        bias = torch.randn(11, device=device, dtype=torch.float32, requires_grad=True)
-        labels = torch.randint(0, 11, (1, 6), device=device)
-        labels[0, 3] = -100
-
-        ref_hidden = _clone_leaf(hidden)
-        ref_weight = _clone_leaf(weight)
-        ref_bias = _clone_leaf(bias)
-        loss = unsloth_fused_dft_loss(
-            trainer=None,
-            hidden_states=hidden,
-            lm_head_weight=weight,
-            lm_head_bias=bias,
-            labels=labels,
-            torch_compile=False,
-            n_chunks=2,
-        )
-        ref_loss = _reference_dft_loss(
-            torch,
-            ref_hidden,
-            ref_weight,
-            ref_bias,
-            labels,
-            shift_labels=True,
-        )
-
-        assert torch.allclose(loss, ref_loss, rtol=CUDA_RTOL, atol=CUDA_ATOL)
-        loss.backward()
-        ref_loss.backward()
-        assert torch.allclose(hidden.grad, ref_hidden.grad, rtol=CUDA_RTOL, atol=CUDA_ATOL)
-        assert torch.allclose(weight.grad, ref_weight.grad, rtol=CUDA_RTOL, atol=CUDA_ATOL)
-        assert torch.allclose(bias.grad, ref_bias.grad, rtol=CUDA_RTOL, atol=CUDA_ATOL)
+        assert fused_losses._FUSED_CE_COMPILE_SUPPORTED is None
+        assert fused_losses._FUSED_CE_COMPILE_FASTPATH_PROVEN == set()

--- a/tests/test_fused_dft_loss.py
+++ b/tests/test_fused_dft_loss.py
@@ -68,12 +68,19 @@ def _lightweight_unsloth_zoo_import():
 @contextmanager
 def _compile_flag_guard(torch, cross_entropy_loss):
     previous = cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED
+    proven = getattr(cross_entropy_loss, "_FUSED_CE_COMPILE_FASTPATH_PROVEN", None)
+    previous_proven = None if proven is None else set(proven)
     torch._dynamo.reset()
     cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = None
+    if proven is not None:
+        proven.clear()
     try:
         yield
     finally:
         cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = previous
+        if proven is not None:
+            proven.clear()
+            proven.update(previous_proven)
         torch._dynamo.reset()
 
 
@@ -314,6 +321,46 @@ def _skip_if_compile_disabled():
         pytest.skip("UNSLOTH_FUSED_CE_COMPILE_DISABLE=1 disables fused-loss compile")
 
 
+def test_compute_dft_uses_unreduced_cross_entropy(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    with _lightweight_unsloth_zoo_import():
+        from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
+
+        original_cross_entropy = torch.nn.functional.cross_entropy
+        calls = []
+
+        def cross_entropy_spy(input, target, *args, **kwargs):
+            calls.append(dict(input=input, target=target, **kwargs))
+            return original_cross_entropy(input, target, *args, **kwargs)
+
+        monkeypatch.setattr(torch.nn.functional, "cross_entropy", cross_entropy_spy)
+
+        hidden = torch.tensor([[[0.20, -0.10], [0.50, 0.30]]], dtype=torch.float64)
+        weight = torch.tensor([[0.10, 0.40], [-0.30, 0.20], [0.50, -0.60]], dtype=torch.float64)
+        labels = torch.tensor([[1, 999]])
+
+        compute_fused_dft_loss(
+            hidden,
+            weight,
+            None,
+            labels,
+            shift_labels=False,
+            ignore_index=999,
+        )
+
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["input"].shape == (2, 3)
+        assert call["input"].dtype == torch.float32
+        assert call["input"].is_contiguous()
+        assert call["target"].shape == (2,)
+        assert call["target"].is_contiguous()
+        assert call["reduction"] == "none"
+        assert call["ignore_index"] == 999
+        assert call["label_smoothing"] == 0.0
+
+
 def test_compute_dft_single_token_closed_form_loss_and_gradient():
     torch = pytest.importorskip("torch")
 
@@ -465,7 +512,40 @@ def test_compute_dft_ignore_index_zeroes_loss_and_grad_rows():
         assert torch.allclose(bias.grad, expected_bias, rtol=DIRECT_RTOL, atol=DIRECT_ATOL)
 
 
-def test_compute_dft_ignored_rows_sanitize_nonfinite_logits_before_log_softmax():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_unreduced_ce_ignored_nonfinite_row_has_finite_zero_gradient(device):
+    torch = pytest.importorskip("torch")
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    logits = torch.tensor(
+        [[0.20, -0.10, 0.30], [float("inf"), float("-inf"), float("nan")]],
+        dtype=torch.float32,
+        device=device,
+        requires_grad=True,
+    )
+    labels = torch.tensor([1, -100], device=device)
+    token_nll = torch.nn.functional.cross_entropy(
+        input=logits,
+        target=labels,
+        reduction="none",
+        ignore_index=-100,
+        label_smoothing=0.0,
+    )
+    token_nll.sum().backward()
+
+    native_ce_is_safe = bool(
+        torch.isfinite(token_nll).all()
+        and torch.isfinite(logits.grad).all()
+        and torch.count_nonzero(logits.grad[1]) == 0
+    )
+    if not native_ce_is_safe:
+        pytest.xfail("native unreduced CE requires DFT ignored-row sanitization on this backend")
+
+    assert token_nll[1] == 0
+
+
+def test_compute_dft_ignored_nonfinite_row_has_finite_zero_gradient():
     torch = pytest.importorskip("torch")
 
     with _lightweight_unsloth_zoo_import():
@@ -1178,7 +1258,7 @@ def test_unsloth_fused_dft_label_smoothing_raise_does_not_poison_compile_flag():
             assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is None
 
 
-def test_unsloth_fused_dft_compiles_when_flag_preset_true():
+def test_fused_ce_then_dft_compile_order():
     torch = pytest.importorskip("torch")
     _skip_if_compile_disabled()
 
@@ -1186,7 +1266,18 @@ def test_unsloth_fused_dft_compiles_when_flag_preset_true():
         import unsloth_zoo.fused_losses.cross_entropy_loss as cross_entropy_loss
 
         hidden, weight, bias, labels = _make_wrapper_inputs(torch, dtype=torch.float32)
-        eager = _run_wrapper(
+        eager_ce = _run_wrapper(
+            torch,
+            cross_entropy_loss.unsloth_fused_ce_loss,
+            hidden,
+            weight,
+            bias,
+            labels,
+            torch_compile=False,
+            n_chunks=2,
+            shift_labels=False,
+        )
+        eager_dft = _run_wrapper(
             torch,
             cross_entropy_loss.unsloth_fused_dft_loss,
             hidden,
@@ -1199,8 +1290,20 @@ def test_unsloth_fused_dft_compiles_when_flag_preset_true():
         )
 
         with _compile_flag_guard(torch, cross_entropy_loss):
-            cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = True
-            compiled = _run_wrapper(
+            compiled_ce = _run_wrapper(
+                torch,
+                cross_entropy_loss.unsloth_fused_ce_loss,
+                hidden,
+                weight,
+                bias,
+                labels,
+                torch_compile=True,
+                n_chunks=2,
+                shift_labels=False,
+            )
+            assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is True
+
+            compiled_dft = _run_wrapper(
                 torch,
                 cross_entropy_loss.unsloth_fused_dft_loss,
                 hidden,
@@ -1213,7 +1316,8 @@ def test_unsloth_fused_dft_compiles_when_flag_preset_true():
             )
             assert cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED is True
 
-        _assert_wrapper_results_close(torch, compiled, eager)
+        _assert_wrapper_results_close(torch, compiled_ce, eager_ce, message="CE")
+        _assert_wrapper_results_close(torch, compiled_dft, eager_dft, message="DFT")
 
 
 def test_unsloth_fused_dft_exports_public_symbol():

--- a/tests/test_fused_dft_loss.py
+++ b/tests/test_fused_dft_loss.py
@@ -551,20 +551,30 @@ def test_compute_dft_ignored_nonfinite_row_has_finite_zero_gradient():
     with _lightweight_unsloth_zoo_import():
         from unsloth_zoo.fused_losses.cross_entropy_loss import compute_fused_dft_loss
 
+        max_float = torch.finfo(torch.float32).max
         hidden = torch.tensor(
-            [[[0.20, -0.10], [1.0e40, -1.0e40]]],
-            dtype=torch.float64,
+            [[[0.20, -0.10], [max_float, max_float]]],
+            dtype=torch.float32,
             requires_grad=True,
         )
         weight = torch.tensor(
-            [[0.30, -0.10], [0.20, 0.50], [-0.40, 0.70]],
-            dtype=torch.float64,
+            [[0.30, -0.10], [2.0, -2.0], [-2.0, 2.0]],
+            dtype=torch.float32,
             requires_grad=True,
         )
-        bias = torch.tensor([0.10, -0.20, 0.30], dtype=torch.float64, requires_grad=True)
+        bias = torch.tensor([0.10, -0.20, 0.30], dtype=torch.float32, requires_grad=True)
         labels = torch.tensor([[1, -100]])
+        raw_logits = _linear_logits(torch, hidden, weight, bias)
+        assert torch.isnan(raw_logits[0, 1]).any()
 
-        loss, aux = compute_fused_dft_loss(hidden, weight, bias, labels, shift_labels=False)
+        loss, aux = compute_fused_dft_loss(
+            hidden,
+            weight,
+            bias,
+            labels,
+            shift_labels=False,
+            logit_softcapping=1.0,
+        )
         expected = _reference_dft_loss(
             torch,
             hidden[:, :1],
@@ -572,6 +582,7 @@ def test_compute_dft_ignored_nonfinite_row_has_finite_zero_gradient():
             bias,
             labels[:, :1],
             shift_labels=False,
+            logit_softcapping=1.0,
         )
 
         assert torch.isfinite(loss)

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -16,8 +16,10 @@
 
 __all__ = [
     "unsloth_fused_ce_loss",
+    "unsloth_fused_dft_loss",
     "apply_autograd_function",
     "compute_fused_ce_loss",
+    "compute_fused_dft_loss",
 ]
 
 import torch
@@ -46,9 +48,13 @@ try:
 except Exception:
     pass
 
-# Module-level flag: None = untested, True = works, False = skip compile.
+# Module-level compile flag shared by all inner fused losses (CE, DFT, etc.):
+# None = untested, True = works, False = skip compile. A loss that skips the
+# probe because another loss already set this True still gets one guarded
+# compiled fast-path call before it is considered proven.
 _FUSED_CE_COMPILE_SUPPORTED = None if \
     os.environ.get("UNSLOTH_FUSED_CE_COMPILE_DISABLE", "0") != "1" else False
+_FUSED_CE_COMPILE_FASTPATH_PROVEN = set()
 
 @functools.cache
 def _get_mapping(autograd):
@@ -132,6 +138,86 @@ def compute_fused_ce_loss(
     # Scale loss if needed for mixed precision training
     scaled_loss = loss * scaling if scaling is not None else loss
     # Must add .loss.detach otherwise autograd uses 2x VRAM
+    return scaled_loss, (loss.detach(),)
+pass
+
+
+def compute_fused_dft_loss(
+    hidden_states  : torch.Tensor,
+    lm_head_weight : torch.Tensor,
+    lm_head_bias   : Optional[torch.Tensor],
+    labels         : torch.Tensor,
+    n_items        : Optional[torch.Tensor] = None,
+    scaling        : Optional[float] = None,
+    shift_labels   : bool = True,
+    **kwargs,
+) -> Tuple[torch.Tensor, Tuple[torch.Tensor,],]:
+    """
+    Computes stop_gradient(exp(-NLL_t)) * NLL_t over target tokens.
+    The signature and return contract intentionally match compute_fused_ce_loss.
+    """
+    ignore_index = int(kwargs.get("ignore_index", -100))
+    label_smoothing = float(kwargs.get("label_smoothing", 0.0))
+    if label_smoothing != 0.0:
+        raise ValueError("Fused DFT loss does not support label_smoothing != 0.0")
+
+    device = lm_head_weight.device
+    if shift_labels:
+        _labels = torch.empty_like(labels, device = device)
+        _labels[..., :-1] = labels[..., 1:]
+        _labels[..., -1] = ignore_index
+        labels = _labels
+    else:
+        labels = labels.to(device = device)
+    pass
+
+    logits = torch.nn.functional.linear(
+        hidden_states.to(dtype = lm_head_weight.dtype, device = device),
+        lm_head_weight,
+        lm_head_bias,
+    )
+    vocab_size = lm_head_weight.shape[0]
+
+    # Apply the same logit transforms as fused CE before computing NLL.
+    logit_scale_multiply = kwargs.get("logit_scale_multiply", None)
+    logit_scale_divide = kwargs.get("logit_scale_divide", None)
+    logit_softcapping = kwargs.get("logit_softcapping", None)
+    if logit_scale_multiply != 0 and logit_scale_multiply is not None:
+        logits = logits * logit_scale_multiply
+    if logit_scale_divide != 0 and logit_scale_divide is not None:
+        logits = logits / logit_scale_divide
+    if logit_softcapping != 0 and logit_softcapping is not None:
+        logits = logits / logit_softcapping
+        logits = torch.tanh(logits)
+        logits = logits * logit_softcapping
+
+    flat_logits = logits.view(-1, vocab_size).float().contiguous()
+    flat_labels = labels.contiguous().view(-1).to(device = device).contiguous()
+    valid = flat_labels != ignore_index
+    safe_labels = flat_labels.masked_fill(~valid, 0)
+    # Ignored rows may contain non-finite logits; sanitize before log_softmax
+    # so both forward and backward remain hard-zeroed for ignored targets.
+    flat_logits = torch.where(
+        valid.unsqueeze(1),
+        flat_logits,
+        torch.zeros((), dtype = flat_logits.dtype, device = flat_logits.device),
+    )
+    logprobs = torch.nn.functional.log_softmax(flat_logits, dim = -1)
+    token_nll = -logprobs.gather(1, safe_labels.unsqueeze(1)).squeeze(1)
+    valid_float = valid.to(dtype = token_nll.dtype)
+    weights = torch.exp(-token_nll.detach()) * valid_float
+
+    if n_items is None:
+        divisor = valid_float.sum()
+    elif torch.is_tensor(n_items):
+        divisor = n_items.to(device = device, dtype = token_nll.dtype)
+    else:
+        divisor = torch.tensor(n_items, dtype = token_nll.dtype, device = device)
+    if divisor.numel() != 1: divisor = divisor.ravel()[0]
+    divisor = torch.where(divisor == 0, torch.ones_like(divisor), divisor)
+
+    loss = (token_nll * weights).sum() / divisor
+    scaled_loss = loss * scaling if scaling is not None else loss
     return scaled_loss, (loss.detach(),)
 pass
 
@@ -246,13 +332,16 @@ class UnslothFusedLoss(torch.autograd.Function):
 
         bsz, qlen, hd = hidden_states.shape
         accumulated_loss = torch.zeros(1, device = device)[0]
+        loss_name = "DFT" if loss_function is compute_fused_dft_loss else \
+            "CE" if loss_function is compute_fused_ce_loss else \
+            getattr(loss_function, "__name__", "custom")
         # Chunk hidden_states and labels
         if "n_chunks" in extra_kwargs:
             n_chunks = extra_kwargs.pop("n_chunks")
         else:
             n_chunks = get_chunk_size(bsz, qlen, vocab_size, target_gb = target_gb)
         if UNSLOTH_ENABLE_LOGGING:
-            logger.info(f"Fused CE Loss [bsz={bsz}][qlen={qlen}][vocab_size={vocab_size}][n_chunks={n_chunks}]")
+            logger.info(f"Fused {loss_name} Loss [bsz={bsz}][qlen={qlen}][vocab_size={vocab_size}][n_chunks={n_chunks}]")
         __shift_labels = torch.chunk(labels,                     n_chunks, dim = 0)
         __shift_states = torch.chunk(hidden_states.reshape(-1, hd), n_chunks, dim = 0)
         __grad_inputs  = torch.chunk(grad_inputs.view(-1, hd),   n_chunks, dim = 0)
@@ -381,6 +470,7 @@ class UnslothFusedLoss(torch.autograd.Function):
                     **extra_kwargs,
                 )
                 _FUSED_CE_COMPILE_SUPPORTED = True
+                _FUSED_CE_COMPILE_FASTPATH_PROVEN.add(loss_function)
             except Exception:
                 _FUSED_CE_COMPILE_SUPPORTED = False
                 torch._dynamo.reset()
@@ -422,8 +512,54 @@ class UnslothFusedLoss(torch.autograd.Function):
                 )
         else:
             # Fast path: compile status already known, original main branch loop
-            for (grad_inputs_j, hidden_states_j, labels_j,) in \
-                zip(__grad_inputs, __shift_states, __shift_labels,):
+            _iter = iter(zip(__grad_inputs, __shift_states, __shift_labels,))
+            if torch_compile and accumulate_chunk is not uncompiled_accumulate_chunk and \
+                loss_function not in _FUSED_CE_COMPILE_FASTPATH_PROVEN:
+
+                grad_inputs_j, hidden_states_j, labels_j = next(_iter)
+                try:
+                    accumulate_chunk(
+                        n_chunks = n_chunks,
+                        grad_inputs_j = grad_inputs_j,
+                        grad_lm_head = grad_lm_head,
+                        grad_lm_head_bias = grad_lm_head_bias,
+                        hidden_states_j = hidden_states_j,
+                        lm_head_weight = lm_head_weight,
+                        lm_head_bias = lm_head_bias,
+                        labels_j = labels_j,
+                        divisor = divisor,
+                        scaling = scaling,
+                        shift_labels = shift_labels,
+                        **extra_kwargs,
+                    )
+                    _FUSED_CE_COMPILE_FASTPATH_PROVEN.add(loss_function)
+                except Exception:
+                    _FUSED_CE_COMPILE_SUPPORTED = False
+                    torch._dynamo.reset()
+                    accumulated_loss.zero_()
+                    if not overwrite:
+                        grad_inputs.zero_()
+                    if grad_lm_head is not None: grad_lm_head.zero_()
+                    if grad_lm_head_bias is not None: grad_lm_head_bias.zero_()
+                    accumulate_chunk = uncompiled_accumulate_chunk
+                    if UNSLOTH_ENABLE_LOGGING:
+                        logger.info(f"Fused {loss_name} Loss compile failed on fast path; retrying without torch.compile")
+                    accumulate_chunk(
+                        n_chunks = n_chunks,
+                        grad_inputs_j = grad_inputs_j,
+                        grad_lm_head = grad_lm_head,
+                        grad_lm_head_bias = grad_lm_head_bias,
+                        hidden_states_j = hidden_states_j,
+                        lm_head_weight = lm_head_weight,
+                        lm_head_bias = lm_head_bias,
+                        labels_j = labels_j,
+                        divisor = divisor,
+                        scaling = scaling,
+                        shift_labels = shift_labels,
+                        **extra_kwargs,
+                    )
+
+            for (grad_inputs_j, hidden_states_j, labels_j,) in _iter:
                 accumulate_chunk(
                     n_chunks = n_chunks,
                     grad_inputs_j = grad_inputs_j,
@@ -576,6 +712,64 @@ def unsloth_fused_ce_loss(
 
     return apply_autograd_function(UnslothFusedLoss, dict(
         loss_function = compute_fused_ce_loss,
+        hidden_states = hidden_states,
+        lm_head_weight = lm_head_weight,
+        lm_head_bias = lm_head_bias,
+        labels = labels,
+        mask = mask,
+        n_items = n_items,
+        scaling = scaling,
+        shift_labels = shift_labels,
+        target_gb = target_gb,
+        torch_compile = torch_compile,
+        overwrite = overwrite,
+        extra_kwargs = kwargs,
+    ))
+pass
+
+def unsloth_fused_dft_loss(
+    trainer,
+    hidden_states  : torch.Tensor,
+    lm_head_weight : torch.Tensor,
+    lm_head_bias   : Optional[torch.Tensor],
+    labels         : torch.Tensor,
+    mask           : Optional[torch.Tensor] = None,
+    n_items        : Optional[torch.Tensor] = None,
+    scaling        : Optional[float] = None,
+    target_gb      : Optional[int] = None,
+    torch_compile  : Optional[bool] = True,
+    overwrite      : Optional[bool] = False,
+    shift_labels   : bool = True,
+    **kwargs,
+):
+    """
+    Computes chunked fused DFT loss over chunk(X) @ W + b.
+    * shift_labels=True (default) shifts internally: hidden_states[..., :-1] and labels[..., 1:].
+      Set False when caller already pre-shifted (e.g. trl padding_free).
+    * Without n_chunks or target_gb, inherits UnslothFusedLoss's automatic,
+      4 GiB-capped chunk sizing.
+    * Allows scaling factor from mixed precision fp16, fp8
+    * target_gb specifies the max GB memory the fused loss can use - default detects VRAM left
+    * Upcasts to float32 and allows kwargs to have:
+    1) logit_scale_multiply (X = X * logit_scale_multiply)
+    2) logit_scale_divide   (X = X / logit_scale_divide)
+    3) logit_softcapping    (X = tanh(X / logit_softcapping) * logit_softcapping)
+    """
+    scaler = trainer.accelerator.scaler if trainer is not None else None
+    scaling = scaler.get_scale() if scaler is not None else scaling
+    if hasattr(scaling, "get_scale"): scaling = scaling.get_scale()
+    if TARGET_GB: target_gb = float(TARGET_GB)
+    elif N_CHUNKS: kwargs["n_chunks"] = max(int(N_CHUNKS), 1)
+
+    if float(kwargs.get("label_smoothing", 0.0)) != 0.0:
+        raise ValueError("Fused DFT loss does not support label_smoothing != 0.0")
+
+    device = lm_head_weight.device
+    if hidden_states.device != device:
+        hidden_states = hidden_states.to(device = device)
+
+    return apply_autograd_function(UnslothFusedLoss, dict(
+        loss_function = compute_fused_dft_loss,
         hidden_states = hidden_states,
         lm_head_weight = lm_head_weight,
         lm_head_bias = lm_head_bias,

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -172,7 +172,7 @@ def compute_fused_dft_loss(
     pass
 
     vocab_size = lm_head_weight.shape[0]
-    flat_labels = labels.contiguous().view(-1).to(device = device).contiguous()
+    flat_labels = labels.reshape(-1).to(device = device)
     valid = flat_labels != ignore_index
     logits = torch.nn.functional.linear(
         hidden_states.to(dtype = lm_head_weight.dtype, device = device),

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -194,21 +194,24 @@ def compute_fused_dft_loss(
     flat_logits = logits.view(-1, vocab_size).float().contiguous()
     flat_labels = labels.contiguous().view(-1).to(device = device).contiguous()
     valid = flat_labels != ignore_index
-    safe_labels = flat_labels.masked_fill(~valid, 0)
-    # Ignored rows may contain non-finite logits; sanitize before log_softmax
-    # so both forward and backward remain hard-zeroed for ignored targets.
+    # Native CE can propagate non-finite ignored logits during backward on some
+    # backends, so sanitize them before CE to keep ignored gradients hard-zeroed.
     flat_logits = torch.where(
         valid.unsqueeze(1),
         flat_logits,
         torch.zeros((), dtype = flat_logits.dtype, device = flat_logits.device),
     )
-    logprobs = torch.nn.functional.log_softmax(flat_logits, dim = -1)
-    token_nll = -logprobs.gather(1, safe_labels.unsqueeze(1)).squeeze(1)
-    valid_float = valid.to(dtype = token_nll.dtype)
-    weights = torch.exp(-token_nll.detach()) * valid_float
+    token_nll = torch.nn.functional.cross_entropy(
+        input = flat_logits,
+        target = flat_labels,
+        reduction = "none",
+        ignore_index = ignore_index,
+        label_smoothing = 0.0,
+    )
+    weighted_nll = torch.exp(-token_nll.detach()) * token_nll
 
     if n_items is None:
-        divisor = valid_float.sum()
+        divisor = valid.to(dtype = token_nll.dtype).sum()
     elif torch.is_tensor(n_items):
         divisor = n_items.to(device = device, dtype = token_nll.dtype)
     else:
@@ -216,7 +219,7 @@ def compute_fused_dft_loss(
     if divisor.numel() != 1: divisor = divisor.ravel()[0]
     divisor = torch.where(divisor == 0, torch.ones_like(divisor), divisor)
 
-    loss = (token_nll * weights).sum() / divisor
+    loss = weighted_nll.sum() / divisor
     scaled_loss = loss * scaling if scaling is not None else loss
     return scaled_loss, (loss.detach(),)
 pass

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -171,12 +171,15 @@ def compute_fused_dft_loss(
         labels = labels.to(device = device)
     pass
 
+    vocab_size = lm_head_weight.shape[0]
+    flat_labels = labels.contiguous().view(-1).to(device = device).contiguous()
+    valid = flat_labels != ignore_index
     logits = torch.nn.functional.linear(
         hidden_states.to(dtype = lm_head_weight.dtype, device = device),
         lm_head_weight,
         lm_head_bias,
     )
-    vocab_size = lm_head_weight.shape[0]
+    logits.view(-1, vocab_size).masked_fill_(~valid.unsqueeze(1), 0.0)
 
     # Apply the same logit transforms as fused CE before computing NLL.
     logit_scale_multiply = kwargs.get("logit_scale_multiply", None)
@@ -192,15 +195,6 @@ def compute_fused_dft_loss(
         logits = logits * logit_softcapping
 
     flat_logits = logits.view(-1, vocab_size).float().contiguous()
-    flat_labels = labels.contiguous().view(-1).to(device = device).contiguous()
-    valid = flat_labels != ignore_index
-    # Native CE can propagate non-finite ignored logits during backward on some
-    # backends, so sanitize them before CE to keep ignored gradients hard-zeroed.
-    flat_logits = torch.where(
-        valid.unsqueeze(1),
-        flat_logits,
-        torch.zeros((), dtype = flat_logits.dtype, device = flat_logits.device),
-    )
     token_nll = torch.nn.functional.cross_entropy(
         input = flat_logits,
         target = flat_labels,

--- a/unsloth_zoo/loss_utils.py
+++ b/unsloth_zoo/loss_utils.py
@@ -72,9 +72,10 @@ __all__ = [
     "fast_linear_cross_entropy",
     "_unsloth_get_batch_samples",
     "unsloth_fused_ce_loss",
+    "unsloth_fused_dft_loss",
 ]
 
-from .fused_losses import unsloth_fused_ce_loss
+from .fused_losses import unsloth_fused_ce_loss, unsloth_fused_dft_loss
 
 def patch_loss_functions(_fast_cross_entropy_loss, torch_compile = True):
     # All Unsloth Zoo code licensed under LGPLv3


### PR DESCRIPTION
## Summary

[Dynamic Fine-Tuning (DFT)](https://arxiv.org/abs/2508.05629v2) has already been added to [TRL](https://github.com/huggingface/trl/blob/1925183c91852c30088ed8ad53181e7b7147489e/trl/trainer/sft_trainer.py#L790) and is accessible by setting `loss_type="dft"` in the `SFTTrainer`. But doing so would currently deviate from the unsloth memory optimized path.

This PR adds  DFT fused loss support for using the existing chunked fused-loss infrastructure. It is the first in a planned series of PRs to add support for RL x SFT hybrid losses as initially attempted in this [PR in the main unsloth repo](https://github.com/unslothai/unsloth/pull/4239).

DFT weights each token’s negative log-likelihood by its detached predicted probability:
$$\text{sg}(\exp(-NLL_t)) * NLL_t$$

This reduces the contribution of low-confidence (high surprise) tokens while preserving the intended detached-weight gradient behavior.

Notably, this isn't just a matter of passing a scaling to fused CE, as access to the per-token $$NLL$$ is required.

Creating this PR in `unsloth-zoo` first before patching `unsloth`.


## Changes

- Add `compute_fused_dft_loss` for direct DFT loss computation.
- Add `unsloth_fused_dft_loss` using the existing UnslothFusedLoss autograd and chunking path.
- Mimic as much of the base `fused_ce_loss` behavior as possible:
  - automatic and explicit chunk sizing
  - shifted and pre-shifted labels
  - masking and custom ignore_index
  - mixed-precision loss scaling
  - logit scaling and soft-capping
  - eager and torch.compile execution
  - optional LM-head bias
- Export `unsloth_fused_dft_loss` through `loss_utils`.
- Prevent CE compile success from treating DFT’s first compiled execution as already proven. Compile failures remain process-wide and disable subsequent fused-loss compilation.
- Reject non-zero label smoothing, which is not currently supported for DFT.
- Add the DFT test suite as a CI hard gate.

For the purpose of this PR, we intentionally avoid doing anything to `compute_fused_ce_loss` and instead duplicate most of its behavior into `compute_fused_dft_loss`.

## Testing

### Correctness

Correctness tests are in `tests/test_fused_dft_loss.py`.

Most notable are 
- `tests/test_fused_dft_loss.py::test_compute_dft_minus_p_log_p_shape`
- `tests/test_fused_dft_loss.py::test_compute_dft_single_token_closed_form_loss_and_gradient`
- `tests/test_fused_dft_loss.py::test_unsloth_fused_dft_compiled_parity_and_probe_success`
- Other tests cover chunking, label shifts/masking, ignored rows


### Compilation 

DFT compiled successfully on:

```
PyTorch 2.12.1+cu130
Triton 3.7.1
```

```
unique_graphs=1
graph_break_count=0
recompilation_count_from_guard_failures=0
```

<details>
<summary>Full compilation test</summary>

```
print(
    "COMPILE_OPTIONS_JSON="
    + json.dumps(cross_entropy_loss.torch_compile_options, sort_keys=True)
)

torch._dynamo.reset()
torch._dynamo.utils.counters.clear()
torch._dynamo.utils.guard_failures.clear()
cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED = None
cross_entropy_loss._FUSED_CE_COMPILE_FASTPATH_PROVEN.clear()

# Two equal chunks exercise one compiled accumulate_chunk region twice. Each
# chunk has one valid and one ignored row. All inputs are finite, but the
# ignored rows overflow in linear(), which makes the sanitizer observable.
hidden_states = torch.tensor(
    [[[2.0e-20, -1.0e-20], [1.0e20, -1.0e20],
      [1.5e-20, -0.5e-20], [1.0e20, -1.0e20]]],
    dtype=torch.float32,
    device="cuda",
    requires_grad=True,
)
lm_head_weight = torch.tensor(
    [[1.0e20, 0.0], [0.0, 1.0e20], [-1.0e20, 1.0e20]],
    dtype=torch.float32,
    device="cuda",
    requires_grad=True,
)
lm_head_bias = torch.tensor(
    [0.1, -0.2, 0.3],
    dtype=torch.float32,
    device="cuda",
    requires_grad=True,
)
labels = torch.tensor([[1, -100, 1, -100]], device="cuda")

with torch.no_grad():
    raw_logits = torch.nn.functional.linear(
        hidden_states,
        lm_head_weight,
        lm_head_bias,
    )
print("RAW_LOGITS=" + repr(raw_logits.detach().cpu().tolist()))

loss = cross_entropy_loss.unsloth_fused_dft_loss(
    trainer=None,
    hidden_states=hidden_states,
    lm_head_weight=lm_head_weight,
    lm_head_bias=lm_head_bias,
    labels=labels,
    shift_labels=False,
    torch_compile=True,
    n_chunks=2,
)
torch.cuda.synchronize()
loss.backward()
torch.cuda.synchronize()

guard_failures = {
    str(code): [str(failure) for failure in failures]
    for code, failures in torch._dynamo.utils.guard_failures.items()
    if failures
}
counters = json_counters()
graph_break_count = sum(counters.get("graph_break", {}).values())
recompilation_count = sum(len(failures) for failures in guard_failures.values())

result = {
    "loss": float(loss.detach().cpu()),
    "compile_supported": cross_entropy_loss._FUSED_CE_COMPILE_SUPPORTED,
    "fastpath_proven": (
        cross_entropy_loss.compute_fused_dft_loss
        in cross_entropy_loss._FUSED_CE_COMPILE_FASTPATH_PROVEN
    ),
    "hidden_grad_finite": bool(torch.isfinite(hidden_states.grad).all()),
    "weight_grad_finite": bool(torch.isfinite(lm_head_weight.grad).all()),
    "bias_grad_finite": bool(torch.isfinite(lm_head_bias.grad).all()),
    "ignored_hidden_grad_zero": bool(
        torch.count_nonzero(hidden_states.grad[0, [1, 3]]) == 0
    ),
    "graph_break_count": graph_break_count,
    "recompilation_count_from_guard_failures": recompilation_count,
    "guard_failures": guard_failures,
    "counters": counters,
}
print("RESULT_JSON=" + json.dumps(result, sort_keys=True))
```

```
COMPILE_OPTIONS_JSON={"benchmark_combo_kernel": true, "combo_kernel_foreach_dynamic_shapes": true, "combo_kernels": false, "compile_threads": 16, "coordinate_descent_tuning": false, "cuda.compile_opt_level": "-O2", "cuda.enable_cuda_lto": true, "dce": true, "debug": true, "disable_progress": true, "epilogue_fusion": true, "group_fusion": true, "max_autotune": false, "memory_planning": false, "shape_padding": true, "trace.enabled": true, "trace.graph_diagram": true, "triton.autotune_at_compile_time": false, "triton.cooperative_reductions": false, "triton.cudagraphs": false, "triton.enable_persistent_tma_matmul": true, "triton.multi_kernel": 0, "triton.use_block_ptr": false, "verbose_progress": false}
```

```
RAW_LOGITS=[[[2.0999999046325684, -1.2000000476837158, -2.700000047683716], [inf, -inf, -inf], [1.600000023841858, -0.699999988079071, -1.7000000476837158], [inf, -inf, -inf]]]
```

```
RESULT_JSON={"bias_grad_finite": true, "compile_supported": true, "counters": {"aot_autograd": {"autograd_cache_miss": 1, "autograd_cache_saved": 1, "ok": 1, "total": 1}, "aten_mm_info": {"aten.mm_s19_s19_s55": 1, "aten.mm_s19_s55_s19": 1, "aten.mm_s55_s19_s19": 1}, "inductor": {"async_compile_cache_hit": 6, "async_compile_cache_miss": 12, "benchmarking.InductorBenchmarker.benchmark": 5, "benchmarking.InductorBenchmarker.benchmark_gpu": 5, "extern_calls": 3, "fxgraph_cache_miss": 1, "pattern_matcher_count": 7, "pattern_matcher_nodes": 12, "triton_bundler_save_kernel": 72, "triton_bundler_save_static_autotuner": 1}, "stats": {"calls_captured": 59, "unique_graphs": 1}}, "fastpath_proven": true, "graph_break_count": 0, "guard_failures": {}, "hidden_grad_finite": true, "ignored_hidden_grad_zero": true, "loss": 0.1660669595003128, "recompilation_count_from_guard_failures": 0, "weight_grad_finite": true}
```
</details>

## Future Work

- Compose DFT around CCE
- Update [unsloth](https://github.com/unslothai/unsloth) so `loss_type=dft` on `SFTTrainer` routes through this change.
- Add `loss_type=asft`