### PR TITLE
MLX: faithful fused CCE for scaled/transformed output heads, head-eligibility gating, and label smoothing

### DIFF
--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -295,26 +295,24 @@ def test_get_logit_scale_normalization(where, value, expected):
     assert _get_logit_scale(_stub_model(where, value)) == expected
 
 
-def test_invalid_logit_scale_selects_baseline_fallback():
-    # Selection precedes lm-head introspection, so a bare stub suffices.
-    from unsloth_zoo.mlx.utils import make_cce_loss_fn
-
-    fn = make_cce_loss_fn(_stub_model("args", float("nan")))
-    assert getattr(fn, "_unsloth_cce_backend", "") == "baseline-fallback"
-
-
 @pytest.mark.parametrize("case", ["no_embeddings", "no_backbone", "invalid_scale"])
 def test_vlm_cce_fallbacks_are_marked(case):
     # Every VLM fallback path must return a loss fn carrying the eager
     # fallback marker.
     from unsloth_zoo.mlx.utils import make_vlm_cce_loss_fn
 
+    from unsloth_zoo.mlx import utils as U
+
     model = _stub_model()
-    model.language_model = _stub_model(
-        "args", float("nan") if case == "invalid_scale" else 0.0625
-    )
-    if case != "no_backbone":
-        model.language_model.model = object()  # separable backbone present
+    if case == "invalid_scale":
+        lm = _lm(U.nn, head=U.nn.Linear(32, 96, bias=False))
+        lm.args = type("A", (), {})()
+        lm.args.logit_scale = float("nan")
+        model.language_model = lm
+    else:
+        model.language_model = _stub_model("args", 0.0625)
+        if case != "no_backbone":
+            model.language_model.model = object()  # separable backbone present
     if case != "no_embeddings":
         model.get_input_embeddings = lambda: None
     with pytest.warns(UserWarning) if case != "invalid_scale" else _no_warning():

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -295,6 +295,26 @@ def test_get_logit_scale_normalization(where, value, expected):
     assert _get_logit_scale(_stub_model(where, value)) == expected
 
 
+def test_backboneless_text_model_selects_baseline_fallback(capsys):
+    # nanochat shape (stack under .transformer, no separable .model): the
+    # biased head would trip the eligibility gate, so seeing ONLY the topology
+    # notice pins topology as decided first, at construction not first use.
+    from unsloth_zoo.mlx import utils as U
+
+    nn = U.nn
+
+    class _BackbonelessLM(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.transformer = nn.Module()
+            self.lm_head = nn.Linear(32, 96, bias=True)
+
+    fn = U.make_cce_loss_fn(_BackbonelessLM())
+    assert getattr(fn, "_unsloth_cce_backend", "") == "baseline-fallback"
+    out = capsys.readouterr().out
+    assert "separable hidden-state backbone" in out and "output head" not in out
+
+
 @pytest.mark.parametrize("case", ["no_embeddings", "no_backbone", "invalid_scale"])
 def test_vlm_cce_fallbacks_are_marked(case):
     # Every VLM fallback path must return a loss fn carrying the eager

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -344,6 +344,33 @@ def test_softcap_alias_value_domain(value, expected):
         assert (softcap, problem) == expected
 
 
+def test_is_lm_head_trainable_follows_descriptor_path():
+    from unsloth_zoo.mlx import utils as U
+
+    nn = U.nn
+    # Alt-named tied embedding (InternLM2 tok_embeddings) trains under full
+    # fine-tuning: name segments used to miss it and drop the head gradient.
+    assert U._is_lm_head_trainable(
+        _lm(nn, tied_flag=True, emb_name="tok_embeddings")) is True
+    # Property-backed wrapper: language_model returns self, so the descriptor
+    # access path is not a registered prefix — module identity must still find
+    # the head in the parameter tree.
+    class _PropWrapped(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lm_head = nn.Linear(32, 96, bias=False)
+
+        @property
+        def language_model(self):
+            return self
+
+    assert U._is_lm_head_trainable(_PropWrapped()) is True
+    # Unresolved head never reports trainable, even with an empty tree.
+    unresolved = _lm(nn)
+    unresolved.freeze()
+    assert U._is_lm_head_trainable(unresolved) is False
+
+
 def test_backboneless_text_model_selects_baseline_fallback(capsys):
     # nanochat shape (stack under .transformer, no separable .model): the
     # biased head would trip the eligibility gate, so seeing ONLY the topology

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -325,6 +325,25 @@ def test_detect_head_transform_rows(attrs, status, expected):
         assert (scale, problem) == expected
 
 
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (30.0, (30.0, None)),
+        (None, (0.0, None)),   # falsy: the forward skips the cap
+        (-5.0, "positive"),
+        (True, "not a finite real scalar"),
+    ],
+)
+def test_softcap_alias_value_domain(value, expected):
+    from unsloth_zoo.mlx.utils import _detect_logit_softcap
+
+    softcap, problem = _detect_logit_softcap(_knobbed(logits_soft_cap=value))
+    if isinstance(expected, str):
+        assert problem is not None and expected in problem
+    else:
+        assert (softcap, problem) == expected
+
+
 def test_backboneless_text_model_selects_baseline_fallback(capsys):
     # nanochat shape (stack under .transformer, no separable .model): the
     # biased head would trip the eligibility gate, so seeing ONLY the topology
@@ -345,19 +364,23 @@ def test_backboneless_text_model_selects_baseline_fallback(capsys):
     assert "separable hidden-state backbone" in out and "output head" not in out
 
 
-@pytest.mark.parametrize("case", ["no_embeddings", "no_backbone", "invalid_scale"])
+@pytest.mark.parametrize("case", ["no_embeddings", "no_backbone", "invalid_scale",
+                                  "masked_tail_knob"])
 def test_vlm_cce_fallbacks_are_marked(case):
-    # Every VLM fallback path must return a loss fn carrying the eager
-    # fallback marker.
+    # Every VLM fallback path returns a loss fn carrying the eager marker,
+    # including the knob-table routes (invalid scale, masked-tail knob).
     from unsloth_zoo.mlx.utils import make_vlm_cce_loss_fn
 
     from unsloth_zoo.mlx import utils as U
 
     model = _stub_model()
-    if case == "invalid_scale":
+    if case in ("invalid_scale", "masked_tail_knob"):
         lm = _lm(U.nn, head=U.nn.Linear(32, 96, bias=False))
         lm.args = type("A", (), {})()
-        lm.args.logit_scale = float("nan")
+        if case == "invalid_scale":
+            lm.args.logit_scale = float("nan")
+        else:
+            lm.args.mup_width_multiplier = 2.0
         model.language_model = lm
     else:
         model.language_model = _stub_model("args", 0.0625)
@@ -365,7 +388,8 @@ def test_vlm_cce_fallbacks_are_marked(case):
             model.language_model.model = object()  # separable backbone present
     if case != "no_embeddings":
         model.get_input_embeddings = lambda: None
-    with pytest.warns(UserWarning) if case != "invalid_scale" else _no_warning():
+    warns = case in ("no_embeddings", "no_backbone")
+    with pytest.warns(UserWarning) if warns else _no_warning():
         fn = make_vlm_cce_loss_fn(model)
     assert getattr(fn, "_unsloth_cce_backend", "") == "baseline-fallback"
 

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -344,6 +344,35 @@ def test_softcap_alias_value_domain(value, expected):
         assert (softcap, problem) == expected
 
 
+def test_dead_tie_flag_fails_closed_to_unknown():
+    from unsloth_zoo.mlx import utils as U
+
+    nn = U.nn
+    head = lambda: nn.Linear(32, 96, bias=False)
+    # Qwen2-MoE hazard: True flag never referenced + unconditional lm_head call.
+    desc = U.describe_output_head(
+        _lm(nn, args_flag=True, head=head(), call_src="calls_lm_head"))
+    assert desc.status == "unknown" and desc.candidate_path == "lm_head"
+    assert U._cce_head_ineligibility(desc) is not None
+    # A referenced flag keeps tied (flag_ref pins the `not references_flag` conjunct).
+    for src in ("flag_guarded", "flag_ref_calls_lm_head"):
+        d = U.describe_output_head(_lm(nn, args_flag=True, head=head(), call_src=src))
+        assert d.status == "tied" and d.path == "model.embed_tokens"
+    # False flag resolves the live head; no live head keeps the True flag tied.
+    assert U.describe_output_head(
+        _lm(nn, args_flag=False, head=head(), call_src="calls_lm_head")).status == "untied"
+    assert U.describe_output_head(
+        _lm(nn, args_flag=True, emb_name="tok_embeddings")).status == "tied"
+    # A non-bool truthy tie flag (int 1 or string "true"; from_dict does not
+    # coerce) is read by truthiness like the forward -> tied, not a fall-through
+    # to lm_head; a falsy value ("" / 0) stays untied.
+    for truthy in (1, "true"):
+        assert U.describe_output_head(
+            _lm(nn, args_flag=truthy, head=head(), call_src="flag_guarded")).status == "tied"
+    assert U.describe_output_head(
+        _lm(nn, args_flag="", head=head(), call_src="calls_lm_head")).status == "untied"
+
+
 def test_is_lm_head_trainable_follows_descriptor_path():
     from unsloth_zoo.mlx import utils as U
 
