### PR TITLE
Fix Whisper pad token repair

### DIFF
--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -189,6 +189,48 @@ def test_whisper_does_not_use_config_pad_when_it_equals_eos():
         fix_pad_token(tok, model_config=cfg)
 
 
+def test_whisper_does_not_use_config_pad_when_it_is_in_eos_list():
+    tok = FakeTokenizer(
+        {"": 50256, "<|endoftext|>": 50257},
+        pad_token="<|endoftext|>",
+        eos_token="<|endoftext|>",
+    )
+    cfg = type(
+        "Cfg",
+        (),
+        {
+            "model_type": "whisper",
+            "vocab_size": 51866,
+            "pad_token_id": 50256,
+            "eos_token_id": [50257, 50256],
+        },
+    )()
+
+    with pytest.raises(RuntimeError):
+        fix_pad_token(tok, model_config=cfg)
+
+
+def test_whisper_non_string_model_type_uses_generic_fallback():
+    tok = FakeTokenizer(
+        {"": 50256, "<|endoftext|>": 50257},
+        pad_token="<|endoftext|>",
+        eos_token="<|endoftext|>",
+    )
+    cfg = type(
+        "Cfg",
+        (),
+        {
+            "model_type": ["whisper"],
+            "vocab_size": 51866,
+            "pad_token_id": 50256,
+            "eos_token_id": 50257,
+        },
+    )()
+
+    with pytest.raises(RuntimeError):
+        fix_pad_token(tok, model_config=cfg)
+
+
 def test_missing_pad_picks_reserved():
     tok = FakeTokenizer({"<|eot_id|>": 1, "<|reserved_special_token_0|>": 5},
                         pad_token=None, eos_token="<|eot_id|>")

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -65,6 +65,14 @@ class FakeTokenizer:
         ids = [self._vocab[text]] if text in self._vocab else [0, 1]
         return type("Enc", (), {"input_ids": ids})()
 
+    def convert_ids_to_tokens(self, token_id):
+        return next(
+            (token for token, index in self._vocab.items() if index == token_id), None
+        )
+
+    def convert_tokens_to_ids(self, token):
+        return self._vocab.get(token)
+
     def add_special_tokens(self, mapping):
         tok = mapping["pad_token"]
         if tok not in self._vocab:
@@ -120,6 +128,65 @@ def test_pad_equals_eos_picks_distinct_reserved():
     res = fix_pad_token(tok)
     assert res["reason"] == "equals_eos" and tok.pad_token == "<pad>"
     assert tok.pad_token != tok.eos_token
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_whisper_uses_existing_config_pad_token(wrapped):
+    # Whisper large-v3's tokenizer aliases pad/eos/unk to 50257 while its model
+    # config declares the existing empty token at 50256 as pad. Align to the
+    # config without adding a random token or resizing the vocabulary.
+    tok = FakeTokenizer(
+        {"": 50256, "<|endoftext|>": 50257},
+        pad_token="<|endoftext|>",
+        eos_token="<|endoftext|>",
+    )
+    tok.unk_token = "<|endoftext|>"
+    cfg = type(
+        "Cfg",
+        (),
+        {
+            "model_type": "whisper",
+            "vocab_size": 51866,
+            "pad_token_id": 50256,
+            "eos_token_id": 50257,
+        },
+    )()
+    tokenizer = type("Processor", (), {"tokenizer": tok})() if wrapped else tok
+
+    res = fix_pad_token(tokenizer, model_config=cfg)
+
+    assert res == {
+        "changed": True,
+        "reason": "equals_eos",
+        "old_pad": "<|endoftext|>",
+        "new_pad": "",
+        "added": False,
+    }
+    assert tok.pad_token == ""
+    assert tok.pad_token_id == cfg.pad_token_id
+    assert tok.pad_token_id != tok.eos_token_id
+    assert len(tok.get_vocab()) == 2
+
+
+def test_whisper_does_not_use_config_pad_when_it_equals_eos():
+    tok = FakeTokenizer(
+        {"<|endoftext|>": 50257},
+        pad_token="<|endoftext|>",
+        eos_token="<|endoftext|>",
+    )
+    cfg = type(
+        "Cfg",
+        (),
+        {
+            "model_type": "whisper",
+            "vocab_size": 51866,
+            "pad_token_id": 50257,
+            "eos_token_id": 50257,
+        },
+    )()
+
+    with pytest.raises(RuntimeError):
+        fix_pad_token(tok, model_config=cfg)
 
 
 def test_missing_pad_picks_reserved():

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -210,25 +210,111 @@ def test_whisper_does_not_use_config_pad_when_it_is_in_eos_list():
         fix_pad_token(tok, model_config=cfg)
 
 
