### PR TITLE
sft_prepare_dataset: fix double-BOS detection reading one character

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -110,7 +110,8 @@ jobs:
         # test_find_common_token_ids_no_match pins the no-match contract for
         # chat-marker core recovery (stub tokenizer, no weights).
         # test_vllm_direct_lora_loading pins the vLLM direct hot-load slot
-        # mapping (no GPU, no vLLM needed).
+        # mapping (no GPU, no vLLM needed). test_sft_prepare_dataset_double_bos
+        # pins add_special_tokens for text that already carries BOS.
         #
         # The seven base-model-source files are here for the same reason. They pin
         # that an unreachable Hub is never reported as a missing or unquantized
@@ -119,8 +120,6 @@ jobs:
         # CPU-pure and monkeypatch every Hub entry point, so they cost under two
         # seconds. Left out of a gate they would have been collected but never
         # run: `pytest tests/ --collect-only` above proves only that they import.
-        # no weights). test_sft_prepare_dataset_double_bos pins the add_special_tokens
-        # contract for text that already carries BOS.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -119,9 +119,8 @@ jobs:
         # CPU-pure and monkeypatch every Hub entry point, so they cost under two
         # seconds. Left out of a gate they would have been collected but never
         # run: `pytest tests/ --collect-only` above proves only that they import.
-        # no weights). test_sft_prepare_dataset_double_bos pins the
-        # add_special_tokens contract for text that already carries BOS (stub
-        # tokenizer, no weights). Executing them here keeps fixture/source drift visible.
+        # no weights). test_sft_prepare_dataset_double_bos pins the add_special_tokens
+        # contract for text that already carries BOS.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -119,6 +119,9 @@ jobs:
         # CPU-pure and monkeypatch every Hub entry point, so they cost under two
         # seconds. Left out of a gate they would have been collected but never
         # run: `pytest tests/ --collect-only` above proves only that they import.
+        # no weights). test_sft_prepare_dataset_double_bos pins the
+        # add_special_tokens contract for text that already carries BOS (stub
+        # tokenizer, no weights). Executing them here keeps fixture/source drift visible.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
@@ -137,6 +140,7 @@ jobs:
             tests/test_gated_and_offline_config_classification.py \
             tests/test_find_common_token_ids_no_match.py \
             tests/test_vllm_direct_lora_loading.py \
