### PR TITLE
feat(mlx): support VLM assistant-only loss

### DIFF
--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -87,6 +87,13 @@ class RankFailingStream:
             raise KeyError("rank0 stream failure")
         return ({"text": f"{i} {i + 20} {i + 30}"} for i in range(10, 15))
 
+class RankFailingResumeStream:
+    def __iter__(self):
+        for i in range(10, 15):
+            if int(world.rank()) == 0:
+                raise KeyError("rank0 resume stream failure")
+            yield {"text": f"{i} {i + 20} {i + 30}"}
+
 class ReplayableVLMStream:
     def __iter__(self): return ({"text": str(i)} for i in range(10, 15))
 
@@ -282,6 +289,17 @@ mx.eval(sync)
 resumed_trainer = make_parity_trainer("resume_resumed", seed=987)
 resumed_trainer.train(resume_from_checkpoint=str(Path(sys.argv[1], "resume_partial", "checkpoint-2")))
 resume_param_delta = max_trainable_delta(fresh_trainer, resumed_trainer)
+def asymmetric_resume_data_error_message():
+    mx.random.seed(795)
+    error_args = MLXTrainingConfig(per_device_train_batch_size=1, gradient_accumulation_steps=1, max_steps=3, logging_steps=1, eval_steps=0, save_steps=0, learning_rate=1e-3, max_seq_length=8, output_dir=str(Path(sys.argv[1], "asymmetric_resume_data_error")), use_cce=False, compile=False, gradient_checkpointing=False, cast_norm_output_to_input_dtype=False, dataset_order="sequential", streaming=True)
+    error_trainer = MLXTrainer(TinyLM(), TinyTokenizer(), RankFailingResumeStream(), args=error_args)
+    error_trainer.save_model = mark("asymmetric_resume_data_error_final")
+    try:
+        error_trainer.train(resume_from_checkpoint=str(Path(sys.argv[1], "resume_partial", "checkpoint-2")))
+    except RuntimeError as exc:
+        return str(exc)
+    return ""
+asymmetric_resume_data_error = asymmetric_resume_data_error_message()
 trainer_mod.save_trainable_adapters = mark("vlm_ckpt_adapter")
 trainer_mod.save_optimizer_state = mark("vlm_ckpt_opt")
 trainer_mod.save_trainer_state = mark("vlm_ckpt_state")
@@ -361,6 +379,7 @@ payload = {
     "fresh_losses": [float(x) for x in fresh_trainer._train_loss_history],
     "resumed_losses": [float(x) for x in resumed_trainer._train_loss_history],
     "resume_param_delta": resume_param_delta,
+    "asymmetric_resume_data_error": asymmetric_resume_data_error,
     "vlm_events": vlm_events,
     "vlm_step": int(vlm_trainer._global_step),
     "vlm_compile_enabled": bool(vlm_result["compile_enabled"]),
@@ -386,14 +405,13 @@ payload = {
 Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
 """,
         encoding="utf-8")
-
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]
     env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
     cmd = [
         str(launcher), "-n", "2", "--backend", "ring",
-        "--python", sys.executable, "--cwd", str(repo_root),
-        str(script), str(tmp_path),
+        "--cwd", str(repo_root),
+        sys.executable, str(script), str(tmp_path),
     ]
     proc = subprocess.run(
         cmd, capture_output=True, env=env, text=True, timeout=120,
@@ -492,5 +510,8 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert ranks[1]["vlm_empty_eval"][1]["ids"][0][1] == 20
     assert ranks[1]["vlm_empty_eval"][1]["mask"][0] == [1, 1, 1, 1]
     assert all(value == -100 for value in ranks[1]["vlm_empty_eval"][1]["labels"][0])
-    assert [rank["stream_text"] for rank in ranks] == expected_stream
+    assert [rank["stream_text"] for rank in ranks] == expected
     assert [rank["stream_vlm"] for rank in ranks] == expected_stream
+    assert all("fast-forwarding training batch" in rank["asymmetric_resume_data_error"] for rank in ranks)
+    assert "rank 0 failed" in ranks[0]["asymmetric_resume_data_error"]
+    assert "peer rank failed" in ranks[1]["asymmetric_resume_data_error"]

--- a/tests/test_mlx_pr684_full_validation_metal.py
+++ b/tests/test_mlx_pr684_full_validation_metal.py
@@ -13,8 +13,8 @@ paths that only real Metal training can prove:
 3. Epoch-based unlabeled runs: num_train_epochs drives the step count when
    max_steps is disabled.
 4. SGD with gradient-coupled weight decay end to end.
-5. Real VLM LoRA training: tiny 4-bit SmolVLM through the VLM collation,
-   label masking, CCE loss, and adapter save pipeline.
+5. Real VLM LoRA training: 4-bit Qwen2-VL through assistant-only VLM
+   collation, CCE loss, and adapter save pipeline.
 """
 
 import gc
@@ -40,6 +40,23 @@ TEXT_MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
 # transformers (the mlx-community SmolVLM-256M repo ships a preprocessor
 # config AutoImageProcessor cannot map).
 VLM_MODEL = "mlx-community/Qwen2-VL-2B-Instruct-4bit"
+VLM_ASSISTANT_CHAT_TEMPLATE = (
+    "{% set image_count = namespace(value=0) %}{% set video_count = namespace(value=0) %}"
+    "{% macro render_content(message) %}{% if message['content'] is string %}{{ message['content'] }}"
+    "{% else %}{% for content in message['content'] %}{% if content['type'] == 'image' or 'image' in content or 'image_url' in content %}"
+    "{% set image_count.value = image_count.value + 1 %}<|vision_start|><|image_pad|><|vision_end|>"
+    "{% elif content['type'] == 'video' or 'video' in content %}{% set video_count.value = video_count.value + 1 %}"
+    "<|vision_start|><|video_pad|><|vision_end|>{% elif 'text' in content %}{{ content['text'] }}{% endif %}"
+    "{% endfor %}{% endif %}{% endmacro %}{% for message in messages %}"
+    "{% if loop.first and message['role'] != 'system' %}"
+    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n{% endif %}"
+    "<|im_start|>{{ message['role'] }}\n"
+    "{% if message['role'] == 'assistant' %}"
+    "{% generation %}{{ render_content(message) }}<|im_end|>\n{% endgeneration %}"
+    "{% else %}{{ render_content(message) }}<|im_end|>\n{% endif %}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+)
 
 
 def _chat_dataset(n=12):
@@ -177,7 +194,7 @@ def test_sgd_coupled_weight_decay_e2e(tmp_path):
 
 @metal_only
 def test_vlm_lora_training_e2e(tmp_path):
-    """Real VLM LoRA fit: collation, label masking, CCE, save."""
+    """Real VLM LoRA fit: assistant-only labels, CCE, and adapter save."""
     from PIL import Image
 
     from unsloth_zoo.mlx.loader import FastMLXModel
@@ -220,9 +237,11 @@ def test_vlm_lora_training_e2e(tmp_path):
             output_dir=str(tmp_path),
             seed=3407,
             report_to="none",
+            assistant_only_loss=True,
+            vlm_chat_template=VLM_ASSISTANT_CHAT_TEMPLATE,
         ),
     )
-    assert trainer._is_vlm, "SmolVLM was not detected as a VLM"
+    assert trainer._is_vlm, "Qwen2-VL was not detected as a VLM"
     trainer.train()
     hist = trainer._train_loss_history
     assert len(hist) == 4
@@ -335,4 +354,3 @@ def test_vlm_resume_from_checkpoint_matches_fresh_run(tmp_path):
             f"step {i}: fresh={a!r} resumed={b!r}\n"
             f"fresh={fresh_hist}\nresumed={resumed_hist}"
         )
