### PR TITLE
Fix vLLM direct LoRA hot-load: up_proj never loaded + aliased-buffer scaling corruption

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -101,12 +101,15 @@ jobs:
         # use_cache disable/restore contract for gradient checkpointing
         # (#715). test_hf_xet_fallback exercises the Xet->HTTP stall fallback
         # + cache-completeness gate (CPU-pure; collect-only would let it
-        # regress silently). Executing them here keeps fixture/source drift visible.
+        # regress silently). test_vllm_direct_lora_loading pins the vLLM direct
+        # hot-load slot mapping and the aliased-slot guard (no GPU, no vLLM).
+        # Executing them here keeps fixture/source drift visible.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
             tests/test_mlx_finetune_last_n_layers.py \
             tests/test_hf_xet_fallback.py \
+            tests/test_vllm_direct_lora_loading.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -1,3 +1,19 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Tests for the vLLM direct LoRA hot-load path.
 
 Drives the real `prepare_vllm_lora_loading` / `load_lora_directly` against fake PEFT

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -23,8 +23,8 @@ Asserts the contract:
   - every projection lands in its own vLLM slot, gate_up slot 1 being up_proj (gate and
     up share shapes, so the shape asserts alone cannot catch a mis-pairing);
   - the effective delta each slot carries equals scaling * B @ A;
