### PR TITLE
Fix silent expert-weight transposition in MoE preprocess_weight

### DIFF
--- a/tests/test_moe_preprocess_weight_transpose.py
+++ b/tests/test_moe_preprocess_weight_transpose.py
@@ -150,11 +150,37 @@ def test_orientation_primitive_returns_none_on_square():
     assert _orientation_needs_transpose((4, 16, 64), "down", 64) is False     # (E, I, H)
 
 
-def test_logical_expert_shape_prefers_original_shape():
+def test_logical_expert_shape_prefers_original_shape_after_linear_unwrap():
     class _PackedParam:
         # bnb Params4bit-like: .shape is packed, _original_shape is logical.
         shape = (2048, 1)
         _original_shape = (4, 128, 64)
 
+    class _QuantLinear:
+        # bnb Linear4bit-like: the logical shape lives on its Params4bit weight.
+        weight = _PackedParam()
+
     assert _logical_expert_shape(_PackedParam()) == (4, 128, 64)
+    assert _logical_expert_shape(_QuantLinear()) == (4, 128, 64)
     assert _logical_expert_shape(torch.randn(4, 128, 64)) == (4, 128, 64)
+
+
+def test_square_grouped_weight_preserved_via_paramwrapper_sibling():
+    class _ParamWrapper:
+        """PEFT-like wrapper whose base_layer is the experts module, not the parameter."""
+
+        def __init__(self, base_layer, param):
+            self.base_layer = base_layer
+            self._param = param
+
+        def get_param(self):
+            return self._param
+
+    E, H, I = 4, 64, 32
+    _gu_f, _dn_f, gu_g, dn_g = _make_flinear_experts(E, H, I)
+    experts = _FakeExperts(gu_g, dn_g)
+    experts.down_proj = _ParamWrapper(experts, dn_g)
+
+    assert _logical_expert_shape(experts.down_proj) == tuple(dn_g.shape)
+    out = preprocess_weight(gu_g, "gate_up", H, experts_module=experts)
+    assert torch.equal(out, gu_g), "a grouped square weight must not be transposed"

