### PR TITLE
Fix: Let UnslothVisionDataCollator accept audio-only processors

### DIFF
--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -629,6 +629,24 @@ class _VisionProcessor(_ChatTemplateMixin):
         self.image_processor = object()
 
 
+class _AudioProcessorAttrProcessor(_ChatTemplateMixin):
+    # Granite-Speech shape: transformers names the audio sub-processor
+    # "audio_processor", not "feature_extractor" (see that model's processor
+    # .attributes). No image_processor either, so a gate that only knows
+    # feature_extractor rejects an audio model it is meant to support.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.audio_processor = _FakeFeatureExtractor()
+
+
+class _NoneImageProcessor(_ChatTemplateMixin):
+    # Defines image_processor but leaves it None: hasattr() is True while there
+    # is no usable processor, so the gate must look at the value, not the name.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.image_processor = None
+
+
 class _TextOnlyProcessor(_ChatTemplateMixin):
     # Neither image_processor nor feature_extractor -> must still be rejected.
     def __init__(self):
@@ -652,6 +670,23 @@ def test_audio_only_processor_constructs():
     # Masking wiring is intact: the audio placeholder is in the padding ids.
     assert AUDIO_ID in collator.padding_token_ids.tolist()
     assert PAD_ID in collator.padding_token_ids.tolist()
+
+
+def test_audio_processor_attribute_processor_constructs():
+    # Granite-Speech exposes "audio_processor" instead of "feature_extractor";
+    # it must be accepted like any other audio-only processor.
+    collator = UnslothVisionDataCollator(
+        model=_stub_model(), processor=_AudioProcessorAttrProcessor(),
+    )
+    assert collator.processor.__class__.__name__ == "_AudioProcessorAttrProcessor"
+    assert AUDIO_ID in collator.padding_token_ids.tolist()
+
+
+def test_none_image_processor_still_rejected():
+    # hasattr() is True here but the attribute is None, so this is really a
+    # text-only processor and must not slip through the gate.
+    with pytest.raises(TypeError, match="image or audio processor"):
+        UnslothVisionDataCollator(model=_stub_model(), processor=_NoneImageProcessor())
 
 
 def test_text_only_processor_still_rejected():

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -585,6 +585,151 @@ def test_userdict_audio_payload_resolves():
     np.testing.assert_allclose(clips[0], DECODED)
 
 
+# ---------------------------------------------------------------------------
+# Constructor gate: audio-only processors (unslothai/unsloth-zoo#757)
+#
+# UnslothVisionDataCollator.__init__ used to hard-require image_processor, so
+# audio-only processors (Qwen2-Audio, Voxtral, Granite-Speech: a feature_extractor
+# but no image_processor) could not be constructed at all. The gate now admits
+# any image- OR audio-capable processor and rejects only a bare text tokenizer.
+# The audio content handling and <|audio|>/<|AUDIO|> masking downstream already
+# landed in #723 / #917; this only unblocks construction.
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace
+
+
+class _ChatTemplateMixin:
+    # Minimal apply_chat_template: renders text parts, ignores modality parts.
+    # Accepts the {"type": "image"} probe __init__ runs without raising.
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        out = []
+        for m in messages:
+            content = m.get("content", "")
+            if isinstance(content, str):
+                out.append(content)
+            else:
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        out.append(part.get("text", ""))
+        return " ".join(out)
+
+
+class _AudioOnlyProcessor(_ChatTemplateMixin):
+    # feature_extractor present, NO image_processor -> the audio-only case.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.feature_extractor = _FakeFeatureExtractor()
+
+
+class _VisionProcessor(_ChatTemplateMixin):
+    # image_processor present -> gate must behave exactly as before.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.image_processor = object()
+
+
+class _TextOnlyProcessor(_ChatTemplateMixin):
+    # Neither image_processor nor feature_extractor -> must still be rejected.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+
+
+def _stub_model():
+    # __init__ reads config (dtype + optional vision_config, both guarded) and,
+    # on transformers builds without config.torch_dtype, the embedding dtype.
+    emb = SimpleNamespace(weight=torch.zeros(1, dtype=torch.float32))
+    return SimpleNamespace(
+        config=SimpleNamespace(torch_dtype="float32"),
+        get_input_embeddings=lambda: emb,
+    )
+
+
+def test_audio_only_processor_constructs():
+    # The fix: an audio-only processor no longer raises at construction.
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=_AudioOnlyProcessor())
+    assert collator.processor.__class__.__name__ == "_AudioOnlyProcessor"
+    # Masking wiring is intact: the audio placeholder is in the padding ids.
+    assert AUDIO_ID in collator.padding_token_ids.tolist()
+    assert PAD_ID in collator.padding_token_ids.tolist()
+
+
+def test_text_only_processor_still_rejected():
+    with pytest.raises(TypeError, match="image or audio processor"):
+        UnslothVisionDataCollator(model=_stub_model(), processor=_TextOnlyProcessor())
+
+
+def test_vision_processor_still_constructs():
+    # Vision path is byte-identical: image_processor present -> gate not triggered.
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=_VisionProcessor())
+    assert hasattr(collator.processor, "image_processor")
+
+
+class _RoundTripAudioProcessor(_AudioOnlyProcessor):
+    # Stands in for a real audio processor's __call__: emits a batch with the
+    # audio placeholder + pad tokens and passthrough input_features, so the
+    # collator's label masking can be exercised hermetically (no audio deps).
+    def __call__(self, text=None, audio=None, padding=None, return_tensors=None,
+                 add_special_tokens=None, **kwargs):
+        # [pad, <|audio|>, <|audio|>, real, real] for one example.
+        input_ids = torch.tensor([[PAD_ID, AUDIO_ID, AUDIO_ID, 5, 6]])
+        return {
+            "input_ids": input_ids,
+            "attention_mask": torch.tensor([[0, 1, 1, 1, 1]]),
+            "input_features": torch.zeros(1, 128, 3000),
+            "feature_attention_mask": torch.ones(1, 3000),
+        }
+
+
+def test_audio_only_collator_masks_audio_and_pad_tokens():
+    # Hermetic round-trip: construct audio-only, run __call__, verify the audio
+    # placeholder and pad tokens are masked out of labels while real tokens stay.
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=_RoundTripAudioProcessor())
+    example = {"messages": [
+        {"role": "user", "content": [
+            {"type": "audio", "audio": CLIP}, {"type": "text", "text": "hi"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+    ]}
+    batch = collator([example])
+    assert "input_features" in batch and tuple(batch["input_features"].shape) == (1, 128, 3000)
+    labels = batch["labels"][0].tolist()
+    ids = batch["input_ids"][0].tolist()
+    for tok, lab in zip(ids, labels):
+        if tok in (AUDIO_ID, PAD_ID):
+            assert lab == -100, f"token {tok} should be masked"
+        else:
+            assert lab == tok, f"real token {tok} should be kept"
+
+
+@pytest.mark.parametrize("model_id", ["Qwen/Qwen2-Audio-7B-Instruct"])
+def test_real_audio_processor_constructs_and_round_trips(model_id):
+    # Full-fidelity check against a REAL audio processor. Skips in CI when
+    # transformers / the processor download / soundfile are unavailable.
+    transformers = pytest.importorskip("transformers")
+    try:
+        proc = transformers.AutoProcessor.from_pretrained(model_id)
+    except Exception as e:  # offline, gated, or missing deps
+        pytest.skip(f"real processor unavailable: {e}")
+    assert not hasattr(proc, "image_processor")
+    assert getattr(proc, "feature_extractor", None) is not None
+
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=proc, max_seq_length=512)
+    wav = np.sin(np.linspace(0, 220 * 2 * np.pi, 16000)).astype(np.float32)
+    example = {"messages": [
+        {"role": "user", "content": [
+            {"type": "audio", "audio": wav}, {"type": "text", "text": "Transcribe."}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "la la la"}]},
+    ]}
+    batch = collator([example])
+    assert "input_features" in batch
+    audio_id = proc.tokenizer.convert_tokens_to_ids("<|AUDIO|>")
+    ids, labels = batch["input_ids"], batch["labels"]
+    n_audio = int((ids == audio_id).sum())
+    assert n_audio > 0
+    assert int(((ids == audio_id) & (labels == -100)).sum()) == n_audio
+    assert int((labels != -100).sum()) > 0  # real assistant tokens survive
+
+
 def test_real_unpatched_decoder_decodes_in_fresh_process():
     # A REAL, never-patched torchcodec AudioDecoder through the collator in a clean
     # interpreter (the patch mutates the class globally, so it can't share a process

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -146,6 +146,31 @@ def test_top_level_dict_rate_mismatch_raises():
             {"audio": {"array": CLIP, "sampling_rate": 44100}}, [])
 
 