-

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -1001,6 +1001,39 @@ def test_text_prepare_data_passes_completion_only_loss_to_create_batches(monkeyp
     assert received["assistant_only_loss"] is True
 
 
+@pytest.mark.parametrize("streaming,failure", [(False, None), (True, None), (False, "local"), (False, "peer")])
+def test_vlm_prepare_data_routes_masks_and_syncs_failures(monkeypatch, streaming, failure):
+    from unsloth_zoo.mlx import trainer as mlx_trainer
+    received, expected = {}, ["batch"]
+
+    def build(**kwargs):
+        received.update(kwargs)
+        if failure == "local":
+            raise RuntimeError("bad assistant mask")
+        return iter(expected) if streaming else expected
+
+    monkeypatch.setattr(mlx_trainer, "iterate_vlm_training_batches" if streaming else "create_vlm_batches", build)
+    monkeypatch.setattr(mlx_trainer, "_check_vlm_all_masked", lambda batches, **_kwargs: received.update(preflight=batches))
+    MLXTrainer, trainer = _make_mlx_text_trainer(max_steps=1, streaming=streaming, assistant_only_loss=True)
+    trainer.processor = object()
+    trainer._resolve_vlm_processor = lambda: trainer.processor
+    trainer._distributed_initialized, trainer._distributed_world = True, None
+    trainer._distributed_rank, trainer._distributed_world_size = 0, 2 if failure else 1
+    trainer._distributed_any_flag = lambda failed: bool(failure) or failed
+    trainer._vlm_response_mask_fn = None
+
+    if failure:
+        with pytest.raises(RuntimeError, match="VLM training batch materialization"):
+            MLXTrainer._prepare_data(trainer, is_vlm=True)
+        assert "preflight" not in received
+        return
+    batches, iterator = MLXTrainer._prepare_data(trainer, is_vlm=True)
+    assert received["assistant_only_loss"] is True
+    assert (list(iterator) if streaming else batches) == expected
+    if not streaming:
+        assert received["preflight"] == expected
+
+
 def test_text_prepare_data_ordered_batches_emit_completion_only_labels():
     MLXTrainer, trainer = _make_mlx_text_trainer(
         max_steps=1,
@@ -1124,6 +1157,7 @@ def test_vlm_eval_batches_define_completion_only_loss_before_use():
     vlm_eval_block = source[vlm_eval_start:text_eval_start]
     assert definition < eval_use
     assert "assistant_only_loss=text_assistant_only_loss" in vlm_eval_block
+    assert "evaluation batch materialization" in source
     assert "completion_only_loss=text_completion_only_loss" in text_eval_block
 
 

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -1120,7 +1120,10 @@ def test_vlm_eval_batches_define_completion_only_loss_before_use():
     text_eval_start = source.index("return create_batches(")
     text_eval_end = source.index("if isinstance(self.eval_dataset, dict)")
     text_eval_block = source[text_eval_start:text_eval_end]
+    vlm_eval_start = source.index("if is_vlm:")
+    vlm_eval_block = source[vlm_eval_start:text_eval_start]
     assert definition < eval_use
+    assert "assistant_only_loss=text_assistant_only_loss" in vlm_eval_block
     assert "completion_only_loss=text_completion_only_loss" in text_eval_block
 
 
@@ -1234,7 +1237,7 @@ def test_check_vlm_all_masked_reduces_counts_across_ranks(monkeypatch):
 
     monkeypatch.setattr(trainer_mod.mx.distributed, "all_sum", fake_all_sum)
 
-    all_bad = [{"labels": mx.array([[-100, -100]])}]
+    all_bad = [{"labels": mx.array([[7, -100]])}]
     _check_vlm_all_masked(all_bad, comm_group=object(), world_size=2)
 
 
@@ -1243,7 +1246,7 @@ def test_check_vlm_all_masked_single_process_still_raises():
 
     from unsloth_zoo.mlx.trainer import _check_vlm_all_masked
 
-    all_bad = [{"labels": mx.array([[-100, -100]])}]
+    all_bad = [{"labels": mx.array([[7, -100]])}]
     with pytest.raises(ZeroDivisionError):
         _check_vlm_all_masked(all_bad)
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -172,28 +172,21 @@ class _AssistantMaskProcessor:
     )
 
     def __init__(self):
-        from tokenizers import Tokenizer
-        from tokenizers.models import WordLevel
-        from tokenizers.pre_tokenizers import WhitespaceSplit
+        from tokenizers import Tokenizer, models, pre_tokenizers
         from transformers import PreTrainedTokenizerFast
 
-        tokens = ["[UNK]", "[PAD]", "<system>", "</system>", "<user>", "</user>",
-                  "<assistant>", "</assistant>", "<tool>",
-                  "</tool>", "same", "answer", "policy", "tool", "<image>"]
+        tokens = ["[UNK]", "[PAD]", "<system>", "</system>", "<user>", "</user>", "<assistant>",
+                  "</assistant>", "<tool>", "</tool>", "same", "answer", "policy", "tool", "<image>"]
         self.vocab = {token: idx for idx, token in enumerate(tokens)}
-        backend = Tokenizer(WordLevel(self.vocab, unk_token="[UNK]"))
-        backend.pre_tokenizer = WhitespaceSplit()
+        backend = Tokenizer(models.WordLevel(self.vocab, unk_token="[UNK]"))
+        backend.pre_tokenizer = pre_tokenizers.WhitespaceSplit()
         self.tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend,
             unk_token="[UNK]", pad_token="[PAD]", chat_template=self.chat_template)
-
-    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
-        return self.tokenizer.apply_chat_template(messages, chat_template=self.chat_template,
-            tokenize=tokenize, add_generation_prompt=add_generation_prompt)
+        self.apply_chat_template = self.tokenizer.apply_chat_template
 
     def __call__(self, text, **kwargs):
-        rows = [[item for token in self.tokenizer(
-            value, add_special_tokens=False,
-        )["input_ids"] for item in [token] * (3 if token == self.image_token_id else 1)]
+        rows = [[item for token in self.tokenizer(value, add_special_tokens=False)["input_ids"]
+                 for item in [token] * (3 if token == self.image_token_id else 1)]
                 for value in text]
         input_ids = np.asarray(rows, dtype=np.int32)
         return {"input_ids": input_ids, "attention_mask": np.ones_like(input_ids)}
@@ -268,11 +261,8 @@ def test_vlm_assistant_only_loss_rejects_final_turn_only_generation_mask():
 
 
 def test_vlm_assistant_only_loss_rejects_untrustworthy_inputs():
-    from unsloth_zoo.mlx.utils import (
-        _align_vlm_assistant_mask_row,
-        _collate_vlm_batch,
-        _tokenize_vlm_assistant_mask_rows,
-    )
+    from unsloth_zoo.mlx.utils import (_align_vlm_assistant_mask_row, _collate_vlm_batch,
+                                       _tokenize_vlm_assistant_mask_rows)
 
     messages = [_assistant_vlm_row()["messages"]]
     with pytest.raises(ValueError, match="generation"):
@@ -293,11 +283,10 @@ def test_vlm_assistant_only_loss_rejects_untrustworthy_inputs():
 
 def _assistant_vlm_row(text="same"):
     return {
-        "messages": [{"role": "user", "content": [
-            {"type": "image"}, {"type": "text", "text": text},
-        ]}, {"role": "assistant", "content": [
-            {"type": "text", "text": "answer"},
-        ]}],
+        "messages": [
+            {"role": "user", "content": [{"type": "image"}, {"type": "text", "text": text}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "answer"}]},
+        ],
         "images": [object()],
     }
 
@@ -339,6 +328,50 @@ def test_vlm_response_mask_preserves_existing_labels_like_cuda():
     out = _apply_response_mask_to_vlm_batch(batch, mask_fn, ignore_token_ids=[0])
 
     assert out["labels"].tolist() == [[-100, 777, -100, -100]]
+
+
+@pytest.mark.parametrize(("source", "mask", "final", "attention", "side", "expected"), [
+        ([1, 2, 3], [0, 1, 1], [1, 2, 3, 0], [1, 1, 1, 0], "right", [0, 1, 1, 0]),
+        ([1, 2, 3], [0, 1, 1], [0, 1, 2, 3], [0, 1, 1, 1], "right", [0, 0, 1, 1]),
+        ([1, 2, 3, 4], [0, 0, 1, 1], [1, 2, 3], None, "right", [0, 0, 1]),
+        ([1, 2, 3, 4], [0, 0, 1, 1], [2, 3, 4], None, "left", [0, 1, 1]),
+        ([1, 200, 2], [0, 0, 1], [1, 200, 200, 2], None, "right", [0, 0, 0, 1]),
+])
+def test_vlm_assistant_mask_alignment_matrix(source, mask, final, attention, side, expected):
+    from unsloth_zoo.mlx.utils import _align_vlm_assistant_mask_row
+
+    assert _align_vlm_assistant_mask_row(
+        source, mask, final, attention, ignore_token_ids=[200],
+        truncation_side=side, max_seq_length=len(final)) == expected
+
+
+def test_vlm_assistant_labels_intersect_and_match_baseline_cce(monkeypatch):
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    batch = {"input_ids": mx.array([[1, 2, 3]]),
+             "attention_mask": mx.array([[1, 1, 1]]),
+             "labels": mx.array([[777, 888, -100]])}
+    batch["labels"] = mlx_utils._apply_vlm_assistant_label_masks(
+        batch, [([1, 2, 3], [0, 1, 1])], _FakeTokenizer(),
+    )
+
+    class Model:
+        def __call__(self, input_ids, **_kwargs): return mx.zeros((*input_ids.shape, 1000))
+        def get_input_embeddings(self, input_ids, *_args, **_kwargs): return mx.zeros((*input_ids.shape, 4))
+
+    seen = []
+    def cross_entropy(_logits, targets):
+        seen.append(targets)
+        return mx.zeros(targets.shape)
+
+    monkeypatch.setattr(mlx_utils.nn.losses, "cross_entropy", cross_entropy)
+    _, baseline_ntoks = mlx_utils.make_vlm_baseline_loss_fn(ignore_token_ids=[])(Model(), batch)
+    monkeypatch.setattr(mlx_utils, "_forward_text_hidden_states",
+                        lambda _model, inputs, **_kwargs: mx.zeros((*inputs.shape, 4)))
+    _, cce_targets, cce_ntoks = mlx_utils._vlm_cce_forward(Model(), batch, image_token_ids=[])
+    assert batch["labels"].tolist() == [[-100, 888, -100]]
+    assert seen[0].tolist() == mx.where(cce_targets == -100, 0, cce_targets).tolist()
+    assert int(baseline_ntoks.item()) == int(cce_ntoks.item())
 
 
 def test_vlm_response_mask_drops_fully_masked_rows():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -490,6 +490,20 @@ def test_vlm_streaming_response_mask_skips_fully_masked_rows():
     assert batch["labels"].tolist() == [[-100, 12, 13, -100]]
 
 
+def test_vlm_assistant_only_loss_materialized_streaming_parity():
+    from unsloth_zoo.mlx.utils import create_vlm_batches, iterate_vlm_training_batches
+    dataset = [_assistant_vlm_row("same"), _assistant_vlm_row("policy")]
+    kwargs = dict(dataset=dataset, config={"image_token_id": _AssistantMaskProcessor.image_token_id},
+                  batch_size=2, max_seq_length=32, image_size=16,
+                  dataset_order="sequential", assistant_only_loss=True)
+    batches = [
+        create_vlm_batches(processor=_AssistantMaskProcessor(), **kwargs)[0],
+        next(iterate_vlm_training_batches(processor=_AssistantMaskProcessor(), **kwargs)),
+    ]
+    assert all(batches[0][key].tolist() == batches[1][key].tolist()
+               for key in ("input_ids", "attention_mask", "labels"))
+
+
 def test_vlm_response_mask_formats_each_filtered_row_once():
     from unsloth_zoo.mlx.utils import create_vlm_batches
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -160,6 +160,45 @@ class _ConversationalPromptCompletionProcessor:
         }
 
 
