### PR TITLE
MLX: lazy/streaming dataset support for text and VLM training, length-grouped batching, and background prefetch

### DIFF
--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -382,6 +382,13 @@ try:
     resume_mismatch = ""
 except RuntimeError as exc:
     resume_mismatch = str(exc)
+def vlm_stream_rejection():
+    try:
+        next(iter(iterate_vlm_training_batches(ReplayableVLMStream(), TinyProcessor(), {"image_token_id": 20}, batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world)))
+        return "no-error"
+    except ValueError as exc:
+        return "rejected" if "DDP training" in str(exc) else f"wrong: {exc}"
+
 payload = {
     "rank": int(world.rank()),
     "size": int(world.size()),
@@ -452,7 +459,7 @@ payload = {
     "stream_labeled_empty": [{"ids": batch.tolist(), "lengths": lengths.tolist(), "labels": labels.tolist()} for batch, lengths, labels in list(iterate_training_batches(ReplayableLabeledStream(), TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world, repeat=False, distributed_pad_mode="empty"))],
     "vlm": [[int(row[0]) for row in batch["input_ids"].tolist()] for batch in create_vlm_batches([{"text": str(i)} for i in range(10, 15)], TinyProcessor(), {"image_token_id": 20}, batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world)],
     "vlm_empty_eval": [{"ids": batch["input_ids"].tolist(), "mask": batch["attention_mask"].tolist(), "labels": batch["labels"].tolist()} for batch in create_vlm_batches([{"text": str(i)} for i in range(10, 13)], TinyProcessor(), {"image_token_id": 20}, batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world, distributed_pad_mode="empty")],
-    "stream_vlm": take_stream_rows(iterate_vlm_training_batches(ReplayableVLMStream(), TinyProcessor(), {"image_token_id": 20}, batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world), 2),
+    "stream_vlm_rejection": vlm_stream_rejection(),
     "stream_window": take_stream_rows(iterate_training_batches(ReplayableStream(), TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="default", comm_group=world, repeat=False, length_window_batches=2), 3),
 }
 Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
@@ -477,7 +484,6 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert all(path.exists() for path in outputs), proc.stdout + proc.stderr
     ranks = [json.loads(path.read_text()) for path in outputs]
     expected = [[[10, 12], [14, 11]], [[11, 13], [10, 12]]]
-    expected_stream = [[[10, 12], [14, 14]], [[11, 13], [14, 14]]]
     assert [rank["size"] for rank in ranks] == [2, 2]
     assert [rank["synced_stop"] for rank in ranks] == [True, True]
     assert [rank["loop_main"] for rank in ranks] == [True, False]
@@ -578,7 +584,9 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert ranks[0]["stream_labeled_empty"][1]["labels"][0] == [-100, 32]
     assert ranks[1]["stream_labeled_empty"][1]["lengths"][0] == [0, 0]
     assert ranks[1]["stream_labeled_empty"][1]["labels"][0] == [-100, -100]
-    assert [rank["stream_vlm"] for rank in ranks] == expected_stream
+    # Intentional compatibility break: every-rank lazy-VLM consumption is
+    # replaced by a synchronized pre-consumption rejection on all ranks.
+    assert [rank["stream_vlm_rejection"] for rank in ranks] == ["rejected", "rejected"]
     # W=2 owner-side window: rows 10..14 (equal length) pool into chunks
     # [10,11],[12,13]; seed-42 permutation emits [12,13] first, so the pass-tail
     # partial [14] cycle-pads from that first dispatched batch.

--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -30,7 +30,7 @@ def test_mlx_launch_ordered_text_batches_are_rank_sharded(tmp_path):
         pytest.skip("mlx.launch not found beside current Python executable")
 
     script = tmp_path / "ddp_batch_probe.py"
-    script.write_text(f"#!{sys.executable}\n" + """import json, sys
+    script.write_text("""import json, sys
 from pathlib import Path
 
 import mlx.core as mx
@@ -465,15 +465,16 @@ payload = {
 Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
 """,
         encoding="utf-8")
-    script.chmod(script.stat().st_mode | 0o111)
 
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]
     env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+    # The ring launcher bash-execs the command array verbatim, so pin the
+    # interpreter as argv[0] instead of relying on a shebang + chmod.
     cmd = [
         str(launcher), "-n", "2", "--backend", "ring",
         "--cwd", str(repo_root),
-        str(script), str(tmp_path),
+        sys.executable, str(script), str(tmp_path),
     ]
     proc = subprocess.run(
         cmd, capture_output=True, env=env, text=True, timeout=120,

--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -453,6 +453,7 @@ payload = {
     "vlm": [[int(row[0]) for row in batch["input_ids"].tolist()] for batch in create_vlm_batches([{"text": str(i)} for i in range(10, 15)], TinyProcessor(), {"image_token_id": 20}, batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world)],
     "vlm_empty_eval": [{"ids": batch["input_ids"].tolist(), "mask": batch["attention_mask"].tolist(), "labels": batch["labels"].tolist()} for batch in create_vlm_batches([{"text": str(i)} for i in range(10, 13)], TinyProcessor(), {"image_token_id": 20}, batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world, distributed_pad_mode="empty")],
     "stream_vlm": take_stream_rows(iterate_vlm_training_batches(ReplayableVLMStream(), TinyProcessor(), {"image_token_id": 20}, batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world), 2),
+    "stream_window": take_stream_rows(iterate_training_batches(ReplayableStream(), TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="default", comm_group=world, repeat=False, length_window_batches=2), 3),
 }
 Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
 """,
@@ -578,3 +579,9 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert ranks[1]["stream_labeled_empty"][1]["lengths"][0] == [0, 0]
     assert ranks[1]["stream_labeled_empty"][1]["labels"][0] == [-100, -100]
     assert [rank["stream_vlm"] for rank in ranks] == expected_stream
+    # W=2 owner-side window: rows 10..14 (equal length) pool into chunks
+    # [10,11],[12,13]; seed-42 permutation emits [12,13] first, so the pass-tail
+    # partial [14] cycle-pads from that first dispatched batch.
+    assert [rank["stream_window"] for rank in ranks] == [
+        [[12], [10], [14]], [[13], [11], [12]],
+    ]

--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -39,7 +39,7 @@ from mlx.utils import tree_flatten
 from unsloth_zoo import dataset_utils
 import unsloth_zoo.mlx.trainer as trainer_mod
 from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig, _create_labeled_batches, train_on_responses_only
-from unsloth_zoo.mlx.utils import create_batches, create_ordered_batches, create_vlm_batches, iterate_training_batches, iterate_vlm_training_batches, make_baseline_loss_fn
+from unsloth_zoo.mlx.utils import _MLXIterableTokenizedDatasetView, create_batches, create_ordered_batches, create_vlm_batches, iterate_training_batches, iterate_vlm_training_batches, make_baseline_loss_fn
 
 class TinyTokenizer:
     pad_token_id = eos_token_id = 2
@@ -79,7 +79,36 @@ def eval_loss_for_batches(model, batches):
     return float((all_losses / ntokens).item())
 
 class ReplayableStream:
-    def __iter__(self): return ({"text": f"{i} {i + 20} {i + 30}"} for i in range(10, 15))
+    @property
+    def _ex_iterable(self):
+        if int(world.rank()) != 0: raise AssertionError("non-owner inspected eval stream")
+        return None
+    def __iter__(self):
+        if int(world.rank()) != 0: raise AssertionError("non-owner consumed text stream")
+        return ({"text": f"{i} {i + 20} {i + 30}"} for i in range(10, 15))
+
+class ReplayableLabeledStream:
+    def __iter__(self):
+        if int(world.rank()) != 0: raise AssertionError("non-owner consumed labeled stream")
+        return ({"input_ids": [i, i + 20], "labels": [-100, i + 20]} for i in range(10, 13))
+
+class ReplayableVariableStream:
+    def __iter__(self):
+        if int(world.rank()) != 0: raise AssertionError("non-owner consumed variable stream")
+        return iter(({"input_ids": [10, 30]}, {"input_ids": [11, 31, 41, 51]}, {"input_ids": [12, 32]}))
+
+class RaisingMetadataStream:
+    @property
+    def _distributed(self): raise RuntimeError("owner metadata failure")
+    def __iter__(self): raise AssertionError("metadata failure must precede consumption")
+
+class RankOwnedLengthStream:
+    def __len__(self):
+        if int(world.rank()) != 0: raise AssertionError("non-owner inspected stream length")
+        return 4
+    def __iter__(self):
+        if int(world.rank()) != 0: raise AssertionError("non-owner consumed length stream")
+        return ({"text": f"{i} {i + 20}"} for i in range(10, 14))
 
 class RankFailingStream:
     def __iter__(self):
@@ -101,6 +130,35 @@ trainer.stop_requested = world.rank() == 0
 synced_stop = trainer._distributed_should_stop()
 trainer.stop_requested = False
 
+def stream_replay_probe():
+    full = take_stream_rows(iterate_training_batches(ReplayableStream(), TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world), 3)
+    resumed = iterate_training_batches(ReplayableStream(), TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world)
+    next(resumed); next(resumed)
+    return [full[2], take_stream_rows(resumed, 1)[0]]
+
+def presharded_stream_error():
+    from datasets import IterableDataset
+    from datasets.distributed import split_dataset_by_node
+    source = IterableDataset.from_generator(lambda: ({"text": f"{i} {i + 20}"} for i in range(4)))
+    source = split_dataset_by_node(source, rank=int(world.rank()), world_size=int(world.size()))
+    try:
+        next(iterate_training_batches(source, TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world))
+    except (RuntimeError, ValueError) as exc:
+        return str(exc)
+    return ""
+
+def owner_metadata_error():
+    try:
+        next(iterate_training_batches(RaisingMetadataStream(), TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world))
+    except RuntimeError as exc:
+        return str(exc)
+    return ""
+
+def prepared_override_batches():
+    override = TinyTokenizer(); override.pad_token_id = 9
+    view = _MLXIterableTokenizedDatasetView(ReplayableVariableStream(), override, max_seq_length=8)
+    return [batch.tolist() for batch, _lengths, _labels in iterate_training_batches(view, TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world, repeat=False)]
+
 class TinyLM(nn.Module):
     def __init__(self):
         super().__init__(); self.embed = nn.Embedding(64, 8)
@@ -116,6 +174,12 @@ class TinyLM(nn.Module):
         if self._record_eval_rows:
             self.eval_first_tokens.extend([int(row[0]) for row in x.tolist()])
         return self.proj(self.embed(x))
+
+def epoch_owned_probe():
+    epoch_args = MLXTrainingConfig(per_device_train_batch_size=1, gradient_accumulation_steps=1, max_steps=-1, num_train_epochs=1, max_seq_length=8, output_dir=str(Path(sys.argv[1], "epoch_owned")), use_cce=False, gradient_checkpointing=False, completion_only_loss=False, dataset_order="sequential", streaming=True)
+    epoch_trainer = MLXTrainer(TinyLM(), TinyTokenizer(), RankOwnedLengthStream(), args=epoch_args)
+    _batches, batch_iter = epoch_trainer._prepare_data(False)
+    return [int(epoch_trainer._streaming_epoch_batch_count), take_stream_rows(batch_iter, 1)[0]]
 
 class BrokenTinyLM(TinyLM):
     def __call__(self, x):
@@ -154,14 +218,15 @@ param_sum = mx.sum(loop_trainer.model.embed.weight) + mx.sum(loop_trainer.model.
 loop_eval_reference_loss = eval_loss_for_batches(loop_trainer.model, _create_labeled_batches(train_data[:3], TinyTokenizer(), keep_all_labels, batch_size=1, max_seq_length=8, seed=args.seed, dataset_order="sequential"))
 mx.random.seed(1)
 stream_args = MLXTrainingConfig(per_device_train_batch_size=1, gradient_accumulation_steps=1, max_steps=1, logging_steps=1, eval_steps=1, save_steps=0, learning_rate=1e-3, max_seq_length=8, output_dir=str(Path(sys.argv[1], "stream_train_out")), use_cce=False, gradient_checkpointing=False, cast_norm_output_to_input_dtype=False, dataset_order="sequential", streaming=True)
-stream_trainer = MLXTrainer(TinyLM(), TinyTokenizer(), ReplayableStream(), eval_dataset=train_data[:3], args=stream_args)
+stream_eval_data = [{"text": f"{i} {i + 20} {i + 30}"} for i in range(10, 15)]
+stream_trainer = MLXTrainer(TinyLM(), TinyTokenizer(), ReplayableStream(), eval_dataset=ReplayableStream(), args=stream_args)
 stream_events = []
 stream_trainer.save_model = mark("stream_final")
 stream_trainer.add_step_callback(lambda step, *_args: stream_events.append(["step", int(step)]))
 stream_trainer.add_eval_callback(lambda step, loss, _ppl: stream_events.append(["eval", int(step), float(loss)]))
 stream_result = stream_trainer.train()
 stream_param_sum = mx.sum(stream_trainer.model.embed.weight) + mx.sum(stream_trainer.model.proj.weight)
-stream_eval_reference_loss = eval_loss_for_batches(stream_trainer.model, create_batches(train_data[:3], TinyTokenizer(), batch_size=1, max_seq_length=8, seed=stream_args.seed))
+stream_eval_reference_loss = eval_loss_for_batches(stream_trainer.model, create_batches(stream_eval_data, TinyTokenizer(), batch_size=1, max_seq_length=8, seed=stream_args.seed))
 trainer_mod.save_trainable_adapters, trainer_mod.save_optimizer_state, trainer_mod.save_trainer_state = real_save_trainable_adapters, real_save_optimizer_state, real_save_trainer_state
 parity_data = [{"text": f"{i} {i + 1} {i + 2}"} for i in range(10, 18)]
 def make_parity_trainer(output_name, seed=123):
@@ -379,6 +444,12 @@ payload = {
     "ordered": first_token_rows(create_ordered_batches(data, TinyTokenizer(), dataset_order="sequential", **common)),
     "labeled": first_token_rows(_create_labeled_batches(data, TinyTokenizer(), keep_all_labels, dataset_order="sequential", **common)),
     "stream_text": take_stream_rows(iterate_training_batches(ReplayableStream(), TinyTokenizer(), batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world), 2),
+    "stream_replay": stream_replay_probe(),
+    "presharded_stream_error": presharded_stream_error(),
+    "owner_metadata_error": owner_metadata_error(),
+    "prepared_override_batches": prepared_override_batches(),
+    "epoch_owned": epoch_owned_probe(),
+    "stream_labeled_empty": [{"ids": batch.tolist(), "lengths": lengths.tolist(), "labels": labels.tolist()} for batch, lengths, labels in list(iterate_training_batches(ReplayableLabeledStream(), TinyTokenizer(), batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world, repeat=False, distributed_pad_mode="empty"))],
     "vlm": [[int(row[0]) for row in batch["input_ids"].tolist()] for batch in create_vlm_batches([{"text": str(i)} for i in range(10, 15)], TinyProcessor(), {"image_token_id": 20}, batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world)],
     "vlm_empty_eval": [{"ids": batch["input_ids"].tolist(), "mask": batch["attention_mask"].tolist(), "labels": batch["labels"].tolist()} for batch in create_vlm_batches([{"text": str(i)} for i in range(10, 13)], TinyProcessor(), {"image_token_id": 20}, batch_size=1, max_seq_length=8, dataset_order="sequential", comm_group=world, distributed_pad_mode="empty")],
     "stream_vlm": take_stream_rows(iterate_vlm_training_batches(ReplayableVLMStream(), TinyProcessor(), {"image_token_id": 20}, batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world), 2),
@@ -429,7 +500,7 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert [rank["stream_step"] for rank in ranks] == [1, 1]
     assert [rank["stream_compile_enabled"] for rank in ranks] == [True, True]
     assert [rank["stream_compile_scope"] for rank in ranks] == ["ddp_local_grad", "ddp_local_grad"]
-    assert [rank["stream_text_eval_rows"] for rank in ranks] == [[10, 12], [11, 2]]
+    assert [rank["stream_text_eval_rows"] for rank in ranks] == [[10, 12, 14], [11, 13, 2]]
     assert ranks[0]["stream_eval_loss"] == pytest.approx(ranks[1]["stream_eval_loss"], abs=1e-6)
     assert ranks[0]["stream_eval_loss"] == pytest.approx(ranks[0]["stream_eval_reference_loss"], abs=1e-6)
     assert ranks[1]["stream_eval_loss"] == pytest.approx(ranks[1]["stream_eval_reference_loss"], abs=1e-6)
@@ -454,7 +525,7 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert all("runtime fallback is disabled" not in rank["non_compile_error"] for rank in ranks)
     assert all("fetching training batch" in rank["asymmetric_data_error"] for rank in ranks)
     assert "rank 0 failed" in ranks[0]["asymmetric_data_error"]
-    assert "peer rank failed" in ranks[1]["asymmetric_data_error"]
+    assert "rank 0 failed while reading" in ranks[1]["asymmetric_data_error"]
     assert all("zero supervised tokens" in rank["zero_token_error"] for rank in ranks)
     assert ranks[0]["fresh_losses"] == pytest.approx(ranks[0]["resumed_losses"], abs=1e-6)
     assert ranks[0]["resume_param_delta"] < 1e-5
@@ -494,4 +565,16 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert ranks[1]["vlm_empty_eval"][1]["mask"][0] == [1, 1, 1, 1]
     assert all(value == -100 for value in ranks[1]["vlm_empty_eval"][1]["labels"][0])
     assert [rank["stream_text"] for rank in ranks] == expected
+    assert all(rank["stream_replay"][0] == rank["stream_replay"][1] for rank in ranks)
+    assert "global unsharded" in ranks[0]["presharded_stream_error"]
+    assert "rank 0 failed" in ranks[1]["presharded_stream_error"]
+    assert "owner metadata failure" in ranks[0]["owner_metadata_error"]
+    assert "rank 0 failed" in ranks[1]["owner_metadata_error"]
+    assert ranks[0]["prepared_override_batches"][1][0] == [12, 32, 9, 9]
+    assert ranks[1]["prepared_override_batches"][1][0] == [10, 30, 9, 9]
+    assert [rank["epoch_owned"] for rank in ranks] == [[2, [10]], [2, [11]]]
+    assert [rank["stream_labeled_empty"][1]["ids"][0][0] for rank in ranks] == [12, 2]
+    assert ranks[0]["stream_labeled_empty"][1]["labels"][0] == [-100, 32]
+    assert ranks[1]["stream_labeled_empty"][1]["lengths"][0] == [0, 0]
+    assert ranks[1]["stream_labeled_empty"][1]["labels"][0] == [-100, -100]
     assert [rank["stream_vlm"] for rank in ranks] == expected_stream

--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -30,7 +30,8 @@ def test_mlx_launch_ordered_text_batches_are_rank_sharded(tmp_path):
         pytest.skip("mlx.launch not found beside current Python executable")
 
     script = tmp_path / "ddp_batch_probe.py"
-    script.write_text("""import json, sys
+    script.write_text("""#!/usr/bin/env python3
+import json, sys
 from pathlib import Path
 
 import mlx.core as mx
@@ -386,13 +387,14 @@ payload = {
 Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
 """,
         encoding="utf-8")
+    script.chmod(script.stat().st_mode | 0o111)
 
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]
     env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
     cmd = [
         str(launcher), "-n", "2", "--backend", "ring",
-        "--python", sys.executable, "--cwd", str(repo_root),
+        "--cwd", str(repo_root),
         str(script), str(tmp_path),
     ]
     proc = subprocess.run(
@@ -492,5 +494,5 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert ranks[1]["vlm_empty_eval"][1]["ids"][0][1] == 20
     assert ranks[1]["vlm_empty_eval"][1]["mask"][0] == [1, 1, 1, 1]
     assert all(value == -100 for value in ranks[1]["vlm_empty_eval"][1]["labels"][0])
-    assert [rank["stream_text"] for rank in ranks] == expected_stream
+    assert [rank["stream_text"] for rank in ranks] == expected
     assert [rank["stream_vlm"] for rank in ranks] == expected_stream

--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -30,8 +30,7 @@ def test_mlx_launch_ordered_text_batches_are_rank_sharded(tmp_path):
         pytest.skip("mlx.launch not found beside current Python executable")
 
     script = tmp_path / "ddp_batch_probe.py"
-    script.write_text("""#!/usr/bin/env python3
-import json, sys
+    script.write_text(f"#!{sys.executable}\n" + """import json, sys
 from pathlib import Path
 
 import mlx.core as mx

--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -470,8 +470,7 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     env = os.environ.copy()
     repo_root = Path(__file__).resolve().parents[1]
     env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
-    # The ring launcher bash-execs the command array verbatim, so pin the
-    # interpreter as argv[0] instead of relying on a shebang + chmod.
+    # Ring launcher execs the array verbatim, so pin the interpreter as argv[0].
     cmd = [
         str(launcher), "-n", "2", "--backend", "ring",
         "--cwd", str(repo_root),
@@ -592,12 +591,10 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert ranks[0]["stream_labeled_empty"][1]["labels"][0] == [-100, 32]
     assert ranks[1]["stream_labeled_empty"][1]["lengths"][0] == [0, 0]
     assert ranks[1]["stream_labeled_empty"][1]["labels"][0] == [-100, -100]
-    # Intentional compatibility break: every-rank lazy-VLM consumption is
-    # replaced by a synchronized pre-consumption rejection on all ranks.
+    # Compatibility break: lazy VLM is now rejected on all ranks pre-consumption.
     assert [rank["stream_vlm_rejection"] for rank in ranks] == ["rejected", "rejected"]
-    # W=2 owner-side window: rows 10..14 (equal length) pool into chunks
-    # [10,11],[12,13]; seed-42 permutation emits [12,13] first, so the pass-tail
-    # partial [14] cycle-pads from that first dispatched batch.
+    # W=2: rows 10..14 pool into [10,11],[12,13]; seed 42 emits [12,13] first,
+    # so the partial tail [14] cycle-pads from it.
     assert [rank["stream_window"] for rank in ranks] == [
         [[12], [10], [14]], [[13], [11], [12]],
     ]

--- a/tests/test_mlx_pr684_full_validation_metal.py
+++ b/tests/test_mlx_pr684_full_validation_metal.py
@@ -335,4 +335,3 @@ def test_vlm_resume_from_checkpoint_matches_fresh_run(tmp_path):
             f"step {i}: fresh={a!r} resumed={b!r}\n"
             f"fresh={fresh_hist}\nresumed={resumed_hist}"
         )
-

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -918,7 +918,6 @@ def test_text_streaming_yields_without_sizing_indexing_or_preconsumption(use_hf)
 
     assert guarded.pulls == 2
     assert [row[:2] for row in batch[0].tolist()] == [[1, 11], [2, 12]]
-    assert batch[2] is None
 
 
 def test_raw_text_streaming_matches_sized_sequential_order():
@@ -950,10 +949,7 @@ def test_streaming_prompt_completion_and_assistant_labels():
         {"prompt": "4", "completion": " 5 6"},
     ]), batch_size=2))
     assert completion_batch[0].tolist() == [[1, 2, 3], [4, 5, 6]]
-    assert completion_batch[2].tolist() == [
-        [-100, -100, 3],
-        [-100, 5, 6],
-    ]
+    assert completion_batch[2].tolist() == [[-100, -100, 3], [-100, 5, 6]]
 
     assistant_batch = next(_streaming_text_batches(
         iter([{
@@ -1110,6 +1106,15 @@ def test_unsized_stream_rejects_randperm_before_consumption():
     with pytest.raises(ValueError, match="torch_randperm.*unsized"):
         next(_streaming_text_batches(rows(), dataset_order="torch_randperm"))
     assert pulls == 0
+
+    class SizedRows(torch.utils.data.Dataset):
+        rows = [{"text": "1 2"}, {"text": "3 4"}]
+        def __len__(self): return len(self.rows)
+        def __getitem__(self, index): return self.rows[index]
+
+    batch = next(_streaming_text_batches(SizedRows(), batch_size=2,
+        completion_only_loss=False, dataset_order="torch_randperm"))
+    assert sorted(row[0] for row in batch[0].tolist()) == [1, 3]
 
 
 def test_text_pretokenized_create_batches_preserves_input_ids():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -1131,8 +1131,11 @@ def test_trainer_drives_dynamic_lr_outside_optimizer_scheduler():
         if field.init and field.name not in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
     ]
     legacy_values = [getattr(MLXTrainingConfig(), field.name) for field in legacy_fields]
-    legacy_values[[field.name for field in legacy_fields].index("warmup_ratio")] = 0.1
-    legacy_values[-1] = (128, 256)
+    _legacy_names = [field.name for field in legacy_fields]
+    legacy_values[_legacy_names.index("warmup_ratio")] = 0.1
+    # image_size is an object field; set it by name (the optional-copy fields
+    # are the trailing suffix, so image_size is no longer the last legacy field).
+    legacy_values[_legacy_names.index("image_size")] = (128, 256)
     copied_ratio_trainer.args = MLXTrainingConfig(*legacy_values)
     assert copied_ratio_trainer.args.image_size == (128, 256)
     assert copied_ratio_trainer._resolve_warmup_steps(total_steps=100) == 10

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -920,6 +920,127 @@ def test_text_streaming_yields_without_sizing_indexing_or_preconsumption(use_hf)
     assert [row[:2] for row in batch[0].tolist()] == [[1, 11], [2, 12]]
 
 
+def test_streaming_trainer_exposes_lazy_prepared_iterable_view():
+    import inspect
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+    from unsloth_zoo.mlx.utils import iterate_training_batches
+
+    class Model:
+        _config = {}
+        def trainable_parameters(self): return {}
+
+    class Rows:
+        def __init__(self): self.pulls = 0
+        def __len__(self): raise AssertionError("must stay unsized")
+        def __getitem__(self, _index): raise AssertionError("must stay unindexed")
+        def take(self, _count): return [{"value": "raw"}]
+        def __iter__(self):
+            self.pulls += 1
+            yield {"value": 1}
+
+    rows = Rows()
+    trainer = MLXTrainer(
+        Model(), _streaming_text_tokenizer(), rows,
+        formatting_func=lambda row: {"text": f"{row['value']} 2"},
+        args=MLXTrainingConfig(
+            streaming=True, max_steps=1, completion_only_loss=False,
+            max_seq_length=8,
+        ),
+    )
+
+    assert rows.pulls == 0
+    assert not hasattr(trainer.train_dataset, "__len__")
+    assert not hasattr(trainer.train_dataset, "__getitem__")
+    assert not hasattr(trainer.train_dataset, "take")
+    assert next(iter(trainer.train_dataset)) == {"input_ids": [1, 2]}
+    assert rows.pulls == 1
+    parameters = list(inspect.signature(iterate_training_batches).parameters)
+    assert parameters.index("response_mask_fn") > parameters.index("require_replayable")
+
+
+def test_train_on_responses_only_masks_unsized_text_lazily():
+    from unsloth_zoo.mlx.trainer import (
+        MLXTrainer, MLXTrainingConfig, train_on_responses_only,
+    )
+
+    class Model:
+        _config = {}
+        def trainable_parameters(self): return {}
+
+    class Encoding:
+        def __init__(self, input_ids): self.input_ids = input_ids
+
+    class Tokenizer:
+        eos_token_id = None
+        pad_token_id = 0
+        def __init__(self, offset=0):
+            self.offset = offset
+            self.chat_template = None
+        def encode(self, text, add_special_tokens=True):
+            return [int(part) + self.offset for part in str(text).split()]
+        def __call__(self, text, **_kwargs):
+            return Encoding(self.encode(text, add_special_tokens=False))
+        def apply_chat_template(self, messages, tokenize=False, **_kwargs):
+            ids = []
+            for message in messages:
+                ids.append(20 if message["role"] == "assistant" else 10)
+                ids.extend(int(part) for part in message["content"].split())
+            return ids if tokenize else " ".join(str(token) for token in ids)
+
+    class Rows:
+        def __init__(self): self.pulls = 0
+        def __iter__(self):
+            values = (
+                "10 1",
+                "10 1 20 2 3",
+                "",
+                {"messages": [
+                    {"role": "user", "content": "4"},
+                    {"role": "assistant", "content": "5"},
+                ]},
+            )
+            for value in values:
+                self.pulls += 1
+                yield value if isinstance(value, dict) else {"text": value}
+
+    rows = Rows()
+    lazy_eval = Rows()
+    trainer = MLXTrainer(
+        Model(), Tokenizer(offset=100), rows,
+        eval_dataset={
+            "sized": [{"text": "10 6 20 7"}],
+            "lazy": lazy_eval,
+        },
+        args=MLXTrainingConfig(
+            streaming=True, max_steps=1, per_device_train_batch_size=1,
+            completion_only_loss=False, dataset_order="sequential",
+            max_seq_length=8, chat_template="{{ messages }}",
+        ),
+    )
+    train_on_responses_only(
+        trainer, instruction_part="10", response_part="20", force_match=True,
+        tokenizer=Tokenizer(),
+    )
+
+    assert rows.pulls == 0
+    prepared_rows = iter(trainer.train_dataset)
+    public_row = next(prepared_rows)
+    assert public_row == {
+        "input_ids": [10, 1, 20, 2, 3],
+        "labels": [-100, -100, -100, 2, 3],
+    }
+    assert rows.pulls == 2  # the fully masked first row is legitimately filtered
+    assert next(prepared_rows) == {
+        "input_ids": [10, 4, 20, 5],
+        "labels": [-100, -100, -100, 5],
+    }
+    assert rows.pulls == 4  # an empty labeled row is filtered, not schema drift
+    assert trainer._eval_batches_labeled is None
+    assert trainer.eval_dataset["sized"][0]["labels"] == [-100, -100, -100, 7]
+    assert lazy_eval.pulls == 0
+
+
 def test_raw_text_streaming_matches_sized_sequential_order():
     class ReplayableRows:
         def __init__(self, rows):
@@ -1014,6 +1135,55 @@ def test_text_streaming_rejects_incremental_schema_drift(rows, match):
 
     next(batches)
     with pytest.raises(ValueError, match=match):
+        next(batches)
+
+
+def test_response_masking_preserves_pretokenized_label_state_validation():
+    rows = iter([
+        {"input_ids": [1, 2], "labels": [-100, 2]},
+        {"input_ids": [3, 4]},
+    ])
+
+    def response_mask(batch):
+        return {
+            "labels": [[-100, input_ids[-1]] for input_ids in batch["input_ids"]]
+        }
+
+    batches = _streaming_text_batches(
+        rows,
+        completion_only_loss=False,
+        response_mask_fn=response_mask,
+    )
+    next(batches)
+    with pytest.raises(ValueError, match="must not be mixed"):
+        next(batches)
+
+
+def test_response_masking_does_not_replace_formatter_completion_boundary():
+    def response_mask(batch):
+        return {
+            "labels": [[-100, input_ids[-1]] for input_ids in batch["input_ids"]]
+        }
+
+    batches = _streaming_text_batches(
+        iter([{"prompt": "1", "completion": " 2"}]),
+        formatting_func=lambda _row: {"input_ids": [1, 2]},
+        response_mask_fn=response_mask,
+    )
+    with pytest.raises(ValueError, match="drops the completion boundary"):
+        next(batches)
+
+
+@pytest.mark.parametrize("formatted", [{"input_ids": [1, 2]}, {"text": "1 2"}])
+def test_fully_masked_response_still_validates_completion_boundary(formatted):
+    batches = _streaming_text_batches(
+        iter([{"prompt": "1", "completion": " 2"}]),
+        formatting_func=lambda _row: formatted,
+        response_mask_fn=lambda batch: {
+            "labels": [[-100] * len(ids) for ids in batch["input_ids"]]
+        },
+    )
+    with pytest.raises(ValueError, match="drops the completion boundary"):
         next(batches)
 
 
@@ -1348,6 +1518,43 @@ def test_train_on_responses_only_forwards_last_response_only(monkeypatch):
     )
 
     assert received["last_response_only"] is True
+
+
+def test_response_mask_closure_does_not_normalize_explicit_tokenizer(monkeypatch):
+    import unsloth_zoo.dataset_utils as dataset_utils
+    from unsloth_zoo.mlx.trainer import train_on_responses_only
+
+    class CallableTokenizer:
+        chat_template = None
+        def __call__(self, text, **kwargs):
+            return {"input_ids": [1, 2, 3]}
+
+    tokenizer = CallableTokenizer()
+    trainer = types.SimpleNamespace(
+        _is_vlm=False,
+        args=types.SimpleNamespace(
+            streaming=True,
+            chat_template="{{ messages }}",
+        ),
+        model=types.SimpleNamespace(_config={}),
+        tokenizer=tokenizer,
+        _train_dataset_for_batches=lambda: iter([{"text": "1 2"}]),
+    )
+    monkeypatch.setattr(
+        dataset_utils,
+        "train_on_responses_only",
+        lambda *args, **kwargs: (lambda batch: batch),
+    )
+
+    train_on_responses_only(
+        trainer,
+        instruction_part="<user>",
+        response_part="<assistant>",
+        tokenizer=tokenizer,
+        return_function=True,
+    )
+
+    assert tokenizer.chat_template is None
 
 
 def test_response_mask_tokenizer_rejects_encode_only_tokenizer():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -997,6 +997,121 @@ def test_pretokenized_streaming_preserves_supported_label_fields():
     assert masked[2].tolist() == [[-100, 5, 6]]
 
 
+@pytest.mark.parametrize(
+    ("rows", "match"),
+    [
+        ([{"text": "1 2"}, {"input_ids": [3, 4]}], "cannot be mixed"),
+        (
+            [
+                {"input_ids": [1, 2], "labels": [-100, 2]},
+                {"input_ids": [3, 4]},
+            ],
+            "must not be mixed",
+        ),
+    ],
+)
+def test_text_streaming_rejects_incremental_schema_drift(rows, match):
+    batches = _streaming_text_batches(
+        iter(rows),
+        completion_only_loss=False,
+    )
+
+    next(batches)
+    with pytest.raises(ValueError, match=match):
+        next(batches)
+
+
+def test_hf_stream_replays_in_source_order_and_sets_epoch():
+    from datasets import IterableDataset
+
+    source = IterableDataset.from_generator(
+        lambda: iter([{"text": "1"}, {"prompt": "2", "completion": " 3"}])
+    )
+    epochs = []
+    original_set_epoch = source.set_epoch
+
+    def record_epoch(epoch):
+        epochs.append(epoch)
+        original_set_epoch(epoch)
+
+    source.set_epoch = record_epoch
+    batches = _streaming_text_batches(source)
+    first = _streaming_batch_signature(next(batches))
+
+    assert first == ([[2, 3]], [[0, 2]], [[-100, 3]])
+    assert _streaming_batch_signature(next(batches)) == first
+    assert epochs == [0, 1]
+
+
+def test_one_shot_stream_exhaustion_and_resume_are_actionable():
+    batches = _streaming_text_batches(
+        iter([{"text": "1 2"}, {"text": "3 4"}]),
+        batch_size=2,
+        completion_only_loss=False,
+    )
+    next(batches)
+    with pytest.raises(RuntimeError, match="one-shot.*exhausted"):
+        next(batches)
+
+    MLXTrainer, trainer = _make_mlx_text_trainer(
+        max_steps=2,
+        streaming=True,
+        dataset_order="sequential",
+    )
+    trainer.train_dataset = iter([{"text": "1 2"}, {"text": "3 4"}])
+    trainer._resume_from_checkpoint = "checkpoint-1"
+    _, resumed = MLXTrainer._prepare_data(trainer, is_vlm=False)
+    with pytest.raises(RuntimeError, match="replayable iterable"):
+        next(resumed)
+
+
+def test_hf_stream_resume_fast_forward_matches_uninterrupted_order():
+    from datasets import IterableDataset
+
+    def make_trainer(resume=False):
+        MLXTrainer, trainer = _make_mlx_text_trainer(
+            max_steps=3,
+            streaming=True,
+            dataset_order="sequential",
+            per_device_train_batch_size=2,
+            gradient_accumulation_steps=2,
+        )
+        trainer.tokenizer = _streaming_text_tokenizer()
+        trainer.train_dataset = IterableDataset.from_generator(
+            lambda: (
+                {"text": f"{value} {value + 10}"}
+                for value in range(1, 6)
+            )
+        ).shuffle(seed=17, buffer_size=3)
+        trainer._resume_from_checkpoint = "checkpoint-2" if resume else None
+        return MLXTrainer, trainer
+
+    MLXTrainer, uninterrupted = make_trainer()
+    _, batches = MLXTrainer._prepare_data(uninterrupted, is_vlm=False)
+    expected = [next(batches) for _ in range(5)][-1]
+
+    MLXTrainer, resumed = make_trainer(resume=True)
+    _, batches = MLXTrainer._prepare_data(resumed, is_vlm=False)
+    for _ in range(4):
+        next(batches)
+    actual = next(batches)
+
+    assert _streaming_batch_signature(actual) == _streaming_batch_signature(expected)
+
+
+def test_unsized_stream_rejects_randperm_before_consumption():
+    pulls = 0
+
+    def rows():
+        nonlocal pulls
+        pulls += 1
+        yield {"text": "1 2"}
+
+    with pytest.raises(ValueError, match="torch_randperm.*unsized"):
+        next(_streaming_text_batches(rows(), dataset_order="torch_randperm"))
+    assert pulls == 0
+
+
 def test_text_pretokenized_create_batches_preserves_input_ids():
     from unsloth_zoo.mlx.utils import create_batches
 

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -1066,49 +1066,6 @@ def test_train_on_responses_only_masks_unsized_text_lazily():
     assert trainer.eval_dataset["sized"][0]["labels"] == [-100, -100, -100, 7]
     assert lazy_eval.pulls == 0
 
-
-def test_lazy_text_eval_restarts_masks_splits_and_bounds_infinite_sources():
-    MLXTrainer, trainer = _streaming_text_trainer(
-        max_steps=1, completion_only_loss=False,
-        per_device_eval_batch_size=1,
-    )
-    trainer._mlx_response_mask_fn = lambda batch: {
-        "labels": [[-100] + ids[1:] for ids in batch["input_ids"]]
-    }
-    source = _CountingTextRows([{"text": "1 2"}, {"text": "3 4"}])
-    batches = MLXTrainer._create_text_eval_batches(trainer, source, 1, False, False)
-    first = [_streaming_batch_signature(batch) for batch in batches]
-    assert [_streaming_batch_signature(batch) for batch in batches] == first
-    assert first[0][2] == [[-100, 2]]
-
-    infinite = _CountingTextRows([{"text": "1 2"}], infinite=True)
-    unbounded = MLXTrainer._create_text_eval_batches(
-        trainer, infinite, 1, False, False,
-    )
-    with pytest.raises(ValueError, match="infinite.*max_eval_batches"):
-        next(iter(unbounded))
-    assert infinite.pulls == 0
-
-    trainer.args.max_eval_batches = 1
-    bounded = MLXTrainer._create_text_eval_batches(
-        trainer, infinite, 1, False, False,
-    )
-    assert len(list(bounded)) == infinite.pulls == 1
-
-    from datasets import IterableDataset, concatenate_datasets, interleave_datasets
-    base = IterableDataset.from_generator(lambda: iter([{"text": "1 2"}]))
-    from unsloth_zoo.mlx.trainer import _mlx_stream_declares_infinite
-    assert (_mlx_stream_declares_infinite(base.repeat(None).take(3)),
-            _mlx_stream_declares_infinite(base.take(3).repeat(None))) == (False, True)
-    assert _mlx_stream_declares_infinite(concatenate_datasets([base.take(1), base.repeat(None)]))
-    assert _mlx_stream_declares_infinite(concatenate_datasets([base.take(1), base.rename_column("text", "other").repeat(None)], axis=1))
-    assert _mlx_stream_declares_infinite(interleave_datasets(
-        [base.take(1), base.repeat(None)], stopping_strategy="all_exhausted"))
-    assert _mlx_stream_declares_infinite(interleave_datasets(
-        [base.repeat(None)] * 2, stopping_strategy="first_exhausted"))
-    assert _mlx_stream_declares_infinite(interleave_datasets(
-        [base.take(1)] * 2, probabilities=[1.0, 0.0], stopping_strategy="all_exhausted"))
-
 def test_sized_response_training_defers_lazy_eval_with_override_tokenizer():
     from unsloth_zoo.mlx.trainer import (
         MLXTrainer, MLXTrainingConfig, train_on_responses_only,
@@ -1155,95 +1112,6 @@ def test_length_declaring_text_stream_supports_epoch_replay():
     signatures = [_streaming_batch_signature(next(iterator)) for _ in range(4)]
     assert signatures[3] == signatures[0]
     assert trainer.train_dataset.epochs == [0, 1]
-
-
-def test_epoch_stream_rejects_ambiguous_or_inexact_cardinality_lazily():
-    MLXTrainer, trainer = _streaming_text_trainer(
-        max_steps=0, num_train_epochs=1,
-        completion_only_loss=False, per_device_train_batch_size=2,
-        gradient_accumulation_steps=1,
-    )
-    trainer.train_dataset = _DeclaredTextRows([{"text": "1 2"}])
-    trainer.formatting_func = lambda row: row
-    _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
-    assert _streaming_batch_signature(next(iterator))[0][0][:2] == [1, 2]
-
-    trainer.args.per_device_train_batch_size = 1
-    trainer.train_dataset = _DeclaredTextRows([
-        {"text": "1 2"}, {"text": "3 4"},
-    ])
-    trainer.formatting_func = lambda row: [row, row]
-    _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
-    with pytest.raises(ValueError, match="exactly one trainable"):
-        next(iterator)
-
-    trainer.args.per_device_train_batch_size = 2
-    trainer.formatting_func = None
-    trainer.train_dataset = _DeclaredTextRows([{"text": "1 2"}, {"text": ""}])
-    _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
-    with pytest.raises(ValueError, match="exactly one trainable"):
-        next(iterator)
-
-    class UnderDeclared(_DeclaredTextRows):
-        def __len__(self): return 2
-        def __iter__(self):
-            for row in ({"text": "1 2"}, {"text": "3 4"}, {"text": ""}):
-                self.pulls += 1
-                yield row
-            raise AssertionError("must reject the first overflow row")
-    trainer.train_dataset = UnderDeclared([
-        {"text": "unused"},
-    ])
-    _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
-    with pytest.raises(ValueError, match="exactly one trainable"):
-        next(iterator)
-    assert trainer.train_dataset.pulls == 3
-
-    trainer.args.gradient_accumulation_steps = 2
-    trainer.args.num_train_epochs = 2
-    trainer.train_dataset = _DeclaredTextRows([
-        {"text": "1 2"}, {"text": "3 4"}, {"text": "5 6"},
-        {"text": "7 8"}, {"text": "9 10"},
-    ])
-    with pytest.raises(ValueError, match="divisible.*gradient_accumulation"):
-        MLXTrainer._prepare_data(trainer, is_vlm=False)
-    assert trainer.train_dataset.pulls == 0
-
-
-def test_epoch_stream_allows_one_to_one_labeled_preparation():
-    def prepare(rows, *, tokenizer=None, response_mask_fn=None, **kwargs):
-        MLXTrainer, trainer = _streaming_text_trainer(
-            max_steps=0, num_train_epochs=1,
-            per_device_train_batch_size=1, gradient_accumulation_steps=1,
-            **kwargs,
-        )
-        trainer.train_dataset = _DeclaredTextRows(rows)
-        if tokenizer is not None:
-            trainer.tokenizer = tokenizer
-        trainer._mlx_response_mask_fn = response_mask_fn
-        _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
-        return next(iterator)
-
-    completion = prepare(
-        [{"prompt": "1 2", "completion": " 3"}],
-        completion_only_loss=True,
-    )
-    assistant_rows = [{"messages": [{"role": "user", "content": "4"}, {"role": "assistant", "content": "5"}]}]
-    assistant = prepare(
-        assistant_rows,
-        tokenizer=_AssistantMaskTokenizer(), completion_only_loss=False,
-        assistant_only_loss=True,
-    )
-    response = prepare(
-        [{"text": "6 7"}], completion_only_loss=False,
-        response_mask_fn=lambda batch: {
-            "labels": [[-100] + ids[1:] for ids in batch["input_ids"]]
-        },
-    )
-
-    assert completion[2].tolist() == [[-100, -100, 3]]
-    assert assistant[2].tolist() == [[-100, -100, -100, 5]]
-    assert response[2].tolist() == [[-100, 7]]
 
 
 def test_raw_text_streaming_matches_sized_sequential_order():
@@ -1389,40 +1257,6 @@ def test_one_shot_stream_exhaustion_and_resume_are_actionable():
     with pytest.raises(RuntimeError, match="replayable iterable"):
         next(iter(eval_batches))
     assert next(source) == {"text": "1 2"}
-
-
-def test_hf_stream_resume_fast_forward_matches_uninterrupted_order():
-    from datasets import IterableDataset
-
-    def make_trainer(resume=False):
-        MLXTrainer, trainer = _make_mlx_text_trainer(
-            max_steps=3,
-            streaming=True,
-            dataset_order="sequential",
-            per_device_train_batch_size=2,
-            gradient_accumulation_steps=2,
-        )
-        trainer.tokenizer = _streaming_text_tokenizer()
-        trainer.train_dataset = IterableDataset.from_generator(
-            lambda: (
-                {"text": f"{value} {value + 10}"}
-                for value in range(1, 6)
-            )
-        ).shuffle(seed=17, buffer_size=3)
-        trainer._resume_from_checkpoint = "checkpoint-2" if resume else None
-        return MLXTrainer, trainer
-
-    MLXTrainer, uninterrupted = make_trainer()
-    _, batches = MLXTrainer._prepare_data(uninterrupted, is_vlm=False)
-    expected = [next(batches) for _ in range(5)][-1]
-
-    MLXTrainer, resumed = make_trainer(resume=True)
-    _, batches = MLXTrainer._prepare_data(resumed, is_vlm=False)
-    for _ in range(4):
-        next(batches)
-    actual = next(batches)
-
-    assert _streaming_batch_signature(actual) == _streaming_batch_signature(expected)
 
 
 def test_unsized_stream_rejects_randperm_before_consumption():
@@ -2522,42 +2356,41 @@ def test_quantized_linear_forward():
     torch.testing.assert_close(out, torch.tensor([[28.0, 28.0]]))
 
 
-def _window_rows(lengths):
-    # Row index rides in the first token so batch order is observable.
-    return [
-        " ".join([str(100 + idx)] + ["7"] * (length - 1))
-        for idx, length in enumerate(lengths)
-    ]
-
-
 def _first_tokens(stream, count):
     return [[row[0] for row in batch.tolist()]
             for batch, _l, _lab in (next(stream) for _ in range(count))]
 
 
-def _window_batches(rows, *, window, order="default", repeat=False, seed=3407,
-                    max_batches=None, source=None):
+def _window_rows(lengths):
+    # Row index rides in the first token so batch order is observable.
+    return [" ".join([str(100 + idx)] + ["7"] * (n - 1)) for idx, n in enumerate(lengths)]
+
+
+def _window_stream(rows, *, window, order="default", repeat=False, seed=3407,
+                   source=None, **kwargs):
     from unsloth_zoo.mlx.utils import iterate_training_batches
-    stream = iterate_training_batches(
+    return iterate_training_batches(
         dataset=_CountingTextRows(rows) if source is None else source,
         tokenizer=_streaming_text_tokenizer(), batch_size=2, max_seq_length=64,
         seed=seed, dataset_order=order, repeat=repeat,
-        length_window_batches=window,
+        length_window_batches=window, **kwargs,
     )
+
+
+def _window_batches(rows, *, max_batches=None, **kwargs):
     out = []
-    for batch, _lengths, _labels in stream:
+    for batch, _l, _lab in _window_stream(rows, **kwargs):
         out.append(([row[0] for row in batch.tolist()], batch.shape[1]))
         if max_batches is not None and len(out) >= max_batches:
-            return out
+            break
     return out
 
 
 _WINDOW_LENGTHS = (40, 3, 44, 4, 2, 46, 3, 41)
 
 
-def test_streaming_window_identity_grouping_and_ddp_slice():
-    rows = _window_rows(_WINDOW_LENGTHS)
-    arrival = [[100, 101], [102, 103], [104, 105], [106, 107]]
+def test_streaming_window_identity_grouping_padding_gate_and_ddp_slice():
+    rows, arrival = _window_rows(_WINDOW_LENGTHS), [[100, 101], [102, 103], [104, 105], [106, 107]]
     assert [ids for ids, _ in _window_batches(rows, window=1)] == arrival
     assert [ids for ids, _ in _window_batches(rows, window=8, order="sequential")] == arrival
 
@@ -2567,122 +2400,81 @@ def test_streaming_window_identity_grouping_and_ddp_slice():
     from unsloth_zoo.mlx.utils import _iterate_lazy_text_training_batches
     ddp = _iterate_lazy_text_training_batches(
         _CountingTextRows(rows), _streaming_text_tokenizer(), 1, 64,
-        comm_group=FakeWorld(), repeat=False, length_window_batches=1,
-    )
+        comm_group=FakeWorld(), repeat=False, length_window_batches=1)
     assert _first_tokens(ddp, 4) == [[101], [103], [105], [107]]
 
-    grouped = _window_batches(rows, window=4)
-    baseline = _window_batches(rows, window=1)
+    grouped, baseline = _window_batches(rows, window=4), _window_batches(rows, window=1)
     assert sorted(t for ids, _ in grouped for t in ids) == [100 + i for i in range(8)]
     assert sum(w for _, w in grouped) < sum(w for _, w in baseline)
-    assert grouped == _window_batches(rows, window=4)  # deterministic
-    assert [ids for ids, _ in grouped] != arrival      # grouping engaged
-    assert [ids for ids, _ in _window_batches(rows, window=4, seed=1)] != \
-        [ids for ids, _ in grouped]  # seed reaches the permutation
+    assert grouped == _window_batches(rows, window=4) != baseline
+    assert [ids for ids, _ in _window_batches(rows, window=4, seed=1)] != [ids for ids, _ in grouped]
 
-    # Single-process windowed slicing must see an EMPTY pad_source: cycle
-    # padding is gated to multi-rank runs (retention stays within the window).
+    # Single-process windowed slicing must see an EMPTY pad_source (cycle
+    # padding is multi-rank-only) and leave the partial tail short.
     from unsloth_zoo.mlx import utils as mlx_utils
-    odd = _window_rows(_WINDOW_LENGTHS[:7])
-    seen_pads = []
+    odd, seen_pads = _window_rows(_WINDOW_LENGTHS[:7]), []
     original = mlx_utils._rank_slice_distributed_batch
-    def spy(items, local_batch_size, comm_group=None, pad_source=None, pad_mode="cycle"):
+    def spy(items, n, comm_group=None, pad_source=None, pad_mode="cycle"):
         seen_pads.append([] if not pad_source else list(pad_source))
-        return original(items, local_batch_size, comm_group=comm_group,
-                        pad_source=pad_source, pad_mode=pad_mode)
+        return original(items, n, comm_group=comm_group, pad_source=pad_source, pad_mode=pad_mode)
     mlx_utils._rank_slice_distributed_batch = spy
     try:
         tail = _window_batches(odd, window=3)[-1]
     finally:
         mlx_utils._rank_slice_distributed_batch = original
-    assert len(tail[0]) == 1
-    assert seen_pads and all(pads == [] for pads in seen_pads)
+    assert len(tail[0]) == 1 and seen_pads and all(p == [] for p in seen_pads)
 
 
-def test_streaming_window_epoch_replay_oneshot_and_knob_validation():
+def test_streaming_window_epochs_cardinality_oneshot_and_knob():
     odd_rows = _window_rows(_WINDOW_LENGTHS[:7])  # 7 rows -> 4 batches/pass
     source = _DeclaredTextRows(odd_rows)
-    crossing = _window_batches(odd_rows, window=3, repeat=True, source=source,
-                               max_batches=6)  # crosses the epoch boundary
+    crossing = _window_batches(odd_rows, window=3, repeat=True, source=source, max_batches=6)
     assert source.epochs[:2] == [0, 1]
-    assert (sorted(t for ids, _ in crossing[:4] for t in ids)
-            == [100 + i for i in range(7)])
-    fresh = _window_batches(odd_rows, window=3, repeat=True, max_batches=6)
-    assert fresh == crossing  # deterministic reconstruction across the boundary
-    assert [ids for ids, _ in crossing[4:6]] != [ids for ids, _ in crossing[:2]]
-    # ^ epoch index reaches the permutation seed (pass-2 order differs)
+    assert sorted(t for ids, _ in crossing[:4] for t in ids) == [100 + i for i in range(7)]
+    assert _window_batches(odd_rows, window=3, repeat=True, max_batches=6) == crossing
+    assert [ids for ids, _ in crossing[4:6]] != [ids for ids, _ in crossing[:2]]  # epoch reaches seed
 
-    # Resume-style fast-forward: a fresh iterator skipped past the boundary
-    # continues exactly where the uninterrupted run would.
-    from unsloth_zoo.mlx.utils import iterate_training_batches
-    skipped = iterate_training_batches(
-        dataset=_CountingTextRows(odd_rows), tokenizer=_streaming_text_tokenizer(),
-        batch_size=2, max_seq_length=64, seed=3407, dataset_order="default",
-        repeat=True, require_replayable=True, length_window_batches=3,
-    )
+    skipped = _window_stream(odd_rows, window=3, repeat=True, require_replayable=True)
     for _ in range(5):
         next(skipped)
-    assert _first_tokens(skipped, 1) == [crossing[5][0]]
+    assert _first_tokens(skipped, 1) == [crossing[5][0]]  # resume fast-forward
 
-    # Declared-cardinality epochs with W>1: the final buffered window flushes
-    # only after per-pass validation; a declared-length mismatch raises before
-    # the buffered final batches are emitted.
     from unsloth_zoo.mlx.utils import _iterate_lazy_text_training_batches
-    exact = _iterate_lazy_text_training_batches(
-        _DeclaredTextRows(odd_rows), _streaming_text_tokenizer(), 2, 64,
-        repeat=True, length_window_batches=3, window_seed=3407,
-        expected_rows_per_pass=7,
-    )
-    two_passes = _first_tokens(exact, 8)
+    def exact_stream(expected):
+        return _iterate_lazy_text_training_batches(
+            _DeclaredTextRows(odd_rows), _streaming_text_tokenizer(), 2, 64,
+            repeat=True, length_window_batches=3, window_seed=3407,
+            expected_rows_per_pass=expected)
+    two_passes = _first_tokens(exact_stream(7), 8)
     assert sorted(t for ids in two_passes[:4] for t in ids) == [100 + i for i in range(7)]
-    mismatched = _iterate_lazy_text_training_batches(
-        _DeclaredTextRows(odd_rows), _streaming_text_tokenizer(), 2, 64,
-        repeat=True, length_window_batches=3, window_seed=3407,
-        expected_rows_per_pass=8,
-    )
     emitted = []
     with pytest.raises(ValueError, match="declared length"):
-        while True:
-            emitted.append(next(mismatched))
-    assert len(emitted) < 4  # buffered final window withheld on mismatch
+        for batch in exact_stream(6):
+            emitted.append(batch)
+    assert len(emitted) < 4  # buffered final window withheld on overrun
 
-    one_shot = iterate_training_batches(
-        dataset=iter(list(_CountingTextRows(odd_rows))),
-        tokenizer=_streaming_text_tokenizer(), batch_size=2, max_seq_length=64,
-        dataset_order="default", repeat=True, length_window_batches=3,
-    )
+    one_shot = _window_stream(odd_rows, window=3, repeat=True,
+                              source=iter(list(_CountingTextRows(odd_rows))))
     for _ in range(4):
         next(one_shot)
     with pytest.raises(RuntimeError, match="one-shot"):
         next(one_shot)
 
-    none_seed = iterate_training_batches(
-        dataset=_CountingTextRows(odd_rows), tokenizer=_streaming_text_tokenizer(),
-        batch_size=2, max_seq_length=64, seed=None, dataset_order="default",
-        repeat=False, length_window_batches=4,
-    )
-    assert next(iter(none_seed))[0].shape[0] == 2  # seed=None normalizes
+    assert next(iter(_window_stream(odd_rows, window=4, seed=None)))[0].shape[0] == 2
 
     for bad in (True, False, 0, -2, 2.0, "4"):
         probe = _CountingTextRows(_window_rows((3, 2)))
-        gen = iterate_training_batches(
-            dataset=probe, tokenizer=_streaming_text_tokenizer(), batch_size=2,
-            max_seq_length=64, dataset_order="default", repeat=False,
-            length_window_batches=bad,
-        )
         with pytest.raises(ValueError, match="streaming_text_length_window"):
-            next(iter(gen))
+            next(iter(_window_stream([], window=bad, source=probe)))
         assert probe.pulls == 0
 
 
-def test_trainer_prepare_data_routes_window_and_preserve_order():
-    rows = _window_rows(_WINDOW_LENGTHS)
-    arrival = [[100, 101], [102, 103], [104, 105], [106, 107]]
+def test_streaming_window_trainer_routing_and_config_copy():
+    rows, arrival = _window_rows(_WINDOW_LENGTHS), [[100, 101], [102, 103], [104, 105], [106, 107]]
 
     def prepared(**config_kwargs):
-        _MLXTrainer, trainer = _streaming_text_trainer(
-            per_device_train_batch_size=2, max_seq_length=64, **config_kwargs,
-        )
+        _T, trainer = _streaming_text_trainer(
+            per_device_train_batch_size=2, max_seq_length=64, **config_kwargs)
         trainer.train_dataset = _CountingTextRows(rows)
         _batches, stream = trainer._prepare_data(is_vlm=False)
         return _first_tokens(stream, 4)
@@ -2693,29 +2485,22 @@ def test_trainer_prepare_data_routes_window_and_preserve_order():
     assert prepared(streaming_text_length_window_batches=4,
                     preserve_dataset_order=True) == arrival
 
-    _MLXTrainer, bad_trainer = _streaming_text_trainer(
+    _T, bad_trainer = _streaming_text_trainer(
         per_device_train_batch_size=2, max_seq_length=64,
-        streaming_text_length_window_batches=0,
-    )
+        streaming_text_length_window_batches=0)
     probe = _DeclaredTextRows(rows)
     bad_trainer.train_dataset = probe
     with pytest.raises(ValueError, match="streaming_text_length_window"):
         bad_trainer._prepare_data(is_vlm=False)
     assert probe.pulls == 0 and probe.epochs == []
 
-
-def test_config_copy_tolerates_missing_suffix_fields():
     from unsloth_zoo.mlx.trainer import MLXTrainingConfig
     base = MLXTrainingConfig(warmup_ratio=0.25)
-    for omitted in (
-        ("streaming_text_length_window_batches",),
-        ("streaming_text_length_window_batches", "max_eval_batches"),
-    ):
-        copied = {
-            field.name: getattr(base, field.name)
-            for field in dataclasses.fields(MLXTrainingConfig)
-            if field.init and field.name not in omitted
-        }
+    for omitted in (("streaming_text_length_window_batches",),
+                    ("streaming_text_length_window_batches", "max_eval_batches")):
+        copied = {f.name: getattr(base, f.name)
+                  for f in dataclasses.fields(MLXTrainingConfig)
+                  if f.init and f.name not in omitted}
         clone = MLXTrainingConfig(**copied)
         assert clone.streaming_text_length_window_batches == 8
         assert clone._unsloth_mlx_warmup_steps_explicit is False

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2570,3 +2570,123 @@ def test_host_staging_seam_parity_and_host_valued_flag():
            "chat_template_kwargs": {"state": "CA", "_unsloth_state": "USER"}}
     assert _tokenize_mlx_prompt_completion_row(TemplateTok(), row) is not None
     assert seen_kwargs.get("state") == "CA" and seen_kwargs.get("_unsloth_state") == "USER"
+
+
+def test_streaming_prefetch_identity_laziness_and_knob():
+    rows = _window_rows(_WINDOW_LENGTHS)
+    sync = _window_batches(rows, window=4)
+    prefetched = _window_batches(rows, window=4, prefetch_batches=2)
+    assert prefetched == sync  # bit-for-bit consumer-visible sequence
+
+    probe = _CountingTextRows(rows)
+    from unsloth_zoo.mlx.utils import iterate_training_batches
+    stream = iterate_training_batches(
+        dataset=probe, tokenizer=_streaming_text_tokenizer(), batch_size=2,
+        max_seq_length=64, seed=3407, dataset_order="default", repeat=False,
+        length_window_batches=4, prefetch_batches=2)
+    assert probe.pulls == 0  # construction-lazy at P>0
+    first = next(iter(stream))
+    assert first[0].shape[0] == 2 and probe.pulls >= 2
+
+    for bad in (True, -1, 1.5):
+        with pytest.raises(ValueError, match="streaming_prefetch_batches"):
+            next(iter(_window_stream(rows, window=1, prefetch_batches=bad)))
+
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig, _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+    assert "streaming_prefetch_batches" in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+    assert MLXTrainingConfig().streaming_prefetch_batches == 0  # default OFF
+
+    # Producer-side resume skip parity: first batch equals the sync sequence
+    # at the skip offset (single skip authority — no double fast-forward).
+    sync_all = _window_batches(rows, window=4)
+    skipped = _window_stream(rows, window=4, prefetch_batches=2,
+                             prefetch_skip_batches=2)
+    first_after_skip = [row[0] for row in next(iter(skipped))[0].tolist()]
+    assert first_after_skip == sync_all[2][0]
+
+    # Trainer records prefetch eligibility synchronously (guards its own
+    # legacy fast-forward) and the orphan gate survives exceptional teardown.
+    _T, trainer = _streaming_text_trainer(
+        per_device_train_batch_size=2, max_seq_length=64,
+        streaming_prefetch_batches=2)
+    trainer.train_dataset = _CountingTextRows(rows)
+    _b, _stream = trainer._prepare_data(is_vlm=False)
+    assert trainer._mlx_prefetch_control.get("eligible") is True
+
+    class FakeOrphan:
+        def close(self): pass
+        def orphan_alive(self): return True
+    trainer._mlx_prefetch_control = {"prefetcher": FakeOrphan()}
+    trainer._active_batch_iter = None
+    trainer._close_active_batch_iterator()  # exceptional-teardown path
+    assert trainer._mlx_prefetch_orphan.orphan_alive()
+
+
+def test_prefetcher_lifecycle_quiescence_orphan_and_positioned_error():
+    import threading
+    import time
+    from unsloth_zoo.mlx import utils as mlx_utils
+    from unsloth_zoo.mlx.utils import _LazyTextPrefetcher
+
+    tok = _streaming_text_tokenizer()
+
+    def staged(rows, **kwargs):
+        return lambda: mlx_utils._iterate_lazy_text_training_batches(
+            _CountingTextRows(rows), tok, 1, 64, repeat=False,
+            yield_host_staged=True, **kwargs)
+
+    # Quiesce/resume mid-stream, then clean terminal close (no orphan).
+    pf = _LazyTextPrefetcher(staged(["1 2", "3 4", "5 6"]), depth=1)
+    next(pf)
+    pf.quiesce()
+    pf.resume()
+    next(pf)
+    assert pf.close() and not pf.orphan_alive()
+
+    # A blocked source orphans within the bounded join and gates trainer reuse.
+    gate, entered = threading.Event(), threading.Event()
+    class Blocked:
+        def __iter__(self):
+            def _gen():
+                entered.set()
+                gate.wait()
+                yield {"text": "1 2"}
+            return _gen()
+    stuck = _LazyTextPrefetcher(
+        lambda: mlx_utils._iterate_lazy_text_training_batches(
+            Blocked(), tok, 1, 64, repeat=False, yield_host_staged=True),
+        depth=1)
+    stuck._JOIN_TIMEOUT = 0.2
+    try:
+        stuck._ensure_started()
+        assert entered.wait(timeout=2.0)  # deterministically inside the pull
+        assert not stuck.close() and stuck.orphan_alive()
+        from unsloth_zoo.mlx.trainer import MLXTrainer
+        trainer = MLXTrainer.__new__(MLXTrainer)
+        trainer._mlx_prefetch_orphan = stuck
+        trainer._mlx_prefetch_control = {}
+        with pytest.raises(RuntimeError, match="refusing to serialize"):
+            trainer._quiesce_prefetcher_for_save()
+    finally:
+        gate.set()
+        assert stuck._done.wait(timeout=2.0)
+        stuck._thread.join(timeout=2.0)
+        assert not stuck._thread.is_alive()  # no daemon leak beyond the test
+
+    # Producer exceptions arrive positioned after prior good batches.
+    class Exploding(_StreamingTextTokenizer):
+        def __init__(self): super().__init__(); self.count = 0
+        def encode(self, text, add_special_tokens=True):
+            self.count += 1
+            if self.count > 2:
+                raise RuntimeError("late tokenizer failure")
+            return super().encode(text, add_special_tokens)
+    boom = _LazyTextPrefetcher(
+        lambda: mlx_utils._iterate_lazy_text_training_batches(
+            _CountingTextRows(["1 2", "3 4", "5 6"]), Exploding(), 1, 64,
+            repeat=False, yield_host_staged=True),
+        depth=2)
+    assert next(boom) is not None and next(boom) is not None
+    with pytest.raises(RuntimeError, match="late tokenizer failure"):
+        next(boom)
+    boom.close()

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2693,8 +2693,6 @@ def test_prefetcher_lifecycle_quiescence_orphan_and_positioned_error():
 
 
 def test_lazy_text_producer_rejects_mlx_valued_rows_before_parsing():
-    """Raw rows / formatter results carrying MLX values reject actionably
-    before any truthiness probe or parsing can evaluate them off-thread."""
     import mlx.core as mx
 
     from unsloth_zoo.mlx.utils import _iterate_lazy_text_training_batches
@@ -2718,8 +2716,7 @@ def test_max_eval_batches_rejects_non_integer_values():
     trainer = MLXTrainer(
         _MinimalTextModel(), _streaming_text_tokenizer(),
         _CountingTextRows(({"text": "10 1"},)),
-        args=MLXTrainingConfig(streaming=True, max_steps=1, max_seq_length=8),
-    )
+        args=MLXTrainingConfig(streaming=True, max_steps=1, max_seq_length=8))
     for bad in (True, 1.9, 0, "2"):
         trainer.args.max_eval_batches = bad
         with pytest.raises(ValueError, match="max_eval_batches"):
@@ -2740,3 +2737,12 @@ def test_distributed_failure_reraises_interrupts_unwrapped():
     with pytest.raises(RuntimeError, match="failed during save"):
         trainer._raise_distributed_failure_from_any(True, "save", ValueError("x"))
     assert trainer.stop_requested
+
+
+def test_lazy_text_mixed_plain_and_prompt_completion_rejects_any_order():
+    from unsloth_zoo.mlx.utils import _iterate_lazy_text_training_batches
+    rows = [{"text": "10 1"}, {"prompt": "10", "completion": " 1 2"}]
+    for ordering in (rows, rows[::-1]):
+        with pytest.raises(ValueError, match="mixed|requires prompt"):
+            list(_iterate_lazy_text_training_batches(
+                iter(list(ordering)), _StreamingTextTokenizer(), 1, 8, repeat=False))

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2614,6 +2614,7 @@ def test_streaming_prefetch_identity_laziness_and_knob():
     assert trainer._mlx_prefetch_control.get("eligible") is True
 
     class FakeOrphan:
+        orphaned = True
         def close(self): pass
         def orphan_alive(self): return True
     trainer._mlx_prefetch_control = {"prefetcher": FakeOrphan()}

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -1105,12 +1105,6 @@ def test_lazy_text_eval_restarts_masks_splits_and_bounds_infinite_sources():
     assert _mlx_stream_declares_infinite(interleave_datasets(
         [base.take(1)] * 2, probabilities=[1.0, 0.0], stopping_strategy="all_exhausted"))
 
-    trainer._distributed_world = types.SimpleNamespace(rank=lambda: 1, size=lambda: 2)
-    padded = list(trainer._create_text_eval_batches(
-        _CountingTextRows([{"text": "7 8"}]), 1, False, False))[0]
-    assert (padded[1].tolist(), padded[2].tolist()) == ([[0, 0]], [[-100, -100]])
-
-
 def test_sized_response_training_defers_lazy_eval_with_override_tokenizer():
     from unsloth_zoo.mlx.trainer import (
         MLXTrainer, MLXTrainingConfig, train_on_responses_only,

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -989,10 +989,13 @@ def test_streaming_trainer_exposes_lazy_prepared_iterable_view():
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
 
     class Rows:
-        def __init__(self): self.pulls = 0
+        def __init__(self):
+            self.pulls = 0; self.features = {"value": "int64"}; self.column_names = ["value"]; self.split = "train"; self.restored = []
         def __len__(self): raise AssertionError("must stay unsized")
         def __getitem__(self, _index): raise AssertionError("must stay unindexed")
         def take(self, _count): return [{"value": "raw"}]
+        def state_dict(self): return {"pulls": self.pulls}
+        def load_state_dict(self, state): self.restored.append(state)
         def __iter__(self):
             self.pulls += 1
             yield {"value": 1}
@@ -1011,7 +1014,13 @@ def test_streaming_trainer_exposes_lazy_prepared_iterable_view():
     assert not hasattr(trainer.train_dataset, "__len__")
     assert not hasattr(trainer.train_dataset, "__getitem__")
     assert not hasattr(trainer.train_dataset, "take")
-    assert next(iter(trainer.train_dataset)) == {"input_ids": [1, 2]}
+    assert not hasattr(trainer.train_dataset, "state_dict")
+    assert not hasattr(trainer.train_dataset, "load_state_dict")
+    assert not hasattr(trainer.train_dataset, "features")
+    assert not hasattr(trainer.train_dataset, "column_names")
+    assert trainer.train_dataset.split == "train"
+    assert rows.restored == []
+    assert next(iter(trainer.train_dataset)) == {"value": 1, "input_ids": [1, 2]}
     assert rows.pulls == 1
 
 
@@ -1050,15 +1059,9 @@ def test_train_on_responses_only_masks_unsized_text_lazily():
     assert rows.pulls == 0
     prepared_rows = iter(trainer.train_dataset)
     public_row = next(prepared_rows)
-    assert public_row == {
-        "input_ids": [10, 1, 20, 2, 3],
-        "labels": [-100, -100, -100, 2, 3],
-    }
+    assert public_row == source_rows[1] | {"input_ids": [10, 1, 20, 2, 3], "labels": [-100, -100, -100, 2, 3]}
     assert rows.pulls == 2  # the fully masked first row is legitimately filtered
-    assert next(prepared_rows) == {
-        "input_ids": [10, 4, 20, 5],
-        "labels": [-100, -100, -100, 5],
-    }
+    assert next(prepared_rows) == source_rows[2] | {"input_ids": [10, 4, 20, 5], "labels": [-100, -100, -100, 5]}
     assert trainer.eval_dataset["sized"][0]["labels"] == [-100, -100, -100, 7]
     assert lazy_eval.pulls == 0
 
@@ -1161,14 +1164,23 @@ def test_epoch_stream_rejects_ambiguous_or_inexact_cardinality_lazily():
     )
     trainer.train_dataset = _DeclaredTextRows([{"text": "1 2"}])
     trainer.formatting_func = lambda row: row
-    with pytest.raises(ValueError, match="formatting_func.*max_steps"):
-        MLXTrainer._prepare_data(trainer, is_vlm=False)
-    assert trainer.train_dataset.pulls == 0
+    _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
+    assert _streaming_batch_signature(next(iterator))[0][0][:2] == [1, 2]
 
+    trainer.args.per_device_train_batch_size = 1
+    trainer.train_dataset = _DeclaredTextRows([
+        {"text": "1 2"}, {"text": "3 4"},
+    ])
+    trainer.formatting_func = lambda row: [row, row]
+    _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
+    with pytest.raises(ValueError, match="exactly one trainable"):
+        next(iterator)
+
+    trainer.args.per_device_train_batch_size = 2
     trainer.formatting_func = None
     trainer.train_dataset = _DeclaredTextRows([{"text": "1 2"}, {"text": ""}])
     _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
-    with pytest.raises(ValueError, match="declared length"):
+    with pytest.raises(ValueError, match="exactly one trainable"):
         next(iterator)
 
     class UnderDeclared(_DeclaredTextRows):
@@ -1195,6 +1207,42 @@ def test_epoch_stream_rejects_ambiguous_or_inexact_cardinality_lazily():
     with pytest.raises(ValueError, match="divisible.*gradient_accumulation"):
         MLXTrainer._prepare_data(trainer, is_vlm=False)
     assert trainer.train_dataset.pulls == 0
+
+
+def test_epoch_stream_allows_one_to_one_labeled_preparation():
+    def prepare(rows, *, tokenizer=None, response_mask_fn=None, **kwargs):
+        MLXTrainer, trainer = _streaming_text_trainer(
+            max_steps=0, num_train_epochs=1,
+            per_device_train_batch_size=1, gradient_accumulation_steps=1,
+            **kwargs,
+        )
+        trainer.train_dataset = _DeclaredTextRows(rows)
+        if tokenizer is not None:
+            trainer.tokenizer = tokenizer
+        trainer._mlx_response_mask_fn = response_mask_fn
+        _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
+        return next(iterator)
+
+    completion = prepare(
+        [{"prompt": "1 2", "completion": " 3"}],
+        completion_only_loss=True,
+    )
+    assistant_rows = [{"messages": [{"role": "user", "content": "4"}, {"role": "assistant", "content": "5"}]}]
+    assistant = prepare(
+        assistant_rows,
+        tokenizer=_AssistantMaskTokenizer(), completion_only_loss=False,
+        assistant_only_loss=True,
+    )
+    response = prepare(
+        [{"text": "6 7"}], completion_only_loss=False,
+        response_mask_fn=lambda batch: {
+            "labels": [[-100] + ids[1:] for ids in batch["input_ids"]]
+        },
+    )
+
+    assert completion[2].tolist() == [[-100, -100, 3]]
+    assert assistant[2].tolist() == [[-100, -100, -100, 5]]
+    assert response[2].tolist() == [[-100, 7]]
 
 
 def test_raw_text_streaming_matches_sized_sequential_order():
@@ -1237,6 +1285,8 @@ def test_streaming_prompt_completion_and_assistant_labels():
 
 
 def test_pretokenized_streaming_preserves_supported_label_fields():
+    from unsloth_zoo.mlx.utils import _MLXIterableTokenizedDatasetView
+
     explicit = next(_streaming_text_batches(
         iter([{
             "input_ids": [1, 2],
@@ -1252,15 +1302,16 @@ def test_pretokenized_streaming_preserves_supported_label_fields():
     assert explicit[0].tolist() == [[1, 2]]
     assert explicit[2].tolist() == [[-100, 2]]
 
+    masked_row = next(iter(_MLXIterableTokenizedDatasetView(iter([{
+        "input_ids": [4, 5, 6], "completion_mask": [1, 1, 1],
+        "assistant_masks": [0, 1, 1],
+    }]), types.SimpleNamespace(), max_seq_length=2)))
+    assert masked_row["completion_mask"] == [1, 1] and masked_row["assistant_masks"] == [0, 1]
     masked = next(_streaming_text_batches(
-        iter([{
-            "input_ids": [4, 5, 6],
-            "completion_mask": [1, 1, 1],
-            "assistant_masks": [0, 1, 1],
-        }]),
+        iter([masked_row]),
         tokenizer=types.SimpleNamespace(pad_token_id=0),
     ))
-    assert masked[2].tolist() == [[-100, 5, 6]]
+    assert masked[2].tolist() == [[-100, 5]]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2710,3 +2710,18 @@ def test_lazy_text_producer_rejects_mlx_valued_rows_before_parsing():
     _reject_probe({"text": mx.array([1, 2])})
     _reject_probe({"messages": mx.array([1, 2])})
     _reject_probe(formatting_func=lambda item: {"text": mx.array([3, 4])})
+
+
+def test_max_eval_batches_rejects_non_integer_values():
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    trainer = MLXTrainer(
+        _MinimalTextModel(), _streaming_text_tokenizer(),
+        _CountingTextRows(({"text": "10 1"},)),
+        args=MLXTrainingConfig(streaming=True, max_steps=1, max_seq_length=8),
+    )
+    for bad in (True, 1.9, 0, "2"):
+        trainer.args.max_eval_batches = bad
+        with pytest.raises(ValueError, match="max_eval_batches"):
+            trainer._create_text_eval_batches(
+                _CountingTextRows(({"text": "10 1"},)), 1, False, False)

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2725,3 +2725,18 @@ def test_max_eval_batches_rejects_non_integer_values():
         with pytest.raises(ValueError, match="max_eval_batches"):
             trainer._create_text_eval_batches(
                 _CountingTextRows(({"text": "10 1"},)), 1, False, False)
+
+
+def test_distributed_failure_reraises_interrupts_unwrapped():
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+    trainer = MLXTrainer(
+        _MinimalTextModel(), _streaming_text_tokenizer(),
+        _CountingTextRows(({"text": "10 1"},)),
+        args=MLXTrainingConfig(streaming=True, max_steps=1, max_seq_length=8))
+    for interrupt in (KeyboardInterrupt, SystemExit):
+        with pytest.raises(interrupt):
+            trainer._raise_distributed_failure_from_any(True, "save", interrupt())
+        assert not trainer.stop_requested  # reuse must not inherit a stop
+    with pytest.raises(RuntimeError, match="failed during save"):
+        trainer._raise_distributed_failure_from_any(True, "save", ValueError("x"))
+    assert trainer.stop_requested

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2504,3 +2504,69 @@ def test_streaming_window_trainer_routing_and_config_copy():
         clone = MLXTrainingConfig(**copied)
         assert clone.streaming_text_length_window_batches == 8
         assert clone._unsloth_mlx_warmup_steps_explicit is False
+
+
+def test_host_staging_seam_parity_and_host_valued_flag():
+    import numpy as np
+    import mlx.core as mx
+    from unsloth_zoo.mlx.utils import (
+        _HostStagedTextBatch, _finalize_text_batch, _stage_tokenized_text_batch,
+    )
+    rows = _window_rows((5, 3, 4, 2))
+
+    from unsloth_zoo.mlx.utils import _iterate_lazy_text_training_batches
+    def _direct(**kwargs):
+        return _iterate_lazy_text_training_batches(
+            _CountingTextRows(rows), _streaming_text_tokenizer(), 2, 64,
+            repeat=False, length_window_batches=2, window_seed=3407, **kwargs)
+    staged_stream = _direct(yield_host_staged=True)
+    finalized_stream = _direct()
+    for _ in range(2):
+        staged = next(staged_stream)
+        assert isinstance(staged, _HostStagedTextBatch)
+        assert isinstance(staged.ids, np.ndarray) and staged.host_valued
+        batch, lengths, labels = next(finalized_stream)
+        f_batch, f_lengths, f_labels = _finalize_text_batch(staged)
+        assert f_batch.tolist() == batch.tolist()
+        assert f_lengths.tolist() == lengths.tolist()
+        assert f_labels is None and labels is None
+
+    # MLX-valued rows via the REAL pipeline: origin recorded pre-.tolist().
+    class MxRows:
+        def __iter__(self):
+            return iter([
+                {"input_ids": mx.array([7, 8, 9])},
+                {"input_ids": [1, 2, 3]},
+            ])
+    mx_staged = next(_iterate_lazy_text_training_batches(
+        MxRows(), _streaming_text_tokenizer(), 2, 8,
+        repeat=False, yield_host_staged=True))
+    assert mx_staged.host_valued is False       # flagged for the prefetch producer
+    ids, _lengths, _labels = _finalize_text_batch(mx_staged)
+    assert ids.tolist()[0][:3] == [7, 8, 9]     # sync mode still accepts it
+
+    assert not _stage_tokenized_text_batch(
+        [(mx.array([7, 8]), None), ([1, 2], None)], 8).host_valued
+
+    # Raw-text pipeline end-to-end: an mx-returning tokenizer must surface as a
+    # host_valued=False STAGED batch (the raw stager forwards the stream flag).
+    class MxRawTok(_StreamingTextTokenizer):
+        def encode(self, text, add_special_tokens=True):
+            return mx.array(super().encode(text, add_special_tokens))
+    raw_staged = next(_iterate_lazy_text_training_batches(
+        _CountingTextRows(["5 6 7", "8 9 10"]), MxRawTok(), 2, 8,
+        repeat=False, yield_host_staged=True))
+    assert raw_staged.host_valued is False
+
+    # User chat-template variables named 'state' must keep working.
+    from unsloth_zoo.mlx.utils import _tokenize_mlx_prompt_completion_row
+    seen_kwargs = {}
+    class TemplateTok(_StreamingTextTokenizer):
+        def apply_chat_template(self, messages, **kwargs):
+            seen_kwargs.update(kwargs)
+            return [10, 11, 12]
+    row = {"prompt": [{"role": "user", "content": "1 2"}],
+           "completion": [{"role": "assistant", "content": "3 4"}],
+           "chat_template_kwargs": {"state": "CA", "_unsloth_state": "USER"}}
+    assert _tokenize_mlx_prompt_completion_row(TemplateTok(), row) is not None
+    assert seen_kwargs.get("state") == "CA" and seen_kwargs.get("_unsloth_state") == "USER"

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -862,6 +862,141 @@ def test_text_completion_probe_keeps_one_shot_iterables_reusable():
     assert list(dataset) == [{"text": "1 2"}]
 
 
+def _streaming_text_tokenizer(pad_token_id=0):
+    return types.SimpleNamespace(
+        chat_template=None,
+        eos_token_id=None,
+        pad_token_id=pad_token_id,
+        encode=lambda text, add_special_tokens=True: [
+            int(part) for part in str(text).split()
+        ],
+    )
+
+
+def _streaming_text_batches(dataset, tokenizer=None, **kwargs):
+    from unsloth_zoo.mlx.utils import iterate_training_batches
+
+    options = dict(batch_size=1, max_seq_length=8, dataset_order="sequential")
+    return iterate_training_batches(
+        dataset, tokenizer or _streaming_text_tokenizer(), **(options | kwargs),
+    )
+
+
+def _streaming_batch_signature(batch):
+    tokens, lengths, labels = batch
+    return tokens.tolist(), lengths.tolist(), None if labels is None else labels.tolist()
+
+
+@pytest.mark.parametrize("use_hf", [False, True])
+def test_text_streaming_yields_without_sizing_indexing_or_preconsumption(use_hf):
+    from datasets import IterableDataset
+
+    class GuardedRows:
+        def __init__(self):
+            self.pulls = 0
+
+        def __len__(self):
+            raise AssertionError("streaming source length must not be requested")
+
+        def __getitem__(self, _index):
+            raise AssertionError("streaming source must not be indexed")
+
+        def __iter__(self):
+            while True:
+                if self.pulls >= 2:
+                    raise AssertionError("source was consumed past the first batch")
+                self.pulls += 1
+                yield {"text": f"{self.pulls} {self.pulls + 10}"}
+
+    guarded = GuardedRows()
+    source = IterableDataset.from_generator(lambda: iter(guarded)) if use_hf else guarded
+    batch = next(_streaming_text_batches(
+        source,
+        batch_size=2,
+        completion_only_loss=False,
+    ))
+
+    assert guarded.pulls == 2
+    assert [row[:2] for row in batch[0].tolist()] == [[1, 11], [2, 12]]
+    assert batch[2] is None
+
+
+def test_raw_text_streaming_matches_sized_sequential_order():
+    class ReplayableRows:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def __iter__(self):
+            return iter(self.rows)
+
+    rows = [{"value": value} for value in range(1, 6)]
+    kwargs = {
+        "batch_size": 2,
+        "completion_only_loss": False,
+        "formatting_func": lambda row: {
+            "text": f"{row['value']} {row['value'] + 10}"
+        },
+    }
+    expected = _streaming_text_batches(rows, **kwargs)
+    actual = _streaming_text_batches(ReplayableRows(rows), **kwargs)
+    assert [_streaming_batch_signature(next(actual)) for _ in range(3)] == [
+        _streaming_batch_signature(next(expected)) for _ in range(3)
+    ]
+
+
+def test_streaming_prompt_completion_and_assistant_labels():
+    completion_batch = next(_streaming_text_batches(iter([
+        {"prompt": "1 2", "completion": " 3"},
+        {"prompt": "4", "completion": " 5 6"},
+    ]), batch_size=2))
+    assert completion_batch[0].tolist() == [[1, 2, 3], [4, 5, 6]]
+    assert completion_batch[2].tolist() == [
+        [-100, -100, 3],
+        [-100, 5, 6],
+    ]
+
+    assistant_batch = next(_streaming_text_batches(
+        iter([{
+            "messages": [
+                {"role": "user", "content": "1"},
+                {"role": "assistant", "content": "2 3"},
+            ],
+        }]),
+        tokenizer=_AssistantMaskTokenizer(),
+        completion_only_loss=False,
+        assistant_only_loss=True,
+    ))
+    assert assistant_batch[0].tolist() == [[10, 1, 20, 2, 3]]
+    assert assistant_batch[2].tolist() == [[-100, -100, -100, 2, 3]]
+
+
+def test_pretokenized_streaming_preserves_supported_label_fields():
+    explicit = next(_streaming_text_batches(
+        iter([{
+            "input_ids": [1, 2],
+            "labels": [-100, 2],
+            "attention_mask": [0, 0],
+        }]),
+        tokenizer=types.SimpleNamespace(pad_token_id=9),
+        completion_only_loss=False,
+        formatting_func=lambda _row: pytest.fail(
+            "pretokenized rows must bypass formatting"
+        ),
+    ))
+    assert explicit[0].tolist() == [[1, 2]]
+    assert explicit[2].tolist() == [[-100, 2]]
+
+    masked = next(_streaming_text_batches(
+        iter([{
+            "input_ids": [4, 5, 6],
+            "completion_mask": [1, 1, 1],
+            "assistant_masks": [0, 1, 1],
+        }]),
+        tokenizer=types.SimpleNamespace(pad_token_id=0),
+    ))
+    assert masked[2].tolist() == [[-100, 5, 6]]
+
+
 def test_text_pretokenized_create_batches_preserves_input_ids():
     from unsloth_zoo.mlx.utils import create_batches
 

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -379,9 +379,10 @@ def test_trainer_drives_dynamic_lr_outside_optimizer_scheduler():
     )
     assert copied_ratio_trainer._resolve_warmup_steps(total_steps=100) == 10
 
+    from unsloth_zoo.mlx.trainer import _MLX_CONFIG_OPTIONAL_COPY_FIELDS
     legacy_fields = [
         field for field in dataclasses.fields(MLXTrainingConfig)
-        if field.init and field.name != "max_eval_batches"
+        if field.init and field.name not in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
     ]
     legacy_values = [getattr(MLXTrainingConfig(), field.name) for field in legacy_fields]
     legacy_values[[field.name for field in legacy_fields].index("warmup_ratio")] = 0.1
@@ -2519,3 +2520,202 @@ def test_quantized_linear_forward():
     # x @ W.T  with W = [[0,1,2,3,4,5,6,7], [0,1,2,3,4,5,6,7]] = [28, 28]
     out = layer(x)
     torch.testing.assert_close(out, torch.tensor([[28.0, 28.0]]))
+
+
+def _window_rows(lengths):
+    # Row index rides in the first token so batch order is observable.
+    return [
+        " ".join([str(100 + idx)] + ["7"] * (length - 1))
+        for idx, length in enumerate(lengths)
+    ]
+
+
+def _first_tokens(stream, count):
+    return [[row[0] for row in batch.tolist()]
+            for batch, _l, _lab in (next(stream) for _ in range(count))]
+
+
+def _window_batches(rows, *, window, order="default", repeat=False, seed=3407,
+                    max_batches=None, source=None):
+    from unsloth_zoo.mlx.utils import iterate_training_batches
+    stream = iterate_training_batches(
+        dataset=_CountingTextRows(rows) if source is None else source,
+        tokenizer=_streaming_text_tokenizer(), batch_size=2, max_seq_length=64,
+        seed=seed, dataset_order=order, repeat=repeat,
+        length_window_batches=window,
+    )
+    out = []
+    for batch, _lengths, _labels in stream:
+        out.append(([row[0] for row in batch.tolist()], batch.shape[1]))
+        if max_batches is not None and len(out) >= max_batches:
+            return out
+    return out
+
+
+_WINDOW_LENGTHS = (40, 3, 44, 4, 2, 46, 3, 41)
+
+
+def test_streaming_window_identity_grouping_and_ddp_slice():
+    rows = _window_rows(_WINDOW_LENGTHS)
+    arrival = [[100, 101], [102, 103], [104, 105], [106, 107]]
+    assert [ids for ids, _ in _window_batches(rows, window=1)] == arrival
+    assert [ids for ids, _ in _window_batches(rows, window=8, order="sequential")] == arrival
+
+    class FakeWorld:
+        def rank(self): return 1
+        def size(self): return 2
+    from unsloth_zoo.mlx.utils import _iterate_lazy_text_training_batches
+    ddp = _iterate_lazy_text_training_batches(
+        _CountingTextRows(rows), _streaming_text_tokenizer(), 1, 64,
+        comm_group=FakeWorld(), repeat=False, length_window_batches=1,
+    )
+    assert _first_tokens(ddp, 4) == [[101], [103], [105], [107]]
+
+    grouped = _window_batches(rows, window=4)
+    baseline = _window_batches(rows, window=1)
+    assert sorted(t for ids, _ in grouped for t in ids) == [100 + i for i in range(8)]
+    assert sum(w for _, w in grouped) < sum(w for _, w in baseline)
+    assert grouped == _window_batches(rows, window=4)  # deterministic
+    assert [ids for ids, _ in grouped] != arrival      # grouping engaged
+    assert [ids for ids, _ in _window_batches(rows, window=4, seed=1)] != \
+        [ids for ids, _ in grouped]  # seed reaches the permutation
+
+    # Single-process windowed slicing must see an EMPTY pad_source: cycle
+    # padding is gated to multi-rank runs (retention stays within the window).
+    from unsloth_zoo.mlx import utils as mlx_utils
+    odd = _window_rows(_WINDOW_LENGTHS[:7])
+    seen_pads = []
+    original = mlx_utils._rank_slice_distributed_batch
+    def spy(items, local_batch_size, comm_group=None, pad_source=None, pad_mode="cycle"):
+        seen_pads.append([] if not pad_source else list(pad_source))
+        return original(items, local_batch_size, comm_group=comm_group,
+                        pad_source=pad_source, pad_mode=pad_mode)
+    mlx_utils._rank_slice_distributed_batch = spy
+    try:
+        tail = _window_batches(odd, window=3)[-1]
+    finally:
+        mlx_utils._rank_slice_distributed_batch = original
+    assert len(tail[0]) == 1
+    assert seen_pads and all(pads == [] for pads in seen_pads)
+
+
+def test_streaming_window_epoch_replay_oneshot_and_knob_validation():
+    odd_rows = _window_rows(_WINDOW_LENGTHS[:7])  # 7 rows -> 4 batches/pass
+    source = _DeclaredTextRows(odd_rows)
+    crossing = _window_batches(odd_rows, window=3, repeat=True, source=source,
+                               max_batches=6)  # crosses the epoch boundary
+    assert source.epochs[:2] == [0, 1]
+    assert (sorted(t for ids, _ in crossing[:4] for t in ids)
+            == [100 + i for i in range(7)])
+    fresh = _window_batches(odd_rows, window=3, repeat=True, max_batches=6)
+    assert fresh == crossing  # deterministic reconstruction across the boundary
+    assert [ids for ids, _ in crossing[4:6]] != [ids for ids, _ in crossing[:2]]
+    # ^ epoch index reaches the permutation seed (pass-2 order differs)
+
+    # Resume-style fast-forward: a fresh iterator skipped past the boundary
+    # continues exactly where the uninterrupted run would.
+    from unsloth_zoo.mlx.utils import iterate_training_batches
+    skipped = iterate_training_batches(
+        dataset=_CountingTextRows(odd_rows), tokenizer=_streaming_text_tokenizer(),
+        batch_size=2, max_seq_length=64, seed=3407, dataset_order="default",
+        repeat=True, require_replayable=True, length_window_batches=3,
+    )
+    for _ in range(5):
+        next(skipped)
+    assert _first_tokens(skipped, 1) == [crossing[5][0]]
+
+    # Declared-cardinality epochs with W>1: the final buffered window flushes
+    # only after per-pass validation; a declared-length mismatch raises before
+    # the buffered final batches are emitted.
+    from unsloth_zoo.mlx.utils import _iterate_lazy_text_training_batches
+    exact = _iterate_lazy_text_training_batches(
+        _DeclaredTextRows(odd_rows), _streaming_text_tokenizer(), 2, 64,
+        repeat=True, length_window_batches=3, window_seed=3407,
+        expected_rows_per_pass=7,
+    )
+    two_passes = _first_tokens(exact, 8)
+    assert sorted(t for ids in two_passes[:4] for t in ids) == [100 + i for i in range(7)]
+    mismatched = _iterate_lazy_text_training_batches(
+        _DeclaredTextRows(odd_rows), _streaming_text_tokenizer(), 2, 64,
+        repeat=True, length_window_batches=3, window_seed=3407,
+        expected_rows_per_pass=8,
+    )
+    emitted = []
+    with pytest.raises(ValueError, match="declared length"):
+        while True:
+            emitted.append(next(mismatched))
+    assert len(emitted) < 4  # buffered final window withheld on mismatch
+
+    one_shot = iterate_training_batches(
+        dataset=iter(list(_CountingTextRows(odd_rows))),
+        tokenizer=_streaming_text_tokenizer(), batch_size=2, max_seq_length=64,
+        dataset_order="default", repeat=True, length_window_batches=3,
+    )
+    for _ in range(4):
+        next(one_shot)
+    with pytest.raises(RuntimeError, match="one-shot"):
+        next(one_shot)
+
+    none_seed = iterate_training_batches(
+        dataset=_CountingTextRows(odd_rows), tokenizer=_streaming_text_tokenizer(),
+        batch_size=2, max_seq_length=64, seed=None, dataset_order="default",
+        repeat=False, length_window_batches=4,
+    )
+    assert next(iter(none_seed))[0].shape[0] == 2  # seed=None normalizes
+
+    for bad in (True, False, 0, -2, 2.0, "4"):
+        probe = _CountingTextRows(_window_rows((3, 2)))
+        gen = iterate_training_batches(
+            dataset=probe, tokenizer=_streaming_text_tokenizer(), batch_size=2,
+            max_seq_length=64, dataset_order="default", repeat=False,
+            length_window_batches=bad,
+        )
+        with pytest.raises(ValueError, match="streaming_text_length_window"):
+            next(iter(gen))
+        assert probe.pulls == 0
+
+
+def test_trainer_prepare_data_routes_window_and_preserve_order():
+    rows = _window_rows(_WINDOW_LENGTHS)
+    arrival = [[100, 101], [102, 103], [104, 105], [106, 107]]
+
+    def prepared(**config_kwargs):
+        _MLXTrainer, trainer = _streaming_text_trainer(
+            per_device_train_batch_size=2, max_seq_length=64, **config_kwargs,
+        )
+        trainer.train_dataset = _CountingTextRows(rows)
+        _batches, stream = trainer._prepare_data(is_vlm=False)
+        return _first_tokens(stream, 4)
+
+    windowed = prepared(streaming_text_length_window_batches=4)
+    assert sorted(t for ids in windowed for t in ids) == [100 + i for i in range(8)]
+    assert windowed != arrival
+    assert prepared(streaming_text_length_window_batches=4,
+                    preserve_dataset_order=True) == arrival
+
+    _MLXTrainer, bad_trainer = _streaming_text_trainer(
+        per_device_train_batch_size=2, max_seq_length=64,
+        streaming_text_length_window_batches=0,
+    )
+    probe = _DeclaredTextRows(rows)
+    bad_trainer.train_dataset = probe
+    with pytest.raises(ValueError, match="streaming_text_length_window"):
+        bad_trainer._prepare_data(is_vlm=False)
+    assert probe.pulls == 0 and probe.epochs == []
+
+
+def test_config_copy_tolerates_missing_suffix_fields():
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
+    base = MLXTrainingConfig(warmup_ratio=0.25)
+    for omitted in (
+        ("streaming_text_length_window_batches",),
+        ("streaming_text_length_window_batches", "max_eval_batches"),
+    ):
+        copied = {
+            field.name: getattr(base, field.name)
+            for field in dataclasses.fields(MLXTrainingConfig)
+            if field.init and field.name not in omitted
+        }
+        clone = MLXTrainingConfig(**copied)
+        assert clone.streaming_text_length_window_batches == 8
+        assert clone._unsloth_mlx_warmup_steps_explicit is False

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2746,3 +2746,14 @@ def test_lazy_text_mixed_plain_and_prompt_completion_rejects_any_order():
         with pytest.raises(ValueError, match="mixed|requires prompt"):
             list(_iterate_lazy_text_training_batches(
                 iter(list(ordering)), _StreamingTextTokenizer(), 1, 8, repeat=False))
+
+
+def test_eval_batch_totals_aborts_before_pull_when_stopped():
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+    tr = MLXTrainer(_MinimalTextModel(), _streaming_text_tokenizer(),
+        _CountingTextRows(({"text": "10 1"},)),
+        args=MLXTrainingConfig(streaming=True, max_steps=1, max_seq_length=8))
+    class _Boom:
+        def __iter__(self): raise AssertionError("pulled despite stop")
+    tr.stop_requested = True
+    assert int(tr._evaluate_batch_totals(_Boom(), loss_fn=None)[1]) == 0

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -3548,3 +3548,33 @@ def test_epoch_permuted_visits_are_deterministic_and_guard_enumerated():
         )
         for m in range(8)
     )
+
+
+def test_horizontal_concat_streaming_eval_infinite_only_if_all_children_infinite():
+    from unsloth_zoo.mlx.trainer import _mlx_stream_declares_infinite
+
+    class RepeatExamplesIterable:  # HF infinite marker: num_times=None
+        num_times = None
+        ex_iterable = None
+
+    class _FiniteChild:  # no infinite markers -> finite
+        ex_iterable = None
+
+    class HorizontallyConcatenatedMultiSourcesExamplesIterable:
+        def __init__(self, children): self.ex_iterables = children
+
+    class VerticallyConcatenatedMultiSourcesExamplesIterable:
+        def __init__(self, children): self.ex_iterables = children
+
+    class _Src:
+        def __init__(self, ex): self._ex_iterable = ex
+
+    inf, fin = RepeatExamplesIterable(), _FiniteChild()
+    # Horizontal (lockstep) ends with the shortest child -> finite if any is.
+    assert _mlx_stream_declares_infinite(
+        _Src(HorizontallyConcatenatedMultiSourcesExamplesIterable([inf, fin]))) is False
+    assert _mlx_stream_declares_infinite(
+        _Src(HorizontallyConcatenatedMultiSourcesExamplesIterable([inf, inf]))) is True
+    # Vertical (sequential) is infinite if any child is.
+    assert _mlx_stream_declares_infinite(
+        _Src(VerticallyConcatenatedMultiSourcesExamplesIterable([inf, fin]))) is True

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2690,3 +2690,23 @@ def test_prefetcher_lifecycle_quiescence_orphan_and_positioned_error():
     with pytest.raises(RuntimeError, match="late tokenizer failure"):
         next(boom)
     boom.close()
+
+
+def test_lazy_text_producer_rejects_mlx_valued_rows_before_parsing():
+    """Raw rows / formatter results carrying MLX values reject actionably
+    before any truthiness probe or parsing can evaluate them off-thread."""
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx.utils import _iterate_lazy_text_training_batches
+
+    def _reject_probe(row=None, formatting_func=None):
+        def _src():
+            yield row if row is not None else {"text": "hello"}
+        with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+            next(_iterate_lazy_text_training_batches(
+                _src(), None, 1, 32, formatting_func=formatting_func,
+                yield_host_staged=True, reject_mlx_valued=True))
+
+    _reject_probe({"text": mx.array([1, 2])})
+    _reject_probe({"messages": mx.array([1, 2])})
+    _reject_probe(formatting_func=lambda item: {"text": mx.array([3, 4])})

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -379,6 +379,17 @@ def test_trainer_drives_dynamic_lr_outside_optimizer_scheduler():
     )
     assert copied_ratio_trainer._resolve_warmup_steps(total_steps=100) == 10
 
+    legacy_fields = [
+        field for field in dataclasses.fields(MLXTrainingConfig)
+        if field.init and field.name != "max_eval_batches"
+    ]
+    legacy_values = [getattr(MLXTrainingConfig(), field.name) for field in legacy_fields]
+    legacy_values[[field.name for field in legacy_fields].index("warmup_ratio")] = 0.1
+    legacy_values[-1] = (128, 256)
+    copied_ratio_trainer.args = MLXTrainingConfig(*legacy_values)
+    assert copied_ratio_trainer.args.image_size == (128, 256)
+    assert copied_ratio_trainer._resolve_warmup_steps(total_steps=100) == 10
+
     explicit_default_trainer = MLXTrainer.__new__(MLXTrainer)
     explicit_default_trainer.args = MLXTrainingConfig(
         learning_rate=5e-5,
@@ -862,15 +873,69 @@ def test_text_completion_probe_keeps_one_shot_iterables_reusable():
     assert list(dataset) == [{"text": "1 2"}]
 
 
+class _StreamingTextTokenizer:
+    chat_template = None
+    eos_token_id = None
+
+    def __init__(self, offset=0, pad_token_id=0):
+        self.offset = offset
+        self.pad_token_id = pad_token_id
+
+    def encode(self, text, add_special_tokens=True):
+        return [int(part) + self.offset for part in str(text).split()]
+
+    def __call__(self, text, **_kwargs):
+        return types.SimpleNamespace(
+            input_ids=self.encode(text, add_special_tokens=False),
+        )
+
+    def apply_chat_template(self, messages, tokenize=False, **_kwargs):
+        ids = []
+        for message in messages:
+            ids.append(20 if message["role"] == "assistant" else 10)
+            ids.extend(int(part) for part in message["content"].split())
+        return ids if tokenize else " ".join(str(token) for token in ids)
+
+
+class _MinimalTextModel:
+    _config = {}
+    def trainable_parameters(self): return {}
+
+
+class _CountingTextRows:
+    def __init__(self, rows, infinite=False):
+        self.rows = tuple(rows)
+        self.pulls = 0
+        self._unsloth_mlx_infinite = infinite
+
+    def __iter__(self):
+        while True:
+            for row in self.rows:
+                self.pulls += 1
+                yield row
+            if not self._unsloth_mlx_infinite:
+                return
+
+
+class _DeclaredTextRows(_CountingTextRows):
+    def __init__(self, rows):
+        super().__init__(rows)
+        self.epochs = []
+    def __len__(self): return len(self.rows)
+    def set_epoch(self, epoch): self.epochs.append(epoch)
+
+
 def _streaming_text_tokenizer(pad_token_id=0):
-    return types.SimpleNamespace(
-        chat_template=None,
-        eos_token_id=None,
-        pad_token_id=pad_token_id,
-        encode=lambda text, add_special_tokens=True: [
-            int(part) for part in str(text).split()
-        ],
-    )
+    return _StreamingTextTokenizer(pad_token_id=pad_token_id)
+
+
+def _streaming_text_trainer(**kwargs):
+    MLXTrainer, trainer = _make_mlx_text_trainer(streaming=True, **kwargs)
+    trainer.tokenizer = _streaming_text_tokenizer()
+    trainer._distributed_initialized = True
+    trainer._distributed_world = None
+    trainer._distributed_world_size = 1
+    return MLXTrainer, trainer
 
 
 def _streaming_text_batches(dataset, tokenizer=None, **kwargs):
@@ -921,14 +986,7 @@ def test_text_streaming_yields_without_sizing_indexing_or_preconsumption(use_hf)
 
 
 def test_streaming_trainer_exposes_lazy_prepared_iterable_view():
-    import inspect
-
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
-    from unsloth_zoo.mlx.utils import iterate_training_batches
-
-    class Model:
-        _config = {}
-        def trainable_parameters(self): return {}
 
     class Rows:
         def __init__(self): self.pulls = 0
@@ -941,7 +999,7 @@ def test_streaming_trainer_exposes_lazy_prepared_iterable_view():
 
     rows = Rows()
     trainer = MLXTrainer(
-        Model(), _streaming_text_tokenizer(), rows,
+        _MinimalTextModel(), _streaming_text_tokenizer(), rows,
         formatting_func=lambda row: {"text": f"{row['value']} 2"},
         args=MLXTrainingConfig(
             streaming=True, max_steps=1, completion_only_loss=False,
@@ -955,8 +1013,6 @@ def test_streaming_trainer_exposes_lazy_prepared_iterable_view():
     assert not hasattr(trainer.train_dataset, "take")
     assert next(iter(trainer.train_dataset)) == {"input_ids": [1, 2]}
     assert rows.pulls == 1
-    parameters = list(inspect.signature(iterate_training_batches).parameters)
-    assert parameters.index("response_mask_fn") > parameters.index("require_replayable")
 
 
 def test_train_on_responses_only_masks_unsized_text_lazily():
@@ -964,50 +1020,18 @@ def test_train_on_responses_only_masks_unsized_text_lazily():
         MLXTrainer, MLXTrainingConfig, train_on_responses_only,
     )
 
-    class Model:
-        _config = {}
-        def trainable_parameters(self): return {}
-
-    class Encoding:
-        def __init__(self, input_ids): self.input_ids = input_ids
-
-    class Tokenizer:
-        eos_token_id = None
-        pad_token_id = 0
-        def __init__(self, offset=0):
-            self.offset = offset
-            self.chat_template = None
-        def encode(self, text, add_special_tokens=True):
-            return [int(part) + self.offset for part in str(text).split()]
-        def __call__(self, text, **_kwargs):
-            return Encoding(self.encode(text, add_special_tokens=False))
-        def apply_chat_template(self, messages, tokenize=False, **_kwargs):
-            ids = []
-            for message in messages:
-                ids.append(20 if message["role"] == "assistant" else 10)
-                ids.extend(int(part) for part in message["content"].split())
-            return ids if tokenize else " ".join(str(token) for token in ids)
-
-    class Rows:
-        def __init__(self): self.pulls = 0
-        def __iter__(self):
-            values = (
-                "10 1",
-                "10 1 20 2 3",
-                "",
-                {"messages": [
-                    {"role": "user", "content": "4"},
-                    {"role": "assistant", "content": "5"},
-                ]},
-            )
-            for value in values:
-                self.pulls += 1
-                yield value if isinstance(value, dict) else {"text": value}
-
-    rows = Rows()
-    lazy_eval = Rows()
+    source_rows = (
+        {"text": "10 1"},
+        {"text": "10 1 20 2 3"},
+        {"messages": [
+            {"role": "user", "content": "4"},
+            {"role": "assistant", "content": "5"},
+        ]},
+    )
+    rows = _CountingTextRows(source_rows)
+    lazy_eval = _CountingTextRows(source_rows)
     trainer = MLXTrainer(
-        Model(), Tokenizer(offset=100), rows,
+        _MinimalTextModel(), _StreamingTextTokenizer(offset=100), rows,
         eval_dataset={
             "sized": [{"text": "10 6 20 7"}],
             "lazy": lazy_eval,
@@ -1020,7 +1044,7 @@ def test_train_on_responses_only_masks_unsized_text_lazily():
     )
     train_on_responses_only(
         trainer, instruction_part="10", response_part="20", force_match=True,
-        tokenizer=Tokenizer(),
+        tokenizer=_StreamingTextTokenizer(),
     )
 
     assert rows.pulls == 0
@@ -1035,20 +1059,151 @@ def test_train_on_responses_only_masks_unsized_text_lazily():
         "input_ids": [10, 4, 20, 5],
         "labels": [-100, -100, -100, 5],
     }
-    assert rows.pulls == 4  # an empty labeled row is filtered, not schema drift
-    assert trainer._eval_batches_labeled is None
     assert trainer.eval_dataset["sized"][0]["labels"] == [-100, -100, -100, 7]
     assert lazy_eval.pulls == 0
 
 
-def test_raw_text_streaming_matches_sized_sequential_order():
-    class ReplayableRows:
-        def __init__(self, rows):
-            self.rows = rows
+def test_lazy_text_eval_restarts_masks_splits_and_bounds_infinite_sources():
+    MLXTrainer, trainer = _streaming_text_trainer(
+        max_steps=1, completion_only_loss=False,
+        per_device_eval_batch_size=1,
+    )
+    trainer._mlx_response_mask_fn = lambda batch: {
+        "labels": [[-100] + ids[1:] for ids in batch["input_ids"]]
+    }
+    source = _CountingTextRows([{"text": "1 2"}, {"text": "3 4"}])
+    batches = MLXTrainer._create_text_eval_batches(trainer, source, 1, False, False)
+    first = [_streaming_batch_signature(batch) for batch in batches]
+    assert [_streaming_batch_signature(batch) for batch in batches] == first
+    assert first[0][2] == [[-100, 2]]
 
+    infinite = _CountingTextRows([{"text": "1 2"}], infinite=True)
+    unbounded = MLXTrainer._create_text_eval_batches(
+        trainer, infinite, 1, False, False,
+    )
+    with pytest.raises(ValueError, match="infinite.*max_eval_batches"):
+        next(iter(unbounded))
+    assert infinite.pulls == 0
+
+    trainer.args.max_eval_batches = 1
+    bounded = MLXTrainer._create_text_eval_batches(
+        trainer, infinite, 1, False, False,
+    )
+    assert len(list(bounded)) == infinite.pulls == 1
+
+    from datasets import IterableDataset, concatenate_datasets, interleave_datasets
+    base = IterableDataset.from_generator(lambda: iter([{"text": "1 2"}]))
+    from unsloth_zoo.mlx.trainer import _mlx_stream_declares_infinite
+    assert (_mlx_stream_declares_infinite(base.repeat(None).take(3)),
+            _mlx_stream_declares_infinite(base.take(3).repeat(None))) == (False, True)
+    assert _mlx_stream_declares_infinite(concatenate_datasets([base.take(1), base.repeat(None)]))
+    assert _mlx_stream_declares_infinite(concatenate_datasets([base.take(1), base.rename_column("text", "other").repeat(None)], axis=1))
+    assert _mlx_stream_declares_infinite(interleave_datasets(
+        [base.take(1), base.repeat(None)], stopping_strategy="all_exhausted"))
+    assert _mlx_stream_declares_infinite(interleave_datasets(
+        [base.repeat(None)] * 2, stopping_strategy="first_exhausted"))
+    assert _mlx_stream_declares_infinite(interleave_datasets(
+        [base.take(1)] * 2, probabilities=[1.0, 0.0], stopping_strategy="all_exhausted"))
+
+    trainer._distributed_world = types.SimpleNamespace(rank=lambda: 1, size=lambda: 2)
+    padded = list(trainer._create_text_eval_batches(
+        _CountingTextRows([{"text": "7 8"}]), 1, False, False))[0]
+    assert (padded[1].tolist(), padded[2].tolist()) == ([[0, 0]], [[-100, -100]])
+
+
+def test_sized_response_training_defers_lazy_eval_with_override_tokenizer():
+    from unsloth_zoo.mlx.trainer import (
+        MLXTrainer, MLXTrainingConfig, train_on_responses_only,
+    )
+
+    eval_rows = _CountingTextRows([{"text": "10 1 20 2"}])
+    trainer = MLXTrainer(
+        _MinimalTextModel(), _StreamingTextTokenizer(100),
+        [{"text": "10 1 20 2"}],
+        eval_dataset=eval_rows,
+        args=MLXTrainingConfig(
+            streaming=True, max_steps=1, completion_only_loss=False,
+            per_device_train_batch_size=1,
+        ),
+    )
+    override = _StreamingTextTokenizer()
+    train_on_responses_only(
+        trainer, instruction_part="10", response_part="20",
+        tokenizer=override,
+    )
+
+    assert eval_rows.pulls == 0
+    eval_batches = trainer._create_text_eval_batches(
+        trainer.eval_dataset, 1, False, False,
+    )
+    batch = next(iter(eval_batches))
+    assert batch[0].tolist() == [[10, 1, 20, 2]]
+    assert batch[2].tolist() == [[-100, -100, -100, 2]]
+
+
+def test_length_declaring_text_stream_supports_epoch_replay():
+    MLXTrainer, trainer = _streaming_text_trainer(
+        max_steps=0, num_train_epochs=2,
+        completion_only_loss=False, dataset_order="sequential",
+        per_device_train_batch_size=2, gradient_accumulation_steps=1,
+    )
+    trainer.train_dataset = _DeclaredTextRows([
+        {"text": f"{value} {value + 10}"} for value in range(1, 6)
+    ])
+    batches, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
+
+    assert batches is None
+    assert trainer._streaming_epoch_batch_count == 3
+    signatures = [_streaming_batch_signature(next(iterator)) for _ in range(4)]
+    assert signatures[3] == signatures[0]
+    assert trainer.train_dataset.epochs == [0, 1]
+
+
+def test_epoch_stream_rejects_ambiguous_or_inexact_cardinality_lazily():
+    MLXTrainer, trainer = _streaming_text_trainer(
+        max_steps=0, num_train_epochs=1,
+        completion_only_loss=False, per_device_train_batch_size=2,
+        gradient_accumulation_steps=1,
+    )
+    trainer.train_dataset = _DeclaredTextRows([{"text": "1 2"}])
+    trainer.formatting_func = lambda row: row
+    with pytest.raises(ValueError, match="formatting_func.*max_steps"):
+        MLXTrainer._prepare_data(trainer, is_vlm=False)
+    assert trainer.train_dataset.pulls == 0
+
+    trainer.formatting_func = None
+    trainer.train_dataset = _DeclaredTextRows([{"text": "1 2"}, {"text": ""}])
+    _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
+    with pytest.raises(ValueError, match="declared length"):
+        next(iterator)
+
+    class UnderDeclared(_DeclaredTextRows):
+        def __len__(self): return 2
         def __iter__(self):
-            return iter(self.rows)
+            for row in ({"text": "1 2"}, {"text": "3 4"}, {"text": ""}):
+                self.pulls += 1
+                yield row
+            raise AssertionError("must reject the first overflow row")
+    trainer.train_dataset = UnderDeclared([
+        {"text": "unused"},
+    ])
+    _, iterator = MLXTrainer._prepare_data(trainer, is_vlm=False)
+    with pytest.raises(ValueError, match="exactly one trainable"):
+        next(iterator)
+    assert trainer.train_dataset.pulls == 3
 
+    trainer.args.gradient_accumulation_steps = 2
+    trainer.args.num_train_epochs = 2
+    trainer.train_dataset = _DeclaredTextRows([
+        {"text": "1 2"}, {"text": "3 4"}, {"text": "5 6"},
+        {"text": "7 8"}, {"text": "9 10"},
+    ])
+    with pytest.raises(ValueError, match="divisible.*gradient_accumulation"):
+        MLXTrainer._prepare_data(trainer, is_vlm=False)
+    assert trainer.train_dataset.pulls == 0
+
+
+def test_raw_text_streaming_matches_sized_sequential_order():
     rows = [{"value": value} for value in range(1, 6)]
     kwargs = {
         "batch_size": 2,
@@ -1058,7 +1213,7 @@ def test_raw_text_streaming_matches_sized_sequential_order():
         },
     }
     expected = _streaming_text_batches(rows, **kwargs)
-    actual = _streaming_text_batches(ReplayableRows(rows), **kwargs)
+    actual = _streaming_text_batches(_CountingTextRows(rows), **kwargs)
     assert [_streaming_batch_signature(next(actual)) for _ in range(3)] == [
         _streaming_batch_signature(next(expected)) for _ in range(3)
     ]
@@ -1137,56 +1292,6 @@ def test_text_streaming_rejects_incremental_schema_drift(rows, match):
     with pytest.raises(ValueError, match=match):
         next(batches)
 
-
-def test_response_masking_preserves_pretokenized_label_state_validation():
-    rows = iter([
-        {"input_ids": [1, 2], "labels": [-100, 2]},
-        {"input_ids": [3, 4]},
-    ])
-
-    def response_mask(batch):
-        return {
-            "labels": [[-100, input_ids[-1]] for input_ids in batch["input_ids"]]
-        }
-
-    batches = _streaming_text_batches(
-        rows,
-        completion_only_loss=False,
-        response_mask_fn=response_mask,
-    )
-    next(batches)
-    with pytest.raises(ValueError, match="must not be mixed"):
-        next(batches)
-
-
-def test_response_masking_does_not_replace_formatter_completion_boundary():
-    def response_mask(batch):
-        return {
-            "labels": [[-100, input_ids[-1]] for input_ids in batch["input_ids"]]
-        }
-
-    batches = _streaming_text_batches(
-        iter([{"prompt": "1", "completion": " 2"}]),
-        formatting_func=lambda _row: {"input_ids": [1, 2]},
-        response_mask_fn=response_mask,
-    )
-    with pytest.raises(ValueError, match="drops the completion boundary"):
-        next(batches)
-
-
-@pytest.mark.parametrize("formatted", [{"input_ids": [1, 2]}, {"text": "1 2"}])
-def test_fully_masked_response_still_validates_completion_boundary(formatted):
-    batches = _streaming_text_batches(
-        iter([{"prompt": "1", "completion": " 2"}]),
-        formatting_func=lambda _row: formatted,
-        response_mask_fn=lambda batch: {
-            "labels": [[-100] * len(ids) for ids in batch["input_ids"]]
-        },
-    )
-    with pytest.raises(ValueError, match="drops the completion boundary"):
-        next(batches)
-
-
 def test_hf_stream_replays_in_source_order_and_sets_epoch():
     from datasets import IterableDataset
 
@@ -1229,6 +1334,15 @@ def test_one_shot_stream_exhaustion_and_resume_are_actionable():
     _, resumed = MLXTrainer._prepare_data(trainer, is_vlm=False)
     with pytest.raises(RuntimeError, match="replayable iterable"):
         next(resumed)
+
+    MLXTrainer, evaluator = _streaming_text_trainer(
+        max_steps=1, completion_only_loss=False,
+    )
+    source = ({"text": "1 2"} for _ in range(1))
+    eval_batches = evaluator._create_text_eval_batches(source, 1, False, False)
+    with pytest.raises(RuntimeError, match="replayable iterable"):
+        next(iter(eval_batches))
+    assert next(source) == {"text": "1 2"}
 
 
 def test_hf_stream_resume_fast_forward_matches_uninterrupted_order():
@@ -1496,6 +1610,7 @@ def test_train_on_responses_only_forwards_last_response_only(monkeypatch):
     from unsloth_zoo.mlx.trainer import train_on_responses_only
 
     class CallableTokenizer:
+        chat_template = None
         def __call__(self, text, **kwargs):
             return {"input_ids": [1, 2, 3]}
 
@@ -1508,67 +1623,17 @@ def test_train_on_responses_only_forwards_last_response_only(monkeypatch):
         return lambda batch: batch
 
     monkeypatch.setattr(dataset_utils, "train_on_responses_only", fake_hf)
+    tokenizer = CallableTokenizer()
     train_on_responses_only(
         None,
         instruction_part="<user>",
         response_part="<assistant>",
-        tokenizer=CallableTokenizer(),
+        tokenizer=tokenizer,
         return_function=True,
         last_response_only=True,
     )
 
     assert received["last_response_only"] is True
-
-
-def test_response_mask_closure_does_not_normalize_explicit_tokenizer(monkeypatch):
-    import unsloth_zoo.dataset_utils as dataset_utils
-    from unsloth_zoo.mlx.trainer import train_on_responses_only
-
-    class CallableTokenizer:
-        chat_template = None
-        def __call__(self, text, **kwargs):
-            return {"input_ids": [1, 2, 3]}
-
-    tokenizer = CallableTokenizer()
-    trainer = types.SimpleNamespace(
-        _is_vlm=False,
-        args=types.SimpleNamespace(
-            streaming=True,
-            chat_template="{{ messages }}",
-        ),
-        model=types.SimpleNamespace(_config={}),
-        tokenizer=tokenizer,
-        _train_dataset_for_batches=lambda: iter([{"text": "1 2"}]),
-    )
-    monkeypatch.setattr(
-        dataset_utils,
-        "train_on_responses_only",
-        lambda *args, **kwargs: (lambda batch: batch),
-    )
-
-    train_on_responses_only(
-        trainer,
-        instruction_part="<user>",
-        response_part="<assistant>",
-        tokenizer=tokenizer,
-        return_function=True,
-    )
-
-    assert tokenizer.chat_template is None
-
-
-def test_response_mask_tokenizer_rejects_encode_only_tokenizer():
-    from unsloth_zoo.mlx.trainer import _resolve_response_mask_tokenizer
-
-    class EncodeOnlyTokenizer:
-        def encode(self, text):
-            return [1, 2, 3]
-
-        def convert_tokens_to_ids(self, token):
-            return 1
-
-    with pytest.raises(TypeError, match="requires a callable"):
-        _resolve_response_mask_tokenizer(EncodeOnlyTokenizer())
 
 
 def test_vlm_eval_batches_define_completion_only_loss_before_use():
@@ -1578,12 +1643,10 @@ def test_vlm_eval_batches_define_completion_only_loss_before_use():
 
     source = inspect.getsource(MLXTrainer._train_inner)
     definition = source.index("text_completion_only_loss = _text_completion_only_loss_arg(args)")
-    eval_use = source.index("completion_only_loss=text_completion_only_loss")
-    text_eval_start = source.index("return create_batches(")
-    text_eval_end = source.index("if isinstance(self.eval_dataset, dict)")
-    text_eval_block = source[text_eval_start:text_eval_end]
+    eval_use = source.index("text_completion_only_loss,")
+    text_eval_block = inspect.getsource(MLXTrainer._create_text_eval_batches)
     assert definition < eval_use
-    assert "completion_only_loss=text_completion_only_loss" in text_eval_block
+    assert "completion_only_loss=completion_only_loss" in text_eval_block
 
 
 def test_evaluate_dict_eval_datasets_records_split_metrics():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -3546,7 +3546,7 @@ def test_epoch_permuted_visits_are_deterministic_and_guard_enumerated():
     )
 
 
-def test_horizontal_concat_streaming_eval_infinite_only_if_all_children_infinite():
+def test_concat_streaming_eval_is_infinite_when_any_child_is():
     from unsloth_zoo.mlx.trainer import _mlx_stream_declares_infinite
 
     class RepeatExamplesIterable:  # HF infinite marker: num_times=None
@@ -3566,11 +3566,45 @@ def test_horizontal_concat_streaming_eval_infinite_only_if_all_children_infinite
         def __init__(self, ex): self._ex_iterable = ex
 
     inf, fin = RepeatExamplesIterable(), _FiniteChild()
-    # Horizontal (lockstep) ends with the shortest child -> finite if any is.
+    # Horizontal concat drops each child as it is exhausted and stops only once
+    # all of them are gone, so it ends with the LONGEST child.
     assert _mlx_stream_declares_infinite(
-        _Src(HorizontallyConcatenatedMultiSourcesExamplesIterable([inf, fin]))) is False
+        _Src(HorizontallyConcatenatedMultiSourcesExamplesIterable([inf, fin]))) is True
     assert _mlx_stream_declares_infinite(
-        _Src(HorizontallyConcatenatedMultiSourcesExamplesIterable([inf, inf]))) is True
+        _Src(HorizontallyConcatenatedMultiSourcesExamplesIterable([fin, inf]))) is True
+    assert _mlx_stream_declares_infinite(
+        _Src(HorizontallyConcatenatedMultiSourcesExamplesIterable([fin, fin]))) is False
     # Vertical (sequential) is infinite if any child is.
     assert _mlx_stream_declares_infinite(
         _Src(VerticallyConcatenatedMultiSourcesExamplesIterable([inf, fin]))) is True
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+def test_real_hf_concat_infinite_detection_matches_actual_termination(axis):
+    """Pin the detector against real ``datasets`` concat termination."""
+    from datasets import IterableDataset, concatenate_datasets
+    from unsloth_zoo.mlx.trainer import _mlx_stream_declares_infinite
+
+    # Generator-backed so the axis=1 cross-check does not hit the arrow-path
+    # cast that datasets raises for a ragged column-wise concat.
+    def rows(column, n):
+        return lambda: ({column: str(i)} for i in range(n))
+
+    finite = IterableDataset.from_generator(rows("a", 3))
+    other = IterableDataset.from_generator(rows("b" if axis else "a", 2))
+    for children, expected in (
+        ((finite, other), False),
+        ((finite, other.repeat(None)), True),
+        ((finite.repeat(None), other), True),
+    ):
+        combined = concatenate_datasets(list(children), axis=axis)
+        assert _mlx_stream_declares_infinite(combined) is expected
+        if not expected:  # a finite stream must actually terminate
+            assert sum(1 for _ in combined) < 1000
+        else:  # an infinite stream must keep producing past every child's length
+            produced = 0
+            for _ in combined:
+                produced += 1
+                if produced > 1000:
+                    break
+            assert produced > 1000

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -1133,8 +1133,7 @@ def test_trainer_drives_dynamic_lr_outside_optimizer_scheduler():
     legacy_values = [getattr(MLXTrainingConfig(), field.name) for field in legacy_fields]
     _legacy_names = [field.name for field in legacy_fields]
     legacy_values[_legacy_names.index("warmup_ratio")] = 0.1
-    # image_size is an object field; set it by name (the optional-copy fields
-    # are the trailing suffix, so image_size is no longer the last legacy field).
+    # image_size is no longer the last legacy field, so set it by name.
     legacy_values[_legacy_names.index("image_size")] = (128, 256)
     copied_ratio_trainer.args = MLXTrainingConfig(*legacy_values)
     assert copied_ratio_trainer.args.image_size == (128, 256)
@@ -3157,8 +3156,8 @@ def test_streaming_window_identity_grouping_padding_gate_and_ddp_slice():
     assert grouped == _window_batches(rows, window=4) != baseline
     assert [ids for ids, _ in _window_batches(rows, window=4, seed=1)] != [ids for ids, _ in grouped]
 
-    # Single-process windowed slicing must see an EMPTY pad_source (cycle
-    # padding is multi-rank-only) and leave the partial tail short.
+    # Single process: pad_source must be empty (cycle padding is multi-rank only)
+    # and the partial tail stays short.
     from unsloth_zoo.mlx import utils as mlx_utils
     odd, seen_pads = _window_rows(_WINDOW_LENGTHS[:7]), []
     original = mlx_utils._rank_slice_distributed_batch
@@ -3296,8 +3295,7 @@ def test_host_staging_seam_parity_and_host_valued_flag():
     assert not _stage_tokenized_text_batch(
         [(mx.array([7, 8]), None), ([1, 2], None)], 8).host_valued
 
-    # Raw-text pipeline end-to-end: an mx-returning tokenizer must surface as a
-    # host_valued=False STAGED batch (the raw stager forwards the stream flag).
+    # An mx-returning tokenizer must stage host_valued=False end to end.
     class MxRawTok(_StreamingTextTokenizer):
         def encode(self, text, add_special_tokens=True):
             return mx.array(super().encode(text, add_special_tokens))
@@ -3344,16 +3342,14 @@ def test_streaming_prefetch_identity_laziness_and_knob():
     assert "streaming_prefetch_batches" in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
     assert MLXTrainingConfig().streaming_prefetch_batches == 0  # default OFF
 
-    # Producer-side resume skip parity: first batch equals the sync sequence
-    # at the skip offset (single skip authority — no double fast-forward).
+    # Resume skip parity: first batch equals sync at the skip offset, once only.
     sync_all = _window_batches(rows, window=4)
     skipped = _window_stream(rows, window=4, prefetch_batches=2,
                              prefetch_skip_batches=2)
     first_after_skip = [row[0] for row in next(iter(skipped))[0].tolist()]
     assert first_after_skip == sync_all[2][0]
 
-    # Trainer records prefetch eligibility synchronously (guards its own
-    # legacy fast-forward) and the orphan gate survives exceptional teardown.
+    # Eligibility is recorded synchronously and the orphan gate survives teardown.
     _T, trainer = _streaming_text_trainer(
         per_device_train_batch_size=2, max_seq_length=64,
         streaming_prefetch_batches=2)
@@ -3566,8 +3562,7 @@ def test_concat_streaming_eval_is_infinite_when_any_child_is():
         def __init__(self, ex): self._ex_iterable = ex
 
     inf, fin = RepeatExamplesIterable(), _FiniteChild()
-    # Horizontal concat drops each child as it is exhausted and stops only once
-    # all of them are gone, so it ends with the LONGEST child.
+    # Horizontal concat ends with the longest child, so any infinite child wins.
     assert _mlx_stream_declares_infinite(
         _Src(HorizontallyConcatenatedMultiSourcesExamplesIterable([inf, fin]))) is True
     assert _mlx_stream_declares_infinite(
@@ -3585,8 +3580,7 @@ def test_real_hf_concat_infinite_detection_matches_actual_termination(axis):
     from datasets import IterableDataset, concatenate_datasets
     from unsloth_zoo.mlx.trainer import _mlx_stream_declares_infinite
 
-    # Generator-backed so the axis=1 cross-check does not hit the arrow-path
-    # cast that datasets raises for a ragged column-wise concat.
+    # Generator-backed: the arrow path rejects a ragged axis=1 concat.
     def rows(column, n):
         return lambda: ({column: str(i)} for i in range(n))
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1310,3 +1310,69 @@ def test_vlm_prefetch_identity_laziness_and_masked_rejection():
         next(iter(stream(masked_probe, prefetch_batches=1,
                          response_mask_fn=lambda b: {"labels": b["input_ids"]})))
     assert masked_probe.pulls == 0 and masked_probe.epochs == []
+
+
+def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
+    """Lazy processor-owned MLX graphs must cross the prefetch boundary.
+
+    Regression: without the producer-side materialization barrier, consumer
+    evaluation raises "There is no Stream ... in current thread". Label
+    decisions for both opaque routes (plain-SFT and prompt/completion) must
+    run on the consumer thread only.
+    """
+    import threading
+
+    import mlx.core as mx
+
+    from unsloth_zoo.mlx import utils as U
+
+    class LazyMxProcessor(_FakeProcessor):
+        def __call__(self, text, **kwargs):
+            out = super().__call__(text, **kwargs)
+            ids = np.asarray(out["input_ids"])
+            ids = ids.reshape(1, -1) if ids.ndim == 1 else ids
+            rows, width = ids.shape
+            return {
+                "input_ids": mx.broadcast_to(mx.arange(1, width + 1), (rows, width)),
+                "attention_mask": mx.broadcast_to(mx.array(1), (rows, width)),
+            }
+
+    label_threads = []
+    legacy_masks = U._apply_vlm_label_masks
+
+    def _spy(*args, **kwargs):
+        label_threads.append(threading.current_thread())
+        return legacy_masks(*args, **kwargs)
+
+    monkeypatch.setattr(U, "_apply_vlm_label_masks", _spy)
+
+    def stream(source, **kwargs):
+        kwargs.setdefault("batch_size", 2)
+        return U.iterate_vlm_training_batches(
+            dataset=source, processor=LazyMxProcessor(), config={},
+            max_seq_length=8, **kwargs)
+
+    it = iter(stream(_LifecycleVLMRows(4), prefetch_batches=1))
+    batch = next(it)
+    mx.eval(batch["input_ids"], batch["labels"])  # consumer-side evaluation
+    assert np.asarray(batch["input_ids"]).tolist() == [[1, 2, 3, 4, 5]] * 2
+    it.close()
+
+    pc_rows = [{"prompt": "101", "completion": "102"},
+               {"prompt": "103", "completion": "104"}]
+
+    def take(iterator, count):
+        taken = []
+        for _ in range(count):
+            b = next(iterator)
+            taken.append((np.asarray(b["input_ids"]).tolist(),
+                          np.asarray(b["labels"]).tolist(), b["labels"].dtype))
+        return taken
+
+    sync_seq = take(iter(stream(pc_rows, batch_size=1)), 2)
+    pf_it = iter(stream(pc_rows, batch_size=1, prefetch_batches=1))
+    pf_seq = take(pf_it, 2)
+    pf_it.close()
+    assert pf_seq == sync_seq  # bit-for-bit parity with the sync legacy route
+    assert label_threads and all(
+        t is threading.main_thread() for t in label_threads)

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -915,3 +915,195 @@ def test_gemma3_vlm_hidden_stack_uses_image_mask_and_embed_scale():
     assert mx.allclose(out, mx.full((1, 4, 4), 2.0))
     assert mx.allclose(layer.seen_h, mx.full((1, 4, 4), 2.0))
     assert layer.seen_mask[0, 0].tolist()[1] == [True, True, True, False]
+
+
+class _LifecycleVLMRows:
+    """Unsized replayable VLM source with consumption/epoch instrumentation."""
+
+    def __init__(self, count=6):
+        self.count, self.pulls, self.epochs = count, 0, []
+
+    def set_epoch(self, epoch):
+        self.epochs.append(epoch)
+
+    def __iter__(self):
+        def _gen():
+            for i in range(self.count):
+                self.pulls += 1
+                yield {"text": str(101 + i)}
+        return _gen()
+
+
+def _lazy_vlm(dataset, **kwargs):
+    from unsloth_zoo.mlx.utils import iterate_vlm_training_batches
+    options = dict(processor=_FakeProcessor(), config={}, batch_size=2, max_seq_length=8)
+    return iterate_vlm_training_batches(dataset=dataset, **(options | kwargs))
+
+
+def test_vlm_lazy_lifecycle_replay_oneshot_and_fast_forward():
+    source = _LifecycleVLMRows(6)
+    stream = _lazy_vlm(source)
+    assert source.pulls == 0 and source.epochs == []      # construction-lazy
+    first = next(stream)["input_ids"].tolist()
+    assert source.pulls == 2 and source.epochs == [0]     # bounded first yield
+    for _ in range(2):
+        next(stream)
+    assert next(stream)["input_ids"].tolist() == first    # replay restart
+    assert source.epochs == [0, 1]
+
+    rows = [{"text": str(101 + i)} for i in range(4)]
+    one_shot = _lazy_vlm(iter(list(rows)))
+    for _ in range(2):
+        next(one_shot)
+    with pytest.raises(RuntimeError, match="one-shot"):
+        next(one_shot)
+
+    consumed = []
+    def counting():
+        for row in rows:
+            consumed.append(row)
+            yield row
+    with pytest.raises(RuntimeError, match="replayable"):
+        next(_lazy_vlm(counting(), require_replayable=True))
+    assert consumed == []                                  # rejected pre-consumption
+
+    steady = _lazy_vlm(_LifecycleVLMRows(6))
+    uninterrupted = [next(steady)["input_ids"].tolist() for _ in range(5)]
+    resumed = _lazy_vlm(_LifecycleVLMRows(6), require_replayable=True)
+    for _ in range(4):
+        next(resumed)
+    assert next(resumed)["input_ids"].tolist() == uninterrupted[4]
+
+
+def test_vlm_lazy_declared_epochs_and_pre_consumption_rejections():
+    exact = _lazy_vlm(_LifecycleVLMRows(4), expected_rows_per_pass=4)
+    seen = [next(exact)["input_ids"].tolist() for _ in range(4)]
+    assert seen[0] == seen[2]                              # deferred final + replay
+
+    overrun, emitted = _lazy_vlm(_LifecycleVLMRows(4), expected_rows_per_pass=3), []
+    with pytest.raises(ValueError, match="declared length"):
+        while True:
+            emitted.append(next(overrun))
+    assert len(emitted) == 1                               # deferred final withheld
+
+    underrun = _lazy_vlm(_LifecycleVLMRows(4), expected_rows_per_pass=5)
+    for _ in range(2):
+        next(underrun)
+    with pytest.raises(ValueError, match="declared length"):
+        next(underrun)
+
+    def mask_fn(batch):
+        return {"labels": [[-100] * len(r) if r[0] == 101 else list(r)
+                           for r in batch["input_ids"]]}
+    filtered = _lazy_vlm(_LifecycleVLMRows(4), expected_rows_per_pass=4,
+                         processor=_ResponseMaskFilteringProcessor(),
+                         response_mask_fn=mask_fn)
+    with pytest.raises(ValueError, match="exactly one trainable"):
+        for _ in range(4):
+            next(filtered)
+
+    class FakeWorld:
+        def rank(self): return 0
+        def size(self): return 2
+    ddp_probe = _LifecycleVLMRows(4)
+    with pytest.raises(ValueError, match="DDP training"):
+        next(_lazy_vlm(ddp_probe, comm_group=FakeWorld()))
+    assert ddp_probe.pulls == 0 and ddp_probe.epochs == []
+    with pytest.raises(ValueError, match="torch_randperm"):
+        next(_lazy_vlm(_LifecycleVLMRows(4), dataset_order="torch_randperm"))
+
+
+def test_vlm_sized_index_routing_guard_and_cleanup():
+    from unsloth_zoo.mlx.utils import create_vlm_batches, iterate_vlm_training_batches
+
+    class SizedIterableMap:
+        """Map-style dataset that ALSO iterates (must stay on the sized path)."""
+        def __init__(self):
+            self.rows = [{"text": str(101 + i)} for i in range(4)]
+        def __len__(self): return len(self.rows)
+        def __getitem__(self, idx): return self.rows[idx]
+        def __iter__(self): return iter(self.rows)
+
+    def _vlm_trainer_shell(world_size, dataset):
+        import types as _types
+        from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+        trainer = MLXTrainer.__new__(MLXTrainer)
+        trainer.args = MLXTrainingConfig(
+            per_device_train_batch_size=1, max_seq_length=8, streaming=True,
+        )
+        trainer.model = _types.SimpleNamespace(_config={})
+        trainer.tokenizer = _FakeProcessor()
+        trainer.processor = trainer.tokenizer
+        trainer.train_dataset = dataset
+        trainer._batches = None
+        trainer.formatting_func = None
+        trainer._distributed_initialized = True
+        trainer._distributed_world = None
+        trainer._distributed_world_size = world_size
+        return trainer
+
+    # Trainer seam: a sized iterable-map hybrid must pass the DDP gate and
+    # batch via the sized path...
+    sized_trainer = _vlm_trainer_shell(2, SizedIterableMap())
+    _batches, sized_stream = sized_trainer._prepare_data(is_vlm=True)
+    assert next(sized_stream)["input_ids"].shape[0] == 1
+    # ...while a genuinely unsized source is rejected before consumption.
+    lazy_probe = _LifecycleVLMRows(4)
+    with pytest.raises(ValueError, match="DDP training"):
+        _vlm_trainer_shell(2, lazy_probe)._prepare_data(is_vlm=True)
+    assert lazy_probe.pulls == 0 and lazy_probe.epochs == []
+
+    with pytest.raises(ValueError, match="__len__ and __getitem__"):
+        create_vlm_batches(dataset=_LifecycleVLMRows(4), processor=_FakeProcessor(),
+                           config={}, batch_size=2, max_seq_length=8)
+
+    class LenOnlyRows(_LifecycleVLMRows):
+        def __len__(self): return self.count
+    assert next(_lazy_vlm(LenOnlyRows(4)))["input_ids"].shape[0] == 2
+
+    import torch.utils.data as tud
+    class TorchStyleRows(_LifecycleVLMRows, tud.IterableDataset):
+        def __init__(self): _LifecycleVLMRows.__init__(self, 4)
+        def __len__(self): return self.count
+    assert next(_lazy_vlm(TorchStyleRows()))["input_ids"].shape[0] == 2
+
+    class GetattrProxyRows(_LifecycleVLMRows):
+        """Instance __getattr__ proxies must not classify as sized."""
+        def __len__(self): return self.count
+        def __getattr__(self, name):
+            if name == "__getitem__":
+                return lambda idx: {"text": "999"}
+            raise AttributeError(name)
+    proxied = GetattrProxyRows(4)
+    assert next(_lazy_vlm(proxied))["input_ids"].shape[0] == 2
+    assert proxied.pulls == 2                              # iterated, not indexed
+
+    closed = []
+    class RecordingCursor:
+        def __init__(self, name, rows, explode_on_close=False):
+            self._name, self._rows, self._explode = name, iter(rows), explode_on_close
+        def __iter__(self): return self
+        def __next__(self): return next(self._rows)
+        def close(self):
+            closed.append(self._name)
+            if self._explode:
+                raise RuntimeError("close exploded")
+    class ClosingRows:
+        def __init__(self): self.handed = 0
+        def __iter__(self):
+            self.handed += 1
+            name = "serving" if self.handed == 1 else "cached"
+            return RecordingCursor(name, [{"text": "101"}, {"text": "boom"}],
+                                   explode_on_close=(name == "serving"))
+    class ExplodingProcessor(_FakeProcessor):
+        def __call__(self, text, **kwargs):
+            if any("boom" in str(item) for item in text):
+                raise RuntimeError("processor exploded")
+            return super().__call__(text, **kwargs)
+    stream = _lazy_vlm(ClosingRows(), processor=ExplodingProcessor(), batch_size=1,
+                       require_replayable=True)
+    next(stream)
+    with pytest.raises(RuntimeError, match="processor exploded"):
+        next(stream)
+    stream.close()
+    assert sorted(closed) == ["cached", "serving"]         # both closed, error kept

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1329,9 +1329,7 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
     class LazyMxProcessor(_FakeProcessor):
         def __call__(self, text, **kwargs):
             out = super().__call__(text, **kwargs)
-            ids = np.asarray(out["input_ids"])
-            ids = ids.reshape(1, -1) if ids.ndim == 1 else ids
-            rows, width = ids.shape
+            rows, width = np.asarray(out["input_ids"]).shape
             return {
                 "input_ids": mx.broadcast_to(mx.arange(1, width + 1), (rows, width)),
                 "attention_mask": mx.broadcast_to(mx.array(1), (rows, width)),
@@ -1358,8 +1356,10 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
     assert np.asarray(batch["input_ids"]).tolist() == [[1, 2, 3, 4, 5]] * 2
     it.close()
 
-    pc_rows = [{"prompt": "101", "completion": "102"},
-               {"prompt": "103", "completion": "104"}]
+    class _PCRows:  # replayable UNSIZED source: the pc_opaque producer runs
+        def __iter__(self):
+            return iter([{"prompt": "101", "completion": "102"},
+                         {"prompt": "103", "completion": "104"}])
 
     def take(iterator, count):
         taken = []
@@ -1369,13 +1369,14 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
                           np.asarray(b["labels"]).tolist(), b["labels"].dtype))
         return taken
 
-    sync_seq = take(iter(stream(pc_rows, batch_size=1)), 2)
-    pf_it = iter(stream(pc_rows, batch_size=1, prefetch_batches=1))
-    pf_seq = take(pf_it, 2)
-    pf_it.close()
-    assert pf_seq == sync_seq  # bit-for-bit parity with the sync legacy route
-    assert label_threads and all(
-        t is threading.main_thread() for t in label_threads)
+    for pc_loss in (None, False):
+        sync_seq = take(iter(stream(
+            _PCRows(), batch_size=1, completion_only_loss=pc_loss)), 2)
+        pf_it = iter(stream(_PCRows(), batch_size=1, prefetch_batches=1,
+                            completion_only_loss=pc_loss))
+        assert take(pf_it, 2) == sync_seq  # parity incl. label dtypes
+        pf_it.close()
+    assert label_threads and set(label_threads) == {threading.main_thread()}
 
     # pc_opaque carries tokenizer-derived data, never the live processor:
     # finalize must succeed after the tokenizer is torn down.
@@ -1385,7 +1386,8 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
 
     proc = LazyMxProcessor()
     staged = U._collate_vlm_prompt_completion_batch(
-        pc_rows[:1], proc, 8, None, reject_mlx_valued=True)
+        [{"prompt": "101", "completion": "102"}], proc, 8, None,
+        reject_mlx_valued=True)
     assert staged.pc_opaque is not None
     proc.tokenizer = _PoisonedTokenizer()
     poisoned = U._finalize_vlm_batch(staged)

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1184,9 +1184,13 @@ def test_vlm_host_label_authority_and_staged_finalize():
         def __call__(self, text, **kwargs):
             out = super().__call__(text, **kwargs)
             return {k: mx.array(v) for k, v in out.items()}
-    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
-        _collate_vlm_batch([{"text": "101"}], MxProcessor(), 8, None,
-                           reject_mlx_valued=True)
+    # Processor-owned MLX outputs (mlx-vlm wrappers) stage OPAQUELY in
+    # producer mode: labels defer to the consumer-side finalizer.
+    opaque = _collate_vlm_batch([{"text": "101"}], MxProcessor(), 8, None,
+                                reject_mlx_valued=True)
+    assert opaque.host_valued is False and opaque.label_mask is None
+    finalized_opaque = _finalize_vlm_batch(opaque)
+    assert "labels" in finalized_opaque
     from unsloth_zoo.mlx.utils import _build_response_masked_vlm_batch as _brm
     with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
         _brm([{"text": "101"}], _FakeProcessor(), {}, 8, None,

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1034,37 +1034,20 @@ def test_vlm_sized_index_routing_guard_and_cleanup():
         def __getitem__(self, idx): return self.rows[idx]
         def __iter__(self): return iter(self.rows)
 
-    def _vlm_trainer_shell(world_size, dataset):
-        import types as _types
-        from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
-        trainer = MLXTrainer.__new__(MLXTrainer)
-        trainer.args = MLXTrainingConfig(
-            per_device_train_batch_size=1, max_seq_length=8, streaming=True,
-        )
-        trainer.model = _types.SimpleNamespace(_config={})
-        trainer.tokenizer = _FakeProcessor()
-        trainer.processor = trainer.tokenizer
-        trainer.train_dataset = dataset
-        trainer._batches = None
-        trainer.formatting_func = None
-        trainer._distributed_initialized = True
-        trainer._distributed_world = None
-        trainer._distributed_world_size = world_size
-        return trainer
 
     # Trainer seam: a sized iterable-map hybrid must pass the DDP gate and
     # batch via the sized path...
-    sized_trainer = _vlm_trainer_shell(2, SizedIterableMap())
+    sized_trainer = _vlm_trainer_shell_for(world_size=2, dataset=SizedIterableMap())
     _batches, sized_stream = sized_trainer._prepare_data(is_vlm=True)
     assert next(sized_stream)["input_ids"].shape[0] == 1
-    knob_trainer = _vlm_trainer_shell(1, SizedIterableMap())
+    knob_trainer = _vlm_trainer_shell_for(world_size=1, dataset=SizedIterableMap())
     knob_trainer.args.streaming_prefetch_batches = 1
     _b2, s2 = knob_trainer._prepare_data(is_vlm=True)  # notice path must not crash
     assert next(s2)["input_ids"].shape[0] == 1
     # ...while a genuinely unsized source is rejected before consumption.
     lazy_probe = _LifecycleVLMRows(4)
     with pytest.raises(ValueError, match="DDP training"):
-        _vlm_trainer_shell(2, lazy_probe)._prepare_data(is_vlm=True)
+        _vlm_trainer_shell_for(world_size=2, dataset=lazy_probe)._prepare_data(is_vlm=True)
     assert lazy_probe.pulls == 0 and lazy_probe.epochs == []
 
     with pytest.raises(ValueError, match="__len__ and __getitem__"):
@@ -1249,3 +1232,77 @@ def test_vlm_host_label_authority_and_staged_finalize():
         [{"text": "101"}], WideProcessor(), {}, 8, None,
         response_mask_fn=identity_closure)
     assert seen["first"] == 2**32 - 100
+
+
+def _vlm_trainer_shell_for(dataset, world_size=1, prefetch=0):
+    import types as _types
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.args = MLXTrainingConfig(
+        per_device_train_batch_size=1, max_seq_length=8, streaming=True,
+        streaming_prefetch_batches=prefetch,
+    )
+    trainer.model = _types.SimpleNamespace(_config={})
+    trainer.tokenizer = _FakeProcessor()
+    trainer.processor = trainer.tokenizer
+    trainer.train_dataset = dataset
+    trainer.formatting_func = None
+    trainer._batches = None
+    trainer._distributed_initialized = True
+    trainer._distributed_world = None
+    trainer._distributed_world_size = world_size
+    return trainer
+
+
+def test_vlm_prefetch_identity_laziness_and_masked_rejection():
+    from unsloth_zoo.mlx.utils import iterate_vlm_training_batches
+
+    class ContentProcessor(_FakeProcessor):
+        """Encodes each row's text so batch content tracks source order."""
+        def __call__(self, text, **kwargs):
+            out = super().__call__(text, **kwargs)
+            ids = np.asarray(out["input_ids"]).copy()
+            for row, value in enumerate(text):
+                ids[row, 0] = int(str(value).split()[0])
+            out["input_ids"] = ids
+            return out
+
+    def stream(source, **kwargs):
+        return iterate_vlm_training_batches(
+            dataset=source, processor=ContentProcessor(), config={},
+            batch_size=2, max_seq_length=8, **kwargs)
+
+    sync = [b["input_ids"].tolist()
+            for b in (lambda it: [next(it) for _ in range(4)])(
+                iter(stream(_LifecycleVLMRows(6))))]
+    assert sync[0] != sync[1]  # content varies with source rows
+    control = {}
+    prefetched_iter = iter(stream(_LifecycleVLMRows(6), prefetch_batches=2,
+                                  prefetch_control=control))
+    prefetched = [next(prefetched_iter)["input_ids"].tolist() for _ in range(4)]
+    assert prefetched == sync  # bit-for-bit consumer-visible sequence
+    assert control["prefetcher"].close()
+
+    # Trainer wiring: eligibility, control registration, and cleanup.
+    shell_probe = _LifecycleVLMRows(6)
+    trainer = _vlm_trainer_shell_for(shell_probe, prefetch=2)
+    _b, shell_stream = trainer._prepare_data(is_vlm=True)
+    assert trainer._mlx_prefetch_control.get("eligible") is True
+    assert next(iter(shell_stream))["input_ids"].shape[0] == 1
+    shell_pf = trainer._mlx_prefetch_control.get("prefetcher")
+    assert shell_pf is not None
+    trainer._active_batch_iter = shell_stream
+    trainer._close_active_batch_iterator()
+    assert trainer._mlx_prefetch_control.get("prefetcher") is None
+
+    probe = _LifecycleVLMRows(6)
+    lazy = iter(stream(probe, prefetch_batches=2))
+    assert probe.pulls == 0  # construction-lazy at P>0
+    next(lazy)
+    assert probe.pulls >= 2
+
+    masked_probe = _LifecycleVLMRows(4)
+    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+        next(iter(stream(masked_probe, prefetch_batches=1,
+                         response_mask_fn=lambda b: {"labels": b["input_ids"]})))
+    assert masked_probe.pulls == 0 and masked_probe.epochs == []

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -160,6 +160,16 @@ class _ConversationalPromptCompletionProcessor:
         }
 
 
+def _finalized_collate(*args, **kwargs):
+    """Direct-collate tests exercise the production staged+finalize composition."""
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch, _finalize_vlm_batch
+    result = _collate_vlm_batch(*args, **kwargs)
+    if isinstance(result, tuple):
+        staged, is_pc = result
+        return _finalize_vlm_batch(staged), is_pc
+    return _finalize_vlm_batch(result)
+
+
 def test_vlm_collate_creates_sft_labels_and_masks_special_tokens():
     from unsloth_zoo.mlx.utils import (
         _collate_vlm_batch,
@@ -171,7 +181,7 @@ def test_vlm_collate_creates_sft_labels_and_masks_special_tokens():
         processor=processor,
         config={"image_token_id": 200},
     )
-    batch = _collate_vlm_batch(
+    batch = _finalized_collate(
         [{"text": "first"}, {"text": "second"}],
         processor,
         max_seq_length=8,
@@ -425,13 +435,13 @@ def test_vlm_prompt_completion_skips_response_mask_like_cuda():
 def test_vlm_prompt_completion_honors_completion_only_loss_false():
     from unsloth_zoo.mlx.utils import _collate_vlm_batch
 
-    default_batch = _collate_vlm_batch(
+    default_batch = _finalized_collate(
         [{"prompt": "prompt", "completion": "completion"}],
         _PromptCompletionProcessor(),
         max_seq_length=8,
         image_size=16,
     )
-    batch = _collate_vlm_batch(
+    batch = _finalized_collate(
         [{"prompt": "prompt", "completion": "completion"}],
         _PromptCompletionProcessor(),
         max_seq_length=8,
@@ -447,7 +457,7 @@ def test_vlm_prompt_completion_conversational_uses_cuda_prompt_split():
     from unsloth_zoo.mlx.utils import _collate_vlm_batch
 
     processor = _ConversationalPromptCompletionProcessor()
-    batch = _collate_vlm_batch(
+    batch = _finalized_collate(
         [{
             "prompt": [{"role": "user", "content": [{"type": "text", "text": "Q"}]}],
             "completion": [{"role": "assistant", "content": [{"type": "text", "text": "A"}]}],
@@ -465,7 +475,7 @@ def test_vlm_prompt_completion_prefers_embedded_images_like_cuda():
     from unsloth_zoo.mlx.utils import _collate_vlm_batch
 
     processor = _ConversationalPromptCompletionProcessor()
-    _collate_vlm_batch(
+    _finalized_collate(
         [{
             "image": "top-level",
             "prompt": [{
@@ -1111,3 +1121,131 @@ def test_vlm_sized_index_routing_guard_and_cleanup():
         next(stream)
     stream.close()
     assert sorted(closed) == ["cached", "serving"]         # both closed, error kept
+
+
+def test_vlm_host_label_authority_and_staged_finalize():
+    import numpy as np
+    import mlx.core as mx
+    from unsloth_zoo.mlx.utils import (
+        _HostStagedVLMBatch, _collate_vlm_batch, _finalize_vlm_batch,
+        _stage_vlm_label_mask_np, _vlm_inputs_host_valued,
+        _RAW_INPUT_IDS_FOR_LABELS,
+    )
+
+    # Placement authority: ignore ids, attention zeros, existing -100s; float
+    # comparisons mirror the finalized float32/int32 narrowing.
+    mask = _stage_vlm_label_mask_np(
+        {"input_ids": np.array([[101, 200, 2, 7]]),
+         "attention_mask": np.array([[1, 1, 0, 1]])},
+        ignore_token_ids=[200])
+    assert mask.tolist() == [[False, True, True, False]]
+    fractional = _stage_vlm_label_mask_np(
+        {"input_ids": [[7, 8, 9]], "attention_mask": [[1, 0.5, 0.99999999]]})
+    assert fractional.tolist() == [[False, True, False]]
+
+    # Float/exotic token-id streams never stage: they route to the bit-exact
+    # legacy path (sync) and reject in producer modes.
+    from unsloth_zoo.mlx.utils import _vlm_ids_integer_host
+    assert _vlm_ids_integer_host({"input_ids": np.array([[1, 2]])}) is True
+    assert _vlm_ids_integer_host(
+        {"input_ids": np.array([[1.0, 2.0]], dtype=np.float64)}) is False
+    assert _vlm_ids_integer_host({"input_ids": [[1, 2.5]]}) is False
+    assert _vlm_ids_integer_host({"input_ids": [[1, True]]}) is False
+    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+        _collate_vlm_batch(
+            [{"text": "101", "images": [mx.array([1.0])]}],
+            _FakeProcessor(), 8, None, reject_mlx_valued=True)
+    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+        _collate_vlm_batch(
+            [{"text": "101"}], _FakeProcessor(), 8, None,
+            reject_mlx_valued=True,
+            formatting_func=lambda item: {
+                "text": item["text"], "images": [mx.array([1.0])],
+            })
+    class FloatProcessor(_FakeProcessor):
+        def __call__(self, text, **kwargs):
+            out = super().__call__(text, **kwargs)
+            out["input_ids"] = np.asarray(out["input_ids"], dtype=np.float32)
+            return out
+    floaty = _collate_vlm_batch([{"text": "101"}], FloatProcessor(), 8, None)
+    assert floaty.prefinalized is not None  # sync legacy route
+    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+        _collate_vlm_batch([{"text": "101"}], FloatProcessor(), 8, None,
+                           reject_mlx_valued=True)
+    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+        _collate_vlm_batch(
+            [{"prompt": "101", "completion": "102"}], FloatProcessor(), 8,
+            None, reject_mlx_valued=True)
+
+    # Finalized values ride the SAME converted ids as legacy (dtype/keys/carrier
+    # by construction), incl. the P/C completion-branch int64 widening.
+    plain = _finalized_collate([{"text": "101"}], _FakeProcessor(), 8, None)
+    assert plain["labels"].dtype == plain["input_ids"].dtype
+    assert _RAW_INPUT_IDS_FOR_LABELS not in plain
+    pc = _finalized_collate(
+        [{"prompt": "101", "completion": "102"}], _FakeProcessor(), 8, None)
+    assert pc["labels"].dtype == mx.int64  # legacy completion branch widens
+    off = _finalized_collate(
+        [{"prompt": "101", "completion": "102"}], _FakeProcessor(), 8, None,
+        completion_only_loss=False)
+    assert off["labels"].dtype == off["input_ids"].dtype
+
+    # MLX-returning processors flag host_valued=False (prefetch contract),
+    # including nested mappings; reject mode raises BEFORE any conversion.
+    assert _vlm_inputs_host_valued(
+        {"input_ids": np.array([[1]])}) is True
+    assert _vlm_inputs_host_valued(
+        {"pixel_values": {"tensor": mx.array([1])}}) is False
+
+    class MxProcessor(_FakeProcessor):
+        def __call__(self, text, **kwargs):
+            out = super().__call__(text, **kwargs)
+            return {k: mx.array(v) for k, v in out.items()}
+    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+        _collate_vlm_batch([{"text": "101"}], MxProcessor(), 8, None,
+                           reject_mlx_valued=True)
+    from unsloth_zoo.mlx.utils import _build_response_masked_vlm_batch as _brm
+    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+        _brm([{"text": "101"}], _FakeProcessor(), {}, 8, None,
+             response_mask_fn=lambda b: {"labels": b["input_ids"]},
+             yield_host_staged=True)
+    # Zero-touch iterator rejection: no set_epoch, no pull, no processor call.
+    from unsloth_zoo.mlx.utils import _iterate_lazy_vlm_training_batches
+    probe = _LifecycleVLMRows(4)
+    with pytest.raises(ValueError, match="streaming_prefetch_batches=0"):
+        next(_iterate_lazy_vlm_training_batches(
+            probe, _FakeProcessor(), {}, 2, 8,
+            response_mask_fn=lambda b: {"labels": b["input_ids"]},
+            yield_host_staged=True))
+    assert probe.pulls == 0 and probe.epochs == []
+
+    # Routed value-carrying closures finalize through the verbatim legacy
+    # pipeline: custom values (777) and identity-closure dtype both match.
+    from unsloth_zoo.mlx.utils import _build_response_masked_vlm_batch
+    def _value_closure(mask_batch):
+        width = len(mask_batch["input_ids"][0])
+        return {"labels": [[-100, 777] + [-100] * (width - 2)]}
+    routed = _build_response_masked_vlm_batch(
+        [{"text": "101"}], _FakeProcessor(), {}, 8, None,
+        response_mask_fn=_value_closure,
+    )
+    assert routed["labels"].tolist()[0][1] == 777  # custom value preserved
+    assert routed["labels"].dtype == mx.int64  # legacy value-pipeline dtype
+
+    # The raw wide-id carrier survives finalize for the legacy closure: an
+    # identity closure sees the invalid uint32 id, not a wrapped -100.
+    class WideProcessor(_FakeProcessor):
+        def __call__(self, text, **kwargs):
+            out = super().__call__(text, **kwargs)
+            ids = np.asarray(out["input_ids"], dtype=np.uint32)
+            ids[0, 0] = np.uint32(2**32 - 100)
+            out["input_ids"] = ids
+            return out
+    seen = {}
+    def identity_closure(mask_batch):
+        seen["first"] = int(mask_batch["input_ids"][0][0])
+        return {"labels": [list(row) for row in mask_batch["input_ids"]]}
+    _build_response_masked_vlm_batch(
+        [{"text": "101"}], WideProcessor(), {}, 8, None,
+        response_mask_fn=identity_closure)
+    assert seen["first"] == 2**32 - 100

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1376,3 +1376,17 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
     assert pf_seq == sync_seq  # bit-for-bit parity with the sync legacy route
     assert label_threads and all(
         t is threading.main_thread() for t in label_threads)
+
+    # pc_opaque carries tokenizer-derived data, never the live processor:
+    # finalize must succeed after the tokenizer is torn down.
+    class _PoisonedTokenizer:
+        def __getattr__(self, name):
+            raise AssertionError(f"finalize dereferenced tokenizer.{name}")
+
+    proc = LazyMxProcessor()
+    staged = U._collate_vlm_prompt_completion_batch(
+        pc_rows[:1], proc, 8, None, reject_mlx_valued=True)
+    assert staged.pc_opaque is not None
+    proc.tokenizer = _PoisonedTokenizer()
+    poisoned = U._finalize_vlm_batch(staged)
+    assert np.asarray(poisoned["input_ids"]).tolist() == sync_seq[0][0]

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1047,6 +1047,10 @@ def test_vlm_sized_index_routing_guard_and_cleanup():
     sized_trainer = _vlm_trainer_shell(2, SizedIterableMap())
     _batches, sized_stream = sized_trainer._prepare_data(is_vlm=True)
     assert next(sized_stream)["input_ids"].shape[0] == 1
+    knob_trainer = _vlm_trainer_shell(1, SizedIterableMap())
+    knob_trainer.args.streaming_prefetch_batches = 1
+    _b2, s2 = knob_trainer._prepare_data(is_vlm=True)  # notice path must not crash
+    assert next(s2)["input_ids"].shape[0] == 1
     # ...while a genuinely unsized source is rejected before consumption.
     lazy_probe = _LifecycleVLMRows(4)
     with pytest.raises(ValueError, match="DDP training"):

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1035,8 +1035,7 @@ def test_vlm_sized_index_routing_guard_and_cleanup():
         def __iter__(self): return iter(self.rows)
 
 
-    # Trainer seam: a sized iterable-map hybrid must pass the DDP gate and
-    # batch via the sized path...
+    # A sized iterable-map hybrid passes the DDP gate and batches via the sized path.
     sized_trainer = _vlm_trainer_shell_for(world_size=2, dataset=SizedIterableMap())
     _batches, sized_stream = sized_trainer._prepare_data(is_vlm=True)
     assert next(sized_stream)["input_ids"].shape[0] == 1
@@ -1044,7 +1043,7 @@ def test_vlm_sized_index_routing_guard_and_cleanup():
     knob_trainer.args.streaming_prefetch_batches = 1
     _b2, s2 = knob_trainer._prepare_data(is_vlm=True)  # notice path must not crash
     assert next(s2)["input_ids"].shape[0] == 1
-    # ...while a genuinely unsized source is rejected before consumption.
+    # A genuinely unsized source is rejected before consumption.
     lazy_probe = _LifecycleVLMRows(4)
     with pytest.raises(ValueError, match="DDP training"):
         _vlm_trainer_shell_for(world_size=2, dataset=lazy_probe)._prepare_data(is_vlm=True)
@@ -1115,8 +1114,7 @@ def test_vlm_host_label_authority_and_staged_finalize():
         _RAW_INPUT_IDS_FOR_LABELS,
     )
 
-    # Placement authority: ignore ids, attention zeros, existing -100s; float
-    # comparisons mirror the finalized float32/int32 narrowing.
+    # Mask ignore ids, attention zeros and existing -100s; floats narrow as finalized.
     mask = _stage_vlm_label_mask_np(
         {"input_ids": np.array([[101, 200, 2, 7]]),
          "attention_mask": np.array([[1, 1, 0, 1]])},
@@ -1126,8 +1124,7 @@ def test_vlm_host_label_authority_and_staged_finalize():
         {"input_ids": [[7, 8, 9]], "attention_mask": [[1, 0.5, 0.99999999]]})
     assert fractional.tolist() == [[False, True, False]]
 
-    # Float/exotic token-id streams never stage: they route to the bit-exact
-    # legacy path (sync) and reject in producer modes.
+    # Non-integer id streams never stage: legacy path in sync, reject in producer.
     from unsloth_zoo.mlx.utils import _vlm_ids_integer_host
     assert _vlm_ids_integer_host({"input_ids": np.array([[1, 2]])}) is True
     assert _vlm_ids_integer_host(
@@ -1160,8 +1157,7 @@ def test_vlm_host_label_authority_and_staged_finalize():
             [{"prompt": "101", "completion": "102"}], FloatProcessor(), 8,
             None, reject_mlx_valued=True)
 
-    # Finalized values ride the SAME converted ids as legacy (dtype/keys/carrier
-    # by construction), incl. the P/C completion-branch int64 widening.
+    # Finalized values ride the same converted ids as legacy, incl. int64 widening.
     plain = _finalized_collate([{"text": "101"}], _FakeProcessor(), 8, None)
     assert plain["labels"].dtype == plain["input_ids"].dtype
     assert _RAW_INPUT_IDS_FOR_LABELS not in plain
@@ -1173,8 +1169,7 @@ def test_vlm_host_label_authority_and_staged_finalize():
         completion_only_loss=False)
     assert off["labels"].dtype == off["input_ids"].dtype
 
-    # MLX-returning processors flag host_valued=False (prefetch contract),
-    # including nested mappings; reject mode raises BEFORE any conversion.
+    # MLX-returning processors flag host_valued=False, nested too; reject raises first.
     assert _vlm_inputs_host_valued(
         {"input_ids": np.array([[1]])}) is True
     assert _vlm_inputs_host_valued(
@@ -1184,8 +1179,7 @@ def test_vlm_host_label_authority_and_staged_finalize():
         def __call__(self, text, **kwargs):
             out = super().__call__(text, **kwargs)
             return {k: mx.array(v) for k, v in out.items()}
-    # Processor-owned MLX outputs (mlx-vlm wrappers) stage OPAQUELY in
-    # producer mode: labels defer to the consumer-side finalizer.
+    # Processor-owned MLX outputs stage opaquely: labels defer to the finalizer.
     opaque = _collate_vlm_batch([{"text": "101"}], MxProcessor(), 8, None,
                                 reject_mlx_valued=True)
     assert opaque.host_valued is False and opaque.label_mask is None
@@ -1206,8 +1200,7 @@ def test_vlm_host_label_authority_and_staged_finalize():
             yield_host_staged=True))
     assert probe.pulls == 0 and probe.epochs == []
 
-    # Routed value-carrying closures finalize through the verbatim legacy
-    # pipeline: custom values (777) and identity-closure dtype both match.
+    # Value-carrying closures finalize through the legacy pipeline unchanged.
     from unsloth_zoo.mlx.utils import _build_response_masked_vlm_batch
     def _value_closure(mask_batch):
         width = len(mask_batch["input_ids"][0])
@@ -1219,8 +1212,7 @@ def test_vlm_host_label_authority_and_staged_finalize():
     assert routed["labels"].tolist()[0][1] == 777  # custom value preserved
     assert routed["labels"].dtype == mx.int64  # legacy value-pipeline dtype
 
-    # The raw wide-id carrier survives finalize for the legacy closure: an
-    # identity closure sees the invalid uint32 id, not a wrapped -100.
+    # The raw wide-id carrier survives finalize: the closure sees the uint32 id.
     class WideProcessor(_FakeProcessor):
         def __call__(self, text, **kwargs):
             out = super().__call__(text, **kwargs)
@@ -1356,7 +1348,7 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
     assert np.asarray(batch["input_ids"]).tolist() == [[1, 2, 3, 4, 5]] * 2
     it.close()
 
-    class _PCRows:  # replayable UNSIZED source: the pc_opaque producer runs
+    class _PCRows:  # replayable unsized source
         def __iter__(self):
             return iter([{"prompt": "101", "completion": "102"},
                          {"prompt": "103", "completion": "104"}])
@@ -1378,8 +1370,7 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
         pf_it.close()
     assert label_threads and set(label_threads) == {threading.main_thread()}
 
-    # pc_opaque carries tokenizer-derived data, never the live processor:
-    # finalize must succeed after the tokenizer is torn down.
+    # pc_opaque holds no live tokenizer: finalize works after it is torn down.
     class _PoisonedTokenizer:
         def __getattr__(self, name):
             raise AssertionError(f"finalize dereferenced tokenizer.{name}")

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1308,9 +1308,8 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
     """Lazy processor-owned MLX graphs must cross the prefetch boundary.
 
     Regression: without the producer-side materialization barrier, consumer
-    evaluation raises "There is no Stream ... in current thread". Label
-    decisions for both opaque routes (plain-SFT and prompt/completion) must
-    run on the consumer thread only.
+    evaluation raises "There is no Stream ... in current thread". Label decisions
+    for both opaque routes must run on the consumer thread only.
     """
     import threading
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -738,8 +738,6 @@ _MLX_CONFIG_OPTIONAL_COPY_FIELDS = (
     "max_eval_batches",
     "streaming_text_length_window_batches",
     "streaming_prefetch_batches",
-    "label_smoothing_factor",
-    "report_grad_norm",
 )
 
 
@@ -833,17 +831,8 @@ class MLXTrainingConfig:
     vlm_chat_template: object = None  # Unsloth template name/tuple or raw Jinja string
     per_device_eval_batch_size: int | None = None
     image_size: object = None  # VLM image resize override from UnslothVisionDataCollator(resize=...)
-    max_eval_batches: int | None = None  # Bound an explicitly infinite lazy text eval stream
-    # Lazy default-order text streams: pool this many global micro-batches,
-    # length-sort, emit seeded-permuted batches. 1 = exact source order (prior
-    # behavior). Memory scales with world size; the DDP owner also retains one
-    # pass-long cycle-padding batch (documented bound W + 1).
-    streaming_text_length_window_batches: int = 8
-    # Lazy text streams: prepare up to this many batches ahead on a producer
-    # thread (0 = synchronous, the default; single-process only; host-valued
-    # rows required). Retention adds the queued batches to the window bound.
-    streaming_prefetch_batches: int = 0
-    # Appended last: the initializer binds positional args by field order.
+    # Appended by main after image_size; kept before this branch's streaming
+    # fields so a positional copy from a main config still maps correctly.
     label_smoothing_factor: float = 0.0  # HF LabelSmoother epsilon (text models only)
 
     # Opt-in true global grad-norm reporting when global-norm clipping is off.
@@ -860,6 +849,20 @@ class MLXTrainingConfig:
     # DDP reduction, and the LoRA+/embedding-LR ratios; before any clipping or
     # weight decay.
     report_grad_norm: bool = False
+
+    # This branch's lazy-streaming fields, appended LAST after every pre-existing
+    # (including main-appended) field, so positional copies from older configs
+    # keep mapping correctly. Listed in _MLX_CONFIG_OPTIONAL_COPY_FIELDS.
+    max_eval_batches: int | None = None  # Bound an explicitly infinite lazy text eval stream
+    # Lazy default-order text streams: pool this many global micro-batches,
+    # length-sort, emit seeded-permuted batches. 1 = exact source order (prior
+    # behavior). Memory scales with world size; the DDP owner also retains one
+    # pass-long cycle-padding batch (documented bound W + 1).
+    streaming_text_length_window_batches: int = 8
+    # Lazy text streams: prepare up to this many batches ahead on a producer
+    # thread (0 = synchronous, the default; single-process only; host-valued
+    # rows required). Retention adds the queued batches to the window bound.
+    streaming_prefetch_batches: int = 0
 
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
@@ -903,8 +906,14 @@ class MLXTrainingConfig:
         # warmup_steps would override a non-default warmup_ratio. Tolerate every
         # field appended since: the positional optional-copy fields plus the
         # later scalar additions.
+        # Every field appended after configs began round-tripping: this branch's
+        # streaming suffix plus the earlier scalar additions (compile_max_variants
+        # is mid-order; label_smoothing_factor / report_grad_norm precede the
+        # streaming suffix). A legacy dump missing any of them is still a copy.
         _appended_fields = set(_MLX_CONFIG_OPTIONAL_COPY_FIELDS) | {
-            "compile_max_variants",  # appended mid-order, not a positional suffix
+            "compile_max_variants",
+            "label_smoothing_factor",
+            "report_grad_norm",
         }
         _field_names = {field.name for field in config_fields}
         copied_all_fields = (_field_names - _appended_fields) <= set(provided)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1817,10 +1817,24 @@ class MLXTrainer:
         self._neftune_emb = None
         self._neftune_base_cls = None
 
+    def _close_active_batch_iterator(self):
+        """Best-effort release of an iterator owned by the training run."""
+        batch_iter = getattr(self, "_active_batch_iter", None)
+        self._active_batch_iter = None
+        close = getattr(batch_iter, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                # Cleanup must not mask the training error already in flight or
+                # make distributed ranks diverge after their final collective.
+                pass
+
 
     def train(self, resume_from_checkpoint: str | None = None):
         """Run MLX-native training loop following mlx-lm's compiled-step pattern
         with gradient accumulation. Returns a dict of training metrics."""
+        self._close_active_batch_iterator()
         # Stash for _train_inner. None = fresh start, a path = resume.
         self._resume_from_checkpoint = resume_from_checkpoint
         self._ensure_distributed()
@@ -1937,6 +1951,7 @@ class MLXTrainer:
                 self._setup_report_to_callbacks()
             return self._train_inner()
         finally:
+            self._close_active_batch_iterator()
             _handles = getattr(self, "_report_to_handles", (None, None))
             _wb, _tb = _handles
             if _tb is not None:
@@ -2034,6 +2049,7 @@ class MLXTrainer:
         if self._batches is None:
             self._prepared_batches_include_epochs = False
         batches, batch_iter = self._prepare_data(is_vlm)
+        self._active_batch_iter = batch_iter
 
         if batches is not None and not batches:
             raise ValueError(

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -3620,33 +3620,14 @@ class MLXTrainer:
                 require_replayable = bool(
                     getattr(self, "_resume_from_checkpoint", None)
                 )
+                response_mask_fn = getattr(
+                    train_dataset, "_response_mask_fn", None,
+                ) or getattr(self, "_mlx_response_mask_fn", None)
                 if (
                     _is_mlx_lazy_text_source(train_dataset)
                     and args.max_steps <= 0
                     and args.num_train_epochs > 0
                 ):
-                    response_mask_fn = getattr(
-                        train_dataset, "_response_mask_fn", None,
-                    ) or getattr(self, "_mlx_response_mask_fn", None)
-                    if self.formatting_func is not None:
-                        raise ValueError(
-                            "Unsloth MLX: num_train_epochs with a streaming text "
-                            "iterable cannot use formatting_func because prepared "
-                            "row cardinality may change. Use max_steps instead."
-                        )
-                    if text_completion_only_loss is not False:
-                        raise ValueError(
-                            "Unsloth MLX: num_train_epochs with a streaming text "
-                            "iterable requires completion_only_loss=False so the "
-                            "declared length remains exact. Use max_steps for "
-                            "completion-masked streams."
-                        )
-                    if text_assistant_only_loss or response_mask_fn is not None:
-                        raise ValueError(
-                            "Unsloth MLX: num_train_epochs cannot guarantee exact "
-                            "steps for a streaming iterable whose rows may be "
-                            "filtered by label masking. Use max_steps instead."
-                        )
                     def _resolve_source_length():
                         length = _mlx_declared_iterable_length(train_dataset)
                         return -1 if length is None else length
@@ -3699,6 +3680,7 @@ class MLXTrainer:
                     append_eos=bool(getattr(args, "append_eos", True)),
                     completion_only_loss=text_completion_only_loss,
                     assistant_only_loss=text_assistant_only_loss,
+                    response_mask_fn=response_mask_fn,
                     dataset_order=text_dataset_order,
                     comm_group=comm_group,
                     require_replayable=require_replayable,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1238,6 +1238,12 @@ class MLXTrainer:
         """Abort this rank after a rank-wide failure consensus."""
         if not failed_any:
             return
+        if exc is not None and not isinstance(exc, Exception):
+            # Interrupts (KeyboardInterrupt/SystemExit) were captured only so
+            # this rank could join the consensus; re-raise them unwrapped and
+            # without mutating trainer state, so a reused trainer does not
+            # inherit a stop request from an interrupt.
+            raise exc
         self.stop_requested = True
         if exc is not None:
             raise RuntimeError(
@@ -1705,7 +1711,9 @@ class MLXTrainer:
                 batch_data = next(iterator)
             except StopIteration:
                 break
-            except Exception as exc:
+            except BaseException as exc:
+                # Interrupts included: every rank must reach the eval status
+                # collective below, or the surviving ranks hang in it.
                 failed = True
                 error = exc
 
@@ -1722,7 +1730,7 @@ class MLXTrainer:
                     all_losses += mx.where(ntoks > 0, loss * ntoks, 0.0)
                     ntokens += ntoks
                     mx.eval(all_losses, ntokens)
-                except Exception as exc:
+                except BaseException as exc:
                     failed = True
                     error = exc
 
@@ -2917,15 +2925,32 @@ class MLXTrainer:
                 )
                 _compiled_local_grad_step = None
                 _compile_setup_error = None
+                _compile_setup_abort = None
                 try:
                     _compiled_local_grad_step = mx.compile(
                         _local_grad_step,
                         inputs=_compile_state,
                         outputs=_compile_state,
                     )
-                except Exception as e:
-                    _compile_setup_error = e
-                if self._distributed_any_flag(_compile_setup_error is not None):
+                except BaseException as e:
+                    # Ordinary failures keep the eager-fallback path; an
+                    # interrupt must abort through the consensus instead of
+                    # silently downgrading the run to eager mode.
+                    if isinstance(e, Exception):
+                        _compile_setup_error = e
+                    else:
+                        _compile_setup_abort = e
+                _setup_base = distributed_world_size + 1
+                _setup_status = self._distributed_status_mask(
+                    (1 if _compile_setup_error is not None else 0)
+                    + _setup_base * (1 if _compile_setup_abort is not None else 0)
+                )
+                self._raise_distributed_failure_from_any(
+                    (_setup_status // _setup_base) > 0,
+                    "compile setup",
+                    _compile_setup_abort,
+                )
+                if (_setup_status % _setup_base) > 0:
                     if not _compile_fallback_allowed():
                         _strict_compile_error(
                             _compile_setup_error,
@@ -3128,7 +3153,7 @@ class MLXTrainer:
                         f"fast-forwarding to resume step {_resume_step}. "
                         f"Dataset may be shorter than the killed run consumed."
                     )
-                except Exception as e:
+                except BaseException as e:
                     fast_forward_error = e
                 if distributed_world_size > 1:
                     self._raise_distributed_failure(
@@ -3163,7 +3188,7 @@ class MLXTrainer:
             try:
                 result = step_fn(batch_data, prev_state, do_update)
                 _eval_local_result(result)
-            except Exception as e:
+            except BaseException as e:
                 if isinstance(e, _DDPCompiledLocalGradError):
                     compile_error = e
                 else:
@@ -3204,7 +3229,7 @@ class MLXTrainer:
                 try:
                     result = step_fn(batch_data, prev_state, do_update)
                     _eval_local_result(result)
-                except Exception as e:
+                except BaseException as e:
                     local_error = e
                 self._raise_distributed_failure(
                     local_error is not None,
@@ -3231,7 +3256,7 @@ class MLXTrainer:
                 else:
                     batch_data = batches[batch_idx % len(batches)]
                     batch_idx += 1
-            except Exception as e:
+            except BaseException as e:
                 batch_error = e
             if distributed_world_size > 1:
                 self._raise_distributed_failure(
@@ -3471,7 +3496,7 @@ class MLXTrainer:
                                 save_trainable_adapters(model, f"{args.output_dir}/best")
                             except ValueError as e:
                                 print(f"  Unsloth: skipped best-model save ({e})")
-                            except Exception as e:
+                            except BaseException as e:
                                 best_save_error = e
                         self._raise_distributed_failure(
                             best_save_error is not None,
@@ -3535,7 +3560,7 @@ class MLXTrainer:
                                     args.output_dir,
                                     args.save_total_limit,
                                 )
-                    except Exception as e:
+                    except BaseException as e:
                         checkpoint_error = e
                 self._raise_distributed_failure(
                     checkpoint_error is not None,
@@ -3562,6 +3587,7 @@ class MLXTrainer:
         )
 
         # load_best_model_at_end: restore best adapters before the final save.
+        restore_abort = None
         if getattr(args, "load_best_model_at_end", False) and self._best_step is not None:
             _best_path = f"{args.output_dir}/best/adapters.safetensors"
             if os.path.exists(_best_path):
@@ -3573,6 +3599,16 @@ class MLXTrainer:
                     )
                 except Exception as e:
                     _main_print(f"Unsloth: failed to restore best model ({e}).")
+                except BaseException as e:
+                    # Ordinary restore failures stay log-and-continue, but an
+                    # interrupt must reach the consensus below before the
+                    # diagnostics collective, or peers hang in it.
+                    restore_abort = e
+        self._raise_distributed_failure(
+            restore_abort is not None,
+            "best-model restore",
+            restore_abort,
+        )
 
         distributed_diagnostics = self._distributed_training_diagnostics(
             total_time=total_time,
@@ -3589,7 +3625,7 @@ class MLXTrainer:
                 self.save_model()
             except ValueError as e:
                 _main_print(f"Unsloth: skipped final save ({e})")
-            except Exception as e:
+            except BaseException as e:
                 final_save_error = e
             else:
                 _main_print(f"Unsloth: Saved final adapters to {args.output_dir}")

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -222,13 +222,19 @@ def _mlx_stream_declares_infinite(dataset):
         # rename in a future release degrades detection (the stream just
         # is not recognized as infinite) instead of failing eval for every
         # stream whose wrapper class matches by name.
-        if kind in (
-            "VerticallyConcatenatedMultiSourcesExamplesIterable",
-            "HorizontallyConcatenatedMultiSourcesExamplesIterable",
-        ):
+        if kind == "VerticallyConcatenatedMultiSourcesExamplesIterable":
+            # Sequential concat runs children one after another, so it never
+            # ends if ANY child is infinite.
             return any(
                 _is_infinite(child, seen)
                 for child in getattr(ex_iterable, "ex_iterables", ())
+            )
+        if kind == "HorizontallyConcatenatedMultiSourcesExamplesIterable":
+            # Column-wise concat advances children in lockstep and ends with
+            # the shortest, so it is infinite only if EVERY child is.
+            children = getattr(ex_iterable, "ex_iterables", ())
+            return bool(children) and all(
+                _is_infinite(child, seen) for child in children
             )
         if kind in (
             "CyclingMultiSourcesExamplesIterable",

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -196,7 +196,6 @@ from .utils import (
     snapshot_mlx_norm_output_cast_state,
     _get_text_model,
     _distributed_global_batch_size,
-    _is_mlx_replayable_text_source,
     _rank_slice_distributed_batch,
 )
 from .compile import (
@@ -3354,15 +3353,6 @@ class MLXTrainer:
         else:
             chat_tmpl = getattr(args, "chat_template", None)
             if args.streaming:
-                if (
-                    getattr(self, "_resume_from_checkpoint", None)
-                    and not _is_mlx_replayable_text_source(train_dataset)
-                ):
-                    raise RuntimeError(
-                        "Unsloth MLX: checkpoint resume requires a replayable "
-                        "iterable text source; a one-shot iterator cannot be "
-                        "fast-forwarded deterministically."
-                    )
                 text_dataset_order = (
                     "sequential"
                     if getattr(args, "preserve_dataset_order", False)
@@ -3384,6 +3374,9 @@ class MLXTrainer:
                     assistant_only_loss=text_assistant_only_loss,
                     dataset_order=text_dataset_order,
                     comm_group=comm_group,
+                    require_replayable=bool(
+                        getattr(self, "_resume_from_checkpoint", None)
+                    ),
                 )
             else:
                 batch_kwargs = dict(

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1769,12 +1769,20 @@ class MLXTrainer:
         if args.streaming and _is_mlx_lazy_text_source(eval_dataset):
             max_batches = getattr(args, "max_eval_batches", None)
             if max_batches is not None:
-                max_batches = int(max_batches)
-                if max_batches <= 0:
+                # Reject rather than truncate non-integral values (1.9, True):
+                # silent coercion would change how much eval data is scored.
+                coerced = None
+                if not isinstance(max_batches, bool):
+                    try:
+                        coerced = int(max_batches)
+                    except (TypeError, ValueError):
+                        coerced = None
+                if coerced is None or coerced != max_batches or coerced <= 0:
                     raise ValueError(
                         "Unsloth MLX: max_eval_batches must be a positive "
                         "integer when provided."
                     )
+                max_batches = coerced
 
             def _factory():
                 return iterate_training_batches(

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -63,6 +63,39 @@ def _mlx_distributed_backend_from_env():
     return None
 
 
+def _mlx_rank0_resolve_int(comm_group, resolver, context):
+    """Resolve source metadata on rank 0 and synchronize its value or failure."""
+    rank, world_size = _distributed_rank_size(comm_group)
+    if world_size <= 1:
+        return int(resolver())
+
+    status = 0
+    value = 0
+    owner_error = None
+    if rank == 0:
+        try:
+            value = int(resolver())
+            status = 1
+        except Exception as exc:
+            owner_error = exc
+            status = -1
+    metadata = mx.array(
+        [status, value] if rank == 0 else [0, 0], dtype=mx.int64,
+    )
+    metadata = mx.distributed.all_sum(metadata, group=comm_group)
+    mx.eval(metadata)
+    status, value = (int(item) for item in metadata.tolist())
+    if status < 0:
+        if owner_error is not None:
+            raise owner_error
+        raise RuntimeError(f"Unsloth MLX: rank 0 failed while {context}.")
+    if status != 1:
+        raise RuntimeError(
+            f"Unsloth MLX: invalid rank-0 metadata status while {context}."
+        )
+    return value
+
+
 class MLXTrainOutput(dict):
     """Dict-compatible train() result with HF Trainer-style attributes."""
 
@@ -218,13 +251,21 @@ def _mlx_stream_declares_infinite(dataset):
 class _MLXLazyEvalBatchView:
     """Restartable eval batch surface that constructs one lazy pass per use."""
 
-    def __init__(self, dataset, factory, max_batches=None):
+    def __init__(self, dataset, factory, max_batches=None, comm_group=None):
         self._dataset = dataset
         self._factory = factory
         self._max_batches = max_batches
+        self._comm_group = comm_group
 
     def __iter__(self):
-        if self._max_batches is None and _mlx_stream_declares_infinite(self._dataset):
+        declared_infinite = False
+        if self._max_batches is None:
+            declared_infinite = bool(_mlx_rank0_resolve_int(
+                self._comm_group,
+                lambda: _mlx_stream_declares_infinite(self._dataset),
+                "checking whether the streaming eval source is infinite",
+            ))
+        if declared_infinite:
             raise ValueError(
                 "Unsloth MLX: an infinite streaming eval_dataset must set "
                 "max_eval_batches to a positive value (or apply dataset.take) "
@@ -293,6 +334,7 @@ from .utils import (
     set_mlx_norm_output_cast_to_input_dtype,
     snapshot_mlx_norm_output_cast_state,
     _get_text_model,
+    _distributed_rank_size,
     _distributed_global_batch_size,
     _rank_slice_distributed_batch,
 )
@@ -1709,6 +1751,7 @@ class MLXTrainer:
                 eval_dataset,
                 _factory,
                 max_batches=max_batches,
+                comm_group=self.distributed_world,
             )
         return create_batches(
             **common,
@@ -3604,8 +3647,16 @@ class MLXTrainer:
                             "steps for a streaming iterable whose rows may be "
                             "filtered by label masking. Use max_steps instead."
                         )
-                    source_length = _mlx_declared_iterable_length(train_dataset)
-                    if source_length is None:
+                    def _resolve_source_length():
+                        length = _mlx_declared_iterable_length(train_dataset)
+                        return -1 if length is None else length
+
+                    source_length = _mlx_rank0_resolve_int(
+                        comm_group,
+                        _resolve_source_length,
+                        "resolving the streaming text source length",
+                    )
+                    if source_length < 0:
                         raise ValueError(
                             "Unsloth MLX: num_train_epochs requires a streaming "
                             "text iterable with an explicit reliable __len__. Use "

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -309,6 +309,7 @@ from .utils import (
     create_ordered_batches,
     iterate_training_batches,
     _validate_streaming_length_window,
+    _validate_streaming_prefetch,
     _is_mlx_lazy_text_source,
     _vlm_has_sized_index_space,
     _MLXIterableTokenizedDatasetView,
@@ -677,6 +678,7 @@ def _prune_stale_checkpoints(output_dir, save_total_limit):
 _MLX_CONFIG_OPTIONAL_COPY_FIELDS = (
     "max_eval_batches",
     "streaming_text_length_window_batches",
+    "streaming_prefetch_batches",
 )
 
 
@@ -775,6 +777,10 @@ class MLXTrainingConfig:
     # behavior). Memory scales with world size; the DDP owner also retains one
     # pass-long cycle-padding batch (documented bound W + 1).
     streaming_text_length_window_batches: int = 8
+    # Lazy text streams: prepare up to this many batches ahead on a producer
+    # thread (0 = synchronous, the default; single-process only; host-valued
+    # rows required). Retention adds the queued batches to the window bound.
+    streaming_prefetch_batches: int = 0
 
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
@@ -2082,7 +2088,58 @@ class MLXTrainer:
                 # Cleanup must not mask the training error already in flight or
                 # make distributed ranks diverge after their final collective.
                 pass
+        # Normal, failed, and interrupted exits all pass through here: close
+        # the producer and persist a live orphan so the next run's gate sees it.
+        control = getattr(self, "_mlx_prefetch_control", None)
+        prefetcher = control.get("prefetcher") if control else None
+        if prefetcher is not None:
+            try:
+                prefetcher.close()
+            except Exception:
+                pass
+            if prefetcher.orphan_alive():
+                self._mlx_prefetch_orphan = prefetcher
+            control["prefetcher"] = None
 
+
+    def _quiesce_prefetcher_for_save(self, terminal=False):
+        """Make serialization exclusive over shared preprocessing objects.
+
+        ``terminal=True`` (end of training) closes the producer for good;
+        otherwise an active producer is PAUSED and returned so the caller can
+        resume it after the save. Live persisted orphans always refuse.
+        """
+        orphan = getattr(self, "_mlx_prefetch_orphan", None)
+        if orphan is not None:
+            if orphan.orphan_alive():
+                raise RuntimeError(
+                    "Unsloth MLX: a prefetch producer is still blocked inside "
+                    "its source and shares this trainer's tokenizer; refusing "
+                    "to serialize concurrently. Wait for the thread to "
+                    "terminate, then call save_model() again."
+                )
+            self._mlx_prefetch_orphan = None
+        control = getattr(self, "_mlx_prefetch_control", None)
+        prefetcher = control.get("prefetcher") if control else None
+        if prefetcher is None:
+            return None
+        if not terminal:
+            prefetcher.quiesce()
+            return prefetcher
+        prefetcher.close()
+        if prefetcher.orphan_alive():
+            self._mlx_prefetch_orphan = prefetcher
+            control["prefetcher"] = None
+            raise RuntimeError(
+                "Unsloth MLX: the prefetch producer is blocked inside its "
+                "source and shares this trainer's tokenizer; refusing to "
+                "serialize concurrently. Wait for the thread to terminate, "
+                "then call save_model() again."
+            )
+        # Terminal close succeeded: drop the control reference so the ensuing
+        # save_model() wrapper gate is a no-op (no quiesce/resume re-entry).
+        control["prefetcher"] = None
+        return None
 
     def train(self, resume_from_checkpoint: str | None = None):
         """Run MLX-native training loop following mlx-lm's compiled-step pattern
@@ -2299,9 +2356,46 @@ class MLXTrainer:
         # Prepare data, determine total_steps first. Keep any prebuilt flag
         # from train_on_responses_only; _prepare_data returns self._batches
         # early and never re-derives it for the completion-only text path.
+        previous_orphan = getattr(self, "_mlx_prefetch_orphan", None)
+        if previous_orphan is not None:
+            if previous_orphan.orphan_alive():
+                raise RuntimeError(
+                    "Unsloth MLX: a previous prefetch producer is still "
+                    "blocked inside its source and shares this trainer's "
+                    "preprocessing objects. Wait for that thread to terminate "
+                    "before training with this trainer again."
+                )
+            # Terminated orphan: release its thread/closures/queued batches.
+            self._mlx_prefetch_orphan = None
+        self._mlx_resume_step_for_prefetch = 0
+        self._mlx_resume_state_cache = None
+        _wants_prefetch = bool(
+            _validate_streaming_prefetch(
+                getattr(self.args, "streaming_prefetch_batches", 0)
+            )
+            and self.distributed_world_size == 1
+            and getattr(self.args, "streaming", False)
+        )
+        if _wants_prefetch and getattr(self, "_resume_from_checkpoint", None):
+            # Single authority: the same validated load feeds the producer skip
+            # now and the scalar restoration later (world size is 1 here, so no
+            # duplicated distributed collectives). Failures stay hard.
+            _early_resume = self._validate_distributed_resume_checkpoint(
+                self._resume_from_checkpoint
+            )
+            if _early_resume:
+                _early_state = load_trainer_state(_early_resume)
+                self._mlx_resume_state_cache = (_early_resume, _early_state)
+                self._mlx_resume_step_for_prefetch = int(
+                    _early_state.get("global_step", 0)
+                )
         if self._batches is None:
             self._prepared_batches_include_epochs = False
         batches, batch_iter = self._prepare_data(is_vlm)
+        _prefetch_active = bool(
+            getattr(self, "_mlx_prefetch_control", None)
+            and self._mlx_prefetch_control.get("eligible")
+        )
         self._active_batch_iter = batch_iter
 
         if batches is not None and not batches:
@@ -2369,7 +2463,12 @@ class MLXTrainer:
                 # 3. Restore trainer scalars (step counter, loss history, and
                 #    best-model / early-stopping tracking). .get defaults keep
                 #    pre-fix checkpoints (which lack these keys) resumable.
-                ts = load_trainer_state(_resume_from)
+                _cached = getattr(self, "_mlx_resume_state_cache", None)
+                ts = (
+                    _cached[1]
+                    if _cached is not None and _cached[0] == _resume_from
+                    else load_trainer_state(_resume_from)
+                )
                 _resume_step = int(ts.get("global_step", 0))
                 # Seed the live step counter from the checkpoint so a no-op
                 # resume (checkpoint already at max_steps, loop body never runs)
@@ -2991,7 +3090,7 @@ class MLXTrainer:
         # The seed is the same and create_batches/iterate_*_batches is
         # deterministic, so consuming N batches gives us the same data
         # ordering the killed run would have produced.
-        if _resume_step > 0 and batch_iter is not None:
+        if _resume_step > 0 and batch_iter is not None and not _prefetch_active:
             for _ in range(_resume_step * grad_accum):
                 fast_forward_error = None
                 try:
@@ -3273,8 +3372,18 @@ class MLXTrainer:
             # Eval
             if (eval_batches and args.eval_steps > 0
                     and current_step % args.eval_steps == 0):
-                val_loss, ppl = self._evaluate(
-                    eval_batches, loss_fn, is_vlm=is_vlm)
+                _pf = (
+                    self._mlx_prefetch_control.get("prefetcher")
+                    if getattr(self, "_mlx_prefetch_control", None) else None
+                )
+                if _pf is not None:
+                    _pf.quiesce()
+                try:
+                    val_loss, ppl = self._evaluate(
+                        eval_batches, loss_fn, is_vlm=is_vlm)
+                finally:
+                    if _pf is not None:
+                        _pf.resume()
                 model.train()
                 _main_print(
                     f"  Eval  {current_step}/{total_steps} | "
@@ -3416,6 +3525,7 @@ class MLXTrainer:
         # Report the step actually reached, which is < total_steps after an
         # early stop (self._global_step == total_steps on a full run).
         completed_steps = self._global_step
+
         _main_print(
             f"\nUnsloth: Training complete! "
             f"Avg loss: {avg_loss:.4f} | "
@@ -3448,6 +3558,7 @@ class MLXTrainer:
         final_save_error = None
         if is_main_process:
             try:
+                self._quiesce_prefetcher_for_save(terminal=True)
                 self.save_model()
             except ValueError as e:
                 _main_print(f"Unsloth: skipped final save ({e})")
@@ -3591,6 +3702,15 @@ class MLXTrainer:
                 else None
             )
             if args.streaming:
+                if _validate_streaming_prefetch(
+                    getattr(args, "streaming_prefetch_batches", 0)
+                ) and not getattr(self, "_mlx_prefetch_vlm_notice", False):
+                    self._mlx_prefetch_vlm_notice = True
+                    if getattr(self, "_distributed_is_main_process", True):
+                        print(
+                            "Unsloth: streaming_prefetch_batches does not "
+                            "cover VLM streams yet; continuing synchronously."
+                        )
                 vlm_lazy = not _vlm_has_sized_index_space(train_dataset)
                 if vlm_lazy and self.distributed_world_size > 1:
                     raise ValueError(
@@ -3730,6 +3850,29 @@ class MLXTrainer:
                         )
                     expected_rows_per_pass = source_length
                     require_replayable = True
+                prefetch_depth = _validate_streaming_prefetch(
+                    getattr(args, "streaming_prefetch_batches", 0)
+                )
+                if prefetch_depth and self.distributed_world_size > 1:
+                    if not getattr(self, "_mlx_prefetch_ddp_notice", False):
+                        self._mlx_prefetch_ddp_notice = True
+                        if getattr(self, "_distributed_is_main_process", True):
+                            print(
+                                "Unsloth: streaming_prefetch_batches is "
+                                "single-process only; continuing "
+                                "synchronously under DDP."
+                            )
+                    prefetch_depth = 0
+                self._mlx_prefetch_control = {
+                    "eligible": bool(
+                        prefetch_depth
+                        and _is_mlx_lazy_text_source(train_dataset)
+                    ),
+                }
+                resume_skip = (
+                    int(getattr(self, "_mlx_resume_step_for_prefetch", 0))
+                    * args.gradient_accumulation_steps
+                )
                 return None, iterate_training_batches(
                     dataset=train_dataset,
                     tokenizer=self.tokenizer,
@@ -3754,6 +3897,9 @@ class MLXTrainer:
                             args, "streaming_text_length_window_batches", 8,
                         )
                     ),
+                    prefetch_batches=prefetch_depth,
+                    prefetch_skip_batches=resume_skip if prefetch_depth else 0,
+                    prefetch_control=self._mlx_prefetch_control,
                 )
             else:
                 batch_kwargs = dict(
@@ -3798,6 +3944,17 @@ class MLXTrainer:
 
     def save_model(self, output_dir=None):
         """Save LoRA adapters or full merged model (if no LoRA)."""
+        paused_prefetcher = self._quiesce_prefetcher_for_save()
+        try:
+            return self._save_model_impl(output_dir)
+        finally:
+            # A mid-training save (e.g. from a step callback) pauses the
+            # producer for exclusivity and resumes it; only the end-of-training
+            # path closes it terminally.
+            if paused_prefetcher is not None:
+                paused_prefetcher.resume()
+
+    def _save_model_impl(self, output_dir=None):
         from .utils import (
             _coerce_mlx_lora_scale,
             _get_mlx_dropout_probability,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -171,6 +171,8 @@ from .utils import (
     create_batches,
     create_ordered_batches,
     iterate_training_batches,
+    _is_mlx_lazy_text_source,
+    _MLXIterableTokenizedDatasetView,
     create_vlm_batches,
     iterate_vlm_training_batches,
     normalize_mlx_chat_template,
@@ -712,6 +714,34 @@ class MLXTrainer:
             self.args.packing = False
 
         if (
+            not self._is_vlm
+            and self.train_dataset is not None
+            and self.tokenizer is not None
+            and self.args.streaming
+            and _is_mlx_lazy_text_source(self.train_dataset)
+        ):
+            config = getattr(self.model, "_config", {})
+            model_type = config.get("model_type") if isinstance(config, dict) else None
+            self.tokenizer = normalize_mlx_chat_template(
+                self.tokenizer,
+                chat_template=getattr(self.args, "chat_template", None),
+                model_name=getattr(self.model, "_hf_repo", None),
+                model_type=model_type,
+                is_vlm=False,
+                strict=False,
+            )
+            self.train_dataset = _MLXIterableTokenizedDatasetView(
+                self.train_dataset,
+                self.tokenizer,
+                dataset_text_field=self.args.dataset_text_field,
+                formatting_func=self.formatting_func,
+                append_eos=bool(getattr(self.args, "append_eos", True)),
+                completion_only_loss=_text_completion_only_loss_arg(self.args),
+                assistant_only_loss=_text_assistant_only_loss_arg(self.args),
+                max_seq_length=self.args.max_seq_length,
+            )
+            self._mlx_train_dataset_for_batches = self.train_dataset
+        elif (
             not self._is_vlm
             and self.train_dataset is not None
             and self.tokenizer is not None
@@ -3903,6 +3933,81 @@ def _check_vlm_all_masked(batches, max_check=100, comm_group=None, world_size=1)
         )
 
 
+def _prepare_response_labeled_eval_batches(
+    trainer,
+    tokenizer,
+    mask_fn,
+    *,
+    sized_only=False,
+):
+    """Prepare response-masked text eval batches, optionally only when sized."""
+    if trainer.eval_dataset is None:
+        return False
+    eval_datasets = (
+        list(trainer.eval_dataset.values())
+        if isinstance(trainer.eval_dataset, dict)
+        else [trainer.eval_dataset]
+    )
+    lazy_splits = [
+        _is_mlx_lazy_text_source(dataset) for dataset in eval_datasets
+    ]
+    if sized_only and all(lazy_splits):
+        return False
+
+    args = trainer.args
+    eval_batch_size = (
+        getattr(args, "per_device_eval_batch_size", None)
+        or args.per_device_train_batch_size
+    )
+    comm_group = getattr(trainer, "distributed_world", None)
+
+    def _create(eval_dataset):
+        batches, response_masked_dataset = _create_labeled_batches(
+            dataset=eval_dataset,
+            tokenizer=tokenizer,
+            mask_fn=mask_fn,
+            batch_size=eval_batch_size,
+            max_seq_length=args.max_seq_length,
+            formatting_func=trainer.formatting_func,
+            dataset_text_field=args.dataset_text_field,
+            seed=args.seed,
+            chat_template=getattr(args, "chat_template", None),
+            model_name=getattr(trainer.model, "_hf_repo", None),
+            model_type=(
+                getattr(trainer.model, "_config", {}).get("model_type")
+                if isinstance(getattr(trainer.model, "_config", {}), dict)
+                else None
+            ),
+            append_eos=bool(getattr(args, "append_eos", True)),
+            dataset_order=getattr(args, "dataset_order", "default"),
+            preserve_dataset_order=bool(
+                getattr(args, "preserve_dataset_order", False)
+            ),
+            return_dataset=True,
+            comm_group=comm_group,
+            distributed_pad_mode="empty",
+        )
+        return batches, response_masked_dataset
+
+    if isinstance(trainer.eval_dataset, dict):
+        if sized_only and any(lazy_splits):
+            for key, value in trainer.eval_dataset.items():
+                if _is_mlx_lazy_text_source(value):
+                    continue
+                _unused_batches, split_dataset = _create(value)
+                trainer.eval_dataset[key] = split_dataset
+            return False
+        eval_batches = {}
+        for key, value in trainer.eval_dataset.items():
+            split_batches, split_dataset = _create(value)
+            eval_batches[key] = split_batches
+            trainer.eval_dataset[key] = split_dataset
+    else:
+        eval_batches, trainer.eval_dataset = _create(trainer.eval_dataset)
+    trainer._eval_batches_labeled = eval_batches
+    return True
+
+
 def train_on_responses_only(
     trainer,
     instruction_part=None,
@@ -3949,6 +4054,23 @@ def train_on_responses_only(
 
     # Callable HF tokenizer for token matching and text batch encoding.
     _tokenizer = _resolve_response_mask_tokenizer(_source)
+    if (
+        not return_function
+        and trainer is not None
+        and not trainer._is_vlm
+        and trainer.args.streaming
+        and _is_mlx_lazy_text_source(trainer._train_dataset_for_batches())
+    ):
+        config = getattr(trainer.model, "_config", {})
+        model_type = config.get("model_type") if isinstance(config, dict) else None
+        _tokenizer = normalize_mlx_chat_template(
+            _tokenizer,
+            chat_template=getattr(trainer.args, "chat_template", None),
+            model_name=getattr(trainer.model, "_hf_repo", None),
+            model_type=model_type,
+            is_vlm=False,
+            strict=False,
+        )
 
     # Omitted markers -> auto-detect from the right chat template (see helper).
     if instruction_part is None and response_part is None:
@@ -3984,8 +4106,38 @@ def train_on_responses_only(
         trainer._vlm_response_mask_fn = mask_fn
         print("Unsloth: train_on_responses_only enabled (VLM mode).")
     else:
-        # Text path: tokenize, mask, and create batches now
         args = trainer.args
+        train_dataset = trainer._train_dataset_for_batches()
+        if args.streaming and _is_mlx_lazy_text_source(train_dataset):
+            if not isinstance(train_dataset, _MLXIterableTokenizedDatasetView):
+                train_dataset = _MLXIterableTokenizedDatasetView(
+                    train_dataset,
+                    _tokenizer,
+                    dataset_text_field=args.dataset_text_field,
+                    formatting_func=trainer.formatting_func,
+                    append_eos=bool(getattr(args, "append_eos", True)),
+                    completion_only_loss=_text_completion_only_loss_arg(args),
+                    assistant_only_loss=_text_assistant_only_loss_arg(args),
+                    max_seq_length=args.max_seq_length,
+                )
+                trainer.train_dataset = train_dataset
+                trainer._mlx_train_dataset_for_batches = train_dataset
+            else:
+                train_dataset.set_tokenizer(_tokenizer)
+            train_dataset.set_response_mask(mask_fn)
+            trainer._mlx_response_mask_fn = mask_fn
+            trainer._batches = None
+            trainer._eval_batches_labeled = None
+            _prepare_response_labeled_eval_batches(
+                trainer,
+                _tokenizer,
+                mask_fn,
+                sized_only=True,
+            )
+            print("Unsloth: train_on_responses_only enabled (lazy text mode).")
+            return trainer
+
+        # Eager/sized text path: tokenize, mask, and create batches now.
         total_batches_needed = (
             args.max_steps * args.gradient_accumulation_steps
             if args.max_steps > 0 else None
@@ -3998,7 +4150,6 @@ def train_on_responses_only(
             if (args.max_steps <= 0 and getattr(args, "num_train_epochs", -1) > 0)
             else None
         )
-        train_dataset = trainer._train_dataset_for_batches()
         comm_group = getattr(trainer, "distributed_world", None)
         batches, response_masked_dataset = _create_labeled_batches(
             dataset=train_dataset,
@@ -4039,53 +4190,11 @@ def train_on_responses_only(
         )
         trainer._batches = batches
 
-        # Process eval dataset too
-        if trainer.eval_dataset is not None:
-            eval_batch_size = (
-                getattr(args, "per_device_eval_batch_size", None)
-                or args.per_device_train_batch_size
-            )
-
-            def _create_labeled_eval_batches(eval_dataset):
-                """Build response-masked eval batches for one dataset split."""
-                batches, response_masked_dataset = _create_labeled_batches(
-                    dataset=eval_dataset,
-                    tokenizer=_tokenizer,
-                    mask_fn=mask_fn,
-                    batch_size=eval_batch_size,
-                    max_seq_length=args.max_seq_length,
-                    formatting_func=trainer.formatting_func,
-                    dataset_text_field=args.dataset_text_field,
-                    seed=args.seed,
-                    chat_template=getattr(args, "chat_template", None),
-                    model_name=getattr(trainer.model, "_hf_repo", None),
-                    model_type=(
-                        getattr(trainer.model, "_config", {}).get("model_type")
-                        if isinstance(getattr(trainer.model, "_config", {}), dict)
-                        else None
-                    ),
-                    append_eos=bool(getattr(args, "append_eos", True)),
-                    dataset_order=getattr(args, "dataset_order", "default"),
-                    preserve_dataset_order=bool(
-                        getattr(args, "preserve_dataset_order", False)
-                    ),
-                    return_dataset=True,
-                    comm_group=comm_group,
-                    distributed_pad_mode="empty",
-                )
-                return batches, response_masked_dataset
-
-            if isinstance(trainer.eval_dataset, dict):
-                eval_batches = {}
-                for key, value in trainer.eval_dataset.items():
-                    split_batches, split_dataset = _create_labeled_eval_batches(value)
-                    eval_batches[key] = split_batches
-                    trainer.eval_dataset[key] = split_dataset
-            else:
-                eval_batches, trainer.eval_dataset = _create_labeled_eval_batches(
-                    trainer.eval_dataset
-                )
-            trainer._eval_batches_labeled = eval_batches
+        _prepare_response_labeled_eval_batches(
+            trainer,
+            _tokenizer,
+            mask_fn,
+        )
 
         print(f"Unsloth: train_on_responses_only enabled "
               f"({len(batches)} batches prepared).")

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2123,26 +2123,35 @@ class MLXTrainer:
         """Best-effort release of an iterator owned by the training run."""
         batch_iter = getattr(self, "_active_batch_iter", None)
         self._active_batch_iter = None
-        close = getattr(batch_iter, "close", None)
-        if callable(close):
-            try:
-                close()
-            except Exception:
-                # Cleanup must not mask the training error already in flight or
-                # make distributed ranks diverge after their final collective.
-                pass
-        # Normal, failed, and interrupted exits all pass through here: close
-        # the producer and persist a live orphan so the next run's gate sees it.
+        # Normal, failed, and interrupted exits all pass through here: close the
+        # producer and persist a live orphan so the next run's gate sees it.
         control = getattr(self, "_mlx_prefetch_control", None)
         prefetcher = control.get("prefetcher") if control else None
-        if prefetcher is not None:
-            try:
-                prefetcher.close()
-            except Exception:
-                pass
-            if prefetcher.orphan_alive():
-                self._mlx_prefetch_orphan = prefetcher
-            control["prefetcher"] = None
+        try:
+            close = getattr(batch_iter, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    # An ordinary cleanup error must not mask the training error
+                    # already in flight or diverge ranks after a final
+                    # collective. A propagating signal is honored (see finally).
+                    pass
+            if prefetcher is not None:
+                try:
+                    prefetcher.close()
+                except Exception:
+                    pass
+        finally:
+            if prefetcher is not None:
+                # close() marks a conservative orphan before doing anything, so
+                # a not-clean close OR a propagating interrupt leaves
+                # orphaned=True; persist it either way (a clean, drained close
+                # clears the flag). The next run's gate drains and clears it.
+                if prefetcher.orphaned:
+                    self._mlx_prefetch_orphan = prefetcher
+                if control is not None:
+                    control["prefetcher"] = None
 
 
     def _quiesce_prefetcher_for_save(self, terminal=False):
@@ -2161,6 +2170,10 @@ class MLXTrainer:
                     "to serialize concurrently. Wait for the thread to "
                     "terminate, then call save_model() again."
                 )
+            # Terminated orphan: close() drains its queued batches (device
+            # tensors for opaque VLM outputs) before this save, rather than
+            # relying on the reference drop to eventually free them.
+            orphan.close()
             self._mlx_prefetch_orphan = None
         control = getattr(self, "_mlx_prefetch_control", None)
         prefetcher = control.get("prefetcher") if control else None
@@ -2169,8 +2182,10 @@ class MLXTrainer:
         if not terminal:
             prefetcher.quiesce()
             return prefetcher
-        prefetcher.close()
-        if prefetcher.orphan_alive():
+        # Gate on close()'s return, not a fresh orphan_alive() read: close()
+        # drained the queue iff it reports clean, so this cannot proceed to
+        # save with staged batches (device tensors) still queued.
+        if not prefetcher.close():
             self._mlx_prefetch_orphan = prefetcher
             control["prefetcher"] = None
             raise RuntimeError(
@@ -2408,7 +2423,9 @@ class MLXTrainer:
                     "preprocessing objects. Wait for that thread to terminate "
                     "before training with this trainer again."
                 )
-            # Terminated orphan: release its thread/closures/queued batches.
+            # Terminated orphan: close() drains its queued batches before the
+            # reference is dropped, releasing them deterministically.
+            previous_orphan.close()
             self._mlx_prefetch_orphan = None
         self._mlx_resume_step_for_prefetch = 0
         self._mlx_resume_state_cache = None

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -163,6 +163,102 @@ class _MLXTokenizedDatasetView:
         return item
 
 
+def _mlx_stream_declares_infinite(dataset):
+    """Recognize explicit/common infinite iterable declarations without probing."""
+    dataset = getattr(dataset, "_mlx_source_dataset", dataset)
+    if bool(getattr(dataset, "_unsloth_mlx_infinite", False)):
+        return True
+
+    def _is_infinite(ex_iterable, seen):
+        if ex_iterable is None or id(ex_iterable) in seen:
+            return False
+        seen = seen | {id(ex_iterable)}
+        kind = type(ex_iterable).__name__
+        if kind == "TakeExamplesIterable":
+            return False
+        if (
+            kind == "RepeatExamplesIterable"
+            and getattr(ex_iterable, "num_times", 0) is None
+        ):
+            return True
+        if kind in (
+            "VerticallyConcatenatedMultiSourcesExamplesIterable",
+            "HorizontallyConcatenatedMultiSourcesExamplesIterable",
+        ):
+            return any(_is_infinite(child, seen) for child in ex_iterable.ex_iterables)
+        if kind in (
+            "CyclingMultiSourcesExamplesIterable",
+            "RandomlyCyclingMultiSourcesExamplesIterable",
+        ):
+            children = ex_iterable.ex_iterables
+            probabilities = getattr(ex_iterable, "probabilities", None)
+            if probabilities is not None:
+                if (
+                    ex_iterable.stopping_strategy.startswith("all_exhausted")
+                    and any(probability <= 0 for probability in probabilities)
+                ):
+                    return True
+                children = [
+                    child for child, probability in zip(children, probabilities)
+                    if probability > 0
+                ]
+            infinite = [_is_infinite(child, seen) for child in children]
+            return (
+                any(infinite)
+                if ex_iterable.stopping_strategy.startswith("all_exhausted")
+                else bool(infinite) and all(infinite)
+            )
+        return _is_infinite(getattr(ex_iterable, "ex_iterable", None), seen)
+
+    ex_iterable = getattr(dataset, "_ex_iterable", None)
+    seen = set()
+    return _is_infinite(ex_iterable, seen)
+
+
+class _MLXLazyEvalBatchView:
+    """Restartable eval batch surface that constructs one lazy pass per use."""
+
+    def __init__(self, dataset, factory, max_batches=None):
+        self._dataset = dataset
+        self._factory = factory
+        self._max_batches = max_batches
+
+    def __iter__(self):
+        if self._max_batches is None and _mlx_stream_declares_infinite(self._dataset):
+            raise ValueError(
+                "Unsloth MLX: an infinite streaming eval_dataset must set "
+                "max_eval_batches to a positive value (or apply dataset.take) "
+                "so evaluation has an explicit boundary."
+            )
+        iterator = iter(self._factory())
+        if self._max_batches is None:
+            yield from iterator
+            return
+        for _ in range(self._max_batches):
+            try:
+                yield next(iterator)
+            except StopIteration:
+                return
+
+
+def _mlx_declared_iterable_length(dataset):
+    """Return a declared source length without probing a truly unsized source."""
+    source = getattr(dataset, "_mlx_source_dataset", dataset)
+    if not any("__len__" in cls.__dict__ for cls in type(source).__mro__):
+        return None
+    try:
+        length = len(source)
+    except (TypeError, AttributeError) as exc:
+        raise ValueError(
+            "Unsloth MLX: num_train_epochs requires a streaming text source "
+            "whose declared __len__ returns the exact source row count. Use "
+            "max_steps for a truly unsized iterable."
+        ) from exc
+    if length < 0:
+        raise ValueError("Unsloth MLX: iterable dataset length cannot be negative.")
+    return int(length)
+
+
 from .utils import (
     make_cce_loss_fn,
     make_baseline_loss_fn,
@@ -620,6 +716,7 @@ class MLXTrainingConfig:
     vlm_chat_template: object = None  # Unsloth template name/tuple or raw Jinja string
     per_device_eval_batch_size: int | None = None
     image_size: object = None  # VLM image resize override from UnslothVisionDataCollator(resize=...)
+    max_eval_batches: int | None = None  # Bound an explicitly infinite lazy text eval stream
 
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
@@ -657,7 +754,14 @@ class MLXTrainingConfig:
 
         warmup_steps_default = type(self).warmup_steps
         warmup_ratio_default = type(self).warmup_ratio
-        copied_all_fields = len(provided) == len(config_fields)
+        copied_all_fields = len(provided) == len(config_fields) or (
+            "max_eval_batches" not in provided
+            and all(
+                field.name in provided
+                for field in config_fields
+                if field.name != "max_eval_batches"
+            )
+        )
         copied_default_warmup_with_ratio = (
             copied_all_fields
             and getattr(self, "warmup_steps", None) == warmup_steps_default
@@ -1551,6 +1655,67 @@ class MLXTrainer:
 
         return all_losses, ntokens
 
+    def _create_text_eval_batches(
+        self,
+        eval_dataset,
+        eval_batch_size,
+        completion_only_loss,
+        assistant_only_loss,
+    ):
+        """Build eager or one-pass lazy text evaluation batches."""
+        args = self.args
+        config = getattr(self.model, "_config", {})
+        model_type = config.get("model_type") if isinstance(config, dict) else None
+        eval_tokenizer = getattr(
+            self, "_mlx_response_mask_tokenizer", self.tokenizer,
+        )
+        common = dict(
+            dataset=eval_dataset,
+            tokenizer=eval_tokenizer,
+            batch_size=eval_batch_size,
+            max_seq_length=args.max_seq_length,
+            seed=args.seed,
+            dataset_text_field=args.dataset_text_field,
+            formatting_func=self.formatting_func,
+            chat_template=getattr(args, "chat_template", None),
+            model_name=getattr(self.model, "_hf_repo", None),
+            model_type=model_type,
+            append_eos=bool(getattr(args, "append_eos", True)),
+            completion_only_loss=completion_only_loss,
+            assistant_only_loss=assistant_only_loss,
+        )
+        if args.streaming and _is_mlx_lazy_text_source(eval_dataset):
+            max_batches = getattr(args, "max_eval_batches", None)
+            if max_batches is not None:
+                max_batches = int(max_batches)
+                if max_batches <= 0:
+                    raise ValueError(
+                        "Unsloth MLX: max_eval_batches must be a positive "
+                        "integer when provided."
+                    )
+
+            def _factory():
+                return iterate_training_batches(
+                    **common,
+                    response_mask_fn=getattr(self, "_mlx_response_mask_fn", None),
+                    dataset_order="sequential",
+                    comm_group=self.distributed_world,
+                    require_replayable=True,
+                    repeat=False,
+                    distributed_pad_mode="empty",
+                )
+
+            return _MLXLazyEvalBatchView(
+                eval_dataset,
+                _factory,
+                max_batches=max_batches,
+            )
+        return create_batches(
+            **common,
+            comm_group=self.distributed_world,
+            distributed_pad_mode="empty",
+        )
+
     def _evaluate(self, eval_batches, loss_fn, is_vlm=False):
         """Run evaluation loop.
 
@@ -2099,6 +2264,11 @@ class MLXTrainer:
             else:
                 total_steps = n_batches // grad_accum
             total_steps = max(1, total_steps)
+        elif getattr(self, "_streaming_epoch_batch_count", None) is not None:
+            total_steps = (
+                self._streaming_epoch_batch_count * args.num_train_epochs
+            ) // grad_accum
+            total_steps = max(1, total_steps)
         else:
             # Streaming mode — must have max_steps
             if args.num_train_epochs > 0:
@@ -2644,7 +2814,7 @@ class MLXTrainer:
                 eval_batches = _labeled_eval
             else:
                 def _create_eval_batches(eval_dataset):
-                    """Materialize eval batches for one dataset split."""
+                    """Build evaluation batches for one dataset split."""
                     if is_vlm:
                         processor = self._resolve_vlm_processor()
                         config = getattr(self.model, "_config", {})
@@ -2663,26 +2833,11 @@ class MLXTrainer:
                             comm_group=self.distributed_world,
                             distributed_pad_mode="empty",
                         )
-                    return create_batches(
-                        dataset=eval_dataset,
-                        tokenizer=self.tokenizer,
-                        batch_size=eval_batch_size,
-                        max_seq_length=args.max_seq_length,
-                        seed=args.seed,
-                        dataset_text_field=args.dataset_text_field,
-                        formatting_func=self.formatting_func,
-                        chat_template=getattr(args, "chat_template", None),
-                        model_name=getattr(self.model, "_hf_repo", None),
-                        model_type=(
-                            getattr(self.model, "_config", {}).get("model_type")
-                            if isinstance(getattr(self.model, "_config", {}), dict)
-                            else None
-                        ),
-                        append_eos=bool(getattr(args, "append_eos", True)),
-                        completion_only_loss=text_completion_only_loss,
-                        assistant_only_loss=text_assistant_only_loss,
-                        comm_group=self.distributed_world,
-                        distributed_pad_mode="empty",
+                    return self._create_text_eval_batches(
+                        eval_dataset,
+                        eval_batch_size,
+                        text_completion_only_loss,
+                        text_assistant_only_loss,
                     )
 
                 if isinstance(self.eval_dataset, dict):
@@ -2693,14 +2848,27 @@ class MLXTrainer:
                 else:
                     eval_batches = _create_eval_batches(self.eval_dataset)
             if eval_batches:
-                eval_batch_count = (
-                    sum(len(value) for value in eval_batches.values())
-                    if isinstance(eval_batches, dict) else len(eval_batches)
+                lazy_eval = isinstance(eval_batches, _MLXLazyEvalBatchView) or (
+                    isinstance(eval_batches, dict)
+                    and any(
+                        isinstance(value, _MLXLazyEvalBatchView)
+                        for value in eval_batches.values()
+                    )
                 )
-                _main_print(
-                    f"Unsloth: Eval enabled every {args.eval_steps} steps "
-                    f"({eval_batch_count} eval batches)."
-                )
+                if lazy_eval:
+                    _main_print(
+                        f"Unsloth: Eval enabled every {args.eval_steps} steps "
+                        "(lazy text batches)."
+                    )
+                else:
+                    eval_batch_count = (
+                        sum(len(value) for value in eval_batches.values())
+                        if isinstance(eval_batches, dict) else len(eval_batches)
+                    )
+                    _main_print(
+                        f"Unsloth: Eval enabled every {args.eval_steps} steps "
+                        f"({eval_batch_count} eval batches)."
+                    )
 
         features = []
         if is_vlm:
@@ -3306,6 +3474,7 @@ class MLXTrainer:
     def _prepare_data(self, is_vlm):
         """Prepare training data. Returns (batches, batch_iter)."""
         args = self.args
+        self._streaming_epoch_batch_count = None
         train_dataset = self._train_dataset_for_batches()
         config = getattr(self.model, "_config", {})
         model_type = config.get("model_type") if isinstance(config, dict) else None
@@ -3404,6 +3573,67 @@ class MLXTrainer:
                     if getattr(args, "preserve_dataset_order", False)
                     else getattr(args, "dataset_order", "default")
                 )
+                expected_rows_per_pass = None
+                require_replayable = bool(
+                    getattr(self, "_resume_from_checkpoint", None)
+                )
+                if (
+                    _is_mlx_lazy_text_source(train_dataset)
+                    and args.max_steps <= 0
+                    and args.num_train_epochs > 0
+                ):
+                    response_mask_fn = getattr(
+                        train_dataset, "_response_mask_fn", None,
+                    ) or getattr(self, "_mlx_response_mask_fn", None)
+                    if self.formatting_func is not None:
+                        raise ValueError(
+                            "Unsloth MLX: num_train_epochs with a streaming text "
+                            "iterable cannot use formatting_func because prepared "
+                            "row cardinality may change. Use max_steps instead."
+                        )
+                    if text_completion_only_loss is not False:
+                        raise ValueError(
+                            "Unsloth MLX: num_train_epochs with a streaming text "
+                            "iterable requires completion_only_loss=False so the "
+                            "declared length remains exact. Use max_steps for "
+                            "completion-masked streams."
+                        )
+                    if text_assistant_only_loss or response_mask_fn is not None:
+                        raise ValueError(
+                            "Unsloth MLX: num_train_epochs cannot guarantee exact "
+                            "steps for a streaming iterable whose rows may be "
+                            "filtered by label masking. Use max_steps instead."
+                        )
+                    source_length = _mlx_declared_iterable_length(train_dataset)
+                    if source_length is None:
+                        raise ValueError(
+                            "Unsloth MLX: num_train_epochs requires a streaming "
+                            "text iterable with an explicit reliable __len__. Use "
+                            "max_steps for an unsized source."
+                        )
+                    if source_length == 0:
+                        raise ValueError(
+                            "Unsloth MLX: streaming text iterable declares zero rows."
+                        )
+                    global_batch_size = (
+                        args.per_device_train_batch_size
+                        * self.distributed_world_size
+                    )
+                    self._streaming_epoch_batch_count = math.ceil(
+                        source_length / global_batch_size
+                    )
+                    if (
+                        self._streaming_epoch_batch_count
+                        % args.gradient_accumulation_steps
+                    ):
+                        raise ValueError(
+                            "Unsloth MLX: streaming num_train_epochs requires "
+                            "the total epoch micro-batches to be divisible by "
+                            "gradient_accumulation_steps. Use max_steps or "
+                            "adjust the accumulation factor."
+                        )
+                    expected_rows_per_pass = source_length
+                    require_replayable = True
                 return None, iterate_training_batches(
                     dataset=train_dataset,
                     tokenizer=self.tokenizer,
@@ -3420,9 +3650,8 @@ class MLXTrainer:
                     assistant_only_loss=text_assistant_only_loss,
                     dataset_order=text_dataset_order,
                     comm_group=comm_group,
-                    require_replayable=bool(
-                        getattr(self, "_resume_from_checkpoint", None)
-                    ),
+                    require_replayable=require_replayable,
+                    expected_rows_per_pass=expected_rows_per_pass,
                 )
             else:
                 batch_kwargs = dict(
@@ -4054,12 +4283,26 @@ def train_on_responses_only(
 
     # Callable HF tokenizer for token matching and text batch encoding.
     _tokenizer = _resolve_response_mask_tokenizer(_source)
+    _lazy_text_eval = False
+    eval_dataset = getattr(trainer, "eval_dataset", None)
+    if eval_dataset is not None:
+        eval_datasets = (
+            eval_dataset.values()
+            if isinstance(eval_dataset, dict)
+            else (eval_dataset,)
+        )
+        _lazy_text_eval = any(
+            _is_mlx_lazy_text_source(dataset) for dataset in eval_datasets
+        )
     if (
         not return_function
         and trainer is not None
         and not trainer._is_vlm
         and trainer.args.streaming
-        and _is_mlx_lazy_text_source(trainer._train_dataset_for_batches())
+        and (
+            _is_mlx_lazy_text_source(trainer._train_dataset_for_batches())
+            or _lazy_text_eval
+        )
     ):
         config = getattr(trainer.model, "_config", {})
         model_type = config.get("model_type") if isinstance(config, dict) else None
@@ -4108,6 +4351,9 @@ def train_on_responses_only(
     else:
         args = trainer.args
         train_dataset = trainer._train_dataset_for_batches()
+        if args.streaming:
+            trainer._mlx_response_mask_fn = mask_fn
+            trainer._mlx_response_mask_tokenizer = _tokenizer
         if args.streaming and _is_mlx_lazy_text_source(train_dataset):
             if not isinstance(train_dataset, _MLXIterableTokenizedDatasetView):
                 train_dataset = _MLXIterableTokenizedDatasetView(
@@ -4125,7 +4371,6 @@ def train_on_responses_only(
             else:
                 train_dataset.set_tokenizer(_tokenizer)
             train_dataset.set_response_mask(mask_fn)
-            trainer._mlx_response_mask_fn = mask_fn
             trainer._batches = None
             trainer._eval_batches_labeled = None
             _prepare_response_labeled_eval_batches(
@@ -4194,6 +4439,7 @@ def train_on_responses_only(
             trainer,
             _tokenizer,
             mask_fn,
+            sized_only=bool(args.streaming),
         )
 
         print(f"Unsloth: train_on_responses_only enabled "

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -308,6 +308,7 @@ from .utils import (
     create_batches,
     create_ordered_batches,
     iterate_training_batches,
+    _validate_streaming_length_window,
     _is_mlx_lazy_text_source,
     _MLXIterableTokenizedDatasetView,
     create_vlm_batches,
@@ -669,6 +670,15 @@ def _prune_stale_checkpoints(output_dir, save_total_limit):
               f"(save_total_limit={save_total_limit})")
 
 
+# Fields added after the original public MLXTrainingConfig surface. They must
+# stay a suffix of the declaration order (append new ones at the end and list
+# them here) so positional copies from older configs keep mapping correctly.
+_MLX_CONFIG_OPTIONAL_COPY_FIELDS = (
+    "max_eval_batches",
+    "streaming_text_length_window_batches",
+)
+
+
 @dataclass
 class MLXTrainingConfig:
     """Training configuration mirroring SFTConfig / TrainingArguments field names."""
@@ -759,6 +769,11 @@ class MLXTrainingConfig:
     per_device_eval_batch_size: int | None = None
     image_size: object = None  # VLM image resize override from UnslothVisionDataCollator(resize=...)
     max_eval_batches: int | None = None  # Bound an explicitly infinite lazy text eval stream
+    # Lazy default-order text streams: pool this many global micro-batches,
+    # length-sort, emit seeded-permuted batches. 1 = exact source order (prior
+    # behavior). Memory scales with world size; the DDP owner also retains one
+    # pass-long cycle-padding batch (documented bound W + 1).
+    streaming_text_length_window_batches: int = 8
 
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
@@ -796,13 +811,12 @@ class MLXTrainingConfig:
 
         warmup_steps_default = type(self).warmup_steps
         warmup_ratio_default = type(self).warmup_ratio
-        copied_all_fields = len(provided) == len(config_fields) or (
-            "max_eval_batches" not in provided
-            and all(
-                field.name in provided
-                for field in config_fields
-                if field.name != "max_eval_batches"
-            )
+        # A config copied field-by-field from an older Unsloth may omit fields
+        # added later; treat such copies as full copies for warmup semantics.
+        copied_all_fields = all(
+            field.name in provided
+            or field.name in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+            for field in config_fields
         )
         copied_default_warmup_with_ratio = (
             copied_all_fields
@@ -3685,6 +3699,11 @@ class MLXTrainer:
                     comm_group=comm_group,
                     require_replayable=require_replayable,
                     expected_rows_per_pass=expected_rows_per_pass,
+                    length_window_batches=_validate_streaming_length_window(
+                        getattr(
+                            args, "streaming_text_length_window_batches", 8,
+                        )
+                    ),
                 )
             else:
                 batch_kwargs = dict(

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -310,6 +310,7 @@ from .utils import (
     iterate_training_batches,
     _validate_streaming_length_window,
     _is_mlx_lazy_text_source,
+    _vlm_has_sized_index_space,
     _MLXIterableTokenizedDatasetView,
     create_vlm_batches,
     iterate_vlm_training_batches,
@@ -2873,6 +2874,13 @@ class MLXTrainer:
                 def _create_eval_batches(eval_dataset):
                     """Build evaluation batches for one dataset split."""
                     if is_vlm:
+                        if not _vlm_has_sized_index_space(eval_dataset):
+                            raise ValueError(
+                                "Unsloth MLX VLM: unsized streaming eval "
+                                "datasets are not supported yet. Provide a "
+                                "sized (__len__ + __getitem__) eval dataset; "
+                                "lazy VLM evaluation is a planned follow-up."
+                            )
                         processor = self._resolve_vlm_processor()
                         config = getattr(self.model, "_config", {})
                         _vlm_mask_fn = getattr(self, '_vlm_response_mask_fn', None)
@@ -3583,6 +3591,46 @@ class MLXTrainer:
                 else None
             )
             if args.streaming:
+                vlm_lazy = not _vlm_has_sized_index_space(train_dataset)
+                if vlm_lazy and self.distributed_world_size > 1:
+                    raise ValueError(
+                        "Unsloth MLX VLM: DDP training with an unsized "
+                        "streaming VLM source is not supported (every rank "
+                        "would re-consume the global stream). Use a sized "
+                        "dataset or single-process training; rank-owned lazy "
+                        "VLM dispatch is a planned follow-up."
+                    )
+                vlm_require_replayable = bool(
+                    getattr(self, "_resume_from_checkpoint", None)
+                )
+                vlm_expected_rows = None
+                if vlm_lazy and args.max_steps <= 0 and args.num_train_epochs > 0:
+                    declared = _mlx_declared_iterable_length(train_dataset)
+                    if declared is None:
+                        raise ValueError(
+                            "Unsloth MLX VLM: num_train_epochs requires a "
+                            "streaming iterable with an explicit reliable "
+                            "__len__. Use max_steps for an unsized source."
+                        )
+                    if declared == 0:
+                        raise ValueError(
+                            "Unsloth MLX VLM: streaming iterable declares zero rows."
+                        )
+                    self._streaming_epoch_batch_count = math.ceil(
+                        declared / args.per_device_train_batch_size
+                    )
+                    if (
+                        self._streaming_epoch_batch_count
+                        % args.gradient_accumulation_steps
+                    ):
+                        raise ValueError(
+                            "Unsloth MLX: streaming num_train_epochs requires "
+                            "the total epoch micro-batches to be divisible by "
+                            "gradient_accumulation_steps. Use max_steps or "
+                            "adjust the accumulation factor."
+                        )
+                    vlm_expected_rows = declared
+                    vlm_require_replayable = True
                 return None, iterate_vlm_training_batches(
                     dataset=train_dataset,
                     processor=processor,
@@ -3596,6 +3644,8 @@ class MLXTrainer:
                     dataset_order=vlm_dataset_order,
                     completion_only_loss=text_completion_only_loss,
                     comm_group=comm_group,
+                    require_replayable=vlm_require_replayable,
+                    expected_rows_per_pass=vlm_expected_rows,
                 )
             else:
                 self._prepared_batches_include_epochs = vlm_num_epochs is not None

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -76,7 +76,11 @@ def _mlx_rank0_resolve_int(comm_group, resolver, context):
         try:
             value = int(resolver())
             status = 1
-        except Exception as exc:
+        except BaseException as exc:
+            # Synchronize the failure (KeyboardInterrupt/SystemExit included)
+            # before it propagates: peers are already blocking in the metadata
+            # collective and would hang if rank 0 unwound past it silently.
+            # The original error is re-raised on rank 0 below.
             owner_error = exc
             status = -1
     metadata = mx.array(
@@ -214,20 +218,28 @@ def _mlx_stream_declares_infinite(dataset):
             and getattr(ex_iterable, "num_times", 0) is None
         ):
             return True
+        # These are private datasets internals: read them defensively so a
+        # rename in a future release degrades detection (the stream just
+        # is not recognized as infinite) instead of failing eval for every
+        # stream whose wrapper class matches by name.
         if kind in (
             "VerticallyConcatenatedMultiSourcesExamplesIterable",
             "HorizontallyConcatenatedMultiSourcesExamplesIterable",
         ):
-            return any(_is_infinite(child, seen) for child in ex_iterable.ex_iterables)
+            return any(
+                _is_infinite(child, seen)
+                for child in getattr(ex_iterable, "ex_iterables", ())
+            )
         if kind in (
             "CyclingMultiSourcesExamplesIterable",
             "RandomlyCyclingMultiSourcesExamplesIterable",
         ):
-            children = ex_iterable.ex_iterables
+            children = getattr(ex_iterable, "ex_iterables", ())
             probabilities = getattr(ex_iterable, "probabilities", None)
+            stopping_strategy = getattr(ex_iterable, "stopping_strategy", "")
             if probabilities is not None:
                 if (
-                    ex_iterable.stopping_strategy.startswith("all_exhausted")
+                    stopping_strategy.startswith("all_exhausted")
                     and any(probability <= 0 for probability in probabilities)
                 ):
                     return True
@@ -238,7 +250,7 @@ def _mlx_stream_declares_infinite(dataset):
             infinite = [_is_infinite(child, seen) for child in children]
             return (
                 any(infinite)
-                if ex_iterable.stopping_strategy.startswith("all_exhausted")
+                if stopping_strategy.startswith("all_exhausted")
                 else bool(infinite) and all(infinite)
             )
         return _is_infinite(getattr(ex_iterable, "ex_iterable", None), seen)
@@ -272,14 +284,21 @@ class _MLXLazyEvalBatchView:
                 "so evaluation has an explicit boundary."
             )
         iterator = iter(self._factory())
-        if self._max_batches is None:
-            yield from iterator
-            return
-        for _ in range(self._max_batches):
-            try:
-                yield next(iterator)
-            except StopIteration:
+        try:
+            if self._max_batches is None:
+                yield from iterator
                 return
+            for _ in range(self._max_batches):
+                try:
+                    yield next(iterator)
+                except StopIteration:
+                    return
+        finally:
+            # max_eval_batches truncation (and early consumer exits) must
+            # release the lazy pass's owned source cursors deterministically.
+            close = getattr(iterator, "close", None)
+            if callable(close):
+                close()
 
 
 def _mlx_declared_iterable_length(dataset):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1702,6 +1702,14 @@ class MLXTrainer:
         """Accumulate weighted loss totals for one flat eval batch stream."""
         all_losses = mx.array(0.0)
         ntokens = mx.array(0)
+        # A stop requested before evaluation (e.g. a step callback firing on an
+        # eval step) must abort before the first pull: an unsized source's next
+        # row can block, so cancellation could otherwise never take effect. The
+        # check is rank-synchronized, so peers return together instead of
+        # diverging at the in-loop status collective.
+        should_stop, _ = self._distributed_eval_status()
+        if should_stop:
+            return all_losses, ntokens
         iterator = iter(eval_batches)
 
         while True:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -3702,15 +3702,19 @@ class MLXTrainer:
                 else None
             )
             if args.streaming:
-                if _validate_streaming_prefetch(
+                vlm_prefetch_depth = _validate_streaming_prefetch(
                     getattr(args, "streaming_prefetch_batches", 0)
-                ) and not getattr(self, "_mlx_prefetch_vlm_notice", False):
-                    self._mlx_prefetch_vlm_notice = True
-                    if getattr(self, "_distributed_is_main_process", True):
-                        print(
-                            "Unsloth: streaming_prefetch_batches does not "
-                            "cover VLM streams yet; continuing synchronously."
-                        )
+                )
+                if vlm_prefetch_depth and self.distributed_world_size > 1:
+                    if not getattr(self, "_mlx_prefetch_ddp_notice", False):
+                        self._mlx_prefetch_ddp_notice = True
+                        if getattr(self, "_distributed_is_main_process", True):
+                            print(
+                                "Unsloth: streaming_prefetch_batches is "
+                                "single-process only; continuing "
+                                "synchronously under DDP."
+                            )
+                    vlm_prefetch_depth = 0
                 vlm_lazy = not _vlm_has_sized_index_space(train_dataset)
                 if vlm_lazy and self.distributed_world_size > 1:
                     raise ValueError(
@@ -3751,6 +3755,13 @@ class MLXTrainer:
                         )
                     vlm_expected_rows = declared
                     vlm_require_replayable = True
+                self._mlx_prefetch_control = {
+                    "eligible": bool(vlm_prefetch_depth and vlm_lazy),
+                }
+                vlm_resume_skip = (
+                    int(getattr(self, "_mlx_resume_step_for_prefetch", 0))
+                    * args.gradient_accumulation_steps
+                )
                 return None, iterate_vlm_training_batches(
                     dataset=train_dataset,
                     processor=processor,
@@ -3766,6 +3777,12 @@ class MLXTrainer:
                     comm_group=comm_group,
                     require_replayable=vlm_require_replayable,
                     expected_rows_per_pass=vlm_expected_rows,
+                    prefetch_batches=vlm_prefetch_depth if vlm_lazy else 0,
+                    prefetch_skip_batches=(
+                        vlm_resume_skip
+                        if vlm_prefetch_depth and vlm_lazy else 0
+                    ),
+                    prefetch_control=self._mlx_prefetch_control,
                 )
             else:
                 self._prepared_batches_include_epochs = vlm_num_epochs is not None

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -733,6 +733,7 @@ _MLX_CONFIG_OPTIONAL_COPY_FIELDS = (
     "max_eval_batches",
     "streaming_text_length_window_batches",
     "streaming_prefetch_batches",
+    "label_smoothing_factor",
 )
 
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -196,6 +196,7 @@ from .utils import (
     snapshot_mlx_norm_output_cast_state,
     _get_text_model,
     _distributed_global_batch_size,
+    _is_mlx_replayable_text_source,
     _rank_slice_distributed_batch,
 )
 from .compile import (
@@ -600,7 +601,7 @@ class MLXTrainingConfig:
     compile_auto_tune: bool = True
     compile_trace: bool = True
     gradient_checkpointing: bool = True
-    streaming: bool = False  # Use streaming iterator instead of materializing batches
+    streaming: bool = False  # Lazily consume unsized text/VLM sources
     dataset_order: str = "default"  # "default", "sequential", or "torch_randperm"
     preserve_dataset_order: bool = False  # Match Unsloth CUDA SequentialSampler order
     memory_limit_gb: float | None = None  # None = auto Metal guard (~85% of recommended working set); <= 0 disables
@@ -2714,14 +2715,25 @@ class MLXTrainer:
         # ordering the killed run would have produced.
         if _resume_step > 0 and batch_iter is not None:
             for _ in range(_resume_step * grad_accum):
+                fast_forward_error = None
                 try:
                     next(batch_iter)
                 except StopIteration:
-                    raise RuntimeError(
+                    fast_forward_error = RuntimeError(
                         f"Unsloth: streaming dataset exhausted while "
                         f"fast-forwarding to resume step {_resume_step}. "
                         f"Dataset may be shorter than the killed run consumed."
-                    ) from None
+                    )
+                except Exception as e:
+                    fast_forward_error = e
+                if distributed_world_size > 1:
+                    self._raise_distributed_failure(
+                        fast_forward_error is not None,
+                        "fast-forwarding training batch",
+                        fast_forward_error,
+                    )
+                elif fast_forward_error is not None:
+                    raise fast_forward_error
 
         def _run_ddp_local_step(batch_data, prev_state, do_update):
             """Run local DDP work, then synchronize failures before collectives."""
@@ -3342,6 +3354,15 @@ class MLXTrainer:
         else:
             chat_tmpl = getattr(args, "chat_template", None)
             if args.streaming:
+                if (
+                    getattr(self, "_resume_from_checkpoint", None)
+                    and not _is_mlx_replayable_text_source(train_dataset)
+                ):
+                    raise RuntimeError(
+                        "Unsloth MLX: checkpoint resume requires a replayable "
+                        "iterable text source; a one-shot iterator cannot be "
+                        "fast-forwarded deterministically."
+                    )
                 text_dataset_order = (
                     "sequential"
                     if getattr(args, "preserve_dataset_order", False)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2476,9 +2476,9 @@ class MLXTrainer:
     def _quiesce_prefetcher_for_save(self, terminal=False):
         """Make serialization exclusive over shared preprocessing objects.
 
-        ``terminal=True`` (end of training) closes the producer for good;
-        otherwise an active producer is PAUSED and returned so the caller can
-        resume it after the save. Live persisted orphans always refuse.
+        ``terminal=True`` closes the producer for good; otherwise an active
+        producer is PAUSED and returned so the caller can resume it after the
+        save. Live persisted orphans always refuse.
         """
         orphan = getattr(self, "_mlx_prefetch_orphan", None)
         if orphan is not None:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -222,19 +222,17 @@ def _mlx_stream_declares_infinite(dataset):
         # rename in a future release degrades detection (the stream just
         # is not recognized as infinite) instead of failing eval for every
         # stream whose wrapper class matches by name.
-        if kind == "VerticallyConcatenatedMultiSourcesExamplesIterable":
-            # Sequential concat runs children one after another, so it never
-            # ends if ANY child is infinite.
+        if kind in (
+            "VerticallyConcatenatedMultiSourcesExamplesIterable",
+            "HorizontallyConcatenatedMultiSourcesExamplesIterable",
+        ):
+            # Vertical concat runs children one after another. Horizontal
+            # concat advances them together but drops each child as it is
+            # exhausted and stops only once every child is gone, so it ends
+            # with the LONGEST child. Both are infinite when ANY child is.
             return any(
                 _is_infinite(child, seen)
                 for child in getattr(ex_iterable, "ex_iterables", ())
-            )
-        if kind == "HorizontallyConcatenatedMultiSourcesExamplesIterable":
-            # Column-wise concat advances children in lockstep and ends with
-            # the shortest, so it is infinite only if EVERY child is.
-            children = getattr(ex_iterable, "ex_iterables", ())
-            return bool(children) and all(
-                _is_infinite(child, seen) for child in children
             )
         if kind in (
             "CyclingMultiSourcesExamplesIterable",

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -77,10 +77,9 @@ def _mlx_rank0_resolve_int(comm_group, resolver, context):
             value = int(resolver())
             status = 1
         except BaseException as exc:
-            # Synchronize the failure (KeyboardInterrupt/SystemExit included)
-            # before it propagates: peers are already blocking in the metadata
-            # collective and would hang if rank 0 unwound past it silently.
-            # The original error is re-raised on rank 0 below.
+            # Synchronize the failure (interrupts included) before it
+            # propagates: peers block in the metadata collective and would hang
+            # if rank 0 unwound past it. Re-raised on rank 0 below.
             owner_error = exc
             status = -1
     metadata = mx.array(
@@ -218,18 +217,15 @@ def _mlx_stream_declares_infinite(dataset):
             and getattr(ex_iterable, "num_times", 0) is None
         ):
             return True
-        # These are private datasets internals: read them defensively so a
-        # rename in a future release degrades detection (the stream just
-        # is not recognized as infinite) instead of failing eval for every
-        # stream whose wrapper class matches by name.
+        # Private datasets internals: read defensively so a future rename only
+        # loses detection instead of failing eval for every matching stream.
         if kind in (
             "VerticallyConcatenatedMultiSourcesExamplesIterable",
             "HorizontallyConcatenatedMultiSourcesExamplesIterable",
         ):
-            # Vertical concat runs children one after another. Horizontal
-            # concat advances them together but drops each child as it is
-            # exhausted and stops only once every child is gone, so it ends
-            # with the LONGEST child. Both are infinite when ANY child is.
+            # Vertical concat runs children in sequence; horizontal concat
+            # drops each as it exhausts and ends with the LONGEST child. Both
+            # are infinite when ANY child is.
             return any(
                 _is_infinite(child, seen)
                 for child in getattr(ex_iterable, "ex_iterables", ())
@@ -298,8 +294,8 @@ class _MLXLazyEvalBatchView:
                 except StopIteration:
                     return
         finally:
-            # max_eval_batches truncation (and early consumer exits) must
-            # release the lazy pass's owned source cursors deterministically.
+            # Truncation and early consumer exits must release the owned
+            # source cursors deterministically.
             close = getattr(iterator, "close", None)
             if callable(close):
                 close()
@@ -729,9 +725,9 @@ def _prune_stale_checkpoints(output_dir, save_total_limit):
               f"(save_total_limit={save_total_limit})")
 
 
-# Fields added after the original public MLXTrainingConfig surface. They must
-# stay a suffix of the declaration order (append new ones at the end and list
-# them here) so positional copies from older configs keep mapping correctly.
+# Fields added after the original public MLXTrainingConfig surface. Keep them a
+# suffix of the declaration order (append new ones at the end and list them
+# here) so positional copies from older configs keep mapping correctly.
 _MLX_CONFIG_OPTIONAL_COPY_FIELDS = (
     "max_eval_batches",
     "streaming_text_length_window_batches",
@@ -829,8 +825,8 @@ class MLXTrainingConfig:
     vlm_chat_template: object = None  # Unsloth template name/tuple or raw Jinja string
     per_device_eval_batch_size: int | None = None
     image_size: object = None  # VLM image resize override from UnslothVisionDataCollator(resize=...)
-    # Appended by main after image_size; kept before this branch's streaming
-    # fields so a positional copy from a main config still maps correctly.
+    # Appended by main after image_size; kept before the streaming fields so a
+    # positional copy from a main config still maps correctly.
     label_smoothing_factor: float = 0.0  # HF LabelSmoother epsilon (text models only)
 
     # Opt-in true global grad-norm reporting when global-norm clipping is off.
@@ -848,18 +844,17 @@ class MLXTrainingConfig:
     # weight decay.
     report_grad_norm: bool = False
 
-    # This branch's lazy-streaming fields, appended LAST after every pre-existing
-    # (including main-appended) field, so positional copies from older configs
-    # keep mapping correctly. Listed in _MLX_CONFIG_OPTIONAL_COPY_FIELDS.
+    # Lazy-streaming fields, appended LAST after every pre-existing field so
+    # positional copies from older configs keep mapping correctly. Listed in
+    # _MLX_CONFIG_OPTIONAL_COPY_FIELDS.
     max_eval_batches: int | None = None  # Bound an explicitly infinite lazy text eval stream
     # Lazy default-order text streams: pool this many global micro-batches,
-    # length-sort, emit seeded-permuted batches. 1 = exact source order (prior
-    # behavior). Memory scales with world size; the DDP owner also retains one
-    # pass-long cycle-padding batch (documented bound W + 1).
+    # length-sort, emit seeded-permuted batches. 1 = exact source order. Memory
+    # scales with world size; the DDP owner retains one extra padding batch.
     streaming_text_length_window_batches: int = 8
-    # Lazy text streams: prepare up to this many batches ahead on a producer
-    # thread (0 = synchronous, the default; single-process only; host-valued
-    # rows required). Retention adds the queued batches to the window bound.
+    # Lazy text streams: prepare this many batches ahead on a producer thread
+    # (0 = synchronous default; single-process, host-valued rows only). Queued
+    # batches add to the window bound.
     streaming_prefetch_batches: int = 0
 
     def __init__(self, *args, **kwargs):
@@ -898,16 +893,11 @@ class MLXTrainingConfig:
 
         warmup_steps_default = type(self).warmup_steps
         warmup_ratio_default = type(self).warmup_ratio
-        # A config copied field-by-field (or round-tripped through a full-field
-        # dump) from an older Unsloth may omit fields added later; treat such
-        # copies as wholesale copies for warmup semantics, or a copied default
-        # warmup_steps would override a non-default warmup_ratio. Tolerate every
-        # field appended since: the positional optional-copy fields plus the
-        # later scalar additions.
-        # Every field appended after configs began round-tripping: this branch's
-        # streaming suffix plus the earlier scalar additions (compile_max_variants
-        # is mid-order; label_smoothing_factor / report_grad_norm precede the
-        # streaming suffix). A legacy dump missing any of them is still a copy.
+        # A config copied or round-tripped from an older Unsloth may omit later
+        # fields; still treat it as a wholesale copy for warmup semantics, or a
+        # copied default warmup_steps would override a non-default warmup_ratio.
+        # So tolerate every field appended since: the positional optional-copy
+        # fields plus the later scalar additions.
         _appended_fields = set(_MLX_CONFIG_OPTIONAL_COPY_FIELDS) | {
             "compile_max_variants",
             "label_smoothing_factor",
@@ -1569,10 +1559,9 @@ class MLXTrainer:
         if not failed_any:
             return
         if exc is not None and not isinstance(exc, Exception):
-            # Interrupts (KeyboardInterrupt/SystemExit) were captured only so
-            # this rank could join the consensus; re-raise them unwrapped and
-            # without mutating trainer state, so a reused trainer does not
-            # inherit a stop request from an interrupt.
+            # Interrupts were captured only so this rank could join the
+            # consensus. Re-raise unwrapped without mutating trainer state, so
+            # a reused trainer does not inherit a stop request.
             raise exc
         self.stop_requested = True
         if exc is not None:
@@ -2034,11 +2023,10 @@ class MLXTrainer:
         """Accumulate weighted loss totals for one flat eval batch stream."""
         all_losses = mx.array(0.0)
         ntokens = mx.array(0)
-        # A stop requested before evaluation (e.g. a step callback firing on an
-        # eval step) must abort before the first pull: an unsized source's next
-        # row can block, so cancellation could otherwise never take effect. The
-        # check is rank-synchronized, so peers return together instead of
-        # diverging at the in-loop status collective.
+        # A stop requested before evaluation must abort before the first pull:
+        # an unsized source's next row can block, so cancellation could
+        # otherwise never take effect. Rank-synchronized so peers return
+        # together instead of diverging at the in-loop status collective.
         should_stop, _ = self._distributed_eval_status()
         if should_stop:
             return all_losses, ntokens
@@ -2053,7 +2041,7 @@ class MLXTrainer:
                 break
             except BaseException as exc:
                 # Interrupts included: every rank must reach the eval status
-                # collective below, or the surviving ranks hang in it.
+                # collective below or the survivors hang in it.
                 failed = True
                 error = exc
 
@@ -2117,8 +2105,8 @@ class MLXTrainer:
         if args.streaming and _is_mlx_lazy_text_source(eval_dataset):
             max_batches = getattr(args, "max_eval_batches", None)
             if max_batches is not None:
-                # Reject rather than truncate non-integral values (1.9, True):
-                # silent coercion would change how much eval data is scored.
+                # Reject rather than truncate: silent coercion would change how
+                # much eval data is scored.
                 coerced = None
                 if not isinstance(max_batches, bool):
                     try:
@@ -2455,8 +2443,8 @@ class MLXTrainer:
         """Best-effort release of an iterator owned by the training run."""
         batch_iter = getattr(self, "_active_batch_iter", None)
         self._active_batch_iter = None
-        # Normal, failed, and interrupted exits all pass through here: close the
-        # producer and persist a live orphan so the next run's gate sees it.
+        # Every exit path lands here: close the producer and persist a live
+        # orphan so the next run's gate sees it.
         control = getattr(self, "_mlx_prefetch_control", None)
         prefetcher = control.get("prefetcher") if control else None
         try:
@@ -2465,9 +2453,9 @@ class MLXTrainer:
                 try:
                     close()
                 except Exception:
-                    # An ordinary cleanup error must not mask the training error
-                    # already in flight or diverge ranks after a final
-                    # collective. A propagating signal is honored (see finally).
+                    # A cleanup error must not mask an in-flight training error
+                    # or diverge ranks after a final collective. A propagating
+                    # signal is still honored (see finally).
                     pass
             if prefetcher is not None:
                 try:
@@ -2476,10 +2464,9 @@ class MLXTrainer:
                     pass
         finally:
             if prefetcher is not None:
-                # close() marks a conservative orphan before doing anything, so
-                # a not-clean close OR a propagating interrupt leaves
-                # orphaned=True; persist it either way (a clean, drained close
-                # clears the flag). The next run's gate drains and clears it.
+                # close() marks a conservative orphan up front, so an unclean
+                # close or a propagating interrupt leaves orphaned=True. Persist
+                # it either way; the next run's gate drains and clears it.
                 if prefetcher.orphaned:
                     self._mlx_prefetch_orphan = prefetcher
                 if control is not None:
@@ -2502,9 +2489,8 @@ class MLXTrainer:
                     "to serialize concurrently. Wait for the thread to "
                     "terminate, then call save_model() again."
                 )
-            # Terminated orphan: close() drains its queued batches (device
-            # tensors for opaque VLM outputs) before this save, rather than
-            # relying on the reference drop to eventually free them.
+            # Terminated orphan: close() drains its queued device tensors
+            # before this save instead of waiting on the reference drop.
             orphan.close()
             self._mlx_prefetch_orphan = None
         control = getattr(self, "_mlx_prefetch_control", None)
@@ -2514,9 +2500,9 @@ class MLXTrainer:
         if not terminal:
             prefetcher.quiesce()
             return prefetcher
-        # Gate on close()'s return, not a fresh orphan_alive() read: close()
-        # drained the queue iff it reports clean, so this cannot proceed to
-        # save with staged batches (device tensors) still queued.
+        # Gate on close()'s return, not a fresh orphan_alive() read: it drained
+        # the queue iff it reports clean, so a save can never proceed with
+        # staged device tensors still queued.
         if not prefetcher.close():
             self._mlx_prefetch_orphan = prefetcher
             control["prefetcher"] = None
@@ -2527,7 +2513,7 @@ class MLXTrainer:
                 "then call save_model() again."
             )
         # Terminal close succeeded: drop the control reference so the ensuing
-        # save_model() wrapper gate is a no-op (no quiesce/resume re-entry).
+        # save_model() wrapper gate is a no-op.
         control["prefetcher"] = None
         return None
 
@@ -2848,9 +2834,9 @@ class MLXTrainer:
                 loss_fn = make_baseline_loss_fn(label_smoothing=label_smoothing)
                 _main_print("Unsloth: Using standard cross-entropy loss.")
 
-        # Prepare data, determine total_steps first. Keep any prebuilt flag
-        # from train_on_responses_only; _prepare_data returns self._batches
-        # early and never re-derives it for the completion-only text path.
+        # Prepare data and total_steps first. Keep any prebuilt flag from
+        # train_on_responses_only: _prepare_data returns self._batches early
+        # and never re-derives it for the completion-only text path.
         previous_orphan = getattr(self, "_mlx_prefetch_orphan", None)
         if previous_orphan is not None:
             if previous_orphan.orphan_alive():
@@ -2861,7 +2847,7 @@ class MLXTrainer:
                     "before training with this trainer again."
                 )
             # Terminated orphan: close() drains its queued batches before the
-            # reference is dropped, releasing them deterministically.
+            # reference is dropped.
             previous_orphan.close()
             self._mlx_prefetch_orphan = None
         self._mlx_resume_step_for_prefetch = 0
@@ -2874,9 +2860,9 @@ class MLXTrainer:
             and getattr(self.args, "streaming", False)
         )
         if _wants_prefetch and getattr(self, "_resume_from_checkpoint", None):
-            # Single authority: the same validated load feeds the producer skip
-            # now and the scalar restoration later (world size is 1 here, so no
-            # duplicated distributed collectives). Failures stay hard.
+            # Single authority: this validated load feeds the producer skip now
+            # and the scalar restoration later. World size is 1 here, so no
+            # duplicated collectives. Failures stay hard.
             _early_resume = self._validate_distributed_resume_checkpoint(
                 self._resume_from_checkpoint
             )
@@ -2909,9 +2895,8 @@ class MLXTrainer:
                 and args.num_train_epochs > 0
             ):
                 # Declared-length streaming epochs: total micro-batches come
-                # from the per-pass trainable-row count. The finite-plan step
-                # resolver rejects streaming + num_train_epochs, so resolve it
-                # here for the streaming path.
+                # from the per-pass trainable-row count. The finite-plan
+                # resolver rejects streaming, so resolve it here.
                 total_steps = max(1, (
                     _stream_epochs * args.num_train_epochs
                 ) // args.gradient_accumulation_steps)
@@ -2938,8 +2923,8 @@ class MLXTrainer:
                 distributed_world_size=distributed_world_size,
                 compile_policy=compile_policy,
             )
-        # Prefetch wiring is shared by both the preflight and prepared paths:
-        # batch_iter is the streaming producer when active, None otherwise.
+        # Shared by the preflight and prepared paths: batch_iter is the
+        # streaming producer when active, None otherwise.
         _prefetch_active = bool(
             getattr(self, "_mlx_prefetch_control", None)
             and self._mlx_prefetch_control.get("eligible")
@@ -3386,9 +3371,9 @@ class MLXTrainer:
                         outputs=_compile_state,
                     )
                 except BaseException as e:
-                    # Ordinary failures keep the eager-fallback path; an
-                    # interrupt must abort through the consensus instead of
-                    # silently downgrading the run to eager mode.
+                    # Ordinary failures fall back to eager, but an interrupt
+                    # must abort through the consensus instead of silently
+                    # downgrading the run.
                     if isinstance(e, Exception):
                         _compile_setup_error = e
                     else:
@@ -4083,9 +4068,9 @@ class MLXTrainer:
                 except Exception as e:
                     _main_print(f"Unsloth: failed to restore best model ({e}).")
                 except BaseException as e:
-                    # Ordinary restore failures stay log-and-continue, but an
+                    # Ordinary restore failures log and continue, but an
                     # interrupt must reach the consensus below before the
-                    # diagnostics collective, or peers hang in it.
+                    # diagnostics collective or peers hang in it.
                     restore_abort = e
         self._raise_distributed_failure(
             restore_abort is not None,
@@ -4512,9 +4497,8 @@ class MLXTrainer:
         try:
             return self._save_model_impl(output_dir)
         finally:
-            # A mid-training save (e.g. from a step callback) pauses the
-            # producer for exclusivity and resumes it; only the end-of-training
-            # path closes it terminally.
+            # A mid-training save pauses the producer for exclusivity and
+            # resumes it; only end-of-training closes it terminally.
             if paused_prefetcher is not None:
                 paused_prefetcher.resume()
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3365,6 +3365,16 @@ def _ensure_reiterable_text_dataset(dataset):
 
 def _is_mlx_lazy_text_source(dataset):
     """Return whether streaming text must avoid map-style source operations."""
+    try:
+        from datasets import Dataset as HFDataset
+        from datasets import IterableDataset as HFIterableDataset
+    except ImportError:
+        pass
+    else:
+        if isinstance(dataset, HFIterableDataset):
+            return True
+        if isinstance(dataset, HFDataset):
+            return False
     if isinstance(dataset, Sequence):
         return False
     if isinstance(dataset, Iterator):
@@ -3374,7 +3384,14 @@ def _is_mlx_lazy_text_source(dataset):
 
 def _is_mlx_replayable_text_source(dataset):
     """Return whether a source can create a fresh iterator for another pass."""
-    return not isinstance(dataset, Iterator)
+    if isinstance(dataset, Iterator):
+        return False
+    try:
+        first = iter(dataset)
+        second = iter(dataset)
+    except TypeError:
+        return False
+    return first is not second
 
 
 def _labeled_row_has_supervision(labels, max_seq_length):
@@ -5191,7 +5208,15 @@ def _iter_lazy_tokenized_text_rows(
     state = {} if state is None else state
     eos_id = getattr(tokenizer, "eos_token_id", None) if append_eos else None
 
-    def _validate_state(kind, labels):
+    if completion_only_loss is not None:
+        state.setdefault(
+            "pretokenized_completion_only_loss",
+            completion_only_loss,
+        )
+
+    def _validate_state(kind, labels, *, usable=True, completion_mode=False):
+        if not usable:
+            return
         if state.get("schema") is None:
             state["schema"] = kind
         elif state["schema"] != kind:
@@ -5199,6 +5224,10 @@ def _iter_lazy_tokenized_text_rows(
                 "Unsloth MLX: pretokenized text rows with 'input_ids' cannot "
                 "be mixed with rows that need text formatting/tokenization."
             )
+        state.setdefault(
+            "pretokenized_completion_only_loss",
+            completion_mode,
+        )
         has_labels = labels is not None
         if state.get("label_state") is None:
             state["label_state"] = has_labels
@@ -5209,6 +5238,16 @@ def _iter_lazy_tokenized_text_rows(
             )
 
     for item in dataset:
+        item_has_completion_boundary = (
+            isinstance(item, Mapping)
+            and "prompt" in item
+            and "completion" in item
+        )
+        formatter_needs_completion_boundary = (
+            formatting_func is not None
+            and completion_only_loss is None
+            and item_has_completion_boundary
+        )
         source_rows = item if (
             isinstance(item, list) and not _looks_like_mlx_chat_messages(item)
         ) else [item]
@@ -5223,25 +5262,57 @@ def _iter_lazy_tokenized_text_rows(
             ) else [formatted]
 
         for row in source_rows:
+            row_has_completion_boundary = (
+                isinstance(row, Mapping)
+                and "prompt" in row
+                and "completion" in row
+            )
+            row_completion_only_loss = (
+                completion_only_loss
+                if completion_only_loss is not None
+                else True
+                if item_has_completion_boundary or row_has_completion_boundary
+                else state.get("pretokenized_completion_only_loss", False)
+            )
             tokenized = _tokenize_mlx_pretokenized_row(
                 row,
-                completion_only_loss=completion_only_loss,
+                completion_only_loss=row_completion_only_loss,
                 assistant_only_loss=assistant_only_loss,
             )
             if tokenized is not None:
                 ids, labels = tokenized
-                _validate_state("pretokenized", labels)
+                if formatter_needs_completion_boundary and labels is None:
+                    raise ValueError(
+                        "Unsloth MLX: a formatting_func was provided for a "
+                        "prompt/completion dataset, which drops the completion "
+                        "boundary needed for the default completion-only loss. "
+                        "Apply your formatting before passing the dataset, or set "
+                        "completion_only_loss=False."
+                    )
                 if max_seq_length is not None:
                     ids = ids[:max_seq_length]
                     labels = (
                         labels[:max_seq_length] if labels is not None else None
                     )
-                if len(ids) >= 2 and _labeled_row_has_supervision(
+                usable = len(ids) >= 2 and _labeled_row_has_supervision(
                     labels, len(ids)
-                ):
+                )
+                _validate_state(
+                    "pretokenized",
+                    labels,
+                    usable=usable,
+                    completion_mode=row_completion_only_loss,
+                )
+                if usable:
                     yield ids, labels
                 continue
 
+            if assistant_only_loss and not _is_mlx_sft_conversational_row(row):
+                raise ValueError(
+                    "You set `assistant_only_loss=True`, but the dataset is not "
+                    "conversational. This option is only supported for "
+                    "conversational datasets."
+                )
             labeled = None
             if completion_only_loss is not False or assistant_only_loss:
                 labeled = _tokenize_mlx_prompt_completion_row(
@@ -5256,13 +5327,19 @@ def _iter_lazy_tokenized_text_rows(
                     labeled = _tokenize_mlx_assistant_messages_row(tokenizer, row)
             if labeled is not None:
                 ids, labels = labeled
-                _validate_state("raw", labels)
                 if max_seq_length is not None:
                     ids = ids[:max_seq_length]
                     labels = labels[:max_seq_length]
-                if len(ids) >= 2 and _labeled_row_has_supervision(
+                usable = len(ids) >= 2 and _labeled_row_has_supervision(
                     labels, len(ids)
-                ):
+                )
+                _validate_state(
+                    "raw",
+                    labels,
+                    usable=usable,
+                    completion_mode=row_completion_only_loss,
+                )
+                if usable:
                     yield ids, labels
                 continue
             if assistant_only_loss:
@@ -5276,6 +5353,14 @@ def _iter_lazy_tokenized_text_rows(
                     "Unsloth MLX: text completion_only_loss=True requires "
                     "prompt/completion rows for streaming text training."
                 )
+            if formatter_needs_completion_boundary:
+                raise ValueError(
+                    "Unsloth MLX: a formatting_func was provided for a "
+                    "prompt/completion dataset, which drops the completion "
+                    "boundary needed for the default completion-only loss. "
+                    "Apply your formatting before passing the dataset, or set "
+                    "completion_only_loss=False."
+                )
 
             for text in collect_mlx_texts(
                 tokenizer,
@@ -5288,7 +5373,12 @@ def _iter_lazy_tokenized_text_rows(
                     ids.append(int(eos_id))
                 if max_seq_length is not None:
                     ids = ids[:max_seq_length]
-                _validate_state("raw", None)
+                _validate_state(
+                    "raw",
+                    None,
+                    usable=len(ids) >= 2,
+                    completion_mode=row_completion_only_loss,
+                )
                 if len(ids) >= 2:
                     yield ids, None
 
@@ -5320,12 +5410,27 @@ def _iterate_lazy_text_training_batches(
     replayable = _is_mlx_replayable_text_source(dataset)
     state = {}
     epoch = 0
+
+    def _make_batch(local_items):
+        if state.get("schema") == "raw" and state.get("label_state") is False:
+            return _make_text_batch_from_items(
+                [ids for ids, _labels in local_items],
+                tokenizer,
+                max_seq_length,
+            )
+        return _create_tokenized_text_batch(
+            local_items,
+            max_seq_length,
+            pad_id=_mlx_text_pad_id(tokenizer),
+        )
+
     while True:
         set_epoch = getattr(dataset, "set_epoch", None)
         if replayable and callable(set_epoch):
             set_epoch(epoch)
 
         pending = []
+        padding_source = []
         yielded = False
         for row in _iter_lazy_tokenized_text_rows(
             dataset,
@@ -5338,6 +5443,8 @@ def _iterate_lazy_text_training_batches(
             max_seq_length=max_seq_length,
             state=state,
         ):
+            if len(padding_source) < global_batch_size:
+                padding_source.append(row)
             pending.append(row)
             if len(pending) < global_batch_size:
                 continue
@@ -5345,14 +5452,10 @@ def _iterate_lazy_text_training_batches(
                 pending,
                 batch_size,
                 comm_group=comm_group,
-                pad_source=pending,
+                pad_source=padding_source,
             )
             yielded = True
-            yield _create_tokenized_text_batch(
-                local_items,
-                max_seq_length,
-                pad_id=_mlx_text_pad_id(tokenizer),
-            )
+            yield _make_batch(local_items)
             pending = []
 
         if pending:
@@ -5360,14 +5463,10 @@ def _iterate_lazy_text_training_batches(
                 pending,
                 batch_size,
                 comm_group=comm_group,
-                pad_source=pending,
+                pad_source=padding_source,
             )
             yielded = True
-            yield _create_tokenized_text_batch(
-                local_items,
-                max_seq_length,
-                pad_id=_mlx_text_pad_id(tokenizer),
-            )
+            yield _make_batch(local_items)
         if not yielded:
             raise ValueError(
                 "Unsloth MLX: streaming text source produced no trainable rows."
@@ -5501,8 +5600,9 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              comm_group=None):
     """Streaming batch generator for MLX training.
 
-    Wraps mlx-lm's iterate_batches(loop=True) as a generator, avoiding
-    materializing all batches in memory at once. Useful for large datasets.
+    Map-style datasets retain the existing mlx-lm batching behavior. Unsized
+    text sources are normalized and tokenized incrementally in source order,
+    with only one distributed micro-batch retained at a time.
 
     Yields:
         (batch, lengths, labels) tuples — same format as create_batches.

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3379,7 +3379,15 @@ def _is_mlx_lazy_text_source(dataset):
         return False
     if isinstance(dataset, Iterator):
         return True
-    return any("__iter__" in cls.__dict__ for cls in type(dataset).__mro__)
+    source_mro = type(dataset).__mro__
+    if any("__iter__" in cls.__dict__ for cls in source_mro):
+        return True
+    # Python's sequence-iteration fallback accepts __getitem__ without
+    # __iter__. Keep custom objects that also declare __len__ on the existing
+    # sized/map path; the no-length protocol must be consumed incrementally.
+    has_getitem = any("__getitem__" in cls.__dict__ for cls in source_mro)
+    has_len = any("__len__" in cls.__dict__ for cls in source_mro)
+    return has_getitem and not has_len
 
 
 def _is_mlx_hf_iterable_text_source(dataset):
@@ -5240,6 +5248,7 @@ def _iter_lazy_tokenized_text_rows(
             and "prompt" in item
             and "completion" in item
         )
+        formatter_applied = False
         formatter_needs_completion_boundary = False
         source_rows = item if (
             isinstance(item, list) and not _looks_like_mlx_chat_messages(item)
@@ -5249,6 +5258,7 @@ def _iter_lazy_tokenized_text_rows(
             for row in source_rows
         ) and formatting_func is not None:
             formatted = formatting_func(item)
+            formatter_applied = True
             formatter_needs_completion_boundary = (
                 completion_only_loss is None
                 and item_has_completion_boundary
@@ -5283,16 +5293,22 @@ def _iter_lazy_tokenized_text_rows(
             if tokenized is not None:
                 ids, labels = tokenized
                 if (
-                    formatter_needs_completion_boundary
+                    formatter_applied
                     and row_completion_only_loss is True
                     and labels is None
                 ):
+                    if formatter_needs_completion_boundary:
+                        raise ValueError(
+                            "Unsloth MLX: a formatting_func was provided for a "
+                            "prompt/completion dataset, which drops the completion "
+                            "boundary needed for the default completion-only loss. "
+                            "Apply your formatting before passing the dataset, or set "
+                            "completion_only_loss=False."
+                        )
                     raise ValueError(
-                        "Unsloth MLX: a formatting_func was provided for a "
-                        "prompt/completion dataset, which drops the completion "
-                        "boundary needed for the default completion-only loss. "
-                        "Apply your formatting before passing the dataset, or set "
-                        "completion_only_loss=False."
+                        "Unsloth MLX: formatting_func produced pretokenized "
+                        "input_ids without labels or completion_mask while "
+                        "completion-only loss is active."
                     )
                 if max_seq_length is not None:
                     ids = ids[:max_seq_length]
@@ -5391,6 +5407,15 @@ def _iter_lazy_tokenized_text_rows(
                     yield ids, None
 
 
+def _close_mlx_owned_iterator(iterator):
+    """Close an iterator owned by the lazy text pipeline when supported."""
+    if iterator is None:
+        return
+    close = getattr(iterator, "close", None)
+    if callable(close):
+        close()
+
+
 def _iterate_lazy_text_training_batches(
     dataset,
     tokenizer,
@@ -5406,7 +5431,13 @@ def _iterate_lazy_text_training_batches(
     comm_group=None,
     require_replayable=False,
 ):
-    """Yield source-ordered text batches without probing an unsized source."""
+    """Yield source-ordered text batches without materializing an unsized source.
+
+    Custom replayable sources must return independent fresh traversals from
+    ``iter(source)``. Resume validation may create one non-consuming iterator
+    ahead of the serving iterator; epoch-aware validation iterators are closed
+    immediately and recreated only after ``set_epoch`` advances.
+    """
     if dataset_order == "torch_randperm":
         raise ValueError(
             "Unsloth MLX: dataset_order='torch_randperm' is not supported for "
@@ -5440,99 +5471,132 @@ def _iterate_lazy_text_training_batches(
     _set_epoch(0)
     current_iterator = iter(dataset)
     cached_next_iterator = None
-    if isinstance(dataset, Iterator):
-        replayable = False
-    elif _is_mlx_hf_iterable_text_source(dataset):
-        replayable = True
-    else:
-        replayable = None
+    try:
+        if isinstance(dataset, Iterator):
+            replayable = False
+        elif _is_mlx_hf_iterable_text_source(dataset):
+            replayable = True
+        else:
+            replayable = None
 
-    if require_replayable:
-        if replayable is False:
-            raise _resume_replay_error()
-        if replayable is None:
+        if require_replayable:
+            if replayable is False:
+                raise _resume_replay_error()
+            if replayable is None:
+                try:
+                    candidate = iter(dataset)
+                except Exception as exc:
+                    raise _resume_replay_error() from exc
+                if candidate is current_iterator:
+                    raise _resume_replay_error()
+                if not callable(set_epoch):
+                    cached_next_iterator = candidate
+                else:
+                    _close_mlx_owned_iterator(candidate)
+                    del candidate
+                replayable = True
+
+        def _make_batch(local_items):
+            if state.get("schema") == "raw" and state.get("label_state") is False:
+                return _make_text_batch_from_items(
+                    [ids for ids, _labels in local_items],
+                    tokenizer,
+                    max_seq_length,
+                )
+            return _create_tokenized_text_batch(
+                local_items,
+                max_seq_length,
+                pad_id=_mlx_text_pad_id(tokenizer),
+            )
+
+        while True:
+            pending = []
+            padding_source = []
+            yielded = False
+            for row in _iter_lazy_tokenized_text_rows(
+                current_iterator,
+                tokenizer,
+                dataset_text_field=dataset_text_field,
+                formatting_func=formatting_func,
+                append_eos=append_eos,
+                completion_only_loss=completion_only_loss,
+                assistant_only_loss=assistant_only_loss,
+                max_seq_length=max_seq_length,
+                state=state,
+            ):
+                if len(padding_source) < global_batch_size:
+                    padding_source.append(row)
+                pending.append(row)
+                if len(pending) < global_batch_size:
+                    continue
+                local_items = _rank_slice_distributed_batch(
+                    pending,
+                    batch_size,
+                    comm_group=comm_group,
+                    pad_source=padding_source,
+                )
+                yielded = True
+                yield _make_batch(local_items)
+                pending = []
+
+            if pending:
+                local_items = _rank_slice_distributed_batch(
+                    pending,
+                    batch_size,
+                    comm_group=comm_group,
+                    pad_source=padding_source,
+                )
+                yielded = True
+                yield _make_batch(local_items)
+
+            exhausted_iterator = current_iterator
+            current_iterator = None
+            _close_mlx_owned_iterator(exhausted_iterator)
+            if not yielded:
+                raise ValueError(
+                    "Unsloth MLX: streaming text source produced no trainable rows."
+                )
+            if replayable is False:
+                raise _exhaustion_error()
+            epoch += 1
+            _set_epoch(epoch)
+            if cached_next_iterator is not None:
+                current_iterator = cached_next_iterator
+                cached_next_iterator = None
+                del exhausted_iterator
+                continue
             try:
                 candidate = iter(dataset)
             except Exception as exc:
-                raise _resume_replay_error() from exc
-            if candidate is current_iterator:
-                raise _resume_replay_error()
-            if not callable(set_epoch):
-                cached_next_iterator = candidate
+                if replayable is True:
+                    raise RuntimeError(
+                        "Unsloth MLX: replayable streaming text source failed to "
+                        f"create an iterator for epoch {epoch}: {exc}"
+                    ) from exc
+                raise _exhaustion_error() from exc
+            if candidate is exhausted_iterator:
+                raise _exhaustion_error()
+            current_iterator = candidate
             replayable = True
-
-    def _make_batch(local_items):
-        if state.get("schema") == "raw" and state.get("label_state") is False:
-            return _make_text_batch_from_items(
-                [ids for ids, _labels in local_items],
-                tokenizer,
-                max_seq_length,
-            )
-        return _create_tokenized_text_batch(
-            local_items,
-            max_seq_length,
-            pad_id=_mlx_text_pad_id(tokenizer),
+            del exhausted_iterator
+    finally:
+        active_iterator = current_iterator
+        current_iterator = None
+        replay_iterator = cached_next_iterator
+        cached_next_iterator = None
+        cleanup_iterators = (
+            (active_iterator,)
+            if replay_iterator is active_iterator
+            else (active_iterator, replay_iterator)
         )
-
-    while True:
-        pending = []
-        padding_source = []
-        yielded = False
-        for row in _iter_lazy_tokenized_text_rows(
-            current_iterator,
-            tokenizer,
-            dataset_text_field=dataset_text_field,
-            formatting_func=formatting_func,
-            append_eos=append_eos,
-            completion_only_loss=completion_only_loss,
-            assistant_only_loss=assistant_only_loss,
-            max_seq_length=max_seq_length,
-            state=state,
-        ):
-            if len(padding_source) < global_batch_size:
-                padding_source.append(row)
-            pending.append(row)
-            if len(pending) < global_batch_size:
-                continue
-            local_items = _rank_slice_distributed_batch(
-                pending,
-                batch_size,
-                comm_group=comm_group,
-                pad_source=padding_source,
-            )
-            yielded = True
-            yield _make_batch(local_items)
-            pending = []
-
-        if pending:
-            local_items = _rank_slice_distributed_batch(
-                pending,
-                batch_size,
-                comm_group=comm_group,
-                pad_source=padding_source,
-            )
-            yielded = True
-            yield _make_batch(local_items)
-        if not yielded:
-            raise ValueError(
-                "Unsloth MLX: streaming text source produced no trainable rows."
-            )
-        if replayable is False:
-            raise _exhaustion_error()
-        epoch += 1
-        _set_epoch(epoch)
-        if cached_next_iterator is not None:
-            current_iterator = cached_next_iterator
-            cached_next_iterator = None
-            continue
-        try:
-            candidate = iter(dataset)
-        except Exception as exc:
-            raise _exhaustion_error() from exc
-        if candidate is current_iterator:
-            raise _exhaustion_error()
-        current_iterator = candidate
-        replayable = True
+        # A schema/source error may already be unwinding. Cleanup must attempt
+        # every owned cursor without replacing that primary failure. The normal
+        # epoch-boundary close above remains strict and still surfaces errors.
+        for iterator in cleanup_iterators:
+            try:
+                _close_mlx_owned_iterator(iterator)
+            except Exception:
+                pass
 
 
 def _iterate_ordered_text_training_batches(dataset, tokenizer, batch_size,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2394,7 +2394,28 @@ def normalize_vlm_processor_chat_template(
     )
 
 
-def encode_mlx_text(tokenizer, text):
+def _contains_mlx_values(value):
+    if isinstance(value, mx.array):
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(_contains_mlx_values(element) for element in value)
+    return False
+
+
+def _guard_host_token_output(value, state, context):
+    """Record/reject an MLX-valued tokenizer or template output pre-conversion."""
+    if state is not None and _contains_mlx_values(value):
+        if state.get("reject_mlx_valued"):
+            raise ValueError(
+                f"Unsloth MLX: {context} returned an MLX array; the prefetch "
+                "producer must not convert MLX values off the consumer "
+                "thread. Use streaming_prefetch_batches=0."
+            )
+        state["host_valued"] = False
+    return value
+
+
+def encode_mlx_text(tokenizer, text, state=None):
     """Tokenize text while mirroring Unsloth's double-BOS guard."""
     add_special_tokens = True
     bos_token = getattr(tokenizer, "bos_token", None)
@@ -2402,9 +2423,10 @@ def encode_mlx_text(tokenizer, text):
         add_special_tokens = False
 
     try:
-        return tokenizer.encode(text, add_special_tokens=add_special_tokens)
+        encoded = tokenizer.encode(text, add_special_tokens=add_special_tokens)
     except TypeError:
-        return tokenizer.encode(text)
+        encoded = tokenizer.encode(text)
+    return _guard_host_token_output(encoded, state, "the tokenizer")
 
 
 def _raise_mlx_chat_template_error(target, *, is_vlm=False):
@@ -2851,10 +2873,11 @@ def _looks_like_mlx_chat_value(value):
     )
 
 
-def _flatten_mlx_chat_template_ids(value):
+def _flatten_mlx_chat_template_ids(value, state=None):
     """Flatten tokenizer chat-template output to a single token-id list."""
     if isinstance(value, Mapping):
         value = value["input_ids"]
+    value = _guard_host_token_output(value, state, "the chat template")
     if hasattr(value, "tolist"):
         value = value.tolist()
     if len(value) > 0 and isinstance(value[0], list):
@@ -2862,10 +2885,11 @@ def _flatten_mlx_chat_template_ids(value):
     return list(value)
 
 
-def _flatten_mlx_chat_template_field(value, field_name):
+def _flatten_mlx_chat_template_field(value, field_name, state=None):
     """Flatten one field from tokenizer chat-template output."""
     if isinstance(value, Mapping):
         value = value[field_name]
+    value = _guard_host_token_output(value, state, "the chat template")
     if hasattr(value, "tolist"):
         value = value.tolist()
     if len(value) > 0 and isinstance(value[0], list):
@@ -2873,20 +2897,22 @@ def _flatten_mlx_chat_template_field(value, field_name):
     return list(value)
 
 
-def _apply_mlx_chat_template_ids(tokenizer, messages, **kwargs):
+def _apply_mlx_chat_template_ids(tokenizer, messages, _unsloth_state=None, /, **kwargs):
     """Tokenize messages through apply_chat_template with a HF-compatible fallback."""
     try:
         return _flatten_mlx_chat_template_ids(
-            tokenizer.apply_chat_template(messages, **kwargs)
+            tokenizer.apply_chat_template(messages, **kwargs),
+            state=_unsloth_state,
         )
     except TypeError:
         kwargs.pop("return_dict", None)
         return _flatten_mlx_chat_template_ids(
-            tokenizer.apply_chat_template(messages, **kwargs)
+            tokenizer.apply_chat_template(messages, **kwargs),
+            state=_unsloth_state,
         )
 
 
-def _apply_mlx_chat_template_dict(tokenizer, messages, **kwargs):
+def _apply_mlx_chat_template_dict(tokenizer, messages, _unsloth_state=None, /, **kwargs):
     """Tokenize messages through apply_chat_template and preserve returned masks."""
     try:
         value = tokenizer.apply_chat_template(messages, **kwargs)
@@ -2896,9 +2922,12 @@ def _apply_mlx_chat_template_dict(tokenizer, messages, **kwargs):
         kwargs.pop("return_assistant_tokens_mask", None)
         kwargs.pop("return_dict", None)
         value = tokenizer.apply_chat_template(messages, **kwargs)
-    if isinstance(value, Mapping):
-        return value
-    return {"input_ids": value}
+    if not isinstance(value, Mapping):
+        value = {"input_ids": value}
+    if _unsloth_state is not None:
+        for field_value in value.values():
+            _guard_host_token_output(field_value, _unsloth_state, "the chat template")
+    return value
 
 
 def _apply_mlx_text_label_masks(input_ids, *, completion_mask=None, assistant_mask=None):
@@ -2982,6 +3011,7 @@ def _tokenize_mlx_conversational_prompt_completion(
     chat_template_kwargs=None,
     assistant_only_loss=False,
     completion_only_loss=None,
+    state=None,
 ):
     """Tokenize conversational prompt/completion rows using TRL's split."""
     prompt_messages = _normalize_mlx_messages(prompt, is_vlm=False)
@@ -2990,6 +3020,7 @@ def _tokenize_mlx_conversational_prompt_completion(
     prompt_ids = _apply_mlx_chat_template_ids(
         tokenizer,
         prompt_messages,
+        state,
         tokenize=True,
         add_generation_prompt=True,
         tools=tools,
@@ -2998,6 +3029,7 @@ def _tokenize_mlx_conversational_prompt_completion(
     prompt_completion_processed = _apply_mlx_chat_template_dict(
         tokenizer,
         prompt_messages + completion_messages,
+        state,
         tokenize=True,
         return_dict=True,
         return_assistant_tokens_mask=bool(assistant_only_loss),
@@ -3005,12 +3037,12 @@ def _tokenize_mlx_conversational_prompt_completion(
         **template_kwargs,
     )
     input_ids = _flatten_mlx_chat_template_field(
-        prompt_completion_processed, "input_ids"
+        prompt_completion_processed, "input_ids", state=state,
     )
     assistant_mask = None
     if "assistant_masks" in prompt_completion_processed:
         assistant_mask = _flatten_mlx_chat_template_field(
-            prompt_completion_processed, "assistant_masks"
+            prompt_completion_processed, "assistant_masks", state=state,
         )
         _validate_mlx_assistant_mask(
             input_ids, assistant_mask, source="conversational"
@@ -3036,10 +3068,11 @@ def _tokenize_mlx_prompt_completion(
     *,
     append_eos=True,
     completion_only_loss=None,
+    state=None,
 ):
     """Tokenize a text prompt/completion pair and mask prompt labels like TRL."""
-    prompt_ids = list(encode_mlx_text(tokenizer, prompt))
-    input_ids = list(encode_mlx_text(tokenizer, prompt + completion))
+    prompt_ids = list(encode_mlx_text(tokenizer, prompt, state=state))
+    input_ids = list(encode_mlx_text(tokenizer, prompt + completion, state=state))
     return _mask_mlx_prompt_completion_labels(
         tokenizer,
         prompt_ids,
@@ -3091,6 +3124,7 @@ def _tokenize_mlx_prompt_completion_row(
     append_eos=True,
     completion_only_loss=None,
     assistant_only_loss=False,
+    state=None,
 ):
     """Tokenize one text prompt/completion row, including conversational rows."""
     if not isinstance(item, dict) or "prompt" not in item or "completion" not in item:
@@ -3106,6 +3140,7 @@ def _tokenize_mlx_prompt_completion_row(
             chat_template_kwargs=item.get("chat_template_kwargs"),
             assistant_only_loss=assistant_only_loss,
             completion_only_loss=completion_only_loss,
+            state=state,
         )
     pair = _render_mlx_prompt_completion_texts(
         tokenizer,
@@ -3121,10 +3156,11 @@ def _tokenize_mlx_prompt_completion_row(
         pair[1],
         append_eos=append_eos,
         completion_only_loss=completion_only_loss,
+        state=state,
     )
 
 
-def _tokenize_mlx_assistant_messages_row(tokenizer, item):
+def _tokenize_mlx_assistant_messages_row(tokenizer, item, state=None):
     """Tokenize one conversational row with chat-template assistant masks."""
     messages = (
         item if _looks_like_mlx_chat_messages(item)
@@ -3142,16 +3178,17 @@ def _tokenize_mlx_assistant_messages_row(tokenizer, item):
     processed = _apply_mlx_chat_template_dict(
         tokenizer,
         messages,
+        state,
         return_dict=True,
         tokenize=True,
         return_assistant_tokens_mask=True,
         tools=item.get("tools") if isinstance(item, Mapping) else None,
         **template_kwargs,
     )
-    input_ids = _flatten_mlx_chat_template_field(processed, "input_ids")
+    input_ids = _flatten_mlx_chat_template_field(processed, "input_ids", state=state)
     assistant_mask = None
     if "assistant_masks" in processed:
-        assistant_mask = _flatten_mlx_chat_template_field(processed, "assistant_masks")
+        assistant_mask = _flatten_mlx_chat_template_field(processed, "assistant_masks", state=state)
         _validate_mlx_assistant_mask(input_ids, assistant_mask, source="text")
     else:
         _validate_mlx_assistant_mask(input_ids, [0] * len(input_ids), source="text")
@@ -3200,8 +3237,23 @@ def _prepare_labeled_text_dataset(
     return formatted
 
 
-def _coerce_mlx_token_list(value, field_name):
-    """Convert one token-id field from a pretokenized row to a Python list."""
+def _coerce_mlx_token_list(value, field_name, state=None):
+    """Convert one token-id field from a pretokenized row to a Python list.
+
+    When ``state`` is provided and the value arrived as an MLX array, the
+    stream is marked ``host_valued=False`` BEFORE conversion — the conversion
+    itself is MLX work, which the prefetch producer must reject rather than
+    perform off the consumer thread.
+    """
+    if state is not None and _contains_mlx_values(value):
+        if state.get("reject_mlx_valued"):
+            raise ValueError(
+                f"Unsloth MLX: pretokenized '{field_name}' is an MLX array; "
+                "the prefetch producer must not convert MLX values off the "
+                "consumer thread. Use streaming_prefetch_batches=0 "
+                "(synchronous mode) for MLX-valued rows."
+            )
+        state["host_valued"] = False
     if hasattr(value, "tolist"):
         value = value.tolist()
     if not isinstance(value, (list, tuple)):
@@ -3250,15 +3302,16 @@ def _tokenize_mlx_pretokenized_row(
     *,
     completion_only_loss=None,
     assistant_only_loss=False,
+    state=None,
 ):
     """Read input_ids plus optional labels/completion_mask from one text row."""
     if not isinstance(item, Mapping) or "input_ids" not in item:
         return None
 
-    input_ids = _coerce_mlx_token_list(item["input_ids"], "input_ids")
+    input_ids = _coerce_mlx_token_list(item["input_ids"], "input_ids", state=state)
     labels = None
     if item.get("labels") is not None:
-        labels = _coerce_mlx_token_list(item["labels"], "labels")
+        labels = _coerce_mlx_token_list(item["labels"], "labels", state=state)
         if len(labels) != len(input_ids):
             raise ValueError(
                 "Unsloth MLX: pretokenized 'labels' must match 'input_ids' length."
@@ -3266,7 +3319,7 @@ def _tokenize_mlx_pretokenized_row(
 
     if completion_only_loss is True and item.get("completion_mask") is not None:
         completion_mask = _coerce_mlx_token_list(
-            item["completion_mask"], "completion_mask"
+            item["completion_mask"], "completion_mask", state=state,
         )
         if len(completion_mask) != len(input_ids):
             raise ValueError(
@@ -3289,7 +3342,7 @@ def _tokenize_mlx_pretokenized_row(
     # Match TRL's collator: pretokenized assistant_masks are labels metadata.
     if assistant_masks is not None:
         assistant_mask = _coerce_mlx_token_list(
-            assistant_masks, "assistant_masks"
+            assistant_masks, "assistant_masks", state=state,
         )
         if len(assistant_mask) != len(input_ids):
             raise ValueError(
@@ -3511,13 +3564,48 @@ def _labeled_row_has_supervision(labels, max_seq_length):
     return any(int(x) != -100 for x in labels[1:max_seq_length])
 
 
-def _create_tokenized_text_batch(
+class _HostStagedTextBatch:
+    """Host-side (python/numpy) text batch awaiting MLX finalization.
+
+    ``host_valued`` is False when any staged field arrived as an MLX array;
+    synchronous mode accepts such rows unchanged, while the prefetch producer
+    must reject them via the FIFO envelope.
+    """
+
+    __slots__ = ("ids", "lengths_info", "labels", "host_valued")
+
+    def __init__(self, ids, lengths_info, labels, host_valued=True):
+        self.ids = ids
+        self.lengths_info = lengths_info
+        self.labels = labels
+        self.host_valued = host_valued
+
+
+def _is_host_valued_field(value):
+    return not _contains_mlx_values(value)
+
+
+def _finalize_text_batch(staged):
+    """The single point where staged text batches become MLX arrays."""
+    labels_array = (
+        mx.array(staged.labels) if staged.labels is not None else None
+    )
+    return mx.array(staged.ids), mx.array(staged.lengths_info), labels_array
+
+
+def _stage_tokenized_text_batch(
     batch_items,
     max_seq_length,
     pad_id=0,
     labels_expected=None,
+    host_valued=None,
 ):
-    """Pad pretokenized ids plus optional labels for one MLX text batch."""
+    """Host staging of one pretokenized text batch (no MLX work).
+
+    ``host_valued=None`` computes the flag from the items; the lazy pipeline
+    passes the stream-level flag recorded at row normalization, where MLX
+    origin is still visible (rows are lists by the time they reach staging).
+    """
     valid_items = [item for item in batch_items if item is not None]
     lengths = [
         0 if item is None else min(len(item[0]), max_seq_length)
@@ -3539,6 +3627,12 @@ def _create_tokenized_text_batch(
             "Unsloth MLX: pretokenized rows with labels/completion_mask must "
             "not be batched with rows that do not provide labels."
         )
+    if host_valued is None:
+        host_valued = all(
+            _is_host_valued_field(item[0])
+            and (item[1] is None or _is_host_valued_field(item[1]))
+            for item in valid_items
+        )
     batch_labels = (
         np.full((len(batch_items), max_length), -100, dtype=np.int64)
         if has_labels else None
@@ -3552,8 +3646,18 @@ def _create_tokenized_text_batch(
         if batch_labels is not None:
             batch_labels[row_idx, :length] = labels[:length]
     lengths_info = [[0, length] for length in lengths]
-    labels_array = mx.array(batch_labels) if batch_labels is not None else None
-    return mx.array(batch_ids), mx.array(lengths_info), labels_array
+    return _HostStagedTextBatch(batch_ids, lengths_info, batch_labels, host_valued)
+
+
+def _create_tokenized_text_batch(batch_items, max_seq_length, pad_id=0,
+                                 labels_expected=None):
+    """Pad pretokenized ids plus optional labels for one MLX text batch."""
+    # host_valued=True skips the recursive provenance scan: this wrapper
+    # finalizes immediately, so the flag is never consumed.
+    return _finalize_text_batch(_stage_tokenized_text_batch(
+        batch_items, max_seq_length, pad_id=pad_id,
+        labels_expected=labels_expected, host_valued=True,
+    ))
 
 
 def _create_labeled_text_batch(batch_items, max_seq_length, pad_id=0):
@@ -5141,6 +5245,13 @@ def _rank_slice_distributed_batch(
 
 
 def _make_text_batch_from_items(batch_items, tokenizer, max_seq_length):
+    """Tokenize raw rows and pad to the mlx-lm rule (finalized MLX batch)."""
+    return _finalize_text_batch(
+        _stage_text_batch_from_items(batch_items, tokenizer, max_seq_length)
+    )
+
+
+def _stage_text_batch_from_items(batch_items, tokenizer, max_seq_length, host_valued=True):
     """Build a text training batch from tokenized items."""
     valid_items = [item for item in batch_items if item is not None]
     with_offsets = bool(
@@ -5185,10 +5296,11 @@ def _make_text_batch_from_items(batch_items, tokenizer, max_seq_length):
             list(ids)[:truncated_length]
             + [pad_id] * (max_length - truncated_length)
         )
-    return (
-        mx.array(np.asarray(batch_ids, dtype=np.int32)),
-        mx.array(np.asarray(list(zip(offsets, truncated_lengths)), dtype=np.int32)),
+    return _HostStagedTextBatch(
+        np.asarray(batch_ids, dtype=np.int32),
+        np.asarray(list(zip(offsets, truncated_lengths)), dtype=np.int32),
         None,
+        host_valued,
     )
 
 
@@ -5498,7 +5610,7 @@ def _iter_tokenized_text_rows(dataset, tokenizer, dataset_text_field="text",
                 yield (ids, 0)
 
 
-def _apply_mlx_response_mask_to_text_row(input_ids, labels, mask_fn):
+def _apply_mlx_response_mask_to_text_row(input_ids, labels, mask_fn, state=None):
     """Apply the CUDA response-marker closure to one tokenized text row."""
     mask_batch = {"input_ids": [list(input_ids)]}
     if labels is not None:
@@ -5506,6 +5618,14 @@ def _apply_mlx_response_mask_to_text_row(input_ids, labels, mask_fn):
         mask_batch["labels"] = np.asarray([labels], dtype=np.int64)
     result = mask_fn(mask_batch)
     masked = result.get("labels") if isinstance(result, Mapping) else None
+    if isinstance(masked, mx.array) and state is not None:
+        if state.get("reject_mlx_valued"):
+            raise ValueError(
+                "Unsloth MLX: the response mask returned an MLX array; the "
+                "prefetch producer must not convert MLX values off the "
+                "consumer thread. Use streaming_prefetch_batches=0."
+            )
+        state["host_valued"] = False
     if hasattr(masked, "tolist"):
         masked = masked.tolist()
     if not isinstance(masked, (list, tuple)) or len(masked) != 1:
@@ -5513,7 +5633,7 @@ def _apply_mlx_response_mask_to_text_row(input_ids, labels, mask_fn):
             "Unsloth MLX: train_on_responses_only masking must return one "
             "labels row for each input_ids row."
         )
-    masked = _coerce_mlx_token_list(masked[0], "labels")
+    masked = _coerce_mlx_token_list(masked[0], "labels", state=state)
     if len(masked) != len(input_ids):
         raise ValueError(
             "Unsloth MLX: train_on_responses_only labels must match "
@@ -5695,6 +5815,7 @@ def _iter_lazy_tokenized_text_rows(
                 row,
                 completion_only_loss=row_completion_only_loss,
                 assistant_only_loss=assistant_only_loss,
+                state=state,
             )
             if tokenized is not None:
                 ids, labels = tokenized
@@ -5714,7 +5835,7 @@ def _iter_lazy_tokenized_text_rows(
                 )
                 if response_mask_fn is not None:
                     ids, labels = _apply_mlx_response_mask_to_text_row(
-                        ids, labels, response_mask_fn,
+                        ids, labels, response_mask_fn, state=state,
                     )
                 usable = len(ids) >= 2 and _labeled_row_has_supervision(
                     labels, len(ids)
@@ -5758,9 +5879,10 @@ def _iter_lazy_tokenized_text_rows(
                     append_eos=append_eos,
                     completion_only_loss=row_completion_only_loss,
                     assistant_only_loss=assistant_only_loss,
+                    state=state,
                 )
                 if labeled is None and assistant_only_loss:
-                    labeled = _tokenize_mlx_assistant_messages_row(tokenizer, row)
+                    labeled = _tokenize_mlx_assistant_messages_row(tokenizer, row, state=state)
             if labeled is not None:
                 ids, labels = labeled
                 if max_seq_length is not None:
@@ -5768,7 +5890,7 @@ def _iter_lazy_tokenized_text_rows(
                     labels = labels[:max_seq_length]
                 if response_mask_fn is not None:
                     ids, labels = _apply_mlx_response_mask_to_text_row(
-                        ids, labels, response_mask_fn,
+                        ids, labels, response_mask_fn, state=state,
                     )
                 usable = len(ids) >= 2 and _labeled_row_has_supervision(
                     labels, len(ids)
@@ -5829,7 +5951,7 @@ def _iter_lazy_tokenized_text_rows(
                 )
                 continue
             for text in texts:
-                ids = list(encode_mlx_text(tokenizer, text))
+                ids = list(encode_mlx_text(tokenizer, text, state=state))
                 if eos_id is not None and (not ids or ids[-1] != eos_id):
                     ids.append(int(eos_id))
                 if max_seq_length is not None:
@@ -5838,7 +5960,7 @@ def _iter_lazy_tokenized_text_rows(
                 labels = None
                 if response_mask_fn is not None:
                     ids, labels = _apply_mlx_response_mask_to_text_row(
-                        ids, None, response_mask_fn,
+                        ids, None, response_mask_fn, state=state,
                     )
                 usable = len(ids) >= 2 and _labeled_row_has_supervision(
                     labels, len(ids)
@@ -5964,6 +6086,7 @@ def _iterate_lazy_text_training_batches(
     include_epoch=False,
     length_window_batches=1,
     window_seed=0,
+    yield_host_staged=False,
 ):
     """Yield text batches without materializing an unsized source.
 
@@ -6037,23 +6160,26 @@ def _iterate_lazy_text_training_batches(
 
         def _make_batch(local_items):
             if state.get("schema") == "raw" and state.get("label_state") is False:
-                return _make_text_batch_from_items(
+                return _stage_text_batch_from_items(
                     [
                         None if item is None else item[0]
                         for item in local_items
                     ],
                     tokenizer,
                     max_seq_length,
+                    host_valued=state.get("host_valued", True),
                 )
-            return _create_tokenized_text_batch(
+            return _stage_tokenized_text_batch(
                 local_items,
                 max_seq_length,
                 pad_id=_mlx_text_pad_id(tokenizer),
                 labels_expected=state.get("label_state"),
+                host_valued=state.get("host_valued", True),
             )
 
         def _yield_value(local_items):
-            batch = _make_batch(local_items)
+            staged = _make_batch(local_items)
+            batch = staged if yield_host_staged else _finalize_text_batch(staged)
             return (batch, epoch) if include_epoch else batch
 
         while True:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3382,16 +3382,13 @@ def _is_mlx_lazy_text_source(dataset):
     return any("__iter__" in cls.__dict__ for cls in type(dataset).__mro__)
 
 
-def _is_mlx_replayable_text_source(dataset):
-    """Return whether a source can create a fresh iterator for another pass."""
-    if isinstance(dataset, Iterator):
-        return False
+def _is_mlx_hf_iterable_text_source(dataset):
+    """Return whether Hugging Face defines this source as replayable."""
     try:
-        first = iter(dataset)
-        second = iter(dataset)
-    except TypeError:
+        from datasets import IterableDataset as HFIterableDataset
+    except ImportError:
         return False
-    return first is not second
+    return isinstance(dataset, HFIterableDataset)
 
 
 def _labeled_row_has_supervision(labels, max_seq_length):
@@ -5243,11 +5240,7 @@ def _iter_lazy_tokenized_text_rows(
             and "prompt" in item
             and "completion" in item
         )
-        formatter_needs_completion_boundary = (
-            formatting_func is not None
-            and completion_only_loss is None
-            and item_has_completion_boundary
-        )
+        formatter_needs_completion_boundary = False
         source_rows = item if (
             isinstance(item, list) and not _looks_like_mlx_chat_messages(item)
         ) else [item]
@@ -5256,6 +5249,10 @@ def _iter_lazy_tokenized_text_rows(
             for row in source_rows
         ) and formatting_func is not None:
             formatted = formatting_func(item)
+            formatter_needs_completion_boundary = (
+                completion_only_loss is None
+                and item_has_completion_boundary
+            )
             source_rows = formatted if (
                 isinstance(formatted, list)
                 and not _looks_like_mlx_chat_messages(formatted)
@@ -5267,13 +5264,17 @@ def _iter_lazy_tokenized_text_rows(
                 and "prompt" in row
                 and "completion" in row
             )
-            row_completion_only_loss = (
-                completion_only_loss
-                if completion_only_loss is not None
-                else True
-                if item_has_completion_boundary or row_has_completion_boundary
-                else state.get("pretokenized_completion_only_loss", False)
-            )
+            if completion_only_loss is not None:
+                row_completion_only_loss = completion_only_loss
+            elif "pretokenized_completion_only_loss" in state:
+                row_completion_only_loss = state[
+                    "pretokenized_completion_only_loss"
+                ]
+            elif item_has_completion_boundary or row_has_completion_boundary:
+                row_completion_only_loss = True
+                state["pretokenized_completion_only_loss"] = True
+            else:
+                row_completion_only_loss = False
             tokenized = _tokenize_mlx_pretokenized_row(
                 row,
                 completion_only_loss=row_completion_only_loss,
@@ -5281,7 +5282,11 @@ def _iter_lazy_tokenized_text_rows(
             )
             if tokenized is not None:
                 ids, labels = tokenized
-                if formatter_needs_completion_boundary and labels is None:
+                if (
+                    formatter_needs_completion_boundary
+                    and row_completion_only_loss is True
+                    and labels is None
+                ):
                     raise ValueError(
                         "Unsloth MLX: a formatting_func was provided for a "
                         "prompt/completion dataset, which drops the completion "
@@ -5314,13 +5319,13 @@ def _iter_lazy_tokenized_text_rows(
                     "conversational datasets."
                 )
             labeled = None
-            if completion_only_loss is not False or assistant_only_loss:
+            if row_completion_only_loss is not False or assistant_only_loss:
                 labeled = _tokenize_mlx_prompt_completion_row(
                     tokenizer,
                     row,
                     dataset_text_field=dataset_text_field,
                     append_eos=append_eos,
-                    completion_only_loss=completion_only_loss,
+                    completion_only_loss=row_completion_only_loss,
                     assistant_only_loss=assistant_only_loss,
                 )
                 if labeled is None and assistant_only_loss:
@@ -5348,18 +5353,21 @@ def _iter_lazy_tokenized_text_rows(
                     "conversational. This option is only supported for "
                     "conversational datasets."
                 )
-            if completion_only_loss is True:
-                raise ValueError(
-                    "Unsloth MLX: text completion_only_loss=True requires "
-                    "prompt/completion rows for streaming text training."
-                )
-            if formatter_needs_completion_boundary:
+            if (
+                formatter_needs_completion_boundary
+                and row_completion_only_loss is True
+            ):
                 raise ValueError(
                     "Unsloth MLX: a formatting_func was provided for a "
                     "prompt/completion dataset, which drops the completion "
                     "boundary needed for the default completion-only loss. "
                     "Apply your formatting before passing the dataset, or set "
                     "completion_only_loss=False."
+                )
+            if row_completion_only_loss is True:
+                raise ValueError(
+                    "Unsloth MLX: text completion_only_loss=True requires "
+                    "prompt/completion rows for streaming text training."
                 )
 
             for text in collect_mlx_texts(
@@ -5396,6 +5404,7 @@ def _iterate_lazy_text_training_batches(
     completion_only_loss=None,
     assistant_only_loss=False,
     comm_group=None,
+    require_replayable=False,
 ):
     """Yield source-ordered text batches without probing an unsized source."""
     if dataset_order == "torch_randperm":
@@ -5407,9 +5416,50 @@ def _iterate_lazy_text_training_batches(
         raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
 
     global_batch_size = _distributed_global_batch_size(batch_size, comm_group)
-    replayable = _is_mlx_replayable_text_source(dataset)
     state = {}
     epoch = 0
+    set_epoch = getattr(dataset, "set_epoch", None)
+
+    def _set_epoch(value):
+        if callable(set_epoch):
+            set_epoch(value)
+
+    def _resume_replay_error():
+        return RuntimeError(
+            "Unsloth MLX: checkpoint resume requires a replayable iterable "
+            "text source; a one-shot iterator cannot be fast-forwarded "
+            "deterministically."
+        )
+
+    def _exhaustion_error():
+        return RuntimeError(
+            "Unsloth MLX: one-shot streaming text source is exhausted and "
+            "cannot be replayed. Use a replayable iterable or reduce max_steps."
+        )
+
+    _set_epoch(0)
+    current_iterator = iter(dataset)
+    cached_next_iterator = None
+    if isinstance(dataset, Iterator):
+        replayable = False
+    elif _is_mlx_hf_iterable_text_source(dataset):
+        replayable = True
+    else:
+        replayable = None
+
+    if require_replayable:
+        if replayable is False:
+            raise _resume_replay_error()
+        if replayable is None:
+            try:
+                candidate = iter(dataset)
+            except Exception as exc:
+                raise _resume_replay_error() from exc
+            if candidate is current_iterator:
+                raise _resume_replay_error()
+            if not callable(set_epoch):
+                cached_next_iterator = candidate
+            replayable = True
 
     def _make_batch(local_items):
         if state.get("schema") == "raw" and state.get("label_state") is False:
@@ -5425,15 +5475,11 @@ def _iterate_lazy_text_training_batches(
         )
 
     while True:
-        set_epoch = getattr(dataset, "set_epoch", None)
-        if replayable and callable(set_epoch):
-            set_epoch(epoch)
-
         pending = []
         padding_source = []
         yielded = False
         for row in _iter_lazy_tokenized_text_rows(
-            dataset,
+            current_iterator,
             tokenizer,
             dataset_text_field=dataset_text_field,
             formatting_func=formatting_func,
@@ -5471,12 +5517,22 @@ def _iterate_lazy_text_training_batches(
             raise ValueError(
                 "Unsloth MLX: streaming text source produced no trainable rows."
             )
-        if not replayable:
-            raise RuntimeError(
-                "Unsloth MLX: one-shot streaming text source is exhausted and "
-                "cannot be replayed. Use a replayable iterable or reduce max_steps."
-            )
+        if replayable is False:
+            raise _exhaustion_error()
         epoch += 1
+        _set_epoch(epoch)
+        if cached_next_iterator is not None:
+            current_iterator = cached_next_iterator
+            cached_next_iterator = None
+            continue
+        try:
+            candidate = iter(dataset)
+        except Exception as exc:
+            raise _exhaustion_error() from exc
+        if candidate is current_iterator:
+            raise _exhaustion_error()
+        current_iterator = candidate
+        replayable = True
 
 
 def _iterate_ordered_text_training_batches(dataset, tokenizer, batch_size,
@@ -5597,7 +5653,7 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              model_name=None, model_type=None,
                              append_eos=True, completion_only_loss=None,
                              assistant_only_loss=False, dataset_order="default",
-                             comm_group=None):
+                             comm_group=None, require_replayable=False):
     """Streaming batch generator for MLX training.
 
     Map-style datasets retain the existing mlx-lm batching behavior. Unsized
@@ -5631,6 +5687,7 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             completion_only_loss=completion_only_loss,
             assistant_only_loss=assistant_only_loss,
             comm_group=comm_group,
+            require_replayable=require_replayable,
         )
         return
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -7216,7 +7216,10 @@ def _iterate_dispatched_lazy_text_training_batches(
                     "global unsharded Hugging Face iterable. Pass the source "
                     "before split_dataset_by_node(); MLX owns rank partitioning."
                 )
-        except Exception as exc:
+        except BaseException as exc:
+            # Even interrupts must be deferred: peers block in the dispatch
+            # collective below, so rank 0 cannot unwind before the failure
+            # status is broadcast. Re-raised through the loop's rank-0 path.
             owner_contract_error = exc
         owner_iterator = _iterate_lazy_text_training_batches(
             dataset,
@@ -7263,7 +7266,11 @@ def _iterate_dispatched_lazy_text_training_batches(
                     status = 1
                 except StopIteration:
                     pass
-                except Exception as exc:
+                except BaseException as exc:
+                    # Synchronize interrupts too (KeyboardInterrupt during a
+                    # source/formatter/tokenizer call): peers are entering the
+                    # all_sum below and would hang if rank 0 unwound past it.
+                    # The original error is re-raised on rank 0 after sync.
                     owner_error = exc
                     status = -1
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3402,6 +3402,76 @@ def _is_mlx_hf_iterable_text_source(dataset):
     return isinstance(dataset, HFIterableDataset)
 
 
+def _mlx_lazy_text_source(dataset):
+    """Return the raw source beneath an MLX prepared iterable view."""
+    return getattr(dataset, "_mlx_source_dataset", dataset)
+
+
+class _MLXIterableTokenizedDatasetView:
+    """Iterable-only public view over MLX's lazy text normalization pipeline.
+
+    The view deliberately has no ``__len__`` or ``__getitem__``. It preserves
+    the source's replay/one-shot behavior and forwards epoch changes without
+    consuming a row during construction.
+    """
+
+    def __init__(
+        self,
+        dataset,
+        tokenizer,
+        *,
+        dataset_text_field="text",
+        formatting_func=None,
+        append_eos=True,
+        completion_only_loss=None,
+        assistant_only_loss=False,
+        max_seq_length=None,
+        response_mask_fn=None,
+    ):
+        self._mlx_source_dataset = dataset
+        self._tokenizer = tokenizer
+        self._dataset_text_field = dataset_text_field
+        self._formatting_func = formatting_func
+        self._append_eos = append_eos
+        self._completion_only_loss = completion_only_loss
+        self._assistant_only_loss = assistant_only_loss
+        self._max_seq_length = max_seq_length
+        self._response_mask_fn = response_mask_fn
+
+    def set_epoch(self, epoch):
+        set_epoch = getattr(self._mlx_source_dataset, "set_epoch", None)
+        if callable(set_epoch):
+            set_epoch(epoch)
+
+    def set_response_mask(self, mask_fn):
+        self._response_mask_fn = mask_fn
+
+    def set_tokenizer(self, tokenizer):
+        self._tokenizer = tokenizer
+
+    def _iter_tokenized_rows(self, dataset=None, *, state=None):
+        source = self._mlx_source_dataset if dataset is None else dataset
+        return _iter_lazy_tokenized_text_rows(
+            source,
+            self._tokenizer,
+            dataset_text_field=self._dataset_text_field,
+            formatting_func=self._formatting_func,
+            append_eos=self._append_eos,
+            completion_only_loss=self._completion_only_loss,
+            assistant_only_loss=self._assistant_only_loss,
+            max_seq_length=self._max_seq_length,
+            response_mask_fn=self._response_mask_fn,
+            state=state,
+        )
+
+    def __iter__(self):
+        for input_ids, labels in self._iter_tokenized_rows():
+            row = {"input_ids": list(input_ids)}
+            if labels is not None:
+                row["labels"] = list(labels)
+            yield row
+
+
 def _labeled_row_has_supervision(labels, max_seq_length):
     # Keep rows with a supervised token in labels[1:max_seq_length] (causal shift,
     # length-capped); an all-masked batch aborts training. labels=None always kept.
@@ -5200,6 +5270,30 @@ def _iter_tokenized_text_rows(dataset, tokenizer, dataset_text_field="text",
                 yield (ids, 0)
 
 
+def _apply_mlx_response_mask_to_text_row(input_ids, labels, mask_fn):
+    """Apply the CUDA response-marker closure to one tokenized text row."""
+    mask_batch = {"input_ids": [list(input_ids)]}
+    if labels is not None:
+        # The shared CUDA closure accepts tensor-like labels with ``tolist``.
+        mask_batch["labels"] = np.asarray([labels], dtype=np.int64)
+    result = mask_fn(mask_batch)
+    masked = result.get("labels") if isinstance(result, Mapping) else None
+    if hasattr(masked, "tolist"):
+        masked = masked.tolist()
+    if not isinstance(masked, (list, tuple)) or len(masked) != 1:
+        raise ValueError(
+            "Unsloth MLX: train_on_responses_only masking must return one "
+            "labels row for each input_ids row."
+        )
+    masked = _coerce_mlx_token_list(masked[0], "labels")
+    if len(masked) != len(input_ids):
+        raise ValueError(
+            "Unsloth MLX: train_on_responses_only labels must match "
+            "input_ids length."
+        )
+    return list(input_ids), masked
+
+
 def _iter_lazy_tokenized_text_rows(
     dataset,
     tokenizer,
@@ -5210,6 +5304,7 @@ def _iter_lazy_tokenized_text_rows(
     completion_only_loss=None,
     assistant_only_loss=False,
     max_seq_length=None,
+    response_mask_fn=None,
     state=None,
 ):
     """Normalize an unsized source one row at a time and lock its schema."""
@@ -5288,7 +5383,7 @@ def _iter_lazy_tokenized_text_rows(
     ):
         # Empty label-owned rows have no token labels, but they also are not an
         # unlabeled schema transition. A non-None sentinel preserves that fact.
-        label_owned = assistant_only_loss or (
+        label_owned = response_mask_fn is not None or assistant_only_loss or (
             completion_mode is True and has_completion_boundary
         )
         return () if label_owned else None
@@ -5368,10 +5463,23 @@ def _iter_lazy_tokenized_text_rows(
             )
             if tokenized is not None:
                 ids, labels = tokenized
+                source_labels = labels
                 if max_seq_length is not None:
                     ids = ids[:max_seq_length]
                     labels = (
                         labels[:max_seq_length] if labels is not None else None
+                    )
+                    source_labels = (
+                        source_labels[:max_seq_length]
+                        if source_labels is not None else None
+                    )
+                source_usable = (
+                    len(ids) >= 2
+                    and _labeled_row_has_supervision(source_labels, len(ids))
+                )
+                if response_mask_fn is not None:
+                    ids, labels = _apply_mlx_response_mask_to_text_row(
+                        ids, labels, response_mask_fn,
                     )
                 usable = len(ids) >= 2 and _labeled_row_has_supervision(
                     labels, len(ids)
@@ -5379,8 +5487,8 @@ def _iter_lazy_tokenized_text_rows(
                 if (
                     formatter_applied
                     and row_completion_only_loss is True
-                    and labels is None
-                    and usable
+                    and source_labels is None
+                    and source_usable
                 ):
                     if formatter_needs_completion_boundary:
                         raise ValueError(
@@ -5397,7 +5505,7 @@ def _iter_lazy_tokenized_text_rows(
                     )
                 _validate_state(
                     "pretokenized",
-                    labels,
+                    source_labels,
                     usable=usable,
                     completion_mode=row_completion_only_loss,
                 )
@@ -5423,6 +5531,10 @@ def _iter_lazy_tokenized_text_rows(
                 if max_seq_length is not None:
                     ids = ids[:max_seq_length]
                     labels = labels[:max_seq_length]
+                if response_mask_fn is not None:
+                    ids, labels = _apply_mlx_response_mask_to_text_row(
+                        ids, labels, response_mask_fn,
+                    )
                 usable = len(ids) >= 2 and _labeled_row_has_supervision(
                     labels, len(ids)
                 )
@@ -5472,7 +5584,11 @@ def _iter_lazy_tokenized_text_rows(
             if not texts:
                 _validate_state(
                     "raw",
-                    None,
+                    _filtered_label_observation(
+                        row_completion_only_loss,
+                        item_has_completion_boundary
+                        or row_has_completion_boundary,
+                    ),
                     usable=False,
                     completion_mode=row_completion_only_loss,
                 )
@@ -5483,9 +5599,17 @@ def _iter_lazy_tokenized_text_rows(
                     ids.append(int(eos_id))
                 if max_seq_length is not None:
                     ids = ids[:max_seq_length]
-                usable = len(ids) >= 2
+                source_usable = len(ids) >= 2
+                labels = None
+                if response_mask_fn is not None:
+                    ids, labels = _apply_mlx_response_mask_to_text_row(
+                        ids, None, response_mask_fn,
+                    )
+                usable = len(ids) >= 2 and _labeled_row_has_supervision(
+                    labels, len(ids)
+                )
                 if (
-                    usable
+                    source_usable
                     and formatter_needs_completion_boundary
                     and row_completion_only_loss is True
                 ):
@@ -5496,19 +5620,19 @@ def _iter_lazy_tokenized_text_rows(
                         "Apply your formatting before passing the dataset, or set "
                         "completion_only_loss=False."
                     )
-                if usable and row_completion_only_loss is True:
+                if source_usable and row_completion_only_loss is True:
                     raise ValueError(
                         "Unsloth MLX: text completion_only_loss=True requires "
                         "prompt/completion rows for streaming text training."
                     )
                 _validate_state(
                     "raw",
-                    None,
+                    labels,
                     usable=usable,
                     completion_mode=row_completion_only_loss,
                 )
                 if usable:
-                    yield ids, None
+                    yield ids, labels
 
 
 def _close_mlx_owned_iterator(iterator):
@@ -5532,6 +5656,7 @@ def _iterate_lazy_text_training_batches(
     append_eos=True,
     completion_only_loss=None,
     assistant_only_loss=False,
+    response_mask_fn=None,
     comm_group=None,
     require_replayable=False,
 ):
@@ -5550,10 +5675,16 @@ def _iterate_lazy_text_training_batches(
     if dataset_order not in (None, "default", "sequential"):
         raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
 
+    prepared_view = (
+        dataset if isinstance(dataset, _MLXIterableTokenizedDatasetView) else None
+    )
+    if prepared_view is not None:
+        tokenizer = prepared_view._tokenizer
+    source_dataset = _mlx_lazy_text_source(dataset)
     global_batch_size = _distributed_global_batch_size(batch_size, comm_group)
     state = {}
     epoch = 0
-    set_epoch = getattr(dataset, "set_epoch", None)
+    set_epoch = getattr(source_dataset, "set_epoch", None)
 
     def _set_epoch(value):
         if callable(set_epoch):
@@ -5573,12 +5704,12 @@ def _iterate_lazy_text_training_batches(
         )
 
     _set_epoch(0)
-    current_iterator = iter(dataset)
+    current_iterator = iter(source_dataset)
     cached_next_iterator = None
     try:
-        if isinstance(dataset, Iterator):
+        if isinstance(source_dataset, Iterator):
             replayable = False
-        elif _is_mlx_hf_iterable_text_source(dataset):
+        elif _is_mlx_hf_iterable_text_source(source_dataset):
             replayable = True
         else:
             replayable = None
@@ -5588,7 +5719,7 @@ def _iterate_lazy_text_training_batches(
                 raise _resume_replay_error()
             if replayable is None:
                 try:
-                    candidate = iter(dataset)
+                    candidate = iter(source_dataset)
                 except Exception as exc:
                     raise _resume_replay_error() from exc
                 if candidate is current_iterator:
@@ -5617,17 +5748,25 @@ def _iterate_lazy_text_training_batches(
             pending = []
             padding_source = []
             yielded = False
-            for row in _iter_lazy_tokenized_text_rows(
-                current_iterator,
-                tokenizer,
-                dataset_text_field=dataset_text_field,
-                formatting_func=formatting_func,
-                append_eos=append_eos,
-                completion_only_loss=completion_only_loss,
-                assistant_only_loss=assistant_only_loss,
-                max_seq_length=max_seq_length,
-                state=state,
-            ):
+            row_iterator = (
+                prepared_view._iter_tokenized_rows(
+                    current_iterator, state=state,
+                )
+                if prepared_view is not None
+                else _iter_lazy_tokenized_text_rows(
+                    current_iterator,
+                    tokenizer,
+                    dataset_text_field=dataset_text_field,
+                    formatting_func=formatting_func,
+                    append_eos=append_eos,
+                    completion_only_loss=completion_only_loss,
+                    assistant_only_loss=assistant_only_loss,
+                    max_seq_length=max_seq_length,
+                    response_mask_fn=response_mask_fn,
+                    state=state,
+                )
+            )
+            for row in row_iterator:
                 if len(padding_source) < global_batch_size:
                     padding_source.append(row)
                 pending.append(row)
@@ -5670,7 +5809,7 @@ def _iterate_lazy_text_training_batches(
                 del exhausted_iterator
                 continue
             try:
-                candidate = iter(dataset)
+                candidate = iter(source_dataset)
             except Exception as exc:
                 if replayable is True:
                     raise RuntimeError(
@@ -5821,7 +5960,8 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              model_name=None, model_type=None,
                              append_eos=True, completion_only_loss=None,
                              assistant_only_loss=False, dataset_order="default",
-                             comm_group=None, require_replayable=False):
+                             comm_group=None, require_replayable=False,
+                             response_mask_fn=None):
     """Streaming batch generator for MLX training.
 
     Map-style datasets retain the existing mlx-lm batching behavior. Unsized
@@ -5854,6 +5994,7 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             append_eos=append_eos,
             completion_only_loss=completion_only_loss,
             assistant_only_loss=assistant_only_loss,
+            response_mask_fn=response_mask_fn,
             comm_group=comm_group,
             require_replayable=require_replayable,
         )

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5700,6 +5700,35 @@ def _close_mlx_owned_iterator(iterator):
         close()
 
 
+def _validate_streaming_length_window(value):
+    """Validate streaming_text_length_window_batches before source consumption."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            "Unsloth MLX: streaming_text_length_window_batches must be an "
+            f"integer >= 1 (got {value!r})."
+        )
+    if value < 1:
+        raise ValueError(
+            "Unsloth MLX: streaming_text_length_window_batches must be >= 1 "
+            f"(got {value})."
+        )
+    return value
+
+
+def _lazy_window_sort_key(item, max_seq_length):
+    """Window grouping key: exact truncated prepared-token length (lazy rows
+    carry ``(input_ids, labels)`` for every schema)."""
+    if item is None:
+        return 0
+    return min(len(item[0]), max_seq_length)
+
+
+def _window_batch_permutation(seed, epoch, window_ordinal, count):
+    """Deterministic batch-order permutation for one flushed window."""
+    mix = (int(seed) * 1_000_003 + int(epoch) * 9_973 + int(window_ordinal)) % (2 ** 32)
+    return np.random.RandomState(mix).permutation(count)
+
+
 def _iterate_lazy_text_training_batches(
     dataset,
     tokenizer,
@@ -5719,8 +5748,16 @@ def _iterate_lazy_text_training_batches(
     distributed_pad_mode="cycle",
     expected_rows_per_pass=None,
     include_epoch=False,
+    length_window_batches=1,
+    window_seed=0,
 ):
-    """Yield source-ordered text batches without materializing an unsized source.
+    """Yield text batches without materializing an unsized source.
+
+    ``sequential`` order and ``length_window_batches=1`` emit exact source
+    order. Default order with a window > 1 pools that many global micro-batches
+    of trainable rows, stable-sorts them by truncated prepared-token length,
+    and emits the full chunks in a seeded deterministic permutation (partial
+    chunk last) — a documented, deterministic reordering.
 
     Custom replayable sources must return independent fresh traversals from
     ``iter(source)``. Resume validation may create one non-consuming iterator
@@ -5734,6 +5771,16 @@ def _iterate_lazy_text_training_batches(
         )
     if dataset_order not in (None, "default", "sequential"):
         raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
+
+    length_window = _validate_streaming_length_window(length_window_batches)
+    if dataset_order == "sequential":
+        # Sequential contract: exact source order, length grouping off.
+        length_window = 1
+    window_seed = _normalize_seed(window_seed)
+    # Cycle padding only feeds direct multi-rank slicing; the single-process
+    # path and the rank-0 owner iterator (comm_group=None, outer cycle_source)
+    # must not retain a pass-long first batch on top of the window bound.
+    needs_padding_source = _distributed_rank_size(comm_group)[1] > 1
 
     prepared_view = (
         dataset if isinstance(dataset, _MLXIterableTokenizedDatasetView) else None
@@ -5821,6 +5868,52 @@ def _iterate_lazy_text_training_batches(
             yielded = False
             source_rows_seen = 0
             prepared_rows_seen = 0
+            window_rows = []
+            window_ordinal = 0
+
+            def _flush_window():
+                # Emit pooled rows as length-grouped global batches: stable sort
+                # by truncated length with arrival tiebreak, chunk, then a seeded
+                # permutation of the FULL chunks only — a trailing partial chunk
+                # always emits last so mid-stream batches keep uniform row counts.
+                nonlocal window_rows, window_ordinal, yielded
+                if not window_rows:
+                    return
+                order = sorted(
+                    range(len(window_rows)),
+                    key=lambda i: (
+                        _lazy_window_sort_key(window_rows[i], max_seq_length),
+                        i,
+                    ),
+                )
+                chunks = [
+                    [window_rows[i] for i in order[start:start + global_batch_size]]
+                    for start in range(0, len(order), global_batch_size)
+                ]
+                full = len(chunks)
+                if chunks and len(chunks[-1]) < global_batch_size:
+                    full -= 1
+                emit = list(_window_batch_permutation(
+                    window_seed, epoch, window_ordinal, full,
+                )) + list(range(full, len(chunks)))
+                window_ordinal += 1
+                window_rows = []
+                for chunk_index in emit:
+                    # Release each chunk as it is emitted so flush-time retention
+                    # stays within the W-batch window bound.
+                    chunk = chunks[chunk_index]
+                    chunks[chunk_index] = None
+                    local_items = _rank_slice_distributed_batch(
+                        chunk,
+                        batch_size,
+                        comm_group=comm_group,
+                        pad_source=padding_source,
+                        pad_mode=distributed_pad_mode,
+                    )
+                    chunk = None
+                    yielded = True
+                    yield _yield_value(local_items)
+                    local_items = None
 
             def _tokenized_rows(source):
                 if prepared_view is not None:
@@ -5882,10 +5975,19 @@ def _iterate_lazy_text_training_batches(
                         "trainable text row per declared source row. Use "
                         "max_steps when rows expand or are filtered."
                     )
-                if len(padding_source) < global_batch_size:
+                if needs_padding_source and len(padding_source) < global_batch_size:
                     padding_source.append(row)
                 pending.append(row)
                 if len(pending) < global_batch_size:
+                    continue
+                if length_window > 1:
+                    window_rows.extend(pending)
+                    pending = []
+                    if len(window_rows) >= length_window * global_batch_size and (
+                        expected_rows_per_pass is None
+                        or prepared_rows_seen < expected_rows_per_pass
+                    ):
+                        yield from _flush_window()
                     continue
                 if (
                     expected_rows_per_pass is not None
@@ -5914,6 +6016,11 @@ def _iterate_lazy_text_training_batches(
                     "does not match one trainable row per source row. Use "
                     "max_steps for filtered or expanding streams."
                 )
+
+            if length_window > 1:
+                window_rows.extend(pending)
+                pending = []
+                yield from _flush_window()
 
             if deferred_final is not None:
                 local_items = _rank_slice_distributed_batch(
@@ -6130,6 +6237,9 @@ def _iterate_dispatched_lazy_text_training_batches(
             width = 0
             has_labels = 0
             status = 0
+            # Drop the previous fetch's tensors before the owner pulls the next
+            # batch so dispatch never holds two batches alongside the window.
+            owner_batch = input_ids = lengths = labels = None
             if rank == 0:
                 try:
                     if owner_contract_error is not None:
@@ -6327,12 +6437,16 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              comm_group=None, require_replayable=False,
                              response_mask_fn=None, repeat=True,
                              distributed_pad_mode="cycle",
-                             expected_rows_per_pass=None):
+                             expected_rows_per_pass=None,
+                             length_window_batches=1):
     """Streaming batch generator for MLX training.
 
     Map-style datasets retain the existing mlx-lm batching behavior. Unsized
-    text sources are normalized and tokenized incrementally in source order,
-    with only one distributed micro-batch retained at a time.
+    text sources are normalized and tokenized incrementally, retaining at most
+    ``length_window_batches`` global micro-batches of prepared rows (plus the
+    rank-0 owner's pass-long cycle-padding batch under DDP). Default order with
+    a window > 1 emits length-grouped, seeded-permuted batches; ``sequential``
+    and window 1 preserve exact source order.
 
     Yields:
         (batch, lengths, labels) tuples — same format as create_batches.
@@ -6360,6 +6474,8 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             require_replayable=require_replayable,
             repeat=repeat,
             expected_rows_per_pass=expected_rows_per_pass,
+            length_window_batches=length_window_batches,
+            window_seed=seed,
         )
         if _distributed_rank_size(comm_group)[1] > 1:
             yield from _iterate_dispatched_lazy_text_training_batches(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -34,7 +34,9 @@ import os
 import sys
 import shutil
 import tempfile
+import queue as _queue_module
 import threading
+import time
 import warnings
 from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
@@ -6036,6 +6038,210 @@ def _probe_lazy_replayability(source_dataset, current_iterator, set_epoch,
     return replayable, cached_next_iterator
 
 
+
+def _validate_streaming_prefetch(value):
+    """Validate streaming_prefetch_batches before source consumption."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            "Unsloth MLX: streaming_prefetch_batches must be an integer >= 0 "
+            f"(got {value!r})."
+        )
+    if value < 0:
+        raise ValueError(
+            "Unsloth MLX: streaming_prefetch_batches must be >= 0 "
+            f"(got {value})."
+        )
+    return value
+
+
+_PREFETCH_ITEM = "item"
+_PREFETCH_END = "end"
+_PREFETCH_ERROR = "error"
+
+
+class _LazyTextPrefetcher:
+    """Bounded single-producer prefetch over host-staged text batches.
+
+    The producer thread owns source consumption and host staging (tokenizer,
+    formatter, response-mask closures included); MLX finalization runs only on
+    the consumer thread. A queue slot is reserved BEFORE staging each batch so
+    read-ahead is exactly the configured depth. Cancellation is cooperative:
+    the stop event is honored between batches, cleanup closes the owned
+    iterator in ``finally``, and a bounded join that times out marks the
+    prefetcher ORPHANED — while the orphan thread lives, reusing the shared
+    preprocessing objects is refused by the trainer.
+    """
+
+    _JOIN_TIMEOUT = 5.0
+    _QUIESCE_TIMEOUT = 30.0
+
+    def __init__(self, make_iterator, depth, skip_batches=0,
+                 finalize=None, include_epoch=False):
+        self._make_iterator = make_iterator
+        self._depth = int(depth)
+        self._skip_batches = int(skip_batches)
+        self._finalize = finalize or _finalize_text_batch
+        self._include_epoch = include_epoch
+        self._slots = threading.BoundedSemaphore(self._depth)
+        self._envelopes = _queue_module.Queue()
+        self._stop = threading.Event()
+        self._pause = threading.Event()
+        self._quiescent = threading.Event()
+        self._ready = threading.Event()
+        self._done = threading.Event()
+        self._thread = None
+        self.orphaned = False
+        self._closed = False
+        self._close_finished = threading.Event()
+        self._lifecycle_lock = threading.Lock()
+
+    # -- producer side ----------------------------------------------------
+    def _run(self):
+        iterator = None
+        try:
+            iterator = self._make_iterator()
+            for _ in range(self._skip_batches):
+                if self._stop.is_set():
+                    return
+                try:
+                    next(iterator)  # resume fast-forward on the producer thread
+                except StopIteration:
+                    if self._stop.is_set():
+                        return  # cooperative stop during skip, not exhaustion
+                    raise RuntimeError(
+                        "Unsloth: streaming dataset exhausted while "
+                        "fast-forwarding to the resume position. Dataset may "
+                        "be shorter than the killed run consumed."
+                    ) from None
+            self._ready.set()
+            while not self._stop.is_set():
+                if self._pause.is_set():
+                    self._quiescent.set()
+                    while self._pause.is_set() and not self._stop.is_set():
+                        time.sleep(0.005)
+                    self._quiescent.clear()
+                    continue
+                if not self._slots.acquire(timeout=0.05):
+                    continue  # queue full: stay responsive to stop/pause
+                try:
+                    staged = next(iterator)
+                except StopIteration:
+                    self._slots.release()
+                    self._envelopes.put((_PREFETCH_END, None))
+                    return
+                except BaseException as exc:  # positioned via FIFO envelope
+                    self._slots.release()
+                    self._envelopes.put((_PREFETCH_ERROR, exc))
+                    return
+                self._envelopes.put((_PREFETCH_ITEM, staged))
+        except BaseException as exc:
+            self._envelopes.put((_PREFETCH_ERROR, exc))
+        finally:
+            self._ready.set()
+            try:
+                if iterator is not None:
+                    try:
+                        _close_mlx_owned_iterator(iterator)
+                    except Exception:
+                        pass
+            finally:
+                # Published only after producer-owned cleanup: quiesce() treats
+                # _done as proof the thread no longer touches shared objects.
+                self._done.set()
+
+    def _ensure_started(self):
+        with self._lifecycle_lock:
+            # One lock covers the closed check and thread publication so a
+            # concurrent close() cannot return "clean" and then observe a
+            # producer started afterwards.
+            if self._closed or self._stop.is_set():
+                raise StopIteration
+            if self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run, name="unsloth-mlx-prefetch", daemon=True,
+                )
+                self._thread.start()
+        while not self._ready.wait(timeout=0.1):
+            if self._closed or self._stop.is_set():
+                raise StopIteration
+
+    # -- consumer side ----------------------------------------------------
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self._ensure_started()
+        while True:
+            try:
+                kind, payload = self._envelopes.get(timeout=0.5)
+            except _queue_module.Empty:
+                if self._stop.is_set():
+                    raise StopIteration
+                continue
+            break
+        if kind == _PREFETCH_ITEM:
+            self._slots.release()
+            if self._include_epoch:
+                staged, epoch = payload
+                return self._finalize(staged), epoch
+            return self._finalize(payload)
+        if kind == _PREFETCH_END:
+            raise StopIteration
+        raise payload
+
+    # -- lifecycle --------------------------------------------------------
+    def quiesce(self):
+        """RUNNING -> PAUSE_REQUESTED -> QUIESCENT; bounded, actionable."""
+        if self._thread is None or not self._thread.is_alive():
+            return
+        self._pause.set()
+        deadline = time.monotonic() + self._QUIESCE_TIMEOUT
+        while True:
+            if self._quiescent.wait(timeout=0.05):
+                return
+            if self._done.is_set():
+                return  # a terminated producer is trivially quiescent
+            if time.monotonic() >= deadline:
+                self._pause.clear()
+                raise RuntimeError(
+                    "Unsloth MLX: the prefetch producer did not quiesce (it "
+                    "may be blocked inside the tokenizer or source). Use "
+                    "streaming_prefetch_batches=0 for this run."
+                )
+
+    def resume(self):
+        self._pause.clear()
+
+    def close(self):
+        """Terminal and idempotent: only the first call pays the bounded join."""
+        with self._lifecycle_lock:
+            self._stop.set()
+            self._pause.clear()
+            first_close = not self._closed
+            self._closed = True
+            thread = self._thread
+        if not first_close:
+            # Wait for the first closer's join to settle so a concurrent
+            # second close never reports clean while the producer still runs.
+            settled = self._close_finished.wait(timeout=self._JOIN_TIMEOUT + 1.0)
+            if not settled and self._thread is not None and self._thread.is_alive():
+                self.orphaned = True  # conservative: unsettled + alive = orphan
+            return not self.orphan_alive()
+        try:
+            if thread is not None and thread.is_alive():
+                thread.join(timeout=self._JOIN_TIMEOUT)
+        finally:
+            # Conservative: classify any still-live thread as orphaned before
+            # publishing settlement, including interrupted joins.
+            if thread is not None and thread.is_alive():
+                self.orphaned = True
+            self._close_finished.set()
+        return not self.orphaned
+
+    def orphan_alive(self):
+        return self.orphaned and self._thread is not None and self._thread.is_alive()
+
+
 def _validate_streaming_length_window(value):
     """Validate streaming_text_length_window_batches before source consumption."""
     if isinstance(value, bool) or not isinstance(value, int):
@@ -6087,6 +6293,8 @@ def _iterate_lazy_text_training_batches(
     length_window_batches=1,
     window_seed=0,
     yield_host_staged=False,
+    reject_mlx_valued=False,
+    should_stop=None,
 ):
     """Yield text batches without materializing an unsized source.
 
@@ -6126,7 +6334,7 @@ def _iterate_lazy_text_training_batches(
         tokenizer = prepared_view._tokenizer
     source_dataset = _mlx_lazy_text_source(dataset)
     global_batch_size = _distributed_global_batch_size(batch_size, comm_group)
-    state = {}
+    state = {"reject_mlx_valued": True} if reject_mlx_valued else {}
     epoch = 0
     set_epoch = getattr(source_dataset, "set_epoch", None)
 
@@ -6256,7 +6464,7 @@ def _iterate_lazy_text_training_batches(
 
             def _exactly_one_prepared_row_per_source():
                 nonlocal source_rows_seen
-                for item in current_iterator:
+                for item in pass_source:
                     source_rows_seen += 1
                     if source_rows_seen > expected_rows_per_pass:
                         raise ValueError(
@@ -6277,12 +6485,39 @@ def _iterate_lazy_text_training_batches(
                         )
                     yield first
 
+            def _stoppable(source):
+                # Cooperative cancellation lands between SOURCE rows — checked
+                # BEFORE each pull (a stop during row processing must not cost
+                # another blocking read) and after, for stops during next().
+                iterator = iter(source)
+                while True:
+                    if should_stop():
+                        return
+                    try:
+                        source_item = next(iterator)
+                    except StopIteration:
+                        return
+                    if should_stop():
+                        return
+                    yield source_item
+
+            pass_source = (
+                _stoppable(current_iterator)
+                if should_stop is not None else current_iterator
+            )
             row_iterator = (
                 _exactly_one_prepared_row_per_source()
                 if expected_rows_per_pass is not None
-                else _tokenized_rows(current_iterator)
+                else _tokenized_rows(pass_source)
             )
-            for row in row_iterator:
+            rows_pending = iter(row_iterator)
+            while True:
+                if should_stop is not None and should_stop():
+                    return
+                try:
+                    row = next(rows_pending)
+                except StopIteration:
+                    break
                 prepared_rows_seen += 1
                 if (
                     expected_rows_per_pass is not None
@@ -6328,6 +6563,8 @@ def _iterate_lazy_text_training_batches(
                 yield _yield_value(local_items)
                 pending = []
 
+            if should_stop is not None and should_stop():
+                return  # cooperative stop: skip pass-end flush and validation
             if expected_rows_per_pass is not None and (
                 source_rows_seen != expected_rows_per_pass
                 or prepared_rows_seen != expected_rows_per_pass
@@ -6759,7 +6996,10 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              response_mask_fn=None, repeat=True,
                              distributed_pad_mode="cycle",
                              expected_rows_per_pass=None,
-                             length_window_batches=1):
+                             length_window_batches=1,
+                             prefetch_batches=0,
+                             prefetch_skip_batches=0,
+                             prefetch_control=None):
     """Streaming batch generator for MLX training.
 
     Map-style datasets retain the existing mlx-lm batching behavior. Unsized
@@ -6798,6 +7038,29 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             length_window_batches=length_window_batches,
             window_seed=seed,
         )
+        prefetch_depth = _validate_streaming_prefetch(prefetch_batches)
+        if prefetch_depth and _distributed_rank_size(comm_group)[1] == 1:
+            prefetcher = _LazyTextPrefetcher(
+                None,
+                prefetch_depth,
+                skip_batches=prefetch_skip_batches,
+            )
+            prefetcher._make_iterator = (
+                lambda pf=prefetcher: _iterate_lazy_text_training_batches(
+                    dataset, tokenizer, batch_size, max_seq_length,
+                    comm_group=None, distributed_pad_mode=distributed_pad_mode,
+                    yield_host_staged=True, reject_mlx_valued=True,
+                    should_stop=pf._stop.is_set,
+                    **lazy_batch_kwargs,
+                )
+            )
+            if prefetch_control is not None:
+                prefetch_control["prefetcher"] = prefetcher
+            try:
+                yield from prefetcher
+            finally:
+                prefetcher.close()
+            return
         if _distributed_rank_size(comm_group)[1] > 1:
             yield from _iterate_dispatched_lazy_text_training_batches(
                 dataset,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3480,13 +3480,30 @@ def _labeled_row_has_supervision(labels, max_seq_length):
     return any(int(x) != -100 for x in labels[1:max_seq_length])
 
 
-def _create_tokenized_text_batch(batch_items, max_seq_length, pad_id=0):
+def _create_tokenized_text_batch(
+    batch_items,
+    max_seq_length,
+    pad_id=0,
+    labels_expected=None,
+):
     """Pad pretokenized ids plus optional labels for one MLX text batch."""
-    lengths = [min(len(ids), max_seq_length) for ids, _labels in batch_items]
+    valid_items = [item for item in batch_items if item is not None]
+    lengths = [
+        0 if item is None else min(len(item[0]), max_seq_length)
+        for item in batch_items
+    ]
     max_length = max(lengths)
+    if max_length == 0:
+        max_length = min(2, max_seq_length)
     batch_ids = np.full((len(batch_items), max_length), int(pad_id), dtype=np.int32)
-    has_labels = batch_items[0][1] is not None
-    if any((labels is not None) != has_labels for _ids, labels in batch_items):
+    has_labels = (
+        valid_items[0][1] is not None
+        if valid_items else bool(labels_expected)
+    )
+    if any(
+        (labels is not None) != has_labels
+        for ids, labels in valid_items
+    ):
         raise ValueError(
             "Unsloth MLX: pretokenized rows with labels/completion_mask must "
             "not be batched with rows that do not provide labels."
@@ -3495,7 +3512,10 @@ def _create_tokenized_text_batch(batch_items, max_seq_length, pad_id=0):
         np.full((len(batch_items), max_length), -100, dtype=np.int64)
         if has_labels else None
     )
-    for row_idx, (ids, labels) in enumerate(batch_items):
+    for row_idx, item in enumerate(batch_items):
+        if item is None:
+            continue
+        ids, labels = item
         length = lengths[row_idx]
         batch_ids[row_idx, :length] = ids[:length]
         if batch_labels is not None:
@@ -5659,6 +5679,9 @@ def _iterate_lazy_text_training_batches(
     response_mask_fn=None,
     comm_group=None,
     require_replayable=False,
+    repeat=True,
+    distributed_pad_mode="cycle",
+    expected_rows_per_pass=None,
 ):
     """Yield source-ordered text batches without materializing an unsized source.
 
@@ -5692,9 +5715,8 @@ def _iterate_lazy_text_training_batches(
 
     def _resume_replay_error():
         return RuntimeError(
-            "Unsloth MLX: checkpoint resume requires a replayable iterable "
-            "text source; a one-shot iterator cannot be fast-forwarded "
-            "deterministically."
+            "Unsloth MLX: this operation requires a replayable iterable text "
+            "source; a one-shot iterator cannot be replayed deterministically."
         )
 
     def _exhaustion_error():
@@ -5702,6 +5724,9 @@ def _iterate_lazy_text_training_batches(
             "Unsloth MLX: one-shot streaming text source is exhausted and "
             "cannot be replayed. Use a replayable iterable or reduce max_steps."
         )
+
+    if require_replayable and isinstance(source_dataset, Iterator):
+        raise _resume_replay_error()
 
     _set_epoch(0)
     current_iterator = iter(source_dataset)
@@ -5734,7 +5759,10 @@ def _iterate_lazy_text_training_batches(
         def _make_batch(local_items):
             if state.get("schema") == "raw" and state.get("label_state") is False:
                 return _make_text_batch_from_items(
-                    [ids for ids, _labels in local_items],
+                    [
+                        None if item is None else item[0]
+                        for item in local_items
+                    ],
                     tokenizer,
                     max_seq_length,
                 )
@@ -5742,19 +5770,40 @@ def _iterate_lazy_text_training_batches(
                 local_items,
                 max_seq_length,
                 pad_id=_mlx_text_pad_id(tokenizer),
+                labels_expected=state.get("label_state"),
             )
 
         while True:
             pending = []
+            deferred_final = None
             padding_source = []
             yielded = False
+            source_rows_seen = 0
+            prepared_rows_seen = 0
+
+            def _counted_source_rows():
+                nonlocal source_rows_seen
+                for item in current_iterator:
+                    source_rows_seen += 1
+                    if source_rows_seen > expected_rows_per_pass:
+                        raise ValueError(
+                            "Unsloth MLX: epoch training requires exactly one "
+                            "trainable text row per declared source row. Use "
+                            "max_steps when the source exceeds its declared length."
+                        )
+                    yield item
+
+            row_source = (
+                _counted_source_rows()
+                if expected_rows_per_pass is not None else current_iterator
+            )
             row_iterator = (
                 prepared_view._iter_tokenized_rows(
-                    current_iterator, state=state,
+                    row_source, state=state,
                 )
                 if prepared_view is not None
                 else _iter_lazy_tokenized_text_rows(
-                    current_iterator,
+                    row_source,
                     tokenizer,
                     dataset_text_field=dataset_text_field,
                     formatting_func=formatting_func,
@@ -5767,20 +5816,62 @@ def _iterate_lazy_text_training_batches(
                 )
             )
             for row in row_iterator:
+                prepared_rows_seen += 1
+                if (
+                    expected_rows_per_pass is not None
+                    and (
+                        source_rows_seen != prepared_rows_seen
+                        or source_rows_seen > expected_rows_per_pass
+                    )
+                ):
+                    raise ValueError(
+                        "Unsloth MLX: epoch training requires exactly one "
+                        "trainable text row per declared source row. Use "
+                        "max_steps when rows expand or are filtered."
+                    )
                 if len(padding_source) < global_batch_size:
                     padding_source.append(row)
                 pending.append(row)
                 if len(pending) < global_batch_size:
+                    continue
+                if (
+                    expected_rows_per_pass is not None
+                    and prepared_rows_seen == expected_rows_per_pass
+                ):
+                    deferred_final = pending
+                    pending = []
                     continue
                 local_items = _rank_slice_distributed_batch(
                     pending,
                     batch_size,
                     comm_group=comm_group,
                     pad_source=padding_source,
+                    pad_mode=distributed_pad_mode,
                 )
                 yielded = True
                 yield _make_batch(local_items)
                 pending = []
+
+            if expected_rows_per_pass is not None and (
+                source_rows_seen != expected_rows_per_pass
+                or prepared_rows_seen != expected_rows_per_pass
+            ):
+                raise ValueError(
+                    "Unsloth MLX: the streaming text source's declared length "
+                    "does not match one trainable row per source row. Use "
+                    "max_steps for filtered or expanding streams."
+                )
+
+            if deferred_final is not None:
+                local_items = _rank_slice_distributed_batch(
+                    deferred_final,
+                    batch_size,
+                    comm_group=comm_group,
+                    pad_source=padding_source,
+                    pad_mode=distributed_pad_mode,
+                )
+                yielded = True
+                yield _make_batch(local_items)
 
             if pending:
                 local_items = _rank_slice_distributed_batch(
@@ -5788,6 +5879,7 @@ def _iterate_lazy_text_training_batches(
                     batch_size,
                     comm_group=comm_group,
                     pad_source=padding_source,
+                    pad_mode=distributed_pad_mode,
                 )
                 yielded = True
                 yield _make_batch(local_items)
@@ -5799,6 +5891,8 @@ def _iterate_lazy_text_training_batches(
                 raise ValueError(
                     "Unsloth MLX: streaming text source produced no trainable rows."
                 )
+            if not repeat:
+                return
             if replayable is False:
                 raise _exhaustion_error()
             epoch += 1
@@ -5961,7 +6055,9 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              append_eos=True, completion_only_loss=None,
                              assistant_only_loss=False, dataset_order="default",
                              comm_group=None, require_replayable=False,
-                             response_mask_fn=None):
+                             response_mask_fn=None, repeat=True,
+                             distributed_pad_mode="cycle",
+                             expected_rows_per_pass=None):
     """Streaming batch generator for MLX training.
 
     Map-style datasets retain the existing mlx-lm batching behavior. Unsized
@@ -5997,6 +6093,9 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             response_mask_fn=response_mask_fn,
             comm_group=comm_group,
             require_replayable=require_replayable,
+            repeat=repeat,
+            distributed_pad_mode=distributed_pad_mode,
+            expected_rows_per_pass=expected_rows_per_pass,
         )
         return
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5111,7 +5111,10 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                                   completion_only_loss=None,
                                   image_size=None, comm_group=None,
                                   require_replayable=False,
-                                  expected_rows_per_pass=None):
+                                  expected_rows_per_pass=None,
+                                  prefetch_batches=0,
+                                  prefetch_skip_batches=0,
+                                  prefetch_control=None):
     """Streaming VLM batch generator using processor directly.
 
     Yields batch dicts with input_ids, pixel_values, attention_mask,
@@ -5221,6 +5224,42 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                     )
             epoch += 1
     else:
+        prefetch_depth = _validate_streaming_prefetch(prefetch_batches)
+        if prefetch_depth and _distributed_rank_size(comm_group)[1] == 1:
+            # The shared prefetch producer generalizes over host-staged
+            # batches; the VLM finalizer converts on the consumer thread.
+            # Response-masked streams reject at the iterator entry
+            # (zero-touch).
+            prefetcher = _LazyTextPrefetcher(
+                None,
+                prefetch_depth,
+                skip_batches=prefetch_skip_batches,
+                finalize=_finalize_vlm_batch,
+            )
+            prefetcher._make_iterator = (
+                lambda pf=prefetcher: _iterate_lazy_vlm_training_batches(
+                    dataset, processor, config, batch_size, max_seq_length,
+                    response_mask_fn=response_mask_fn,
+                    formatting_func=formatting_func,
+                    dataset_order=dataset_order,
+                    completion_only_loss=completion_only_loss,
+                    image_size=image_size,
+                    comm_group=None,
+                    require_replayable=require_replayable,
+                    expected_rows_per_pass=expected_rows_per_pass,
+                    ignore_token_ids=ignore_token_ids,
+                    yield_host_staged=True,
+                    reject_mlx_valued=True,
+                    should_stop=pf._stop.is_set,
+                )
+            )
+            if prefetch_control is not None:
+                prefetch_control["prefetcher"] = prefetcher
+            try:
+                yield from prefetcher
+            finally:
+                prefetcher.close()
+            return
         yield from _iterate_lazy_vlm_training_batches(
             dataset, processor, config, batch_size, max_seq_length,
             response_mask_fn=response_mask_fn,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3415,6 +3415,10 @@ class _MLXIterableTokenizedDatasetView:
     consuming a row during construction.
     """
 
+    _INVALIDATED_SOURCE_METADATA = frozenset((
+        "column_names", "features", "info", "num_columns", "supervised_keys",
+    ))
+
     def __init__(
         self,
         dataset,
@@ -3438,6 +3442,15 @@ class _MLXIterableTokenizedDatasetView:
         self._max_seq_length = max_seq_length
         self._response_mask_fn = response_mask_fn
 
+    def __getattr__(self, name):
+        """Lazily expose public metadata and cursor state, not raw transforms."""
+        if name.startswith("_") or name in self._INVALIDATED_SOURCE_METADATA:
+            raise AttributeError(name)
+        value = getattr(self._mlx_source_dataset, name)
+        if callable(value):
+            raise AttributeError(name)
+        return value
+
     def set_epoch(self, epoch):
         set_epoch = getattr(self._mlx_source_dataset, "set_epoch", None)
         if callable(set_epoch):
@@ -3449,7 +3462,9 @@ class _MLXIterableTokenizedDatasetView:
     def set_tokenizer(self, tokenizer):
         self._tokenizer = tokenizer
 
-    def _iter_tokenized_rows(self, dataset=None, *, state=None):
+    def _iter_tokenized_rows(
+        self, dataset=None, *, state=None, include_source=False,
+    ):
         source = self._mlx_source_dataset if dataset is None else dataset
         return _iter_lazy_tokenized_text_rows(
             source,
@@ -3462,13 +3477,27 @@ class _MLXIterableTokenizedDatasetView:
             max_seq_length=self._max_seq_length,
             response_mask_fn=self._response_mask_fn,
             state=state,
+            include_source=include_source,
         )
 
     def __iter__(self):
-        for input_ids, labels in self._iter_tokenized_rows():
-            row = {"input_ids": list(input_ids)}
+        for source, input_ids, labels in self._iter_tokenized_rows(
+            include_source=True,
+        ):
+            row = dict(source) if isinstance(source, Mapping) else {}
+            row["input_ids"] = list(input_ids)
+            row.pop("labels", None)
             if labels is not None:
                 row["labels"] = list(labels)
+            if isinstance(source, Mapping) and "input_ids" in source:
+                for field in ("completion_mask", "assistant_masks"):
+                    mask = row.get(field)
+                    if hasattr(mask, "tolist"):
+                        mask = mask.tolist()
+                    if isinstance(mask, (list, tuple)) and (
+                        not mask or not isinstance(mask[0], (list, tuple))
+                    ):
+                        row[field] = list(mask)[:len(input_ids)]
             yield row
 
 
@@ -5326,12 +5355,18 @@ def _iter_lazy_tokenized_text_rows(
     max_seq_length=None,
     response_mask_fn=None,
     state=None,
+    include_source=False,
 ):
     """Normalize an unsized source one row at a time and lock its schema."""
     state = {} if state is None else state
     eos_id = getattr(tokenizer, "eos_token_id", None) if append_eos else None
     saw_usable_this_pass = False
     completion_labels_seen_this_pass = False
+
+    def _output(source, input_ids, labels):
+        if include_source:
+            return source, input_ids, labels
+        return input_ids, labels
 
     if completion_only_loss is not None:
         state.setdefault(
@@ -5467,6 +5502,7 @@ def _iter_lazy_tokenized_text_rows(
             continue
 
         for row in source_rows:
+            prepared_source = item if isinstance(item, Mapping) else row
             row_has_completion_boundary = (
                 isinstance(row, Mapping)
                 and "prompt" in row
@@ -5530,7 +5566,7 @@ def _iter_lazy_tokenized_text_rows(
                     completion_mode=row_completion_only_loss,
                 )
                 if usable:
-                    yield ids, labels
+                    yield _output(prepared_source, ids, labels)
                 continue
 
             _require_assistant_conversation(row)
@@ -5565,7 +5601,7 @@ def _iter_lazy_tokenized_text_rows(
                     completion_mode=row_completion_only_loss,
                 )
                 if usable:
-                    yield ids, labels
+                    yield _output(prepared_source, ids, labels)
                 continue
             if assistant_only_loss:
                 raise ValueError(
@@ -5652,7 +5688,7 @@ def _iter_lazy_tokenized_text_rows(
                     completion_mode=row_completion_only_loss,
                 )
                 if usable:
-                    yield ids, labels
+                    yield _output(prepared_source, ids, labels)
 
 
 def _close_mlx_owned_iterator(iterator):
@@ -5786,29 +5822,13 @@ def _iterate_lazy_text_training_batches(
             source_rows_seen = 0
             prepared_rows_seen = 0
 
-            def _counted_source_rows():
-                nonlocal source_rows_seen
-                for item in current_iterator:
-                    source_rows_seen += 1
-                    if source_rows_seen > expected_rows_per_pass:
-                        raise ValueError(
-                            "Unsloth MLX: epoch training requires exactly one "
-                            "trainable text row per declared source row. Use "
-                            "max_steps when the source exceeds its declared length."
-                        )
-                    yield item
-
-            row_source = (
-                _counted_source_rows()
-                if expected_rows_per_pass is not None else current_iterator
-            )
-            row_iterator = (
-                prepared_view._iter_tokenized_rows(
-                    row_source, state=state,
-                )
-                if prepared_view is not None
-                else _iter_lazy_tokenized_text_rows(
-                    row_source,
+            def _tokenized_rows(source):
+                if prepared_view is not None:
+                    return prepared_view._iter_tokenized_rows(
+                        source, state=state,
+                    )
+                return _iter_lazy_tokenized_text_rows(
+                    source,
                     tokenizer,
                     dataset_text_field=dataset_text_field,
                     formatting_func=formatting_func,
@@ -5819,6 +5839,34 @@ def _iterate_lazy_text_training_batches(
                     response_mask_fn=response_mask_fn,
                     state=state,
                 )
+
+            def _exactly_one_prepared_row_per_source():
+                nonlocal source_rows_seen
+                for item in current_iterator:
+                    source_rows_seen += 1
+                    if source_rows_seen > expected_rows_per_pass:
+                        raise ValueError(
+                            "Unsloth MLX: epoch training requires exactly one "
+                            "trainable text row per declared source row. Use "
+                            "max_steps when the source exceeds its declared length."
+                        )
+                    prepared = _tokenized_rows((item,))
+                    missing = object()
+                    first = next(prepared, missing)
+                    extra = next(prepared, missing)
+                    _close_mlx_owned_iterator(prepared)
+                    if first is missing or extra is not missing:
+                        raise ValueError(
+                            "Unsloth MLX: epoch training requires exactly one "
+                            "trainable text row per declared source row. Use "
+                            "max_steps when rows expand or are filtered."
+                        )
+                    yield first
+
+            row_iterator = (
+                _exactly_one_prepared_row_per_source()
+                if expected_rows_per_pass is not None
+                else _tokenized_rows(current_iterator)
             )
             for row in row_iterator:
                 prepared_rows_seen += 1

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1014,6 +1014,155 @@ def _normalize_cce_label_dtype(labels):
     return labels
 
 
+def _stage_vlm_label_mask_np(inputs, ignore_token_ids=None, labels=None):
+    """Host-side label-mask AUTHORITY for VLM batches: placement only.
+
+    Decides WHICH positions are ignored (ignore tokens, attention zeros, and
+    positions a response/completion mask already set to -100). Label VALUES
+    and dtypes are assembled at finalize time from the SAME converted ids the
+    legacy path used, so coercion parity holds by construction — including
+    legacy's conversion-time rejections. Float comparisons mirror MLX's
+    effective float32 narrowing so placement matches the finalized tensors.
+    """
+    if labels is None:
+        labels = inputs.get(_RAW_INPUT_IDS_FOR_LABELS)
+        if labels is None:
+            labels = inputs["input_ids"]
+    if isinstance(labels, np.ndarray):
+        values = labels
+    elif hasattr(labels, "tolist"):
+        try:
+            values = np.asarray(labels)  # dtype-preserving (torch fp16 etc.)
+        except (TypeError, ValueError):
+            values = np.asarray(labels.tolist())
+    else:
+        values = np.asarray(labels)
+    if values.ndim == 1:
+        values = values.reshape(1, -1)
+    if values.dtype == np.float64:
+        values = values.astype(np.float32)
+    if np.issubdtype(values.dtype, np.integer):
+        # Compare on the SAME normalized representation finalize uses for the
+        # label base (wide unsigned ids become their int64 sentinels first).
+        values = _normalize_numpy_cce_labels(values)
+    mask = values == -100
+    if ignore_token_ids:
+        compare = np.asarray(list(ignore_token_ids))
+        if np.issubdtype(values.dtype, np.floating):
+            compare = compare.astype(values.dtype)  # mirror mx scalar narrowing
+        mask = mask | np.isin(values, compare)
+    attention = inputs.get("attention_mask")
+    if attention is not None:
+        attention_np = (
+            attention if isinstance(attention, np.ndarray)
+            else np.asarray(
+                attention.tolist() if hasattr(attention, "tolist")
+                else attention
+            )
+        )
+        if attention_np.ndim == 1:
+            attention_np = attention_np.reshape(1, -1)
+        if attention_np.dtype == np.float64:
+            attention_np = attention_np.astype(np.float32)
+        mask = mask | (attention_np.astype(np.int32) == 0)
+    return mask
+
+def _reject_mlx_valued_vlm(context):
+    raise ValueError(
+        f"Unsloth MLX VLM: {context} produced MLX-array values; the prefetch "
+        "producer must not convert MLX values off the consumer thread. Use "
+        "streaming_prefetch_batches=0 for this stream."
+    )
+
+
+def _vlm_ids_integer_host(inputs):
+    """True when label-bearing ids are integer host values (the staged case).
+
+    Real processors emit integer token ids; float or exotic-dtype ids (fp16,
+    bf16, float64 probes) route to the bit-exact legacy path instead of a
+    numpy re-implementation of MLX float semantics.
+    """
+    ids = inputs.get(_RAW_INPUT_IDS_FOR_LABELS)
+    if ids is None:
+        ids = inputs.get("input_ids")
+    if isinstance(ids, np.ndarray):
+        return np.issubdtype(ids.dtype, np.integer)
+    if isinstance(ids, (list, tuple)):
+        def _all_integer_leaves(value):
+            if isinstance(value, (list, tuple)):
+                return all(_all_integer_leaves(element) for element in value)
+            return (
+                isinstance(value, (int, np.integer))
+                and not isinstance(value, bool)
+            )
+        return _all_integer_leaves(ids)
+    try:
+        arr = np.asarray(ids)
+    except (TypeError, ValueError):
+        return False
+    return np.issubdtype(arr.dtype, np.integer)
+
+
+def _vlm_inputs_host_valued(inputs):
+    """False when any processor output field arrived as an MLX array."""
+    return not any(_contains_mlx_values(value) for value in inputs.values())
+
+
+class _HostStagedVLMBatch:
+    """Host-side VLM batch: processor fields + decided labels, pre-MLX.
+
+    ``prefinalized`` carries an already-MLX legacy batch for MLX-valued
+    processor outputs (``host_valued=False``) — synchronous mode only; the
+    Stage-6 producer rejects such streams before staging.
+    """
+
+    __slots__ = ("inputs", "label_mask", "widen_labels_int64", "host_valued",
+                 "ignore_token_ids", "config", "prefinalized")
+
+    def __init__(self, inputs, label_mask, host_valued=True,
+                 ignore_token_ids=None, config=None, prefinalized=None,
+                 widen_labels_int64=False):
+        self.inputs = inputs
+        self.label_mask = label_mask
+        self.host_valued = host_valued
+        self.ignore_token_ids = ignore_token_ids
+        self.config = config
+        self.prefinalized = prefinalized
+        self.widen_labels_int64 = widen_labels_int64
+
+
+def _finalize_vlm_batch(staged, keep_raw_carrier=False):
+    """The single consumer-thread point converting staged VLM batches to MLX.
+
+    Conversion and compile preparation only — every semantic label decision
+    already happened host-side (or, for ``prefinalized`` legacy batches, on
+    this same thread inside the collator).
+    """
+    if staged.prefinalized is not None:
+        return _prepare_vlm_batch_for_compile(staged.prefinalized, staged.config)
+    batch = _to_mx_vlm_batch(staged.inputs)
+    if staged.label_mask is not None:
+        # Values ride the SAME converted ids the legacy path used; only the
+        # host-decided placement differs from raw ids. Conversion-time errors
+        # therefore match legacy exactly.
+        raw = (
+            batch.get(_RAW_INPUT_IDS_FOR_LABELS)
+            if keep_raw_carrier
+            else batch.pop(_RAW_INPUT_IDS_FOR_LABELS, None)
+        )
+        base = _normalize_cce_label_dtype(
+            raw if raw is not None else batch["input_ids"]
+        )
+        ignore = mx.array(-100, dtype=base.dtype)
+        labels = mx.where(mx.array(staged.label_mask), ignore, base)
+        if staged.widen_labels_int64:
+            labels = mx.array(
+                np.asarray(labels.tolist(), dtype=np.int64)
+            )  # legacy completion-branch coercion, verbatim
+        batch["labels"] = labels
+    return _prepare_vlm_batch_for_compile(batch, staged.config)
+
+
 def _mask_label_token_ids(targets, ignore_token_ids, ignore_index=-100):
     if not ignore_token_ids:
         return targets
@@ -2401,6 +2550,8 @@ def _contains_mlx_values(value):
         return True
     if isinstance(value, (list, tuple)):
         return any(_contains_mlx_values(element) for element in value)
+    if isinstance(value, Mapping):
+        return any(_contains_mlx_values(element) for element in value.values())
     return False
 
 
@@ -4164,6 +4315,7 @@ def _collate_vlm_prompt_completion_batch(
     image_size,
     ignore_token_ids=None,
     completion_only_loss=None,
+    reject_mlx_valued=False,
 ):
     prompt_texts = []
     completion_texts = []
@@ -4227,6 +4379,12 @@ def _collate_vlm_prompt_completion_batch(
         padding_side="right",
     )
 
+    pc_host_valued = (
+        _vlm_inputs_host_valued(prompt_inputs)
+        and _vlm_inputs_host_valued(completion_inputs)
+    )
+    if not pc_host_valued and reject_mlx_valued:
+        _reject_mlx_valued_vlm("the processor")
     p_ids = _as_numpy_vlm_field(prompt_inputs, "input_ids")
     c_ids = _as_numpy_vlm_field(completion_inputs, "input_ids")
     p_mask = _as_numpy_vlm_field(prompt_inputs, "attention_mask")
@@ -4256,21 +4414,41 @@ def _collate_vlm_prompt_completion_batch(
     combined_inputs["attention_mask"] = attention_mask
     if token_type_key is not None:
         combined_inputs[token_type_key] = extras[token_type_key]
+    completion_only_loss_enabled = (
+        True if completion_only_loss is None else bool(completion_only_loss)
+    )
+    if pc_host_valued and _vlm_ids_integer_host(combined_inputs):
+        label_mask = _stage_vlm_label_mask_np(
+            combined_inputs, ignore_token_ids=ignore_token_ids,
+        )
+        if completion_only_loss_enabled:
+            label_mask = label_mask | (
+                np.asarray(extras["completion_mask"]) == 0
+            )
+        return _HostStagedVLMBatch(
+            combined_inputs, label_mask, ignore_token_ids=ignore_token_ids,
+            widen_labels_int64=completion_only_loss_enabled,
+        )
+    if reject_mlx_valued:
+        # Non-stageable producer batches (float/exotic ids) must never reach
+        # MLX conversion off the consumer thread.
+        _reject_mlx_valued_vlm("the processor")
     batch = _to_mx_vlm_batch(combined_inputs)
     batch["labels"] = _apply_vlm_label_masks(
-        batch,
-        ignore_token_ids=ignore_token_ids,
+        batch, ignore_token_ids=ignore_token_ids,
     )
-
-    completion_only_loss_enabled = True if completion_only_loss is None else bool(completion_only_loss)
     if completion_only_loss_enabled:
-        labels_np = np.asarray(batch["labels"].tolist(), dtype=np.int64)
-        labels_np[np.asarray(extras["completion_mask"]) == 0] = -100
-        batch["labels"] = mx.array(labels_np)
-    return batch
+        legacy_np = np.asarray(batch["labels"].tolist(), dtype=np.int64)
+        legacy_np[np.asarray(extras["completion_mask"]) == 0] = -100
+        batch["labels"] = mx.array(legacy_np)
+    return _HostStagedVLMBatch(
+        None, None, host_valued=False,
+        ignore_token_ids=ignore_token_ids, prefinalized=batch,
+    )
 
 
 def _collate_vlm_batch(items, processor, max_seq_length, image_size,
+                       reject_mlx_valued=False,
                        formatting_func=None, ignore_token_ids=None,
                        completion_only_loss=None,
                        return_prompt_completion=False):
@@ -4281,10 +4459,17 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
     tokenization + image processing + padding.
     """
     normalize_vlm_processor_chat_template(processor, strict=False)
+    if reject_mlx_valued and any(_contains_mlx_values(item) for item in items):
+        # Source rows carrying MLX arrays (e.g. mx image tensors) must reject
+        # before formatting or the processor touches them off-thread.
+        _reject_mlx_valued_vlm("the dataset row")
     formatted_items = []
     for item in items:
         if formatting_func is not None:
             item = formatting_func(item)
+            if reject_mlx_valued and _contains_mlx_values(item):
+                # Formatters can introduce MLX values after the row-level scan.
+                _reject_mlx_valued_vlm("the formatting function")
         formatted_items.append(item)
 
     if (
@@ -4297,6 +4482,7 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
             formatted_items, processor, max_seq_length, image_size,
             ignore_token_ids=ignore_token_ids,
             completion_only_loss=completion_only_loss,
+            reject_mlx_valued=reject_mlx_valued,
         )
         return (batch, True) if return_prompt_completion else batch
 
@@ -4326,12 +4512,27 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         processor, all_texts, all_images, max_seq_length,
         suffixes=all_suffixes,
     )
-    batch = _to_mx_vlm_batch(inputs)
-    batch["labels"] = _apply_vlm_label_masks(
-        batch,
-        ignore_token_ids=ignore_token_ids,
-    )
-    return (batch, False) if return_prompt_completion else batch
+    if _vlm_inputs_host_valued(inputs) and _vlm_ids_integer_host(inputs):
+        label_mask = _stage_vlm_label_mask_np(
+            inputs, ignore_token_ids=ignore_token_ids,
+        )
+        staged = _HostStagedVLMBatch(
+            inputs, label_mask, ignore_token_ids=ignore_token_ids,
+        )
+    elif reject_mlx_valued:
+        _reject_mlx_valued_vlm("the processor")
+    else:
+        # MLX-valued processor outputs: legacy synchronous label path, wrapped
+        # so the single finalizer stays the only exit to the trainer.
+        batch = _to_mx_vlm_batch(inputs)
+        batch["labels"] = _apply_vlm_label_masks(
+            batch, ignore_token_ids=ignore_token_ids,
+        )
+        staged = _HostStagedVLMBatch(
+            None, None, host_valued=False,
+            ignore_token_ids=ignore_token_ids, prefinalized=batch,
+        )
+    return (staged, False) if return_prompt_completion else staged
 
 
 def _apply_response_mask_to_vlm_batch(batch_dict, mask_fn, ignore_token_ids=None):
@@ -4375,6 +4576,14 @@ def _apply_response_mask_to_vlm_batch(batch_dict, mask_fn, ignore_token_ids=None
 
 def _vlm_trainable_label_rows(batch_dict):
     """Return per-row trainability from VLM labels after response masking."""
+    if isinstance(batch_dict, _HostStagedVLMBatch):
+        if batch_dict.prefinalized is not None:
+            return _vlm_trainable_label_rows(batch_dict.prefinalized)
+        mask = batch_dict.label_mask
+        if mask is None:
+            return None
+        mask_np = mask if mask.ndim > 1 else mask.reshape(1, -1)
+        return [bool(np.any(~row[1:])) for row in mask_np]
     labels = batch_dict.get("labels")
     if labels is None:
         return None
@@ -4396,22 +4605,51 @@ def _build_response_masked_vlm_batch(
     ignore_token_ids=None,
     completion_only_loss=None,
     return_prompt_completion=False,
+    yield_host_staged=False,
+    reject_mlx_valued=False,
 ):
-    """Collate VLM rows and apply the CUDA response-mask closure."""
-    batch_dict, is_prompt_completion = _collate_vlm_batch(
+    """Collate VLM rows and apply the CUDA response-mask closure.
+
+    Plain-SFT and prompt/completion streams stage host-side and exit through
+    the single ``_finalize_vlm_batch`` call (``yield_host_staged`` defers it
+    for the prefetch producer). Response-masked streams run the verbatim
+    legacy consumer-side order and are rejected in producer modes.
+    """
+    staged, is_prompt_completion = _collate_vlm_batch(
         items, processor, max_seq_length, image_size,
+        reject_mlx_valued=reject_mlx_valued,
         formatting_func=formatting_func,
         ignore_token_ids=ignore_token_ids,
         completion_only_loss=completion_only_loss,
         return_prompt_completion=True,
     )
-    batch_dict = _prepare_vlm_batch_for_compile(batch_dict, config)
+    staged.config = config
     if response_mask_fn is not None and not is_prompt_completion:
+        # Closure semantics are DEFINED on the converted, compile-prepared
+        # tensors (image-token expansion shifts positions), so response
+        # masking is consumer-side by nature and runs the verbatim legacy
+        # order. Producer-destined staging therefore cannot cover it.
+        if yield_host_staged:
+            raise ValueError(
+                "Unsloth MLX VLM: train_on_responses_only streams are not "
+                "covered by the prefetch producer yet; use "
+                "streaming_prefetch_batches=0 for response-masked VLM "
+                "streams."
+            )
+        batch_dict = _finalize_vlm_batch(staged, keep_raw_carrier=True)
         batch_dict = _apply_response_mask_to_vlm_batch(
             batch_dict,
             response_mask_fn,
             ignore_token_ids=ignore_token_ids,
         )
+        if return_prompt_completion:
+            return batch_dict, is_prompt_completion
+        return batch_dict
+    if yield_host_staged:
+        if return_prompt_completion:
+            return staged, is_prompt_completion
+        return staged
+    batch_dict = _finalize_vlm_batch(staged)
     if return_prompt_completion:
         return batch_dict, is_prompt_completion
     return batch_dict
@@ -4638,7 +4876,8 @@ def _iterate_lazy_vlm_training_batches(
     response_mask_fn=None, formatting_func=None, dataset_order="default",
     completion_only_loss=None, image_size=None, comm_group=None,
     require_replayable=False, expected_rows_per_pass=None,
-    ignore_token_ids=None,
+    ignore_token_ids=None, yield_host_staged=False, reject_mlx_valued=False,
+    should_stop=None,
 ):
     """Unsized VLM batches under the lazy text-stream lifecycle contracts.
 
@@ -4647,6 +4886,13 @@ def _iterate_lazy_vlm_training_batches(
     tensors is a planned follow-up. Per-row trainability filtering, label
     masking, and collation reuse the sized-path helpers unchanged.
     """
+    if (yield_host_staged or reject_mlx_valued) and response_mask_fn is not None:
+        # Zero-touch rejection: no set_epoch, no iterator, no source pull.
+        raise ValueError(
+            "Unsloth MLX VLM: train_on_responses_only streams are not "
+            "covered by the prefetch producer yet; use "
+            "streaming_prefetch_batches=0 for response-masked VLM streams."
+        )
     if _distributed_rank_size(comm_group)[1] > 1:
         raise ValueError(
             "Unsloth MLX VLM: DDP training with an unsized streaming VLM "
@@ -4670,12 +4916,26 @@ def _iterate_lazy_vlm_training_batches(
             formatting_func=batch_formatting_func,
             ignore_token_ids=ignore_token_ids,
             completion_only_loss=completion_only_loss,
+            yield_host_staged=yield_host_staged,
+            reject_mlx_valued=reject_mlx_valued,
         )
 
     def _filter_stream_item(item):
-        """Return a formatted trainable streaming row, or None to skip it."""
+        """Return a formatted trainable streaming row, or None to skip it.
+
+        Synchronous response-masked filtering finalizes and runs the legacy
+        closure (consumer thread); producer modes reject before reaching here.
+        """
         if response_mask_fn is None:
             return item
+        if yield_host_staged or reject_mlx_valued:
+            # Producer-destined streams cannot run the consumer-side closure.
+            raise ValueError(
+                "Unsloth MLX VLM: train_on_responses_only streams are not "
+                "covered by the prefetch producer yet; use "
+                "streaming_prefetch_batches=0 for response-masked VLM "
+                "streams."
+            )
         if formatting_func is not None:
             item = formatting_func(item)
         batch_dict, is_prompt_completion = _build_response_masked_vlm_batch(
@@ -4731,7 +4991,16 @@ def _iterate_lazy_vlm_training_batches(
             yielded = False
             source_rows_seen = 0
             prepared_rows_seen = 0
-            for item in current_iterator:
+            source_iter = iter(current_iterator)
+            while True:
+                if should_stop is not None and should_stop():
+                    return
+                try:
+                    item = next(source_iter)
+                except StopIteration:
+                    break
+                if should_stop is not None and should_stop():
+                    return  # stop arrived during the blocking pull
                 source_rows_seen += 1
                 item = _filter_stream_item(item)
                 if item is None:
@@ -4766,6 +5035,8 @@ def _iterate_lazy_vlm_training_batches(
                 yield _build_batch(pending, batch_formatting_func)
                 pending = []
 
+            if should_stop is not None and should_stop():
+                return  # skip pass-end validation and flush on cooperative stop
             if expected_rows_per_pass is not None and (
                 source_rows_seen != expected_rows_per_pass
                 or prepared_rows_seen != expected_rows_per_pass

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2609,6 +2609,14 @@ def _materialize_mlx_values(*trees):
         mx.eval(*arrays)
 
 
+def _reject_mlx_valued_text(context):
+    raise ValueError(
+        f"Unsloth MLX text: {context} carried MLX-array values; the prefetch "
+        "producer must not convert MLX values off the consumer thread. Use "
+        "streaming_prefetch_batches=0 for this stream."
+    )
+
+
 def _guard_host_token_output(value, state, context):
     """Record/reject an MLX-valued tokenizer or template output pre-conversion."""
     if state is not None and _contains_mlx_values(value):
@@ -6072,6 +6080,7 @@ def _iter_lazy_tokenized_text_rows(
 ):
     """Normalize an unsized source one row at a time and lock its schema."""
     state = {} if state is None else state
+    reject_rows = bool(state.get("reject_mlx_valued"))
     eos_id = getattr(tokenizer, "eos_token_id", None) if append_eos else None
     saw_usable_this_pass = False
     completion_labels_seen_this_pass = False
@@ -6157,6 +6166,10 @@ def _iter_lazy_tokenized_text_rows(
         return () if label_owned else None
 
     for item in dataset:
+        if reject_rows and _contains_mlx_values(item):
+            # Rows carrying MLX arrays must reject before any parsing,
+            # truthiness probe, or formatter call can touch them off-thread.
+            _reject_mlx_valued_text("the dataset row")
         item_has_completion_boundary = (
             isinstance(item, Mapping)
             and "prompt" in item
@@ -6188,6 +6201,9 @@ def _iter_lazy_tokenized_text_rows(
             state["assistant_source_checked"] = True
         if formatting_func is not None and not source_has_input_ids:
             formatted = formatting_func(item)
+            if reject_rows and _contains_mlx_values(formatted):
+                # Formatters can introduce MLX values after the row scan.
+                _reject_mlx_valued_text("the formatting function")
             formatter_applied = True
             formatter_needs_completion_boundary = (
                 completion_only_loss is None

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1141,6 +1141,16 @@ def _finalize_vlm_batch(staged, keep_raw_carrier=False):
     if staged.prefinalized is not None:
         return _prepare_vlm_batch_for_compile(staged.prefinalized, staged.config)
     batch = _to_mx_vlm_batch(staged.inputs)
+    if staged.label_mask is None:
+        # Opaque processor outputs (the processor itself returned MLX arrays,
+        # e.g. mlx-vlm wrappers): label semantics run the legacy path here on
+        # the consumer thread. No Unsloth-issued MLX op touched the payload
+        # producer-side — it was carried through untouched.
+        batch["labels"] = _apply_vlm_label_masks(
+            batch, ignore_token_ids=staged.ignore_token_ids,
+        )
+        batch.pop(_RAW_INPUT_IDS_FOR_LABELS, None)
+        return _prepare_vlm_batch_for_compile(batch, staged.config)
     if staged.label_mask is not None:
         # Values ride the SAME converted ids the legacy path used; only the
         # host-decided placement differs from raw ids. Conversion-time errors
@@ -4519,7 +4529,17 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         staged = _HostStagedVLMBatch(
             inputs, label_mask, ignore_token_ids=ignore_token_ids,
         )
+    elif reject_mlx_valued and not _vlm_inputs_host_valued(inputs):
+        # The PROCESSOR itself emitted MLX arrays (mlx-vlm wrappers do this
+        # regardless of return_tensors): carry them through untouched and
+        # decide labels at finalize. Producer-side unsloth MLX ops: none.
+        staged = _HostStagedVLMBatch(
+            inputs, None, host_valued=False,
+            ignore_token_ids=ignore_token_ids,
+        )
     elif reject_mlx_valued:
+        # Host-valued but non-integer ids: legacy conversion would run
+        # producer-side, so reject with the synchronous remedy.
         _reject_mlx_valued_vlm("the processor")
     else:
         # MLX-valued processor outputs: legacy synchronous label path, wrapped

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6539,8 +6539,8 @@ class _LazyTextPrefetcher:
         self._thread = None
         self.orphaned = False
         self._closed = False
-        self._close_finished = threading.Event()
         self._lifecycle_lock = threading.Lock()
+        self._close_lock = threading.Lock()
 
     # -- producer side ----------------------------------------------------
     def _run(self):
@@ -6660,30 +6660,50 @@ class _LazyTextPrefetcher:
         self._pause.clear()
 
     def close(self):
-        """Terminal and idempotent: only the first call pays the bounded join."""
+        """Join the producer, then release any queued batches once it is
+        confirmed dead. Terminal, idempotent, and safe under concurrent
+        callers. Returns True when the producer terminated (queue drained),
+        False when it overran the join and is a live orphan.
+
+        The join, classification, and drain run under one lock, and the return
+        reflects this caller's own post-join observation — so a True return
+        guarantees the queue was drained under that lock before it was reported,
+        and no concurrent closer can observe it half-drained. ``orphaned`` is
+        set conservatively before the join, so an interrupted join leaves a live
+        producer classified as an orphan rather than falsely clean."""
+        # Mark a conservative orphan up front: if anything below is interrupted
+        # (a signal during lock acquisition, the join, or the drain), the
+        # producer is already recorded as unresolved rather than left falsely
+        # clean. A clean termination clears it below.
+        self.orphaned = True
         with self._lifecycle_lock:
             self._stop.set()
             self._pause.clear()
-            first_close = not self._closed
             self._closed = True
             thread = self._thread
-        if not first_close:
-            # Wait for the first closer's join to settle so a concurrent
-            # second close never reports clean while the producer still runs.
-            settled = self._close_finished.wait(timeout=self._JOIN_TIMEOUT + 1.0)
-            if not settled and self._thread is not None and self._thread.is_alive():
-                self.orphaned = True  # conservative: unsettled + alive = orphan
-            return not self.orphan_alive()
-        try:
+        with self._close_lock:
             if thread is not None and thread.is_alive():
                 thread.join(timeout=self._JOIN_TIMEOUT)
-        finally:
-            # Conservative: classify any still-live thread as orphaned before
-            # publishing settlement, including interrupted joins.
-            if thread is not None and thread.is_alive():
-                self.orphaned = True
-            self._close_finished.set()
-        return not self.orphaned
+            terminated = thread is None or not thread.is_alive()
+            if terminated:
+                # A joined-dead thread has published its final enqueue and will
+                # never write again, so draining here cannot lose a batch. Clear
+                # the orphan flag only AFTER the drain completes: a signal during
+                # the drain then still leaves a conservative orphan (flag set,
+                # queue not yet empty) for the caller's finally to persist.
+                self._drain_envelopes()
+                self.orphaned = False
+            return terminated
+
+    def _drain_envelopes(self):
+        """Discard queued batches so their payloads (device tensors for opaque
+        VLM outputs) are released instead of retained until the consumer
+        generator is collected — a terminal close is followed by a save."""
+        while True:
+            try:
+                self._envelopes.get_nowait()
+            except _queue_module.Empty:
+                return
 
     def orphan_alive(self):
         return self.orphaned and self._thread is not None and self._thread.is_alive()

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -36,7 +36,7 @@ import shutil
 import tempfile
 import threading
 import warnings
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 
 
@@ -3363,6 +3363,20 @@ def _ensure_reiterable_text_dataset(dataset):
     return list(dataset)
 
 
+def _is_mlx_lazy_text_source(dataset):
+    """Return whether streaming text must avoid map-style source operations."""
+    if isinstance(dataset, Sequence):
+        return False
+    if isinstance(dataset, Iterator):
+        return True
+    return any("__iter__" in cls.__dict__ for cls in type(dataset).__mro__)
+
+
+def _is_mlx_replayable_text_source(dataset):
+    """Return whether a source can create a fresh iterator for another pass."""
+    return not isinstance(dataset, Iterator)
+
+
 def _labeled_row_has_supervision(labels, max_seq_length):
     # Keep rows with a supervised token in labels[1:max_seq_length] (causal shift,
     # length-capped); an all-masked batch aborts training. labels=None always kept.
@@ -5161,6 +5175,211 @@ def _iter_tokenized_text_rows(dataset, tokenizer, dataset_text_field="text",
                 yield (ids, 0)
 
 
+def _iter_lazy_tokenized_text_rows(
+    dataset,
+    tokenizer,
+    *,
+    dataset_text_field="text",
+    formatting_func=None,
+    append_eos=True,
+    completion_only_loss=None,
+    assistant_only_loss=False,
+    max_seq_length=None,
+    state=None,
+):
+    """Normalize an unsized source one row at a time and lock its schema."""
+    state = {} if state is None else state
+    eos_id = getattr(tokenizer, "eos_token_id", None) if append_eos else None
+
+    def _validate_state(kind, labels):
+        if state.get("schema") is None:
+            state["schema"] = kind
+        elif state["schema"] != kind:
+            raise ValueError(
+                "Unsloth MLX: pretokenized text rows with 'input_ids' cannot "
+                "be mixed with rows that need text formatting/tokenization."
+            )
+        has_labels = labels is not None
+        if state.get("label_state") is None:
+            state["label_state"] = has_labels
+        elif state["label_state"] != has_labels:
+            raise ValueError(
+                "Unsloth MLX: streaming text rows with labels or masks must "
+                "not be mixed with rows that do not provide labels."
+            )
+
+    for item in dataset:
+        source_rows = item if (
+            isinstance(item, list) and not _looks_like_mlx_chat_messages(item)
+        ) else [item]
+        if not any(
+            isinstance(row, Mapping) and "input_ids" in row
+            for row in source_rows
+        ) and formatting_func is not None:
+            formatted = formatting_func(item)
+            source_rows = formatted if (
+                isinstance(formatted, list)
+                and not _looks_like_mlx_chat_messages(formatted)
+            ) else [formatted]
+
+        for row in source_rows:
+            tokenized = _tokenize_mlx_pretokenized_row(
+                row,
+                completion_only_loss=completion_only_loss,
+                assistant_only_loss=assistant_only_loss,
+            )
+            if tokenized is not None:
+                ids, labels = tokenized
+                _validate_state("pretokenized", labels)
+                if max_seq_length is not None:
+                    ids = ids[:max_seq_length]
+                    labels = (
+                        labels[:max_seq_length] if labels is not None else None
+                    )
+                if len(ids) >= 2 and _labeled_row_has_supervision(
+                    labels, len(ids)
+                ):
+                    yield ids, labels
+                continue
+
+            labeled = None
+            if completion_only_loss is not False or assistant_only_loss:
+                labeled = _tokenize_mlx_prompt_completion_row(
+                    tokenizer,
+                    row,
+                    dataset_text_field=dataset_text_field,
+                    append_eos=append_eos,
+                    completion_only_loss=completion_only_loss,
+                    assistant_only_loss=assistant_only_loss,
+                )
+                if labeled is None and assistant_only_loss:
+                    labeled = _tokenize_mlx_assistant_messages_row(tokenizer, row)
+            if labeled is not None:
+                ids, labels = labeled
+                _validate_state("raw", labels)
+                if max_seq_length is not None:
+                    ids = ids[:max_seq_length]
+                    labels = labels[:max_seq_length]
+                if len(ids) >= 2 and _labeled_row_has_supervision(
+                    labels, len(ids)
+                ):
+                    yield ids, labels
+                continue
+            if assistant_only_loss:
+                raise ValueError(
+                    "You set `assistant_only_loss=True`, but the dataset is not "
+                    "conversational. This option is only supported for "
+                    "conversational datasets."
+                )
+            if completion_only_loss is True:
+                raise ValueError(
+                    "Unsloth MLX: text completion_only_loss=True requires "
+                    "prompt/completion rows for streaming text training."
+                )
+
+            for text in collect_mlx_texts(
+                tokenizer,
+                row,
+                dataset_text_field=dataset_text_field,
+                is_vlm=False,
+            ):
+                ids = list(encode_mlx_text(tokenizer, text))
+                if eos_id is not None and (not ids or ids[-1] != eos_id):
+                    ids.append(int(eos_id))
+                if max_seq_length is not None:
+                    ids = ids[:max_seq_length]
+                _validate_state("raw", None)
+                if len(ids) >= 2:
+                    yield ids, None
+
+
+def _iterate_lazy_text_training_batches(
+    dataset,
+    tokenizer,
+    batch_size,
+    max_seq_length,
+    *,
+    dataset_text_field="text",
+    formatting_func=None,
+    dataset_order="default",
+    append_eos=True,
+    completion_only_loss=None,
+    assistant_only_loss=False,
+    comm_group=None,
+):
+    """Yield source-ordered text batches without probing an unsized source."""
+    if dataset_order == "torch_randperm":
+        raise ValueError(
+            "Unsloth MLX: dataset_order='torch_randperm' is not supported for "
+            "an unsized streaming text source."
+        )
+    if dataset_order not in (None, "default", "sequential"):
+        raise ValueError(f"Unsupported MLX dataset_order: {dataset_order!r}")
+
+    global_batch_size = _distributed_global_batch_size(batch_size, comm_group)
+    replayable = _is_mlx_replayable_text_source(dataset)
+    state = {}
+    epoch = 0
+    while True:
+        set_epoch = getattr(dataset, "set_epoch", None)
+        if replayable and callable(set_epoch):
+            set_epoch(epoch)
+
+        pending = []
+        yielded = False
+        for row in _iter_lazy_tokenized_text_rows(
+            dataset,
+            tokenizer,
+            dataset_text_field=dataset_text_field,
+            formatting_func=formatting_func,
+            append_eos=append_eos,
+            completion_only_loss=completion_only_loss,
+            assistant_only_loss=assistant_only_loss,
+            max_seq_length=max_seq_length,
+            state=state,
+        ):
+            pending.append(row)
+            if len(pending) < global_batch_size:
+                continue
+            local_items = _rank_slice_distributed_batch(
+                pending,
+                batch_size,
+                comm_group=comm_group,
+                pad_source=pending,
+            )
+            yielded = True
+            yield _create_tokenized_text_batch(
+                local_items,
+                max_seq_length,
+                pad_id=_mlx_text_pad_id(tokenizer),
+            )
+            pending = []
+
+        if pending:
+            local_items = _rank_slice_distributed_batch(
+                pending,
+                batch_size,
+                comm_group=comm_group,
+                pad_source=pending,
+            )
+            yielded = True
+            yield _create_tokenized_text_batch(
+                local_items,
+                max_seq_length,
+                pad_id=_mlx_text_pad_id(tokenizer),
+            )
+        if not yielded:
+            raise ValueError(
+                "Unsloth MLX: streaming text source produced no trainable rows."
+            )
+        if not replayable:
+            raise RuntimeError(
+                "Unsloth MLX: one-shot streaming text source is exhausted and "
+                "cannot be replayed. Use a replayable iterable or reduce max_steps."
+            )
+        epoch += 1
+
+
 def _iterate_ordered_text_training_batches(dataset, tokenizer, batch_size,
                                            max_seq_length, seed=42,
                                            dataset_text_field="text",
@@ -5290,6 +5509,30 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
         ``labels`` is ``None`` unless text prompt/completion masking is active.
     """
     from mlx_lm.tuner.trainer import iterate_batches
+
+    if _is_mlx_lazy_text_source(dataset):
+        tokenizer = normalize_mlx_chat_template(
+            tokenizer,
+            chat_template=chat_template,
+            model_name=model_name,
+            model_type=model_type,
+            is_vlm=False,
+            strict=False,
+        )
+        yield from _iterate_lazy_text_training_batches(
+            dataset,
+            tokenizer,
+            batch_size,
+            max_seq_length,
+            dataset_text_field=dataset_text_field,
+            formatting_func=formatting_func,
+            dataset_order=dataset_order,
+            append_eos=append_eos,
+            completion_only_loss=completion_only_loss,
+            assistant_only_loss=assistant_only_loss,
+            comm_group=comm_group,
+        )
+        return
 
     dataset = _ensure_reiterable_text_dataset(dataset)
     tokenized, saw_pretokenized = _prepare_pretokenized_text_dataset(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6162,11 +6162,15 @@ def _iter_lazy_tokenized_text_rows(
     def _resolve_completion_mode(item_has_boundary, row_has_boundary=False):
         if completion_only_loss is not None:
             return completion_only_loss
-        if "pretokenized_completion_only_loss" in state:
-            return state["pretokenized_completion_only_loss"]
         if item_has_boundary or row_has_boundary:
+            # A prompt/completion row always resolves the default mask mode
+            # from its own shape; inheriting a plain-text row's False here
+            # would silently train prompt tokens, and ordering would decide.
+            # The schema/label validators then reject mixed streams.
             state["pretokenized_completion_only_loss"] = True
             return True
+        if "pretokenized_completion_only_loss" in state:
+            return state["pretokenized_completion_only_loss"]
         return False
 
     def _filtered_label_observation(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3394,12 +3394,14 @@ def _is_mlx_lazy_text_source(dataset):
 
 
 def _is_mlx_hf_iterable_text_source(dataset):
-    """Return whether Hugging Face defines this source as replayable."""
-    try:
-        from datasets import IterableDataset as HFIterableDataset
-    except ImportError:
-        return False
-    return isinstance(dataset, HFIterableDataset)
+    """Return whether Hugging Face defines this source as replayable.
+
+    Detected through ``sys.modules`` so classification never imports
+    ``datasets``: if the package was never imported, no instance can exist.
+    """
+    hf_datasets = sys.modules.get("datasets")
+    hf_iterable = getattr(hf_datasets, "IterableDataset", None)
+    return hf_iterable is not None and isinstance(dataset, hf_iterable)
 
 
 def _mlx_lazy_text_source(dataset):
@@ -4369,6 +4371,14 @@ def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
     """
     import numpy as np
 
+    if not _vlm_has_sized_index_space(dataset):
+        raise ValueError(
+            "Unsloth MLX VLM: this path requires a sized dataset exposing "
+            "__len__ and __getitem__. Unsized/streaming VLM sources are only "
+            "supported for training with streaming=True; unsized VLM "
+            "evaluation is a planned follow-up."
+        )
+
     image_size = _resolve_vlm_image_size(image_size, config, processor)
     ignore_token_ids = _get_vlm_ignore_token_ids(processor=processor, config=config)
 
@@ -4492,13 +4502,239 @@ def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
     return batch_list
 
 
+
+def _vlm_has_sized_index_space(dataset):
+    """True when the VLM batcher can index the dataset (`__len__` + `__getitem__`).
+
+    Both protocols must be declared on the TYPE (instance `__getattr__` proxies
+    do not make an object subscriptable), and known iterable-only bases are
+    excluded even when they inherit a raising `__getitem__` (torch
+    `IterableDataset`) or declare stream topology (HF iterables). Everything
+    else streams lazily; the sized path's permutations and response-mask
+    pre-scan require real indexing.
+    """
+    cls = type(dataset)
+    if not callable(getattr(cls, "__len__", None)):
+        return False
+    if not callable(getattr(cls, "__getitem__", None)):
+        return False
+    if _is_mlx_hf_iterable_text_source(dataset):
+        return False
+    torch_data = sys.modules.get("torch.utils.data")
+    torch_iterable = getattr(torch_data, "IterableDataset", None)
+    if torch_iterable is not None and isinstance(dataset, torch_iterable):
+        return False
+    return True
+
+
+def _iterate_lazy_vlm_training_batches(
+    dataset, processor, config, batch_size, max_seq_length, *,
+    response_mask_fn=None, formatting_func=None, dataset_order="default",
+    completion_only_loss=None, image_size=None, comm_group=None,
+    require_replayable=False, expected_rows_per_pass=None,
+    ignore_token_ids=None,
+):
+    """Unsized VLM batches under the lazy text-stream lifecycle contracts.
+
+    Single-process only: the previous every-rank consumption of the global
+    stream is intentionally removed, and rank-owned dispatch of ragged VLM
+    tensors is a planned follow-up. Per-row trainability filtering, label
+    masking, and collation reuse the sized-path helpers unchanged.
+    """
+    if _distributed_rank_size(comm_group)[1] > 1:
+        raise ValueError(
+            "Unsloth MLX VLM: DDP training with an unsized streaming VLM "
+            "source is not supported (every rank would re-consume the global "
+            "stream). Use a sized dataset or single-process training; "
+            "rank-owned lazy VLM dispatch is a planned follow-up."
+        )
+    if dataset_order == "torch_randperm":
+        raise ValueError(
+            "Unsloth MLX VLM: preserve_dataset_order / "
+            "dataset_order='torch_randperm' requires a sized "
+            "(`__len__`) dataset."
+        )
+    if dataset_order not in (None, "default", "sequential"):
+        raise ValueError(f"Unsupported MLX VLM dataset_order: {dataset_order!r}")
+
+    def _build_batch(items, batch_formatting_func):
+        return _build_response_masked_vlm_batch(
+            items, processor, config, max_seq_length, image_size,
+            response_mask_fn=response_mask_fn,
+            formatting_func=batch_formatting_func,
+            ignore_token_ids=ignore_token_ids,
+            completion_only_loss=completion_only_loss,
+        )
+
+    def _filter_stream_item(item):
+        """Return a formatted trainable streaming row, or None to skip it."""
+        if response_mask_fn is None:
+            return item
+        if formatting_func is not None:
+            item = formatting_func(item)
+        batch_dict, is_prompt_completion = _build_response_masked_vlm_batch(
+            [item], processor, config, max_seq_length, image_size,
+            response_mask_fn=response_mask_fn,
+            formatting_func=None,
+            ignore_token_ids=ignore_token_ids,
+            completion_only_loss=completion_only_loss,
+            return_prompt_completion=True,
+        )
+        if is_prompt_completion:
+            return item
+        valid_rows = _vlm_trainable_label_rows(batch_dict)
+        if valid_rows is not None and len(valid_rows) == 1 and not valid_rows[0]:
+            return None
+        return item
+
+    batch_formatting_func = None if response_mask_fn is not None else formatting_func
+    source_dataset = _mlx_lazy_text_source(dataset)
+    set_epoch = getattr(source_dataset, "set_epoch", None)
+
+    def _set_epoch(value):
+        if callable(set_epoch):
+            set_epoch(value)
+
+    def _resume_replay_error():
+        return RuntimeError(
+            "Unsloth MLX VLM: this operation requires a replayable iterable "
+            "source; a one-shot iterator cannot be replayed deterministically."
+        )
+
+    def _exhaustion_error():
+        return RuntimeError(
+            "Unsloth MLX VLM: one-shot streaming source is exhausted and "
+            "cannot be replayed. Use a replayable iterable or reduce max_steps."
+        )
+
+    if require_replayable and isinstance(source_dataset, Iterator):
+        raise _resume_replay_error()
+
+    _set_epoch(0)
+    current_iterator = iter(source_dataset)
+    cached_next_iterator = None
+    epoch = 0
+    try:
+        replayable, cached_next_iterator = _probe_lazy_replayability(
+            source_dataset, current_iterator, set_epoch,
+            require_replayable, _resume_replay_error,
+        )
+        while True:
+            pending = []
+            deferred_final = None
+            yielded = False
+            source_rows_seen = 0
+            prepared_rows_seen = 0
+            for item in current_iterator:
+                source_rows_seen += 1
+                item = _filter_stream_item(item)
+                if item is None:
+                    if expected_rows_per_pass is not None:
+                        raise ValueError(
+                            "Unsloth MLX VLM: epoch training requires exactly "
+                            "one trainable row per declared source row. Use "
+                            "max_steps when rows are filtered."
+                        )
+                    continue
+                prepared_rows_seen += 1
+                if (
+                    expected_rows_per_pass is not None
+                    and source_rows_seen > expected_rows_per_pass
+                ):
+                    raise ValueError(
+                        "Unsloth MLX VLM: the streaming source's declared "
+                        "length does not match one trainable row per source "
+                        "row. Use max_steps for filtered or expanding streams."
+                    )
+                pending.append(item)
+                if len(pending) < batch_size:
+                    continue
+                if (
+                    expected_rows_per_pass is not None
+                    and prepared_rows_seen == expected_rows_per_pass
+                ):
+                    deferred_final = pending
+                    pending = []
+                    continue
+                yielded = True
+                yield _build_batch(pending, batch_formatting_func)
+                pending = []
+
+            if expected_rows_per_pass is not None and (
+                source_rows_seen != expected_rows_per_pass
+                or prepared_rows_seen != expected_rows_per_pass
+            ):
+                raise ValueError(
+                    "Unsloth MLX VLM: the streaming source's declared length "
+                    "does not match one trainable row per source row. Use "
+                    "max_steps for filtered or expanding streams."
+                )
+            if deferred_final is not None:
+                yielded = True
+                yield _build_batch(deferred_final, batch_formatting_func)
+                deferred_final = None
+            if pending:
+                yielded = True
+                yield _build_batch(pending, batch_formatting_func)
+                pending = []
+
+            exhausted_iterator = current_iterator
+            current_iterator = None
+            _close_mlx_owned_iterator(exhausted_iterator)
+            if not yielded:
+                raise ValueError(
+                    "Unsloth MLX VLM: streaming dataset produced no trainable rows."
+                )
+            if replayable is False:
+                raise _exhaustion_error()
+            epoch += 1
+            _set_epoch(epoch)
+            if cached_next_iterator is not None:
+                current_iterator = cached_next_iterator
+                cached_next_iterator = None
+                del exhausted_iterator
+                continue
+            try:
+                candidate = iter(source_dataset)
+            except Exception as exc:
+                if replayable is True:
+                    raise RuntimeError(
+                        "Unsloth MLX VLM: replayable streaming source failed "
+                        f"to create an iterator for epoch {epoch}: {exc}"
+                    ) from exc
+                raise _exhaustion_error() from exc
+            if candidate is exhausted_iterator:
+                raise _exhaustion_error()
+            current_iterator = candidate
+            replayable = True
+            del exhausted_iterator
+    finally:
+        active_iterator = current_iterator
+        current_iterator = None
+        replay_iterator = cached_next_iterator
+        cached_next_iterator = None
+        cleanup_iterators = (
+            (active_iterator,)
+            if replay_iterator is active_iterator
+            else (active_iterator, replay_iterator)
+        )
+        # A processor/cardinality error may already be unwinding; attempt every
+        # owned cursor without replacing that primary failure.
+        for iterator in cleanup_iterators:
+            try:
+                _close_mlx_owned_iterator(iterator)
+            except Exception:
+                pass
+
 def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                                   max_seq_length, seed=42,
                                   response_mask_fn=None,
                                   formatting_func=None,
                                   dataset_order="default",
                                   completion_only_loss=None,
-                                  image_size=None, comm_group=None):
+                                  image_size=None, comm_group=None,
+                                  require_replayable=False,
+                                  expected_rows_per_pass=None):
     """Streaming VLM batch generator using processor directly.
 
     Yields batch dicts with input_ids, pixel_values, attention_mask,
@@ -4525,7 +4761,7 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
             completion_only_loss=completion_only_loss,
         )
 
-    if hasattr(dataset, "__len__"):
+    if _vlm_has_sized_index_space(dataset):
         if len(dataset) <= 0:
             raise ValueError("Unsloth MLX VLM: streaming dataset produced no rows.")
         base_indices = list(range(len(dataset)))
@@ -4608,75 +4844,18 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                     )
             epoch += 1
     else:
-        # Streaming has no index space to permute; torch_randperm needs sized epochs.
-        if dataset_order == "torch_randperm":
-            raise ValueError(
-                "Unsloth MLX VLM: preserve_dataset_order / "
-                "dataset_order='torch_randperm' requires a sized "
-                "(`__len__`) dataset."
-            )
-        if dataset_order not in (None, "default", "sequential"):
-            raise ValueError(f"Unsupported MLX VLM dataset_order: {dataset_order!r}")
-        def _filter_stream_item(item):
-            """Return a formatted trainable streaming row, or None to skip it."""
-            if response_mask_fn is None:
-                return item
-            if formatting_func is not None:
-                item = formatting_func(item)
-            batch_dict, is_prompt_completion = _build_response_masked_vlm_batch(
-                [item],
-                processor,
-                config,
-                max_seq_length,
-                image_size,
-                response_mask_fn=response_mask_fn,
-                formatting_func=None,
-                ignore_token_ids=ignore_token_ids,
-                completion_only_loss=completion_only_loss,
-                return_prompt_completion=True,
-            )
-            if is_prompt_completion:
-                return item
-            valid_rows = _vlm_trainable_label_rows(batch_dict)
-            if valid_rows is not None and len(valid_rows) == 1 and not valid_rows[0]:
-                return None
-            return item
-
-        batch_formatting_func = None if response_mask_fn is not None else formatting_func
-        while True:
-            pending = []
-            yielded = False
-            for item in dataset:
-                item = _filter_stream_item(item)
-                if item is None:
-                    continue
-                pending.append(item)
-                if len(pending) >= global_batch_size:
-                    local_items = _rank_slice_distributed_batch(
-                        pending,
-                        batch_size,
-                        comm_group=comm_group,
-                        pad_source=pending,
-                    )
-                    if local_items:
-                        yielded = True
-                        yield _build_batch(local_items, batch_formatting_func)
-                    pending = []
-            if pending:
-                local_items = _rank_slice_distributed_batch(
-                    pending,
-                    batch_size,
-                    comm_group=comm_group,
-                    pad_source=pending,
-                )
-                if local_items:
-                    yielded = True
-                    yield _build_batch(local_items, batch_formatting_func)
-            if not yielded:
-                raise ValueError(
-                    "Unsloth MLX VLM: streaming dataset produced no rows. "
-                    "If resuming, use a replayable iterable rather than a one-shot iterator."
-                )
+        yield from _iterate_lazy_vlm_training_batches(
+            dataset, processor, config, batch_size, max_seq_length,
+            response_mask_fn=response_mask_fn,
+            formatting_func=formatting_func,
+            dataset_order=dataset_order,
+            completion_only_loss=completion_only_loss,
+            image_size=image_size,
+            comm_group=comm_group,
+            require_replayable=require_replayable,
+            expected_rows_per_pass=expected_rows_per_pass,
+            ignore_token_ids=ignore_token_ids,
+        )
 
 
 def _prepare_dataset(dataset, tokenizer, dataset_text_field="text",
@@ -5700,6 +5879,41 @@ def _close_mlx_owned_iterator(iterator):
         close()
 
 
+
+def _probe_lazy_replayability(source_dataset, current_iterator, set_epoch,
+                              require_replayable, resume_error):
+    """Classify a lazy source's replayability; prove it when resume needs it.
+
+    Returns ``(replayable, cached_next_iterator)`` where ``replayable`` is
+    True / False / None (unknown until first restart) and the cached iterator
+    is a proven-fresh traversal retained only for sources without
+    ``set_epoch`` (epoch-aware sources recreate after ``set_epoch`` advances).
+    """
+    if isinstance(source_dataset, Iterator):
+        replayable = False
+    elif _is_mlx_hf_iterable_text_source(source_dataset):
+        replayable = True
+    else:
+        replayable = None
+    cached_next_iterator = None
+    if require_replayable:
+        if replayable is False:
+            raise resume_error()
+        if replayable is None:
+            try:
+                candidate = iter(source_dataset)
+            except Exception as exc:
+                raise resume_error() from exc
+            if candidate is current_iterator:
+                raise resume_error()
+            if not callable(set_epoch):
+                cached_next_iterator = candidate
+            else:
+                _close_mlx_owned_iterator(candidate)
+            replayable = True
+    return replayable, cached_next_iterator
+
+
 def _validate_streaming_length_window(value):
     """Validate streaming_text_length_window_batches before source consumption."""
     if isinstance(value, bool) or not isinstance(value, int):
@@ -5816,29 +6030,10 @@ def _iterate_lazy_text_training_batches(
     current_iterator = iter(source_dataset)
     cached_next_iterator = None
     try:
-        if isinstance(source_dataset, Iterator):
-            replayable = False
-        elif _is_mlx_hf_iterable_text_source(source_dataset):
-            replayable = True
-        else:
-            replayable = None
-
-        if require_replayable:
-            if replayable is False:
-                raise _resume_replay_error()
-            if replayable is None:
-                try:
-                    candidate = iter(source_dataset)
-                except Exception as exc:
-                    raise _resume_replay_error() from exc
-                if candidate is current_iterator:
-                    raise _resume_replay_error()
-                if not callable(set_epoch):
-                    cached_next_iterator = candidate
-                else:
-                    _close_mlx_owned_iterator(candidate)
-                    del candidate
-                replayable = True
+        replayable, cached_next_iterator = _probe_lazy_replayability(
+            source_dataset, current_iterator, set_epoch,
+            require_replayable, _resume_replay_error,
+        )
 
         def _make_batch(local_items):
             if state.get("schema") == "raw" and state.get("label_state") is False:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3380,11 +3380,14 @@ def _is_mlx_lazy_text_source(dataset):
     if isinstance(dataset, Iterator):
         return True
     source_mro = type(dataset).__mro__
+    # Explicit iteration wins over custom size/index methods: guarded streams
+    # may expose advisory or deliberately unusable map-style operations that
+    # must not be probed merely to decide whether streaming is safe.
     if any("__iter__" in cls.__dict__ for cls in source_mro):
         return True
     # Python's sequence-iteration fallback accepts __getitem__ without
-    # __iter__. Keep custom objects that also declare __len__ on the existing
-    # sized/map path; the no-length protocol must be consumed incrementally.
+    # __iter__. Preserve classes declaring both map-style protocols without
+    # probing either operation; getitem-only fallback iterables remain lazy.
     has_getitem = any("__getitem__" in cls.__dict__ for cls in source_mro)
     has_len = any("__len__" in cls.__dict__ for cls in source_mro)
     return has_getitem and not has_len
@@ -5212,6 +5215,8 @@ def _iter_lazy_tokenized_text_rows(
     """Normalize an unsized source one row at a time and lock its schema."""
     state = {} if state is None else state
     eos_id = getattr(tokenizer, "eos_token_id", None) if append_eos else None
+    saw_usable_this_pass = False
+    completion_labels_seen_this_pass = False
 
     if completion_only_loss is not None:
         state.setdefault(
@@ -5219,28 +5224,74 @@ def _iter_lazy_tokenized_text_rows(
             completion_only_loss,
         )
 
+    def _require_assistant_conversation(row):
+        if assistant_only_loss and not _is_mlx_sft_conversational_row(row):
+            raise ValueError(
+                "You set `assistant_only_loss=True`, but the dataset is not "
+                "conversational. This option is only supported for "
+                "conversational datasets."
+            )
+
     def _validate_state(kind, labels, *, usable=True, completion_mode=False):
-        if not usable:
-            return
-        if state.get("schema") is None:
-            state["schema"] = kind
-        elif state["schema"] != kind:
+        nonlocal saw_usable_this_pass, completion_labels_seen_this_pass
+        schema = state.get("schema")
+        has_labels = labels is not None
+        label_state = state.get("label_state")
+        validate_locked_state = usable or saw_usable_this_pass
+        if validate_locked_state and schema is not None and schema != kind:
             raise ValueError(
                 "Unsloth MLX: pretokenized text rows with 'input_ids' cannot "
                 "be mixed with rows that need text formatting/tokenization."
             )
-        state.setdefault(
-            "pretokenized_completion_only_loss",
-            completion_mode,
-        )
-        has_labels = labels is not None
-        if state.get("label_state") is None:
-            state["label_state"] = has_labels
-        elif state["label_state"] != has_labels:
+        if (
+            validate_locked_state
+            and label_state is not None
+            and label_state != has_labels
+        ):
             raise ValueError(
                 "Unsloth MLX: streaming text rows with labels or masks must "
                 "not be mixed with rows that do not provide labels."
             )
+        if completion_mode is True:
+            if has_labels:
+                completion_labels_seen_this_pass = True
+            elif completion_labels_seen_this_pass:
+                raise ValueError(
+                    "Unsloth MLX: streaming text rows with labels or masks must "
+                    "not be mixed with rows that do not provide labels."
+                )
+        if not usable:
+            return
+        if schema is None:
+            state["schema"] = kind
+        state.setdefault(
+            "pretokenized_completion_only_loss",
+            completion_mode,
+        )
+        if label_state is None:
+            state["label_state"] = has_labels
+        saw_usable_this_pass = True
+
+    def _resolve_completion_mode(item_has_boundary, row_has_boundary=False):
+        if completion_only_loss is not None:
+            return completion_only_loss
+        if "pretokenized_completion_only_loss" in state:
+            return state["pretokenized_completion_only_loss"]
+        if item_has_boundary or row_has_boundary:
+            state["pretokenized_completion_only_loss"] = True
+            return True
+        return False
+
+    def _filtered_label_observation(
+        completion_mode,
+        has_completion_boundary=False,
+    ):
+        # Empty label-owned rows have no token labels, but they also are not an
+        # unlabeled schema transition. A non-None sentinel preserves that fact.
+        label_owned = assistant_only_loss or (
+            completion_mode is True and has_completion_boundary
+        )
+        return () if label_owned else None
 
     for item in dataset:
         item_has_completion_boundary = (
@@ -5253,10 +5304,26 @@ def _iter_lazy_tokenized_text_rows(
         source_rows = item if (
             isinstance(item, list) and not _looks_like_mlx_chat_messages(item)
         ) else [item]
-        if not any(
+        if not source_rows:
+            # Assistant-only validation applies to the original logical row
+            # before a formatter can replace it or produce side effects.
+            source_rows = [None]
+        source_has_input_ids = any(
             isinstance(row, Mapping) and "input_ids" in row
             for row in source_rows
-        ) and formatting_func is not None:
+        )
+        if (
+            assistant_only_loss
+            and formatting_func is not None
+            and "assistant_source_checked" not in state
+        ):
+            # Match the eager/SFT contract: validate the first original sample
+            # once, then validate every formatter result below. Pretokenized
+            # rows bypass the formatter and carry their own assistant metadata.
+            if not source_has_input_ids:
+                _require_assistant_conversation(item)
+            state["assistant_source_checked"] = True
+        if formatting_func is not None and not source_has_input_ids:
             formatted = formatting_func(item)
             formatter_applied = True
             formatter_needs_completion_boundary = (
@@ -5267,6 +5334,22 @@ def _iter_lazy_tokenized_text_rows(
                 isinstance(formatted, list)
                 and not _looks_like_mlx_chat_messages(formatted)
             ) else [formatted]
+        if not source_rows:
+            # An empty formatter list expands to zero rows, not one invalid
+            # row. Preserve only its schema/label observation, then continue.
+            row_completion_only_loss = _resolve_completion_mode(
+                item_has_completion_boundary
+            )
+            _validate_state(
+                "raw",
+                _filtered_label_observation(
+                    row_completion_only_loss,
+                    item_has_completion_boundary,
+                ),
+                usable=False,
+                completion_mode=row_completion_only_loss,
+            )
+            continue
 
         for row in source_rows:
             row_has_completion_boundary = (
@@ -5274,17 +5357,10 @@ def _iter_lazy_tokenized_text_rows(
                 and "prompt" in row
                 and "completion" in row
             )
-            if completion_only_loss is not None:
-                row_completion_only_loss = completion_only_loss
-            elif "pretokenized_completion_only_loss" in state:
-                row_completion_only_loss = state[
-                    "pretokenized_completion_only_loss"
-                ]
-            elif item_has_completion_boundary or row_has_completion_boundary:
-                row_completion_only_loss = True
-                state["pretokenized_completion_only_loss"] = True
-            else:
-                row_completion_only_loss = False
+            row_completion_only_loss = _resolve_completion_mode(
+                item_has_completion_boundary,
+                row_has_completion_boundary,
+            )
             tokenized = _tokenize_mlx_pretokenized_row(
                 row,
                 completion_only_loss=row_completion_only_loss,
@@ -5292,10 +5368,19 @@ def _iter_lazy_tokenized_text_rows(
             )
             if tokenized is not None:
                 ids, labels = tokenized
+                if max_seq_length is not None:
+                    ids = ids[:max_seq_length]
+                    labels = (
+                        labels[:max_seq_length] if labels is not None else None
+                    )
+                usable = len(ids) >= 2 and _labeled_row_has_supervision(
+                    labels, len(ids)
+                )
                 if (
                     formatter_applied
                     and row_completion_only_loss is True
                     and labels is None
+                    and usable
                 ):
                     if formatter_needs_completion_boundary:
                         raise ValueError(
@@ -5310,14 +5395,6 @@ def _iter_lazy_tokenized_text_rows(
                         "input_ids without labels or completion_mask while "
                         "completion-only loss is active."
                     )
-                if max_seq_length is not None:
-                    ids = ids[:max_seq_length]
-                    labels = (
-                        labels[:max_seq_length] if labels is not None else None
-                    )
-                usable = len(ids) >= 2 and _labeled_row_has_supervision(
-                    labels, len(ids)
-                )
                 _validate_state(
                     "pretokenized",
                     labels,
@@ -5328,12 +5405,7 @@ def _iter_lazy_tokenized_text_rows(
                     yield ids, labels
                 continue
 
-            if assistant_only_loss and not _is_mlx_sft_conversational_row(row):
-                raise ValueError(
-                    "You set `assistant_only_loss=True`, but the dataset is not "
-                    "conversational. This option is only supported for "
-                    "conversational datasets."
-                )
+            _require_assistant_conversation(row)
             labeled = None
             if row_completion_only_loss is not False or assistant_only_loss:
                 labeled = _tokenize_mlx_prompt_completion_row(
@@ -5369,41 +5441,73 @@ def _iter_lazy_tokenized_text_rows(
                     "conversational. This option is only supported for "
                     "conversational datasets."
                 )
-            if (
-                formatter_needs_completion_boundary
-                and row_completion_only_loss is True
-            ):
-                raise ValueError(
-                    "Unsloth MLX: a formatting_func was provided for a "
-                    "prompt/completion dataset, which drops the completion "
-                    "boundary needed for the default completion-only loss. "
-                    "Apply your formatting before passing the dataset, or set "
-                    "completion_only_loss=False."
+            texts = None
+            if formatter_applied:
+                texts = collect_mlx_texts(
+                    tokenizer,
+                    row,
+                    dataset_text_field=dataset_text_field,
+                    is_vlm=False,
                 )
-            if row_completion_only_loss is True:
-                raise ValueError(
-                    "Unsloth MLX: text completion_only_loss=True requires "
-                    "prompt/completion rows for streaming text training."
-                )
+                if not texts:
+                    _validate_state(
+                        "raw",
+                        _filtered_label_observation(
+                            row_completion_only_loss,
+                            item_has_completion_boundary
+                            or row_has_completion_boundary,
+                        ),
+                        usable=False,
+                        completion_mode=row_completion_only_loss,
+                    )
+                    continue
 
-            for text in collect_mlx_texts(
-                tokenizer,
-                row,
-                dataset_text_field=dataset_text_field,
-                is_vlm=False,
-            ):
+            if texts is None:
+                texts = collect_mlx_texts(
+                    tokenizer,
+                    row,
+                    dataset_text_field=dataset_text_field,
+                    is_vlm=False,
+                )
+            if not texts:
+                _validate_state(
+                    "raw",
+                    None,
+                    usable=False,
+                    completion_mode=row_completion_only_loss,
+                )
+                continue
+            for text in texts:
                 ids = list(encode_mlx_text(tokenizer, text))
                 if eos_id is not None and (not ids or ids[-1] != eos_id):
                     ids.append(int(eos_id))
                 if max_seq_length is not None:
                     ids = ids[:max_seq_length]
+                usable = len(ids) >= 2
+                if (
+                    usable
+                    and formatter_needs_completion_boundary
+                    and row_completion_only_loss is True
+                ):
+                    raise ValueError(
+                        "Unsloth MLX: a formatting_func was provided for a "
+                        "prompt/completion dataset, which drops the completion "
+                        "boundary needed for the default completion-only loss. "
+                        "Apply your formatting before passing the dataset, or set "
+                        "completion_only_loss=False."
+                    )
+                if usable and row_completion_only_loss is True:
+                    raise ValueError(
+                        "Unsloth MLX: text completion_only_loss=True requires "
+                        "prompt/completion rows for streaming text training."
+                    )
                 _validate_state(
                     "raw",
                     None,
-                    usable=len(ids) >= 2,
+                    usable=usable,
                     completion_mode=row_completion_only_loss,
                 )
-                if len(ids) >= 2:
+                if usable:
                     yield ids, None
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1112,16 +1112,20 @@ class _HostStagedVLMBatch:
     """Host-side VLM batch: processor fields + decided labels, pre-MLX.
 
     ``prefinalized`` carries an already-MLX legacy batch for MLX-valued
-    processor outputs (``host_valued=False``) — synchronous mode only; the
-    Stage-6 producer rejects such streams before staging.
+    processor outputs (``host_valued=False``) in synchronous mode. In
+    producer mode, MLX-valued PROCESSOR outputs stage opaquely instead —
+    materialized producer-side first, because lazy MLX graphs cannot cross
+    threads: plain-SFT payloads ride ``inputs`` with ``label_mask=None``;
+    prompt/completion payloads ride ``pc_opaque`` with the combine deferred
+    to the consumer finalizer.
     """
 
     __slots__ = ("inputs", "label_mask", "widen_labels_int64", "host_valued",
-                 "ignore_token_ids", "config", "prefinalized")
+                 "ignore_token_ids", "config", "prefinalized", "pc_opaque")
 
     def __init__(self, inputs, label_mask, host_valued=True,
                  ignore_token_ids=None, config=None, prefinalized=None,
-                 widen_labels_int64=False):
+                 widen_labels_int64=False, pc_opaque=None):
         self.inputs = inputs
         self.label_mask = label_mask
         self.host_valued = host_valued
@@ -1129,17 +1133,31 @@ class _HostStagedVLMBatch:
         self.config = config
         self.prefinalized = prefinalized
         self.widen_labels_int64 = widen_labels_int64
+        self.pc_opaque = pc_opaque
 
 
 def _finalize_vlm_batch(staged, keep_raw_carrier=False):
     """The single consumer-thread point converting staged VLM batches to MLX.
 
-    Conversion and compile preparation only — every semantic label decision
-    already happened host-side (or, for ``prefinalized`` legacy batches, on
-    this same thread inside the collator).
+    For host-staged batches every semantic label decision already happened
+    host-side; only conversion and compile preparation run here. Opaque
+    processor-owned payloads (plain-SFT with ``label_mask=None``, and
+    ``pc_opaque`` prompt/completion carriers) instead run their combine and
+    legacy label decisions here on the consumer thread — the producer only
+    materialized and transported them.
     """
     if staged.prefinalized is not None:
         return _prepare_vlm_batch_for_compile(staged.prefinalized, staged.config)
+    if staged.pc_opaque is not None:
+        (prompt_inputs, completion_inputs, processor, max_seq_length,
+         completion_only_loss) = staged.pc_opaque
+        inner = _combine_vlm_prompt_completion_inputs(
+            prompt_inputs, completion_inputs, processor, max_seq_length,
+            ignore_token_ids=staged.ignore_token_ids,
+            completion_only_loss=completion_only_loss,
+        )
+        inner.config = staged.config
+        return _finalize_vlm_batch(inner, keep_raw_carrier=keep_raw_carrier)
     batch = _to_mx_vlm_batch(staged.inputs)
     if staged.label_mask is None:
         # Opaque processor outputs (the processor itself returned MLX arrays,
@@ -2563,6 +2581,32 @@ def _contains_mlx_values(value):
     if isinstance(value, Mapping):
         return any(_contains_mlx_values(element) for element in value.values())
     return False
+
+
+def _collect_mlx_values(value, out):
+    if isinstance(value, mx.array):
+        out.append(value)
+    elif isinstance(value, (list, tuple)):
+        for element in value:
+            _collect_mlx_values(element, out)
+    elif isinstance(value, Mapping):
+        for element in value.values():
+            _collect_mlx_values(element, out)
+
+
+def _materialize_mlx_values(*trees):
+    """Force pending MLX graphs on the thread that created them.
+
+    Lazy MLX arrays cannot be evaluated from another thread, so opaque
+    processor-owned payloads must cross the prefetch boundary materialized.
+    This completes computation the processor already issued on this thread;
+    Unsloth still introduces no new MLX computation off the consumer thread.
+    """
+    arrays = []
+    for tree in trees:
+        _collect_mlx_values(tree, arrays)
+    if arrays:
+        mx.eval(*arrays)
 
 
 def _guard_host_token_output(value, state, context):
@@ -4394,7 +4438,42 @@ def _collate_vlm_prompt_completion_batch(
         and _vlm_inputs_host_valued(completion_inputs)
     )
     if not pc_host_valued and reject_mlx_valued:
-        _reject_mlx_valued_vlm("the processor")
+        # Processor-owned MLX outputs: materialize their pending graphs on
+        # this thread (lazy arrays cannot cross the thread boundary) and
+        # defer the combine + label decisions to the consumer finalizer.
+        _materialize_mlx_values(prompt_inputs, completion_inputs)
+        return _HostStagedVLMBatch(
+            None, None, host_valued=False,
+            ignore_token_ids=ignore_token_ids,
+            pc_opaque=(prompt_inputs, completion_inputs, processor,
+                       max_seq_length, completion_only_loss),
+        )
+    return _combine_vlm_prompt_completion_inputs(
+        prompt_inputs, completion_inputs, processor, max_seq_length,
+        ignore_token_ids=ignore_token_ids,
+        completion_only_loss=completion_only_loss,
+        reject_mlx_valued=reject_mlx_valued,
+    )
+
+
+def _combine_vlm_prompt_completion_inputs(
+    prompt_inputs,
+    completion_inputs,
+    processor,
+    max_seq_length,
+    ignore_token_ids=None,
+    completion_only_loss=None,
+    reject_mlx_valued=False,
+):
+    """Concatenate prompt/completion processor outputs into one staged batch.
+
+    Runs on the collating thread for host-valued outputs and on the consumer
+    thread (via the ``pc_opaque`` carrier) for MLX-valued outputs.
+    """
+    pc_host_valued = (
+        _vlm_inputs_host_valued(prompt_inputs)
+        and _vlm_inputs_host_valued(completion_inputs)
+    )
     p_ids = _as_numpy_vlm_field(prompt_inputs, "input_ids")
     c_ids = _as_numpy_vlm_field(completion_inputs, "input_ids")
     p_mask = _as_numpy_vlm_field(prompt_inputs, "attention_mask")
@@ -4531,8 +4610,11 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         )
     elif reject_mlx_valued and not _vlm_inputs_host_valued(inputs):
         # The PROCESSOR itself emitted MLX arrays (mlx-vlm wrappers do this
-        # regardless of return_tensors): carry them through untouched and
-        # decide labels at finalize. Producer-side unsloth MLX ops: none.
+        # regardless of return_tensors): materialize its pending graphs on
+        # this thread (lazy arrays cannot cross the thread boundary), carry
+        # the payload through otherwise untouched, and decide labels at
+        # finalize. Unsloth issues no new MLX computation producer-side.
+        _materialize_mlx_values(inputs)
         staged = _HostStagedVLMBatch(
             inputs, None, host_valued=False,
             ignore_token_ids=ignore_token_ids,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1075,6 +1075,14 @@ def _reject_mlx_valued_vlm(context):
     )
 
 
+def _reject_non_integer_host_vlm_ids(context):
+    raise ValueError(
+        f"Unsloth MLX VLM: {context} produced non-integer host token ids, "
+        "which need the synchronous legacy conversion path. Use "
+        "streaming_prefetch_batches=0 for this stream."
+    )
+
+
 def _vlm_ids_integer_host(inputs):
     """True when label-bearing ids are integer host values (the staged case).
 
@@ -1149,10 +1157,11 @@ def _finalize_vlm_batch(staged, keep_raw_carrier=False):
     if staged.prefinalized is not None:
         return _prepare_vlm_batch_for_compile(staged.prefinalized, staged.config)
     if staged.pc_opaque is not None:
-        (prompt_inputs, completion_inputs, processor, max_seq_length,
+        (prompt_inputs, completion_inputs, flush_side, pad_id, max_seq_length,
          completion_only_loss) = staged.pc_opaque
         inner = _combine_vlm_prompt_completion_inputs(
-            prompt_inputs, completion_inputs, processor, max_seq_length,
+            prompt_inputs, completion_inputs, flush_side, pad_id,
+            max_seq_length,
             ignore_token_ids=staged.ignore_token_ids,
             completion_only_loss=completion_only_loss,
         )
@@ -1162,8 +1171,9 @@ def _finalize_vlm_batch(staged, keep_raw_carrier=False):
     if staged.label_mask is None:
         # Opaque processor outputs (the processor itself returned MLX arrays,
         # e.g. mlx-vlm wrappers): label semantics run the legacy path here on
-        # the consumer thread. No Unsloth-issued MLX op touched the payload
-        # producer-side — it was carried through untouched.
+        # the consumer thread. Producer-side, Unsloth only ran the permitted
+        # materialization barrier over the processor's own pending graphs —
+        # no new MLX computation or value transform touched the payload.
         batch["labels"] = _apply_vlm_label_masks(
             batch, ignore_token_ids=staged.ignore_token_ids,
         )
@@ -4445,6 +4455,11 @@ def _collate_vlm_prompt_completion_batch(
         _vlm_inputs_host_valued(prompt_inputs)
         and _vlm_inputs_host_valued(completion_inputs)
     )
+    # Snapshot the tokenizer-derived collation scalars while this thread
+    # still exclusively owns the processor; the carrier transports data, not
+    # the live processor, so the consumer never dereferences it.
+    flush_side = _vlm_tokenizer_padding_side(processor)
+    pad_id = _vlm_pad_token_id(processor)
     if not pc_host_valued and reject_mlx_valued:
         # Processor-owned MLX outputs: materialize their pending graphs on
         # this thread (lazy arrays cannot cross the thread boundary) and
@@ -4453,11 +4468,11 @@ def _collate_vlm_prompt_completion_batch(
         return _HostStagedVLMBatch(
             None, None, host_valued=False,
             ignore_token_ids=ignore_token_ids,
-            pc_opaque=(prompt_inputs, completion_inputs, processor,
+            pc_opaque=(prompt_inputs, completion_inputs, flush_side, pad_id,
                        max_seq_length, completion_only_loss),
         )
     return _combine_vlm_prompt_completion_inputs(
-        prompt_inputs, completion_inputs, processor, max_seq_length,
+        prompt_inputs, completion_inputs, flush_side, pad_id, max_seq_length,
         ignore_token_ids=ignore_token_ids,
         completion_only_loss=completion_only_loss,
         reject_mlx_valued=reject_mlx_valued,
@@ -4467,7 +4482,8 @@ def _collate_vlm_prompt_completion_batch(
 def _combine_vlm_prompt_completion_inputs(
     prompt_inputs,
     completion_inputs,
-    processor,
+    flush_side,
+    pad_id,
     max_seq_length,
     ignore_token_ids=None,
     completion_only_loss=None,
@@ -4476,7 +4492,8 @@ def _combine_vlm_prompt_completion_inputs(
     """Concatenate prompt/completion processor outputs into one staged batch.
 
     Runs on the collating thread for host-valued outputs and on the consumer
-    thread (via the ``pc_opaque`` carrier) for MLX-valued outputs.
+    thread (via the ``pc_opaque`` carrier) for MLX-valued outputs. Takes the
+    tokenizer-derived collation scalars, never the processor itself.
     """
     pc_host_valued = (
         _vlm_inputs_host_valued(prompt_inputs)
@@ -4497,8 +4514,6 @@ def _combine_vlm_prompt_completion_inputs(
     if token_type_key is not None:
         extras[token_type_key] = token_type_ids
 
-    flush_side = _vlm_tokenizer_padding_side(processor)
-    pad_id = _vlm_pad_token_id(processor)
     input_ids, attention_mask, extras = _flush_vlm_arrays_to_side(
         input_ids, attention_mask, flush_side, pad_id, extras,
     )
@@ -4529,7 +4544,7 @@ def _combine_vlm_prompt_completion_inputs(
     if reject_mlx_valued:
         # Non-stageable producer batches (float/exotic ids) must never reach
         # MLX conversion off the consumer thread.
-        _reject_mlx_valued_vlm("the processor")
+        _reject_non_integer_host_vlm_ids("the processor")
     batch = _to_mx_vlm_batch(combined_inputs)
     batch["labels"] = _apply_vlm_label_masks(
         batch, ignore_token_ids=ignore_token_ids,
@@ -4630,7 +4645,7 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
     elif reject_mlx_valued:
         # Host-valued but non-integer ids: legacy conversion would run
         # producer-side, so reject with the synchronous remedy.
-        _reject_mlx_valued_vlm("the processor")
+        _reject_non_integer_host_vlm_ids("the processor")
     else:
         # MLX-valued processor outputs: legacy synchronous label path, wrapped
         # so the single finalizer stays the only exit to the trainer.

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5682,6 +5682,7 @@ def _iterate_lazy_text_training_batches(
     repeat=True,
     distributed_pad_mode="cycle",
     expected_rows_per_pass=None,
+    include_epoch=False,
 ):
     """Yield source-ordered text batches without materializing an unsized source.
 
@@ -5773,6 +5774,10 @@ def _iterate_lazy_text_training_batches(
                 labels_expected=state.get("label_state"),
             )
 
+        def _yield_value(local_items):
+            batch = _make_batch(local_items)
+            return (batch, epoch) if include_epoch else batch
+
         while True:
             pending = []
             deferred_final = None
@@ -5849,7 +5854,7 @@ def _iterate_lazy_text_training_batches(
                     pad_mode=distributed_pad_mode,
                 )
                 yielded = True
-                yield _make_batch(local_items)
+                yield _yield_value(local_items)
                 pending = []
 
             if expected_rows_per_pass is not None and (
@@ -5871,7 +5876,7 @@ def _iterate_lazy_text_training_batches(
                     pad_mode=distributed_pad_mode,
                 )
                 yielded = True
-                yield _make_batch(local_items)
+                yield _yield_value(local_items)
 
             if pending:
                 local_items = _rank_slice_distributed_batch(
@@ -5882,7 +5887,7 @@ def _iterate_lazy_text_training_batches(
                     pad_mode=distributed_pad_mode,
                 )
                 yielded = True
-                yield _make_batch(local_items)
+                yield _yield_value(local_items)
 
             exhausted_iterator = current_iterator
             current_iterator = None
@@ -5934,6 +5939,223 @@ def _iterate_lazy_text_training_batches(
                 _close_mlx_owned_iterator(iterator)
             except Exception:
                 pass
+
+
+def _pad_dispatched_text_batch(
+    batch,
+    target_size,
+    *,
+    pad_id,
+    pad_mode,
+    cycle_source=None,
+):
+    """Pad one owner-built global text batch before rank dispatch."""
+    input_ids, lengths, labels = batch
+    row_count = int(input_ids.shape[0])
+    if row_count >= target_size:
+        return input_ids[:target_size], lengths[:target_size], (
+            None if labels is None else labels[:target_size]
+        )
+    if row_count == 0:
+        raise ValueError("Unsloth MLX: cannot dispatch an empty text batch.")
+    if pad_mode not in ("cycle", "empty"):
+        raise ValueError(f"Unsupported distributed pad mode: {pad_mode!r}.")
+
+    missing = target_size - row_count
+    if pad_mode == "empty":
+        padded_ids = mx.full(
+            (missing, int(input_ids.shape[1])), int(pad_id), dtype=input_ids.dtype,
+        )
+        padded_lengths = mx.zeros(
+            (missing, int(lengths.shape[1])), dtype=lengths.dtype,
+        )
+        padded_labels = (
+            None
+            if labels is None
+            else mx.full(
+                (missing, int(labels.shape[1])), -100, dtype=labels.dtype,
+            )
+        )
+    else:
+        source_ids, source_lengths, source_labels = cycle_source or batch
+        if (labels is None) != (source_labels is None):
+            raise ValueError(
+                "Unsloth MLX: streaming text labels changed within one pass."
+            )
+        source_rows = int(source_ids.shape[0])
+        indices = mx.array(
+            [index % source_rows for index in range(missing)], dtype=mx.int32,
+        )
+        padded_ids = mx.take(source_ids, indices, axis=0)
+        padded_lengths = mx.take(source_lengths, indices, axis=0)
+        padded_labels = (
+            None
+            if source_labels is None
+            else mx.take(source_labels, indices, axis=0)
+        )
+
+    width = max(int(input_ids.shape[1]), int(padded_ids.shape[1]))
+
+    def _pad_width(value, fill):
+        missing_width = width - int(value.shape[1])
+        if missing_width <= 0:
+            return value
+        padding = mx.full(
+            (int(value.shape[0]), missing_width), fill, dtype=value.dtype,
+        )
+        return mx.concatenate((value, padding), axis=1)
+
+    input_ids = _pad_width(input_ids, int(pad_id))
+    padded_ids = _pad_width(padded_ids, int(pad_id))
+    if labels is not None:
+        labels = _pad_width(labels, -100)
+        padded_labels = _pad_width(padded_labels, -100)
+    return (
+        mx.concatenate((input_ids, padded_ids), axis=0),
+        mx.concatenate((lengths, padded_lengths), axis=0),
+        None
+        if labels is None
+        else mx.concatenate((labels, padded_labels), axis=0),
+    )
+
+
+def _iterate_dispatched_lazy_text_training_batches(
+    dataset,
+    tokenizer,
+    batch_size,
+    max_seq_length,
+    *,
+    comm_group,
+    distributed_pad_mode="cycle",
+    **kwargs,
+):
+    """Dispatch rank-0-owned lazy text batches to all data-parallel ranks.
+
+    The owner retains the first global batch of the current pass only to keep
+    legacy cycle-padding deterministic. Non-owner ranks never touch the source.
+    The supplied source is therefore interpreted as the global, unsharded stream.
+    """
+    rank, world_size = _distributed_rank_size(comm_group)
+    target_size = int(batch_size) * world_size
+    if target_size <= 0:
+        raise ValueError("batch_size must be positive for distributed batching.")
+    if distributed_pad_mode not in ("cycle", "empty"):
+        raise ValueError(
+            f"Unsupported distributed pad mode: {distributed_pad_mode!r}."
+        )
+
+    owner_iterator = None
+    owner_contract_error = None
+    owner_tokenizer = tokenizer
+    if rank == 0:
+        try:
+            if isinstance(dataset, _MLXIterableTokenizedDatasetView):
+                owner_tokenizer = dataset._tokenizer
+            source_distribution = getattr(
+                _mlx_lazy_text_source(dataset), "_distributed", None,
+            )
+            if int(getattr(source_distribution, "world_size", 1)) > 1:
+                owner_contract_error = ValueError(
+                    "Unsloth MLX: distributed lazy text dispatch requires the "
+                    "global unsharded Hugging Face iterable. Pass the source "
+                    "before split_dataset_by_node(); MLX owns rank partitioning."
+                )
+        except Exception as exc:
+            owner_contract_error = exc
+        owner_iterator = _iterate_lazy_text_training_batches(
+            dataset,
+            owner_tokenizer,
+            target_size,
+            max_seq_length,
+            comm_group=None,
+            distributed_pad_mode=distributed_pad_mode,
+            include_epoch=True,
+            **kwargs,
+        )
+    cycle_source = None
+    cycle_epoch = None
+    try:
+        while True:
+            owner_error = None
+            epoch = 0
+            rows = 0
+            width = 0
+            has_labels = 0
+            status = 0
+            if rank == 0:
+                try:
+                    if owner_contract_error is not None:
+                        raise owner_contract_error
+                    owner_batch, epoch = next(owner_iterator)
+                    if cycle_epoch != epoch:
+                        cycle_epoch = epoch
+                        cycle_source = owner_batch
+                    owner_batch = _pad_dispatched_text_batch(
+                        owner_batch,
+                        target_size,
+                        pad_id=_mlx_text_pad_id(owner_tokenizer),
+                        pad_mode=distributed_pad_mode,
+                        cycle_source=cycle_source,
+                    )
+                    input_ids, lengths, labels = owner_batch
+                    rows = int(input_ids.shape[0])
+                    width = int(input_ids.shape[1])
+                    has_labels = int(labels is not None)
+                    status = 1
+                except StopIteration:
+                    pass
+                except Exception as exc:
+                    owner_error = exc
+                    status = -1
+
+            metadata = mx.array(
+                [status, rows, width, has_labels]
+                if rank == 0 else [0, 0, 0, 0],
+                dtype=mx.int32,
+            )
+            metadata = mx.distributed.all_sum(metadata, group=comm_group)
+            mx.eval(metadata)
+            status, rows, width, has_labels = (
+                int(value) for value in metadata.tolist()
+            )
+            if status < 0:
+                if owner_error is not None:
+                    raise owner_error
+                raise RuntimeError(
+                    "Unsloth MLX: rank 0 failed while reading the global "
+                    "streaming text source before batch dispatch."
+                )
+            if status == 0:
+                return
+            if rows != target_size or width <= 0:
+                raise RuntimeError(
+                    "Unsloth MLX: rank-0 streaming text dispatch produced "
+                    f"invalid global batch shape ({rows}, {width})."
+                )
+
+            if rank != 0:
+                input_ids = mx.zeros((rows, width), dtype=mx.int32)
+                lengths = mx.zeros((rows, 2), dtype=mx.int32)
+                labels = (
+                    mx.zeros((rows, width), dtype=mx.int64)
+                    if has_labels else None
+                )
+            input_ids = mx.distributed.all_sum(input_ids, group=comm_group)
+            lengths = mx.distributed.all_sum(lengths, group=comm_group)
+            if has_labels:
+                labels = mx.distributed.all_sum(labels, group=comm_group)
+                mx.eval(input_ids, lengths, labels)
+            else:
+                mx.eval(input_ids, lengths)
+            yield (
+                input_ids[rank:target_size:world_size],
+                lengths[rank:target_size:world_size],
+                None
+                if labels is None
+                else labels[rank:target_size:world_size],
+            )
+    finally:
+        _close_mlx_owned_iterator(owner_iterator)
 
 
 def _iterate_ordered_text_training_batches(dataset, tokenizer, batch_size,
@@ -6079,11 +6301,7 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             is_vlm=False,
             strict=False,
         )
-        yield from _iterate_lazy_text_training_batches(
-            dataset,
-            tokenizer,
-            batch_size,
-            max_seq_length,
+        lazy_batch_kwargs = dict(
             dataset_text_field=dataset_text_field,
             formatting_func=formatting_func,
             dataset_order=dataset_order,
@@ -6091,12 +6309,30 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             completion_only_loss=completion_only_loss,
             assistant_only_loss=assistant_only_loss,
             response_mask_fn=response_mask_fn,
-            comm_group=comm_group,
             require_replayable=require_replayable,
             repeat=repeat,
-            distributed_pad_mode=distributed_pad_mode,
             expected_rows_per_pass=expected_rows_per_pass,
         )
+        if _distributed_rank_size(comm_group)[1] > 1:
+            yield from _iterate_dispatched_lazy_text_training_batches(
+                dataset,
+                tokenizer,
+                batch_size,
+                max_seq_length,
+                comm_group=comm_group,
+                distributed_pad_mode=distributed_pad_mode,
+                **lazy_batch_kwargs,
+            )
+        else:
+            yield from _iterate_lazy_text_training_batches(
+                dataset,
+                tokenizer,
+                batch_size,
+                max_seq_length,
+                comm_group=comm_group,
+                distributed_pad_mode=distributed_pad_mode,
+                **lazy_batch_kwargs,
+            )
         return
 
     dataset = _ensure_reiterable_text_dataset(dataset)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1546,13 +1546,10 @@ def _normalize_cce_label_dtype(labels):
 
 
 def _stage_vlm_label_mask_np(inputs, ignore_token_ids=None, labels=None):
-    """Host-side label-mask AUTHORITY for VLM batches: placement only.
-
-    Decides WHICH positions are ignored (ignore tokens, attention zeros, and
-    positions a response/completion mask already set to -100). Label VALUES
-    and dtypes are assembled at finalize time from the SAME converted ids the
-    legacy path used, so coercion parity holds by construction — including
-    legacy's conversion-time rejections. Float comparisons mirror MLX's
+    """Decide WHICH VLM positions are ignored (ignore tokens, attention zeros,
+    positions a response/completion mask already set to -100). Label VALUES come
+    at finalize time from the SAME converted ids the legacy path used, so
+    coercion parity holds by construction. Float comparisons mirror MLX's
     effective float32 narrowing so placement matches the finalized tensors.
     """
     if labels is None:
@@ -1615,11 +1612,8 @@ def _reject_non_integer_host_vlm_ids(context):
 
 def _vlm_ids_integer_host(inputs):
     """True when label-bearing ids are integer host values (the staged case).
-
-    Real processors emit integer token ids; float or exotic-dtype ids (fp16,
-    bf16, float64 probes) route to the bit-exact legacy path instead of a
-    numpy re-implementation of MLX float semantics.
-    """
+    Float or exotic-dtype ids route to the bit-exact legacy path instead of a
+    numpy re-implementation of MLX float semantics."""
     ids = inputs.get(_RAW_INPUT_IDS_FOR_LABELS)
     if ids is None:
         ids = inputs.get("input_ids")
@@ -1650,12 +1644,11 @@ class _HostStagedVLMBatch:
     """Host-side VLM batch: processor fields + decided labels, pre-MLX.
 
     ``prefinalized`` carries an already-MLX legacy batch for MLX-valued
-    processor outputs (``host_valued=False``) in synchronous mode. In
-    producer mode, MLX-valued PROCESSOR outputs stage opaquely instead —
-    materialized producer-side first, because lazy MLX graphs cannot cross
-    threads: plain-SFT payloads ride ``inputs`` with ``label_mask=None``;
-    prompt/completion payloads ride ``pc_opaque`` with the combine deferred
-    to the consumer finalizer.
+    processor outputs in synchronous mode. In producer mode those stage
+    opaquely instead, materialized producer-side because lazy MLX graphs cannot
+    cross threads: plain-SFT rides ``inputs`` with ``label_mask=None``,
+    prompt/completion rides ``pc_opaque`` with the combine deferred to the
+    consumer finalizer.
     """
 
     __slots__ = ("inputs", "label_mask", "widen_labels_int64", "host_valued",
@@ -1677,12 +1670,10 @@ class _HostStagedVLMBatch:
 def _finalize_vlm_batch(staged, keep_raw_carrier=False):
     """The single consumer-thread point converting staged VLM batches to MLX.
 
-    For host-staged batches every semantic label decision already happened
-    host-side; only conversion and compile preparation run here. Opaque
-    processor-owned payloads (plain-SFT with ``label_mask=None``, and
-    ``pc_opaque`` prompt/completion carriers) instead run their combine and
-    legacy label decisions here on the consumer thread — the producer only
-    materialized and transported them.
+    Host-staged batches already made every label decision, so only conversion
+    and compile preparation run here. Opaque processor-owned payloads (plain-SFT
+    with ``label_mask=None``, ``pc_opaque`` prompt/completion carriers) instead
+    run their combine and legacy label decisions here.
     """
     if staged.prefinalized is not None:
         return _prepare_vlm_batch_for_compile(staged.prefinalized, staged.config)
@@ -3160,8 +3151,7 @@ def _materialize_mlx_values(*trees):
 
     Lazy MLX arrays cannot be evaluated from another thread, so opaque
     processor-owned payloads must cross the prefetch boundary materialized.
-    This completes computation the processor already issued on this thread;
-    Unsloth still introduces no new MLX computation off the consumer thread.
+    This only completes computation the processor already issued on this thread.
     """
     arrays = []
     for tree in trees:
@@ -4016,10 +4006,9 @@ def _prepare_labeled_text_dataset(
 def _coerce_mlx_token_list(value, field_name, state=None):
     """Convert one token-id field from a pretokenized row to a Python list.
 
-    When ``state`` is provided and the value arrived as an MLX array, the
-    stream is marked ``host_valued=False`` BEFORE conversion — the conversion
-    itself is MLX work, which the prefetch producer must reject rather than
-    perform off the consumer thread.
+    With ``state``, an MLX-valued field marks the stream ``host_valued=False``
+    BEFORE conversion, since the conversion is itself MLX work the prefetch
+    producer must reject rather than run off the consumer thread.
     """
     if state is not None and _contains_mlx_values(value):
         if state.get("reject_mlx_valued"):
@@ -4221,11 +4210,9 @@ def _is_mlx_lazy_text_source(dataset):
 
 
 def _is_mlx_hf_iterable_text_source(dataset):
-    """Return whether Hugging Face defines this source as replayable.
-
-    Detected through ``sys.modules`` so classification never imports
-    ``datasets``: if the package was never imported, no instance can exist.
-    """
+    """Return whether Hugging Face defines this source as replayable. Detected
+    through ``sys.modules`` so classification never imports ``datasets``: if the
+    package was never imported, no instance can exist."""
     hf_datasets = sys.modules.get("datasets")
     hf_iterable = getattr(hf_datasets, "IterableDataset", None)
     return hf_iterable is not None and isinstance(dataset, hf_iterable)
@@ -4239,9 +4226,8 @@ def _mlx_lazy_text_source(dataset):
 class _MLXIterableTokenizedDatasetView:
     """Iterable-only public view over MLX's lazy text normalization pipeline.
 
-    The view deliberately has no ``__len__`` or ``__getitem__``. It preserves
-    the source's replay/one-shot behavior and forwards epoch changes without
-    consuming a row during construction.
+    Deliberately has no ``__len__`` or ``__getitem__``. Preserves the source's
+    replay/one-shot behavior and forwards epoch changes without consuming a row.
     """
 
     _INVALIDATED_SOURCE_METADATA = frozenset((
@@ -4341,9 +4327,8 @@ def _labeled_row_has_supervision(labels, max_seq_length):
 class _HostStagedTextBatch:
     """Host-side (python/numpy) text batch awaiting MLX finalization.
 
-    ``host_valued`` is False when any staged field arrived as an MLX array;
-    synchronous mode accepts such rows unchanged, while the prefetch producer
-    must reject them via the FIFO envelope.
+    ``host_valued`` is False when any staged field arrived as an MLX array:
+    synchronous mode accepts those unchanged, the prefetch producer rejects them.
     """
 
     __slots__ = ("ids", "lengths_info", "labels", "host_valued")
@@ -4377,8 +4362,8 @@ def _stage_tokenized_text_batch(
     """Host staging of one pretokenized text batch (no MLX work).
 
     ``host_valued=None`` computes the flag from the items; the lazy pipeline
-    passes the stream-level flag recorded at row normalization, where MLX
-    origin is still visible (rows are lists by the time they reach staging).
+    instead passes the stream-level flag recorded at row normalization, where
+    MLX origin is still visible.
     """
     valid_items = [item for item in batch_items if item is not None]
     lengths = [
@@ -5372,9 +5357,9 @@ def _combine_vlm_prompt_completion_inputs(
 ):
     """Concatenate prompt/completion processor outputs into one staged batch.
 
-    Runs on the collating thread for host-valued outputs and on the consumer
-    thread (via the ``pc_opaque`` carrier) for MLX-valued outputs. Takes the
-    tokenizer-derived collation scalars, never the processor itself.
+    Runs on the collating thread for host-valued outputs, on the consumer thread
+    (via ``pc_opaque``) for MLX-valued ones. Takes the tokenizer-derived
+    collation scalars, never the processor itself.
     """
     pc_host_valued = (
         _vlm_inputs_host_valued(prompt_inputs)
@@ -5612,10 +5597,10 @@ def _build_response_masked_vlm_batch(
 ):
     """Collate VLM rows and apply the CUDA response-mask closure.
 
-    Plain-SFT and prompt/completion streams stage host-side and exit through
-    the single ``_finalize_vlm_batch`` call (``yield_host_staged`` defers it
-    for the prefetch producer). Response-masked streams run the verbatim
-    legacy consumer-side order and are rejected in producer modes.
+    Plain-SFT and prompt/completion streams stage host-side and exit through the
+    single ``_finalize_vlm_batch`` call (``yield_host_staged`` defers it for the
+    prefetch producer). Response-masked streams run the verbatim legacy
+    consumer-side order and are rejected in producer modes.
     """
     staged, is_prompt_completion = _collate_vlm_batch(
         items, processor, max_seq_length, image_size,
@@ -5851,12 +5836,11 @@ def create_vlm_batches(dataset, processor, config, batch_size, max_seq_length,
 def _vlm_has_sized_index_space(dataset):
     """True when the VLM batcher can index the dataset (`__len__` + `__getitem__`).
 
-    Both protocols must be declared on the TYPE (instance `__getattr__` proxies
-    do not make an object subscriptable), and known iterable-only bases are
-    excluded even when they inherit a raising `__getitem__` (torch
-    `IterableDataset`) or declare stream topology (HF iterables). Everything
-    else streams lazily; the sized path's permutations and response-mask
-    pre-scan require real indexing.
+    Both must be declared on the TYPE (instance `__getattr__` proxies do not
+    make an object subscriptable), and known iterable-only bases are excluded
+    even when they inherit a raising `__getitem__` or declare stream topology.
+    Everything else streams lazily; the sized path's permutations and
+    response-mask pre-scan require real indexing.
     """
     cls = type(dataset)
     if not callable(getattr(cls, "__len__", None)):
@@ -5882,10 +5866,10 @@ def _iterate_lazy_vlm_training_batches(
 ):
     """Unsized VLM batches under the lazy text-stream lifecycle contracts.
 
-    Single-process only: the previous every-rank consumption of the global
-    stream is intentionally removed, and rank-owned dispatch of ragged VLM
-    tensors is a planned follow-up. Per-row trainability filtering, label
-    masking, and collation reuse the sized-path helpers unchanged.
+    Single-process only: every-rank consumption of the global stream is
+    intentionally removed and rank-owned dispatch of ragged VLM tensors is a
+    planned follow-up. Trainability filtering, label masking, and collation
+    reuse the sized-path helpers unchanged.
     """
     if (yield_host_staged or reject_mlx_valued) and response_mask_fn is not None:
         # Zero-touch rejection: no set_epoch, no iterator, no source pull.
@@ -5923,10 +5907,8 @@ def _iterate_lazy_vlm_training_batches(
 
     def _filter_stream_item(item):
         """Return a formatted trainable streaming row, or None to skip it.
-
         Synchronous response-masked filtering finalizes and runs the legacy
-        closure (consumer thread); producer modes reject before reaching here.
-        """
+        closure; producer modes reject before reaching here."""
         if response_mask_fn is None:
             return item
         if yield_host_staged or reject_mlx_valued:
@@ -6115,11 +6097,8 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                                   prefetch_batches=0,
                                   prefetch_skip_batches=0,
                                   prefetch_control=None):
-    """Streaming VLM batch generator using processor directly.
-
-    Yields batch dicts with input_ids, pixel_values, attention_mask,
-    and optionally labels.
-    """
+    """Streaming VLM batch generator using processor directly. Yields batch
+    dicts with input_ids, pixel_values, attention_mask, and optionally labels."""
     import numpy as np
 
     image_size = _resolve_vlm_image_size(image_size, config, processor)
@@ -7440,10 +7419,10 @@ def _probe_lazy_replayability(source_dataset, current_iterator, set_epoch,
                               require_replayable, resume_error):
     """Classify a lazy source's replayability; prove it when resume needs it.
 
-    Returns ``(replayable, cached_next_iterator)`` where ``replayable`` is
-    True / False / None (unknown until first restart) and the cached iterator
-    is a proven-fresh traversal retained only for sources without
-    ``set_epoch`` (epoch-aware sources recreate after ``set_epoch`` advances).
+    Returns ``(replayable, cached_next_iterator)``; ``replayable`` is True /
+    False / None (unknown until first restart), and the cached proven-fresh
+    traversal is retained only for sources without ``set_epoch`` (epoch-aware
+    sources recreate after ``set_epoch`` advances).
     """
     if isinstance(source_dataset, Iterator):
         replayable = False
@@ -7494,14 +7473,12 @@ _PREFETCH_ERROR = "error"
 class _LazyTextPrefetcher:
     """Bounded single-producer prefetch over host-staged text batches.
 
-    The producer thread owns source consumption and host staging (tokenizer,
-    formatter, response-mask closures included); MLX finalization runs only on
-    the consumer thread. A queue slot is reserved BEFORE staging each batch so
-    read-ahead is exactly the configured depth. Cancellation is cooperative:
-    the stop event is honored between batches, cleanup closes the owned
-    iterator in ``finally``, and a bounded join that times out marks the
-    prefetcher ORPHANED — while the orphan thread lives, reusing the shared
-    preprocessing objects is refused by the trainer.
+    The producer thread owns source consumption and host staging; MLX
+    finalization runs only on the consumer thread. A queue slot is reserved
+    BEFORE staging each batch so read-ahead is exactly the configured depth.
+    Cancellation is cooperative, and a bounded join that times out marks the
+    prefetcher ORPHANED; while the orphan lives the trainer refuses to reuse the
+    shared preprocessing objects.
     """
 
     _JOIN_TIMEOUT = 5.0
@@ -7645,16 +7622,13 @@ class _LazyTextPrefetcher:
 
     def close(self):
         """Join the producer, then release any queued batches once it is
-        confirmed dead. Terminal, idempotent, and safe under concurrent
-        callers. Returns True when the producer terminated (queue drained),
-        False when it overran the join and is a live orphan.
-
-        The join, classification, and drain run under one lock, and the return
-        reflects this caller's own post-join observation — so a True return
-        guarantees the queue was drained under that lock before it was reported,
-        and no concurrent closer can observe it half-drained. ``orphaned`` is
-        set conservatively before the join, so an interrupted join leaves a live
-        producer classified as an orphan rather than falsely clean."""
+        confirmed dead. Terminal, idempotent, safe under concurrent callers.
+        Returns True when the producer terminated (queue drained), False when it
+        overran the join and is a live orphan. Join, classification, and drain
+        run under one lock, so a True return guarantees the queue was drained
+        before it was reported and no concurrent closer can see it half-drained.
+        ``orphaned`` is set conservatively before the join, so an interrupted
+        join leaves a live producer classified as an orphan."""
         # Conservative orphan up front: an interrupt during the lock, join, or
         # drain then leaves the producer unresolved rather than falsely clean.
         self.orphaned = True
@@ -7677,8 +7651,8 @@ class _LazyTextPrefetcher:
 
     def _drain_envelopes(self):
         """Discard queued batches so their payloads (device tensors for opaque
-        VLM outputs) are released instead of retained until the consumer
-        generator is collected — a terminal close is followed by a save."""
+        VLM outputs) are released at close instead of being retained until the
+        consumer generator is collected."""
         while True:
             try:
                 self._envelopes.get_nowait()
@@ -7705,8 +7679,7 @@ def _validate_streaming_length_window(value):
 
 
 def _lazy_window_sort_key(item, max_seq_length):
-    """Window grouping key: exact truncated prepared-token length (lazy rows
-    carry ``(input_ids, labels)`` for every schema)."""
+    """Window grouping key: exact truncated prepared-token length."""
     if item is None:
         return 0
     return min(len(item[0]), max_seq_length)
@@ -7747,14 +7720,11 @@ def _iterate_lazy_text_training_batches(
 
     ``sequential`` order and ``length_window_batches=1`` emit exact source
     order. Default order with a window > 1 pools that many global micro-batches
-    of trainable rows, stable-sorts them by truncated prepared-token length,
-    and emits the full chunks in a seeded deterministic permutation (partial
-    chunk last) — a documented, deterministic reordering.
-
-    Custom replayable sources must return independent fresh traversals from
-    ``iter(source)``. Resume validation may create one non-consuming iterator
-    ahead of the serving iterator; epoch-aware validation iterators are closed
-    immediately and recreated only after ``set_epoch`` advances.
+    of trainable rows, stable-sorts them by truncated prepared-token length, and
+    emits the full chunks in a seeded deterministic permutation (partial chunk
+    last). Custom replayable sources must return independent fresh traversals
+    from ``iter(source)``; resume validation may create one non-consuming
+    iterator ahead of the serving iterator.
     """
     if dataset_order == "torch_randperm":
         raise ValueError(
@@ -8185,9 +8155,9 @@ def _iterate_dispatched_lazy_text_training_batches(
 ):
     """Dispatch rank-0-owned lazy text batches to all data-parallel ranks.
 
-    The owner retains the first global batch of the current pass only to keep
-    legacy cycle-padding deterministic. Non-owner ranks never touch the source.
-    The supplied source is therefore interpreted as the global, unsharded stream.
+    The owner retains the first global batch of the pass only to keep legacy
+    cycle-padding deterministic. Non-owner ranks never touch the source, so the
+    supplied source is interpreted as the global, unsharded stream.
     """
     rank, world_size = _distributed_rank_size(comm_group)
     target_size = int(batch_size) * world_size
@@ -8454,11 +8424,9 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
     ``length_window_batches`` global micro-batches of prepared rows (plus the
     rank-0 owner's pass-long cycle-padding batch under DDP). Default order with
     a window > 1 emits length-grouped, seeded-permuted batches; ``sequential``
-    and window 1 preserve exact source order.
-
-    Yields:
-        (batch, lengths, labels) tuples — same format as create_batches.
-        ``labels`` is ``None`` unless text prompt/completion masking is active.
+    and window 1 preserve exact source order. Yields ``(batch, lengths, labels)``
+    like create_batches, with ``labels`` None unless text prompt/completion
+    masking is active.
     """
     from mlx_lm.tuner.trainer import iterate_batches
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1573,8 +1573,7 @@ def _stage_vlm_label_mask_np(inputs, ignore_token_ids=None, labels=None):
     if values.dtype == np.float64:
         values = values.astype(np.float32)
     if np.issubdtype(values.dtype, np.integer):
-        # Compare on the SAME normalized representation finalize uses for the
-        # label base (wide unsigned ids become their int64 sentinels first).
+        # Same normalization finalize uses (wide unsigned ids -> int64 sentinels)
         values = _normalize_numpy_cce_labels(values)
     mask = values == -100
     if ignore_token_ids:
@@ -1700,20 +1699,17 @@ def _finalize_vlm_batch(staged, keep_raw_carrier=False):
         return _finalize_vlm_batch(inner, keep_raw_carrier=keep_raw_carrier)
     batch = _to_mx_vlm_batch(staged.inputs)
     if staged.label_mask is None:
-        # Opaque processor outputs (the processor itself returned MLX arrays,
-        # e.g. mlx-vlm wrappers): label semantics run the legacy path here on
-        # the consumer thread. Producer-side, Unsloth only ran the permitted
-        # materialization barrier over the processor's own pending graphs —
-        # no new MLX computation or value transform touched the payload.
+        # Opaque processor outputs (mlx-vlm wrappers return MLX arrays): run the
+        # legacy label path here on the consumer thread. The producer only
+        # materialized the processor's own pending graphs, nothing more.
         batch["labels"] = _apply_vlm_label_masks(
             batch, ignore_token_ids=staged.ignore_token_ids,
         )
         batch.pop(_RAW_INPUT_IDS_FOR_LABELS, None)
         return _prepare_vlm_batch_for_compile(batch, staged.config)
     if staged.label_mask is not None:
-        # Values ride the SAME converted ids the legacy path used; only the
-        # host-decided placement differs from raw ids. Conversion-time errors
-        # therefore match legacy exactly.
+        # Values ride the same converted ids legacy used, so conversion-time
+        # errors match exactly; only the host-decided placement differs.
         raw = (
             batch.get(_RAW_INPUT_IDS_FOR_LABELS)
             if keep_raw_carrier
@@ -4213,14 +4209,12 @@ def _is_mlx_lazy_text_source(dataset):
     if isinstance(dataset, Iterator):
         return True
     source_mro = type(dataset).__mro__
-    # Explicit iteration wins over custom size/index methods: guarded streams
-    # may expose advisory or deliberately unusable map-style operations that
-    # must not be probed merely to decide whether streaming is safe.
+    # Explicit iteration wins over map-style methods, which may be advisory or
+    # deliberately unusable and must not be probed just to classify the source.
     if any("__iter__" in cls.__dict__ for cls in source_mro):
         return True
-    # Python's sequence-iteration fallback accepts __getitem__ without
-    # __iter__. Preserve classes declaring both map-style protocols without
-    # probing either operation; getitem-only fallback iterables remain lazy.
+    # Python's sequence-iteration fallback accepts __getitem__ without __iter__:
+    # both protocols means map-style, getitem-only stays lazy. Neither is probed.
     has_getitem = any("__getitem__" in cls.__dict__ for cls in source_mro)
     has_len = any("__len__" in cls.__dict__ for cls in source_mro)
     return has_getitem and not has_len
@@ -4432,8 +4426,7 @@ def _stage_tokenized_text_batch(
 def _create_tokenized_text_batch(batch_items, max_seq_length, pad_id=0,
                                  labels_expected=None):
     """Pad pretokenized ids plus optional labels for one MLX text batch."""
-    # host_valued=True skips the recursive provenance scan: this wrapper
-    # finalizes immediately, so the flag is never consumed.
+    # host_valued=True skips the provenance scan: this finalizes immediately.
     return _finalize_text_batch(_stage_tokenized_text_batch(
         batch_items, max_seq_length, pad_id=pad_id,
         labels_expected=labels_expected, host_valued=True,
@@ -5345,15 +5338,13 @@ def _collate_vlm_prompt_completion_batch(
         _vlm_inputs_host_valued(prompt_inputs)
         and _vlm_inputs_host_valued(completion_inputs)
     )
-    # Snapshot the tokenizer-derived collation scalars while this thread
-    # still exclusively owns the processor; the carrier transports data, not
-    # the live processor, so the consumer never dereferences it.
+    # Snapshot the tokenizer-derived collation scalars while this thread still
+    # owns the processor: the carrier transports data, never the live processor.
     flush_side = _vlm_tokenizer_padding_side(processor)
     pad_id = _vlm_pad_token_id(processor)
     if not pc_host_valued and reject_mlx_valued:
-        # Processor-owned MLX outputs: materialize their pending graphs on
-        # this thread (lazy arrays cannot cross the thread boundary) and
-        # defer the combine + label decisions to the consumer finalizer.
+        # Processor-owned MLX outputs: materialize their pending graphs here
+        # (lazy arrays cannot cross threads) and defer combine + labels.
         _materialize_mlx_values(prompt_inputs, completion_inputs)
         return _HostStagedVLMBatch(
             None, None, host_valued=False,
@@ -5462,15 +5453,14 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
     """
     normalize_vlm_processor_chat_template(processor, strict=False)
     if reject_mlx_valued and any(_contains_mlx_values(item) for item in items):
-        # Source rows carrying MLX arrays (e.g. mx image tensors) must reject
-        # before formatting or the processor touches them off-thread.
+        # Reject before formatting or the processor touches them off-thread.
         _reject_mlx_valued_vlm("the dataset row")
     formatted_items = []
     for item in items:
         if formatting_func is not None:
             item = formatting_func(item)
             if reject_mlx_valued and _contains_mlx_values(item):
-                # Formatters can introduce MLX values after the row-level scan.
+                # Formatters can introduce MLX values after the row scan.
                 _reject_mlx_valued_vlm("the formatting function")
         formatted_items.append(item)
 
@@ -5522,23 +5512,20 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
             inputs, label_mask, ignore_token_ids=ignore_token_ids,
         )
     elif reject_mlx_valued and not _vlm_inputs_host_valued(inputs):
-        # The PROCESSOR itself emitted MLX arrays (mlx-vlm wrappers do this
-        # regardless of return_tensors): materialize its pending graphs on
-        # this thread (lazy arrays cannot cross the thread boundary), carry
-        # the payload through otherwise untouched, and decide labels at
-        # finalize. Unsloth issues no new MLX computation producer-side.
+        # The processor itself emitted MLX arrays (mlx-vlm wrappers always do):
+        # materialize its pending graphs here (lazy arrays cannot cross threads),
+        # carry the payload through untouched, and decide labels at finalize.
         _materialize_mlx_values(inputs)
         staged = _HostStagedVLMBatch(
             inputs, None, host_valued=False,
             ignore_token_ids=ignore_token_ids,
         )
     elif reject_mlx_valued:
-        # Host-valued but non-integer ids: legacy conversion would run
-        # producer-side, so reject with the synchronous remedy.
+        # Host-valued non-integer ids: legacy conversion would run producer-side.
         _reject_non_integer_host_vlm_ids("the processor")
     else:
         # MLX-valued processor outputs: legacy synchronous label path, wrapped
-        # so the single finalizer stays the only exit to the trainer.
+        # so the finalizer stays the only exit to the trainer.
         batch = _to_mx_vlm_batch(inputs)
         batch["labels"] = _apply_vlm_label_masks(
             batch, ignore_token_ids=ignore_token_ids,
@@ -5640,10 +5627,9 @@ def _build_response_masked_vlm_batch(
     )
     staged.config = config
     if response_mask_fn is not None and not is_prompt_completion:
-        # Closure semantics are DEFINED on the converted, compile-prepared
-        # tensors (image-token expansion shifts positions), so response
-        # masking is consumer-side by nature and runs the verbatim legacy
-        # order. Producer-destined staging therefore cannot cover it.
+        # Closure semantics are defined on the converted, compile-prepared
+        # tensors (image-token expansion shifts positions), so response masking
+        # is consumer-side by nature and staging cannot cover it.
         if yield_host_staged:
             raise ValueError(
                 "Unsloth MLX VLM: train_on_responses_only streams are not "
@@ -6110,8 +6096,7 @@ def _iterate_lazy_vlm_training_batches(
             if replay_iterator is active_iterator
             else (active_iterator, replay_iterator)
         )
-        # A processor/cardinality error may already be unwinding; attempt every
-        # owned cursor without replacing that primary failure.
+        # Close every owned cursor without replacing an in-flight failure.
         for iterator in cleanup_iterators:
             try:
                 _close_mlx_owned_iterator(iterator)
@@ -6241,10 +6226,8 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
     else:
         prefetch_depth = _validate_streaming_prefetch(prefetch_batches)
         if prefetch_depth and _distributed_rank_size(comm_group)[1] == 1:
-            # The shared prefetch producer generalizes over host-staged
-            # batches; the VLM finalizer converts on the consumer thread.
-            # Response-masked streams reject at the iterator entry
-            # (zero-touch).
+            # The shared producer stages; the VLM finalizer converts on the
+            # consumer thread. Response-masked streams reject at iterator entry.
             prefetcher = _LazyTextPrefetcher(
                 None,
                 prefetch_depth,
@@ -7171,10 +7154,8 @@ def _iter_lazy_tokenized_text_rows(
         if completion_only_loss is not None:
             return completion_only_loss
         if item_has_boundary or row_has_boundary:
-            # A prompt/completion row always resolves the default mask mode
-            # from its own shape; inheriting a plain-text row's False here
-            # would silently train prompt tokens, and ordering would decide.
-            # The schema/label validators then reject mixed streams.
+            # Resolve from the row's own shape: inheriting a plain-text row's
+            # False would silently train prompt tokens, order-dependently.
             state["pretokenized_completion_only_loss"] = True
             return True
         if "pretokenized_completion_only_loss" in state:
@@ -7185,8 +7166,8 @@ def _iter_lazy_tokenized_text_rows(
         completion_mode,
         has_completion_boundary=False,
     ):
-        # Empty label-owned rows have no token labels, but they also are not an
-        # unlabeled schema transition. A non-None sentinel preserves that fact.
+        # Empty label-owned rows have no labels yet are not an unlabeled schema
+        # transition; a non-None sentinel preserves that.
         label_owned = response_mask_fn is not None or assistant_only_loss or (
             completion_mode is True and has_completion_boundary
         )
@@ -7194,8 +7175,7 @@ def _iter_lazy_tokenized_text_rows(
 
     for item in dataset:
         if reject_rows and _contains_mlx_values(item):
-            # Rows carrying MLX arrays must reject before any parsing,
-            # truthiness probe, or formatter call can touch them off-thread.
+            # Reject before any parse, truthiness probe, or formatter call.
             _reject_mlx_valued_text("the dataset row")
         item_has_completion_boundary = (
             isinstance(item, Mapping)
@@ -7208,8 +7188,7 @@ def _iter_lazy_tokenized_text_rows(
             isinstance(item, list) and not _looks_like_mlx_chat_messages(item)
         ) else [item]
         if not source_rows:
-            # Assistant-only validation applies to the original logical row
-            # before a formatter can replace it or produce side effects.
+            # Validate the original logical row, before any formatter runs.
             source_rows = [None]
         source_has_input_ids = any(
             isinstance(row, Mapping) and "input_ids" in row
@@ -7220,9 +7199,8 @@ def _iter_lazy_tokenized_text_rows(
             and formatting_func is not None
             and "assistant_source_checked" not in state
         ):
-            # Match the eager/SFT contract: validate the first original sample
-            # once, then validate every formatter result below. Pretokenized
-            # rows bypass the formatter and carry their own assistant metadata.
+            # Eager/SFT contract: validate the first original sample once, then
+            # every formatter result below. Pretokenized rows bypass both.
             if not source_has_input_ids:
                 _require_assistant_conversation(item)
             state["assistant_source_checked"] = True
@@ -7241,8 +7219,7 @@ def _iter_lazy_tokenized_text_rows(
                 and not _looks_like_mlx_chat_messages(formatted)
             ) else [formatted]
         if not source_rows:
-            # An empty formatter list expands to zero rows, not one invalid
-            # row. Preserve only its schema/label observation, then continue.
+            # An empty formatter list expands to zero rows, not one invalid row.
             row_completion_only_loss = _resolve_completion_mode(
                 item_has_completion_boundary
             )
@@ -7600,15 +7577,14 @@ class _LazyTextPrefetcher:
                     except Exception:
                         pass
             finally:
-                # Published only after producer-owned cleanup: quiesce() treats
-                # _done as proof the thread no longer touches shared objects.
+                # quiesce() treats _done as proof the thread is finished with
+                # the shared objects, so publish it only after cleanup.
                 self._done.set()
 
     def _ensure_started(self):
         with self._lifecycle_lock:
-            # One lock covers the closed check and thread publication so a
-            # concurrent close() cannot return "clean" and then observe a
-            # producer started afterwards.
+            # One lock covers the closed check and thread publication, so a
+            # concurrent close() cannot report "clean" then see a new producer.
             if self._closed or self._stop.is_set():
                 raise StopIteration
             if self._thread is None:
@@ -7679,10 +7655,8 @@ class _LazyTextPrefetcher:
         and no concurrent closer can observe it half-drained. ``orphaned`` is
         set conservatively before the join, so an interrupted join leaves a live
         producer classified as an orphan rather than falsely clean."""
-        # Mark a conservative orphan up front: if anything below is interrupted
-        # (a signal during lock acquisition, the join, or the drain), the
-        # producer is already recorded as unresolved rather than left falsely
-        # clean. A clean termination clears it below.
+        # Conservative orphan up front: an interrupt during the lock, join, or
+        # drain then leaves the producer unresolved rather than falsely clean.
         self.orphaned = True
         with self._lifecycle_lock:
             self._stop.set()
@@ -7694,11 +7668,9 @@ class _LazyTextPrefetcher:
                 thread.join(timeout=self._JOIN_TIMEOUT)
             terminated = thread is None or not thread.is_alive()
             if terminated:
-                # A joined-dead thread has published its final enqueue and will
-                # never write again, so draining here cannot lose a batch. Clear
-                # the orphan flag only AFTER the drain completes: a signal during
-                # the drain then still leaves a conservative orphan (flag set,
-                # queue not yet empty) for the caller's finally to persist.
+                # A joined-dead thread never writes again, so this cannot lose
+                # a batch. Clear the flag only after the drain, so an interrupt
+                # mid-drain still leaves a conservative orphan.
                 self._drain_envelopes()
                 self.orphaned = False
             return terminated
@@ -7797,9 +7769,8 @@ def _iterate_lazy_text_training_batches(
         # Sequential contract: exact source order, length grouping off.
         length_window = 1
     window_seed = _normalize_seed(window_seed)
-    # Cycle padding only feeds direct multi-rank slicing; the single-process
-    # path and the rank-0 owner iterator (comm_group=None, outer cycle_source)
-    # must not retain a pass-long first batch on top of the window bound.
+    # Cycle padding only feeds direct multi-rank slicing; single-process and
+    # rank-0 owner iterators must not retain a pass-long first batch.
     needs_padding_source = _distributed_rank_size(comm_group)[1] > 1
 
     prepared_view = (
@@ -7876,10 +7847,8 @@ def _iterate_lazy_text_training_batches(
             window_ordinal = 0
 
             def _flush_window():
-                # Emit pooled rows as length-grouped global batches: stable sort
-                # by truncated length with arrival tiebreak, chunk, then a seeded
-                # permutation of the FULL chunks only — a trailing partial chunk
-                # always emits last so mid-stream batches keep uniform row counts.
+                # Stable sort by truncated length, chunk, then seeded-permute
+                # the FULL chunks only, so a partial chunk always emits last.
                 nonlocal window_rows, window_ordinal, yielded
                 if not window_rows:
                     return
@@ -7903,8 +7872,7 @@ def _iterate_lazy_text_training_batches(
                 window_ordinal += 1
                 window_rows = []
                 for chunk_index in emit:
-                    # Release each chunk as it is emitted so flush-time retention
-                    # stays within the W-batch window bound.
+                    # Release each chunk as emitted to stay within the window.
                     chunk = chunks[chunk_index]
                     chunks[chunk_index] = None
                     local_items = _rank_slice_distributed_batch(
@@ -7961,9 +7929,8 @@ def _iterate_lazy_text_training_batches(
                     yield first
 
             def _stoppable(source):
-                # Cooperative cancellation lands between SOURCE rows — checked
-                # BEFORE each pull (a stop during row processing must not cost
-                # another blocking read) and after, for stops during next().
+                # Cancellation lands between source rows: checked before each
+                # pull (so a stop costs no extra blocking read) and after it.
                 iterator = iter(source)
                 while True:
                     if should_stop():
@@ -8119,9 +8086,8 @@ def _iterate_lazy_text_training_batches(
             if replay_iterator is active_iterator
             else (active_iterator, replay_iterator)
         )
-        # A schema/source error may already be unwinding. Cleanup must attempt
-        # every owned cursor without replacing that primary failure. The normal
-        # epoch-boundary close above remains strict and still surfaces errors.
+        # Close every owned cursor without replacing an in-flight failure. The
+        # epoch-boundary close above stays strict and still surfaces errors.
         for iterator in cleanup_iterators:
             try:
                 _close_mlx_owned_iterator(iterator)
@@ -8249,9 +8215,9 @@ def _iterate_dispatched_lazy_text_training_batches(
                     "before split_dataset_by_node(); MLX owns rank partitioning."
                 )
         except BaseException as exc:
-            # Even interrupts must be deferred: peers block in the dispatch
-            # collective below, so rank 0 cannot unwind before the failure
-            # status is broadcast. Re-raised through the loop's rank-0 path.
+            # Defer even interrupts: peers block in the dispatch collective
+            # below, so rank 0 must broadcast the failure status before it
+            # unwinds. Re-raised through the loop's rank-0 path.
             owner_contract_error = exc
         owner_iterator = _iterate_lazy_text_training_batches(
             dataset,
@@ -8273,8 +8239,8 @@ def _iterate_dispatched_lazy_text_training_batches(
             width = 0
             has_labels = 0
             status = 0
-            # Drop the previous fetch's tensors before the owner pulls the next
-            # batch so dispatch never holds two batches alongside the window.
+            # Drop the previous fetch before pulling, so dispatch never holds
+            # two batches alongside the window.
             owner_batch = input_ids = lengths = labels = None
             if rank == 0:
                 try:
@@ -8299,10 +8265,9 @@ def _iterate_dispatched_lazy_text_training_batches(
                 except StopIteration:
                     pass
                 except BaseException as exc:
-                    # Synchronize interrupts too (KeyboardInterrupt during a
-                    # source/formatter/tokenizer call): peers are entering the
-                    # all_sum below and would hang if rank 0 unwound past it.
-                    # The original error is re-raised on rank 0 after sync.
+                    # Synchronize interrupts too: peers are entering the all_sum
+                    # below and would hang if rank 0 unwound past it. The
+                    # original error is re-raised on rank 0 after the sync.
                     owner_error = exc
                     status = -1
 


### PR DESCRIPTION
## Summary

MLX text and VLM training now work end to end with lazy / streaming datasets (Hugging Face `IterableDataset`, generators, custom iterables), which previously required sized, indexable sources. On top of the streaming lifecycle, two opt-in throughput features: bounded length-grouped batching and background batch prefetch. The CUDA path already supports streaming through the HF/TRL stack; this brings the MLX trainer to parity without ever materializing the source.

## What's new

- **Lazy text lifecycle**: sources are classified without probing (`len()`, indexing, and listing are never called); replayable vs one-shot semantics with per-pass `set_epoch`; actionable errors for exhausted one-shot sources; resume fast-forward validates replayability before consuming anything. Pretokenized, raw-text, chat, formatter, prompt/completion, and labeled rows all stream, with mixed schemas rejected.
- **Streaming eval, declared-length epochs, DDP owner dispatch**: `expected_rows_per_pass` validates per-pass cardinality, eval no longer requires a sized source, and under DDP rank 0 owns source consumption and dispatches batch slices so a stream is consumed exactly once globally.
- **Lazy VLM streaming**: the unsized VLM path is rebuilt on the same lifecycle contracts (it previously re-iterated the raw source every pass with no epoch or replay semantics); trainability filtering, label masking, and collation reuse the sized-path helpers unchanged.
- **Length-grouping window** (`streaming_text_length_window_batches`, default 8): pools a bounded number of global micro-batches, stable-sorts pooled rows by truncated prepared length, and emits full chunks in a seeded deterministic permutation (partial chunk last) — less padding waste at a bounded memory hold. `dataset_order="sequential"` or a window of 1 preserves exact source order.
- **Background prefetch** (`streaming_prefetch_batches`, default 0 = off): one producer thread stages up to N batches ahead (source pulls, formatting, tokenization, collation) while MLX conversion and label decisions stay on the consumer thread. Cancellation is cooperative, checkpoint saves pause/resume the producer, and a producer that cannot stop within a bounded join is quarantined so shared tokenizer/processor objects are never reused while its thread lives. Single-process only; disabled with a one-time notice under DDP.

## Behavior and compatibility

- Default-order lazy text batches are now length-grouped and deterministically permuted (window default 8). Exact arrival order remains via `dataset_order="sequential"` or `streaming_text_length_window_batches=1`. Sized datasets, eager training, and eval batching are unchanged.
- **Intentional break**: multi-rank lazy VLM previously trained every rank on the full stream (silent duplication, no slicing); it now rejects up front with a synchronized error on all ranks. Single-process lazy VLM is fully supported; rank-owned VLM dispatch is future work. Sized VLM under DDP is unchanged.
- Unsized VLM eval raises an actionable error instead of crashing on `len()`.
- With prefetch enabled, MLX-array values coming from dataset rows, formatters, tokenizers, or templates reject with a `streaming_prefetch_batches=0` remedy — converting them off the consumer thread is unsafe. Processor outputs are the exception (below). Synchronous behavior is unchanged.

## Design notes

- **Host-staging seam**: batch preparation is split into thread-safe host stagers and a single consumer-thread MLX finalizer per modality; every text chokepoint tracks value provenance and rejects pre-conversion in producer mode.
- **Opaque processor staging**: real `mlx-vlm` processors return `mx.array` outputs regardless of `return_tensors="np"`, so the collator materializes the processor's own pending graphs on the producer thread (lazy MLX graphs cannot be evaluated from another thread) and defers label decisions to the consumer-side finalizer. Prompt/completion batches carry the two processor result mappings plus snapshotted tokenizer scalars — never the live processor.
- **Exact read-ahead**: a queue slot is reserved before staging each batch, so memory held is exactly the configured depth, and producer exceptions surface in FIFO position after previously staged batches.
- Float/exotic token-id streams and `train_on_responses_only` closures (defined on converted, compile-prepared tensors) route to the bit-exact synchronous path and reject in producer mode.

## Validation

- 189 unit tests across the five MLX suites covering this area, incl. threaded prefetch lifecycle (quiesce/resume, idempotent close, orphan quarantine, positioned exceptions), a lazy-processor regression that fails without the materialization barrier, and prefetch-vs-sync bit parity for plain-SFT and prompt/completion incl. label dtypes.
- 9 Metal tests incl. a real 2-rank DDP probe (owner-dispatched windowed text stream + the synchronized lazy-VLM rejection).
- Real streaming LoRA training with prefetch on both modalities (`Qwen2.5-0.5B-Instruct-4bit`, `Qwen2-VL-2B-Instruct-4bit`): finite losses, checkpoint saves exercising producer pause/resume.
- Throughput, collation-heavy VLM stream on an M-series machine: prefetch depth 2 cut mean step time ~32% (0.423 s → 0.286 s); text ~3%. The default stays off.

```bash
python -m pytest tests/test_mlx_trainer_internals.py tests/test_mlx_vlm_label_masks.py tests/test_mlx_batching_and_decay.py tests/test_mlx_batch_padding.py tests/test_mlx_distributed_loader.py -q   # 189 passed
python -m pytest tests/test_mlx_ddp_metal.py tests/test_mlx_pr684_full_validation_metal.py tests/test_mlx_training_e2e_metal.py -q   # 9 passed (Apple Silicon)
```