+class _AudioProcessorProcessor:
+    # Granite-Speech shape: the audio sub-processor is "audio_processor", not
+    # "feature_extractor". Its sampling_rate must still drive the rate check.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.audio_processor = _FakeFeatureExtractor()
+
+
+def test_audio_processor_sampling_rate_mismatch_raises():
+    # For an audio_processor-only processor the rate check must fire off
+    # audio_processor.sampling_rate; before the fallback target_sr was None and
+    # a wrong-rate clip trained silently.
+    collator = UnslothVisionDataCollator.__new__(UnslothVisionDataCollator)
+    collator.processor = _AudioProcessorProcessor()
+    collator.max_seq_length = 4
+    collator.truncation = True
+    with pytest.raises(ValueError, match="sampling_rate"):
+        collator._extract_audio_for_example(
+            {"audio": {"array": CLIP, "sampling_rate": 44100}}, [])
+    # A matching-rate clip is accepted.
+    out = collator._extract_audio_for_example(
+        {"audio": {"array": CLIP, "sampling_rate": 16000}}, [])
+    assert len(out) == 1
+
+
 def test_top_level_flat_list_is_one_clip():
     collator = make_collator()
     out = collator._extract_audio_for_example({"audio": [0.0] * 16}, [])

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -1240,3 +1240,89 @@ def test_empty_string_key_falls_through_to_the_next_key():
     # Preserved from the old `or` chain: a blank url must not shadow a real path.
     out = extract_audio_info(msgs({"type": "audio", "url": "", "path": "/tmp/a.wav"}))
     assert out == ["/tmp/a.wav"]
+
+
+# ---------------------------------------------------------------------------
+# The assistant-content probe must match the processor's modality.
+#
+# __init__ decides assistant_single_content by rendering a fixed conversation
+# that hard-coded a {"type": "image"} part. Now that audio-only processors are
+# admitted, an audio chat template that validates content types can reject that
+# probe and block construction for a model the collator can otherwise serve.
+# ---------------------------------------------------------------------------
+
+class _ModalityStrictProcessor:
+    # Accepts only the modality it declares; records what it was probed with.
+    def __init__(self, accepts, image=False):
+        self.tokenizer = _FakeTokenizer()
+        self.accepts = accepts
+        self.probed_types = []
+        if image: self.image_processor = object()
+        else: self.feature_extractor = _FakeFeatureExtractor()
+
+    def apply_chat_template(self, messages, **kwargs):
+        for m in messages:
+            content = m.get("content")
+            if not isinstance(content, list): continue
+            for part in content:
+                kind = part.get("type")
+                if kind == "text": continue
+                self.probed_types.append(kind)
+                if kind != self.accepts:
+                    raise ValueError(f"unsupported content type {kind!r}")
+        return "rendered"
+
+    def __call__(self, text=None, audio=None, **kwargs):
+        return {}
+
+
+def test_audio_only_processor_is_probed_with_an_audio_part():
+    proc = _ModalityStrictProcessor(accepts="audio")
+    UnslothVisionDataCollator(model=_stub_model(), processor=proc)
+    assert proc.probed_types and set(proc.probed_types) == {"audio"}, proc.probed_types
+
+
+def test_image_processor_is_still_probed_with_an_image_part():
+    # Backward compatibility: the vision path's probe must not change.
+    proc = _ModalityStrictProcessor(accepts="image", image=True)
+    UnslothVisionDataCollator(model=_stub_model(), processor=proc)
+    assert proc.probed_types and set(proc.probed_types) == {"image"}, proc.probed_types
+
+
+class _StringContentOnlyProcessor:
+    # Granite-Speech shape: the chat template concatenates message["content"]
+    # into the prompt, so any list content raises TypeError for every role.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.audio_processor = _FakeFeatureExtractor()
+
+    def apply_chat_template(self, messages, **kwargs):
+        out = ""
+        for m in messages:
+            out = out + "<|role|>" + m["content"]   # TypeError on a list
+        return out
+
+    def __call__(self, text=None, audio=None, **kwargs):
+        return {}
+
+
+def test_string_only_chat_template_rejected_with_an_actionable_message():
+    # Previously this surfaced as RuntimeError("can only concatenate str (not
+    # \"list\") to str") from the generic chat-template handler, with no
+    # indication of what to do. Reject at construction like the no-audio-kwarg
+    # case does, naming the processor and the reason.
+    with pytest.raises(TypeError, match="plain-string message content"):
+        UnslothVisionDataCollator(model=_stub_model(), processor=_StringContentOnlyProcessor())
+
+
+def test_broken_chat_template_still_raises_the_generic_error():
+    # A template that fails on plain strings too is a genuinely broken template,
+    # not a string-only one: keep routing it to _raise_chat_template_error.
+    class _Broken(_StringContentOnlyProcessor):
+        def apply_chat_template(self, messages, **kwargs):
+            if any(isinstance(m["content"], list) for m in messages):
+                raise TypeError("can only concatenate str (not \"list\") to str")
+            raise RuntimeError("template is broken")
+    with pytest.raises(Exception) as info:
+        UnslothVisionDataCollator(model=_stub_model(), processor=_Broken())
+    assert "plain-string message content" not in str(info.value)

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -113,8 +113,53 @@ def test_inline_url_and_path_resolved():
         assert out == ["/tmp/a.wav"]
 
 
+def test_inline_qwen_audio_url_resolved():
+    # Qwen2-Audio's OWN documented content shape. Its built-in chat template
+    # branches on `'audio' in content or 'audio_url' in content` and renders an
+    # <|AUDIO|> placeholder, so the clip must be collected -- otherwise the
+    # rendered text carries the placeholder with no audio payload behind it.
+    # Source: transformers/models/qwen2_audio/processing_qwen2_audio.py,
+    # Qwen2AudioProcessor.default_chat_template + its __call__ docstring example.
+    url = "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen2-Audio/audio/glass-breaking-151256.mp3"
+    out = extract_audio_info(msgs({"type": "audio", "audio_url": url}))
+    assert out == [url]
+
+
+def test_audio_url_does_not_shadow_the_generic_keys():
+    # Priority order must stay audio > url > path > audio_url so that the keys
+    # transformers' generic loader uses keep winning.
+    part = {"type": "audio", "url": "/tmp/generic.wav", "audio_url": "/tmp/qwen.wav"}
+    assert extract_audio_info(msgs(part)) == ["/tmp/generic.wav"]
+    part = {"type": "audio", "audio": CLIP, "audio_url": "/tmp/qwen.wav"}
+    assert extract_audio_info(msgs(part))[0] is CLIP
+
+
+def test_qwen_audio_url_template_parity():
+    # Derive the expectation from transformers, not from our own code: every
+    # content shape Qwen2-Audio's template turns into an audio placeholder must
+    # yield exactly one clip from extract_audio_info.
+    transformers = pytest.importorskip("transformers")
+    jinja2 = pytest.importorskip("jinja2")
+    from transformers.models.qwen2_audio.processing_qwen2_audio import Qwen2AudioProcessor
+    template = Qwen2AudioProcessor.default_chat_template
+    if isinstance(template, property):
+        template = template.fget(None)
+    render = jinja2.Environment().from_string(template).render
+    for part in (
+        {"type": "audio", "audio_url": "/tmp/a.wav"},
+        {"type": "audio", "audio": "/tmp/a.wav"},
+    ):
+        conversation = msgs(part)
+        n_placeholders = render(messages=conversation).count("<|AUDIO|>")
+        assert n_placeholders == 1, part
+        assert len(extract_audio_info(conversation)) == n_placeholders, part
+
+
 def test_inline_no_payload_raises():
     with pytest.raises(ValueError, match="cannot be loaded"):
+        extract_audio_info(msgs({"type": "audio"}))
+    # The message names every accepted key, including the Qwen spelling.
+    with pytest.raises(ValueError, match="audio_url"):
         extract_audio_info(msgs({"type": "audio"}))
 
 

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -31,6 +31,7 @@ Hermetic CPU tests with stub processors, no model or network needed:
 
 from __future__ import annotations
 
+import inspect
 import os
 import subprocess
 import sys
@@ -735,6 +736,65 @@ def test_vision_processor_still_constructs():
     # Vision path is byte-identical: image_processor present -> gate not triggered.
     collator = UnslothVisionDataCollator(model=_stub_model(), processor=_VisionProcessor())
     assert hasattr(collator.processor, "image_processor")