+class _AssistantMaskProcessor:
+    image_processor = object()
+    image_token_id = 14
+    chat_template = (
+        "{% for m in messages %}{{ '<' + m.role + '>' }} {% if m.role == 'assistant' %}{% generation %}"
+        "{% for p in m.content %}{{ '<image> ' if p.type == 'image' else p.text + ' ' }}{% endfor %}"
+        "{{ '</' + m.role + '>' }}{% endgeneration %} {% else %}{% for p in m.content %}"
+        "{{ '<image> ' if p.type == 'image' else p.text + ' ' }}{% endfor %}"
+        "{{ '</' + m.role + '>' }} {% endif %}{% endfor %}"
+    )
+
+    def __init__(self):
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordLevel
+        from tokenizers.pre_tokenizers import WhitespaceSplit
+        from transformers import PreTrainedTokenizerFast
+
+        tokens = ["[UNK]", "[PAD]", "<system>", "</system>", "<user>", "</user>",
+                  "<assistant>", "</assistant>", "<tool>",
+                  "</tool>", "same", "answer", "policy", "tool", "<image>"]
+        self.vocab = {token: idx for idx, token in enumerate(tokens)}
+        backend = Tokenizer(WordLevel(self.vocab, unk_token="[UNK]"))
+        backend.pre_tokenizer = WhitespaceSplit()
+        self.tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend,
+            unk_token="[UNK]", pad_token="[PAD]", chat_template=self.chat_template)
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        return self.tokenizer.apply_chat_template(messages, chat_template=self.chat_template,
+            tokenize=tokenize, add_generation_prompt=add_generation_prompt)
+
+    def __call__(self, text, **kwargs):
+        rows = [[item for token in self.tokenizer(
+            value, add_special_tokens=False,
+        )["input_ids"] for item in [token] * (3 if token == self.image_token_id else 1)]
+                for value in text]
+        input_ids = np.asarray(rows, dtype=np.int32)
+        return {"input_ids": input_ids, "attention_mask": np.ones_like(input_ids)}
+
+
 def test_vlm_collate_creates_sft_labels_and_masks_special_tokens():
     from unsloth_zoo.mlx.utils import (
         _collate_vlm_batch,
@@ -177,6 +216,7 @@ def test_vlm_collate_creates_sft_labels_and_masks_special_tokens():
         max_seq_length=8,
         image_size=16,
         ignore_token_ids=ignore_ids,
+        assistant_only_loss=False,
     )
 
     assert "labels" in batch
@@ -188,6 +228,78 @@ def test_vlm_collate_creates_sft_labels_and_masks_special_tokens():
         [101, 10, -100, 11, -100],
         [101, 12, 13, -100, -100],
     ]
+
+
+def test_vlm_assistant_only_loss_uses_real_multiturn_generation_spans():
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch
+
+    processor = _AssistantMaskProcessor()
+    row = _assistant_vlm_row()
+    user, final = row["messages"]
+    row["messages"] = [
+        {"role": "system", "content": [{"type": "text", "text": "policy"}]}, user,
+        {"role": "assistant", "content": [{"type": "text", "text": "same"}]},
+        {"role": "tool", "content": [{"type": "text", "text": "tool"}]}, final,
+    ]
+    batch = _collate_vlm_batch([row], processor, max_seq_length=32, image_size=16,
+        ignore_token_ids=[processor.image_token_id], assistant_only_loss=True)
+
+    assert batch["input_ids"].tolist()[0].count(processor.image_token_id) == 3
+    assert batch["labels"].tolist() == [[-100] * 10 + [
+        processor.vocab["same"], processor.vocab["</assistant>"],
+    ] + [-100] * 4 + [processor.vocab["answer"], processor.vocab["</assistant>"]]]
+
+
+def test_vlm_assistant_only_loss_rejects_final_turn_only_generation_mask():
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch
+
+    processor = _AssistantMaskProcessor()
+    processor.chat_template = processor.chat_template.replace(
+        "m.role == 'assistant'", "m.role == 'assistant' and loop.last")
+    processor.tokenizer.chat_template = processor.chat_template
+    row = _assistant_vlm_row()
+    row["messages"] = [row["messages"][0],
+        {"role": "assistant", "content": [{"type": "text", "text": "same"}]},
+        {"role": "user", "content": [{"type": "text", "text": "policy"}]},
+        row["messages"][1]]
+    with pytest.raises(RuntimeError, match="every assistant turn"):
+        _collate_vlm_batch([row], processor, max_seq_length=32, image_size=16,
+            ignore_token_ids=[processor.image_token_id], assistant_only_loss=True)
+
+
+def test_vlm_assistant_only_loss_rejects_untrustworthy_inputs():
+    from unsloth_zoo.mlx.utils import (
+        _align_vlm_assistant_mask_row,
+        _collate_vlm_batch,
+        _tokenize_vlm_assistant_mask_rows,
+    )
+
+    messages = [_assistant_vlm_row()["messages"]]
+    with pytest.raises(ValueError, match="generation"):
+        _tokenize_vlm_assistant_mask_rows(_FakeProcessor(), messages)
+    processor = _AssistantMaskProcessor()
+    processor.tokenizer.apply_chat_template = lambda rows, **_kwargs: {
+        "input_ids": [[1]] * len(rows)}
+    with pytest.raises(RuntimeError, match="returned none"):
+        _tokenize_vlm_assistant_mask_rows(processor, messages)
+    with pytest.raises(ValueError, match="non-multimodal token"):
+        _align_vlm_assistant_mask_row([1], [0], [2], None)
+    with pytest.raises(ValueError, match="prompt/completion"):
+        _collate_vlm_batch(
+            [{"prompt": [], "completion": []}], _AssistantMaskProcessor(),
+            max_seq_length=16, image_size=16, assistant_only_loss=True,
+        )
+
+
+def _assistant_vlm_row(text="same"):
+    return {
+        "messages": [{"role": "user", "content": [
+            {"type": "image"}, {"type": "text", "text": text},
+        ]}, {"role": "assistant", "content": [
+            {"type": "text", "text": "answer"},
+        ]}],
+        "images": [object()],
+    }
 
 
 def test_vlm_response_mask_reapplies_special_token_masks():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -260,8 +260,74 @@ def test_vlm_assistant_only_loss_rejects_final_turn_only_generation_mask():
             ignore_token_ids=[processor.image_token_id], assistant_only_loss=True)
 
 
+def test_vlm_assistant_only_loss_rejects_non_assistant_generation_mask():
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch
+
+    processor = _AssistantMaskProcessor()
+    processor.chat_template = processor.chat_template.replace("m.role == 'assistant'", "true")
+    processor.tokenizer.chat_template = processor.chat_template
+    with pytest.raises(RuntimeError, match="only assistant"):
+        _collate_vlm_batch([_assistant_vlm_row()], processor, max_seq_length=32,
+            image_size=16, ignore_token_ids=[processor.image_token_id], assistant_only_loss=True)
+
+
+def test_vlm_assistant_only_loss_rejects_unsupported_assistant_fields():
+    from unsloth_zoo.mlx.utils import _tokenize_vlm_assistant_mask_rows
+
+    messages = _assistant_vlm_row()["messages"]
+    messages[1]["reasoning_content"] = "think"
+
+    with pytest.raises(ValueError, match="unsupported assistant message fields"):
+        _tokenize_vlm_assistant_mask_rows(_AssistantMaskProcessor(), [messages])
+
+    messages = _assistant_vlm_row()["messages"]
+    messages[1]["content"] = [{"type": "image", "caption": "same"}]
+    with pytest.raises(ValueError, match="unsupported assistant content"):
+        _tokenize_vlm_assistant_mask_rows(_AssistantMaskProcessor(), [messages])
+    processor = _AssistantMaskProcessor()
+    processor._unsloth_assistant_single_content = True
+    with pytest.raises(ValueError, match="unsupported assistant content"):
+        _tokenize_vlm_assistant_mask_rows(processor, [messages])
+
+
+def test_vlm_assistant_only_loss_rejects_partial_assistant_content_mask():
+    from unsloth_zoo.mlx.utils import _tokenize_vlm_assistant_mask_rows
+
+    processor = _AssistantMaskProcessor()
+    processor.chat_template = processor.chat_template.replace(
+        "{% generation %}{% for p in m.content %}", "{% for p in m.content %}",
+    ).replace(
+        "{{ '</' + m.role + '>' }}{% endgeneration %}",
+        "{% generation %}{{ '</' + m.role + '>' }}{% endgeneration %}",
+    )
+    processor.tokenizer.chat_template = processor.chat_template
+    with pytest.raises(RuntimeError, match="content span"):
+        _tokenize_vlm_assistant_mask_rows(
+            processor, [_assistant_vlm_row()["messages"]],
+        )
+
+
+def test_vlm_assistant_only_loss_rejects_adjacent_role_templates():
+    from unsloth_zoo.mlx.utils import _tokenize_vlm_assistant_mask_rows
+
+    row = _assistant_vlm_row()
+    processor = _AssistantMaskProcessor()
+    processor.chat_template = processor.chat_template.replace(
+        "{% endgeneration %}",
+        "{% if loop.nextitem is defined and loop.nextitem.role == 'tool' %}"
+        "{{ '<tool_response> ' }}{% endif %}{% endgeneration %}")
+    processor.tokenizer.chat_template = processor.chat_template
+    row["messages"] = [row["messages"][0], row["messages"][1],
+        {"role": "tool", "content": [{"type": "text", "text": "tool"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "answer"}]}]
+    with pytest.raises(RuntimeError, match="prefix-stable"):
+        _tokenize_vlm_assistant_mask_rows(processor, [row["messages"]])
+
+
 def test_vlm_assistant_only_loss_rejects_untrustworthy_inputs():
-    from unsloth_zoo.mlx.utils import (_align_vlm_assistant_mask_row, _collate_vlm_batch,
+    from unsloth_zoo.mlx.utils import (_align_vlm_assistant_mask_row, _as_vlm_token_rows,
+                                       _collate_vlm_batch,
+                                       _validate_mlx_assistant_mask,
                                        _tokenize_vlm_assistant_mask_rows)
 
     messages = [_assistant_vlm_row()["messages"]]
@@ -272,6 +338,15 @@ def test_vlm_assistant_only_loss_rejects_untrustworthy_inputs():
         "input_ids": [[1]] * len(rows)}
     with pytest.raises(RuntimeError, match="returned none"):
         _tokenize_vlm_assistant_mask_rows(processor, messages)
+    with pytest.raises(ValueError, match="0 or 1"):
+        _validate_mlx_assistant_mask([1], [2], source="test")
+    with pytest.raises(ValueError, match="0 or 1"):
+        _validate_mlx_assistant_mask(
+            [1], _as_vlm_token_rows(
+                [1.5], "assistant_masks", 1, coerce_int=False,
+            )[0],
+            source="test",
+        )
     with pytest.raises(ValueError, match="non-multimodal token"):
         _align_vlm_assistant_mask_row([1], [0], [2], None)
     with pytest.raises(ValueError, match="prompt/completion"):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2715,14 +2715,25 @@ class MLXTrainer:
         # ordering the killed run would have produced.
         if _resume_step > 0 and batch_iter is not None:
             for _ in range(_resume_step * grad_accum):
