### PR TITLE
DiffusionGemma: make the visual server's GPU layer split configurable

### DIFF
--- a/tests/test_diffusion_visual_engine_env.py
+++ b/tests/test_diffusion_visual_engine_env.py
@@ -36,8 +36,47 @@ def test_linux_prepends_nvidia_wheels_and_excludes_torch_lib(monkeypatch):
     assert all("torch" not in p for p in ld)       # torch/lib excluded on Linux
     assert env["PATH"] == "/usr/bin"               # PATH untouched on Linux
     assert env["CUDA_VISIBLE_DEVICES"] == "3"
-    assert env["NGL"] == "99"
+    assert env["NGL"] == "99"          # unset -> all layers, the historical default
     assert env["MAXTOK"] == "4096"
+
+
+def test_explicit_ngl_is_forwarded():
+    """A caller-supplied split reaches the child: the whole point of the knob (small-VRAM cards)."""
+    env = V._build_subprocess_env(
+        "/dg/srv", gpu = "0", maxtok = 0, ngl = 8,
+        base_env = {"PATH": "/usr/bin"}, os_name = "posix",
+    )
+    assert env["NGL"] == "8"
+
+
+def test_ngl_zero_is_not_treated_as_unset():
+    """CPU-only must survive the falsiness trap: 0 is a real request, not 'use the default'."""
+    env = V._build_subprocess_env(
+        "/dg/srv", ngl = 0, base_env = {"PATH": "/usr/bin"}, os_name = "posix",
+    )
+    assert env["NGL"] == "0"
+
+
+def test_env_ngl_is_honoured_when_caller_passes_none():
+    """Escape hatch for a user whose studio predates the plumbing."""
+    env = V._build_subprocess_env(
+        "/dg/srv", base_env = {"PATH": "/usr/bin", "NGL": "12"}, os_name = "posix",
+    )
+    assert env["NGL"] == "12"
+
+
+def test_explicit_ngl_beats_env():
+    env = V._build_subprocess_env(
+        "/dg/srv", ngl = 4, base_env = {"PATH": "/usr/bin", "NGL": "99"}, os_name = "posix",
+    )
+    assert env["NGL"] == "4"
+
+
+def test_garbage_env_ngl_falls_back_to_default():
+    env = V._build_subprocess_env(
+        "/dg/srv", base_env = {"PATH": "/usr/bin", "NGL": "all"}, os_name = "posix",
+    )
+    assert env["NGL"] == "99"
 
 
 # Note: paths here are colon-free so the assertions hold regardless of the host's

--- a/unsloth_zoo/diffusion_studio/shim.py
+++ b/unsloth_zoo/diffusion_studio/shim.py
@@ -368,11 +368,15 @@ def main():
     ap.add_argument("--gpu", default=os.environ.get("DG_GPU", "0"))
     ap.add_argument("--maxtok", type=int, default=0,
                     help="per-turn context budget; 0 = auto-size the largest that fits VRAM")
+    ap.add_argument("--ngl", type=int, default=None,
+                    help="layers to offload to GPU; omit for all, 0 for CPU-only. Lower this when "
+                         "the model does not fit VRAM (else the load OOMs in cudaMalloc)")
     args = ap.parse_args()
 
     _STATE["player"] = open(_PLAYER_TEMPLATE).read()
     print(f"loading {args.gguf} on GPU {args.gpu} (optimized visual decoder) ...", flush=True)
-    _STATE["server"] = V.VisualServer(args.gguf, gpu=args.gpu, maxtok=args.maxtok)
+    _STATE["server"] = V.VisualServer(args.gguf, gpu=args.gpu, maxtok=args.maxtok, ngl=args.ngl)
+    print(f"gpu layers (NGL) = {_STATE['server'].ngl}", flush=True)
     print(f"DiffusionGemma OpenAI shim ready on http://{args.host}:{args.port}  (model={MODEL_ID})",
           flush=True)
     uvicorn.run(app, host=args.host, port=args.port, log_level="warning")

--- a/unsloth_zoo/diffusion_studio/visual_engine.py
+++ b/unsloth_zoo/diffusion_studio/visual_engine.py
@@ -138,7 +138,29 @@ def _bundled_cuda_lib_dirs():
     return dirs
 
 
