### PR TITLE
fix(mlx): freeze base when reloading a LoRA adapter for continued training

### DIFF
--- a/tests/test_mlx_ddp_metal.py
+++ b/tests/test_mlx_ddp_metal.py
@@ -382,6 +382,21 @@ try:
     resume_mismatch = ""
 except RuntimeError as exc:
     resume_mismatch = str(exc)
+adapter_only = Path(sys.argv[1], "resume_adapter_only"); adapter_only.mkdir(exist_ok=True)
+(adapter_only / "adapters.safetensors").write_text("x")
+try:
+    trainer._validate_distributed_resume_checkpoint(adapter_only)
+    resume_adapter_only = ""
+except RuntimeError as exc:
+    resume_adapter_only = str(exc)
+no_adapters = Path(sys.argv[1], "resume_no_adapters"); no_adapters.mkdir(exist_ok=True)
+for name in ("optimizer_state.safetensors", "trainer_state.json"):
+    (no_adapters / name).write_text("x")
+try:
+    trainer._validate_distributed_resume_checkpoint(no_adapters)
+    resume_no_adapters = ""
+except RuntimeError as exc:
+    resume_no_adapters = str(exc)
 def vlm_stream_rejection():
     try:
         next(iter(iterate_vlm_training_batches(ReplayableVLMStream(), TinyProcessor(), {"image_token_id": 20}, batch_size=2, max_seq_length=8, dataset_order="sequential", comm_group=world)))
