### PR TITLE
Fix CPU MLX shim: drop duplicate Module.children/__contains__

### DIFF
--- a/tests/mlx_simulation/mlx_nn_stub.py
+++ b/tests/mlx_simulation/mlx_nn_stub.py
@@ -143,32 +143,6 @@ class Module:
                         sub_prefix = f"{prefix}.{attr_name}.{k}" if prefix else f"{attr_name}.{k}"
                         yield from item.named_modules(sub_prefix)
 
-    def __contains__(self, key):
-        """MLX's Module derives from dict, so ``"bias" in module`` is valid on
-        any module and checks the parameter/child entry. Mirror that here by
-        answering for tensor- or Module-valued attributes; subclasses whose
-        parameters live on a wrapped torch module (Linear) override this."""
-        value = getattr(self, key, None)
-        return isinstance(value, (torch.Tensor, Module))
-
-    def children(self):
-        """Direct sub-structure keyed by attribute name, mirroring MLX's
-        ``Module.children()``: Module-valued attributes map to the Module,
-        list/dict containers of Modules map to the container itself (MLX
-        returns the nested structure; consumers type-check the values, so
-        containers fall through their exact-type filters unchanged)."""
-        out = {}
-        for attr_name, attr_val in vars(self).items():
-            if isinstance(attr_val, Module):
-                out[attr_name] = attr_val
-            elif isinstance(attr_val, (list, tuple)):
-                if any(isinstance(item, Module) for item in attr_val):
-                    out[attr_name] = attr_val
-            elif isinstance(attr_val, dict):
-                if any(isinstance(item, Module) for item in attr_val.values()):
-                    out[attr_name] = attr_val
-        return out
-
     def freeze(self, *, recurse=True, keys=None):
         return self
 


### PR DESCRIPTION
## Summary

`Core` CI (the `unsloth_zoo @ main -- full pytest (CPU)` step in unslothai/unsloth) fails on one test:

```
FAILED tests/test_mlx_torch_shim_smoke.py::test_module_children_preserves_direct_child_tree
assert children["layers"] == [model.layers[0], {}]
  At index 1 diff: <object object at 0x...> != {}
```

## Root cause

Two PRs landed within ~23 minutes and both added `Module.children()` / `__contains__` to the CPU MLX stub:

- #934 (`fix(tests): implement MLX shim children traversal`) added a structure-preserving `children()` (a Module leaf maps to the Module; non-Module items inside a list/dict map to `{}`; top-level tuples are excluded) and a `vars`-based `__contains__`, plus the smoke test that pins this MLX-faithful behavior.
- #935 (`Fix CPU MLX shim: add Module.children() and a base __contains__ ...`) landed minutes later and re-added its own `children()` and `__contains__` without seeing #934's.

Because the second definitions appear later in the class body, they silently shadow the first (a redefinition, flake8 F811). #935's `children()` returns the raw container unchanged and its `__contains__` resolves via `getattr` (which fires `@property` descriptors), so `test_module_children_preserves_direct_child_tree` fails at the `layers` assertion.

## Fix

Remove the duplicate (`#935`) definitions and keep #934's versions, which the test encodes and which mirror MLX's `Module.children()` (`filter_and_map` with the child filter).

## Test

- `tests/test_mlx_torch_shim_smoke.py`: 57 passed.
- The full MLX suite, including the output-head resolution paths #935 targeted (`test_mlx_adapter_metadata_persistence`, `test_mlx_qk_norm_version_gap`, `test_mlx_dequantize_modules`, `test_mlx_cce_kernel`, `test_mlx_save_lora_adapters_filter`): 545 passed, 58 skipped.