-def test_whisper_non_string_model_type_uses_generic_fallback():
+def test_config_declared_pad_used_regardless_of_model_type():
+    # The config-declared-pad rescue is model-type agnostic: any model whose config
+    # declares a valid, distinct pad id pointing at an existing token gets it reused,
+    # so a non-string / non-whisper model_type must NOT fall back to adding a token.
     tok = FakeTokenizer(
         {"": 50256, "<|endoftext|>": 50257},
         pad_token="<|endoftext|>",
         eos_token="<|endoftext|>",
     )
+    tok.unk_token = "<|endoftext|>"
     cfg = type(
         "Cfg",
         (),
         {
-            "model_type": ["whisper"],
+            "model_type": ["whisper"],  # not a str: the old whisper-only gate is gone
             "vocab_size": 51866,
             "pad_token_id": 50256,
             "eos_token_id": 50257,
         },
     )()
 
-    with pytest.raises(RuntimeError):
-        fix_pad_token(tok, model_config=cfg)
+    res = fix_pad_token(tok, model_config=cfg)
+    assert res["changed"] and res["new_pad"] == "" and res["added"] is False
+    assert tok.pad_token_id == 50256 and tok.pad_token_id != tok.eos_token_id
+    assert len(tok.get_vocab()) == 2
+
+
+def test_non_whisper_model_reuses_config_declared_pad():
+    # Generalization: a non-whisper model whose tokenizer aliases pad to eos but whose
+    # config declares a valid distinct pad id (pointing at an existing, non-reserved
+    # token the search families do not recognise) reuses it instead of adding a token.
+    tok = FakeTokenizer(
+        {"<|end|>": 7, "<extra_0>": 3},
+        pad_token="<|end|>",
+        eos_token="<|end|>",
+    )
+    cfg = type(
+        "Cfg",
+        (),
+        {"model_type": "llama", "vocab_size": 100, "pad_token_id": 3, "eos_token_id": 7},
+    )()
+
+    res = fix_pad_token(tok, model_config=cfg)
+    assert res == {
+        "changed": True,
+        "reason": "equals_eos",
+        "old_pad": "<|end|>",
+        "new_pad": "<extra_0>",
+        "added": False,
+    }
+    assert tok.pad_token_id == 3 and tok.pad_token_id != tok.eos_token_id
+    assert len(tok.get_vocab()) == 2
+
+
+def test_valid_pad_in_generation_stop_list_is_left_alone():
+    # Qwen2/2.5 regression: the tokenizer pads with <|endoftext|> (a distinct, valid pad)
+    # while its generation config lists that id as a SECONDARY stop token alongside the
+    # real training eos <|im_end|>. A generation stop id is not the training eos, so the
+    # pad must NOT be "healed" - this stays a no-op.
+    tok = FakeTokenizer(
+        {"<|endoftext|>": 151643, "<|im_end|>": 151645, "<|vision_pad|>": 151654},
+        pad_token="<|endoftext|>",
+        eos_token="<|im_end|>",
+    )
+    model = type(
+        "Model",
+        (),
+        {
+            "config": type("Cfg", (), {
+                "model_type": "qwen2", "vocab_size": 151936,
+                "pad_token_id": 151643, "eos_token_id": 151645,
+            })(),
+            "generation_config": type("Gen", (), {
+                "eos_token_id": [151645, 151643], "pad_token_id": 151643,
+            })(),
+        },
+    )()
+
+    res = fix_pad_token(tok, model=model)
+    assert res["changed"] is False
+    assert tok.pad_token == "<|endoftext|>"
+
+
+def test_bool_config_pad_id_is_rejected():
+    # bool subclasses int; True/False must never be accepted as a pad id.
+    tok = FakeTokenizer({"</s>": 2}, pad_token="</s>", eos_token="</s>")
+    cfg = type("Cfg", (), {"vocab_size": 100, "pad_token_id": True, "eos_token_id": 2})()
+    res = fix_pad_token(tok, model_config=cfg, allow_add=False)
+    assert res["changed"] is False and tok.pad_token == "</s>"
+
+
+def test_string_vocab_size_does_not_crash():
+    # A malformed (string) vocab_size must be treated as unknown, not raise TypeError.
+    tok = FakeTokenizer(
+        {"": 50256, "<|endoftext|>": 50257},
+        pad_token="<|endoftext|>",
+        eos_token="<|endoftext|>",
+    )
+    tok.unk_token = "<|endoftext|>"
+    cfg = type("Cfg", (), {
+        "model_type": "whisper", "vocab_size": "51866",
+        "pad_token_id": 50256, "eos_token_id": 50257,
+    })()
+    res = fix_pad_token(tok, model_config=cfg)
+    assert res["changed"] and res["new_pad"] == "" and tok.pad_token_id == 50256
 
 
 def test_missing_pad_picks_reserved():

