### PR TITLE
feat(mlx): add KTO preference tuning

### DIFF
--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -1,0 +1,140 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Pure-logic regression for the MLX KTO loss primitives.
+
+Covers the unpaired KTO loss (`_kto_loss`), the batch KL baseline clamp
+(`_kto_kl_baseline`), the summed-logp extractor (`_kto_sum_logp`), and the
+batch-size guard in `_build_kto_batches`. Runs under the torch shim so Linux
+CI collection covers it without MLX/Metal (all four primitives are backend-
+agnostic MLX-array math).
+
+Reference values are the ones proven in the KTO Step 1 investigation, where
+`_kto_loss` matched a torch reimplementation of TRL's kto_loss and a pure-numpy
+hand computation to ~1e-8 across desirable/undesirable weight settings.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+# --------------------------------------------------------------------------
+# Fixed inputs + independent numpy reference (the KTO Step 1 fixtures).
+# --------------------------------------------------------------------------
+def _fixed_logps():
+    rng = np.random.default_rng(0)
+    return dict(
+        pol_ch=rng.normal(-8, 2, size=3).astype(np.float32),
+        pol_rej=rng.normal(-9, 2, size=2).astype(np.float32),
+        pol_kl=rng.normal(-8.5, 2, size=5).astype(np.float32),
+        ref_ch=rng.normal(-8, 2, size=3).astype(np.float32),
+        ref_rej=rng.normal(-9, 2, size=2).astype(np.float32),
+        ref_kl=rng.normal(-8.5, 2, size=5).astype(np.float32),
+    )
+
+
+def _numpy_kto_loss(pol_ch, pol_rej, ref_ch, ref_rej, kl, beta, wd, wu):
+    sig = lambda z: 1.0 / (1.0 + np.exp(-z))
+    ch = wd * (1 - sig(beta * ((pol_ch - ref_ch) - kl)))
+    rej = wu * (1 - sig(beta * (kl - (pol_rej - ref_rej))))
+    return float(np.concatenate([ch, rej]).mean())
+
+
+# Pinned from Step 1 (MLX == numpy == TRL-torch to ~1e-8).
+_EXPECTED = {(1.0, 1.0): 0.4772096276283264,
+             (1.33, 1.0): 0.566311240196228,
+             (1.0, 1.5): 0.5808119177818298}
+_EXPECTED_KL = 0.31288090348243713
+
+
+def test_kto_loss_matches_reference_across_weights():
+    import mlx.core as mx
+    from unsloth_zoo.mlx.trainer import _kto_loss, _kto_kl_baseline
+    f = _fixed_logps()
+    kl = float(_kto_kl_baseline(mx.array(f["pol_kl"]), mx.array(f["ref_kl"])))
+    assert kl == pytest.approx(_EXPECTED_KL, abs=1e-6)  # matches TRL 0.31288
+    for (wd, wu), expected in _EXPECTED.items():
+        loss = float(_kto_loss(
+            mx.array(f["pol_ch"]), mx.array(f["pol_rej"]),
+            mx.array(f["ref_ch"]), mx.array(f["ref_rej"]), mx.array(kl),
+            0.1, wd, wu,
+        ))
+        npy = _numpy_kto_loss(f["pol_ch"], f["pol_rej"], f["ref_ch"], f["ref_rej"], kl, 0.1, wd, wu)
+        assert loss == pytest.approx(npy, abs=1e-6), f"w=({wd},{wu}) MLX vs numpy"
+        assert loss == pytest.approx(expected, abs=1e-6), f"w=({wd},{wu}) vs pinned"
+
+
+def test_kl_baseline_clamps_negative_to_zero():
+    import mlx.core as mx
+    from unsloth_zoo.mlx.trainer import _kto_kl_baseline
+    # policy far below reference on the mismatched completions -> raw mean < 0.
+    pol_kl = mx.array([-30.0, -28.0, -35.0])
+    ref_kl = mx.array([-20.0, -22.0, -19.0])
+    assert float(_kto_kl_baseline(pol_kl, ref_kl)) == 0.0
+    # positive estimate passes through unclamped.
+    assert float(_kto_kl_baseline(ref_kl, pol_kl)) > 0.0
+
+
+@pytest.mark.parametrize("labels_present", ["desirable_only", "undesirable_only"])
+def test_kto_loss_single_label_batches_are_finite(labels_present):
+    import mlx.core as mx
+    from unsloth_zoo.mlx.trainer import _kto_loss
+    empty = mx.array(np.array([], dtype=np.float32))
+    if labels_present == "desirable_only":
+        pol_ch, ref_ch = mx.array([-8.0, -9.0]), mx.array([-8.3, -9.4])
+        pol_rej = ref_rej = empty
+    else:
+        pol_rej, ref_rej = mx.array([-8.0, -9.0]), mx.array([-8.3, -9.4])
+        pol_ch = ref_ch = empty
+    loss = float(_kto_loss(pol_ch, pol_rej, ref_ch, ref_rej, mx.array(0.5), 0.1, 1.0, 1.0))
+    assert np.isfinite(loss) and 0.0 <= loss <= 1.0
+
+
+# NOTE: _kto_sum_logp's numpy-reference check lives in the Metal-gated
+# test_mlx_kto_train_metal.py. Its .astype(mx.float32) / cross_entropy path
+# resolves a real mlx dtype under the torch shim in the pytest import order, so
+# it is exercised against real MLX instead of the shim.
+
+
+def test_build_kto_batches_requires_batch_size_two():
+    from unsloth_zoo.mlx.trainer import _build_kto_batches, MLXKTOConfig
+
+    class _DummyTokenizer:
+        pad_token_id = 0
+        eos_token_id = 0
+        def __call__(self, text, add_special_tokens=False):
+            return {"input_ids": [1, 2, 3]}
+
+    dataset = [{"prompt": "a", "completion": " b", "label": True},
+               {"prompt": "c", "completion": " d", "label": False}]
+    with pytest.raises(ValueError) as exc:
+        _build_kto_batches(dataset, _DummyTokenizer(), MLXKTOConfig(per_device_train_batch_size=1))
+    msg = str(exc.value)
+    assert "per_device_train_batch_size" in msg and ">= 2" in msg
+
+    # batch_size >= 2 builds batches with the mismatched-pair KL variant.
+    batches = _build_kto_batches(dataset, _DummyTokenizer(), MLXKTOConfig(per_device_train_batch_size=2))
+    assert len(batches) == 1
+    for key in ("comp_ids", "comp_labels", "kl_ids", "kl_labels", "label"):
+        assert key in batches[0]

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -171,3 +171,20 @@ def test_kto_string_labels_parsed_not_truthy():
         dataset, _DummyTokenizer(), MLXKTOConfig(per_device_train_batch_size=2),
     )
     assert batches[0]["label"] == [False, False], batches[0]["label"]
+
+
+def test_kto_tokenize_row_caps_completion_exceeding_max_length():
+    # When max_completion_length is unset and a completion alone exceeds
+    # max_length, the old code set keep=0 (dropping the prompt) but left the
+    # whole completion, so the returned sequence exceeded max_length. The
+    # completion must be capped too.
+    from unsloth_zoo.mlx.trainer import _kto_tokenize_row, MLXKTOConfig
+
+    class _LenTokenizer:  # one token id per whitespace-split word
+        def __call__(self, text, add_special_tokens=False):
+            return {"input_ids": list(range(len(text.split())))}
+
+    args = MLXKTOConfig(max_length=8, max_completion_length=None, max_prompt_length=0)
+    p, c = _kto_tokenize_row(_LenTokenizer(), "a b c", " ".join(["w"] * 20), args)
+    assert len(p) + len(c) <= 8, (len(p), len(c))
+    assert len(p) == 0 and len(c) == 8  # prompt dropped, completion capped

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -212,3 +212,12 @@ def test_kto_rejects_streaming_dataset():
     with pytest.raises(NotImplementedError, match="streaming"):
         _build_kto_batches(_gen(), _DummyTokenizer(),
                            MLXKTOConfig(per_device_train_batch_size=2))
+
+
+def test_kto_rejects_non_kto_loss_type():
+    # loss_type is never read by the KTO loop; a non-'kto' value would silently
+    # run standard KTO. Reject it instead of ignoring the caller's request.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer, MLXKTOConfig
+    with pytest.raises(ValueError, match="loss_type='kto'"):
+        MLXKTOTrainer(object(), object(), [],
+                      args=MLXKTOConfig(loss_type="apo_zero_unpaired"))

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -221,3 +221,11 @@ def test_kto_rejects_non_kto_loss_type():
     with pytest.raises(ValueError, match="loss_type='kto'"):
         MLXKTOTrainer(object(), object(), [],
                       args=MLXKTOConfig(loss_type="apo_zero_unpaired"))
+
+
+def test_kto_rejects_ref_model_kwarg():
+    # KTO's reference is the adapter-off forward; a passed ref_model would be
+    # swallowed by **kwargs and ignored, so reject it.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer, MLXKTOConfig
+    with pytest.raises(ValueError, match="ref_model"):
+        MLXKTOTrainer(object(), object(), [], args=MLXKTOConfig(), ref_model=object())

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -188,3 +188,27 @@ def test_kto_tokenize_row_caps_completion_exceeding_max_length():
     p, c = _kto_tokenize_row(_LenTokenizer(), "a b c", " ".join(["w"] * 20), args)
     assert len(p) + len(c) <= 8, (len(p), len(c))
     assert len(p) == 0 and len(c) == 8  # prompt dropped, completion capped
+
+
+def test_kto_rejects_streaming_dataset():
+    # KTO materializes the whole dataset to form KL batches, so streaming must
+    # be rejected loudly rather than silently exhausting the source.
+    from unsloth_zoo.mlx.trainer import _build_kto_batches, MLXKTOConfig
+
+    class _DummyTokenizer:
+        pad_token_id = 0
+        eos_token_id = 0
+        def __call__(self, text, add_special_tokens=False):
+            return {"input_ids": [1, 2, 3]}
+
+    ds = [{"prompt": "a", "completion": " b", "label": True},
+          {"prompt": "c", "completion": " d", "label": False}]
+    with pytest.raises(NotImplementedError, match="streaming"):
+        _build_kto_batches(ds, _DummyTokenizer(),
+                           MLXKTOConfig(per_device_train_batch_size=2, streaming=True))
+
+    def _gen():  # a bare iterable-without-__len__ passed directly
+        yield from ds
+    with pytest.raises(NotImplementedError, match="streaming"):
+        _build_kto_batches(_gen(), _DummyTokenizer(),
+                           MLXKTOConfig(per_device_train_batch_size=2))

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -190,6 +190,46 @@ def test_kto_tokenize_row_caps_completion_exceeding_max_length():
     assert len(p) == 0 and len(c) == 8  # prompt dropped, completion capped
 
 
