### PR TITLE
Preserve MLX-VLM compatibility across 0.4.4–0.6.7

### DIFF
--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -79,6 +79,32 @@ def _write_config(tmp_path, config):
     return path
 
 
+def test_vlm_detection_requires_a_real_modality(monkeypatch, tmp_path):
+    import unsloth_zoo.mlx.loader as loader
+    text = tmp_path / "text"
+    text.mkdir()
+    (text / "config.py").write_text("class ModelConfig:\n    text_config: object\n")
+    omni = tmp_path / "omni"
+    omni.mkdir()
+    (omni / "config.py").write_text("class ThinkerConfig:\n    vision_config: object\n")
+    assert not loader._config_source_has_modality(text)
+    assert loader._config_source_has_modality(omni)
+    models = tmp_path / "models"
+    models.mkdir()
+    static_vlm = models / "static_vlm"
+    static_vlm.mkdir()
+    (static_vlm / "__init__.py").write_text("raise RuntimeError('must not import')\n")
+    (static_vlm / "config.py").write_text("class ModelConfig:\n    vision_config: object\n")
+    import mlx_vlm.models as mlx_vlm_models
+    monkeypatch.setattr(mlx_vlm_models, "__path__", [str(models)])
+    assert "static_vlm" in loader._build_vlm_model_types()
+    monkeypatch.setattr(loader, "_vlm_model_types_cache", frozenset({"vendored_vlm"}))
+    assert loader._is_vlm({"vision_config": {"hidden_size": 32}})
+    assert loader._is_vlm({"model_type": "vendored_vlm"})
+    assert not loader._is_vlm({"model_type": "text_only", "architectures": ["TextForCausalLM"]})
+    assert not loader._is_vlm({"vision_config": {}, "model_type": "text_only"})
+
+
 def test_apply_mlx_distributed_sharding_modes_and_guards():
     from unsloth_zoo.mlx.loader import (
         _apply_mlx_distributed_sharding,

--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -246,6 +246,8 @@ def test_load_mlx_vlm_distributed_delegates_to_mlx_vlm_sharded_load(monkeypatch,
 
     monkeypatch.setattr(loader, "_bind_mlx_vlm_quantized_projector_loader", bind)
     model_dir = _write_config(tmp_path, {"model_type": "raw"})
+    (model_dir / "model.safetensors").write_text("weights")
+    monkeypatch.chdir(tmp_path)
     messages = ["The model does not support pipeline parallelism", "Model type kimi_k25 not supported", "Unsupported model type kimi_k25", "checkpoint exploded"]
 
     class _FakeVLM:
@@ -259,7 +261,7 @@ def test_load_mlx_vlm_distributed_delegates_to_mlx_vlm_sharded_load(monkeypatch,
         return _FakeVLM(), types.SimpleNamespace(name="processor")
 
     vlm_utils = types.ModuleType("mlx_vlm.utils")
-    vlm_utils.get_model_path = lambda repo, revision=None: model_dir
+    vlm_utils.get_model_path = lambda repo, revision=None: Path("model")
     vlm_utils.sharded_load = sharded_load
     monkeypatch.setitem(sys.modules, "mlx_vlm", types.ModuleType("mlx_vlm"))
     monkeypatch.setitem(sys.modules, "mlx_vlm.utils", vlm_utils)
@@ -272,6 +274,7 @@ def test_load_mlx_vlm_distributed_delegates_to_mlx_vlm_sharded_load(monkeypatch,
         _load_mlx_vlm_distributed("fake/vlm", "kimi_k25", pipeline_group=pipeline_group)
     assert calls[0][3] == "patched"
     assert Path(calls[0][0]).exists()
+    assert (Path(calls[0][0]) / "model.safetensors").read_text() == "weights"
     assert model._unsloth_mlx_config_view_paths == [str(calls[0][0])]
     model._unsloth_mlx_config_view_finalizers[0]()
     assert not Path(calls[0][0]).exists()

--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -325,11 +325,12 @@ def test_from_pretrained_distributed_vlm_passes_override_without_temp_view(monke
     from unsloth_zoo.mlx.loader import FastMLXModel
 
     config = {"model_type": "raw", "vision_config": {}, "architectures": ["DeepSeekOCRForCausalLM"], "auto_map": {"x": "y"}}
-    model_path, calls = _write_config(tmp_path, config), []
+    model_path, calls, sanitize_calls = _write_config(tmp_path, config), [], []
     monkeypatch.setattr(mlx_lm_utils, "_download", lambda *_a, **_k: model_path)
     monkeypatch.setattr(loader, "_load_mlx_vlm_distributed", lambda *_a, config_override_data=None, **_k: (calls.append(config_override_data), (types.SimpleNamespace(), types.SimpleNamespace(tokenizer=object())))[1])
-    for name in ("install_mlx_compile_patches", "_ensure_vlm_prompt_utils_patched", "_convert_mlx_dtype", "_patch_mixed_precision_set_dtype", "_fix_gemma4_kv_sharing", "_fix_gemma3_vision_post_layernorm_eps", "_fix_gemma3_vision_attention_fp32_sdpa", "_fix_gemma3_vision_encoder_fp32_layernorm", "_fix_gemma3_vision_post_layernorm_fp32", "_fix_gemma3_vision_mlp_fp32_activation", "_fix_gemma3_language_mlp_fp32_activation", "_fix_gemma3_multimodal_image_feature_scale"):
+    for name in ("install_mlx_compile_patches", "_ensure_vlm_processor_inputs_patched", "_ensure_vlm_prompt_utils_patched", "_convert_mlx_dtype", "_patch_mixed_precision_set_dtype", "_fix_gemma4_kv_sharing", "_fix_gemma3_vision_post_layernorm_eps", "_fix_gemma3_vision_attention_fp32_sdpa", "_fix_gemma3_vision_encoder_fp32_layernorm", "_fix_gemma3_vision_post_layernorm_fp32", "_fix_gemma3_vision_mlp_fp32_activation", "_fix_gemma3_language_mlp_fp32_activation", "_fix_gemma3_multimodal_image_feature_scale"):
         monkeypatch.setattr(loader, name, lambda *_a, **_k: None)
+    monkeypatch.setattr(loader, "_ensure_minicpmo_mlx_sanitize", sanitize_calls.append)
     monkeypatch.setattr(loader, "_repair_degraded_vlm_processor", lambda processor, *_a, **_k: processor)
     monkeypatch.setattr(loader, "_infer_snapshot_commit", lambda *_a, **_k: "commit")
     monkeypatch.setitem(sys.modules, "mlx_vlm", types.SimpleNamespace(load=lambda *_a, **_k: None))
@@ -337,6 +338,7 @@ def test_from_pretrained_distributed_vlm_passes_override_without_temp_view(monke
     FastMLXModel.from_pretrained("fake/vlm", text_only=False, tensor_group=_FakeGroup(), load_in_4bit=False)
 
     assert calls == [{k: v for k, v in config.items() if k != "auto_map"} | {"model_type": "deepseekocr"}]
+    assert sanitize_calls == ["deepseekocr"]
 
 
 def _patch_fast_mlx_text_load(monkeypatch, tmp_path, config):

--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -239,8 +239,11 @@ def test_load_mlx_vlm_distributed_delegates_to_mlx_vlm_sharded_load(monkeypatch,
     bound_calls = []
     def bind(sharded):
         def wrapped(*args, **kwargs):
-            bound_calls.append(True); return sharded(*args, **kwargs)
+            bound_calls.append(True)
+            return sharded(*args, **kwargs)
+
         return wrapped
+
     monkeypatch.setattr(loader, "_bind_mlx_vlm_quantized_projector_loader", bind)
     model_dir = _write_config(tmp_path, {"model_type": "raw"})
     messages = ["The model does not support pipeline parallelism", "Model type kimi_k25 not supported", "Unsupported model type kimi_k25", "checkpoint exploded"]
@@ -278,69 +281,47 @@ def test_load_mlx_vlm_distributed_delegates_to_mlx_vlm_sharded_load(monkeypatch,
     assert len(bound_calls) == 5
 
 
-def test_load_mlx_vlm_distributed_applies_llava_processor_geometry(monkeypatch, tmp_path):
-    from unsloth_zoo.mlx.loader import _load_mlx_vlm_distributed
-
-    config = {
-        "model_type": "llava",
-        "vision_config": {"patch_size": 14},
-        "vision_feature_select_strategy": "default",
-    }
-    model_dir = _write_config(tmp_path, config)
-    processor_config = {
-        "processor_class": "LlavaProcessor",
-        "patch_size": None,
-        "vision_feature_select_strategy": None,
-    }
-    (model_dir / "processor_config.json").write_text(json.dumps(processor_config))
-    seen = []
-
-    class _FakeVLM:
-        pass
-
-    def sharded_load(repo, **_kwargs):
-        seen.append(json.loads((Path(repo) / "processor_config.json").read_text()))
-        return _FakeVLM(), types.SimpleNamespace(name="processor")
-
-    vlm_utils = types.ModuleType("mlx_vlm.utils")
-    vlm_utils.get_model_path = lambda *_a, **_k: model_dir
-    vlm_utils.sharded_load = sharded_load
-    monkeypatch.setitem(sys.modules, "mlx_vlm", types.ModuleType("mlx_vlm"))
-    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", vlm_utils)
-
-    model, _ = _load_mlx_vlm_distributed(
-        "fake/llava",
-        "llava",
-        tensor_group=_FakeGroup(name="tensor"),
-    )
-
-    assert (seen[0]["patch_size"], seen[0]["vision_feature_select_strategy"]) == (14, "default")
-    assert json.loads((model_dir / "processor_config.json").read_text()) == processor_config
-    model._unsloth_mlx_config_view_finalizers[0]()
-
-
-def test_from_pretrained_distributed_vlm_passes_override_without_temp_view(monkeypatch, tmp_path):
+def test_from_pretrained_distributed_vlm_forwards_normalized_override(monkeypatch, tmp_path):
     import mlx_lm.utils as mlx_lm_utils
     import unsloth_zoo.mlx.loader as loader
     from unsloth_zoo.mlx.loader import FastMLXModel
 
-    config = {"model_type": "raw", "vision_config": {}, "architectures": ["DeepSeekOCRForCausalLM"], "auto_map": {"x": "y"}}
-    model_path, calls, sanitize_calls, vision_calls = _write_config(tmp_path, config), [], [], []
+    config = {
+        "model_type": "raw",
+        "vision_config": {},
+        "architectures": ["DeepSeekOCRForCausalLM"],
+        "auto_map": {"x": "y"},
+    }
+    model_path, calls = _write_config(tmp_path, config), []
     monkeypatch.setattr(mlx_lm_utils, "_download", lambda *_a, **_k: model_path)
-    monkeypatch.setattr(loader, "_load_mlx_vlm_distributed", lambda *_a, config_override_data=None, **_k: (calls.append(config_override_data), (types.SimpleNamespace(), types.SimpleNamespace(tokenizer=object())))[1])
-    for name in ("install_mlx_compile_patches", "_ensure_vlm_processor_inputs_patched", "_ensure_vlm_prompt_utils_patched", "_convert_mlx_dtype", "_patch_mixed_precision_set_dtype", "_fix_gemma4_kv_sharing", "_fix_gemma3_vision_post_layernorm_eps", "_fix_gemma3_vision_attention_fp32_sdpa", "_fix_gemma3_vision_encoder_fp32_layernorm", "_fix_gemma3_vision_post_layernorm_fp32", "_fix_gemma3_vision_mlp_fp32_activation", "_fix_gemma3_language_mlp_fp32_activation", "_fix_gemma3_multimodal_image_feature_scale"):
+
+    def distributed(_name, model_type, *, config_override_data=None, allow_remote_code=None, **_kwargs):
+        calls.append((model_type, config_override_data, allow_remote_code))
+        return types.SimpleNamespace(), types.SimpleNamespace(tokenizer=object())
+
+    monkeypatch.setattr(loader, "_load_mlx_vlm_distributed", distributed)
+    noops = (
+        "install_mlx_compile_patches", "_ensure_vlm_processor_inputs_patched",
+        "_ensure_vlm_prompt_utils_patched", "_convert_mlx_dtype",
+        "_patch_mixed_precision_set_dtype", "_ensure_minicpmo_mlx_sanitize",
+        "_ensure_minicpmo_vision_dtype", "_fix_gemma4_kv_sharing",
+        "_fix_gemma3_vision_post_layernorm_eps", "_fix_gemma3_vision_attention_fp32_sdpa",
+        "_fix_gemma3_vision_encoder_fp32_layernorm", "_fix_gemma3_vision_post_layernorm_fp32",
+        "_fix_gemma3_vision_mlp_fp32_activation", "_fix_gemma3_language_mlp_fp32_activation",
+        "_fix_gemma3_multimodal_image_feature_scale",
+    )
+    for name in noops:
         monkeypatch.setattr(loader, name, lambda *_a, **_k: None)
-    monkeypatch.setattr(loader, "_ensure_minicpmo_mlx_sanitize", sanitize_calls.append)
-    monkeypatch.setattr(loader, "_ensure_minicpmo_vision_dtype", vision_calls.append)
     monkeypatch.setattr(loader, "_repair_degraded_vlm_processor", lambda processor, *_a, **_k: processor)
     monkeypatch.setattr(loader, "_infer_snapshot_commit", lambda *_a, **_k: "commit")
     monkeypatch.setitem(sys.modules, "mlx_vlm", types.SimpleNamespace(load=lambda *_a, **_k: None))
 
-    FastMLXModel.from_pretrained("fake/vlm", text_only=False, tensor_group=_FakeGroup(), load_in_4bit=False)
-
-    assert calls == [{k: v for k, v in config.items() if k != "auto_map"} | {"model_type": "deepseekocr"}]
-    assert sanitize_calls == ["deepseekocr"]
-    assert vision_calls == ["deepseekocr"]
+    FastMLXModel.from_pretrained(
+        "fake/vlm", text_only=False, tensor_group=_FakeGroup(),
+        load_in_4bit=False, trust_remote_code=True,
+    )
+    expected = {key: value for key, value in config.items() if key != "auto_map"}
+    assert calls == [("deepseekocr", expected | {"model_type": "deepseekocr"}, True)]
 
 
 def _patch_fast_mlx_text_load(monkeypatch, tmp_path, config):

--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -233,8 +233,15 @@ def test_load_mlx_lm_distributed_tensor_uses_strict_fallback(monkeypatch, tmp_pa
 
 
 def test_load_mlx_vlm_distributed_delegates_to_mlx_vlm_sharded_load(monkeypatch, tmp_path):
+    import unsloth_zoo.mlx.loader as loader
     from unsloth_zoo.mlx.loader import _load_mlx_vlm_distributed
     calls = []
+    bound_calls = []
+    def bind(sharded):
+        def wrapped(*args, **kwargs):
+            bound_calls.append(True); return sharded(*args, **kwargs)
+        return wrapped
+    monkeypatch.setattr(loader, "_bind_mlx_vlm_quantized_projector_loader", bind)
     model_dir = _write_config(tmp_path, {"model_type": "raw"})
     messages = ["The model does not support pipeline parallelism", "Model type kimi_k25 not supported", "Unsupported model type kimi_k25", "checkpoint exploded"]
 
@@ -268,6 +275,7 @@ def test_load_mlx_vlm_distributed_delegates_to_mlx_vlm_sharded_load(monkeypatch,
     assert "Unsloth:" not in str(exc_info.value)
     assert calls[0][1:3] == (tensor_group, None)
     assert all(call[1:3] == (None, pipeline_group) for call in calls[1:])
+    assert len(bound_calls) == 5
 
 
 def test_load_mlx_vlm_distributed_applies_llava_processor_geometry(monkeypatch, tmp_path):

--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -325,12 +325,13 @@ def test_from_pretrained_distributed_vlm_passes_override_without_temp_view(monke
     from unsloth_zoo.mlx.loader import FastMLXModel
 
     config = {"model_type": "raw", "vision_config": {}, "architectures": ["DeepSeekOCRForCausalLM"], "auto_map": {"x": "y"}}
-    model_path, calls, sanitize_calls = _write_config(tmp_path, config), [], []
+    model_path, calls, sanitize_calls, vision_calls = _write_config(tmp_path, config), [], [], []
     monkeypatch.setattr(mlx_lm_utils, "_download", lambda *_a, **_k: model_path)
     monkeypatch.setattr(loader, "_load_mlx_vlm_distributed", lambda *_a, config_override_data=None, **_k: (calls.append(config_override_data), (types.SimpleNamespace(), types.SimpleNamespace(tokenizer=object())))[1])
     for name in ("install_mlx_compile_patches", "_ensure_vlm_processor_inputs_patched", "_ensure_vlm_prompt_utils_patched", "_convert_mlx_dtype", "_patch_mixed_precision_set_dtype", "_fix_gemma4_kv_sharing", "_fix_gemma3_vision_post_layernorm_eps", "_fix_gemma3_vision_attention_fp32_sdpa", "_fix_gemma3_vision_encoder_fp32_layernorm", "_fix_gemma3_vision_post_layernorm_fp32", "_fix_gemma3_vision_mlp_fp32_activation", "_fix_gemma3_language_mlp_fp32_activation", "_fix_gemma3_multimodal_image_feature_scale"):
         monkeypatch.setattr(loader, name, lambda *_a, **_k: None)
     monkeypatch.setattr(loader, "_ensure_minicpmo_mlx_sanitize", sanitize_calls.append)
+    monkeypatch.setattr(loader, "_ensure_minicpmo_vision_dtype", vision_calls.append)
     monkeypatch.setattr(loader, "_repair_degraded_vlm_processor", lambda processor, *_a, **_k: processor)
     monkeypatch.setattr(loader, "_infer_snapshot_commit", lambda *_a, **_k: "commit")
     monkeypatch.setitem(sys.modules, "mlx_vlm", types.SimpleNamespace(load=lambda *_a, **_k: None))
@@ -339,6 +340,7 @@ def test_from_pretrained_distributed_vlm_passes_override_without_temp_view(monke
 
     assert calls == [{k: v for k, v in config.items() if k != "auto_map"} | {"model_type": "deepseekocr"}]
     assert sanitize_calls == ["deepseekocr"]
+    assert vision_calls == ["deepseekocr"]
 
 
 def _patch_fast_mlx_text_load(monkeypatch, tmp_path, config):

--- a/tests/test_mlx_distributed_loader.py
+++ b/tests/test_mlx_distributed_loader.py
@@ -270,6 +270,47 @@ def test_load_mlx_vlm_distributed_delegates_to_mlx_vlm_sharded_load(monkeypatch,
     assert all(call[1:3] == (None, pipeline_group) for call in calls[1:])
 
 
+def test_load_mlx_vlm_distributed_applies_llava_processor_geometry(monkeypatch, tmp_path):
+    from unsloth_zoo.mlx.loader import _load_mlx_vlm_distributed
+
+    config = {
+        "model_type": "llava",
+        "vision_config": {"patch_size": 14},
+        "vision_feature_select_strategy": "default",
+    }
+    model_dir = _write_config(tmp_path, config)
+    processor_config = {
+        "processor_class": "LlavaProcessor",
+        "patch_size": None,
+        "vision_feature_select_strategy": None,
+    }
+    (model_dir / "processor_config.json").write_text(json.dumps(processor_config))
+    seen = []
+
+    class _FakeVLM:
+        pass
+
+    def sharded_load(repo, **_kwargs):
+        seen.append(json.loads((Path(repo) / "processor_config.json").read_text()))
+        return _FakeVLM(), types.SimpleNamespace(name="processor")
+
+    vlm_utils = types.ModuleType("mlx_vlm.utils")
+    vlm_utils.get_model_path = lambda *_a, **_k: model_dir
+    vlm_utils.sharded_load = sharded_load
+    monkeypatch.setitem(sys.modules, "mlx_vlm", types.ModuleType("mlx_vlm"))
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", vlm_utils)
+
+    model, _ = _load_mlx_vlm_distributed(
+        "fake/llava",
+        "llava",
+        tensor_group=_FakeGroup(name="tensor"),
+    )
+
+    assert (seen[0]["patch_size"], seen[0]["vision_feature_select_strategy"]) == (14, "default")
+    assert json.loads((model_dir / "processor_config.json").read_text()) == processor_config
+    model._unsloth_mlx_config_view_finalizers[0]()
+
+
 def test_from_pretrained_distributed_vlm_passes_override_without_temp_view(monkeypatch, tmp_path):
     import mlx_lm.utils as mlx_lm_utils
     import unsloth_zoo.mlx.loader as loader
@@ -278,7 +319,6 @@ def test_from_pretrained_distributed_vlm_passes_override_without_temp_view(monke
     config = {"model_type": "raw", "vision_config": {}, "architectures": ["DeepSeekOCRForCausalLM"], "auto_map": {"x": "y"}}
     model_path, calls = _write_config(tmp_path, config), []
     monkeypatch.setattr(mlx_lm_utils, "_download", lambda *_a, **_k: model_path)
-    monkeypatch.setattr(loader, "_materialize_mlx_vlm_config_data", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("first temp view")))
     monkeypatch.setattr(loader, "_load_mlx_vlm_distributed", lambda *_a, config_override_data=None, **_k: (calls.append(config_override_data), (types.SimpleNamespace(), types.SimpleNamespace(tokenizer=object())))[1])
     for name in ("install_mlx_compile_patches", "_ensure_vlm_prompt_utils_patched", "_convert_mlx_dtype", "_patch_mixed_precision_set_dtype", "_fix_gemma4_kv_sharing", "_fix_gemma3_vision_post_layernorm_eps", "_fix_gemma3_vision_attention_fp32_sdpa", "_fix_gemma3_vision_encoder_fp32_layernorm", "_fix_gemma3_vision_post_layernorm_fp32", "_fix_gemma3_vision_mlp_fp32_activation", "_fix_gemma3_language_mlp_fp32_activation", "_fix_gemma3_multimodal_image_feature_scale"):
         monkeypatch.setattr(loader, name, lambda *_a, **_k: None)

--- a/tests/test_mlx_extra_special_tokens_compat.py
+++ b/tests/test_mlx_extra_special_tokens_compat.py
@@ -234,3 +234,39 @@ def test_temporary_patch_exposes_original_init_for_probe(
 
     assert hasattr(base_init.__init__, "_unsloth_original_init")
     assert _tokenizer_supports_list_extra_special_tokens() is False
+
+
+def test_materialize_persists_corrected_config_only_when_sidecar_exists(tmp_path):
+    """A caller-corrected config is written; an absent sidecar stays in place."""
+    from unsloth_zoo.mlx.loader import _materialize_mlx_vlm_config_override
+
+    # No config.json on disk: nothing to reconcile, so load in place.
+    bare_dir = tmp_path / "bare"
+    bare_dir.mkdir()
+    (bare_dir / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+    load_path, _ = _materialize_mlx_vlm_config_override(
+        str(bare_dir),
+        {"model_type": "qwen3_vl"},
+    )
+    assert load_path == str(bare_dir)
+
+    # config.json on disk disagrees with the corrected data mlx-vlm must see,
+    # so the override view has to carry the corrected copy.
+    ocr_dir = tmp_path / "ocr"
+    ocr_dir.mkdir()
+    on_disk = {
+        "model_type": "deepseek_vl_v2",
+        "architectures": ["DeepseekOCRForCausalLM"],
+        "auto_map": {"AutoModel": "modeling_deepseekocr.DeepseekOCRForCausalLM"},
+    }
+    (ocr_dir / "config.json").write_text(json.dumps(on_disk), encoding="utf-8")
+    corrected = {
+        "model_type": "deepseekocr",
+        "architectures": ["DeepseekOCRForCausalLM"],
+    }
+    load_path, _ = _materialize_mlx_vlm_config_override(str(ocr_dir), corrected)
+    assert load_path != str(ocr_dir)
+    written = json.loads(
+        (Path(load_path) / "config.json").read_text(encoding="utf-8")
+    )
+    assert written == corrected

--- a/tests/test_mlx_extra_special_tokens_compat.py
+++ b/tests/test_mlx_extra_special_tokens_compat.py
@@ -270,3 +270,50 @@ def test_materialize_persists_corrected_config_only_when_sidecar_exists(tmp_path
         (Path(load_path) / "config.json").read_text(encoding="utf-8")
     )
     assert written == corrected
+
+
+def test_config_view_links_resolve_from_a_relative_model_directory(tmp_path, monkeypatch):
+    """A relative local model dir must still yield links a loader can open."""
+    import os
+    import shutil
+
+    from unsloth_zoo.mlx.loader import _materialize_mlx_vlm_config_override
+
+    model_dir = tmp_path / "relmodel"
+    model_dir.mkdir()
+    config = {
+        "model_type": "llava",
+        "vision_config": {"patch_size": 14},
+        "vision_feature_select_strategy": "default",
+    }
+    (model_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    # Missing patch_size: the repair rewrites processor_config.json, which is
+    # what forces the temporary view in the first place.
+    (model_dir / "processor_config.json").write_text(
+        json.dumps({"processor_class": "LlavaProcessor"}), encoding="utf-8"
+    )
+    (model_dir / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+    (model_dir / "model.safetensors").write_bytes(b"\x00" * 16)
+
+    # mlx-lm hands a local directory straight back, so a relative model name
+    # reaches the view builder still relative to the caller's cwd.
+    monkeypatch.chdir(tmp_path)
+    load_path, _ = _materialize_mlx_vlm_config_override("relmodel", config)
+    try:
+        assert load_path != "relmodel"
+        dangling = sorted(
+            name
+            for name in os.listdir(load_path)
+            if not os.path.exists(os.path.join(load_path, name))
+        )
+        assert dangling == [], f"config view has dangling links: {dangling}"
+        assert (Path(load_path) / "model.safetensors").read_bytes() == b"\x00" * 16
+        assert json.loads(
+            (Path(load_path) / "config.json").read_text(encoding="utf-8")
+        ) == config
+        # Links still point at the caller's directory, not into the view.
+        target = os.readlink(os.path.join(load_path, "model.safetensors"))
+        assert os.path.isabs(target)
+        assert Path(target).parent == model_dir
+    finally:
+        shutil.rmtree(load_path, ignore_errors=True)

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -42,7 +42,11 @@ def test_qk_norm_mismatch_raises_actionable_error():
     with pytest.raises(ValueError) as exc:
         _raise_if_qk_norm_version_gap("gemma4", _TESTER_MSG, ValueError("orig"))
     msg = str(exc.value)
-    assert "mlx-lm" in msg and "0.31.3" in msg and "gemma4" in msg
+    assert "mlx-lm" in msg and "q_norm" in msg and "gemma4" in msg
+    assert "unsloth-zoo" in msg and "mlx-vlm" in msg and "mlx-audio" in msg
+    assert "Studio users should rerun installer/repair" in msg
+    assert "strict=False" in msg
+    assert "0.31.3 broke" not in msg and "!=0.31.3" not in msg
 
 
 def test_qwen3_5_q_norm_also_caught():
@@ -129,5 +133,6 @@ def test_vlm_retry_qk_norm_mismatch_raises_actionable_error():
     with pytest.raises(ValueError) as exc:
         _load_mlx_vlm_with_extra_weight_filter("some/model", "gemma4", fake_vlm_load, {}, hf_token=None)
     msg = str(exc.value)
-    assert "mlx-lm" in msg and "0.31.3" in msg and "gemma4" in msg
+    assert "mlx-lm" in msg and "q_norm" in msg and "gemma4" in msg
+    assert "unsloth-zoo" in msg and "mlx-audio" in msg and "!=0.31.3" not in msg
     assert calls["n"] == 2  # it must have entered the filtered retry

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -139,33 +139,93 @@ def test_vlm_retry_qk_norm_mismatch_raises_actionable_error():
 
 
 def test_vlm_retry_filters_only_owned_shared_kv(monkeypatch):
-    import re, threading, types; import mlx.nn as nn; import unsloth_zoo.mlx.loader as loader
+    import threading, types
 
-    def unused(self, key): layer = int(key.removeprefix("language_model.model.layers.").split(".", 1)[0]); return layer < len(self.model.layers) and self.model.layers[layer].self_attn.is_kv_shared_layer
-    LanguageModel = type("LanguageModel", (), {"__module__": "mlx_vlm.models.gemma4.language", "_is_unused_shared_kv_weight": unused})
-    language = LanguageModel(); language.model = types.SimpleNamespace(layers=[types.SimpleNamespace(self_attn=types.SimpleNamespace(is_kv_shared_layer=False)), types.SimpleNamespace(self_attn=types.SimpleNamespace(is_kv_shared_layer=True))]); model = types.SimpleNamespace(language_model=language)
-    assert loader._GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256 == "e859b50eb966089f8966a38ca2e69c3b68ccf48c5b4a264fbc01f415be60003f"; fingerprint = loader._source_token_sha256(loader._safe_getsource(unused)); monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", fingerprint)
-    known = [f"language_model.model.layers.1.self_attn.{name}" for name in ("k_norm.weight", "k_proj.scales", "v_proj.biases")]; assert all(loader._gemma4_unused_shared_kv_weight(model, key) for key in known)
-    bad = ("language_model.model.layers.-1.self_attn.k_proj.weight", "language_model.model.layers.01.self_attn.k_proj.weight", "language_model.model.layers.0.self_attn.k_proj.weight", "language_model.model.layers.2.self_attn.k_proj.weight", "language_model.model.layers.1.self_attn.q_proj.weight", "language_model.model.layers.1.self_attn.k_proj.garbage", f"language_model.model.layers.{'9' * 5000}.self_attn.k_proj.weight"); assert not any(loader._gemma4_unused_shared_kv_weight(model, key) for key in bad)
-    monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", "unknown"); assert not loader._gemma4_unused_shared_kv_weight(model, known[0]); monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", fingerprint); LanguageModel.__name__ = "Other"; assert not loader._gemma4_unused_shared_kv_weight(model, known[0]); LanguageModel.__name__, LanguageModel.__module__ = "LanguageModel", "foreign"; assert not loader._gemma4_unused_shared_kv_weight(model, known[0]); LanguageModel.__module__ = "mlx_vlm.models.gemma4.language"; Inherited = type("LanguageModel", (LanguageModel,), {"__module__": LanguageModel.__module__}); inherited = Inherited(); inherited.model = language.model; assert not loader._gemma4_unused_shared_kv_weight(types.SimpleNamespace(language_model=inherited), known[0])
-    initial = "Received parameters not in model: language_model.model.layers.1.self_attn.k_norm.weight, language_model.model.layers.1.self_attn.k_proj.weight, language_model.model.layers.1.self_attn.v_proj.weight"
-    state, seen, foreign = {"attempt": 0, "weights": [(key, object()) for key in known], "concurrent": True}, [], []
-    def strict_load(_self, weights, strict=True): seen.append(([key for key, _ in weights], strict)); return (_ for _ in ()).throw(ValueError("Received parameters not in model: " + ", ".join(key for key, _ in weights))) if weights else "loaded"
+    import mlx.nn as nn
+    import unsloth_zoo.mlx.loader as loader
+
+    def unused(self, key):
+        layer = int(key.removeprefix("language_model.model.layers.").split(".", 1)[0])
+        return layer < len(self.model.layers) and self.model.layers[layer].self_attn.is_kv_shared_layer
+
+    class LanguageModel:
+        __module__ = "mlx_vlm.models.gemma4.language"
+        _is_unused_shared_kv_weight = unused
+
+    language = LanguageModel()
+    language.model = types.SimpleNamespace(
+        layers=[types.SimpleNamespace(
+            self_attn=types.SimpleNamespace(is_kv_shared_layer=value)
+        ) for value in (False, True)]
+    )
+    model = types.SimpleNamespace(language_model=language)
+    expected_hash = "e859b50eb966089f8966a38ca2e69c3b68ccf48c5b4a264fbc01f415be60003f"
+    assert loader._GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256 == expected_hash
+    fingerprint = loader._source_token_sha256(loader._safe_getsource(unused))
+    monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", fingerprint)
+    prefix = "language_model.model.layers."
+    known = [f"{prefix}1.self_attn.{name}" for name in ("k_norm.weight", "k_proj.scales", "v_proj.biases")]
+    assert all(loader._gemma4_unused_shared_kv_weight(model, key) for key in known)
+    bad = tuple(f"{prefix}{suffix}" for suffix in (
+        "-1.self_attn.k_proj.weight", "01.self_attn.k_proj.weight",
+        "1.self_attn.q_proj.weight", "1.self_attn.k_proj.garbage",
+    ))
+    assert not any(loader._gemma4_unused_shared_kv_weight(model, key) for key in bad)
+
+    monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", "unknown")
+    assert not loader._gemma4_unused_shared_kv_weight(model, known[0])
+    monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", fingerprint)
+    LanguageModel.__name__ = "Other"
+    assert not loader._gemma4_unused_shared_kv_weight(model, known[0])
+    LanguageModel.__name__, LanguageModel.__module__ = "LanguageModel", "foreign"
+    assert not loader._gemma4_unused_shared_kv_weight(model, known[0])
+    LanguageModel.__module__ = "mlx_vlm.models.gemma4.language"
+    Inherited = type("LanguageModel", (LanguageModel,), {"__module__": LanguageModel.__module__})
+    inherited = Inherited()
+    inherited.model = language.model
+    assert not loader._gemma4_unused_shared_kv_weight(
+        types.SimpleNamespace(language_model=inherited), known[0]
+    )
+
+    initial = "Received parameters not in model: " + ", ".join(known)
+    state = {"attempt": 0, "weights": [(key, object()) for key in known], "concurrent": True}
+    seen, foreign = [], []
+
+    def strict_load(_self, weights, strict=True):
+        keys = [key for key, _ in weights]
+        seen.append((keys, strict))
+        if weights:
+            raise ValueError("Received parameters not in model: " + ", ".join(keys))
+        return "loaded"
+
     def foreign_load():
-        try: nn.Module.load_weights(model, state["weights"])
-        except ValueError as error: foreign.append(str(error))
+        try:
+            nn.Module.load_weights(model, state["weights"])
+        except ValueError as error:
+            foreign.append(str(error))
+
     def vlm_load(_model_name, **_kwargs):
         state["attempt"] += 1
-        if state["attempt"] == 1: raise ValueError(initial)
-        if state.pop("concurrent", False): thread = threading.Thread(target=foreign_load); thread.start(); thread.join()
+        if state["attempt"] == 1:
+            raise ValueError(initial)
+        if state.pop("concurrent", False):
+            thread = threading.Thread(target=foreign_load)
+            thread.start()
+            thread.join()
         return nn.Module.load_weights(model, state["weights"])
+
     monkeypatch.setattr(nn.Module, "load_weights", strict_load)
-    partial_calls = []; partial = lambda *_a, **_k: (partial_calls.append(1), (_ for _ in ()).throw(ValueError("parameters not in model: self_attn.k_proj")))[1]
-    with pytest.raises(ValueError, match="k_proj"): loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", partial, {})
-    assert partial_calls == [1] and nn.Module.load_weights is strict_load and loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", lambda *_a, **_k: "native", {}) == "native"
+
+    def partial(*_args, **_kwargs):
+        raise ValueError("parameters not in model: self_attn.k_proj")
+
+    with pytest.raises(ValueError, match="k_proj"):
+        loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", partial, {})
+    assert nn.Module.load_weights is strict_load
+    native = loader._load_mlx_vlm_with_extra_weight_filter(
+        "model", "gemma4", lambda *_a, **_k: "native", {})
+    assert native == "native"
     assert loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", vlm_load, {}) == "loaded"
-    assert seen == [(known, True), ([], True)] and known[0] in foreign[0] and nn.Module.load_weights is strict_load
-    for key in bad:
-        state.update(attempt=0, weights=[(key, object())])
-        with pytest.raises(ValueError, match=re.escape(key)): loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", vlm_load, {})
-        assert seen[-1] == ([key], True) and nn.Module.load_weights is strict_load
+    assert seen == [(known, True), ([], True)]
+    assert known[0] in foreign[0]
+    assert nn.Module.load_weights is strict_load

--- a/tests/test_mlx_qk_norm_version_gap.py
+++ b/tests/test_mlx_qk_norm_version_gap.py
@@ -136,3 +136,36 @@ def test_vlm_retry_qk_norm_mismatch_raises_actionable_error():
     assert "mlx-lm" in msg and "q_norm" in msg and "gemma4" in msg
     assert "unsloth-zoo" in msg and "mlx-audio" in msg and "!=0.31.3" not in msg
     assert calls["n"] == 2  # it must have entered the filtered retry
+
+
+def test_vlm_retry_filters_only_owned_shared_kv(monkeypatch):
+    import re, threading, types; import mlx.nn as nn; import unsloth_zoo.mlx.loader as loader
+
+    def unused(self, key): layer = int(key.removeprefix("language_model.model.layers.").split(".", 1)[0]); return layer < len(self.model.layers) and self.model.layers[layer].self_attn.is_kv_shared_layer
+    LanguageModel = type("LanguageModel", (), {"__module__": "mlx_vlm.models.gemma4.language", "_is_unused_shared_kv_weight": unused})
+    language = LanguageModel(); language.model = types.SimpleNamespace(layers=[types.SimpleNamespace(self_attn=types.SimpleNamespace(is_kv_shared_layer=False)), types.SimpleNamespace(self_attn=types.SimpleNamespace(is_kv_shared_layer=True))]); model = types.SimpleNamespace(language_model=language)
+    assert loader._GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256 == "e859b50eb966089f8966a38ca2e69c3b68ccf48c5b4a264fbc01f415be60003f"; fingerprint = loader._source_token_sha256(loader._safe_getsource(unused)); monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", fingerprint)
+    known = [f"language_model.model.layers.1.self_attn.{name}" for name in ("k_norm.weight", "k_proj.scales", "v_proj.biases")]; assert all(loader._gemma4_unused_shared_kv_weight(model, key) for key in known)
+    bad = ("language_model.model.layers.-1.self_attn.k_proj.weight", "language_model.model.layers.01.self_attn.k_proj.weight", "language_model.model.layers.0.self_attn.k_proj.weight", "language_model.model.layers.2.self_attn.k_proj.weight", "language_model.model.layers.1.self_attn.q_proj.weight", "language_model.model.layers.1.self_attn.k_proj.garbage", f"language_model.model.layers.{'9' * 5000}.self_attn.k_proj.weight"); assert not any(loader._gemma4_unused_shared_kv_weight(model, key) for key in bad)
+    monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", "unknown"); assert not loader._gemma4_unused_shared_kv_weight(model, known[0]); monkeypatch.setattr(loader, "_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256", fingerprint); LanguageModel.__name__ = "Other"; assert not loader._gemma4_unused_shared_kv_weight(model, known[0]); LanguageModel.__name__, LanguageModel.__module__ = "LanguageModel", "foreign"; assert not loader._gemma4_unused_shared_kv_weight(model, known[0]); LanguageModel.__module__ = "mlx_vlm.models.gemma4.language"; Inherited = type("LanguageModel", (LanguageModel,), {"__module__": LanguageModel.__module__}); inherited = Inherited(); inherited.model = language.model; assert not loader._gemma4_unused_shared_kv_weight(types.SimpleNamespace(language_model=inherited), known[0])
+    initial = "Received parameters not in model: language_model.model.layers.1.self_attn.k_norm.weight, language_model.model.layers.1.self_attn.k_proj.weight, language_model.model.layers.1.self_attn.v_proj.weight"
+    state, seen, foreign = {"attempt": 0, "weights": [(key, object()) for key in known], "concurrent": True}, [], []
+    def strict_load(_self, weights, strict=True): seen.append(([key for key, _ in weights], strict)); return (_ for _ in ()).throw(ValueError("Received parameters not in model: " + ", ".join(key for key, _ in weights))) if weights else "loaded"
+    def foreign_load():
+        try: nn.Module.load_weights(model, state["weights"])
+        except ValueError as error: foreign.append(str(error))
+    def vlm_load(_model_name, **_kwargs):
+        state["attempt"] += 1
+        if state["attempt"] == 1: raise ValueError(initial)
+        if state.pop("concurrent", False): thread = threading.Thread(target=foreign_load); thread.start(); thread.join()
+        return nn.Module.load_weights(model, state["weights"])
+    monkeypatch.setattr(nn.Module, "load_weights", strict_load)
+    partial_calls = []; partial = lambda *_a, **_k: (partial_calls.append(1), (_ for _ in ()).throw(ValueError("parameters not in model: self_attn.k_proj")))[1]
+    with pytest.raises(ValueError, match="k_proj"): loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", partial, {})
+    assert partial_calls == [1] and nn.Module.load_weights is strict_load and loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", lambda *_a, **_k: "native", {}) == "native"
+    assert loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", vlm_load, {}) == "loaded"
+    assert seen == [(known, True), ([], True)] and known[0] in foreign[0] and nn.Module.load_weights is strict_load
+    for key in bad:
+        state.update(attempt=0, weights=[(key, object())])
+        with pytest.raises(ValueError, match=re.escape(key)): loader._load_mlx_vlm_with_extra_weight_filter("model", "gemma4", vlm_load, {})
+        assert seen[-1] == ([key], True) and nn.Module.load_weights is strict_load

--- a/tests/test_mlx_qwen3_prompt_batch_isolated.py
+++ b/tests/test_mlx_qwen3_prompt_batch_isolated.py
@@ -36,7 +36,15 @@ _SCRIPT = textwrap.dedent(
         import mlx.core as mx
         import unsloth_zoo.mlx.compile as mc
         ar = importlib.import_module("mlx_vlm.generate.ar")
-    except Exception as error:
+    except ImportError as error:
+        # Only an absent optional dependency is a skip. An import-time
+        # regression in the modules under test must fail the subprocess, or
+        # this regression test reports success for the very break it exists
+        # to catch.
+        if (getattr(error, "name", "") or "").split(".")[0] not in (
+            "mlx", "mlx_lm", "mlx_vlm",
+        ):
+            raise
         print("SKIP", type(error).__name__, error)
         raise SystemExit(0)
 
@@ -137,3 +145,31 @@ def test_qwen3_mixed_prompt_batch_survives_a_three_row_unequal_batch():
     assert "QWEN3_MIXED_PROMPT_BATCH_OK" in result.stdout, (
         f"stdout={result.stdout}\n---\nstderr={result.stderr}"
     )
+
+
+def test_import_regressions_fail_instead_of_reporting_a_skip(tmp_path):
+    """Only an absent optional dependency may skip the isolated run.
+
+    A blanket ``except Exception`` around the imports turns any import-time
+    break in the modules under test into a successful skip, so the regression
+    test above would report success for exactly the failure it exists to catch.
+    """
+    import os
+
+    shim = tmp_path / "shim"
+    (shim / "mlx").mkdir(parents=True)
+    (shim / "mlx" / "__init__.py").write_text("")
+    (shim / "mlx" / "core.py").write_text(
+        "raise RuntimeError('simulated import-time regression')\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(shim), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    result = subprocess.run(
+        [sys.executable, "-c", _SCRIPT],
+        capture_output=True, text=True, env=env,
+    )
+    assert result.returncode != 0, f"stdout={result.stdout}"
+    assert "SKIP" not in result.stdout, result.stdout
+    assert "simulated import-time regression" in result.stderr, result.stderr

--- a/tests/test_mlx_qwen3_prompt_batch_isolated.py
+++ b/tests/test_mlx_qwen3_prompt_batch_isolated.py
@@ -1,0 +1,136 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression: a mixed Qwen3 prompt batch keeps one visual row per input row.
+
+Runs in a subprocess on purpose. Sibling MLX test modules install the
+tests/mlx_simulation torch shim over `mlx.core` AND `mlx_vlm` for the rest of
+the session, so an in-process version of this check can only skip once any of
+them has run -- which is exactly what happens in the full suite. A subprocess
+gets the real mlx-vlm merger every time, whatever ran before.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+_SCRIPT = textwrap.dedent(
+    """
+    import importlib, sys
+
+    try:
+        import mlx.core as mx
+        import unsloth_zoo.mlx.compile as mc
+        ar = importlib.import_module("mlx_vlm.generate.ar")
+    except Exception as error:
+        print("SKIP", type(error).__name__, error)
+        raise SystemExit(0)
+
+    if "mlx_simulation" in str(getattr(mx, "__file__", "")):
+        print("SKIP simulation stub leaked into the subprocess")
+        raise SystemExit(0)
+    merge = getattr(ar, "_merge_prefill_prompt_kwargs", None)
+    if merge is None:
+        print("SKIP mlx-vlm without _merge_prefill_prompt_kwargs")
+        raise SystemExit(0)
+    merge = getattr(merge, "__wrapped__", merge)
+
+    def visual_row(length, positions, base):
+        flags = [False] * length
+        for position in positions:
+            flags[position] = True
+        masks = mx.array([flags], dtype=mx.bool_)
+        embeds = [mx.array([[float(base + i)] for i in range(len(positions))])]
+        state, packed = mc._pack_qwen3_visual_state(masks, embeds)
+        return {
+            "inputs_embeds": mx.zeros((1, length, 4)),
+            "visual_pos_masks": masks,
+            mc._QWEN3_VISUAL_STATE_KEY: state,
+            mc._QWEN3_VISUAL_POSITIONS_KEY: packed,
+        }
+
+    # Three rows of UNEQUAL length so mlx-vlm really left-pads, and a text-only
+    # row first so a dropped row shifts every visual row onto the wrong entry.
+    rows = [
+        {"inputs_embeds": mx.zeros((1, 4, 4))},
+        visual_row(7, [2, 3], 10),
+        visual_row(6, [1, 2, 4], 20),
+    ]
+    input_ids = [[0] * 4, [0] * 7, [0] * 6]
+
+    embeds, merged = merge(mc._pad_qwen3_prompt_rows(rows), input_ids)
+
+    for key in ("visual_pos_masks",
+                mc._QWEN3_VISUAL_STATE_KEY,
+                mc._QWEN3_VISUAL_POSITIONS_KEY):
+        assert key in merged, f"{key} dropped out of the merged batch"
+        assert merged[key].shape[0] == 3, (
+            f"{key} came back with {merged[key].shape[0]} of 3 rows"
+        )
+    assert embeds.shape[:2] == merged["visual_pos_masks"].shape, (
+        f"mask {merged['visual_pos_masks'].shape} does not match embeds {embeds.shape}"
+    )
+
+    # Left padding shifts each short row's mask; positions stay in unpadded
+    # coordinates, which is what the cache offsets are measured against.
+    mask_rows = merged["visual_pos_masks"].tolist()
+    true_at = [[i for i, flag in enumerate(row) if flag] for row in mask_rows]
+    assert true_at == [[], [2, 3], [2, 3, 5]], true_at
+    assert merged[mc._QWEN3_VISUAL_POSITIONS_KEY].tolist() == [
+        [-1, -1, -1], [2, 3, -1], [1, 2, 4]
+    ]
+
+    # Rebuild the window and scatter, exactly as the language call does.
+    window_mask, layers = mc._qwen3_visual_window(
+        merged["visual_pos_masks"],
+        merged[mc._QWEN3_VISUAL_STATE_KEY],
+        merged[mc._QWEN3_VISUAL_POSITIONS_KEY],
+        mask_offsets=(0, 0, 0),
+        window=int(embeds.shape[1]),
+    )
+    assert int(window_mask.sum().item()) == layers[0].shape[0], (
+        f"{int(window_mask.sum().item())} masked tokens vs {layers[0].shape[0]} features"
+    )
+    scattered = mc._add_visual_embeds(
+        mx.zeros((window_mask.shape[0], window_mask.shape[1], 1)),
+        window_mask,
+        layers[0],
+    ).reshape(window_mask.shape).tolist()
+    assert scattered == [
+        [0.0] * 7,
+        [0.0, 0.0, 10.0, 11.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 20.0, 21.0, 0.0, 22.0, 0.0],
+    ], scattered
+
+    print("QWEN3_MIXED_PROMPT_BATCH_OK")
+    """
+)
+
+
+def test_qwen3_mixed_prompt_batch_survives_a_three_row_unequal_batch():
+    result = subprocess.run(
+        [sys.executable, "-c", _SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    if "SKIP" in result.stdout:
+        import pytest
+
+        pytest.skip(result.stdout.strip())
+    assert "QWEN3_MIXED_PROMPT_BATCH_OK" in result.stdout, (
+        f"stdout={result.stdout}\n---\nstderr={result.stderr}"
+    )

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -357,6 +357,50 @@ def test_tokenizer_wrapper_chat_template_return_dict_expands_for_generate():
     assert tokenizer("hi") == {"called": True}
 
 
+def test_vlm_prompt_patch_preserves_model_specific_media_markers(monkeypatch):
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    marker, state = "<|image_1|>Describe it.", {"result": None}
+    def original(*_args, **_kwargs):
+        if isinstance(state["result"], Exception):
+            raise state["result"]
+        return marker if state["result"] is None else state["result"]
+    monkeypatch.setattr(prompt_utils, "apply_chat_template", original, raising=False)
+    monkeypatch.setattr(prompt_utils, "_get_role_content", lambda item: (item["role"], item["content"]), raising=False)
+    monkeypatch.setattr(prompt_utils, "get_chat_template", lambda *_a, **_k: "fallback", raising=False)
+    monkeypatch.setattr(prompt_utils, "MODEL_CONFIG", {"phi3_v": object()}, raising=False)
+    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
+    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
+    for name in ("mlx_vlm.chat", "mlx_vlm.generate", "mlx_vlm.generate.dispatch", "mlx_vlm.generate.ar", "mlx_vlm.server", "mlx_vlm.evals.utils"):
+        if name in sys.modules:
+            monkeypatch.setattr(sys.modules[name], "apply_chat_template", original, raising=False)
+    loader._ensure_vlm_prompt_utils_patched()
+    messages = [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "Describe it."}]}]
+    render = lambda value, model_type="phi3_v", **kwargs: prompt_utils.apply_chat_template(object(), {"model_type": model_type}, value, **kwargs)
+
+    assert render(messages, num_images=1) == marker
+    assert render([{"role": "system", "content": "Be concise."}] + messages, num_images=1) == marker
+    assert render([{"role": "user", "content": [{"type": "audio"}]}], num_audios=1) == marker
+    assert render([{"role": "user", "content": [{"type": "audio"}]}], num_audios=2) == "fallback"
+    assert render(messages, num_images=2) == "fallback"
+    assert render(messages, model_type="unknown", num_images=1) == "fallback"
+    assert render(messages + [{"role": "user", "content": "Again."}], num_images=1) == "fallback"
+    nested = [{"role": "user", "content": [{"type": "group", "content": messages[0]["content"]}]}]
+    assert render(nested, num_images=1) == "fallback"
+    nested_text = [{"type": "group", "content": [{"type": "text", "text": "Policy"}]}]
+    assert render([{"role": "system", "content": nested_text}] + messages, num_images=1) == "fallback"
+    assert render([{"role": "User", "content": messages[0]["content"]}], num_images=1) == "fallback"
+    assert render([{**messages[0], "tool_calls": []}], num_images=1) == "fallback"
+    assert render([{"role": "user", "content": [{"type": "IMAGE"}, {"type": "TEXT", "text": "Describe it."}]}], num_images=1) == "fallback"
+    for video_type in ("video", "input_video", "video_url"):
+        assert render([{"role": "user", "content": [{"type": video_type}]}]) == "fallback"
+    assert render(messages, num_images=1, video="clip.mp4") == "fallback"
+    assert render(messages, num_images=1, return_messages=True) == messages
+    for state["result"] in ("", ValueError("rejected")):
+        assert render(messages, num_images=1) == "fallback"
+
+
 def test_vlm_generate_hf_kwargs(monkeypatch):
     import torch
     from transformers.tokenization_utils_base import to_py_obj

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -52,6 +52,8 @@ def _test_make_streaming_detokenizer(processor):
 def _test_naive_detokenizer_init(self, tokenizer):
     self._tokenizer, self._tokens = tokenizer, []
 def _test_naive_detokenizer_reset(self): self._tokens = []
+def _test_lfm_projector_init(self, config): self.projector_use_layernorm, self.layer_norm = config.projector_use_layernorm, lambda x: ("normalized", x)
+def _test_lfm_projector_call(self, x): return self.layer_norm(x) if self.projector_use_layernorm else x
 def _test_minicpmo_legacy_vision(self, pixel_values, tgt_sizes):
     dtype = self.language_model.model.embed_tokens.weight.dtype
     return _to_mx_array(pixel_values, dtype=dtype)
@@ -935,6 +937,26 @@ def test_legacy_naive_detokenizer_copy_is_capability_gated(monkeypatch):
     loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
     fixed = NaiveStreamingDetokenizer(tokenizer)
     assert "__copy__" not in NaiveStreamingDetokenizer.__dict__ and copy(fixed) is fixed
+
+
+def test_lfm_disabled_projector_norm_is_loader_gated(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+
+    module_name = "mlx_vlm.models.lfm2_vl.lfm2_vl"
+    Projector = type("Lfm2VlMultiModalProjector", (), {"__module__": module_name, "__init__": _test_lfm_projector_init, "__call__": _test_lfm_projector_call})
+    module = types.ModuleType(module_name); module.Lfm2VlMultiModalProjector = Projector
+    monkeypatch.setitem(sys.modules, module_name, module)
+    init_hash = loader._source_token_sha256(loader._safe_getsource(_test_lfm_projector_init)); call_hash = loader._source_token_sha256(loader._safe_getsource(_test_lfm_projector_call))
+    original = Projector.__init__
+    for init_token, call_token, class_name in (("unknown", call_hash, Projector.__name__), (init_hash, "unknown", Projector.__name__), (init_hash, call_hash, "OtherProjector")):
+        monkeypatch.setattr(loader, "_LFM2_PROJECTOR_INIT_TOKEN_SHA256", init_token); monkeypatch.setattr(loader, "_LFM2_PROJECTOR_CALL_TOKEN_SHA256", call_token); Projector.__name__ = class_name
+        loader._bind_mlx_vlm_quantized_projector_loader(lambda: None, model_type="lfm2_vl"); assert Projector.__init__ is original
+    Projector.__name__ = "Lfm2VlMultiModalProjector"; monkeypatch.setattr(loader, "_LFM2_PROJECTOR_INIT_TOKEN_SHA256", init_hash); monkeypatch.setattr(loader, "_LFM2_PROJECTOR_CALL_TOKEN_SHA256", call_hash)
+    loader._bind_mlx_vlm_quantized_projector_loader(lambda: None, model_type="lfm2_vl")
+    disabled, enabled = Projector(types.SimpleNamespace(projector_use_layernorm=False)), Projector(types.SimpleNamespace(projector_use_layernorm=True))
+    assert not hasattr(disabled, "layer_norm") and enabled("x") == ("normalized", "x")
+    installed = Projector.__init__; loader._bind_mlx_vlm_quantized_projector_loader(lambda: None, model_type="lfm2_vl")
+    assert Projector.__init__ is installed
 
 
 def test_declared_mlx_vlm_processor_owns_custom_components_and_recovery(

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -460,9 +460,6 @@ def test_vlm_prompt_patch_preserves_model_specific_media_markers(monkeypatch):
     messages = [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "Describe it."}]}]
     render = lambda value, model_type="phi3_v", **kwargs: prompt_utils.apply_chat_template(object(), {"model_type": model_type}, value, **kwargs)
 
-    assert render(messages, num_images=1) == marker
-    assert render([{"role": "system", "content": "Be concise."}] + messages, num_images=1) == marker
-    assert render([{"role": "user", "content": [{"type": "audio"}]}], num_audios=1) == marker
     assert render([{"role": "user", "content": [{"type": "audio"}]}], num_audios=2) == "fallback"
     assert render(messages, num_images=2) == "fallback"
     assert render(messages, model_type="unknown", num_images=1) == "fallback"
@@ -472,7 +469,12 @@ def test_vlm_prompt_patch_preserves_model_specific_media_markers(monkeypatch):
     nested_text = [{"type": "group", "content": [{"type": "text", "text": "Policy"}]}]
     assert render([{"role": "system", "content": nested_text}] + messages, num_images=1) == "fallback"
     assert render([{"role": "User", "content": messages[0]["content"]}], num_images=1) == "fallback"
-    assert render([{**messages[0], "tool_calls": []}], num_images=1) == "fallback"
+    tool_calls = [{"function": {"name": "inspect", "arguments": '{"detail":"full"}'}}]
+    normalized_calls = [{"function": {"name": "inspect", "arguments": {"detail": "full"}}}]
+    monkeypatch.setattr(prompt_utils, "_normalize_tool_call_arguments", lambda message: {**message, **({"tool_calls": normalized_calls} if "tool_calls" in message else {})}, raising=False)
+    tool_messages = [{**messages[0], "tool_calls": tool_calls}]
+    assert render(tool_messages, num_images=1, return_messages=True) == [{**messages[0], "tool_calls": normalized_calls}]
+    assert tool_messages[0]["tool_calls"] == tool_calls
     assert render([{"role": "user", "content": [{"type": "IMAGE"}, {"type": "TEXT", "text": "Describe it."}]}], num_images=1) == "fallback"
     for video_type in ("video", "input_video", "video_url"):
         assert render([{"role": "user", "content": [{"type": video_type}]}]) == "fallback"
@@ -480,6 +482,11 @@ def test_vlm_prompt_patch_preserves_model_specific_media_markers(monkeypatch):
     assert render(messages, num_images=1, return_messages=True) == messages
     for state["result"] in ("", ValueError("rejected")):
         assert render(messages, num_images=1) == "fallback"
+    monkeypatch.setattr(prompt_utils, "extract_text_from_content", lambda content: content, raising=False)
+    monkeypatch.setattr(prompt_utils, "get_message_json", lambda *_args, **_kwargs: "anchored", raising=False)
+    string_messages = ["Plain.", {"role": "user", "content": "Plain dict."}, {"role": "user", "content": "Describe.", "name": "owner"}, {"role": "assistant", "content": "", "tool_calls": tool_calls}]
+    expected = ["anchored", "anchored", {**string_messages[2], "content": "anchored"}, {**string_messages[3], "content": "anchored", "tool_calls": normalized_calls}]
+    assert render(string_messages, num_images=1, return_messages=True) == expected
 
 
 def test_vlm_generate_hf_kwargs(monkeypatch):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -32,6 +32,7 @@ import pytest
 
 AutoProcessor = None
 load_processor = None
+load_model = skip_multimodal_module = nn = _has_quantized_weights = None
 
 
 def _test_bound_load_processor(model_path, **kwargs):
@@ -40,6 +41,47 @@ def _test_bound_load_processor(model_path, **kwargs):
 
 def _test_bound_vlm_load(model_path):
     return load_processor(model_path)
+
+
+def _test_bound_model_load(paths, weights):
+    return load_model(paths, weights)
+def _test_legacy_model_load(paths, weights):
+    config, skip_vision = {"quantization": {"multi_modal_projector.dense": True}}, True
+    def get_class_predicate(p, m):
+        if skip_multimodal_module(p) and skip_vision:
+            return False
+        if p in config["quantization"]:
+            return config["quantization"][p]
+        if not hasattr(m, "to_quantized"):
+            return False
+        if hasattr(m, "weight") and m.weight.size % 64 != 0:
+            return False
+        return f"{p}.scales" in weights
+    return nn.quantize(paths, class_predicate=get_class_predicate)
+
+
+def _test_fixed_model_load(paths, weights):
+    skip_vision = True
+    def get_class_predicate(p, m):
+        if skip_multimodal_module(p) and skip_vision and not _has_quantized_weights(p, weights):
+            return False
+        return f"{p}.scales" in weights
+    return nn.quantize(paths, class_predicate=get_class_predicate)
+
+
+def _test_positional_model_load(paths, weights):
+    config, skip_vision = {"quantization": {}}, True
+    def get_class_predicate(p, m):
+        if skip_multimodal_module(p) and skip_vision:
+            return False
+        if p in config["quantization"]:
+            return config["quantization"][p]
+        if not hasattr(m, "to_quantized"):
+            return False
+        if hasattr(m, "weight") and m.weight.size % 64 != 0:
+            return False
+        return f"{p}.scales" in weights
+    return nn.quantize(paths, get_class_predicate)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -931,6 +973,30 @@ def test_declared_mlx_vlm_processor_owns_custom_components_and_recovery(
         ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, True),
     ]
     assert load_processor is _test_bound_load_processor
+
+
+def test_legacy_quantized_projector_binding_is_scoped_and_capability_gated(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+    paths = ["multi_modal_projector.quantized", "multi_modal_projector.dense", "vision_model.quantized", "language_model.quantized"]
+    weights = {f"{path}.scales": object() for path in paths if "dense" not in path}
+    def skip(path): return "multi_modal_projector" in path or "vision_model" in path
+    monkeypatch.setitem(globals(), "nn", types.SimpleNamespace(quantize=lambda values, class_predicate: [class_predicate(path, types.SimpleNamespace(to_quantized=True, weight=types.SimpleNamespace(size=64))) for path in values]))
+    monkeypatch.setitem(globals(), "skip_multimodal_module", skip)
+    monkeypatch.setitem(globals(), "load_model", _test_legacy_model_load)
+    assert _test_bound_model_load(paths, weights) == [False, False, False, True]
+    scoped = loader._bind_mlx_vlm_quantized_projector_loader(_test_bound_model_load)
+    assert scoped(paths, weights) == [True, False, False, True]
+    assert load_model is _test_legacy_model_load and skip_multimodal_module is skip
+    monkeypatch.setitem(globals(), "_has_quantized_weights", lambda path, state: f"{path}.scales" in state)
+    monkeypatch.setitem(globals(), "load_model", _test_fixed_model_load)
+    assert loader._bind_mlx_vlm_quantized_projector_loader(_test_bound_model_load) is _test_bound_model_load
+    monkeypatch.setitem(globals(), "load_model", _test_positional_model_load)
+    assert loader._bind_mlx_vlm_quantized_projector_loader(_test_bound_model_load) is _test_bound_model_load
+    monkeypatch.setitem(globals(), "load_model", _test_legacy_model_load)
+    monkeypatch.setitem(globals(), "AutoProcessor", types.SimpleNamespace(from_pretrained=lambda *_a, **_k: "processor"))
+    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
+    processor_bound = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    assert loader._bind_mlx_vlm_quantized_projector_loader(processor_bound)("model") == "processor"
 
 
 def test_llava_processor_geometry_uses_temporary_config_view(tmp_path):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -31,9 +31,7 @@ from pathlib import Path
 import pytest
 
 
-AutoProcessor = None
-load_processor = None
-load_model = skip_multimodal_module = nn = _has_quantized_weights = None
+AutoProcessor = load_model = load_processor = nn = skip_multimodal_module = None
 _to_mx_array = None
 
 
@@ -41,62 +39,76 @@ def _test_bound_load_processor(model_path, **kwargs):
     return AutoProcessor.from_pretrained(model_path, **kwargs)
 
 
-def _test_bound_vlm_load(model_path):
-    return load_processor(model_path)
-
-
-def _test_bound_model_load(paths, weights):
+def _test_bound_load_model(paths, weights):
     return load_model(paths, weights)
+
+
+def _test_bound_vlm_load(model_path, paths=None, weights=None, **kwargs):
+    if paths is not None:
+        load_model(paths, weights)
+    return load_processor(model_path, **kwargs)
+
+
 def _test_make_streaming_detokenizer(processor):
-    detokenizer = copy(processor.detokenizer); detokenizer.reset(); return detokenizer
+    detokenizer = copy(processor.detokenizer)
+    detokenizer.reset()
+    return detokenizer
+
+
 def _test_naive_detokenizer_init(self, tokenizer):
     self._tokenizer, self._tokens = tokenizer, []
-def _test_naive_detokenizer_reset(self): self._tokens = []
-def _test_lfm_projector_init(self, config): self.projector_use_layernorm, self.layer_norm = config.projector_use_layernorm, lambda x: ("normalized", x)
-def _test_lfm_projector_call(self, x): return self.layer_norm(x) if self.projector_use_layernorm else x
+
+
+def _test_naive_detokenizer_reset(self):
+    self._tokens = []
+
+
+def _test_legacy_projector_load(paths, weights):
+    skip_vision = True
+    config = {"quantization": {}}
+
+    def get_class_predicate(p, m):
+        if skip_multimodal_module(p) and skip_vision:
+            return False
+        if p in config["quantization"]:
+            return config["quantization"][p]
+        if not hasattr(m, "to_quantized"):
+            return False
+        if hasattr(m, "weight") and m.weight.size % 64 != 0:
+            return False
+        return f"{p}.scales" in weights
+
+    return nn.quantize(paths, class_predicate=get_class_predicate)
+
+
+def _test_aware_projector_load(paths, weights):
+    skip_vision = True
+
+    def get_class_predicate(path, module):
+        if skip_multimodal_module(path) and skip_vision and f"{path}.scales" not in weights:
+            return False
+        return f"{path}.scales" in weights
+
+    return nn.quantize(paths, class_predicate=get_class_predicate)
+
+
+def _test_lfm_projector_init(self, config):
+    self.projector_use_layernorm = config.projector_use_layernorm
+    self.layer_norm = lambda x: ("normalized", x)
+
+
+def _test_lfm_projector_call(self, x):
+    return self.layer_norm(x) if self.projector_use_layernorm else x
+
+
 def _test_minicpmo_legacy_vision(self, pixel_values, tgt_sizes):
     dtype = self.language_model.model.embed_tokens.weight.dtype
     return _to_mx_array(pixel_values, dtype=dtype)
+
+
 def _test_minicpmo_fixed_vision(self, pixel_values, tgt_sizes):
     dtype = self.vision_tower.embeddings.patch_embedding.weight.dtype
     return _to_mx_array(pixel_values, dtype=dtype)
-def _test_legacy_model_load(paths, weights):
-    config, skip_vision = {"quantization": {"multi_modal_projector.dense": True}}, True
-    def get_class_predicate(p, m):
-        if skip_multimodal_module(p) and skip_vision:
-            return False
-        if p in config["quantization"]:
-            return config["quantization"][p]
-        if not hasattr(m, "to_quantized"):
-            return False
-        if hasattr(m, "weight") and m.weight.size % 64 != 0:
-            return False
-        return f"{p}.scales" in weights
-    return nn.quantize(paths, class_predicate=get_class_predicate)
-
-
-def _test_fixed_model_load(paths, weights):
-    skip_vision = True
-    def get_class_predicate(p, m):
-        if skip_multimodal_module(p) and skip_vision and not _has_quantized_weights(p, weights):
-            return False
-        return f"{p}.scales" in weights
-    return nn.quantize(paths, class_predicate=get_class_predicate)
-
-
-def _test_positional_model_load(paths, weights):
-    config, skip_vision = {"quantization": {}}, True
-    def get_class_predicate(p, m):
-        if skip_multimodal_module(p) and skip_vision:
-            return False
-        if p in config["quantization"]:
-            return config["quantization"][p]
-        if not hasattr(m, "to_quantized"):
-            return False
-        if hasattr(m, "weight") and m.weight.size % 64 != 0:
-            return False
-        return f"{p}.scales" in weights
-    return nn.quantize(paths, get_class_predicate)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -910,157 +922,138 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     assert tokenizer.chat_template == "{{ messages }}"
 
 
-def test_legacy_naive_detokenizer_copy_is_capability_gated(monkeypatch):
+def test_processor_loader_is_call_scoped_and_preserves_failure_policy(
+    monkeypatch,
+    tmp_path,
+):
+    import unsloth_zoo.mlx.loader as loader
+
+    native, calls = object(), []
+
+    class FakeAutoProcessor:
+        error = ValueError("Unrecognized processing class")
+
+        @classmethod
+        def from_pretrained(cls, _path, **kwargs):
+            calls.append(kwargs["trust_remote_code"])
+            raise cls.error
+
+    monkeypatch.setitem(globals(), "AutoProcessor", FakeAutoProcessor)
+    monkeypatch.setattr(loader, "_ensure_vlm_detokenizer_copy", lambda: None)
+    monkeypatch.setattr(loader, "_load_declared_mlx_vlm_processor", lambda *_a, **_k: native)
+    (tmp_path / "config.json").write_text('{"model_type":"native"}', encoding="utf-8")
+    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
+    scoped = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    trusted = loader._bind_mlx_vlm_processor_loader(
+        _test_bound_vlm_load, allow_remote_code=True
+    )
+    assert scoped(tmp_path) is native and trusted(tmp_path) is native
+    assert calls == [False, True] and load_processor is _test_bound_load_processor
+    assert AutoProcessor is FakeAutoProcessor
+    FakeAutoProcessor.error = RuntimeError("unrelated")
+    with pytest.raises(RuntimeError, match="unrelated"):
+        scoped(tmp_path)
+
+
+def test_legacy_detokenizer_copy_is_reset_and_inherited_native_copy_wins(monkeypatch):
     import unsloth_zoo.mlx.loader as loader
 
     module_name = "mlx_vlm.tokenizer_utils"
-    StreamingDetokenizer = type("StreamingDetokenizer", (), {"__module__": module_name, "__slots__": ("text", "tokens", "offset")})
-    NaiveStreamingDetokenizer = type("NaiveStreamingDetokenizer", (StreamingDetokenizer,), {"__module__": module_name, "__init__": _test_naive_detokenizer_init, "reset": _test_naive_detokenizer_reset, "text": property(lambda self: "")})
-    module = types.ModuleType(module_name)
-    module.StreamingDetokenizer, module.NaiveStreamingDetokenizer, module.make_streaming_detokenizer = StreamingDetokenizer, NaiveStreamingDetokenizer, _test_make_streaming_detokenizer
-    monkeypatch.setitem(sys.modules, module_name, module)
-    monkeypatch.setattr(loader, "_MLX_VLM_DETOKENIZER_COPY_TOKEN_SHA256", loader._source_token_sha256(loader._safe_getsource(_test_make_streaming_detokenizer)))
+    base = type(
+        "StreamingDetokenizer",
+        (),
+        {"__module__": module_name, "__slots__": ("text", "tokens", "offset")},
+    )
+    legacy = type(
+        "NaiveStreamingDetokenizer",
+        (base,),
+        {
+            "__module__": module_name,
+            "__init__": _test_naive_detokenizer_init,
+            "reset": _test_naive_detokenizer_reset,
+            "text": property(lambda self: ""),
+        },
+    )
+    module = types.SimpleNamespace(
+        __name__=module_name,
+        StreamingDetokenizer=base,
+        NaiveStreamingDetokenizer=legacy,
+        make_streaming_detokenizer=_test_make_streaming_detokenizer,
+    )
+    monkeypatch.setattr(loader.importlib, "import_module", lambda _name: module)
+    source_hash = loader._source_token_sha256(loader._safe_getsource(_test_make_streaming_detokenizer))
+    monkeypatch.setattr(loader, "_MLX_VLM_DETOKENIZER_COPY_TOKEN_SHA256", source_hash)
+    loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    original = legacy(object())
+    original._tokens.append(1)
+    assert copy(original)._tokens == [] and original._tokens == [1]
+    del legacy.__copy__
+    base.__copy__ = lambda self: self
+    loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    inherited = legacy(object())
+    assert copy(inherited) is inherited
+    assert "__copy__" not in legacy.__dict__
 
-    tokenizer = object(); original = NaiveStreamingDetokenizer(tokenizer)
-    with pytest.raises(AttributeError, match="property 'text'"):
-        copy(original)
-    loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
-    original._tokens.append(1); copied = copy(original)
-    assert copied is not original and copied._tokenizer is tokenizer
-    assert copied._tokens == [] and original._tokens == [1]
-    installed_copy = NaiveStreamingDetokenizer.__copy__
-    loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
-    assert NaiveStreamingDetokenizer.__copy__ is installed_copy
 
-    native_copy = lambda self: self
-    del NaiveStreamingDetokenizer.__copy__; StreamingDetokenizer.__copy__ = native_copy
-    loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
-    fixed = NaiveStreamingDetokenizer(tokenizer)
-    assert "__copy__" not in NaiveStreamingDetokenizer.__dict__ and copy(fixed) is fixed
+def test_quantized_projector_binding_is_call_scoped_and_fail_closed(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+
+    paths = ["multi_modal_projector.quantized", "multi_modal_projector.dense", "vision.quantized"]
+    weights = {f"{paths[0]}.scales": object(), f"{paths[2]}.scales": object()}
+    skip = lambda path: path.startswith(("multi_modal_projector", "vision"))
+    module = types.SimpleNamespace(to_quantized=True, weight=types.SimpleNamespace(size=64))
+    quantize = lambda values, class_predicate: [class_predicate(path, module) for path in values]
+    monkeypatch.setitem(globals(), "nn", types.SimpleNamespace(quantize=quantize))
+    monkeypatch.setitem(globals(), "skip_multimodal_module", skip)
+    monkeypatch.setitem(globals(), "load_model", _test_legacy_projector_load)
+    original = _test_bound_load_model
+    scoped = loader._bind_mlx_vlm_quantized_projector_loader(original)
+    assert scoped(paths, weights) == [True, False, False]
+    assert load_model is _test_legacy_projector_load and skip_multimodal_module is skip
+    monkeypatch.setitem(globals(), "load_model", _test_aware_projector_load)
+    assert loader._bind_mlx_vlm_quantized_projector_loader(original) is original
+    monkeypatch.setitem(globals(), "load_model", _test_legacy_projector_load)
+    monkeypatch.setitem(globals(), "AutoProcessor", types.SimpleNamespace(from_pretrained=lambda *_a, **_k: "processor"))
+    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
+    processor_bound = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    assert loader._bind_mlx_vlm_quantized_projector_loader(processor_bound)(
+        "model", paths=paths, weights=weights
+    ) == "processor"
 
 
 def test_lfm_disabled_projector_norm_is_loader_gated(monkeypatch):
     import unsloth_zoo.mlx.loader as loader
 
     module_name = "mlx_vlm.models.lfm2_vl.lfm2_vl"
-    Projector = type("Lfm2VlMultiModalProjector", (), {"__module__": module_name, "__init__": _test_lfm_projector_init, "__call__": _test_lfm_projector_call})
-    module = types.ModuleType(module_name); module.Lfm2VlMultiModalProjector = Projector
-    monkeypatch.setitem(sys.modules, module_name, module)
-    init_hash = loader._source_token_sha256(loader._safe_getsource(_test_lfm_projector_init)); call_hash = loader._source_token_sha256(loader._safe_getsource(_test_lfm_projector_call))
-    original = Projector.__init__
-    for init_token, call_token, class_name in (("unknown", call_hash, Projector.__name__), (init_hash, "unknown", Projector.__name__), (init_hash, call_hash, "OtherProjector")):
-        monkeypatch.setattr(loader, "_LFM2_PROJECTOR_INIT_TOKEN_SHA256", init_token); monkeypatch.setattr(loader, "_LFM2_PROJECTOR_CALL_TOKEN_SHA256", call_token); Projector.__name__ = class_name
-        loader._bind_mlx_vlm_quantized_projector_loader(lambda: None, model_type="lfm2_vl"); assert Projector.__init__ is original
-    Projector.__name__ = "Lfm2VlMultiModalProjector"; monkeypatch.setattr(loader, "_LFM2_PROJECTOR_INIT_TOKEN_SHA256", init_hash); monkeypatch.setattr(loader, "_LFM2_PROJECTOR_CALL_TOKEN_SHA256", call_hash)
-    loader._bind_mlx_vlm_quantized_projector_loader(lambda: None, model_type="lfm2_vl")
-    disabled, enabled = Projector(types.SimpleNamespace(projector_use_layernorm=False)), Projector(types.SimpleNamespace(projector_use_layernorm=True))
-    assert not hasattr(disabled, "layer_norm") and enabled("x") == ("normalized", "x")
-    installed = Projector.__init__; loader._bind_mlx_vlm_quantized_projector_loader(lambda: None, model_type="lfm2_vl")
-    assert Projector.__init__ is installed
-
-
-def test_declared_mlx_vlm_processor_owns_custom_components_and_recovery(
-    monkeypatch,
-    tmp_path,
-):
-    import unsloth_zoo.mlx.loader as loader
-
-    class NativeImageProcessor: pass
-    factory_calls = []
-
-    class NativeProcessor:
-        __module__ = "mlx_vlm.models.molmo.processor"
-        get_possibly_dynamic_module = staticmethod(lambda name: (_ for _ in ()).throw(ValueError(f"Could not find module {name} in `transformers`")))
-        @classmethod
-        def from_pretrained(cls, model_path, **kwargs):
-            factory_calls.append((
-                loader._read_json_file(Path(model_path) / "config.json").get("auto_map"),
-                loader._read_json_file(Path(model_path) / "tokenizer_config.json").get("auto_map"),
-                kwargs.get("trust_remote_code", False),
-            ))
-            return cls(cls.get_possibly_dynamic_module("NativeImageProcessor")())
-        def __init__(self, image_processor): self.image_processor, self.chat_template, self.tokenizer = image_processor, None, types.SimpleNamespace()
-
-    native_module = types.ModuleType("mlx_vlm.models.molmo.processor")
-    native_module.NativeProcessor, native_module.NativeImageProcessor = NativeProcessor, NativeImageProcessor
-    monkeypatch.setitem(sys.modules, "mlx_vlm.models.molmo.processor", native_module)
-    (tmp_path / "config.json").write_text('{"model_type":"molmo","auto_map":{"AutoConfig":"remote.Config"}}', encoding="utf-8")
-    (tmp_path / "processor_config.json").write_text('{"processor_class":"NativeProcessor"}', encoding="utf-8")
-    (tmp_path / "tokenizer_config.json").write_text('{"auto_map":{"AutoTokenizer":"remote.Tokenizer"}}', encoding="utf-8")
-
-    processor = loader._load_declared_mlx_vlm_processor(tmp_path, "molmo")
-    assert isinstance(processor, NativeProcessor) and isinstance(processor.image_processor, NativeImageProcessor)
-    assert factory_calls[-1] == (None, None, False)
-    loader._load_declared_mlx_vlm_processor(tmp_path, "molmo", trust_remote_code=True)
-    assert factory_calls[-1] == ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, True)
-    detokenizer, stopping = object(), object(); degraded = types.SimpleNamespace(image_processor=None, chat_template="{{ messages }}", detokenizer=detokenizer, tokenizer=types.SimpleNamespace(stopping_criteria=stopping))
-    repaired = loader._repair_degraded_vlm_processor(degraded, tmp_path, "molmo")
-    assert isinstance(repaired, NativeProcessor) and repaired.chat_template == "{{ messages }}" and repaired.detokenizer is detokenizer and repaired.tokenizer.stopping_criteria is stopping
-
-    healthy = object()
-    class AutoProcessor:
-        outcome = ValueError("Unrecognized processing class")
-        calls = []
-        @classmethod
-        def from_pretrained(cls, model_path, **kwargs):
-            cls.calls.append((
-                loader._read_json_file(Path(model_path) / "config.json").get("auto_map"),
-                loader._read_json_file(Path(model_path) / "tokenizer_config.json").get("auto_map"),
-                kwargs.get("trust_remote_code"),
-            ))
-            if isinstance(cls.outcome, BaseException): raise cls.outcome
-            return cls.outcome
-
-    monkeypatch.setitem(globals(), "AutoProcessor", AutoProcessor)
-    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
-    scoped_load = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
-    recovered = scoped_load(tmp_path)
-    (tmp_path / "config.json").write_text('{"model_type":"native","auto_map":{"AutoConfig":"remote.Config"}}', encoding="utf-8")
-    AutoProcessor.outcome = healthy
-    assert _test_bound_vlm_load(tmp_path) is healthy
-    assert scoped_load(tmp_path) is healthy
-    AutoProcessor.outcome = RuntimeError("unrelated")
-    with pytest.raises(RuntimeError, match="unrelated"):
-        scoped_load(tmp_path)
-    AutoProcessor.outcome = healthy
-    trusted_load = loader._bind_mlx_vlm_processor_loader(
-        _test_bound_vlm_load,
-        allow_remote_code=True,
+    Projector = type(
+        "Lfm2VlMultiModalProjector", (), {"__module__": module_name,
+        "__init__": _test_lfm_projector_init, "__call__": _test_lfm_projector_call},
     )
-    assert trusted_load(tmp_path) is healthy
-    assert isinstance(recovered, NativeProcessor)
-    assert AutoProcessor.calls == [
-        (None, None, False),
-        ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, None),
-        ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, False),
-        ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, False),
-        ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, True),
-    ]
-    assert load_processor is _test_bound_load_processor
+    module = types.ModuleType(module_name)
+    module.Lfm2VlMultiModalProjector = Projector
+    monkeypatch.setitem(sys.modules, module_name, module)
+    init_hash = loader._source_token_sha256(loader._safe_getsource(_test_lfm_projector_init))
+    call_hash = loader._source_token_sha256(loader._safe_getsource(_test_lfm_projector_call))
+    original = Projector.__init__
+    incompatible_contracts = (
+        ("unknown", call_hash, Projector.__name__),
+        (init_hash, "unknown", Projector.__name__),
+        (init_hash, call_hash, "OtherProjector"),
+    )
+    for init_token, call_token, class_name in incompatible_contracts:
+        monkeypatch.setattr(loader, "_LFM2_PROJECTOR_INIT_TOKEN_SHA256", init_token)
+        monkeypatch.setattr(loader, "_LFM2_PROJECTOR_CALL_TOKEN_SHA256", call_token)
+        Projector.__name__ = class_name
+        loader._bind_mlx_vlm_quantized_projector_loader(lambda: None, model_type="lfm2_vl")
+        assert Projector.__init__ is original
 
-
-def test_legacy_quantized_projector_binding_is_scoped_and_capability_gated(monkeypatch):
-    import unsloth_zoo.mlx.loader as loader
-    paths = ["multi_modal_projector.quantized", "multi_modal_projector.dense", "vision_model.quantized", "language_model.quantized"]
-    weights = {f"{path}.scales": object() for path in paths if "dense" not in path}
-    def skip(path): return "multi_modal_projector" in path or "vision_model" in path
-    monkeypatch.setitem(globals(), "nn", types.SimpleNamespace(quantize=lambda values, class_predicate: [class_predicate(path, types.SimpleNamespace(to_quantized=True, weight=types.SimpleNamespace(size=64))) for path in values]))
-    monkeypatch.setitem(globals(), "skip_multimodal_module", skip)
-    monkeypatch.setitem(globals(), "load_model", _test_legacy_model_load)
-    assert _test_bound_model_load(paths, weights) == [False, False, False, True]
-    scoped = loader._bind_mlx_vlm_quantized_projector_loader(_test_bound_model_load)
-    assert scoped(paths, weights) == [True, False, False, True]
-    assert load_model is _test_legacy_model_load and skip_multimodal_module is skip
-    monkeypatch.setitem(globals(), "_has_quantized_weights", lambda path, state: f"{path}.scales" in state)
-    monkeypatch.setitem(globals(), "load_model", _test_fixed_model_load)
-    assert loader._bind_mlx_vlm_quantized_projector_loader(_test_bound_model_load) is _test_bound_model_load
-    monkeypatch.setitem(globals(), "load_model", _test_positional_model_load)
-    assert loader._bind_mlx_vlm_quantized_projector_loader(_test_bound_model_load) is _test_bound_model_load
-    monkeypatch.setitem(globals(), "load_model", _test_legacy_model_load)
-    monkeypatch.setitem(globals(), "AutoProcessor", types.SimpleNamespace(from_pretrained=lambda *_a, **_k: "processor"))
-    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
-    processor_bound = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
-    assert loader._bind_mlx_vlm_quantized_projector_loader(processor_bound)("model") == "processor"
+    Projector.__name__ = "Lfm2VlMultiModalProjector"
+    monkeypatch.setattr(loader, "_LFM2_PROJECTOR_INIT_TOKEN_SHA256", init_hash)
+    monkeypatch.setattr(loader, "_LFM2_PROJECTOR_CALL_TOKEN_SHA256", call_hash)
+    loader._bind_mlx_vlm_quantized_projector_loader(lambda: None, model_type="lfm2_vl")
+    disabled = Projector(types.SimpleNamespace(projector_use_layernorm=False))
+    enabled = Projector(types.SimpleNamespace(projector_use_layernorm=True))
+    assert not hasattr(disabled, "layer_norm") and enabled("x") == ("normalized", "x")
 
 
 def test_minicpmo_mlx_sanitize_is_complete_and_loader_gated(monkeypatch):
@@ -1095,116 +1088,84 @@ def test_minicpmo_mlx_sanitize_is_complete_and_loader_gated(monkeypatch):
             return output
 
     sanitize_weights = lambda _model, weights: weights
-    def affected_load_model(model, weights): return sanitize_weights(model, weights)
-    def bypassing_load_model(model, weights):
-        mlx_format = True
-        return weights if mlx_format else sanitize_weights(model, weights)
+
+    def affected_load_model(model, weights):
+        return sanitize_weights(model, weights)
 
     load_source = "def load_model(model, weights):\n    weights = sanitize_weights(model, weights)\n    return weights\n"
-    bypass_source = "def load_model(model, weights):\n    if mlx_format:\n        return weights\n    weights = sanitize_weights(model, weights)\n    return weights\n"
-    sources = {affected_load_model: load_source, bypassing_load_model: bypass_source}
+    sources = {affected_load_model: load_source}
     original_getsource = loader._safe_getsource
-    def getsource(obj): return sources[obj] if obj in sources else original_getsource(obj)
-    monkeypatch.setattr(loader, "_MINICPM_SANITIZE_TOKEN_SHA256", loader._source_token_sha256(getsource(MiniCPM.sanitize)))
-    monkeypatch.setattr(loader, "_safe_getsource", getsource); monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: MiniCPM)
-    utils = types.ModuleType("mlx_vlm.utils")
-    utils.load_model = affected_load_model; monkeypatch.setitem(sys.modules, "mlx_vlm.utils", utils)
 
-    original = MiniCPM.sanitize; loader._ensure_minicpmo_mlx_sanitize("minicpmo")
+    def getsource(obj):
+        return sources[obj] if obj in sources else original_getsource(obj)
+
+    expected_hash = loader._source_token_sha256(getsource(MiniCPM.sanitize))
+    monkeypatch.setattr(loader, "_MINICPM_SANITIZE_TOKEN_SHA256", expected_hash)
+    monkeypatch.setattr(loader, "_safe_getsource", getsource)
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: MiniCPM)
+    utils = types.ModuleType("mlx_vlm.utils")
+    utils.load_model = affected_load_model
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", utils)
+
+    original = MiniCPM.sanitize
+    loader._ensure_minicpmo_mlx_sanitize("minicpmo")
     assert MiniCPM.sanitize.__wrapped__ is original
     language, vision, audio = object(), object(), object()
-    values = {"language_model.model.norm.weight": language, "vision_tower.embeddings.patch_embedding.weight": vision, "audio_tower.conv1.weight": audio,
-              "resampler.attn.in_proj_weight": ("q", "k", "v"), "language_model.lm_head.weight": object()}
+    values = {
+        "language_model.model.norm.weight": language,
+        "vision_tower.embeddings.patch_embedding.weight": vision,
+        "audio_tower.conv1.weight": audio,
+        "resampler.attn.in_proj_weight": ("q", "k", "v"),
+        "language_model.lm_head.weight": object(),
+    }
     result = MiniCPM().sanitize(values)
     assert result["language_model.model.norm.weight"] is language and result["vision_tower.embeddings.patch_embedding.weight"] == ("vision-layout", vision)
     assert result["audio_tower.conv1.weight"] == ("audio-layout", audio) and "language_model.lm_head.weight" not in result
     assert tuple(result[f"resampler.attn.{name}_proj.weight"] for name in ("q", "k", "v")) == ("q", "k", "v")
-    source_values = {name: object() for name in ("llm.x", "vpm.x", "apm.x")}; assert set(MiniCPM().sanitize(source_values)) == {"language_model.x", "vision_tower.x", "audio_tower.x"}
     with pytest.raises(ValueError, match="mixes source and MLX tower names"):
         MiniCPM().sanitize({"llm.x": 1, "language_model.x": 2})
     assert MiniCPM().sanitize({"language_model.x": 1}) == {}
-    loader._ensure_minicpmo_mlx_sanitize("minicpmo"); assert MiniCPM.sanitize.__wrapped__ is original
-
-    class CompatibleMiniCPM:
-        def sanitize(self, weights): return weights
-    assert loader._minicpmo_mlx_sanitize_adapter(CompatibleMiniCPM.sanitize) is CompatibleMiniCPM.sanitize
-
-    class NativeMiniCPM: pass
-    NativeMiniCPM.__module__, NativeMiniCPM.sanitize = MiniCPM.__module__, original
-    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: NativeMiniCPM)
-    utils.load_model = bypassing_load_model
-    native = NativeMiniCPM.sanitize
     loader._ensure_minicpmo_mlx_sanitize("minicpmo")
-    assert NativeMiniCPM.sanitize is native
+    assert MiniCPM.sanitize.__wrapped__ is original
 
 
-def test_minicpmo_legacy_vision_uses_call_scoped_float_dtype(monkeypatch):
+def test_minicpmo_vision_dtype_adapter_is_scoped_and_fail_closed(monkeypatch):
     import unsloth_zoo.mlx.loader as loader
 
     convert = lambda value, dtype=None: (value, dtype)
     owner = "mlx_vlm.models.minicpmo.minicpmo"
-    for function, name in ((convert, "_to_mx_array"), (_test_minicpmo_legacy_vision, "get_vision_embedding"), (_test_minicpmo_fixed_vision, "get_vision_embedding")):
-        monkeypatch.setattr(function, "__module__", owner); monkeypatch.setattr(function, "__name__", name)
-    monkeypatch.setitem(globals(), "_to_mx_array", convert)
-    monkeypatch.setattr(loader, "_MINICPM_LEGACY_VISION_TOKEN_SHA256", loader._source_token_sha256(loader._safe_getsource(_test_minicpmo_legacy_vision)))
-    adapted = loader._minicpmo_vision_dtype_adapter(_test_minicpmo_legacy_vision)
-    model = types.SimpleNamespace(
-        language_model=types.SimpleNamespace(model=types.SimpleNamespace(embed_tokens=types.SimpleNamespace(weight=types.SimpleNamespace(dtype="uint32")))),
-        vision_tower=types.SimpleNamespace(embeddings=types.SimpleNamespace(patch_embedding=types.SimpleNamespace(weight=types.SimpleNamespace(dtype="float16")))),
+    functions = (
+        (convert, "_to_mx_array"),
+        (_test_minicpmo_legacy_vision, "get_vision_embedding"),
+        (_test_minicpmo_fixed_vision, "get_vision_embedding"),
     )
+    for function, name in functions:
+        monkeypatch.setattr(function, "__module__", owner)
+        monkeypatch.setattr(function, "__name__", name)
+    monkeypatch.setitem(globals(), "_to_mx_array", convert)
+    fingerprint = loader._source_token_sha256(
+        loader._safe_getsource(_test_minicpmo_legacy_vision)
+    )
+    monkeypatch.setattr(loader, "_MINICPM_LEGACY_VISION_TOKEN_SHA256", fingerprint)
+    language = types.SimpleNamespace(
+        model=types.SimpleNamespace(
+            embed_tokens=types.SimpleNamespace(weight=types.SimpleNamespace(dtype="uint32"))
+        )
+    )
+    vision = types.SimpleNamespace(
+        embeddings=types.SimpleNamespace(
+            patch_embedding=types.SimpleNamespace(weight=types.SimpleNamespace(dtype="float16"))
+        )
+    )
+    model = types.SimpleNamespace(language_model=language, vision_tower=vision)
+    adapted = loader._minicpmo_vision_dtype_adapter(_test_minicpmo_legacy_vision)
     assert _test_minicpmo_legacy_vision(model, "pixels", None) == ("pixels", "uint32")
     assert adapted(model, "pixels", None) == ("pixels", "float16")
-    model.vision_tower.embeddings.patch_embedding.weight.dtype = "bfloat16"
-    assert adapted(model, "next", None) == ("next", "bfloat16") and _to_mx_array is convert
-    assert adapted.__wrapped__ is _test_minicpmo_legacy_vision and loader._minicpmo_vision_dtype_adapter(adapted) is adapted
+    assert _to_mx_array is convert and adapted.__wrapped__ is _test_minicpmo_legacy_vision
+    assert loader._minicpmo_vision_dtype_adapter(adapted) is adapted
     assert loader._minicpmo_vision_dtype_adapter(_test_minicpmo_fixed_vision) is _test_minicpmo_fixed_vision
-
-
-def test_llava_processor_geometry_uses_temporary_config_view(tmp_path):
-    import unsloth_zoo.mlx.loader as loader
-
-    config = {"model_type": "llava", "vision_config": {"patch_size": 14}, "vision_feature_select_strategy": "default"}
-    processor_config = {"processor_class": "LlavaProcessor", "patch_size": None, "vision_feature_select_strategy": None}
-    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
-    (tmp_path / "processor_config.json").write_text(json.dumps(processor_config), encoding="utf-8")
-
-    view, returned_config = loader._materialize_mlx_vlm_config_override(tmp_path, config)
-    patched = loader._read_json_file(Path(view) / "processor_config.json")
-    assert returned_config is config
-    assert (patched["patch_size"], patched["vision_feature_select_strategy"]) == (14, "default")
-    assert loader._read_json_file(tmp_path / "processor_config.json") == processor_config
-
-    class Model: pass
-    model = Model()
-    owner = loader._MLXVLMConfigViewOwner(view, tmp_path)
-    owner.transfer_to(model)
-    assert model._unsloth_mlx_config_view_paths == [str(view)]
-    model._unsloth_mlx_config_view_finalizers[0]()
-    assert not Path(view).exists()
-
-    processor_config["patch_size"], processor_config["vision_feature_select_strategy"] = 16, "full"
-    (tmp_path / "processor_config.json").write_text(json.dumps(processor_config), encoding="utf-8")
-    assert loader._materialize_mlx_vlm_config_override(tmp_path, config)[0] == tmp_path
-    processor_config["patch_size"], processor_config["vision_feature_select_strategy"] = None, None
-    (tmp_path / "processor_config.json").write_text(json.dumps(processor_config), encoding="utf-8")
-    failed_view, _ = loader._materialize_mlx_vlm_config_override(tmp_path, {**config, "vision_config": {"patch_size": 14}})
-    failed_owner = loader._MLXVLMConfigViewOwner(failed_view, tmp_path)
-    with pytest.raises(RuntimeError, match="load failed"):
-        failed_owner.call(lambda: (_ for _ in ()).throw(RuntimeError("load failed")))
-    assert not Path(failed_view).exists()
-    invalid_config = {
-        **config,
-        "vision_config": {"patch_size": 0},
-        "vision_feature_select_strategy": "unsupported",
-    }
-    invalid_view, _ = loader._materialize_mlx_vlm_config_override(
-        tmp_path,
-        invalid_config,
-    )
-    assert loader._read_json_file(
-        Path(invalid_view) / "processor_config.json"
-    ) == processor_config
-    loader._MLXVLMConfigViewOwner(invalid_view, tmp_path).cleanup()
+    monkeypatch.setattr(_test_minicpmo_legacy_vision, "__module__", "foreign")
+    assert loader._minicpmo_vision_dtype_adapter(_test_minicpmo_legacy_vision) is _test_minicpmo_legacy_vision
 
 
 def test_read_json_file_returns_empty_for_missing_or_malformed_files(tmp_path):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -999,6 +999,81 @@ def test_legacy_quantized_projector_binding_is_scoped_and_capability_gated(monke
     assert loader._bind_mlx_vlm_quantized_projector_loader(processor_bound)("model") == "processor"
 
 
+def test_minicpmo_mlx_sanitize_is_complete_and_loader_gated(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+
+    class MiniCPM:
+        __module__ = "mlx_vlm.models.minicpmo.minicpmo"
+        def sanitize(self, weights):
+            output = {}
+            for key, value in weights.items():
+                for source, target in zip(
+                    ("llm.", "vpm.", "apm."),
+                    ("language_model.", "vision_tower.", "audio_tower."),
+                ):
+                    if key.startswith(source):
+                        key = target + key[len(source) :]
+                        break
+                else:
+                    if not key.startswith(("resampler.", "audio_projection_layer.")):
+                        continue
+                if key == "resampler.attn.in_proj_weight":
+                    output.update({
+                        f"resampler.attn.{name}_proj.weight": part
+                        for name, part in zip(("q", "k", "v"), value)
+                    })
+                elif key.endswith("embeddings.patch_embedding.weight"):
+                    output[key] = ("vision-layout", value)
+                elif key.endswith("audio_tower.conv1.weight"):
+                    output[key] = ("audio-layout", value)
+                elif key != "language_model.lm_head.weight":
+                    output[key] = value
+            return output
+
+    sanitize_weights = lambda _model, weights: weights
+    def affected_load_model(model, weights): return sanitize_weights(model, weights)
+    def bypassing_load_model(model, weights):
+        mlx_format = True
+        return weights if mlx_format else sanitize_weights(model, weights)
+
+    load_source = "def load_model(model, weights):\n    weights = sanitize_weights(model, weights)\n    return weights\n"
+    bypass_source = "def load_model(model, weights):\n    if mlx_format:\n        return weights\n    weights = sanitize_weights(model, weights)\n    return weights\n"
+    sources = {affected_load_model: load_source, bypassing_load_model: bypass_source}
+    original_getsource = loader._safe_getsource
+    def getsource(obj): return sources[obj] if obj in sources else original_getsource(obj)
+    monkeypatch.setattr(loader, "_MINICPM_SANITIZE_TOKEN_SHA256", loader._source_token_sha256(getsource(MiniCPM.sanitize)))
+    monkeypatch.setattr(loader, "_safe_getsource", getsource); monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: MiniCPM)
+    utils = types.ModuleType("mlx_vlm.utils")
+    utils.load_model = affected_load_model; monkeypatch.setitem(sys.modules, "mlx_vlm.utils", utils)
+
+    original = MiniCPM.sanitize; loader._ensure_minicpmo_mlx_sanitize("minicpmo")
+    assert MiniCPM.sanitize.__wrapped__ is original
+    language, vision, audio = object(), object(), object()
+    values = {"language_model.model.norm.weight": language, "vision_tower.embeddings.patch_embedding.weight": vision, "audio_tower.conv1.weight": audio,
+              "resampler.attn.in_proj_weight": ("q", "k", "v"), "language_model.lm_head.weight": object()}
+    result = MiniCPM().sanitize(values)
+    assert result["language_model.model.norm.weight"] is language and result["vision_tower.embeddings.patch_embedding.weight"] == ("vision-layout", vision)
+    assert result["audio_tower.conv1.weight"] == ("audio-layout", audio) and "language_model.lm_head.weight" not in result
+    assert tuple(result[f"resampler.attn.{name}_proj.weight"] for name in ("q", "k", "v")) == ("q", "k", "v")
+    source_values = {name: object() for name in ("llm.x", "vpm.x", "apm.x")}; assert set(MiniCPM().sanitize(source_values)) == {"language_model.x", "vision_tower.x", "audio_tower.x"}
+    with pytest.raises(ValueError, match="mixes source and MLX tower names"):
+        MiniCPM().sanitize({"llm.x": 1, "language_model.x": 2})
+    assert MiniCPM().sanitize({"language_model.x": 1}) == {}
+    loader._ensure_minicpmo_mlx_sanitize("minicpmo"); assert MiniCPM.sanitize.__wrapped__ is original
+
+    class CompatibleMiniCPM:
+        def sanitize(self, weights): return weights
+    assert loader._minicpmo_mlx_sanitize_adapter(CompatibleMiniCPM.sanitize) is CompatibleMiniCPM.sanitize
+
+    class NativeMiniCPM: pass
+    NativeMiniCPM.__module__, NativeMiniCPM.sanitize = MiniCPM.__module__, original
+    monkeypatch.setattr(loader, "_resolve_mlx_vlm_model_class", lambda _: NativeMiniCPM)
+    utils.load_model = bypassing_load_model
+    native = NativeMiniCPM.sanitize
+    loader._ensure_minicpmo_mlx_sanitize("minicpmo")
+    assert NativeMiniCPM.sanitize is native
+
+
 def test_llava_processor_geometry_uses_temporary_config_view(tmp_path):
     import unsloth_zoo.mlx.loader as loader
 

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -482,6 +482,45 @@ def test_vlm_prompt_patch_preserves_model_specific_media_markers(monkeypatch):
         assert render(messages, num_images=1) == "fallback"
 
 
+def test_vlm_prompt_patch_rebinds_every_loaded_mlx_vlm_alias(monkeypatch):
+    """No loaded mlx-vlm module may keep the original chat-template callable.
+
+    The hard-coded list only force-imports mlx-vlm's entry points, so aliases in
+    modules that are already loaded -- `mlx_vlm` itself re-exports this one --
+    survive the patch and render multi-turn prompts the old way.
+    """
+    import mlx_vlm.prompt_utils as prompt_utils
+    import unsloth_zoo.mlx.loader as loader
+
+    def original(*_args, **_kwargs):
+        return "original"
+
+    monkeypatch.setattr(prompt_utils, "apply_chat_template", original, raising=False)
+    monkeypatch.setattr(loader, "_vlm_prompt_utils_patched", False)
+    monkeypatch.setattr(loader, "_original_vlm_apply_chat_template", None)
+
+    # Aliases mlx-vlm really holds: the package re-export and a submodule that
+    # any `import mlx_vlm` already pulls in through mlx_vlm/trainer/__init__.py.
+    aliased = ("mlx_vlm", "mlx_vlm.trainer.datasets")
+    for name in aliased:
+        module = sys.modules.get(name) or types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, module)
+        monkeypatch.setattr(module, "apply_chat_template", original, raising=False)
+
+    # A same-named alias outside mlx-vlm must stay untouched.
+    outsider = types.ModuleType("unsloth_zoo_y952_outsider")
+    outsider.apply_chat_template = original
+    monkeypatch.setitem(sys.modules, outsider.__name__, outsider)
+
+    loader._ensure_vlm_prompt_utils_patched()
+
+    patched = prompt_utils.apply_chat_template
+    assert patched is not original
+    stale = [name for name in aliased if sys.modules[name].apply_chat_template is original]
+    assert stale == [], f"stale mlx-vlm chat-template aliases: {stale}"
+    assert outsider.apply_chat_template is original
+
+
 def test_vlm_generate_hf_kwargs(monkeypatch):
     import torch
     from transformers.tokenization_utils_base import to_py_obj

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -30,6 +30,18 @@ from pathlib import Path
 import pytest
 
 
+AutoProcessor = None
+load_processor = None
+
+
+def _test_bound_load_processor(model_path, **kwargs):
+    return AutoProcessor.from_pretrained(model_path, **kwargs)
+
+
+def _test_bound_vlm_load(model_path):
+    return load_processor(model_path)
+
+
 @pytest.fixture(autouse=True, scope="module")
 def _install_mlx_torch_shim():
     pytest.importorskip("torch")
@@ -839,6 +851,133 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     assert repaired.tokenizer is tokenizer
     assert repaired.chat_template == "{{ messages }}"
     assert tokenizer.chat_template == "{{ messages }}"
+
+
+def test_declared_mlx_vlm_processor_owns_custom_components_and_recovery(
+    monkeypatch,
+    tmp_path,
+):
+    import unsloth_zoo.mlx.loader as loader
+
+    class NativeImageProcessor: pass
+    factory_calls = []
+
+    class NativeProcessor:
+        __module__ = "mlx_vlm.models.molmo.processor"
+        get_possibly_dynamic_module = staticmethod(lambda name: (_ for _ in ()).throw(ValueError(f"Could not find module {name} in `transformers`")))
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            factory_calls.append((
+                loader._read_json_file(Path(model_path) / "config.json").get("auto_map"),
+                loader._read_json_file(Path(model_path) / "tokenizer_config.json").get("auto_map"),
+                kwargs.get("trust_remote_code", False),
+            ))
+            return cls(cls.get_possibly_dynamic_module("NativeImageProcessor")())
+        def __init__(self, image_processor): self.image_processor, self.chat_template, self.tokenizer = image_processor, None, types.SimpleNamespace()
+
+    native_module = types.ModuleType("mlx_vlm.models.molmo.processor")
+    native_module.NativeProcessor, native_module.NativeImageProcessor = NativeProcessor, NativeImageProcessor
+    monkeypatch.setitem(sys.modules, "mlx_vlm.models.molmo.processor", native_module)
+    (tmp_path / "config.json").write_text('{"model_type":"molmo","auto_map":{"AutoConfig":"remote.Config"}}', encoding="utf-8")
+    (tmp_path / "processor_config.json").write_text('{"processor_class":"NativeProcessor"}', encoding="utf-8")
+    (tmp_path / "tokenizer_config.json").write_text('{"auto_map":{"AutoTokenizer":"remote.Tokenizer"}}', encoding="utf-8")
+
+    processor = loader._load_declared_mlx_vlm_processor(tmp_path, "molmo")
+    assert isinstance(processor, NativeProcessor) and isinstance(processor.image_processor, NativeImageProcessor)
+    assert factory_calls[-1] == (None, None, False)
+    loader._load_declared_mlx_vlm_processor(tmp_path, "molmo", trust_remote_code=True)
+    assert factory_calls[-1] == ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, True)
+    detokenizer, stopping = object(), object(); degraded = types.SimpleNamespace(image_processor=None, chat_template="{{ messages }}", detokenizer=detokenizer, tokenizer=types.SimpleNamespace(stopping_criteria=stopping))
+    repaired = loader._repair_degraded_vlm_processor(degraded, tmp_path, "molmo")
+    assert isinstance(repaired, NativeProcessor) and repaired.chat_template == "{{ messages }}" and repaired.detokenizer is detokenizer and repaired.tokenizer.stopping_criteria is stopping
+
+    healthy = object()
+    class AutoProcessor:
+        outcome = ValueError("Unrecognized processing class")
+        calls = []
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            cls.calls.append((
+                loader._read_json_file(Path(model_path) / "config.json").get("auto_map"),
+                loader._read_json_file(Path(model_path) / "tokenizer_config.json").get("auto_map"),
+                kwargs.get("trust_remote_code"),
+            ))
+            if isinstance(cls.outcome, BaseException): raise cls.outcome
+            return cls.outcome
+
+    monkeypatch.setitem(globals(), "AutoProcessor", AutoProcessor)
+    monkeypatch.setitem(globals(), "load_processor", _test_bound_load_processor)
+    scoped_load = loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    recovered = scoped_load(tmp_path)
+    (tmp_path / "config.json").write_text('{"model_type":"native","auto_map":{"AutoConfig":"remote.Config"}}', encoding="utf-8")
+    AutoProcessor.outcome = healthy
+    assert _test_bound_vlm_load(tmp_path) is healthy
+    assert scoped_load(tmp_path) is healthy
+    AutoProcessor.outcome = RuntimeError("unrelated")
+    with pytest.raises(RuntimeError, match="unrelated"):
+        scoped_load(tmp_path)
+    AutoProcessor.outcome = healthy
+    trusted_load = loader._bind_mlx_vlm_processor_loader(
+        _test_bound_vlm_load,
+        allow_remote_code=True,
+    )
+    assert trusted_load(tmp_path) is healthy
+    assert isinstance(recovered, NativeProcessor)
+    assert AutoProcessor.calls == [
+        (None, None, False),
+        ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, None),
+        ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, False),
+        ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, False),
+        ({"AutoConfig": "remote.Config"}, {"AutoTokenizer": "remote.Tokenizer"}, True),
+    ]
+    assert load_processor is _test_bound_load_processor
+
+
+def test_llava_processor_geometry_uses_temporary_config_view(tmp_path):
+    import unsloth_zoo.mlx.loader as loader
+
+    config = {"model_type": "llava", "vision_config": {"patch_size": 14}, "vision_feature_select_strategy": "default"}
+    processor_config = {"processor_class": "LlavaProcessor", "patch_size": None, "vision_feature_select_strategy": None}
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (tmp_path / "processor_config.json").write_text(json.dumps(processor_config), encoding="utf-8")
+
+    view, returned_config = loader._materialize_mlx_vlm_config_override(tmp_path, config)
+    patched = loader._read_json_file(Path(view) / "processor_config.json")
+    assert returned_config is config
+    assert (patched["patch_size"], patched["vision_feature_select_strategy"]) == (14, "default")
+    assert loader._read_json_file(tmp_path / "processor_config.json") == processor_config
+
+    class Model: pass
+    model = Model()
+    owner = loader._MLXVLMConfigViewOwner(view, tmp_path)
+    owner.transfer_to(model)
+    assert model._unsloth_mlx_config_view_paths == [str(view)]
+    model._unsloth_mlx_config_view_finalizers[0]()
+    assert not Path(view).exists()
+
+    processor_config["patch_size"], processor_config["vision_feature_select_strategy"] = 16, "full"
+    (tmp_path / "processor_config.json").write_text(json.dumps(processor_config), encoding="utf-8")
+    assert loader._materialize_mlx_vlm_config_override(tmp_path, config)[0] == tmp_path
+    processor_config["patch_size"], processor_config["vision_feature_select_strategy"] = None, None
+    (tmp_path / "processor_config.json").write_text(json.dumps(processor_config), encoding="utf-8")
+    failed_view, _ = loader._materialize_mlx_vlm_config_override(tmp_path, {**config, "vision_config": {"patch_size": 14}})
+    failed_owner = loader._MLXVLMConfigViewOwner(failed_view, tmp_path)
+    with pytest.raises(RuntimeError, match="load failed"):
+        failed_owner.call(lambda: (_ for _ in ()).throw(RuntimeError("load failed")))
+    assert not Path(failed_view).exists()
+    invalid_config = {
+        **config,
+        "vision_config": {"patch_size": 0},
+        "vision_feature_select_strategy": "unsupported",
+    }
+    invalid_view, _ = loader._materialize_mlx_vlm_config_override(
+        tmp_path,
+        invalid_config,
+    )
+    assert loader._read_json_file(
+        Path(invalid_view) / "processor_config.json"
+    ) == processor_config
+    loader._MLXVLMConfigViewOwner(invalid_view, tmp_path).cleanup()
 
 
 def test_read_json_file_returns_empty_for_missing_or_malformed_files(tmp_path):

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -25,6 +25,7 @@ import json
 import os
 import sys
 import types
+from copy import copy
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,11 @@ def _test_bound_vlm_load(model_path):
 
 def _test_bound_model_load(paths, weights):
     return load_model(paths, weights)
+def _test_make_streaming_detokenizer(processor):
+    detokenizer = copy(processor.detokenizer); detokenizer.reset(); return detokenizer
+def _test_naive_detokenizer_init(self, tokenizer):
+    self._tokenizer, self._tokens = tokenizer, []
+def _test_naive_detokenizer_reset(self): self._tokens = []
 def _test_minicpmo_legacy_vision(self, pixel_values, tgt_sizes):
     dtype = self.language_model.model.embed_tokens.weight.dtype
     return _to_mx_array(pixel_values, dtype=dtype)
@@ -900,6 +906,35 @@ def test_repair_degraded_vlm_processor_rebuilds_from_sidecar_configs(
     assert repaired.tokenizer is tokenizer
     assert repaired.chat_template == "{{ messages }}"
     assert tokenizer.chat_template == "{{ messages }}"
+
+
+def test_legacy_naive_detokenizer_copy_is_capability_gated(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+
+    module_name = "mlx_vlm.tokenizer_utils"
+    StreamingDetokenizer = type("StreamingDetokenizer", (), {"__module__": module_name, "__slots__": ("text", "tokens", "offset")})
+    NaiveStreamingDetokenizer = type("NaiveStreamingDetokenizer", (StreamingDetokenizer,), {"__module__": module_name, "__init__": _test_naive_detokenizer_init, "reset": _test_naive_detokenizer_reset, "text": property(lambda self: "")})
+    module = types.ModuleType(module_name)
+    module.StreamingDetokenizer, module.NaiveStreamingDetokenizer, module.make_streaming_detokenizer = StreamingDetokenizer, NaiveStreamingDetokenizer, _test_make_streaming_detokenizer
+    monkeypatch.setitem(sys.modules, module_name, module)
+    monkeypatch.setattr(loader, "_MLX_VLM_DETOKENIZER_COPY_TOKEN_SHA256", loader._source_token_sha256(loader._safe_getsource(_test_make_streaming_detokenizer)))
+
+    tokenizer = object(); original = NaiveStreamingDetokenizer(tokenizer)
+    with pytest.raises(AttributeError, match="property 'text'"):
+        copy(original)
+    loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    original._tokens.append(1); copied = copy(original)
+    assert copied is not original and copied._tokenizer is tokenizer
+    assert copied._tokens == [] and original._tokens == [1]
+    installed_copy = NaiveStreamingDetokenizer.__copy__
+    loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    assert NaiveStreamingDetokenizer.__copy__ is installed_copy
+
+    native_copy = lambda self: self
+    del NaiveStreamingDetokenizer.__copy__; StreamingDetokenizer.__copy__ = native_copy
+    loader._bind_mlx_vlm_processor_loader(_test_bound_vlm_load)
+    fixed = NaiveStreamingDetokenizer(tokenizer)
+    assert "__copy__" not in NaiveStreamingDetokenizer.__dict__ and copy(fixed) is fixed
 
 
 def test_declared_mlx_vlm_processor_owns_custom_components_and_recovery(

--- a/tests/test_mlx_save_export_regressions.py
+++ b/tests/test_mlx_save_export_regressions.py
@@ -33,6 +33,7 @@ import pytest
 AutoProcessor = None
 load_processor = None
 load_model = skip_multimodal_module = nn = _has_quantized_weights = None
+_to_mx_array = None
 
 
 def _test_bound_load_processor(model_path, **kwargs):
@@ -45,6 +46,12 @@ def _test_bound_vlm_load(model_path):
 
 def _test_bound_model_load(paths, weights):
     return load_model(paths, weights)
+def _test_minicpmo_legacy_vision(self, pixel_values, tgt_sizes):
+    dtype = self.language_model.model.embed_tokens.weight.dtype
+    return _to_mx_array(pixel_values, dtype=dtype)
+def _test_minicpmo_fixed_vision(self, pixel_values, tgt_sizes):
+    dtype = self.vision_tower.embeddings.patch_embedding.weight.dtype
+    return _to_mx_array(pixel_values, dtype=dtype)
 def _test_legacy_model_load(paths, weights):
     config, skip_vision = {"quantization": {"multi_modal_projector.dense": True}}, True
     def get_class_predicate(p, m):
@@ -1072,6 +1079,28 @@ def test_minicpmo_mlx_sanitize_is_complete_and_loader_gated(monkeypatch):
     native = NativeMiniCPM.sanitize
     loader._ensure_minicpmo_mlx_sanitize("minicpmo")
     assert NativeMiniCPM.sanitize is native
+
+
+def test_minicpmo_legacy_vision_uses_call_scoped_float_dtype(monkeypatch):
+    import unsloth_zoo.mlx.loader as loader
+
+    convert = lambda value, dtype=None: (value, dtype)
+    owner = "mlx_vlm.models.minicpmo.minicpmo"
+    for function, name in ((convert, "_to_mx_array"), (_test_minicpmo_legacy_vision, "get_vision_embedding"), (_test_minicpmo_fixed_vision, "get_vision_embedding")):
+        monkeypatch.setattr(function, "__module__", owner); monkeypatch.setattr(function, "__name__", name)
+    monkeypatch.setitem(globals(), "_to_mx_array", convert)
+    monkeypatch.setattr(loader, "_MINICPM_LEGACY_VISION_TOKEN_SHA256", loader._source_token_sha256(loader._safe_getsource(_test_minicpmo_legacy_vision)))
+    adapted = loader._minicpmo_vision_dtype_adapter(_test_minicpmo_legacy_vision)
+    model = types.SimpleNamespace(
+        language_model=types.SimpleNamespace(model=types.SimpleNamespace(embed_tokens=types.SimpleNamespace(weight=types.SimpleNamespace(dtype="uint32")))),
+        vision_tower=types.SimpleNamespace(embeddings=types.SimpleNamespace(patch_embedding=types.SimpleNamespace(weight=types.SimpleNamespace(dtype="float16")))),
+    )
+    assert _test_minicpmo_legacy_vision(model, "pixels", None) == ("pixels", "uint32")
+    assert adapted(model, "pixels", None) == ("pixels", "float16")
+    model.vision_tower.embeddings.patch_embedding.weight.dtype = "bfloat16"
+    assert adapted(model, "next", None) == ("next", "bfloat16") and _to_mx_array is convert
+    assert adapted.__wrapped__ is _test_minicpmo_legacy_vision and loader._minicpmo_vision_dtype_adapter(adapted) is adapted
+    assert loader._minicpmo_vision_dtype_adapter(_test_minicpmo_fixed_vision) is _test_minicpmo_fixed_vision
 
 
 def test_llava_processor_geometry_uses_temporary_config_view(tmp_path):

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2551,13 +2551,7 @@ def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
     assert adapted(types.SimpleNamespace(training=True), position_ids=object()) == "replacement"
     batched = types.SimpleNamespace(VisionModel=type("V", (), {"_forward_same_grid_batch": lambda self: None}))
     assert mc._paddleocr_vl_has_batched_vision(batched)
-    gemma3n = types.SimpleNamespace(masked_scatter=object())
-    language = types.SimpleNamespace(Gemma3Model=type("G", (), {"__call__": len}))
-    monkeypatch.setattr(mc, "_iter_trait_model_modules", lambda *args, **kwargs: [("gemma3n", gemma3n)])
-    monkeypatch.setattr(mc, "_try_import_module", lambda name: language)
-    mc._install_masked_scatter_multimodal_patches()
-    assert gemma3n.masked_scatter is not mc._masked_scatter_no_numpy
-    assert "gemma3n" not in mc._PATCHED_ARCHES
+    assert mc._gemma3n_language_contract(len) is None
 
 
 def test_quantized_cce_uses_layer_mode_and_affine_bias_guard():
@@ -2593,6 +2587,50 @@ def test_compile_patch_primitives_exist():
     import unsloth_zoo.mlx.compile as mc
     primitives = mc.list_compile_patch_primitives()
     assert len(primitives) > 0
+
+
+def test_shared_family_installers_import_only_allowlisted_models(monkeypatch):
+    import unsloth_zoo.mlx.compile as mc
+    native = lambda *_args, **_kwargs: None
+    qwen_arches = frozenset({"qwen2_vl", "qwen2_5_vl", "glm_ocr", "paddleocr_vl"})
+    masked_arches = frozenset({"gemma3", "gemma4", "idefics2", "idefics3"})
+    idefics_arches = frozenset({"idefics2", "idefics3"})
+    assert (mc._QWEN_LIKE_MERGE_ARCHES, mc._MASKED_SCATTER_PATCH_ARCHES, mc._IDEFICS_SHARED_PATCH_ARCHES) == (qwen_arches, masked_arches, idefics_arches)
+    methods = {
+        "merge_input_ids_with_image_features": staticmethod(native),
+        "_prepare_inputs_for_multimodal": native,
+        "get_input_embeddings": native,
+    }
+    modules = {
+        arch: types.SimpleNamespace(
+            masked_scatter=native,
+            Model=type(f"{arch}Model", (), methods),
+        )
+        for arch in qwen_arches | masked_arches
+    }
+    paddle_vision = types.SimpleNamespace(
+        VisionModel=type("PaddleVision", (), {"_forward_same_grid_batch": native})
+    )
+    imported = []
+    def import_module(name):
+        imported.append(name)
+        if name == "mlx_vlm.models.paddleocr_vl.vision":
+            return paddle_vision
+        parts = name.split(".")
+        return modules.get(parts[-1]) if parts[-2:] == [parts[-1], parts[-1]] else None
+    monkeypatch.setattr(mc, "_try_import_module", import_module)
+    monkeypatch.setattr(mc, "build_compile_trait_reports", lambda: pytest.fail("runtime traits"))
+    monkeypatch.setattr(mc, "_PATCHED_ARCHES", set())
+    monkeypatch.setattr(mc, "_PATCH_BINDINGS", set())
+    monkeypatch.setattr(mc, "_VERIFIED_TRAINING_ARCHES", set(mc._VERIFIED_TRAINING_ARCHES))
+    mc._install_qwen_like_image_merge_patches()
+    mc._install_masked_scatter_multimodal_patches()
+    mc._install_idefics_family_compile_patches()
+    assert not any(name.split(".")[-1] in {"lfm2_vl", "minicpmo", "phi4mm"} for name in imported)
+    assert all(modules[arch].masked_scatter is mc._masked_scatter_no_numpy for arch in masked_arches)
+    assert modules["paddleocr_vl"].Model.merge_input_ids_with_image_features is native
+    assert all(modules[arch].Model.merge_input_ids_with_image_features is mc._merge_special_token_features_only for arch in qwen_arches - {"paddleocr_vl"})
+    assert all(modules[arch].Model.get_input_embeddings is not native for arch in idefics_arches)
 
 
 def test_compile_protocol_requirements_exist():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2541,6 +2541,25 @@ def test_qwen3_vl_training_compile_verified():
     assert "qwen3_vl_moe" in mc._VERIFIED_TRAINING_ARCHES
 
 
+def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
+    import unsloth_zoo.mlx.compile as mc
+    upstream = lambda self, input_ids=None, pixel_values=None, **kwargs: "upstream"
+    replacement = lambda self, input_ids=None, pixel_values=None, **kwargs: "replacement"
+    adapted = mc._explicit_position_embedding_adapter(upstream, replacement)
+    assert adapted(types.SimpleNamespace(training=True)) == "upstream"
+    assert adapted(types.SimpleNamespace(training=False), position_ids=object()) == "upstream"
+    assert adapted(types.SimpleNamespace(training=True), position_ids=object()) == "replacement"
+    batched = types.SimpleNamespace(VisionModel=type("V", (), {"_forward_same_grid_batch": lambda self: None}))
+    assert mc._paddleocr_vl_has_batched_vision(batched)
+    gemma3n = types.SimpleNamespace(masked_scatter=object())
+    language = types.SimpleNamespace(Gemma3Model=type("G", (), {"__call__": len}))
+    monkeypatch.setattr(mc, "_iter_trait_model_modules", lambda *args, **kwargs: [("gemma3n", gemma3n)])
+    monkeypatch.setattr(mc, "_try_import_module", lambda name: language)
+    mc._install_masked_scatter_multimodal_patches()
+    assert gemma3n.masked_scatter is not mc._masked_scatter_no_numpy
+    assert "gemma3n" not in mc._PATCHED_ARCHES
+
+
 def test_quantized_cce_uses_layer_mode_and_affine_bias_guard():
     import inspect
     import unsloth_zoo.mlx.utils as mlx_utils

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2542,6 +2542,7 @@ def test_qwen3_vl_training_compile_verified():
 
 
 def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
+    import mlx.core as mx
     import unsloth_zoo.mlx.compile as mc
     upstream = lambda self, input_ids=None, pixel_values=None, **kwargs: "upstream"
     replacement = lambda self, input_ids=None, pixel_values=None, **kwargs: "replacement"
@@ -2552,6 +2553,8 @@ def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
     batched = types.SimpleNamespace(VisionModel=type("V", (), {"_forward_same_grid_batch": lambda self: None}))
     assert mc._paddleocr_vl_has_batched_vision(batched)
     assert mc._gemma3n_language_contract(len) is None
+    assert mc._gemma3n_cache_offset([types.SimpleNamespace(offset=700, _idx=188)]) == 700
+    assert mc._gemma3n_cache_offset([types.SimpleNamespace(offset=mx.array([650, 700]), _idx=188)]) == 700
 
 
 def test_quantized_cce_uses_layer_mode_and_affine_bias_guard():

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2955,7 +2955,7 @@ def test_qwen3_visual_window_preserves_batched_row_ownership():
     assert packed.shape == (2, 3, 1, 1)
     assert positions.tolist() == [[1, 2, 4], [0, 2, 3]]
     window_masks, window_embeds = mc._qwen3_visual_window(
-        masks, packed, positions, mask_offsets=(1, 1), feature_offsets=(1, 1), window=2
+        masks, packed, positions, mask_offsets=(1, 1), window=2
     )
     assert window_masks.tolist() == [[1, 1], [0, 1]]
     assert window_embeds[0].tolist() == [[10], [11], [21]]
@@ -3975,7 +3975,6 @@ def test_qwen3_visual_window_keeps_features_when_mask_spans_whole_window():
             packed,
             positions,
             mask_offsets=(carried_offset,),
-            feature_offsets=(carried_offset,),
             window=6,
         )
         assert window_masks.tolist() == [[0, 0, 1, 1, 0, 0]]
@@ -3997,7 +3996,6 @@ def test_qwen3_visual_window_keeps_rows_apart_under_left_padding():
         packed,
         positions,
         mask_offsets=(0, 0),
-        feature_offsets=(-3, 0),
         window=6,
     )
     assert window_masks.tolist() == masks.tolist()
@@ -4080,3 +4078,41 @@ def test_qwen3_prompt_rows_defer_to_the_native_deepstack_path():
 
     rows = [native_row, compact_row]
     assert mc._pad_qwen3_prompt_rows(rows) is rows
+
+
+def test_qwen3_visual_window_slices_features_in_padded_coordinates():
+    """A chunked window must count features in the same coordinates as the mask.
+
+    _pack_qwen3_visual_state records positions against the padded mask, so
+    slicing features with the unpadded cache offset lets the mask select a
+    visual token whose feature the window excludes. Only reachable when the
+    window is shorter than the row: a whole-row window spans everything and
+    hides the mismatch, which is why it went unnoticed.
+    """
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    pad, seq = 3, 10
+    masks = mx.zeros((1, seq), dtype=mx.bool_)
+    masks[0, 4] = True
+    masks[0, 5] = True
+    packed, positions = mc._pack_qwen3_visual_state(
+        masks, [mx.array([[1], [2]])],
+    )
+    cache = [types.SimpleNamespace(
+        offset=mx.array([1]), left_padding=mx.array([pad]),
+    )]
+    _unpadded, mask_offsets = mc._qwen3_cache_offsets(cache, 1)
+    assert (_unpadded, mask_offsets) == ((1,), (4,)), "padding must shift them apart"
+
+    for window in (4, seq):
+        window_masks, window_embeds = mc._qwen3_visual_window(
+            masks, packed, positions,
+            mask_offsets=mask_offsets, window=window,
+        )
+        selected = int(window_masks.sum().item())
+        supplied = int(window_embeds[0].shape[0])
+        assert selected == supplied, (
+            f"window={window}: mask selected {selected} visual token(s) but "
+            f"the feature slice supplied {supplied}"
+        )

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2954,6 +2954,30 @@ def test_qwen3_visual_window_preserves_batched_row_ownership():
     packed, positions = mc._pack_qwen3_visual_state(masks, embeds)
     assert packed.shape == (2, 3, 1, 1)
     assert positions.tolist() == [[1, 2, 4], [0, 2, 3]]
+    visual_row = dict(
+        inputs_embeds=mx.zeros((1, 6, 1)),
+        visual_pos_masks=masks[:1],
+        _unsloth_qwen3_visual_state=packed[:1],
+        _unsloth_qwen3_visual_positions=positions[:1],
+    )
+    text_row = dict(inputs_embeds=mx.zeros((1, 4, 1)))
+    cold = mc._qwen3_prompt_merge_adapter(lambda rows, _ids: rows)
+    aligned = cold([visual_row, text_row], [range(6), range(4)])
+    assert aligned[0]["_unsloth_qwen3_visual_state"].tolist() == packed[:1].tolist()
+    assert aligned[1]["_unsloth_qwen3_visual_state"].shape == (1, 3, 1, 1)
+    assert not aligned[1]["_unsloth_qwen3_visual_state"].any().item()
+    assert aligned[1]["_unsloth_qwen3_visual_positions"].tolist() == [[-1, -1, -1]]
+    assert aligned[1]["visual_pos_masks"].shape == (1, 4)
+    assert not aligned[1]["visual_pos_masks"].any().item()
+    cached_row = dict(
+        inputs_embeds=visual_row["inputs_embeds"],
+        visual_pos_masks=masks[:1],
+    )
+    cached = cold([cached_row, visual_row], [range(6)] * 2)[0]
+    assert not cached["_unsloth_qwen3_visual_state"].any().item()
+    assert cached["_unsloth_qwen3_visual_positions"].tolist() == [[1, 2, 4]]
+    assert mc._pad_qwen3_prompt_rows([]) == []
+    assert mc._pad_qwen3_prompt_rows([text_row])[0] is text_row
     window_masks, window_embeds = mc._qwen3_visual_window(
         masks, packed, positions, mask_offsets=(1, 1), feature_offsets=(1, 1), window=2
     )

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -3956,3 +3956,57 @@ def test_real_hf_concat_infinite_detection_matches_actual_termination(axis):
                 if produced > 1000:
                     break
             assert produced > 1000
+
+
+def test_qwen3_visual_window_keeps_features_when_mask_spans_whole_window():
+    """A reused prompt cache must not shift the feature window off the mask."""
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    masks = mx.array([[0, 0, 1, 1, 0, 0]], dtype=mx.bool_)
+    embeds = [mx.array([[1], [2]])]
+    packed, positions = mc._pack_qwen3_visual_state(masks, embeds)
+
+    # The mask already covers only the new turn, so an offset carried over from
+    # an earlier turn must not be applied to it a second time.
+    for carried_offset in (0, 6, 20):
+        window_masks, window_embeds = mc._qwen3_visual_window(
+            masks,
+            packed,
+            positions,
+            mask_offsets=(carried_offset,),
+            feature_offsets=(carried_offset,),
+            window=6,
+        )
+        assert window_masks.tolist() == [[0, 0, 1, 1, 0, 0]]
+        assert window_embeds[0].tolist() == [[1], [2]]
+
+
+def test_qwen3_visual_window_keeps_rows_apart_under_left_padding():
+    """Left-padded rows keep their own features instead of borrowing a neighbour's."""
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    # Row 0 is left-padded by 3, so its cache offset is negative at prefill.
+    masks = mx.array([[0, 0, 0, 0, 1, 1], [1, 1, 0, 0, 0, 0]], dtype=mx.bool_)
+    embeds = [mx.array([[1], [2], [3], [4]])]
+    packed, positions = mc._pack_qwen3_visual_state(masks, embeds)
+
+    window_masks, window_embeds = mc._qwen3_visual_window(
+        masks,
+        packed,
+        positions,
+        mask_offsets=(0, 0),
+        feature_offsets=(-3, 0),
+        window=6,
+    )
+    assert window_masks.tolist() == masks.tolist()
+    assert window_embeds[0].tolist() == [[1], [2], [3], [4]]
+
+
+def test_qwen3_cache_offsets_accepts_declared_none_left_padding():
+    """Some cache classes declare left_padding as None rather than omitting it."""
+    import unsloth_zoo.mlx.compile as mc
+
+    cache = [types.SimpleNamespace(offset=0, left_padding=None)]
+    assert mc._qwen3_cache_offsets(cache, batch_size=1) == ((0,), (0,))

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -4006,3 +4006,74 @@ def test_real_hf_concat_infinite_detection_matches_actual_termination(axis):
                 if produced > 1000:
                     break
             assert produced > 1000
+
+
+def test_qwen3_visual_window_keeps_features_when_mask_spans_whole_window():
+    """A reused prompt cache must not shift the feature window off the mask."""
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    masks = mx.array([[0, 0, 1, 1, 0, 0]], dtype=mx.bool_)
+    embeds = [mx.array([[1], [2]])]
+    packed, positions = mc._pack_qwen3_visual_state(masks, embeds)
+
+    # The mask already covers only the new turn, so an offset carried over from
+    # an earlier turn must not be applied to it a second time.
+    for carried_offset in (0, 6, 20):
+        window_masks, window_embeds = mc._qwen3_visual_window(
+            masks,
+            packed,
+            positions,
+            mask_offsets=(carried_offset,),
+            window=6,
+        )
+        assert window_masks.tolist() == [[0, 0, 1, 1, 0, 0]]
+        assert window_embeds[0].tolist() == [[1], [2]]
+
+
+def test_qwen3_prompt_rows_defer_to_the_native_deepstack_path():
+    """A row carrying mlx-vlm's own deepstack features keeps them.
+
+    Synthesizing empty compact state for such a row hands the language call
+    zeros in place of its real visual features.
+    """
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    masks = mx.array([[0, 1, 1, 0]], dtype=mx.bool_)
+    state, positions = mc._pack_qwen3_visual_state(masks, [mx.array([[1.0], [2.0]])])
+    compact_row = {
+        "inputs_embeds": mx.zeros((1, 4, 1)),
+        "visual_pos_masks": masks,
+        mc._QWEN3_VISUAL_STATE_KEY: state,
+        mc._QWEN3_VISUAL_POSITIONS_KEY: positions,
+    }
+    native_row = {
+        "inputs_embeds": mx.zeros((1, 4, 1)),
+        "visual_pos_masks": masks,
+        # A bare array is what _pack_qwen3_visual_state declines to compact.
+        "deepstack_visual_embeds": mx.array([[7.0], [8.0]]),
+    }
+
+    rows = [native_row, compact_row]
+    assert mc._pad_qwen3_prompt_rows(rows) is rows
+
+    seen = []
+
+    def language(self, inputs, inputs_embeds=None, mask=None, cache=None,
+                 visual_pos_masks=None, deepstack_visual_embeds=None, **kwargs):
+        seen.append(deepstack_visual_embeds)
+
+    padded = mc._pad_qwen3_prompt_rows(rows)[0]
+    call_kwargs = dict(padded)
+    call_kwargs.pop("inputs_embeds")
+    mc._qwen3_visual_state_adapter(language)(
+        object(), mx.zeros((1, 4)), cache=None, **call_kwargs
+    )
+    assert seen[0].tolist() == [[7.0], [8.0]]
+
+    # A mask-only row owns no features, so it still gets an empty state to keep
+    # its slot in the batch.
+    mask_only = {"inputs_embeds": mx.zeros((1, 4, 1)), "visual_pos_masks": masks}
+    filled = mc._pad_qwen3_prompt_rows([mask_only, compact_row])[0]
+    assert not filled[mc._QWEN3_VISUAL_STATE_KEY].any().item()

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -4010,3 +4010,73 @@ def test_qwen3_cache_offsets_accepts_declared_none_left_padding():
 
     cache = [types.SimpleNamespace(offset=0, left_padding=None)]
     assert mc._qwen3_cache_offsets(cache, batch_size=1) == ((0,), (0,))
+
+
+def test_qwen3_prompt_rows_keep_a_slot_for_text_only_rows():
+    """A text-only row in a mixed batch must not vacate its batch position."""
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    masks = mx.array([[0, 0, 1, 1, 0, 0]], dtype=mx.bool_)
+    state, positions = mc._pack_qwen3_visual_state(
+        masks, [mx.array([[1.0], [2.0]]), mx.array([[3.0], [4.0]])]
+    )
+    text_row = {"inputs_embeds": mx.zeros((1, 4, 1))}
+    visual_row = {
+        "inputs_embeds": mx.zeros((1, 6, 1)),
+        "visual_pos_masks": masks,
+        mc._QWEN3_VISUAL_STATE_KEY: state,
+        mc._QWEN3_VISUAL_POSITIONS_KEY: positions,
+    }
+
+    padded = mc._pad_qwen3_prompt_rows([text_row, visual_row])
+
+    # mlx-vlm concatenates an optional prompt key only over the rows that carry
+    # it, so an absent row slides every later row onto the wrong batch entry.
+    assert all(
+        row.get(mc._QWEN3_VISUAL_STATE_KEY) is not None
+        and row.get(mc._QWEN3_VISUAL_POSITIONS_KEY) is not None
+        and row.get("visual_pos_masks") is not None
+        for row in padded
+    ), "a text-only row must still carry an empty visual state, positions and mask"
+
+    empty_state = padded[0][mc._QWEN3_VISUAL_STATE_KEY]
+    assert tuple(empty_state.shape) == tuple(state.shape)
+    assert float(mx.abs(empty_state).max().item()) == 0.0
+    assert padded[0][mc._QWEN3_VISUAL_POSITIONS_KEY].tolist() == [[-1, -1]]
+    # The synthesized mask spans the row's own prompt so mlx-vlm's
+    # sequence-aligned left padding still recognizes and pads it.
+    assert tuple(padded[0]["visual_pos_masks"].shape) == (1, 4)
+    assert padded[0]["visual_pos_masks"].tolist() == [[False, False, False, False]]
+
+    # The visual row is untouched.
+    assert padded[1][mc._QWEN3_VISUAL_POSITIONS_KEY].tolist() == positions.tolist()
+    assert padded[1]["visual_pos_masks"].tolist() == masks.tolist()
+
+
+def test_qwen3_prompt_rows_left_alone_without_any_visual_row():
+    """Text-only batches keep mlx-vlm's original prompt kwargs untouched."""
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    rows = [{"inputs_embeds": mx.zeros((1, 4, 1))}, {"inputs_embeds": mx.zeros((1, 5, 1))}]
+    assert mc._pad_qwen3_prompt_rows(rows) is rows
+
+
+def test_qwen3_prompt_rows_defer_to_the_native_deepstack_path():
+    """A row still on mlx-vlm's own deepstack keys is left exactly as it is."""
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    masks = mx.array([[0, 1, 1, 0]], dtype=mx.bool_)
+    state, positions = mc._pack_qwen3_visual_state(masks, [mx.array([[1.0], [2.0]])])
+    compact_row = {
+        "inputs_embeds": mx.zeros((1, 4, 1)),
+        "visual_pos_masks": masks,
+        mc._QWEN3_VISUAL_STATE_KEY: state,
+        mc._QWEN3_VISUAL_POSITIONS_KEY: positions,
+    }
+    native_row = {"inputs_embeds": mx.zeros((1, 4, 1)), "visual_pos_masks": masks}
+
+    rows = [native_row, compact_row]
+    assert mc._pad_qwen3_prompt_rows(rows) is rows

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2955,111 +2955,10 @@ def test_qwen3_visual_window_preserves_batched_row_ownership():
     assert packed.shape == (2, 3, 1, 1)
     assert positions.tolist() == [[1, 2, 4], [0, 2, 3]]
     window_masks, window_embeds = mc._qwen3_visual_window(
-        masks,
-        packed,
-        positions,
-        mask_offsets=(1, 1),
-        feature_offsets=(1, 1),
-        window=2,
+        masks, packed, positions, mask_offsets=(1, 1), feature_offsets=(1, 1), window=2
     )
     assert window_masks.tolist() == [[1, 1], [0, 1]]
     assert window_embeds[0].tolist() == [[10], [11], [21]]
-    padded_window_masks = mx.array([[0, 0, 0, 0], [1, 0, 0, 0]], dtype=mx.bool_)
-    future_masks = mx.array([[0, 0, 1, 1], [1, 0, 0, 0]], dtype=mx.bool_)
-    future_state, future_positions = mc._pack_qwen3_visual_state(
-        future_masks,
-        [mx.array([[10], [11], [20]])],
-    )
-    _, current_embeds = mc._qwen3_visual_window(
-        padded_window_masks,
-        future_state,
-        future_positions,
-        mask_offsets=(0, 0),
-        feature_offsets=(-2, 0),
-        window=4,
-    )
-    assert current_embeds[0].tolist() == [[20]]
-    calls = []
-
-    def make_features():
-        features = types.SimpleNamespace(visual_pos_masks=masks[:1], deepstack_visual_embeds=[embeds[0][:3]])
-        features.to_dict = lambda: {
-            "visual_pos_masks": features.visual_pos_masks,
-            "deepstack_visual_embeds": features.deepstack_visual_embeds,
-        }
-        return features
-
-    def installed(self, input_ids=None, pixel_values=None, **kwargs):
-        calls.append("installed")
-        return types.SimpleNamespace(
-            visual_pos_masks=masks[:1],
-            deepstack_visual_embeds=None,
-        )
-
-    def replacement(self, input_ids=None, pixel_values=None, **kwargs):
-        calls.append("replacement")
-        return make_features()
-
-    adapted = mc._qwen3_batch_embedding_adapter(
-        installed,
-        replacement,
-        replace_visual_inference=True,
-    )
-    native_training = adapted(types.SimpleNamespace(training=True), pixel_values=object()); training_features = adapted(types.SimpleNamespace(training=True), pixel_values=object(), position_ids=object())
-    assert native_training.deepstack_visual_embeds is None and isinstance(training_features.deepstack_visual_embeds, list) and "_unsloth_qwen3_visual_state" not in training_features.to_dict()
-
-    repaired = adapted(
-        types.SimpleNamespace(training=False),
-        pixel_values=object(),
-    )
-    assert calls == ["installed", "replacement", "replacement"]
-    repaired_values = repaired.to_dict()
-    assert repaired_values["deepstack_visual_embeds"] is None
-    assert repaired_values["_unsloth_qwen3_visual_state"].shape == (1, 3, 1, 1)
-    assert repaired_values["_unsloth_qwen3_visual_positions"].tolist() == [[1, 2, 4]]
-    assert adapted.__wrapped__ is installed
-    assert mc._qwen3_batch_embedding_adapter(adapted) is adapted
-
-    merged_prompt_kwargs = []
-
-    def merge_prompt_kwargs(rows, input_ids):
-        merged_prompt_kwargs.extend(rows)
-        return None, {}
-
-    prompt_rows = [
-        {
-            "_unsloth_qwen3_visual_state": packed[:1, :1],
-            "_unsloth_qwen3_visual_positions": positions[:1, :1],
-        },
-        {
-            "_unsloth_qwen3_visual_state": packed[1:2],
-            "_unsloth_qwen3_visual_positions": positions[1:2],
-        },
-    ]
-    merge_adapter = mc._qwen3_prompt_merge_adapter(merge_prompt_kwargs)
-    merge_adapter(prompt_rows, [[1], [2]])
-    assert merged_prompt_kwargs[0]["_unsloth_qwen3_visual_state"].shape == (
-        1,
-        3,
-        1,
-        1,
-    )
-    assert merged_prompt_kwargs[0]["_unsloth_qwen3_visual_positions"].tolist() == [
-        [1, -1, -1]
-    ]
-    mixed_prompt_batches = []
-
-    def build_mixed_prompt_batch(self, sequences):
-        mixed_prompt_batches.append(sequences)
-
-    mixed_adapter = mc._qwen3_mixed_prompt_batch_adapter(build_mixed_prompt_batch)
-    mixed_adapter(
-        object(),
-        [(1, [1], 1, prompt_rows[0], None), (2, [2], 1, prompt_rows[1], None)],
-    )
-    assert mixed_prompt_batches[0][0][3][
-        "_unsloth_qwen3_visual_state"
-    ].shape == (1, 3, 1, 1)
 
     def drops_deepstack(self):
         deepstack_visual_embeds = mx.eval([])
@@ -3099,23 +2998,22 @@ def test_qwen3_visual_window_preserves_batched_row_ownership():
         mx.zeros((1, 2)),
         cache=[types.SimpleNamespace(offset=1, left_padding=0)],
         visual_pos_masks=masks[:1],
-        deepstack_visual_embeds=repaired_values["deepstack_visual_embeds"],
-        _unsloth_qwen3_visual_state=repaired_values[
-            "_unsloth_qwen3_visual_state"
-        ],
-        _unsloth_qwen3_visual_positions=repaired_values[
-            "_unsloth_qwen3_visual_positions"
-        ],
+        deepstack_visual_embeds=None,
+        _unsloth_qwen3_visual_state=packed[:1],
+        _unsloth_qwen3_visual_positions=positions[:1],
     )
     assert language_calls[0][0].tolist() == [[1, 1]]
     assert language_calls[0][1][0].tolist() == [[10], [11]]
 
 
-def test_qwen_video_tensor_adapter_is_exact_and_composable(monkeypatch):
+def test_qwen_video_tensor_adapter_is_exact_and_composable():
     from functools import wraps
+
     import mlx.core as mx
     import unsloth_zoo.mlx.compile as mc
+
     calls = []
+
     def legacy(self, input_ids=None, pixel_values=None, **kwargs):
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
@@ -3125,18 +3023,24 @@ def test_qwen_video_tensor_adapter_is_exact_and_composable(monkeypatch):
             return ("text", grid_thw, mask)
         calls.append((input_ids, pixel_values, kwargs))
         return pixel_values
+
     video, image = object(), object()
     adapted = mc._qwen_video_tensor_adapter(legacy)
     assert adapted(object(), 1, pixel_values_videos=video, video_grid_thw=2) is video
-    assert adapted(object(), 1, image, pixel_values_videos=video, video_grid_thw=2) is image
-    assert calls == [(1, video, {"pixel_values_videos": video, "video_grid_thw": 2}), (1, image, {"pixel_values_videos": video, "video_grid_thw": 2})]
-    assert adapted.__wrapped__ is legacy and mc._qwen_video_tensor_adapter(adapted) is adapted
+    assert adapted(
+        object(), 1, image, pixel_values_videos=video, video_grid_thw=2
+    ) is image
+    expected_kwargs = {"pixel_values_videos": video, "video_grid_thw": 2}
+    assert calls == [(1, video, expected_kwargs), (1, image, expected_kwargs)]
+    assert adapted.__wrapped__ is legacy
+    assert mc._qwen_video_tensor_adapter(adapted) is adapted
 
     def fixed(self, input_ids=None, pixel_values=None, **kwargs):
         if pixel_values is None:
             pixel_values = kwargs.get("pixel_values_videos", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         return pixel_values, video_grid_thw
+
     assert mc._qwen_video_tensor_adapter(fixed) is fixed
 
     def unknown(self, input_ids=None, pixel_values=None, **kwargs):
@@ -3144,13 +3048,17 @@ def test_qwen_video_tensor_adapter_is_exact_and_composable(monkeypatch):
         if pixel_values is None:
             kwargs.pop("pixel_values_videos", None)
             return ("text", video_grid_thw)
+
     assert mc._qwen_video_tensor_adapter(unknown) is unknown
+
     def unreachable(self, input_ids=None, pixel_values=None, **kwargs):
         video_grid_thw = kwargs.get("video_grid_thw", None)
         if pixel_values is None:
             return video_grid_thw
             pixel_values = kwargs.get("pixel_values_videos", None)
+
     assert not mc._qwen_video_contract_matches(unreachable, "fixed")
+
     def unreachable_guard(self, input_ids=None, pixel_values=None, **kwargs):
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
@@ -3159,7 +3067,9 @@ def test_qwen_video_tensor_adapter_is_exact_and_composable(monkeypatch):
         return grid_thw, mask
         if pixel_values is None:
             pixel_values = kwargs.get("pixel_values_videos", None)
-    assert not mc._qwen_video_contract_matches(unreachable_guard, "fixed") and not mc._qwen_video_contract_matches(unreachable_guard, "legacy")
+
+    assert not mc._qwen_video_contract_matches(unreachable_guard, "fixed")
+    assert not mc._qwen_video_contract_matches(unreachable_guard, "legacy")
 
     @wraps(legacy)
     def keyword_outer(self, *, input_ids=None, pixel_values=None, **kwargs):
@@ -3169,8 +3079,10 @@ def test_qwen_video_tensor_adapter_is_exact_and_composable(monkeypatch):
             pixel_values=pixel_values,
             **kwargs,
         )
+
     composed = mc._qwen_video_tensor_adapter(keyword_outer)
     assert composed(object(), input_ids=3, pixel_values_videos=video) is video
+
 
     def staged_legacy(self, input_ids=None, pixel_values=None, **kwargs):
         image_grid_thw = kwargs.get("image_grid_thw", None)
@@ -3179,23 +3091,33 @@ def test_qwen_video_tensor_adapter_is_exact_and_composable(monkeypatch):
         grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
         if pixel_values is None:
             return grid_thw, mask, mx.eval([])
-    staged = mc._qwen3_batch_embedding_adapter(staged_legacy, replace_visual_inference=True)
+
+    staged = mc._qwen3_batch_embedding_adapter(
+        staged_legacy, replace_visual_inference=True
+    )
     assert mc._qwen_video_tensor_adapter(staged) is not staged
-    replacing_stage = mc._qwen3_batch_embedding_adapter(staged_legacy, fixed, replace_visual_inference=True)
-    assert mc._qwen_video_tensor_adapter(replacing_stage) is replacing_stage
-    owner = type("LegacyQwen", (), {"get_input_embeddings": legacy})
-    monkeypatch.setattr(mc, "_PATCH_BINDINGS", set())
-    mc._patch_qwen_video_tensor(owner)
-    assert owner.get_input_embeddings._unsloth_qwen_video_tensor
+    replacing = mc._qwen3_batch_embedding_adapter(
+        staged_legacy, fixed, replace_visual_inference=True
+    )
+    assert mc._qwen_video_tensor_adapter(replacing) is replacing
 
 
-def test_qwen_video_tensor_installer_has_exact_owners(monkeypatch):
+def test_qwen_installers_bind_exact_release_owners(monkeypatch):
     import unsloth_zoo.mlx.compile as mc
-    expected = ("mlx_vlm.models.qwen2_vl.qwen2_vl", "mlx_vlm.models.qwen2_5_vl.qwen2_5_vl",
-                "mlx_vlm.models.qwen3_5.qwen3_5", "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe")
+
+    expected = (
+        "mlx_vlm.models.qwen2_vl.qwen2_vl",
+        "mlx_vlm.models.qwen2_5_vl.qwen2_5_vl",
+        "mlx_vlm.models.qwen3_5.qwen3_5",
+        "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe",
+    )
     assert mc._QWEN_VIDEO_TENSOR_OWNER_MODULES == expected
-    owners = {name: type(name, (), {"get_input_embeddings": lambda self: None}) for name in expected}
+    owners = {
+        name: type(name, (), {"get_input_embeddings": lambda self: None})
+        for name in expected
+    }
     patched, imported = [], []
+
     def import_module(module_name):
         imported.append(module_name)
         return types.SimpleNamespace(Model=owners[module_name])
@@ -3205,12 +3127,79 @@ def test_qwen_video_tensor_installer_has_exact_owners(monkeypatch):
     mc._install_qwen_video_tensor_patches()
     assert imported == list(expected)
     assert patched == [owners[module_name] for module_name in expected]
-    assert "mlx_vlm.models.qwen3_vl.qwen3_vl" not in imported
-    monkeypatch.setattr(mc.importlib, "import_module", lambda _: types.SimpleNamespace()); mc._install_qwen_video_tensor_patches()
+
+    method_names = (
+        "__call__", "_deepstack_process", "get_input_embeddings",
+        "merge_input_ids_with_image_features", "rot_pos_emb",
+        "fast_pos_embed_interpolate", "_build_mixed_prompt_batch",
+    )
+
+    def owner(name):
+        methods = {
+            key: lambda *_args, _name=f"{name}.{key}", **_kwargs: _name
+            for key in method_names
+        }
+        methods["merge_input_ids_with_image_features"] = staticmethod(
+            methods["merge_input_ids_with_image_features"]
+        )
+        return type(name, (), methods)
+
+    dense_model, dense_language = owner("DenseModel"), owner("DenseLanguage")
+    moe_model, moe_language = owner("MoeModel"), owner("MoeLanguage")
+    cold_batch, apc_batch = owner("ColdBatch"), owner("ApcBatch")
+    vision = types.SimpleNamespace(
+        Attention=owner("Attention"),
+        Qwen3VLMoEVisionBlock=owner("VisionBlock"),
+        VisionModel=owner("VisionModel"),
+    )
+    namespace = types.SimpleNamespace
+    generate = namespace(
+        _merge_prefill_prompt_kwargs=cold_batch.get_input_embeddings,
+        BatchGenerator=cold_batch,
+    )
+    generate_ar = namespace(
+        _merge_prefill_prompt_kwargs=apc_batch.get_input_embeddings,
+        BatchGenerator=apc_batch,
+    )
+    modules = {
+        "mlx_vlm.models.qwen3_vl.qwen3_vl": namespace(Model=dense_model),
+        "mlx_vlm.models.qwen3_vl.vision": vision,
+        "mlx_vlm.models.qwen3_5.qwen3_5": namespace(Model=owner("Qwen35")),
+        "mlx_vlm.models.qwen3_vl.language": namespace(
+            Qwen3VLModel=owner("DenseBackbone"), LanguageModel=dense_language),
+        "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe": namespace(Model=moe_model),
+        "mlx_vlm.models.qwen3_vl_moe.vision": vision,
+        "mlx_vlm.models.qwen3_vl_moe.language": namespace(
+            Qwen3VLMoEModel=owner("MoeBackbone"), LanguageModel=moe_language),
+        "mlx_vlm.generate": generate,
+        "mlx_vlm.generate.ar": generate_ar,
+    }
+    bindings = (
+        (dense_model, "get_input_embeddings", "_unsloth_qwen3_batch_visual_state"),
+        (moe_model, "get_input_embeddings", "_unsloth_qwen3_batch_visual_state"),
+        (dense_language, "__call__", "_unsloth_qwen3_visual_state"),
+        (moe_language, "__call__", "_unsloth_qwen3_visual_state"),
+        (cold_batch, "_build_mixed_prompt_batch", "_unsloth_qwen3_mixed_prompt_batch"),
+        (apc_batch, "_build_mixed_prompt_batch", "_unsloth_qwen3_mixed_prompt_batch"),
+        (generate, "_merge_prefill_prompt_kwargs", "_unsloth_qwen3_prompt_merge"),
+        (generate_ar, "_merge_prefill_prompt_kwargs", "_unsloth_qwen3_prompt_merge"),
+    )
+    originals = [getattr(owner, name) for owner, name, _marker in bindings]
+    monkeypatch.setattr(mc.importlib, "import_module", modules.__getitem__)
+    monkeypatch.setattr(mc, "_PATCHED_ARCHES", set())
+    monkeypatch.setattr(mc, "_PATCH_BINDINGS", set())
+    mc._install_qwen3_family_compile_patches()
+    for (owner, name, marker), original in zip(bindings, originals):
+        wrapped = getattr(owner, name)
+        assert getattr(wrapped, marker)
+        assert wrapped.__wrapped__ is original
     called = []
-    monkeypatch.setattr(mc, "_PATCHES_INSTALLED", False); monkeypatch.setattr(mc, "_PATCHED_PATTERN_BUNDLES", set())
-    monkeypatch.setattr(mc, "_install_safe_fused_sdpa_mask_patches", lambda: None); monkeypatch.setattr(mc, "list_compile_pattern_bundles", lambda: ())
-    monkeypatch.setattr(mc, "_install_qwen_video_tensor_patches", lambda: called.append(True)); monkeypatch.setattr(mc, "_invalidate_qualification_cache", lambda: None)
+    monkeypatch.setattr(mc, "_PATCHES_INSTALLED", False)
+    monkeypatch.setattr(mc, "_PATCHED_PATTERN_BUNDLES", set())
+    monkeypatch.setattr(mc, "_install_safe_fused_sdpa_mask_patches", lambda: None)
+    monkeypatch.setattr(mc, "list_compile_pattern_bundles", lambda: ())
+    monkeypatch.setattr(mc, "_install_qwen_video_tensor_patches", lambda: called.append(True))
+    monkeypatch.setattr(mc, "_invalidate_qualification_cache", lambda: None)
     monkeypatch.setattr(mc, "build_compile_qualifications", lambda: {})
     assert mc.install_mlx_compile_patches() == {} and called == [True]
 
@@ -3218,12 +3207,7 @@ def test_qwen_video_tensor_installer_has_exact_owners(monkeypatch):
 def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
     import mlx.core as mx
     import unsloth_zoo.mlx.compile as mc
-    upstream = lambda self, input_ids=None, pixel_values=None, **kwargs: "upstream"; owner = lambda name: type(name, (), {key: (staticmethod(lambda *_args, _name=name, **_kwargs: _name) if key == "merge_input_ids_with_image_features" else lambda *_args, _name=f"{name}.{key}", **_kwargs: _name) for key in ("__call__", "_deepstack_process", "get_input_embeddings", "merge_input_ids_with_image_features", "rot_pos_emb", "fast_pos_embed_interpolate", "_build_mixed_prompt_batch")})
-    dense_model, dense_language, moe_model, moe_language, cold_batch, apc_batch = (owner(name) for name in ("DenseModel", "DenseLanguage", "MoeModel", "MoeLanguage", "ColdBatch", "ApcBatch")); vision = types.SimpleNamespace(Attention=owner("Attention"), Qwen3VLMoEVisionBlock=owner("VisionBlock"), VisionModel=owner("VisionModel"))
-    modules = {"mlx_vlm.models.qwen3_vl.qwen3_vl": types.SimpleNamespace(Model=dense_model), "mlx_vlm.models.qwen3_vl.vision": vision, "mlx_vlm.models.qwen3_5.qwen3_5": types.SimpleNamespace(Model=owner("Qwen35Model")), "mlx_vlm.models.qwen3_vl.language": types.SimpleNamespace(Qwen3VLModel=owner("DenseBackbone"), LanguageModel=dense_language), "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe": types.SimpleNamespace(Model=moe_model), "mlx_vlm.models.qwen3_vl_moe.vision": vision, "mlx_vlm.models.qwen3_vl_moe.language": types.SimpleNamespace(Qwen3VLMoEModel=owner("MoeBackbone"), LanguageModel=moe_language), "mlx_vlm.generate": types.SimpleNamespace(_merge_prefill_prompt_kwargs=cold_batch.get_input_embeddings, BatchGenerator=cold_batch), "mlx_vlm.generate.ar": types.SimpleNamespace(_merge_prefill_prompt_kwargs=apc_batch.get_input_embeddings, BatchGenerator=apc_batch)}
-    monkeypatch.setattr(mc.importlib, "import_module", modules.__getitem__); monkeypatch.setattr(mc, "_PATCHED_ARCHES", set()); monkeypatch.setattr(mc, "_PATCH_BINDINGS", set())
-    originals = (dense_model.get_input_embeddings, moe_model.get_input_embeddings, dense_language.__call__, moe_language.__call__, cold_batch._build_mixed_prompt_batch, apc_batch._build_mixed_prompt_batch, modules["mlx_vlm.generate"]._merge_prefill_prompt_kwargs, modules["mlx_vlm.generate.ar"]._merge_prefill_prompt_kwargs); mc._install_qwen3_family_compile_patches()
-    assert all((dense_model.get_input_embeddings._unsloth_qwen3_batch_visual_state, moe_model.get_input_embeddings._unsloth_qwen3_batch_visual_state, dense_language.__call__._unsloth_qwen3_visual_state, moe_language.__call__._unsloth_qwen3_visual_state, cold_batch._build_mixed_prompt_batch._unsloth_qwen3_mixed_prompt_batch, apc_batch._build_mixed_prompt_batch._unsloth_qwen3_mixed_prompt_batch, modules["mlx_vlm.generate"]._merge_prefill_prompt_kwargs._unsloth_qwen3_prompt_merge, modules["mlx_vlm.generate.ar"]._merge_prefill_prompt_kwargs._unsloth_qwen3_prompt_merge)) and tuple(fn.__wrapped__ for fn in (dense_model.get_input_embeddings, moe_model.get_input_embeddings, dense_language.__call__, moe_language.__call__, cold_batch._build_mixed_prompt_batch, apc_batch._build_mixed_prompt_batch, modules["mlx_vlm.generate"]._merge_prefill_prompt_kwargs, modules["mlx_vlm.generate.ar"]._merge_prefill_prompt_kwargs)) == originals
+    upstream = lambda self, input_ids=None, pixel_values=None, **kwargs: "upstream"
     replacement = lambda self, input_ids=None, pixel_values=None, **kwargs: "replacement"
     adapted = mc._explicit_position_embedding_adapter(upstream, replacement)
     assert adapted(types.SimpleNamespace(training=True)) == "upstream"

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2534,10 +2534,185 @@ def test_qwen3_vl_training_compile_verified():
     assert "qwen3_vl_moe" in mc._VERIFIED_TRAINING_ARCHES
 
 
+def test_qwen3_visual_window_preserves_batched_row_ownership():
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+
+    masks = mx.array([[0, 1, 1, 0, 1, 0], [1, 0, 1, 1, 0, 0]], dtype=mx.bool_)
+    embeds = [mx.array([[10], [11], [12], [20], [21], [22]])]
+
+    padded_cache = [types.SimpleNamespace(offset=mx.array([0, -2]), left_padding=mx.array([0, 2]))]
+    assert mc._qwen3_cache_offsets(padded_cache, batch_size=2) == ((0, -2), (0, 0))
+
+    packed, positions = mc._pack_qwen3_visual_state(masks, embeds)
+    assert packed.shape == (2, 3, 1, 1)
+    assert positions.tolist() == [[1, 2, 4], [0, 2, 3]]
+    window_masks, window_embeds = mc._qwen3_visual_window(
+        masks,
+        packed,
+        positions,
+        mask_offsets=(1, 1),
+        feature_offsets=(1, 1),
+        window=2,
+    )
+    assert window_masks.tolist() == [[1, 1], [0, 1]]
+    assert window_embeds[0].tolist() == [[10], [11], [21]]
+    padded_window_masks = mx.array([[0, 0, 0, 0], [1, 0, 0, 0]], dtype=mx.bool_)
+    future_masks = mx.array([[0, 0, 1, 1], [1, 0, 0, 0]], dtype=mx.bool_)
+    future_state, future_positions = mc._pack_qwen3_visual_state(
+        future_masks,
+        [mx.array([[10], [11], [20]])],
+    )
+    _, current_embeds = mc._qwen3_visual_window(
+        padded_window_masks,
+        future_state,
+        future_positions,
+        mask_offsets=(0, 0),
+        feature_offsets=(-2, 0),
+        window=4,
+    )
+    assert current_embeds[0].tolist() == [[20]]
+    calls = []
+
+    def make_features():
+        features = types.SimpleNamespace(visual_pos_masks=masks[:1], deepstack_visual_embeds=[embeds[0][:3]])
+        features.to_dict = lambda: {
+            "visual_pos_masks": features.visual_pos_masks,
+            "deepstack_visual_embeds": features.deepstack_visual_embeds,
+        }
+        return features
+
+    def installed(self, input_ids=None, pixel_values=None, **kwargs):
+        calls.append("installed")
+        return types.SimpleNamespace(
+            visual_pos_masks=masks[:1],
+            deepstack_visual_embeds=None,
+        )
+
+    def replacement(self, input_ids=None, pixel_values=None, **kwargs):
+        calls.append("replacement")
+        return make_features()
+
+    adapted = mc._qwen3_batch_embedding_adapter(
+        installed,
+        replacement,
+        replace_visual_inference=True,
+    )
+    native_training = adapted(types.SimpleNamespace(training=True), pixel_values=object()); training_features = adapted(types.SimpleNamespace(training=True), pixel_values=object(), position_ids=object())
+    assert native_training.deepstack_visual_embeds is None and isinstance(training_features.deepstack_visual_embeds, list) and "_unsloth_qwen3_visual_state" not in training_features.to_dict()
+
+    repaired = adapted(
+        types.SimpleNamespace(training=False),
+        pixel_values=object(),
+    )
+    assert calls == ["installed", "replacement", "replacement"]
+    repaired_values = repaired.to_dict()
+    assert repaired_values["deepstack_visual_embeds"] is None
+    assert repaired_values["_unsloth_qwen3_visual_state"].shape == (1, 3, 1, 1)
+    assert repaired_values["_unsloth_qwen3_visual_positions"].tolist() == [[1, 2, 4]]
+    assert adapted.__wrapped__ is installed
+    assert mc._qwen3_batch_embedding_adapter(adapted) is adapted
+
+    merged_prompt_kwargs = []
+
+    def merge_prompt_kwargs(rows, input_ids):
+        merged_prompt_kwargs.extend(rows)
+        return None, {}
+
+    prompt_rows = [
+        {
+            "_unsloth_qwen3_visual_state": packed[:1, :1],
+            "_unsloth_qwen3_visual_positions": positions[:1, :1],
+        },
+        {
+            "_unsloth_qwen3_visual_state": packed[1:2],
+            "_unsloth_qwen3_visual_positions": positions[1:2],
+        },
+    ]
+    merge_adapter = mc._qwen3_prompt_merge_adapter(merge_prompt_kwargs)
+    merge_adapter(prompt_rows, [[1], [2]])
+    assert merged_prompt_kwargs[0]["_unsloth_qwen3_visual_state"].shape == (
+        1,
+        3,
+        1,
+        1,
+    )
+    assert merged_prompt_kwargs[0]["_unsloth_qwen3_visual_positions"].tolist() == [
+        [1, -1, -1]
+    ]
+    mixed_prompt_batches = []
+
+    def build_mixed_prompt_batch(self, sequences):
+        mixed_prompt_batches.append(sequences)
+
+    mixed_adapter = mc._qwen3_mixed_prompt_batch_adapter(build_mixed_prompt_batch)
+    mixed_adapter(
+        object(),
+        [(1, [1], 1, prompt_rows[0], None), (2, [2], 1, prompt_rows[1], None)],
+    )
+    assert mixed_prompt_batches[0][0][3][
+        "_unsloth_qwen3_visual_state"
+    ].shape == (1, 3, 1, 1)
+
+    def drops_deepstack(self):
+        deepstack_visual_embeds = mx.eval([])
+        return deepstack_visual_embeds
+
+    assert mc._qwen3_drops_deepstack_after_eval(drops_deepstack)
+
+    language_calls = []
+
+    def native_language(
+        self,
+        inputs,
+        inputs_embeds=None,
+        mask=None,
+        cache=None,
+        visual_pos_masks=None,
+        deepstack_visual_embeds=None,
+        **kwargs,
+    ):
+        if visual_pos_masks.shape[-1] != inputs.shape[-1]:
+            start = int(cache[0].offset)
+            window = inputs.shape[1]
+            n_before = int(visual_pos_masks[:, :start].sum().item())
+            n_window = int(
+                visual_pos_masks[:, start : start + window].sum().item()
+            )
+            deepstack_visual_embeds = [
+                layer[n_before : n_before + n_window]
+                for layer in deepstack_visual_embeds
+            ]
+            visual_pos_masks = visual_pos_masks[:, start : start + window]
+        language_calls.append((visual_pos_masks, deepstack_visual_embeds))
+
+    language_adapter = mc._qwen3_visual_state_adapter(native_language)
+    language_adapter(
+        object(),
+        mx.zeros((1, 2)),
+        cache=[types.SimpleNamespace(offset=1, left_padding=0)],
+        visual_pos_masks=masks[:1],
+        deepstack_visual_embeds=repaired_values["deepstack_visual_embeds"],
+        _unsloth_qwen3_visual_state=repaired_values[
+            "_unsloth_qwen3_visual_state"
+        ],
+        _unsloth_qwen3_visual_positions=repaired_values[
+            "_unsloth_qwen3_visual_positions"
+        ],
+    )
+    assert language_calls[0][0].tolist() == [[1, 1]]
+    assert language_calls[0][1][0].tolist() == [[10], [11]]
+
+
 def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
     import mlx.core as mx
     import unsloth_zoo.mlx.compile as mc
-    upstream = lambda self, input_ids=None, pixel_values=None, **kwargs: "upstream"
+    upstream = lambda self, input_ids=None, pixel_values=None, **kwargs: "upstream"; owner = lambda name: type(name, (), {key: (staticmethod(lambda *_args, _name=name, **_kwargs: _name) if key == "merge_input_ids_with_image_features" else lambda *_args, _name=f"{name}.{key}", **_kwargs: _name) for key in ("__call__", "_deepstack_process", "get_input_embeddings", "merge_input_ids_with_image_features", "rot_pos_emb", "fast_pos_embed_interpolate", "_build_mixed_prompt_batch")})
+    dense_model, dense_language, moe_model, moe_language, cold_batch, apc_batch = (owner(name) for name in ("DenseModel", "DenseLanguage", "MoeModel", "MoeLanguage", "ColdBatch", "ApcBatch")); vision = types.SimpleNamespace(Attention=owner("Attention"), Qwen3VLMoEVisionBlock=owner("VisionBlock"), VisionModel=owner("VisionModel"))
+    modules = {"mlx_vlm.models.qwen3_vl.qwen3_vl": types.SimpleNamespace(Model=dense_model), "mlx_vlm.models.qwen3_vl.vision": vision, "mlx_vlm.models.qwen3_5.qwen3_5": types.SimpleNamespace(Model=owner("Qwen35Model")), "mlx_vlm.models.qwen3_vl.language": types.SimpleNamespace(Qwen3VLModel=owner("DenseBackbone"), LanguageModel=dense_language), "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe": types.SimpleNamespace(Model=moe_model), "mlx_vlm.models.qwen3_vl_moe.vision": vision, "mlx_vlm.models.qwen3_vl_moe.language": types.SimpleNamespace(Qwen3VLMoEModel=owner("MoeBackbone"), LanguageModel=moe_language), "mlx_vlm.generate": types.SimpleNamespace(_merge_prefill_prompt_kwargs=cold_batch.get_input_embeddings, BatchGenerator=cold_batch), "mlx_vlm.generate.ar": types.SimpleNamespace(_merge_prefill_prompt_kwargs=apc_batch.get_input_embeddings, BatchGenerator=apc_batch)}
+    monkeypatch.setattr(mc.importlib, "import_module", modules.__getitem__); monkeypatch.setattr(mc, "_PATCHED_ARCHES", set()); monkeypatch.setattr(mc, "_PATCH_BINDINGS", set())
+    originals = (dense_model.get_input_embeddings, moe_model.get_input_embeddings, dense_language.__call__, moe_language.__call__, cold_batch._build_mixed_prompt_batch, apc_batch._build_mixed_prompt_batch, modules["mlx_vlm.generate"]._merge_prefill_prompt_kwargs, modules["mlx_vlm.generate.ar"]._merge_prefill_prompt_kwargs); mc._install_qwen3_family_compile_patches()
+    assert all((dense_model.get_input_embeddings._unsloth_qwen3_batch_visual_state, moe_model.get_input_embeddings._unsloth_qwen3_batch_visual_state, dense_language.__call__._unsloth_qwen3_visual_state, moe_language.__call__._unsloth_qwen3_visual_state, cold_batch._build_mixed_prompt_batch._unsloth_qwen3_mixed_prompt_batch, apc_batch._build_mixed_prompt_batch._unsloth_qwen3_mixed_prompt_batch, modules["mlx_vlm.generate"]._merge_prefill_prompt_kwargs._unsloth_qwen3_prompt_merge, modules["mlx_vlm.generate.ar"]._merge_prefill_prompt_kwargs._unsloth_qwen3_prompt_merge)) and tuple(fn.__wrapped__ for fn in (dense_model.get_input_embeddings, moe_model.get_input_embeddings, dense_language.__call__, moe_language.__call__, cold_batch._build_mixed_prompt_batch, apc_batch._build_mixed_prompt_batch, modules["mlx_vlm.generate"]._merge_prefill_prompt_kwargs, modules["mlx_vlm.generate.ar"]._merge_prefill_prompt_kwargs)) == originals
     replacement = lambda self, input_ids=None, pixel_values=None, **kwargs: "replacement"
     adapted = mc._explicit_position_embedding_adapter(upstream, replacement)
     assert adapted(types.SimpleNamespace(training=True)) == "upstream"

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2725,6 +2725,38 @@ def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
     assert mc._gemma3n_cache_offset([types.SimpleNamespace(offset=mx.array([650, 700]), _idx=188)]) == 700
 
 
+def test_legacy_llava_prefill_adapter_is_signature_gated(monkeypatch):
+    import unsloth_zoo.mlx.compile as mc
+
+    calls = []
+
+    def strict(self, inputs, cache=None):
+        calls.append((inputs, cache))
+        return "strict"
+
+    class LegacyLanguage:
+        __call__ = strict
+
+    module = types.SimpleNamespace(LanguageModel=LegacyLanguage)
+    monkeypatch.setattr(mc.importlib, "import_module", lambda name: module)
+    mc._install_legacy_llava_prefill_patch()
+    inputs = object()
+    assert LegacyLanguage()(inputs, cache="cache", n_to_process=4) == "strict"
+    assert calls == [(inputs, "cache")]
+    assert LegacyLanguage.__call__.__wrapped__ is strict
+    assert mc._legacy_vlm_prefill_kwargs_adapter(LegacyLanguage.__call__) is LegacyLanguage.__call__
+    def explicit(self, inputs, n_to_process=None):
+        return n_to_process
+
+    @mc.wraps(strict)
+    def permissive(self, *args, **kwargs):
+        return kwargs
+    assert mc._legacy_vlm_prefill_kwargs_adapter(explicit) is explicit
+    assert mc._legacy_vlm_prefill_kwargs_adapter(permissive) is permissive
+    monkeypatch.setattr(mc.importlib, "import_module", lambda name: (_ for _ in ()).throw(RuntimeError))
+    mc._install_legacy_llava_prefill_patch()
+
+
 def test_quantized_cce_uses_layer_mode_and_affine_bias_guard():
     import inspect
     import unsloth_zoo.mlx.utils as mlx_utils

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -2704,6 +2704,110 @@ def test_qwen3_visual_window_preserves_batched_row_ownership():
     assert language_calls[0][1][0].tolist() == [[10], [11]]
 
 
+def test_qwen_video_tensor_adapter_is_exact_and_composable(monkeypatch):
+    from functools import wraps
+    import mlx.core as mx
+    import unsloth_zoo.mlx.compile as mc
+    calls = []
+    def legacy(self, input_ids=None, pixel_values=None, **kwargs):
+        image_grid_thw = kwargs.get("image_grid_thw", None)
+        video_grid_thw = kwargs.get("video_grid_thw", None)
+        mask = kwargs.get("mask", None)
+        grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
+        if pixel_values is None:
+            return ("text", grid_thw, mask)
+        calls.append((input_ids, pixel_values, kwargs))
+        return pixel_values
+    video, image = object(), object()
+    adapted = mc._qwen_video_tensor_adapter(legacy)
+    assert adapted(object(), 1, pixel_values_videos=video, video_grid_thw=2) is video
+    assert adapted(object(), 1, image, pixel_values_videos=video, video_grid_thw=2) is image
+    assert calls == [(1, video, {"pixel_values_videos": video, "video_grid_thw": 2}), (1, image, {"pixel_values_videos": video, "video_grid_thw": 2})]
+    assert adapted.__wrapped__ is legacy and mc._qwen_video_tensor_adapter(adapted) is adapted
+
+    def fixed(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
+        video_grid_thw = kwargs.get("video_grid_thw", None)
+        return pixel_values, video_grid_thw
+    assert mc._qwen_video_tensor_adapter(fixed) is fixed
+
+    def unknown(self, input_ids=None, pixel_values=None, **kwargs):
+        video_grid_thw = kwargs.get("video_grid_thw", None)
+        if pixel_values is None:
+            kwargs.pop("pixel_values_videos", None)
+            return ("text", video_grid_thw)
+    assert mc._qwen_video_tensor_adapter(unknown) is unknown
+    def unreachable(self, input_ids=None, pixel_values=None, **kwargs):
+        video_grid_thw = kwargs.get("video_grid_thw", None)
+        if pixel_values is None:
+            return video_grid_thw
+            pixel_values = kwargs.get("pixel_values_videos", None)
+    assert not mc._qwen_video_contract_matches(unreachable, "fixed")
+    def unreachable_guard(self, input_ids=None, pixel_values=None, **kwargs):
+        image_grid_thw = kwargs.get("image_grid_thw", None)
+        video_grid_thw = kwargs.get("video_grid_thw", None)
+        mask = kwargs.get("mask", None)
+        grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
+        return grid_thw, mask
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
+    assert not mc._qwen_video_contract_matches(unreachable_guard, "fixed") and not mc._qwen_video_contract_matches(unreachable_guard, "legacy")
+
+    @wraps(legacy)
+    def keyword_outer(self, *, input_ids=None, pixel_values=None, **kwargs):
+        return legacy(
+            self,
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            **kwargs,
+        )
+    composed = mc._qwen_video_tensor_adapter(keyword_outer)
+    assert composed(object(), input_ids=3, pixel_values_videos=video) is video
+
+    def staged_legacy(self, input_ids=None, pixel_values=None, **kwargs):
+        image_grid_thw = kwargs.get("image_grid_thw", None)
+        video_grid_thw = kwargs.get("video_grid_thw", None)
+        mask = kwargs.get("mask", None)
+        grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
+        if pixel_values is None:
+            return grid_thw, mask, mx.eval([])
+    staged = mc._qwen3_batch_embedding_adapter(staged_legacy, replace_visual_inference=True)
+    assert mc._qwen_video_tensor_adapter(staged) is not staged
+    replacing_stage = mc._qwen3_batch_embedding_adapter(staged_legacy, fixed, replace_visual_inference=True)
+    assert mc._qwen_video_tensor_adapter(replacing_stage) is replacing_stage
+    owner = type("LegacyQwen", (), {"get_input_embeddings": legacy})
+    monkeypatch.setattr(mc, "_PATCH_BINDINGS", set())
+    mc._patch_qwen_video_tensor(owner)
+    assert owner.get_input_embeddings._unsloth_qwen_video_tensor
+
+
+def test_qwen_video_tensor_installer_has_exact_owners(monkeypatch):
+    import unsloth_zoo.mlx.compile as mc
+    expected = ("mlx_vlm.models.qwen2_vl.qwen2_vl", "mlx_vlm.models.qwen2_5_vl.qwen2_5_vl",
+                "mlx_vlm.models.qwen3_5.qwen3_5", "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe")
+    assert mc._QWEN_VIDEO_TENSOR_OWNER_MODULES == expected
+    owners = {name: type(name, (), {"get_input_embeddings": lambda self: None}) for name in expected}
+    patched, imported = [], []
+    def import_module(module_name):
+        imported.append(module_name)
+        return types.SimpleNamespace(Model=owners[module_name])
+
+    monkeypatch.setattr(mc.importlib, "import_module", import_module)
+    monkeypatch.setattr(mc, "_patch_qwen_video_tensor", patched.append)
+    mc._install_qwen_video_tensor_patches()
+    assert imported == list(expected)
+    assert patched == [owners[module_name] for module_name in expected]
+    assert "mlx_vlm.models.qwen3_vl.qwen3_vl" not in imported
+    monkeypatch.setattr(mc.importlib, "import_module", lambda _: types.SimpleNamespace()); mc._install_qwen_video_tensor_patches()
+    called = []
+    monkeypatch.setattr(mc, "_PATCHES_INSTALLED", False); monkeypatch.setattr(mc, "_PATCHED_PATTERN_BUNDLES", set())
+    monkeypatch.setattr(mc, "_install_safe_fused_sdpa_mask_patches", lambda: None); monkeypatch.setattr(mc, "list_compile_pattern_bundles", lambda: ())
+    monkeypatch.setattr(mc, "_install_qwen_video_tensor_patches", lambda: called.append(True)); monkeypatch.setattr(mc, "_invalidate_qualification_cache", lambda: None)
+    monkeypatch.setattr(mc, "build_compile_qualifications", lambda: {})
+    assert mc.install_mlx_compile_patches() == {} and called == [True]
+
+
 def test_vlm_compile_patches_preserve_current_upstream_contracts(monkeypatch):
     import mlx.core as mx
     import unsloth_zoo.mlx.compile as mc

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1538,3 +1538,64 @@ def test_gemma3n_token_type_ownership_survives_module_relocation():
     assert _vlm_processor_requests_mm_token_type_ids(
         processor("transformers.models.gemma3.processing_gemma3", "Gemma3Processor")
     ) is True
+
+
+def test_qwen3_mixed_prompt_batch_keeps_every_row_through_the_real_merger():
+    """mlx-vlm's shipped merger must return one visual row per input_ids row.
+
+    A server batches a text-only request next to an image request, so only the
+    image row carries the compact visual keys. mlx-vlm concatenates an optional
+    key over just the rows that hold it, so the batch dimension has to be filled
+    in beforehand or the features land on the wrong row.
+    """
+    import importlib
+
+    pytest.importorskip("mlx_vlm")
+    try:
+        ar = importlib.import_module("mlx_vlm.generate.ar")
+    except Exception:
+        pytest.skip("mlx-vlm without the batched generate module")
+    merge = getattr(ar, "_merge_prefill_prompt_kwargs", None)
+    if merge is None:
+        pytest.skip("mlx-vlm without _merge_prefill_prompt_kwargs")
+    # Call the shipped function directly, whether or not the patches are live.
+    merge = getattr(merge, "__wrapped__", merge)
+
+    import unsloth_zoo.mlx.compile as mc
+
+    # why: a sibling module can swap these modules' `mx` for the simulation
+    # stub, which cannot consume the real MLX arrays this file builds.
+    for module in (mc, ar):
+        if "mlx_simulation" in str(getattr(module, "__file__", "")) or (
+            "mlx_simulation" in str(getattr(getattr(module, "mx", None), "__file__", ""))
+        ):
+            pytest.skip("module is bound to the MLX simulation stub")
+
+    masks = mx.array([[0, 0, 1, 1, 0, 0]], dtype=mx.bool_)
+    state, positions = mc._pack_qwen3_visual_state(masks, [mx.array([[1.0], [2.0]])])
+    text_ids = [7, 8, 9, 10, 11, 12]
+    visual_ids = [7, 1, 2, 2, 3, 12]
+    rows = [
+        {"inputs_embeds": mx.zeros((1, 6, 4))},
+        {
+            "inputs_embeds": mx.zeros((1, 6, 4)),
+            "visual_pos_masks": masks,
+            mc._QWEN3_VISUAL_STATE_KEY: state,
+            mc._QWEN3_VISUAL_POSITIONS_KEY: positions,
+        },
+    ]
+
+    _, merged = merge(mc._pad_qwen3_prompt_rows(rows), [text_ids, visual_ids])
+
+    for key in (
+        "visual_pos_masks",
+        mc._QWEN3_VISUAL_STATE_KEY,
+        mc._QWEN3_VISUAL_POSITIONS_KEY,
+    ):
+        assert merged[key].shape[0] == 2, (
+            f"{key} came back with {merged[key].shape[0]} of 2 rows"
+        )
+    # Only the image row owns live feature positions.
+    assert merged[mc._QWEN3_VISUAL_POSITIONS_KEY].tolist() == [[-1, -1], [2, 3]]
+    assert merged["visual_pos_masks"].tolist()[0] == [False] * 6
+    assert merged["visual_pos_masks"].tolist()[1] == masks.tolist()[0]

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -835,8 +835,13 @@ def test_vlm_processor_inputs_retry_only_exact_pytorch_output_error():
     converted = _call_vlm_processor(
         pytorch_only, (), {"return_tensors": "mlx"}
     )
-    assert isinstance(converted["ids"], mx.array)
-    assert converted["ids"].dtype == mx.int64
+    # why: a sibling module can swap the util's `mx` for the simulation stub,
+    # whose `array` is a factory rather than a type.
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    if "mlx_simulation" not in str(getattr(mlx_utils.mx, "__file__", "")):
+        assert isinstance(converted["ids"], mx.array)
+        assert converted["ids"].dtype == mx.int64
 
     native, native_calls = object(), []
     assert _call_vlm_processor(lambda **kw: native_calls.append(kw["return_tensors"]) or native, (), {"return_tensors": "np"}) is native
@@ -1508,3 +1513,28 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
     proc.tokenizer = _PoisonedTokenizer()
     poisoned = U._finalize_vlm_batch(staged)
     assert np.asarray(poisoned["input_ids"]).tolist() == sync_seq[0][0]
+
+
+def test_gemma3n_token_type_ownership_survives_module_relocation():
+    """Gemma3n builds token types itself however its module is named."""
+    from unsloth_zoo.mlx.utils import _vlm_processor_requests_mm_token_type_ids
+
+    def processor(module, name="Gemma3nProcessor"):
+        def __call__(self, *_args, **_kwargs):
+            return {}
+        return type(name, (object,), {"__module__": module, "__call__": __call__})()
+
+    # Remote-code and single-file loads expose the marker only as a suffix of
+    # the module name, never as a standalone path component.
+    for module in (
+        "transformers.models.gemma3n.processing_gemma3n",
+        "transformers_modules.google.gemma-3n-E4B-it.a1b2c3.processing_gemma3n",
+        "processing_gemma3n",
+        "mlx_vlm.models.gemma3n.processing",
+    ):
+        assert _vlm_processor_requests_mm_token_type_ids(processor(module)) is False
+
+    # Gemma3 proper still asks the processor for the multimodal token types.
+    assert _vlm_processor_requests_mm_token_type_ids(
+        processor("transformers.models.gemma3.processing_gemma3", "Gemma3Processor")
+    ) is True

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -835,8 +835,13 @@ def test_vlm_processor_inputs_retry_only_exact_pytorch_output_error():
     converted = _call_vlm_processor(
         pytorch_only, (), {"return_tensors": "mlx"}
     )
-    assert isinstance(converted["ids"], mx.array)
-    assert converted["ids"].dtype == mx.int64
+    # why: a sibling module can swap the util's `mx` for the simulation stub,
+    # whose `array` is a factory rather than a type.
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    if "mlx_simulation" not in str(getattr(mlx_utils.mx, "__file__", "")):
+        assert isinstance(converted["ids"], mx.array)
+        assert converted["ids"].dtype == mx.int64
 
     native, native_calls = object(), []
     assert _call_vlm_processor(lambda **kw: native_calls.append(kw["return_tensors"]) or native, (), {"return_tensors": "np"}) is native
@@ -1508,3 +1513,28 @@ def test_vlm_prefetch_opaque_lazy_mx_processor_paths(monkeypatch):
     proc.tokenizer = _PoisonedTokenizer()
     poisoned = U._finalize_vlm_batch(staged)
     assert np.asarray(poisoned["input_ids"]).tolist() == sync_seq[0][0]
+
+
+def test_gemma3n_token_type_ownership_survives_module_relocation():
+    """Gemma3n builds token types itself however its module is named."""
+    from unsloth_zoo.mlx.utils import _vlm_processor_requests_mm_token_type_ids
+
+    def processor(module, name="Gemma3nProcessor"):
+        def __call__(self, *_args, **_kwargs):
+            return {}
+        return type(name, (object,), {"__module__": module, "__call__": __call__})()
+
+    # Remote-code and single-file loads expose the marker only as a suffix of
+    # the module name, never as a standalone path component.
+    for module in (
+        "transformers.models.gemma3n.processing_gemma3n",
+        "google.gemma-3n-E4B-it.a1b2c3.processing_gemma3n",
+        "processing_gemma3n",
+        "mlx_vlm.models.gemma3n.processing",
+    ):
+        assert _vlm_processor_requests_mm_token_type_ids(processor(module)) is False
+
+    # Gemma3 proper still asks the processor for the multimodal token types.
+    assert _vlm_processor_requests_mm_token_type_ids(
+        processor("transformers.models.gemma3.processing_gemma3", "Gemma3Processor")
+    ) is True

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -779,6 +779,33 @@ def test_vlm_processor_inputs_retry_only_exact_pytorch_output_error():
     assert raised.value is unrelated
 
 
+def test_vlm_processor_multimodal_token_type_ownership():
+    from unsloth_zoo.mlx.utils import _processor_vlm_inputs
+    def call(self, text, **kwargs):
+        self.request = kwargs.get("return_mm_token_type_ids")
+        output = {"input_ids": np.ones((len(text), 2))}
+        if self.native_types or self.request is True:
+            output["token_type_ids"] = np.zeros((len(text), 2))
+        return output
+    def processor(model, name="Processor", base=object, native_types=False, inherit_call=False):
+        attrs = {"__module__": f"mlx_vlm.models.{model}.processing", "native_types": native_types}
+        if not inherit_call:
+            attrs["__call__"] = call
+        return type(name, (base,), attrs)()
+    gemma3n = processor("gemma3n", "Gemma3nProcessor", native_types=True)
+    relocated = processor("custom", "CustomGemma3nProcessor", type(gemma3n), True, True)
+    owners = [processor("gemma3", "Gemma3NextProcessor")]
+    for model in ("gemma3", "gemma4", "qwen3_vl", "qwen3_5"):
+        native = processor(model)
+        owners.extend((native, processor("custom", f"Custom{model}Processor", type(native), inherit_call=True)))
+    owners.append(processor("custom", "Gemma3nFlagProcessor", type(gemma3n)))
+    owners.append(processor("custom", "Gemma3nProcessor", type(gemma3n)))
+    for candidate in owners:
+        assert "token_type_ids" in _processor_vlm_inputs(candidate, ["x"], [[]], 8) and candidate.request is True
+    for candidate in (gemma3n, relocated):
+        assert "token_type_ids" in _processor_vlm_inputs(candidate, ["x"], [[]], 8) and candidate.request is None
+
+
 def test_deepseek_ocr_loader_patches_removed_llama_flash_attention(monkeypatch):
     import sys
     import types

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -738,6 +738,47 @@ def test_vlm_processor_inputs_retries_duplicate_add_special_tokens():
     assert "add_special_tokens" not in processor.calls[1]
 
 
+def test_vlm_processor_inputs_retry_only_exact_pytorch_output_error():
+    import torch
+
+    from unsloth_zoo.mlx.utils import _call_vlm_processor
+
+    class Batch(dict):
+        pass
+
+    calls = []
+    def pytorch_only(*_args, return_tensors=None, **_kwargs):
+        calls.append(return_tensors)
+        if return_tensors != "pt":
+            raise ValueError("Only returning PyTorch tensors is currently supported.")
+        return Batch({
+            "ids": torch.tensor([[1, 2]], dtype=torch.int64),
+            "nested": [torch.tensor([1.5], dtype=torch.float16), ("meta",)],
+        })
+
+    converted = _call_vlm_processor(
+        pytorch_only, (), {"return_tensors": "np"}
+    )
+    assert calls == ["np", "pt"] and isinstance(converted, Batch)
+    assert converted["ids"].dtype == np.int64
+    assert converted["nested"][0].dtype == np.float16
+    assert converted["nested"][1] == ("meta",)
+
+    converted = _call_vlm_processor(
+        pytorch_only, (), {"return_tensors": "mlx"}
+    )
+    assert isinstance(converted["ids"], mx.array)
+    assert converted["ids"].dtype == mx.int64
+
+    native, native_calls = object(), []
+    assert _call_vlm_processor(lambda **kw: native_calls.append(kw["return_tensors"]) or native, (), {"return_tensors": "np"}) is native
+    assert native_calls == ["np"]
+    unrelated = ValueError("unrelated")
+    with pytest.raises(ValueError) as raised:
+        _call_vlm_processor(lambda **_kwargs: (_ for _ in ()).throw(unrelated), (), {"return_tensors": "np"})
+    assert raised.value is unrelated
+
+
 def test_deepseek_ocr_loader_patches_removed_llama_flash_attention(monkeypatch):
     import sys
     import types

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -1535,6 +1535,15 @@ def _arch_matches_prefixes(arch: str, prefixes: tuple[str, ...]) -> bool:
     return bool(prefixes) and arch.startswith(prefixes)
 
 
+_QWEN_LIKE_MERGE_ARCHES = frozenset(
+    {"qwen2_vl", "qwen2_5_vl", "glm_ocr", "paddleocr_vl"}
+)
+_MASKED_SCATTER_PATCH_ARCHES = frozenset(
+    {"gemma3", "gemma4", "idefics2", "idefics3"}
+)
+_IDEFICS_SHARED_PATCH_ARCHES = frozenset({"idefics2", "idefics3"})
+
+
 def _adapter_matches(
     adapter: CompilePatchAdapter,
     arch: str,
@@ -1877,30 +1886,6 @@ def _try_import_module(module_name: str):
         return importlib.import_module(module_name)
     except Exception:
         return None
-
-
-def _iter_trait_model_modules(
-    trait: str,
-    *,
-    include_arches: Iterable[str] = (),
-):
-    """Yield model modules for architectures that share a compile trait.
-
-    Trait discovery (over the standard `mlx_vlm.models.<arch>.<arch>` layout)
-    lets future architectures inherit a shared patch automatically.
-    """
-
-    candidate_arches = set(include_arches)
-    candidate_arches.update(
-        arch
-        for arch, report in build_compile_trait_reports().items()
-        if trait in report.pattern_traits
-    )
-    for arch in sorted(candidate_arches):
-        module = _try_import_module(f"mlx_vlm.models.{arch}.{arch}")
-        if module is None:
-            continue
-        yield arch, module
 
 
 def _install_safe_fused_sdpa_mask_patches():
@@ -3387,11 +3372,9 @@ def _install_qwen_like_image_merge_patches():
     plumbing.
     """
 
-    for arch, module in _iter_trait_model_modules(
-        "qwen_like_image_merge",
-        include_arches=("qwen2_vl", "qwen2_5_vl", "glm_ocr", "paddleocr_vl"),
-    ):
-        if arch.startswith("qwen3"):
+    for arch in sorted(_QWEN_LIKE_MERGE_ARCHES):
+        module = _try_import_module(f"mlx_vlm.models.{arch}.{arch}")
+        if module is None:
             continue
         if arch == "paddleocr_vl":
             vision_module = _try_import_module("mlx_vlm.models.paddleocr_vl.vision")
@@ -4477,17 +4460,10 @@ def _install_deepseek_ocr_compile_patches():
 def _install_masked_scatter_multimodal_patches():
     """Patch `masked_scatter` implementations that rely on host-side mutation."""
 
-    for arch, module in _iter_trait_model_modules(
-        "masked_scatter_multimodal",
-        include_arches=("gemma3", "idefics2", "idefics3"),
-    ):
-        if arch == "gemma3n":
-            language = _try_import_module("mlx_vlm.models.gemma3n.language")
-            model = getattr(language, "Gemma3Model", None)
-            if _gemma3n_language_contract(getattr(model, "__call__", None)) is None:
-                _VERIFIED_TRAINING_ARCHES.discard(arch)
-                _PATCHED_ARCHES.discard(arch)
-                continue
+    for arch in sorted(_MASKED_SCATTER_PATCH_ARCHES):
+        module = _try_import_module(f"mlx_vlm.models.{arch}.{arch}")
+        if module is None:
+            continue
         if getattr(module, "masked_scatter", None) is None:
             continue
         setattr(module, "masked_scatter", _masked_scatter_no_numpy)
@@ -4498,7 +4474,6 @@ def _install_idefics_family_compile_patches():
     """Patch Idefics-family image filtering and multimodal merges for compile.
 
     Shared issue: Python-side padded-image filtering and placeholder merging.
-    Architectures with the same trait and standard layout inherit this patch.
     """
 
     def patched_prepare_inputs_for_multimodal(self, image_features, inputs_embeds, input_ids):
@@ -4568,11 +4543,9 @@ def _install_idefics_family_compile_patches():
         )
         return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
 
-    for arch, module in _iter_trait_model_modules(
-        "padded_image_filtering",
-        include_arches=("idefics2", "idefics3"),
-    ):
-        if arch == "smolvlm":
+    for arch in sorted(_IDEFICS_SHARED_PATCH_ARCHES):
+        module = _try_import_module(f"mlx_vlm.models.{arch}.{arch}")
+        if module is None:
             continue
         model_cls = getattr(module, "Model", None)
         if model_cls is None:

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -3894,6 +3894,27 @@ def _gemma3n_language_contract(method):
     return None
 
 
+def _gemma3n_cache_offset(cache):
+    """Normalize absolute cache progress for per-layer embedding slices.
+
+    Rotating caches compact or wrap their private ``_idx`` storage cursor while
+    the public ``offset`` continues to track the processed token position.
+    """
+
+    raw_offset = next(
+        (
+            c.offset
+            for c in (cache or [])
+            if c is not None and hasattr(c, "offset")
+        ),
+        0,
+    )
+    if isinstance(raw_offset, mx.array):
+        raw_offset = raw_offset.max() if raw_offset.ndim else raw_offset
+        return int(raw_offset.item())
+    return int(raw_offset)
+
+
 def _install_gemma3n_compile_patches():
     """Install Gemma3n multiscale fusion and merge compatibility patches."""
 
@@ -3998,29 +4019,7 @@ def _install_gemma3n_compile_patches():
                     0,
                 )
             else:
-                c0 = next(
-                    (c for c in (cache or []) if c is not None and hasattr(c, "_idx")),
-                    None,
-                )
-                if c0 is not None:
-                    cache_offset = int(c0._idx)
-                else:
-                    raw_offset = next(
-                        (
-                            c.offset
-                            for c in (cache or [])
-                            if c is not None and hasattr(c, "offset")
-                        ),
-                        0,
-                    )
-                    if isinstance(raw_offset, mx.array):
-                        cache_offset = (
-                            int(raw_offset.max().item())
-                            if raw_offset.size > 1
-                            else int(raw_offset.item())
-                        )
-                    else:
-                        cache_offset = int(raw_offset)
+                cache_offset = _gemma3n_cache_offset(cache)
             max_start = max(per_layer_inputs.shape[1] - target_len, 0)
             start = min(cache_offset, max_start)
             per_layer_inputs = per_layer_inputs[:, start : start + target_len]

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -27,7 +27,7 @@ compile-ready only once explicitly verified.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import lru_cache, wraps
 from pathlib import Path
 from itertools import accumulate
 import importlib
@@ -2174,6 +2174,23 @@ def _attach_position_ids(features, position_ids):
     return features
 
 
+def _explicit_position_embedding_adapter(original, replacement):
+    """Use Zoo's explicit-position path only while training."""
+
+    @wraps(original)
+    def patched(self, input_ids=None, pixel_values=None, **kwargs):
+        if not getattr(self, "training", False) or kwargs.get("position_ids") is None:
+            return original(self, input_ids, pixel_values, **kwargs)
+        return replacement(self, input_ids, pixel_values, **kwargs)
+
+    return patched
+
+
+def _patch_explicit_position_embeddings(model_cls, replacement):
+    adapted = _explicit_position_embedding_adapter(model_cls.get_input_embeddings, replacement)
+    _patch_method(model_cls, "get_input_embeddings", adapted)
+
+
 def _add_visual_embeds(hidden_states, visual_pos_masks, visual_embeds):
     """Compile-safe additive merge for sparse visual embeddings."""
 
@@ -2393,6 +2410,8 @@ def _install_qwen2_5_compile_patches():
         return hidden_states
 
     def patched_qwen2_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         explicit_position_ids = kwargs.get("position_ids", None)
@@ -2434,7 +2453,7 @@ def _install_qwen2_5_compile_patches():
     _patch_method(vision_module.VisionModel, "rot_pos_emb", patched_qwen2_rot_pos_emb)
     _patch_method(vision_module.VisionModel, "get_window_index", patched_qwen2_get_window_index)
     _patch_method(vision_module.VisionModel, "__call__", patched_qwen2_vision_call)
-    _patch_method(module.Model, "get_input_embeddings", patched_qwen2_get_input_embeddings)
+    _patch_explicit_position_embeddings(module.Model, patched_qwen2_get_input_embeddings)
     _PATCHED_ARCHES.add("qwen2_5_vl")
 
 
@@ -2545,6 +2564,8 @@ def _install_qwen2_compile_patches():
         return self.merger(hidden_states)
 
     def patched_qwen2_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         explicit_position_ids = kwargs.get("position_ids", None)
@@ -2585,7 +2606,7 @@ def _install_qwen2_compile_patches():
     _patch_method(vision_module.Attention, "__call__", patched_qwen2_attention)
     _patch_method(vision_module.VisionModel, "rot_pos_emb", patched_qwen2_rot_pos_emb)
     _patch_method(vision_module.VisionModel, "__call__", patched_qwen2_vision_call)
-    _patch_method(module.Model, "get_input_embeddings", patched_qwen2_get_input_embeddings)
+    _patch_explicit_position_embeddings(module.Model, patched_qwen2_get_input_embeddings)
     _PATCHED_ARCHES.add("qwen2_vl")
 
 
@@ -2867,6 +2888,8 @@ def _install_qwen3_family_compile_patches():
         return _add_visual_embeds(hidden_states, visual_pos_masks, visual_embeds)
 
     def patched_qwen3_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         mask = kwargs.get("mask", None)
@@ -2915,6 +2938,8 @@ def _install_qwen3_family_compile_patches():
         return _attach_position_ids(features, position_ids)
 
     def patched_qwen35_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         mask = kwargs.get("mask", None)
@@ -2962,8 +2987,8 @@ def _install_qwen3_family_compile_patches():
     _patch_method(vision_module.VisionModel, "fast_pos_embed_interpolate", patched_qwen3_fast_pos_embed_interpolate)
     _patch_method(vision_module.VisionModel, "__call__", patched_qwen3_vision_call)
     _patch_method(importlib.import_module("mlx_vlm.models.qwen3_vl.language").Qwen3VLModel, "_deepstack_process", patched_qwen3_deepstack)
-    _patch_method(module.Model, "get_input_embeddings", patched_qwen3_get_input_embeddings)
-    _patch_method(qwen35_module.Model, "get_input_embeddings", patched_qwen35_get_input_embeddings)
+    _patch_explicit_position_embeddings(module.Model, patched_qwen3_get_input_embeddings)
+    _patch_explicit_position_embeddings(qwen35_module.Model, patched_qwen35_get_input_embeddings)
     if qwen3moe_module is not None:
         qwen3moe_module.masked_scatter = _masked_scatter_no_numpy
         _patch_staticmethod(qwen3moe_module.Model, "merge_input_ids_with_image_features", merge_qwen3)
@@ -2973,7 +2998,7 @@ def _install_qwen3_family_compile_patches():
         _patch_method(qwen3moe_vision_module.VisionModel, "fast_pos_embed_interpolate", patched_qwen3_fast_pos_embed_interpolate)
         _patch_method(qwen3moe_vision_module.VisionModel, "__call__", patched_qwen3_vision_call)
         _patch_method(qwen3moe_language_module.Qwen3VLMoEModel, "_deepstack_process", patched_qwen3_deepstack)
-        _patch_method(qwen3moe_module.Model, "get_input_embeddings", patched_qwen3_get_input_embeddings)
+        _patch_explicit_position_embeddings(qwen3moe_module.Model, patched_qwen3_get_input_embeddings)
         _PATCHED_ARCHES.add("qwen3_vl_moe")
     _PATCHED_ARCHES.update({"qwen3_vl", "qwen3_5", "qwen3_5_moe"})
 
@@ -3087,6 +3112,8 @@ def _install_glm_ocr_compile_patches():
         return self.merger(hidden_states)
 
     def patched_glm_get_input_embeddings(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos", None)
         image_grid_thw = kwargs.get("image_grid_thw", None)
         video_grid_thw = kwargs.get("video_grid_thw", None)
         mask = kwargs.get("mask", None)
@@ -3132,8 +3159,21 @@ def _install_glm_ocr_compile_patches():
     _patch_method(vision_module.GlmOcrVisionAttention, "__call__", patched_glm_attention)
     _patch_method(vision_module.VisionModel, "rot_pos_emb", patched_glm_rot_pos_emb)
     _patch_method(vision_module.VisionModel, "__call__", patched_glm_vision_call)
-    _patch_method(module.Model, "get_input_embeddings", patched_glm_get_input_embeddings)
+    _patch_explicit_position_embeddings(module.Model, patched_glm_get_input_embeddings)
     _PATCHED_ARCHES.add("glm_ocr")
+
+
+def _paddleocr_vl_has_batched_vision(vision_module) -> bool:
+    """Whether PaddleOCR-VL exposes its newer batched vision contract."""
+
+    for class_name, method in (
+        ("VisionModel", "_forward_same_grid_batch"),
+        ("PaddleOCRVisionEmbeddings", "same_grid_batch"),
+        ("PaddleOCRProjector", "same_grid_batch"),
+    ):
+        if callable(getattr(getattr(vision_module, class_name, None), method, None)):
+            return True
+    return False
 
 
 def _install_paddleocr_vl_compile_patches():
@@ -3143,6 +3183,11 @@ def _install_paddleocr_vl_compile_patches():
         module = importlib.import_module("mlx_vlm.models.paddleocr_vl.paddleocr_vl")
         vision_module = importlib.import_module("mlx_vlm.models.paddleocr_vl.vision")
     except Exception:
+        return
+
+    if _paddleocr_vl_has_batched_vision(vision_module):
+        _VERIFIED_TRAINING_ARCHES.discard("paddleocr_vl")
+        _PATCHED_ARCHES.discard("paddleocr_vl")
         return
 
     InputEmbeddingsFeatures = module.InputEmbeddingsFeatures
@@ -3348,6 +3393,15 @@ def _install_qwen_like_image_merge_patches():
     ):
         if arch.startswith("qwen3"):
             continue
+        if arch == "paddleocr_vl":
+            vision_module = _try_import_module("mlx_vlm.models.paddleocr_vl.vision")
+            if (
+                vision_module is not None
+                and _paddleocr_vl_has_batched_vision(vision_module)
+            ):
+                _VERIFIED_TRAINING_ARCHES.discard(arch)
+                _PATCHED_ARCHES.discard(arch)
+                continue
         model_cls = getattr(module, "Model", None)
         if (
             model_cls is None
@@ -3839,6 +3893,24 @@ def _install_mistral4_compile_patches():
     _PATCHED_ARCHES.add("mistral4")
 
 
+def _gemma3n_language_contract(method):
+    """Identify the installed Gemma3n cache and attention-mask contract."""
+
+    try:
+        source = inspect.getsource(method)
+    except (OSError, TypeError):
+        return None
+    if "cache[self.first_full_idx :]" in source and "int(c.offset)" in source:
+        return "legacy"
+    if (
+        "cache[self.first_full_idx]" in source
+        and "window_size=self.config.sliding_window" in source
+        and "raw_offset.max().item()" in source
+    ):
+        return "current"
+    return None
+
+
 def _install_gemma3n_compile_patches():
     """Install Gemma3n multiscale fusion and merge compatibility patches."""
 
@@ -3848,6 +3920,12 @@ def _install_gemma3n_compile_patches():
         language_module = importlib.import_module("mlx_vlm.models.gemma3n.language")
         kernels_module = importlib.import_module("mlx_vlm.models.kernels")
     except Exception:
+        return
+
+    language_contract = _gemma3n_language_contract(language_module.Gemma3Model.__call__)
+    if language_contract is None:
+        _VERIFIED_TRAINING_ARCHES.discard("gemma3n")
+        _PATCHED_ARCHES.discard("gemma3n")
         return
 
     def patched_merge_multimodal_and_text(
@@ -3927,14 +4005,39 @@ def _install_gemma3n_compile_patches():
             if target_len != h.shape[1]:
                 target_len = h.shape[1]
 
-            cache_offset = next(
-                (
-                    int(c.offset)
-                    for c in (cache or [])
-                    if c is not None and hasattr(c, "offset")
-                ),
-                0,
-            )
+            if language_contract == "legacy":
+                cache_offset = next(
+                    (
+                        int(c.offset)
+                        for c in (cache or [])
+                        if c is not None and hasattr(c, "offset")
+                    ),
+                    0,
+                )
+            else:
+                c0 = next(
+                    (c for c in (cache or []) if c is not None and hasattr(c, "_idx")),
+                    None,
+                )
+                if c0 is not None:
+                    cache_offset = int(c0._idx)
+                else:
+                    raw_offset = next(
+                        (
+                            c.offset
+                            for c in (cache or [])
+                            if c is not None and hasattr(c, "offset")
+                        ),
+                        0,
+                    )
+                    if isinstance(raw_offset, mx.array):
+                        cache_offset = (
+                            int(raw_offset.max().item())
+                            if raw_offset.size > 1
+                            else int(raw_offset.item())
+                        )
+                    else:
+                        cache_offset = int(raw_offset)
             max_start = max(per_layer_inputs.shape[1] - target_len, 0)
             start = min(cache_offset, max_start)
             per_layer_inputs = per_layer_inputs[:, start : start + target_len]
@@ -3945,14 +4048,25 @@ def _install_gemma3n_compile_patches():
             cache = [None] * len(self.layers)
 
         if mask is None:
-            full_mask = language_module.create_attention_mask(
-                h,
-                cache[self.first_full_idx :],
-            )
-            sliding_window_mask = language_module.create_attention_mask(
-                h,
-                cache[self.first_sliding_idx :],
-            )
+            if language_contract == "legacy":
+                full_mask = language_module.create_attention_mask(
+                    h,
+                    cache[self.first_full_idx :],
+                )
+                sliding_window_mask = language_module.create_attention_mask(
+                    h,
+                    cache[self.first_sliding_idx :],
+                )
+            else:
+                full_mask = language_module.create_attention_mask(
+                    h,
+                    cache[self.first_full_idx],
+                )
+                sliding_window_mask = language_module.create_attention_mask(
+                    h,
+                    cache[self.first_sliding_idx],
+                    window_size=self.config.sliding_window,
+                )
         h0 = h
 
         target_magnitude = _safe_branch_magnitude(h0)
@@ -4367,6 +4481,13 @@ def _install_masked_scatter_multimodal_patches():
         "masked_scatter_multimodal",
         include_arches=("gemma3", "idefics2", "idefics3"),
     ):
+        if arch == "gemma3n":
+            language = _try_import_module("mlx_vlm.models.gemma3n.language")
+            model = getattr(language, "Gemma3Model", None)
+            if _gemma3n_language_contract(getattr(model, "__call__", None)) is None:
+                _VERIFIED_TRAINING_ARCHES.discard(arch)
+                _PATCHED_ARCHES.discard(arch)
+                continue
         if getattr(module, "masked_scatter", None) is None:
             continue
         setattr(module, "masked_scatter", _masked_scatter_no_numpy)

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -2608,21 +2608,67 @@ def _attach_qwen3_visual_state(features, visual_state, visual_positions):
 def _pad_qwen3_prompt_rows(prompt_kwargs_list):
     """Equalize compact visual widths before generic batch concatenation."""
 
-    max_features = max(
+    template = next(
         (
-            kwargs[_QWEN3_VISUAL_STATE_KEY].shape[1]
+            kwargs
             for kwargs in prompt_kwargs_list
-            if kwargs and kwargs.get(_QWEN3_VISUAL_STATE_KEY) is not None
+            if kwargs
+            and kwargs.get(_QWEN3_VISUAL_STATE_KEY) is not None
+            and kwargs.get(_QWEN3_VISUAL_POSITIONS_KEY) is not None
+            and kwargs.get("visual_pos_masks") is not None
         ),
-        default=0,
+        None,
     )
+    if template is None:
+        return prompt_kwargs_list
+
+    feature_widths = []
+    for kwargs in prompt_kwargs_list:
+        if not kwargs:
+            continue
+        state = kwargs.get(_QWEN3_VISUAL_STATE_KEY)
+        if state is not None:
+            feature_widths.append(state.shape[1])
+        elif (
+            kwargs.get(_QWEN3_VISUAL_POSITIONS_KEY) is None
+            and kwargs.get("visual_pos_masks") is not None
+        ):
+            feature_widths.extend(kwargs["visual_pos_masks"].sum(axis=1).tolist())
+    max_features = max(feature_widths, default=0)
     if not max_features:
         return prompt_kwargs_list
 
     padded_rows = [dict(kwargs) if kwargs else kwargs for kwargs in prompt_kwargs_list]
     for kwargs in padded_rows:
-        if not kwargs or kwargs.get(_QWEN3_VISUAL_STATE_KEY) is None:
+        if not kwargs:
             continue
+        if kwargs.get(_QWEN3_VISUAL_STATE_KEY) is None:
+            if kwargs.get(_QWEN3_VISUAL_POSITIONS_KEY) is not None:
+                continue
+            inputs_embeds = kwargs.get("inputs_embeds")
+            if inputs_embeds is None:
+                continue
+            state = template[_QWEN3_VISUAL_STATE_KEY]
+            visual_mask = template["visual_pos_masks"]
+            if kwargs.get("visual_pos_masks") is None:
+                kwargs["visual_pos_masks"] = mx.zeros(
+                    inputs_embeds.shape[:2],
+                    dtype=visual_mask.dtype,
+                )
+            visual_mask = kwargs["visual_pos_masks"]
+            empty_layers = [
+                mx.zeros(
+                    (int(visual_mask.sum().item()), state.shape[-1]),
+                    dtype=state.dtype,
+                )
+                for _ in range(state.shape[2])
+            ]
+            state, positions = _pack_qwen3_visual_state(
+                visual_mask,
+                empty_layers,
+            )
+            kwargs[_QWEN3_VISUAL_STATE_KEY] = state
+            kwargs[_QWEN3_VISUAL_POSITIONS_KEY] = positions
         state = kwargs[_QWEN3_VISUAL_STATE_KEY]
         positions = kwargs[_QWEN3_VISUAL_POSITIONS_KEY]
         pad = max_features - state.shape[1]

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -2614,25 +2614,70 @@ def _attach_qwen3_visual_state(features, visual_state, visual_positions):
     return features
 
 
+def _qwen3_prompt_row_length(kwargs):
+    """Prompt length of one merge row, read off its required inputs_embeds."""
+
+    embeds = kwargs.get("inputs_embeds") if kwargs else None
+    shape = getattr(embeds, "shape", None)
+    if shape is None or len(shape) < 2:
+        return None
+    return int(shape[1])
+
+
 def _pad_qwen3_prompt_rows(prompt_kwargs_list):
     """Equalize compact visual widths before generic batch concatenation."""
 
-    max_features = max(
-        (
-            kwargs[_QWEN3_VISUAL_STATE_KEY].shape[1]
-            for kwargs in prompt_kwargs_list
-            if kwargs and kwargs.get(_QWEN3_VISUAL_STATE_KEY) is not None
-        ),
-        default=0,
-    )
-    if not max_features:
+    states = [
+        kwargs.get(_QWEN3_VISUAL_STATE_KEY) if kwargs else None
+        for kwargs in prompt_kwargs_list
+    ]
+    present = [state for state in states if state is not None]
+    if not present:
         return prompt_kwargs_list
+    max_features = max(state.shape[1] for state in present)
+
+    # why: mlx-vlm concatenates an optional prompt key only over the rows that
+    # actually carry it, so a text-only row in a mixed batch drops out and
+    # every visual row slides onto the wrong batch entry. Absent rows need an
+    # empty state plus an empty mask so all three keys keep the input_ids batch.
+    absent_rows = [
+        kwargs
+        for kwargs, state in zip(prompt_kwargs_list, states)
+        if state is None and kwargs
+    ]
+    mask_template = next(
+        (
+            kwargs["visual_pos_masks"]
+            for kwargs, state in zip(prompt_kwargs_list, states)
+            if state is not None and kwargs.get("visual_pos_masks") is not None
+        ),
+        None,
+    )
+    for kwargs in absent_rows:
+        # A row still on mlx-vlm's native deepstack path cannot be reconciled
+        # with the compact one, so leave the batch exactly as it is today.
+        if kwargs.get("visual_pos_masks") is not None:
+            return prompt_kwargs_list
+        if _qwen3_prompt_row_length(kwargs) is None or mask_template is None:
+            return prompt_kwargs_list
 
     padded_rows = [dict(kwargs) if kwargs else kwargs for kwargs in prompt_kwargs_list]
-    for kwargs in padded_rows:
-        if not kwargs or kwargs.get(_QWEN3_VISUAL_STATE_KEY) is None:
+    for kwargs, state in zip(padded_rows, states):
+        if not kwargs:
             continue
-        state = kwargs[_QWEN3_VISUAL_STATE_KEY]
+        if state is None:
+            kwargs[_QWEN3_VISUAL_STATE_KEY] = mx.zeros(
+                (1, max_features) + tuple(present[0].shape[2:]),
+                dtype=present[0].dtype,
+            )
+            kwargs[_QWEN3_VISUAL_POSITIONS_KEY] = mx.full(
+                (1, max_features), -1, dtype=mx.int32
+            )
+            kwargs["visual_pos_masks"] = mx.zeros(
+                (1, _qwen3_prompt_row_length(kwargs)),
+                dtype=mask_template.dtype,
+            )
+            continue
         positions = kwargs[_QWEN3_VISUAL_POSITIONS_KEY]
         pad = max_features - state.shape[1]
         if pad <= 0:

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -2458,7 +2458,8 @@ def _qwen3_visual_window(
     for row, (mask_start, feature_start) in enumerate(
         zip(mask_offsets, feature_offsets)
     ):
-        if visual_pos_masks.shape[-1] == window:
+        whole_row = visual_pos_masks.shape[-1] == window
+        if whole_row:
             active_mask = visual_pos_masks[row]
         else:
             row_mask = visual_pos_masks[row]
@@ -2476,8 +2477,14 @@ def _qwen3_visual_window(
         window_masks.append(active_mask[None, :])
 
         row_positions = visual_positions[row]
-        feature_stop = max(0, feature_start + window)
-        feature_start = max(0, feature_start)
+        if whole_row:
+            # why: the whole mask row is consumed, so the feature window spans
+            # the whole row too -- a non-zero cache offset here belongs to an
+            # earlier prompt, not to this mask.
+            feature_start, feature_stop = 0, int(visual_pos_masks.shape[-1])
+        else:
+            feature_stop = max(0, feature_start + window)
+            feature_start = max(0, feature_start)
         feature_before = int(
             ((row_positions >= 0) & (row_positions < feature_start)).sum().item()
         )
@@ -2515,7 +2522,9 @@ def _qwen3_cache_offsets(cache, batch_size):
         return (int(value),) * batch_size
 
     offsets = row_values(getattr(cache_entry, "offset", 0))
-    left_padding = row_values(getattr(cache_entry, "left_padding", 0))
+    # why: some cache classes declare `left_padding` as None rather than omitting it.
+    left_padding = getattr(cache_entry, "left_padding", None)
+    left_padding = row_values(0 if left_padding is None else left_padding)
     if len(offsets) != batch_size or len(left_padding) != batch_size:
         return offsets, offsets
     mask_offsets = tuple(

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -2438,26 +2438,26 @@ def _qwen3_visual_window(
     visual_positions,
     *,
     mask_offsets,
-    feature_offsets,
     window,
 ):
-    """Restore flattened Qwen3 features for one compact-state window."""
+    """Restore flattened Qwen3 features for one compact-state window.
+
+    Everything here is in padded mask coordinates, because that is what
+    _pack_qwen3_visual_state records `visual_positions` in. Slicing features
+    with the unpadded cache offset instead lets a chunked prefill select a
+    visual token by mask while excluding its feature.
+    """
 
     batch_size = int(visual_pos_masks.shape[0])
     mask_offsets = tuple(int(offset) for offset in mask_offsets)
-    feature_offsets = tuple(int(offset) for offset in feature_offsets)
     if len(mask_offsets) == 1 and batch_size > 1:
         mask_offsets *= batch_size
-    if len(feature_offsets) == 1 and batch_size > 1:
-        feature_offsets *= batch_size
-    if len(mask_offsets) != batch_size or len(feature_offsets) != batch_size:
+    if len(mask_offsets) != batch_size:
         raise ValueError("Qwen3 visual state does not match the cache batch")
 
     window_masks = []
     feature_slices = [[] for _ in range(visual_state.shape[2])]
-    for row, (mask_start, feature_start) in enumerate(
-        zip(mask_offsets, feature_offsets)
-    ):
+    for row, mask_start in enumerate(mask_offsets):
         whole_row = visual_pos_masks.shape[-1] == window
         if whole_row:
             active_mask = visual_pos_masks[row]
@@ -2483,8 +2483,8 @@ def _qwen3_visual_window(
             # earlier prompt, not to this mask.
             feature_start, feature_stop = 0, int(visual_pos_masks.shape[-1])
         else:
+            feature_start = max(0, mask_start)
             feature_stop = max(0, feature_start + window)
-            feature_start = max(0, feature_start)
         feature_before = int(
             ((row_positions >= 0) & (row_positions < feature_start)).sum().item()
         )
@@ -2815,7 +2815,7 @@ def _qwen3_visual_state_adapter(original):
             compact_state = kwargs.pop(_QWEN3_VISUAL_STATE_KEY, None)
             visual_positions = kwargs.pop(_QWEN3_VISUAL_POSITIONS_KEY, None)
             if compact_state is not None and visual_positions is not None:
-                feature_offsets, mask_offsets = _qwen3_cache_offsets(
+                _unpadded_offsets, mask_offsets = _qwen3_cache_offsets(
                     cache,
                     int(visual_pos_masks.shape[0]),
                 )
@@ -2824,7 +2824,6 @@ def _qwen3_visual_state_adapter(original):
                     compact_state,
                     visual_positions,
                     mask_offsets=mask_offsets,
-                    feature_offsets=feature_offsets,
                     window=int(inputs.shape[1]),
                 )
                 kwargs.pop("n_to_process", None)

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -50,6 +50,8 @@ _PATCH_BINDINGS: set[tuple[str, str, str, str]] = set()
 # `_set_norm_output_cast_to_input_dtype` so the generic and Qwen3-VL
 # paths agree.
 _QWEN3_VISION_NORM_CAST_OUTPUT = True
+_QWEN3_VISUAL_STATE_KEY = "_unsloth_qwen3_visual_state"
+_QWEN3_VISUAL_POSITIONS_KEY = "_unsloth_qwen3_visual_positions"
 
 
 def set_qwen3_vision_norm_cast_output(enabled: bool) -> None:
@@ -2176,6 +2178,359 @@ def _patch_explicit_position_embeddings(model_cls, replacement):
     _patch_method(model_cls, "get_input_embeddings", adapted)
 
 
+def _qwen3_visual_window(
+    visual_pos_masks,
+    visual_state,
+    visual_positions,
+    *,
+    mask_offsets,
+    feature_offsets,
+    window,
+):
+    """Restore flattened Qwen3 features for one compact-state window."""
+
+    batch_size = int(visual_pos_masks.shape[0])
+    mask_offsets = tuple(int(offset) for offset in mask_offsets)
+    feature_offsets = tuple(int(offset) for offset in feature_offsets)
+    if len(mask_offsets) == 1 and batch_size > 1:
+        mask_offsets *= batch_size
+    if len(feature_offsets) == 1 and batch_size > 1:
+        feature_offsets *= batch_size
+    if len(mask_offsets) != batch_size or len(feature_offsets) != batch_size:
+        raise ValueError("Qwen3 visual state does not match the cache batch")
+
+    window_masks = []
+    feature_slices = [[] for _ in range(visual_state.shape[2])]
+    for row, (mask_start, feature_start) in enumerate(
+        zip(mask_offsets, feature_offsets)
+    ):
+        if visual_pos_masks.shape[-1] == window:
+            active_mask = visual_pos_masks[row]
+        else:
+            row_mask = visual_pos_masks[row]
+            active_mask = row_mask[mask_start : mask_start + window]
+            if active_mask.shape[0] < window:
+                active_mask = mx.concatenate(
+                    [
+                        active_mask,
+                        mx.zeros(
+                            (window - active_mask.shape[0],),
+                            dtype=row_mask.dtype,
+                        ),
+                    ]
+                )
+        window_masks.append(active_mask[None, :])
+
+        row_positions = visual_positions[row]
+        feature_stop = max(0, feature_start + window)
+        feature_start = max(0, feature_start)
+        feature_before = int(
+            ((row_positions >= 0) & (row_positions < feature_start)).sum().item()
+        )
+        feature_count = int(
+            (
+                (row_positions >= feature_start)
+                & (row_positions < feature_stop)
+            ).sum().item()
+        )
+        selected = visual_state[row][
+            feature_before : feature_before + feature_count
+        ]
+        for layer in range(visual_state.shape[2]):
+            feature_slices[layer].append(selected[:, layer, :])
+
+    return mx.concatenate(window_masks, axis=0), [
+        mx.concatenate(parts, axis=0)
+        for parts in feature_slices
+    ]
+
+
+def _qwen3_cache_offsets(cache, batch_size):
+    """Return unpadded and padded prompt progress for each cache row."""
+
+    if not cache or cache[0] is None:
+        zeros = (0,) * batch_size
+        return zeros, zeros
+    cache_entry = cache[0]
+
+    def row_values(value):
+        if hasattr(value, "ndim"):
+            if value.ndim > 0:
+                return tuple(int(item) for item in value.reshape((-1,)).tolist())
+            value = value.item()
+        return (int(value),) * batch_size
+
+    offsets = row_values(getattr(cache_entry, "offset", 0))
+    left_padding = row_values(getattr(cache_entry, "left_padding", 0))
+    if len(offsets) != batch_size or len(left_padding) != batch_size:
+        return offsets, offsets
+    mask_offsets = tuple(
+        max(0, offset + padding)
+        for offset, padding in zip(offsets, left_padding)
+    )
+    return offsets, mask_offsets
+
+
+def _pack_qwen3_visual_state(visual_pos_masks, deepstack_visual_embeds):
+    """Pack flattened Qwen3 features by row without scaling to prompt length."""
+
+    if (
+        deepstack_visual_embeds is None
+        or isinstance(deepstack_visual_embeds, mx.array)
+    ):
+        return deepstack_visual_embeds, None
+    if not deepstack_visual_embeds:
+        return deepstack_visual_embeds, None
+
+    counts = [
+        int(visual_pos_masks[row].sum().item())
+        for row in range(visual_pos_masks.shape[0])
+    ]
+    max_count = max(counts, default=0)
+    positions = []
+    packed_rows = []
+    feature_start = 0
+    for row, count in enumerate(counts):
+        prompt_positions = mx.arange(
+            visual_pos_masks.shape[1],
+            dtype=mx.int32,
+        )
+        position_keys = mx.where(
+            visual_pos_masks[row],
+            prompt_positions,
+            visual_pos_masks.shape[1],
+        )
+        row_positions = prompt_positions[mx.argsort(position_keys)[:count]]
+        if count < max_count:
+            row_positions = mx.concatenate(
+                [
+                    row_positions,
+                    mx.full((max_count - count,), -1, dtype=mx.int32),
+                ]
+            )
+        positions.append(row_positions[None, :])
+
+        row_layers = []
+        for embeds in deepstack_visual_embeds:
+            row_embeds = embeds[feature_start : feature_start + count]
+            if count < max_count:
+                row_embeds = mx.concatenate(
+                    [
+                        row_embeds,
+                        mx.zeros(
+                            (max_count - count, embeds.shape[-1]),
+                            dtype=embeds.dtype,
+                        ),
+                    ],
+                    axis=0,
+                )
+            row_layers.append(row_embeds)
+        packed_rows.append(mx.stack(row_layers, axis=1)[None, ...])
+        feature_start += count
+
+    return (
+        mx.concatenate(packed_rows, axis=0),
+        mx.concatenate(positions, axis=0),
+    )
+
+
+def _attach_qwen3_visual_state(features, visual_state, visual_positions):
+    """Carry compact Qwen3 state through mlx-vlm's generic prompt kwargs."""
+
+    original_to_dict = features.to_dict
+
+    @wraps(original_to_dict)
+    def to_dict():
+        values = original_to_dict()
+        values[_QWEN3_VISUAL_STATE_KEY] = visual_state
+        values[_QWEN3_VISUAL_POSITIONS_KEY] = visual_positions
+        return values
+
+    features.deepstack_visual_embeds = None
+    features.to_dict = to_dict
+    return features
+
+
+def _pad_qwen3_prompt_rows(prompt_kwargs_list):
+    """Equalize compact visual widths before generic batch concatenation."""
+
+    max_features = max(
+        (
+            kwargs[_QWEN3_VISUAL_STATE_KEY].shape[1]
+            for kwargs in prompt_kwargs_list
+            if kwargs and kwargs.get(_QWEN3_VISUAL_STATE_KEY) is not None
+        ),
+        default=0,
+    )
+    if not max_features:
+        return prompt_kwargs_list
+
+    padded_rows = [dict(kwargs) if kwargs else kwargs for kwargs in prompt_kwargs_list]
+    for kwargs in padded_rows:
+        if not kwargs or kwargs.get(_QWEN3_VISUAL_STATE_KEY) is None:
+            continue
+        state = kwargs[_QWEN3_VISUAL_STATE_KEY]
+        positions = kwargs[_QWEN3_VISUAL_POSITIONS_KEY]
+        pad = max_features - state.shape[1]
+        if pad <= 0:
+            continue
+        kwargs[_QWEN3_VISUAL_STATE_KEY] = mx.pad(
+            state,
+            [(0, 0), (0, pad), (0, 0), (0, 0)],
+        )
+        kwargs[_QWEN3_VISUAL_POSITIONS_KEY] = mx.pad(
+            positions,
+            [(0, 0), (0, pad)],
+            constant_values=-1,
+        )
+    return padded_rows
+
+
+def _qwen3_prompt_merge_adapter(original):
+    """Pad compact visual rows in mlx-vlm's cold prompt batching path."""
+
+    if getattr(original, "_unsloth_qwen3_prompt_merge", False):
+        return original
+
+    @wraps(original)
+    def patched(prompt_kwargs_list, input_ids):
+        return original(_pad_qwen3_prompt_rows(prompt_kwargs_list), input_ids)
+
+    patched._unsloth_qwen3_prompt_merge = True
+    return patched
+
+
+def _qwen3_mixed_prompt_batch_adapter(original):
+    """Pad compact visual rows in mlx-vlm's APC prompt batching path."""
+
+    if getattr(original, "_unsloth_qwen3_mixed_prompt_batch", False):
+        return original
+
+    @wraps(original)
+    def patched(self, sequences):
+        prompt_rows = [sequence[3] for sequence in sequences]
+        padded_rows = _pad_qwen3_prompt_rows(prompt_rows)
+        if padded_rows is not prompt_rows:
+            sequences = [
+                (*sequence[:3], kwargs, *sequence[4:])
+                for sequence, kwargs in zip(sequences, padded_rows)
+            ]
+        return original(self, sequences)
+
+    patched._unsloth_qwen3_mixed_prompt_batch = True
+    return patched
+
+
+def _qwen3_callable_source(original):
+    try:
+        return inspect.getsource(original)
+    except (OSError, TypeError):
+        return ""
+
+
+def _qwen3_drops_deepstack_after_eval(original):
+    return "deepstack_visual_embeds = mx.eval(" in _qwen3_callable_source(original)
+
+
+def _qwen3_batch_embedding_adapter(
+    original,
+    replacement=None,
+    *,
+    replace_visual_inference=False,
+):
+    """Expose flattened Qwen3 deepstack state in a compact row-owned format."""
+
+    if getattr(original, "_unsloth_qwen3_batch_visual_state", False):
+        return original
+
+    @wraps(original)
+    def patched(self, input_ids=None, pixel_values=None, **kwargs):
+        training = getattr(self, "training", False)
+        use_replacement = replacement is not None and (
+            (
+                training
+                and kwargs.get("position_ids") is not None
+            )
+            or (
+                not training and replace_visual_inference
+                and (
+                    pixel_values is not None
+                    or kwargs.get("pixel_values_videos") is not None
+                )
+            )
+        )
+        embedding_call = replacement if use_replacement else original
+        features = embedding_call(self, input_ids, pixel_values, **kwargs)
+        if training:
+            return features
+        visual_pos_masks = getattr(features, "visual_pos_masks", None)
+        if visual_pos_masks is not None:
+            visual_state, visual_positions = _pack_qwen3_visual_state(
+                visual_pos_masks,
+                getattr(features, "deepstack_visual_embeds", None),
+            )
+            if visual_positions is not None:
+                features = _attach_qwen3_visual_state(
+                    features,
+                    visual_state,
+                    visual_positions,
+                )
+        return features
+
+    patched._unsloth_qwen3_batch_visual_state = True
+    return patched
+
+
+def _qwen3_visual_state_adapter(original):
+    """Align Qwen3 mask/deepstack side channels before the language call."""
+
+    if getattr(original, "_unsloth_qwen3_visual_state", False):
+        return original
+
+    @wraps(original)
+    def patched(
+        self,
+        inputs,
+        inputs_embeds=None,
+        mask=None,
+        cache=None,
+        visual_pos_masks=None,
+        deepstack_visual_embeds=None,
+        **kwargs,
+    ):
+        if visual_pos_masks is not None:
+            compact_state = kwargs.pop(_QWEN3_VISUAL_STATE_KEY, None)
+            visual_positions = kwargs.pop(_QWEN3_VISUAL_POSITIONS_KEY, None)
+            if compact_state is not None and visual_positions is not None:
+                feature_offsets, mask_offsets = _qwen3_cache_offsets(
+                    cache,
+                    int(visual_pos_masks.shape[0]),
+                )
+                visual_pos_masks, deepstack_visual_embeds = _qwen3_visual_window(
+                    visual_pos_masks,
+                    compact_state,
+                    visual_positions,
+                    mask_offsets=mask_offsets,
+                    feature_offsets=feature_offsets,
+                    window=int(inputs.shape[1]),
+                )
+                kwargs.pop("n_to_process", None)
+
+        return original(
+            self,
+            inputs,
+            inputs_embeds=inputs_embeds,
+            mask=mask,
+            cache=cache,
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+            **kwargs,
+        )
+
+    patched._unsloth_qwen3_visual_state = True
+    return patched
+
+
 def _add_visual_embeds(hidden_states, visual_pos_masks, visual_embeds):
     """Compile-safe additive merge for sparse visual embeddings."""
 
@@ -2613,6 +2968,35 @@ def _install_qwen3_family_compile_patches():
         qwen3moe_vision_module = None
         qwen3moe_language_module = None
 
+    for generate_name in ("mlx_vlm.generate", "mlx_vlm.generate.ar"):
+        try:
+            generate_module = importlib.import_module(generate_name)
+        except Exception:
+            continue
+        prompt_merge = getattr(
+            generate_module,
+            "_merge_prefill_prompt_kwargs",
+            None,
+        )
+        if prompt_merge is not None:
+            setattr(
+                generate_module,
+                "_merge_prefill_prompt_kwargs",
+                _qwen3_prompt_merge_adapter(prompt_merge),
+            )
+        batch_generator = getattr(generate_module, "BatchGenerator", None)
+        mixed_prompt_batch = getattr(
+            batch_generator,
+            "_build_mixed_prompt_batch",
+            None,
+        )
+        if mixed_prompt_batch is not None:
+            _patch_method(
+                batch_generator,
+                "_build_mixed_prompt_batch",
+                _qwen3_mixed_prompt_batch_adapter(mixed_prompt_batch),
+            )
+
     def merge_qwen3(image_features, inputs_embeds, input_ids, image_token_index, video_token_index):
         import mlx.core as mx
 
@@ -2971,8 +3355,25 @@ def _install_qwen3_family_compile_patches():
     _patch_method(vision_module.VisionModel, "rot_pos_emb", patched_qwen3_rot_pos_emb)
     _patch_method(vision_module.VisionModel, "fast_pos_embed_interpolate", patched_qwen3_fast_pos_embed_interpolate)
     _patch_method(vision_module.VisionModel, "__call__", patched_qwen3_vision_call)
-    _patch_method(importlib.import_module("mlx_vlm.models.qwen3_vl.language").Qwen3VLModel, "_deepstack_process", patched_qwen3_deepstack)
-    _patch_explicit_position_embeddings(module.Model, patched_qwen3_get_input_embeddings)
+    language_module = importlib.import_module("mlx_vlm.models.qwen3_vl.language")
+    _patch_method(language_module.Qwen3VLModel, "_deepstack_process", patched_qwen3_deepstack)
+    language_call = language_module.LanguageModel.__call__
+    _patch_method(
+        language_module.LanguageModel,
+        "__call__",
+        _qwen3_visual_state_adapter(language_call),
+    )
+    _patch_method(
+        module.Model,
+        "get_input_embeddings",
+        _qwen3_batch_embedding_adapter(
+            module.Model.get_input_embeddings,
+            patched_qwen3_get_input_embeddings,
+            replace_visual_inference=_qwen3_drops_deepstack_after_eval(
+                module.Model.get_input_embeddings
+            ),
+        ),
+    )
     _patch_explicit_position_embeddings(qwen35_module.Model, patched_qwen35_get_input_embeddings)
     if qwen3moe_module is not None:
         qwen3moe_module.masked_scatter = _masked_scatter_no_numpy
@@ -2983,7 +3384,23 @@ def _install_qwen3_family_compile_patches():
         _patch_method(qwen3moe_vision_module.VisionModel, "fast_pos_embed_interpolate", patched_qwen3_fast_pos_embed_interpolate)
         _patch_method(qwen3moe_vision_module.VisionModel, "__call__", patched_qwen3_vision_call)
         _patch_method(qwen3moe_language_module.Qwen3VLMoEModel, "_deepstack_process", patched_qwen3_deepstack)
-        _patch_explicit_position_embeddings(qwen3moe_module.Model, patched_qwen3_get_input_embeddings)
+        moe_language_call = qwen3moe_language_module.LanguageModel.__call__
+        _patch_method(
+            qwen3moe_language_module.LanguageModel,
+            "__call__",
+            _qwen3_visual_state_adapter(moe_language_call),
+        )
+        _patch_method(
+            qwen3moe_module.Model,
+            "get_input_embeddings",
+            _qwen3_batch_embedding_adapter(
+                qwen3moe_module.Model.get_input_embeddings,
+                patched_qwen3_get_input_embeddings,
+                replace_visual_inference=_qwen3_drops_deepstack_after_eval(
+                    qwen3moe_module.Model.get_input_embeddings
+                ),
+            ),
+        )
         _PATCHED_ARCHES.add("qwen3_vl_moe")
     _PATCHED_ARCHES.update({"qwen3_vl", "qwen3_5", "qwen3_5_moe"})
 

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -2645,6 +2645,17 @@ def _pad_qwen3_prompt_rows(prompt_kwargs_list):
     if template is None:
         return prompt_kwargs_list
 
+    # why: a row still on mlx-vlm's native deepstack keys owns real features
+    # that no compact state can stand in for, so synthesizing an empty one
+    # would replace them with zeros. Leave the batch exactly as it is.
+    if any(
+        kwargs
+        and kwargs.get(_QWEN3_VISUAL_STATE_KEY) is None
+        and kwargs.get("deepstack_visual_embeds") is not None
+        for kwargs in prompt_kwargs_list
+    ):
+        return prompt_kwargs_list
+
     feature_widths = []
     for kwargs in prompt_kwargs_list:
         if not kwargs:

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -30,12 +30,14 @@ from dataclasses import dataclass
 from functools import lru_cache, wraps
 from pathlib import Path
 from itertools import accumulate
+import ast
 import importlib
 import inspect
 import mlx.core as mx
 import numpy as np
 import pkgutil
 import re
+import textwrap
 from typing import Any, Callable, Iterable, Mapping
 
 
@@ -2178,6 +2180,258 @@ def _patch_explicit_position_embeddings(model_cls, replacement):
     _patch_method(model_cls, "get_input_embeddings", adapted)
 
 
+def _qwen_kwargs_lookup(node, key):
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "kwargs"
+        and node.func.attr == "get"
+        and bool(node.args)
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == key
+    )
+
+
+def _qwen_pixel_none_guard(node):
+    return (
+        isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Name)
+        and node.test.left.id == "pixel_values"
+        and len(node.test.ops) == 1
+        and isinstance(node.test.ops[0], ast.Is)
+        and len(node.test.comparators) == 1
+        and isinstance(node.test.comparators[0], ast.Constant)
+        and node.test.comparators[0].value is None
+    )
+
+
+def _qwen_video_tensor_access(node):
+    if isinstance(node, (ast.Name, ast.arg)):
+        name = node.id if isinstance(node, ast.Name) else node.arg
+        return name == "pixel_values_videos"
+    if isinstance(node, ast.Call):
+        return (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "kwargs"
+            and bool(node.args)
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "pixel_values_videos"
+        )
+    if isinstance(node, ast.Subscript):
+        return (
+            isinstance(node.value, ast.Name)
+            and node.value.id == "kwargs"
+            and isinstance(node.slice, ast.Constant)
+            and node.slice.value == "pixel_values_videos"
+        )
+    return False
+
+
+def _qwen_video_tensor_contract(source):
+    try:
+        tree = ast.parse(textwrap.dedent(source))
+    except (IndentationError, SyntaxError):
+        return None
+    function = next(
+        (node for node in tree.body if isinstance(node, ast.FunctionDef)),
+        None,
+    )
+    if function is None:
+        return None
+    has_grid_lookup = False
+    pixel_none_guards = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if (
+                any(
+                    isinstance(target, ast.Name)
+                    and target.id == "video_grid_thw"
+                    for target in targets
+                )
+                and _qwen_kwargs_lookup(node.value, "video_grid_thw")
+            ):
+                has_grid_lookup = True
+        if _qwen_pixel_none_guard(node):
+            pixel_none_guards.append(node)
+    if not has_grid_lookup or not pixel_none_guards:
+        return None
+
+    video_accesses = [
+        node for node in ast.walk(tree) if _qwen_video_tensor_access(node)
+    ]
+    native_fallbacks = []
+    for guard in pixel_none_guards:
+        for statement in guard.body:
+            if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = (
+                statement.targets
+                if isinstance(statement, ast.Assign)
+                else [statement.target]
+            )
+            if (
+                any(
+                    isinstance(target, ast.Name)
+                    and target.id == "pixel_values"
+                    for target in targets
+                )
+                and _qwen_kwargs_lookup(statement.value, "pixel_values_videos")
+            ):
+                native_fallbacks.append(statement.value)
+    if native_fallbacks:
+        first_guard_body = pixel_none_guards[0].body
+        first_statement = first_guard_body[0] if first_guard_body else None
+        if (
+            len(native_fallbacks) == 1
+            and function.body
+            and function.body[0] is pixel_none_guards[0]
+            and isinstance(first_statement, (ast.Assign, ast.AnnAssign))
+            and first_statement.value is native_fallbacks[0]
+            and video_accesses == native_fallbacks
+        ):
+            return "fixed"
+        return None
+    if video_accesses:
+        return None
+    legacy_guards = [
+        guard
+        for guard in pixel_none_guards
+        if guard in function.body
+        and any(
+            isinstance(node, ast.Return)
+            for statement in guard.body
+            for node in ast.walk(statement)
+        )
+    ]
+    if len(legacy_guards) != 1:
+        return None
+    guard_index = function.body.index(legacy_guards[0])
+    prelude_names = []
+    for statement in function.body[:guard_index]:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            return None
+        targets = (
+            statement.targets
+            if isinstance(statement, ast.Assign)
+            else [statement.target]
+        )
+        if len(targets) != 1 or not isinstance(targets[0], ast.Name):
+            return None
+        prelude_names.append(targets[0].id)
+    if tuple(prelude_names) == (
+        "image_grid_thw",
+        "video_grid_thw",
+        "mask",
+        "grid_thw",
+    ):
+        return "legacy"
+    return None
+
+
+def _qwen_video_signature_supported(original):
+    try:
+        parameters = inspect.signature(
+            original,
+            follow_wrapped=False,
+        ).parameters
+    except (TypeError, ValueError):
+        return False
+    keyword_kinds = {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    }
+    return (
+        all(
+            parameters.get(name) is not None
+            and parameters[name].kind in keyword_kinds
+            for name in ("input_ids", "pixel_values")
+        )
+        and any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+    )
+
+
+def _qwen_video_contract_matches(original, expected):
+    try:
+        source = inspect.getsource(original)
+    except (OSError, TypeError):
+        return False
+    return (
+        _qwen_video_signature_supported(original)
+        and _qwen_video_tensor_contract(source) == expected
+    )
+
+
+def _qwen_video_tensor_adapter(original):
+    """Route processor-owned video pixels into legacy Qwen embedding calls."""
+
+    if getattr(original, "_unsloth_qwen_video_tensor", False):
+        return original
+    if getattr(
+        original,
+        "_unsloth_qwen3_replaces_visual_inference",
+        False,
+    ):
+        return original
+    underlying = inspect.unwrap(original)
+    if (
+        not _qwen_video_signature_supported(original)
+        or not _qwen_video_contract_matches(underlying, "legacy")
+    ):
+        return original
+
+    @wraps(original)
+    def patched(self, input_ids=None, pixel_values=None, **kwargs):
+        if pixel_values is None:
+            video_pixels = kwargs.get("pixel_values_videos")
+            if video_pixels is not None:
+                pixel_values = video_pixels
+        return original(
+            self,
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            **kwargs,
+        )
+
+    patched._unsloth_qwen_video_tensor = True
+    return patched
+
+
+def _patch_qwen_video_tensor(model_cls):
+    original = model_cls.get_input_embeddings
+    adapted = _qwen_video_tensor_adapter(original)
+    if adapted is not original:
+        _patch_method(model_cls, "get_input_embeddings", adapted)
+
+
+_QWEN_VIDEO_TENSOR_OWNER_MODULES = (
+    "mlx_vlm.models.qwen2_vl.qwen2_vl",
+    "mlx_vlm.models.qwen2_5_vl.qwen2_5_vl",
+    "mlx_vlm.models.qwen3_5.qwen3_5",
+    "mlx_vlm.models.qwen3_vl_moe.qwen3_vl_moe",
+)
+
+
+def _install_qwen_video_tensor_patches():
+    """Patch only Qwen owners with the legacy processor/model video split."""
+
+    for module_name in _QWEN_VIDEO_TENSOR_OWNER_MODULES:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:
+            continue
+        model_cls = getattr(module, "Model", None)
+        if model_cls is None or not hasattr(model_cls, "get_input_embeddings"):
+            continue
+        _patch_qwen_video_tensor(model_cls)
+
+
 def _qwen3_visual_window(
     visual_pos_masks,
     visual_state,
@@ -2478,6 +2732,11 @@ def _qwen3_batch_embedding_adapter(
         return features
 
     patched._unsloth_qwen3_batch_visual_state = True
+    patched._unsloth_qwen3_replaces_visual_inference = bool(
+        replacement is not None
+        and replace_visual_inference
+        and _qwen_video_contract_matches(replacement, "fixed")
+    )
     return patched
 
 
@@ -5953,6 +6212,7 @@ def install_mlx_compile_patches():
         _apply_compile_patch_plan(_resolve_compile_patch_plan(bundle))
         _PATCHED_PATTERN_BUNDLES.add(bundle.name)
 
+    _install_qwen_video_tensor_patches()
     _PATCHES_INSTALLED = True
     _invalidate_qualification_cache()
     return build_compile_qualifications()

--- a/unsloth_zoo/mlx/compile.py
+++ b/unsloth_zoo/mlx/compile.py
@@ -3894,8 +3894,48 @@ def _install_qwen3_get_input_embeddings_patch():
     _PATCHED_ARCHES.add("qwen3_vl")
 
 
+def _legacy_vlm_prefill_kwargs_adapter(original):
+    """Drop generator bookkeeping only for strict legacy language callables."""
+
+    if getattr(original, "_unsloth_legacy_prefill_kwargs", False):
+        return original
+    try:
+        parameters = inspect.signature(original, follow_wrapped=False).parameters
+    except (TypeError, ValueError):
+        return original
+    if (
+        "n_to_process" in parameters
+        or any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+    ):
+        return original
+
+    @wraps(original)
+    def patched(self, *args, **kwargs):
+        kwargs.pop("n_to_process", None)
+        return original(self, *args, **kwargs)
+
+    patched._unsloth_legacy_prefill_kwargs = True
+    return patched
+
+
+def _install_legacy_llava_prefill_patch():
+    language_module = _try_import_module("mlx_vlm.models.llava.language")
+    language_class = getattr(language_module, "LanguageModel", None)
+    if language_class is None:
+        return
+    original = language_class.__call__
+    adapted = _legacy_vlm_prefill_kwargs_adapter(original)
+    if adapted is not original:
+        _patch_method(language_class, "__call__", adapted)
+
+
 def _install_llama_pixtral_mistral_compile_patches():
     """Install compile-safe multimodal merge patches for llama-like families."""
+
+    _install_legacy_llava_prefill_patch()
 
     def merge_single_image_token_family(
         image_token_index, image_features, inputs_embeds, input_ids

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -20,6 +20,7 @@ No GPU deps: uses mlx-lm (text) and mlx-vlm (VLM) instead of unsloth.models
 (which pulls in CUDA kernels).
 """
 
+import ast
 import gc
 import json
 import importlib
@@ -50,6 +51,7 @@ from .compile import (
 )
 
 _vlm_model_types_cache = None
+_VLM_MODALITY_CONFIG_FIELDS = ("vision_config", "audio_config", "dflash_config")
 _SAFE_TEXT_SANITIZE_PATCHED: set[str] = set()
 _AUDIO_CONV_SANITIZE_PATCHED: set[str] = set()
 _MULTIMODAL_STRIP_KEYS = (
@@ -217,16 +219,11 @@ def _collect_all_linear_target_names(model):
 
 
 def _is_vlm(config: dict) -> bool:
-    """Detect whether a config describes a VLM (via "vision_config" or a
-    model_type in mlx_vlm's supported set)."""
-    if "vision_config" in config:
+    """Detect a VLM from explicit modality data or a modality-aware model set."""
+    if any(config.get(key) not in (None, {}) for key in _VLM_MODALITY_CONFIG_FIELDS):
         return True
-
-    architectures = config.get("architectures") or ()
-    if isinstance(architectures, str):
-        architectures = (architectures,)
-    if any(str(arch).endswith("ForCausalLM") for arch in architectures):
-        return False
+    if _deepseek_ocr_config_model_type(config) is not None:
+        return True
 
     model_type = config.get("model_type", "")
     if not model_type:
@@ -235,6 +232,15 @@ def _is_vlm(config: dict) -> bool:
     global _vlm_model_types_cache
     if _vlm_model_types_cache is None:
         _vlm_model_types_cache = _build_vlm_model_types()
+
+    architectures = config.get("architectures") or ()
+    if isinstance(architectures, str):
+        architectures = (architectures,)
+    if (
+        any(str(arch).endswith("ForCausalLM") for arch in architectures)
+        and model_type not in _vlm_model_types_cache
+    ):
+        return False
 
     return model_type in _vlm_model_types_cache
 
@@ -1160,15 +1166,41 @@ def _repair_degraded_vlm_processor(
     return repaired
 
 
+def _config_source_has_modality(package_dir: Path) -> bool:
+    """Inspect config declarations without importing model packages."""
+
+    candidates = (
+        package_dir / "config.py",
+        package_dir / f"{package_dir.name}.py",
+        package_dir / "__init__.py",
+    )
+    for path in candidates:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            fields = {
+                item.target.id for item in node.body
+                if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name)
+            }
+            if fields.intersection(_VLM_MODALITY_CONFIG_FIELDS):
+                return True
+    return False
+
+
 def _build_vlm_model_types():
-    """Frozenset of model_type strings mlx_vlm supports (discovered via
-    pkgutil + MODEL_REMAPPING); cached at module level by _is_vlm()."""
+    """Discover only model types whose mlx-vlm config declares a modality."""
     types_set = set()
     try:
         import mlx_vlm.models as vlm_models_pkg
         import pkgutil
-        for importer, modname, ispkg in pkgutil.iter_modules(vlm_models_pkg.__path__):
-            if ispkg:
+        for finder, modname, ispkg in pkgutil.iter_modules(vlm_models_pkg.__path__):
+            if not ispkg:
+                continue
+            if _config_source_has_modality(Path(finder.path) / modname):
                 types_set.add(modname)
     except ImportError:
         pass
@@ -1176,8 +1208,8 @@ def _build_vlm_model_types():
     try:
         from mlx_vlm.utils import MODEL_REMAPPING
         for src, tgt in MODEL_REMAPPING.items():
-            types_set.add(src)
-            types_set.add(tgt)
+            if src in types_set or tgt in types_set:
+                types_set.update((src, tgt))
     except (ImportError, AttributeError):
         pass
 
@@ -4019,6 +4051,8 @@ def _ensure_vlm_prompt_utils_patched():
     for modname in (
         "mlx_vlm.chat",
         "mlx_vlm.generate",
+        "mlx_vlm.generate.dispatch",
+        "mlx_vlm.generate.ar",
         "mlx_vlm.server",
         "mlx_vlm.evals.utils",
     ):
@@ -4026,7 +4060,7 @@ def _ensure_vlm_prompt_utils_patched():
             module = importlib.import_module(modname)
         except Exception:
             continue
-        if hasattr(module, "apply_chat_template"):
+        if getattr(module, "apply_chat_template", None) is _original_vlm_apply_chat_template:
             module.apply_chat_template = patched_apply_chat_template
 
     _vlm_prompt_utils_patched = True

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -280,8 +280,8 @@ def _message_matches_known_fallback(message, rule):
 
 def _raise_if_qk_norm_version_gap(model_type, message, error):
     """A strict mlx load rejecting q_norm / k_norm means mlx-lm / mlx-vlm is too
-    old (or regressed, e.g. 0.31.3 - mlx-lm #1242) for a QK-norm arch; dropping
-    those weights breaks the model, so raise a clear error instead."""
+    old or incompatible for a QK-norm arch; dropping those weights breaks the
+    model, so raise a clear error instead."""
     if "parameters not in model" not in message:
         return
     if not any(marker in message for marker in ("k_norm", "q_norm")):
@@ -309,9 +309,10 @@ def _raise_if_qk_norm_version_gap(model_type, message, error):
     raise ValueError(
         f"Unsloth: cannot load MLX {model_type or 'model'} - the installed "
         f"mlx-lm / mlx-vlm rejects its QK-norm (q_norm/k_norm) weights, so it is "
-        f"too old or regressed for this architecture (mlx-lm 0.31.3 broke "
-        f"gemma4 / qwen3_5). Reinstall an arch-complete build, e.g. "
-        f'`pip install -U "mlx-lm>=0.22.0,!=0.31.3" "mlx-vlm"`. See mlx-lm #1242.{installed}'
+        f"too old or incompatible for this architecture. Upgrade unsloth-zoo, mlx, "
+        f"mlx-lm, mlx-vlm, and mlx-audio together through the supported installer "
+        f"or dependency policy for your environment; Studio users should rerun "
+        f"installer/repair. Do not bypass this error with strict=False.{installed}"
     ) from error
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2049,17 +2049,10 @@ def _patch_mixed_precision_set_dtype(model):
 _vlm_prompt_utils_patched = False
 _original_vlm_apply_chat_template = None
 
-_MULTIMODAL_ITEM_TYPES = frozenset(
-    {
-        "image",
-        "image_url",
-        "input_image",
-        "audio",
-        "input_audio",
-        "video",
-    }
-)
 _NON_USER_ROLES = frozenset({"system", "assistant"})
+_COUNT_RENDERER_ITEM_TYPES = frozenset(
+    {"text", "input_text", "image", "image_url", "input_image", "audio", "input_audio", "video", "input_video", "video_url"}
+)
 _ROLE_PROMPT_NAMES = {
     "user": "Human",
     "assistant": "Assistant",
@@ -3697,24 +3690,31 @@ def _apply_mlx_distributed_sharding(
     return mode
 
 
+def _structured_multimodal_counts(content):
+    """Count explicit image, audio, and video items in structured content."""
+    if isinstance(content, list):
+        counts = [_structured_multimodal_counts(item) for item in content]
+        return tuple(sum(values) for values in zip(*counts)) if counts else (0, 0, 0)
+
+    if not isinstance(content, dict):
+        return (0, 0, 0)
+
+    item_type = str(content.get("type", "")).lower()
+    if item_type in ("image", "image_url", "input_image"):
+        return (1, 0, 0)
+    if item_type in ("audio", "input_audio"):
+        return (0, 1, 0)
+    if item_type in ("video", "input_video", "video_url"):
+        return (0, 0, 1)
+    nested = content.get("content", None)
+    if nested is not None and nested is not content:
+        return _structured_multimodal_counts(nested)
+    return (0, 0, 0)
+
+
 def _content_has_structured_multimodal_markers(content):
     """Return True when content already contains explicit image/audio/video items."""
-    if isinstance(content, list):
-        for item in content:
-            if _content_has_structured_multimodal_markers(item):
-                return True
-        return False
-
-    if isinstance(content, dict):
-        item_type = str(content.get("type", "")).lower()
-        if item_type in _MULTIMODAL_ITEM_TYPES:
-            return True
-        nested = content.get("content", None)
-        if nested is not None and nested is not content:
-            return _content_has_structured_multimodal_markers(nested)
-        return False
-
-    return False
+    return any(_structured_multimodal_counts(content))
 
 
 def _normalize_prompt_messages(prompt_utils_module, prompt):
@@ -3740,6 +3740,56 @@ def _messages_have_structured_multimodal_content(messages):
     return any(
         _content_has_structured_multimodal_markers(message.get("content", ""))
         for message in messages
+    )
+
+
+def _content_matches_count_renderer_shape(content):
+    """Return whether mlx-vlm's flat content extractor preserves this content."""
+    if isinstance(content, str):
+        return True
+    if not isinstance(content, list):
+        return False
+    return all(
+        isinstance(item, dict)
+        and str(item.get("type", "")) in _COUNT_RENDERER_ITEM_TYPES
+        and not isinstance(item.get("content"), (list, dict))
+        for item in content
+    )
+
+
+def _prompt_has_tool_metadata(prompt):
+    """Return whether mlx-vlm bypasses count rendering for a tool message."""
+    items = prompt if isinstance(prompt, list) else [prompt]
+    return any(
+        isinstance(item, dict)
+        and ("tool_calls" in item or "tool_call_id" in item or item.get("role") == "tool")
+        for item in items
+    )
+
+
+def _structured_media_matches_count_renderer(messages, num_images, num_audios):
+    """Return whether upstream count-based rendering preserves media ownership."""
+    last_target_idx = -1
+    media_indices = set()
+    totals = [0, 0, 0]
+    for i, message in enumerate(messages):
+        role = str(message.get("role", "user"))
+        if role not in _NON_USER_ROLES:
+            last_target_idx = i
+        content = message.get("content", "")
+        if not _content_matches_count_renderer_shape(content):
+            return False
+        counts = _structured_multimodal_counts(content)
+        if any(counts):
+            media_indices.add(i)
+            totals = [total + count for total, count in zip(totals, counts)]
+
+    return (
+        last_target_idx >= 0
+        and str(messages[last_target_idx].get("role", "user")) == "user"
+        and media_indices == {last_target_idx}
+        and any(totals)
+        and totals == [num_images, num_audios, 0]
     )
 
 
@@ -3844,7 +3894,7 @@ def _flatten_multimodal_content_for_prompt(
             return image_token
         if item_type in ("audio", "input_audio"):
             return audio_token
-        if item_type == "video":
+        if item_type in ("video", "input_video", "video_url"):
             return video_token
         nested = content.get("content", None)
         if nested is not None and nested is not content:
@@ -3965,6 +4015,15 @@ def _render_vlm_template_or_fallback(
     return rendered
 
 
+def _has_vlm_template_result(rendered):
+    """Return whether a chat renderer produced a usable prompt or message list."""
+    if isinstance(rendered, str):
+        return bool(rendered.strip())
+    if isinstance(rendered, (list, tuple, dict)):
+        return bool(rendered)
+    return rendered is not None
+
+
 def _ensure_vlm_prompt_utils_patched():
     """Patch mlx-vlm chat-template helper for stable multi-turn multimodal chat."""
     global _vlm_prompt_utils_patched, _original_vlm_apply_chat_template
@@ -4012,6 +4071,32 @@ def _ensure_vlm_prompt_utils_patched():
                 kwargs=kwargs,
             )
         )
+        if (
+            not return_messages
+            and not kwargs.get("video")
+            and not _prompt_has_tool_metadata(prompt)
+            and model_type in getattr(prompt_utils, "MODEL_CONFIG", {})
+            and _structured_media_matches_count_renderer(
+                normalized_messages, num_images, num_audios
+            )
+        ):
+            try:
+                rendered = _original_vlm_apply_chat_template(
+                    processor,
+                    config,
+                    prompt,
+                    add_generation_prompt=add_generation_prompt,
+                    return_messages=return_messages,
+                    num_images=num_images,
+                    num_audios=num_audios,
+                    **kwargs,
+                )
+            except Exception:
+                pass
+            else:
+                if _has_vlm_template_result(rendered):
+                    return rendered
+
         if needs_custom_render:
             if return_messages:
                 return template_messages

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -22,15 +22,19 @@ No GPU deps: uses mlx-lm (text) and mlx-vlm (VLM) instead of unsloth.models
 
 import ast
 import gc
+import hashlib
 import json
 import importlib
 import inspect
+import io
 import math
 import os
 import re
 import shutil
 import sys
 import tempfile
+import textwrap
+import tokenize
 import types
 import warnings
 import weakref
@@ -38,6 +42,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from fnmatch import fnmatch
+from functools import wraps
 from pathlib import Path
 
 from .compile import (
@@ -2331,6 +2336,205 @@ def _resolve_mlx_vlm_model_class(model_type):
         if cls is not None:
             return cls
     return None
+
+
+_MINICPM_SOURCE_PREFIXES = ("llm.", "vpm.", "apm.")
+_MINICPM_MLX_PREFIX_ALIASES = {
+    "language_model.": "llm.",
+    "vision_tower.": "vpm.",
+    "audio_tower.": "apm.",
+}
+_MINICPM_SANITIZE_TOKEN_SHA256 = (
+    "0706ec1a5d2252c16b6e9a2e665c7774fb6061aef763494d8e78d3fda68b439b"
+)
+
+
+def _source_token_sha256(source: str) -> str:
+    """Hash Python tokens while retaining indentation as semantic markers."""
+
+    ignored = {
+        tokenize.ENCODING,
+        tokenize.COMMENT,
+        tokenize.NL,
+        tokenize.NEWLINE,
+        tokenize.ENDMARKER,
+    }
+    parts = []
+    try:
+        tokens = tokenize.generate_tokens(
+            io.StringIO(textwrap.dedent(source)).readline
+        )
+        for token in tokens:
+            if token.type in ignored:
+                continue
+            if token.type == tokenize.INDENT:
+                parts.append("<INDENT>")
+            elif token.type == tokenize.DEDENT:
+                parts.append("<DEDENT>")
+            else:
+                parts.append(token.string)
+    except (IndentationError, tokenize.TokenError, TypeError):
+        return ""
+    return hashlib.sha256("\0".join(parts).encode()).hexdigest()
+
+
+def _unconditionally_sanitizes_mlx_vlm_weights(load_model) -> bool:
+    """Whether load_model sanitizes model weights without an MLX-format gate."""
+
+    try:
+        tree = ast.parse(textwrap.dedent(_safe_getsource(load_model)))
+    except (IndentationError, SyntaxError):
+        return False
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "load_model"
+    ]
+    if len(functions) != 1:
+        return False
+    function = functions[0]
+    sanitize_calls = [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "sanitize_weights"
+        and len(node.args) >= 2
+        and all(
+            isinstance(argument, ast.Name) and argument.id == expected
+            for argument, expected in zip(node.args[:2], ("model", "weights"))
+        )
+    ]
+    direct_assignments = [
+        statement
+        for statement in function.body
+        if isinstance(statement, ast.Assign)
+        and len(statement.targets) == 1
+        and isinstance(statement.targets[0], ast.Name)
+        and statement.targets[0].id == "weights"
+        and sanitize_calls
+        and statement.value is sanitize_calls[0]
+    ]
+    if len(sanitize_calls) != 1 or len(direct_assignments) != 1:
+        return False
+    assignment_index = function.body.index(direct_assignments[0])
+    return not any(
+        isinstance(node, ast.Return)
+        for statement in function.body[:assignment_index]
+        for node in ast.walk(statement)
+    )
+
+
+def _minicpmo_sanitize_requires_source_prefixes(sanitize) -> bool:
+    """Whether MiniCPM accepts source tower names but drops converted names."""
+
+    try:
+        parameters = inspect.signature(
+            sanitize,
+            follow_wrapped=False,
+        ).parameters
+    except (TypeError, ValueError):
+        return False
+    fingerprint = _source_token_sha256(_safe_getsource(sanitize))
+    if (
+        tuple(parameters) != ("self", "weights")
+        or fingerprint != _MINICPM_SANITIZE_TOKEN_SHA256
+    ):
+        return False
+
+    suffixes = (
+        "model.norm._unsloth_probe",
+        "embeddings.norm._unsloth_probe",
+        "layer_norm._unsloth_probe",
+    )
+    source_keys = tuple(
+        prefix + suffix
+        for prefix, suffix in zip(_MINICPM_SOURCE_PREFIXES, suffixes)
+    )
+    mlx_keys = tuple(
+        prefix + suffix
+        for prefix, suffix in zip(_MINICPM_MLX_PREFIX_ALIASES, suffixes)
+    )
+    values = tuple(object() for _ in source_keys)
+    probe = types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            text_config=types.SimpleNamespace(tie_word_embeddings=False),
+        ),
+    )
+    try:
+        source_result = sanitize(probe, dict(zip(source_keys, values)))
+        mlx_result = sanitize(probe, dict(zip(mlx_keys, values)))
+    except Exception:
+        return False
+    return (
+        isinstance(source_result, Mapping)
+        and tuple(source_result) == mlx_keys
+        and all(source_result[key] is value for key, value in zip(mlx_keys, values))
+        and isinstance(mlx_result, Mapping)
+        and not mlx_result
+    )
+
+
+def _minicpmo_mlx_sanitize_adapter(original):
+    """Delegate converted MiniCPM tower names through its installed sanitizer."""
+
+    if getattr(original, "_unsloth_minicpmo_mlx_weights", False):
+        return original
+    if not _minicpmo_sanitize_requires_source_prefixes(original):
+        return original
+
+    @wraps(original)
+    def patched(self, weights):
+        if not isinstance(weights, Mapping):
+            return original(self, weights)
+        has_source_names = any(
+            key.startswith(_MINICPM_SOURCE_PREFIXES)
+            for key in weights
+        )
+        mlx_prefix_presence = tuple(
+            any(key.startswith(prefix) for key in weights)
+            for prefix in _MINICPM_MLX_PREFIX_ALIASES
+        )
+        if has_source_names and any(mlx_prefix_presence):
+            raise ValueError(
+                "Unsloth: MiniCPM checkpoint mixes source and MLX tower names."
+            )
+        if not all(mlx_prefix_presence):
+            return original(self, weights)
+
+        prepared = {}
+        for key, value in weights.items():
+            for target, source in _MINICPM_MLX_PREFIX_ALIASES.items():
+                if key.startswith(target):
+                    key = source + key[len(target) :]
+                    break
+            prepared[key] = value
+        return original(self, prepared)
+
+    patched._unsloth_minicpmo_mlx_weights = True
+    return patched
+
+
+def _ensure_minicpmo_mlx_sanitize(model_type: str) -> None:
+    """Preserve converted MiniCPM weights in unconditional sanitize loaders."""
+
+    cls = _resolve_mlx_vlm_model_class(model_type)
+    if (
+        cls is None
+        or cls.__module__ != "mlx_vlm.models.minicpmo.minicpmo"
+        or not hasattr(cls, "sanitize")
+    ):
+        return
+    try:
+        from mlx_vlm.utils import load_model
+    except (ImportError, AttributeError):
+        return
+    if not _unconditionally_sanitizes_mlx_vlm_weights(load_model):
+        return
+    adapted = _minicpmo_mlx_sanitize_adapter(cls.sanitize)
+    if adapted is not cls.sanitize:
+        cls.sanitize = adapted
 
 
 def _lookup_module_array(root, dotted_key):
@@ -6206,6 +6410,7 @@ class FastMLXModel:
                 install_mlx_compile_patches()
             _ensure_vlm_processor_inputs_patched()
             _ensure_vlm_prompt_utils_patched()
+            _ensure_minicpmo_mlx_sanitize(model_type)
             _ensure_audio_conv_sanitize(model_type)
 
             quant_state = _ensure_quantization_compatible(

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4833,7 +4833,14 @@ def _normalize_prompt_messages(prompt_utils_module, prompt):
         role_content = prompt_utils_module._get_role_content(item)
         if role_content is not None:
             role, content = role_content
-            messages.append({"role": role, "content": content})
+            message = dict(item) if isinstance(item, dict) else {}
+            normalize_tool_calls = getattr(
+                prompt_utils_module, "_normalize_tool_call_arguments", None
+            )
+            if isinstance(item, dict) and callable(normalize_tool_calls):
+                message = normalize_tool_calls(message)
+            message.update(role=role, content=content)
+            messages.append(message)
             continue
 
         messages.append({"role": "user", "content": str(item)})
@@ -4933,18 +4940,22 @@ def _anchor_conversation_media_to_first_user_turn(
             message.get("content", "")
         )
         is_target = i == target_idx and role.lower() not in _NON_USER_ROLES
-        anchored.append(
-            prompt_utils_module.get_message_json(
-                model_type,
-                content,
-                role,
-                skip_image_token=not is_target,
-                skip_audio_token=not is_target,
-                num_images=num_images,
-                num_audios=num_audios,
-                **kwargs,
-            )
+        rendered = prompt_utils_module.get_message_json(
+            model_type,
+            content,
+            role,
+            skip_image_token=not is_target,
+            skip_audio_token=not is_target,
+            num_images=num_images,
+            num_audios=num_audios,
+            **kwargs,
         )
+        if isinstance(message, dict):
+            if isinstance(rendered, dict):
+                rendered = {**message, **rendered}
+            elif set(message).difference(("role", "content")):
+                rendered = {**message, "role": role, "content": rendered}
+        anchored.append(rendered)
     return anchored
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -1233,6 +1233,7 @@ def _inherit_mlx_vlm_processor_runtime(processor, repaired):
 def _bind_mlx_vlm_processor_loader(load_callable, *, allow_remote_code=False):
     """Bind processor recovery to one mlx-vlm load without global mutation."""
 
+    _ensure_vlm_detokenizer_copy()
     if not isinstance(load_callable, types.FunctionType):
         return load_callable
     processor_loader = load_callable.__globals__.get("load_processor")
@@ -2350,6 +2351,9 @@ _MINICPM_SANITIZE_TOKEN_SHA256 = (
 _MINICPM_LEGACY_VISION_TOKEN_SHA256 = (
     "54965adc15f72ca21df0dc646467c8e588f83de19edd2aacad70362690d6648a"
 )
+_MLX_VLM_DETOKENIZER_COPY_TOKEN_SHA256 = (
+    "deceb0843cbd9ba04bb86cded962550e7ae0a8814cf321fd61d654a07458262e"
+)
 
 
 def _source_token_sha256(source: str) -> str:
@@ -2379,6 +2383,49 @@ def _source_token_sha256(source: str) -> str:
     except (IndentationError, tokenize.TokenError, TypeError):
         return ""
     return hashlib.sha256("\0".join(parts).encode()).hexdigest()
+
+
+def _ensure_vlm_detokenizer_copy() -> None:
+    """Backfill request-local copies for the defective naive detokenizer."""
+
+    try:
+        module = importlib.import_module("mlx_vlm.tokenizer_utils")
+    except Exception:
+        return
+    detokenizer = getattr(module, "NaiveStreamingDetokenizer", None)
+    factory = getattr(module, "make_streaming_detokenizer", None)
+    if (
+        not isinstance(detokenizer, type)
+        or getattr(detokenizer, "__copy__", None) is not None
+        or _source_token_sha256(_safe_getsource(factory))
+        != _MLX_VLM_DETOKENIZER_COPY_TOKEN_SHA256
+    ):
+        return
+    base = detokenizer.__mro__[1]
+    text = detokenizer.__dict__.get("text")
+    try:
+        parameters = tuple(
+            inspect.signature(
+                detokenizer.__init__, follow_wrapped=False
+            ).parameters
+        )
+    except (TypeError, ValueError):
+        return
+    if (
+        detokenizer.__module__ != module.__name__
+        or base.__module__ != module.__name__
+        or base.__name__ != "StreamingDetokenizer"
+        or "text" not in getattr(base, "__slots__", ())
+        or not isinstance(text, property)
+        or text.fset is not None
+        or parameters != ("self", "tokenizer")
+    ):
+        return
+
+    def __copy__(self):
+        return type(self)(self._tokenizer)
+
+    detokenizer.__copy__ = __copy__
 
 
 def _unconditionally_sanitizes_mlx_vlm_weights(load_model) -> bool:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -742,9 +742,13 @@ def _materialize_mlx_vlm_config_override(
         return local_path, config_data
 
     override_dir = tempfile.mkdtemp(prefix="unsloth_mlx_vlm_config_")
+    # why: a relative model dir would make every link resolve against the
+    # temporary directory instead of the caller's cwd, dangling the weights and
+    # tokenizer. Only the link targets change; the returned path is untouched.
+    source_dir = os.path.abspath(local_path)
     try:
-        for name in os.listdir(local_path):
-            src = os.path.join(local_path, name)
+        for name in os.listdir(source_dir):
+            src = os.path.join(source_dir, name)
             dst = os.path.join(override_dir, name)
             if name in patched_files:
                 continue

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -741,7 +741,7 @@ def _materialize_mlx_vlm_config_override(
     override_dir = tempfile.mkdtemp(prefix="unsloth_mlx_vlm_config_")
     try:
         for name in os.listdir(local_path):
-            src = os.path.join(local_path, name)
+            src = os.path.abspath(os.path.join(local_path, name))
             dst = os.path.join(override_dir, name)
             if name in patched_files:
                 continue

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -1025,6 +1025,7 @@ def _load_mlx_vlm_distributed(
         sharded_load,
         allow_remote_code=allow_remote_code,
     )
+    sharded_load = _bind_mlx_vlm_quantized_projector_loader(sharded_load)
 
     try:
         with _temporary_hf_token_env(hf_token):
@@ -1307,6 +1308,171 @@ def _bind_mlx_vlm_processor_loader(load_callable, *, allow_remote_code=False):
 
     load_globals = dict(load_callable.__globals__)
     load_globals["load_processor"] = scoped_processor_loader
+    scoped_load = types.FunctionType(
+        load_callable.__code__,
+        load_globals,
+        load_callable.__name__,
+        load_callable.__defaults__,
+        load_callable.__closure__,
+    )
+    scoped_load.__kwdefaults__ = load_callable.__kwdefaults__
+    return scoped_load
+
+
+def _bind_mlx_vlm_quantized_projector_loader(load_callable):
+    """Honor checkpoint-quantized projectors in a known legacy loader shape.
+
+    Mlx-vlm briefly skipped every ``multi_modal_projector`` whenever the
+    vision tower was dense, before considering projector tensors that were
+    independently quantized. Keep the installed predicate and alter only that
+    ordering, in this load call, when its source still has the exact legacy
+    branch. Unknown and already checkpoint-aware loaders remain untouched.
+
+    The outer quantize call is part of the capability contract too. Requiring
+    its keyword predicate binding keeps positional or otherwise refactored
+    loaders native, while the scoped ``nn`` proxy ensures no installed module
+    global is changed for concurrent loads.
+    """
+
+    if not isinstance(load_callable, types.FunctionType):
+        return load_callable
+    model_loader = load_callable.__globals__.get("load_model")
+    if not isinstance(model_loader, types.FunctionType):
+        return load_callable
+    original_skip = model_loader.__globals__.get("skip_multimodal_module")
+    original_nn = model_loader.__globals__.get("nn")
+    if not callable(original_skip) or not callable(getattr(original_nn, "quantize", None)):
+        return load_callable
+    try:
+        projector_is_skipped = original_skip("multi_modal_projector.linear_1")
+    except Exception:
+        return load_callable
+
+    try:
+        source_tree = ast.parse(_safe_getsource(model_loader))
+    except (IndentationError, SyntaxError):
+        return load_callable
+    source_predicates = [
+        node
+        for node in ast.walk(source_tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "get_class_predicate"
+    ]
+    quantize_calls = [
+        node
+        for node in ast.walk(source_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "nn"
+        and node.func.attr == "quantize"
+    ]
+    predicate_keywords = [
+        keyword
+        for call in quantize_calls
+        for keyword in call.keywords
+        if keyword.arg == "class_predicate"
+    ]
+    expected_predicate = ast.parse(
+        """
+def get_class_predicate(p, m):
+    if skip_multimodal_module(p) and skip_vision:
+        return False
+    if p in config["quantization"]:
+        return config["quantization"][p]
+    if not hasattr(m, "to_quantized"):
+        return False
+    if hasattr(m, "weight") and m.weight.size % 64 != 0:
+        return False
+    return f"{p}.scales" in weights
+"""
+    ).body[0]
+    predicates = [
+        value
+        for value in model_loader.__code__.co_consts
+        if isinstance(value, types.CodeType)
+        and value.co_name == "get_class_predicate"
+    ]
+    if (
+        not projector_is_skipped
+        or len(predicates) != 1
+        or len(source_predicates) != 1
+        or ast.dump(source_predicates[0]) != ast.dump(expected_predicate)
+        or len(quantize_calls) != 1
+        or len(predicate_keywords) != 1
+        or not isinstance(predicate_keywords[0].value, ast.Name)
+        or predicate_keywords[0].value.id != "get_class_predicate"
+    ):
+        return load_callable
+
+    def checkpoint_aware_skip(path):
+        if "multi_modal_projector" in path:
+            return False
+        return original_skip(path)
+
+    def checkpoint_aware_quantize(model, *args, class_predicate=None, **kwargs):
+        if (
+            not isinstance(class_predicate, types.FunctionType)
+            or class_predicate.__code__ is not predicates[0]
+            or class_predicate.__closure__ is None
+        ):
+            if class_predicate is None:
+                return original_nn.quantize(model, *args, **kwargs)
+            return original_nn.quantize(
+                model, *args, class_predicate=class_predicate, **kwargs,
+            )
+        closure = dict(zip(
+            class_predicate.__code__.co_freevars,
+            (cell.cell_contents for cell in class_predicate.__closure__),
+        ))
+        weights = closure.get("weights")
+        if not isinstance(weights, Mapping):
+            if class_predicate is None:
+                return original_nn.quantize(model, *args, **kwargs)
+            return original_nn.quantize(
+                model, *args, class_predicate=class_predicate, **kwargs,
+            )
+
+        predicate_globals = dict(class_predicate.__globals__)
+        predicate_globals["skip_multimodal_module"] = checkpoint_aware_skip
+        projector_predicate = types.FunctionType(
+            class_predicate.__code__,
+            predicate_globals,
+            class_predicate.__name__,
+            class_predicate.__defaults__,
+            class_predicate.__closure__,
+        )
+
+        def guarded_predicate(path, module):
+            if "multi_modal_projector" not in path:
+                return class_predicate(path, module)
+            if f"{path}.scales" not in weights:
+                return False
+            return projector_predicate(path, module)
+
+        return original_nn.quantize(
+            model, *args, class_predicate=guarded_predicate, **kwargs,
+        )
+
+    class ScopedNN:
+        quantize = staticmethod(checkpoint_aware_quantize)
+
+        def __getattr__(self, name):
+            return getattr(original_nn, name)
+
+    model_globals = dict(model_loader.__globals__)
+    model_globals["nn"] = ScopedNN()
+    scoped_model_loader = types.FunctionType(
+        model_loader.__code__,
+        model_globals,
+        model_loader.__name__,
+        model_loader.__defaults__,
+        model_loader.__closure__,
+    )
+    scoped_model_loader.__kwdefaults__ = model_loader.__kwdefaults__
+
+    load_globals = dict(load_callable.__globals__)
+    load_globals["load_model"] = scoped_model_loader
     scoped_load = types.FunctionType(
         load_callable.__code__,
         load_globals,
@@ -6027,6 +6193,7 @@ class FastMLXModel:
                 vlm_load,
                 allow_remote_code=trust_remote_code,
             )
+            vlm_load = _bind_mlx_vlm_quantized_projector_loader(vlm_load)
 
             if text_only is False and not _is_vlm(config_data):
                 warnings.warn(

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -4452,6 +4452,18 @@ def _ensure_vlm_prompt_utils_patched():
     _vlm_prompt_utils_patched = True
 
 
+def _ensure_vlm_processor_inputs_patched():
+    """Patch mlx-vlm's processor call without replacing its input preparation."""
+
+    from .utils import _mlx_vlm_process_inputs_adapter
+
+    vlm_utils = importlib.import_module("mlx_vlm.utils")
+    original = vlm_utils.process_inputs
+    adapted = _mlx_vlm_process_inputs_adapter(original)
+    if adapted is not original:
+        vlm_utils.process_inputs = adapted
+
+
 def _mlx_save_pretrained_merged(self, save_directory, tokenizer=None, **kwargs):
     from .utils import collect_mlx_lora_adapter_tensors, save_pretrained_merged
     tokenizer = tokenizer or self._tokenizer
@@ -6025,6 +6037,7 @@ class FastMLXModel:
 
             if patch_mode == "patched":
                 install_mlx_compile_patches()
+            _ensure_vlm_processor_inputs_patched()
             _ensure_vlm_prompt_utils_patched()
             _ensure_audio_conv_sanitize(model_type)
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -665,9 +665,12 @@ def _materialize_mlx_vlm_config_override(
     if not local_path:
         return local_path, config_data
     patched_files = {}
-    source_config = _read_json_file(os.path.join(local_path, "config.json"))
-    if source_config != config_data:
-        patched_files["config.json"] = config_data
+    # why: persist a caller-corrected config only when a sidecar exists to
+    # differ from. An absent config.json must not force a temporary view.
+    source_config_path = os.path.join(local_path, "config.json")
+    if os.path.exists(source_config_path):
+        if _read_json_file(source_config_path) != config_data:
+            patched_files["config.json"] = config_data
 
     corrected_model_type = _deepseek_ocr_config_model_type(config_data)
     patched_config = config_data

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2347,6 +2347,9 @@ _MINICPM_MLX_PREFIX_ALIASES = {
 _MINICPM_SANITIZE_TOKEN_SHA256 = (
     "0706ec1a5d2252c16b6e9a2e665c7774fb6061aef763494d8e78d3fda68b439b"
 )
+_MINICPM_LEGACY_VISION_TOKEN_SHA256 = (
+    "54965adc15f72ca21df0dc646467c8e588f83de19edd2aacad70362690d6648a"
+)
 
 
 def _source_token_sha256(source: str) -> str:
@@ -2535,6 +2538,79 @@ def _ensure_minicpmo_mlx_sanitize(model_type: str) -> None:
     adapted = _minicpmo_mlx_sanitize_adapter(cls.sanitize)
     if adapted is not cls.sanitize:
         cls.sanitize = adapted
+
+
+def _minicpmo_vision_dtype_adapter(original):
+    """Use the vision execution dtype in the exact legacy MiniCPM method."""
+
+    if getattr(original, "_unsloth_minicpmo_vision_dtype", False):
+        return original
+    owner = "mlx_vlm.models.minicpmo.minicpmo"
+    if (
+        not isinstance(original, types.FunctionType)
+        or original.__module__ != owner
+        or original.__name__ != "get_vision_embedding"
+    ):
+        return original
+    try:
+        parameters = inspect.signature(
+            original,
+            follow_wrapped=False,
+        ).parameters
+    except (TypeError, ValueError):
+        return original
+    converter = original.__globals__.get("_to_mx_array")
+    if (
+        tuple(parameters) != ("self", "pixel_values", "tgt_sizes")
+        or _source_token_sha256(_safe_getsource(original))
+        != _MINICPM_LEGACY_VISION_TOKEN_SHA256
+        or not isinstance(converter, types.FunctionType)
+        or converter.__module__ != owner
+        or converter.__name__ != "_to_mx_array"
+    ):
+        return original
+
+    @wraps(original)
+    def patched(self, pixel_values, tgt_sizes):
+        try:
+            vision_dtype = (
+                self.vision_tower.embeddings.patch_embedding.weight.dtype
+            )
+        except AttributeError:
+            return original(self, pixel_values, tgt_sizes)
+
+        def convert(value, dtype=None):
+            return converter(value, dtype=vision_dtype)
+
+        scoped_globals = dict(original.__globals__)
+        scoped_globals["_to_mx_array"] = convert
+        scoped = types.FunctionType(
+            original.__code__,
+            scoped_globals,
+            original.__name__,
+            original.__defaults__,
+            original.__closure__,
+        )
+        scoped.__kwdefaults__ = original.__kwdefaults__
+        return scoped(self, pixel_values, tgt_sizes)
+
+    patched._unsloth_minicpmo_vision_dtype = True
+    return patched
+
+
+def _ensure_minicpmo_vision_dtype(model_type: str) -> None:
+    """Patch only the MiniCPM callable that uses packed language dtype."""
+
+    cls = _resolve_mlx_vlm_model_class(model_type)
+    if (
+        cls is None
+        or cls.__module__ != "mlx_vlm.models.minicpmo.minicpmo"
+        or not hasattr(cls, "get_vision_embedding")
+    ):
+        return
+    adapted = _minicpmo_vision_dtype_adapter(cls.get_vision_embedding)
+    if adapted is not cls.get_vision_embedding:
+        cls.get_vision_embedding = adapted
 
 
 def _lookup_module_array(root, dotted_key):
@@ -6411,6 +6487,7 @@ class FastMLXModel:
             _ensure_vlm_processor_inputs_patched()
             _ensure_vlm_prompt_utils_patched()
             _ensure_minicpmo_mlx_sanitize(model_type)
+            _ensure_minicpmo_vision_dtype(model_type)
             _ensure_audio_conv_sanitize(model_type)
 
             quant_state = _ensure_quantization_compatible(

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -1325,7 +1325,7 @@ def _bind_mlx_vlm_processor_loader(load_callable, *, allow_remote_code=False):
     return scoped_load
 
 
-def _bind_mlx_vlm_quantized_projector_loader(load_callable):
+def _bind_mlx_vlm_quantized_projector_loader(load_callable, *, model_type=None):
     """Honor checkpoint-quantized projectors in a known legacy loader shape.
 
     Mlx-vlm briefly skipped every ``multi_modal_projector`` whenever the
@@ -1340,6 +1340,7 @@ def _bind_mlx_vlm_quantized_projector_loader(load_callable):
     global is changed for concurrent loads.
     """
 
+    _ensure_lfm2_projector_layernorm(model_type)
     if not isinstance(load_callable, types.FunctionType):
         return load_callable
     model_loader = load_callable.__globals__.get("load_model")
@@ -2354,6 +2355,12 @@ _MINICPM_LEGACY_VISION_TOKEN_SHA256 = (
 _MLX_VLM_DETOKENIZER_COPY_TOKEN_SHA256 = (
     "deceb0843cbd9ba04bb86cded962550e7ae0a8814cf321fd61d654a07458262e"
 )
+_LFM2_PROJECTOR_INIT_TOKEN_SHA256 = (
+    "6534244e2803564731343c4768c75b04d7bc86fc061ae12c59df55c8867b894e"
+)
+_LFM2_PROJECTOR_CALL_TOKEN_SHA256 = (
+    "4405529c372e5bc69cf782c1038b674b55b46434e9a515d9db46a2a92e0414fa"
+)
 
 
 def _source_token_sha256(source: str) -> str:
@@ -2426,6 +2433,45 @@ def _ensure_vlm_detokenizer_copy() -> None:
         return type(self)(self._tokenizer)
 
     detokenizer.__copy__ = __copy__
+
+
+def _ensure_lfm2_projector_layernorm(model_type) -> None:
+    """Do not register LFM projector normalization when config disables it."""
+
+    if model_type != "lfm2_vl":
+        return
+    try:
+        module = importlib.import_module(
+            "mlx_vlm.models.lfm2_vl.lfm2_vl"
+        )
+    except Exception:
+        return
+    projector = getattr(module, "Lfm2VlMultiModalProjector", None)
+    if (
+        not isinstance(projector, type)
+        or projector.__module__ != module.__name__
+        or projector.__name__ != "Lfm2VlMultiModalProjector"
+    ):
+        return
+    installed_init = projector.__init__
+    installed_call = projector.__call__
+    if (
+        getattr(installed_init, "_unsloth_disabled_layernorm", False)
+        or _source_token_sha256(_safe_getsource(installed_init))
+        != _LFM2_PROJECTOR_INIT_TOKEN_SHA256
+        or _source_token_sha256(_safe_getsource(installed_call))
+        != _LFM2_PROJECTOR_CALL_TOKEN_SHA256
+    ):
+        return
+
+    @wraps(installed_init)
+    def patched(self, config):
+        installed_init(self, config)
+        if not self.projector_use_layernorm:
+            del self.layer_norm
+
+    patched._unsloth_disabled_layernorm = True
+    projector.__init__ = patched
 
 
 def _unconditionally_sanitizes_mlx_vlm_weights(load_model) -> bool:
@@ -6520,7 +6566,10 @@ class FastMLXModel:
                 vlm_load,
                 allow_remote_code=trust_remote_code,
             )
-            vlm_load = _bind_mlx_vlm_quantized_projector_loader(vlm_load)
+            vlm_load = _bind_mlx_vlm_quantized_projector_loader(
+                vlm_load,
+                model_type=model_type,
+            )
 
             if text_only is False and not _is_vlm(config_data):
                 warnings.warn(

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -267,26 +267,39 @@ _KNOWN_MLX_LM_STRICT_FALLBACKS = {
 
 _KNOWN_VLM_EXTRA_WEIGHT_FILTERS = {
     "gemma4": {
-        "message_tokens": (
-            "parameters not in model",
-            "per_layer_model_projection",
-            "scales",
-            "biases",
+        "message_token_sets": (
+            (
+                "parameters not in model",
+                "per_layer_model_projection",
+                "scales",
+                "biases",
+            ),
+            (
+                "parameters not in model",
+                "language_model.model.layers.",
+                "self_attn.k_proj",
+                "self_attn.v_proj",
+                "self_attn.k_norm",
+            ),
         ),
         "notice": (
-            "Unsloth: Gemma4 VLM checkpoint has extra quantized "
-            "per-layer projection state - ignoring only those known keys."
+            "Unsloth: Gemma4 VLM checkpoint has extra model state - "
+            "ignoring only keys known to be unused by the installed model."
         ),
         "allowed_extra": frozenset({
             "language_model.model.per_layer_model_projection.biases",
             "language_model.model.per_layer_model_projection.scales",
         }),
+        "allow_shared_kv": True,
     },
 }
 
 
 def _message_matches_known_fallback(message, rule):
-    return all(token in message for token in rule.get("message_tokens", ()))
+    token_sets = rule.get("message_token_sets")
+    if token_sets is None:
+        token_sets = (rule.get("message_tokens", ()),)
+    return any(all(token in message for token in tokens) for tokens in token_sets)
 
 
 def _raise_if_qk_norm_version_gap(model_type, message, error):
@@ -972,17 +985,28 @@ def _load_mlx_vlm_with_extra_weight_filter(
 
         allowed_extra = rule["allowed_extra"]
 
-        # why: nn.Module.load_weights is patched process-globally; lock so
-        # a concurrent load doesn't see the filtered version.
+        # why: nn.Module.load_weights is patched process-globally; the lock
+        # serializes retries and the owner check preserves concurrent native loads.
         with _LOAD_WEIGHTS_PATCH_LOCK:
             original_load_weights = nn.Module.load_weights
+            retry_thread = threading.get_ident()
 
             def _load_weights_without_projection_quant_state(self, file_or_weights, strict=True):
+                if threading.get_ident() != retry_thread:
+                    return original_load_weights(
+                        self, file_or_weights, strict=strict
+                    )
                 if isinstance(file_or_weights, list):
                     file_or_weights = [
                         (key, value)
                         for key, value in file_or_weights
-                        if key not in allowed_extra
+                        if (
+                            key not in allowed_extra
+                            and not (
+                                rule.get("allow_shared_kv", False)
+                                and _gemma4_unused_shared_kv_weight(self, key)
+                            )
+                        )
                     ]
                 return original_load_weights(self, file_or_weights, strict=strict)
 
@@ -2361,6 +2385,9 @@ _LFM2_PROJECTOR_INIT_TOKEN_SHA256 = (
 _LFM2_PROJECTOR_CALL_TOKEN_SHA256 = (
     "4405529c372e5bc69cf782c1038b674b55b46434e9a515d9db46a2a92e0414fa"
 )
+_GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256 = (
+    "e859b50eb966089f8966a38ca2e69c3b68ccf48c5b4a264fbc01f415be60003f"
+)
 
 
 def _source_token_sha256(source: str) -> str:
@@ -2472,6 +2499,38 @@ def _ensure_lfm2_projector_layernorm(model_type) -> None:
 
     patched._unsloth_disabled_layernorm = True
     projector.__init__ = patched
+
+
+def _gemma4_unused_shared_kv_weight(model, key) -> bool:
+    """Whether the installed Gemma4 model owns this redundant shared-KV key."""
+
+    language_model = getattr(model, "language_model", None)
+    cls = type(language_model)
+    predicate = cls.__dict__.get("_is_unused_shared_kv_weight")
+    if (
+        cls.__module__ != "mlx_vlm.models.gemma4.language"
+        or cls.__name__ != "LanguageModel"
+        or not callable(predicate)
+        or _source_token_sha256(_safe_getsource(predicate))
+        != _GEMMA4_UNUSED_SHARED_KV_TOKEN_SHA256
+    ):
+        return False
+    match = re.fullmatch(
+        r"language_model\.model\.layers\.(0|[1-9][0-9]*)"
+        r"\.self_attn\.(?:[kv]_proj\.(?:weight|bias|biases|scales)"
+        r"|[kv]_norm\.weight)",
+        key,
+    )
+    if match is None:
+        return False
+    layers = getattr(getattr(language_model, "model", None), "layers", ())
+    try:
+        layer_index = int(match.group(1))
+        if layer_index >= len(layers):
+            return False
+        return bool(predicate(language_model, key))
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return False
 
 
 def _unconditionally_sanitizes_mlx_vlm_weights(load_model) -> bool:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5352,6 +5352,19 @@ def _ensure_vlm_prompt_utils_patched():
         if getattr(module, "apply_chat_template", None) is _original_vlm_apply_chat_template:
             module.apply_chat_template = patched_apply_chat_template
 
+    # why: the list above only force-imports mlx-vlm's entry points, so an
+    # already-loaded alias keeps the original -- `mlx_vlm` itself re-exports
+    # this. Sweep loaded mlx-vlm modules by identity instead. Read __dict__
+    # rather than getattr so a lazy module __getattr__ is not woken.
+    for name, module in list(sys.modules.items()):
+        if not name.startswith("mlx_vlm"):
+            continue
+        namespace = getattr(module, "__dict__", None)
+        if namespace is None:
+            continue
+        if namespace.get("apply_chat_template") is _original_vlm_apply_chat_template:
+            namespace["apply_chat_template"] = patched_apply_chat_template
+
     _vlm_prompt_utils_patched = True
 
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -432,19 +432,6 @@ def _normalize_tokenizer_config_extra_special_tokens(
     return patched_config, True
 
 
-def _materialize_mlx_vlm_config_data(local_path, config_data):
-    override_dir = tempfile.mkdtemp(prefix="unsloth_mlx_vlm_config_")
-    for name in os.listdir(local_path):
-        src = os.path.join(local_path, name)
-        dst = os.path.join(override_dir, name)
-        if name == "config.json":
-            continue
-        _link_or_copy_path(src, dst)
-    with open(os.path.join(override_dir, "config.json"), "w") as f:
-        json.dump(config_data, f, indent=2)
-    return override_dir
-
-
 def _mlx_vlm_config_override_data(config_data):
     corrected_model_type = _deepseek_ocr_config_model_type(config_data)
     if (
@@ -479,17 +466,61 @@ def _keep_mlx_vlm_config_view_alive(model, override_dir):
         pass
 
 
+class _MLXVLMConfigViewOwner:
+    """Own a temporary load view until its lifetime moves to the model."""
+
+    def __init__(self, local_path, original_local_path):
+        self._path = str(local_path) if local_path else None
+        self._finalizer = None
+        if (
+            self._path
+            and original_local_path
+            and self._path != str(original_local_path)
+        ):
+            self._finalizer = weakref.finalize(
+                self,
+                shutil.rmtree,
+                self._path,
+                ignore_errors=True,
+            )
+
+    def call(self, operation, *args, **kwargs):
+        try:
+            return operation(*args, **kwargs)
+        except Exception:
+            self.cleanup()
+            raise
+
+    def cleanup(self):
+        if self._finalizer is not None and self._finalizer.alive:
+            self._finalizer()
+
+    def transfer_to(self, model):
+        if self._finalizer is None:
+            return
+        try:
+            _keep_mlx_vlm_config_view_alive(model, self._path)
+        except Exception:
+            self.cleanup()
+            raise
+        self._finalizer.detach()
+
+
 def _materialize_mlx_vlm_config_override(
     local_path,
     config_data,
     *,
     normalize_tokenizer_config=False,
     supports_list_extra_special_tokens=None,
+    allow_tokenizer_remote_code=True,
 ):
     """Return a load path whose sidecars are compatible with mlx-vlm loaders."""
     if not local_path:
         return local_path, config_data
     patched_files = {}
+    source_config = _read_json_file(os.path.join(local_path, "config.json"))
+    if source_config != config_data:
+        patched_files["config.json"] = config_data
 
     corrected_model_type = _deepseek_ocr_config_model_type(config_data)
     patched_config = config_data
@@ -504,35 +535,79 @@ def _materialize_mlx_vlm_config_override(
         patched_config.pop("auto_map", None)
         patched_files["config.json"] = patched_config
 
-    if normalize_tokenizer_config:
+    if normalize_tokenizer_config or not allow_tokenizer_remote_code:
         tokenizer_config = _read_json_file(
             os.path.join(local_path, "tokenizer_config.json")
         )
-        patched_tokenizer_config, patched_tokenizer = (
-            _normalize_tokenizer_config_extra_special_tokens(
-                tokenizer_config,
-                supports_list_extra_special_tokens=supports_list_extra_special_tokens,
+        patched_tokenizer_config = tokenizer_config
+        patched_tokenizer = False
+        if normalize_tokenizer_config:
+            patched_tokenizer_config, patched_tokenizer = (
+                _normalize_tokenizer_config_extra_special_tokens(
+                    patched_tokenizer_config,
+                    supports_list_extra_special_tokens=supports_list_extra_special_tokens,
+                )
             )
-        )
+        if not allow_tokenizer_remote_code:
+            auto_map = patched_tokenizer_config.get("auto_map")
+            if isinstance(auto_map, dict) and auto_map:
+                patched_tokenizer_config = dict(patched_tokenizer_config)
+                patched_tokenizer_config.pop("auto_map", None)
+                patched_tokenizer = True
         if patched_tokenizer:
             patched_files["tokenizer_config.json"] = patched_tokenizer_config
+
+        model_auto_map = patched_config.get("auto_map")
+        if not allow_tokenizer_remote_code and isinstance(model_auto_map, dict):
+            patched_model_config = dict(patched_config)
+            patched_model_config.pop("auto_map", None)
+            patched_config = patched_model_config
+            patched_files["config.json"] = patched_model_config
+
+    if config_data.get("model_type") == "llava":
+        processor_config = _read_json_file(
+            os.path.join(local_path, "processor_config.json")
+        )
+        if processor_config.get("processor_class") == "LlavaProcessor":
+            patched_processor_config = dict(processor_config)
+            vision_config = config_data.get("vision_config")
+            if not isinstance(vision_config, dict):
+                vision_config = {}
+            if patched_processor_config.get("patch_size") is None:
+                patch_size = vision_config.get("patch_size")
+                if (
+                    isinstance(patch_size, int)
+                    and not isinstance(patch_size, bool)
+                    and patch_size > 0
+                ):
+                    patched_processor_config["patch_size"] = patch_size
+            if patched_processor_config.get("vision_feature_select_strategy") is None:
+                strategy = config_data.get("vision_feature_select_strategy")
+                if strategy in {"default", "full"}:
+                    patched_processor_config["vision_feature_select_strategy"] = strategy
+            if patched_processor_config != processor_config:
+                patched_files["processor_config.json"] = patched_processor_config
 
     if not patched_files:
         return local_path, config_data
 
     override_dir = tempfile.mkdtemp(prefix="unsloth_mlx_vlm_config_")
-    for name in os.listdir(local_path):
-        src = os.path.join(local_path, name)
-        dst = os.path.join(override_dir, name)
-        if name in patched_files:
-            continue
-        try:
-            os.symlink(src, dst)
-        except FileExistsError:
-            pass
-    for name, data in patched_files.items():
-        with open(os.path.join(override_dir, name), "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
+    try:
+        for name in os.listdir(local_path):
+            src = os.path.join(local_path, name)
+            dst = os.path.join(override_dir, name)
+            if name in patched_files:
+                continue
+            try:
+                os.symlink(src, dst)
+            except FileExistsError:
+                pass
+        for name, data in patched_files.items():
+            with open(os.path.join(override_dir, name), "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+    except Exception:
+        shutil.rmtree(override_dir, ignore_errors=True)
+        raise
     if corrected_model_type is not None and "config.json" in patched_files:
         print(
             "Unsloth: Routing DeepSeek OCR checkpoint through "
@@ -928,6 +1003,7 @@ def _load_mlx_vlm_distributed(
     hf_token=None,
     revision=None,
     config_override_data=None,
+    allow_remote_code=False,
 ):
     pipeline_group, tensor_group = _mlx_active_distributed_groups(
         pipeline_group,
@@ -945,31 +1021,36 @@ def _load_mlx_vlm_distributed(
             "Unsloth: distributed MLX VLM inference requires mlx-vlm with "
             "sharded_load support. Install or upgrade mlx-vlm on Apple Silicon."
         ) from error
+    sharded_load = _bind_mlx_vlm_processor_loader(
+        sharded_load,
+        allow_remote_code=allow_remote_code,
+    )
 
     try:
         with _temporary_hf_token_env(hf_token):
-            load_target = get_model_path(model_name, revision=revision)
-            if config_override_data is not None:
-                load_target = _materialize_mlx_vlm_config_data(
-                    str(load_target),
-                    config_override_data,
-                )
-                try:
-                    model, processor = sharded_load(
-                        load_target,
-                        tensor_group=tensor_group,
-                        pipeline_group=pipeline_group,
-                    )
-                except Exception:
-                    shutil.rmtree(load_target, ignore_errors=True)
-                    raise
-                _keep_mlx_vlm_config_view_alive(model, load_target)
-                return model, processor
-            return sharded_load(
-                load_target,
-                tensor_group=tensor_group,
-                pipeline_group=pipeline_group,
+            resolved_path = str(get_model_path(model_name, revision=revision))
+            load_config = config_override_data or _read_json_file(
+                os.path.join(resolved_path, "config.json")
             )
+            load_target, _ = _materialize_mlx_vlm_config_override(
+                resolved_path,
+                load_config,
+                normalize_tokenizer_config=True,
+            )
+            temporary_view = str(load_target) != resolved_path
+            try:
+                model, processor = sharded_load(
+                    load_target,
+                    tensor_group=tensor_group,
+                    pipeline_group=pipeline_group,
+                )
+            except Exception:
+                if temporary_view:
+                    shutil.rmtree(load_target, ignore_errors=True)
+                raise
+            if temporary_view:
+                _keep_mlx_vlm_config_view_alive(model, load_target)
+            return model, processor
     except ValueError as error:
         message = str(error)
         lower_message = message.lower()
@@ -1024,6 +1105,7 @@ def _resolve_mlx_vlm_processor_class(model_type, processor_class_name):
         name
         for module_type in module_types
         for name in (
+            f"mlx_vlm.models.{module_type}.processor",
             f"mlx_vlm.models.{module_type}.processing",
             f"mlx_vlm.models.{module_type}.processing_{module_type}",
         )
@@ -1034,14 +1116,206 @@ def _resolve_mlx_vlm_processor_class(model_type, processor_class_name):
         except Exception:
             continue
         processor_class = getattr(module, processor_class_name, None)
-        if processor_class is not None:
+        if isinstance(processor_class, type):
             return processor_class
 
     try:
         import transformers
-        return getattr(transformers, processor_class_name, None)
+        processor_class = getattr(transformers, processor_class_name, None)
+        return processor_class if isinstance(processor_class, type) else None
     except Exception:
         return None
+
+
+def _load_declared_mlx_vlm_processor(model_path, model_type, **kwargs):
+    """Construct a sidecar-declared processor with its installed components."""
+
+    if not model_path or not os.path.isdir(str(model_path)):
+        return None
+    processor_config = _read_json_file(
+        os.path.join(str(model_path), "processor_config.json")
+    )
+    preprocessor_config = _read_json_file(
+        os.path.join(str(model_path), "preprocessor_config.json")
+    )
+    processor_class_name = (
+        processor_config.get("processor_class")
+        or preprocessor_config.get("processor_class")
+    )
+    processor_class = _resolve_mlx_vlm_processor_class(
+        model_type, processor_class_name,
+    )
+    if processor_class is None or not str(
+        getattr(processor_class, "__module__", "")
+    ).startswith("mlx_vlm.models."):
+        return None
+
+    component_module = importlib.import_module(processor_class.__module__)
+    inherited_resolver = getattr(
+        processor_class, "get_possibly_dynamic_module", None,
+    )
+    scoped_processor_class = processor_class
+    if inherited_resolver is not None:
+        def resolve_component(class_name):
+            component_class = getattr(component_module, class_name, None)
+            if isinstance(component_class, type):
+                return component_class
+            return inherited_resolver(class_name)
+
+        scoped_processor_class = type(
+            processor_class.__name__,
+            (processor_class,),
+            {
+                "__module__": processor_class.__module__,
+                "get_possibly_dynamic_module": staticmethod(resolve_component),
+            },
+        )
+    processor_load_path = model_path
+    if not kwargs.get("trust_remote_code", False):
+        config_data = _read_json_file(
+            os.path.join(str(model_path), "config.json")
+        )
+        processor_load_path, _ = _materialize_mlx_vlm_config_override(
+            str(model_path),
+            config_data,
+            allow_tokenizer_remote_code=False,
+        )
+    try:
+        return scoped_processor_class.from_pretrained(
+            processor_load_path,
+            **kwargs,
+        )
+    finally:
+        if str(processor_load_path) != str(model_path):
+            shutil.rmtree(processor_load_path, ignore_errors=True)
+
+
+def _is_mlx_vlm_processor_resolution_error(error):
+    """Return whether AutoProcessor failed before native MLX construction."""
+
+    message = str(error).lower()
+    if isinstance(error, ValueError):
+        return any(
+            marker in message
+            for marker in (
+                "contains custom code which must be executed",
+                "unrecognized processing class",
+                "could not find module",
+            )
+        )
+    return isinstance(error, ImportError) and "tensorflow" in message
+
+
+def _inherit_mlx_vlm_processor_runtime(processor, repaired):
+    """Carry mlx-vlm's runtime generation state onto a rebuilt processor."""
+
+    chat_template = getattr(processor, "chat_template", None)
+    if chat_template is not None and getattr(repaired, "chat_template", None) is None:
+        repaired.chat_template = chat_template
+    detokenizer = getattr(processor, "detokenizer", None)
+    if detokenizer is not None:
+        repaired.detokenizer = detokenizer
+
+    source_tokenizer = getattr(processor, "tokenizer", processor)
+    target_tokenizer = getattr(repaired, "tokenizer", repaired)
+    stopping_criteria = getattr(source_tokenizer, "stopping_criteria", None)
+    if stopping_criteria is not None:
+        target_tokenizer.stopping_criteria = stopping_criteria
+    return repaired
+
+
+def _bind_mlx_vlm_processor_loader(load_callable, *, allow_remote_code=False):
+    """Bind processor recovery to one mlx-vlm load without global mutation."""
+
+    if not isinstance(load_callable, types.FunctionType):
+        return load_callable
+    processor_loader = load_callable.__globals__.get("load_processor")
+    if not isinstance(processor_loader, types.FunctionType):
+        return load_callable
+    direct_processor_load = load_callable is processor_loader
+    original_auto_processor = processor_loader.__globals__.get("AutoProcessor")
+    if original_auto_processor is None:
+        return load_callable
+
+    class ScopedAutoProcessor:
+        @classmethod
+        def from_pretrained(cls, model_path, *args, **kwargs):
+            processor_load_path = model_path
+            call_kwargs = dict(kwargs)
+            call_kwargs["trust_remote_code"] = bool(allow_remote_code)
+            if not allow_remote_code and os.path.isdir(str(model_path)):
+                config_data = _read_json_file(
+                    os.path.join(str(model_path), "config.json")
+                )
+                model_type = config_data.get("model_type")
+                processor_config = _read_json_file(
+                    os.path.join(str(model_path), "processor_config.json")
+                )
+                processor_class = _resolve_mlx_vlm_processor_class(
+                    model_type,
+                    processor_config.get("processor_class"),
+                )
+                processor_owner = str(
+                    getattr(processor_class, "__module__", "")
+                )
+                if (
+                    model_type in {"molmo", "molmo2"}
+                    and processor_owner.startswith("mlx_vlm.models.")
+                ):
+                    processor_load_path, _ = _materialize_mlx_vlm_config_override(
+                        str(model_path),
+                        config_data,
+                        allow_tokenizer_remote_code=False,
+                    )
+            try:
+                try:
+                    return original_auto_processor.from_pretrained(
+                        processor_load_path,
+                        *args,
+                        **call_kwargs,
+                    )
+                except Exception as error:
+                    if not _is_mlx_vlm_processor_resolution_error(error):
+                        raise
+                    config_data = _read_json_file(
+                        os.path.join(str(processor_load_path), "config.json")
+                    )
+                    processor = _load_declared_mlx_vlm_processor(
+                        processor_load_path,
+                        config_data.get("model_type"),
+                        **call_kwargs,
+                    )
+                    if processor is None:
+                        raise
+                    return processor
+            finally:
+                if str(processor_load_path) != str(model_path):
+                    shutil.rmtree(processor_load_path, ignore_errors=True)
+
+    processor_globals = dict(processor_loader.__globals__)
+    processor_globals["AutoProcessor"] = ScopedAutoProcessor
+    scoped_processor_loader = types.FunctionType(
+        processor_loader.__code__,
+        processor_globals,
+        processor_loader.__name__,
+        processor_loader.__defaults__,
+        processor_loader.__closure__,
+    )
+    scoped_processor_loader.__kwdefaults__ = processor_loader.__kwdefaults__
+    if direct_processor_load:
+        return scoped_processor_loader
+
+    load_globals = dict(load_callable.__globals__)
+    load_globals["load_processor"] = scoped_processor_loader
+    scoped_load = types.FunctionType(
+        load_callable.__code__,
+        load_globals,
+        load_callable.__name__,
+        load_callable.__defaults__,
+        load_callable.__closure__,
+    )
+    scoped_load.__kwdefaults__ = load_callable.__kwdefaults__
+    return scoped_load
 
 
 def _build_vlm_image_processor_from_config(
@@ -1122,6 +1396,23 @@ def _repair_degraded_vlm_processor(
     )
     if processor_class is None:
         return processor
+
+    native_kwargs = {
+        "use_fast": True,
+        "trust_remote_code": trust_remote_code,
+    }
+    if token:
+        native_kwargs["token"] = token
+    try:
+        repaired = _load_declared_mlx_vlm_processor(
+            model_path,
+            model_type,
+            **native_kwargs,
+        )
+    except Exception:
+        repaired = None
+    if repaired is not None and getattr(repaired, "image_processor", None) is not None:
+        return _inherit_mlx_vlm_processor_runtime(processor, repaired)
 
     image_processor = _build_vlm_image_processor_from_config(
         model_path, processor_config, preprocessor_config, model_type,
@@ -5166,19 +5457,10 @@ class FastMLXModel:
                 except (json.JSONDecodeError, KeyError):
                     config_data = {}
             original_local_path = local_path
-            original_config_data = dict(config_data)
-            if distributed_requested:
-                patched_config_data = _mlx_vlm_config_override_data(config_data)
-                if patched_config_data is not None:
-                    config_data = patched_config_data
-                    vlm_config_override_data = dict(config_data)
-            else:
-                local_path, config_data = _materialize_mlx_vlm_config_override(
-                    local_path,
-                    config_data,
-                )
-                if local_path != original_local_path or config_data != original_config_data:
-                    vlm_config_override_data = dict(config_data)
+            patched_config_data = _mlx_vlm_config_override_data(config_data)
+            if patched_config_data is not None:
+                config_data = patched_config_data
+                vlm_config_override_data = dict(config_data)
 
         # bitsandbytes-quantized repos store NF4 weights MLX cannot read. When
         # the real bitsandbytes wheel is importable, let bnb dequantize to fp16
@@ -5729,19 +6011,16 @@ class FastMLXModel:
                     "Install via: pip install mlx-vlm\n"
                     "Or pass text_only=True to load as text-only via mlx-lm."
                 )
+            vlm_load = _bind_mlx_vlm_processor_loader(
+                vlm_load,
+                allow_remote_code=trust_remote_code,
+            )
 
             if text_only is False and not _is_vlm(config_data):
                 warnings.warn(
                     f"text_only=False but '{model_name}' does not appear to be a VLM. "
                     f"Attempting mlx_vlm.load() anyway — this may fail.",
                     stacklevel=2,
-                )
-
-            if local_path:
-                local_path, config_data = _materialize_mlx_vlm_config_override(
-                    local_path,
-                    config_data,
-                    normalize_tokenizer_config=True,
                 )
 
             if patch_mode == "patched":
@@ -5770,13 +6049,37 @@ class FastMLXModel:
             if want_runtime_quant:
                 import mlx.core as mx
                 from mlx_vlm.utils import load_config as _vlm_load_config
+                _patch_deepseek_ocr_transformers_import_compat(model_type)
+            from .utils import (
+                normalize_mlx_chat_template,
+                normalize_vlm_processor_chat_template,
+            )
+
+            vlm_config_view_owner = None
+            if local_path and not distributed_requested:
+                local_path, config_data = _materialize_mlx_vlm_config_override(
+                    local_path,
+                    config_data,
+                    normalize_tokenizer_config=True,
+                )
+                vlm_config_view_owner = _MLXVLMConfigViewOwner(
+                    local_path,
+                    original_local_path,
+                )
+
+            def _run_with_vlm_config_view(operation, *args, **kwargs):
+                if vlm_config_view_owner is None:
+                    return operation(*args, **kwargs)
+                return vlm_config_view_owner.call(operation, *args, **kwargs)
+
+            if want_runtime_quant:
                 print(f"Unsloth: Loading {model_name} via mlx-vlm (VLM, "
                       f"runtime {quantization_spec.bits}-bit {quantization_spec.mode} quantization)...")
-                _patch_deepseek_ocr_transformers_import_compat(model_type)
                 vlm_load_target = local_path or model_name
                 with _temporary_hf_token_env(token):
                     try:
-                        model, processor = vlm_load(
+                        model, processor = _run_with_vlm_config_view(
+                            vlm_load,
                             vlm_load_target,
                             lazy=True,
                             revision=revision,
@@ -5787,13 +6090,19 @@ class FastMLXModel:
                         # surface the QK-norm version gap here too.
                         _raise_if_qk_norm_version_gap(model_type, str(error), error)
                         raise
-                    vlm_cfg = _vlm_load_config(vlm_load_target)
-                model, vlm_cfg = _apply_mlx_quantization(
+                    vlm_cfg = _run_with_vlm_config_view(
+                        _vlm_load_config,
+                        vlm_load_target,
+                    )
+                model, vlm_cfg = _run_with_vlm_config_view(
+                    _apply_mlx_quantization,
                     model, vlm_cfg, quantization_spec,
                     is_vlm=True, user_predicate=quant_predicate,
                 )
                 model._config = vlm_cfg
-                mx.eval(model.parameters())
+                _run_with_vlm_config_view(
+                    lambda: mx.eval(model.parameters()),
+                )
             elif distributed_requested:
                 if text_only is False and not _is_vlm(config_data):
                     raise ValueError(
@@ -5807,7 +6116,8 @@ class FastMLXModel:
                 )
                 mode = "tensor" if active_tensor_group is not None else "pipeline"
                 print(f"Unsloth: Loading {model_name} via mlx-vlm (distributed {mode} VLM)...")
-                model, processor = _load_mlx_vlm_distributed(
+                model, processor = _run_with_vlm_config_view(
+                    _load_mlx_vlm_distributed,
                     model_name,
                     model_type,
                     pipeline_group=active_pipeline_group,
@@ -5815,6 +6125,7 @@ class FastMLXModel:
                     hf_token=token,
                     revision=revision,
                     config_override_data=vlm_config_override_data,
+                    allow_remote_code=trust_remote_code,
                 )
             else:
                 print(f"Unsloth: Loading {model_name} via mlx-vlm (VLM)...")
@@ -5823,7 +6134,8 @@ class FastMLXModel:
                 vlm_kwargs["revision"] = revision
                 if target_dtype is not None:
                     vlm_kwargs["lazy"] = True
-                model, processor = _load_mlx_vlm_with_extra_weight_filter(
+                model, processor = _run_with_vlm_config_view(
+                    _load_mlx_vlm_with_extra_weight_filter,
                     local_path or model_name,
                     model_type,
                     vlm_load,
@@ -5831,7 +6143,8 @@ class FastMLXModel:
                     hf_token=token,
                 )
 
-            processor = _repair_degraded_vlm_processor(
+            processor = _run_with_vlm_config_view(
+                _repair_degraded_vlm_processor,
                 processor,
                 local_path or model_name,
                 model_type,
@@ -5840,18 +6153,20 @@ class FastMLXModel:
             )
 
             if target_dtype is not None:
-                _convert_mlx_dtype(model, target_dtype, model_type=model_type)
+                _run_with_vlm_config_view(
+                    _convert_mlx_dtype,
+                    model,
+                    target_dtype,
+                    model_type=model_type,
+                )
             elif want_runtime_quant:
-                import mlx.core as mx
-                mx.eval(model.parameters())
-            _fix_gemma3_text_rmsnorm_fp32(model)
+                _run_with_vlm_config_view(
+                    lambda: mx.eval(model.parameters()),
+                )
+            _run_with_vlm_config_view(_fix_gemma3_text_rmsnorm_fp32, model)
 
-            from .utils import (
-                normalize_mlx_chat_template,
+            processor = _run_with_vlm_config_view(
                 normalize_vlm_processor_chat_template,
-            )
-
-            processor = normalize_vlm_processor_chat_template(
                 processor,
                 chat_template=chat_template,
                 model_name=model_name,
@@ -5866,14 +6181,17 @@ class FastMLXModel:
                 model._unsloth_text_only_vlm = True
             model._is_vlm_model = True
             model._processor = processor
-            _fix_gemma4_kv_sharing(model)
-            _fix_gemma3_vision_post_layernorm_eps(model)
-            _fix_gemma3_vision_attention_fp32_sdpa(model)
-            _fix_gemma3_vision_encoder_fp32_layernorm(model)
-            _fix_gemma3_vision_post_layernorm_fp32(model)
-            _fix_gemma3_vision_mlp_fp32_activation(model)
-            _fix_gemma3_language_mlp_fp32_activation(model)
-            _fix_gemma3_multimodal_image_feature_scale(model)
+            for fixup in (
+                _fix_gemma4_kv_sharing,
+                _fix_gemma3_vision_post_layernorm_eps,
+                _fix_gemma3_vision_attention_fp32_sdpa,
+                _fix_gemma3_vision_encoder_fp32_layernorm,
+                _fix_gemma3_vision_post_layernorm_fp32,
+                _fix_gemma3_vision_mlp_fp32_activation,
+                _fix_gemma3_language_mlp_fp32_activation,
+                _fix_gemma3_multimodal_image_feature_scale,
+            ):
+                _run_with_vlm_config_view(fixup, model)
 
             model._config = getattr(model, "_config", config_data)
             model._hf_repo = model_name
@@ -5884,26 +6202,43 @@ class FastMLXModel:
             # model_type/auto_map the override drops.
             model._config_src_path = local_path or original_local_path
             model._unsloth_base_revision = revision
-            model._unsloth_base_commit_hash = _infer_snapshot_commit(
-                original_local_path or local_path
+            model._unsloth_base_commit_hash = _run_with_vlm_config_view(
+                _infer_snapshot_commit,
+                original_local_path or local_path,
             )
             model.max_seq_length = max_seq_length
             model._unsloth_patch_mode = patch_mode
             model._unsloth_full_finetuning = bool(full_finetuning)
             if quant_state == "compatible":
-                model._unsloth_quantization_config = _get_existing_mlx_quantization(config_data)
+                model._unsloth_quantization_config = _run_with_vlm_config_view(
+                    _get_existing_mlx_quantization,
+                    config_data,
+                )
                 model._unsloth_quantization_policy = quantization_spec.to_metadata()
                 model._unsloth_quantized_source = "mlx_config"
-            model._unsloth_compile_trait_report = get_compile_trait_report(model)
-            model._unsloth_compile_qualification = get_compile_qualification(model)
-            model._unsloth_compile_backend_qualifications = get_backend_compile_qualifications(model)
-            model._unsloth_compile_trace = trace_compile_application(model)
-            model._unsloth_compile_explain = explain_compile_support(model)
-            _patch_mixed_precision_set_dtype(model)
+            model._unsloth_compile_trait_report = _run_with_vlm_config_view(
+                get_compile_trait_report, model,
+            )
+            model._unsloth_compile_qualification = _run_with_vlm_config_view(
+                get_compile_qualification, model,
+            )
+            model._unsloth_compile_backend_qualifications = (
+                _run_with_vlm_config_view(
+                    get_backend_compile_qualifications, model,
+                )
+            )
+            model._unsloth_compile_trace = _run_with_vlm_config_view(
+                trace_compile_application, model,
+            )
+            model._unsloth_compile_explain = _run_with_vlm_config_view(
+                explain_compile_support, model,
+            )
+            _run_with_vlm_config_view(_patch_mixed_precision_set_dtype, model)
 
             public_target = processor
             if force_vlm_text_path:
-                public_target = normalize_mlx_chat_template(
+                public_target = _run_with_vlm_config_view(
+                    normalize_mlx_chat_template,
                     getattr(processor, "tokenizer", processor),
                     chat_template=chat_template,
                     model_name=model_name,
@@ -5913,7 +6248,9 @@ class FastMLXModel:
                 )
                 model._tokenizer = public_target
 
-            _patch_mlx_saving(model, public_target)
+            _run_with_vlm_config_view(_patch_mlx_saving, model, public_target)
+            if vlm_config_view_owner is not None:
+                vlm_config_view_owner.transfer_to(model)
             return model, public_target
         else:
             # Text path via mlx-lm (original behavior)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -4640,6 +4640,68 @@ def _call_vlm_processor(processor_call, args, kwargs):
     return _convert_vlm_processor_output(output, return_tensors)
 
 
+_VLM_MM_TOKEN_TYPE_PROCESSOR_MARKERS = (
+    "gemma3",
+    "gemma4",
+    "qwen3_vl",
+    "qwen3_5",
+)
+
+
+def _effective_processor_call_owner(cls):
+    """Return the first MRO class that supplies the active processor call.
+
+    Keeping this lookup separate makes the distinction between inherited
+    behavior and a subclass override explicit at the policy boundary.
+    """
+
+    return next(
+        (
+            candidate
+            for candidate in getattr(cls, "__mro__", (cls,))
+            if "__call__" in getattr(candidate, "__dict__", {})
+        ),
+        cls,
+    )
+
+
+def _processor_class_owns_gemma3n_token_types(cls):
+    """Recognize the effective Gemma3n processor call across relocation.
+
+    A subclass can live in a custom namespace, but an override can also replace
+    the inherited call contract. Classify the first MRO class that actually
+    supplies ``__call__`` so both cases keep their own behavior.
+    """
+
+    owner = _effective_processor_call_owner(cls)
+    # Class names can be regenerated or reused by custom processors. Only the
+    # module that supplies the effective call identifies the installed owner.
+    module = str(getattr(owner, "__module__", "")).lower()
+    return "gemma3n" in module.split(".")
+
+
+def _vlm_processor_requests_mm_token_type_ids(processor):
+    """Return whether the installed processor owns the multimodal type flag.
+
+    Gemma3n builds token types itself and forwards unknown kwargs to its
+    tokenizer. Follow the effective call owner for both negative and positive
+    classification so relocated inheritance preserves the installed behavior,
+    while a subclass override retains its own request contract.
+    Concrete wrapper names never authorize or suppress the processor flag.
+    """
+
+    cls = processor.__class__
+    owner = _effective_processor_call_owner(cls)
+    module = str(getattr(owner, "__module__", "")).lower()
+    if _processor_class_owns_gemma3n_token_types(cls):
+        return False
+    marker = f"{module}.{getattr(owner, '__name__', '')}".lower()
+    return any(
+        owner in marker
+        for owner in _VLM_MM_TOKEN_TYPE_PROCESSOR_MARKERS
+    )
+
+
 def _mlx_vlm_process_inputs_adapter(original):
     """Apply the exact PyTorch-only retry to mlx-vlm's processor boundary."""
 
@@ -4705,13 +4767,7 @@ def _processor_vlm_inputs(
         image_layouts = (None,)
     if suffixes is not None and any(suffix is not None for suffix in suffixes):
         base_kwargs["suffix"] = [suffix or "" for suffix in suffixes]
-    marker = f"{processor.__class__.__module__}.{processor.__class__.__name__}".lower()
-    if (
-        "gemma3" in marker
-        or "gemma4" in marker
-        or "qwen3_vl" in marker
-        or "qwen3_5" in marker
-    ):
+    if _vlm_processor_requests_mm_token_type_ids(processor):
         base_kwargs["return_mm_token_type_ids"] = True
 
     first_error = None

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -43,6 +43,7 @@ import threading
 import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
+from functools import wraps
 from pathlib import Path
 
 
@@ -4588,6 +4589,90 @@ def _to_mx_vlm_batch(inputs):
     return batch
 
 
+_PYTORCH_ONLY_PROCESSOR_OUTPUT = (
+    "Only returning PyTorch tensors is currently supported."
+)
+
+
+def _convert_vlm_processor_output(value, return_tensors):
+    """Convert PyTorch-only processor output without changing its containers."""
+
+    import torch
+
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu()
+        return mx.array(value) if return_tensors == "mlx" else value.numpy()
+    if isinstance(value, Mapping):
+        converted = copy.copy(value)
+        for key, item in value.items():
+            converted[key] = _convert_vlm_processor_output(item, return_tensors)
+        return converted
+    if isinstance(value, list):
+        return [_convert_vlm_processor_output(item, return_tensors) for item in value]
+    if isinstance(value, tuple):
+        converted = tuple(
+            _convert_vlm_processor_output(item, return_tensors) for item in value
+        )
+        return (
+            type(value)(*converted)
+            if hasattr(value, "_fields")
+            else type(value)(converted)
+        )
+    return value
+
+
+def _call_vlm_processor(processor_call, args, kwargs):
+    """Retry only the Transformers fast-processor PyTorch output contract."""
+
+    return_tensors = kwargs.get("return_tensors")
+    try:
+        return processor_call(*args, **kwargs)
+    except ValueError as error:
+        if (
+            return_tensors not in {"mlx", "np"}
+            or str(error) != _PYTORCH_ONLY_PROCESSOR_OUTPUT
+        ):
+            raise
+
+    retry_kwargs = dict(kwargs)
+    retry_kwargs["return_tensors"] = "pt"
+    output = processor_call(*args, **retry_kwargs)
+    return _convert_vlm_processor_output(output, return_tensors)
+
+
+def _mlx_vlm_process_inputs_adapter(original):
+    """Apply the exact PyTorch-only retry to mlx-vlm's processor boundary."""
+
+    if getattr(original, "_unsloth_pytorch_processor_output", False):
+        return original
+
+    @wraps(original)
+    def patched(
+        processor,
+        prompts,
+        images=None,
+        audio=None,
+        add_special_tokens=False,
+        padding=True,
+        padding_side="left",
+        return_tensors="mlx",
+        **kwargs,
+    ):
+        call_kwargs = dict(
+            images=images,
+            audio=audio,
+            add_special_tokens=add_special_tokens,
+            padding=padding,
+            padding_side=padding_side,
+            return_tensors=return_tensors,
+            **kwargs,
+        )
+        return _call_vlm_processor(original, (processor, prompts), call_kwargs)
+
+    patched._unsloth_pytorch_processor_output = True
+    return patched
+
+
 def _processor_vlm_inputs(
     processor,
     texts,
@@ -4639,7 +4724,7 @@ def _processor_vlm_inputs(
                 image_layout=image_layout,
             )
         try:
-            return processor(**proc_kwargs)
+            return _call_vlm_processor(processor, (), proc_kwargs)
         except TypeError as exc:
             if (
                 "add_special_tokens" in str(exc)
@@ -4648,7 +4733,7 @@ def _processor_vlm_inputs(
             ):
                 proc_kwargs.pop("add_special_tokens", None)
                 try:
-                    return processor(**proc_kwargs)
+                    return _call_vlm_processor(processor, (), proc_kwargs)
                 except Exception as retry_exc:
                     if first_error is None:
                         first_error = retry_exc
@@ -4658,7 +4743,7 @@ def _processor_vlm_inputs(
             if "padding_side" in str(exc) and "padding_side" in proc_kwargs:
                 proc_kwargs.pop("padding_side", None)
                 try:
-                    return processor(**proc_kwargs)
+                    return _call_vlm_processor(processor, (), proc_kwargs)
                 except Exception as retry_exc:
                     if first_error is None:
                         first_error = retry_exc

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5182,7 +5182,9 @@ def _processor_class_owns_gemma3n_token_types(cls):
     # Class names can be regenerated or reused by custom processors. Only the
     # module that supplies the effective call identifies the installed owner.
     module = str(getattr(owner, "__module__", "")).lower()
-    return "gemma3n" in module.split(".")
+    # why: remote-code and single-file loads land the marker as a suffix
+    # (`...selfcontained.processing_gemma3n`), never as its own path component.
+    return "gemma3n" in module
 
 
 def _vlm_processor_requests_mm_token_type_ids(processor):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5182,7 +5182,10 @@ def _processor_class_owns_gemma3n_token_types(cls):
     # Class names can be regenerated or reused by custom processors. Only the
     # module that supplies the effective call identifies the installed owner.
     module = str(getattr(owner, "__module__", "")).lower()
-    return "gemma3n" in module.split(".")
+    # why: match the marker anywhere in the module path. Remote-code and
+    # single-file processors expose it as `...processing_gemma3n`, never as a
+    # standalone path component.
+    return "gemma3n" in module
 
 
 def _vlm_processor_requests_mm_token_type_ids(processor):


### PR DESCRIPTION
## Summary

- Preserve supported vision/audio chat and training paths across mlx-vlm 0.4.4 through 0.6.7 without package-version branches.
- Align Qwen3 long/chunked visual state across cold left-padding, pre-sliced prompt windows, APC right-padding, whole-row reuse, and mixed visual/text batches.
- Recover installed mlx-vlm processors and metadata for InternVL, Molmo/Molmo2, Aya, LLaVA, Phi, and MiniCPM paths while retaining fail-closed ownership checks.
- Preserve MiniCPM MLX weights and vision dtype, legacy detokenizer isolation, LFM disabled-projector semantics, Gemma shared-KV loading, and Gemma3n training inputs.
- Rebind stale loaded mlx-vlm chat-template aliases by exact package and callable identity.
- Keep open-ended dependency policy unchanged; no exact MLX pins, floor changes, lockfiles, or code from #893.

## Why

The original compatibility policy and compact family-scoping work landed in #898. Current Studio resolution can now select mlx-vlm 0.6.7, whose processor, generation, cache, sanitizer, and model layouts differ materially from the shipped 0.4.4 stack. Successful import alone is insufficient: several families either degrade to tokenizer-only processors, lose media tensors or markers, misalign Qwen deepstack state during chunked prefill, register checkpoint-absent parameters, or fail strict loading at specific intermediate releases.

This continuation follows installed callable capabilities and ownership rather than release numbers. Unknown or already-fixed contracts stay native. The compatibility adapters are call-scoped or exact-owner gated so unrelated families and future upstream implementations are not patched merely because they share broad traits.

## Key behavior

- Qwen3 dense/MoE visual masks and deepstack features retain row ownership when prompt merging changes coordinate widths or prompt processing slices a chunk whose length equals the current window.
- Qwen2-VL, Qwen2.5-VL, Qwen3.5, and Qwen3-VL-MoE consume legacy video tensors only when their effective installed callable still omits them.
- Installed mlx-vlm processor classes remain authoritative; recovery avoids unrelated remote code and preserves component/runtime state.
- Aya retries only its exact PyTorch-output processor failure and converts nested tensors back to the requested representation.
- MiniCPM converted tower names still traverse the installed sanitizer, and legacy vision calls use the floating-point vision execution dtype rather than packed language weights.
- LFM disabled normalization owns no absent parameters; legacy detokenizers retain per-request copy isolation.
- Gemma strict-load recovery drops only canonical live-model keys classified by the installed shared-KV predicate.
- Gemma3n keeps native token-type construction and absolute cache progress.
- Loaded `mlx_vlm` and `mlx_vlm.*` aliases that still hold the exact original chat-template callable are rebound without importing the package tree or touching prefix-collision modules.

## Scope

The complete continuation modifies `unsloth_zoo/mlx/compile.py`, `unsloth_zoo/mlx/loader.py`, `unsloth_zoo/mlx/utils.py`, five existing focused test files, and one subprocess-isolated Qwen regression file. It also includes current `main` through `bf960653`. The final diff contains no dependency metadata, exact pins, package-version special cases, or code from #893.

## Validation

- Before the two narrow maintainer follow-ups, a forced actual-Studio matrix passed 399/399 required checkpoint/modality/release cells across mlx-vlm 0.4.4, 0.5.0, and 0.6.0 through 0.6.7.
- Shipped mlx-lm 0.31.2 / mlx-vlm 0.4.4 endpoint: 39/39 passed.
- Current mlx-vlm 0.6.7 runtime endpoint with mlx 0.32.0, mlx-lm 0.31.3, and mlx-audio 0.4.5: 40/40 passed.
- The exact resolved mlx-audio 0.4.6 tuple passed audio generation and controlled conditioning for Gemma 4 through the Transformers 5.5 sidecar and for Gemma3n/MiniCPM-o through Studio main Transformers 4.57.6.
- Dependency-supported reference probes passed with Transformers 5.3, 5.5, 5.10, and 5.14.1 as appropriate.
- Qwen2-VL, long-prefill Qwen3-VL, Gemma3n, and recovered InternVL training canaries passed finite loss, nonzero gradients/updates, adapter save/reload, exact saved-to-live binding, controlled image conditioning, and generation.
- The padded-coordinate follow-up passed 149 trainer-internals tests, installed-owner probes on mlx-vlm 0.5.0 and 0.6.7, and frozen long-image Qwen3-VL prefill/generation on mlx-vlm 0.4.4 and 0.6.7.
- The latest maintainer merge passed 49 prompt/export tests, its subprocess-isolated Qwen regression on the packaged mlx-vlm 0.6.7 owner, and 20 current-main Metal tests.
- Python compilation, Ruff correctness selectors, and `git diff --check` pass.
- The latest merge and both review-required corrections received clean single-reviewer fast-path confirmation; no full matrix replay was performed for this narrow follow-up.

## Rollout

Merge and publish this Zoo compatibility continuation before [unsloth#7061](https://github.com/unslothai/unsloth/pull/7061) exposes the current open-ended MLX stack. The broader #893 work is intentionally independent.
