### PR TITLE
Fix Gemma 4 MLX GGUF tensor namespace restoration

### DIFF
--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -314,6 +314,17 @@ class _ConvAndRenameSanitizer:
         return out
 
 
+class _StripModelNamespaceSanitizer:
+    """HF -> MLX replay: strip the canonical top-level model namespace."""
+
+    @staticmethod
+    def sanitize(weights):
+        return {
+            name[len("model."):] if name.startswith("model.") else name: tensor
+            for name, tensor in weights.items()
+        }
+
+
 def _write_shard(path, tensors):
     from safetensors.torch import save_file
     save_file(tensors, str(path))
@@ -388,6 +399,58 @@ def test_prepare_export_rewrites_real_shards_and_index(monkeypatch, tmp_path):
     assert index_data["weight_map"] == {
         "language_model.layers.0.mlp.weight": "model-00002-of-00002.safetensors",
         "visual.patch_embed.weight": "model-00001-of-00002.safetensors",
+    }
+
+
+def test_prepare_export_restores_stripped_multimodal_namespaces_and_index(
+    monkeypatch,
+    tmp_path,
+):
+    import unsloth_zoo.mlx.utils as mutils
+    monkeypatch.setattr(mutils, "mx", sys.modules["mlx.core"])
+    _patch_mlx_tensor_helpers_for_torch(monkeypatch, mutils)
+    monkeypatch.setattr(
+        mutils,
+        "_build_mlx_vlm_sanitize_pipelines",
+        lambda config, model=None: [[(_StripModelNamespaceSanitizer, None)]],
+    )
+
+    tensors = {
+        "audio_tower.layers.0.ffw.input_max": torch.tensor([1.0]),
+        "audio_tower.layers.0.ffw.input_min": torch.tensor([-1.0]),
+        "audio_tower.layers.0.ffw.output_max": torch.tensor([2.0]),
+        "audio_tower.layers.0.ffw.output_min": torch.tensor([-2.0]),
+        "vision_tower.encoder.layers.0.weight": torch.arange(6).reshape(2, 3),
+        "embed_audio.weight": torch.arange(8).reshape(2, 4),
+        "embed_vision.weight": torch.arange(10).reshape(2, 5),
+    }
+    unrelated_name = "multi_modal_projector.linear.weight"
+    unrelated_tensor = torch.arange(24).reshape(2, 3, 4)
+    shard_name = "model-00001-of-00001.safetensors"
+    weight_map = {name: shard_name for name in (*tensors, unrelated_name)}
+    out = _export_dir_with_shards(
+        tmp_path,
+        config={"model_type": "fake_vlm"},
+        shards={shard_name: {**tensors, unrelated_name: unrelated_tensor}},
+        index={"metadata": {"total_size": 123}, "weight_map": weight_map},
+    )
+
+    assert mutils._prepare_vlm_gguf_export_directory(out) == len(tensors)
+
+    shard = _read_shard(out / shard_name)
+    expected_names = {f"model.{name}" for name in tensors}
+    assert set(shard) == expected_names | {unrelated_name}
+    for old_name, original in tensors.items():
+        assert torch.equal(shard[f"model.{old_name}"], original)
+    assert torch.equal(shard[unrelated_name], unrelated_tensor)
+
+    index_data = json.loads(
+        (out / "model.safetensors.index.json").read_text(encoding="utf-8")
+    )
+    assert index_data["metadata"] == {"total_size": 123}
+    assert index_data["weight_map"] == {
+        **{f"model.{name}": shard_name for name in tensors},
+        unrelated_name: shard_name,
     }
 
 

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -563,6 +563,64 @@ def _patch_mlx_tensor_helpers_for_torch(monkeypatch, mutils):
     monkeypatch.setattr(mutils.mx, "all", torch.all)
 
 