+def test_kto_appends_eos_and_preserves_it_under_truncation():
+    from unsloth_zoo.mlx.trainer import _kto_tokenize_row, MLXKTOConfig
+
+    EOS = 99
+
+    class _Tok:  # one id per word, never emits EOS itself
+        eos_token_id = EOS
+        def __call__(self, text, add_special_tokens=False):
+            return {"input_ids": [1 + i for i in range(len(text.split()))]}
+
+    big = MLXKTOConfig(max_length=1024, max_completion_length=None, max_prompt_length=0)
+
+    # 1) EOS appended when the completion lacks it
+    _, c = _kto_tokenize_row(_Tok(), "q", "a b c", big)
+    assert c[-1] == EOS and c.count(EOS) == 1
+
+    # 2) no double EOS when the completion already ends in EOS
+    class _TokEndsEos(_Tok):
+        def __call__(self, text, add_special_tokens=False):
+            return {"input_ids": super().__call__(text)["input_ids"] + [EOS]}
+    _, c = _kto_tokenize_row(_TokEndsEos(), "q", "a b", big)
+    assert c[-1] == EOS and c.count(EOS) == 1
+
+    # 3) append_eos=False -> no EOS
+    no_eos = MLXKTOConfig(max_length=1024, max_completion_length=None,
+                          max_prompt_length=0, append_eos=False)
+    _, c = _kto_tokenize_row(_Tok(), "q", "a b c", no_eos)
+    assert EOS not in c
+
+    # 4) over-length vs max_completion_length: EOS survives the cap
+    cap = MLXKTOConfig(max_length=1024, max_completion_length=4, max_prompt_length=0)
+    _, c = _kto_tokenize_row(_Tok(), "q", " ".join(["w"] * 20), cap)
+    assert len(c) == 4 and c[-1] == EOS
+
+    # 5) over-length vs max_length: EOS survives
+    ml = MLXKTOConfig(max_length=4, max_completion_length=None, max_prompt_length=0)
+    p, c = _kto_tokenize_row(_Tok(), "q", " ".join(["w"] * 20), ml)
+    assert len(p) + len(c) <= 4 and c[-1] == EOS
+
+
 def test_kto_rejects_streaming_dataset():
     # KTO materializes the whole dataset to form KL batches, so streaming must
     # be rejected loudly rather than silently exhausting the source.

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -269,3 +269,32 @@ def test_kto_rejects_ref_model_kwarg():
     from unsloth_zoo.mlx.trainer import MLXKTOTrainer, MLXKTOConfig
     with pytest.raises(ValueError, match="ref_model"):
         MLXKTOTrainer(object(), object(), [], args=MLXKTOConfig(), ref_model=object())
+
+
+def test_kto_rejects_gated_delta_and_vlm(monkeypatch):
+    # KTO bypasses the base trainer's patch_gated_delta and VLM handling; both
+    # cases already hard-fail downstream, so train() rejects them up front.
+    import unsloth_zoo.mlx.trainer as T
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer, MLXKTOConfig
+
+    def _mk(tokenizer):
+        tr = MLXKTOTrainer.__new__(MLXKTOTrainer)  # skip __init__ (needs a real model)
+        tr.args = MLXKTOConfig()
+        tr.model = object()
+        tr.tokenizer = tokenizer
+        return tr
+
+    monkeypatch.setattr(T, "iter_mlx_lora_modules", lambda m: [("m", object())])
+
+    # gated-delta model -> reject
+    monkeypatch.setattr(T, "model_has_gated_delta_layers", lambda m: True)
+    with pytest.raises(NotImplementedError, match="gated-delta"):
+        _mk(object()).train()
+
+    # VLM tokenizer (has image_processor) -> reject
+    monkeypatch.setattr(T, "model_has_gated_delta_layers", lambda m: False)
+
+    class _VLMTok:
+        image_processor = object()
+    with pytest.raises(NotImplementedError, match="vision-language"):
+        _mk(_VLMTok()).train()

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -138,3 +138,36 @@ def test_build_kto_batches_requires_batch_size_two():
     assert len(batches) == 1
     for key in ("comp_ids", "comp_labels", "kl_ids", "kl_labels", "label"):
         assert key in batches[0]
+
+
+def test_kto_string_labels_parsed_not_truthy():
+    # KTO data from CSV stores the binary label as a STRING. Plain bool() is
+    # wrong: bool("false") and bool("0") are both True, so every undesirable row
+    # would silently flip to desirable. _build_kto_batches must parse the string.
+    from unsloth_zoo.mlx.trainer import (
+        _build_kto_batches, _kto_parse_label, MLXKTOConfig,
+    )
+
+    # The exact coercions bool() gets wrong:
+    assert _kto_parse_label("false") is False
+    assert _kto_parse_label("0") is False
+    assert _kto_parse_label("0.0") is False
+    assert _kto_parse_label("true") is True
+    assert _kto_parse_label("1") is True
+    assert _kto_parse_label(True) is True and _kto_parse_label(0) is False
+    with pytest.raises(ValueError):
+        _kto_parse_label("maybe")
+
+    class _DummyTokenizer:
+        pad_token_id = 0
+        eos_token_id = 0
+        def __call__(self, text, add_special_tokens=False):
+            return {"input_ids": [1, 2, 3]}
+
+    # Two rows with string labels "false"/"0" -> both must be undesirable.
+    dataset = [{"prompt": "a", "completion": " b", "label": "false"},
+               {"prompt": "c", "completion": " d", "label": "0"}]
+    batches = _build_kto_batches(
+        dataset, _DummyTokenizer(), MLXKTOConfig(per_device_train_batch_size=2),
+    )
+    assert batches[0]["label"] == [False, False], batches[0]["label"]

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -324,3 +324,16 @@ def test_kto_rejects_non_lora_trainable_params(monkeypatch):
     monkeypatch.setattr(T, "_kto_model_has_non_lora_trainable_params", lambda m: True)
     with pytest.raises(ValueError, match="structural limit"):
         tr.train()
+
+
+def test_kto_config_inherits_parent_init_not_a_generated_one():
+    # Bare @dataclass regenerates __init__ and bypasses MLXTrainingConfig.__init__
+    # (dropping e.g. _unsloth_mlx_warmup_steps_explicit). @dataclass(init=False)
+    # inherits the parent init while keeping the KTO-specific fields.
+    from unsloth_zoo.mlx.trainer import MLXKTOConfig, MLXTrainingConfig
+    assert MLXKTOConfig.__init__ is MLXTrainingConfig.__init__
+    c = MLXKTOConfig()
+    assert hasattr(c, "_unsloth_mlx_warmup_steps_explicit")  # parent init ran
+    assert c.beta == 0.1 and c.loss_type == "kto"  # KTO fields intact
+    c2 = MLXKTOConfig(beta=0.5, desirable_weight=2.0)
+    assert c2.beta == 0.5 and c2.desirable_weight == 2.0

--- a/tests/test_mlx_kto_loss.py
+++ b/tests/test_mlx_kto_loss.py
@@ -298,3 +298,29 @@ def test_kto_rejects_gated_delta_and_vlm(monkeypatch):
         image_processor = object()
     with pytest.raises(NotImplementedError, match="vision-language"):
         _mk(_VLMTok()).train()
+
+
+def test_kto_rejects_non_lora_trainable_params(monkeypatch):
+    # KTO's reference is the adapter-off forward; trainable non-LoRA tensors would
+    # drift and corrupt it. train() rejects them (structural, no reference_free).
+    import unsloth_zoo.mlx.trainer as T
+    from unsloth_zoo.mlx.trainer import (
+        MLXKTOTrainer, MLXKTOConfig, _kto_model_has_non_lora_trainable_params,
+    )
+
+    # Predicate: a model with no trainable params has no non-LoRA trainables.
+    class _Empty:
+        def trainable_parameters(self):
+            return {}
+    assert _kto_model_has_non_lora_trainable_params(_Empty()) is False
+
+    # Guard: train() raises when the predicate reports non-LoRA trainables.
+    tr = MLXKTOTrainer.__new__(MLXKTOTrainer)
+    tr.args = MLXKTOConfig()
+    tr.model = object()
+    tr.tokenizer = object()
+    monkeypatch.setattr(T, "iter_mlx_lora_modules", lambda m: [("m", object())])
+    monkeypatch.setattr(T, "model_has_gated_delta_layers", lambda m: False)
+    monkeypatch.setattr(T, "_kto_model_has_non_lora_trainable_params", lambda m: True)
+    with pytest.raises(ValueError, match="structural limit"):
+        tr.train()

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -75,11 +75,17 @@ def test_kto_trains_finite_and_decreasing(tmp_path):
     model, tok = _load_peft()
     trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
                             args=_config(output_dir=str(tmp_path)))
-    hist = trainer.train()
+    output = trainer.train()
 
+    # train() returns MLXTrainOutput, matching MLXTrainer; the per-step losses
+    # live on the trainer.
+    hist = trainer._train_loss_history
     assert len(hist) == 6, f"expected 6 steps, got {len(hist)}"
     assert all(math.isfinite(x) for x in hist), f"non-finite loss: {hist}"
     assert hist[-1] < hist[0], f"loss did not decrease: {hist}"
+    assert output.global_step == 6, f"expected 6 steps, got {output.global_step}"
+    assert math.isfinite(output.training_loss)
+    assert output["total_train_steps"] == 6
     # KL baseline recorded per step, finite and clamped >= 0.
     assert trainer._kl_history and all(math.isfinite(k) and k >= 0.0 for k in trainer._kl_history)
 

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -134,6 +134,31 @@ def test_kto_num_train_epochs_scales_steps(tmp_path):
 
 
 @metal_only
+def test_kto_rejects_resume_from_checkpoint(tmp_path):
+    # Resume is unimplemented; a resumed call would restart and overwrite, so
+    # it must raise rather than silently restart.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
+                            args=_config(output_dir=str(tmp_path)))
+    with pytest.raises(ValueError, match="resume_from_checkpoint"):
+        trainer.train(resume_from_checkpoint=str(tmp_path))
+
+
+@metal_only
+def test_kto_rejects_eval_dataset(tmp_path):
+    # No eval loop yet; passing eval_dataset must raise rather than silently
+    # ignore eval_steps / load_best_model_at_end.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
+                            eval_dataset=_dataset(n=4),
+                            args=_config(output_dir=str(tmp_path)))
+    with pytest.raises(ValueError, match="eval loop"):
+        trainer.train()
+
+
+@metal_only
 def test_kto_rejects_lora_plus(tmp_path):
     # LoRA+ per-leaf scaling is unimplemented on the KTO path, so setting
     # lora_plus_ratio must raise loudly rather than silently train lora_b at

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -63,7 +63,10 @@ def _load_peft():
 
 def _config(**overrides):
     from unsloth_zoo.mlx.trainer import MLXKTOConfig
