### PR TITLE
feat(mlx): CUDA-parity continued pretraining (embed_tokens / lm_head)

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -87,6 +87,11 @@ jobs:
         # MLXTrainer, exercising the PR 684 trainer rework end to end.
         run: python -m pytest tests/test_mlx_training_e2e_metal.py -v -rs
 
+      - name: tests/test_mlx_cpt_partition_metal.py
+        # Continued-pretraining partition (embed_tokens / lm_head), target
+        # normalization, and full-module save routing on real Metal.
+        run: python -m pytest tests/test_mlx_cpt_partition_metal.py -v -rs
+
       - name: tests/test_mlx_pr684_full_validation_metal.py
         # Deep behavior checks: resume determinism, completion-only training,
         # epoch step counts, SGD coupled decay, real Qwen2-VL LoRA training.

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -88,8 +88,7 @@ jobs:
         run: python -m pytest tests/test_mlx_training_e2e_metal.py -v -rs
 
       - name: tests/test_mlx_cpt_partition_metal.py
-        # Continued-pretraining partition (embed_tokens / lm_head), target
-        # normalization, and full-module save routing on real Metal.
+        # CPT partition, target normalization and full-module save routing.
         run: python -m pytest tests/test_mlx_cpt_partition_metal.py -v -rs
 
       - name: tests/test_mlx_pr684_full_validation_metal.py

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -1,0 +1,98 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License, version 3 or (at your
+# option) any later version. See <https://www.gnu.org/licenses/>.
+
+"""CUDA-parity continued pretraining, end-to-end on real MLX (Apple Silicon).
+
+Drives get_peft_model + save routing (LR key, full-module unfreeze, save/reload).
+Fine-grained matrix: analysis_artifacts/2026-07-21_mlx-cpt-validation/.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.utils as mu
+
+
+@pytest.fixture(autouse=True)
+def _require_real_metal():
+    # Re-import: the shim swaps mlx.core in sys.modules at run time, after this
+    # module imported real MLX; these must skip (not fail) under the shim.
+    import mlx.core as _mx
+    if not (getattr(_mx, "metal", None) and _mx.metal.is_available()
+            and _mx.default_device() == _mx.gpu):
+        pytest.skip("real Metal required; shim active or no GPU")
+
+
+class _Attn(nn.Module):
+    def __init__(s):
+        super().__init__()
+        for n in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            setattr(s, n, nn.Linear(32, 32, bias=False))
+
+
+class _Core(nn.Module):
+    def __init__(s, tied, emb):
+        super().__init__()
+        s._emb, s._tied = emb, tied
+        s.model = nn.Module()
+        setattr(s.model, emb, nn.Embedding(64, 32))
+        lyr = nn.Module(); lyr.self_attn = _Attn(); s.model.layers = [lyr]
+        if tied:
+            s.args = type("A", (), {"tie_word_embeddings": True})()
+        else:
+            s.lm_head = nn.Linear(32, 64, bias=False)
+
+    @property
+    def layers(s):
+        return s.model.layers
+
+    def __call__(s, x):
+        e = getattr(s.model, s._emb); h = e(x)
+        return e.as_linear(h) if s._tied else s.lm_head(h)
+
+
+def _tiny(tied=False, emb="embed_tokens"):
+    return _Core(tied, emb)
+
+
+def _peft(model, **kw):
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    return FastMLXModel.get_peft_model(
+        model, r=4, use_gradient_checkpointing="none", **kw)
+
+
+def test_untied_cpt_partition_lr_key_and_save_reload():
+    m = _tiny()
+    _peft(m, target_modules=["q_proj", "embed_tokens", "lm_head"])
+    # embed -> full module (weight trainable); lm_head -> LoRA; q_proj -> LoRA.
+    trainable = set(dict(mu.tree_flatten(m.trainable_parameters())))
+    assert "model.embed_tokens.weight" in trainable
+    assert {"lm_head.lora_a", "lm_head.lora_b"} <= trainable
+    assert "lm_head.weight" not in trainable
+    # AD-7: recorded LR keys are the exact registered full-module weight keys.
+    assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
+    # Save keeps the full module; a reloaded model (no marker) saves it too.
+    from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters  # noqa: E402
+    d, d2 = tempfile.mkdtemp(), tempfile.mkdtemp()
+    _mlx_save_lora_adapters(m, d)
+    assert "model.embed_tokens.weight" in mx.load(os.path.join(d, "adapters.safetensors"))
+    r = _tiny(); r.freeze(); r.model.embed_tokens.unfreeze(recurse=True)
+    _mlx_save_lora_adapters(r, d2)
+    assert "model.embed_tokens.weight" in mx.load(os.path.join(d2, "adapters.safetensors"))
+
+
+def test_tied_trains_shared_matrix_and_rejects_lm_head():
+    m = _tiny(tied=True)
+    _peft(m, target_modules=["embed_tokens"], finetune_language_layers=False)
+    assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
+    with pytest.raises(ValueError, match="tied"):
+        _peft(_tiny(tied=True), target_modules=["lm_head"])

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -17,6 +17,10 @@ import os
 import tempfile
 
 import pytest
+
+# Skip the whole module (before importing mlx.nn/utils) when MLX is absent, so
+# collection on Linux / non-MLX environments does not raise ModuleNotFoundError.
+pytest.importorskip("mlx.core")
 import mlx.core as mx
 import mlx.nn as nn
 import mlx.utils as mu
@@ -94,5 +98,44 @@ def test_tied_trains_shared_matrix_and_rejects_lm_head():
     m = _tiny(tied=True)
     _peft(m, target_modules=["embed_tokens"], finetune_language_layers=False)
     assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
+    # The documented recipe co-requests embed_tokens + lm_head; on a tied model
+    # that trains the shared matrix via embed_tokens rather than erroring.
+    m2 = _tiny(tied=True)
+    _peft(m2, target_modules=["embed_tokens", "lm_head"], finetune_language_layers=False)
+    assert m2._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
+    trn = set(dict(mu.tree_flatten(m2.trainable_parameters())))
+    assert not any(k.startswith("lm_head") for k in trn)  # tied: no separate head
+    # A standalone lm_head request is still rejected.
     with pytest.raises(ValueError, match="tied"):
         _peft(_tiny(tied=True), target_modules=["lm_head"])
+
+
+def test_set_valued_target_modules_are_not_silently_emptied():
+    # A set/frozenset selection must be honored, not dropped to keys=None.
+    m = _tiny()
+    _peft(m, target_modules={"q_proj", "embed_tokens"})
+    assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
+    # A bare-string modules_to_save must not iterate characters.
+    ms = _tiny()
+    _peft(ms, target_modules=["q_proj"], modules_to_save="embed_tokens")
+    assert ms._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
+
+
+def test_all_linear_sentinel_accepts_set_form():
+    # target_modules={"all-linear"} must expand like the string sentinel rather
+    # than be treated as a literal module name that matches nothing.
+    m = _tiny()
+    _peft(m, target_modules={"all-linear"})
+    trn = set(dict(mu.tree_flatten(m.trainable_parameters())))
+    assert any(k.endswith("q_proj.lora_a") for k in trn)
+
+
+def test_set_target_modules_respects_finetune_filters():
+    # A set selection must still honor finetune_attention_modules=False:
+    # q_proj (attention) is filtered out while embed_tokens still trains.
+    m = _tiny()
+    _peft(m, target_modules={"q_proj", "embed_tokens"},
+          finetune_attention_modules=False)
+    trn = set(dict(mu.tree_flatten(m.trainable_parameters())))
+    assert "model.embed_tokens.weight" in trn
+    assert not any("q_proj.lora" in k for k in trn)

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -132,6 +132,97 @@ def test_all_linear_sentinel_accepts_set_form():
     assert any(k.endswith("q_proj.lora_a") for k in trn)
 
 
+def test_all_linear_expands_inside_a_mixed_cpt_target_list():
+    # ["all-linear", "embed_tokens"] is the CPT spelling of the sentinel. A
+    # literal "all-linear" left in the list matches no module, and the CPT
+    # entry keeps the no-target guard quiet, so every layer adapter vanished.
+    m = _tiny()
+    _peft(m, target_modules=["all-linear", "embed_tokens"])
+    trn = set(dict(mu.tree_flatten(m.trainable_parameters())))
+    assert "model.embed_tokens.weight" in trn
+    for leaf in ("q_proj", "k_proj", "v_proj", "o_proj"):
+        assert any(k.endswith(f"{leaf}.lora_a") for k in trn), leaf
+    assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
+
+    # The head entry survives the PEFT-parity exclusion of the output layer.
+    h = _tiny()
+    _peft(h, target_modules=["all-linear", "lm_head"])
+    trn = set(dict(mu.tree_flatten(h.trainable_parameters())))
+    assert {"lm_head.lora_a", "lm_head.lora_b"} <= trn
+    assert any(k.endswith("q_proj.lora_a") for k in trn)
+
+    # Set form, and a duplicate sentinel, resolve the same way.
+    s = _tiny()
+    _peft(s, target_modules={"all-linear", "embed_tokens", "lm_head"})
+    trn = set(dict(mu.tree_flatten(s.trainable_parameters())))
+    assert {"lm_head.lora_a", "model.embed_tokens.weight"} <= trn
+    assert any(k.endswith("v_proj.lora_a") for k in trn)
+
+
+def test_full_module_only_checkpoint_reloads_without_unfreezing_the_base():
+    # No LoRA anywhere, so the artifact is stamped fine_tune_type="full" with
+    # no exact LoRA paths and reload takes the pathless route. mlx-lm's
+    # load_adapters never freezes, so without a selective freeze every base
+    # tensor came back trainable and the scoped-LR keys were lost.
+    import json
+
+    from unsloth_zoo.mlx.loader import (
+        _is_partial_mlx_checkpoint,
+        _load_pathless_mlx_adapter,
+        _mlx_save_lora_adapters,
+        _normalize_mlx_lora_module_paths,
+    )
+
+    m = _tiny()
+    _peft(m, target_modules=["embed_tokens"])
+    assert set(dict(mu.tree_flatten(m.trainable_parameters()))) == {
+        "model.embed_tokens.weight"}
+    d = tempfile.mkdtemp()
+    _mlx_save_lora_adapters(m, d)
+    weights = os.path.join(d, "adapters.safetensors")
+    assert sorted(mx.load(weights)) == ["model.embed_tokens.weight"]
+    with open(os.path.join(d, "adapter_config.json")) as fh:
+        cfg = json.load(fh)
+    assert cfg["fine_tune_type"] == "full"
+    assert not _normalize_mlx_lora_module_paths(
+        cfg.get("unsloth_mlx_lora_module_paths"))
+
+    r = _load_pathless_mlx_adapter(_tiny(), d, weights, cfg, False)
+    assert set(dict(mu.tree_flatten(r.trainable_parameters()))) == {
+        "model.embed_tokens.weight"}
+    assert getattr(r, "_unsloth_cpt_full_module_weight_keys", set()) == {
+        "model.embed_tokens.weight"}
+    assert mx.array_equal(r.model.embed_tokens.weight, m.model.embed_tokens.weight)
+
+    # A full-module head-only checkpoint restores the head, nothing else.
+    hm = _tiny()
+    _peft(hm, target_modules=[], modules_to_save=["lm_head"])
+    hd = tempfile.mkdtemp()
+    _mlx_save_lora_adapters(hm, hd)
+    hw = os.path.join(hd, "adapters.safetensors")
+    with open(os.path.join(hd, "adapter_config.json")) as fh:
+        hcfg = json.load(fh)
+    hr = _load_pathless_mlx_adapter(_tiny(), hd, hw, hcfg, False)
+    assert set(dict(mu.tree_flatten(hr.trainable_parameters()))) == {
+        "lm_head.weight"}
+    assert getattr(hr, "_unsloth_cpt_full_module_weight_keys", set()) == {
+        "lm_head.weight"}
+
+    # A whole-model artifact is a real full fine-tune: keep it unfrozen.
+    fd = tempfile.mkdtemp()
+    whole = _tiny()
+    mx.save_safetensors(
+        os.path.join(fd, "adapters.safetensors"),
+        dict(mu.tree_flatten(whole.parameters())),
+    )
+    assert not _is_partial_mlx_checkpoint(
+        _tiny(), os.path.join(fd, "adapters.safetensors"))
+    # full_finetuning=True never freezes either.
+    ff = _load_pathless_mlx_adapter(_tiny(), d, weights, cfg, True)
+    assert len(dict(mu.tree_flatten(ff.trainable_parameters()))) == len(
+        dict(mu.tree_flatten(ff.parameters())))
+
+
 def test_set_target_modules_respects_finetune_filters():
     # A set selection must still honor finetune_attention_modules=False.
     m = _tiny()

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -213,6 +213,26 @@ def test_lm_head_wrapper_mlx_lm_cannot_lora_is_dropped_not_fatal():
     assert "lm_head.linear.weight" in trn
 
 
+def test_wrapper_head_records_its_real_weight_keys_for_the_scoped_lr():
+    # A wrapper head owns no `.weight` of its own, so recording `lm_head.weight`
+    # named a tensor that does not exist: it matches neither the trainer's
+    # recorded-key lookup nor its `<...>.embed_tokens/lm_head.weight` leaf
+    # fallback, and embedding_learning_rate silently never reached the head.
+    m = _tiny(); m.lm_head = _WrappedHead()
+    _peft(m, target_modules=["q_proj"], modules_to_save=["lm_head"])
+    keys = m._unsloth_cpt_full_module_weight_keys
+    assert keys == {"lm_head.ln.weight", "lm_head.linear.weight"}
+    trainable = set(dict(mu.tree_flatten(m.trainable_parameters())))
+    assert keys <= trainable
+    # A plain Linear / Embedding full module keeps the exact previous key.
+    plain = _tiny()
+    _peft(plain, target_modules=["q_proj", "embed_tokens"],
+          modules_to_save=["lm_head"])
+    assert plain._unsloth_cpt_full_module_weight_keys == {
+        "model.embed_tokens.weight", "lm_head.weight",
+    }
+
+
 def test_quantized_child_of_a_wrapper_head_is_rejected():
     # Quantization on a wrapper head lives on a descendant, so a leaf-only
     # `scales` check accepted it and MLX then raised

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -251,3 +251,82 @@ def test_unusable_lm_head_still_raises_when_nothing_else_trains():
     with pytest.raises(ValueError, match="tied"):
         _peft(_tiny(tied=True), target_modules=["q_proj"],
               modules_to_save=["lm_head"])
+
+
+class _VlmCore(nn.Module):
+    """VLM wrapper: the head is a root module of the language stack."""
+
+    def __init__(s):
+        super().__init__()
+        s.language_model = _Core(False, "embed_tokens")
+        s._is_vlm_model = True
+
+    @property
+    def layers(s):
+        return s.language_model.layers
+
+    def __call__(s, x):
+        return s.language_model(x)
+
+
+def test_root_lm_head_lora_is_attached_outside_the_layer_walk():
+    # The head is a root module, not a layer submodule, so a layer-only walk
+    # never reaches it: head-only must attach it, mixed must not freeze it.
+    head_only = _tiny()
+    _peft(head_only, target_modules=["lm_head"])
+    assert {"lm_head.lora_a", "lm_head.lora_b"} <= set(
+        dict(mu.tree_flatten(head_only.trainable_parameters())))
+
+    mixed = _tiny()
+    _peft(mixed, target_modules=["q_proj", "lm_head"])
+    trn = set(dict(mu.tree_flatten(mixed.trainable_parameters())))
+    assert {"lm_head.lora_a", "lm_head.lora_b"} <= trn
+    assert any(k.endswith("q_proj.lora_a") for k in trn)
+
+    # CPT recipe: an lm_head adapter plus a full embedding, no layer targets.
+    cpt = _tiny()
+    _peft(cpt, target_modules=["embed_tokens", "lm_head"])
+    trn = set(dict(mu.tree_flatten(cpt.trainable_parameters())))
+    assert {"lm_head.lora_a", "lm_head.lora_b",
+            "model.embed_tokens.weight"} <= trn
+
+    vlm = _VlmCore()
+    _peft(vlm, target_modules=["q_proj", "lm_head"],
+          finetune_vision_layers=False, train_projector=False)
+    trn = set(dict(mu.tree_flatten(vlm.trainable_parameters())))
+    assert {"language_model.lm_head.lora_a",
+            "language_model.lm_head.lora_b"} <= trn
+
+
+def test_reloaded_cpt_adapter_rebuilds_the_scoped_lr_keys():
+    # Reload restores the full module's trainability, so the scoped-LR key set
+    # must come back too or embedding_learning_rate degrades to the main LR
+    # for every embedding not literally named embed_tokens.
+    import json
+
+    from unsloth_zoo.mlx.loader import (
+        _apply_lora_at_paths,
+        _mlx_save_lora_adapters,
+        _unfreeze_saved_mlx_non_adapter_parameters,
+    )
+
+    m = _tiny(emb="tok_embeddings")
+    _peft(m, target_modules=["q_proj", "embed_tokens"])
+    assert m._unsloth_cpt_full_module_weight_keys == {
+        "model.tok_embeddings.weight"}
+    d = tempfile.mkdtemp()
+    _mlx_save_lora_adapters(m, d)
+    weights = os.path.join(d, "adapters.safetensors")
+    with open(os.path.join(d, "adapter_config.json")) as fh:
+        cfg = json.load(fh)
+
+    r = _tiny(emb="tok_embeddings")
+    r.freeze()
+    _apply_lora_at_paths(r, cfg.get("unsloth_mlx_lora_module_paths"), cfg,
+                         adapter_weights_file=weights)
+    r.load_weights(weights, strict=False)
+    _unfreeze_saved_mlx_non_adapter_parameters(r, weights)
+    assert "model.tok_embeddings.weight" in set(
+        dict(mu.tree_flatten(r.trainable_parameters())))
+    assert getattr(r, "_unsloth_cpt_full_module_weight_keys", set()) == {
+        "model.tok_embeddings.weight"}

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -187,6 +187,32 @@ def test_unusable_lm_head_keeps_the_other_lora_targets():
                for k in dict(mu.tree_flatten(alt.trainable_parameters())))
 
 
+class _WrappedHead(nn.Module):
+    """Phixtral's OutputHead shape: a LayerNorm+Linear module, not a Linear."""
+
+    def __init__(s, d=32, v=64):
+        super().__init__()
+        s.ln = nn.LayerNorm(d); s.linear = nn.Linear(d, v, bias=False)
+
+    def __call__(s, x):
+        return s.linear(s.ln(x))
+
+
+def test_lm_head_wrapper_mlx_lm_cannot_lora_is_dropped_not_fatal():
+    # mlx-lm's to_lora() raises for a head it cannot wrap, which used to take
+    # the whole run down; modules_to_save still trains it as a full module.
+    m = _tiny(); m.lm_head = _WrappedHead()
+    with pytest.warns(UserWarning, match="cannot wrap as a LoRA layer"):
+        _peft(m, target_modules=["q_proj", "lm_head"])
+    assert any(k.endswith("q_proj.lora_a")
+               for k in dict(mu.tree_flatten(m.trainable_parameters())))
+
+    full = _tiny(); full.lm_head = _WrappedHead()
+    _peft(full, target_modules=["q_proj"], modules_to_save=["lm_head"])
+    trn = set(dict(mu.tree_flatten(full.trainable_parameters())))
+    assert "lm_head.linear.weight" in trn
+
+
 def test_unusable_lm_head_still_raises_when_nothing_else_trains():
     # Dropping lm_head must never leave an empty selection to fall through to
     # mlx-lm's auto-discovery, and an explicit modules_to_save request names

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -1,9 +1,18 @@
 # Unsloth Zoo - Utilities for Unsloth
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
-# This program is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Affero General Public License, version 3 or (at your
-# option) any later version. See <https://www.gnu.org/licenses/>.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """CUDA-parity continued pretraining, end-to-end on real MLX (Apple Silicon).
 
@@ -139,3 +148,53 @@ def test_set_target_modules_respects_finetune_filters():
     trn = set(dict(mu.tree_flatten(m.trainable_parameters())))
     assert "model.embed_tokens.weight" in trn
     assert not any("q_proj.lora" in k for k in trn)
+
+
+class _AltHead(nn.Module):
+    """No lm_head and no tie flag: the head descriptor stays unresolved."""
+
+    def __init__(s):
+        super().__init__()
+        s.model = nn.Module()
+        s.model.embed_tokens = nn.Embedding(64, 32)
+        lyr = nn.Module(); lyr.self_attn = _Attn(); s.model.layers = [lyr]
+        s.embed_out = nn.Linear(32, 64, bias=False)
+
+    @property
+    def layers(s):
+        return s.model.layers
+
+    def __call__(s, x):
+        return s.embed_out(s.model.embed_tokens(x))
+
+
+def test_unusable_lm_head_keeps_the_other_lora_targets():
+    # target_modules=[..., "lm_head"] LoRA'd the other targets before CPT
+    # existed. An lm_head this backend cannot train must not abort the run:
+    # warn and drop it, so tied models (Llama/Qwen/Gemma) and unresolved-head
+    # models (GPT-NeoX embed_out, InternLM2 output) still train.
+    m = _tiny(tied=True)
+    with pytest.warns(UserWarning, match="tied"):
+        _peft(m, target_modules=["q_proj", "lm_head"])
+    trn = set(dict(mu.tree_flatten(m.trainable_parameters())))
+    assert any(k.endswith("q_proj.lora_a") for k in trn)
+    assert not any(k.startswith("lm_head") for k in trn)
+
+    alt = _AltHead()
+    with pytest.warns(UserWarning, match="output head could not be resolved"):
+        _peft(alt, target_modules=["q_proj", "lm_head"])
+    assert any(k.endswith("q_proj.lora_a")
+               for k in dict(mu.tree_flatten(alt.trainable_parameters())))
+
+
+def test_unusable_lm_head_still_raises_when_nothing_else_trains():
+    # Dropping lm_head must never leave an empty selection to fall through to
+    # mlx-lm's auto-discovery, and an explicit modules_to_save request names
+    # one module, so both keep raising.
+    with pytest.raises(ValueError, match="tied"):
+        _peft(_tiny(tied=True), target_modules=["lm_head"])
+    with pytest.raises(ValueError, match="output head could not be resolved"):
+        _peft(_AltHead(), target_modules=["lm_head"])
+    with pytest.raises(ValueError, match="tied"):
+        _peft(_tiny(tied=True), target_modules=["q_proj"],
+              modules_to_save=["lm_head"])

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""CUDA-parity continued pretraining, end-to-end on real MLX (Apple Silicon).
+"""CUDA-parity continued pretraining, end to end on real MLX (Apple Silicon).
 
 Drives get_peft_model + save routing (LR key, full-module unfreeze, save/reload).
 Fine-grained matrix: analysis_artifacts/2026-07-21_mlx-cpt-validation/.
@@ -27,8 +27,7 @@ import tempfile
 
 import pytest
 
-# Skip the whole module (before importing mlx.nn/utils) when MLX is absent, so
-# collection on Linux / non-MLX environments does not raise ModuleNotFoundError.
+# Skip before importing mlx.nn/utils so non-MLX collection does not error.
 pytest.importorskip("mlx.core")
 import mlx.core as mx
 import mlx.nn as nn
@@ -37,8 +36,8 @@ import mlx.utils as mu
 
 @pytest.fixture(autouse=True)
 def _require_real_metal():
-    # Re-import: the shim swaps mlx.core in sys.modules at run time, after this
-    # module imported real MLX; these must skip (not fail) under the shim.
+    # Re-import: the shim swaps mlx.core in sys.modules after this module
+    # imported real MLX, and these must skip (not fail) under the shim.
     import mlx.core as _mx
     if not (getattr(_mx, "metal", None) and _mx.metal.is_available()
             and _mx.default_device() == _mx.gpu):
@@ -86,12 +85,10 @@ def _peft(model, **kw):
 def test_untied_cpt_partition_lr_key_and_save_reload():
     m = _tiny()
     _peft(m, target_modules=["q_proj", "embed_tokens", "lm_head"])
-    # embed -> full module (weight trainable); lm_head -> LoRA; q_proj -> LoRA.
     trainable = set(dict(mu.tree_flatten(m.trainable_parameters())))
     assert "model.embed_tokens.weight" in trainable
     assert {"lm_head.lora_a", "lm_head.lora_b"} <= trainable
     assert "lm_head.weight" not in trainable
-    # AD-7: recorded LR keys are the exact registered full-module weight keys.
     assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
     # Save keeps the full module; a reloaded model (no marker) saves it too.
     from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters  # noqa: E402
@@ -107,14 +104,13 @@ def test_tied_trains_shared_matrix_and_rejects_lm_head():
     m = _tiny(tied=True)
     _peft(m, target_modules=["embed_tokens"], finetune_language_layers=False)
     assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
-    # The documented recipe co-requests embed_tokens + lm_head; on a tied model
-    # that trains the shared matrix via embed_tokens rather than erroring.
+    # The recipe co-requests embed_tokens + lm_head; tied trains the shared
+    # matrix via embed_tokens rather than erroring.
     m2 = _tiny(tied=True)
     _peft(m2, target_modules=["embed_tokens", "lm_head"], finetune_language_layers=False)
     assert m2._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
     trn = set(dict(mu.tree_flatten(m2.trainable_parameters())))
     assert not any(k.startswith("lm_head") for k in trn)  # tied: no separate head
-    # A standalone lm_head request is still rejected.
     with pytest.raises(ValueError, match="tied"):
         _peft(_tiny(tied=True), target_modules=["lm_head"])
 
@@ -131,8 +127,7 @@ def test_set_valued_target_modules_are_not_silently_emptied():
 
 
 def test_all_linear_sentinel_accepts_set_form():
-    # target_modules={"all-linear"} must expand like the string sentinel rather
-    # than be treated as a literal module name that matches nothing.
+    # {"all-linear"} must expand like the string sentinel, not be a literal name.
     m = _tiny()
     _peft(m, target_modules={"all-linear"})
     trn = set(dict(mu.tree_flatten(m.trainable_parameters())))
@@ -140,8 +135,7 @@ def test_all_linear_sentinel_accepts_set_form():
 
 
 def test_set_target_modules_respects_finetune_filters():
-    # A set selection must still honor finetune_attention_modules=False:
-    # q_proj (attention) is filtered out while embed_tokens still trains.
+    # A set selection must still honor finetune_attention_modules=False.
     m = _tiny()
     _peft(m, target_modules={"q_proj", "embed_tokens"},
           finetune_attention_modules=False)
@@ -169,10 +163,8 @@ class _AltHead(nn.Module):
 
 
 def test_unusable_lm_head_keeps_the_other_lora_targets():
-    # target_modules=[..., "lm_head"] LoRA'd the other targets before CPT
-    # existed. An lm_head this backend cannot train must not abort the run:
-    # warn and drop it, so tied models (Llama/Qwen/Gemma) and unresolved-head
-    # models (GPT-NeoX embed_out, InternLM2 output) still train.
+    # An lm_head this backend cannot train must warn and drop, not abort, so
+    # tied and unresolved-head models keep the pre-CPT behaviour.
     m = _tiny(tied=True)
     with pytest.warns(UserWarning, match="tied"):
         _peft(m, target_modules=["q_proj", "lm_head"])
@@ -199,8 +191,8 @@ class _WrappedHead(nn.Module):
 
 
 def test_lm_head_wrapper_mlx_lm_cannot_lora_is_dropped_not_fatal():
-    # mlx-lm's to_lora() raises for a head it cannot wrap, which used to take
-    # the whole run down; modules_to_save still trains it as a full module.
+    # mlx-lm's to_lora() raises for a head it cannot wrap; that must not take
+    # the run down, and modules_to_save still trains it as a full module.
     m = _tiny(); m.lm_head = _WrappedHead()
     with pytest.warns(UserWarning, match="cannot wrap as a LoRA layer"):
         _peft(m, target_modules=["q_proj", "lm_head"])
@@ -214,10 +206,8 @@ def test_lm_head_wrapper_mlx_lm_cannot_lora_is_dropped_not_fatal():
 
 
 def test_wrapper_head_records_its_real_weight_keys_for_the_scoped_lr():
-    # A wrapper head owns no `.weight` of its own, so recording `lm_head.weight`
-    # named a tensor that does not exist: it matches neither the trainer's
-    # recorded-key lookup nor its `<...>.embed_tokens/lm_head.weight` leaf
-    # fallback, and embedding_learning_rate silently never reached the head.
+    # A wrapper head owns no `.weight`, so recording `lm_head.weight` named a
+    # nonexistent tensor and embedding_learning_rate never reached the head.
     m = _tiny(); m.lm_head = _WrappedHead()
     _peft(m, target_modules=["q_proj"], modules_to_save=["lm_head"])
     keys = m._unsloth_cpt_full_module_weight_keys
@@ -235,9 +225,7 @@ def test_wrapper_head_records_its_real_weight_keys_for_the_scoped_lr():
 
 def test_quantized_child_of_a_wrapper_head_is_rejected():
     # Quantization on a wrapper head lives on a descendant, so a leaf-only
-    # `scales` check accepted it and MLX then raised
-    # "[QuantizedMatmul::vjp] no gradient wrt the quantized weights" at the
-    # first backward instead of this actionable error.
+    # `scales` check accepted it and MLX raised at the first backward instead.
     m = _tiny(); m.lm_head = _WrappedHead()
     m.lm_head.linear = nn.QuantizedLinear.from_linear(
         m.lm_head.linear, group_size=32, bits=4)
@@ -255,8 +243,7 @@ def test_quantized_child_of_a_wrapper_head_is_rejected():
 
 def test_unusable_lm_head_still_raises_when_nothing_else_trains():
     # Dropping lm_head must never leave an empty selection to fall through to
-    # mlx-lm's auto-discovery, and an explicit modules_to_save request names
-    # one module, so both keep raising.
+    # auto-discovery, and modules_to_save names one module, so both raise.
     with pytest.raises(ValueError, match="tied"):
         _peft(_tiny(tied=True), target_modules=["lm_head"])
     with pytest.raises(ValueError, match="output head could not be resolved"):

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -213,6 +213,26 @@ def test_lm_head_wrapper_mlx_lm_cannot_lora_is_dropped_not_fatal():
     assert "lm_head.linear.weight" in trn
 
 
+def test_quantized_child_of_a_wrapper_head_is_rejected():
+    # Quantization on a wrapper head lives on a descendant, so a leaf-only
+    # `scales` check accepted it and MLX then raised
+    # "[QuantizedMatmul::vjp] no gradient wrt the quantized weights" at the
+    # first backward instead of this actionable error.
+    m = _tiny(); m.lm_head = _WrappedHead()
+    m.lm_head.linear = nn.QuantizedLinear.from_linear(
+        m.lm_head.linear, group_size=32, bits=4)
+    with pytest.raises(ValueError, match=r"quantized module at 'lm_head\.linear'"):
+        _peft(m, target_modules=["q_proj"], modules_to_save=["lm_head"])
+    # A directly quantized full module still reports its own path.
+    e = _tiny()
+    e.model.embed_tokens = nn.QuantizedEmbedding.from_embedding(
+        e.model.embed_tokens, group_size=32, bits=4)
+    with pytest.raises(
+        ValueError, match=r"quantized module at 'model\.embed_tokens'",
+    ):
+        _peft(e, target_modules=["q_proj", "embed_tokens"])
+
+
 def test_unusable_lm_head_still_raises_when_nothing_else_trains():
     # Dropping lm_head must never leave an empty selection to fall through to
     # mlx-lm's auto-discovery, and an explicit modules_to_save request names

--- a/tests/test_mlx_cpt_partition_metal.py
+++ b/tests/test_mlx_cpt_partition_metal.py
@@ -36,8 +36,7 @@ import mlx.utils as mu
 
 @pytest.fixture(autouse=True)
 def _require_real_metal():
-    # Re-import: the shim swaps mlx.core in sys.modules after this module
-    # imported real MLX, and these must skip (not fail) under the shim.
+    # Re-import: the shim may have swapped mlx.core in sys.modules since import.
     import mlx.core as _mx
     if not (getattr(_mx, "metal", None) and _mx.metal.is_available()
             and _mx.default_device() == _mx.gpu):
@@ -104,8 +103,7 @@ def test_tied_trains_shared_matrix_and_rejects_lm_head():
     m = _tiny(tied=True)
     _peft(m, target_modules=["embed_tokens"], finetune_language_layers=False)
     assert m._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
-    # The recipe co-requests embed_tokens + lm_head; tied trains the shared
-    # matrix via embed_tokens rather than erroring.
+    # Co-requesting lm_head trains the shared matrix rather than erroring.
     m2 = _tiny(tied=True)
     _peft(m2, target_modules=["embed_tokens", "lm_head"], finetune_language_layers=False)
     assert m2._unsloth_cpt_full_module_weight_keys == {"model.embed_tokens.weight"}
@@ -163,8 +161,8 @@ class _AltHead(nn.Module):
 
 
 def test_unusable_lm_head_keeps_the_other_lora_targets():
-    # An lm_head this backend cannot train must warn and drop, not abort, so
-    # tied and unresolved-head models keep the pre-CPT behaviour.
+    # An untrainable lm_head must warn and drop, not abort, so the other
+    # targets keep the pre-CPT behaviour.
     m = _tiny(tied=True)
     with pytest.warns(UserWarning, match="tied"):
         _peft(m, target_modules=["q_proj", "lm_head"])
@@ -191,8 +189,7 @@ class _WrappedHead(nn.Module):
 
 
 def test_lm_head_wrapper_mlx_lm_cannot_lora_is_dropped_not_fatal():
-    # mlx-lm's to_lora() raises for a head it cannot wrap; that must not take
-    # the run down, and modules_to_save still trains it as a full module.
+    # An unwrappable head must warn, not abort; modules_to_save still trains it.
     m = _tiny(); m.lm_head = _WrappedHead()
     with pytest.warns(UserWarning, match="cannot wrap as a LoRA layer"):
         _peft(m, target_modules=["q_proj", "lm_head"])
@@ -206,8 +203,8 @@ def test_lm_head_wrapper_mlx_lm_cannot_lora_is_dropped_not_fatal():
 
 
 def test_wrapper_head_records_its_real_weight_keys_for_the_scoped_lr():
-    # A wrapper head owns no `.weight`, so recording `lm_head.weight` named a
-    # nonexistent tensor and embedding_learning_rate never reached the head.
+    # A wrapper head owns no `.weight`, so `lm_head.weight` named nothing live
+    # and embedding_learning_rate never reached the head.
     m = _tiny(); m.lm_head = _WrappedHead()
     _peft(m, target_modules=["q_proj"], modules_to_save=["lm_head"])
     keys = m._unsloth_cpt_full_module_weight_keys
@@ -224,8 +221,8 @@ def test_wrapper_head_records_its_real_weight_keys_for_the_scoped_lr():
 
 
 def test_quantized_child_of_a_wrapper_head_is_rejected():
-    # Quantization on a wrapper head lives on a descendant, so a leaf-only
-    # `scales` check accepted it and MLX raised at the first backward instead.
+    # A wrapper head carries `scales` on a descendant, which a leaf-only check
+    # missed until MLX raised at the first backward.
     m = _tiny(); m.lm_head = _WrappedHead()
     m.lm_head.linear = nn.QuantizedLinear.from_linear(
         m.lm_head.linear, group_size=32, bits=4)
@@ -242,8 +239,7 @@ def test_quantized_child_of_a_wrapper_head_is_rejected():
 
 
 def test_unusable_lm_head_still_raises_when_nothing_else_trains():
-    # Dropping lm_head must never leave an empty selection to fall through to
-    # auto-discovery, and modules_to_save names one module, so both raise.
+    # Dropping lm_head must never leave an empty selection for auto-discovery.
     with pytest.raises(ValueError, match="tied"):
         _peft(_tiny(tied=True), target_modules=["lm_head"])
     with pytest.raises(ValueError, match="output head could not be resolved"):
@@ -270,8 +266,7 @@ class _VlmCore(nn.Module):
 
 
 def test_root_lm_head_lora_is_attached_outside_the_layer_walk():
-    # The head is a root module, not a layer submodule, so a layer-only walk
-    # never reaches it: head-only must attach it, mixed must not freeze it.
+    # The head is a root module, so a layer-only walk never reaches it.
     head_only = _tiny()
     _peft(head_only, target_modules=["lm_head"])
     assert {"lm_head.lora_a", "lm_head.lora_b"} <= set(
@@ -299,9 +294,8 @@ def test_root_lm_head_lora_is_attached_outside_the_layer_walk():
 
 
 def test_reloaded_cpt_adapter_rebuilds_the_scoped_lr_keys():
-    # Reload restores the full module's trainability, so the scoped-LR key set
-    # must come back too or embedding_learning_rate degrades to the main LR
-    # for every embedding not literally named embed_tokens.
+    # Reload restores trainability, so the scoped-LR keys must come back too or
+    # embedding_learning_rate degrades to the main LR for alt-named embeddings.
     import json
 
     from unsloth_zoo.mlx.loader import (

--- a/tests/test_mlx_save_lora_adapters_filter.py
+++ b/tests/test_mlx_save_lora_adapters_filter.py
@@ -1548,3 +1548,55 @@ def test_push_lora_adapters_falls_back_to_large_folder_when_unavailable(
     assert calls["folder"] == 1
     assert len(calls["large"]) == 1, calls
     assert calls["large"][0]["repo_id"] == "me/adapter"
+
+
+def test_save_lora_adapters_method_ignores_a_fully_unfrozen_tree(tmp_path):
+    # mlx-lm's load_adapters() never freezes, so a model whose adapters were
+    # just reloaded reports EVERY base weight as trainable. That is not
+    # continued-pretraining state, so model.save_lora_adapters() must keep the
+    # LoRA-only writer instead of dumping the whole base model.
+    from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters
+
+    model = _make_model({
+        "q_proj": _MockLoRALinear(8, 16, 4, 1.0, _MockDropoutKeepProb(0.0)),
+        "up_proj": _MockPlainLinear(16, 32),
+    })
+    _mlx_save_lora_adapters(model, tmp_path)
+
+    from safetensors.torch import load_file
+    keys = set(load_file(str(tmp_path / "adapters.safetensors")).keys())
+    assert keys == {"q_proj.lora_a", "q_proj.lora_b"}, sorted(keys)
+
+
+def test_save_lora_adapters_method_raises_when_no_lora_modules(tmp_path):
+    # A base model that never went through get_peft_model must still get the
+    # actionable error rather than a whole-model file labelled as an adapter.
+    from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters
+
+    model = _make_model({"up_proj": _MockPlainLinear(16, 32)})
+    with pytest.raises(ValueError, match="LoRA adapter tensors"):
+        _mlx_save_lora_adapters(model, tmp_path)
+
+
+def test_save_lora_adapters_method_keeps_continued_pretraining_tensors(tmp_path):
+    # The CPT case get_peft_model actually produces: embed_tokens.weight is
+    # trainable while the rest of the tree stays frozen.
+    from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters
+
+    model = _make_model({
+        "q_proj": _MockLoRALinear(8, 16, 4, 1.0, _MockDropoutKeepProb(0.0)),
+        "embed_tokens": _MockPlainLinear(16, 32),
+    })
+    everything = model.parameters()
+    model.trainable_parameters = lambda: {
+        key: everything[key] for key in (
+            "embed_tokens.weight", "q_proj.lora_a", "q_proj.lora_b",
+        )
+    }
+    _mlx_save_lora_adapters(model, tmp_path)
+
+    from safetensors.torch import load_file
+    keys = set(load_file(str(tmp_path / "adapters.safetensors")).keys())
+    assert keys == {
+        "q_proj.lora_a", "q_proj.lora_b", "embed_tokens.weight",
+    }, sorted(keys)

--- a/tests/test_mlx_save_lora_adapters_filter.py
+++ b/tests/test_mlx_save_lora_adapters_filter.py
@@ -1551,10 +1551,8 @@ def test_push_lora_adapters_falls_back_to_large_folder_when_unavailable(
 
 
 def test_save_lora_adapters_method_ignores_a_fully_unfrozen_tree(tmp_path):
-    # mlx-lm's load_adapters() never freezes, so a model whose adapters were
-    # just reloaded reports EVERY base weight as trainable. That is not
-    # continued-pretraining state, so model.save_lora_adapters() must keep the
-    # LoRA-only writer instead of dumping the whole base model.
+    # load_adapters() never freezes, so a just-reloaded model reports EVERY
+    # base weight as trainable. Not CPT state: keep the LoRA-only writer.
     from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters
 
     model = _make_model({
@@ -1569,8 +1567,7 @@ def test_save_lora_adapters_method_ignores_a_fully_unfrozen_tree(tmp_path):
 
 
 def test_save_lora_adapters_method_raises_when_no_lora_modules(tmp_path):
-    # A base model that never went through get_peft_model must still get the
-    # actionable error rather than a whole-model file labelled as an adapter.
+    # A base model must still error, not write a whole-model "adapter".
     from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters
 
     model = _make_model({"up_proj": _MockPlainLinear(16, 32)})
@@ -1579,8 +1576,7 @@ def test_save_lora_adapters_method_raises_when_no_lora_modules(tmp_path):
 
 
 def test_save_lora_adapters_method_keeps_continued_pretraining_tensors(tmp_path):
-    # The CPT case get_peft_model actually produces: embed_tokens.weight is
-    # trainable while the rest of the tree stays frozen.
+    # Real CPT state: embed_tokens.weight trainable, the rest frozen.
     from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters
 
     model = _make_model({

--- a/tests/test_mlx_save_lora_adapters_filter.py
+++ b/tests/test_mlx_save_lora_adapters_filter.py
@@ -1551,8 +1551,8 @@ def test_push_lora_adapters_falls_back_to_large_folder_when_unavailable(
 
 
 def test_save_lora_adapters_method_ignores_a_fully_unfrozen_tree(tmp_path):
-    # load_adapters() never freezes, so a just-reloaded model reports EVERY
-    # base weight as trainable. Not CPT state: keep the LoRA-only writer.
+    # load_adapters() never freezes: every base weight reads trainable, which
+    # is not CPT state, so keep the LoRA-only writer.
     from unsloth_zoo.mlx.loader import _mlx_save_lora_adapters
 
     model = _make_model({

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -324,3 +324,61 @@ def test_lora_plus_ratio_scales_the_lora_b_step(tmp_path):
         f"LoRA+ ratio did not scale the step (fix regressed): "
         f"base={base:.4f} boosted={boosted:.4f} ratio={boosted / base:.2f}"
     )
+
+
+@metal_only
+@pytest.mark.parametrize("nested", [True, False])
+def test_lora_plus_scales_layer_wrapped_lora_b_weight(tmp_path, nested):
+    """mlx-lm may wrap the LoRA halves in nn.Linear children, flattening lora_b
+    to `...lora_b.weight` (the layout loader.py / utils.py already unwrap). The
+    LoRA+ scoped rescale must scale that layout too, not only a raw `.lora_b` —
+    for both a nested (`proj.lora_b.weight`) and a root (`lora_b.weight`) key.
+    """
+    key = "proj.lora_b.weight" if nested else "lora_b.weight"
+
+    def _b_weight_norm(ratio):
+        class _WrappedLoRA(nn.Module):
+            def __init__(s):
+                super().__init__()
+                s.embed = nn.Embedding(32, 4)
+                host = nn.Module() if nested else s
+                host.lora_a = mx.random.normal((4, 8)) * 0.2   # frozen, non-zero
+                host.lora_b = nn.Linear(8, 32, bias=False)     # -> lora_b.weight
+                host.lora_b.weight = mx.zeros((32, 8))          # zero-init B
+                if nested:
+                    s.proj = host
+                s._config = {"model_type": "tiny"}
+
+            def __call__(s, input_ids):
+                host = s.proj if nested else s
+                return host.lora_b(s.embed(input_ids) @ host.lora_a)
+
+        mx.random.seed(77)
+        m = _WrappedLoRA()
+        mx.eval(m.parameters())
+        m.freeze()
+        (m.proj.lora_b if nested else m.lora_b).unfreeze(recurse=True)
+        args = MLXTrainingConfig(
+            per_device_train_batch_size=1, gradient_accumulation_steps=1,
+            max_steps=6, warmup_steps=0, learning_rate=1e-3, optim="adamw",
+            logging_steps=1, eval_steps=0, save_steps=0, max_seq_length=8,
+            output_dir=str(tmp_path / str(ratio)), compile=False,
+            compile_mode="eager", gradient_checkpointing=False,
+            cast_norm_output_to_input_dtype=False, dataset_order="sequential",
+            disable_memory_limits=True, use_cce=False, lora_plus_ratio=ratio,
+            max_grad_norm=0.0, max_grad_value=0.0, max_grad_leaf_norm=0.0,
+        )
+        t = MLXTrainer(m, _NormTok(), [], args=args)
+        t._batches = _norm_batches(6)
+        t.save_model = lambda *_a, **_k: None
+        t.train()
+        w = dict(tree_flatten(t.model.trainable_parameters()))[key]
+        return float(mx.sqrt(mx.sum(w.astype(mx.float32) ** 2)).item())
+
+    base = _b_weight_norm(1.0)
+    boosted = _b_weight_norm(8.0)
+    assert base > 0.0, f"wrapped {key} never moved at ratio=1"
+    assert boosted > 3.0 * base, (
+        f"LoRA+ did not scale the wrapped {key} step: "
+        f"base={base:.4f} boosted={boosted:.4f}"
+    )

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -296,3 +296,31 @@ def test_evaluation_failure_propagates_without_eager_retry(tmp_path, monkeypatch
                     overrides={"compile_mode": "best_effort"})
     assert state["step_ran"] and state["raised"]
     assert "falling back to eager" not in capsys.readouterr().out
+
+@metal_only
+def test_lora_plus_ratio_scales_the_lora_b_step(tmp_path):
+    """Post-update step rescale: the LoRA+ ratio must actually scale
+    lora_b's realized step. The old gradient pre-scale was an AdamW no-op, so
+    boosting the ratio left lora_b movement unchanged. lora_b initialises to
+    zero, so its final L2 norm is its total movement. Same mechanism as the
+    embedding-LR scope (validated end-to-end by the CUDA comparison after CPT).
+    """
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+
+    def _lora_b_norm(trainer):
+        total = 0.0
+        for k, v in tree_flatten(trainer.model.trainable_parameters()):
+            if k == "lora_b" or k.endswith(".lora_b"):
+                total += float(mx.sqrt(mx.sum(v.astype(mx.float32) ** 2)).item())
+        return total
+
+    base = _lora_b_norm(_train(tmp_path / "r1", lora_plus_ratio=1.0, max_steps=6))
+    boosted = _lora_b_norm(_train(tmp_path / "r8", lora_plus_ratio=8.0, max_steps=6))
+    assert base > 0.0, "lora_b never moved at ratio=1"
+    # Under the fix, boosting the ratio 8x moves lora_b markedly farther; under
+    # the old gradient-scale AdamW no-op, boosted/base would be ~1.0.
+    assert boosted > 3.0 * base, (
+        f"LoRA+ ratio did not scale the step (fix regressed): "
+        f"base={base:.4f} boosted={boosted:.4f} ratio={boosted / base:.2f}"
+    )

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -299,11 +299,10 @@ def test_evaluation_failure_propagates_without_eager_retry(tmp_path, monkeypatch
 
 @metal_only
 def test_lora_plus_ratio_scales_the_lora_b_step(tmp_path):
-    """Post-update step rescale: the LoRA+ ratio must actually scale
-    lora_b's realized step. The old gradient pre-scale was an AdamW no-op, so
-    boosting the ratio left lora_b movement unchanged. lora_b initialises to
-    zero, so its final L2 norm is its total movement. Same mechanism as the
-    embedding-LR scope (validated end-to-end by the CUDA comparison after CPT).
+    """The LoRA+ ratio must actually scale lora_b's realized step.
+
+    The old gradient pre-scale was an AdamW no-op. lora_b starts at zero, so
+    its final L2 norm is its total movement. Same mechanism as embedding LR.
     """
     import mlx.core as mx
     from mlx.utils import tree_flatten
@@ -318,8 +317,7 @@ def test_lora_plus_ratio_scales_the_lora_b_step(tmp_path):
     base = _lora_b_norm(_train(tmp_path / "r1", lora_plus_ratio=1.0, max_steps=6))
     boosted = _lora_b_norm(_train(tmp_path / "r8", lora_plus_ratio=8.0, max_steps=6))
     assert base > 0.0, "lora_b never moved at ratio=1"
-    # Under the fix, boosting the ratio 8x moves lora_b markedly farther; under
-    # the old gradient-scale AdamW no-op, boosted/base would be ~1.0.
+    # Under the old gradient-scale no-op, boosted/base would be ~1.0.
     assert boosted > 3.0 * base, (
         f"LoRA+ ratio did not scale the step (fix regressed): "
         f"base={base:.4f} boosted={boosted:.4f} ratio={boosted / base:.2f}"
@@ -329,10 +327,9 @@ def test_lora_plus_ratio_scales_the_lora_b_step(tmp_path):
 @metal_only
 @pytest.mark.parametrize("nested", [True, False])
 def test_lora_plus_scales_layer_wrapped_lora_b_weight(tmp_path, nested):
-    """mlx-lm may wrap the LoRA halves in nn.Linear children, flattening lora_b
-    to `...lora_b.weight` (the layout loader.py / utils.py already unwrap). The
-    LoRA+ scoped rescale must scale that layout too, not only a raw `.lora_b` —
-    for both a nested (`proj.lora_b.weight`) and a root (`lora_b.weight`) key.
+    """mlx-lm may wrap the LoRA halves in nn.Linear children, flattening
+    lora_b to `...lora_b.weight`. The scoped rescale must scale that layout
+    too, both nested (`proj.lora_b.weight`) and root (`lora_b.weight`).
     """
     key = "proj.lora_b.weight" if nested else "lora_b.weight"
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4735,10 +4735,12 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
 
     if isinstance(target_modules, str):
         tm = [target_modules]  # a bare module name, not a char iterable
-    elif isinstance(target_modules, (list, tuple)):
-        tm = list(target_modules)
+    elif isinstance(target_modules, (list, tuple, set, frozenset)):
+        tm = list(target_modules)  # accept any selection iterable, incl. sets
     else:
         tm = []
+    if isinstance(modules_to_save, str):
+        modules_to_save = [modules_to_save]  # a bare name, not a char iterable
     mts = list(dict.fromkeys(modules_to_save or []))  # dedup, keep order
     for name in mts:
         if name not in ("embed_tokens", "lm_head"):
@@ -4777,12 +4779,19 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
     lm_head_lora_path = None
     if "lm_head" in tm or "lm_head" in mts:
         if tied:
-            raise ValueError(
-                "Unsloth: lm_head cannot be trained separately on a tied-"
-                "embedding model — the output head shares embed_tokens' weight. "
-                "Add 'embed_tokens' to target_modules to train the shared matrix."
-            )
-        if desc.module is None:
+            # The tied output head shares embed_tokens' weight, so it trains via
+            # the embed_tokens full module. Accept the common recipe
+            # target_modules=[..., "embed_tokens", "lm_head"] by treating a
+            # co-requested lm_head as already selected; reject only a standalone
+            # lm_head, which cannot train the head without the shared embedding.
+            if "embed_tokens" not in tm and "embed_tokens" not in mts:
+                raise ValueError(
+                    "Unsloth: lm_head cannot be trained separately on a tied-"
+                    "embedding model — the output head shares embed_tokens' "
+                    "weight. Add 'embed_tokens' to target_modules to train the "
+                    "shared matrix."
+                )
+        elif desc.module is None:
             _raise_no_lora_targets(["lm_head"])
         elif "lm_head" in mts:            # precedence: modules_to_save -> full module
             _add_full(desc.path, desc.module)
@@ -6111,7 +6120,10 @@ class FastMLXModel:
         # vision linears, projector, untied lm_head). Walk the tree for those
         # names rather than collapsing to the canonical 7, which would leave
         # fused-attention archs and MoEs mostly un-LoRA'd.
-        if target_modules == ["all-linear"] or target_modules == "all-linear":
+        if target_modules == "all-linear" or (
+            isinstance(target_modules, (list, tuple, set, frozenset))
+            and list(target_modules) == ["all-linear"]
+        ):
             target_modules = _collect_all_linear_target_names(model)
             # PEFT parity: "all-linear" excludes the output layer. Drop the
             # descriptor-resolved head's leaf name (or the unique shape-matched
@@ -6138,8 +6150,9 @@ class FastMLXModel:
             ]
 
         # Filter by finetune_attention_modules / finetune_mlp_modules,
-        # whatever the source of target_modules, so these flags always apply.
-        if isinstance(target_modules, list) and len(target_modules) > 0:
+        # whatever the source of target_modules, so these flags always apply
+        # (incl. set/frozenset/tuple selections, not just lists).
+        if isinstance(target_modules, (list, tuple, set, frozenset)) and len(target_modules) > 0:
             _ATTN = {
                 "q_proj", "k_proj", "v_proj", "o_proj",
                 "qkv", "qkv_proj", "Wqkv", "in_proj",

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4113,8 +4113,23 @@ def _mlx_push_to_hub_gguf(self, repo_id, tokenizer=None,
 
 
 def _mlx_save_lora_adapters(self, path, adapter_config=None):
-    from .utils import save_lora_adapters
-    save_lora_adapters(self, path, adapter_config=adapter_config)
+    import mlx.utils as _mu
+    from .utils import (
+        save_lora_adapters, save_trainable_adapters,
+        collect_mlx_lora_adapter_tensors,
+    )
+    # Continued pretraining trains full modules (embed_tokens / lm_head weight)
+    # that are not LoRA tensors; the LoRA-only writer would silently drop them
+    # and reload would revert to the base weight. Detect any trainable non-LoRA
+    # tensor directly (robust to a reloaded model that no longer carries the
+    # get_peft_model marker) and route through the trainable-tensor writer.
+    _trainable = dict(_mu.tree_flatten(self.trainable_parameters()))
+    _lora = set(collect_mlx_lora_adapter_tensors(self))
+    _has_full_module = any(k not in _lora for k in _trainable)
+    if _has_full_module:
+        save_trainable_adapters(self, path, adapter_config=adapter_config)
+    else:
+        save_lora_adapters(self, path, adapter_config=adapter_config)
 
 
 def _mlx_prompt_to_ids(prompt):
@@ -4669,6 +4684,140 @@ def _raise_no_lora_targets(target_modules):
         f"target_modules={target_modules!r}. Check the module names or use "
         "target_modules='all-linear'."
     )
+
+
+def _resolve_embedding_module(model):
+    """``(module, path)`` of the token embedding, rooted at ``model``.
+
+    Uses the same live-anchor logic as the output-head descriptor so alt-named
+    embeddings (InternLM2 ``tok_embeddings``, GPT-NeoX ``embed_in``) resolve by
+    type, not by name. Returns ``(None, None)`` when it cannot be resolved.
+    """
+    import mlx.nn as nn
+    from .utils import (
+        _get_text_model, _resolve_embedding_anchor, _output_accessor_modules,
+    )
+    prefix = "language_model." if hasattr(model, "language_model") else ""
+    tm = _get_text_model(model)
+    backbone = getattr(tm, "model", None)
+    if backbone is not None:
+        owner, owner_prefix = backbone, prefix + "model."
+    else:
+        owner, owner_prefix = tm, prefix
+    entry = _resolve_embedding_anchor(
+        owner, (nn.Embedding, nn.QuantizedEmbedding),
+        accessor_modules=_output_accessor_modules(tm),
+    )
+    if entry is None:
+        return None, None
+    return entry[1], owner_prefix + entry[0]
+
+
+def _partition_cpt_targets(model, target_modules, modules_to_save):
+    """Split LoRA targets from full-module (continued-pretraining) targets.
+
+    Mirrors the CUDA CPT recipe (unsloth/models/llama.py:3283-3307): an
+    ``embed_tokens`` request trains the token embedding as a full module (the
+    ``modules_to_save`` analog); an ``lm_head`` request is a LoRA target on the
+    output-head Linear unless routed to ``modules_to_save`` (then full module).
+    ``modules_to_save`` takes precedence over ``target_modules`` on overlap.
+
+    Returns ``(lora_targets, full_specs, lm_head_lora_path, desc)``:
+      * ``lora_targets`` — ``target_modules`` minus ``embed_tokens``/``lm_head``.
+      * ``full_specs`` — ``[(path, module), ...]`` trained as full modules.
+      * ``lm_head_lora_path`` — descriptor-rooted path of a LoRA output head, or
+        ``None``.
+      * ``desc`` — the output-head descriptor (topology).
+    """
+    from .utils import describe_output_head
+    desc = describe_output_head(model)
+    tied = desc.status == "tied"
+
+    if isinstance(target_modules, str):
+        tm = [target_modules]  # a bare module name, not a char iterable
+    elif isinstance(target_modules, (list, tuple)):
+        tm = list(target_modules)
+    else:
+        tm = []
+    mts = list(dict.fromkeys(modules_to_save or []))  # dedup, keep order
+    for name in mts:
+        if name not in ("embed_tokens", "lm_head"):
+            raise ValueError(
+                f"Unsloth: modules_to_save={name!r} is not supported on MLX; "
+                "only 'embed_tokens' and 'lm_head' can be trained as full "
+                "modules (continued-pretraining recipe)."
+            )
+
+    full_specs, seen_full = [], set()
+
+    def _add_full(path, module):
+        if path is None or path in seen_full:
+            return
+        # Quantized modules cannot be full-module trained: the CCE backward
+        # zeroes the quantized weight gradient (dequant->grad->requant is
+        # unimplemented), so the module would silently never update.
+        if hasattr(module, "scales"):
+            raise ValueError(
+                f"Unsloth: full-module training of the quantized module at "
+                f"{path!r} is not supported. Load the unquantized (16-bit) base "
+                "model for continued pretraining, or LoRA-target it instead."
+            )
+        seen_full.add(path)
+        full_specs.append((path, module))
+
+    if "embed_tokens" in tm or "embed_tokens" in mts:
+        emb, emb_path = _resolve_embedding_module(model)
+        if emb is None:
+            raise ValueError(
+                "Unsloth: could not resolve the token embedding for full-module "
+                "(embed_tokens) training on this model."
+            )
+        _add_full(emb_path, emb)
+
+    lm_head_lora_path = None
+    if "lm_head" in tm or "lm_head" in mts:
+        if tied:
+            raise ValueError(
+                "Unsloth: lm_head cannot be trained separately on a tied-"
+                "embedding model — the output head shares embed_tokens' weight. "
+                "Add 'embed_tokens' to target_modules to train the shared matrix."
+            )
+        if desc.module is None:
+            _raise_no_lora_targets(["lm_head"])
+        elif "lm_head" in mts:            # precedence: modules_to_save -> full module
+            _add_full(desc.path, desc.module)
+        else:                            # target_modules -> LoRA on the head Linear
+            lm_head_lora_path = desc.path
+
+    lora_targets = [m for m in tm if m not in ("embed_tokens", "lm_head")]
+    return lora_targets, full_specs, lm_head_lora_path, desc
+
+
+def _unfreeze_full_modules(full_specs):
+    """Unfreeze the weights of the continued-pretraining full modules (kept at
+    their load dtype). The trainer scales only their ``.weight`` by
+    ``embedding_learning_rate``; any bias stays in the normal group."""
+    for _path, module in full_specs:
+        module.unfreeze(recurse=True)
+
+
+def _full_module_weight_keys(model, full_specs):
+    """Registered ``.weight`` parameter keys of the CPT full modules, matched by
+    module identity in the live tree.
+
+    Uses the registered parameter path (what ``tree_flatten`` /
+    ``named_modules`` yield and the trainer's grad scaler sees), NOT the
+    descriptor access path, which diverges for property-backed VLM wrappers
+    (e.g. Moondream3 exposes its ``text`` stack through a ``language_model``
+    property, so the embedding registers at ``text.model.wte`` while the
+    descriptor path reads ``language_model.model.wte``).
+    """
+    targets = [m for _, m in full_specs]
+    keys = set()
+    for name, module in model.named_modules():
+        if name and any(module is t for t in targets):
+            keys.add(f"{name}.weight")
+    return keys
 
 
 def _validate_mlx_init_lora_weights(init_lora_weights):
@@ -5911,6 +6060,7 @@ class FastMLXModel:
         finetune_attention_modules=True,
         finetune_mlp_modules=True,
         finetune_last_n_layers=None,
+        modules_to_save=None,
         **kwargs,  # Accept and ignore GPU-only kwargs
     ):
         """Apply LoRA via mlx-lm on Apple Silicon.
@@ -5963,6 +6113,17 @@ class FastMLXModel:
         # fused-attention archs and MoEs mostly un-LoRA'd.
         if target_modules == ["all-linear"] or target_modules == "all-linear":
             target_modules = _collect_all_linear_target_names(model)
+            # PEFT parity: "all-linear" excludes the output layer. Drop the
+            # descriptor-resolved head's leaf name (or the unique shape-matched
+            # candidate when topology is unknown) so a raw untied lm_head /
+            # .output / embed_out is not adapted here — the head is trained
+            # explicitly via target_modules=["lm_head"] instead.
+            from .utils import describe_output_head
+            _hd = describe_output_head(model)
+            _head_path = _hd.path or _hd.candidate_path
+            if _head_path:
+                _head_leaf = _head_path.split(".")[-1]
+                target_modules = [m for m in target_modules if m != _head_leaf]
             if not target_modules:
                 # No Linear modules found; fall back to the canonical default.
                 target_modules = [
@@ -5997,6 +6158,28 @@ class FastMLXModel:
                 filtered.append(m)
             target_modules = filtered
 
+        # Continued-pretraining partition: embed_tokens -> full module, lm_head
+        # -> LoRA target (or full module via modules_to_save); everything else
+        # stays a layer LoRA target. Mirrors the CUDA CPT recipe
+        # (unsloth/models/llama.py:3283-3307).
+        (target_modules, _cpt_full_specs, _cpt_lm_head_lora_path,
+         _cpt_head_desc) = _partition_cpt_targets(
+            model, target_modules, modules_to_save,
+        )
+        # The lm_head LoRA key is descriptor-rooted at `model`; the VLM branch
+        # LoRAs `model.language_model`, so strip that prefix there.
+        _cpt_lm_head_keys = (
+            {_cpt_lm_head_lora_path} if _cpt_lm_head_lora_path else set()
+        )
+        # Record the full-module weight keys (registered paths, by module
+        # identity) so the trainer scopes embedding_learning_rate to exactly
+        # these tensors regardless of the module's name or a property-backed
+        # VLM wrapper (embed_tokens / tok_embeddings / embed_in / wte / lm_head).
+        model._unsloth_cpt_full_module_weight_keys = (
+            _full_module_weight_keys(model, _cpt_full_specs)
+            if _cpt_full_specs else set()
+        )
+
         lora_config = {
             "rank": r,
             "alpha": lora_alpha,
@@ -6012,19 +6195,29 @@ class FastMLXModel:
             _fix_gemma4_kv_sharing(model)
             model.freeze()
 
+            # The lm_head LoRA key is rooted at `model`; the LoRA call below
+            # targets `model.language_model`, so drop that prefix.
+            _vlm_lm_head_keys = {
+                p[len("language_model."):] if p.startswith("language_model.") else p
+                for p in _cpt_lm_head_keys
+            }
             # LoRA the language model (filtered by target_modules).
             language_lora_count = 0
-            if finetune_language_layers and (
+            if (finetune_language_layers and (
                 target_modules is None or (isinstance(target_modules, list) and len(target_modules) > 0)
-            ):
+            )) or _vlm_lm_head_keys:
                 lm = model.language_model
                 num_layers = 0
                 if hasattr(lm, "model") and hasattr(lm.model, "layers"):
                     num_layers = len(lm.model.layers)
                 if finetune_last_n_layers is not None and num_layers > 0:
                     num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
-                language_lora_keys = _resolve_lora_keys(lm, target_modules)
-                if language_lora_keys is None or len(language_lora_keys) > 0:
+                language_lora_keys = (
+                    _resolve_lora_keys(lm, target_modules)
+                    if finetune_language_layers else None
+                )
+                language_lora_keys = set(language_lora_keys or set()) | _vlm_lm_head_keys
+                if len(language_lora_keys) > 0:
                     # Compat patch (older mlx-lm rejects scale=/dropout= on
                     # from_base); before the seed since monkey-patching doesn't
                     # advance mx.random.
@@ -6039,7 +6232,7 @@ class FastMLXModel:
                         config={**lora_config, "keys": language_lora_keys},
                         use_dora=False,
                     )
-                    language_lora_count = len(language_lora_keys) if language_lora_keys is not None else num_layers
+                    language_lora_count = len(language_lora_keys)
 
             # Optionally LoRA the vision tower.
             vision_lora_count = 0
@@ -6074,6 +6267,7 @@ class FastMLXModel:
                 language_lora_count == 0
                 and vision_lora_count == 0
                 and projector_lora_count == 0
+                and not _cpt_full_specs
             ):
                 if not finetune_language_layers and not train_vision and not train_projector:
                     raise ValueError(
@@ -6094,26 +6288,41 @@ class FastMLXModel:
 
             # Unfreeze all LoRA params across the tree.
             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
+            # Continued-pretraining full modules (embed_tokens / lm_head weight).
+            _unfreeze_full_modules(_cpt_full_specs)
         else:
             # Text-only path. _fix_missing_no_grad handles modules using
             # __new__ without __init__ (e.g. Gemma4 AudioRelativePosition...).
             _fix_missing_no_grad(model)
 
-            if not finetune_language_layers:
-                warnings.warn(
-                    "Unsloth: finetune_language_layers=False on a text-only model — "
-                    "no LoRA will be applied; the model has no trainable parameters.",
-                    stacklevel=2,
-                )
+            num_layers = 0
+            if hasattr(model, "model") and hasattr(model.model, "layers"):
+                num_layers = len(model.model.layers)
+            if finetune_last_n_layers is not None and num_layers > 0:
+                num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
+            # Layer LoRA keys (empty when finetune_language_layers=False or the
+            # only targets were embed_tokens/lm_head), plus the descriptor-rooted
+            # lm_head LoRA key (a root module, not a layer submodule).
+            language_lora_keys = (
+                _resolve_lora_keys(model, target_modules)
+                if finetune_language_layers else None
+            )
+            if _cpt_lm_head_keys or _cpt_full_specs:
+                # CPT: merge the descriptor-rooted lm_head key; empty layer
+                # targets are valid when full modules / an lm_head adapter
+                # still train (never fall through to keys=None auto-discovery).
+                language_lora_keys = set(language_lora_keys or set()) | _cpt_lm_head_keys
+                _apply_layer_lora = len(language_lora_keys) > 0
             else:
-                num_layers = 0
-                if hasattr(model, "model") and hasattr(model.model, "layers"):
-                    num_layers = len(model.model.layers)
-                if finetune_last_n_layers is not None and num_layers > 0:
-                    num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
-                language_lora_keys = _resolve_lora_keys(model, target_modules)
-                if language_lora_keys is not None and len(language_lora_keys) == 0:
+                # Non-CPT: preserve the original semantics exactly, including
+                # keys=None -> mlx-lm auto-discovers all supported modules.
+                if (finetune_language_layers and language_lora_keys is not None
+                        and len(language_lora_keys) == 0):
                     _raise_no_lora_targets(target_modules)
+                _apply_layer_lora = finetune_language_layers and (
+                    language_lora_keys is None or len(language_lora_keys) > 0
+                )
+            if _apply_layer_lora:
                 # Compat patch (older mlx-lm rejects scale=/dropout= on
                 # from_base); before the seed since monkey-patching doesn't
                 # advance mx.random.
@@ -6128,9 +6337,19 @@ class FastMLXModel:
                     config={**lora_config, "keys": language_lora_keys},
                     use_dora=False,
                 )
+            elif not _cpt_full_specs and not finetune_language_layers:
+                warnings.warn(
+                    "Unsloth: finetune_language_layers=False on a text-only "
+                    "model — no LoRA will be applied; the model has no "
+                    "trainable parameters.",
+                    stacklevel=2,
+                )
 
             model.freeze()
             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
+            # Continued-pretraining full modules (embed_tokens / lm_head weight)
+            # train at their load dtype, scaled by embedding_learning_rate.
+            _unfreeze_full_modules(_cpt_full_specs)
 
         _apply_mlx_lora_initialization(model, init_lora_weights)
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4736,6 +4736,23 @@ def _is_lora_capable_head(module):
         module, (nn.Linear, nn.QuantizedLinear))
 
 
+def _quantized_descendant_path(path, module):
+    """Registered path of ``module`` or of its first quantized descendant.
+
+    A wrapper head keeps its quantization one level down (mlx-lm's phixtral
+    ``OutputHead`` is a LayerNorm + Linear, so a 4-bit checkpoint carries the
+    ``scales`` on ``lm_head.linear``), so a leaf-only ``scales`` check accepts
+    the wrapper and MLX raises ``[QuantizedMatmul::vjp] no gradient wrt the
+    quantized weights`` at the first backward instead of the actionable error.
+    ``named_modules()`` yields the module itself under the empty name, so this
+    covers the direct case too. Returns ``None`` when nothing is quantized.
+    """
+    for name, child in module.named_modules():
+        if hasattr(child, "scales"):
+            return f"{path}.{name}" if name else path
+    return None
+
+
 def _partition_cpt_targets(model, target_modules, modules_to_save):
     """Split LoRA targets from full-module (continued-pretraining) targets.
 
@@ -4781,11 +4798,13 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
         # Quantized modules cannot be full-module trained: the CCE backward
         # zeroes the quantized weight gradient (dequant->grad->requant is
         # unimplemented), so the module would silently never update.
-        if hasattr(module, "scales"):
+        quantized_path = _quantized_descendant_path(path, module)
+        if quantized_path is not None:
             raise ValueError(
                 f"Unsloth: full-module training of the quantized module at "
-                f"{path!r} is not supported. Load the unquantized (16-bit) base "
-                "model for continued pretraining, or LoRA-target it instead."
+                f"{quantized_path!r} is not supported. Load the unquantized "
+                "(16-bit) base model for continued pretraining, or LoRA-target "
+                "it instead."
             )
         seen_full.add(path)
         full_specs.append((path, module))

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4728,6 +4728,14 @@ def _resolve_embedding_module(model):
     return entry[1], owner_prefix + entry[0]
 
 
+def _is_lora_capable_head(module):
+    """Whether mlx-lm's ``to_lora`` can wrap this output head (it raises for
+    anything else, which would abort the whole ``get_peft_model`` call)."""
+    import mlx.nn as nn
+    return hasattr(module, "to_lora") or isinstance(
+        module, (nn.Linear, nn.QuantizedLinear))
+
+
 def _partition_cpt_targets(model, target_modules, modules_to_save):
     """Split LoRA targets from full-module (continued-pretraining) targets.
 
@@ -4817,8 +4825,18 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
             )
         elif "lm_head" in mts:            # precedence: modules_to_save -> full module
             _add_full(desc.path, desc.module)
