### PR TITLE
feat(mlx): PEFT adapter interop for the MLX backend

### DIFF
--- a/tests/test_mlx_adapter_interop_metal.py
+++ b/tests/test_mlx_adapter_interop_metal.py
@@ -1,0 +1,434 @@
+"""PEFT <-> MLX adapter interop contracts, on genuine peft-generated files."""
+
+import json
+import os
+import sys
+
+import numpy as np
+import pytest
+from pathlib import Path
+
+mx = pytest.importorskip("mlx.core")
+torch = pytest.importorskip("torch")
+peft = pytest.importorskip("peft")
+transformers = pytest.importorskip("transformers")
+nn = pytest.importorskip("mlx.nn")
+load_model = pytest.importorskip("mlx_lm.utils").load_model
+st_load_file = pytest.importorskip("safetensors.torch").load_file
+
+from unsloth_zoo.mlx.utils import (
+    attach_and_bind_peft_adapter,
+    detect_adapter_format,
+    normalize_peft_adapter_config,
+)
+from unsloth_zoo.saving_utils import (
+    MLX_WEIGHTS_FILE,
+    PEFT_WEIGHTS_FILE,
+    convert_mlx_dir_to_peft,
+    convert_peft_dir_to_mlx,
+    _resolve_pattern,
+)
+
+VOCAB, HIDDEN, LAYERS = 256, 64, 2
+IDS = [1, 5, 9, 13]
+
+
+@pytest.fixture(scope="module")
+def base_dir(tmp_path_factory):
+    path = tmp_path_factory.mktemp("tiny-llama-base")
+    config = transformers.LlamaConfig(
+        vocab_size=VOCAB, hidden_size=HIDDEN, intermediate_size=128,
+        num_hidden_layers=LAYERS, num_attention_heads=4,
+        num_key_value_heads=2, max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    transformers.LlamaForCausalLM(config).to(torch.float32).save_pretrained(
+        path, safe_serialization=True
+    )
+    transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/llama-tokenizer"
+    ).save_pretrained(path)
+    return str(path)
+
+
+def _make_peft_adapter(base_dir, out, dtype=torch.float32, **lora_kwargs):
+    model = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=dtype)
+    kwargs = dict(r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"])
+    kwargs.update(lora_kwargs)
+    wrapped = peft.get_peft_model(model, peft.LoraConfig(**kwargs))
+    torch.manual_seed(7)
+    with torch.no_grad():
+        for name, param in wrapped.named_parameters():
+            if "lora_B" in name:
+                param.copy_(torch.randn_like(param) * 0.05)
+            if "lora_" in name:
+                # peft autocasts adapter params to fp32 regardless of the
+                # base dtype; force the requested dtype so bf16 runs test
+                # bf16 tensors rather than fp32 twice.
+                param.data = param.data.to(dtype)
+    wrapped.save_pretrained(out)
+    cfg_path = os.path.join(out, "adapter_config.json")
+    cfg = json.load(open(cfg_path))
+    cfg["base_model_name_or_path"] = base_dir
+    json.dump(cfg, open(cfg_path, "w"))
+    return wrapped, cfg
+
+
+def _peft_logits(wrapped, ids=IDS):
+    with torch.no_grad():
+        return wrapped(torch.tensor([ids])).logits[0, -1].float().numpy()
+
+
+def _mlx_logits(model, ids=IDS):
+    out = model(mx.array([ids]))
+    logits = out.logits if hasattr(out, "logits") else out
+    return np.array(logits[0, -1].astype(mx.float32))
+
+
+def test_format_detection_and_fresh_destination(tmp_path, base_dir):
+    d = tmp_path / "a"
+    d.mkdir()
+    with pytest.raises(FileNotFoundError):
+        detect_adapter_format(str(d))
+    (d / PEFT_WEIGHTS_FILE).write_bytes(b"")
+    (d / MLX_WEIGHTS_FILE).write_bytes(b"")
+    with pytest.raises(ValueError, match="both"):
+        detect_adapter_format(str(d))
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    (tmp_path / "dst").mkdir()
+    with pytest.raises(ValueError, match="already exists"):
+        convert_peft_dir_to_mlx(peft_dir, str(tmp_path / "dst"), {"num_hidden_layers": LAYERS})
+
+
+@pytest.mark.parametrize("field,value,match", [
+    ("use_dora", True, "DoRA"),
+    ("modules_to_save", ["lm_head"], "modules_to_save"),
+    ("target_parameters", ["experts.gate_up_proj"], "expert-parameter"),
+    ("alora_invocation_tokens", [1, 2], "aLoRA"),
+    ("bias", "all", "bias"),
+    ("corda_config", {"x": 1}, "corda_config"),
+    ("layer_replication", [[0, 1], [0, 1]], "layer_replication"),
+    ("use_qalora", True, "QALoRA"),
+    ("lora_bias", True, "lora_bias"),
+    ("init_lora_weights", "pissa_niter_4", "mutated"),
+    ("init_lora_weights", "OLoRA", "mutated"),
+    ("loftq_config", {"bits": 4}, "LoftQ"),
+])
+def test_normalize_rejects_by_name(field, value, match):
+    cfg = {"peft_type": "LORA", "r": 8, "lora_alpha": 16, field: value}
+    with pytest.raises(ValueError, match=match):
+        normalize_peft_adapter_config(cfg)
+
+
+def test_pattern_resolution_and_eva_acceptance():
+    normalize_peft_adapter_config({"peft_type": "LORA", "r": 8, "init_lora_weights": "eva", "eva_config": {"rho": 1.0}})
+    path = "model.layers.0.self_attn.q_proj"
+    assert _resolve_pattern({"q_proj": 4}, path) == 4
+    assert _resolve_pattern({"layers.0": 4}, path) is None  # end-anchored
+    assert _resolve_pattern({"layers.0.self_attn.q_proj": 2, "q_proj": 4}, path) == 2
+    with pytest.raises(ValueError, match="regular expression"):
+        _resolve_pattern({"(": 1}, "x")
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_roundtrip_bitwise_with_revision_and_nested_layers(tmp_path, base_dir, dtype):
+    peft_dir = str(tmp_path / "peft")
+    _, cfg = _make_peft_adapter(base_dir, peft_dir, dtype=dtype)
+    cfg["revision"] = "deadbeef"
+    json.dump(cfg, open(os.path.join(peft_dir, "adapter_config.json"), "w"))
+    mlx_dir, back_dir = str(tmp_path / "mlx"), str(tmp_path / "back")
+    convert_peft_dir_to_mlx(
+        peft_dir, mlx_dir, {"text_config": {"num_hidden_layers": LAYERS}}
+    )
+    mlx_cfg = json.load(open(os.path.join(mlx_dir, "adapter_config.json")))
+    assert mlx_cfg["num_layers"] == LAYERS
+    assert mlx_cfg["base_model_revision"] == "deadbeef"
+    assert mlx_cfg["lora_parameters"]["keys"] == mlx_cfg["unsloth_mlx_lora_module_paths"]
+    convert_mlx_dir_to_peft(mlx_dir, back_dir)
+
+    orig = st_load_file(os.path.join(peft_dir, PEFT_WEIGHTS_FILE))
+    back = st_load_file(os.path.join(back_dir, PEFT_WEIGHTS_FILE))
+    assert set(orig) == set(back)
+    for key in orig:
+        assert orig[key].dtype == back[key].dtype and torch.equal(orig[key], back[key]), key
+    back_cfg = json.load(open(os.path.join(back_dir, "adapter_config.json")))
+    assert back_cfg["r"] == 8 and back_cfg["lora_alpha"] == pytest.approx(16)
+    assert back_cfg["revision"] == "deadbeef"
+    targets = back_cfg["target_modules"]
+    assert len(targets) == 2 * LAYERS and all(
+        t.startswith("model.layers.") for t in targets
+    )
+    if dtype is torch.float32:  # exported artifact must BIND in peft
+        base = transformers.LlamaForCausalLM.from_pretrained(
+            base_dir, dtype=torch.float32
+        )
+        back_cfg.pop("revision")
+        json.dump(back_cfg, open(os.path.join(back_dir, "adapter_config.json"), "w"))
+        reloaded = peft.PeftModel.from_pretrained(base, back_dir)
+        orig_model = transformers.LlamaForCausalLM.from_pretrained(
+            base_dir, dtype=torch.float32
+        )
+        ref = peft.PeftModel.from_pretrained(orig_model, peft_dir)
+        np.testing.assert_allclose(
+            _peft_logits(reloaded), _peft_logits(ref), atol=1e-5,
+        )
+
+
+def test_attach_matches_peft_forward_with_patterns(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    wrapped, cfg = _make_peft_adapter(
+        base_dir, peft_dir,
+        rank_pattern={"q_proj": 4}, alpha_pattern={"v_proj": 8}, use_rslora=True,
+        lora_dropout=0.1,
+    )
+    wrapped.eval()
+    model, _ = load_model(Path(base_dir))
+    assert attach_and_bind_peft_adapter(
+        model, peft_dir, normalize_peft_adapter_config(cfg)
+    ) == 2 * LAYERS
+    modules = dict(model.named_modules())
+    assert modules["model.layers.0.self_attn.q_proj"].lora_a.shape[-1] == 4
+    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=2e-4)
+    assert model._unsloth_lora_module_scales[
+        "model.layers.0.self_attn.v_proj"
+    ] == pytest.approx(8 / (8 ** 0.5))
+    # Eval-mode host + nonzero lora_dropout must stay deterministic.
+    np.testing.assert_array_equal(_mlx_logits(model), _mlx_logits(model))
+
+
+@pytest.mark.parametrize("key,shape,match", [
+    ("base_model.model.language_model.model.layers.0.self_attn.q_proj.lora_A.weight",
+     (8, HIDDEN), "language_model"),
+    ("base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight",
+     (HIDDEN + 8, 8), "out-dim"),
+])
+def test_attach_rejects_bad_tensors(tmp_path, base_dir, key, shape, match):
+    peft_dir = str(tmp_path / "peft")
+    _, cfg = _make_peft_adapter(base_dir, peft_dir)
+
+    def mutate(tensors):
+        tensors[key] = torch.zeros(*shape)
+        if "language_model" in key:  # give the alien path a complete pair
+            tensors[key.replace("lora_A", "lora_B")] = torch.zeros(HIDDEN, 8)
+
+    from safetensors.torch import save_file
+    wpath = os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
+    tensors = st_load_file(wpath)
+    mutate(tensors)
+    save_file(tensors, wpath)
+    model, _ = load_model(Path(base_dir))
+    with pytest.raises(ValueError, match=match):
+        attach_and_bind_peft_adapter(
+            model, peft_dir, normalize_peft_adapter_config(cfg)
+        )
+
+
+def test_mlx_to_peft_rejects_out_of_layer_paths(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    mlx_dir = str(tmp_path / "mlx")
+    convert_peft_dir_to_mlx(
+        peft_dir, mlx_dir,
+        json.load(open(os.path.join(base_dir, "config.json"))),
+    )
+    tensors = dict(mx.load(os.path.join(mlx_dir, MLX_WEIGHTS_FILE)))
+    tensors["model.embed_tokens.lora_a"] = mx.zeros((VOCAB, 8))
+    tensors["model.embed_tokens.lora_b"] = mx.zeros((8, HIDDEN))
+    mx.save_safetensors(os.path.join(mlx_dir, MLX_WEIGHTS_FILE), tensors)
+    with pytest.raises(ValueError, match="transformer stack"):
+        convert_mlx_dir_to_peft(mlx_dir, str(tmp_path / "back"))
+    with pytest.raises(ValueError, match="embedding LoRA"):
+        convert_mlx_dir_to_peft(
+            mlx_dir, str(tmp_path / "b2"),
+            module_types={"model.embed_tokens": "embedding"},
+        )
+    out = convert_mlx_dir_to_peft(
+        mlx_dir, str(tmp_path / "b3"),
+        module_types={"model.embed_tokens": "linear"},
+    )
+    assert any("embed_tokens.lora_A" in k
+               for k in st_load_file(os.path.join(out, PEFT_WEIGHTS_FILE)))
+    tensors["model.layers.0.mlp.experts.lora_a"] = mx.zeros((4, HIDDEN, 8))
+    tensors["model.layers.0.mlp.experts.lora_b"] = mx.zeros((4, 8, HIDDEN))
+    mx.save_safetensors(os.path.join(mlx_dir, MLX_WEIGHTS_FILE), tensors)
+    with pytest.raises(ValueError, match="non-2-D"):
+        convert_mlx_dir_to_peft(
+            mlx_dir, str(tmp_path / "b4"),
+            module_types={"model.embed_tokens": "linear"},
+        )
+    # VLM wrapper layouts reorder the stack root; they must not pass the gate.
+    tensors["language_model.model.layers.0.self_attn.q_proj.lora_a"] = mx.zeros((HIDDEN, 8))
+    tensors["language_model.model.layers.0.self_attn.q_proj.lora_b"] = mx.zeros((8, HIDDEN))
+    mx.save_safetensors(os.path.join(mlx_dir, MLX_WEIGHTS_FILE), tensors)
+    with pytest.raises(ValueError, match="transformer stack"):
+        convert_mlx_dir_to_peft(mlx_dir, str(tmp_path / "b5"))
+
+
+@pytest.mark.parametrize("lora_kwargs,q_rank,q_scale,v_scale", [
+    ({"rank_pattern": {"q_proj": 4}, "alpha_pattern": {"v_proj": 8}}, 4, 4.0, 1.0),
+    ({"alpha_pattern": {"v_proj": 8}}, 8, 2.0, 1.0),  # scale-only repair path
+])
+def test_converted_dir_full_loop(tmp_path, base_dir, lora_kwargs, q_rank, q_scale, v_scale):
+    peft_dir = str(tmp_path / "peft")
+    wrapped, _ = _make_peft_adapter(base_dir, peft_dir, **lora_kwargs)
+    mlx_dir = str(tmp_path / "mlx")
+    convert_peft_dir_to_mlx(
+        peft_dir, mlx_dir,
+        json.load(open(os.path.join(base_dir, "config.json"))),
+    )
+    assert json.load(open(os.path.join(mlx_dir, "adapter_config.json")))[
+        "unsloth_mlx_requires_unsloth_loader"
+    ] is True
+
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    model, _ = FastMLXModel.from_pretrained(
+        mlx_dir, load_in_4bit=False, max_seq_length=64,
+    )
+    modules = dict(model.named_modules())
+    q = modules["model.layers.0.self_attn.q_proj"]
+    assert q.lora_a.shape[-1] == q_rank and q.scale == pytest.approx(q_scale)
+    assert modules["model.layers.0.self_attn.v_proj"].scale == pytest.approx(v_scale)
+    wrapped_paths = {n for n, m in modules.items() if hasattr(m, "lora_a")}
+    assert len(wrapped_paths) == 2 * LAYERS  # no zero-init topology growth
+    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=5e-3)
+
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    resaved = str(tmp_path / "resaved")
+    save_lora_adapters(model, resaved)
+    recfg = json.load(open(os.path.join(resaved, "adapter_config.json")))
+    assert recfg.get("unsloth_mlx_requires_unsloth_loader") is True
+    model2, _ = FastMLXModel.from_pretrained(
+        resaved, load_in_4bit=False, max_seq_length=64,
+    )
+    m2 = dict(model2.named_modules())
+    assert m2["model.layers.0.self_attn.q_proj"].scale == pytest.approx(q_scale)
+    assert m2["model.layers.0.self_attn.v_proj"].scale == pytest.approx(v_scale)
+    np.testing.assert_allclose(_mlx_logits(model2), _mlx_logits(model), atol=2e-4)
+
+
+def test_loader_import_train_step_save_reload(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    wrapped, _ = _make_peft_adapter(base_dir, peft_dir)
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    model, _ = FastMLXModel.from_pretrained(
+        peft_dir, load_in_4bit=False, max_seq_length=64,
+    )
+    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=5e-3)
+
+    import mlx.optimizers as optim
+    q = dict(model.named_modules())["model.layers.0.self_attn.q_proj"]
+    lora_b_before, base_before = mx.array(q.lora_b), mx.array(q.linear.weight)
+
+    def loss_fn(m):
+        logits = m(mx.array([IDS]))
+        logits = logits.logits if hasattr(logits, "logits") else logits
+        return nn.losses.cross_entropy(logits, mx.array([IDS[1:] + [2]])).mean()
+
+    _, grads = nn.value_and_grad(model, loss_fn)(model)
+    optim.AdamW(learning_rate=1e-2).update(model, grads)
+    mx.eval(model.parameters())
+    assert not mx.array_equal(q.lora_b, lora_b_before)   # LoRA moved
+    assert mx.array_equal(q.linear.weight, base_before)  # base frozen
+
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    saved = str(tmp_path / "saved")
+    save_lora_adapters(model, saved)
+    stepped = _mlx_logits(model)
+    model2, _ = FastMLXModel.from_pretrained(
+        saved, load_in_4bit=False, max_seq_length=64,
+    )
+    np.testing.assert_allclose(_mlx_logits(model2), stepped, atol=2e-4)
+
+
+def test_peft_import_honors_quantized_base_request(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    wrapped, _ = _make_peft_adapter(base_dir, peft_dir)
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    model, _ = FastMLXModel.from_pretrained(peft_dir, max_seq_length=64)
+    q = dict(model.named_modules())["model.layers.0.self_attn.q_proj"]
+    assert type(q.linear) is nn.QuantizedLinear  # default load_in_4bit=True
+    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=0.35)
+
+
+def test_converter_entries_reject_ambiguous_and_subclassed(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _, cfg = _make_peft_adapter(base_dir, peft_dir)
+    mlx_dir = str(tmp_path / "mlx")
+    convert_peft_dir_to_mlx(
+        peft_dir, mlx_dir,
+        json.load(open(os.path.join(base_dir, "config.json"))),
+    )
+    open(os.path.join(mlx_dir, PEFT_WEIGHTS_FILE), "wb").close()
+    with pytest.raises(ValueError, match="both"):
+        convert_mlx_dir_to_peft(mlx_dir, str(tmp_path / "b"))
+    model, _ = load_model(Path(base_dir))
+
+    class _Fusedish(nn.Linear):
+        pass
+    layer0 = model.model.layers[0].self_attn
+    sub = _Fusedish(HIDDEN, HIDDEN, bias=False)
+    sub.weight = layer0.q_proj.weight
+    layer0.q_proj = sub
+    with pytest.raises(ValueError, match="_Fusedish"):
+        attach_and_bind_peft_adapter(
+            model, peft_dir, normalize_peft_adapter_config(cfg),
+        )
+
+
+def test_helpers_import_without_torch(tmp_path):
+    """Default Apple installs exclude torch: detection/validation and the
+    saving_utils module itself must import and run with torch blocked."""
+    import subprocess, sys, textwrap
+    script = textwrap.dedent("""
+        import importlib.abc, sys
+        class _Block(importlib.abc.MetaPathFinder):
+            BLOCKED = ("torch", "bitsandbytes", "peft", "triton", "xformers")
+            def find_spec(self, name, path=None, target=None):
+                if name.split(".")[0] in self.BLOCKED:
+                    raise ModuleNotFoundError("blocked: " + name)
+        sys.meta_path.insert(0, _Block())
+        import unsloth_zoo.saving_utils as s
+        cfg = {"peft_type": "LORA", "r": 8, "lora_alpha": 16}
+        assert s.normalize_peft_adapter_config(cfg)["_unsloth_peft_import"]
+        import unsloth_zoo.mlx.utils as mu
+        assert mu.normalize_peft_adapter_config(dict(cfg))["_unsloth_peft_import"]
+        print("OK")
+    """)
+    out = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    assert out.returncode == 0 and "OK" in out.stdout, out.stderr[-2000:]
+
+
+def test_peft_import_quant_override_predicate():
+    from unsloth_zoo.mlx.loader import _peft_import_quant_override as ov
+    assert ov({"load_in_4bit": False})            # explicit full-precision
+    assert ov({"load_in_8bit": True})
+    assert ov({"q_bits": 8})
+    assert ov({"quantization_config": {"load_in_8bit": True}})
+    assert not ov({"load_in_4bit": True})         # untouched default
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_converters_torch_fallback_without_mlx(tmp_path, base_dir, monkeypatch, dtype):
+    """mlx-less hosts take the torch IO fallback; it must produce identical
+    artifacts (the two backends differ in save-argument order)."""
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir, dtype=dtype)
+    # Poison the import machinery the way a torch-only host resolves it:
+    # `import mlx.core` inside _tensor_backend raises ImportError.
+    for name in ("mlx", "mlx.core"):
+        monkeypatch.setitem(sys.modules, name, None)
+    convert_peft_dir_to_mlx(
+        peft_dir, str(tmp_path / "m2"), {"num_hidden_layers": LAYERS}
+    )
+    convert_mlx_dir_to_peft(str(tmp_path / "m2"), str(tmp_path / "back"))
+    orig = st_load_file(os.path.join(peft_dir, PEFT_WEIGHTS_FILE))
+    back = st_load_file(os.path.join(str(tmp_path / "back"), PEFT_WEIGHTS_FILE))
+    assert set(orig) == set(back)
+    for key in orig:
+        assert orig[key].dtype == back[key].dtype, key
+        assert torch.equal(orig[key], back[key]), key

--- a/tests/test_mlx_adapter_interop_metal.py
+++ b/tests/test_mlx_adapter_interop_metal.py
@@ -63,11 +63,10 @@ def _make_peft_adapter(base_dir, out, dtype=torch.float32, **lora_kwargs):
             if "lora_B" in name:
                 param.copy_(torch.randn_like(param) * 0.05)
             if "lora_" in name:
-                # peft autocasts adapter params to fp32 regardless of the
-                # base dtype; force the requested dtype so bf16 runs test
-                # bf16 tensors rather than fp32 twice.
+                # peft autocasts adapter params to fp32; force the dtype so
+                # bf16 runs exercise real bf16 tensors.
                 param.data = param.data.to(dtype)
-    wrapped.save_pretrained(out)
+    wrapped.save_pretrained(out, save_embedding_layers=False)
     cfg_path = os.path.join(out, "adapter_config.json")
     cfg = json.load(open(cfg_path))
     cfg["base_model_name_or_path"] = base_dir
@@ -139,8 +138,9 @@ def test_roundtrip_bitwise_with_revision_and_nested_layers(tmp_path, base_dir, d
     cfg["revision"] = "deadbeef"
     json.dump(cfg, open(os.path.join(peft_dir, "adapter_config.json"), "w"))
     mlx_dir, back_dir = str(tmp_path / "mlx"), str(tmp_path / "back")
+    # Path-typed destination must keep working (os.PathLike contract).
     convert_peft_dir_to_mlx(
-        peft_dir, mlx_dir, {"text_config": {"num_hidden_layers": LAYERS}}
+        peft_dir, tmp_path / "mlx", {"text_config": {"num_hidden_layers": LAYERS}}
     )
     mlx_cfg = json.load(open(os.path.join(mlx_dir, "adapter_config.json")))
     assert mlx_cfg["num_layers"] == LAYERS
@@ -432,3 +432,145 @@ def test_converters_torch_fallback_without_mlx(tmp_path, base_dir, monkeypatch, 
     for key in orig:
         assert orig[key].dtype == back[key].dtype, key
         assert torch.equal(orig[key], back[key]), key
+
+
+def test_save_lora_adapters_peft_format(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    wrapped, _ = _make_peft_adapter(base_dir, peft_dir)
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    model, _ = FastMLXModel.from_pretrained(
+        peft_dir, load_in_4bit=False, max_seq_length=64,
+    )
+    with pytest.raises(ValueError, match="adapter_format"):
+        save_lora_adapters(model, str(tmp_path / "x"), adapter_format="bogus")
+    out = str(tmp_path / "exported")
+    model.save_lora_adapters(out, adapter_format="peft")  # bound method
+    base = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=torch.float32)
+    reexported = peft.PeftModel.from_pretrained(base, out)
+    np.testing.assert_allclose(
+        _peft_logits(reexported), _mlx_logits(model), atol=5e-3,
+    )
+    from unsloth_zoo.saving_utils import export_peft_adapter
+    with pytest.raises(ValueError, match="base_weights_source"):
+        export_peft_adapter(str(tmp_path / "m"), str(tmp_path / "n"),
+                            base_weights_source=object())
+
+
+def test_peft_export_includes_lm_head_on_mirrored_layout(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    wrapped, _ = _make_peft_adapter(
+        base_dir, peft_dir, target_modules=["q_proj", "lm_head"],
+        rank_pattern={"q_proj": 4},
+    )
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    model, _ = FastMLXModel.from_pretrained(
+        peft_dir, load_in_4bit=False, max_seq_length=64,
+    )
+    out = str(tmp_path / "exported")
+    save_lora_adapters(model, out, adapter_format="peft")
+    keys = set(st_load_file(os.path.join(out, PEFT_WEIGHTS_FILE)))
+    assert any("lm_head.lora_A" in k for k in keys)
+    exported_cfg_text = open(os.path.join(out, "adapter_config.json")).read()
+    assert "rank_pattern" in exported_cfg_text
+    assert "unsloth_mlx" not in exported_cfg_text  # no zoo-internal leaks
+    base = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=torch.float32)
+    reexported = peft.PeftModel.from_pretrained(base, out)
+    # An lm_head adapter amplifies the zoo loader's bf16 base rounding at
+    # the output layer; allow slightly more than the in-stack cases.
+    np.testing.assert_allclose(
+        _peft_logits(reexported), _mlx_logits(model), atol=8e-3,
+    )
+
+
+def test_peft_export_rejects_unsupported_wrapper(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    model, _ = FastMLXModel.from_pretrained(
+        peft_dir, load_in_4bit=False, max_seq_length=64,
+    )
+
+    class _FusedWrap(nn.Module):
+        # Plain factors AND a stock .linear base: the wrapper type itself
+        # is what makes the semantics non-plain.
+        def __init__(self, inner):
+            super().__init__()
+            self.lora_a = inner.lora_a
+            self.lora_b = inner.lora_b
+            self.linear = inner.linear
+
+    layers = model.model.layers
+    layers[0].self_attn.q_proj = _FusedWrap(layers[0].self_attn.q_proj)
+    with pytest.raises(ValueError, match="_FusedWrap"):
+        save_lora_adapters(model, str(tmp_path / "x"), adapter_format="peft")
+
+
+def test_conversion_failure_leaves_no_destination(tmp_path, base_dir, monkeypatch):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    import unsloth_zoo.saving_utils as su
+    dst = str(tmp_path / "mlx")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated write failure")
+
+    monkeypatch.setattr(su.json, "dump", boom)
+    with pytest.raises(RuntimeError, match="simulated"):
+        convert_peft_dir_to_mlx(peft_dir, dst, {"num_hidden_layers": LAYERS})
+    monkeypatch.undo()
+    assert not os.path.exists(dst)  # failed claim fully released
+    convert_peft_dir_to_mlx(peft_dir, dst, {"num_hidden_layers": LAYERS})
+    assert os.path.exists(os.path.join(dst, MLX_WEIGHTS_FILE))
+    # Trailing-separator spelling must not break staging or publication.
+    dst2 = str(tmp_path / "mlx2") + os.sep
+    convert_peft_dir_to_mlx(peft_dir, dst2, {"num_hidden_layers": LAYERS})
+    assert os.path.exists(os.path.join(str(tmp_path / "mlx2"), MLX_WEIGHTS_FILE))
+
+
+def test_peft_export_rejects_mixed_dropout(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir, lora_dropout=0.1)
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    model, _ = FastMLXModel.from_pretrained(
+        peft_dir, load_in_4bit=False, max_seq_length=64,
+    )
+    modules = dict(model.named_modules())
+    modules["model.layers.0.self_attn.q_proj"].dropout = nn.Dropout(p=0.4)
+    with pytest.raises(ValueError, match="different lora_dropout"):
+        save_lora_adapters(model, str(tmp_path / "x"), adapter_format="peft")
+
+
+def test_dangling_symlink_destination_refused(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    link = tmp_path / "link"
+    link.symlink_to(tmp_path / "missing-target")
+    for spelling in (str(link), str(link) + os.sep):
+        with pytest.raises(ValueError, match="already exists"):
+            convert_peft_dir_to_mlx(
+                peft_dir, spelling, {"num_hidden_layers": LAYERS}
+            )
+    assert not (tmp_path / "missing-target").exists()
+
+
+def test_exported_patterns_are_exact_anchored(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir, rank_pattern={"q_proj": 4})
+    mlx_dir, back = str(tmp_path / "m"), str(tmp_path / "b")
+    convert_peft_dir_to_mlx(
+        peft_dir, mlx_dir,
+        json.load(open(os.path.join(base_dir, "config.json"))),
+    )
+    convert_mlx_dir_to_peft(mlx_dir, back)
+    cfg = json.load(open(os.path.join(back, "adapter_config.json")))
+    pattern = cfg["rank_pattern"]
+    assert pattern and all(k.startswith("^") for k in pattern)
+    key, rank = next(iter(sorted(pattern.items())))
+    # Exact under peft's matcher: hits its own path, never a dotted suffix.
+    path = key[1:].replace("\\.", ".")
+    assert _resolve_pattern({key: rank}, path) == rank
+    assert _resolve_pattern({key: rank}, "prefix." + path) is None

--- a/tests/test_mlx_adapter_interop_metal.py
+++ b/tests/test_mlx_adapter_interop_metal.py
@@ -790,3 +790,212 @@ def test_full_state_shape_mismatch_rejected(tmp_path, base_dir):
     from unsloth_zoo.mlx.loader import FastMLXModel
     with pytest.raises(Exception, match="shape mismatch"):
         FastMLXModel.from_pretrained(peft_dir, load_in_4bit=False, max_seq_length=64)
+
+
+def test_nested_text_tower_bridge(tmp_path, base_dir):
+    """A PEFT adapter names modules one level shallower than an mlx-vlm
+    tree nests them; the import resolves that nesting and the export emits
+    Hugging-Face-native paths again."""
+    peft_dir = str(tmp_path / "peft")
+    wrapped, cfg = _make_peft_adapter(base_dir, peft_dir)
+    model, _ = load_model(Path(base_dir))
+
+    class _Tower(nn.Module):
+        """Stand-in for the mlx-vlm wrapper: the text model nested one level."""
+        def __init__(self, inner):
+            super().__init__()
+            self.language_model = inner
+
+        def __call__(self, *args, **kwargs):
+            return self.language_model(*args, **kwargs)
+
+    nested = _Tower(model)
+    assert attach_and_bind_peft_adapter(
+        nested, peft_dir, normalize_peft_adapter_config(cfg),
+    ) == 2 * LAYERS
+    assert nested._unsloth_tree_prefix == "language_model."
+    np.testing.assert_allclose(
+        _mlx_logits(nested), _peft_logits(wrapped), atol=5e-3,
+    )
+    # Live state is keyed by the real (nested) module paths.
+    assert all(
+        k.startswith("language_model.")
+        for k in nested._unsloth_lora_module_scales
+    )
+
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    out = str(tmp_path / "back")
+    save_lora_adapters(nested, out, adapter_format="peft")
+    back_cfg = json.load(open(os.path.join(out, "adapter_config.json")))
+    keys = st_load_file(os.path.join(out, PEFT_WEIGHTS_FILE))
+    assert all(t.startswith("model.layers.") for t in back_cfg["target_modules"])
+    assert all("language_model" not in k for k in keys)
+    base = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=torch.float32)
+    reloaded = peft.PeftModel.from_pretrained(base, out)
+    np.testing.assert_allclose(
+        _peft_logits(reloaded), _peft_logits(wrapped), atol=5e-3,
+    )
+
+
+def test_nested_tower_is_never_guessed(tmp_path, base_dir):
+    """A tower outside the known text-tower names is not inferred, and a
+    natively nested adapter without import provenance is not unnested: both
+    keep the named refusal rather than binding the wrong module set."""
+    from unsloth_zoo.mlx.utils import _resolve_tree_prefix, save_lora_adapters
+    from mlx_lm.tuner.lora import LoRALinear
+
+    paths = ["model.layers.0.self_attn.q_proj"]
+    assert _resolve_tree_prefix({"vision_tower." + paths[0]: 1}, paths) is None
+    assert _resolve_tree_prefix({"language_model." + paths[0]: 1}, paths) == "language_model."
+
+    class _Tower(nn.Module):
+        def __init__(self, inner):
+            super().__init__()
+            self.language_model = inner
+
+    inner, _ = load_model(Path(base_dir))
+    model = _Tower(inner)
+    attn = model.language_model.model.layers[0].self_attn
+    attn.q_proj = LoRALinear.from_base(attn.q_proj, r=8, dropout=0.0, scale=2.0)
+    with pytest.raises(ValueError, match="outside a Hugging-Face-mirroring|not possible"):
+        save_lora_adapters(model, str(tmp_path / "out"), adapter_format="peft")
+
+
+def _nested(model):
+    """Wrap a text model the way mlx-vlm nests it."""
+    class _Tower(nn.Module):
+        def __init__(self, inner):
+            super().__init__()
+            self.language_model = inner
+        def __call__(self, *a, **kw):
+            return self.language_model(*a, **kw)
+    return _Tower(model)
+
+
+def test_tree_prefix_bridge_resolution():
+    """The nesting resolver: unique prefix wins, ambiguity and unknown
+    layouts fall through to the caller's per-path report."""
+    from unsloth_zoo.mlx.utils import _resolve_tree_prefix
+
+    flat = {"model.layers.0.self_attn.q_proj": 1, "model.layers.1.self_attn.q_proj": 1}
+    nested = {"language_model." + k: v for k, v in flat.items()}
+    paths = list(flat)
+
+    assert _resolve_tree_prefix(flat, paths) == ""
+    assert _resolve_tree_prefix(nested, paths) == "language_model."
+    # A vision tower is never a candidate, even when its shapes would fit:
+    # binding a language adapter onto it would be silently wrong.
+    vision_only = {"vision_tower." + k: v for k, v in flat.items()}
+    assert _resolve_tree_prefix(vision_only, paths) is None
+    both = dict(nested)
+    both.update(vision_only)
+    assert _resolve_tree_prefix(both, paths) == "language_model."
+    # A tail that exists nowhere resolves to nothing.
+    assert _resolve_tree_prefix(nested, ["decoder.layers.0.attn.q_proj"]) is None
+    # A prefix must map EVERY path, not just one.
+    partial = dict(nested)
+    partial.pop("language_model.model.layers.1.self_attn.q_proj")
+    assert _resolve_tree_prefix(partial, paths) is None
+
+
+def test_nested_tower_survives_mlx_reload_and_dir_conversion(tmp_path, base_dir):
+    """The nesting marker persists through MLX save -> reload -> re-save, so a
+    later directory-only conversion still emits Hugging-Face-native paths."""
+    from pathlib import Path
+    from unsloth_zoo.mlx.utils import (
+        attach_and_bind_peft_adapter, normalize_peft_adapter_config,
+        save_lora_adapters,
+    )
+    from unsloth_zoo.saving_utils import convert_mlx_dir_to_peft
+
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    cfg = normalize_peft_adapter_config(
+        json.load(open(os.path.join(peft_dir, "adapter_config.json")))
+    )
+    inner, _ = load_model(Path(base_dir))
+    model = _nested(inner)
+    attach_and_bind_peft_adapter(model, peft_dir, cfg)
+
+    first = str(tmp_path / "mlx1")
+    save_lora_adapters(model, first)
+    saved = json.load(open(os.path.join(first, "adapter_config.json")))
+    assert saved["unsloth_mlx_tree_prefix"] == "language_model."
+    assert any(k.startswith("language_model.")
+               for k in mx.load(os.path.join(first, MLX_WEIGHTS_FILE)))
+
+    # Directory-only conversion honours the recorded marker.
+    back = str(tmp_path / "back")
+    convert_mlx_dir_to_peft(first, back)
+    keys = st_load_file(os.path.join(back, PEFT_WEIGHTS_FILE))
+    assert keys and all("language_model" not in k for k in keys)
+
+    # An explicit empty prefix means "do not unnest", unlike omitting it.
+    with pytest.raises(ValueError, match="outside a Hugging-Face-mirroring"):
+        convert_mlx_dir_to_peft(first, str(tmp_path / "raw"), strip_prefix="")
+
+
+def test_nested_tower_ambiguity_and_collisions_refuse(tmp_path, base_dir):
+    """Two towers that both fit, or that collapse onto one path, refuse."""
+    from unsloth_zoo.mlx.utils import _resolve_tree_prefix
+    from unsloth_zoo.saving_utils import convert_mlx_dir_to_peft
+
+    flat = {"model.layers.0.self_attn.q_proj": 1}
+    both = dict(flat, **{"language_model.model.layers.0.self_attn.q_proj": 1})
+    with pytest.raises(ValueError, match="match both the root"):
+        _resolve_tree_prefix(both, list(flat))
+
+    # An artifact carrying the same module in two towers cannot unnest.
+    d = str(tmp_path / "mlx")
+    os.makedirs(d)
+    mx.save_safetensors(os.path.join(d, MLX_WEIGHTS_FILE), {
+        "language_model.model.layers.0.self_attn.q_proj.lora_a": mx.zeros((HIDDEN, 8)),
+        "language_model.model.layers.0.self_attn.q_proj.lora_b": mx.zeros((8, HIDDEN)),
+        "model.layers.0.self_attn.q_proj.lora_a": mx.zeros((HIDDEN, 8)),
+        "model.layers.0.self_attn.q_proj.lora_b": mx.zeros((8, HIDDEN)),
+    })
+    json.dump({"fine_tune_type": "lora", "lora_parameters": {"rank": 8, "scale": 2.0},
+               "unsloth_mlx_tree_prefix": "language_model."},
+              open(os.path.join(d, "adapter_config.json"), "w"))
+    with pytest.raises(ValueError, match="collapses"):
+        convert_mlx_dir_to_peft(d, str(tmp_path / "out"))
+
+
+def test_nested_tower_mixed_dropout_is_still_caught(tmp_path, base_dir):
+    """The dropout guard must see through the nesting, not skip it."""
+    from pathlib import Path
+    from unsloth_zoo.mlx.utils import (
+        attach_and_bind_peft_adapter, normalize_peft_adapter_config,
+        save_lora_adapters,
+    )
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir, lora_dropout=0.1)
+    cfg = normalize_peft_adapter_config(
+        json.load(open(os.path.join(peft_dir, "adapter_config.json")))
+    )
+    inner, _ = load_model(Path(base_dir))
+    model = _nested(inner)
+    attach_and_bind_peft_adapter(model, peft_dir, cfg)
+    wrappers = [m for _n, m in model.named_modules() if hasattr(m, "lora_a")]
+    drop = getattr(wrappers[0], "dropout", None)
+    if drop is not None and hasattr(drop, "_p_1"):
+        drop._p_1 = 1.0 - 0.5   # diverge one module's dropout
+    with pytest.raises(ValueError, match="different lora_dropout"):
+        save_lora_adapters(model, str(tmp_path / "out"), adapter_format="peft")
+
+
+def test_native_nested_adapter_is_not_guessed_on_export(tmp_path, base_dir):
+    """Without import provenance the Hugging Face counterpart of a nested
+    tower is unknowable (a VLM class nests it the other way round), so the
+    export refuses instead of emitting paths that bind the wrong modules."""
+    from pathlib import Path
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    from mlx_lm.tuner.lora import LoRALinear
+
+    inner, _ = load_model(Path(base_dir))
+    model = _nested(inner)
+    layer = model.language_model.model.layers[0].self_attn
+    layer.q_proj = LoRALinear.from_base(layer.q_proj, r=8, dropout=0.0, scale=2.0)
+    assert not getattr(model, "_unsloth_tree_prefix", "")
+    with pytest.raises(ValueError, match="outside a Hugging-Face-mirroring|not possible"):
+        save_lora_adapters(model, str(tmp_path / "out"), adapter_format="peft")

--- a/tests/test_mlx_adapter_interop_metal.py
+++ b/tests/test_mlx_adapter_interop_metal.py
@@ -102,7 +102,6 @@ def test_format_detection_and_fresh_destination(tmp_path, base_dir):
 
 
 @pytest.mark.parametrize("field,value,match", [
-    ("use_dora", True, "DoRA"),
     ("modules_to_save", ["lm_head"], "modules_to_save"),
     ("target_parameters", ["experts.gate_up_proj"], "expert-parameter"),
     ("alora_invocation_tokens", [1, 2], "aLoRA"),
@@ -225,47 +224,6 @@ def test_attach_rejects_bad_tensors(tmp_path, base_dir, key, shape, match):
         )
 
 
-def test_mlx_to_peft_rejects_out_of_layer_paths(tmp_path, base_dir):
-    peft_dir = str(tmp_path / "peft")
-    _make_peft_adapter(base_dir, peft_dir)
-    mlx_dir = str(tmp_path / "mlx")
-    convert_peft_dir_to_mlx(
-        peft_dir, mlx_dir,
-        json.load(open(os.path.join(base_dir, "config.json"))),
-    )
-    tensors = dict(mx.load(os.path.join(mlx_dir, MLX_WEIGHTS_FILE)))
-    tensors["model.embed_tokens.lora_a"] = mx.zeros((VOCAB, 8))
-    tensors["model.embed_tokens.lora_b"] = mx.zeros((8, HIDDEN))
-    mx.save_safetensors(os.path.join(mlx_dir, MLX_WEIGHTS_FILE), tensors)
-    with pytest.raises(ValueError, match="transformer stack"):
-        convert_mlx_dir_to_peft(mlx_dir, str(tmp_path / "back"))
-    with pytest.raises(ValueError, match="embedding LoRA"):
-        convert_mlx_dir_to_peft(
-            mlx_dir, str(tmp_path / "b2"),
-            module_types={"model.embed_tokens": "embedding"},
-        )
-    out = convert_mlx_dir_to_peft(
-        mlx_dir, str(tmp_path / "b3"),
-        module_types={"model.embed_tokens": "linear"},
-    )
-    assert any("embed_tokens.lora_A" in k
-               for k in st_load_file(os.path.join(out, PEFT_WEIGHTS_FILE)))
-    tensors["model.layers.0.mlp.experts.lora_a"] = mx.zeros((4, HIDDEN, 8))
-    tensors["model.layers.0.mlp.experts.lora_b"] = mx.zeros((4, 8, HIDDEN))
-    mx.save_safetensors(os.path.join(mlx_dir, MLX_WEIGHTS_FILE), tensors)
-    with pytest.raises(ValueError, match="non-2-D"):
-        convert_mlx_dir_to_peft(
-            mlx_dir, str(tmp_path / "b4"),
-            module_types={"model.embed_tokens": "linear"},
-        )
-    # VLM wrapper layouts reorder the stack root; they must not pass the gate.
-    tensors["language_model.model.layers.0.self_attn.q_proj.lora_a"] = mx.zeros((HIDDEN, 8))
-    tensors["language_model.model.layers.0.self_attn.q_proj.lora_b"] = mx.zeros((8, HIDDEN))
-    mx.save_safetensors(os.path.join(mlx_dir, MLX_WEIGHTS_FILE), tensors)
-    with pytest.raises(ValueError, match="transformer stack"):
-        convert_mlx_dir_to_peft(mlx_dir, str(tmp_path / "b5"))
-
-
 @pytest.mark.parametrize("lora_kwargs,q_rank,q_scale,v_scale", [
     ({"rank_pattern": {"q_proj": 4}, "alpha_pattern": {"v_proj": 8}}, 4, 4.0, 1.0),
     ({"alpha_pattern": {"v_proj": 8}}, 8, 2.0, 1.0),  # scale-only repair path
@@ -306,40 +264,28 @@ def test_converted_dir_full_loop(tmp_path, base_dir, lora_kwargs, q_rank, q_scal
     assert m2["model.layers.0.self_attn.q_proj"].scale == pytest.approx(q_scale)
     assert m2["model.layers.0.self_attn.v_proj"].scale == pytest.approx(v_scale)
     np.testing.assert_allclose(_mlx_logits(model2), _mlx_logits(model), atol=2e-4)
-
-
-def test_loader_import_train_step_save_reload(tmp_path, base_dir):
-    peft_dir = str(tmp_path / "peft")
-    wrapped, _ = _make_peft_adapter(base_dir, peft_dir)
-    from unsloth_zoo.mlx.loader import FastMLXModel
-    model, _ = FastMLXModel.from_pretrained(
-        peft_dir, load_in_4bit=False, max_seq_length=64,
-    )
-    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=5e-3)
-
+    # One step must move LoRA weights and a save/reload must reproduce the
+    # stepped logits. A native MLX reload leaves the base trainable (longstanding
+    # loader behavior, unlike the PEFT import, which freezes — asserted in
+    # test_peft_import_honors_quantized_base_request).
     import mlx.optimizers as optim
-    q = dict(model.named_modules())["model.layers.0.self_attn.q_proj"]
-    lora_b_before, base_before = mx.array(q.lora_b), mx.array(q.linear.weight)
-
+    q2 = m2["model.layers.0.self_attn.q_proj"]
+    lora_b_before = mx.array(q2.lora_b)
     def loss_fn(m):
         logits = m(mx.array([IDS]))
         logits = logits.logits if hasattr(logits, "logits") else logits
         return nn.losses.cross_entropy(logits, mx.array([IDS[1:] + [2]])).mean()
-
-    _, grads = nn.value_and_grad(model, loss_fn)(model)
-    optim.AdamW(learning_rate=1e-2).update(model, grads)
-    mx.eval(model.parameters())
-    assert not mx.array_equal(q.lora_b, lora_b_before)   # LoRA moved
-    assert mx.array_equal(q.linear.weight, base_before)  # base frozen
-
-    from unsloth_zoo.mlx.utils import save_lora_adapters
-    saved = str(tmp_path / "saved")
-    save_lora_adapters(model, saved)
-    stepped = _mlx_logits(model)
-    model2, _ = FastMLXModel.from_pretrained(
-        saved, load_in_4bit=False, max_seq_length=64,
-    )
-    np.testing.assert_allclose(_mlx_logits(model2), stepped, atol=2e-4)
+    _, grads = nn.value_and_grad(model2, loss_fn)(model2)
+    optim.AdamW(learning_rate=1e-2).update(model2, grads)
+    mx.eval(model2.parameters())
+    assert not mx.array_equal(q2.lora_b, lora_b_before)
+    saved2 = str(tmp_path / "stepped")
+    save_lora_adapters(model2, saved2)
+    model3, _ = FastMLXModel.from_pretrained(saved2, load_in_4bit=False, max_seq_length=64)
+    # Adapter state round-trips bitwise. No logits assert: this path's trainable
+    # base moved during the step, and adapter saves carry only adapter tensors.
+    q3 = dict(model3.named_modules())["model.layers.0.self_attn.q_proj"]
+    assert mx.array_equal(q3.lora_b, q2.lora_b)
 
 
 def test_peft_import_honors_quantized_base_request(tmp_path, base_dir):
@@ -350,6 +296,26 @@ def test_peft_import_honors_quantized_base_request(tmp_path, base_dir):
     q = dict(model.named_modules())["model.layers.0.self_attn.q_proj"]
     assert type(q.linear) is nn.QuantizedLinear  # default load_in_4bit=True
     np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=0.35)
+    # One step moves LoRA and the stepped state survives save/reload.
+    # QuantizedLinear freezes independently; the attach-freeze contract on
+    # full-precision bases is asserted in the DoRA lifecycle test.
+    import mlx.optimizers as optim
+    lora_b_before, base_before = mx.array(q.lora_b), mx.array(q.linear.weight)
+    def loss_fn(m):
+        logits = m(mx.array([IDS]))
+        logits = logits.logits if hasattr(logits, "logits") else logits
+        return nn.losses.cross_entropy(logits, mx.array([IDS[1:] + [2]])).mean()
+    _, grads = nn.value_and_grad(model, loss_fn)(model)
+    optim.AdamW(learning_rate=1e-2).update(model, grads)
+    mx.eval(model.parameters())
+    assert not mx.array_equal(q.lora_b, lora_b_before)
+    assert mx.array_equal(q.linear.weight, base_before)
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    from unsloth_zoo.mlx.loader import FastMLXModel as _F
+    saved = str(tmp_path / "stepped")
+    save_lora_adapters(model, saved)
+    m2, _ = _F.from_pretrained(saved, max_seq_length=64)
+    np.testing.assert_allclose(_mlx_logits(m2), _mlx_logits(model), atol=2e-3)
 
 
 def test_converter_entries_reject_ambiguous_and_subclassed(tmp_path, base_dir):
@@ -508,28 +474,6 @@ def test_peft_export_rejects_unsupported_wrapper(tmp_path, base_dir):
         save_lora_adapters(model, str(tmp_path / "x"), adapter_format="peft")
 
 
-def test_conversion_failure_leaves_no_destination(tmp_path, base_dir, monkeypatch):
-    peft_dir = str(tmp_path / "peft")
-    _make_peft_adapter(base_dir, peft_dir)
-    import unsloth_zoo.saving_utils as su
-    dst = str(tmp_path / "mlx")
-
-    def boom(*args, **kwargs):
-        raise RuntimeError("simulated write failure")
-
-    monkeypatch.setattr(su.json, "dump", boom)
-    with pytest.raises(RuntimeError, match="simulated"):
-        convert_peft_dir_to_mlx(peft_dir, dst, {"num_hidden_layers": LAYERS})
-    monkeypatch.undo()
-    assert not os.path.exists(dst)  # failed claim fully released
-    convert_peft_dir_to_mlx(peft_dir, dst, {"num_hidden_layers": LAYERS})
-    assert os.path.exists(os.path.join(dst, MLX_WEIGHTS_FILE))
-    # Trailing-separator spelling must not break staging or publication.
-    dst2 = str(tmp_path / "mlx2") + os.sep
-    convert_peft_dir_to_mlx(peft_dir, dst2, {"num_hidden_layers": LAYERS})
-    assert os.path.exists(os.path.join(str(tmp_path / "mlx2"), MLX_WEIGHTS_FILE))
-
-
 def test_peft_export_rejects_mixed_dropout(tmp_path, base_dir):
     peft_dir = str(tmp_path / "peft")
     _make_peft_adapter(base_dir, peft_dir, lora_dropout=0.1)
@@ -574,3 +518,116 @@ def test_exported_patterns_are_exact_anchored(tmp_path, base_dir):
     path = key[1:].replace("\\.", ".")
     assert _resolve_pattern({key: rank}, path) == rank
     assert _resolve_pattern({key: rank}, "prefix." + path) is None
+
+
+def test_dora_import_roundtrip_and_training(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    wrapped, cfg = _make_peft_adapter(base_dir, peft_dir, use_dora=True)
+    with torch.no_grad():  # make magnitudes informative
+        for n, prm in wrapped.named_parameters():
+            if "lora_magnitude_vector" in n:
+                prm.add_(torch.randn_like(prm) * 0.05)
+    wrapped.save_pretrained(peft_dir, save_embedding_layers=False)
+
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    model, _ = FastMLXModel.from_pretrained(
+        peft_dir, load_in_4bit=False, max_seq_length=64,
+    )
+    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=5e-3)
+
+    q = dict(model.named_modules())["model.layers.0.self_attn.q_proj"]
+    m_before = mx.array(q.m)
+    base_before = mx.array(q.linear.weight)
+    import mlx.optimizers as optim
+    def loss_fn(m):
+        logits = m(mx.array([IDS]))
+        logits = logits.logits if hasattr(logits, "logits") else logits
+        return nn.losses.cross_entropy(logits, mx.array([IDS[1:] + [2]])).mean()
+    _, grads = nn.value_and_grad(model, loss_fn)(model)
+    optim.AdamW(learning_rate=1e-2).update(model, grads)
+    mx.eval(model.parameters())
+    assert not mx.array_equal(q.m, m_before)  # magnitude trains
+    assert mx.array_equal(q.linear.weight, base_before)  # fp base frozen
+
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    saved = str(tmp_path / "saved")
+    save_lora_adapters(model, saved)
+    stepped = _mlx_logits(model)
+    model2, _ = FastMLXModel.from_pretrained(saved, load_in_4bit=False, max_seq_length=64)
+    np.testing.assert_allclose(_mlx_logits(model2), stepped, atol=2e-4)
+
+    exported = str(tmp_path / "exported")
+    model2.save_lora_adapters(exported, adapter_format="peft")
+    ecfg = json.load(open(os.path.join(exported, "adapter_config.json")))
+    assert ecfg["use_dora"] is True
+    keys = set(st_load_file(os.path.join(exported, PEFT_WEIGHTS_FILE)))
+    # peft's canonical on-disk key has no .weight suffix.
+    assert any(k.endswith(".lora_magnitude_vector") for k in keys)
+    assert not any(".lora_magnitude_vector.weight" in k for k in keys)
+    base = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=torch.float32)
+    reloaded = peft.PeftModel.from_pretrained(base, exported)
+    np.testing.assert_allclose(_peft_logits(reloaded), stepped, atol=5e-3)
+
+
+def test_dora_dropout_rejected():
+    with pytest.raises(ValueError, match="different training-mode"):
+        normalize_peft_adapter_config({
+            "peft_type": "LORA", "r": 8, "use_dora": True, "lora_dropout": 0.1,
+        })
+
+
+def test_dora_rejects_embedding_and_mixed(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(
+        base_dir, peft_dir, use_dora=True,
+        target_modules=["q_proj", "embed_tokens"],
+    )
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    with pytest.raises((ValueError, RuntimeError)):
+        FastMLXModel.from_pretrained(peft_dir, load_in_4bit=False, max_seq_length=64)
+    peft2 = str(tmp_path / "p2")
+    _make_peft_adapter(base_dir, peft2, use_dora=True)
+    from safetensors.torch import save_file
+    wpath = os.path.join(peft2, PEFT_WEIGHTS_FILE)
+    tensors = st_load_file(wpath)
+    drop = next(k for k in tensors if "lora_magnitude_vector" in k)
+    tensors.pop(drop)
+    save_file(tensors, wpath)
+    with pytest.raises(ValueError, match="all-or-nothing|magnitude"):
+        convert_peft_dir_to_mlx(
+            peft2, str(tmp_path / "m"),
+            json.load(open(os.path.join(base_dir, "config.json"))),
+        )
+
+
+def test_dora_embedding_export_rejected(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    from mlx_lm.tuner.dora import DoRAEmbedding
+    model, _ = FastMLXModel.from_pretrained(
+        peft_dir, load_in_4bit=False, max_seq_length=64,
+    )
+    model.model.embed_tokens = DoRAEmbedding.from_base(
+        model.model.embed_tokens, r=4,
+    )
+    with pytest.raises(ValueError, match="DoRAEmbedding"):
+        save_lora_adapters(model, str(tmp_path / "x"), adapter_format="peft")
+
+
+def test_mixed_lora_dora_save_refused(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir, use_dora=True)
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    from mlx_lm.tuner.lora import LoRALinear
+    model, _ = FastMLXModel.from_pretrained(
+        peft_dir, load_in_4bit=False, max_seq_length=64,
+    )
+    attn = model.model.layers[1].self_attn
+    attn.k_proj = LoRALinear.from_base(attn.k_proj, r=4)
+    from unsloth_zoo.mlx.utils import save_trainable_adapters
+    for saver in (save_lora_adapters, save_trainable_adapters):
+        with pytest.raises(ValueError, match="mixes plain-LoRA and DoRA"):
+            saver(model, str(tmp_path / "x"))

--- a/tests/test_mlx_adapter_interop_metal.py
+++ b/tests/test_mlx_adapter_interop_metal.py
@@ -792,6 +792,89 @@ def test_full_state_shape_mismatch_rejected(tmp_path, base_dir):
         FastMLXModel.from_pretrained(peft_dir, load_in_4bit=False, max_seq_length=64)
 
 
+def test_auto_saved_base_state_refused_off_embedding_and_head(tmp_path, base_dir):
+    """peft auto-saves full base state for the input embedding and the output
+    head only. Every LoRA target carries a .base_layer, so a key spelled that
+    way on any other module would bind and replace live base weights."""
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    wf = os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
+    tensors = st_load_file(wf)
+    target = "model.layers.0.self_attn.q_proj"
+    tensors[f"base_model.model.{target}.base_layer.weight"] = torch.zeros(
+        HIDDEN, HIDDEN
+    )
+    from safetensors.torch import save_file as _st_save
+    _st_save(tensors, wf)
+
+    model, _ = load_model(Path(base_dir))
+    before = np.array(dict(model.named_modules())[target].weight)
+    cfg = json.load(open(os.path.join(peft_dir, "adapter_config.json")))
+    with pytest.raises(ValueError, match="not the input embedding or output head"):
+        attach_and_bind_peft_adapter(model, peft_dir, cfg)
+    live = dict(model.named_modules())[target]
+    assert np.array_equal(np.array(getattr(live, "linear", live).weight), before)
+
+
+def test_auto_saved_base_state_refused_before_conversion(tmp_path, base_dir):
+    """The converted directory is loadable by stock mlx-lm, whose load_adapters
+    binds adapters.safetensors with load_weights(strict=False) and never reads
+    full_state_modules, so the key must be refused before anything is written."""
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    wf = os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
+    tensors = st_load_file(wf)
+    target = "model.layers.0.self_attn.q_proj"
+    tensors[f"base_model.model.{target}.base_layer.weight"] = torch.zeros(
+        HIDDEN, HIDDEN
+    )
+    from safetensors.torch import save_file as _st_save
+    _st_save(tensors, wf)
+
+    mlx_dir = tmp_path / "mlx"
+    with pytest.raises(ValueError, match="not the input embedding or output head"):
+        convert_peft_dir_to_mlx(
+            peft_dir, str(mlx_dir),
+            json.load(open(os.path.join(base_dir, "config.json"))),
+        )
+    assert not mlx_dir.exists()
+
+
+@pytest.mark.parametrize("path,accepted", [
+    ("model.embed_tokens", True),
+    ("lm_head", True),
+    ("transformer.wte", True),                 # GPT-2 / MPT
+    ("gpt_neox.embed_in", True),
+    ("backbone.embeddings", True),             # Mamba
+    ("model.transformer.ff_out", True),        # OLMo's root output head
+    ("model.tok_embeddings", True),            # InternLM2
+    ("model.layers.0.self_attn.q_proj", False),
+    ("model.ngram.embedders.0", False),
+    ("model.embed_tokens_per_layer", False),   # Gemma 4 auxiliary table
+    ("model.layers.0.mlp.gate_proj", False),
+    # Leaves the root head shares with a per-layer module: OLMo names every
+    # block's MLP output ff_out, and `output` also spells an attention
+    # projection.
+    ("model.transformer.blocks.0.ff_out", False),
+    ("model.layers.0.attention.output", False),
+])
+def test_grouping_admits_only_hugging_face_embedding_and_head_paths(path, accepted):
+    """A PEFT artifact carries Hugging Face paths, whose input-embedding and
+    output-head spellings are a small known set. Conversion has no live tree to
+    ask and the directory it writes is loadable by stock mlx-lm, so the path is
+    all this layer has; a leaf shared with a per-layer module is told apart by
+    the numbered segment such a path always carries."""
+    from unsloth_zoo.saving_utils import group_peft_lora_pairs
+    lora = "base_model.model.model.layers.0.self_attn.q_proj"
+    _, full_state, rejected = group_peft_lora_pairs({
+        f"{lora}.lora_A.weight": mx.zeros((8, HIDDEN)),
+        f"{lora}.lora_B.weight": mx.zeros((HIDDEN, 8)),
+        f"base_model.model.{path}.base_layer.weight": mx.zeros((VOCAB, HIDDEN)),
+    }, {})
+    assert (not rejected) is accepted
+    assert (path in full_state) is accepted
+
+
 def test_nested_text_tower_bridge(tmp_path, base_dir):
     """A PEFT adapter names modules one level shallower than an mlx-vlm
     tree nests them; the import resolves that nesting and the export emits

--- a/tests/test_mlx_adapter_interop_metal.py
+++ b/tests/test_mlx_adapter_interop_metal.py
@@ -999,3 +999,43 @@ def test_native_nested_adapter_is_not_guessed_on_export(tmp_path, base_dir):
     assert not getattr(model, "_unsloth_tree_prefix", "")
     with pytest.raises(ValueError, match="outside a Hugging-Face-mirroring|not possible"):
         save_lora_adapters(model, str(tmp_path / "out"), adapter_format="peft")
+
+
+def _peft_task_type(name):
+    # A config built with peft's TaskType keeps the enum, while adapter JSON
+    # carries the bare string; both spellings must reach the same verdict.
+    from peft import TaskType
+    return getattr(TaskType, name)
+
+
+@pytest.mark.parametrize("cfg_extra, refused", [
+    ({"task_type": "CAUSAL_LM"}, False),
+    ({"task_type": "causal_lm"}, False),
+    ({}, False),
+    ({"task_type": "SEQ_CLS"}, True),
+    ({"task_type": "SEQ_2_SEQ_LM"}, True),
+    ({"task_type": _peft_task_type("CAUSAL_LM")}, False),
+])
+def test_import_refuses_non_causal_task(cfg_extra, refused):
+    # The backend serves causal LMs, so a differently-tasked adapter would
+    # bind its backbone factors and answer with vocabulary logits.
+    from unsloth_zoo.saving_utils import normalize_peft_adapter_config
+    cfg = {"peft_type": "LORA", "r": 4, "lora_alpha": 8,
+           "target_modules": ["q_proj"], **cfg_extra}
+    if refused:
+        with pytest.raises(ValueError, match="CAUSAL_LM"):
+            normalize_peft_adapter_config(cfg)
+    else:
+        normalize_peft_adapter_config(cfg)
+
+
+def test_import_accepts_a_live_peft_config():
+    # LoraConfig.to_dict() hands back peft's enum for peft_type, whose str() is
+    # "PeftType.LORA", so comparing it would refuse an ordinary causal adapter.
+    # The task_type enum spelling is covered by the case above.
+    import peft
+    from unsloth_zoo.saving_utils import normalize_peft_adapter_config
+    cfg = peft.LoraConfig(
+        task_type="CAUSAL_LM", r=4, lora_alpha=8, target_modules=["q_proj"],
+    ).to_dict()
+    normalize_peft_adapter_config(cfg)

--- a/tests/test_mlx_adapter_interop_metal.py
+++ b/tests/test_mlx_adapter_interop_metal.py
@@ -52,7 +52,8 @@ def base_dir(tmp_path_factory):
     return str(path)
 
 
-def _make_peft_adapter(base_dir, out, dtype=torch.float32, **lora_kwargs):
+def _make_peft_adapter(base_dir, out, dtype=torch.float32,
+                       save_embedding_layers=False, mutate=None, **lora_kwargs):
     model = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=dtype)
     kwargs = dict(r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"])
     kwargs.update(lora_kwargs)
@@ -60,13 +61,16 @@ def _make_peft_adapter(base_dir, out, dtype=torch.float32, **lora_kwargs):
     torch.manual_seed(7)
     with torch.no_grad():
         for name, param in wrapped.named_parameters():
-            if "lora_B" in name:
+            if "lora_B" in name or "lora_embedding_A" in name:
                 param.copy_(torch.randn_like(param) * 0.05)
             if "lora_" in name:
                 # peft autocasts adapter params to fp32; force the dtype so
                 # bf16 runs exercise real bf16 tensors.
                 param.data = param.data.to(dtype)
-    wrapped.save_pretrained(out, save_embedding_layers=False)
+    if mutate is not None:
+        with torch.no_grad():
+            mutate(wrapped)
+    wrapped.save_pretrained(out, save_embedding_layers=save_embedding_layers)
     cfg_path = os.path.join(out, "adapter_config.json")
     cfg = json.load(open(cfg_path))
     cfg["base_model_name_or_path"] = base_dir
@@ -102,7 +106,6 @@ def test_format_detection_and_fresh_destination(tmp_path, base_dir):
 
 
 @pytest.mark.parametrize("field,value,match", [
-    ("modules_to_save", ["lm_head"], "modules_to_save"),
     ("target_parameters", ["experts.gate_up_proj"], "expert-parameter"),
     ("alora_invocation_tokens", [1, 2], "aLoRA"),
     ("bias", "all", "bias"),
@@ -417,10 +420,16 @@ def test_save_lora_adapters_peft_format(tmp_path, base_dir):
     np.testing.assert_allclose(
         _peft_logits(reexported), _mlx_logits(model), atol=5e-3,
     )
+    # base_weights_source is inert for a linear-only adapter: no embedding
+    # targets means nothing to source.
     from unsloth_zoo.saving_utils import export_peft_adapter
-    with pytest.raises(ValueError, match="base_weights_source"):
-        export_peft_adapter(str(tmp_path / "m"), str(tmp_path / "n"),
-                            base_weights_source=object())
+    mlx_dir = str(tmp_path / "mlx")
+    save_lora_adapters(model, mlx_dir)
+    sourced = str(tmp_path / "sourced")
+    export_peft_adapter(mlx_dir, sourced, base_weights_source=base_dir)
+    assert set(st_load_file(os.path.join(sourced, PEFT_WEIGHTS_FILE))) == set(
+        st_load_file(os.path.join(out, PEFT_WEIGHTS_FILE))
+    )
 
 
 def test_peft_export_includes_lm_head_on_mirrored_layout(tmp_path, base_dir):
@@ -631,3 +640,153 @@ def test_mixed_lora_dora_save_refused(tmp_path, base_dir):
     for saver in (save_lora_adapters, save_trainable_adapters):
         with pytest.raises(ValueError, match="mixes plain-LoRA and DoRA"):
             saver(model, str(tmp_path / "x"))
+
+
+def test_embedding_lora_genuine_roundtrip(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    wrapped, _ = _make_peft_adapter(
+        base_dir, peft_dir, target_modules=["q_proj", "embed_tokens"],
+        save_embedding_layers="auto",
+    )
+    assert "base_model.model.model.embed_tokens.base_layer.weight" in st_load_file(
+        os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
+    )
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    model, _ = FastMLXModel.from_pretrained(peft_dir, load_in_4bit=False, max_seq_length=64)
+    emb = dict(model.named_modules())["model.embed_tokens"]
+    assert hasattr(emb, "lora_a") and type(emb).__name__ == "LoRAEmbedding"
+    # The auto-saved base embedding is value-equal here: verified and skipped.
+    assert getattr(model, "_unsloth_full_state_modules", {}) == {}
+    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=5e-3)
+
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    out_peft = str(tmp_path / "reexport")
+    save_lora_adapters(model, out_peft, adapter_format="peft")
+    keys = set(st_load_file(os.path.join(out_peft, PEFT_WEIGHTS_FILE)))
+    assert "base_model.model.model.embed_tokens.lora_embedding_A" in keys
+    # No base_weights_source: the auto-saved embedding weights are omitted.
+    assert not any("base_layer" in k for k in keys)
+    base = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=torch.float32)
+    reloaded = peft.PeftModel.from_pretrained(base, out_peft)
+    np.testing.assert_allclose(_peft_logits(reloaded), _peft_logits(wrapped), atol=5e-3)
+
+    # The standalone-converted directory reloads and agrees (its full
+    # state binds under the reload wrappers' inner paths).
+    conv = str(tmp_path / "converted")
+    convert_peft_dir_to_mlx(
+        peft_dir, conv, json.load(open(os.path.join(base_dir, "config.json"))),
+    )
+    mconv, _ = FastMLXModel.from_pretrained(conv, load_in_4bit=False, max_seq_length=64)
+    np.testing.assert_allclose(_mlx_logits(mconv), _peft_logits(wrapped), atol=5e-3)
+
+    # Studio-style emission: source the embedding weights from the base dir.
+    from unsloth_zoo.saving_utils import export_peft_adapter
+    mlx_dir = str(tmp_path / "mlx")
+    save_lora_adapters(model, mlx_dir)
+    sourced = str(tmp_path / "sourced")
+    export_peft_adapter(
+        mlx_dir, sourced, module_types={"model.embed_tokens": "embedding"},
+        base_weights_source=base_dir,
+    )
+    st = st_load_file(os.path.join(sourced, PEFT_WEIGHTS_FILE))
+    torch.testing.assert_close(
+        st["base_model.model.model.embed_tokens.base_layer.weight"],
+        base.get_input_embeddings().weight,
+    )
+
+
+def test_full_state_modules_lifecycle(tmp_path, base_dir):
+    def _mutate(pm):
+        dict(pm.named_modules())["base_model.model.lm_head"].modules_to_save[
+            "default"
+        ].weight += 0.01
+        pm.get_input_embeddings().weight += 0.02
+    peft_dir = str(tmp_path / "peft")
+    wrapped, _ = _make_peft_adapter(
+        base_dir, peft_dir, modules_to_save=["lm_head"],
+        save_embedding_layers=True, mutate=_mutate,
+    )
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    model, _ = FastMLXModel.from_pretrained(peft_dir, load_in_4bit=False, max_seq_length=64)
+    assert model._unsloth_full_state_modules == {
+        "lm_head": "modules_to_save", "model.embed_tokens": "embedding_auto",
+    }
+    mods = dict(model.named_modules())
+    emb_live = mods["model.embed_tokens"].weight
+    # Applied exactly, up to the loader's own base-dtype cast.
+    assert mx.array_equal(
+        emb_live,
+        mx.array(
+            wrapped.get_input_embeddings().weight.detach().numpy()
+        ).astype(emb_live.dtype),
+    )
+    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=5e-3)
+    # modules_to_save is trainable, the replaced embedding is not.
+    from mlx.utils import tree_flatten
+    trainable = dict(tree_flatten(model.trainable_parameters()))
+    assert "lm_head.weight" in trainable
+    assert "model.embed_tokens.weight" not in trainable
+
+    import mlx.optimizers as optim
+    lm_before = mx.array(mods["lm_head"].weight)
+    emb_before = mx.array(mods["model.embed_tokens"].weight)
+    def loss_fn(m):
+        logits = m(mx.array([IDS]))
+        logits = logits.logits if hasattr(logits, "logits") else logits
+        return nn.losses.cross_entropy(logits, mx.array([IDS[1:] + [2]])).mean()
+    _, grads = nn.value_and_grad(model, loss_fn)(model)
+    optim.AdamW(learning_rate=1e-2).update(model, grads)
+    mx.eval(model.parameters())
+    assert not mx.array_equal(mods["lm_head"].weight, lm_before)
+    assert mx.array_equal(mods["model.embed_tokens"].weight, emb_before)
+
+    from unsloth_zoo.mlx.utils import save_lora_adapters
+    mlx_dir = str(tmp_path / "mlx")
+    save_lora_adapters(model, mlx_dir)
+    cfg = json.load(open(os.path.join(mlx_dir, "adapter_config.json")))
+    assert cfg["full_state_modules"] == model._unsloth_full_state_modules
+    model2, _ = FastMLXModel.from_pretrained(mlx_dir, load_in_4bit=False, max_seq_length=64)
+    mods2 = dict(model2.named_modules())
+    assert mx.array_equal(mods2["lm_head"].weight, mods["lm_head"].weight)
+    assert mx.array_equal(mods2["model.embed_tokens"].weight, emb_before)
+    assert model2._unsloth_full_state_modules == model._unsloth_full_state_modules
+    tr2 = dict(tree_flatten(model2.trainable_parameters()))
+    assert "lm_head.weight" in tr2
+    assert "model.embed_tokens.weight" not in tr2
+
+    exported = str(tmp_path / "exported")
+    save_lora_adapters(model2, exported, adapter_format="peft")
+    ecfg = json.load(open(os.path.join(exported, "adapter_config.json")))
+    # Reconstructed from origin tags: only the modules_to_save entry.
+    assert ecfg["modules_to_save"] == ["lm_head"]
+    base = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=torch.float32)
+    reloaded = peft.PeftModel.from_pretrained(base, exported, is_trainable=True)
+    m2s_param = dict(reloaded.named_parameters())[
+        "base_model.model.lm_head.modules_to_save.default.weight"
+    ]
+    assert m2s_param.requires_grad
+    np.testing.assert_allclose(
+        m2s_param.detach().numpy(),
+        np.array(mods["lm_head"].weight.astype(mx.float32)), atol=0,
+    )
+    np.testing.assert_allclose(
+        reloaded.get_input_embeddings().weight.detach().to(torch.float32).numpy(),
+        np.array(emb_before.astype(mx.float32)), atol=0,
+    )
+
+
+def test_full_state_shape_mismatch_rejected(tmp_path, base_dir):
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(
+        base_dir, peft_dir, modules_to_save=["lm_head"],
+        mutate=lambda pm: None,
+    )
+    wf = os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
+    tensors = st_load_file(wf)
+    key = "base_model.model.lm_head.weight"
+    tensors[key] = torch.cat([tensors[key], tensors[key][:4]], dim=0)
+    from safetensors.torch import save_file as _st_save
+    _st_save(tensors, wf)
+    from unsloth_zoo.mlx.loader import FastMLXModel
+    with pytest.raises(Exception, match="shape mismatch"):
+        FastMLXModel.from_pretrained(peft_dir, load_in_4bit=False, max_seq_length=64)

--- a/tests/test_mlx_adapter_interop_metal.py
+++ b/tests/test_mlx_adapter_interop_metal.py
@@ -105,6 +105,122 @@ def test_format_detection_and_fresh_destination(tmp_path, base_dir):
         convert_peft_dir_to_mlx(peft_dir, str(tmp_path / "dst"), {"num_hidden_layers": LAYERS})
 
 
+def test_converter_refuses_disagreeing_factor_ranks(tmp_path, base_dir):
+    """A factor pair whose ranks disagree is refused, not silently bound."""
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(base_dir, peft_dir)
+    wf = os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
+    tensors = st_load_file(wf)
+    key = next(k for k in tensors if k.endswith("lora_B.weight"))
+    tensors[key] = torch.zeros(HIDDEN, 4)   # rank 4 against lora_A's 8
+    from safetensors.torch import save_file as _st_save
+    _st_save(tensors, wf)
+
+    with pytest.raises(ValueError, match="lora_A rank 8 but lora_B rank 4"):
+        convert_peft_dir_to_mlx(
+            peft_dir, str(tmp_path / "mlx"),
+            json.load(open(os.path.join(base_dir, "config.json"))),
+        )
+    # The export direction reads the other axis, in its own key spelling.
+    mlx_dir = str(tmp_path / "mlx-ok")
+    _make_peft_adapter(base_dir, str(tmp_path / "p2"))
+    convert_peft_dir_to_mlx(
+        str(tmp_path / "p2"), mlx_dir,
+        json.load(open(os.path.join(base_dir, "config.json"))),
+    )
+    mt = st_load_file(os.path.join(mlx_dir, MLX_WEIGHTS_FILE))
+    bkey = next(k for k in mt if k.endswith(".lora_b"))
+    mt[bkey] = torch.zeros(4, HIDDEN)
+    _st_save(mt, os.path.join(mlx_dir, MLX_WEIGHTS_FILE))
+    with pytest.raises(ValueError, match="lora_a rank 8 but lora_b rank 4"):
+        convert_mlx_dir_to_peft(mlx_dir, str(tmp_path / "back"))
+
+
+@pytest.fixture(scope="module")
+def tied_base_dir(tmp_path_factory):
+    """Most small on-device models tie word embeddings, and peft auto-saves
+    both the embedding and the head for them."""
+    path = tmp_path_factory.mktemp("tiny-llama-tied")
+    torch.manual_seed(0)
+    transformers.LlamaForCausalLM(transformers.LlamaConfig(
+        vocab_size=VOCAB, hidden_size=HIDDEN, intermediate_size=128,
+        num_hidden_layers=LAYERS, num_attention_heads=4,
+        num_key_value_heads=2, max_position_embeddings=128,
+        tie_word_embeddings=True,
+    )).to(torch.float32).save_pretrained(path, safe_serialization=True)
+    return str(path)
+
+
+def test_tied_output_head_snapshot_folds_or_refuses(tmp_path, tied_base_dir):
+    """On a tied base the auto-saved head IS the embedding weight: it folds
+    away silently, and a head that does not duplicate the embedding is
+    refused rather than bound as independent head state."""
+    peft_dir = str(tmp_path / "peft")
+    _make_peft_adapter(
+        tied_base_dir, peft_dir, save_embedding_layers=True,
+        mutate=lambda pm: pm.get_input_embeddings().weight.add_(0.02),
+    )
+    base_config = json.load(open(os.path.join(tied_base_dir, "config.json")))
+    wf = os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
+    head = next(k for k in st_load_file(wf) if "lm_head" in k)
+
+    convert_peft_dir_to_mlx(peft_dir, str(tmp_path / "ok"), base_config)
+    mlx_cfg = json.load(open(os.path.join(tmp_path, "ok", "adapter_config.json")))
+    assert "lm_head" not in json.dumps(mlx_cfg.get("full_state_modules") or {})
+    # Folded, not dropped: the written artifact must still carry the trained
+    # embedding, or a reload silently reverts it to the base weight.
+    assert any("embed_tokens" in p for p in mlx_cfg["full_state_modules"])
+    torch.testing.assert_close(
+        st_load_file(os.path.join(tmp_path, "ok", MLX_WEIGHTS_FILE))[
+            "model.embed_tokens.weight"
+        ],
+        st_load_file(wf)[head],
+    )
+
+    # The live attach path folds through the same helper, with an MLX
+    # equality callback that casts before comparing.
+    cfg = json.load(open(os.path.join(peft_dir, "adapter_config.json")))
+    model, _ = load_model(Path(tied_base_dir))
+    attach_and_bind_peft_adapter(model, peft_dir, cfg)
+    assert not any(
+        "lm_head" in p
+        for p in getattr(model, "_unsloth_full_state_modules", {})
+    )
+
+    # Folded, not dropped: the trained embedding must survive both paths.
+    assert any(
+        "embed_tokens" in p
+        for p in getattr(model, "_unsloth_full_state_modules", {})
+    )
+    emb = dict(model.named_modules())["model.embed_tokens"]
+    torch.testing.assert_close(
+        torch.tensor(np.array(emb.weight)),
+        st_load_file(wf)[head],
+    )
+
+    # export_peft_adapter's own refusal: a modules_to_save snapshot of a tied
+    # embedding has no untied PEFT form.
+    from unsloth_zoo.saving_utils import export_peft_adapter
+    ok_cfg = os.path.join(tmp_path, "ok", "adapter_config.json")
+    _c = json.load(open(ok_cfg))
+    _c["full_state_modules"] = {"model.embed_tokens": "modules_to_save"}
+    json.dump(_c, open(ok_cfg, "w"))
+    with pytest.raises(ValueError, match="tied embedding or output head"):
+        export_peft_adapter(
+            str(tmp_path / "ok"), str(tmp_path / "exp"), base_config=base_config,
+        )
+
+    tensors = st_load_file(wf)
+    tensors[head] = tensors[head] + 1.0
+    from safetensors.torch import save_file as _st_save
+    _st_save(tensors, wf)
+    with pytest.raises(ValueError, match="tied output-head snapshot"):
+        convert_peft_dir_to_mlx(peft_dir, str(tmp_path / "bad"), base_config)
+    model2, _ = load_model(Path(tied_base_dir))
+    with pytest.raises(ValueError, match="tied output-head snapshot"):
+        attach_and_bind_peft_adapter(model2, peft_dir, cfg)
+
+
 @pytest.mark.parametrize("field,value,match", [
     ("target_parameters", ["experts.gate_up_proj"], "expert-parameter"),
     ("alora_invocation_tokens", [1, 2], "aLoRA"),
@@ -201,8 +317,8 @@ def test_attach_matches_peft_forward_with_patterns(tmp_path, base_dir):
 
 
 @pytest.mark.parametrize("key,shape,match", [
-    ("base_model.model.language_model.model.layers.0.self_attn.q_proj.lora_A.weight",
-     (8, HIDDEN), "language_model"),
+    ("base_model.model.decoder.blocks.0.attn.q_proj.lora_A.weight",
+     (8, HIDDEN), "decoder.blocks"),
     ("base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight",
      (HIDDEN + 8, 8), "out-dim"),
 ])
@@ -212,7 +328,7 @@ def test_attach_rejects_bad_tensors(tmp_path, base_dir, key, shape, match):
 
     def mutate(tensors):
         tensors[key] = torch.zeros(*shape)
-        if "language_model" in key:  # give the alien path a complete pair
+        if "decoder.blocks" in key:  # give the alien path a complete pair
             tensors[key.replace("lora_A", "lora_B")] = torch.zeros(HIDDEN, 8)
 
     from safetensors.torch import save_file
@@ -420,16 +536,6 @@ def test_save_lora_adapters_peft_format(tmp_path, base_dir):
     np.testing.assert_allclose(
         _peft_logits(reexported), _mlx_logits(model), atol=5e-3,
     )
-    # base_weights_source is inert for a linear-only adapter: no embedding
-    # targets means nothing to source.
-    from unsloth_zoo.saving_utils import export_peft_adapter
-    mlx_dir = str(tmp_path / "mlx")
-    save_lora_adapters(model, mlx_dir)
-    sourced = str(tmp_path / "sourced")
-    export_peft_adapter(mlx_dir, sourced, base_weights_source=base_dir)
-    assert set(st_load_file(os.path.join(sourced, PEFT_WEIGHTS_FILE))) == set(
-        st_load_file(os.path.join(out, PEFT_WEIGHTS_FILE))
-    )
 
 
 def test_peft_export_includes_lm_head_on_mirrored_layout(tmp_path, base_dir):
@@ -459,7 +565,11 @@ def test_peft_export_includes_lm_head_on_mirrored_layout(tmp_path, base_dir):
     )
 
 
-def test_peft_export_rejects_unsupported_wrapper(tmp_path, base_dir):
+@pytest.mark.parametrize("wrapper", ["fused", "dora_embedding"])
+def test_peft_export_rejects_unsupported_wrapper(tmp_path, base_dir, wrapper):
+    """Only a stock LoRALinear/DoRALinear over a stock Linear is
+    representable: a foreign wrapper type and a stock wrapper over an
+    embedding are both refused by name."""
     peft_dir = str(tmp_path / "peft")
     _make_peft_adapter(base_dir, peft_dir)
     from unsloth_zoo.mlx.loader import FastMLXModel
@@ -473,13 +583,20 @@ def test_peft_export_rejects_unsupported_wrapper(tmp_path, base_dir):
         # is what makes the semantics non-plain.
         def __init__(self, inner):
             super().__init__()
-            self.lora_a = inner.lora_a
-            self.lora_b = inner.lora_b
+            self.lora_a, self.lora_b = inner.lora_a, inner.lora_b
             self.linear = inner.linear
 
-    layers = model.model.layers
-    layers[0].self_attn.q_proj = _FusedWrap(layers[0].self_attn.q_proj)
-    with pytest.raises(ValueError, match="_FusedWrap"):
+    if wrapper == "fused":
+        attn = model.model.layers[0].self_attn
+        attn.q_proj = _FusedWrap(attn.q_proj)
+        match = "_FusedWrap"
+    else:
+        from mlx_lm.tuner.dora import DoRAEmbedding
+        model.model.embed_tokens = DoRAEmbedding.from_base(
+            model.model.embed_tokens, r=4,
+        )
+        match = "DoRAEmbedding"
+    with pytest.raises(ValueError, match=match):
         save_lora_adapters(model, str(tmp_path / "x"), adapter_format="peft")
 
 
@@ -585,15 +702,7 @@ def test_dora_dropout_rejected():
         })
 
 
-def test_dora_rejects_embedding_and_mixed(tmp_path, base_dir):
-    peft_dir = str(tmp_path / "peft")
-    _make_peft_adapter(
-        base_dir, peft_dir, use_dora=True,
-        target_modules=["q_proj", "embed_tokens"],
-    )
-    from unsloth_zoo.mlx.loader import FastMLXModel
-    with pytest.raises((ValueError, RuntimeError)):
-        FastMLXModel.from_pretrained(peft_dir, load_in_4bit=False, max_seq_length=64)
+def test_dora_rejects_partial_magnitudes(tmp_path, base_dir):
     peft2 = str(tmp_path / "p2")
     _make_peft_adapter(base_dir, peft2, use_dora=True)
     from safetensors.torch import save_file
@@ -607,22 +716,6 @@ def test_dora_rejects_embedding_and_mixed(tmp_path, base_dir):
             peft2, str(tmp_path / "m"),
             json.load(open(os.path.join(base_dir, "config.json"))),
         )
-
-
-def test_dora_embedding_export_rejected(tmp_path, base_dir):
-    peft_dir = str(tmp_path / "peft")
-    _make_peft_adapter(base_dir, peft_dir)
-    from unsloth_zoo.mlx.loader import FastMLXModel
-    from unsloth_zoo.mlx.utils import save_lora_adapters
-    from mlx_lm.tuner.dora import DoRAEmbedding
-    model, _ = FastMLXModel.from_pretrained(
-        peft_dir, load_in_4bit=False, max_seq_length=64,
-    )
-    model.model.embed_tokens = DoRAEmbedding.from_base(
-        model.model.embed_tokens, r=4,
-    )
-    with pytest.raises(ValueError, match="DoRAEmbedding"):
-        save_lora_adapters(model, str(tmp_path / "x"), adapter_format="peft")
 
 
 def test_mixed_lora_dora_save_refused(tmp_path, base_dir):
@@ -642,57 +735,27 @@ def test_mixed_lora_dora_save_refused(tmp_path, base_dir):
             saver(model, str(tmp_path / "x"))
 
 
-def test_embedding_lora_genuine_roundtrip(tmp_path, base_dir):
+def test_embedding_lora_is_refused(tmp_path, base_dir):
+    """Embedding LoRA is unsupported, so it is named and refused rather than
+    silently dropped from the converted adapter."""
     peft_dir = str(tmp_path / "peft")
-    wrapped, _ = _make_peft_adapter(
+    _make_peft_adapter(
         base_dir, peft_dir, target_modules=["q_proj", "embed_tokens"],
         save_embedding_layers="auto",
     )
-    assert "base_model.model.model.embed_tokens.base_layer.weight" in st_load_file(
+    assert any("lora_embedding_A" in k for k in st_load_file(
         os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
-    )
+    ))
+    with pytest.raises(ValueError, match="does not support"):
+        convert_peft_dir_to_mlx(
+            peft_dir, str(tmp_path / "mlx"),
+            json.load(open(os.path.join(base_dir, "config.json"))),
+        )
     from unsloth_zoo.mlx.loader import FastMLXModel
-    model, _ = FastMLXModel.from_pretrained(peft_dir, load_in_4bit=False, max_seq_length=64)
-    emb = dict(model.named_modules())["model.embed_tokens"]
-    assert hasattr(emb, "lora_a") and type(emb).__name__ == "LoRAEmbedding"
-    # The auto-saved base embedding is value-equal here: verified and skipped.
-    assert getattr(model, "_unsloth_full_state_modules", {}) == {}
-    np.testing.assert_allclose(_mlx_logits(model), _peft_logits(wrapped), atol=5e-3)
-
-    from unsloth_zoo.mlx.utils import save_lora_adapters
-    out_peft = str(tmp_path / "reexport")
-    save_lora_adapters(model, out_peft, adapter_format="peft")
-    keys = set(st_load_file(os.path.join(out_peft, PEFT_WEIGHTS_FILE)))
-    assert "base_model.model.model.embed_tokens.lora_embedding_A" in keys
-    # No base_weights_source: the auto-saved embedding weights are omitted.
-    assert not any("base_layer" in k for k in keys)
-    base = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=torch.float32)
-    reloaded = peft.PeftModel.from_pretrained(base, out_peft)
-    np.testing.assert_allclose(_peft_logits(reloaded), _peft_logits(wrapped), atol=5e-3)
-
-    # The standalone-converted directory reloads and agrees (its full
-    # state binds under the reload wrappers' inner paths).
-    conv = str(tmp_path / "converted")
-    convert_peft_dir_to_mlx(
-        peft_dir, conv, json.load(open(os.path.join(base_dir, "config.json"))),
-    )
-    mconv, _ = FastMLXModel.from_pretrained(conv, load_in_4bit=False, max_seq_length=64)
-    np.testing.assert_allclose(_mlx_logits(mconv), _peft_logits(wrapped), atol=5e-3)
-
-    # Studio-style emission: source the embedding weights from the base dir.
-    from unsloth_zoo.saving_utils import export_peft_adapter
-    mlx_dir = str(tmp_path / "mlx")
-    save_lora_adapters(model, mlx_dir)
-    sourced = str(tmp_path / "sourced")
-    export_peft_adapter(
-        mlx_dir, sourced, module_types={"model.embed_tokens": "embedding"},
-        base_weights_source=base_dir,
-    )
-    st = st_load_file(os.path.join(sourced, PEFT_WEIGHTS_FILE))
-    torch.testing.assert_close(
-        st["base_model.model.model.embed_tokens.base_layer.weight"],
-        base.get_input_embeddings().weight,
-    )
+    with pytest.raises(ValueError, match="does not support"):
+        FastMLXModel.from_pretrained(
+            peft_dir, load_in_4bit=False, max_seq_length=64,
+        )
 
 
 def test_full_state_modules_lifecycle(tmp_path, base_dir):
@@ -795,7 +858,9 @@ def test_full_state_shape_mismatch_rejected(tmp_path, base_dir):
 def test_auto_saved_base_state_refused_off_embedding_and_head(tmp_path, base_dir):
     """peft auto-saves full base state for the input embedding and the output
     head only. Every LoRA target carries a .base_layer, so a key spelled that
-    way on any other module would bind and replace live base weights."""
+    way on any other module would bind and replace live base weights. Stock
+    mlx-lm binds adapters.safetensors with load_weights(strict=False) and never
+    reads full_state_modules, so conversion must refuse before it writes."""
     peft_dir = str(tmp_path / "peft")
     _make_peft_adapter(base_dir, peft_dir)
     wf = os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
@@ -806,33 +871,20 @@ def test_auto_saved_base_state_refused_off_embedding_and_head(tmp_path, base_dir
     )
     from safetensors.torch import save_file as _st_save
     _st_save(tensors, wf)
+    refused = pytest.raises(
+        ValueError, match="not the input embedding or output head",
+    )
 
     model, _ = load_model(Path(base_dir))
     before = np.array(dict(model.named_modules())[target].weight)
     cfg = json.load(open(os.path.join(peft_dir, "adapter_config.json")))
-    with pytest.raises(ValueError, match="not the input embedding or output head"):
+    with refused:
         attach_and_bind_peft_adapter(model, peft_dir, cfg)
     live = dict(model.named_modules())[target]
     assert np.array_equal(np.array(getattr(live, "linear", live).weight), before)
 
-
-def test_auto_saved_base_state_refused_before_conversion(tmp_path, base_dir):
-    """The converted directory is loadable by stock mlx-lm, whose load_adapters
-    binds adapters.safetensors with load_weights(strict=False) and never reads
-    full_state_modules, so the key must be refused before anything is written."""
-    peft_dir = str(tmp_path / "peft")
-    _make_peft_adapter(base_dir, peft_dir)
-    wf = os.path.join(peft_dir, PEFT_WEIGHTS_FILE)
-    tensors = st_load_file(wf)
-    target = "model.layers.0.self_attn.q_proj"
-    tensors[f"base_model.model.{target}.base_layer.weight"] = torch.zeros(
-        HIDDEN, HIDDEN
-    )
-    from safetensors.torch import save_file as _st_save
-    _st_save(tensors, wf)
-
     mlx_dir = tmp_path / "mlx"
-    with pytest.raises(ValueError, match="not the input embedding or output head"):
+    with refused:
         convert_peft_dir_to_mlx(
             peft_dir, str(mlx_dir),
             json.load(open(os.path.join(base_dir, "config.json"))),
@@ -873,215 +925,6 @@ def test_grouping_admits_only_hugging_face_embedding_and_head_paths(path, accept
     }, {})
     assert (not rejected) is accepted
     assert (path in full_state) is accepted
-
-
-def test_nested_text_tower_bridge(tmp_path, base_dir):
-    """A PEFT adapter names modules one level shallower than an mlx-vlm
-    tree nests them; the import resolves that nesting and the export emits
-    Hugging-Face-native paths again."""
-    peft_dir = str(tmp_path / "peft")
-    wrapped, cfg = _make_peft_adapter(base_dir, peft_dir)
-    model, _ = load_model(Path(base_dir))
-
-    class _Tower(nn.Module):
-        """Stand-in for the mlx-vlm wrapper: the text model nested one level."""
-        def __init__(self, inner):
-            super().__init__()
-            self.language_model = inner
-
-        def __call__(self, *args, **kwargs):
-            return self.language_model(*args, **kwargs)
-
-    nested = _Tower(model)
-    assert attach_and_bind_peft_adapter(
-        nested, peft_dir, normalize_peft_adapter_config(cfg),
-    ) == 2 * LAYERS
-    assert nested._unsloth_tree_prefix == "language_model."
-    np.testing.assert_allclose(
-        _mlx_logits(nested), _peft_logits(wrapped), atol=5e-3,
-    )
-    # Live state is keyed by the real (nested) module paths.
-    assert all(
-        k.startswith("language_model.")
-        for k in nested._unsloth_lora_module_scales
-    )
-
-    from unsloth_zoo.mlx.utils import save_lora_adapters
-    out = str(tmp_path / "back")
-    save_lora_adapters(nested, out, adapter_format="peft")
-    back_cfg = json.load(open(os.path.join(out, "adapter_config.json")))
-    keys = st_load_file(os.path.join(out, PEFT_WEIGHTS_FILE))
-    assert all(t.startswith("model.layers.") for t in back_cfg["target_modules"])
-    assert all("language_model" not in k for k in keys)
-    base = transformers.LlamaForCausalLM.from_pretrained(base_dir, dtype=torch.float32)
-    reloaded = peft.PeftModel.from_pretrained(base, out)
-    np.testing.assert_allclose(
-        _peft_logits(reloaded), _peft_logits(wrapped), atol=5e-3,
-    )
-
-
-def test_nested_tower_is_never_guessed(tmp_path, base_dir):
-    """A tower outside the known text-tower names is not inferred, and a
-    natively nested adapter without import provenance is not unnested: both
-    keep the named refusal rather than binding the wrong module set."""
-    from unsloth_zoo.mlx.utils import _resolve_tree_prefix, save_lora_adapters
-    from mlx_lm.tuner.lora import LoRALinear
-
-    paths = ["model.layers.0.self_attn.q_proj"]
-    assert _resolve_tree_prefix({"vision_tower." + paths[0]: 1}, paths) is None
-    assert _resolve_tree_prefix({"language_model." + paths[0]: 1}, paths) == "language_model."
-
-    class _Tower(nn.Module):
-        def __init__(self, inner):
-            super().__init__()
-            self.language_model = inner
-
-    inner, _ = load_model(Path(base_dir))
-    model = _Tower(inner)
-    attn = model.language_model.model.layers[0].self_attn
-    attn.q_proj = LoRALinear.from_base(attn.q_proj, r=8, dropout=0.0, scale=2.0)
-    with pytest.raises(ValueError, match="outside a Hugging-Face-mirroring|not possible"):
-        save_lora_adapters(model, str(tmp_path / "out"), adapter_format="peft")
-
-
-def _nested(model):
-    """Wrap a text model the way mlx-vlm nests it."""
-    class _Tower(nn.Module):
-        def __init__(self, inner):
-            super().__init__()
-            self.language_model = inner
-        def __call__(self, *a, **kw):
-            return self.language_model(*a, **kw)
-    return _Tower(model)
-
-
-def test_tree_prefix_bridge_resolution():
-    """The nesting resolver: unique prefix wins, ambiguity and unknown
-    layouts fall through to the caller's per-path report."""
-    from unsloth_zoo.mlx.utils import _resolve_tree_prefix
-
-    flat = {"model.layers.0.self_attn.q_proj": 1, "model.layers.1.self_attn.q_proj": 1}
-    nested = {"language_model." + k: v for k, v in flat.items()}
-    paths = list(flat)
-
-    assert _resolve_tree_prefix(flat, paths) == ""
-    assert _resolve_tree_prefix(nested, paths) == "language_model."
-    # A vision tower is never a candidate, even when its shapes would fit:
-    # binding a language adapter onto it would be silently wrong.
-    vision_only = {"vision_tower." + k: v for k, v in flat.items()}
-    assert _resolve_tree_prefix(vision_only, paths) is None
-    both = dict(nested)
-    both.update(vision_only)
-    assert _resolve_tree_prefix(both, paths) == "language_model."
-    # A tail that exists nowhere resolves to nothing.
-    assert _resolve_tree_prefix(nested, ["decoder.layers.0.attn.q_proj"]) is None
-    # A prefix must map EVERY path, not just one.
-    partial = dict(nested)
-    partial.pop("language_model.model.layers.1.self_attn.q_proj")
-    assert _resolve_tree_prefix(partial, paths) is None
-
-
-def test_nested_tower_survives_mlx_reload_and_dir_conversion(tmp_path, base_dir):
-    """The nesting marker persists through MLX save -> reload -> re-save, so a
-    later directory-only conversion still emits Hugging-Face-native paths."""
-    from pathlib import Path
-    from unsloth_zoo.mlx.utils import (
-        attach_and_bind_peft_adapter, normalize_peft_adapter_config,
-        save_lora_adapters,
-    )
-    from unsloth_zoo.saving_utils import convert_mlx_dir_to_peft
-
-    peft_dir = str(tmp_path / "peft")
-    _make_peft_adapter(base_dir, peft_dir)
-    cfg = normalize_peft_adapter_config(
-        json.load(open(os.path.join(peft_dir, "adapter_config.json")))
-    )
-    inner, _ = load_model(Path(base_dir))
-    model = _nested(inner)
-    attach_and_bind_peft_adapter(model, peft_dir, cfg)
-
-    first = str(tmp_path / "mlx1")
-    save_lora_adapters(model, first)
-    saved = json.load(open(os.path.join(first, "adapter_config.json")))
-    assert saved["unsloth_mlx_tree_prefix"] == "language_model."
-    assert any(k.startswith("language_model.")
-               for k in mx.load(os.path.join(first, MLX_WEIGHTS_FILE)))
-
-    # Directory-only conversion honours the recorded marker.
-    back = str(tmp_path / "back")
-    convert_mlx_dir_to_peft(first, back)
-    keys = st_load_file(os.path.join(back, PEFT_WEIGHTS_FILE))
-    assert keys and all("language_model" not in k for k in keys)
-
-    # An explicit empty prefix means "do not unnest", unlike omitting it.
-    with pytest.raises(ValueError, match="outside a Hugging-Face-mirroring"):
-        convert_mlx_dir_to_peft(first, str(tmp_path / "raw"), strip_prefix="")
-
-
-def test_nested_tower_ambiguity_and_collisions_refuse(tmp_path, base_dir):
-    """Two towers that both fit, or that collapse onto one path, refuse."""
-    from unsloth_zoo.mlx.utils import _resolve_tree_prefix
-    from unsloth_zoo.saving_utils import convert_mlx_dir_to_peft
-
-    flat = {"model.layers.0.self_attn.q_proj": 1}
-    both = dict(flat, **{"language_model.model.layers.0.self_attn.q_proj": 1})
-    with pytest.raises(ValueError, match="match both the root"):
-        _resolve_tree_prefix(both, list(flat))
-
-    # An artifact carrying the same module in two towers cannot unnest.
-    d = str(tmp_path / "mlx")
-    os.makedirs(d)
-    mx.save_safetensors(os.path.join(d, MLX_WEIGHTS_FILE), {
-        "language_model.model.layers.0.self_attn.q_proj.lora_a": mx.zeros((HIDDEN, 8)),
-        "language_model.model.layers.0.self_attn.q_proj.lora_b": mx.zeros((8, HIDDEN)),
-        "model.layers.0.self_attn.q_proj.lora_a": mx.zeros((HIDDEN, 8)),
-        "model.layers.0.self_attn.q_proj.lora_b": mx.zeros((8, HIDDEN)),
-    })
-    json.dump({"fine_tune_type": "lora", "lora_parameters": {"rank": 8, "scale": 2.0},
-               "unsloth_mlx_tree_prefix": "language_model."},
-              open(os.path.join(d, "adapter_config.json"), "w"))
-    with pytest.raises(ValueError, match="collapses"):
-        convert_mlx_dir_to_peft(d, str(tmp_path / "out"))
-
-
-def test_nested_tower_mixed_dropout_is_still_caught(tmp_path, base_dir):
-    """The dropout guard must see through the nesting, not skip it."""
-    from pathlib import Path
-    from unsloth_zoo.mlx.utils import (
-        attach_and_bind_peft_adapter, normalize_peft_adapter_config,
-        save_lora_adapters,
-    )
-    peft_dir = str(tmp_path / "peft")
-    _make_peft_adapter(base_dir, peft_dir, lora_dropout=0.1)
-    cfg = normalize_peft_adapter_config(
-        json.load(open(os.path.join(peft_dir, "adapter_config.json")))
-    )
-    inner, _ = load_model(Path(base_dir))
-    model = _nested(inner)
-    attach_and_bind_peft_adapter(model, peft_dir, cfg)
-    wrappers = [m for _n, m in model.named_modules() if hasattr(m, "lora_a")]
-    drop = getattr(wrappers[0], "dropout", None)
-    if drop is not None and hasattr(drop, "_p_1"):
-        drop._p_1 = 1.0 - 0.5   # diverge one module's dropout
-    with pytest.raises(ValueError, match="different lora_dropout"):
-        save_lora_adapters(model, str(tmp_path / "out"), adapter_format="peft")
-
-
-def test_native_nested_adapter_is_not_guessed_on_export(tmp_path, base_dir):
-    """Without import provenance the Hugging Face counterpart of a nested
-    tower is unknowable (a VLM class nests it the other way round), so the
-    export refuses instead of emitting paths that bind the wrong modules."""
-    from pathlib import Path
-    from unsloth_zoo.mlx.utils import save_lora_adapters
-    from mlx_lm.tuner.lora import LoRALinear
-
-    inner, _ = load_model(Path(base_dir))
-    model = _nested(inner)
-    layer = model.language_model.model.layers[0].self_attn
-    layer.q_proj = LoRALinear.from_base(layer.q_proj, r=8, dropout=0.0, scale=2.0)
-    assert not getattr(model, "_unsloth_tree_prefix", "")
-    with pytest.raises(ValueError, match="outside a Hugging-Face-mirroring|not possible"):
-        save_lora_adapters(model, str(tmp_path / "out"), adapter_format="peft")
 
 
 def _peft_task_type(name):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -3780,6 +3780,10 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
     # Defer rank validation until a module needs wrapping, so a legacy adapter
     # with no rank (but already wrapped by load_adapters) doesn't crash here.
     _metadata = {"rank": None, "scale": None, "dropout": None}
+    # PEFT imports may carry per-module ranks/scales that one global
+    # lora_parameters entry cannot represent; honor the saved maps.
+    _per_path_ranks = adapter_cfg.get("unsloth_mlx_lora_module_ranks") or {}
+    _per_path_scales = adapter_cfg.get("unsloth_mlx_lora_module_scales") or {}
 
     def _ensure_metadata(module_path=None):
         if _metadata["rank"] is not None:
@@ -3830,9 +3834,49 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
         if module is None:
             _skipped_paths.append((name, "module_missing"))
             continue
-        # Skip already-wrapped paths so we don't nest LoRALinear(LoRALinear).
+        # Skip already-wrapped paths to avoid nesting LoRALinear(LoRALinear),
+        # unless per-path metadata disagrees with what mlx-lm's global rebuild
+        # produced: uniform ranks with per-module scales would silently reload
+        # with the wrong scales, per-module ranks would fail shape binding.
         if hasattr(module, "lora_a") and hasattr(module, "lora_b"):
-            continue
+            _want_rank = _per_path_ranks.get(name)
+            _want_scale = _per_path_scales.get(name)
+            _have_rank = None
+            try:
+                # Routed (switch) wrappers keep rank on lora_b's last axis —
+                # lora_a's is the input width; plain LoRALinear stores
+                # (in_dims, rank), so its rank is lora_a's last axis.
+                _b = getattr(module, "lora_b", None)
+                if hasattr(module, "num_experts") and getattr(_b, "ndim", 0) >= 3:
+                    _have_rank = int(_b.shape[-1])
+                else:
+                    _have_rank = int(module.lora_a.shape[-1])
+            except Exception:
+                pass
+            _have_scale = getattr(module, "scale", None)
+            _rank_ok = _want_rank is None or _have_rank == int(_want_rank)
+            try:
+                _scale_ok = (
+                    _want_scale is None
+                    or (_have_scale is not None
+                        and float(_have_scale) == float(_want_scale))
+                )
+            except (TypeError, ValueError):
+                # A per-expert (array) scale cannot equal a scalar entry; leave
+                # the wrapper alone rather than rebuild from metadata that
+                # cannot describe it.
+                _scale_ok = True
+            _base_mod = (
+                getattr(module, "linear", None)
+                or getattr(module, "embedding", None)
+            )
+            if (_rank_ok and _scale_ok) or _base_mod is None:
+                continue
+            # Rebuild from the wrapped base with the recorded per-path
+            # parameters, then fall through to the shared wrap path.
+            module = _base_mod
+            by_name[name] = module
+        # Resolved after any rebuild, so the spec matches the base actually wrapped.
         type_spec = _mlx_lora_spec_for_module(module, type_specs)
         if use_dora and isinstance(module, linear_types):
             type_spec = None
@@ -3874,15 +3918,36 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
                 (name, f"unhandled_type:{type(module).__name__}"),
             )
             continue
-        _ensure_metadata(module_path=name)
+        if name in _per_path_ranks or name in _per_path_scales:
+            # Per-path metadata is self-sufficient; fall back to the global
+            # entry only for whichever half is absent.
+            if name not in _per_path_ranks or name not in _per_path_scales:
+                _ensure_metadata(module_path=name)
+            _rank = int(_per_path_ranks.get(name, _metadata["rank"] or 0))
+            _scale = float(
+                _per_path_scales.get(
+                    name,
+                    _metadata["scale"] if _metadata["scale"] is not None else 1.0,
+                )
+            )
+            _dropout = _metadata["dropout"] if _metadata["dropout"] is not None else 0.0
+            if _metadata["dropout"] is None:
+                _lp = adapter_cfg.get("lora_parameters") or {}
+                _dropout = float(_lp.get("dropout", adapter_cfg.get("dropout", 0.0)))
+        else:
+            _ensure_metadata(module_path=name)
+            _rank = _metadata["rank"]
+            _scale = _metadata["scale"]
+            _dropout = _metadata["dropout"]
         if type_spec is not None:
             wrapped = _mlx_lora_from_base(
-                module, _metadata, specs=type_specs,
+                module,
+                {**_metadata, "rank": _rank, "scale": _scale, "dropout": _dropout},
+                specs=type_specs,
             )
         else:
             wrapped = _lora_from_base_compat(
-                lora_cls, module,
-                _metadata["rank"], _metadata["scale"], _metadata["dropout"],
+                lora_cls, module, _rank, _scale, _dropout,
             )
         # Resolve numeric path segments (e.g. `...layers.0`) via parent[int(seg)]
         # then getattr; same pattern on the leaf so list-indexed wrappers install.
@@ -4341,6 +4406,25 @@ def _adapter_actual_quant_config(adapter_cfg, resolved_map):
         expected["quantize_modules"] = None
         return expected
     return _quant_config_from_resolved_map(resolved_map)
+
+
+def _peft_import_quant_override(flags):
+    """True when the caller explicitly chose a base quantization for a PEFT
+    import, in any spelling. load_in_4bit defaults to True, so False can
+    only be an explicit choice; the other flags default to False/None."""
+    if flags.get("load_in_4bit") is False:
+        return True
+    if any(
+        flags.get(k)
+        for k in ("load_in_8bit", "load_in_16bit", "load_in_fp8",
+                  "load_in_mxfp4", "load_in_nvfp4")
+    ):
+        return True
+    return any(
+        flags.get(k) is not None
+        for k in ("q_bits", "q_mode", "q_group_size",
+                  "mlx_quantization_config", "quantization_config")
+    )
 
 
 def _adapter_base_revision(adapter_cfg):
@@ -7114,6 +7198,37 @@ class FastMLXModel:
             try:
                 with open(adapter_cfg_path, "r") as f:
                     adapter_cfg = json.load(f)
+                # PEFT-format adapters import through the interop path;
+                # validate the config now so unsupported features are refused
+                # by name before the base model is downloaded.
+                if os.path.exists(
+                    os.path.join(local_path, "adapter_model.safetensors")
+                ) or os.path.exists(
+                    # Sharded PEFT saves carry only the index plus shards;
+                    # route them here for the named rejection instead of a
+                    # missing-adapters.safetensors failure after the base loads.
+                    os.path.join(
+                        local_path, "adapter_model.safetensors.index.json"
+                    )
+                ):
+                    from .utils import (
+                        detect_adapter_format,
+                        normalize_peft_adapter_config,
+                    )
+                    adapter_cfg = normalize_peft_adapter_config(
+                        adapter_cfg, adapter_dir=local_path,
+                    )
+                    # Raises when both weight formats coexist in one dir.
+                    detect_adapter_format(local_path)
+                    if full_finetuning:
+                        raise ValueError(
+                            "Unsloth MLX: full_finetuning=True cannot be "
+                            "combined with importing a PEFT LoRA adapter; "
+                            "training the unfrozen base would move weights "
+                            "the adapter save does not capture. Load "
+                            "without full_finetuning, or merge the adapter "
+                            "first."
+                        )
                 base_model_id = adapter_cfg.get("base_model_name_or_path", "")
                 if base_model_id:
                     print(f"Unsloth: Detected LoRA adapter, loading base model '{base_model_id}'...")
@@ -7236,16 +7351,70 @@ class FastMLXModel:
                     # Reload the base via FastMLXModel.from_pretrained (text +
                     # VLM); the old mlx_lm.load fallback broke VLM adapters
                     # (mlx-lm load is text-only).
+                    # MLX adapters carry base quantization in metadata (applied
+                    # via mlx_quantization_config below), so the flags are pinned
+                    # off. PEFT configs carry none: honor the caller's flags as a
+                    # plain base load would, else every QLoRA-style import
+                    # silently loads a full-precision base.
+                    _base_quant_flags = (
+                        {
+                            "load_in_4bit": load_in_4bit,
+                            "load_in_8bit": load_in_8bit,
+                            "load_in_16bit": load_in_16bit,
+                            "load_in_fp8": load_in_fp8,
+                            "load_in_mxfp4": load_in_mxfp4,
+                            "load_in_nvfp4": load_in_nvfp4,
+                            # The richer controls must travel too: an explicit
+                            # config/predicate changes how the flags resolve, so
+                            # dropping it would quantize against the caller's ask.
+                            **{
+                                _qk: _qv
+                                for _qk, _qv in (
+                                    ("q_bits", q_bits),
+                                    ("q_group_size", q_group_size),
+                                    ("q_mode", q_mode),
+                                    ("mlx_quantization_config", mlx_quantization_config),
+                                    ("quantization_config", quantization_config),
+                                    ("quant_predicate", quant_predicate),
+                                    ("quantize_modules", quantize_modules),
+                                )
+                                if _qv is not None
+                            },
+                            **({"force_requantize": True} if force_requantize else {}),
+                        }
+                        if adapter_cfg.get("_unsloth_peft_import")
+                        else {
+                            "load_in_4bit": False,
+                            "load_in_8bit": False,
+                            "load_in_16bit": False,
+                            "load_in_fp8": False,
+                            "load_in_mxfp4": False,
+                            "load_in_nvfp4": False,
+                        }
+                    )
+                    if (
+                        adapter_mlx_quant_config is not None
+                        and adapter_cfg.get("_unsloth_peft_import")
+                    ):
+                        # bnb-remapped base: the generated 4-bit config is only
+                        # a default, so any explicit caller request wins
+                        # UNIFORMLY whatever its spelling (flag, q_* knob, config
+                        # dict). Otherwise the remap config applies and caller
+                        # dicts are dropped so the keyword is not passed twice.
+                        _caller_quant_override = _peft_import_quant_override(_base_quant_flags)
+                        if _caller_quant_override:
+                            adapter_mlx_quant_config = None
+                        else:
+                            _base_quant_flags.pop("mlx_quantization_config", None)
+                            _base_quant_flags.pop("quantization_config", None)
+                    elif adapter_mlx_quant_config is not None:
+                        _base_quant_flags.pop("mlx_quantization_config", None)
+                        _base_quant_flags.pop("quantization_config", None)
                     model, tokenizer = FastMLXModel.from_pretrained(
                         base_model_id,
                         max_seq_length=max_seq_length,
                         dtype=dtype,
-                        load_in_4bit=False,
-                        load_in_8bit=False,
-                        load_in_16bit=False,
-                        load_in_fp8=False,
-                        load_in_mxfp4=False,
-                        load_in_nvfp4=False,
+                        **_base_quant_flags,
                         full_finetuning=full_finetuning,
                         token=token,
                         trust_remote_code=trust_remote_code,
@@ -7263,101 +7432,118 @@ class FastMLXModel:
                         ),
                     )
                     _validate_mlx_adapter_base(model, adapter_cfg)
-                    # why: load_adapters rebuilds only language-tower LoRA;
-                    # vision/projector LoRA must be re-attached so load_weights
-                    # binds the trained tensors.
-                    _saved_lora_paths = _normalize_mlx_lora_module_paths(
-                        adapter_cfg.get("unsloth_mlx_lora_module_paths"),
-                    )
-                    # Saved exact paths win: build and shape-check those wrappers before strict=False can mutate them.
-                    # Let older mlx-lm load_adapters accept scale=/dropout=.
-                    _patch_mlx_lora_from_base_compat()
-                    adapter_weights_file = os.path.join(local_path, "adapters.safetensors")
-                    _tensor_lora_shapes = _saved_mlx_lora_tensor_shapes(
-                        adapter_weights_file,
-                    )
-                    if _saved_lora_paths:
-                        _unbacked_paths = sorted(
-                            path for path in _saved_lora_paths
-                            if set(_tensor_lora_shapes.get(path, ())) != {"a", "b"}
+                    if adapter_cfg.get("_unsloth_peft_import"):
+                        # PEFT import: the weight file drives attachment (module
+                        # set, rank from shapes, scale from the validated config).
+                        # Binding is all-or-nothing inside the interop module,
+                        # which also applies the freeze contract, so the
+                        # mlx-format reload path below is skipped whole.
+                        from .utils import attach_and_bind_peft_adapter
+                        attach_and_bind_peft_adapter(
+                            model, local_path, adapter_cfg,
                         )
-                        if _unbacked_paths:
-                            raise RuntimeError(
-                                "Unsloth MLX: saved LoRA module paths have no "
-                                "complete A/B tensor pair; refusing to load a "
-                                f"partial adapter ({_unbacked_paths[:5]!r})."
-                            )
+                        adapter_weights_file = os.path.join(
+                            local_path, "adapters.safetensors",
+                        )
                     else:
-                        _validate_pathless_switch_adapter(
-                            model,
-                            _tensor_lora_shapes,
-                            adapter_cfg,
+                        # load_adapters rebuilds only language-tower LoRA;
+                        # vision/projector LoRA must be re-attached so
+                        # load_weights binds the trained tensors.
+                        _saved_lora_paths = _normalize_mlx_lora_module_paths(
+                            adapter_cfg.get("unsloth_mlx_lora_module_paths"),
+                        )
+                        # Saved exact paths win: build and shape-check those wrappers before strict=False can mutate them.
+                        # Let older mlx-lm load_adapters accept scale=/dropout=.
+                        _patch_mlx_lora_from_base_compat()
+                        adapter_weights_file = os.path.join(local_path, "adapters.safetensors")
+                        _tensor_lora_shapes = _saved_mlx_lora_tensor_shapes(
                             adapter_weights_file,
                         )
-                    # Pre-validate DoRA: catch missing mlx_lm.tuner.dora before
-                    # load_adapters rebuilds plain LoRA and drops saved DoRA
-                    # `.m` via strict=False (distinct from the per-module
-                    # post-check in _apply_lora_at_paths).
-                    if adapter_cfg.get("fine_tune_type") == "dora":
-                        try:
-                            import mlx_lm.tuner.dora  # noqa: F401
-                        except Exception as _dora_exc:
-                            raise RuntimeError(
-                                "Unsloth MLX: adapter_config declares "
-                                "fine_tune_type='dora' but mlx_lm.tuner.dora "
-                                "is unavailable; install a DoRA-capable "
-                                "mlx-lm or convert the adapter to plain "
-                                "LoRA before reload."
-                            ) from _dora_exc
-                    if _saved_lora_paths:
-                        if not full_finetuning:
-                            _fix_missing_no_grad(model)
-                            model.freeze()
-                        _apply_lora_at_paths(
-                            model, _saved_lora_paths, adapter_cfg,
-                            adapter_weights_file=adapter_weights_file,
-                        )
-                        _missing_before_load = _warn_missing_adapter_keys(
-                            model, adapter_weights_file,
-                        )
-                        if _missing_before_load:
-                            raise RuntimeError(
-                                "Unsloth MLX: saved LoRA tensors are missing "
-                                "or shape-incompatible with the exact module "
-                                "paths; refusing to load a partial adapter "
-                                f"({_missing_before_load[:5]!r})."
+                        if _saved_lora_paths:
+                            _unbacked_paths = sorted(
+                                path for path in _saved_lora_paths
+                                if set(_tensor_lora_shapes.get(path, ())) != {"a", "b"}
                             )
-                        model.load_weights(adapter_weights_file, strict=False)
-                    else:
-                        model = _load_pathless_mlx_adapter(
-                            model, local_path, adapter_weights_file,
-                            adapter_cfg, full_finetuning,
-                        )
-                        if os.path.exists(adapter_weights_file):
-                            _missing_after_load = _warn_missing_adapter_keys(
+                            if _unbacked_paths:
+                                raise RuntimeError(
+                                    "Unsloth MLX: saved LoRA module paths have no "
+                                    "complete A/B tensor pair; refusing to load a "
+                                    f"partial adapter ({_unbacked_paths[:5]!r})."
+                                )
+                        else:
+                            _validate_pathless_switch_adapter(
+                                model,
+                                _tensor_lora_shapes,
+                                adapter_cfg,
+                                adapter_weights_file,
+                            )
+                        # Catch a missing mlx_lm.tuner.dora before load_adapters
+                        # rebuilds plain LoRA and drops saved `.m` via
+                        # strict=False (distinct from the per-module post-check
+                        # in _apply_lora_at_paths).
+                        if adapter_cfg.get("fine_tune_type") == "dora":
+                            try:
+                                import mlx_lm.tuner.dora  # noqa: F401
+                            except Exception as _dora_exc:
+                                raise RuntimeError(
+                                    "Unsloth MLX: adapter_config declares "
+                                    "fine_tune_type='dora' but mlx_lm.tuner.dora "
+                                    "is unavailable; install a DoRA-capable "
+                                    "mlx-lm or convert the adapter to plain "
+                                    "LoRA before reload."
+                                ) from _dora_exc
+                        if _saved_lora_paths:
+                            if not full_finetuning:
+                                _fix_missing_no_grad(model)
+                                model.freeze()
+                            _apply_lora_at_paths(
+                                model, _saved_lora_paths, adapter_cfg,
+                                adapter_weights_file=adapter_weights_file,
+                            )
+                            _missing_before_load = _warn_missing_adapter_keys(
                                 model, adapter_weights_file,
                             )
-                            if _missing_after_load:
-                                _preview = ", ".join(_missing_after_load[:5])
-                                if len(_missing_after_load) > 5:
-                                    _preview += (
-                                        f", ... (+{len(_missing_after_load) - 5} more)"
-                                    )
+                            if _missing_before_load:
                                 raise RuntimeError(
-                                    "Unsloth MLX: load_adapters succeeded but "
-                                    f"{len(_missing_after_load)} saved LoRA "
-                                    "tensor(s) are missing or shape-incompatible "
-                                    "with the live module tree "
-                                    f"({_preview}). Refusing to return a "
-                                    "partially loaded adapter."
+                                    "Unsloth MLX: saved LoRA tensors are missing "
+                                    "or shape-incompatible with the exact module "
+                                    "paths; refusing to load a partial adapter "
+                                    f"({_missing_before_load[:5]!r})."
                                 )
+                            model.load_weights(adapter_weights_file, strict=False)
+                        else:
+                            model = _load_pathless_mlx_adapter(
+                                model, local_path, adapter_weights_file,
+                                adapter_cfg, full_finetuning,
+                            )
+                            if os.path.exists(adapter_weights_file):
+                                _missing_after_load = _warn_missing_adapter_keys(
+                                    model, adapter_weights_file,
+                                )
+                                if _missing_after_load:
+                                    _preview = ", ".join(_missing_after_load[:5])
+                                    if len(_missing_after_load) > 5:
+                                        _preview += (
+                                            f", ... (+{len(_missing_after_load) - 5} more)"
+                                        )
+                                    raise RuntimeError(
+                                        "Unsloth MLX: load_adapters succeeded but "
+                                        f"{len(_missing_after_load)} saved LoRA "
+                                        "tensor(s) are missing or shape-incompatible "
+                                        "with the live module tree "
+                                        f"({_preview}). Refusing to return a "
+                                        "partially loaded adapter."
+                                    )
                     # mlx-lm's load_adapters applies the adapter layers but,
                     # unlike get_peft_model, never freezes the base, so a fresh
                     # MLXTrainer would full-finetune it at a LoRA learning rate.
-                    # Skipped for full_finetuning, and when there are no LoRA
-                    # modules (a fine_tune_type="full" adapter) since that would
-                    # leave the model fully frozen.
-                    if not full_finetuning:
+                    # Skipped for full_finetuning; for PEFT imports, whose attach
+                    # already froze the base and left modules_to_save trainable;
+                    # and when there are no LoRA modules (fine_tune_type="full"),
+                    # which would otherwise freeze the model entirely.
+                    if not full_finetuning and not adapter_cfg.get(
+                        "_unsloth_peft_import"
+                    ):
                         from .utils import iter_mlx_lora_modules
                         _lora_modules = list(iter_mlx_lora_modules(model))
                         if _lora_modules:

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -7493,7 +7493,33 @@ class FastMLXModel:
                         _saved_lora_paths = _normalize_mlx_lora_module_paths(
                             adapter_cfg.get("unsloth_mlx_lora_module_paths"),
                         )
-                        # Saved exact paths win: build and shape-check those wrappers before strict=False can mutate them.
+                        # Saved exact paths win: build and shape-check those
+                        # wrappers before strict=False can mutate them. The
+                        # full-state shape snapshot must be taken here too —
+                        # afterwards the live tree reflects whatever the file
+                        # carried, and the resized-artifact check needs the
+                        # base's shapes.
+                        _fs_prebind = {}
+                        _fs_cfg_map = dict(
+                            adapter_cfg.get("full_state_modules") or {}
+                        )
+                        if _fs_cfg_map:
+                            from mlx.utils import tree_flatten as _tf
+                            _params0 = dict(_tf(model.parameters()))
+                            for _p in _fs_cfg_map:
+                                for _t in ("weight", "bias"):
+                                    # The base tree may be unwrapped; a
+                                    # wrapper-inner spelling falls back to the
+                                    # bare module tensor.
+                                    _bare_v = _params0.get(f"{_p}.{_t}")
+                                    for _k in (
+                                        f"{_p}.{_t}",
+                                        f"{_p}.embedding.{_t}",
+                                        f"{_p}.linear.{_t}",
+                                    ):
+                                        _v = _params0.get(_k, _bare_v)
+                                        if _v is not None:
+                                            _fs_prebind[_k] = tuple(_v.shape)
                         # Let older mlx-lm load_adapters accept scale=/dropout=.
                         _patch_mlx_lora_from_base_compat()
                         adapter_weights_file = os.path.join(local_path, "adapters.safetensors")
@@ -7603,6 +7629,43 @@ class FastMLXModel:
                     if os.path.exists(adapter_weights_file):
                         _unfreeze_saved_mlx_non_adapter_parameters(
                             model, adapter_weights_file,
+                        )
+                    if adapter_cfg.get("unsloth_peft_converted") and not (
+                        adapter_cfg.get("_unsloth_peft_import")
+                    ):
+                        _emb_wrapped = sorted(
+                            _n for _n, _m in model.named_modules()
+                            if hasattr(_m, "lora_a")
+                            and getattr(_m, "embedding", None) is not None
+                        )
+                        if _emb_wrapped:
+                            from .utils import _model_ties_output_to_embedding
+                            if _model_ties_output_to_embedding(model):
+                                raise ValueError(
+                                    f"Unsloth MLX: {_emb_wrapped} carry "
+                                    "embedding adapters but this model "
+                                    "routes output logits through the "
+                                    "embedding; mlx-lm would apply the "
+                                    "update to output projection while "
+                                    "peft-side training applied it to "
+                                    "input lookup only. The artifact "
+                                    "cannot load faithfully."
+                                )
+                    if adapter_cfg.get("unsloth_peft_converted"):
+                        # Provenance survives load/save: derivatives keep their
+                        # peft-parity guarantees.
+                        model._unsloth_peft_converted = True
+                    _fs_map = dict(adapter_cfg.get("full_state_modules") or {})
+                    if _fs_map and not adapter_cfg.get("_unsloth_peft_import"):
+                        # After the freeze, never before: restores
+                        # modules_to_save trainability.
+                        from .utils import _mark_full_state_modules
+                        _mark_full_state_modules(
+                            model, _fs_map, adapter_weights_file,
+                            expected_shapes=_fs_prebind,
+                            trainable_paths=adapter_cfg.get(
+                                "full_state_trainable"
+                            ),
                         )
                     model = _eval_mlx_model_after_adapter_reload(model)
                     loaded_model_config = getattr(model, "_config", None)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -5904,7 +5904,14 @@ def _mlx_push_to_hub_gguf(self, repo_id, tokenizer=None,
                      quantization_method=quantization_method, **kwargs)
 
 
-def _mlx_save_lora_adapters(self, path, adapter_config=None):
+def _mlx_save_lora_adapters(self, path, adapter_config=None, adapter_format="mlx"):
+    # Validate before routing: the trainable-tensor writer takes no
+    # adapter_format, so an unrecognized value would silently write MLX.
+    if adapter_format not in ("mlx", "peft"):
+        raise ValueError(
+            f"Unsloth MLX: adapter_format={adapter_format!r}; expected "
+            "'mlx' or 'peft'."
+        )
     import mlx.utils as _mu
     from .utils import (
         save_lora_adapters, save_trainable_adapters,
@@ -5920,18 +5927,52 @@ def _mlx_save_lora_adapters(self, path, adapter_config=None):
     _lora_names = [name for name, _ in iter_mlx_lora_modules(self)]
     _lora_prefixes = tuple(f"{name}." for name in _lora_names if name)
     _root_lora = any(name == "" for name in _lora_names)
+    # modules_to_save is trainable BY CONTRACT and representable in both
+    # formats, so it is not CPT evidence. embedding_auto is frozen by contract,
+    # so a trainable one means continued pretraining unfroze it and it counts.
+    _fs_paths = frozenset(
+        path
+        for path, origin in (
+            getattr(self, "_unsloth_full_state_modules", None) or {}
+        ).items()
+        if origin == "modules_to_save"
+    )
+
+    def _is_adapter_full_state(key):
+        owner = key.rsplit(".", 1)[0]
+        if owner in _fs_paths:
+            return True
+        # LoRA wrappers keep the base under an inner path; strip that only
+        # when the exact path is not itself recorded.
+        for _inner in (".embedding", ".linear"):
+            if owner.endswith(_inner) and owner[: -len(_inner)] in _fs_paths:
+                return True
+        return False
     # A tree nothing froze reports EVERY parameter trainable, which is not CPT
     # evidence: keep the LoRA-only writer. The wrapped-base filter matches
     # MLXTrainer.save_model, so a reload-leaked q_proj.weight does not count.
     _has_full_module = len(_trainable) < len(_all) and any(
         k not in _lora
         and not _is_base_tensor_inside_lora_module(k, _lora_prefixes, _root_lora)
+        and not _is_adapter_full_state(k)
         for k in _trainable
     )
     if _has_full_module:
+        if adapter_format == "peft":
+            # The writer emits full module weights only the MLX artifact
+            # describes; PEFT would need each declared as modules_to_save,
+            # which this checkpoint does not record.
+            raise ValueError(
+                "Unsloth MLX: this checkpoint trains full modules "
+                "(continued pretraining), which the PEFT adapter format "
+                "cannot represent here. Export the MLX adapter, or merge "
+                "the model and export the merged weights."
+            )
         save_trainable_adapters(self, path, adapter_config=adapter_config)
     else:
-        save_lora_adapters(self, path, adapter_config=adapter_config)
+        save_lora_adapters(
+            self, path, adapter_config=adapter_config, adapter_format=adapter_format,
+        )
 
 
 def _mlx_prompt_to_ids(prompt):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -7655,6 +7655,12 @@ class FastMLXModel:
                         # Provenance survives load/save: derivatives keep their
                         # peft-parity guarantees.
                         model._unsloth_peft_converted = True
+                    if adapter_cfg.get("unsloth_mlx_tree_prefix"):
+                        # Same for the text-tower nesting, so a re-save keeps the
+                        # marker a later PEFT conversion needs.
+                        model._unsloth_tree_prefix = adapter_cfg[
+                            "unsloth_mlx_tree_prefix"
+                        ]
                     _fs_map = dict(adapter_cfg.get("full_state_modules") or {})
                     if _fs_map and not adapter_cfg.get("_unsloth_peft_import"):
                         # After the freeze, never before: restores

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -3835,17 +3835,15 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
             _skipped_paths.append((name, "module_missing"))
             continue
         # Skip already-wrapped paths to avoid nesting LoRALinear(LoRALinear),
-        # unless per-path metadata disagrees with what mlx-lm's global rebuild
-        # produced: uniform ranks with per-module scales would silently reload
-        # with the wrong scales, per-module ranks would fail shape binding.
+        # unless per-path metadata disagrees with mlx-lm's global rebuild:
+        # those wrappers carry the wrong scale or the wrong shape.
         if hasattr(module, "lora_a") and hasattr(module, "lora_b"):
             _want_rank = _per_path_ranks.get(name)
             _want_scale = _per_path_scales.get(name)
             _have_rank = None
             try:
-                # Routed (switch) wrappers keep rank on lora_b's last axis —
-                # lora_a's is the input width; plain LoRALinear stores
-                # (in_dims, rank), so its rank is lora_a's last axis.
+                # Routed (switch) wrappers keep rank on lora_b's last axis;
+                # plain LoRALinear stores (in_dims, rank), so it is lora_a's.
                 _b = getattr(module, "lora_b", None)
                 if hasattr(module, "num_experts") and getattr(_b, "ndim", 0) >= 3:
                     _have_rank = int(_b.shape[-1])
@@ -3862,9 +3860,8 @@ def _apply_lora_at_paths(model, module_paths, adapter_cfg, adapter_weights_file=
                         and float(_have_scale) == float(_want_scale))
                 )
             except (TypeError, ValueError):
-                # A per-expert (array) scale cannot equal a scalar entry; leave
-                # the wrapper alone rather than rebuild from metadata that
-                # cannot describe it.
+                # A per-expert (array) scale cannot equal a scalar entry, so
+                # metadata cannot describe this wrapper; leave it alone.
                 _scale_ok = True
             _base_mod = (
                 getattr(module, "linear", None)
@@ -5927,9 +5924,8 @@ def _mlx_save_lora_adapters(self, path, adapter_config=None, adapter_format="mlx
     _lora_names = [name for name, _ in iter_mlx_lora_modules(self)]
     _lora_prefixes = tuple(f"{name}." for name in _lora_names if name)
     _root_lora = any(name == "" for name in _lora_names)
-    # modules_to_save is trainable BY CONTRACT and representable in both
-    # formats, so it is not CPT evidence. embedding_auto is frozen by contract,
-    # so a trainable one means continued pretraining unfroze it and it counts.
+    # modules_to_save is trainable by contract, so it is not CPT evidence; a
+    # trainable embedding_auto means continued pretraining unfroze it.
     _fs_paths = frozenset(
         path
         for path, origin in (
@@ -5938,16 +5934,10 @@ def _mlx_save_lora_adapters(self, path, adapter_config=None, adapter_format="mlx
         if origin == "modules_to_save"
     )
 
+    from unsloth_zoo.saving_utils import _full_state_owner
+
     def _is_adapter_full_state(key):
-        owner = key.rsplit(".", 1)[0]
-        if owner in _fs_paths:
-            return True
-        # LoRA wrappers keep the base under an inner path; strip that only
-        # when the exact path is not itself recorded.
-        for _inner in (".embedding", ".linear"):
-            if owner.endswith(_inner) and owner[: -len(_inner)] in _fs_paths:
-                return True
-        return False
+        return _full_state_owner(key.rsplit(".", 1)[0], _fs_paths) is not None
     # A tree nothing froze reports EVERY parameter trainable, which is not CPT
     # evidence: keep the LoRA-only writer. The wrapped-base filter matches
     # MLXTrainer.save_model, so a reload-leaked q_proj.weight does not count.
@@ -5960,8 +5950,7 @@ def _mlx_save_lora_adapters(self, path, adapter_config=None, adapter_format="mlx
     if _has_full_module:
         if adapter_format == "peft":
             # The writer emits full module weights only the MLX artifact
-            # describes; PEFT would need each declared as modules_to_save,
-            # which this checkpoint does not record.
+            # describes; PEFT would need each declared as modules_to_save.
             raise ValueError(
                 "Unsloth MLX: this checkpoint trains full modules "
                 "(continued pretraining), which the PEFT adapter format "
@@ -7239,15 +7228,13 @@ class FastMLXModel:
             try:
                 with open(adapter_cfg_path, "r") as f:
                     adapter_cfg = json.load(f)
-                # PEFT-format adapters import through the interop path;
-                # validate the config now so unsupported features are refused
-                # by name before the base model is downloaded.
+                # Validate the PEFT config now, so unsupported features are
+                # refused by name before the base model is downloaded.
                 if os.path.exists(
                     os.path.join(local_path, "adapter_model.safetensors")
                 ) or os.path.exists(
                     # Sharded PEFT saves carry only the index plus shards;
-                    # route them here for the named rejection instead of a
-                    # missing-adapters.safetensors failure after the base loads.
+                    # route them here for the named rejection.
                     os.path.join(
                         local_path, "adapter_model.safetensors.index.json"
                     )
@@ -7392,11 +7379,10 @@ class FastMLXModel:
                     # Reload the base via FastMLXModel.from_pretrained (text +
                     # VLM); the old mlx_lm.load fallback broke VLM adapters
                     # (mlx-lm load is text-only).
-                    # MLX adapters carry base quantization in metadata (applied
-                    # via mlx_quantization_config below), so the flags are pinned
-                    # off. PEFT configs carry none: honor the caller's flags as a
-                    # plain base load would, else every QLoRA-style import
-                    # silently loads a full-precision base.
+                    # MLX adapters carry base quantization in metadata, so the
+                    # flags are pinned off. PEFT configs carry none: honor the
+                    # caller's flags as a plain base load would, else every
+                    # QLoRA-style import loads a full-precision base.
                     _base_quant_flags = (
                         {
                             "load_in_4bit": load_in_4bit,
@@ -7405,9 +7391,8 @@ class FastMLXModel:
                             "load_in_fp8": load_in_fp8,
                             "load_in_mxfp4": load_in_mxfp4,
                             "load_in_nvfp4": load_in_nvfp4,
-                            # The richer controls must travel too: an explicit
-                            # config/predicate changes how the flags resolve, so
-                            # dropping it would quantize against the caller's ask.
+                            # The richer controls travel too: an explicit
+                            # config or predicate changes how flags resolve.
                             **{
                                 _qk: _qv
                                 for _qk, _qv in (
@@ -7438,10 +7423,9 @@ class FastMLXModel:
                         and adapter_cfg.get("_unsloth_peft_import")
                     ):
                         # bnb-remapped base: the generated 4-bit config is only
-                        # a default, so any explicit caller request wins
-                        # UNIFORMLY whatever its spelling (flag, q_* knob, config
-                        # dict). Otherwise the remap config applies and caller
-                        # dicts are dropped so the keyword is not passed twice.
+                        # a default, so any explicit caller request wins whatever
+                        # its spelling. Otherwise the remap config applies and
+                        # caller dicts are dropped, so nothing is passed twice.
                         _caller_quant_override = _peft_import_quant_override(_base_quant_flags)
                         if _caller_quant_override:
                             adapter_mlx_quant_config = None
@@ -7474,9 +7458,8 @@ class FastMLXModel:
                     )
                     _validate_mlx_adapter_base(model, adapter_cfg)
                     if adapter_cfg.get("_unsloth_peft_import"):
-                        # PEFT import: the weight file drives attachment (module
-                        # set, rank from shapes, scale from the validated config).
-                        # Binding is all-or-nothing inside the interop module,
+                        # PEFT import: the weight file drives attachment, and
+                        # binding is all-or-nothing inside the interop module,
                         # which also applies the freeze contract, so the
                         # mlx-format reload path below is skipped whole.
                         from .utils import attach_and_bind_peft_adapter
@@ -7494,11 +7477,9 @@ class FastMLXModel:
                             adapter_cfg.get("unsloth_mlx_lora_module_paths"),
                         )
                         # Saved exact paths win: build and shape-check those
-                        # wrappers before strict=False can mutate them. The
-                        # full-state shape snapshot must be taken here too —
-                        # afterwards the live tree reflects whatever the file
-                        # carried, and the resized-artifact check needs the
-                        # base's shapes.
+                        # wrappers before strict=False can mutate them. Snapshot
+                        # full-state shapes here too, while the live tree still
+                        # holds the base's.
                         _fs_prebind = {}
                         _fs_cfg_map = dict(
                             adapter_cfg.get("full_state_modules") or {}
@@ -7544,10 +7525,9 @@ class FastMLXModel:
                                 adapter_cfg,
                                 adapter_weights_file,
                             )
-                        # Catch a missing mlx_lm.tuner.dora before load_adapters
-                        # rebuilds plain LoRA and drops saved `.m` via
-                        # strict=False (distinct from the per-module post-check
-                        # in _apply_lora_at_paths).
+                        # Catch a missing mlx_lm.tuner.dora before
+                        # load_adapters rebuilds plain LoRA and drops saved
+                        # `.m` via strict=False.
                         if adapter_cfg.get("fine_tune_type") == "dora":
                             try:
                                 import mlx_lm.tuner.dora  # noqa: F401
@@ -7604,10 +7584,9 @@ class FastMLXModel:
                     # mlx-lm's load_adapters applies the adapter layers but,
                     # unlike get_peft_model, never freezes the base, so a fresh
                     # MLXTrainer would full-finetune it at a LoRA learning rate.
-                    # Skipped for full_finetuning; for PEFT imports, whose attach
-                    # already froze the base and left modules_to_save trainable;
-                    # and when there are no LoRA modules (fine_tune_type="full"),
-                    # which would otherwise freeze the model entirely.
+                    # Skipped for full_finetuning; for PEFT imports, whose
+                    # attach already applied the freeze contract; and with no
+                    # LoRA modules, which would freeze the model entirely.
                     if not full_finetuning and not adapter_cfg.get(
                         "_unsloth_peft_import"
                     ):
@@ -7630,37 +7609,10 @@ class FastMLXModel:
                         _unfreeze_saved_mlx_non_adapter_parameters(
                             model, adapter_weights_file,
                         )
-                    if adapter_cfg.get("unsloth_peft_converted") and not (
-                        adapter_cfg.get("_unsloth_peft_import")
-                    ):
-                        _emb_wrapped = sorted(
-                            _n for _n, _m in model.named_modules()
-                            if hasattr(_m, "lora_a")
-                            and getattr(_m, "embedding", None) is not None
-                        )
-                        if _emb_wrapped:
-                            from .utils import _model_ties_output_to_embedding
-                            if _model_ties_output_to_embedding(model):
-                                raise ValueError(
-                                    f"Unsloth MLX: {_emb_wrapped} carry "
-                                    "embedding adapters but this model "
-                                    "routes output logits through the "
-                                    "embedding; mlx-lm would apply the "
-                                    "update to output projection while "
-                                    "peft-side training applied it to "
-                                    "input lookup only. The artifact "
-                                    "cannot load faithfully."
-                                )
                     if adapter_cfg.get("unsloth_peft_converted"):
                         # Provenance survives load/save: derivatives keep their
                         # peft-parity guarantees.
                         model._unsloth_peft_converted = True
-                    if adapter_cfg.get("unsloth_mlx_tree_prefix"):
-                        # Same for the text-tower nesting, so a re-save keeps the
-                        # marker a later PEFT conversion needs.
-                        model._unsloth_tree_prefix = adapter_cfg[
-                            "unsloth_mlx_tree_prefix"
-                        ]
                     _fs_map = dict(adapter_cfg.get("full_state_modules") or {})
                     if _fs_map and not adapter_cfg.get("_unsloth_peft_import"):
                         # After the freeze, never before: restores

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -13235,13 +13235,9 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
             if tower_prefix and _name.startswith(tower_prefix):
                 _name = _name[len(tower_prefix):]
             if _name in module_types:
-                _d = getattr(_module, "dropout", None)
-                # mlx nn.Dropout keeps 1-p internally; older builds exposed p.
-                _p = getattr(_d, "p", None)
-                if _p is None and hasattr(_d, "_p_1"):
-                    _p = 1.0 - float(_d._p_1)
-                if _p is not None:
-                    _dropouts.add(round(float(_p), 6))
+                _dropouts.add(round(_get_mlx_dropout_probability(
+                    getattr(_module, "dropout", None)
+                ), 6))
         if len(_dropouts) > 1:
             raise ValueError(
                 "Unsloth MLX: modules carry different lora_dropout values "

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -15670,6 +15670,11 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
     import mlx.nn as nn
     from mlx_lm.tuner.lora import LoRALinear
 
+    # Older mlx-lm wheels reject scale/dropout on from_base(); the native
+    # adapter path patches that gap and this path builds the same wrappers.
+    from .loader import _patch_mlx_lora_from_base_compat
+    _patch_mlx_lora_from_base_compat()
+
     from unsloth_zoo.saving_utils import _reject_dora_dropout
     _reject_dora_dropout(cfg)
     use_dora = bool(cfg.get("use_dora"))

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -12750,6 +12750,53 @@ def _save_adapter_artifacts(model, path, tensors, adapter_config=None):
             "tensors; use save_lora_adapters() or "
             "save_trainable_adapters() at the public entry point."
         )
+    _fs_map = dict(getattr(model, "_unsloth_full_state_modules", None) or {})
+    if _fs_map:
+        # No pristine base at save time: every recorded module ships as-is.
+        _by_name = dict(model.named_modules())
+        tensors = dict(tensors)
+        for _p in sorted(_fs_map):
+            _module = _by_name.get(_p)
+            if _module is None:
+                raise ValueError(
+                    f"Unsloth MLX: full-state module {_p!r} was recorded at "
+                    "adapter attach but no longer exists in the model tree; "
+                    "refusing to write an artifact that cannot restore it."
+                )
+            # LoRA wrappers hold the base under .embedding/.linear; that
+            # inner path is what a reload's load_weights binds.
+            _prefix, _source = _p, _module
+            if hasattr(_module, "lora_a"):
+                for _inner in ("embedding", "linear"):
+                    _in = getattr(_module, _inner, None)
+                    if _in is not None and hasattr(_in, "parameters"):
+                        _prefix, _source = f"{_p}.{_inner}", _in
+                        break
+            if isinstance(_source, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
+                raise ValueError(
+                    f"Unsloth MLX: full-state module {_p!r} was quantized "
+                    "after adapter attach; its packed tensors cannot be "
+                    "persisted as module state. Keep it unquantized."
+                )
+            _found = False
+            for _tname in ("weight", "bias"):
+                _live = getattr(_source, _tname, None)
+                if isinstance(_live, mx.array):
+                    if "float" not in str(_live.dtype).lower():
+                        raise ValueError(
+                            f"Unsloth MLX: full-state module {_p!r} holds "
+                            f"non-floating {_tname} ({_live.dtype}); packed "
+                            "or quantized state cannot be persisted as "
+                            "module state. Keep it unquantized."
+                        )
+                    tensors.setdefault(f"{_prefix}.{_tname}", _live)
+                    _found = True
+            if not _found:
+                raise ValueError(
+                    f"Unsloth MLX: full-state module {_p!r} carries no "
+                    "weight/bias arrays to persist (it may have been "
+                    "quantized after attach); refusing a partial artifact."
+                )
     path = Path(path)
     path.mkdir(parents=True, exist_ok=True)
 
@@ -13088,7 +13135,8 @@ def _lora_module_types(model):
         n: t for n, t in wrapped.items() if not t.startswith("unsupported:")
     }
     mirrored_layout = supported and not unsupported and all(
-        in_stack.match(name) or name == "lm_head" for name in supported
+        in_stack.match(name) or name in ("lm_head", "model.embed_tokens")
+        for name in supported
     )
     if not mirrored_layout:
         supported = {n: t for n, t in supported.items() if in_stack.match(n)}
@@ -13127,6 +13175,36 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
                 "Unsloth MLX: this model carries LoRA wrappers that plain "
                 f"PEFT format cannot represent ({preview}); PEFT export is "
                 "not possible for it."
+            )
+        from unsloth_zoo.saving_utils import _OUTPUT_HEAD_LEAF_NAMES, _leaf_in
+        _fs_map = dict(getattr(model, "_unsloth_full_state_modules", None) or {})
+        _named = dict(model.named_modules())
+        _m2s_emb = sorted(
+            p for p, o in _fs_map.items()
+            if o == "modules_to_save"
+            and (
+                isinstance(
+                    _named.get(p), (nn.Embedding, nn.QuantizedEmbedding)
+                )
+                or _leaf_in(p, _OUTPUT_HEAD_LEAF_NAMES)
+            )
+        )
+        if _m2s_emb and _model_ties_output_to_embedding(model):
+            raise ValueError(
+                f"Unsloth MLX: {_m2s_emb} are modules_to_save replacements "
+                "of a tied embedding or output head; peft would train an "
+                "untied copy while the tied MLX embedding both looks up "
+                "inputs and projects output logits, so no faithful export "
+                "exists."
+            )
+        if any(t == "embedding" for t in module_types.values()) and (
+            _model_ties_output_to_embedding(model)
+        ):
+            raise ValueError(
+                "Unsloth MLX: this model ties word embeddings and routes "
+                "output logits through the embedding adapter; peft applies "
+                "embedding LoRA to input lookup only, so PEFT export would "
+                "change semantics."
             )
         # PEFT has no per-module dropout; a mixed-dropout model would
         # silently train differently after export.
@@ -13174,6 +13252,230 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
         convert_mlx_dir_to_peft(scratch_dir, path, module_types=module_types)
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
+
+
+def _model_ties_output_to_embedding(model, by_name=None):
+    """True when output logits may route through the embedding module: the
+    config declares tied word embeddings, OR the tree carries no output head
+    under any known spelling (always-tied architectures carry no flag). A tree
+    WITH a head cannot prove the reverse — some build one and still route tied
+    logits through the embedding — so a true flag stays conservative."""
+    flag = getattr(
+        getattr(model, "args", None), "tie_word_embeddings", None,
+    )
+    if flag is None:
+        config = getattr(model, "_config", None)
+        if isinstance(config, dict):
+            text_config = config.get("text_config")
+            for scope in (
+                text_config if isinstance(text_config, dict) else {},
+                config,
+            ):
+                if "tie_word_embeddings" in scope:
+                    flag = bool(scope["tie_word_embeddings"])
+                    break
+    if flag is True:
+        # Declared True stays conservative: some architectures keep a dead head.
+        return True
+    if by_name is None:
+        by_name = dict(model.named_modules())
+    # No head module means output NECESSARILY projects through the embedding,
+    # outranking even a declared False (some declare False yet route via
+    # as_linear). Spellings: lm_head (most), output (Llama-4 text, InternLM2),
+    # embed_out (GPT-NeoX). Bare "output" stays root-only so unrelated nested
+    # submodules cannot masquerade as the head.
+    return not any(
+        name in ("lm_head", "output", "embed_out")
+        or name.endswith(".lm_head")
+        or name.endswith(".embed_out")
+        for name in by_name
+    )
+
+
+def _full_state_base_module(module):
+    """The module holding a full-state tensor: a LoRA wrapper keeps its base
+    under .embedding/.linear, which carries the non-adapter parameters."""
+    if hasattr(module, "lora_a"):
+        for inner in ("embedding", "linear"):
+            candidate = getattr(module, inner, None)
+            if candidate is not None and hasattr(candidate, "parameters"):
+                return candidate
+    return module
+
+
+def _full_state_key_candidates(path):
+    """Tree-native key spellings a full-state module's tensors may use:
+    plain for a bare module, .embedding/.linear-inner for a LoRA wrapper."""
+    keys = []
+    for prefix in (path, f"{path}.embedding", f"{path}.linear"):
+        for tname in ("weight", "bias"):
+            keys.append(f"{prefix}.{tname}")
+    return keys
+
+
+def _mark_full_state_modules(model, fs_map, adapter_weights_file,
+                             expected_shapes=None, trainable_paths=None):
+    """Re-establish full-state bookkeeping after an mlx-format reload.
+
+    load_weights(strict=False) neither validates shapes nor reports what it
+    bound, and a resized saved tensor silently replaces the live array, so
+    verify each recorded module's saved tensors against the live tree AND
+    against ``expected_shapes`` captured before binding, restore
+    modules_to_save trainability, and re-record the origin map.
+    """
+    fs_map = dict(fs_map or {})
+    if not fs_map:
+        return
+    _bad_origins = {
+        p: o for p, o in fs_map.items()
+        if o not in ("modules_to_save", "embedding_auto")
+    }
+    if _bad_origins:
+        raise ValueError(
+            f"Unsloth MLX: full_state_modules carries unknown origin "
+            f"tag(s) {_bad_origins}; expected 'modules_to_save' or "
+            "'embedding_auto'."
+        )
+    by_name = dict(model.named_modules())
+    params = dict(mlx.utils.tree_flatten(model.parameters()))
+    expected_shapes = expected_shapes or {}
+    problems = []
+    saved_shapes = {}
+    saved_dtypes = {}
+    try:
+        from safetensors import safe_open
+        with safe_open(adapter_weights_file, framework="numpy") as f:
+            keys = set(f.keys())
+            for p in fs_map:
+                for key in _full_state_key_candidates(p):
+                    if key in keys:
+                        # Metadata-only: works for dtypes numpy cannot hold (bf16).
+                        sl = f.get_slice(key)
+                        saved_shapes[key] = tuple(sl.get_shape())
+                        saved_dtypes[key] = str(sl.get_dtype())
+    except Exception as exc:
+        raise ValueError(
+            "Unsloth MLX: adapter_config lists full_state_modules but the "
+            f"weights file could not be inspected ({exc!r})."
+        ) from exc
+    tied_routing = None
+    for p, origin in sorted(fs_map.items()):
+        module = by_name.get(p)
+        if module is None:
+            problems.append(f"{p} (module missing from the live tree)")
+            continue
+        import mlx.nn as nn
+        from unsloth_zoo.saving_utils import _OUTPUT_HEAD_LEAF_NAMES, _leaf_in
+        _embeddingish = isinstance(
+            module, (nn.Embedding, nn.QuantizedEmbedding)
+        ) or _leaf_in(p, _OUTPUT_HEAD_LEAF_NAMES)
+        if origin == "modules_to_save" and _embeddingish:
+            if tied_routing is None:
+                tied_routing = _model_ties_output_to_embedding(
+                    model, by_name,
+                )
+            if tied_routing:
+                problems.append(
+                    f"{p} (modules_to_save replacement of a tied "
+                    "embedding or output head: peft trained an untied "
+                    "copy while this model's tied embedding both "
+                    "looks up inputs and projects output logits)"
+                )
+                continue
+        if origin == "embedding_auto" and _leaf_in(
+            p, _OUTPUT_HEAD_LEAF_NAMES
+        ):
+            # A tied conversion folds head duplicates away; a survivor would
+            # bind dead head state while logits flow through the embedding.
+            if tied_routing is None:
+                tied_routing = _model_ties_output_to_embedding(
+                    model, by_name,
+                )
+            if tied_routing:
+                problems.append(
+                    f"{p} (auto-saved output-head state on a model that "
+                    "routes logits through its embedding; the snapshot "
+                    "cannot restore as head state)"
+                )
+                continue
+        found = False
+        for key in _full_state_key_candidates(p):
+            if key not in saved_shapes:
+                # Full-module snapshots: a missing tensor would silently
+                # retain base state.
+                if key in params:
+                    problems.append(f"{key} (live tensor missing from the artifact)")
+                continue
+            found = True
+            if not saved_dtypes.get(key, "").upper().startswith(("F", "BF")):
+                problems.append(
+                    f"{key} (non-floating dtype {saved_dtypes[key]}; "
+                    "quantized or corrupted full-module state cannot "
+                    "restore)"
+                )
+                continue
+            live = params.get(key)
+            live_shape = tuple(getattr(live, "shape", ()) or ())
+            if live_shape != saved_shapes[key]:
+                problems.append(
+                    f"{key} (saved {saved_shapes[key]} vs live {live_shape})"
+                )
+                continue
+            expected = expected_shapes.get(key)
+            if expected is not None and saved_shapes[key] != expected:
+                problems.append(
+                    f"{key} (saved {saved_shapes[key]} vs base "
+                    f"{expected}; resized vocabularies are not supported "
+                    "yet)"
+                )
+        if not found:
+            problems.append(f"{p} (no saved weight/bias tensors)")
+    if problems:
+        preview = "; ".join(problems[:5])
+        if len(problems) > 5:
+            preview += f"; ... (+{len(problems) - 5} more)"
+        raise ValueError(
+            f"Unsloth MLX: {len(problems)} full-state entr(ies) failed to "
+            f"restore on reload ({preview}). Refusing a partial adapter."
+        )
+    _trainable_at_save = frozenset(trainable_paths or ())
+    for p, origin in fs_map.items():
+        module = by_name[p]
+        if origin == "modules_to_save":
+            module.unfreeze()
+            continue
+        # Auto-saved embeddings are frozen by default, but continued
+        # pretraining may have trained one; the artifact records which so a
+        # reload restores the same contract. Only the inner base is touched.
+        target = _full_state_base_module(module)
+        if p in _trainable_at_save:
+            target.unfreeze()
+        else:
+            target.freeze()
+    # An mlx-format reload treats restored non-adapter tensors as continued-
+    # pretraining state eligible for the scoped embedding LR. modules_to_save
+    # is adapter state: drop it so this path trains it at the main LR, exactly
+    # as a direct PEFT import does.
+    _cpt_keys = getattr(model, "_unsloth_cpt_full_module_weight_keys", None)
+    if _cpt_keys:
+        _m2s = frozenset(
+            path for path, origin in fs_map.items()
+            if origin == "modules_to_save"
+        )
+
+        def _owns(key):
+            owner = key.rsplit(".", 1)[0]
+            if owner in _m2s:
+                return True
+            for inner in (".embedding", ".linear"):
+                if owner.endswith(inner) and owner[: -len(inner)] in _m2s:
+                    return True
+            return False
+
+        model._unsloth_cpt_full_module_weight_keys = {
+            key for key in _cpt_keys if not _owns(key)
+        }
+    model._unsloth_full_state_modules = fs_map
 
 
 def _infer_snapshot_commit(path):
@@ -13485,6 +13787,34 @@ def _enrich_mlx_adapter_config(model, adapter_config):
     if resolved_map and quant_source != "mlx_config":
         requires_runtime = True
     adapter_config["requires_unsloth_mlx_runtime_quantization"] = bool(requires_runtime)
+
+    _fs_map = dict(getattr(model, "_unsloth_full_state_modules", None) or {})
+    if _fs_map:
+        adapter_config["full_state_modules"] = _fs_map
+        # Record save-time trainability so a reload restores it:
+        # modules_to_save is trainable by definition, an auto-saved embedding
+        # frozen UNLESS continued pretraining unfroze it.
+        _by_name = dict(model.named_modules())
+        _trainable_fs = []
+        for _p in sorted(_fs_map):
+            _module = _by_name.get(_p)
+            if _module is None:
+                continue
+            _base = _full_state_base_module(_module)
+            if dict(mlx.utils.tree_flatten(_base.trainable_parameters())):
+                _trainable_fs.append(_p)
+        if _trainable_fs:
+            adapter_config["full_state_trainable"] = _trainable_fs
+        else:
+            adapter_config.pop("full_state_trainable", None)
+    else:
+        adapter_config.pop("full_state_modules", None)
+        adapter_config.pop("full_state_trainable", None)
+
+    if getattr(model, "_unsloth_peft_converted", False):
+        adapter_config["unsloth_peft_converted"] = True
+    else:
+        adapter_config.pop("unsloth_peft_converted", None)
 
     # Only stamp LoRA fields when the live model has LoRA modules (or the
     # caller declared a lora/dora artifact); otherwise mlx-lm.load_adapters()
@@ -15228,24 +15558,12 @@ def push_to_hub_gguf(
 
 
 # ---------------------------------------------------------------------------
-# PEFT <-> MLX LoRA adapter interop.
-#
-# PEFT adapters (adapter_model.safetensors, lora_A/lora_B keys under a
-# base_model.model. prefix) and mlx-lm adapters (adapters.safetensors,
-# lora_a/lora_b keys) encode the same math in different layouts:
-#
-#     peft {p}.lora_A.weight [r, in]   ==  mlx {p}.lora_a [in, r], transposed
-#     peft {p}.lora_B.weight [out, r]  ==  mlx {p}.lora_b [r, out], transposed
-#     effective scale = lora_alpha / r     (rsLoRA: lora_alpha / sqrt(r))
-#
-# Conversion is rename + transpose only; dtypes are preserved exactly and a
-# round trip is bitwise-identical for the supported subset (plain linear
-# LoRA and linear DoRA, whose magnitude maps to mlx-lm's m without
-# transpose). Adapters carrying modules_to_save state, embedding LoRA, or
-# expert target_parameters factors are refused with a named reason instead
-# of being partially or lossily converted. Tensor IO prefers
-# mlx.core (native bfloat16) with a safetensors.torch fallback off Apple
-# hardware; the safetensors numpy backend cannot represent bf16.
+# PEFT <-> MLX LoRA adapter interop. The format mapping and conversion rules
+# are documented in unsloth_zoo.saving_utils, which holds the detection,
+# validation and conversion helpers so CUDA hosts can import them without mlx.
+# The delegates below keep the loader-facing surface here, and mx-native
+# attach_and_bind_peft_adapter stays so torch-less Apple installs never import
+# the torch-side module.
 # ---------------------------------------------------------------------------
 
 def detect_adapter_format(path):
@@ -15270,7 +15588,10 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
     """
     from unsloth_zoo.saving_utils import (
         PEFT_WEIGHTS_FILE,
+        _EMBEDDING_LEAF_NAMES,
+        _OUTPUT_HEAD_LEAF_NAMES,
         _effective_scale,
+        _leaf_in,
         _raise_rejected,
         group_peft_lora_pairs,
     )
@@ -15291,13 +15612,17 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
             ) from exc
 
     tensors = dict(mx.load(os.path.join(adapter_dir, PEFT_WEIGHTS_FILE)))
-    pairs, rejected = group_peft_lora_pairs(tensors)
+    pairs, full_state, rejected = group_peft_lora_pairs(tensors, cfg)
     if rejected:
         _raise_rejected(rejected, f"{adapter_dir!r}")
     if not pairs:
         raise ValueError(
-            f"Unsloth MLX: {adapter_dir!r} has no linear LoRA tensor pairs."
+            f"Unsloth MLX: {adapter_dir!r} has no LoRA tensor pairs."
         )
+    try:
+        from mlx_lm.tuner.lora import LoRAEmbedding
+    except ImportError:
+        LoRAEmbedding = None
 
     by_name = dict(model.named_modules())
     linear_types = (nn.Linear, nn.QuantizedLinear)
@@ -15306,7 +15631,55 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
     module_scales = {}
     module_ranks = {}
     staged = []
+    emb_types = tuple(
+        t for t in (nn.Embedding, nn.QuantizedEmbedding) if t is not None
+    )
+    tied_embeddings = _model_ties_output_to_embedding(model, by_name)
     for path in sorted(pairs):
+        if "EA" in pairs[path]:
+            module = by_name.get(path)
+            if module is None or type(module) not in emb_types:
+                unmatched.append(
+                    f"{path} ({type(module).__name__ if module else 'missing'};"
+                    " embedding LoRA needs a stock embedding module)"
+                )
+                continue
+            if tied_embeddings:
+                unmatched.append(
+                    f"{path} (embedding LoRA on a tied-embeddings model: "
+                    "mlx-lm applies the update to the tied output "
+                    "projection while peft applies it to input lookup "
+                    "only, so no faithful import exists)"
+                )
+                continue
+            if dropout > 0:
+                unmatched.append(
+                    f"{path} (embedding LoRA with nonzero lora_dropout: "
+                    "peft applies no dropout on embedding adapters while "
+                    "mlx-lm does; import would change training behavior)"
+                )
+                continue
+            if LoRAEmbedding is None:
+                raise ImportError(
+                    "Unsloth MLX: embedding LoRA needs mlx_lm.tuner.lora."
+                    "LoRAEmbedding; upgrade mlx-lm."
+                )
+            ea, eb = pairs[path]["EA"], pairs[path]["EB"]
+            rank = int(ea.shape[0])
+            scale = _effective_scale(cfg, path, rank)
+            wrapped = LoRAEmbedding.from_base(
+                module, r=rank, dropout=dropout, scale=scale
+            )
+            la, lb = ea.T, eb.T
+            if wrapped.lora_a.shape != la.shape or wrapped.lora_b.shape != lb.shape:
+                unmatched.append(f"{path} (embedding LoRA shape mismatch)")
+                continue
+            wrapped.lora_a = la
+            wrapped.lora_b = lb
+            staged.append((path, wrapped))
+            module_scales[path] = scale
+            module_ranks[path] = rank
+            continue
         a, b = pairs[path]["A"], pairs[path]["B"]
         rank = int(a.shape[0])
         if int(b.shape[1]) != rank:
@@ -15366,24 +15739,172 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
         staged.append((path, wrapped))
         module_scales[path] = scale
         module_ranks[path] = rank
+    # Full-state entries: verify against the live base and PLAN the
+    # application — nothing mutates until every entry validates, so a refused
+    # import leaves the caller's model untouched. Equal snapshots are skipped;
+    # differing ones are applied and origin-recorded so saves round-trip them.
+    applied_full_state = {}
+    fs_plan = []
+    for path, entries in sorted(full_state.items()):
+        origin = entries["__origin__"]
+        module = by_name.get(path)
+        if (
+            origin == "embedding_auto"
+            and tied_embeddings
+            and _leaf_in(path, _OUTPUT_HEAD_LEAF_NAMES)
+        ):
+            # peft saves the tied output head as its own entry, but the
+            # tensor IS the tied embedding weight: verify against the incoming
+            # snapshot (or the live embedding) and fold — never apply as head
+            # state, whether or not the tree keeps a dead head module.
+            emb_candidates = [
+                m for n, m in by_name.items()
+                if _leaf_in(n, _EMBEDDING_LEAF_NAMES)
+                and isinstance(m, emb_types)
+            ]
+            if len(emb_candidates) > 1:
+                unmatched.append(
+                    f"{path} (multiple embedding modules; the tied "
+                    "output-head duplicate cannot be attributed)"
+                )
+                continue
+            emb_module = emb_candidates[0] if emb_candidates else None
+            emb_weight = getattr(emb_module, "weight", None)
+            for _ep, _ev in full_state.items():
+                if _leaf_in(_ep, _EMBEDDING_LEAF_NAMES):
+                    # Artifact replaces the embedding: match the INCOMING weight.
+                    emb_weight = _ev.get("weight", emb_weight)
+                    break
+            snapshot = entries.get("weight")
+            if snapshot is not None and "float" not in str(
+                snapshot.dtype
+            ).lower():
+                unmatched.append(
+                    f"{path} (non-floating tied output-head snapshot "
+                    f"dtype {snapshot.dtype})"
+                )
+                continue
+            extra = sorted(set(entries) - {"__origin__", "weight"})
+            if extra:
+                unmatched.append(
+                    f"{path} (tied output-head snapshot carries "
+                    f"{extra}; the tied MLX embedding has no slot for "
+                    "them)"
+                )
+                continue
+            if emb_weight is not None and snapshot is not None:
+                if snapshot.dtype != emb_weight.dtype:
+                    snapshot = snapshot.astype(emb_weight.dtype)
+                if bool(mx.array_equal(emb_weight, snapshot)):
+                    continue
+            unmatched.append(
+                f"{path} (tied output-head snapshot differs from the "
+                "tied embedding; a tied MLX model cannot hold an "
+                "independent output head)"
+            )
+            continue
+        if module is None:
+            unmatched.append(f"{path} (full-state target missing)")
+            continue
+        if isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
+            unmatched.append(
+                f"{path} (a quantized base cannot verify or accept a "
+                "full-module snapshot; exclude the module from "
+                "quantization to import it)"
+            )
+            continue
+        if (
+            origin == "modules_to_save"
+            and tied_embeddings
+            and (
+                isinstance(module, emb_types)
+                or _leaf_in(path, _OUTPUT_HEAD_LEAF_NAMES)
+            )
+        ):
+            unmatched.append(
+                f"{path} (modules_to_save snapshot of a tied embedding or "
+                "output head: peft trains an untied copy while the tied "
+                "MLX embedding both looks up inputs and projects output "
+                "logits)"
+            )
+            continue
+        for tname, tensor in entries.items():
+            if tname == "__origin__":
+                continue
+            live = getattr(module, tname, None)
+            if live is None or tuple(live.shape) != tuple(tensor.shape):
+                unmatched.append(
+                    f"{path}.{tname} (full-state shape mismatch; resized "
+                    "vocabularies are not supported yet)"
+                )
+                continue
+            if "float" not in str(tensor.dtype).lower():
+                unmatched.append(
+                    f"{path}.{tname} (non-floating snapshot dtype "
+                    f"{tensor.dtype}; packed or quantized state cannot "
+                    "restore as module state)"
+                )
+                continue
+            # Compare and apply in the live dtype: the loader may have cast
+            # the base while peft saved full precision, and a pure precision
+            # gap is not a replacement.
+            if tensor.dtype != live.dtype:
+                tensor = tensor.astype(live.dtype)
+            if bool(mx.array_equal(live, tensor)):
+                continue
+            fs_plan.append((module, tname, tensor))
+            applied_full_state[path] = origin
+        if origin == "modules_to_save" and path not in applied_full_state:
+            # Equal-valued snapshot still marks the module trainable.
+            applied_full_state[path] = origin
+    # peft replaces the ENTIRE module for modules_to_save: every tensor the
+    # live module carries must be in the snapshot, else a truncated artifact
+    # silently retains base state.
+    from mlx.utils import tree_flatten as _tree_flatten
+    for _name in sorted(set(cfg.get("modules_to_save") or [])):
+        for _parent_path, _parent in by_name.items():
+            # Raw endswith, matching peft's selection (["head"] wraps lm_head).
+            if not _parent_path.endswith(_name):
+                continue
+            for _k, _v in _tree_flatten(_parent.parameters()):
+                _tname = _k.rsplit(".", 1)[-1]
+                _sub = (
+                    _parent_path if "." not in _k
+                    else f"{_parent_path}.{_k[: -len(_tname) - 1]}"
+                )
+                if _tname not in (full_state.get(_sub) or {}):
+                    unmatched.append(
+                        f"{_sub}.{_tname} (modules_to_save snapshot for "
+                        f"{_name!r} lacks this tensor; peft snapshots are "
+                        "full module state)"
+                    )
     if unmatched:
         preview = "; ".join(unmatched[:5])
         if len(unmatched) > 5:
             preview += f"; ... (+{len(unmatched) - 5} more)"
         raise ValueError(
-            f"Unsloth MLX: {len(unmatched)} PEFT adapter tensor pair(s) do "
-            f"not map onto the loaded MLX model ({preview}). Refusing a "
+            f"Unsloth MLX: {len(unmatched)} PEFT adapter entr(ies) do not "
+            f"map onto the loaded MLX model ({preview}). Refusing a "
             "partial import."
         )
     # Freeze the base before installing wrappers so only the new LoRA tensors
     # train (peft's is_trainable contract); a save must capture everything an
     # optimizer moved.
     model.freeze()
+    for module, tname, tensor in fs_plan:
+        setattr(module, tname, tensor)
     from mlx.utils import tree_unflatten
     model.update_modules(tree_unflatten(staged))
     # New wrappers start in training mode regardless of the host's; re-propagate
     # so nonzero lora_dropout cannot make inference stochastic on an eval model.
     model.train(bool(getattr(model, "training", False)))
+    # modules_to_save stays trainable (peft semantics); auto-saved frozen.
+    for path, origin in applied_full_state.items():
+        if origin == "modules_to_save":
+            by_name[path].unfreeze()
+    model._unsloth_full_state_modules = dict(applied_full_state)
+    # peft-origin: saves of this model carry the conversion marker.
+    model._unsloth_peft_converted = True
     mx.eval(model.parameters())
     # Shapes carry ranks, but scale variance must survive a zoo-side re-save
     # (stock mlx-lm has a single global scale).

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -13008,14 +13008,119 @@ def load_trainer_state(path):
         return json.load(f)
 
 
-def save_lora_adapters(model, path, adapter_config=None):
+def _lora_module_types(model):
+    """Map LoRA-wrapped module paths to 'linear' / 'embedding', but only where
+    the live tree demonstrates the Hugging Face identity an oracle entry
+    asserts (module type AND an identical dotted path). The tree proves the
+    type, not the path — mlx-lm renames GPT-2-style roots — so out-of-stack
+    entries are emitted only when every wrapped path is either inside the
+    HF-mirroring `model.layers.N.` layout or one of the root-level names that
+    layout mirrors (lm_head, model.embed_tokens), and then only for those
+    roots. Everything else stays unasserted and the converter's named
+    rejection stands."""
+    from mlx_lm.tuner.lora import LoRALinear
+    try:
+        from mlx_lm.tuner.lora import LoRAEmbedding
+    except ImportError:
+        LoRAEmbedding = None
+    wrapped = {}
+    for name, module in model.named_modules():
+        if not (hasattr(module, "lora_a") and hasattr(module, "lora_b")):
+            continue
+        base_linear = getattr(module, "linear", None)
+        base_embedding = getattr(module, "embedding", None)
+        # Exact stock types only: a custom wrapper or base can carry gating
+        # or rescaling that plain PEFT LoRA cannot express.
+        if (
+            LoRAEmbedding is not None
+            and type(module) is LoRAEmbedding
+            and type(base_embedding) in (nn.Embedding, nn.QuantizedEmbedding)
+        ):
+            wrapped[name] = "embedding"
+        elif type(module) is LoRALinear and type(base_linear) in (
+            nn.Linear, nn.QuantizedLinear,
+        ):
+            wrapped[name] = "linear"
+        elif type(module) is LoRALinear or (
+            LoRAEmbedding is not None and type(module) is LoRAEmbedding
+        ):
+            # Name the base class — the actual reason for refusal.
+            _base = base_linear if base_linear is not None else base_embedding
+            wrapped[name] = (
+                f"unsupported:{type(module).__name__} wrapping "
+                f"{type(_base).__name__}"
+            )
+        else:
+            # Record it so callers refuse, rather than let an in-stack path
+            # slip through the converter's layout gate as linear.
+            wrapped[name] = f"unsupported:{type(module).__name__}"
+    in_stack = re.compile(r"^model\.layers\.\d+\.")
+    unsupported = {
+        n: t.split(":", 1)[1]
+        for n, t in wrapped.items() if t.startswith("unsupported:")
+    }
+    supported = {
+        n: t for n, t in wrapped.items() if not t.startswith("unsupported:")
+    }
+    mirrored_layout = supported and not unsupported and all(
+        in_stack.match(name) or name == "lm_head" for name in supported
+    )
+    if not mirrored_layout:
+        supported = {n: t for n, t in supported.items() if in_stack.match(n)}
+    return supported, unsupported
+
+
+def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
     """Save LoRA adapter weights (lora_a / lora_b only) to disk.
 
     Args:
         model: MLX model with LoRA-wrapped modules.
         path: Directory to save adapters.
         adapter_config: Optional dict with LoRA config metadata.
+        adapter_format: "mlx" (default: the native MLX artifact) or "peft"
+            (standard Hugging Face layout). Uniform plain-LoRA exports load in
+            transformers, PEFT, and vLLM; per-module rank/alpha patterns are
+            transformers/PEFT-only, since vLLM applies one global rank/alpha.
+            The live module tree supplies the linear-vs-embedding oracle where
+            the layout demonstrably mirrors Hugging Face.
     """
+    if adapter_format not in ("mlx", "peft"):
+        raise ValueError(
+            f"Unsloth MLX: adapter_format={adapter_format!r}; expected "
+            "'mlx' or 'peft'."
+        )
+    if adapter_format == "peft":
+        # Refuse by name BEFORE collecting tensors: stacked-factor wrappers
+        # (e.g. switch experts) would otherwise fail as a generic no-tensors error.
+        module_types, unsupported = _lora_module_types(model)
+        if unsupported:
+            preview = "; ".join(
+                f"{n} ({t})" for n, t in list(unsupported.items())[:5]
+            )
+            raise ValueError(
+                "Unsloth MLX: this model carries LoRA wrappers that plain "
+                f"PEFT format cannot represent ({preview}); PEFT export is "
+                "not possible for it."
+            )
+        # PEFT has no per-module dropout; a mixed-dropout model would
+        # silently train differently after export.
+        _dropouts = set()
+        for _name, _module in model.named_modules():
+            if _name in module_types:
+                _d = getattr(_module, "dropout", None)
+                # mlx nn.Dropout keeps 1-p internally; older builds exposed p.
+                _p = getattr(_d, "p", None)
+                if _p is None and hasattr(_d, "_p_1"):
+                    _p = 1.0 - float(_d._p_1)
+                if _p is not None:
+                    _dropouts.add(round(float(_p), 6))
+        if len(_dropouts) > 1:
+            raise ValueError(
+                "Unsloth MLX: modules carry different lora_dropout values "
+                f"({sorted(_dropouts)}); PEFT format has no per-module "
+                "dropout, so exporting would silently change training "
+                "behavior. Unify dropout before exporting."
+            )
     adapter_tensors = collect_mlx_lora_adapter_tensors(model)
     if not adapter_tensors:
         raise ValueError(
@@ -13024,9 +13129,24 @@ def save_lora_adapters(model, path, adapter_config=None):
             "merged. Use save_trainable_adapters() to checkpoint non-LoRA "
             "trainable state instead."
         )
-    _save_adapter_artifacts(
-        model, path, adapter_tensors, adapter_config=adapter_config
-    )
+    if adapter_format == "mlx":
+        _save_adapter_artifacts(
+            model, path, adapter_tensors, adapter_config=adapter_config
+        )
+        return
+    # PEFT: write the canonical mlx artifact to scratch, then convert with the
+    # model-derived type oracle — one conversion implementation, one validation.
+    import tempfile
+    from unsloth_zoo.saving_utils import convert_mlx_dir_to_peft
+    scratch = tempfile.mkdtemp(prefix="unsloth_mlx_adapter_")
+    scratch_dir = os.path.join(scratch, "mlx")
+    try:
+        _save_adapter_artifacts(
+            model, scratch_dir, adapter_tensors, adapter_config=adapter_config
+        )
+        convert_mlx_dir_to_peft(scratch_dir, path, module_types=module_types)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
 
 
 def _infer_snapshot_commit(path):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -12871,6 +12871,7 @@ def save_trainable_adapters(model, path, adapter_config=None):
     base weights INSIDE a LoRA module (reload-leaked state that would
     reintroduce the original Unsloth adapter-export bloat).
     """
+    _reject_mixed_lora_dora(model)
     trainable = dict(mlx.utils.tree_flatten(model.trainable_parameters()))
     adapter_tensors = collect_mlx_lora_adapter_tensors(model)
     _lora_module_names = [name for name, _ in iter_mlx_lora_modules(model)]
@@ -13008,6 +13009,25 @@ def load_trainer_state(path):
         return json.load(f)
 
 
+def _reject_mixed_lora_dora(model):
+    """One fine_tune_type is recorded, so a mixed save would reload every
+    module as DoRA and silently change the plain ones."""
+    has_dora = has_plain = False
+    for _name, _module in model.named_modules():
+        if hasattr(_module, "lora_a") and hasattr(_module, "lora_b"):
+            if type(_module).__name__.startswith("DoRA"):
+                has_dora = True
+            else:
+                has_plain = True
+    if has_dora and has_plain:
+        raise ValueError(
+            "Unsloth MLX: this model mixes plain-LoRA and DoRA wrappers; "
+            "the adapter format records one fine_tune_type, so a mixed "
+            "save would reload every module as DoRA. Unify the wrapper "
+            "kind before saving."
+        )
+
+
 def _lora_module_types(model):
     """Map LoRA-wrapped module paths to 'linear' / 'embedding', but only where
     the live tree demonstrates the Hugging Face identity an oracle entry
@@ -13023,6 +13043,10 @@ def _lora_module_types(model):
         from mlx_lm.tuner.lora import LoRAEmbedding
     except ImportError:
         LoRAEmbedding = None
+    try:
+        from mlx_lm.tuner.dora import DoRALinear
+    except ImportError:
+        DoRALinear = None
     wrapped = {}
     for name, module in model.named_modules():
         if not (hasattr(module, "lora_a") and hasattr(module, "lora_b")):
@@ -13037,9 +13061,10 @@ def _lora_module_types(model):
             and type(base_embedding) in (nn.Embedding, nn.QuantizedEmbedding)
         ):
             wrapped[name] = "embedding"
-        elif type(module) is LoRALinear and type(base_linear) in (
-            nn.Linear, nn.QuantizedLinear,
-        ):
+        elif (
+            type(module) is LoRALinear
+            or (DoRALinear is not None and type(module) is DoRALinear)
+        ) and type(base_linear) in (nn.Linear, nn.QuantizedLinear):
             wrapped[name] = "linear"
         elif type(module) is LoRALinear or (
             LoRAEmbedding is not None and type(module) is LoRAEmbedding
@@ -13071,7 +13096,8 @@ def _lora_module_types(model):
 
 
 def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
-    """Save LoRA adapter weights (lora_a / lora_b only) to disk.
+    """Save LoRA adapter weights (lora_a / lora_b, plus DoRA magnitudes) to
+    disk.
 
     Args:
         model: MLX model with LoRA-wrapped modules.
@@ -13121,6 +13147,7 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
                 "dropout, so exporting would silently change training "
                 "behavior. Unify dropout before exporting."
             )
+    _reject_mixed_lora_dora(model)
     adapter_tensors = collect_mlx_lora_adapter_tensors(model)
     if not adapter_tensors:
         raise ValueError(
@@ -15213,9 +15240,10 @@ def push_to_hub_gguf(
 #
 # Conversion is rename + transpose only; dtypes are preserved exactly and a
 # round trip is bitwise-identical for the supported subset (plain linear
-# LoRA). Adapters carrying DoRA magnitudes, modules_to_save state, embedding
-# LoRA, or expert target_parameters factors are refused with a named reason
-# instead of being partially or lossily converted. Tensor IO prefers
+# LoRA and linear DoRA, whose magnitude maps to mlx-lm's m without
+# transpose). Adapters carrying modules_to_save state, embedding LoRA, or
+# expert target_parameters factors are refused with a named reason instead
+# of being partially or lossily converted. Tensor IO prefers
 # mlx.core (native bfloat16) with a safetensors.torch fallback off Apple
 # hardware; the safetensors numpy backend cannot represent bf16.
 # ---------------------------------------------------------------------------
@@ -15249,6 +15277,18 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
     import mlx.core as mx
     import mlx.nn as nn
     from mlx_lm.tuner.lora import LoRALinear
+
+    from unsloth_zoo.saving_utils import _reject_dora_dropout
+    _reject_dora_dropout(cfg)
+    use_dora = bool(cfg.get("use_dora"))
+    if use_dora:
+        try:
+            from mlx_lm.tuner.dora import DoRALinear
+        except ImportError as exc:
+            raise ImportError(
+                "Unsloth MLX: this adapter uses DoRA but mlx_lm.tuner.dora "
+                "is unavailable; upgrade mlx-lm."
+            ) from exc
 
     tensors = dict(mx.load(os.path.join(adapter_dir, PEFT_WEIGHTS_FILE)))
     pairs, rejected = group_peft_lora_pairs(tensors)
@@ -15285,7 +15325,21 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
             )
             continue
         scale = _effective_scale(cfg, path, rank)
-        wrapped = LoRALinear.from_base(module, r=rank, dropout=dropout, scale=scale)
+        mag = pairs[path].get("M")
+        if use_dora and mag is None:
+            unmatched.append(f"{path} (use_dora set but magnitude missing)")
+            continue
+        if not use_dora and mag is not None:
+            unmatched.append(f"{path} (magnitude present without use_dora)")
+            continue
+        if use_dora:
+            wrapped = DoRALinear.from_base(
+                module, r=rank, dropout=dropout, scale=scale
+            )
+        else:
+            wrapped = LoRALinear.from_base(
+                module, r=rank, dropout=dropout, scale=scale
+            )
         lora_a, lora_b = a.T, b.T
         if wrapped.lora_a.shape != lora_a.shape:
             unmatched.append(
@@ -15301,6 +15355,14 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
             continue
         wrapped.lora_a = lora_a
         wrapped.lora_b = lora_b
+        if use_dora:
+            if getattr(mag, "ndim", 0) != 1 or mag.shape != wrapped.m.shape:
+                unmatched.append(
+                    f"{path} (magnitude shape {tuple(mag.shape)} != module "
+                    f"out-dim {wrapped.m.shape[0]})"
+                )
+                continue
+            wrapped.m = mag
         staged.append((path, wrapped))
         module_scales[path] = scale
         module_ranks[path] = rank

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -12785,9 +12785,8 @@ def _save_adapter_artifacts(model, path, tensors, adapter_config=None):
                     if "float" not in str(_live.dtype).lower():
                         raise ValueError(
                             f"Unsloth MLX: full-state module {_p!r} holds "
-                            f"non-floating {_tname} ({_live.dtype}); packed "
-                            "or quantized state cannot be persisted as "
-                            "module state. Keep it unquantized."
+                            f"non-floating {_tname} ({_live.dtype}); keep it "
+                            "unquantized to persist it as module state."
                         )
                     tensors.setdefault(f"{_prefix}.{_tname}", _live)
                     _found = True
@@ -13068,28 +13067,22 @@ def _reject_mixed_lora_dora(model):
                 has_plain = True
     if has_dora and has_plain:
         raise ValueError(
-            "Unsloth MLX: this model mixes plain-LoRA and DoRA wrappers; "
-            "the adapter format records one fine_tune_type, so a mixed "
-            "save would reload every module as DoRA. Unify the wrapper "
-            "kind before saving."
+            "Unsloth MLX: this model mixes plain-LoRA and DoRA wrappers; the "
+            "adapter format records one fine_tune_type, so a mixed save would "
+            "reload every module as DoRA."
         )
 
 
 def _lora_module_types(model):
-    """Map LoRA-wrapped module paths to 'linear' / 'embedding', but only where
-    the live tree demonstrates the Hugging Face identity an oracle entry
-    asserts (module type AND an identical dotted path). The tree proves the
-    type, not the path — mlx-lm renames GPT-2-style roots — so out-of-stack
-    entries are emitted only when every wrapped path is either inside the
-    HF-mirroring `model.layers.N.` layout or one of the root-level names that
-    layout mirrors (lm_head, model.embed_tokens), and then only for those
-    roots. Everything else stays unasserted and the converter's named
+    """Map LoRA-wrapped module paths to 'linear', but only where the live tree
+    demonstrates the Hugging Face identity an oracle entry asserts (module type
+    AND an identical dotted path). The tree proves the type, not the path —
+    mlx-lm renames GPT-2-style roots — so out-of-stack entries are emitted only
+    when every wrapped path is either inside the HF-mirroring `model.layers.N.`
+    layout or at the one root-level name that layout mirrors for a Linear
+    (lm_head). Everything else stays unasserted and the converter's named
     rejection stands."""
     from mlx_lm.tuner.lora import LoRALinear
-    try:
-        from mlx_lm.tuner.lora import LoRAEmbedding
-    except ImportError:
-        LoRAEmbedding = None
     try:
         from mlx_lm.tuner.dora import DoRALinear
     except ImportError:
@@ -13099,53 +13092,23 @@ def _lora_module_types(model):
         if not (hasattr(module, "lora_a") and hasattr(module, "lora_b")):
             continue
         base_linear = getattr(module, "linear", None)
-        base_embedding = getattr(module, "embedding", None)
         # Exact stock types only: a custom wrapper or base can carry gating
         # or rescaling that plain PEFT LoRA cannot express.
         if (
-            LoRAEmbedding is not None
-            and type(module) is LoRAEmbedding
-            and type(base_embedding) in (nn.Embedding, nn.QuantizedEmbedding)
-        ):
-            wrapped[name] = "embedding"
-        elif (
             type(module) is LoRALinear
             or (DoRALinear is not None and type(module) is DoRALinear)
         ) and type(base_linear) in (nn.Linear, nn.QuantizedLinear):
             wrapped[name] = "linear"
-        elif type(module) is LoRALinear or (
-            LoRAEmbedding is not None and type(module) is LoRAEmbedding
-        ):
-            # Name the base class — the actual reason for refusal.
-            _base = base_linear if base_linear is not None else base_embedding
-            wrapped[name] = (
-                f"unsupported:{type(module).__name__} wrapping "
-                f"{type(_base).__name__}"
-            )
         else:
-            # Record it so callers refuse, rather than let an in-stack path
-            # slip through the converter's layout gate as linear.
-            wrapped[name] = f"unsupported:{type(module).__name__}"
-    # A nested text tower (mlx-vlm) mirrors HF one level deeper; unnest ONLY
-    # with provenance from an import that resolved it. The HF counterpart is
-    # not recoverable by inspection — mlx-vlm `language_model.model.layers.*`
-    # is HF `model.language_model.layers.*` for a VLM class but plain
-    # `model.layers.*` for a text class — so guessing would bind the wrong
-    # modules. Without provenance the layout gate downstream refuses.
-    tower_prefix = getattr(model, "_unsloth_tree_prefix", "") or ""
-    if tower_prefix:
-        _unnested = {}
-        for n, t in wrapped.items():
-            key = n[len(tower_prefix):] if n.startswith(tower_prefix) else n
-            if key in _unnested:
-                raise ValueError(
-                    f"Unsloth MLX: unnesting {tower_prefix!r} collapses "
-                    f"{n!r} onto an existing module path {key!r}; this "
-                    "model carries LoRA wrappers in more than one tower, "
-                    "which a single PEFT adapter cannot represent."
-                )
-            _unnested[key] = t
-        wrapped = _unnested
+            # Name the base class where there is one — the actual reason for
+            # refusal — so an in-stack path cannot slip through as linear.
+            _base = (
+                base_linear if base_linear is not None
+                else getattr(module, "embedding", None)
+            )
+            wrapped[name] = f"unsupported:{type(module).__name__}" + (
+                f" wrapping {type(_base).__name__}" if _base is not None else ""
+            )
     in_stack = re.compile(r"^model\.layers\.\d+\.")
     unsupported = {
         n: t.split(":", 1)[1]
@@ -13155,12 +13118,11 @@ def _lora_module_types(model):
         n: t for n, t in wrapped.items() if not t.startswith("unsupported:")
     }
     mirrored_layout = supported and not unsupported and all(
-        in_stack.match(name) or name in ("lm_head", "model.embed_tokens")
-        for name in supported
+        in_stack.match(name) or name == "lm_head" for name in supported
     )
     if not mirrored_layout:
         supported = {n: t for n, t in supported.items() if in_stack.match(n)}
-    return supported, unsupported, tower_prefix
+    return supported, unsupported
 
 
 def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
@@ -13186,7 +13148,7 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
     if adapter_format == "peft":
         # Refuse by name BEFORE collecting tensors: stacked-factor wrappers
         # (e.g. switch experts) would otherwise fail as a generic no-tensors error.
-        module_types, unsupported, tower_prefix = _lora_module_types(model)
+        module_types, unsupported = _lora_module_types(model)
         if unsupported:
             preview = "; ".join(
                 f"{n} ({t})" for n, t in list(unsupported.items())[:5]
@@ -13210,30 +13172,14 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
             )
         )
         if _m2s_emb and _model_ties_output_to_embedding(model):
+            from unsloth_zoo.saving_utils import _TIED_FULL_STATE_REASON
             raise ValueError(
-                f"Unsloth MLX: {_m2s_emb} are modules_to_save replacements "
-                "of a tied embedding or output head; peft would train an "
-                "untied copy while the tied MLX embedding both looks up "
-                "inputs and projects output logits, so no faithful export "
-                "exists."
-            )
-        if any(t == "embedding" for t in module_types.values()) and (
-            _model_ties_output_to_embedding(model)
-        ):
-            raise ValueError(
-                "Unsloth MLX: this model ties word embeddings and routes "
-                "output logits through the embedding adapter; peft applies "
-                "embedding LoRA to input lookup only, so PEFT export would "
-                "change semantics."
+                f"Unsloth MLX: {_m2s_emb} carry {_TIED_FULL_STATE_REASON}."
             )
         # PEFT has no per-module dropout; a mixed-dropout model would
         # silently train differently after export.
         _dropouts = set()
         for _name, _module in model.named_modules():
-            # module_types is keyed by HF-native paths; live names carry the
-            # nesting, so compare in the same space or nested wrappers are missed.
-            if tower_prefix and _name.startswith(tower_prefix):
-                _name = _name[len(tower_prefix):]
             if _name in module_types:
                 _dropouts.add(round(_get_mlx_dropout_probability(
                     getattr(_module, "dropout", None)
@@ -13242,8 +13188,7 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
             raise ValueError(
                 "Unsloth MLX: modules carry different lora_dropout values "
                 f"({sorted(_dropouts)}); PEFT format has no per-module "
-                "dropout, so exporting would silently change training "
-                "behavior. Unify dropout before exporting."
+                "dropout. Unify dropout before exporting."
             )
     _reject_mixed_lora_dora(model)
     adapter_tensors = collect_mlx_lora_adapter_tensors(model)
@@ -13269,10 +13214,7 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
         _save_adapter_artifacts(
             model, scratch_dir, adapter_tensors, adapter_config=adapter_config
         )
-        convert_mlx_dir_to_peft(
-            scratch_dir, path, module_types=module_types,
-            strip_prefix=tower_prefix,
-        )
+        convert_mlx_dir_to_peft(scratch_dir, path, module_types=module_types)
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
 
@@ -13302,57 +13244,16 @@ def _model_ties_output_to_embedding(model, by_name=None):
         return True
     if by_name is None:
         by_name = dict(model.named_modules())
-    # No head module means output NECESSARILY projects through the embedding,
-    # outranking even a declared False (some declare False yet route via
-    # as_linear). Spellings: lm_head (most), output (Llama-4 text, InternLM2),
-    # embed_out (GPT-NeoX). Bare "output" stays root-only so unrelated nested
-    # submodules cannot masquerade as the head.
+    # No head module means output NECESSARILY routes through the embedding,
+    # outranking even a declared False (some declare False yet use as_linear).
+    # Bare "output" stays root-only so nested submodules cannot pose as the
+    # head.
     return not any(
         name in ("lm_head", "output", "embed_out")
         or name.endswith(".lm_head")
         or name.endswith(".embed_out")
         for name in by_name
     )
-
-
-# Text-tower attribute names used by mlx-vlm. A prefix outside this set is
-# never inferred: vision and audio towers can carry identically shaped
-# projections, and binding a language adapter onto one is silently wrong.
-_TEXT_TOWER_PREFIXES = ("language_model.", "text_model.", "model.language_model.")
-
-
-def _resolve_tree_prefix(by_name, paths):
-    """The single nesting prefix mapping HF adapter paths onto this tree.
-
-    mlx-vlm nests a text tower under `language_model.`, so an adapter trained
-    against the HF text model names modules one level shallower. Returns ""
-    when the paths already resolve, the unique prefix when exactly one
-    candidate maps EVERY path, or None when none or several do — the caller
-    refuses rather than guess which tower the adapter belongs to. Raises when
-    the paths fit BOTH the root and a nested tower, an ambiguity no return
-    value can express safely.
-    """
-    paths = list(paths)
-    if not paths:
-        return ""
-    probe = min(paths, key=len)
-    candidates = sorted({
-        name[: -len(probe)] for name in by_name
-        if name.endswith(probe) and name != probe
-        and name[: -len(probe)] in _TEXT_TOWER_PREFIXES
-    })
-    viable = [c for c in candidates if all(c + p in by_name for p in paths)]
-    if all(p in by_name for p in paths):
-        if viable:
-            # Fits the root AND a nested tower; either binding is a guess.
-            raise ValueError(
-                "Unsloth MLX: this adapter's module paths match both the "
-                f"root of the model and the nested tower(s) {viable}; the "
-                "artifact does not say which it was trained against, so "
-                "the import is refused rather than guessing."
-            )
-        return ""
-    return viable[0] if len(viable) == 1 else None
 
 
 def _full_state_base_module(module):
@@ -13389,16 +13290,12 @@ def _mark_full_state_modules(model, fs_map, adapter_weights_file,
     fs_map = dict(fs_map or {})
     if not fs_map:
         return
-    _bad_origins = {
-        p: o for p, o in fs_map.items()
-        if o not in ("modules_to_save", "embedding_auto")
-    }
-    if _bad_origins:
-        raise ValueError(
-            f"Unsloth MLX: full_state_modules carries unknown origin "
-            f"tag(s) {_bad_origins}; expected 'modules_to_save' or "
-            "'embedding_auto'."
-        )
+    from unsloth_zoo.saving_utils import _validate_full_state_origins
+    _validate_full_state_origins(fs_map)
+    import mlx.nn as nn
+    from unsloth_zoo.saving_utils import (
+        _OUTPUT_HEAD_LEAF_NAMES, _TIED_FULL_STATE_REASON, _leaf_in,
+    )
     by_name = dict(model.named_modules())
     params = dict(mlx.utils.tree_flatten(model.parameters()))
     expected_shapes = expected_shapes or {}
@@ -13427,39 +13324,19 @@ def _mark_full_state_modules(model, fs_map, adapter_weights_file,
         if module is None:
             problems.append(f"{p} (module missing from the live tree)")
             continue
-        import mlx.nn as nn
-        from unsloth_zoo.saving_utils import _OUTPUT_HEAD_LEAF_NAMES, _leaf_in
-        _embeddingish = isinstance(
-            module, (nn.Embedding, nn.QuantizedEmbedding)
-        ) or _leaf_in(p, _OUTPUT_HEAD_LEAF_NAMES)
-        if origin == "modules_to_save" and _embeddingish:
-            if tied_routing is None:
-                tied_routing = _model_ties_output_to_embedding(
-                    model, by_name,
-                )
-            if tied_routing:
-                problems.append(
-                    f"{p} (modules_to_save replacement of a tied "
-                    "embedding or output head: peft trained an untied "
-                    "copy while this model's tied embedding both "
-                    "looks up inputs and projects output logits)"
-                )
-                continue
-        if origin == "embedding_auto" and _leaf_in(
-            p, _OUTPUT_HEAD_LEAF_NAMES
+        # One refusal for anything a tied model cannot hold apart: any head
+        # snapshot (an auto-saved one that survived the fold, or a
+        # modules_to_save replacement) plus peft's untied modules_to_save copy
+        # of an embedding that here also projects the logits.
+        _headish = _leaf_in(p, _OUTPUT_HEAD_LEAF_NAMES)
+        if _headish or (
+            origin == "modules_to_save"
+            and isinstance(module, (nn.Embedding, nn.QuantizedEmbedding))
         ):
-            # A tied conversion folds head duplicates away; a survivor would
-            # bind dead head state while logits flow through the embedding.
             if tied_routing is None:
-                tied_routing = _model_ties_output_to_embedding(
-                    model, by_name,
-                )
+                tied_routing = _model_ties_output_to_embedding(model, by_name)
             if tied_routing:
-                problems.append(
-                    f"{p} (auto-saved output-head state on a model that "
-                    "routes logits through its embedding; the snapshot "
-                    "cannot restore as head state)"
-                )
+                problems.append(f"{p} ({_TIED_FULL_STATE_REASON})")
                 continue
         found = False
         for key in _full_state_key_candidates(p):
@@ -13508,8 +13385,7 @@ def _mark_full_state_modules(model, fs_map, adapter_weights_file,
             module.unfreeze()
             continue
         # Auto-saved embeddings are frozen by default, but continued
-        # pretraining may have trained one; the artifact records which so a
-        # reload restores the same contract. Only the inner base is touched.
+        # pretraining may have trained one; the artifact records which.
         target = _full_state_base_module(module)
         if p in _trainable_at_save:
             target.unfreeze()
@@ -13517,8 +13393,8 @@ def _mark_full_state_modules(model, fs_map, adapter_weights_file,
             target.freeze()
     # An mlx-format reload treats restored non-adapter tensors as continued-
     # pretraining state eligible for the scoped embedding LR. modules_to_save
-    # is adapter state: drop it so this path trains it at the main LR, exactly
-    # as a direct PEFT import does.
+    # is adapter state: drop it so it trains at the main LR, as a PEFT import
+    # does.
     _cpt_keys = getattr(model, "_unsloth_cpt_full_module_weight_keys", None)
     if _cpt_keys:
         _m2s = frozenset(
@@ -13526,17 +13402,10 @@ def _mark_full_state_modules(model, fs_map, adapter_weights_file,
             if origin == "modules_to_save"
         )
 
-        def _owns(key):
-            owner = key.rsplit(".", 1)[0]
-            if owner in _m2s:
-                return True
-            for inner in (".embedding", ".linear"):
-                if owner.endswith(inner) and owner[: -len(inner)] in _m2s:
-                    return True
-            return False
-
+        from unsloth_zoo.saving_utils import _full_state_owner
         model._unsloth_cpt_full_module_weight_keys = {
-            key for key in _cpt_keys if not _owns(key)
+            key for key in _cpt_keys
+            if _full_state_owner(key.rsplit(".", 1)[0], _m2s) is None
         }
     model._unsloth_full_state_modules = fs_map
 
@@ -13854,9 +13723,8 @@ def _enrich_mlx_adapter_config(model, adapter_config):
     _fs_map = dict(getattr(model, "_unsloth_full_state_modules", None) or {})
     if _fs_map:
         adapter_config["full_state_modules"] = _fs_map
-        # Record save-time trainability so a reload restores it:
-        # modules_to_save is trainable by definition, an auto-saved embedding
-        # frozen UNLESS continued pretraining unfroze it.
+        # Record save-time trainability so a reload restores it: an auto-saved
+        # embedding is frozen unless continued pretraining unfroze it.
         _by_name = dict(model.named_modules())
         _trainable_fs = []
         for _p in sorted(_fs_map):
@@ -13878,14 +13746,6 @@ def _enrich_mlx_adapter_config(model, adapter_config):
         adapter_config["unsloth_peft_converted"] = True
     else:
         adapter_config.pop("unsloth_peft_converted", None)
-
-    # Records the mlx-vlm text-tower nesting so a directory-only PEFT
-    # conversion can emit Hugging-Face-native paths.
-    _tree_prefix = getattr(model, "_unsloth_tree_prefix", "") or ""
-    if _tree_prefix:
-        adapter_config["unsloth_mlx_tree_prefix"] = _tree_prefix
-    else:
-        adapter_config.pop("unsloth_mlx_tree_prefix", None)
 
     # Only stamp LoRA fields when the live model has LoRA modules (or the
     # caller declared a lora/dora artifact); otherwise mlx-lm.load_adapters()
@@ -13937,18 +13797,17 @@ def _enrich_mlx_adapter_config(model, adapter_config):
             for key in ("rank", "scale", "dropout"):
                 if key in lora_parameters:
                     adapter_config[key] = lora_parameters[key]
-        # One global rank/scale cannot represent per-module adapters (imported
-        # rank_pattern/alpha_pattern). Persist per-module maps and mark the
-        # artifact as needing the unsloth loader; stock mlx-lm rebuilds wrong.
+        # One global rank/scale cannot represent imported rank_pattern /
+        # alpha_pattern; persist per-module maps and mark the artifact as
+        # needing the unsloth loader.
         if has_lora_modules:
             _module_ranks, _module_scales = {}, {}
             _maps_reliable = True
             for _name, _module in iter_mlx_lora_modules(model):
                 _lora_a = getattr(_module, "lora_a", None)
                 _scale = getattr(_module, "scale", None)
-                # Only plain 2-D factors with a scalar scale are representable;
-                # switch-LoRA stacks experts into 3-D where shape[-1] is the
-                # input width, not the rank. A partial map is worse than none.
+                # Only plain 2-D factors with a scalar scale are
+                # representable; a partial map is worse than none.
                 if (
                     _lora_a is None
                     or getattr(_lora_a, "ndim", 0) != 2
@@ -15628,14 +15487,11 @@ def push_to_hub_gguf(
     print(f"Unsloth: GGUF pushed to https://huggingface.co/{repo_id}")
 
 
-# ---------------------------------------------------------------------------
-# PEFT <-> MLX LoRA adapter interop. The format mapping and conversion rules
-# are documented in unsloth_zoo.saving_utils, which holds the detection,
-# validation and conversion helpers so CUDA hosts can import them without mlx.
-# The delegates below keep the loader-facing surface here, and mx-native
-# attach_and_bind_peft_adapter stays so torch-less Apple installs never import
-# the torch-side module.
-# ---------------------------------------------------------------------------
+# PEFT <-> MLX LoRA adapter interop. unsloth_zoo.saving_utils documents the
+# format mapping and holds the detection, validation and conversion helpers so
+# CUDA hosts can import them without mlx. The delegates below keep the
+# loader-facing surface here, and mx-native attach_and_bind_peft_adapter stays
+# so torch-less Apple installs never import the torch-side module.
 
 def detect_adapter_format(path):
     from unsloth_zoo.saving_utils import detect_adapter_format as _impl
@@ -15661,9 +15517,12 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
         PEFT_WEIGHTS_FILE,
         _EMBEDDING_LEAF_NAMES,
         _OUTPUT_HEAD_LEAF_NAMES,
+        _TIED_FULL_STATE_REASON,
         _effective_scale,
+        _tied_head_fold_error,
         _leaf_in,
         _raise_rejected,
+        _reject_dora_dropout,
         group_peft_lora_pairs,
     )
     import mlx.core as mx
@@ -15675,7 +15534,6 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
     from .loader import _patch_mlx_lora_from_base_compat
     _patch_mlx_lora_from_base_compat()
 
-    from unsloth_zoo.saving_utils import _reject_dora_dropout
     _reject_dora_dropout(cfg)
     use_dora = bool(cfg.get("use_dora"))
     if use_dora:
@@ -15695,11 +15553,6 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
         raise ValueError(
             f"Unsloth MLX: {adapter_dir!r} has no LoRA tensor pairs."
         )
-    try:
-        from mlx_lm.tuner.lora import LoRAEmbedding
-    except ImportError:
-        LoRAEmbedding = None
-
     by_name = dict(model.named_modules())
     linear_types = (nn.Linear, nn.QuantizedLinear)
     dropout = float(cfg.get("lora_dropout") or 0.0)
@@ -15711,75 +15564,15 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
         t for t in (nn.Embedding, nn.QuantizedEmbedding) if t is not None
     )
     tied_embeddings = _model_ties_output_to_embedding(model, by_name)
-    # HF-trained adapters name modules one level shallower than an mlx-vlm
-    # tree; resolve that nesting once and bind every path through it
-    # (all-or-nothing). Resolved from the LoRA pairs alone, since full-state
-    # entries may legitimately have no counterpart (a tied model may carry no
-    # head module) and deserve their own diagnosis below. Paths fitting the root AND a tower
-    # are refused in there; None — no prefix maps every pair, or several towers
-    # do — falls through to plain matching, so the per-path report names exact
-    # mismatches instead of guessing a tower.
-    _tree_prefix = _resolve_tree_prefix(by_name, list(pairs)) or ""
-    if _tree_prefix:
-        by_name = {
-            path[len(_tree_prefix):]: module
-            for path, module in by_name.items()
-            if path.startswith(_tree_prefix)
-        }
     for path in sorted(pairs):
-        if "EA" in pairs[path]:
-            module = by_name.get(path)
-            if module is None or type(module) not in emb_types:
-                unmatched.append(
-                    f"{path} ({type(module).__name__ if module else 'missing'};"
-                    " embedding LoRA needs a stock embedding module)"
-                )
-                continue
-            if tied_embeddings:
-                unmatched.append(
-                    f"{path} (embedding LoRA on a tied-embeddings model: "
-                    "mlx-lm applies the update to the tied output "
-                    "projection while peft applies it to input lookup "
-                    "only, so no faithful import exists)"
-                )
-                continue
-            if dropout > 0:
-                unmatched.append(
-                    f"{path} (embedding LoRA with nonzero lora_dropout: "
-                    "peft applies no dropout on embedding adapters while "
-                    "mlx-lm does; import would change training behavior)"
-                )
-                continue
-            if LoRAEmbedding is None:
-                raise ImportError(
-                    "Unsloth MLX: embedding LoRA needs mlx_lm.tuner.lora."
-                    "LoRAEmbedding; upgrade mlx-lm."
-                )
-            ea, eb = pairs[path]["EA"], pairs[path]["EB"]
-            rank = int(ea.shape[0])
-            scale = _effective_scale(cfg, path, rank)
-            wrapped = LoRAEmbedding.from_base(
-                module, r=rank, dropout=dropout, scale=scale
-            )
-            la, lb = ea.T, eb.T
-            if wrapped.lora_a.shape != la.shape or wrapped.lora_b.shape != lb.shape:
-                unmatched.append(f"{path} (embedding LoRA shape mismatch)")
-                continue
-            wrapped.lora_a = la
-            wrapped.lora_b = lb
-            staged.append((path, wrapped))
-            module_scales[path] = scale
-            module_ranks[path] = rank
-            continue
         a, b = pairs[path]["A"], pairs[path]["B"]
         rank = int(a.shape[0])
         if int(b.shape[1]) != rank:
             unmatched.append(f"{path} (lora_A rank {rank} != lora_B rank {int(b.shape[1])})")
             continue
         module = by_name.get(path)
-        # Exact types only: nn.Linear subclasses (fused projections with
-        # tuple-returning forwards and their own to_lora()) accept these factor
-        # shapes, then crash or misbehave inside a generic LoRALinear wrapper.
+        # Exact types only: nn.Linear subclasses accept these factor shapes,
+        # then misbehave inside a generic LoRALinear wrapper.
         if module is None or type(module) not in linear_types:
             found = type(module).__name__ if module is not None else "no module"
             unmatched.append(
@@ -15830,10 +15623,9 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
         staged.append((path, wrapped))
         module_scales[path] = scale
         module_ranks[path] = rank
-    # Full-state entries: verify against the live base and PLAN the
-    # application — nothing mutates until every entry validates, so a refused
-    # import leaves the caller's model untouched. Equal snapshots are skipped;
-    # differing ones are applied and origin-recorded so saves round-trip them.
+    # Verify full-state entries and PLAN their application: nothing mutates
+    # until every entry validates, so a refused import leaves the caller's
+    # model untouched. Equal snapshots are skipped.
     applied_full_state = {}
     fs_plan = []
     for path, entries in sorted(full_state.items()):
@@ -15846,8 +15638,8 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
         ):
             # peft saves the tied output head as its own entry, but the
             # tensor IS the tied embedding weight: verify against the incoming
-            # snapshot (or the live embedding) and fold — never apply as head
-            # state, whether or not the tree keeps a dead head module.
+            # snapshot (or the live embedding) and fold, never apply as head
+            # state.
             emb_candidates = [
                 m for n, m in by_name.items()
                 if _leaf_in(n, _EMBEDDING_LEAF_NAMES)
@@ -15866,33 +15658,15 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
                     # Artifact replaces the embedding: match the INCOMING weight.
                     emb_weight = _ev.get("weight", emb_weight)
                     break
-            snapshot = entries.get("weight")
-            if snapshot is not None and "float" not in str(
-                snapshot.dtype
-            ).lower():
-                unmatched.append(
-                    f"{path} (non-floating tied output-head snapshot "
-                    f"dtype {snapshot.dtype})"
-                )
-                continue
-            extra = sorted(set(entries) - {"__origin__", "weight"})
-            if extra:
-                unmatched.append(
-                    f"{path} (tied output-head snapshot carries "
-                    f"{extra}; the tied MLX embedding has no slot for "
-                    "them)"
-                )
-                continue
-            if emb_weight is not None and snapshot is not None:
-                if snapshot.dtype != emb_weight.dtype:
-                    snapshot = snapshot.astype(emb_weight.dtype)
-                if bool(mx.array_equal(emb_weight, snapshot)):
-                    continue
-            unmatched.append(
-                f"{path} (tied output-head snapshot differs from the "
-                "tied embedding; a tied MLX model cannot hold an "
-                "independent output head)"
-            )
+
+            def _equal(live, snap):
+                # The loader may have cast the base while peft saved full
+                # precision, and that gap is not a difference.
+                return bool(mx.array_equal(live, snap.astype(live.dtype)))
+
+            _err = _tied_head_fold_error(path, entries, emb_weight, _equal)
+            if _err:
+                unmatched.append(_err)
             continue
         if module is None:
             if tied_embeddings and _leaf_in(path, _OUTPUT_HEAD_LEAF_NAMES):
@@ -15920,12 +15694,7 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
                 or _leaf_in(path, _OUTPUT_HEAD_LEAF_NAMES)
             )
         ):
-            unmatched.append(
-                f"{path} (modules_to_save snapshot of a tied embedding or "
-                "output head: peft trains an untied copy while the tied "
-                "MLX embedding both looks up inputs and projects output "
-                "logits)"
-            )
+            unmatched.append(f"{path} ({_TIED_FULL_STATE_REASON})")
             continue
         for tname, tensor in entries.items():
             if tname == "__origin__":
@@ -15944,9 +15713,8 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
                     "restore as module state)"
                 )
                 continue
-            # Compare and apply in the live dtype: the loader may have cast
-            # the base while peft saved full precision, and a pure precision
-            # gap is not a replacement.
+            # Compare in the live dtype: the loader may have cast the base
+            # while peft saved full precision, and that gap is not a change.
             if tensor.dtype != live.dtype:
                 tensor = tensor.astype(live.dtype)
             if bool(mx.array_equal(live, tensor)):
@@ -15956,9 +15724,8 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
         if origin == "modules_to_save" and path not in applied_full_state:
             # Equal-valued snapshot still marks the module trainable.
             applied_full_state[path] = origin
-    # peft replaces the ENTIRE module for modules_to_save: every tensor the
-    # live module carries must be in the snapshot, else a truncated artifact
-    # silently retains base state.
+    # peft replaces the ENTIRE module for modules_to_save, so a truncated
+    # snapshot would silently retain base state.
     from mlx.utils import tree_flatten as _tree_flatten
     for _name in sorted(set(cfg.get("modules_to_save") or [])):
         for _parent_path, _parent in by_name.items():
@@ -15987,14 +15754,13 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
             "partial import."
         )
     # Freeze the base before installing wrappers so only the new LoRA tensors
-    # train (peft's is_trainable contract); a save must capture everything an
-    # optimizer moved.
+    # train (peft's is_trainable contract).
     model.freeze()
     for module, tname, tensor in fs_plan:
         setattr(module, tname, tensor)
     from mlx.utils import tree_unflatten
     model.update_modules(tree_unflatten(
-        [(_tree_prefix + path, wrapped) for path, wrapped in staged]
+        [(path, wrapped) for path, wrapped in staged]
     ))
     # New wrappers start in training mode regardless of the host's; re-propagate
     # so nonzero lora_dropout cannot make inference stochastic on an eval model.
@@ -16003,20 +15769,12 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
     for path, origin in applied_full_state.items():
         if origin == "modules_to_save":
             by_name[path].unfreeze()
-    model._unsloth_full_state_modules = {
-        _tree_prefix + path: origin for path, origin in applied_full_state.items()
-    }
+    model._unsloth_full_state_modules = dict(applied_full_state)
     # peft-origin: saves of this model carry the conversion marker.
     model._unsloth_peft_converted = True
     mx.eval(model.parameters())
     # Shapes carry ranks, but scale variance must survive a zoo-side re-save
     # (stock mlx-lm has a single global scale).
-    model._unsloth_lora_module_scales = {
-        _tree_prefix + p: v for p, v in module_scales.items()
-    }
-    model._unsloth_lora_module_ranks = {
-        _tree_prefix + p: v for p, v in module_ranks.items()
-    }
-    # Remembered so a PEFT export re-emits Hugging-Face-native paths.
-    model._unsloth_tree_prefix = _tree_prefix
+    model._unsloth_lora_module_scales = dict(module_scales)
+    model._unsloth_lora_module_ranks = dict(module_ranks)
     return len(staged)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -35,6 +35,7 @@ import json
 import math
 import numbers
 import operator
+import re
 import textwrap
 import numpy as np
 import os
@@ -13388,6 +13389,47 @@ def _enrich_mlx_adapter_config(model, adapter_config):
             for key in ("rank", "scale", "dropout"):
                 if key in lora_parameters:
                     adapter_config[key] = lora_parameters[key]
+        # One global rank/scale cannot represent per-module adapters (imported
+        # rank_pattern/alpha_pattern). Persist per-module maps and mark the
+        # artifact as needing the unsloth loader; stock mlx-lm rebuilds wrong.
+        if has_lora_modules:
+            _module_ranks, _module_scales = {}, {}
+            _maps_reliable = True
+            for _name, _module in iter_mlx_lora_modules(model):
+                _lora_a = getattr(_module, "lora_a", None)
+                _scale = getattr(_module, "scale", None)
+                # Only plain 2-D factors with a scalar scale are representable;
+                # switch-LoRA stacks experts into 3-D where shape[-1] is the
+                # input width, not the rank. A partial map is worse than none.
+                if (
+                    _lora_a is None
+                    or getattr(_lora_a, "ndim", 0) != 2
+                    or _scale is None
+                    or not isinstance(_scale, (int, float))
+                ):
+                    _maps_reliable = False
+                    break
+                _module_ranks[_name] = int(_lora_a.shape[-1])
+                _module_scales[_name] = float(_scale)
+            if _maps_reliable and (
+                len(set(_module_ranks.values())) > 1
+                or len(set(_module_scales.values())) > 1
+            ):
+                adapter_config["unsloth_mlx_lora_module_ranks"] = _module_ranks
+                adapter_config["unsloth_mlx_lora_module_scales"] = _module_scales
+                adapter_config["unsloth_mlx_requires_unsloth_loader"] = True
+                print(
+                    "Unsloth: this adapter uses per-module ranks/scales; "
+                    "reloading it needs Unsloth (stock mlx-lm assumes one "
+                    "global rank/scale)."
+                )
+            else:
+                for _stale_key in (
+                    "unsloth_mlx_lora_module_ranks",
+                    "unsloth_mlx_lora_module_scales",
+                    "unsloth_mlx_requires_unsloth_loader",
+                ):
+                    adapter_config.pop(_stale_key, None)
         # mlx-lm.load_adapters() reads num_layers off the config.
         if "num_layers" not in adapter_config:
             try:
@@ -13408,6 +13450,8 @@ def _enrich_mlx_adapter_config(model, adapter_config):
         for _stale in (
             "peft_type", "lora_parameters", "rank", "scale", "dropout",
             "num_layers", "unsloth_mlx_lora_module_paths",
+            "unsloth_mlx_lora_module_ranks", "unsloth_mlx_lora_module_scales",
+            "unsloth_mlx_requires_unsloth_loader",
         ):
             adapter_config.pop(_stale, None)
 
@@ -15034,3 +15078,133 @@ def push_to_hub_gguf(
         )
 
     print(f"Unsloth: GGUF pushed to https://huggingface.co/{repo_id}")
+
+
+# ---------------------------------------------------------------------------
+# PEFT <-> MLX LoRA adapter interop.
+#
+# PEFT adapters (adapter_model.safetensors, lora_A/lora_B keys under a
+# base_model.model. prefix) and mlx-lm adapters (adapters.safetensors,
+# lora_a/lora_b keys) encode the same math in different layouts:
+#
+#     peft {p}.lora_A.weight [r, in]   ==  mlx {p}.lora_a [in, r], transposed
+#     peft {p}.lora_B.weight [out, r]  ==  mlx {p}.lora_b [r, out], transposed
+#     effective scale = lora_alpha / r     (rsLoRA: lora_alpha / sqrt(r))
+#
+# Conversion is rename + transpose only; dtypes are preserved exactly and a
+# round trip is bitwise-identical for the supported subset (plain linear
+# LoRA). Adapters carrying DoRA magnitudes, modules_to_save state, embedding
+# LoRA, or expert target_parameters factors are refused with a named reason
+# instead of being partially or lossily converted. Tensor IO prefers
+# mlx.core (native bfloat16) with a safetensors.torch fallback off Apple
+# hardware; the safetensors numpy backend cannot represent bf16.
+# ---------------------------------------------------------------------------
+
+def detect_adapter_format(path):
+    from unsloth_zoo.saving_utils import detect_adapter_format as _impl
+    return _impl(path)
+
+
+def normalize_peft_adapter_config(cfg, adapter_dir=None):
+    from unsloth_zoo.saving_utils import normalize_peft_adapter_config as _impl
+    return _impl(cfg, adapter_dir=adapter_dir)
+
+
+def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
+    """Attach LoRA modules described by a PEFT directory onto a live MLX model
+    and bind the converted weights.
+
+    The weight file decides what is attached: the module set, each module's
+    rank (from tensor shapes), and — with ``alpha_pattern`` / ``use_rslora``
+    from the config — each module's scale. Any tensor that cannot bind, or any
+    expected module missing from the live tree, aborts the load; a partially
+    applied adapter is never returned.
+    """
+    from unsloth_zoo.saving_utils import (
+        PEFT_WEIGHTS_FILE,
+        _effective_scale,
+        _raise_rejected,
+        group_peft_lora_pairs,
+    )
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.tuner.lora import LoRALinear
+
+    tensors = dict(mx.load(os.path.join(adapter_dir, PEFT_WEIGHTS_FILE)))
+    pairs, rejected = group_peft_lora_pairs(tensors)
+    if rejected:
+        _raise_rejected(rejected, f"{adapter_dir!r}")
+    if not pairs:
+        raise ValueError(
+            f"Unsloth MLX: {adapter_dir!r} has no linear LoRA tensor pairs."
+        )
+
+    by_name = dict(model.named_modules())
+    linear_types = (nn.Linear, nn.QuantizedLinear)
+    dropout = float(cfg.get("lora_dropout") or 0.0)
+    unmatched = []
+    module_scales = {}
+    module_ranks = {}
+    staged = []
+    for path in sorted(pairs):
+        a, b = pairs[path]["A"], pairs[path]["B"]
+        rank = int(a.shape[0])
+        if int(b.shape[1]) != rank:
+            unmatched.append(f"{path} (lora_A rank {rank} != lora_B rank {int(b.shape[1])})")
+            continue
+        module = by_name.get(path)
+        # Exact types only: nn.Linear subclasses (fused projections with
+        # tuple-returning forwards and their own to_lora()) accept these factor
+        # shapes, then crash or misbehave inside a generic LoRALinear wrapper.
+        if module is None or type(module) not in linear_types:
+            found = type(module).__name__ if module is not None else "no module"
+            unmatched.append(
+                f"{path} ({found}; the base model's MLX module tree names "
+                "this weight differently, lacks it, or wraps it in an "
+                "unsupported linear variant)"
+            )
+            continue
+        scale = _effective_scale(cfg, path, rank)
+        wrapped = LoRALinear.from_base(module, r=rank, dropout=dropout, scale=scale)
+        lora_a, lora_b = a.T, b.T
+        if wrapped.lora_a.shape != lora_a.shape:
+            unmatched.append(
+                f"{path} (adapter in-dim {lora_a.shape[0]} != module in-dim "
+                f"{wrapped.lora_a.shape[0]})"
+            )
+            continue
+        if wrapped.lora_b.shape != lora_b.shape:
+            unmatched.append(
+                f"{path} (adapter out-dim {lora_b.shape[1]} != module "
+                f"out-dim {wrapped.lora_b.shape[1]})"
+            )
+            continue
+        wrapped.lora_a = lora_a
+        wrapped.lora_b = lora_b
+        staged.append((path, wrapped))
+        module_scales[path] = scale
+        module_ranks[path] = rank
+    if unmatched:
+        preview = "; ".join(unmatched[:5])
+        if len(unmatched) > 5:
+            preview += f"; ... (+{len(unmatched) - 5} more)"
+        raise ValueError(
+            f"Unsloth MLX: {len(unmatched)} PEFT adapter tensor pair(s) do "
+            f"not map onto the loaded MLX model ({preview}). Refusing a "
+            "partial import."
+        )
+    # Freeze the base before installing wrappers so only the new LoRA tensors
+    # train (peft's is_trainable contract); a save must capture everything an
+    # optimizer moved.
+    model.freeze()
+    from mlx.utils import tree_unflatten
+    model.update_modules(tree_unflatten(staged))
+    # New wrappers start in training mode regardless of the host's; re-propagate
+    # so nonzero lora_dropout cannot make inference stochastic on an eval model.
+    model.train(bool(getattr(model, "training", False)))
+    mx.eval(model.parameters())
+    # Shapes carry ranks, but scale variance must survive a zoo-side re-save
+    # (stock mlx-lm has a single global scale).
+    model._unsloth_lora_module_scales = module_scales
+    model._unsloth_lora_module_ranks = module_ranks
+    return len(staged)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -13126,6 +13126,26 @@ def _lora_module_types(model):
             # Record it so callers refuse, rather than let an in-stack path
             # slip through the converter's layout gate as linear.
             wrapped[name] = f"unsupported:{type(module).__name__}"
+    # A nested text tower (mlx-vlm) mirrors HF one level deeper; unnest ONLY
+    # with provenance from an import that resolved it. The HF counterpart is
+    # not recoverable by inspection — mlx-vlm `language_model.model.layers.*`
+    # is HF `model.language_model.layers.*` for a VLM class but plain
+    # `model.layers.*` for a text class — so guessing would bind the wrong
+    # modules. Without provenance the layout gate downstream refuses.
+    tower_prefix = getattr(model, "_unsloth_tree_prefix", "") or ""
+    if tower_prefix:
+        _unnested = {}
+        for n, t in wrapped.items():
+            key = n[len(tower_prefix):] if n.startswith(tower_prefix) else n
+            if key in _unnested:
+                raise ValueError(
+                    f"Unsloth MLX: unnesting {tower_prefix!r} collapses "
+                    f"{n!r} onto an existing module path {key!r}; this "
+                    "model carries LoRA wrappers in more than one tower, "
+                    "which a single PEFT adapter cannot represent."
+                )
+            _unnested[key] = t
+        wrapped = _unnested
     in_stack = re.compile(r"^model\.layers\.\d+\.")
     unsupported = {
         n: t.split(":", 1)[1]
@@ -13140,7 +13160,7 @@ def _lora_module_types(model):
     )
     if not mirrored_layout:
         supported = {n: t for n, t in supported.items() if in_stack.match(n)}
-    return supported, unsupported
+    return supported, unsupported, tower_prefix
 
 
 def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
@@ -13166,7 +13186,7 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
     if adapter_format == "peft":
         # Refuse by name BEFORE collecting tensors: stacked-factor wrappers
         # (e.g. switch experts) would otherwise fail as a generic no-tensors error.
-        module_types, unsupported = _lora_module_types(model)
+        module_types, unsupported, tower_prefix = _lora_module_types(model)
         if unsupported:
             preview = "; ".join(
                 f"{n} ({t})" for n, t in list(unsupported.items())[:5]
@@ -13210,6 +13230,10 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
         # silently train differently after export.
         _dropouts = set()
         for _name, _module in model.named_modules():
+            # module_types is keyed by HF-native paths; live names carry the
+            # nesting, so compare in the same space or nested wrappers are missed.
+            if tower_prefix and _name.startswith(tower_prefix):
+                _name = _name[len(tower_prefix):]
             if _name in module_types:
                 _d = getattr(_module, "dropout", None)
                 # mlx nn.Dropout keeps 1-p internally; older builds exposed p.
@@ -13249,7 +13273,10 @@ def save_lora_adapters(model, path, adapter_config=None, adapter_format="mlx"):
         _save_adapter_artifacts(
             model, scratch_dir, adapter_tensors, adapter_config=adapter_config
         )
-        convert_mlx_dir_to_peft(scratch_dir, path, module_types=module_types)
+        convert_mlx_dir_to_peft(
+            scratch_dir, path, module_types=module_types,
+            strip_prefix=tower_prefix,
+        )
     finally:
         shutil.rmtree(scratch, ignore_errors=True)
 
@@ -13290,6 +13317,46 @@ def _model_ties_output_to_embedding(model, by_name=None):
         or name.endswith(".embed_out")
         for name in by_name
     )
+
+
+# Text-tower attribute names used by mlx-vlm. A prefix outside this set is
+# never inferred: vision and audio towers can carry identically shaped
+# projections, and binding a language adapter onto one is silently wrong.
+_TEXT_TOWER_PREFIXES = ("language_model.", "text_model.", "model.language_model.")
+
+
+def _resolve_tree_prefix(by_name, paths):
+    """The single nesting prefix mapping HF adapter paths onto this tree.
+
+    mlx-vlm nests a text tower under `language_model.`, so an adapter trained
+    against the HF text model names modules one level shallower. Returns ""
+    when the paths already resolve, the unique prefix when exactly one
+    candidate maps EVERY path, or None when none or several do — the caller
+    refuses rather than guess which tower the adapter belongs to. Raises when
+    the paths fit BOTH the root and a nested tower, an ambiguity no return
+    value can express safely.
+    """
+    paths = list(paths)
+    if not paths:
+        return ""
+    probe = min(paths, key=len)
+    candidates = sorted({
+        name[: -len(probe)] for name in by_name
+        if name.endswith(probe) and name != probe
+        and name[: -len(probe)] in _TEXT_TOWER_PREFIXES
+    })
+    viable = [c for c in candidates if all(c + p in by_name for p in paths)]
+    if all(p in by_name for p in paths):
+        if viable:
+            # Fits the root AND a nested tower; either binding is a guess.
+            raise ValueError(
+                "Unsloth MLX: this adapter's module paths match both the "
+                f"root of the model and the nested tower(s) {viable}; the "
+                "artifact does not say which it was trained against, so "
+                "the import is refused rather than guessing."
+            )
+        return ""
+    return viable[0] if len(viable) == 1 else None
 
 
 def _full_state_base_module(module):
@@ -13815,6 +13882,14 @@ def _enrich_mlx_adapter_config(model, adapter_config):
         adapter_config["unsloth_peft_converted"] = True
     else:
         adapter_config.pop("unsloth_peft_converted", None)
+
+    # Records the mlx-vlm text-tower nesting so a directory-only PEFT
+    # conversion can emit Hugging-Face-native paths.
+    _tree_prefix = getattr(model, "_unsloth_tree_prefix", "") or ""
+    if _tree_prefix:
+        adapter_config["unsloth_mlx_tree_prefix"] = _tree_prefix
+    else:
+        adapter_config.pop("unsloth_mlx_tree_prefix", None)
 
     # Only stamp LoRA fields when the live model has LoRA modules (or the
     # caller declared a lora/dora artifact); otherwise mlx-lm.load_adapters()
@@ -15635,6 +15710,21 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
         t for t in (nn.Embedding, nn.QuantizedEmbedding) if t is not None
     )
     tied_embeddings = _model_ties_output_to_embedding(model, by_name)
+    # HF-trained adapters name modules one level shallower than an mlx-vlm
+    # tree; resolve that nesting once and bind every path through it
+    # (all-or-nothing). Resolved from the LoRA pairs alone, since full-state
+    # entries may legitimately have no counterpart (a tied model may carry no
+    # head module) and deserve their own diagnosis below. Paths fitting the root AND a tower
+    # are refused in there; None — no prefix maps every pair, or several towers
+    # do — falls through to plain matching, so the per-path report names exact
+    # mismatches instead of guessing a tower.
+    _tree_prefix = _resolve_tree_prefix(by_name, list(pairs)) or ""
+    if _tree_prefix:
+        by_name = {
+            path[len(_tree_prefix):]: module
+            for path, module in by_name.items()
+            if path.startswith(_tree_prefix)
+        }
     for path in sorted(pairs):
         if "EA" in pairs[path]:
             module = by_name.get(path)
@@ -15804,7 +15894,15 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
             )
             continue
         if module is None:
-            unmatched.append(f"{path} (full-state target missing)")
+            if tied_embeddings and _leaf_in(path, _OUTPUT_HEAD_LEAF_NAMES):
+                # A tied model has no head module to represent this on.
+                unmatched.append(
+                    f"{path} (this model ties its embeddings and has no "
+                    "output-head module, so peft modules_to_save on the "
+                    "head has no MLX counterpart)"
+                )
+            else:
+                unmatched.append(f"{path} (full-state target missing)")
             continue
         if isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
             unmatched.append(
@@ -15894,7 +15992,9 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
     for module, tname, tensor in fs_plan:
         setattr(module, tname, tensor)
     from mlx.utils import tree_unflatten
-    model.update_modules(tree_unflatten(staged))
+    model.update_modules(tree_unflatten(
+        [(_tree_prefix + path, wrapped) for path, wrapped in staged]
+    ))
     # New wrappers start in training mode regardless of the host's; re-propagate
     # so nonzero lora_dropout cannot make inference stochastic on an eval model.
     model.train(bool(getattr(model, "training", False)))
@@ -15902,12 +16002,20 @@ def attach_and_bind_peft_adapter(model, adapter_dir, cfg):
     for path, origin in applied_full_state.items():
         if origin == "modules_to_save":
             by_name[path].unfreeze()
-    model._unsloth_full_state_modules = dict(applied_full_state)
+    model._unsloth_full_state_modules = {
+        _tree_prefix + path: origin for path, origin in applied_full_state.items()
+    }
     # peft-origin: saves of this model carry the conversion marker.
     model._unsloth_peft_converted = True
     mx.eval(model.parameters())
     # Shapes carry ranks, but scale variance must survive a zoo-side re-save
     # (stock mlx-lm has a single global scale).
-    model._unsloth_lora_module_scales = module_scales
-    model._unsloth_lora_module_ranks = module_ranks
+    model._unsloth_lora_module_scales = {
+        _tree_prefix + p: v for p, v in module_scales.items()
+    }
+    model._unsloth_lora_module_ranks = {
+        _tree_prefix + p: v for p, v in module_ranks.items()
+    }
+    # Remembered so a PEFT export re-emits Hugging-Face-native paths.
+    model._unsloth_tree_prefix = _tree_prefix
     return len(staged)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -15,7 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+import uuid
 __all__ = [
+    "export_peft_adapter",
+    "convert_peft_dir_to_mlx",
+    "convert_mlx_dir_to_peft",
+    "detect_adapter_format",
     "create_huggingface_repo",
     "merge_and_dequantize_lora",
     "merge_and_overwrite_lora",
@@ -6320,14 +6325,10 @@ def _raise_rejected(rejected, where):
     )
 
 
-def _require_fresh_dir(dst):
-    # mkdir is the lock: exactly one caller can create the directory, so
-    # racing conversions cannot interleave into one destination. Accepting
-    # a pre-existing empty directory would reopen that race (created-but-
-    # not-yet-written looks identical to empty), so it is refused too.
-    try:
-        os.makedirs(dst)
-    except FileExistsError:
+def _require_fresh_destination(dst):
+    # Early refusal including dangling symlinks; the atomic publish rename at
+    # the end of conversion makes the claim final.
+    if os.path.lexists(dst):
         raise ValueError(
             f"Unsloth MLX: destination {dst!r} already exists. Adapter "
             "conversion creates its own fresh directory so two formats can "
@@ -6414,12 +6415,44 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
             "copy needs Unsloth to load (stock mlx-lm assumes one global "
             "rank/scale)."
         )
-    # Claim the destination only after everything above validated, so a
-    # refused conversion never leaves a half-written directory behind.
-    _require_fresh_dir(dst)
-    save_file(os.path.join(dst, MLX_WEIGHTS_FILE), out)
-    with open(os.path.join(dst, "adapter_config.json"), "w") as f:
-        json.dump(mlx_cfg, f, indent=2, sort_keys=True)
+    # Destination contract: the complete artifact is staged in a unique sibling
+    # directory and published by ONE atomic rename, so readers never observe a
+    # partial adapter: a crash leaves either nothing at dst or the complete
+    # artifact, never a half-written one. Claim-first designs
+    # were tried and rejected: a kill between claim and publish strands a
+    # partial destination that blocks retries. The rename refuses a concurrently
+    # created non-empty dst (ENOTEMPTY), so content is never replaced and
+    # formats never mix; the residual — adopting a ZERO-DATA entry (empty
+    # directory or bare symlink) created in the race window — is accepted, since
+    # two uncoordinated writers on one path are outside the contract under any
+    # protocol. dst is refused by the caller's spelling BEFORE resolving so a
+    # pre-planted dangling symlink is rejected rather than followed (trailing
+    # separators are stripped first — lexists("link/") follows the terminal
+    # symlink); resolution only normalizes parents, and the resolved path is
+    # re-checked in case a parent symlink retargeted it.
+    dst = os.fspath(dst)
+    _require_fresh_destination(dst.rstrip(os.sep) or dst)
+    dst = os.path.realpath(dst)
+    _require_fresh_destination(dst)
+    os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+    _tmp = f"{dst}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    _tmp_created = False
+    try:
+        os.makedirs(_tmp)
+        _tmp_created = True
+        save_file(os.path.join(_tmp, MLX_WEIGHTS_FILE), out)
+        with open(os.path.join(_tmp, "adapter_config.json"), "w") as f:
+            json.dump(mlx_cfg, f, indent=2, sort_keys=True)
+        try:
+            os.rename(_tmp, dst)
+        except OSError as exc:
+            raise ValueError(
+                f"Unsloth MLX: destination {dst!r} appeared concurrently "
+                "and is not empty; refusing to mix adapter artifacts."
+            ) from exc
+    finally:
+        if _tmp_created:
+            shutil.rmtree(_tmp, ignore_errors=True)
     return dst
 
 
@@ -6454,6 +6487,12 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
             f"Unsloth MLX: fine_tune_type={cfg.get('fine_tune_type')!r} "
             "adapters cannot be exported to PEFT format yet; only plain "
             "LoRA is supported."
+        )
+    if cfg.get("full_state_modules"):
+        raise ValueError(
+            "Unsloth MLX: this adapter carries full-module state "
+            "(full_state_modules); it cannot be represented as plain "
+            "linear LoRA and PEFT export does not support it yet."
         )
     tensors = load_file(os.path.join(src, MLX_WEIGHTS_FILE))
     pairs = {}
@@ -6531,12 +6570,17 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
         ranks[path] = rank
         scale = float(scale_map.get(path, global_scale))
         alphas[path] = scale * rank
-    ref_path = next(iter(sorted(ranks)))
+    # Modal values minimize pattern entries; peft's matcher
+    # re.match(r"(.*\.)?(key)$", name) is ^-anchored, giving exact-path
+    # semantics so overlapping dotted suffixes cannot shadow.
+    from collections import Counter
+    ref_rank = Counter(ranks.values()).most_common(1)[0][0]
+    ref_alpha = Counter(alphas.values()).most_common(1)[0][0]
     peft_cfg = {
         "peft_type": "LORA",
         "task_type": "CAUSAL_LM",
-        "r": ranks[ref_path],
-        "lora_alpha": alphas[ref_path],
+        "r": ref_rank,
+        "lora_alpha": ref_alpha,
         "lora_dropout": dropout,
         "bias": "none",
         "use_rslora": False,
@@ -6552,15 +6596,56 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
         peft_cfg["revision"] = revision
     if len(set(ranks.values())) > 1:
         peft_cfg["rank_pattern"] = {
-            re.escape(p): r for p, r in ranks.items() if r != peft_cfg["r"]
+            "^" + re.escape(p): r for p, r in ranks.items()
+            if r != peft_cfg["r"]
         }
     if len(set(alphas.values())) > 1:
         peft_cfg["alpha_pattern"] = {
-            re.escape(p): a for p, a in alphas.items()
+            "^" + re.escape(p): a for p, a in alphas.items()
             if a != peft_cfg["lora_alpha"]
         }
-    _require_fresh_dir(dst)
-    save_file(os.path.join(dst, PEFT_WEIGHTS_FILE), out)
-    with open(os.path.join(dst, "adapter_config.json"), "w") as f:
-        json.dump(peft_cfg, f, indent=2, sort_keys=True)
+    # Same stage-then-atomic-rename destination contract as
+    # convert_peft_dir_to_mlx; see the note there.
+    dst = os.fspath(dst)
+    _require_fresh_destination(dst.rstrip(os.sep) or dst)
+    dst = os.path.realpath(dst)
+    _require_fresh_destination(dst)
+    os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+    _tmp = f"{dst}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    _tmp_created = False
+    try:
+        os.makedirs(_tmp)
+        _tmp_created = True
+        save_file(os.path.join(_tmp, PEFT_WEIGHTS_FILE), out)
+        with open(os.path.join(_tmp, "adapter_config.json"), "w") as f:
+            json.dump(peft_cfg, f, indent=2, sort_keys=True)
+        try:
+            os.rename(_tmp, dst)
+        except OSError as exc:
+            raise ValueError(
+                f"Unsloth MLX: destination {dst!r} appeared concurrently "
+                "and is not empty; refusing to mix adapter artifacts."
+            ) from exc
+    finally:
+        if _tmp_created:
+            shutil.rmtree(_tmp, ignore_errors=True)
     return dst
+
+
+def export_peft_adapter(src, dst, *, base_config=None, module_types=None,
+                        base_weights_source=None):
+    """Public wrapper: convert an mlx-lm adapter directory to PEFT format.
+
+    ``module_types`` follows convert_mlx_dir_to_peft. ``base_config`` is
+    accepted for signature parity with the import direction; this direction
+    derives everything it needs from the adapter itself. ``base_weights_source``
+    is reserved for emitting PEFT-convention full embedding weights; passing
+    it is refused until full-weight module state is supported end to end.
+    """
+    if base_weights_source is not None:
+        raise ValueError(
+            "Unsloth MLX: base_weights_source is not supported yet; "
+            "embedding/full-weight emission lands with modules_to_save "
+            "support."
+        )
+    return convert_mlx_dir_to_peft(src, dst, module_types=module_types)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -6375,6 +6375,15 @@ def group_peft_lora_pairs(tensors, cfg=None):
                 # peft saves it under the wrapper's inner path; normalize to
                 # the module path the MLX tree uses.
                 fs_path = fs_path[: -len(".base_layer")]
+                if not _is_auto_saved_module_path(fs_path):
+                    # Every LoRA target has a .base_layer, so without this any
+                    # of them could carry full state and replace its own base
+                    # weights.
+                    rejected[key] = (
+                        "auto-saved base state on a module that is not the "
+                        "input embedding or output head"
+                    )
+                    continue
                 full_state.setdefault(fs_path, {})[tname] = tensor
                 full_state[fs_path]["__origin__"] = "embedding_auto"
                 continue
@@ -6429,10 +6438,8 @@ def group_peft_lora_pairs(tensors, cfg=None):
                 _slot[tname] = tensor
                 _slot["__origin__"] = "modules_to_save"
                 continue
-            leaf = fs_path.rsplit(".", 1)[-1]
-            if leaf in _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES:
-                # Auto-saved embedding/head state across mlx-lm spellings;
-                # biased heads (e.g. Phi) include their bias.
+            if _is_auto_saved_module_path(fs_path):
+                # Auto-saved embedding/head state; biased heads include bias.
                 full_state.setdefault(fs_path, {})[tname] = tensor
                 full_state[fs_path]["__origin__"] = "embedding_auto"
                 continue
@@ -6830,6 +6837,23 @@ _OUTPUT_HEAD_LEAF_NAMES = ("lm_head", "output", "embed_out")
 
 def _leaf_in(path, names):
     return path.rsplit(".", 1)[-1] in names
+
+
+def _is_auto_saved_module_path(path):
+    """Whether a path could name the input embedding or output head, the two
+    modules peft auto-saves full base state for. These are Hugging Face paths,
+    whose spellings for those two are a small fixed set, but some are reused
+    deeper in the tree: OLMo names both its root head and every block's MLP
+    output ff_out, and `output` also spells an attention projection. Neither
+    of those sits at the root, so a path through a numbered layer is never
+    one of them."""
+    if any(segment.isdigit() for segment in path.split(".")):
+        return False
+    # ff_out is hf_olmo's head, kept local: the tied-embedding checks read the
+    # shared tuple without the numbered-segment rule.
+    return _leaf_in(
+        path, _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES + ("ff_out",)
+    )
 
 
 def _config_ties_word_embeddings(config):

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -14,17 +14,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
 __all__ = [
     "create_huggingface_repo",
     "merge_and_dequantize_lora",
     "merge_and_overwrite_lora",
 ]
 import warnings
-from .peft_utils import get_lora_layer_modules
-from .utils import _get_dtype, Version
-from .hf_utils import dtype_from_config
-from .device_type import DEVICE_TYPE, DEVICE_TYPE_TORCH, device_empty_cache
-from unsloth_zoo.temporary_patches.common import UNSLOTH_ENABLE_LOGGING, logger
 from collections import defaultdict
 
 # Import each independently: convert_moe_packed_tensors_cpu is injected at runtime by Unsloth's
@@ -66,15 +62,77 @@ This {model_type} model was trained 2x faster with [Unsloth](https://github.com/
 [<img src="https://raw.githubusercontent.com/unslothai/unsloth/main/images/unsloth%20made%20with%20love.png" width="200"/>](https://github.com/unslothai/unsloth)
 """
 
-import torch
-try:
-    import bitsandbytes as bnb
-    _BNB_LINEAR4BIT = (bnb.nn.Linear4bit,)
-except Exception:
-    # No bnb (e.g. gfx906, whose generic wheel has no kernels) -> no 4bit layers
-    # exist, so the isinstance check below is simply always False.
-    bnb = None
-    _BNB_LINEAR4BIT = ()
+class _LazyModule:
+    """Import-on-first-attribute proxy so this module stays importable on
+    hosts without the heavy CUDA-side dependencies (e.g. MLX-only Apple
+    installs importing the adapter-format helpers below)."""
+    def __init__(self, name):
+        self._lazy_name = name
+        self._lazy_module = None
+    def __getattr__(self, attr):
+        if self._lazy_module is None:
+            import importlib
+            self._lazy_module = importlib.import_module(self._lazy_name)
+        return getattr(self._lazy_module, attr)
+
+
+class _LazyLogger:
+    """Defers unsloth_zoo.temporary_patches.common (which imports torch)."""
+    def __getattr__(self, attr):
+        from unsloth_zoo.temporary_patches.common import logger as _logger
+        return getattr(_logger, attr)
+
+logger = _LazyLogger()
+
+def _unsloth_logging_enabled():
+    from unsloth_zoo.temporary_patches.common import UNSLOTH_ENABLE_LOGGING
+    return UNSLOTH_ENABLE_LOGGING
+
+def _device_type():
+    from .device_type import DEVICE_TYPE
+    return DEVICE_TYPE
+
+def _device_type_torch():
+    from .device_type import DEVICE_TYPE_TORCH
+    return DEVICE_TYPE_TORCH
+
+def _device_empty_cache():
+    from .device_type import device_empty_cache
+    return device_empty_cache()
+
+def _st_save_file(*args, **kwargs):
+    from safetensors.torch import save_file as _sf
+    return _sf(*args, **kwargs)
+
+torch = _LazyModule("torch")
+bnb = _LazyModule("bitsandbytes")
+
+def _lazy_symbol(module_name, symbol):
+    import importlib
+    return getattr(importlib.import_module(module_name), symbol)
+
+def _inference_mode(fn):
+    """@torch.inference_mode without importing torch at decoration time."""
+    import functools
+    @functools.wraps(fn)
+    def _wrapped(*args, **kwargs):
+        with torch.inference_mode():
+            return fn(*args, **kwargs)
+    return _wrapped
+
+
+def _bnb_linear4bit():
+    # Empty when bitsandbytes is absent (e.g. gfx906, whose generic wheel has
+    # no kernels) or stubbed out, as it is on hosts with no CUDA build: either
+    # way there are no 4bit layers, so isinstance against an empty tuple is
+    # exactly right. Resolved lazily to keep the import off this module's
+    # import path, and filtered to real classes because the stub answers every
+    # attribute with a placeholder object that isinstance would reject.
+    try:
+        candidate = bnb.nn.Linear4bit
+    except Exception:
+        return ()
+    return (candidate,) if isinstance(candidate, type) else ()
 try:
     from huggingface_hub import get_token
 except:
@@ -85,19 +143,17 @@ except:
         from huggingface_hub.utils._token import get_token
     pass
 pass
-from transformers.modeling_utils import PushToHubMixin
 import json
 import os
 from pathlib import Path
 from typing import Union, List, Optional
 import tempfile
-from peft import PeftModelForCausalLM, PeftModel
 
 def find_skipped_quantized_modules(model):
     skipped_modules = []
     quantized_modules = []
     for name, module in model.named_modules():
-        if isinstance(module, _BNB_LINEAR4BIT):
+        if isinstance(module, _bnb_linear4bit()):
             if hasattr(module.weight, 'quant_state') and module.weight.quant_state is not None:
                 quantized_modules.append(name)
             else:
@@ -159,7 +215,6 @@ from huggingface_hub import (
     HfFileSystem,
 )
 from safetensors import safe_open
-from safetensors.torch import save_file
 from collections import OrderedDict
 from tqdm import tqdm as ProgressBar
 import os, shutil, re, functools
@@ -173,7 +228,7 @@ _EMPTY_CACHE_BYTES_THRESHOLD = 256 * 1024 * 1024
 def _active_merge_device():
     """Pick the active accelerator family for LoRA merge math, cached.
 
-    Hardcoding "cuda" breaks ROCm/XPU/MPS; DEVICE_TYPE_TORCH drops MPS (needed
+    Hardcoding "cuda" breaks ROCm/XPU/MPS; _device_type_torch() drops MPS (needed
     by the MLX backend's on-host merge). So probe at first call instead.
     """
     if torch.cuda.is_available():
@@ -229,7 +284,7 @@ def _merge_lora(W, lora_stats, name, use_dequant_base = False):
     # for export has no merge-time provenance signal, so it would also fold onto dequant(W4).
     if use_dequant_base and _is_bnb_4bit_base(getattr(lora_stats, "module", None)):
         try:
-            W_dq = dequantize_module_weight(lora_stats.module)
+            W_dq = _lazy_symbol("peft.utils.integrations", "dequantize_module_weight")(lora_stats.module)
         except Exception as e:
             # For a gated arch the 16bit base is the known-wrong base (the +q error this path
             # exists to remove), so silently folding onto it would emit a corrupt merged_16bit.
@@ -345,7 +400,6 @@ def expand_module_keys(name, module, original_keys):
 pass
 
 
-from peft.utils.integrations import dequantize_module_weight
 import collections
 import numpy as np
 import inspect
@@ -445,12 +499,12 @@ def _get_lora_scaling(module):
 pass
 
 
-@torch.inference_mode
+@_inference_mode
 def create_lora_statistics(model, merge_into_original = False, return_state_dict = True):
     # All Unsloth Zoo code licensed under LGPLv3
     # merge_into_original is merging directly into 16bit downloaded model
     # without dequantizing
-    Linear_LoRA_Layers = get_lora_layer_modules()
+    Linear_LoRA_Layers = _lazy_symbol("unsloth_zoo.peft_utils", "get_lora_layer_modules")()
     Linear_LoRA_Layers = tuple(x[0] for x in Linear_LoRA_Layers)
 
     lora_weights = collections.defaultdict(lambda: LoraStats(None, None, None, 0))
@@ -622,38 +676,35 @@ def create_lora_statistics(model, merge_into_original = False, return_state_dict
 pass
 
 
-import torch
 import gc
 import time
 import safetensors
 import json
 import mmap
 import ctypes
-# Mapping from BF16 to torch.blfloat16 etc
-try:
-    SAFETENSORS_DTYPES = safetensors.torch._TYPES
-except:
-    logger.info("Unsloth: `safetensors.torch._TYPES` does not exist. Will set to our default version")
-    SAFETENSORS_DTYPES = {
-        'F64': torch.float64,
-        'F32': torch.float32,
-        'F16': torch.float16,
-        'BF16': torch.bfloat16,
-        'I64': torch.int64,
-        'I32': torch.int32,
-        'I16': torch.int16,
-        'I8': torch.int8,
-        'U8': torch.uint8,
-        'BOOL': torch.bool,
-        'F8_E4M3': torch.float8_e4m3fn,
-        'F8_E5M2': torch.float8_e5m2,
-        'U64': torch.uint64,
-        'U32': torch.uint32,
-        'U16': torch.uint16,
-    }
-pass
+# BF16 -> torch.bfloat16 etc; lazy because both sources import torch.
+_SAFETENSORS_DTYPES_CACHE = None
+def _safetensors_dtypes():
+    global _SAFETENSORS_DTYPES_CACHE
+    if _SAFETENSORS_DTYPES_CACHE is None:
+        try:
+            # No longer imported eagerly anywhere; without this a fresh process
+            # takes the smaller fallback table and KeyErrors on newer dtype tags.
+            import safetensors.torch as _st_mod
+            _SAFETENSORS_DTYPES_CACHE = _st_mod._TYPES
+        except Exception:
+            logger.info("Unsloth: `safetensors.torch._TYPES` does not exist. Will set to our default version")
+            _SAFETENSORS_DTYPES_CACHE = {
+                'F64': torch.float64, 'F32': torch.float32, 'F16': torch.float16,
+                'BF16': torch.bfloat16, 'I64': torch.int64, 'I32': torch.int32,
+                'I16': torch.int16, 'I8': torch.int8, 'U8': torch.uint8,
+                'BOOL': torch.bool, 'F8_E4M3': torch.float8_e4m3fn,
+                'F8_E5M2': torch.float8_e5m2, 'U64': torch.uint64,
+                'U32': torch.uint32, 'U16': torch.uint16,
+            }
+    return _SAFETENSORS_DTYPES_CACHE
 
-@torch.inference_mode
+@_inference_mode
 def _merge_and_overwrite_lora(
     save_directory,
     filename,
@@ -671,7 +722,7 @@ def _merge_and_overwrite_lora(
     # All Unsloth Zoo code licensed under LGPLv3
     # Merges LoRA and overwrites the safetensors file it was merged to
     if base_model_is_quantized and quant_type == "mxfp4" and save_method != "mxfp4":
-        if UNSLOTH_ENABLE_LOGGING:
+        if _unsloth_logging_enabled():
             logger.info("mxfp4 quantized model detected. Using safe rewrite strategy (requires temporary disk space).")
         # mxfp4 needs the full-rewrite path
         return _merge_and_overwrite_lora_mxfp4(
@@ -688,7 +739,7 @@ def _merge_and_overwrite_lora(
         isinstance(k, str) and (".experts" in k or ".moe" in k) for k in lora_weights
     )
     if base_model_is_quantized and quant_type == "fp8" and save_method == "merged_16bit" and not _fp8_moe_expert_lora:
-        if UNSLOTH_ENABLE_LOGGING:
+        if _unsloth_logging_enabled():
             logger.info("FP8 quantized model detected. Dequantizing to 16bit via full rewrite.")
         return _merge_and_overwrite_lora_fp8(
             save_directory, filename, lora_weights, output_dtype,
@@ -757,7 +808,7 @@ def _merge_and_overwrite_lora(
                 if _ne is not None and _ne > 1:
                     moe_num_experts[_prefix] = _ne
             processed_mxfp4_keys = set()
-            if UNSLOTH_ENABLE_LOGGING:
+            if _unsloth_logging_enabled():
                 try:
                     logger.info(f"[merge_debug] Converted LoRA keys (sample): {list(converted_lora_weights.keys())[:6]}")
                 except Exception:
@@ -784,7 +835,7 @@ def _merge_and_overwrite_lora(
                     continue
 
                 if (
-                    UNSLOTH_ENABLE_LOGGING
+                    _unsloth_logging_enabled()
                     and count == 0
                     and len(processed_moe_gate) == 0
                     and len(processed_mxfp4_keys) == 0
@@ -841,7 +892,7 @@ def _merge_and_overwrite_lora(
                 # sharded as per-expert gate_proj/up_proj on disk.
                 m_gate = re.match(r"^(.*mlp\.experts)\.(\d+)\.(gate_proj|up_proj)\.weight$", key)
                 if m_gate:
-                    if UNSLOTH_ENABLE_LOGGING and len(processed_moe_gate) < 2:
+                    if _unsloth_logging_enabled() and len(processed_moe_gate) < 2:
                         logger.info(f"[merge_debug] Matched gate/up key {key}")
                     base_prefix, expert_idx, proj_type = m_gate.groups()
                     expert_idx = int(expert_idx)
@@ -891,11 +942,11 @@ def _merge_and_overwrite_lora(
                     fused_key = base_prefix  # down_proj LoRA stored on experts module
                     lora_stats = converted_lora_weights.get(fused_key)
                     if lora_stats is None and len(processed_moe_gate) < 3:
-                        if UNSLOTH_ENABLE_LOGGING:
+                        if _unsloth_logging_enabled():
                             logger.info(f"[merge_debug] No LoRA found for down_proj prefix {base_prefix}")
                     if lora_stats is not None and lora_stats.lora_A is not None and lora_stats.lora_B is not None:
                         num_experts = moe_num_experts.get(base_prefix, None)
-                        if UNSLOTH_ENABLE_LOGGING:
+                        if _unsloth_logging_enabled():
                             logger.info(f"[merge_debug] Applying down_proj LoRA for {fused_key} expert {expert_idx}")
                         down_W = file.get_tensor(key)
                         merged_down = _merge_moe_down_proj_expert(
@@ -913,7 +964,7 @@ def _merge_and_overwrite_lora(
                     # In this mode, we don't dequantize or modify MXFP4 tensors.
                     # Since we're doing an in-place overwrite on the file,
                     # skipping these keys leaves them untouched in the final model file.
-                    if UNSLOTH_ENABLE_LOGGING:
+                    if _unsloth_logging_enabled():
                         logger.info(f"[DEBUG] Preserving MXFP4 tensor: {key}")
                     continue
                 pass
@@ -976,7 +1027,7 @@ def _merge_and_overwrite_lora(
                 del W
                 # flush only after a large tensor; per-key flush was pure stall.
                 if nbytes >= _EMPTY_CACHE_BYTES_THRESHOLD:
-                    device_empty_cache()
+                    _device_empty_cache()
             pass
         pass
         mm.flush()
@@ -989,7 +1040,7 @@ def _merge_and_overwrite_lora(
         if resized:
             _merge_and_overwrite_lora._resized = {}
             gc.collect()
-            device_empty_cache()
+            _device_empty_cache()
 
             temp_dir = os.path.dirname(os.path.abspath(filename_original))
             est_bytes = _estimate_resized_shard_bytes(header_metadata, resized, length_of_header)
@@ -1026,9 +1077,9 @@ def _merge_and_overwrite_lora(
                 )
             del resized
             gc.collect()
-            device_empty_cache()
+            _device_empty_cache()
 
-        device_empty_cache()
+        _device_empty_cache()
         return count, safetensor_keys_seen
 
     except RuntimeError:
@@ -1439,7 +1490,7 @@ def _resolve_moe_num_experts(prefix, lora_stats, moe_num_experts):
             value = getattr(module, attr, None)
             if isinstance(value, int) and value > 1:
                 moe_num_experts[prefix] = value
-                if UNSLOTH_ENABLE_LOGGING:
+                if _unsloth_logging_enabled():
                     try:
                         logger.info(
                             f"[merge_debug] Derived num_experts={value} for {prefix} from module.{attr}"
@@ -1465,7 +1516,7 @@ def _resolve_moe_num_experts(prefix, lora_stats, moe_num_experts):
 
     candidate = total_rank // rank
     moe_num_experts[prefix] = candidate
-    if UNSLOTH_ENABLE_LOGGING:
+    if _unsloth_logging_enabled():
         try:
             logger.info(
                 f"[merge_debug] Derived num_experts={candidate} for {prefix} from LoRA stats"
@@ -1535,7 +1586,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
     count = 0
     debug_logged = 0
     file_path = getattr(file, "path", None)
-    if UNSLOTH_ENABLE_LOGGING:
+    if _unsloth_logging_enabled():
         try:
             logger.info(
                 f"[merge_debug] Running MoE expert merge for {file_path or 'safetensors shard'}"
@@ -1565,7 +1616,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
                     _is_transposed_format = shape[2] > shape[1]
                 break
 
-    if is_gpt_oss_format and UNSLOTH_ENABLE_LOGGING:
+    if is_gpt_oss_format and _unsloth_logging_enabled():
         try:
             logger.info(f"[merge_debug] Detected fused 3D tensor format (transposed={_is_transposed_format})")
         except Exception:
@@ -1593,7 +1644,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
             if _fused_key in processed_mxfp4_keys:
                 continue
             _fused_W = file.get_tensor(_fused_key)
-            if _fused_W.dim() != 3 or _fused_W.dtype in _FP8_WEIGHT_DTYPES:
+            if _fused_W.dim() != 3 or _fused_W.dtype in _fp8_weight_dtypes():
                 continue
             _num_experts_disk = _fused_W.shape[0]
             _device = _active_merge_device()
@@ -1656,7 +1707,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
                 gate_up_key = f"{shard_prefix}.gate_up_proj"
                 if gate_up_key in header_metadata:
                     gate_up_W = file.get_tensor(gate_up_key)
-                    if gate_up_W.dtype in _FP8_WEIGHT_DTYPES:
+                    if gate_up_W.dtype in _fp8_weight_dtypes():
                         raise RuntimeError(
                             "Unsloth: FP8 fused MoE expert LoRA merge (gate_up_proj) is not "
                             "supported; merging raw FP8 without its companion scale would "
@@ -1677,7 +1728,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
                     )
                     processed_mxfp4_keys.add(gate_up_key)
                     module_updated = True
-                    if UNSLOTH_ENABLE_LOGGING and debug_logged < 8:
+                    if _unsloth_logging_enabled() and debug_logged < 8:
                         try:
                             logger.info(
                                 f"[merge_debug] Merged GPT-OSS gate_up_proj for {shard_prefix}"
@@ -1690,7 +1741,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
                 down_key = f"{shard_prefix}.down_proj"
                 if down_key in header_metadata:
                     down_W = file.get_tensor(down_key)
-                    if down_W.dtype in _FP8_WEIGHT_DTYPES:
+                    if down_W.dtype in _fp8_weight_dtypes():
                         raise RuntimeError(
                             "Unsloth: FP8 fused MoE expert LoRA merge (down_proj) is not "
                             "supported; merging raw FP8 without its companion scale would "
@@ -1711,7 +1762,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
                     )
                     processed_mxfp4_keys.add(down_key)
                     module_updated = True
-                    if UNSLOTH_ENABLE_LOGGING and debug_logged < 8:
+                    if _unsloth_logging_enabled() and debug_logged < 8:
                         try:
                             logger.info(
                                 f"[merge_debug] Merged GPT-OSS down_proj for {shard_prefix}"
@@ -1741,7 +1792,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
             prefix, resolution_stats, moe_num_experts,
             header_metadata, (gate_name, up_name, down_name),
         )
-        if UNSLOTH_ENABLE_LOGGING and num_experts is not None and debug_logged < 2:
+        if _unsloth_logging_enabled() and num_experts is not None and debug_logged < 2:
             try:
                 logger.info(
                     f"[merge_debug] {lora_key}: merging {num_experts} experts via MoE merge path"
@@ -1750,7 +1801,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
             except Exception:
                 pass
         if num_experts is None or num_experts == 0:
-            if UNSLOTH_ENABLE_LOGGING and debug_logged < 4:
+            if _unsloth_logging_enabled() and debug_logged < 4:
                 try:
                     logger.info(f"[merge_debug] Skipping {lora_key}: num_experts missing")
                     debug_logged += 1
@@ -1760,7 +1811,7 @@ def _merge_moe_experts_file(mm, header_metadata, length_of_header, file, convert
 
         module_updated = False
         already_counted = lora_key in counted_lora_modules
-        if UNSLOTH_ENABLE_LOGGING and debug_logged < 8:
+        if _unsloth_logging_enabled() and debug_logged < 8:
             try:
                 logger.info(f"[merge_debug] Merging {lora_key} is_gate={is_gate} num_experts={num_experts} A={tuple(lora_stats.lora_A.shape) if getattr(lora_stats,'lora_A',None) is not None else None} B={tuple(lora_stats.lora_B.shape) if getattr(lora_stats,'lora_B',None) is not None else None}")
                 debug_logged += 1
@@ -2019,7 +2070,7 @@ def _mxfp4_base_returns_transposed(convert_cpu_variant, transformers_version):
         # are treated like the final 4.56.0, which self-transposes -- a plain
         # Version(...) >= Version("4.56.0") sorts every pre-release BELOW 4.56.0 and
         # would wrongly re-apply the external transpose (double-transpose) on them.
-        return Version(transformers_version).release >= (4, 56, 0)
+        return _lazy_symbol("unsloth_zoo.utils", "Version")(transformers_version).release >= (4, 56, 0)
     except Exception:
         # Version unparseable: assume the modern stock behaviour (self-transposes).
         return True
@@ -2063,7 +2114,7 @@ def _fold_perexpert_lora_into_fused(W, fused_base_name, converted_lora_weights):
 pass
 
 
-@torch.inference_mode
+@_inference_mode
 def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, output_dtype, model_class_name, base_model_is_quantized=False, quant_type=None):
     # All Unsloth Zoo code licensed under LGPLv3
     # Merges LoRA and overwrites the safetensors file it was merged to
@@ -2129,7 +2180,7 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                 blocks_tensor, scales_tensor = file.get_tensor(key), file.get_tensor(scales_key)
 
                 # Free the allocator before the large dequant alloc.
-                device_empty_cache()
+                _device_empty_cache()
 
                 # Pick device + chunk size for mxfp4 dequantization
                 device_type, device_id, rows_per_chunk = _choose_mxfp4_processing_strategy(
@@ -2164,7 +2215,7 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     W = _cmpt_cpu(
                         blocks_tensor, scales_tensor, rows_per_chunk=rows_per_chunk
                     ).transpose(1, 2).contiguous()
-                    if UNSLOTH_ENABLE_LOGGING:
+                    if _unsloth_logging_enabled():
                         logger.info(f"[DEBUG] Using CPU dequantization for {base_name} with {rows_per_chunk:,} rows per chunk")
                 else:
                     W = _cmpt_base(
@@ -2173,7 +2224,7 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     # Add the external transpose unless the base already returns the transposed
                     # GPT-OSS layout (stock transformers >= 4.56.0).
                     W = W.contiguous() if _base_returns_transposed else W.transpose(1, 2).contiguous()
-                    if UNSLOTH_ENABLE_LOGGING:
+                    if _unsloth_logging_enabled():
                         _which = "GPU" if device_type != 'cpu' else "CPU-fallback"
                         logger.info(f"[DEBUG] Using {_which} dequantization for {base_name} with {rows_per_chunk:,} rows per chunk")
 
@@ -2186,7 +2237,7 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     # use_dora adapter on the experts bypasses the refuse and _merge_lora fails with an
                     # opaque shape error on the 3D expert group instead of the clear message.
                     _refuse_dora_on_moe(lora_stats)
-                    if UNSLOTH_ENABLE_LOGGING:
+                    if _unsloth_logging_enabled():
                         logger.info(f"[DEBUG] DEQUANTIZING MXFP4 & MERGING LoRA into Key Group: {base_name}")
                     count += 1; W = _merge_lora(W, lora_stats, output_key)
                 else:
@@ -2194,7 +2245,7 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
                     # lookup above misses it, so fold each delta into its slice of W.
                     _folded = _fold_perexpert_lora_into_fused(W, base_name, converted_lora_weights)
                     count += _folded
-                    if UNSLOTH_ENABLE_LOGGING:
+                    if _unsloth_logging_enabled():
                         if _folded:
                             logger.info(f"[DEBUG] DEQUANTIZING MXFP4 & MERGING {_folded} per-expert LoRA(s) into Key Group: {base_name}")
                         else:
@@ -2243,7 +2294,7 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
 
             # Free VRAM only after a large dequant/merge, not every small tensor.
             if W.numel() * W.element_size() >= _EMPTY_CACHE_BYTES_THRESHOLD:
-                device_empty_cache()
+                _device_empty_cache()
 
     # CRITICAL: Force cleanup to release file handles on Windows
     if os.name == 'nt':
@@ -2254,7 +2305,7 @@ def _merge_and_overwrite_lora_mxfp4(save_directory, filename, lora_weights, outp
     with tempfile.NamedTemporaryFile(suffix=".safetensors", dir=save_directory, delete=False) as tmpfile:
         temp_filename_safetensors = tmpfile.name
 
-    save_file(tensors, temp_filename_safetensors, metadata={"format": "pt"})  # Save to the temporary safetensors file
+    _st_save_file(tensors, temp_filename_safetensors, metadata={"format": "pt"})  # Save to the temporary safetensors file
 
     # Replace the temporary file with the original file
     try:
@@ -2290,9 +2341,11 @@ pass
 
 # FP8 weight dtypes and companion scale suffixes (dropped on merge). Underscore
 # variants cover fused params whose scale is <key>_scale(_inv), not <key>.weight_scale.
-_FP8_WEIGHT_DTYPES = tuple(
-    getattr(torch, _n) for _n in ("float8_e4m3fn", "float8_e5m2") if hasattr(torch, _n)
-)
+def _fp8_weight_dtypes():
+    return tuple(
+        getattr(torch, _n) for _n in ("float8_e4m3fn", "float8_e5m2")
+        if hasattr(torch, _n)
+    )
 _FP8_SCALE_SUFFIXES = (".weight_scale_inv", ".weight_scale", ".input_scale",
                        "_scale_inv", "_scale")
 # safetensors header dtype tags for FP8 weights (used to find genuine scale companions).
@@ -2309,7 +2362,7 @@ def _fp8_dequantize_weight(file, header_metadata, weight_key, weight_block_size 
     """
     from unsloth_zoo.temporary_patches.moe_utils_fp8 import _fp8_dequant_blockwise
     W = file.get_tensor(weight_key)
-    if W.dtype not in _FP8_WEIGHT_DTYPES:
+    if W.dtype not in _fp8_weight_dtypes():
         return W, []
     base = weight_key[: -len(".weight")] if weight_key.endswith(".weight") else weight_key
     # <base>.weight_scale(_inv) for .weight; <key>_scale(_inv) for fused params.
@@ -2475,7 +2528,7 @@ def _drop_resolved_fp8_scales_after_rewrite(save_directory, filenames, prerewrit
                     tensors[key] = f.get_tensor(key).contiguous()
         with tempfile.NamedTemporaryFile(suffix = ".safetensors", dir = save_directory, delete = False) as tmp:
             tmp_path = tmp.name
-        save_file(tensors, tmp_path, metadata = {"format": "pt"})
+        _st_save_file(tensors, tmp_path, metadata = {"format": "pt"})
         os.replace(tmp_path, path)
         removed.update(drop)
     return removed
@@ -2581,7 +2634,7 @@ def _merge_and_overwrite_lora_fp8(save_directory, filename, lora_weights, output
             tensors[output_key] = W.to(device = "cpu", dtype = write_dtype).contiguous()
             del W
             if tensors[output_key].numel() * tensors[output_key].element_size() >= _EMPTY_CACHE_BYTES_THRESHOLD:
-                device_empty_cache()
+                _device_empty_cache()
 
         # Remove the dropped scale companions from the rewritten shard.
         for sk in scale_keys_to_drop:
@@ -2596,7 +2649,7 @@ def _merge_and_overwrite_lora_fp8(save_directory, filename, lora_weights, output
 
     with tempfile.NamedTemporaryFile(suffix=".safetensors", dir=save_directory, delete=False) as tmpfile:
         temp_filename_safetensors = tmpfile.name
-    save_file(tensors, temp_filename_safetensors, metadata={"format": "pt"})
+    _st_save_file(tensors, temp_filename_safetensors, metadata={"format": "pt"})
     try:
         os.replace(temp_filename_safetensors, filename_original)
     except OSError as e:
@@ -2683,7 +2736,7 @@ def prepare_saving(
         pass
     pass
 
-    if output_dtype is None: output_dtype = _get_dtype(dtype_from_config(model.config))
+    if output_dtype is None: output_dtype = _lazy_symbol("unsloth_zoo.utils", "_get_dtype")(_lazy_symbol("unsloth_zoo.hf_utils", "dtype_from_config")(model.config))
     assert(output_dtype in (torch.float32, torch.float16, torch.float64, torch.bfloat16))
     assert(type(torch.bfloat16) is torch.dtype)
     element_size = torch.tensor([], dtype = output_dtype).element_size()
@@ -2877,7 +2930,7 @@ def is_hf_sharded_safetensors(filenames: list[str]) -> bool:
     prefixes, _, totals = zip(*parsed)
     return len(set(prefixes)) == 1 and len(set(totals)) == 1
 
-@torch.inference_mode
+@_inference_mode
 def merge_and_overwrite_lora(
     get_model_name,
     model,
@@ -2894,7 +2947,7 @@ def merge_and_overwrite_lora(
 ):
     # All Unsloth Zoo code licensed under LGPLv3
     # Directly downloads 16bit original weights and merges LoRA
-    inner_model = model.base_model.model if isinstance(model, PeftModel) else model
+    inner_model = model.base_model.model if isinstance(model, _lazy_symbol("peft", "PeftModel")) else model
     inner_model = inner_model.base_model if hasattr(model, "base_model") else inner_model
     safetensors_list = []
     max_size_in_bytes = 0
@@ -2902,7 +2955,7 @@ def merge_and_overwrite_lora(
     config = model.config
 
     for loop_iteration in range(2):
-        if not isinstance(model, PeftModel):
+        if not isinstance(model, _lazy_symbol("peft", "PeftModel")):
             warnings.warn("Model is not a PeftModel (no Lora adapters detected). Skipping Merge. Please use save_pretrained() or push_to_hub() instead!")
             return None
         if loop_iteration == 0:
@@ -2923,7 +2976,7 @@ def merge_and_overwrite_lora(
         if base_model_is_quantized and quant_type == "fp8" and save_method == "merged_16bit":
             _sibling = _resolve_fp8_16bit_sibling(model_name, token)
             if _sibling is not None:
-                if UNSLOTH_ENABLE_LOGGING:
+                if _unsloth_logging_enabled():
                     logger.info(f"Unsloth: FP8 base detected; merging onto 16bit sibling `{_sibling}`.")
                 model_name = _sibling
                 final_model_name, is_local_path, source_info, base_model_is_quantized, quant_type = determine_base_model_source(model_name, token, save_method)
@@ -3165,16 +3218,16 @@ def merge_and_overwrite_lora(
 
     # --- Handle 4-bit merging first ---
     if save_method == "merged_4bit" or save_method == "forced_merged_4bit":
-        base_model = model.base_model if isinstance(model, PeftModel) else model
+        base_model = model.base_model if isinstance(model, _lazy_symbol("peft", "PeftModel")) else model
         print(f"Unsloth: Merging LoRA weights into 4bit model...")
-        if not isinstance(model, PeftModelForCausalLM) and not isinstance(model, PeftModel):
+        if not isinstance(model, _lazy_symbol("peft", "PeftModelForCausalLM")) and not isinstance(model, _lazy_symbol("peft", "PeftModel")):
              raise TypeError("Model must be a PeftModelForCausalLM or PeftModel for 'merged_4bit' save.")
         if not getattr(model.config, "quantization_config", None):
              raise ValueError("Model does not appear to be quantized. Cannot use 'merged_4bit'.")
 
         # Perform the merge
         try:
-            # Use the base_model reference which points to the PeftModel's base
+            # Use the base_model reference which points to the _lazy_symbol("peft", "PeftModel")'s base
             merged_model = base_model.merge_and_unload()
             print(f"Unsloth: Merging finished.")
         except Exception as e:
@@ -3244,7 +3297,7 @@ def merge_and_overwrite_lora(
 
     # Step 3: Conditional index handling
     import subprocess
-    is_t4 = DEVICE_TYPE == "cuda" and "Tesla T4" in torch.cuda.get_device_name(0)
+    is_t4 = _device_type() == "cuda" and "Tesla T4" in torch.cuda.get_device_name(0)
     needs_splitting = should_split_shards(is_t4, config, safetensors_list, max_size_in_bytes) if save_method == "merged_16bit" else False
     _hf_cache_dir = _get_hf_cache_dir()
     copied_all_from_cache = False
@@ -3447,7 +3500,7 @@ def merge_and_overwrite_lora(
     # path in the loop below. Keeps a genuine 16bit output instead of FP8-labelled-as-16bit.
     if (base_model_is_quantized and quant_type == "fp8" and save_method == "merged_16bit"
             and any(isinstance(k, str) and (".experts" in k or ".moe" in k) for k in lora_weights)):
-        if UNSLOTH_ENABLE_LOGGING:
+        if _unsloth_logging_enabled():
             logger.info("FP8 MoE-expert LoRA detected: dequantizing to 16bit, then merging experts.")
         _prerewrite_fp8_keys = _collect_fp8_weight_keys(save_directory, final_safetensors_list)
         for _fn in final_safetensors_list:
@@ -3488,7 +3541,7 @@ def merge_and_overwrite_lora(
         )
         n_saved_modules += merged_count
         safetensor_keys_seen.update(shard_keys)
-        device_empty_cache()
+        _device_empty_cache()
 
         file_path = os.path.join(save_directory, filename)
 
@@ -3734,8 +3787,8 @@ pass
 
 _PUSHING_CODE = \
 """
-PushToHubMixin._upload_modified_files(
-    PushToHubMixin,
+_lazy_symbol("transformers.modeling_utils", "PushToHubMixin")._upload_modified_files(
+    _lazy_symbol("transformers.modeling_utils", "PushToHubMixin"),
     working_dir = save_directory,
     repo_id = '{repo_id}',
     files_timestamps = files_timestamps,
@@ -3752,7 +3805,7 @@ else:
 if {use_temp_file}:
     temp_file = tempfile.TemporaryDirectory(ignore_cleanup_errors = True)
     save_directory = temp_file.name
-files_timestamps = PushToHubMixin._get_files_timestamps(PushToHubMixin, save_directory)
+files_timestamps = _lazy_symbol("transformers.modeling_utils", "PushToHubMixin")._get_files_timestamps(_lazy_symbol("transformers.modeling_utils", "PushToHubMixin"), save_directory)
 """
 
 def incremental_save_pretrained(
@@ -3855,7 +3908,7 @@ def merge_and_dequantize_lora(
 ):
     # All Unsloth Zoo code licensed under LGPLv3
     # Dequantizes model to 16bit weights and merges LoRA
-    inner_model = model.base_model.model if isinstance(model, PeftModelForCausalLM) else model
+    inner_model = model.base_model.model if isinstance(model, _lazy_symbol("peft", "PeftModelForCausalLM")) else model
     inner_model = inner_model.base_model if hasattr(model, "base_model") else inner_model
 
     (
@@ -3947,7 +4000,7 @@ def merge_and_dequantize_lora(
         x = state_dict[name]
         if type(x) is LoraStats:
             DEQUANTIZED_KEYS.append(name)
-            W = dequantize_module_weight(x.module)
+            W = _lazy_symbol("peft.utils.integrations", "dequantize_module_weight")(x.module)
             W = _merge_lora(W, x, name)
             x = W.to(device = 'cpu', dtype = {str(output_dtype)}, non_blocking = True)
         # Remove memory leak
@@ -3988,8 +4041,8 @@ def merge_and_dequantize_lora(
     save_pretrained_dequantized = functions["save_pretrained_dequantized"]
     save_pretrained_dequantized = torch.inference_mode(save_pretrained_dequantized)
 
-    files_timestamps = PushToHubMixin._get_files_timestamps(
-        PushToHubMixin,
+    files_timestamps = _lazy_symbol("transformers.modeling_utils", "PushToHubMixin")._get_files_timestamps(
+        _lazy_symbol("transformers.modeling_utils", "PushToHubMixin"),
         save_directory,
     )
     save_pretrained_dequantized(
@@ -4008,8 +4061,8 @@ def merge_and_dequantize_lora(
     if tokenizer is not None: tokenizer.save_pretrained(save_directory = save_directory,)
 
     if push_to_hub:
-        commit = PushToHubMixin._upload_modified_files(
-            PushToHubMixin,
+        commit = _lazy_symbol("transformers.modeling_utils", "PushToHubMixin")._upload_modified_files(
+            _lazy_symbol("transformers.modeling_utils", "PushToHubMixin"),
             working_dir = save_directory,
             repo_id = repo_id,
             files_timestamps = files_timestamps,
@@ -5529,7 +5582,7 @@ def _choose_mxfp4_processing_strategy(blocks_tensor, scales_tensor):
             combined_score = calculate_combined_score(3.0, chunk_size)
 
             suitable_strategies.append({
-                'device_type': DEVICE_TYPE_TORCH,  # 'cuda' on ROCm (PyTorch alias)
+                'device_type': _device_type_torch(),  # 'cuda' on ROCm (PyTorch alias)
                 'device_id': gpu['device_id'],
                 'rows_per_chunk': chunk_size,
                 'available_memory': gpu['free'] * GPU_SAFETY_FACTOR,
@@ -5577,7 +5630,7 @@ def _choose_mxfp4_processing_strategy(blocks_tensor, scales_tensor):
 
         best = suitable_strategies[0]
 
-        if UNSLOTH_ENABLE_LOGGING:
+        if _unsloth_logging_enabled():
             logger.info(
                 f"[MXFP4] Selected {best['device_type']}:{best['device_id'] or ''} "
                 f"with {best['rows_per_chunk']:,} rows per chunk "
@@ -5603,7 +5656,7 @@ def _choose_mxfp4_processing_strategy(blocks_tensor, scales_tensor):
     # Add GPU fallbacks
     for gpu in stats['gpus']:
         fallback_options.append({
-            'device_type': DEVICE_TYPE_TORCH,  # 'cuda' on ROCm (PyTorch alias)
+            'device_type': _device_type_torch(),  # 'cuda' on ROCm (PyTorch alias)
             'device_id': gpu['device_id'],
             'available': gpu['free'] * GPU_SAFETY_FACTOR,
             'total_available': gpu['free']
@@ -5676,16 +5729,16 @@ def split_safetensor_file(filename, save_directory, max_shard_size_gb=2):
         for i, shard in enumerate(shards):
             temp_filename = f"temp_split_{temp_base}_{i:03d}.safetensors"
             temp_file_path = os.path.join(save_directory, temp_filename)
-            save_file(shard, temp_file_path, metadata={"format": "pt"})
+            _st_save_file(shard, temp_file_path, metadata={"format": "pt"})
             temp_filenames.append(temp_filename)
 
             shard_size = sum(tensor.numel() * tensor.element_size() for tensor in shard.values())
-            if UNSLOTH_ENABLE_LOGGING:
+            if _unsloth_logging_enabled():
                 logger.info(f"Created temp chunk: {temp_filename} (size: {shard_size / (1024**3):.2f} GB)")
 
         # Remove original file
         os.remove(file_path)
-        if UNSLOTH_ENABLE_LOGGING:
+        if _unsloth_logging_enabled():
             logger.info(f"Removed original file: {filename}")
 
         return temp_filenames
@@ -5704,7 +5757,7 @@ def renumber_safetensor_files(file_list, save_directory):
             new_path = os.path.join(save_directory, "model.safetensors")
             if os.path.exists(old_path):
                 os.rename(old_path, new_path)
-                if UNSLOTH_ENABLE_LOGGING:
+                if _unsloth_logging_enabled():
                     logger.info(f"Renamed {file_list[0]} -> model.safetensors")
             return ["model.safetensors"]
         return file_list
@@ -5713,7 +5766,7 @@ def renumber_safetensor_files(file_list, save_directory):
     total_files = len(file_list)
     clean_names = [f"model-{i+1:05d}-of-{total_files:05d}.safetensors" for i in range(total_files)]
 
-    if UNSLOTH_ENABLE_LOGGING:
+    if _unsloth_logging_enabled():
         logger.info("Unsloth: Renumbering safetensor files with sequential numbering...")
 
     # Create mapping of old -> new names
@@ -5729,7 +5782,7 @@ def renumber_safetensor_files(file_list, save_directory):
             temp_path = os.path.join(save_directory, f"renaming_{new_name}")
             os.rename(old_path, temp_path)
             os.rename(temp_path, new_path)
-            if UNSLOTH_ENABLE_LOGGING:
+            if _unsloth_logging_enabled():
                 logger.info(f"Renamed {old_name} -> {new_name}")
 
     return clean_names
@@ -5775,7 +5828,7 @@ def _stream_rewrite_resized_shard(src_path, dst_path, header_metadata, length_of
     # Cast resized tensors to the header dtype so bytes match the label.
     res_t = {}
     for k in resized:
-        dt = SAFETENSORS_DTYPES[header_metadata[k]["dtype"]]
+        dt = _safetensors_dtypes()[header_metadata[k]["dtype"]]
         res_t[k] = resized[k].detach().to(dt).contiguous().cpu()
 
     new_header = {}
@@ -5847,7 +5900,7 @@ def _inplace_rewrite_resized_shard(filename_original, header_metadata, resized):
     with safe_open(filename_original, framework = "pt", device = "cpu") as f:
         for key in f.keys():
             tensors[key] = resized[key] if key in resized else f.get_tensor(key)
-    save_file(tensors, filename_original, metadata = meta)
+    _st_save_file(tensors, filename_original, metadata = meta)
     tensors.clear()
 
 
@@ -5879,7 +5932,7 @@ def _stream_rewrite_resized_shard_and_replace(filename_original, temp_dir, heade
                 pass
 
         gc.collect()
-        device_empty_cache()
+        _device_empty_cache()
 
         for attempt in range(max_retries):
             try:
@@ -5903,7 +5956,7 @@ def _stream_rewrite_resized_shard_and_replace(filename_original, temp_dir, heade
                 )
                 if is_lock_error and attempt < max_retries - 1:
                     delay = base_delay * (2 ** attempt)
-                    if UNSLOTH_ENABLE_LOGGING:
+                    if _unsloth_logging_enabled():
                         logger.warning(
                             f"[Retry {attempt + 1}/{max_retries}] Windows file lock "
                             f"detected for {filename_original}: {e}. "
@@ -5955,7 +6008,7 @@ def _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key
         tensor_bytes = tensor_formatted.untyped_storage().nbytes()
 
         if tensor_bytes != expected_size:
-            if UNSLOTH_ENABLE_LOGGING:
+            if _unsloth_logging_enabled():
                 logger.warning(f"Size mismatch for {output_key}: expected {expected_size}, got {tensor_bytes}")
             return False
 
@@ -5973,7 +6026,7 @@ def _write_tensor_direct_torch(mm, header_metadata, length_of_header, output_key
         return True
 
     except Exception as e:
-        if UNSLOTH_ENABLE_LOGGING:
+        if _unsloth_logging_enabled():
             logger.info(f"Direct tensor write failed for {output_key}: {e}")
         return False
 pass
@@ -5992,3 +6045,522 @@ pass
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+# ---------------------------------------------------------------------------
+# PEFT <-> MLX LoRA adapter interop. PEFT adapters
+# (adapter_model.safetensors, lora_A/lora_B keys under a base_model.model.
+# prefix) and mlx-lm adapters (adapters.safetensors, lora_a/lora_b keys)
+# encode the same math in different layouts:
+#
+#     peft {p}.lora_A.weight [r, in]   ==  mlx {p}.lora_a [in, r], transposed
+#     peft {p}.lora_B.weight [out, r]  ==  mlx {p}.lora_b [r, out], transposed
+#     effective scale = lora_alpha / r     (rsLoRA: lora_alpha / sqrt(r))
+#
+# Conversion is rename + transpose only; dtypes are preserved exactly and a
+# round trip is bitwise-identical for the supported subset (plain linear
+# LoRA). Adapters carrying DoRA magnitudes, modules_to_save state, embedding
+# LoRA, or expert target_parameters factors are refused with a named reason
+# instead of being partially or lossily converted. Tensor IO prefers
+# mlx.core (native bfloat16) with a safetensors.torch fallback off Apple
+# hardware; the safetensors numpy backend cannot represent bf16.
+# ---------------------------------------------------------------------------
+
+import math
+import re
+
+PEFT_WEIGHTS_FILE = "adapter_model.safetensors"
+MLX_WEIGHTS_FILE = "adapters.safetensors"
+_PEFT_PREFIX = "base_model.model."
+
+# peft resolves rank_pattern / alpha_pattern keys by ordered first-match against
+# the module path, and a key may be a regex fragment; mirror peft's expression
+# exactly (end-anchored, optional dotted ancestry).
+def _resolve_pattern(patterns, module_path):
+    if not patterns:
+        return None
+    for key, value in patterns.items():
+        try:
+            if re.match(rf"(.*\.)?({key})$", module_path):
+                return value
+        except re.error:
+            # A malformed regex key cannot silently mean "no override".
+            raise ValueError(
+                f"Unsloth MLX: PEFT pattern key {key!r} is not a valid "
+                f"regular expression; fix rank_pattern/alpha_pattern in "
+                f"adapter_config.json."
+            )
+    return None
+
+
+def _tensor_backend():
+    """Return (name, load_file, save_file, transpose) for the host."""
+    try:
+        import mlx.core as mx
+
+        def _load(path):
+            return dict(mx.load(str(path)))
+
+        def _save(path, tensors):
+            mx.save_safetensors(str(path), tensors)
+
+        return "mlx", _load, _save, lambda t: t.T
+    except ImportError:
+        pass
+    try:
+        import torch  # noqa: F401
+        from safetensors.torch import load_file, save_file
+
+        def _transpose(t):
+            return t.transpose(0, 1).contiguous()
+
+        def _save(path, tensors):
+            # safetensors.torch.save_file takes (tensors, filename); normalize
+            # to the (path, tensors) order the mlx branch uses.
+            save_file(tensors, str(path))
+
+        return "torch", load_file, _save, _transpose
+    except ImportError:
+        raise ImportError(
+            "Unsloth MLX: adapter conversion needs mlx (Apple hosts) or "
+            "torch + safetensors (other hosts) for bf16-safe tensor IO; "
+            "the safetensors numpy backend cannot represent bfloat16."
+        )
+
+
+def detect_adapter_format(path):
+    """Return 'peft' or 'mlx' for an adapter directory; refuse ambiguity."""
+    has_peft = os.path.exists(os.path.join(path, PEFT_WEIGHTS_FILE))
+    has_mlx = os.path.exists(os.path.join(path, MLX_WEIGHTS_FILE))
+    if has_peft and has_mlx:
+        raise ValueError(
+            f"Unsloth MLX: {path!r} contains both {PEFT_WEIGHTS_FILE} and "
+            f"{MLX_WEIGHTS_FILE}; cannot tell which adapter is current. "
+            "Remove one of the weight files."
+        )
+    if has_peft:
+        return "peft"
+    if has_mlx:
+        return "mlx"
+    raise FileNotFoundError(
+        f"Unsloth MLX: no adapter weights ({PEFT_WEIGHTS_FILE} or "
+        f"{MLX_WEIGHTS_FILE}) found in {path!r}."
+    )
+
+
+# Config keys this converter implements or may safely ignore. Anything else set
+# to a non-empty value is refused by name so a feature is never silently dropped
+# (an aLoRA adapter would otherwise become an always-on LoRA).
+_PEFT_HANDLED_KEYS = {
+    "peft_type", "r", "lora_alpha", "use_rslora", "lora_dropout",
+    "target_modules", "base_model_name_or_path", "revision",
+    "rank_pattern", "alpha_pattern", "layers_to_transform", "layers_pattern",
+}
+_PEFT_NEUTRAL_KEYS = {
+    "task_type", "inference_mode", "init_lora_weights", "peft_version",
+    "auto_mapping", "fan_in_fan_out", "exclude_modules",
+    # EVA redistributes ranks/alphas through the supported pattern fields and
+    # leaves base weights alone; peft serializes eva_config even at defaults.
+    "eva_config",
+    # Only meaningful when use_qalora is set, which is rejected below.
+    "qalora_group_size",
+    # megatron_core is set by default; only megatron_config makes it megatron.
+    "megatron_core",
+}
+_PEFT_REJECTED_KEYS = {
+    "use_dora": "DoRA adapters are not supported on the MLX backend yet",
+    "modules_to_save": "modules_to_save (full-weight modules) is not "
+                       "supported on the MLX backend yet",
+    "target_parameters": "expert-parameter (MoE) LoRA is not supported on "
+                         "the MLX backend yet",
+    "alora_invocation_tokens": "aLoRA adapters activate conditionally; "
+                               "converting would silently make them "
+                               "always-on",
+    "trainable_token_indices": "trainable token indices are not supported "
+                               "on the MLX backend",
+    "megatron_config": "megatron-format adapters are not supported on the "
+                       "MLX backend",
+    # Replicated/reordered stacks change which base layer a path denotes, so
+    # strict binding would attach weights to the wrong layers.
+    "layer_replication": "layer_replication adapters remap base layers and "
+                         "cannot bind onto the unmodified model",
+    # QALoRA pools/reshapes A-side inputs; not plain LoRA factors.
+    "use_qalora": "QALoRA adapters are not plain LoRA and are not supported "
+                  "on the MLX backend",
+    # Adds a trainable bias to lora_B; mlx-lm LoRA layers have no such term.
+    "lora_bias": "lora_bias (trainable LoRA bias) is not supported on the "
+                 "MLX backend",
+}
+
+
+def _is_empty(value):
+    return value in (None, False, 0, 0.0, "", "none") or value == [] or value == {}
+
+
+def normalize_peft_adapter_config(cfg, adapter_dir=None):
+    """Validate a PEFT LoraConfig dict for MLX import; return a copy with
+    zoo-loader key aliases (``base_model_revision``) filled in. Raises
+    ValueError naming the first unsupported field, so an adapter is refused
+    before the expensive base-model load.
+    """
+    if str(cfg.get("peft_type", "")).upper() != "LORA":
+        raise ValueError(
+            f"Unsloth MLX: only peft_type='LORA' adapters can be imported; "
+            f"got {cfg.get('peft_type')!r}."
+        )
+    if cfg.get("bias") not in (None, "none"):
+        raise ValueError(
+            "Unsloth MLX: PEFT LoRA bias terms (bias="
+            f"{cfg.get('bias')!r}) are not supported on the MLX backend."
+        )
+    for key, reason in _PEFT_REJECTED_KEYS.items():
+        if not _is_empty(cfg.get(key)):
+            raise ValueError(
+                f"Unsloth MLX: cannot import this PEFT adapter: {reason} "
+                f"(adapter_config.json field {key!r})."
+            )
+    # PiSSA/OLoRA/CorDA subtract their decomposition from the base at init and
+    # LoftQ writes its re-quantized weight back, so their factors only reproduce
+    # the trained model on that mutated base, which this importer never applies.
+    # peft can convert them to plain LoRA at save time; require that instead of
+    # silently changing logits.
+    init_mode = cfg.get("init_lora_weights")
+    # peft matches these case-insensitively, dispatching corda by prefix.
+    init_norm = init_mode.lower() if isinstance(init_mode, str) else ""
+    if not _is_empty(cfg.get("loftq_config")) or init_norm == "loftq":
+        raise ValueError(
+            "Unsloth MLX: LoftQ-initialized adapters assume the base weight "
+            "was replaced by its re-quantized form at initialization; "
+            "re-save the adapter converted to plain LoRA before importing."
+        )
+    if (
+        init_norm.startswith("pissa")
+        or init_norm.startswith("corda")
+        or init_norm == "olora"
+    ):
+        raise ValueError(
+            f"Unsloth MLX: init_lora_weights={init_mode!r} adapters assume "
+            "a base model mutated at initialization; re-save the adapter "
+            "converted to plain LoRA (peft's "
+            "path_initial_model_for_weight_conversion) before importing."
+        )
+    known = _PEFT_HANDLED_KEYS | _PEFT_NEUTRAL_KEYS | set(_PEFT_REJECTED_KEYS)
+    known |= {"bias", "loftq_config"}
+    for key, value in cfg.items():
+        if key in known or _is_empty(value):
+            continue
+        raise ValueError(
+            f"Unsloth MLX: PEFT adapter_config.json field {key!r}="
+            f"{value!r} is not understood by the MLX importer; refusing to "
+            "import an adapter whose semantics would be dropped."
+        )
+    normalized = dict(cfg)
+    if cfg.get("revision") and not normalized.get("base_model_revision"):
+        normalized["base_model_revision"] = cfg["revision"]
+    normalized["_unsloth_peft_import"] = True
+    if adapter_dir is not None:
+        index_file = os.path.join(adapter_dir, "adapter_model.safetensors.index.json")
+        if os.path.exists(index_file):
+            raise ValueError(
+                "Unsloth MLX: sharded PEFT adapters "
+                "(adapter_model.safetensors.index.json) are not supported."
+            )
+    return normalized
+
+
+def _effective_scale(cfg, module_path, rank):
+    alpha = _resolve_pattern(cfg.get("alpha_pattern"), module_path)
+    if alpha is None:
+        alpha = cfg.get("lora_alpha", rank)
+    denom = math.sqrt(rank) if cfg.get("use_rslora") else rank
+    return float(alpha) / float(denom)
+
+
+def group_peft_lora_pairs(tensors):
+    """Split raw PEFT tensors into {mlx_module_path: {'A':..., 'B':...}}.
+
+    Returns (pairs, rejected) where ``rejected`` maps keys to the reason they
+    cannot be treated as plain linear LoRA. The wrapper prefix is stripped
+    exactly once; keys without it are rejected rather than guessed at.
+    """
+    pairs = {}
+    rejected = {}
+    for key, tensor in tensors.items():
+        if ".lora_embedding_" in key:
+            rejected[key] = "embedding LoRA is not supported on MLX yet"
+            continue
+        if ".lora_magnitude_vector" in key:
+            rejected[key] = "DoRA magnitudes are not supported on MLX yet"
+            continue
+        m = re.match(
+            rf"^{re.escape(_PEFT_PREFIX)}(.+)\.lora_(A|B)\.weight$", key
+        )
+        if m is None:
+            rejected[key] = "not a recognized PEFT linear LoRA key"
+            continue
+        path, which = m.group(1), m.group(2)
+        pairs.setdefault(path, {})[which] = tensor
+    for path, pair in pairs.items():
+        if "A" not in pair or "B" not in pair:
+            rejected[f"{_PEFT_PREFIX}{path}.lora_*"] = (
+                "incomplete lora_A/lora_B pair"
+            )
+    pairs = {p: v for p, v in pairs.items() if "A" in v and "B" in v}
+    return pairs, rejected
+
+
+def _raise_rejected(rejected, where):
+    preview = "; ".join(f"{k}: {v}" for k, v in list(rejected.items())[:5])
+    if len(rejected) > 5:
+        preview += f"; ... (+{len(rejected) - 5} more)"
+    raise ValueError(
+        f"Unsloth MLX: {where} contains adapter tensors that cannot be "
+        f"converted as plain linear LoRA ({preview}). No partial conversion "
+        "is performed."
+    )
+
+
+def _require_fresh_dir(dst):
+    # mkdir is the lock: exactly one caller can create the directory, so
+    # racing conversions cannot interleave into one destination. Accepting
+    # a pre-existing empty directory would reopen that race (created-but-
+    # not-yet-written looks identical to empty), so it is refused too.
+    try:
+        os.makedirs(dst)
+    except FileExistsError:
+        raise ValueError(
+            f"Unsloth MLX: destination {dst!r} already exists. Adapter "
+            "conversion creates its own fresh directory so two formats can "
+            "never mix in one place; pass a path that does not exist yet."
+        )
+
+
+def _num_hidden_layers(base_config):
+    for holder in (base_config, base_config.get("text_config") or {}):
+        for key in ("num_hidden_layers", "num_layers"):
+            if isinstance(holder, dict) and holder.get(key) is not None:
+                return int(holder[key])
+    raise ValueError(
+        "Unsloth MLX: base config lacks num_hidden_layers (top-level or "
+        "text_config); cannot synthesize mlx-lm adapter metadata."
+    )
+
+
+def convert_peft_dir_to_mlx(src, dst, base_config):
+    """Convert a PEFT LoRA directory to an mlx-lm adapter directory."""
+    # Raises on a both-formats directory; the source must be unambiguous.
+    detect_adapter_format(src)
+    backend, load_file, save_file, transpose = _tensor_backend()
+    with open(os.path.join(src, "adapter_config.json"), "r") as f:
+        cfg = normalize_peft_adapter_config(json.load(f), adapter_dir=src)
+    tensors = load_file(os.path.join(src, PEFT_WEIGHTS_FILE))
+    pairs, rejected = group_peft_lora_pairs(tensors)
+    if rejected:
+        _raise_rejected(rejected, f"{src!r}")
+    if not pairs:
+        raise ValueError(f"Unsloth MLX: {src!r} has no linear LoRA tensor pairs.")
+
+    out = {}
+    ranks, scales = {}, {}
+    for path in sorted(pairs):
+        a, b = pairs[path]["A"], pairs[path]["B"]
+        # 2-D only: higher-rank factors are not linear LoRA, and the two IO
+        # backends transpose them differently.
+        if getattr(a, "ndim", 0) != 2 or getattr(b, "ndim", 0) != 2:
+            raise ValueError(
+                f"Unsloth MLX: {path} carries non-2-D LoRA factors "
+                f"(A ndim={getattr(a, 'ndim', '?')}, "
+                f"B ndim={getattr(b, 'ndim', '?')}); not plain linear LoRA."
+            )
+        rank = int(a.shape[0])
+        if int(b.shape[1]) != rank:
+            raise ValueError(
+                f"Unsloth MLX: {path} has lora_A rank {rank} but lora_B "
+                f"rank {int(b.shape[1])}; the adapter file is inconsistent."
+            )
+        out[f"{path}.lora_a"] = transpose(a)
+        out[f"{path}.lora_b"] = transpose(b)
+        ranks[path] = rank
+        scales[path] = _effective_scale(cfg, path, rank)
+    uniform_rank = len(set(ranks.values())) == 1
+    uniform_scale = len(set(scales.values())) == 1
+    any_path = next(iter(sorted(ranks)))
+    mlx_cfg = {
+        "fine_tune_type": "lora",
+        "peft_type": "LORA",
+        "num_layers": _num_hidden_layers(base_config),
+        "base_model_name_or_path": cfg.get("base_model_name_or_path", ""),
+        "lora_parameters": {
+            "rank": ranks[any_path],
+            "scale": scales[any_path],
+            "dropout": float(cfg.get("lora_dropout") or 0.0),
+            # Pin the exact module set: without "keys", mlx-lm wraps every
+            # supported projection in the selected layers, growing the topology
+            # with zero-initialized extras.
+            "keys": sorted(ranks),
+        },
+        "unsloth_mlx_lora_module_paths": sorted(ranks),
+    }
+    if cfg.get("base_model_revision"):
+        mlx_cfg["base_model_revision"] = cfg["base_model_revision"]
+    if not (uniform_rank and uniform_scale):
+        # Stock mlx-lm rebuilds from one global rank/scale; record the
+        # per-module truth and flag that reloads need the unsloth loader.
+        mlx_cfg["unsloth_mlx_lora_module_ranks"] = ranks
+        mlx_cfg["unsloth_mlx_lora_module_scales"] = scales
+        mlx_cfg["unsloth_mlx_requires_unsloth_loader"] = True
+        print(
+            "Unsloth: this adapter uses per-module ranks/alphas; the MLX "
+            "copy needs Unsloth to load (stock mlx-lm assumes one global "
+            "rank/scale)."
+        )
+    # Claim the destination only after everything above validated, so a
+    # refused conversion never leaves a half-written directory behind.
+    _require_fresh_dir(dst)
+    save_file(os.path.join(dst, MLX_WEIGHTS_FILE), out)
+    with open(os.path.join(dst, "adapter_config.json"), "w") as f:
+        json.dump(mlx_cfg, f, indent=2, sort_keys=True)
+    return dst
+
+
+def convert_mlx_dir_to_peft(src, dst, module_types=None):
+    """Convert an mlx-lm adapter directory to a PEFT LoRA directory.
+
+    ``module_types`` optionally maps module paths to ``"linear"`` /
+    ``"embedding"``. Supplying an entry is a caller assertion of BOTH facts
+    a weights file cannot establish: the module's type on the live base
+    model, AND that the same dotted path exists in the Hugging Face module
+    tree (mlx-lm renames some roots — e.g. GPT-2's ``model.h.*`` vs HF's
+    ``transformer.h.*`` — and a mis-asserted path yields an adapter peft
+    cannot bind). Without the map, only paths inside a ``layers.N`` stack —
+    where mlx-lm mirrors the HF tree and every LoRA target is a Linear —
+    are converted; anything else is refused, and that refusal points at the
+    MLX-format fallback rather than at this map, which only a caller able to
+    make the assertions above can safely supply.
+    """
+    for _path, _kind in (module_types or {}).items():
+        if _kind not in ("linear", "embedding"):
+            raise ValueError(
+                f"Unsloth MLX: module_types[{_path!r}]={_kind!r}; expected "
+                "'linear' or 'embedding'."
+            )
+    # Raises on a both-formats directory; the source must be unambiguous.
+    detect_adapter_format(src)
+    backend, load_file, save_file, transpose = _tensor_backend()
+    with open(os.path.join(src, "adapter_config.json"), "r") as f:
+        cfg = json.load(f)
+    if str(cfg.get("fine_tune_type", "lora")).lower() != "lora":
+        raise ValueError(
+            f"Unsloth MLX: fine_tune_type={cfg.get('fine_tune_type')!r} "
+            "adapters cannot be exported to PEFT format yet; only plain "
+            "LoRA is supported."
+        )
+    tensors = load_file(os.path.join(src, MLX_WEIGHTS_FILE))
+    pairs = {}
+    rejected = {}
+    for key, tensor in tensors.items():
+        m = re.match(r"^(.+)\.lora_(a|b)$", key)
+        if m is None:
+            rejected[key] = (
+                "not a plain LoRA tensor; DoRA/full-weight/embedding state "
+                "cannot be exported to PEFT format yet"
+            )
+            continue
+        # Embedding LoRA shares the lora_a/lora_b key shape but PEFT stores it
+        # as lora_embedding_A/B, and a weights file alone cannot tell an
+        # Embedding from a Linear. An explicit module_types entry wins; else
+        # only the root-anchored stack below converts, where every LoRA target
+        # is a Linear, and anything else is refused rather than guessed.
+        path = m.group(1)
+        declared = (module_types or {}).get(path)
+        if declared == "embedding":
+            rejected[key] = (
+                "embedding LoRA cannot be exported to PEFT format yet"
+            )
+            continue
+        if declared is None and re.match(
+            # Root-anchored `model.layers.N.` only: that is the layout mlx-lm
+            # mirrors from HF, so emitted paths bind in peft. GPT-2-style stacks
+            # rename roots (`model.h.*` vs HF `transformer.h.*`) and VLM
+            # wrappers reorder them (`language_model.model.layers.*` vs HF
+            # `model.language_model.layers.*`), so any unanchored heuristic
+            # would emit adapters peft cannot load.
+            r"^model\.layers\.\d+\.", path
+        ) is None:
+            rejected[key] = (
+                "outside a Hugging-Face-mirroring transformer stack, so its "
+                "Hugging Face path cannot be confirmed and PEFT export could "
+                "emit an adapter that binds to nothing — save this adapter "
+                "in MLX format instead"
+            )
+            continue
+        pairs.setdefault(path, {})[m.group(2)] = tensor
+    for path, pair in list(pairs.items()):
+        if "a" not in pair or "b" not in pair:
+            rejected[f"{path}.lora_*"] = "incomplete lora_a/lora_b pair"
+            pairs.pop(path)
+    if rejected:
+        _raise_rejected(rejected, f"{src!r}")
+    if not pairs:
+        raise ValueError(f"Unsloth MLX: {src!r} has no LoRA tensor pairs.")
+
+    scale_map = cfg.get("unsloth_mlx_lora_module_scales") or {}
+    lora_params = cfg.get("lora_parameters") or {}
+    global_scale = float(lora_params.get("scale", cfg.get("scale", 1.0)))
+    dropout = float(lora_params.get("dropout", cfg.get("dropout", 0.0)) or 0.0)
+
+    out = {}
+    ranks, alphas = {}, {}
+    for path in sorted(pairs):
+        a, b = pairs[path]["a"], pairs[path]["b"]
+        if getattr(a, "ndim", 0) != 2 or getattr(b, "ndim", 0) != 2:
+            raise ValueError(
+                f"Unsloth MLX: {path} carries non-2-D LoRA factors "
+                f"(lora_a ndim={getattr(a, 'ndim', '?')}, "
+                f"lora_b ndim={getattr(b, 'ndim', '?')}); switch/MoE LoRA "
+                "cannot be exported to PEFT format yet."
+            )
+        rank = int(a.shape[1])
+        if int(b.shape[0]) != rank:
+            raise ValueError(
+                f"Unsloth MLX: {path} has lora_a rank {rank} but lora_b "
+                f"rank {int(b.shape[0])}; the adapter file is inconsistent."
+            )
+        out[f"{_PEFT_PREFIX}{path}.lora_A.weight"] = transpose(a)
+        out[f"{_PEFT_PREFIX}{path}.lora_B.weight"] = transpose(b)
+        ranks[path] = rank
+        scale = float(scale_map.get(path, global_scale))
+        alphas[path] = scale * rank
+    ref_path = next(iter(sorted(ranks)))
+    peft_cfg = {
+        "peft_type": "LORA",
+        "task_type": "CAUSAL_LM",
+        "r": ranks[ref_path],
+        "lora_alpha": alphas[ref_path],
+        "lora_dropout": dropout,
+        "bias": "none",
+        "use_rslora": False,
+        # Full module paths, matched exactly by peft's list semantics. Leaf
+        # names would suffix-match EVERY layer's projection, so a layer-subset
+        # adapter would grow zero-initialized extras and train a different
+        # topology.
+        "target_modules": sorted(ranks),
+        "base_model_name_or_path": cfg.get("base_model_name_or_path", ""),
+    }
+    revision = cfg.get("base_model_revision") or cfg.get("base_model_commit_hash")
+    if revision:
+        peft_cfg["revision"] = revision
+    if len(set(ranks.values())) > 1:
+        peft_cfg["rank_pattern"] = {
+            re.escape(p): r for p, r in ranks.items() if r != peft_cfg["r"]
+        }
+    if len(set(alphas.values())) > 1:
+        peft_cfg["alpha_pattern"] = {
+            re.escape(p): a for p, a in alphas.items()
+            if a != peft_cfg["lora_alpha"]
+        }
+    _require_fresh_dir(dst)
+    save_file(os.path.join(dst, PEFT_WEIGHTS_FILE), out)
+    with open(os.path.join(dst, "adapter_config.json"), "w") as f:
+        json.dump(peft_cfg, f, indent=2, sort_keys=True)
+    return dst

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -6868,7 +6868,7 @@ def _load_base_weight(source, key):
 
 
 def convert_mlx_dir_to_peft(src, dst, module_types=None,
-                            base_weights_source=None):
+                            base_weights_source=None, strip_prefix=None):
     """Convert an mlx-lm adapter directory to a PEFT LoRA directory.
 
     ``module_types`` optionally maps module paths to ``"linear"`` /
@@ -6905,6 +6905,8 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
             f"Unsloth MLX: fine_tune_type={cfg.get('fine_tune_type')!r} "
             "adapters cannot be exported to PEFT format."
         )
+    if strip_prefix is None:
+        strip_prefix = cfg.get("unsloth_mlx_tree_prefix") or ""
     fs_origins = dict(cfg.get("full_state_modules") or {})
     # PEFT expresses trainable module state ONLY as modules_to_save, and no
     # module can be both a LoRA target and a modules_to_save entry, so a
@@ -6933,6 +6935,39 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
             "'embedding_auto'."
         )
     tensors = load_file(os.path.join(src, MLX_WEIGHTS_FILE))
+    if strip_prefix:
+        # An mlx-vlm tree nests the text tower one level deeper than the HF
+        # model it mirrors; normalize every keyed map to HF-native paths so the
+        # adapter binds in peft. A key without the nesting is left alone for the
+        # layout gate below rather than silently renamed.
+        def _unnest(key):
+            return key[len(strip_prefix):] if key.startswith(strip_prefix) else key
+
+        def _unnest_map(mapping, what):
+            out = {}
+            for key, value in mapping.items():
+                unnested = _unnest(key)
+                if unnested in out:
+                    raise ValueError(
+                        f"Unsloth MLX: unnesting {strip_prefix!r} collapses "
+                        f"{what} {key!r} onto {unnested!r}; the artifact "
+                        "carries entries for more than one tower, which a "
+                        "single PEFT adapter cannot represent."
+                    )
+                out[unnested] = value
+            return out
+
+        tensors = _unnest_map(tensors, "tensor")
+        fs_origins = _unnest_map(fs_origins, "full-state entry")
+        for _key in (
+            "unsloth_mlx_lora_module_scales", "unsloth_mlx_lora_module_ranks",
+        ):
+            if isinstance(cfg.get(_key), dict):
+                cfg[_key] = _unnest_map(cfg[_key], _key)
+        if isinstance(cfg.get("full_state_trainable"), list):
+            cfg["full_state_trainable"] = [
+                _unnest(k) for k in cfg["full_state_trainable"]
+            ]
     pairs = {}
     rejected = {}
     full_state_out = {}

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -6062,14 +6062,16 @@ pass
 #     peft {p}.lora_B.weight [out, r]  ==  mlx {p}.lora_b [r, out], transposed
 #     effective scale = lora_alpha / r     (rsLoRA: lora_alpha / sqrt(r))
 #
-# Conversion is rename + transpose only; dtypes are preserved exactly and a
-# round trip is bitwise-identical for the supported subset (plain linear
-# LoRA). Linear DoRA converts (magnitude <-> m, numerically verified);
-# modules_to_save state, embedding LoRA, and expert target_parameters
-# factors are refused with a named reason instead of being partially or
-# lossily converted. Tensor IO prefers
-# mlx.core (native bfloat16) with a safetensors.torch fallback off Apple
-# hardware; the safetensors numpy backend cannot represent bf16.
+# Conversion is rename + transpose only, so dtypes are exact and a round trip
+# is bitwise-identical for the supported subset: plain linear LoRA; linear
+# DoRA, whose magnitude maps to m with numeric verification; embedding LoRA
+# via lora_embedding_A/B; and full-module state (modules_to_save snapshots and
+# peft's auto-saved embeddings) tracked through origin-tagged
+# full_state_modules maps. Expert target_parameters factors, embedding DoRA,
+# and embedding adapters on tied-output models are refused with a named reason
+# rather than lossily converted. Tensor IO prefers mlx.core (native bfloat16),
+# falling back to safetensors.torch off Apple hardware — the numpy backend
+# cannot represent bf16.
 # ---------------------------------------------------------------------------
 
 import math
@@ -6163,6 +6165,9 @@ _PEFT_HANDLED_KEYS = {
     "rank_pattern", "alpha_pattern", "layers_to_transform", "layers_pattern",
     # Linear DoRA converts (magnitude <-> m); embedding DoRA refuses later.
     "use_dora",
+    # Full-weight snapshots convert; peft strips the modules_to_save infix at
+    # save, so detection is config-driven.
+    "modules_to_save",
 }
 # peft applies DoRA dropout inside the correction term, mlx-lm scales
 # base-plus-dropped-update together: continued training would diverge.
@@ -6185,8 +6190,6 @@ _PEFT_NEUTRAL_KEYS = {
     "megatron_core",
 }
 _PEFT_REJECTED_KEYS = {
-    "modules_to_save": "modules_to_save (full-weight modules) is not "
-                       "supported on the MLX backend yet",
     "target_parameters": "expert-parameter (MoE) LoRA is not supported on "
                          "the MLX backend yet",
     "alora_invocation_tokens": "aLoRA adapters activate conditionally; "
@@ -6293,18 +6296,47 @@ def _effective_scale(cfg, module_path, rank):
     return float(alpha) / float(denom)
 
 
-def group_peft_lora_pairs(tensors):
-    """Split raw PEFT tensors into {mlx_module_path: {'A':..., 'B':...}}.
+def group_peft_lora_pairs(tensors, cfg=None):
+    """Split raw PEFT tensors into (pairs, full_state, rejected).
 
-    Returns (pairs, rejected) where ``rejected`` maps keys to the reason they
-    cannot be treated as plain linear LoRA. The wrapper prefix is stripped
-    exactly once; keys without it are rejected rather than guessed at.
+    ``pairs`` maps module paths to {'A','B'[,'M']} for linear LoRA/DoRA and
+    {'EA','EB'} for embedding LoRA. ``full_state`` maps module paths to
+    {tensor_name: tensor} for modules_to_save snapshots (peft strips the infix
+    at save, so detection is config-driven) and auto-saved embedding weights.
+    The wrapper prefix is stripped exactly once; keys without it are rejected.
     """
+    cfg = cfg or {}
+    m2s_paths = set(cfg.get("modules_to_save") or [])
+
+    def _m2s_hit(cand):
+        # peft selects with a RAW key.endswith(name) — no dot boundary, so
+        # ["head"] wraps lm_head. A composite module's snapshot arrives as
+        # SUBMODULE keys (classifier.0.weight), so a name may also suffix-match
+        # a dotted ancestor of the key path.
+        for m2s in m2s_paths:
+            if cand.endswith(m2s):
+                return m2s
+            for j, ch in enumerate(cand):
+                if ch == "." and cand[:j].endswith(m2s):
+                    return m2s
+        return None
+
+    def _tensors_equal(a, b):
+        if tuple(getattr(a, "shape", ())) != tuple(getattr(b, "shape", ())):
+            return False
+        if getattr(a, "dtype", None) != getattr(b, "dtype", None):
+            return False
+        return bool((a == b).all())
+
     pairs = {}
+    full_state = {}
     rejected = {}
     for key, tensor in tensors.items():
-        if ".lora_embedding_" in key:
-            rejected[key] = "embedding LoRA is not supported on MLX yet"
+        emb = re.match(
+            rf"^{re.escape(_PEFT_PREFIX)}(.+)\.lora_embedding_(A|B)$", key
+        )
+        if emb is not None:
+            pairs.setdefault(emb.group(1), {})["E" + emb.group(2)] = tensor
             continue
         mag = re.match(
             rf"^{re.escape(_PEFT_PREFIX)}(.+)\.lora_magnitude_vector(?:\.weight)?$",
@@ -6316,27 +6348,162 @@ def group_peft_lora_pairs(tensors):
         m = re.match(
             rf"^{re.escape(_PEFT_PREFIX)}(.+)\.lora_(A|B)\.weight$", key
         )
-        if m is None:
-            rejected[key] = "not a recognized PEFT linear LoRA key"
+        if m is not None:
+            pairs.setdefault(m.group(1), {})[m.group(2)] = tensor
             continue
-        path, which = m.group(1), m.group(2)
-        pairs.setdefault(path, {})[which] = tensor
+        fs = re.match(
+            rf"^{re.escape(_PEFT_PREFIX)}(.+)\.(weight|bias)$", key
+        )
+        if fs is not None:
+            fs_path, tname = fs.group(1), fs.group(2)
+            if fs_path.endswith(".base_layer"):
+                # peft saves it under the wrapper's inner path; normalize to
+                # the module path the MLX tree uses.
+                fs_path = fs_path[: -len(".base_layer")]
+                full_state.setdefault(fs_path, {})[tname] = tensor
+                full_state[fs_path]["__origin__"] = "embedding_auto"
+                continue
+            # peft's embedding auto-save copies raw wrapper internals:
+            # `{p}.modules_to_save[.name].{t}` duplicates the snapshot and
+            # `{p}.original_module[.name].{t}` is the pristine base. Fold the
+            # former, drop the latter — before the general modules_to_save
+            # match, which would adopt these as real submodules. A user module
+            # genuinely named like a wrapper internal is misread; genuine
+            # wrapper keys are common and such names are not.
+            for _marker in (".modules_to_save", ".original_module"):
+                _idx = fs_path.find(_marker)
+                if _idx > 0 and _m2s_hit(fs_path[:_idx]) is not None:
+                    _rem = fs_path[_idx + len(_marker):].lstrip(".")
+                    if _rem and "." in _rem:
+                        # Cannot attribute a composite child to one snapshot
+                        # tensor; surface it rather than fold it wrongly.
+                        rejected[key] = (
+                            "wrapper-internal duplicate of a composite "
+                            "modules_to_save entry cannot be attributed"
+                        )
+                        fs_path = None
+                        break
+                    _base_path = fs_path[:_idx]
+                    if _marker == ".modules_to_save":
+                        # The duplicate counts as a snapshot; the pristine
+                        # copy does not — alone it means state was lost.
+                        _slot = full_state.setdefault(_base_path, {})
+                        if tname in _slot and not _tensors_equal(
+                            _slot[tname], tensor
+                        ):
+                            rejected[key] = (
+                                "disagrees with the module's canonical "
+                                "snapshot tensor; the adapter file is "
+                                "inconsistent"
+                            )
+                        else:
+                            _slot.setdefault(tname, tensor)
+                            _slot["__origin__"] = "modules_to_save"
+                    fs_path = None
+                    break
+            if fs_path is None:
+                continue
+            if _m2s_hit(fs_path) is not None:
+                _slot = full_state.setdefault(fs_path, {})
+                if tname in _slot and not _tensors_equal(_slot[tname], tensor):
+                    rejected[key] = (
+                        "disagrees with the module's duplicate snapshot "
+                        "tensor; the adapter file is inconsistent"
+                    )
+                    continue
+                _slot[tname] = tensor
+                _slot["__origin__"] = "modules_to_save"
+                continue
+            leaf = fs_path.rsplit(".", 1)[-1]
+            if leaf in _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES:
+                # Auto-saved embedding/head state across mlx-lm spellings;
+                # biased heads (e.g. Phi) include their bias.
+                full_state.setdefault(fs_path, {})[tname] = tensor
+                full_state[fs_path]["__origin__"] = "embedding_auto"
+                continue
+        rejected[key] = "not a recognized PEFT adapter key"
+        continue
     has_mag = {p for p, v in pairs.items() if "M" in v}
     for path, pair in pairs.items():
+        if ("EA" in pair) != ("EB" in pair):
+            rejected[f"{_PEFT_PREFIX}{path}.lora_embedding_*"] = (
+                "incomplete lora_embedding_A/B pair"
+            )
+        if "EA" in pair and "M" in pair:
+            rejected[f"{_PEFT_PREFIX}{path}.lora_magnitude_vector"] = (
+                "embedding DoRA decompositions are incompatible between "
+                "peft and mlx-lm"
+            )
+        if "EA" in pair:
+            continue
         if "A" not in pair or "B" not in pair:
             rejected[f"{_PEFT_PREFIX}{path}.lora_*"] = (
                 "incomplete lora_A/lora_B pair"
             )
+    # use_dora is global, so an embedding target under it is embedding DoRA
+    # (incompatible decompositions) or a truncated file. Either way, refuse.
+    if cfg.get("use_dora"):
+        for _p, _v in pairs.items():
+            if "EA" in _v:
+                rejected[f"{_PEFT_PREFIX}{_p}.lora_embedding_*"] = (
+                    "embedding adapters under use_dora have no compatible "
+                    "peft/mlx-lm decomposition (or the magnitude vector "
+                    "is missing from the file)"
+                )
     # use_dora is global: a partial magnitude set means file and config
     # disagree about what the adapter is.
-    if has_mag and len(has_mag) != len(pairs):
+    _linear_pairs = {p for p, v in pairs.items() if "A" in v}
+    if has_mag and has_mag != _linear_pairs:
         rejected[f"{_PEFT_PREFIX}<mixed>.lora_magnitude_vector"] = (
             "magnitudes present on only some modules; peft DoRA is all-or-"
             "nothing"
         )
         pairs = {}
-    pairs = {p: v for p, v in pairs.items() if "A" in v and "B" in v}
-    return pairs, rejected
+    for _p, _v in pairs.items():
+        if ("A" in _v or "B" in _v) and ("EA" in _v or "EB" in _v):
+            rejected[f"{_PEFT_PREFIX}{_p}.lora_*"] = (
+                "carries both linear (lora_A/B) and embedding "
+                "(lora_embedding_A/B) factors for one module; the artifact "
+                "is inconsistent"
+            )
+        _bad = sorted(
+            k for k in ("A", "B", "EA", "EB", "M")
+            if k in _v and not _is_float_dtype(_v[k])
+        )
+        if _bad:
+            rejected[f"{_PEFT_PREFIX}{_p}.lora_*"] = (
+                f"non-floating adapter factor dtype(s) "
+                f"({', '.join(str(_v[k].dtype) for k in _bad)}); LoRA "
+                "factors must be floating point"
+            )
+    pairs = {
+        p: v for p, v in pairs.items()
+        if ("A" in v and "B" in v) or ("EA" in v and "EB" in v)
+    }
+    # An entry with no tensors would silently downgrade to plain LoRA, dropping
+    # a trained replacement. Credit every declaration a snapshot satisfies —
+    # overlapping names like ["head", "lm_head"] select the same module.
+    _m2s_snapshot_paths = [
+        p for p, v in full_state.items()
+        if v.get("__origin__") == "modules_to_save"
+    ]
+
+    def _name_credited(name):
+        for cand in _m2s_snapshot_paths:
+            if cand.endswith(name):
+                return True
+            for j, ch in enumerate(cand):
+                if ch == "." and cand[:j].endswith(name):
+                    return True
+        return False
+
+    for _name in sorted(m2s_paths):
+        if not _name_credited(_name):
+            rejected[f"modules_to_save:{_name}"] = (
+                "adapter_config lists this module under modules_to_save "
+                "but the weight file carries no tensors for it"
+            )
+    return pairs, full_state, rejected
 
 
 def _raise_rejected(rejected, where):
@@ -6380,15 +6547,141 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
     with open(os.path.join(src, "adapter_config.json"), "r") as f:
         cfg = normalize_peft_adapter_config(json.load(f), adapter_dir=src)
     tensors = load_file(os.path.join(src, PEFT_WEIGHTS_FILE))
-    pairs, rejected = group_peft_lora_pairs(tensors)
+    pairs, full_state, rejected = group_peft_lora_pairs(tensors, cfg)
     if rejected:
         _raise_rejected(rejected, f"{src!r}")
     if not pairs:
-        raise ValueError(f"Unsloth MLX: {src!r} has no linear LoRA tensor pairs.")
+        raise ValueError(f"Unsloth MLX: {src!r} has no LoRA tensor pairs.")
 
     out = {}
     ranks, scales = {}, {}
-    for path in sorted(pairs):
+    fs_origins = {}
+    emb_paths = {p for p, v in pairs.items() if "EA" in v}
+    if emb_paths and _config_ties_word_embeddings(base_config):
+        # Routing cannot be verified from configs alone and a wrongly-admitted
+        # adapter silently changes logits, so a true flag refuses even where the
+        # forward ignores it.
+        raise ValueError(
+            f"Unsloth MLX: {sorted(emb_paths)} carry embedding LoRA but the "
+            "base model ties word embeddings; mlx-lm applies the update to "
+            "the tied output projection while peft applies it to input "
+            "lookup only, so no faithful conversion exists."
+        )
+    if emb_paths and float(cfg.get("lora_dropout") or 0.0) > 0:
+        raise ValueError(
+            f"Unsloth MLX: {sorted(emb_paths)} carry embedding LoRA with "
+            "nonzero lora_dropout; peft applies no dropout on embedding "
+            "adapters while mlx-lm does, so training behavior cannot be "
+            "preserved. Set lora_dropout=0 to convert."
+        )
+    _base_ties = _config_ties_word_embeddings(base_config)
+    if _base_ties:
+        _vocab = None
+        for _scope in ((base_config or {}).get("text_config") or {},
+                       base_config or {}):
+            if isinstance(_scope, dict) and _scope.get("vocab_size"):
+                _vocab = int(_scope["vocab_size"])
+                break
+
+        def _looks_like_embedding(p, v):
+            w = v.get("weight")
+            if (
+                _vocab is not None
+                and w is not None
+                and getattr(w, "ndim", 0) == 2
+                and int(w.shape[0]) == _vocab
+            ):
+                return True
+            return p.rsplit(".", 1)[-1] in (
+                _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES
+            )
+
+        _m2s_emb = sorted(
+            p for p, v in full_state.items()
+            if v.get("__origin__") == "modules_to_save"
+            and _looks_like_embedding(p, v)
+        )
+        if _m2s_emb:
+            raise ValueError(
+                f"Unsloth MLX: {_m2s_emb} are modules_to_save snapshots of "
+                "a tied embedding or output head; peft trains an untied "
+                "copy while the tied MLX embedding both looks up inputs "
+                "and projects output logits, so no faithful conversion "
+                "exists."
+            )
+    for path, entries in sorted(full_state.items()):
+        if (
+            _base_ties
+            and entries["__origin__"] == "embedding_auto"
+            and _leaf_in(path, _OUTPUT_HEAD_LEAF_NAMES)
+        ):
+            # On a tied base the auto-saved head IS the embedding weight, so
+            # verify it against the embedding snapshot and fold; emitting head
+            # state would restore a duplicate the tree may not even carry.
+            _emb_matches = [
+                v for p, v in full_state.items()
+                if _leaf_in(p, _EMBEDDING_LEAF_NAMES)
+            ]
+            if len(_emb_matches) > 1:
+                raise ValueError(
+                    f"Unsloth MLX: {path} is a tied output-head snapshot "
+                    "but the artifact carries multiple embed_tokens "
+                    "snapshots; the duplicate cannot be attributed."
+                )
+            _emb_entries = _emb_matches[0] if _emb_matches else None
+            _ew = (_emb_entries or {}).get("weight")
+            _lw = entries.get("weight")
+            _extra = sorted(set(entries) - {"__origin__", "weight"})
+            if (
+                _ew is None
+                or _lw is None
+                or _extra
+                or tuple(_ew.shape) != tuple(_lw.shape)
+                or _ew.dtype != _lw.dtype
+                or not bool((_ew == _lw).all())
+            ):
+                raise ValueError(
+                    f"Unsloth MLX: {path} is a tied model's output-head "
+                    "snapshot but does not exactly duplicate the tied "
+                    "embedding snapshot"
+                    + (f" (extra tensors {_extra})" if _extra else "")
+                    + "; a tied MLX model cannot hold an independent "
+                    "lm_head."
+                )
+            continue
+        fs_origins[path] = entries["__origin__"]
+        # A reload wraps LoRA-paired modules, so base tensors live under the
+        # wrapper's inner module.
+        if path in pairs:
+            _kp = f"{path}.embedding" if "EA" in pairs[path] else f"{path}.linear"
+        else:
+            _kp = path
+        for tname, tensor in entries.items():
+            if tname == "__origin__":
+                continue
+            if not _is_float_dtype(tensor):
+                raise ValueError(
+                    f"Unsloth MLX: {path}.{tname} holds non-floating "
+                    f"({getattr(tensor, 'dtype', '?')}) full-module state; "
+                    "the artifact cannot restore as module state."
+                )
+            out[f"{_kp}.{tname}"] = tensor
+    for path in sorted(emb_paths):
+        ea, eb = pairs[path]["EA"], pairs[path]["EB"]
+        if getattr(ea, "ndim", 0) != 2 or getattr(eb, "ndim", 0) != 2:
+            raise ValueError(
+                f"Unsloth MLX: {path} embedding LoRA factors are not 2-D."
+            )
+        rank = int(ea.shape[0])
+        if int(eb.shape[1]) != rank:
+            raise ValueError(
+                f"Unsloth MLX: {path} embedding LoRA ranks disagree."
+            )
+        out[f"{path}.lora_a"] = transpose(ea)
+        out[f"{path}.lora_b"] = transpose(eb)
+        ranks[path] = rank
+        scales[path] = _effective_scale(cfg, path, rank)
+    for path in sorted(set(pairs) - emb_paths):
         a, b = pairs[path]["A"], pairs[path]["B"]
         # 2-D only: higher-rank factors are not linear LoRA, and the two IO
         # backends transpose them differently.
@@ -6449,6 +6742,11 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
     }
     if cfg.get("base_model_revision"):
         mlx_cfg["base_model_revision"] = cfg["base_model_revision"]
+    # Converted artifacts carry peft-parity guarantees native ones do not;
+    # reload validation keys off this stamp.
+    mlx_cfg["unsloth_peft_converted"] = True
+    if fs_origins:
+        mlx_cfg["full_state_modules"] = fs_origins
     if not (uniform_rank and uniform_scale):
         # Stock mlx-lm rebuilds from one global rank/scale; record the
         # per-module truth and flag that reloads need the unsloth loader.
@@ -6501,20 +6799,94 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
     return dst
 
 
-def convert_mlx_dir_to_peft(src, dst, module_types=None):
+def _is_float_dtype(tensor):
+    """Full-module state must be float; packed or boolean tensors cannot restore."""
+    return "float" in str(getattr(tensor, "dtype", "")).lower()
+
+
+# Embedding/head module spellings across mlx-lm text models, used when a
+# tensor-shape test cannot decide.
+_EMBEDDING_LEAF_NAMES = (
+    "embed_tokens", "tok_embeddings", "token_embeddings", "wte",
+    "embed_in", "word_embeddings", "embeddings", "embedding",
+)
+_OUTPUT_HEAD_LEAF_NAMES = ("lm_head", "output", "embed_out")
+
+
+def _leaf_in(path, names):
+    return path.rsplit(".", 1)[-1] in names
+
+
+def _config_ties_word_embeddings(config):
+    """True when a config ties word embeddings. A nested text config governs
+    when it carries the key (embedding adapters live in the language tower, so
+    an outer multimodal false must not shadow it). An ABSENT key counts as
+    tied: PretrainedConfig defaults it True and always-tied architectures may
+    omit it."""
+    config = config or {}
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict) and "tie_word_embeddings" in text_config:
+        return bool(text_config["tie_word_embeddings"])
+    if "tie_word_embeddings" in config:
+        return bool(config["tie_word_embeddings"])
+    return True
+
+
+def _load_base_weight(source, key):
+    """Fetch one named tensor from a base-model snapshot: ``source`` is a
+    safetensors file or a directory of them (a sharded index is honored)."""
+    backend, load_file, _save, _transpose = _tensor_backend()
+    source = os.fspath(source)
+    candidates = []
+    if os.path.isdir(source):
+        index_path = os.path.join(source, "model.safetensors.index.json")
+        if os.path.exists(index_path):
+            with open(index_path, "r") as f:
+                weight_map = (json.load(f).get("weight_map") or {})
+            shard = weight_map.get(key)
+            if shard is not None:
+                candidates = [os.path.join(source, shard)]
+        if not candidates:
+            candidates = sorted(
+                os.path.join(source, name)
+                for name in os.listdir(source)
+                if name.endswith(".safetensors")
+            )
+    else:
+        candidates = [source]
+    from safetensors import safe_open
+    for path in candidates:
+        with safe_open(path, framework="numpy") as f:
+            if key not in f.keys():
+                continue
+        tensors = load_file(path)
+        return tensors[key]
+    raise ValueError(
+        f"Unsloth MLX: base_weights_source {source!r} does not contain "
+        f"{key!r}; cannot emit the auto-saved embedding weights."
+    )
+
+
+def convert_mlx_dir_to_peft(src, dst, module_types=None,
+                            base_weights_source=None):
     """Convert an mlx-lm adapter directory to a PEFT LoRA directory.
 
     ``module_types`` optionally maps module paths to ``"linear"`` /
-    ``"embedding"``. Supplying an entry is a caller assertion of BOTH facts
-    a weights file cannot establish: the module's type on the live base
-    model, AND that the same dotted path exists in the Hugging Face module
-    tree (mlx-lm renames some roots — e.g. GPT-2's ``model.h.*`` vs HF's
-    ``transformer.h.*`` — and a mis-asserted path yields an adapter peft
-    cannot bind). Without the map, only paths inside a ``layers.N`` stack —
-    where mlx-lm mirrors the HF tree and every LoRA target is a Linear —
-    are converted; anything else is refused, and that refusal points at the
-    MLX-format fallback rather than at this map, which only a caller able to
-    make the assertions above can safely supply.
+    ``"embedding"``. An entry asserts what a weights file cannot establish:
+    the module's type on the live base, that the base does not route tied
+    output logits through it (see export_peft_adapter's base_config check),
+    and that the same dotted path exists in the Hugging Face tree — mlx-lm
+    renames some roots (GPT-2's ``model.h.*`` vs HF's ``transformer.h.*``), so
+    a mis-asserted path yields an adapter peft cannot bind. Directory-only
+    conversion also cannot verify full-state completeness the way a live tree
+    can (attach refuses truncated snapshots and walks every module a selector
+    matches), and a composite modules_to_save entry re-exports as its wrapped
+    submodules, which peft restores with identical state and trainability.
+    Without the map, only root-anchored ``model.layers.N.`` paths convert —
+    the one layout where mlx-lm mirrors the HF tree and every LoRA target is a
+    Linear — and
+    anything else is refused, pointing at the MLX-format fallback rather than
+    at this map, which only a caller able to make those assertions can supply.
     """
     for _path, _kind in (module_types or {}).items():
         if _kind not in ("linear", "embedding"):
@@ -6533,16 +6905,67 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
             f"Unsloth MLX: fine_tune_type={cfg.get('fine_tune_type')!r} "
             "adapters cannot be exported to PEFT format."
         )
-    if cfg.get("full_state_modules"):
+    fs_origins = dict(cfg.get("full_state_modules") or {})
+    # PEFT expresses trainable module state ONLY as modules_to_save, and no
+    # module can be both a LoRA target and a modules_to_save entry, so a
+    # trainable auto-saved replacement has no faithful PEFT form; refuse rather
+    # than emit an artifact whose reload silently freezes it.
+    _trainable_auto = sorted(
+        p for p in (cfg.get("full_state_trainable") or [])
+        if fs_origins.get(p) != "modules_to_save"
+    )
+    if _trainable_auto:
         raise ValueError(
-            "Unsloth MLX: this adapter carries full-module state "
-            "(full_state_modules); it cannot be represented as plain "
-            "linear LoRA and PEFT export does not support it yet."
+            f"Unsloth MLX: {_trainable_auto} carry trainable auto-saved "
+            "full-module state, which PEFT cannot represent (its trainable "
+            "module state is modules_to_save, which cannot coexist with a "
+            "LoRA target on the same module). Export the MLX adapter "
+            "instead."
+        )
+    _bad_origins = {
+        p: o for p, o in fs_origins.items()
+        if o not in ("modules_to_save", "embedding_auto")
+    }
+    if _bad_origins:
+        raise ValueError(
+            f"Unsloth MLX: full_state_modules carries unknown origin "
+            f"tag(s) {_bad_origins}; expected 'modules_to_save' or "
+            "'embedding_auto'."
         )
     tensors = load_file(os.path.join(src, MLX_WEIGHTS_FILE))
     pairs = {}
     rejected = {}
+    full_state_out = {}
     for key, tensor in tensors.items():
+        fsm = re.match(r"^(.+)\.(weight|bias)$", key)
+        if fsm is not None:
+            _fs_path = fsm.group(1)
+            # Wrapped modules persist their base under .embedding/.linear.
+            for _inner in (".embedding", ".linear"):
+                if _fs_path.endswith(_inner) and _fs_path[: -len(_inner)] in fs_origins:
+                    _fs_path = _fs_path[: -len(_inner)]
+                    break
+            if _fs_path in fs_origins:
+                if not _is_float_dtype(tensor):
+                    raise ValueError(
+                        f"Unsloth MLX: {key} holds non-floating "
+                        f"({getattr(tensor, 'dtype', '?')}) full-module "
+                        "state; dequantize before exporting to PEFT format."
+                    )
+                _slot = full_state_out.setdefault(_fs_path, {})
+                _prev = _slot.get(fsm.group(2))
+                if _prev is not None and (
+                    tuple(_prev.shape) != tuple(tensor.shape)
+                    or _prev.dtype != tensor.dtype
+                    or not bool((_prev == tensor).all())
+                ):
+                    raise ValueError(
+                        f"Unsloth MLX: {key} disagrees with another "
+                        "spelling of the same module tensor; the adapter "
+                        "file is inconsistent."
+                    )
+                _slot[fsm.group(2)] = tensor
+                continue
         magm = re.match(r"^(.+)\.m$", key)
         if magm is not None and str(cfg.get("fine_tune_type", "")).lower() == "dora":
             pairs.setdefault(magm.group(1), {})["m_vec"] = tensor
@@ -6564,9 +6987,8 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
         path = m.group(1)
         declared = (module_types or {}).get(path)
         if declared == "embedding":
-            rejected[key] = (
-                "embedding LoRA cannot be exported to PEFT format yet"
-            )
+            pairs.setdefault(path, {})[m.group(2)] = tensor
+            pairs[path]["embedding"] = True
             continue
         if declared is None and re.match(
             # Root-anchored `model.layers.N.` only: that is the layout mlx-lm
@@ -6589,6 +7011,18 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
         if "a" not in pair or "b" not in pair:
             rejected[f"{path}.lora_*"] = "incomplete lora_a/lora_b pair"
             pairs.pop(path)
+            continue
+        _bad = sorted(
+            k for k in ("a", "b", "m_vec")
+            if k in pair and not _is_float_dtype(pair[k])
+        )
+        if _bad:
+            rejected[f"{path}.lora_*"] = (
+                f"non-floating adapter factor dtype(s) "
+                f"({', '.join(str(pair[k].dtype) for k in _bad)}); LoRA "
+                "factors must be floating point"
+            )
+            pairs.pop(path)
     if rejected:
         _raise_rejected(rejected, f"{src!r}")
     if not pairs:
@@ -6607,7 +7041,21 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
             "exported; peft and mlx-lm apply DoRA dropout with different "
             "training-mode formulas."
         )
+    _emb_export = sorted(p for p in pairs if pairs[p].get("embedding"))
+    if _emb_export and dropout > 0:
+        raise ValueError(
+            f"Unsloth MLX: {_emb_export} carry embedding LoRA with nonzero "
+            "lora_dropout; peft applies no dropout on embedding adapters, "
+            "so exporting would silently change training behavior."
+        )
     _mag_paths = {p for p, v in pairs.items() if "m_vec" in v}
+    _emb_mags = sorted(p for p in _mag_paths if pairs[p].get("embedding"))
+    if _emb_mags:
+        raise ValueError(
+            f"Unsloth MLX: {_emb_mags} carry DoRA magnitudes on embedding "
+            "modules; peft and mlx-lm decompose embedding DoRA "
+            "incompatibly, so it cannot be exported."
+        )
     if _ft == "dora" and _mag_paths != set(pairs):
         raise ValueError(
             "Unsloth MLX: DoRA magnitudes present on only some modules; "
@@ -6629,8 +7077,14 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
                 f"Unsloth MLX: {path} has lora_a rank {rank} but lora_b "
                 f"rank {int(b.shape[0])}; the adapter file is inconsistent."
             )
-        out[f"{_PEFT_PREFIX}{path}.lora_A.weight"] = transpose(a)
-        out[f"{_PEFT_PREFIX}{path}.lora_B.weight"] = transpose(b)
+        # mlx-lm uses the same [in,r]/[r,out] layout for embedding and linear,
+        # so only peft's key names differ (lora_embedding_* has no .weight).
+        if pairs[path].get("embedding"):
+            out[f"{_PEFT_PREFIX}{path}.lora_embedding_A"] = transpose(a)
+            out[f"{_PEFT_PREFIX}{path}.lora_embedding_B"] = transpose(b)
+        else:
+            out[f"{_PEFT_PREFIX}{path}.lora_A.weight"] = transpose(a)
+            out[f"{_PEFT_PREFIX}{path}.lora_B.weight"] = transpose(b)
         if "m_vec" in pairs[path]:
             _mv = pairs[path]["m_vec"]
             if getattr(_mv, "ndim", 0) != 1 or int(_mv.shape[0]) != int(b.shape[1]):
@@ -6679,6 +7133,53 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
             "^" + re.escape(p): a for p, a in alphas.items()
             if a != peft_cfg["lora_alpha"]
         }
+    _missing_fs = set(fs_origins) - set(full_state_out)
+    if _missing_fs:
+        raise ValueError(
+            "Unsloth MLX: full_state_modules lists "
+            f"{sorted(_missing_fs)} but the weight file carries no "
+            "tensors for them; the artifact is inconsistent."
+        )
+    _m2s_list = sorted(
+        p for p, origin in fs_origins.items() if origin == "modules_to_save"
+    )
+    if _m2s_list:
+        peft_cfg["modules_to_save"] = _m2s_list
+    for _p, _entries in sorted(full_state_out.items()):
+        # peft's on-disk forms: plain {path}.{tensor} for modules_to_save
+        # snapshots and untargeted auto-saved embeddings (the infix is stripped
+        # at save), but a LoRA-wrapped module's base state sits under the
+        # wrapper's .base_layer path, since a plain key would not bind.
+        _wrapped = _p in pairs
+        for _tname, _tensor in sorted(_entries.items()):
+            if _wrapped:
+                out[f"{_PEFT_PREFIX}{_p}.base_layer.{_tname}"] = _tensor
+            else:
+                out[f"{_PEFT_PREFIX}{_p}.{_tname}"] = _tensor
+    _unsourced_emb = sorted(
+        p for p in pairs
+        if pairs[p].get("embedding") and p not in full_state_out
+    )
+    if _unsourced_emb and base_weights_source is not None:
+        for _p in _unsourced_emb:
+            _w = _load_base_weight(base_weights_source, f"{_p}.weight")
+            _want = (int(pairs[_p]["a"].shape[0]), int(pairs[_p]["b"].shape[1]))
+            _got = tuple(int(x) for x in getattr(_w, "shape", ()))
+            if _got != _want or not _is_float_dtype(_w):
+                raise ValueError(
+                    f"Unsloth MLX: base_weights_source weight for {_p} has "
+                    f"shape {_got} / dtype {getattr(_w, 'dtype', '?')}; the "
+                    f"adapter factors imply a float {_want} embedding. The "
+                    "source does not match the adapter's base model."
+                )
+            out[f"{_PEFT_PREFIX}{_p}.base_layer.weight"] = _w
+    elif _unsourced_emb:
+        logger.info(
+            "Unsloth MLX: exporting embedding LoRA for "
+            f"{_unsourced_emb} without base embedding weights (no "
+            "base_weights_source); PEFT loads such adapters cleanly and "
+            "takes the embeddings from the base model."
+        )
     # Same stage-then-atomic-rename destination contract as
     # convert_peft_dir_to_mlx; see the note there.
     dst = os.fspath(dst)
@@ -6711,16 +7212,91 @@ def export_peft_adapter(src, dst, *, base_config=None, module_types=None,
                         base_weights_source=None):
     """Public wrapper: convert an mlx-lm adapter directory to PEFT format.
 
-    ``module_types`` follows convert_mlx_dir_to_peft. ``base_config`` is
-    accepted for signature parity with the import direction; this direction
-    derives everything it needs from the adapter itself. ``base_weights_source``
-    is reserved for emitting PEFT-convention full embedding weights; passing
-    it is refused until full-weight module state is supported end to end.
+    ``module_types`` follows convert_mlx_dir_to_peft. ``base_config`` adds the
+    tie_word_embeddings check for embedding exports, since a tied model routes
+    output logits through the embedding adapter in mlx-lm but not in peft.
+    ``base_weights_source`` (a safetensors file or snapshot directory) supplies
+    the PEFT-convention auto-saved embedding weights when the adapter targets
+    an embedding; without it they are omitted, which PEFT loads cleanly by
+    resolving embeddings from the base model.
     """
-    if base_weights_source is not None:
-        raise ValueError(
-            "Unsloth MLX: base_weights_source is not supported yet; "
-            "embedding/full-weight emission lands with modules_to_save "
-            "support."
+    if base_config is not None and _config_ties_word_embeddings(base_config):
+        try:
+            with open(os.path.join(os.fspath(src), "adapter_config.json")) as _f:
+                _src_fs = dict(
+                    (json.load(_f).get("full_state_modules") or {})
+                )
+        except OSError:
+            _src_fs = {}
+        _vocab = None
+        for _scope in ((base_config or {}).get("text_config") or {},
+                       base_config or {}):
+            if isinstance(_scope, dict) and _scope.get("vocab_size"):
+                _vocab = int(_scope["vocab_size"])
+                break
+        _shapes = {}
+        if _src_fs:
+            try:
+                from safetensors import safe_open
+                with safe_open(
+                    os.path.join(os.fspath(src), MLX_WEIGHTS_FILE),
+                    framework="numpy",
+                ) as _f:
+                    _keys = set(_f.keys())
+                    for _p in _src_fs:
+                        for _k in (
+                            f"{_p}.weight",
+                            f"{_p}.embedding.weight",
+                            f"{_p}.linear.weight",
+                        ):
+                            if _k in _keys:
+                                _shapes[_p] = tuple(
+                                    _f.get_slice(_k).get_shape()
+                                )
+                                break
+            except OSError:
+                pass
+
+        def _looks_like_embedding(p):
+            shape = _shapes.get(p)
+            if (
+                _vocab is not None
+                and shape is not None
+                and len(shape) == 2
+                and int(shape[0]) == _vocab
+            ):
+                return True
+            return p.rsplit(".", 1)[-1] in (
+                _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES
+            )
+
+        _m2s_emb = sorted(
+            p for p, o in _src_fs.items()
+            if o == "modules_to_save" and _looks_like_embedding(p)
         )
-    return convert_mlx_dir_to_peft(src, dst, module_types=module_types)
+        if _m2s_emb:
+            raise ValueError(
+                f"Unsloth MLX: {_m2s_emb} are modules_to_save replacements "
+                "of a tied embedding; peft would train an untied input "
+                "copy while the tied MLX embedding also projects output "
+                "logits, so no faithful export exists."
+            )
+    _emb_declared = sorted(
+        p for p, t in (module_types or {}).items() if t == "embedding"
+    )
+    # The tie check is opt-in: without base_config there is no config to test,
+    # and a module_types entry already carries the caller's tied-routing
+    # assertion. An ABSENT key inside a provided config still means tied.
+    if _emb_declared and base_config is not None and (
+        _config_ties_word_embeddings(base_config)
+    ):
+        raise ValueError(
+            f"Unsloth MLX: {_emb_declared} carry embedding LoRA but the "
+            "base model ties word embeddings; mlx-lm applies the update "
+            "to the tied output projection while peft applies it to "
+            "input lookup only, so no faithful export exists."
+        )
+    return convert_mlx_dir_to_peft(
+        src, dst, module_types=module_types,
+        base_weights_source=base_weights_source,
+    )

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -7208,13 +7208,10 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
                     "source does not match the adapter's base model."
                 )
             out[f"{_PEFT_PREFIX}{_p}.base_layer.weight"] = _w
-    elif _unsourced_emb:
-        logger.info(
-            "Unsloth MLX: exporting embedding LoRA for "
-            f"{_unsourced_emb} without base embedding weights (no "
-            "base_weights_source); PEFT loads such adapters cleanly and "
-            "takes the embeddings from the base model."
-        )
+    # An embedding adapter exported without base_weights_source simply omits
+    # those weights; peft resolves them from the base model. Nothing is logged
+    # here on purpose -- this module stays importable and usable without torch,
+    # and the shared logger pulls in a torch-importing module on first use.
     # Same stage-then-atomic-rename destination contract as
     # convert_peft_dir_to_mlx; see the note there.
     dst = os.fspath(dst)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -127,12 +127,9 @@ def _inference_mode(fn):
 
 
 def _bnb_linear4bit():
-    # Empty when bitsandbytes is absent (e.g. gfx906, whose generic wheel has
-    # no kernels) or stubbed out, as it is on hosts with no CUDA build: either
-    # way there are no 4bit layers, so isinstance against an empty tuple is
-    # exactly right. Resolved lazily to keep the import off this module's
-    # import path, and filtered to real classes because the stub answers every
-    # attribute with a placeholder object that isinstance would reject.
+    # Empty when bitsandbytes is absent or stubbed: no 4bit layers exist, so
+    # isinstance against () is right. Filtered to real classes because the stub
+    # answers every attribute with a placeholder.
     try:
         candidate = bnb.nn.Linear4bit
     except Exception:
@@ -6053,25 +6050,19 @@ pass
 
 
 # ---------------------------------------------------------------------------
-# PEFT <-> MLX LoRA adapter interop. PEFT adapters
-# (adapter_model.safetensors, lora_A/lora_B keys under a base_model.model.
-# prefix) and mlx-lm adapters (adapters.safetensors, lora_a/lora_b keys)
-# encode the same math in different layouts:
+# PEFT <-> MLX LoRA adapter interop. The two formats encode the same math in
+# different layouts:
 #
 #     peft {p}.lora_A.weight [r, in]   ==  mlx {p}.lora_a [in, r], transposed
 #     peft {p}.lora_B.weight [out, r]  ==  mlx {p}.lora_b [r, out], transposed
 #     effective scale = lora_alpha / r     (rsLoRA: lora_alpha / sqrt(r))
 #
-# Conversion is rename + transpose only, so dtypes are exact and a round trip
-# is bitwise-identical for the supported subset: plain linear LoRA; linear
-# DoRA, whose magnitude maps to m with numeric verification; embedding LoRA
-# via lora_embedding_A/B; and full-module state (modules_to_save snapshots and
-# peft's auto-saved embeddings) tracked through origin-tagged
-# full_state_modules maps. Expert target_parameters factors, embedding DoRA,
-# and embedding adapters on tied-output models are refused with a named reason
-# rather than lossily converted. Tensor IO prefers mlx.core (native bfloat16),
-# falling back to safetensors.torch off Apple hardware — the numpy backend
-# cannot represent bf16.
+# Conversion is rename + transpose only, so a round trip is bitwise-identical
+# for the supported subset: linear LoRA, linear DoRA, and full-module state
+# (modules_to_save snapshots and peft's auto-saved embeddings) tracked through
+# origin-tagged full_state_modules maps. Everything else is refused by name.
+# Tensor IO prefers mlx.core for native bfloat16, falling back to
+# safetensors.torch off Apple hardware.
 # ---------------------------------------------------------------------------
 
 import math
@@ -6081,9 +6072,8 @@ PEFT_WEIGHTS_FILE = "adapter_model.safetensors"
 MLX_WEIGHTS_FILE = "adapters.safetensors"
 _PEFT_PREFIX = "base_model.model."
 
-# peft resolves rank_pattern / alpha_pattern keys by ordered first-match against
-# the module path, and a key may be a regex fragment; mirror peft's expression
-# exactly (end-anchored, optional dotted ancestry).
+# peft resolves rank_pattern / alpha_pattern by ordered first-match, and a key
+# may be a regex fragment; mirror its expression exactly.
 def _resolve_pattern(patterns, module_path):
     if not patterns:
         return None
@@ -6232,9 +6222,8 @@ def normalize_peft_adapter_config(cfg, adapter_dir=None):
             f"Unsloth MLX: only peft_type='LORA' adapters can be imported; "
             f"got {cfg.get('peft_type')!r}."
         )
-    # The MLX backend builds a causal language model, so an adapter trained
-    # for another task would attach its backbone factors and then answer with
-    # vocabulary logits instead of what it was trained to produce.
+    # The MLX backend builds a causal LM, so another task's adapter would
+    # attach its backbone factors and then answer with vocabulary logits.
     task_type = cfg.get("task_type")
     task_type = getattr(task_type, "value", task_type)
     if task_type is not None and str(task_type).upper() != "CAUSAL_LM":
@@ -6254,30 +6243,22 @@ def normalize_peft_adapter_config(cfg, adapter_dir=None):
                 f"Unsloth MLX: cannot import this PEFT adapter: {reason} "
                 f"(adapter_config.json field {key!r})."
             )
-    # PiSSA/OLoRA/CorDA subtract their decomposition from the base at init and
-    # LoftQ writes its re-quantized weight back, so their factors only reproduce
-    # the trained model on that mutated base, which this importer never applies.
-    # peft can convert them to plain LoRA at save time; require that instead of
-    # silently changing logits.
+    # PiSSA/OLoRA/CorDA/LoftQ factors only reproduce the trained model on the
+    # base they mutated at init, which this importer never applies. peft can
+    # convert them to plain LoRA at save time; require that.
     init_mode = cfg.get("init_lora_weights")
     # peft matches these case-insensitively, dispatching corda by prefix.
     init_norm = init_mode.lower() if isinstance(init_mode, str) else ""
     if not _is_empty(cfg.get("loftq_config")) or init_norm == "loftq":
+        _named = "LoftQ"
+    elif init_norm.startswith(("pissa", "corda")) or init_norm == "olora":
+        _named = f"init_lora_weights={init_mode!r}"
+    else:
+        _named = None
+    if _named:
         raise ValueError(
-            "Unsloth MLX: LoftQ-initialized adapters assume the base weight "
-            "was replaced by its re-quantized form at initialization; "
-            "re-save the adapter converted to plain LoRA before importing."
-        )
-    if (
-        init_norm.startswith("pissa")
-        or init_norm.startswith("corda")
-        or init_norm == "olora"
-    ):
-        raise ValueError(
-            f"Unsloth MLX: init_lora_weights={init_mode!r} adapters assume "
-            "a base model mutated at initialization; re-save the adapter "
-            "converted to plain LoRA (peft's "
-            "path_initial_model_for_weight_conversion) before importing."
+            f"Unsloth MLX: {_named} adapters assume a base mutated at "
+            "initialization; re-save converted to plain LoRA."
         )
     known = _PEFT_HANDLED_KEYS | _PEFT_NEUTRAL_KEYS | set(_PEFT_REJECTED_KEYS)
     known |= {"bias", "loftq_config"}
@@ -6314,8 +6295,7 @@ def _effective_scale(cfg, module_path, rank):
 def group_peft_lora_pairs(tensors, cfg=None):
     """Split raw PEFT tensors into (pairs, full_state, rejected).
 
-    ``pairs`` maps module paths to {'A','B'[,'M']} for linear LoRA/DoRA and
-    {'EA','EB'} for embedding LoRA. ``full_state`` maps module paths to
+    ``pairs`` maps module paths to {'A','B'[,'M']}. ``full_state`` maps to
     {tensor_name: tensor} for modules_to_save snapshots (peft strips the infix
     at save, so detection is config-driven) and auto-saved embedding weights.
     The wrapper prefix is stripped exactly once; keys without it are rejected.
@@ -6325,9 +6305,8 @@ def group_peft_lora_pairs(tensors, cfg=None):
 
     def _m2s_hit(cand):
         # peft selects with a RAW key.endswith(name) — no dot boundary, so
-        # ["head"] wraps lm_head. A composite module's snapshot arrives as
-        # SUBMODULE keys (classifier.0.weight), so a name may also suffix-match
-        # a dotted ancestor of the key path.
+        # ["head"] wraps lm_head — and a composite module's snapshot arrives as
+        # submodule keys, so a name may suffix-match a dotted ancestor too.
         for m2s in m2s_paths:
             if cand.endswith(m2s):
                 return m2s
@@ -6336,22 +6315,17 @@ def group_peft_lora_pairs(tensors, cfg=None):
                     return m2s
         return None
 
-    def _tensors_equal(a, b):
-        if tuple(getattr(a, "shape", ())) != tuple(getattr(b, "shape", ())):
-            return False
-        if getattr(a, "dtype", None) != getattr(b, "dtype", None):
-            return False
-        return bool((a == b).all())
-
     pairs = {}
     full_state = {}
     rejected = {}
     for key, tensor in tensors.items():
-        emb = re.match(
+        if re.match(
             rf"^{re.escape(_PEFT_PREFIX)}(.+)\.lora_embedding_(A|B)$", key
-        )
-        if emb is not None:
-            pairs.setdefault(emb.group(1), {})["E" + emb.group(2)] = tensor
+        ):
+            rejected[key] = (
+                "embedding LoRA, which this converter does not support; "
+                "retrain without the embedding in target_modules"
+            )
             continue
         mag = re.match(
             rf"^{re.escape(_PEFT_PREFIX)}(.+)\.lora_magnitude_vector(?:\.weight)?$",
@@ -6377,8 +6351,7 @@ def group_peft_lora_pairs(tensors, cfg=None):
                 fs_path = fs_path[: -len(".base_layer")]
                 if not _is_auto_saved_module_path(fs_path):
                     # Every LoRA target has a .base_layer, so without this any
-                    # of them could carry full state and replace its own base
-                    # weights.
+                    # of them could replace its own base weights.
                     rejected[key] = (
                         "auto-saved base state on a module that is not the "
                         "input embedding or output head"
@@ -6391,9 +6364,7 @@ def group_peft_lora_pairs(tensors, cfg=None):
             # `{p}.modules_to_save[.name].{t}` duplicates the snapshot and
             # `{p}.original_module[.name].{t}` is the pristine base. Fold the
             # former, drop the latter — before the general modules_to_save
-            # match, which would adopt these as real submodules. A user module
-            # genuinely named like a wrapper internal is misread; genuine
-            # wrapper keys are common and such names are not.
+            # match, which would adopt them as real submodules.
             for _marker in (".modules_to_save", ".original_module"):
                 _idx = fs_path.find(_marker)
                 if _idx > 0 and _m2s_hit(fs_path[:_idx]) is not None:
@@ -6447,31 +6418,10 @@ def group_peft_lora_pairs(tensors, cfg=None):
         continue
     has_mag = {p for p, v in pairs.items() if "M" in v}
     for path, pair in pairs.items():
-        if ("EA" in pair) != ("EB" in pair):
-            rejected[f"{_PEFT_PREFIX}{path}.lora_embedding_*"] = (
-                "incomplete lora_embedding_A/B pair"
-            )
-        if "EA" in pair and "M" in pair:
-            rejected[f"{_PEFT_PREFIX}{path}.lora_magnitude_vector"] = (
-                "embedding DoRA decompositions are incompatible between "
-                "peft and mlx-lm"
-            )
-        if "EA" in pair:
-            continue
         if "A" not in pair or "B" not in pair:
             rejected[f"{_PEFT_PREFIX}{path}.lora_*"] = (
                 "incomplete lora_A/lora_B pair"
             )
-    # use_dora is global, so an embedding target under it is embedding DoRA
-    # (incompatible decompositions) or a truncated file. Either way, refuse.
-    if cfg.get("use_dora"):
-        for _p, _v in pairs.items():
-            if "EA" in _v:
-                rejected[f"{_PEFT_PREFIX}{_p}.lora_embedding_*"] = (
-                    "embedding adapters under use_dora have no compatible "
-                    "peft/mlx-lm decomposition (or the magnitude vector "
-                    "is missing from the file)"
-                )
     # use_dora is global: a partial magnitude set means file and config
     # disagree about what the adapter is.
     _linear_pairs = {p for p, v in pairs.items() if "A" in v}
@@ -6482,14 +6432,8 @@ def group_peft_lora_pairs(tensors, cfg=None):
         )
         pairs = {}
     for _p, _v in pairs.items():
-        if ("A" in _v or "B" in _v) and ("EA" in _v or "EB" in _v):
-            rejected[f"{_PEFT_PREFIX}{_p}.lora_*"] = (
-                "carries both linear (lora_A/B) and embedding "
-                "(lora_embedding_A/B) factors for one module; the artifact "
-                "is inconsistent"
-            )
         _bad = sorted(
-            k for k in ("A", "B", "EA", "EB", "M")
+            k for k in ("A", "B", "M")
             if k in _v and not _is_float_dtype(_v[k])
         )
         if _bad:
@@ -6498,13 +6442,10 @@ def group_peft_lora_pairs(tensors, cfg=None):
                 f"({', '.join(str(_v[k].dtype) for k in _bad)}); LoRA "
                 "factors must be floating point"
             )
-    pairs = {
-        p: v for p, v in pairs.items()
-        if ("A" in v and "B" in v) or ("EA" in v and "EB" in v)
-    }
-    # An entry with no tensors would silently downgrade to plain LoRA, dropping
-    # a trained replacement. Credit every declaration a snapshot satisfies —
-    # overlapping names like ["head", "lm_head"] select the same module.
+    pairs = {p: v for p, v in pairs.items() if "A" in v and "B" in v}
+    # An entry with no tensors would silently downgrade to plain LoRA. Credit
+    # every declaration a snapshot satisfies: overlapping names like
+    # ["head", "lm_head"] select the same module.
     _m2s_snapshot_paths = [
         p for p, v in full_state.items()
         if v.get("__origin__") == "modules_to_save"
@@ -6578,58 +6519,16 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
     out = {}
     ranks, scales = {}, {}
     fs_origins = {}
-    emb_paths = {p for p, v in pairs.items() if "EA" in v}
-    if emb_paths and _config_ties_word_embeddings(base_config):
-        # Routing cannot be verified from configs alone and a wrongly-admitted
-        # adapter silently changes logits, so a true flag refuses even where the
-        # forward ignores it.
-        raise ValueError(
-            f"Unsloth MLX: {sorted(emb_paths)} carry embedding LoRA but the "
-            "base model ties word embeddings; mlx-lm applies the update to "
-            "the tied output projection while peft applies it to input "
-            "lookup only, so no faithful conversion exists."
-        )
-    if emb_paths and float(cfg.get("lora_dropout") or 0.0) > 0:
-        raise ValueError(
-            f"Unsloth MLX: {sorted(emb_paths)} carry embedding LoRA with "
-            "nonzero lora_dropout; peft applies no dropout on embedding "
-            "adapters while mlx-lm does, so training behavior cannot be "
-            "preserved. Set lora_dropout=0 to convert."
-        )
     _base_ties = _config_ties_word_embeddings(base_config)
     if _base_ties:
-        _vocab = None
-        for _scope in ((base_config or {}).get("text_config") or {},
-                       base_config or {}):
-            if isinstance(_scope, dict) and _scope.get("vocab_size"):
-                _vocab = int(_scope["vocab_size"])
-                break
-
-        def _looks_like_embedding(p, v):
-            w = v.get("weight")
-            if (
-                _vocab is not None
-                and w is not None
-                and getattr(w, "ndim", 0) == 2
-                and int(w.shape[0]) == _vocab
-            ):
-                return True
-            return p.rsplit(".", 1)[-1] in (
-                _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES
-            )
-
         _m2s_emb = sorted(
             p for p, v in full_state.items()
             if v.get("__origin__") == "modules_to_save"
-            and _looks_like_embedding(p, v)
+            and _names_embedding_or_head(p, v.get("weight"), base_config)
         )
         if _m2s_emb:
             raise ValueError(
-                f"Unsloth MLX: {_m2s_emb} are modules_to_save snapshots of "
-                "a tied embedding or output head; peft trains an untied "
-                "copy while the tied MLX embedding both looks up inputs "
-                "and projects output logits, so no faithful conversion "
-                "exists."
+                f"Unsloth MLX: {_m2s_emb} carry {_TIED_FULL_STATE_REASON}."
             )
     for path, entries in sorted(full_state.items()):
         if (
@@ -6637,9 +6536,6 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
             and entries["__origin__"] == "embedding_auto"
             and _leaf_in(path, _OUTPUT_HEAD_LEAF_NAMES)
         ):
-            # On a tied base the auto-saved head IS the embedding weight, so
-            # verify it against the embedding snapshot and fold; emitting head
-            # state would restore a duplicate the tree may not even carry.
             _emb_matches = [
                 v for p, v in full_state.items()
                 if _leaf_in(p, _EMBEDDING_LEAF_NAMES)
@@ -6650,34 +6546,17 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
                     "but the artifact carries multiple embed_tokens "
                     "snapshots; the duplicate cannot be attributed."
                 )
-            _emb_entries = _emb_matches[0] if _emb_matches else None
-            _ew = (_emb_entries or {}).get("weight")
-            _lw = entries.get("weight")
-            _extra = sorted(set(entries) - {"__origin__", "weight"})
-            if (
-                _ew is None
-                or _lw is None
-                or _extra
-                or tuple(_ew.shape) != tuple(_lw.shape)
-                or _ew.dtype != _lw.dtype
-                or not bool((_ew == _lw).all())
-            ):
-                raise ValueError(
-                    f"Unsloth MLX: {path} is a tied model's output-head "
-                    "snapshot but does not exactly duplicate the tied "
-                    "embedding snapshot"
-                    + (f" (extra tensors {_extra})" if _extra else "")
-                    + "; a tied MLX model cannot hold an independent "
-                    "lm_head."
-                )
+            _err = _tied_head_fold_error(
+                path, entries, (_emb_matches or [{}])[0].get("weight"),
+                _tensors_equal,
+            )
+            if _err:
+                raise ValueError(f"Unsloth MLX: {_err}.")
             continue
         fs_origins[path] = entries["__origin__"]
         # A reload wraps LoRA-paired modules, so base tensors live under the
         # wrapper's inner module.
-        if path in pairs:
-            _kp = f"{path}.embedding" if "EA" in pairs[path] else f"{path}.linear"
-        else:
-            _kp = path
+        _kp = f"{path}.linear" if path in pairs else path
         for tname, tensor in entries.items():
             if tname == "__origin__":
                 continue
@@ -6688,37 +6567,9 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
                     "the artifact cannot restore as module state."
                 )
             out[f"{_kp}.{tname}"] = tensor
-    for path in sorted(emb_paths):
-        ea, eb = pairs[path]["EA"], pairs[path]["EB"]
-        if getattr(ea, "ndim", 0) != 2 or getattr(eb, "ndim", 0) != 2:
-            raise ValueError(
-                f"Unsloth MLX: {path} embedding LoRA factors are not 2-D."
-            )
-        rank = int(ea.shape[0])
-        if int(eb.shape[1]) != rank:
-            raise ValueError(
-                f"Unsloth MLX: {path} embedding LoRA ranks disagree."
-            )
-        out[f"{path}.lora_a"] = transpose(ea)
-        out[f"{path}.lora_b"] = transpose(eb)
-        ranks[path] = rank
-        scales[path] = _effective_scale(cfg, path, rank)
-    for path in sorted(set(pairs) - emb_paths):
+    for path in sorted(pairs):
         a, b = pairs[path]["A"], pairs[path]["B"]
-        # 2-D only: higher-rank factors are not linear LoRA, and the two IO
-        # backends transpose them differently.
-        if getattr(a, "ndim", 0) != 2 or getattr(b, "ndim", 0) != 2:
-            raise ValueError(
-                f"Unsloth MLX: {path} carries non-2-D LoRA factors "
-                f"(A ndim={getattr(a, 'ndim', '?')}, "
-                f"B ndim={getattr(b, 'ndim', '?')}); not plain linear LoRA."
-            )
-        rank = int(a.shape[0])
-        if int(b.shape[1]) != rank:
-            raise ValueError(
-                f"Unsloth MLX: {path} has lora_A rank {rank} but lora_B "
-                f"rank {int(b.shape[1])}; the adapter file is inconsistent."
-            )
+        rank = _lora_pair_rank(path, a, b, 0)
         out[f"{path}.lora_a"] = transpose(a)
         out[f"{path}.lora_b"] = transpose(b)
         mag = pairs[path].get("M")
@@ -6733,12 +6584,7 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
                 "config does not set use_dora; the artifact is inconsistent."
             )
         if mag is not None:
-            if getattr(mag, "ndim", 0) != 1 or int(mag.shape[0]) != int(b.shape[0]):
-                raise ValueError(
-                    f"Unsloth MLX: {path} magnitude shape "
-                    f"{tuple(getattr(mag, 'shape', ()))} does not match the "
-                    f"module out-dim {int(b.shape[0])}."
-                )
+            _check_dora_magnitude(path, mag, int(b.shape[0]))
             out[f"{path}.m"] = mag
         ranks[path] = rank
         scales[path] = _effective_scale(cfg, path, rank)
@@ -6756,8 +6602,7 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
             "scale": scales[any_path],
             "dropout": float(cfg.get("lora_dropout") or 0.0),
             # Pin the exact module set: without "keys", mlx-lm wraps every
-            # supported projection in the selected layers, growing the topology
-            # with zero-initialized extras.
+            # projection in the selected layers with zero-initialized extras.
             "keys": sorted(ranks),
         },
         "unsloth_mlx_lora_module_paths": sorted(ranks),
@@ -6780,44 +6625,148 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
             "copy needs Unsloth to load (stock mlx-lm assumes one global "
             "rank/scale)."
         )
-    # Destination contract: the complete artifact is staged in a unique sibling
-    # directory and published by ONE atomic rename, so readers never observe a
-    # partial adapter: a crash leaves either nothing at dst or the complete
-    # artifact, never a half-written one. Claim-first designs
-    # were tried and rejected: a kill between claim and publish strands a
-    # partial destination that blocks retries. The rename refuses a concurrently
-    # created non-empty dst (ENOTEMPTY), so content is never replaced and
-    # formats never mix; the residual — adopting a ZERO-DATA entry (empty
-    # directory or bare symlink) created in the race window — is accepted, since
-    # two uncoordinated writers on one path are outside the contract under any
-    # protocol. dst is refused by the caller's spelling BEFORE resolving so a
-    # pre-planted dangling symlink is rejected rather than followed (trailing
-    # separators are stripped first — lexists("link/") follows the terminal
-    # symlink); resolution only normalizes parents, and the resolved path is
-    # re-checked in case a parent symlink retargeted it.
+    return _publish_adapter_dir(dst, MLX_WEIGHTS_FILE, out, mlx_cfg, save_file)
+
+
+def _names_embedding_or_head(path, weight=None, config=None):
+    """Whether a full-state path is the embedding or the output head. Callers
+    decide tie-ness from the config; this only identifies the module, by a row
+    count matching the declared vocabulary when a weight is at hand, else by
+    leaf spelling."""
+    shape = tuple(getattr(weight, "shape", ()) or ())
+    if len(shape) == 2:
+        for scope in ((config or {}).get("text_config") or {}, config or {}):
+            if isinstance(scope, dict) and scope.get("vocab_size"):
+                return int(shape[0]) == int(scope["vocab_size"]) or _leaf_in(
+                    path, _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES
+                )
+    return _leaf_in(path, _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES)
+
+
+def _full_state_owner(path, recorded):
+    """The recorded full-state module a path belongs to: the path itself, or
+    the module whose LoRA wrapper keeps its base under .embedding/.linear."""
+    if path in recorded:
+        return path
+    for inner in (".embedding", ".linear"):
+        if path.endswith(inner) and path[: -len(inner)] in recorded:
+            return path[: -len(inner)]
+    return None
+
+
+def _validate_full_state_origins(fs_origins):
+    bad = {
+        p: o for p, o in fs_origins.items()
+        if o not in ("modules_to_save", "embedding_auto")
+    }
+    if bad:
+        raise ValueError(
+            f"Unsloth MLX: full_state_modules carries unknown origin tag(s) "
+            f"{bad}; expected 'modules_to_save' or 'embedding_auto'."
+        )
+
+
+def _tensors_equal(a, b):
+    if tuple(getattr(a, "shape", ())) != tuple(getattr(b, "shape", ())):
+        return False
+    if getattr(a, "dtype", None) != getattr(b, "dtype", None):
+        return False
+    return bool((a == b).all())
+
+
+def _tied_head_fold_error(path, entries, emb_weight, equal):
+    """Why a tied base's auto-saved output-head snapshot cannot fold into the
+    embedding, or None when ``equal`` accepts it as a duplicate. On a tied base
+    the head tensor IS the embedding weight, so emitting it would restore a
+    duplicate the MLX tree may not even carry. ``equal`` is the caller's:
+    the converter demands an identical dtype, while a live attach compares in
+    the live dtype, since the loader may have cast the base."""
+    extra = sorted(set(entries) - {"__origin__", "weight"})
+    if extra:
+        return (
+            f"{path} (tied output-head snapshot carries {extra}; a tied "
+            "embedding has no slot for them)"
+        )
+    snapshot = entries.get("weight")
+    if snapshot is None or not _is_float_dtype(snapshot):
+        return (
+            f"{path} (tied output-head snapshot is missing or non-floating)"
+        )
+    if emb_weight is None or not equal(emb_weight, snapshot):
+        return (
+            f"{path} (tied output-head snapshot differs from the tied "
+            "embedding; a tied model has no independent head)"
+        )
+    return None
+
+
+def _lora_pair_rank(path, a, b, rank_axis):
+    """The rank a LoRA factor pair agrees on. ``rank_axis`` is 0 for peft's
+    [r,in]/[out,r] layout and 1 for mlx-lm's [in,r]/[r,out]; ``b`` is indexed
+    on the other axis. Messages use the direction's own key spelling."""
+    _a, _b, _why = (
+        ("lora_A", "lora_B", "not plain linear LoRA") if rank_axis == 0
+        else ("lora_a", "lora_b", "switch/MoE LoRA cannot be exported")
+    )
+    if getattr(a, "ndim", 0) != 2 or getattr(b, "ndim", 0) != 2:
+        raise ValueError(
+            f"Unsloth MLX: {path} carries non-2-D LoRA factors ({_a} ndim "
+            f"{getattr(a, 'ndim', '?')}, {_b} ndim {getattr(b, 'ndim', '?')}); "
+            f"{_why}."
+        )
+    rank = int(a.shape[rank_axis])
+    other = int(b.shape[1 - rank_axis])
+    if other != rank:
+        raise ValueError(
+            f"Unsloth MLX: {path} has {_a} rank {rank} but {_b} rank "
+            f"{other}; the adapter file is inconsistent."
+        )
+    return rank
+
+
+def _check_dora_magnitude(path, mag, out_dim):
+    if getattr(mag, "ndim", 0) != 1 or int(mag.shape[0]) != out_dim:
+        raise ValueError(
+            f"Unsloth MLX: {path} DoRA magnitude shape "
+            f"{tuple(getattr(mag, 'shape', ()))} does not match the module "
+            f"out-dim {out_dim}."
+        )
+
+
+def _publish_adapter_dir(dst, weights_name, tensors, cfg, save_file):
+    """Stage the whole artifact in a unique sibling directory and publish it
+    with ONE atomic rename, so a crash leaves either nothing at ``dst`` or the
+    complete adapter. Claim-first designs strand a partial destination that
+    blocks retries. The rename refuses a concurrently created non-empty dst,
+    so content is never replaced and formats never mix; adopting a zero-data
+    entry (empty directory or bare symlink) created in the race window is
+    accepted. dst is checked in the caller's spelling BEFORE resolving, so a
+    pre-planted dangling symlink is rejected rather than followed — trailing
+    separators go first, since lexists("link/") follows the terminal symlink —
+    and again after, in case a parent symlink retargeted it."""
     dst = os.fspath(dst)
     _require_fresh_destination(dst.rstrip(os.sep) or dst)
     dst = os.path.realpath(dst)
     _require_fresh_destination(dst)
     os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
-    _tmp = f"{dst}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
-    _tmp_created = False
+    tmp = f"{dst}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    created = False
     try:
-        os.makedirs(_tmp)
-        _tmp_created = True
-        save_file(os.path.join(_tmp, MLX_WEIGHTS_FILE), out)
-        with open(os.path.join(_tmp, "adapter_config.json"), "w") as f:
-            json.dump(mlx_cfg, f, indent=2, sort_keys=True)
+        os.makedirs(tmp)
+        created = True
+        save_file(os.path.join(tmp, weights_name), tensors)
+        with open(os.path.join(tmp, "adapter_config.json"), "w") as f:
+            json.dump(cfg, f, indent=2, sort_keys=True)
         try:
-            os.rename(_tmp, dst)
+            os.rename(tmp, dst)
         except OSError as exc:
             raise ValueError(
                 f"Unsloth MLX: destination {dst!r} appeared concurrently "
                 "and is not empty; refusing to mix adapter artifacts."
             ) from exc
     finally:
-        if _tmp_created:
-            shutil.rmtree(_tmp, ignore_errors=True)
+        if created:
+            shutil.rmtree(tmp, ignore_errors=True)
     return dst
 
 
@@ -6833,6 +6782,14 @@ _EMBEDDING_LEAF_NAMES = (
     "embed_in", "word_embeddings", "embeddings", "embedding",
 )
 _OUTPUT_HEAD_LEAF_NAMES = ("lm_head", "output", "embed_out")
+
+
+# peft trains an untied copy of a tied embedding or head, while the tied MLX
+# module both looks up inputs and projects output logits.
+_TIED_FULL_STATE_REASON = (
+    "full-module state for a tied embedding or output head, which peft and "
+    "mlx-lm cannot represent the same way"
+)
 
 
 def _leaf_in(path, names):
@@ -6871,67 +6828,21 @@ def _config_ties_word_embeddings(config):
     return True
 
 
-def _load_base_weight(source, key):
-    """Fetch one named tensor from a base-model snapshot: ``source`` is a
-    safetensors file or a directory of them (a sharded index is honored)."""
-    backend, load_file, _save, _transpose = _tensor_backend()
-    source = os.fspath(source)
-    candidates = []
-    if os.path.isdir(source):
-        index_path = os.path.join(source, "model.safetensors.index.json")
-        if os.path.exists(index_path):
-            with open(index_path, "r") as f:
-                weight_map = (json.load(f).get("weight_map") or {})
-            shard = weight_map.get(key)
-            if shard is not None:
-                candidates = [os.path.join(source, shard)]
-        if not candidates:
-            candidates = sorted(
-                os.path.join(source, name)
-                for name in os.listdir(source)
-                if name.endswith(".safetensors")
-            )
-    else:
-        candidates = [source]
-    from safetensors import safe_open
-    for path in candidates:
-        with safe_open(path, framework="numpy") as f:
-            if key not in f.keys():
-                continue
-        tensors = load_file(path)
-        return tensors[key]
-    raise ValueError(
-        f"Unsloth MLX: base_weights_source {source!r} does not contain "
-        f"{key!r}; cannot emit the auto-saved embedding weights."
-    )
-
-
-def convert_mlx_dir_to_peft(src, dst, module_types=None,
-                            base_weights_source=None, strip_prefix=None):
+def convert_mlx_dir_to_peft(src, dst, module_types=None):
     """Convert an mlx-lm adapter directory to a PEFT LoRA directory.
 
-    ``module_types`` optionally maps module paths to ``"linear"`` /
-    ``"embedding"``. An entry asserts what a weights file cannot establish:
-    the module's type on the live base, that the base does not route tied
-    output logits through it (see export_peft_adapter's base_config check),
-    and that the same dotted path exists in the Hugging Face tree — mlx-lm
-    renames some roots (GPT-2's ``model.h.*`` vs HF's ``transformer.h.*``), so
-    a mis-asserted path yields an adapter peft cannot bind. Directory-only
-    conversion also cannot verify full-state completeness the way a live tree
-    can (attach refuses truncated snapshots and walks every module a selector
-    matches), and a composite modules_to_save entry re-exports as its wrapped
-    submodules, which peft restores with identical state and trainability.
-    Without the map, only root-anchored ``model.layers.N.`` paths convert —
-    the one layout where mlx-lm mirrors the HF tree and every LoRA target is a
-    Linear — and
-    anything else is refused, pointing at the MLX-format fallback rather than
-    at this map, which only a caller able to make those assertions can supply.
+    ``module_types`` optionally declares LoRA target paths as ``"linear"``.
+    Such an entry asserts what a weights file cannot: that the same dotted
+    path exists in the Hugging Face tree. mlx-lm renames some roots (GPT-2's
+    ``model.h.*`` vs HF's ``transformer.h.*``), so a mis-asserted path yields
+    an adapter peft cannot bind. Without the map only root-anchored
+    ``model.layers.N.`` paths convert and anything else is refused.
     """
     for _path, _kind in (module_types or {}).items():
-        if _kind not in ("linear", "embedding"):
+        if _kind != "linear":
             raise ValueError(
                 f"Unsloth MLX: module_types[{_path!r}]={_kind!r}; expected "
-                "'linear' or 'embedding'."
+                "'linear'."
             )
     # Raises on a both-formats directory; the source must be unambiguous.
     detect_adapter_format(src)
@@ -6944,13 +6855,10 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
             f"Unsloth MLX: fine_tune_type={cfg.get('fine_tune_type')!r} "
             "adapters cannot be exported to PEFT format."
         )
-    if strip_prefix is None:
-        strip_prefix = cfg.get("unsloth_mlx_tree_prefix") or ""
     fs_origins = dict(cfg.get("full_state_modules") or {})
-    # PEFT expresses trainable module state ONLY as modules_to_save, and no
-    # module can be both a LoRA target and a modules_to_save entry, so a
-    # trainable auto-saved replacement has no faithful PEFT form; refuse rather
-    # than emit an artifact whose reload silently freezes it.
+    # PEFT expresses trainable module state only as modules_to_save, which
+    # cannot coexist with a LoRA target on one module, so a trainable
+    # auto-saved replacement has no faithful PEFT form.
     _trainable_auto = sorted(
         p for p in (cfg.get("full_state_trainable") or [])
         if fs_origins.get(p) != "modules_to_save"
@@ -6958,68 +6866,19 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
     if _trainable_auto:
         raise ValueError(
             f"Unsloth MLX: {_trainable_auto} carry trainable auto-saved "
-            "full-module state, which PEFT cannot represent (its trainable "
-            "module state is modules_to_save, which cannot coexist with a "
-            "LoRA target on the same module). Export the MLX adapter "
-            "instead."
+            "full-module state, which PEFT cannot represent. Export the MLX "
+            "adapter instead."
         )
-    _bad_origins = {
-        p: o for p, o in fs_origins.items()
-        if o not in ("modules_to_save", "embedding_auto")
-    }
-    if _bad_origins:
-        raise ValueError(
-            f"Unsloth MLX: full_state_modules carries unknown origin "
-            f"tag(s) {_bad_origins}; expected 'modules_to_save' or "
-            "'embedding_auto'."
-        )
+    _validate_full_state_origins(fs_origins)
     tensors = load_file(os.path.join(src, MLX_WEIGHTS_FILE))
-    if strip_prefix:
-        # An mlx-vlm tree nests the text tower one level deeper than the HF
-        # model it mirrors; normalize every keyed map to HF-native paths so the
-        # adapter binds in peft. A key without the nesting is left alone for the
-        # layout gate below rather than silently renamed.
-        def _unnest(key):
-            return key[len(strip_prefix):] if key.startswith(strip_prefix) else key
-
-        def _unnest_map(mapping, what):
-            out = {}
-            for key, value in mapping.items():
-                unnested = _unnest(key)
-                if unnested in out:
-                    raise ValueError(
-                        f"Unsloth MLX: unnesting {strip_prefix!r} collapses "
-                        f"{what} {key!r} onto {unnested!r}; the artifact "
-                        "carries entries for more than one tower, which a "
-                        "single PEFT adapter cannot represent."
-                    )
-                out[unnested] = value
-            return out
-
-        tensors = _unnest_map(tensors, "tensor")
-        fs_origins = _unnest_map(fs_origins, "full-state entry")
-        for _key in (
-            "unsloth_mlx_lora_module_scales", "unsloth_mlx_lora_module_ranks",
-        ):
-            if isinstance(cfg.get(_key), dict):
-                cfg[_key] = _unnest_map(cfg[_key], _key)
-        if isinstance(cfg.get("full_state_trainable"), list):
-            cfg["full_state_trainable"] = [
-                _unnest(k) for k in cfg["full_state_trainable"]
-            ]
     pairs = {}
     rejected = {}
     full_state_out = {}
     for key, tensor in tensors.items():
         fsm = re.match(r"^(.+)\.(weight|bias)$", key)
         if fsm is not None:
-            _fs_path = fsm.group(1)
-            # Wrapped modules persist their base under .embedding/.linear.
-            for _inner in (".embedding", ".linear"):
-                if _fs_path.endswith(_inner) and _fs_path[: -len(_inner)] in fs_origins:
-                    _fs_path = _fs_path[: -len(_inner)]
-                    break
-            if _fs_path in fs_origins:
+            _fs_path = _full_state_owner(fsm.group(1), fs_origins)
+            if _fs_path is not None:
                 if not _is_float_dtype(tensor):
                     raise ValueError(
                         f"Unsloth MLX: {key} holds non-floating "
@@ -7028,11 +6887,7 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
                     )
                 _slot = full_state_out.setdefault(_fs_path, {})
                 _prev = _slot.get(fsm.group(2))
-                if _prev is not None and (
-                    tuple(_prev.shape) != tuple(tensor.shape)
-                    or _prev.dtype != tensor.dtype
-                    or not bool((_prev == tensor).all())
-                ):
+                if _prev is not None and not _tensors_equal(_prev, tensor):
                     raise ValueError(
                         f"Unsloth MLX: {key} disagrees with another "
                         "spelling of the same module tensor; the adapter "
@@ -7048,36 +6903,20 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
         if m is None:
             rejected[key] = (
                 "not a LoRA/DoRA adapter tensor for this artifact's "
-                "fine_tune_type; full-weight/embedding state cannot be "
-                "exported, and a stray magnitude means the flag and "
-                "weights disagree"
+                "fine_tune_type; full-weight state cannot be exported"
             )
             continue
-        # Embedding LoRA shares the lora_a/lora_b key shape but PEFT stores it
-        # as lora_embedding_A/B, and a weights file alone cannot tell an
-        # Embedding from a Linear. An explicit module_types entry wins; else
-        # only the root-anchored stack below converts, where every LoRA target
-        # is a Linear, and anything else is refused rather than guessed.
         path = m.group(1)
-        declared = (module_types or {}).get(path)
-        if declared == "embedding":
-            pairs.setdefault(path, {})[m.group(2)] = tensor
-            pairs[path]["embedding"] = True
-            continue
-        if declared is None and re.match(
-            # Root-anchored `model.layers.N.` only: that is the layout mlx-lm
-            # mirrors from HF, so emitted paths bind in peft. GPT-2-style stacks
-            # rename roots (`model.h.*` vs HF `transformer.h.*`) and VLM
-            # wrappers reorder them (`language_model.model.layers.*` vs HF
-            # `model.language_model.layers.*`), so any unanchored heuristic
-            # would emit adapters peft cannot load.
+        if (module_types or {}).get(path) is None and re.match(
+            # Root-anchored `model.layers.N.` only: the layout mlx-lm mirrors
+            # from HF, so emitted paths bind in peft. GPT-2-style stacks rename
+            # roots, so an unanchored heuristic would emit unloadable adapters.
             r"^model\.layers\.\d+\.", path
         ) is None:
             rejected[key] = (
-                "outside a Hugging-Face-mirroring transformer stack, so its "
-                "Hugging Face path cannot be confirmed and PEFT export could "
-                "emit an adapter that binds to nothing — save this adapter "
-                "in MLX format instead"
+                "outside a Hugging-Face-mirroring transformer stack, so PEFT "
+                "export could emit an adapter that binds to nothing — save "
+                "this adapter in MLX format instead"
             )
             continue
         pairs.setdefault(path, {})[m.group(2)] = tensor
@@ -7115,21 +6954,7 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
             "exported; peft and mlx-lm apply DoRA dropout with different "
             "training-mode formulas."
         )
-    _emb_export = sorted(p for p in pairs if pairs[p].get("embedding"))
-    if _emb_export and dropout > 0:
-        raise ValueError(
-            f"Unsloth MLX: {_emb_export} carry embedding LoRA with nonzero "
-            "lora_dropout; peft applies no dropout on embedding adapters, "
-            "so exporting would silently change training behavior."
-        )
     _mag_paths = {p for p, v in pairs.items() if "m_vec" in v}
-    _emb_mags = sorted(p for p in _mag_paths if pairs[p].get("embedding"))
-    if _emb_mags:
-        raise ValueError(
-            f"Unsloth MLX: {_emb_mags} carry DoRA magnitudes on embedding "
-            "modules; peft and mlx-lm decompose embedding DoRA "
-            "incompatibly, so it cannot be exported."
-        )
     if _ft == "dora" and _mag_paths != set(pairs):
         raise ValueError(
             "Unsloth MLX: DoRA magnitudes present on only some modules; "
@@ -7138,43 +6963,19 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
         )
     for path in sorted(pairs):
         a, b = pairs[path]["a"], pairs[path]["b"]
-        if getattr(a, "ndim", 0) != 2 or getattr(b, "ndim", 0) != 2:
-            raise ValueError(
-                f"Unsloth MLX: {path} carries non-2-D LoRA factors "
-                f"(lora_a ndim={getattr(a, 'ndim', '?')}, "
-                f"lora_b ndim={getattr(b, 'ndim', '?')}); switch/MoE LoRA "
-                "cannot be exported to PEFT format yet."
-            )
-        rank = int(a.shape[1])
-        if int(b.shape[0]) != rank:
-            raise ValueError(
-                f"Unsloth MLX: {path} has lora_a rank {rank} but lora_b "
-                f"rank {int(b.shape[0])}; the adapter file is inconsistent."
-            )
-        # mlx-lm uses the same [in,r]/[r,out] layout for embedding and linear,
-        # so only peft's key names differ (lora_embedding_* has no .weight).
-        if pairs[path].get("embedding"):
-            out[f"{_PEFT_PREFIX}{path}.lora_embedding_A"] = transpose(a)
-            out[f"{_PEFT_PREFIX}{path}.lora_embedding_B"] = transpose(b)
-        else:
-            out[f"{_PEFT_PREFIX}{path}.lora_A.weight"] = transpose(a)
-            out[f"{_PEFT_PREFIX}{path}.lora_B.weight"] = transpose(b)
+        rank = _lora_pair_rank(path, a, b, 1)
+        out[f"{_PEFT_PREFIX}{path}.lora_A.weight"] = transpose(a)
+        out[f"{_PEFT_PREFIX}{path}.lora_B.weight"] = transpose(b)
         if "m_vec" in pairs[path]:
             _mv = pairs[path]["m_vec"]
-            if getattr(_mv, "ndim", 0) != 1 or int(_mv.shape[0]) != int(b.shape[1]):
-                raise ValueError(
-                    f"Unsloth MLX: {path} DoRA magnitude shape "
-                    f"{tuple(getattr(_mv, 'shape', ()))} does not match the "
-                    f"module out-dim {int(b.shape[1])}."
-                )
+            _check_dora_magnitude(path, _mv, int(b.shape[1]))
             # peft's on-disk form has no .weight suffix (stripped at save).
             out[f"{_PEFT_PREFIX}{path}.lora_magnitude_vector"] = _mv
         ranks[path] = rank
         scale = float(scale_map.get(path, global_scale))
         alphas[path] = scale * rank
-    # Modal values minimize pattern entries; peft's matcher
-    # re.match(r"(.*\.)?(key)$", name) is ^-anchored, giving exact-path
-    # semantics so overlapping dotted suffixes cannot shadow.
+    # Modal values minimize pattern entries; peft's ^-anchored matcher gives
+    # exact-path semantics, so overlapping dotted suffixes cannot shadow.
     from collections import Counter
     ref_rank = Counter(ranks.values()).most_common(1)[0][0]
     ref_alpha = Counter(alphas.values()).most_common(1)[0][0]
@@ -7187,10 +6988,9 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
         "bias": "none",
         "use_rslora": False,
         "use_dora": _ft == "dora",
-        # Full module paths, matched exactly by peft's list semantics. Leaf
-        # names would suffix-match EVERY layer's projection, so a layer-subset
-        # adapter would grow zero-initialized extras and train a different
-        # topology.
+        # Full module paths, matched exactly by peft's list semantics: leaf
+        # names would suffix-match every layer's projection, growing a
+        # layer-subset adapter into a different topology.
         "target_modules": sorted(ranks),
         "base_model_name_or_path": cfg.get("base_model_name_or_path", ""),
     }
@@ -7220,154 +7020,38 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None,
     if _m2s_list:
         peft_cfg["modules_to_save"] = _m2s_list
     for _p, _entries in sorted(full_state_out.items()):
-        # peft's on-disk forms: plain {path}.{tensor} for modules_to_save
-        # snapshots and untargeted auto-saved embeddings (the infix is stripped
-        # at save), but a LoRA-wrapped module's base state sits under the
-        # wrapper's .base_layer path, since a plain key would not bind.
+        # peft's on-disk forms: plain {path}.{tensor} for snapshots and
+        # untargeted auto-saved embeddings, but a LoRA-wrapped module's base
+        # state sits under .base_layer, since a plain key would not bind.
         _wrapped = _p in pairs
         for _tname, _tensor in sorted(_entries.items()):
             if _wrapped:
                 out[f"{_PEFT_PREFIX}{_p}.base_layer.{_tname}"] = _tensor
             else:
                 out[f"{_PEFT_PREFIX}{_p}.{_tname}"] = _tensor
-    _unsourced_emb = sorted(
-        p for p in pairs
-        if pairs[p].get("embedding") and p not in full_state_out
-    )
-    if _unsourced_emb and base_weights_source is not None:
-        for _p in _unsourced_emb:
-            _w = _load_base_weight(base_weights_source, f"{_p}.weight")
-            _want = (int(pairs[_p]["a"].shape[0]), int(pairs[_p]["b"].shape[1]))
-            _got = tuple(int(x) for x in getattr(_w, "shape", ()))
-            if _got != _want or not _is_float_dtype(_w):
-                raise ValueError(
-                    f"Unsloth MLX: base_weights_source weight for {_p} has "
-                    f"shape {_got} / dtype {getattr(_w, 'dtype', '?')}; the "
-                    f"adapter factors imply a float {_want} embedding. The "
-                    "source does not match the adapter's base model."
-                )
-            out[f"{_PEFT_PREFIX}{_p}.base_layer.weight"] = _w
-    # An embedding adapter exported without base_weights_source simply omits
-    # those weights; peft resolves them from the base model. Nothing is logged
-    # here on purpose -- this module stays importable and usable without torch,
-    # and the shared logger pulls in a torch-importing module on first use.
-    # Same stage-then-atomic-rename destination contract as
-    # convert_peft_dir_to_mlx; see the note there.
-    dst = os.fspath(dst)
-    _require_fresh_destination(dst.rstrip(os.sep) or dst)
-    dst = os.path.realpath(dst)
-    _require_fresh_destination(dst)
-    os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
-    _tmp = f"{dst}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
-    _tmp_created = False
-    try:
-        os.makedirs(_tmp)
-        _tmp_created = True
-        save_file(os.path.join(_tmp, PEFT_WEIGHTS_FILE), out)
-        with open(os.path.join(_tmp, "adapter_config.json"), "w") as f:
-            json.dump(peft_cfg, f, indent=2, sort_keys=True)
-        try:
-            os.rename(_tmp, dst)
-        except OSError as exc:
-            raise ValueError(
-                f"Unsloth MLX: destination {dst!r} appeared concurrently "
-                "and is not empty; refusing to mix adapter artifacts."
-            ) from exc
-    finally:
-        if _tmp_created:
-            shutil.rmtree(_tmp, ignore_errors=True)
-    return dst
+    return _publish_adapter_dir(dst, PEFT_WEIGHTS_FILE, out, peft_cfg, save_file)
 
 
-def export_peft_adapter(src, dst, *, base_config=None, module_types=None,
-                        base_weights_source=None):
+def export_peft_adapter(src, dst, *, base_config=None, module_types=None):
     """Public wrapper: convert an mlx-lm adapter directory to PEFT format.
 
     ``module_types`` follows convert_mlx_dir_to_peft. ``base_config`` adds the
-    tie_word_embeddings check for embedding exports, since a tied model routes
-    output logits through the embedding adapter in mlx-lm but not in peft.
-    ``base_weights_source`` (a safetensors file or snapshot directory) supplies
-    the PEFT-convention auto-saved embedding weights when the adapter targets
-    an embedding; without it they are omitted, which PEFT loads cleanly by
-    resolving embeddings from the base model.
+    tie_word_embeddings check that a modules_to_save snapshot of a tied
+    embedding cannot be exported.
     """
     if base_config is not None and _config_ties_word_embeddings(base_config):
         try:
             with open(os.path.join(os.fspath(src), "adapter_config.json")) as _f:
-                _src_fs = dict(
-                    (json.load(_f).get("full_state_modules") or {})
-                )
+                _src_fs = dict(json.load(_f).get("full_state_modules") or {})
         except OSError:
             _src_fs = {}
-        _vocab = None
-        for _scope in ((base_config or {}).get("text_config") or {},
-                       base_config or {}):
-            if isinstance(_scope, dict) and _scope.get("vocab_size"):
-                _vocab = int(_scope["vocab_size"])
-                break
-        _shapes = {}
-        if _src_fs:
-            try:
-                from safetensors import safe_open
-                with safe_open(
-                    os.path.join(os.fspath(src), MLX_WEIGHTS_FILE),
-                    framework="numpy",
-                ) as _f:
-                    _keys = set(_f.keys())
-                    for _p in _src_fs:
-                        for _k in (
-                            f"{_p}.weight",
-                            f"{_p}.embedding.weight",
-                            f"{_p}.linear.weight",
-                        ):
-                            if _k in _keys:
-                                _shapes[_p] = tuple(
-                                    _f.get_slice(_k).get_shape()
-                                )
-                                break
-            except OSError:
-                pass
-
-        def _looks_like_embedding(p):
-            shape = _shapes.get(p)
-            if (
-                _vocab is not None
-                and shape is not None
-                and len(shape) == 2
-                and int(shape[0]) == _vocab
-            ):
-                return True
-            return p.rsplit(".", 1)[-1] in (
-                _EMBEDDING_LEAF_NAMES + _OUTPUT_HEAD_LEAF_NAMES
-            )
-
         _m2s_emb = sorted(
             p for p, o in _src_fs.items()
-            if o == "modules_to_save" and _looks_like_embedding(p)
+            if o == "modules_to_save"
+            and _names_embedding_or_head(p)
         )
         if _m2s_emb:
             raise ValueError(
-                f"Unsloth MLX: {_m2s_emb} are modules_to_save replacements "
-                "of a tied embedding; peft would train an untied input "
-                "copy while the tied MLX embedding also projects output "
-                "logits, so no faithful export exists."
+                f"Unsloth MLX: {_m2s_emb} carry {_TIED_FULL_STATE_REASON}."
             )
-    _emb_declared = sorted(
-        p for p, t in (module_types or {}).items() if t == "embedding"
-    )
-    # The tie check is opt-in: without base_config there is no config to test,
-    # and a module_types entry already carries the caller's tied-routing
-    # assertion. An ABSENT key inside a provided config still means tied.
-    if _emb_declared and base_config is not None and (
-        _config_ties_word_embeddings(base_config)
-    ):
-        raise ValueError(
-            f"Unsloth MLX: {_emb_declared} carry embedding LoRA but the "
-            "base model ties word embeddings; mlx-lm applies the update "
-            "to the tied output projection while peft applies it to "
-            "input lookup only, so no faithful export exists."
-        )
-    return convert_mlx_dir_to_peft(
-        src, dst, module_types=module_types,
-        base_weights_source=base_weights_source,
-    )
+    return convert_mlx_dir_to_peft(src, dst, module_types=module_types)

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -6064,9 +6064,10 @@ pass
 #
 # Conversion is rename + transpose only; dtypes are preserved exactly and a
 # round trip is bitwise-identical for the supported subset (plain linear
-# LoRA). Adapters carrying DoRA magnitudes, modules_to_save state, embedding
-# LoRA, or expert target_parameters factors are refused with a named reason
-# instead of being partially or lossily converted. Tensor IO prefers
+# LoRA). Linear DoRA converts (magnitude <-> m, numerically verified);
+# modules_to_save state, embedding LoRA, and expert target_parameters
+# factors are refused with a named reason instead of being partially or
+# lossily converted. Tensor IO prefers
 # mlx.core (native bfloat16) with a safetensors.torch fallback off Apple
 # hardware; the safetensors numpy backend cannot represent bf16.
 # ---------------------------------------------------------------------------
@@ -6160,7 +6161,18 @@ _PEFT_HANDLED_KEYS = {
     "peft_type", "r", "lora_alpha", "use_rslora", "lora_dropout",
     "target_modules", "base_model_name_or_path", "revision",
     "rank_pattern", "alpha_pattern", "layers_to_transform", "layers_pattern",
+    # Linear DoRA converts (magnitude <-> m); embedding DoRA refuses later.
+    "use_dora",
 }
+# peft applies DoRA dropout inside the correction term, mlx-lm scales
+# base-plus-dropped-update together: continued training would diverge.
+def _reject_dora_dropout(cfg):
+    if cfg.get("use_dora") and float(cfg.get("lora_dropout") or 0.0) > 0:
+        raise ValueError(
+            "Unsloth MLX: use_dora with nonzero lora_dropout cannot be "
+            "converted; peft and mlx-lm apply DoRA dropout with different "
+            "training-mode formulas. Zero the dropout before converting."
+        )
 _PEFT_NEUTRAL_KEYS = {
     "task_type", "inference_mode", "init_lora_weights", "peft_version",
     "auto_mapping", "fan_in_fan_out", "exclude_modules",
@@ -6173,7 +6185,6 @@ _PEFT_NEUTRAL_KEYS = {
     "megatron_core",
 }
 _PEFT_REJECTED_KEYS = {
-    "use_dora": "DoRA adapters are not supported on the MLX backend yet",
     "modules_to_save": "modules_to_save (full-weight modules) is not "
                        "supported on the MLX backend yet",
     "target_parameters": "expert-parameter (MoE) LoRA is not supported on "
@@ -6213,6 +6224,7 @@ def normalize_peft_adapter_config(cfg, adapter_dir=None):
             f"Unsloth MLX: only peft_type='LORA' adapters can be imported; "
             f"got {cfg.get('peft_type')!r}."
         )
+    _reject_dora_dropout(cfg)
     if cfg.get("bias") not in (None, "none"):
         raise ValueError(
             "Unsloth MLX: PEFT LoRA bias terms (bias="
@@ -6294,8 +6306,12 @@ def group_peft_lora_pairs(tensors):
         if ".lora_embedding_" in key:
             rejected[key] = "embedding LoRA is not supported on MLX yet"
             continue
-        if ".lora_magnitude_vector" in key:
-            rejected[key] = "DoRA magnitudes are not supported on MLX yet"
+        mag = re.match(
+            rf"^{re.escape(_PEFT_PREFIX)}(.+)\.lora_magnitude_vector(?:\.weight)?$",
+            key,
+        )
+        if mag is not None:
+            pairs.setdefault(mag.group(1), {})["M"] = tensor
             continue
         m = re.match(
             rf"^{re.escape(_PEFT_PREFIX)}(.+)\.lora_(A|B)\.weight$", key
@@ -6305,11 +6321,20 @@ def group_peft_lora_pairs(tensors):
             continue
         path, which = m.group(1), m.group(2)
         pairs.setdefault(path, {})[which] = tensor
+    has_mag = {p for p, v in pairs.items() if "M" in v}
     for path, pair in pairs.items():
         if "A" not in pair or "B" not in pair:
             rejected[f"{_PEFT_PREFIX}{path}.lora_*"] = (
                 "incomplete lora_A/lora_B pair"
             )
+    # use_dora is global: a partial magnitude set means file and config
+    # disagree about what the adapter is.
+    if has_mag and len(has_mag) != len(pairs):
+        rejected[f"{_PEFT_PREFIX}<mixed>.lora_magnitude_vector"] = (
+            "magnitudes present on only some modules; peft DoRA is all-or-"
+            "nothing"
+        )
+        pairs = {}
     pairs = {p: v for p, v in pairs.items() if "A" in v and "B" in v}
     return pairs, rejected
 
@@ -6381,13 +6406,33 @@ def convert_peft_dir_to_mlx(src, dst, base_config):
             )
         out[f"{path}.lora_a"] = transpose(a)
         out[f"{path}.lora_b"] = transpose(b)
+        mag = pairs[path].get("M")
+        if cfg.get("use_dora") and mag is None:
+            raise ValueError(
+                f"Unsloth MLX: use_dora is set but {path} has no magnitude "
+                "vector; the config and weights disagree."
+            )
+        if mag is not None and not cfg.get("use_dora"):
+            raise ValueError(
+                f"Unsloth MLX: {path} carries a DoRA magnitude but the "
+                "config does not set use_dora; the artifact is inconsistent."
+            )
+        if mag is not None:
+            if getattr(mag, "ndim", 0) != 1 or int(mag.shape[0]) != int(b.shape[0]):
+                raise ValueError(
+                    f"Unsloth MLX: {path} magnitude shape "
+                    f"{tuple(getattr(mag, 'shape', ()))} does not match the "
+                    f"module out-dim {int(b.shape[0])}."
+                )
+            out[f"{path}.m"] = mag
         ranks[path] = rank
         scales[path] = _effective_scale(cfg, path, rank)
     uniform_rank = len(set(ranks.values())) == 1
     uniform_scale = len(set(scales.values())) == 1
     any_path = next(iter(sorted(ranks)))
+    _is_dora = bool(cfg.get("use_dora"))
     mlx_cfg = {
-        "fine_tune_type": "lora",
+        "fine_tune_type": "dora" if _is_dora else "lora",
         "peft_type": "LORA",
         "num_layers": _num_hidden_layers(base_config),
         "base_model_name_or_path": cfg.get("base_model_name_or_path", ""),
@@ -6482,11 +6527,11 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
     backend, load_file, save_file, transpose = _tensor_backend()
     with open(os.path.join(src, "adapter_config.json"), "r") as f:
         cfg = json.load(f)
-    if str(cfg.get("fine_tune_type", "lora")).lower() != "lora":
+    _ft = str(cfg.get("fine_tune_type", "lora")).lower()
+    if _ft not in ("lora", "dora"):
         raise ValueError(
             f"Unsloth MLX: fine_tune_type={cfg.get('fine_tune_type')!r} "
-            "adapters cannot be exported to PEFT format yet; only plain "
-            "LoRA is supported."
+            "adapters cannot be exported to PEFT format."
         )
     if cfg.get("full_state_modules"):
         raise ValueError(
@@ -6498,11 +6543,17 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
     pairs = {}
     rejected = {}
     for key, tensor in tensors.items():
+        magm = re.match(r"^(.+)\.m$", key)
+        if magm is not None and str(cfg.get("fine_tune_type", "")).lower() == "dora":
+            pairs.setdefault(magm.group(1), {})["m_vec"] = tensor
+            continue
         m = re.match(r"^(.+)\.lora_(a|b)$", key)
         if m is None:
             rejected[key] = (
-                "not a plain LoRA tensor; DoRA/full-weight/embedding state "
-                "cannot be exported to PEFT format yet"
+                "not a LoRA/DoRA adapter tensor for this artifact's "
+                "fine_tune_type; full-weight/embedding state cannot be "
+                "exported, and a stray magnitude means the flag and "
+                "weights disagree"
             )
             continue
         # Embedding LoRA shares the lora_a/lora_b key shape but PEFT stores it
@@ -6550,6 +6601,19 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
 
     out = {}
     ranks, alphas = {}, {}
+    if _ft == "dora" and dropout > 0:
+        raise ValueError(
+            "Unsloth MLX: DoRA adapters with nonzero dropout cannot be "
+            "exported; peft and mlx-lm apply DoRA dropout with different "
+            "training-mode formulas."
+        )
+    _mag_paths = {p for p, v in pairs.items() if "m_vec" in v}
+    if _ft == "dora" and _mag_paths != set(pairs):
+        raise ValueError(
+            "Unsloth MLX: DoRA magnitudes present on only some modules; "
+            "peft applies use_dora globally, so a partial set cannot be "
+            "exported."
+        )
     for path in sorted(pairs):
         a, b = pairs[path]["a"], pairs[path]["b"]
         if getattr(a, "ndim", 0) != 2 or getattr(b, "ndim", 0) != 2:
@@ -6567,6 +6631,16 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
             )
         out[f"{_PEFT_PREFIX}{path}.lora_A.weight"] = transpose(a)
         out[f"{_PEFT_PREFIX}{path}.lora_B.weight"] = transpose(b)
+        if "m_vec" in pairs[path]:
+            _mv = pairs[path]["m_vec"]
+            if getattr(_mv, "ndim", 0) != 1 or int(_mv.shape[0]) != int(b.shape[1]):
+                raise ValueError(
+                    f"Unsloth MLX: {path} DoRA magnitude shape "
+                    f"{tuple(getattr(_mv, 'shape', ()))} does not match the "
+                    f"module out-dim {int(b.shape[1])}."
+                )
+            # peft's on-disk form has no .weight suffix (stripped at save).
+            out[f"{_PEFT_PREFIX}{path}.lora_magnitude_vector"] = _mv
         ranks[path] = rank
         scale = float(scale_map.get(path, global_scale))
         alphas[path] = scale * rank
@@ -6584,6 +6658,7 @@ def convert_mlx_dir_to_peft(src, dst, module_types=None):
         "lora_dropout": dropout,
         "bias": "none",
         "use_rslora": False,
+        "use_dora": _ft == "dora",
         # Full module paths, matched exactly by peft's list semantics. Leaf
         # names would suffix-match EVERY layer's projection, so a layer-subset
         # adapter would grow zero-initialized extras and train a different

--- a/unsloth_zoo/saving_utils.py
+++ b/unsloth_zoo/saving_utils.py
@@ -6179,6 +6179,8 @@ def _reject_dora_dropout(cfg):
             "training-mode formulas. Zero the dropout before converting."
         )
 _PEFT_NEUTRAL_KEYS = {
+    # task_type is checked explicitly above; listed here so the unknown-field
+    # sweep does not reject the CAUSAL_LM value that check accepts.
     "task_type", "inference_mode", "init_lora_weights", "peft_version",
     "auto_mapping", "fan_in_fan_out", "exclude_modules",
     # EVA redistributes ranks/alphas through the supported pattern fields and
@@ -6222,10 +6224,23 @@ def normalize_peft_adapter_config(cfg, adapter_dir=None):
     ValueError naming the first unsupported field, so an adapter is refused
     before the expensive base-model load.
     """
-    if str(cfg.get("peft_type", "")).upper() != "LORA":
+    # A dict straight from LoraConfig.to_dict() carries peft's enums, whose
+    # str() is "PeftType.LORA"; adapter JSON carries the bare value.
+    peft_type = cfg.get("peft_type", "")
+    if str(getattr(peft_type, "value", peft_type)).upper() != "LORA":
         raise ValueError(
             f"Unsloth MLX: only peft_type='LORA' adapters can be imported; "
             f"got {cfg.get('peft_type')!r}."
+        )
+    # The MLX backend builds a causal language model, so an adapter trained
+    # for another task would attach its backbone factors and then answer with
+    # vocabulary logits instead of what it was trained to produce.
+    task_type = cfg.get("task_type")
+    task_type = getattr(task_type, "value", task_type)
+    if task_type is not None and str(task_type).upper() != "CAUSAL_LM":
+        raise ValueError(
+            f"Unsloth MLX: task_type={task_type!r} adapters cannot be "
+            "imported; the MLX backend serves CAUSAL_LM only."
         )
     _reject_dora_dropout(cfg)
     if cfg.get("bias") not in (None, "none"):


### PR DESCRIPTION
## What this does

LoRA adapters could not cross between Apple silicon and CUDA machines. An adapter trained with PEFT on a GPU box could not be loaded by the MLX backend, and an adapter trained on MLX could not be loaded by `transformers`/PEFT anywhere else. This adds conversion in both directions, so the same LoRA can be trained on one platform and continued or served on the other.

Two entry points change behaviour:

- `FastMLXModel.from_pretrained(<peft adapter dir>)` now imports PEFT adapters directly, attaching and binding them onto the live MLX tree.
- `save_lora_adapters(model, path, adapter_format="peft")` writes a standard Hugging Face adapter. The default stays `"mlx"`, so training checkpoints and every existing caller are untouched.

## Supported and refused

Converted: plain linear LoRA, linear DoRA (the magnitude vector maps to mlx-lm's `m`), per-module `rank_pattern`/`alpha_pattern`, rsLoRA scaling, and full-module state — both `modules_to_save` snapshots and PEFT's auto-saved embeddings, tracked through an origin-tagged map so a save round-trips them with the right trainability. That last one matters more than it sounds: PEFT's default `save_embedding_layers="auto"` turns itself on whenever the vocabulary was resized during finetuning, so any adapter trained after adding chat-template or special tokens carries it.

Refused by name, rather than partially or lossily converted: embedding LoRA (`lora_embedding_A/B`), expert `target_parameters` factors, LoRA wrappers plain PEFT cannot represent, and any config field carrying semantics this converter does not implement. That last one is deliberate — an unknown non-empty field is refused rather than ignored, so for example an aLoRA adapter cannot silently import as an always-on LoRA.

Embedding LoRA is refused rather than converted because it has no faithful form on a tied base: mlx-lm applies the update to the tied output projection while PEFT applies it to input lookup only. Most small on-device models tie, so the majority of real targets could not have been served correctly. mlx-lm's own native embedding-LoRA training is untouched; only PEFT interop for it is out of scope here.

## How the mapping works

The two formats encode the same math in different layouts:

```text
peft {p}.lora_A.weight [r, in]   ==  mlx {p}.lora_a [in, r], transposed
peft {p}.lora_B.weight [out, r]  ==  mlx {p}.lora_b [r, out], transposed
effective scale = lora_alpha / r     (rsLoRA: lora_alpha / sqrt(r))
```

Conversion is rename plus transpose only, so dtypes are preserved exactly and a round trip is bitwise identical for the supported subset. This is measured, not assumed — see the validation section.

Three design points are worth a reviewer's attention.

**Auto-saved base state is admitted only for the two modules PEFT actually auto-saves.** PEFT emits full base weights for the input embedding and the output head, spelled `<path>.base_layer.<tensor>` when the module is LoRA-wrapped. Every LoRA target has a `.base_layer`, so accepting that spelling unconditionally let an adapter carrying full state on an ordinary projection silently replace its base weights — reproduced as a `q_proj` weight going from norm 1.3166 to 0 with no error. Admission is now gated on a path predicate over the Hugging Face namespace, where those two modules have a small fixed set of spellings. Some of those leaves are reused deeper in the tree (hf_olmo names both its root head and every block's MLP output `ff_out`, and `output` also spells an attention projection), so a path through a numbered layer is never one of them.

**Tied bases fold the auto-saved head away.** On a tied model the auto-saved output head *is* the embedding weight, so emitting it would restore a duplicate the MLX tree may not even carry. Both the directory converter and the live attach verify the head snapshot against the embedding and fold it, refusing when it does not duplicate it — a tied model has no independent head to bind it to.

**Directory-only conversion is conservative about paths.** Without a caller-supplied `module_types` map it converts only root-anchored `model.layers.N.` paths, the one layout where mlx-lm mirrors the Hugging Face tree. GPT-2-style stacks rename roots (`model.h.*` versus `transformer.h.*`), so an unanchored heuristic would emit adapters PEFT cannot bind.

Adapter directories are published by staging into a unique sibling directory and renaming once, so a reader never observes a partial adapter and a crash leaves either nothing or the complete artifact.

## Validation

Beyond the tests added here, the loop was driven end to end on real hardware between an Apple silicon host and a CUDA host, in four orderings, on `Qwen/Qwen3-0.6B`:

| Order | Path | Result |
|---|---|---|
| A | CUDA train → MLX import → MLX train → PEFT export → CUDA load | pass |
| B | Mac train from scratch → PEFT export → CUDA load → CUDA train → MLX reimport | pass |
| C | Two full cycles of A on the same adapter | pass |
| D | CUDA train → MLX import → native MLX save/reload → MLX train → PEFT export → CUDA load | pass |

Agreement at every hop was top-5 5/5 and correlation ≥ 0.9996 on held-out probe logits (both sides bf16, so exact equality is not the right bar; one hop showed 4/5 from a near-tie reordering).

Import→export is bitwise lossless: identical key sets and worst per-tensor drift `0.000e+00` across a full crossing.

The same matrix was also run on `Qwen/Qwen3.5-0.8B`, which routes through mlx-vlm and nests its text tower. Binding through a nested tower was dropped from this PR, so those runs no longer describe shipped behaviour and are not claimed here; such an adapter now hits the named refusal instead. See the scope note below.

Local suites:

```bash
python -m pytest tests/test_mlx_adapter_interop_metal.py -q
# 62 passed
```

The full suite matches the pre-change baseline.

## Notes for reviewers

- Nothing about training or checkpoint output changes. Checkpoints remain MLX-format; `adapter_format` defaults to `"mlx"`.
- **Scope.** Binding a PEFT adapter through a nested vision-language text tower was removed before review. It resolved a nesting *prefix* only, so it reached adapters trained against a standalone text tower but not those trained on a full VLM under transformers ≥ 4.52, which spell the same modules `model.language_model.layers.*` while mlx-vlm mirrors the older `language_model.model.layers.*`. Supporting both means replacing the prefix contract with a bidirectional path mapping across import and export; that is follow-up work, and until then such adapters are refused with each unmapped path named rather than partially bound.
- The `module_types` parameter on `convert_mlx_dir_to_peft` is an assertion interface for callers that can establish what a weights file cannot: that the same dotted path exists in the Hugging Face tree. The live-model export path supplies it from the tree it can see.
- Tied-output detection is `declared-True OR no-head-module`, checking `lm_head`, `output`, and `embed_out` spellings. A declared `True` stays conservative even where a forward would ignore it, because wrongly-admitted full-module state silently changes output logits.
