### PR TITLE
Fix MLX LoRA for routed SwitchLinear experts

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -78,6 +78,10 @@ jobs:
         # on Apple Silicon; on Linux runners it would run against tests/mlx_simulation/ stubs.
         run: python -m pytest tests/test_mlx_torch_shim_smoke.py -v
 
+      - name: tests/test_mlx_switch_lora.py
+        # Real-runtime routed LoRA training and adapter lifecycle coverage.
+        run: python -m pytest tests/test_mlx_switch_lora.py -v -rs
+
       - name: tests/test_qwen35_vjp_metal.py
         # Metal VJP regressions for the qwen3_5 training patches (issue 6002).
         run: python -m pytest tests/test_qwen35_vjp_metal.py -v -rs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ dependencies = [
     "cut_cross_entropy ; python_version >= '3.10' and (sys_platform != 'darwin' or platform_machine != 'arm64')",
     # --- MLX-only deps (macOS arm64) ---
     "mlx>=0.22.0 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
-    "mlx-lm>=0.22.0 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
+    # mlx_lm.utils._download replaced get_model_path in mlx-lm 0.28.3; the MLX
+    # loader imports it unconditionally, so 0.28.3 is the real minimum.
+    "mlx-lm>=0.28.3 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
     "mlx-vlm>=0.4.4 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
     # --- Shared deps (all platforms) ---
     "packaging>=24.1",
@@ -69,7 +71,8 @@ exclude = ["images*"]
 [project.optional-dependencies]
 mlx = [
     "mlx>=0.22.0",
-    "mlx-lm>=0.22.0",
+    # Keep in sync with the MLX-only dependency pin above.
+    "mlx-lm>=0.28.3",
     "mlx-vlm>=0.4.4",
 ]
 core = [

--- a/tests/test_mlx_finetune_last_n_layers.py
+++ b/tests/test_mlx_finetune_last_n_layers.py
@@ -87,7 +87,6 @@ def test_get_peft_model_passes_finetune_last_n_layers_through(monkeypatch):
         "model.layers.1.mlp.gate_proj",
     ])
     monkeypatch.setattr(L, "_apply_mlx_lora_initialization", lambda m, init: None)
-    monkeypatch.setattr(L, "_unfreeze_mlx_lora_parameters", lambda m: None)
     monkeypatch.setattr(L, "linear_to_lora_layers", fake_linear_to_lora_layers)
 
     # Case 1: default (None) -> all 8 layers

--- a/tests/test_mlx_finetune_last_n_layers.py
+++ b/tests/test_mlx_finetune_last_n_layers.py
@@ -33,8 +33,11 @@ import pytest
 
 @pytest.fixture(autouse=True, scope="module")
 def _install_shim():
-    from mlx_simulation import simulate_mlx_on_torch
-    simulate_mlx_on_torch()
+    try:
+        import mlx  # noqa: F401
+    except ImportError:
+        from mlx_simulation import simulate_mlx_on_torch
+        simulate_mlx_on_torch()
 
 
 def test_get_peft_model_has_finetune_last_n_layers_param():
@@ -45,14 +48,13 @@ def test_get_peft_model_has_finetune_last_n_layers_param():
     assert sig.parameters["finetune_last_n_layers"].default is None
 
 
-def test_get_peft_model_passes_finetune_last_n_layers_through():
+def test_get_peft_model_passes_finetune_last_n_layers_through(monkeypatch):
     """linear_to_lora_layers receives the right num_layers value.
 
-    Patches mlx_lm.tuner.utils.linear_to_lora_layers to record num_layers and
+    Patches the loader's linear_to_lora_layers to record num_layers and
     runs against a synthetic text model (we assert the passed value, not real
     side effects).
     """
-    import sys
     import unsloth_zoo.mlx.loader as loader_mod
 
     # Build a minimal text-only fake model with .model.layers of len=8.
@@ -72,23 +74,21 @@ def test_get_peft_model_passes_finetune_last_n_layers_through():
 
     # Capture num_layers values seen by linear_to_lora_layers.
     captured = {"calls": []}
-    def fake_linear_to_lora_layers(model, num_layers, config, use_dora=False):
+    def fake_linear_to_lora_layers(model, num_layers, config):
         captured["calls"].append(num_layers)
+        return 1
 
     # Stub out the helpers get_peft_model uses internally so the test
     # doesn't need to walk a real model tree.
     import unsloth_zoo.mlx.loader as L
-    L._fix_missing_no_grad = lambda m: None
-    L._resolve_lora_keys = lambda m, t: [
+    monkeypatch.setattr(L, "_fix_missing_no_grad", lambda m: None)
+    monkeypatch.setattr(L, "_resolve_lora_keys", lambda m, t: [
         "model.layers.0.self_attn.q_proj",
         "model.layers.1.mlp.gate_proj",
-    ]
-    L._apply_mlx_lora_initialization = lambda m, init: None
-    L.linear_to_lora_layers = fake_linear_to_lora_layers
-    # mlx_lm.tuner.utils is imported inside the function:
-    fake_mod = type(sys)("mlx_lm.tuner.utils")
-    fake_mod.linear_to_lora_layers = fake_linear_to_lora_layers
-    sys.modules["mlx_lm.tuner.utils"] = fake_mod
+    ])
+    monkeypatch.setattr(L, "_apply_mlx_lora_initialization", lambda m, init: None)
+    monkeypatch.setattr(L, "_unfreeze_mlx_lora_parameters", lambda m: None)
+    monkeypatch.setattr(L, "linear_to_lora_layers", fake_linear_to_lora_layers)
 
     # Case 1: default (None) -> all 8 layers
     captured["calls"].clear()

--- a/tests/test_mlx_get_peft_model_seed_ordering.py
+++ b/tests/test_mlx_get_peft_model_seed_ordering.py
@@ -15,8 +15,11 @@ import pytest
 
 @pytest.fixture(autouse=True, scope="module")
 def _install_mlx_shim():
-    from mlx_simulation import simulate_mlx_on_torch
-    simulate_mlx_on_torch()
+    try:
+        import mlx  # noqa: F401
+    except ImportError:
+        from mlx_simulation import simulate_mlx_on_torch
+        simulate_mlx_on_torch()
 
 
 def _get_peft_model_source():