+                fast_forward_error = None
                 try:
                     next(batch_iter)
                 except StopIteration:
-                    raise RuntimeError(
+                    fast_forward_error = RuntimeError(
                         f"Unsloth: streaming dataset exhausted while "
                         f"fast-forwarding to resume step {_resume_step}. "
                         f"Dataset may be shorter than the killed run consumed."
-                    ) from None
+                    )
+                except Exception as e:
+                    fast_forward_error = e
+                if distributed_world_size > 1:
+                    self._raise_distributed_failure(
+                        fast_forward_error is not None,
+                        "fast-forwarding training batch",
+                        fast_forward_error,
+                    )
+                elif fast_forward_error is not None:
+                    raise fast_forward_error
 
         def _run_ddp_local_step(batch_data, prev_state, do_update):
             """Run local DDP work, then synchronize failures before collectives."""

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2614,6 +2614,7 @@ class MLXTrainer:
                             response_mask_fn=_vlm_mask_fn,
                             formatting_func=self.formatting_func,
                             completion_only_loss=text_completion_only_loss,
+                            assistant_only_loss=text_assistant_only_loss,
                             comm_group=self.distributed_world,
                             distributed_pad_mode="empty",
                         )
@@ -3278,12 +3279,6 @@ class MLXTrainer:
         comm_group = self.distributed_world
 
         if is_vlm:
-            if text_assistant_only_loss:
-                raise ValueError(
-                    "Unsloth MLX VLM: assistant_only_loss=True is not supported for "
-                    "vision-language models. Set assistant_only_loss=False, or use "
-                    "train_on_responses_only for response masking."
-                )
             _vlm_mask_fn = getattr(self, '_vlm_response_mask_fn', None)
             vlm_dataset_order = (
                 "sequential"
@@ -3312,6 +3307,7 @@ class MLXTrainer:
                     formatting_func=self.formatting_func,
                     dataset_order=vlm_dataset_order,
                     completion_only_loss=text_completion_only_loss,
+                    assistant_only_loss=text_assistant_only_loss,
                     comm_group=comm_group,
                 )
             else:
@@ -3330,9 +3326,10 @@ class MLXTrainer:
                     dataset_order=vlm_dataset_order,
                     num_epochs=vlm_num_epochs,
                     completion_only_loss=text_completion_only_loss,
+                    assistant_only_loss=text_assistant_only_loss,
                     comm_group=comm_group,
                 )
-                if _vlm_mask_fn is not None and batches:
+                if (_vlm_mask_fn is not None or text_assistant_only_loss) and batches:
                     _check_vlm_all_masked(
                         batches,
                         comm_group=comm_group,
@@ -3831,8 +3828,8 @@ def _check_vlm_all_masked(batches, max_check=100, comm_group=None, world_size=1)
             continue
         labels_list = labels.tolist()
         for row in labels_list:
-            unique = set(row)
-            if unique == {-100}:
+            # Causal losses consume labels[:, 1:], never the first position.
+            if not any(label != -100 for label in row[1:]):
                 seen_bad += 1
             else:
                 seen_good += 1
@@ -3859,16 +3856,15 @@ def _check_vlm_all_masked(batches, max_check=100, comm_group=None, world_size=1)
     if ratio == 1.0:
         raise ZeroDivisionError(
             "Unsloth: All VLM labels in your dataset are -100. Training losses will be all 0.\n"
-            "Are you sure you used `train_on_responses_only` correctly?\n"
-            "Check that your instruction_part and response_part strings match "
-            "the chat template used by your processor."
+            "Check assistant_only_loss, train_on_responses_only, truncation, "
+            "and the chat template used by your processor."
         )
     elif ratio >= 0.9:
         import warnings
         warnings.warn(
             f"Unsloth: {seen_bad}/{seen_bad + seen_good} VLM samples have all -100 labels "
-            f"({ratio:.0%}). Your instruction_part / response_part may not match "
-            f"the chat template correctly.",
+            f"({ratio:.0%}). Check assistant/response masking, truncation, and "
+            f"the processor chat template.",
             UserWarning,
         )
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1041,6 +1041,24 @@ class MLXTrainer:
             exc,
         )
 
+    def _run_distributed_setup(self, callback, context):
+        """Run rank-local setup and synchronize failures before collectives."""
+        result = None
+        local_error = None
+        try:
+            result = callback()
+        except Exception as exc:
+            local_error = exc
+        if self.distributed_world_size > 1:
+            self._raise_distributed_failure(
+                local_error is not None,
+                context,
+                local_error,
+            )
+        elif local_error is not None:
+            raise local_error
+        return result
+
     def _distributed_sum_gradient_tree(self, grad):
         """All-sum a gradient tree while preserving MLX's grouped all-reduce."""
         world = self._ensure_distributed()
@@ -2640,13 +2658,18 @@ class MLXTrainer:
                         distributed_pad_mode="empty",
                     )
 
-                if isinstance(self.eval_dataset, dict):
-                    eval_batches = {
-                        key: _create_eval_batches(value)
-                        for key, value in self.eval_dataset.items()
-                    }
-                else:
-                    eval_batches = _create_eval_batches(self.eval_dataset)
+                def _materialize_eval_batches():
+                    if isinstance(self.eval_dataset, dict):
+                        return {
+                            key: _create_eval_batches(value)
+                            for key, value in self.eval_dataset.items()
+                        }
+                    return _create_eval_batches(self.eval_dataset)
+
+                eval_batches = self._run_distributed_setup(
+                    _materialize_eval_batches,
+                    "evaluation batch materialization",
+                )
             if eval_batches:
                 eval_batch_count = (
                     sum(len(value) for value in eval_batches.values())
@@ -3323,22 +3346,25 @@ class MLXTrainer:
                 )
             else:
                 self._prepared_batches_include_epochs = vlm_num_epochs is not None
-                batches = create_vlm_batches(
-                    dataset=train_dataset,
-                    processor=processor,
-                    config=config,
-                    batch_size=args.per_device_train_batch_size,
-                    max_seq_length=args.max_seq_length,
-                    image_size=getattr(args, "image_size", None),
-                    num_batches=total_batches_needed,
-                    seed=args.seed,
-                    response_mask_fn=_vlm_mask_fn,
-                    formatting_func=self.formatting_func,
-                    dataset_order=vlm_dataset_order,
-                    num_epochs=vlm_num_epochs,
-                    completion_only_loss=text_completion_only_loss,
-                    assistant_only_loss=text_assistant_only_loss,
-                    comm_group=comm_group,
+                batches = self._run_distributed_setup(
+                    lambda: create_vlm_batches(
+                        dataset=train_dataset,
+                        processor=processor,
+                        config=config,
+                        batch_size=args.per_device_train_batch_size,
+                        max_seq_length=args.max_seq_length,
+                        image_size=getattr(args, "image_size", None),
+                        num_batches=total_batches_needed,
+                        seed=args.seed,
+                        response_mask_fn=_vlm_mask_fn,
+                        formatting_func=self.formatting_func,
+                        dataset_order=vlm_dataset_order,
+                        num_epochs=vlm_num_epochs,
+                        completion_only_loss=text_completion_only_loss,
+                        assistant_only_loss=text_assistant_only_loss,
+                        comm_group=comm_group,
+                    ),
+                    "VLM training batch materialization",
                 )
                 if (_vlm_mask_fn is not None or text_assistant_only_loss) and batches:
                     _check_vlm_all_masked(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -4474,6 +4474,7 @@ def _filter_trainable_vlm_indices(
     formatting_func=None,
     ignore_token_ids=None,
     completion_only_loss=None,
+    assistant_only_loss=False,
 ):
     """Filter VLM rows before batching, matching CUDA dataset.filter order."""
     kept_indices = []
@@ -4493,6 +4494,7 @@ def _filter_trainable_vlm_indices(
             formatting_func=None,
             ignore_token_ids=ignore_token_ids,
             completion_only_loss=completion_only_loss,
+            assistant_only_loss=assistant_only_loss,
             return_prompt_completion=True,
         )
         if is_prompt_completion:
@@ -4515,7 +4517,8 @@ def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
                        formatting_func=None, dataset_order="default",
                        num_epochs=None, completion_only_loss=None,
                        image_size=None, comm_group=None,
-                       distributed_pad_mode="cycle"):
+                       distributed_pad_mode="cycle",
+                       assistant_only_loss=False):
     """Pre-materialize VLM training batches using the processor directly.
 
     Mirrors Unsloth's GPU UnslothVisionDataCollator:
@@ -4547,6 +4550,7 @@ def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
             formatting_func=formatting_func,
             ignore_token_ids=ignore_token_ids,
             completion_only_loss=completion_only_loss,
+            assistant_only_loss=assistant_only_loss,
         )
         if not base_indices and total_removed > 0:
             raise ValueError(
@@ -4621,6 +4625,7 @@ def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
             formatting_func=batch_formatting_func,
             ignore_token_ids=ignore_token_ids,
             completion_only_loss=completion_only_loss,
+            assistant_only_loss=assistant_only_loss,
         )
         if any(empty_rows):
             batch_dict = _mask_empty_vlm_padding_rows(
@@ -4652,7 +4657,8 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                                   formatting_func=None,
                                   dataset_order="default",
                                   completion_only_loss=None,
-                                  image_size=None, comm_group=None):
+                                  image_size=None, comm_group=None,
+                                  assistant_only_loss=False):
     """Streaming VLM batch generator using processor directly.
 
     Yields batch dicts with input_ids, pixel_values, attention_mask,
@@ -4677,6 +4683,7 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
             formatting_func=batch_formatting_func,
             ignore_token_ids=ignore_token_ids,
             completion_only_loss=completion_only_loss,
+            assistant_only_loss=assistant_only_loss,
         )
 
     if hasattr(dataset, "__len__"):
@@ -4697,6 +4704,7 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                 formatting_func=formatting_func,
                 ignore_token_ids=ignore_token_ids,
                 completion_only_loss=completion_only_loss,
