### PR TITLE
Auto-disable gradient-checkpoint double buffering on unified-memory GPUs

### DIFF
--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -70,20 +70,28 @@ def _any_device_integrated():
         return False
 
 
-def _double_buffer_disabled():
-    # Double buffering overlaps the H2D offload copy with compute, but on unified-
-    # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to
-    # hide: pure overhead (~2x slower, no memory saved). UNSLOTH_DISABLE_DOUBLE_BUFFER
-    # =0/1 forces it; else disable when any visible device is integrated.
-    env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
-    if env is not None: return env == "1"
-    if DEVICE_TYPE not in ("cuda", "hip"): return False
-    return _any_device_integrated()
+# Whether to skip double buffering. Resolved lazily on the first checkpointing init
+# (below) and cached here -- NOT at import: get_device_properties forces CUDA lazy-init
+# on GPU 0, which would poison fork workers and pre-empt per-rank device selection.
+# None = unresolved. UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 forces it either way.
+UNSLOTH_DOUBLE_BUFFER_DISABLED = None
 
-# Resolved once at import, like DEVICE_TYPE / DEVICE_COUNT (the visible device set and
-# env are fixed by then). Set UNSLOTH_DISABLE_DOUBLE_BUFFER before importing unsloth
-# to override.
-UNSLOTH_DOUBLE_BUFFER_DISABLED = _double_buffer_disabled()
+
+def _double_buffer_disabled():
+    # Resolve once (after the caller has selected its device), memoized into the global.
+    # Double buffering overlaps the H2D offload copy with compute, but on unified-memory
+    # devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to hide: pure
+    # overhead (~2x slower, no memory saved), so disable when any device is integrated.
+    global UNSLOTH_DOUBLE_BUFFER_DISABLED
+    if UNSLOTH_DOUBLE_BUFFER_DISABLED is None:
+        env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
+        if env is not None:
+            UNSLOTH_DOUBLE_BUFFER_DISABLED = env == "1"
+        elif DEVICE_TYPE not in ("cuda", "hip"):
+            UNSLOTH_DOUBLE_BUFFER_DISABLED = False
+        else:
+            UNSLOTH_DOUBLE_BUFFER_DISABLED = _any_device_integrated()
+    return UNSLOTH_DOUBLE_BUFFER_DISABLED
 
 
 @contextmanager
@@ -457,7 +465,7 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
         with _no_inference_mode():
             GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
         # Double buffering: try to allocate buffer B (auto-off on unified memory, or via env var)
-        if UNSLOTH_DOUBLE_BUFFER_DISABLED:
+        if _double_buffer_disabled():
             GPU_BUFFERS_B = None
             USE_DOUBLE_BUFFER = False
             BUFFER_EVENTS_A = None
@@ -1038,7 +1046,7 @@ def reset_unsloth_gradient_checkpointing_buffers():
             NEXT_BUFFER_SLOT[i] = 0
 
     # Reset double buffering if buffer B still exists, or try to re-allocate
-    if UNSLOTH_DOUBLE_BUFFER_DISABLED:
+    if _double_buffer_disabled():
         if GPU_BUFFERS_B is not None:
             for i in range(len(GPU_BUFFERS_B)):
                 if GPU_BUFFERS_B[i] is not None and hasattr(GPU_BUFFERS_B[i], "resize_"):

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -59,8 +59,8 @@ DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable doub
 
 def _any_device_integrated():
     # True if ANY visible CUDA/HIP device is integrated (unified memory). A single
