### PR TITLE
Fix sys.modules leak in offline cross-sync test breaking Core CI

### DIFF
--- a/tests/test_offline_env_cross_sync.py
+++ b/tests/test_offline_env_cross_sync.py
@@ -24,15 +24,38 @@ import pytest
 @pytest.fixture
 def reload_zoo(monkeypatch):
     """Strip the three offline env vars, then reload ``unsloth_zoo`` so its
-    import-time cross-sync runs."""
+    import-time cross-sync runs.
+
+    Reloading swaps a fresh, half-initialized ``unsloth_zoo`` object into
+    ``sys.modules`` -- one that lacks submodule attributes (e.g.
+    ``vision_utils``) the package only binds when they are first imported.
+    Snapshot the original ``unsloth_zoo*`` modules and restore them on
+    teardown so the reload does not leak that shell into the rest of the
+    session and break later tests that resolve submodules via string paths
+    (e.g. ``monkeypatch.setattr("unsloth_zoo.vision_utils.<attr>", ...)``).
+    """
     for v in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"):
         monkeypatch.delenv(v, raising = False)
+
+    saved = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "unsloth_zoo" or name.startswith("unsloth_zoo.")
+    }
 
     def _reload():
         sys.modules.pop("unsloth_zoo", None)
         return importlib.import_module("unsloth_zoo")
 
-    return _reload
+    yield _reload
+
+    for name in [
+        name for name in sys.modules
+        if name == "unsloth_zoo" or name.startswith("unsloth_zoo.")
+    ]:
+        if name not in saved:
+            del sys.modules[name]
+    sys.modules.update(saved)
 
 
 class TestOfflineCrossSync:

--- a/tests/test_vision_collator_audio.py
+++ b/tests/test_vision_collator_audio.py
@@ -507,8 +507,14 @@ class _UnpatchedFakeAudioDecoder:
 @pytest.fixture
 def _recognize_unpatched_decoder(monkeypatch):
     # Treat _UnpatchedFakeAudioDecoder as the decoder type so these run in CI.
+    # Patch the imported module object directly rather than the
+    # "unsloth_zoo.vision_utils._audio_decoder_types" string path: the string
+    # form resolves unsloth_zoo through sys.modules at runtime, so a preceding
+    # test that swaps unsloth_zoo in sys.modules would break resolution here.
+    import unsloth_zoo.vision_utils as vision_utils
     monkeypatch.setattr(
-        "unsloth_zoo.vision_utils._audio_decoder_types",
+        vision_utils,
+        "_audio_decoder_types",
         lambda: (_UnpatchedFakeAudioDecoder,),
     )
 


### PR DESCRIPTION
## Problem

The `Core` workflow (`unsloth_zoo @ main` full pytest step) is failing on `main` and, by extension, on every open unsloth PR that runs it. Five errors in `tests/test_vision_collator_audio.py`:

```
AttributeError: 'module' object at unsloth_zoo.vision_utils has no attribute 'vision_utils'
```

The tests pass in isolation but fail in the full suite, which points to a test-ordering / `sys.modules` pollution problem rather than a real product bug.

## Root cause

`reload_zoo` in `tests/test_offline_env_cross_sync.py` reloads the package to exercise the import-time offline cross-sync:

```python
sys.modules.pop("unsloth_zoo", None)
importlib.import_module("unsloth_zoo")
```

It never restores the original module. The reimport installs a fresh `unsloth_zoo` package object that does not carry lazily-bound submodule attributes (for example `vision_utils`, which the package only binds once something imports it). After this fixture runs, `sys.modules["unsloth_zoo"]` stays that stripped-down object for the rest of the session.

`tests/test_vision_collator_audio.py` later patches through a string path:

```python
monkeypatch.setattr("unsloth_zoo.vision_utils._audio_decoder_types", ...)
```

`monkeypatch` resolves `unsloth_zoo.vision_utils` via `sys.modules` at runtime, so it now hits the stripped object and `getattr(unsloth_zoo, "vision_utils")` raises.

Reproduces deterministically:

```
pytest tests/test_offline_env_cross_sync.py tests/test_vision_collator_audio.py
```

fails with the same 5 errors, while each file on its own passes.

## Fix

- `reload_zoo` now snapshots the `unsloth_zoo*` entries in `sys.modules` and restores them on teardown, so the reload no longer leaks a half-initialized package into the rest of the session.
- As defense in depth, the audio collator test patches the imported module object directly instead of the string path, so it stays robust to any future `sys.modules` pollution.

## Verification

- `pytest tests/test_offline_env_cross_sync.py tests/test_vision_collator_audio.py` now passes.
- Full suite: 2255 passed, 134 skipped, no `vision_utils` errors.
- The hardened audio test passes even with the fixture fix reverted, confirming it is independently robust.