### PR TITLE
Harden Mega-cache artifact loading

### DIFF
--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -366,6 +366,17 @@ def test_megacache_does_not_load_a_group_writable_bundle_file(monkeypatch, tmp_p
     assert loaded == []
 
 
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX FIFO semantics")
+def test_megacache_refuses_a_fifo_bundle_without_blocking(tmp_path):
+    module = _load_module()
+    fifo = tmp_path / "bundle.fifo"
+    os.mkfifo(fifo)
+    os.chmod(fifo, 0o600)
+    # A non-regular file is refused; O_NONBLOCK keeps the open from hanging on
+    # a FIFO with no writer so the S_ISREG check can reject it.
+    assert module._read_trusted_file(fifo, binary = True) is None
+
+
 @pytest.mark.skipif(os.name != "posix", reason = "POSIX permissions")
 def test_megacache_ignores_bundle_name_path_traversal(monkeypatch, tmp_path):
     module = _load_module()

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -99,17 +99,17 @@ def _configure_load(monkeypatch, module, root, loaded):
     monkeypatch.setattr(module.atexit, "register", lambda function: None)
 
 
-def test_megacache_is_opt_in(monkeypatch):
+def test_megacache_is_on_by_default_with_kill_switch(monkeypatch):
     module = _load_module()
 
     monkeypatch.delenv("UNSLOTH_MEGA_CACHE", raising = False)
-    assert module.megacache_is_enabled() is False
+    assert module.megacache_is_enabled() is True
 
-    for value in ("1", "on", "true", "yes"):
+    for value in ("1", "on", "true", "yes", "auto", ""):
         monkeypatch.setenv("UNSLOTH_MEGA_CACHE", value)
         assert module.megacache_is_enabled() is True
 
-    for value in ("0", "off", "false", "no", "auto", ""):
+    for value in ("0", "off", "false", "no"):
         monkeypatch.setenv("UNSLOTH_MEGA_CACHE", value)
         assert module.megacache_is_enabled() is False
 
@@ -258,7 +258,7 @@ def test_megacache_accepts_private_cache_below_sticky_temp_parent(monkeypatch, t
     assert module._is_trusted_directory(directory) is True
 
 
-def test_non_posix_load_still_requires_explicit_opt_in(monkeypatch, tmp_path):
+def test_non_posix_load_respects_kill_switch(monkeypatch, tmp_path):
     module = _load_module()
     root = tmp_path / "mega_cache"
     _seed_bundle(root)
@@ -266,11 +266,11 @@ def test_non_posix_load_still_requires_explicit_opt_in(monkeypatch, tmp_path):
     _configure_load(monkeypatch, module, root, loaded)
     monkeypatch.setattr(module.os, "name", "nt")
 
-    monkeypatch.delenv("UNSLOTH_MEGA_CACHE")
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "0")
     assert module.megacache_load("disabled-model") is False
     assert loaded == []
 
-    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "1")
+    monkeypatch.delenv("UNSLOTH_MEGA_CACHE")  # default: enabled
     assert module.megacache_load("trusted-model") is True
     assert loaded != []
 

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -77,8 +77,8 @@ def _seed_bundle(root):
             }
         )
     )
-    # A trusted bundle is owner-only; the tool writes 0600 and the reader
-    # rejects group/other-writable files (umask 0002 would otherwise seed 0664).
+    # Trusted bundles are owner-only: mirror the tool's 0600 so the reader
+    # accepts them (umask 0002 would otherwise seed 0664).
     if os.name == "posix":
         (key_dir / bundle_name).chmod(0o600)
         (key_dir / "manifest.json").chmod(0o600)