--- a/tests/test_pad_token.py
+++ b/tests/test_pad_token.py
@@ -293,6 +293,27 @@ def test_valid_pad_in_generation_stop_list_is_left_alone():
     assert tok.pad_token == "<|endoftext|>"
 
 
+class _NoEosIdTokenizer(FakeTokenizer):
+    """A tokenizer that exposes eos_token but not eos_token_id (some remote-code ones)."""
+
+    @property
+    def eos_token_id(self):
+        return None
+
+
+@pytest.mark.parametrize("cls", [FakeTokenizer, _NoEosIdTokenizer])
+def test_config_declared_pad_never_re_aliases_eos(cls):
+    # A config that declares pad == eos must never be honoured - that is the very bug
+    # being repaired. Caught by id normally, and by token name when the tokenizer hides
+    # eos_token_id (where the id check alone would miss it).
+    tok = cls({"</s>": 2, "<s>": 1}, pad_token="</s>", eos_token="</s>")
+    cfg = type("Cfg", (), {"vocab_size": 100, "pad_token_id": 2})()
+
+    res = fix_pad_token(tok, model_config=cfg, allow_add=False)
+    assert res["changed"] is False
+    assert tok.pad_token == "</s>"
+
+
 def test_bool_config_pad_id_is_rejected():
     # bool subclasses int; True/False must never be accepted as a pad id.
     tok = FakeTokenizer({"</s>": 2}, pad_token="</s>", eos_token="</s>")

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -18,7 +18,8 @@
 A wrong/missing pad_token breaks training: pad == eos makes the loss ignore real
 pad positions (the model never learns to stop). `fix_pad_token` heals such
 tokenizers by picking a reserved pad-like token already in the vocab; if none
-exists it adds one. It is a no-op for an already valid, distinct pad_token.
+exists it reuses the model config's own declared pad id, and only if that is
+unusable does it add a new token. It is a no-op for an already valid, distinct pad_token.
 
 Any "*pad*"-named token (e.g. <|vision_pad|>, <|fim_pad|>, [PAD]) is a valid pad and
 is kept as-is. Qwen3 text models share Qwen3-VL's vocab and ship