+@pytest.mark.parametrize(
+    ("mlx_name", "hf_name"),
+    [
+        (
+            "audio_tower.layers.0.feed_forward1.ffw_layer_1.input_max",
+            "model.audio_tower.layers.0.feed_forward1.ffw_layer_1.input_max",
+        ),
+        (
+            "vision_tower.vision_model.embeddings.patch_embedding.weight",
+            "model.vision_tower.vision_model.embeddings.patch_embedding.weight",
+        ),
+        ("embed_audio.weight", "model.embed_audio.weight"),
+        ("embed_vision.weight", "model.embed_vision.weight"),
+    ],
+)
+def test_vlm_gguf_candidates_prefer_canonical_model_namespace(mlx_name, hf_name):
+    import unsloth_zoo.mlx.utils as mutils
+
+    candidates = mutils._vlm_gguf_name_candidates(mlx_name)
+
+    assert candidates[0] == hf_name
+    assert candidates.index(hf_name) < candidates.index(mlx_name)
+
+
+def test_vlm_rewrite_restores_namespace_with_conv1d_layout(monkeypatch):
+    import torch
+    import unsloth_zoo.mlx.utils as mutils
+
+    _patch_mlx_tensor_helpers_for_torch(monkeypatch, mutils)
+
+    class StripNamespaceAndTransposeConv1d:
+        @staticmethod
+        def sanitize(weights):
+            sanitized = {}
+            for name, tensor in weights.items():
+                if name.startswith("model."):
+                    name = name[len("model."):]
+                if "depthwise_conv1d.weight" in name:
+                    tensor = mutils.mx.transpose(tensor, (0, 2, 1))
+                sanitized[name] = tensor
+            return sanitized
+
+    mlx_layout = torch.arange(2 * 3 * 4).reshape(2, 3, 4)
+    new_name, hf_layout, changed = mutils._rewrite_mlx_vlm_tensor_for_gguf(
+        "audio_tower.layers.0.lconv1d.depthwise_conv1d.weight",
+        mlx_layout,
+        [(StripNamespaceAndTransposeConv1d, None)],
+    )
+
+    assert changed is True
+    assert new_name == "model.audio_tower.layers.0.lconv1d.depthwise_conv1d.weight"
+    assert tuple(hf_layout.shape) == (2, 4, 3)
+    assert mutils._mlx_arrays_match(
+        mutils.mx.transpose(hf_layout, (0, 2, 1)),
+        mlx_layout,
+    )
+
+
 def test_vlm_rewrite_prefers_hf_alias_before_current_name(monkeypatch):
     import torch
     import unsloth_zoo.mlx.utils as mutils

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -566,23 +566,15 @@ def _patch_mlx_tensor_helpers_for_torch(monkeypatch, mutils):
 @pytest.mark.parametrize(
     ("mlx_name", "hf_name"),
     [
-        (
-            "audio_tower.layers.0.feed_forward1.ffw_layer_1.input_max",
-            "model.audio_tower.layers.0.feed_forward1.ffw_layer_1.input_max",
-        ),
-        (
-            "vision_tower.vision_model.embeddings.patch_embedding.weight",
-            "model.vision_tower.vision_model.embeddings.patch_embedding.weight",
-        ),
+        ("audio_tower.weight", "model.audio_tower.weight"),
+        ("vision_tower.weight", "model.vision_tower.weight"),
         ("embed_audio.weight", "model.embed_audio.weight"),
         ("embed_vision.weight", "model.embed_vision.weight"),
     ],
 )
 def test_vlm_gguf_candidates_prefer_canonical_model_namespace(mlx_name, hf_name):
     import unsloth_zoo.mlx.utils as mutils
-
     candidates = mutils._vlm_gguf_name_candidates(mlx_name)
-
     assert candidates[0] == hf_name
     assert candidates.index(hf_name) < candidates.index(mlx_name)
 
@@ -596,14 +588,10 @@ def test_vlm_rewrite_restores_namespace_with_conv1d_layout(monkeypatch):
     class StripNamespaceAndTransposeConv1d:
         @staticmethod
         def sanitize(weights):
-            sanitized = {}
-            for name, tensor in weights.items():
-                if name.startswith("model."):
-                    name = name[len("model."):]
-                if "depthwise_conv1d.weight" in name:
-                    tensor = mutils.mx.transpose(tensor, (0, 2, 1))
-                sanitized[name] = tensor
-            return sanitized
+            return {
+                name.removeprefix("model."): mutils.mx.transpose(tensor, (0, 2, 1))
+                for name, tensor in weights.items()
+            }
 
     mlx_layout = torch.arange(2 * 3 * 4).reshape(2, 3, 4)
     new_name, hf_layout, changed = mutils._rewrite_mlx_vlm_tensor_for_gguf(
@@ -679,30 +667,33 @@ def test_vlm_rewrite_handles_same_name_layout_transforms(monkeypatch):
     )
 
 
-def test_vlm_rewrite_skips_untransformable_text_tensors():
+def test_vlm_rewrite_restores_alias_without_transposing_unrelated_rank3(monkeypatch):
     import torch
     import unsloth_zoo.mlx.utils as mutils
 
     calls = 0
+    monkeypatch.setattr(mutils.mx, "transpose", pytest.fail)
 
-    class CountingSanitizer:
+    class StripModelNamespace:
         @staticmethod
         def sanitize(weights):
             nonlocal calls
             calls += 1