+    # gradient_accumulation_steps=1 keeps these tests at one optimizer step per
+    # batch; the accumulation path has its own test below.
     base = dict(per_device_train_batch_size=4, max_steps=6, warmup_steps=1,
+                gradient_accumulation_steps=1,
                 learning_rate=1e-4, beta=0.1, logging_steps=99, seed=3407, report_to="none")
     base.update(overrides)
     return MLXKTOConfig(**base)
@@ -88,6 +91,28 @@ def test_kto_trains_finite_and_decreasing(tmp_path):
     assert output["total_train_steps"] == 6
     # KL baseline recorded per step, finite and clamped >= 0.
     assert trainer._kl_history and all(math.isfinite(k) and k >= 0.0 for k in trainer._kl_history)
+
+
+@metal_only
+def test_kto_gradient_accumulation_reduces_optimizer_steps(tmp_path):
+    # 24 examples / batch 4 = 6 micro-batches. With max_steps unset, one epoch
+    # is len(batches) // grad_accum optimizer steps: grad_accum=2 -> 3 steps,
+    # each averaging 2 micro-batches. If accumulation were ignored (one update
+    # per micro-batch) this would be 6 steps, so the history length pins that
+    # grad_accum actually groups micro-batches into optimizer steps.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(
+        model=model, tokenizer=tok, train_dataset=_dataset(),
+        args=_config(output_dir=str(tmp_path), max_steps=0,
+                     gradient_accumulation_steps=2),
+    )
+    output = trainer.train()
+    assert len(trainer._train_loss_history) == 3, trainer._train_loss_history
+    assert len(trainer._kl_history) == 3
+    assert output.global_step == 3
+    assert output["total_train_steps"] == 3
+    assert all(math.isfinite(x) for x in trainer._train_loss_history)
 
 
 @metal_only

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -116,6 +116,39 @@ def test_kto_gradient_accumulation_reduces_optimizer_steps(tmp_path):
 
 
 @metal_only