+
+
+class _VoxtralLikeProcessor(_ChatTemplateMixin):
+    # Mirrors transformers' VoxtralProcessor: an audio-only processor whose
+    # __call__ is (text, **kwargs) with NO audio= parameter. Voxtral requires
+    # audio to go through apply_chat_template and raises if the rendered text
+    # contains its audio token, so the collator's self.processor(text=..., audio=...)
+    # call cannot work -- the guard must reject it at construction.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.feature_extractor = _FakeFeatureExtractor()
+
+    def __call__(self, text, **kwargs):  # no audio= -> unsupported by the collator
+        raise AssertionError("collator must reject before ever calling __call__")
+
+
+class _AudioKwargProcessor(_ChatTemplateMixin):
+    # Qwen2-Audio / Granite-Speech shape: audio-only processor whose __call__
+    # declares a named audio= parameter and processes it -> supported.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.feature_extractor = _FakeFeatureExtractor()
+
+    def __call__(self, text=None, audio=None, **kwargs):
+        return {}
+
+
+def test_audio_processor_without_audio_kwarg_rejected():
+    # A Voxtral-shaped processor passes the acceptance guard (it has a
+    # feature_extractor) but its __call__ takes no audio=, so audio cannot be
+    # batched through the collator. Reject up front with an actionable message
+    # that points at apply_chat_template rather than failing later inside collation.
+    with pytest.raises(TypeError, match="does not yet support|apply_chat_template"):
+        UnslothVisionDataCollator(model=_stub_model(), processor=_VoxtralLikeProcessor())
+
+
+def test_audio_processor_with_audio_kwarg_constructs():
+    # The capability check must NOT reject a working audio processor: __call__
+    # declares audio=, so construction succeeds as before.
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=_AudioKwargProcessor())
+    assert collator.processor.__class__.__name__ == "_AudioKwargProcessor"
+    assert AUDIO_ID in collator.padding_token_ids.tolist()
+
+
+def test_capability_check_matches_real_transformers_processors():
+    # Lock the guard's signal against the real classes: the unsupported processor
+    # (Voxtral) has no audio= on __call__; a supported one (Qwen2-Audio) does.
+    # Importing the classes needs no audio backend -- only from_pretrained does.
+    transformers = pytest.importorskip("transformers")
+    Voxtral = getattr(transformers, "VoxtralProcessor", None)
+    Qwen2Audio = getattr(transformers, "Qwen2AudioProcessor", None)
+    if Voxtral is None or Qwen2Audio is None:
+        pytest.skip("Voxtral/Qwen2Audio not present in this transformers build")
+    vox = inspect.signature(Voxtral.__call__).parameters
+    qwen = inspect.signature(Qwen2Audio.__call__).parameters
+    assert "audio" not in vox and "audios" not in vox, (
+        "VoxtralProcessor.__call__ unexpectedly grew an audio= param; revisit the guard"
+    )
+    assert "audio" in qwen or "audios" in qwen
 
 
 class _RoundTripAudioProcessor(_AudioOnlyProcessor):

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -1069,3 +1069,110 @@ def test_real_unpatched_decoder_decodes_in_fresh_process():
     )
     assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
     assert result.stdout.strip().endswith("OK")
+
+
+# ---------------------------------------------------------------------------
+# Audio-span truncation must be guarded on BOTH collation paths.
+#
+# __call__ truncates via _truncate_sequence_tensors, which refuses to cut into
+# the expanded audio placeholders. _collate_prompt_completion truncates via
+# _truncate_by_side, which had no such check -- while `out = dict(proc_prompts)`
+# carries input_features through at full width. A prompt/completion example
+# whose audio span exceeds max_seq_length therefore reached the model with N
+# audio embeddings and fewer than N placeholder slots, silently, where the
+# messages path raises. The check now lives in one helper used by both.
+# ---------------------------------------------------------------------------
+
+N_EXPANDED_AUDIO = 8
+_PC_VOCAB = {"hi": 1, "ok": 2}
+
+
+class _ExpandingAudioProcessor(_ChatTemplateMixin):
+    # Renders an audio part as a marker that __call__ expands into
+    # N_EXPANDED_AUDIO placeholder ids, like a real audio processor does.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer(padding_side="right")
+        self.feature_extractor = _FakeFeatureExtractor()
+
+    def apply_chat_template(self, messages, **kwargs):
+        out = []
+        for m in messages:
+            content = m.get("content", "")
+            if isinstance(content, str):
+                out.append(content)
+                continue
+            for part in content:
+                if not isinstance(part, dict): continue
+                if part.get("type") == "text": out.append(part.get("text", ""))
+                elif part.get("type") == "audio": out.append("<AUD>")
+        return " ".join(out)
+
+    def __call__(self, text=None, audio=None, padding=None, padding_side="right",
+                 return_tensors=None, add_special_tokens=None, **kwargs):
+        rows = []
+        for s in text:
+            row = []
+            for word in s.split():
+                if word == "<AUD>": row += [AUDIO_ID] * N_EXPANDED_AUDIO
+                else: row.append(_PC_VOCAB.get(word, 3))
+            rows.append(row)
+        width = max(len(r) for r in rows)
+        ids, mask = [], []
+        for r in rows:
+            pad = [PAD_ID] * (width - len(r))
+            if padding_side == "left":
+                ids.append(pad + r); mask.append([0] * len(pad) + [1] * len(r))
+            else:
+                ids.append(r + pad); mask.append([1] * len(r) + [0] * len(pad))
+        out = {"input_ids": torch.tensor(ids), "attention_mask": torch.tensor(mask)}
+        if audio is not None:
+            # Full-width features, exactly what makes a short input_ids dangerous.
+            out["input_features"] = torch.zeros(len(rows), 128, 3000)
+        return out
+
+
+_AUDIO_PC_MESSAGES = [
+    {"role": "user", "content": [
+        {"type": "audio", "audio": CLIP}, {"type": "text", "text": "hi"}]},
+    {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+]
+
+
+@pytest.mark.parametrize("path", ["messages", "prompt_completion"])
+def test_audio_span_truncation_raises_on_both_paths(path):
+    collator = UnslothVisionDataCollator(
+        model=_stub_model(), processor=_ExpandingAudioProcessor(), max_seq_length=4,
+    )
+    if path == "messages":
+        batch = [{"messages": _AUDIO_PC_MESSAGES}]
+    else:
+        batch = [{"prompt": _AUDIO_PC_MESSAGES[:1], "completion": _AUDIO_PC_MESSAGES[1:]}]
+    with pytest.raises(ValueError, match="cuts into the expanded audio tokens"):
+        collator(batch)
+
+
+@pytest.mark.parametrize("path", ["messages", "prompt_completion"])
+def test_audio_span_fits_is_not_rejected_on_either_path(path):
+    # The guard must only fire when placeholders are actually lost.
+    collator = UnslothVisionDataCollator(
+        model=_stub_model(), processor=_ExpandingAudioProcessor(), max_seq_length=64,
+    )
+    if path == "messages":
+        batch = [{"messages": _AUDIO_PC_MESSAGES}]
+    else:
+        batch = [{"prompt": _AUDIO_PC_MESSAGES[:1], "completion": _AUDIO_PC_MESSAGES[1:]}]
+    out = collator(batch)
+    assert int((out["input_ids"] == AUDIO_ID).sum()) == N_EXPANDED_AUDIO
+
+
+def test_text_only_prompt_completion_truncation_still_allowed():
+    # Backward compatibility: the new guard must not turn ordinary text
+    # truncation in the prompt/completion path into an error.
+    collator = UnslothVisionDataCollator(
+        model=_stub_model(), processor=_ExpandingAudioProcessor(), max_seq_length=2,
+    )
+    out = collator([{
+        "prompt": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        "completion": [{"role": "assistant", "content": [{"type": "text", "text": "ok"}]}],
+    }])
+    assert out["input_ids"].shape[1] == 2

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -294,6 +294,18 @@ def test_right_padded_feature_extractor_untouched():
     assert proc.feature_extractor.padding_side == "right"
 
 
+def test_left_padded_audio_processor_reset_to_right():
+    # Granite-Speech exposes the audio sub-processor as "audio_processor", not
+    # "feature_extractor"; its left padding must be normalized too.
+    class _AudioProcessorOnly:
+        def __init__(self):
+            self.audio_processor = _FakeFeatureExtractor()
+    proc = _AudioProcessorOnly()
+    proc.audio_processor.padding_side = "left"
+    _fix_audio_feature_extractor_padding_side(proc)
+    assert proc.audio_processor.padding_side == "right"
+
+
 def test_processor_without_feature_extractor_noop():
     class _TextOnly:
         pass

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -43,6 +43,7 @@ import pytest
 import torch
 
 from unsloth_zoo.vision_utils import (
+    _AUDIO_SUB_PROCESSOR_ATTRS,
     UnslothVisionDataCollator,
     _audio_call_kwarg,
     _fix_audio_feature_extractor_padding_side,
@@ -1003,7 +1004,7 @@ def test_real_audio_processor_constructs_and_round_trips(model_id):
         proc = transformers.AutoProcessor.from_pretrained(model_id)
     except Exception as e:  # offline, gated, or missing deps
         pytest.skip(f"real processor unavailable: {e}")
-    assert not hasattr(proc, "image_processor")
+    assert getattr(proc, "image_processor", None) is None
     assert getattr(proc, "feature_extractor", None) is not None
 
     collator = UnslothVisionDataCollator(model=_stub_model(), processor=proc, max_seq_length=512)
@@ -1176,3 +1177,49 @@ def test_text_only_prompt_completion_truncation_still_allowed():
         "completion": [{"role": "assistant", "content": [{"type": "text", "text": "ok"}]}],
     }])
     assert out["input_ids"].shape[1] == 2