@@ -448,6 +463,8 @@ payload = {
     "vlm_compile_parity_tokens": int(vlm_compile_parity_result["trained_tokens"]),
     "resume_ok": Path(trainer._validate_distributed_resume_checkpoint(ckpt)).name,
     "resume_mismatch": resume_mismatch,
+    "resume_adapter_only": resume_adapter_only,
+    "resume_no_adapters": resume_no_adapters,
     "default": first_token_rows(create_batches(data, TinyTokenizer(), seed=1, **common)),
     "ordered": first_token_rows(create_ordered_batches(data, TinyTokenizer(), dataset_order="sequential", **common)),
     "labeled": first_token_rows(_create_labeled_batches(data, TinyTokenizer(), keep_all_labels, dataset_order="sequential", **common)),
@@ -561,6 +578,22 @@ Path(sys.argv[1], f"rank{world.rank()}.json").write_text(json.dumps(payload))
     assert abs(ranks[0]["vlm_param_sum"] - ranks[1]["vlm_param_sum"]) < 1e-5
     assert [rank["resume_ok"] for rank in ranks] == ["resume_ckpt", "resume_ckpt"]
     assert all("all ranks must either resume" in rank["resume_mismatch"] for rank in ranks)
+    # An adapter-only directory is the mistake the single-process resume gate
+    # names FastMLXModel.from_pretrained for; DDP must name it on every rank
+    # instead of blaming cross-rank file visibility.
+    assert all(
+        "FastMLXModel.from_pretrained" in rank["resume_adapter_only"]
+        and "optimizer_state.safetensors" in rank["resume_adapter_only"]
+        and "trainer_state.json" in rank["resume_adapter_only"]
+        for rank in ranks
+    ), [rank["resume_adapter_only"] for rank in ranks]
+    # A directory that is not adapter-shaped keeps the coordinated
+    # visibility message, which warm-start guidance would not fit.
+    assert all(
+        "not visible on every rank" in rank["resume_no_adapters"]
+        and "FastMLXModel.from_pretrained" not in rank["resume_no_adapters"]
+        for rank in ranks
+    ), [rank["resume_no_adapters"] for rank in ranks]
     for prefix in ("ckpt_adapter", "ckpt_opt", "ckpt_state", "final"):
         assert (tmp_path / f"{prefix}_rank0").exists()
         assert not (tmp_path / f"{prefix}_rank1").exists()

--- a/tests/test_mlx_module_exports.py
+++ b/tests/test_mlx_module_exports.py
@@ -205,6 +205,37 @@ def test_trainer_config_smoke():
     assert ok
 
 
+# ---------------------------------------------------------------------------
+# 8. Warm-start contract: the documented from_pretrained behaviour must match
+#    the adapter-reload code. The reload restores the non-adapter tensors a
+#    save_trainable_adapters checkpoint recorded as trainable, so the docstring
+#    must describe that instead of promising an adapter-only trainable set.
+# ---------------------------------------------------------------------------
+
+def test_from_pretrained_documents_restored_non_adapter_trainables():
+    import inspect
+    import unsloth_zoo.mlx.loader as ml
+
+    source = inspect.getsource(ml.FastMLXModel.from_pretrained)
+    assert "_unfreeze_saved_mlx_non_adapter_parameters(" in source, (
+        "adapter reload no longer restores saved non-adapter trainables; "
+        "the from_pretrained docstring must be updated to match"
+    )
+    doc = inspect.getdoc(ml.FastMLXModel.from_pretrained) or ""
+    assert "save_trainable_adapters" in doc, (
+        "from_pretrained restores the non-adapter tensors held by a "
+        "save_trainable_adapters checkpoint, but its docstring never says so"
+    )
+    stale = [
+        phrase for phrase in ("are not re-enabled", "re-specify them")
+        if phrase in doc
+    ]
+    assert not stale, (
+        "from_pretrained docstring still claims saved non-adapter tensors stay "
+        f"frozen on reload: {stale}"
+    )
+
+
 def test_adam_optimizers_enable_bias_correction():
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
 

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -8,6 +8,7 @@ functions (CCE and baseline).
 """
 
 import glob
+import json
 import os
 
 import pytest
@@ -30,7 +31,8 @@ if _METAL:
     from unsloth_zoo.mlx.loader import FastMLXModel
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
     from unsloth_zoo.mlx.utils import (
-        FiniteTextBatchPlan, _FiniteTextRow, make_baseline_loss_fn,
+        FiniteTextBatchPlan, _FiniteTextRow, collect_mlx_lora_adapter_tensors,
+        make_baseline_loss_fn,
     )
 
 MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
@@ -296,3 +298,185 @@ def test_evaluation_failure_propagates_without_eager_retry(tmp_path, monkeypatch
                     overrides={"compile_mode": "best_effort"})
     assert state["step_ran"] and state["raised"]
     assert "falling back to eager" not in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Warm-starting continued training from a saved adapter.
+#
+# Reloading a saved LoRA/DoRA adapter via FastMLXModel.from_pretrained must
+# return the same trainable state as a fresh get_peft_model (base frozen,
+# adapter trainable), so a new MLXTrainer continues adapter training with a
+# fresh optimizer instead of silently full-finetuning the base. These use a
+# tiny locally-built unquantized Llama (no pretrained-model download; a small
+# tokenizer is fetched once) so the full_finetuning and DoRA branches are cheap.
+# ---------------------------------------------------------------------------
+
+
+def _trainable_names(model):
+    return {name for name, _ in tree_flatten(model.trainable_parameters())}
+
+
+def _adapter_keys(model):
+    # The canonical adapter parameter set the production code targets
+    # (lora_a/lora_b for every LoRA module, plus m for DoRA modules only).
+    return set(collect_mlx_lora_adapter_tensors(model).keys())
+
+
+def _tiny_base(path):
+    """Write a tiny unquantized HF Llama + tokenizer to ``path``."""
+    import torch
+    from transformers import LlamaConfig, LlamaForCausalLM, AutoTokenizer
+    # vocab_size matches hf-internal-testing/llama-tokenizer so tokenized
+    # training inputs stay in range (out-of-range ids would silently corrupt
+    # the embedding/label ops under unchecked Metal indexing).
+    cfg = LlamaConfig(
+        hidden_size=64, intermediate_size=128, num_hidden_layers=2,
+        num_attention_heads=4, num_key_value_heads=2, vocab_size=32000,
+        max_position_embeddings=128, tie_word_embeddings=False,
+    )
+    LlamaForCausalLM(cfg).save_pretrained(path, safe_serialization=True)
+    AutoTokenizer.from_pretrained(
+        "hf-internal-testing/llama-tokenizer"
+    ).save_pretrained(path)
+    return path
+
+
+def _save_lora_adapter(base_path, adapter_path):
+    """Attach LoRA to the tiny base and save an adapter directory."""
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    model, _ = FastMLXModel.from_pretrained(
+        str(base_path), load_in_4bit=False, max_seq_length=64,
+    )
+    model = FastMLXModel.get_peft_model(
+        model, r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"],
+    )
+    save_lora_adapters(model, str(adapter_path))
+    return adapter_path
+
+
+def _save_dora_adapter(base_path, adapter_path):
+    """Build a DoRA adapter with mlx-lm and save it in reloadable form."""
+    from mlx_lm.tuner.utils import linear_to_lora_layers
+    model, _ = FastMLXModel.from_pretrained(
+        str(base_path), load_in_4bit=False, max_seq_length=64,
+    )
+    num_layers = 2
+    lora_params = {"rank": 8, "scale": 16.0, "dropout": 0.0,
+                   "keys": ["self_attn.q_proj", "self_attn.v_proj"]}
+    model.freeze()
+    linear_to_lora_layers(model, num_layers, lora_params, use_dora=True)
+    os.makedirs(adapter_path, exist_ok=True)
+    mx.save_safetensors(
+        os.path.join(str(adapter_path), "adapters.safetensors"),
+        dict(tree_flatten(model.trainable_parameters())),
+    )
+    with open(os.path.join(str(adapter_path), "adapter_config.json"), "w") as f:
+        json.dump({"fine_tune_type": "dora", "num_layers": num_layers,
+                   "lora_parameters": lora_params,
+                   "base_model_name_or_path": str(base_path)}, f)
+    return adapter_path
+
+
+@metal_only
+def test_adapter_reload_freezes_base(tmp_path):
+    base = _tiny_base(tmp_path / "base")
+    adapter = _save_lora_adapter(base, tmp_path / "adapter")
+
+    model, _ = FastMLXModel.from_pretrained(
+        str(adapter), load_in_4bit=False, max_seq_length=64,
+    )
+    adapter_keys = _adapter_keys(model)
+    assert any(n.endswith("lora_a") for n in adapter_keys)
+    # The regression: the whole base used to come back trainable. The trainable
+    # set must be exactly the adapter tensors, nothing more.
+    assert _trainable_names(model) == adapter_keys
+
+
+@metal_only
+def test_warm_start_trains_only_adapter(tmp_path):
+    base = _tiny_base(tmp_path / "base")
+    adapter = _save_lora_adapter(base, tmp_path / "adapter")
+
+    model, tok = FastMLXModel.from_pretrained(
+        str(adapter), load_in_4bit=False, max_seq_length=64,
+    )
+    # A non-adapter base weight must be untouched by warm-start training, while
+    # an adapter tensor must actually change (else a no-op run would pass).
+    probe_key = "model.layers.0.mlp.down_proj.weight"
+    lora_key = next(n for n in _trainable_names(model) if n.endswith("lora_b"))
+    params_before = dict(tree_flatten(model.parameters()))
+    base_before = params_before[probe_key]
+    lora_before = params_before[lora_key]
+    cfg = MLXTrainingConfig(
+        output_dir=str(tmp_path / "out"), per_device_train_batch_size=2,
+        max_steps=2, learning_rate=1e-3, compile=False, use_cce=False,
+        report_to="none",
+    )
+    MLXTrainer(
+        model=model, tokenizer=tok,
+        train_dataset=[{"text": f"warm start {i}"} for i in range(6)],
+        args=cfg,
+    ).train()
+    params_after = dict(tree_flatten(model.parameters()))
+    assert mx.array_equal(base_before, params_after[probe_key])
+    assert not mx.array_equal(lora_before, params_after[lora_key])
+    assert _trainable_names(model) == _adapter_keys(model)
+
+
+@metal_only
+def test_dora_reload_keeps_magnitude_trainable(tmp_path):
+    base = _tiny_base(tmp_path / "base")
+    adapter = _save_dora_adapter(base, tmp_path / "dora")
+
+    from unsloth_zoo.mlx.utils import iter_mlx_lora_modules
+    model, _ = FastMLXModel.from_pretrained(
+        str(adapter), load_in_4bit=False, max_seq_length=64,
+    )
+    trainable = _trainable_names(model)
+    dora_modules = [n for n, m in iter_mlx_lora_modules(model)
+                    if type(m).__name__.startswith("DoRA")]
+    assert len(dora_modules) > 0
+    # Every DoRA magnitude must stay trainable (not just one).
+    assert len([n for n in trainable if n.endswith(".m")]) == len(dora_modules)
+    # Trainable set is exactly the adapter tensors (lora_a/lora_b + DoRA m),
+    # so no base weight leaks in. (A regression that also unfroze an unrelated
+    # base parameter literally named "m" is not observable on this stock-Llama
+    # fixture, which has none; that pathological case is left to follow-up.)
+    assert trainable == _adapter_keys(model)
+
+
+@metal_only
+def test_full_finetuning_reload_keeps_base_trainable(tmp_path):
+    base = _tiny_base(tmp_path / "base")
+    adapter = _save_lora_adapter(base, tmp_path / "adapter")
+
+    model, _ = FastMLXModel.from_pretrained(
+        str(adapter), load_in_4bit=False, max_seq_length=64,
+        full_finetuning=True,
+    )
+    # full_finetuning is an explicit full-training request: the freeze is
+    # skipped, so the trainable set strictly exceeds the adapter tensors.
+    assert _trainable_names(model) > _adapter_keys(model)
+
+
+@metal_only
+def test_resume_from_adapter_dir_names_warm_start(tmp_path):
+    base = _tiny_base(tmp_path / "base")
+    adapter = _save_lora_adapter(base, tmp_path / "adapter")
+
+    model, tok = FastMLXModel.from_pretrained(
+        str(adapter), load_in_4bit=False, max_seq_length=64,
+    )
+    cfg = MLXTrainingConfig(
+        output_dir=str(tmp_path / "out"), per_device_train_batch_size=2,
+        max_steps=2, learning_rate=1e-3, compile=False, use_cce=False,
+        report_to="none",
+    )
+    trainer = MLXTrainer(
+        model=model, tokenizer=tok,
+        train_dataset=[{"text": f"row {i}"} for i in range(6)], args=cfg,
+    )
+    # The adapter dir has no optimizer_state.safetensors, so resume must fail
+    # and point at the warm-start route rather than silently restarting.
+    with pytest.raises(RuntimeError, match="from_pretrained"):
+        trainer.train(resume_from_checkpoint=str(adapter))

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -301,14 +301,10 @@ def test_evaluation_failure_propagates_without_eager_retry(tmp_path, monkeypatch
 
 
 # ---------------------------------------------------------------------------
-# Warm-starting continued training from a saved adapter.
-#
-# Reloading a saved LoRA/DoRA adapter via FastMLXModel.from_pretrained must
-# return the same trainable state as a fresh get_peft_model (base frozen,
-# adapter trainable), so a new MLXTrainer continues adapter training with a
-# fresh optimizer instead of silently full-finetuning the base. These use a
-# tiny locally-built unquantized Llama (no pretrained-model download; a small
-# tokenizer is fetched once) so the full_finetuning and DoRA branches are cheap.
+# Warm-starting continued training from a saved adapter: reloading a LoRA/DoRA
+# adapter via FastMLXModel.from_pretrained must give the same trainable state as
+# a fresh get_peft_model (base frozen, adapter trainable). Uses a tiny
+# locally-built Llama so the full_finetuning and DoRA branches stay cheap.
 # ---------------------------------------------------------------------------
 
 
@@ -317,8 +313,7 @@ def _trainable_names(model):
 
 
 def _adapter_keys(model):
-    # The canonical adapter parameter set the production code targets
-    # (lora_a/lora_b for every LoRA module, plus m for DoRA modules only).
+    # lora_a/lora_b for every LoRA module, plus m for DoRA modules only.
     return set(collect_mlx_lora_adapter_tensors(model).keys())
 
 
@@ -326,9 +321,8 @@ def _tiny_base(path):
     """Write a tiny unquantized HF Llama + tokenizer to ``path``."""
     import torch
     from transformers import LlamaConfig, LlamaForCausalLM, AutoTokenizer
-    # vocab_size matches hf-internal-testing/llama-tokenizer so tokenized
-    # training inputs stay in range (out-of-range ids would silently corrupt
-    # the embedding/label ops under unchecked Metal indexing).
+    # vocab_size matches hf-internal-testing/llama-tokenizer so token ids stay
+    # in range (Metal indexing is unchecked).
     cfg = LlamaConfig(
         hidden_size=64, intermediate_size=128, num_hidden_layers=2,
         num_attention_heads=4, num_key_value_heads=2, vocab_size=32000,
@@ -387,8 +381,7 @@ def test_adapter_reload_freezes_base(tmp_path):
     )
     adapter_keys = _adapter_keys(model)
     assert any(n.endswith("lora_a") for n in adapter_keys)
-    # The regression: the whole base used to come back trainable. The trainable
-    # set must be exactly the adapter tensors, nothing more.
+    # The regression: the whole base used to come back trainable.
     assert _trainable_names(model) == adapter_keys
 
 
@@ -400,8 +393,8 @@ def test_warm_start_trains_only_adapter(tmp_path):
     model, tok = FastMLXModel.from_pretrained(
         str(adapter), load_in_4bit=False, max_seq_length=64,
     )
-    # A non-adapter base weight must be untouched by warm-start training, while
-    # an adapter tensor must actually change (else a no-op run would pass).
+    # A base weight must stay untouched while an adapter tensor must change
+    # (else a no-op run would pass).
     probe_key = "model.layers.0.mlp.down_proj.weight"
     lora_key = next(n for n in _trainable_names(model) if n.endswith("lora_b"))
     params_before = dict(tree_flatten(model.parameters()))
@@ -438,10 +431,9 @@ def test_dora_reload_keeps_magnitude_trainable(tmp_path):
     assert len(dora_modules) > 0
     # Every DoRA magnitude must stay trainable (not just one).
     assert len([n for n in trainable if n.endswith(".m")]) == len(dora_modules)
-    # Trainable set is exactly the adapter tensors (lora_a/lora_b + DoRA m),
-    # so no base weight leaks in. (A regression that also unfroze an unrelated
-    # base parameter literally named "m" is not observable on this stock-Llama
-    # fixture, which has none; that pathological case is left to follow-up.)
+    # Exactly the adapter tensors, so no base weight leaks in. (A base parameter
+    # literally named "m" does not exist on this fixture, so that pathological
+    # case is left to follow-up.)
     assert trainable == _adapter_keys(model)
 
 
@@ -454,8 +446,7 @@ def test_full_finetuning_reload_keeps_base_trainable(tmp_path):
         str(adapter), load_in_4bit=False, max_seq_length=64,
         full_finetuning=True,
     )
-    # full_finetuning is an explicit full-training request: the freeze is
-    # skipped, so the trainable set strictly exceeds the adapter tensors.
+    # full_finetuning is an explicit full-training request, so no freeze.
     assert _trainable_names(model) > _adapter_keys(model)
 
 
@@ -476,7 +467,7 @@ def test_resume_from_adapter_dir_names_warm_start(tmp_path):
         model=model, tokenizer=tok,
         train_dataset=[{"text": f"row {i}"} for i in range(6)], args=cfg,
     )
-    # The adapter dir has no optimizer_state.safetensors, so resume must fail
-    # and point at the warm-start route rather than silently restarting.
+    # No optimizer_state.safetensors, so resume must fail and name warm-start
+    # rather than silently restarting.
     with pytest.raises(RuntimeError, match="from_pretrained"):
         trainer.train(resume_from_checkpoint=str(adapter))

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -302,9 +302,10 @@ def test_evaluation_failure_propagates_without_eager_retry(tmp_path, monkeypatch
 
 # ---------------------------------------------------------------------------
 # Warm-starting continued training from a saved adapter: reloading a LoRA/DoRA
-# adapter via FastMLXModel.from_pretrained must give the same trainable state as
-# a fresh get_peft_model (base frozen, adapter trainable). Uses a tiny
-# locally-built Llama so the full_finetuning and DoRA branches stay cheap.
+# adapter via FastMLXModel.from_pretrained must freeze the base and leave the
+# adapter parameters trainable, together with any non-adapter tensors the
+# checkpoint itself recorded as trainable. Uses a tiny locally-built Llama so
+# the full_finetuning and DoRA branches stay cheap.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_mlx_training_e2e_metal.py
+++ b/tests/test_mlx_training_e2e_metal.py
@@ -451,17 +451,24 @@ def test_full_finetuning_reload_keeps_base_trainable(tmp_path):
 
 
 @metal_only
-def test_resume_from_adapter_dir_names_warm_start(tmp_path):
+@pytest.mark.parametrize("prefetch", [False, True])
+def test_resume_from_adapter_dir_names_warm_start(tmp_path, prefetch):
     base = _tiny_base(tmp_path / "base")
     adapter = _save_lora_adapter(base, tmp_path / "adapter")
 
     model, tok = FastMLXModel.from_pretrained(
         str(adapter), load_in_4bit=False, max_seq_length=64,
     )
+    # Single-process streaming prefetch reads resume state early, before the
+    # main resume block; that read must not pre-empt the completeness check
+    # with a raw FileNotFoundError for trainer_state.json.
+    extra = (
+        dict(streaming=True, streaming_prefetch_batches=2) if prefetch else {}
+    )
     cfg = MLXTrainingConfig(
         output_dir=str(tmp_path / "out"), per_device_train_batch_size=2,
         max_steps=2, learning_rate=1e-3, compile=False, use_cce=False,
-        report_to="none",
+        report_to="none", **extra,
     )
     trainer = MLXTrainer(
         model=model, tokenizer=tok,
@@ -471,3 +478,40 @@ def test_resume_from_adapter_dir_names_warm_start(tmp_path):
     # rather than silently restarting.
     with pytest.raises(RuntimeError, match="from_pretrained"):
         trainer.train(resume_from_checkpoint=str(adapter))
+
+
+@metal_only
+def test_reload_keeps_saved_non_adapter_trainables(tmp_path):
+    from unsloth_zoo.mlx.utils import save_trainable_adapters
+
+    base = _tiny_base(tmp_path / "base")
+    model, _ = FastMLXModel.from_pretrained(
+        str(base), load_in_4bit=False, max_seq_length=64,
+    )
+    model = FastMLXModel.get_peft_model(
+        model, r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"],
+    )
+    # Non-adapter tensors a user legitimately trains alongside LoRA.
+    aux = set()
+    modules = dict(model.named_modules())
+    for path in ("model.embed_tokens", "lm_head", "model.norm"):
+        modules[path].unfreeze(recurse=True)
+        aux.update(
+            f"{path}.{name}" for name, _ in tree_flatten(modules[path].parameters())
+        )
+    assert aux <= _trainable_names(model)
+
+    adapter = tmp_path / "adapter"
+    save_trainable_adapters(model, str(adapter))
+    saved = set(mx.load(str(adapter / "adapters.safetensors")).keys())
+    assert aux <= saved
+
+    reloaded, _ = FastMLXModel.from_pretrained(
+        str(adapter), load_in_4bit=False, max_seq_length=64,
+    )
+    trainable = _trainable_names(reloaded)
+    # The base freeze must not silently drop the saved auxiliary trainables.
+    assert aux <= trainable, sorted(aux - trainable)
+    assert _adapter_keys(reloaded) <= trainable
+    # Still a warm start, not a full finetune: nothing beyond adapters + aux.
+    assert trainable == _adapter_keys(reloaded) | aux

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4876,6 +4876,14 @@ class FastMLXModel:
                 parallel text or VLM inference.
             tensor_group: Optional MLX distributed group for tensor parallel
                 text or VLM inference.
+
+        Reloading a saved LoRA/DoRA adapter directory returns a model whose
+        base is frozen and whose adapter parameters are trainable — the same
+        state as a fresh ``get_peft_model`` — so it can be passed straight to a
+        new ``MLXTrainer`` to warm-start continued adapter training with a fresh
+        optimizer and schedule. Non-LoRA weights that were separately trained
+        (for example embeddings or a projector) are not re-enabled for training
+        on reload; re-specify them if continued training of those is needed.
         """
         _coerce_list_extra_special_tokens()
         _mlx_active_distributed_groups(pipeline_group, tensor_group)
@@ -5481,6 +5489,31 @@ class FastMLXModel:
                                 "Unsloth MLX: adapter load failed and "
                                 "adapters.safetensors is missing."
                             )
