### PR TITLE
Fix Gemma 4 audio training crash

### DIFF
--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -31,6 +31,12 @@ Hermetic CPU tests with stub processors, no model or network needed:
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+import textwrap
+from collections import UserDict
+
 import numpy as np
 import pytest
 import torch
@@ -478,3 +484,163 @@ def test_real_decoder_decodes_to_float32_at_every_gate(gate):
     assert clips[0].dtype == np.float32
     assert clips[0].dtype != object
     assert clips[0].ndim == 1
+
+
+# ---------------------------------------------------------------------------
+# Unpatched torchcodec AudioDecoder (unsloth/unsloth#7226, follow-up)
+#
+# UnslothVisionDataCollator is exported and can be driven on datasets >= 4
+# Audio() columns WITHOUT importing `unsloth` -- which is what applies
+# patch_torchcodec_audio_decoder() (unsloth/_gpu_init.py). An *unpatched* decoder
+# exposes only __getitem__ (no get/keys/__contains__), so a duck-typed gate alone
+# misses it and it reaches the feature extractor as an object array. The gate now
+# also matches the AudioDecoder type directly, and _resolve_audio_dict reads
+# values through _audio_get, which subscripts when .get is absent.
+#
+# In CI (no torchcodec) we stand a fake class in as the recognized decoder type by
+# patching _audio_decoder_types; the real-decoder variant runs in a fresh
+# subprocess because the monkey-patch mutates the class for the whole process.
+# ---------------------------------------------------------------------------
+
+
+class _UnpatchedFakeAudioDecoder:
+    """An *unpatched* datasets torchcodec AudioDecoder surface: only __getitem__,
+    none of the get/keys/__contains__/__iter__ methods the patch grafts."""
+
+    def __getitem__(self, key):
+        if key == "array":
+            return DECODED
+        if key == "sampling_rate":
+            return 16000
+        raise KeyError(key)
+
+
+@pytest.fixture
+def _recognize_unpatched_decoder(monkeypatch):
+    # Treat _UnpatchedFakeAudioDecoder as the torchcodec AudioDecoder type so these
+    # run in CI without datasets >= 4 / torchcodec installed.
+    monkeypatch.setattr(
+        "unsloth_zoo.vision_utils._audio_decoder_types",
+        lambda: (_UnpatchedFakeAudioDecoder,),
+    )
+
+
+def test_unpatched_decoder_is_recognized_by_type(_recognize_unpatched_decoder):
+    decoder = _UnpatchedFakeAudioDecoder()
+    # The premise: not a dict and none of the grafted mapping methods exist.
+    assert not isinstance(decoder, dict)
+    assert not hasattr(decoder, "get")
+    assert not hasattr(decoder, "keys")
+    assert _is_audio_mapping(decoder)
+
+
+def test_unpatched_decoder_top_level_gate(_recognize_unpatched_decoder):
+    collator = make_collator()
+    clips = collator._extract_audio_for_example(
+        {"audio": _UnpatchedFakeAudioDecoder()}, msgs({"type": "text", "text": "hi"})
+    )
+    assert len(clips) == 1
+    assert clips[0].dtype == np.float32
+    assert clips[0].dtype != object
+    np.testing.assert_allclose(clips[0], DECODED)
+
+
+def test_unpatched_decoder_list_gate(_recognize_unpatched_decoder):
+    # Also guards the flat-samples branch: a list of decoders is a list of clips.
+    collator = make_collator()
+    clips = collator._extract_audio_for_example(
+        {"audio": [_UnpatchedFakeAudioDecoder(), _UnpatchedFakeAudioDecoder()]},
+        msgs({"type": "text", "text": "hi"}),
+    )
+    assert len(clips) == 2
+    for clip in clips:
+        assert clip.dtype == np.float32
+        np.testing.assert_allclose(clip, DECODED)
+
+
+def test_unpatched_decoder_inline_gate(_recognize_unpatched_decoder):
+    out = extract_audio_info(msgs({"type": "audio", "audio": _UnpatchedFakeAudioDecoder()}))
+    assert len(out) == 1
+    assert out[0].dtype == np.float32
+    np.testing.assert_allclose(out[0], DECODED)
+
+
+def test_unpatched_decoder_sampling_rate_still_validated(_recognize_unpatched_decoder):
+    # Resolves via subscript through _resolve_audio_dict, so validation still fires.
+    with pytest.raises(ValueError, match="does not match the feature extractor"):
+        extract_audio_info(
+            msgs({"type": "audio", "audio": _UnpatchedFakeAudioDecoder()}), sampling_rate=24000
+        )
+
+
+class _NonCallableMappingAttrs:
+    """get / keys / __contains__ exist as attributes but are not callable."""
+
+    get = None
+    keys = None
+    __contains__ = None
+
+
+def test_non_callable_mapping_attrs_are_not_treated_as_mappings():
+    # hasattr would accept this and then fail later calling a None `.get`; the
+    # callable() gate rejects it up front instead.
+    assert not _is_audio_mapping(_NonCallableMappingAttrs())
+
+
+def test_userdict_audio_payload_resolves():
+    # A non-dict collections.abc.Mapping still routes through _resolve_audio_dict.
+    collator = make_collator()
+    clips = collator._extract_audio_for_example(
+        {"audio": UserDict({"array": DECODED, "sampling_rate": 16000})},
+        msgs({"type": "text", "text": "hi"}),
+    )
+    assert len(clips) == 1
+    np.testing.assert_allclose(clips[0], DECODED)
+
+
+def test_real_unpatched_decoder_decodes_in_fresh_process():
+    # Gold-standard: a REAL torchcodec AudioDecoder, never patched, decoded through
+    # the collator in a clean interpreter (the patch mutates the class globally, so
+    # this must not share a process with the patched real-decoder tests above).
+    pytest.importorskip("datasets", minversion="4.0.0")
+    pytest.importorskip("torchcodec")
+    code = textwrap.dedent(
+        """
+        import io, struct, wave
+        from types import SimpleNamespace
+        import numpy as np
+        from datasets.features._torchcodec import AudioDecoder
+        from unsloth_zoo.vision_utils import (
+            UnslothVisionDataCollator, _is_audio_mapping, extract_audio_info,
+        )
+
+        sr = 16000
+        samples = (0.3 * np.sin(2 * np.pi * 440 * np.linspace(0, 0.25, sr // 4, endpoint=False))).astype(np.float32)
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as h:
+            h.setnchannels(1); h.setsampwidth(2); h.setframerate(sr)
+            h.writeframes(b"".join(struct.pack("<h", int(s * 32767)) for s in samples))
+        def decoder():
+            return AudioDecoder(buf.getvalue())
+
+        assert not hasattr(decoder(), "get"), "decoder unexpectedly already patched"
+        assert _is_audio_mapping(decoder())
+
+        c = UnslothVisionDataCollator.__new__(UnslothVisionDataCollator)
+        c.processor = SimpleNamespace(feature_extractor=SimpleNamespace(sampling_rate=sr))
+        m = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        inline = [{"role": "user", "content": [{"type": "audio", "audio": decoder()}]}]
+        for clips in (
+            c._extract_audio_for_example({"audio": decoder()}, m),
+            c._extract_audio_for_example({"audio": [decoder()]}, m),
+            extract_audio_info(inline),
+        ):
+            assert clips[0].dtype == np.float32 and clips[0].dtype != object and clips[0].ndim == 1
+        print("OK")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=os.environ.copy()
+    )
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert result.stdout.strip().endswith("OK")

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -38,6 +38,7 @@ import torch
 from unsloth_zoo.vision_utils import (
     UnslothVisionDataCollator,
     _fix_audio_feature_extractor_padding_side,
+    _is_audio_mapping,
     extract_audio_info,
 )
 
@@ -331,3 +332,149 @@ def test_truncation_cutting_audio_span_raises():
     }
     with pytest.raises(ValueError, match="audio tokens"):
         collator._truncate_sequence_tensors(batch, seq_len=6)
+
+
+# ---------------------------------------------------------------------------
+# datasets >= 4 torchcodec AudioDecoder columns (unsloth/unsloth#7226)
+#
+# patch_torchcodec_audio_decoder grafts the mapping protocol onto AudioDecoder
+# instead of making it a dict subclass, so the audio gates' isinstance(x, dict)
+# checks used to reject it and drop the decoder into the raw-waveform catch-all.
+# It then reached the feature extractor as an object array and blew up inside
+# np.fft.rfft. These cover all three gates.
+#
+# _FakeAudioDecoder mirrors the real class: __getitem__ plus exactly the methods
+# patch_torchcodec_audio_decoder grafts, not a dict subclass, and no ndim. These
+# tests run in CI. The real-decoder tests below need datasets >= 4 + torchcodec
+# and skip when either is missing.
+# ---------------------------------------------------------------------------
+
+DECODED = np.linspace(-0.5, 0.5, 32, dtype=np.float32)
+
+
+class _FakeAudioDecoder:
+    """Same surface as a patched datasets.features._torchcodec.AudioDecoder."""
+
+    def __getitem__(self, key):
+        if key == "array":
+            return DECODED
+        if key == "sampling_rate":
+            return 16000
+        raise KeyError(key)
+
+    # exactly what patch_torchcodec_audio_decoder grafts
+    def __contains__(self, key):
+        return key in ("array", "sampling_rate")
+
+    def __iter__(self):
+        return iter(("array", "sampling_rate"))
+
+    def keys(self):
+        return ("array", "sampling_rate")
+
+    def get(self, key, default=None):
+        return self[key] if key in ("array", "sampling_rate") else default
+
+
+def test_fake_decoder_is_not_a_dict():
+    # The premise of the bug: the gates' isinstance check cannot see this object.
+    decoder = _FakeAudioDecoder()
+    assert not isinstance(decoder, dict)
+    assert _is_audio_mapping(decoder)
+
+
+def test_gate1_top_level_decoder_column_decoded():
+    collator = make_collator()
+    clips = collator._extract_audio_for_example({"audio": _FakeAudioDecoder()}, msgs({"type": "text", "text": "hi"}))
+    assert len(clips) == 1
+    assert clips[0].dtype == np.float32
+    assert clips[0].dtype != object
+    np.testing.assert_allclose(clips[0], DECODED)
+
+
+def test_gate2_list_of_decoders_is_list_of_clips():
+    # Guards the flat-samples branch too: a list of decoders must not be
+    # collapsed into a single clip.
+    collator = make_collator()
+    clips = collator._extract_audio_for_example(
+        {"audio": [_FakeAudioDecoder(), _FakeAudioDecoder()]}, msgs({"type": "text", "text": "hi"})
+    )
+    assert len(clips) == 2
+    for clip in clips:
+        assert clip.dtype == np.float32
+        np.testing.assert_allclose(clip, DECODED)
+
+
+def test_gate3_inline_decoder_message_content_decoded():
+    out = extract_audio_info(msgs({"type": "audio", "audio": _FakeAudioDecoder()}))
+    assert len(out) == 1
+    assert out[0].dtype == np.float32
+    np.testing.assert_allclose(out[0], DECODED)
+
+
+def test_decoder_sampling_rate_still_validated():
+    # The decoder must go through _resolve_audio_dict, not bypass its checks.
+    with pytest.raises(ValueError, match="does not match the feature extractor"):
+        extract_audio_info(msgs({"type": "audio", "audio": _FakeAudioDecoder()}), sampling_rate=24000)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.zeros(8, dtype=np.float32),          # bare ndarray
+        [0.0, 1.0, 2.0],                        # flat list
+        "clip.wav",                             # path string
+        torch.zeros(8),                         # torch tensor
+    ],
+)
+def test_non_mapping_audio_values_are_not_treated_as_mappings(value):
+    # The capability check is looser than isinstance; make sure the ordinary
+    # waveform/path payloads still fall through to their own branches.
+    assert not _is_audio_mapping(value)
+
+
+# --- the real decoder, when the optional deps are installed ----------------
+
+def _real_decoder():
+    datasets = pytest.importorskip("datasets", minversion="4.0.0")
+    pytest.importorskip("torchcodec")
+    try:
+        from datasets.features._torchcodec import AudioDecoder
+    except ImportError:
+        pytest.skip("datasets.features._torchcodec.AudioDecoder unavailable")
+
+    from unsloth_zoo.dataset_utils import patch_torchcodec_audio_decoder
+    patch_torchcodec_audio_decoder()
+
+    import io, struct, wave
+    sr = 16000
+    samples = (0.3 * np.sin(2 * np.pi * 440 * np.linspace(0, 0.25, sr // 4, endpoint=False))).astype(np.float32)
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sr)
+        handle.writeframes(b"".join(struct.pack("<h", int(s * 32767)) for s in samples))
+    return AudioDecoder(buffer.getvalue())
+
+
+def test_real_decoder_is_not_a_dict_but_is_a_mapping():
+    decoder = _real_decoder()
+    assert not isinstance(decoder, dict)
+    assert _is_audio_mapping(decoder)
+
+
+@pytest.mark.parametrize("gate", ["top_level", "list", "inline"])
+def test_real_decoder_decodes_to_float32_at_every_gate(gate):
+    decoder = _real_decoder()
+    collator = make_collator()
+    if gate == "top_level":
+        clips = collator._extract_audio_for_example({"audio": decoder}, msgs({"type": "text", "text": "hi"}))
+    elif gate == "list":
+        clips = collator._extract_audio_for_example({"audio": [decoder]}, msgs({"type": "text", "text": "hi"}))
+    else:
+        clips = extract_audio_info(msgs({"type": "audio", "audio": decoder}))
+    assert len(clips) == 1
+    assert clips[0].dtype == np.float32
+    assert clips[0].dtype != object
+    assert clips[0].ndim == 1

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -344,15 +344,10 @@ def test_truncation_cutting_audio_span_raises():
 # datasets >= 4 torchcodec AudioDecoder columns (unsloth/unsloth#7226)
 #
 # patch_torchcodec_audio_decoder grafts the mapping protocol onto AudioDecoder
-# instead of making it a dict subclass, so the audio gates' isinstance(x, dict)
-# checks used to reject it and drop the decoder into the raw-waveform catch-all.
-# It then reached the feature extractor as an object array and blew up inside
-# np.fft.rfft. These cover all three gates.
-#
-# _FakeAudioDecoder mirrors the real class: __getitem__ plus exactly the methods
-# patch_torchcodec_audio_decoder grafts, not a dict subclass, and no ndim. These
-# tests run in CI. The real-decoder tests below need datasets >= 4 + torchcodec
-# and skip when either is missing.
+# rather than subclassing dict, so the gates' isinstance(x, dict) checks rejected
+# it, dropped it into the raw-waveform catch-all and blew up inside np.fft.rfft.
+# _FakeAudioDecoder mirrors the patched surface and runs in CI; the real-decoder
+# tests below need datasets >= 4 + torchcodec and skip otherwise.
 # ---------------------------------------------------------------------------
 
 DECODED = np.linspace(-0.5, 0.5, 32, dtype=np.float32)
@@ -368,7 +363,7 @@ class _FakeAudioDecoder:
             return 16000
         raise KeyError(key)
 
-    # exactly what patch_torchcodec_audio_decoder grafts
+    # the methods patch_torchcodec_audio_decoder grafts
     def __contains__(self, key):
         return key in ("array", "sampling_rate")
 
@@ -383,7 +378,7 @@ class _FakeAudioDecoder:
 
 
 def test_fake_decoder_is_not_a_dict():
-    # The premise of the bug: the gates' isinstance check cannot see this object.
+    # Premise of the bug: the gates' isinstance check cannot see this object.
     decoder = _FakeAudioDecoder()
     assert not isinstance(decoder, dict)
     assert _is_audio_mapping(decoder)
@@ -399,8 +394,7 @@ def test_gate1_top_level_decoder_column_decoded():
 
 
 def test_gate2_list_of_decoders_is_list_of_clips():
-    # Guards the flat-samples branch too: a list of decoders must not be
-    # collapsed into a single clip.
+    # A list of decoders must not be collapsed into a single clip.
     collator = make_collator()
     clips = collator._extract_audio_for_example(
         {"audio": [_FakeAudioDecoder(), _FakeAudioDecoder()]}, msgs({"type": "text", "text": "hi"})
@@ -434,8 +428,7 @@ def test_decoder_sampling_rate_still_validated():
     ],
 )
 def test_non_mapping_audio_values_are_not_treated_as_mappings(value):
-    # The capability check is looser than isinstance; make sure the ordinary
-    # waveform/path payloads still fall through to their own branches.
+    # Ordinary waveform/path payloads still fall through to their own branches.
     assert not _is_audio_mapping(value)
 
 
@@ -489,17 +482,13 @@ def test_real_decoder_decodes_to_float32_at_every_gate(gate):
 # ---------------------------------------------------------------------------
 # Unpatched torchcodec AudioDecoder (unsloth/unsloth#7226, follow-up)
 #
-# UnslothVisionDataCollator is exported and can be driven on datasets >= 4
-# Audio() columns WITHOUT importing `unsloth` -- which is what applies
-# patch_torchcodec_audio_decoder() (unsloth/_gpu_init.py). An *unpatched* decoder
-# exposes only __getitem__ (no get/keys/__contains__), so a duck-typed gate alone
-# misses it and it reaches the feature extractor as an object array. The gate now
-# also matches the AudioDecoder type directly, and _resolve_audio_dict reads
-# values through _audio_get, which subscripts when .get is absent.
-#
-# In CI (no torchcodec) we stand a fake class in as the recognized decoder type by
-# patching _audio_decoder_types; the real-decoder variant runs in a fresh
-# subprocess because the monkey-patch mutates the class for the whole process.
+# Driving the collator without importing `unsloth` skips
+# patch_torchcodec_audio_decoder(), leaving a decoder with only __getitem__ (no
+# get/keys/__contains__) that a duck-typed gate misses. The gate now matches the
+# AudioDecoder type directly and _audio_get subscripts when .get is absent.
+# In CI (no torchcodec) a fake stands in as the decoder type via _audio_decoder_types;
+# the real-decoder variant runs in a fresh subprocess since the patch mutates the
+# class process-wide.
 # ---------------------------------------------------------------------------
 
 
@@ -517,8 +506,7 @@ class _UnpatchedFakeAudioDecoder:
 
 @pytest.fixture
 def _recognize_unpatched_decoder(monkeypatch):
-    # Treat _UnpatchedFakeAudioDecoder as the torchcodec AudioDecoder type so these
-    # run in CI without datasets >= 4 / torchcodec installed.
+    # Treat _UnpatchedFakeAudioDecoder as the decoder type so these run in CI.
     monkeypatch.setattr(
         "unsloth_zoo.vision_utils._audio_decoder_types",
         lambda: (_UnpatchedFakeAudioDecoder,),
@@ -527,7 +515,7 @@ def _recognize_unpatched_decoder(monkeypatch):
 
 def test_unpatched_decoder_is_recognized_by_type(_recognize_unpatched_decoder):
     decoder = _UnpatchedFakeAudioDecoder()
-    # The premise: not a dict and none of the grafted mapping methods exist.
+    # Premise: not a dict and none of the grafted mapping methods exist.
     assert not isinstance(decoder, dict)
     assert not hasattr(decoder, "get")
     assert not hasattr(decoder, "keys")
@@ -546,7 +534,7 @@ def test_unpatched_decoder_top_level_gate(_recognize_unpatched_decoder):
 
 
 def test_unpatched_decoder_list_gate(_recognize_unpatched_decoder):
-    # Also guards the flat-samples branch: a list of decoders is a list of clips.
+    # A list of decoders is a list of clips.
     collator = make_collator()
     clips = collator._extract_audio_for_example(
         {"audio": [_UnpatchedFakeAudioDecoder(), _UnpatchedFakeAudioDecoder()]},
@@ -582,8 +570,7 @@ class _NonCallableMappingAttrs:
 
 
 def test_non_callable_mapping_attrs_are_not_treated_as_mappings():
-    # hasattr would accept this and then fail later calling a None `.get`; the
-    # callable() gate rejects it up front instead.
+    # callable() gate rejects this up front (hasattr would accept, then fail on None .get).
     assert not _is_audio_mapping(_NonCallableMappingAttrs())
 
 
@@ -599,9 +586,9 @@ def test_userdict_audio_payload_resolves():
 
 
 def test_real_unpatched_decoder_decodes_in_fresh_process():
-    # Gold-standard: a REAL torchcodec AudioDecoder, never patched, decoded through
-    # the collator in a clean interpreter (the patch mutates the class globally, so
-    # this must not share a process with the patched real-decoder tests above).
+    # A REAL, never-patched torchcodec AudioDecoder through the collator in a clean
+    # interpreter (the patch mutates the class globally, so it can't share a process
+    # with the patched real-decoder tests above).
     pytest.importorskip("datasets", minversion="4.0.0")
     pytest.importorskip("torchcodec")
     code = textwrap.dedent(

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -551,6 +551,23 @@ def _fix_audio_feature_extractor_padding_side(processor):
         feature_extractor.padding_side = "right"
 
 
+def _is_audio_mapping(audio):
+    # datasets >= 4 hands back torchcodec AudioDecoder objects for Audio() columns.
+    # patch_torchcodec_audio_decoder grafts the mapping protocol onto that class
+    # rather than making it a dict subclass, so isinstance(audio, dict) is False
+    # even though _resolve_audio_dict's `.get("array")` access works on it. Gating
+    # on isinstance alone therefore drops decoders into the raw-waveform catch-all,
+    # and they reach the feature extractor as an object array (see #7226). Match on
+    # the interface the patch actually grafts so the gates agree with the patch.
+    if isinstance(audio, dict):
+        return True
+    return (
+        hasattr(audio, "get") and
+        hasattr(audio, "keys") and
+        hasattr(audio, "__contains__")
+    )
+
+
 def _resolve_audio_dict(audio, sampling_rate=None):
     # HuggingFace Audio feature dict -> waveform array, else a path / url string
     # (covers Audio(decode=False) payloads like {"bytes": None, "path": ...})
@@ -581,7 +598,7 @@ def extract_audio_info(
                     # Feature extractors also accept local paths and URLs as strings
                     if audio is None:
                         audio = ele.get("url") or ele.get("path")
-                    if isinstance(audio, dict):
+                    if _is_audio_mapping(audio):
                         audio = _resolve_audio_dict(audio, sampling_rate)
                     if audio is None:
                         raise ValueError(
@@ -1049,7 +1066,7 @@ class UnslothVisionDataCollator:
             # No usable top-level audio -> fall back to inline message content
             clips = extract_audio_info(messages, sampling_rate=target_sr)
         # HuggingFace Audio feature: {"array": np.ndarray, "sampling_rate": int, ...}
-        elif isinstance(audio_val, dict):
+        elif _is_audio_mapping(audio_val):
             clip = _resolve_audio_dict(audio_val, target_sr)
             if clip is None:
                 raise ValueError(
@@ -1062,12 +1079,16 @@ class UnslothVisionDataCollator:
                 clips = []
             # A flat list of samples is one clip, not a list of clips
             # (strings are path/url clips, so they stay in the list-of-clips branch)
-            elif not isinstance(audio_val[0], (dict, list, tuple, str)) and getattr(audio_val[0], "ndim", 0) == 0:
+            elif (
+                not _is_audio_mapping(audio_val[0])
+                and not isinstance(audio_val[0], (list, tuple, str))
+                and getattr(audio_val[0], "ndim", 0) == 0
+            ):
                 clips = [audio_val]
             else:
                 clips = []
                 for clip in audio_val:
-                    if isinstance(clip, dict):
+                    if _is_audio_mapping(clip):
                         clip = _resolve_audio_dict(clip, target_sr)
                         if clip is None:
                             raise ValueError(

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -554,14 +554,9 @@ def _fix_audio_feature_extractor_padding_side(processor):
 
 @lru_cache(maxsize=1)
 def _audio_decoder_types():
-    # datasets >= 4 hands back torchcodec AudioDecoder objects for Audio() columns.
-    # Recognize that class directly so the gates work whether or not
-    # patch_torchcodec_audio_decoder() has grafted the mapping protocol onto it:
-    # UnslothVisionDataCollator is exported and can be used without importing
-    # `unsloth` (which is what applies the patch, in unsloth/_gpu_init.py). An
-    # *unpatched* decoder exposes only __getitem__, so a duck-typed get/keys check
-    # misses it and it reaches the feature extractor as an object array (see #7226).
-    # Returns () when the optional dependency is unavailable (e.g. datasets < 4).
+    # torchcodec AudioDecoder type (datasets >= 4 Audio() columns), matched
+    # directly so an unpatched decoder (only __getitem__) is still recognized.
+    # Returns () when datasets < 4 / the dep is unavailable. See #7226.
     try:
         from datasets.features._torchcodec import AudioDecoder
     except (ImportError, AttributeError, RuntimeError):
@@ -570,14 +565,10 @@ def _audio_decoder_types():
 
 
 def _is_audio_mapping(audio):
-    # A value that _resolve_audio_dict can pull an "array"/"sampling_rate" out of:
-    # a genuine mapping (dict / UserDict / ...), a torchcodec AudioDecoder (patched
-    # or not), or a test double that grafts the same mapping protocol. Gating on
-    # isinstance(dict) alone drops decoders into the raw-waveform catch-all (#7226).
-    # The decoder type check covers the unpatched decoder; the callable duck-type
-    # fallback covers a patched decoder even where the class identity is not
-    # importable. callable() (not hasattr) avoids matching objects with a non-
-    # callable `get`/`keys` attribute.
+    # True for anything _resolve_audio_dict can read "array"/"sampling_rate" from:
+    # a Mapping, a torchcodec AudioDecoder, or a duck-typed mapping. isinstance(dict)
+    # alone drops decoders into the raw-waveform catch-all (#7226). callable() (not
+    # hasattr) rejects objects with a non-callable get/keys.
     if isinstance(audio, Mapping):
         return True
     if isinstance(audio, _audio_decoder_types()):
@@ -590,10 +581,8 @@ def _is_audio_mapping(audio):
 
 
 def _audio_get(audio, key, default=None):
-    # Mapping-style lookup that also works on an *unpatched* torchcodec AudioDecoder
-    # (only __getitem__, no .get). Genuine dicts and patched decoders keep using
-    # .get; the subscript fallback is reached only for the unpatched decoder, whose
-    # __getitem__ raises KeyError for anything other than "array"/"sampling_rate".
+    # Mapping-style lookup that falls back to subscripting for an unpatched
+    # AudioDecoder (only __getitem__, no .get).
     getter = getattr(audio, "get", None)
     if callable(getter):
         return getter(key, default)

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -47,6 +47,7 @@ import time
 import warnings
 import os
 from functools import lru_cache
+from collections.abc import Mapping
 
 
 import requests
@@ -551,30 +552,64 @@ def _fix_audio_feature_extractor_padding_side(processor):
         feature_extractor.padding_side = "right"
 
 
-def _is_audio_mapping(audio):
+@lru_cache(maxsize=1)
+def _audio_decoder_types():
     # datasets >= 4 hands back torchcodec AudioDecoder objects for Audio() columns.
-    # patch_torchcodec_audio_decoder grafts the mapping protocol onto that class
-    # rather than making it a dict subclass, so isinstance(audio, dict) is False
-    # even though _resolve_audio_dict's `.get("array")` access works on it. Gating
-    # on isinstance alone therefore drops decoders into the raw-waveform catch-all,
-    # and they reach the feature extractor as an object array (see #7226). Match on
-    # the interface the patch actually grafts so the gates agree with the patch.
-    if isinstance(audio, dict):
+    # Recognize that class directly so the gates work whether or not
+    # patch_torchcodec_audio_decoder() has grafted the mapping protocol onto it:
+    # UnslothVisionDataCollator is exported and can be used without importing
+    # `unsloth` (which is what applies the patch, in unsloth/_gpu_init.py). An
+    # *unpatched* decoder exposes only __getitem__, so a duck-typed get/keys check
+    # misses it and it reaches the feature extractor as an object array (see #7226).
+    # Returns () when the optional dependency is unavailable (e.g. datasets < 4).
+    try:
+        from datasets.features._torchcodec import AudioDecoder
+    except (ImportError, AttributeError, RuntimeError):
+        return ()
+    return (AudioDecoder,)
+
+
+def _is_audio_mapping(audio):
+    # A value that _resolve_audio_dict can pull an "array"/"sampling_rate" out of:
+    # a genuine mapping (dict / UserDict / ...), a torchcodec AudioDecoder (patched
+    # or not), or a test double that grafts the same mapping protocol. Gating on
+    # isinstance(dict) alone drops decoders into the raw-waveform catch-all (#7226).
+    # The decoder type check covers the unpatched decoder; the callable duck-type
+    # fallback covers a patched decoder even where the class identity is not
+    # importable. callable() (not hasattr) avoids matching objects with a non-
+    # callable `get`/`keys` attribute.
+    if isinstance(audio, Mapping):
+        return True
+    if isinstance(audio, _audio_decoder_types()):
         return True
     return (
-        hasattr(audio, "get") and
-        hasattr(audio, "keys") and
-        hasattr(audio, "__contains__")
+        callable(getattr(audio, "get", None)) and
+        callable(getattr(audio, "keys", None)) and
+        callable(getattr(audio, "__contains__", None))
     )
+
+
+def _audio_get(audio, key, default=None):
+    # Mapping-style lookup that also works on an *unpatched* torchcodec AudioDecoder
+    # (only __getitem__, no .get). Genuine dicts and patched decoders keep using
+    # .get; the subscript fallback is reached only for the unpatched decoder, whose
+    # __getitem__ raises KeyError for anything other than "array"/"sampling_rate".
+    getter = getattr(audio, "get", None)
+    if callable(getter):
+        return getter(key, default)
+    try:
+        return audio[key]
+    except (KeyError, TypeError, IndexError):
+        return default
 
 
 def _resolve_audio_dict(audio, sampling_rate=None):
     # HuggingFace Audio feature dict -> waveform array, else a path / url string
     # (covers Audio(decode=False) payloads like {"bytes": None, "path": ...})
-    _check_audio_sampling_rate(audio.get("sampling_rate"), sampling_rate)
-    value = audio.get("array")
+    _check_audio_sampling_rate(_audio_get(audio, "sampling_rate"), sampling_rate)
+    value = _audio_get(audio, "array")
     if value is None:
-        value = audio.get("path") or audio.get("url")
+        value = _audio_get(audio, "path") or _audio_get(audio, "url")
     return value
 
 


### PR DESCRIPTION
# Fix Gemma 4 audio training crash on `datasets>=4` AudioDecoder columns
 
Refs unslothai/unsloth#7226
 
## The bug
 
Gemma 4 audio training crashes before step 1 with:
 
```
TypeError: ufunc 'rfft_n_even' not supported for the input types
```
 
Root cause is a contradiction between two pieces of our own code:
 
- `patch_torchcodec_audio_decoder` (`dataset_utils.py`) grafts the **mapping protocol** (`get` / `keys` / `__contains__` / `__iter__`) onto `datasets`' torchcodec `AudioDecoder` — it teaches the decoder to quack like a dict, but does **not** make it a `dict` subclass.
- The audio gates in `vision_utils.py` then test `isinstance(x, dict)`, which is `False` for a patched decoder. So decoders fall through every audio branch to the raw-waveform catch-all and reach the feature extractor as an **object-dtype array**. `np.fft.rfft` has no object loop, so it raises.
The patch says "treat this as a dict"; the gates refuse to. `_resolve_audio_dict` — the code that actually handles a dict — already works on a patched decoder (it only uses `.get`), so **only the gates needed changing**.
 
## Not a numpy 2 bug
 
numpy 2.x is only why the error message reads `ufunc 'rfft_n_even' not supported`. On numpy 1.x the same object array fails with `ValueError: setting an array element with a sequence`. The defect is the dict-gate miss, not the numpy version, and the fix is not numpy-conditional.
 
## The fix
 
One module-level predicate in `vision_utils.py`:
 
```python
def _is_audio_mapping(audio):
    if isinstance(audio, dict):
        return True
    return (
        hasattr(audio, "get") and
        hasattr(audio, "keys") and
        hasattr(audio, "__contains__")
    )
```
 
Applied at **four** sites (the `isinstance(dict)` check is kept first, so genuine dicts take the byte-for-byte identical branch as before):
 
| Site | Gate |
|---|---|
| inline message content (`{"type": "audio", ...}`) | top gate for the conversational path |
| top-level audio column | list/column path |
| inside a list of clips | multi-audio examples |
| the flat-samples guard | **required too** — a list of decoders was collapsed into a single clip here *before* it could reach the list-of-clips gate |
 
The fourth site is why fixing only the obvious gates wouldn't have fixed it: `[decoder]` never reached the list-of-clips gate because the flat-samples guard caught it first (a decoder is not `(dict, list, tuple, str)` and `ndim` falls back to `0`).
 
`dataset_utils.py` and `_resolve_audio_dict` are untouched.
 
## Verification (CPU, no CUDA, no model weights)
 
Reproduced end-to-end against the **real** `datasets` `AudioDecoder` (not a stub), constructed from an in-memory WAV and driven through the real `UnslothVisionDataCollator` into the real `Gemma4AudioFeatureExtractor`:
 
- Original repro now passes: decoder → `float32 (4000,)` → `input_features (1, 25, 128)`, no crash.
- All three gates fixed (`decoder` column, `[decoder]`, inline message content) — all previously reproduced the crash.
- Confirmed on two version combinations: `datasets 5.0.0 / torchcodec 0.15.0 / numpy 2.5.1` and `datasets 4.3.0 / torchcodec 0.10.0 / numpy 2.4.4`.
No regressions — these baselines are byte-identical before and after (same dtype and shape), confirming genuine dicts and raw waveforms are unaffected:
 
| Input | Result |
|---|---|
| real dict | `(1, 25, 128)` float32 |
| bare ndarray | `(1, 25, 128)` float32 |
| flat list | `(1, 25, 128)` **float64** (unchanged) |
| ragged list | `(2, 25, 128)` float64 |
 
(The flat-list path staying float64 confirms an alternative "just cast to float32 in the collator" fix was correctly **not** taken — it would have changed a working path for no benefit.)
 
## Tests
 
`tests/test_vision_collator_audio.py`: 44 passed (4 new groups). Adjacent collator suites: 129 passed, 2 skipped. Canonical MLX baseline: 128 passed, 0 failures.
 
**CI coverage measured, not assumed** — simulating a torchcodec-free box (as Unsloth CI runs):
- **40 tests run in CI unconditionally**, including all three gate regressions, driven through a `_FakeAudioDecoder` that mirrors the real class's surface exactly (the four grafted methods + `__getitem__`, not a dict subclass, no `ndim`), asserting `float32` output and `dtype != object`.
- **4 tests skip** without torchcodec — the real-`AudioDecoder` tests.
## Named risk (not a no-op)
 
The capability check is **looser** than `isinstance(dict)`: any object exposing `get` + `keys` + `__contains__` passed as audio now routes to `_resolve_audio_dict` instead of the raw-waveform catch-all. This is a genuine widening. A dedicated test (`test_non_mapping_audio_values_are_not_treated_as_mappings`, covering ndarray / flat list / path string / torch tensor) pins that ordinary payloads are unaffected. Such an object crashes today regardless, so the widening only changes behavior for values that were already broken.
 
A related fragility for reviewers: if a future `datasets` adds `__contains__` to `AudioDecoder` but not `get`/`keys`, `patch_torchcodec_audio_decoder`'s early-out would fire and this predicate would return `False`, resurfacing the bug. Speculative, so not coded against.
 
## Honest scope
 
The mechanism is confirmed end-to-end against the real decoder. I could **not** confirm the reporter's exact environment — #7226 has no version info — so "this is the path that bit them" remains inference rather than proof. Using `Refs` rather than `Fixes` so the issue can be closed once the reporter confirms versions.