-def _build_subprocess_env(server_bin, gpu = "0", maxtok = 0, base_env = None, os_name = None):
+DEFAULT_NGL = 99
+
+
+def _resolve_ngl(ngl = None, base_env = None):
+    """Layers the child offloads to GPU (its ``NGL`` knob -> llama.cpp ``n_gpu_layers``).
+
+    Explicit caller value wins, then an ``NGL`` already in the environment, else all layers.
+    Both overrides used to be impossible: the value was hardcoded to 99, so a GGUF larger than
+    VRAM died in ``cudaMalloc`` with no way to split it across GPU and RAM, even with studio's
+    GPU-layers set to 0 (unsloth#7574). The server itself defaults to 0 and handles partial
+    offload normally."""
+    if ngl is not None:
+        return max(0, int(ngl))
+    raw = (os.environ if base_env is None else base_env).get("NGL")
+    if raw is not None:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            pass
+    return DEFAULT_NGL
+
+
+def _build_subprocess_env(server_bin, gpu = "0", maxtok = 0, ngl = None, base_env = None, os_name = None):
     """Build the visual-server child env so it loads the CUDA backend, not CPU.
 
     Binary dir first, then bundled CUDA runtime, then the inherited path. Windows: torch/lib
@@ -148,7 +170,7 @@ def _build_subprocess_env(server_bin, gpu = "0", maxtok = 0, base_env = None, os
     name = os.name if os_name is None else os_name
     env = dict(os.environ if base_env is None else base_env)
     env["CUDA_VISIBLE_DEVICES"] = str(gpu)
-    env["NGL"] = "99"
+    env["NGL"] = str(_resolve_ngl(ngl, base_env))
     env["MAXTOK"] = str(maxtok)
 
     bin_dir = os.path.dirname(server_bin)
@@ -180,13 +202,14 @@ def _canvas_maxtok(maxtok):
 class VisualServer:
     """Persistent optimized decoder: send chat messages, stream per-step canvas frames + committed text."""
 
-    def __init__(self, gguf, gpu="0", maxtok=0, server_bin=None, req_path=None):
+    def __init__(self, gguf, gpu="0", maxtok=0, server_bin=None, req_path=None, ngl=None):
         self.gguf = gguf
         self.server_bin = _resolve_bin(server_bin)
         self.maxtok_req = int(maxtok)
         req_dir = "/dev/shm" if os.path.isdir("/dev/shm") else tempfile.gettempdir()
         self.req = req_path or os.path.join(req_dir, f"dg_visual_{os.getpid()}.req")
-        self.env = _build_subprocess_env(self.server_bin, gpu=gpu, maxtok=_canvas_maxtok(maxtok))
+        self.env = _build_subprocess_env(self.server_bin, gpu=gpu, maxtok=_canvas_maxtok(maxtok), ngl=ngl)
+        self.ngl = int(self.env["NGL"])
         self.p = None
         self._spawn()
 


### PR DESCRIPTION
Fixes unslothai/unsloth#7574.

`_build_subprocess_env` spawned the visual-server child with `NGL=99` hardcoded, pinning every
layer to the GPU. A GGUF larger than VRAM died in `cudaMalloc` with no way to split it across
GPU and RAM:

```
allocating 16013.20 MiB on device 0: cudaMalloc failed: out of memory
```

The knob was unreachable by design: the function takes a `base_env` but overwrote `NGL`
unconditionally, and `VisualServer.__init__` had no layer parameter.

Meanwhile the server itself does `atoi(getenv("NGL") ? getenv("NGL") : "0")` — a plain
llama.cpp `n_gpu_layers`, defaulting to CPU, with partial offload fully supported. Its own OOM
message advises *"Try a smaller quant, lower NGL, or more VRAM/RAM"*, which no Unsloth user
could act on.

## Change

`_resolve_ngl()` resolves, in order: explicit caller value → `NGL` already in the environment →
the previous all-layers default. `--ngl` is exposed on the shim, which now logs the value it
resolved. Nothing changes when no split is requested.

The env-var step is deliberate: it gives users on an already-installed Studio a way out without
waiting for the Studio-side plumbing.

## Performance note

The reporter measured **~6 tok/s against ~31 tok/s** for non-diffusion Gemma-4-26B-A4B once
layers sit on CPU. Block diffusion is compute-bound rather than bandwidth-bound, so a CPU split
costs much more here than on an autoregressive model, which may be why the value was pinned at
99 originally. The all-layers default is kept for exactly that reason: only a caller that asks
for a split gets one. An OOM with no override is still the wrong failure mode.

## Tests

Five cases added to `tests/test_diffusion_visual_engine_env.py`: explicit value forwarded,
`ngl=0` not swallowed as falsy (the exact reported case), env honoured when the caller passes
nothing, explicit beating env, and garbage env falling back to the default. 9 passed.

