### PR TITLE
Fix compiler codegen for a forward hidden behind a bare decorator

### DIFF
--- a/tests/test_compiler_decorated_forward.py
+++ b/tests/test_compiler_decorated_forward.py
@@ -1,0 +1,314 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""`create_standalone_class` against a forward hidden behind a decorator that
+does not use `functools.wraps`.
+
+transformers decorates `Qwen3_5GatedDeltaNet.forward` with
+`@force_accelerate_hooks("conv1d")`, and
+`transformers/integrations/accelerate.py` returns a bare inner closure with no
+`functools.wraps`. The class attribute is therefore
+`force_accelerate_hooks.<locals>.decorator.<locals>.wrapped`, so
+`inspect.getsource` returned the wrapper (defined in another file, closing over
+free variables that do not exist at module scope) and `inspect.signature`
+returned `(self, *args, **kwargs)`. The compiler emitted the wrapper body at
+module scope and generated
+
+    def forward(self, hidden_states, cache_params=None, attention_mask=None, **kwargs):
+        return wrapped(self, *args, **kwargs)
+
+which is `NameError: name 'args' is not defined` at the first forward.
+
+The fakes below reproduce that decorator shape without needing transformers or
+a GPU. The negative cases pin that every other decorator shape keeps the
+pre-existing behaviour byte for byte.
+"""
+
+import functools
+import importlib.util
+import inspect
+import sys
+import textwrap
+
+import pytest
+import torch
+
+from unsloth_zoo import compiler
+
+
+def _unwrap_undecorated_method(func, owner_qualname):
+    """Indirection so this module still imports on a build without the fix.
+    A missing helper then fails the tests that exercise it, instead of
+    erroring collection for the whole file and hiding the codegen tests."""
+    return compiler._unwrap_undecorated_method(func, owner_qualname)
+
+
+# Mirrors transformers/integrations/accelerate.py force_accelerate_hooks: an
+# inner closure over (child_module_name, forward_func), returned WITHOUT
+# functools.wraps.
+_FAKE_MODELING_SOURCE = """
+    import torch
+    from torch import nn
+
+
+    def fake_accelerate_hooks(child_module_name):
+        def decorator(forward_func):
+            def wrapped(self, *args, **kwargs):
+                self.hook_calls = getattr(self, "hook_calls", 0) + 1
+                self.hooked_child = child_module_name
+                return forward_func(self, *args, **kwargs)
+            return wrapped
+        return decorator
+
+
+    class FakeGatedDeltaNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.in_proj = nn.Linear(4, 4, bias = False)
+
+        @fake_accelerate_hooks("conv1d")
+        def forward(self, hidden_states, cache_params = None, attention_mask = None, **kwargs):
+            real_body_ran = self.in_proj(hidden_states)
+            return real_body_ran * 3.0
+
+
+    class FakePlainNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.in_proj = nn.Linear(4, 4, bias = False)
+
+        def forward(self, hidden_states, cache_params = None, **kwargs):
+            return self.in_proj(hidden_states) * 3.0
+"""
+
+
+def _load_fake_modeling_module(tmp_path, monkeypatch, name):
+    """Write the fake modeling file to disk so inspect.getsource can read it,
+    import it, and expose it to the `eval(f"{model_location}.{module}")` lookup
+    inside create_standalone_class."""
+    path = tmp_path / f"{name}.py"
+    path.write_text(textwrap.dedent(_FAKE_MODELING_SOURCE), encoding = "utf-8")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(compiler, name, module, raising = False)
+    return module
+
+
+def _generate(module_name, class_name, module):
+    return compiler.create_standalone_class(
+        class_name, module_name, dir(module), disable = True,
+    )
+
+
+def test_bare_closure_decorator_really_hides_the_method(tmp_path, monkeypatch):
+    """The premise: without unwrapping, the class attribute reports the
+    wrapper's name, signature and source, not the method's."""
+    module = _load_fake_modeling_module(tmp_path, monkeypatch, "fake_bare_closure_premise")
+    attribute = module.FakeGatedDeltaNet.forward
+
+    assert attribute.__name__ == "wrapped"
+    assert not hasattr(attribute, "__wrapped__")
+    assert str(inspect.signature(attribute)) == "(self, *args, **kwargs)"
+    assert "real_body_ran" not in inspect.getsource(attribute)
+
+
+def test_decorated_forward_emits_the_real_body_and_no_unbound_name(tmp_path, monkeypatch):
+    module = _load_fake_modeling_module(tmp_path, monkeypatch, "fake_bare_closure_codegen")
+    generated = _generate("fake_bare_closure_codegen", "FakeGatedDeltaNet", module)
+
+    # The real body is emitted, and the decorator's wrapper is not.
+    assert "real_body_ran = self.in_proj(hidden_states)" in generated
+    assert "def wrapped(" not in generated
+    assert "return wrapped(" not in generated
+
+    # The forwarding call is built from the real signature, so `args` / `kwargs`
+    # are never referenced without being bound.
+    assert "return FakeGatedDeltaNet_forward(" in generated
+    assert "hidden_states=hidden_states" in generated
+    assert "cache_params=cache_params" in generated
+    assert "attention_mask=attention_mask" in generated
+
+    compile(generated, "<fake-bare-closure-codegen>", "exec")
+
+
+def test_decorated_forward_keeps_the_disable_classification(tmp_path, monkeypatch):
+    """The wrapper's name is `wrapped`, not `forward`, so the renamed-forward
+    heuristic used to classify the method as an Unsloth temporary patch and set
+    `disable = None`, silently dropping the caller's compile decision."""
+    module = _load_fake_modeling_module(tmp_path, monkeypatch, "fake_bare_closure_disable")
+
+    disabled = _generate("fake_bare_closure_disable", "FakeGatedDeltaNet", module)
+    assert "@torch.compiler.disable(recursive = False)" in disabled
+
+    compiled = compiler.create_standalone_class(
+        "FakeGatedDeltaNet", "fake_bare_closure_disable", dir(module), disable = False,
+    )
+    assert "@torch.compile(" in compiled
+
+
+def test_decorated_forward_runs_and_fires_the_decorator_exactly_once(tmp_path, monkeypatch):
+    """`inspect.getsource` on the real method returns the class-body text
+    INCLUDING the decorator line, so the decorator travels onto the standalone
+    function and is dropped from the emitted class method. It must therefore
+    still fire exactly once, and the numerics must match eager."""
+    module = _load_fake_modeling_module(tmp_path, monkeypatch, "fake_bare_closure_runtime")
+    generated = _generate("fake_bare_closure_runtime", "FakeGatedDeltaNet", module)
+
+    assert '@fake_accelerate_hooks("conv1d")' in generated
+    assert generated.count('@fake_accelerate_hooks("conv1d")') == 1
+
+    namespace = {
+        "torch": torch,
+        "nn": torch.nn,
+        "torch_compile_options": {},
+        "fake_accelerate_hooks": module.fake_accelerate_hooks,
+    }
+    exec(generated, namespace)
+
+    generated_model = namespace["FakeGatedDeltaNet"]()
+    eager_model = module.FakeGatedDeltaNet()
+    eager_model.load_state_dict(generated_model.state_dict())
+
+    hidden_states = torch.randn(2, 3, 4)
+    generated_out = generated_model(hidden_states)
+
+    assert generated_model.hook_calls == 1
+    assert generated_model.hooked_child == "conv1d"
+    assert torch.equal(generated_out, eager_model(hidden_states))
+
+
+def test_undecorated_forward_is_untouched(tmp_path, monkeypatch):
+    """Negative case: a plain forward must generate exactly what it always did."""
+    module = _load_fake_modeling_module(tmp_path, monkeypatch, "fake_bare_closure_plain")
+    generated = _generate("fake_bare_closure_plain", "FakePlainNet", module)
+
+    assert "def FakePlainNet_forward(self, hidden_states, cache_params = None, **kwargs):" in generated
+    assert (
+        "return FakePlainNet_forward(self, hidden_states=hidden_states, "
+        "cache_params=cache_params, **kwargs)"
+    ) in generated
+    assert "@fake_accelerate_hooks" not in generated
+    compile(generated, "<fake-bare-closure-plain>", "exec")
+
+
+# ---------------------------------------------------------------------------
+# _unwrap_undecorated_method must be inert for every other shape.
+# ---------------------------------------------------------------------------
+
+def test_unwrap_returns_plain_method_identically():
+    class Plain:
+        def forward(self, x):
+            return x
+
+    assert _unwrap_undecorated_method(Plain.forward, Plain.__qualname__) is Plain.forward
+
+
+def test_unwrap_leaves_functools_wraps_decorators_alone():
+    """functools.wraps copies __qualname__ (and sets __wrapped__, which
+    inspect.getsource / inspect.signature already follow), so the wrapper is
+    returned unchanged and behaviour is identical to before the fix."""
+    def polite(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            return func(self, *args, **kwargs)
+        return wrapper
+
+    class Wrapped:
+        @polite
+        def forward(self, x):
+            return x
+
+    attribute = Wrapped.forward
+    assert _unwrap_undecorated_method(attribute, Wrapped.__qualname__) is attribute
+
+
+def test_unwrap_leaves_inherited_forward_alone():
+    class Base:
+        def forward(self, x):
+            return x
+
+    class Child(Base):
+        pass
+
+    assert _unwrap_undecorated_method(Child.forward, Child.__qualname__) is Base.forward
+
+
+def test_unwrap_leaves_ambiguous_closures_alone():
+    """Two functions in the closure is ambiguous, so nothing is unwrapped."""
+    def ambiguous(func):
+        def helper(x):
+            return x
+        def wrapper(self, *args, **kwargs):
+            return func(self, helper(0), *args, **kwargs)
+        return wrapper
+
+    class Ambiguous:
+        @ambiguous
+        def forward(self, unused, x):
+            return x
+
+    attribute = Ambiguous.forward
+    assert _unwrap_undecorated_method(attribute, Ambiguous.__qualname__) is attribute
+
+
+def test_unwrap_refuses_a_function_from_another_class():
+    """The recovered function must belong to the class being compiled."""
+    class Other:
+        def forward(self, x):
+            return x
+
+    def steal(_func):
+        target = Other.forward
+        def wrapper(self, *args, **kwargs):
+            return target(self, *args, **kwargs)
+        return wrapper
+
+    class Thief:
+        @steal
+        def forward(self, x):
+            return x
+
+    attribute = Thief.forward
+    assert _unwrap_undecorated_method(attribute, Thief.__qualname__) is attribute
+
+
+def test_unwrap_survives_non_function_attributes():
+    class Weird:
+        forward = staticmethod(print)
+
+    assert _unwrap_undecorated_method(Weird.forward, Weird.__qualname__) is Weird.forward
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3])
+def test_unwrap_walks_stacked_bare_decorators(depth):
+    """Stacked bare closures still resolve to the real method."""
+    def bare(func):
+        def wrapper(self, *args, **kwargs):
+            return func(self, *args, **kwargs)
+        return wrapper
+
+    class Stacked:
+        def forward(self, x):
+            return x
+
+    real = Stacked.forward
+    attribute = real
+    for _ in range(depth):
+        attribute = bare(attribute)
+
+    assert _unwrap_undecorated_method(attribute, Stacked.__qualname__) is real