+                    # A reloaded LoRA/DoRA adapter comes back with the base
+                    # model still trainable: mlx-lm's load_adapters applies the
+                    # adapter layers but, unlike get_peft_model, never freezes
+                    # the base. Left as-is, a fresh MLXTrainer over this model
+                    # would warm-start into a full-base finetune under a
+                    # LoRA-scale learning rate. Restore the get_peft_model
+                    # trainable state (base frozen, adapter trainable) so
+                    # continued training updates only the adapter. Skip when
+                    # full_finetuning was requested (an explicit full-training
+                    # reload) or when no LoRA modules exist (e.g. a
+                    # fine_tune_type="full" adapter), which would otherwise be
+                    # left fully frozen and untrainable.
+                    if not full_finetuning:
+                        from .utils import iter_mlx_lora_modules
+                        _lora_modules = list(iter_mlx_lora_modules(model))
+                        if _lora_modules:
+                            _fix_missing_no_grad(model)
+                            model.freeze()
+                            model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
+                            # DoRA magnitude is unfrozen per DoRA module rather
+                            # than via a global "m" key, so an unrelated base
+                            # parameter named "m" is never made trainable.
+                            for _lora_name, _lora_module in _lora_modules:
+                                if type(_lora_module).__name__.startswith("DoRA"):
+                                    _lora_module.unfreeze(keys=["m"], recurse=False)
                     model = _eval_mlx_model_after_adapter_reload(model)
                     loaded_model_config = getattr(model, "_config", None)
                     is_vlm_model = bool(getattr(model, "_is_vlm_model", False))

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5489,18 +5489,12 @@ class FastMLXModel:
                                 "Unsloth MLX: adapter load failed and "
                                 "adapters.safetensors is missing."
                             )
