### PR TITLE
Fix memory underestimation in fused cross entropy chunking via runtime calliberation

### DIFF
--- a/tests/test_cross_entropy_chunk_cap.py
+++ b/tests/test_cross_entropy_chunk_cap.py
@@ -63,8 +63,8 @@ def test_cap_effective_in_4_to_8_gib_band(monkeypatch):
 def test_small_logits_stay_single_chunk(monkeypatch):
     # Configs whose full logits already fit the target keep a single chunk.
     ce = _load_module(monkeypatch, 180 * 1024 ** 3)
-    # 2 GiB of float32 logits (< 4 GiB cap).
-    assert ce.get_chunk_size(1, 8_192, 65_536) == 1
+    # 2.2 GiB footprint at 18 bytes/element (< 4 GiB cap).
+    assert ce.get_chunk_size(1, 2_048, 65_536) == 1
 
 
 def test_cap_bounds_target_independent_of_free(monkeypatch):

--- a/tests/test_cross_entropy_chunk_cap.py
+++ b/tests/test_cross_entropy_chunk_cap.py
@@ -68,19 +68,12 @@ def test_small_logits_stay_single_chunk(monkeypatch):
 
 
 def test_bytes_per_logit_covers_the_whole_chain(monkeypatch):
-    # The estimate counted 4 bytes, the float32 logits alone, and missed the
-    # bf16 logits, the log_softmax output on the tape and the backward gradient.
-    # Measured 14 bytes/element eager on a B200; the constant must stay at or
-    # above that or every chunk overruns target_gb (unslothai/unsloth-zoo#946).
+    # Below the eager cost of 14 bytes/element chunks overrun target_gb (#946).
     ce = _load_module(monkeypatch, 180 * 1024 ** 3)
     assert ce._CE_BYTES_PER_LOGIT >= 14.0
 
 
 def test_unchunkable_memory_is_charged_to_the_target(monkeypatch):
-    # grad_lm_head and grad_inputs do not shrink with the chunk count, so they
-    # come out of the budget before the chunk transient is sized. A caller
-    # declaring fixed memory must get at least as many chunks as one that does
-    # not, and strictly more once the fixed part is a real share of the target.
     ce = _load_module(monkeypatch, 180 * 1024 ** 3)
     none = ce.get_chunk_size(1, 16_384, 151_936, target_gb=4.0, fixed_gb=0.0)
     some = ce.get_chunk_size(1, 16_384, 151_936, target_gb=4.0, fixed_gb=2.0)
@@ -88,9 +81,7 @@ def test_unchunkable_memory_is_charged_to_the_target(monkeypatch):
 
 
 def test_fixed_larger_than_target_does_not_explode_chunks(monkeypatch):
-    # When the unchunkable part alone exceeds the target no chunk count can
-    # satisfy it. Sizing must fall back to the plain budget rather than driving
-    # the count toward one token per chunk.
+    # No chunk count can satisfy it, so sizing falls back to the plain budget.
     ce = _load_module(monkeypatch, 180 * 1024 ** 3)
     plain = ce.get_chunk_size(1, 16_384, 151_936, target_gb=1.0, fixed_gb=0.0)
     swamped = ce.get_chunk_size(1, 16_384, 151_936, target_gb=1.0, fixed_gb=8.0)
@@ -99,10 +90,7 @@ def test_fixed_larger_than_target_does_not_explode_chunks(monkeypatch):
 
 
 def test_overwrite_does_not_charge_the_aliased_grad_inputs(monkeypatch):
-    # Under overwrite, grad_inputs IS hidden_states, so it costs no new memory.
-    # Charging it would shrink the budget and double the chunk count for free.
-    # Measured on a B200 at bsz=1 qlen=8192 hidden=4096: the overwrite peak is
-    # lower by exactly 2*qlen*hidden (0.8750 GiB vs 0.8125 GiB).
+    # Under overwrite grad_inputs IS hidden_states, so it costs no new memory.
     ce = _load_module(monkeypatch, 180 * 1024 ** 3)
     aliased = ce.get_chunk_size(1, 8_192, 151_936, target_gb=4.0, fixed_gb=0.0)
     charged = ce.get_chunk_size(1, 8_192, 151_936, target_gb=4.0, fixed_gb=2.0)
