### PR TITLE
Prefer rocBLAS over hipBLASLt on ROCm RDNA to avoid Composable Kernel GEMM JIT stall

### DIFF
--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -385,13 +385,13 @@ if not _SKIP_GPU_INIT:
         # CCE also fails in HIP / AMD
         os.environ["UNSLOTH_ENABLE_CCE"] = "0"
 
-    # ROCm RDNA (gfx10xx/11xx/12xx): the bundled hipBLASLt has no fallback Tensile
-    # kernels, so odd GEMM shapes from the compiled fwd+bwd graph get JIT-built via
-    # Composable Kernel on the first training step (the ~300s "a_grid_desc_*"
-    # descriptor flood). rocBLAS has prebuilt fallbacks and never JITs, so prefer it.
-    # torch reads these env vars lazily at first BLAS init, so setting them here
-    # (before any GEMM) is honoured, and it is the only lever that works on Windows.
-    # NVIDIA/Intel/Mac and AMD CDNA (good hipBLASLt coverage) are untouched.
+    # ROCm RDNA2/3/3.5/4: the bundled hipBLASLt can ship no fallback Tensile kernels
+    # (e.g. none for gfx1151, unlike rocBLAS), so odd GEMM shapes from the compiled
+    # fwd+bwd graph get JIT-built via Composable Kernel on the first training step
+    # (the ~300s "a_grid_desc_*" descriptor flood). rocBLAS has prebuilt fallbacks
+    # and never JITs, so prefer it. torch reads these env vars lazily at first BLAS
+    # init, so setting them here (before any GEMM) is honoured, and is the only lever
+    # that works on Windows. NVIDIA/Intel/Mac and AMD CDNA are untouched.
     # Kill switch: UNSLOTH_ROCM_PREFER_ROCBLAS=0.
     if IS_HIP_RUNTIME and os.environ.get(
         "UNSLOTH_ROCM_PREFER_ROCBLAS", "1"

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -400,6 +400,11 @@ if not _SKIP_GPU_INIT:
         import sys as _sys  # the MLX-alias _sys was del'd above; re-import locally
         # Did the user pin a BLAS backend? If so, do not override it at runtime.
         _user_blas = "TORCH_BLAS_PREFER_HIPBLASLT" in os.environ or "TORCH_BLAS_PREFER_CUBLASLT" in os.environ
+        # Did they pin it to the LT backend specifically? Then leave addmm on it too.
+        _user_wants_lt = any(
+            os.environ.get(_k, "").strip().lower() in ("1", "on", "true", "yes")
+            for _k in ("TORCH_BLAS_PREFER_HIPBLASLT", "TORCH_BLAS_PREFER_CUBLASLT")
+        )
         try:
             import torch as _torch
             _rocm_arch = str(getattr(
@@ -415,7 +420,8 @@ if not _SKIP_GPU_INIT:
         ):
             os.environ.setdefault("TORCH_BLAS_PREFER_HIPBLASLT", "0")
             os.environ.setdefault("TORCH_BLAS_PREFER_CUBLASLT", "0")
-            os.environ.setdefault("DISABLE_ADDMM_HIP_LT", "1")
+            if not _user_wants_lt:
+                os.environ.setdefault("DISABLE_ADDMM_HIP_LT", "1")
             # Non-Windows: also flip at runtime (no-op setter on Windows). Skip when
             # the user pinned a backend, so an explicit hipBLASLt choice is honoured.
             if not _user_blas and _sys.platform != "win32" and _torch is not None:
@@ -424,7 +430,7 @@ if not _SKIP_GPU_INIT:
                     try: _pref("cublas")  # prefer rocBLAS on ROCm
                     except Exception: pass  # best-effort; some builds lack the setter
                 del _pref
-        del _torch, _rocm_arch, _sys, _user_blas
+        del _torch, _rocm_arch, _sys, _user_blas, _user_wants_lt
     del remove_expandable_segments, delete_key, IS_HIP_RUNTIME, IS_TORCH_2_9_OR_NEWER, IS_TORCH_ROCM_BUILD, major_torch, minor_torch, torch_version, torch_version_raw, importlib_version, find_spec
     del clean_expandable_segments_value
     del _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF, _ORIGINAL_PYTORCH_HIP_ALLOC_CONF, _HAS_ORIGINAL_PYTORCH_ALLOC_CONF

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -389,9 +389,10 @@ if not _SKIP_GPU_INIT:
     # (e.g. none for gfx1151, unlike rocBLAS), so odd GEMM shapes from the compiled
     # fwd+bwd graph get JIT-built via Composable Kernel on the first training step
     # (the ~300s "a_grid_desc_*" descriptor flood). rocBLAS has prebuilt fallbacks
-    # and never JITs, so prefer it. torch reads these env vars lazily at first BLAS
-    # init, so setting them here (before any GEMM) is honoured, and is the only lever
-    # that works on Windows. NVIDIA/Intel/Mac and AMD CDNA are untouched.
+    # and never JITs, so prefer it. DISABLE_ADDMM_HIP_LT is read at addmm dispatch,
+    # so setting it here (before the first GEMM) keeps addmm off hipBLASLt-LT even on
+    # Windows, where the runtime setter below is a no-op; the TORCH_BLAS_PREFER_* env
+    # vars back it up on other paths. NVIDIA/Intel/Mac and AMD CDNA are untouched.
     # Kill switch: UNSLOTH_ROCM_PREFER_ROCBLAS=0.
     if IS_HIP_RUNTIME and os.environ.get(
         "UNSLOTH_ROCM_PREFER_ROCBLAS", "1"

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -420,8 +420,8 @@ if not _SKIP_GPU_INIT:
             if not _user_blas and _sys.platform != "win32" and _torch is not None:
                 _pref = getattr(getattr(_torch.backends, "cuda", None), "preferred_blas_library", None)
                 if callable(_pref):
-                    try: _pref("cublas")  # rocBLAS on ROCm
-                    except Exception: pass
+                    try: _pref("cublas")  # prefer rocBLAS on ROCm
+                    except Exception: pass  # best-effort; some builds lack the setter
                 del _pref
         del _torch, _rocm_arch, _sys, _user_blas
     del remove_expandable_segments, delete_key, IS_HIP_RUNTIME, IS_TORCH_2_9_OR_NEWER, IS_TORCH_ROCM_BUILD, major_torch, minor_torch, torch_version, torch_version_raw, importlib_version, find_spec

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -396,6 +396,9 @@ if not _SKIP_GPU_INIT:
     if IS_HIP_RUNTIME and os.environ.get(
         "UNSLOTH_ROCM_PREFER_ROCBLAS", "1"
     ).strip().lower() not in ("0", "off", "false", "no"):
+        import sys as _sys  # the MLX-alias _sys was del'd above; re-import locally
+        # Did the user pin a BLAS backend? If so, do not override it at runtime.
+        _user_blas = "TORCH_BLAS_PREFER_HIPBLASLT" in os.environ or "TORCH_BLAS_PREFER_CUBLASLT" in os.environ
         try:
             import torch as _torch
             _rocm_arch = str(getattr(
@@ -412,14 +415,15 @@ if not _SKIP_GPU_INIT:
             os.environ.setdefault("TORCH_BLAS_PREFER_HIPBLASLT", "0")
             os.environ.setdefault("TORCH_BLAS_PREFER_CUBLASLT", "0")
             os.environ.setdefault("DISABLE_ADDMM_HIP_LT", "1")
-            # Non-Windows: also flip at runtime (setter is a no-op on Windows).
-            if _sys.platform != "win32" and _torch is not None:
+            # Non-Windows: also flip at runtime (no-op setter on Windows). Skip when
+            # the user pinned a backend, so an explicit hipBLASLt choice is honoured.
+            if not _user_blas and _sys.platform != "win32" and _torch is not None:
                 _pref = getattr(getattr(_torch.backends, "cuda", None), "preferred_blas_library", None)
                 if callable(_pref):
                     try: _pref("cublas")  # rocBLAS on ROCm
                     except Exception: pass
                 del _pref
-        del _torch, _rocm_arch
+        del _torch, _rocm_arch, _sys, _user_blas
     del remove_expandable_segments, delete_key, IS_HIP_RUNTIME, IS_TORCH_2_9_OR_NEWER, IS_TORCH_ROCM_BUILD, major_torch, minor_torch, torch_version, torch_version_raw, importlib_version, find_spec
     del clean_expandable_segments_value
     del _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF, _ORIGINAL_PYTORCH_HIP_ALLOC_CONF, _HAS_ORIGINAL_PYTORCH_ALLOC_CONF

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -384,6 +384,42 @@ if not _SKIP_GPU_INIT:
     elif DEVICE_TYPE == "hip":
         # CCE also fails in HIP / AMD
         os.environ["UNSLOTH_ENABLE_CCE"] = "0"
+
+    # ROCm RDNA (gfx10xx/11xx/12xx): the bundled hipBLASLt has no fallback Tensile
+    # kernels, so odd GEMM shapes from the compiled fwd+bwd graph get JIT-built via
+    # Composable Kernel on the first training step (the ~300s "a_grid_desc_*"
+    # descriptor flood). rocBLAS has prebuilt fallbacks and never JITs, so prefer it.
+    # torch reads these env vars lazily at first BLAS init, so setting them here
+    # (before any GEMM) is honoured, and it is the only lever that works on Windows.
+    # NVIDIA/Intel/Mac and AMD CDNA (good hipBLASLt coverage) are untouched.
+    # Kill switch: UNSLOTH_ROCM_PREFER_ROCBLAS=0.
+    if IS_HIP_RUNTIME and os.environ.get(
+        "UNSLOTH_ROCM_PREFER_ROCBLAS", "1"
+    ).strip().lower() not in ("0", "off", "false", "no"):
+        try:
+            import torch as _torch
+            _rocm_arch = str(getattr(
+                _torch.cuda.get_device_properties(0), "gcnArchName", "") or ""
+            ).split(":")[0].strip()
+        except Exception:
+            _torch, _rocm_arch = None, ""
+        # is_rdna set (RDNA2/3/3.5/4); CDNA (MI, gfx9xx) excluded on purpose.
+        if _rocm_arch in (
+            "gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034", "gfx1035", "gfx1036",
+            "gfx1100", "gfx1101", "gfx1102", "gfx1103",
+            "gfx1150", "gfx1151", "gfx1152", "gfx1200", "gfx1201",
+        ):
+            os.environ.setdefault("TORCH_BLAS_PREFER_HIPBLASLT", "0")
+            os.environ.setdefault("TORCH_BLAS_PREFER_CUBLASLT", "0")
+            os.environ.setdefault("DISABLE_ADDMM_HIP_LT", "1")
+            # Non-Windows: also flip at runtime (setter is a no-op on Windows).
+            if _sys.platform != "win32" and _torch is not None:
+                _pref = getattr(getattr(_torch.backends, "cuda", None), "preferred_blas_library", None)
+                if callable(_pref):
+                    try: _pref("cublas")  # rocBLAS on ROCm
+                    except Exception: pass
+                del _pref
+        del _torch, _rocm_arch
     del remove_expandable_segments, delete_key, IS_HIP_RUNTIME, IS_TORCH_2_9_OR_NEWER, IS_TORCH_ROCM_BUILD, major_torch, minor_torch, torch_version, torch_version_raw, importlib_version, find_spec
     del clean_expandable_segments_value
     del _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF, _ORIGINAL_PYTORCH_HIP_ALLOC_CONF, _HAS_ORIGINAL_PYTORCH_ALLOC_CONF


### PR DESCRIPTION
## Summary

On ROCm RDNA GPUs (gfx10xx/11xx/12xx, e.g. gfx1151 Strix Halo / Radeon 8060S), the first `torch.compile` training step stalls for several minutes and floods stdout with Composable Kernel GEMM descriptors:

```
a_grid_desc_m_ak_container_{512, 32}
b_grid_desc_n_bk_container_{64, 32}
e_grid_desc_mblock_mperblock_nblock_nperblock_container_{512, 64}
```

The run looks frozen at `0/30`.

## Root cause

The bundled hipBLASLt for these arches ships no fallback Tensile kernels (rocBLAS ships 108 for gfx1151). Every odd GEMM shape the compiled forward+backward graph emits that hipBLASLt lacks a specialised solution for gets JIT-built through hipBLASLt's Composable Kernel path on first execution. That JIT is the flood and the multi-minute stall, and it recurs on every process because it happens inside hipBLASLt (Mega-cache only persists inductor/autograd/autotune artifacts, not the BLAS library's own kernel cache). rocBLAS serves any shape from prebuilt kernels and never JITs.

Eager training does not hit this (its shapes are the model's natural, well-covered ones); only the compiled graph, which materialises many small/padded/transposed shapes, does.

## Fix

Prefer rocBLAS over hipBLASLt on RDNA. The lever that removes the stall is `DISABLE_ADDMM_HIP_LT`, which torch reads at addmm dispatch (not at import), so setting it before the first GEMM keeps addmm off the hipBLASLt-LT path even on Windows, where `torch.backends.cuda.preferred_blas_library()` is a documented no-op. On other platforms we additionally flip the preference at runtime. `TORCH_BLAS_PREFER_HIPBLASLT` / `TORCH_BLAS_PREFER_CUBLASLT` are set too as a backstop (RDNA already defaults to rocBLAS).

- Gated to RDNA arches (the same set as `unsloth.kernels.utils.is_rdna`). NVIDIA (not HIP), Intel/XPU, Mac, and AMD CDNA (MI, gfx9xx, good hipBLASLt coverage) are left untouched.
- Uses `setdefault`, and skips the runtime setter when either `TORCH_BLAS_PREFER_*` is already set, so an explicit user choice always wins.
- Kill switch: `UNSLOTH_ROCM_PREFER_ROCBLAS=0`.

## Measured impact

Qwen3.5-2B LoRA (4bit), gfx1151 (Radeon 8060S), ROCm 7.13, torch 2.11, transformers 5.5. Same script, only `UNSLOTH_ROCM_PREFER_ROCBLAS` toggled:

| | step 0 | step 1 | `a_grid_desc` flood |
| --- | --- | --- | --- |
| before (hipBLASLt) | 368.87 s | 1.34 s | 24 lines |
| after (rocBLAS) | 9.02 s | 1.33 s | none |

`torch.compile` stays enabled, steady-state step time is unchanged, and losses match (0.0671 vs 0.0675). Setting only `DISABLE_ADDMM_HIP_LT=1` after torch import reproduces the fix on its own (step 0 8.2 s, no flood), confirming it is the operative lever. The kill switch restores the previous behaviour.

## Notes

- No change to any transformers / TRL / vLLM code path; this only sets a torch BLAS preference.
- Guarded against no GPU, hipBLASLt absent, and older torch lacking `preferred_blas_library`.
