### PR TITLE
Replace standalone Studio wording with Unsloth

### DIFF
--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -3,7 +3,7 @@
 
 # Whole-repo Python source-lint gate. Adapted from unsloth's lint-ci.yml:
 # Python (compileall + narrow ruff) + YAML/JSON round-trip. Dropped vs unsloth:
-# shell lint (zoo has no committed *.sh), TypeScript/Rust (Studio/Tauri are unsloth-side).
+# shell lint (zoo has no committed *.sh), TypeScript/Rust (Unsloth/Tauri are unsloth-side).
 
 name: Lint CI
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -2,7 +2,7 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
 # Pure-Python supply-chain audit for unsloth_zoo. Mirrors unslothai/unsloth's
-# security-audit.yml with npm/Cargo/Studio jobs stripped (zoo is pure Python).
+# security-audit.yml with npm/Cargo/Unsloth jobs stripped (zoo is pure Python).
 # Jobs: advisory-audit (pip-audit + trufflehog), pip-scan-packages (transitive
 # closure pattern scan), workflow-trigger-lint, tests-security (HARD GATE).
 

--- a/tests/mlx_simulation/mlx_vlm_stub.py
+++ b/tests/mlx_simulation/mlx_vlm_stub.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Unsloth Zoo - Utilities for Unsloth
-# mlx_vlm stub — Studio inference + permissive submodules for 40+ VLM archs
+# mlx_vlm stub — Unsloth inference + permissive submodules for 40+ VLM archs
 """
 mlx_vlm — Vision Language Model wrapper.
 
@@ -44,7 +44,7 @@ def generate_step(*args, **kwargs):
 def load(*args, **kwargs):
     raise NotImplementedError(
         "mlx-shim: mlx_vlm.load not implemented; PR-B's tests assert this is "
-        "NOT called by Studio. If you hit this, Studio dispatch is broken."
+        "NOT called by Unsloth. If you hit this, Unsloth dispatch is broken."
     )
 
 

--- a/tests/test_mlx_module_exports.py
+++ b/tests/test_mlx_module_exports.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Verify every MLX-using unsloth_zoo module imports under the shim
-and exposes the symbols Studio integrations rely on.
+and exposes the symbols Unsloth integrations rely on.
 
 If a test fails with `_Noop` / NotImplementedError, the failing
 symbol identifies a TODO in mlx_simulation/.
@@ -52,7 +52,7 @@ def test_mlx_module_imports(module_path):
 
 
 # ---------------------------------------------------------------------------
-# 2. Studio backend contract: FastMLXModel and the dynamically-attached save methods
+# 2. Unsloth backend contract: FastMLXModel and the dynamically-attached save methods
 #    must be reachable.
 # ---------------------------------------------------------------------------
 
@@ -84,7 +84,7 @@ def test_full_finetune_dtype_default_matches_torch_bf16():
 
 
 def test_fast_mlx_model_save_helpers_exist():
-    """Studio backend calls model.save_pretrained_merged / save_lora_adapters /
+    """Unsloth backend calls model.save_pretrained_merged / save_lora_adapters /
     push_to_hub_merged on the FastMLXModel INSTANCE returned by
     FastMLXModel.from_pretrained.  The helpers are module-level in
     loader.py and attached via types.MethodType after load.
@@ -106,7 +106,7 @@ def test_trainer_classes():
         MLXTrainer,
         MLXTrainingConfig,
     )
-    # train_on_responses_only is the third symbol Studio backend imports
+    # train_on_responses_only is the third symbol Unsloth backend imports
     import unsloth_zoo.mlx.trainer as mt
     assert hasattr(mt, "train_on_responses_only") or hasattr(mt, "MLXTrainer")
 

--- a/tests/test_mlx_torch_shim_smoke.py
+++ b/tests/test_mlx_torch_shim_smoke.py
@@ -19,7 +19,7 @@ Smoke + Tier 1 + Tier 2 tests for the mlx_stub package.
 
 Verifies:
 1. simulate_mlx_on_torch() succeeds and registers all named submodules.
-2. Studio backend's 5 fresh symbols (mx.metal.is_available, set_wired_limit,
+2. Unsloth backend's 5 fresh symbols (mx.metal.is_available, set_wired_limit,
    device_info, clear_cache, synchronize) work as expected.
 3. The ~70 trivial passthroughs round-trip vs torch on random inputs.
 4. Sub-architecture VLM submodules auto-resolve via the MetaPathFinder.
@@ -99,7 +99,7 @@ def test_vlm_subarch_auto_resolve(submodule):
 
 
 # ---------------------------------------------------------------------------
-# 2. Tier 1: Studio backend fresh symbols.
+# 2. Tier 1: Unsloth backend fresh symbols.
 # ---------------------------------------------------------------------------
 
 def test_metal_is_available_returns_false():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -555,7 +555,7 @@ def test_scheduler_lr_matches_expected_optimizer_update_steps(scheduler, warmup)
 
 
 def test_mlx_text_dataset_does_not_append_eos(monkeypatch):
-    """Studio formatting owns EOS decisions; MLX batching must not add one."""
+    """Unsloth formatting owns EOS decisions; MLX batching must not add one."""
     import sys
 
     class CacheDataset:
@@ -586,7 +586,7 @@ def test_mlx_text_dataset_does_not_append_eos(monkeypatch):
             assert text == "hello"
             return [1, 2, 3]
 
-    # append_eos=False is what Studio passes (chat-template renders EOS).
+    # append_eos=False is what Unsloth passes (chat-template renders EOS).
     dataset = _prepare_dataset([{"text": "hello"}], Tokenizer(), append_eos=False)
     assert dataset[0] == ([1, 2, 3], 0)
 

--- a/tests/test_quantize_gguf_q2_k_l.py
+++ b/tests/test_quantize_gguf_q2_k_l.py
@@ -131,7 +131,7 @@ def test_q2_k_l_ffn_down_pattern_order_is_specific_first(monkeypatch):
 
 
 def test_q2_k_l_is_case_insensitive(monkeypatch):
-    """Studio frontend may send Q2_K_L / Q2_k_L / etc. Treat them identically."""
+    """Unsloth frontend may send Q2_K_L / Q2_k_L / etc. Treat them identically."""
 
     llama_cpp = _load_llama_cpp_module()
     captured = _install_fake_subprocess_run(monkeypatch, llama_cpp)

--- a/tests/test_rl_replacements_cpu.py
+++ b/tests/test_rl_replacements_cpu.py
@@ -200,7 +200,7 @@ def test_RL_REPLACEMENTS_values_are_callables_or_source_strings():
 
 
 def test_RL_REPLACEMENTS_contains_public_api_keys():
-    # The known-good keys that downstream unsloth + Studio code calls
+    # The known-good keys that downstream unsloth + Unsloth code calls
     # by name. If any of these go missing the consumer side breaks.
     expected = {
         "calculate_pad_tokens_in_prompt",

--- a/tests/test_zoo_history_regressions.py
+++ b/tests/test_zoo_history_regressions.py
@@ -152,7 +152,7 @@ def test_device_synchronize_tolerates_partial_backend():
 
 
 def test_device_type_module_has_expected_helpers():
-    """Pin the public API downstream zoo/unsloth/Studio code calls; a rename
+    """Pin the public API downstream zoo/unsloth/Unsloth code calls; a rename
     or removal here breaks consumers silently (AttributeError at train time)."""
     import unsloth_zoo.device_type as dt
 