-                    # A reloaded LoRA/DoRA adapter comes back with the base
-                    # model still trainable: mlx-lm's load_adapters applies the
-                    # adapter layers but, unlike get_peft_model, never freezes
-                    # the base. Left as-is, a fresh MLXTrainer over this model
-                    # would warm-start into a full-base finetune under a
-                    # LoRA-scale learning rate. Restore the get_peft_model
-                    # trainable state (base frozen, adapter trainable) so
-                    # continued training updates only the adapter. Skip when
-                    # full_finetuning was requested (an explicit full-training
-                    # reload) or when no LoRA modules exist (e.g. a
-                    # fine_tune_type="full" adapter), which would otherwise be
-                    # left fully frozen and untrainable.
+                    # mlx-lm's load_adapters applies the adapter layers but,
+                    # unlike get_peft_model, never freezes the base, so a fresh
+                    # MLXTrainer would full-finetune it at a LoRA learning rate.
+                    # Skipped for full_finetuning, and when there are no LoRA
+                    # modules (a fine_tune_type="full" adapter) since that would
+                    # leave the model fully frozen.
                     if not full_finetuning:
                         from .utils import iter_mlx_lora_modules
                         _lora_modules = list(iter_mlx_lora_modules(model))
@@ -5508,9 +5502,8 @@ class FastMLXModel:
                             _fix_missing_no_grad(model)
                             model.freeze()
                             model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