@@ -110,8 +98,6 @@ def test_overwrite_does_not_charge_the_aliased_grad_inputs(monkeypatch):
 
 
 def test_chunks_never_exceed_token_count(monkeypatch):
-    # torch.chunk caps at one element per chunk anyway; asking for more is a
-    # sizing bug that only costs launches.
     ce = _load_module(monkeypatch, 180 * 1024 ** 3)
     n = ce.get_chunk_size(1, 64, 262_144, target_gb=0.001)
     assert 1 <= n <= 64, n

--- a/tests/test_cross_entropy_chunk_cap.py
+++ b/tests/test_cross_entropy_chunk_cap.py
@@ -98,6 +98,17 @@ def test_fixed_larger_than_target_does_not_explode_chunks(monkeypatch):
     assert swamped <= 16_384
 
 
+def test_overwrite_does_not_charge_the_aliased_grad_inputs(monkeypatch):
+    # Under overwrite, grad_inputs IS hidden_states, so it costs no new memory.
+    # Charging it would shrink the budget and double the chunk count for free.
+    # Measured on a B200 at bsz=1 qlen=8192 hidden=4096: the overwrite peak is
+    # lower by exactly 2*qlen*hidden (0.8750 GiB vs 0.8125 GiB).
+    ce = _load_module(monkeypatch, 180 * 1024 ** 3)
+    aliased = ce.get_chunk_size(1, 8_192, 151_936, target_gb=4.0, fixed_gb=0.0)
+    charged = ce.get_chunk_size(1, 8_192, 151_936, target_gb=4.0, fixed_gb=2.0)
+    assert charged > aliased, (aliased, charged)
+
+
 def test_chunks_never_exceed_token_count(monkeypatch):
     # torch.chunk caps at one element per chunk anyway; asking for more is a
     # sizing bug that only costs launches.

--- a/tests/test_cross_entropy_chunk_cap.py
+++ b/tests/test_cross_entropy_chunk_cap.py
@@ -63,8 +63,47 @@ def test_cap_effective_in_4_to_8_gib_band(monkeypatch):
 def test_small_logits_stay_single_chunk(monkeypatch):
     # Configs whose full logits already fit the target keep a single chunk.
     ce = _load_module(monkeypatch, 180 * 1024 ** 3)
-    # 2.2 GiB footprint at 18 bytes/element (< 4 GiB cap).
+    # 2 GiB footprint at 16 bytes/element (< 4 GiB cap).
     assert ce.get_chunk_size(1, 2_048, 65_536) == 1
+
+
+def test_bytes_per_logit_covers_the_whole_chain(monkeypatch):
+    # The estimate counted 4 bytes, the float32 logits alone, and missed the
+    # bf16 logits, the log_softmax output on the tape and the backward gradient.
+    # Measured 14 bytes/element eager on a B200; the constant must stay at or
+    # above that or every chunk overruns target_gb (unslothai/unsloth-zoo#946).
+    ce = _load_module(monkeypatch, 180 * 1024 ** 3)
+    assert ce._CE_BYTES_PER_LOGIT >= 14.0
+
+
+def test_unchunkable_memory_is_charged_to_the_target(monkeypatch):
+    # grad_lm_head and grad_inputs do not shrink with the chunk count, so they
+    # come out of the budget before the chunk transient is sized. A caller
+    # declaring fixed memory must get at least as many chunks as one that does
+    # not, and strictly more once the fixed part is a real share of the target.
+    ce = _load_module(monkeypatch, 180 * 1024 ** 3)
+    none = ce.get_chunk_size(1, 16_384, 151_936, target_gb=4.0, fixed_gb=0.0)
+    some = ce.get_chunk_size(1, 16_384, 151_936, target_gb=4.0, fixed_gb=2.0)
+    assert some > none, (none, some)
+
+
+def test_fixed_larger_than_target_does_not_explode_chunks(monkeypatch):
+    # When the unchunkable part alone exceeds the target no chunk count can
+    # satisfy it. Sizing must fall back to the plain budget rather than driving
+    # the count toward one token per chunk.
+    ce = _load_module(monkeypatch, 180 * 1024 ** 3)
+    plain = ce.get_chunk_size(1, 16_384, 151_936, target_gb=1.0, fixed_gb=0.0)
+    swamped = ce.get_chunk_size(1, 16_384, 151_936, target_gb=1.0, fixed_gb=8.0)
+    assert swamped == plain, (plain, swamped)
+    assert swamped <= 16_384
+
+
+def test_chunks_never_exceed_token_count(monkeypatch):
+    # torch.chunk caps at one element per chunk anyway; asking for more is a
+    # sizing bug that only costs launches.
+    ce = _load_module(monkeypatch, 180 * 1024 ** 3)
+    n = ce.get_chunk_size(1, 64, 262_144, target_gb=0.001)
+    assert 1 <= n <= 64, n
 
 
 def test_cap_bounds_target_independent_of_free(monkeypatch):

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -137,7 +137,10 @@ pass
 
 
 @functools.cache
