### PR TITLE
Fix GGUF export crash for fine-tuned MTP models (Qwen3.5)

### DIFF
--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -81,6 +81,18 @@ def test_has_mtp_weight_tensors_reads_each_unindexed_safetensors_part(llama_cpp,
     assert llama_cpp._has_mtp_weight_tensors(tmp_path, 24) is True
 
 
+def test_has_mtp_weight_tensors_matches_converter_index_precedence(llama_cpp, tmp_path):
+    torch = pytest.importorskip("torch")
+    safetensors_torch = pytest.importorskip("safetensors.torch")
+    safetensors_torch.save_file(
+        {"model.layers.0.self_attn.q_proj.weight": torch.ones(1)},
+        tmp_path / "model.safetensors",
+    )
+    _write_index(tmp_path, "model.layers.24.eh_proj.weight")
+
+    assert llama_cpp._has_mtp_weight_tensors(tmp_path, 24) is True
+
+
 def _write_converter(path: Path) -> Path:
     converter = path / "fake_convert.py"
     converter.write_text(

--- a/tests/test_convert_to_gguf_mtp_reconcile.py
+++ b/tests/test_convert_to_gguf_mtp_reconcile.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _load_llama_cpp_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "unsloth_zoo" / "llama_cpp.py"
+    spec = importlib.util.spec_from_file_location(
+        "llama_cpp_under_test_mtp_reconcile",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def llama_cpp():
+    return _load_llama_cpp_module()
+
+
+def _write_index(model_dir: Path, tensor_name: str) -> None:
+    (model_dir / "model-00001-of-00001.safetensors").touch()
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    tensor_name: "model-00001-of-00001.safetensors",
+                },
+            }
+        ),
+        encoding = "utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "tensor_name",
+    (
+        "model.layers.24.eh_proj.weight",
+        "model.language_model.layers.24.eh_proj.weight",
+        "language_model.mtp.fc.weight",
+        "model.language_model.mtp.layers.0.mlp.down_proj.weight",
+    ),
+)
+def test_has_mtp_weight_tensors_normalizes_converter_prefixes(llama_cpp, tmp_path, tensor_name):
+    _write_index(tmp_path, tensor_name)
+
+    assert llama_cpp._has_mtp_weight_tensors(tmp_path, 24) is True
+
+
+def test_has_mtp_weight_tensors_reads_single_pytorch_checkpoint(llama_cpp, tmp_path):
+    torch = pytest.importorskip("torch")
+    torch.save(
+        {"model.layers.24.eh_proj.weight": torch.ones(1)},
+        tmp_path / "pytorch_model.bin",
+    )
+
+    assert llama_cpp._has_mtp_weight_tensors(tmp_path, 24) is True
+
+
+def test_has_mtp_weight_tensors_reads_each_unindexed_safetensors_part(llama_cpp, tmp_path):
+    torch = pytest.importorskip("torch")
+    safetensors_torch = pytest.importorskip("safetensors.torch")
+    safetensors_torch.save_file(
+        {"model.layers.0.self_attn.q_proj.weight": torch.ones(1)},
+        tmp_path / "model-00001-of-00002.safetensors",
+    )
+    safetensors_torch.save_file(
+        {"model.language_model.layers.24.eh_proj.weight": torch.ones(1)},
+        tmp_path / "model-00002-of-00002.safetensors",
+    )
+
+    assert llama_cpp._has_mtp_weight_tensors(tmp_path, 24) is True
+
+
+def _write_converter(path: Path) -> Path:
+    converter = path / "fake_convert.py"
+    converter.write_text(
+        textwrap.dedent(
+            """
+            import argparse
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--outfile")
+            parser.add_argument("--outtype")
+            parser.add_argument("--split-max-size")
+            parser.add_argument("model_dir")
+            args = parser.parse_args()
+            Path(args.outfile).write_bytes(b"GGUF")
+            """
+        ),
+        encoding = "utf-8",
+    )
+    return converter
+
+
+@pytest.mark.parametrize("has_mtp", (False, True))
+def test_convert_to_gguf_reconciles_mtp_config_to_index(llama_cpp, tmp_path, has_mtp):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = model_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "mtp_num_hidden_layers": 1,
+                "unsloth_fixed_mtp": True,
+                "text_config": {
+                    "num_hidden_layers": 24,
+                    "mtp_num_hidden_layers": 1,
+                    "unsloth_fixed_mtp": True,
+                },
+            }
+        ),
+        encoding = "utf-8",
+    )
+    tensor_name = (
+        "model.language_model.layers.24.eh_proj.weight"
+        if has_mtp
+        else "model.language_model.layers.23.self_attn.q_proj.weight"
+    )
+    _write_index(model_dir, tensor_name)
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(tmp_path / "output.gguf"),
+        input_folder = str(model_dir),
+        converter_location = str(_write_converter(tmp_path)),
+        quantization_type = "bf16",
+    )
+
+    updated = json.loads(config_path.read_text(encoding = "utf-8"))
+    assert "unsloth_fixed_mtp" not in updated
+    assert "unsloth_fixed_mtp" not in updated["text_config"]
+    assert ("mtp_num_hidden_layers" in updated) is has_mtp
+    assert ("mtp_num_hidden_layers" in updated["text_config"]) is has_mtp
+
+
+def test_convert_to_gguf_always_removes_null_internal_marker(llama_cpp, tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config_path = model_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "architectures": ["LlamaForCausalLM"],
+                "unsloth_fixed_mtp": None,
+            }
+        ),
+        encoding = "utf-8",
+    )
+
+    llama_cpp.convert_to_gguf(
+        model_name = str(tmp_path / "output.gguf"),
+        input_folder = str(model_dir),
+        converter_location = str(_write_converter(tmp_path)),
+        quantization_type = "bf16",
+    )
+
+    updated = json.loads(config_path.read_text(encoding = "utf-8"))
+    assert "unsloth_fixed_mtp" not in updated
+
+
+def test_convert_to_gguf_does_not_rewrite_config_after_index_error(llama_cpp, tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config = {
+        "mtp_num_hidden_layers": 1,
+        "unsloth_fixed_mtp": True,
+        "num_hidden_layers": 24,
+    }
+    config_path = model_dir / "config.json"
+    config_path.write_text(json.dumps(config), encoding = "utf-8")
+    (model_dir / "model.safetensors").touch()
+    (model_dir / "model.safetensors.index.json").write_text("{", encoding = "utf-8")
+
+    with pytest.raises(RuntimeError, match="config.json.*was not changed"):
+        llama_cpp.convert_to_gguf(
+            model_name = str(tmp_path / "output.gguf"),
+            input_folder = str(model_dir),
+            converter_location = str(tmp_path / "unused.py"),
+        )
+
+    assert json.loads(config_path.read_text(encoding = "utf-8")) == config
+
+
+def test_convert_to_gguf_rejects_malformed_layer_count_before_rewrite(llama_cpp, tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    config = {
+        "mtp_num_hidden_layers": 1,
+        "unsloth_fixed_mtp": True,
+        "num_hidden_layers": "24",
+    }
+    config_path = model_dir / "config.json"
+    config_path.write_text(json.dumps(config), encoding = "utf-8")
+
+    with pytest.raises(ValueError, match="positive integer.*config.json.*was not changed"):
+        llama_cpp.convert_to_gguf(
+            model_name = str(tmp_path / "output.gguf"),
+            input_folder = str(model_dir),
+            converter_location = str(tmp_path / "unused.py"),
+        )
+
+    assert json.loads(config_path.read_text(encoding = "utf-8")) == config

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -1027,6 +1027,16 @@ def test_save_pretrained_gguf_anchors_patcher_to_checked_llama_cpp_root(
     def fake_save_merged_model(model, tokenizer, path, dequantize=False):
         calls["dequantize"] = dequantize
         Path(path).mkdir(parents=True, exist_ok=True)
+        (Path(path) / "config.json").write_text(
+            json.dumps(
+                {
+                    "mtp_num_hidden_layers": 1,
+                    "unsloth_fixed_mtp": True,
+                    "num_hidden_layers": 24,
+                }
+            ),
+            encoding="utf-8",
+        )
 
     def fake_download_convert_hf_to_gguf():
         calls["scripts_dir"] = os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR")
@@ -1036,6 +1046,9 @@ def test_save_pretrained_gguf_anchors_patcher_to_checked_llama_cpp_root(
 
     def fake_convert_to_gguf(**kwargs):
         calls["convert_kwargs"] = kwargs
+        calls["convert_config"] = json.loads(
+            (Path(kwargs["input_folder"]) / "config.json").read_text(encoding="utf-8")
+        )
         output = Path(
             f"{kwargs['model_name']}.{kwargs['quantization_type'].upper()}.gguf"
         )
@@ -1083,6 +1096,8 @@ def test_save_pretrained_gguf_anchors_patcher_to_checked_llama_cpp_root(
         llama_root / "unsloth_convert_hf_to_gguf.py"
     )
     assert calls["convert_kwargs"]["supported_text_archs"] == {"Qwen3ForCausalLM"}
+    assert calls["convert_config"]["mtp_num_hidden_layers"] == 1
+    assert calls["convert_config"]["unsloth_fixed_mtp"] is True
     assert (out / "TestModel.F16.gguf").read_bytes() == b"GGUF"
     assert os.environ.get("UNSLOTH_LLAMA_CPP_SCRIPTS_DIR") == old_scripts_dir
 

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2245,29 +2245,74 @@ def _reinstall_converter_deps(python_exe, print_output = False):
 
 
 def _has_mtp_weight_tensors(input_folder, num_layers):
-    """True if the checkpoint carries MTP / nextn weights: the `mtp.*` /
-    `model.mtp.*` layout, or a decoder layer at index >= num_layers. Reads
-    only tensor names."""
+    """Return whether the checkpoint's tensor names include an MTP layer."""
+    input_folder = Path(input_folder)
     _layer_re = re.compile(r"^(?:model\.)?layers\.(\d+)\.")
 
     def _is_mtp(name):
+        # Match the converter's TextModel.filter_tensors normalization.
+        name = name.replace("language_model.", "")
         if name.startswith(("mtp.", "model.mtp.")):
             return True
         m = _layer_re.match(name)
         return m is not None and int(m.group(1)) >= num_layers
 
-    for index_name in ("model.safetensors.index.json", "pytorch_model.bin.index.json"):
-        index_path = os.path.join(input_folder, index_name)
-        if os.path.exists(index_path):
-            with open(index_path, "r", encoding = "utf-8") as f:
-                weight_map = json.load(f).get("weight_map", {})
-            return any(_is_mtp(n) for n in weight_map)
+    def _inspection_error(path):
+        return RuntimeError(
+            f"Unsloth: Could not inspect `{path.name}` for MTP tensors; "
+            "`config.json` was not changed."
+        )
 
-    single = os.path.join(input_folder, "model.safetensors")
-    if os.path.exists(single):
+    def _names_from_index(index_path):
+        try:
+            with index_path.open("r", encoding = "utf-8") as f:
+                index = json.load(f)
+        except Exception as error:
+            raise _inspection_error(index_path) from error
+        weight_map = index.get("weight_map") if isinstance(index, dict) else None
+        if not isinstance(weight_map, dict):
+            raise _inspection_error(index_path)
+        return weight_map.keys()
+
+    parts = sorted(input_folder.glob("model*.safetensors"))
+    if parts:
+        index_path = input_folder / "model.safetensors.index.json"
+        if index_path.is_file():
+            return any(_is_mtp(name) for name in _names_from_index(index_path))
         from safetensors import safe_open
-        with safe_open(single, framework = "pt") as f:
-            return any(_is_mtp(n) for n in f.keys())
+
+        for part in parts:
+            try:
+                with safe_open(part, framework = "pt", device = "cpu") as f:
+                    if any(_is_mtp(name) for name in f.keys()):
+                        return True
+            except Exception as error:
+                raise _inspection_error(part) from error
+        return False
+
+    parts = sorted(input_folder.glob("pytorch_model*.bin"))
+    if parts:
+        index_path = input_folder / "pytorch_model.bin.index.json"
+        if index_path.is_file():
+            return any(_is_mtp(name) for name in _names_from_index(index_path))
+        if torch is None:
+            raise RuntimeError("Unsloth: PyTorch is required to inspect `.bin` model weights.")
+        for part in parts:
+            try:
+                state_dict = torch.load(
+                    part,
+                    map_location = "cpu",
+                    mmap = True,
+                    weights_only = True,
+                )
+            except Exception as error:
+                raise _inspection_error(part) from error
+            if isinstance(state_dict, dict) and isinstance(state_dict.get("state_dict"), dict):
+                state_dict = state_dict["state_dict"]
+            if not isinstance(state_dict, dict):
+                raise _inspection_error(part)
+            if any(_is_mtp(name) for name in state_dict):
+                return True
     return False
 
 
@@ -2308,21 +2353,33 @@ def convert_to_gguf(
     # tensor), and strip it when they don't (else it errors on the missing one).
     # `unsloth_fixed_mtp` is an internal marker, always dropped. Only Qwen3.5/3.6 set
     # these keys, so other arches are untouched.
-    _tc = config_file.get("text_config") or {}
+    _tc = config_file.get("text_config")
+    if not isinstance(_tc, dict):
+        _tc = {}
     _mtp_declared = "mtp_num_hidden_layers" in config_file or "mtp_num_hidden_layers" in _tc
     _num_layers = _tc.get("num_hidden_layers", config_file.get("num_hidden_layers"))
-    _keep_mtp = (
-        _mtp_declared
-        and _num_layers is not None
-        and _has_mtp_weight_tensors(input_folder, int(_num_layers))
+    if _mtp_declared and (
+        not isinstance(_num_layers, int)
+        or isinstance(_num_layers, bool)
+        or _num_layers <= 0
+    ):
+        raise ValueError(
+            "Unsloth: `num_hidden_layers` must be a positive integer to reconcile MTP tensors; "
+            "`config.json` was not changed."
+        )
+    _keep_mtp = _mtp_declared and _has_mtp_weight_tensors(input_folder, _num_layers)
+    _strip_keys = (
+        ("unsloth_fixed_mtp",)
+        if _keep_mtp
+        else ("unsloth_fixed_mtp", "mtp_num_hidden_layers")
     )
-    _strip_keys = ("unsloth_fixed_mtp",) if _keep_mtp else ("unsloth_fixed_mtp", "mtp_num_hidden_layers")
     _changed = False
-    for _cfg in (config_file, config_file.get("text_config")):
+    for _cfg in (config_file, _tc):
         if not _cfg:
             continue
         for _key in _strip_keys:
-            if _cfg.pop(_key, None) is not None:
+            if _key in _cfg:
+                _cfg.pop(_key)
                 _changed = True
     if _changed:
         with open(config_path, "w", encoding = "utf-8") as f:

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2245,10 +2245,9 @@ def _reinstall_converter_deps(python_exe, print_output = False):
 
 
 def _has_mtp_weight_tensors(input_folder, num_layers):
-    """True if the checkpoint actually carries MTP / nextn weights: the raw
-    `mtp.*` / `model.mtp.*` layout, or a decoder layer at index >= num_layers
-    (the layout a transformers merge writes). Reads only weight-map / header
-    names, never tensor data."""
+    """True if the checkpoint carries MTP / nextn weights: the `mtp.*` /
+    `model.mtp.*` layout, or a decoder layer at index >= num_layers. Reads
+    only tensor names."""
     _layer_re = re.compile(r"^(?:model\.)?layers\.(\d+)\.")
 
     def _is_mtp(name):
@@ -2304,15 +2303,11 @@ def convert_to_gguf(
     with open(config_path, "r", encoding = "utf-8") as f:
         config_file = json.load(f)
 
-    # Reconcile the Qwen3.5/3.6 MTP config to the actual weights. `unsloth_fixed_mtp`
-    # is an internal marker and always goes. `mtp_num_hidden_layers` we keep only
-    # when the merged weights still carry the MTP layer, so the converter's nextn
-    # path maps them (block_count += mtp, emits blk.N.nextn.*). We strip it when the
-    # weights lack the layer (an MLX merge, or a transformers build that drops the
-    # head), otherwise the converter is sized for a layer that isn't there and
-    # crashes on "Can not map tensor 'model.layers.N.eh_proj.weight'" (or errors on
-    # a missing tensor). Only Qwen3.5/3.6 set this key; GLM and other nextn arches
-    # use their own and are untouched.
+    # The converter sizes block_count from the config, so keep `mtp_num_hidden_layers`
+    # only when the weights still carry the MTP layer (else it crashes on the extra
+    # tensor), and strip it when they don't (else it errors on the missing one).
+    # `unsloth_fixed_mtp` is an internal marker, always dropped. Only Qwen3.5/3.6 set
+    # these keys, so other arches are untouched.
     _tc = config_file.get("text_config") or {}
     _mtp_declared = "mtp_num_hidden_layers" in config_file or "mtp_num_hidden_layers" in _tc
     _num_layers = _tc.get("num_hidden_layers", config_file.get("num_hidden_layers"))

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2277,6 +2277,8 @@ def _has_mtp_weight_tensors(input_folder, num_layers):
     parts = sorted(input_folder.glob("model*.safetensors"))
     if parts:
         index_path = input_folder / "model.safetensors.index.json"
+        # llama.cpp gives the canonical index precedence whenever any
+        # safetensors part exists, including alongside model.safetensors.
         if index_path.is_file():
             return any(_is_mtp(name) for name in _names_from_index(index_path))
         from safetensors import safe_open

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2244,6 +2244,34 @@ def _reinstall_converter_deps(python_exe, print_output = False):
     return result
 
 
+def _has_mtp_weight_tensors(input_folder, num_layers):
+    """True if the checkpoint actually carries MTP / nextn weights: the raw
+    `mtp.*` / `model.mtp.*` layout, or a decoder layer at index >= num_layers
+    (the layout a transformers merge writes). Reads only weight-map / header
+    names, never tensor data."""
+    _layer_re = re.compile(r"^(?:model\.)?layers\.(\d+)\.")
+
+    def _is_mtp(name):
+        if name.startswith(("mtp.", "model.mtp.")):
+            return True
+        m = _layer_re.match(name)
+        return m is not None and int(m.group(1)) >= num_layers
+
+    for index_name in ("model.safetensors.index.json", "pytorch_model.bin.index.json"):
+        index_path = os.path.join(input_folder, index_name)
+        if os.path.exists(index_path):
+            with open(index_path, "r", encoding = "utf-8") as f:
+                weight_map = json.load(f).get("weight_map", {})
+            return any(_is_mtp(n) for n in weight_map)
+
+    single = os.path.join(input_folder, "model.safetensors")
+    if os.path.exists(single):
+        from safetensors import safe_open
+        with safe_open(single, framework = "pt") as f:
+            return any(_is_mtp(n) for n in f.keys())
+    return False
+
+
 def convert_to_gguf(
     model_name,
     input_folder,
@@ -2276,15 +2304,31 @@ def convert_to_gguf(
     with open(config_path, "r", encoding = "utf-8") as f:
         config_file = json.load(f)
 
-    # Strip MTP / nextn config keys so the downstream convert_hf_to_gguf.py
-    # doesn't inflate block_count / inject nextn_predict_layers.
+    # Reconcile the Qwen3.5/3.6 MTP config to the actual weights. `unsloth_fixed_mtp`
+    # is an internal marker and always goes. `mtp_num_hidden_layers` we keep only
+    # when the merged weights still carry the MTP layer, so the converter's nextn
+    # path maps them (block_count += mtp, emits blk.N.nextn.*). We strip it when the
+    # weights lack the layer (an MLX merge, or a transformers build that drops the
+    # head), otherwise the converter is sized for a layer that isn't there and
+    # crashes on "Can not map tensor 'model.layers.N.eh_proj.weight'" (or errors on
+    # a missing tensor). Only Qwen3.5/3.6 set this key; GLM and other nextn arches
+    # use their own and are untouched.
+    _tc = config_file.get("text_config") or {}
+    _mtp_declared = "mtp_num_hidden_layers" in config_file or "mtp_num_hidden_layers" in _tc
+    _num_layers = _tc.get("num_hidden_layers", config_file.get("num_hidden_layers"))
+    _keep_mtp = (
+        _mtp_declared
+        and _num_layers is not None
+        and _has_mtp_weight_tensors(input_folder, int(_num_layers))
+    )
+    _strip_keys = ("unsloth_fixed_mtp",) if _keep_mtp else ("unsloth_fixed_mtp", "mtp_num_hidden_layers")
     _changed = False
-    for _key in ("mtp_num_hidden_layers", "unsloth_fixed_mtp"):
-        if config_file.pop(_key, None) is not None:
-            _changed = True
-        _tc = config_file.get("text_config")
-        if _tc and _tc.pop(_key, None) is not None:
-            _changed = True
+    for _cfg in (config_file, config_file.get("text_config")):
+        if not _cfg:
+            continue
+        for _key in _strip_keys:
+            if _cfg.pop(_key, None) is not None:
+                _changed = True
     if _changed:
         with open(config_path, "w", encoding = "utf-8") as f:
             json.dump(config_file, f, indent = 2)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -7246,20 +7246,13 @@ def save_pretrained_gguf(
                     f"{rewritten} MLX VLM tensors for llama.cpp GGUF export."
                 )
 
-        # Strip MTP/nextn config keys so llama.cpp converter
-        # doesn't inflate block_count / inject nextn_predict_layers.
-        # Also restore architectures from the original HF config since
-        # mlx-vlm's save_config strips that key.
+        # Restore architectures from the original HF config since mlx-vlm's
+        # save_config strips that key. convert_to_gguf reconciles MTP metadata
+        # with the exported tensor names for every save path.
         _config_path = tmp_path / "config.json"
         if _config_path.exists():
             _cfg = json.loads(_config_path.read_text())
             _changed = False
-            for _key in ("mtp_num_hidden_layers", "unsloth_fixed_mtp"):
-                if _cfg.pop(_key, None) is not None:
-                    _changed = True
-                _tc = _cfg.get("text_config")
-                if _tc and _tc.pop(_key, None) is not None:
-                    _changed = True
             # Restore architectures from the original HF config
             if "architectures" not in _cfg:
                 _orig_cfg_path = getattr(tokenizer, "name_or_path", None)


### PR DESCRIPTION
Fixes unslothai/unsloth#6754.

## Problem

GGUF export of a fine-tuned Qwen3.5/3.6 model fails at the HF to GGUF step:

```
ValueError: Can not map tensor 'model.layers.24.eh_proj.weight'
```

It dies before quantization, so every quant fails. Non-MTP models are unaffected.

## Root cause

`convert_to_gguf` always strips `mtp_num_hidden_layers` from `config.json` before converting. But whether the merged weights still carry the MTP layer depends on the path:

- A CUDA fine-tune + merge (recent transformers) keeps it as `model.layers.{N}.*`.
- An MLX merge drops it (`mlx_lm` sanitizes `mtp.*` away on load).

When the weights keep the MTP layer but the config no longer declares it, the converter is sized to N blocks and crashes on the extra tensor. The strip was added for the MLX case (weights already MTP-free); applying it unconditionally broke the CUDA case.

## Fix

Reconcile the config to the actual weights instead of always stripping:

- Weights still carry the MTP layer: keep `mtp_num_hidden_layers` so the converter's nextn path maps them. The export keeps the MTP head.
- Weights don't have it: strip the key so the converter isn't sized for a missing layer. The export is a standard MTP-free GGUF.

`unsloth_fixed_mtp` (an internal marker) is always removed. Detection reads tensor names from shard indexes, safetensors headers, or memory-mapped PyTorch metadata. It covers single `.bin` checkpoints and VLM `language_model.*` prefixes. Inspection failures leave `config.json` unchanged. The earlier MLX-only strip was removed so all export paths use the same reconciliation.

The export stays faithful to the model: MTP is kept when the checkpoint has it, and dropped only when it was never there.

## Relation to the other PRs

unslothai/unsloth-zoo#847 and unslothai/unsloth#6764 fix the crash by always keeping the MTP config. That works when the weights have the MTP layer, but errors when they don't (an MLX-derived checkpoint, or a transformers build that drops the head), since the converter then expects a layer that is absent. Reconciling keeps MTP only when the weights actually carry it.

## Verification

Linux (CUDA converter):
- Base `unsloth/Qwen3.5-0.8B` (`mtp.*` weights) and the merged `model.layers.24.*` layout: keep MTP, convert to 335 tensors with nextn, `block_count 25` (matches `unsloth/Qwen3.5-0.8B-MTP-GGUF`).
- MTP-free weights with the config key still present: strip, convert to 320 tensors, no nextn, `block_count 24` (matches `unsloth/Qwen3.5-0.8B-GGUF`).

macOS / MLX (real `mlx_lm` convert on Apple Silicon):
- `mlx_lm` drops the `mtp.*` weights on load, so the MLX save has no MTP but the config still declares it. Reconcile detects no MTP weights, strips the key, and converts cleanly to a standard MTP-free GGUF (`block_count 24`). No crash.

GLM-style checkpoint (nextn layer, no `mtp_num_hidden_layers`): untouched.

Automated GGUF and MLX export regression suite: 218 passed.

