### PR TITLE
Fix OLMoE load_in_4bit crash: route fused experts through the MoE backend

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -121,6 +121,7 @@ jobs:
             tests/test_temporary_patches_imports.py \
             tests/test_zoo_history_regressions.py \
             tests/test_pypi_version_sync.py \
+            tests/test_olmoe_moe_routing.py \
             -v
 
   # Core (HF/TRL/peft) drift matrix. Three cells: HF=4.57.6+TRL<1, HF=latest+TRL=latest,

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -239,6 +239,11 @@ jobs:
         # here, which masks labels[position_ids == 0] (trl added that in 0.23.1),
         # so this job exercises the regressed regime on every pull request.
         #
+        # test_olmoe_moe_routing pins the OLMoE fused-experts routing through the MoE
+        # backend and its preprocessor registration (#850): stub OlmoeConfig, CPU-pure,
+        # sub-second. The zoo-specific step below is continue-on-error, so a
+        # regression there would only ever be yellow.
+        #
         # The last two are here because `--collect-only` is exactly what missed
         # the bug they cover. `tests/` is not a package, so `from tests.x import
         # y` binds to whatever `tests` package is importable; unsloth's CI runs
@@ -252,6 +257,7 @@ jobs:
           python -m pytest \
             tests/test_training_utils_use_cache.py \
             tests/test_loss_normalization_contract.py \
+            tests/test_olmoe_moe_routing.py \
             tests/test_mlx_finetune_last_n_layers.py \
             tests/test_mlx_double_quant_reject.py \
             tests/test_hf_xet_fallback.py \
@@ -298,7 +304,6 @@ jobs:
             tests/test_temporary_patches_imports.py \
             tests/test_zoo_history_regressions.py \
             tests/test_pypi_version_sync.py \
-            tests/test_olmoe_moe_routing.py \
             -v
 
   # Real MLX numerics on Linux. mlx-cpu publishes a manylinux x86-64 wheel and

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -298,6 +298,7 @@ jobs:
             tests/test_temporary_patches_imports.py \
             tests/test_zoo_history_regressions.py \
             tests/test_pypi_version_sync.py \
+            tests/test_olmoe_moe_routing.py \
             -v
 
   # Real MLX numerics on Linux. mlx-cpu publishes a manylinux x86-64 wheel and