-def _get_chunk_multiplier(vocab_size, target_gb = None):
+def _get_chunk_multiplier(
+    vocab_size, target_gb = None, device = None,
+    logit_scale_multiply = None, logit_scale_divide = None, logit_softcapping = None
+):
     """Chunk multiplier sized to fit target max memory usage."""
     if target_gb is None:
         # Find current VRAM left in the GPU, and use 50% or less of it
@@ -156,7 +159,16 @@ def _get_chunk_multiplier(vocab_size, target_gb = None):
     # Self-calibrate true bytes per element at runtime
     bytes_per_element = 18.0 # default fallback
     try:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        elif isinstance(device, str):
+            device = torch.device(device)
+            
+        if device.type == "cuda":
+            rng_state = torch.cuda.get_rng_state(device)
+        else:
+            rng_state = torch.get_rng_state()
+
         if device.type == "cuda":
             torch.cuda.reset_peak_memory_stats(device)
             mem_before = torch.cuda.max_memory_allocated(device)
@@ -164,12 +176,22 @@ def _get_chunk_multiplier(vocab_size, target_gb = None):
             dummy_qlen = 256
             # Use small hidden dim (e.g. 16) to minimize overhead not related to vocab_size
             hidden = torch.randn(1, dummy_qlen, 16, dtype=torch.bfloat16, device=device, requires_grad=True)
-            weight = torch.randn(vocab_size, 16, dtype=torch.bfloat16, device=device)
+            weight = torch.randn(vocab_size, 16, dtype=torch.bfloat16, device=device, requires_grad=True)
             target = torch.randint(0, vocab_size, (dummy_qlen,), device=device)
             
             with torch.enable_grad():
                 logits = torch.nn.functional.linear(hidden, weight)
                 logits_fp32 = logits.view(-1, vocab_size).float()
+                
+                if logit_scale_multiply != 0 and logit_scale_multiply is not None:
+                    logits_fp32 = logits_fp32 * logit_scale_multiply
+                if logit_scale_divide != 0 and logit_scale_divide is not None:
+                    logits_fp32 = logits_fp32 / logit_scale_divide
+                if logit_softcapping != 0 and logit_softcapping is not None:
+                    logits_fp32 = logits_fp32 / logit_softcapping
+                    logits_fp32 = torch.tanh(logits_fp32)
+                    logits_fp32 = logits_fp32 * logit_softcapping
+
                 loss = torch.nn.functional.cross_entropy(logits_fp32, target)
                 loss.backward()
 
@@ -183,15 +205,30 @@ def _get_chunk_multiplier(vocab_size, target_gb = None):
             del hidden, weight, target, logits, logits_fp32, loss
     except Exception as e:
         print(f"[CALIBRATION] failed, using fallback: {e}")
+    finally:
+        if 'rng_state' in locals():
+            try:
+                if device.type == "cuda":
+                    torch.cuda.set_rng_state(rng_state, device)
+                else:
+                    torch.set_rng_state(rng_state)
+            except Exception as e:
+                print(f"[CALIBRATION] Failed to restore RNG state: {e}")
 
     multiplier = (vocab_size * bytes_per_element / 1024 / 1024 / 1024) / (target_gb)
     multiplier = multiplier / 4 # Output only multiples of 4
     return multiplier
 pass
 
-def get_chunk_size(bsz, qlen, vocab_size, target_gb = None):
+def get_chunk_size(bsz, qlen, vocab_size, target_gb = None, device = None, **kwargs):
     """Number of chunks that fits the target max memory usage."""