-            return weights
+            (name, tensor), = weights.items()
+            return {name.removeprefix("model."): tensor}
 
-    tensor = torch.zeros(2, 3)
+    tensor = torch.zeros(2, 3, 4)
     new_name, new_tensor, changed = mutils._rewrite_mlx_vlm_tensor_for_gguf(
-        "language_model.model.layers.0.mlp.gate_proj.weight",
+        "vision_tower.position_embedding",
         tensor,
-        [(CountingSanitizer, None)],
+        [(StripModelNamespace, None)],
     )
 
-    assert calls == 0
-    assert changed is False
-    assert new_name == "language_model.model.layers.0.mlp.gate_proj.weight"
+    assert calls == 1
+    assert changed is True
+    assert new_name == "model.vision_tower.position_embedding"
     assert new_tensor is tensor
+    assert not mutils._has_vlm_gguf_rewrite_candidate("language_model.weight", tensor)
 
 
 def test_mlx_arrays_match_checks_2d_tensor_values(monkeypatch):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6392,6 +6392,16 @@ def _vlm_gguf_name_candidates(name):
         if value not in candidates:
             candidates.append(value)
 
+    for namespace in (
+        "audio_tower.",
+        "vision_tower.",
+        "embed_audio.",
+        "embed_vision.",
+    ):
+        if name.startswith(namespace):
+            add(f"model.{name}")
+            break
+
     if name.startswith("thinker.vision_tower."):
         suffix = name[len("thinker.vision_tower."):]
         add(f"thinker.visual.{suffix}")
@@ -6418,6 +6428,8 @@ def _vlm_gguf_tensor_candidates(tensor):
         candidates.append(mx.transpose(tensor, (0, 4, 1, 2, 3)))
     elif len(shape) == 4:
         candidates.append(mx.transpose(tensor, (0, 3, 1, 2)))
+    elif len(shape) == 3:
+        candidates.append(mx.transpose(tensor, (0, 2, 1)))
 
     if len(shape) == 1 and mx.issubdtype(tensor.dtype, mx.floating):
         candidates.append(tensor - 1)
@@ -6429,7 +6441,7 @@ def _vlm_gguf_tensor_candidates(tensor):
 def _has_vlm_gguf_tensor_candidate(tensor):
     """Return whether a tensor shape can require HF-layout recovery."""
     shape = getattr(tensor, "shape", ())
-    if len(shape) in (4, 5):
+    if len(shape) in (3, 4, 5):
         return True
     if len(shape) == 1:
         dtype = getattr(tensor, "dtype", None)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6414,7 +6414,7 @@ def _vlm_gguf_name_candidates(name):
     return candidates
 
 
-def _vlm_gguf_tensor_candidates(tensor):
+def _vlm_gguf_tensor_candidates(name, tensor):
     """Yield HF-layout tensor candidates for an MLX VLM tensor."""
     candidates = []
     shape = getattr(tensor, "shape", ())
@@ -6423,7 +6423,7 @@ def _vlm_gguf_tensor_candidates(tensor):
         candidates.append(mx.transpose(tensor, (0, 4, 1, 2, 3)))
     elif len(shape) == 4:
         candidates.append(mx.transpose(tensor, (0, 3, 1, 2)))
-    elif len(shape) == 3:
+    elif len(shape) == 3 and "depthwise_conv1d.weight" in name:
         candidates.append(mx.transpose(tensor, (0, 2, 1)))
 
     if len(shape) == 1 and mx.issubdtype(tensor.dtype, mx.floating):
@@ -6433,10 +6433,12 @@ def _vlm_gguf_tensor_candidates(tensor):
     return candidates
 
 
-def _has_vlm_gguf_tensor_candidate(tensor):
+def _has_vlm_gguf_tensor_candidate(name, tensor):
     """Return whether a tensor shape can require HF-layout recovery."""
     shape = getattr(tensor, "shape", ())
-    if len(shape) in (3, 4, 5):
+    if len(shape) in (4, 5) or (
+        len(shape) == 3 and "depthwise_conv1d.weight" in name
+    ):
         return True
     if len(shape) == 1:
         dtype = getattr(tensor, "dtype", None)
@@ -6448,7 +6450,7 @@ def _has_vlm_gguf_rewrite_candidate(name, tensor):
     """Return whether a tensor can differ between mlx-vlm and GGUF layouts."""
     if any(candidate_name != name for candidate_name in _vlm_gguf_name_candidates(name)):
         return True
