### PR TITLE
hf_utils: unwrap single-adapter peft_config and reject empty model_types

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -108,6 +108,7 @@ jobs:
             tests/test_mlx_finetune_last_n_layers.py \
             tests/test_mlx_double_quant_reject.py \
             tests/test_hf_xet_fallback.py \
+            tests/test_get_transformers_model_type_empty.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/tests/test_get_transformers_model_type_empty.py
+++ b/tests/test_get_transformers_model_type_empty.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Regression tests for get_transformers_model_type's config unwrapping and guard.
+
+Two behaviours are pinned here:
+
+1. An unresolved config must not come back as `[]`. `model_types` is assigned from
+   `list(find(...))`, so it reaches the guard as `[]` and never as `None`; the guard
+   used to test `is None`, so `[]` passed through and consumers broke on it --
+   `unsloth/models/vision.py` indexes `model_types[0]`, `unsloth/models/loader.py`
+   joins the list and silently matches no architecture.
+2. `model.peft_config` maps adapter name -> config, and only the literal key
+   "default" used to be unwrapped, so an adapter named anything else was unreadable.
+   A single-adapter dict now unwraps whatever its key is; a multi-adapter dict
+   without "default" stays ambiguous and must raise rather than pick a winner.
+
+All cases are CPU-only and network-free: configs are built in a temp directory so
+AutoConfig resolves from disk and never contacts the Hub.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from unsloth_zoo.hf_utils import get_transformers_model_type
+
+
+_UNRESOLVED_MESSAGE = "Cannot determine model type for config file"
+
+
+@pytest.fixture(autouse = True)
+def _no_env_leak():
+    """get_transformers_model_type sets os.environ["UNSLOTH_MODEL_NAME"] as a side
+    effect for every PeftConfig input (hf_utils.py). Other test modules read that
+    variable, so restore it rather than leaking temp paths into the session."""
+    sentinel = object()
+    previous = os.environ.get("UNSLOTH_MODEL_NAME", sentinel)
+    try:
+        yield
+    finally:
+        if previous is sentinel:
+            os.environ.pop("UNSLOTH_MODEL_NAME", None)
+        else:
+            os.environ["UNSLOTH_MODEL_NAME"] = previous
+
+
+@pytest.fixture(scope = "module")
+def local_llama_base(tmp_path_factory):
+    """A real on-disk base checkpoint dir AutoConfig can resolve without network."""
+    base = tmp_path_factory.mktemp("llama_base")
+    (base / "config.json").write_text(json.dumps({
+        "model_type"          : "llama",
+        "architectures"       : ["LlamaForCausalLM"],
+        "hidden_size"         : 16,
+        "intermediate_size"   : 32,
+        "num_attention_heads" : 1,
+        "num_key_value_heads" : 1,
+        "num_hidden_layers"   : 1,
+        "vocab_size"          : 32,
+    }))
+    return str(base)
+
+
+def _lora_config(base_model_name_or_path):
+    from peft import LoraConfig
+    return LoraConfig(
+        base_model_name_or_path = base_model_name_or_path,
+        r                       = 8,
+        lora_alpha              = 16,
+        lora_dropout            = 0.0,
+        target_modules          = ["q_proj", "v_proj"],
+    )
+
+
+# --- adapter-name unwrapping -------------------------------------------------
+
+def test_single_adapter_dict_with_non_default_name_resolves(local_llama_base):
+    """`get_peft_model(..., adapter_name = "my_adapter")` produces a peft_config keyed
+    by that name. One adapter is unambiguous, so it must resolve like "default" does."""
+    config = {"my_adapter": _lora_config(local_llama_base)}
+    assert get_transformers_model_type(config) == ["llama"]
+
+
+def test_multi_adapter_dict_without_default_raises(local_llama_base):
+    """Adapters may carry different base models, so no winner may be guessed."""
+    config = {
+        "adapter_a": _lora_config(local_llama_base),
+        "adapter_b": _lora_config(local_llama_base),
+    }
+    with pytest.raises(TypeError, match = _UNRESOLVED_MESSAGE):
+        get_transformers_model_type(config)
+
+
+def test_multi_adapter_dict_with_default_keeps_default_precedence(local_llama_base):
+    config = {
+        "default"  : _lora_config(local_llama_base),
+        "adapter_b": _lora_config(local_llama_base),
+    }
+    assert get_transformers_model_type(config) == ["llama"]
+
+
+def test_empty_dict_raises():
+    with pytest.raises(TypeError, match = _UNRESOLVED_MESSAGE):
+        get_transformers_model_type({})
+
+
+# --- inputs that used to yield [] and then break the consumer -----------------
+
+def test_config_object_whose_to_dict_lacks_model_type_raises():
+    class RemoteCodeConfig:
+        def to_dict(self):
+            return {
+                "architectures" : ["MyCustomModel"],
+                "hidden_size"   : 16,
+                "vision_config" : {"depth": 2},
+            }
+
+    with pytest.raises(TypeError, match = _UNRESOLVED_MESSAGE):
+        get_transformers_model_type(RemoteCodeConfig())
+
+
+def test_config_object_without_to_dict_raises():
+    """The `lambda *args, **kwargs: {}` fallback yields an empty dict to walk."""
+    class NoToDict:
+        architectures = ["MyCustomModel"]
+
+    with pytest.raises(TypeError, match = _UNRESOLVED_MESSAGE):
+        get_transformers_model_type(NoToDict())
+
+
+# --- paths that already worked must be byte-identical ------------------------
+
+def test_plain_transformers_config_unchanged():
+    from transformers import LlamaConfig
+    config = LlamaConfig(
+        hidden_size = 16, num_hidden_layers = 1, num_attention_heads = 1,
+        intermediate_size = 32, vocab_size = 32,
+    )
+    assert get_transformers_model_type(config) == ["llama"]
+
+
+def test_peft_config_dict_keyed_default_unchanged(local_llama_base):
+    config = {"default": _lora_config(local_llama_base)}
+    assert get_transformers_model_type(config) == ["llama"]
+
+
+# --- the swallowing call site in hf_utils.py must behave identically ---------
+
+def test_bare_except_call_site_still_swallows(local_llama_base):
+    """get_auto_processor wraps `get_transformers_model_type(peft_config)[0]` in a
+    bare `except:`. That caught the old IndexError and catches the new TypeError
+    alike, so `model_type` stays None and the caller falls through to
+    AutoTokenizer. Uses an ambiguous multi-adapter dict, which still cannot
+    resolve after the unwrap change."""
+    config = {
+        "adapter_a": _lora_config(local_llama_base),
+        "adapter_b": _lora_config(local_llama_base),
+    }
+    model_type = None
+    try:
+        model_type = get_transformers_model_type(config)[0]
+    except:
+        pass
+    assert model_type is None
+
+
+# --- the OTHER guard (the AutoConfig fallback) must be untouched -------------
+
+def test_peft_config_with_unresolvable_base_still_raises(tmp_path):
+    """When AutoConfig cannot resolve the base, `retry_config` stays False, so
+    `model_types` is still genuinely None at the guard. That path is unchanged."""
+    missing = str(tmp_path / "definitely-not-a-model")
+    with pytest.raises(TypeError, match = _UNRESOLVED_MESSAGE):
+        get_transformers_model_type(_lora_config(missing))
+
+
+def test_peft_config_without_base_model_name_raises():
+    """Distinct earlier guard; proves we did not shadow it."""
+    with pytest.raises(TypeError, match = "base_model_name_or_path"):
+        get_transformers_model_type(_lora_config(None))

