### PR TITLE
Batched generation for MLX text and vision models

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -64,6 +64,9 @@ jobs:
           pip install "torch>=2.4.0,<2.13.0"
           pip install -e .[mlx]
           pip install pytest==9.0.3
+          # The vision model used by tests/test_mlx_generate_metal.py loads
+          # remote processor code that imports timm, which .[mlx] does not pull.
+          pip install timm
 
       - name: MLX module import smoke
         run: |
@@ -90,6 +93,19 @@ jobs:
         # Real LoRA training smoke: tiny 4-bit model through FastMLXModel +
         # MLXTrainer, exercising the PR 684 trainer rework end to end.
         run: python -m pytest tests/test_mlx_training_e2e_metal.py -v -rs
+
+      - name: tests/test_mlx_generate.py
+        # Batched-generation logic that needs no Metal but does need the mlx-vlm
+        # import: release-protocol handling, prompt-kwarg splitting, stop-string
+        # trimming, the audio fallback contract, and request validation.
+        run: python -m pytest tests/test_mlx_generate.py -v -rs
+
+      - name: tests/test_mlx_generate_metal.py
+        # Batched generation on real models: batched-vs-sequential greedy
+        # equivalence with aligned sampled-token logprobs, memory-limit
+        # restoration, compiled train/generate interplay, and the vision
+        # ordering and stop-string contracts.
+        run: python -m pytest tests/test_mlx_generate_metal.py -v -rs
 
       - name: tests/test_mlx_cpt_partition_metal.py
         # CPT partition, target normalization and full-module save routing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ dependencies = [
     "cut_cross_entropy ; python_version >= '3.10' and (sys_platform != 'darwin' or platform_machine != 'arm64')",
     # --- MLX-only deps (macOS arm64) ---
     "mlx>=0.22.0 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
-    # mlx_lm.utils._download replaced get_model_path in mlx-lm 0.28.3; the MLX
-    # loader imports it unconditionally, so 0.28.3 is the real minimum.
-    "mlx-lm>=0.28.3 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
+    # GenerationBatch.Response and BatchGenerator.next_generated, which batched
+    # generation drives, first ship in mlx-lm 0.31.2.
+    "mlx-lm>=0.31.2 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
     "mlx-vlm>=0.4.4 ; (sys_platform == 'darwin' and platform_machine == 'arm64')",
     # --- Shared deps (all platforms) ---
     "packaging>=24.1",
@@ -72,7 +72,7 @@ exclude = ["images*"]
 mlx = [
     "mlx>=0.22.0",
     # Keep in sync with the MLX-only dependency pin above.
-    "mlx-lm>=0.28.3",
+    "mlx-lm>=0.31.2",
     "mlx-vlm>=0.4.4",
 ]
 core = [

--- a/tests/mlx_simulation/mlx_lm_stub.py
+++ b/tests/mlx_simulation/mlx_lm_stub.py
@@ -236,7 +236,7 @@ tuner_trainer_module.iterate_batches = _iterate_batches
 sample_utils_module = _pkg("mlx_lm.sample_utils")
 
 
-def _make_sampler(temp=1.0, top_p=1.0, top_k=0, min_tokens_to_keep=1, **kw):
+def _make_sampler(temp=1.0, top_p=1.0, top_k=0, min_p=0.0, min_tokens_to_keep=1, **kw):
     """Build a callable that takes logits and returns a sampled token id."""
     def sampler(logits):
         if temp == 0:

--- a/tests/mlx_simulation/mlx_vlm_stub.py
+++ b/tests/mlx_simulation/mlx_vlm_stub.py
@@ -68,8 +68,19 @@ def _vlm_load_config(*args, **kwargs):
     return {}
 
 
+def _prepare_inputs(*args, **kwargs):
+    return {}
+
+
+def _process_image(image, *args, **kwargs):
+    return image
+
+
 utils_module.skip_multimodal_module = _skip_multimodal_module
 utils_module.load_config = _vlm_load_config
+# The batched vision adapter binds both at construction time.
+utils_module.prepare_inputs = _prepare_inputs
+utils_module.process_image = _process_image
 
 prompt_utils_module = _pkg("mlx_vlm.prompt_utils")
 models_module = _pkg("mlx_vlm.models")

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -324,10 +324,9 @@ def test_vlm_requests_accept_stop_strings():
                                   GenerationDefaults(stop_strings=("STOP",)))
 
 
-def test_vlm_requests_reject_audio_and_token_id_prompts():
+def test_vlm_requests_reject_token_id_prompts_and_unsupported_controls():
     from unsloth_zoo.mlx.generate import _validate_vlm_requests
