### PR TITLE
Fix allocator fragmentation on Windows/WSL and correct the torch 2.10 alloc conf boundary

### DIFF
--- a/tests/test_alloc_conf_platform_matrix.py
+++ b/tests/test_alloc_conf_platform_matrix.py
@@ -45,7 +45,18 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 _CHILD = textwrap.dedent(
     """
-    import os, json, importlib.metadata as _m
+    import os, sys, types, json, importlib.metadata as _m, importlib.util, importlib.machinery
+    # unsloth_zoo.__init__ requires find_spec("unsloth"); stub it so this fresh
+    # subprocess is self-contained even when unsloth is not installed.
+    try:
+        _has_unsloth = importlib.util.find_spec("unsloth") is not None
+    except Exception:
+        _has_unsloth = False
+    if not _has_unsloth:
+        _u = types.ModuleType("unsloth")
+        _u.__spec__ = importlib.machinery.ModuleSpec("unsloth", loader=None)
+        _u.__path__ = []
+        sys.modules["unsloth"] = _u
     _real = _m.version
     _fake_torch = os.environ.pop("_FAKE_TORCH_VERSION", "") or None
     def _version(name, *a, **k):
@@ -60,15 +71,14 @@ _CHILD = textwrap.dedent(
     # DEVICE_TYPE / is_hip (which gate the fallback) are what the block reads.
     _fake_dev = os.environ.pop("_FAKE_DEVICE", "") or None
     if _fake_dev:
-        import sys as _sys, types as _types
-        _dt = _types.ModuleType("unsloth_zoo.device_type")
+        _dt = types.ModuleType("unsloth_zoo.device_type")
         _dt.is_hip = lambda: _fake_dev == "hip"
         _dt.get_device_type = lambda: _fake_dev
         _dt.DEVICE_TYPE = _fake_dev
         _dt.DEVICE_TYPE_TORCH = "cuda"
         _dt.DEVICE_COUNT = 1
         _dt.ALLOW_PREQUANTIZED_MODELS = True
-        _sys.modules["unsloth_zoo.device_type"] = _dt
+        sys.modules["unsloth_zoo.device_type"] = _dt
     import unsloth_zoo  # runs the import-time allocator block
     print("RESULT:" + json.dumps(
         {k: os.environ.get(k) for k in
@@ -85,6 +95,7 @@ def _conf(*, torch_version, wsl=False, wsl_interop=False, windows=False,
     env = {k: v for k, v in os.environ.items() if k not in _WIPE and k != "_FAKE_TORCH_VERSION"}
     env["_FAKE_TORCH_VERSION"] = torch_version
     env["CUDA_VISIBLE_DEVICES"] = env.get("CUDA_VISIBLE_DEVICES", "0")
+    env.setdefault("UNSLOTH_ALLOW_CPU", "1")   # import unsloth_zoo without a real GPU
     env["PYTHONPATH"] = _REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
     if wsl:
         env["WSL_DISTRO_NAME"] = "Ubuntu"
@@ -207,6 +218,18 @@ class TestUserPrecedence:
         conf = _conf(torch_version="2.10.0", wsl=True,
                      preset={"PYTORCH_ALLOC_CONF": "expandable_segments:True"})
         assert conf["PYTORCH_ALLOC_CONF"] == ROUNDUP, conf
+
+    def test_explicit_empty_preserved_2_10(self):
+        # An explicit empty value is a user opt-out (gradient_checkpointing.py
+        # advises it); do not overwrite it with the roundup fallback.
+        conf = _conf(torch_version="2.10.0", wsl=True,
+                     preset={"PYTORCH_ALLOC_CONF": ""})
+        assert conf["PYTORCH_ALLOC_CONF"] == "", conf
+
+    def test_explicit_empty_legacy_preserved_2_9(self):
+        conf = _conf(torch_version="2.9.1", wsl=True,
+                     preset={"PYTORCH_CUDA_ALLOC_CONF": ""})
+        assert conf["PYTORCH_CUDA_ALLOC_CONF"] == "", conf
 
 
 # --- opt-out and vLLM standby ----------------------------------------------

--- a/tests/test_alloc_conf_platform_matrix.py
+++ b/tests/test_alloc_conf_platform_matrix.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Regression tests for the import-time PyTorch allocator config.
+
+``unsloth_zoo/__init__.py`` configures the CUDA/HIP caching allocator env vars
+(``PYTORCH_ALLOC_CONF`` / ``PYTORCH_CUDA_ALLOC_CONF`` / ``PYTORCH_HIP_ALLOC_CONF``)
+at import time. Two behaviours are covered here:
+
+* The unified ``PYTORCH_ALLOC_CONF`` is only *read* by the allocator from torch
+  2.10; torch <= 2.9.x reads only the legacy per-backend vars. The block must
+  therefore write the legacy var on torch <= 2.9.x and the unified var on 2.10+.
+* Windows / WSL cannot use ``expandable_segments``, so a
+  ``roundup_power2_divisions`` fallback is applied there instead of leaving the
+  allocator with no fragmentation mitigation (unslothai/unsloth#7203).
+
+Each case runs ``import unsloth_zoo`` in a **fresh subprocess** so the
+import-time, process-global allocator config is exercised in isolation (the
+block cannot be re-run cleanly in-process, and doing so would leak module state
+into sibling tests). The torch version and device backend are faked in the
+child so the whole matrix runs deterministically under whatever torch is
+actually installed; only the selected env var / value (branch logic) is
+asserted, never torch's own reading.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+ROUNDUP = "roundup_power2_divisions:[32:256,64:128,256:64,>:32]"
+_ALLOC_KEYS = ("PYTORCH_ALLOC_CONF", "PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_HIP_ALLOC_CONF")
+_WIPE = _ALLOC_KEYS + (
+    "WSL_DISTRO_NAME", "WSL_INTEROP", "UNSLOTH_VLLM_STANDBY", "UNSLOTH_DISABLE_ALLOC_FALLBACK",
+)
+
+# Repo root (.../unsloth_zoo), so the child's `import unsloth_zoo` resolves to this
+# checkout rather than a namespace-package shadow on a crowded sys.path.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+_CHILD = textwrap.dedent(
+    """
+    import os, json, importlib.metadata as _m
+    _real = _m.version
+    _fake_torch = os.environ.pop("_FAKE_TORCH_VERSION", "") or None
+    def _version(name, *a, **k):
+        if name == "torch" and _fake_torch is not None:
+            return _fake_torch
+        return _real(name, *a, **k)
+    _m.version = _version
+    # Fake the device backend by injecting a stub unsloth_zoo.device_type BEFORE
+    # unsloth_zoo import (faking torch.version.hip instead would make torch route
+    # device_count() through amdsmi and crash on a CUDA box). DEVICE_TYPE_TORCH is
+    # mapped to "cuda" so the rest of the import still runs on this box; only
+    # DEVICE_TYPE / is_hip (which gate the fallback) are what the block reads.
+    _fake_dev = os.environ.pop("_FAKE_DEVICE", "") or None
+    if _fake_dev:
+        import sys as _sys, types as _types
+        _dt = _types.ModuleType("unsloth_zoo.device_type")
+        _dt.is_hip = lambda: _fake_dev == "hip"
+        _dt.get_device_type = lambda: _fake_dev
+        _dt.DEVICE_TYPE = _fake_dev
+        _dt.DEVICE_TYPE_TORCH = "cuda"
+        _dt.DEVICE_COUNT = 1
+        _dt.ALLOW_PREQUANTIZED_MODELS = True
+        _sys.modules["unsloth_zoo.device_type"] = _dt
+    import unsloth_zoo  # runs the import-time allocator block
+    print("RESULT:" + json.dumps(
+        {k: os.environ.get(k) for k in
+         ("PYTORCH_ALLOC_CONF", "PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_HIP_ALLOC_CONF")}
+    ))
+    """
+)
+
+
+def _conf(*, torch_version, wsl=False, wsl_interop=False, windows=False,
+          standby=False, opt_out=False, device=None, preset=None):
+    """Import unsloth_zoo in a fresh child with the given fake env and return the
+    resulting allocator env vars as a dict (values may be ``None``)."""
+    env = {k: v for k, v in os.environ.items() if k not in _WIPE and k != "_FAKE_TORCH_VERSION"}
+    env["_FAKE_TORCH_VERSION"] = torch_version
+    env["CUDA_VISIBLE_DEVICES"] = env.get("CUDA_VISIBLE_DEVICES", "0")
+    env["PYTHONPATH"] = _REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    if wsl:
+        env["WSL_DISTRO_NAME"] = "Ubuntu"
+    if wsl_interop:
+        env["WSL_INTEROP"] = "/run/WSL/1_interop"
+    if standby:
+        env["UNSLOTH_VLLM_STANDBY"] = "1"
+    if opt_out:
+        env["UNSLOTH_DISABLE_ALLOC_FALLBACK"] = "1"
+    if device:
+        env["_FAKE_DEVICE"] = device
+    for key, val in (preset or {}).items():
+        env[key] = val
+    # `windows` (os.name=='nt') cannot be faked on Linux (pathlib raises), so it
+    # is covered by the drift guard test instead, not here.
+    assert not windows
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD],
+        env=env, cwd=_REPO_ROOT, capture_output=True, text=True, timeout=300,
+    )
+    lines = [l for l in (proc.stdout + proc.stderr).splitlines() if l.startswith("RESULT:")]
+    if not lines:
+        raise AssertionError(
+            "child produced no RESULT.\nSTDOUT:\n{}\nSTDERR:\n{}".format(
+                proc.stdout[-2000:], proc.stderr[-2000:]
+            )
+        )
+    return json.loads(lines[-1][len("RESULT:"):])
+
+
+# --- torch version boundary (Linux CUDA, no user config) -------------------
+
+class TestBoundary:
+    @pytest.mark.parametrize("ver", ["2.6.0", "2.8.1", "2.9.1"])
+    def test_le_2_9_uses_legacy_cuda_var(self, ver):
+        # torch <= 2.9.x only READS PYTORCH_CUDA_ALLOC_CONF, so the mitigation
+        # must land there (expandable + roundup); the unified var stays unset.
+        conf = _conf(torch_version=ver)
+        assert conf["PYTORCH_CUDA_ALLOC_CONF"] is not None, conf
+        assert "expandable_segments:True" in conf["PYTORCH_CUDA_ALLOC_CONF"], conf
+        assert "roundup_power2_divisions" in conf["PYTORCH_CUDA_ALLOC_CONF"], conf
+        assert conf["PYTORCH_ALLOC_CONF"] is None, conf
+        assert conf["PYTORCH_HIP_ALLOC_CONF"] is None, conf
+
+    @pytest.mark.parametrize("ver", ["2.10.0", "2.13.0"])
+    def test_ge_2_10_uses_unified_var(self, ver):
+        # torch >= 2.10 reads the unified var; behaviour matches today (expandable
+        # only, no roundup) -> guards against a Linux regression.
+        conf = _conf(torch_version=ver)
+        assert conf["PYTORCH_ALLOC_CONF"] == "expandable_segments:True", conf
+        assert conf["PYTORCH_CUDA_ALLOC_CONF"] is None, conf
+        assert conf["PYTORCH_HIP_ALLOC_CONF"] is None, conf
+
+
+# --- Windows / WSL fragmentation fallback (issue #7203) --------------------
+
+class TestWindowsWslFallback:
+    def test_wsl_torch_2_9_roundup_on_legacy(self):
+        conf = _conf(torch_version="2.9.1", wsl=True)
+        assert conf["PYTORCH_CUDA_ALLOC_CONF"] == ROUNDUP, conf
+        assert conf["PYTORCH_ALLOC_CONF"] is None, conf
+
+    def test_wsl_torch_2_10_roundup_on_unified(self):
+        conf = _conf(torch_version="2.10.0", wsl=True)
+        assert conf["PYTORCH_ALLOC_CONF"] == ROUNDUP, conf
+        assert conf["PYTORCH_CUDA_ALLOC_CONF"] is None, conf
+
+    def test_wsl_interop_also_triggers(self):
+        conf = _conf(torch_version="2.10.0", wsl_interop=True)
+        assert conf["PYTORCH_ALLOC_CONF"] == ROUNDUP, conf
+
+    def test_linux_2_10_no_fallback(self):
+        # Regression guard: native Linux keeps expandable, never gets roundup.
+        conf = _conf(torch_version="2.10.0")
+        assert conf["PYTORCH_ALLOC_CONF"] == "expandable_segments:True", conf
+        assert "roundup" not in (conf["PYTORCH_ALLOC_CONF"] or ""), conf
+
+    def test_windows_shares_wsl_branch_source_guard(self):
+        # Native Windows (os.name == 'nt') takes the exact same
+        # `elif IS_WSL_OR_WINDOWS` branch + fallback as WSL, so the WSL cases
+        # above cover the runtime behaviour. A reload under a spoofed os.name
+        # cannot run on Linux (pathlib flips to WindowsPath), so guard the shared
+        # detection + fallback wiring against drift (same source-inspection style
+        # as tests/test_upstream_import_fixes_drift.py).
+        src = os.path.join(_REPO_ROOT, "unsloth_zoo", "__init__.py")
+        text = open(src).read()
+        assert 'os.name == "nt"' in text
+        assert "IS_WSL_OR_WINDOWS" in text
+        assert "roundup_power2_divisions" in text
+
+
+# --- user precedence + promotion gap ---------------------------------------
+
+class TestUserPrecedence:
+    def test_user_unified_backend_preserved_2_10(self):
+        # A custom backend on torch 2.10 must survive untouched (roundup is a
+        # no-op under cudaMallocAsync anyway, so none is added).
+        conf = _conf(torch_version="2.10.0", wsl=True,
+                     preset={"PYTORCH_ALLOC_CONF": "backend:cudaMallocAsync"})
+        assert conf["PYTORCH_ALLOC_CONF"] == "backend:cudaMallocAsync", conf
+
+    def test_user_legacy_backend_preserved_2_9(self):
+        conf = _conf(torch_version="2.9.1", wsl=True,
+                     preset={"PYTORCH_CUDA_ALLOC_CONF": "backend:cudaMallocAsync"})
+        assert conf["PYTORCH_CUDA_ALLOC_CONF"] == "backend:cudaMallocAsync", conf
+
+    def test_promotion_gap_closed_2_10(self):
+        # A legacy var pairing expandable with another option must end up with
+        # expandable stripped (futile on WSL) but the other option preserved, and
+        # must NOT re-surface expandable via the >=2.10 promotion step.
+        conf = _conf(torch_version="2.10.0", wsl=True,
+                     preset={"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True,max_split_size_mb:128"})
+        assert conf["PYTORCH_ALLOC_CONF"] == "max_split_size_mb:128", conf
+        assert "expandable_segments" not in (conf["PYTORCH_ALLOC_CONF"] or ""), conf
+
+    def test_user_only_expandable_on_wsl_replaced_by_roundup_2_10(self):
+        # If the only thing the user set is the futile expandable, strip it and
+        # fall back to roundup so the box is not left unmitigated.
+        conf = _conf(torch_version="2.10.0", wsl=True,
+                     preset={"PYTORCH_ALLOC_CONF": "expandable_segments:True"})
+        assert conf["PYTORCH_ALLOC_CONF"] == ROUNDUP, conf
+
+
+# --- opt-out and vLLM standby ----------------------------------------------
+
+class TestControls:
+    def test_opt_out_disables_fallback_2_10(self):
+        conf = _conf(torch_version="2.10.0", wsl=True, opt_out=True)
+        assert conf["PYTORCH_ALLOC_CONF"] is None, conf
+        assert conf["PYTORCH_CUDA_ALLOC_CONF"] is None, conf
+
+    def test_standby_no_expandable_no_roundup(self):
+        conf = _conf(torch_version="2.10.0", wsl=True, standby=True)
+        for key, val in conf.items():
+            assert "expandable_segments:True" not in (val or ""), (key, val)
+            assert "roundup" not in (val or ""), (key, val)
+
+
+# --- backend isolation: AMD (hip) / Intel (xpu) never get the CUDA fallback -
+
+class TestBackendIsolation:
+    def test_hip_wsl_no_roundup(self):
+        # AMD/ROCm: IS_HIP_RUNTIME short-circuits the CUDA-only fallback.
+        conf = _conf(torch_version="2.10.0", wsl=True, device="hip")
+        for key, val in conf.items():
+            assert "roundup" not in (val or ""), (key, val)
+            assert "expandable_segments:True" not in (val or ""), (key, val)
+
+    def test_xpu_wsl_no_roundup(self):
+        # Intel XPU: the DEVICE_TYPE == "cuda" clause gates the fallback out.
+        conf = _conf(torch_version="2.10.0", wsl=True, device="xpu")
+        for key, val in conf.items():
+            assert "roundup" not in (val or ""), (key, val)
+
+    def test_fake_cuda_control_still_fires(self):
+        # Sanity: same fake-device harness with device="cuda" DOES fire, proving
+        # the hip/xpu isolation above is real and not a harness artefact.
+        conf = _conf(torch_version="2.10.0", wsl=True, device="cuda")
+        assert conf["PYTORCH_ALLOC_CONF"] == ROUNDUP, conf

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -224,12 +224,15 @@ if not _SKIP_GPU_INIT:
     torch_version = str(re.match(r"[0-9\.]{3,}", torch_version_raw).group(0)).split(".")
     major_torch, minor_torch = torch_version[0], torch_version[1]
     major_torch, minor_torch = int(major_torch), int(minor_torch)
-    IS_TORCH_2_9_OR_NEWER = (major_torch > 2) or (major_torch == 2 and minor_torch >= 9)
+    # Unified PYTORCH_ALLOC_CONF is only read from torch 2.10; <= 2.9.x reads the legacy vars.
+    IS_TORCH_2_10_OR_NEWER = (major_torch > 2) or (major_torch == 2 and minor_torch >= 10)
     IS_TORCH_ROCM_BUILD = "+rocm" in torch_version_raw.lower()
+    # expandable_segments is unsupported on Windows/WSL.
+    IS_WSL_OR_WINDOWS = bool(os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP")) or os.name == "nt"
 
     # Reduce VRAM fragmentation and optimize memory pinning
     if os.environ.get("UNSLOTH_VLLM_STANDBY", "0") == "0":
-        if IS_TORCH_2_9_OR_NEWER:
+        if IS_TORCH_2_10_OR_NEWER:
             if "PYTORCH_ALLOC_CONF" not in os.environ:
                 os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
         else:
@@ -296,16 +299,12 @@ if not _SKIP_GPU_INIT:
         delete_key("PYTORCH_CUDA_ALLOC_CONF")
         delete_key("PYTORCH_HIP_ALLOC_CONF")
         delete_key("PYTORCH_ALLOC_CONF")
-    elif bool(os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP")):
-        # Expandable segments does NOT work on WSL
-        delete_key("PYTORCH_CUDA_ALLOC_CONF")
-        delete_key("PYTORCH_HIP_ALLOC_CONF")
-        delete_key("PYTORCH_ALLOC_CONF")
-    elif os.name == 'nt':
-        # Expandable segments does NOT work on Windows
-        delete_key("PYTORCH_CUDA_ALLOC_CONF")
-        delete_key("PYTORCH_HIP_ALLOC_CONF")
-        delete_key("PYTORCH_ALLOC_CONF")
+    elif IS_WSL_OR_WINDOWS:
+        # Strip unsupported expandable_segments but keep other user config; a
+        # roundup fallback is applied below (unslothai/unsloth#7203).
+        remove_expandable_segments("PYTORCH_CUDA_ALLOC_CONF")
+        remove_expandable_segments("PYTORCH_HIP_ALLOC_CONF")
+        remove_expandable_segments("PYTORCH_ALLOC_CONF")
 
     # IMPORTANT: run ROCm cleanup before importing device_type (which imports torch).
     # HIP allocator settings can be read during torch initialization.
@@ -340,8 +339,8 @@ if not _SKIP_GPU_INIT:
     )
     IS_HIP_RUNTIME = (DEVICE_TYPE == "hip") or bool(is_hip())
 
-    # Torch >= 2.9 uses PYTORCH_ALLOC_CONF and treats legacy per-backend vars as deprecated.
-    if IS_TORCH_2_9_OR_NEWER:
+    # Torch >= 2.10 reads PYTORCH_ALLOC_CONF and treats legacy per-backend vars as deprecated.
+    if IS_TORCH_2_10_OR_NEWER:
         # Preserve explicit legacy allocator settings when user did not directly set PYTORCH_ALLOC_CONF.
         if not _HAS_ORIGINAL_PYTORCH_ALLOC_CONF:
             promoted = _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF
@@ -357,8 +356,8 @@ if not _SKIP_GPU_INIT:
 
     # Specify PYTORCH_CUDA_ALLOC_CONF or PYTORCH_HIP_ALLOC_CONF
     if IS_HIP_RUNTIME:
-        if IS_TORCH_2_9_OR_NEWER:
-            # PyTorch >= 2.9 uses PYTORCH_ALLOC_CONF. expandable_segments is unsupported on HIP.
+        if IS_TORCH_2_10_OR_NEWER:
+            # PyTorch >= 2.10 uses PYTORCH_ALLOC_CONF. expandable_segments is unsupported on HIP.
             remove_expandable_segments("PYTORCH_ALLOC_CONF")
             delete_key("PYTORCH_CUDA_ALLOC_CONF")
             delete_key("PYTORCH_HIP_ALLOC_CONF")
@@ -373,9 +372,27 @@ if not _SKIP_GPU_INIT:
             remove_expandable_segments("PYTORCH_HIP_ALLOC_CONF")
             remove_expandable_segments("PYTORCH_ALLOC_CONF")
             delete_key("PYTORCH_CUDA_ALLOC_CONF")
-    elif DEVICE_TYPE == "cuda" and not IS_HIP_RUNTIME and not IS_TORCH_2_9_OR_NEWER:
+    elif DEVICE_TYPE == "cuda" and not IS_HIP_RUNTIME and not IS_TORCH_2_10_OR_NEWER:
         delete_key("PYTORCH_HIP_ALLOC_CONF")
         delete_key("PYTORCH_ALLOC_CONF")
+
+    # Windows/WSL lack expandable_segments, so the branches above leave long context
+    # training with no fragmentation mitigation (cudaMalloc retry storms / OOM). Give
+    # NVIDIA CUDA a roundup_power2_divisions fallback instead (unslothai/unsloth#7203).
+    if (
+        IS_WSL_OR_WINDOWS
+        and DEVICE_TYPE == "cuda" and not IS_HIP_RUNTIME
+        and os.environ.get("UNSLOTH_VLLM_STANDBY", "0") == "0"
+        and os.environ.get("UNSLOTH_DISABLE_ALLOC_FALLBACK", "0") == "0"
+        and not (major_torch == 2 and minor_torch < 2)
+    ):
+        # torch <= 2.9.x reads the legacy var; >= 2.10 reads the unified one.
+        _alloc_key = "PYTORCH_ALLOC_CONF" if IS_TORCH_2_10_OR_NEWER else "PYTORCH_CUDA_ALLOC_CONF"
+        # Promotion above can re-add expandable_segments (only cleaned for standby/ROCm); strip it.
+        remove_expandable_segments(_alloc_key)
+        if os.environ.get(_alloc_key, "").strip() == "":
+            os.environ[_alloc_key] = "roundup_power2_divisions:[32:256,64:128,256:64,>:32]"
+        del _alloc_key
 
     # CCE fails on Torch 2.8 and above
     # OutOfResources: out of resource: shared memory, Required: 98304, Hardware limit: 65536. Reducing block sizes or `num_stages`
@@ -431,7 +448,7 @@ if not _SKIP_GPU_INIT:
                     except Exception: pass  # best-effort; some builds lack the setter
                 del _pref
         del _torch, _rocm_arch, _sys, _user_blas, _user_wants_lt
-    del remove_expandable_segments, delete_key, IS_HIP_RUNTIME, IS_TORCH_2_9_OR_NEWER, IS_TORCH_ROCM_BUILD, major_torch, minor_torch, torch_version, torch_version_raw, importlib_version, find_spec
+    del remove_expandable_segments, delete_key, IS_HIP_RUNTIME, IS_TORCH_2_10_OR_NEWER, IS_WSL_OR_WINDOWS, IS_TORCH_ROCM_BUILD, major_torch, minor_torch, torch_version, torch_version_raw, importlib_version, find_spec
     del clean_expandable_segments_value
     del _ORIGINAL_PYTORCH_CUDA_ALLOC_CONF, _ORIGINAL_PYTORCH_HIP_ALLOC_CONF, _HAS_ORIGINAL_PYTORCH_ALLOC_CONF
 

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -390,7 +390,9 @@ if not _SKIP_GPU_INIT:
         _alloc_key = "PYTORCH_ALLOC_CONF" if IS_TORCH_2_10_OR_NEWER else "PYTORCH_CUDA_ALLOC_CONF"
         # Promotion above can re-add expandable_segments (only cleaned for standby/ROCm); strip it.
         remove_expandable_segments(_alloc_key)
-        if os.environ.get(_alloc_key, "").strip() == "":
+        # Only fill when absent. An explicit empty value is a user opt-out
+        # (gradient_checkpointing.py advises PYTORCH_CUDA_ALLOC_CONF="").
+        if _alloc_key not in os.environ:
             os.environ[_alloc_key] = "roundup_power2_divisions:[32:256,64:128,256:64,>:32]"
         del _alloc_key
 


### PR DESCRIPTION
## Problem

Long context QLoRA training on Windows and WSL (for example the 64k context Qwen3.5 and Gemma 4 runs in unslothai/unsloth#7203) sits on the first step trying to allocate memory and then OOMs, even for small models on 96GB, although steady state only needs around 22GB. This is CUDA caching allocator fragmentation rather than actual memory exhaustion.

Two issues in the import time allocator block in `unsloth_zoo/__init__.py`:

1. Windows and WSL had no fragmentation fallback. `expandable_segments` is unsupported there, and the Windows and WSL branches deleted every allocator env var, so those platforms ran with no mitigation at all.

2. Off by one on the PyTorch version gate. The unified `PYTORCH_ALLOC_CONF` is only read by the caching allocator from torch 2.10. On torch 2.9.x the code wrote `PYTORCH_ALLOC_CONF`, which 2.9.x ignores, so `expandable_segments` was silently dropped on every platform, not just Windows and WSL.

Verified directly: on torch 2.9.1 a bad key in `PYTORCH_ALLOC_CONF` is ignored while the same key in `PYTORCH_CUDA_ALLOC_CONF` raises; on torch 2.10.0 both raise. So 2.9.x reads only the legacy var and 2.10 reads the unified one.

## Fix

- Rename `IS_TORCH_2_9_OR_NEWER` to `IS_TORCH_2_10_OR_NEWER` (threshold `minor >= 10`) so the loader writes the legacy `PYTORCH_CUDA_ALLOC_CONF` on torch <= 2.9.x and the unified `PYTORCH_ALLOC_CONF` on 2.10 and newer.
- On Windows and WSL, strip only `expandable_segments` instead of wiping the whole config, so any other user allocator options survive, then apply a `roundup_power2_divisions` fallback on NVIDIA CUDA when nothing else remains.
- Strip `expandable_segments` again inside the fallback, since the 2.10 promotion step can re-read the original value (it only cleans it under standby or ROCm).

The change is env var only, so it is compatible across transformers, TRL and vLLM versions. It is gated to NVIDIA CUDA and does not run under vLLM standby. Opt out with `UNSLOTH_DISABLE_ALLOC_FALLBACK=1`.

### Behaviour with no user config

| Platform | torch <= 2.9.x | torch 2.10+ |
| --- | --- | --- |
| Linux NVIDIA | `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,roundup_power2_divisions:[...]` | `PYTORCH_ALLOC_CONF=expandable_segments:True` |
| Windows or WSL NVIDIA | `PYTORCH_CUDA_ALLOC_CONF=roundup_power2_divisions:[...]` | `PYTORCH_ALLOC_CONF=roundup_power2_divisions:[...]` |
| AMD, Intel, Mac | unchanged | unchanged |

Only torch 2.9.x behaviour changes on Linux, from silently dropped to actually applied. torch 2.6 to 2.8 and torch 2.10+ are unchanged.

## Isolation and safety

- Linux CUDA on torch 2.10+ is unchanged.
- Mac and MLX are skipped via `_SKIP_GPU_INIT`.
- AMD (hip) and Intel (xpu) are gated out by `DEVICE_TYPE == "cuda" and not IS_HIP_RUNTIME`.
- vLLM standby is respected, and a roundup only value passes the standby assertion in `vllm_utils.py`.

## Tests

New `tests/test_alloc_conf_platform_matrix.py` runs `import unsloth_zoo` in a fresh subprocess per case (the allocator config is import time, process global state, so an in process reload is not used) and asserts the resulting allocator env vars. It covers the torch version boundary (2.6, 2.8, 2.9.1, 2.10, 2.13), the Windows and WSL fallback, user precedence, the promotion strip, the opt out, vLLM standby, and AMD and Intel isolation. All pass.

## Note on torch 2.9.x

Because torch 2.9.x only reads the legacy `PYTORCH_CUDA_ALLOC_CONF`, setting it surfaces torch's own one time deprecation notice for that variable. This is unavoidable and is the cost of the config actually taking effect on 2.9.x, which previously it did not. torch 2.6 to 2.8 and torch 2.10+ do not print it.

Addresses unslothai/unsloth#7203