@@ -69,7 +72,8 @@ def test_no_other_mlx_op_between_seed_and_linear_to_lora_layers():
     pattern = re.compile(
         r"_seed_mlx_random_state\(random_state\)\s*"
         r"(?:\n\s*#[^\n]*)*"
-        r"\s*\n\s*linear_to_lora_layers\(",
+        r"\s*\n\s*(?:[A-Za-z_][A-Za-z0-9_]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*\s*=\s*)?"
+        r"linear_to_lora_layers\(",
     )
     matches = pattern.findall(src)
     assert len(matches) >= 2, (

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -4,6 +4,7 @@
 
 """MLX LoRA coverage for routed SwitchLinear expert projections."""
 
+import json
 import sys
 import types
 
@@ -280,3 +281,132 @@ def test_independent_vlm_switch_uses_matching_wrapper(monkeypatch, quantized):
     wrapped = model.language_model.model.layers[0].proj
     assert isinstance(wrapped, wrapper_type)
     assert bool(mx.allclose(wrapped(x, indices), before))
+
+
+@pytest.mark.parametrize(
+    "backend,quantized,corrupt",
+    [
+        ("mlx_lm", False, None),
+        ("mlx_lm", True, None),
+        ("mlx_vlm", False, None),
+        ("mlx_vlm", True, None),
+        ("mlx_vlm", False, "fp32"),
+        ("mlx_lm", False, "bf16"),
+        ("mlx_lm", False, "missing_b"),
+        ("mlx_lm", False, "legacy_flattened"),
+        ("mlx_lm", False, "pathless"),
+    ],
+)
+def test_switch_adapter_public_lifecycle(
+    monkeypatch, tmp_path, backend, quantized, corrupt,
+):
+    import mlx.core as mx
+    import mlx_lm.utils as mlx_lm_utils
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchLinear
+    from mlx_lm.tuner.lora import LoRASwitchLinear
+    import unsloth_zoo.mlx.loader as loader
+    from unsloth_zoo.mlx.utils import save_lora_adapters, save_merged_model
+
+    switch, quantized_switch, wrapper = (
+        _install_vlm_types(monkeypatch)
+        if backend == "mlx_vlm"
+        else (SwitchLinear, QuantizedSwitchLinear, LoRASwitchLinear)
+    )
+    projection_type = quantized_switch if quantized else switch
+
+    def make_model():
+        mx.random.seed(17)
+        projection = (
+            projection_type()
+            if backend == "mlx_vlm"
+            else projection_type(64, 16, 2, bias=False)
+        )
+        model = _direct_layer_model([_Block(projection)])
+        return model
+
+    trained, base = make_model(), make_model()
+    loader.FastMLXModel.get_peft_model(
+        trained, r=2, lora_alpha=2, target_modules=["proj"],
+        use_gradient_checkpointing=False,
+    )
+    trained.layers[0].proj.lora_b = mx.ones_like(
+        trained.layers[0].proj.lora_b,
+    ) * 0.125
+    trained._hf_repo = "test/switch-base"
+    x = mx.random.normal((1, 2, 1, 1, 64))
+    indices = mx.array([[[0], [1]]])
+    expected = trained.layers[0].proj(x, indices)
+    adapter = tmp_path / f"{backend}-{'q' if quantized else 'dense'}-{corrupt}"
+    save_lora_adapters(trained, adapter)
+    config = json.loads((adapter / "adapter_config.json").read_text())
+    path = "backbone.blocks.0.proj"
+    assert config["unsloth_mlx_lora_module_paths"] == [path]
+    if quantized:
+        assert config["base_resolved_quantization_map"] == {
+            path: {"bits": 4, "group_size": 64, "mode": "affine"},
+        }
+    weights_path = adapter / "adapters.safetensors"
+    weights = mx.load(str(weights_path))
+    assert {value.ndim for value in weights.values()} == {3}
+    if corrupt == "pathless":
+        config.pop("unsloth_mlx_lora_module_paths")
+        (adapter / "adapter_config.json").write_text(json.dumps(config))
+    elif corrupt:
+        if corrupt == "missing_b":
+            weights.pop(f"{path}.lora_b")
+        elif corrupt == "legacy_flattened":
+            lora_a = weights[f"{path}.lora_a"]
+            weights[f"{path}.lora_a"] = lora_a.reshape((-1, lora_a.shape[-1]))
+            config.pop("unsloth_mlx_lora_module_paths")
+            (adapter / "adapter_config.json").write_text(json.dumps(config))
+        else:
+            weights[f"{path}.lora_b"] = weights[f"{path}.lora_b"][..., :1]
+        if corrupt == "bf16":
+            weights = {key: value.astype(mx.bfloat16) for key, value in weights.items()}
+        mx.save_safetensors(str(weights_path), weights)
+
+    original = loader.FastMLXModel.from_pretrained
+    tokenizer = types.SimpleNamespace()
+    monkeypatch.setattr(mlx_lm_utils, "_download", lambda *args, **kwargs: adapter)
+
+    def load_base(*args, **kwargs):
+        if quantized:
+            assert kwargs["mlx_quantization_config"]["quantize_modules"] == [path]
+        return base, tokenizer
+
+    monkeypatch.setattr(
+        loader.FastMLXModel, "from_pretrained", staticmethod(load_base),
+    )
+    if corrupt not in (None, "pathless"):
+        with pytest.raises(RuntimeError, match="partial adapter"):
+            original(str(adapter), load_in_4bit=False)
+        return
+
+    loaded, tokenizer = original(str(adapter), load_in_4bit=False)
+    assert isinstance(loaded.layers[0].proj, wrapper)
+    assert bool(mx.allclose(loaded.layers[0].proj(x, indices), expected))
+    if not quantized:
+        monkeypatch.setattr(mlx_lm_utils, "save_model", lambda *args, **kwargs: None)
+        monkeypatch.setattr(mlx_lm_utils, "create_model_card", lambda *args, **kwargs: None)
+        tokenizer.save_pretrained = lambda *args, **kwargs: None
+        save_merged_model(loaded, tokenizer, tmp_path / f"merged-{backend}")
+        assert not hasattr(loaded.layers[0].proj, "lora_a")
+        assert bool(mx.allclose(loaded.layers[0].proj(x, indices), expected, atol=1e-5))
+
+
+def test_legacy_switch_rank_layout(tmp_path):
+    import mlx.core as mx
+    import unsloth_zoo.mlx.loader as loader
+    import unsloth_zoo.mlx.utils as mlx_utils
+
+    module = types.SimpleNamespace(
+        lora_a=mx.zeros((4, 64)), lora_b=mx.zeros((2, 16, 2)),
+    )
+    assert mlx_utils._infer_mlx_lora_rank(module) == 2
+
+    weights = tmp_path / "legacy.safetensors"
+    mx.save_safetensors(str(weights), {
+        "proj.lora_a": module.lora_a.astype(mx.bfloat16),
+        "proj.lora_b": module.lora_b.astype(mx.bfloat16),
+    })
+    assert loader._infer_rank_from_saved_adapter(str(weights), "proj") == 2

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -1,0 +1,41 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team.
+# Licensed under the GNU Affero General Public License, version 3 or later.
+
+"""MLX LoRA coverage for routed SwitchLinear expert projections."""
+
+import pytest
+
+
+pytest.importorskip("mlx")
+
+
+class _Model:
+    def __init__(self, modules):
+        self._modules = modules
+        self.layers = [self]
+
+    def named_modules(self):
+        yield from self._modules
+
+
+def test_mlx_lm_switch_targets_are_discovered():
+    import mlx.nn as nn
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchLinear
+    from unsloth_zoo.mlx.loader import (
+        _collect_all_linear_target_names,
+        _resolve_lora_keys,
+    )
+
+    modules = [
+        ("mlp.gate_proj", SwitchLinear(8, 16, 2, bias=False)),
+        ("mlp.down_proj", QuantizedSwitchLinear(64, 16, 2, bias=False)),
+        ("mlp.quant_proj", nn.QuantizedLinear(64, 16, bias=False)),
+    ]
+    model = _Model(modules)
+    assert _collect_all_linear_target_names(model) == [
+        "down_proj", "gate_proj", "quant_proj",
+    ]
+    assert _resolve_lora_keys(model, ["gate_proj", "down_proj", "quant_proj"]) == {
+        name for name, _ in modules
+    }

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -152,7 +152,11 @@ def _direct_layer_model(layers):
 
 
 @pytest.mark.parametrize("quantized", [False, True])
-def test_type_driven_peft_trains_routed_expert_without_unfreezing_base(quantized):
+@pytest.mark.parametrize("init_lora_weights", [True, "gaussian", False])
+def test_type_driven_peft_trains_routed_expert_without_unfreezing_base(
+    quantized, init_lora_weights,
+):
+    import math
     import mlx.core as mx
     import mlx.nn as nn
     import mlx.optimizers as optim
@@ -175,14 +179,22 @@ def test_type_driven_peft_trains_routed_expert_without_unfreezing_base(quantized
 
     FastMLXModel.get_peft_model(
         model, r=4, lora_alpha=4, target_modules=["proj"],
+        init_lora_weights=init_lora_weights,
         use_gradient_checkpointing=False,
     )
     dense = model.model.layers[0].proj
     switch = model.model.layers[1].proj
     assert isinstance(dense, LoRALinear)
     assert isinstance(switch, LoRASwitchLinear)
-    assert bool(mx.allclose(dense(dense_x), dense_before))
-    assert bool(mx.allclose(switch(switch_x, indices), switch_before))
+    if init_lora_weights is not False:
+        assert bool(mx.allclose(dense(dense_x), dense_before))
+        assert bool(mx.allclose(switch(switch_x, indices), switch_before))
+    if init_lora_weights == "gaussian":
+        assert 0.15 < float(mx.std(switch.lora_a)) < 0.35
+    elif init_lora_weights is False:
+        assert float(mx.max(mx.abs(switch.lora_a))) <= 1.0 / math.sqrt(64)
+        assert float(mx.max(mx.abs(switch.lora_b))) <= 1.0 / math.sqrt(4)
+        assert bool(mx.any(switch.lora_b != 0))
     trainable = dict(tree_flatten(model.trainable_parameters()))
     assert trainable and all(name.endswith(("lora_a", "lora_b")) for name in trainable)
 
@@ -433,14 +445,26 @@ def test_switch_adapter_public_lifecycle(
 
 
 def test_legacy_switch_rank_layout(tmp_path):
+    import math
     import mlx.core as mx
     import unsloth_zoo.mlx.loader as loader
     import unsloth_zoo.mlx.utils as mlx_utils
 
     module = types.SimpleNamespace(
         lora_a=mx.zeros((4, 64)), lora_b=mx.zeros((2, 16, 2)),
+        num_experts=2,
     )
     assert mlx_utils._infer_mlx_lora_rank(module) == 2
+
+    model = _Model([("proj", module)])
+    mx.random.seed(31)
+    loader._apply_mlx_lora_initialization(model, "gaussian")
+    assert 0.35 < float(mx.std(module.lora_a)) < 0.65
+    mx.random.seed(31)
+    loader._apply_mlx_lora_initialization(model, False)
+    assert float(mx.max(mx.abs(module.lora_a))) <= 1.0 / math.sqrt(64)
+    assert float(mx.max(mx.abs(module.lora_b))) <= 1.0 / math.sqrt(2)
+    assert bool(mx.any(module.lora_b != 0))
 
     weights = tmp_path / "legacy.safetensors"
     mx.save_safetensors(str(weights), {

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -4,6 +4,9 @@
 
 """MLX LoRA coverage for routed SwitchLinear expert projections."""
 
+import sys
+import types
+
 import pytest
 
 
@@ -39,3 +42,241 @@ def test_mlx_lm_switch_targets_are_discovered():
     assert _resolve_lora_keys(model, ["gate_proj", "down_proj", "quant_proj"]) == {
         name for name, _ in modules
     }
+
+
+def _install_vlm_types(monkeypatch):
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+    from mlx_lm.tuner.lora import LoRASwitchLinear
+
+    class VLMSwitchLinear(nn.Module):
+        def __init__(self, input_dims=64, output_dims=16, num_experts=2):
+            super().__init__()
+            self.weight = mx.random.normal((num_experts, output_dims, input_dims))
+
+        input_dims = property(lambda self: self.weight.shape[2])
+        output_dims = property(lambda self: self.weight.shape[1])
+        num_experts = property(lambda self: self.weight.shape[0])
+
+        def __call__(self, x, indices, sorted_indices=False):
+            return mx.gather_mm(
+                x, self.weight.swapaxes(-1, -2), rhs_indices=indices,
+                sorted_indices=sorted_indices,
+            )
+
+    class VLMQuantizedSwitchLinear(nn.Module):
+        def __init__(self, input_dims=64, output_dims=16, num_experts=2):
+            super().__init__()
+            source = QuantizedSwitchLinear(
+                input_dims, output_dims, num_experts, bias=False,
+            )
+            self.weight = source.weight
+            self.scales = source.scales
+            self.biases = source.biases
+            self.group_size = source.group_size
+            self.bits = source.bits
+            self.mode = source.mode
+            self.freeze()
+
+        input_dims = property(lambda self: self.scales.shape[2] * self.group_size)
+        output_dims = property(lambda self: self.weight.shape[1])
+        num_experts = property(lambda self: self.weight.shape[0])
+
+        def __call__(self, x, indices, sorted_indices=False):
+            return mx.gather_qmm(
+                x, self.weight, self.scales, self.biases,
+                rhs_indices=indices, transpose=True,
+                group_size=self.group_size, bits=self.bits, mode=self.mode,
+                sorted_indices=sorted_indices,
+            )
+
+    class VLMLoRASwitchLinear(LoRASwitchLinear):
+        @staticmethod
+        def from_base(linear, r=8, dropout=0.0, scale=20.0):
+            wrapped = VLMLoRASwitchLinear(
+                linear.input_dims, linear.output_dims, linear.num_experts,
+                r=r, dropout=dropout, scale=scale,
+            )
+            wrapped.linear = linear
+            return wrapped
+
+    switch_module = types.ModuleType("mlx_vlm.models.switch_layers")
+    switch_module.SwitchLinear = VLMSwitchLinear
+    switch_module.QuantizedSwitchLinear = VLMQuantizedSwitchLinear
+    lora_module = types.ModuleType("mlx_vlm.trainer.lora_layers")
+    lora_module.LoRASwitchLinear = VLMLoRASwitchLinear
+    monkeypatch.setitem(sys.modules, switch_module.__name__, switch_module)
+    monkeypatch.setitem(sys.modules, lora_module.__name__, lora_module)
+    return VLMSwitchLinear, VLMQuantizedSwitchLinear, VLMLoRASwitchLinear
+
+
+class _Block:
+    def __new__(cls, projection):
+        import mlx.nn as nn
+
+        block = nn.Module()
+        block.proj = projection
+        return block
+
+
+class _TinyModel:
+    def __new__(cls, projections):
+        import mlx.nn as nn
+
+        model = nn.Module()
+        model.model = nn.Module()
+        model.model.layers = [_Block(projection) for projection in projections]
+        model._unsloth_full_finetuning = False
+        model._is_vlm_model = False
+        return model
+
+
+def _direct_layer_model(layers):
+    import mlx.nn as nn
+
+    class DirectLayerModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.backbone = nn.Module()
+            self.backbone.blocks = layers
+            self._unsloth_full_finetuning = False
+            self._is_vlm_model = False
+
+        @property
+        def layers(self):
+            return self.backbone.blocks
+
+    return DirectLayerModel()
+
+
+@pytest.mark.parametrize("quantized", [False, True])
+def test_type_driven_peft_trains_routed_expert_without_unfreezing_base(quantized):
+    import mlx.core as mx
+    import mlx.nn as nn
+    import mlx.optimizers as optim
+    from mlx.utils import tree_flatten
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchLinear
+    from mlx_lm.tuner.lora import LoRALinear, LoRASwitchLinear
+    from unsloth_zoo.mlx.loader import FastMLXModel
+
+    switch_type = QuantizedSwitchLinear if quantized else SwitchLinear
+    model = _TinyModel([
+        nn.Linear(64, 16, bias=False),
+        switch_type(64, 16, 2, bias=False),
+    ])
+    dense_x = mx.random.normal((3, 64))
+    switch_x = mx.random.normal((1, 3, 1, 1, 64))
+    indices = mx.array([[[0], [0], [0]]])
+    dense_before = model.model.layers[0].proj(dense_x)
+    switch_before = model.model.layers[1].proj(switch_x, indices)
+    mx.eval(dense_before, switch_before)
+
+    FastMLXModel.get_peft_model(
+        model, r=4, lora_alpha=4, target_modules=["proj"],
+        use_gradient_checkpointing=False,
+    )
+    dense = model.model.layers[0].proj
+    switch = model.model.layers[1].proj
+    assert isinstance(dense, LoRALinear)
+    assert isinstance(switch, LoRASwitchLinear)
+    assert bool(mx.allclose(dense(dense_x), dense_before))
+    assert bool(mx.allclose(switch(switch_x, indices), switch_before))
+    trainable = dict(tree_flatten(model.trainable_parameters()))
+    assert trainable and all(name.endswith(("lora_a", "lora_b")) for name in trainable)
+
+    base_before = mx.array(switch.linear.weight)
+    adapter_before = mx.array(switch.lora_b)
+
+    def loss_fn(active_model, inputs, expert_indices):
+        return mx.sum(active_model.model.layers[1].proj(inputs, expert_indices))
+
+    _, grads = nn.value_and_grad(model, loss_fn)(model, switch_x, indices)
+    b_grad = next(
+        value for name, value in tree_flatten(grads)
+        if ".layers.1." in name and name.endswith("lora_b")
+    )
+    mx.eval(b_grad)
+    assert float(mx.sum(mx.abs(b_grad[0]))) > 0.0
+    assert float(mx.sum(mx.abs(b_grad[1]))) == 0.0
+
+    optimizer = optim.SGD(learning_rate=0.1)
+    optimizer.update(model, grads)
+    mx.eval(model.parameters(), optimizer.state)
+    assert not bool(mx.array_equal(switch.lora_b, adapter_before))
+    assert bool(mx.array_equal(switch.linear.weight, base_before))
+
+
+def test_custom_to_lora_dispatch_preserves_fused_outputs():
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+    from mlx_lm.models.afm7 import FusedLinear, FusedLoRALinear
+    from unsloth_zoo.mlx.loader import FastMLXModel
+
+    model = _TinyModel([FusedLinear(64, [8, 8])])
+    x = mx.random.normal((2, 64))
+    before = model.model.layers[0].proj(x)
+    FastMLXModel.get_peft_model(
+        model, r=2, lora_alpha=2, target_modules=["proj"],
+        use_gradient_checkpointing=False,
+    )
+    wrapped = model.model.layers[0].proj
+    assert isinstance(wrapped, FusedLoRALinear)
+    assert all(
+        bool(mx.allclose(left, right))
+        for left, right in zip(before, wrapped(x))
+    )
+    trainable = dict(tree_flatten(model.trainable_parameters()))
+    assert any("lora_a." in name for name in trainable)
+    assert any("lora_b." in name for name in trainable)
+
+
+def test_direct_layers_respect_finetune_last_n_layers():
+    from mlx_lm.models.switch_layers import SwitchLinear
+    from mlx_lm.tuner.lora import LoRASwitchLinear
+    from unsloth_zoo.mlx.loader import FastMLXModel
+
+    model = _direct_layer_model([
+        _Block(SwitchLinear(8, 16, 2, bias=False)) for _ in range(3)
+    ])
+    FastMLXModel.get_peft_model(
+        model, r=2, lora_alpha=2, target_modules=["proj"],
+        finetune_last_n_layers=1, use_gradient_checkpointing=False,
+    )
+    assert all(
+        not isinstance(layer.proj, LoRASwitchLinear)
+        for layer in model.layers[:2]
+    )
+    assert isinstance(model.layers[2].proj, LoRASwitchLinear)
+
+
+@pytest.mark.parametrize("quantized", [False, True])
+def test_independent_vlm_switch_uses_matching_wrapper(monkeypatch, quantized):
+    import mlx.core as mx
+    import mlx.nn as nn
+    from unsloth_zoo.mlx.loader import (
+        FastMLXModel,
+        _collect_all_linear_target_names,
+        _resolve_lora_keys,
+    )
+
+    switch_type, quantized_type, wrapper_type = _install_vlm_types(monkeypatch)
+    base_type = quantized_type if quantized else switch_type
+    language_model = _TinyModel([base_type()])
+    assert _collect_all_linear_target_names(language_model) == ["proj"]
+    assert _resolve_lora_keys(language_model, ["proj"]) == {"proj"}
+
+    model = nn.Module()
+    model.language_model = language_model
+    model._unsloth_full_finetuning = False
+    model._is_vlm_model = True
+    x = mx.random.normal((1, 2, 1, 1, 64))
+    indices = mx.array([[[0], [1]]])
+    before = language_model.model.layers[0].proj(x, indices)
+    FastMLXModel.get_peft_model(
+        model, r=2, lora_alpha=2, target_modules=["proj"],
+        use_gradient_checkpointing=False,
+    )
+    wrapped = model.language_model.model.layers[0].proj
+    assert isinstance(wrapped, wrapper_type)
+    assert bool(mx.allclose(wrapped(x, indices), before))

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -302,6 +302,7 @@ def test_direct_layers_respect_finetune_last_n_layers():
 
 def test_mixed_dora_switch_reload_preserves_routed_lora():
     import mlx.nn as nn
+    from mlx.utils import tree_flatten
     from mlx_lm.models.switch_layers import SwitchLinear
     from mlx_lm.tuner.dora import DoRALinear
     from mlx_lm.tuner.lora import LoRASwitchLinear
@@ -310,6 +311,7 @@ def test_mixed_dora_switch_reload_preserves_routed_lora():
     model = nn.Module()
     model.dense = nn.Linear(64, 16, bias=False)
     model.experts = SwitchLinear(64, 16, 2, bias=False)
+    model.freeze()
     attached = _apply_lora_at_paths(
         model,
         ["dense", "experts"],
@@ -322,6 +324,10 @@ def test_mixed_dora_switch_reload_preserves_routed_lora():
     assert attached == 2
     assert isinstance(model.dense, DoRALinear)
     assert isinstance(model.experts, LoRASwitchLinear)
+    assert set(dict(tree_flatten(model.trainable_parameters()))) == {
+        "dense.lora_a", "dense.lora_b", "dense.m",
+        "experts.lora_a", "experts.lora_b",
+    }
 
 
 @pytest.mark.parametrize("quantized", [False, True])
@@ -375,10 +381,15 @@ def test_switch_adapter_public_lifecycle(
 ):
     import mlx.core as mx
     import mlx_lm.utils as mlx_lm_utils
+    from mlx.utils import tree_flatten
     from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchLinear
     from mlx_lm.tuner.lora import LoRASwitchLinear
     import unsloth_zoo.mlx.loader as loader
-    from unsloth_zoo.mlx.utils import save_lora_adapters, save_merged_model
+    from unsloth_zoo.mlx.utils import (
+        save_lora_adapters,
+        save_merged_model,
+        save_trainable_adapters,
+    )
 
     switch, quantized_switch, wrapper = (
         _install_vlm_types(monkeypatch)
@@ -386,6 +397,7 @@ def test_switch_adapter_public_lifecycle(
         else (SwitchLinear, QuantizedSwitchLinear, LoRASwitchLinear)
     )
     projection_type = quantized_switch if quantized else switch
+    external_case = backend == "mlx_lm" and not quantized and corrupt is None
 
     def make_model():
         mx.random.seed(17)
@@ -395,6 +407,8 @@ def test_switch_adapter_public_lifecycle(
             else projection_type(64, 16, 2, bias=False)
         )
         model = _direct_layer_model([_Block(projection)])
+        if external_case:
+            model.external = {"scale": mx.zeros((1,)), "m": mx.zeros((1,))}
         return model
 
     trained, base = make_model(), make_model()
@@ -405,12 +419,17 @@ def test_switch_adapter_public_lifecycle(
     trained.layers[0].proj.lora_b = mx.ones_like(
         trained.layers[0].proj.lora_b,
     ) * 0.125
+    if external_case:
+        trained.unfreeze(keys=["external.scale", "external.m"], recurse=False)
     trained._hf_repo = "test/switch-base"
     x = mx.random.normal((1, 2, 1, 1, 64))
     indices = mx.array([[[0], [1]]])
     expected = trained.layers[0].proj(x, indices)
     adapter = tmp_path / f"{backend}-{'q' if quantized else 'dense'}-{corrupt}"
-    save_lora_adapters(trained, adapter)
+    if external_case:
+        save_trainable_adapters(trained, adapter)
+    else:
+        save_lora_adapters(trained, adapter)
     config = json.loads((adapter / "adapter_config.json").read_text())
     path = "backbone.blocks.0.proj"
     assert config["unsloth_mlx_lora_module_paths"] == [path]
@@ -421,7 +440,9 @@ def test_switch_adapter_public_lifecycle(
         assert config["base_resolved_quantization_map_supports_switch"] is True
     weights_path = adapter / "adapters.safetensors"
     weights = mx.load(str(weights_path))
-    assert {value.ndim for value in weights.values()} == {3}
+    assert {value.ndim for value in weights.values()} == (
+        {1, 3} if external_case else {3}
+    )
     if corrupt == "pathless":
         config.pop("unsloth_mlx_lora_module_paths")
         (adapter / "adapter_config.json").write_text(json.dumps(config))
@@ -459,6 +480,13 @@ def test_switch_adapter_public_lifecycle(
     loaded, tokenizer = original(str(adapter), load_in_4bit=False)
     assert isinstance(loaded.layers[0].proj, wrapper)
     assert bool(mx.allclose(loaded.layers[0].proj(x, indices), expected))
+    if corrupt != "pathless":
+        expected_trainable = {f"{path}.lora_a", f"{path}.lora_b"}
+        if external_case:
+            expected_trainable.update({"external.scale", "external.m"})
+        assert set(dict(tree_flatten(loaded.trainable_parameters()))) == (
+            expected_trainable
+        )
     if not quantized:
         monkeypatch.setattr(mlx_lm_utils, "save_model", lambda *args, **kwargs: None)
         monkeypatch.setattr(mlx_lm_utils, "create_model_card", lambda *args, **kwargs: None)

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -210,7 +210,6 @@ def test_type_driven_peft_trains_routed_expert_without_unfreezing_base(quantized
 
 def test_custom_to_lora_dispatch_preserves_fused_outputs():
     import mlx.core as mx
-    from mlx.utils import tree_flatten
     from mlx_lm.models.afm7 import FusedLinear, FusedLoRALinear
     from unsloth_zoo.mlx.loader import FastMLXModel
 
@@ -227,9 +226,47 @@ def test_custom_to_lora_dispatch_preserves_fused_outputs():
         bool(mx.allclose(left, right))
         for left, right in zip(before, wrapped(x))
     )
-    trainable = dict(tree_flatten(model.trainable_parameters()))
-    assert any("lora_a." in name for name in trainable)
-    assert any("lora_b." in name for name in trainable)
+
+
+def test_legacy_quant_map_may_omit_switch_paths():
+    import mlx.nn as nn
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+    from unsloth_zoo.mlx.loader import (
+        _effective_mlx_quantization_map,
+        _validate_mlx_adapter_base,
+    )
+
+    model = nn.Module()
+    model.dense = nn.QuantizedLinear(64, 16)
+    model.experts = QuantizedSwitchLinear(64, 16, 2, bias=False)
+    live_map = _effective_mlx_quantization_map(model)
+    legacy_config = {
+        "base_resolved_quantization_map": {"dense": live_map["dense"]},
+    }
+
+    _validate_mlx_adapter_base(model, legacy_config)
+
+    marked_config = {
+        **legacy_config,
+        "base_resolved_quantization_map_supports_switch": True,
+    }
+    with pytest.raises(ValueError, match="unexpected quantized modules"):
+        _validate_mlx_adapter_base(model, marked_config)
+
+    model.extra_dense = nn.QuantizedLinear(64, 16)
+    with pytest.raises(ValueError, match="unexpected quantized modules"):
+        _validate_mlx_adapter_base(model, legacy_config)
+
+    switch_aware = nn.Module()
+    switch_aware.experts = QuantizedSwitchLinear(64, 16, 2, bias=False)
+    switch_aware.extra_experts = QuantizedSwitchLinear(64, 16, 2, bias=False)
+    switch_map = _effective_mlx_quantization_map(switch_aware)
+    with pytest.raises(ValueError, match="unexpected quantized modules"):
+        _validate_mlx_adapter_base(switch_aware, {
+            "base_resolved_quantization_map": {
+                "experts": switch_map["experts"],
+            },
+        })
 
 
 def test_direct_layers_respect_finetune_last_n_layers():
@@ -345,6 +382,7 @@ def test_switch_adapter_public_lifecycle(
         assert config["base_resolved_quantization_map"] == {
             path: {"bits": 4, "group_size": 64, "mode": "affine"},
         }
+        assert config["base_resolved_quantization_map_supports_switch"] is True
     weights_path = adapter / "adapters.safetensors"
     weights = mx.load(str(weights_path))
     assert {value.ndim for value in weights.values()} == {3}

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -300,6 +300,30 @@ def test_direct_layers_respect_finetune_last_n_layers():
     assert isinstance(model.layers[2].proj, LoRASwitchLinear)
 
 
+def test_mixed_dora_switch_reload_preserves_routed_lora():
+    import mlx.nn as nn
+    from mlx_lm.models.switch_layers import SwitchLinear
+    from mlx_lm.tuner.dora import DoRALinear
+    from mlx_lm.tuner.lora import LoRASwitchLinear
+    from unsloth_zoo.mlx.loader import _apply_lora_at_paths
+
+    model = nn.Module()
+    model.dense = nn.Linear(64, 16, bias=False)
+    model.experts = SwitchLinear(64, 16, 2, bias=False)
+    attached = _apply_lora_at_paths(
+        model,
+        ["dense", "experts"],
+        {
+            "fine_tune_type": "dora",
+            "lora_parameters": {"rank": 2, "scale": 1.0, "dropout": 0.0},
+        },
+    )
+
+    assert attached == 2
+    assert isinstance(model.dense, DoRALinear)
+    assert isinstance(model.experts, LoRASwitchLinear)
+
+
 @pytest.mark.parametrize("quantized", [False, True])
 def test_independent_vlm_switch_uses_matching_wrapper(monkeypatch, quantized):
     import mlx.core as mx

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -17,13 +17,33 @@
 """MLX LoRA coverage for routed SwitchLinear expert projections."""
 
 import json
+import importlib
 import sys
 import types
 
 import pytest
 
 
-pytest.importorskip("mlx")
+def _real_mlx_runtime():
+    """True only when mlx and the routed switch layers are the genuine packages.
+
+    importorskip("mlx") is not enough: sibling files install the mlx_simulation
+    torch stub unconditionally, so `import mlx` still succeeds afterwards. Reject
+    both the pure stub, where SwitchLinear is a placeholder, and the hybrid where
+    switch layers stay real but mlx.core was swapped underneath them.
+    """
+    try:
+        switch_layers = importlib.import_module("mlx_lm.models.switch_layers")
+    except Exception:  # mlx / mlx-lm absent entirely
+        return False
+    if not isinstance(getattr(switch_layers, "SwitchLinear", None), type):
+        return False
+    origin = getattr(sys.modules.get("mlx.core"), "__file__", "") or ""
+    return "mlx_simulation" not in origin
+
+
+if not _real_mlx_runtime():
+    pytest.skip("needs the real mlx runtime", allow_module_level=True)
 
 
 class _Model:

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -27,10 +27,9 @@ import pytest
 def _real_mlx_runtime():
     """True only when mlx and the routed switch layers are the genuine packages.
 
-    importorskip("mlx") is not enough: sibling files install the mlx_simulation
-    torch stub unconditionally, so `import mlx` still succeeds afterwards. Reject
-    both the pure stub, where SwitchLinear is a placeholder, and the hybrid where
-    switch layers stay real but mlx.core was swapped underneath them.
+    Sibling files install the mlx_simulation stub unconditionally, so `import
+    mlx` still succeeds: reject the pure stub (placeholder SwitchLinear) and the
+    hybrid where mlx.core was swapped under real switch layers.
     """
     try:
         switch_layers = importlib.import_module("mlx_lm.models.switch_layers")

--- a/tests/test_mlx_switch_lora.py
+++ b/tests/test_mlx_switch_lora.py
@@ -1,6 +1,18 @@
 # Unsloth Zoo - Utilities for Unsloth
-# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team.
-# Licensed under the GNU Affero General Public License, version 3 or later.
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """MLX LoRA coverage for routed SwitchLinear expert projections."""
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -233,15 +233,24 @@ def _mlx_lora_base_types():
     )
 
 
-def _mlx_quantized_module_types():
-    import mlx.nn as nn
+def _mlx_quantized_switch_module_types():
     from mlx_lm.models.switch_layers import QuantizedSwitchLinear
 
-    types = [nn.QuantizedLinear, nn.QuantizedEmbedding, QuantizedSwitchLinear]
+    types = [QuantizedSwitchLinear]
     vlm_switch_module = sys.modules.get("mlx_vlm.models.switch_layers")
     if vlm_switch_module is not None:
         types.append(vlm_switch_module.QuantizedSwitchLinear)
     return tuple(types)
+
+
+def _mlx_quantized_module_types():
+    import mlx.nn as nn
+
+    return (
+        nn.QuantizedLinear,
+        nn.QuantizedEmbedding,
+        *_mlx_quantized_switch_module_types(),
+    )
 
 
 def _mlx_lora_spec_for_module(module, specs):
@@ -276,23 +285,6 @@ def _mlx_language_layers(model):
     if hasattr(model, "layers"):
         return model.layers
     return model.model.layers
-
-
-def _unfreeze_mlx_lora_parameters(model):
-    """Unfreeze scalar, array, and list-valued LoRA parameter containers."""
-    from mlx.utils import tree_flatten
-
-    for _, module in model.named_modules():
-        if not (hasattr(module, "lora_a") and hasattr(module, "lora_b")):
-            continue
-        keys = [
-            key
-            for key, _ in tree_flatten({
-                "lora_a": module.lora_a,
-                "lora_b": module.lora_b,
-            })
-        ]
-        module.unfreeze(recurse=False, keys=keys, strict=False)
 
 
 def linear_to_lora_layers(model, num_layers, config):
@@ -2434,13 +2426,31 @@ def _validate_mlx_adapter_base(model, adapter_cfg):
     )
     if expected_map:
         live_map = _normalize_quantization_map(_effective_mlx_quantization_map(model))
-        if live_map != expected_map:
-            missing = sorted(set(expected_map) - set(live_map))
-            extra = sorted(set(live_map) - set(expected_map))
-            changed = sorted(
-                path for path in set(expected_map) & set(live_map)
-                if expected_map[path] != live_map[path]
-            )
+        expected_paths = set(expected_map)
+        live_paths = set(live_map)
+        missing = sorted(expected_paths - live_paths)
+        extra = live_paths - expected_paths
+        changed = sorted(
+            path for path in expected_paths & live_paths
+            if expected_map[path] != live_map[path]
+        )
+
+        # Older Unsloth saves could not discover quantized Switch modules.
+        # New saves mark that capability even when no Switch layer is quantized;
+        # only an unmarked, Switch-free map receives the legacy allowance.
+        switch_types = _mlx_quantized_switch_module_types()
+        legacy_switch_paths = {
+            _canonical_mlx_quantization_path(path)
+            for path, module in model.named_modules()
+            if path and isinstance(module, switch_types)
+        }
+        switch_aware_map = bool(
+            adapter_cfg.get("base_resolved_quantization_map_supports_switch")
+        ) or not expected_paths.isdisjoint(legacy_switch_paths)
+        if not switch_aware_map:
+            extra -= legacy_switch_paths
+        extra = sorted(extra)
+        if missing or extra or changed:
             details = []
             if missing:
                 details.append(f"missing quantized modules: {missing[:5]!r}")
@@ -6204,7 +6214,7 @@ class FastMLXModel:
                 _raise_no_lora_targets(target_modules)
 
             # Unfreeze all LoRA params across the tree.
-            _unfreeze_mlx_lora_parameters(model)
+            model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
         else:
             # Text-only path. _fix_missing_no_grad handles modules using
             # __new__ without __init__ (e.g. Gemma4 AudioRelativePosition...).
@@ -6240,7 +6250,7 @@ class FastMLXModel:
                     _raise_no_lora_targets(target_modules)
 
             model.freeze()
-            _unfreeze_mlx_lora_parameters(model)
+            model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
 
         _apply_mlx_lora_initialization(model, init_lora_weights)
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2820,6 +2820,29 @@ _ADAPTER_LORA_KEY_SUFFIXES = (
 )
 
 
+def _unfreeze_saved_mlx_non_adapter_parameters(model, adapter_weights_file):
+    """Restore trainability for non-adapter tensors saved in a checkpoint."""
+    from safetensors import safe_open
+    from mlx.utils import tree_flatten
+    from .utils import collect_mlx_lora_adapter_tensors
+
+    with safe_open(adapter_weights_file, framework="numpy") as adapter_file:
+        saved_keys = set(adapter_file.keys())
+    live_keys = {name for name, _ in tree_flatten(model.parameters())}
+    adapter_keys = set(collect_mlx_lora_adapter_tensors(model))
+    modules = {"": model, **dict(model.named_modules())}
+    for path in (saved_keys & live_keys) - adapter_keys:
+        parts = path.split(".")
+        for split in range(len(parts) - 1, -1, -1):
+            module_path = ".".join(parts[:split])
+            module = modules.get(module_path)
+            if module is None:
+                continue
+            key = ".".join(parts[split:])
+            module.unfreeze(keys=[key], recurse=False, strict=False)
+            break
+
+
 def _saved_mlx_lora_tensor_shapes(adapter_weights_file):
     """Return raw MLX LoRA A/B shapes grouped by module path."""
     if not adapter_weights_file or not os.path.exists(adapter_weights_file):
@@ -5572,6 +5595,9 @@ class FastMLXModel:
                                 "LoRA before reload."
                             ) from _dora_exc
                     if _saved_lora_paths:
+                        if not full_finetuning:
+                            _fix_missing_no_grad(model)
+                            model.freeze()
                         _apply_lora_at_paths(
                             model, _saved_lora_paths, adapter_cfg,
                             adapter_weights_file=adapter_weights_file,
@@ -5587,6 +5613,9 @@ class FastMLXModel:
                                 f"({_missing_before_load[:5]!r})."
                             )
                         model.load_weights(adapter_weights_file, strict=False)
+                        _unfreeze_saved_mlx_non_adapter_parameters(
+                            model, adapter_weights_file,
+                        )
                     else:
                         from mlx_lm.tuner.utils import load_adapters
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2698,9 +2698,9 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
         # Skip already-wrapped paths so we don't nest LoRALinear(LoRALinear).
         if hasattr(module, "lora_a") and hasattr(module, "lora_b"):
             continue
-        type_spec = None if use_dora else _mlx_lora_spec_for_module(
-            module, type_specs,
-        )
+        type_spec = _mlx_lora_spec_for_module(module, type_specs)
+        if use_dora and isinstance(module, linear_types):
+            type_spec = None
         lora_cls = None
         if type_spec is None and use_dora and isinstance(module, linear_types):
             # Fail loud: a plain-LoRA downgrade drops the saved DoRA `.m`

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -190,11 +190,128 @@ def _seed_mlx_random_state(random_state):
     mx.random.seed(seed)
 
 
-def _mlx_lora_base_types():
+@dataclass(frozen=True)
+class _MLXLoRATypeSpec:
+    base_types: tuple[type, ...]
+    wrapper_type: type
+
+
+def _mlx_lora_type_specs():
     import mlx.nn as nn
     from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchLinear
+    from mlx_lm.tuner.lora import LoRALinear, LoRASwitchLinear
 
-    return (nn.Linear, nn.QuantizedLinear, SwitchLinear, QuantizedSwitchLinear)
+    specs = [
+        _MLXLoRATypeSpec(
+            (nn.Linear, nn.QuantizedLinear), LoRALinear,
+        ),
+        _MLXLoRATypeSpec(
+            (SwitchLinear, QuantizedSwitchLinear),
+            LoRASwitchLinear,
+        ),
+    ]
+    vlm_switch_module = sys.modules.get("mlx_vlm.models.switch_layers")
+    if vlm_switch_module is not None:
+        vlm_lora_module = importlib.import_module("mlx_vlm.trainer.lora_layers")
+        specs.append(
+            _MLXLoRATypeSpec(
+                (
+                    vlm_switch_module.SwitchLinear,
+                    vlm_switch_module.QuantizedSwitchLinear,
+                ),
+                vlm_lora_module.LoRASwitchLinear,
+            )
+        )
+    return tuple(specs)
+
+
+def _mlx_lora_base_types():
+    return tuple(
+        base_type
+        for spec in _mlx_lora_type_specs()
+        for base_type in spec.base_types
+    )
+
+
+def _mlx_lora_spec_for_module(module, specs):
+    for spec in specs:
+        if isinstance(module, spec.base_types):
+            return spec
+    return None
+
+
+def _mlx_lora_from_base(module, config, *, specs):
+    if callable(getattr(module, "to_lora", None)):
+        return module.to_lora(
+            r=config["rank"],
+            scale=config["scale"],
+            dropout=config["dropout"],
+        )
+    spec = _mlx_lora_spec_for_module(module, specs)
+    if spec is None:
+        raise ValueError(
+            "Unsloth MLX: cannot convert unsupported module type "
+            f"{type(module).__module__}.{type(module).__name__} to LoRA."
+        )
+    return spec.wrapper_type.from_base(
+        module,
+        r=config["rank"],
+        scale=config["scale"],
+        dropout=config["dropout"],
+    )
+
+
+def _mlx_language_layers(model):
+    if hasattr(model, "layers"):
+        return model.layers
+    return model.model.layers
+
+
+def _unfreeze_mlx_lora_parameters(model):
+    """Unfreeze scalar, array, and list-valued LoRA parameter containers."""
+    from mlx.utils import tree_flatten
+
+    for _, module in model.named_modules():
+        if not (hasattr(module, "lora_a") and hasattr(module, "lora_b")):
+            continue
+        keys = [
+            key
+            for key, _ in tree_flatten({
+                "lora_a": module.lora_a,
+                "lora_b": module.lora_b,
+            })
+        ]
+        module.unfreeze(recurse=False, keys=keys, strict=False)
+
+
+def linear_to_lora_layers(model, num_layers, config):
+    """Attach namespace-compatible LoRA wrappers to selected language layers."""
+    from mlx.utils import tree_unflatten
+
+    layers = _mlx_language_layers(model)
+    type_specs = _mlx_lora_type_specs()
+    keys = set(config.get("keys") or ())
+
+    limit = max(int(num_layers), 0)
+    attached = 0
+    for layer in layers[max(len(layers) - limit, 0):]:
+        replacements = []
+        for name, module in layer.named_modules():
+            if name not in keys:
+                continue
+            replacements.append((
+                name,
+                _mlx_lora_from_base(
+                    module,
+                    config,
+                    specs=type_specs,
+                ),
+            ))
+        if replacements:
+            layer.update_modules(tree_unflatten(replacements))
+            attached += len(replacements)
+
+    return attached
 
 
 def _collect_all_linear_target_names(model):
@@ -202,7 +319,8 @@ def _collect_all_linear_target_names(model):
 
     Mirrors PEFT's ``target_modules="all-linear"``: walk the live tree and
     return each leaf's semantic name (``w1``, ``q_proj``, ``lm_head``, ...),
-    skipping numeric list indices.
+    skipping numeric list indices. Both mlx-lm and independent mlx-vlm switch
+    types participate when their defining modules are loaded.
     """
     names = set()
     try:
@@ -4649,15 +4767,7 @@ def _resolve_lora_keys(model, target_modules):
 
     linear_types = _mlx_lora_base_types()
     keys = set()
-    roots = []
-    if hasattr(model, "model") and hasattr(model.model, "layers"):
-        roots.extend(model.model.layers)
-    elif hasattr(model, "layers"):
-        roots.extend(model.layers)
-    else:
-        roots.append(model)
-
-    for root in roots:
+    for root in _mlx_language_layers(model):
         for name, module in root.named_modules():
             if not isinstance(module, linear_types):
                 continue
@@ -5949,7 +6059,7 @@ class FastMLXModel:
             )
             return model
         try:
-            from mlx_lm.tuner.utils import linear_to_lora_layers
+            importlib.import_module("mlx_lm.tuner.lora")
         except ImportError:
             raise ImportError(
                 "Unsloth: mlx-lm is required for LoRA on Apple Silicon. "
@@ -6022,9 +6132,7 @@ class FastMLXModel:
                 target_modules is None or (isinstance(target_modules, list) and len(target_modules) > 0)
             ):
                 lm = model.language_model
-                num_layers = 0
-                if hasattr(lm, "model") and hasattr(lm.model, "layers"):
-                    num_layers = len(lm.model.layers)
+                num_layers = len(_mlx_language_layers(lm))
                 if finetune_last_n_layers is not None and num_layers > 0:
                     num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
                 language_lora_keys = _resolve_lora_keys(lm, target_modules)
@@ -6037,13 +6145,11 @@ class FastMLXModel:
                     # mlx_lm/tuner/lora.py train); otherwise lazy state
                     # advances leak into lora_a sampling.
                     _seed_mlx_random_state(random_state)
-                    linear_to_lora_layers(
+                    language_lora_count = linear_to_lora_layers(
                         lm,
                         num_layers=num_layers,
                         config={**lora_config, "keys": language_lora_keys},
-                        use_dora=False,
                     )
-                    language_lora_count = len(language_lora_keys) if language_lora_keys is not None else num_layers
 
             # Optionally LoRA the vision tower.
             vision_lora_count = 0
@@ -6097,7 +6203,7 @@ class FastMLXModel:
                 _raise_no_lora_targets(target_modules)
 
             # Unfreeze all LoRA params across the tree.
-            model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
+            _unfreeze_mlx_lora_parameters(model)
         else:
             # Text-only path. _fix_missing_no_grad handles modules using
             # __new__ without __init__ (e.g. Gemma4 AudioRelativePosition...).
@@ -6110,9 +6216,7 @@ class FastMLXModel:
                     stacklevel=2,
                 )
             else:
-                num_layers = 0
-                if hasattr(model, "model") and hasattr(model.model, "layers"):
-                    num_layers = len(model.model.layers)
+                num_layers = len(_mlx_language_layers(model))
                 if finetune_last_n_layers is not None and num_layers > 0:
                     num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
                 language_lora_keys = _resolve_lora_keys(model, target_modules)
@@ -6126,15 +6230,16 @@ class FastMLXModel:
                 # mlx_lm/tuner/lora.py train); otherwise lazy state advances
                 # leak into lora_a sampling.
                 _seed_mlx_random_state(random_state)
-                linear_to_lora_layers(
+                language_lora_count = linear_to_lora_layers(
                     model,
                     num_layers=num_layers,
                     config={**lora_config, "keys": language_lora_keys},
-                    use_dora=False,
                 )
+                if language_lora_count == 0:
+                    _raise_no_lora_targets(target_modules)
 
             model.freeze()
-            model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
+            _unfreeze_mlx_lora_parameters(model)
 
         _apply_mlx_lora_initialization(model, init_lora_weights)
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -190,18 +190,23 @@ def _seed_mlx_random_state(random_state):
     mx.random.seed(seed)
 
 
+def _mlx_lora_base_types():
+    import mlx.nn as nn
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear, SwitchLinear
+
+    return (nn.Linear, nn.QuantizedLinear, SwitchLinear, QuantizedSwitchLinear)
+
+
 def _collect_all_linear_target_names(model):
-    """Leaf-suffix names of every Linear / QuantizedLinear in `model`.
+    """Leaf-suffix names of every dense or routed linear in ``model``.
 
     Mirrors PEFT's ``target_modules="all-linear"``: walk the live tree and
     return each leaf's semantic name (``w1``, ``q_proj``, ``lm_head``, ...),
-    skipping numeric list indices. mlx-lm's ``linear_to_lora_layers`` matches
-    on these, so LoRA covers fused-QKV, MoE, projector, and untied heads.
+    skipping numeric list indices.
     """
-    import mlx.nn as nn
-    linear_types = (nn.Linear, nn.QuantizedLinear)
     names = set()
     try:
+        linear_types = _mlx_lora_base_types()
         for path, mod in model.named_modules():
             if not isinstance(mod, linear_types):
                 continue
@@ -4638,12 +4643,11 @@ def _lora_walk_module(
 
 def _resolve_lora_keys(model, target_modules):
     """Resolve user-facing target module names to mlx-lm layer-local keys."""
-    import mlx.nn as nn
-
     target_modules = set(target_modules or ())
     if not target_modules:
         return None
 
+    linear_types = _mlx_lora_base_types()
     keys = set()
     roots = []
     if hasattr(model, "model") and hasattr(model.model, "layers"):
@@ -4655,7 +4659,7 @@ def _resolve_lora_keys(model, target_modules):
 
     for root in roots:
         for name, module in root.named_modules():
-            if not isinstance(module, (nn.Linear, nn.QuantizedLinear)):
+            if not isinstance(module, linear_types):
                 continue
             if _lora_name_matches_target(name, target_modules):
                 keys.add(name)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -233,6 +233,17 @@ def _mlx_lora_base_types():
     )
 
 
+def _mlx_quantized_module_types():
+    import mlx.nn as nn
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+
+    types = [nn.QuantizedLinear, nn.QuantizedEmbedding, QuantizedSwitchLinear]
+    vlm_switch_module = sys.modules.get("mlx_vlm.models.switch_layers")
+    if vlm_switch_module is not None:
+        types.append(vlm_switch_module.QuantizedSwitchLinear)
+    return tuple(types)
+
+
 def _mlx_lora_spec_for_module(module, specs):
     for spec in specs:
         if isinstance(module, spec.base_types):
@@ -2320,7 +2331,7 @@ def _infer_snapshot_commit(path):
 
 
 def _effective_mlx_quantization_map(model):
-    import mlx.nn as nn
+    quantized_types = _mlx_quantized_module_types()
     quantized = {}
     quantized.update(_quantization_config_to_path_map(
         _get_existing_mlx_quantization(getattr(model, "_config", None))
@@ -2334,7 +2345,7 @@ def _effective_mlx_quantization_map(model):
         # isinstance, not an exact class-name match: a training-time subclass of
         # the quantized layer (e.g. NEFTune's _NEFTuneEmbed) must still be
         # recognised, else embed_tokens is silently dropped from the map.
-        if not isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
+        if not isinstance(module, quantized_types):
             continue
         path = _canonical_mlx_quantization_path(path)
         entry = {}
@@ -2559,13 +2570,20 @@ def _infer_rank_from_saved_adapter(adapter_weights_file, module_path):
                 key = f"{module_path}{suffix}"
                 if key not in keys:
                     continue
-                tensor = _f.get_tensor(key)
-                shape = tuple(tensor.shape)
+                shape = tuple(_f.get_slice(key).get_shape())
                 if not shape:
                     return None
                 # MoE/switch (experts, rank, in_dims): rank is shape[-2].
                 if len(shape) >= 3:
                     return int(shape[-2])
+                if suffix == ".lora_a" and len(shape) == 2:
+                    b_key = f"{module_path}.lora_b"
+                    if b_key in keys:
+                        b_shape = tuple(_f.get_slice(b_key).get_shape())
+                        if len(b_shape) == 3:
+                            experts, _, rank = b_shape
+                            if shape[0] == experts * rank:
+                                return int(rank)
                 if suffix in _rank_first_2d_suffixes:
                     return int(shape[0])
                 return int(shape[-1])
@@ -2583,29 +2601,16 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
     last-resort rank source for legacy adapters lacking rank/scale/dropout.
     """
     import mlx.nn as nn
-    from mlx_lm.tuner.lora import LoRALinear
 
     module_paths = _normalize_mlx_lora_module_paths(module_paths)
     if not module_paths:
         return 0
 
-    # Lazy import: tolerate older mlx-lm without switch / embedding LoRA.
-    try:
-        from mlx_lm.tuner.lora import LoRASwitchLinear
-    except Exception:
-        LoRASwitchLinear = None
+    type_specs = _mlx_lora_type_specs()
     try:
         from mlx_lm.tuner.lora import LoRAEmbedding
     except Exception:
         LoRAEmbedding = None
-    try:
-        from mlx_lm.models.switch_layers import (
-            QuantizedSwitchLinear,
-            SwitchLinear,
-        )
-        switch_types = (SwitchLinear, QuantizedSwitchLinear)
-    except Exception:
-        switch_types = ()
 
     embedding_types = tuple(
         t for t in (getattr(nn, "Embedding", None), getattr(nn, "QuantizedEmbedding", None))
@@ -2683,34 +2688,22 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
         # Skip already-wrapped paths so we don't nest LoRALinear(LoRALinear).
         if hasattr(module, "lora_a") and hasattr(module, "lora_b"):
             continue
+        type_spec = None if use_dora else _mlx_lora_spec_for_module(
+            module, type_specs,
+        )
         lora_cls = None
-        if isinstance(module, linear_types):
-            if use_dora:
-                # Fail loud: a plain-LoRA downgrade drops the saved DoRA `.m`
-                # tensor on strict=False.
-                if DoRALinear_cls is None:
-                    raise ImportError(
-                        "Unsloth MLX: adapter_config.json says "
-                        "fine_tune_type='dora' but mlx_lm.tuner.dora."
-                        "DoRALinear is unavailable; refusing to silently "
-                        "downgrade to plain LoRA. Upgrade mlx-lm."
-                    )
-                lora_cls = DoRALinear_cls
-            else:
-                lora_cls = LoRALinear
-        elif switch_types and isinstance(module, switch_types):
-            # mlx-lm has no DoRA on switch layers; fail loud, don't drop saved
-            # switch LoRA tensors.
-            if LoRASwitchLinear is None:
+        if type_spec is None and use_dora and isinstance(module, linear_types):
+            # Fail loud: a plain-LoRA downgrade drops the saved DoRA `.m`
+            # tensor on strict=False.
+            if DoRALinear_cls is None:
                 raise ImportError(
-                    "Unsloth MLX: adapter_config.json contains a saved "
-                    f"switch LoRA path {name!r}, but mlx_lm.tuner.lora."
-                    "LoRASwitchLinear is unavailable; refusing to silently "
-                    "drop the saved switch LoRA tensors. Upgrade mlx-lm "
-                    "or re-save without switch LoRA."
+                    "Unsloth MLX: adapter_config.json says "
+                    "fine_tune_type='dora' but mlx_lm.tuner.dora."
+                    "DoRALinear is unavailable; refusing to silently "
+                    "downgrade to plain LoRA. Upgrade mlx-lm."
                 )
-            lora_cls = LoRASwitchLinear
-        elif embedding_types and isinstance(module, embedding_types):
+            lora_cls = DoRALinear_cls
+        elif type_spec is None and embedding_types and isinstance(module, embedding_types):
             if use_dora:
                 if DoRAEmbedding_cls is None:
                     raise ImportError(
@@ -2732,16 +2725,21 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
                         "Upgrade mlx-lm or re-save without embedding LoRA."
                     )
                 lora_cls = LoRAEmbedding
-        if lora_cls is None:
+        if type_spec is None and lora_cls is None:
             _skipped_paths.append(
                 (name, f"unhandled_type:{type(module).__name__}"),
             )
             continue
         _ensure_metadata(module_path=name)
-        wrapped = _lora_from_base_compat(
-            lora_cls, module,
-            _metadata["rank"], _metadata["scale"], _metadata["dropout"],
-        )
+        if type_spec is not None:
+            wrapped = _mlx_lora_from_base(
+                module, _metadata, specs=type_specs,
+            )
+        else:
+            wrapped = _lora_from_base_compat(
+                lora_cls, module,
+                _metadata["rank"], _metadata["scale"], _metadata["dropout"],
+            )
         # Resolve numeric path segments (e.g. `...layers.0`) via parent[int(seg)]
         # then getattr; same pattern on the leaf so list-indexed wrappers install.
         parts = name.split(".")
@@ -2812,13 +2810,69 @@ _ADAPTER_LORA_KEY_SUFFIXES = (
 )
 
 
+def _saved_mlx_lora_tensor_shapes(adapter_weights_file):
+    """Return raw MLX LoRA A/B shapes grouped by module path."""
+    if not adapter_weights_file or not os.path.exists(adapter_weights_file):
+        return {}
+
+    from safetensors import safe_open
+
+    roots = {}
+    with safe_open(adapter_weights_file, framework="numpy") as adapter_file:
+        for key in adapter_file.keys():
+            for suffix, side in ((".lora_a", "a"), (".lora_b", "b")):
+                if key.endswith(suffix):
+                    roots.setdefault(key[:-len(suffix)], {})[side] = tuple(
+                        adapter_file.get_slice(key).get_shape()
+                    )
+                    break
+    return roots
+
+
+def _validate_pathless_switch_adapter(model, tensor_shapes, adapter_cfg, weights_file):
+    """Preflight pathless Switch tensors before upstream strict=False loading."""
+    import mlx.nn as nn
+
+    specs = _mlx_lora_type_specs()
+    modules = dict(model.named_modules())
+    lora_params = adapter_cfg.get("lora_parameters") or {}
+
+    for path, saved in tensor_shapes.items():
+        module = modules.get(path)
+        spec = _mlx_lora_spec_for_module(module, specs) if module is not None else None
+        if spec is None or isinstance(module, (nn.Linear, nn.QuantizedLinear)):
+            continue
+        if set(saved) != {"a", "b"}:
+            raise RuntimeError(
+                "Unsloth MLX: saved Switch LoRA path has an incomplete A/B "
+                f"tensor pair; refusing to load a partial adapter ({path!r})."
+            )
+
+        rank = lora_params.get("rank", adapter_cfg.get("rank"))
+        if rank is None:
+            rank = _infer_rank_from_saved_adapter(weights_file, path)
+        if rank is None:
+            raise RuntimeError(
+                f"Unsloth MLX: cannot infer the saved Switch LoRA rank for {path!r}."
+            )
+        wrapped = spec.wrapper_type.from_base(
+            module, r=int(rank), scale=1.0, dropout=0.0,
+        )
+        expected = {
+            "a": tuple(wrapped.lora_a.shape),
+            "b": tuple(wrapped.lora_b.shape),
+        }
+        if saved != expected:
+            raise RuntimeError(
+                "Unsloth MLX: saved Switch LoRA tensors are shape-incompatible "
+                f"with {path!r}; refusing to load a partial adapter."
+            )
 def _warn_missing_adapter_keys(model, adapter_weights_file):
     """Diff saved adapter LoRA keys against live params and warn.
 
     Compares presence AND shape so a wrong-rank live wrapper (e.g. default
-    rank=8 over saved rank-4) counts as missing. Never blocks the following
-    load_weights() (exceptions become a skip warning). Returns the sorted
-    missing-key list so the fallback can raise; `[]` means clean or skipped.
+    rank=8 over saved rank-4) counts as missing. Returns the sorted missing-key
+    list so callers can fail before loading incompatible tensors.
     """
     if not adapter_weights_file or not os.path.exists(adapter_weights_file):
         return []
@@ -2828,7 +2882,7 @@ def _warn_missing_adapter_keys(model, adapter_weights_file):
 
         with safe_open(adapter_weights_file, framework="numpy") as _f:
             _saved_shapes = {
-                k: tuple(_f.get_tensor(k).shape)
+                k: tuple(_f.get_slice(k).get_shape())
                 for k in _f.keys()
                 if k.endswith(_ADAPTER_LORA_KEY_SUFFIXES)
             }
@@ -2862,13 +2916,9 @@ def _warn_missing_adapter_keys(model, adapter_weights_file):
             )
         return _missing
     except Exception as _diff_exc:
-        warnings.warn(
-            f"Unsloth MLX: skipped saved-vs-live adapter key diff "
-            f"({_diff_exc!r}); silently-dropped LoRA tensors will not "
-            f"be surfaced.",
-            stacklevel=3,
-        )
-        return []
+        raise RuntimeError(
+            "Unsloth MLX: failed to validate saved LoRA tensor shapes."
+        ) from _diff_exc
 
 
 def _apply_lora_metadata_to_wrapper(wrapped, scale, dropout):
@@ -5466,16 +5516,33 @@ class FastMLXModel:
                     _saved_lora_paths = _normalize_mlx_lora_module_paths(
                         adapter_cfg.get("unsloth_mlx_lora_module_paths"),
                     )
-                    # load_adapters FIRST (rebuilds the language tower);
-                    # _apply_lora_at_paths runs after and skips wrapped paths,
-                    # attaching only auxiliary (vision/projector/MoE/embedding).
-                    # The old order nested LoRALinear(LoRALinear).
-                    from mlx_lm.tuner.utils import load_adapters
+                    # Saved exact paths are authoritative when present. Build
+                    # those wrappers and validate shapes before any
+                    # strict=False weight load can mutate them.
                     # Let older mlx-lm load_adapters accept scale=/dropout=.
                     _patch_mlx_lora_from_base_compat()
                     adapter_weights_file = os.path.join(local_path, "adapters.safetensors")
-                    _load_adapters_ok = False
-                    _load_adapters_exc = None
+                    _tensor_lora_shapes = _saved_mlx_lora_tensor_shapes(
+                        adapter_weights_file,
+                    )
+                    if _saved_lora_paths:
+                        _unbacked_paths = sorted(
+                            path for path in _saved_lora_paths
+                            if set(_tensor_lora_shapes.get(path, ())) != {"a", "b"}
+                        )
+                        if _unbacked_paths:
+                            raise RuntimeError(
+                                "Unsloth MLX: saved LoRA module paths have no "
+                                "complete A/B tensor pair; refusing to load a "
+                                f"partial adapter ({_unbacked_paths[:5]!r})."
+                            )
+                    else:
+                        _validate_pathless_switch_adapter(
+                            model,
+                            _tensor_lora_shapes,
+                            adapter_cfg,
+                            adapter_weights_file,
+                        )
                     # Pre-validate DoRA: catch missing mlx_lm.tuner.dora before
                     # load_adapters rebuilds plain LoRA and drops saved DoRA
                     # `.m` via strict=False (distinct from the per-module
@@ -5491,110 +5558,44 @@ class FastMLXModel:
                                 "mlx-lm or convert the adapter to plain "
                                 "LoRA before reload."
                             ) from _dora_exc
-                    try:
-                        model = load_adapters(model, local_path)
-                        _load_adapters_ok = True
-                    except Exception as _exc:
-                        # Fall through to the manual-wrap + strict=False fallback
-                        # (for adapters lacking mlx-lm metadata, e.g. num_layers).
-                        _load_adapters_exc = _exc
-
-                    _aux_attached = 0
                     if _saved_lora_paths:
-                        # Attach auxiliary paths (vision/projector/MoE) that
-                        # linear_to_lora_layers skips; language-tower paths are
-                        # no-ops via the skip-if-wrapped guard.
-                        try:
-                            _aux_attached = _apply_lora_at_paths(
-                                model, _saved_lora_paths, adapter_cfg,
-                                adapter_weights_file=adapter_weights_file,
-                            ) or 0
-                        except (ValueError, ImportError):
-                            # Caller-actionable (missing rank / DoRA class); never
-                            # downgrade.
-                            raise
-                        except Exception as _exc:
-                            warnings.warn(
-                                f"Unsloth MLX: failed to re-attach auxiliary "
-                                f"LoRA wrappers ({_exc!r}); some adapter "
-                                f"tensors may not load.",
-                                stacklevel=2,
-                            )
-
-                    # Bind aux tensors via a follow-up load_weights and run
-                    # the shared key diff so silent drops surface here too.
-                    if _load_adapters_ok and os.path.exists(adapter_weights_file):
-                        # Always diff (even _aux_attached == 0): a declared aux
-                        # path the live tree no longer satisfies has no module
-                        # to bind into.
-                        _missing_after_success = _warn_missing_adapter_keys(
+                        _apply_lora_at_paths(
+                            model, _saved_lora_paths, adapter_cfg,
+                            adapter_weights_file=adapter_weights_file,
+                        )
+                        _missing_before_load = _warn_missing_adapter_keys(
                             model, adapter_weights_file,
                         )
-                        if _aux_attached > 0:
-                            model.load_weights(adapter_weights_file, strict=False)
-                        # Refuse a partial adapter on any shape mismatch (e.g.
-                        # stale rank=8 over rank-4), matching the fallback.
-                        if _missing_after_success:
-                            _preview = ", ".join(_missing_after_success[:5])
-                            if len(_missing_after_success) > 5:
-                                _preview += (
-                                    f", ... (+{len(_missing_after_success) - 5} more)"
-                                )
+                        if _missing_before_load:
                             raise RuntimeError(
-                                "Unsloth MLX: load_adapters succeeded but "
-                                f"{len(_missing_after_success)} saved LoRA "
-                                "tensor(s) are missing or shape-incompatible "
-                                "with the live module tree "
-                                f"({_preview}). Refusing to return a "
-                                "partially loaded adapter."
+                                "Unsloth MLX: saved LoRA tensors are missing "
+                                "or shape-incompatible with the exact module "
+                                "paths; refusing to load a partial adapter "
+                                f"({_missing_before_load[:5]!r})."
                             )
+                        model.load_weights(adapter_weights_file, strict=False)
+                    else:
+                        from mlx_lm.tuner.utils import load_adapters
 
-                    if not _load_adapters_ok:
-                        # No wrappers: strict=False would drop every saved
-                        # tensor and return a base model; re-raise instead.
-                        if _aux_attached == 0:
-                            if _load_adapters_exc is not None:
-                                raise _load_adapters_exc
-                            raise RuntimeError(
-                                "Unsloth MLX: adapter load failed and no "
-                                "live LoRA wrappers exist to bind the "
-                                "saved tensors against."
-                            )
+                        model = load_adapters(model, local_path)
                         if os.path.exists(adapter_weights_file):
-                            # Diff saved-vs-live before strict=False (covers DoRA
-                            # `.m` + lora_{a,b}).
-                            _missing_saved_keys = _warn_missing_adapter_keys(
+                            _missing_after_load = _warn_missing_adapter_keys(
                                 model, adapter_weights_file,
                             )
-                            # Refuse an aux-only partial adapter (language tower
-                            # would mis-train); chain the original error.
-                            if _missing_saved_keys:
-                                _preview = ", ".join(_missing_saved_keys[:5])
-                                if len(_missing_saved_keys) > 5:
+                            if _missing_after_load:
+                                _preview = ", ".join(_missing_after_load[:5])
+                                if len(_missing_after_load) > 5:
                                     _preview += (
-                                        f", ... (+{len(_missing_saved_keys) - 5} more)"
+                                        f", ... (+{len(_missing_after_load) - 5} more)"
                                     )
-                                _partial_err = RuntimeError(
-                                    "Unsloth MLX: adapter load failed and "
-                                    "the manual fallback would only bind "
-                                    f"part of the adapter "
-                                    f"({len(_missing_saved_keys)} saved "
-                                    f"LoRA tensor(s) have no live module: "
-                                    f"{_preview}). Refusing to return a "
+                                raise RuntimeError(
+                                    "Unsloth MLX: load_adapters succeeded but "
+                                    f"{len(_missing_after_load)} saved LoRA "
+                                    "tensor(s) are missing or shape-incompatible "
+                                    "with the live module tree "
+                                    f"({_preview}). Refusing to return a "
                                     "partially loaded adapter."
                                 )
-                                if _load_adapters_exc is not None:
-                                    raise _partial_err from _load_adapters_exc
-                                raise _partial_err
-                            model.load_weights(adapter_weights_file, strict=False)
-                        else:
-                            # No safetensors; surface the original failure.
-                            if _load_adapters_exc is not None:
-                                raise _load_adapters_exc
-                            raise RuntimeError(
-                                "Unsloth MLX: adapter load failed and "
-                                "adapters.safetensors is missing."
-                            )
                     model = _eval_mlx_model_after_adapter_reload(model)
                     loaded_model_config = getattr(model, "_config", None)
                     is_vlm_model = bool(getattr(model, "_is_vlm_model", False))

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4911,6 +4911,9 @@ def _apply_mlx_lora_initialization(model, init_lora_weights):
         b_shape = _lora_tensor_shape(module.lora_b)
         if a_shape is None or b_shape is None:
             continue
+        is_routed = hasattr(module, "num_experts")
+        a_scale_dim = a_shape[-1] if is_routed else a_shape[0]
+        b_scale_dim = b_shape[-1] if is_routed else b_shape[0]
         if init_lora_weights == "gaussian":
             if hasattr(module, "embedding"):
                 _assign_lora_tensor(module, "lora_a", mx.zeros(a_shape))
@@ -4918,23 +4921,23 @@ def _apply_mlx_lora_initialization(model, init_lora_weights):
             else:
                 _assign_lora_tensor(
                     module, "lora_a",
-                    mx.random.normal(shape=a_shape) * (1.0 / b_shape[0]),
+                    mx.random.normal(shape=a_shape) * (1.0 / b_scale_dim),
                 )
                 _assign_lora_tensor(module, "lora_b", mx.zeros(b_shape))
         elif init_lora_weights is False:
             _assign_lora_tensor(
                 module, "lora_a",
                 mx.random.uniform(
-                    low=-1.0 / math.sqrt(a_shape[0]),
-                    high=1.0 / math.sqrt(a_shape[0]),
+                    low=-1.0 / math.sqrt(a_scale_dim),
+                    high=1.0 / math.sqrt(a_scale_dim),
                     shape=a_shape,
                 ),
             )
             _assign_lora_tensor(
                 module, "lora_b",
                 mx.random.uniform(
-                    low=-1.0 / math.sqrt(b_shape[0]),
-                    high=1.0 / math.sqrt(b_shape[0]),
+                    low=-1.0 / math.sqrt(b_scale_dim),
+                    high=1.0 / math.sqrt(b_scale_dim),
                     shape=b_shape,
                 ),
             )

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -246,10 +246,15 @@ def _mlx_quantized_switch_module_types():
 def _mlx_quantized_module_types():
     import mlx.nn as nn
 
-    return (
-        nn.QuantizedLinear,
-        nn.QuantizedEmbedding,
-        *_mlx_quantized_switch_module_types(),
+    # Filter to real classes: a stand-in runtime can export the switch names as
+    # non-class placeholders, which makes isinstance() raise instead of False.
+    return tuple(
+        t for t in (
+            nn.QuantizedLinear,
+            nn.QuantizedEmbedding,
+            *_mlx_quantized_switch_module_types(),
+        )
+        if isinstance(t, type)
     )
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -246,8 +246,7 @@ def _mlx_quantized_switch_module_types():
 def _mlx_quantized_module_types():
     import mlx.nn as nn
 
-    # Filter to real classes: a stand-in runtime can export the switch names as
-    # non-class placeholders, which makes isinstance() raise instead of False.
+    # Drop non-class placeholders a stand-in runtime exports, else isinstance() raises.
     return tuple(
         t for t in (
             nn.QuantizedLinear,

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2435,9 +2435,7 @@ def _validate_mlx_adapter_base(model, adapter_cfg):
             if expected_map[path] != live_map[path]
         )
 
-        # Older Unsloth saves could not discover quantized Switch modules.
-        # New saves mark that capability even when no Switch layer is quantized;
-        # only an unmarked, Switch-free map receives the legacy allowance.
+        # Legacy allowance only for unmarked, Switch-free maps: old saves could not see quantized Switch modules.
         switch_types = _mlx_quantized_switch_module_types()
         legacy_switch_paths = {
             _canonical_mlx_quantization_path(path)
@@ -2703,8 +2701,7 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
             type_spec = None
         lora_cls = None
         if type_spec is None and use_dora and isinstance(module, linear_types):
-            # Fail loud: a plain-LoRA downgrade drops the saved DoRA `.m`
-            # tensor on strict=False.
+            # Fail loud: a plain-LoRA downgrade drops the saved DoRA `.m` tensor.
             if DoRALinear_cls is None:
                 raise ImportError(
                     "Unsloth MLX: adapter_config.json says "
@@ -5552,9 +5549,7 @@ class FastMLXModel:
                     _saved_lora_paths = _normalize_mlx_lora_module_paths(
                         adapter_cfg.get("unsloth_mlx_lora_module_paths"),
                     )
-                    # Saved exact paths are authoritative when present. Build
-                    # those wrappers and validate shapes before any
-                    # strict=False weight load can mutate them.
+                    # Saved exact paths win: build and shape-check those wrappers before strict=False can mutate them.
                     # Let older mlx-lm load_adapters accept scale=/dropout=.
                     _patch_mlx_lora_from_base_compat()
                     adapter_weights_file = os.path.join(local_path, "adapters.safetensors")

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5928,9 +5928,11 @@ def _enrich_mlx_adapter_config(model, adapter_config):
     resolved_map = _effective_mlx_quantization_map(model)
     if resolved_map:
         adapter_config["base_resolved_quantization_map"] = resolved_map
+        adapter_config["base_resolved_quantization_map_supports_switch"] = True
         adapter_config.pop("base_quantization_map", None)
     else:
         adapter_config.pop("base_resolved_quantization_map", None)
+        adapter_config.pop("base_resolved_quantization_map_supports_switch", None)
         adapter_config.pop("base_quantization_map", None)
 
     requires_runtime = False

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5660,6 +5660,18 @@ def _infer_snapshot_commit(path):
 
 
 def _effective_mlx_quantization_map(model):
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+
+    quantized_types = [
+        nn.QuantizedLinear,
+        nn.QuantizedEmbedding,
+        QuantizedSwitchLinear,
+    ]
+    vlm_switch_module = sys.modules.get("mlx_vlm.models.switch_layers")
+    if vlm_switch_module is not None:
+        quantized_types.append(vlm_switch_module.QuantizedSwitchLinear)
+    quantized_types = tuple(quantized_types)
+
     quantized = {}
     config = getattr(model, "_config", None)
     if isinstance(config, dict):
@@ -5675,7 +5687,7 @@ def _effective_mlx_quantization_map(model):
         # isinstance, not an exact class-name match: a training-time subclass of
         # the quantized layer (e.g. NEFTune's _NEFTuneEmbed) must still be
         # recognised, else embed_tokens is silently dropped from the map.
-        if not isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
+        if not isinstance(module, quantized_types):
             continue
         name = _canonical_mlx_quantization_path(name)
         entry = {}
@@ -5831,6 +5843,11 @@ def _infer_mlx_lora_rank(module):
         if lora_a_shape[:-2] != lora_b_shape[:-2]:
             return None
         return int(rank)
+
+    # mlx-lm < 0.28.3 flattened experts into lora_a's leading dimension.
+    if len(lora_a_shape) == 2 and len(lora_b_shape) == 3:
+        experts, _, rank = lora_b_shape
+        return int(rank) if lora_a_shape[0] == experts * rank else None
 
     if len(lora_a_shape) < 2 or len(lora_b_shape) < 2:
         return None

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6688,6 +6688,31 @@ def _copy_source_sidecars(src_path, path):
         copied += 1
     return copied
 
+def _fuse_mlx_module(module, dequantize):
+    """Call ``module.fuse()`` regardless of how the flag is spelled.
+
+    mlx-lm 0.28.3 names the fuse flag ``de_quantize``; 0.28.4 renamed it to
+    ``dequantize``. The supported range starts at 0.28.3, so it spans both
+    spellings: pick whichever the installed implementation accepts instead of
+    hardcoding one. A few modules expose ``fuse()`` with no flag at all (for
+    example mlx-vlm's ``ExtendedLmHead``); those have nothing to dequantize, and
+    ``save_merged_model`` still runs ``dequantize_model`` afterwards, so calling
+    them without the flag stays correct.
+    """
+    fuse = module.fuse
+    try:
+        parameters = inspect.signature(fuse).parameters
+    except (TypeError, ValueError):
+        # C extensions can hide their signature; assume the current spelling.
+        return fuse(dequantize=dequantize)
+
+    for name in ("dequantize", "de_quantize"):
+        if name in parameters:
+            return fuse(**{name: dequantize})
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
+        return fuse(dequantize=dequantize)
+    return fuse()
+
 def save_merged_model(model, tokenizer, path, dequantize=False):
     """Fuse LoRA weights and save the full merged model.
 
@@ -6713,7 +6738,7 @@ def save_merged_model(model, tokenizer, path, dequantize=False):
     # Fuse LoRA weights into base model (mlx-lm pattern)
     model.eval()
     fused_linears = [
-        (n, m.fuse(dequantize=dequantize))
+        (n, _fuse_mlx_module(m, dequantize))
         for n, m in model.named_modules()
         if hasattr(m, "fuse")
     ]

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5670,7 +5670,9 @@ def _effective_mlx_quantization_map(model):
     vlm_switch_module = sys.modules.get("mlx_vlm.models.switch_layers")
     if vlm_switch_module is not None:
         quantized_types.append(vlm_switch_module.QuantizedSwitchLinear)
-    quantized_types = tuple(quantized_types)
+    # A stand-in runtime can export these names as non-class placeholders, which
+    # makes isinstance() below raise instead of returning False.
+    quantized_types = tuple(t for t in quantized_types if isinstance(t, type))
 
     quantized = {}
     config = getattr(model, "_config", None)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5670,8 +5670,7 @@ def _effective_mlx_quantization_map(model):
     vlm_switch_module = sys.modules.get("mlx_vlm.models.switch_layers")
     if vlm_switch_module is not None:
         quantized_types.append(vlm_switch_module.QuantizedSwitchLinear)
-    # A stand-in runtime can export these names as non-class placeholders, which
-    # makes isinstance() below raise instead of returning False.
+    # Drop non-class placeholders a stand-in runtime exports, else isinstance() raises.
     quantized_types = tuple(t for t in quantized_types if isinstance(t, type))
 
     quantized = {}
@@ -6693,13 +6692,10 @@ def _copy_source_sidecars(src_path, path):
 def _fuse_mlx_module(module, dequantize):
     """Call ``module.fuse()`` regardless of how the flag is spelled.
 
-    mlx-lm 0.28.3 names the fuse flag ``de_quantize``; 0.28.4 renamed it to
-    ``dequantize``. The supported range starts at 0.28.3, so it spans both
-    spellings: pick whichever the installed implementation accepts instead of
-    hardcoding one. A few modules expose ``fuse()`` with no flag at all (for
-    example mlx-vlm's ``ExtendedLmHead``); those have nothing to dequantize, and
-    ``save_merged_model`` still runs ``dequantize_model`` afterwards, so calling
-    them without the flag stays correct.
+    mlx-lm renamed it from ``de_quantize`` (0.28.3) to ``dequantize`` (0.28.4)
+    and the supported range spans both, so pick the spelling the installed
+    implementation accepts. A flagless ``fuse()`` (mlx-vlm's ``ExtendedLmHead``)
+    has nothing to dequantize and ``save_merged_model`` dequantizes afterwards.
     """
     fuse = module.fuse
     try:


### PR DESCRIPTION
## Problem resolved

Unsloth MLX LoRA only recognized standard `Linear` and `QuantizedLinear` modules. MoE expert projections implemented with `SwitchLinear` or `QuantizedSwitchLinear` were therefore missing from `target_modules="all-linear"`, and explicitly named expert targets could resolve to nothing.

As a result, training could adapt attention and ordinary dense layers while leaving routed expert projections such as `gate_proj`, `up_proj`, and `down_proj` frozen. Newer VLM models using independent MLX-VLM Switch classes could also fail during LoRA conversion. Quantized Switch adapters additionally lacked complete quantization metadata for reliable reload.

## Affected models

This affects MLX model implementations that use Switch layers for routed experts. Representative families include:

- MLX-LM: Mixtral, DeepSeek-V2/V3, Qwen2/3 MoE, Qwen3-Next, PhiMoE, OLMoE, Jamba, GraniteMoE, Llama 4, Gemma 4 text, and GPT-OSS.
- MLX-VLM: DeepSeek-VL2/DeepSeek-OCR, Kimi-VL, Llama 4, Gemma 4, Mistral 4, Moondream3, Qwen3-VL/Omni MoE, and GLM4V-MoE.
- Current upstream MLX-VLM models with independent Switch classes, including DeepSeek-V3.2/V4, Zaya1-VL, and MiniMax-M3-VL.

## How it was resolved

- Added a shared live-type registry covering standard linears plus MLX-LM and MLX-VLM Switch classes.
- Used that registry for target discovery, explicit target resolution, LoRA attachment, and exact-path adapter reload.
- Selected wrappers from each live module's concrete type, so mixed dense/MoE and VLM language towers receive the correct wrapper.
- Added quantized Switch metadata replay and pre-load checks for incomplete or shape-incompatible adapter tensors.
- Preserved upstream handling for non-Switch legacy pathless adapters.

## Validation

- 95 related tests pass, covering dense and quantized Switch training, routed expert gradients, frozen base weights, last-N-layer selection, MLX-LM/MLX-VLM wrapper selection, save/reload parity, malformed adapter rejection, and unquantized fusion parity.
- A real one-step training A/B test used `mlx-community/DeepSeek-V2-Lite-Chat-4bit-mlx` with identical rank, last-layer selection, prompt, seed, and SGD update. `origin/main` loaded 78 quantized Switch modules but attached 0 Switch LoRA wrappers and produced 0 Switch gradients. This branch attached the 3 last-layer expert projections, exposed 6 trainable A/B tensors, produced a nonzero Switch B gradient (`23.47`), updated Switch B from `0` to `1.1736`, and left the sampled quantized base expert weight unchanged.
- Current MLX-LM and MLX-VLM source probes pass dense and quantized training, exact save/reload, quantized map replay, and dense merged export.
- `compileall` and `git diff --check` pass.