@@ -444,6 +473,21 @@ def _lm(nn, tied_flag=_UNSET, args_flag=_UNSET, head=None, emb_name="embed_token
         class _LM(nn.Module):
             def __call__(self, x):
                 return self.model.embed_tokens.as_linear(x)
+    elif call_src == "calls_lm_head":
+        class _LM(nn.Module):
+            def __call__(self, x):
+                return self.lm_head(x)
+    elif call_src == "flag_guarded":
+        class _LM(nn.Module):
+            def __call__(self, x):
+                if self.args.tie_word_embeddings:
+                    return self.model.embed_tokens.as_linear(x)
+                return self.lm_head(x)
+    elif call_src == "flag_ref_calls_lm_head":
+        class _LM(nn.Module):
+            def __call__(self, x):
+                _ = self.args.tie_word_embeddings
+                return self.lm_head(x)
     else:
         class _LM(nn.Module):
             def __call__(self, x):
@@ -486,5 +530,3 @@ def test_describe_output_head_evidence_ladder():
     for i, (model, status, path, cand) in enumerate(rows):
         d = U.describe_output_head(model)
         assert (d.status, d.path, d.candidate_path) == (status, path, cand), (i, d)
-
-

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -301,3 +301,30 @@ def test_invalid_logit_scale_selects_baseline_fallback():
 
     fn = make_cce_loss_fn(_stub_model("args", float("nan")))
     assert getattr(fn, "_unsloth_cce_backend", "") == "baseline-fallback"
+
+
+@pytest.mark.parametrize("case", ["no_embeddings", "no_backbone", "invalid_scale"])
+def test_vlm_cce_fallbacks_are_marked(case):
+    # Every VLM fallback path must return a loss fn carrying the eager
+    # fallback marker.
+    from unsloth_zoo.mlx.utils import make_vlm_cce_loss_fn
+
+    model = _stub_model()
+    model.language_model = _stub_model(
+        "args", float("nan") if case == "invalid_scale" else 0.0625
+    )
+    if case != "no_backbone":
+        model.language_model.model = object()  # separable backbone present
+    if case != "no_embeddings":
+        model.get_input_embeddings = lambda: None
+    with pytest.warns(UserWarning) if case != "invalid_scale" else _no_warning():
+        fn = make_vlm_cce_loss_fn(model)
+    assert getattr(fn, "_unsloth_cce_backend", "") == "baseline-fallback"
+
+
+def _no_warning():
+    import contextlib
+
+    return contextlib.nullcontext()
+
+

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -259,3 +259,45 @@ def test_transpose_two_args_unchanged():
     t = torch.zeros(2, 3, 4)
     out = t.transpose(0, 1)
     assert out.shape == (3, 2, 4)
+
+
+# 7. logit_scale discovery/normalization feeding CCE loss selection.
+
+def _stub_model(where=None, value=None):
+    class _Holder:
+        pass
+
+    model = _Holder()
+    if where == "attr":
+        model.logit_scale = value
+    elif where in ("args", "config"):
+        setattr(model, where, _Holder())
+        getattr(model, where).logit_scale = value
+    return model
+
+
+@pytest.mark.parametrize(
+    "where,value,expected",
+    [
+        (None, None, (None, False)),
+        ("attr", 0.0625, (None, False)),       # direct attr deliberately ignored
+        ("args", 0.0625, (0.0625, False)),     # mlx-lm cohere / cohere2_moe
+        ("config", 0.0625, (0.0625, False)),   # mlx-vlm aya_vision
+        ("args", 0.0, (0.0, False)),           # honored: matches model forward
+        ("args", 1.0, (None, False)),          # identity -> no-op path
+        ("args", True, (None, True)),          # bool is not a scale
+        ("args", 8.0, (None, True)),           # above supported range
+    ],
+)
+def test_get_logit_scale_normalization(where, value, expected):
+    from unsloth_zoo.mlx.utils import _get_logit_scale
+
+    assert _get_logit_scale(_stub_model(where, value)) == expected
+
+
+def test_invalid_logit_scale_selects_baseline_fallback():
+    # Selection precedes lm-head introspection, so a bare stub suffices.
+    from unsloth_zoo.mlx.utils import make_cce_loss_fn
+
+    fn = make_cce_loss_fn(_stub_model("args", float("nan")))
+    assert getattr(fn, "_unsloth_cce_backend", "") == "baseline-fallback"

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -295,6 +295,36 @@ def test_get_logit_scale_normalization(where, value, expected):
     assert _get_logit_scale(_stub_model(where, value)) == expected
 
 
+def _knobbed(_where="args", **attrs):
+    model = type("Model", (), {})()
+    setattr(model, _where, type("Holder", (), attrs)())
+    return model
+
+
+@pytest.mark.parametrize(
+    "attrs,status,expected",
+    [
+        # Each row mirrors its consuming forward's arithmetic and branch.
+        (dict(logits_scaling=4.0), "untied", (0.25, None)),  # granite divide
+        (dict(lm_head_multiplier=2.0, embedding_multiplier=1.0), "tied", (2.0, None)),
+        (dict(lm_head_multiplier=0.0390625, embedding_multiplier=5.656854249492381),
+         "tied", "outside the range"),  # Falcon-H1 defaults ~x0.0069 -> fallback
+        (dict(dim_model_base=16, hidden_size=32), "untied", (0.5, None)),  # minicpm, untied only
+        (dict(mup_width_multiplier=2.0), "untied", "cannot reproduce"),  # phi3small masked tail
+        (dict(logit_scale=None), "tied", "present but None"),  # malformed -> fail closed
+        (dict(logit_scale=0.0625, logits_scaling=4.0), "tied", "multiple output-transform knobs"),
+    ],
+)
+def test_detect_head_transform_rows(attrs, status, expected):
+    from unsloth_zoo.mlx.utils import _detect_head_transform
+
+    scale, problem = _detect_head_transform(_knobbed(**attrs), status)
+    if isinstance(expected, str):
+        assert problem is not None and expected in problem
+    else:
+        assert (scale, problem) == expected
+
+
 def test_backboneless_text_model_selects_baseline_fallback(capsys):
     # nanochat shape (stack under .transformer, no separable .model): the
     # biased head would trip the eligibility gate, so seeing ONLY the topology

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -328,3 +328,64 @@ def _no_warning():
     return contextlib.nullcontext()
 
 
+_UNSET = object()
+
+
+def _lm(nn, tied_flag=_UNSET, args_flag=_UNSET, head=None, emb_name="embed_tokens",
+        alt=None, call_src="plain"):
+    class _Backbone(nn.Module):
+        pass
+
+    backbone = _Backbone()
+    setattr(backbone, emb_name, nn.Embedding(96, 32))
+    if alt is not None:
+        setattr(backbone, alt, nn.Linear(32, 96, bias=False))
+
+    if call_src == "as_linear":
+        class _LM(nn.Module):
+            def __call__(self, x):
+                return self.model.embed_tokens.as_linear(x)
+    else:
+        class _LM(nn.Module):
+            def __call__(self, x):
+                return x
+
+    lm = _LM()
+    lm.model = backbone
+    if tied_flag is not _UNSET:
+        lm.tie_word_embeddings = tied_flag
+    if args_flag is not _UNSET:
+        lm.args = type("A", (), {})()
+        lm.args.tie_word_embeddings = args_flag
+    if head is not None:
+        lm.lm_head = head
+    return lm
+
+
+def test_describe_output_head_evidence_ladder():
+    from unsloth_zoo.mlx import utils as U
+
+    nn = U.nn
+    rows = [
+        # (model, status, path, candidate_path)
+        (_lm(nn, head=nn.Linear(32, 96, bias=False)), "untied", "lm_head", None),
+        # Helium-style dead lm_head + True flag -> tied via embedding
+        (_lm(nn, args_flag=True, head=nn.Linear(32, 96, bias=False)),
+         "tied", "model.embed_tokens", None),
+        # flag False blocks source evidence; alt head -> candidate
+        (_lm(nn, tied_flag=False, alt="output", call_src="as_linear"),
+         "unknown", None, "model.output"),
+        # Conflicting flags fail closed; the head surfaces as an exclusion
+        # candidate (identity, not proof of tying)
+        (_lm(nn, tied_flag=True, args_flag=False, head=nn.Linear(32, 96, bias=False)),
+         "unknown", None, "lm_head"),
+        # No flag: unconditional as_linear source evidence -> tied
+        (_lm(nn, call_src="as_linear"), "tied", "model.embed_tokens", None),
+        # GPT-NeoX embed_in/embed_out shapes -> alt-name candidate
+        (_lm(nn, emb_name="embed_in", alt="embed_out"), "unknown", None, "model.embed_out"),
+    ]
+    for i, (model, status, path, cand) in enumerate(rows):
+        d = U.describe_output_head(model)
+        assert (d.status, d.path, d.candidate_path) == (status, path, cand), (i, d)
+
+

--- a/tests/test_mlx_cce_kernel.py
+++ b/tests/test_mlx_cce_kernel.py
@@ -371,6 +371,11 @@ def test_dead_tie_flag_fails_closed_to_unknown():
             _lm(nn, args_flag=truthy, head=head(), call_src="flag_guarded")).status == "tied"
     assert U.describe_output_head(
         _lm(nn, args_flag="", head=head(), call_src="calls_lm_head")).status == "untied"
+    # A config-only truthy flag is read; with no resolvable anchor it fails
+    # closed to unknown, never falling through to a (dead) lm_head.
+    cfg = _lm(nn, head=head(), call_src="calls_lm_head")
+    cfg.model, cfg.config = nn.Module(), type("C", (), {"tie_word_embeddings": True})()
+    assert U.describe_output_head(cfg).status == "unknown"
 
 
 def test_is_lm_head_trainable_follows_descriptor_path():

--- a/tests/test_mlx_runtime_cce_compile.py
+++ b/tests/test_mlx_runtime_cce_compile.py
@@ -504,3 +504,5 @@ def test_quantized_runtime_cce_rejects_missing_affine_biases():
 
     with pytest.raises(ValueError, match="Biases must be provided for affine"):
         mx.eval(loss_fn(hidden))
+
+

--- a/tests/test_mlx_runtime_cce_compile.py
+++ b/tests/test_mlx_runtime_cce_compile.py
@@ -506,3 +506,30 @@ def test_quantized_runtime_cce_rejects_missing_affine_biases():
         mx.eval(loss_fn(hidden))
 
 
+def test_label_smoothing_matches_closed_form():
+    # label_smoothing>0 disables the Metal kernels and takes the python chunk
+    # path with the HF LabelSmoother loss/gradient (eps=0 kernel-path no-op is
+    # covered by recorded validation).
+    _skip_torch_shim()
+    from unsloth_zoo.mlx.cce import make_chunked_cross_entropy_loss
+
+    mx.random.seed(3)
+    hidden, weight = mx.random.normal((5, 8)), mx.random.normal((16, 8))
+    targets = mx.array([1, 7, 15, -100, 4], dtype=mx.int32)
+    valid, eps = targets != -100, 0.1
+    cce, _ = make_chunked_cross_entropy_loss(
+        ignore_index=-100, chunk_size=4, label_smoothing=eps)
+
+    def manual(h, w):
+        lg = (h @ w.T).astype(mx.float32)
+        safe = mx.where(valid, targets, mx.zeros_like(targets))
+        tgt = mx.take_along_axis(lg, mx.expand_dims(safe, -1), -1).squeeze(-1)
+        tok = mx.logsumexp(lg, -1) - (1.0 - eps) * tgt - eps * lg.mean(-1)
+        return mx.where(valid, tok, mx.zeros_like(tok)).sum()
+
+    lc, gc = mx.value_and_grad(
+        lambda h, w: cce(h, w, targets).astype(mx.float32).sum(), argnums=(0, 1))(hidden, weight)
+    lm, gm = mx.value_and_grad(manual, argnums=(0, 1))(hidden, weight)
+    mx.eval(lc, gc, lm, gm)
+    assert float(lc.item()) == pytest.approx(float(lm.item()), rel=1e-5)
+    assert max(float(mx.abs(a - b).max().item()) for a, b in zip(gc, gm)) < 2e-5

--- a/tests/test_mlx_save_lora_adapters_filter.py
+++ b/tests/test_mlx_save_lora_adapters_filter.py
@@ -1192,7 +1192,7 @@ def test_enrich_stamps_fine_tune_type_dora_when_dora_modules_present():
     assert cfg.get("fine_tune_type") == "dora", cfg
 
 
-def test_is_lm_head_trainable_skips_base_weight_under_lora_wrapped_lm_head():
+def test_is_lm_head_trainable_skips_base_weight_under_lora_wrapped_lm_head(monkeypatch):
     # After reload, mlx-lm wrappers may leak the inner base .weight as
     # trainable. For a LoRA-wrapped lm_head the leaked lm_head.weight is
     # not real user intent; treating it as trainable defeats the CCE
@@ -1223,8 +1223,18 @@ def test_is_lm_head_trainable_skips_base_weight_under_lora_wrapped_lm_head():
             yield "lm_head", self._lm
 
     # lm_head.weight under a LoRA-wrapped lm_head must be filtered out;