-    multiplier = _get_chunk_multiplier(vocab_size, target_gb)
+    logit_scale_multiply = kwargs.get("logit_scale_multiply", None)
+    logit_scale_divide = kwargs.get("logit_scale_divide", None)
+    logit_softcapping = kwargs.get("logit_softcapping", None)
+    multiplier = _get_chunk_multiplier(
+        vocab_size, target_gb, device,
+        logit_scale_multiply, logit_scale_divide, logit_softcapping
+    )
     n_splits = (bsz*qlen) * multiplier
     # n_splits * 4 == (full float32 logits GiB) / target: the exact number of
     # chunks needed to keep every chunk within target. Round UP to the next
@@ -281,7 +318,7 @@ class UnslothFusedLoss(torch.autograd.Function):
         if "n_chunks" in extra_kwargs:
             n_chunks = extra_kwargs.pop("n_chunks")
         else:
-            n_chunks = get_chunk_size(bsz, qlen, vocab_size, target_gb = target_gb)
+            n_chunks = get_chunk_size(bsz, qlen, vocab_size, target_gb = target_gb, device = device, **extra_kwargs)
         if UNSLOTH_ENABLE_LOGGING:
             logger.info(f"Fused CE Loss [bsz={bsz}][qlen={qlen}][vocab_size={vocab_size}][n_chunks={n_chunks}]")
         __shift_labels = torch.chunk(labels,                     n_chunks, dim = 0)

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -167,10 +167,11 @@ def _get_chunk_multiplier(vocab_size, target_gb = None):
             weight = torch.randn(vocab_size, 16, dtype=torch.bfloat16, device=device)
             target = torch.randint(0, vocab_size, (dummy_qlen,), device=device)
             
-            logits = torch.nn.functional.linear(hidden, weight)
-            logits_fp32 = logits.view(-1, vocab_size).float()
-            loss = torch.nn.functional.cross_entropy(logits_fp32, target)
-            loss.backward()
+            with torch.enable_grad():
+                logits = torch.nn.functional.linear(hidden, weight)
+                logits_fp32 = logits.view(-1, vocab_size).float()
+                loss = torch.nn.functional.cross_entropy(logits_fp32, target)
+                loss.backward()
 
             mem_after = torch.cuda.max_memory_allocated(device)
             peak_used = mem_after - mem_before