+            tests/test_sft_prepare_dataset_double_bos.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/tests/test_sft_prepare_dataset_double_bos.py
+++ b/tests/test_sft_prepare_dataset_double_bos.py
@@ -1,0 +1,161 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Double-BOS detection in ``sft_prepare_dataset``.
+
+``sft_prepare_dataset`` decides whether to pass ``add_special_tokens=False`` to the
+tokenizer so a dataset whose text ALREADY carries the BOS token does not get a
+second one prepended. Detection has two arms:
+
+    (test_text is not None and test_text.startswith(bos_token)) or bos_token in chat_template
+
+Arm B only fires when the chat template contains the BOS token *as a literal*. The
+Llama-3 family emits it via the Jinja variable ``{{- bos_token }}``, so the literal
+is absent and arm A is the only detector. Arm A read ``row[field][0]``, which indexes
+a plain string and yields its first CHARACTER, so ``startswith(bos_token)`` could
+never be true for any multi-character BOS. These tests pin arm A.
+
+CPU-pure and offline: the tokenizer/processor are local stubs, no weights are loaded.
+"""
+
+import pytest
+from datasets import Dataset
+
+from unsloth_zoo.dataset_utils import sft_prepare_dataset
+
+
+BOS = "<|begin_of_text|>"
+
+# Mirrors the Llama-3 chat template: BOS is emitted through a Jinja variable, so the
+# literal token string never appears in the template source and arm B cannot fire.
+JINJA_BOS_TEMPLATE = "{{- bos_token }}\n{%- for m in messages %}{{ m['content'] }}{%- endfor %}"
+
+
+class RecordingTokenizer:
+    """Minimal tokenizer stub that records the add_special_tokens it was called with."""
+
+    def __init__(self, bos_token=BOS, chat_template=JINJA_BOS_TEMPLATE):
+        self.bos_token = bos_token
+        self.chat_template = chat_template
+        self.add_special_tokens_seen = []
+
+    def __call__(
+        self,
+        texts,
+        truncation=True,
+        max_length=None,
+        return_token_type_ids=False,
+        add_special_tokens=True,
+    ):
+        self.add_special_tokens_seen.append(add_special_tokens)
+        if isinstance(texts, str):
+            texts = [texts]
+        return {"input_ids": [[1, 2, 3] for _ in texts]}
+
+
+class Args:
+    def __init__(self, dataset_text_field="text"):
+        self.max_length = 64
+        self.dataset_text_field = dataset_text_field
+        self.remove_unused_columns = True
+
+
+class DummyTrainer:
+    """Stands in for SFTTrainer: sft_prepare_dataset only reads .model and sets
+    .data_collator."""
+
+    def __init__(self):
+        self.model = None
+        self.data_collator = None
+
+
+def _run(dataset, tokenizer, dataset_text_field="text"):
+    trainer = DummyTrainer()
+    sft_prepare_dataset(
+        trainer,
+        dataset,
+        tokenizer,
+        Args(dataset_text_field),
+        packing=False,
+        formatting_func=None,
+        dataset_name="train",
+    )
+    assert tokenizer.add_special_tokens_seen, "tokenizer was never invoked"
+    return tokenizer.add_special_tokens_seen
+
+
+def test_text_already_starting_with_bos_disables_add_special_tokens():
+    """The regression: text that already carries BOS must tokenize with
+    add_special_tokens=False, otherwise every sequence gets a doubled BOS."""
+    dataset = Dataset.from_dict({"text": [BOS + "hello world", BOS + "second row"]})
+    tokenizer = RecordingTokenizer()
+
+    seen = _run(dataset, tokenizer)
+
+    assert all(flag is False for flag in seen), (
+        "double BOS not detected: sft_prepare_dataset tokenized with "
+        f"add_special_tokens={seen}, so a second {BOS!r} is prepended to every row"
+    )
+
+
+def test_text_without_bos_keeps_add_special_tokens():
+    """Guard the other direction: a dataset with no leading BOS must keep
+    add_special_tokens=True so the tokenizer still adds one."""
+    dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
+    tokenizer = RecordingTokenizer()
+
+    seen = _run(dataset, tokenizer)
+
+    assert all(flag is True for flag in seen), (
+        f"add_special_tokens was disabled for text that has no leading BOS: {seen}"
+    )
+
+
+def test_literal_bos_in_chat_template_still_detected():
+    """Arm B must keep working: a template holding the literal BOS disables
+    add_special_tokens even when the text itself does not start with BOS."""
+    dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
+    tokenizer = RecordingTokenizer(chat_template="{{ '" + BOS + "' }}{{ messages }}")
+
+    seen = _run(dataset, tokenizer)
+
+    assert all(flag is False for flag in seen), (
+        f"literal BOS in the chat template no longer disables add_special_tokens: {seen}"
+    )
+
+
+def test_list_valued_text_field_is_unwrapped():
+    """Some datasets store the text field as a list of strings. Indexing element 0
+    is correct there, and detection must still fire."""
+    dataset = Dataset.from_dict({"text": [[BOS + "hello world"], [BOS + "second row"]]})
+    tokenizer = RecordingTokenizer()
+
+    seen = _run(dataset, tokenizer)
+
+    assert all(flag is False for flag in seen), (
+        f"double BOS not detected for a list-valued text field: {seen}"
+    )
+
+
+def test_no_bos_token_on_tokenizer_is_a_noop():
+    """A tokenizer without a BOS token (e.g. Qwen2.5) must not crash and must keep
+    add_special_tokens=True."""
+    dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
+    tokenizer = RecordingTokenizer(bos_token=None, chat_template="{{ messages }}")
+
+    seen = _run(dataset, tokenizer)
+
+    assert all(flag is True for flag in seen), seen

--- a/tests/test_sft_prepare_dataset_double_bos.py
+++ b/tests/test_sft_prepare_dataset_double_bos.py
@@ -26,9 +26,16 @@ Arm B only fires when the chat template contains the BOS token *as a literal*. T
 Llama-3 family emits it via the Jinja variable ``{{- bos_token }}``, so the literal
 is absent and arm A is the only detector. Arm A read ``row[field][0]``, which indexes
 a plain string and yields its first CHARACTER, so ``startswith(bos_token)`` could
-never be true for any multi-character BOS. These tests pin arm A.
+never be true for any multi-character BOS.
 
-CPU-pure and offline: the tokenizer/processor are local stubs, no weights are loaded.
+These tests assert on the TOKENIZED OUTPUT rather than on a flag recorded by the
+stub. ``sft_prepare_dataset`` hands ``num_proc`` to ``Dataset.map`` whenever the
+multiprocessing start method is ``fork`` (Linux), so the map body runs in child
+processes and any state a stub records there is invisible to the parent. Reading
+the returned dataset is what crosses that boundary - and doubled BOS ids in the
+tokenized rows are the user-visible harm anyway.
+
+CPU-pure and offline: the tokenizer/processor is a local stub, no weights are loaded.
 """
 
 import pytest