+def test_kto_num_train_epochs_scales_steps(tmp_path):
+    # max_steps unset + num_train_epochs=2: optimizer steps =
+    # (len(batches) * epochs) // grad_accum. 8 examples / batch 4 = 2 batches,
+    # grad_accum=1, epochs=2 -> 4 steps. One epoch would be 2, so this pins that
+    # num_train_epochs is honored instead of silently running a single pass.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(
+        model=model, tokenizer=tok, train_dataset=_dataset(n=8),
+        args=_config(output_dir=str(tmp_path), max_steps=0,
+                     gradient_accumulation_steps=1, num_train_epochs=2),
+    )
+    output = trainer.train()
+    assert output["total_train_steps"] == 4, output["total_train_steps"]
+    assert output.global_step == 4
+
+
+@metal_only
+def test_kto_rejects_lora_plus(tmp_path):
+    # LoRA+ per-leaf scaling is unimplemented on the KTO path, so setting
+    # lora_plus_ratio must raise loudly rather than silently train lora_b at
+    # the wrong learning rate.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(
+        model=model, tokenizer=tok, train_dataset=_dataset(),
+        args=_config(output_dir=str(tmp_path), lora_plus_ratio=16.0),
+    )
+    with pytest.raises(ValueError, match="lora_plus_ratio"):
+        trainer.train()
+
+
+@metal_only
 def test_kto_saves_adapters_at_end(tmp_path):
     # save_steps defaults to 0 (save at end); train() must leave adapters on
     # disk, not only in memory, matching MLXTrainer.

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -1,0 +1,169 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Real-MLX regression for MLXKTOTrainer on Apple Silicon.
+
+Trains a 4-bit Qwen2.5-0.5B + LoRA with KTO on a small unpaired dataset and
+checks the loss is finite and decreasing, that the LoRA-disable reference path
+restores adapter scales (including when a forward throws mid-step), and that a
+non-PEFT model raises the clear LoRA-only error.
+
+Metal-gated so Linux CI collection skips cleanly.
+"""
+
+import math
+
+import pytest
+
+try:
+    import mlx.core as mx
+    _METAL = mx.metal.is_available()
+except Exception:
+    _METAL = False
+
+if not _METAL:
+    print("NOTICE: Metal unavailable; MLX KTO training tests will be skipped.")
+
+metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
+
+MODEL = "unsloth/Qwen2.5-0.5B"
+
+
+def _dataset(n=24):
+    rows = []
+    for i in range(n):
+        prompt = f"### Question: what is {i} plus {i}?\n### Answer:"
+        if i % 2 == 0:
+            rows.append({"prompt": prompt, "completion": f" {2 * i}.", "label": True})
+        else:
+            rows.append({"prompt": prompt, "completion": f" {2 * i + 7}, wrong.", "label": False})
+    return rows
+
+
+def _load_peft():
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    mx.random.seed(3407)
+    model, tok = FastMLXModel.from_pretrained(MODEL, max_seq_length=256, load_in_4bit=True)
+    model = FastMLXModel.get_peft_model(model, r=8, lora_alpha=16, lora_dropout=0, random_state=3407)
+    return model, tok
+
+
+def _config(**overrides):
+    from unsloth_zoo.mlx.trainer import MLXKTOConfig
+    base = dict(per_device_train_batch_size=4, max_steps=6, warmup_steps=1,
+                learning_rate=1e-4, beta=0.1, logging_steps=99, seed=3407, report_to="none")
+    base.update(overrides)
+    return MLXKTOConfig(**base)
+
+
+@metal_only
+def test_kto_trains_finite_and_decreasing(tmp_path):
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
+                            args=_config(output_dir=str(tmp_path)))
+    hist = trainer.train()
+
+    assert len(hist) == 6, f"expected 6 steps, got {len(hist)}"
+    assert all(math.isfinite(x) for x in hist), f"non-finite loss: {hist}"
+    assert hist[-1] < hist[0], f"loss did not decrease: {hist}"
+    # KL baseline recorded per step, finite and clamped >= 0.
+    assert trainer._kl_history and all(math.isfinite(k) and k >= 0.0 for k in trainer._kl_history)
+
+
+@metal_only
+def test_lora_scales_restored_after_training(tmp_path):
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    from unsloth_zoo.mlx.utils import iter_mlx_lora_modules
+    model, tok = _load_peft()
+    before = [m.scale for _, m in iter_mlx_lora_modules(model)]
+    assert before and all(s != 0 for s in before)
+
+    trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
+                            args=_config(output_dir=str(tmp_path)))
+    trainer.train()
+
+    after = [m.scale for _, m in iter_mlx_lora_modules(model)]
+    assert after == before, "LoRA scales not restored to their pre-training values"
+
+
+@metal_only
+def test_lora_scales_restored_when_forward_throws(tmp_path, monkeypatch):
+    """The reference forward runs with scales set to 0; if it throws, the
+    finally must restore scales so the model is not left adapter-disabled."""
+    import unsloth_zoo.mlx.trainer as T
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    from unsloth_zoo.mlx.utils import iter_mlx_lora_modules
+    model, tok = _load_peft()
+    before = [m.scale for _, m in iter_mlx_lora_modules(model)]
+
+    # Fail on the 2nd sum-logp call: that is the reference forward, which runs
+    # while adapter scales are 0 (policy-KL is the 1st call, scales still on).
+    real = T._kto_sum_logp
+    calls = {"n": 0}
+    def flaky(logits, labels):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("injected forward failure")
+        return real(logits, labels)
+    monkeypatch.setattr(T, "_kto_sum_logp", flaky)
+
+    trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
+                            args=_config(output_dir=str(tmp_path)))
+    with pytest.raises(RuntimeError, match="injected forward failure"):
+        trainer.train()
+
+    after = [m.scale for _, m in iter_mlx_lora_modules(model)]
+    assert after == before, "scales left disabled after a throwing reference forward"
+    assert all(s != 0 for s in after), "adapters left at scale 0"
+
+
+@metal_only
+def test_kto_sum_logp_matches_numpy():
+    """Summed-logp extractor vs a from-scratch numpy log-softmax reference."""
+    import numpy as np
+    from unsloth_zoo.mlx.trainer import _kto_sum_logp
+    rng = np.random.default_rng(1)
+    B, T, V = 3, 6, 11
+    logits = rng.normal(0, 1, size=(B, T, V)).astype(np.float32)
+    labels = rng.integers(0, V, size=(B, T)).astype(np.int64)
+    labels[0, :2] = -100; labels[1, :3] = -100; labels[2, :1] = -100  # masked prompt prefixes
+
+    got = np.array(_kto_sum_logp(mx.array(logits), mx.array(labels)))
+
+    inp, tgt = logits[:, :-1, :], labels[:, 1:]
+    m = inp.max(axis=-1, keepdims=True)
+    logsm = inp - (m + np.log(np.exp(inp - m).sum(axis=-1, keepdims=True)))
+    ref = np.zeros(B)
+    for b in range(B):
+        for t in range(tgt.shape[1]):
+            if tgt[b, t] != -100:
+                ref[b] += logsm[b, t, tgt[b, t]]
+    assert np.abs(got - ref).max() < 1e-4
+
+
+@metal_only
+def test_non_peft_model_raises_lora_only_error(tmp_path):
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    mx.random.seed(3407)
+    model, tok = FastMLXModel.from_pretrained(MODEL, max_seq_length=256, load_in_4bit=True)
+    # No get_peft_model -> no LoRA adapters -> reference forward is impossible.
+    trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
+                            args=_config(output_dir=str(tmp_path)))
+    with pytest.raises(ValueError) as exc:
+        trainer.train()
+    assert "LoRA" in str(exc.value)

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -91,6 +91,20 @@ def test_kto_trains_finite_and_decreasing(tmp_path):
 
 
 @metal_only
+def test_kto_saves_adapters_at_end(tmp_path):
+    # save_steps defaults to 0 (save at end); train() must leave adapters on
+    # disk, not only in memory, matching MLXTrainer.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
+                            args=_config(output_dir=str(tmp_path)))
+    trainer.train()
+    written = {p.name for p in tmp_path.iterdir()}
+    assert "adapters.safetensors" in written, f"no adapters saved: {sorted(written)}"
+    assert "adapter_config.json" in written, f"no adapter config saved: {sorted(written)}"
+
+
+@metal_only
 def test_lora_scales_restored_after_training(tmp_path):
     from unsloth_zoo.mlx.trainer import MLXKTOTrainer
     from unsloth_zoo.mlx.utils import iter_mlx_lora_modules

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -134,6 +134,21 @@ def test_kto_num_train_epochs_scales_steps(tmp_path):
 
 
 @metal_only
+def test_kto_resets_run_state_between_train_calls(tmp_path):
+    # Re-running the same trainer must not accumulate stale loss/KL history, or
+    # the MLXTrainOutput mean would blend the two runs.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(model=model, tokenizer=tok, train_dataset=_dataset(),
+                            args=_config(output_dir=str(tmp_path), max_steps=3))
+    trainer.train()
+    assert len(trainer._train_loss_history) == 3
+    trainer.train()
+    assert len(trainer._train_loss_history) == 3, "history should reset, not append"
+    assert len(trainer._kl_history) == 3
+
+
+@metal_only
 def test_kto_rejects_resume_from_checkpoint(tmp_path):
     # Resume is unimplemented; a resumed call would restart and overwrite, so
     # it must raise rather than silently restart.

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -94,6 +94,23 @@ def test_kto_trains_finite_and_decreasing(tmp_path):
 
 
 @metal_only
+def test_kto_logging_steps_uses_one_based_cadence(tmp_path, capsys):
+    # logging_steps must gate on the 1-based step: logging_steps=2 over 4 steps
+    # logs at steps 2 and 4, not the old zero-based 1 and 3.
+    import re
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    model, tok = _load_peft()
+    trainer = MLXKTOTrainer(
+        model=model, tokenizer=tok, train_dataset=_dataset(),
+        args=_config(output_dir=str(tmp_path), max_steps=4, logging_steps=2, warmup_steps=0),
+    )
+    trainer.train()
+    out = capsys.readouterr().out
+    logged = [int(m) for m in re.findall(r"Unsloth KTO: step (\d+)/", out)]
+    assert logged == [2, 4], f"expected logs at 1-based steps [2,4], got {logged}"
+
+
+@metal_only
 def test_kto_gradient_accumulation_reduces_optimizer_steps(tmp_path):
     # 24 examples / batch 4 = 6 micro-batches. With max_steps unset, one epoch
     # is len(batches) // grad_accum optimizer steps: grad_accum=2 -> 3 steps,

--- a/tests/test_mlx_kto_train_metal.py
+++ b/tests/test_mlx_kto_train_metal.py
@@ -111,6 +111,32 @@ def test_kto_logging_steps_uses_one_based_cadence(tmp_path, capsys):
 
 
 @metal_only
+def test_kto_grad_accum_weights_microbatches_by_example_count(tmp_path):
+    # 6 rows, batch_size=4 -> micro-batches of sizes [4, 2]. With lr=0 nothing
+    # updates, so both are scored on the same initial model. A grad-accum window
+    # over both must report the EXAMPLE-weighted mean (4*L1+2*L2)/6, not the equal
+    # mean (L1+L2)/2 -- otherwise the trailing size-2 batch is over-weighted.
+    from unsloth_zoo.mlx.trainer import MLXKTOTrainer
+    data = _dataset(6)
+
+    def _run(tmp, **over):
+        m, t = _load_peft()
+        cfg = _config(output_dir=str(tmp), per_device_train_batch_size=4,
+                      learning_rate=0.0, weight_decay=0.0, warmup_steps=0, **over)
+        tr = MLXKTOTrainer(model=m, tokenizer=t, train_dataset=data, args=cfg)
+        tr.train()
+        return tr._train_loss_history
+
+    L1, L2 = _run(tmp_path / "a", gradient_accumulation_steps=1, max_steps=2)
+    Lw = _run(tmp_path / "b", gradient_accumulation_steps=2, max_steps=1)[0]
+
+    example_weighted = (4 * L1 + 2 * L2) / 6
+    equal_weighted = (L1 + L2) / 2
+    assert abs(example_weighted - equal_weighted) > 1e-5, "test needs L1 != L2 to discriminate"
+    assert Lw == pytest.approx(example_weighted, abs=1e-4), (Lw, example_weighted, equal_weighted)
+
+
+@metal_only
 def test_kto_gradient_accumulation_reduces_optimizer_steps(tmp_path):
     # 24 examples / batch 4 = 6 micro-batches. With max_steps unset, one epoch
     # is len(batches) // grad_accum optimizer steps: grad_accum=2 -> 3 steps,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4061,3 +4061,300 @@ def train_on_responses_only(
               f"({len(batches)} batches prepared).")
 
     return trainer
+
+
+# ============================================================================
+# KTO (Kahneman-Tversky Optimization) - unpaired preference tuning
+#
+# Mirrors TRL's KTOTrainer (loss_type="kto", Eqn 7 of arXiv:2402.01306). KTO
+# trains on UNPAIRED data: one completion per row with a binary desirable/
+# undesirable label, not chosen/rejected pairs. The KL term is a batch-level
+# baseline estimated from MISMATCHED pairs (each prompt scored against a
+# different row's completion), computed under no-grad and detached. The
+# reference model is obtained by disabling LoRA adapters (scale=0), so no
+# second model copy is needed. Standalone trainer: the SFT compile/accumulate
+# loop is left completely untouched.
+# ============================================================================
+
+
+@dataclass
+class MLXKTOConfig(MLXTrainingConfig):
+    """KTO configuration mirroring TRL's KTOConfig field names, on top of the
+    shared MLX training knobs (optimizer, schedule, clipping, save)."""
+
+    beta: float = 0.1
+    desirable_weight: float = 1.0
+    undesirable_weight: float = 1.0
+    max_length: int = 1024
+    max_prompt_length: int = 512
+    max_completion_length: int | None = None
+    loss_type: str = "kto"
+
+
+def _kto_sum_logp(logits, labels):
+    """Sum of per-token log-probs over non-masked completion tokens.
+
+    Shifts labels left by one (causal) and masks label_pad (-100), matching
+    TRL get_batch_logps with average_log_prob=False. Returns shape (batch,).
+    """
+    inp = logits[:, :-1, :]
+    tgt = labels[:, 1:]
+    mask = (tgt != -100).astype(mx.float32)
+    safe = mx.where(tgt == -100, mx.array(0, dtype=tgt.dtype), tgt)
+    per_tok = -nn.losses.cross_entropy(inp, safe)  # logp = -cross_entropy
+    return (per_tok * mask).sum(axis=1)
+
+
+def _kto_gather(vec, idx):
+    """vec[idx] for a python index list, or an empty (0,) slice when idx is
+    empty (a batch can be all-desirable or all-undesirable)."""
+    if len(idx) == 0:
+        return vec[0:0]
+    return vec[mx.array(idx, dtype=mx.int32)]
+
+
+def _kto_kl_baseline(pol_kl, ref_kl):
+    """Batch KL baseline: clamp(mean(policy_KL - reference_KL), min=0), detached.
+
+    Estimated from the mismatched-pair completions (TRL kto_loss lines
+    1131-1132). Detached so no gradient flows through the KL term, and clamped
+    at 0 (a raw negative estimate becomes 0 - frequent early in training).
+    """
+    return mx.stop_gradient(mx.maximum((pol_kl - ref_kl).mean(), 0.0))
+
+
+def _kto_loss(pol_ch, pol_rej, ref_ch, ref_rej, kl,
+              beta, desirable_weight, undesirable_weight):
+    """KTO loss (TRL loss_type='kto', Eqn 7 of arXiv:2402.01306).
+
+    ``ref_ch``/``ref_rej`` are the reference (adapter-off) logps and ``kl`` is
+    the pre-clamped, detached batch KL baseline; all three are constants w.r.t.
+    the policy, so gradient flows only through ``pol_ch``/``pol_rej``. Either
+    side may be empty (all-desirable or all-undesirable batch). Returns the mean
+    over the concatenated, weighted per-example losses.
+    """
+    parts = []
+    if pol_ch.shape[0] > 0:
+        chosen_logratio = pol_ch - ref_ch
+        parts.append(desirable_weight * (1 - mx.sigmoid(beta * (chosen_logratio - kl))))
+    if pol_rej.shape[0] > 0:
+        rejected_logratio = pol_rej - ref_rej
+        parts.append(undesirable_weight * (1 - mx.sigmoid(beta * (kl - rejected_logratio))))
+    return mx.concatenate(parts, axis=0).mean()
+
+
+def _kto_pad(seqs, fill):
+    length = max(len(s) for s in seqs)
+    return mx.array([list(s) + [fill] * (length - len(s)) for s in seqs])
+
+
+def _kto_tokenize_row(tokenizer, prompt, completion, args):
+    """Tokenize one KTO row to (prompt_ids, completion_ids), truncated to the
+    configured lengths. Prompt is truncated (kept-completion) if the combined
+    length exceeds max_length, matching TRL's keep-completion policy."""
+    p = tokenizer(prompt, add_special_tokens=False)["input_ids"]
+    c = tokenizer(completion, add_special_tokens=False)["input_ids"]
+    max_completion = args.max_completion_length
+    if max_completion is not None and max_completion > 0:
+        c = c[:max_completion]
+    if args.max_prompt_length and args.max_prompt_length > 0:
+        p = p[-args.max_prompt_length:]
+    if args.max_length and args.max_length > 0 and len(p) + len(c) > args.max_length:
+        # Keep the whole completion; trim the prompt from the left.
+        keep = max(args.max_length - len(c), 0)
+        p = p[-keep:] if keep > 0 else []
+    return p, c
+
+
+def _build_kto_batches(dataset, tokenizer, args):
+    """Build unpaired KTO batches with the mismatched-pair KL variant.
+
+    Each batch dict carries: comp_ids/comp_labels (prompt+completion, prompt
+    masked), kl_ids/kl_labels (prompt + a DIFFERENT row's completion, rolled by
+    +1 within the batch), and label (list[bool]). Rolling within the batch keeps
+    the KL y' set equal to the reward y set for that batch (TRL _get_kl_dataset).
+    """
+    bs = int(args.per_device_train_batch_size)
+    if bs < 2:
+        raise ValueError(
+            "Unsloth: KTO requires per_device_train_batch_size >= 2. The KL "
+            "baseline is estimated from mismatched pairs by rolling completions "
+            "by +1 within the batch; with batch size 1 the roll pairs each "
+            "prompt with its own completion, so the KL term collapses to the "
+            "reward and training is invalid. Increase the batch size."
+        )
+    pad_id = tokenizer.pad_token_id
+    if pad_id is None:
+        pad_id = tokenizer.eos_token_id
+    if pad_id is None:
+        pad_id = 0
+
+    rows = []
+    for ex in dataset:
+        missing = [k for k in ("prompt", "completion", "label") if k not in ex]
+        if missing:
+            raise ValueError(
+                "Unsloth: KTO dataset rows must have 'prompt', 'completion' and "
+                f"'label' columns; missing {missing}. KTO uses unpaired data "
+                "(one completion + a binary desirable/undesirable label per row), "
+                "not chosen/rejected pairs."
+            )
+        p, c = _kto_tokenize_row(tokenizer, ex["prompt"], ex["completion"], args)
+        if len(c) == 0:
+            continue  # nothing to score
+        rows.append((p, c, bool(ex["label"])))
+
+    batches = []
+    dropped = 0
+    for i in range(0, len(rows), bs):
+        chunk = rows[i:i + bs]
+        if len(chunk) < 2:
+            dropped += len(chunk)
+            continue  # a size-1 tail would self-pair the KL roll
+        prompts = [p for p, _, _ in chunk]
+        comps = [c for _, c, _ in chunk]
+        labels = [lab for _, _, lab in chunk]
+        rolled = [comps[-1]] + comps[:-1]  # TRL _get_kl_dataset roll (+1)
+        batches.append(dict(
+            comp_ids=_kto_pad([p + c for p, c in zip(prompts, comps)], pad_id),
+            comp_labels=_kto_pad([[-100] * len(p) + list(c) for p, c in zip(prompts, comps)], -100),
+            kl_ids=_kto_pad([p + cr for p, cr in zip(prompts, rolled)], pad_id),
+            kl_labels=_kto_pad([[-100] * len(p) + list(cr) for p, cr in zip(prompts, rolled)], -100),
+            label=labels,
+        ))
+    if dropped:
+        print(f"Unsloth: KTO dropped {dropped} trailing example(s) that could not "
+              f"form a batch of >= 2 (needed for the mismatched-pair KL term).")
+    return batches
+
+
+class MLXKTOTrainer(MLXTrainer):
+    """MLX-native KTO trainer, mirroring TRL's KTOTrainer constructor API.
+
+    Standalone loop (no mx.compile of the step): each step runs the policy
+    forward (grad), plus policy-KL and reference (LoRA-disabled) forwards that
+    are computed under stop_gradient and passed to the loss as constants.
+    Requires a LoRA model (get_peft_model) so the reference is the adapter-off
+    forward. Reuses MLXTrainer's optimizer/schedule/clip/decay helpers.
+    """
+
+    def __init__(self, model, tokenizer, train_dataset, args=None,
+                 eval_dataset=None, processor=None, **kwargs):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.processor = processor
+        self.args = args if args is not None else MLXKTOConfig()
+        if not isinstance(self.args, MLXKTOConfig):
+            raise TypeError(
+                "Unsloth: MLXKTOTrainer requires an MLXKTOConfig (got "
+                f"{type(self.args).__name__}). Use MLXKTOConfig for beta / "
+                "desirable_weight / undesirable_weight."
+            )
+        self._is_vlm = False
+        # Raw KTO rows: do NOT wrap in the SFT tokenized dataset view.
+        self.train_dataset = train_dataset
+        self.eval_dataset = eval_dataset
+        self.formatting_func = None
+        self._ensure_lora_frozen(model)
+        self._reset_run_state()
+        self.stop_requested = False
+        self._batches = None
+        self._step_callbacks = []
+        self._eval_callbacks = []
+        self._kl_history = []
+
+    def train(self, resume_from_checkpoint: str | None = None):
+        args = self.args
+        model = self.model
+        lora_mods = [m for _, m in iter_mlx_lora_modules(model)]
+        if not lora_mods:
+            raise ValueError(
+                "Unsloth: MLXKTOTrainer needs a LoRA model. Call "
+                "FastMLXModel.get_peft_model(...) first; the KTO reference is the "
+                "adapter-disabled forward (there is no separate reference copy)."
+            )
+
+        batches = _build_kto_batches(self.train_dataset, self.tokenizer, args)
+        if not batches:
+            raise ValueError(
+                "Unsloth: KTO produced no usable batches (need >= 2 examples with "
+                "non-empty completions per batch)."
+            )
+
+        total_steps = args.max_steps if args.max_steps and args.max_steps > 0 else len(batches)
+        optimizer = self._build_optimizer(total_steps)
+        (max_grad_norm, max_grad_value, max_grad_leaf_norm,
+         _clip_mode) = _resolve_mlx_grad_clipping(args)
+
+        def _reference_and_kl(batch):
+            """Policy-KL + reference (LoRA-off) logps, all detached. Scales are
+            restored in a finally so a throwing forward never leaves adapters
+            disabled."""
+            pol_kl = mx.stop_gradient(_kto_sum_logp(model(batch["kl_ids"]), batch["kl_labels"]))
+            saved = [mm.scale for mm in lora_mods]
+            try:
+                for mm in lora_mods:
+                    mm.scale = 0.0
+                ref_comp = mx.stop_gradient(_kto_sum_logp(model(batch["comp_ids"]), batch["comp_labels"]))
+                ref_kl = mx.stop_gradient(_kto_sum_logp(model(batch["kl_ids"]), batch["kl_labels"]))
+            finally:
+                for mm, s in zip(lora_mods, saved):
+                    mm.scale = s
+            kl_scalar = _kto_kl_baseline(pol_kl, ref_kl)
+            return ref_comp, kl_scalar
+
+        step = 0
+        stop = False
+        max_epochs = 1_000_000
+        for _epoch in range(max_epochs):
+            if stop:
+                break
+            for batch in batches:
+                if step >= total_steps or self.stop_requested:
+                    stop = True
+                    break
+                labels = batch["label"]
+                chosen_idx = [i for i, l in enumerate(labels) if l]
+                rejected_idx = [i for i, l in enumerate(labels) if not l]
+
+                ref_comp, kl_scalar = _reference_and_kl(batch)
+                ref_ch = _kto_gather(ref_comp, chosen_idx)
+                ref_rej = _kto_gather(ref_comp, rejected_idx)
+                mx.eval(ref_ch, ref_rej, kl_scalar)
+
+                def loss_fn(model):
+                    comp_logps = _kto_sum_logp(model(batch["comp_ids"]), batch["comp_labels"])
+                    pol_ch = _kto_gather(comp_logps, chosen_idx)
+                    pol_rej = _kto_gather(comp_logps, rejected_idx)
+                    return _kto_loss(
+                        pol_ch, pol_rej, ref_ch, ref_rej, kl_scalar,
+                        args.beta, args.desirable_weight, args.undesirable_weight,
+                    )
+
+                loss, grad = nn.value_and_grad(model, loss_fn)(model)
+
+                if max_grad_norm > 0:
+                    grad, _ = _clip_grad_norm_fp32(grad, max_norm=max_grad_norm)
+                if max_grad_value is not None and max_grad_value > 0:
+                    grad = _clip_grad_by_value(grad, max_grad_value)
+                if max_grad_leaf_norm is not None and max_grad_leaf_norm > 0:
+                    grad = _clip_grad_by_leaf_norm(grad, max_grad_leaf_norm)
+                grad = self._apply_coupled_weight_decay(model, grad)
+                self._apply_manual_weight_decay(model, optimizer, grad)
+                self._set_optimizer_lr_for_step(optimizer, step)
+                optimizer.update(model, grad)
+                mx.eval(model.parameters(), optimizer.state, loss)
+
+                train_loss = float(loss)
+                self._train_loss_history.append(train_loss)
+                self._kl_history.append(float(kl_scalar))
+                self._global_step = step + 1
+                if args.logging_steps and (step % max(int(args.logging_steps), 1) == 0):
+                    print(
+                        f"Unsloth KTO: step {step + 1}/{total_steps} "
+                        f"loss={train_loss:.4f} kl={float(kl_scalar):.4f} "
+                        f"(desirable={len(chosen_idx)} undesirable={len(rejected_idx)})"
+                    )
+                step += 1
+
+        return self._train_loss_history

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4281,7 +4281,15 @@ class MLXKTOTrainer(MLXTrainer):
                 "non-empty completions per batch)."
             )
 