-                            # DoRA magnitude is unfrozen per DoRA module rather
-                            # than via a global "m" key, so an unrelated base
-                            # parameter named "m" is never made trainable.
+                            # Per module, so an unrelated base parameter named
+                            # "m" is never unfrozen.
                             for _lora_name, _lora_module in _lora_modules:
                                 if type(_lora_module).__name__.startswith("DoRA"):
                                     _lora_module.unfreeze(keys=["m"], recurse=False)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5208,12 +5208,15 @@ class FastMLXModel:
                 text or VLM inference.
 
         Reloading a saved LoRA/DoRA adapter directory returns a model whose
-        base is frozen and whose adapter parameters are trainable — the same
-        state as a fresh ``get_peft_model`` — so it can be passed straight to a
-        new ``MLXTrainer`` to warm-start continued adapter training with a fresh
-        optimizer and schedule. Non-LoRA weights that were separately trained
-        (for example embeddings or a projector) are not re-enabled for training
-        on reload; re-specify them if continued training of those is needed.
+        base is frozen and whose adapter parameters are trainable, so it can be
+        passed straight to a new ``MLXTrainer`` to warm-start continued training
+        with a fresh optimizer and schedule. The reload restores the trainable
+        set the checkpoint recorded, not the adapter-only set of a fresh
+        ``get_peft_model``: a directory written by ``save_trainable_adapters``
+        also holds the non-adapter tensors that were trainable at save time
+        (embeddings, the head, a projector, biases or norms), and those come
+        back trainable too. Freeze them again after loading if the continued
+        run should train the adapters alone.
         """
         _coerce_list_extra_special_tokens()
         _mlx_active_distributed_groups(pipeline_group, tensor_group)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5749,9 +5749,6 @@ class FastMLXModel:
                                 f"({_missing_before_load[:5]!r})."
                             )
                         model.load_weights(adapter_weights_file, strict=False)
-                        _unfreeze_saved_mlx_non_adapter_parameters(
-                            model, adapter_weights_file,
-                        )
                     else:
                         from mlx_lm.tuner.utils import load_adapters
 
@@ -5792,6 +5789,14 @@ class FastMLXModel:
                             for _lora_name, _lora_module in _lora_modules:
                                 if type(_lora_module).__name__.startswith("DoRA"):
                                     _lora_module.unfreeze(keys=["m"], recurse=False)
+                    # After the freeze above, never before it: an adapter written
+                    # by save_trainable_adapters also carries non-adapter
+                    # trainables (embeddings, head, projector, biases, norms), and
+                    # restoring them earlier would be undone by that freeze.
+                    if os.path.exists(adapter_weights_file):
+                        _unfreeze_saved_mlx_non_adapter_parameters(
+                            model, adapter_weights_file,
+                        )
                     model = _eval_mlx_model_after_adapter_reload(model)
                     loaded_model_config = getattr(model, "_config", None)
                     is_vlm_model = bool(getattr(model, "_is_vlm_model", False))

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2506,6 +2506,29 @@ class MLXTrainer:
         _resume_from = getattr(self, "_resume_from_checkpoint", None)
         _resume_from = self._validate_distributed_resume_checkpoint(_resume_from)
         if _resume_from:
+            # A complete checkpoint has all three resume files; a saved adapter
+            # directory has only adapters.safetensors. Detect an incomplete set
+            # up front and point the user at the warm-start route, rather than
+            # surfacing a raw mx.load open failure — mx.load raises a generic
+            # RuntimeError (not FileNotFoundError) for a missing file, so the
+            # handler below would not catch it. Mirrors the required-file set of
+            # the distributed resume validator, and uses isfile so a same-named
+            # directory is not mistaken for a present file.
+            _missing_resume = [
+                _f for _f in ("adapters.safetensors",
+                              "optimizer_state.safetensors", "trainer_state.json")
+                if not os.path.isfile(os.path.join(_resume_from, _f))
+            ]
+            if _missing_resume:
+                raise RuntimeError(
+                    f"Unsloth: resume_from_checkpoint={_resume_from!r} is "
+                    f"missing resume state file(s) {_missing_resume}. Refusing "
+                    f"to silently restart from step 0. If this is a saved "
+                    f"adapter directory rather than a training checkpoint and "
+                    f"you meant to start a new run from it with a fresh "
+                    f"optimizer, load it with FastMLXModel.from_pretrained(<dir>) "
+                    f"and train without resume_from_checkpoint."
+                )
             try:
                 # 1. Load trained adapter weights into the model. The model
                 #    already has LoRA wrappers applied (Unsloth pipeline does

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -2506,14 +2506,10 @@ class MLXTrainer:
         _resume_from = getattr(self, "_resume_from_checkpoint", None)
         _resume_from = self._validate_distributed_resume_checkpoint(_resume_from)
         if _resume_from:
-            # A complete checkpoint has all three resume files; a saved adapter
-            # directory has only adapters.safetensors. Detect an incomplete set
-            # up front and point the user at the warm-start route, rather than
-            # surfacing a raw mx.load open failure — mx.load raises a generic
-            # RuntimeError (not FileNotFoundError) for a missing file, so the
-            # handler below would not catch it. Mirrors the required-file set of
-            # the distributed resume validator, and uses isfile so a same-named
-            # directory is not mistaken for a present file.
+            # A saved adapter directory has only adapters.safetensors. Detect an
+            # incomplete resume set up front and name the warm-start route: a
+            # missing file otherwise surfaces as a generic mx.load RuntimeError
+            # that the handler below does not catch.
             _missing_resume = [
                 _f for _f in ("adapters.safetensors",
                               "optimizer_state.safetensors", "trainer_state.json")

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1682,6 +1682,14 @@ class MLXTrainer:
                 "resume_from_checkpoint path."
             )
         if int(missing_total.item()) > 0:
+            # missing_total is all-reduced, so every rank enters this branch
+            # together and raising here cannot strand a peer in a later
+            # collective. A rank that can see adapters.safetensors but not the
+            # rest is holding a saved adapter directory, so give it the same
+            # warm-start guidance the single-process path gives; the plain
+            # visibility failure keeps the coordinated message below.
+            if (path / "adapters.safetensors").is_file():
+                _require_complete_resume_checkpoint(str(path))
             raise RuntimeError(
                 "Unsloth MLX DDP: resume checkpoint is incomplete or not "
                 "visible on every rank. Expected adapters.safetensors, "

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -691,6 +691,32 @@ def _validate_label_smoothing(value, is_vlm):
     return eps
 
 
+def _require_complete_resume_checkpoint(resume_from):
+    """Reject an incomplete resume directory and name the warm-start route.
+
+    A saved adapter directory has only adapters.safetensors. Called from every
+    path that reads resume state, so the streaming-prefetch early read raises
+    the same guidance instead of a raw FileNotFoundError from trainer_state.json.
+    """
+    if not resume_from:
+        return
+    _missing_resume = [
+        _f for _f in ("adapters.safetensors",
+                      "optimizer_state.safetensors", "trainer_state.json")
+        if not os.path.isfile(os.path.join(resume_from, _f))
+    ]
+    if _missing_resume:
+        raise RuntimeError(
+            f"Unsloth: resume_from_checkpoint={resume_from!r} is "
+            f"missing resume state file(s) {_missing_resume}. Refusing "
+            f"to silently restart from step 0. If this is a saved "
+            f"adapter directory rather than a training checkpoint and "
+            f"you meant to start a new run from it with a fresh "
+            f"optimizer, load it with FastMLXModel.from_pretrained(<dir>) "
+            f"and train without resume_from_checkpoint."
+        )
+
+
 def _prune_stale_checkpoints(output_dir, save_total_limit):
     """Keep the newest ``save_total_limit`` checkpoint-* dirs (HF Trainer parity).
 