--- a/unsloth_zoo/diffusion_studio/README.md
+++ b/unsloth_zoo/diffusion_studio/README.md
@@ -5,7 +5,7 @@ emitting tokens left to right, so llama.cpp serves it through a dedicated diffus
 the standard autoregressive `llama-server`. This package drives the optimized on-device visual decoder
 and exposes it as an OpenAI-compatible HTTP shim, so Unsloth Studio can serve DiffusionGemma as an
 ordinary llama.cpp model. The shim streams the committed answer text and a self-contained ```html
-artifact that replays the per-step denoising canvas; Studio auto-renders that for DiffusionGemma so you
+artifact that replays the per-step denoising canvas; Unsloth auto-renders that for DiffusionGemma so you
 watch the canvas resolve out of noise. It is an additive path - the autoregressive flow is untouched.
 
 ## What you need
@@ -36,7 +36,7 @@ python -m unsloth_zoo.diffusion_studio.shim \
 The binary also resolves from `DG_VISUAL_BIN` or from `PATH`. The model loads once; requests are
 serialized. It prints `... shim ready on http://127.0.0.1:8123`.
 
-## 2. Use it from Studio
+## 2. Use it from Unsloth
 
 Unsloth Studio detects a DiffusionGemma GGUF (`general.architecture = diffusion-gemma`) and launches this
 shim for it automatically, so selecting any quant of `unsloth/diffusiongemma-26B-A4B-it-GGUF` just works