-        total_steps = args.max_steps if args.max_steps and args.max_steps > 0 else len(batches)
+        # total_steps counts optimizer steps. When max_steps is unset, one pass
+        # over the data is len(batches) // grad_accum optimizer steps (matching
+        # MLXTrainer); at least 1 so a run with fewer batches than grad_accum
+        # still takes a (short) step.
+        grad_accum = max(int(args.gradient_accumulation_steps), 1)
+        if args.max_steps and args.max_steps > 0:
+            total_steps = args.max_steps
+        else:
+            total_steps = max(len(batches) // grad_accum, 1)
         optimizer = self._build_optimizer(total_steps)
         (max_grad_norm, max_grad_value, max_grad_leaf_norm,
          _clip_mode) = _resolve_mlx_grad_clipping(args)
@@ -4304,7 +4312,20 @@ class MLXKTOTrainer(MLXTrainer):
             kl_scalar = _kto_kl_baseline(pol_kl, ref_kl)
             return ref_comp, kl_scalar
 
+        # gradient accumulation: run grad_accum micro-batches, average their
+        # gradients, then take one optimizer step, so the effective batch size
+        # is per_device_train_batch_size * grad_accum. step/total_steps and the
+        # LR schedule count optimizer steps (not micro-batches), matching
+        # MLXTrainer and TRL's HF-Trainer-backed KTOTrainer. A simple mean is
+        # used rather than the token-weighted accumulation MLXTrainer uses for
+        # SFT: the KTO loss is a per-example preference objective, not a
+        # per-token mean, so each micro-batch contributes equally. grad_accum is
+        # resolved above (it also sets total_steps).
         step = 0
+        micro = 0            # micro-batches accumulated in the current window
+        acc_grad = None      # running mean of the window's gradients
+        acc_loss = 0.0       # running mean of the window's losses
+        acc_kl = 0.0         # running mean of the window's KL diagnostics
         stop = False
         max_epochs = 1_000_000
         for _epoch in range(max_epochs):
@@ -4334,6 +4355,24 @@ class MLXKTOTrainer(MLXTrainer):
 
                 loss, grad = nn.value_and_grad(model, loss_fn)(model)
 
+                # Accumulate the mean gradient. Dividing each micro-batch by
+                # grad_accum before summing keeps the accumulator at update
+                # scale; sum(g_i / N) == mean(g_i).
+                contrib = tree_map(lambda g: g / grad_accum, grad)
+                if acc_grad is None:
+                    acc_grad = contrib
+                else:
+                    acc_grad = tree_map(lambda a, g: a + g, acc_grad, contrib)
+                acc_loss += float(loss) / grad_accum
+                acc_kl += float(kl_scalar) / grad_accum
+                micro += 1
+                if micro < grad_accum:
+                    # Materialize the running accumulator so the autograd graph
+                    # does not grow across the window.
+                    mx.eval(acc_grad)
+                    continue
+
+                grad = acc_grad
                 if max_grad_norm > 0:
                     grad, _ = _clip_grad_norm_fp32(grad, max_norm=max_grad_norm)
                 if max_grad_value is not None and max_grad_value > 0:
@@ -4344,19 +4383,23 @@ class MLXKTOTrainer(MLXTrainer):
                 self._apply_manual_weight_decay(model, optimizer, grad)
                 self._set_optimizer_lr_for_step(optimizer, step)
                 optimizer.update(model, grad)
-                mx.eval(model.parameters(), optimizer.state, loss)
+                mx.eval(model.parameters(), optimizer.state)
 
-                train_loss = float(loss)
+                train_loss = acc_loss
                 self._train_loss_history.append(train_loss)
-                self._kl_history.append(float(kl_scalar))
+                self._kl_history.append(acc_kl)
                 self._global_step = step + 1
                 if args.logging_steps and (step % max(int(args.logging_steps), 1) == 0):
                     print(
                         f"Unsloth KTO: step {step + 1}/{total_steps} "
-                        f"loss={train_loss:.4f} kl={float(kl_scalar):.4f} "
+                        f"loss={train_loss:.4f} kl={acc_kl:.4f} "
                         f"(desirable={len(chosen_idx)} undesirable={len(rejected_idx)})"
                     )
                 step += 1
+                acc_grad = None
+                acc_loss = 0.0
+                acc_kl = 0.0
+                micro = 0
 
         # Honor the documented save_steps=0 contract (save at end of training),
         # matching MLXTrainer.train(). Without this the trained adapters live

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4358,6 +4358,19 @@ class MLXKTOTrainer(MLXTrainer):
                     )
                 step += 1
 