-        else:                            # target_modules -> LoRA on the head Linear
-            lm_head_lora_path = desc.path
+        elif _is_lora_capable_head(desc.module):
+            lm_head_lora_path = desc.path  # target_modules -> LoRA on the head
+        else:
+            # mlx-lm's to_lora() raises deep inside linear_to_lora_layers for a
+            # head it cannot wrap (Phixtral's OutputHead is a LayerNorm+Linear
+            # module, not a Linear), which would take the whole run down.
+            unusable = (
+                f"Unsloth: the output head at {desc.path!r} is a "
+                f"{type(desc.module).__name__}, which mlx-lm cannot wrap as a "
+                "LoRA layer, so lm_head cannot be trained. Pass "
+                "modules_to_save=['lm_head'] to train it as a full module."
+            )
         if unusable is not None:
             # modules_to_save names one module and nothing else, so an
             # unusable head there is unambiguous and must fail loudly. In

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -320,8 +320,8 @@ def linear_to_lora_layers(model, num_layers, config):
             layer.update_modules(tree_unflatten(replacements))
             attached += len(replacements)
 
-    # Root-module pass (mlx-lm parity): a head named in `keys` lives beside the
-    # layers, not inside them, so the layer walk above never reaches it.
+    # Root-module pass: a head named in `keys` sits beside the layers, so the
+    # layer walk above never reaches it.
     root_replacements = [
         (name, _mlx_lora_from_base(module, config, specs=type_specs))
         for name, module in model.named_modules()
@@ -2914,8 +2914,7 @@ def _rebuild_cpt_full_module_weight_keys(model, restored_keys):
         specs.append((head.path, head.module))
     if not specs:
         return
-    # Only tensors this reload actually made trainable: a saved weight the
-    # descriptors do not own stays on the main learning rate.
+    # Only tensors this reload made trainable; anything else stays on the main LR.
     keys = _full_module_weight_keys(model, specs) & set(restored_keys)
     if keys:
         model._unsloth_cpt_full_module_weight_keys = keys
@@ -4496,19 +4495,18 @@ def _mlx_save_lora_adapters(self, path, adapter_config=None):
         collect_mlx_lora_adapter_tensors, iter_mlx_lora_modules,
         _is_base_tensor_inside_lora_module,
     )
