### PR TITLE
fix: unstack hf_to_vllm_mapper for in-memory LoRA on vLLM >= 0.25.0 and enable XPU

### DIFF
--- a/tests/test_vllm_lora_unstacked_mapper.py
+++ b/tests/test_vllm_lora_unstacked_mapper.py
@@ -1,0 +1,198 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""GPU-free regression tests for the vLLM >= 0.25.0 LoRA weights-mapper fix.
+
+vLLM 0.25.0 folds the QKV/MLP fusion (q_proj/k_proj/v_proj -> qkv_proj,
+gate/up -> gate_up_proj) into WeightsMapper.orig_to_new_stacked. The LoRA name
+parser calls mapper._map_name which drops the shard id, so the constituent
+projections collapse onto one fused key and collide in the in-memory LoRA tensor
+dict, crashing GRPO fast_inference=True with IndexError during activation.
+
+The fix in vllm_lora_worker_manager.py calls WeightsMapper.get_unstacked_mapper()
+(present only on vLLM >= 0.25.0) to drop the stacked maps while keeping genuine
+renames. These tests drive the real WorkerLoRAManager._load_adapter with light
+fakes (no GPU, no real vLLM init) and assert which mapper reaches the loader,
+for both the in-memory and local-checkpoint paths and both loader signatures.
+"""
+
+import types
+import pytest
+
+import unsloth_zoo.vllm_lora_worker_manager as wm
+
+
+class _StackedMapper:
+    """Fake vLLM >= 0.25.0 WeightsMapper exposing get_unstacked_mapper()."""
+
+    def __init__(self):
+        self.calls = 0
+        self.unstacked = object()  # distinct sentinel returned by the method
+
+    def get_unstacked_mapper(self):
+        self.calls += 1
+        return self.unstacked
+
+
+class _FakePEFTHelper:
+    @staticmethod
+    def from_dict(config):
+        return _FakePEFTHelper()
+
+    @staticmethod
+    def from_local_dir(lora_dir, max_position_embeddings, *args, **kwargs):
+        return _FakePEFTHelper()
+
+    def validate_legal(self, lora_config):
+        return None
+
+
+def _make_recording_lora_model_cls(record, *, new_signature):
+    """Fake _lora_model_cls whose loaders record the kwargs they receive.
+
+    ``new_signature`` toggles whether the loader exposes ``model_vocab_size``
+    (newer vLLM) so we cover _load_adapter's signature branch without installing
+    multiple vLLM versions.
+    """
+    if new_signature:
+        def _loader(lora_model_id, peft_helper, dtype, weights_mapper,
+                    tensors=None, lora_dir=None, device=None,
+                    expected_lora_modules=None, model_vocab_size=None):
+            record["weights_mapper"] = weights_mapper
+            record["tensors"] = tensors
+            record["lora_dir"] = lora_dir
+            return types.SimpleNamespace(extra_vocab_size=0, id=lora_model_id)
+    else:
+        def _loader(lora_model_id, peft_helper, dtype, weights_mapper,
+                    tensors=None, lora_dir=None, device=None,
+                    expected_lora_modules=None, target_embedding_padding=None,
+                    embedding_modules=None, embedding_padding_modules=None):
+            record["weights_mapper"] = weights_mapper
+            record["tensors"] = tensors
+            record["lora_dir"] = lora_dir
+            return types.SimpleNamespace(extra_vocab_size=0, id=lora_model_id)
+
+    return types.SimpleNamespace(from_lora_tensors=_loader,
+                                 from_local_checkpoint=_loader)
+
+
+def _make_manager(record, *, mapper, set_mapper_attr=True, new_signature=True):
+    """Construct a WorkerLoRAManager via __new__ with only what _load_adapter reads."""
+    mgr = object.__new__(wm.WorkerLoRAManager)
+
+    model = types.SimpleNamespace(supported_lora_modules=[], packed_modules_mapping={})
+    if set_mapper_attr:
+        model.hf_to_vllm_mapper = mapper
+
+    mgr._adapter_manager = types.SimpleNamespace(model=model)
+    mgr.max_position_embeddings = 2048
+    mgr.lora_config = types.SimpleNamespace(lora_dtype=None, lora_extra_vocab_size=0)
+    mgr.vocab_size = 32000
+    mgr.embedding_modules = {}
+    mgr.embedding_padding_modules = []
+    mgr._lora_model_cls = _make_recording_lora_model_cls(record, new_signature=new_signature)
+    return mgr
+
+
+def _in_memory_request():
+    return types.SimpleNamespace(
+        lora_path=None, lora_config={}, config={},
+        lora_tensors={"base_model.model.layer.q_proj.lora_A.weight": object()},
+        lora_int_id=1,
+    )
+
+
+def _checkpoint_request():
+    return types.SimpleNamespace(
+        lora_path="/tmp/does-not-need-to-exist", lora_config={}, config={},
+        lora_tensors=None, lora_int_id=2,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_vllm_helpers(monkeypatch):
+    """Swap in fakes for the vLLM helpers _load_adapter calls, GPU/vLLM-free."""
+    monkeypatch.setattr(wm, "PEFTHelper", _FakePEFTHelper, raising=False)
+    monkeypatch.setattr(wm, "get_adapter_absolute_path", lambda p: p, raising=False)
+    monkeypatch.setattr(wm, "LoRAModel", types.SimpleNamespace, raising=False)
+
+
+@pytest.mark.parametrize("new_signature", [True, False])
+def test_unstacked_mapper_used_for_in_memory_tensors(new_signature):
+    record = {}
+    mapper = _StackedMapper()
+    mgr = _make_manager(record, mapper=mapper, new_signature=new_signature)
+
+    mgr._load_adapter(_in_memory_request())
+
+    assert mapper.calls == 1, "get_unstacked_mapper must be called exactly once"
+    assert record["weights_mapper"] is mapper.unstacked
+    assert record["weights_mapper"] is not mapper
+    assert record["weights_mapper"] is not None
+    assert record["tensors"] is not None, "should hit the in-memory branch"
+
+
+def test_unstacked_mapper_used_for_local_checkpoint():
+    record = {}
+    mapper = _StackedMapper()
+    mgr = _make_manager(record, mapper=mapper)
+
+    mgr._load_adapter(_checkpoint_request())
+
+    assert mapper.calls == 1
+    assert record["weights_mapper"] is mapper.unstacked
+    assert record["tensors"] is None, "should hit the local-checkpoint branch"
+    assert record["lora_dir"] == "/tmp/does-not-need-to-exist"
+
+
+def test_legacy_mapper_without_unstack_is_forwarded_unchanged():
+    # vLLM < 0.25.0: mapper has no get_unstacked_mapper -> pass through intact
+    record = {}
+    legacy_mapper = object()
+    mgr = _make_manager(record, mapper=legacy_mapper)
+
+    mgr._load_adapter(_in_memory_request())
+
+    assert record["weights_mapper"] is legacy_mapper
+
+
+def test_noncallable_unstacked_attribute_is_forwarded_unchanged():
+    # Defensive: an attribute exists but is not callable -> do not invoke it
+    record = {}
+    weird_mapper = types.SimpleNamespace(get_unstacked_mapper="not-callable")
+    mgr = _make_manager(record, mapper=weird_mapper)
+
+    mgr._load_adapter(_in_memory_request())
+
+    assert record["weights_mapper"] is weird_mapper
+
+
+def test_none_mapper_is_forwarded():
+    record = {}
+    mgr = _make_manager(record, mapper=None, set_mapper_attr=True)
+
+    mgr._load_adapter(_in_memory_request())
+
+    assert record["weights_mapper"] is None
+
+
+def test_model_without_mapper_attribute_is_supported():
+    record = {}
+    mgr = _make_manager(record, mapper=None, set_mapper_attr=False)
+
+    mgr._load_adapter(_in_memory_request())
+
+    assert record["weights_mapper"] is None

--- a/tests/test_vllm_utils_xpu_sm_cap.py
+++ b/tests/test_vllm_utils_xpu_sm_cap.py
@@ -1,0 +1,58 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression guard for XPU SM-capability handling in _get_vllm_state_dict.
+
+Intel XPU (like AMD ROCm) has no NVIDIA SM capability, and
+torch.cuda.get_device_capability() fails there. _get_vllm_state_dict must skip
+the CUDA query and set sm_cap = 0 on XPU, gating out the SM90-only
+CUTLASS/DeepGEMM paths. The full function needs a live vLLM model, so this checks
+the source-level invariant (metadata-only, no import / no CUDA probe) the same
+way tests/test_zoo_history_regressions_deep.py does.
+"""
+
+import importlib.util
+import pathlib
+import re
+
+
+def _module_source_text(module_name: str) -> str:
+    # find_spec is metadata-only, so importing vllm_utils (and its import-time
+    # torch.cuda probes) is avoided on a CPU-only box.
+    spec = importlib.util.find_spec(module_name)
+    if spec is None or spec.origin in (None, "built-in"):
+        raise ImportError(f"could not locate source for {module_name!r}")
+    return pathlib.Path(spec.origin).read_text(encoding="utf-8")
+
+
+def test_get_vllm_state_dict_sm_cap_guards_rocm_and_xpu():
+    src = _module_source_text("unsloth_zoo.vllm_utils")
+
+    idx = src.find("sm_cap")
+    assert idx != -1, "sm_cap computation missing from vllm_utils.py"
+    window = src[max(0, idx - 400): idx + 400]
+
+    # The CUDA capability query must be gated behind BOTH the ROCm and XPU checks
+    guard = re.search(r"if\s+not\s+is_hip\(\)\s+and\s+DEVICE_TYPE\s*!=\s*[\"']xpu[\"']\s*:", window)
+    assert guard is not None, (
+        "sm_cap guard must exclude both ROCm and Intel XPU from the CUDA "
+        "capability query, e.g. `if not is_hip() and DEVICE_TYPE != \"xpu\":`. "
+        "Regression: XPU would call torch.cuda.get_device_capability() and crash."
+    )
+
+    assert re.search(r"sm_cap\s*=\s*0", window) is not None, (
+        "XPU/ROCm fallback must set sm_cap = 0."
+    )

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -150,12 +150,18 @@ class WorkerLoRAManager(AbstractWorkerManager):
                 peft_helper = PEFTHelper.from_dict(lora_request.config)
             peft_helper.validate_legal(self.lora_config)
 