-    # the trainable check should return False (LoRA-only training).
-    assert _is_lm_head_trainable(_Model()) is False
+    # the trainable check should return False (LoRA-only training). The
+    # descriptor is stubbed to resolve this head so the leaked-base filter
+    # is actually on the decision path (an unresolved head would return
+    # False before reaching it, making this test vacuous).
+    import unsloth_zoo.mlx.utils as _U
+
+    model = _Model()
+    monkeypatch.setattr(
+        _U, "describe_output_head",
+        lambda m: type("_Desc", (), {"module": model._lm})(),
+    )
+    assert _is_lm_head_trainable(model) is False
 
 
 def test_push_lora_adapters_uses_allow_patterns_to_avoid_stale_uploads(

--- a/unsloth_zoo/mlx/cce/__init__.py
+++ b/unsloth_zoo/mlx/cce/__init__.py
@@ -26,10 +26,14 @@ except ImportError:
 
 if _MLX_AVAILABLE:
     from .runtime_cce import (
+        _normalize_label_smoothing,
         make_chunked_cross_entropy_loss,
         make_runtime_cce_loss_fused_finalize,
     )
 else:
+    def _normalize_label_smoothing(value):
+        return float(value)
+
     def make_chunked_cross_entropy_loss(**kwargs):
         raise RuntimeError("mlx is required for CCE loss but is not installed")
 
@@ -43,7 +47,7 @@ __all__ = [
 ]
 
 
-_RUNTIME_CCE_CACHE: dict[tuple[int, float, int, bool, int | None, int | None, str], Any] = {}
+_RUNTIME_CCE_CACHE: dict[tuple[int, float, int, bool, int | None, int | None, str, float], Any] = {}
 
 
 def _get_runtime_cce(
@@ -55,8 +59,12 @@ def _get_runtime_cce(
     group_size: int | None = None,
     bits: int | None = None,
     mode: str = "affine",
+    label_smoothing: float = 0.0,
 ):
-    key = (ignore_index, logit_softcap, chunk_size, quantized, group_size, bits, mode)
+    # Normalize BEFORE key lookup: a cached entry must never let an invalid
+    # value (e.g. True -> 1.0) bypass validation.
+    label_smoothing = _normalize_label_smoothing(label_smoothing)
+    key = (ignore_index, logit_softcap, chunk_size, quantized, group_size, bits, mode, label_smoothing)
     runtime_cce = _RUNTIME_CCE_CACHE.get(key)
     if runtime_cce is None:
         runtime_cce, _ = make_chunked_cross_entropy_loss(
@@ -67,6 +75,7 @@ def _get_runtime_cce(
             group_size=group_size,
             bits=bits,
             mode=mode,
+            label_smoothing=label_smoothing,
         )
         _RUNTIME_CCE_CACHE[key] = runtime_cce
     return runtime_cce

--- a/unsloth_zoo/mlx/cce/__init__.py
+++ b/unsloth_zoo/mlx/cce/__init__.py
@@ -32,7 +32,18 @@ if _MLX_AVAILABLE:
     )
 else:
     def _normalize_label_smoothing(value):
-        return float(value)
+        # Mirror the MLX implementation's domain check so validation is
+        # consistent whether or not MLX is installed.
+        import math
+        import numbers
+        if isinstance(value, bool) or not isinstance(value, numbers.Real):
+            raise ValueError(
+                f"label_smoothing must be a real number in [0, 1], got {value!r}")
+        value = float(value)
+        if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+            raise ValueError(
+                f"label_smoothing must be a finite value in [0, 1], got {value!r}")
+        return value
 
     def make_chunked_cross_entropy_loss(**kwargs):
         raise RuntimeError("mlx is required for CCE loss but is not installed")

--- a/unsloth_zoo/mlx/cce/runtime_cce.py
+++ b/unsloth_zoo/mlx/cce/runtime_cce.py
@@ -632,7 +632,8 @@ def _forward_chunked_fused_finalize(
             chunk_target = mx.take_along_axis(logits, mx.expand_dims(local_targets, -1), axis=1).squeeze(-1)
             target_logit = mx.where(in_chunk, chunk_target, target_logit)
             if sum_capped is not None:
-                sum_capped = sum_capped + logits.astype(mx.float32).sum(axis=-1)
+                # logits is already float32 here (cast above under the same guard)
+                sum_capped = sum_capped + logits.sum(axis=-1)
 
         lse = running_max + mx.log(running_sum_exp + 1e-9)
         if sum_capped is not None:

--- a/unsloth_zoo/mlx/cce/runtime_cce.py
+++ b/unsloth_zoo/mlx/cce/runtime_cce.py
@@ -725,6 +725,8 @@ def _fallback_dlogits(
     label_smoothing: float = 0.0,
     vocab_size: int = 0,
 ) -> mx.array:
+    if label_smoothing > 0.0 and vocab_size <= 0:
+        raise ValueError("vocab_size must be positive when label_smoothing > 0")
     capped = _apply_softcap(logits, logit_softcap)
     probs = mx.exp(capped - mx.expand_dims(lse, -1))
 

--- a/unsloth_zoo/mlx/cce/runtime_cce.py
+++ b/unsloth_zoo/mlx/cce/runtime_cce.py
@@ -110,6 +110,27 @@ def _resolve_chunk_size(
     return min(chunk_v, vocab_size)
 
 
+def _normalize_label_smoothing(value) -> float:
+    """Shared domain check for every loss entry point: finite real 0<=eps<=1."""
+    import numbers
+
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        raise ValueError(
+            f"label_smoothing must be a real number in [0, 1], got {value!r}"
+        )
+    try:
+        eps = float(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError(
+            f"label_smoothing must be a real number in [0, 1], got {value!r}"
+        )
+    if not (eps == eps and 0.0 <= eps <= 1.0):
+        raise ValueError(
+            f"label_smoothing must be a finite value in [0, 1], got {value!r}"
+        )
+    return eps
+
+
 def _apply_softcap(logits: mx.array, logit_softcap: float) -> mx.array:
     if logit_softcap <= 0.0:
         return logits
@@ -525,6 +546,7 @@ def _forward_chunked_fused_finalize(
     chunk_size: int,
     forward_update_kernel: Callable | None,
     forward_update_finalize_kernel: Callable | None,
+    label_smoothing: float = 0.0,
 ) -> tuple[mx.array, mx.array]:
     hidden_compute = hidden
     weight_compute = weight
@@ -562,6 +584,8 @@ def _forward_chunked_fused_finalize(
     )
     targets = targets_raw.astype(mx.int32)
     compute_bytes = 2 if hidden_compute.dtype in (mx.float16, mx.bfloat16) else 4
+    if label_smoothing > 0.0:
+        compute_bytes = 4  # smoothing casts each logits chunk to fp32
     chunk_size = _resolve_chunk_size(
         chunk_size,
         n,
@@ -571,6 +595,8 @@ def _forward_chunked_fused_finalize(
     running_max = mx.full((n,), -mx.inf, dtype=mx.float32)
     running_sum_exp = mx.zeros((n,), dtype=mx.float32)
     target_logit = mx.zeros((n,), dtype=mx.float32)
+    # HF LabelSmoother accumulates the smoothed vocabulary term in float32.
+    sum_capped = mx.zeros((n,), dtype=mx.float32) if label_smoothing > 0.0 else None
 
     if forward_update_kernel is None or forward_update_finalize_kernel is None:
         for v_start in range(0, vocab_size, chunk_size):
@@ -588,6 +614,10 @@ def _forward_chunked_fused_finalize(
                 mode=mode,
             )
             logits = _apply_softcap(logits, logit_softcap)
+            if sum_capped is not None:
+                # eps>0 always takes this python path (kernels disabled), so
+                # match the Metal kernels' float32 LSE accumulation here.
+                logits = logits.astype(mx.float32)
 
             chunk_max = mx.max(logits, axis=-1)
             chunk_sum_exp = mx.sum(mx.exp(logits - mx.expand_dims(chunk_max, -1)), axis=-1)
@@ -601,9 +631,18 @@ def _forward_chunked_fused_finalize(
             local_targets = mx.clip(targets - v_start, 0, v_end - v_start - 1)
             chunk_target = mx.take_along_axis(logits, mx.expand_dims(local_targets, -1), axis=1).squeeze(-1)
             target_logit = mx.where(in_chunk, chunk_target, target_logit)
+            if sum_capped is not None:
+                sum_capped = sum_capped + logits.astype(mx.float32).sum(axis=-1)
 
         lse = running_max + mx.log(running_sum_exp + 1e-9)
-        loss = mx.where(valid_pre, lse - target_logit, mx.zeros_like(lse))
+        if sum_capped is not None:
+            # loss = lse - (1-eps)*target - eps*mean_v(logits): equals
+            # (1-eps)*NLL + eps*uniform smoothing (HF LabelSmoother form).
+            eps = label_smoothing
+            token_loss = lse - (1.0 - eps) * target_logit - eps * (sum_capped / vocab_size)
+        else:
+            token_loss = lse - target_logit
+        loss = mx.where(valid_pre, token_loss, mx.zeros_like(lse))
         loss = _poison_invalid_targets(loss, invalid_pre)
         lse = _poison_invalid_targets(lse, invalid_pre)
         return loss, lse
@@ -682,6 +721,8 @@ def _fallback_dlogits(
     v_end: int,
     ignore_index: int,
     logit_softcap: float,
+    label_smoothing: float = 0.0,
+    vocab_size: int = 0,
 ) -> mx.array:
     capped = _apply_softcap(logits, logit_softcap)
     probs = mx.exp(capped - mx.expand_dims(lse, -1))
@@ -691,7 +732,15 @@ def _fallback_dlogits(
     valid = (targets >= v_start) & (targets < v_end) & (targets != ignore_index)
     target_mask = target_mask & mx.expand_dims(valid, -1)
 
-    d_capped = probs - target_mask.astype(mx.float32)
+    if label_smoothing > 0.0:
+        # d/dlogit_v of the smoothed loss: p_v - (1-eps)*onehot_v - eps/V.
+        d_capped = (
+            probs
+            - (1.0 - label_smoothing) * target_mask.astype(mx.float32)
+            - label_smoothing / vocab_size
+        )
+    else:
+        d_capped = probs - target_mask.astype(mx.float32)
     d_capped = d_capped * mx.expand_dims(grad_output, -1)
 
     if logit_softcap > 0.0:
@@ -718,8 +767,14 @@ def make_runtime_cce_loss_fused_finalize(
     group_size: int | None = None,
     bits: int | None = None,
     mode: str = "affine",
+    label_smoothing: float = 0.0,
 ):
+    label_smoothing = _normalize_label_smoothing(label_smoothing)
     forward_update_kernel, forward_update_finalize_kernel, dlogits_kernel = _build_kernel_set()
+    if label_smoothing > 0.0:
+        # Smoothing lives in the chunked python path; the fused Metal kernels
+        # do not carry the vocabulary-sum term. eps=0 keeps the kernel path.
+        forward_update_kernel = forward_update_finalize_kernel = dlogits_kernel = None
     use_metal_kernel = dlogits_kernel is not None
 
     ignore_arr = mx.array([ignore_index], dtype=mx.int32)
@@ -743,6 +798,8 @@ def make_runtime_cce_loss_fused_finalize(
         n_tokens = hidden.shape[0]
         vocab_size = weight.shape[0]
         compute_bytes = 2 if hidden.dtype in (mx.float16, mx.bfloat16) else 4
+        if label_smoothing > 0.0:
+            compute_bytes = 4  # smoothing casts each logits chunk to fp32
         resolved_chunk_size = _resolve_chunk_size(
             chunk_size,
             n_tokens,
@@ -816,6 +873,7 @@ def make_runtime_cce_loss_fused_finalize(
                 chunk_size=get_chunk_plan(hidden, weight)[0],
                 forward_update_kernel=forward_update_kernel,
                 forward_update_finalize_kernel=forward_update_finalize_kernel,
+                label_smoothing=label_smoothing,
             )
             return losses, lse
 
@@ -890,6 +948,8 @@ def make_runtime_cce_loss_fused_finalize(
                         v_end=v_end,
                         ignore_index=ignore_index,
                         logit_softcap=logit_softcap,
+                        label_smoothing=label_smoothing,
+                        vocab_size=vocab_size,
                     ).astype(logits.dtype)
 
                 d_logits_compute = d_logits.astype(hidden_compute.dtype)
@@ -948,6 +1008,7 @@ def make_runtime_cce_loss_fused_finalize(
             chunk_size=get_chunk_plan(hidden, weight)[0],
             forward_update_kernel=forward_update_kernel,
             forward_update_finalize_kernel=forward_update_finalize_kernel,
+            label_smoothing=label_smoothing,
         )
         return losses, lse
 
@@ -1013,6 +1074,8 @@ def make_runtime_cce_loss_fused_finalize(
                     v_end=v_end,
                     ignore_index=ignore_index,
                     logit_softcap=logit_softcap,
+                    label_smoothing=label_smoothing,
+                    vocab_size=vocab_size,
                 ).astype(logits.dtype)
 
             d_logits_compute = d_logits.astype(hidden_compute.dtype)
@@ -1049,6 +1112,7 @@ def make_chunked_cross_entropy_loss(
     group_size: int | None = None,
     bits: int | None = None,
     mode: str = "affine",
+    label_smoothing: float = 0.0,
 ):
     """Return a standalone chunked CCE loss callable and a kernel-usage flag."""
 
@@ -1060,4 +1124,5 @@ def make_chunked_cross_entropy_loss(
         group_size=group_size,
         bits=bits,
         mode=mode,
+        label_smoothing=label_smoothing,
     )

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2372,10 +2372,16 @@ class MLXTrainer:
                     ignore_token_ids=_vlm_ignore_token_ids,
                 )
                 cce_backend = getattr(loss_fn, "_unsloth_cce_backend", "unknown")
-                _main_print(
-                    f"Unsloth: Using VLM CCE loss ({cce_backend}) "
-                    "for memory-efficient training."
-                )
+                if cce_backend == "baseline-fallback":
+                    use_cce = False
+                    _main_print(
+                        "Unsloth: VLM CCE is unavailable for this model; using "
+                        "standard cross-entropy loss.")
+                else:
+                    _main_print(
+                        f"Unsloth: Using VLM CCE loss ({cce_backend}) "
+                        "for memory-efficient training."
+                    )
             else:
                 loss_fn = make_vlm_baseline_loss_fn(
                     model,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -172,6 +172,7 @@ from .utils import (
     _FiniteTextRow,
     _create_text_batch_plan,
     _create_ordered_text_plan,
+    _normalize_label_smoothing,
     create_batches,
     iterate_training_batches,
     create_vlm_batches,
@@ -511,6 +512,18 @@ def _clip_grad_norm_fp32(grad, max_norm):
     return tree_map(lambda g: g * scale.astype(g.dtype), grad), total_norm
 
 
+def _validate_label_smoothing(value, is_vlm):
+    """Configuration gate for ``label_smoothing_factor``: delegates the
+    domain check to the shared loss-layer normalizer (config errors raise,
+    unlike model-derived properties, which fall back) and adds the VLM rule."""
+    eps = _normalize_label_smoothing(value)
+    if is_vlm and eps > 0.0:
+        raise ValueError(
+            "label_smoothing_factor > 0 is not supported for VLM training on MLX."
+        )
+    return eps
+
+
 def _prune_stale_checkpoints(output_dir, save_total_limit):
     """Keep the newest ``save_total_limit`` checkpoint-* dirs (HF Trainer parity).
 
@@ -635,6 +648,8 @@ class MLXTrainingConfig:
     vlm_chat_template: object = None  # Unsloth template name/tuple or raw Jinja string
     per_device_eval_batch_size: int | None = None
     image_size: object = None  # VLM image resize override from UnslothVisionDataCollator(resize=...)
+    # Appended last: the initializer binds positional args by field order.
+    label_smoothing_factor: float = 0.0  # HF LabelSmoother epsilon (text models only)
 
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
@@ -2353,8 +2368,13 @@ class MLXTrainer:
             if is_main_process:
                 print(*print_args, **print_kwargs)
 
-        # Pick loss function (returns (loss, ntoks))
+        # Pick loss function (returns (loss, ntoks)). Validate configuration
+        # before any model-derived loss selection (config errors raise; model
+        # properties fall back).
         use_cce = args.use_cce
+        label_smoothing = _validate_label_smoothing(
+            getattr(args, "label_smoothing_factor", 0.0), is_vlm,
+        )
         _vlm_ignore_token_ids = None
 
         if is_vlm:
@@ -2391,7 +2411,7 @@ class MLXTrainer:
                 _main_print("Unsloth: Using VLM standard cross-entropy loss.")
         else:
             if use_cce:
-                loss_fn = make_cce_loss_fn(model)
+                loss_fn = make_cce_loss_fn(model, label_smoothing=label_smoothing)
                 cce_backend = getattr(loss_fn, "_unsloth_cce_backend", "unknown")
                 if cce_backend == "baseline-fallback":
                     use_cce = False
@@ -2406,7 +2426,7 @@ class MLXTrainer:
                         "for memory-efficient training."
                     )
             else:
-                loss_fn = make_baseline_loss_fn()
+                loss_fn = make_baseline_loss_fn(label_smoothing=label_smoothing)
                 _main_print("Unsloth: Using standard cross-entropy loss.")
 
         compile_policy = build_compile_policy(args=args)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2387,10 +2387,18 @@ class MLXTrainer:
             if use_cce:
                 loss_fn = make_cce_loss_fn(model)
                 cce_backend = getattr(loss_fn, "_unsloth_cce_backend", "unknown")
-                _main_print(
-                    f"Unsloth: Using CCE loss ({cce_backend}) "
-                    "for memory-efficient training."
-                )
+                if cce_backend == "baseline-fallback":
+                    use_cce = False
+                    # The factory already printed the specific reason (topology,
+                    # head eligibility, or logit transform); keep this generic.
+                    _main_print(
+                        "Unsloth: fused CCE is unavailable for this model; "
+                        "using standard cross-entropy loss.")
+                else:
+                    _main_print(
+                        f"Unsloth: Using CCE loss ({cce_backend}) "
+                        "for memory-efficient training."
+                    )
             else:
                 loss_fn = make_baseline_loss_fn()
                 _main_print("Unsloth: Using standard cross-entropy loss.")

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -795,7 +795,9 @@ def describe_output_head(model):
     )
 
     flags, flag_attr_present = [], False
-    for holder in (tm, getattr(tm, "args", None)):
+    # Include config: some models (e.g. VLM language stacks) carry the live
+    # tie flag only on tm.config, the same site logit_scale/softcap are read from.
+    for holder in (tm, getattr(tm, "args", None), getattr(tm, "config", None)):
         if holder is None or not hasattr(holder, "tie_word_embeddings"):
             continue
         flag_attr_present = True
@@ -808,7 +810,7 @@ def describe_output_head(model):
             flags.append(bool(value))
         except Exception:
             pass
-    conflicting = len(flags) == 2 and flags[0] != flags[1]
+    conflicting = len(set(flags)) > 1
 
     # An uncorroborated True flag: the analyzed route calls a live lm_head
     # at EITHER supported location (any type — a wrapped head the forward
@@ -832,8 +834,12 @@ def describe_output_head(model):
     head, path, status = None, None, "unknown"
     if conflicting:
         pass
-    elif flags and flags[0] and emb_entry is not None:
-        if not flag_contradicted:
+    elif flags and flags[0]:
+        # A truthy tie flag routes the forward through the embedding: resolve
+        # that anchor (unless the flag is contradicted), else fail closed to
+        # unknown -- never fall through to a possibly-dead lm_head, which would
+        # train the wrong weight.
+        if emb_entry is not None and not flag_contradicted:
             head, path, status = emb_entry[1], emb_prefix + emb_entry[0], "tied"
     elif getattr(tm, "lm_head", None) is not None:
         head, path, status = tm.lm_head, prefix + "lm_head", "untied"

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -44,6 +44,7 @@ from pathlib import Path
 
 
 from .cce import _get_runtime_cce
+from .cce.runtime_cce import _normalize_label_smoothing
 
 
 _LLAMA_CPP_PATCHER_ENV_LOCK = threading.Lock()
@@ -717,7 +718,7 @@ def _is_lm_head_trainable(model):
     return len(trainable) == 0  # no LoRA = full fine-tuning
 
 
-def make_cce_loss_fn(model):
+def make_cce_loss_fn(model, label_smoothing=0.0):
     """Create a chunked cross-entropy (CCE) loss function.
 
     CCE computes loss directly from hidden states and the LM head weight,
@@ -727,6 +728,7 @@ def make_cce_loss_fn(model):
     With labels, uses labels[:,1:] as targets and (targets != -100) as mask.
     The returned function has a ``_unsloth_cce_backend`` attribute for logging.
     """
+    label_smoothing = _normalize_label_smoothing(label_smoothing)
     # Validate before announcing any CCE configuration so an abandoned CCE
     # never advertises itself first.
     logit_scale, _scale_invalid = _get_logit_scale(model)
@@ -734,7 +736,7 @@ def make_cce_loss_fn(model):
         print("Unsloth: logit_scale cannot be applied by fused CCE (non-finite, "
               "non-scalar, or outside the supported range); falling back to "
               "standard cross-entropy.")
-        loss_fn = make_baseline_loss_fn()
+        loss_fn = make_baseline_loss_fn(label_smoothing=label_smoothing)
         loss_fn._unsloth_cce_backend = "baseline-fallback"
         return loss_fn
 
@@ -804,6 +806,7 @@ def make_cce_loss_fn(model):
             group_size=group_size,
             bits=bits,
             mode=quant_mode,
+            label_smoothing=label_smoothing,
         )
 
         def loss_fn(model, batch, lengths, labels=None):
@@ -849,6 +852,7 @@ def make_cce_loss_fn(model):
         rt_cce = _get_runtime_cce(
             ignore_index=-100,
             logit_softcap=softcap,
+            label_smoothing=label_smoothing,
         )
 
         def loss_fn(model, batch, lengths, labels=None):
@@ -885,14 +889,29 @@ def make_cce_loss_fn(model):
     return loss_fn
 
 
-def make_baseline_loss_fn():
+def make_baseline_loss_fn(label_smoothing=0.0):
     """Create a standard cross-entropy loss function (full logits via LM head).
 
     Used when use_cce=False. Returns a function
     (model, batch, lengths, labels=None) -> (loss, ntoks). With labels, uses
-    labels[:,1:] and (targets != -100) as mask. The labels=None branch is
-    byte-identical to ``mlx_lm.tuner.trainer.default_loss``.
+    labels[:,1:] and (targets != -100) as mask. With label_smoothing=0 the
+    labels=None branch is byte-identical to ``mlx_lm.tuner.trainer.default_loss``.
     """
+    eps = _normalize_label_smoothing(label_smoothing)
+    if eps > 0.0:
+
+        def _token_ce(logits, targets):
+            # HF LabelSmoother form: lse - (1-eps)*target - eps*mean_v, with
+            # the smoothed vocabulary term reduced in float32.
+            logits32 = logits.astype(mx.float32)
+            lse = mx.logsumexp(logits32, axis=-1)
+            tgt = mx.take_along_axis(
+                logits32, mx.expand_dims(targets, -1), axis=-1
+            ).squeeze(-1)
+            return lse - (1.0 - eps) * tgt - eps * logits32.mean(axis=-1)
+    else:
+        _token_ce = nn.losses.cross_entropy
+
     def loss_fn(model, batch, lengths, labels=None):
         if labels is None:
             # Half-open [start, end) end-exclusive mask; matches CCE/labels paths
@@ -902,7 +921,7 @@ def make_baseline_loss_fn():
             logits = model(inputs)
             steps = mx.arange(1, targets.shape[1] + 1)
             mask = mx.logical_and(steps >= lengths[:, 0:1], steps < lengths[:, 1:])
-            ce = nn.losses.cross_entropy(logits, targets) * mask
+            ce = _token_ce(logits, targets) * mask
             ntoks = mask.sum()
             # Raw ntoks (no safe denominator) to match mlx_lm default_loss
             # byte-for-byte; the safe wrapper stays on the labels-aware path.
@@ -925,7 +944,7 @@ def make_baseline_loss_fn():
         safe_targets = mx.where(
             targets == -100, mx.array(0, dtype=targets.dtype), targets,
         )
-        ce = nn.losses.cross_entropy(logits, safe_targets) * mask
+        ce = _token_ce(logits, safe_targets) * mask
         ntoks = mask.sum()
         loss = ce.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
         return loss, ntoks

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -659,21 +659,17 @@ def _output_accessor_chains(tree):
     return chains
 
 
-def _output_accessor_modules(tm):
-    """Live modules with recognized accessors in the analyzed forward bodies.
+def _analyze_output_route(tm):
+    """Syntactic evidence from the analyzed forward bodies, live-resolved.
 
-    Parses ``type(tm).__call__`` (AST, so only real ``self.X.as_linear(...)``
-    calls and ``self.X.weight.T`` attribute expressions count — never strings
-    or comments), follows one hop of ``self.<method>(...)`` delegation to
-    methods the entry point syntactically calls, and resolves each extracted
-    chain on the LIVE module tree; unresolvable chains contribute nothing.
-    Neither reachability nor terminal position is analyzed: ANY
-    syntactically recognized accessor counts — dead branches, reachable
-    side computations, nested scopes, or a shadowed ``self``. Uniqueness
-    and fail-closed consumers bound the resulting risk: mis-selection
-    additionally requires that no other candidate contributes a recognized,
-    live-resolving accessor (the real route may use unsupported syntax, an
-    alias, or deeper delegation). Returns ``{id(module): (relative_path, module)}``."""
+    Parses ``type(tm).__call__`` (AST — strings/comments never count) plus one
+    hop of ``self.<method>()`` delegation, returning ``(accessor_modules,
+    called_module_ids, references_tie_flag)``: chains under
+    ``self.X.as_linear(...)`` / ``self.X.weight.T``; modules a self-rooted chain
+    is called on (``self.lm_head(x)``); and whether ``tie_word_embeddings`` is
+    referenced anywhere. Reachability is NOT analyzed — any recognized syntax
+    counts (dead branches included); uniqueness plus fail-closed consumers bound
+    mis-selection. Unresolvable chains contribute nothing."""
     cls = type(tm)
 
     def _parse(method):
@@ -684,7 +680,7 @@ def _output_accessor_modules(tm):
 
     entry = _parse(getattr(cls, "__call__", None))
     if entry is None:
-        return {}
+        return {}, set(), False
     trees = [entry]
     invoked = {
         node.func.attr
@@ -698,17 +694,37 @@ def _output_accessor_modules(tm):
             tree = _parse(method)
             if tree is not None:
                 trees.append(tree)
-    modules = {}
+
+    def _resolve(chain):
+        obj = tm
+        for part in chain.split("."):
+            obj = getattr(obj, part, None)
+            if obj is None:
+                return None
+        return obj
+
+    modules, called, references_flag = {}, set(), False
     for tree in trees:
         for chain in _output_accessor_chains(tree):
-            obj = tm
-            for part in chain.split("."):
-                obj = getattr(obj, part, None)
-                if obj is None:
-                    break
+            obj = _resolve(chain)
             if obj is not None:
                 modules[id(obj)] = (chain, obj)
-    return modules
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "tie_word_embeddings":
+                references_flag = True
+            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                chain = _self_attr_chain(node.func)
+                if chain:
+                    obj = _resolve(chain)
+                    if obj is not None:
+                        called.add(id(obj))
+    return modules, called, references_flag
+
+
+def _output_accessor_modules(tm):
+    """Live modules with recognized accessors in the analyzed forward bodies
+    (see ``_analyze_output_route``). Returns ``{id(module): (path, module)}``."""
+    return _analyze_output_route(tm)[0]
 
 
 def _resolve_embedding_anchor(owner, types, accessor_modules=None):
@@ -752,17 +768,18 @@ def _resolve_module_path(model, path):
 
 
 def describe_output_head(model):
-    """Resolve the live output head with affirmative evidence only: a True
-    tie flag, a real ``lm_head``, or (only when no flag attribute exists) an
-    embedding with a recognized, live-resolving accessor syntactically
-    present in the analyzed forward bodies — any embedding name, via
-    ``.as_linear(...)`` or ``.weight.T``, including one hop of
-    ``self.<method>()`` delegation (see ``_output_accessor_modules``).
-    Missing ``lm_head`` never implies tying; conflicting flags fail closed.
-    ``path`` is rooted at the argument (VLM wrappers keep the
-    ``language_model.`` prefix); at unknown status ``candidate_*`` carry the
-    unique structural shape-matched alternative head (accessor identity
-    selects only the embedding anchor).
+    """Resolve the live output head with affirmative evidence only: a True tie
+    flag, a real ``lm_head``, or (when no flag attribute exists) an embedding
+    named via a live-resolving ``.as_linear(...)`` / ``.weight.T`` accessor in
+    the analyzed forward bodies (see ``_analyze_output_route``). Missing
+    ``lm_head`` never implies tying; conflicting flags fail closed. ``path`` is
+    rooted at the argument (VLM wrappers keep the ``language_model.`` prefix);
+    at unknown status ``candidate_*`` carry the unique shape-matched alt head.
+    A True flag is corroborated against the route: if a live ``lm_head`` is
+    called there with no syntactic flag reference and no accessor for the
+    anchored embedding, it fails closed to unknown (Qwen2-MoE ships a dead
+    flag). Syntax is evidence, not proof — deeper consultation downgrades
+    conservatively to baseline; a dead reference keeps today's resolution.
     """
     prefix = "language_model." if hasattr(model, "language_model") else ""
     tm = _get_text_model(model)
@@ -771,7 +788,7 @@ def describe_output_head(model):
         emb_owner, emb_prefix = backbone, prefix + "model."
     else:
         emb_owner, emb_prefix = tm, prefix
-    accessor_modules = _output_accessor_modules(tm)
+    accessor_modules, called_modules, references_flag = _analyze_output_route(tm)
     emb_entry = _resolve_embedding_anchor(
         emb_owner, (nn.Embedding, nn.QuantizedEmbedding),
         accessor_modules=accessor_modules,
@@ -783,15 +800,41 @@ def describe_output_head(model):
             continue
         flag_attr_present = True
         value = holder.tie_word_embeddings
-        if isinstance(value, bool):
-            flags.append(value)
+        # Mirror the forward's `if self.args.tie_word_embeddings:` truthiness for
+        # any value: from_dict does not coerce, so a config may ship the flag as
+        # an int or string, and the forward consumes it by truth value. Only a
+        # value whose truth is undefined (raises) stays unread.
+        try:
+            flags.append(bool(value))
+        except Exception:
+            pass
     conflicting = len(flags) == 2 and flags[0] != flags[1]
+
+    # An uncorroborated True flag: the analyzed route calls a live lm_head
+    # at EITHER supported location (any type — a wrapped head the forward
+    # uses is just as contradictory as a raw one), shows no syntactic flag
+    # consultation, and no accessor evidence for the anchored embedding.
+    # When both routes are syntactically visible the flag plausibly selects
+    # between them through indirection the analyzer cannot see, so the flag
+    # keeps winning there. No execution-order claim is made; syntax alone
+    # fails closed (see the docstring for both residual directions).
+    live_head_ids = {
+        id(owner.lm_head)
+        for owner in (tm, backbone)
+        if owner is not None and getattr(owner, "lm_head", None) is not None
+    }
+    flag_contradicted = (
+        bool(live_head_ids & called_modules)
+        and not references_flag
+        and (emb_entry is None or id(emb_entry[1]) not in accessor_modules)
+    )
 
     head, path, status = None, None, "unknown"
     if conflicting:
         pass
     elif flags and flags[0] and emb_entry is not None:
-        head, path, status = emb_entry[1], emb_prefix + emb_entry[0], "tied"
+        if not flag_contradicted:
+            head, path, status = emb_entry[1], emb_prefix + emb_entry[0], "tied"
     elif getattr(tm, "lm_head", None) is not None:
         head, path, status = tm.lm_head, prefix + "lm_head", "untied"
     elif backbone is not None and getattr(backbone, "lm_head", None) is not None:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -25,6 +25,7 @@ and merged models (safetensors, GGUF, HuggingFace Hub).
 import mlx.core as mx
 import mlx.nn as nn
 import mlx.utils
+import ast
 import collections
 import copy
 import inspect
@@ -32,6 +33,7 @@ import importlib
 import json
 import numbers
 import operator
+import textwrap
 import numpy as np
 import os
 import sys
@@ -625,13 +627,105 @@ OutputHeadDescriptor = collections.namedtuple(
 _RAW_HEAD_TYPES = (nn.Linear, nn.QuantizedLinear, nn.Embedding, nn.QuantizedEmbedding)
 
 
-def _unique_child_of_type(owner, types):
+def _self_attr_chain(node):
+    """Dotted chain for an ``ast.Attribute`` rooted at the name ``self``,
+    else None (subscripts, calls, or other roots break the chain)."""
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name) and node.id == "self":
+        return ".".join(reversed(parts))
+    return None
+
+
+def _output_accessor_chains(tree):
+    """Chains with recognized accessor syntax within a parsed body: the X of
+    ``self.X.as_linear(...)`` and ``self.X.weight.T``. Syntax-level, so
+    strings, comments, and prose can never contribute."""
+    chains = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+                and node.func.attr == "as_linear":
+            chain = _self_attr_chain(node.func.value)
+            if chain:
+                chains.append(chain)
+        elif isinstance(node, ast.Attribute) and node.attr == "T" \
+                and isinstance(node.value, ast.Attribute) \
+                and node.value.attr == "weight":
+            chain = _self_attr_chain(node.value.value)
+            if chain:
+                chains.append(chain)
+    return chains
+
+
+def _output_accessor_modules(tm):
+    """Live modules with recognized accessors in the analyzed forward bodies.
+
+    Parses ``type(tm).__call__`` (AST, so only real ``self.X.as_linear(...)``
+    calls and ``self.X.weight.T`` attribute expressions count — never strings
+    or comments), follows one hop of ``self.<method>(...)`` delegation to
+    methods the entry point syntactically calls, and resolves each extracted
+    chain on the LIVE module tree; unresolvable chains contribute nothing.
+    Neither reachability nor terminal position is analyzed: ANY
+    syntactically recognized accessor counts — dead branches, reachable
+    side computations, nested scopes, or a shadowed ``self``. Uniqueness
+    and fail-closed consumers bound the resulting risk: mis-selection
+    additionally requires that no other candidate contributes a recognized,
+    live-resolving accessor (the real route may use unsupported syntax, an
+    alias, or deeper delegation). Returns ``{id(module): (relative_path, module)}``."""
+    cls = type(tm)
+
+    def _parse(method):
+        try:
+            return ast.parse(textwrap.dedent(inspect.getsource(method)))
+        except (OSError, TypeError, AttributeError, SyntaxError):
+            return None
+
+    entry = _parse(getattr(cls, "__call__", None))
+    if entry is None:
+        return {}
+    trees = [entry]
+    invoked = {
+        node.func.attr
+        for node in ast.walk(entry)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name) and node.func.value.id == "self"
+    }
+    for helper in invoked - {"__call__"}:
+        method = getattr(cls, helper, None)
+        if callable(method):
+            tree = _parse(method)
+            if tree is not None:
+                trees.append(tree)
+    modules = {}
+    for tree in trees:
+        for chain in _output_accessor_chains(tree):
+            obj = tm
+            for part in chain.split("."):
+                obj = getattr(obj, part, None)
+                if obj is None:
+                    break
+            if obj is not None:
+                modules[id(obj)] = (chain, obj)
+    return modules
+
+
+def _resolve_embedding_anchor(owner, types, accessor_modules=None):
     """(name, module) of the unique direct child whose type is exactly in
-    ``types``; None when absent, ambiguous, or not a module tree."""
+    ``types``; None when absent, ambiguous, or not a module tree. Multiple
+    embedding candidates (Gemma-4 backbones carry a second vocab-sized
+    per-layer embedding) resolve ONLY by live accessor identity — the unique
+    candidate that IS one of the modules the output route accesses
+    (`_output_accessor_modules`). Dimensional agreement is deliberately not
+    identity evidence (metadata can be stale after a vocab resize).
+    Still-ambiguous stays None (fail closed)."""
     children = getattr(owner, "children", None)
     if not callable(children):
         return None
     found = [(n, c) for n, c in children().items() if type(c) in types]
+    if len(found) > 1 and accessor_modules:
+        found = [e for e in found if id(e[1]) in accessor_modules]
     return found[0] if len(found) == 1 else None
 
 
@@ -660,10 +754,15 @@ def _resolve_module_path(model, path):
 def describe_output_head(model):
     """Resolve the live output head with affirmative evidence only: a True
     tie flag, a real ``lm_head``, or (only when no flag attribute exists) an
-    unconditional ``embed_tokens.as_linear`` forward route. Missing ``lm_head``
-    never implies tying; conflicting flags fail closed. ``path`` is rooted at
-    the argument (VLM wrappers keep the ``language_model.`` prefix); at
-    unknown status ``candidate_*`` carry the unique shape-matched child.
+    embedding with a recognized, live-resolving accessor syntactically
+    present in the analyzed forward bodies — any embedding name, via
+    ``.as_linear(...)`` or ``.weight.T``, including one hop of
+    ``self.<method>()`` delegation (see ``_output_accessor_modules``).
+    Missing ``lm_head`` never implies tying; conflicting flags fail closed.
+    ``path`` is rooted at the argument (VLM wrappers keep the
+    ``language_model.`` prefix); at unknown status ``candidate_*`` carry the
+    unique structural shape-matched alternative head (accessor identity
+    selects only the embedding anchor).
     """
     prefix = "language_model." if hasattr(model, "language_model") else ""
     tm = _get_text_model(model)
@@ -672,7 +771,11 @@ def describe_output_head(model):
         emb_owner, emb_prefix = backbone, prefix + "model."
     else:
         emb_owner, emb_prefix = tm, prefix
-    emb_entry = _unique_child_of_type(emb_owner, (nn.Embedding, nn.QuantizedEmbedding))
+    accessor_modules = _output_accessor_modules(tm)
+    emb_entry = _resolve_embedding_anchor(
+        emb_owner, (nn.Embedding, nn.QuantizedEmbedding),
+        accessor_modules=accessor_modules,
+    )
 
     flags, flag_attr_present = [], False
     for holder in (tm, getattr(tm, "args", None)):
@@ -694,11 +797,9 @@ def describe_output_head(model):
     elif backbone is not None and getattr(backbone, "lm_head", None) is not None:
         head, path, status = backbone.lm_head, prefix + "model.lm_head", "untied"
     elif not flag_attr_present and emb_entry is not None:
-        try:
-            source = inspect.getsource(type(tm).__call__)
-        except (OSError, TypeError):
-            source = ""
-        if "embed_tokens.as_linear" in source:
+        # Same structured interpretation as the anchor: tied evidence means
+        # the analyzed output-route bodies access THIS embedding module.
+        if id(emb_entry[1]) in accessor_modules:
             head, path, status = emb_entry[1], emb_prefix + emb_entry[0], "tied"
 
     candidate, candidate_path = None, None

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -963,6 +963,41 @@ def _validated_knob(value, source):
     return value, None
 
 
+def _detect_logit_softcap(model):
+    """Logit softcap from either known attr, as ``(softcap, problem)``.
+
+    ``final_logit_softcapping`` keeps its ``_get_logit_softcap`` semantics.
+    ``logits_soft_cap`` (RecurrentGemma) caps for any truthy value: None/0.0
+    mean no cap, a positive finite real caps, anything else (or both attrs
+    present) fails closed rather than dropping the cap.
+    """
+    tm = _get_text_model(model)
+    # Presence, not value: an explicitly-None legacy attr still makes the
+    # dual-attr combination unverified.
+    legacy = getattr(tm, "final_logit_softcapping", _KNOB_MISSING)
+    if legacy is _KNOB_MISSING and hasattr(tm, "args"):
+        legacy = getattr(tm.args, "final_logit_softcapping", _KNOB_MISSING)
+    alias, conflict = _knob_value(tm, "logits_soft_cap", ("args", "config"))
+    if conflict:
+        return 0.0, ("logits_soft_cap differs between its configuration "
+                     "sites")
+    if alias is not _KNOB_MISSING and legacy is not _KNOB_MISSING:
+        return 0.0, ("both final_logit_softcapping and logits_soft_cap are "
+                     "present, an unverified combination")
+    if alias is _KNOB_MISSING:
+        return _get_logit_softcap(model), None
+    if alias is None:
+        return 0.0, None  # falsy: the forward skips the cap entirely
+    value, problem = _validated_knob(alias, "logits_soft_cap")
+    if problem is not None:
+        return 0.0, problem
+    if value == 0.0:
+        return 0.0, None  # falsy: the forward skips the cap entirely
+    if value < 0:
+        return 0.0, "logits_soft_cap must be positive when set"
+    return value, None
+
+
 def _aux_knob(tm, name):
     """A ratio's companion knob: value or a fail-closed reason string."""
     value, conflict = _knob_value(tm, name, _KNOB_AUX_SITES[name])
@@ -1114,7 +1149,12 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
         loss_fn._unsloth_cce_backend = "baseline-fallback"
         return loss_fn
 
-    softcap = _get_logit_softcap(model)
+    softcap, _softcap_problem = _detect_logit_softcap(model)
+    if _softcap_problem is not None:
+        print(f"Unsloth: {_softcap_problem}; falling back to standard cross-entropy.")
+        loss_fn = make_baseline_loss_fn(label_smoothing=label_smoothing)
+        loss_fn._unsloth_cce_backend = "baseline-fallback"
+        return loss_fn
     if softcap > 0:
         print(f"Unsloth: CCE using logit_softcap={softcap} for this model.")
     if logit_scale is not None:
@@ -2576,14 +2616,15 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
               f"head ({_ineligible}); falling back to standard cross-entropy.")
         return _marked_vlm_baseline()
 
-    logit_scale, _scale_invalid = _get_logit_scale(model)
-    if _scale_invalid:
-        print("Unsloth: logit_scale cannot be applied by fused CCE (non-finite, "
-              "non-scalar, or outside the supported range); falling back to "
-              "standard cross-entropy.")
+    logit_scale, _transform_problem = _detect_head_transform(model, head_desc.status)
+    if _transform_problem is not None:
+        print(f"Unsloth: {_transform_problem}; falling back to standard cross-entropy.")
         return _marked_vlm_baseline()
 
-    softcap = _get_logit_softcap(model)
+    softcap, _softcap_problem = _detect_logit_softcap(model)
+    if _softcap_problem is not None:
+        print(f"Unsloth: {_softcap_problem}; falling back to standard cross-entropy.")
+        return _marked_vlm_baseline()
     lm_layer = head_desc.module
     use_quantized = _is_quantized_layer(lm_layer)
     _head_path = head_desc.path

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2165,6 +2165,15 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
     assistant_token_id > 0 enables completion-only training (mask tokens before
     the first occurrence). Returns a function (model, batch_dict) -> (loss, ntoks).
     """
+    def _marked_vlm_baseline():
+        loss_fn = make_vlm_baseline_loss_fn(
+            model,
+            assistant_token_id=assistant_token_id,
+            ignore_token_ids=ignore_token_ids,
+        )
+        loss_fn._unsloth_cce_backend = "baseline-fallback"
+        return loss_fn
+
     if not hasattr(model, "get_input_embeddings"):
         import warnings
         warnings.warn(
@@ -2172,11 +2181,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             "falling back to baseline CE loss.",
             stacklevel=2,
         )
-        return make_vlm_baseline_loss_fn(
-            model,
-            assistant_token_id=assistant_token_id,
-            ignore_token_ids=ignore_token_ids,
-        )
+        return _marked_vlm_baseline()
 
     tm = _get_text_model(model)
     if getattr(tm, "model", None) is None and not _has_direct_hidden_stack(model):
@@ -2186,11 +2191,14 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             "falling back to baseline CE loss.",
             stacklevel=2,
         )
-        return make_vlm_baseline_loss_fn(
-            model,
-            assistant_token_id=assistant_token_id,
-            ignore_token_ids=ignore_token_ids,
-        )
+        return _marked_vlm_baseline()
+
+    logit_scale, _scale_invalid = _get_logit_scale(model)
+    if _scale_invalid:
+        print("Unsloth: logit_scale cannot be applied by fused CCE (non-finite, "
+              "non-scalar, or outside the supported range); falling back to "
+              "standard cross-entropy.")
+        return _marked_vlm_baseline()
 
     softcap = _get_logit_softcap(model)
     lm_layer = _get_lm_head_layer(model)
@@ -2248,6 +2256,10 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             # gradients (see runtime_cce.py VJP), so stop_gradient is
             # redundant here even when the LM head is frozen.
             hidden_flat = hidden.reshape((-1, hidden.shape[-1]))
+            if logit_scale is not None:
+                # (h * s) @ W equals s * (h @ W) per vocab chunk (Aya Vision,
+                # Cohere2-MoE apply logit_scale in their forward tails).
+                hidden_flat = hidden_flat * logit_scale
             targets_flat = masked_targets.reshape((-1,))  # runtime CCE validates dtype before narrowing
             loss = rt_cce(hidden_flat, w, sc, bi, targets_flat)
             loss = loss.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
@@ -2269,6 +2281,9 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             if _skip_weight_grad:
                 w = mx.stop_gradient(w)
             hidden_flat = hidden.reshape((-1, hidden.shape[-1]))
+            if logit_scale is not None:
+                # Same pre-scaling identity as the quantized branch above.
+                hidden_flat = hidden_flat * logit_scale
             targets_flat = masked_targets.reshape((-1,))  # runtime CCE validates dtype before narrowing
             loss = rt_cce(hidden_flat, w, targets_flat)
             loss = loss.astype(mx.float32).sum() / _safe_token_denominator(ntoks)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -29,6 +29,7 @@ import copy
 import inspect
 import importlib
 import json
+import numbers
 import operator
 import numpy as np
 import os
@@ -643,6 +644,42 @@ def _get_logit_softcap(model):
     return float(softcap) if softcap is not None and softcap > 0 else 0.0
 
 
+def _get_logit_scale(model):
+    """Get the scalar multiplier some archs apply to lm-head logits, if any.
+
+    Cohere-family models (mlx-lm ``cohere``/``cohere2``, mlx-vlm
+    ``aya_vision``/``cohere2_moe``) multiply logits by ``logit_scale`` inside
+    the forward — a step CCE bypasses and must re-apply. Returns
+    ``(scale, invalid)``: scale None when absent or 1.0; ``invalid=True`` for
+    bool/non-scalar/non-finite/out-of-range values (callers must fall back).
+    """
+    tm = _get_text_model(model)
+    # Only the verified application sites — args (cohere/cohere2/cohere2_moe)
+    # then config (aya_vision); no upstream forward reads a direct attribute.
+    scale = None
+    if hasattr(tm, "args"):
+        scale = getattr(tm.args, "logit_scale", None)
+    if scale is None and hasattr(tm, "config"):
+        scale = getattr(tm.config, "logit_scale", None)
+    if scale is None:
+        return None, False
+    if isinstance(scale, bool) or not isinstance(scale, numbers.Real):
+        return None, True
+    try:
+        scale = float(scale)
+    except (TypeError, ValueError, OverflowError):
+        return None, True
+    if not np.isfinite(scale):
+        return None, True
+    if scale == 1.0:
+        return None, False
+    # Pre-scaling is validated only for moderate magnitudes; extreme scales
+    # can under/overflow before accumulation, so fail closed outside 2^-6..4.
+    if scale != 0.0 and not (2.0 ** -6 <= abs(scale) <= 2.0 ** 2):
+        return None, True
+    return scale, False
+
+
 def _is_lm_head_trainable(model):
     """Whether the LM head weight is trainable (not frozen by LoRA).
 
@@ -690,9 +727,22 @@ def make_cce_loss_fn(model):
     With labels, uses labels[:,1:] as targets and (targets != -100) as mask.
     The returned function has a ``_unsloth_cce_backend`` attribute for logging.
     """
+    # Validate before announcing any CCE configuration so an abandoned CCE
+    # never advertises itself first.
+    logit_scale, _scale_invalid = _get_logit_scale(model)
+    if _scale_invalid:
+        print("Unsloth: logit_scale cannot be applied by fused CCE (non-finite, "
+              "non-scalar, or outside the supported range); falling back to "
+              "standard cross-entropy.")
+        loss_fn = make_baseline_loss_fn()
+        loss_fn._unsloth_cce_backend = "baseline-fallback"
+        return loss_fn
+
     softcap = _get_logit_softcap(model)
     if softcap > 0:
         print(f"Unsloth: CCE using logit_softcap={softcap} for this model.")
+    if logit_scale is not None:
+        print(f"Unsloth: CCE using logit_scale={logit_scale} for this model.")
 
     lm_layer = _get_lm_head_layer(model)
     use_quantized = _is_quantized_layer(lm_layer)
@@ -782,6 +832,11 @@ def make_cce_loss_fn(model):
             masked_targets = mx.where(mask, targets, ignore)
             ntoks = mask.sum()
             hidden_flat = hidden.reshape((-1, hidden.shape[-1]))
+            if logit_scale is not None:
+                # (h * s) @ W equals s * (h @ W) per vocab chunk, so softcap
+                # and the CCE backward see the model's own scaled logits while
+                # cached kernels stay scale-independent.
+                hidden_flat = hidden_flat * logit_scale
             targets_flat = masked_targets.reshape((-1,))  # runtime CCE validates dtype before narrowing
             loss = rt_cce(hidden_flat, w, sc, bi, targets_flat)
             loss = loss.astype(mx.float32).sum() / _safe_token_denominator(ntoks)
@@ -818,6 +873,9 @@ def make_cce_loss_fn(model):
             masked_targets = mx.where(mask, targets, ignore)
             ntoks = mask.sum()
             hidden_flat = hidden.reshape((-1, hidden.shape[-1]))
+            if logit_scale is not None:
+                # Same pre-scaling identity as the quantized branch above.
+                hidden_flat = hidden_flat * logit_scale
             targets_flat = masked_targets.reshape((-1,))  # runtime CCE validates dtype before narrowing
             loss = rt_cce(hidden_flat, w, targets_flat)
             loss = loss.astype(mx.float32).sum() / _safe_token_denominator(ntoks)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -733,19 +733,30 @@ def describe_output_head(model):
     )
 
 
+def _cce_head_ineligibility(desc):
+    """Reason fused CCE must not run for this head, or None when eligible."""
+    if desc.status == "unknown":
+        return "unresolved output-head topology"
+    if not desc.raw:
+        return f"non-raw output-head wrapper ({desc.wrapper_type.__name__})"
+    if desc.has_additive_bias:
+        return "additive output-head bias"
+    return None
+
+
 def _get_lm_head_layer(model):
-    """The affirmatively resolved output head (see describe_output_head),
-    with the historical lookup preserved for unresolved topologies."""
+    """The affirmatively resolved output head (see describe_output_head).
+
+    Raises for unknown topology: the loss factories gate on the descriptor
+    first, so reaching this without a resolved head is a caller bug.
+    """
     desc = describe_output_head(model)
-    if desc.module is not None:
-        return desc.module
-    tm = _get_text_model(model)
-    if getattr(tm, "lm_head", None) is not None:
-        return tm.lm_head
-    backbone = getattr(tm, "model", tm)
-    if getattr(backbone, "lm_head", None) is not None:
-        return backbone.lm_head
-    return backbone.embed_tokens
+    if desc.module is None:
+        raise ValueError(
+            "Unsloth: output-head topology is unresolved for this model; "
+            "gate on describe_output_head before requesting the head layer."
+        )
+    return desc.module
 
 
 def _is_quantized_layer(layer):
@@ -846,8 +857,16 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
     The returned function has a ``_unsloth_cce_backend`` attribute for logging.
     """
     label_smoothing = _normalize_label_smoothing(label_smoothing)
-    # Validate before announcing any CCE configuration so an abandoned CCE
-    # never advertises itself first.
+    # Head eligibility first, then scale validation — no positive CCE notice
+    # may precede an ineligibility decision.
+    head_desc = describe_output_head(model)
+    _ineligible = _cce_head_ineligibility(head_desc)
+    if _ineligible is not None:
+        print(f"Unsloth: fused CCE cannot faithfully use this model's output "
+              f"head ({_ineligible}); falling back to standard cross-entropy.")
+        loss_fn = make_baseline_loss_fn(label_smoothing=label_smoothing)
+        loss_fn._unsloth_cce_backend = "baseline-fallback"
+        return loss_fn
     logit_scale, _scale_invalid = _get_logit_scale(model)
     if _scale_invalid:
         print("Unsloth: logit_scale cannot be applied by fused CCE (non-finite, "
@@ -863,20 +882,18 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
     if logit_scale is not None:
         print(f"Unsloth: CCE using logit_scale={logit_scale} for this model.")
 
-    lm_layer = _get_lm_head_layer(model)
+    lm_layer = head_desc.module
     use_quantized = _is_quantized_layer(lm_layer)
 
-    _head_path = describe_output_head(model).path
+    _head_path = head_desc.path
 
     def _get_backbone(model):
         """Get backbone (for hidden states) from the live model tree."""
         return _forward_text_hidden_states
 
     def _get_lm_weight_layer(model):
-        """Get LM head or embed_tokens layer from the live model tree."""
-        if _head_path is not None:
-            return _resolve_module_path(model, _head_path)
-        return _get_lm_head_layer(model)
+        """Re-resolve the head from the live model tree by its descriptor path."""
+        return _resolve_module_path(model, _head_path)
 
     if use_quantized:
         # Backstop: quantized CCE backward zeros the weight gradient
@@ -2314,6 +2331,13 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
         )
         return _marked_vlm_baseline()
 
+    head_desc = describe_output_head(model)
+    _ineligible = _cce_head_ineligibility(head_desc)
+    if _ineligible is not None:
+        print(f"Unsloth: fused CCE cannot faithfully use this model's output "
+              f"head ({_ineligible}); falling back to standard cross-entropy.")
+        return _marked_vlm_baseline()
+
     logit_scale, _scale_invalid = _get_logit_scale(model)
     if _scale_invalid:
         print("Unsloth: logit_scale cannot be applied by fused CCE (non-finite, "
@@ -2322,9 +2346,9 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
         return _marked_vlm_baseline()
 
     softcap = _get_logit_softcap(model)
-    lm_layer = _get_lm_head_layer(model)
+    lm_layer = head_desc.module
     use_quantized = _is_quantized_layer(lm_layer)
-    _head_path = describe_output_head(model).path
+    _head_path = head_desc.path
     # Evaluate once (after LoRA setup); trainability doesn't change mid-training.
     _skip_weight_grad = not _is_lm_head_trainable(model)
 
@@ -2368,7 +2392,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             hidden, masked_targets, ntoks = _vlm_cce_forward(
                 model, batch_dict, image_token_ids=_image_token_ids,
                 assistant_token_id=_assistant_token_id)
-            lm_head = _resolve_module_path(model, _head_path) if _head_path is not None else _get_lm_head_layer(model)
+            lm_head = _resolve_module_path(model, _head_path)
             w = lm_head.weight
             sc = lm_head.scales
             bi = getattr(lm_head, "biases", None)
@@ -2399,7 +2423,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             hidden, masked_targets, ntoks = _vlm_cce_forward(
                 model, batch_dict, image_token_ids=_image_token_ids,
                 assistant_token_id=_assistant_token_id)
-            w = (_resolve_module_path(model, _head_path) if _head_path is not None else _get_lm_head_layer(model)).weight
+            w = _resolve_module_path(model, _head_path).weight
             if _skip_weight_grad:
                 w = mx.stop_gradient(w)
             hidden_flat = hidden.reshape((-1, hidden.shape[-1]))

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1075,21 +1075,36 @@ def _detect_head_transform(model, head_status):
 
 
 def _is_lm_head_trainable(model):
-    """Whether the LM head weight is trainable (not frozen by LoRA).
+    """Whether fused CCE should compute the output head's weight gradient.
 
-    When frozen, its CCE gradient is a wasted V x chunk_size x H matmul per
-    chunk, so callers wrap the weight with mx.stop_gradient (returns False).
+    Returns False when the head is frozen by a LoRA/adapter setup or is
+    unresolved (its gradient would be a wasted V x chunk_size x H matmul per
+    chunk, so callers wrap the weight with mx.stop_gradient); True when the
+    resolved head carries a trainable param, or when there are no adapters at
+    all (full fine-tuning). Resolution is by descriptor module identity in the
+    registered tree, not by name — a property-backed ``language_model``
+    returning ``self`` is not a registered child, and an alt-named tied
+    embedding (InternLM2 ``tok_embeddings``) is classified like any head.
     """
     trainable = dict(mlx.utils.tree_flatten(model.trainable_parameters()))
     # Module-anchored so unrelated trainables containing the substring
     # "lora" are not treated as adapter state.
     adapter_keys = set(collect_mlx_lora_adapter_tensors(model))
-    # Drop reload-leaked base tensors INSIDE a LoRA-wrapped lm_head (would
+    # Drop reload-leaked base tensors INSIDE a LoRA-wrapped head (would
     # defeat the CCE memory guard) while keeping intentional trainables
     # like `lm_head.bias`. Shares the filter with save_trainable_adapters.
     _lora_module_names = [name for name, _ in iter_mlx_lora_modules(model)]
     lora_module_prefixes = tuple(f"{name}." for name in _lora_module_names if name)
     has_root_lora_module = any(name == "" for name in _lora_module_names)
+    head_module = describe_output_head(model).module
+    head_prefix = None
+    if head_module is not None:
+        for name, module in model.named_modules():
+            if module is head_module and name:
+                head_prefix = f"{name}."
+                break
+    if head_prefix is None:
+        return False
     for key in trainable:
         if key in adapter_keys:
             continue
@@ -1097,16 +1112,7 @@ def _is_lm_head_trainable(model):
             key, lora_module_prefixes, has_root_lora_module,
         ):
             continue
-        # Segment-match (not substring) so e.g.
-        # `decoder.not_lm_head_router.weight` is not classified as lm_head.
-        segments = key.split(".")
-        is_lm_head_param = "lm_head" in segments
-        is_embed_tokens_weight = (
-            len(segments) >= 2
-            and segments[-2] == "embed_tokens"
-            and segments[-1] == "weight"
-        )
-        if is_lm_head_param or is_embed_tokens_weight:
+        if key.startswith(head_prefix):
             return True
     return len(trainable) == 0  # no LoRA = full fine-tuning
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -910,6 +910,135 @@ def _get_logit_scale(model):
     return scale, False
 
 
+_KNOB_MISSING = object()
+
+# Knobs whose consuming forwards transform logits after the output head,
+# with lookup sites in consumer-preference order. "attr" = the live module
+# attribute (Granite/Phi3Small forwards read a constructor copy, so copy vs
+# config drift must fail closed); others read args (config for VLM wrappers).
+_HEAD_TRANSFORM_KNOBS = {
+    "logit_scale": ("args", "config"),          # Cohere: out * logit_scale
+    "logits_scaling": ("attr", "args", "config"),  # Granite: out / logits_scaling
+    "lm_head_multiplier": ("args", "config"),   # Falcon-H1 tied composite
+    "dim_model_base": ("args", "config"),       # MiniCPM untied ratio divide
+    "mup_width_multiplier": ("attr", "args", "config"),  # Phi3Small masked tail
+}
+_KNOB_AUX_SITES = {
+    "embedding_multiplier": ("args", "config"),
+    "hidden_size": ("args", "config"),
+}
+
+
+def _knob_values_equal(a, b):
+    """Total equality: raising / non-boolean comparisons count as disagreement."""
+    try:
+        return a is b or bool(a == b)
+    except Exception:
+        return False
+
+
+def _knob_value(tm, name, sites):
+    """(value, conflict) from the consumer sites; ``_KNOB_MISSING`` when no
+    site defines the knob. A present ``None`` is a value, never absence."""
+    holders = {"attr": tm, "args": getattr(tm, "args", None), "config": getattr(tm, "config", None)}
+    found = [v for site in sites if holders[site] is not None
+             for v in (getattr(holders[site], name, _KNOB_MISSING),)
+             if v is not _KNOB_MISSING]
+    if not found:
+        return _KNOB_MISSING, False
+    conflict = any(not _knob_values_equal(v, found[0]) for v in found[1:])
+    return found[0], conflict
+
+
+def _validated_knob(value, source):
+    """Normalize one knob value to a finite float, or return a reason string."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return None, f"{source} is not a finite real scalar"
+    try:
+        value = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None, f"{source} is not a finite real scalar"
+    if not np.isfinite(value):
+        return None, f"{source} is not a finite real scalar"
+    return value, None
+
+
+def _aux_knob(tm, name):
+    """A ratio's companion knob: value or a fail-closed reason string."""
+    value, conflict = _knob_value(tm, name, _KNOB_AUX_SITES[name])
+    if conflict or value is _KNOB_MISSING:
+        return None, (f"{name} is missing or inconsistent across its "
+                      "configuration sites")
+    return _validated_knob(value, name)
+
+
+def _detect_head_transform(model, head_status):
+    """Resolve known output-transform knobs to one effective logit scale.
+
+    Mirrors the scalar transforms the consuming forwards apply between the
+    output head and the returned logits. Returns ``(scale, problem)``: a
+    reason string means fall back to the eager baseline; scale None is the
+    no-op case; accepted scales obey the ``_get_logit_scale`` range.
+    ``head_status`` selects branch-conditional transforms as the forwards do.
+    """
+    tm = _get_text_model(model)
+    present = {}
+    for name, sites in _HEAD_TRANSFORM_KNOBS.items():
+        value, conflict = _knob_value(tm, name, sites)
+        if conflict:
+            return None, f"{name} is inconsistent across its configuration sites"
+        if value is not _KNOB_MISSING:
+            present[name] = value
+    if len(present) > 1:
+        return None, ("multiple output-transform knobs are present "
+                      f"({', '.join(present)}), an unverified combination")
+    if not present:
+        return None, None
+    knob, raw = next(iter(present.items()))
+    if knob == "mup_width_multiplier":
+        # Its only consumer (Phi3Small) masks dummy-token logits after the
+        # value-guarded divide: presence alone makes the tail non-scalar.
+        return None, ("mup_width_multiplier models mask logits after the "
+                      "output head, which fused CCE cannot reproduce")
+    if knob == "logit_scale":
+        # A present-None value is malformed live state (the forward would
+        # multiply logits by None); fail closed rather than run unscaled.
+        if raw is None:
+            return None, "logit_scale is present but None"
+        scale, invalid = _get_logit_scale(model)
+        if invalid:
+            return None, ("logit_scale cannot be applied by fused CCE "
+                          "(non-finite, non-scalar, or outside the "
+                          "supported range)")
+        return scale, None
+    # The remaining knobs are ratios num/den mirrored from their forwards.
+    if knob == "logits_scaling":
+        num, problem = 1.0, None
+        den, p2 = _validated_knob(raw, knob)
+    elif knob == "lm_head_multiplier":
+        if head_status != "tied":  # the untied branch applies the plain head
+            return None, None
+        num, problem = _validated_knob(raw, knob)
+        den, p2 = _aux_knob(tm, "embedding_multiplier")
+    else:  # dim_model_base: divide by hidden_size/dim_model_base pre-head
+        if head_status != "untied":  # the tied branch is a plain matmul
+            return None, None
+        num, problem = _validated_knob(raw, knob)
+        den, p2 = _aux_knob(tm, "hidden_size")
+    problem = problem or p2
+    if problem is None and den == 0.0:
+        problem = f"the {knob} configuration divides the logits by zero"
+    if problem is not None:
+        return None, problem
+    scale = num / den
+    if scale == 1.0:
+        return None, None
+    if not np.isfinite(scale) or not (2.0 ** -6 <= abs(scale) <= 2.0 ** 2):
+        return None, (f"effective logit scale {scale!r} from {knob} is "
+                      "outside the range validated for fused CCE")
+    return scale, None
+
+
 def _is_lm_head_trainable(model):
     """Whether the LM head weight is trainable (not frozen by LoRA).
 
@@ -978,11 +1107,9 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
         loss_fn = make_baseline_loss_fn(label_smoothing=label_smoothing)
         loss_fn._unsloth_cce_backend = "baseline-fallback"
         return loss_fn
-    logit_scale, _scale_invalid = _get_logit_scale(model)
-    if _scale_invalid:
-        print("Unsloth: logit_scale cannot be applied by fused CCE (non-finite, "
-              "non-scalar, or outside the supported range); falling back to "
-              "standard cross-entropy.")
+    logit_scale, _transform_problem = _detect_head_transform(model, head_desc.status)
+    if _transform_problem is not None:
+        print(f"Unsloth: {_transform_problem}; falling back to standard cross-entropy.")
         loss_fn = make_baseline_loss_fn(label_smoothing=label_smoothing)
         loss_fn._unsloth_cce_backend = "baseline-fallback"
         return loss_fn

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -25,6 +25,7 @@ and merged models (safetensors, GGUF, HuggingFace Hub).
 import mlx.core as mx
 import mlx.nn as nn
 import mlx.utils
+import collections
 import copy
 import inspect
 import importlib
@@ -615,18 +616,134 @@ def _forward_text_hidden_states(model, inputs, inputs_embeds=None, **kwargs):
     return _run_hidden_stack(tm, inputs, inputs_embeds=inputs_embeds, **kwargs)
 
 
-def _get_lm_head_layer(model):
-    """Get the raw LM head layer (QuantizedLinear or Linear/Embedding).
+OutputHeadDescriptor = collections.namedtuple(
+    "OutputHeadDescriptor",
+    ["module", "path", "status", "has_additive_bias", "quantized",
+     "wrapper_type", "raw", "candidate_module", "candidate_path"],
+)
 
-    Prefers a separate lm_head (untied models like Qwen), else falls back to
-    embed_tokens (tied models like Gemma/Llama). Returns the layer object (not
-    its weight) so callers can read .weight/.scales/.biases/.group_size/.bits.
+_RAW_HEAD_TYPES = (nn.Linear, nn.QuantizedLinear, nn.Embedding, nn.QuantizedEmbedding)
+
+
+def _unique_child_of_type(owner, types):
+    """(name, module) of the unique direct child whose type is exactly in
+    ``types``; None when absent, ambiguous, or not a module tree."""
+    children = getattr(owner, "children", None)
+    if not callable(children):
+        return None
+    found = [(n, c) for n, c in children().items() if type(c) in types]
+    return found[0] if len(found) == 1 else None
+
+
+def _embedding_dims(emb):
+    """Semantic (vocab, hidden). QuantizedEmbedding packs its weight, so read
+    the stored attributes instead of the array shape."""
+    if type(emb) is nn.QuantizedEmbedding:
+        return int(emb.num_embeddings), int(emb.dims)
+    return int(emb.weight.shape[0]), int(emb.weight.shape[1])
+
+
+def _linear_semantic_dims(layer):
+    out_dim, in_dim = int(layer.weight.shape[0]), int(layer.weight.shape[1])
+    if type(layer) is nn.QuantizedLinear:
+        in_dim = in_dim * 32 // int(layer.bits)
+    return out_dim, in_dim
+
+
+def _resolve_module_path(model, path):
+    obj = model
+    for part in path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+def describe_output_head(model):
+    """Resolve the live output head with affirmative evidence only: a True
+    tie flag, a real ``lm_head``, or (only when no flag attribute exists) an
+    unconditional ``embed_tokens.as_linear`` forward route. Missing ``lm_head``
+    never implies tying; conflicting flags fail closed. ``path`` is rooted at
+    the argument (VLM wrappers keep the ``language_model.`` prefix); at
+    unknown status ``candidate_*`` carry the unique shape-matched child.
     """
+    prefix = "language_model." if hasattr(model, "language_model") else ""
     tm = _get_text_model(model)
-    if hasattr(tm, "lm_head") and tm.lm_head is not None:
+    backbone = getattr(tm, "model", None)
+    if backbone is not None:
+        emb_owner, emb_prefix = backbone, prefix + "model."
+    else:
+        emb_owner, emb_prefix = tm, prefix
+    emb_entry = _unique_child_of_type(emb_owner, (nn.Embedding, nn.QuantizedEmbedding))
+
+    flags, flag_attr_present = [], False
+    for holder in (tm, getattr(tm, "args", None)):
+        if holder is None or not hasattr(holder, "tie_word_embeddings"):
+            continue
+        flag_attr_present = True
+        value = holder.tie_word_embeddings
+        if isinstance(value, bool):
+            flags.append(value)
+    conflicting = len(flags) == 2 and flags[0] != flags[1]
+
+    head, path, status = None, None, "unknown"
+    if conflicting:
+        pass
+    elif flags and flags[0] and emb_entry is not None:
+        head, path, status = emb_entry[1], emb_prefix + emb_entry[0], "tied"
+    elif getattr(tm, "lm_head", None) is not None:
+        head, path, status = tm.lm_head, prefix + "lm_head", "untied"
+    elif backbone is not None and getattr(backbone, "lm_head", None) is not None:
+        head, path, status = backbone.lm_head, prefix + "model.lm_head", "untied"
+    elif not flag_attr_present and emb_entry is not None:
+        try:
+            source = inspect.getsource(type(tm).__call__)
+        except (OSError, TypeError):
+            source = ""
+        if "embed_tokens.as_linear" in source:
+            head, path, status = emb_entry[1], emb_prefix + emb_entry[0], "tied"
+
+    candidate, candidate_path = None, None
+    if status == "unknown" and emb_entry is not None:
+        vocab, hidden = _embedding_dims(emb_entry[1])
+        owners = [(tm, prefix)]
+        if backbone is not None:
+            owners.append((backbone, prefix + "model."))
+        matches, seen = [], set()
+        for owner, owner_prefix in owners:
+            for name, child in (owner.children() if callable(getattr(owner, "children", None)) else {}).items():
+                if id(child) in seen:
+                    continue
+                seen.add(id(child))
+                if (type(child) in (nn.Linear, nn.QuantizedLinear)
+                        and _linear_semantic_dims(child) == (vocab, hidden)):
+                    matches.append((owner_prefix + name, child))
+        if len(matches) == 1:
+            candidate_path, candidate = matches[0]
+
+    target = head if head is not None else candidate
+    return OutputHeadDescriptor(
+        module=head,
+        path=path,
+        status=status,
+        has_additive_bias=(target is not None and "bias" in target),
+        quantized=(target is not None and hasattr(target, "scales")),
+        wrapper_type=(type(target) if target is not None else None),
+        raw=(target is not None and type(target) in _RAW_HEAD_TYPES),
+        candidate_module=candidate,
+        candidate_path=candidate_path,
+    )
+
+
+def _get_lm_head_layer(model):
+    """The affirmatively resolved output head (see describe_output_head),
+    with the historical lookup preserved for unresolved topologies."""
+    desc = describe_output_head(model)
+    if desc.module is not None:
+        return desc.module
+    tm = _get_text_model(model)
+    if getattr(tm, "lm_head", None) is not None:
         return tm.lm_head
     backbone = getattr(tm, "model", tm)
-    if hasattr(backbone, "lm_head") and backbone.lm_head is not None:
+    if getattr(backbone, "lm_head", None) is not None:
         return backbone.lm_head
     return backbone.embed_tokens
 
@@ -749,13 +866,7 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
     lm_layer = _get_lm_head_layer(model)
     use_quantized = _is_quantized_layer(lm_layer)
 
-    _has_wrapper = hasattr(model, "language_model")
-    tm = _get_text_model(model)
-    backbone = getattr(tm, "model", None)
-    _has_lm_head = (
-        (hasattr(tm, "lm_head") and tm.lm_head is not None)
-        or (backbone is not None and hasattr(backbone, "lm_head") and backbone.lm_head is not None)
-    )
+    _head_path = describe_output_head(model).path
 
     def _get_backbone(model):
         """Get backbone (for hidden states) from the live model tree."""
@@ -763,18 +874,9 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
 
     def _get_lm_weight_layer(model):
         """Get LM head or embed_tokens layer from the live model tree."""
-        if _has_wrapper:
-            tm = model.language_model
-        else:
-            tm = model
-        if _has_lm_head:
-            if hasattr(tm, "lm_head") and tm.lm_head is not None:
-                return tm.lm_head
-            backbone = getattr(tm, "model", tm)
-            if hasattr(backbone, "lm_head") and backbone.lm_head is not None:
-                return backbone.lm_head
-        backbone = getattr(tm, "model", tm)
-        return backbone.embed_tokens
+        if _head_path is not None:
+            return _resolve_module_path(model, _head_path)
+        return _get_lm_head_layer(model)
 
     if use_quantized:
         # Backstop: quantized CCE backward zeros the weight gradient
@@ -2222,6 +2324,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
     softcap = _get_logit_softcap(model)
     lm_layer = _get_lm_head_layer(model)
     use_quantized = _is_quantized_layer(lm_layer)
+    _head_path = describe_output_head(model).path
     # Evaluate once (after LoRA setup); trainability doesn't change mid-training.
     _skip_weight_grad = not _is_lm_head_trainable(model)
 
@@ -2265,7 +2368,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             hidden, masked_targets, ntoks = _vlm_cce_forward(
                 model, batch_dict, image_token_ids=_image_token_ids,
                 assistant_token_id=_assistant_token_id)
-            lm_head = _get_lm_head_layer(model)
+            lm_head = _resolve_module_path(model, _head_path) if _head_path is not None else _get_lm_head_layer(model)
             w = lm_head.weight
             sc = lm_head.scales
             bi = getattr(lm_head, "biases", None)
@@ -2296,7 +2399,7 @@ def make_vlm_cce_loss_fn(model, assistant_token_id=0, ignore_token_ids=None):
             hidden, masked_targets, ntoks = _vlm_cce_forward(
                 model, batch_dict, image_token_ids=_image_token_ids,
                 assistant_token_id=_assistant_token_id)
-            w = _get_lm_head_layer(model).weight
+            w = (_resolve_module_path(model, _head_path) if _head_path is not None else _get_lm_head_layer(model)).weight
             if _skip_weight_grad:
                 w = mx.stop_gradient(w)
             hidden_flat = hidden.reshape((-1, hidden.shape[-1]))

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -958,8 +958,18 @@ def make_cce_loss_fn(model, label_smoothing=0.0):
     The returned function has a ``_unsloth_cce_backend`` attribute for logging.
     """
     label_smoothing = _normalize_label_smoothing(label_smoothing)
-    # Head eligibility first, then scale validation — no positive CCE notice
-    # may precede an ineligibility decision.
+    # Topology first (mirrors the VLM factory), then head eligibility, then
+    # scale validation — no positive CCE notice may precede a fallback decision.
+    # Backboneless models (e.g. a stack not exposed as `.model` or as direct
+    # embed_tokens/layers/norm attributes) cannot yield pre-head hidden states,
+    # so the full model forward is the only faithful loss.
+    tm = _get_text_model(model)
+    if getattr(tm, "model", None) is None and not _has_direct_hidden_stack(model):
+        print("Unsloth: text model does not expose a separable hidden-state "
+              "backbone for CCE; falling back to standard cross-entropy.")
+        loss_fn = make_baseline_loss_fn(label_smoothing=label_smoothing)
+        loss_fn._unsloth_cce_backend = "baseline-fallback"
+        return loss_fn
     head_desc = describe_output_head(model)
     _ineligible = _cce_head_ineligibility(head_desc)
     if _ineligible is not None:


### PR DESCRIPTION
## Summary

The MLX chunked cross-entropy (CCE) fused loss computes the training objective directly from hidden states and the output-head weight, bypassing the model's own forward tail. That is a large memory win, but it silently trains a *different* objective whenever the real forward applies anything between the head projection and the returned logits — a scalar multiply, a divide, a softcap, an additive bias — or when it uses a head the reconstruction resolves incorrectly. This branch makes fused CCE faithful to the model's forward across the affected architectures, gates it off (to the exact eager baseline) whenever it cannot be faithful, and adds `label_smoothing_factor` support. Every fallback is fail-closed and reported.

## Problem and impact

Concrete pre-fix failures (tiny random-weight instances, exact objective mismatch):

- Cohere/Cohere2 multiply logits by `logit_scale` (0.0625). Fused CCE omitted it: loss off by ~11%, and the tied-embedding gradient was ~16× too large (it picked up `1/logit_scale`). Same exposure on the VLM side (Aya Vision, Cohere2-MoE).
- Granite divides by `logits_scaling`, tied Falcon-H1 multiplies by `lm_head_multiplier/embedding_multiplier`, untied MiniCPM divides hidden states by `hidden_size/dim_model_base`, RecurrentGemma softcaps under the alias `logits_soft_cap` — all previously reconstructed without the transform.
- Phi/PhiMoE additive head bias was dropped; a LoRA-wrapped head crashed on `.weight`; alt-named tied embeddings (InternLM2 `tok_embeddings`) were misclassified as frozen, silently stop-gradienting the head; and dead `tie_word_embeddings` config flags (Qwen2-MoE, GLM4-MoE-Lite) routed CCE through the wrong weight.

## What changed

- **Scale/transform faithfulness.** `logit_scale` is applied by pre-scaling hidden states — `(h·s) @ W == s·(h @ W)` per vocab chunk — so the cached Metal kernels and VJP stay scale-agnostic while both `dH` and `dW` pick up the scale via the chain rule. A small declarative table extends this to the Granite divide, the Falcon tied composite, the MiniCPM untied ratio, and the `logits_soft_cap` softcap alias, funnelling each into one effective scale under a validated magnitude range. VLM factories share the same detection.
- **Output-head descriptor + eligibility gate.** A single `describe_output_head` resolves the live head with affirmative evidence only (a true tie flag read by the same truthiness the forward uses, a real `lm_head`, or a source-level embedding accessor), never inferring "tied" from a missing `lm_head`. Fused CCE runs only for a raw, additive-bias-free, affirmatively-resolved head; everything else (unknown topology, additive bias, non-raw wrapper, out-of-range/unverified transform, non-separable backbone) falls back to the eager baseline with one reason-bearing notice. Head trainability is decided by resolved-module identity in the registered parameter tree, not by name segments.
- **Label smoothing.** `label_smoothing_factor` with HF `LabelSmoother` semantics on the text path, in both fused CCE and the eager baseline; `ε=0` is a bitwise and performance no-op; invalid values raise; VLM rejects `ε>0`.

## Fail-closed design

Detection trusts only the value the live forward consumes, and every ambiguous or unverified state routes to the baseline rather than guessing: config/live-attribute drift, present-`None` knobs, more than one transform knob at once, effective scales outside the measured range, dead tie flags contradicted by the analyzed route, and unresolved topologies all fail closed. The reconstruction never invents a route the forward does not implement; where it cannot match, the model's own forward is used.

## Validation

- Focused MLX suites pass on Apple Silicon (Cohere/Granite/Falcon/MiniCPM/Helium/InternLM2/Qwen2-MoE/GLM4-MoE-Lite checked for exact baseline parity or correct gating); the four pre-existing torch-shim failures in `tests/test_mlx_cce_kernel.py` reproduce on an unmodified tree and are unrelated to this change.
- A cross-architecture routing sweep over every instantiable text architecture (both tie modes) shows zero unintended routing changes; the only behavior deltas are the intended fixes, and the un-swept architectures are guaranteed by construction to route to the correct baseline rather than a wrong loss.
- Exhaustive numeric/gradient parity matrices are kept as recorded validation to keep the in-repo test footprint proportionate; the in-repo suite retains the structural invariants for each change.

## Notes for reviewers

The branch is organized as 11 focused commits (logit_scale text → VLM → label smoothing → descriptor → eligibility gate → multi-embedding anchor → topology fallback → knob table → softcap alias/VLM wiring → identity trainability → tie-flag corroboration); reviewing commit-by-commit follows the design's evolution. No CUDA-path changes.
