### PR TITLE
Tests: unblock MLX CI on Mac by not requiring the fused MRoPE grad to raise

### DIFF
--- a/tests/test_qwen35_vjp_metal.py
+++ b/tests/test_qwen35_vjp_metal.py
@@ -214,15 +214,18 @@ def test_disable_fused_mrope_fixes_rotary_grad():
     fused_q, fused_k = rot.apply_rotary(q, k, pos, unsqueeze_dim=1)
     mx.eval(fused_q, fused_k)
 
-    # Pre-flip: grad through fused apply raises the VJP error.
+    # Pre-flip: grad through fused apply raises the VJP error on mlx releases
+    # whose fused rotary kernel has no VJP. mlx 0.32.0 added one, so only the
+    # message is asserted, not that it raises at all.
     def loss(q_, k_):
         oq, ok = rot.apply_rotary(q_, k_, pos, unsqueeze_dim=1)
         return (oq.astype(mx.float32).sum() + ok.astype(mx.float32).sum())
 
-    with pytest.raises(ValueError) as exc:
+    try:
         val, _ = mx.value_and_grad(loss, argnums=(0, 1))(q, k)
         mx.eval(val)
-    assert "vjp" in str(exc.value).lower() or "CustomKernel" in str(exc.value), exc.value
+    except ValueError as exc:
+        assert "vjp" in str(exc).lower() or "CustomKernel" in str(exc), exc
 
     # Apply the fix.
     _disable_fused_mrope(model)


### PR DESCRIPTION
## Problem

`MLX CI on Mac M1` has failed on every nightly run since 2026-07-21 (for example run `30192235473`), and the failure is one stale assertion, not a real defect:

```
tests/test_qwen35_vjp_metal.py::test_disable_fused_mrope_fixes_rotary_grad FAILED
E   Failed: DID NOT RAISE <class 'ValueError'>
```

The test asserts that, before `_disable_fused_mrope` is applied, taking a gradient through the fused MRoPE kernel raises a missing-VJP `ValueError`. mlx 0.32.0 added a VJP for that custom kernel, so it no longer raises.

The real cost is not the one red test. The job is fail-fast, so every step after it is skipped:

```
 8  success  tests/test_mlx_torch_shim_smoke.py
 9  failure  tests/test_qwen35_vjp_metal.py
10  skipped  tests/test_mlx_training_e2e_metal.py
11  skipped  tests/test_mlx_pr684_full_validation_metal.py
```

So the two steps that actually exercise MLX training on Apple Silicon, the LoRA training smoke and the deep behaviour checks (resume determinism, completion-only training, epoch step counts, SGD coupled decay, real Qwen2-VL LoRA training), have not run in over a month. Several open MLX PRs are affected by this, since none of them can get real Mac signal from CI.

## Change

Keep the message assertion for older mlx releases, where the kernel still has no VJP, but stop requiring that it raises at all.

```python
try:
    val, _ = mx.value_and_grad(loss, argnums=(0, 1))(q, k)
    mx.eval(val)
except ValueError as exc:
    assert "vjp" in str(exc).lower() or "CustomKernel" in str(exc), exc
```

Everything the test is actually for is unchanged and still asserted: `_disable_fused_mrope` flips `fused_apply` off, gradients afterwards are finite and non-zero, and the fallback forward matches the fused forward.

The sibling gated-delta kernel still has no VJP, so `test_gated_delta_kernel_grad_raises_without_patch` is deliberately left alone; it passes today.

## Validation

Diagnosed on a real macos-14 runner (mlx 0.32.0, mlx-lm 0.31.3, mlx-vlm 0.6.4, `Device(gpu, 0)`), where the other three tests in the file pass and only this one fails.

```
tests/test_qwen35_vjp_metal.py::test_gated_delta_kernel_grad_raises_without_patch PASSED
tests/test_qwen35_vjp_metal.py::test_patch_gated_delta_vlm_fixes_grad_and_matches_reference PASSED
tests/test_qwen35_vjp_metal.py::test_disable_fused_mrope_fixes_rotary_grad FAILED
tests/test_qwen35_vjp_metal.py::test_end_to_end_training_step_all_patches PASSED
```

Needs the `mlx` label to run the job on this PR.