+        # Honor the documented save_steps=0 contract (save at end of training),
+        # matching MLXTrainer.train(). Without this the trained adapters live
+        # only in memory and are lost on process exit unless the caller knows to
+        # call save_model() by hand. KTO is LoRA-only, so save_model() takes the
+        # adapter path.
+        if self.is_main_process:
+            try:
+                self.save_model()
+            except ValueError as e:
+                print(f"Unsloth: skipped final save ({e})")
+            else:
+                print(f"Unsloth: Saved final adapters to {args.output_dir}")
+
         # Same result type as MLXTrainer.train(): callers reach for
         # output.metrics / output.global_step / output.training_loss, which a
         # bare list does not provide. The per-step losses stay available on

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4285,6 +4285,7 @@ class MLXKTOTrainer(MLXTrainer):
         optimizer = self._build_optimizer(total_steps)
         (max_grad_norm, max_grad_value, max_grad_leaf_norm,
          _clip_mode) = _resolve_mlx_grad_clipping(args)
+        start_time = time.perf_counter()
 
         def _reference_and_kl(batch):
             """Policy-KL + reference (LoRA-off) logps, all detached. Scales are
@@ -4357,4 +4358,18 @@ class MLXKTOTrainer(MLXTrainer):
                     )
                 step += 1
 
-        return self._train_loss_history
+        # Same result type as MLXTrainer.train(): callers reach for
+        # output.metrics / output.global_step / output.training_loss, which a
+        # bare list does not provide. The per-step losses stay available on
+        # self._train_loss_history.
+        total_time = time.perf_counter() - start_time
+        avg_loss = (
+            sum(self._train_loss_history) / len(self._train_loss_history)
+            if self._train_loss_history else 0.0
+        )
+        return MLXTrainOutput({
+            "train_loss": avg_loss,
+            "train_runtime": total_time,
+            "train_steps": self._global_step,
+            "total_train_steps": total_steps,
+        })

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4285,6 +4285,31 @@ class MLXKTOTrainer(MLXTrainer):
                 "Set lora_plus_ratio=0 to run KTO."
             )
 
+        # The KTO loop does not yet implement checkpoint resume, an eval loop,
+        # or distributed gradient averaging. Each of these is silently ignored
+        # by the standalone loop below, so reject them loudly rather than return
+        # a result that looks trained but ignored the caller's request. (These
+        # can be added later by mirroring MLXTrainer's paths.)
+        if resume_from_checkpoint is not None:
+            raise ValueError(
+                "Unsloth: MLXKTOTrainer does not support resume_from_checkpoint "
+                "yet; a resumed call would restart from scratch and overwrite "
+                "the output adapters. Start a fresh run instead."
+            )
+        if self.eval_dataset is not None:
+            raise ValueError(
+                "Unsloth: MLXKTOTrainer does not run an eval loop yet, so "
+                "eval_dataset / eval_steps / load_best_model_at_end are ignored. "
+                "Remove eval_dataset to run KTO, or evaluate separately."
+            )
+        if self.distributed_world_size > 1:
+            raise ValueError(
+                "Unsloth: MLXKTOTrainer does not support MLX distributed "
+                "training yet; it neither shards KTO batches nor averages "
+                "gradients across ranks, so each rank would train independently. "
+                "Run KTO on a single process."
+            )
+
         batches = _build_kto_batches(self.train_dataset, self.tokenizer, args)
         if not batches:
             raise ValueError(

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4274,6 +4274,17 @@ class MLXKTOTrainer(MLXTrainer):
                 "adapter-disabled forward (there is no separate reference copy)."
             )
 
+        # LoRA+ needs per-leaf gradient scaling (a higher LR on lora_b), which
+        # the base trainer weaves into its update path but this KTO loop does
+        # not implement. Rather than silently train lora_b at the wrong LR,
+        # reject the option loudly; KTO LoRA+ can be added later.
+        if float(getattr(args, "lora_plus_ratio", 0.0) or 0.0) > 0:
+            raise ValueError(
+                "Unsloth: MLXKTOTrainer does not support lora_plus_ratio yet "
+                "(LoRA+ per-leaf scaling is unimplemented on the KTO path). "
+                "Set lora_plus_ratio=0 to run KTO."
+            )
+
         batches = _build_kto_batches(self.train_dataset, self.tokenizer, args)
         if not batches:
             raise ValueError(
@@ -4281,15 +4292,16 @@ class MLXKTOTrainer(MLXTrainer):
                 "non-empty completions per batch)."
             )
 
-        # total_steps counts optimizer steps. When max_steps is unset, one pass
-        # over the data is len(batches) // grad_accum optimizer steps (matching
-        # MLXTrainer); at least 1 so a run with fewer batches than grad_accum
-        # still takes a (short) step.
+        # total_steps counts optimizer steps. When max_steps is unset it is
+        # num_train_epochs passes over the data // grad_accum (matching
+        # MLXTrainer, which multiplies by num_train_epochs); at least 1 so a run
+        # with fewer batches than grad_accum still takes a (short) step.
         grad_accum = max(int(args.gradient_accumulation_steps), 1)
         if args.max_steps and args.max_steps > 0:
             total_steps = args.max_steps
         else:
-            total_steps = max(len(batches) // grad_accum, 1)
+            epochs = max(int(getattr(args, "num_train_epochs", 1) or 1), 1)
+            total_steps = max((len(batches) * epochs) // grad_accum, 1)
         optimizer = self._build_optimizer(total_steps)
         (max_grad_norm, max_grad_value, max_grad_leaf_norm,
          _clip_mode) = _resolve_mlx_grad_clipping(args)
@@ -4373,6 +4385,11 @@ class MLXKTOTrainer(MLXTrainer):
                     continue
 
                 grad = acc_grad
+                # Install this step's scheduled LR before the decay helpers:
+                # _apply_manual_weight_decay reads optimizer.learning_rate, so
+                # setting the LR afterwards would decouple decay using the
+                # previous step's LR (the base trainer sets the LR first).
+                self._set_optimizer_lr_for_step(optimizer, step)
                 if max_grad_norm > 0:
                     grad, _ = _clip_grad_norm_fp32(grad, max_norm=max_grad_norm)
                 if max_grad_value is not None and max_grad_value > 0:
@@ -4381,7 +4398,6 @@ class MLXKTOTrainer(MLXTrainer):
                     grad = _clip_grad_by_leaf_norm(grad, max_grad_leaf_norm)
                 grad = self._apply_coupled_weight_decay(model, grad)
                 self._apply_manual_weight_decay(model, optimizer, grad)
-                self._set_optimizer_lr_for_step(optimizer, step)
                 optimizer.update(model, grad)
                 mx.eval(model.parameters(), optimizer.state)
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4358,6 +4358,19 @@ class MLXKTOTrainer(MLXTrainer):
         # SFT: the KTO loss is a per-example preference objective, not a
         # per-token mean, so each micro-batch contributes equally. grad_accum is
         # resolved above (it also sets total_steps).
+
+        # Enter training mode so training-gated modules (e.g. LoRA dropout) are
+        # active, in case the model was left in eval mode by a prior
+        # generation/evaluation. The reference forward disables adapters by
+        # scale, not by eval mode, so this does not affect it.
+        model.train()
+        # Reset per-run metric state so re-running the same trainer instance
+        # does not average this run's loss/KL against the previous run's
+        # (train() reports the mean over _train_loss_history).
+        self._train_loss_history = []
+        self._kl_history = []
+        self._global_step = 0
+
         step = 0
         micro = 0            # micro-batches accumulated in the current window
         acc_grad = None      # running mean of the window's gradients

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8288,6 +8288,22 @@ def _build_kto_batches(dataset, tokenizer, args):
     +1 within the batch), and label (list[bool]). Rolling within the batch keeps
     the KL y' set equal to the reward y set for that batch (TRL _get_kl_dataset).
     """
+    # KTO needs the full row set materialized to form mismatched-pair KL batches
+    # (completions are rolled +1 within each batch), so a streaming/IterableDataset
+    # would be exhausted up front rather than yielding bounded batches. Reject it
+    # loudly instead of silently consuming it, mirroring the ORPO/DPO streaming
+    # guard. Detect both the config flag and a bare iterable-without-__len__
+    # (HF IterableDataset / generator) passed directly.
+    if getattr(args, "streaming", False) or (
+        hasattr(dataset, "__iter__") and not hasattr(dataset, "__len__")
+    ):
+        raise NotImplementedError(
+            "Unsloth: MLXKTOTrainer does not support streaming datasets yet. "
+            "_build_kto_batches materializes the whole dataset to form the "
+            "mismatched-pair KL batches, so a streaming / IterableDataset is fully "
+            "consumed before training instead of yielding bounded batches. Use a "
+            "finite (map-style) dataset, or disable streaming."
+        )
     bs = int(args.per_device_train_batch_size)
     if bs < 2:
         raise ValueError(

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8446,6 +8446,30 @@ class MLXKTOTrainer(MLXTrainer):
                 "adapter-disabled forward (there is no separate reference copy)."
             )
 
+        # KTO is a text-LoRA-only path: it does NOT replicate the base trainer's
+        # architecture setup (patch_gated_delta) or its VLM batch/forward handling.
+        # Both unsupported cases already hard-fail, so this is UX clarity, not a
+        # correctness fix -- reject up front with a clear message instead of a
+        # cryptic downstream crash:
+        #  - gated-delta (Qwen3.5 / Qwen3-Next): the backward fails with
+        #    "[Primitive::vjp] Not implemented for CustomKernel" (no VJP patch).
+        #  - VLM: the processor has no pad_token_id (batch build) and the model
+        #    returns LanguageModelOutput, not raw logits (forward).
+        if model_has_gated_delta_layers(model):
+            raise NotImplementedError(
+                "Unsloth: MLXKTOTrainer does not support gated-delta models "
+                "(e.g. Qwen3.5 / Qwen3-Next) yet: the KTO loop bypasses the base "
+                "trainer's patch_gated_delta setup, so the backward fails with a "
+                "missing custom-kernel VJP. Use a non-gated-delta model for KTO."
+            )
+        if hasattr(self.tokenizer, "image_processor"):
+            raise NotImplementedError(
+                "Unsloth: MLXKTOTrainer is text-LoRA only and does not support "
+                "vision-language models yet (the VLM processor has no pad_token_id "
+                "and the model returns structured outputs, not raw logits). Use a "
+                "text model + tokenizer for KTO."
+            )
+
         # LoRA+ needs per-leaf gradient scaling (a higher LR on lora_b), which
         # the base trainer weaves into its update path but this KTO loop does
         # not implement. Rather than silently train lora_b at the wrong LR,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8622,9 +8622,10 @@ class MLXKTOTrainer(MLXTrainer):
 
         step = 0
         micro = 0            # micro-batches accumulated in the current window
