### PR TITLE
Fix CPU MLX shim so output-head resolution tests pass without real MLX

### DIFF
--- a/tests/mlx_simulation/mlx_nn_stub.py
+++ b/tests/mlx_simulation/mlx_nn_stub.py
@@ -104,6 +104,32 @@ class Module:
                         sub_prefix = f"{prefix}.{attr_name}.{k}" if prefix else f"{attr_name}.{k}"
                         yield from item.named_modules(sub_prefix)
 
+    def __contains__(self, key):
+        """MLX's Module derives from dict, so ``"bias" in module`` is valid on
+        any module and checks the parameter/child entry. Mirror that here by
+        answering for tensor- or Module-valued attributes; subclasses whose
+        parameters live on a wrapped torch module (Linear) override this."""
+        value = getattr(self, key, None)
+        return isinstance(value, (torch.Tensor, Module))
+
+    def children(self):
+        """Direct sub-structure keyed by attribute name, mirroring MLX's
+        ``Module.children()``: Module-valued attributes map to the Module,
+        list/dict containers of Modules map to the container itself (MLX
+        returns the nested structure; consumers type-check the values, so
+        containers fall through their exact-type filters unchanged)."""
+        out = {}
+        for attr_name, attr_val in vars(self).items():
+            if isinstance(attr_val, Module):
+                out[attr_name] = attr_val
+            elif isinstance(attr_val, (list, tuple)):
+                if any(isinstance(item, Module) for item in attr_val):
+                    out[attr_name] = attr_val
+            elif isinstance(attr_val, dict):
+                if any(isinstance(item, Module) for item in attr_val.values()):
+                    out[attr_name] = attr_val
+        return out
+
     def freeze(self, *, recurse=True, keys=None):
         return self
 


### PR DESCRIPTION
## What broke

PR #930 added `describe_output_head` / `_is_lm_head_trainable` in `unsloth_zoo/mlx/utils.py`. They resolve the tied-embedding anchor via `mlx.nn.Module.children()` and probe for an additive bias with `"bias" in module`. Both are part of MLX's dict-derived `Module` API, but the torch-based CPU test shim (`tests/mlx_simulation/mlx_nn_stub.py`) implemented neither.

On CI runners without real MLX, `_resolve_embedding_anchor` therefore failed closed and every tied head degraded to `status='unknown'` with no path, and the bias probe raised `TypeError: argument of type 'Embedding' is not iterable`. Three tests in `tests/test_mlx_cce_kernel.py` failed and turned every Core CI leg of unsloth PRs red:

- `test_dead_tie_flag_fails_closed_to_unknown`
- `test_is_lm_head_trainable_follows_descriptor_path`
- `test_describe_output_head_evidence_ladder`

This is a fixture gap, not a product bug: real MLX modules carry both APIs, and the failures are identical on transformers 4.57.6 and 5.5.0 (transformers is not involved).

## Fix

Test shim only, no product code changes:

- `Module.children()`: direct sub-structure keyed by attribute name, mirroring MLX semantics (Module attributes map to the Module, list/dict containers of Modules map to the container; consumers type-check values, so containers fall through exact-type filters unchanged).
- Base `Module.__contains__`: answers for tensor- or Module-valued attributes; `Linear`/`QuantizedLinear` keep their wrapped-module overrides.

## Test matrix (CPU)

| transformers | tests/test_mlx_cce_kernel.py | full tests/ |
|---|---|---|
| 4.57.6 | 41 passed (was 3 failed, 38 passed) | 2469 passed, 120 skipped, 0 failed |
| 5.5.0 | 41 passed (was 3 failed, 38 passed) | 2393 passed, 184 skipped, 3 failed* |

*The 3 transformers-5.5 failures (`test_unsloth_trainer_exec_marker`, `test_triton_compiled_kernel_has_num_ctas_and_cluster_dims`, `test_logging_utils_utils_notebook`) reproduce identically on main before this change and are unrelated to this diff.