+
+
+def test_audio_sub_processor_attr_names_cover_transformers():
+    # Derive the attribute set from transformers, not from our own code: every
+    # `attributes` entry that transformers binds to a *FeatureExtractor class is
+    # an audio sub-processor the gate, the padding-side normalisation and the
+    # sampling-rate read must all see. Today that is exactly
+    # {"feature_extractor", "audio_processor"} -- a new spelling appearing
+    # upstream must widen _AUDIO_SUB_PROCESSOR_ATTRS or this fails.
+    pytest.importorskip("transformers")
+    import importlib, pkgutil
+    import transformers.models as models_pkg
+
+    upstream = set()
+    for module_info in pkgutil.iter_modules(models_pkg.__path__):
+        name = module_info.name
+        try:
+            module = importlib.import_module(f"transformers.models.{name}.processing_{name}")
+        except Exception:
+            continue
+        for cls in vars(module).values():
+            if not inspect.isclass(cls) or cls.__module__ != module.__name__: continue
+            for attr in (getattr(cls, "attributes", None) or ()):
+                klass = getattr(cls, f"{attr}_class", None)
+                if isinstance(klass, str) and "FeatureExtractor" in klass:
+                    upstream.add(attr)
+    assert upstream, "scan found no feature-extractor attributes; the scan broke"
+    assert upstream <= set(_AUDIO_SUB_PROCESSOR_ATTRS), (
+        f"transformers uses audio sub-processor attribute(s) the collator does not "
+        f"resolve: {sorted(upstream - set(_AUDIO_SUB_PROCESSOR_ATTRS))}"
+    )
+
+
+def test_all_three_consumers_agree_on_an_audio_processor_only_shape():
+    # One shape, three consumers: the gate must admit it, the padding-side fix
+    # must normalise it, and the sampling-rate read must use it. Each of these
+    # was patched in a separate round of this branch after the others; they now
+    # share _audio_sub_processors, so they cannot disagree again.
+    proc = _AudioProcessorAttrProcessor()
+    proc.audio_processor.padding_side = "left"
+
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=proc)  # gate
+    assert proc.audio_processor.padding_side == "right"                        # padding
+    with pytest.raises(ValueError, match="sampling_rate"):                     # rate
+        collator._extract_audio_for_example(
+            {"audio": {"array": CLIP, "sampling_rate": 44100}}, [])

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -44,6 +44,7 @@ import torch
 
 from unsloth_zoo.vision_utils import (
     UnslothVisionDataCollator,
+    _audio_call_kwarg,
     _fix_audio_feature_extractor_padding_side,
     _is_audio_mapping,
     extract_audio_info,
@@ -685,7 +686,8 @@ from types import SimpleNamespace
 class _ChatTemplateMixin:
     # Minimal apply_chat_template: renders text parts, ignores modality parts.
     # Accepts the {"type": "image"} probe __init__ runs without raising.
-    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False,
+                            **kwargs):
         out = []
         for m in messages:
             content = m.get("content", "")
@@ -840,6 +842,120 @@ def test_capability_check_matches_real_transformers_processors():
         "VoxtralProcessor.__call__ unexpectedly grew an audio= param; revisit the guard"
     )
     assert "audio" in qwen or "audios" in qwen
+    # ... and the resolver reports the keyword the collator must actually send.
+    assert _audio_call_kwarg(Voxtral) is None
+    assert _audio_call_kwarg(Qwen2Audio) == "audio"
+
+
+# ---------------------------------------------------------------------------
+# The keyword the guard accepts must be the keyword the collator sends.
+#
+# The guard admits a processor whose __call__ names `audio` OR `audios`, but
+# both audio call sites used to hard-code `audio=`. An `audios=`-only processor
+# therefore constructed fine and then lost its clips on the first batch: the
+# unexpected `audio=` is absorbed by **kwargs while the plural parameter the
+# processor actually reads stays None. _audio_call_kwarg is now the single
+# resolution used by the guard AND by both call sites, so they cannot drift.
+# ---------------------------------------------------------------------------
+
+class _AudiosOnlyProcessor(_ChatTemplateMixin):
+    # __call__ names ONLY the plural. Records the audio kwarg it was handed.
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.feature_extractor = _FakeFeatureExtractor()
+        # One entry per __call__; the prompt/completion path calls twice.
+        self.calls = []
+
+    def __call__(self, text=None, audios=None, padding=None, padding_side="right",
+                 return_tensors=None, add_special_tokens=None, **kwargs):
+        self.calls.append((audios, sorted(kwargs)))
+        n = len(text) if isinstance(text, (list, tuple)) else 1
+        return {
+            "input_ids": torch.tensor([[PAD_ID, AUDIO_ID, 5, 6]] * n),
+            "attention_mask": torch.tensor([[0, 1, 1, 1]] * n),
+            "input_features": torch.zeros(n, 128, 3000),
+        }
+
+
+AUDIO_EXAMPLE = {"messages": [
+    {"role": "user", "content": [
+        {"type": "audio", "audio": CLIP}, {"type": "text", "text": "hi"}]},
+    {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+]}
+
+
+def _assert_clips_arrived_under_plural(proc):
+    delivered = [audios for audios, _ in proc.calls if audios]
+    assert len(delivered) == 1 and len(delivered[0]) == 1, (
+        "clips were sent under a keyword this processor does not read; "
+        f"calls={proc.calls}"
+    )
+    # And never under the singular, which would land in **kwargs and be dropped.
+    assert all("audio" not in stray for _, stray in proc.calls), proc.calls
+
+
+def test_audios_only_processor_gets_the_plural_kwarg_in_call_path():
+    proc = _AudiosOnlyProcessor()
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=proc)
+    assert collator.audio_call_kwarg == "audios"
+    collator([AUDIO_EXAMPLE])
+    _assert_clips_arrived_under_plural(proc)
+
+
+def test_audios_only_processor_gets_the_plural_kwarg_in_prompt_completion_path():
+    # Second entry point: _collate_prompt_completion has its own audio kwarg
+    # assignment, and a fix that only covered __call__ would miss it.
+    proc = _AudiosOnlyProcessor()
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=proc)
+    collator([{
+        "prompt": AUDIO_EXAMPLE["messages"][:1],
+        "completion": AUDIO_EXAMPLE["messages"][1:],
+    }])
+    _assert_clips_arrived_under_plural(proc)
+
+
+def test_singular_kwarg_still_used_for_audio_processors():
+    # Backward compatibility: the historical spelling must not change for any
+    # processor that names `audio`, which is every audio processor transformers
+    # ships today except the plural-also pair (Clap, SeamlessM4T).
+    collator = UnslothVisionDataCollator(model=_stub_model(), processor=_AudioKwargProcessor())
+    assert collator.audio_call_kwarg == "audio"
+    # Vision-only processors name no audio argument and never send one; the
+    # slot must still hold the historical default rather than None.
+    vision = UnslothVisionDataCollator(model=_stub_model(), processor=_VisionProcessor())
+    assert vision.audio_call_kwarg == "audio"
+
+
+def test_every_transformers_audio_processor_is_classified_by_what_it_accepts():
+    # Derive the expectation from transformers itself: for every processor class
+    # that ships an audio sub-processor, the resolver must return a keyword its
+    # __call__ actually binds (or None, meaning "reject at construction").
+    pytest.importorskip("transformers")
+    import importlib, pkgutil
+    import transformers.models as models_pkg
+
+    checked = 0
+    for module_info in pkgutil.iter_modules(models_pkg.__path__):
+        name = module_info.name
+        try:
+            module = importlib.import_module(f"transformers.models.{name}.processing_{name}")
+        except Exception:
+            continue
+        for cls in vars(module).values():
+            if not inspect.isclass(cls) or cls.__module__ != module.__name__: continue
+            attrs = getattr(cls, "attributes", None) or ()
+            if not ({"feature_extractor", "audio_processor"} & set(attrs)): continue
+            try:
+                params = inspect.signature(cls.__call__).parameters
+            except (TypeError, ValueError):
+                continue
+            checked += 1
+            kwarg = _audio_call_kwarg(cls)
+            if kwarg is None:
+                assert "audio" not in params and "audios" not in params, cls.__name__
+            else:
+                assert kwarg in params, f"{cls.__name__}: __call__ has no {kwarg}="
+    assert checked > 10, f"only inspected {checked} audio processors; scan broke"
 
 
 class _RoundTripAudioProcessor(_AudioOnlyProcessor):

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -783,7 +783,7 @@ def test_text_only_processor_still_rejected():
 def test_vision_processor_still_constructs():
     # Vision path is byte-identical: image_processor present -> gate not triggered.
     collator = UnslothVisionDataCollator(model=_stub_model(), processor=_VisionProcessor())