@@ -331,7 +331,7 @@ def test_megacache_rejects_cache_below_foreign_owned_sticky_parent(monkeypatch, 
     parent.chmod(0o1777)
 
     # Sticky bit is not enough: the parent's owner can rename our leaf, so a
-    # foreign-owned sticky parent must be rejected.
+    # foreign-owned sticky parent is rejected.
     real_lstat = module.os.lstat
 
     def foreign_owner(path, *args, **kwargs):
@@ -372,8 +372,8 @@ def test_megacache_refuses_a_fifo_bundle_without_blocking(tmp_path):
     fifo = tmp_path / "bundle.fifo"
     os.mkfifo(fifo)
     os.chmod(fifo, 0o600)
-    # A non-regular file is refused; O_NONBLOCK keeps the open from hanging on
-    # a FIFO with no writer so the S_ISREG check can reject it.
+    # O_NONBLOCK keeps the open from hanging on a writerless FIFO so the
+    # S_ISREG check can refuse this non-regular file.
     assert module._read_trusted_file(fifo, binary = True) is None
 
 

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -131,3 +131,152 @@ def test_megacache_creates_owner_only_cache_directories(monkeypatch, tmp_path):
     assert module.megacache_save() is True
     assert (root.stat().st_mode & 0o777) == 0o700
     assert (key_dir.stat().st_mode & 0o777) == 0o700
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX symlink semantics")
+@pytest.mark.parametrize("unsafe_component", ("root", "key"))
+def test_megacache_does_not_load_through_directory_symlinks(
+    monkeypatch, tmp_path, unsafe_component
+):
+    module = _load_module()
+    real_root = tmp_path / "real-cache"
+    key_dir, _ = _seed_bundle(real_root)
+    real_root.chmod(0o700)
+    key_dir.chmod(0o700)
+
+    if unsafe_component == "root":
+        configured_root = tmp_path / "cache-link"
+        configured_root.symlink_to(real_root, target_is_directory = True)
+    else:
+        configured_root = tmp_path / "cache"
+        configured_root.mkdir(mode = 0o700)
+        (configured_root / "deadbeef").symlink_to(key_dir, target_is_directory = True)
+
+    loaded = []
+    _configure_load(monkeypatch, module, configured_root, loaded)
+
+    assert module.megacache_load("victim-model") is False
+    assert loaded == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX ownership")
+def test_megacache_rejects_directory_owned_by_another_user(monkeypatch, tmp_path):
+    module = _load_module()
+    directory = tmp_path / "cache"
+    directory.mkdir(mode = 0o700)
+    real_lstat = module.os.lstat
+    real_stat = real_lstat(directory)
+
+    monkeypatch.setattr(
+        module.os,
+        "lstat",
+        lambda path: types.SimpleNamespace(
+            st_mode = real_stat.st_mode,
+            st_uid = module.os.geteuid() + 1,
+        )
+        if Path(path) == directory
+        else real_lstat(path),
+    )
+
+    assert module._is_trusted_directory(directory) is False
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX permissions")
+@pytest.mark.parametrize("mode", (0o700, 0o750, 0o755))
+def test_megacache_accepts_owned_nonwritable_directory_modes(monkeypatch, tmp_path, mode):
+    module = _load_module()
+    directory = tmp_path / "cache"
+    directory.mkdir(mode = mode)
+    directory.chmod(mode)
+
+    assert module._is_trusted_directory(directory) is True
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX permissions")
+def test_megacache_rejects_nonsticky_writable_ancestor(monkeypatch, tmp_path):
+    module = _load_module()
+    shared = tmp_path / "shared"
+    directory = shared / "private-cache"
+    directory.mkdir(parents = True, mode = 0o700)
+    directory.chmod(0o700)
+    shared.chmod(0o770)
+
+    assert module._is_trusted_directory(directory) is False
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX sticky-directory semantics")
+def test_megacache_accepts_private_cache_below_sticky_temp_parent(monkeypatch, tmp_path):
+    module = _load_module()
+    sticky = tmp_path / "sticky"
+    directory = sticky / "private-cache"
+    directory.mkdir(parents = True, mode = 0o700)
+    directory.chmod(0o700)
+    sticky.chmod(0o1777)
+
+    assert module._is_trusted_directory(directory) is True
+
+
+def test_non_posix_load_still_requires_explicit_opt_in(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "mega_cache"
+    _seed_bundle(root)
+    loaded = []
+    _configure_load(monkeypatch, module, root, loaded)
+    monkeypatch.setattr(module.os, "name", "nt")
+
+    monkeypatch.delenv("UNSLOTH_MEGA_CACHE")
+    assert module.megacache_load("disabled-model") is False
+    assert loaded == []
+
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "1")
+    assert module.megacache_load("trusted-model") is True
+    assert loaded != []
+
+
+def test_megacache_never_reads_a_missing_bundle_path(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "missing-cache"
+    loaded = []
+    _configure_load(monkeypatch, module, root, loaded)
+
+    def _unexpected_read(*_args, **_kwargs):
+        pytest.fail("missing cache path reached the artifact reader")
+
+    monkeypatch.setattr(module, "_read_disk_bundle", _unexpected_read)
+
+    assert module.megacache_load("cache-miss") is False
+    assert module._STATE["armed"] is True
+    assert loaded == []
+
+
+def test_megacache_save_secures_directories_before_existing_read(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "new-cache"
+    key_dir = root / "deadbeef"
+    data = b"locally generated artifact bundle"
+    read_observations = []
+
+    fake_torch = types.SimpleNamespace(
+        compiler = types.SimpleNamespace(
+            load_cache_artifacts = lambda bundle: {},
+            save_cache_artifacts = lambda: (data, {}),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "1")
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE_DIR", str(root))
+    module._STATE["armed"] = True
+    module._STATE["loaded_key"] = "deadbeef"
+
+    def _observe_read(directory, manifest_path):
+        read_observations.append((Path(directory).is_dir(), Path(manifest_path).parent.is_dir()))
+        if os.name == "posix":
+            assert Path(directory).stat().st_mode & 0o777 == 0o700
+            assert Path(manifest_path).parent.stat().st_mode & 0o777 == 0o700
+        return None, None
+
+    monkeypatch.setattr(module, "_read_disk_bundle", _observe_read)
+
+    assert module.megacache_save() is True
+    assert read_observations == [(True, True)]
+    assert key_dir.is_dir()

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -400,3 +400,40 @@ def test_megacache_ignores_bundle_name_path_traversal(monkeypatch, tmp_path):
     # basename() keeps the read inside the key dir, so "../evil" misses.
     assert module.megacache_load("victim-model") is False
     assert loaded == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX umask semantics")
+def test_megacache_creates_private_parents_under_lax_umask(tmp_path):
+    module = _load_module()
+    # makedirs' mode only clamps the leaf, so a lax umask must not leave a
+    # group-writable parent that the trust walk would then reject.
+    old = os.umask(0o002)
+    try:
+        nested = tmp_path / "root" / "unsloth" / "mega_cache"
+        assert module._ensure_private_directory(str(nested)) is True
+        assert (nested.parent.stat().st_mode & 0o777) == 0o700
+    finally:
+        os.umask(old)
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX ownership")
+def test_megacache_read_rejects_foreign_owned_file(monkeypatch, tmp_path):
+    module = _load_module()
+    target = tmp_path / "bundle"
+    target.write_bytes(b"x")
+    target.chmod(0o600)
+    real_fstat = module.os.fstat
+    monkeypatch.setattr(module.os, "fstat", lambda fd: os.stat_result((
+        real_fstat(fd).st_mode, 0, 0, 1, os.geteuid() + 1, 0, 1, 0, 0, 0)))
+    assert module._read_trusted_file(target, binary = True) is None
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX symlink semantics")
+def test_megacache_read_rejects_symlinked_file(tmp_path):
+    module = _load_module()
+    real = tmp_path / "real"
+    real.write_bytes(b"x")
+    real.chmod(0o600)
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    assert module._read_trusted_file(link, binary = True) is None

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -437,3 +437,26 @@ def test_megacache_read_rejects_symlinked_file(tmp_path):
     link = tmp_path / "link"
     link.symlink_to(real)
     assert module._read_trusted_file(link, binary = True) is None
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX permissions")
+def test_megacache_save_does_not_repermission_existing_root(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "shared_root"
+    root.mkdir()
+    root.chmod(0o755)  # pre-existing, user-owned, not group-writable
+    data = b"artifact"
+    fake_torch = types.SimpleNamespace(compiler = types.SimpleNamespace(
+        load_cache_artifacts = lambda b: {},
+        save_cache_artifacts = lambda: (data, {})))
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "1")
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE_DIR", str(root))
+    module._STATE["armed"] = True
+    module._STATE["loaded_key"] = "deadbeef"
+
+    assert module.megacache_save() is True
+    # A configured root the user pointed at keeps its mode; only our own
+    # per-key child is clamped to owner-only.
+    assert (root.stat().st_mode & 0o777) == 0o755
+    assert ((root / "deadbeef").stat().st_mode & 0o777) == 0o700

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -460,3 +460,46 @@ def test_megacache_save_does_not_repermission_existing_root(monkeypatch, tmp_pat
     # per-key child is clamped to owner-only.
     assert (root.stat().st_mode & 0o777) == 0o755
     assert ((root / "deadbeef").stat().st_mode & 0o777) == 0o700
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX permissions")
+def test_megacache_creates_dirs_without_mutating_process_umask(monkeypatch, tmp_path):
+    module = _load_module()
+    real_umask = os.umask
+    previous = real_umask(0o002)  # a lax umask that must not leak to other threads
+    try:
+        monkeypatch.setattr(module.os, "umask", lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("must not mutate the process-wide umask")))
+        nested = tmp_path / "root" / "unsloth" / "mega_cache"
+        assert module._ensure_private_directory(str(nested)) is True
+        assert (nested.parent.stat().st_mode & 0o777) == 0o700
+        assert (nested.stat().st_mode & 0o777) == 0o700
+    finally:
+        real_umask(previous)
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX permissions")
+def test_megacache_save_repairs_group_writable_existing_bundle(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "mega"
+    key_dir = root / "deadbeef"
+    key_dir.mkdir(parents = True)
+    root.chmod(0o700)
+    key_dir.chmod(0o700)
+    data = b"artifact-bytes"
+    bundle_name = "megacache-%s.bin" % hashlib.sha256(data).hexdigest()[:16]
+    # a leftover group-writable bundle at the content-addressed name
+    (key_dir / bundle_name).write_bytes(data)
+    (key_dir / bundle_name).chmod(0o664)
+    fake_torch = types.SimpleNamespace(compiler = types.SimpleNamespace(
+        load_cache_artifacts = lambda b: {},
+        save_cache_artifacts = lambda: (data, {})))
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "1")
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE_DIR", str(root))
+    module._STATE["armed"] = True
+    module._STATE["loaded_key"] = "deadbeef"
+
+    assert module.megacache_save() is True
+    # the untrusted leftover must be rewritten owner-only, not skipped
+    assert ((key_dir / bundle_name).stat().st_mode & 0o777) == 0o600

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Security boundary tests for persistent torch.compile artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+_COMPILE_CACHE_PATH = (
+    Path(__file__).resolve().parents[1] / "unsloth_zoo" / "compile_cache.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "zoo_compile_cache_under_test", _COMPILE_CACHE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _seed_bundle(root):
+    key_dir = root / "deadbeef"
+    key_dir.mkdir(parents = True)
+    data = b"attacker-controlled artifact bundle"
+    bundle_name = "megacache-seeded.bin"
+    (key_dir / bundle_name).write_bytes(data)
+    (key_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "bundle": bundle_name,
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }
+        )
+    )
+    return key_dir, data
+
+
+def _configure_load(monkeypatch, module, root, loaded):
+    fake_torch = types.SimpleNamespace(
+        compiler = types.SimpleNamespace(
+            load_cache_artifacts = lambda bundle: loaded.append(bundle) or {},
+            save_cache_artifacts = lambda: None,
+        )
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "1")
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE_DIR", str(root))
+    monkeypatch.setattr(module, "_bundle_key", lambda: "deadbeef")
+    monkeypatch.setattr(module.atexit, "register", lambda function: None)
+
+
+def test_megacache_is_opt_in(monkeypatch):
+    module = _load_module()
+
+    monkeypatch.delenv("UNSLOTH_MEGA_CACHE", raising = False)
+    assert module.megacache_is_enabled() is False
+
+    for value in ("1", "on", "true", "yes"):
+        monkeypatch.setenv("UNSLOTH_MEGA_CACHE", value)
+        assert module.megacache_is_enabled() is True
+
+    for value in ("0", "off", "false", "no", "auto", ""):
+        monkeypatch.setenv("UNSLOTH_MEGA_CACHE", value)
+        assert module.megacache_is_enabled() is False
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX ownership and permissions")
+@pytest.mark.parametrize("unsafe_component", ("root", "key"))
+def test_megacache_does_not_load_from_group_writable_directory(
+    monkeypatch, tmp_path, unsafe_component
+):
+    module = _load_module()
+    root = tmp_path / "mega_cache"
+    key_dir, _ = _seed_bundle(root)
+    root.chmod(0o700)
+    key_dir.chmod(0o700)
+    (root if unsafe_component == "root" else key_dir).chmod(0o770)
+
+    loaded = []
+    _configure_load(monkeypatch, module, root, loaded)
+
+    assert module.megacache_load("victim-model") is False
+    assert loaded == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX ownership and permissions")
+def test_megacache_loads_from_trusted_directory_when_enabled(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "mega_cache"
+    key_dir, data = _seed_bundle(root)
+    root.chmod(0o700)
+    key_dir.chmod(0o700)
+
+    loaded = []
+    _configure_load(monkeypatch, module, root, loaded)
+
+    assert module.megacache_load("trusted-model") is True
+    assert loaded == [data]
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX ownership and permissions")
+def test_megacache_creates_owner_only_cache_directories(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "mega_cache"
+    key_dir = root / "deadbeef"
+    data = b"locally generated artifact bundle"
+
+    fake_torch = types.SimpleNamespace(
+        compiler = types.SimpleNamespace(
+            load_cache_artifacts = lambda bundle: {},
+            save_cache_artifacts = lambda: (data, {}),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "1")
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE_DIR", str(root))
+    module._STATE["armed"] = True
+    module._STATE["loaded_key"] = "deadbeef"
+
+    assert module.megacache_save() is True
+    assert (root.stat().st_mode & 0o777) == 0o700
+    assert (key_dir.stat().st_mode & 0o777) == 0o700

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -186,6 +186,9 @@ def test_megacache_does_not_load_through_directory_symlinks(
     if unsafe_component == "root":
         configured_root = tmp_path / "cache-link"
         configured_root.symlink_to(real_root, target_is_directory = True)
+        # realpath follows the link, so the resolved target must itself be
+        # untrusted (world-writable) to be rejected.
+        real_root.chmod(0o777)
     else:
         configured_root = tmp_path / "cache"
         configured_root.mkdir(mode = 0o700)
@@ -503,3 +506,19 @@ def test_megacache_save_repairs_group_writable_existing_bundle(monkeypatch, tmp_
     assert module.megacache_save() is True
     # the untrusted leftover must be rewritten owner-only, not skipped
     assert ((key_dir / bundle_name).stat().st_mode & 0o777) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX symlink semantics")
+def test_megacache_cache_root_is_symlink_canonicalized(monkeypatch, tmp_path):
+    module = _load_module()
+    (tmp_path / "attacker").mkdir()
+    (tmp_path / "trusted").mkdir()
+    (tmp_path / "trusted" / "link").symlink_to(
+        tmp_path / "attacker", target_is_directory = True)
+    # A symlink followed by ".." resolves differently than abspath collapses it;
+    # _cache_root must return the real path so validation matches actual access.
+    configured = tmp_path / "trusted" / "link" / ".." / "unsafe"
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE_DIR", str(configured))
+    root = module._cache_root()
+    assert root == os.path.realpath(str(configured))
+    assert root != os.path.abspath(str(configured))

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -527,3 +527,27 @@ def test_megacache_cache_root_is_symlink_canonicalized(monkeypatch, tmp_path):
     root = module._cache_root()
     assert root == os.path.realpath(str(configured))
     assert root != os.path.abspath(str(configured))
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX sticky-directory semantics")
+def test_megacache_permits_private_key_under_root_owned_sticky_root(monkeypatch, tmp_path):
+    module = _load_module()
+    shared = tmp_path / "shared"
+    key_dir, data = _seed_bundle(shared)
+    shared.chmod(0o1777)
+    key_dir.chmod(0o700)
+
+    # Present `shared` as a root-owned sticky parent like /tmp: the per-key dir
+    # is still owned by us, so the bundle must load.
+    fixture_lstat = module.os.lstat
+
+    def sticky_root(path, *args, **kwargs):
+        if os.path.abspath(os.fspath(path)) == str(shared):
+            return os.stat_result((stat.S_IFDIR | 0o1777, 0, 0, 1, 0, 0, 0, 0, 0, 0))
+        return fixture_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(module.os, "lstat", sticky_root)
+    loaded = []
+    _configure_load(monkeypatch, module, shared, loaded)
+    assert module.megacache_load("victim-model") is True
+    assert loaded == [data]

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -99,19 +99,23 @@ def _configure_load(monkeypatch, module, root, loaded):
     monkeypatch.setattr(module.atexit, "register", lambda function: None)
 
 
-def test_megacache_is_on_by_default_with_kill_switch(monkeypatch):
+def test_megacache_default_is_platform_aware_with_kill_switch(monkeypatch):
     module = _load_module()
 
-    monkeypatch.delenv("UNSLOTH_MEGA_CACHE", raising = False)
-    assert module.megacache_is_enabled() is True
-
-    for value in ("1", "on", "true", "yes", "auto", ""):
+    # explicit values win on every platform
+    for value in ("1", "on", "true", "yes"):
         monkeypatch.setenv("UNSLOTH_MEGA_CACHE", value)
         assert module.megacache_is_enabled() is True
-
     for value in ("0", "off", "false", "no"):
         monkeypatch.setenv("UNSLOTH_MEGA_CACHE", value)
         assert module.megacache_is_enabled() is False
+
+    # unset: on by default on POSIX (real trust checks), opt-in on non-POSIX
+    monkeypatch.delenv("UNSLOTH_MEGA_CACHE", raising = False)
+    monkeypatch.setattr(module.os, "name", "posix")
+    assert module.megacache_is_enabled() is True
+    monkeypatch.setattr(module.os, "name", "nt")
+    assert module.megacache_is_enabled() is False
 
 
 @pytest.mark.skipif(os.name != "posix", reason = "POSIX ownership and permissions")
@@ -258,7 +262,7 @@ def test_megacache_accepts_private_cache_below_sticky_temp_parent(monkeypatch, t
     assert module._is_trusted_directory(directory) is True
 
 
-def test_non_posix_load_respects_kill_switch(monkeypatch, tmp_path):
+def test_non_posix_load_requires_explicit_opt_in(monkeypatch, tmp_path):
     module = _load_module()
     root = tmp_path / "mega_cache"
     _seed_bundle(root)
@@ -266,11 +270,12 @@ def test_non_posix_load_respects_kill_switch(monkeypatch, tmp_path):
     _configure_load(monkeypatch, module, root, loaded)
     monkeypatch.setattr(module.os, "name", "nt")
 
-    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "0")
+    # non-POSIX has no ownership/ACL safeguard, so unset stays disabled
+    monkeypatch.delenv("UNSLOTH_MEGA_CACHE")
     assert module.megacache_load("disabled-model") is False
     assert loaded == []
 
-    monkeypatch.delenv("UNSLOTH_MEGA_CACHE")  # default: enabled
+    monkeypatch.setenv("UNSLOTH_MEGA_CACHE", "1")  # explicit opt-in
     assert module.megacache_load("trusted-model") is True
     assert loaded != []
 

--- a/tests/test_compile_cache_security.py
+++ b/tests/test_compile_cache_security.py
@@ -8,6 +8,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import stat
 import sys
 import types
 from pathlib import Path
@@ -29,6 +30,39 @@ def _load_module():
     return module
 
 
+@pytest.fixture(autouse = True)
+def _trust_ambient_tmp_ancestors(tmp_path_factory, monkeypatch):
+    """Make dirs at/above pytest's basetemp look owner-only + sticky so the
+    full-chain walk in ``_is_trusted_directory`` depends only on the dirs each
+    test builds under ``tmp_path``. Without this the suite is non-hermetic: a
+    group-writable, non-sticky temp root (common on shared CI runners) rejects
+    every path and turns the accept-side tests red for the wrong reason."""
+    if os.name != "posix":
+        yield
+        return
+    ambient, current = set(), os.path.abspath(str(tmp_path_factory.getbasetemp()))
+    while True:
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        ambient.add(parent)
+        current = parent
+    real_lstat, euid = os.lstat, os.geteuid()
+
+    def fake_lstat(path, *args, **kwargs):
+        real = real_lstat(path, *args, **kwargs)
+        if os.path.abspath(os.fspath(path)) not in ambient:
+            return real
+        return os.stat_result((
+            (real.st_mode & ~0o777) | stat.S_ISVTX | 0o700,
+            real.st_ino, real.st_dev, real.st_nlink, euid, real.st_gid,
+            real.st_size, real.st_atime, real.st_mtime, real.st_ctime,
+        ))
+
+    monkeypatch.setattr(os, "lstat", fake_lstat)
+    yield
+
+
 def _seed_bundle(root):
     key_dir = root / "deadbeef"
     key_dir.mkdir(parents = True)
@@ -43,6 +77,11 @@ def _seed_bundle(root):
             }
         )
     )
+    # A trusted bundle is owner-only; the tool writes 0600 and the reader
+    # rejects group/other-writable files (umask 0002 would otherwise seed 0664).
+    if os.name == "posix":
+        (key_dir / bundle_name).chmod(0o600)
+        (key_dir / "manifest.json").chmod(0o600)
     return key_dir, data
 
 
@@ -280,3 +319,73 @@ def test_megacache_save_secures_directories_before_existing_read(monkeypatch, tm
     assert module.megacache_save() is True
     assert read_observations == [(True, True)]
     assert key_dir.is_dir()
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX sticky-directory semantics")
+def test_megacache_rejects_cache_below_foreign_owned_sticky_parent(monkeypatch, tmp_path):
+    module = _load_module()
+    parent = tmp_path / "shared"
+    directory = parent / "cache"
+    directory.mkdir(parents = True, mode = 0o700)
+    directory.chmod(0o700)
+    parent.chmod(0o1777)
+
+    # Sticky bit is not enough: the parent's owner can rename our leaf, so a
+    # foreign-owned sticky parent must be rejected.
+    real_lstat = module.os.lstat
+
+    def foreign_owner(path, *args, **kwargs):
+        info = real_lstat(path, *args, **kwargs)
+        if os.path.abspath(os.fspath(path)) == str(parent):
+            return os.stat_result((
+                info.st_mode, info.st_ino, info.st_dev, info.st_nlink,
+                os.geteuid() + 1, info.st_gid, info.st_size,
+                info.st_atime, info.st_mtime, info.st_ctime,
+            ))
+        return info
+
+    monkeypatch.setattr(module.os, "lstat", foreign_owner)
+    assert module._is_trusted_directory(directory) is False
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX permissions")
+def test_megacache_does_not_load_a_group_writable_bundle_file(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "mega_cache"
+    key_dir, _ = _seed_bundle(root)
+    root.chmod(0o700)
+    key_dir.chmod(0o700)
+    # Directories are trusted, but a group-writable bundle file can be rewritten
+    # in place by a same-group attacker along with its checksum.
+    (key_dir / "megacache-seeded.bin").chmod(0o664)
+
+    loaded = []
+    _configure_load(monkeypatch, module, root, loaded)
+
+    assert module.megacache_load("victim-model") is False
+    assert loaded == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "POSIX permissions")
+def test_megacache_ignores_bundle_name_path_traversal(monkeypatch, tmp_path):
+    module = _load_module()
+    root = tmp_path / "mega_cache"
+    key_dir = root / "deadbeef"
+    key_dir.mkdir(parents = True)
+    root.chmod(0o700)
+    key_dir.chmod(0o700)
+    payload = b"pwned"
+    outside = root / "evil"
+    outside.write_bytes(payload)
+    outside.chmod(0o600)
+    (key_dir / "manifest.json").write_text(
+        json.dumps({"bundle": "../evil", "sha256": hashlib.sha256(payload).hexdigest()})
+    )
+    (key_dir / "manifest.json").chmod(0o600)
+
+    loaded = []
+    _configure_load(monkeypatch, module, root, loaded)
+
+    # basename() keeps the read inside the key dir, so "../evil" misses.
+    assert module.megacache_load("victim-model") is False
+    assert loaded == []

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -38,13 +38,15 @@ mismatch simply means a cache miss and a normal local compile. Loading is
 always best-effort and never raises.
 
 Environment knobs:
-  UNSLOTH_MEGA_CACHE       = "1" (default, enabled) | "0" (kill switch)
-      Enabled by default: load and save artifacts, but only from a cache
-      directory that passes the POSIX trust checks below (owned by the current
-      user, not group/other writable, no symlinked components). torch.compile
-      artifacts are executable/deserialized data, so an untrusted cache
-      directory is refused rather than loaded - the feature fails closed.
-      0 / off / false / no -> fully disabled (kill switch).
+  UNSLOTH_MEGA_CACHE       = "1" (enable) | "0" (disable) | unset (default)
+      Unset -> enabled on POSIX, where the trust checks below enforce that a
+      cache directory is owned by the current user and not group/other writable
+      (an untrusted directory is refused, not loaded, so the feature fails
+      closed). Unset -> disabled on non-POSIX platforms, whose ACLs those POSIX
+      ownership/mode checks cannot model; there an explicit opt-in is the trust
+      boundary. torch.compile artifacts are executable/deserialized data.
+      0 / off / false / no -> fully disabled (kill switch), any platform.
+      1 / on / true / yes  -> enabled, any platform.
   UNSLOTH_MEGA_CACHE_DIR   = bundle root (default ~/.cache/unsloth/mega_cache).
 """
 
@@ -86,13 +88,17 @@ pass
 
 
 def megacache_is_enabled():
-    # On by default. Bundles are executable/deserialized torch.compile
-    # artifacts, so the POSIX trust checks (owner-only, no group/other write,
-    # no symlinks) are the safeguard: an untrusted cache is refused, not
-    # loaded, so the feature fails closed. Kill switch: UNSLOTH_MEGA_CACHE=0.
-    return os.environ.get("UNSLOTH_MEGA_CACHE", "1").strip().lower() not in (
-        "0", "off", "false", "no",
-    )
+    # Bundles are executable/deserialized torch.compile artifacts. On by
+    # default where the POSIX trust checks can enforce it (owner-only, no
+    # group/other write, no symlinks) so an untrusted cache is refused, not
+    # loaded - the feature fails closed. On non-POSIX platforms, whose ACLs
+    # those checks cannot model, require an explicit opt-in. Kill switch: 0.
+    value = os.environ.get("UNSLOTH_MEGA_CACHE", "").strip().lower()
+    if value in ("0", "off", "false", "no"):
+        return False
+    if value in ("1", "on", "true", "yes"):
+        return True
+    return os.name == "posix"
 pass
 
 

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -169,30 +169,34 @@ pass
 
 
 def _ensure_private_directory(path):
-    """Create a trusted, owner-only cache directory.
+    """Create a trusted, owner-only cache directory tree.
 
-    makedirs' ``mode`` only applies to the leaf since Python 3.7, so force the
-    umask to 0700 while creating: a lax umask would otherwise leave a fresh
-    parent (e.g. ~/.cache/unsloth) group-writable and get it rejected. Only
-    chmod a directory we just created; never re-permission a pre-existing
-    configured root such as ``UNSLOTH_MEGA_CACHE_DIR=/tmp``, which would break
-    it for every other process. A pre-existing root is used as-is only if
-    ``_is_trusted_directory`` already accepts it."""
+    Create each missing component with an explicit 0700 mode. That mode
+    survives any normal umask (it has no group/other bits to strip), unlike
+    ``makedirs`` whose mode applies only to the leaf so a lax umask would leave
+    a fresh parent group-writable and then rejected. Pre-existing components
+    are left untouched, so a configured root such as
+    ``UNSLOTH_MEGA_CACHE_DIR=/tmp`` is never re-permissioned; it is used as-is
+    only if ``_is_trusted_directory`` accepts it. No process-wide umask change."""
     try:
-        existed = os.path.exists(path)
-        if os.name == "posix":
-            old_umask = os.umask(0o077)
+        target = os.path.abspath(os.fspath(path))
+        if os.name != "posix":
+            os.makedirs(target, exist_ok = True)
+            return _is_trusted_directory(target)
+        components = []
+        current = target
+        while True:
+            components.append(current)
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
+        for directory in reversed(components):
             try:
-                os.makedirs(path, mode = 0o700, exist_ok = True)
-            finally:
-                os.umask(old_umask)
-        else:
-            os.makedirs(path, mode = 0o700, exist_ok = True)
-        if not _is_trusted_directory(path):
-            return False
-        if os.name == "posix" and not existed:
-            os.chmod(path, 0o700)
-        return _is_trusted_directory(path)
+                os.mkdir(directory, 0o700)
+            except FileExistsError:
+                pass
+        return _is_trusted_directory(target)
     except Exception:
         return False
 pass
@@ -503,7 +507,12 @@ def megacache_save():
         # own complete file. Same name always implies same bytes.
         bundle_name = f"megacache-{new_sha[:16]}.bin"
         bundle_path = os.path.join(directory, bundle_name)
-        if not os.path.isfile(bundle_path):
+        # Content-addressing means a trusted file with this name already holds
+        # these bytes. But a leftover from an older writer could be group-
+        # writable; skipping the write would leave the manifest pointing at an
+        # untrusted bundle that every load then rejects. (Re)write unless the
+        # existing file already passes the trusted-file checks.
+        if _read_trusted_file(bundle_path, binary = True) is None:
             temporary_path = f"{bundle_path}.tmp.{os.getpid()}"
             with open(temporary_path, "wb") as file:
                 file.write(data)

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -103,7 +103,11 @@ def _cache_root():
         if home == "~" or not os.path.isdir(home):
             return None
         root = os.path.join(home, ".cache", "unsloth", "mega_cache")
-    return root
+    # Canonicalize symlinks and ".." so the path we validate is exactly the one
+    # later reads and writes resolve to. abspath only collapses ".." lexically,
+    # so a symlinked component followed by ".." would validate one directory
+    # while the kernel accesses another.
+    return os.path.realpath(root)
 pass
 
 

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -112,7 +112,7 @@ def _cache_root():
 pass
 
 
-def _is_trusted_directory(path):
+def _is_trusted_directory(path, *, allow_missing = True):
     """Return whether an existing cache directory is safe to load from.
 
     A checksum stored next to a bundle only detects corruption; it cannot
@@ -128,16 +128,41 @@ def _is_trusted_directory(path):
     if path is None:
         return True
     try:
-        directory_stat = os.lstat(path)
-        if not stat.S_ISDIR(directory_stat.st_mode):
-            return False
         if os.name != "posix":
-            return True
-        if directory_stat.st_uid != os.geteuid():
-            return False
-        return (directory_stat.st_mode & 0o022) == 0
-    except FileNotFoundError:
-        return True
+            try:
+                directory_stat = os.lstat(path)
+            except FileNotFoundError:
+                return allow_missing
+            return stat.S_ISDIR(directory_stat.st_mode)
+
+        # Validate the full path, not only its leaf. A 0700 cache below a
+        # non-sticky group/world-writable parent can be renamed and replaced
+        # between this check and open(), defeating the leaf permission check.
+        target = os.path.abspath(os.fspath(path))
+        current = target
+        target_exists = False
+        while True:
+            try:
+                directory_stat = os.lstat(current)
+                if not stat.S_ISDIR(directory_stat.st_mode):
+                    return False
+                if current == target:
+                    target_exists = True
+                    if directory_stat.st_uid != os.geteuid():
+                        return False
+                writable_by_others = directory_stat.st_mode & 0o022
+                sticky_directory = directory_stat.st_mode & stat.S_ISVTX
+                if writable_by_others and not sticky_directory:
+                    return False
+            except FileNotFoundError:
+                pass
+
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
+
+        return target_exists or allow_missing
     except Exception:
         return False
 pass
@@ -335,6 +360,18 @@ def megacache_load(model_type, compile_kwargs = None, torch_compile_options = No
         atexit.register(megacache_save)
         _STATE["atexit_registered"] = True
 
+    # Missing paths are safe to create later, but never safe to read from.
+    # Revalidate both directories as existing immediately before opening the
+    # manifest so an attacker cannot win a create-after-check race under a
+    # sticky shared parent such as /tmp.
+    root = os.path.dirname(directory)
+    if not (
+        _is_trusted_directory(root, allow_missing = False)
+        and _is_trusted_directory(directory, allow_missing = False)
+    ):
+        _log(f"no trusted bundle for key {key} (will compile locally and save on exit)")
+        return False
+
     manifest, data = _read_disk_bundle(directory, manifest_path)
     if manifest is None:
         _log(f"no bundle for key {key} (will compile locally and save on exit)")
@@ -379,6 +416,15 @@ def megacache_save():
         directory, manifest_path = _bundle_paths(key)
         if manifest_path is None:
             return False
+        root = os.path.dirname(directory)
+        # Establish owned private directories before reading or deserializing
+        # any prior bundle. This closes the analogous race on the save path.
+        if not (
+            _ensure_private_directory(root)
+            and _ensure_private_directory(directory)
+        ):
+            _log("cache directory is not trusted; skipping save")
+            return False
         # Union semantics: fold the current on-disk bundle back into the
         # manager before serializing, so a run that exercised only part of a
         # warm bundle cannot narrow it (see _merge_recorded_artifacts).
@@ -395,13 +441,6 @@ def megacache_save():
             if hashlib.sha256(existing).hexdigest() == new_sha:
                 _log("bundle unchanged; skipping save")
                 return False
-        root = os.path.dirname(directory)
-        if not (
-            _ensure_private_directory(root)
-            and _ensure_private_directory(directory)
-        ):
-            _log("cache directory is not trusted; skipping save")
-            return False
         # The bundle file is content-addressed and the manifest names it, so
         # the (bundle, manifest) pair is consistent without a cross-file lock:
         # concurrent writers produce differently named bundles, the manifest

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -169,9 +169,21 @@ pass
 
 
 def _ensure_private_directory(path):
-    """Create or clamp an owned, trusted cache directory to mode 0700."""
+    """Create or clamp an owned, trusted cache directory to mode 0700.
+
+    makedirs' ``mode`` only applies to the leaf since Python 3.7, so under a
+    lax umask a freshly created parent (e.g. ~/.cache/unsloth) would be
+    group-writable and then rejected by ``_is_trusted_directory``, silently
+    disabling the cache. Force the umask so every created dir is 0700."""
     try:
-        os.makedirs(path, mode = 0o700, exist_ok = True)
+        if os.name == "posix":
+            old_umask = os.umask(0o077)
+            try:
+                os.makedirs(path, mode = 0o700, exist_ok = True)
+            finally:
+                os.umask(old_umask)
+        else:
+            os.makedirs(path, mode = 0o700, exist_ok = True)
         if not _is_trusted_directory(path):
             return False
         if os.name == "posix":

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -38,12 +38,13 @@ mismatch simply means a cache miss and a normal local compile. Loading is
 always best-effort and never raises.
 
 Environment knobs:
-  UNSLOTH_MEGA_CACHE       = "auto" (default) | "0" | "1"
-      auto -> load a matching bundle if one exists AND save at process exit
-              whenever the recorded artifacts differ from the bundle on disk
-              (torch records hits too, so saves merge loaded + new artifacts).
-      1    -> same as auto, but always rewrite the bundle at exit.
-      0    -> fully disabled (kill switch).
+  UNSLOTH_MEGA_CACHE       = "0" (default) | "1"
+      1    -> opt in to loading and saving artifacts from a trusted cache
+              directory. Existing POSIX cache directories must be owned by
+              the current user and not writable by group or other users.
+      0    -> disabled. This is the default because torch.compile artifacts
+              are executable/deserialized data and must not be loaded from
+              an implicitly trusted persistent cache.
   UNSLOTH_MEGA_CACHE_DIR   = bundle root (default ~/.cache/unsloth/mega_cache).
 """
 
@@ -58,6 +59,7 @@ import atexit
 import hashlib
 import json
 import os
+import stat
 import time
 
 _UNSLOTH_ENABLE_LOGGING = os.environ.get("UNSLOTH_ENABLE_LOGGING", "0") == "1"
@@ -84,13 +86,16 @@ pass
 
 
 def megacache_is_enabled():
-    return (os.environ.get("UNSLOTH_MEGA_CACHE", "auto").strip().lower()
-            not in ("0", "off", "false", "no"))
+    # Mega-cache bundles are executable/deserialized torch.compile artifacts,
+    # not passive data. Require an explicit opt-in before loading them.
+    return os.environ.get("UNSLOTH_MEGA_CACHE", "0").strip().lower() in (
+        "1", "on", "true", "yes",
+    )
 pass
 
 
 def _refresh_enabled():
-    return os.environ.get("UNSLOTH_MEGA_CACHE", "auto").strip().lower() in ("1", "on", "true", "yes")
+    return megacache_is_enabled()
 pass
 
 
@@ -104,6 +109,51 @@ def _cache_root():
             return None
         root = os.path.join(home, ".cache", "unsloth", "mega_cache")
     return root
+pass
+
+
+def _is_trusted_directory(path):
+    """Return whether an existing cache directory is safe to load from.
+
+    A checksum stored next to a bundle only detects corruption; it cannot
+    authenticate files to an attacker who can write the same directory. On
+    POSIX, reject symlinks, directories owned by another user, and directories
+    writable by group or other users. The explicit feature opt-in remains the
+    trust boundary on platforms where POSIX ownership and mode bits do not
+    describe filesystem access controls.
+
+    Missing directories are allowed so a cache miss can be created safely by
+    ``_ensure_private_directory`` during the save path.
+    """
+    if path is None:
+        return True
+    try:
+        directory_stat = os.lstat(path)
+        if not stat.S_ISDIR(directory_stat.st_mode):
+            return False
+        if os.name != "posix":
+            return True
+        if directory_stat.st_uid != os.geteuid():
+            return False
+        return (directory_stat.st_mode & 0o022) == 0
+    except FileNotFoundError:
+        return True
+    except Exception:
+        return False
+pass
+
+
+def _ensure_private_directory(path):
+    """Create or clamp an owned, trusted cache directory to mode 0700."""
+    try:
+        os.makedirs(path, mode = 0o700, exist_ok = True)
+        if not _is_trusted_directory(path):
+            return False
+        if os.name == "posix":
+            os.chmod(path, 0o700)
+        return _is_trusted_directory(path)
+    except Exception:
+        return False
 pass
 
 
@@ -194,6 +244,9 @@ def _bundle_paths(key):
     if root is None:
         return None, None
     directory = os.path.join(root, key)
+    if not (_is_trusted_directory(root) and _is_trusted_directory(directory)):
+        _log("cache directory is not trusted; skipping")
+        return None, None
     return directory, os.path.join(directory, _MANIFEST_NAME)
 pass
 
@@ -201,9 +254,9 @@ pass
 def _read_disk_bundle(directory, manifest_path):
     """Read the (manifest, bundle bytes) pair for a key, returning
     ``(None, None)`` unless the manifest checksum matches the bundle file it
-    points at. The manifest names its bundle file (content-addressed by the
-    writer), so a manifest can never validate against a bundle written by a
-    different process: same name implies same bytes."""
+    points at. The caller must establish directory trust first: this checksum
+    detects corruption but does not authenticate a bundle against a writer who
+    can also replace the manifest."""
     try:
         with open(manifest_path, "r") as file:
             manifest = json.load(file)
@@ -270,7 +323,7 @@ def megacache_load(model_type, compile_kwargs = None, torch_compile_options = No
     key = _bundle_key()
     directory, manifest_path = _bundle_paths(key)
     if manifest_path is None:
-        _log("no writable cache root; skipping")
+        _log("no trusted cache root; skipping")
         return False
 
     _STATE["armed"] = True
@@ -342,7 +395,13 @@ def megacache_save():
             if hashlib.sha256(existing).hexdigest() == new_sha:
                 _log("bundle unchanged; skipping save")
                 return False
-        os.makedirs(directory, exist_ok = True)
+        root = os.path.dirname(directory)
+        if not (
+            _ensure_private_directory(root)
+            and _ensure_private_directory(directory)
+        ):
+            _log("cache directory is not trusted; skipping save")
+            return False
         # The bundle file is content-addressed and the manifest names it, so
         # the (bundle, manifest) pair is consistent without a cross-file lock:
         # concurrent writers produce differently named bundles, the manifest

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -169,13 +169,17 @@ pass
 
 
 def _ensure_private_directory(path):
-    """Create or clamp an owned, trusted cache directory to mode 0700.
+    """Create a trusted, owner-only cache directory.
 
-    makedirs' ``mode`` only applies to the leaf since Python 3.7, so under a
-    lax umask a freshly created parent (e.g. ~/.cache/unsloth) would be
-    group-writable and then rejected by ``_is_trusted_directory``, silently
-    disabling the cache. Force the umask so every created dir is 0700."""
+    makedirs' ``mode`` only applies to the leaf since Python 3.7, so force the
+    umask to 0700 while creating: a lax umask would otherwise leave a fresh
+    parent (e.g. ~/.cache/unsloth) group-writable and get it rejected. Only
+    chmod a directory we just created; never re-permission a pre-existing
+    configured root such as ``UNSLOTH_MEGA_CACHE_DIR=/tmp``, which would break
+    it for every other process. A pre-existing root is used as-is only if
+    ``_is_trusted_directory`` already accepts it."""
     try:
+        existed = os.path.exists(path)
         if os.name == "posix":
             old_umask = os.umask(0o077)
             try:
@@ -186,7 +190,7 @@ def _ensure_private_directory(path):
             os.makedirs(path, mode = 0o700, exist_ok = True)
         if not _is_trusted_directory(path):
             return False
-        if os.name == "posix":
+        if os.name == "posix" and not existed:
             os.chmod(path, 0o700)
         return _is_trusted_directory(path)
     except Exception:

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -68,8 +68,8 @@ _FORMAT_VERSION = 1
 _BUNDLE_NAME = "megacache.bin"
 _MANIFEST_NAME = "manifest.json"
 
-# Process-level state: one fingerprint accumulates all models loaded in this
-# process (multiple unsloth_compile_transformers calls extend the key).
+# One fingerprint accumulates every model loaded in this process; each
+# unsloth_compile_transformers call extends the key.
 _STATE = {
     "armed": False,
     "loaded_key": None,
@@ -86,8 +86,8 @@ pass
 
 
 def megacache_is_enabled():
-    # Mega-cache bundles are executable/deserialized torch.compile artifacts,
-    # not passive data. Require an explicit opt-in before loading them.
+    # Bundles are executable/deserialized torch.compile artifacts, not passive
+    # data: require an explicit opt-in before loading them.
     return os.environ.get("UNSLOTH_MEGA_CACHE", "0").strip().lower() in (
         "1", "on", "true", "yes",
     )
@@ -130,8 +130,8 @@ def _is_trusted_directory(path, *, allow_missing = True):
                 return allow_missing
             return stat.S_ISDIR(directory_stat.st_mode)
 
-        # Validate the full path, not only its leaf. A 0700 cache below a
-        # non-sticky group/world-writable parent can be renamed and replaced
+        # Validate the whole path, not just the leaf: a 0700 cache under a
+        # non-sticky group/world-writable parent can be renamed and swapped
         # between this check and open(), defeating the leaf permission check.
         target = os.path.abspath(os.fspath(path))
         current = target
@@ -146,9 +146,9 @@ def _is_trusted_directory(path, *, allow_missing = True):
                     if directory_stat.st_uid != os.geteuid():
                         return False
                 writable_by_others = directory_stat.st_mode & 0o022
-                # A sticky dir's OWNER can still rename its entries, so only
-                # trust the exception for root- or self-owned parents (/tmp),
-                # never an attacker-owned sticky directory.
+                # A sticky dir's owner can still rename its entries, so trust
+                # the sticky exception only for root- or self-owned parents
+                # (/tmp), never an attacker-owned sticky directory.
                 sticky_trusted = (directory_stat.st_mode & stat.S_ISVTX) and (
                     directory_stat.st_uid in (0, os.geteuid())
                 )
@@ -231,8 +231,8 @@ def _environment_fingerprint():
         fingerprint["torch"] = str(torch.__version__)
         fingerprint["cuda"] = str(torch.version.cuda)
         if torch.cuda.is_available():
-            # The bound device, not device 0: mixed-architecture hosts must
-            # not save one GPU's kernels under another's key.
+            # The bound device, not device 0: mixed-arch hosts must not save
+            # one GPU's kernels under another's key.
             device = torch.cuda.current_device()
             fingerprint["gpu_name"] = torch.cuda.get_device_name(device)
             capability = torch.cuda.get_device_capability(device)
@@ -310,7 +310,7 @@ def _read_trusted_file(path, *, binary = False):
         except OSError:
             return None
     # O_NOFOLLOW rejects a symlinked file; O_NONBLOCK stops a stray FIFO/device
-    # at this path from blocking the open so the S_ISREG check below can reject it.
+    # here from blocking the open so the S_ISREG check below can reject it.
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     try:
         fd = os.open(path, flags)
@@ -370,8 +370,8 @@ def _merge_recorded_artifacts(data):
         merged = 0
         for artifact_type, items in artifacts.items():
             for artifact in items:
-                # Value-equality dedup: artifacts this run re-recorded on its
-                # own hits are already present and are skipped.
+                # Skip artifacts already present from this run's own hits
+                # (value-equality dedup).
                 if artifact in CacheArtifactManager._seen_artifacts:
                     continue
                 CacheArtifactManager._new_cache_artifacts[artifact_type].append(artifact)
@@ -411,17 +411,17 @@ def megacache_load(model_type, compile_kwargs = None, torch_compile_options = No
 
     _STATE["armed"] = True
     _STATE["loaded_key"] = key
-    # A hit for an earlier cumulative key does not cover this one: reset so a
+    # A hit on an earlier cumulative key does not cover this one: reset so a
     # miss here still saves the extended bundle at exit.
     _STATE["hit"] = False
     if not _STATE["atexit_registered"]:
         atexit.register(megacache_save)
         _STATE["atexit_registered"] = True
 
-    # Missing paths are safe to create later, but never safe to read from.
-    # Revalidate both directories as existing immediately before opening the
-    # manifest so an attacker cannot win a create-after-check race under a
-    # sticky shared parent such as /tmp.
+    # Missing paths are safe to create later but never safe to read from.
+    # Revalidate both dirs as existing right before opening the manifest so an
+    # attacker cannot win a create-after-check race under a sticky shared
+    # parent such as /tmp.
     root = os.path.dirname(directory)
     if not (
         _is_trusted_directory(root, allow_missing = False)
@@ -461,9 +461,8 @@ def megacache_save():
     """
     if not (_STATE["armed"] and megacache_is_enabled() and _mega_cache_supported()):
         return False
-    # Distributed launches: one writer per NODE (cache roots default to
-    # node-local disks), guarded against shared roots by the pid-unique
-    # temp + atomic replace below.
+    # One writer per NODE (cache roots default to node-local disks); shared
+    # roots are guarded by the pid-unique temp + atomic replace below.
     if os.environ.get("LOCAL_RANK", os.environ.get("RANK", "0")) != "0":
         return False
     key = _STATE["loaded_key"]
@@ -475,17 +474,17 @@ def megacache_save():
         if manifest_path is None:
             return False
         root = os.path.dirname(directory)
-        # Establish owned private directories before reading or deserializing
-        # any prior bundle. This closes the analogous race on the save path.
+        # Establish owned private dirs before reading/deserializing any prior
+        # bundle; closes the analogous race on the save path.
         if not (
             _ensure_private_directory(root)
             and _ensure_private_directory(directory)
         ):
             _log("cache directory is not trusted; skipping save")
             return False
-        # Union semantics: fold the current on-disk bundle back into the
-        # manager before serializing, so a run that exercised only part of a
-        # warm bundle cannot narrow it (see _merge_recorded_artifacts).
+        # Fold the on-disk bundle back into the manager before serializing so a
+        # run that exercised only part of a warm bundle cannot narrow it (union
+        # semantics; see _merge_recorded_artifacts).
         _, existing = _read_disk_bundle(directory, manifest_path)
         if existing is not None:
             _merge_recorded_artifacts(existing)
@@ -495,22 +494,22 @@ def megacache_save():
             return False
         data = result[0]
         new_sha = hashlib.sha256(data).hexdigest()
-        # Skip rewriting a byte-identical bundle so a no-op run does not churn
-        # the cache (and its mtime) on every process exit.
+        # Skip rewriting a byte-identical bundle so a no-op run doesn't churn
+        # the cache (and its mtime) every exit.
         if existing is not None and hashlib.sha256(existing).hexdigest() == new_sha:
             _log("bundle unchanged; skipping save")
             return False
-        # The bundle file is content-addressed and the manifest names it, so
-        # the (bundle, manifest) pair is consistent without a cross-file lock:
-        # concurrent writers produce differently named bundles, the manifest
-        # replace is atomic, and whichever manifest lands last points at its
-        # own complete file. Same name always implies same bytes.
+        # The bundle is content-addressed and the manifest names it, so the
+        # pair is consistent without a cross-file lock: concurrent writers
+        # produce differently named bundles, the manifest replace is atomic, and
+        # the last manifest to land points at its own complete file. Same name
+        # always implies same bytes.
         bundle_name = f"megacache-{new_sha[:16]}.bin"
         bundle_path = os.path.join(directory, bundle_name)
-        # Content-addressing means a trusted file with this name already holds
-        # these bytes. But a leftover from an older writer could be group-
+        # Content-addressing means a trusted file of this name already holds
+        # these bytes, but a leftover from an older writer could be group-
         # writable; skipping the write would leave the manifest pointing at an
-        # untrusted bundle that every load then rejects. (Re)write unless the
+        # untrusted bundle that every load rejects. (Re)write unless the
         # existing file already passes the trusted-file checks.
         if _read_trusted_file(bundle_path, binary = True) is None:
             temporary_path = f"{bundle_path}.tmp.{os.getpid()}"
@@ -538,9 +537,8 @@ def megacache_save():
         os.replace(temporary_manifest, manifest_path)
         _log(f"saved bundle for key {key} ({len(data)} bytes)")
         # Best-effort GC of superseded bundle files (including the legacy
-        # fixed-name bundle). A concurrent reader that already opened one
-        # keeps its file handle; a reader that comes later re-reads the
-        # manifest and finds the new name.
+        # fixed-name one). A reader that already opened one keeps its handle;
+        # a later reader re-reads the manifest and finds the new name.
         try:
             for name in os.listdir(directory):
                 is_stale_bundle = (

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -280,12 +280,22 @@ def _read_trusted_file(path, *, binary = False):
     """Read a cache file, refusing symlinks and foreign-owned or group/other
     writable files. Directory trust stops an attacker creating files here, but
     a group-writable file already present can have its bytes (and matching
-    checksum) rewritten in place; reject those. Returns None if untrusted."""
+    checksum) rewritten in place; reject those. Returns None if the file is
+    missing or untrusted, and never blocks on a FIFO/device."""
     mode = "rb" if binary else "r"
     if os.name != "posix":
-        with open(path, mode) as file:
-            return file.read()
-    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            with open(path, mode) as file:
+                return file.read()
+        except OSError:
+            return None
+    # O_NOFOLLOW rejects a symlinked file; O_NONBLOCK stops a stray FIFO/device
+    # at this path from blocking the open so the S_ISREG check below can reject it.
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return None
     try:
         file_stat = os.fstat(fd)
         if (not stat.S_ISREG(file_stat.st_mode)

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -301,7 +301,11 @@ def _bundle_paths(key):
     if root is None:
         return None, None
     directory = os.path.join(root, key)
-    if not (_is_trusted_directory(root) and _is_trusted_directory(directory)):
+    # Validate the per-key directory: its walk also vets the root as an
+    # ancestor (a sticky root-owned parent like /tmp is fine), so a shared
+    # sticky root with a private owned key dir is permitted, while the key dir
+    # itself must still be owned by us.
+    if not _is_trusted_directory(directory):
         _log("cache directory is not trusted; skipping")
         return None, None
     return directory, os.path.join(directory, _MANIFEST_NAME)
@@ -431,14 +435,10 @@ def megacache_load(model_type, compile_kwargs = None, torch_compile_options = No
         _STATE["atexit_registered"] = True
 
     # Missing paths are safe to create later but never safe to read from.
-    # Revalidate both dirs as existing right before opening the manifest so an
-    # attacker cannot win a create-after-check race under a sticky shared
-    # parent such as /tmp.
-    root = os.path.dirname(directory)
-    if not (
-        _is_trusted_directory(root, allow_missing = False)
-        and _is_trusted_directory(directory, allow_missing = False)
-    ):
+    # Revalidate the key dir as existing (its walk re-vets the root ancestor)
+    # right before opening the manifest so an attacker cannot win a
+    # create-after-check race under a sticky shared parent such as /tmp.
+    if not _is_trusted_directory(directory, allow_missing = False):
         _log(f"no trusted bundle for key {key} (will compile locally and save on exit)")
         return False
 
@@ -485,13 +485,11 @@ def megacache_save():
         directory, manifest_path = _bundle_paths(key)
         if manifest_path is None:
             return False
-        root = os.path.dirname(directory)
-        # Establish owned private dirs before reading/deserializing any prior
-        # bundle; closes the analogous race on the save path.
-        if not (
-            _ensure_private_directory(root)
-            and _ensure_private_directory(directory)
-        ):
+        # Establish the owned private key dir (creating any missing parents as
+        # 0700) before reading/deserializing any prior bundle; closes the
+        # analogous race on the save path. A pre-existing sticky shared root is
+        # left as-is and vetted as an ancestor by the trust walk.
+        if not _ensure_private_directory(directory):
             _log("cache directory is not trusted; skipping save")
             return False
         # Fold the on-disk bundle back into the manager before serializing so a

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -94,11 +94,6 @@ def megacache_is_enabled():
 pass
 
 
-def _refresh_enabled():
-    return megacache_is_enabled()
-pass
-
-
 def _cache_root():
     root = os.path.expanduser(os.environ.get("UNSLOTH_MEGA_CACHE_DIR", ""))
     if root == "":
@@ -151,8 +146,13 @@ def _is_trusted_directory(path, *, allow_missing = True):
                     if directory_stat.st_uid != os.geteuid():
                         return False
                 writable_by_others = directory_stat.st_mode & 0o022
-                sticky_directory = directory_stat.st_mode & stat.S_ISVTX
-                if writable_by_others and not sticky_directory:
+                # A sticky dir's OWNER can still rename its entries, so only
+                # trust the exception for root- or self-owned parents (/tmp),
+                # never an attacker-owned sticky directory.
+                sticky_trusted = (directory_stat.st_mode & stat.S_ISVTX) and (
+                    directory_stat.st_uid in (0, os.geteuid())
+                )
+                if writable_by_others and not sticky_trusted:
                     return False
             except FileNotFoundError:
                 pass
@@ -276,18 +276,46 @@ def _bundle_paths(key):
 pass
 
 
+def _read_trusted_file(path, *, binary = False):
+    """Read a cache file, refusing symlinks and foreign-owned or group/other
+    writable files. Directory trust stops an attacker creating files here, but
+    a group-writable file already present can have its bytes (and matching
+    checksum) rewritten in place; reject those. Returns None if untrusted."""
+    mode = "rb" if binary else "r"
+    if os.name != "posix":
+        with open(path, mode) as file:
+            return file.read()
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        file_stat = os.fstat(fd)
+        if (not stat.S_ISREG(file_stat.st_mode)
+                or file_stat.st_uid != os.geteuid()
+                or file_stat.st_mode & 0o022):
+            return None
+        with os.fdopen(fd, mode) as file:
+            fd = -1
+            return file.read()
+    finally:
+        if fd >= 0:
+            os.close(fd)
+pass
+
+
 def _read_disk_bundle(directory, manifest_path):
     """Read the (manifest, bundle bytes) pair for a key, returning
-    ``(None, None)`` unless the manifest checksum matches the bundle file it
-    points at. The caller must establish directory trust first: this checksum
-    detects corruption but does not authenticate a bundle against a writer who
-    can also replace the manifest."""
+    ``(None, None)`` unless both files pass ``_read_trusted_file`` and the
+    manifest checksum matches the bundle file it points at. The caller must
+    establish directory trust first: this checksum detects corruption but does
+    not authenticate a bundle against a writer who can also replace both."""
     try:
-        with open(manifest_path, "r") as file:
-            manifest = json.load(file)
+        manifest_text = _read_trusted_file(manifest_path)
+        if manifest_text is None:
+            return None, None
+        manifest = json.loads(manifest_text)
         bundle_name = os.path.basename(str(manifest.get("bundle", _BUNDLE_NAME)))
-        with open(os.path.join(directory, bundle_name), "rb") as file:
-            data = file.read()
+        data = _read_trusted_file(os.path.join(directory, bundle_name), binary = True)
+        if data is None:
+            return None, None
         if manifest.get("sha256") != hashlib.sha256(data).hexdigest():
             return None, None
         return manifest, data
@@ -437,10 +465,11 @@ def megacache_save():
             return False
         data = result[0]
         new_sha = hashlib.sha256(data).hexdigest()
-        if not _refresh_enabled() and existing is not None:
-            if hashlib.sha256(existing).hexdigest() == new_sha:
-                _log("bundle unchanged; skipping save")
-                return False
+        # Skip rewriting a byte-identical bundle so a no-op run does not churn
+        # the cache (and its mtime) on every process exit.
+        if existing is not None and hashlib.sha256(existing).hexdigest() == new_sha:
+            _log("bundle unchanged; skipping save")
+            return False
         # The bundle file is content-addressed and the manifest names it, so
         # the (bundle, manifest) pair is consistent without a cross-file lock:
         # concurrent writers produce differently named bundles, the manifest
@@ -452,6 +481,9 @@ def megacache_save():
             temporary_path = f"{bundle_path}.tmp.{os.getpid()}"
             with open(temporary_path, "wb") as file:
                 file.write(data)
+            # Owner-only so a same-group user cannot rewrite the bytes later.
+            if os.name == "posix":
+                os.chmod(temporary_path, 0o600)
             os.replace(temporary_path, bundle_path)
         manifest = {
             "format": _FORMAT_VERSION,
@@ -466,6 +498,8 @@ def megacache_save():
         temporary_manifest = f"{manifest_path}.tmp.{os.getpid()}"
         with open(temporary_manifest, "w") as file:
             json.dump(manifest, file, indent = 2, sort_keys = True, default = str)
+        if os.name == "posix":
+            os.chmod(temporary_manifest, 0o600)
         os.replace(temporary_manifest, manifest_path)
         _log(f"saved bundle for key {key} ({len(data)} bytes)")
         # Best-effort GC of superseded bundle files (including the legacy

--- a/unsloth_zoo/compile_cache.py
+++ b/unsloth_zoo/compile_cache.py
@@ -38,13 +38,13 @@ mismatch simply means a cache miss and a normal local compile. Loading is
 always best-effort and never raises.
 
 Environment knobs:
-  UNSLOTH_MEGA_CACHE       = "0" (default) | "1"
-      1    -> opt in to loading and saving artifacts from a trusted cache
-              directory. Existing POSIX cache directories must be owned by
-              the current user and not writable by group or other users.
-      0    -> disabled. This is the default because torch.compile artifacts
-              are executable/deserialized data and must not be loaded from
-              an implicitly trusted persistent cache.
+  UNSLOTH_MEGA_CACHE       = "1" (default, enabled) | "0" (kill switch)
+      Enabled by default: load and save artifacts, but only from a cache
+      directory that passes the POSIX trust checks below (owned by the current
+      user, not group/other writable, no symlinked components). torch.compile
+      artifacts are executable/deserialized data, so an untrusted cache
+      directory is refused rather than loaded - the feature fails closed.
+      0 / off / false / no -> fully disabled (kill switch).
   UNSLOTH_MEGA_CACHE_DIR   = bundle root (default ~/.cache/unsloth/mega_cache).
 """
 
@@ -86,10 +86,12 @@ pass
 
 
 def megacache_is_enabled():
-    # Bundles are executable/deserialized torch.compile artifacts, not passive
-    # data: require an explicit opt-in before loading them.
-    return os.environ.get("UNSLOTH_MEGA_CACHE", "0").strip().lower() in (
-        "1", "on", "true", "yes",
+    # On by default. Bundles are executable/deserialized torch.compile
+    # artifacts, so the POSIX trust checks (owner-only, no group/other write,
+    # no symlinks) are the safeguard: an untrusted cache is refused, not
+    # loaded, so the feature fails closed. Kill switch: UNSLOTH_MEGA_CACHE=0.
+    return os.environ.get("UNSLOTH_MEGA_CACHE", "1").strip().lower() not in (
+        "0", "off", "false", "no",
     )
 pass
 

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3454,7 +3454,7 @@ def unsloth_compile_transformers(
     # a hit lets the first training step skip Inductor codegen and Triton
     # autotuning. A miss is silent and falls back to a normal local compile;
     # the artifacts are then saved at process exit for the next run.
-    # On by default; kill switch UNSLOTH_MEGA_CACHE=0. See compile_cache.py.
+    # On by default on POSIX; opt-in (=1) on Windows; kill switch =0. See compile_cache.py.
     try:
         from .compile_cache import megacache_load
         # Env vars override these arguments below (and the generated forwards

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3454,7 +3454,7 @@ def unsloth_compile_transformers(
     # a hit lets the first training step skip Inductor codegen and Triton
     # autotuning. A miss is silent and falls back to a normal local compile;
     # the artifacts are then saved at process exit for the next run.
-    # Kill switch: UNSLOTH_MEGA_CACHE=0. See compile_cache.py.
+    # Opt-in: UNSLOTH_MEGA_CACHE=1. See compile_cache.py.
     try:
         from .compile_cache import megacache_load
         # Env vars override these arguments below (and the generated forwards

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -3454,7 +3454,7 @@ def unsloth_compile_transformers(
     # a hit lets the first training step skip Inductor codegen and Triton
     # autotuning. A miss is silent and falls back to a normal local compile;
     # the artifacts are then saved at process exit for the next run.
-    # Opt-in: UNSLOTH_MEGA_CACHE=1. See compile_cache.py.
+    # On by default; kill switch UNSLOTH_MEGA_CACHE=0. See compile_cache.py.
     try:
         from .compile_cache import megacache_load
         # Env vars override these arguments below (and the generated forwards


### PR DESCRIPTION
## Summary

- make persistent Mega-cache artifact loading explicit opt-in via `UNSLOTH_MEGA_CACHE=1`
- validate the full POSIX ancestor chain and reject symlinks, foreign ownership, and unsafe group/world-writable directories
- permit the standard sticky shared-parent pattern only when the cache leaf is private and owned by the current user
- create/clamp cache directories to owner-only `0700` before any existing bundle is read
- revalidate trust immediately before reads to close create-after-check and save-side TOCTOU windows
- document that a co-located SHA-256 detects corruption but does not authenticate a malicious writer

## Why this is a real issue

`torch.compiler.load_cache_artifacts` consumes executable/deserialized compiler artifacts. Previously Mega-cache was enabled by default, and an attacker able to replace both the bundle and adjacent hash could reach the real PyTorch loader. The initial PR added leaf checks but still had ancestor and time-of-check/time-of-use gaps.

After the final fix, persistent loads are off by default, unsafe POSIX paths never reach the artifact reader, and trusted opt-in directories are secured/revalidated before reads.

## Validation

- Linux/WSL security suite: **16 passed**
- native Windows: **4 passed, 12 POSIX-only checks skipped**
- real PyTorch 2.13 CPU probe with a **152,651-byte** compile-artifact bundle:
  - unsafe workspace ancestor chain: load refused
  - sticky `/tmp` parent plus private owned leaf: trusted load succeeds
- explicit tests cover symlinks, owner/mode failures, sticky parents, missing paths, create-after-check, and securing directories before save-side reads
- targeted Ruff and `git diff --check`: pass

## Compatibility

No compilation algorithm, GPU backend, model, browser, or hardware path is added. Default-off can reduce cache reuse performance but does not change computed results. Existing trusted caches still load when users explicitly opt in. On Windows, where POSIX uid/mode checks do not model ACLs, explicit opt-in remains the trust boundary and normal per-user profile ACLs are preserved.