--- a/unsloth_zoo/compiler.py
+++ b/unsloth_zoo/compiler.py
@@ -1309,6 +1309,65 @@ def fix_gemma4_forced_float32_ple_dtype(source, module = None):
 pass
 
 
+def _unwrap_undecorated_method(func, owner_qualname):
+    """
+    Recover the real, undecorated method hidden behind a decorator that returns
+    a bare closure without `functools.wraps`.
+
+    `functools.wraps` copies `__qualname__` and sets `__wrapped__`, and both
+    `inspect.getsource` and `inspect.signature` already follow `__wrapped__`, so
+    well behaved decorators need no help here and are returned unchanged by the
+    `__qualname__` fast path below.
+
+    A decorator that does NOT use `functools.wraps` leaves a class attribute
+    whose source and signature belong to the wrapper, not to the method. One
+    such decorator is transformers' `@force_accelerate_hooks(...)` in
+    `transformers/integrations/accelerate.py`, applied to
+    `Qwen3_5GatedDeltaNet.forward`: it leaves behind
+    `force_accelerate_hooks.<locals>.decorator.<locals>.wrapped`, so
+    `inspect.getsource` returns the wrapper (which lives in another file and
+    closes over free variables that do not exist at module scope) and
+    `inspect.signature` returns `(self, *args, **kwargs)`. Generating a
+    standalone function from that emits `return wrapped(self, *args, **kwargs)`
+    under the real named signature, which is a `NameError` at the first forward.
+
+    Walk `__wrapped__` and then single function closure cells until we land on a
+    function that really belongs to `owner_qualname`. If no such function is
+    found, return `func` unchanged so nothing else changes behaviour.
+    """
+    prefix = owner_qualname + "."
+    if getattr(func, "__qualname__", "").startswith(prefix):
+        return func
+    seen = set()
+    current = func
+    for _ in range(10):
+        candidate = getattr(current, "__wrapped__", None)
+        if candidate is None:
+            cells = getattr(current, "__closure__", None)
+            if getattr(current, "__code__", None) is None or not cells:
+                break
+            inner = []
+            for cell in cells:
+                try:
+                    value = cell.cell_contents
+                except ValueError:
+                    continue
+                if inspect.isfunction(value):
+                    inner.append(value)
+            # More than one candidate is ambiguous, so leave `func` alone.
+            if len(inner) != 1:
+                break
+            candidate = inner[0]
+        if not inspect.isfunction(candidate) or id(candidate) in seen:
+            break
+        seen.add(id(candidate))
+        current = candidate
+        if getattr(current, "__qualname__", "").startswith(prefix):
+            return current
+    return func
+pass
+
+
 def create_standalone_class(
     module,
     model_location,
@@ -1332,7 +1391,11 @@ def create_standalone_class(
     # All Unsloth Zoo code licensed under LGPLv3
     f = eval(f"{model_location}.{module}")
     full_class = inspect.getsource(f)
-    old_source = inspect.getsource(f.forward)
+    # A decorator that returns a bare closure (no `functools.wraps`) hides the
+    # real method behind the wrapper, so read the source and the signature off
+    # the undecorated function instead of off the class attribute.
+    real_forward = _unwrap_undecorated_method(f.forward, f.__qualname__)
+    old_source = inspect.getsource(real_forward)
     old_init = inspect.getsource(f.__init__)
     if forward_source is None:
         forward_source = old_source
@@ -1465,7 +1528,7 @@ def create_standalone_class(
         compile = ""
 
     # Create new forward calling optimized function
-    parameters = inspect.signature(f.forward).parameters
+    parameters = inspect.signature(real_forward).parameters
     # Build the forwarding call using keyword arguments (name=name) for regular
     # parameters so that decorators like @merge_with_config_defaults can find
     # them in **kwargs.  When args are passed positionally, the decorator's


### PR DESCRIPTION
## What breaks

Fine-tuning Qwen3.5 fails at the very first forward with the module compiler enabled, which is the default:

```
  File "unsloth_compiled_cache/unsloth_compiled_module_qwen3_5.py", line 95, in forward
    return wrapped(self, *args, **kwargs)
                          ^^^^
NameError: name 'args' is not defined
```

The same generated-source defect hits the linear attention / mixer module of 14 classes across 14 model families, not just Qwen3.5. See the measured list below.

This is a regression from transformers, not from unsloth_zoo. Qwen3.5 fine-tuning worked on every transformers release from v5.2.0 (when the model landed, undecorated) through v5.12.1, and breaks from v5.13.0 onward. Both compiler call sites below have read the forward off the class attribute since compiler.py was first committed in November 2024, and have never changed; nothing in transformers put a `functools.wraps`-less decorator on a `forward` until 2026-07-01.

## Root cause

`unsloth_zoo/compiler.py:create_standalone_class` reads the model's forward through the class attribute at two places:

- `old_source = inspect.getsource(f.forward)`
- `parameters = inspect.signature(f.forward).parameters`

Both assume the class attribute is the method. That holds for an undecorated forward, and for any decorator that uses `functools.wraps` (which copies `__qualname__` and sets `__wrapped__`, and both `inspect.getsource` and `inspect.signature` already follow `__wrapped__`). It does not hold for a decorator that returns a bare closure.

transformers commit 36778030cb (PR #46978, 2026-07-01, released in v5.13.0 on 2026-07-03) added `force_accelerate_hooks` and applied it to the mixer forward of 11 classes in one change; v5.14.0 and v5.14.1 took it to 14 (`git grep -l @force_accelerate_hooks v5.14.1 -- 'src/transformers/models/*/modeling_*.py'` returns 14 files, against 0 at v5.12.1). `transformers/models/qwen3_5/modeling_qwen3_5.py:440` (v5.14.1; line 458 on current main) has:

```python
@force_accelerate_hooks("conv1d")
def forward(
    self,
    hidden_states: torch.Tensor,
    cache_params: Cache | None = None,
    attention_mask: torch.Tensor | None = None,
    **kwargs: Unpack[TransformersKwargs],
):
```

and `transformers/integrations/accelerate.py:931-951` returns a bare inner closure:

```python
def decorator(forward_func: Callable) -> Callable:
    def wrapped(self, *args, **kwargs):
        hooked_module = getattr(self, child_module_name)
        ...
        output = forward_func(self, *args, **kwargs)
        ...
        return output

    return wrapped
```

There is no `functools.wraps` anywhere in that file, and `functools` is not even imported. So for `Qwen3_5GatedDeltaNet.forward` the class attribute is `force_accelerate_hooks.<locals>.decorator.<locals>.wrapped`: `__name__` is `wrapped`, `__wrapped__` is absent, `inspect.signature` reports `(self, *args, **kwargs)`, `inspect.getsource` returns the wrapper from accelerate.py, and `co_freevars` is `('child_module_name', 'forward_func')`.

Three failures chain from that:

1. **The compile decision is silently dropped.** The `re.search(r"def\s+(\w+)\s*\(", forward_source)` check at `compiler.py:1490` sees the name `wrapped` rather than `forward`, misclassifies the method as an Unsloth temporary-patch rename, and sets `disable = None`. That suppresses the `@torch.compiler.disable` the caller asked for, and with it the fact that the class is listed in `DISABLE_COMPILE_MODULES`.
2. **The wrong body is emitted.** The decorator's closure body goes out at module scope, where its free variables `child_module_name` and `forward_func` do not exist. The real mixer body is never emitted at all.
3. **The call does not match the definition.** The forwarding call is built from the wrapper's `(self, *args, **kwargs)` signature while the definition comes from the class's real `def forward(...)`.

The generated file before this change, verbatim:

```python
def wrapped(self, *args, **kwargs):
    hooked_module = getattr(self, child_module_name)      # NameError waiting to happen
    ...
    output = forward_func(self, *args, **kwargs)
    ...

class Qwen3_5GatedDeltaNet(nn.Module):
    def forward(
        self,
        hidden_states: torch.Tensor,
        cache_params: Cache | None = None,
        attention_mask: torch.Tensor | None = None,
        **kwargs: Unpack[TransformersKwargs],
    ):
        return wrapped(self, *args, **kwargs)             # NameError: name 'args' is not defined
```

Note there is no `@torch.compiler.disable(recursive = False)` on that file even though `disable = True` was requested. That is failure 1.

## The fix

Add `_unwrap_undecorated_method`, and use it at both call sites.

It walks `__wrapped__` and then single-function closure cells, and accepts a candidate **only** when its `__qualname__` belongs to the class being compiled. Anything else returns the input unchanged, so no other decorator shape changes behaviour:

- a plain method returns immediately via the `__qualname__` fast path;
- a `functools.wraps` decorator also returns immediately, because `wraps` copies `__qualname__`;
- an inherited forward, an ambiguous closure holding more than one function, a recovered function belonging to a different class, and a non-function attribute all return the input unchanged.

The load-bearing detail: `inspect.getsource` on the real method returns the class-body text **including** the decorator line, and that is the exact substring replaced in `full_class`. So the decorator moves onto the generated standalone function and is removed from the class method, which means it still fires exactly once. There is a test asserting exactly that, including a numerical comparison against eager.

After this change the same file is generated as:

```python
@torch.compiler.disable(recursive = False)
@force_accelerate_hooks("conv1d")
def Qwen3_5GatedDeltaNet_forward(
    self,
    hidden_states: torch.Tensor,
    ...
):
    hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)   # the real body
    ...

class Qwen3_5GatedDeltaNet(nn.Module):
    def forward(self, hidden_states, cache_params=None, attention_mask=None, **kwargs):
        return Qwen3_5GatedDeltaNet_forward(self, hidden_states=hidden_states, cache_params=cache_params, attention_mask=attention_mask, **kwargs)
```

## Measured before and after

End to end, `unsloth/Qwen3.5-2B` LoRA fine-tune on a B200, torch 2.11.0+cu128, transformers 5.14.1, module compiler enabled:

| | before | after |
| --- | --- | --- |
| 10-step LoRA fine-tune | `NameError: name 'args' is not defined` | passes |
| 16bit merge + export | not reached | 4.55 GB, bfloat16, all files present |
| generation from base / adapter / merged | not reached | all three coherent |

New regression test, run against the same tree with and without the fix:

```
################ VARIANT: pristine ################
12 failed, 2 passed, 14 warnings in 0.28s
################ VARIANT: patched ################
14 passed, 14 warnings in 0.08s
```

The 2 that pass both ways are deliberate controls: the premise test (the class attribute really does report the wrapper's name, signature and source) and the negative case (an undecorated forward is untouched).

## Why this cannot affect other models

I generated every `nn.Module` class of 30 transformers families through `create_standalone_class`, in both the `disable` and `compile` variants, once with the pristine compiler and once with the patched one, and diffed the two output trees byte for byte.

**22 of 686 generated files differ.** They are exactly the 11 `force_accelerate_hooks` classes times the 2 variants:

`BambaMixer`, `FalconH1Mixer`, `FalconMambaMixer`, `GraniteMoeHybridMambaLayer`, `JambaMambaMixer`, `Lfm2ShortConv`, `MambaMixer`, `NemotronHMamba2Mixer`, `Qwen3_5GatedDeltaNet`, `Qwen3NextGatedDeltaNet`, `Zamba2MambaMixer`.

The set of files that differ is identical to the set of files that contained the broken `return wrapped(` before the change, and no generated file contains `def wrapped(` or `return wrapped(` after it.

Every other family is **byte identical**: llama, qwen2, qwen3, mistral, gemma, gemma2, gemma3, phi3, mixtral, falcon, gpt2, starcoder2, cohere, olmo, granite, siglip, clip, qwen2_vl, qwen3_moe.

Existing suites, same tree with and without the fix, identical results either way:

```
tests/test_compiler_dynamic_exec.py tests/test_compiler_output_capture.py
tests/test_compiler_rewriter_exhaustive.py tests/test_compile_cache_security.py
tests/test_temporary_patches_exhaustive.py
-> 286 passed, 28 skipped   (both pristine and patched)
```

## Known limitation

The recovered function must belong to the class being compiled. A class that *inherits* an already-decorated forward from a base class is therefore left alone rather than unwrapped. That is deliberately conservative: it keeps the change inert where the correct answer is not obvious. No class in the 30 families swept hits this case, all 14 affected classes define their own forward.

## Tests added

`tests/test_compiler_decorated_forward.py`, GPU-free and transformers-version independent. It builds a fake modeling module whose decorator mirrors `force_accelerate_hooks` exactly (bare inner closure, no `functools.wraps`), writes it to disk so `inspect.getsource` can read it, and runs it through the real `create_standalone_class`.

Covers: the premise; the real body being emitted with no unbound name; the `disable` classification surviving; the decorator firing exactly once with numerics matching eager; an undecorated forward being untouched; and six inertness cases for `_unwrap_undecorated_method` (plain method, `functools.wraps`, inherited, ambiguous closure, function from another class, non-function attribute, plus stacked bare decorators at depth 1/2/3).

## Why here and not upstream

`force_accelerate_hooks` in `transformers/integrations/accelerate.py` returns a bare inner closure with no
`functools.wraps`, which is what makes the decorated `forward` unreadable. That is the trigger, but it is not
a defect on their side: the decorator is correct code doing what it documents, `forward` on a mixer module is
internal, and nothing guarantees that a class attribute named `forward` is the undecorated function or that
its source text is recoverable. Reading a method's source with `inspect.getsource` and regenerating it is a
much deeper assumption than any library offers, and that assumption is ours. The fix belongs here.

Adding the affected classes to `DISABLE_COMPILE_MODULES` does not work either. `Qwen3_5GatedDeltaNet`
already matches that list through its `GatedDeltaNet` suffix entry. Matching only sets `disable = True`;
the class still goes through `create_standalone_class`, which is where the defect is, so it is generated
just as wrongly.

## Loud versus silent

Worth separating what transformers caused from what this repo owns. Against a decorated forward, the
codegen used to raise, and the caller catches that and skips the module with a warning. The
rename-detection branch was originally guarded by `if "@torch.compiler.disable" in forward_source:` so it
only fired on Unsloth's own temporary patches. That guard was dropped, restored a day later, and then
replaced by a module-name check that applies to everything except one module. In the two unguarded states a
decorated forward is silently mis-generated instead of raising, which is why this surfaces as a `NameError`
at the first forward rather than as a skipped module. This PR fixes the generation; the guard history is
noted here only so the failure mode is not mistaken for the cause.