-    assert hasattr(collator.processor, "image_processor")
+    assert getattr(collator.processor, "image_processor", None) is not None
 
 
 class _VoxtralLikeProcessor(_ChatTemplateMixin):
@@ -998,7 +998,7 @@ def test_audio_only_collator_masks_audio_and_pad_tokens():
 @pytest.mark.parametrize("model_id", ["Qwen/Qwen2-Audio-7B-Instruct"])
 def test_real_audio_processor_constructs_and_round_trips(model_id):
     # Full-fidelity check against a REAL audio processor. Skips in CI when
-    # transformers / the processor download / soundfile are unavailable.
+    # transformers or the processor download are unavailable.
     transformers = pytest.importorskip("transformers")
     try:
         proc = transformers.AutoProcessor.from_pretrained(model_id)

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -1223,3 +1223,20 @@ def test_all_three_consumers_agree_on_an_audio_processor_only_shape():
     with pytest.raises(ValueError, match="sampling_rate"):                     # rate
         collator._extract_audio_for_example(
             {"audio": {"array": CLIP, "sampling_rate": 44100}}, [])
+
+
+@pytest.mark.parametrize("key", ["audio", "url", "path", "audio_url"])
+def test_array_payload_under_any_key_does_not_trip_numpy_truthiness(key):
+    # A waveform handed to a string-ish key must resolve, not raise
+    # "truth value of an array with more than one element is ambiguous".
+    # On the previous `ele.get("url") or ele.get("path")` chain this held for
+    # `path` (last term, never truth-tested) but raised for `url`.
+    out = extract_audio_info(msgs({"type": "audio", key: CLIP}))
+    assert len(out) == 1
+    np.testing.assert_allclose(out[0], CLIP)
+
+
+def test_empty_string_key_falls_through_to_the_next_key():
+    # Preserved from the old `or` chain: a blank url must not shadow a real path.
+    out = extract_audio_info(msgs({"type": "audio", "url": "", "path": "/tmp/a.wav"}))
+    assert out == ["/tmp/a.wav"]

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -777,8 +777,15 @@ class UnslothVisionDataCollator:
         snap_to_patch_size = False,
         last_response_only = False, # Train only on the last assistant turn
     ):
-        if not hasattr(processor, "image_processor"):
-            raise TypeError("Unsloth: UnslothVisionDataCollator is only for image models!")
+        # Accept image processors, audio-only processors (Qwen2-Audio, Voxtral,
+        # Granite-Speech, ... expose a feature_extractor but no image_processor),
+        # and combined vision+audio processors. Reject only a bare text tokenizer.
+        # feature_extractor is the same audio signal used by
+        # _fix_audio_feature_extractor_padding_side below.
+        if not hasattr(processor, "image_processor") and getattr(processor, "feature_extractor", None) is None:
+            raise TypeError(
+                "Unsloth: UnslothVisionDataCollator requires an image or audio processor!"
+            )
 
         self.padding_token_ids = get_padding_tokens_ids(processor)
         self.dtype = _get_dtype(

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1097,8 +1097,17 @@ class UnslothVisionDataCollator:
         return image, video, video_kwarg
 
     def _extract_audio_for_example(self, example, messages):
-        feature_extractor = getattr(self.processor, "feature_extractor", None)
-        target_sr = getattr(feature_extractor, "sampling_rate", None)
+        # Read the expected sampling rate from whichever audio sub-processor the
+        # processor exposes: Qwen2-Audio and Voxtral use "feature_extractor",
+        # Granite-Speech uses "audio_processor". Without the audio_processor
+        # fallback, an audio_processor-only processor yields target_sr=None and
+        # the sampling-rate check is skipped, so a clip decoded at the wrong rate
+        # would be trained on silently instead of raising _check_audio_sampling_rate.
+        audio_sub = (
+            getattr(self.processor, "feature_extractor", None)
+            or getattr(self.processor, "audio_processor", None)
+        )
+        target_sr = getattr(audio_sub, "sampling_rate", None)
         audio_val = example.get("audio")
         if audio_val is None:
             # No usable top-level audio -> fall back to inline message content

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -777,12 +777,19 @@ class UnslothVisionDataCollator:
         snap_to_patch_size = False,
         last_response_only = False, # Train only on the last assistant turn
     ):
-        # Accept image processors, audio-only processors (Qwen2-Audio, Voxtral,
-        # Granite-Speech, ... expose a feature_extractor but no image_processor),
-        # and combined vision+audio processors. Reject only a bare text tokenizer.
-        # feature_extractor is the same audio signal used by
-        # _fix_audio_feature_extractor_padding_side below.
-        if not hasattr(processor, "image_processor") and getattr(processor, "feature_extractor", None) is None:
+        # Accept image processors, audio-only processors, and combined
+        # vision+audio processors. Reject only a bare text tokenizer.
+        # Audio processors do not agree on one attribute name: Qwen2-Audio and
+        # Voxtral expose "feature_extractor", while Granite-Speech exposes
+        # "audio_processor" (see each model's processor .attributes in
+        # transformers), so both spellings are accepted here. getattr(...) is
+        # None rather than hasattr so a processor that defines the attribute and
+        # sets it to None is treated as not having it.
+        if (
+            getattr(processor, "image_processor", None) is None
+            and getattr(processor, "feature_extractor", None) is None
+            and getattr(processor, "audio_processor", None) is None
+        ):
             raise TypeError(
                 "Unsloth: UnslothVisionDataCollator requires an image or audio processor!"
             )

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -643,18 +643,18 @@ _AUDIO_CONTENT_KEYS_TEXT = ", ".join(f"`{k}`" for k in _AUDIO_CONTENT_KEYS[:-1])
 
 
 def _audio_payload_from_content(ele):
-    # "audio" carries an inline payload (array / HF Audio dict), so only a real
-    # None means absent -- an empty array must not fall through to the string keys.
-    value = ele.get("audio")
-    if value is not None:
-        return value
-    # The remaining keys are string sources (local path or URL); feature
-    # extractors accept those directly. Falsy (empty) strings fall through,
-    # matching the previous `ele.get("url") or ele.get("path")` behaviour.
-    for key in _AUDIO_CONTENT_KEYS[1:]:
+    # First usable payload among the accepted keys. Only `is None` counts as
+    # absent -- a bare truthiness test would raise on a numpy waveform
+    # ("truth value of an array with more than one element is ambiguous"),
+    # which the previous `ele.get("url") or ele.get("path")` chain did for any
+    # array passed under a string key.
+    for key in _AUDIO_CONTENT_KEYS:
         value = ele.get(key)
-        if value:
-            return value
+        if value is None: continue
+        # An empty string is not a loadable path or URL: fall through to the
+        # next key, matching the previous chain's behaviour for "" .
+        if isinstance(value, str) and not value: continue
+        return value
     return None
 
 

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -608,6 +608,40 @@ def _resolve_audio_dict(audio, sampling_rate=None):
     return value
 
 
