### PR TITLE
Fix Windows GGUF export PermissionError [Errno 13]: anchor converter --outfile to input_folder

### DIFF
--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2477,32 +2477,26 @@ def convert_to_gguf(
             }
         runs_to_do.append((args, final_output, "model"))
 
-    # A bare --outfile (just a filename, no directory) is created by llama.cpp in the
-    # process CWD. On Windows that CWD is frequently not writable (e.g. an app launched
-    # from a protected/install dir), so the final write died with PermissionError
-    # [Errno 13] even though conversion fully succeeded. Only in that case do we redirect
-    # the bare name into input_folder. When the CWD is writable we change nothing, so
-    # behavior on Linux/Colab/Mac (and Windows-with-writable-CWD) is byte-for-byte as
-    # before: the file is written to CWD and callers relocate it from there.
+    # A bare --outfile lands in the process CWD. On Windows that CWD is often not writable
+    # (app launched from a protected dir), so the final write failed with PermissionError
+    # [Errno 13] even though conversion succeeded. Only then redirect the bare name into
+    # input_folder; a writable CWD (Linux/Mac/Colab) is left unchanged.
     def _dir_is_writable(d):
+        # mkstemp is exclusive: never truncates an existing file or follows a symlink.
         try:
-            # Exclusive, unique temp file (never truncates an existing path or follows
-            # a planted symlink); its existence proves the dir is writable.
             fd, probe = tempfile.mkstemp(prefix=".unsloth_write_test_", dir=d)
             os.close(fd)
             os.remove(probe)
             return True
         except Exception:
             return False
-    # Probe the CWD once; input_folder is only probed if we actually need to redirect.
     _cwd_writable = _dir_is_writable(os.getcwd())
 
     # Execute conversions
     for args, output_file, description in runs_to_do:
-        # Redirect only a bare filename, and only when the CWD (where llama.cpp would
-        # otherwise write it) is not writable. Relative paths that include a directory
-        # and absolute paths are the caller's chosen destination and are left untouched;
-        # input_folder is never assumed writable (it may be a read-only model source).
+        # Redirect only a bare filename under an unwritable CWD. Absolute paths and
+        # relative paths with a directory are the caller's choice; input_folder is probed
+        # too since it may be a read-only model source.
         if (not _cwd_writable
                 and not os.path.isabs(output_file)
                 and os.path.dirname(output_file) == ""):

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2480,40 +2480,35 @@ def convert_to_gguf(
     # A bare --outfile (just a filename, no directory) is created by llama.cpp in the
     # process CWD. On Windows that CWD is frequently not writable (e.g. an app launched
     # from a protected/install dir), so the final write died with PermissionError
-    # [Errno 13] even though conversion fully succeeded. Resolve such bare names against
-    # a directory we have actually confirmed is writable. CWD is preferred so the
-    # historical behavior (callers relocate the file from CWD) is unchanged wherever the
-    # CWD is writable; input_folder / a temp dir are only fallbacks, and input_folder is
-    # never assumed writable (it may be a read-only/mounted model source).
-    _writable_dir_cache = {}
+    # [Errno 13] even though conversion fully succeeded. Only in that case do we redirect
+    # the bare name into input_folder. When the CWD is writable we change nothing, so
+    # behavior on Linux/Colab/Mac (and Windows-with-writable-CWD) is byte-for-byte as
+    # before: the file is written to CWD and callers relocate it from there.
     def _dir_is_writable(d):
-        ok = _writable_dir_cache.get(d)
-        if ok is not None: return ok
         try:
             # Exclusive, unique temp file (never truncates an existing path or follows
             # a planted symlink); its existence proves the dir is writable.
             fd, probe = tempfile.mkstemp(prefix=".unsloth_write_test_", dir=d)
             os.close(fd)
             os.remove(probe)
-            ok = True
+            return True
         except Exception:
-            ok = False
-        _writable_dir_cache[d] = ok
-        return ok
-    def _resolve_bare_outfile(name):
-        for d in (os.getcwd(), os.path.abspath(input_folder), tempfile.gettempdir()):
-            if _dir_is_writable(d):
-                return os.path.join(d, name)
-        return name  # nothing writable found; leave as-is and let the error surface
+            return False
+    # Probe the CWD once; input_folder is only probed if we actually need to redirect.
+    _cwd_writable = _dir_is_writable(os.getcwd())
 
     # Execute conversions
     for args, output_file, description in runs_to_do:
-        # Only touch bare filenames. A caller that passed a relative path with a
-        # directory (e.g. "exports/model") or an absolute path chose its destination
-        # on purpose, so leave those exactly as they were.
-        if not os.path.isabs(output_file) and os.path.dirname(output_file) == "":
-            output_file = _resolve_bare_outfile(output_file)
-            if os.path.isabs(output_file):
+        # Redirect only a bare filename, and only when the CWD (where llama.cpp would
+        # otherwise write it) is not writable. Relative paths that include a directory
+        # and absolute paths are the caller's chosen destination and are left untouched;
+        # input_folder is never assumed writable (it may be a read-only model source).
+        if (not _cwd_writable
+                and not os.path.isabs(output_file)
+                and os.path.dirname(output_file) == ""):
+            _dst = os.path.abspath(input_folder)
+            if _dir_is_writable(_dst):
+                output_file = os.path.join(_dst, output_file)
                 args = {**args, "--outfile": output_file}
         if print_output: print(f"\nUnsloth: Converting {description}...")
         command = [sys.executable, converter_location]

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2479,6 +2479,16 @@ def convert_to_gguf(
 
     # Execute conversions
     for args, output_file, description in runs_to_do:
+        # Anchor the output to an absolute, writable directory. The --outfile above
+        # is a bare relative name, so the converter would otherwise write the GGUF
+        # into the process CWD. On Windows that CWD is frequently not writable (e.g.
+        # an app launched from a protected/install dir), so the final write failed
+        # with PermissionError [Errno 13] even though conversion fully succeeded.
+        # input_folder is always present and writable, so resolve relative outputs
+        # against it; callers already relocate the produced files to their final home.
+        if not os.path.isabs(output_file):
+            output_file = os.path.join(os.path.abspath(input_folder), output_file)
+            args = {**args, "--outfile": output_file}
         if print_output: print(f"\nUnsloth: Converting {description}...")
         command = [sys.executable, converter_location]
         for key, value in args.items():

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2477,18 +2477,42 @@ def convert_to_gguf(
             }
         runs_to_do.append((args, final_output, "model"))
 
+    # A bare --outfile (just a filename, no directory) is created by llama.cpp in the
+    # process CWD. On Windows that CWD is frequently not writable (e.g. an app launched
+    # from a protected/install dir), so the final write died with PermissionError
+    # [Errno 13] even though conversion fully succeeded. Resolve such bare names against
+    # a directory we have actually confirmed is writable. CWD is preferred so the
+    # historical behavior (callers relocate the file from CWD) is unchanged wherever the
+    # CWD is writable; input_folder / a temp dir are only fallbacks, and input_folder is
+    # never assumed writable (it may be a read-only/mounted model source).
+    _writable_dir_cache = {}
+    def _dir_is_writable(d):
+        ok = _writable_dir_cache.get(d)
+        if ok is not None: return ok
+        try:
+            probe = os.path.join(d, f".unsloth_gguf_write_test_{os.getpid()}")
+            with open(probe, "wb"): pass
+            os.remove(probe)
+            ok = True
+        except Exception:
+            ok = False
+        _writable_dir_cache[d] = ok
+        return ok
+    def _resolve_bare_outfile(name):
+        for d in (os.getcwd(), os.path.abspath(input_folder), tempfile.gettempdir()):
+            if _dir_is_writable(d):
+                return os.path.join(d, name)
+        return name  # nothing writable found; leave as-is and let the error surface
+
     # Execute conversions
     for args, output_file, description in runs_to_do:
-        # Anchor the output to an absolute, writable directory. The --outfile above
-        # is a bare relative name, so the converter would otherwise write the GGUF
-        # into the process CWD. On Windows that CWD is frequently not writable (e.g.
-        # an app launched from a protected/install dir), so the final write failed
-        # with PermissionError [Errno 13] even though conversion fully succeeded.
-        # input_folder is always present and writable, so resolve relative outputs
-        # against it; callers already relocate the produced files to their final home.
-        if not os.path.isabs(output_file):
-            output_file = os.path.join(os.path.abspath(input_folder), output_file)
-            args = {**args, "--outfile": output_file}
+        # Only touch bare filenames. A caller that passed a relative path with a
+        # directory (e.g. "exports/model") or an absolute path chose its destination
+        # on purpose, so leave those exactly as they were.
+        if not os.path.isabs(output_file) and os.path.dirname(output_file) == "":
+            output_file = _resolve_bare_outfile(output_file)
+            if os.path.isabs(output_file):
+                args = {**args, "--outfile": output_file}
         if print_output: print(f"\nUnsloth: Converting {description}...")
         command = [sys.executable, converter_location]
         for key, value in args.items():

--- a/unsloth_zoo/llama_cpp.py
+++ b/unsloth_zoo/llama_cpp.py
@@ -2490,8 +2490,10 @@ def convert_to_gguf(
         ok = _writable_dir_cache.get(d)
         if ok is not None: return ok
         try:
-            probe = os.path.join(d, f".unsloth_gguf_write_test_{os.getpid()}")
-            with open(probe, "wb"): pass
+            # Exclusive, unique temp file (never truncates an existing path or follows
+            # a planted symlink); its existence proves the dir is writable.
+            fd, probe = tempfile.mkstemp(prefix=".unsloth_write_test_", dir=d)
+            os.close(fd)
             os.remove(probe)
             ok = True
         except Exception:


### PR DESCRIPTION
## Problem
On Windows, GGUF export fails at the very last step (writing the output file):

```
File ".../gguf-py/gguf/gguf_writer.py", line 182, in open_output_file
  self.fout = [open(filename, "wb") for filename in filenames]
PermissionError: [Errno 13] Permission denied: 'llama-3.2-3b.BF16.gguf'
```

Conversion fully succeeds (all tensors, tokenizer, total size); only the write fails. Reproduced on two Windows machines (one NVIDIA GPU, one AMD GPU), so it's Windows-specific and GPU-independent. Exports fine on Colab/Linux.

Refs unslothai/unsloth#7190

## Cause
`convert_to_gguf` builds a bare relative `--outfile` (e.g. `llama-3.2-3b.BF16.gguf`) and runs the converter subprocess with no `cwd=`, so llama.cpp creates the GGUF in the process's current working directory. On Windows that CWD is frequently not writable (e.g. an app launched from a protected/install dir), so `open(..., "wb")` fails with Errno 13. On Colab/Linux the CWD is writable, so it never surfaces.

## Fix
Redirect the output **only** when the CWD (where llama.cpp would write a bare filename) is actually not writable, and only for a bare filename. In that case the bare name is written into `input_folder` instead, if `input_folder` is writable.

Deliberately narrow, to avoid changing any working path:
- **CWD writable** (Linux/Colab/Mac, and Windows-with-writable-CWD): nothing changes. The file is written to CWD and returned exactly as today, so callers that relocate from CWD (`save.py`) or reconstruct a relative path from CWD (the MLX backend) are unaffected.
- **Relative paths with a directory** (e.g. `exports/model`) and **absolute paths**: left untouched (caller's chosen destination).
- **`input_folder` never assumed writable** (it may be a read-only/mounted model source); it is probed first, and if neither CWD nor `input_folder` is writable the name is left as-is so the same error surfaces as today (no silent redirect into a temp dir).

Writability is probed with an exclusive `tempfile.mkstemp` (unique name, no truncation of any existing file, no symlink following). Single choke point in the conversion loop, so it covers text, mmproj, gpt-oss, and sharded outputs.

## Testing
Not verified through an actual end-to-end GGUF export on the failing Windows machine. What was checked:
- `py_compile` passes on the changed file.
- The redirect/probe logic was exercised in isolation (standalone copy of the exact logic, not the real `convert_to_gguf` code path): CWD writable → unchanged (relative preserved); CWD not writable + `input_folder` writable → redirected into `input_folder`; both non-writable → unchanged (errors as before); relative-with-directory and absolute paths left unchanged; and the `mkstemp` probe leaves a pre-existing same-named file intact.

An end-to-end Windows export from the original non-writable-CWD launch context still needs a maintainer/reporter confirmation before merge.
