### PR TITLE
Fix Gemma-4 vision pooler float16 overflow (26B-A4B / 31B NaN loss)

### DIFF
--- a/tests/test_gemma4_vision_pooler_fp16.py
+++ b/tests/test_gemma4_vision_pooler_fp16.py
@@ -3,21 +3,23 @@
 The buggy transformers (<= 5.9.x) Gemma4VisionPooler scales pooled activations
 by sqrt(hidden_size) in the input dtype, so fp16 activations ~2300 overflow to
 inf (2300 * 33.94 > 65504) and NaN the loss. The zoo patch upcasts the pooler
-input to fp32 (reproducing the upstream >= 5.10.1 fixed pooler's fp32 output),
-lets standardization run in fp32, and casts last_hidden_state back to the
-pixel_values dtype in Gemma4VisionModel.forward.
+input to fp32 (matching the upstream >= 5.10.1 fixed pooler's fp32 output up
+to fp16 rounding), lets standardization run in fp32, and casts
+last_hidden_state back to the encoder's working dtype (the patch embedder's
+input_proj weight dtype, i.e. upstream's inputs_embeds.dtype) in
+Gemma4VisionModel.forward.
 
 Synthetic classes below mirror the exact 5.5.0 source shapes so the tests run
 on any installed transformers (including 4.57.6, which has no gemma4 at all).
 """
 
-import math
 import types
 
 import pytest
 import torch
 
 from unsloth_zoo.temporary_patches.gemma4 import (
+    _gemma4_vision_cast_dtype,
     _gemma4_vision_pooler_status,
     _patch_gemma4_vision_pooler_fp16,
     patch_Gemma4VisionPoolerFP16,
@@ -27,7 +29,7 @@ from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
 HIDDEN = 1152  # 26B-A4B / 31B vision tower width; sqrt = 33.94
 
 
-def make_buggy_classes(standardize=True):
+def make_buggy_classes(standardize=True, model_dtype=torch.float16, return_tuple=False):
     """Fresh classes per test (the patch mutates class attributes)."""
 
     class TinyPooler(torch.nn.Module):
@@ -40,23 +42,42 @@ def make_buggy_classes(standardize=True):
             hidden_states *= self.root_hidden_size
             return hidden_states, padding_positions
 
+    class TinyPatchEmbedder(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.input_proj = torch.nn.Linear(HIDDEN, HIDDEN, bias=False)
+
+        def forward(self, pixel_values):
+            # Like upstream: the embedder casts pixels to its weight dtype.
+            # Identity pass instead of the matmul to keep amax controlled.
+            return pixel_values.to(self.input_proj.weight.dtype)
+
     class TinyVisionModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
+            self.patch_embedder = TinyPatchEmbedder()
             self.pooler = TinyPooler()
             self.standardize = standardize
-            self.register_buffer("std_bias", torch.full((HIDDEN,), 50000.0, dtype=torch.float16))
-            self.register_buffer("std_scale", torch.full((HIDDEN,), 0.02, dtype=torch.float16))
+            self.register_buffer("std_bias", torch.full((HIDDEN,), 50000.0, dtype=model_dtype))
+            self.register_buffer("std_scale", torch.full((HIDDEN,), 0.02, dtype=model_dtype))
 
         def forward(self, pixel_values, padding_positions=None):
+            hidden_states = self.patch_embedder(pixel_values)
             if padding_positions is None:
-                padding_positions = torch.zeros(pixel_values.shape[:2], dtype=torch.bool)
-            hidden_states, pooler_mask = self.pooler(pixel_values, None, padding_positions)
+                padding_positions = torch.zeros(hidden_states.shape[:2], dtype=torch.bool)
+            hidden_states, pooler_mask = self.pooler(hidden_states, None, padding_positions)
             if self.standardize:
                 hidden_states = (hidden_states - self.std_bias) * self.std_scale
+            if return_tuple:
+                return (hidden_states,)
             return types.SimpleNamespace(last_hidden_state=hidden_states)
 
     return TinyPooler, TinyVisionModel
+
+
+def make_model(vision_cls, model_dtype=torch.float16):
+    model = vision_cls()
+    return model.to(model_dtype)
 
 
 def make_fixed_pooler():
@@ -73,10 +94,10 @@ def make_fixed_pooler():
     return FixedPooler
 
 
-def fp16_overflow_input():
+def fp16_overflow_input(dtype=torch.float16):
     # amax ~2300 in fp16: finite before the pooler, 2300 * 33.94 = 78k > 65504 after.
     x = torch.linspace(-2300.0, 2300.0, 2 * HIDDEN, dtype=torch.float32)
-    return x.reshape(1, 2, HIDDEN).to(torch.float16)
+    return x.reshape(1, 2, HIDDEN).to(dtype)
 
 
 def test_status_classification():
@@ -91,9 +112,21 @@ def test_status_classification():
     assert _gemma4_vision_pooler_status(Drifted) == "unknown"
 
 
+def test_status_unknown_when_source_unavailable():
+    # exec'd class: inspect.getsource fails -> fail open to "unknown"/skip.
+    namespace = {"torch": torch}
+    exec(
+        "class NoSourcePooler(torch.nn.Module):\n"
+        "    def forward(self, hidden_states):\n"
+        "        return hidden_states * self.root_hidden_size\n",
+        namespace,
+    )
+    assert _gemma4_vision_pooler_status(namespace["NoSourcePooler"]) == "unknown"
+
+
 def test_unpatched_fp16_overflows():
     _, TinyVisionModel = make_buggy_classes()
-    out = TinyVisionModel()(fp16_overflow_input()).last_hidden_state
+    out = make_model(TinyVisionModel)(fp16_overflow_input()).last_hidden_state
     assert not torch.isfinite(out).all(), "expected the buggy pooler to overflow fp16"
 
 
@@ -102,11 +135,12 @@ def test_patched_fp16_finite_and_matches_fp32_reference():
     x = fp16_overflow_input()
 
     # fp32 reference on the UNPATCHED classes.
-    ref = TinyVisionModel()(x.float()).last_hidden_state
+    _, RefVisionModel = make_buggy_classes()
+    ref = make_model(RefVisionModel, torch.float32)(x.float()).last_hidden_state
 
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
-    out = TinyVisionModel()(x).last_hidden_state
-    assert out.dtype == torch.float16, "caller must cast back to the pixel_values dtype"
+    out = make_model(TinyVisionModel)(x).last_hidden_state
+    assert out.dtype == torch.float16, "caller must cast back to the encoder dtype"
     assert torch.isfinite(out).all()
     torch.testing.assert_close(out.float(), ref, rtol=2e-3, atol=2.0)
 
@@ -114,23 +148,57 @@ def test_patched_fp16_finite_and_matches_fp32_reference():
 def test_patched_standardize_false_casts_back():
     TinyPooler, TinyVisionModel = make_buggy_classes(standardize=False)
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
-    out = TinyVisionModel()(fp16_overflow_input()).last_hidden_state
+    x = fp16_overflow_input()
+    out = make_model(TinyVisionModel)(x).last_hidden_state
     assert out.dtype == torch.float16
-    # No standardization to cancel the overflow: fp32 78k saturates the fp16
-    # cast to inf, matching what upstream >= 5.10.1 does for standardize=False.
-    assert torch.isfinite(out).any()
+    # Exact upstream >= 5.10.1 semantics for standardize=False: fp32 scale
+    # then a saturating fp16 cast (values past 65504 become inf).
+    expected = (x.float() * HIDDEN**0.5).to(torch.float16)
+    assert torch.equal(out, expected)
+
+
+def test_mixed_fp32_pixels_fp16_tower_casts_to_tower_dtype():
+    # Standard HF processor output is fp32; the embedder casts it to fp16.
+    # The cast-back target must be the tower dtype, NOT the pixel dtype -
+    # otherwise fp32 features hit the fp16 embed_vision projection downstream.
+    TinyPooler, TinyVisionModel = make_buggy_classes()
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    out = make_model(TinyVisionModel)(fp16_overflow_input(torch.float32)).last_hidden_state
+    assert out.dtype == torch.float16
+    assert torch.isfinite(out).all()
+
+
+def test_mixed_fp32_pixels_bf16_tower_untouched():
+    # bf16 tower: the pooler gate and the fp16-only cast must both stay off.
+    TinyPooler, TinyVisionModel = make_buggy_classes(model_dtype=torch.bfloat16)
+    x = fp16_overflow_input(torch.float32)
+    before = make_model(TinyVisionModel, torch.bfloat16)(x).last_hidden_state
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    after = make_model(TinyVisionModel, torch.bfloat16)(x).last_hidden_state
+    assert after.dtype == before.dtype
+    assert torch.equal(after, before)
 
 
 def test_bf16_and_fp32_bit_identical():
     for dtype in (torch.bfloat16, torch.float32):
-        TinyPooler, TinyVisionModel = make_buggy_classes()
-        x = fp16_overflow_input().to(dtype)
-        before_model = TinyVisionModel().to(dtype)  # real bf16/fp32 models have uniform buffers
-        before = before_model(x).last_hidden_state
+        TinyPooler, TinyVisionModel = make_buggy_classes(model_dtype=dtype)
+        x = fp16_overflow_input(dtype)
+        before = make_model(TinyVisionModel, dtype)(x).last_hidden_state
         assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
-        after = TinyVisionModel().to(dtype)(x).last_hidden_state
+        after = make_model(TinyVisionModel, dtype)(x).last_hidden_state
         assert after.dtype == before.dtype
         assert torch.equal(after, before), f"{dtype} must be untouched"
+
+
+def test_tuple_output_cast():
+    # transformers decorators return a plain tuple under return_dict=False;
+    # the cast-back must not silently skip that path.
+    TinyPooler, TinyVisionModel = make_buggy_classes(return_tuple=True)
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    out = make_model(TinyVisionModel)(fp16_overflow_input())
+    assert isinstance(out, tuple)
+    assert out[0].dtype == torch.float16
+    assert torch.isfinite(out[0]).all()
 
 
 def test_fixed_source_is_skipped():
@@ -166,6 +234,21 @@ def test_idempotent():
     assert TinyVisionModel.forward is once_vision
 
 
+def test_repair_reinstalls_missing_vision_wrapper():
+    # A marked pooler without the paired vision wrapper (external rebind or
+    # an interrupt between installs cannot produce this - the pooler marker
+    # is the commit point - but external code can) must be repaired, never
+    # reported "already".
+    TinyPooler, TinyVisionModel = make_buggy_classes()
+    original_vision = TinyVisionModel.forward
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    TinyVisionModel.forward = original_vision  # simulate external rebind
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "repaired"
+    assert getattr(TinyVisionModel.forward, "_unsloth_vision_pooler_fp16", False)
+    out = make_model(TinyVisionModel)(fp16_overflow_input()).last_hidden_state
+    assert out.dtype == torch.float16 and torch.isfinite(out).all()
+
+
 def test_kwarg_calls_handled():
     TinyPooler, TinyVisionModel = make_buggy_classes()
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
@@ -174,15 +257,25 @@ def test_kwarg_calls_handled():
     padding = torch.zeros(x.shape[:2], dtype=torch.bool)
     hs, _ = pooler(hidden_states=x, pixel_position_ids=None, padding_positions=padding)
     assert hs.dtype == torch.float32 and torch.isfinite(hs).all()
-    out = TinyVisionModel()(pixel_values=x).last_hidden_state
+    out = make_model(TinyVisionModel)(pixel_values=x).last_hidden_state
     assert out.dtype == torch.float16 and torch.isfinite(out).all()
+
+
+def test_cast_dtype_helper_fallbacks():
+    TinyPooler, TinyVisionModel = make_buggy_classes()
+    model = make_model(TinyVisionModel)
+    assert _gemma4_vision_cast_dtype(model, None) == torch.float16
+    bare = types.SimpleNamespace()  # no patch_embedder: fall back to pixels
+    assert _gemma4_vision_cast_dtype(bare, torch.zeros(1, dtype=torch.bfloat16)) == torch.bfloat16
+    assert _gemma4_vision_cast_dtype(bare, [torch.zeros(1, dtype=torch.float16)]) == torch.float16
+    assert _gemma4_vision_cast_dtype(bare, None) is None
 
 
 def test_gradients_flow_through_patch():
     TinyPooler, TinyVisionModel = make_buggy_classes()
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
     x = fp16_overflow_input().requires_grad_(True)
-    out = TinyVisionModel()(x).last_hidden_state
+    out = make_model(TinyVisionModel)(x).last_hidden_state
     out.float().sum().backward()
     assert x.grad is not None and torch.isfinite(x.grad).all()
 
@@ -208,7 +301,10 @@ def test_real_transformers_source_canary():
 
 def test_real_transformers_patch_applies_or_skips():
     """End-to-end on the installed transformers: the public wrapper either
-    patches (buggy source), skips (fixed source), or no-ops (no gemma4)."""
+    patches (buggy source), skips (fixed source), or no-ops (no gemma4).
+    NOTE: on buggy installs this mutates the process-global transformers
+    classes (that is the shipping behavior); other tests here only use
+    per-test synthetic classes, so ordering does not matter."""
     try:
         import transformers.models.gemma4.modeling_gemma4 as modeling
     except ImportError:

--- a/tests/test_gemma4_vision_pooler_fp16.py
+++ b/tests/test_gemma4_vision_pooler_fp16.py
@@ -62,11 +62,14 @@ def make_buggy_classes(standardize=True, model_dtype=torch.float16, return_tuple
         def __init__(self):
             super().__init__()
             self.input_proj = torch.nn.Linear(HIDDEN, HIDDEN, bias=False)
+            with torch.no_grad():
+                self.input_proj.weight.copy_(torch.eye(HIDDEN))
 
         def forward(self, pixel_values):
-            # Like upstream: the embedder casts pixels to its weight dtype.
-            # Identity pass instead of the matmul to keep amax controlled.
-            return pixel_values.to(self.input_proj.weight.dtype)
+            # Like upstream: cast pixels to the weight dtype, then run the
+            # real (autocast-eligible) Linear. Identity weight keeps amax
+            # controlled while preserving autocast dtype semantics.
+            return self.input_proj(pixel_values.to(self.input_proj.weight.dtype))
 
     class TinyVisionModel(torch.nn.Module):
         def __init__(self):
@@ -215,6 +218,42 @@ def test_tuple_output_cast():
     assert isinstance(out, tuple)
     assert out[0].dtype == torch.float16
     assert torch.isfinite(out[0]).all()
+
+
+def test_bf16_autocast_over_fp16_weights_untouched():
+    # Under bf16 autocast an fp16-weight input_proj emits bf16 (the true
+    # inputs_embeds dtype); the wrapper must key on that, not the weight
+    # dtype, or it would downcast a previously-safe bf16 path to fp16.
+    TinyPooler, TinyVisionModel = make_buggy_classes(standardize=False)
+    x = fp16_overflow_input(torch.float32)
+    with torch.autocast("cpu", torch.bfloat16):
+        before = make_model(TinyVisionModel)(x).last_hidden_state
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    with torch.autocast("cpu", torch.bfloat16):
+        after = make_model(TinyVisionModel)(x).last_hidden_state
+    assert after.dtype == before.dtype
+    assert torch.equal(after, before)
+    assert torch.isfinite(after).all(), "bf16 range must be preserved (no fp16 saturation)"
+
+
+def test_captured_hidden_states_stay_consistent():
+    # transformers' capture wrapper ties hidden_states[-1] to the pre-cast
+    # final state; the wrapper must cast that entry too.
+    TinyPooler, TinyVisionModel = make_buggy_classes()
+
+    original_forward = TinyVisionModel.forward
+
+    def forward_with_capture(self, pixel_values, padding_positions=None):
+        output = original_forward(self, pixel_values, padding_positions)
+        output.hidden_states = (torch.zeros(1, dtype=torch.float16), output.last_hidden_state)
+        return output
+
+    TinyVisionModel.forward = forward_with_capture
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    out = make_model(TinyVisionModel)(fp16_overflow_input())
+    assert out.last_hidden_state.dtype == torch.float16
+    assert out.hidden_states[-1].dtype == torch.float16
+    assert out.hidden_states[-1] is out.last_hidden_state
 
 
 def test_fixed_source_is_skipped():

--- a/tests/test_gemma4_vision_pooler_fp16.py
+++ b/tests/test_gemma4_vision_pooler_fp16.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """CPU tests for the Gemma-4 vision pooler float16 overflow fix.
 
 The buggy transformers (<= 5.9.x) Gemma4VisionPooler scales pooled activations

--- a/tests/test_gemma4_vision_pooler_fp16.py
+++ b/tests/test_gemma4_vision_pooler_fp16.py
@@ -16,17 +16,15 @@
 
 """CPU tests for the Gemma-4 vision pooler float16 overflow fix.
 
-The buggy transformers (<= 5.9.x) Gemma4VisionPooler scales pooled activations
-by sqrt(hidden_size) in the input dtype, so fp16 activations ~2300 overflow to
-inf (2300 * 33.94 > 65504) and NaN the loss. The zoo patch upcasts the pooler
-input to fp32 (matching the upstream >= 5.10.1 fixed pooler's fp32 output up
-to fp16 rounding), lets standardization run in fp32, and casts
-last_hidden_state back to the encoder's working dtype (the patch embedder's
-input_proj weight dtype, i.e. upstream's inputs_embeds.dtype) in
-Gemma4VisionModel.forward.
+The buggy transformers (<= 5.9.x) Gemma4VisionPooler scales by sqrt(hidden_size)
+in the input dtype, so fp16 activations ~2300 overflow to inf (2300 * 33.94 >
+65504) and NaN the loss. The zoo patch runs the pooler in fp32 (matching the
+upstream >= 5.10.1 fixed output up to fp16 rounding), keeps standardization in
+fp32, and casts last_hidden_state back to the encoder dtype (inputs_embeds.dtype)
+in Gemma4VisionModel.forward.
 
-Synthetic classes below mirror the exact 5.5.0 source shapes so the tests run
-on any installed transformers (including 4.57.6, which has no gemma4 at all).
+The synthetic classes below mirror the 5.5.0 source shapes so the tests run on
+any installed transformers (including 4.57.6, which has no gemma4).
 """
 
 import types
@@ -66,9 +64,8 @@ def make_buggy_classes(standardize=True, model_dtype=torch.float16, return_tuple
                 self.input_proj.weight.copy_(torch.eye(HIDDEN))
 
         def forward(self, pixel_values):
-            # Like upstream: cast pixels to the weight dtype, then run the
-            # real (autocast-eligible) Linear. Identity weight keeps amax
-            # controlled while preserving autocast dtype semantics.
+            # Upstream-like: cast pixels to the weight dtype, then run the real
+            # (autocast-eligible) Linear; identity weight keeps amax controlled.
             return self.input_proj(pixel_values.to(self.input_proj.weight.dtype))
 
     class TinyVisionModel(torch.nn.Module):
@@ -114,7 +111,7 @@ def make_fixed_pooler():
 
 
 def fp16_overflow_input(dtype=torch.float16):
-    # amax ~2300 in fp16: finite before the pooler, 2300 * 33.94 = 78k > 65504 after.
+    # amax ~2300: finite pre-pooler, 2300 * 33.94 = 78k > 65504 after.
     x = torch.linspace(-2300.0, 2300.0, 2 * HIDDEN, dtype=torch.float32)
     return x.reshape(1, 2, HIDDEN).to(dtype)
 
@@ -132,7 +129,7 @@ def test_status_classification():
 
 
 def test_status_unknown_when_source_unavailable():
-    # exec'd class: inspect.getsource fails -> fail open to "unknown"/skip.
+    # exec'd class: inspect.getsource fails -> "unknown"/skip.
     namespace = {"torch": torch}
     exec(
         "class NoSourcePooler(torch.nn.Module):\n"
@@ -170,16 +167,16 @@ def test_patched_standardize_false_casts_back():
     x = fp16_overflow_input()
     out = make_model(TinyVisionModel)(x).last_hidden_state
     assert out.dtype == torch.float16
-    # Exact upstream >= 5.10.1 semantics for standardize=False: fp32 scale
-    # then a saturating fp16 cast (values past 65504 become inf).
+    # Upstream >= 5.10.1 standardize=False: fp32 scale then saturating fp16
+    # cast (values past 65504 become inf).
     expected = (x.float() * HIDDEN**0.5).to(torch.float16)
     assert torch.equal(out, expected)
 
 
 def test_mixed_fp32_pixels_fp16_tower_casts_to_tower_dtype():
-    # Standard HF processor output is fp32; the embedder casts it to fp16.
-    # The cast-back target must be the tower dtype, NOT the pixel dtype -
-    # otherwise fp32 features hit the fp16 embed_vision projection downstream.
+    # HF processor output is fp32; the embedder casts it to fp16. The cast-back
+    # target must be the tower dtype, not the pixel dtype, or fp32 features hit
+    # the fp16 embed_vision projection downstream.
     TinyPooler, TinyVisionModel = make_buggy_classes()
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
     out = make_model(TinyVisionModel)(fp16_overflow_input(torch.float32)).last_hidden_state
@@ -188,7 +185,7 @@ def test_mixed_fp32_pixels_fp16_tower_casts_to_tower_dtype():
 
 
 def test_mixed_fp32_pixels_bf16_tower_untouched():
-    # bf16 tower: the pooler gate and the fp16-only cast must both stay off.
+    # bf16 tower: pooler gate and fp16-only cast must both stay off.
     TinyPooler, TinyVisionModel = make_buggy_classes(model_dtype=torch.bfloat16)
     x = fp16_overflow_input(torch.float32)
     before = make_model(TinyVisionModel, torch.bfloat16)(x).last_hidden_state
@@ -210,8 +207,7 @@ def test_bf16_and_fp32_bit_identical():
 
 
 def test_tuple_output_cast():
-    # transformers decorators return a plain tuple under return_dict=False;
-    # the cast-back must not silently skip that path.
+    # return_dict=False yields a plain tuple; cast-back must not skip it.
     TinyPooler, TinyVisionModel = make_buggy_classes(return_tuple=True)
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
     out = make_model(TinyVisionModel)(fp16_overflow_input())
@@ -222,8 +218,8 @@ def test_tuple_output_cast():
 
 def test_bf16_autocast_over_fp16_weights_untouched():
     # Under bf16 autocast an fp16-weight input_proj emits bf16 (the true
-    # inputs_embeds dtype); the wrapper must key on that, not the weight
-    # dtype, or it would downcast a previously-safe bf16 path to fp16.
+    # inputs_embeds dtype); keying on the weight dtype would downcast a
+    # safe bf16 path to fp16.
     TinyPooler, TinyVisionModel = make_buggy_classes(standardize=False)
     x = fp16_overflow_input(torch.float32)
     with torch.autocast("cpu", torch.bfloat16):
@@ -237,8 +233,8 @@ def test_bf16_autocast_over_fp16_weights_untouched():
 
 
 def test_captured_hidden_states_stay_consistent():
-    # transformers' capture wrapper ties hidden_states[-1] to the pre-cast
-    # final state; the wrapper must cast that entry too.
+    # The capture wrapper ties hidden_states[-1] to the pre-cast final
+    # state; that entry must be cast too.
     TinyPooler, TinyVisionModel = make_buggy_classes()
 
     original_forward = TinyVisionModel.forward
@@ -290,10 +286,8 @@ def test_idempotent():
 
 
 def test_repair_reinstalls_missing_vision_wrapper():
-    # A marked pooler without the paired vision wrapper (external rebind or
-    # an interrupt between installs cannot produce this - the pooler marker
-    # is the commit point - but external code can) must be repaired, never
-    # reported "already".
+    # A marked pooler without its paired vision wrapper (only external rebind
+    # can produce this) must be repaired, never reported "already".
     TinyPooler, TinyVisionModel = make_buggy_classes()
     original_vision = TinyVisionModel.forward
     assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
@@ -320,7 +314,7 @@ def test_cast_dtype_helper_fallbacks():
     TinyPooler, TinyVisionModel = make_buggy_classes()
     model = make_model(TinyVisionModel)
     assert _gemma4_vision_cast_dtype(model, None) == torch.float16
-    bare = types.SimpleNamespace()  # no patch_embedder: fall back to pixels
+    bare = types.SimpleNamespace()  # no patch_embedder -> fall back to pixels
     assert _gemma4_vision_cast_dtype(bare, torch.zeros(1, dtype=torch.bfloat16)) == torch.bfloat16
     assert _gemma4_vision_cast_dtype(bare, [torch.zeros(1, dtype=torch.float16)]) == torch.float16
     assert _gemma4_vision_cast_dtype(bare, None) is None
@@ -340,9 +334,8 @@ def test_wrapper_registered():
 
 
 def test_real_transformers_source_canary():
-    """Drift guard: the installed pooler must be a known-buggy or known-fixed
-    shape. Fails loudly when upstream rewrites the pooler so the pattern list
-    gets refreshed."""
+    """Drift guard: the installed pooler must be known-buggy or known-fixed;
+    fails loudly when upstream rewrites it so the patterns get refreshed."""
     modeling = pytest.importorskip("transformers.models.gemma4.modeling_gemma4")
     pooler_cls = getattr(modeling, "Gemma4VisionPooler", None)
     if pooler_cls is None:
@@ -355,10 +348,9 @@ def test_real_transformers_source_canary():
 
 
 def test_real_transformers_patch_applies_or_skips():
-    """End-to-end on the installed transformers: the public wrapper either
-    patches (buggy source), skips (fixed source), or no-ops (no gemma4).
-    NOTE: on buggy installs this mutates the process-global transformers
-    classes (that is the shipping behavior); other tests here only use
+    """End-to-end on the installed transformers: the public wrapper patches
+    (buggy), skips (fixed), or no-ops (no gemma4). On buggy installs this
+    mutates the process-global classes (shipping behavior); other tests use
     per-test synthetic classes, so ordering does not matter."""
     try:
         import transformers.models.gemma4.modeling_gemma4 as modeling

--- a/tests/test_gemma4_vision_pooler_fp16.py
+++ b/tests/test_gemma4_vision_pooler_fp16.py
@@ -1,0 +1,228 @@
+"""CPU tests for the Gemma-4 vision pooler float16 overflow fix.
+
+The buggy transformers (<= 5.9.x) Gemma4VisionPooler scales pooled activations
+by sqrt(hidden_size) in the input dtype, so fp16 activations ~2300 overflow to
+inf (2300 * 33.94 > 65504) and NaN the loss. The zoo patch upcasts the pooler
+input to fp32 (reproducing the upstream >= 5.10.1 fixed pooler's fp32 output),
+lets standardization run in fp32, and casts last_hidden_state back to the
+pixel_values dtype in Gemma4VisionModel.forward.
+
+Synthetic classes below mirror the exact 5.5.0 source shapes so the tests run
+on any installed transformers (including 4.57.6, which has no gemma4 at all).
+"""
+
+import math
+import types
+
+import pytest
+import torch
+
+from unsloth_zoo.temporary_patches.gemma4 import (
+    _gemma4_vision_pooler_status,
+    _patch_gemma4_vision_pooler_fp16,
+    patch_Gemma4VisionPoolerFP16,
+)
+from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES
+
+HIDDEN = 1152  # 26B-A4B / 31B vision tower width; sqrt = 33.94
+
+
+def make_buggy_classes(standardize=True):
+    """Fresh classes per test (the patch mutates class attributes)."""
+
+    class TinyPooler(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.root_hidden_size = HIDDEN**0.5
+
+        def forward(self, hidden_states, pixel_position_ids, padding_positions, output_length=None):
+            hidden_states = hidden_states.masked_fill(padding_positions.unsqueeze(-1), 0.0)
+            hidden_states *= self.root_hidden_size
+            return hidden_states, padding_positions
+
+    class TinyVisionModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.pooler = TinyPooler()
+            self.standardize = standardize
+            self.register_buffer("std_bias", torch.full((HIDDEN,), 50000.0, dtype=torch.float16))
+            self.register_buffer("std_scale", torch.full((HIDDEN,), 0.02, dtype=torch.float16))
+
+        def forward(self, pixel_values, padding_positions=None):
+            if padding_positions is None:
+                padding_positions = torch.zeros(pixel_values.shape[:2], dtype=torch.bool)
+            hidden_states, pooler_mask = self.pooler(pixel_values, None, padding_positions)
+            if self.standardize:
+                hidden_states = (hidden_states - self.std_bias) * self.std_scale
+            return types.SimpleNamespace(last_hidden_state=hidden_states)
+
+    return TinyPooler, TinyVisionModel
+
+
+def make_fixed_pooler():
+    class FixedPooler(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.root_hidden_size = HIDDEN**0.5
+
+        def forward(self, hidden_states, pixel_position_ids, padding_positions, output_length=None):
+            hidden_states = hidden_states.masked_fill(padding_positions.unsqueeze(-1), 0.0)
+            hidden_states = hidden_states.float() * self.root_hidden_size
+            return hidden_states, padding_positions
+
+    return FixedPooler
+
+
+def fp16_overflow_input():
+    # amax ~2300 in fp16: finite before the pooler, 2300 * 33.94 = 78k > 65504 after.
+    x = torch.linspace(-2300.0, 2300.0, 2 * HIDDEN, dtype=torch.float32)
+    return x.reshape(1, 2, HIDDEN).to(torch.float16)
+
+
+def test_status_classification():
+    TinyPooler, _ = make_buggy_classes()
+    assert _gemma4_vision_pooler_status(TinyPooler) == "buggy"
+    assert _gemma4_vision_pooler_status(make_fixed_pooler()) == "fixed"
+
+    class Drifted(torch.nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states * self.some_other_scale
+
+    assert _gemma4_vision_pooler_status(Drifted) == "unknown"
+
+
+def test_unpatched_fp16_overflows():
+    _, TinyVisionModel = make_buggy_classes()
+    out = TinyVisionModel()(fp16_overflow_input()).last_hidden_state
+    assert not torch.isfinite(out).all(), "expected the buggy pooler to overflow fp16"
+
+
+def test_patched_fp16_finite_and_matches_fp32_reference():
+    TinyPooler, TinyVisionModel = make_buggy_classes()
+    x = fp16_overflow_input()
+
+    # fp32 reference on the UNPATCHED classes.
+    ref = TinyVisionModel()(x.float()).last_hidden_state
+
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    out = TinyVisionModel()(x).last_hidden_state
+    assert out.dtype == torch.float16, "caller must cast back to the pixel_values dtype"
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out.float(), ref, rtol=2e-3, atol=2.0)
+
+
+def test_patched_standardize_false_casts_back():
+    TinyPooler, TinyVisionModel = make_buggy_classes(standardize=False)
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    out = TinyVisionModel()(fp16_overflow_input()).last_hidden_state
+    assert out.dtype == torch.float16
+    # No standardization to cancel the overflow: fp32 78k saturates the fp16
+    # cast to inf, matching what upstream >= 5.10.1 does for standardize=False.
+    assert torch.isfinite(out).any()
+
+
+def test_bf16_and_fp32_bit_identical():
+    for dtype in (torch.bfloat16, torch.float32):
+        TinyPooler, TinyVisionModel = make_buggy_classes()
+        x = fp16_overflow_input().to(dtype)
+        before_model = TinyVisionModel().to(dtype)  # real bf16/fp32 models have uniform buffers
+        before = before_model(x).last_hidden_state
+        assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+        after = TinyVisionModel().to(dtype)(x).last_hidden_state
+        assert after.dtype == before.dtype
+        assert torch.equal(after, before), f"{dtype} must be untouched"
+
+
+def test_fixed_source_is_skipped():
+    FixedPooler = make_fixed_pooler()
+    _, TinyVisionModel = make_buggy_classes()
+    original_pooler = FixedPooler.forward
+    original_vision = TinyVisionModel.forward
+    assert _patch_gemma4_vision_pooler_fp16(FixedPooler, TinyVisionModel) == "fixed"
+    assert FixedPooler.forward is original_pooler
+    assert TinyVisionModel.forward is original_vision
+
+
+def test_drift_source_is_skipped_atomically():
+    class Drifted(torch.nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states * self.some_other_scale
+
+    _, TinyVisionModel = make_buggy_classes()
+    original_pooler = Drifted.forward
+    original_vision = TinyVisionModel.forward
+    assert _patch_gemma4_vision_pooler_fp16(Drifted, TinyVisionModel) == "unknown"
+    assert Drifted.forward is original_pooler
+    assert TinyVisionModel.forward is original_vision, "drift must skip BOTH classes"
+
+
+def test_idempotent():
+    TinyPooler, TinyVisionModel = make_buggy_classes()
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    once_pooler = TinyPooler.forward
+    once_vision = TinyVisionModel.forward
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "already"
+    assert TinyPooler.forward is once_pooler
+    assert TinyVisionModel.forward is once_vision
+
+
+def test_kwarg_calls_handled():
+    TinyPooler, TinyVisionModel = make_buggy_classes()
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    x = fp16_overflow_input()
+    pooler = TinyPooler()
+    padding = torch.zeros(x.shape[:2], dtype=torch.bool)
+    hs, _ = pooler(hidden_states=x, pixel_position_ids=None, padding_positions=padding)
+    assert hs.dtype == torch.float32 and torch.isfinite(hs).all()
+    out = TinyVisionModel()(pixel_values=x).last_hidden_state
+    assert out.dtype == torch.float16 and torch.isfinite(out).all()
+
+
+def test_gradients_flow_through_patch():
+    TinyPooler, TinyVisionModel = make_buggy_classes()
+    assert _patch_gemma4_vision_pooler_fp16(TinyPooler, TinyVisionModel) == "patched"
+    x = fp16_overflow_input().requires_grad_(True)
+    out = TinyVisionModel()(x).last_hidden_state
+    out.float().sum().backward()
+    assert x.grad is not None and torch.isfinite(x.grad).all()
+
+
+def test_wrapper_registered():
+    assert patch_Gemma4VisionPoolerFP16 in TEMPORARY_PATCHES
+
+
+def test_real_transformers_source_canary():
+    """Drift guard: the installed pooler must be a known-buggy or known-fixed
+    shape. Fails loudly when upstream rewrites the pooler so the pattern list
+    gets refreshed."""
+    modeling = pytest.importorskip("transformers.models.gemma4.modeling_gemma4")
+    pooler_cls = getattr(modeling, "Gemma4VisionPooler", None)
+    if pooler_cls is None:
+        pytest.skip("transformers has no Gemma4VisionPooler")
+    status = _gemma4_vision_pooler_status(pooler_cls)
+    assert status in ("buggy", "fixed"), (
+        f"Gemma4VisionPooler.forward drifted (status={status}) - update "
+        "_gemma4_vision_pooler_status patterns and re-verify the fp16 fix"
+    )
+
+
+def test_real_transformers_patch_applies_or_skips():
+    """End-to-end on the installed transformers: the public wrapper either
+    patches (buggy source), skips (fixed source), or no-ops (no gemma4)."""
+    try:
+        import transformers.models.gemma4.modeling_gemma4 as modeling
+    except ImportError:
+        patch_Gemma4VisionPoolerFP16()  # must no-op without raising
+        return
+    pooler_cls = getattr(modeling, "Gemma4VisionPooler", None)
+    vision_cls = getattr(modeling, "Gemma4VisionModel", None)
+    if pooler_cls is None or vision_cls is None:
+        patch_Gemma4VisionPoolerFP16()
+        return
+    status_before = _gemma4_vision_pooler_status(pooler_cls)
+    patch_Gemma4VisionPoolerFP16()
+    if status_before == "buggy":
+        assert getattr(pooler_cls.forward, "_unsloth_vision_pooler_fp16", False)
+        assert getattr(vision_cls.forward, "_unsloth_vision_pooler_fp16", False)
+    elif status_before == "fixed":
+        assert not getattr(pooler_cls.forward, "_unsloth_vision_pooler_fp16", False)

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -828,17 +828,15 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextMLP)
 # (fp16 request on non-bf16 GPUs keeps the fp16 vision tower with autocast
 # off). E2B / E4B (hidden 768, clipped linears) and bf16 / fp32 are safe.
 #
-# Fix mirrors upstream >= 5.10.1: run the pooler in fp32 (its ops all preserve
-# dtype, so casting the input matches the fixed fp32 output up to fp16 rounding
-# and never overflows), let promotion carry fp32 through the caller's
-# standardization (std_bias cancels the large values; buffer amax 53760 is
-# inside fp16 range), then cast last_hidden_state back to the encoder dtype in
-# Gemma4VisionModel.forward. The cast target is the actual embedder output
-# dtype (upstream's inputs_embeds.dtype) and only engages for fp16 towers, so
-# bf16 / fp32 setups are bit-identical to upstream. Wrappers call the original
-# forwards, preserving HF decorators (@merge_with_config_defaults /
-# @capture_outputs); the already-fixed upstream cast-back makes the wrapper a
-# no-op there.
+# Fix mirrors upstream >= 5.10.1: run the pooler in fp32 (dtype-preserving ops
+# make the cast input match the fixed output up to fp16 rounding, never
+# overflowing), let fp32 carry through the caller's standardization (std_bias
+# cancels the large values; buffer amax 53760 is in fp16 range), then cast
+# last_hidden_state back in Gemma4VisionModel.forward to the actual embedder
+# output dtype (inputs_embeds.dtype). Only fp16 towers engage, so bf16 / fp32
+# stay bit-identical to upstream. Wrappers call the original forwards to
+# preserve HF decorators (@merge_with_config_defaults / @capture_outputs); on
+# already-fixed upstream the cast-back is a no-op.
 #
 # Source-pattern classification (not version compares) stays correct on every
 # release including the yanked 5.10.0: fixed sources skip, unknown (future

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -832,11 +832,17 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextMLP)
 #
 # Fix mirrors upstream >= 5.10.1: compute the pooler in fp32 (the buggy
 # pooler's ops - masked_fill, avg pool, scale - all preserve input dtype, so
-# casting the input to fp32 reproduces the fixed pooler's fp32 output), let
-# dtype promotion carry fp32 through the caller's standardization (the
-# std_bias subtraction cancels the large values; buffer amax is 53760, well
-# inside fp16 range), then cast last_hidden_state back to the pixel_values
-# dtype in Gemma4VisionModel.forward exactly like the upstream fix. Wrappers
+# casting the input to fp32 matches the fixed pooler's fp32 output up to fp16
+# rounding of the pooled activations; the patched path is slightly more
+# precise and never overflows), let dtype promotion carry fp32 through the
+# caller's standardization (the std_bias subtraction cancels the large
+# values; buffer amax is 53760, well inside fp16 range), then cast
+# last_hidden_state back to the encoder's working dtype in
+# Gemma4VisionModel.forward. The cast target is the patch embedder's
+# input_proj weight dtype - the embedder casts pixels to it, so it equals
+# upstream's inputs_embeds.dtype even when callers pass fp32 processor
+# pixels to an fp16 tower. The cast only engages for fp16 towers, so bf16 /
+# fp32 setups (uniform or mixed) are bit-identical to upstream. Wrappers
 # call the original forwards, so the HF decorators on Gemma4VisionModel
 # (@merge_with_config_defaults / @capture_outputs) are preserved, and the
 # already-fixed upstream cast-back makes the caller wrapper a no-op there.
@@ -862,38 +868,100 @@ def _gemma4_vision_pooler_status(pooler_cls):
     except Exception:
         return "unknown"
     source = source.replace(" ", "")
-    if "hidden_states.float()*self.root_hidden_size" in source:
-        return "fixed"
     if (
         "hidden_states*=self.root_hidden_size" in source
         or "hidden_states=hidden_states*self.root_hidden_size" in source
     ):
         return "buggy"
+    if "hidden_states.float()*self.root_hidden_size" in source:
+        return "fixed"
     return "unknown"
+pass
+
+
+def _gemma4_vision_cast_dtype(vision_model, pixel_values):
+    """The dtype upstream >= 5.10.1 casts last_hidden_state back to.
+
+    Upstream uses inputs_embeds.dtype; the patch embedder casts pixels to its
+    input_proj weight dtype, so that weight is the authoritative target even
+    when callers pass fp32 processor pixels to an fp16 tower. Fall back to
+    the pixel dtype only if the embedder shape ever drifts.
+    """
+    embedder = getattr(vision_model, "patch_embedder", None)
+    weight = getattr(getattr(embedder, "input_proj", None), "weight", None)
+    if torch.is_tensor(weight):
+        return weight.dtype
+    if torch.is_tensor(pixel_values):
+        return pixel_values.dtype
+    if isinstance(pixel_values, (list, tuple)) and len(pixel_values) > 0 \
+            and torch.is_tensor(pixel_values[0]):
+        return pixel_values[0].dtype
+    return None
 pass
 
 
 def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
     """Install the fp16-overflow wrappers on a (pooler, vision model) pair.
 
-    Returns the action taken: "already", "fixed", "unknown" or "patched".
-    Both classes are patched atomically or not at all.
+    Returns the action taken: "already", "repaired", "fixed", "unknown" or
+    "patched". The vision wrapper is installed before the pooler wrapper -
+    the pooler marker is the commit point - so an interrupt can never leave
+    an fp32-emitting pooler without the cast-back, and a missing vision
+    wrapper next to a marked pooler is re-installed ("repaired").
     """
     import functools
-    if getattr(pooler_cls.forward, "_unsloth_vision_pooler_fp16", False):
+    pooler_marked = getattr(pooler_cls.forward, "_unsloth_vision_pooler_fp16", False)
+    vision_marked = getattr(vision_cls.forward, "_unsloth_vision_pooler_fp16", False)
+    if pooler_marked and vision_marked:
         return "already"
-    status = _gemma4_vision_pooler_status(pooler_cls)
-    if status == "fixed":
-        return "fixed"
-    if status == "unknown":
-        raise_error(
-            "Gemma4VisionPooler.forward fp16 overflow fix",
-            "unrecognized upstream pooler source - skipping",
-        )
-        return "unknown"
+    if not pooler_marked:
+        status = _gemma4_vision_pooler_status(pooler_cls)
+        if status == "fixed":
+            return "fixed"
+        if status == "unknown":
+            raise_error(
+                "Gemma4VisionPooler.forward fp16 overflow fix",
+                "unrecognized upstream pooler source - skipping",
+            )
+            return "unknown"
+
+    if not vision_marked:
+        _original_vision_forward = vision_cls.forward
+
+        @functools.wraps(_original_vision_forward)
+        def vision_forward(self, *args, **kwargs):
+            pixel_values = args[0] if args else kwargs.get("pixel_values", None)
+            output = _original_vision_forward(self, *args, **kwargs)
+            target_dtype = _gemma4_vision_cast_dtype(self, pixel_values)
+            # fp16 towers only: bf16 / fp32 setups (uniform or mixed) keep
+            # bit-identical upstream behavior.
+            if target_dtype != torch.float16:
+                return output
+            is_tuple = isinstance(output, tuple)
+            hidden_states = (
+                output[0] if is_tuple and len(output) > 0
+                else getattr(output, "last_hidden_state", None)
+            )
+            if (
+                torch.is_tensor(hidden_states)
+                and hidden_states.is_floating_point()
+                and hidden_states.dtype != target_dtype
+            ):
+                # Covers standardize = False checkpoints too: the fp32
+                # pooler output is cast straight back to the encoder dtype.
+                hidden_states = hidden_states.to(target_dtype)
+                if is_tuple:
+                    output = (hidden_states,) + output[1:]
+                else:
+                    output.last_hidden_state = hidden_states
+            return output
+
+        vision_forward._unsloth_vision_pooler_fp16 = True
+        vision_cls.forward = vision_forward
+    if pooler_marked:
+        return "repaired"
 
     _original_pooler_forward = pooler_cls.forward
-    _original_vision_forward = vision_cls.forward
 
     @functools.wraps(_original_pooler_forward)
     def pooler_forward(self, *args, **kwargs):
@@ -905,27 +973,8 @@ def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
             kwargs["hidden_states"] = kwargs["hidden_states"].float()
         return _original_pooler_forward(self, *args, **kwargs)
 
-    @functools.wraps(_original_vision_forward)
-    def vision_forward(self, *args, **kwargs):
-        pixel_values = args[0] if args else kwargs.get("pixel_values", None)
-        output = _original_vision_forward(self, *args, **kwargs)
-        hidden_states = getattr(output, "last_hidden_state", None)
-        if (
-            torch.is_tensor(pixel_values)
-            and pixel_values.is_floating_point()
-            and torch.is_tensor(hidden_states)
-            and hidden_states.is_floating_point()
-            and hidden_states.dtype != pixel_values.dtype
-        ):
-            # Covers standardize = False checkpoints too: the fp32 pooler
-            # output is cast straight back to the encoder dtype.
-            output.last_hidden_state = hidden_states.to(pixel_values.dtype)
-        return output
-
     pooler_forward._unsloth_vision_pooler_fp16 = True
-    vision_forward._unsloth_vision_pooler_fp16 = True
     pooler_cls.forward = pooler_forward
-    vision_cls.forward = vision_forward
     return "patched"
 pass
 

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -814,3 +814,136 @@ def patch_Gemma4TextMLP():
         return raise_error("Gemma4TextMLP.forward", e)
 pass
 TEMPORARY_PATCHES.append(patch_Gemma4TextMLP)
+
+
+# ============================================================================
+# Gemma-4 vision pooler float16 overflow fix (transformers 5.5.0 - 5.9.x and
+# the yanked 5.10.0; fixed upstream in >= 5.10.1 by PR #46277).
+#
+# Root cause: Gemma4VisionPooler.forward scales pooled activations by
+# sqrt(hidden_size) in the input dtype:
+#     hidden_states *= self.root_hidden_size
+# For the 26B-A4B / 31B vision tower (hidden 1152, sqrt = 33.94,
+# use_clipped_linears = False) fp16 activations around ~2300 scale to ~79k,
+# past the fp16 max of 65504 -> inf -> NaN loss through embed_vision /
+# masked_scatter. Engages under Unsloth forced-float32 mode (fp16 request on
+# non-bf16 GPUs keeps the unquantized vision tower in fp16 with autocast off).
+# E2B / E4B (vision hidden 768, clipped linears) and bf16 / fp32 are safe.
+#
+# Fix mirrors upstream >= 5.10.1: compute the pooler in fp32 (the buggy
+# pooler's ops - masked_fill, avg pool, scale - all preserve input dtype, so
+# casting the input to fp32 reproduces the fixed pooler's fp32 output), let
+# dtype promotion carry fp32 through the caller's standardization (the
+# std_bias subtraction cancels the large values; buffer amax is 53760, well
+# inside fp16 range), then cast last_hidden_state back to the pixel_values
+# dtype in Gemma4VisionModel.forward exactly like the upstream fix. Wrappers
+# call the original forwards, so the HF decorators on Gemma4VisionModel
+# (@merge_with_config_defaults / @capture_outputs) are preserved, and the
+# already-fixed upstream cast-back makes the caller wrapper a no-op there.
+#
+# Source-pattern classification (not version compares) keeps this correct on
+# every release including the yanked 5.10.0: fixed sources are skipped
+# entirely, unrecognized (future drift) sources are left untouched.
+# transformers without gemma4 (e.g. 4.57.6) no-op via ImportError. The pooler
+# runs eager (the Unsloth compiler never traces Gemma4VisionPooler /
+# Gemma4VisionModel), so no compiler-cache companion is needed.
+# ============================================================================
+
+def _gemma4_vision_pooler_status(pooler_cls):
+    """Classify the installed Gemma4VisionPooler.forward source.
+
+    Returns "buggy" (dtype-preserving sqrt(hidden_size) scale, <= 5.9.x),
+    "fixed" (fp32 scale, >= 5.10.1) or "unknown" (source unavailable or
+    drifted - fail open to upstream behavior).
+    """
+    import inspect
+    try:
+        source = inspect.getsource(pooler_cls.forward)
+    except Exception:
+        return "unknown"
+    source = source.replace(" ", "")
+    if "hidden_states.float()*self.root_hidden_size" in source:
+        return "fixed"
+    if (
+        "hidden_states*=self.root_hidden_size" in source
+        or "hidden_states=hidden_states*self.root_hidden_size" in source
+    ):
+        return "buggy"
+    return "unknown"
+pass
+
+
+def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
+    """Install the fp16-overflow wrappers on a (pooler, vision model) pair.
+
+    Returns the action taken: "already", "fixed", "unknown" or "patched".
+    Both classes are patched atomically or not at all.
+    """
+    import functools
+    if getattr(pooler_cls.forward, "_unsloth_vision_pooler_fp16", False):
+        return "already"
+    status = _gemma4_vision_pooler_status(pooler_cls)
+    if status == "fixed":
+        return "fixed"
+    if status == "unknown":
+        raise_error(
+            "Gemma4VisionPooler.forward fp16 overflow fix",
+            "unrecognized upstream pooler source - skipping",
+        )
+        return "unknown"
+
+    _original_pooler_forward = pooler_cls.forward
+    _original_vision_forward = vision_cls.forward
+
+    @functools.wraps(_original_pooler_forward)
+    def pooler_forward(self, *args, **kwargs):
+        # fp16 only: bf16 / fp32 keep bit-identical upstream behavior.
+        if args and torch.is_tensor(args[0]) and args[0].dtype == torch.float16:
+            args = (args[0].float(),) + args[1:]
+        elif torch.is_tensor(kwargs.get("hidden_states", None)) and \
+                kwargs["hidden_states"].dtype == torch.float16:
+            kwargs["hidden_states"] = kwargs["hidden_states"].float()
+        return _original_pooler_forward(self, *args, **kwargs)
+
+    @functools.wraps(_original_vision_forward)
+    def vision_forward(self, *args, **kwargs):
+        pixel_values = args[0] if args else kwargs.get("pixel_values", None)
+        output = _original_vision_forward(self, *args, **kwargs)
+        hidden_states = getattr(output, "last_hidden_state", None)
+        if (
+            torch.is_tensor(pixel_values)
+            and pixel_values.is_floating_point()
+            and torch.is_tensor(hidden_states)
+            and hidden_states.is_floating_point()
+            and hidden_states.dtype != pixel_values.dtype
+        ):
+            # Covers standardize = False checkpoints too: the fp32 pooler
+            # output is cast straight back to the encoder dtype.
+            output.last_hidden_state = hidden_states.to(pixel_values.dtype)
+        return output
+
+    pooler_forward._unsloth_vision_pooler_fp16 = True
+    vision_forward._unsloth_vision_pooler_fp16 = True
+    pooler_cls.forward = pooler_forward
+    vision_cls.forward = vision_forward
+    return "patched"
+pass
+
+
+def patch_Gemma4VisionPoolerFP16():
+    try:
+        import transformers.models.gemma4.modeling_gemma4 as modeling_gemma4
+    except ImportError:
+        return
+    except Exception as e:
+        return raise_error("Gemma4VisionPooler.forward", e)
+    pooler_cls = getattr(modeling_gemma4, "Gemma4VisionPooler", None)
+    vision_cls = getattr(modeling_gemma4, "Gemma4VisionModel", None)
+    if pooler_cls is None or vision_cls is None:
+        return
+    try:
+        _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls)
+    except Exception as e:
+        return raise_error("Gemma4VisionPooler.forward", e)
+pass
+TEMPORARY_PATCHES.append(patch_Gemma4VisionPoolerFP16)

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -820,48 +820,36 @@ TEMPORARY_PATCHES.append(patch_Gemma4TextMLP)
 # Gemma-4 vision pooler float16 overflow fix (transformers 5.5.0 - 5.9.x and
 # the yanked 5.10.0; fixed upstream in >= 5.10.1 by PR #46277).
 #
-# Root cause: Gemma4VisionPooler.forward scales pooled activations by
-# sqrt(hidden_size) in the input dtype:
-#     hidden_states *= self.root_hidden_size
-# For the 26B-A4B / 31B vision tower (hidden 1152, sqrt = 33.94,
-# use_clipped_linears = False) fp16 activations around ~2300 scale to ~79k,
-# past the fp16 max of 65504 -> inf -> NaN loss through embed_vision /
-# masked_scatter. Engages under Unsloth forced-float32 mode (fp16 request on
-# non-bf16 GPUs keeps the unquantized vision tower in fp16 with autocast off).
-# E2B / E4B (vision hidden 768, clipped linears) and bf16 / fp32 are safe.
+# Root cause: Gemma4VisionPooler.forward scales by sqrt(hidden_size) in the
+# input dtype (hidden_states *= self.root_hidden_size). On the 26B-A4B / 31B
+# tower (hidden 1152, sqrt 33.94, use_clipped_linears = False) fp16 activations
+# ~2300 scale to ~79k, past the fp16 max 65504 -> inf -> NaN loss via
+# embed_vision / masked_scatter. Engages under Unsloth forced-float32 mode
+# (fp16 request on non-bf16 GPUs keeps the fp16 vision tower with autocast
+# off). E2B / E4B (hidden 768, clipped linears) and bf16 / fp32 are safe.
 #
-# Fix mirrors upstream >= 5.10.1: compute the pooler in fp32 (the buggy
-# pooler's ops - masked_fill, avg pool, scale - all preserve input dtype, so
-# casting the input to fp32 matches the fixed pooler's fp32 output up to fp16
-# rounding of the pooled activations; the patched path is slightly more
-# precise and never overflows), let dtype promotion carry fp32 through the
-# caller's standardization (the std_bias subtraction cancels the large
-# values; buffer amax is 53760, well inside fp16 range), then cast
-# last_hidden_state back to the encoder's working dtype in
-# Gemma4VisionModel.forward. The cast target is the patch embedder's
-# input_proj weight dtype - the embedder casts pixels to it, so it equals
-# upstream's inputs_embeds.dtype even when callers pass fp32 processor
-# pixels to an fp16 tower. The cast only engages for fp16 towers, so bf16 /
-# fp32 setups (uniform or mixed) are bit-identical to upstream. Wrappers
-# call the original forwards, so the HF decorators on Gemma4VisionModel
-# (@merge_with_config_defaults / @capture_outputs) are preserved, and the
-# already-fixed upstream cast-back makes the caller wrapper a no-op there.
+# Fix mirrors upstream >= 5.10.1: run the pooler in fp32 (its ops all preserve
+# dtype, so casting the input matches the fixed fp32 output up to fp16 rounding
+# and never overflows), let promotion carry fp32 through the caller's
+# standardization (std_bias cancels the large values; buffer amax 53760 is
+# inside fp16 range), then cast last_hidden_state back to the encoder dtype in
+# Gemma4VisionModel.forward. The cast target is the actual embedder output
+# dtype (upstream's inputs_embeds.dtype) and only engages for fp16 towers, so
+# bf16 / fp32 setups are bit-identical to upstream. Wrappers call the original
+# forwards, preserving HF decorators (@merge_with_config_defaults /
+# @capture_outputs); the already-fixed upstream cast-back makes the wrapper a
+# no-op there.
 #
-# Source-pattern classification (not version compares) keeps this correct on
-# every release including the yanked 5.10.0: fixed sources are skipped
-# entirely, unrecognized (future drift) sources are left untouched.
-# transformers without gemma4 (e.g. 4.57.6) no-op via ImportError. The pooler
-# runs eager (the Unsloth compiler never traces Gemma4VisionPooler /
-# Gemma4VisionModel), so no compiler-cache companion is needed.
+# Source-pattern classification (not version compares) stays correct on every
+# release including the yanked 5.10.0: fixed sources skip, unknown (future
+# drift) sources are left untouched, transformers without gemma4 no-ops via
+# ImportError. The pooler runs eager, so no compiler-cache companion is needed.
 # ============================================================================
 
 def _gemma4_vision_pooler_status(pooler_cls):
-    """Classify the installed Gemma4VisionPooler.forward source.
-
-    Returns "buggy" (dtype-preserving sqrt(hidden_size) scale, <= 5.9.x),
-    "fixed" (fp32 scale, >= 5.10.1) or "unknown" (source unavailable or
-    drifted - fail open to upstream behavior).
-    """
+    """Classify Gemma4VisionPooler.forward source: "buggy" (dtype-preserving
+    scale, <= 5.9.x), "fixed" (fp32 scale, >= 5.10.1) or "unknown" (source
+    unavailable or drifted - fail open to upstream)."""
     import inspect
     try:
         source = inspect.getsource(pooler_cls.forward)
@@ -880,14 +868,9 @@ pass
 
 
 def _gemma4_vision_cast_dtype(vision_model, pixel_values):
-    """Fallback for the dtype upstream >= 5.10.1 casts last_hidden_state to.
-
-    Upstream uses inputs_embeds.dtype - the ACTUAL patch embedder output
-    dtype, which the vision wrapper captures with a transient forward hook.
-    This fallback approximates it from the input_proj weight dtype (the
-    embedder casts pixels to it outside autocast) only when the hook saw
-    nothing, then from the pixel dtype if the embedder shape ever drifts.
-    """
+    """Fallback cast dtype when the vision wrapper's embedder hook saw nothing:
+    approximate inputs_embeds.dtype from the input_proj weight (pixels are cast
+    to it outside autocast), then from the pixel dtype if the embedder drifts."""
     embedder = getattr(vision_model, "patch_embedder", None)
     weight = getattr(getattr(embedder, "input_proj", None), "weight", None)
     if torch.is_tensor(weight):
@@ -902,14 +885,11 @@ pass
 
 
 def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
-    """Install the fp16-overflow wrappers on a (pooler, vision model) pair.
-
-    Returns the action taken: "already", "repaired", "fixed", "unknown" or
-    "patched". The vision wrapper is installed before the pooler wrapper -
-    the pooler marker is the commit point - so an interrupt can never leave
-    an fp32-emitting pooler without the cast-back, and a missing vision
-    wrapper next to a marked pooler is re-installed ("repaired").
-    """
+    """Install the fp16-overflow wrappers on a (pooler, vision) pair; returns
+    the action ("already"/"repaired"/"fixed"/"unknown"/"patched"). The vision
+    wrapper goes on before the pooler wrapper (the pooler marker is the commit
+    point) so an interrupt can never leave an fp32-emitting pooler without the
+    cast-back; a missing vision wrapper beside a marked pooler is "repaired"."""
     import functools
     pooler_marked = getattr(pooler_cls.forward, "_unsloth_vision_pooler_fp16", False)
     vision_marked = getattr(vision_cls.forward, "_unsloth_vision_pooler_fp16", False)
@@ -932,9 +912,9 @@ def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
         @functools.wraps(_original_vision_forward)
         def vision_forward(self, *args, **kwargs):
             pixel_values = args[0] if args else kwargs.get("pixel_values", None)
-            # Capture the ACTUAL embedder output dtype (upstream's
-            # inputs_embeds.dtype): under bf16 autocast an fp16-weight
-            # input_proj emits bf16, and that path must stay untouched.
+            # Capture the actual embedder output dtype (inputs_embeds.dtype):
+            # under bf16 autocast an fp16-weight input_proj emits bf16, which
+            # must stay untouched.
             seen = {}
             handle = None
             embedder = getattr(self, "patch_embedder", None)
@@ -951,8 +931,7 @@ def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
             target_dtype = seen.get("dtype")
             if target_dtype is None:
                 target_dtype = _gemma4_vision_cast_dtype(self, pixel_values)
-            # fp16 towers only: bf16 / fp32 setups (uniform, mixed, or
-            # autocast) keep bit-identical upstream behavior.
+            # fp16 towers only; bf16 / fp32 stay bit-identical to upstream.
             if target_dtype != torch.float16:
                 return output
             is_tuple = isinstance(output, tuple)
@@ -965,13 +944,11 @@ def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
                 and hidden_states.is_floating_point()
                 and hidden_states.dtype != target_dtype
             ):
-                # Covers standardize = False checkpoints too: the fp32
-                # pooler output is cast straight back to the encoder dtype.
+                # Also covers standardize = False checkpoints.
                 cast = hidden_states.to(target_dtype)
                 if is_tuple:
                     # Swap the pre-cast tensor wherever it appears, including
-                    # one level down (return_dict=False may nest the
-                    # hidden-states tuple).
+                    # one level down (return_dict=False may nest the tuple).
                     output = tuple(
                         cast if element is hidden_states else (
                             tuple(cast if item is hidden_states else item for item in element)
@@ -980,9 +957,8 @@ def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
                         for element in output
                     )
                 else:
-                    # Keep captured hidden_states consistent: transformers'
-                    # capture wrapper ties the tuple's final entry to the
-                    # (pre-cast) final state.
+                    # Keep captured hidden_states consistent: the capture
+                    # wrapper ties its final entry to the pre-cast final state.
                     extra = getattr(output, "hidden_states", None)
                     if isinstance(extra, tuple) and len(extra) > 0 \
                             and extra[-1] is hidden_states:
@@ -999,7 +975,7 @@ def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
 
     @functools.wraps(_original_pooler_forward)
     def pooler_forward(self, *args, **kwargs):
-        # fp16 only: bf16 / fp32 keep bit-identical upstream behavior.
+        # fp16 only; bf16 / fp32 stay bit-identical to upstream.
         if args and torch.is_tensor(args[0]) and args[0].dtype == torch.float16:
             args = (args[0].float(),) + args[1:]
         elif torch.is_tensor(kwargs.get("hidden_states", None)) and \

--- a/unsloth_zoo/temporary_patches/gemma4.py
+++ b/unsloth_zoo/temporary_patches/gemma4.py
@@ -880,12 +880,13 @@ pass
 
 
 def _gemma4_vision_cast_dtype(vision_model, pixel_values):
-    """The dtype upstream >= 5.10.1 casts last_hidden_state back to.
+    """Fallback for the dtype upstream >= 5.10.1 casts last_hidden_state to.
 
-    Upstream uses inputs_embeds.dtype; the patch embedder casts pixels to its
-    input_proj weight dtype, so that weight is the authoritative target even
-    when callers pass fp32 processor pixels to an fp16 tower. Fall back to
-    the pixel dtype only if the embedder shape ever drifts.
+    Upstream uses inputs_embeds.dtype - the ACTUAL patch embedder output
+    dtype, which the vision wrapper captures with a transient forward hook.
+    This fallback approximates it from the input_proj weight dtype (the
+    embedder casts pixels to it outside autocast) only when the hook saw
+    nothing, then from the pixel dtype if the embedder shape ever drifts.
     """
     embedder = getattr(vision_model, "patch_embedder", None)
     weight = getattr(getattr(embedder, "input_proj", None), "weight", None)
@@ -931,10 +932,27 @@ def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
         @functools.wraps(_original_vision_forward)
         def vision_forward(self, *args, **kwargs):
             pixel_values = args[0] if args else kwargs.get("pixel_values", None)
-            output = _original_vision_forward(self, *args, **kwargs)
-            target_dtype = _gemma4_vision_cast_dtype(self, pixel_values)
-            # fp16 towers only: bf16 / fp32 setups (uniform or mixed) keep
-            # bit-identical upstream behavior.
+            # Capture the ACTUAL embedder output dtype (upstream's
+            # inputs_embeds.dtype): under bf16 autocast an fp16-weight
+            # input_proj emits bf16, and that path must stay untouched.
+            seen = {}
+            handle = None
+            embedder = getattr(self, "patch_embedder", None)
+            if isinstance(embedder, torch.nn.Module):
+                def _capture_embed_dtype(module, hook_args, hook_output):
+                    if torch.is_tensor(hook_output):
+                        seen["dtype"] = hook_output.dtype
+                handle = embedder.register_forward_hook(_capture_embed_dtype)
+            try:
+                output = _original_vision_forward(self, *args, **kwargs)
+            finally:
+                if handle is not None:
+                    handle.remove()
+            target_dtype = seen.get("dtype")
+            if target_dtype is None:
+                target_dtype = _gemma4_vision_cast_dtype(self, pixel_values)
+            # fp16 towers only: bf16 / fp32 setups (uniform, mixed, or
+            # autocast) keep bit-identical upstream behavior.
             if target_dtype != torch.float16:
                 return output
             is_tuple = isinstance(output, tuple)
@@ -949,11 +967,27 @@ def _patch_gemma4_vision_pooler_fp16(pooler_cls, vision_cls):
             ):
                 # Covers standardize = False checkpoints too: the fp32
                 # pooler output is cast straight back to the encoder dtype.
-                hidden_states = hidden_states.to(target_dtype)
+                cast = hidden_states.to(target_dtype)
                 if is_tuple:
-                    output = (hidden_states,) + output[1:]
+                    # Swap the pre-cast tensor wherever it appears, including
+                    # one level down (return_dict=False may nest the
+                    # hidden-states tuple).
+                    output = tuple(
+                        cast if element is hidden_states else (
+                            tuple(cast if item is hidden_states else item for item in element)
+                            if isinstance(element, tuple) else element
+                        )
+                        for element in output
+                    )
                 else:
-                    output.last_hidden_state = hidden_states
+                    # Keep captured hidden_states consistent: transformers'
+                    # capture wrapper ties the tuple's final entry to the
+                    # (pre-cast) final state.
+                    extra = getattr(output, "hidden_states", None)
+                    if isinstance(extra, tuple) and len(extra) > 0 \
+                            and extra[-1] is hidden_states:
+                        output.hidden_states = extra[:-1] + (cast,)
+                    output.last_hidden_state = cast
             return output
 
         vision_forward._unsloth_vision_pooler_fp16 = True


### PR DESCRIPTION
## Problem

Fine-tuning Gemma-4 26B-A4B or 31B Vision with `dtype = torch.float16` produces NaN training loss from step 1 on transformers 5.5.0 through 5.9.x (and the yanked 5.10.0). Text and audio are unaffected, as are E2B / E4B vision and all bf16 runs.

Root cause is an upstream transformers bug: `Gemma4VisionPooler.forward` scales pooled activations by `sqrt(hidden_size)` in the input dtype:

```python
hidden_states *= self.root_hidden_size
```

The 26B / 31B vision tower (hidden 1152, `sqrt = 33.94`, no clipped linears) produces fp16 activations around 2300, which scale to roughly 79k, past the fp16 max of 65504, giving inf and then NaN through `embed_vision`. This engages under forced-float32 mode, which keeps the unquantized vision tower in fp16 with autocast off. Localized empirically on a 26B fp16 run: the pooler input was finite (amax 2330), its output inf, and every module before it finite. Upstream fixed this in transformers 5.10.1 via huggingface/transformers#46277.

## Fix

`patch_Gemma4VisionPoolerFP16` in `temporary_patches/gemma4.py` mirrors the upstream fix with two pass-through wrappers:

- `Gemma4VisionPooler.forward`: upcasts a float16 `hidden_states` input to fp32. The buggy pooler's ops (masked_fill, avg pool, scale) all preserve input dtype, so this matches the fixed pooler's fp32 output up to fp16 rounding of the pooled activations. Dtype promotion then carries fp32 through the caller's standardization, where the `std_bias` subtraction cancels the large values (buffer amax is 53760, inside fp16 range).
- `Gemma4VisionModel.forward`: casts `last_hidden_state` back to the encoder's working dtype, taken from the patch embedder's `input_proj` weight (the embedder casts pixels to it, so this equals upstream's `inputs_embeds.dtype` even when callers pass fp32 processor pixels to an fp16 tower). Only engages for fp16 towers and also handles `return_dict = False` tuple returns.

Design points:

- Source-pattern classification instead of version compares: known-buggy sources get patched, known-fixed sources (5.10.1 and later) are skipped entirely, unrecognized future sources are left untouched with an optional log line, and transformers without gemma4 (4.57.6) no-op via ImportError. This also handles the yanked 5.10.0 correctly.
- The wrappers call the original forwards, so the HF decorators on `Gemma4VisionModel.forward` (`merge_with_config_defaults`, `capture_outputs`) are preserved, as is signature introspection via `functools.wraps`.
- The vision wrapper installs before the pooler wrapper, making the pooler marker the commit point; a missing vision wrapper next to a marked pooler is re-installed rather than reported as already patched.
- bf16 and fp32 setups, uniform or mixed input dtypes, are bit-identical to upstream (the pooler gate and the cast-back both check for fp16).
- No compiler companion is needed: the compiler never traces `Gemma4VisionPooler` or `Gemma4VisionModel` (verified by grepping generated `unsloth_compiled_cache` modules from 52 notebook-matrix runs plus fresh validation runs).
- vLLM's gemma4 multimodal path calls the transformers pooler with keyword arguments and casts to its model dtype before `embed_vision`, so the fp32 pooler output composes there too and fixes the same overflow for fp16 vLLM multimodal on old transformers.

## Testing

CPU (`tests/test_gemma4_vision_pooler_fp16.py`, 19 tests): overflow reproduction, fp32-reference match, standardize on and off, mixed fp32-pixels/fp16-tower, fp32-pixels/bf16-tower untouched, bf16/fp32 bit-identical, tuple returns, kwarg calls, idempotency, repair path, drift and no-source classification, gradient flow, and a real-source canary that fails loudly if upstream rewrites the pooler. Green on transformers 4.57.6 (no gemma4, no-op), 5.5.0 (patches), and 5.14.1 (skips), and the classification was checked against every 5.x release tag: 5.5.0-5.10.0 classify buggy, 5.10.1-5.14.1 classify fixed.

GPU (B200, transformers 5.5.0, 3-step LoRA notebook replicas with inference and merged save):

| Run | Before | After |
|-----|--------|-------|
| 26B-A4B Vision fp16 | NaN loss | 1.02 / 1.41 / 0.65 |
| 31B Vision fp16 | NaN loss | 0.99 / 1.36 / 0.81 |
| 26B-A4B Vision bf16 | 1.01 / 1.43 / 0.74 | unchanged (run-to-run noise band) |
| E4B Vision fp16 | pass | pass |
| 26B-A4B Text fp16 | pass | pass |
| GRPO fp16 (tf 5.14.1) | pass | pass |

Also reproduced the mixed-dtype path on real 5.5.0 classes: fp32 pixels into an fp16 `Gemma4VisionModel` return fp16 finite features after the patch.

Note: the package currently pins `transformers<=5.5.0`, which is exactly the buggy release users get; if the pin is later lifted into 5.6-5.9 the patch covers those too, and from 5.10.1 it automatically stands down. The complementary notebook-side fix would be bumping the Gemma-4 vision notebooks off the `==5.5.0` pin once supported.