--- a/tests/test_olmoe_moe_routing.py
+++ b/tests/test_olmoe_moe_routing.py
@@ -28,6 +28,8 @@ OLMoE expert math on CPU. The bnb-4bit path itself needs CUDA and is exercised b
 the end-to-end run in the PR.
 """
 
+import types
+
 import pytest
 import torch
 
@@ -43,7 +45,7 @@ from unsloth_zoo.temporary_patches.moe_utils import (
 try:
     from transformers.models.olmoe.modeling_olmoe import OlmoeExperts
     from transformers.models.olmoe.configuration_olmoe import OlmoeConfig
-except Exception:  # transformers < 5: ModuleList experts, the patch is a strict no-op
+except ImportError:  # transformers < 5: ModuleList experts, the patch is a strict no-op
     OlmoeExperts = None
     OlmoeConfig = None
 
@@ -127,3 +129,61 @@ def test_patched_forward_matches_stock_math_cpu(monkeypatch):
         )
     finally:
         select_moe_backend.cache_clear()
+
+
+# --- 4. The compiled-cache registry split (Codex review on #915): get_forward_moe_backend
+#        may resolve the forward from the unsloth_compiled_cache copy of moe_utils — a
+#        distinct module object whose _WEIGHT_PREPROCESSORS starts empty, where a package-
+#        only registration is invisible and OLMoE's square gate_up falls back to shape
+#        inference (#849). The patch must land the preprocessor in BOTH namespaces. ---
+
+_SPLIT_NAMESPACE_SRC = """
+import torch
+
+_WEIGHT_PREPROCESSORS = {}
+
+def register_weight_preprocessor(model_type, preprocessor_fn):
+    _WEIGHT_PREPROCESSORS[model_type] = preprocessor_fn
+
+def get_weight_preprocessor(model_type):
+    return _WEIGHT_PREPROCESSORS.get(model_type)
+
+# The signature (names + annotations) must match the real dispatcher: patch_function's
+# strict fingerprint check compares them before installing the replacement.
+def forward_moe_backend(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    raise NotImplementedError("routing stand-in; never called in this test")
+"""
+
+
+@requires_fused_olmoe
+def test_preprocessor_registered_in_executing_namespace(monkeypatch):
+    import unsloth_zoo.temporary_patches.olmoe as olmoe_mod
+
+    # Stand-in for the cache-loaded moe_utils: a real module object with its own empty
+    # registry, its own register/get API, and a forward bound to its namespace.
+    split = types.ModuleType("unsloth_cached_moe_utils_standin")
+    exec(compile(_SPLIT_NAMESPACE_SRC, split.__name__, "exec"), split.__dict__)
+    assert split.forward_moe_backend.__globals__ is split.__dict__
+
+    # Re-run the patch with the stand-in as the resolved backend; register the current
+    # forward with monkeypatch so it is restored for the other tests afterwards.
+    monkeypatch.setattr(OlmoeExperts, "forward", OlmoeExperts.forward)
+    monkeypatch.setattr(OlmoeExperts, "_unsloth_already_patched", False, raising=False)
+    monkeypatch.setattr(
+        olmoe_mod, "get_forward_moe_backend", lambda: split.forward_moe_backend
+    )
+
+    olmoe_mod.patch_olmoe_moe()
+
+    # The package registry has the preprocessor ...
+    assert get_weight_preprocessor("olmoe") is _olmoe_weight_preprocessor
+    # ... and so does the namespace the installed forward actually reads.
+    installed = OlmoeExperts.forward
+    assert installed is split.forward_moe_backend
+    assert installed.__globals__["_WEIGHT_PREPROCESSORS"].get("olmoe") is _olmoe_weight_preprocessor
+    assert split.get_weight_preprocessor("olmoe") is _olmoe_weight_preprocessor

--- a/tests/test_olmoe_moe_routing.py
+++ b/tests/test_olmoe_moe_routing.py
@@ -1,0 +1,118 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for OLMoE fused-experts routing (unslothai/unsloth-zoo#850).
+
+Transformers v5 stores OLMoE experts as fused 3D nn.Parameters, so the generic MoE
+bnb-4bit quantizer matches and quantizes them — but with no per-arch forward patch
+the native OlmoeExperts.forward received the packed 2D uint8 Params4bit storage and
+crashed on the first forward (IndexError / 'expected mat_a ... got Byte'). These
+tests assert patch_olmoe_moe routes OlmoeExperts.forward through the Unsloth MoE
+backend, registers the explicit weight preprocessor (OLMoE's shipping gate_up is
+square — 2*1024 == 2048 == hidden — so grouped_mm layout cannot be inferred from
+shape, unslothai/unsloth-zoo#849), and that the patched forward still matches stock
+OLMoE expert math on CPU. The bnb-4bit path itself needs CUDA and is exercised by
+the end-to-end run in the PR.
+"""
+
+import pytest
+import torch
+
+from unsloth_zoo.temporary_patches.olmoe import (
+    patch_olmoe_moe,
+    _olmoe_weight_preprocessor,
+)
+from unsloth_zoo.temporary_patches.moe_utils import get_weight_preprocessor
+
+try:
+    from transformers.models.olmoe.modeling_olmoe import OlmoeExperts
+    from transformers.models.olmoe.configuration_olmoe import OlmoeConfig
+except Exception:  # transformers < 5: ModuleList experts, the patch is a strict no-op
+    OlmoeExperts = None
+    OlmoeConfig = None
+
+requires_fused_olmoe = pytest.mark.skipif(
+    OlmoeExperts is None, reason="transformers < 5 has no fused OlmoeExperts"
+)
+
+
+# --- 1. The registered preprocessor: F.linear layout -> grouped_mm layout, both projections. ---
+
+def test_preprocessor_transposes_flinear_to_grouped():
+    E, H, I = 4, 64, 32  # 2I == H: OLMoE's ambiguous square gate_up shape
+    gate_up_flinear = torch.randn(E, 2 * I, H)
+    down_flinear = torch.randn(E, H, I)
+
+    out_gu = _olmoe_weight_preprocessor(gate_up_flinear, "gate_up", H)
+    out_dn = _olmoe_weight_preprocessor(down_flinear, "down", H)
+    assert torch.equal(out_gu, gate_up_flinear.transpose(-2, -1))  # (E, H, 2I)
+    assert torch.equal(out_dn, down_flinear.transpose(-2, -1))     # (E, I, H)
+
+
+# --- 2. Patch wiring: forward replaced, model_type + registry installed, idempotent. ---
+
+@requires_fused_olmoe
+def test_patch_installs_backend_and_registry():
+    patch_olmoe_moe()
+
+    assert getattr(OlmoeExperts, "_unsloth_already_patched", False)
+    assert getattr(OlmoeExperts, "_unsloth_model_type", None) == "olmoe"
+    assert get_weight_preprocessor("olmoe") is _olmoe_weight_preprocessor
+    assert getattr(OlmoeExperts, "_unsloth_lora_extractor_fn", None) is not None
+    # The dispatcher replaced the native expert loop.
+    assert OlmoeExperts.forward.__name__ == "forward_moe_backend"
+
+    patch_olmoe_moe()  # second call must be a no-op, not a double-patch
+    assert OlmoeExperts.forward.__name__ == "forward_moe_backend"
+
+
+# --- 3. Patched forward == stock OLMoE expert math on CPU (square gate_up config). ---
+
+@requires_fused_olmoe
+def test_patched_forward_matches_stock_math_cpu(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_MOE_BACKEND", "native_torch")
+    patch_olmoe_moe()
+
+    E, H, I, T, K = 8, 64, 32, 16, 2  # 2I == H -> the #849-ambiguous shape
+    cfg = OlmoeConfig(
+        hidden_size=H, intermediate_size=I, num_local_experts=E,
+        num_experts_per_tok=K, hidden_act="silu",
+    )
+    torch.manual_seed(0)
+    experts = OlmoeExperts(cfg).float().eval()
+    with torch.no_grad():
+        experts.gate_up_proj.normal_(0.0, 0.2)
+        experts.down_proj.normal_(0.0, 0.2)
+
+    hs = torch.randn(T, H)
+    idx = torch.randint(0, E, (T, K))
+    w = torch.softmax(torch.rand(T, K), dim=-1)
+
+    with torch.no_grad():
+        out = experts(hs, idx, w)
+
+        # Stock OlmoeExperts math: F.linear over the (E, 2I, H)/(E, H, I) weights.
+        ref = torch.zeros(T, H)
+        for t in range(T):
+            for k in range(K):
+                e = idx[t, k].item()
+                gate, up = torch.nn.functional.linear(hs[t], experts.gate_up_proj[e]).chunk(2, dim=-1)
+                ref[t] += w[t, k] * torch.nn.functional.linear(torch.nn.functional.silu(gate) * up, experts.down_proj[e])
+
+    assert out.shape == ref.shape
+    assert torch.allclose(out, ref, rtol=1e-5, atol=1e-5), (
+        f"max abs diff {(out - ref).abs().max().item()}"
+    )

--- a/tests/test_olmoe_moe_routing.py
+++ b/tests/test_olmoe_moe_routing.py
@@ -35,7 +35,10 @@ from unsloth_zoo.temporary_patches.olmoe import (
     patch_olmoe_moe,
     _olmoe_weight_preprocessor,
 )
-from unsloth_zoo.temporary_patches.moe_utils import get_weight_preprocessor
+from unsloth_zoo.temporary_patches.moe_utils import (
+    get_weight_preprocessor,
+    select_moe_backend,
+)
 
 try:
     from transformers.models.olmoe.modeling_olmoe import OlmoeExperts
@@ -84,35 +87,43 @@ def test_patch_installs_backend_and_registry():
 @requires_fused_olmoe
 def test_patched_forward_matches_stock_math_cpu(monkeypatch):
     monkeypatch.setenv("UNSLOTH_MOE_BACKEND", "native_torch")
-    patch_olmoe_moe()
+    # select_moe_backend is @lru_cache(maxsize=1): drop any choice cached by an
+    # earlier test so the env pin above actually takes effect, and drop ours on
+    # the way out so it can't leak into later tests (e.g. on a GPU host whose
+    # uncached choice would be grouped_mm).
+    select_moe_backend.cache_clear()
+    try:
+        patch_olmoe_moe()
 
-    E, H, I, T, K = 8, 64, 32, 16, 2  # 2I == H -> the #849-ambiguous shape
-    cfg = OlmoeConfig(
-        hidden_size=H, intermediate_size=I, num_local_experts=E,
-        num_experts_per_tok=K, hidden_act="silu",
-    )
-    torch.manual_seed(0)
-    experts = OlmoeExperts(cfg).float().eval()
-    with torch.no_grad():
-        experts.gate_up_proj.normal_(0.0, 0.2)
-        experts.down_proj.normal_(0.0, 0.2)
+        E, H, I, T, K = 8, 64, 32, 16, 2  # 2I == H -> the #849-ambiguous shape
+        cfg = OlmoeConfig(
+            hidden_size=H, intermediate_size=I, num_local_experts=E,
+            num_experts_per_tok=K, hidden_act="silu",
+        )
+        torch.manual_seed(0)
+        experts = OlmoeExperts(cfg).float().eval()
+        with torch.no_grad():
+            experts.gate_up_proj.normal_(0.0, 0.2)
+            experts.down_proj.normal_(0.0, 0.2)
 
-    hs = torch.randn(T, H)
-    idx = torch.randint(0, E, (T, K))
-    w = torch.softmax(torch.rand(T, K), dim=-1)
+        hs = torch.randn(T, H)
+        idx = torch.randint(0, E, (T, K))
+        w = torch.softmax(torch.rand(T, K), dim=-1)
 
-    with torch.no_grad():
-        out = experts(hs, idx, w)
+        with torch.no_grad():
+            out = experts(hs, idx, w)
 
-        # Stock OlmoeExperts math: F.linear over the (E, 2I, H)/(E, H, I) weights.
-        ref = torch.zeros(T, H)
-        for t in range(T):
-            for k in range(K):
-                e = idx[t, k].item()
-                gate, up = torch.nn.functional.linear(hs[t], experts.gate_up_proj[e]).chunk(2, dim=-1)
-                ref[t] += w[t, k] * torch.nn.functional.linear(torch.nn.functional.silu(gate) * up, experts.down_proj[e])
+            # Stock OlmoeExperts math: F.linear over the (E, 2I, H)/(E, H, I) weights.
+            ref = torch.zeros(T, H)
+            for t in range(T):
+                for k in range(K):
+                    e = idx[t, k].item()
+                    gate, up = torch.nn.functional.linear(hs[t], experts.gate_up_proj[e]).chunk(2, dim=-1)
+                    ref[t] += w[t, k] * torch.nn.functional.linear(torch.nn.functional.silu(gate) * up, experts.down_proj[e])
 
-    assert out.shape == ref.shape
-    assert torch.allclose(out, ref, rtol=1e-5, atol=1e-5), (
-        f"max abs diff {(out - ref).abs().max().item()}"
-    )
+        assert out.shape == ref.shape
+        assert torch.allclose(out, ref, rtol=1e-5, atol=1e-5), (
+            f"max abs diff {(out - ref).abs().max().item()}"
+        )
+    finally:
+        select_moe_backend.cache_clear()

--- a/tests/test_olmoe_moe_routing.py
+++ b/tests/test_olmoe_moe_routing.py
@@ -187,3 +187,25 @@ def test_preprocessor_registered_in_executing_namespace(monkeypatch):
     assert installed is split.forward_moe_backend
     assert installed.__globals__["_WEIGHT_PREPROCESSORS"].get("olmoe") is _olmoe_weight_preprocessor
     assert split.get_weight_preprocessor("olmoe") is _olmoe_weight_preprocessor
+
+
+# --- 5. A rejected forward patch must not record success (Codex review on #915): if
+#        patch_function returns False (e.g. signature drift in a future transformers),
+#        the sentinel must stay unset and the skip must be loudly diagnosable — a silent
+#        sentinel would leave the native forward installed and #850 crashing with no clue. ---
+
+@requires_fused_olmoe
+def test_rejected_patch_does_not_set_sentinel(monkeypatch, capsys):
+    import unsloth_zoo.temporary_patches.olmoe as olmoe_mod
+
+    monkeypatch.setattr(OlmoeExperts, "forward", OlmoeExperts.forward)
+    monkeypatch.setattr(OlmoeExperts, "_unsloth_already_patched", False, raising=False)
+    monkeypatch.setattr(olmoe_mod, "patch_function", lambda *a, **k: False)
+
+    olmoe_mod.patch_olmoe_moe()
+
+    assert not getattr(OlmoeExperts, "_unsloth_already_patched", False), (
+        "sentinel must not be set when patch_function rejects the patch"
+    )
+    err = capsys.readouterr().err
+    assert "#850" in err and "OlmoeExperts" in err

--- a/tests/test_olmoe_moe_routing.py
+++ b/tests/test_olmoe_moe_routing.py
@@ -28,8 +28,6 @@ OLMoE expert math on CPU. The bnb-4bit path itself needs CUDA and is exercised b
 the end-to-end run in the PR.
 """
 
-import types
-
 import pytest
 import torch
 
@@ -131,65 +129,7 @@ def test_patched_forward_matches_stock_math_cpu(monkeypatch):
         select_moe_backend.cache_clear()
 
 
-# --- 4. The compiled-cache registry split (Codex review on #915): get_forward_moe_backend
-#        may resolve the forward from the unsloth_compiled_cache copy of moe_utils — a
-#        distinct module object whose _WEIGHT_PREPROCESSORS starts empty, where a package-
-#        only registration is invisible and OLMoE's square gate_up falls back to shape
-#        inference (#849). The patch must land the preprocessor in BOTH namespaces. ---
-
-_SPLIT_NAMESPACE_SRC = """
-import torch
-
-_WEIGHT_PREPROCESSORS = {}
-
-def register_weight_preprocessor(model_type, preprocessor_fn):
-    _WEIGHT_PREPROCESSORS[model_type] = preprocessor_fn
-
-def get_weight_preprocessor(model_type):
-    return _WEIGHT_PREPROCESSORS.get(model_type)
-
-# The signature (names + annotations) must match the real dispatcher: patch_function's
-# strict fingerprint check compares them before installing the replacement.
-def forward_moe_backend(
-    self,
-    hidden_states: torch.Tensor,
-    top_k_index: torch.Tensor,
-    top_k_weights: torch.Tensor,
-) -> torch.Tensor:
-    raise NotImplementedError("routing stand-in; never called in this test")
-"""
-
-
-@requires_fused_olmoe
-def test_preprocessor_registered_in_executing_namespace(monkeypatch):
-    import unsloth_zoo.temporary_patches.olmoe as olmoe_mod
-
-    # Stand-in for the cache-loaded moe_utils: a real module object with its own empty
-    # registry, its own register/get API, and a forward bound to its namespace.
-    split = types.ModuleType("unsloth_cached_moe_utils_standin")
-    exec(compile(_SPLIT_NAMESPACE_SRC, split.__name__, "exec"), split.__dict__)
-    assert split.forward_moe_backend.__globals__ is split.__dict__
-
-    # Re-run the patch with the stand-in as the resolved backend; register the current
-    # forward with monkeypatch so it is restored for the other tests afterwards.
-    monkeypatch.setattr(OlmoeExperts, "forward", OlmoeExperts.forward)
-    monkeypatch.setattr(OlmoeExperts, "_unsloth_already_patched", False, raising=False)
-    monkeypatch.setattr(
-        olmoe_mod, "get_forward_moe_backend", lambda: split.forward_moe_backend
-    )
-
-    olmoe_mod.patch_olmoe_moe()
-
-    # The package registry has the preprocessor ...
-    assert get_weight_preprocessor("olmoe") is _olmoe_weight_preprocessor
-    # ... and so does the namespace the installed forward actually reads.
-    installed = OlmoeExperts.forward
-    assert installed is split.forward_moe_backend
-    assert installed.__globals__["_WEIGHT_PREPROCESSORS"].get("olmoe") is _olmoe_weight_preprocessor
-    assert split.get_weight_preprocessor("olmoe") is _olmoe_weight_preprocessor
-
-
-# --- 5. A rejected forward patch must not record success (Codex review on #915): if
+# --- 4. A rejected forward patch must not record success (Codex review on #915): if
 #        patch_function returns False (e.g. signature drift in a future transformers),
 #        the sentinel must stay unset and the skip must be loudly diagnosable — a silent
 #        sentinel would leave the native forward installed and #850 crashing with no clue. ---

--- a/tests/test_temporary_patches_exhaustive.py
+++ b/tests/test_temporary_patches_exhaustive.py
@@ -1348,6 +1348,30 @@ def test_mxfp4_mxfp4_config_top_level_class():
         )
 
 
+# olmoe.py: OlmoeExperts.forward (5.0+-only).
+
+def test_olmoe_experts_forward_signature_5x():
+    """patch_olmoe_moe patches OlmoeExperts.forward(hidden_states, top_k_index,
+    top_k_weights) via ``get_forward_moe_backend()`` with strict signature
+    matching, so all three names are load-bearing: a rename makes patch_function
+    decline and the native forward keeps crashing on 4-bit (#850)."""
+    cls = _try_get_class(
+        "transformers.models.olmoe.modeling_olmoe", "OlmoeExperts",
+    )
+    if cls is None:
+        pytest.skip(
+            f"OlmoeExperts absent on transformers {_TX_VERSION} "
+            "(5.0+-only; transformers < 5 keeps OLMoE experts as a ModuleList)"
+        )
+    fwd = _assert_method_exists(cls, "forward", "olmoe.py")
+    _assert_params_superset(
+        fwd,
+        required=["hidden_states", "top_k_index", "top_k_weights"],
+        zoo_file="olmoe.py",
+        label="OlmoeExperts.forward",
+    )
+
+
 # pixtral.py: PixtralAttention.{__init__, forward}.
 
 def test_pixtral_attention_init_signature():

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -58,6 +58,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.moe_utils_bnb4bit",
     "unsloth_zoo.temporary_patches.moe_utils_fp8",
     "unsloth_zoo.temporary_patches.mxfp4",
+    "unsloth_zoo.temporary_patches.olmoe",
     "unsloth_zoo.temporary_patches.pixtral",
     "unsloth_zoo.temporary_patches.qwen3_5_moe",
     "unsloth_zoo.temporary_patches.qwen3_moe",

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -60,6 +60,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.moe_utils_bnb4bit",
     "unsloth_zoo.temporary_patches.moe_utils_fp8",
     "unsloth_zoo.temporary_patches.mxfp4",
+    "unsloth_zoo.temporary_patches.olmoe",
     "unsloth_zoo.temporary_patches.pixtral",
     "unsloth_zoo.temporary_patches.qwen3_5_moe",
     "unsloth_zoo.temporary_patches.qwen3_moe",

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -36,6 +36,7 @@ from .gemma4_moe import *
 from .lfm2_moe import *
 from .mixtral_moe import *
 from .ernie4_5_moe import *
+from .olmoe import *
 from .pixtral import *
 from .ministral import *
 from .mxfp4 import *

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -37,6 +37,7 @@ from .gemma4_moe import *
 from .lfm2_moe import *
 from .mixtral_moe import *
 from .ernie4_5_moe import *
+from .olmoe import *
 from .pixtral import *
 from .ministral import *
 from .amd_aiter import *

--- a/unsloth_zoo/temporary_patches/olmoe.py
+++ b/unsloth_zoo/temporary_patches/olmoe.py
@@ -1,0 +1,128 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .common import (
+    TEMPORARY_PATCHES,
+    UNSLOTH_ENABLE_LOGGING,
+)
+from .utils import (
+    patch_function,
+    logger,
+)
+
+# Grouped GEMM kernel integration for MoE training acceleration.
+from .moe_utils import (
+    patch_param_wrapper_for_moe,
+    get_forward_moe_backend,
+    extract_moe_lora_weights_for_grouped_mm,
+    register_weight_preprocessor,
+    get_weight_preprocessor,
+)
+
+
+def _olmoe_weight_preprocessor(weight, proj_type, hidden_dim):
+    """OLMoE expert weights are stored in the transformers F.linear layout
+    (gate_up (E, 2I, H), down (E, H, I)); grouped_mm wants (E, in, out), so both
+    projections always transpose. Registered explicitly because OLMoE's shipping
+    shape makes gate_up square (2*1024 == 2048 == hidden_size on OLMoE-1B-7B), where
+    shape inspection cannot tell the two layouts apart (unslothai/unsloth-zoo#849) —
+    the registry bypasses the shape guess entirely."""
+    return weight.transpose(-2, -1)
+
+
+def _make_olmoe_moe_lora_extractor():
+    """LoRA extractor for the fused OlmoeExperts. Same 3D layout as Qwen3MoeExperts
+    (gate_up_proj (E, 2*I, H), down_proj (E, H, I)); io-dims read off hidden_dim / intermediate_dim."""
+    def _get_olmoe_moe_lora_dims(wrapper):
+        if wrapper is None or not hasattr(wrapper, "get_base_layer"):
+            return None, None
+
+        base = wrapper.get_base_layer()
+        param_name = getattr(wrapper, "parameter_name", None)
+        if param_name == "gate_up_proj":
+            input_dim = getattr(base, "hidden_dim", None)
+            output_dim = getattr(base, "intermediate_dim", None)
+            return input_dim, None if output_dim is None else 2 * output_dim
+        if param_name == "down_proj":
+            return getattr(base, "intermediate_dim", None), getattr(base, "hidden_dim", None)
+
+        return None, None
+
+    def _olmoe_moe_lora_extractor(wrapper, weight_A, weight_B, scaling, num_experts):
+        input_dim, output_dim = _get_olmoe_moe_lora_dims(wrapper)
+        return extract_moe_lora_weights_for_grouped_mm(
+            wrapper,
+            weight_A,
+            weight_B,
+            scaling,
+            num_experts,
+            input_dim=input_dim,
+            output_dim=output_dim,
+            model_name="OLMoE",
+            enable_logging=UNSLOTH_ENABLE_LOGGING,
+            logger_obj=logger,
+        )
+
+    return _olmoe_moe_lora_extractor
+
+
+def patch_olmoe_moe():
+    """Patch OLMoE (olmoe) fused experts for bnb-4bit QLoRA + Split LoRA via grouped GEMM.
+
+    The generic MoE bnb-4bit quantizer already matches OlmoeExperts (any module with
+    fused gate_up_proj/down_proj nn.Parameters), but with no per-arch forward patch the
+    native OlmoeExperts.forward receives the packed 2D uint8 Params4bit storage and
+    crashes on the first forward (unslothai/unsloth-zoo#850): the model loads with
+    load_in_4bit=True, VRAM drops, then IndexError/'got Byte' at first use. Routing the
+    forward through Unsloth's MoE backend (dequantize + grouped_mm) fixes it, as for
+    qwen3_moe / glm4_moe / lfm2_moe / etc. The OlmoeSparseMoeBlock keeps its native
+    routing — its gate returns (router_logits, top_k_weights, top_k_index) and it calls
+    self.experts(hidden_states, top_k_index, top_k_weights), which matches the
+    dispatcher signature — so only the experts forward is replaced.
+    """
+    # Separated LoRA on the fused experts params. Idempotent (qwen3_moe installs it too).
+    patch_param_wrapper_for_moe()
+
+    # Transformers < 5 has no OlmoeExperts (ModuleList experts, handled by
+    # moe_grouped_modulelist) -> strict no-op there.
+    try:
+        from transformers.models.olmoe.modeling_olmoe import OlmoeExperts
+    except Exception:
+        return
+
+    if getattr(OlmoeExperts, "_unsloth_already_patched", False):
+        return
+
+    # Deterministic grouped_mm layout for the square-dims arch (#849): model_type on
+    # the class routes preprocess_weight through the registry instead of shape
+    # inference, which is ambiguous for OLMoE's square gate_up.
+    OlmoeExperts._unsloth_model_type = "olmoe"
+    if get_weight_preprocessor("olmoe") is None:
+        register_weight_preprocessor("olmoe", _olmoe_weight_preprocessor)
+
+    _olmoe_lora_extractor = _make_olmoe_moe_lora_extractor()
+    OlmoeExperts._unsloth_lora_extractor_fn = staticmethod(_olmoe_lora_extractor)
+
+    # Pass the function object directly (no closure): patch_function serializes the source into
+    # the compiled cache, so a closure var would be a NameError there. Mirrors qwen3_moe.py.
+    patch_function(OlmoeExperts, "forward", get_forward_moe_backend())
+    OlmoeExperts._unsloth_already_patched = True
+
+    if UNSLOTH_ENABLE_LOGGING:
+        logger.info("Unsloth: Patched OLMoE experts for bnb-4bit + Split LoRA support.")
+
+
+TEMPORARY_PATCHES.append(patch_olmoe_moe)

--- a/unsloth_zoo/temporary_patches/olmoe.py
+++ b/unsloth_zoo/temporary_patches/olmoe.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import sys
+
 from .common import (
     TEMPORARY_PATCHES,
     UNSLOTH_ENABLE_LOGGING,
@@ -136,7 +138,18 @@ def patch_olmoe_moe():
 
     # Pass the function object directly (no closure): patch_function serializes the source into
     # the compiled cache, so a closure var would be a NameError there. Mirrors qwen3_moe.py.
-    patch_function(OlmoeExperts, "forward", forward_backend)
+    # Strict matching is the drift tripwire: if a future transformers changes the forward
+    # signature (or postpones annotations into strings), patch_function returns False — in
+    # that case the native forward would still crash on 4-bit (#850), so say why loudly and
+    # leave the sentinel unset instead of recording success that didn't happen.
+    if not patch_function(OlmoeExperts, "forward", forward_backend):
+        print(
+            "Unsloth: could not install the MoE forward on OlmoeExperts (signature "
+            "drift in this transformers version?). OLMoE load_in_4bit will crash on "
+            "its first forward (unslothai/unsloth-zoo#850).",
+            file=sys.stderr,
+        )
+        return
     OlmoeExperts._unsloth_already_patched = True
 
     if UNSLOTH_ENABLE_LOGGING:

--- a/unsloth_zoo/temporary_patches/olmoe.py
+++ b/unsloth_zoo/temporary_patches/olmoe.py
@@ -51,6 +51,8 @@ def _make_olmoe_moe_lora_extractor():
             return None, None
 
         base = wrapper.get_base_layer()
+        if base is None:
+            return None, None
         param_name = getattr(wrapper, "parameter_name", None)
         if param_name == "gate_up_proj":
             input_dim = getattr(base, "hidden_dim", None)
@@ -100,7 +102,7 @@ def patch_olmoe_moe():
     # moe_grouped_modulelist) -> strict no-op there.
     try:
         from transformers.models.olmoe.modeling_olmoe import OlmoeExperts
-    except Exception:
+    except ImportError:
         return
 
     if getattr(OlmoeExperts, "_unsloth_already_patched", False):
@@ -113,12 +115,28 @@ def patch_olmoe_moe():
     if get_weight_preprocessor("olmoe") is None:
         register_weight_preprocessor("olmoe", _olmoe_weight_preprocessor)
 
+    # get_forward_moe_backend() prefers the unsloth_compiled_cache copy of moe_utils —
+    # a distinct module object with its own (empty) _WEIGHT_PREPROCESSORS, where the
+    # package registration above is invisible and square gate_up falls back to shape
+    # inference (#849). Register through the executing namespace's own API as well.
+    forward_backend = get_forward_moe_backend()
+    backend_ns = getattr(forward_backend, "__globals__", None) or {}
+    ns_get = backend_ns.get("get_weight_preprocessor")
+    ns_register = backend_ns.get("register_weight_preprocessor")
+    if (
+        callable(ns_get)
+        and callable(ns_register)
+        and ns_get is not get_weight_preprocessor
+        and ns_get("olmoe") is None
+    ):
+        ns_register("olmoe", _olmoe_weight_preprocessor)
+
     _olmoe_lora_extractor = _make_olmoe_moe_lora_extractor()
     OlmoeExperts._unsloth_lora_extractor_fn = staticmethod(_olmoe_lora_extractor)
 
     # Pass the function object directly (no closure): patch_function serializes the source into
     # the compiled cache, so a closure var would be a NameError there. Mirrors qwen3_moe.py.
-    patch_function(OlmoeExperts, "forward", get_forward_moe_backend())
+    patch_function(OlmoeExperts, "forward", forward_backend)
     OlmoeExperts._unsloth_already_patched = True
 
     if UNSLOTH_ENABLE_LOGGING:

--- a/unsloth_zoo/temporary_patches/olmoe.py
+++ b/unsloth_zoo/temporary_patches/olmoe.py
@@ -112,26 +112,13 @@ def patch_olmoe_moe():
 
     # Deterministic grouped_mm layout for the square-dims arch (#849): model_type on
     # the class routes preprocess_weight through the registry instead of shape
-    # inference, which is ambiguous for OLMoE's square gate_up.
+    # inference, which is ambiguous for OLMoE's square gate_up. (Since #913 the
+    # sibling vote resolves it from the non-square down_proj as well; the explicit
+    # registration keeps the layout deterministic and covers a forward with no
+    # readable sibling.)
     OlmoeExperts._unsloth_model_type = "olmoe"
     if get_weight_preprocessor("olmoe") is None:
         register_weight_preprocessor("olmoe", _olmoe_weight_preprocessor)
-
-    # get_forward_moe_backend() prefers the unsloth_compiled_cache copy of moe_utils —
-    # a distinct module object with its own (empty) _WEIGHT_PREPROCESSORS, where the
-    # package registration above is invisible and square gate_up falls back to shape
-    # inference (#849). Register through the executing namespace's own API as well.
-    forward_backend = get_forward_moe_backend()
-    backend_ns = getattr(forward_backend, "__globals__", None) or {}
-    ns_get = backend_ns.get("get_weight_preprocessor")
-    ns_register = backend_ns.get("register_weight_preprocessor")
-    if (
-        callable(ns_get)
-        and callable(ns_register)
-        and ns_get is not get_weight_preprocessor
-        and ns_get("olmoe") is None
-    ):
-        ns_register("olmoe", _olmoe_weight_preprocessor)
 
     _olmoe_lora_extractor = _make_olmoe_moe_lora_extractor()
     OlmoeExperts._unsloth_lora_extractor_fn = staticmethod(_olmoe_lora_extractor)
@@ -142,7 +129,7 @@ def patch_olmoe_moe():
     # signature (or postpones annotations into strings), patch_function returns False — in
     # that case the native forward would still crash on 4-bit (#850), so say why loudly and
     # leave the sentinel unset instead of recording success that didn't happen.
-    if not patch_function(OlmoeExperts, "forward", forward_backend):
+    if not patch_function(OlmoeExperts, "forward", get_forward_moe_backend()):
         print(
             "Unsloth: could not install the MoE forward on OlmoeExperts (signature "
             "drift in this transformers version?). OLMoE load_in_4bit will crash on "


### PR DESCRIPTION
# Fix OLMoE `load_in_4bit` crash: route fused experts through the MoE backend (#850)

## The bug (load fine, crash on first forward)

The MoE bnb-4bit quantizer matches **any** module holding fused `gate_up_proj`/`down_proj` `nn.Parameter`s, so transformers-v5 OLMoE quantizes on load (16/16 layers, ~3.0 GiB) — but the forward routing that dequantizes at compute time is a per-arch patch list, and there is no `olmoe` entry. The native `OlmoeExperts.forward` then receives the packed 2-D uint8 `Params4bit` storage and crashes on the first forward: `IndexError` at transformers' `_grouped_mm_fallback` (`weight.size(2)` on a 2-D tensor) in a full-model forward, `'expected mat_a ... got Byte'` at module level. Quantize-coverage is generic; route-coverage is a list — every fused-experts arch outside the list loads, drops VRAM, then dies on first use. Details and repro gist in #849's sibling report, #850.

## The fix

Per-arch patch in the exact `lfm2_moe`/`qwen3_moe` idiom (`unsloth_zoo/temporary_patches/olmoe.py`):

- **Routing entry:** `patch_function(OlmoeExperts, "forward", get_forward_moe_backend())` + the fused-experts LoRA extractor (`OlmoeExperts` exposes the same `hidden_dim`/`intermediate_dim` attrs and `(E, 2I, H)`/`(E, H, I)` layout as `Qwen3MoeExperts`). The `OlmoeSparseMoeBlock` keeps its native routing — its gate already returns `(router_logits, top_k_weights, top_k_index)` and it calls `self.experts(hidden_states, top_k_index, top_k_weights)`, which is the dispatcher signature — so only the experts forward is replaced, as in `lfm2_moe`.
- **Explicit layout preprocessor — first real use of the existing registry:** OLMoE's shipping gate_up is **square** (2·1024 == 2048 == `hidden_size`), the exact shape where `preprocess_weight`'s layout inference is ambiguous (#849). `register_weight_preprocessor("olmoe", ...)` + `OlmoeExperts._unsloth_model_type = "olmoe"` route both projections through a deterministic transpose from the F.linear storage layout, bypassing shape inference entirely.
- **Cache-copy registry visibility — split out to #1082 (Codex review catch):** `get_forward_moe_backend()` prefers the `unsloth_compiled_cache` copy of `moe_utils`, a distinct module object with its own empty `_WEIGHT_PREPROCESSORS`, so a package-only registration is invisible to the very forward this patch installs. An earlier revision of this PR registered through that namespace directly; @danielhanchen asked for it as a separate change, so it now lives in **#1082**, which resolves the registry through the package module inside `moe_utils` itself. This PR does not depend on it: since #913 the square `gate_up` is disambiguated by the non-square `down_proj` sibling on every path (`preprocess_weight` is called with `experts_module=self` at every call site), and the cache copy returns the bit-identical transpose to the registry hit — verified directly against a loaded cache copy. The explicit registration here keeps the layout deterministic rather than inferred.

Transformers < 5 (ModuleList experts, no `OlmoeExperts`) is a strict no-op, same guard as `lfm2_moe`.

## Testing

CPU regression tests `tests/test_olmoe_moe_routing.py` (4 tests): preprocessor layout correctness, patch wiring/idempotence + registry installation, patched-forward vs stock OLMoE expert math on the square-gate_up shape, and a rejected-patch guard — force `patch_function` to decline and assert the `_unsloth_already_patched` sentinel stays unset and the stderr diagnostic names the class and #850, so a silent skip can't leave the crashing native forward installed. `tests/test_temporary_patches_exhaustive.py` gains the upstream-signature pin for `OlmoeExperts.forward`: all three parameter names are load-bearing, since `patch_function` matches strictly and a rename makes it decline. The routing file also moves out of the `continue-on-error` zoo-specific step into the hard-gate step, so a regression there is red rather than yellow. On the rebased tree those plus #913's `test_moe_preprocess_weight_transpose.py` pass together: **159 passed, 13 skipped**.

End-to-end on real `allenai/OLMoE-1B-7B-0924` (RTX A2000 12 GB, torch 2.11.0+cu128, transformers 5.5.0, bitsandbytes 0.49.2, unsloth 2026.6.9; same harness as the #849/#850 reports — `FastLanguageModel.from_pretrained(..., load_in_4bit=True)`, module parity vs an independent fp32 loop over bnb-dequantized stored weights, then LoRA train probes):

| | main @ 25b7c07 (control) | + this patch (pre-rebase) | on main @ 31c3e56 (the #913 squash-merge) — the GPU measurement base |
|---|---|---|---|
| quantized | 16/16 layers, 3.0 GiB | 16/16 | 16/16, 3.0 GiB |
| first forward | **crash** — `got Byte` at module level, `IndexError` in full-model forward (both #850 signatures) | OK | OK |
| parity, excess over bf16-noise | — (crash) | **0.78×** (at/below the noise floor) | **0.67×** (at/below the noise floor) |
| bf16 (non-quantized) module parity, grouped_mm | n/a | **174.9×** on the pre-#913 fallback → **1.01×** with an explicit registration | **1.01×** — on the shipped branch that registration moved to #1082 and #913's sibling vote resolves the same layout, returning the bit-identical transpose (verified against a loaded cache copy), so the same forward runs |
| expert LoRA grads | — (crash) | **nonzero, both adapter routes** (unsloth `get_peft_model` and raw-peft `target_parameters`; 64 expert adapters each) | **nonzero, both adapter routes** (64 expert-adapter params each; every `lora_B` grad nonzero on the first backward — `lora_A` grads are zero at step 1 by construction with peft's B-zero init, `dL/dA = Bᵀδ`) |

The pre-rebase column was measured against this PR's original base (pre-#913); the third column was measured on this branch rebased onto the #913 squash-merge. The registry takes precedence over #913's sibling vote by construction (`preprocess_weight` consults it first, moe_utils.py:1217), and parity on that tree stays at/below the bf16 noise floor, so the two fixes compose as claimed; the pre-rebase column documents why the registration exists — without either fix, this routing patch alone would have landed OLMoE straight in #849, and the two reports were always coupled.

**Re-measured on current main (2026-08-21).** The A2000 column above was taken on the 31c3e56 base with the `FastLanguageModel` harness. The branch is now rebased onto ce232d6c, which carries ~250 changed lines in `moe_utils.py` — including #1008, which touches the grouped_mm LoRA path this forward uses — so I re-ran the load / forward / parity / grad checks on the rebased tree. The re-measurement harness is independently written: plain `AutoModelForCausalLM` + `BitsAndBytesConfig` plus the zoo's own `TEMPORARY_PATCHES`, with no unsloth wrapper in the path, so it exercises this PR's code directly. RTX A2000 12 GB, torch 2.11.0+cu128, transformers 5.5.0, bitsandbytes 0.49.2, peft 0.20.0:

| check on ce232d6c + this branch | result |
|---|---|
| zoo temporary patches applied | 102 ok, 0 failed |
| `OlmoeExperts.forward` | `forward_moe_backend`; sentinel set; `_unsloth_model_type = "olmoe"` |
| shipping dims | hidden 2048, intermediate 1024, 64 experts, top-k 8 — so `gate_up` is **square** (2·1024 == 2048): the #849 shape, confirmed on the real checkpoint, and the dequantized stack is `(64, 2048, 2048)` |
| 4-bit quantized | **16/16** expert modules, 3.62 GiB allocated |
| first forward (the #850 crash site) | **OK** — logits `(1, 8, 50304)`, all finite |
| 4-bit module parity vs an fp32 loop over dequantized stored weights | **1.033×** the bf16 noise floor |
| bf16 (non-quantized) module parity, grouped_mm | **1.040×** the bf16 noise floor |
| expert LoRA grads (raw peft `target_parameters`) | **32/32** `lora_B` grads nonzero across 64 trainable adapter params; loss 6.98 |

Because that harness is independently written, these are not line-for-line comparable with the older column — the noise-floor normalisation and the sampled inputs both differ. What they establish is the claim that matters after a 151-commit rebase: on current main the routing patch still loads 16/16, still forwards without the #850 crash, still trains the expert adapters, and both parity checks sit at the bf16 noise floor.

Train-probe footnote: with the harness's `use_gradient_checkpointing=False` the unsloth-route probe OOMs my 12 GB card (each layer's dequantized gate_up stack is 512 MiB and ~3 GiB is held by unrelated services) — with unsloth's default `"unsloth"` checkpointing it passes. Harness limit, not a fix limit; the raw-peft route trains through the identical patched forward either way.

Honest scope: the bnb-4bit forward path is exercised on the A2000's grouped_mm route (torch 2.11 enables `torch._grouped_mm` on sm86; on the pinned torch the same default path serves H100-class GPUs), and the non-4bit grouped_mm path is now exercised at module level by the bf16 probe above. The FP8 and `unsloth_triton` routes are not reachable for OLMoE on my hardware and are unchanged by this PR.

## Related

- Fixes #850.
- Coupled to #849/#913 as described above; no file overlap with #913 (`olmoe.py` is new; `__init__.py` gains one import line), rebased cleanly onto current main (ce232d6c).
- Codex review finding (compiled-cache registry split) verified here and, at @danielhanchen's
  request, split out to #1082 — measurements in the review thread. Either order merges; this PR
  is correct on its own via #913's sibling vote, #1082 makes the registration hold on the cache path.

---
*Written with AI assistance (Claude); the fix was designed against the shipped per-arch patch idiom and every number above was measured on my hardware.*