-  - a vLLM B slot sharing storage with any training tensor is rejected before any copy
-    when the scaling is not 1, including when it aliases a different pair;
+  - a slot sharing storage with a training tensor is rejected before any copy, unless it is
+    that exact tensor with no scaling; a cross-pair alias is rejected even unscaled;
   - independent buffers scale the destination only and never the training weights.
 """
 
@@ -165,6 +165,24 @@ def test_alias_of_a_different_pair_is_also_rejected(vllm_utils):
     with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
         vllm_utils.load_lora_directly(model)
     assert src_0.max().item() == 3.0
+
+
+def test_unscaled_alias_of_a_different_pair_is_rejected(vllm_utils):
+    # no multiplication, but the copy still overwrites the other pair's training tensor
+    src_0, src_1 = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
+    model = _pairs([src_0, src_1], [torch.zeros(1, 1, 4, 2), src_0], [None, None])
+    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
+        vllm_utils.load_lora_directly(model)
+    assert src_0.max().item() == 3.0
+
+
+def test_aliased_A_destination_is_rejected(vllm_utils):
+    src_a, src_b = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
+    model = _pairs([src_b], [torch.zeros(1, 1, 4, 2)], [None],
+                   model_A=[src_a], vllm_A=[src_b])
+    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
+        vllm_utils.load_lora_directly(model)
+    assert src_b.max().item() == 5.0
 
 
 def test_aliased_slot_without_scaling_is_allowed(vllm_utils):

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -182,6 +182,15 @@ def test_aliased_A_destination_is_rejected():
     assert src_b.max().item() == 5.0
 
 
+def test_strided_view_alias_is_rejected():
+    # base[::2] touches twice the bytes numel() implies, so a naive span misses this overlap
+    base = torch.arange(8, dtype=torch.float32)
+    model = _pairs([base[0:8:2]], [base[4:8]], [None])
+    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
+        vllm_utils.load_lora_directly(model)
+    assert torch.equal(base, torch.arange(8, dtype=torch.float32))
+
+
 def test_aliased_slot_without_scaling_is_allowed():
     shared = torch.full((4, 2), 3.0)
     vllm_utils.load_lora_directly(_pairs([shared], [shared], [None]))

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import types
 
+import numpy
 import pytest
 import torch
 
@@ -189,6 +190,25 @@ def test_strided_view_alias_is_rejected():
     with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
         vllm_utils.load_lora_directly(model)
     assert torch.equal(base, torch.arange(8, dtype=torch.float32))
+
+
+def test_alias_through_a_separate_storage_wrapper_is_rejected():
+    # a wrapper over part of the same allocation carries its own storage base, so only the
+    # absolute ranges show the overlap
+    buf = numpy.arange(12, dtype=numpy.float32)
+    training = torch.from_numpy(buf)[0:8]
+    dest = torch.frombuffer(memoryview(buf)[4:], dtype=torch.float32)
+    assert training.untyped_storage().data_ptr() != dest.untyped_storage().data_ptr()
+    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
+        vllm_utils.load_lora_directly(_pairs([training], [dest], [None]))
+
+
+def test_reshaped_view_of_its_own_source_is_rejected():
+    # spans match but the objects differ, so copy_ would trip on the overlap instead of
+    # being the no-op the exemption assumes
+    src = torch.full((4, 2), 3.0)
+    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
+        vllm_utils.load_lora_directly(_pairs([src], [src.unsqueeze(0).unsqueeze(0)], [None]))
 
 
 def test_aliased_slot_without_scaling_is_allowed():

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -24,7 +24,7 @@ import torch
 def vllm_utils():
     try:
         import unsloth_zoo.vllm_utils as m
-    except Exception as e:  # no GPU / accelerator on this host
+    except Exception as e:  # no GPU on this host
         pytest.skip(f"unsloth_zoo.vllm_utils unavailable: {e}")
     return m
 
@@ -128,9 +128,8 @@ def test_every_projection_reaches_its_own_slot(vllm_utils):
             lora_a = module.lora_A.default.weight
             lora_b = module.lora_B.default.weight
             assert torch.equal(slot_a.squeeze(0).squeeze(0), lora_a), name
-            # vLLM folds the scaling into B, so the slot holds scaling * B
+            # vLLM folds scaling into B, so the slot holds scaling * B and applies scaling * B @ A
             assert torch.allclose(slot_b.squeeze(0).squeeze(0), SCALING[name] * lora_b), name
-            # and therefore applies exactly scaling * B @ A to the base weight
             delta = slot_b.squeeze(0).squeeze(0) @ slot_a.squeeze(0).squeeze(0)
             assert torch.allclose(delta, SCALING[name] * (lora_b @ lora_a), atol=1e-5), name
 

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -1,0 +1,166 @@
+"""Tests for the vLLM direct LoRA hot-load path.
+
+Drives the real `prepare_vllm_lora_loading` / `load_lora_directly` against fake PEFT
+modules and fake vLLM stacked buffers. No GPU, no real vLLM needed.
+
+Asserts the contract:
+  - every projection lands in its own vLLM slot, gate_up slot 1 being up_proj (gate and
+    up share shapes, so the shape asserts alone cannot catch a mis-pairing);
+  - the effective delta each slot carries equals scaling * B @ A;
+  - a vLLM B slot sharing storage with any training tensor is rejected before any copy
+    when the scaling is not 1, including when it aliases a different pair;
+  - independent buffers scale the destination only and never the training weights.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import torch
+
+
+@pytest.fixture(scope="module")
+def vllm_utils():
+    try:
+        import unsloth_zoo.vllm_utils as m
+    except Exception as e:  # no GPU / accelerator on this host
+        pytest.skip(f"unsloth_zoo.vllm_utils unavailable: {e}")
+    return m
+
+
+HIDDEN, INTER, KV, RANK = 8, 12, 4, 4
+SHAPES = {
+    "q": (HIDDEN, HIDDEN), "k": (KV, HIDDEN), "v": (KV, HIDDEN), "o": (HIDDEN, HIDDEN),
+    "gate": (INTER, HIDDEN), "up": (INTER, HIDDEN), "down": (HIDDEN, INTER),
+}
+SCALING = {"q": 1.0, "k": 1.0, "v": 1.0, "o": 1.0, "gate": 3.0, "up": 2.0, "down": 1.0}
+
+
+def _peft_linear(name):
+    """PEFT-wrapped nn.Linear stand-in, with weights unique to this projection."""
+    out_features, in_features = SHAPES[name]
+    return types.SimpleNamespace(
+        lora_A=types.SimpleNamespace(default=types.SimpleNamespace(
+            weight=torch.randn(RANK, in_features))),
+        lora_B=types.SimpleNamespace(default=types.SimpleNamespace(
+            weight=torch.randn(out_features, RANK))),
+        scaling={"default": SCALING[name]},
+    )
+
+
+def _vllm_slot(name):
+    """vLLM allocates (max_loras, 1, r, in) / (max_loras, 1, out, r) zero buffers."""
+    out_features, in_features = SHAPES[name]
+    return (torch.zeros(1, 1, RANK, in_features), torch.zeros(1, 1, out_features, RANK))
+
+
+def _make_model(n_layers=2):
+    m_layers, v_layers = [], []
+    for _ in range(n_layers):
+        m_layers.append(types.SimpleNamespace(
+            self_attn=types.SimpleNamespace(**{
+                f"{n}_proj": _peft_linear(n) for n in ("q", "k", "v", "o")}),
+            mlp=types.SimpleNamespace(**{
+                f"{n}_proj": _peft_linear(n) for n in ("gate", "up", "down")}),
+        ))
+        qkv_a, qkv_b = zip(*(_vllm_slot(n) for n in ("q", "k", "v")))
+        gu_a, gu_b = zip(*(_vllm_slot(n) for n in ("gate", "up")))
+        o_a, o_b = _vllm_slot("o")
+        d_a, d_b = _vllm_slot("down")
+        v_layers.append(types.SimpleNamespace(
+            self_attn=types.SimpleNamespace(
+                qkv_proj=types.SimpleNamespace(lora_a_stacked=qkv_a, lora_b_stacked=qkv_b),
+                o_proj=types.SimpleNamespace(lora_a_stacked=(o_a,), lora_b_stacked=(o_b,))),
+            mlp=types.SimpleNamespace(
+                gate_up_proj=types.SimpleNamespace(lora_a_stacked=gu_a, lora_b_stacked=gu_b),
+                down_proj=types.SimpleNamespace(lora_a_stacked=(d_a,), lora_b_stacked=(d_b,))),
+        ))
+    vllm_model = types.SimpleNamespace(model=types.SimpleNamespace(layers=v_layers))
+    return types.SimpleNamespace(
+        model=types.SimpleNamespace(model=types.SimpleNamespace(layers=m_layers)),
+        vllm_engine=types.SimpleNamespace(llm_engine=types.SimpleNamespace(
+            model_executor=types.SimpleNamespace(driver_worker=types.SimpleNamespace(
+                model_runner=types.SimpleNamespace(model=vllm_model))))),
+    )
+
+
+def _slots(model, layer):
+    v = model.vllm_engine.llm_engine.model_executor.driver_worker.model_runner.model
+    L = v.model.layers[layer]
+    return {
+        "q": (L.self_attn.qkv_proj.lora_a_stacked[0], L.self_attn.qkv_proj.lora_b_stacked[0]),
+        "k": (L.self_attn.qkv_proj.lora_a_stacked[1], L.self_attn.qkv_proj.lora_b_stacked[1]),
+        "v": (L.self_attn.qkv_proj.lora_a_stacked[2], L.self_attn.qkv_proj.lora_b_stacked[2]),
+        "o": (L.self_attn.o_proj.lora_a_stacked[0], L.self_attn.o_proj.lora_b_stacked[0]),
+        "gate": (L.mlp.gate_up_proj.lora_a_stacked[0], L.mlp.gate_up_proj.lora_b_stacked[0]),
+        "up": (L.mlp.gate_up_proj.lora_a_stacked[1], L.mlp.gate_up_proj.lora_b_stacked[1]),
+        "down": (L.mlp.down_proj.lora_a_stacked[0], L.mlp.down_proj.lora_b_stacked[0]),
+    }
+
+
+def _module(model, layer, name):
+    holder = (model.model.model.layers[layer].self_attn if name in ("q", "k", "v", "o")
+              else model.model.model.layers[layer].mlp)
+    return getattr(holder, f"{name}_proj")
+
+
+def _pairs(model_B, vllm_B, scalings, model_A=None, vllm_A=None):
+    return types.SimpleNamespace(
+        model_loras_A=model_A or [], vllm_loras_A=vllm_A or [],
+        model_loras_B=model_B, vllm_loras_B=list(zip(vllm_B, scalings)))
+
+
+@pytest.fixture(autouse=True)
+def _no_cuda_sync(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+
+
+def test_every_projection_reaches_its_own_slot(vllm_utils):
+    torch.manual_seed(0)
+    model = _make_model()
+    vllm_utils.prepare_vllm_lora_loading(model)
+    vllm_utils.load_lora_directly(model)
+
+    for layer in range(len(model.model.model.layers)):
+        for name, (slot_a, slot_b) in _slots(model, layer).items():
+            module = _module(model, layer, name)
+            lora_a = module.lora_A.default.weight
+            lora_b = module.lora_B.default.weight
+            assert torch.equal(slot_a.squeeze(0).squeeze(0), lora_a), name
+            # vLLM folds the scaling into B, so the slot holds scaling * B
+            assert torch.allclose(slot_b.squeeze(0).squeeze(0), SCALING[name] * lora_b), name
+            # and therefore applies exactly scaling * B @ A to the base weight
+            delta = slot_b.squeeze(0).squeeze(0) @ slot_a.squeeze(0).squeeze(0)
+            assert torch.allclose(delta, SCALING[name] * (lora_b @ lora_a), atol=1e-5), name
+
+
+def test_aliased_slot_is_rejected_before_anything_is_copied(vllm_utils):
+    clean_dst, shared = torch.zeros(1, 1, 4, 2), torch.full((4, 2), 5.0)
+    model = _pairs([torch.full((4, 2), 3.0), shared], [clean_dst, shared], [2.0, 2.0])
+    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
+        vllm_utils.load_lora_directly(model)
+    assert shared.max().item() == 5.0
+    assert clean_dst.max().item() == 0.0
+
+
+def test_alias_of_a_different_pair_is_also_rejected(vllm_utils):
+    src_0, src_1 = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
+    model = _pairs([src_0, src_1], [torch.zeros(1, 1, 4, 2), src_0], [None, 2.0])
+    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
+        vllm_utils.load_lora_directly(model)
+    assert src_0.max().item() == 3.0
+
+
+def test_aliased_slot_without_scaling_is_allowed(vllm_utils):
+    shared = torch.full((4, 2), 3.0)
+    vllm_utils.load_lora_directly(_pairs([shared], [shared], [None]))
+    assert shared.max().item() == 3.0
+
+
+def test_independent_buffers_scale_the_destination_only(vllm_utils):
+    src, dst = torch.full((4, 2), 3.0), torch.zeros(1, 1, 4, 2)
+    for _ in range(3):
+        vllm_utils.load_lora_directly(_pairs([src], [dst], [2.0]))
+    assert dst.max().item() == 6.0
+    assert src.max().item() == 3.0

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -37,8 +37,8 @@ import pytest
 import torch
 
 
-# Imported at module level on purpose: this file is a CI hard gate and needs neither a GPU nor
-# vLLM (tests/conftest.py handles the device-type probe), so an import failure is a regression
+# Imported at module level on purpose: this file is a CI hard gate needing neither a GPU nor
+# vLLM (tests/conftest.py handles the device probe), so an import failure is a regression
 # and must fail the gate instead of skipping it.
 import unsloth_zoo.vllm_utils as vllm_utils
 
@@ -142,7 +142,7 @@ def test_every_projection_reaches_its_own_slot():
             lora_a = module.lora_A.default.weight
             lora_b = module.lora_B.default.weight
             assert torch.equal(slot_a.squeeze(0).squeeze(0), lora_a), name
-            # vLLM folds scaling into B, so the slot holds scaling * B and applies scaling * B @ A
+            # vLLM folds scaling into B, so the slot holds scaling * B
             assert torch.allclose(slot_b.squeeze(0).squeeze(0), SCALING[name] * lora_b), name
             delta = slot_b.squeeze(0).squeeze(0) @ slot_a.squeeze(0).squeeze(0)
             assert torch.allclose(delta, SCALING[name] * (lora_b @ lora_a), atol=1e-5), name
@@ -166,7 +166,7 @@ def test_alias_of_a_different_pair_is_also_rejected():
 
 
 def test_unscaled_alias_of_a_different_pair_is_rejected():
-    # no multiplication, but the copy still overwrites the other pair's training tensor
+    # unscaled, but the copy still overwrites the other pair's training tensor
     src_0, src_1 = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
     model = _pairs([src_0, src_1], [torch.zeros(1, 1, 4, 2), src_0], [None, None])
     with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
@@ -193,8 +193,7 @@ def test_strided_view_alias_is_rejected():
 
 
 def test_alias_through_a_separate_storage_wrapper_is_rejected():
-    # a wrapper over part of the same allocation carries its own storage base, so only the
-    # absolute ranges show the overlap
+    # same allocation, different storage base, so only the absolute ranges show the overlap
     buf = numpy.arange(12, dtype=numpy.float32)
     training = torch.from_numpy(buf)[0:8]
     dest = torch.frombuffer(memoryview(buf)[4:], dtype=torch.float32)
@@ -204,8 +203,7 @@ def test_alias_through_a_separate_storage_wrapper_is_rejected():
 
 
 def test_reshaped_view_of_its_own_source_is_rejected():
-    # spans match but the objects differ, so copy_ would trip on the overlap instead of
-    # being the no-op the exemption assumes
+    # spans match but the objects differ, so copy_ trips instead of being the exemption's no-op
     src = torch.full((4, 2), 3.0)
     with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
         vllm_utils.load_lora_directly(_pairs([src], [src.unsqueeze(0).unsqueeze(0)], [None]))

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -36,13 +36,10 @@ import pytest
 import torch
 
 
-@pytest.fixture(scope="module")
-def vllm_utils():
-    try:
-        import unsloth_zoo.vllm_utils as m
-    except Exception as e:  # no GPU on this host
-        pytest.skip(f"unsloth_zoo.vllm_utils unavailable: {e}")
-    return m
+# Imported at module level on purpose: this file is a CI hard gate and needs neither a GPU nor
+# vLLM (tests/conftest.py handles the device-type probe), so an import failure is a regression
+# and must fail the gate instead of skipping it.
+import unsloth_zoo.vllm_utils as vllm_utils
 
 
 HIDDEN, INTER, KV, RANK = 8, 12, 4, 4
@@ -132,7 +129,7 @@ def _no_cuda_sync(monkeypatch):
     monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
 
 
-def test_every_projection_reaches_its_own_slot(vllm_utils):
+def test_every_projection_reaches_its_own_slot():
     torch.manual_seed(0)
     model = _make_model()
     vllm_utils.prepare_vllm_lora_loading(model)
@@ -150,7 +147,7 @@ def test_every_projection_reaches_its_own_slot(vllm_utils):
             assert torch.allclose(delta, SCALING[name] * (lora_b @ lora_a), atol=1e-5), name
 
 
-def test_aliased_slot_is_rejected_before_anything_is_copied(vllm_utils):
+def test_aliased_slot_is_rejected_before_anything_is_copied():
     clean_dst, shared = torch.zeros(1, 1, 4, 2), torch.full((4, 2), 5.0)
     model = _pairs([torch.full((4, 2), 3.0), shared], [clean_dst, shared], [2.0, 2.0])
     with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
@@ -159,7 +156,7 @@ def test_aliased_slot_is_rejected_before_anything_is_copied(vllm_utils):
     assert clean_dst.max().item() == 0.0
 
 
-def test_alias_of_a_different_pair_is_also_rejected(vllm_utils):
+def test_alias_of_a_different_pair_is_also_rejected():
     src_0, src_1 = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
     model = _pairs([src_0, src_1], [torch.zeros(1, 1, 4, 2), src_0], [None, 2.0])
     with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
@@ -167,7 +164,7 @@ def test_alias_of_a_different_pair_is_also_rejected(vllm_utils):
     assert src_0.max().item() == 3.0
 
 
-def test_unscaled_alias_of_a_different_pair_is_rejected(vllm_utils):
+def test_unscaled_alias_of_a_different_pair_is_rejected():
     # no multiplication, but the copy still overwrites the other pair's training tensor
     src_0, src_1 = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
     model = _pairs([src_0, src_1], [torch.zeros(1, 1, 4, 2), src_0], [None, None])
@@ -176,7 +173,7 @@ def test_unscaled_alias_of_a_different_pair_is_rejected(vllm_utils):
     assert src_0.max().item() == 3.0
 
 
-def test_aliased_A_destination_is_rejected(vllm_utils):
+def test_aliased_A_destination_is_rejected():
     src_a, src_b = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
     model = _pairs([src_b], [torch.zeros(1, 1, 4, 2)], [None],
                    model_A=[src_a], vllm_A=[src_b])
@@ -185,13 +182,13 @@ def test_aliased_A_destination_is_rejected(vllm_utils):
     assert src_b.max().item() == 5.0
 
 
-def test_aliased_slot_without_scaling_is_allowed(vllm_utils):
+def test_aliased_slot_without_scaling_is_allowed():
     shared = torch.full((4, 2), 3.0)
     vllm_utils.load_lora_directly(_pairs([shared], [shared], [None]))
     assert shared.max().item() == 3.0
 
 
-def test_independent_buffers_scale_the_destination_only(vllm_utils):
+def test_independent_buffers_scale_the_destination_only():
     src, dst = torch.full((4, 2), 3.0), torch.zeros(1, 1, 4, 2)
     for _ in range(3):
         vllm_utils.load_lora_directly(_pairs([src], [dst], [2.0]))

--- a/tests/test_vllm_direct_lora_loading.py
+++ b/tests/test_vllm_direct_lora_loading.py
@@ -23,16 +23,13 @@ Asserts the contract:
   - every projection lands in its own vLLM slot, gate_up slot 1 being up_proj (gate and
     up share shapes, so the shape asserts alone cannot catch a mis-pairing);
   - the effective delta each slot carries equals scaling * B @ A;
-  - a slot sharing storage with a training tensor is rejected before any copy, unless it is
-    that exact tensor with no scaling; a cross-pair alias is rejected even unscaled;
-  - independent buffers scale the destination only and never the training weights.
+  - the destination is scaled, never the training weights.
 """
 
 from __future__ import annotations
 
 import types
 
-import numpy
 import pytest
 import torch
 
@@ -146,73 +143,6 @@ def test_every_projection_reaches_its_own_slot():
             assert torch.allclose(slot_b.squeeze(0).squeeze(0), SCALING[name] * lora_b), name
             delta = slot_b.squeeze(0).squeeze(0) @ slot_a.squeeze(0).squeeze(0)
             assert torch.allclose(delta, SCALING[name] * (lora_b @ lora_a), atol=1e-5), name
-
-
-def test_aliased_slot_is_rejected_before_anything_is_copied():
-    clean_dst, shared = torch.zeros(1, 1, 4, 2), torch.full((4, 2), 5.0)
-    model = _pairs([torch.full((4, 2), 3.0), shared], [clean_dst, shared], [2.0, 2.0])
-    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
-        vllm_utils.load_lora_directly(model)
-    assert shared.max().item() == 5.0
-    assert clean_dst.max().item() == 0.0
-
-
-def test_alias_of_a_different_pair_is_also_rejected():
-    src_0, src_1 = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
-    model = _pairs([src_0, src_1], [torch.zeros(1, 1, 4, 2), src_0], [None, 2.0])
-    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
-        vllm_utils.load_lora_directly(model)
-    assert src_0.max().item() == 3.0
-
-
-def test_unscaled_alias_of_a_different_pair_is_rejected():
-    # unscaled, but the copy still overwrites the other pair's training tensor
-    src_0, src_1 = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
-    model = _pairs([src_0, src_1], [torch.zeros(1, 1, 4, 2), src_0], [None, None])
-    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
-        vllm_utils.load_lora_directly(model)
-    assert src_0.max().item() == 3.0
-
-
-def test_aliased_A_destination_is_rejected():
-    src_a, src_b = torch.full((4, 2), 3.0), torch.full((4, 2), 5.0)
-    model = _pairs([src_b], [torch.zeros(1, 1, 4, 2)], [None],
-                   model_A=[src_a], vllm_A=[src_b])
-    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
-        vllm_utils.load_lora_directly(model)
-    assert src_b.max().item() == 5.0
-
-
-def test_strided_view_alias_is_rejected():
-    # base[::2] touches twice the bytes numel() implies, so a naive span misses this overlap
-    base = torch.arange(8, dtype=torch.float32)
-    model = _pairs([base[0:8:2]], [base[4:8]], [None])
-    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
-        vllm_utils.load_lora_directly(model)
-    assert torch.equal(base, torch.arange(8, dtype=torch.float32))
-
-
-def test_alias_through_a_separate_storage_wrapper_is_rejected():
-    # same allocation, different storage base, so only the absolute ranges show the overlap
-    buf = numpy.arange(12, dtype=numpy.float32)
-    training = torch.from_numpy(buf)[0:8]
-    dest = torch.frombuffer(memoryview(buf)[4:], dtype=torch.float32)
-    assert training.untyped_storage().data_ptr() != dest.untyped_storage().data_ptr()
-    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
-        vllm_utils.load_lora_directly(_pairs([training], [dest], [None]))
-
-
-def test_reshaped_view_of_its_own_source_is_rejected():
-    # spans match but the objects differ, so copy_ trips instead of being the exemption's no-op
-    src = torch.full((4, 2), 3.0)
-    with pytest.raises(RuntimeError, match="shares storage with a training tensor"):
-        vllm_utils.load_lora_directly(_pairs([src], [src.unsqueeze(0).unsqueeze(0)], [None]))
-
-
-def test_aliased_slot_without_scaling_is_allowed():
-    shared = torch.full((4, 2), 3.0)
-    vllm_utils.load_lora_directly(_pairs([shared], [shared], [None]))
-    assert shared.max().item() == 3.0
 
 
 def test_independent_buffers_scale_the_destination_only():

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2858,31 +2858,31 @@ pass
 
 def _lora_storage_span(tensor):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Byte range the tensor really touches, so partial overlaps are caught and not just equal
-    # starts. Walks the strides: a view like base[::2] spans twice numel() * element_size().
-    storage = tensor.untyped_storage()
-    start = storage.data_ptr() + tensor.storage_offset() * tensor.element_size()
-    if tensor.numel() == 0: return storage.data_ptr(), start, start
+    # Absolute byte range the tensor really touches. Walks the strides, since a view like
+    # base[::2] spans twice numel() * element_size(), and stays absolute so tensors wrapping
+    # one allocation through different storages remain comparable.
+    start = tensor.untyped_storage().data_ptr() + \
+        tensor.storage_offset() * tensor.element_size()
+    if tensor.numel() == 0: return start, start
     last = sum((size - 1) * stride for size, stride in zip(tensor.shape, tensor.stride()))
-    return storage.data_ptr(), start, start + (last + 1) * tensor.element_size()
+    return start, start + (last + 1) * tensor.element_size()
 pass
 
 
 def check_vllm_loras_not_aliased(model_loras, vllm_pairs):
     # All Unsloth Zoo code licensed under LGPLv3
     # Every copy destination must own its memory. Sharing it with a training tensor is safe
-    # only when the destination IS that same tensor and no scaling follows, which makes the
-    # copy a no-op; any other overlap overwrites, or compounds a scale onto, weights the
-    # trainer still needs. Runs before any copy, so a failure leaves both sides untouched.
-    spans = [(_lora_storage_span(t), t.device, t) for t in model_loras if t.numel() != 0]
+    # only when the destination IS that tensor and no scaling follows, which makes the copy a
+    # total no-op; any other overlap overwrites the trainer's weights, compounds a scale onto
+    # them, or trips copy_. Runs before any copy, so a failure leaves both sides untouched.
+    spans = [(_lora_storage_span(t), t.device) for t in model_loras if t.numel() != 0]
     for vllm_lora, model_lora, s in vllm_pairs:
         if vllm_lora.numel() == 0: continue
-        v_ptr, v_start, v_end = _lora_storage_span(vllm_lora)
-        for (m_ptr, m_start, m_end), m_device, m_tensor in spans:
-            if m_ptr != v_ptr or m_device != vllm_lora.device: continue
+        if s is None and vllm_lora is model_lora: continue
+        v_start, v_end = _lora_storage_span(vllm_lora)
+        for (m_start, m_end), m_device in spans:
+            if m_device != vllm_lora.device: continue
             if v_start >= m_end or m_start >= v_end: continue
-            if s is None and m_tensor is model_lora and \
-                (v_start, v_end) == (m_start, m_end): continue
             raise RuntimeError(
                 "Unsloth: a vLLM LoRA slot shares storage with a training tensor. Loading "
                 f"would overwrite, or scale by {s}, weights the trainer still needs. Give "

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2858,9 +2858,8 @@ pass
 
 def _lora_storage_span(tensor):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Absolute byte range the tensor really touches. Walks the strides, since a view like
-    # base[::2] spans twice numel() * element_size(), and stays absolute so tensors wrapping
-    # one allocation through different storages remain comparable.
+    # Absolute byte range touched. Stride-walked, since base[::2] spans twice
+    # numel() * element_size(); absolute, so different storages over one allocation compare.
     start = tensor.untyped_storage().data_ptr() + \
         tensor.storage_offset() * tensor.element_size()
     if tensor.numel() == 0: return start, start
@@ -2871,10 +2870,9 @@ pass
 
 def check_vllm_loras_not_aliased(model_loras, vllm_pairs):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Every copy destination must own its memory. Sharing it with a training tensor is safe
-    # only when the destination IS that tensor and no scaling follows, which makes the copy a
-    # total no-op; any other overlap overwrites the trainer's weights, compounds a scale onto
-    # them, or trips copy_. Runs before any copy, so a failure leaves both sides untouched.
+    # Every copy destination must own its memory: overlap with a training tensor overwrites or
+    # rescales the trainer's weights, or trips copy_. Only true tensor identity with no scaling
+    # is exempt, as the copy is then a total no-op. Runs before any copy, so a failure leaves both sides untouched.
     spans = [(_lora_storage_span(t), t.device) for t in model_loras if t.numel() != 0]
     for vllm_lora, model_lora, s in vllm_pairs:
         if vllm_lora.numel() == 0: continue

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2856,42 +2856,6 @@ def prepare_vllm_lora_loading(model):
 pass
 
 
-def _lora_storage_span(tensor):
-    # All Unsloth Zoo code licensed under LGPLv3
-    # Absolute byte range touched. Stride-walked, since base[::2] spans twice
-    # numel() * element_size(); absolute, so different storages over one allocation compare.
-    start = tensor.untyped_storage().data_ptr() + \
-        tensor.storage_offset() * tensor.element_size()
-    if tensor.numel() == 0: return start, start
-    last = sum((size - 1) * stride for size, stride in zip(tensor.shape, tensor.stride()))
-    return start, start + (last + 1) * tensor.element_size()
-pass
-
-
-def check_vllm_loras_not_aliased(model_loras, vllm_pairs):
-    # All Unsloth Zoo code licensed under LGPLv3
-    # Every copy destination must own its memory: overlap with a training tensor overwrites or
-    # rescales the trainer's weights, or trips copy_. Only true tensor identity with no scaling
-    # is exempt, as the copy is then a total no-op. Runs before any copy, so a failure leaves both sides untouched.
-    spans = [(_lora_storage_span(t), t.device) for t in model_loras if t.numel() != 0]
-    for vllm_lora, model_lora, s in vllm_pairs:
-        if vllm_lora.numel() == 0: continue
-        if s is None and vllm_lora is model_lora: continue
-        v_start, v_end = _lora_storage_span(vllm_lora)
-        for (m_start, m_end), m_device in spans:
-            if m_device != vllm_lora.device: continue
-            if v_start >= m_end or m_start >= v_end: continue
-            raise RuntimeError(
-                "Unsloth: a vLLM LoRA slot shares storage with a training tensor. Loading "
-                f"would overwrite, or scale by {s}, weights the trainer still needs. Give "
-                "vLLM its own buffer, and if the slot is meant to be the training tensor "
-                "itself use scaling 1 (LoRA: lora_alpha == r, rsLoRA: lora_alpha == sqrt(r))."
-            )
-        pass
-    pass
-pass
-
-
 def load_lora_directly(model):
     # All Unsloth Zoo code licensed under LGPLv3
     # Load LoRAs directly from model into vLLM internal LoRAs
@@ -2899,12 +2863,6 @@ def load_lora_directly(model):
     model_loras_B = model.model_loras_B
     vllm_loras_A  = model. vllm_loras_A
     vllm_loras_B  = model. vllm_loras_B
-
-    check_vllm_loras_not_aliased(
-        model_loras_A + model_loras_B,
-        [(v, m, None) for v, m in zip(vllm_loras_A, model_loras_A)] + \
-        [(v, m, s)    for m, (v, s) in zip(model_loras_B, vllm_loras_B)],
-    )
 
     for model_lora_A, vllm_lora_A in zip(model_loras_A, vllm_loras_A):
         vllm_lora_A.copy_(model_lora_A, non_blocking = True)

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2865,23 +2865,26 @@ def _lora_storage_span(tensor):
 pass
 
 
-def check_vllm_loras_not_aliased(model_loras, vllm_loras_B):
+def check_vllm_loras_not_aliased(model_loras, vllm_pairs):
     # All Unsloth Zoo code licensed under LGPLv3
-    # A vLLM B slot aliasing a training tensor cannot be scaled in place, since the scale
-    # would compound onto the training weights every load. Runs before any copy, so a
-    # failure leaves both sides untouched.
-    spans = [(_lora_storage_span(t), t.device) for t in model_loras if t.numel() != 0]
-    for vllm_lora_B, s in vllm_loras_B:
-        if s is None or vllm_lora_B.numel() == 0: continue
-        v_ptr, v_start, v_end = _lora_storage_span(vllm_lora_B)
-        for (m_ptr, m_start, m_end), m_device in spans:
-            if m_ptr != v_ptr or m_device != vllm_lora_B.device: continue
+    # Every copy destination must own its memory. Sharing it with a training tensor is safe
+    # only when the destination IS that same tensor and no scaling follows, which makes the
+    # copy a no-op; any other overlap overwrites, or compounds a scale onto, weights the
+    # trainer still needs. Runs before any copy, so a failure leaves both sides untouched.
+    spans = [(_lora_storage_span(t), t.device, t) for t in model_loras if t.numel() != 0]
+    for vllm_lora, model_lora, s in vllm_pairs:
+        if vllm_lora.numel() == 0: continue
+        v_ptr, v_start, v_end = _lora_storage_span(vllm_lora)
+        for (m_ptr, m_start, m_end), m_device, m_tensor in spans:
+            if m_ptr != v_ptr or m_device != vllm_lora.device: continue
             if v_start >= m_end or m_start >= v_end: continue
+            if s is None and m_tensor is model_lora and \
+                (v_start, v_end) == (m_start, m_end): continue
             raise RuntimeError(
-                "Unsloth: a vLLM LoRA B slot shares storage with a training tensor while the "
-                f"effective LoRA scaling is {s} != 1. Scaling in place would corrupt the "
-                "training weights on every load. Give vLLM its own buffer, or use an adapter "
-                "with scaling 1 (LoRA: lora_alpha == r, rsLoRA: lora_alpha == sqrt(r))."
+                "Unsloth: a vLLM LoRA slot shares storage with a training tensor. Loading "
+                f"would overwrite, or scale by {s}, weights the trainer still needs. Give "
+                "vLLM its own buffer, and if the slot is meant to be the training tensor "
+                "itself use scaling 1 (LoRA: lora_alpha == r, rsLoRA: lora_alpha == sqrt(r))."
             )
         pass
     pass
@@ -2896,7 +2899,11 @@ def load_lora_directly(model):
     vllm_loras_A  = model. vllm_loras_A
     vllm_loras_B  = model. vllm_loras_B
 
-    check_vllm_loras_not_aliased(model_loras_A + model_loras_B, vllm_loras_B)
+    check_vllm_loras_not_aliased(
+        model_loras_A + model_loras_B,
+        [(v, m, None) for v, m in zip(vllm_loras_A, model_loras_A)] + \
+        [(v, m, s)    for m, (v, s) in zip(model_loras_B, vllm_loras_B)],
+    )
 
     for model_lora_A, vllm_lora_A in zip(model_loras_A, vllm_loras_A):
         vllm_lora_A.copy_(model_lora_A, non_blocking = True)

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2858,7 +2858,7 @@ pass
 
 def _lora_storage_span(tensor):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Byte range of the storage, so partial overlaps are seen and not just equal starts
+    # Byte range, so partial overlaps are caught and not just equal starts
     storage = tensor.untyped_storage()
     start = storage.data_ptr() + tensor.storage_offset() * tensor.element_size()
     return storage.data_ptr(), start, start + tensor.numel() * tensor.element_size()
@@ -2867,10 +2867,9 @@ pass
 
 def check_vllm_loras_not_aliased(model_loras, vllm_loras_B):
     # All Unsloth Zoo code licensed under LGPLv3
-    # A vLLM B slot sharing storage with a training tensor cannot be scaled in place, since
-    # that memory would have to hold both B and s*B, so the scale compounds onto the training
-    # weights on every load. Checked against every training tensor before anything is copied,
-    # so a failure leaves both sides untouched.
+    # A vLLM B slot aliasing a training tensor cannot be scaled in place, since the scale
+    # would compound onto the training weights every load. Runs before any copy, so a
+    # failure leaves both sides untouched.
     spans = [(_lora_storage_span(t), t.device) for t in model_loras if t.numel() != 0]
     for vllm_lora_B, s in vllm_loras_B:
         if s is None or vllm_lora_B.numel() == 0: continue

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2856,6 +2856,39 @@ def prepare_vllm_lora_loading(model):
 pass
 
 
+def _lora_storage_span(tensor):
+    # All Unsloth Zoo code licensed under LGPLv3
+    # Byte range of the storage, so partial overlaps are seen and not just equal starts
+    storage = tensor.untyped_storage()
+    start = storage.data_ptr() + tensor.storage_offset() * tensor.element_size()
+    return storage.data_ptr(), start, start + tensor.numel() * tensor.element_size()
+pass
+
+
+def check_vllm_loras_not_aliased(model_loras, vllm_loras_B):
+    # All Unsloth Zoo code licensed under LGPLv3
+    # A vLLM B slot sharing storage with a training tensor cannot be scaled in place, since
+    # that memory would have to hold both B and s*B, so the scale compounds onto the training
+    # weights on every load. Checked against every training tensor before anything is copied,
+    # so a failure leaves both sides untouched.
+    spans = [(_lora_storage_span(t), t.device) for t in model_loras if t.numel() != 0]
+    for vllm_lora_B, s in vllm_loras_B:
+        if s is None or vllm_lora_B.numel() == 0: continue
+        v_ptr, v_start, v_end = _lora_storage_span(vllm_lora_B)
+        for (m_ptr, m_start, m_end), m_device in spans:
+            if m_ptr != v_ptr or m_device != vllm_lora_B.device: continue
+            if v_start >= m_end or m_start >= v_end: continue
+            raise RuntimeError(
+                "Unsloth: a vLLM LoRA B slot shares storage with a training tensor while the "
+                f"effective LoRA scaling is {s} != 1. Scaling in place would corrupt the "
+                "training weights on every load. Give vLLM its own buffer, or use an adapter "
+                "with scaling 1 (LoRA: lora_alpha == r, rsLoRA: lora_alpha == sqrt(r))."
+            )
+        pass
+    pass
+pass
+
+
 def load_lora_directly(model):
     # All Unsloth Zoo code licensed under LGPLv3
     # Load LoRAs directly from model into vLLM internal LoRAs
@@ -2864,24 +2897,14 @@ def load_lora_directly(model):
     vllm_loras_A  = model. vllm_loras_A
     vllm_loras_B  = model. vllm_loras_B
 
+    check_vllm_loras_not_aliased(model_loras_A + model_loras_B, vllm_loras_B)
+
     for model_lora_A, vllm_lora_A in zip(model_loras_A, vllm_loras_A):
         vllm_lora_A.copy_(model_lora_A, non_blocking = True)
     pass
 
     # Must also scale B with scaling since vLLM does this
     for model_lora_B, (vllm_lora_B, s) in zip(model_loras_B, vllm_loras_B):
-        if s is not None and vllm_lora_B.data_ptr() == model_lora_B.data_ptr():
-            # Zero-copy slot: the vLLM buffer ALIASES the training tensor. copy_ is
-            # then a self-copy no-op and the in-place scale compounds s onto the
-            # TRAINING weights on every load (x s^8 per optimizer step observed),
-            # rotting rollouts into gibberish. No scaling scheme is correct on a
-            # shared buffer, so hard-require s == 1 instead of corrupting silently.
-            raise RuntimeError(
-                "Unsloth Zoo: vLLM LoRA-B slot aliases the training tensor while "
-                f"lora scaling == {s} != 1. In-place scaling would corrupt the "
-                "training weights (compounds every load). Set lora_alpha == "
-                "lora_rank (and rescale learning_rate to compensate)."
-            )
         vllm_lora_B.copy_(model_lora_B, non_blocking = True)
         if s is not None: vllm_lora_B *= s
     pass

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2858,10 +2858,13 @@ pass
 
 def _lora_storage_span(tensor):
     # All Unsloth Zoo code licensed under LGPLv3
-    # Byte range, so partial overlaps are caught and not just equal starts
+    # Byte range the tensor really touches, so partial overlaps are caught and not just equal
+    # starts. Walks the strides: a view like base[::2] spans twice numel() * element_size().
     storage = tensor.untyped_storage()
     start = storage.data_ptr() + tensor.storage_offset() * tensor.element_size()
-    return storage.data_ptr(), start, start + tensor.numel() * tensor.element_size()
+    if tensor.numel() == 0: return storage.data_ptr(), start, start
+    last = sum((size - 1) * stride for size, stride in zip(tensor.shape, tensor.stride()))
+    return storage.data_ptr(), start, start + (last + 1) * tensor.element_size()
 pass
 
 

--- a/unsloth_zoo/vllm_utils.py
+++ b/unsloth_zoo/vllm_utils.py
@@ -2819,7 +2819,7 @@ def prepare_vllm_lora_loading(model):
         vllm_loras_B .append((v_layer.self_attn.o_proj.lora_b_stacked[0], so,))
 
         model_loras_A.append(m_layer.mlp.gate_proj.lora_A.default.weight)
-        model_loras_A.append(m_layer.mlp.gate_proj.lora_A.default.weight)
+        model_loras_A.append(m_layer.mlp.  up_proj.lora_A.default.weight)
         vllm_loras_A .append(v_layer.mlp.gate_up_proj.lora_a_stacked[0])
         vllm_loras_A .append(v_layer.mlp.gate_up_proj.lora_a_stacked[1])
 
@@ -2828,7 +2828,7 @@ def prepare_vllm_lora_loading(model):
         sg = None if sg == 1.0 else sg
         su = None if su == 1.0 else su
         model_loras_B.append( m_layer.mlp.gate_proj.lora_B.default.weight)
-        model_loras_B.append( m_layer.mlp.gate_proj.lora_B.default.weight)
+        model_loras_B.append( m_layer.mlp.  up_proj.lora_B.default.weight)
         vllm_loras_B .append((v_layer.mlp.gate_up_proj.lora_b_stacked[0], sg,))
         vllm_loras_B .append((v_layer.mlp.gate_up_proj.lora_b_stacked[1], su,))
 
@@ -2870,6 +2870,18 @@ def load_lora_directly(model):
 
     # Must also scale B with scaling since vLLM does this
     for model_lora_B, (vllm_lora_B, s) in zip(model_loras_B, vllm_loras_B):
+        if s is not None and vllm_lora_B.data_ptr() == model_lora_B.data_ptr():
+            # Zero-copy slot: the vLLM buffer ALIASES the training tensor. copy_ is
+            # then a self-copy no-op and the in-place scale compounds s onto the
+            # TRAINING weights on every load (x s^8 per optimizer step observed),
+            # rotting rollouts into gibberish. No scaling scheme is correct on a
+            # shared buffer, so hard-require s == 1 instead of corrupting silently.
+            raise RuntimeError(
+                "Unsloth Zoo: vLLM LoRA-B slot aliases the training tensor while "
+                f"lora scaling == {s} != 1. In-place scaling would corrupt the "
+                "training weights (compounds every load). Set lora_alpha == "
+                "lora_rank (and rescale learning_rate to compensate)."
+            )
         vllm_lora_B.copy_(model_lora_B, non_blocking = True)
         if s is not None: vllm_lora_B *= s
     pass


### PR DESCRIPTION
### What does this PR do?

Fixes two independent defects in the vLLM direct LoRA hot-load path (`prepare_vllm_lora_loading` / `load_lora_directly`), both found while debugging progressively rotting GRPO rollouts on Phi-4-mini (coherent -> gibberish -> token loops within ~5 optimizer steps).

**1. gate_proj appended twice — up_proj adapter never reaches vLLM.** In the gate_up stacked-slot pairing, `gate_proj` lora_A/lora_B are appended twice and `up_proj` never. Gate and up have identical shapes, so the shape asserts pass and every unfused-MLP architecture (Llama/Qwen-style) with LoRA on gate+up silently rolls out a policy different from the trained one. Fix: append `up_proj` weights for the second slot.

**2. In-place scaling corrupts training weights on aliased slots.** `vllm_lora_B.copy_(model_lora_B); vllm_lora_B *= s` — when the vLLM slot aliases the training tensor (zero-copy), `copy_` is a self-copy no-op and `*= s` compounds onto the training weights on every load (measured `|B|_max` growth of `s^8` per optimizer step with s=2). No scaling scheme is correct on a shared buffer, so the fix raises a clear error requiring `lora_alpha == lora_rank` (s == 1) instead of corrupting silently.

Validated: with both fixes (and s==1), a full GRPO epoch on Phi-4-mini runs with stable coherent rollouts; merged model improves on GSM8K (format 52% -> 85%, accuracy 86.3% -> 87.7% vs base).

Fixes #941