-    return _has_vlm_gguf_tensor_candidate(tensor)
+    return _has_vlm_gguf_tensor_candidate(name, tensor)
 
 
 def _mlx_arrays_match(actual, expected):
@@ -6488,7 +6490,7 @@ def _rewrite_mlx_vlm_tensor_for_gguf(name, tensor, sanitize_steps):
         return name, tensor, False
 
     for candidate_name in _vlm_gguf_name_candidates(name):
-        for candidate_tensor in _vlm_gguf_tensor_candidates(tensor):
+        for candidate_tensor in _vlm_gguf_tensor_candidates(name, tensor):
             for pipeline in _normalize_mlx_vlm_sanitize_pipelines(sanitize_steps):
                 sanitized = _apply_mlx_vlm_sanitizers(
                     pipeline,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6392,15 +6392,10 @@ def _vlm_gguf_name_candidates(name):
         if value not in candidates:
             candidates.append(value)
 
-    for namespace in (
-        "audio_tower.",
-        "vision_tower.",
-        "embed_audio.",
-        "embed_vision.",
+    if name.startswith(
+        ("audio_tower.", "vision_tower.", "embed_audio.", "embed_vision.")
     ):
-        if name.startswith(namespace):
-            add(f"model.{name}")
-            break
+        add(f"model.{name}")
 
     if name.startswith("thinker.vision_tower."):
         suffix = name[len("thinker.vision_tower."):]


### PR DESCRIPTION
## Summary

- Restore canonical Hugging Face `model.audio_tower.*`, `model.vision_tower.*`, `model.embed_audio.*`, and `model.embed_vision.*` candidates when inverting mlx-vlm sanitization for temporary GGUF staging.
- Prefer those canonical candidates before the unchanged MLX-native name so sanitizer replay selects the original checkpoint form.
- Add the rank-3 transpose candidate required to invert Gemma 4 audio depthwise Conv1d weights, scoped to the sanitizer's `depthwise_conv1d.weight` predicate.
- Cover candidate precedence, all four namespaces, calibration tensor preservation, unrelated rank-3 passthrough, real shard rewrites, and safetensors index consistency.

## Root cause

mlx-vlm's Gemma 4 sanitizer removes the leading `model.` namespace when loading canonical Hugging Face weights. The GGUF staging inversion did not reconstruct that namespace for the audio/vision towers or modality embeddings, so llama.cpp could not map tensors such as `audio_tower.layers.0.feed_forward1.ffw_layer_1.input_max`. The same sanitizer transposes rank-3 audio depthwise Conv1d weights, which also needed a self-inverse layout candidate before their canonical names could be selected.

## Behavior and scope

This changes only the temporary checkpoint prepared for GGUF conversion. Normal MLX merged-save names remain unchanged, calibration tensors are preserved, and `model.safetensors.index.json` continues to follow every staged tensor rename. The logic remains generic to sanitizer inversion: there is no Gemma 4 model-name branch, no Studio or llama.cpp change, and no MTP-specific behavior.

Rank-3 layout inversion is attempted only for `depthwise_conv1d.weight`, matching the upstream sanitizer that performs that transpose. Unrelated non-aliased rank-3 tensors skip sanitizer replay, while alias-bearing rank-3 VLM tensors can still receive sanitizer-proven name-only restoration without transpose or replacement of the tensor object. Rank-4, rank-5, and floating 1D inversion behavior is unchanged.

## Validation

```bash
python -m pytest tests/test_mlx_save_export_regressions.py -q
# 41 passed
```

```bash
python - <<'PY'
import sys
sys.path.insert(0, "tests")
from mlx_simulation import simulate_mlx_on_torch
simulate_mlx_on_torch()
import pytest
raise SystemExit(pytest.main(["tests/test_mlx_save_export_edge_cases.py", "-q"]))
PY
# 77 passed
```

A real non-Gemma LFM2.5-VL rank-3 tensor remained unchanged by name and object identity and triggered zero sanitizer replays. An alias-bearing unrelated rank-3 regression also verifies canonical name-only restoration with exactly one replay and fails if transpose is attempted.

A real 16-bit export of `unsloth/gemma-4-E2B-it` completed both conversions. The staged checkpoint rewrote 1,411 multimodal tensors, retained 232 tensors for each of `input_max`, `input_min`, `output_max`, and `output_min`, left zero stripped modality namespace names, and had exact equality between all 2,011 shard keys and safetensors index entries.

The resulting text GGUF contained 601 tensors and the BF16 mmproj contained all 1,411 multimodal tensors. A local llama.cpp server loaded both artifacts together and returned HTTP 200 from its health endpoint.

Fixes unslothai/unsloth#6808