--- a/tests/test_moe_preprocess_weight_transpose.py
+++ b/tests/test_moe_preprocess_weight_transpose.py
@@ -14,19 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Regression tests for preprocess_weight layout inference (unslothai/unsloth-zoo#849).
-
-MoE gate_up experts are stored F.linear (E, 2I, H) and must become grouped_mm layout
-(E, H, 2I); down is (E, H, I) -> (E, I, H). The layout was inferred from shape alone,
-which is ambiguous when the two matmul dims are equal (2*moe_intermediate == hidden_size
-for gate_up, or moe_intermediate == hidden_size for down): the tensor is square, the check
-guessed "already correct", and every expert silently trained on transposed weights.
-
-These tests drive that square branch and assert preprocess_weight recovers the correct
-grouped_mm layout by voting with the guaranteed-non-square sibling projection. CPU-only,
-no CUDA — the reporter proved UNSLOTH_MOE_BACKEND=native_torch is bit-exact on CPU, so an
-exact-equality check against the reference grouped layout is a faithful oracle.
-"""
+"""Regression tests for MoE expert weight layout inference (#849)."""
 
 import torch
 import pytest
@@ -39,8 +27,7 @@ from unsloth_zoo.temporary_patches.moe_utils import (
 
 
 class _FakeExperts:
-    """Minimal stand-in for a transformers MoE experts module: exposes the two fused
-    expert weights as plain tensors, which is all the sibling-vote needs to read a shape."""
+    """Minimal fused experts module."""
 
     def __init__(self, gate_up_proj=None, down_proj=None, num_experts=4):
         if gate_up_proj is not None:
@@ -51,11 +38,7 @@ class _FakeExperts:
 
 
 def _make_flinear_experts(num_experts, hidden, inter, seed=0):
-    """Build reference F.linear-layout expert weights and their correct grouped_mm targets.
-
-    F.linear:  gate_up (E, 2I, H), down (E, H, I)
-    grouped_mm: gate_up (E, H, 2I), down (E, I, H)
-    """
+    """Return F.linear weights and grouped_mm transposes."""
     g = torch.Generator().manual_seed(seed)
     gate_up_flinear = torch.randn(num_experts, 2 * inter, hidden, generator=g)
     down_flinear = torch.randn(num_experts, hidden, inter, generator=g)
@@ -64,10 +47,8 @@ def _make_flinear_experts(num_experts, hidden, inter, seed=0):
     return gate_up_flinear, down_flinear, gate_up_grouped, down_grouped
 
 
-# --- 1. Non-square control: fast path must be byte-identical to the historical behaviour ---
-
 def test_nonsquare_gate_up_and_down_unchanged():
-    E, H, I = 4, 64, 16  # 2I=32 != H=64, and I=16 != H=64 -> both non-square
+    E, H, I = 4, 64, 16
     gu_f, dn_f, gu_g, dn_g = _make_flinear_experts(E, H, I)
     experts = _FakeExperts(gu_f, dn_f)
 
@@ -76,32 +57,26 @@ def test_nonsquare_gate_up_and_down_unchanged():
     assert torch.equal(out_gu, gu_g)
     assert torch.equal(out_dn, dn_g)
 
-    # Non-square inputs already in grouped layout are returned untouched (idempotent).
     assert torch.equal(preprocess_weight(gu_g, "gate_up", H, experts_module=experts), gu_g)
     assert torch.equal(preprocess_weight(dn_g, "down", H, experts_module=experts), dn_g)
 
 
-# --- 2. Square gate_up (2I == H): the #849 bug. Sibling `down` is non-square and decides. ---
-
 def test_square_gate_up_transposed_via_down_sibling():
-    E, H, I = 4, 64, 32  # 2I == H == 64 -> gate_up is square; down (64, 32) is not
+    E, H, I = 4, 64, 32
     gu_f, dn_f, gu_g, dn_g = _make_flinear_experts(E, H, I)
-    assert gu_f.shape[1] == gu_f.shape[2]  # confirm we're driving the ambiguous branch
+    assert gu_f.shape[1] == gu_f.shape[2]
     experts = _FakeExperts(gu_f, dn_f)
 
     out_gu = preprocess_weight(gu_f, "gate_up", H, experts_module=experts)
     assert torch.equal(out_gu, gu_g), "square gate_up must be transposed to grouped layout"
-    # And already-grouped square input stays put (sibling reports grouped orientation).
     experts_g = _FakeExperts(gu_g, dn_g)
     assert torch.equal(preprocess_weight(gu_g, "gate_up", H, experts_module=experts_g), gu_g)
 
 
-# --- 3. Square down (I == H): sibling `gate_up` is non-square and decides. ---
-
 def test_square_down_transposed_via_gate_up_sibling():
-    E, H, I = 4, 64, 64  # I == H == 64 -> down is square; gate_up (128, 64) is not
+    E, H, I = 4, 64, 64
     gu_f, dn_f, gu_g, dn_g = _make_flinear_experts(E, H, I)
-    assert dn_f.shape[1] == dn_f.shape[2]  # confirm ambiguous branch
+    assert dn_f.shape[1] == dn_f.shape[2]
     experts = _FakeExperts(gu_f, dn_f)
 
     out_dn = preprocess_weight(dn_f, "down", H, experts_module=experts)
@@ -110,20 +85,16 @@ def test_square_down_transposed_via_gate_up_sibling():
     assert torch.equal(preprocess_weight(dn_g, "down", H, experts_module=experts_g), dn_g)
 
 
-# --- 4. Square input, no sibling reachable: warn + transpose (F.linear default). ---
-
 def test_square_without_module_warns_and_transposes(capsys):
     E, H, I = 4, 64, 32
     gu_f, _dn_f, gu_g, _dn_g = _make_flinear_experts(E, H, I)
 
-    out = preprocess_weight(gu_f, "gate_up", H)  # no experts_module
+    out = preprocess_weight(gu_f, "gate_up", H)
     assert torch.equal(out, gu_g)
     err = capsys.readouterr().err
     assert "#849" in err and "ambiguous" in err.lower()
-    assert "register_weight_preprocessor" in err  # tells the user how to remove the guess
+    assert "register_weight_preprocessor" in err
 
-
-# --- 5. Escape hatch still wins: a registered preprocessor bypasses shape inference entirely. ---
 
 def test_registered_preprocessor_takes_precedence():
     from unsloth_zoo.temporary_patches import moe_utils
@@ -138,26 +109,23 @@ def test_registered_preprocessor_takes_precedence():
         moe_utils._WEIGHT_PREPROCESSORS.pop(key, None)
 
 
-# --- Unit coverage for the orientation primitive and the cheap shape reader. ---
-
 def test_orientation_primitive_returns_none_on_square():
     assert _orientation_needs_transpose((4, 64, 64), "gate_up", 64) is None
     assert _orientation_needs_transpose((4, 64, 64), "down", 64) is None
-    # F.linear (transpose) vs grouped (keep), non-square:
-    assert _orientation_needs_transpose((4, 32, 64), "gate_up", 64) is True   # (E, 2I, H)
-    assert _orientation_needs_transpose((4, 64, 32), "gate_up", 64) is False  # (E, H, 2I)
-    assert _orientation_needs_transpose((4, 64, 16), "down", 64) is True      # (E, H, I)
-    assert _orientation_needs_transpose((4, 16, 64), "down", 64) is False     # (E, I, H)
+    assert _orientation_needs_transpose((4, 32, 64), "gate_up", 64) is True
+    assert _orientation_needs_transpose((4, 64, 32), "gate_up", 64) is False
+    assert _orientation_needs_transpose((4, 64, 16), "down", 64) is True
+    assert _orientation_needs_transpose((4, 16, 64), "down", 64) is False
 
 
 def test_logical_expert_shape_prefers_original_shape_after_linear_unwrap():
     class _PackedParam:
-        # bnb Params4bit-like: .shape is packed, _original_shape is logical.
+        # Physical shape is packed; logical shape is recorded separately.
         shape = (2048, 1)
         _original_shape = (4, 128, 64)
 
     class _QuantLinear:
-        # bnb Linear4bit-like: the logical shape lives on its Params4bit weight.
+        # Linear4bit stores Params4bit on .weight.
         weight = _PackedParam()
 
     assert _logical_expert_shape(_PackedParam()) == (4, 128, 64)
@@ -167,7 +135,7 @@ def test_logical_expert_shape_prefers_original_shape_after_linear_unwrap():
 
 def test_square_grouped_weight_preserved_via_paramwrapper_sibling():
     class _ParamWrapper:
-        """PEFT-like wrapper whose base_layer is the experts module, not the parameter."""
+        """PEFT-like target-parameter wrapper."""
 
         def __init__(self, base_layer, param):
             self.base_layer = base_layer

--- a/tests/test_moe_preprocess_weight_transpose.py
+++ b/tests/test_moe_preprocess_weight_transpose.py
@@ -1,0 +1,160 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for preprocess_weight layout inference (unslothai/unsloth-zoo#849).
+
+MoE gate_up experts are stored F.linear (E, 2I, H) and must become grouped_mm layout
+(E, H, 2I); down is (E, H, I) -> (E, I, H). The layout was inferred from shape alone,
+which is ambiguous when the two matmul dims are equal (2*moe_intermediate == hidden_size
+for gate_up, or moe_intermediate == hidden_size for down): the tensor is square, the check
+guessed "already correct", and every expert silently trained on transposed weights.
+
+These tests drive that square branch and assert preprocess_weight recovers the correct
+grouped_mm layout by voting with the guaranteed-non-square sibling projection. CPU-only,
+no CUDA — the reporter proved UNSLOTH_MOE_BACKEND=native_torch is bit-exact on CPU, so an
+exact-equality check against the reference grouped layout is a faithful oracle.
+"""
+
+import torch
+import pytest
+
+from unsloth_zoo.temporary_patches.moe_utils import (
+    preprocess_weight,
+    _orientation_needs_transpose,
+    _logical_expert_shape,
+)
+
+
+class _FakeExperts:
+    """Minimal stand-in for a transformers MoE experts module: exposes the two fused
+    expert weights as plain tensors, which is all the sibling-vote needs to read a shape."""
+
+    def __init__(self, gate_up_proj=None, down_proj=None, num_experts=4):
+        if gate_up_proj is not None:
+            self.gate_up_proj = gate_up_proj
+        if down_proj is not None:
+            self.down_proj = down_proj
+        self.num_experts = num_experts
+
+
+def _make_flinear_experts(num_experts, hidden, inter, seed=0):
+    """Build reference F.linear-layout expert weights and their correct grouped_mm targets.
+
+    F.linear:  gate_up (E, 2I, H), down (E, H, I)
+    grouped_mm: gate_up (E, H, 2I), down (E, I, H)
+    """
+    g = torch.Generator().manual_seed(seed)
+    gate_up_flinear = torch.randn(num_experts, 2 * inter, hidden, generator=g)
+    down_flinear = torch.randn(num_experts, hidden, inter, generator=g)
+    gate_up_grouped = gate_up_flinear.transpose(-2, -1).contiguous()
+    down_grouped = down_flinear.transpose(-2, -1).contiguous()
+    return gate_up_flinear, down_flinear, gate_up_grouped, down_grouped
+
+
+# --- 1. Non-square control: fast path must be byte-identical to the historical behaviour ---
+
+def test_nonsquare_gate_up_and_down_unchanged():
+    E, H, I = 4, 64, 16  # 2I=32 != H=64, and I=16 != H=64 -> both non-square
+    gu_f, dn_f, gu_g, dn_g = _make_flinear_experts(E, H, I)
+    experts = _FakeExperts(gu_f, dn_f)
+
+    out_gu = preprocess_weight(gu_f, "gate_up", H, experts_module=experts)
+    out_dn = preprocess_weight(dn_f, "down", H, experts_module=experts)
+    assert torch.equal(out_gu, gu_g)
+    assert torch.equal(out_dn, dn_g)
+
+    # Non-square inputs already in grouped layout are returned untouched (idempotent).
+    assert torch.equal(preprocess_weight(gu_g, "gate_up", H, experts_module=experts), gu_g)
+    assert torch.equal(preprocess_weight(dn_g, "down", H, experts_module=experts), dn_g)
+
+
+# --- 2. Square gate_up (2I == H): the #849 bug. Sibling `down` is non-square and decides. ---
+
+def test_square_gate_up_transposed_via_down_sibling():
+    E, H, I = 4, 64, 32  # 2I == H == 64 -> gate_up is square; down (64, 32) is not
+    gu_f, dn_f, gu_g, dn_g = _make_flinear_experts(E, H, I)
+    assert gu_f.shape[1] == gu_f.shape[2]  # confirm we're driving the ambiguous branch
+    experts = _FakeExperts(gu_f, dn_f)
+
+    out_gu = preprocess_weight(gu_f, "gate_up", H, experts_module=experts)
+    assert torch.equal(out_gu, gu_g), "square gate_up must be transposed to grouped layout"
+    # And already-grouped square input stays put (sibling reports grouped orientation).
+    experts_g = _FakeExperts(gu_g, dn_g)
+    assert torch.equal(preprocess_weight(gu_g, "gate_up", H, experts_module=experts_g), gu_g)
+
+
+# --- 3. Square down (I == H): sibling `gate_up` is non-square and decides. ---
+
+def test_square_down_transposed_via_gate_up_sibling():
+    E, H, I = 4, 64, 64  # I == H == 64 -> down is square; gate_up (128, 64) is not
+    gu_f, dn_f, gu_g, dn_g = _make_flinear_experts(E, H, I)
+    assert dn_f.shape[1] == dn_f.shape[2]  # confirm ambiguous branch
+    experts = _FakeExperts(gu_f, dn_f)
+
+    out_dn = preprocess_weight(dn_f, "down", H, experts_module=experts)
+    assert torch.equal(out_dn, dn_g), "square down must be transposed to grouped layout"
+    experts_g = _FakeExperts(gu_g, dn_g)
+    assert torch.equal(preprocess_weight(dn_g, "down", H, experts_module=experts_g), dn_g)
+
+
+# --- 4. Square input, no sibling reachable: warn + transpose (F.linear default). ---
+
+def test_square_without_module_warns_and_transposes(capsys):
+    E, H, I = 4, 64, 32
+    gu_f, _dn_f, gu_g, _dn_g = _make_flinear_experts(E, H, I)
+
+    out = preprocess_weight(gu_f, "gate_up", H)  # no experts_module
+    assert torch.equal(out, gu_g)
+    err = capsys.readouterr().err
+    assert "#849" in err and "ambiguous" in err.lower()
+    assert "register_weight_preprocessor" in err  # tells the user how to remove the guess
+
+
+# --- 5. Escape hatch still wins: a registered preprocessor bypasses shape inference entirely. ---
+
+def test_registered_preprocessor_takes_precedence():
+    from unsloth_zoo.temporary_patches import moe_utils
+
+    sentinel = torch.zeros(1)
+    key = "unit_test_dummy_arch"
+    moe_utils.register_weight_preprocessor(key, lambda w, p, h: sentinel)
+    try:
+        out = preprocess_weight(torch.randn(4, 64, 64), "gate_up", 64, model_type=key)
+        assert out is sentinel
+    finally:
+        moe_utils._WEIGHT_PREPROCESSORS.pop(key, None)
+
+
+# --- Unit coverage for the orientation primitive and the cheap shape reader. ---
+
+def test_orientation_primitive_returns_none_on_square():
+    assert _orientation_needs_transpose((4, 64, 64), "gate_up", 64) is None
+    assert _orientation_needs_transpose((4, 64, 64), "down", 64) is None
+    # F.linear (transpose) vs grouped (keep), non-square:
+    assert _orientation_needs_transpose((4, 32, 64), "gate_up", 64) is True   # (E, 2I, H)
+    assert _orientation_needs_transpose((4, 64, 32), "gate_up", 64) is False  # (E, H, 2I)
+    assert _orientation_needs_transpose((4, 64, 16), "down", 64) is True      # (E, H, I)
+    assert _orientation_needs_transpose((4, 16, 64), "down", 64) is False     # (E, I, H)
+
+
+def test_logical_expert_shape_prefers_original_shape():
+    class _PackedParam:
+        # bnb Params4bit-like: .shape is packed, _original_shape is logical.
+        shape = (2048, 1)
+        _original_shape = (4, 128, 64)
+
+    assert _logical_expert_shape(_PackedParam()) == (4, 128, 64)
+    assert _logical_expert_shape(torch.randn(4, 128, 64)) == (4, 128, 64)

--- a/tests/test_moe_preprocess_weight_transpose.py
+++ b/tests/test_moe_preprocess_weight_transpose.py
@@ -152,3 +152,14 @@ def test_square_grouped_weight_preserved_via_paramwrapper_sibling():
     assert _logical_expert_shape(experts.down_proj) == tuple(dn_g.shape)
     out = preprocess_weight(gu_g, "gate_up", H, experts_module=experts)
     assert torch.equal(out, gu_g), "a grouped square weight must not be transposed"
+
+
+def test_logical_expert_shape_reads_shape_3d_without_materializing():
+    class _Provider:
+        # ParameterModule-like: shape_3d is recorded; get_param would build a full tensor.
+        shape_3d = (4, 64, 128)
+
+        def get_param(self):
+            raise AssertionError("get_param must not run when shape_3d is recorded")
+
+    assert _logical_expert_shape(_Provider()) == (4, 64, 128)

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -887,13 +887,10 @@ def get_weight_preprocessor(model_type: str):
 
 
 def _logical_expert_shape(param):
-    """Best-effort logical (E, d1, d2) shape of an expert weight without dequantizing.
+    """Return the logical expert shape without dequantizing.
 
-    Resolve PEFT ParamWrappers before walking ordinary module wrappers: their base_layer
-    points back to the experts module, while get_param() returns the underlying parameter.
-    A bnb Params4bit's .shape is the packed uint8 layout, so prefer its recorded
-    _original_shape. Returns None if the logical shape can't be determined cheaply (caller
-    degrades gracefully).
+    Resolve PEFT parameters before module wrappers. Packed bnb weights record their
+    logical shape in _original_shape.
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
@@ -916,7 +913,7 @@ def _logical_expert_shape(param):
             param = base_layer
             continue
 
-        # Linear-like modules (including bnb Linear4bit) store the parameter in .weight.
+        # Linear modules store parameters on .weight.
         weight = getattr(param, "weight", None)
         if weight is not None and weight is not param:
             param = weight
@@ -937,24 +934,18 @@ def _logical_expert_shape(param):
 
 
 def _orientation_needs_transpose(shape, proj_type, hidden_dim):
-    """Whether an expert weight is stored F.linear (needs transpose to grouped_mm layout).
-
-    Returns True (stored F.linear -> transpose), False (already grouped_mm layout), or
-    None when the two matmul dims are equal so the shape carries no layout signal.
-    """
+    """Return whether a weight needs transposition, or None when ambiguous."""
     # This Unsloth Zoo code section is licensed under AGPL3
 
     if shape is None or len(shape) < 3:
         return None
     d1, d2 = int(shape[1]), int(shape[2])
     if d1 == d2:
-        return None  # square: ambiguous, shape reveals nothing
+        return None
     if proj_type == "gate_up":
-        # grouped_mm (E, hidden_dim, 2*intermediate) has shape[1] == hidden_dim;
-        # F.linear (E, 2*intermediate, hidden_dim) does not.
+        # grouped_mm uses (E, hidden, 2I).
         return d1 != hidden_dim
-    # down: grouped_mm (E, intermediate, hidden_dim) has shape[2] == hidden_dim;
-    # F.linear (E, hidden_dim, intermediate) does not.
+    # grouped_mm down uses (E, I, hidden).
     return d2 != hidden_dim
 
 
@@ -968,15 +959,14 @@ def _warn_ambiguous_layout_once(proj_type, shape, hidden_dim):
     if key in _WARNED_AMBIGUOUS_LAYOUTS:
         return
     _WARNED_AMBIGUOUS_LAYOUTS.add(key)
-    # Not gated behind UNSLOTH_ENABLE_LOGGING: a wrong guess here silently corrupts
-    # training (unslothai/unsloth-zoo#849), so it must always be visible.
+    # Always warn because a wrong guess corrupts training (#849).
     print(
         f"Unsloth: MoE '{proj_type}' expert weight of shape {tuple(shape)} has equal matmul "
         f"dims (hidden_dim={hidden_dim}), so its layout is ambiguous, and no unambiguous "
         f"sibling projection was reachable to disambiguate it. Assuming the transformers "
         f"F.linear layout and transposing to grouped_mm layout. If these experts were "
         f"already in grouped_mm layout this transpose is WRONG and trains on transposed "
-        f"weights (see unslothai/unsloth-zoo#849) — register an explicit preprocessor via "
+        f"weights (see unslothai/unsloth-zoo#849). Register an explicit preprocessor via "
         f"register_weight_preprocessor('<model_type>', ...) to remove the guess.",
         file=sys.stderr,
     )
@@ -986,29 +976,21 @@ def preprocess_weight(
     weight: torch.Tensor, proj_type: str, hidden_dim: int, model_type=None,
     experts_module=None,
 ):
-    """Preprocess a weight into (E, in_dim, out_dim) for grouped_mm.
+    """Convert an expert weight to grouped_mm layout.
 
-    Uses a registered model-specific preprocessor if present, else infers the layout by
-    shape. proj_type is "gate_up" or "down". When the two matmul dims are equal
-    (2*moe_intermediate == hidden_size for gate_up, or moe_intermediate == hidden_size for
-    down) shape alone is ambiguous; passing experts_module lets the guaranteed-non-square
-    sibling projection resolve the layout instead of silently guessing (#849).
+    Registered preprocessors take precedence. Square weights use the non-square sibling.
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
     if model_type and model_type in _WEIGHT_PREPROCESSORS:
         return _WEIGHT_PREPROCESSORS[model_type](weight, proj_type, hidden_dim)
 
-    # Non-ambiguous fast path (behaviour-identical to the historical shape check): the two
-    # matmul dims differ, so shape alone reveals the layout.
+    # Non-square shapes reveal layout directly.
     needs_transpose = _orientation_needs_transpose(tuple(weight.shape), proj_type, hidden_dim)
     if needs_transpose is not None:
         return weight.transpose(-2, -1) if needs_transpose else weight
 
-    # Ambiguous square case. The pair {gate_up, down} can never be square at once
-    # (2I == H forces down (H, I) non-square; I == H forces gate_up (2I, H) non-square), so
-    # the sibling projection unambiguously reveals the module-wide layout. Same principle as
-    # transformers#47031.
+    # One sibling is always non-square and reveals the shared layout.
     if experts_module is not None:
         sibling_name = "down_proj" if proj_type == "gate_up" else "gate_up_proj"
         sibling_type = "down" if proj_type == "gate_up" else "gate_up"
@@ -1020,8 +1002,7 @@ def preprocess_weight(
             if sibling_transpose is not None:
                 return weight.transpose(-2, -1) if sibling_transpose else weight
 
-    # No unambiguous sibling reachable: assume the F.linear layout that loaded transformers
-    # modules always hold, and warn loudly so a wrong guess is diagnosable rather than silent.
+    # Default to F.linear when no sibling is readable.
     _warn_ambiguous_layout_once(proj_type, weight.shape, hidden_dim)
     return weight.transpose(-2, -1)
 

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -889,22 +889,44 @@ def get_weight_preprocessor(model_type: str):
 def _logical_expert_shape(param):
     """Best-effort logical (E, d1, d2) shape of an expert weight without dequantizing.
 
-    Mirrors _get_base_weight's unwrap order but reads shape only. A bnb Params4bit's
-    .shape is the packed uint8 layout, so prefer its recorded _original_shape. Returns
-    None if the logical shape can't be determined cheaply (caller degrades gracefully).
+    Resolve PEFT ParamWrappers before walking ordinary module wrappers: their base_layer
+    points back to the experts module, while get_param() returns the underlying parameter.
+    A bnb Params4bit's .shape is the packed uint8 layout, so prefer its recorded
+    _original_shape. Returns None if the logical shape can't be determined cheaply (caller
+    degrades gracefully).
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
-    while hasattr(param, "base_layer"):
-        param = param.base_layer
+    seen = set()
+    while param is not None and id(param) not in seen:
+        seen.add(id(param))
+
+        get_param = getattr(param, "get_param", None)
+        if callable(get_param):
+            try:
+                inner = get_param()
+            except Exception:
+                inner = None
+            if inner is not None and inner is not param:
+                param = inner
+                continue
+
+        base_layer = getattr(param, "base_layer", None)
+        if base_layer is not None and base_layer is not param:
+            param = base_layer
+            continue
+
+        # Linear-like modules (including bnb Linear4bit) store the parameter in .weight.
+        weight = getattr(param, "weight", None)
+        if weight is not None and weight is not param:
+            param = weight
+            continue
+
+        break
+
     original_shape = getattr(param, "_original_shape", None)
     if original_shape is not None:
         return tuple(int(x) for x in original_shape)
-    # Plain Parameters / Linear layers expose the logical shape directly; only unwrap a
-    # `.weight` container (a Linear-like module), not a `get_param` provider we'd rather
-    # not materialize.
-    if not hasattr(param, "get_param") and hasattr(param, "weight"):
-        param = param.weight
     shape = getattr(param, "shape", None)
     if shape is None:
         return None

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -886,31 +886,122 @@ def get_weight_preprocessor(model_type: str):
     return _WEIGHT_PREPROCESSORS.get(model_type)
 
 
+def _logical_expert_shape(param):
+    """Best-effort logical (E, d1, d2) shape of an expert weight without dequantizing.
+
+    Mirrors _get_base_weight's unwrap order but reads shape only. A bnb Params4bit's
+    .shape is the packed uint8 layout, so prefer its recorded _original_shape. Returns
+    None if the logical shape can't be determined cheaply (caller degrades gracefully).
+    """
+    # This Unsloth Zoo code section is licensed under AGPL3
+
+    while hasattr(param, "base_layer"):
+        param = param.base_layer
+    original_shape = getattr(param, "_original_shape", None)
+    if original_shape is not None:
+        return tuple(int(x) for x in original_shape)
+    # Plain Parameters / Linear layers expose the logical shape directly; only unwrap a
+    # `.weight` container (a Linear-like module), not a `get_param` provider we'd rather
+    # not materialize.
+    if not hasattr(param, "get_param") and hasattr(param, "weight"):
+        param = param.weight
+    shape = getattr(param, "shape", None)
+    if shape is None:
+        return None
+    try:
+        return tuple(int(x) for x in shape)
+    except TypeError:
+        return None
+
+
+def _orientation_needs_transpose(shape, proj_type, hidden_dim):
+    """Whether an expert weight is stored F.linear (needs transpose to grouped_mm layout).
+
+    Returns True (stored F.linear -> transpose), False (already grouped_mm layout), or
+    None when the two matmul dims are equal so the shape carries no layout signal.
+    """
+    # This Unsloth Zoo code section is licensed under AGPL3
+
+    if shape is None or len(shape) < 3:
+        return None
+    d1, d2 = int(shape[1]), int(shape[2])
+    if d1 == d2:
+        return None  # square: ambiguous, shape reveals nothing
+    if proj_type == "gate_up":
+        # grouped_mm (E, hidden_dim, 2*intermediate) has shape[1] == hidden_dim;
+        # F.linear (E, 2*intermediate, hidden_dim) does not.
+        return d1 != hidden_dim
+    # down: grouped_mm (E, intermediate, hidden_dim) has shape[2] == hidden_dim;
+    # F.linear (E, hidden_dim, intermediate) does not.
+    return d2 != hidden_dim
+
+
+_WARNED_AMBIGUOUS_LAYOUTS = set()
+
+
+def _warn_ambiguous_layout_once(proj_type, shape, hidden_dim):
+    # This Unsloth Zoo code section is licensed under AGPL3
+
+    key = (proj_type, tuple(shape), hidden_dim)
+    if key in _WARNED_AMBIGUOUS_LAYOUTS:
+        return
+    _WARNED_AMBIGUOUS_LAYOUTS.add(key)
+    # Not gated behind UNSLOTH_ENABLE_LOGGING: a wrong guess here silently corrupts
+    # training (unslothai/unsloth-zoo#849), so it must always be visible.
+    print(
+        f"Unsloth: MoE '{proj_type}' expert weight of shape {tuple(shape)} has equal matmul "
+        f"dims (hidden_dim={hidden_dim}), so its layout is ambiguous, and no unambiguous "
+        f"sibling projection was reachable to disambiguate it. Assuming the transformers "
+        f"F.linear layout and transposing to grouped_mm layout. If these experts were "
+        f"already in grouped_mm layout this transpose is WRONG and trains on transposed "
+        f"weights (see unslothai/unsloth-zoo#849) — register an explicit preprocessor via "
+        f"register_weight_preprocessor('<model_type>', ...) to remove the guess.",
+        file=sys.stderr,
+    )
+
+
 def preprocess_weight(
-    weight: torch.Tensor, proj_type: str, hidden_dim: int, model_type=None
+    weight: torch.Tensor, proj_type: str, hidden_dim: int, model_type=None,
+    experts_module=None,
 ):
     """Preprocess a weight into (E, in_dim, out_dim) for grouped_mm.
 
-    Uses a registered model-specific preprocessor if present, else transposes
-    by shape. proj_type is "gate_up" or "down".
+    Uses a registered model-specific preprocessor if present, else infers the layout by
+    shape. proj_type is "gate_up" or "down". When the two matmul dims are equal
+    (2*moe_intermediate == hidden_size for gate_up, or moe_intermediate == hidden_size for
+    down) shape alone is ambiguous; passing experts_module lets the guaranteed-non-square
+    sibling projection resolve the layout instead of silently guessing (#849).
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
     if model_type and model_type in _WEIGHT_PREPROCESSORS:
         return _WEIGHT_PREPROCESSORS[model_type](weight, proj_type, hidden_dim)
 
-    if proj_type == "gate_up":
-        # Want (E, hidden_dim, 2*intermediate).
-        if weight.shape[1] == hidden_dim:
-            return weight
-        else:
-            return weight.transpose(-2, -1)
-    else:  # down
-        # Want (E, intermediate, hidden_dim).
-        if weight.shape[2] == hidden_dim:
-            return weight
-        else:
-            return weight.transpose(-2, -1)
+    # Non-ambiguous fast path (behaviour-identical to the historical shape check): the two
+    # matmul dims differ, so shape alone reveals the layout.
+    needs_transpose = _orientation_needs_transpose(tuple(weight.shape), proj_type, hidden_dim)
+    if needs_transpose is not None:
+        return weight.transpose(-2, -1) if needs_transpose else weight
+
+    # Ambiguous square case. The pair {gate_up, down} can never be square at once
+    # (2I == H forces down (H, I) non-square; I == H forces gate_up (2I, H) non-square), so
+    # the sibling projection unambiguously reveals the module-wide layout. Same principle as
+    # transformers#47031.
+    if experts_module is not None:
+        sibling_name = "down_proj" if proj_type == "gate_up" else "gate_up_proj"
+        sibling_type = "down" if proj_type == "gate_up" else "gate_up"
+        sibling = getattr(experts_module, sibling_name, None)
+        if sibling is not None:
+            sibling_transpose = _orientation_needs_transpose(
+                _logical_expert_shape(sibling), sibling_type, hidden_dim,
+            )
+            if sibling_transpose is not None:
+                return weight.transpose(-2, -1) if sibling_transpose else weight
+
+    # No unambiguous sibling reachable: assume the F.linear layout that loaded transformers
+    # modules always hold, and warn loudly so a wrong guess is diagnosable rather than silent.
+    _warn_ambiguous_layout_once(proj_type, weight.shape, hidden_dim)
+    return weight.transpose(-2, -1)
 
 
 # Generic MoE detection and ParamWrapper patching.
@@ -1307,8 +1398,8 @@ def forward_native_grouped_mm(
 
         # Provider re-derives the base weight on demand so Fix 3 can recompute it in
         # backward instead of pinning it (grouped_mm needs contiguous weights).
-        def _gate_up_provider(_src=_gate_up_src, _mt=model_type, _h=hidden_dim, _dt=hidden_states.dtype):
-            return preprocess_weight(_get_base_weight(_src, _dt), "gate_up", _h, _mt)
+        def _gate_up_provider(_src=_gate_up_src, _mt=model_type, _h=hidden_dim, _dt=hidden_states.dtype, _mod=self):
+            return preprocess_weight(_get_base_weight(_src, _dt), "gate_up", _h, _mt, experts_module=_mod)
         mm1_out = _base_grouped_mm(
             permuted_input, offsets, _gate_up_provider, _moe_recompute_enabled(_gate_up_src),
         )
@@ -1477,8 +1568,8 @@ def forward_native_grouped_mm(
     if hasattr(self, "down_proj"):
         model_type = getattr(self, "_unsloth_model_type", None)
         _down_src = self.down_proj
-        def _down_provider(_src=_down_src, _mt=model_type, _h=hidden_dim, _dt=hidden_states.dtype):
-            return preprocess_weight(_get_base_weight(_src, _dt), "down", _h, _mt)
+        def _down_provider(_src=_down_src, _mt=model_type, _h=hidden_dim, _dt=hidden_states.dtype, _mod=self):
+            return preprocess_weight(_get_base_weight(_src, _dt), "down", _h, _mt, experts_module=_mod)
         mm2_out = _base_grouped_mm(
             inter, offsets, _down_provider, _moe_recompute_enabled(_down_src),
         )

--- a/unsloth_zoo/temporary_patches/moe_utils.py
+++ b/unsloth_zoo/temporary_patches/moe_utils.py
@@ -887,16 +887,24 @@ def get_weight_preprocessor(model_type: str):
 
 
 def _logical_expert_shape(param):
-    """Return the logical expert shape without dequantizing.
+    """Return the logical expert shape without dequantizing or materializing.
 
-    Resolve PEFT parameters before module wrappers. Packed bnb weights record their
-    logical shape in _original_shape.
+    Resolve PEFT parameters before module wrappers. A recorded logical shape (bnb
+    Params4bit _original_shape, ParameterModule shape_3d) is read directly so a
+    get_param provider is never materialized just to read its shape.
     """
     # This Unsloth Zoo code section is licensed under AGPL3
 
     seen = set()
     while param is not None and id(param) not in seen:
         seen.add(id(param))
+
+        # Recorded logical shape avoids materializing a get_param provider.
+        recorded = getattr(param, "_original_shape", None)
+        if recorded is None:
+            recorded = getattr(param, "shape_3d", None)
+        if recorded is not None:
+            return tuple(int(x) for x in recorded)
 
         get_param = getattr(param, "get_param", None)
         if callable(get_param):
@@ -921,9 +929,6 @@ def _logical_expert_shape(param):
 
         break
 
-    original_shape = getattr(param, "_original_shape", None)
-    if original_shape is not None:
-        return tuple(int(x) for x in original_shape)
     shape = getattr(param, "shape", None)
     if shape is None:
         return None

--- a/unsloth_zoo/temporary_patches/moe_utils_fp8.py
+++ b/unsloth_zoo/temporary_patches/moe_utils_fp8.py
@@ -431,7 +431,7 @@ def _prepare_scaled_grouped_mm_weight(experts_module, param_name: str, proj_type
     weight, quant_state, quant_kind = _get_moe_weight_and_quant_info(experts_module, param_name)
     if not _is_float8_tensor(weight):
         return None
-    processed_weight = preprocess_weight(weight, proj_type, hidden_dim, model_type)
+    processed_weight = preprocess_weight(weight, proj_type, hidden_dim, model_type, experts_module=experts_module)
     processed_weight = _make_grouped_mm_rhs_column_major(processed_weight)
     scale = _extract_scaled_grouped_mm_weight_scale(weight, processed_weight, quant_state, quant_kind)
     if scale is None:


### PR DESCRIPTION
# Fix silent expert-weight transposition in MoE `preprocess_weight`

## Summary

- Disambiguate square expert weights using the guaranteed non-square sibling projection.
- Pass the experts module through grouped MM and FP8 preprocessing paths.
- Resolve PEFT target parameters with `get_param()` before walking `base_layer` wrappers.
- Read bitsandbytes logical `_original_shape` after unwrapping a linear module's `.weight`.
- Warn and default to the transformers `F.linear` layout when no readable sibling exists.

## Root cause

Shape-only inference cannot distinguish `F.linear` and grouped MM layouts when an expert weight is square. The first shape helper also inspected wrapper objects before reaching the underlying PEFT or bitsandbytes parameter, so valid sibling layout information could be lost.

Within a fused experts module, `gate_up` and `down` cannot both be square. The non-square sibling therefore identifies the shared storage layout without dequantizing the weights.

## Behavior

- Non-square weights keep the existing fast path.
- Square `gate_up` and `down` weights use the sibling projection to select the correct orientation.
- PEFT target-parameter wrappers and bitsandbytes `Linear4bit` containers preserve their logical shapes.
- Model-specific preprocessors still take precedence.

## Validation

- `tests/test_moe_preprocess_weight_transpose.py`: 8 passed.
- Real PEFT 0.18 `ParamWrapper` shape resolution passed.
- Python compile check passed.
- Targeted ruff check passed.
- The reporter's CUDA harness confirmed parity for square `gate_up`, square `down`, 4-bit, and non-square cases.

Thanks to @pjordanandrsn for the diagnosis and CUDA validation.

Fixes #849