@@ -102,11 +103,32 @@ def _display_name(model, model_config, inner):
     return "Model"
 
 
+def _eos_id_set(*values):
+    """Collect EOS ids from scalar and list/tuple/set/frozenset forms into one flat set.
+
+    `bool` is excluded (it subclasses int, but True/False are never real token ids).
+    Used to reject replacement-pad candidates whose id is really an EOS. Callers pass the
+    tokenizer's and the model config's eos, each of which may be a multi-EOS list. It does
+    NOT take the generation_config stop list: a valid pad (e.g. Qwen's <|endoftext|>)
+    legitimately appears there, so that list must not drive pad decisions.
+    """
+    ids = set()
+    for value in values:
+        if type(value) is int:
+            ids.add(value)
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            ids.update(v for v in value if type(v) is int)
+    return ids
+
+
 def _classify_bad_pad(inner, vocab_size):
     """Return a reason string if the current pad_token is bad, else None.
 
     A pad-named token (e.g. <|vision_pad|>) is valid; only missing, eos-collision
-    and out-of-range pads are healed.
+    and out-of-range pads are healed. Only the tokenizer's OWN eos defines a bad pad:
+    a token that also appears in a model/generation multi-EOS stop list (e.g. Qwen pads
+    with <|endoftext|>, which is also a secondary generation stop id) is still a valid,
+    distinct pad and must be left alone.
     """
     if not hasattr(inner, "pad_token"):
         return None
@@ -126,31 +148,27 @@ def _classify_bad_pad(inner, vocab_size):
     return None
 
 
-def _try_whisper_config_pad(inner, cfg, reason, vocab_size):
-    """Use Whisper's existing config-declared pad token when it is safe."""
-    if reason != "equals_eos" or cfg is None:
-        return None
-    model_type = getattr(cfg, "model_type", "")
-    if not isinstance(model_type, str) or model_type.lower() != "whisper":
-        return None
+def _config_declared_pad(inner, cfg, eos_token_ids, vocab_size):
+    """Reuse the model config's own declared pad_token_id, as a last resort before
+    synthesizing a brand-new token.
 
+    Some shipped tokenizers alias pad to eos (or leave pad out of range) even though the
+    model config already declares a valid, distinct pad id pointing at an existing token.
+    Whisper-large-v3 is the canonical case (config pad 50256 -> the existing empty token,
+    while the tokenizer reports pad == eos == 50257), but the pattern is not Whisper
+    specific, so this stays model-type agnostic. Honoring that declared id avoids adding a
+    token and resizing embeddings. Guards: the id must be a real int (not bool), in vocab,
+    distinct from every known EOS id, and round-trip cleanly through the tokenizer. Runs
+    only after the reserved-token search fails, so it never overrides a pad-named choice
+    for an already-working model.
+    """
+    if cfg is None:
+        return None
     pad_token_id = getattr(cfg, "pad_token_id", None)
-    if not isinstance(pad_token_id, int) or pad_token_id < 0:
+    if type(pad_token_id) is not int or pad_token_id < 0:
         return None
-    if vocab_size is None or pad_token_id >= vocab_size:
+    if vocab_size is not None and pad_token_id >= vocab_size:
         return None
-
-    eos_token_ids = set()
-    for eos_token_id in (
-        getattr(cfg, "eos_token_id", None),
-        getattr(inner, "eos_token_id", None),
-    ):
-        if isinstance(eos_token_id, int):
-            eos_token_ids.add(eos_token_id)
-        elif isinstance(eos_token_id, (list, tuple, set)):
-            eos_token_ids.update(
-                token_id for token_id in eos_token_id if isinstance(token_id, int)
-            )
     if pad_token_id in eos_token_ids:
         return None
 
@@ -160,9 +178,8 @@ def _try_whisper_config_pad(inner, cfg, reason, vocab_size):
         return None
     try:
         candidate = convert_ids_to_tokens(pad_token_id)
