### PR TITLE
Fix Gemma 4 audio and forced-float32 PLE dtype mismatches

### DIFF
--- a/tests/test_gemma4_audio_dtype.py
+++ b/tests/test_gemma4_audio_dtype.py
@@ -1,0 +1,184 @@
+import importlib.util
+import inspect
+import sys
+import textwrap
+
+import pytest
+import torch
+
+from unsloth_zoo.temporary_patches import gemma4
+from unsloth_zoo.compiler import fix_gemma4_audio_feature_dtype
+
+
+def _load_fake_gemma4(tmp_path, monkeypatch, name, cast_expression):
+    source = textwrap.dedent(
+        f"""
+        import functools
+        import torch
+
+        def preserve_metadata(function):
+            @functools.wraps(function)
+            def wrapper(*args, **kwargs):
+                return function(*args, **kwargs)
+            return wrapper
+
+        class Gemma4Model:
+            def __init__(self):
+                pass
+
+            @preserve_metadata
+            def forward(self, inputs_embeds, audio_features=None):
+                if audio_features is None:
+                    return inputs_embeds
+                audio_mask = torch.ones_like(inputs_embeds, dtype=torch.bool)
+                return inputs_embeds.masked_scatter(
+                    audio_mask,
+                    {cast_expression},
+                )
+        """
+    )
+    path = tmp_path / f"{name}.py"
+    path.write_text(source, encoding="utf-8")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module.Gemma4Model
+
+
+@pytest.mark.parametrize("inputs_dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("audio_dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_gemma4_audio_merge_aligns_to_actual_inputs_embeds_dtype(
+    tmp_path, monkeypatch, inputs_dtype, audio_dtype,
+):
+    model_cls = _load_fake_gemma4(
+        tmp_path,
+        monkeypatch,
+        f"fake_gemma4_{str(inputs_dtype)}_{str(audio_dtype)}".replace(".", "_"),
+        "audio_features.to(inputs_embeds.device)",
+    )
+    assert gemma4._patch_gemma4_audio_feature_dtype_on_class(model_cls) is True
+    patched_source = inspect.getsource(model_cls.forward)
+    assert "audio_features.to(inputs_embeds.device)" not in patched_source
+    assert "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)" in patched_source
+
+    inputs = torch.zeros(1, 2, dtype=inputs_dtype, requires_grad=True)
+    audio = torch.tensor([[1.25, -2.5]], dtype=audio_dtype, requires_grad=True)
+    output = model_cls().forward(inputs_embeds=inputs, audio_features=audio)
+
+    assert output.dtype == inputs_dtype
+    torch.testing.assert_close(output, audio.to(inputs_dtype))
+    output.float().sum().backward()
+    assert audio.grad is not None
+
+
+def test_gemma4_audio_dtype_patch_preserves_no_audio_and_is_idempotent(
+    tmp_path, monkeypatch,
+):
+    model_cls = _load_fake_gemma4(
+        tmp_path,
+        monkeypatch,
+        "fake_gemma4_idempotent",
+        "audio_features.to(inputs_embeds.device)",
+    )
+    original_signature = inspect.signature(model_cls.forward)
+    original_forward = model_cls.forward
+    assert gemma4._patch_gemma4_audio_feature_dtype_on_class(model_cls) is True
+    patched_forward = model_cls.forward
+    assert patched_forward is original_forward
+    assert gemma4._patch_gemma4_audio_feature_dtype_on_class(model_cls) is False
+    assert model_cls.forward is patched_forward
+    assert inspect.signature(model_cls.forward) == original_signature
+
+    inputs = torch.randn(1, 2, dtype=torch.float32)
+    assert model_cls().forward(inputs_embeds=inputs) is inputs
+
+
+def test_gemma4_audio_dtype_patch_noops_when_upstream_is_fixed(tmp_path, monkeypatch):
+    model_cls = _load_fake_gemma4(
+        tmp_path,
+        monkeypatch,
+        "fake_gemma4_fixed",
+        "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)",
+    )
+    original_forward = model_cls.forward
+
+    assert gemma4._patch_gemma4_audio_feature_dtype_on_class(model_cls) is False
+    assert model_cls.forward is original_forward
+    output = model_cls().forward(
+        inputs_embeds=torch.zeros(1, 2, dtype=torch.float32),
+        audio_features=torch.ones(1, 2, dtype=torch.float16),
+    )
+    assert output.dtype == torch.float32
+
+
+def test_gemma4_audio_dtype_patch_fails_closed_on_source_drift(tmp_path, monkeypatch):
+    model_cls = _load_fake_gemma4(
+        tmp_path,
+        monkeypatch,
+        "fake_gemma4_drifted",
+        "audio_features.to(device=inputs_embeds.device)",
+    )
+    original_forward = model_cls.forward
+
+    assert gemma4._patch_gemma4_audio_feature_dtype_on_class(model_cls) is False
+    assert model_cls.forward is original_forward
+    assert not hasattr(model_cls, "_unsloth_audio_feature_dtype_patched")
+
+
+def test_gemma4_audio_dtype_patch_is_registered_before_model_wrapper():
+    names = [patch.__name__ for patch in gemma4.TEMPORARY_PATCHES]
+    assert names.index("patch_Gemma4Model_audio_feature_dtype") < names.index(
+        "patch_Gemma4Model_forward_kv_shared_no_cache"
+    )
+
+
+def test_gemma4_compiler_transform_is_guarded_and_upstream_safe():
+    buggy = "audio_features.to(inputs_embeds.device)"
+    fixed = "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)"
+
+    assert fix_gemma4_audio_feature_dtype(buggy) == fixed
+    assert fix_gemma4_audio_feature_dtype(fixed) == fixed
+    multiline = "audio_features.to(\n    inputs_embeds.device\n)"
+    assert fix_gemma4_audio_feature_dtype(multiline) == fixed
+    duplicated = f"{buggy}\n{buggy}"
+    assert fix_gemma4_audio_feature_dtype(duplicated) == duplicated
+
+
+def test_gemma4_compiler_emits_fixed_generated_forward(tmp_path, monkeypatch):
+    from unsloth_zoo import compiler
+
+    module_name = "fake_gemma4_compiler_source"
+    _load_fake_gemma4(
+        tmp_path,
+        monkeypatch,
+        module_name,
+        "audio_features.to(inputs_embeds.device)",
+    )
+    module = sys.modules[module_name]
+    monkeypatch.setattr(compiler, module_name, module, raising=False)
+
+    generated = compiler.create_standalone_class(
+        "Gemma4Model",
+        module_name,
+        dir(module),
+        disable=True,
+    )
+    assert "audio_features.to(inputs_embeds.device)" not in generated
+    assert "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)" in generated
+
+
+def test_gemma4_audio_dtype_patch_is_torch_compile_safe(tmp_path, monkeypatch):
+    model_cls = _load_fake_gemma4(
+        tmp_path,
+        monkeypatch,
+        "fake_gemma4_compiled",
+        "audio_features.to(inputs_embeds.device)",
+    )
+    gemma4._patch_gemma4_audio_feature_dtype_on_class(model_cls)
+    model = model_cls()
+    compiled = torch.compile(model.forward, backend="eager", fullgraph=True)
+
+    inputs = torch.zeros(1, 2, dtype=torch.float32)
+    audio = torch.ones(1, 2, dtype=torch.float16)
+    torch.testing.assert_close(compiled(inputs, audio), model.forward(inputs, audio))

--- a/tests/test_gemma4_dtype_drift_guards.py
+++ b/tests/test_gemma4_dtype_drift_guards.py
@@ -1,0 +1,247 @@
+"""CPU/CI regression guards for the Gemma 4 dtype fixes (PR #925).
+
+These lock in the three failures we traced:
+
+  1. Audio merge: upstream `Gemma4Model.forward` cast `audio_features.to(device)`
+     without dtype (transformers #45192), while image/video cast dtype too ->
+     `masked_scatter_: expected self and source to have same dtypes`.
+  2. Forced-float32 PLE: fp32 residual into the fp16 PLE Linears (unsloth-zoo #866
+     forced fp32 but left PLE inputs uncast) -> `mat1 and mat2 ... float != Half`.
+  3. Cross-path NameError: the eager patch rewrote calls to one helper name while
+     the compiler emitted another; a compile after the eager patch called an
+     undefined helper.
+
+Everything here is CPU-only (dtype-check errors raise on CPU), no GPU required.
+The real-source canaries import the real transformers gemma4 module and skip
+cleanly when it is absent; when present (transformers >= 5.5.0, as on CI) they
+catch upstream source drift that would silently disable the patch.
+"""
+import inspect
+import re
+
+import pytest
+import torch
+
+from unsloth_zoo.temporary_patches import gemma4_float32 as g4f
+from unsloth_zoo.temporary_patches.gemma4_float32 import _unsloth_gemma4_ple_cast_input
+from unsloth_zoo import compiler as C
+from unsloth_zoo.compiler import _GEMMA4_PLE_CAST_HELPER, fix_gemma4_forced_float32_ple_dtype
+
+CANONICAL_HELPER = "_unsloth_gemma4_ple_cast_input"
+
+try:
+    from transformers.models.gemma4 import modeling_gemma4 as real_gemma4
+    HAS_GEMMA4 = True
+except Exception:
+    real_gemma4 = None
+    HAS_GEMMA4 = False
+
+requires_gemma4 = pytest.mark.skipif(not HAS_GEMMA4, reason="transformers gemma4 not installed")
+
+
+# ---------------------------------------------------------------------------
+# Guard 3: the eager and compiler PLE helpers must share ONE name (string/AST).
+# This is what broke as the cross-path NameError. Any reintroduction of a second
+# spelling fails here instantly, with no GPU / model needed.
+# ---------------------------------------------------------------------------
+def _ple_cast_identifiers(source):
+    return set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*_ple_cast_input", source))
+
+
+def test_ple_cast_helper_has_exactly_one_name_across_eager_and_compiler():
+    eager_src = inspect.getsource(g4f)
+    compiler_src = inspect.getsource(C)
+    names = _ple_cast_identifiers(eager_src) | _ple_cast_identifiers(compiler_src)
+    assert names == {CANONICAL_HELPER}, (
+        f"PLE cast helper name diverged across eager/compiler paths: {sorted(names)}. "
+        f"Both must use exactly {CANONICAL_HELPER!r} or a compile after the eager "
+        f"patch will call an undefined helper (NameError)."
+    )
+
+
+def test_compiler_generated_helper_defines_the_name_it_calls():
+    # The name the compiler REWRITE inserts must equal the name the appended
+    # helper DEFINES. Extract both from the compiler source directly.
+    on_flag = _run_ple_rewrite("Gemma4TextDecoderLayer")
+    called = set(re.findall(r"([A-Za-z_][A-Za-z0-9_]*_ple_cast_input)\(", on_flag))
+    defined = set(re.findall(r"def ([A-Za-z_][A-Za-z0-9_]*_ple_cast_input)\b", _GEMMA4_PLE_CAST_HELPER))
+    assert called and defined and called == defined == {CANONICAL_HELPER}, (
+        f"compiler rewrite calls {called} but helper defines {defined}"
+    )
+
+
+def _run_ple_rewrite(module, monkey_env="1"):
+    import os
+    prev = os.environ.get("UNSLOTH_FORCE_FLOAT32")
+    os.environ["UNSLOTH_FORCE_FLOAT32"] = monkey_env
+    try:
+        src = (
+            "def forward(self, hidden_states):\n"
+            "    hidden_states = self.per_layer_input_gate(hidden_states)\n"
+            "    return self.per_layer_projection(hidden_states)\n"
+        )
+        return fix_gemma4_forced_float32_ple_dtype(src, module)
+    finally:
+        if prev is None:
+            os.environ.pop("UNSLOTH_FORCE_FLOAT32", None)
+        else:
+            os.environ["UNSLOTH_FORCE_FLOAT32"] = prev
+
+
+# ---------------------------------------------------------------------------
+# Guard: eager and compiler helper implementations must stay behaviourally
+# identical (both copies are hand-maintained; catch silent drift between them).
+# ---------------------------------------------------------------------------
+def _compiler_helper_callable():
+    ns = {}
+    exec(_GEMMA4_PLE_CAST_HELPER, ns)
+    return ns[CANONICAL_HELPER]
+
+
+class _ModWithWeight:
+    def __init__(self, weight): self.weight = weight
+class _WeightStub:
+    pass
+
+
+def _dtype_cases():
+    cases = []
+    for name, dt in (("f16", torch.float16), ("bf16", torch.bfloat16), ("f32", torch.float32)):
+        w = torch.nn.Linear(3, 3, bias=False, dtype=dt)
+        cases.append((f"dense_{name}", w))
+    q = torch.zeros(3, 3, dtype=torch.uint8); q.quant_state = object()
+    cases.append(("bnb4bit", _ModWithWeight(q)))
+    cases.append(("int8", _ModWithWeight(torch.zeros(3, 3, dtype=torch.int8))))
+    fp8 = getattr(torch, "float8_e4m3fn", None)
+    if fp8 is not None:
+        s = _WeightStub(); s.dtype = fp8
+        cases.append(("fp8", _ModWithWeight(s)))
+    cases.append(("no_dtype", _ModWithWeight(_WeightStub())))
+    return cases
+
+
+@pytest.mark.parametrize("label,module", _dtype_cases())
+def test_eager_and_compiler_helpers_agree(label, module):
+    eager = _unsloth_gemma4_ple_cast_input
+    comp = _compiler_helper_callable()
+    x = torch.randn(2, 3, dtype=torch.float32)
+    e, c = eager(module, x), comp(module, x)
+    assert (e is x) == (c is x), f"{label}: identity divergence"
+    assert e.dtype == c.dtype, f"{label}: dtype divergence {e.dtype} vs {c.dtype}"
+
+
+# ---------------------------------------------------------------------------
+# Guard 1 & 2 behaviour (pure CPU torch): prove the fix actually resolves the
+# two dtype crashes. No gemma4 needed - exercises the exact failing op.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("dst_dt", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("src_dt", [torch.float16, torch.bfloat16, torch.float32])
+def test_audio_dtype_cast_fixes_masked_scatter(dst_dt, src_dt):
+    dst = torch.zeros(1, 4, dtype=dst_dt)
+    mask = torch.ones(1, 4, dtype=torch.bool)
+    src = torch.arange(4, dtype=src_dt).reshape(1, 4)
+    if dst_dt != src_dt:
+        # BEFORE the fix (device-only cast) the merge raises.
+        with pytest.raises(RuntimeError, match="same dtype"):
+            dst.masked_scatter(mask, src.to(dst.device))
+    # AFTER the fix (device + dtype) it works and preserves values.
+    out = dst.masked_scatter(mask, src.to(dst.device, dst.dtype))
+    assert out.dtype == dst_dt
+    torch.testing.assert_close(out, src.to(dst_dt))
+
+
+@pytest.mark.parametrize("w_dt", [torch.float16, torch.bfloat16])
+def test_ple_helper_fixes_fp32_into_lowprec_linear(w_dt):
+    lin = torch.nn.Linear(3, 3, bias=False, dtype=w_dt)
+    x = torch.randn(2, 3, dtype=torch.float32, requires_grad=True)
+    # BEFORE: fp32 activation into low-precision weight raises.
+    with pytest.raises(RuntimeError, match="same dtype"):
+        lin(x)
+    # AFTER: helper casts the input to the weight dtype; forward + backward work.
+    out = lin(_unsloth_gemma4_ple_cast_input(lin, x))
+    assert out.dtype == w_dt
+    out.float().sum().backward()
+    assert x.grad is not None and torch.isfinite(x.grad).all()
+
+
+def test_ple_helper_never_casts_to_fp8_or_packed_weight():
+    x = torch.randn(2, 3, dtype=torch.float32)
+    # fp8 packed storage must be left alone (fp8 kernels scale internally).
+    fp8 = getattr(torch, "float8_e4m3fn", None)
+    if fp8 is not None:
+        s = _WeightStub(); s.dtype = fp8
+        assert _unsloth_gemma4_ple_cast_input(_ModWithWeight(s), x) is x
+    # bnb 4-bit: uint8 + quant_state -> unchanged (never cast activation to uint8).
+    q = torch.zeros(3, 3, dtype=torch.uint8); q.quant_state = object()
+    assert _unsloth_gemma4_ple_cast_input(_ModWithWeight(q), x) is x
+
+
+# ---------------------------------------------------------------------------
+# Real-source drift canaries: the highest-value "never again" guards. They read
+# the REAL transformers gemma4 module FILE FROM DISK (no mutation, no GPU) and
+# assert the exact call sites the unsloth patches target are still present.
+#
+# Reading from disk is deliberate: importing unsloth_zoo monkeypatches
+# Gemma4Model.forward (the KV-carrier wrapper) and can poison linecache for the
+# PLE methods, so inspect.getsource() on the class attributes returns the
+# unsloth-wrapped source, not upstream. The on-disk file is pristine upstream.
+#
+# If a future transformers reshapes a call site so the patch can no longer match
+# AND upstream has not fixed the dtype itself, these FAIL loudly instead of the
+# patch silently no-op-ing and the dtype crash quietly returning.
+# ---------------------------------------------------------------------------
+def _gemma4_modeling_source():
+    import pathlib
+    return pathlib.Path(inspect.getsourcefile(real_gemma4)).read_text()
+
+
+@requires_gemma4
+def test_real_gemma4_audio_merge_site_is_recognized():
+    src = _gemma4_modeling_source()
+    buggy = "audio_features.to(inputs_embeds.device)"
+    fixed = "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)"
+    assert (buggy in src) or (fixed in src), (
+        "Gemma4 audio merge site drifted: neither the known device-only pattern "
+        "nor the fixed device+dtype pattern is present in modeling_gemma4.py. The "
+        "unsloth audio patch would silently no-op and the masked_scatter dtype crash "
+        "would return. Update _patch_gemma4_audio_feature_dtype_on_class (eager) and "
+        "fix_gemma4_audio_feature_dtype (compiler)."
+    )
+
+
+@requires_gemma4
+def test_real_gemma4_image_and_video_merges_still_cast_dtype():
+    # Regression anchor: image/video have always cast dtype; if upstream ever
+    # drops it there too, that is a new modality that also needs patching.
+    src = _gemma4_modeling_source()
+    assert "image_features.to(inputs_embeds.device, inputs_embeds.dtype)" in src
+    assert "video_features.to(inputs_embeds.device, inputs_embeds.dtype)" in src
+
+
+@requires_gemma4
+def test_real_gemma4_ple_call_sites_are_recognized():
+    src = _gemma4_modeling_source()
+
+    def _ok(attr, arg):
+        raw = f"self.{attr}({arg})"
+        wrapped = f"self.{attr}({CANONICAL_HELPER}(self.{attr}, {arg})"
+        return (raw in src) or (wrapped in src)
+
+    assert _ok("per_layer_model_projection", "inputs_embeds"), (
+        "Gemma4TextModel.project_per_layer_inputs PLE call drifted; PLE dtype patch "
+        "would silently no-op under UNSLOTH_FORCE_FLOAT32."
+    )
+    assert _ok("per_layer_input_gate", "hidden_states"), "per_layer_input_gate call drifted"
+    assert _ok("per_layer_projection", "hidden_states"), "per_layer_projection call drifted"
+
+
+@requires_gemma4
+def test_real_gemma4_audio_compiler_transform_emits_dtype_cast():
+    # Drive the compiler's audio rewrite against the REAL upstream source; either
+    # upstream already casts dtype, or our regex still matches and inserts it.
+    src = _gemma4_modeling_source()
+    out = C.fix_gemma4_audio_feature_dtype(src)
+    assert "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)" in out, (
+        "fix_gemma4_audio_feature_dtype no longer produces the dtype-aligned cast on "
+        "upstream source (regex drift or multiple matches)."
+    )

--- a/tests/test_gemma4_forced_float32_ple_dtype.py
+++ b/tests/test_gemma4_forced_float32_ple_dtype.py
@@ -10,7 +10,7 @@ from unsloth_zoo.compiler import (
     _GEMMA4_PLE_CAST_HELPER,
     fix_gemma4_forced_float32_ple_dtype,
 )
-from unsloth_zoo.temporary_patches.gemma4_float32 import _gemma4_ple_cast_input
+from unsloth_zoo.temporary_patches.gemma4_float32 import _unsloth_gemma4_ple_cast_input
 from unsloth_zoo.temporary_patches.gemma4_float32 import _patch_gemma4_ple_dtype_on_method
 
 
@@ -20,7 +20,7 @@ def _compiler_ple_cast_input(module, x):
     return namespace["_unsloth_gemma4_ple_cast_input"](module, x)
 
 
-@pytest.fixture(params=[_gemma4_ple_cast_input, _compiler_ple_cast_input])
+@pytest.fixture(params=[_unsloth_gemma4_ple_cast_input, _compiler_ple_cast_input])
 def ple_cast_input(request):
     return request.param
 
@@ -152,12 +152,12 @@ def test_gemma4_ple_method_patch_lifecycle_covers_all_three_boundaries(tmp_path,
         (("per_layer_input_gate", "hidden_states"), ("per_layer_projection", "hidden_states")),
     ) is True
 
-    assert "_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds)" in inspect.getsource(
+    assert "_unsloth_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds)" in inspect.getsource(
         model_cls.project_per_layer_inputs
     )
     patched_decoder = inspect.getsource(decoder_cls.forward)
-    assert "_gemma4_ple_cast_input(self.per_layer_input_gate, hidden_states)" in patched_decoder
-    assert "_gemma4_ple_cast_input(self.per_layer_projection, hidden_states)" in patched_decoder
+    assert "_unsloth_gemma4_ple_cast_input(self.per_layer_input_gate, hidden_states)" in patched_decoder
+    assert "_unsloth_gemma4_ple_cast_input(self.per_layer_projection, hidden_states)" in patched_decoder
     assert model_cls._unsloth_ple_dtype_project_per_layer_inputs_patched is True
     assert decoder_cls._unsloth_ple_dtype_forward_patched is True
 
@@ -199,7 +199,7 @@ def test_gemma4_ple_method_patch_lifecycle_covers_all_three_boundaries(tmp_path,
     [
         (
             "fixed",
-            "return self.per_layer_model_projection(_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds))",
+            "return self.per_layer_model_projection(_unsloth_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds))",
             True,
         ),
         (
@@ -287,14 +287,14 @@ def test_gemma4_ple_three_boundary_eager_and_compiled_parity():
 
         def forward(self, inputs_embeds, hidden_states, per_layer_input):
             self.per_layer_model_projection(
-                _gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds)
+                _unsloth_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds)
             )
             hidden_states = self.per_layer_input_gate(
-                _gemma4_ple_cast_input(self.per_layer_input_gate, hidden_states)
+                _unsloth_gemma4_ple_cast_input(self.per_layer_input_gate, hidden_states)
             )
             hidden_states = torch.nn.functional.silu(hidden_states) * per_layer_input
             return self.per_layer_projection(
-                _gemma4_ple_cast_input(self.per_layer_projection, hidden_states)
+                _unsloth_gemma4_ple_cast_input(self.per_layer_projection, hidden_states)
             )
 
     model = ThreePLEBoundaries()
@@ -307,3 +307,162 @@ def test_gemma4_ple_three_boundary_eager_and_compiled_parity():
         pytest.skip("torch.compile is unavailable")
     compiled = torch.compile(model, backend="eager", fullgraph=True)
     torch.testing.assert_close(compiled(inputs, hidden_states, per_layer_input), eager)
+
+
+class _WeightStub:
+    """Minimal `.weight` stand-in: the cast helper only reads dtype/quant_state."""
+    pass
+
+
+def test_gemma4_ple_cast_input_leaves_fp8_weight_unchanged(ple_cast_input):
+    fp8 = getattr(torch, "float8_e4m3fn", None)
+    if fp8 is None:
+        pytest.skip("float8_e4m3fn is unavailable on this torch build")
+    x = torch.randn(2, 3, dtype=torch.float32)
+    weight = _WeightStub()
+    weight.dtype = fp8  # sub-2-byte float, no quant_state
+
+    cast = ple_cast_input(_ModuleWithWeight(weight), x)
+
+    # Must not downcast the fp32 carrier to fp8 (fp8 kernels scale internally).
+    assert cast is x
+    assert cast.dtype == torch.float32
+
+
+def test_gemma4_ple_cast_input_leaves_weight_without_dtype_unchanged(ple_cast_input):
+    x = torch.randn(2, 3, dtype=torch.float32)
+    # A weight proxy that does not expose `.dtype` must not raise AttributeError.
+    cast = ple_cast_input(_ModuleWithWeight(_WeightStub()), x)
+
+    assert cast is x
+    assert cast.dtype == torch.float32
+
+
+def test_gemma4_ple_dry_run_classifies_without_mutating(tmp_path, monkeypatch):
+    module = _load_fake_ple_module(
+        tmp_path,
+        monkeypatch,
+        "fake_gemma4_ple_dryrun",
+        """
+        import torch
+
+        class Gemma4TextModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.per_layer_model_projection = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+
+            def project_per_layer_inputs(self, inputs_embeds):
+                return self.per_layer_model_projection(inputs_embeds)
+
+        class Gemma4TextModelDrifted(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.per_layer_model_projection = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+
+            def project_per_layer_inputs(self, inputs_embeds):
+                return self.per_layer_model_projection(inputs_embeds.to(inputs_embeds.dtype))
+        """,
+    )
+    targets = (("per_layer_model_projection", "inputs_embeds"),)
+
+    ok_cls = module.Gemma4TextModel
+    original_code = ok_cls.project_per_layer_inputs.__code__
+    status = _patch_gemma4_ple_dtype_on_method(
+        ok_cls, "project_per_layer_inputs", targets, dry_run=True,
+    )
+    assert status == "PATCH"
+    # Dry run must not touch bytecode, the marker, or linecache.
+    assert ok_cls.project_per_layer_inputs.__code__ is original_code
+    assert not getattr(ok_cls, "_unsloth_ple_dtype_project_per_layer_inputs_patched", False)
+
+    drift_cls = module.Gemma4TextModelDrifted
+    assert _patch_gemma4_ple_dtype_on_method(
+        drift_cls, "project_per_layer_inputs", targets, dry_run=True,
+    ) == "DRIFT"
+
+    # A real (non-dry) call on the drifted class fails closed without mutating.
+    drift_code = drift_cls.project_per_layer_inputs.__code__
+    assert _patch_gemma4_ple_dtype_on_method(
+        drift_cls, "project_per_layer_inputs", targets,
+    ) is False
+    assert drift_cls.project_per_layer_inputs.__code__ is drift_code
+
+    # Dry run on the already-marked good class reports ALREADY.
+    assert _patch_gemma4_ple_dtype_on_method(ok_cls, "project_per_layer_inputs", targets) is True
+    assert _patch_gemma4_ple_dtype_on_method(
+        ok_cls, "project_per_layer_inputs", targets, dry_run=True,
+    ) == "ALREADY"
+
+
+def _make_fake_decoder_module(tmp_path, monkeypatch, name):
+    return _load_fake_ple_module(
+        tmp_path,
+        monkeypatch,
+        name,
+        """
+        import torch
+
+        class Gemma4TextDecoderLayer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.per_layer_input_gate = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+                self.per_layer_projection = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+
+            def forward(self, hidden_states, per_layer_input):
+                hidden_states = self.per_layer_input_gate(hidden_states)
+                hidden_states = hidden_states * per_layer_input
+                return self.per_layer_projection(hidden_states)
+        """,
+    )
+
+
+def test_gemma4_ple_compiler_appends_helper_only_when_call_present(tmp_path, monkeypatch):
+    from unsloth_zoo import compiler
+
+    module = _make_fake_decoder_module(tmp_path, monkeypatch, "fake_gemma4_ple_append")
+    monkeypatch.setattr(compiler, "fake_gemma4_ple_append", module, raising=False)
+
+    # Flag off: no PLE rewrite, so no helper call and no appended helper def.
+    monkeypatch.delenv("UNSLOTH_FORCE_FLOAT32", raising=False)
+    off = compiler.create_standalone_class(
+        "Gemma4TextDecoderLayer", "fake_gemma4_ple_append", dir(module), disable=True,
+    )
+    assert "_unsloth_gemma4_ple_cast_input(" not in off
+    assert "def _unsloth_gemma4_ple_cast_input" not in off
+
+    # Flag on: the rewrite inserts the call, so the helper def is appended exactly once.
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    on = compiler.create_standalone_class(
+        "Gemma4TextDecoderLayer", "fake_gemma4_ple_append", dir(module), disable=True,
+    )
+    assert "_unsloth_gemma4_ple_cast_input(" in on
+    assert on.count("def _unsloth_gemma4_ple_cast_input") == 1
+    compile(on, "<gemma4-ple-append>", "exec")
+
+
+def test_gemma4_ple_eager_then_compile_share_one_helper_name(tmp_path, monkeypatch):
+    """Guards the fixed bug: compiling AFTER the eager patch must not emit a call to
+    a helper name the generated module never defines (previously a NameError)."""
+    from unsloth_zoo import compiler
+
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    module = _make_fake_decoder_module(tmp_path, monkeypatch, "fake_gemma4_ple_crosspath")
+    decoder_cls = module.Gemma4TextDecoderLayer
+
+    # Eager patch first: rewrites __code__ AND poisons linecache with wrapped source.
+    assert _patch_gemma4_ple_dtype_on_method(
+        decoder_cls, "forward",
+        (("per_layer_input_gate", "hidden_states"), ("per_layer_projection", "hidden_states")),
+    ) is True
+    # inspect.getsource (which the compiler uses) now returns the eager-patched source.
+    assert "_unsloth_gemma4_ple_cast_input(" in inspect.getsource(decoder_cls.forward)
+
+    # The compiler reads that poisoned source; the generated module must DEFINE the
+    # same helper name it CALLS.
+    monkeypatch.setattr(compiler, "fake_gemma4_ple_crosspath", module, raising=False)
+    generated = compiler.create_standalone_class(
+        "Gemma4TextDecoderLayer", "fake_gemma4_ple_crosspath", dir(module), disable=True,
+    )
+    assert "_unsloth_gemma4_ple_cast_input(" in generated
+    assert generated.count("def _unsloth_gemma4_ple_cast_input") == 1
+    compile(generated, "<gemma4-ple-crosspath>", "exec")

--- a/tests/test_gemma4_forced_float32_ple_dtype.py
+++ b/tests/test_gemma4_forced_float32_ple_dtype.py
@@ -1,0 +1,309 @@
+import importlib.util
+import inspect
+import sys
+import textwrap
+
+import pytest
+import torch
+
+from unsloth_zoo.compiler import (
+    _GEMMA4_PLE_CAST_HELPER,
+    fix_gemma4_forced_float32_ple_dtype,
+)
+from unsloth_zoo.temporary_patches.gemma4_float32 import _gemma4_ple_cast_input
+from unsloth_zoo.temporary_patches.gemma4_float32 import _patch_gemma4_ple_dtype_on_method
+
+
+def _compiler_ple_cast_input(module, x):
+    namespace = {}
+    exec(_GEMMA4_PLE_CAST_HELPER, namespace)
+    return namespace["_unsloth_gemma4_ple_cast_input"](module, x)
+
+
+@pytest.fixture(params=[_gemma4_ple_cast_input, _compiler_ple_cast_input])
+def ple_cast_input(request):
+    return request.param
+
+
+class _ModuleWithWeight:
+    def __init__(self, weight):
+        self.weight = weight
+
+
+class _PeftLikeModule:
+    def __init__(self, base_layer):
+        self._base_layer = base_layer
+
+    def get_base_layer(self):
+        return self._base_layer
+
+
+def _load_fake_ple_module(tmp_path, monkeypatch, name, source):
+    path = tmp_path / f"{name}.py"
+    path.write_text(textwrap.dedent(source), encoding="utf-8")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_gemma4_ple_cast_input_aligns_floating_weight_and_peft_base_layer(ple_cast_input):
+    x = torch.randn(2, 3, dtype=torch.float32)
+    linear = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+
+    cast = ple_cast_input(_PeftLikeModule(linear), x)
+
+    assert cast.dtype == torch.float16
+    assert cast is not x
+    assert linear(cast).dtype == torch.float16
+
+
+def test_gemma4_ple_cast_input_leaves_quant_state_activation_exactly_unchanged(ple_cast_input):
+    weight = torch.empty(3, 3, dtype=torch.uint8)
+    weight.quant_state = object()
+    x = torch.randn(2, 3, dtype=torch.float32)
+
+    cast = ple_cast_input(_ModuleWithWeight(weight), x)
+
+    assert cast is x
+    assert cast.dtype == torch.float32
+
+
+def test_gemma4_ple_cast_input_leaves_nonfloating_packed_weight_unchanged(ple_cast_input):
+    x = torch.randn(2, 3, dtype=torch.float32)
+    cast = ple_cast_input(_ModuleWithWeight(torch.empty(3, 3, dtype=torch.uint8)), x)
+
+    assert cast is x
+    assert cast.dtype == torch.float32
+
+
+@pytest.mark.parametrize(
+    "module, source, expected",
+    [
+        (
+            "Gemma4TextModel",
+            "return self.per_layer_model_projection(inputs_embeds)",
+            ("self.per_layer_model_projection(_unsloth_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds))",),
+        ),
+        (
+            "Gemma4TextDecoderLayer",
+            "hidden_states = self.per_layer_input_gate(hidden_states)\n    return self.per_layer_projection(hidden_states)",
+            (
+                "self.per_layer_input_gate(_unsloth_gemma4_ple_cast_input(self.per_layer_input_gate, hidden_states))",
+                "self.per_layer_projection(_unsloth_gemma4_ple_cast_input(self.per_layer_projection, hidden_states))",
+            ),
+        ),
+    ],
+)
+def test_gemma4_ple_compiler_transform_is_gated_exact_and_idempotent(
+    monkeypatch, module, source, expected,
+):
+    source = f"def forward(self, inputs_embeds=None, hidden_states=None):\n    {source}\n"
+    monkeypatch.delenv("UNSLOTH_FORCE_FLOAT32", raising=False)
+    assert fix_gemma4_forced_float32_ple_dtype(source, module) == source
+
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    rewritten = fix_gemma4_forced_float32_ple_dtype(source, module)
+    for call in expected:
+        assert rewritten.count(call) == 1
+    assert fix_gemma4_forced_float32_ple_dtype(rewritten, module) == rewritten
+
+
+def test_gemma4_ple_method_patch_lifecycle_covers_all_three_boundaries(tmp_path, monkeypatch):
+    module = _load_fake_ple_module(
+        tmp_path,
+        monkeypatch,
+        "fake_gemma4_ple_lifecycle",
+        """
+        import torch
+
+        class Gemma4TextModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.per_layer_model_projection = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+
+            def project_per_layer_inputs(self, inputs_embeds):
+                return self.per_layer_model_projection(inputs_embeds)
+
+        class Gemma4TextDecoderLayer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.per_layer_input_gate = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+                self.per_layer_projection = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+
+            def forward(self, hidden_states, per_layer_input):
+                hidden_states = self.per_layer_input_gate(hidden_states)
+                hidden_states = hidden_states * per_layer_input
+                return self.per_layer_projection(hidden_states)
+        """,
+    )
+    model_cls = module.Gemma4TextModel
+    decoder_cls = module.Gemma4TextDecoderLayer
+
+    assert _patch_gemma4_ple_dtype_on_method(
+        model_cls,
+        "project_per_layer_inputs",
+        (("per_layer_model_projection", "inputs_embeds"),),
+    ) is True
+    assert _patch_gemma4_ple_dtype_on_method(
+        decoder_cls,
+        "forward",
+        (("per_layer_input_gate", "hidden_states"), ("per_layer_projection", "hidden_states")),
+    ) is True
+
+    assert "_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds)" in inspect.getsource(
+        model_cls.project_per_layer_inputs
+    )
+    patched_decoder = inspect.getsource(decoder_cls.forward)
+    assert "_gemma4_ple_cast_input(self.per_layer_input_gate, hidden_states)" in patched_decoder
+    assert "_gemma4_ple_cast_input(self.per_layer_projection, hidden_states)" in patched_decoder
+    assert model_cls._unsloth_ple_dtype_project_per_layer_inputs_patched is True
+    assert decoder_cls._unsloth_ple_dtype_forward_patched is True
+
+    model, decoder = model_cls(), decoder_cls()
+    model_dtypes, decoder_dtypes = [], []
+    model.per_layer_model_projection.register_forward_pre_hook(lambda _, args: model_dtypes.append(args[0].dtype))
+    decoder.per_layer_input_gate.register_forward_pre_hook(lambda _, args: decoder_dtypes.append(args[0].dtype))
+    decoder.per_layer_projection.register_forward_pre_hook(lambda _, args: decoder_dtypes.append(args[0].dtype))
+    inputs_embeds = torch.randn(2, 3, dtype=torch.float32, requires_grad=True)
+    hidden_states = torch.randn(2, 3, dtype=torch.float32, requires_grad=True)
+    per_layer_input = torch.randn(2, 3, dtype=torch.float32)
+    model_output = model.project_per_layer_inputs(inputs_embeds)
+    decoder_output = decoder.forward(hidden_states, per_layer_input)
+
+    assert model_output.dtype == torch.float16
+    assert decoder_output.dtype == torch.float16
+    assert model_dtypes == [torch.float16]
+    assert decoder_dtypes == [torch.float16, torch.float16]
+    (model_output.float().sum() + decoder_output.float().sum()).backward()
+    assert inputs_embeds.grad is not None and torch.isfinite(inputs_embeds.grad).all()
+    assert hidden_states.grad is not None and torch.isfinite(hidden_states.grad).all()
+    for parameter in (*model.parameters(), *decoder.parameters()):
+        assert parameter.grad is not None and torch.isfinite(parameter.grad).all()
+
+    assert _patch_gemma4_ple_dtype_on_method(
+        model_cls,
+        "project_per_layer_inputs",
+        (("per_layer_model_projection", "inputs_embeds"),),
+    ) is False
+    assert _patch_gemma4_ple_dtype_on_method(
+        decoder_cls,
+        "forward",
+        (("per_layer_input_gate", "hidden_states"), ("per_layer_projection", "hidden_states")),
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "name, body, expected_marker",
+    [
+        (
+            "fixed",
+            "return self.per_layer_model_projection(_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds))",
+            True,
+        ),
+        (
+            "drifted",
+            "return self.per_layer_model_projection(inputs_embeds.to(inputs_embeds.dtype))",
+            False,
+        ),
+    ],
+)
+def test_gemma4_ple_method_patch_fails_closed_for_fixed_or_drifted_source(
+    tmp_path, monkeypatch, name, body, expected_marker,
+):
+    module = _load_fake_ple_module(
+        tmp_path,
+        monkeypatch,
+        f"fake_gemma4_ple_{name}",
+        f"""
+        class Gemma4TextModel:
+            def project_per_layer_inputs(self, inputs_embeds):
+                {body}
+        """,
+    )
+    model_cls = module.Gemma4TextModel
+
+    assert _patch_gemma4_ple_dtype_on_method(
+        model_cls,
+        "project_per_layer_inputs",
+        (("per_layer_model_projection", "inputs_embeds"),),
+    ) is False
+    assert getattr(model_cls, "_unsloth_ple_dtype_project_per_layer_inputs_patched", False) is expected_marker
+
+
+@pytest.mark.parametrize(
+    "module, source",
+    [
+        (
+        "Gemma4TextModel",
+        """
+        def forward(self, inputs_embeds):
+            return self.per_layer_model_projection(inputs_embeds)
+        """),
+        (
+        "Gemma4TextDecoderLayer",
+        """
+        def forward(self, hidden_states):
+            hidden_states = self.per_layer_input_gate(hidden_states)
+            return self.per_layer_projection(hidden_states)
+        """),
+        (
+        "Gemma4TextModel",
+        """
+        class Gemma4TextModel:
+            def forward(self, inputs_embeds):
+                return self.per_layer_model_projection(inputs_embeds)
+        """),
+        (
+        "Gemma4TextDecoderLayer",
+        """
+        class Gemma4TextDecoderLayer:
+            def forward(self, hidden_states):
+                hidden_states = self.per_layer_input_gate(hidden_states)
+                return self.per_layer_projection(hidden_states)
+        """),
+    ],
+)
+def test_gemma4_ple_compiler_transform_emits_valid_forward_and_full_class_source(
+    monkeypatch, module, source,
+):
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    rewritten = fix_gemma4_forced_float32_ple_dtype(textwrap.dedent(source), module)
+
+    expected_calls = 1 if module == "Gemma4TextModel" else 2
+    assert rewritten.count("_unsloth_gemma4_ple_cast_input") == expected_calls
+    assert _GEMMA4_PLE_CAST_HELPER.count("def _unsloth_gemma4_ple_cast_input") == 1
+    compile(rewritten + _GEMMA4_PLE_CAST_HELPER, "<gemma4-ple-generated>", "exec")
+
+
+def test_gemma4_ple_three_boundary_eager_and_compiled_parity():
+    class ThreePLEBoundaries(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.per_layer_model_projection = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+            self.per_layer_input_gate = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+            self.per_layer_projection = torch.nn.Linear(3, 3, bias=False, dtype=torch.float16)
+
+        def forward(self, inputs_embeds, hidden_states, per_layer_input):
+            self.per_layer_model_projection(
+                _gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds)
+            )
+            hidden_states = self.per_layer_input_gate(
+                _gemma4_ple_cast_input(self.per_layer_input_gate, hidden_states)
+            )
+            hidden_states = torch.nn.functional.silu(hidden_states) * per_layer_input
+            return self.per_layer_projection(
+                _gemma4_ple_cast_input(self.per_layer_projection, hidden_states)
+            )
+
+    model = ThreePLEBoundaries()
+    inputs = torch.randn(2, 3, dtype=torch.float32)
+    hidden_states = torch.randn(2, 3, dtype=torch.float32)
+    per_layer_input = torch.randn(2, 3, dtype=torch.float32)
+    eager = model(inputs, hidden_states, per_layer_input)
+
+    if not hasattr(torch, "compile"):
+        pytest.skip("torch.compile is unavailable")
+    compiled = torch.compile(model, backend="eager", fullgraph=True)
+    torch.testing.assert_close(compiled(inputs, hidden_states, per_layer_input), eager)

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1231,6 +1231,19 @@ def create_new_function(
 pass
 
 
+def fix_gemma4_audio_feature_dtype(source):
+    """Align Gemma 4 audio features with the destination embedding dtype."""
+    rewritten, count = re.subn(
+        r"audio_features\.to\(\s*inputs_embeds\.device\s*\)",
+        "audio_features.to(inputs_embeds.device, inputs_embeds.dtype)",
+        source,
+    )
+    if count != 1:
+        return source
+    return rewritten
+pass
+
+
 def create_standalone_class(
     module,
     model_location,
@@ -1258,6 +1271,8 @@ def create_standalone_class(
     old_init = inspect.getsource(f.__init__)
     if forward_source is None:
         forward_source = old_source
+    if module == "Gemma4Model":
+        forward_source = fix_gemma4_audio_feature_dtype(forward_source)
 
     # We disable this for nn.Embedding modules if torch is older than 2.5 since
     if OLD_TORCH_VERSION and "nn.Embedding(" in old_init:
@@ -1505,6 +1520,8 @@ def create_standalone_class(
         source,
     )
 
+    if module == "Gemma4Model":
+        source = fix_gemma4_audio_feature_dtype(source)
     return source
 
 

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1244,6 +1244,69 @@ def fix_gemma4_audio_feature_dtype(source):
 pass
 
 
+_GEMMA4_PLE_CAST_HELPER = """
+def _unsloth_gemma4_ple_cast_input(module, x):
+    get_base_layer = getattr(module, "get_base_layer", None)
+    base_layer = get_base_layer() if callable(get_base_layer) else getattr(module, "base_layer", module)
+    weight = getattr(module, "weight", None)
+    if weight is None:
+        weight = getattr(base_layer, "weight", None)
+    if weight is None:
+        return x
+    quant_state = getattr(weight, "quant_state", None)
+    if quant_state is not None:
+        return x
+    dtype = weight.dtype
+    if dtype is None or not getattr(dtype, "is_floating_point", False):
+        return x
+    return x if x.dtype == dtype else x.to(dtype)
+pass
+"""
+
+
+def fix_gemma4_forced_float32_ple_dtype(source, module = None):
+    """Align only Gemma 4 PLE Linear inputs for forced-float32 residuals."""
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return source
+
+    replacements_by_module = {
+        "Gemma4TextModel": (
+            (
+            "self.per_layer_model_projection(inputs_embeds)",
+            "self.per_layer_model_projection(_unsloth_gemma4_ple_cast_input(self.per_layer_model_projection, inputs_embeds))",
+            ),
+        ),
+        "Gemma4TextDecoderLayer": (
+            (
+            "self.per_layer_input_gate(hidden_states)",
+            "self.per_layer_input_gate(_unsloth_gemma4_ple_cast_input(self.per_layer_input_gate, hidden_states))",
+            ),
+            (
+            "self.per_layer_projection(hidden_states)",
+            "self.per_layer_projection(_unsloth_gemma4_ple_cast_input(self.per_layer_projection, hidden_states))",
+            ),
+        ),
+    }
+    replacements = (
+        tuple(item for group in replacements_by_module.values() for item in group)
+        if module is None else replacements_by_module.get(module, ())
+    )
+    if not replacements:
+        return source
+    rewritten = source
+    counts = [rewritten.count(old) for old, _ in replacements]
+    if not any(counts):
+        return source
+    if (module is None and any(count > 1 for count in counts)) or \
+        (module is not None and any(count != 1 for count in counts)):
+        return source
+    for old, new in replacements:
+        if old in rewritten:
+            rewritten = rewritten.replace(old, new, 1)
+    return rewritten
+pass
+
+
 def create_standalone_class(
     module,
     model_location,
@@ -1273,6 +1336,8 @@ def create_standalone_class(
         forward_source = old_source
     if module == "Gemma4Model":
         forward_source = fix_gemma4_audio_feature_dtype(forward_source)
+    elif module in ("Gemma4TextModel", "Gemma4TextDecoderLayer"):
+        forward_source = fix_gemma4_forced_float32_ple_dtype(forward_source, module)
 
     # We disable this for nn.Embedding modules if torch is older than 2.5 since
     if OLD_TORCH_VERSION and "nn.Embedding(" in old_init:
@@ -1475,6 +1540,9 @@ def create_standalone_class(
 
     # Combine all into file
     source = source + full_class
+    if module in ("Gemma4TextModel", "Gemma4TextDecoderLayer") and \
+        os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "1":
+        source += _GEMMA4_PLE_CAST_HELPER
     if supports_return_hidden_states:
         source += f"\n{module}.__UNSLOTH_SUPPORTS_RETURN_HIDDEN_STATES__ = True\n"
 
@@ -1522,6 +1590,8 @@ def create_standalone_class(
 
     if module == "Gemma4Model":
         source = fix_gemma4_audio_feature_dtype(source)
+    elif module in ("Gemma4TextModel", "Gemma4TextDecoderLayer"):
+        source = fix_gemma4_forced_float32_ple_dtype(source, module)
     return source
 
 

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1256,8 +1256,10 @@ def _unsloth_gemma4_ple_cast_input(module, x):
     quant_state = getattr(weight, "quant_state", None)
     if quant_state is not None:
         return x
-    dtype = weight.dtype
+    dtype = getattr(weight, "dtype", None)
     if dtype is None or not getattr(dtype, "is_floating_point", False):
+        return x
+    if getattr(dtype, "itemsize", 2) < 2:
         return x
     return x if x.dtype == dtype else x.to(dtype)
 pass
@@ -1540,9 +1542,6 @@ def create_standalone_class(
 
     # Combine all into file
     source = source + full_class
-    if module in ("Gemma4TextModel", "Gemma4TextDecoderLayer") and \
-        os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") == "1":
-        source += _GEMMA4_PLE_CAST_HELPER
     if supports_return_hidden_states:
         source += f"\n{module}.__UNSLOTH_SUPPORTS_RETURN_HIDDEN_STATES__ = True\n"
 
@@ -1592,6 +1591,15 @@ def create_standalone_class(
         source = fix_gemma4_audio_feature_dtype(source)
     elif module in ("Gemma4TextModel", "Gemma4TextDecoderLayer"):
         source = fix_gemma4_forced_float32_ple_dtype(source, module)
+
+    # Append the PLE cast helper only once a call to it actually exists in the
+    # generated source (from the rewrite above, or from already-cast eager source
+    # read back through inspect.getsource). This keeps the emitted helper name in
+    # sync with the eager patch and avoids appending dead code when nothing was
+    # rewritten (drift / already-fixed upstream / flag off).
+    if "_unsloth_gemma4_ple_cast_input(" in source and \
+        "def _unsloth_gemma4_ple_cast_input" not in source:
+        source += _GEMMA4_PLE_CAST_HELPER
     return source
 
 

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -14,8 +14,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import ast
+import inspect
+import linecache
+import sys
+
 import torch
-import os
 from .common import TEMPORARY_PATCHES
 from .utils import raise_error, patch_function
 
@@ -656,6 +660,136 @@ def patch_Gemma4TextModel_forward_kv_shared_no_cache():
         return raise_error("Gemma4TextModel.forward kv-shared GC fix", e)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma4TextModel_forward_kv_shared_no_cache)
+
+
+def _is_gemma4_attr(node, owner, attr):
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == attr
+        and isinstance(node.value, ast.Name)
+        and node.value.id == owner
+    )
+
+
+def _patch_gemma4_audio_feature_dtype_on_class(model_cls):
+    """Align audio features to the actual text-embedding dtype at the merge site."""
+    marker = "_unsloth_audio_feature_dtype_patched"
+    if getattr(model_cls, marker, False):
+        return False
+
+    module = sys.modules.get(model_cls.__module__)
+    source_file = inspect.getsourcefile(model_cls)
+    if module is None or source_file is None:
+        return False
+
+    module_source = inspect.getsource(module)
+    tree = ast.parse(module_source, filename=source_file)
+    class_nodes = [
+        node for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == model_cls.__name__
+    ]
+    if len(class_nodes) != 1:
+        return False
+    forward_nodes = [
+        node for node in class_nodes[0].body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "forward"
+    ]
+    if len(forward_nodes) != 1:
+        return False
+    forward_node = forward_nodes[0]
+
+    buggy_casts = []
+    fixed_casts = []
+    for node in ast.walk(forward_node):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "masked_scatter"
+            and len(node.args) >= 2
+        ):
+            continue
+        source = node.args[1]
+        if not (
+            isinstance(source, ast.Call)
+            and _is_gemma4_attr(source.func, "audio_features", "to")
+            and source.args
+            and _is_gemma4_attr(source.args[0], "inputs_embeds", "device")
+        ):
+            continue
+        has_dtype = (
+            len(source.args) >= 2
+            and _is_gemma4_attr(source.args[1], "inputs_embeds", "dtype")
+        ) or any(
+            keyword.arg == "dtype"
+            and _is_gemma4_attr(keyword.value, "inputs_embeds", "dtype")
+            for keyword in source.keywords
+        )
+        (fixed_casts if has_dtype else buggy_casts).append(source)
+
+    if not buggy_casts and len(fixed_casts) == 1:
+        setattr(model_cls, marker, True)
+        return False
+    if len(buggy_casts) != 1 or fixed_casts:
+        return False
+
+    buggy_cast = buggy_casts[0]
+    old_cast_source = ast.get_source_segment(module_source, buggy_cast)
+    if old_cast_source is None or module_source.count(old_cast_source) != 1:
+        return False
+    buggy_cast.args.append(
+        ast.Attribute(
+            value=ast.Name(id="inputs_embeds", ctx=ast.Load()),
+            attr="dtype",
+            ctx=ast.Load(),
+        )
+    )
+    new_cast_source = old_cast_source[:-1] + ", inputs_embeds.dtype)"
+    patched_module_source = module_source.replace(
+        old_cast_source,
+        new_cast_source,
+        1,
+    )
+
+    # Keep Hugging Face's installed decorators intact. Re-running a method-level
+    # @auto_docstring outside its class loses class context and fails; transplant
+    # only the undecorated function body beneath the existing wrapper chain.
+    forward_node.decorator_list = []
+    ast.fix_missing_locations(forward_node)
+    namespace = {}
+    exec(
+        compile(ast.Module(body=[forward_node], type_ignores=[]), source_file, "exec"),
+        module.__dict__,
+        namespace,
+    )
+    original_body = inspect.unwrap(model_cls.forward)
+    patched_body = namespace["forward"]
+    if original_body.__code__.co_freevars != patched_body.__code__.co_freevars:
+        return False
+    original_body.__code__ = patched_body.__code__
+    linecache.cache[source_file] = (
+        len(patched_module_source),
+        None,
+        patched_module_source.splitlines(keepends=True),
+        source_file,
+    )
+    setattr(model_cls, marker, True)
+    return True
+
+
+def patch_Gemma4Model_audio_feature_dtype():
+    """Fix mixed-dtype audio merging without adding a per-forward wrapper."""
+    try:
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4Model
+    except ImportError:
+        return
+    except Exception as e:
+        return raise_error("Gemma4Model.forward audio feature dtype fix", e)
+    try:
+        _patch_gemma4_audio_feature_dtype_on_class(Gemma4Model)
+    except Exception as e:
+        return raise_error("Gemma4Model.forward audio feature dtype fix", e)
+pass
+TEMPORARY_PATCHES.append(patch_Gemma4Model_audio_feature_dtype)
 
 
 def patch_Gemma4Model_forward_kv_shared_no_cache():

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -20,7 +20,7 @@ import linecache
 import sys
 
 import torch
-from .common import TEMPORARY_PATCHES
+from .common import TEMPORARY_PATCHES, logger
 from .utils import raise_error, patch_function
 
 
@@ -730,6 +730,13 @@ def _patch_gemma4_audio_feature_dtype_on_class(model_cls):
         setattr(model_cls, marker, True)
         return False
     if len(buggy_casts) != 1 or fixed_casts:
+        if not buggy_casts and not fixed_casts:
+            logger.warning(
+                f"Unsloth: Gemma4 audio dtype patch skipped for "
+                f"`{model_cls.__name__}.forward` - the expected `masked_scatter` audio "
+                f"cast was not found (transformers source drift). Audio merges may hit a "
+                f"dtype mismatch until the patch is updated."
+            )
         return False
 
     buggy_cast = buggy_casts[0]

--- a/unsloth_zoo/temporary_patches/gemma4_float32.py
+++ b/unsloth_zoo/temporary_patches/gemma4_float32.py
@@ -37,13 +37,167 @@
 # ============================================================================
 
 import os
+import ast
 import inspect
+import linecache
+import sys
 import torch
 from .common import TEMPORARY_PATCHES
 from .utils import patch_function, raise_error
 
 # Mirrors gemma.py: flex dispatch can be turned off globally.
 _UNSLOTH_FLEX_ATTENTION_DISABLED = os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0"
+
+
+def _gemma4_ple_cast_input(module, x):
+    """Cast at a learned PLE Linear boundary without touching the fp32 carrier."""
+    get_base_layer = getattr(module, "get_base_layer", None)
+    base_layer = get_base_layer() if callable(get_base_layer) else \
+        getattr(module, "base_layer", module)
+    weight = getattr(module, "weight", None)
+    if weight is None:
+        weight = getattr(base_layer, "weight", None)
+    if weight is None:
+        return x
+    quant_state = getattr(weight, "quant_state", None)
+    if quant_state is not None:
+        return x
+    dtype = weight.dtype
+    if dtype is None or not getattr(dtype, "is_floating_point", False):
+        return x
+    return x if x.dtype == dtype else x.to(dtype)
+pass
+
+
+def _is_gemma4_ple_linear_call(node, attr, argument):
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == attr
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+        and len(node.args) == 1
+        and not node.keywords
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == argument
+    )
+
+
+def _is_gemma4_ple_fixed_call(node, attr, argument):
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == attr
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Call)
+        and isinstance(node.args[0].func, ast.Name)
+        and node.args[0].func.id == "_gemma4_ple_cast_input"
+        and len(node.args[0].args) == 2
+        and isinstance(node.args[0].args[0], ast.Attribute)
+        and node.args[0].args[0].attr == attr
+        and isinstance(node.args[0].args[0].value, ast.Name)
+        and node.args[0].args[0].value.id == "self"
+        and isinstance(node.args[0].args[1], ast.Name)
+        and node.args[0].args[1].id == argument
+    )
+
+
+def _patch_gemma4_ple_dtype_on_method(model_cls, method_name, targets):
+    marker = f"_unsloth_ple_dtype_{method_name}_patched"
+    if getattr(model_cls, marker, False):
+        return False
+    module = sys.modules.get(model_cls.__module__)
+    source_file = inspect.getsourcefile(model_cls)
+    if module is None or source_file is None:
+        return False
+    module_source = inspect.getsource(module)
+    tree = ast.parse(module_source, filename = source_file)
+    class_nodes = [x for x in tree.body if isinstance(x, ast.ClassDef) and x.name == model_cls.__name__]
+    if len(class_nodes) != 1:
+        return False
+    method_nodes = [x for x in class_nodes[0].body if isinstance(x, ast.FunctionDef) and x.name == method_name]
+    if len(method_nodes) != 1:
+        return False
+    method_node = method_nodes[0]
+
+    raw_calls, fixed_calls = {}, {}
+    for attr, argument in targets:
+        raw_calls[attr] = [x for x in ast.walk(method_node) if _is_gemma4_ple_linear_call(x, attr, argument)]
+        fixed_calls[attr] = [x for x in ast.walk(method_node) if _is_gemma4_ple_fixed_call(x, attr, argument)]
+        if not raw_calls[attr] and len(fixed_calls[attr]) == 1:
+            continue
+        if len(raw_calls[attr]) != 1 or fixed_calls[attr]:
+            return False
+    if all(not raw_calls[attr] for attr, _ in targets):
+        setattr(model_cls, marker, True)
+        return False
+
+    patched_module_source = module_source
+    for attr, argument in targets:
+        if not raw_calls[attr]:
+            continue
+        old = ast.get_source_segment(module_source, raw_calls[attr][0])
+        new = f"self.{attr}(_gemma4_ple_cast_input(self.{attr}, {argument}))"
+        if old is None or patched_module_source.count(old) != 1:
+            return False
+        patched_module_source = patched_module_source.replace(old, new, 1)
+
+    class PLEInputCast(ast.NodeTransformer):
+        def visit_Call(self, node):
+            self.generic_visit(node)
+            for attr, argument in targets:
+                if _is_gemma4_ple_linear_call(node, attr, argument):
+                    node.args[0] = ast.copy_location(
+                        ast.Call(
+                            func = ast.Name(id = "_gemma4_ple_cast_input", ctx = ast.Load()),
+                            args = [node.func, node.args[0]],
+                            keywords = [],
+                        ),
+                        node.args[0],
+                    )
+            return node
+
+    method_node.decorator_list = []
+    method_node = PLEInputCast().visit(method_node)
+    ast.fix_missing_locations(method_node)
+    module.__dict__["_gemma4_ple_cast_input"] = _gemma4_ple_cast_input
+    namespace = {}
+    exec(compile(ast.Module(body = [method_node], type_ignores = []), source_file, "exec"), module.__dict__, namespace)
+    original_body = inspect.unwrap(getattr(model_cls, method_name))
+    patched_body = namespace[method_name]
+    if original_body.__code__.co_freevars != patched_body.__code__.co_freevars:
+        return False
+    original_body.__code__ = patched_body.__code__
+    linecache.cache[source_file] = (
+        len(patched_module_source), None, patched_module_source.splitlines(keepends = True), source_file,
+    )
+    setattr(model_cls, marker, True)
+    return True
+
+
+def patch_Gemma4PLEInputDtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1": return
+    try:
+        import transformers.models.gemma4.modeling_gemma4
+        Gemma4TextModel = transformers.models.gemma4.modeling_gemma4.Gemma4TextModel
+        Gemma4TextDecoderLayer = transformers.models.gemma4.modeling_gemma4.Gemma4TextDecoderLayer
+    except Exception as e:
+        return raise_error("Gemma4 PLE Linear input dtype", e)
+    try:
+        _patch_gemma4_ple_dtype_on_method(
+            Gemma4TextModel, "project_per_layer_inputs",
+            (("per_layer_model_projection", "inputs_embeds"),),
+        )
+        _patch_gemma4_ple_dtype_on_method(
+            Gemma4TextDecoderLayer, "forward",
+            (("per_layer_input_gate", "hidden_states"), ("per_layer_projection", "hidden_states")),
+        )
+    except Exception as e:
+        return raise_error("Gemma4 PLE Linear input dtype", e)
+pass
+TEMPORARY_PATCHES.append(patch_Gemma4PLEInputDtype)
 
 
 def patch_Gemma4TextScaledWordEmbedding():

--- a/unsloth_zoo/temporary_patches/gemma4_float32.py
+++ b/unsloth_zoo/temporary_patches/gemma4_float32.py
@@ -42,14 +42,14 @@ import inspect
 import linecache
 import sys
 import torch
-from .common import TEMPORARY_PATCHES
+from .common import TEMPORARY_PATCHES, logger
 from .utils import patch_function, raise_error
 
 # Mirrors gemma.py: flex dispatch can be turned off globally.
 _UNSLOTH_FLEX_ATTENTION_DISABLED = os.environ.get("UNSLOTH_ENABLE_FLEX_ATTENTION", "1") == "0"
 
 
-def _gemma4_ple_cast_input(module, x):
+def _unsloth_gemma4_ple_cast_input(module, x):
     """Cast at a learned PLE Linear boundary without touching the fp32 carrier."""
     get_base_layer = getattr(module, "get_base_layer", None)
     base_layer = get_base_layer() if callable(get_base_layer) else \
@@ -62,8 +62,14 @@ def _gemma4_ple_cast_input(module, x):
     quant_state = getattr(weight, "quant_state", None)
     if quant_state is not None:
         return x
-    dtype = weight.dtype
+    dtype = getattr(weight, "dtype", None)
     if dtype is None or not getattr(dtype, "is_floating_point", False):
+        return x
+    # Skip sub-2-byte floats (e.g. float8_e4m3fn / float8_e5m2): casting the fp32
+    # carrier down to fp8 destroys it, and fp8 matmul kernels expect a higher
+    # precision input they scale internally. getattr keeps this a no-op on older
+    # torch builds whose dtypes lack `itemsize`.
+    if getattr(dtype, "itemsize", 2) < 2:
         return x
     return x if x.dtype == dtype else x.to(dtype)
 pass
@@ -93,7 +99,7 @@ def _is_gemma4_ple_fixed_call(node, attr, argument):
         and len(node.args) == 1
         and isinstance(node.args[0], ast.Call)
         and isinstance(node.args[0].func, ast.Name)
-        and node.args[0].func.id == "_gemma4_ple_cast_input"
+        and node.args[0].func.id == "_unsloth_gemma4_ple_cast_input"
         and len(node.args[0].args) == 2
         and isinstance(node.args[0].args[0], ast.Attribute)
         and node.args[0].args[0].attr == attr
@@ -104,42 +110,75 @@ def _is_gemma4_ple_fixed_call(node, attr, argument):
     )
 
 
-def _patch_gemma4_ple_dtype_on_method(model_cls, method_name, targets):
+def _gemma4_ple_validate(model_cls, method_name, targets):
+    """Classify a PLE method WITHOUT mutating anything.
+
+    Returns (status, payload) where status is one of:
+      "ALREADY"     - marker set, or every boundary is already cast (safe no-op).
+      "PATCH"       - payload carries what is needed to rewrite the method.
+      "DRIFT"       - the method exists but its source shape is unexpected.
+      "UNAVAILABLE" - the class / source cannot be introspected here.
+    payload is None unless status == "PATCH".
+    """
     marker = f"_unsloth_ple_dtype_{method_name}_patched"
     if getattr(model_cls, marker, False):
-        return False
+        return "ALREADY", None
     module = sys.modules.get(model_cls.__module__)
     source_file = inspect.getsourcefile(model_cls)
     if module is None or source_file is None:
-        return False
+        return "UNAVAILABLE", None
     module_source = inspect.getsource(module)
     tree = ast.parse(module_source, filename = source_file)
     class_nodes = [x for x in tree.body if isinstance(x, ast.ClassDef) and x.name == model_cls.__name__]
     if len(class_nodes) != 1:
-        return False
+        return "DRIFT", None
     method_nodes = [x for x in class_nodes[0].body if isinstance(x, ast.FunctionDef) and x.name == method_name]
     if len(method_nodes) != 1:
-        return False
+        return "DRIFT", None
     method_node = method_nodes[0]
 
-    raw_calls, fixed_calls = {}, {}
+    raw_calls = {}
     for attr, argument in targets:
-        raw_calls[attr] = [x for x in ast.walk(method_node) if _is_gemma4_ple_linear_call(x, attr, argument)]
-        fixed_calls[attr] = [x for x in ast.walk(method_node) if _is_gemma4_ple_fixed_call(x, attr, argument)]
-        if not raw_calls[attr] and len(fixed_calls[attr]) == 1:
+        raw = [x for x in ast.walk(method_node) if _is_gemma4_ple_linear_call(x, attr, argument)]
+        fixed = [x for x in ast.walk(method_node) if _is_gemma4_ple_fixed_call(x, attr, argument)]
+        if not raw and len(fixed) == 1:
+            raw_calls[attr] = []
             continue
-        if len(raw_calls[attr]) != 1 or fixed_calls[attr]:
-            return False
+        if len(raw) != 1 or fixed:
+            return "DRIFT", None
+        raw_calls[attr] = raw
     if all(not raw_calls[attr] for attr, _ in targets):
+        return "ALREADY", None
+    return "PATCH", (module, source_file, module_source, method_node, raw_calls)
+
+
+def _patch_gemma4_ple_dtype_on_method(model_cls, method_name, targets, dry_run = False):
+    status, payload = _gemma4_ple_validate(model_cls, method_name, targets)
+    if dry_run:
+        return status
+
+    marker = f"_unsloth_ple_dtype_{method_name}_patched"
+    if status == "ALREADY":
+        # Covers both the marker-preset case and "every boundary already cast".
         setattr(model_cls, marker, True)
         return False
+    if status in ("DRIFT", "UNAVAILABLE"):
+        if status == "DRIFT":
+            logger.warning(
+                f"Unsloth: Gemma4 PLE dtype patch skipped for "
+                f"`{model_cls.__name__}.{method_name}` - the expected source shape was "
+                f"not found (transformers source drift). Forced-float32 runs may hit a "
+                f"dtype mismatch here until the patch is updated."
+            )
+        return False
 
+    module, source_file, module_source, method_node, raw_calls = payload
     patched_module_source = module_source
     for attr, argument in targets:
         if not raw_calls[attr]:
             continue
         old = ast.get_source_segment(module_source, raw_calls[attr][0])
-        new = f"self.{attr}(_gemma4_ple_cast_input(self.{attr}, {argument}))"
+        new = f"self.{attr}(_unsloth_gemma4_ple_cast_input(self.{attr}, {argument}))"
         if old is None or patched_module_source.count(old) != 1:
             return False
         patched_module_source = patched_module_source.replace(old, new, 1)
@@ -151,7 +190,7 @@ def _patch_gemma4_ple_dtype_on_method(model_cls, method_name, targets):
                 if _is_gemma4_ple_linear_call(node, attr, argument):
                     node.args[0] = ast.copy_location(
                         ast.Call(
-                            func = ast.Name(id = "_gemma4_ple_cast_input", ctx = ast.Load()),
+                            func = ast.Name(id = "_unsloth_gemma4_ple_cast_input", ctx = ast.Load()),
                             args = [node.func, node.args[0]],
                             keywords = [],
                         ),
@@ -162,7 +201,7 @@ def _patch_gemma4_ple_dtype_on_method(model_cls, method_name, targets):
     method_node.decorator_list = []
     method_node = PLEInputCast().visit(method_node)
     ast.fix_missing_locations(method_node)
-    module.__dict__["_gemma4_ple_cast_input"] = _gemma4_ple_cast_input
+    module.__dict__["_unsloth_gemma4_ple_cast_input"] = _unsloth_gemma4_ple_cast_input
     namespace = {}
     exec(compile(ast.Module(body = [method_node], type_ignores = []), source_file, "exec"), module.__dict__, namespace)
     original_body = inspect.unwrap(getattr(model_cls, method_name))
@@ -185,15 +224,32 @@ def patch_Gemma4PLEInputDtype():
         Gemma4TextDecoderLayer = transformers.models.gemma4.modeling_gemma4.Gemma4TextDecoderLayer
     except Exception as e:
         return raise_error("Gemma4 PLE Linear input dtype", e)
+    specs = (
+        (Gemma4TextModel, "project_per_layer_inputs",
+            (("per_layer_model_projection", "inputs_embeds"),)),
+        (Gemma4TextDecoderLayer, "forward",
+            (("per_layer_input_gate", "hidden_states"), ("per_layer_projection", "hidden_states"))),
+    )
     try:
-        _patch_gemma4_ple_dtype_on_method(
-            Gemma4TextModel, "project_per_layer_inputs",
-            (("per_layer_model_projection", "inputs_embeds"),),
-        )
-        _patch_gemma4_ple_dtype_on_method(
-            Gemma4TextDecoderLayer, "forward",
-            (("per_layer_input_gate", "hidden_states"), ("per_layer_projection", "hidden_states")),
-        )
+        # Validate every boundary before mutating any, so a drift in one method can
+        # never leave a half-patched model that still crashes at the other boundary.
+        statuses = [
+            ((cls, method), _patch_gemma4_ple_dtype_on_method(cls, method, targets, dry_run = True))
+            for cls, method, targets in specs
+        ]
+        # Abort all boundaries if any cannot be safely patched (DRIFT) or introspected
+        # (UNAVAILABLE), so a per-method failure can never leave a half-patched model.
+        if any(status in ("DRIFT", "UNAVAILABLE") for _, status in statuses):
+            for (cls, method), status in statuses:
+                if status == "DRIFT":
+                    logger.warning(
+                        f"Unsloth: Gemma4 PLE dtype patch skipped for "
+                        f"`{cls.__name__}.{method}` (transformers source drift); skipping "
+                        f"all PLE boundaries to avoid a half-patched model."
+                    )
+            return
+        for cls, method, targets in specs:
+            _patch_gemma4_ple_dtype_on_method(cls, method, targets)
     except Exception as e:
         return raise_error("Gemma4 PLE Linear input dtype", e)
 pass


### PR DESCRIPTION
## Summary

Fixes two Gemma 4 mixed-dtype failures on FP16 hardware:

- Casts audio features to the destination text-embedding dtype before `masked_scatter`.
- Aligns forced-FP32 residual activations with the three PLE projection boundaries.

## Motivation

Gemma 4 inference and training on a T4 could fail with:

```text
masked_scatter_: expected self and source to have same dtypes but got Float and Half
```

Training could then fail at the PLE projections with:

```text
expected mat1 and mat2 to have the same dtype, but got: float != c10::Half
```

## Changes

- Patch the eager audio merge in `unsloth_zoo/temporary_patches/gemma4.py:674` while preserving the existing decorated forward wrapper.
- Apply the same audio rewrite to generated compiled modules in `unsloth_zoo/compiler.py:1234`.
- Add a quantization-aware PLE input helper in `unsloth_zoo/temporary_patches/gemma4_float32.py:52`.
- Patch `per_layer_model_projection`, `per_layer_input_gate`, and `per_layer_projection` in eager and compiled paths.
- Support PEFT-wrapped linear layers without casting activations to packed `uint8` weight dtypes.
- Gate PLE changes on `UNSLOTH_FORCE_FLOAT32=1`. BF16, FP32, and unrelated model families retain their existing paths.
- Add regression tests for dtype combinations, PEFT wrappers, quantized weights, source drift, idempotency, compiled generation, and eager/compiled parity.

## How to test

Run the focused regression suite:

```bash
pytest -q tests/test_gemma4_audio_dtype.py tests/test_gemma4_forced_float32_ple_dtype.py
```

Expected result:

```text
32 passed
```

The broader Gemma 4/compiler suite completed with 122 passed and 1 skipped.

The pushed commit was also tested on a Tesla T4 with Gemma 4 E2B:

- Default LoRA completed three steps with finite loss and gradient norm.
- Explicit PLE-targeted LoRA wrapped all 71 PLE modules and completed three steps.
- Compiled and compile-disabled runs produced numerically matching metrics.
- Reentrant checkpointing was active on 52 modules and completed backward passes.
- A BitsAndBytes 4-bit model contained 169 packed `uint8` modules while zero PLE activations were cast to `uint8`.
- Text, image, audio, and video forwards completed with finite outputs.
- All 35 inspected attention softmax calls remained FP32.
- The dtype guard had identical logits and peak memory compared with the minimal correct cast.
- A clean runtime executed TRL's `_chunked_ce_forward` 12 times without OOM. Peak allocation was 12.937 GiB on the T4.

## Notes for reviewers

The transforms fail closed when the expected upstream source pattern is missing or ambiguous. Already-fixed upstream implementations are left unchanged.

T4 does not support native BF16 model execution. The BF16 no-op path was therefore checked directly at the dtype boundary, including tensor identity, storage identity, and gradient preservation.