-    # static check on purpose: an integrated device anywhere makes the global double-
-    # buffer flag pure overhead, and a mixed integrated + discrete box is rare.
+    # static check on purpose: an integrated device anywhere makes double buffering
+    # pure overhead, and a mixed integrated + discrete box is rare.
     try:
         return any(
             bool(getattr(torch.cuda.get_device_properties(i), "is_integrated", 0))
@@ -70,28 +70,16 @@ def _any_device_integrated():
         return False
 
 
-# Whether to skip double buffering. Resolved lazily on the first checkpointing init
-# (below) and cached here -- NOT at import: get_device_properties forces CUDA lazy-init
-# on GPU 0, which would poison fork workers and pre-empt per-rank device selection.
-# None = unresolved. UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 forces it either way.
-UNSLOTH_DOUBLE_BUFFER_DISABLED = None
-
-
 def _double_buffer_disabled():
-    # Resolve once (after the caller has selected its device), memoized into the global.
-    # Double buffering overlaps the H2D offload copy with compute, but on unified-memory
-    # devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to hide: pure
-    # overhead (~2x slower, no memory saved), so disable when any device is integrated.
-    global UNSLOTH_DOUBLE_BUFFER_DISABLED
-    if UNSLOTH_DOUBLE_BUFFER_DISABLED is None:
-        env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
-        if env is not None:
-            UNSLOTH_DOUBLE_BUFFER_DISABLED = env == "1"
-        elif DEVICE_TYPE not in ("cuda", "hip"):
-            UNSLOTH_DOUBLE_BUFFER_DISABLED = False
-        else:
-            UNSLOTH_DOUBLE_BUFFER_DISABLED = _any_device_integrated()
-    return UNSLOTH_DOUBLE_BUFFER_DISABLED
+    # Double buffering overlaps the H2D offload copy with compute, but on unified-
+    # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to hide:
+    # pure overhead (~2x slower, no memory saved). UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1
+    # forces it; else disable when any visible device is integrated. Called at GC init,
+    # not import, so it never probes the GPU before the caller selects its device.
+    env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
+    if env is not None: return env == "1"
+    if DEVICE_TYPE not in ("cuda", "hip"): return False
+    return _any_device_integrated()
 
 
 @contextmanager

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -60,9 +60,8 @@ DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable doub
 
 @functools.cache
 def _device_is_integrated(idx):
-    # Cached per device index: a device's integrated flag is immutable for the
-    # process. Keyed by idx (not zero-arg) so a mid-process set_device() on a
-    # mixed APU + discrete box still reflects the device selected for this run.
+    # Cached per device index (the integrated flag never changes); keyed by idx so a
+    # mid-process set_device() on a mixed APU + discrete box picks the right device.
     try:
         return bool(getattr(torch.cuda.get_device_properties(idx), "is_integrated", 0))
     except Exception:
@@ -70,13 +69,11 @@ def _device_is_integrated(idx):
 
 
 def _double_buffer_disabled():
-    # Double buffering overlaps the H2D offload copy with compute. On unified-
-    # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) GPU and system RAM are
-    # one physical pool, so there is no real transfer to hide: the overlap is
-    # pure overhead (~2x slower, no memory saved). Default it off there; an
-    # explicit UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins (read every call).
-    # Gate on the active device (read fresh) so an unrelated integrated device
-    # never disables the overlap for a discrete GPU.
+    # Double buffering overlaps the H2D offload copy with compute, but on unified-
+    # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to
+    # hide: pure overhead (~2x slower, no memory saved), so default it off there.
+    # Env UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins; gate on the live active
+    # device so a mixed box does not disable the overlap for a discrete GPU.
     env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
     if env is not None: return env == "1"
     if DEVICE_TYPE not in ("cuda", "hip"): return False

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -58,12 +58,10 @@ INITIAL_CPU_BUFFER_COUNT = 200             # number of CPU buffers
 DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable double buffering
 
 
-@functools.cache
 def _any_device_integrated():
-    # True if ANY visible CUDA/HIP device is integrated (unified memory). The visible
-    # device set is fixed for the process, so this is computed once. A single static
-    # check on purpose: an integrated device anywhere makes the global double-buffer
-    # flag pure overhead, and a mixed integrated + discrete box is vanishingly rare.
+    # True if ANY visible CUDA/HIP device is integrated (unified memory). A single
+    # static check on purpose: an integrated device anywhere makes the global double-
+    # buffer flag pure overhead, and a mixed integrated + discrete box is rare.
     try:
         return any(
             bool(getattr(torch.cuda.get_device_properties(i), "is_integrated", 0))
@@ -73,12 +71,14 @@ def _any_device_integrated():
         return False
 
 
+@functools.cache
 def _double_buffer_disabled():
-    # Double buffering overlaps the H2D offload copy with compute, but on unified-
-    # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to
-    # hide: pure overhead (~2x slower, no memory saved), so default it off there.
-    # Env UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins; otherwise disable whenever
-    # any visible device is integrated.
+    # Decided once per process (cached): the env and the visible device set are both
+    # fixed by the time gradient checkpointing initializes. Double buffering overlaps
+    # the H2D offload copy with compute, but on unified-memory devices (AMD APUs
+    # gfx1150/1151, NVIDIA GB10) there is no transfer to hide: pure overhead (~2x
+    # slower, no memory saved). UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 forces it (set it
+    # before the first GC init); else disable when any visible device is integrated.
     env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
     if env is not None: return env == "1"
     if DEVICE_TYPE not in ("cuda", "hip"): return False

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -19,7 +19,6 @@ import numpy as np
 from typing import Union, Optional, List, Any, Callable, Tuple
 from contextlib import contextmanager, nullcontext
 import os
-import functools
 import warnings
 import gc
 import threading
@@ -71,18 +70,20 @@ def _any_device_integrated():
         return False
 
 
-@functools.cache
 def _double_buffer_disabled():
-    # Decided once per process (cached): the env and the visible device set are both
-    # fixed by the time gradient checkpointing initializes. Double buffering overlaps
-    # the H2D offload copy with compute, but on unified-memory devices (AMD APUs
-    # gfx1150/1151, NVIDIA GB10) there is no transfer to hide: pure overhead (~2x
-    # slower, no memory saved). UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 forces it (set it
-    # before the first GC init); else disable when any visible device is integrated.
+    # Double buffering overlaps the H2D offload copy with compute, but on unified-
+    # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to
+    # hide: pure overhead (~2x slower, no memory saved). UNSLOTH_DISABLE_DOUBLE_BUFFER
+    # =0/1 forces it; else disable when any visible device is integrated.
     env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
     if env is not None: return env == "1"
     if DEVICE_TYPE not in ("cuda", "hip"): return False
     return _any_device_integrated()
+
+# Resolved once at import, like DEVICE_TYPE / DEVICE_COUNT (the visible device set and
+# env are fixed by then). Set UNSLOTH_DISABLE_DOUBLE_BUFFER before importing unsloth
+# to override.
+UNSLOTH_DOUBLE_BUFFER_DISABLED = _double_buffer_disabled()
 
 
 @contextmanager
@@ -456,7 +457,7 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
         with _no_inference_mode():
             GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
         # Double buffering: try to allocate buffer B (auto-off on unified memory, or via env var)
-        if _double_buffer_disabled():
+        if UNSLOTH_DOUBLE_BUFFER_DISABLED:
             GPU_BUFFERS_B = None
             USE_DOUBLE_BUFFER = False
             BUFFER_EVENTS_A = None
@@ -1037,7 +1038,7 @@ def reset_unsloth_gradient_checkpointing_buffers():
             NEXT_BUFFER_SLOT[i] = 0
 
     # Reset double buffering if buffer B still exists, or try to re-allocate
-    if _double_buffer_disabled():
+    if UNSLOTH_DOUBLE_BUFFER_DISABLED:
         if GPU_BUFFERS_B is not None:
             for i in range(len(GPU_BUFFERS_B)):
                 if GPU_BUFFERS_B[i] is not None and hasattr(GPU_BUFFERS_B[i], "resize_"):

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -67,8 +67,11 @@ def _double_buffer_disabled():
     if env is not None: return env == "1"
     if DEVICE_TYPE not in ("cuda", "hip"): return False
     try:
-        return any(getattr(torch.cuda.get_device_properties(i), "is_integrated", 0)
-                   for i in range(torch.cuda.device_count()))
+        # Gate on the active training device, not any visible one: a discrete
+        # GPU sharing a box with an APU has a real H2D copy and should keep the
+        # overlap, so an unrelated integrated device must not disable it.
+        idx = torch.cuda.current_device()
+        return bool(getattr(torch.cuda.get_device_properties(idx), "is_integrated", 0))
     except Exception:
         return False
 

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -19,6 +19,7 @@ import numpy as np
 from typing import Union, Optional, List, Any, Callable, Tuple
 from contextlib import contextmanager, nullcontext
 import os
+import functools
 import warnings
 import gc
 import threading
@@ -57,23 +58,30 @@ INITIAL_CPU_BUFFER_COUNT = 200             # number of CPU buffers
 DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable double buffering
 
 
+@functools.cache
+def _active_device_is_integrated():
+    # Gate on the active training device, not any visible one: a discrete GPU
+    # sharing a box with an APU has a real H2D copy and should keep the overlap,
+    # so an unrelated integrated device must not disable it. Cached: a device's
+    # integrated flag is immutable for the process (call _active_device_is_
+    # integrated.cache_clear() if the visible-device set is swapped mid-process).
+    if DEVICE_TYPE not in ("cuda", "hip"): return False
+    try:
+        idx = torch.cuda.current_device()
+        return bool(getattr(torch.cuda.get_device_properties(idx), "is_integrated", 0))
+    except Exception:
+        return False
+
+
 def _double_buffer_disabled():
     # Double buffering overlaps the H2D offload copy with compute. On unified-
     # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) GPU and system RAM are
     # one physical pool, so there is no real transfer to hide: the overlap is
     # pure overhead (~2x slower, no memory saved). Default it off there; an
-    # explicit UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins.
+    # explicit UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins (read every call).
     env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
     if env is not None: return env == "1"
-    if DEVICE_TYPE not in ("cuda", "hip"): return False
-    try:
-        # Gate on the active training device, not any visible one: a discrete
-        # GPU sharing a box with an APU has a real H2D copy and should keep the
-        # overlap, so an unrelated integrated device must not disable it.
-        idx = torch.cuda.current_device()
-        return bool(getattr(torch.cuda.get_device_properties(idx), "is_integrated", 0))
-    except Exception:
-        return False
+    return _active_device_is_integrated()
 
 
 @contextmanager

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -57,6 +57,22 @@ INITIAL_CPU_BUFFER_COUNT = 200             # number of CPU buffers
 DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable double buffering
 
 
+def _double_buffer_disabled():
+    # Double buffering overlaps the H2D offload copy with compute. On unified-
+    # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) GPU and system RAM are
+    # one physical pool, so there is no real transfer to hide: the overlap is
+    # pure overhead (~2x slower, no memory saved). Default it off there; an
+    # explicit UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins.
+    env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
+    if env is not None: return env == "1"
+    if DEVICE_TYPE not in ("cuda", "hip"): return False
+    try:
+        return any(getattr(torch.cuda.get_device_properties(i), "is_integrated", 0)
+                   for i in range(torch.cuda.device_count()))
+    except Exception:
+        return False
+
+
 @contextmanager
 def _no_inference_mode():
     # Allocate GC buffers outside inference_mode (but in no_grad) so a later
@@ -427,8 +443,8 @@ def initialize_unsloth_gradient_checkpointing(dtype = None):
     try:
         with _no_inference_mode():
             GPU_BUFFERS = tuple([torch.empty(INITIAL_GPU_BUFFER_SIZE, dtype = dtype, device = f"{DEVICE_TYPE_TORCH}:{i}") for i in range(n_gpus)])
-        # Double buffering: try to allocate buffer B (can be disabled via env var)
-        if os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER", "0") == "1":
+        # Double buffering: try to allocate buffer B (auto-off on unified memory, or via env var)
+        if _double_buffer_disabled():
             GPU_BUFFERS_B = None
             USE_DOUBLE_BUFFER = False
             BUFFER_EVENTS_A = None
@@ -1009,7 +1025,7 @@ def reset_unsloth_gradient_checkpointing_buffers():
             NEXT_BUFFER_SLOT[i] = 0
 
     # Reset double buffering if buffer B still exists, or try to re-allocate
-    if os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER", "0") == "1":
+    if _double_buffer_disabled():
         if GPU_BUFFERS_B is not None:
             for i in range(len(GPU_BUFFERS_B)):
                 if GPU_BUFFERS_B[i] is not None and hasattr(GPU_BUFFERS_B[i], "resize_"):

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -59,11 +59,16 @@ DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable doub
 
 
 @functools.cache
-def _device_is_integrated(idx):
-    # Cached per device index (the integrated flag never changes); keyed by idx so a
-    # mid-process set_device() on a mixed APU + discrete box picks the right device.
+def _any_device_integrated():
+    # True if ANY visible CUDA/HIP device is integrated (unified memory). The visible
+    # device set is fixed for the process, so this is computed once. A single static
+    # check on purpose: an integrated device anywhere makes the global double-buffer
+    # flag pure overhead, and a mixed integrated + discrete box is vanishingly rare.
     try:
-        return bool(getattr(torch.cuda.get_device_properties(idx), "is_integrated", 0))
+        return any(
+            bool(getattr(torch.cuda.get_device_properties(i), "is_integrated", 0))
+            for i in range(torch.cuda.device_count())
+        )
     except Exception:
         return False
 
@@ -72,15 +77,12 @@ def _double_buffer_disabled():
     # Double buffering overlaps the H2D offload copy with compute, but on unified-
     # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to
     # hide: pure overhead (~2x slower, no memory saved), so default it off there.
-    # Env UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins; gate on the live active
-    # device so a mixed box does not disable the overlap for a discrete GPU.
+    # Env UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins; otherwise disable whenever
+    # any visible device is integrated.
     env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
     if env is not None: return env == "1"
     if DEVICE_TYPE not in ("cuda", "hip"): return False
-    try:
-        return _device_is_integrated(torch.cuda.current_device())
-    except Exception:
-        return False
+    return _any_device_integrated()
 
 
 @contextmanager

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -19,6 +19,7 @@ import numpy as np
 from typing import Union, Optional, List, Any, Callable, Tuple
 from contextlib import contextmanager, nullcontext
 import os
+import functools
 import warnings
 import gc
 import threading
@@ -70,12 +71,14 @@ def _any_device_integrated():
         return False
 
 
+@functools.cache
 def _double_buffer_disabled():
-    # Double buffering overlaps the H2D offload copy with compute, but on unified-
-    # memory devices (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to hide:
-    # pure overhead (~2x slower, no memory saved). UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1
-    # forces it; else disable when any visible device is integrated. Called at GC init,
-    # not import, so it never probes the GPU before the caller selects its device.
+    # Cached: computed once on the first GC init (after device selection), never at
+    # import, so it does not probe the GPU before the caller picks its device. Double
+    # buffering overlaps the H2D offload copy with compute, but on unified-memory devices
+    # (AMD APUs gfx1150/1151, NVIDIA GB10) there is no transfer to hide: pure overhead
+    # (~2x slower, no memory saved). UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 forces it; else
+    # disable when any visible device is integrated.
     env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
     if env is not None: return env == "1"
     if DEVICE_TYPE not in ("cuda", "hip"): return False

--- a/unsloth_zoo/gradient_checkpointing.py
+++ b/unsloth_zoo/gradient_checkpointing.py
@@ -59,15 +59,11 @@ DOUBLE_BUFFER_HEADROOM = 512 * 1024 * 1024 # min free CUDA memory to enable doub
 
 
 @functools.cache
-def _active_device_is_integrated():
-    # Gate on the active training device, not any visible one: a discrete GPU
-    # sharing a box with an APU has a real H2D copy and should keep the overlap,
-    # so an unrelated integrated device must not disable it. Cached: a device's
-    # integrated flag is immutable for the process (call _active_device_is_
-    # integrated.cache_clear() if the visible-device set is swapped mid-process).
-    if DEVICE_TYPE not in ("cuda", "hip"): return False
+def _device_is_integrated(idx):
+    # Cached per device index: a device's integrated flag is immutable for the
+    # process. Keyed by idx (not zero-arg) so a mid-process set_device() on a
+    # mixed APU + discrete box still reflects the device selected for this run.
     try:
-        idx = torch.cuda.current_device()
         return bool(getattr(torch.cuda.get_device_properties(idx), "is_integrated", 0))
     except Exception:
         return False
@@ -79,9 +75,15 @@ def _double_buffer_disabled():
     # one physical pool, so there is no real transfer to hide: the overlap is
     # pure overhead (~2x slower, no memory saved). Default it off there; an
     # explicit UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1 always wins (read every call).
+    # Gate on the active device (read fresh) so an unrelated integrated device
+    # never disables the overlap for a discrete GPU.
     env = os.environ.get("UNSLOTH_DISABLE_DOUBLE_BUFFER")
     if env is not None: return env == "1"
-    return _active_device_is_integrated()
+    if DEVICE_TYPE not in ("cuda", "hip"): return False
+    try:
+        return _device_is_integrated(torch.cuda.current_device())
+    except Exception:
+        return False
 
 
 @contextmanager


### PR DESCRIPTION
### What

Auto-disable gradient-checkpoint double buffering on unified-memory GPUs (AMD APUs, NVIDIA GB10 Spark).

### Why

Double buffering allocates a second GPU offload buffer (buffer B) so the H2D copy of the next checkpoint can overlap with compute. On a **discrete** GPU that overlap hides a real PCIe transfer and is a win. On a **unified-memory** device the GPU and system RAM are the same physical pool, so there is no transfer to hide: the extra buffer, the second stream, and the per-buffer events are pure overhead.

Measured on a Ryzen AI MAX+ 395 (gfx1151 Strix Halo, `is_integrated=1`), Qwen3.5-2B 4bit LoRA, `use_gradient_checkpointing="unsloth"`:

| | double buffer ON (old default) | OFF (new default on UMA) |
|---|---|---|
| peak allocated | 3381 MB | 3377 MB |
| peak reserved | 3867 MB | 3861 MB |
| steady step | 3.620 s | **1.684 s** |

So ~2.15x faster steps, no memory change, identical loss.

### How

Both the init path (`initialize_unsloth_gradient_checkpointing`) and the reset path (`reset_unsloth_gradient_checkpointing_buffers`) now go through one helper, `_double_buffer_disabled()`:

- explicit `UNSLOTH_DISABLE_DOUBLE_BUFFER=0/1` always wins (either direction);
- when unset, defaults **off** if torch reports `is_integrated` on any visible cuda/hip device, else **on**.

`is_integrated` is the driver's own unified-memory answer (`hipDeviceProp_t.integrated` / `cudaDeviceProp.integrated`), so this also covers integrated parts outside a hardcoded arch list (e.g. gfx1103 Phoenix, GB10).

### Scope / safety

- Discrete NVIDIA and AMD GPUs report `is_integrated=0`, so their behaviour is unchanged (double buffering stays on).
- `getattr(..., "is_integrated", 0)` and the `try/except` keep it safe on older torch that lacks the attribute (falls back to on).
- Non cuda/hip backends (xpu) are untouched.

Verified: helper returns `True` (env unset, APU), `False` (env=0), `True` (env=1), and `False` (discrete, env unset); file passes `ast.parse`.