-        # Whisper large-v3 reserves an existing empty token at config pad id 50256.
-        # Keep this repair narrow instead of promoting an arbitrary model token.
-        if candidate != "" or convert_tokens_to_ids(candidate) != pad_token_id:
+        # Require a clean round-trip so we never promote an unknown / unstable id.
+        if candidate is None or convert_tokens_to_ids(candidate) != pad_token_id:
             return None
     except Exception:
         return None
@@ -182,8 +199,8 @@ def _try_whisper_config_pad(inner, cfg, reason, vocab_size):
     return candidate
 
 
-def _single_token_id(inner, token, vocab_size):
-    """Return token's id if it encodes to exactly one in-vocab id, else None."""
+def _single_token_id(inner, token, vocab_size, eos_token_ids=frozenset()):
+    """Return token's id if it encodes to exactly one in-vocab, non-EOS id, else None."""
     try:
         ids = inner(token, add_special_tokens=False).input_ids
     except Exception:
@@ -193,10 +210,12 @@ def _single_token_id(inner, token, vocab_size):
     token_id = ids[0]
     if vocab_size is not None and token_id >= vocab_size:
         return None
+    if token_id in eos_token_ids:
+        return None
     return token_id
 
 
-def _find_reserved_pad(inner, eos_token, vocab_size):
+def _find_reserved_pad(inner, eos_token, vocab_size, eos_token_ids=frozenset()):
     """Pick the best reserved/pad-named token already in the vocab, or None."""
     try:
         added = [_token_content(t) for t in inner.added_tokens_decoder.values()]
@@ -218,7 +237,7 @@ def _find_reserved_pad(inner, eos_token, vocab_size):
         for candidate in ordered:
             if candidate == eos_token:
                 continue
-            if _single_token_id(inner, candidate, vocab_size) is not None:
+            if _single_token_id(inner, candidate, vocab_size, eos_token_ids) is not None:
                 return candidate
 
     # Last resort: any pad sentinel (a bracketed "*pad*" token such as <|fim_pad|>)
@@ -228,17 +247,17 @@ def _find_reserved_pad(inner, eos_token, vocab_size):
     for candidate in added:
         if candidate == eos_token or not _is_pad_named(candidate):
             continue
-        if _single_token_id(inner, candidate, vocab_size) is not None:
+        if _single_token_id(inner, candidate, vocab_size, eos_token_ids) is not None:
             return candidate
     return None
 
 
-def _unk_fallback(inner, eos_token, vocab_size):
+def _unk_fallback(inner, eos_token, vocab_size, eos_token_ids=frozenset()):
     """Last-resort existing-token pad: reuse unk_token (Llama-2 style), or None."""
     unk = getattr(inner, "unk_token", None)
     if not unk or unk == eos_token:
         return None
-    if _single_token_id(inner, unk, vocab_size) is not None:
+    if _single_token_id(inner, unk, vocab_size, eos_token_ids) is not None:
         return unk
     return None
 