-        acc_grad = None      # running mean of the window's gradients
-        acc_loss = 0.0       # running mean of the window's losses
-        acc_kl = 0.0         # running mean of the window's KL diagnostics
+        acc_grad = None      # running SUM of example-weighted window gradients
+        acc_loss = 0.0       # running SUM of example-weighted window losses
+        acc_kl = 0.0         # running SUM of example-weighted KL diagnostics
+        acc_n = 0            # total examples (rows) accumulated in the window
         stop = False
         max_epochs = 1_000_000
         for _epoch in range(max_epochs):
@@ -8654,16 +8655,23 @@ class MLXKTOTrainer(MLXTrainer):
 
                 loss, grad = nn.value_and_grad(model, loss_fn)(model)
 
-                # Accumulate the mean gradient. Dividing each micro-batch by
-                # grad_accum before summing keeps the accumulator at update
-                # scale; sum(g_i / N) == mean(g_i).
-                contrib = tree_map(lambda g: g / grad_accum, grad)
+                # Example-count weighting. _kto_loss is a mean over the batch's
+                # rows, so a grad-accum window that mixes batches of different
+                # sizes (e.g. a full batch plus the trailing size-2 batch) must
+                # weight each micro-batch by its row count and normalize by the
+                # window total -- equal weighting would over-weight the smaller
+                # batch. This mirrors the pair/example-count accumulation Daniel
+                # adopted for ORPO/DPO/GRPO (the weight the loss averaged over is
+                # what makes accumulate-then-normalize match the single-batch mean).
+                n_i = len(labels)
+                contrib = tree_map(lambda g: g * n_i, grad)
                 if acc_grad is None:
                     acc_grad = contrib
                 else:
                     acc_grad = tree_map(lambda a, g: a + g, acc_grad, contrib)
-                acc_loss += float(loss) / grad_accum
-                acc_kl += float(kl_scalar) / grad_accum
+                acc_loss += float(loss) * n_i
+                acc_kl += float(kl_scalar) * n_i
+                acc_n += n_i
                 micro += 1
                 if micro < grad_accum:
                     # Materialize the running accumulator so the autograd graph
@@ -8671,7 +8679,10 @@ class MLXKTOTrainer(MLXTrainer):
                     mx.eval(acc_grad)
                     continue
 
-                grad = acc_grad
+                # Normalize the window by its total example count.
+                grad = tree_map(lambda g: g / acc_n, acc_grad)
+                mean_loss = acc_loss / acc_n
+                mean_kl = acc_kl / acc_n
                 # Install this step's scheduled LR before the decay helpers:
                 # _apply_manual_weight_decay reads optimizer.learning_rate, so
                 # setting the LR afterwards would decouple decay using the
@@ -8688,9 +8699,9 @@ class MLXKTOTrainer(MLXTrainer):
                 optimizer.update(model, grad)
                 mx.eval(model.parameters(), optimizer.state)
 
-                train_loss = acc_loss
+                train_loss = mean_loss
                 self._train_loss_history.append(train_loss)
-                self._kl_history.append(acc_kl)
+                self._kl_history.append(mean_kl)
                 self._global_step = step + 1
                 # Gate on the ONE-based step (step is a 0-based counter here), so
                 # logging_steps=N logs at steps N, 2N, ... like MLXTrainer -- not
@@ -8698,13 +8709,14 @@ class MLXKTOTrainer(MLXTrainer):
                 if args.logging_steps and ((step + 1) % max(int(args.logging_steps), 1) == 0):
                     print(
                         f"Unsloth KTO: step {step + 1}/{total_steps} "
-                        f"loss={train_loss:.4f} kl={acc_kl:.4f} "
+                        f"loss={train_loss:.4f} kl={mean_kl:.4f} "
                         f"(desirable={len(chosen_idx)} undesirable={len(rejected_idx)})"
                     )
                 step += 1
                 acc_grad = None
                 acc_loss = 0.0
                 acc_kl = 0.0
+                acc_n = 0
                 micro = 0
 
         # Honor the documented save_steps=0 contract (save at end of training),

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8243,6 +8243,35 @@ def _kto_tokenize_row(tokenizer, prompt, completion, args):
     return p, c
 
 
+def _kto_parse_label(value):
+    """Coerce a KTO desirable/undesirable label to bool, parsing string forms.
+
+    KTO data often arrives from CSV, where the binary label is a STRING. Plain
+    ``bool()`` is wrong there: ``bool("false")`` and ``bool("0")`` are both True
+    (any non-empty string is truthy), so every undesirable row would silently
+    flip to desirable. Accept real bools/ints/floats as-is and parse the common
+    string spellings; reject anything ambiguous rather than guess.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        s = value.strip().lower()
+        if s in ("true", "1", "1.0", "yes", "y", "desirable"):
+            return True
+        if s in ("false", "0", "0.0", "no", "n", "undesirable", ""):
+            return False
+        raise ValueError(
+            f"Unsloth: KTO label {value!r} is not a recognized boolean. Use "
+            "True/False (or 1/0, 'true'/'false', 'yes'/'no')."
+        )
+    raise ValueError(
+        f"Unsloth: KTO label must be bool, int, float or str; got "
+        f"{type(value).__name__}."
+    )
+
+
 def _build_kto_batches(dataset, tokenizer, args):
     """Build unpaired KTO batches with the mismatched-pair KL variant.
 
@@ -8279,7 +8308,7 @@ def _build_kto_batches(dataset, tokenizer, args):
         p, c = _kto_tokenize_row(tokenizer, ex["prompt"], ex["completion"], args)
         if len(c) == 0:
             continue  # nothing to score
-        rows.append((p, c, bool(ex["label"])))
+        rows.append((p, c, _kto_parse_label(ex["label"])))
 
     batches = []
     dropped = 0

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8692,7 +8692,10 @@ class MLXKTOTrainer(MLXTrainer):
                 self._train_loss_history.append(train_loss)
                 self._kl_history.append(acc_kl)
                 self._global_step = step + 1