@@ -38,19 +45,28 @@ from unsloth_zoo.dataset_utils import sft_prepare_dataset
 
 
 BOS = "<|begin_of_text|>"
+BOS_ID = 128000
+CONTENT_IDS = [10, 11, 12]
 
 # Mirrors the Llama-3 chat template: BOS is emitted through a Jinja variable, so the
 # literal token string never appears in the template source and arm B cannot fire.
 JINJA_BOS_TEMPLATE = "{{- bos_token }}\n{%- for m in messages %}{{ m['content'] }}{%- endfor %}"
+# A template that does carry the literal, which arm B is supposed to catch.
+LITERAL_BOS_TEMPLATE = "{{ '" + BOS + "' }}{{ messages }}"
 
 
-class RecordingTokenizer:
-    """Minimal tokenizer stub that records the add_special_tokens it was called with."""
+class BosStubTokenizer:
+    """Encodes the add_special_tokens decision into its OUTPUT.
+
+    A leading BOS id appears once for a text that already starts with the BOS
+    string, and once more when the caller asks for special tokens. A correct
+    caller therefore yields exactly one leading BOS id in every case; the bug
+    yields two.
+    """
 
     def __init__(self, bos_token=BOS, chat_template=JINJA_BOS_TEMPLATE):
         self.bos_token = bos_token
         self.chat_template = chat_template
-        self.add_special_tokens_seen = []
 
     def __call__(
         self,
@@ -60,10 +76,22 @@ class RecordingTokenizer:
         return_token_type_ids=False,
         add_special_tokens=True,
     ):
-        self.add_special_tokens_seen.append(add_special_tokens)
         if isinstance(texts, str):
             texts = [texts]
-        return {"input_ids": [[1, 2, 3] for _ in texts]}
+        rows = []
+        for text in texts:
+            # A list-valued text column arrives here as a list of lists under
+            # batched=True. Mirror the unwrap the caller does for its BOS probe so
+            # this stub can still tokenize that shape.
+            if isinstance(text, (list, tuple)):
+                text = text[0] if len(text) != 0 else ""
+            ids = list(CONTENT_IDS)
+            if self.bos_token is not None and text.startswith(self.bos_token):
+                ids = [BOS_ID] + ids
+            if self.bos_token is not None and add_special_tokens:
+                ids = [BOS_ID] + ids
+            rows.append(ids)
+        return {"input_ids": rows}
 
 
 class Args:
@@ -82,10 +110,9 @@ class DummyTrainer:
         self.data_collator = None
 
 