@@ -254,8 +273,10 @@ def fix_pad_token(
     """Heal a bad/missing pad_token in place.
 
     Returns a result dict: {changed, reason, old_pad, new_pad, added}. No-op (and
-    `changed=False`) when the pad_token is already valid and distinct from eos.
-    With `allow_add=False` (tokenizer-only callers with no model to resize) a brand
+    `changed=False`) when the pad_token is already valid and distinct from eos. Repair
+    order: an existing reserved/pad-named token, then the tokenizer's unk, then the model
+    config's own declared pad id (reused, no resize), and only if all fail a brand-new
+    token. With `allow_add=False` (tokenizer-only callers with no model to resize) a brand
     new pad token is never added; repair is deferred to the model-aware call.
     `is_vision_model` is accepted for API compatibility but unused: any pad-named
     token is a valid pad regardless of modality.
@@ -270,7 +291,19 @@ def fix_pad_token(
 
     cfg = model_config if model_config is not None else getattr(model, "config", None)
     vocab_size = getattr(cfg, "vocab_size", None)
+    if type(vocab_size) is not int:
+        # A malformed (e.g. string) vocab_size must not crash a later `id >= vocab_size`
+        # comparison; treat it as unknown and skip range checks.
+        vocab_size = None
     eos_token = getattr(inner, "eos_token", None)
+    # EOS ids used to reject a replacement pad that would alias an EOS: the tokenizer's own
+    # and the model config's (each a scalar or a multi-EOS list). Deliberately NOT the
+    # generation_config stop list, which legitimately lists a valid pad (Qwen's
+    # <|endoftext|>) and must not drive pad selection.
+    eos_token_ids = _eos_id_set(
+        getattr(inner, "eos_token_id", None),
+        getattr(cfg, "eos_token_id", None),
+    )
 
     reason = _classify_bad_pad(inner, vocab_size)
     if reason is None:
@@ -278,28 +311,32 @@ def fix_pad_token(
     result["reason"] = reason
     result["old_pad"] = getattr(inner, "pad_token", None)
 
-    whisper_pad = _try_whisper_config_pad(inner, cfg, reason, vocab_size)
-    if whisper_pad is not None:
-        result.update(changed=True, new_pad=whisper_pad, added=False)
-        pad_token_id = getattr(inner, "pad_token_id", None)
-        if model is not None:
-            model_cfg = getattr(model, "config", None)
-            if model_cfg is not None:
-                model_cfg.update({"pad_token_id": pad_token_id})
-            if getattr(model, "generation_config", None) is not None:
-                model.generation_config.update(pad_token_id=pad_token_id)
-        name = _display_name(model, model_config, inner)
-        print(
-            f"Unsloth: {name} had a bad pad_token ({result['old_pad']}). "
-            f"Using model config pad_token_id = {pad_token_id} ({whisper_pad!r})."
-        )
-        return result
-
-    new_pad = _find_reserved_pad(inner, eos_token, vocab_size)
+    new_pad = _find_reserved_pad(inner, eos_token, vocab_size, eos_token_ids)
     if new_pad is None:
-        new_pad = _unk_fallback(inner, eos_token, vocab_size)
-    added = False
+        new_pad = _unk_fallback(inner, eos_token, vocab_size, eos_token_ids)
 
+    if new_pad is None:
+        # Before synthesizing a token and resizing embeddings, honor the model config's
+        # own declared pad id when it is safe (Whisper-large-v3 and any similarly
+        # misconfigured tokenizer). This reuses an existing token, so no resize.
+        config_pad = _config_declared_pad(inner, cfg, eos_token_ids, vocab_size)
+        if config_pad is not None:
+            result.update(changed=True, new_pad=config_pad, added=False)
+            pad_token_id = getattr(inner, "pad_token_id", None)
+            if model is not None:
+                model_cfg = getattr(model, "config", None)
+                if model_cfg is not None:
+                    model_cfg.update({"pad_token_id": pad_token_id})
+                if getattr(model, "generation_config", None) is not None:
+                    model.generation_config.update(pad_token_id=pad_token_id)
+            name = _display_name(model, model_config, inner)
+            print(
+                f"Unsloth: {name} had a bad pad_token ({result['old_pad']}). "
+                f"Using model config pad_token_id = {pad_token_id} ({config_pad!r})."
+            )
+            return result
+
+    added = False
     if new_pad is None:
         if not allow_add:
             # No model here to resize embeddings; let the model-aware call repair.

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -130,7 +130,8 @@ def _try_whisper_config_pad(inner, cfg, reason, vocab_size):
     """Use Whisper's existing config-declared pad token when it is safe."""
     if reason != "equals_eos" or cfg is None:
         return None
-    if (getattr(cfg, "model_type", "") or "").lower() != "whisper":
+    model_type = getattr(cfg, "model_type", "")
+    if not isinstance(model_type, str) or model_type.lower() != "whisper":
         return None
 
     pad_token_id = getattr(cfg, "pad_token_id", None)
@@ -139,14 +140,17 @@ def _try_whisper_config_pad(inner, cfg, reason, vocab_size):
     if vocab_size is None or pad_token_id >= vocab_size:
         return None
 
-    eos_token_ids = {
-        token_id
-        for token_id in (
-            getattr(cfg, "eos_token_id", None),
-            getattr(inner, "eos_token_id", None),
-        )
-        if isinstance(token_id, int)
-    }
+    eos_token_ids = set()
+    for eos_token_id in (
+        getattr(cfg, "eos_token_id", None),
+        getattr(inner, "eos_token_id", None),
+    ):
+        if isinstance(eos_token_id, int):
+            eos_token_ids.add(eos_token_id)
+        elif isinstance(eos_token_id, (list, tuple, set)):
+            eos_token_ids.update(
+                token_id for token_id in eos_token_id if isinstance(token_id, int)
+            )
     if pad_token_id in eos_token_ids:
         return None
 

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -126,6 +126,58 @@ def _classify_bad_pad(inner, vocab_size):
     return None
 
 
+def _try_whisper_config_pad(inner, cfg, reason, vocab_size):
+    """Use Whisper's existing config-declared pad token when it is safe."""
+    if reason != "equals_eos" or cfg is None:
+        return None
+    if (getattr(cfg, "model_type", "") or "").lower() != "whisper":
+        return None
+
+    pad_token_id = getattr(cfg, "pad_token_id", None)
+    if not isinstance(pad_token_id, int) or pad_token_id < 0:
+        return None
+    if vocab_size is None or pad_token_id >= vocab_size:
+        return None
+
+    eos_token_ids = {
+        token_id
+        for token_id in (
+            getattr(cfg, "eos_token_id", None),
+            getattr(inner, "eos_token_id", None),
+        )
+        if isinstance(token_id, int)
+    }
+    if pad_token_id in eos_token_ids:
+        return None
+
+    convert_ids_to_tokens = getattr(inner, "convert_ids_to_tokens", None)
+    convert_tokens_to_ids = getattr(inner, "convert_tokens_to_ids", None)
+    if not callable(convert_ids_to_tokens) or not callable(convert_tokens_to_ids):
+        return None
+    try:
+        candidate = convert_ids_to_tokens(pad_token_id)
+        # Whisper large-v3 reserves an existing empty token at config pad id 50256.
+        # Keep this repair narrow instead of promoting an arbitrary model token.
+        if candidate != "" or convert_tokens_to_ids(candidate) != pad_token_id:
+            return None
+    except Exception:
+        return None
+
+    old_pad = getattr(inner, "pad_token", None)
+    try:
+        inner.pad_token = candidate
+        if getattr(inner, "pad_token_id", None) != pad_token_id:
+            inner.pad_token = old_pad
+            return None
+    except Exception:
+        try:
+            inner.pad_token = old_pad
+        except Exception:
+            pass
+        return None
+    return candidate
+
+
 def _single_token_id(inner, token, vocab_size):
     """Return token's id if it encodes to exactly one in-vocab id, else None."""
     try:
@@ -221,6 +273,23 @@ def fix_pad_token(
         return result
     result["reason"] = reason
     result["old_pad"] = getattr(inner, "pad_token", None)
+
+    whisper_pad = _try_whisper_config_pad(inner, cfg, reason, vocab_size)
+    if whisper_pad is not None:
+        result.update(changed=True, new_pad=whisper_pad, added=False)
+        pad_token_id = getattr(inner, "pad_token_id", None)
+        if model is not None:
+            model_cfg = getattr(model, "config", None)
+            if model_cfg is not None:
+                model_cfg.update({"pad_token_id": pad_token_id})
+            if getattr(model, "generation_config", None) is not None:
+                model.generation_config.update(pad_token_id=pad_token_id)
+        name = _display_name(model, model_config, inner)
+        print(
+            f"Unsloth: {name} had a bad pad_token ({result['old_pad']}). "
+            f"Using model config pad_token_id = {pad_token_id} ({whisper_pad!r})."
+        )
+        return result
 
     new_pad = _find_reserved_pad(inner, eos_token, vocab_size)
     if new_pad is None:

--- a/unsloth_zoo/pad_token.py
+++ b/unsloth_zoo/pad_token.py
@@ -148,7 +148,7 @@ def _classify_bad_pad(inner, vocab_size):
     return None
 
 
-def _config_declared_pad(inner, cfg, eos_token_ids, vocab_size):
+def _config_declared_pad(inner, cfg, eos_token, eos_token_ids, vocab_size):
     """Reuse the model config's own declared pad_token_id, as a last resort before
     synthesizing a brand-new token.
 
@@ -158,7 +158,9 @@ def _config_declared_pad(inner, cfg, eos_token_ids, vocab_size):
     while the tokenizer reports pad == eos == 50257), but the pattern is not Whisper
     specific, so this stays model-type agnostic. Honoring that declared id avoids adding a
     token and resizing embeddings. Guards: the id must be a real int (not bool), in vocab,
-    distinct from every known EOS id, and round-trip cleanly through the tokenizer. Runs
+    distinct from every known EOS id, and round-trip cleanly through the tokenizer; the
+    token it resolves to must also differ from the eos token itself, so a config that
+    declares pad == eos can never re-alias the two (the very bug being repaired). Runs
     only after the reserved-token search fails, so it never overrides a pad-named choice
     for an already-working model.
     """
@@ -178,8 +180,12 @@ def _config_declared_pad(inner, cfg, eos_token_ids, vocab_size):
         return None
     try:
         candidate = convert_ids_to_tokens(pad_token_id)
-        # Require a clean round-trip so we never promote an unknown / unstable id.
-        if candidate is None or convert_tokens_to_ids(candidate) != pad_token_id:
+        # Require a clean round-trip so we never promote an unknown / unstable id, and
+        # reject the eos token by name as well as by id: a tokenizer that does not expose
+        # eos_token_id would otherwise let a config-declared pad == eos slip through.
+        if candidate is None or candidate == eos_token:
+            return None
+        if convert_tokens_to_ids(candidate) != pad_token_id:
             return None
     except Exception:
         return None
@@ -319,7 +325,7 @@ def fix_pad_token(
         # Before synthesizing a token and resizing embeddings, honor the model config's
         # own declared pad id when it is safe (Whisper-large-v3 and any similarly
         # misconfigured tokenizer). This reuses an existing token, so no resize.
-        config_pad = _config_declared_pad(inner, cfg, eos_token_ids, vocab_size)
+        config_pad = _config_declared_pad(inner, cfg, eos_token, eos_token_ids, vocab_size)
         if config_pad is not None:
             result.update(changed=True, new_pad=config_pad, added=False)
             pad_token_id = getattr(inner, "pad_token_id", None)


### PR DESCRIPTION
## Summary

  Fixes loading `unsloth/whisper-large-v3` when its tokenizer aliases pad and EOS.

  The repair reuses Whisper's existing config-declared pad token (`50256`) instead of adding a temporary token or
  resizing embeddings.

  ## Changes

  - Add a Whisper-specific path in `unsloth_zoo/pad_token.py` for the known empty token at the config pad ID.
  - Keep the generic pad-token fallback for non-Whisper and malformed configurations.
  - Reject a candidate pad ID when it appears in either a scalar or list-form EOS configuration.
  - Treat non-string `model_type` values as unsupported and fall back without raising.
  - Add direct-tokenizer and processor-wrapper regression coverage in `tests/test_pad_token.py`.