--- a/unsloth_zoo/diffusion_studio/__init__.py
+++ b/unsloth_zoo/diffusion_studio/__init__.py
@@ -17,9 +17,9 @@
 
 DiffusionGemma is a block-diffusion model, so llama.cpp serves it through a dedicated diffusion runner
 rather than the autoregressive server. This package drives the optimized on-device visual decoder
-(llama-diffusion-gemma-visual-server) and wraps it in an OpenAI-compatible shim so Studio can serve it
+(llama-diffusion-gemma-visual-server) and wraps it in an OpenAI-compatible shim so Unsloth can serve it
 as an ordinary llama.cpp / OpenAI-compatible model. The shim streams the committed answer text and a
-self-contained ```html artifact that replays the per-step denoising canvas, which Studio auto-renders for
+self-contained ```html artifact that replays the per-step denoising canvas, which Unsloth auto-renders for
 DiffusionGemma. Autoregressive flows are untouched.
 
 The visual server tokenizes, applies the chat template and detokenizes from the GGUF's own embedded

--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -59,7 +59,7 @@ _LOCK = threading.Lock()
 
 
 def _close_server():
-    """Terminate the visual-server child so a parent exit (e.g. Studio's teardown) never leaves an
+    """Terminate the visual-server child so a parent exit (e.g. Unsloth's teardown) never leaves an
     orphaned GPU process. Idempotent. The child is also launched with PR_SET_PDEATHSIG (see
     visual_engine) so a hard kill of this process still reaps it."""
     srv = _STATE.pop("server", None)
@@ -138,7 +138,7 @@ def _timings_from_stats(stats):
     """Build a `timings` block from the server STATS summary. Returns (timings, prompt_n, completion_n).
 
     No autoregressive prefill exists, so we emit no prompt tok/s (the old one divided tokens by host
-    tokenize time and showed a meaningless ~14000). We report the diffusion CLI's two rates so Studio
+    tokenize time and showed a meaningless ~14000). We report the diffusion CLI's two rates so Unsloth
     matches the terminal: effective = canvas*blocks/wall (end-to-end, ~hundreds) and in-step parallel =
     canvas*steps/wall (the model's real per-step rate, ~thousands)."""
     def rate(n, ms):
@@ -163,7 +163,7 @@ def _timings_from_stats(stats):
         "predicted_ms": wall_ms,
         "predicted_per_second": par_tps,
         "cache_n": 0,
-        # Diffusion-specific breakdown (Studio shows these in a dedicated tooltip section).
+        # Diffusion-specific breakdown (Unsloth shows these in a dedicated tooltip section).
         "diffusion": True,
         "diffusion_blocks": blocks,
         "diffusion_steps": steps,
@@ -309,7 +309,7 @@ async def chat(req: Request):
         while True:
             kind, payload = await q.get()
             if kind == "frame":
-                # A valid (empty-delta) chunk plus a type tag: Studio routes on the tag, while a
+                # A valid (empty-delta) chunk plus a type tag: Unsloth routes on the tag, while a
                 # strict OpenAI client parses it as a no-op chunk and ignores the extra fields.
                 block, step, total, text = payload
                 yield _sse({**_chunk(cid, created, {}), "type": "diffusion_frame",
@@ -336,7 +336,7 @@ async def chat(req: Request):
                         art = _artifact(frames)
                         if art:
                             yield _sse(_chunk(cid, created, {"content": art}))
-                    # llama-server-style usage+timings chunk (empty choices) so Studio shows the
+                    # llama-server-style usage+timings chunk (empty choices) so Unsloth shows the
                     # stat tooltip plus the diffusion rows (steps, blocks).
                     timings, P, G = _timings_from_stats(stats_box)
                     yield _sse({"id": cid, "object": "chat.completion.chunk", "created": created,

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -21,7 +21,7 @@ Xet (``hf_xet``) is fast but can hang with no progress, no exception, and an un-
 thread) that sets the env before importing ``huggingface_hub``. Cached files short-circuit with no
 child; deterministic errors (401/403/404/disk-full) and cancellation propagate without a fallback.
 ``snapshot_download_with_xet_fallback`` warms a whole repo in a killable child before Unsloth's
-in-process load; ``hf_hub_download_with_xet_fallback`` does a single file. Studio cache / secret /
+in-process load; ``hf_hub_download_with_xet_fallback`` does a single file. Unsloth cache / secret /
 process helpers are used best-effort (imported only if present) or injected. The child sets
 ``UNSLOTH_ZOO_DISABLE_GPU_INIT=1`` for unsloth_zoo's lightweight import path (no torch / transformers).
 """
@@ -76,7 +76,7 @@ from unsloth_zoo.hf_cache_state import (
 
 logger = logging.getLogger(__name__)
 
-# Explicit list keeps stdlib imports out of Studio's `import *` re-export shim.
+# Explicit list keeps stdlib imports out of Unsloth's `import *` re-export shim.
 __all__ = [
     "DownloadStallError",
     "hf_hub_download_with_xet_fallback",
@@ -90,7 +90,7 @@ __all__ = [
 
 _CTX = mp.get_context("spawn")
 
-# Defaults match the existing Studio inference watchdog and hub shutdown deadline.
+# Defaults match the existing Unsloth inference watchdog and hub shutdown deadline.
 DEFAULT_HEARTBEAT_INTERVAL = 30.0
 DEFAULT_STALL_TIMEOUT = 180.0
 DEFAULT_GRACE_PERIOD = 10.0
@@ -123,7 +123,7 @@ def _safe_status(callback: Optional[Callable[[str], None]], message: str) -> Non
 
 
 class DownloadStallError(RuntimeError):
-    """Raised when no download progress is observed for too long. Studio re-imports this canonical type."""
+    """Raised when no download progress is observed for too long. Unsloth re-imports this canonical type."""
 
 
 def is_hf_xet_available() -> bool:
@@ -218,7 +218,7 @@ def _default_prepare_for_http(
     HTTP resume over a sparse Xet / hf_transfer partial silently corrupts the blob) and the broken
     snapshot symlinks the detector counts as active (else the retry inherits stale state and re-trips).
     ``iter_active_repo_cache_dirs`` is case-collision safe, so this destructive purge only touches an
-    unambiguous repo cache dir. Studio injects its marker-aware version instead.
+    unambiguous repo cache dir. Unsloth injects its marker-aware version instead.
 
     *owned_incomplete_blobs* (basenames the stalled child held open, captured before the kill) SCOPES the
     purge so a same-repo sibling writing a DIFFERENT blob is spared even if aged past *active_grace*;
@@ -464,7 +464,7 @@ def start_watchdog(
 
 
 def _scrub_in_child(text: str, token: Optional[str]) -> str:
-    """Redact secrets from a child error string, preferring Studio's patterns if present."""
+    """Redact secrets from a child error string, preferring Unsloth's patterns if present."""
     try:
         from hub.utils.download_registry import scrub_secrets  # type: ignore
 
@@ -669,7 +669,7 @@ def _download_child_entry(
     """Spawn-child entrypoint (top-level + picklable): set the Xet env BEFORE importing huggingface_hub,
     form its own process group so the parent can kill the whole transfer, never log token / signed
     URLs."""
-    # Die with the parent on Linux under Studio (best-effort; module absent standalone).
+    # Die with the parent on Linux under Unsloth (best-effort; module absent standalone).
     try:
         from utils.process_lifetime import bind_current_process_to_parent_lifetime  # type: ignore
 
@@ -870,7 +870,7 @@ def _run_download_attempt(
                 else:
                     main_module.__spec__ = saved_main_spec
 
-    # Bind the child to the parent lifetime when running under Studio (best-effort).
+    # Bind the child to the parent lifetime when running under Unsloth (best-effort).
     try:
         from utils.process_lifetime import adopt_pid  # type: ignore
 
@@ -1734,7 +1734,7 @@ def _download_with_xet_fallback(
         if disable_xet:
             # Purge a non-HTTP partial first (an HTTP resume over a sparse Xet/hf_transfer partial
             # silently corrupts the blob), scoped to the stalled child's own partials so a same-repo
-            # sibling is spared. An injected (Studio) hook keeps the plain (repo_type, repo_id) signature.
+            # sibling is spared. An injected (Unsloth) hook keeps the plain (repo_type, repo_id) signature.
             owned_incomplete = params.pop("_owned_incomplete_blobs", None)
             try:
                 if prepare_for_http_fn is None:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -602,13 +602,13 @@ class MLXTrainingConfig:
     gradient_checkpointing: bool = True
     streaming: bool = False  # Use streaming iterator instead of materializing batches
     dataset_order: str = "default"  # "default", "sequential", or "torch_randperm"
-    preserve_dataset_order: bool = False  # Match Studio CUDA SequentialSampler order
+    preserve_dataset_order: bool = False  # Match Unsloth CUDA SequentialSampler order
     memory_limit_gb: float | None = None  # None = auto Metal guard (~85% of recommended working set); <= 0 disables
     cache_limit_gb: float | None = None  # Optional MLX Metal cache cap in GB; <= 0 disables override
     wired_limit_gb: float | None = None  # None = min(recommended working set, memory limit); <= 0 disables
     disable_memory_limits: bool = False
     cast_norm_output_to_input_dtype: bool = True  # fp32 norm storage/math, bf16/fp16 downstream activations
-    append_eos: bool = True  # True = mlx-lm parity; Studio sets False (template owns EOS)
+    append_eos: bool = True  # True = mlx-lm parity; Unsloth sets False (template owns EOS)
 
     # VLM / completion masking
     train_on_completions: bool = False  # Mask prompt tokens in loss
@@ -1659,7 +1659,7 @@ class MLXTrainer:
 
     def _setup_report_to_callbacks(self):
         """Auto-register W&B / TensorBoard callbacks from report_to, mirroring
-        Studio worker.py log keys so notebook and Studio runs chart identically."""
+        Unsloth worker.py log keys so notebook and Unsloth runs chart identically."""
         raw = getattr(self.args, "report_to", "none")
         if not raw or raw == "none":
             return
@@ -2069,7 +2069,7 @@ class MLXTrainer:
 
         # Resume from checkpoint: load adapter weights, optimizer state,
         # and trainer state (step counter + loss history). Adapters were
-        # already loaded by the Studio worker into the model before train()
+        # already loaded by the Unsloth worker into the model before train()
         # was called, so we only handle optimizer and trainer state here.
         # The step offset is applied below at loop start so the LR scheduler
         # and dataloader fast-forward to the right position.
@@ -2084,7 +2084,7 @@ class MLXTrainer:
         if _resume_from:
             try:
                 # 1. Load trained adapter weights into the model. The model
-                #    already has LoRA wrappers applied (Studio pipeline does
+                #    already has LoRA wrappers applied (Unsloth pipeline does
                 #    get_peft_model before training); strict=False ensures
                 #    only the LoRA params match and base weights are untouched.
                 model.load_weights(
@@ -3485,7 +3485,7 @@ class MLXTrainer:
 
             # Keep intentionally-trained non-LoRA tensors OUTSIDE any LoRA
             # module; drop wrapped base weights INSIDE one (else q_proj.weight
-            # under a LoRA-wrapped q_proj re-leaks the Studio reload bug). Uses
+            # under a LoRA-wrapped q_proj re-leaks the Unsloth reload bug). Uses
             # the shared filter to match save_trainable_adapters / _merged.
             trainable = dict(tree_flatten(self.model.trainable_parameters()))
             adapter_keys = set(adapter_tensors)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -4536,7 +4536,7 @@ def _prepare_dataset(dataset, tokenizer, dataset_text_field="text",
     each encoded row. Default True preserves the pre-PR behavior that
     delegated EOS appending to ``mlx_lm.tuner.datasets.TextDataset`` for
     direct MLX text fine-tuning callers (raw ``{"text": str}`` rows
-    without already-rendered EOS). Studio passes False because its
+    without already-rendered EOS). Unsloth passes False because its
     chat-template rendering already includes EOS.
 
     Returns:
@@ -4583,7 +4583,7 @@ def _prepare_dataset(dataset, tokenizer, dataset_text_field="text",
 
     class _StudioTextDataset:
         """TextDataset variant. Optionally appends EOS (mlx-lm parity);
-        Studio passes append_eos=False because chat templates already render it."""
+        Unsloth passes append_eos=False because chat templates already render it."""
 
         def __init__(self, data, tokenizer, text_key="text", eos_id=None):
             self._data = data
@@ -4950,7 +4950,7 @@ def _torch_randperm_order(length, seed):
     except Exception as exc:
         raise ImportError(
             "Unsloth MLX: dataset_order='torch_randperm' requires torch so MLX "
-            "Studio can mirror CUDA Studio batch order."
+            "Unsloth can mirror CUDA Unsloth batch order."
         ) from exc
     generator = torch.Generator()
     generator.manual_seed(3407 if seed is None else int(seed))
@@ -4967,7 +4967,7 @@ def create_ordered_batches(dataset, tokenizer, batch_size, max_seq_length,
                            comm_group=None):
     """Create text batches with an explicit dataset order.
 
-    Studio uses this to mirror CUDA's effective sampler stream without
+    Unsloth uses this to mirror CUDA's effective sampler stream without
     changing generic mlx-lm batching behavior.
 
     In DDP, ``batch_size`` remains local to each rank. ``comm_group`` expands
@@ -5542,7 +5542,7 @@ def save_trainable_adapters(model, path, adapter_config=None):
 
     Includes all LoRA adapter tensors (frozen or not). Excludes wrapped
     base weights INSIDE a LoRA module (reload-leaked state that would
-    reintroduce the original Studio adapter-export bloat).
+    reintroduce the original Unsloth adapter-export bloat).
     """
     trainable = dict(mlx.utils.tree_flatten(model.trainable_parameters()))
     adapter_tensors = collect_mlx_lora_adapter_tensors(model)


### PR DESCRIPTION
## What this does

Replaces the single word "Studio" with "Unsloth" wherever it was used as shorthand for Unsloth Studio. In this repo that is comments, docstrings, one workflow header comment, and one ImportError message in `unsloth_zoo/mlx/utils.py`.

44 lines across 15 files, all one-word substitutions with no logic changes. Companion to unslothai/unsloth#7221.

## Deliberately left unchanged

- The full name "Unsloth Studio" and third party names like LM Studio
- All identifiers and paths, including the `diffusion_studio` module name

## Testing

- Grepped the tree after the change: no standalone "Studio" tokens remain
- `python -m py_compile` passes on every changed Python file
