### PR TITLE
Fix MLX simulation shim children traversal

### DIFF
--- a/tests/mlx_simulation/mlx_nn_stub.py
+++ b/tests/mlx_simulation/mlx_nn_stub.py
@@ -57,6 +57,7 @@ class Module:
 
     def __init__(self):
         self._mlx_inference_mode = False
+        self._mlx_property_state = set()
 
     def parameters(self):
         """Return a dict of {leaf_path: tensor} for tree_flatten consumption."""
@@ -72,6 +73,44 @@ class Module:
 
     def trainable_parameters(self):
         return self.parameters()
+
+    def __contains__(self, key):
+        """Mirror membership in MLX's dict-backed module state."""
+        if key in self._mlx_property_state:
+            return True
+        value = vars(self).get(key)
+        return isinstance(value, (torch.Tensor, Module, dict, list, tuple))
+
+    def _track_property_state(self, key, value):
+        if isinstance(value, (torch.Tensor, Module, dict, list, tuple)):
+            self._mlx_property_state.add(key)
+        else:
+            self._mlx_property_state.discard(key)
+
+    def children(self):
+        """Return direct child Modules while preserving container structure."""
+        def child_tree(value):
+            if isinstance(value, Module):
+                return value
+            if isinstance(value, dict):
+                return {
+                    key: child_tree(item)
+                    if isinstance(item, (Module, dict, list)) else {}
+                    for key, item in value.items()
+                }
+            if isinstance(value, list):
+                return [
+                    child_tree(item)
+                    if isinstance(item, (Module, dict, list)) else {}
+                    for item in value
+                ]
+            return {}
+
+        return {
+            name: child_tree(value)
+            for name, value in vars(self).items()
+            if isinstance(value, (Module, dict, list))
+        }
 
     def named_modules(self, prefix=""):
         """Yield (path, module) pairs walking the full Module tree.
@@ -194,6 +233,9 @@ class Linear(Module):
     def __init__(self, in_features, out_features, bias=True):
         super().__init__()
         self.linear = torch.nn.Linear(in_features, out_features, bias=bias)
+        self._mlx_property_state.add("weight")
+        if self.linear.bias is not None:
+            self._mlx_property_state.add("bias")
         self.in_features = in_features
         self.out_features = out_features
 
@@ -204,11 +246,16 @@ class Linear(Module):
     @weight.setter
     def weight(self, value):
         if isinstance(value, torch.Tensor):
+            requires_grad = (
+                self.linear.weight.requires_grad
+                if self.linear.weight is not None else True
+            )
             self.linear.weight = torch.nn.Parameter(
-                value.detach().clone(), requires_grad=self.linear.weight.requires_grad
+                value.detach().clone(), requires_grad=requires_grad
             )
         else:
             self.linear.weight = value
+        self._track_property_state("weight", value)
 
     @property
     def bias(self):
@@ -217,25 +264,25 @@ class Linear(Module):
     @bias.setter
     def bias(self, value):
         if isinstance(value, torch.Tensor):
+            requires_grad = (
+                self.linear.bias.requires_grad
+                if self.linear.bias is not None else True
+            )
             self.linear.bias = torch.nn.Parameter(
-                value.detach().clone(), requires_grad=self.linear.bias.requires_grad
+                value.detach().clone(), requires_grad=requires_grad
             )
         else:
             self.linear.bias = value
+        self._track_property_state("bias", value)
 
     def __call__(self, x):
         return self.linear(x)
-
-    def __contains__(self, key):
-        if key == "bias":
-            return self.linear.bias is not None
-        return False
-
 
 class Embedding(Module):
     def __init__(self, num_embeddings, dims):
         super().__init__()
         self.embedding = torch.nn.Embedding(num_embeddings, dims)
+        self._mlx_property_state.add("weight")
         self.num_embeddings = num_embeddings
         self.dims = dims
 
@@ -246,12 +293,17 @@ class Embedding(Module):
     @weight.setter
     def weight(self, value):
         if isinstance(value, torch.Tensor):
+            requires_grad = (
+                self.embedding.weight.requires_grad
+                if self.embedding.weight is not None else True
+            )
             self.embedding.weight = torch.nn.Parameter(
                 value.detach().clone(),
-                requires_grad=self.embedding.weight.requires_grad,
+                requires_grad=requires_grad,
             )
         else:
             self.embedding.weight = value
+        self._track_property_state("weight", value)
 
     def __call__(self, x):
         return self.embedding(x)
@@ -259,7 +311,6 @@ class Embedding(Module):
     def as_linear(self, x):
         """MLX shortcut for tied lm_head: weight @ x."""
         return F.linear(x, self.embedding.weight)
-
 
 class AvgPool2d(Module):
     def __init__(self, kernel_size, stride=None, padding=0):
@@ -302,9 +353,6 @@ class QuantizedLinear(Module):
         if self.bias is not None:
             out = out + self.bias
         return out
-
-    def __contains__(self, key):
-        return key == "bias" and self.bias is not None
 
 
 class QuantizedEmbedding(Module):

--- a/tests/test_mlx_torch_shim_smoke.py
+++ b/tests/test_mlx_torch_shim_smoke.py
@@ -220,6 +220,55 @@ def test_finfo_and_dtype_kinds():
     assert mx.issubdtype(mx.int32, mx.integer) is True
 
 
+def test_module_children_preserves_direct_child_tree():
+    import mlx.nn as nn
+
+    class PropertyModule(nn.Module):
+        @property
+        def virtual(self):
+            return self
+
+    model = nn.Module()
+    model.direct = nn.Module()
+    model.alias = model.direct
+    model.layers = [nn.Module(), object()]
+    model.named = {
+        "leaf": nn.Module(),
+        "nested": [nn.Module(), 1],
+        "tupled": (nn.Module(),),
+    }
+    model.tupled = (nn.Module(),)
+    model.loop = model
+
+    children = model.children()
+    assert children["direct"] is model.direct
+    assert children["alias"] is model.direct
+    assert children["layers"] == [model.layers[0], {}]
+    assert children["named"] == {
+        "leaf": model.named["leaf"],
+        "nested": [model.named["nested"][0], {}],
+        "tupled": {},
+    }
+    assert "tupled" not in children and children["loop"] is model
+    assert "direct" in model and "virtual" not in PropertyModule()
+    linear, embedding = nn.Linear(2, 2, bias=False), nn.Embedding(2, 2)
+    linear.extra = model.direct
+    assert "weight" in linear and "weight" in embedding and "extra" in linear
+    linear.weight = embedding.weight = None
+    assert "weight" not in linear and "weight" not in embedding
+    linear.weight = embedding.weight = torch.ones(2, 2)
+    linear.bias = torch.zeros(2)
+    assert "weight" in linear and "weight" in embedding and "bias" in linear
+    assert linear.weight.requires_grad and embedding.weight.requires_grad
+    assert linear.bias.requires_grad
+    quantized = nn.QuantizedLinear(2, 2, bias=False)
+    quantized.weight = torch.zeros(2, 2)
+    assert "weight" in quantized
+    assert [name for name, _ in model.named_modules()] == [
+        "", "direct", "layers.0", "named.leaf", "tupled.0",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # 4. Tree utils round-trip.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- implement `mlx.nn.Module.children()` semantics in the Linux MLX simulation shim for direct module attributes and nested dict/list containers
- preserve real MLX placeholder, tuple-omission, alias, state-membership, and parameter lifecycle behavior without changing `named_modules()` traversal
- add a compact shim regression covering child discovery, container shapes, state removal/restoration, and quantized state

## Root cause

Output-head discovery now uses the real `mlx.nn.Module.children()` API. The Linux simulation `Module` only exposed `named_modules()`, so embedding children and alternate output-head candidates disappeared when the shim was active. Tied-head resolution consequently failed closed, including the trainability check that follows the resolved module.

## Impact

The simulation shim now exposes the same direct-child tree expected by production MLX code. This restores tied embedding discovery, alternate output-head candidate discovery, and descriptor-based LM-head trainability in CPU Core CI without modifying production MLX behavior.

## Validation

```text
python -m pytest -q --tb=short tests/test_mlx_cce_kernel.py
41 passed

python -m pytest -q --tb=short tests/test_mlx_torch_shim_smoke.py tests/test_mlx_module_exports.py tests/test_mlx_dequantize_modules.py
78 passed

all test_mlx*.py files that invoke simulate_mlx_on_torch
516 passed, 12 skipped

python -m py_compile tests/mlx_simulation/mlx_nn_stub.py tests/test_mlx_torch_shim_smoke.py
passed

git diff --check
passed
```