-    cases = ((GenerationRequest(prompt="a", audio=object()), GenerationDefaults(), "carries audio"),
-        (GenerationRequest(prompt_token_ids=[1]), GenerationDefaults(), "rendered prompt string"),
+    cases = ((GenerationRequest(prompt_token_ids=[1]), GenerationDefaults(), "rendered prompt string"),
         (GenerationRequest(prompt="a"), GenerationDefaults(max_kv_size=64), "max_kv_size is not supported"),
         # One that stopped being refused would reach generation and be dropped.
         *((GenerationRequest(prompt="a"), GenerationDefaults(**{name: value}),
@@ -692,3 +691,141 @@ def test_detokenizer_never_re_emits_after_a_shortening_decode():
         state.append(tokenizer, token, -0.1)
     state.finish(tokenizer, "length")
     assert state.result(tokenizer).text == "hello there"
+
+
+class _EosTokenizer(_CharTokenizer):
+    eos_token_id = 3
+
+def _audio_events(*specs):
+    """Sequential events; `finish` omitted models releases carrying no reason.
+
+    Each event carries a distinct logprob, so committing a successor's value
+    against its predecessor's token shifts alignment visibly.
+    """
+    made = []
+    for position, (token, finish) in enumerate(specs):
+        fields = {"token": token, "logprobs": {token: -0.5 - position}}
+        if finish is not None:
+            fields["finish_reason"] = finish
+        made.append(types.SimpleNamespace(**fields))
+    return made
+
+def _audio_adapter(events, tokenizer=None, stops=()):
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults = GenerationDefaults(stop_strings=stops)
+    adapter.processor = types.SimpleNamespace(tokenizer=tokenizer or _CharTokenizer())
+    adapter.model = object()
+    adapter.sampler = object()
+    adapter.sampler_kwargs = {}
+    adapter.make_sampler = lambda **k: (adapter.sampler_kwargs.update(k), adapter.sampler)[1]
+    adapter._wired_limit = contextlib.nullcontext
+    adapter.stream_calls = []
+    def stream(*args, **kwargs):
+        adapter.stream_calls.append((args, kwargs))
+        return iter(events)
+    adapter.stream_module = types.SimpleNamespace(stream_generate=stream)
+    return adapter
+
+
+class _CriteriaTokenizer(_CharTokenizer):
+    # Processors stop on ids their eos attribute never lists, so these disagree.
+    eos_token_id = 1
+    stopping_criteria = staticmethod(lambda token: token == 3)
+
+
+@pytest.mark.parametrize("specs,tokenizer,expected", [
+    # The terminal event repeats the last token; committing it would duplicate.
+    (((1, None), (2, None), (2, None)), None, ([1, 2], "length")),
+    # No finish reason on the terminal event, but its token is end-of-sequence.
+    (((1, None), (3, None)), _EosTokenizer(), ([1], "stop")),
+    # The release stops through criteria the tokenizer's eos id does not list.
+    (((1, None), (3, None)), _CriteriaTokenizer(), ([1], "stop")),
+    # ... and that same authority reports an ordinary token as a length cut-off.
+    (((1, None), (2, None), (2, None)), _CriteriaTokenizer(), ([1, 2], "length")),
+    # A reported reason is believed, not re-inferred, in both directions.
+    (((1, None), (2, "stop")), None, ([1], "stop")),
+    (((1, None), (3, "length")), _CriteriaTokenizer(), ([1], "length")),
+    # Nothing generated at all: newer releases emit one event with no token.
+    (((None, "length"),), None, ([], "length")),
+])
+def test_audio_fallback_keeps_the_batched_result_contract(specs, tokenizer, expected):
+    result = _audio_adapter(_audio_events(*specs), tokenizer)._generate_sequentially(
+        GenerationRequest(prompt="p", audio="a.wav"))
+    assert (result.token_ids, result.finish_reason) == expected
+    # Logprobs must belong to the tokens they sit beside, not to their successors.
+    assert result.logprobs == [-0.5 - n for n in range(len(result.token_ids))]
+    assert result.text == "".join(_CharTokenizer.pieces[t] for t in result.token_ids)
+
+
+def test_audio_terminal_event_flushes_text_held_back_during_streaming():
+    # Cleanup withholds a trailing space until finalize; losing it truncates.
+    tokenizer = _TableTokenizer({(1,): "a ", (1, 2): "a b "}, clean=True)
+    result = _audio_adapter(_audio_events((1, None), (2, None), (2, None)),
+                            tokenizer)._generate_sequentially(
+        GenerationRequest(prompt="p", audio="a.wav"))
+    assert (result.token_ids, result.text) == ([1, 2], "a b ")
+
+
+def test_audio_fallback_forwards_the_request_to_the_stream():
+    # A dropped audio payload or ignored control shows up in the stream call.
+    adapter = _audio_adapter(_audio_events((1, None), (2, "length")))
+    adapter._generate_sequentially(GenerationRequest(
+        prompt="p", audio="a.wav", max_tokens=9,
+        sampling=SamplingParams(temperature=0.25, top_k=7)))
+    args, kwargs = adapter.stream_calls[0]
+    assert args[2] == "p"  # the rendered prompt, after model and processor
+    assert (kwargs["audio"], kwargs["max_tokens"]) == ("a.wav", 9)
+    assert kwargs["sampler"] is adapter.sampler
+    # Per-request sampling, not the batch-wide default.
+    assert (adapter.sampler_kwargs["temp"], adapter.sampler_kwargs["top_k"]) == (0.25, 7)
+
+
+def test_audio_fallback_honours_stop_strings():
+    # Audio reaches the same scanner: "<ST" + "OP>" completes the stop string.
+    result = _audio_adapter(_audio_events((2, None), (3, None), (3, "length")),
+                            stops=("STOP",))._generate_sequentially(
+        GenerationRequest(prompt="p", audio="a.wav"))
+    assert (result.token_ids, result.finish_reason, result.stop_match) == (
+        [], "stop_string", "STOP")
+
+
+def test_audio_requests_reach_the_fallback_through_the_public_entry_point(monkeypatch):
+    # The tests above drive the adapter directly and would stay green if the
+    # old blanket audio rejection came back.
+    from unsloth_zoo.mlx import generate as engine
+    seen = []
+    monkeypatch.setattr(engine._VLMBatchAdapter, "__init__",
+                        lambda self, *a: setattr(self, "per_row_prompt_kwargs", True))
+    monkeypatch.setattr(engine._VLMBatchAdapter, "_decode_image", lambda self, r: r)
+    monkeypatch.setattr(engine._VLMBatchAdapter, "_generate_sequentially",
+                        lambda self, request: seen.append(request.audio) or "audio")
+    model = types.SimpleNamespace(_is_vlm_model=True, training=False, eval=lambda: None)
+    model.named_modules = lambda: [("", model)]
+    with pytest.warns(RuntimeWarning, match="decode one at a time"):
+        results = engine.generate_batch(
+            model, object(), [GenerationRequest(prompt="p", audio="a.wav")])
+    assert (results, seen) == (["audio"], ["a.wav"])
+    # The at-most-one-media invariant has to survive audio becoming supported.
+    with pytest.raises(ValueError, match="both an image and audio"):
+        engine.generate_batch(model, object(),
+                              [GenerationRequest(prompt="p", image=object(), audio="a.wav")])
+
+
+def test_audio_requests_decode_alone_while_the_rest_of_the_batch_still_batches():
+    # Audio has no batched path, but must not drag the others out of theirs.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    adapter = _audio_adapter(_audio_events((1, None), (2, "length")))
+    batched = []
+    adapter._decode_image = lambda request: request
+    adapter._group_key = lambda request: "g"
+    adapter.per_row_prompt_kwargs = True
+    adapter._run_chunk = lambda chunk, indices: (
+        batched.append(list(indices)), ["batched"] * len(chunk))[1]
+    requests = [GenerationRequest(prompt="a"), GenerationRequest(prompt="b", audio="a.wav"),
+                GenerationRequest(prompt="c")]
+    with pytest.warns(RuntimeWarning, match="decode one at a time"):
+        results = _VLMBatchAdapter.generate(adapter, requests)
+    assert batched == [[0, 2]]  # the audio row never reached the batched path
+    assert [results[0], results[2]] == ["batched", "batched"]
+    assert results[1].token_ids == [1]

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1,7 +1,5 @@
-import asyncio
 import concurrent.futures
 import inspect
-import threading
 import types
 from dataclasses import make_dataclass
 import pytest
@@ -63,35 +61,10 @@ def test_stop_scanner_trims_to_token_boundary():
     )
     assert mid_token.append(tokenizer, 4, -0.4) is True
     assert mid_token.result(tokenizer).token_ids == []
-    scanner = _StopStringScanner(("STOP",))
-    assert scanner.feed("abcde") is None
-    assert scanner.feed("abcdeSTOP") == (5, "STOP")
     canonical = _TableTokenizer({(1,): " hello", (2,): "\ufffd", (2, 3): "¡STOP"})
     leading = _PendingResult(_new_detokenizer(canonical), _StopStringScanner((" hello",)))
     assert leading.append(canonical, 1, -0.1) is True
     assert leading.result(canonical).token_ids == []
-    byte_stop = _PendingResult(_new_detokenizer(canonical), _StopStringScanner(("STOP",)))
-    assert byte_stop.append(canonical, 2, -0.2) is False
-    assert byte_stop.append(canonical, 3, -0.3) is True
-    assert (byte_stop.result(canonical).token_ids, byte_stop.text) == ([], "")
-    unicode_text = _PendingResult(_new_detokenizer(canonical), _StopStringScanner(()))
-    unicode_text.append(canonical, 2, -0.2)
-    unicode_text.append(canonical, 3, -0.3)
-    unicode_text.finish(canonical, "length")
-    assert unicode_text.text == "¡STOP"
-
-    rewriting = _TableTokenizer({(1,): "abcST", (1, 2): "abcXYOP"})
-    rewritten = _PendingResult(_new_detokenizer(rewriting), _StopStringScanner(("STOP",)))
-    assert rewritten.append(rewriting, 1, -0.1) is False
-    assert rewritten.append(rewriting, 2, -0.2) is True
-    assert rewritten.result(rewriting).text == ""
-
-    shrinking = _TableTokenizer({(1,): "abcde", (1, 2): "x "}, clean=True)
-    terminal = _PendingResult(_new_detokenizer(shrinking), _StopStringScanner((" ",)))
-    terminal.append(shrinking, 1, -0.1)
-    terminal.add_terminal(2, -0.2)
-    terminal.finish(shrinking, "length")
-    assert (terminal.text, terminal.finish_reason) == ("abcde", "length")
 
 @pytest.mark.parametrize(
     "generation_request,error",
@@ -112,7 +85,7 @@ def test_one_shot_prompt_ids_are_normalized_during_validation():
         [GenerationRequest(prompt_token_ids=iter((11, 12)))], GenerationDefaults())
     assert validated[0].prompt_token_ids == (11, 12)
 
-def test_text_api_probe_accepts_pinned_shape_and_names_pin_on_mismatch():
+def test_text_api_probe_accepts_supported_shape_and_names_gap_on_mismatch():
     Response = make_dataclass(
         "Response",
         [("uid", int), ("token", int), ("logprobs", object), ("finish_reason", str | None)],
@@ -143,7 +116,7 @@ def test_text_api_probe_accepts_pinned_shape_and_names_pin_on_mismatch():
             _probe_text_api(module)
     del BatchGenerator.__signature__
     del BatchGenerator.remove
-    with pytest.raises(RuntimeError, match=r"remove missing.*mlx-lm==0\.31\.2"):
+    with pytest.raises(RuntimeError, match=r"remove missing"):
         _probe_text_api(module)
     with pytest.raises(RuntimeError, match=r"make_sampler missing min_p"):
         _probe_sampler_api(type("Sample", (), {"make_sampler": lambda temp: None}))
@@ -153,7 +126,7 @@ def test_falsey_defaults_are_not_silently_replaced(monkeypatch):
     with pytest.raises(TypeError, match="defaults"):
         generate_batch(object(), None, [], defaults={})
     for name in ("kv_bits", "kv_group_size"):
-        with pytest.raises(ValueError, match=rf"{name} are not supported by mlx-lm==0\.31\.2"):
+        with pytest.raises(ValueError, match=rf"{name} are not forwarded by this engine"):
             GenerationDefaults(**{name: 4})
     for name in ("prefill_batch_size", "completion_batch_size", "max_kv_size"):
         for value in (-1, 0, True, 1.5):
@@ -254,30 +227,6 @@ def test_generation_mode_releases_lock_when_limit_restore_raises(monkeypatch):
         return acquired
     with concurrent.futures.ThreadPoolExecutor() as executor:
         assert executor.submit(acquire_elsewhere).result()
-    monkeypatch.setattr(
-        "unsloth_zoo.mlx.generate._restore_metal_limits", lambda _state: None
-    )
-    async def overlap():
-        async def enter_mode():
-            with generation_mode(model):
-                pass
-        with generation_mode(model):
-            with pytest.raises(RuntimeError, match="async tasks"):
-                await asyncio.create_task(enter_mode())
-    asyncio.run(overlap())
-    assert model.training is True
-    entered, release = threading.Event(), threading.Event()
-    def hold_mode():
-        with generation_mode(model):
-            entered.set()
-            release.wait(1)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-        holder = executor.submit(hold_mode)
-        assert entered.wait(1)
-        blocked = executor.submit(_GENERATION_MODE_LOCK.acquire, True, 0.05)
-        assert blocked.result() is False
-        release.set()
-        holder.result()
     assert model.training is True
 
 def test_fast_generate_binds_only_text_models_and_maps_shared_controls(monkeypatch):

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -39,6 +39,8 @@ class _CharTokenizer:
         return _CharDetokenizer(self)
     def decode(self, tokens):
         return "".join(self.pieces[item] for item in tokens)
+    def encode(self, text, **kwargs):
+        return [0] * len(text)
 
 class _TableTokenizer:
     def __init__(self, pieces, clean=False):
@@ -595,7 +597,14 @@ def test_vlm_requests_group_by_sampling_params():
     adapter._run_chunk = lambda requests, indices: (
         chunks.append(list(indices)) or [object() for _ in indices])
     hot = SamplingParams(temperature=0.9)
+    adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
     adapter.generate([GenerationRequest(prompt="a"), GenerationRequest(prompt="b", sampling=hot),
+                      GenerationRequest(prompt="c")])
+    assert sorted(chunks) == [[0, 2], [1]]
+    # Preprocessing stacks a group without padding, so differing prompt lengths
+    # must not share a chunk; upstream raises when they do.
+    chunks.clear()
+    adapter.generate([GenerationRequest(prompt="a"), GenerationRequest(prompt="bb"),
                       GenerationRequest(prompt="c")])
     assert sorted(chunks) == [[0, 2], [1]]
 

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -126,9 +126,13 @@ def test_text_api_probe_accepts_supported_shape_and_names_gap_on_mismatch():
 def test_falsey_defaults_are_not_silently_replaced(monkeypatch):
     with pytest.raises(TypeError, match="defaults"):
         generate_batch(object(), None, [], defaults={})
-    for name in ("kv_bits", "kv_group_size"):
+    # Refused per backend, not by the container, so each reason is true.
+    from unsloth_zoo.mlx.generate import _validate_text_requests
+    for name in ("kv_bits", "kv_group_size", "kv_quant_scheme", "quantized_kv_start"):
+        value = "affine" if name == "kv_quant_scheme" else 4
         with pytest.raises(ValueError, match=rf"{name} are not forwarded by this engine"):
-            GenerationDefaults(**{name: 4})
+            _validate_text_requests([GenerationRequest(prompt="a")],
+                                    GenerationDefaults(**{name: value}))
     for name in ("prefill_batch_size", "completion_batch_size", "max_kv_size"):
         for value in (-1, 0, True, 1.5):
             with pytest.raises((TypeError, ValueError), match=name):
@@ -313,12 +317,23 @@ def test_inverted_batch_sizes_are_rejected_for_vision_but_kept_for_text():
     assert _validate_text_requests([GenerationRequest(prompt="a")], inverted)
 
 
-def test_vlm_requests_reject_audio_token_ids_and_stop_strings():
+def test_vlm_requests_accept_stop_strings():
+    # Reinstating the old blanket rejection left every _drive-level test green.
+    from unsloth_zoo.mlx.generate import _validate_vlm_requests
+    assert _validate_vlm_requests([GenerationRequest(prompt="a")],
+                                  GenerationDefaults(stop_strings=("STOP",)))
+
+
+def test_vlm_requests_reject_audio_and_token_id_prompts():
     from unsloth_zoo.mlx.generate import _validate_vlm_requests
     cases = ((GenerationRequest(prompt="a", audio=object()), GenerationDefaults(), "carries audio"),
         (GenerationRequest(prompt_token_ids=[1]), GenerationDefaults(), "rendered prompt string"),
-        (GenerationRequest(prompt="a"), GenerationDefaults(stop_strings=("x",)), "stop_strings are not supported"),
-        (GenerationRequest(prompt="a"), GenerationDefaults(max_kv_size=64), "max_kv_size is not supported"))
+        (GenerationRequest(prompt="a"), GenerationDefaults(max_kv_size=64), "max_kv_size is not supported"),
+        # One that stopped being refused would reach generation and be dropped.
+        *((GenerationRequest(prompt="a"), GenerationDefaults(**{name: value}),
+           "not forwarded by this engine")
+          for name, value in (("kv_bits", 4), ("kv_group_size", 64),
+                              ("kv_quant_scheme", "affine"), ("quantized_kv_start", 100))))
     for request, defaults, message in cases:
         with pytest.raises(ValueError, match=message):
             _validate_vlm_requests([request], defaults)
@@ -504,6 +519,7 @@ def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
         def insert(self, prompts, max_tokens, prompt_kwargs=None,
                    logits_processors=None): pass
         def next(self): pass
+        def remove(self, uid): pass
         def close(self): pass
     Generator.__module__ = "mlx_vlm.generate.ar"
     ar = types.ModuleType("mlx_vlm.generate.ar")
@@ -523,6 +539,8 @@ def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
     assert adapter._split_prompt_kwargs({}, 3) == [{}, {}, {}]  # upstream splitter chosen
     assert adapter._chunked_prefill_kwargs(input_ids=None, prefill_kwargs={}) == {}
     assert policy_calls  # the policy helper was consulted, not bypassed
+    # The probed capability must reach the adapter, not merely exist on the module.
+    assert adapter.cancel is not None
 
 
 def test_vlm_drive_raises_on_true_stall_and_survives_long_prefill():
@@ -574,3 +592,103 @@ def test_vlm_requests_group_by_sampling_params():
     adapter.generate([GenerationRequest(prompt="a"), GenerationRequest(prompt="b", sampling=hot),
                       GenerationRequest(prompt="c")])
     assert sorted(chunks) == [[0, 2], [1]]
+
+
+@pytest.mark.parametrize("plural", (True, False))
+def test_vlm_stop_strings_trim_and_cancel_in_the_release_form(plural):
+    # Both signature forms, collection and single uid, must drive correctly.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter, _resolve_cancel
+    cancelled = []
+    class Generator(_vlm_stub(True, events=[[(0, 2, None)], [(0, 3, None)]])):
+        if plural:
+            def remove(self, uids): cancelled.append(list(uids))
+        else:
+            def remove(self, uid): cancelled.append([uid])
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults = GenerationDefaults(stop_strings=("STOP",))
+    adapter.per_row_prompt_kwargs = True
+    adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
+    adapter.cancel = _resolve_cancel(Generator)
+    result = adapter._drive(Generator(object(), object()), [0], {})[0]
+    # "<ST" + "OP>" completes the stop string: trimmed back to the boundary.
+    assert (result.token_ids, result.finish_reason, result.stop_match) == ([], "stop_string", "STOP")
+    assert cancelled == [[0]]
+
+
+def test_vlm_stop_strings_drop_later_events_when_the_release_cannot_cancel():
+    # Without remove(), a stopped sequence keeps decoding: its later events must
+    # not reach its result, and the sibling must still complete.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter, _resolve_cancel
+    Generator = _vlm_stub(False, events=[
+        [(0, 2, None), (1, 1, None)],
+        [(0, 3, None), (1, 1, None)],       # uid 0 completes "<STOP>" here
+        [(0, 1, None), (1, 1, "length")]])  # uid 0's late token must be ignored
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults = GenerationDefaults(stop_strings=("STOP",))
+    adapter.per_row_prompt_kwargs = False
+    adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
+    adapter.cancel = _resolve_cancel(Generator)
+    assert adapter.cancel is None  # no cancellation on this release
+    stopped, sibling = adapter._drive(Generator(object(), object()), [0, 1], {})
+    assert (stopped.token_ids, stopped.finish_reason, stopped.stop_match) == (
+        [], "stop_string", "STOP")
+    assert (sibling.token_ids, sibling.finish_reason) == ([1, 1, 1], "length")
+
+
+def test_generation_mode_serializes_threads_and_rejects_overlapping_tasks():
+    # Process-global MLX state is shared by neither threads nor async tasks.
+    import asyncio
+    import concurrent.futures
+    import threading
+    from unsloth_zoo.mlx.generate import generation_mode
+    model = types.SimpleNamespace(training=True, eval=lambda: None)
+    model.named_modules = lambda: [("", model)]
+    held, release = threading.Event(), threading.Event()
+    def hold():
+        with generation_mode(model):
+            held.set()
+            release.wait(5)  # held open until the probe has run: no timing race
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        task = pool.submit(hold)
+        try:
+            assert held.wait(5)
+            acquired = _GENERATION_MODE_LOCK.acquire(True, 0.05)
+            if acquired:  # never leak global lock state on failure
+                _GENERATION_MODE_LOCK.release()
+            assert acquired is False  # serialized across threads
+        finally:
+            release.set()
+            task.result()
+    async def overlap():
+        async def inner():
+            with generation_mode(model):
+                pass
+        with generation_mode(model):
+            with pytest.raises(RuntimeError, match="async tasks"):
+                await asyncio.create_task(inner())
+    asyncio.run(overlap())
+
+
+def test_detokenizer_buffers_partial_characters_and_emits_once():
+    # A replacement character is an incomplete sequence: it contributes nothing
+    # until resolved, then appears exactly once.
+    from unsloth_zoo.mlx.generate import _PendingResult, _StopStringScanner
+    tokenizer = _TableTokenizer({(1,): "hi ", (1, 2): "hi \ufffd", (1, 2, 3): "hi ok"})
+    state = _PendingResult(detokenizer=_new_detokenizer(tokenizer),
+                           scanner=_StopStringScanner(()))
+    for token in (1, 2, 3):
+        state.append(tokenizer, token, -0.1)
+    state.finish(tokenizer, "length")
+    assert state.result(tokenizer).text == "hi ok"
+
+
+def test_detokenizer_never_re_emits_after_a_shortening_decode():
+    # A shortening decode must not push the offset back and re-emit that tail.
+    from unsloth_zoo.mlx.generate import _PendingResult, _StopStringScanner
+    tokenizer = _TableTokenizer({(1,): "hello", (1, 2): "he", (1, 2, 3): "hello there"})
+    state = _PendingResult(detokenizer=_new_detokenizer(tokenizer),
+                           scanner=_StopStringScanner(()))
+    for token in (1, 2, 3):
+        state.append(tokenizer, token, -0.1)
+    state.finish(tokenizer, "length")
+    assert state.result(tokenizer).text == "hello there"

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import inspect
 import threading
 import types
 from dataclasses import make_dataclass
@@ -8,7 +9,7 @@ from unsloth_zoo.mlx.generate import (
     GenerationDefaults, GenerationRequest,
     _GENERATION_MODE_LOCK, _PendingResult, _StopStringScanner, _TextBatchAdapter,
     _eos_stop_tokens, _new_detokenizer, _probe_sampler_api, _probe_text_api,
-    _restore_training_flags,
+    _generation_cache_hygiene, _restore_training_flags,
     _validate_text_requests, generate_batch, generation_mode,
 )
 
@@ -118,7 +119,8 @@ def test_text_api_probe_accepts_pinned_shape_and_names_pin_on_mismatch():
     )
     GenerationBatch = type("GenerationBatch", (), {"Response": Response})
     class BatchGenerator:
-        def __init__(self, model, max_tokens=1, stop_tokens=None):
+        def __init__(self, model, max_tokens=1, stop_tokens=None,
+                     prefill_batch_size=8, completion_batch_size=32, max_kv_size=None):
             pass
         def insert(self, prompts, max_tokens=None, samplers=None,
                    logits_processors=None):
@@ -133,6 +135,13 @@ def test_text_api_probe_accepts_pinned_shape_and_names_pin_on_mismatch():
         "PinnedShape", (), {"BatchGenerator": BatchGenerator, "GenerationBatch": GenerationBatch}
     )
     _probe_text_api(module)
+    signature = inspect.signature(BatchGenerator)
+    for name in ("prefill_batch_size", "completion_batch_size", "max_kv_size"):
+        BatchGenerator.__signature__ = signature.replace(
+            parameters=[item for item in signature.parameters.values() if item.name != name])
+        with pytest.raises(RuntimeError, match=rf"constructor missing {name}"):
+            _probe_text_api(module)
+    del BatchGenerator.__signature__
     del BatchGenerator.remove
     with pytest.raises(RuntimeError, match=r"remove missing.*mlx-lm==0\.31\.2"):
         _probe_text_api(module)
@@ -140,9 +149,25 @@ def test_text_api_probe_accepts_pinned_shape_and_names_pin_on_mismatch():
         _probe_sampler_api(type("Sample", (), {"make_sampler": lambda temp: None}))
     assert _eos_stop_tokens(types.SimpleNamespace(eos_token_ids={2, None})) == [[2]]
 
-def test_falsey_defaults_are_not_silently_replaced():
+def test_falsey_defaults_are_not_silently_replaced(monkeypatch):
     with pytest.raises(TypeError, match="defaults"):
         generate_batch(object(), None, [], defaults={})
+    for name in ("kv_bits", "kv_group_size"):
+        with pytest.raises(ValueError, match=rf"{name} are not supported by mlx-lm==0\.31\.2"):
+            GenerationDefaults(**{name: 4})
+    for name in ("prefill_batch_size", "completion_batch_size", "max_kv_size"):
+        for value in (-1, 0, True, 1.5):
+            with pytest.raises((TypeError, ValueError), match=name):
+                GenerationDefaults(**{name: value})
+    calls = []
+    def clear():
+        calls.append(None)
+        if len(calls) == 2:
+            raise RuntimeError("clear")
+    monkeypatch.setattr("mlx.core.clear_cache", clear)
+    with pytest.warns(RuntimeWarning, match="clear_cache"), pytest.raises(ValueError, match="body"):
+        with _generation_cache_hygiene():
+            raise ValueError("body")
 
 def test_training_flag_restore_attempts_every_module():
     class Module:
@@ -162,7 +187,7 @@ def test_adapter_removes_stop_matches_and_closes_on_failure():
     class Generator:
         instances, fail, eos, close_fail = [], False, False, False
         def __init__(self, *_args, **_kwargs):
-            self.removed, self.closed = [], False
+            self.removed, self.closed, self.kwargs = [], False, _kwargs
             self.instances.append(self)
         def insert(self, *_args, **_kwargs):
             return [7]
@@ -189,11 +214,12 @@ def test_adapter_removes_stop_matches_and_closes_on_failure():
     tokenizer, adapter = _CharTokenizer(), object.__new__(_TextBatchAdapter)
     tokenizer.eos_token_ids = ()
     adapter.model, adapter.tokenizer = object(), tokenizer
-    adapter.defaults = GenerationDefaults(stop_strings=("<STOP>",))
+    adapter.defaults = GenerationDefaults(stop_strings=("<STOP>",), prefill_batch_size=2, completion_batch_size=3, max_kv_size=16)
     adapter.batch_generator_type = Generator
     adapter.make_sampler = lambda **_kwargs: None
     result = adapter.generate([GenerationRequest(prompt_token_ids=[9])])[0]
     assert result.token_ids == [1] and Generator.instances[-1].removed == [7]
+    assert tuple(Generator.instances[-1].kwargs[name] for name in ("prefill_batch_size", "completion_batch_size", "max_kv_size")) == (2, 3, 16)
     assert Generator.instances[-1].closed is True
     Generator.eos = True
     eos = adapter.generate([GenerationRequest(prompt_token_ids=[9])])[0]

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -7,8 +7,8 @@ import types
 from dataclasses import make_dataclass
 import pytest
 
-# These are logic tests, but they cross into mlx.core and mlx_vlm at a few
-# points, so off Apple Silicon they run against the torch-backed shim.
+# Logic tests, but a few cross into mlx.core and mlx_vlm, so off Apple Silicon
+# they run against the torch-backed shim.
 if importlib.util.find_spec("mlx") is None:
     from mlx_simulation import simulate_mlx_on_torch
     simulate_mlx_on_torch()
@@ -268,8 +268,7 @@ def test_fast_generate_binds_text_and_vision_models_and_maps_shared_controls(mon
     assert (captured["defaults"].prefill_batch_size, captured["defaults"].completion_batch_size, captured["defaults"].max_kv_size) == (2, 3, 32)
     with pytest.raises(TypeError, match="every fast_generate prompt"):
         model.fast_generate(["valid", 3])
-    # A vLLM prompt dict iterates to its keys, so it must be refused by type
-    # rather than silently generating from the key names.
+    # A vLLM prompt dict iterates to its keys, so it must be refused by type.
     with pytest.raises(TypeError, match="not vLLM prompt dicts"):
         model.fast_generate({"prompt": "hi", "multi_modal_data": {}})
     # KV-cache quantisation is never forwarded, so it is not a parameter.

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -260,12 +260,7 @@ def test_fast_generate_binds_text_and_vision_models_and_maps_shared_controls(mon
     vlm = types.SimpleNamespace(_is_vlm_model=True)
     _patch_mlx_saving(vlm, tokenizer)
     assert vlm.fast_generate(["look"]) is expected
-    # A text-only multimodal load publishes its inner tokenizer; the vision
-    # adapter needs the processor.
-    processor = object()
-    vlm._processor = processor
-    vlm.fast_generate(["look"])
-    assert captured["tokenizer"] is processor
+    assert vlm.fast_generate(["look"]) is expected
 
 
 @contextlib.contextmanager
@@ -845,3 +840,20 @@ def test_audio_requests_decode_alone_while_the_rest_of_the_batch_still_batches()
     assert batched == [[0, 2]]  # the audio row never reached the batched path
     assert [results[0], results[2]] == ["batched", "batched"]
     assert results[1].token_ids == [1]
+
+
+def test_vision_generation_resolves_the_saved_processor(monkeypatch):
+    # A text-only multimodal load publishes its inner tokenizer, so the typed
+    # core resolves the saved processor for both it and fast_generate.
+    from unsloth_zoo.mlx.generate import generate_batch as engine_generate_batch
+    from unsloth_zoo.mlx import generate as engine
+    seen = {}
+    class _Adapter:
+        def __init__(self, model, tok, defaults): seen["tok"] = tok
+        def generate(self, requests): return ["ok"]
+    monkeypatch.setattr(engine, "_VLMBatchAdapter", _Adapter)
+    monkeypatch.setattr(engine, "generation_mode", lambda model: contextlib.nullcontext())
+    processor = object()
+    model = types.SimpleNamespace(_is_vlm_model=True, _processor=processor)
+    assert engine_generate_batch(model, object(), [GenerationRequest(prompt="a")]) == ["ok"]
+    assert seen["tok"] is processor

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1,11 +1,19 @@
 import concurrent.futures
 import contextlib
+import importlib.util
 import inspect
 import pathlib
 import types
 from dataclasses import make_dataclass
 import pytest
-from unsloth_zoo.mlx.generate import (
+
+# These are logic tests, but they cross into mlx.core and mlx_vlm at a few
+# points, so off Apple Silicon they run against the torch-backed shim.
+if importlib.util.find_spec("mlx") is None:
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+from unsloth_zoo.mlx.generate import (  # noqa: E402
     GenerationDefaults, GenerationRequest, SamplingParams,
     _GENERATION_MODE_LOCK, _PendingResult, _StopStringScanner, _TextBatchAdapter,
     _eos_stop_tokens, _new_detokenizer, _probe_sampler_api, _probe_text_api,
@@ -257,6 +265,14 @@ def test_fast_generate_binds_text_and_vision_models_and_maps_shared_controls(mon
     assert (captured["defaults"].prefill_batch_size, captured["defaults"].completion_batch_size, captured["defaults"].max_kv_size) == (2, 3, 32)
     with pytest.raises(TypeError, match="every fast_generate prompt"):
         model.fast_generate(["valid", 3])
+    # A vLLM prompt dict iterates to its keys, so it must be refused by type
+    # rather than silently generating from the key names.
+    with pytest.raises(TypeError, match="not vLLM prompt dicts"):
+        model.fast_generate({"prompt": "hi", "multi_modal_data": {}})
+    # KV-cache quantisation is never forwarded, so it is not a parameter.
+    for control in ("kv_bits", "kv_group_size"):
+        with pytest.raises(TypeError):
+            model.fast_generate(["one"], **{control: 4})
     vlm = types.SimpleNamespace(_is_vlm_model=True)
     _patch_mlx_saving(vlm, tokenizer)
     assert vlm.fast_generate(["look"]) is expected

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1,10 +1,12 @@
 import concurrent.futures
+import contextlib
 import inspect
+import pathlib
 import types
 from dataclasses import make_dataclass
 import pytest
 from unsloth_zoo.mlx.generate import (
-    GenerationDefaults, GenerationRequest,
+    GenerationDefaults, GenerationRequest, SamplingParams,
     _GENERATION_MODE_LOCK, _PendingResult, _StopStringScanner, _TextBatchAdapter,
     _eos_stop_tokens, _new_detokenizer, _probe_sampler_api, _probe_text_api,
     _generation_cache_hygiene, _restore_training_flags,
@@ -81,8 +83,7 @@ def test_request_invariants(generation_request, error):
         _validate_text_requests([generation_request], GenerationDefaults())
 
 def test_one_shot_prompt_ids_are_normalized_during_validation():
-    validated = _validate_text_requests(
-        [GenerationRequest(prompt_token_ids=iter((11, 12)))], GenerationDefaults())
+    validated = _validate_text_requests([GenerationRequest(prompt_token_ids=iter((11, 12)))], GenerationDefaults())  # noqa: E501
     assert validated[0].prompt_token_ids == (11, 12)
 
 def test_text_api_probe_accepts_supported_shape_and_names_gap_on_mismatch():
@@ -229,7 +230,7 @@ def test_generation_mode_releases_lock_when_limit_restore_raises(monkeypatch):
         assert executor.submit(acquire_elsewhere).result()
     assert model.training is True
 
-def test_fast_generate_binds_only_text_models_and_maps_shared_controls(monkeypatch):
+def test_fast_generate_binds_text_and_vision_models_and_maps_shared_controls(monkeypatch):
     from unsloth_zoo.mlx import generate as generate_module
     from unsloth_zoo.mlx.loader import _patch_mlx_saving
     captured, expected = {}, [object()]
@@ -251,4 +252,325 @@ def test_fast_generate_binds_only_text_models_and_maps_shared_controls(monkeypat
         model.fast_generate(["valid", 3])
     vlm = types.SimpleNamespace(_is_vlm_model=True)
     _patch_mlx_saving(vlm, tokenizer)
-    assert not hasattr(vlm, "fast_generate")
+    assert vlm.fast_generate(["look"]) is expected
+
+
+@contextlib.contextmanager
+def _entry_ctx(order):
+    order.append("wired")
+    yield
+
+
+def _vlm_stub(per_row, *, events):
+    """BatchGenerator stand-in: pre-0.5 nests Response with a logprob vector,
+    0.5+ moves it to GenerationBatch with a scalar token_logprob."""
+    class _Response:
+        __dataclass_fields__ = dict.fromkeys(
+            ("uid", "token", "finish_reason",
+             "token_logprob" if per_row else "logprobs"))
+        def __init__(self, uid, token, finish_reason):
+            self.uid, self.token, self.finish_reason = uid, token, finish_reason
+            if per_row:
+                self.token_logprob = -0.5
+            else:
+                self.logprobs = {token: -0.5}
+    class Generator:
+        if not per_row:
+            Response = _Response
+        GenerationBatch = types.SimpleNamespace(Response=_Response)
+        def __init__(self, model, processor, **kwargs):
+            self._prompt_batch = None
+            self._generation_batch = []
+            self._unprocessed_sequences = []
+            self._polls = 0
+        def insert(self, prompts, max_tokens, **kwargs):
+            return list(range(len(prompts)))
+        @property
+        def has_work(self):
+            return self._polls < len(events)
+        def next(self, **kwargs):
+            batch = events[self._polls] if self._polls < len(events) else []
+            self._polls += 1
+            emitted = [_Response(*item) for item in batch]
+            return (([], emitted) if per_row else emitted)
+        def close(self):
+            pass
+    if per_row:
+        Generator.insert.__signature__ = inspect.Signature([
+            inspect.Parameter("prompts", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter("max_tokens", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter("prompt_kwargs", inspect.Parameter.KEYWORD_ONLY, default=None),
+        ])
+    return Generator
+
+
+def test_inverted_batch_sizes_are_rejected_for_vision_but_kept_for_text():
+    # Vision refuses an inverted pair rather than hang; mlx-lm normalizes it.
+    from unsloth_zoo.mlx.generate import _validate_text_requests, _validate_vlm_requests
+    inverted = GenerationDefaults(prefill_batch_size=16, completion_batch_size=8)  # noqa: E501
+    with pytest.raises(ValueError, match="must not exceed completion_batch_size"):
+        _validate_vlm_requests([GenerationRequest(prompt="a")], inverted)
+    assert _validate_text_requests([GenerationRequest(prompt="a")], inverted)
+
+
+def test_vlm_requests_reject_audio_token_ids_and_stop_strings():
+    from unsloth_zoo.mlx.generate import _validate_vlm_requests
+    cases = ((GenerationRequest(prompt="a", audio=object()), GenerationDefaults(), "carries audio"),
+        (GenerationRequest(prompt_token_ids=[1]), GenerationDefaults(), "rendered prompt string"),
+        (GenerationRequest(prompt="a"), GenerationDefaults(stop_strings=("x",)), "stop_strings are not supported"),
+        (GenerationRequest(prompt="a"), GenerationDefaults(max_kv_size=64), "max_kv_size is not supported"))
+    for request, defaults, message in cases:
+        with pytest.raises(ValueError, match=message):
+            _validate_vlm_requests([request], defaults)
+    # Path images normalize to str once: mlx-vlm's loader opens str only, and
+    # grouping and preprocessing must see the same value.
+    assert _validate_vlm_requests([GenerationRequest(prompt="a", image=pathlib.Path("/tmp/i.png"))], GenerationDefaults())[0].image == "/tmp/i.png"  # noqa: E501
+
+
+def test_prompt_kwargs_fallback_splits_mrope_on_the_batch_axis():
+    # MRoPE position_ids are [3, batch, sequence]; axis 0 would hand every row
+    # the same rope section.
+    from unsloth_zoo.mlx.generate import _split_prompt_kwargs_fallback
+    class Fake:
+        def __init__(self, shape): self.shape, self.ndim = shape, len(shape)
+        def __getitem__(self, key): return ("sliced", key)
+    rows = _split_prompt_kwargs_fallback(
+        {"position_ids": Fake((3, 2, 5)), "image_position_ids": Fake((2, 4, 5)),
+         "inputs_embeds": Fake((2, 5, 7)), "scale": 3}, 2)
+    assert rows[1]["position_ids"][1] == (slice(None), slice(1, 2), slice(None))
+    assert rows[1]["image_position_ids"][1] == slice(1, 2)  # batch-first, not MRoPE
+    assert rows[1]["inputs_embeds"][1] == slice(1, 2) and rows[0]["scale"] == 3
+
+
+def test_vlm_adapter_reports_admission_stall_without_counting_polls():
+    # Prefill yields eventless polls, so only impossible admission is a stall.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults = GenerationDefaults()
+    def state(prompt_batch):
+        return types.SimpleNamespace(_prompt_batch=prompt_batch,
+                                     _generation_batch=[], _unprocessed_sequences=[1])
+    assert (adapter._admission_stalled(state(object())), adapter._admission_stalled(
+        state(None)), adapter._admission_stalled(types.SimpleNamespace())) == (
+        False, True, None)
+
+
+@pytest.mark.parametrize("per_row", (False, True))
+def test_vlm_adapter_drives_both_upstream_protocols(per_row):
+    # Pre-0.5 polls next() until empty; later ones own has_work and return pairs.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    generator = _vlm_stub(per_row, events=[[(0, 1, None)], [(0, 3, "stop")]])(
+        object(), object())
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.per_row_prompt_kwargs = per_row
+    adapter.defaults = GenerationDefaults()
+    adapter.processor = _CharTokenizer()
+    results = adapter._drive(generator, [0], {})
+    assert ([r.token_ids for r in results], results[0].finish_reason) == ([[1]], "stop")
+
+
+def test_vlm_adapter_isolates_detokenizers_and_reads_scalar_logprobs():
+    # A shared-detokenizer processor must not interleave sequences into one buffer.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    class SharedDetokenizerTokenizer(_CharTokenizer):
+        def __init__(self):
+            self._shared = _CharDetokenizer(self)
+        @property
+        def detokenizer(self):
+            return self._shared
+    processor = types.SimpleNamespace(tokenizer=SharedDetokenizerTokenizer())
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.per_row_prompt_kwargs = True
+    adapter.defaults = GenerationDefaults()
+    adapter.processor = processor
+    generator = _vlm_stub(True, events=[
+        [(0, 1, None), (1, 4, None)], [(0, 3, "stop"), (1, 3, "stop")]])(
+        object(), object())
+    results = adapter._drive(generator, [0, 1], {})
+    # Distinct buffers: a shared one concatenates both sequences into the first.
+    assert [(r.token_ids, r.text) for r in results] == [
+        ([1], "hello "), ([4], "tailSTOPsuffix")] and results[0].logprobs == [-0.5]
+
+
+def test_vlm_chunking_respects_release_capabilities():
+    # Older releases run one chunk per generator to avoid row-zero reuse.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults = GenerationDefaults(prefill_batch_size=2, completion_batch_size=4)
+    chunks = []
+    adapter._group_key = lambda request: "same"
+    adapter._run_chunk = lambda requests, indices: (
+        chunks.append(list(indices)) or [object() for _ in indices])
+    requests = [GenerationRequest(prompt="p") for _ in range(5)]
+    for per_row, expected in ((True, [[0, 1, 2, 3, 4]]), (False, [[0, 1], [2, 3], [4]])):
+        chunks.clear(); adapter.per_row_prompt_kwargs = per_row  # noqa: E702
+        adapter.generate(requests)
+        assert chunks == expected
+
+
+def test_vlm_run_chunk_builds_the_generator_after_embeddings():
+    # The policy needs real inputs, so the generator is built after embeddings.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    order, seen = [], {}
+    ids, embeds = (types.SimpleNamespace(tolist=lambda: [[1], [2]]),
+                   types.SimpleNamespace(to_dict=lambda: {"inputs_embeds": "E", "position_ids": None}))
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults, adapter.per_row_prompt_kwargs = GenerationDefaults(), True
+    adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
+    adapter.constructor_params = {"prefill_batch_size", "completion_batch_size", "sampler", "stop_tokens"}  # noqa: E501
+    adapter.prepare_inputs = lambda *a, **k: {"input_ids": ids, "extra": "D", "position_ids": "P"}  # noqa: E501
+    adapter.make_sampler = lambda **k: object()
+    adapter._add_special_tokens, adapter._drive = (lambda: True), (lambda *a: ["ok"] * 2)
+    adapter._split_prompt_kwargs = lambda kw, n: (seen.update(kwargs=kw), [{}] * n)[1]
+    # Recording on ENTRY proves embeddings run inside the wired-limit context.
+    adapter._wired_limit = lambda: _entry_ctx(order)  # records on ENTRY
+    adapter._chunked_prefill_kwargs = lambda **kw: (
+        order.append("policy"), seen.update(policy=kw), {})[2]
+    adapter.model = types.SimpleNamespace(
+        config=types.SimpleNamespace(image_token_index=None), language_model=object(),
+        get_input_embeddings=lambda *a, **k: (order.append("embed"), embeds)[1])
+    adapter.generator_type = lambda *a, **k: (order.append("construct"),
+        seen.update(ctor=k), _vlm_stub(True, events=[[(0, 1, "stop")]])(*a[:2]))[2]
+    assert adapter._run_chunk([GenerationRequest(prompt="p")] * 2, [0, 1]) == ["ok", "ok"]
+    assert order == ["wired", "embed", "policy", "construct"]
+    assert seen["policy"]["prefill_kwargs"]["inputs_embeds"] == "E"
+    assert seen["kwargs"]["extra"] == "D"
+    # A None embedding field must not overwrite a valid preprocessing value.
+    assert seen["kwargs"]["position_ids"] == "P"
+    # Per-row keeps configured sizes; EOS stays with the processor.
+    assert (seen["ctor"]["prefill_batch_size"], seen["ctor"]["completion_batch_size"]) == (8, 32)
+    assert "stop_tokens" not in seen["ctor"]
+
+
+@pytest.mark.parametrize("nested", (True, False))
+def test_vlm_probe_accepts_both_event_class_locations(nested):
+    # Pre-0.5 nests Response with a logprob vector; 0.5+ moves it to
+    # GenerationBatch with a scalar token_logprob.
+    from unsloth_zoo.mlx.generate import _probe_vlm_api
+    response = type("Response", (), {"__dataclass_fields__": dict.fromkeys(
+        ("uid", "token", "finish_reason", "logprobs" if nested else "token_logprob"))})
+    class Generator:
+        def __init__(self, model, processor, prefill_batch_size=1, completion_batch_size=1): pass  # noqa: E501
+        def insert(self, prompts, max_tokens): pass
+        def next(self): pass
+    if nested:
+        Generator.Response = response
+    module = types.SimpleNamespace(BatchGenerator=Generator, **(
+        {} if nested else {"GenerationBatch": types.SimpleNamespace(Response=response)}))
+    assert _probe_vlm_api(module)
+
+
+def test_vlm_prompt_kwargs_prefer_upstream_only_when_mrope_aware():
+    # An axis-0 upstream splitter is refused in favour of the local MRoPE one.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    adapter, calls = _VLMBatchAdapter.__new__(_VLMBatchAdapter), []
+    adapter.batch_module = types.SimpleNamespace(
+        _split_prompt_kwargs_per_row=lambda kwargs, size: calls.append(size) or ["up"])
+    assert adapter._split_prompt_kwargs({}, 2) == [{}, {}] and not calls
+    adapter.batch_module._is_mrope_position_ids_prompt_kwarg = lambda key, value: False
+    assert adapter._split_prompt_kwargs({}, 2) == ["up"] and calls == [2]
+
+
+def test_vlm_images_are_decoded_once_and_flow_to_preprocessing():
+    # One fetch per request; the decoded object reaches grouping and
+    # prepare_inputs; raw bytes are rejected.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    loads, seen = [], {}
+    decoded = types.SimpleNamespace(size=(8, 8))
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults, adapter.per_row_prompt_kwargs = GenerationDefaults(), True
+    adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
+    adapter.process_image = lambda src, shape, proc: loads.append(src) or decoded
+    adapter._run_chunk = lambda requests, indices: (
+        seen.update(image=requests[indices[0]].image), [object()])[1]
+    adapter.generate([GenerationRequest(prompt="p", image="/tmp/one-use.png")])
+    assert loads == ["/tmp/one-use.png"] and seen["image"] is decoded
+    with pytest.raises(ValueError, match="raw bytes"):
+        adapter.generate([GenerationRequest(prompt="p", image=b"\x89PNG")])
+
+
+def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
+    # Newer layout: the package re-exports BatchGenerator while helpers and the
+    # event class live on the defining module. Delegation via __getattr__ is
+    # omitted so this proves the defining-module binding alone.
+    import sys
+    import mlx_vlm.utils  # noqa: F401  (cache the real module before shadowing)
+    from unsloth_zoo.mlx import generate as engine
+    response = type("Response", (), {"__dataclass_fields__": dict.fromkeys(
+        ("uid", "token", "finish_reason", "token_logprob"))})
+    class Generator:
+        def __init__(self, model, processor, prefill_batch_size=1,
+                     completion_batch_size=1, compute_logprobs=False): pass
+        def insert(self, prompts, max_tokens, prompt_kwargs=None,
+                   logits_processors=None): pass
+        def next(self): pass
+        def close(self): pass
+    Generator.__module__ = "mlx_vlm.generate.ar"
+    ar = types.ModuleType("mlx_vlm.generate.ar")
+    ar.BatchGenerator = Generator
+    ar.GenerationBatch = types.SimpleNamespace(Response=response)
+    ar._split_prompt_kwargs_per_row = lambda kwargs, size: [{}] * size
+    ar._is_mrope_position_ids_prompt_kwarg = lambda key, value: False
+    policy_calls = []
+    ar._chunked_prefill_enabled = lambda model, **kwargs: policy_calls.append(model) or True
+    bare = types.ModuleType("mlx_vlm.generate")
+    bare.BatchGenerator = Generator  # re-export only; no delegation here
+    monkeypatch.setitem(sys.modules, "mlx_vlm.generate", bare)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.generate.ar", ar)
+    adapter = engine._VLMBatchAdapter(object(), _CharTokenizer(), GenerationDefaults())
+    # Binds the DEFINING module although the re-exporting one matched first.
+    assert adapter.batch_module is ar and adapter.per_row_prompt_kwargs
+    assert adapter._split_prompt_kwargs({}, 3) == [{}, {}, {}]  # upstream splitter chosen
+    assert adapter._chunked_prefill_kwargs(input_ids=None, prefill_kwargs={}) == {}
+    assert policy_calls  # the policy helper was consulted, not bypassed
+
+
+def test_vlm_drive_raises_on_true_stall_and_survives_long_prefill():
+    # Impossible admission raises; a multi-poll prefill must still complete.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults, adapter.per_row_prompt_kwargs = GenerationDefaults(), True
+    adapter.processor = types.SimpleNamespace(tokenizer=_CharTokenizer())
+    base = _vlm_stub(True, events=[[(0, 1, "stop")]])
+    class LongPrefill(base):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self._prompt_batch, self._unprocessed_sequences = object(), [1]
+            self._empty_polls = 3
+        @property
+        def has_work(self):
+            return self._empty_polls > 0 or self._polls < 1
+        def next(self, **kwargs):
+            if self._empty_polls:
+                self._empty_polls -= 1
+                if not self._empty_polls:
+                    # Prefill done: the sequence is promoted into decoding.
+                    self._prompt_batch, self._generation_batch = None, [1]
+                return ([], [])
+            return super().next(**kwargs)
+    assert adapter._drive(LongPrefill(object(), object()), [0], {})[0].finish_reason == "stop"
+    class Stalled(base):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self._prompt_batch, self._generation_batch = None, []
+            self._unprocessed_sequences = [1]
+        has_work = True
+        def next(self, **kwargs):
+            return ([], [])
+    with pytest.raises(RuntimeError, match="admitted no prompt"):
+        adapter._drive(Stalled(object(), object()), [0], {})
+
+
+def test_vlm_requests_group_by_sampling_params():
+    # Differing sampling must not share one constructor-level sampler.
+    from unsloth_zoo.mlx.generate import _VLMBatchAdapter
+    adapter = _VLMBatchAdapter.__new__(_VLMBatchAdapter)
+    adapter.defaults, adapter.per_row_prompt_kwargs = GenerationDefaults(), True
+    adapter.process_image = None
+    chunks = []
+    adapter._run_chunk = lambda requests, indices: (
+        chunks.append(list(indices)) or [object() for _ in indices])
+    hot = SamplingParams(temperature=0.9)
+    adapter.generate([GenerationRequest(prompt="a"), GenerationRequest(prompt="b", sampling=hot),
+                      GenerationRequest(prompt="c")])
+    assert sorted(chunks) == [[0, 2], [1]]

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -279,3 +279,27 @@ def test_generation_mode_releases_lock_when_limit_restore_raises(monkeypatch):
         release.set()
         holder.result()
     assert model.training is True
+
+def test_fast_generate_binds_only_text_models_and_maps_shared_controls(monkeypatch):
+    from unsloth_zoo.mlx import generate as generate_module
+    from unsloth_zoo.mlx.loader import _patch_mlx_saving
+    captured, expected = {}, [object()]
+    def fake_generate(model, tokenizer, requests, *, defaults):
+        captured.update(model=model, tokenizer=tokenizer, requests=requests, defaults=defaults)
+        return expected
+    monkeypatch.setattr(generate_module, "generate_batch", fake_generate)
+    tokenizer, model = object(), types.SimpleNamespace(_is_vlm_model=False)
+    _patch_mlx_saving(model, tokenizer)
+    result = model.fast_generate(
+        ("one", "two"), max_tokens=7, temperature=0.5,
+        prefill_batch_size=2, completion_batch_size=3, max_kv_size=32,
+    )
+    assert result is expected
+    assert [request.prompt for request in captured["requests"]] == ["one", "two"]
+    assert (captured["defaults"].max_tokens, captured["defaults"].sampling.temperature) == (7, 0.5)
+    assert (captured["defaults"].prefill_batch_size, captured["defaults"].completion_batch_size, captured["defaults"].max_kv_size) == (2, 3, 32)
+    with pytest.raises(TypeError, match="every fast_generate prompt"):
+        model.fast_generate(["valid", 3])
+    vlm = types.SimpleNamespace(_is_vlm_model=True)
+    _patch_mlx_saving(vlm, tokenizer)
+    assert not hasattr(vlm, "fast_generate")

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -1,0 +1,255 @@
+import asyncio
+import concurrent.futures
+import threading
+import types
+from dataclasses import make_dataclass
+import pytest
+from unsloth_zoo.mlx.generate import (
+    GenerationDefaults, GenerationRequest,
+    _GENERATION_MODE_LOCK, _PendingResult, _StopStringScanner, _TextBatchAdapter,
+    _eos_stop_tokens, _new_detokenizer, _probe_sampler_api, _probe_text_api,
+    _restore_training_flags,
+    _validate_text_requests, generate_batch, generation_mode,
+)
+
+class _CharDetokenizer:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+        self.reset()
+    def reset(self):
+        self.offset = 0
+        self.tokens = []
+        self.text = ""
+    def add_token(self, token):
+        self.tokens.append(token)
+        self.text = "".join(self.tokenizer.pieces[item] for item in self.tokens)
+    def finalize(self):
+        pass
+    @property
+    def last_segment(self):
+        segment = self.text[self.offset:]
+        self.offset = len(self.text)
+        return segment
+
+class _CharTokenizer:
+    pieces = {1: "hello ", 2: "<ST", 3: "OP>", 4: "tailSTOPsuffix"}
+    @property
+    def detokenizer(self):
+        return _CharDetokenizer(self)
+    def decode(self, tokens):
+        return "".join(self.pieces[item] for item in tokens)
+
+class _TableTokenizer:
+    def __init__(self, pieces, clean=False):
+        self.pieces, self.clean_up_tokenization_spaces = pieces, clean
+    def decode(self, tokens):
+        return self.pieces.get(tuple(tokens), "")
+def test_stop_scanner_trims_to_token_boundary():
+    tokenizer = _CharTokenizer()
+    pending = _PendingResult(
+        _new_detokenizer(tokenizer),
+        _StopStringScanner(("<STOP>", "STOP")),
+    )
+    assert pending.append(tokenizer, 1, -0.1) is False
+    assert pending.append(tokenizer, 2, -0.2) is False
+    assert pending.append(tokenizer, 3, -0.3) is True
+    result = pending.result(tokenizer)
+    assert (result.token_ids, result.logprobs, result.text) == ([1], [-0.1], "hello ")
+    assert (result.finish_reason, result.stop_match) == ("stop_string", "<STOP>")
+    mid_token = _PendingResult(
+        _new_detokenizer(tokenizer),
+        _StopStringScanner(("STOP",)),
+    )
+    assert mid_token.append(tokenizer, 4, -0.4) is True
+    assert mid_token.result(tokenizer).token_ids == []
+    scanner = _StopStringScanner(("STOP",))
+    assert scanner.feed("abcde") is None
+    assert scanner.feed("abcdeSTOP") == (5, "STOP")
+    canonical = _TableTokenizer({(1,): " hello", (2,): "\ufffd", (2, 3): "¡STOP"})
+    leading = _PendingResult(_new_detokenizer(canonical), _StopStringScanner((" hello",)))
+    assert leading.append(canonical, 1, -0.1) is True
+    assert leading.result(canonical).token_ids == []
+    byte_stop = _PendingResult(_new_detokenizer(canonical), _StopStringScanner(("STOP",)))
+    assert byte_stop.append(canonical, 2, -0.2) is False
+    assert byte_stop.append(canonical, 3, -0.3) is True
+    assert (byte_stop.result(canonical).token_ids, byte_stop.text) == ([], "")
+    unicode_text = _PendingResult(_new_detokenizer(canonical), _StopStringScanner(()))
+    unicode_text.append(canonical, 2, -0.2)
+    unicode_text.append(canonical, 3, -0.3)
+    unicode_text.finish(canonical, "length")
+    assert unicode_text.text == "¡STOP"
+
+    rewriting = _TableTokenizer({(1,): "abcST", (1, 2): "abcXYOP"})
+    rewritten = _PendingResult(_new_detokenizer(rewriting), _StopStringScanner(("STOP",)))
+    assert rewritten.append(rewriting, 1, -0.1) is False
+    assert rewritten.append(rewriting, 2, -0.2) is True
+    assert rewritten.result(rewriting).text == ""
+
+    shrinking = _TableTokenizer({(1,): "abcde", (1, 2): "x "}, clean=True)
+    terminal = _PendingResult(_new_detokenizer(shrinking), _StopStringScanner((" ",)))
+    terminal.append(shrinking, 1, -0.1)
+    terminal.add_terminal(2, -0.2)
+    terminal.finish(shrinking, "length")
+    assert (terminal.text, terminal.finish_reason) == ("abcde", "length")
+
+@pytest.mark.parametrize(
+    "generation_request,error",
+    [
+        (GenerationRequest(), "exactly one"),
+        (GenerationRequest(prompt="x", prompt_token_ids=[1]), "exactly one"),
+        (GenerationRequest(prompt_token_ids=[]), "must not be empty"),
+        (GenerationRequest(prompt="x", image=object()), "text prompts only"),
+        (GenerationRequest(prompt="x", max_tokens=0), "must be positive"),
+    ],
+)
+def test_request_invariants(generation_request, error):
+    with pytest.raises((TypeError, ValueError), match=error):
+        _validate_text_requests([generation_request], GenerationDefaults())
+
+def test_one_shot_prompt_ids_are_normalized_during_validation():
+    validated = _validate_text_requests(
+        [GenerationRequest(prompt_token_ids=iter((11, 12)))], GenerationDefaults())
+    assert validated[0].prompt_token_ids == (11, 12)
+
+def test_text_api_probe_accepts_pinned_shape_and_names_pin_on_mismatch():
+    Response = make_dataclass(
+        "Response",
+        [("uid", int), ("token", int), ("logprobs", object), ("finish_reason", str | None)],
+    )
+    GenerationBatch = type("GenerationBatch", (), {"Response": Response})
+    class BatchGenerator:
+        def __init__(self, model, max_tokens=1, stop_tokens=None):
+            pass
+        def insert(self, prompts, max_tokens=None, samplers=None,
+                   logits_processors=None):
+            pass
+        def next_generated(self):
+            pass
+        def remove(self, uids):
+            pass
+        def close(self):
+            pass
+    module = type(
+        "PinnedShape", (), {"BatchGenerator": BatchGenerator, "GenerationBatch": GenerationBatch}
+    )
+    _probe_text_api(module)
+    del BatchGenerator.remove
+    with pytest.raises(RuntimeError, match=r"remove missing.*mlx-lm==0\.31\.2"):
+        _probe_text_api(module)
+    with pytest.raises(RuntimeError, match=r"make_sampler missing min_p"):
+        _probe_sampler_api(type("Sample", (), {"make_sampler": lambda temp: None}))
+    assert _eos_stop_tokens(types.SimpleNamespace(eos_token_ids={2, None})) == [[2]]
+
+def test_falsey_defaults_are_not_silently_replaced():
+    with pytest.raises(TypeError, match="defaults"):
+        generate_batch(object(), None, [], defaults={})
+
+def test_training_flag_restore_attempts_every_module():
+    class Module:
+        def __init__(self, fails=False):
+            self.training, self.fails = False, fails
+        def _set_training_mode(self, mode):
+            self.training = mode
+            if self.fails:
+                raise RuntimeError("module restore failed")
+
+    first, later = Module(True), Module()
+    with pytest.raises(RuntimeError, match="module restore failed"):
+        _restore_training_flags([(first, True), (later, True)])
+    assert later.training is True
+
+def test_adapter_removes_stop_matches_and_closes_on_failure():
+    class Generator:
+        instances, fail, eos, close_fail = [], False, False, False
+        def __init__(self, *_args, **_kwargs):
+            self.removed, self.closed = [], False
+            self.instances.append(self)
+        def insert(self, *_args, **_kwargs):
+            return [7]
+        def next_generated(self):
+            if self.fail:
+                raise RuntimeError("event failure")
+            def event(token):
+                return types.SimpleNamespace(
+                    uid=7, token=token, logprobs=[-9.0, -0.1, -0.2, -0.3],
+                    finish_reason=None,
+                )
+            if self.eos:
+                terminal = event(3)
+                terminal.finish_reason = "stop"
+                return [event(1), terminal]
+            return [event(1), event(2), event(3)]
+        def remove(self, uids):
+            self.removed.extend(uids)
+        def close(self):
+            self.closed = True
+            if self.close_fail:
+                raise RuntimeError("close failure")
+
+    tokenizer, adapter = _CharTokenizer(), object.__new__(_TextBatchAdapter)
+    tokenizer.eos_token_ids = ()
+    adapter.model, adapter.tokenizer = object(), tokenizer
+    adapter.defaults = GenerationDefaults(stop_strings=("<STOP>",))
+    adapter.batch_generator_type = Generator
+    adapter.make_sampler = lambda **_kwargs: None
+    result = adapter.generate([GenerationRequest(prompt_token_ids=[9])])[0]
+    assert result.token_ids == [1] and Generator.instances[-1].removed == [7]
+    assert Generator.instances[-1].closed is True
+    Generator.eos = True
+    eos = adapter.generate([GenerationRequest(prompt_token_ids=[9])])[0]
+    assert eos.token_ids == [1] and eos.finish_reason == "stop"
+    Generator.eos = False
+    Generator.fail = True
+    Generator.close_fail = True
+    with pytest.warns(RuntimeWarning, match=r"close\(\) failed"):
+        with pytest.raises(RuntimeError, match="event failure"):
+            adapter.generate([GenerationRequest(prompt_token_ids=[9])])
+    assert Generator.instances[-1].closed is True
+
+def test_generation_mode_releases_lock_when_limit_restore_raises(monkeypatch):
+    model = types.SimpleNamespace(training=True)
+    model.named_modules = lambda: [("", model)]
+    model.eval = lambda: setattr(model, "training", False)
+
+    monkeypatch.setattr(
+        "unsloth_zoo.mlx.generate._snapshot_metal_limits", lambda: {"memory": 1}
+    )
+    monkeypatch.setattr(
+        "unsloth_zoo.mlx.generate._restore_metal_limits",
+        lambda _snapshot: (_ for _ in ()).throw(RuntimeError("restore failed")),
+    )
+    with pytest.raises(RuntimeError, match="restore failed"):
+        with generation_mode(model):
+            pass
+    def acquire_elsewhere():
+        acquired = _GENERATION_MODE_LOCK.acquire(timeout=1)
+        if acquired:
+            _GENERATION_MODE_LOCK.release()
+        return acquired
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        assert executor.submit(acquire_elsewhere).result()
+    monkeypatch.setattr(
+        "unsloth_zoo.mlx.generate._restore_metal_limits", lambda _state: None
+    )
+    async def overlap():
+        async def enter_mode():
+            with generation_mode(model):
+                pass
+        with generation_mode(model):
+            with pytest.raises(RuntimeError, match="async tasks"):
+                await asyncio.create_task(enter_mode())
+    asyncio.run(overlap())
+    assert model.training is True
+    entered, release = threading.Event(), threading.Event()
+    def hold_mode():
+        with generation_mode(model):
+            entered.set()
+            release.wait(1)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        holder = executor.submit(hold_mode)
+        assert entered.wait(1)
+        blocked = executor.submit(_GENERATION_MODE_LOCK.acquire, True, 0.05)
+        assert blocked.result() is False
+        release.set()
+        holder.result()
+    assert model.training is True

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -227,11 +227,13 @@ def test_generation_mode_releases_lock_when_limit_restore_raises(monkeypatch):
     model.named_modules = lambda: [("", model)]
     model.eval = lambda: setattr(model, "training", False)
 
+    # Patch the loaded module: a string target reimports unsloth_zoo, whose
+    # install guard fires on a CPU checkout without the unsloth package.
+    from unsloth_zoo.mlx import generate as generate_module
+    monkeypatch.setattr(generate_module, "_snapshot_metal_limits", lambda: {"memory": 1})
     monkeypatch.setattr(
-        "unsloth_zoo.mlx.generate._snapshot_metal_limits", lambda: {"memory": 1}
-    )
-    monkeypatch.setattr(
-        "unsloth_zoo.mlx.generate._restore_metal_limits",
+        generate_module,
+        "_restore_metal_limits",
         lambda _snapshot: (_ for _ in ()).throw(RuntimeError("restore failed")),
     )
     with pytest.raises(RuntimeError, match="restore failed"):

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -89,7 +89,8 @@ def test_one_shot_prompt_ids_are_normalized_during_validation():
 def test_text_api_probe_accepts_supported_shape_and_names_gap_on_mismatch():
     Response = make_dataclass(
         "Response",
-        [("uid", int), ("token", int), ("logprobs", object), ("finish_reason", str | None)],
+        # make_dataclass evaluates these, so no PEP 604 union: the package supports 3.9.
+        [("uid", int), ("token", int), ("logprobs", object), ("finish_reason", object)],
     )
     GenerationBatch = type("GenerationBatch", (), {"Response": Response})
     class BatchGenerator:
@@ -257,6 +258,12 @@ def test_fast_generate_binds_text_and_vision_models_and_maps_shared_controls(mon
     vlm = types.SimpleNamespace(_is_vlm_model=True)
     _patch_mlx_saving(vlm, tokenizer)
     assert vlm.fast_generate(["look"]) is expected
+    # A text-only multimodal load publishes its inner tokenizer; the vision
+    # adapter needs the processor.
+    processor = object()
+    vlm._processor = processor
+    vlm.fast_generate(["look"])
+    assert captured["tokenizer"] is processor
 
 
 @contextlib.contextmanager

--- a/tests/test_mlx_generate.py
+++ b/tests/test_mlx_generate.py
@@ -84,6 +84,7 @@ def test_stop_scanner_trims_to_token_boundary():
         (GenerationRequest(), "exactly one"),
         (GenerationRequest(prompt="x", prompt_token_ids=[1]), "exactly one"),
         (GenerationRequest(prompt_token_ids=[]), "must not be empty"),
+        (GenerationRequest(prompt=""), "must not be empty"),
         (GenerationRequest(prompt="x", image=object()), "text prompts only"),
         (GenerationRequest(prompt="x", max_tokens=0), "must be positive"),
     ],
@@ -347,6 +348,7 @@ def test_vlm_requests_accept_stop_strings():
 def test_vlm_requests_reject_token_id_prompts_and_unsupported_controls():
     from unsloth_zoo.mlx.generate import _validate_vlm_requests
     cases = ((GenerationRequest(prompt_token_ids=[1]), GenerationDefaults(), "rendered prompt string"),
+        (GenerationRequest(prompt=""), GenerationDefaults(), "must not be empty"),
         (GenerationRequest(prompt="a"), GenerationDefaults(max_kv_size=64), "max_kv_size is not supported"),
         # One that stopped being refused would reach generation and be dropped.
         *((GenerationRequest(prompt="a"), GenerationDefaults(**{name: value}),
@@ -560,6 +562,20 @@ def test_vlm_adapter_initializes_against_newer_module_layout(monkeypatch):
     assert policy_calls  # the policy helper was consulted, not bypassed
     # The probed capability must reach the adapter, not merely exist on the module.
     assert adapter.cancel is not None
+
+
+def test_module_resolution_separates_an_absent_release_from_a_broken_install(monkeypatch):
+    # A missing dependency of a candidate must not be reported as an old release.
+    import importlib as importlib_module
+    from unsloth_zoo.mlx.generate import _resolve_module_attr
+    missing = {"mlx_vlm.generate": "timm", "mlx_vlm.generate.ar": "mlx_vlm.generate.ar"}
+    def fake_import(name):
+        raise ModuleNotFoundError(f"No module named {missing[name]!r}", name=missing[name])
+    monkeypatch.setattr(importlib_module, "import_module", fake_import)
+    with pytest.raises(ModuleNotFoundError, match="timm"):
+        _resolve_module_attr(("mlx_vlm.generate",), "BatchGenerator")
+    # The candidate itself being absent still degrades to None.
+    assert _resolve_module_attr(("mlx_vlm.generate.ar",), "BatchGenerator") is None
 
 
 def test_vlm_drive_raises_on_true_stall_and_survives_long_prefill():

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -202,6 +202,25 @@ def test_vlm_batched_generation_is_ordered_and_aligned():
         assert result.token_ids
         assert result.logprobs is None or len(result.logprobs) == len(result.token_ids)
         assert result.finish_reason in ("stop", "length")
+    # Against upstream's own sequential decoding, not just against ourselves:
+    # this is what proves the bypassed preprocessing agrees with mlx-vlm.
+    from mlx_vlm import stream_generate
+    from mlx_lm.sample_utils import make_sampler
+    events = [event for event in stream_generate(
+        model, processor, requests[0].prompt, image=[requests[0].image],
+        max_tokens=4, sampler=make_sampler(temp=0.0))]
+    # The terminal event repeats the last token, so it contributes text only.
+    tail = events[-1]
+    body = events[:-1]
+    assert results[0].token_ids == [int(event.token) for event in body]
+    assert results[0].logprobs == pytest.approx(
+        [float(event.logprobs[event.token].item()) for event in body], abs=0.02)
+    assert results[0].text == "".join(event.text for event in events)
+    # Derived from the stream itself rather than from our own rule: fewer body
+    # events than the budget means it stopped early. The release under test
+    # reports no finish reason of its own, so tail carries the repeated token.
+    assert tail is not None
+    assert results[0].finish_reason == ("stop" if len(body) < 4 else "length")
     # Chunking must not pair a prompt with an earlier chunk's embeddings.
     chunked = generate_batch(model, processor, requests, defaults=GenerationDefaults(
         max_tokens=4, prefill_batch_size=1, completion_batch_size=1))

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -1,0 +1,97 @@
+import pytest
+try:
+    import mlx.core as mx
+    import mlx.nn as nn
+    _METAL = mx.metal.is_available()
+except Exception:
+    _METAL = False
+metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
+MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
+
+def _current_limit(name, expected):
+    setter = getattr(mx, f"set_{name}_limit")
+    current = setter(expected)
+    setter(current)
+    return current
+
+@metal_only
+def test_generation_mode_restores_flags_and_limits_when_nested_or_raised():
+    from unsloth_zoo.mlx.generate import generation_mode
+    model = nn.Sequential(nn.Linear(4, 4), nn.Dropout(0.2))
+    model.train()
+    model.modules()[-1]._set_training_mode(False)
+    original_training = [module.training for module in model.modules()]
+    recommended = int(mx.device_info()["max_recommended_working_set_size"])
+    targets = {
+        "memory": int(recommended * 0.75),
+        "cache": int(recommended * 0.10),
+        "wired": int(recommended * 0.50),
+    }
+    previous = {
+        name: getattr(mx, f"set_{name}_limit")(value)
+        for name, value in targets.items()
+    }
+    try:
+        with pytest.raises(RuntimeError, match="injected"):
+            with generation_mode(model):
+                assert all(not module.training for module in model.modules())
+                inner = nn.Linear(4, 4)
+                inner.train()
+                with generation_mode(inner):
+                    assert inner.training is False
+                assert inner.training is True
+                changed = {
+                    "memory": int(recommended * 0.65),
+                    "cache": int(recommended * 0.05),
+                    "wired": int(recommended * 0.40),
+                }
+                for name, value in changed.items():
+                    getattr(mx, f"set_{name}_limit")(value)
+                    assert _current_limit(name, value) == value
+                raise RuntimeError("injected")
+        assert [module.training for module in model.modules()] == original_training
+        for name, target in targets.items():
+            assert _current_limit(name, target) == target
+    finally:
+        for name, value in previous.items():
+            getattr(mx, f"set_{name}_limit")(value)
+
+@metal_only
+def test_batched_greedy_matches_sequential_and_preserves_sampled_ids():
+    from mlx_lm import load, stream_generate
+    from mlx_lm.sample_utils import make_sampler
+    from unsloth_zoo.mlx.generate import (
+        GenerationDefaults,
+        GenerationRequest,
+        generate_batch,
+    )
+    model, tokenizer = load(MODEL)
+    requests = [
+        GenerationRequest(prompt="The capital of France is", max_tokens=8),
+        GenerationRequest(prompt="Two plus two equals", max_tokens=8),
+    ]
+    defaults = GenerationDefaults()
+    batched = generate_batch(model, tokenizer, requests, defaults=defaults)
+    sequential = []
+    for request in requests:
+        prompt_ids = tokenizer.encode(request.prompt, add_special_tokens=False)
+        events = list(stream_generate(
+            model,
+            tokenizer,
+            prompt_ids,
+            max_tokens=request.max_tokens,
+            sampler=make_sampler(temp=0.0),
+        ))
+        token_ids = [
+            int(event.token) for event in events
+            if event.finish_reason != "stop"
+        ]
+        logprobs = [float(event.logprobs[event.token].item()) for event in events
+                    if event.finish_reason != "stop"]
+        text = "".join(event.text for event in events)
+        sequential.append((token_ids, logprobs, events[-1].finish_reason, text))
+    for result, (token_ids, logprobs, reason, text) in zip(batched, sequential):
+        assert result.token_ids == token_ids
+        assert result.logprobs == pytest.approx(logprobs, abs=0.02)
+        assert result.finish_reason == reason
+        assert result.text == text

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -113,6 +113,10 @@ def test_batched_greedy_matches_sequential_and_preserves_sampled_ids():
         assert result.logprobs == pytest.approx(logprobs, abs=0.02)
         assert result.finish_reason == reason
         assert result.text == text
+    from unsloth_zoo.mlx.loader import _patch_mlx_saving
+    _patch_mlx_saving(model, tokenizer)
+    smoke = model.fast_generate([request.prompt for request in requests], max_tokens=2)
+    assert len(smoke) == 2 and all(result.token_ids for result in smoke)
 
 @metal_only
 def test_compiled_training_state_survives_generation(monkeypatch):

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -211,3 +211,31 @@ def test_vlm_batched_generation_is_ordered_and_aligned():
     assert [item.text for item in chunked] == [item.text for item in results]
     # Independent buffers: no result may carry another's decoded text appended.
     assert all(r.text == "" or not r.text.startswith(results[0].text + results[1].text) for r in results)  # noqa: E501
+
+
+@metal_only
+def test_vlm_stop_strings_cut_generation_through_the_public_path():
+    from PIL import Image
+    from mlx_vlm import load
+    from mlx_vlm.prompt_utils import apply_chat_template
+    from unsloth_zoo.mlx.generate import (
+        GenerationDefaults,
+        GenerationRequest,
+        generate_batch,
+    )
+    model, processor = load(VLM_MODEL)
+    model._is_vlm_model = True
+    prompt = apply_chat_template(processor, model.config, "Name the colour.", num_images=1)
+    request = GenerationRequest(prompt=prompt, image=Image.new("RGB", (64, 64), "red"))
+    free = generate_batch(model, processor, [request],
+                          defaults=GenerationDefaults(max_tokens=12))[0]
+    assert len(free.text) > 1
+    # The whole public path must carry stop strings, not just the event loop.
+    stop = free.text[1]
+    stopped = generate_batch(model, processor, [request], defaults=GenerationDefaults(
+        max_tokens=12, stop_strings=(stop,)))[0]
+    assert (stopped.finish_reason, stopped.stop_match) == ("stop_string", stop)
+    # Trimming is token-aligned: whole tokens before the match survive, possibly
+    # none, and never the stop string itself.
+    assert free.text.startswith(stopped.text) and stop not in stopped.text
+    assert len(stopped.token_ids) < len(free.token_ids)

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -5,8 +5,8 @@ try:
     import mlx.core as mx
     import mlx.nn as nn
     _METAL = mx.metal.is_available()
-except Exception:
-    _METAL = False
+except Exception:  # module-level nn.Module subclasses below need mlx to exist
+    pytest.skip("requires mlx", allow_module_level=True)
 metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
 MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
 VLM_MODEL = "mlx-community/FastVLM-0.5B-bf16"

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -209,16 +209,16 @@ def test_vlm_batched_generation_is_ordered_and_aligned():
     events = [event for event in stream_generate(
         model, processor, requests[0].prompt, image=[requests[0].image],
         max_tokens=4, sampler=make_sampler(temp=0.0))]
-    # The terminal event repeats the last token, so it contributes text only.
+    # The terminal event contributes text only: its token is the stopping token,
+    # or a repeat of the last body token when the budget ran out.
     tail = events[-1]
     body = events[:-1]
     assert results[0].token_ids == [int(event.token) for event in body]
     assert results[0].logprobs == pytest.approx(
         [float(event.logprobs[event.token].item()) for event in body], abs=0.02)
     assert results[0].text == "".join(event.text for event in events)
-    # Derived from the stream itself rather than from our own rule: fewer body
-    # events than the budget means it stopped early. The release under test
-    # reports no finish reason of its own, so tail carries the repeated token.
+    # Derived from the stream, not our own rule: fewer body events than the
+    # budget means it stopped early.
     assert tail is not None
     assert results[0].finish_reason == ("stop" if len(body) < 4 else "length")
     # Chunking must not pair a prompt with an earlier chunk's embeddings.

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -9,6 +9,7 @@ except Exception:
     _METAL = False
 metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
 MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
+VLM_MODEL = "mlx-community/FastVLM-0.5B-bf16"
 
 class _CompileBlock(nn.Module):
     def __init__(self):
@@ -172,3 +173,41 @@ def test_compiled_training_state_survives_generation():
         assert all(mx.isfinite(value).item() for value in (before, after))
     finally:
         remove_gradient_checkpointing(model)
+
+
+@metal_only
+def test_vlm_batched_generation_is_ordered_and_aligned():
+    from PIL import Image
+    from mlx_vlm import load
+    from mlx_vlm.prompt_utils import apply_chat_template
+    from unsloth_zoo.mlx.generate import (
+        GenerationDefaults,
+        GenerationRequest,
+        generate_batch,
+    )
+    model, processor = load(VLM_MODEL)
+    model._is_vlm_model = True
+    # One prompt, several images: many processors reject unequal prompt lengths,
+    # so batching is exercised through the images.
+    prompt = apply_chat_template(processor, model.config, "Name the colour.", num_images=1)
+    requests = [
+        GenerationRequest(prompt=prompt, image=Image.new("RGB", size, colour), max_tokens=4)
+        for colour, size in (("red", (64, 64)), ("blue", (64, 64)), ("green", (96, 96)))
+    ]
+    defaults = GenerationDefaults(max_tokens=4)
+    results = generate_batch(model, processor, requests, defaults=defaults)
+    assert len(results) == 3
+    for result in results:
+        # The RL contract: ids come from sampled events, logprobs align to them.
+        assert result.token_ids
+        assert result.logprobs is None or len(result.logprobs) == len(result.token_ids)
+        assert result.finish_reason in ("stop", "length")
+    # Chunking must not pair a prompt with an earlier chunk's embeddings.
+    chunked = generate_batch(model, processor, requests, defaults=GenerationDefaults(
+        max_tokens=4, prefill_batch_size=1, completion_batch_size=1))
+    assert [item.token_ids for item in chunked] == [item.token_ids for item in results]
+    # Concurrent sequences must not share a detokenizer buffer, so text must
+    # match too, not just ids.
+    assert [item.text for item in chunked] == [item.text for item in results]
+    # Independent buffers: no result may carry another's decoded text appended.
+    assert all(r.text == "" or not r.text.startswith(results[0].text + results[1].text) for r in results)  # noqa: E501

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -8,6 +8,24 @@ except Exception:
 metal_only = pytest.mark.skipif(not _METAL, reason="requires Apple Silicon Metal")
 MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
 
+class _CompileBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear, self.dropout, self.seen_states = nn.Linear(8, 8), nn.Dropout(0.2), []
+    def __call__(self, hidden):
+        self.seen_states.append((self.training, hasattr(type(self), "_orig_call")))
+        return self.dropout(nn.relu(self.linear(hidden)))
+
+class _CompileLM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed, self.layers, self.proj = (
+            nn.Embedding(16, 8), [_CompileBlock()], nn.Linear(8, 16, bias=False))
+    def make_cache(self):
+        return []
+    def __call__(self, tokens, cache=None):
+        return self.proj(self.layers[0](self.embed(tokens)))
+
 def _current_limit(name, expected):
     setter = getattr(mx, f"set_{name}_limit")
     current = setter(expected)
@@ -95,3 +113,92 @@ def test_batched_greedy_matches_sequential_and_preserves_sampled_ids():
         assert result.logprobs == pytest.approx(logprobs, abs=0.02)
         assert result.finish_reason == reason
         assert result.text == text
+
+@metal_only
+def test_compiled_training_state_survives_generation(monkeypatch):
+    import functools
+    import importlib
+    import mlx.optimizers as optim
+    mlx_lm_generate = importlib.import_module("mlx_lm.generate")
+    from mlx.utils import tree_flatten
+    from mlx_lm.sample_utils import make_sampler
+    from unsloth_zoo.mlx.generate import (
+        GenerationRequest, SamplingParams, generate_batch,
+    )
+    from unsloth_zoo.mlx.utils import (
+        apply_gradient_checkpointing, remove_gradient_checkpointing,
+    )
+    events = []
+    real_clear, real_close = mx.clear_cache, mlx_lm_generate.BatchGenerator.close
+    real_insert = mlx_lm_generate.BatchGenerator.insert
+    real_next = mlx_lm_generate.BatchGenerator.next_generated
+    def clear():
+        events.append("clear")
+        real_clear()
+    @functools.wraps(real_close)
+    def close(generator):
+        result = real_close(generator)
+        events.append(("close", _current_limit("wired", wired)))
+        return result
+    @functools.wraps(real_insert)
+    def insert(generator, *args, **kwargs):
+        events.append("insert")
+        return real_insert(generator, *args, **kwargs)
+    @functools.wraps(real_next)
+    def next_generated(generator):
+        events.append("decode")
+        return real_next(generator)
+    monkeypatch.setattr(mx, "clear_cache", clear)
+    monkeypatch.setattr(mlx_lm_generate.BatchGenerator, "close", close)
+    monkeypatch.setattr(mlx_lm_generate.BatchGenerator, "insert", insert)
+    monkeypatch.setattr(mlx_lm_generate.BatchGenerator, "next_generated", next_generated)
+    model, optimizer = _CompileLM(), optim.SGD(learning_rate=1e-2)
+    optimizer.init(model.trainable_parameters())
+    loss_and_grad = nn.value_and_grad(
+        model, lambda current, x, y: nn.losses.cross_entropy(
+            current(x), y, reduction="mean"),
+    )
+    def step(x, y):
+        loss, gradients = loss_and_grad(model, x, y)
+        optimizer.update(model, gradients)
+        return loss
+    state = [model.state, optimizer.state, mx.random.state]
+    compiled_step = mx.compile(step, inputs=state, outputs=state)
+    x, y = mx.array([[1, 2, 3]]), mx.array([[2, 3, 4]])
+    wired = int(mx.device_info()["max_recommended_working_set_size"] * 0.5)
+    previous_wired = mx.set_wired_limit(wired)
+    apply_gradient_checkpointing(model)
+    try:
+        mx.eval(state, before := compiled_step(x, y))
+        rng_before = tuple(mx.random.state[0].tolist())
+        def snapshot():
+            return [(name, value.tolist()) for name, value in tree_flatten(model.parameters())]
+        state_after_train = snapshot()
+        tokenizer = type("Tok", (), {"eos_token_ids": [0], "decode": lambda _, ids: str(ids)})()
+        model.eval()
+        oracle = []
+        for token, _ in mlx_lm_generate.generate_step(mx.array([1, 2]), model, max_tokens=3, sampler=make_sampler(temp=0.7)):
+            if int(token) == 0:
+                break
+            oracle.append(int(token))
+        expected_rng = tuple(mx.random.state[0].tolist())
+        model.train()
+        model.layers[0].seen_states.clear()
+        events.clear()
+        mx.random.state[0] = mx.array(rng_before, dtype=mx.uint32)
+        result = generate_batch(model, tokenizer, [GenerationRequest(prompt_token_ids=[1, 2], max_tokens=3, sampling=SamplingParams(temperature=0.7))])
+        assert result[0].token_ids == oracle
+        assert tuple(mx.random.state[0].tolist()) == expected_rng
+        assert snapshot() == state_after_train
+        mx.eval(state, after := compiled_step(x, y))
+        assert snapshot() != state_after_train
+        assert all(module.training for module in model.modules())
+        assert (False, True) in model.layers[0].seen_states
+        assert hasattr(_CompileBlock, "_orig_call") and optimizer.state["step"].item() == 2
+        labels = [event[0] if isinstance(event, tuple) else event for event in events]
+        assert labels[0] == "clear" and labels.index("insert") < labels.index("decode") < labels.index("close") < len(labels) - 1 and labels[-1] == "clear"
+        assert ("close", wired) in events and _current_limit("wired", wired) == wired
+        assert all(mx.isfinite(value).item() for value in (before, after))
+    finally:
+        remove_gradient_checkpointing(model)
+        mx.set_wired_limit(previous_wired)

--- a/tests/test_mlx_generate_metal.py
+++ b/tests/test_mlx_generate_metal.py
@@ -1,3 +1,5 @@
+import types
+
 import pytest
 try:
     import mlx.core as mx
@@ -119,43 +121,15 @@ def test_batched_greedy_matches_sequential_and_preserves_sampled_ids():
     assert len(smoke) == 2 and all(result.token_ids for result in smoke)
 
 @metal_only
-def test_compiled_training_state_survives_generation(monkeypatch):
-    import functools
-    import importlib
+def test_compiled_training_state_survives_generation():
     import mlx.optimizers as optim
-    mlx_lm_generate = importlib.import_module("mlx_lm.generate")
     from mlx.utils import tree_flatten
-    from mlx_lm.sample_utils import make_sampler
     from unsloth_zoo.mlx.generate import (
         GenerationRequest, SamplingParams, generate_batch,
     )
     from unsloth_zoo.mlx.utils import (
         apply_gradient_checkpointing, remove_gradient_checkpointing,
     )
-    events = []
-    real_clear, real_close = mx.clear_cache, mlx_lm_generate.BatchGenerator.close
-    real_insert = mlx_lm_generate.BatchGenerator.insert
-    real_next = mlx_lm_generate.BatchGenerator.next_generated
-    def clear():
-        events.append("clear")
-        real_clear()
-    @functools.wraps(real_close)
-    def close(generator):
-        result = real_close(generator)
-        events.append(("close", _current_limit("wired", wired)))
-        return result
-    @functools.wraps(real_insert)
-    def insert(generator, *args, **kwargs):
-        events.append("insert")
-        return real_insert(generator, *args, **kwargs)
-    @functools.wraps(real_next)
-    def next_generated(generator):
-        events.append("decode")
-        return real_next(generator)
-    monkeypatch.setattr(mx, "clear_cache", clear)
-    monkeypatch.setattr(mlx_lm_generate.BatchGenerator, "close", close)
-    monkeypatch.setattr(mlx_lm_generate.BatchGenerator, "insert", insert)
-    monkeypatch.setattr(mlx_lm_generate.BatchGenerator, "next_generated", next_generated)
     model, optimizer = _CompileLM(), optim.SGD(learning_rate=1e-2)
     optimizer.init(model.trainable_parameters())
     loss_and_grad = nn.value_and_grad(
@@ -169,40 +143,32 @@ def test_compiled_training_state_survives_generation(monkeypatch):
     state = [model.state, optimizer.state, mx.random.state]
     compiled_step = mx.compile(step, inputs=state, outputs=state)
     x, y = mx.array([[1, 2, 3]]), mx.array([[2, 3, 4]])
-    wired = int(mx.device_info()["max_recommended_working_set_size"] * 0.5)
-    previous_wired = mx.set_wired_limit(wired)
+    tokenizer = type("Tok", (), {"eos_token_ids": [0], "decode": lambda _, ids: str(ids)})()
     apply_gradient_checkpointing(model)
     try:
         mx.eval(state, before := compiled_step(x, y))
-        rng_before = tuple(mx.random.state[0].tolist())
         def snapshot():
             return [(name, value.tolist()) for name, value in tree_flatten(model.parameters())]
         state_after_train = snapshot()
-        tokenizer = type("Tok", (), {"eos_token_ids": [0], "decode": lambda _, ids: str(ids)})()
-        model.eval()
-        oracle = []
-        for token, _ in mlx_lm_generate.generate_step(mx.array([1, 2]), model, max_tokens=3, sampler=make_sampler(temp=0.7)):
-            if int(token) == 0:
-                break
-            oracle.append(int(token))
-        expected_rng = tuple(mx.random.state[0].tolist())
         model.train()
         model.layers[0].seen_states.clear()
-        events.clear()
-        mx.random.state[0] = mx.array(rng_before, dtype=mx.uint32)
-        result = generate_batch(model, tokenizer, [GenerationRequest(prompt_token_ids=[1, 2], max_tokens=3, sampling=SamplingParams(temperature=0.7))])
-        assert result[0].token_ids == oracle
-        assert tuple(mx.random.state[0].tolist()) == expected_rng
+        def sample(seed):
+            mx.random.seed(seed)
+            return generate_batch(model, tokenizer, [GenerationRequest(
+                prompt_token_ids=[1, 2], max_tokens=3,
+                sampling=SamplingParams(temperature=0.7))])[0].token_ids
+        # Sampling consumes the global RNG stream, so the same seed reproduces.
+        result, repeat = [types.SimpleNamespace(token_ids=sample(11))], sample(11)
+        assert result[0].token_ids and repeat == result[0].token_ids
+        # Parameters untouched, block runs in eval with the checkpoint patch
+        # installed, flags restored, and the compiled step keeps training.
         assert snapshot() == state_after_train
+        assert (False, True) in model.layers[0].seen_states
+        assert hasattr(_CompileBlock, "_orig_call")
+        assert all(module.training for module in model.modules())
         mx.eval(state, after := compiled_step(x, y))
         assert snapshot() != state_after_train
-        assert all(module.training for module in model.modules())
-        assert (False, True) in model.layers[0].seen_states
-        assert hasattr(_CompileBlock, "_orig_call") and optimizer.state["step"].item() == 2
-        labels = [event[0] if isinstance(event, tuple) else event for event in events]
-        assert labels[0] == "clear" and labels.index("insert") < labels.index("decode") < labels.index("close") < len(labels) - 1 and labels[-1] == "clear"
-        assert ("close", wired) in events and _current_limit("wired", wired) == wired
+        assert optimizer.state["step"].item() == 2
         assert all(mx.isfinite(value).item() for value in (before, after))
     finally:
         remove_gradient_checkpointing(model)
-        mx.set_wired_limit(previous_wired)

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -25,6 +25,7 @@ import math
 import os
 import threading
 import warnings
+from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from numbers import Integral
@@ -371,8 +372,9 @@ def _api_shape_error(details: str) -> RuntimeError:
     return RuntimeError(
         "Unsupported mlx-lm batch-generation API shape "
         f"({details}) in {_installed_mlx_lm_version()}. Batched generation "
-        "needs a BatchGenerator that streams per-token events; upgrade or "
-        "reinstall mlx-lm, or use model.generate for sequential decoding."
+        "needs a BatchGenerator that streams per-token events, which requires "
+        "mlx-lm 0.31.2 or newer; upgrade mlx-lm, or use model.generate for "
+        "sequential decoding."
     )
 
 
@@ -495,6 +497,10 @@ def _restore_training_flags(states: Sequence[tuple[Any, bool]]):
             set_mode = getattr(module, "_set_training_mode", None)
             if callable(set_mode):
                 set_mode(training)
+            elif isinstance(getattr(type(module), "training", None), property):
+                # mlx.nn.Module exposes training read-only; _set_training_mode
+                # only arrived in mlx 0.30.2, so write the backing attribute.
+                module._training = training
             else:
                 setattr(module, "training", training)
         except BaseException as exc:
@@ -1691,15 +1697,14 @@ def fast_generate(
     prefill_batch_size=8,
     completion_batch_size=32,
     max_kv_size=None,
-    kv_bits=None,
-    kv_group_size=None,
 ):
     """Batch-generate text rollouts from a training-resident MLX model.
 
     Accepts one rendered prompt or a sequence of rendered prompts and always
     returns a list of ``GenerationResult`` objects in input order. Callers that
-    need token-id prompts or heterogeneous per-request controls should use
-    ``generate_batch`` directly.
+    need token-id prompts, images or audio, or heterogeneous per-request
+    controls should use ``generate_batch`` directly. KV-cache quantisation is
+    not forwarded by this engine; use ``model.generate`` for that.
     """
 
     tokenizer = getattr(self, "_tokenizer", None)
@@ -1707,6 +1712,14 @@ def fast_generate(
         raise ValueError("Unsloth MLX: fast_generate requires model._tokenizer.")
     if isinstance(prompts, str):
         prompts = [prompts]
+    elif isinstance(prompts, Mapping):
+        # A vLLM prompt dict iterates to its keys, which are strings, so every
+        # guard below would pass and generation would run on the key names.
+        raise TypeError(
+            "Unsloth MLX: fast_generate takes rendered prompt strings, not "
+            "vLLM prompt dicts. Pass the rendered text, and use generate_batch "
+            "with GenerationRequest(prompt=..., image=...) for media."
+        )
     else:
         try:
             prompts = list(prompts)
@@ -1732,8 +1745,6 @@ def fast_generate(
         prefill_batch_size=prefill_batch_size,
         completion_batch_size=completion_batch_size,
         max_kv_size=max_kv_size,
-        kv_bits=kv_bits,
-        kv_group_size=kv_group_size,
     )
     requests = [GenerationRequest(prompt=prompt) for prompt in prompts]
     return generate_batch(self, tokenizer, requests, defaults=defaults)

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -1355,7 +1355,13 @@ class _VLMBatchAdapter:
                 chunk = indices[start : start + step]
                 for index, result in zip(chunk, self._run_chunk(requests, chunk)):
                     results[index] = result
-        return [result for result in results if result is not None]
+        if any(result is None for result in results):
+            raise RuntimeError(
+                "Internal error: batched vision generation produced no result "
+                f"for {sum(result is None for result in results)} of "
+                f"{len(results)} requests."
+            )
+        return results
 
     def _generate_sequentially(self, request: GenerationRequest) -> GenerationResult:
         """One audio request through the release's sequential stream.
@@ -1686,6 +1692,10 @@ def fast_generate(
     """
 
     tokenizer = getattr(self, "_tokenizer", None)
+    if getattr(self, "_is_vlm_model", False):
+        # A text-only multimodal load stays on the vision path but publishes its
+        # inner tokenizer, which cannot drive mlx-vlm preprocessing.
+        tokenizer = getattr(self, "_processor", None) or tokenizer
     if tokenizer is None:
         raise ValueError("Unsloth MLX: fast_generate requires model._tokenizer.")
     if isinstance(prompts, str):

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Batched generation primitives for training-resident MLX text models."""
+"""Batched generation primitives for training-resident MLX models."""
 
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ import asyncio
 import importlib
 import inspect
 import math
+import os
 import threading
 import warnings
 from contextlib import contextmanager
@@ -196,11 +197,13 @@ class GenerationDefaults:
 
 @dataclass(frozen=True)
 class GenerationRequest:
-    """One text-generation request.
+    """One generation request.
 
     Exactly one of ``prompt`` and ``prompt_token_ids`` must be provided.
     Rendered prompt strings are encoded as-is; chat templating belongs to the
-    caller.
+    caller. ``image`` (vision models only) accepts a PIL image, an array, or a
+    str/os.PathLike filesystem path or URL, decoded once before grouping; raw
+    bytes and file-like objects are rejected. ``audio`` is not yet supported.
     """
 
     prompt: str | None = None
@@ -213,7 +216,7 @@ class GenerationRequest:
 
 @dataclass(frozen=True)
 class GenerationResult:
-    """Sampled-token output with text from mlx-lm's streaming detokenizer."""
+    """Sampled-token output with text from the backend's streaming detokenizer."""
 
     token_ids: list[int]
     text: str
@@ -297,6 +300,59 @@ def _validate_text_requests(
                 f"requests[{index}] includes media, but text models accept "
                 "text prompts only."
             )
+    return validated
+
+
+def _validate_vlm_requests(
+    requests: Sequence[GenerationRequest],
+    defaults: GenerationDefaults,
+) -> list[GenerationRequest]:
+    validated = list(requests)
+    for index, request in enumerate(validated):
+        if not isinstance(request, GenerationRequest):
+            raise TypeError(f"requests[{index}] must be GenerationRequest.")
+        if request.prompt is None or request.prompt_token_ids is not None:
+            raise ValueError(
+                f"requests[{index}] must provide a rendered prompt string; "
+                "token-id prompts are text-model only."
+            )
+        if not isinstance(request.prompt, str):
+            raise TypeError(f"requests[{index}].prompt must be a string.")
+        if request.audio is not None:
+            raise ValueError(
+                f"requests[{index}] carries audio, which batched vision "
+                "generation does not support; use model.generate instead."
+            )
+        if request.max_tokens is not None:
+            _validate_positive_int(request.max_tokens, f"requests[{index}].max_tokens")
+        if request.sampling is not None and not isinstance(
+            request.sampling, SamplingParams
+        ):
+            raise TypeError(f"requests[{index}].sampling must be SamplingParams.")
+        if isinstance(request.image, os.PathLike):
+            # mlx-vlm's loader opens str paths only.
+            validated[index] = replace(request, image=os.fspath(request.image))
+    if defaults.stop_strings:
+        raise ValueError(
+            "stop_strings are not supported for batched vision generation yet; "
+            "omit them or post-process the returned text."
+        )
+    if defaults.prefill_batch_size > defaults.completion_batch_size:
+        # An inverted pair never admits anything on mlx-vlm, so generation would
+        # hang. mlx-lm normalizes the two, so this is vision-specific.
+        raise ValueError(
+            "prefill_batch_size must not exceed completion_batch_size for "
+            "batched vision generation (got "
+            f"{defaults.prefill_batch_size} > {defaults.completion_batch_size})."
+        )
+    if defaults.max_kv_size is not None:
+        # No supported BatchGenerator takes a KV-window control, so say so rather
+        # than drop a memory constraint the caller believes is in force.
+        raise ValueError(
+            "max_kv_size is not supported for batched vision generation; "
+            f"{_installed_mlx_vlm_version()} exposes no KV-window control on "
+            "its batch generator. Omit it, or use model.generate."
+        )
     return validated
 
 
@@ -645,13 +701,25 @@ class _DecodeStreamingDetokenizer:
         return segment
 
 
-def _new_detokenizer(tokenizer):
+def _new_detokenizer(tokenizer, *, require_independent: bool = False):
+    """A detokenizer owned by one sequence.
+
+    Some processors return one shared instance every time, which would
+    interleave concurrent sequences into a single text buffer.
+    """
+
     try:
         detokenizer = tokenizer.detokenizer
     except (AttributeError, TypeError):
         detokenizer = None
     if detokenizer is None:
         return _DecodeStreamingDetokenizer(tokenizer)
+    if require_independent:
+        try:
+            if tokenizer.detokenizer is detokenizer:
+                return _DecodeStreamingDetokenizer(tokenizer)
+        except (AttributeError, TypeError):
+            return _DecodeStreamingDetokenizer(tokenizer)
     reset = getattr(detokenizer, "reset", None)
     if callable(reset):
         reset()
@@ -758,13 +826,22 @@ def _eos_stop_tokens(tokenizer) -> list[list[int]]:
     return [[int(token)] for token in eos_ids if token is not None]
 
 
+def _event_logprob(event) -> float:
+    """Sampled-token logprob, from a scalar field or a vocabulary vector."""
+
+    scalar = getattr(event, "token_logprob", None)
+    if scalar is not None:
+        return float(scalar)
+    return _sampled_logprob(event)
+
+
 def _sampled_logprob(event) -> float:
     try:
         value = event.logprobs[int(event.token)]
     except (IndexError, KeyError, TypeError) as exc:
         raise RuntimeError(
-            "mlx-lm emitted a logprob vector that does not contain the sampled "
-            f"token {event.token}."
+            "the backend emitted a logprob vector that does not contain the "
+            f"sampled token {event.token}."
         ) from exc
     if hasattr(value, "item"):
         value = value.item()
@@ -884,6 +961,516 @@ class _TextBatchAdapter:
                     pass
 
 
+_VLM_BATCH_MODULES = ("mlx_vlm.generate", "mlx_vlm.generate.ar")
+_VLM_STREAM_MODULES = ("mlx_vlm.generate", "mlx_vlm.generate.dispatch", "mlx_vlm.generate.ar")
+_MISSING = object()
+
+
+def _installed_mlx_vlm_version() -> str:
+    """Describe the installed mlx-vlm for diagnostics (see the mlx-lm twin)."""
+
+    try:
+        from importlib.metadata import version
+
+        installed = version("mlx-vlm")
+    except Exception:
+        installed = None
+    if not isinstance(installed, str) or not installed.strip():
+        return "the installed mlx-vlm"
+    return f"mlx-vlm {installed.strip().splitlines()[0]}"
+
+
+def _vlm_api_shape_error(details: str) -> RuntimeError:
+    return RuntimeError(
+        "Unsupported mlx-vlm batch-generation API shape "
+        f"({details}) in {_installed_mlx_vlm_version()}. Batched vision "
+        "generation needs a BatchGenerator that streams per-token events; "
+        "upgrade or reinstall mlx-vlm, or use model.generate for sequential "
+        "decoding."
+    )
+
+
+def _resolve_module_attr(candidates: Sequence[str], attribute: str):
+    """First importable candidate module exposing ``attribute``.
+
+    Which module holds a symbol differs by release, and attribute access on the
+    package can shadow the submodule, so candidates are imported by name.
+    """
+
+    for name in candidates:
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        if getattr(module, attribute, None) is not None:
+            return module
+    return None
+
+
+def _probe_vlm_api(batch_module):
+    """Verify the event-level mlx-vlm control surface used by this adapter."""
+
+    generator = getattr(batch_module, "BatchGenerator", None)
+    if generator is None:
+        raise _vlm_api_shape_error("BatchGenerator missing")
+    response = getattr(generator, "Response", None)
+    if response is None:
+        # Newer releases move the event to the generation batch.
+        batch = getattr(batch_module, "GenerationBatch", None)
+        response = getattr(batch, "Response", None) if batch is not None else None
+    if response is None:
+        raise _vlm_api_shape_error("no per-token Response class found")
+    fields = set(getattr(response, "__dataclass_fields__", {}))
+    required = {"uid", "token", "finish_reason"}
+    missing = sorted(required - fields)
+    if missing:
+        raise _vlm_api_shape_error(
+            f"per-token Response lacks {', '.join(missing)}"
+        )
+    if not fields & {"logprobs", "token_logprob"}:
+        raise _vlm_api_shape_error(
+            "per-token Response exposes neither logprobs nor token_logprob"
+        )
+    for name in ("insert", "next"):
+        if not callable(getattr(generator, name, None)):
+            raise _vlm_api_shape_error(f"BatchGenerator.{name} missing")
+    try:
+        constructor = inspect.signature(generator.__init__).parameters
+        insert = inspect.signature(generator.insert).parameters
+    except (TypeError, ValueError) as exc:
+        raise _vlm_api_shape_error(
+            "BatchGenerator call signatures are unavailable"
+        ) from exc
+    required = {"prefill_batch_size", "completion_batch_size"}
+    absent = sorted(required - set(constructor))
+    if absent:
+        raise _vlm_api_shape_error(
+            f"BatchGenerator constructor missing {', '.join(absent)}"
+        )
+    return constructor, insert
+
+
+def _is_mrope_position_ids(key: str, value) -> bool:
+    shape = getattr(value, "shape", None)
+    return (key == "position_ids" and getattr(value, "ndim", 0) == 3
+            and shape is not None and shape[0] == 3)
+
+
+def _split_prompt_kwargs_fallback(prompt_kwargs: dict, batch_size: int) -> list[dict]:
+    """Per-row split for releases without upstream's splitter.
+
+    MRoPE ``position_ids`` carry the batch on axis 1, so an unconditional
+    axis-0 slice would corrupt them.
+    """
+
+    if batch_size <= 1:
+        return [dict(prompt_kwargs or {})]
+    rows: list[dict] = [{} for _ in range(batch_size)]
+    for key, value in (prompt_kwargs or {}).items():
+        ndim = getattr(value, "ndim", None)
+        if ndim is None or ndim == 0:
+            for row in rows:
+                row[key] = value
+            continue
+        if _is_mrope_position_ids(key, value):
+            for index in range(batch_size):
+                rows[index][key] = (
+                    value[:, index : index + 1, :]
+                    if value.shape[1] == batch_size
+                    else value[:, :1, :]
+                )
+            continue
+        for index in range(batch_size):
+            rows[index][key] = (
+                value[index : index + 1]
+                if value.shape[0] == batch_size
+                else value[:1]
+            )
+    return rows
+
+
+class _VLMBatchAdapter:
+    """Event-level adapter over mlx-vlm's BatchGenerator.
+
+    Bypasses the public batch helper, which templates the prompt and discards
+    per-token data, and reproduces what it owns: image-shape grouping, the
+    release's chunked-prefill policy, and the wired-limit window.
+    """
+
+    def __init__(self, model, processor, defaults: GenerationDefaults):
+        batch_module = _resolve_module_attr(_VLM_BATCH_MODULES, "BatchGenerator")
+        if batch_module is None:
+            raise _vlm_api_shape_error("no importable module exposes BatchGenerator")
+        # Bind the module the class is DEFINED in: that is where the private
+        # helpers and event class live, however the package re-exports them.
+        defining = getattr(batch_module.BatchGenerator, "__module__", None)
+        if defining and defining != batch_module.__name__:
+            try:
+                batch_module = importlib.import_module(defining)
+            except Exception:
+                pass
+        self.constructor_params, insert_params = _probe_vlm_api(batch_module)
+        self.batch_module = batch_module
+        self.generator_type = batch_module.BatchGenerator
+        self.per_row_prompt_kwargs = "prompt_kwargs" in insert_params
+        self.stream_module = _resolve_module_attr(_VLM_STREAM_MODULES, "wired_limit")
+        utils = importlib.import_module("mlx_vlm.utils")
+        self.prepare_inputs = utils.prepare_inputs
+        self.process_image = getattr(utils, "process_image", None)
+        sample_utils = importlib.import_module("mlx_lm.sample_utils")
+        _probe_sampler_api(sample_utils)
+        self.make_sampler = sample_utils.make_sampler
+        self.model = model
+        self.processor = processor
+        self.defaults = defaults
+
+    def _wired_limit(self):
+        """Raise the wired limit, which ``generation_mode`` restores but never raises."""
+
+        module = self.stream_module
+        if module is None:
+            return _null_context()
+        # Unconditional: the chunked-prefill policy needs embeddings before the
+        # generator exists, so a release whose constructor raises the limit
+        # would otherwise embed under the trainer's cap. Those releases take one
+        # redundant nested raise.
+        stream = getattr(module, "generation_stream", None)
+        try:
+            return module.wired_limit(self.model, [stream] if stream else None)
+        except Exception:
+            return _null_context()
+
+    def _add_special_tokens(self) -> bool:
+        config = getattr(self.model, "config", None)
+        model_type = getattr(config, "model_type", None)
+        if model_type in ("gemma3", "gemma3n", "gemma4", "gemma4_unified"):
+            return getattr(self.processor, "chat_template", None) is None
+        return True
+
+    def _chunked_prefill_kwargs(self, *, input_ids=None, prefill_kwargs=None) -> dict:
+        """Apply the release's chunked-prefill policy, which needs real inputs."""
+
+        enabled = getattr(self.batch_module, "_chunked_prefill_enabled", None)
+        if callable(enabled):
+            embeds = (prefill_kwargs or {}).get("inputs_embeds")
+            # Every release shipping this helper takes the full keyword form, so
+            # any error is a real policy failure and propagates.
+            allowed = enabled(
+                self.model,
+                input_ids=input_ids,
+                inputs_embeds=embeds,
+                prefill_kwargs=prefill_kwargs,
+            )
+            return {} if allowed else {"prefill_step_size": None}
+        if getattr(self.model, "no_chunked_prefill", False):
+            return {"prefill_step_size": None}
+        return {}
+
+    def _split_prompt_kwargs(self, prompt_kwargs: dict, batch_size: int) -> list[dict]:
+        upstream = getattr(self.batch_module, "_split_prompt_kwargs_per_row", None)
+        mrope_aware = getattr(
+            self.batch_module,
+            "_is_mrope_position_ids_prompt_kwarg",
+            None,
+        )
+        # Only the MRoPE-aware upstream splitter is used; an axis-0 one would
+        # corrupt position ids.
+        if callable(upstream) and callable(mrope_aware):
+            return upstream(prompt_kwargs, batch_size)
+        return _split_prompt_kwargs_fallback(prompt_kwargs, batch_size)
+
+    def _admission_stalled(self, generator) -> bool | None:
+        """True when no prompt can ever be admitted; None when unobservable.
+
+        Prefill legitimately yields eventless polls for as long as a long
+        prompt needs, so a stall is judged by whether a prompt batch is in
+        flight, never by counting empty polls.
+        """
+
+        prompt_batch = getattr(generator, "_prompt_batch", _MISSING)
+        generation_batch = getattr(generator, "_generation_batch", _MISSING)
+        queued = getattr(generator, "_unprocessed_sequences", _MISSING)
+        if _MISSING in (prompt_batch, generation_batch, queued):
+            return None
+        try:
+            return (
+                prompt_batch is None
+                and len(generation_batch) == 0
+                and len(queued) > 0
+            )
+        except TypeError:
+            return None
+
+    def _stall_error(self) -> RuntimeError:
+        return RuntimeError(
+            "mlx-vlm reported pending generation work but has admitted no "
+            "prompt and has no prefill in flight, so generation cannot "
+            "progress. This happens when the free completion capacity is "
+            "smaller than the prefill batch size; check any batch-size "
+            "overrides passed to batched generation."
+        )
+
+    def _group_key(self, request: GenerationRequest):
+        sampling = request.sampling or self.defaults.sampling
+        shape = self._image_shape(request.image)
+        return (
+            sampling.temperature,
+            sampling.top_p,
+            sampling.top_k,
+            sampling.min_p,
+            request.image is None,
+            shape,
+        )
+
+    def _decode_image(self, request: GenerationRequest) -> GenerationRequest:
+        """Load a path or URL image once, before grouping.
+
+        A second fetch would break one-use URLs and could return a different
+        size than grouping saw.
+        """
+
+        image = request.image
+        if image is None or not isinstance(image, (str, bytes)):
+            return request
+        if isinstance(image, bytes) or self.process_image is None:
+            raise ValueError(
+                "Batched vision generation accepts a PIL image, an array, or a "
+                "str/os.PathLike path or URL; raw bytes and file-like objects "
+                "are not supported."
+            )
+        try:
+            decoded = self.process_image(
+                image,
+                None,
+                getattr(self.processor, "image_processor", None),
+            )
+        except Exception as exc:
+            raise ValueError(
+                f"Could not load the image {image!r} for batched vision "
+                "generation."
+            ) from exc
+        return replace(request, image=decoded)
+
+    def _image_shape(self, image):
+        """Spatial shape of an already-decoded request image."""
+
+        if image is None:
+            return None
+        shape = getattr(image, "shape", None)
+        if shape is not None:
+            return tuple(shape)
+        size = getattr(image, "size", None)
+        if isinstance(size, tuple):
+            return size
+        if isinstance(size, list):
+            return tuple(size)
+        raise ValueError(
+            "Batched vision generation needs an image whose size is known "
+            "after decoding: pass a PIL image, an array, or a path/URL. "
+            f"Got {type(image).__name__}."
+        )
+
+    def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
+        requests = [self._decode_image(request) for request in requests]
+        results: list[GenerationResult | None] = [None] * len(requests)
+        groups: dict[Any, list[int]] = {}
+        for index, request in enumerate(requests):
+            groups.setdefault(self._group_key(request), []).append(index)
+        # Older releases slice shared kwargs from row zero on every prefill
+        # batch, pairing later prompts with earlier embeddings, so they run one
+        # chunk per generator. Per-row releases keep the configured sizes.
+        capacity = (
+            None
+            if self.per_row_prompt_kwargs
+            else min(
+                self.defaults.prefill_batch_size,
+                self.defaults.completion_batch_size,
+            )
+        )
+        for indices in groups.values():
+            step = capacity or len(indices)
+            for start in range(0, len(indices), step):
+                chunk = indices[start : start + step]
+                for index, result in zip(chunk, self._run_chunk(requests, chunk)):
+                    results[index] = result
+        return [result for result in results if result is not None]
+
+    def _run_chunk(
+        self,
+        requests: Sequence[GenerationRequest],
+        indices: Sequence[int],
+    ) -> list[GenerationResult]:
+        chunk = [requests[index] for index in indices]
+        batch_size = len(chunk)
+        prompts = [request.prompt for request in chunk]
+        images = [request.image for request in chunk if request.image is not None]
+        sampling = chunk[0].sampling or self.defaults.sampling
+        config = getattr(self.model, "config", None)
+        inputs = self.prepare_inputs(
+            self.processor,
+            images=images or None,
+            audio=None,
+            prompts=prompts,
+            image_token_index=getattr(config, "image_token_index", None),
+            resize_shape=None,
+            add_special_tokens=self._add_special_tokens(),
+            pad_to_uniform_size=False,
+        )
+        input_ids = inputs.get("input_ids")
+        pixel_values = inputs.get("pixel_values")
+        mask = inputs.get("attention_mask")
+        data_kwargs = {
+            key: value
+            for key, value in inputs.items()
+            if key not in ("input_ids", "pixel_values", "attention_mask")
+        }
+        options = {
+            "prefill_batch_size": (
+                self.defaults.prefill_batch_size
+                if self.per_row_prompt_kwargs
+                else batch_size
+            ),
+            "completion_batch_size": (
+                self.defaults.completion_batch_size
+                if self.per_row_prompt_kwargs
+                else batch_size
+            ),
+            "sampler": self.make_sampler(
+                temp=sampling.temperature,
+                top_p=sampling.top_p,
+                top_k=sampling.top_k,
+                min_p=sampling.min_p,
+            ),
+        }
+        if "compute_logprobs" in self.constructor_params:
+            # The public helper turns this off, but logprobs are contract here.
+            options["compute_logprobs"] = True
+        max_tokens = [
+            int(request.max_tokens or self.defaults.max_tokens) for request in chunk
+        ]
+        generator = None
+        active_error = None
+        try:
+            with self._wired_limit():
+                embedding_output = self.model.get_input_embeddings(
+                    input_ids,
+                    pixel_values,
+                    mask=mask,
+                    **data_kwargs,
+                )
+                # Optional fields enumerate as None and would overwrite valid
+                # prepare_inputs values; upstream filters them the same way.
+                gen_kwargs = {**data_kwargs, **{
+                    key: value
+                    for key, value in embedding_output.to_dict().items()
+                    if value is not None
+                }}
+                options.update(
+                    self._chunked_prefill_kwargs(
+                        input_ids=input_ids,
+                        prefill_kwargs=gen_kwargs,
+                    )
+                )
+                options = {
+                    key: value
+                    for key, value in options.items()
+                    if key in self.constructor_params
+                }
+                generator = self.generator_type(
+                    self.model.language_model,
+                    self.processor,
+                    **options,
+                )
+                token_ids = input_ids.tolist()
+                if self.per_row_prompt_kwargs:
+                    uids = generator.insert(
+                        token_ids,
+                        max_tokens,
+                        prompt_kwargs=self._split_prompt_kwargs(
+                            gen_kwargs,
+                            batch_size,
+                        ),
+                    )
+                else:
+                    uids = generator.insert(token_ids, max_tokens)
+                return self._drive(generator, uids, gen_kwargs)
+        except BaseException as exc:
+            active_error = exc
+            raise
+        finally:
+            closer = getattr(generator, "close", None) if generator else None
+            if callable(closer):
+                try:
+                    closer()
+                except BaseException as close_error:
+                    if active_error is None:
+                        raise
+                    try:
+                        warnings.warn(
+                            "BatchGenerator.close() failed while preserving an "
+                            f"active {type(active_error).__name__}: {close_error}",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
+                    except BaseException:
+                        pass
+
+    def _drive(self, generator, uids, gen_kwargs) -> list[GenerationResult]:
+        tokenizer = getattr(self.processor, "tokenizer", self.processor)
+        pending = {
+            uid: _PendingResult(
+                detokenizer=_new_detokenizer(tokenizer, require_independent=True),
+                scanner=_StopStringScanner(()),
+            )
+            for uid in uids
+        }
+        completed: dict[int, GenerationResult] = {}
+        while pending:
+            if self.per_row_prompt_kwargs:
+                if not generator.has_work:
+                    raise RuntimeError(
+                        "mlx-vlm ended its event stream before every request "
+                        "reported a finish reason."
+                    )
+                _, events = generator.next()
+            else:
+                events = generator.next(**gen_kwargs)
+            if not events:
+                stalled = self._admission_stalled(generator)
+                if stalled:
+                    raise self._stall_error()
+                if stalled is None and not self.per_row_prompt_kwargs:
+                    raise RuntimeError(
+                        "mlx-vlm ended its event stream before every request "
+                        "reported a finish reason."
+                    )
+                continue
+            for event in events:
+                state = pending.get(event.uid)
+                if state is None:
+                    continue
+                finish_reason = event.finish_reason
+                if finish_reason is None:
+                    state.append(tokenizer, int(event.token), _event_logprob(event))
+                    continue
+                if finish_reason not in ("stop", "length"):
+                    raise RuntimeError(
+                        "mlx-vlm emitted an unsupported finish reason: "
+                        f"{finish_reason!r}."
+                    )
+                if finish_reason == "length":
+                    state.add_terminal(int(event.token), _event_logprob(event))
+                state.finish(tokenizer, finish_reason)
+                completed[event.uid] = state.result(tokenizer)
+                del pending[event.uid]
+        return [completed[uid] for uid in uids]
+
+
+@contextmanager
+def _null_context():
+    yield
+
+
 def generate_batch(
     model,
     tokenizer_or_processor,
@@ -891,28 +1478,40 @@ def generate_batch(
     *,
     defaults: GenerationDefaults | None = None,
 ) -> list[GenerationResult]:
-    """Generate a batch from a training-resident MLX text model.
+    """Generate a batch from a training-resident MLX text or vision model.
 
-    Results preserve input order. ``token_ids`` come directly from mlx-lm's
-    sampled-token events, and ``logprobs`` are aligned one-to-one with them.
+    Results preserve input order. ``token_ids`` come directly from the
+    backend's sampled-token events, and ``logprobs`` are aligned one-to-one
+    with them.
     """
 
-    if getattr(model, "_is_vlm_model", False):
-        raise ValueError(
-            "VLM batched generation is not enabled in this text-only engine."
-        )
     if defaults is None:
         defaults = GenerationDefaults()
     if not isinstance(defaults, GenerationDefaults):
         raise TypeError("defaults must be GenerationDefaults.")
-    validated = _validate_text_requests(requests, defaults)
+    # Routing follows the model, not the request: a vision model preprocesses
+    # text-only prompts too.
+    is_vlm = bool(getattr(model, "_is_vlm_model", False))
+    validated = (
+        _validate_vlm_requests(requests, defaults)
+        if is_vlm
+        else _validate_text_requests(requests, defaults)
+    )
     if not validated:
         return []
     if tokenizer_or_processor is None:
-        raise ValueError("Text batched generation requires a tokenizer.")
+        raise ValueError(
+            "Batched generation requires a processor."
+            if is_vlm
+            else "Text batched generation requires a tokenizer."
+        )
     with generation_mode(model):
         with _generation_cache_hygiene():
-            adapter = _TextBatchAdapter(model, tokenizer_or_processor, defaults)
+            adapter = (
+                _VLMBatchAdapter(model, tokenizer_or_processor, defaults)
+                if is_vlm
+                else _TextBatchAdapter(model, tokenizer_or_processor, defaults)
+            )
             return adapter.generate(validated)
 
 
@@ -940,11 +1539,6 @@ def fast_generate(
     ``generate_batch`` directly.
     """
 
-    if getattr(self, "_is_vlm_model", False):
-        raise ValueError(
-            "Unsloth MLX: fast_generate is currently available for text "
-            "models only."
-        )
     tokenizer = getattr(self, "_tokenizer", None)
     if tokenizer is None:
         raise ValueError("Unsloth MLX: fast_generate requires model._tokenizer.")

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -901,11 +901,78 @@ def generate_batch(
             return adapter.generate(validated)
 
 
+def fast_generate(
+    self,
+    prompts,
+    *,
+    max_tokens=256,
+    temperature=0.0,
+    top_p=0.0,
+    top_k=0,
+    min_p=0.0,
+    stop_strings=(),
+    prefill_batch_size=8,
+    completion_batch_size=32,
+    max_kv_size=None,
+    kv_bits=None,
+    kv_group_size=None,
+):
+    """Batch-generate text rollouts from a training-resident MLX model.
+
+    Accepts one rendered prompt or a sequence of rendered prompts and always
+    returns a list of ``GenerationResult`` objects in input order. Callers that
+    need token-id prompts or heterogeneous per-request controls should use
+    ``generate_batch`` directly.
+    """
+
+    if getattr(self, "_is_vlm_model", False):
+        raise ValueError(
+            "Unsloth MLX: fast_generate is currently available for text "
+            "models only."
+        )
+    tokenizer = getattr(self, "_tokenizer", None)
+    if tokenizer is None:
+        raise ValueError("Unsloth MLX: fast_generate requires model._tokenizer.")
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    else:
+        try:
+            prompts = list(prompts)
+        except TypeError as exc:
+            raise TypeError(
+                "Unsloth MLX: fast_generate prompts must be a string or a "
+                "sequence of strings."
+            ) from exc
+    if any(not isinstance(prompt, str) for prompt in prompts):
+        raise TypeError(
+            "Unsloth MLX: every fast_generate prompt must be a string."
+        )
+
+    defaults = GenerationDefaults(
+        max_tokens=max_tokens,
+        sampling=SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
+        ),
+        stop_strings=stop_strings,
+        prefill_batch_size=prefill_batch_size,
+        completion_batch_size=completion_batch_size,
+        max_kv_size=max_kv_size,
+        kv_bits=kv_bits,
+        kv_group_size=kv_group_size,
+    )
+    requests = [GenerationRequest(prompt=prompt) for prompt in prompts]
+    return generate_batch(self, tokenizer, requests, defaults=defaults)
+
+
 __all__ = [
     "GenerationDefaults",
     "GenerationRequest",
     "GenerationResult",
     "SamplingParams",
+    "fast_generate",
     "generate_batch",
     "generation_mode",
 ]

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -1656,6 +1656,12 @@ def generate_batch(
     )
     if not validated:
         return []
+    if is_vlm:
+        # A text-only multimodal load stays on the vision path but publishes its
+        # inner tokenizer, which cannot drive mlx-vlm preprocessing.
+        tokenizer_or_processor = (
+            getattr(model, "_processor", None) or tokenizer_or_processor
+        )
     if tokenizer_or_processor is None:
         raise ValueError(
             "Batched generation requires a processor."
@@ -1697,10 +1703,6 @@ def fast_generate(
     """
 
     tokenizer = getattr(self, "_tokenizer", None)
-    if getattr(self, "_is_vlm_model", False):
-        # A text-only multimodal load stays on the vision path but publishes its
-        # inner tokenizer, which cannot drive mlx-vlm preprocessing.
-        tokenizer = getattr(self, "_processor", None) or tokenizer
     if tokenizer is None:
         raise ValueError("Unsloth MLX: fast_generate requires model._tokenizer.")
     if isinstance(prompts, str):

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -30,8 +30,21 @@ from numbers import Integral
 from typing import Any, Literal, Sequence
 
 
-_MLX_LM_PIN = "mlx-lm==0.31.2"
 _TEXT_EVENT_FIELDS = frozenset(("uid", "token", "logprobs", "finish_reason"))
+
+
+def _installed_mlx_lm_version() -> str:
+    """Name the installed mlx-lm, or an unversioned phrase if metadata is unusable."""
+
+    try:
+        from importlib.metadata import version
+
+        installed = version("mlx-lm")
+    except Exception:
+        installed = None
+    if not isinstance(installed, str) or not installed.strip():
+        return "the installed mlx-lm"
+    return f"mlx-lm {installed.strip().splitlines()[0]}"
 
 
 def _current_async_task():
@@ -162,8 +175,9 @@ class GenerationDefaults:
         if unsupported_kv:
             names = " and ".join(unsupported_kv)
             raise ValueError(
-                f"{names} are not supported by {_MLX_LM_PIN}'s "
-                "BatchGenerator; omit these controls."
+                f"{names} are not forwarded by this engine's mlx-lm text "
+                f"path (installed: {_installed_mlx_lm_version()}); omit these "
+                "controls."
             )
         if not isinstance(self.sampling, SamplingParams):
             raise TypeError("defaults.sampling must be SamplingParams.")
@@ -289,8 +303,9 @@ def _validate_text_requests(
 def _api_shape_error(details: str) -> RuntimeError:
     return RuntimeError(
         "Unsupported mlx-lm batch-generation API shape "
-        f"({details}). This engine requires the workspace pin {_MLX_LM_PIN}; "
-        "sync the workspace dependencies before using batched generation."
+        f"({details}) in {_installed_mlx_lm_version()}. Batched generation "
+        "needs a BatchGenerator that streams per-token events; upgrade or "
+        "reinstall mlx-lm, or use model.generate for sequential decoding."
     )
 
 

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -1,0 +1,825 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Batched generation primitives for training-resident MLX text models."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import math
+import threading
+import warnings
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
+from numbers import Integral
+from typing import Any, Literal, Sequence
+
+
+_MLX_LM_PIN = "mlx-lm==0.31.2"
+_TEXT_EVENT_FIELDS = frozenset(("uid", "token", "logprobs", "finish_reason"))
+
+
+def _current_async_task():
+    try:
+        return asyncio.current_task()
+    except RuntimeError:
+        return None
+
+
+class _GenerationModeLock:
+    """Thread-reentrant lock that rejects unsafe same-thread task overlap."""
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._state_lock = threading.Lock()
+        self._owner_thread = None
+        self._owner_task = None
+        self._depth = 0
+
+    def acquire(self, blocking=True, timeout=-1):
+        owner_thread = threading.get_ident()
+        owner_task = _current_async_task()
+        with self._state_lock:
+            if (
+                self._depth
+                and self._owner_thread == owner_thread
+                and self._owner_task is not owner_task
+            ):
+                raise RuntimeError(
+                    "generation_mode contexts from different async tasks cannot "
+                    "overlap on the same thread."
+                )
+        acquired = (
+            self._lock.acquire(blocking)
+            if timeout == -1
+            else self._lock.acquire(blocking, timeout)
+        )
+        if not acquired:
+            return False
+        with self._state_lock:
+            if self._depth == 0:
+                self._owner_thread = owner_thread
+                self._owner_task = owner_task
+            self._depth += 1
+        return True
+
+    def release(self):
+        owner_thread = threading.get_ident()
+        owner_task = _current_async_task()
+        with self._state_lock:
+            if (
+                not self._depth
+                or self._owner_thread != owner_thread
+                or self._owner_task is not owner_task
+            ):
+                raise RuntimeError("generation_mode lock released by a non-owner.")
+            self._depth -= 1
+            if self._depth == 0:
+                self._owner_thread = None
+                self._owner_task = None
+        self._lock.release()
+
+
+_GENERATION_MODE_LOCK = _GenerationModeLock()
+_GENERATION_MODE_DEPTH = 0
+_GENERATION_LIMIT_SNAPSHOT: dict[str, int] | None = None
+
+
+@dataclass(frozen=True)
+class SamplingParams:
+    """Sampling controls understood by mlx-lm's sampler factory."""
+
+    temperature: float = 0.0
+    top_p: float = 0.0
+    top_k: int = 0
+    min_p: float = 0.0
+
+    def __post_init__(self):
+        temperature = float(self.temperature)
+        top_p = float(self.top_p)
+        min_p = float(self.min_p)
+        if not math.isfinite(temperature) or temperature < 0:
+            raise ValueError("temperature must be a finite value >= 0.")
+        if not math.isfinite(top_p) or not 0 <= top_p <= 1:
+            raise ValueError("top_p must be a finite value between 0 and 1.")
+        if isinstance(self.top_k, bool) or not isinstance(self.top_k, Integral):
+            raise TypeError("top_k must be an integer.")
+        if self.top_k < 0:
+            raise ValueError("top_k must be >= 0.")
+        if not math.isfinite(min_p) or not 0 <= min_p <= 1:
+            raise ValueError("min_p must be a finite value between 0 and 1.")
+        object.__setattr__(self, "temperature", temperature)
+        object.__setattr__(self, "top_p", top_p)
+        object.__setattr__(self, "top_k", int(self.top_k))
+        object.__setattr__(self, "min_p", min_p)
+
+
+@dataclass(frozen=True)
+class GenerationDefaults:
+    """Batch-wide defaults used when a request does not override a value."""
+
+    max_tokens: int = 256
+    sampling: SamplingParams = field(default_factory=SamplingParams)
+    stop_strings: tuple[str, ...] = ()
+
+    def __post_init__(self):
+        _validate_max_tokens(self.max_tokens, "defaults.max_tokens")
+        if not isinstance(self.sampling, SamplingParams):
+            raise TypeError("defaults.sampling must be SamplingParams.")
+        stops = _normalize_stop_strings(self.stop_strings)
+        object.__setattr__(self, "max_tokens", int(self.max_tokens))
+        object.__setattr__(self, "stop_strings", stops)
+
+
+@dataclass(frozen=True)
+class GenerationRequest:
+    """One text-generation request.
+
+    Exactly one of ``prompt`` and ``prompt_token_ids`` must be provided.
+    Rendered prompt strings are encoded as-is; chat templating belongs to the
+    caller.
+    """
+
+    prompt: str | None = None
+    prompt_token_ids: Sequence[int] | None = None
+    image: Any | None = None
+    audio: Any | None = None
+    max_tokens: int | None = None
+    sampling: SamplingParams | None = None
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    """Sampled-token output with text from mlx-lm's streaming detokenizer."""
+
+    token_ids: list[int]
+    text: str
+    logprobs: list[float] | None
+    finish_reason: Literal["stop", "length", "stop_string"]
+    stop_match: str | None = None
+
+
+def _validate_max_tokens(value: Any, name: str):
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer.")
+    if value <= 0:
+        raise ValueError(f"{name} must be positive.")
+
+
+def _normalize_stop_strings(stop_strings: Sequence[str] | str | None) -> tuple[str, ...]:
+    if stop_strings is None:
+        return ()
+    if isinstance(stop_strings, str):
+        stop_strings = (stop_strings,)
+    try:
+        stops = tuple(stop_strings)
+    except TypeError as exc:
+        raise TypeError("stop_strings must be a string or a sequence of strings.") from exc
+    if any(not isinstance(stop, str) for stop in stops):
+        raise TypeError("Every stop string must be a string.")
+    if any(not stop for stop in stops):
+        raise ValueError("Stop strings must not be empty.")
+    return tuple(dict.fromkeys(stops))
+
+
+def _validate_text_requests(
+    requests: Sequence[GenerationRequest],
+    defaults: GenerationDefaults,
+) -> list[GenerationRequest]:
+    validated = list(requests)
+    for index, request in enumerate(validated):
+        if not isinstance(request, GenerationRequest):
+            raise TypeError(f"requests[{index}] must be GenerationRequest.")
+        has_prompt = request.prompt is not None
+        has_ids = request.prompt_token_ids is not None
+        if has_prompt == has_ids:
+            raise ValueError(
+                f"requests[{index}] must provide exactly one of prompt or "
+                "prompt_token_ids."
+            )
+        if has_prompt and not isinstance(request.prompt, str):
+            raise TypeError(f"requests[{index}].prompt must be a string.")
+        if has_ids:
+            try:
+                prompt_ids = list(request.prompt_token_ids)
+            except TypeError as exc:
+                raise TypeError(
+                    f"requests[{index}].prompt_token_ids must be a sequence "
+                    "of integers."
+                ) from exc
+            if not prompt_ids:
+                raise ValueError(
+                    f"requests[{index}].prompt_token_ids must not be empty."
+                )
+            if any(
+                isinstance(token, bool) or not isinstance(token, Integral)
+                for token in prompt_ids
+            ):
+                raise TypeError(
+                    f"requests[{index}].prompt_token_ids must contain only "
+                    "integers."
+                )
+            validated[index] = replace(
+                request,
+                prompt_token_ids=tuple(int(token) for token in prompt_ids),
+            )
+        if request.max_tokens is not None:
+            _validate_max_tokens(request.max_tokens, f"requests[{index}].max_tokens")
+        if request.sampling is not None and not isinstance(
+            request.sampling, SamplingParams
+        ):
+            raise TypeError(f"requests[{index}].sampling must be SamplingParams.")
+        if request.image is not None or request.audio is not None:
+            raise ValueError(
+                f"requests[{index}] includes media, but text models accept "
+                "text prompts only."
+            )
+    return validated
+
+
+def _api_shape_error(details: str) -> RuntimeError:
+    return RuntimeError(
+        "Unsupported mlx-lm batch-generation API shape "
+        f"({details}). This engine requires the workspace pin {_MLX_LM_PIN}; "
+        "sync the workspace dependencies before using batched generation."
+    )
+
+
+def _probe_text_api(generate_module):
+    """Verify the event-level mlx-lm control surface used by this adapter."""
+
+    batch_generator = getattr(generate_module, "BatchGenerator", None)
+    generation_batch = getattr(generate_module, "GenerationBatch", None)
+    response_type = getattr(generation_batch, "Response", None)
+    if batch_generator is None or response_type is None:
+        raise _api_shape_error("BatchGenerator or GenerationBatch.Response missing")
+    for name in ("insert", "next_generated", "remove", "close"):
+        if not callable(getattr(batch_generator, name, None)):
+            raise _api_shape_error(f"BatchGenerator.{name} missing")
+
+    try:
+        constructor_signature = inspect.signature(batch_generator)
+        insert_parameters = inspect.signature(batch_generator.insert).parameters
+        insert_signature = inspect.signature(batch_generator.insert)
+        next_signature = inspect.signature(batch_generator.next_generated)
+        remove_signature = inspect.signature(batch_generator.remove)
+        close_signature = inspect.signature(batch_generator.close)
+    except AttributeError as exc:
+        raise _api_shape_error("required BatchGenerator method missing") from exc
+    except (TypeError, ValueError) as exc:
+        raise _api_shape_error("BatchGenerator callable signature unavailable") from exc
+
+    required_constructor = {"max_tokens", "stop_tokens"}
+    missing_constructor = required_constructor.difference(
+        constructor_signature.parameters
+    )
+    if missing_constructor:
+        names = ", ".join(sorted(missing_constructor))
+        raise _api_shape_error(f"BatchGenerator constructor missing {names}")
+    required_insert = {"prompts", "max_tokens", "samplers", "logits_processors"}
+    missing_insert = required_insert.difference(insert_parameters)
+    if missing_insert:
+        names = ", ".join(sorted(missing_insert))
+        raise _api_shape_error(f"BatchGenerator.insert missing {names}")
+    try:
+        constructor_signature.bind(object(), max_tokens=1, stop_tokens=[])
+        insert_signature.bind(
+            object(),
+            [[1]],
+            max_tokens=[1],
+            samplers=[None],
+            logits_processors=[[]],
+        )
+        next_signature.bind(object())
+        remove_signature.bind(object(), [0])
+        close_signature.bind(object())
+    except TypeError as exc:
+        raise _api_shape_error("BatchGenerator call signatures are incompatible") from exc
+
+    fields = set(getattr(response_type, "__dataclass_fields__", ()))
+    if not fields:
+        fields = set(getattr(response_type, "__annotations__", ()))
+    missing_fields = _TEXT_EVENT_FIELDS.difference(fields)
+    if missing_fields:
+        names = ", ".join(sorted(missing_fields))
+        raise _api_shape_error(f"GenerationBatch.Response missing {names}")
+
+
+def _probe_sampler_api(sample_utils_module):
+    make_sampler = getattr(sample_utils_module, "make_sampler", None)
+    if not callable(make_sampler):
+        raise _api_shape_error("sample_utils.make_sampler missing")
+    try:
+        signature = inspect.signature(make_sampler)
+    except (TypeError, ValueError) as exc:
+        raise _api_shape_error("make_sampler signature unavailable") from exc
+    required = {"temp", "top_p", "top_k", "min_p"}
+    missing = required.difference(signature.parameters)
+    if missing:
+        names = ", ".join(sorted(missing))
+        raise _api_shape_error(f"make_sampler missing {names}")
+    try:
+        signature.bind(temp=0.0, top_p=0.0, top_k=0, min_p=0.0)
+    except TypeError as exc:
+        raise _api_shape_error("make_sampler call signature is incompatible") from exc
+
+
+def _iter_model_modules(model) -> list[Any]:
+    named_modules = getattr(model, "named_modules", None)
+    if callable(named_modules):
+        modules = [module for _, module in named_modules()]
+        if modules:
+            return modules
+    return [model]
+
+
+def _snapshot_training_flags(model) -> list[tuple[Any, bool]]:
+    states = []
+    seen = set()
+    for module in _iter_model_modules(model):
+        if id(module) in seen or not hasattr(module, "training"):
+            continue
+        seen.add(id(module))
+        states.append((module, bool(module.training)))
+    return states
+
+
+def _restore_training_flags(states: Sequence[tuple[Any, bool]]):
+    first_error = None
+    for module, training in states:
+        try:
+            set_mode = getattr(module, "_set_training_mode", None)
+            if callable(set_mode):
+                set_mode(training)
+            else:
+                setattr(module, "training", training)
+        except BaseException as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
+
+
+def _snapshot_metal_limits() -> dict[str, int]:
+    """Read process-global Metal limits through their return-previous setters."""
+
+    import mlx.core as mx
+
+    if not mx.metal.is_available():
+        return {}
+    snapshot = {}
+    try:
+        for name in ("memory", "cache", "wired"):
+            setter = getattr(mx, f"set_{name}_limit")
+            previous = setter(0)
+            snapshot[name] = int(previous)
+            setter(previous)
+    except BaseException:
+        _restore_metal_limits(snapshot)
+        raise
+    return snapshot
+
+
+def _restore_metal_limits(snapshot: dict[str, int] | None):
+    if not snapshot:
+        return
+    import mlx.core as mx
+
+    first_error = None
+    for name in ("memory", "cache", "wired"):
+        if name in snapshot:
+            try:
+                getattr(mx, f"set_{name}_limit")(int(snapshot[name]))
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+    if first_error is not None:
+        raise first_error
+
+
+@contextmanager
+def generation_mode(model):
+    """Temporarily switch a model to eval mode and steward global MLX limits.
+
+    The outermost context snapshots the process-global memory, cache, and wired
+    limits. Nested contexts only track their own model flags; the outer context
+    restores the limits after all nested generation work completes. Gradient
+    checkpointing patches are intentionally left untouched because they are
+    class-level and may belong to a live compiled training step.
+    """
+
+    global _GENERATION_MODE_DEPTH, _GENERATION_LIMIT_SNAPSHOT
+
+    _GENERATION_MODE_LOCK.acquire()
+    training_states: list[tuple[Any, bool]] = []
+    entered = False
+    active_error = None
+    try:
+        if _GENERATION_MODE_DEPTH == 0:
+            _GENERATION_LIMIT_SNAPSHOT = _snapshot_metal_limits()
+        training_states = _snapshot_training_flags(model)
+        eval_model = getattr(model, "eval", None)
+        if not callable(eval_model):
+            raise TypeError("generation_mode requires a model with eval().")
+        eval_model()
+        _GENERATION_MODE_DEPTH += 1
+        entered = True
+        yield model
+    except BaseException as exc:
+        active_error = exc
+        raise
+    finally:
+        restoration_error = None
+        try:
+            if training_states:
+                _restore_training_flags(training_states)
+        except BaseException as exc:
+            restoration_error = exc
+        if entered:
+            _GENERATION_MODE_DEPTH -= 1
+        try:
+            if _GENERATION_MODE_DEPTH == 0:
+                snapshot = _GENERATION_LIMIT_SNAPSHOT
+                _GENERATION_LIMIT_SNAPSHOT = None
+                try:
+                    _restore_metal_limits(snapshot)
+                except BaseException as exc:
+                    if restoration_error is None:
+                        restoration_error = exc
+        finally:
+            _GENERATION_MODE_LOCK.release()
+        if restoration_error is not None:
+            if active_error is None:
+                raise restoration_error
+            try:
+                warnings.warn(
+                    "generation_mode could not fully restore model or MLX "
+                    f"state after {type(active_error).__name__}: "
+                    f"{restoration_error}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            except BaseException:
+                pass
+
+
+class _StopStringScanner:
+    """Incrementally search new detokenized text with longest-stop lookback."""
+
+    def __init__(self, stop_strings: Sequence[str]):
+        self.stop_strings = tuple(stop_strings)
+        self.max_stop_length = max(map(len, self.stop_strings), default=0)
+        self.previous_length = 0
+
+    def feed(self, text: str) -> tuple[int, str] | None:
+        if not self.stop_strings:
+            self.previous_length = len(text)
+            return None
+        search_start = max(0, self.previous_length - self.max_stop_length + 1)
+        matches = []
+        for order, stop in enumerate(self.stop_strings):
+            position = text.find(stop, search_start)
+            if position >= 0:
+                matches.append((position, -len(stop), order, stop))
+        self.previous_length = len(text)
+        if not matches:
+            return None
+        position, _, _, stop = min(matches)
+        return position, stop
+
+
+class _DecodeStreamingDetokenizer:
+    """Pinned mlx-lm naive-streaming semantics for raw tokenizers."""
+
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+        self.reset()
+
+    def reset(self):
+        self.offset = 0
+        self.tokens: list[int] = []
+        self._text = ""
+        self._current_tokens: list[int] = []
+        self._current_text = ""
+
+    def add_token(self, token: int):
+        self._current_tokens.append(token)
+        self.tokens.append(token)
+
+    def finalize(self):
+        self._text += self.tokenizer.decode(self._current_tokens)
+        self._current_tokens = []
+        self._current_text = ""
+
+    @property
+    def text(self):
+        if self._current_tokens:
+            self._current_text = self.tokenizer.decode(self._current_tokens)
+            if self._current_text.endswith("\ufffd") or (
+                getattr(self.tokenizer, "clean_up_tokenization_spaces", False)
+                and self._current_text.endswith(" ")
+            ):
+                self._current_text = self._current_text[:-1]
+        if self._current_text.endswith("\n"):
+            self._text += self._current_text
+            self._current_tokens.clear()
+            self._current_text = ""
+        return self._text + self._current_text
+
+    @property
+    def last_segment(self):
+        segment = self.text[self.offset :]
+        self.offset = len(self.text)
+        return segment
+
+
+def _new_detokenizer(tokenizer):
+    try:
+        detokenizer = tokenizer.detokenizer
+    except (AttributeError, TypeError):
+        detokenizer = None
+    if detokenizer is None:
+        return _DecodeStreamingDetokenizer(tokenizer)
+    reset = getattr(detokenizer, "reset", None)
+    if callable(reset):
+        reset()
+    return detokenizer
+
+
+def _replay_stream_text(detokenizer, token_ids: Sequence[int]) -> str:
+    detokenizer.reset()
+    text = ""
+    for token in token_ids:
+        detokenizer.add_token(int(token))
+        text += detokenizer.last_segment
+    detokenizer.finalize()
+    return text + detokenizer.last_segment
+
+
+@dataclass
+class _PendingResult:
+    detokenizer: Any
+    scanner: _StopStringScanner
+    token_ids: list[int] = field(default_factory=list)
+    logprobs: list[float] = field(default_factory=list)
+    text: str = ""
+    finish_reason: Literal["stop", "length", "stop_string"] | None = None
+    stop_match: str | None = None
+
+    def _apply_stop_match(
+        self,
+        tokenizer,
+        match: tuple[int, str],
+    ):
+        stop_start, self.stop_match = match
+        target_prefix = self.text[:stop_start]
+        boundary_detokenizer = _new_detokenizer(tokenizer)
+        keep = 0
+        for token_count in range(len(self.token_ids) - 1, -1, -1):
+            candidate_text = _replay_stream_text(
+                boundary_detokenizer,
+                self.token_ids[:token_count],
+            )
+            if target_prefix.startswith(candidate_text):
+                keep = token_count
+                break
+        del self.token_ids[keep:]
+        del self.logprobs[keep:]
+        self.text = _replay_stream_text(self.detokenizer, self.token_ids)
+        self.finish_reason = "stop_string"
+
+    def add_terminal(self, token: int, logprob: float):
+        self.token_ids.append(token)
+        self.logprobs.append(logprob)
+        self.detokenizer.add_token(token)
+
+    def append(self, tokenizer, token: int, logprob: float) -> bool:
+        self.add_terminal(token, logprob)
+        self.text += self.detokenizer.last_segment
+        match = self.scanner.feed(self.text)
+        if match is None:
+            return False
+        self._apply_stop_match(tokenizer, match)
+        return True
+
+    def finish(self, tokenizer, reason: Literal["stop", "length"]):
+        self.detokenizer.finalize()
+        self.text += self.detokenizer.last_segment
+        match = self.scanner.feed(self.text)
+        if match is not None:
+            self._apply_stop_match(tokenizer, match)
+        else:
+            self.finish_reason = reason
+
+    def result(self, tokenizer) -> GenerationResult:
+        if self.finish_reason is None:
+            raise RuntimeError("Internal error: generation ended without a finish reason.")
+        return GenerationResult(
+            token_ids=list(self.token_ids),
+            text=self.text,
+            logprobs=list(self.logprobs),
+            finish_reason=self.finish_reason,
+            stop_match=self.stop_match,
+        )
+
+
+def _encode_prompt(tokenizer, request: GenerationRequest) -> list[int]:
+    if request.prompt_token_ids is not None:
+        return [int(token) for token in request.prompt_token_ids]
+    try:
+        prompt_ids = tokenizer.encode(request.prompt, add_special_tokens=False)
+    except TypeError:
+        prompt_ids = tokenizer.encode(request.prompt)
+    prompt_ids = [int(token) for token in prompt_ids]
+    if not prompt_ids:
+        raise ValueError("Encoded prompts must contain at least one token.")
+    return prompt_ids
+
+
+def _eos_stop_tokens(tokenizer) -> list[list[int]]:
+    eos_ids = getattr(tokenizer, "eos_token_ids", None)
+    if eos_ids is None:
+        eos_id = getattr(tokenizer, "eos_token_id", None)
+        eos_ids = () if eos_id is None else (eos_id,)
+    if isinstance(eos_ids, Integral):
+        eos_ids = (eos_ids,)
+    return [[int(token)] for token in eos_ids if token is not None]
+
+
+def _sampled_logprob(event) -> float:
+    try:
+        value = event.logprobs[int(event.token)]
+    except (IndexError, KeyError, TypeError) as exc:
+        raise RuntimeError(
+            "mlx-lm emitted a logprob vector that does not contain the sampled "
+            f"token {event.token}."
+        ) from exc
+    if hasattr(value, "item"):
+        value = value.item()
+    return float(value)
+
+
+class _TextBatchAdapter:
+    def __init__(self, model, tokenizer, defaults: GenerationDefaults):
+        generate_module = importlib.import_module("mlx_lm.generate")
+        sample_utils_module = importlib.import_module("mlx_lm.sample_utils")
+        _probe_text_api(generate_module)
+        _probe_sampler_api(sample_utils_module)
+        self.batch_generator_type = generate_module.BatchGenerator
+        self.make_sampler = sample_utils_module.make_sampler
+        self.model = model
+        self.tokenizer = tokenizer
+        self.defaults = defaults
+
+    def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
+        prompts = [_encode_prompt(self.tokenizer, request) for request in requests]
+        max_tokens = [
+            int(request.max_tokens or self.defaults.max_tokens)
+            for request in requests
+        ]
+        sampling = [
+            request.sampling or self.defaults.sampling
+            for request in requests
+        ]
+        samplers = [
+            self.make_sampler(
+                temp=params.temperature,
+                top_p=params.top_p,
+                top_k=params.top_k,
+                min_p=params.min_p,
+            )
+            for params in sampling
+        ]
+        generator = self.batch_generator_type(
+            self.model,
+            max_tokens=self.defaults.max_tokens,
+            stop_tokens=_eos_stop_tokens(self.tokenizer),
+        )
+        active_error = None
+        try:
+            uids = generator.insert(
+                prompts,
+                max_tokens=max_tokens,
+                samplers=samplers,
+                logits_processors=[[] for _ in requests],
+            )
+            pending = {
+                uid: _PendingResult(
+                    detokenizer=_new_detokenizer(self.tokenizer),
+                    scanner=_StopStringScanner(self.defaults.stop_strings),
+                )
+                for uid in uids
+            }
+            completed: dict[int, GenerationResult] = {}
+            while pending:
+                events = generator.next_generated()
+                if not events:
+                    raise RuntimeError(
+                        "mlx-lm ended its event stream before every request "
+                        "reported a finish reason."
+                    )
+                for event in events:
+                    state = pending.get(event.uid)
+                    if state is None:
+                        continue
+                    finish_reason = event.finish_reason
+                    if finish_reason is None:
+                        stopped = state.append(
+                            self.tokenizer,
+                            int(event.token),
+                            _sampled_logprob(event),
+                        )
+                        if stopped:
+                            generator.remove([event.uid])
+                            completed[event.uid] = state.result(self.tokenizer)
+                            del pending[event.uid]
+                            continue
+                        continue
+                    if finish_reason not in ("stop", "length"):
+                        raise RuntimeError(
+                            "mlx-lm emitted an unsupported finish reason: "
+                            f"{finish_reason!r}."
+                        )
+                    if finish_reason == "length":
+                        state.add_terminal(
+                            int(event.token),
+                            _sampled_logprob(event),
+                        )
+                    state.finish(self.tokenizer, finish_reason)
+                    completed[event.uid] = state.result(self.tokenizer)
+                    del pending[event.uid]
+            return [completed[uid] for uid in uids]
+        except BaseException as exc:
+            active_error = exc
+            raise
+        finally:
+            try:
+                generator.close()
+            except BaseException as close_error:
+                if active_error is None:
+                    raise
+                try:
+                    warnings.warn(
+                        "BatchGenerator.close() failed while preserving an "
+                        f"active {type(active_error).__name__}: {close_error}",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
+                except BaseException:
+                    pass
+
+
+def generate_batch(
+    model,
+    tokenizer_or_processor,
+    requests: Sequence[GenerationRequest],
+    *,
+    defaults: GenerationDefaults | None = None,
+) -> list[GenerationResult]:
+    """Generate a batch from a training-resident MLX text model.
+
+    Results preserve input order. ``token_ids`` come directly from mlx-lm's
+    sampled-token events, and ``logprobs`` are aligned one-to-one with them.
+    """
+
+    if getattr(model, "_is_vlm_model", False):
+        raise ValueError(
+            "VLM batched generation is not enabled in this text-only engine."
+        )
+    if defaults is None:
+        defaults = GenerationDefaults()
+    if not isinstance(defaults, GenerationDefaults):
+        raise TypeError("defaults must be GenerationDefaults.")
+    validated = _validate_text_requests(requests, defaults)
+    if not validated:
+        return []
+    if tokenizer_or_processor is None:
+        raise ValueError("Text batched generation requires a tokenizer.")
+    with generation_mode(model):
+        adapter = _TextBatchAdapter(model, tokenizer_or_processor, defaults)
+        return adapter.generate(validated)
+
+
+__all__ = [
+    "GenerationDefaults",
+    "GenerationRequest",
+    "GenerationResult",
+    "SamplingParams",
+    "generate_batch",
+    "generation_mode",
+]

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -1259,8 +1259,12 @@ class _VLMBatchAdapter:
         )
 
     def _group_key(self, request: GenerationRequest):
+        # Prompt length is part of the key: preprocessing stacks a group without
+        # padding, so mixing lengths raises instead of generating. Grouping by
+        # length keeps varied batches working, at the cost of smaller groups.
         sampling = request.sampling or self.defaults.sampling
         shape = self._image_shape(request.image)
+        tokenizer = getattr(self.processor, "tokenizer", self.processor)
         return (
             sampling.temperature,
             sampling.top_p,
@@ -1268,6 +1272,7 @@ class _VLMBatchAdapter:
             sampling.min_p,
             request.image is None,
             shape,
+            len(tokenizer.encode(request.prompt)),
         )
 
     def _decode_image(self, request: GenerationRequest) -> GenerationRequest:

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -114,6 +114,9 @@ _GENERATION_MODE_DEPTH = 0
 _GENERATION_LIMIT_SNAPSHOT: dict[str, int] | None = None
 
 
+_KV_QUANT_CONTROLS = ("kv_bits", "kv_group_size", "kv_quant_scheme", "quantized_kv_start")
+
+
 @dataclass(frozen=True)
 class SamplingParams:
     """Sampling controls understood by mlx-lm's sampler factory."""
@@ -153,8 +156,10 @@ class GenerationDefaults:
     prefill_batch_size: int = 8
     completion_batch_size: int = 32
     max_kv_size: int | None = None
-    kv_bits: int | None = None
+    kv_bits: float | None = None
     kv_group_size: int | None = None
+    kv_quant_scheme: str | None = None
+    quantized_kv_start: int | None = None
 
     def __post_init__(self):
         _validate_positive_int(self.max_tokens, "defaults.max_tokens")
@@ -168,18 +173,6 @@ class GenerationDefaults:
         )
         if self.max_kv_size is not None:
             _validate_positive_int(self.max_kv_size, "defaults.max_kv_size")
-        unsupported_kv = [
-            name
-            for name in ("kv_bits", "kv_group_size")
-            if getattr(self, name) is not None
-        ]
-        if unsupported_kv:
-            names = " and ".join(unsupported_kv)
-            raise ValueError(
-                f"{names} are not forwarded by this engine's mlx-lm text "
-                f"path (installed: {_installed_mlx_lm_version()}); omit these "
-                "controls."
-            )
         if not isinstance(self.sampling, SamplingParams):
             raise TypeError("defaults.sampling must be SamplingParams.")
         stops = _normalize_stop_strings(self.stop_strings)
@@ -300,6 +293,15 @@ def _validate_text_requests(
                 f"requests[{index}] includes media, but text models accept "
                 "text prompts only."
             )
+    refused_kv = [
+        name for name in _KV_QUANT_CONTROLS if getattr(defaults, name) is not None
+    ]
+    if refused_kv:
+        raise ValueError(
+            f"{' and '.join(refused_kv)} are not forwarded by this engine's "
+            f"mlx-lm text path (installed: {_installed_mlx_lm_version()}); "
+            "omit these controls."
+        )
     return validated
 
 
@@ -332,11 +334,6 @@ def _validate_vlm_requests(
         if isinstance(request.image, os.PathLike):
             # mlx-vlm's loader opens str paths only.
             validated[index] = replace(request, image=os.fspath(request.image))
-    if defaults.stop_strings:
-        raise ValueError(
-            "stop_strings are not supported for batched vision generation yet; "
-            "omit them or post-process the returned text."
-        )
     if defaults.prefill_batch_size > defaults.completion_batch_size:
         # An inverted pair never admits anything on mlx-vlm, so generation would
         # hang. mlx-lm normalizes the two, so this is vision-specific.
@@ -344,6 +341,18 @@ def _validate_vlm_requests(
             "prefill_batch_size must not exceed completion_batch_size for "
             "batched vision generation (got "
             f"{defaults.prefill_batch_size} > {defaults.completion_batch_size})."
+        )
+    refused_kv = [
+        name for name in _KV_QUANT_CONTROLS if getattr(defaults, name) is not None
+    ]
+    if refused_kv:
+        # Whether these bound anything depends on the release, the rest of the
+        # configuration, and the model's own cache classes, which upstream
+        # resolves per layer. None is forwarded rather than promise a bound
+        # that may not exist.
+        raise ValueError(
+            f"{' and '.join(refused_kv)} are not forwarded by this engine's "
+            "batched vision path; omit these controls, or use model.generate."
         )
     if defaults.max_kv_size is not None:
         # No supported BatchGenerator takes a KV-window control, so say so rather
@@ -696,8 +705,13 @@ class _DecodeStreamingDetokenizer:
 
     @property
     def last_segment(self):
-        segment = self.text[self.offset :]
-        self.offset = len(self.text)
+        text = self.text
+        if self.offset > len(text):
+            # A decode can shorten when a trailing character becomes incomplete.
+            # The offset only advances; lowering it would re-emit that tail.
+            return ""
+        segment = text[self.offset :]
+        self.offset = len(text)
         return segment
 
 
@@ -1047,7 +1061,35 @@ def _probe_vlm_api(batch_module):
         raise _vlm_api_shape_error(
             f"BatchGenerator constructor missing {', '.join(absent)}"
         )
-    return constructor, insert
+    return constructor, insert, _resolve_cancel(generator)
+
+
+def _resolve_cancel(generator):
+    """How this generator cancels one sequence, decided once.
+
+    Retrying the other form on TypeError would re-run a partially applied
+    cancel against an already mutated batch.
+    """
+
+    remove = getattr(generator, "remove", None)
+    if not callable(remove):
+        return None
+    try:
+        params = [
+            name
+            for name, param in inspect.signature(remove).parameters.items()
+            if name != "self"
+            and param.kind
+            in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)
+        ]
+    except (TypeError, ValueError):
+        return None
+    if not params:
+        return None
+    plural = params[0].endswith("s")
+    return (lambda gen, uid: gen.remove([uid])) if plural else (
+        lambda gen, uid: gen.remove(uid)
+    )
 
 
 def _is_mrope_position_ids(key: str, value) -> bool:
@@ -1109,7 +1151,11 @@ class _VLMBatchAdapter:
                 batch_module = importlib.import_module(defining)
             except Exception:
                 pass
-        self.constructor_params, insert_params = _probe_vlm_api(batch_module)
+        (
+            self.constructor_params,
+            insert_params,
+            self.cancel,
+        ) = _probe_vlm_api(batch_module)
         self.batch_module = batch_module
         self.generator_type = batch_module.BatchGenerator
         self.per_row_prompt_kwargs = "prompt_kwargs" in insert_params
@@ -1420,7 +1466,7 @@ class _VLMBatchAdapter:
         pending = {
             uid: _PendingResult(
                 detokenizer=_new_detokenizer(tokenizer, require_independent=True),
-                scanner=_StopStringScanner(()),
+                scanner=_StopStringScanner(self.defaults.stop_strings),
             )
             for uid in uids
         }
@@ -1451,7 +1497,19 @@ class _VLMBatchAdapter:
                     continue
                 finish_reason = event.finish_reason
                 if finish_reason is None:
-                    state.append(tokenizer, int(event.token), _event_logprob(event))
+                    stopped = state.append(
+                        tokenizer,
+                        int(event.token),
+                        _event_logprob(event),
+                    )
+                    if stopped:
+                        # Where the release cannot cancel, the sequence keeps
+                        # decoding upstream and its later events are ignored;
+                        # results match either way, only wasted decode differs.
+                        if self.cancel is not None:
+                            self.cancel(generator, event.uid)
+                        completed[event.uid] = state.result(tokenizer)
+                        del pending[event.uid]
                     continue
                 if finish_reason not in ("stop", "length"):
                     raise RuntimeError(

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -196,7 +196,9 @@ class GenerationRequest:
     Rendered prompt strings are encoded as-is; chat templating belongs to the
     caller. ``image`` (vision models only) accepts a PIL image, an array, or a
     str/os.PathLike filesystem path or URL, decoded once before grouping; raw
-    bytes and file-like objects are rejected. ``audio`` is not yet supported.
+    bytes and file-like objects are rejected. ``audio`` (vision models only) is
+    accepted but decodes one request at a time, since no supported mlx-vlm
+    release batches it. At most one of ``image`` and ``audio`` per request.
     """
 
     prompt: str | None = None
@@ -320,10 +322,10 @@ def _validate_vlm_requests(
             )
         if not isinstance(request.prompt, str):
             raise TypeError(f"requests[{index}].prompt must be a string.")
-        if request.audio is not None:
+        if request.image is not None and request.audio is not None:
             raise ValueError(
-                f"requests[{index}] carries audio, which batched vision "
-                "generation does not support; use model.generate instead."
+                f"requests[{index}] carries both an image and audio; batched "
+                "vision generation takes at most one medium per request."
             )
         if request.max_tokens is not None:
             _validate_positive_int(request.max_tokens, f"requests[{index}].max_tokens")
@@ -1319,9 +1321,23 @@ class _VLMBatchAdapter:
     def generate(self, requests: Sequence[GenerationRequest]) -> list[GenerationResult]:
         requests = [self._decode_image(request) for request in requests]
         results: list[GenerationResult | None] = [None] * len(requests)
+        audio_indices = [
+            index for index, request in enumerate(requests) if request.audio is not None
+        ]
+        if audio_indices:
+            # No supported release batches audio.
+            warnings.warn(
+                f"{len(audio_indices)} audio request(s) decode one at a time: "
+                f"{_installed_mlx_vlm_version()} batches text and images only.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+            for index in audio_indices:
+                results[index] = self._generate_sequentially(requests[index])
         groups: dict[Any, list[int]] = {}
         for index, request in enumerate(requests):
-            groups.setdefault(self._group_key(request), []).append(index)
+            if request.audio is None:
+                groups.setdefault(self._group_key(request), []).append(index)
         # Older releases slice shared kwargs from row zero on every prefill
         # batch, pairing later prompts with earlier embeddings, so they run one
         # chunk per generator. Per-row releases keep the configured sizes.
@@ -1340,6 +1356,78 @@ class _VLMBatchAdapter:
                 for index, result in zip(chunk, self._run_chunk(requests, chunk)):
                     results[index] = result
         return [result for result in results if result is not None]
+
+    def _generate_sequentially(self, request: GenerationRequest) -> GenerationResult:
+        """One audio request through the release's sequential stream.
+
+        The stream's terminal event carries no new token: it repeats the last
+        one on budget exhaustion, or is the stopping token, which this contract
+        excludes. So an event is committed only once a successor arrives, and
+        the terminal one contributes text alone.
+        """
+
+        stream = getattr(self.stream_module, "stream_generate", None)
+        if not callable(stream):
+            raise _vlm_api_shape_error("no importable module exposes stream_generate")
+        tokenizer = getattr(self.processor, "tokenizer", self.processor)
+        sampling = request.sampling or self.defaults.sampling
+        state = _PendingResult(
+            detokenizer=_new_detokenizer(tokenizer, require_independent=True),
+            scanner=_StopStringScanner(self.defaults.stop_strings),
+        )
+        previous = None
+        # No wrap here: the sequential stream owns its own wired-limit window.
+        events = stream(
+            self.model,
+            self.processor,
+            request.prompt,
+            audio=request.audio,
+            max_tokens=int(request.max_tokens or self.defaults.max_tokens),
+            sampler=self.make_sampler(
+                temp=sampling.temperature,
+                top_p=sampling.top_p,
+                top_k=sampling.top_k,
+                min_p=sampling.min_p,
+            ),
+        )
+        for event in events:
+            if previous is not None and state.append(
+                tokenizer,
+                int(previous.token),
+                _event_logprob(previous),
+            ):
+                return state.result(tokenizer)
+            previous = event
+        if previous is None:
+            raise RuntimeError(
+                "mlx-vlm produced no events for an audio request."
+            )
+        state.finish(tokenizer, self._terminal_reason(previous, tokenizer))
+        return state.result(tokenizer)
+
+    @staticmethod
+    def _terminal_reason(event, tokenizer) -> Literal["stop", "length"]:
+        reason = getattr(event, "finish_reason", None)
+        if reason in ("stop", "length"):
+            return reason
+        if reason is not None:
+            raise RuntimeError(
+                f"mlx-vlm emitted an unsupported finish reason: {reason!r}."
+            )
+        token = getattr(event, "token", None)
+        if token is None:
+            return "length"
+        # Ask the criteria object that actually ended the loop: processors carry
+        # stop ids the tokenizer's EOS attributes do not list, so rebuilding the
+        # set would report a genuine stop as a length cut-off.
+        criteria = getattr(tokenizer, "stopping_criteria", None)
+        if callable(criteria):
+            try:
+                return "stop" if criteria(int(token)) else "length"
+            except Exception:
+                pass
+        eos = {ids[0] for ids in _eos_stop_tokens(tokenizer)}
+        return "stop" if int(token) in eos else "length"
 
     def _run_chunk(
         self,

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -216,7 +216,7 @@ class GenerationResult:
 
     token_ids: list[int]
     text: str
-    logprobs: list[float] | None
+    logprobs: list[float]
     finish_reason: Literal["stop", "length", "stop_string"]
     stop_match: str | None = None
 
@@ -261,6 +261,8 @@ def _validate_text_requests(
             )
         if has_prompt and not isinstance(request.prompt, str):
             raise TypeError(f"requests[{index}].prompt must be a string.")
+        if has_prompt and not request.prompt:
+            raise ValueError(f"requests[{index}].prompt must not be empty.")
         if has_ids:
             try:
                 prompt_ids = list(request.prompt_token_ids)
@@ -323,6 +325,8 @@ def _validate_vlm_requests(
             )
         if not isinstance(request.prompt, str):
             raise TypeError(f"requests[{index}].prompt must be a string.")
+        if not request.prompt:
+            raise ValueError(f"requests[{index}].prompt must not be empty.")
         if request.image is not None and request.audio is not None:
             raise ValueError(
                 f"requests[{index}] carries both an image and audio; batched "
@@ -1019,13 +1023,25 @@ def _resolve_module_attr(candidates: Sequence[str], attribute: str):
     package can shadow the submodule, so candidates are imported by name.
     """
 
+    broken = None
     for name in candidates:
         try:
             module = importlib.import_module(name)
-        except Exception:
+        except ModuleNotFoundError as exc:
+            # Absent candidate, unless what is missing is a dependency of it.
+            missing = exc.name
+            if broken is None and missing and not name.startswith(missing):
+                broken = exc
+            continue
+        except Exception as exc:
+            if broken is None:
+                broken = exc
             continue
         if getattr(module, attribute, None) is not None:
             return module
+    if broken is not None:
+        # A partial install is not an unsupported release; say which it is.
+        raise broken
     return None
 
 
@@ -1191,7 +1207,16 @@ class _VLMBatchAdapter:
         stream = getattr(module, "generation_stream", None)
         try:
             return module.wired_limit(self.model, [stream] if stream else None)
-        except Exception:
+        except TypeError:
+            # Only a signature change reaches here: wired_limit is a context
+            # manager, so it sets the limit at __enter__, not on this call.
+            warnings.warn(
+                f"{_installed_mlx_vlm_version()} exposes an incompatible "
+                "wired_limit(); batched vision generation runs under the "
+                "caller's wired-memory limit.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
             return _null_context()
 
     def _add_special_tokens(self) -> bool:

--- a/unsloth_zoo/mlx/generate.py
+++ b/unsloth_zoo/mlx/generate.py
@@ -136,13 +136,47 @@ class GenerationDefaults:
     max_tokens: int = 256
     sampling: SamplingParams = field(default_factory=SamplingParams)
     stop_strings: tuple[str, ...] = ()
+    prefill_batch_size: int = 8
+    completion_batch_size: int = 32
+    max_kv_size: int | None = None
+    kv_bits: int | None = None
+    kv_group_size: int | None = None
 
     def __post_init__(self):
-        _validate_max_tokens(self.max_tokens, "defaults.max_tokens")
+        _validate_positive_int(self.max_tokens, "defaults.max_tokens")
+        _validate_positive_int(
+            self.prefill_batch_size,
+            "defaults.prefill_batch_size",
+        )
+        _validate_positive_int(
+            self.completion_batch_size,
+            "defaults.completion_batch_size",
+        )
+        if self.max_kv_size is not None:
+            _validate_positive_int(self.max_kv_size, "defaults.max_kv_size")
+        unsupported_kv = [
+            name
+            for name in ("kv_bits", "kv_group_size")
+            if getattr(self, name) is not None
+        ]
+        if unsupported_kv:
+            names = " and ".join(unsupported_kv)
+            raise ValueError(
+                f"{names} are not supported by {_MLX_LM_PIN}'s "
+                "BatchGenerator; omit these controls."
+            )
         if not isinstance(self.sampling, SamplingParams):
             raise TypeError("defaults.sampling must be SamplingParams.")
         stops = _normalize_stop_strings(self.stop_strings)
         object.__setattr__(self, "max_tokens", int(self.max_tokens))
+        object.__setattr__(self, "prefill_batch_size", int(self.prefill_batch_size))
+        object.__setattr__(
+            self,
+            "completion_batch_size",
+            int(self.completion_batch_size),
+        )
+        if self.max_kv_size is not None:
+            object.__setattr__(self, "max_kv_size", int(self.max_kv_size))
         object.__setattr__(self, "stop_strings", stops)
 
 
@@ -174,7 +208,7 @@ class GenerationResult:
     stop_match: str | None = None
 
 
-def _validate_max_tokens(value: Any, name: str):
+def _validate_positive_int(value: Any, name: str):
     if isinstance(value, bool) or not isinstance(value, Integral):
         raise TypeError(f"{name} must be an integer.")
     if value <= 0:
@@ -239,7 +273,7 @@ def _validate_text_requests(
                 prompt_token_ids=tuple(int(token) for token in prompt_ids),
             )
         if request.max_tokens is not None:
-            _validate_max_tokens(request.max_tokens, f"requests[{index}].max_tokens")
+            _validate_positive_int(request.max_tokens, f"requests[{index}].max_tokens")
         if request.sampling is not None and not isinstance(
             request.sampling, SamplingParams
         ):
@@ -284,7 +318,13 @@ def _probe_text_api(generate_module):
     except (TypeError, ValueError) as exc:
         raise _api_shape_error("BatchGenerator callable signature unavailable") from exc
 
-    required_constructor = {"max_tokens", "stop_tokens"}
+    required_constructor = {
+        "max_tokens",
+        "stop_tokens",
+        "prefill_batch_size",
+        "completion_batch_size",
+        "max_kv_size",
+    }
     missing_constructor = required_constructor.difference(
         constructor_signature.parameters
     )
@@ -297,7 +337,14 @@ def _probe_text_api(generate_module):
         names = ", ".join(sorted(missing_insert))
         raise _api_shape_error(f"BatchGenerator.insert missing {names}")
     try:
-        constructor_signature.bind(object(), max_tokens=1, stop_tokens=[])
+        constructor_signature.bind(
+            object(),
+            max_tokens=1,
+            stop_tokens=[],
+            prefill_batch_size=1,
+            completion_batch_size=1,
+            max_kv_size=None,
+        )
         insert_signature.bind(
             object(),
             [[1]],
@@ -471,6 +518,41 @@ def generation_mode(model):
                     "generation_mode could not fully restore model or MLX "
                     f"state after {type(active_error).__name__}: "
                     f"{restoration_error}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            except BaseException:
+                pass
+
+
+@contextmanager
+def _generation_cache_hygiene():
+    """Cache hygiene around one burst; limits stay owned by ``generation_mode``."""
+
+    import mlx.core as mx
+
+    clear_cache = getattr(mx, "clear_cache", None)
+    if not callable(clear_cache):
+        raise RuntimeError(
+            "Unsupported MLX runtime API shape (mlx.core.clear_cache missing)."
+        )
+    clear_cache()
+    active_error = None
+    try:
+        yield
+    except BaseException as exc:
+        active_error = exc
+        raise
+    finally:
+        try:
+            clear_cache()
+        except BaseException as clear_error:
+            if active_error is None:
+                raise
+            try:
+                warnings.warn(
+                    "mlx.core.clear_cache() failed while preserving an active "
+                    f"{type(active_error).__name__}: {clear_error}",
                     RuntimeWarning,
                     stacklevel=2,
                 )
@@ -709,6 +791,9 @@ class _TextBatchAdapter:
             self.model,
             max_tokens=self.defaults.max_tokens,
             stop_tokens=_eos_stop_tokens(self.tokenizer),
+            prefill_batch_size=self.defaults.prefill_batch_size,
+            completion_batch_size=self.defaults.completion_batch_size,
+            max_kv_size=self.defaults.max_kv_size,
         )
         active_error = None
         try:
@@ -811,8 +896,9 @@ def generate_batch(
     if tokenizer_or_processor is None:
         raise ValueError("Text batched generation requires a tokenizer.")
     with generation_mode(model):
-        adapter = _TextBatchAdapter(model, tokenizer_or_processor, defaults)
-        return adapter.generate(validated)
+        with _generation_cache_hygiene():
+            adapter = _TextBatchAdapter(model, tokenizer_or_processor, defaults)
+            return adapter.generate(validated)
 
 
 __all__ = [

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5938,9 +5938,8 @@ def _patch_mlx_saving(model, tokenizer):
     _patch_mlx_tokenizer_call(tokenizer)
     model._tokenizer = tokenizer
     model.generate               = types.MethodType(_mlx_generate, model)
-    if not getattr(model, "_is_vlm_model", False):
-        from .generate import fast_generate
-        model.fast_generate      = types.MethodType(fast_generate, model)
+    from .generate import fast_generate
+    model.fast_generate          = types.MethodType(fast_generate, model)
     model.save_pretrained        = types.MethodType(_mlx_save_pretrained_merged, model)
     model.save_pretrained_merged = types.MethodType(_mlx_save_pretrained_merged, model)
     model.save_pretrained_gguf   = types.MethodType(_mlx_save_pretrained_gguf, model)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5938,6 +5938,9 @@ def _patch_mlx_saving(model, tokenizer):
     _patch_mlx_tokenizer_call(tokenizer)
     model._tokenizer = tokenizer
     model.generate               = types.MethodType(_mlx_generate, model)
+    if not getattr(model, "_is_vlm_model", False):
+        from .generate import fast_generate
+        model.fast_generate      = types.MethodType(fast_generate, model)
     model.save_pretrained        = types.MethodType(_mlx_save_pretrained_merged, model)
     model.save_pretrained_merged = types.MethodType(_mlx_save_pretrained_merged, model)
     model.save_pretrained_gguf   = types.MethodType(_mlx_save_pretrained_gguf, model)


### PR DESCRIPTION
## What this adds

A shared batched-generation engine for the MLX backend: one module that batch-generates from the training-resident model — text through mlx-lm, vision through mlx-vlm — with an RL-grade result contract. Results come back in input order carrying the sampled token ids, logprobs aligned one-to-one with those ids, a finish reason, and the matched stop string where one fired.

Until now the MLX backend generated one sequence at a time. Batching is where RL rollouts and generation-based evaluation spend their wall-clock, so this is the seam those need.

```python
from unsloth_zoo.mlx.generate import GenerationRequest, GenerationDefaults, generate_batch

results = generate_batch(model, tokenizer, [
    GenerationRequest(prompt="The capital of France is", max_tokens=32),
    GenerationRequest(prompt="Two plus two equals", max_tokens=32),
], defaults=GenerationDefaults(stop_strings=("\n\n",)))

results[0].token_ids   # sampled ids, terminating EOS excluded
results[0].logprobs    # aligned 1:1 with token_ids
results[0].finish_reason, results[0].stop_match
```

`model.fast_generate(prompts, **kwargs)` is bound for text and vision models as a thin convenience layer over the same core.

## Why it is built on the event stream

The released convenience helpers cannot carry this contract: `mlx_lm.batch_generate` returns texts, stats and caches, and mlx-vlm's `batch_generate` discards per-token data. Both backends' `BatchGenerator` classes do emit the full per-token event, so each adapter drives its own backend's loop and normalises those events into the shared result type. This is orchestration around upstream decoding, not a reimplementation of it — no decode math is duplicated here.

The vision path additionally bypasses `_generate_batch`, because every supported release force-templates the prompt inside it. Bypassing means reproducing two behaviours upstream owns: image-shape grouping, and the token-axis chunked-prefill policy, both of which the adapter applies from whichever form the installed release defines.

## Compatibility

Declared floors are unchanged (`mlx-lm>=0.28.3`, `mlx-vlm>=0.4.4`, both unbounded above). The vision adapter spans **mlx-vlm 0.4.4 through 0.6.7 by capability detection, never by version comparison**, following the range-compat pattern established by #898 and #952.

The releases differ more than a version check would suggest: 0.5.0 changes the decode protocol (per-row `prompt_kwargs`, a `has_work` loop, a tuple-returning `next()`), the per-token event moves from `BatchGenerator.Response` with a vocabulary logprob vector to `GenerationBatch.Response` with a scalar `token_logprob`, sequence cancellation appears at 0.5.0, and `quantized_kv_start` is accepted from 0.5.0 but only reaches the batch cache from 0.6.5. Each of those is detected from the installed API shape.

This was verified by running against per-version installs rather than by reading source:

| mlx-vlm | logic suite | bound module | protocol | cancellation | start index reaches cache |
|---|---|---|---|---|---|
| 0.4.4 | 48 passed | `mlx_vlm.generate` | pre-0.5.0 | no | no |
| 0.5.0 | 48 passed | — | per-row | yes | no |
| 0.6.0 / 0.6.4 | — | — | per-row | yes | no |
| 0.6.5 / 0.6.7 | 48 passed (0.6.7) | `mlx_vlm.generate.ar` | per-row | yes | yes |

The five real-model tests also pass against 0.6.7 with transformers 5.10.2.

Newer releases are not merely tolerated — the adapter takes the better path wherever one exists, so nothing is held back to a lowest common denominator:

| behaviour | 0.4.4 | 0.5.0 and later |
|---|---|---|
| prompt-kwarg splitting | local MRoPE-aware fallback | upstream's own splitter (MRoPE-aware from 0.6.4) |
| stop-string cancellation | later events dropped, decode continues | `remove(uid)` — 2 tokens wasted against 0.4.4's 10 on the same run |
| batching within a group | split into chunks, because embedding kwargs slice from row zero | whole groups in one generator |
| chunked-prefill policy | `no_chunked_prefill` | `_chunked_prefill_enabled` (0.6.2+) |
| generator teardown | no `close()`; the wrapper restores limits | `close()` restores upstream's own wired limit |

Roughly 150–200 lines of this module exist solely to support the 0.4.4 floor — the second decode protocol, the second event shape, the cancellation fallback, the row-zero chunking, and the local splitter. If the declared floor is ever raised, they delete mechanically rather than needing a redesign; the capability checks that select them are already the seams.

## Benchmarks

Apple Silicon, 128 tokens per prompt, median of three runs, peak memory per point.

Text — `Qwen/Qwen3-1.7B` (mlx-lm 0.31.3; the text path does not involve mlx-vlm):

| Batch | Sequential | Batched | Speedup | Peak |
|---|---|---|---|---|
| 1 | 80.07 tok/s | 76.89 tok/s | 0.96x | 3.48 GB |
| 4 | 81.51 tok/s | 183.88 tok/s | 2.26x | 3.62 GB |
| 8 | 87.59 tok/s | 301.91 tok/s | 3.45x | 3.80 GB |
| 16 | 73.79 tok/s | 360.37 tok/s | **4.88x** | 4.25 GB |

Vision — `unsloth/gemma-4-E4B-it-UD-MLX-4bit` on mlx-vlm 0.6.7:

| Batch | Sequential | Batched | Speedup | Peak |
|---|---|---|---|---|
| 1 | 29.72 tok/s | 29.39 tok/s | 0.99x | 7.28 GB |
| 4 | 31.89 tok/s | 45.41 tok/s | 1.42x | 8.35 GB |
| 8 | 33.83 tok/s | 53.60 tok/s | 1.58x | 10.47 GB |
| 16 | 32.12 tok/s | 55.23 tok/s | 1.72x | 14.98 GB |

**The two paths scale differently, and the vision one has a memory cost worth planning around.** Text batching is close to free: 4.88x throughput at B=16 for 0.77 GB more than B=1. Vision gains less and costs more — 1.72x at B=16 for 7.7 GB more than B=1, because each request carries its own image embeddings, so batching only amortises the decode phase while prefill stays proportional to the batch. On a 16 GB machine, vision B=16 at 14.98 GB is at the edge; B=8 at 10.47 GB is the more comfortable operating point. Generation length matters too: at 24 tokens per prompt the same text configuration measured 2.45x at B=8, against 3.45x here, because a longer generation amortises the batch setup over more decode steps.

**Vision batching is prefill-bound, which is why it gains less and costs more.** Splitting the vision run into prefill and decode, a 64x64 image expands a 14-token prompt to 271 tokens, so 95% of the sequence is image:

| Batch | Prefill | Prefill share | Decode/token |
|---|---|---|---|
| 1 | 0.45s | 51% | 3.3 ms |
| 4 | 1.57s | 73% | 4.4 ms |
| 8 | 3.32s | 73% | 9.5 ms |
| 16 | 7.36s | 69% | 25.3 ms |

Prefill is essentially linear in batch size — about 0.46s per request at every batch — because it is compute-bound over those image tokens, and batching does not reduce the work. Decode is what batching amortises, improving from 3.3 to about 1.2 ms per request per token. Text prompts are short enough to be decode-dominated, which is why they scale to 4.88x while vision reaches 1.72x. Memory splits the same way: a floor of roughly 10 GB for weights and the vision encoder, plus about 0.35 GB per request of KV cache over the 271-token sequences, which is 5.64 GB of the 15.66 GB peak at B=16.

**Lowering `prefill_batch_size` is worth it on vision.** At B=16 with 128 tokens:

| `prefill_batch_size` | Time | Peak |
|---|---|---|
| 4 | 12.89s | **12.74 GB** |
| 8 (default) | 13.64s | 15.65 GB |
| 16 | 12.43s | 16.27 GB |

Peak memory falls about 3.5 GB with no time cost outside run-to-run noise, which can decide whether a batch fits on a 16 GB machine. The knob is already on `GenerationDefaults`; the default stays 8 because it suits the text path, where prefill is a small share.

**At B=1 both paths sit at parity** (0.96x text, 0.99x vision) — batching neither helps nor meaningfully hurts a single request. A much smaller model does show a real penalty there (`SmolLM-135M-Instruct-4bit` measured 0.71x), where fixed batching overhead is large relative to the model itself. A single-request fast path is a sensible follow-up but is not needed for correctness.

## Behaviour worth reviewing closely

**Stop strings.** Both paths run the same incremental scanner, trimming tokens back to the boundary before the match, so a stop landing mid-token drops that token rather than splitting it. Where the installed release exposes `remove()` the matching sequence is cancelled immediately; where it does not, the sequence keeps decoding upstream and its later events are ignored. Visible results are identical either way — measured on the same scenario, 0.6.7 wasted 2 tokens of decode against 0.4.4's 10.

**Audio falls back to sequential decoding**, one request at a time, while the rest of the batch still runs batched. No supported release batches audio. The terminal event of upstream's sequential stream repeats the last token and its logprobs, and older releases attach no finish reason to mark it, so an event is committed only once a successor arrives: the terminal one contributes its finalised text but never another token or logprob. Where no finish reason is reported, it is inferred by asking the tokenizer's own stopping criteria — processors carry stop ids their tokenizer's EOS attributes do not list, so reconstructing that set would report a genuine stop as a length cut-off.

**KV-quantisation controls are refused on the vision path**, and this is a deliberate decision rather than an omission. Whether such a control bounds anything depends on the release, on the rest of the configuration (no quantised cache without `kv_bits`; the turbo cache ignores `kv_group_size`; the uniform cache ignores `quantized_kv_start`), and on the model's own cache classes — `_make_cache` dispatches per layer, and caches carrying their own `to_batch` conversion bypass `kv_bits` entirely. The third of those is answerable only by running upstream's dispatch against the real model. Rather than report a bound that may not exist, the engine forwards none of them and points at `model.generate`, where mlx-vlm's own KV quantisation works. Forwarding them behind a per-layer report is a reasonable follow-up.

**Train/generate switching** is handled by a `generation_mode(model)` context that flips eval flags and snapshots the process-global memory, cache and wired limits, restoring them exception- and nest-safely. It deliberately leaves gradient-checkpointing class patches installed: those are class-level `__call__` patches, so unpatching during generation would mutate every instance and invalidate a live compiled training step.

## Validation

48 logic tests and 5 real-model Metal tests, the latter covering batched-versus-sequential greedy equivalence against upstream's own sequential decoding — exact token ids, logprobs within tolerance, matching text — plus memory-limit restoration, compiled training state surviving a generation burst, and the vision ordering and stop-string contracts.

Both suites are wired into the Apple Silicon workflow. They previously ran in no job at all: that workflow names each file it executes, and these were never added.

```bash
python -m pytest tests/test_mlx_generate.py tests/test_mlx_generate_metal.py -v
```

## Notes for reviewers

- New module plus a small loader binding; `trainer.py` and `utils.py` are untouched, so this does not overlap #832.
- The test share is above the usual bar for this repository. The coverage that could be relocated without losing an invariant was relocated; an attempt to go further was reverted after review showed it deleted the only executable guard for 0.6.x initialisation.
- No continuous batching or slot scheduler here — the typed `generate_batch(requests)` core is the seam a scheduler would plug into.



