### PR TITLE
Keep saving_utils importable when bitsandbytes is absent

### DIFF
--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -67,7 +67,14 @@ This {model_type} model was trained 2x faster with [Unsloth](https://github.com/
 """
 
 import torch
-import bitsandbytes as bnb
+try:
+    import bitsandbytes as bnb
+    _BNB_LINEAR4BIT = (bnb.nn.Linear4bit,)
+except Exception:
+    # No bnb (e.g. gfx906, whose generic wheel has no kernels) -> no 4bit layers
+    # exist, so the isinstance check below is simply always False.
+    bnb = None
+    _BNB_LINEAR4BIT = ()
 try:
     from huggingface_hub import get_token
 except:
@@ -90,7 +97,7 @@ def find_skipped_quantized_modules(model):
     skipped_modules = []
     quantized_modules = []
     for name, module in model.named_modules():
-        if isinstance(module, bnb.nn.Linear4bit):
+        if isinstance(module, _BNB_LINEAR4BIT):
             if hasattr(module.weight, 'quant_state') and module.weight.quant_state is not None:
                 quantized_modules.append(name)
             else:


### PR DESCRIPTION
`unsloth_zoo/saving_utils.py` is on the `import unsloth` chain (`unsloth/save.py` imports it at module level), so its unconditional `import bitsandbytes as bnb` made a bnb-less host unable to import unsloth at all.

That host is now reachable: unslothai/unsloth#7354 uninstalls the generic bitsandbytes wheel on gfx906 (MI50 / Radeon VII) because it carries no gfx906 kernels, and unsloth's own message on that path promises 16bit LoRA and full finetuning still work.

### Change

Guard the import and route the one use site through a `_BNB_LINEAR4BIT` tuple, empty when bnb is missing:

```python
if isinstance(module, _BNB_LINEAR4BIT):
```

`isinstance` against an empty tuple is `False`, which is exact rather than merely safe: with no bitsandbytes there are no 4bit layers, so those modules fall through to the `torch.nn.Linear` branch of `find_skipped_quantized_modules` as they should.

`vllm_utils.py` already guards its bitsandbytes imports behind `find_spec`, and the `temporary_patches/moe_*` modules already use `try: ... except ImportError`, so this was the only unguarded module-level import left in the package.

### Verification

Strix Halo (gfx1151, `DEVICE_TYPE=hip`, torch 2.11.0+rocm7.13.0), bitsandbytes blocked via `sys.modules["bitsandbytes"] = None` so `find_spec` returns `None` and the import raises exactly as when the package is absent:

- without bnb: `import unsloth` succeeds, `_BNB_LINEAR4BIT == ()`
- with bnb: `_BNB_LINEAR4BIT == (bitsandbytes.nn.modules.Linear4bit,)`, unchanged

Pairs with unslothai/unsloth#7502, which fixes the four equivalent imports on the unsloth side. Either one alone still leaves the import broken.