### PR TITLE
feat(mlx): true grad-norm reporting and compiled global-norm clipping with gradient accumulation

### DIFF
--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -392,8 +392,8 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
     cmd = [
         str(launcher), "-n", "2", "--backend", "ring",
-        "--python", sys.executable, "--cwd", str(repo_root),
-        str(script), str(tmp_path),
+        "--cwd", str(repo_root),
+        "--", sys.executable, str(script), str(tmp_path),
     ]
     proc = subprocess.run(
         cmd, capture_output=True, env=env, text=True, timeout=120,

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -499,13 +499,12 @@ def test_norm_clip_dtype_restore_keeps_lora_and_norms_promotable():
 def test_global_norm_clip_reduces_in_float32():
     import inspect
 
-    from unsloth_zoo.mlx.trainer import _clip_grad_norm_fp32
+    from unsloth_zoo.mlx.trainer import _clip_grad_norm_fp32, _global_grad_norm_fp32
 
-    source = inspect.getsource(_clip_grad_norm_fp32)
-
-    assert "g.astype(mx.float32)" in source
-    assert "scale.astype(g.dtype)" in source
-    assert "tree_reduce" in source
+    norm_source = inspect.getsource(_global_grad_norm_fp32)
+    assert "g.astype(mx.float32)" in norm_source
+    assert "tree_reduce" in norm_source
+    assert "scale.astype(g.dtype)" in inspect.getsource(_clip_grad_norm_fp32)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -23,6 +23,14 @@ if not _METAL:
 
 metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
 
+if _METAL:
+    # Module scope: leaked mlx-simulation shims must not hijack test-time imports.
+    import mlx.nn as nn
+    from mlx.utils import tree_flatten, tree_map
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+    from unsloth_zoo.mlx.utils import make_baseline_loss_fn
+
 MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
 
 
@@ -34,9 +42,6 @@ def _dataset(n=24):
 
 
 def _train(tmp_path, **config_overrides):
-    from unsloth_zoo.mlx.loader import FastMLXModel
-    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
-
     model, tokenizer = FastMLXModel.from_pretrained(MODEL, max_seq_length=256)
     model = FastMLXModel.get_peft_model(model, r=8, lora_alpha=16, lora_dropout=0)
     config = dict(
@@ -90,3 +95,140 @@ def test_lora_sft_baseline_loss_value_clip(tmp_path):
         max_steps=4,
     )
     _assert_history(trainer, min_steps=4)
+
+
+_NormTok = type("Tok", (), {"pad_token_id": 0, "eos_token_id": 0})
+
+
+def _norm_model(seed=77, dtype=None):
+    class _TinyLM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed = nn.Embedding(32, 4)
+            self.proj = nn.Linear(4, 32, bias=False)
+            self._config = {"model_type": "tiny"}
+
+        def __call__(self, input_ids):
+            return self.proj(self.embed(input_ids))
+
+    mx.random.seed(seed)
+    model = _TinyLM()
+    if dtype is not None:
+        model.set_dtype(dtype)
+    mx.eval(model.parameters())
+    return model
+
+
+def _norm_batches(count):
+    rows = ([1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14, 15])
+    return [
+        (mx.array([rows[i % 3]], dtype=mx.int32),
+         mx.array([[0, len(rows[i % 3])]], dtype=mx.int32), None)
+        for i in range(count)
+    ]
+
+
+_CLIP = {
+    "none": dict(max_grad_norm=0.0, max_grad_value=0.0, max_grad_leaf_norm=0.0),
+    "leaf": dict(max_grad_norm=0.0, max_grad_value=None, max_grad_leaf_norm=0.01),
+    "global": dict(max_grad_norm=0.01, max_grad_value=None, max_grad_leaf_norm=None),
+}
+
+
+def _norm_train(tmp_path, mode, *, report=False, compiled=False, accum=1,
+                optim="adamw", weight_decay=0.0, dtype=None, max_steps=1,
+                batches=None, overrides=None):
+    import numpy as np
+
+    model = _norm_model(dtype=dtype)
+    config = dict(
+        per_device_train_batch_size=1, gradient_accumulation_steps=accum,
+        max_steps=max_steps, warmup_steps=0, learning_rate=1e-3,
+        weight_decay=weight_decay, optim=optim, logging_steps=1, eval_steps=0,
+        save_steps=0, max_seq_length=8, output_dir=str(tmp_path),
+        compile=compiled, compile_mode="strict" if compiled else "eager",
+        gradient_checkpointing=False, cast_norm_output_to_input_dtype=False,
+        dataset_order="sequential", disable_memory_limits=True,
+        use_cce=False, report_grad_norm=report, **_CLIP[mode],
+    )
+    config.update(overrides or {})
+    args = MLXTrainingConfig(**config)
+
+    class _Capturing(MLXTrainer):
+        def _build_optimizer(self, total_steps):
+            optimizer = super()._build_optimizer(total_steps)
+            self.captured_optimizer = optimizer
+            return optimizer
+
+    trainer = _Capturing(model, _NormTok(), [], args=args)
+    trainer._batches = batches if batches is not None else _norm_batches(max_steps * accum)
+    trainer.save_model = lambda *_a, **_k: None
+    callbacks = []
+    trainer.add_step_callback(lambda *v: callbacks.append(v))
+    result = trainer.train()
+    snap = {
+        f"param.{name}": (str(v.dtype), np.asarray(v.tolist()))
+        for name, v in tree_flatten(trainer.model.trainable_parameters())
+    }
+    snap.update({
+        f"opt.{name}": (str(v.dtype), np.asarray(v.tolist()))
+        for name, v in tree_flatten(trainer.captured_optimizer.state)
+        if hasattr(v, "dtype")
+    })
+    return trainer, result, callbacks, snap
+
+
+def _oracle_norm(batches, seed=77):
+    model = _norm_model(seed)
+    acc, toks = None, mx.array(0.0, dtype=mx.float32)
+    for batch in batches:
+        (_l, n), grad = nn.value_and_grad(model, make_baseline_loss_fn())(model, *batch)
+        weighted = tree_map(lambda g: g * n.astype(g.dtype), grad)
+        acc = weighted if acc is None else tree_map(lambda a, b: a + b, acc, weighted)
+        toks = toks + n.astype(mx.float32)
+    sq = mx.array(0.0, dtype=mx.float32)
+    for _n, v in tree_flatten(acc):
+        sq = sq + mx.sum((v.astype(mx.float32) / toks) ** 2)
+    return float(mx.sqrt(sq).item())
+
+
+@metal_only
+@pytest.mark.parametrize("mode,report,compiled,accum,optim,wd,expect", [
+    ("global", False, True, 2, "adamw", 0.0, "oracle"),
+    ("none", True, False, 3, "sgd", 0.5, "oracle"),  # decay excluded from norm
+    ("none", True, True, 1, "lion", 0.0, "reported"),  # no Adam second moment
+    ("leaf", False, False, 1, "adamw", 0.0, "absent"),
+])
+def test_grad_norm_reporting_matrix(tmp_path, mode, report, compiled, accum, optim, wd, expect):
+    batches = _norm_batches(accum)
+    trainer, _result, callbacks, _snap = _norm_train(
+        tmp_path, mode, report=report, compiled=compiled, accum=accum,
+        optim=optim, weight_decay=wd, batches=batches,
+    )
+    history = trainer._grad_norm_history
+    if expect == "absent":
+        assert history == [] and callbacks[0][8] is None
+    else:
+        assert len(history) == 1 and callbacks[0][8] == history[0]
+        if expect == "oracle":
+            assert history[0] == pytest.approx(_oracle_norm(batches), abs=1e-6)
+
+
+@metal_only
+def test_reporting_flag_never_changes_update_numerics(tmp_path):
+    import numpy as np
+
+    runs = {
+        r: _norm_train(tmp_path / str(r), "none", report=r, compiled=True,
+                       accum=1, max_steps=2, dtype=mx.bfloat16,
+                       batches=_norm_batches(2))
+        for r in (False, True)
+    }
+    (off_t, _res, _cb, off_snap), (on_t, _res2, _cb2, on_snap) = runs[False], runs[True]
+    assert off_t._train_loss_history == on_t._train_loss_history
+    for key in off_snap:
+        if key.startswith("param."):
+            assert off_snap[key][0] == on_snap[key][0] == "mlx.core.bfloat16"
+        assert off_snap[key][0] == on_snap[key][0], key
+        assert np.array_equal(off_snap[key][1], on_snap[key][1]), key
+    assert on_t._grad_norm_history and not off_t._grad_norm_history

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -232,3 +232,63 @@ def test_reporting_flag_never_changes_update_numerics(tmp_path):
         assert off_snap[key][0] == on_snap[key][0], key
         assert np.array_equal(off_snap[key][1], on_snap[key][1]), key
     assert on_t._grad_norm_history and not off_t._grad_norm_history
+
+
+# ---- Compiled global-norm clipping with gradient accumulation ----
+
+@metal_only
+def test_compiled_clip_accum_matches_eager_bitwise(tmp_path, capsys):
+    import numpy as np
+
+    runs = {
+        c: _norm_train(tmp_path / str(c), "global", compiled=c, accum=3,
+                       max_steps=2, dtype=mx.bfloat16, batches=_norm_batches(6))
+        for c in (False, True)
+    }
+    assert "mx.compile disabled because MLX global norm" not in capsys.readouterr().out
+    (eager_t, _r, _cb, eager_snap), (comp_t, comp_res, _cb2, comp_snap) = runs[False], runs[True]
+    assert comp_res["compile_enabled"] is True
+    assert comp_res["compile_scope"] == "full_step"
+    assert eager_t._train_loss_history == comp_t._train_loss_history
+    assert eager_t._grad_norm_history == comp_t._grad_norm_history
+    for key in eager_snap:
+        assert eager_snap[key][0] == comp_snap[key][0], key
+        assert np.array_equal(eager_snap[key][1], comp_snap[key][1]), key
+
+
+
+@metal_only
+def test_evaluation_failure_propagates_without_eager_retry(tmp_path, monkeypatch, capsys):
+    import functools
+
+    real_eval, real_compile = mx.eval, mx.compile
+    state = {"armed": False, "raised": False, "step_ran": False}
+
+    def failing_eval(*a, **k):
+        if state["armed"] and not state["raised"]:
+            state["raised"] = True
+            raise RuntimeError("injected compile evaluation failure")
+        return real_eval(*a, **k)
+
+    def arming_compile(fn, *ca, **ck):
+        compiled = real_compile(fn, *ca, **ck)
+
+        @functools.wraps(fn)
+        def wrapper(*fa, **fk):
+            # Arm AFTER the compiled step returns so the next mx.eval is the
+            # unified post-call boundary; a regression moving that eval inside
+            # the fallback try would retry eagerly and fail this test.
+            result = compiled(*fa, **fk)
+            state["step_ran"] = True
+            state["armed"] = True
+            return result
+        return wrapper
+
+    monkeypatch.setattr(mx, "eval", failing_eval)
+    monkeypatch.setattr(mx, "compile", arming_compile)
+    with pytest.raises(RuntimeError, match="injected compile evaluation failure"):
+        _norm_train(tmp_path, "global", compiled=True, accum=2,
+                    batches=_norm_batches(2),
+                    overrides={"compile_mode": "best_effort"})
+    assert state["step_ran"] and state["raised"]
+    assert "falling back to eager" not in capsys.readouterr().out

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2441,17 +2441,6 @@ class MLXTrainer:
         _compile_decision = getattr(self, "_compile_decision", None)
         _use_compile = compile_policy.mode != "eager"
         _ddp_compile_local_grad = _use_compile and distributed_world_size > 1
-        if (
-            _use_compile
-            and not _ddp_compile_local_grad
-            and max_grad_norm > 0
-            and grad_accum > 1
-        ):
-            _main_print(
-                "Unsloth: mx.compile disabled because MLX global norm "
-                "clipping is enabled with gradient accumulation."
-            )
-            _use_compile = False
         if is_vlm and _use_compile:
             qual = getattr(model, "_unsloth_compile_qualification", None) or get_compile_qualification(model)
             if qual is not None:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -472,6 +472,16 @@ def _clip_grad_by_leaf_norm(grad, max_grad_leaf_norm):
     return tree_map(_clip_leaf_norm, grad)
 
 
+def _global_grad_norm_fp32(grad):
+    """Fp32 L2 norm of a gradient tree (one cross-tree reduction)."""
+    norm_squared = tree_reduce(
+        lambda acc, g: acc + mx.sum(mx.square(g.astype(mx.float32))),
+        grad,
+        mx.array(0.0, dtype=mx.float32),
+    )
+    return mx.sqrt(norm_squared)
+
+
 def _clip_grad_norm_fp32(grad, max_norm):
     """Global norm clipping with a float32 norm reduction.
 
@@ -480,12 +490,7 @@ def _clip_grad_norm_fp32(grad, max_norm):
     which computes the clipping norm in fp32. Keep clipped leaves in their
     original dtype, but compute the single global scale in fp32.
     """
-    norm_squared = tree_reduce(
-        lambda acc, g: acc + mx.sum(mx.square(g.astype(mx.float32))),
-        grad,
-        mx.array(0.0, dtype=mx.float32),
-    )
-    total_norm = mx.sqrt(norm_squared)
+    total_norm = _global_grad_norm_fp32(grad)
     scale = mx.minimum(
         mx.array(max_norm, dtype=mx.float32) / (
             total_norm + mx.array(1e-6, dtype=mx.float32)
@@ -619,6 +624,29 @@ class MLXTrainingConfig:
     per_device_eval_batch_size: int | None = None
     image_size: object = None  # VLM image resize override from UnslothVisionDataCollator(resize=...)
 
+    # Opt-in true global grad-norm reporting when global-norm clipping is off.
+    # Declared LAST so every pre-existing field keeps its positional index in
+    # the custom __init__'s field-order binding.
+    # When global-norm clipping is the RESOLVED clip mode (max_grad_norm > 0
+    # and not overridden by max_grad_value / max_grad_leaf_norm), the pre-clip
+    # norm is computed for clipping anyway and is always reported; this flag
+    # has no effect there. Enabling it adds one cross-tree fp32 reduction
+    # per optimizer update — the same class of peak-memory cost global
+    # clipping itself pays (see the max_grad_norm note above).
+    # When False (default) no reporting reduction exists in the graph;
+    # grad_norm is absent from console/W&B/TB, _grad_norm_history stays empty
+    # (so Studio's grad-norm chart shows no samples), and the legacy 9-argument
+    # step callback receives None as its final argument. Reporting never
+    # changes update numerics: the grad_accum == 1 fast path keeps its exact
+    # update and derives the reported value from a norm-only copy that
+    # reproduces the accumulated path's rounding, so the value is numerically
+    # identical to the norm global clipping computes for bf16/fp32 models
+    # (fp16 leaves are weighted in fp32, since fp16 cannot represent token
+    # counts >= 65520). The reported value is the norm of the token-normalized
+    # gradient — after the accumulation divide, DDP reduction, and the
+    # LoRA+/embedding-LR ratios; before any clipping and before weight decay.
+    report_grad_norm: bool = False
+
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
         if len(args) > len(config_fields):
@@ -655,7 +683,14 @@ class MLXTrainingConfig:
 
         warmup_steps_default = type(self).warmup_steps
         warmup_ratio_default = type(self).warmup_ratio
-        copied_all_fields = len(provided) == len(config_fields)
+        # Fields appended to the dataclass after configs began round-tripping
+        # through full-field dict dumps. A legacy dump that predates them is
+        # still a wholesale copy and must be detected as one, or its copied
+        # default warmup_steps would start overriding a non-default
+        # warmup_ratio.
+        _appended_fields = {"report_grad_norm"}
+        _field_names = {field.name for field in config_fields}
+        copied_all_fields = (_field_names - _appended_fields) <= set(provided)
         copied_default_warmup_with_ratio = (
             copied_all_fields
             and getattr(self, "warmup_steps", None) == warmup_steps_default
@@ -1127,6 +1162,9 @@ class MLXTrainer:
 
         fn(step, total_steps, loss, lr, tokens_sec, peak_gb, elapsed,
            num_tokens, grad_norm=None)
+
+        grad_norm: fp32 pre-clip norm; a float when global-norm clipping is
+        active or ``report_grad_norm=True``, otherwise passed as None.
         """
         self._step_callbacks.append(fn)
 
@@ -2154,7 +2192,6 @@ class MLXTrainer:
             )
 
         _needs_grad_scaling = use_lora_plus or use_embedding_lr
-        _warned_skip_optimizer_state_grad_norm = False
 
         # Build step functions following mlx-lm's pattern. `max_grad_value`
         # remains an elementwise clamp. MLX's cheap default is now the clearer
@@ -2188,6 +2225,11 @@ class MLXTrainer:
             )
         _clip_grad_value = max_grad_value > 0
         _clip_grad_leaf_norm = max_grad_leaf_norm > 0
+        # Construction-time Python constant: selects one of two step-graph
+        # shapes for the whole run. Never a runtime or mx.array condition —
+        # that would add a report/no-report compile trace signature.
+        _report_grad_norm = bool(getattr(args, "report_grad_norm", False))
+        _compute_report_norm = _report_grad_norm and max_grad_norm <= 0
         state = [model.state, optimizer.state, mx.random.state]
         # grad_accum==1 fast path: only for unclipped updates, since
         # clip_grad_norm can spike peak memory on bf16 VLM runs.
@@ -2253,57 +2295,11 @@ class MLXTrainer:
                 scale = scale.astype(dtype)
             return scale
 
-        optimizer_v_sum = None
-
-        def _optimizer_v_total():
-            total = mx.array(0.0, dtype=mx.float32)
-            found = False
-            for name, value in tree_flatten(getattr(optimizer, "state", {})):
-                if name != "v" and not name.endswith(".v"):
-                    continue
-                found = True
-                value_f = value.astype(mx.float32)
-                total = total + mx.sum(value_f)
-            return total if found else None
-
-        def _grad_norm_from_optimizer_state():
-            nonlocal optimizer_v_sum
-            betas = getattr(optimizer, "betas", None)
-            if not betas or len(betas) < 2:
-                return None
-            current_v_sum = _optimizer_v_total()
-            if current_v_sum is None:
-                return None
-            previous_v_sum = (
-                optimizer_v_sum
-                if optimizer_v_sum is not None
-                else mx.array(0.0, dtype=mx.float32)
-            )
-            beta2 = mx.array(float(betas[1]), dtype=mx.float32)
-            denom = mx.maximum(
-                mx.array(1.0, dtype=mx.float32) - beta2,
-                mx.array(1e-30, dtype=mx.float32),
-            )
-            grad_norm_sq = mx.maximum(
-                (current_v_sum - beta2 * previous_v_sum) / denom,
-                mx.array(0.0, dtype=mx.float32),
-            )
-            grad_norm = mx.sqrt(grad_norm_sq)
-            mx.eval(current_v_sum, grad_norm)
-            optimizer_v_sum = current_v_sum
-            return grad_norm
-
-        def _can_report_optimizer_state_norm():
-            # Adam-family: recover ||g|| from the second moment after update
-            # (v_t = beta2*v_{t-1} + (1-beta2)*g_t^2), avoiding a second
-            # consumer on the lazy backward graph.
-            return getattr(optimizer, "betas", None)
-
         def _apply_update(grad, toks_f):
             """Scale accumulated grads by supervised-token count, apply the
             selected clipping mode, and update. Global-norm clipping reports
-            its norm; non-global modes report after update from Adam state to
-            keep the backward graph single-consumer.
+            its pre-clip norm; other modes report the same norm only when
+            ``report_grad_norm`` opts in (default: no reporting reduction).
             """
             if distributed_world_size > 1:
                 grad = self._distributed_sum_gradient_tree(grad)
@@ -2326,6 +2322,8 @@ class MLXTrainer:
                 final_grad, grad_norm = _clip_grad_norm_fp32(
                     final_grad, max_norm=max_grad_norm
                 )
+            elif _compute_report_norm:
+                grad_norm = _global_grad_norm_fp32(final_grad)
             if _clip_grad_value:
                 final_grad = _clip_grad_by_value(final_grad, max_grad_value)
             if _clip_grad_leaf_norm:
@@ -2338,7 +2336,7 @@ class MLXTrainer:
             _restore_trainable_storage_dtypes()
             return grad_norm
 
-        def _apply_update_direct(grad):
+        def _apply_update_direct(grad, toks_f):
             """Fast exact path for ``grad_accum == 1`` with no per-leaf scaling.
 
             The raw grads already are the per-token average, so skip the
@@ -2348,6 +2346,28 @@ class MLXTrainer:
             grad_norm = None
             if max_grad_norm > 0:
                 grad, grad_norm = _clip_grad_norm_fp32(grad, max_norm=max_grad_norm)
+            elif _compute_report_norm:
+                # Report the exact value the accumulated path computes by
+                # emulating its token multiply/divide round-trip on a copy
+                # used only for the norm; the fast-path update itself stays
+                # on the raw gradients (a telemetry flag must never change
+                # optimizer numerics).
+                safe_toks_f = mx.maximum(
+                    toks_f, mx.array(1.0, dtype=mx.float32)
+                )
+                inv_toks = mx.array(1.0, dtype=mx.float32) / safe_toks_f
+                def _rounded_for_norm(g):
+                    if g.dtype == mx.float16:
+                        # fp16 cannot represent token counts >= 65520: the
+                        # dtype cast becomes inf and zero grads turn nan.
+                        # Weight fp16 leaves in fp32 instead; fp16 reports the
+                        # mathematically exact norm rather than a bit-match of
+                        # the accumulated path's rounding.
+                        return g.astype(mx.float32) * toks_f * inv_toks
+                    return (g * toks_f.astype(g.dtype)) * inv_toks.astype(g.dtype)
+
+                rounded = tree_map(_rounded_for_norm, grad)
+                grad_norm = _global_grad_norm_fp32(rounded)
             if _clip_grad_value:
                 grad = _clip_grad_by_value(grad, max_grad_value)
             if _clip_grad_leaf_norm:
@@ -2402,7 +2422,7 @@ class MLXTrainer:
             (lvalue, toks), grad = _loss_and_grad(batch_data)
 
             if _direct_single_step_update:
-                grad_norm = _apply_update_direct(grad)
+                grad_norm = _apply_update_direct(grad, toks.astype(mx.float32))
                 return lvalue, toks, None, grad_norm
 
             toks_f = toks.astype(mx.float32)
@@ -2872,31 +2892,16 @@ class MLXTrainer:
             losses += lvalue * toks
             n_tokens += toks
             steps += 1
-            if grad_norm is not None:
-                mx.eval(grad_norm)
+            # One evaluation boundary: the reported norm (when present) is
+            # evaluated together with model/optimizer state and metric
+            # accumulators, never as a separate earlier graph execution.
+            eval_targets = [state, losses, n_tokens]
             if grad_accum_state is not None:
-                mx.eval(state, losses, n_tokens, grad_accum_state[0], grad_accum_state[1])
-            else:
-                mx.eval(state, losses, n_tokens)
-            if (
-                do_update
-                and grad_norm is None
-                and max_grad_norm <= 0
-                and _can_report_optimizer_state_norm()
-            ):
-                grad_norm = _grad_norm_from_optimizer_state()
-            elif (
-                do_update
-                and grad_norm is None
-                and max_grad_norm <= 0
-                and not _can_report_optimizer_state_norm()
-                and not _warned_skip_optimizer_state_grad_norm
-            ):
-                _main_print(
-                    "Unsloth: skipping grad norm reporting for this MLX "
-                    "optimizer/mode to avoid materializing the gradient graph."
-                )
-                _warned_skip_optimizer_state_grad_norm = True
+                eval_targets.append(grad_accum_state[0])
+                eval_targets.append(grad_accum_state[1])
+            if grad_norm is not None:
+                eval_targets.append(grad_norm)
+            mx.eval(*eval_targets)
             global_toks = self._distributed_all_sum(toks, stream=mx.cpu)
             mx.eval(global_toks)
             if int(global_toks.item()) == 0:


### PR DESCRIPTION
## Summary

Two changes to the MLX trainer's gradient-norm handling, one commit each:

1. **Report the true gradient norm, behind an opt-in flag when global-norm clipping is off.** For non-global-clip runs, `grad_norm` was previously reconstructed from Adam's second-moment state. That reconstruction is exact only for uninterrupted Adam/AdamW and has several defects: it measures the wrong quantity (the gradient after value/leaf clipping and LoRA+/embedding-LR scaling, not the pre-clip norm global clipping reports); it is wrong on the first step after `resume_from_checkpoint` (its closure-local previous-`v` accumulator restarts at zero while the restored optimizer state does not); it silently reports nothing for Lion (which exposes `betas` but has no `v` state); it skips Adafactor/SGD/Muon with a one-time warning; and it forces an extra host-side evaluation every logging step. Measured impact: under default leaf clipping it understates the true pre-clip norm by 49-69% (median 59%; same-trajectory Gemma3-270M run, per-step aligned); on the first step after a resume it overshoots 2.1x-6.4x depending on accumulated optimizer state; where no clipping binds the two agree to float noise (max 8.7e-7 relative). See the cross-backend section for the CUDA-anchored measurements. This PR deletes the reconstruction and computes the true fp32 global L2 norm in-graph inside the update path.
2. **Enable `mx.compile` for global-norm clipping with gradient accumulation.** The trainer disabled compilation whenever `max_grad_norm > 0` was combined with `gradient_accumulation_steps > 1`. That guard predates the current clipping implementation: `git log -S` shows it landed with the original MLX training path, while the lazy fp32 `_clip_grad_norm_fp32` (pure MLX ops, no host sync) arrived a month later — and clipped single-step training already ran compiled. The guard is removed; compiled clip+accum is validated below. After merging current `main`, this also removes the finite-text shape planner's `compile_ineligible_global_norm` branch (and its pinning test case): #918 added that branch to mirror the old guard, and keeping it would have silently kept single-process clipped accumulation eager. The e2e tests inject a `FiniteTextBatchPlan` so compiled runs stay compile-eligible under #918's shape guard, and the compiled clip+accum bitwise test now exercises the planned path end to end.

## Behavior changes (please read before reviewing)

- **Runs without global-norm clipping no longer display a grad-norm** — console output, `train/grad_norm` in W&B/TensorBoard, and the grad-norm history — unless global-norm clipping is the resolved clip mode or the user sets the new `MLXTrainingConfig(report_grad_norm=True)`. **Standard TRL-driven runs (the notebooks) are unaffected:** TRL's `SFTConfig` defaults `max_grad_norm=1.0`, which forwards to the MLX trainer and keeps them on the global-clip path — verified on the Gemma3-270M notebook settings (byte-identical losses, gradient norms, adapter weights, and log format vs `main`). The absence applies where `max_grad_norm` resolves to 0: direct `MLXTrainingConfig(...)` construction with defaults, or the Unsloth Studio worker, which currently passes 0. The legacy 9-argument step callback keeps its exact signature and receives `None` as its final argument in that case. Rationale: the old fallback value was misleading in the ways listed above, and HF Trainer likewise reports no gradient norm when norm clipping is off. The flag defaults off because the reporting reduction has the same class of peak-memory cost as global clipping itself.
- **Clip+accum users now train compiled.** Loss curves will not bit-match previous eager runs: eager and compiled execution produce different, individually deterministic rounding trajectories in low precision — a pre-existing property visible at multi-billion-parameter scale. `compile=False` reproduces the previous eager behavior exactly.

## Design notes

- `report_grad_norm` is captured as a Python constant before the step closures are built, so each run has exactly one compiled step graph (a runtime condition would add a trace signature per reporting state). With the flag off and no global clipping there is no reporting reduction, scalar output, or evaluation in the graph at all — default leaf/value/no-clip training is numerically and memory-wise unchanged.
- Reporting never changes update numerics. The `grad_accum == 1` fast path keeps its exact update on raw gradients and derives the reported value from a norm-only copy that reproduces the accumulated path's token multiply/divide rounding, so the value is numerically identical to the norm global clipping computes for bf16/fp32 models (fp16 leaves are weighted in fp32 because fp16 cannot represent token counts >= 65520).
- The reported quantity is the norm of the token-normalized gradient: after the accumulation divide, DDP reduction, and LoRA+/embedding-LR ratios; before any clipping and before weight decay — matching what the global-clip path already reported. Under DDP it is computed after the cross-rank reduction, so all ranks report the same value.
- The norm is evaluated in the same `mx.eval` boundary as model/optimizer state (previously a separate early evaluation); `.item()` happens only at the logging boundary.
- The field is appended last in `MLXTrainingConfig`, so every pre-existing field keeps its positional index in the custom `__init__`; the wholesale-config-copy detection treats dumps that predate the field as complete copies, keeping `warmup_ratio` precedence unchanged for older serialized configs.

## Validation

Unit/regression tests (Apple Silicon, real MLX) in `tests/test_mlx_training_e2e_metal.py`: a bitwise update-invariance test (the flag changes no parameter or optimizer-state bit; compiled, bf16, dtypes pinned); an independent-oracle norm test covering value and placement across clip modes, optimizers (including Lion, and SGD with nonzero coupled weight decay to pin that decay is excluded), eager and compiled execution, and accumulation 1-3; a bitwise eager-vs-compiled parity test for clipped accumulation on tiny models; a regression asserting clip+accum compiles at full-step scope without the old disable message; and an injected-failure test pinning that an evaluation-time error after the compiled step propagates rather than triggering a silent eager retry.

Production-scale validation (Qwen/Qwen2.5-VL-3B-Instruct, full BF16, LoRA r=16, chunked-CE loss, sequence lengths cycling 1024/1536/2048 with two 448x448 images per sample, batch 1, accumulation 4, fresh process per run, two repetitions per variant):

- Reporting off: peak allocator memory in default leaf, value-clip, and no-clip modes unchanged vs the pre-change trainer (raw byte ratios at most 1.0000016).
- Reporting on: peak memory within 2.8% of what compiled global clipping itself costs (the documented equal-cost intent); throughput unchanged at 3B (identical steady-state tokens/sec). The cost inverts at small scale: a 270M LoRA run costs no peak memory but about 7% throughput (interleaved repetitions, tight variance) — per-leaf reduction launch overhead against a fast step, another reason the flag defaults off.
- Compiled clip+accum halves peak memory vs eager clipping (12.3 vs 22.5 GiB) and adds zero compile trace signatures after warm-up vs compiled unclipped training (equal trace counts, stable through the measured window).
- Compiled runs are bit-deterministic across fresh processes (losses, reported norms, SHA-256 digests of every parameter and optimizer-state leaf), and strict vs best-effort compile modes are bit-identical.
- Eager-vs-compiled loss divergence for clipped accumulation stays below the untouched unclipped control pair's (max per-step relative delta 0.73x the control's; median 2.25x, within the 3x bound) — the guard removal adds no divergence beyond pre-existing eager/compiled rounding. A simulated corruption (clipping dropped) exceeds the control envelope by 7.8x, so the comparison discriminates real errors.

Notebook parity: the Gemma3-270M notebook's exact settings (public `FastModel` API, 16-bit load, LoRA r=128 on q/k/v/o/gate/up/down, batch 4, `adamw_8bit`, seed 3407, 10 steps on a fixed dataset) produce byte-identical loss history, gradient norms, and adapter-tensor SHA-256 digests between `main` and this branch — and byte-identical again with `report_grad_norm=True` enabled.

```bash
# focused
python -m pytest tests/test_mlx_training_e2e_metal.py -q
# broader selection
python -m pytest tests/ -q -k "mlx and (grad or clip or norm or trainer)"
```

## Cross-backend validation against CUDA

The reported quantity and the deleted value's defects were measured against the CUDA path as an external reference. In global-clip mode — the path the notebooks use — 30 steps of the same Gemma3-270M LoRA configuration (uniform-length data, `max_grad_norm=1.0` on both backends) put the MLX-reported norm within 4.1% of CUDA's HF-reported median grad-norm with 0.996 curve correlation (loss correlation 0.99995).

The two defect measurements used 64 identical dataset rows (verified identical token IDs and batch composition on both backends), removing batch-content and data-order differences so per-step cross-backend comparison is meaningful; backend rounding still compounds across updates, so early steps carry the strongest signal (MLX `adamw`, CUDA the matched `adamw_torch`). CUDA ran `max_grad_norm=1e9` — never binding — so the HF trainer logs its standard pre-clip global norm.

- **Leaf-clip understatement.** MLX trained in its default mode (resolved 1.0 per-leaf L2 clip); CUDA replicated it with an `on_pre_optimizer_step` callback rescaling each parameter gradient to L2 <= 1.0, after HF's norm logging and before the optimizer step (ordering validated in-run to 6.2e-8 max relative error). The branch's norm tracks CUDA's pre-clip norm to a 2.6% median gap over 12 steps (2.3% over steps 1-6); the old reconstruction sits 53.5% below CUDA at the first-six-step median (up to 68.6% on the earliest steps), converging late once few leaves still exceed the threshold. Direct wrong-quantity confirmation: over those early steps the old value matches CUDA's **post**-leaf-clip global norm to a 0.5% median gap — it reported the clipped-gradient scale, while this branch and CUDA report the pre-clip norm.
- **Resume overshoot.** All variants unclipped, 12 steps, checkpoint at step 6, then resumed. Boundary continuity (step-7 norm over the mean of steps 6 and 8): CUDA 1.02, this branch 1.04, old reconstruction 6.43 (62.17 against a ~9.7 neighborhood). The branch's resumed norms exactly equal its uninterrupted baseline at every post-resume step and sit within 1.1% of CUDA at the boundary; CUDA shows no boundary artifact. The spike is confined to reporting — old and new loss histories are bitwise-equal through and after the resume. The 2.1x end of the summary's range came from a small controlled model; here it is 6.4x — the magnitude grows with the second-moment state accumulated before the checkpoint.

Both defect experiments produced bitwise-identical `main`-vs-branch MLX loss histories (update-invariance on real runs, not only in the unit test), and the CUDA reference ran stock HF/TRL semantics — pre-clip norm, no resume artifact — the semantics this PR adopts.

## Known pre-existing test-suite issues (not addressed here)

Combined MLX test runs order-couple a few failures that also occur on `main`: `tests/test_mlx_save_lora_adapters_filter.py` installs the torch-backed simulation shim only when real MLX is not already imported, so its torch mocks can reach the real `mx.save_safetensors` and raise `std::bad_cast`; `tests/test_mlx_adapter_metadata_persistence.py` installs the shim without teardown, which can hijack later MLX imports in real-runtime modules (why the new tests bind their MLX imports at module scope). Fixture repair is left to a follow-up so this PR stays scoped; this branch introduces no new failures relative to `main` (failure sets verified name-identical).

## Coordination

The HF-callbacks rework in #873 touches the same logging loop; whichever lands second should rebase, and the norm-reporting behavior here (computed every optimizer update when active, surfaced at logging boundaries) is the cadence that rebase should preserve. Related user demand for richer MLX training telemetry: unslothai/unsloth#5138.