-            # For some models like Qwen2VL, we need to use hf_to_vllm_mapper
-            # to ensure correct loading of lora weights.
+            # For some models like Qwen2VL, we need hf_to_vllm_mapper for correct
+            # lora loading. On vLLM >= 0.25.0 it also folds q/k/v (and gate/up)
+            # into orig_to_new_stacked; _map_name drops the shard id so they
+            # collide onto one key -> IndexError. Drop the stacked maps (keeping
+            # genuine renames) like vLLM's own worker_manager; absent on <0.25.0.
             hf_to_vllm_mapper = None
             if (hasattr(model, "hf_to_vllm_mapper")
                     and model.hf_to_vllm_mapper is not None):
                 hf_to_vllm_mapper = model.hf_to_vllm_mapper
+                unstack = getattr(hf_to_vllm_mapper, "get_unstacked_mapper", None)
+                if callable(unstack):
+                    hf_to_vllm_mapper = unstack()
 
             lora_extra_vocab_size = getattr(self.lora_config, "lora_extra_vocab_size", 0)
             kwargs = {
@@ -169,7 +175,6 @@ class WorkerLoRAManager(AbstractWorkerManager):
                 load_method = self._lora_model_cls.from_lora_tensors
                 kwargs["tensors"] = lora_request.lora_tensors
                 kwargs["device"] = None # Keep whatever the original device was
-                kwargs["weights_mapper"] = None
             else:
                 load_method = self._lora_model_cls.from_local_checkpoint
                 kwargs["lora_dir"] = lora_path

--- a/unsloth_zoo/vllm_lora_worker_manager.py
+++ b/unsloth_zoo/vllm_lora_worker_manager.py
@@ -169,6 +169,7 @@ class WorkerLoRAManager(AbstractWorkerManager):
                 load_method = self._lora_model_cls.from_lora_tensors
                 kwargs["tensors"] = lora_request.lora_tensors
                 kwargs["device"] = None # Keep whatever the original device was
+                kwargs["weights_mapper"] = None
             else:
                 load_method = self._lora_model_cls.from_local_checkpoint
                 kwargs["lora_dir"] = lora_path

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -943,13 +943,13 @@ def _get_vllm_state_dict(llm, return_state_dict = False, config = None, is_visio
     state_dict = OrderedDict()
     quant_state_dict = OrderedDict()
 
-    # AMD ROCm: SM architecture (SM80/SM90) concepts don't apply to gfx9xx.
+    # AMD ROCm (gfx9xx) and XPU: SM architecture (SM80/SM90) concepts don't apply.
     # CUTLASS block FP8 and DeepGEMM are NVIDIA Hopper (SM90) only.
-    if not is_hip():
+    if not is_hip() and DEVICE_TYPE != "xpu":
         capability = torch.cuda.get_device_capability()
         sm_cap = capability[0] * 10 + capability[1]
     else:
-        sm_cap = 0  # Not applicable on AMD; gates all SM90-specific paths
+        sm_cap = 0  # Not applicable on AMD/XPU; gates all SM90-specific paths
 
 
     try:


### PR DESCRIPTION
## What This PR Does

This PR adds 2 fixes for when using `fast_inference=True` in the GRPO trainer for vLLM rollout.

1. XPU enablement for compatibility.
Changes made to `unsloth_zoo/vllm_utils.py`: set `sm_cap = 0` when an XPU device is detected, so `torch.cuda.get_device_capability()` is not called on XPU. This extends the existing ROCm handling.

2. Fix for a LoRA collision bug on newer versions of vLLM (>= 0.25.0).
vLLM 0.25.0 introduced `orig_to_new_stacked` on the `WeightsMapper` class (`vllm/model_executor/models/utils.py`), which folds the QKV/MLP fusion (`q_proj`/`k_proj`/`v_proj` into `qkv_proj`, `gate`/`up` into `gate_up_proj`). vLLM's LoRA name parser calls `WeightsMapper._map_name`, which drops the shard id, so the constituent projections all map to the same fused key and collide in the in-memory LoRA tensor dict. This surfaces as `IndexError: tuple index out of range` during adapter activation.

The fix keeps `hf_to_vllm_mapper` but calls `get_unstacked_mapper()` on it (available on vLLM >= 0.25.0), which drops only the stacked `orig_to_new_stacked` maps while preserving the genuine renames and prefixes that multimodal models like Qwen2-VL need (for example `model.` to `language_model.model.`). This mirrors vLLM's own `vllm/lora/worker_manager.py`. It is applied at the shared mapper construction, so both the in-memory (`from_lora_tensors`) and local-checkpoint (`from_local_checkpoint`) load paths are covered. The call is guarded by a `callable()` check, so older vLLM without that method is unaffected (there is no stacking to undo there).

An earlier revision of this PR set `weights_mapper=None` for the in-memory branch. That avoided the collision but also dropped the genuine renames, which would skip or misplace LoRA weights for multimodal models. The `get_unstacked_mapper()` approach fixes the collision without that regression.

## Testing

Added GPU-free regression tests (no real vLLM required):

- `tests/test_vllm_lora_unstacked_mapper.py` drives the real `WorkerLoRAManager._load_adapter` with lightweight fakes and asserts the unstacked mapper reaches the loader for both the in-memory and local-checkpoint paths and both loader signatures, and that a legacy mapper without the method, a `None` mapper, and a model without the attribute all pass through unchanged.
- `tests/test_vllm_utils_xpu_sm_cap.py` guards the source invariant that `_get_vllm_state_dict` excludes both ROCm and XPU from the CUDA capability query and zeros `sm_cap`.

The end-to-end reproduction lives in [unsloth PR #7136](https://github.com/unslothai/unsloth/pull/7136).

Full traceback of the error on CUDA (the same error is observed on XPU after adding the XPU compatibility fix):

<details>
<summary>Traceback</summary>

```bash
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/joshua/dev/test_fast_inference.py", line 134, in <module>
[rank0]:     trainer_stats = trainer.train()
[rank0]:   File "/home/joshua/dev/unsloth_compiled_cache/UnslothGRPOTrainer.py", line 101, in wrapper
[rank0]:     output = f(self, *args, **kwargs)
[rank0]:   File "/home/joshua/dev/.venv/lib/python3.12/site-packages/unsloth/models/rl.py", line 143, in _unsloth_train_with_resume_guard
[rank0]:     return original_train(self, *args, **kwargs)
[rank0]:   File "/home/joshua/dev/.venv/lib/python3.12/site-packages/transformers/trainer.py", line 1437, in train
[rank0]:     return inner_training_loop(
[rank0]:   File "<string>", line 87, in _fast_inner_training_loop
[rank0]:   File "/home/joshua/dev/.venv/lib/python3.12/site-packages/transformers/trainer.py", line 1747, in _run_epoch
[rank0]:     tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
[rank0]:   File "<string>", line 34, in _unsloth_training_step
[rank0]:   File "/home/joshua/dev/.venv/lib/python3.12/site-packages/trl/extras/profiling.py", line 98, in wrapper
[rank0]:     return func(self, *args, **kwargs)
[rank0]:   File "/home/joshua/dev/unsloth_compiled_cache/UnslothGRPOTrainer.py", line 3951, in _prepare_inputs
[rank0]:     generation_batch = self._generate_and_score_completions(generation_batch)
[rank0]:   File "/home/joshua/dev/.venv/lib/python3.12/site-packages/unsloth/models/rl.py", line 561, in wrapped
[rank0]:     return original(self, *args, **kwargs)
[rank0]:   File "/home/joshua/dev/unsloth_compiled_cache/UnslothGRPOTrainer.py", line 4359, in _generate_and_score_completions
[rank0]:     ) = self._generate(prompts, images)
[rank0]:   File "/home/joshua/dev/unsloth_compiled_cache/UnslothGRPOTrainer.py", line 4290, in _generate
[rank0]:     prompt_ids, completion_ids, logprobs, forward_kwargs = self._generate_single_turn(prompts, images)
[rank0]:   File "/home/joshua/dev/unsloth_compiled_cache/UnslothGRPOTrainer.py", line 4179, in _generate_single_turn
[rank0]:     all_outputs = self.llm.generate(vllm_inputs, sampling_params=sampling_params, use_tqdm=False, lora_request = self.model.load_lora('grpo_trainer_lora_model', load_tensors = True) if getattr(self.llm, 'shared_weights', False) else None)
[rank0]:   File "/home/joshua/dev/.venv/lib/python3.12/site-packages/vllm/lora/model_manager.py", line 328, in activate_adapter
[rank0]:     module.set_lora(
[rank0]:   File "/home/joshua/dev/.venv/lib/python3.12/site-packages/vllm/lora/layers/column_parallel_linear.py", line 323, in set_lora
[rank0]:     index, 0, : lora_a_i.shape[0], : lora_a_i.shape[1]
[rank0]: IndexError: tuple index out of range
```

</details>

## Related Issues

Fixes [issue #7283](https://github.com/unslothai/unsloth/issues/7283). Unblocks the run with the test in [unsloth PR #7136](https://github.com/unslothai/unsloth/pull/7136).

## Environments Used

NVIDIA A100 (CUDA):
- vllm 0.25.1
- unsloth 2026.7.3
- unsloth-zoo 2026.7.3
- torch 2.11.0+cu129 (installed with vllm)
- triton 3.6.0
- trl 0.24.0

Intel Arc Pro B60 (XPU):
- vllm 0.23.1rc1.dev920+gdd127d82e.xpu (built from source)
- vllm-xpu-kernels 0.1.10.1
- unsloth 2026.7.3
- unsloth-zoo 2026.7.3
- torch 2.12.0+xpu
- triton-xpu 3.7.1
- trl 0.24.0