-                if args.logging_steps and (step % max(int(args.logging_steps), 1) == 0):
+                # Gate on the ONE-based step (step is a 0-based counter here), so
+                # logging_steps=N logs at steps N, 2N, ... like MLXTrainer -- not
+                # 1, N+1, ... (the old zero-based test).
+                if args.logging_steps and ((step + 1) % max(int(args.logging_steps), 1) == 0):
                     print(
                         f"Unsloth KTO: step {step + 1}/{total_steps} "
                         f"loss={train_loss:.4f} kl={acc_kl:.4f} "

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8237,9 +8237,17 @@ def _kto_tokenize_row(tokenizer, prompt, completion, args):
     if args.max_prompt_length and args.max_prompt_length > 0:
         p = p[-args.max_prompt_length:]
     if args.max_length and args.max_length > 0 and len(p) + len(c) > args.max_length:
-        # Keep the whole completion; trim the prompt from the left.
-        keep = max(args.max_length - len(c), 0)
-        p = p[-keep:] if keep > 0 else []
+        # Keep the completion, trim the prompt from the left. If the completion
+        # alone meets or exceeds max_length there is no room for the prompt AND
+        # the completion itself must be capped to max_length -- otherwise
+        # (with max_completion_length unset) the returned sequence would exceed
+        # max_length. Keep the leading completion tokens.
+        keep = args.max_length - len(c)
+        if keep > 0:
+            p = p[-keep:]
+        else:
+            p = []
+            c = c[:args.max_length]
     return p, c
 
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8155,10 +8155,16 @@ def train_on_responses_only(
 # ============================================================================
 
 
-@dataclass
+@dataclass(init=False)
 class MLXKTOConfig(MLXTrainingConfig):
     """KTO configuration mirroring TRL's KTOConfig field names, on top of the
-    shared MLX training knobs (optimizer, schedule, clipping, save)."""
+    shared MLX training knobs (optimizer, schedule, clipping, save).
+
+    init=False (not a bare @dataclass) so the subclass inherits
+    MLXTrainingConfig.__init__ rather than a generated one that would bypass the
+    parent's setup (e.g. the warmup-steps-explicit initialization). Mirrors
+    #830's MLXORPOConfig/MLXDPOConfig. fields() still registers the KTO-specific
+    fields below, which the inherited __init__ reads via fields(type(self))."""
 
     beta: float = 0.1
     desirable_weight: float = 1.0

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8231,23 +8231,43 @@ def _kto_tokenize_row(tokenizer, prompt, completion, args):
     length exceeds max_length, matching TRL's keep-completion policy."""
     p = tokenizer(prompt, add_special_tokens=False)["input_ids"]
     c = tokenizer(completion, add_special_tokens=False)["input_ids"]
+    # Ensure the completion ends with EOS so the model learns to terminate
+    # (TRL's add_eos_token_if_needed); tokenizing with add_special_tokens=False
+    # never adds one. Gated on the inherited append_eos flag, guarded against a
+    # double EOS and a tokenizer with no eos_token.
+    _eos = getattr(tokenizer, "eos_token_id", None)
+    _want_eos = bool(getattr(args, "append_eos", True)) and _eos is not None
+    _has_eos = bool(c) and c[-1] == _eos
+    if _want_eos and not _has_eos:
+        c = list(c) + [_eos]
+        _has_eos = True
+
+    def _cap_completion(seq, limit):
+        # Truncate the completion to `limit`, PRESERVING a trailing EOS. This
+        # deviates from TRL (which truncates then appends, dropping the EOS when
+        # the completion is over-length): here the termination signal is kept by
+        # trimming to limit-1 and re-appending the EOS.
+        if limit <= 0:
+            return seq[:0]
+        if _want_eos and _has_eos and len(seq) > limit:
+            return seq[:limit - 1] + [_eos]
+        return seq[:limit]
+
     max_completion = args.max_completion_length
     if max_completion is not None and max_completion > 0:
-        c = c[:max_completion]
+        c = _cap_completion(c, max_completion)
     if args.max_prompt_length and args.max_prompt_length > 0:
         p = p[-args.max_prompt_length:]
     if args.max_length and args.max_length > 0 and len(p) + len(c) > args.max_length:
         # Keep the completion, trim the prompt from the left. If the completion
         # alone meets or exceeds max_length there is no room for the prompt AND
-        # the completion itself must be capped to max_length -- otherwise
-        # (with max_completion_length unset) the returned sequence would exceed
-        # max_length. Keep the leading completion tokens.
+        # the completion itself must be capped to max_length (EOS preserved).
         keep = args.max_length - len(c)
         if keep > 0:
             p = p[-keep:]
         else:
             p = []
-            c = c[:args.max_length]
+            c = _cap_completion(c, args.max_length)
     return p, c
 
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -526,6 +526,7 @@ from .utils import (
     load_trainer_state,
     collect_mlx_lora_adapter_tensors,
     iter_mlx_lora_modules,
+    _is_base_tensor_inside_lora_module,
     apply_gradient_checkpointing,
     remove_gradient_checkpointing,
     _is_vlm_model,
@@ -8378,6 +8379,34 @@ def _build_kto_batches(dataset, tokenizer, args):
     return batches
 
 
+def _kto_model_has_non_lora_trainable_params(model):
+    """True when the model has trainable tensors outside any LoRA module.
+
+    KTO's reference is the adapter-off (LoRA scale=0) forward of the SAME model,
+    so a trainable non-LoRA tensor (a directly-trained lm_head/embed_tokens, or a
+    trainable non-LoRA bias) moves during training and leaves the reference
+    carrying trained weights -- not the frozen initial policy.
+
+    Mirrors #832's utils.model_has_non_lora_trainable_params verbatim; kept local
+    here to avoid depending on that unmerged branch (consolidate onto the shared
+    helper once #832 lands on main).
+    """
+    trainable = dict(tree_flatten(model.trainable_parameters()))
+    if not trainable:
+        return False
+    adapter_tensors = collect_mlx_lora_adapter_tensors(model)
+    lora_module_names = [name for name, _ in iter_mlx_lora_modules(model)]
+    lora_module_prefixes = tuple(f"{name}." for name in lora_module_names if name)
+    has_root_lora_module = any(name == "" for name in lora_module_names)
+    return any(
+        key not in adapter_tensors
+        and not _is_base_tensor_inside_lora_module(
+            key, lora_module_prefixes, has_root_lora_module,
+        )
+        for key in trainable
+    )
+
+
 class MLXKTOTrainer(MLXTrainer):
     """MLX-native KTO trainer, mirroring TRL's KTOTrainer constructor API.
 
@@ -8468,6 +8497,24 @@ class MLXKTOTrainer(MLXTrainer):
                 "vision-language models yet (the VLM processor has no pad_token_id "
                 "and the model returns structured outputs, not raw logits). Use a "
                 "text model + tokenizer for KTO."
+            )
+
+        # The KTO reference is the adapter-off (LoRA scale=0) forward of the SAME
+        # model, so any trainable non-LoRA tensor (a directly-trained
+        # lm_head/embed_tokens, a non-LoRA bias) would move during training and
+        # leave the "reference" carrying trained weights -- corrupting the KTO
+        # signal. Unlike DPO/GRPO there is no reference_free escape in KTO: the
+        # adapter-off reference is structural, so this is a hard requirement, not
+        # a togglable option. (Mirrors #832's referenced-DPO/GRPO guard.)
+        if _kto_model_has_non_lora_trainable_params(model):
+            raise ValueError(
+                "Unsloth: MLXKTOTrainer requires ALL trainable parameters to be "
+                "LoRA adapters. A trainable non-LoRA tensor (e.g. a directly "
+                "trained lm_head/embed_tokens) would drift during training and "
+                "corrupt the adapter-off KTO reference. This is a structural limit "
+                "of KTO's reference (there is no reference_free mode), not a "
+                "togglable option -- train only LoRA adapters, e.g. via "
+                "FastMLXModel.get_peft_model(...) without unfreezing base weights."
             )
 
         # LoRA+ needs per-leaf gradient scaling (a higher LR on lora_b), which

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8391,6 +8391,17 @@ class MLXKTOTrainer(MLXTrainer):
                 f"{_loss_type!r}). Other TRL KTO variants are not implemented on "
                 "the MLX KTO path. Set loss_type='kto'."
             )
+        # KTO's reference is the adapter-disabled (LoRA scale=0) forward of the
+        # same model -- there is no separate reference copy. A caller porting
+        # from TRL's KTOTrainer(ref_model=...) would otherwise have it silently
+        # swallowed by **kwargs and ignored. Reject it loudly.
+        if kwargs.get("ref_model") is not None:
+            raise ValueError(
+                "Unsloth: MLXKTOTrainer does not take a separate ref_model. The "
+                "KTO reference is the adapter-disabled (LoRA scale=0) forward of "
+                "the policy model, so a passed ref_model would be ignored. Remove "
+                "ref_model."
+            )
         self._is_vlm = False
         # Raw KTO rows: do NOT wrap in the SFT tokenized dataset view.
         self.train_dataset = train_dataset

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -8380,6 +8380,17 @@ class MLXKTOTrainer(MLXTrainer):
                 f"{type(self.args).__name__}). Use MLXKTOConfig for beta / "
                 "desirable_weight / undesirable_weight."
             )
+        # Only the standard KTO loss is implemented. The training path always
+        # calls _kto_loss and never reads args.loss_type, so any other value
+        # (e.g. TRL's 'apo_zero_unpaired') would be silently ignored and run
+        # plain KTO. Reject it rather than mistrain against the caller's request.
+        _loss_type = getattr(self.args, "loss_type", "kto")
+        if _loss_type != "kto":
+            raise ValueError(
+                "Unsloth: MLXKTOTrainer only implements loss_type='kto' (got "
+                f"{_loss_type!r}). Other TRL KTO variants are not implemented on "
+                "the MLX KTO path. Set loss_type='kto'."
+            )
         self._is_vlm = False
         # Raw KTO rows: do NOT wrap in the SFT tokenized dataset view.
         self.train_dataset = train_dataset


### PR DESCRIPTION
## Summary
 
Adds KTO preference tuning to the MLX path on Apple Silicon, mirroring TRL's `KTOTrainer` (`loss_type="kto"`, Eqn 7 of [arXiv:2402.01306](https://arxiv.org/abs/2402.01306)).
 
The selling point is the data. KTO trains on **unpaired** examples — a single completion per row with a binary desirable/undesirable label — instead of the chosen/rejected pairs DPO and ORPO require. Binary-labelled completions are far cheaper to collect than matched preference pairs (any "was this output good or bad?" signal works: thumbs up/down, task success/failure, filters), which makes KTO the practical choice when you don't have paired data. This is the first unpaired preference method on the MLX trainer.
 
## What's included
 
- **`MLXKTOTrainer` / `MLXKTOConfig`** — standalone trainer + config mirroring TRL's API, reusing `MLXTrainer`'s optimizer / schedule / gradient-clip / weight-decay helpers. The SFT compile/accumulate loop is left completely untouched.
- **Unpaired batch builder** with the mismatched-pair KL variant (completions rolled +1 within the batch, matching TRL's `_get_kl_dataset`), the summed-logp extractor (`_kto_sum_logp`), the clamped batch KL baseline (`_kto_kl_baseline`), and the KTO loss (`_kto_loss`).
- **Reference model = the LoRA-disabled forward** (adapter scale=0), so no second model copy. Reference and KL forwards are `stop_gradient`'d; adapter scales are restored in a `finally` so a throwing forward can't leave the model adapter-disabled.
- **Fail-loud guards:** `per_device_train_batch_size < 2` raises (the mismatched-pair roll would self-pair and collapse the KL term to the reward); a non-PEFT model raises (no reference forward without adapters).
## Correctness evidence
 
`_kto_loss` matches both numpy and a torch reimplementation of TRL's `kto_loss` to ~1e-8, across three weight settings:
 
| (desirable_weight, undesirable_weight) | loss |
|---|---|
| (1.0, 1.0) | 0.47720963 |
| (1.33, 1.0) | 0.56631130 |
| (1.0, 1.5) | 0.58081198 |
 
- KL baseline matches TRL exactly (**0.31288**), including the `clamp(min=0)` branch (raw negative estimate → 0.0).
- `_kto_sum_logp` vs numpy log-softmax reference: max|Δ| = **7e-07**.
- Real Qwen2.5-0.5B 4-bit + LoRA: deterministic across reruns; 336 LoRA leaves all finite and nonzero; trains **0.4997 → 0.2146** over 8 steps.
## Tests
 
- **`tests/test_mlx_kto_loss.py`** — pure-logic, runs under the torch shim in normal CI (no Metal needed): loss vs numpy and vs the pinned TRL values, the KL clamp branch, single-label (all-desirable / all-undesirable) batches, and the `batch_size < 2` guard. 5 passed.
- **`tests/test_mlx_kto_train_metal.py`** — Metal-gated e2e (skips cleanly off Apple Silicon): finite & decreasing loss, LoRA-scale restoration including the scales-restored-when-a-forward-throws `finally` path, the non-PEFT fail-loud error, and `_kto_sum_logp` vs numpy. 5 passed.
- Canonical MLX baseline: **128 passed, 0 failures**.
<sub>(The `_kto_sum_logp` numeric check lives in the Metal file rather than the shim file — its `.astype(mx.float32)` resolves a real mlx dtype under the torch shim's pytest import order; it runs against real MLX instead. A code comment explains this in place.)</sub>
 
## Limitations (please read — not buried)
 
- **LoRA-only.** The reference is the adapter-off forward, so full-finetune KTO is not supported and raises a clear error rather than silently running reference-free.
- **Not `mx.compile`'d.** The KTO step runs eager with 4 forwards/step (policy, policy-KL, reference, reference-KL). Correct and verified, but slower per step than the compiled SFT path. The blocker is structural: the LoRA-disable reference mutates module scale state, which under `mx.compile` would execute at trace time only and freeze the traced scale. Threading scale as a compiled input is a plausible follow-up, but it needs its own benchmark — compiling 1 of 4 forwards may not pay for the added risk.
- **Within-batch KL roll vs TRL's global roll — affects reproducibility, not the optimization.** TRL builds the KL set by rolling the whole dataset; this rolls completions +1 within each batch, so boundary examples pair with a different mismatched completion than a specific TRL run would. This changes the exact per-batch KL scalar (and thus bit-exact reproducibility against a given TRL run), but not the training method: the KL baseline is a detached, clamped, batch-level scalar (no gradient flows through it — it only shifts the loss threshold), and both rolls estimate the same expectation over the batch's completions. The within-batch variant in fact satisfies TRL's own documented "best results" condition (the mismatched y′ set equals the reward y set for that batch) more cleanly. This is a mechanism-based claim from the loss structure; I have **not** run a head-to-head TRL-vs-MLX training comparison to measure end-task parity.
- **`kl = 0` is expected often.** The raw mismatched-pair estimate is frequently negative early in training and gets clamped to 0. This is TRL-faithful, not a bug (verified: the LoRA is active in the KL forward; the raw estimate was e.g. −4.82 → clamped).