+                assistant_only_loss=assistant_only_loss,
             )
             if not base_indices and total_removed > 0:
                 raise ValueError(
@@ -4787,6 +4795,7 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                 formatting_func=None,
                 ignore_token_ids=ignore_token_ids,
                 completion_only_loss=completion_only_loss,
+                assistant_only_loss=assistant_only_loss,
                 return_prompt_completion=True,
             )
             if is_prompt_completion:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -31,7 +31,6 @@ import importlib
 import json
 import numpy as np
 import os
-import re
 import sys
 import shutil
 import tempfile
@@ -2924,7 +2923,11 @@ def _validate_mlx_assistant_mask(input_ids, assistant_mask, *, source):
         raise ValueError(
             f"Unsloth MLX: {source} assistant_masks must match input_ids length."
         )
-    if not any(int(mask) == 1 for mask in assistant_mask):
+    if any(mask not in (0, 1) for mask in assistant_mask):
+        raise ValueError(
+            f"Unsloth MLX: {source} assistant_masks must contain only 0 or 1."
+        )
+    if not any(mask == 1 for mask in assistant_mask):
         raise RuntimeError(
             "You're using `assistant_only_loss=True`, but at least one example has "
             "no assistant tokens. This usually means the tokenizer's chat template "
@@ -3788,7 +3791,7 @@ def _processor_vlm_inputs(
     raise first_error
 
 
-def _as_vlm_token_rows(value, field_name, expected_rows):
+def _as_vlm_token_rows(value, field_name, expected_rows, *, coerce_int=True):
     """Normalize one batched chat-template field to Python token rows."""
     if hasattr(value, "tolist"):
         value = value.tolist()
@@ -3807,16 +3810,224 @@ def _as_vlm_token_rows(value, field_name, expected_rows):
             raise ValueError(
                 f"Unsloth MLX VLM: chat-template {field_name} rows must be sequences."
             )
-        rows.append([int(token) for token in row])
+        rows.append([int(token) for token in row] if coerce_int else list(row))
     return rows
+
+
+def _as_vlm_offset_rows(value, expected_rows):
+    """Normalize fast-tokenizer offset mappings to batched Python rows."""
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    try:
+        if expected_rows == 1 and (
+            not value
+            or (value[0] and not isinstance(value[0][0], (list, tuple)))
+        ):
+            value = [value]
+        rows = [
+            [(int(start), int(end)) for start, end in row]
+            for row in value
+        ]
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("Unsloth MLX VLM: invalid fast-tokenizer offsets.") from exc
+    if len(rows) != expected_rows:
+        raise ValueError("Unsloth MLX VLM: offset row count must match input_ids.")
+    return rows
+
+
+def _annotate_vlm_content(messages, marker_root, row_index):
+    """Mark supported assistant content while preserving media by reference."""
+    annotated = []
+    spans = []
+    part_index = 0
+
+    def mark_text(value, message_index):
+        nonlocal part_index
+        text = str(value)
+        if not text.strip():
+            return text
+        key = f"{row_index}_{message_index}_{part_index}"
+        part_index += 1
+        start_marker = f"{marker_root}1_{key}__"
+        end_marker = f"{marker_root}2_{key}__"
+        spans.append((start_marker, end_marker))
+        return start_marker + text + end_marker
+
+    def unsupported_part():
+        return ValueError(
+            "Unsloth MLX VLM: unsupported assistant content; use one `text` field."
+        )
+
+    for message_index, message in enumerate(messages):
+        if not isinstance(message, Mapping):
+            raise ValueError("Unsloth MLX VLM: messages must be mappings.")
+        if message.get("role") != "assistant":
+            annotated.append(message)
+            continue
+        extra_fields = set(message).difference(("role", "content"))
+        if extra_fields:
+            raise ValueError(
+                "Unsloth MLX VLM: unsupported assistant message fields outside "
+                "`role` and `content`."
+            )
+
+        cloned = dict(message)
+        content = message.get("content")
+        if isinstance(content, str):
+            cloned["content"] = mark_text(content, message_index)
+        elif isinstance(content, (list, tuple)):
+            cloned_parts = []
+            for part in content:
+                if isinstance(part, str):
+                    cloned_parts.append(mark_text(part, message_index))
+                    continue
+                if not isinstance(part, Mapping):
+                    raise ValueError(
+                        "Unsloth MLX VLM: VLM content parts must be strings or mappings."
+                    )
+                media_field = {
+                    "image": "image",
+                    "video": "video",
+                    "audio": "audio",
+                }.get(part.get("type"))
+                if media_field is not None:
+                    if set(part).difference(("type", media_field)):
+                        raise unsupported_part()
+                    cloned_parts.append(part)
+                    continue
+                text = part.get("text")
+                if (
+                    not isinstance(text, str)
+                    or set(part).difference(("type", "text"))
+                ):
+                    raise unsupported_part()
+                cloned_part = dict(part)
+                cloned_part["text"] = mark_text(text, message_index)
+                cloned_parts.append(cloned_part)
+            cloned["content"] = cloned_parts
+        else:
+            raise ValueError(
+                "Unsloth MLX VLM: unsupported message content; expected text or parts."
+            )
+        annotated.append(cloned)
+    return annotated, spans
+
+
+def _strip_vlm_content_markers(value, specs):
+    """Remove supported-content markers and return their character spans."""
+    occurrences = []
+    raw_spans = []
+    for start_marker, end_marker in specs:
+        start_count = value.count(start_marker)
+        end_count = value.count(end_marker)
+        if start_count == end_count == 0:
+            raise RuntimeError(
+                "Unsloth MLX VLM: could not prove every assistant content span."
+            )
+        if start_count != 1 or end_count != 1:
+            raise RuntimeError("Unsloth MLX VLM: content markers must render once.")
+        start_at = value.index(start_marker)
+        end_at = value.index(end_marker)
+        content_at = start_at + len(start_marker)
+        if end_at < content_at:
+            raise RuntimeError("Unsloth MLX VLM: content markers were reordered.")
+        occurrences.extend(((start_at, start_marker), (end_at, end_marker)))
+        raw_spans.append((content_at, end_at))
+
+    stripped = value
+    for position, marker in sorted(occurrences, reverse=True):
+        stripped = stripped[:position] + stripped[position + len(marker):]
+
+    def removed_before(position):
+        return sum(
+            len(marker) for marker_at, marker in occurrences
+            if marker_at < position
+        )
+
+    spans = [
+        (
+            start_at - removed_before(start_at),
+            end_at - removed_before(end_at),
+        )
+        for start_at, end_at in raw_spans
+    ]
+    return stripped, spans
+
+
+def _validate_vlm_prefix_assistant_mask(
+    rendered, annotated, content_specs, message_spans, offsets, assistant_mask,
+):
+    """Validate one full mask against prefix-stable message and content spans."""
+    annotated, content_spans = _strip_vlm_content_markers(
+        annotated, content_specs,
+    )
+    if annotated != rendered:
+        raise RuntimeError(
+            "Unsloth MLX VLM: assistant_only_loss=True could not map supported "
+            "content onto the tokenizer's full chat-template render."
+        )
+
+    valid_offsets = [
+        (token_index, token_start, token_end)
+        for token_index, (token_start, token_end) in enumerate(offsets)
+        if token_end > token_start
+    ]
+
+    def span_tokens(start_at, end_at):
+        return {
+            token_index
+            for token_index, token_start, token_end in valid_offsets
+            if token_start < end_at and token_end > start_at
+        }
+
+    assistant_message_tokens = []
+    allowed_mask_tokens = set()
+    non_assistant_tokens = set()
+    for role, start_at, end_at in message_spans:
+        token_positions = span_tokens(start_at, end_at)
+        if role == "assistant":
+            allowed_mask_tokens.update(token_positions)
+            assistant_message_tokens.append(token_positions)
+        else:
+            non_assistant_tokens.update(token_positions)
+
+    masked_tokens = {
+        index for index, value in enumerate(assistant_mask) if int(value) == 1
+    }
+    if (
+        not masked_tokens.issubset(allowed_mask_tokens)
+        or masked_tokens.intersection(non_assistant_tokens)
+    ):
+        raise RuntimeError(
+            "Unsloth MLX VLM: assistant_only_loss=True requires the active "
+            "chat template to mark only assistant-authored spans with "
+            "`{% generation %}` blocks."
+        )
+    if any(
+        not masked_tokens.intersection(token_positions)
+        for token_positions in assistant_message_tokens
+    ):
+        raise RuntimeError(
+            "Unsloth MLX VLM: assistant_only_loss=True requires the active "
+            "chat template to mark every assistant turn with `{% generation %}`."
+        )
+
+    for start_at, end_at in content_spans:
+        token_positions = span_tokens(start_at, end_at)
+        if (
+            not token_positions or not token_positions.issubset(masked_tokens)
+        ):
+            raise RuntimeError(
+                "Unsloth MLX VLM: assistant_only_loss=True requires the active "
+                "chat template to mark every rendered assistant content span "
+                "with `{% generation %}`."
+            )
 
 
 def _tokenize_vlm_assistant_mask_rows(processor, messages_batch):
     """Return unexpanded template token ids and generation masks per VLM row."""
     template = getattr(processor, "chat_template", None)
-    if not isinstance(template, str) or re.search(
-        r"\{%-?\s*generation\s*-?%\}", template,
-    ) is None:
+    if not isinstance(template, str):
         raise ValueError(
             "Unsloth MLX VLM: assistant_only_loss=True requires the active "
             "processor chat_template to mark assistant spans with "
@@ -3827,40 +4038,40 @@ def _tokenize_vlm_assistant_mask_rows(processor, messages_batch):
     if tokenizer is None or not hasattr(tokenizer, "apply_chat_template"):
         raise ValueError(
             "Unsloth MLX VLM: assistant_only_loss=True requires a tokenizer "
-            "that supports apply_chat_template(..., return_assistant_tokens_mask=True)."
+            "that supports generation blocks through "
+            "apply_chat_template(..., return_assistant_tokens_mask=True)."
         )
 
     render_batch = []
-    turn_probe_batch = []
-    turn_probes = []
     accepts_list_content = _processor_accepts_assistant_list_content(processor)
+    marker_root = f"__3141592653589793238462643383279_{id(render_batch)}_"
+    while marker_root in repr(messages_batch) or marker_root in template:
+        marker_root += "_"
+    annotated_batch = []
+    content_spec_rows = []
     for row_index, messages in enumerate(messages_batch):
-        rendered_messages = (
-            messages
-            if accepts_list_content
-            else _collapse_vlm_assistant_content(messages)
+        annotated, specs = _annotate_vlm_content(
+            messages, marker_root, row_index,
         )
-        render_batch.append(rendered_messages)
-        assistant_positions = [
-            index for index, message in enumerate(rendered_messages)
-            if isinstance(message, Mapping) and message.get("role") == "assistant"
-        ]
-        if len(assistant_positions) > 1:
-            for position in assistant_positions:
-                before_index = None
-                if position > 0:
-                    before_index = len(turn_probe_batch)
-                    turn_probe_batch.append(rendered_messages[:position])
-                through_index = len(turn_probe_batch)
-                turn_probe_batch.append(rendered_messages[:position + 1])
-                turn_probes.append((row_index, before_index, through_index))
+        if not accepts_list_content:
+            messages = _collapse_vlm_assistant_content(messages)
+            annotated = _collapse_vlm_assistant_content(annotated)
+        render_batch.append(messages)
+        annotated_batch.append(annotated)
+        content_spec_rows.append(specs)
 
-    # Tokenize full rows and structured turn probes together so correctness does
-    # not add another chat-template processor pass.
-    template_batch = render_batch + turn_probe_batch
+    prefix_batch = []
+    prefix_ranges = []
+    for messages in render_batch:
+        start = len(prefix_batch)
+        prefix_batch.extend(
+            messages[:end] for end in range(1, len(messages))
+        )
+        prefix_ranges.append((start, len(prefix_batch)))
+
     try:
         processed = tokenizer.apply_chat_template(
-            template_batch,
+            render_batch,
             chat_template=template,
             tokenize=True,
             add_generation_prompt=False,
@@ -3868,6 +4079,7 @@ def _tokenize_vlm_assistant_mask_rows(processor, messages_batch):
             return_assistant_tokens_mask=True,
             padding=False,
             truncation=False,
+            tokenizer_kwargs={"return_offsets_mapping": True},
         )
     except Exception as exc:
         raise RuntimeError(
@@ -3882,51 +4094,86 @@ def _tokenize_vlm_assistant_mask_rows(processor, messages_batch):
             "masks, but the processor tokenizer returned none. Ensure the "
             "active chat template contains `{% generation %}` blocks."
         )
+    if "offset_mapping" not in processed:
+        raise RuntimeError(
+            "Unsloth MLX VLM: assistant_only_loss=True requires a fast "
+            "processor tokenizer that returns token offset mappings."
+        )
     input_rows = _as_vlm_token_rows(
-        processed["input_ids"], "input_ids", len(template_batch),
+        processed["input_ids"], "input_ids", len(render_batch),
     )
     mask_rows = _as_vlm_token_rows(
-        processed["assistant_masks"], "assistant_masks", len(template_batch),
+        processed["assistant_masks"], "assistant_masks", len(render_batch),
+        coerce_int=False,
     )
-    full_count = len(render_batch)
-    full_input_rows, probe_input_rows = input_rows[:full_count], input_rows[full_count:]
-    full_mask_rows, probe_mask_rows = mask_rows[:full_count], mask_rows[full_count:]
-    for input_ids, assistant_mask in zip(full_input_rows, full_mask_rows):
+    offset_rows = _as_vlm_offset_rows(
+        processed["offset_mapping"], len(render_batch),
+    )
+    for input_ids, assistant_mask, offsets in zip(input_rows, mask_rows, offset_rows):
         _validate_mlx_assistant_mask(
             input_ids, assistant_mask, source="VLM chat-template",
         )
-
-    def _matching_prefix_length(left, right):
-        length = 0
-        while length < min(len(left), len(right)) and left[length] == right[length]:
-            length += 1
-        return length
-
-    for row_index, before_index, through_index in turn_probes:
-        before_ids = [] if before_index is None else probe_input_rows[before_index]
-        through_ids = probe_input_rows[through_index]
-        through_mask = probe_mask_rows[through_index]
-        _validate_mlx_assistant_mask(
-            through_ids, through_mask, source="VLM assistant-turn probe",
-        )
-        turn_start = _matching_prefix_length(before_ids, through_ids)
-        turn_positions = [
-            index for index in range(turn_start, len(through_ids))
-            if through_mask[index] == 1
-        ]
-        full_prefix = _matching_prefix_length(
-            through_ids, full_input_rows[row_index],
-        )
-        if not turn_positions or any(
-            index >= full_prefix or full_mask_rows[row_index][index] != 1
-            for index in turn_positions
-        ):
-            raise RuntimeError(
-                "Unsloth MLX VLM: assistant_only_loss=True requires the active "
-                "chat template to mark every assistant turn with `{% generation %}`. "
-                "The template returned a partial or final-turn-only assistant mask."
+        if len(offsets) != len(input_ids):
+            raise ValueError(
+                "Unsloth MLX VLM: offset_mapping must match chat-template input_ids."
             )
-    return list(zip(full_input_rows, full_mask_rows))
+    mask_rows = [[int(mask) for mask in row] for row in mask_rows]
+
+    try:
+        render_values = tokenizer.apply_chat_template(
+            render_batch + annotated_batch + prefix_batch,
+            chat_template=template,
+            tokenize=False,
+            add_generation_prompt=False,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "Unsloth MLX VLM: the processor tokenizer could not validate "
+            "assistant boundaries in prefix-stable chat-template renders."
+        ) from exc
+    if isinstance(render_values, str):
+        render_values = [render_values]
+    expected_renders = 2 * len(render_batch) + len(prefix_batch)
+    if (
+        not isinstance(render_values, (list, tuple))
+        or len(render_values) != expected_renders
+        or not all(isinstance(value, str) for value in render_values)
+    ):
+        raise RuntimeError(
+            "Unsloth MLX VLM: the processor tokenizer returned an unexpected "
+            "number of renders while validating assistant roles."
+        )
+
+    full_count = len(render_batch)
+    rendered_rows = render_values[:full_count]
+    annotated_rows = render_values[full_count:2 * full_count]
+    prefix_rows = render_values[2 * full_count:]
+    for row_index in range(len(render_batch)):
+        messages = render_batch[row_index]
+        start, end = prefix_ranges[row_index]
+        prefixes = list(prefix_rows[start:end]) + [rendered_rows[row_index]]
+        previous = ""
+        message_spans = []
+        for message_index, prefix in enumerate(prefixes):
+            if not prefix.startswith(previous):
+                raise RuntimeError(
+                    "Unsloth MLX VLM: assistant_only_loss=True requires a "
+                    "prefix-stable chat template; the rendered history changed "
+                    "when a later message was added."
+                )
+            role = str(messages[message_index].get("role", ""))
+            message_spans.append((role, len(previous), len(prefix)))
+            previous = prefix
+
+        _validate_vlm_prefix_assistant_mask(
+            rendered_rows[row_index],
+            annotated_rows[row_index],
+            content_spec_rows[row_index],
+            message_spans,
+            offset_rows[row_index],
+            mask_rows[row_index],
+        )
+    return list(zip(input_rows, mask_rows))
 
 
 def _align_vlm_assistant_mask_row(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -31,6 +31,7 @@ import importlib
 import json
 import numpy as np
 import os
+import re
 import sys
 import shutil
 import tempfile
@@ -3787,6 +3788,281 @@ def _processor_vlm_inputs(
     raise first_error
 
 
+def _as_vlm_token_rows(value, field_name, expected_rows):
+    """Normalize one batched chat-template field to Python token rows."""
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if expected_rows == 1 and value and not isinstance(value[0], (list, tuple)):
+        value = [value]
+    if not isinstance(value, (list, tuple)) or len(value) != expected_rows:
+        raise ValueError(
+            f"Unsloth MLX VLM: chat-template {field_name} must contain "
+            f"{expected_rows} row(s)."
+        )
+    rows = []
+    for row in value:
+        if hasattr(row, "tolist"):
+            row = row.tolist()
+        if not isinstance(row, (list, tuple)):
+            raise ValueError(
+                f"Unsloth MLX VLM: chat-template {field_name} rows must be sequences."
+            )
+        rows.append([int(token) for token in row])
+    return rows
+
+
+def _tokenize_vlm_assistant_mask_rows(processor, messages_batch):
+    """Return unexpanded template token ids and generation masks per VLM row."""
+    template = getattr(processor, "chat_template", None)
+    if not isinstance(template, str) or re.search(
+        r"\{%-?\s*generation\s*-?%\}", template,
+    ) is None:
+        raise ValueError(
+            "Unsloth MLX VLM: assistant_only_loss=True requires the active "
+            "processor chat_template to mark assistant spans with "
+            "`{% generation %}...{% endgeneration %}`."
+        )
+
+    tokenizer = _get_processor_tokenizer(processor)
+    if tokenizer is None or not hasattr(tokenizer, "apply_chat_template"):
+        raise ValueError(
+            "Unsloth MLX VLM: assistant_only_loss=True requires a tokenizer "
+            "that supports apply_chat_template(..., return_assistant_tokens_mask=True)."
+        )
+
+    render_batch = []
+    turn_probe_batch = []
+    turn_probes = []
+    accepts_list_content = _processor_accepts_assistant_list_content(processor)
+    for row_index, messages in enumerate(messages_batch):
+        rendered_messages = (
+            messages
+            if accepts_list_content
+            else _collapse_vlm_assistant_content(messages)
+        )
+        render_batch.append(rendered_messages)
+        assistant_positions = [
+            index for index, message in enumerate(rendered_messages)
+            if isinstance(message, Mapping) and message.get("role") == "assistant"
+        ]
+        if len(assistant_positions) > 1:
+            for position in assistant_positions:
+                before_index = None
+                if position > 0:
+                    before_index = len(turn_probe_batch)
+                    turn_probe_batch.append(rendered_messages[:position])
+                through_index = len(turn_probe_batch)
+                turn_probe_batch.append(rendered_messages[:position + 1])
+                turn_probes.append((row_index, before_index, through_index))
+
+    # Tokenize full rows and structured turn probes together so correctness does
+    # not add another chat-template processor pass.
+    template_batch = render_batch + turn_probe_batch
+    try:
+        processed = tokenizer.apply_chat_template(
+            template_batch,
+            chat_template=template,
+            tokenize=True,
+            add_generation_prompt=False,
+            return_dict=True,
+            return_assistant_tokens_mask=True,
+            padding=False,
+            truncation=False,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "Unsloth MLX VLM: the processor tokenizer could not produce "
+            "trustworthy assistant token masks. Use a fast tokenizer and a "
+            "chat template with `{% generation %}` blocks."
+        ) from exc
+
+    if not isinstance(processed, Mapping) or "assistant_masks" not in processed:
+        raise RuntimeError(
+            "Unsloth MLX VLM: assistant_only_loss=True requested assistant "
+            "masks, but the processor tokenizer returned none. Ensure the "
+            "active chat template contains `{% generation %}` blocks."
+        )
+    input_rows = _as_vlm_token_rows(
+        processed["input_ids"], "input_ids", len(template_batch),
+    )
+    mask_rows = _as_vlm_token_rows(
+        processed["assistant_masks"], "assistant_masks", len(template_batch),
+    )
+    full_count = len(render_batch)
+    full_input_rows, probe_input_rows = input_rows[:full_count], input_rows[full_count:]
+    full_mask_rows, probe_mask_rows = mask_rows[:full_count], mask_rows[full_count:]
+    for input_ids, assistant_mask in zip(full_input_rows, full_mask_rows):
+        _validate_mlx_assistant_mask(
+            input_ids, assistant_mask, source="VLM chat-template",
+        )
+
+    def _matching_prefix_length(left, right):
+        length = 0
+        while length < min(len(left), len(right)) and left[length] == right[length]:
+            length += 1
+        return length
+
+    for row_index, before_index, through_index in turn_probes:
+        before_ids = [] if before_index is None else probe_input_rows[before_index]
+        through_ids = probe_input_rows[through_index]
+        through_mask = probe_mask_rows[through_index]
+        _validate_mlx_assistant_mask(
+            through_ids, through_mask, source="VLM assistant-turn probe",
+        )
+        turn_start = _matching_prefix_length(before_ids, through_ids)
+        turn_positions = [
+            index for index in range(turn_start, len(through_ids))
+            if through_mask[index] == 1
+        ]
+        full_prefix = _matching_prefix_length(
+            through_ids, full_input_rows[row_index],
+        )
+        if not turn_positions or any(
+            index >= full_prefix or full_mask_rows[row_index][index] != 1
+            for index in turn_positions
+        ):
+            raise RuntimeError(
+                "Unsloth MLX VLM: assistant_only_loss=True requires the active "
+                "chat template to mark every assistant turn with `{% generation %}`. "
+                "The template returned a partial or final-turn-only assistant mask."
+            )
+    return list(zip(full_input_rows, full_mask_rows))
+
+
+def _align_vlm_assistant_mask_row(
+    source_ids,
+    source_mask,
+    final_ids,
+    attention_mask,
+    *,
+    ignore_token_ids=None,
+    truncation_side="right",
+    max_seq_length=None,
+):
+    """Align a template mask to final processor ids without content searching."""
+    structural_ids = {int(token) for token in (ignore_token_ids or ())}
+    final_ids = [int(token) for token in final_ids]
+    if attention_mask is None:
+        valid_positions = list(range(len(final_ids)))
+    else:
+        valid_positions = [
+            idx for idx, keep in enumerate(attention_mask) if int(keep) != 0
+        ]
+    final_valid = [final_ids[idx] for idx in valid_positions]
+    source_ids = [int(token) for token in source_ids]
+    source_mask = [int(mask) for mask in source_mask]
+
+    reverse = truncation_side == "left"
+    if reverse:
+        source_ids.reverse()
+        source_mask.reverse()
+        final_valid.reverse()
+
+    aligned_valid = []
+    source_idx = 0
+    for final_token in final_valid:
+        while (
+            source_idx < len(source_ids)
+            and source_ids[source_idx] in structural_ids
+            and source_ids[source_idx] != final_token
+        ):
+            source_idx += 1
+        if source_idx < len(source_ids) and source_ids[source_idx] == final_token:
+            aligned_valid.append(source_mask[source_idx])
+            source_idx += 1
+        elif final_token in structural_ids:
+            # Processor-expanded image/video/audio tokens never train.
+            aligned_valid.append(0)
+        else:
+            source_token = (
+                source_ids[source_idx] if source_idx < len(source_ids) else None
+            )
+            raise ValueError(
+                "Unsloth MLX VLM: assistant mask could not be aligned with "
+                "final processor input_ids; the processor changed a "
+                f"non-multimodal token ({source_token!r} -> {final_token!r})."
+            )
+
+    while source_idx < len(source_ids) and source_ids[source_idx] in structural_ids:
+        source_idx += 1
+    was_truncated = (
+        max_seq_length is not None
+        and max_seq_length > 0
+        and len(final_valid) >= int(max_seq_length)
+    )
+    if source_idx < len(source_ids) and not was_truncated:
+        raise ValueError(
+            "Unsloth MLX VLM: assistant mask alignment ended before all "
+            "non-multimodal chat-template tokens were consumed."
+        )
+
+    if reverse:
+        aligned_valid.reverse()
+    aligned = [0] * len(final_ids)
+    for position, mask in zip(valid_positions, aligned_valid):
+        aligned[position] = int(mask != 0)
+    return aligned
+
+
+def _apply_vlm_assistant_label_masks(
+    batch_dict,
+    source_rows,
+    tokenizer,
+    *,
+    ignore_token_ids=None,
+    max_seq_length=None,
+):
+    """Intersect assistant masks with existing labels and VLM ignore masks."""
+    raw_input_ids = batch_dict.get(
+        _RAW_INPUT_IDS_FOR_LABELS, batch_dict["input_ids"],
+    )
+    final_rows = np.asarray(
+        raw_input_ids.tolist()
+        if hasattr(raw_input_ids, "tolist") else raw_input_ids
+    )
+    if final_rows.ndim == 1:
+        final_rows = final_rows.reshape(1, -1)
+    attention = batch_dict.get("attention_mask")
+    attention_rows = None if attention is None else np.asarray(
+        attention.tolist() if hasattr(attention, "tolist") else attention
+    )
+    if len(source_rows) != final_rows.shape[0]:
+        raise ValueError(
+            "Unsloth MLX VLM: assistant mask row count must match processor input_ids."
+        )
+
+    truncation_side = getattr(tokenizer, "truncation_side", "right")
+    assistant_masks = []
+    for row_idx, (source_ids, source_mask) in enumerate(source_rows):
+        assistant_masks.append(
+            _align_vlm_assistant_mask_row(
+                source_ids,
+                source_mask,
+                final_rows[row_idx],
+                None if attention_rows is None else attention_rows[row_idx],
+                ignore_token_ids=ignore_token_ids,
+                truncation_side=truncation_side,
+                max_seq_length=max_seq_length,
+            )
+        )
+
+    labels = batch_dict.get("labels", raw_input_ids)
+    labels = _normalize_cce_label_dtype(labels)
+    assistant_mask = mx.array(np.asarray(assistant_masks, dtype=np.int32))
+    if tuple(labels.shape) != tuple(assistant_mask.shape):
+        raise ValueError(
+            "Unsloth MLX VLM: existing labels must match final processor "
+            "input_ids before applying assistant_only_loss."
+        )
+    ignore = mx.array(-100, dtype=labels.dtype)
+    labels = mx.where(assistant_mask != 0, labels, ignore)
+    return _apply_vlm_label_masks(
+        batch_dict,
+        labels=labels,
+        ignore_token_ids=ignore_token_ids,
+    )
+
+
 def _as_numpy_vlm_field(inputs, key):
     """Return a processor output field as a 2-D numpy array."""
     value = inputs[key]
@@ -4007,6 +4283,7 @@ def _collate_vlm_prompt_completion_batch(
 def _collate_vlm_batch(items, processor, max_seq_length, image_size,
                        formatting_func=None, ignore_token_ids=None,
                        completion_only_loss=None,
+                       assistant_only_loss=False,
                        return_prompt_completion=False):
     """Collate a batch of VLM samples using the processor directly.
 
@@ -4027,6 +4304,13 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         and "prompt" in formatted_items[0]
         and "completion" in formatted_items[0]
     ):
+        if assistant_only_loss:
+            raise ValueError(
+                "Unsloth MLX VLM: assistant_only_loss=True is not supported "
+                "for prompt/completion VLM rows because the CUDA-parity "
+                "collator tokenizes the two parts separately. Use a single "
+                "conversational messages column instead."
+            )
         batch = _collate_vlm_prompt_completion_batch(
             formatted_items, processor, max_seq_length, image_size,
             ignore_token_ids=ignore_token_ids,
@@ -4037,15 +4321,24 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
     all_texts = []
     all_images = []
     all_suffixes = []
+    assistant_messages = []
 
     for item in formatted_items:
         raw = _select_vlm_messages_or_raw(item)
         if raw is item:
+            if assistant_only_loss:
+                raise ValueError(
+                    "Unsloth MLX VLM: assistant_only_loss=True requires "
+                    "conversational messages/conversations rows; pre-rendered "
+                    "text and pretokenized VLM rows do not preserve assistant boundaries."
+                )
             text = render_mlx_chat_example(processor, item, is_vlm=True)
             messages = []
         else:
             messages = _normalize_vlm_messages(raw)
             text = _render_vlm_messages(processor, messages)
+            if assistant_only_loss:
+                assistant_messages.append(messages)
         if not text:
             raise ValueError(
                 "Unsloth MLX VLM: no text could be rendered for this dataset row. "
@@ -4061,10 +4354,27 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         suffixes=all_suffixes,
     )
     batch = _to_mx_vlm_batch(inputs)
-    batch["labels"] = _apply_vlm_label_masks(
-        batch,
-        ignore_token_ids=ignore_token_ids,
-    )
+    if assistant_only_loss:
+        effective_ignore_ids = (
+            ignore_token_ids
+            if ignore_token_ids is not None
+            else _get_vlm_ignore_token_ids(processor=processor)
+        )
+        source_rows = _tokenize_vlm_assistant_mask_rows(
+            processor, assistant_messages,
+        )
+        batch["labels"] = _apply_vlm_assistant_label_masks(
+            batch,
+            source_rows,
+            _get_processor_tokenizer(processor),
+            ignore_token_ids=effective_ignore_ids,
+            max_seq_length=max_seq_length,
+        )
+    else:
+        batch["labels"] = _apply_vlm_label_masks(
+            batch,
+            ignore_token_ids=ignore_token_ids,
+        )
     return (batch, False) if return_prompt_completion else batch
 
 
@@ -4129,6 +4439,7 @@ def _build_response_masked_vlm_batch(
     formatting_func=None,
     ignore_token_ids=None,
     completion_only_loss=None,
+    assistant_only_loss=False,
     return_prompt_completion=False,
 ):
     """Collate VLM rows and apply the CUDA response-mask closure."""
@@ -4137,6 +4448,7 @@ def _build_response_masked_vlm_batch(
         formatting_func=formatting_func,
         ignore_token_ids=ignore_token_ids,
         completion_only_loss=completion_only_loss,
+        assistant_only_loss=assistant_only_loss,
         return_prompt_completion=True,
     )
     batch_dict = _prepare_vlm_batch_for_compile(batch_dict, config)


### PR DESCRIPTION
## Summary

This PR adds direct `MLXTrainingConfig(assistant_only_loss=True)` support for conversational vision-language model training in `MLXTrainer`.

The implementation supervises every assistant-authored turn in a multi-turn conversation. System, user, tool-response, padding, multimodal placeholder/expansion, and model-specific ignored tokens remain `-100`. The same effective labels are used by materialized and streaming training, evaluation, baseline cross-entropy, and Cut Cross Entropy (CCE).

The public Unsloth application dispatcher is intentionally unchanged. This PR establishes the zoo-side MLX trainer contract so argument routing can be added separately without coupling the masking implementation to application or Studio plumbing.

## Motivation

The MLX trainer previously rejected `assistant_only_loss=True` for VLM datasets. Treating this as final-completion masking would be incorrect: a conversation can contain multiple assistant turns, and every assistant turn must remain supervised while system, user, and tool-response turns remain ignored.

VLM masking also cannot be derived safely by finding response text in a rendered prompt. Repeated user/assistant text, merged tokenizer tokens, role delimiters, padding side, truncation, and processor-side expansion of image/video/audio placeholders can all invalidate substring or token-subsequence matching. The mask therefore has to originate from the active chat-template contract and remain aligned with the final processor output.

## User-visible behavior

| Input/configuration | Behavior |
|---|---|
| Conversational VLM rows with `assistant_only_loss=False` | Existing full-sequence VLM label behavior is unchanged. |
| Conversational VLM rows with `assistant_only_loss=True` | Every assistant turn is supervised; non-assistant and ignored structural tokens are `-100`. |
| Existing labels or response masking plus assistant-only loss | Masks intersect; existing `-100` labels are never overwritten with raw token IDs. |
| Materialized or streaming datasets | Both paths call the same assistant-aware VLM collation and produce equivalent labels for the same rows. |
| Evaluation datasets | Evaluation uses the same assistant-mask generation and final-label semantics as training. |
| Prompt/completion VLM rows plus assistant-only loss | Raises an actionable error because the CUDA-parity collator tokenizes prompt and completion separately and cannot preserve one authoritative assistant mask. |
| Pre-rendered or pretokenized VLM rows plus assistant-only loss | Raises an actionable error because the current backend has no token-index-preserving assistant-boundary pathway for these rows. |
| Missing, incomplete, non-binary, or untrustworthy processor assistant masks | Fails closed instead of falling back to full-sequence or final-response-only supervision. |

## Mask-generation strategy

### 1. Obtain authoritative unexpanded token boundaries

The active processor tokenizer is called with the processor's chat template, `return_assistant_tokens_mask=True`, and fast-tokenizer offset mappings. Source tokenization is deliberately unpadded and untruncated so the returned `input_ids`, `assistant_masks`, and offsets describe one authoritative full render before processor-side multimodal expansion.

Assistant mask values are validated before integer normalization. Row counts and token lengths must match, values must compare exactly as binary `0` or `1`, and every example must contain assistant tokens. This prevents values such as `1.5` or `"1"` from becoming valid through lossy coercion.

### 2. Prove role ownership without content searching

The implementation renders cumulative structured-message prefixes. Each later render must begin with the previous render exactly, allowing every character interval added by one message to be assigned to that message's role. Templates whose earlier history changes when a later message is appended are prefix-unstable and fail with a clear error.

Supported assistant text fields are also wrapped with unique temporary markers in a separate structured render. Removing every marker exactly once must reproduce the authoritative full render. Fast-tokenizer offsets then map message and content character intervals to source-token positions.

Validation requires all of the following:

- every processor-masked token belongs to an assistant message interval;
- no masked token overlaps a system, user, tool-response, or other non-assistant interval;
- every assistant turn contributes masked tokens, preventing final-turn-only templates from passing;
- every rendered assistant text span is fully covered by the assistant mask;
- the processor mask remains binary and length-aligned with source `input_ids`.

This provides multi-turn role provenance without naïve substring matching, token-subsequence matching, model-name checks, or template-specific delimiter assumptions.

### 3. Preserve processor compatibility while failing closed

Assistant schema validation runs before processors that require string-only assistant content collapse list-style content. Both the original and marker-annotated copies are collapsed together, preserving marker alignment while preventing unsupported parts from disappearing before validation.

The supported initial assistant schema is deliberately narrow:

- `role` plus string `content`;
- list content containing strings or `{ "type": "text", "text": <string> }` parts;
- exact `image`, `video`, or `audio` media part types with no keys beyond `type` and the matching media payload key.

Extra assistant fields such as reasoning/tool-call structures, unknown text-bearing media metadata, arbitrary nested structured payloads, and prefix-unstable/exotic Jinja templates fail clearly. This is a compatibility boundary, not a fallback: the implementation never silently broadens supervision when assistant ownership cannot be proven.

## Alignment with final processor inputs

After the normal VLM processor has expanded multimodal placeholders, inserted processor-specific structural tokens, padded, and truncated the batch, the validated source mask is aligned to final processor `input_ids` by token index and identity.

Only configured VLM ignore-token IDs may be inserted, removed, or expanded during alignment. Expanded image/video/audio runs always receive mask value `0`. Any unexplained non-multimodal token change raises instead of guessing an alignment. Left and right truncation follow the tokenizer's `truncation_side`, while the final attention mask determines which padded positions are valid.

The aligned assistant mask is intersected with the batch's existing labels using the existing label dtype and raw-ID safeguards. The normal VLM label-mask pass is then reapplied so attention padding and model-specific special/vision/audio token IDs remain ignored. This preserves explicit labels rather than reconstructing them from `input_ids`.

## Trainer, evaluation, and distributed integration

`assistant_only_loss` now flows through the existing VLM architecture rather than introducing a parallel trainer path:

- `_collate_vlm_batch` builds and applies assistant-aware labels;
- `create_vlm_batches` uses those labels for materialized datasets;
- `iterate_vlm_training_batches` uses the same collation for streaming datasets;
- evaluation batch construction receives the same flag and masking contract;
- response masking, when present, intersects the assistant-aware labels;
- both baseline CE and CCE consume the same final batch labels.

Distributed setup is synchronized before later collectives. Rank-local materialized training or evaluation failures are converted into a shared failure outcome, and streaming checkpoint fast-forward errors are synchronized before training resumes. This prevents one rank from raising on an invalid assistant mask or exhausted resume stream while peer ranks continue into a collective.

Synthetic DDP padding rows remain fully `-100` and cannot create supervised padding. The VLM all-masked preflight checks `labels[:, 1:]`, matching the causal shift consumed by the loss, so a token present only at position zero does not incorrectly classify a row as trainable.

## Files and review surface

- `unsloth_zoo/mlx/utils.py`: assistant-mask extraction and provenance validation, final processor-ID alignment, label intersection, and materialized/streaming VLM collation plumbing.
- `unsloth_zoo/mlx/trainer.py`: training/evaluation routing, synchronized setup/resume failures, and causal-shift-aware all-masked validation.
- `tests/test_mlx_vlm_label_masks.py`: focused mask contracts and alignment regressions.
- `tests/test_mlx_trainer_internals.py`: trainer/evaluation routing and synchronized setup behavior.
- `tests/test_mlx_ddp_metal.py`: two-rank resume failure and synthetic-padding safety.
- `tests/test_mlx_pr684_full_validation_metal.py`: real Qwen2-VL assistant-only LoRA and checkpoint-resume coverage.

The main reviewer-sensitive areas are the trust boundary around the processor-provided assistant mask, the source-to-final token alignment rules, and the deliberately fail-closed template/schema contract. `assistant_only_loss=False` stays on the existing label path.

## Validation coverage

Focused and integration tests cover:

- one user/assistant turn with an image;
- multiple assistant turns, proving that all assistant responses are supervised;
- masked system, user, and tool-response spans;
- duplicate user/assistant text, preventing substring-based false matches;
- left and right padding plus truncation at assistant boundaries;
- expanded vision-token runs remaining `-100`;
- intersection with existing labels and response masks;
- missing, partial, final-turn-only, non-assistant, and non-binary generation masks;
- unsupported assistant fields and media metadata in both list-content and string-only processor modes;
- materialized/streaming and train/evaluation parity;
- DDP synthetic padding, setup failures, resume fast-forward failures, and all-masked safety;
- baseline CE/CCE effective-label parity;
- `assistant_only_loss=False` regression behavior;
- real Qwen2-VL assistant-only LoRA training and VLM checkpoint resume on Metal.

```bash
python -m pytest \
  tests/test_mlx_vlm_label_masks.py \
  tests/test_mlx_trainer_internals.py \
  tests/test_mlx_ddp_metal.py \
  tests/test_mlx_pr684_full_validation_metal.py -q
```

Result after rebasing onto the current `main`: **155 passed**.

The branch contains 967 added lines across six files, of which 321 are test lines (33.20%).

## Intentionally deferred

This PR does not add generic structured-assistant provenance, arbitrary Jinja dependency analysis, packing, generic pretokenized VLM support, public dispatcher/UI argument plumbing, or audio-training support. Those concerns can be addressed independently without weakening the fail-closed correctness contract introduced here.