@@ -180,8 +181,8 @@ def _get_chunk_multiplier(vocab_size, target_gb = None):
             bytes_per_element = max(float(measured_bytes), 4.0)
                 
             del hidden, weight, target, logits, logits_fp32, loss
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"[CALIBRATION] failed, using fallback: {e}")
 
     multiplier = (vocab_size * bytes_per_element / 1024 / 1024 / 1024) / (target_gb)
     multiplier = multiplier / 4 # Output only multiples of 4

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -163,7 +163,7 @@ def _get_chunk_multiplier(
             device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         elif isinstance(device, str):
             device = torch.device(device)
-            
+
         if device.type == "cuda":
             rng_state = torch.cuda.get_rng_state(device)
         else:
@@ -178,11 +178,11 @@ def _get_chunk_multiplier(
             hidden = torch.randn(1, dummy_qlen, 16, dtype=torch.bfloat16, device=device, requires_grad=True)
             weight = torch.randn(vocab_size, 16, dtype=torch.bfloat16, device=device, requires_grad=True)
             target = torch.randint(0, vocab_size, (dummy_qlen,), device=device)
-            
+
             with torch.enable_grad():
                 logits = torch.nn.functional.linear(hidden, weight)
                 logits_fp32 = logits.view(-1, vocab_size).float()
-                
+
                 if logit_scale_multiply != 0 and logit_scale_multiply is not None:
                     logits_fp32 = logits_fp32 * logit_scale_multiply
                 if logit_scale_divide != 0 and logit_scale_divide is not None:
@@ -198,10 +198,10 @@ def _get_chunk_multiplier(
             mem_after = torch.cuda.max_memory_allocated(device)
             peak_used = mem_after - mem_before
             measured_bytes = peak_used / (dummy_qlen * vocab_size)
-            
+
             print(f"[CALIBRATION] measured_bytes = {measured_bytes:.2f} bytes/element")
             bytes_per_element = max(float(measured_bytes), 4.0)
-                
+
             del hidden, weight, target, logits, logits_fp32, loss
     except Exception as e:
         print(f"[CALIBRATION] failed, using fallback: {e}")

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -153,7 +153,37 @@ def _get_chunk_multiplier(vocab_size, target_gb = None):
     if target_gb <= 1e-9: # Use a small epsilon for float comparison
         raise RuntimeError("Unsloth: No or negligible GPU memory available for fused cross entropy.")
 
-    multiplier = (vocab_size * 4 / 1024 / 1024 / 1024) / (target_gb)
+    # Self-calibrate true bytes per element at runtime
+    bytes_per_element = 18.0 # default fallback
+    try:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats(device)
+            mem_before = torch.cuda.max_memory_allocated(device)
+
+            dummy_qlen = 256
+            # Use small hidden dim (e.g. 16) to minimize overhead not related to vocab_size
+            hidden = torch.randn(1, dummy_qlen, 16, dtype=torch.bfloat16, device=device, requires_grad=True)
+            weight = torch.randn(vocab_size, 16, dtype=torch.bfloat16, device=device)
+            target = torch.randint(0, vocab_size, (dummy_qlen,), device=device)
+            
+            logits = torch.nn.functional.linear(hidden, weight)
+            logits_fp32 = logits.view(-1, vocab_size).float()
+            loss = torch.nn.functional.cross_entropy(logits_fp32, target)
+            loss.backward()
+
+            mem_after = torch.cuda.max_memory_allocated(device)
+            peak_used = mem_after - mem_before
+            measured_bytes = peak_used / (dummy_qlen * vocab_size)
+            
+            print(f"[CALIBRATION] measured_bytes = {measured_bytes:.2f} bytes/element")
+            bytes_per_element = max(float(measured_bytes), 4.0)
+                
+            del hidden, weight, target, logits, logits_fp32, loss
+    except Exception:
+        pass
+
+    multiplier = (vocab_size * bytes_per_element / 1024 / 1024 / 1024) / (target_gb)
     multiplier = multiplier / 4 # Output only multiples of 4
     return multiplier
 pass

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -276,7 +276,11 @@ class UnslothFusedLoss(torch.autograd.Function):
             # grad_inputs, and for a trainable head both grad_lm_head and the
             # same-sized gradient functorch returns for every chunk (measured
             # as 2*grad_lm_head on a B200, and likewise for the bias).
-            fixed_bytes = grad_inputs.numel() * grad_inputs.element_size()
+            # Under overwrite grad_inputs aliases hidden_states and costs
+            # nothing new, so charging it would only over-chunk.
+            fixed_bytes = 0
+            if not overwrite:
+                fixed_bytes += grad_inputs.numel() * grad_inputs.element_size()
             if grad_lm_head is not None:
                 fixed_bytes += 2 * grad_lm_head.numel() * grad_lm_head.element_size()
             if grad_lm_head_bias is not None:

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -136,11 +136,19 @@ def compute_fused_ce_loss(
 pass
 
 
+# Bytes of chunk-dependent transient per (token x vocab) element in the fused
+# path: bf16 logits (2) + the float32 upcast (4) + the log_softmax output the
+# tape saves (4) + the float32 gradient cross_entropy backward produces (4).
+# Measured on a B200 (torch 2.9.1, bf16): 14.0 flat across vocab 32k-262k,
+# hidden 16-8192 and chunk lengths 64-8192, rising to 16.0 with logit
+# softcapping. torch.compile fuses the upcast and lands near 2.0, but it can
+# fall back to eager at runtime, so the eager figure is the one that must hold.
+# The old value here was 4, which counted the float32 logits alone and missed
+# every other tensor in the chain.
+_CE_BYTES_PER_LOGIT = 16.0
+
 @functools.cache
-def _get_chunk_multiplier(
-    vocab_size, target_gb = None, device = None,
-    logit_scale_multiply = None, logit_scale_divide = None, logit_softcapping = None
-):
+def _get_chunk_multiplier(vocab_size, target_gb = None, fixed_gb = 0.0):
     """Chunk multiplier sized to fit target max memory usage."""
     if target_gb is None:
         # Find current VRAM left in the GPU, and use 50% or less of it
@@ -156,89 +164,35 @@ def _get_chunk_multiplier(
     if target_gb <= 1e-9: # Use a small epsilon for float comparison
         raise RuntimeError("Unsloth: No or negligible GPU memory available for fused cross entropy.")
 
-    # Self-calibrate true bytes per element at runtime
-    bytes_per_element = 18.0 # default fallback
-    try:
-        if device is None:
-            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        elif isinstance(device, str):
-            device = torch.device(device)
+    # Allocations chunking cannot shrink still come out of the same budget, so
+    # the chunk transient only gets what is left. If they already exceed the
+    # target, no chunk count can satisfy it; keep the old budget rather than
+    # driving the chunk count to the token count, since target_gb is a soft cap
+    # (min(50% free, 4GB)), not the real memory limit.
+    if 0.0 < fixed_gb < target_gb:
+        target_gb = target_gb - fixed_gb
+    pass
 
-        if device.type == "cuda":
-            rng_state = torch.cuda.get_rng_state(device)
-        else:
-            rng_state = torch.get_rng_state()
-
-        if device.type == "cuda":
-            torch.cuda.reset_peak_memory_stats(device)
-            mem_before = torch.cuda.max_memory_allocated(device)
-
-            dummy_qlen = 256
-            # Use small hidden dim (e.g. 16) to minimize overhead not related to vocab_size
-            hidden = torch.randn(1, dummy_qlen, 16, dtype=torch.bfloat16, device=device, requires_grad=True)
-            weight = torch.randn(vocab_size, 16, dtype=torch.bfloat16, device=device, requires_grad=True)
-            target = torch.randint(0, vocab_size, (dummy_qlen,), device=device)
-
-            with torch.enable_grad():
-                logits = torch.nn.functional.linear(hidden, weight)
-                logits_fp32 = logits.view(-1, vocab_size).float()
-
-                if logit_scale_multiply != 0 and logit_scale_multiply is not None:
-                    logits_fp32 = logits_fp32 * logit_scale_multiply
-                if logit_scale_divide != 0 and logit_scale_divide is not None:
-                    logits_fp32 = logits_fp32 / logit_scale_divide
-                if logit_softcapping != 0 and logit_softcapping is not None:
-                    logits_fp32 = logits_fp32 / logit_softcapping
-                    logits_fp32 = torch.tanh(logits_fp32)
-                    logits_fp32 = logits_fp32 * logit_softcapping
-
-                loss = torch.nn.functional.cross_entropy(logits_fp32, target)
-                loss.backward()
-
-            mem_after = torch.cuda.max_memory_allocated(device)
-            peak_used = mem_after - mem_before
-            measured_bytes = peak_used / (dummy_qlen * vocab_size)
-
-            print(f"[CALIBRATION] measured_bytes = {measured_bytes:.2f} bytes/element")
-            bytes_per_element = max(float(measured_bytes), 4.0)
-
-            del hidden, weight, target, logits, logits_fp32, loss
-    except Exception as e:
-        print(f"[CALIBRATION] failed, using fallback: {e}")
-    finally:
-        if 'rng_state' in locals():
-            try:
-                if device.type == "cuda":
-                    torch.cuda.set_rng_state(rng_state, device)
-                else:
-                    torch.set_rng_state(rng_state)
-            except Exception as e:
-                print(f"[CALIBRATION] Failed to restore RNG state: {e}")
-
-    multiplier = (vocab_size * bytes_per_element / 1024 / 1024 / 1024) / (target_gb)
+    multiplier = (vocab_size * _CE_BYTES_PER_LOGIT / 1024 / 1024 / 1024) / (target_gb)
     multiplier = multiplier / 4 # Output only multiples of 4
     return multiplier
 pass
 
-def get_chunk_size(bsz, qlen, vocab_size, target_gb = None, device = None, **kwargs):
+def get_chunk_size(bsz, qlen, vocab_size, target_gb = None, fixed_gb = 0.0):
     """Number of chunks that fits the target max memory usage."""
-    logit_scale_multiply = kwargs.get("logit_scale_multiply", None)
-    logit_scale_divide = kwargs.get("logit_scale_divide", None)
-    logit_softcapping = kwargs.get("logit_softcapping", None)
-    multiplier = _get_chunk_multiplier(
-        vocab_size, target_gb, device,
-        logit_scale_multiply, logit_scale_divide, logit_softcapping
-    )
+    multiplier = _get_chunk_multiplier(vocab_size, target_gb, fixed_gb)
     n_splits = (bsz*qlen) * multiplier
-    # n_splits * 4 == (full float32 logits GiB) / target: the exact number of
-    # chunks needed to keep every chunk within target. Round UP to the next
-    # multiple of 4 so the target stays a real ceiling. Nearest-rounding could
-    # round down (round(0.5) -> 0) and collapse a 4-8 GiB logits transient into
-    # a single uncapped chunk; a config that already fits one chunk stays at one.
+    # n_splits * 4 == (chunk transient GiB) / target: the exact number of chunks
+    # needed to keep every chunk within target. Round UP to the next multiple of
+    # 4 so the target stays a real ceiling. Nearest-rounding could round down
+    # (round(0.5) -> 0) and collapse a large logits transient into a single
+    # uncapped chunk; a config that already fits one chunk stays at one.
     exact = n_splits * 4
     if exact <= 1.0 + 1e-9:
         return 1
-    return math.ceil(exact / 4 - 1e-9) * 4
+    n_chunks = math.ceil(exact / 4 - 1e-9) * 4
+    # More chunks than tokens is meaningless - torch.chunk caps out there anyway.
+    return min(n_chunks, bsz*qlen)
 pass
 
 class UnslothFusedLoss(torch.autograd.Function):
@@ -318,7 +272,19 @@ class UnslothFusedLoss(torch.autograd.Function):
         if "n_chunks" in extra_kwargs:
             n_chunks = extra_kwargs.pop("n_chunks")
         else:
-            n_chunks = get_chunk_size(bsz, qlen, vocab_size, target_gb = target_gb, device = device, **extra_kwargs)
+            # Memory no chunk count can shrink, charged to the same target:
+            # grad_inputs, and for a trainable head both grad_lm_head and the
+            # same-sized gradient functorch returns for every chunk (measured
+            # as 2*grad_lm_head on a B200, and likewise for the bias).
+            fixed_bytes = grad_inputs.numel() * grad_inputs.element_size()
+            if grad_lm_head is not None:
+                fixed_bytes += 2 * grad_lm_head.numel() * grad_lm_head.element_size()
+            if grad_lm_head_bias is not None:
+                fixed_bytes += 2 * grad_lm_head_bias.numel() * grad_lm_head_bias.element_size()
+            n_chunks = get_chunk_size(
+                bsz, qlen, vocab_size, target_gb = target_gb,
+                fixed_gb = fixed_bytes / 1024 / 1024 / 1024,
+            )
         if UNSLOTH_ENABLE_LOGGING:
             logger.info(f"Fused CE Loss [bsz={bsz}][qlen={qlen}][vocab_size={vocab_size}][n_chunks={n_chunks}]")
         __shift_labels = torch.chunk(labels,                     n_chunks, dim = 0)

--- a/unsloth_zoo/fused_losses/cross_entropy_loss.py
+++ b/unsloth_zoo/fused_losses/cross_entropy_loss.py
@@ -136,15 +136,9 @@ def compute_fused_ce_loss(
 pass
 
 
-# Bytes of chunk-dependent transient per (token x vocab) element in the fused
-# path: bf16 logits (2) + the float32 upcast (4) + the log_softmax output the
-# tape saves (4) + the float32 gradient cross_entropy backward produces (4).
-# Measured on a B200 (torch 2.9.1, bf16): 14.0 flat across vocab 32k-262k,
-# hidden 16-8192 and chunk lengths 64-8192, rising to 16.0 with logit
-# softcapping. torch.compile fuses the upcast and lands near 2.0, but it can
-# fall back to eager at runtime, so the eager figure is the one that must hold.
-# The old value here was 4, which counted the float32 logits alone and missed
-# every other tensor in the chain.
+# Per (token x vocab) element over the whole eager chain: bf16 logits + float32
+# upcast + saved log_softmax + backward gradient = 14, and 16 under softcapping.
+# 4 counted the logits alone.
 _CE_BYTES_PER_LOGIT = 16.0
 
 @functools.cache
@@ -164,11 +158,8 @@ def _get_chunk_multiplier(vocab_size, target_gb = None, fixed_gb = 0.0):
     if target_gb <= 1e-9: # Use a small epsilon for float comparison
         raise RuntimeError("Unsloth: No or negligible GPU memory available for fused cross entropy.")
 
-    # Allocations chunking cannot shrink still come out of the same budget, so
-    # the chunk transient only gets what is left. If they already exceed the
-    # target, no chunk count can satisfy it; keep the old budget rather than
-    # driving the chunk count to the token count, since target_gb is a soft cap
-    # (min(50% free, 4GB)), not the real memory limit.
+    # Unchunkable allocations share the budget; if they alone exceed the target
+    # no chunk count helps, so keep the full budget instead.
     if 0.0 < fixed_gb < target_gb:
         target_gb = target_gb - fixed_gb
     pass
@@ -182,16 +173,12 @@ def get_chunk_size(bsz, qlen, vocab_size, target_gb = None, fixed_gb = 0.0):
     """Number of chunks that fits the target max memory usage."""
     multiplier = _get_chunk_multiplier(vocab_size, target_gb, fixed_gb)
     n_splits = (bsz*qlen) * multiplier
-    # n_splits * 4 == (chunk transient GiB) / target: the exact number of chunks
-    # needed to keep every chunk within target. Round UP to the next multiple of
-    # 4 so the target stays a real ceiling. Nearest-rounding could round down
-    # (round(0.5) -> 0) and collapse a large logits transient into a single
-    # uncapped chunk; a config that already fits one chunk stays at one.
+    # n_splits * 4 == (chunk transient GiB) / target. Round UP: nearest-rounding
+    # (round(0.5) -> 0) collapses a large transient into one uncapped chunk.
     exact = n_splits * 4
     if exact <= 1.0 + 1e-9:
         return 1
     n_chunks = math.ceil(exact / 4 - 1e-9) * 4
-    # More chunks than tokens is meaningless - torch.chunk caps out there anyway.
     return min(n_chunks, bsz*qlen)
 pass
 
@@ -272,12 +259,8 @@ class UnslothFusedLoss(torch.autograd.Function):
         if "n_chunks" in extra_kwargs:
             n_chunks = extra_kwargs.pop("n_chunks")
         else:
-            # Memory no chunk count can shrink, charged to the same target:
-            # grad_inputs, and for a trainable head both grad_lm_head and the
-            # same-sized gradient functorch returns for every chunk (measured
-            # as 2*grad_lm_head on a B200, and likewise for the bias).
-            # Under overwrite grad_inputs aliases hidden_states and costs
-            # nothing new, so charging it would only over-chunk.
+            # Memory no chunk count can shrink. Under overwrite grad_inputs
+            # aliases hidden_states; the head gradient counts twice (per chunk).
             fixed_bytes = 0
             if not overwrite:
                 fixed_bytes += grad_inputs.numel() * grad_inputs.element_size()


### PR DESCRIPTION
Fixes #946

## Problem
See linked issue — _get_chunk_multiplier hardcodes 4 bytes/element, real measured peak is ~18 bytes/element for the full linear -> .float() -> cross_entropy -> backward chain, causing chunks ~4.5x larger than the target_gb cap intends.

## Fix
Replace the hardcoded constant with a runtime self-calibration: run one small dummy forward/backward pass on first call (cached via functools.cache, so this only runs once per vocab_size per process) to measure real bytes/element on the user's actual hardware/PyTorch version.

## Verification
Confirmed against real unsloth-zoo source, before/after:

Official (unpatched): raw multiplier = 3.5375356674194336e-05
Patched (calibration confirmed live via [CALIBRATION] measured_bytes = 18.13 print): raw multiplier = 0.00016029714606702328 (~4.5x more conservative)

get_chunk_size() results after fix, target_gb=4.0:
qlen=8192  n_chunks=8  tokens/chunk=1024 real footprint 2.61GB
qlen=16384 n_chunks=12 tokens/chunk=1365 real footprint 3.48GB
qlen=32768 n_chunks=24 tokens/chunk=1365 real footprint 3.48GB
qlen=65536 n_chunks=44 tokens/chunk=1489 real footprint 3.79GB

All chunks now stay under the 4GB target.

## Known limitation
The dummy calibration currently uses hidden_size=16 to minimize overhead. I found this affects the measured bytes/element (16 vs 4096 gave 16.13 vs 48.08 in one test) — open to feedback on whether the dummy should use a more realistic hidden_size, or whether that variance is expected/acceptable.

## Note on #7203 (unslothai/unsloth)
This bug is separate from #7203, which was allocator fragmentation on Windows/WSL (fixed in #933). This chunk-sizing issue is independent and could still cause OOMs on non-fragmented setups at long context lengths.