-    # Continued pretraining trains full modules (embed_tokens / lm_head weight)
-    # that the LoRA-only writer would silently drop. Detect a trainable non-LoRA
-    # tensor in a selectively frozen tree and use the trainable-tensor writer.
+    # CPT trains full modules (embed_tokens / lm_head weight) that the LoRA-only
+    # writer would drop, so a trainable non-LoRA tensor in a selectively frozen
+    # tree switches to the trainable-tensor writer.
     _trainable = dict(_mu.tree_flatten(self.trainable_parameters()))
     _all = dict(_mu.tree_flatten(self.parameters()))
     _lora = set(collect_mlx_lora_adapter_tensors(self))
     _lora_names = [name for name, _ in iter_mlx_lora_modules(self)]
     _lora_prefixes = tuple(f"{name}." for name in _lora_names if name)
     _root_lora = any(name == "" for name in _lora_names)
-    # A tree nothing has frozen reports EVERY parameter as trainable, which is
-    # not CPT evidence: keep the LoRA-only writer rather than dumping the base
-    # model. The wrapped-base filter matches MLXTrainer.save_model, so a
-    # reload-leaked q_proj.weight under a LoRA-wrapped q_proj does not count.
+    # A tree nothing froze reports EVERY parameter trainable, which is not CPT
+    # evidence: keep the LoRA-only writer. The wrapped-base filter matches
+    # MLXTrainer.save_model, so a reload-leaked q_proj.weight does not count.
     _has_full_module = len(_trainable) < len(_all) and any(
         k not in _lora
         and not _is_base_tensor_inside_lora_module(k, _lora_prefixes, _root_lora)
@@ -5131,9 +5129,9 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
     tied = desc.status == "tied"
 
     if isinstance(target_modules, str):
-        tm = [target_modules]  # a bare module name, not a char iterable
+        tm = [target_modules]  # a bare name, not a char iterable
     elif isinstance(target_modules, (list, tuple, set, frozenset)):
-        tm = list(target_modules)  # accept any selection iterable, incl. sets
+        tm = list(target_modules)
     else:
         tm = []
     if isinstance(modules_to_save, str):
@@ -5152,8 +5150,7 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
     def _add_full(path, module):
         if path is None or path in seen_full:
             return
-        # Quantized modules cannot be full-module trained: the CCE backward
-        # zeroes their gradient, so they would silently never update.
+        # Quantized full modules never update: the CCE backward zeroes the grad.
         quantized_path = _quantized_descendant_path(path, module)
         if quantized_path is not None:
             raise ValueError(
@@ -5181,7 +5178,7 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
         unusable = None
         if tied:
             # A tied head shares embed_tokens' weight, so it trains via that
-            # full module: a co-requested lm_head is already selected.
+            # full module when embed_tokens is co-requested.
             if "embed_tokens" not in tm and "embed_tokens" not in mts:
                 unusable = (
                     "Unsloth: lm_head cannot be trained separately on a tied-"
@@ -5201,8 +5198,8 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
         elif _is_lora_capable_head(desc.module):
             lm_head_lora_path = desc.path  # target_modules -> LoRA on the head
         else:
-            # to_lora() raises deep inside linear_to_lora_layers for a head it
-            # cannot wrap (phixtral's OutputHead is a LayerNorm+Linear).
+            # to_lora() raises inside linear_to_lora_layers for a head it cannot
+            # wrap (phixtral's OutputHead is a LayerNorm+Linear).
             unusable = (
                 f"Unsloth: the output head at {desc.path!r} is a "
                 f"{type(desc.module).__name__}, which mlx-lm cannot wrap as a "
@@ -5210,9 +5207,8 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
                 "modules_to_save=['lm_head'] to train it as a full module."
             )
         if unusable is not None:
-            # modules_to_save names one module, so an unusable head there must
-            # fail loudly. In target_modules it is one entry among many:
-            # dropping it preserves the pre-CPT behaviour of the other targets.
+            # In modules_to_save the head is the only module, so fail loudly; in
+            # target_modules it is one entry among many, so drop it and warn.
             if "lm_head" in mts or not (lora_targets or full_specs):
                 raise ValueError(unusable)
             warnings.warn(unusable, stacklevel=3)
@@ -6507,9 +6503,8 @@ class FastMLXModel:
             and list(target_modules) == ["all-linear"]
         ):
             target_modules = _collect_all_linear_target_names(model)
-            # PEFT parity: "all-linear" excludes the output layer, so drop the
-            # resolved head's leaf name. The head is trained explicitly via
-            # target_modules=["lm_head"] instead.
+            # PEFT parity: "all-linear" excludes the output layer; the head is
+            # trained explicitly via target_modules=["lm_head"].
             from .utils import describe_output_head
             _hd = describe_output_head(model)
             _head_path = _hd.path or _hd.candidate_path
@@ -6529,9 +6524,8 @@ class FastMLXModel:
                 "gate_proj", "up_proj", "down_proj",
             ]
 
-        # Filter by finetune_attention_modules / finetune_mlp_modules,
-        # whatever the source of target_modules (incl. sets/tuples, not just
-        # lists), so these flags always apply.
+        # Filter by finetune_attention_modules / finetune_mlp_modules, whatever
+        # the source or container type of target_modules, so the flags apply.
         if isinstance(target_modules, (list, tuple, set, frozenset)) and len(target_modules) > 0:
             _ATTN = {
                 "q_proj", "k_proj", "v_proj", "o_proj",
@@ -6562,8 +6556,7 @@ class FastMLXModel:
             {_cpt_lm_head_lora_path} if _cpt_lm_head_lora_path else set()
         )
         # Record the registered full-module weight keys so the trainer scopes
-        # embedding_learning_rate to exactly these tensors, whatever the
-        # module's name or VLM wrapper.
+        # embedding_learning_rate to exactly these tensors, whatever the layout.
         model._unsloth_cpt_full_module_weight_keys = (
             _full_module_weight_keys(model, _cpt_full_specs)
             if _cpt_full_specs else set()
@@ -6584,7 +6577,7 @@ class FastMLXModel:
             _fix_gemma4_kv_sharing(model)
             model.freeze()
 
-            # The key is rooted at `model` but the LoRA call below targets
+            # Keys are rooted at `model`; the LoRA call below targets
             # `model.language_model`, so drop that prefix.
             _vlm_lm_head_keys = {
                 p[len("language_model."):] if p.startswith("language_model.") else p
@@ -6683,15 +6676,14 @@ class FastMLXModel:
             num_layers = len(_mlx_language_layers(model))
             if finetune_last_n_layers is not None and num_layers > 0:
                 num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
-            # Layer LoRA keys, plus the descriptor-rooted lm_head key (a root
-            # module, not a layer submodule).
+            # Layer LoRA keys plus the lm_head key (a root module, not a layer).
             language_lora_keys = (
                 _resolve_lora_keys(model, target_modules)
                 if finetune_language_layers else None
             )
             if _cpt_lm_head_keys or _cpt_full_specs:
-                # Empty layer targets are valid when full modules / an lm_head
-                # adapter still train; never fall through to auto-discovery.
+                # Empty layer targets are valid here (full modules / an lm_head
+                # adapter still train); never fall through to auto-discovery.
                 language_lora_keys = set(language_lora_keys or set()) | _cpt_lm_head_keys
                 _apply_layer_lora = len(language_lora_keys) > 0
             else:
@@ -6728,8 +6720,7 @@ class FastMLXModel:
 
             model.freeze()
             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
-            # CPT full modules train at their load dtype, scaled by
-            # embedding_learning_rate.
+            # CPT full modules train at load dtype, scaled by embedding_learning_rate.
             _unfreeze_full_modules(_cpt_full_specs)
 
         _apply_mlx_lora_initialization(model, init_lora_weights)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4120,22 +4120,18 @@ def _mlx_save_lora_adapters(self, path, adapter_config=None):
         _is_base_tensor_inside_lora_module,
     )
     # Continued pretraining trains full modules (embed_tokens / lm_head weight)
-    # that are not LoRA tensors; the LoRA-only writer would silently drop them
-    # and reload would revert to the base weight. Detect a trainable non-LoRA
-    # tensor in a selectively frozen tree and route through the trainable-tensor
-    # writer (no get_peft_model marker needed).
+    # that the LoRA-only writer would silently drop. Detect a trainable non-LoRA
+    # tensor in a selectively frozen tree and use the trainable-tensor writer.
     _trainable = dict(_mu.tree_flatten(self.trainable_parameters()))
     _all = dict(_mu.tree_flatten(self.parameters()))
     _lora = set(collect_mlx_lora_adapter_tensors(self))
     _lora_names = [name for name, _ in iter_mlx_lora_modules(self)]
     _lora_prefixes = tuple(f"{name}." for name in _lora_names if name)
     _root_lora = any(name == "" for name in _lora_names)
-    # A model nothing has frozen (a plain base model, or one whose adapters
-    # were just reloaded) reports EVERY parameter as trainable, which is not
-    # continued-pretraining evidence: keep the LoRA-only writer there instead
-    # of dumping the whole base model into adapters.safetensors. The wrapped-
-    # base filter matches MLXTrainer.save_model so a reload-leaked q_proj.weight
-    # under a LoRA-wrapped q_proj does not count either.
+    # A tree nothing has frozen reports EVERY parameter as trainable, which is
+    # not CPT evidence: keep the LoRA-only writer rather than dumping the base
+    # model. The wrapped-base filter matches MLXTrainer.save_model, so a
+    # reload-leaked q_proj.weight under a LoRA-wrapped q_proj does not count.
     _has_full_module = len(_trainable) < len(_all) and any(
         k not in _lora
         and not _is_base_tensor_inside_lora_module(k, _lora_prefixes, _root_lora)
@@ -4704,9 +4700,9 @@ def _raise_no_lora_targets(target_modules):
 def _resolve_embedding_module(model):
     """``(module, path)`` of the token embedding, rooted at ``model``.
 
-    Uses the same live-anchor logic as the output-head descriptor so alt-named
-    embeddings (InternLM2 ``tok_embeddings``, GPT-NeoX ``embed_in``) resolve by
-    type, not by name. Returns ``(None, None)`` when it cannot be resolved.
+    Same live-anchor logic as the output-head descriptor, so alt-named
+    embeddings (``tok_embeddings``, ``embed_in``) resolve by type, not by name.
+    Returns ``(None, None)`` when unresolved.
     """
     import mlx.nn as nn
     from .utils import (
@@ -4729,8 +4725,7 @@ def _resolve_embedding_module(model):
 
 
 def _is_lora_capable_head(module):
-    """Whether mlx-lm's ``to_lora`` can wrap this output head (it raises for
-    anything else, which would abort the whole ``get_peft_model`` call)."""
+    """Whether mlx-lm's ``to_lora`` can wrap this head; it raises otherwise."""
     import mlx.nn as nn
     return hasattr(module, "to_lora") or isinstance(
         module, (nn.Linear, nn.QuantizedLinear))
@@ -4739,13 +4734,11 @@ def _is_lora_capable_head(module):
 def _quantized_descendant_path(path, module):
     """Registered path of ``module`` or of its first quantized descendant.
 
-    A wrapper head keeps its quantization one level down (mlx-lm's phixtral
-    ``OutputHead`` is a LayerNorm + Linear, so a 4-bit checkpoint carries the
-    ``scales`` on ``lm_head.linear``), so a leaf-only ``scales`` check accepts
-    the wrapper and MLX raises ``[QuantizedMatmul::vjp] no gradient wrt the
-    quantized weights`` at the first backward instead of the actionable error.
-    ``named_modules()`` yields the module itself under the empty name, so this
-    covers the direct case too. Returns ``None`` when nothing is quantized.
+    A wrapper head keeps its quantization one level down (phixtral's
+    ``OutputHead`` carries the ``scales`` on ``lm_head.linear``), so a leaf-only
+    check would miss it and MLX would raise at the first backward instead.
+    ``named_modules()`` also yields the module itself, covering the direct case.
+    Returns ``None`` when nothing is quantized.
     """
     for name, child in module.named_modules():
         if hasattr(child, "scales"):
@@ -4756,18 +4749,14 @@ def _quantized_descendant_path(path, module):
 def _partition_cpt_targets(model, target_modules, modules_to_save):
     """Split LoRA targets from full-module (continued-pretraining) targets.
 
-    Mirrors the CUDA CPT recipe (unsloth/models/llama.py:3283-3307): an
-    ``embed_tokens`` request trains the token embedding as a full module (the
-    ``modules_to_save`` analog); an ``lm_head`` request is a LoRA target on the
-    output-head Linear unless routed to ``modules_to_save`` (then full module).
-    ``modules_to_save`` takes precedence over ``target_modules`` on overlap.
+    Mirrors the CUDA CPT recipe (unsloth/models/llama.py:3283-3307):
+    ``embed_tokens`` trains as a full module; ``lm_head`` is a LoRA target on
+    the output-head Linear unless routed to ``modules_to_save``, which takes
+    precedence over ``target_modules`` on overlap.
 
-    Returns ``(lora_targets, full_specs, lm_head_lora_path, desc)``:
-      * ``lora_targets`` — ``target_modules`` minus ``embed_tokens``/``lm_head``.
-      * ``full_specs`` — ``[(path, module), ...]`` trained as full modules.
-      * ``lm_head_lora_path`` — descriptor-rooted path of a LoRA output head, or
-        ``None``.
-      * ``desc`` — the output-head descriptor (topology).
+    Returns ``(lora_targets, full_specs, lm_head_lora_path, desc)``: targets
+    minus embed_tokens/lm_head, ``[(path, module), ...]`` full modules, the
+    descriptor-rooted LoRA head path (or ``None``), and the head descriptor.
     """
     from .utils import describe_output_head
     desc = describe_output_head(model)
@@ -4796,8 +4785,7 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
         if path is None or path in seen_full:
             return
         # Quantized modules cannot be full-module trained: the CCE backward
-        # zeroes the quantized weight gradient (dequant->grad->requant is
-        # unimplemented), so the module would silently never update.
+        # zeroes their gradient, so they would silently never update.
         quantized_path = _quantized_descendant_path(path, module)
         if quantized_path is not None:
             raise ValueError(
@@ -4824,10 +4812,8 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
     if "lm_head" in tm or "lm_head" in mts:
         unusable = None
         if tied:
-            # The tied output head shares embed_tokens' weight, so it trains via
-            # the embed_tokens full module. Accept the common recipe
-            # target_modules=[..., "embed_tokens", "lm_head"] by treating a
-            # co-requested lm_head as already selected.
+            # A tied head shares embed_tokens' weight, so it trains via that
+            # full module: a co-requested lm_head is already selected.
             if "embed_tokens" not in tm and "embed_tokens" not in mts:
                 unusable = (
                     "Unsloth: lm_head cannot be trained separately on a tied-"
@@ -4847,9 +4833,8 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
         elif _is_lora_capable_head(desc.module):
             lm_head_lora_path = desc.path  # target_modules -> LoRA on the head
         else:
-            # mlx-lm's to_lora() raises deep inside linear_to_lora_layers for a
-            # head it cannot wrap (Phixtral's OutputHead is a LayerNorm+Linear
-            # module, not a Linear), which would take the whole run down.
+            # to_lora() raises deep inside linear_to_lora_layers for a head it
+            # cannot wrap (phixtral's OutputHead is a LayerNorm+Linear).
             unusable = (
                 f"Unsloth: the output head at {desc.path!r} is a "
                 f"{type(desc.module).__name__}, which mlx-lm cannot wrap as a "
@@ -4857,11 +4842,9 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
                 "modules_to_save=['lm_head'] to train it as a full module."
             )
         if unusable is not None:
-            # modules_to_save names one module and nothing else, so an
-            # unusable head there is unambiguous and must fail loudly. In
-            # target_modules it is one entry among many: dropping it while the
-            # other targets still train preserves the pre-CPT behaviour instead
-            # of aborting a run that used to work.
+            # modules_to_save names one module, so an unusable head there must
+            # fail loudly. In target_modules it is one entry among many:
+            # dropping it preserves the pre-CPT behaviour of the other targets.
             if "lm_head" in mts or not (lora_targets or full_specs):
                 raise ValueError(unusable)
             warnings.warn(unusable, stacklevel=3)
@@ -4870,29 +4853,25 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
 
 
 def _unfreeze_full_modules(full_specs):
-    """Unfreeze the weights of the continued-pretraining full modules (kept at
-    their load dtype). The trainer scales only their ``.weight`` by
-    ``embedding_learning_rate``; any bias stays in the normal group."""
+    """Unfreeze the CPT full modules, kept at their load dtype. The trainer
+    scales only their ``.weight`` by ``embedding_learning_rate``."""
     for _path, module in full_specs:
         module.unfreeze(recurse=True)
 
 
 def _full_module_weight_keys(model, full_specs):
-    """Registered ``.weight`` parameter keys of the CPT full modules, matched by
-    module identity in the live tree.
+    """Registered ``.weight`` keys of the CPT full modules, matched by module
+    identity in the live tree.
 
-    Uses the registered parameter path (what ``tree_flatten`` /
-    ``named_modules`` yield and the trainer's grad scaler sees), NOT the
+    Uses the registered parameter path (what the trainer sees), NOT the
     descriptor access path, which diverges for property-backed VLM wrappers
-    (e.g. Moondream3 exposes its ``text`` stack through a ``language_model``
-    property, so the embedding registers at ``text.model.wte`` while the
-    descriptor path reads ``language_model.model.wte``).
+    (Moondream3 registers at ``text.model.wte`` but reads
+    ``language_model.model.wte``).
 
-    Descends into the selected module: a wrapper head owns no ``.weight`` of
-    its own (mlx-lm's phixtral ``OutputHead`` registers ``ln.weight`` and
-    ``linear.weight``), so recording ``<name>.weight`` there names a tensor
-    that does not exist and the scoped LR silently never applies. For a plain
-    Embedding / Linear this still yields exactly ``<name>.weight``.
+    Descends into the module: a wrapper head owns no ``.weight`` of its own
+    (phixtral's ``OutputHead`` registers ``ln.weight`` / ``linear.weight``), so
+    ``<name>.weight`` would name a nonexistent tensor and the scoped LR would
+    never apply. A plain Embedding / Linear still yields ``<name>.weight``.
     """
     import mlx.utils as _mu
     targets = [m for _, m in full_specs]
@@ -6202,11 +6181,9 @@ class FastMLXModel:
             and list(target_modules) == ["all-linear"]
         ):
             target_modules = _collect_all_linear_target_names(model)
-            # PEFT parity: "all-linear" excludes the output layer. Drop the
-            # descriptor-resolved head's leaf name (or the unique shape-matched
-            # candidate when topology is unknown) so a raw untied lm_head /
-            # .output / embed_out is not adapted here — the head is trained
-            # explicitly via target_modules=["lm_head"] instead.
+            # PEFT parity: "all-linear" excludes the output layer, so drop the
+            # resolved head's leaf name. The head is trained explicitly via
+            # target_modules=["lm_head"] instead.
             from .utils import describe_output_head
             _hd = describe_output_head(model)
             _head_path = _hd.path or _hd.candidate_path
@@ -6227,8 +6204,8 @@ class FastMLXModel:
             ]
 
         # Filter by finetune_attention_modules / finetune_mlp_modules,
-        # whatever the source of target_modules, so these flags always apply
-        # (incl. set/frozenset/tuple selections, not just lists).
+        # whatever the source of target_modules (incl. sets/tuples, not just
+        # lists), so these flags always apply.
         if isinstance(target_modules, (list, tuple, set, frozenset)) and len(target_modules) > 0:
             _ATTN = {
                 "q_proj", "k_proj", "v_proj", "o_proj",
@@ -6248,23 +6225,19 @@ class FastMLXModel:
                 filtered.append(m)
             target_modules = filtered
 
-        # Continued-pretraining partition: embed_tokens -> full module, lm_head
-        # -> LoRA target (or full module via modules_to_save); everything else
-        # stays a layer LoRA target. Mirrors the CUDA CPT recipe
-        # (unsloth/models/llama.py:3283-3307).
+        # CPT partition: embed_tokens -> full module, lm_head -> LoRA target
+        # (or full module via modules_to_save), everything else a layer target.
         (target_modules, _cpt_full_specs, _cpt_lm_head_lora_path,
          _cpt_head_desc) = _partition_cpt_targets(
             model, target_modules, modules_to_save,
         )
-        # The lm_head LoRA key is descriptor-rooted at `model`; the VLM branch
-        # LoRAs `model.language_model`, so strip that prefix there.
+        # Descriptor-rooted at `model`; the VLM branch strips its own prefix.
         _cpt_lm_head_keys = (
             {_cpt_lm_head_lora_path} if _cpt_lm_head_lora_path else set()
         )
-        # Record the full-module weight keys (registered paths, by module
-        # identity) so the trainer scopes embedding_learning_rate to exactly
-        # these tensors regardless of the module's name or a property-backed
-        # VLM wrapper (embed_tokens / tok_embeddings / embed_in / wte / lm_head).
+        # Record the registered full-module weight keys so the trainer scopes
+        # embedding_learning_rate to exactly these tensors, whatever the
+        # module's name or VLM wrapper.
         model._unsloth_cpt_full_module_weight_keys = (
             _full_module_weight_keys(model, _cpt_full_specs)
             if _cpt_full_specs else set()
@@ -6285,8 +6258,8 @@ class FastMLXModel:
             _fix_gemma4_kv_sharing(model)
             model.freeze()
 
-            # The lm_head LoRA key is rooted at `model`; the LoRA call below
-            # targets `model.language_model`, so drop that prefix.
+            # The key is rooted at `model` but the LoRA call below targets
+            # `model.language_model`, so drop that prefix.
             _vlm_lm_head_keys = {
                 p[len("language_model."):] if p.startswith("language_model.") else p
                 for p in _cpt_lm_head_keys
@@ -6378,7 +6351,7 @@ class FastMLXModel:
 
             # Unfreeze all LoRA params across the tree.
             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
-            # Continued-pretraining full modules (embed_tokens / lm_head weight).
+            # CPT full modules (embed_tokens / lm_head weight).
             _unfreeze_full_modules(_cpt_full_specs)
         else:
             # Text-only path. _fix_missing_no_grad handles modules using
@@ -6390,22 +6363,19 @@ class FastMLXModel:
                 num_layers = len(model.model.layers)
             if finetune_last_n_layers is not None and num_layers > 0:
                 num_layers = max(1, min(int(finetune_last_n_layers), num_layers))
-            # Layer LoRA keys (empty when finetune_language_layers=False or the
-            # only targets were embed_tokens/lm_head), plus the descriptor-rooted
-            # lm_head LoRA key (a root module, not a layer submodule).
+            # Layer LoRA keys, plus the descriptor-rooted lm_head key (a root
+            # module, not a layer submodule).
             language_lora_keys = (
                 _resolve_lora_keys(model, target_modules)
                 if finetune_language_layers else None
             )
             if _cpt_lm_head_keys or _cpt_full_specs:
-                # CPT: merge the descriptor-rooted lm_head key; empty layer
-                # targets are valid when full modules / an lm_head adapter
-                # still train (never fall through to keys=None auto-discovery).
+                # Empty layer targets are valid when full modules / an lm_head
+                # adapter still train; never fall through to auto-discovery.
                 language_lora_keys = set(language_lora_keys or set()) | _cpt_lm_head_keys
                 _apply_layer_lora = len(language_lora_keys) > 0
             else:
-                # Non-CPT: preserve the original semantics exactly, including
-                # keys=None -> mlx-lm auto-discovers all supported modules.
+                # Non-CPT: keys=None still means mlx-lm auto-discovery.
                 if (finetune_language_layers and language_lora_keys is not None
                         and len(language_lora_keys) == 0):
                     _raise_no_lora_targets(target_modules)
@@ -6437,8 +6407,8 @@ class FastMLXModel:
 
             model.freeze()
             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
-            # Continued-pretraining full modules (embed_tokens / lm_head weight)
-            # train at their load dtype, scaled by embedding_learning_rate.
+            # CPT full modules train at their load dtype, scaled by
+            # embedding_learning_rate.
             _unfreeze_full_modules(_cpt_full_specs)
 
         _apply_mlx_lora_initialization(model, init_lora_weights)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4887,12 +4887,22 @@ def _full_module_weight_keys(model, full_specs):
     (e.g. Moondream3 exposes its ``text`` stack through a ``language_model``
     property, so the embedding registers at ``text.model.wte`` while the
     descriptor path reads ``language_model.model.wte``).
+
+    Descends into the selected module: a wrapper head owns no ``.weight`` of
+    its own (mlx-lm's phixtral ``OutputHead`` registers ``ln.weight`` and
+    ``linear.weight``), so recording ``<name>.weight`` there names a tensor
+    that does not exist and the scoped LR silently never applies. For a plain
+    Embedding / Linear this still yields exactly ``<name>.weight``.
     """
+    import mlx.utils as _mu
     targets = [m for _, m in full_specs]
     keys = set()
     for name, module in model.named_modules():
-        if name and any(module is t for t in targets):
-            keys.add(f"{name}.weight")
+        if not name or not any(module is t for t in targets):
+            continue
+        for leaf, _value in _mu.tree_flatten(module.parameters()):
+            if leaf == "weight" or leaf.endswith(".weight"):
+                keys.add(f"{name}.{leaf}")
     return keys
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -320,6 +320,17 @@ def linear_to_lora_layers(model, num_layers, config):
             layer.update_modules(tree_unflatten(replacements))
             attached += len(replacements)
 
+    # Root-module pass (mlx-lm parity): a head named in `keys` lives beside the
+    # layers, not inside them, so the layer walk above never reaches it.
+    root_replacements = [
+        (name, _mlx_lora_from_base(module, config, specs=type_specs))
+        for name, module in model.named_modules()
+        if name in keys
+    ]
+    if root_replacements:
+        model.update_modules(tree_unflatten(root_replacements))
+        attached += len(root_replacements)
+
     return attached
 
 
@@ -2868,6 +2879,7 @@ def _unfreeze_saved_mlx_non_adapter_parameters(model, adapter_weights_file):
     live_keys = {name for name, _ in tree_flatten(model.parameters())}
     adapter_keys = set(collect_mlx_lora_adapter_tensors(model))
     modules = {"": model, **dict(model.named_modules())}
+    restored = set()
     for path in (saved_keys & live_keys) - adapter_keys:
         parts = path.split(".")
         for split in range(len(parts) - 1, -1, -1):
@@ -2877,7 +2889,36 @@ def _unfreeze_saved_mlx_non_adapter_parameters(model, adapter_weights_file):
                 continue
             key = ".".join(parts[split:])
             module.unfreeze(keys=[key], recurse=False, strict=False)
+            restored.add(path)
             break
+    _rebuild_cpt_full_module_weight_keys(model, restored)
+
+
+def _rebuild_cpt_full_module_weight_keys(model, restored_keys):
+    """Re-derive the CPT scoped-LR key set after an adapter reload.
+
+    ``get_peft_model`` records it; this path never runs it, so without a
+    rebuild ``embedding_learning_rate`` falls back to the literal
+    ``embed_tokens`` / ``lm_head`` names and misses every other layout.
+    """
+    if not restored_keys:
+        return
+    from .utils import describe_output_head
+
+    specs = []
+    embedding, embedding_path = _resolve_embedding_module(model)
+    if embedding is not None:
+        specs.append((embedding_path, embedding))
+    head = describe_output_head(model)
+    if head.module is not None:
+        specs.append((head.path, head.module))
+    if not specs:
+        return
+    # Only tensors this reload actually made trainable: a saved weight the
+    # descriptors do not own stays on the main learning rate.
+    keys = _full_module_weight_keys(model, specs) & set(restored_keys)
+    if keys:
+        model._unsloth_cpt_full_module_weight_keys = keys
 
 
 def _saved_mlx_lora_tensor_shapes(adapter_weights_file):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2920,6 +2920,58 @@ def _rebuild_cpt_full_module_weight_keys(model, restored_keys):
         model._unsloth_cpt_full_module_weight_keys = keys
 
 
+def _is_partial_mlx_checkpoint(model, adapter_weights_file):
+    """Whether the artifact holds only part of the live parameter tree.
+
+    A whole-model save (every live tensor present) is a real full fine-tune and
+    must keep the unfrozen reload. A strict subset came from a selectively
+    frozen tree, so only those tensors should train again.
+    """
+    if not adapter_weights_file or not os.path.exists(adapter_weights_file):
+        return False
+    from safetensors import safe_open
+    from mlx.utils import tree_flatten
+
+    with safe_open(adapter_weights_file, framework="numpy") as adapter_file:
+        saved_keys = set(adapter_file.keys())
+    if not saved_keys:
+        return False
+    live_keys = {name for name, _ in tree_flatten(model.parameters())}
+    # Overlap required: a checkpoint naming nothing live is a mismatch, not a
+    # partition, and the existing missing-key check should own that error.
+    return bool(saved_keys & live_keys) and not live_keys <= saved_keys
+
+
+def _load_pathless_mlx_adapter(
+    model, local_path, adapter_weights_file, adapter_cfg, full_finetuning,
+):
+    """Reload an adapter that records no exact LoRA module paths.
+
+    Continued pretraining that trains only full modules (``embed_tokens`` /
+    ``lm_head``) builds no LoRA, so the artifact is stamped
+    ``fine_tune_type="full"`` with no paths and reload lands here. mlx-lm's
+    ``load_adapters`` binds the saved tensors but never freezes, so every base
+    parameter would come back trainable and the scoped-LR keys would be lost,
+    silently turning a resumed run into a full fine-tune. Freeze first and
+    restore trainability for exactly the tensors the checkpoint holds; a whole-
+    model artifact is a real full fine-tune and keeps the unfrozen route.
+    """
+    from mlx_lm.tuner.utils import load_adapters
+
+    partial_full_module = (
+        not full_finetuning
+        and adapter_cfg.get("fine_tune_type") == "full"
+        and _is_partial_mlx_checkpoint(model, adapter_weights_file)
+    )
+    if partial_full_module:
+        _fix_missing_no_grad(model)
+        model.freeze()
+    model = load_adapters(model, local_path)
+    if partial_full_module:
+        _unfreeze_saved_mlx_non_adapter_parameters(model, adapter_weights_file)
+    return model
+
+
 def _saved_mlx_lora_tensor_shapes(adapter_weights_file):
     """Return raw MLX LoRA A/B shapes grouped by module path."""
     if not adapter_weights_file or not os.path.exists(adapter_weights_file):
@@ -5996,9 +6048,10 @@ class FastMLXModel:
                             model, adapter_weights_file,
                         )
                     else:
-                        from mlx_lm.tuner.utils import load_adapters
-
-                        model = load_adapters(model, local_path)
+                        model = _load_pathless_mlx_adapter(
+                            model, local_path, adapter_weights_file,
+                            adapter_cfg, full_finetuning,
+                        )
                         if os.path.exists(adapter_weights_file):
                             _missing_after_load = _warn_missing_adapter_keys(
                                 model, adapter_weights_file,
@@ -6498,10 +6551,25 @@ class FastMLXModel:
         # vision linears, projector, untied lm_head). Walk the tree for those
         # names rather than collapsing to the canonical 7, which would leave
         # fused-attention archs and MoEs mostly un-LoRA'd.
-        if target_modules == "all-linear" or (
-            isinstance(target_modules, (list, tuple, set, frozenset))
-            and list(target_modules) == ["all-linear"]
-        ):
+        # The sentinel also has to expand inside a mixed list: the CPT recipe
+        # spells continued pretraining as target_modules=["all-linear",
+        # "embed_tokens", "lm_head"], and a literal "all-linear" left in that
+        # list matches no module, so every layer adapter would be dropped.
+        if isinstance(target_modules, str):
+            _expand_all_linear = target_modules == "all-linear"
+            _kept_targets = []
+        elif isinstance(target_modules, (list, tuple, set, frozenset)):
+            _tm_entries = list(target_modules)
+            _expand_all_linear = "all-linear" in _tm_entries
+            # dedup, keep order; the sentinel itself is never a module name.
+            _kept_targets = list(dict.fromkeys(
+                m for m in _tm_entries if m != "all-linear"
+            ))
+        else:
+            _expand_all_linear = False
+            _kept_targets = []
+
+        if _expand_all_linear:
             target_modules = _collect_all_linear_target_names(model)
             # PEFT parity: "all-linear" excludes the output layer; the head is
             # trained explicitly via target_modules=["lm_head"].
@@ -6517,6 +6585,11 @@ class FastMLXModel:
                     "q_proj", "k_proj", "v_proj", "o_proj",
                     "gate_proj", "up_proj", "down_proj",
                 ]
+            # Re-add the co-requested names (embed_tokens / lm_head / an extra
+            # module) that the expansion above does not cover.
+            target_modules = target_modules + [
+                m for m in _kept_targets if m not in target_modules
+            ]
 
         if target_modules is None:
             target_modules = [

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4116,16 +4116,31 @@ def _mlx_save_lora_adapters(self, path, adapter_config=None):
     import mlx.utils as _mu
     from .utils import (
         save_lora_adapters, save_trainable_adapters,
-        collect_mlx_lora_adapter_tensors,
+        collect_mlx_lora_adapter_tensors, iter_mlx_lora_modules,
+        _is_base_tensor_inside_lora_module,
     )
     # Continued pretraining trains full modules (embed_tokens / lm_head weight)
     # that are not LoRA tensors; the LoRA-only writer would silently drop them
-    # and reload would revert to the base weight. Detect any trainable non-LoRA
-    # tensor directly (robust to a reloaded model that no longer carries the
-    # get_peft_model marker) and route through the trainable-tensor writer.
+    # and reload would revert to the base weight. Detect a trainable non-LoRA
+    # tensor in a selectively frozen tree and route through the trainable-tensor
+    # writer (no get_peft_model marker needed).
     _trainable = dict(_mu.tree_flatten(self.trainable_parameters()))
+    _all = dict(_mu.tree_flatten(self.parameters()))
     _lora = set(collect_mlx_lora_adapter_tensors(self))
-    _has_full_module = any(k not in _lora for k in _trainable)
+    _lora_names = [name for name, _ in iter_mlx_lora_modules(self)]
+    _lora_prefixes = tuple(f"{name}." for name in _lora_names if name)
+    _root_lora = any(name == "" for name in _lora_names)
+    # A model nothing has frozen (a plain base model, or one whose adapters
+    # were just reloaded) reports EVERY parameter as trainable, which is not
+    # continued-pretraining evidence: keep the LoRA-only writer there instead
+    # of dumping the whole base model into adapters.safetensors. The wrapped-
+    # base filter matches MLXTrainer.save_model so a reload-leaked q_proj.weight
+    # under a LoRA-wrapped q_proj does not count either.
+    _has_full_module = len(_trainable) < len(_all) and any(
+        k not in _lora
+        and not _is_base_tensor_inside_lora_module(k, _lora_prefixes, _root_lora)
+        for k in _trainable
+    )
     if _has_full_module:
         save_trainable_adapters(self, path, adapter_config=adapter_config)
     else:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4776,29 +4776,44 @@ def _partition_cpt_targets(model, target_modules, modules_to_save):
             )
         _add_full(emb_path, emb)
 
+    lora_targets = [m for m in tm if m not in ("embed_tokens", "lm_head")]
+
     lm_head_lora_path = None
     if "lm_head" in tm or "lm_head" in mts:
+        unusable = None
         if tied:
             # The tied output head shares embed_tokens' weight, so it trains via
             # the embed_tokens full module. Accept the common recipe
             # target_modules=[..., "embed_tokens", "lm_head"] by treating a
-            # co-requested lm_head as already selected; reject only a standalone
-            # lm_head, which cannot train the head without the shared embedding.
+            # co-requested lm_head as already selected.
             if "embed_tokens" not in tm and "embed_tokens" not in mts:
-                raise ValueError(
+                unusable = (
                     "Unsloth: lm_head cannot be trained separately on a tied-"
                     "embedding model — the output head shares embed_tokens' "
                     "weight. Add 'embed_tokens' to target_modules to train the "
                     "shared matrix."
                 )
         elif desc.module is None:
-            _raise_no_lora_targets(["lm_head"])
+            unusable = (
+                "Unsloth: the output head could not be resolved on this model, "
+                "so lm_head cannot be trained. Use target_modules='all-linear' "
+                "or name the head's own module (for example 'output' or "
+                "'embed_out') instead."
+            )
         elif "lm_head" in mts:            # precedence: modules_to_save -> full module
             _add_full(desc.path, desc.module)
         else:                            # target_modules -> LoRA on the head Linear
             lm_head_lora_path = desc.path
+        if unusable is not None:
+            # modules_to_save names one module and nothing else, so an
+            # unusable head there is unambiguous and must fail loudly. In
+            # target_modules it is one entry among many: dropping it while the
+            # other targets still train preserves the pre-CPT behaviour instead
+            # of aborting a run that used to work.
+            if "lm_head" in mts or not (lora_targets or full_specs):
+                raise ValueError(unusable)
+            warnings.warn(unusable, stacklevel=3)
 
-    lora_targets = [m for m in tm if m not in ("embed_tokens", "lm_head")]
     return lora_targets, full_specs, lm_head_lora_path, desc
 
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2597,7 +2597,13 @@ class MLXTrainer:
             model, "_unsloth_cpt_full_module_weight_keys", None) or set()
 
         def _scoped_step_ratio(name):
-            if use_lora_plus and (name == "lora_b" or name.endswith(".lora_b")):
+            # mlx-lm may wrap the LoRA halves in nn.Linear children, flattening
+            # lora_b to `...lora_b.weight` (the layout loader.py / utils.py
+            # already unwrap); match it too so LoRA+ scales that layout as well.
+            if use_lora_plus and (
+                name == "lora_b" or name.endswith(".lora_b")
+                or name == "lora_b.weight" or name.endswith(".lora_b.weight")
+            ):
                 return lora_plus_ratio
             if use_embedding_lr:
                 if name in _cpt_full_keys:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2579,6 +2579,55 @@ class MLXTrainer:
 
         _needs_grad_scaling = use_lora_plus or use_embedding_lr
 
+        # --- Per-group LR via post-update STEP rescale (not gradient scaling) ---
+        # The update-normalizing optimizers (AdamW/Adam/Lion/Adafactor, and Muon
+        # for rank->=2 matrices) are scale-invariant to a constant gradient
+        # scale, so applying LoRA+ / embedding-LR ratios to the gradient is a
+        # near no-op. Instead, let the single optimizer take its normal step,
+        # then rescale the realized delta of the scoped params:
+        # ``param = pre + ratio*(post - pre)``. This yields effective LR
+        # ``ratio*base_lr`` for ANY optimizer, scales the decoupled decay along
+        # with the step (the snapshot precedes it), and adds no optimizer state.
+        # Scoped keys: LoRA+ -> ``lora_b``; embedding LR -> the full-module
+        # embed_tokens/lm_head weight (registered keys recorded by
+        # get_peft_model's CPT partition when present, else the literal
+        # ``<...>.embed_tokens/lm_head.weight`` fallback).
+        _cpt_full_keys = getattr(
+            model, "_unsloth_cpt_full_module_weight_keys", None) or set()
+
+        def _scoped_step_ratio(name):
+            if use_lora_plus and (name == "lora_b" or name.endswith(".lora_b")):
+                return lora_plus_ratio
+            if use_embedding_lr:
+                if name in _cpt_full_keys:
+                    return embedding_lr_ratio
+                _seg = name.split(".")
+                if (len(_seg) >= 2 and _seg[-1] == "weight"
+                        and _seg[-2] in ("embed_tokens", "lm_head")):
+                    return embedding_lr_ratio
+            return None
+
+        def _snapshot_scoped_params():
+            """Pre-update values (immutable mx arrays) + ratio for scoped leaves,
+            captured before decoupled decay so the rescale scales decay too."""
+            snap = {}
+            for name, value in tree_flatten(model.trainable_parameters()):
+                r = _scoped_step_ratio(name)
+                if r is not None:
+                    snap[name] = (value, r)
+            return snap
+
+        def _rescale_scoped_params(snap):
+            if not snap:
+                return
+            live = dict(tree_flatten(model.trainable_parameters()))
+            updates = []
+            for name, (pre, ratio) in snap.items():
+                post = live[name]
+                r = mx.array(ratio, dtype=mx.float32).astype(post.dtype)
+                updates.append((name, pre + r * (post - pre)))
+            model.update(tree_unflatten(updates))
+
         # Build step functions following mlx-lm's pattern. `max_grad_value`
         # remains an elementwise clamp. MLX's cheap default is now the clearer
         # `max_grad_leaf_norm`, a proportional per-leaf norm cap that avoids
@@ -2663,18 +2712,11 @@ class MLXTrainer:
             optimizer.update to promote params/m/v too).
             """
             scale = mx.array(1.0, dtype=mx.float32) / safe_toks_f
-            # Suffix-anchor so lora_b_router.weight doesn't pick up the LoRA+ mult.
-            if use_lora_plus and (name == "lora_b" or name.endswith(".lora_b")):
-                scale = scale * lora_plus_ratio
-            # Segment-anchor so not_lm_head_router.weight doesn't pick up embed LR.
-            if use_embedding_lr:
-                _segments = name.split(".")
-                _is_embed_or_lm_head = (
-                    "embed_tokens" in _segments
-                    or "lm_head" in _segments
-                )
-                if _is_embed_or_lm_head:
-                    scale = scale * embedding_lr_ratio
+            # NOTE: the per-group LoRA+ / embedding-LR ratios are NOT applied
+            # here. Scaling the gradient is a near no-op under the update-
+            # normalizing optimizers (AdamW/Lion/Adafactor/Muon), so those
+            # ratios are applied as a post-update STEP rescale instead (see
+            # _snapshot_scoped_params / _rescale_scoped_params).
             if clip_scale is not None:
                 scale = scale * clip_scale
             if dtype is not None and scale.dtype != dtype:
@@ -2714,11 +2756,17 @@ class MLXTrainer:
                 final_grad = _clip_grad_by_value(final_grad, max_grad_value)
             if _clip_grad_leaf_norm:
                 final_grad = _clip_grad_by_leaf_norm(final_grad, max_grad_leaf_norm)
+            # Snapshot the scoped params BEFORE decay so the post-update rescale
+            # scales the whole realized delta (decoupled decay + optimizer step)
+            # by the per-group ratio (LoRA+ / embedding-LR).
+            _scoped_snap = _snapshot_scoped_params() if _needs_grad_scaling else None
             # Coupled (SGD) decay folds into the post-clip grad so it feeds
             # momentum; decoupled (AdamW-family) decay shrinks params directly.
             final_grad = self._apply_coupled_weight_decay(model, final_grad)
             self._apply_manual_weight_decay(model, optimizer, final_grad)
             optimizer.update(model, final_grad)
+            if _scoped_snap:
+                _rescale_scoped_params(_scoped_snap)
             _restore_trainable_storage_dtypes()
             return grad_norm
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2561,7 +2561,7 @@ class MLXTrainer:
         # Build loss+grad function — returns ((loss, ntoks), grads)
         loss_and_grad_fn = nn.value_and_grad(model, loss_fn)
 
-        # Per-parameter gradient scaling (LoRA+, embedding LR)
+        # Per-group learning rates (LoRA+, embedding LR) via post-update rescale
         lora_plus_ratio = args.lora_plus_ratio
         use_lora_plus = lora_plus_ratio > 0
         if use_lora_plus:
@@ -2578,11 +2578,11 @@ class MLXTrainer:
                 f"(ratio={embedding_lr_ratio:.3f} of main LR {main_lr:.2e})."
             )
 
-        _needs_grad_scaling = use_lora_plus or use_embedding_lr
+        _scoped_lr_requested = use_lora_plus or use_embedding_lr
 
         # --- Per-group LR via post-update STEP rescale (not gradient scaling) ---
         # The update-normalizing optimizers (AdamW/Adam/Lion/Adafactor, and Muon
-        # for rank->=2 matrices) are scale-invariant to a constant gradient
+        # for rank>=2 matrices) are scale-invariant to a constant gradient
         # scale, so applying LoRA+ / embedding-LR ratios to the gradient is a
         # near no-op. Instead, let the single optimizer take its normal step,
         # then rescale the realized delta of the scoped params:
@@ -2618,7 +2618,7 @@ class MLXTrainer:
         # scoped leaves once here rather than re-running _scoped_step_ratio over
         # the whole tree every optimizer step.
         _scoped_ratios = {}
-        if _needs_grad_scaling:
+        if _scoped_lr_requested:
             for name, _value in tree_flatten(model.trainable_parameters()):
                 r = _scoped_step_ratio(name)
                 # ratio == 1.0 is a no-op rescale (pre + 1*(post-pre) == post);
@@ -2626,6 +2626,11 @@ class MLXTrainer:
                 # scoped LR equals the base LR.
                 if r is not None and r != 1.0:
                     _scoped_ratios[name] = r
+        # True only when some scoped leaf actually needs rescaling. A requested
+        # but no-op ratio (lora_plus_ratio=1.0, or embedding_learning_rate ==
+        # learning_rate) leaves this False, so it neither snapshots anything nor
+        # disables the single-step fast path below.
+        _needs_step_rescale = bool(_scoped_ratios)
 
         def _snapshot_scoped_params():
             """Pre-update values (immutable mx arrays) + ratio for scoped leaves,
@@ -2693,7 +2698,7 @@ class MLXTrainer:
         _direct_single_step_update = (
             grad_accum == 1 and
             distributed_world_size <= 1 and
-            not _needs_grad_scaling and
+            not _needs_step_rescale and
             max_grad_norm <= 0 and
             not _clip_grad_value and
             not _clip_grad_leaf_norm
@@ -2781,7 +2786,7 @@ class MLXTrainer:
             # Snapshot the scoped params BEFORE decay so the post-update rescale
             # scales the whole realized delta (decoupled decay + optimizer step)
             # by the per-group ratio (LoRA+ / embedding-LR).
-            _scoped_snap = _snapshot_scoped_params() if _needs_grad_scaling else None
+            _scoped_snap = _snapshot_scoped_params() if _needs_step_rescale else None
             # Coupled (SGD) decay folds into the post-clip grad so it feeds
             # momentum; decoupled (AdamW-family) decay shrinks params directly.
             final_grad = self._apply_coupled_weight_decay(model, final_grad)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -666,9 +666,10 @@ class MLXTrainingConfig:
     # reporting reduction exists in the graph; grad_norm is absent from
     # console/W&B/TB, _grad_norm_history, and the legacy step callback (None).
     # Reporting never changes update numerics; the reported value is the fp32
-    # norm of the token-normalized gradient — after the accumulation divide,
-    # DDP reduction, and the LoRA+/embedding-LR ratios; before any clipping or
-    # weight decay.
+    # norm of the token-normalized gradient — after the accumulation divide and
+    # DDP reduction; before any clipping, weight decay, the optimizer update, and
+    # the LoRA+/embedding-LR post-update step rescale (which no longer scales the
+    # gradient).
     report_grad_norm: bool = False
 
     def __init__(self, *args, **kwargs):
@@ -2607,12 +2608,27 @@ class MLXTrainer:
                     return embedding_lr_ratio
             return None
 
+        # The trainable set is fixed after get_peft_model, so classify the
+        # scoped leaves once here rather than re-running _scoped_step_ratio over
+        # the whole tree every optimizer step.
+        _scoped_ratios = {}
+        if _needs_grad_scaling:
+            for name, _value in tree_flatten(model.trainable_parameters()):
+                r = _scoped_step_ratio(name)
+                # ratio == 1.0 is a no-op rescale (pre + 1*(post-pre) == post);
+                # skip it so no large full-module tensor is snapshotted when the
+                # scoped LR equals the base LR.
+                if r is not None and r != 1.0:
+                    _scoped_ratios[name] = r
+
         def _snapshot_scoped_params():
             """Pre-update values (immutable mx arrays) + ratio for scoped leaves,
             captured before decoupled decay so the rescale scales decay too."""
+            if not _scoped_ratios:
+                return {}
             snap = {}
             for name, value in tree_flatten(model.trainable_parameters()):
-                r = _scoped_step_ratio(name)
+                r = _scoped_ratios.get(name)
                 if r is not None:
                     snap[name] = (value, r)
             return snap

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -667,9 +667,8 @@ class MLXTrainingConfig:
     # console/W&B/TB, _grad_norm_history, and the legacy step callback (None).
     # Reporting never changes update numerics; the reported value is the fp32
     # norm of the token-normalized gradient — after the accumulation divide and
-    # DDP reduction; before any clipping, weight decay, the optimizer update, and
-    # the LoRA+/embedding-LR post-update step rescale (which no longer scales the
-    # gradient).
+    # DDP reduction; before clipping, weight decay, the optimizer update and the
+    # LoRA+/embedding-LR post-update step rescale.
     report_grad_norm: bool = False
 
     def __init__(self, *args, **kwargs):
@@ -2581,25 +2580,21 @@ class MLXTrainer:
         _scoped_lr_requested = use_lora_plus or use_embedding_lr
 
         # --- Per-group LR via post-update STEP rescale (not gradient scaling) ---
-        # The update-normalizing optimizers (AdamW/Adam/Lion/Adafactor, and Muon
-        # for rank>=2 matrices) are scale-invariant to a constant gradient
-        # scale, so applying LoRA+ / embedding-LR ratios to the gradient is a
-        # near no-op. Instead, let the single optimizer take its normal step,
-        # then rescale the realized delta of the scoped params:
-        # ``param = pre + ratio*(post - pre)``. This yields effective LR
+        # Update-normalizing optimizers (AdamW/Adam/Lion/Adafactor, Muon for
+        # rank>=2) are scale-invariant to a constant gradient scale, so scaling
+        # the gradient is a near no-op. Instead let the optimizer take its
+        # normal step, then rescale the realized delta of the scoped params:
+        # ``param = pre + ratio*(post - pre)``. That gives effective LR
         # ``ratio*base_lr`` for ANY optimizer, scales the decoupled decay along
-        # with the step (the snapshot precedes it), and adds no optimizer state.
-        # Scoped keys: LoRA+ -> ``lora_b``; embedding LR -> the full-module
-        # embed_tokens/lm_head weight (registered keys recorded by
-        # get_peft_model's CPT partition when present, else the literal
-        # ``<...>.embed_tokens/lm_head.weight`` fallback).
+        # with the step, and adds no optimizer state. Scoped keys: LoRA+ ->
+        # ``lora_b``; embedding LR -> the full-module embed_tokens/lm_head
+        # weight (keys recorded by the CPT partition, else a literal fallback).
         _cpt_full_keys = getattr(
             model, "_unsloth_cpt_full_module_weight_keys", None) or set()
 
         def _scoped_step_ratio(name):
             # mlx-lm may wrap the LoRA halves in nn.Linear children, flattening
-            # lora_b to `...lora_b.weight` (the layout loader.py / utils.py
-            # already unwrap); match it too so LoRA+ scales that layout as well.
+            # lora_b to `...lora_b.weight`; match that layout too.
             if use_lora_plus and (
                 name == "lora_b" or name.endswith(".lora_b")
                 or name == "lora_b.weight" or name.endswith(".lora_b.weight")
@@ -2615,26 +2610,22 @@ class MLXTrainer:
             return None
 
         # The trainable set is fixed after get_peft_model, so classify the
-        # scoped leaves once here rather than re-running _scoped_step_ratio over
-        # the whole tree every optimizer step.
+        # scoped leaves once instead of re-walking the tree every step.
         _scoped_ratios = {}
         if _scoped_lr_requested:
             for name, _value in tree_flatten(model.trainable_parameters()):
                 r = _scoped_step_ratio(name)
-                # ratio == 1.0 is a no-op rescale (pre + 1*(post-pre) == post);
-                # skip it so no large full-module tensor is snapshotted when the
-                # scoped LR equals the base LR.
+                # ratio == 1.0 is a no-op; skip it so no large full-module
+                # tensor is snapshotted when the scoped LR is the base LR.
                 if r is not None and r != 1.0:
                     _scoped_ratios[name] = r
-        # True only when some scoped leaf actually needs rescaling. A requested
-        # but no-op ratio (lora_plus_ratio=1.0, or embedding_learning_rate ==
-        # learning_rate) leaves this False, so it neither snapshots anything nor
-        # disables the single-step fast path below.
+        # True only when some scoped leaf actually needs rescaling, so a no-op
+        # ratio neither snapshots anything nor disables the fast path below.
         _needs_step_rescale = bool(_scoped_ratios)
 
         def _snapshot_scoped_params():
-            """Pre-update values (immutable mx arrays) + ratio for scoped leaves,
-            captured before decoupled decay so the rescale scales decay too."""
+            """Pre-update values + ratio per scoped leaf, captured before
+            decoupled decay so the rescale scales the decay too."""
             if not _scoped_ratios:
                 return {}
             snap = {}
@@ -2739,10 +2730,9 @@ class MLXTrainer:
             optimizer.update to promote params/m/v too).
             """
             scale = mx.array(1.0, dtype=mx.float32) / safe_toks_f
-            # NOTE: the per-group LoRA+ / embedding-LR ratios are NOT applied
-            # here. Scaling the gradient is a near no-op under the update-
-            # normalizing optimizers (AdamW/Lion/Adafactor/Muon), so those
-            # ratios are applied as a post-update STEP rescale instead (see
+            # The LoRA+ / embedding-LR ratios are NOT applied here: scaling the
+            # gradient is a near no-op under update-normalizing optimizers, so
+            # they are applied as a post-update step rescale instead (see
             # _snapshot_scoped_params / _rescale_scoped_params).
             if clip_scale is not None:
                 scale = scale * clip_scale
@@ -2783,9 +2773,8 @@ class MLXTrainer:
                 final_grad = _clip_grad_by_value(final_grad, max_grad_value)
             if _clip_grad_leaf_norm:
                 final_grad = _clip_grad_by_leaf_norm(final_grad, max_grad_leaf_norm)
-            # Snapshot the scoped params BEFORE decay so the post-update rescale
-            # scales the whole realized delta (decoupled decay + optimizer step)
-            # by the per-group ratio (LoRA+ / embedding-LR).
+            # Snapshot BEFORE decay so the rescale scales the whole realized
+            # delta (decoupled decay + optimizer step) by the per-group ratio.
             _scoped_snap = _snapshot_scoped_params() if _needs_step_rescale else None
             # Coupled (SGD) decay folds into the post-clip grad so it feeds
             # momentum; decoupled (AdamW-family) decay shrinks params directly.

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -840,8 +840,7 @@ class MLXTrainingConfig:
     # console/W&B/TB, _grad_norm_history, and the legacy step callback (None).
     # Reporting never changes update numerics; the reported value is the fp32
     # norm of the token-normalized gradient — after the accumulation divide and
-    # DDP reduction; before clipping, weight decay, the optimizer update and the
-    # LoRA+/embedding-LR post-update step rescale.
+    # DDP reduction; before clipping, decay, the update and the scoped-LR rescale.
     report_grad_norm: bool = False
 
     # Lazy-streaming fields, appended LAST after every pre-existing field so
@@ -3029,22 +3028,19 @@ class MLXTrainer:
 
         _scoped_lr_requested = use_lora_plus or use_embedding_lr
 
-        # --- Per-group LR via post-update STEP rescale (not gradient scaling) ---
-        # Update-normalizing optimizers (AdamW/Adam/Lion/Adafactor, Muon for
-        # rank>=2) are scale-invariant to a constant gradient scale, so scaling
-        # the gradient is a near no-op. Instead let the optimizer take its
-        # normal step, then rescale the realized delta of the scoped params:
-        # ``param = pre + ratio*(post - pre)``. That gives effective LR
-        # ``ratio*base_lr`` for ANY optimizer, scales the decoupled decay along
-        # with the step, and adds no optimizer state. Scoped keys: LoRA+ ->
-        # ``lora_b``; embedding LR -> the full-module embed_tokens/lm_head
-        # weight (keys recorded by the CPT partition, else a literal fallback).
+        # Per-group LR via post-update STEP rescale, not gradient scaling:
+        # update-normalizing optimizers (AdamW/Lion/Adafactor, Muon rank>=2) are
+        # invariant to a constant gradient scale. Rescaling the realized delta
+        # (``param = pre + ratio*(post - pre)``) gives effective LR
+        # ``ratio*base_lr`` for ANY optimizer, scales the decoupled decay with
+        # the step, and adds no optimizer state. Scoped keys: LoRA+ -> lora_b;
+        # embedding LR -> the CPT full-module keys, else a literal fallback.
         _cpt_full_keys = getattr(
             model, "_unsloth_cpt_full_module_weight_keys", None) or set()
 
         def _scoped_step_ratio(name):
             # mlx-lm may wrap the LoRA halves in nn.Linear children, flattening
-            # lora_b to `...lora_b.weight`; match that layout too.
+            # lora_b to `...lora_b.weight`.
             if use_lora_plus and (
                 name == "lora_b" or name.endswith(".lora_b")
                 or name == "lora_b.weight" or name.endswith(".lora_b.weight")
@@ -3059,18 +3055,15 @@ class MLXTrainer:
                     return embedding_lr_ratio
             return None
 
-        # The trainable set is fixed after get_peft_model, so classify the
-        # scoped leaves once instead of re-walking the tree every step.
+        # The trainable set is fixed after get_peft_model, so classify once.
         _scoped_ratios = {}
         if _scoped_lr_requested:
             for name, _value in tree_flatten(model.trainable_parameters()):
                 r = _scoped_step_ratio(name)
-                # ratio == 1.0 is a no-op; skip it so no large full-module
-                # tensor is snapshotted when the scoped LR is the base LR.
+                # ratio == 1.0 is a no-op; skip it so nothing large is snapshotted.
                 if r is not None and r != 1.0:
                     _scoped_ratios[name] = r
-        # True only when some scoped leaf actually needs rescaling, so a no-op
-        # ratio neither snapshots anything nor disables the fast path below.
+        # A no-op ratio then neither snapshots anything nor disables the fast path.
         _needs_step_rescale = bool(_scoped_ratios)
 
         def _snapshot_scoped_params():
@@ -3180,10 +3173,8 @@ class MLXTrainer:
             optimizer.update to promote params/m/v too).
             """
             scale = mx.array(1.0, dtype=mx.float32) / safe_toks_f
-            # The LoRA+ / embedding-LR ratios are NOT applied here: scaling the
-            # gradient is a near no-op under update-normalizing optimizers, so
-            # they are applied as a post-update step rescale instead (see
-            # _snapshot_scoped_params / _rescale_scoped_params).
+            # Scoped ratios are NOT applied here: gradient scaling is a near
+            # no-op under update-normalizing optimizers (see the step rescale).
             if clip_scale is not None:
                 scale = scale * clip_scale
             if dtype is not None and scale.dtype != dtype:
@@ -3223,8 +3214,7 @@ class MLXTrainer:
                 final_grad = _clip_grad_by_value(final_grad, max_grad_value)
             if _clip_grad_leaf_norm:
                 final_grad = _clip_grad_by_leaf_norm(final_grad, max_grad_leaf_norm)
-            # Snapshot BEFORE decay so the rescale scales the whole realized
-            # delta (decoupled decay + optimizer step) by the per-group ratio.
+            # Snapshot BEFORE decay so the rescale covers decay + optimizer step.
             _scoped_snap = _snapshot_scoped_params() if _needs_step_rescale else None
             # Coupled (SGD) decay folds into the post-clip grad so it feeds
             # momentum; decoupled (AdamW-family) decay shrinks params directly.


### PR DESCRIPTION
## Summary

This adds continued-pretraining (CPT) support to the MLX backend, reproducing the CUDA continued-pretraining recipe on Apple Silicon, and fixes a latent correctness bug that made a separate `embedding_learning_rate` (and `lora_plus_ratio`) silently inert under Adam-family optimizers. An `embed_tokens` target now trains the token embedding as a full module (the `modules_to_save` analog), and an `lm_head` target trains the output head — as a LoRA adapter by default, or as a full module when routed through a new `modules_to_save` argument that takes precedence over `target_modules` on overlap.

## What changed

### Continued-pretraining partition (`loader.py`)

`get_peft_model` now builds the CUDA-parity CPT partition from the live output-head descriptor rather than by string-matching module names:

- `embed_tokens` → trained as a full module (weight trainable), matching CUDA's `modules_to_save` treatment; the reduced `embedding_learning_rate` applies to this weight only.
- `lm_head` → a LoRA adapter on the output-head `Linear` by default, or a full module when requested through `modules_to_save`.
- Tied-embedding models train the shared matrix via `embed_tokens`; a separate `lm_head` request is rejected with a clear error, because a tied head has no independent storage to train (mlx-lm deletes the tied head module).
- Alt-named embeddings (for example InternLM2 `tok_embeddings`) resolve by module type, so property-backed and renamed embeddings are covered rather than missed by a name match.
- A quantized embedding or head is rejected for full-module training up front: the fused CCE backward zeroes the quantized weight gradient, so such a module would silently never update.
- `all-linear` now excludes the resolved output head, matching PEFT semantics.
- Full-module weights train at their load dtype and are captured by the existing trainable-adapter checkpoint path, so save/reload round-trips the embedding and head.

### Separate embedding / LoRA+ learning rate applied as a step rescale, not a gradient scale (`trainer.py`)

Previously `embedding_learning_rate` and `lora_plus_ratio` were applied as a constant multiplier on the per-leaf gradient before `optimizer.update`. Adam, AdamW, Lion, and Adafactor — and Muon for matrix parameters — are invariant to a constant gradient scale: scaling the gradient by `c` scales the first moment by `c` and the second-moment square-root by `c`, leaving the `m / sqrt(v)` update unchanged. The multiplier therefore had essentially no effect on the realized step, so the separate embedding learning rate was silently inert.

The ratio is now applied as a post-update step rescale on the scoped parameters (full-module `embed_tokens` / `lm_head` weights, and `lora_b` under LoRA+): the realized update is rescaled as `param = pre + ratio * (post - pre)`. This makes the separate learning rate effective for any optimizer, applies after gradient clipping (matching the CUDA ordering), and leaves the reported gradient norm as the raw pre-rescale value. Plain single-learning-rate LoRA is unaffected — the rescale path is inert when no ratio is configured.


## Validation: matched-optimizer CUDA comparison

Every comparison uses a matched optimizer on both sides — MLX standard `adamw` versus CUDA PyTorch `adamw_torch`, weight decay `0.0` — with matched learning rates, schedule, batch recipe, data order, inputs, and trainable topology, so no result is confounded by an optimizer-class difference. MLX ran on real Apple Metal with BF16 weights; trainable-parameter counts and tokenization/input hashes matched across backends in every run.

| Model / path | Trainable params | Loss final gap | Loss MAE | Loss Pearson r | Grad-norm Pearson r | Embedding MLX/CUDA |
|---|---:|---:|---:|---:|---:|---:|
| Qwen3-0.6B tied text (60 steps) | 165,675,008 | 0.0270 | 0.1446 | 0.9794 | 0.9447 | caveated (see below) |
| Qwen3.5-0.8B text-only VLM (60 steps) | 261,554,176 | 0.0322 | 0.0689 | 0.9955 | 0.9897 | 0.9637x |
| Qwen3.5-0.8B image VLM (24 steps) | 264,077,312 | 0.0798 | 0.0353 | 0.9994 | 0.9975 | 1.0930x |
| TinyLlama-1.1B untied text (60 steps) | 78,696,448 | 0.0971 | 0.1349 | 0.9770 | 0.8484 | 0.9908x |

**Full-module embedding movement tracks CUDA.** The reduced embedding learning rate produces the right amount of embedding movement: the full-module embedding endpoint agrees with CUDA within 1% on the untied model (`0.048496` vs `0.048944`, 0.9908x) and within 3.6% on the text-only VLM (`0.633742` vs `0.657617`, 0.9637x). The tied Qwen3-0.6B endpoint is not a valid parity reference because that CUDA PEFT path did not preserve shared input/output storage (MLX `0.567580` vs CUDA `0.020051`); its loss trajectory still tracks CUDA closely, and the text-only VLM — where CUDA explicitly restored tied active input/output storage — provides the valid tied comparison.

**Image-conditioned CPT matches CUDA end to end.** The image VLM run trained 24 matched steps on eight pinned `lmms-lab/COCO-Caption2017` photographs (varied dimensions: `256x352`, `352x256`, `384x256`), with both backends consuming identical processed PNG bytes, token IDs, labels, pixel shapes, and visual grids. Every trainable component moved on both backends and agrees within 9.3%:

| Component | MLX / CUDA delta L2 ratio |
|---|---:|
| Full language embedding | 1.0930x |
| Language LoRA | 1.0192x |
| Vision-attention LoRA | 1.0101x |
| Vision-MLP LoRA | 1.0459x |
| Visual merger/projector LoRA | 1.0480x |

All 100 visual adapter tensors moved on both backends (including the nested merger/projector), and representative visual base weights stayed frozen, as expected for LoRA.

## Risks and limitations

- These are 24-to-60-step matched-optimizer development-gate comparisons, not convergence studies; long-run convergence was not evaluated.
- The tied Qwen3-0.6B embedding endpoint is not a valid shared-matrix parity reference because that CUDA PEFT path did not preserve shared input/output storage; loss parity still holds, and the text-only VLM provides the valid tied embedding comparison.

## Test plan

- `tests/test_mlx_cpt_partition_metal.py` — CPT partition, tied-model rejection, and full-module save/reload on real Metal (skips under the CPU simulation shim).
- `tests/test_mlx_training_e2e_metal.py::test_lora_plus_ratio_scales_the_lora_b_step` — end-to-end proof that the ratio scales the realized `lora_b` step (the same rescale path used for the embedding LR).
- Matched-optimizer real-model CUDA comparison summarized above.