--- a/unsloth_zoo/hf_utils.py
+++ b/unsloth_zoo/hf_utils.py
@@ -115,9 +115,17 @@ def get_transformers_model_type(config, trust_remote_code=False):
     model_types = None
 
     from peft import PeftConfig
-    # Handle model.peft_config["default"]
-    if type(config) is dict and "default" in config:
-        config = config["default"]
+    # Handle model.peft_config, which maps adapter name -> config. "default" wins when
+    # present. Otherwise a single-adapter dict is unambiguous and unwraps whatever its
+    # key is, since get_peft_model(..., adapter_name = ...) names the adapter freely.
+    # A multi-adapter dict without "default" stays ambiguous - adapters may carry
+    # different base models - so leave it be and let the guard below raise rather than
+    # silently pick a winner.
+    if type(config) is dict:
+        if "default" in config:
+            config = config["default"]
+        elif len(config) == 1:
+            config = next(iter(config.values()))
     
     retry_config = False
     if issubclass(type(config), PeftConfig):
@@ -195,7 +203,10 @@ def get_transformers_model_type(config, trust_remote_code=False):
                     stack.extend(obj)
         model_types = list(find(getattr(config, "to_dict", lambda *args, **kwargs: {})(), "model_type"))
     pass
-    if model_types is None:
+    # `find` above returns a list, so an unresolved config arrives here as [], never
+    # None - an `is None` check would let it through and every consumer indexes [0]
+    # or joins the list. Treat empty and None the same.
+    if not model_types:
         raise TypeError(f"Unsloth: Cannot determine model type for config file: {str(config)}")
     # Standardize model_type
     final_model_types = []


### PR DESCRIPTION
## Summary
 
`get_transformers_model_type` could not read a `model.peft_config` unless the adapter was named `"default"`, and the guard meant to catch that failure never fired. Two coupled one-line fixes, plus regression tests and CI wiring.
 
## The problem
 
**1. Only `"default"` was unwrapped.** `model.peft_config` maps adapter name → config. The unwrap at `hf_utils.py:118-119` handled exactly one key:
 