@@ -2867,6 +2893,10 @@ class MLXTrainer:
                 self._resume_from_checkpoint
             )
             if _early_resume:
+                # Same completeness gate as the main resume block below, which
+                # this early read would otherwise pre-empt with a raw
+                # FileNotFoundError for trainer_state.json.
+                _require_complete_resume_checkpoint(_early_resume)
                 _early_state = load_trainer_state(_early_resume)
                 self._mlx_resume_state_cache = (_early_resume, _early_state)
                 self._mlx_resume_step_for_prefetch = int(
@@ -2951,25 +2981,9 @@ class MLXTrainer:
         _resume_from = getattr(self, "_resume_from_checkpoint", None)
         _resume_from = self._validate_distributed_resume_checkpoint(_resume_from)
         if _resume_from:
-            # A saved adapter directory has only adapters.safetensors. Detect an
-            # incomplete resume set up front and name the warm-start route: a
-            # missing file otherwise surfaces as a generic mx.load RuntimeError
-            # that the handler below does not catch.
-            _missing_resume = [
-                _f for _f in ("adapters.safetensors",
-                              "optimizer_state.safetensors", "trainer_state.json")
-                if not os.path.isfile(os.path.join(_resume_from, _f))
-            ]
-            if _missing_resume:
-                raise RuntimeError(
-                    f"Unsloth: resume_from_checkpoint={_resume_from!r} is "
-                    f"missing resume state file(s) {_missing_resume}. Refusing "
-                    f"to silently restart from step 0. If this is a saved "
-                    f"adapter directory rather than a training checkpoint and "
-                    f"you meant to start a new run from it with a fresh "
-                    f"optimizer, load it with FastMLXModel.from_pretrained(<dir>) "
-                    f"and train without resume_from_checkpoint."
-                )
+            # Up front: a missing file otherwise surfaces as a generic mx.load
+            # RuntimeError that the handler below does not catch.
+            _require_complete_resume_checkpoint(_resume_from)
             try:
                 # 1. Load trained adapter weights into the model. The model
                 #    already has LoRA wrappers applied (Unsloth pipeline does


### PR DESCRIPTION
## Problem

Reloading a saved LoRA/DoRA adapter with `FastMLXModel.from_pretrained(<adapter_dir>)` returned a model whose entire base was still trainable. mlx-lm's `load_adapters` applies the adapter layers but never freezes the base, unlike `get_peft_model`. As a result, passing a reloaded adapter to a fresh `MLXTrainer` to continue training silently full-finetuned the whole base under a LoRA-scale learning rate instead of training only the adapter.

On a small model this is easy to see: after reload, 8 LoRA tensors plus 21 base tensors (~4.17M params — embeddings and every attention/MLP projection) were trainable, whereas a fresh `get_peft_model` on the same base leaves 0 non-adapter tensors trainable.

## Change

At the adapter-reload site, restore the same trainable state a fresh `get_peft_model` produces: freeze the base and unfreeze the adapter (`lora_a`/`lora_b`, plus each DoRA module's magnitude `m`). The step is gated so it does not change any unrelated behavior:

- Skipped when `full_finetuning=True` is requested, since that is an explicit full-training reload.
- Skipped when the adapter has no LoRA modules (for example a `fine_tune_type="full"` adapter), which would otherwise leave the model fully frozen and untrainable.
- DoRA magnitude is unfrozen per DoRA module rather than through a global key, so an unrelated base parameter literally named `m` is never made trainable.
- Preceded by the existing `_fix_missing_no_grad` step so models that lack MLX's no-grad state (for example Gemma 4) do not fail during `freeze()`.

A reloaded adapter directory is now a valid warm-start point: load it and hand it to a new `MLXTrainer` for continued adapter training with a fresh optimizer and schedule.

Separately, `resume_from_checkpoint` now detects an incomplete checkpoint directory up front and points the user at the warm-start route. A saved adapter directory has adapter weights but no optimizer/trainer state, and `mx.load` raises a generic `RuntimeError` (not `FileNotFoundError`) for a missing file, so the previous handler never surfaced a helpful message and users saw a raw load error instead.

## Not changed

Inference and merge paths are unaffected, since neither depends on trainable state. Reloading intentionally does not restore non-LoRA modules that were separately trained (for example embeddings or a projector) to trainable — the saved artifact does not reliably encode per-tensor trainability, so reload matches a fresh `get_peft_model`. Restoring those is left to follow-up.

## Validation

Adds real-MLX coverage in `tests/test_mlx_training_e2e_metal.py`: the reload trainable state, warm-start training updating only the adapter (a probed base weight is unchanged while a LoRA tensor changes), the `full_finetuning` and DoRA branches, and the resume guidance. The full test suite shows no new failures relative to the base branch.

```bash
python -m pytest tests/test_mlx_training_e2e_metal.py \
    -k "reload or warm_start or dora or full_finetuning or resume_from_adapter"
# 5 passed
```