+# Content-part keys that can carry an audio payload, in priority order.
+#
+# "audio", "url" and "path" mirror transformers' generic chat-template audio
+# loader (processing_utils.py, `for key in ["audio", "url", "path"]` inside
+# ProcessorMixin.apply_chat_template), which is what most audio templates parse.
+#
+# "audio_url" is the Qwen family's spelling: Qwen2AudioProcessor's built-in chat
+# template branches on `'audio' in content or 'audio_url' in content` (see
+# transformers/models/qwen2_audio/processing_qwen2_audio.py, default_chat_template)
+# and the processor's own docstring example uses {"type": "audio", "audio_url": ...};
+# Qwen2.5-Omni and Qwen3-Omni document the same shape. Without it the template
+# renders an <|AUDIO|> placeholder while no clip is collected, so the example
+# either raises here or reaches the model with a token/feature mismatch.
+_AUDIO_CONTENT_KEYS = ("audio", "url", "path", "audio_url")
+_AUDIO_CONTENT_KEYS_TEXT = ", ".join(f"`{k}`" for k in _AUDIO_CONTENT_KEYS[:-1]) + \
+    f" or `{_AUDIO_CONTENT_KEYS[-1]}`"
+
+
+def _audio_payload_from_content(ele):
+    # "audio" carries an inline payload (array / HF Audio dict), so only a real
+    # None means absent -- an empty array must not fall through to the string keys.
+    value = ele.get("audio")
+    if value is not None:
+        return value
+    # The remaining keys are string sources (local path or URL); feature
+    # extractors accept those directly. Falsy (empty) strings fall through,
+    # matching the previous `ele.get("url") or ele.get("path")` behaviour.
+    for key in _AUDIO_CONTENT_KEYS[1:]:
+        value = ele.get(key)
+        if value:
+            return value
+    return None
+
+
 def extract_audio_info(
     conversations: Union[List[Dict], List[List[Dict]]],
     sampling_rate: int = None,
@@ -624,15 +658,13 @@ def extract_audio_info(
                 for ele in content:
                     if not (isinstance(ele, dict) and ele.get("type") == "audio"):
                         continue
-                    audio = ele.get("audio")
-                    # Feature extractors also accept local paths and URLs as strings
-                    if audio is None:
-                        audio = ele.get("url") or ele.get("path")
+                    audio = _audio_payload_from_content(ele)
                     if _is_audio_mapping(audio):
                         audio = _resolve_audio_dict(audio, sampling_rate)
                     if audio is None:
                         raise ValueError(
-                            "Unsloth: an audio content part has no `audio`, `url` or `path` data, "
+                            "Unsloth: an audio content part has no "
+                            f"{_AUDIO_CONTENT_KEYS_TEXT} data, "
                             "so the clip cannot be loaded and the example would train as text only."
                         )
                     audio_inputs.append(audio)

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -544,17 +544,33 @@ def _check_audio_sampling_rate(sampling_rate, target_sampling_rate):
         )
 
 
+# Transformers processors do not agree on what to call the audio sub-processor:
+# `attributes` is ["feature_extractor", "tokenizer"] for Qwen2-Audio, Voxtral,
+# Whisper and most speech models, but ["audio_processor", "tokenizer"] for
+# Granite-Speech and ["image_processor", "audio_processor", "tokenizer"] for
+# Phi-4-multimodal. Resolve it in ONE place: the constructor gate, the
+# padding-side normalisation and the sampling-rate read must agree on what
+# counts as audio support, and updating one without the others is exactly how
+# this collator ended up admitting processors it then could not serve.
+_AUDIO_SUB_PROCESSOR_ATTRS = ("feature_extractor", "audio_processor")
+
+
+def _audio_sub_processors(processor):
+    # Every audio sub-processor the processor exposes, in preference order.
+    # Empty means "no audio support" -- the gate's rejection condition.
+    subs = []
+    for attr in _AUDIO_SUB_PROCESSOR_ATTRS:
+        sub = getattr(processor, attr, None)
+        if sub is not None: subs.append(sub)
+    return subs
+
+
 def _fix_audio_feature_extractor_padding_side(processor):
     # The loader's padding_side="left" (a text setting) leaks into the audio
     # feature extractor via from_pretrained. Frame-validity masks assume right
     # padding; left padding desyncs Gemma 4 audio token counts (crash on tf < 5.10).
-    # Audio processors do not agree on the sub-processor attribute name
-    # (feature_extractor for Qwen2-Audio/Voxtral, audio_processor for
-    # Granite-Speech), so normalize whichever is present -- matching the
-    # sampling-rate fallback in _extract_audio_for_example.
-    for attr in ("feature_extractor", "audio_processor"):
-        sub = getattr(processor, attr, None)
-        if sub is not None and getattr(sub, "padding_side", None) == "left":
+    for sub in _audio_sub_processors(processor):
+        if getattr(sub, "padding_side", None) == "left":
             sub.padding_side = "right"
 
 
@@ -852,16 +868,12 @@ class UnslothVisionDataCollator:
     ):
         # Accept image processors, audio-only processors, and combined
         # vision+audio processors. Reject only a bare text tokenizer.