```python
# Handle model.peft_config["default"]
if type(config) is dict and "default" in config:
    config = config["default"]
```
 
So `get_peft_model(model, cfg, adapter_name = "my_adapter")` — ordinary PEFT usage — produced a dict this function fell straight through. A plain dict has no `.to_dict`, so the `lambda *args, **kwargs: {}` default fires and `find({})` yields nothing.
 
**2. The guard that should have caught it is dead.** `model_types` is assigned from `list(find(...))` at `hf_utils.py:196`, which returns `[]` and never `None`. The next line tests `if model_types is None:`, so it never fires for that case and the empty list is returned to callers.
 
Reproduction, no weights or network required:
 
```
peft_config dict keyed 'default'      -> ['llama']
peft_config dict keyed 'my_adapter'   -> []        <- silently empty
config object whose to_dict() lacks model_type -> []
config object with no to_dict at all           -> []
```
 
## What breaks downstream
 
Worth stating precisely, because it is not uniformly a crash:
 
| Consumer | With `[]` | Result |
|---|---|---|
| `unsloth/models/vision.py:900` | `model_types[0]` | `IndexError` — the only hard crash |
| `unsloth/models/loader.py:640-644` | `len(...) == 1` false → `model_type = []` | no crash, silently wrong |
| `unsloth/models/loader.py:1349` | `",".join(model_types) + ","` → `","` | every arch check silently `False` |
| `unsloth_zoo/hf_utils.py:312` | `[0]` inside a bare `except:` | swallowed, `model_type` stays `None` |
 
`vision.py:856` already does `if model_types is None: raise RuntimeError(...)` — the same dead-guard shape — which is reasonable evidence the intended contract is a non-empty list and that raising at the source is what consumers want. No consumer has meaningful empty-list behaviour to fall back on.
 
## The fix
 
**Unwrap any single-adapter dict**, whatever its key:
 
```python
if type(config) is dict:
    if "default" in config:
        config = config["default"]
    elif len(config) == 1:
        config = next(iter(config.values()))
```
 
`"default"` keeps precedence in a multi-adapter dict. A multi-adapter dict **without** `"default"` is deliberately left unresolved — adapters can carry different base models, so unioning their model types or picking one would be a guess. It falls through and raises with an actionable message. `fix_lora_auto_mapping` (`hf_utils.py:244-245`) iterates `.values()` for its own purposes; unaffected here, and verified unchanged by diffing every adapter's `auto_mapping` before and after.
 
**Make the guard live:** `if model_types is None:` → `if not model_types:`.
 
The other `is None` check (`hf_utils.py:157`, gating the AutoConfig fallback inside the PeftConfig branch) is deliberately untouched — there `model_types` genuinely is `None`, never `[]`, and a test pins that path so it stays reachable.
 
Behaviour before and after:
 
| Input | Before | After |
|---|---|---|
| single-key `"my_adapter"` | `TypeError` | `["llama"]` |
| multi-key, no `"default"` | `TypeError` | `TypeError` |
| multi-key with `"default"` | `["llama"]` | `["llama"]` |
| `{}` | `TypeError` | `TypeError` |
| normal `LlamaConfig` | `["llama"]` | `["llama"]` |
 
## Compatibility
 
`get_auto_processor` indexes `[0]` inside a bare `except:`, which catches the new `TypeError` exactly as it caught the old `IndexError` — `model_type` stays `None` and falls through to the `AutoTokenizer` branch. Identical behaviour, pinned by a test.
 
`unsloth/models/_utils.py:3663` and `unsloth/trainer.py:696` consume via `any(... for mt in model_types)` and would tolerate `[]`; they now raise instead. Both pass a `PretrainedConfig`, which always emits `model_type`, so this is unreachable for them in practice — confirmed by running both consumer expressions verbatim over eleven real configs (llama, qwen2, mistral, gemma2, gpt_neox, gpt_oss, gemma3_text, nested gemma3, nested qwen2-VL, an `AutoConfig.from_pretrained` off disk, and an instantiated model's `.config`). Every boolean verdict is identical before and after.
 
The new tests restore `UNSLOTH_MODEL_NAME`, which `get_transformers_model_type` sets as a side effect at `hf_utils.py:154` and which two other test files read, so they do not leak session-wide.
 
## Tests
 
New `tests/test_get_transformers_model_type_empty.py`, CPU-only and network-free (temp-dir configs, no HF cache dependency):
 
- all four unwrap cases from the table above
- the three inputs that reach `[]`, each raising `TypeError` with the config named
- the paths that already worked, unchanged
- the `hf_utils.py:312` bare-`except:` site still yielding `model_type is None`
- both untouched guards still reachable and still firing
Five of these fail against unpatched source; the rest are the no-regression half.
 
The file is wired into the behavioral-gates step in `.github/workflows/consolidated-tests-ci.yml`, without which a new test file is collected but never executed.
 