-def _run(dataset, tokenizer, dataset_text_field="text"):
-    trainer = DummyTrainer()
-    sft_prepare_dataset(
-        trainer,
+def _prepare(dataset, tokenizer, dataset_text_field="text"):
+    prepared = sft_prepare_dataset(
+        DummyTrainer(),
         dataset,
         tokenizer,
         Args(dataset_text_field),
@@ -93,69 +120,80 @@ def _run(dataset, tokenizer, dataset_text_field="text"):
         formatting_func=None,
         dataset_name="train",
     )
-    assert tokenizer.add_special_tokens_seen, "tokenizer was never invoked"
-    return tokenizer.add_special_tokens_seen
+    rows = [list(row["input_ids"]) for row in prepared]
+    assert rows, "sft_prepare_dataset returned no rows"
+    return rows
 
 
-def test_text_already_starting_with_bos_disables_add_special_tokens():
-    """The regression: text that already carries BOS must tokenize with
-    add_special_tokens=False, otherwise every sequence gets a doubled BOS."""
+def _leading_bos_count(ids):
+    count = 0
+    for token in ids:
+        if token != BOS_ID:
+            break
+        count += 1
+    return count
+
+
+def test_text_already_starting_with_bos_is_not_double_bos():
+    """The regression: text that already carries BOS must not be given a second
+    one. Unpatched, arm A never fires and every row starts with two BOS ids."""
     dataset = Dataset.from_dict({"text": [BOS + "hello world", BOS + "second row"]})
-    tokenizer = RecordingTokenizer()
 
-    seen = _run(dataset, tokenizer)
+    rows = _prepare(dataset, BosStubTokenizer())
 
-    assert all(flag is False for flag in seen), (
-        "double BOS not detected: sft_prepare_dataset tokenized with "
-        f"add_special_tokens={seen}, so a second {BOS!r} is prepended to every row"
-    )
+    for ids in rows:
+        assert _leading_bos_count(ids) == 1, (
+            f"expected exactly one leading BOS id, got {_leading_bos_count(ids)} "
+            f"in {ids} - a second {BOS!r} was prepended to text that already had one"
+        )
 
 
-def test_text_without_bos_keeps_add_special_tokens():
-    """Guard the other direction: a dataset with no leading BOS must keep
-    add_special_tokens=True so the tokenizer still adds one."""
+def test_text_without_bos_still_gets_exactly_one():
+    """Guard the other direction: a dataset with no leading BOS must still have one
+    added by the tokenizer."""
     dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
-    tokenizer = RecordingTokenizer()
 
-    seen = _run(dataset, tokenizer)
+    rows = _prepare(dataset, BosStubTokenizer())
 
-    assert all(flag is True for flag in seen), (
-        f"add_special_tokens was disabled for text that has no leading BOS: {seen}"
-    )
+    for ids in rows:
+        assert _leading_bos_count(ids) == 1, (
+            f"expected exactly one leading BOS id, got {_leading_bos_count(ids)} in {ids}"
+        )
 
 
 def test_literal_bos_in_chat_template_still_detected():
     """Arm B must keep working: a template holding the literal BOS disables
-    add_special_tokens even when the text itself does not start with BOS."""
-    dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
-    tokenizer = RecordingTokenizer(chat_template="{{ '" + BOS + "' }}{{ messages }}")
+    add_special_tokens, so BOS-carrying text is still not doubled."""
+    dataset = Dataset.from_dict({"text": [BOS + "hello world", BOS + "second row"]})
 
-    seen = _run(dataset, tokenizer)
+    rows = _prepare(dataset, BosStubTokenizer(chat_template=LITERAL_BOS_TEMPLATE))
 
-    assert all(flag is False for flag in seen), (
-        f"literal BOS in the chat template no longer disables add_special_tokens: {seen}"
-    )
+    for ids in rows:
+        assert _leading_bos_count(ids) == 1, (
+            f"literal BOS in the chat template no longer suppresses the extra BOS: {ids}"
+        )
 
 
 def test_list_valued_text_field_is_unwrapped():
     """Some datasets store the text field as a list of strings. Indexing element 0
     is correct there, and detection must still fire."""
     dataset = Dataset.from_dict({"text": [[BOS + "hello world"], [BOS + "second row"]]})
-    tokenizer = RecordingTokenizer()
 
-    seen = _run(dataset, tokenizer)
+    rows = _prepare(dataset, BosStubTokenizer())
 
-    assert all(flag is False for flag in seen), (
-        f"double BOS not detected for a list-valued text field: {seen}"
-    )
+    for ids in rows:
+        assert _leading_bos_count(ids) == 1, (
+            f"double BOS not detected for a list-valued text field: {ids}"
+        )
 
 
 def test_no_bos_token_on_tokenizer_is_a_noop():
-    """A tokenizer without a BOS token (e.g. Qwen2.5) must not crash and must keep
-    add_special_tokens=True."""
+    """A tokenizer without a BOS token (e.g. Qwen2.5) must not crash, and no BOS id
+    may appear."""
     dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
-    tokenizer = RecordingTokenizer(bos_token=None, chat_template="{{ messages }}")
 
-    seen = _run(dataset, tokenizer)
+    rows = _prepare(dataset, BosStubTokenizer(bos_token=None, chat_template="{{ messages }}"))
 
-    assert all(flag is True for flag in seen), seen
+    for ids in rows:
+        assert _leading_bos_count(ids) == 0, ids
+        assert ids == CONTENT_IDS, ids

--- a/tests/test_sft_prepare_dataset_double_bos.py
+++ b/tests/test_sft_prepare_dataset_double_bos.py
@@ -163,13 +163,17 @@ def test_text_without_bos_still_gets_exactly_one():
 
 def test_literal_bos_in_chat_template_still_detected():
     """Arm B must keep working: a template holding the literal BOS disables
-    add_special_tokens, so BOS-carrying text is still not doubled."""
-    dataset = Dataset.from_dict({"text": [BOS + "hello world", BOS + "second row"]})
+    add_special_tokens on its own.
+
+    The text deliberately carries NO BOS, so arm A cannot fire and the template literal is
+    the only thing that can suppress the extra token. With BOS-carrying text here instead,
+    arm A alone satisfies the assertion and the test passes even with arm B deleted."""
+    dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
 
     rows = _prepare(dataset, BosStubTokenizer(chat_template=LITERAL_BOS_TEMPLATE))
 
     for ids in rows:
-        assert _leading_bos_count(ids) == 1, (
+        assert _leading_bos_count(ids) == 0, (
             f"literal BOS in the chat template no longer suppresses the extra BOS: {ids}"
         )
 

--- a/tests/test_sft_prepare_dataset_double_bos.py
+++ b/tests/test_sft_prepare_dataset_double_bos.py
@@ -17,12 +17,12 @@
 """Double-BOS detection in ``sft_prepare_dataset``.
 
 Detection is ``test_text.startswith(bos_token) or bos_token in chat_template``. Arm B
-needs the BOS as a literal, which Llama-3 style templates never have (they emit
-``{{- bos_token }}``), so arm A is the only detector - and it read ``row[field][0]``,
-the first CHARACTER of a string, which no multi-character BOS can match.
+needs a literal BOS, which Llama-3 templates never have (they emit ``{{- bos_token }}``),
+so arm A is the only live detector - and it read ``row[field][0]``, the first CHARACTER
+of a string, which no multi-character BOS can match.
 
-Assertions read the tokenized output, not stub state: under ``fork`` the map body runs
-in child processes where recorded state is invisible to the parent.
+Assertions read tokenized output, not stub state: under ``fork`` the map body runs in
+child processes whose recorded state is invisible to the parent.
 """
 
 import pytest
@@ -42,9 +42,8 @@ LITERAL_BOS_TEMPLATE = "{{ '" + BOS + "' }}{{ messages }}"
 
 
 class BosStubTokenizer:
-    """Encodes the add_special_tokens decision into its output: one leading BOS id
-    for text that already starts with BOS, one more if the caller asks for specials.
-    A correct caller yields exactly one; the bug yields two."""
+    """Encodes the add_special_tokens decision into its output: one leading BOS id if the
+    text starts with BOS, one more if the caller asks for specials. Correct -> one, bug -> two."""
 
     def __init__(self, bos_token=BOS, chat_template=JINJA_BOS_TEMPLATE):
         self.bos_token = bos_token
@@ -114,7 +113,7 @@ def _leading_bos_count(ids):
 
 
 def test_text_already_starting_with_bos_is_not_double_bos():
-    """The regression: unpatched, arm A never fires and every row gets two BOS ids."""
+    """Unpatched, arm A never fires and every row gets two BOS ids."""
     dataset = Dataset.from_dict({"text": [BOS + "hello world", BOS + "second row"]})
 
     rows = _prepare(dataset, BosStubTokenizer())
@@ -152,7 +151,7 @@ def test_literal_bos_in_chat_template_still_detected():
 
 
 def test_list_valued_text_field_is_unwrapped():
-    """A list-valued text field: indexing element 0 is correct there."""
+    """A list-valued field: element 0 really is the text, so unwrapping is correct."""
     dataset = Dataset.from_dict({"text": [[BOS + "hello world"], [BOS + "second row"]]})
 
     rows = _prepare(dataset, BosStubTokenizer())
@@ -164,7 +163,7 @@ def test_list_valued_text_field_is_unwrapped():
 
 
 def test_no_bos_token_on_tokenizer_is_a_noop():
-    """No bos_token (e.g. Qwen2.5): must not crash, no BOS id may appear."""
+    """No bos_token (Qwen2.5): must not crash, no BOS id may appear."""
     dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
 
     rows = _prepare(dataset, BosStubTokenizer(bos_token=None, chat_template="{{ messages }}"))

--- a/tests/test_sft_prepare_dataset_double_bos.py
+++ b/tests/test_sft_prepare_dataset_double_bos.py
@@ -16,26 +16,13 @@
 
 """Double-BOS detection in ``sft_prepare_dataset``.
 
-``sft_prepare_dataset`` decides whether to pass ``add_special_tokens=False`` to the
-tokenizer so a dataset whose text ALREADY carries the BOS token does not get a
-second one prepended. Detection has two arms:
+Detection is ``test_text.startswith(bos_token) or bos_token in chat_template``. Arm B
+needs the BOS as a literal, which Llama-3 style templates never have (they emit
+``{{- bos_token }}``), so arm A is the only detector - and it read ``row[field][0]``,
+the first CHARACTER of a string, which no multi-character BOS can match.
 
-    (test_text is not None and test_text.startswith(bos_token)) or bos_token in chat_template
-
-Arm B only fires when the chat template contains the BOS token *as a literal*. The
-Llama-3 family emits it via the Jinja variable ``{{- bos_token }}``, so the literal
-is absent and arm A is the only detector. Arm A read ``row[field][0]``, which indexes
-a plain string and yields its first CHARACTER, so ``startswith(bos_token)`` could
-never be true for any multi-character BOS.
-
-These tests assert on the TOKENIZED OUTPUT rather than on a flag recorded by the
-stub. ``sft_prepare_dataset`` hands ``num_proc`` to ``Dataset.map`` whenever the
-multiprocessing start method is ``fork`` (Linux), so the map body runs in child
-processes and any state a stub records there is invisible to the parent. Reading
-the returned dataset is what crosses that boundary - and doubled BOS ids in the
-tokenized rows are the user-visible harm anyway.
-
-CPU-pure and offline: the tokenizer/processor is a local stub, no weights are loaded.
+Assertions read the tokenized output, not stub state: under ``fork`` the map body runs
+in child processes where recorded state is invisible to the parent.
 """
 
 import pytest
@@ -48,21 +35,16 @@ BOS = "<|begin_of_text|>"
 BOS_ID = 128000
 CONTENT_IDS = [10, 11, 12]
 
-# Mirrors the Llama-3 chat template: BOS is emitted through a Jinja variable, so the
-# literal token string never appears in the template source and arm B cannot fire.
+# BOS via a Jinja variable, so the literal is absent and arm B cannot fire.
 JINJA_BOS_TEMPLATE = "{{- bos_token }}\n{%- for m in messages %}{{ m['content'] }}{%- endfor %}"
-# A template that does carry the literal, which arm B is supposed to catch.
+# Carries the literal, which arm B is supposed to catch.
 LITERAL_BOS_TEMPLATE = "{{ '" + BOS + "' }}{{ messages }}"
 
 
 class BosStubTokenizer:
-    """Encodes the add_special_tokens decision into its OUTPUT.
-
-    A leading BOS id appears once for a text that already starts with the BOS
-    string, and once more when the caller asks for special tokens. A correct
-    caller therefore yields exactly one leading BOS id in every case; the bug
-    yields two.
-    """
+    """Encodes the add_special_tokens decision into its output: one leading BOS id
+    for text that already starts with BOS, one more if the caller asks for specials.
+    A correct caller yields exactly one; the bug yields two."""
 
     def __init__(self, bos_token=BOS, chat_template=JINJA_BOS_TEMPLATE):
         self.bos_token = bos_token
@@ -80,9 +62,7 @@ class BosStubTokenizer:
             texts = [texts]
         rows = []
         for text in texts:
-            # A list-valued text column arrives here as a list of lists under
-            # batched=True. Mirror the unwrap the caller does for its BOS probe so
-            # this stub can still tokenize that shape.
+            # list-valued column arrives as a list of lists under batched=True
             if isinstance(text, (list, tuple)):
                 text = text[0] if len(text) != 0 else ""
             ids = list(CONTENT_IDS)
@@ -102,8 +82,7 @@ class Args:
 
 
 class DummyTrainer:
-    """Stands in for SFTTrainer: sft_prepare_dataset only reads .model and sets
-    .data_collator."""
+    """Stands in for SFTTrainer: only .model is read and .data_collator is set."""
 
     def __init__(self):
         self.model = None
@@ -135,8 +114,7 @@ def _leading_bos_count(ids):
 
 
 def test_text_already_starting_with_bos_is_not_double_bos():
-    """The regression: text that already carries BOS must not be given a second
-    one. Unpatched, arm A never fires and every row starts with two BOS ids."""
+    """The regression: unpatched, arm A never fires and every row gets two BOS ids."""
     dataset = Dataset.from_dict({"text": [BOS + "hello world", BOS + "second row"]})
 
     rows = _prepare(dataset, BosStubTokenizer())
@@ -149,8 +127,7 @@ def test_text_already_starting_with_bos_is_not_double_bos():
 
 
 def test_text_without_bos_still_gets_exactly_one():
-    """Guard the other direction: a dataset with no leading BOS must still have one
-    added by the tokenizer."""
+    """The other direction: text with no BOS must still get one."""
     dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
 
     rows = _prepare(dataset, BosStubTokenizer())
@@ -162,12 +139,8 @@ def test_text_without_bos_still_gets_exactly_one():
 
 
 def test_literal_bos_in_chat_template_still_detected():
-    """Arm B must keep working: a template holding the literal BOS disables
-    add_special_tokens on its own.
-
-    The text deliberately carries NO BOS, so arm A cannot fire and the template literal is
-    the only thing that can suppress the extra token. With BOS-carrying text here instead,
-    arm A alone satisfies the assertion and the test passes even with arm B deleted."""
+    """Arm B alone. The text carries NO BOS so arm A cannot fire; with BOS-carrying
+    text here the test would pass even with arm B deleted."""
     dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
 
     rows = _prepare(dataset, BosStubTokenizer(chat_template=LITERAL_BOS_TEMPLATE))
@@ -179,8 +152,7 @@ def test_literal_bos_in_chat_template_still_detected():
 
 
 def test_list_valued_text_field_is_unwrapped():
-    """Some datasets store the text field as a list of strings. Indexing element 0
-    is correct there, and detection must still fire."""
+    """A list-valued text field: indexing element 0 is correct there."""
     dataset = Dataset.from_dict({"text": [[BOS + "hello world"], [BOS + "second row"]]})
 
     rows = _prepare(dataset, BosStubTokenizer())
@@ -192,8 +164,7 @@ def test_list_valued_text_field_is_unwrapped():
 
 
 def test_no_bos_token_on_tokenizer_is_a_noop():
-    """A tokenizer without a BOS token (e.g. Qwen2.5) must not crash, and no BOS id
-    may appear."""
+    """No bos_token (e.g. Qwen2.5): must not crash, no BOS id may appear."""
     dataset = Dataset.from_dict({"text": ["hello world", "second row"]})
 
     rows = _prepare(dataset, BosStubTokenizer(bos_token=None, chat_template="{{ messages }}"))

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1040,7 +1040,15 @@ def sft_prepare_dataset(
             else:
                 test_text = None  # chat template handles BOS
         else:
-            test_text = next(iter(dataset))[dataset_text_field][0]
+            # A row's text field is a plain string, so do NOT index [0] here: that
+            # takes the first CHARACTER, and the BOS check below (which needs
+            # test_text.startswith(bos_token)) can then never be true for a
+            # multi-character BOS. The [0] is correct one branch up, where
+            # formatting_func returns a LIST of strings. Some datasets do store the
+            # field as a list of strings, so unwrap those.
+            test_text = next(iter(dataset))[dataset_text_field]
+            if isinstance(test_text, (list, tuple)):
+                test_text = test_text[0] if len(test_text) != 0 else None
 
         chat_template = getattr(processing_class, 'chat_template', '')
         if chat_template == '' and is_vlm:

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -1040,12 +1040,8 @@ def sft_prepare_dataset(
             else:
                 test_text = None  # chat template handles BOS
         else:
-            # A row's text field is a plain string, so do NOT index [0] here: that
-            # takes the first CHARACTER, and the BOS check below (which needs
-            # test_text.startswith(bos_token)) can then never be true for a
-            # multi-character BOS. The [0] is correct one branch up, where
-            # formatting_func returns a LIST of strings. Some datasets do store the
-            # field as a list of strings, so unwrap those.
+            # No [0] on a str: that is the first CHARACTER, so startswith(bos_token)
+            # below could never match. Only unwrap when the field really is a list.
             test_text = next(iter(dataset))[dataset_text_field]
             if isinstance(test_text, (list, tuple)):
                 test_text = test_text[0] if len(test_text) != 0 else None


### PR DESCRIPTION
## Impact
 
`sft_prepare_dataset` passes `add_special_tokens = False` when a dataset's text already carries the BOS token. That detection was broken for plain-string text fields, and for Llama-3 it was the only working detector — so every row was tokenized with a doubled BOS.
 
Verified on `unsloth/Llama-3.2-1B-Instruct`: unpatched, `sft_prepare_dataset` tokenizes with `add_special_tokens = [True]` on text that already begins with `<|begin_of_text|>`.
 
## Mechanism
 
Detection is two-armed:
 
```python
(test_text is not None and test_text.startswith(bos_token)) or bos_token in chat_template
```
 
For the plain-text-field branch, `test_text` was built as `next(iter(dataset))[dataset_text_field][0]` (`dataset_utils.py:1000`). That indexes a string, yielding its first character, so `startswith(bos_token)` could never be true for any multi-character BOS. The `[0]` is correct one branch up at line 981, where `formatting_func` returns a list of strings; it was copied into a branch where the value is a plain string.
 
## Reachability
 
The second arm only fires when the chat template holds the BOS token as a **literal**. Llama-3 templates open with `{{- bos_token }}`, a Jinja variable, so the literal is absent — verified: `'<|begin_of_text|>' in chat_template` is `False` while `'bos_token' in chat_template` is `True`.
 
So the broken arm is the only detector whenever a template emits BOS via `{{ bos_token }}` rather than as a literal string. Llama-3 is confirmed by execution; other templates using the variable form are likely affected but untested here.
 
## Change
 
Use the field value directly. List/tuple-valued text fields are unwrapped (element 0, `None` if empty) so that shape keeps working.
 
## Tested
 
New `tests/test_sft_prepare_dataset_double_bos.py` — 5 tests, stub tokenizer, no weights, no network. Fails on unpatched source (`add_special_tokens = [True]`), passes after. Guards cover: text without BOS, template with a literal BOS, list-valued field, and a tokenizer with no BOS token.
 
Wired into the behavioral-gates CI step so the file is executed rather than merely collected (#669/#739 precedent: an unexecuted test was born broken in #669 and stayed invisible until #739).
 
Full zoo suite run twice per side with `-p no:randomly`: no test failing in both patched runs that passed in both baseline runs. Collected totals reconcile — 2977 → 2982, the 5 tests added.
 
Note on the test harness: `sft_prepare_dataset` passes `num_proc` to `Dataset.map` only when the multiprocessing start method is `fork`. macOS defaults to `spawn`, so the map body runs in-process; Linux CI defaults to `fork`, so it runs in child processes. An earlier version of these tests asserted on a recorder in the parent process, which could only ever pass under `spawn`. The tests now assert on doubled BOS ids in the returned dataset — the user-visible harm rather than a proxy for it — which reads back correctly across the process boundary. Verified passing under both start methods, and failing under both on unpatched source.
 
Inferred, not tested: that no caller depends on receiving a single character from this expression. Every use is a BOS prefix check, so reading the whole string is the intended behaviour.
 
Refs #106