-        # Audio processors do not agree on one attribute name: Qwen2-Audio and
-        # Voxtral expose "feature_extractor", while Granite-Speech exposes
-        # "audio_processor" (see each model's processor .attributes in
-        # transformers), so both spellings are accepted here. getattr(...) is
-        # None rather than hasattr so a processor that defines the attribute and
-        # sets it to None is treated as not having it.
+        # getattr(...) is None rather than hasattr so a processor that defines
+        # image_processor and sets it to None is treated as not having one; the
+        # audio side goes through the shared _audio_sub_processors resolution.
         if (
             getattr(processor, "image_processor", None) is None
-            and getattr(processor, "feature_extractor", None) is None
-            and getattr(processor, "audio_processor", None) is None
+            and not _audio_sub_processors(processor)
         ):
             raise TypeError(
                 "Unsloth: UnslothVisionDataCollator requires an image or audio processor!"
@@ -1202,16 +1214,14 @@ class UnslothVisionDataCollator:
 
     def _extract_audio_for_example(self, example, messages):
         # Read the expected sampling rate from whichever audio sub-processor the
-        # processor exposes: Qwen2-Audio and Voxtral use "feature_extractor",
-        # Granite-Speech uses "audio_processor". Without the audio_processor
-        # fallback, an audio_processor-only processor yields target_sr=None and
-        # the sampling-rate check is skipped, so a clip decoded at the wrong rate
+        # processor exposes (same resolution the gate admitted it on). Without
+        # this, an audio_processor-only processor yields target_sr=None and the
+        # sampling-rate check is skipped, so a clip decoded at the wrong rate
         # would be trained on silently instead of raising _check_audio_sampling_rate.
-        audio_sub = (
-            getattr(self.processor, "feature_extractor", None)
-            or getattr(self.processor, "audio_processor", None)
-        )
-        target_sr = getattr(audio_sub, "sampling_rate", None)
+        target_sr = None
+        for audio_sub in _audio_sub_processors(self.processor):
+            target_sr = getattr(audio_sub, "sampling_rate", None)
+            if target_sr is not None: break
         audio_val = example.get("audio")
         if audio_val is None:
             # No usable top-level audio -> fall back to inline message content

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1013,29 +1013,54 @@ class UnslothVisionDataCollator:
 
         # Check what type for assistant VLM tokenizer allows!
         # Good for Mistral V3 and Pixtral I think
-        try:
+        #
+        # Probe with the modality this processor actually has: an audio-only
+        # processor's chat template need not understand an {"type": "image"}
+        # part, and probing it with one can fail construction for a model the
+        # collator can otherwise serve.
+        modality_part = {"type": "image"} if \
+            getattr(processor, "image_processor", None) is not None else {"type": "audio"}
+        def _probe(user_content, assistant_content):
             processor.apply_chat_template([
-                {"role": "user", "content": [
-                    {"type": "image"},
-                    {"type": "text", "text": "Hello!"}]},
-                {"role": "assistant", "content": [
-                    {"type": "text", "text": "How can I help you?"}]}
+                {"role": "user", "content": user_content},
+                {"role": "assistant", "content": assistant_content},
             ])
+        list_user = [modality_part, {"type": "text", "text": "Hello!"}]
+        try:
+            _probe(list_user, [{"type": "text", "text": "How can I help you?"}])
             self.assistant_single_content = False
         except TypeError:
             try:
-                processor.apply_chat_template([
-                    {"role": "user", "content": [
-                        {"type": "image"},
-                        {"type": "text", "text": "Hello!"}]},
-                    {"role": "assistant", "content": "How can I help you?"}
-                ])
+                _probe(list_user, "How can I help you?")
                 self.assistant_single_content = True
                 print(
                     f"Unsloth: {processor.__class__.__name__} only accepts 1 "\
                     "text field for assistant roles!\n"\
                     "We will auto fix the data collator to support it!"
                 )
+            except TypeError as list_content_error:
+                # Some speech chat templates concatenate message["content"]
+                # straight into the prompt ('...' + message['content'] + '...'),
+                # so they accept only plain strings for EVERY role and raise
+                # "can only concatenate str (not list) to str" on both probes
+                # above -- Granite-Speech is one. The collator normalises all
+                # message content INTO content parts
+                # (_validate_and_normalize_first_message), so such a template
+                # cannot be rendered here at all. Say so at construction rather
+                # than letting it fail on the first batch, matching how an
+                # audio processor with no `audio=` argument is handled.
+                try:
+                    _probe("Hello!", "How can I help you?")
+                except Exception:
+                    _raise_chat_template_error(list_content_error, processor, model)
+                raise TypeError(
+                    f"Unsloth: UnslothVisionDataCollator does not yet support "
+                    f"{type(processor).__name__}: its chat template accepts only "
+                    "plain-string message content, while the collator renders "
+                    "messages as content parts ([{'type': 'text', ...}]). "
+                    "Tokenize with processor.apply_chat_template(..., tokenize=True) "
+                    "and pass audio through the processor directly instead."
+                ) from list_content_error
             except Exception as e:
                 _raise_chat_template_error(e, processor, model)
         except Exception as e:

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -783,6 +783,40 @@ def _raise_chat_template_error(error, processor, model = None):
     raise RuntimeError(error) from error
 
 
+# Keywords a processor's __call__ can name its audio argument, in the order the
+# collator prefers them. Every audio processor in transformers that accepts
+# audio names one of these; the two that name the plural (Clap, SeamlessM4T)
+# also name the singular, so today the singular always wins.
+_AUDIO_CALL_KWARGS = ("audio", "audios")
+
+
+def _audio_call_kwarg(processor):
+    # Which keyword `processor(text=..., <kwarg>=clips)` must use, or None when
+    # __call__ names no audio argument at all (VoxtralProcessor, WhisperProcessor,
+    # MusicgenProcessor, ... -- these cannot batch audio through this collator).
+    #
+    # Callers must use the returned name rather than a hard-coded "audio":
+    # deciding admission on one spelling and then sending the other means an
+    # `audios=`-only processor constructs successfully and then loses its clips
+    # (the unexpected `audio=` is swallowed by **kwargs while the parameter the
+    # processor actually reads stays None), or raises an unexpected-keyword
+    # TypeError on the first audio batch.
+    #
+    # Capability check rather than a class-name check, so a processor added to
+    # transformers later is classified by what it accepts. The limit of a
+    # signature check is a processor that takes audio only through **kwargs with
+    # no named parameter; none in transformers does that today. If __call__
+    # cannot be introspected at all (a minimal stub), fail open with the
+    # historical spelling rather than regress a processor that works.
+    try:
+        params = inspect.signature(processor.__call__).parameters
+    except (AttributeError, TypeError, ValueError):
+        return _AUDIO_CALL_KWARGS[0]
+    for name in _AUDIO_CALL_KWARGS:
+        if name in params: return name
+    return None
+
+
 class UnslothVisionDataCollator:
     # All Unsloth Zoo code licensed under LGPLv3
     __slots__ = (
@@ -792,6 +826,7 @@ class UnslothVisionDataCollator:
         "num_proc", "assistant_single_content", "patch_size",
         "resize_dimension", "snap_to_patch_size",
         "completion_only_loss", "pad_to_multiple_of", "size_func",
+        "audio_call_kwarg",
     )
 
     def __init__(
@@ -832,47 +867,33 @@ class UnslothVisionDataCollator:
                 "Unsloth: UnslothVisionDataCollator requires an image or audio processor!"
             )
 
+        # Resolve, once, the keyword this processor names its audio argument.
+        # This is both the admission test and the keyword every audio call site
+        # in this class uses, so the keyword sent can never drift from the
+        # keyword accepted -- see _audio_call_kwarg for why that matters.
+        audio_call_kwarg = _audio_call_kwarg(processor)
+
         # An audio-only processor (no image_processor) reaches the collator's
-        # audio path, which calls self.processor(text=..., audio=...). Some audio
-        # processors do not accept an `audio=` argument in __call__ -- notably
-        # transformers' VoxtralProcessor, whose __call__ is (text, **kwargs) with
-        # no audio parameter and which raises when the rendered text contains its
-        # audio token (it requires audio to go through apply_chat_template). Such a
-        # processor passes the acceptance guard above (it has a feature_extractor)
-        # but then fails inside the collate call. Reject it up front instead.
-        #
-        # Capability check rather than a class-name check: the audio processors the
-        # collator does support (Qwen2-Audio, Granite-Speech, ...) declare a named
-        # `audio` parameter on __call__ and process it, while Voxtral does not --
-        # so the presence of a named audio parameter is a reliable, forward-
-        # compatible signal. Both spellings are checked: `audio`, and `audios`
-        # for the only two audio processors that name it in the plural today,
-        # Clap and SeamlessM4T (both of which also expose `audio`). If __call__
-        # cannot be introspected we fail open (accept) rather than regress a
-        # working processor.
-        #
-        # The check is signature-based: a processor that consumed audio only
-        # through **kwargs, with no named audio/audios parameter, would be
-        # rejected here despite working -- none of transformers' audio processors
-        # do this today.
-        if getattr(processor, "image_processor", None) is None:
-            try:
-                _call_params = inspect.signature(processor.__call__).parameters
-            except (AttributeError, TypeError, ValueError):
-                # No/uninspectable __call__ (e.g. a minimal stub): fail open.
-                _call_params = None
-            if _call_params is not None and not (
-                "audio" in _call_params or "audios" in _call_params
-            ):
-                raise TypeError(
-                    f"Unsloth: UnslothVisionDataCollator does not yet support "
-                    f"{type(processor).__name__}: its processor __call__ takes no "
-                    "`audio=` argument, so audio cannot be batched through the "
-                    "collator (e.g. VoxtralProcessor requires audio to go through "
-                    "apply_chat_template and rejects text containing its audio "
-                    "token). Prepare audio with processor.apply_chat_template("
-                    "..., tokenize=True, return_dict=True) instead."
-                )
+        # audio path, which calls self.processor(text=..., <audio kwarg>=...).
+        # Some audio processors accept no audio argument at all -- notably
+        # transformers' VoxtralProcessor, whose __call__ is (text, **kwargs) and
+        # which raises when the rendered text contains its audio token (it
+        # requires audio to go through apply_chat_template). Such a processor
+        # passes the acceptance guard above (it has a feature_extractor) but then
+        # fails inside the collate call, so reject it up front instead.
+        if getattr(processor, "image_processor", None) is None and audio_call_kwarg is None:
+            raise TypeError(
+                f"Unsloth: UnslothVisionDataCollator does not yet support "
+                f"{type(processor).__name__}: its processor __call__ takes no "
+                "`audio=` argument, so audio cannot be batched through the "
+                "collator (e.g. VoxtralProcessor requires audio to go through "
+                "apply_chat_template and rejects text containing its audio "
+                "token). Prepare audio with processor.apply_chat_template("
+                "..., tokenize=True, return_dict=True) instead."
+            )
+        # Vision-only processors name no audio argument and never send one
+        # (`audios` stays empty), so the historical spelling is a safe default.
+        self.audio_call_kwarg = audio_call_kwarg or "audio"
 
         self.padding_token_ids = get_padding_tokens_ids(processor)
         self.dtype = _get_dtype(
@@ -1084,7 +1105,10 @@ class UnslothVisionDataCollator:
             for k, v in video_kwargs.items():
                 proc_kwargs[k] = v
         if audios:
-            proc_kwargs["audio"] = audios
+            # Send the keyword __init__ verified this processor names. getattr
+            # with a default because instances built via __new__ (several tests
+            # do) leave the slot unset; the collator has always sent `audio=`.
+            proc_kwargs[getattr(self, "audio_call_kwarg", None) or "audio"] = audios
         if self.pad_to_multiple_of is not None:
             proc_kwargs["pad_to_multiple_of"] = self.pad_to_multiple_of
         batch = self.processor(**proc_kwargs)
@@ -1594,7 +1618,8 @@ class UnslothVisionDataCollator:
             for k, v in video_kwargs.items():
                 prompt_kwargs[k] = v
         if audios:
-            prompt_kwargs["audio"] = audios
+            # Same keyword as the __call__ path above; see the note there.
+            prompt_kwargs[getattr(self, "audio_call_kwarg", None) or "audio"] = audios
 
         proc_prompts = self.processor(text=prompt_texts, **prompt_kwargs)
         # Encode completions (RIGHT pad) text-only

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -547,9 +547,14 @@ def _fix_audio_feature_extractor_padding_side(processor):
     # The loader's padding_side="left" (a text setting) leaks into the audio
     # feature extractor via from_pretrained. Frame-validity masks assume right
     # padding; left padding desyncs Gemma 4 audio token counts (crash on tf < 5.10).
-    feature_extractor = getattr(processor, "feature_extractor", None)
-    if feature_extractor is not None and getattr(feature_extractor, "padding_side", None) == "left":
-        feature_extractor.padding_side = "right"
+    # Audio processors do not agree on the sub-processor attribute name
+    # (feature_extractor for Qwen2-Audio/Voxtral, audio_processor for
+    # Granite-Speech), so normalize whichever is present -- matching the
+    # sampling-rate fallback in _extract_audio_for_example.
+    for attr in ("feature_extractor", "audio_processor"):
+        sub = getattr(processor, attr, None)
+        if sub is not None and getattr(sub, "padding_side", None) == "left":
+            sub.padding_side = "right"
 
 
 @lru_cache(maxsize=1)

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -1283,14 +1283,7 @@ class UnslothVisionDataCollator:
             normalized.append(clip)
         return normalized
 
-    def _truncate_sequence_tensors(self, batch, seq_len):
-        # Slice only per-token tensors. Matching on shape[-1] == seq_len can clip
-        # input_features [B, frames, mel] or input_features_mask [B, frames].
-        new_len = self.max_seq_length
-        keys = [
-            k for k in ("input_ids", "attention_mask", "token_type_ids", "mm_token_type_ids")
-            if k in batch and isinstance(batch[k], torch.Tensor) and batch[k].shape[-1] == seq_len
-        ]
+    def _audio_token_ids(self, device):
         tok = getattr(self.processor, "tokenizer", self.processor)
         audio_tokens = list(AUDIO_TOKENS)
         if getattr(tok, "audio_token", None) is not None:
@@ -1299,12 +1292,37 @@ class UnslothVisionDataCollator:
         # get_padding_tokens_ids); excluding it keeps a truncated unk text token from being
         # miscounted as an audio token and tripping the alignment check below.
         unk_id = getattr(tok, "unk_token_id", None)
-        audio_ids = torch.tensor(
+        return torch.tensor(
             [i for i in tok.convert_tokens_to_ids(audio_tokens)
              if isinstance(i, int) and i >= 0 and i != unk_id],
-            device=batch["input_ids"].device,
+            device=device,
         )
-        n_audio = int(torch.isin(batch["input_ids"], audio_ids).sum())
+
+    def _check_audio_tokens_survived(self, before_ids, after_ids, new_len):
+        # Truncation may only remove text: the audio feature tensors keep their
+        # full width, so dropping expanded audio placeholders leaves the model
+        # splicing N audio embeddings into fewer than N slots. Shared by the
+        # __call__ path (_truncate_sequence_tensors) and the prompt/completion
+        # path (_truncate_by_side) -- checking only one of them lets the other
+        # corrupt the batch silently.
+        audio_ids = self._audio_token_ids(before_ids.device)
+        if audio_ids.numel() == 0: return
+        if int(torch.isin(after_ids, audio_ids).sum()) == \
+           int(torch.isin(before_ids, audio_ids).sum()): return
+        raise ValueError(
+            f"Unsloth: max_seq_length = {new_len} cuts into the expanded audio tokens, which "
+            "breaks audio alignment at model forward. Increase max_seq_length or shorten the audio."
+        )
+
+    def _truncate_sequence_tensors(self, batch, seq_len):
+        # Slice only per-token tensors. Matching on shape[-1] == seq_len can clip
+        # input_features [B, frames, mel] or input_features_mask [B, frames].
+        new_len = self.max_seq_length
+        keys = [
+            k for k in ("input_ids", "attention_mask", "token_type_ids", "mm_token_type_ids")
+            if k in batch and isinstance(batch[k], torch.Tensor) and batch[k].shape[-1] == seq_len
+        ]
+        pre_truncation_ids = batch["input_ids"]
         if self._tokenizer_padding_side() == "left":
             # Keep each row's first new_len content tokens and re-pad on the left,
             # otherwise short rows keep only their left padding.
@@ -1316,11 +1334,7 @@ class UnslothVisionDataCollator:
         else:
             for k in keys:
                 batch[k] = batch[k][..., :new_len]
-        if int(torch.isin(batch["input_ids"], audio_ids).sum()) != n_audio:
-            raise ValueError(
-                f"Unsloth: max_seq_length = {new_len} cuts into the expanded audio tokens, which "
-                "breaks audio alignment at model forward. Increase max_seq_length or shorten the audio."
-            )
+        self._check_audio_tokens_survived(pre_truncation_ids, batch["input_ids"], new_len)
         return batch
 
     def _extract_images_for_pc(self, example, p_msgs, c_msgs):
@@ -1505,6 +1519,11 @@ class UnslothVisionDataCollator:
         if L <= max_len:
             return [input_ids, attention_mask, completion_mask] + ([token_type_ids] if token_type_ids is not None else [])
         sl = slice(-max_len, None) if side == "left" else slice(0, max_len)
+
+        # Same guard the __call__ path applies in _truncate_sequence_tensors: the
+        # prompt batch's input_features are carried through at full width, so
+        # slicing away audio placeholders here would desync audio at forward.
+        self._check_audio_tokens_survived(input_ids, input_ids[:, sl], max_len)
 
         input_ids       = input_ids[:, sl]
         attention_mask  = attention_mask[:, sl]

--- a/unsloth_zoo/vision_utils.py
+++ b/unsloth_zoo/vision_utils.py
@@ -46,6 +46,7 @@ import math
 import time
 import warnings
 import os
+import inspect
 from functools import lru_cache
 from collections.abc import Mapping
 
@@ -798,6 +799,48 @@ class UnslothVisionDataCollator:
             raise TypeError(
                 "Unsloth: UnslothVisionDataCollator requires an image or audio processor!"
             )
+
+        # An audio-only processor (no image_processor) reaches the collator's
+        # audio path, which calls self.processor(text=..., audio=...). Some audio
+        # processors do not accept an `audio=` argument in __call__ -- notably
+        # transformers' VoxtralProcessor, whose __call__ is (text, **kwargs) with
+        # no audio parameter and which raises when the rendered text contains its
+        # audio token (it requires audio to go through apply_chat_template). Such a
+        # processor passes the acceptance guard above (it has a feature_extractor)
+        # but then fails inside the collate call. Reject it up front instead.
+        #
+        # Capability check rather than a class-name check: the audio processors the
+        # collator does support (Qwen2-Audio, Granite-Speech, ...) declare a named
+        # `audio` parameter on __call__ and process it, while Voxtral does not --
+        # so the presence of a named audio parameter is a reliable, forward-
+        # compatible signal. Both spellings are checked: `audio`, and `audios`
+        # for the only two audio processors that name it in the plural today,
+        # Clap and SeamlessM4T (both of which also expose `audio`). If __call__
+        # cannot be introspected we fail open (accept) rather than regress a
+        # working processor.
+        #
+        # The check is signature-based: a processor that consumed audio only
+        # through **kwargs, with no named audio/audios parameter, would be
+        # rejected here despite working -- none of transformers' audio processors
+        # do this today.
+        if getattr(processor, "image_processor", None) is None:
+            try:
+                _call_params = inspect.signature(processor.__call__).parameters
+            except (AttributeError, TypeError, ValueError):
+                # No/uninspectable __call__ (e.g. a minimal stub): fail open.
+                _call_params = None
+            if _call_params is not None and not (
+                "audio" in _call_params or "audios" in _call_params
+            ):
+                raise TypeError(
+                    f"Unsloth: UnslothVisionDataCollator does not yet support "
+                    f"{type(processor).__name__}: its processor __call__ takes no "
+                    "`audio=` argument, so audio cannot be batched through the "
+                    "collator (e.g. VoxtralProcessor requires audio to go through "
+                    "apply_chat_template and rejects text containing its audio "
+                    "token). Prepare audio with processor.apply_chat_template("
+                    "..., tokenize=True, return_dict=True) instead."
+                )
 
         self.padding_token_ids = get_padding_tokens_ids(processor)
         self.dtype = _get_dtype(


### PR DESCRIPTION
# Let `UnslothVisionDataCollator` accept audio-only processors
 
Refs #757
 
## The bug
 
`UnslothVisionDataCollator.__init__` hard-required an `image_processor`. Audio-only processors — Qwen2-Audio, Voxtral, Granite-Speech, which carry a `feature_extractor` but no `image_processor` — hit the guard and raised at construction:
 
```
TypeError: Unsloth: UnslothVisionDataCollator is only for image models!
```
 
So audio LoRA training couldn't even get off the ground: the collator refused to build.
 
## The audio pipeline was already there — only construction was blocked
 
The downstream machinery for audio already landed in earlier PRs:
 
- **#723** added audio content extraction and `AUDIO_TOKENS` masking, so `<|AUDIO|>` is already masked in labels.
- **#917** hardened the audio path.
The only remaining gap was the constructor gate. This is why the fix is small and why the scope here is **construction, not masking** — the masking the issue mentions is already handled.
 
## The fix
 
Widen the constructor gate to admit any **image- or audio-capable** processor, and reject only a bare text tokenizer:
 
```python
if not hasattr(processor, "image_processor") and getattr(processor, "feature_extractor", None) is None:
    raise TypeError("Unsloth: UnslothVisionDataCollator requires an image or audio processor!")
```
 
`feature_extractor` is the same audio signal already used by `_fix_audio_feature_extractor_padding_side`, so this keys audio detection on an existing convention rather than a new heuristic. The vision and vision+audio paths are **byte-identical** — they carry an `image_processor`, so the first clause is false and the gate is never triggered (Gemma3n vision+audio included).
 
## Verification (CPU, no CUDA, no weights)
 
- A real `Qwen2AudioProcessor` (config only, no weights) now constructs the collator.
- A full `__call__` round-trip on a synthetic waveform produces `input_features`, correctly masks the audio and pad tokens, and keeps the real assistant tokens unmasked.
- Vision and vision+audio paths confirmed byte-identical; a bare text tokenizer still raises.
## Tests
 
Regression tests extend `tests/test_vision_collator_audio.py`:
 
- the construction gate (audio-only admitted, text-only rejected),
- a hermetic stub-processor round-trip that runs in CI **without** audio deps,
- a real Qwen2-Audio round-trip that skips cleanly when transformers / the processor download are unavailable.
Canonical MLX baseline suite: 0 failures.
 
## Scope
 
Addresses #757 (a maintainer-scoped task). `<|AUDIO|>` masking was already handled by #723, so this covers construction plus the audio round-trip, not masking. The synthetic stub round-trip is exercised in CI; the real-processor round-trip is verified locally but inferred for CI.