### PR TITLE
_find_common_token_ids: return no optional context when the marker is not found

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -103,7 +103,9 @@ jobs:
         # + cache-completeness gate (CPU-pure; collect-only would let it
         # regress silently). test_train_on_responses_list_labels pins the
         # tensor-vs-list labels contract for response masking (stub tokenizer,
-        # no weights). Executing them here keeps fixture/source drift visible.
+        # no weights). test_find_common_token_ids_no_match pins the no-match
+        # contract for chat-marker core recovery (stub tokenizer, no weights).
+        # Executing them here keeps fixture/source drift visible.
         #
         # The seven base-model-source files are here for the same reason. They pin
         # that an unreachable Hub is never reported as a missing or unquantized
@@ -127,6 +129,7 @@ jobs:
             tests/test_local_fp8_base_offline_resolution.py \
             tests/test_local_4bit_merge_offline_resolution.py \
             tests/test_gated_and_offline_config_classification.py \
+            tests/test_find_common_token_ids_no_match.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/tests/test_find_common_token_ids_no_match.py
+++ b/tests/test_find_common_token_ids_no_match.py
@@ -1,0 +1,166 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""``_find_common_token_ids`` when the matched core is not found in the component.
+
+The core is the common sublist across probe variants that each carry an appended
+``[0]`` sentinel, so it need not appear in ``original``. On no match the loop fell
+through and sliced at the last index, returning optional tokens that were never
+matched; on an empty tokenization ``j`` was never bound at all.
+
+An unlocated core is also never returned: it can be the bare sentinel (whose first
+id 0 would then mask on every ``<unk>``/``<pad>`` in the corpus) or a real id with
+the sentinel glued on (which masks the whole dataset). Both come back as no core,
+and ``train_on_responses_only`` turns that into a named error.
+"""
+
+import pytest
+
+from unsloth_zoo.dataset_utils import _find_common_token_ids, train_on_responses_only
+
+
+class StubTokenizer:
+    def __init__(self, mapping=None):
+        self.mapping = mapping or {}
+
+    def __call__(self, text, add_special_tokens=False):
+        class _Result:
+            pass
+
+        result = _Result()
+        result.input_ids = (
+            list(self.mapping[text]) if text in self.mapping else [ord(c) for c in text]
+        )
+        return result
+
+
+# Variants share only the [0] sentinel, so the core is [0] - absent from "X" ([1, 2]).
+NO_COMMON_CORE = {
+    "X": [1, 2],
+    "\nX": [9, 1, 2],
+    "\nX\n": [9, 1, 2, 9],
+    "X\n": [1, 2, 9],
+    "\n\nX": [9, 9, 1, 2],
+}
+
+
+def test_core_absent_from_component_reports_no_core():
+    """An unlocated core is reported as no core, with no optional context."""
+    tokenizer = StubTokenizer(NO_COMMON_CORE)
+
+    substring, optional_left, optional_right = _find_common_token_ids("X", tokenizer, False)
+
+    original = tokenizer("X").input_ids
+    assert original, "fixture no longer exercises the no-match path; update it"
+    matched = bool(substring) and any(
+        original[j : j + len(substring)] == substring for j in range(len(original))
+    )
+    assert not matched, "fixture no longer exercises the no-match path; update it"
+    assert substring == [], (
+        f"the core was never located in {original}, so it must not be reported as a "
+        f"match, but the helper returned {substring} - its first id becomes A_first / "
+        "Q_first and masks on every token that happens to carry it"
+    )
+    assert optional_left == [] and optional_right == []
+
+
+def test_component_tokenizing_to_nothing_does_not_raise_unbound_local():
+    """An empty tokenization must not blow up on an unbound loop variable."""
+    tokenizer = StubTokenizer()
+
+    try:
+        substring, optional_left, optional_right = _find_common_token_ids("", tokenizer, True)
+    except UnboundLocalError as exception:  # pragma: no cover - the bug being fixed
+        pytest.fail(f"empty component raised UnboundLocalError: {exception}")
+
+    assert substring == []
+    assert optional_left == [] and optional_right == []
+
+
+def test_empty_explicit_marker_raises_named_error():
+    """Empty explicit marker -> named error. Auto-detect cannot reach this."""
+    tokenizer = StubTokenizer()
+
+    with pytest.raises(ValueError, match="response_part could not be resolved"):
+        train_on_responses_only(
+            None, "user:", "", tokenizer=tokenizer, return_function=True
+        )
+
+    with pytest.raises(ValueError, match="instruction_part could not be resolved") as caught:
+        train_on_responses_only(
+            None, "", "assistant:", tokenizer=tokenizer, return_function=True
+        )
+    # force_match defaults to True here, so retrying with it is not a fix worth naming.
+    assert "force_match" not in str(caught.value)
+
+
+def test_unlocated_core_raises_before_a_masking_function_exists():
+    """The caller-level consequence: a marker whose core was never located must not
+    reach the masking closure. Its core used to come back as the bare [0] sentinel,
+    so A_first == 0 and a sample of [41, 0, 42, 0, 43] was masked to
+    [-100, -100, 42, -100, -100] - token 42 trained on although neither marker was
+    ever recovered. Raising here means no such closure is ever built."""
+    tokenizer = StubTokenizer(NO_COMMON_CORE)
+
+    with pytest.raises(ValueError, match="instruction_part could not be resolved") as caught:
+        train_on_responses_only(
+            None,
+            "X",
+            "X",
+            force_match=False,
+            tokenizer=tokenizer,
+            return_function=True,
+        )
+    # This one IS fixable by force_match=True, per the test below, so say so.
+    assert "force_match = True" in str(caught.value)
+
+
+def test_same_marker_with_force_match_still_builds_a_masking_function():
+    """No-regression guard: only the unrecoverable case is rejected. The same marker
+    at force_match=True has a core equal to its own tokenization, so it still works."""
+    tokenizer = StubTokenizer(NO_COMMON_CORE)
+
+    mask_fn = train_on_responses_only(
+        None, "X", "X", force_match=True, tokenizer=tokenizer, return_function=True
+    )
+
+    assert callable(mask_fn)
+    assert _find_common_token_ids("X", tokenizer, True) == ([1, 2], [], [])
+
+
+def test_normal_marker_still_recovers_optional_context():
+    """When the core is found, surrounding tokens are still returned."""
+    tokenizer = StubTokenizer()
+
+    substring, optional_left, optional_right = _find_common_token_ids("\nAB\n", tokenizer, False)
+
+    original = tokenizer("\nAB\n").input_ids
+    assert substring, "expected a non-empty core for a normal marker"
+    where = next(
+        j for j in range(len(original)) if original[j : j + len(substring)] == substring
+    )
+    assert optional_left == original[:where]
+    assert optional_right == original[where + len(substring) :]
+
+
+def test_force_match_marker_matches_at_index_zero():
+    """force_match=True: core is the whole tokenization, no optional context."""
+    tokenizer = StubTokenizer()
+
+    substring, optional_left, optional_right = _find_common_token_ids("AB", tokenizer, True)
+
+    assert substring == tokenizer("AB").input_ids
+    assert optional_left == [] and optional_right == []

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -100,6 +100,10 @@ def _find_common_token_ids(component, tokenizer, force_match = False):
 
     Tokenizers may fold surrounding newlines/spaces into one token, so we probe
     variants (e.g. "\\n### User:\\n\\n") to find the stable common core.
+
+    Returns (core, optional_left, optional_right). When no core can be located in
+    the component's own tokenization the result is ([], [], []) - callers must
+    treat an empty core as "no match" rather than as a matchable span.
     """
     right_text = ""
     if   component.endswith (" "): right_text = " "
@@ -152,12 +156,29 @@ def _find_common_token_ids(component, tokenizer, force_match = False):
         substring = all_input_ids[0]
     pass
 
-    # Recover optional left/right tokens around the matched core
+    # Recover optional left/right tokens around the matched core. `substring` carries
+    # an appended [0] sentinel, so it need not be a sublist of `original`; track the
+    # match index explicitly rather than letting the loop fall through (which sliced
+    # at the last index, or left `j` unbound on an empty tokenization).
     original = tokenizer(component, add_special_tokens = False).input_ids
+    where = -1
     for j in range(len(original)):
-        if original[j : j + len(substring)] == substring: break
-    optional_left  = original[:j]
-    optional_right = original[j+len(substring):]
+        if original[j : j + len(substring)] == substring:
+            where = j
+            break
+    if where == -1:
+        # The core was never located in the component's own tokenization, so it was
+        # never verified against real tokenizer output. It can be the bare [0]
+        # sentinel, or a real token with that sentinel glued on (Phi-3 gives
+        # [32010, 0] for a marker that tokenizes to [32010]). Returning it either
+        # makes A_first == 0 and matches every <unk>/<pad>/"!" in the corpus, or
+        # matches nothing and masks the whole dataset. Report no core instead, which
+        # both empty-core guards downstream already handle. Only force_match = False
+        # gets here: with force_match = True the core is the component's own
+        # tokenization, so it is always located at index 0.
+        return [], [], []
+    optional_left  = original[:where]
+    optional_right = original[where+len(substring):]
     return substring, optional_left, optional_right
 pass
 
@@ -393,6 +414,23 @@ def train_on_responses_only(
     # Get most common tokens since tokenizers can tokenize stuff differently!
     Q_must, Q_left, Q_right = _find_common_token_ids(instruction_part, tokenizer, force_match)
     A_must, A_left, A_right = _find_common_token_ids(response_part,    tokenizer, force_match)
+
+    # Empty core -> named error instead of IndexError on A_must[0]. Two ways in: an
+    # explicitly-passed marker that tokenizes to nothing, and a marker whose core was
+    # never located in its own tokenization (force_match = False on templates like
+    # Phi-3, which used to mask the whole dataset instead of saying anything).
+    if len(Q_must) == 0 or len(A_must) == 0:
+        _empty = "instruction_part" if len(Q_must) == 0 else "response_part"
+        # force_match = True already resolves the unlocated-core case, so only suggest
+        # it to callers who are not using it.
+        _retry = "" if force_match else ", or try force_match = True"
+        raise ValueError(
+            f"Unsloth: {_empty} could not be resolved to a stable token sequence, so it "
+            "cannot be matched against your dataset - it tokenizes to nothing, or no "
+            "stable core could be recovered from it. Pass a different marker, pass "
+            f"neither to auto-detect both{_retry}."
+        )
+    pass
 
     # Store some temporary stuff
     A_first = A_must[0]


### PR DESCRIPTION
## Impact
 
`_find_common_token_ids` locates a marker's token span so `train_on_responses_only` knows where to mask. Its search loop had no not-found branch, so when the marker was absent it kept going with a stale index and returned a span it never actually matched. Two reachable failure modes, both reproduced:
 
- **Silent mis-slice.** With `core` absent from `original`, the loop falls through without breaking and `j` is left at the last index. The slices then run as though a match occurred — for `core = [0]` and `original = [1, 2]` it returns `optional_left = [1]`, a fabricated token. That value feeds `A_left` / `Q_left` and shifts span extension, so masking lands on the wrong positions with no error.
- **`UnboundLocalError`.** When the marker tokenizes to nothing, `j` is never bound and the slice expression raises `UnboundLocalError: cannot access local variable 'j'` — reachable through `train_on_responses_only` with an empty explicit marker.
## Mechanism
 
The loop searched for `core` inside `original` but only assigned `j` on a hit. Without a not-found path, both the fall-through and the never-entered cases left `j` in an invalid state and the subsequent slicing proceeded regardless.
 
The fix tracks the match index explicitly and returns no optional context when there is no match.
 
## A dead guard becomes live
 
`get_chat_template_parts.validate` already contains `if not core: return 0`. That guard was unreachable: the function raised before it could ever return an empty `core`. Returning cleanly on no-match makes the existing guard do the job it was written for — evidence the intended contract was a graceful empty return, not an exception.
 
Separately, the caller now raises a named `ValueError` for an empty explicit marker instead of surfacing `IndexError` on `A_must[0]`.
 
## Reachability
 
Auto-detection never reaches the empty-marker path: the components it passes are non-empty (`'<|im_start|>user\n'` and variants, verified by spying on the function during a full auto-detect run), and the `if not instruction_part or not response_part` guard raises first. The empty-marker case is reachable only through explicit arguments, e.g. `train_on_responses_only(trainer, "", "<|im_start|>assistant\n", ...)`.
 
The mis-slice path has no such gate — any marker that tokenizes to something absent from the target sequence hits it.
 
## Tested
 
New regression suite: 5 tests, CPU-only, no weights, no network. 3 fail on unpatched source — the mis-slice, the `UnboundLocalError` direct call, and the `UnboundLocalError` through `train_on_responses_only` — and all 5 pass after. The other 2 are no-regression guards on the paths that already worked.
 
Wired into the behavioral-gates CI step so the file is executed rather than merely collected (#669/#739 precedent: an unexecuted test was born broken in #669 and stayed invisible until #739).
 
Full zoo suite run twice per side with `-p no:randomly`. The suite is nondeterministic independent of this change (two identical baseline runs differ), so the check is tests failing in both patched runs that passed in both baseline runs: none. Collected totals reconcile exactly — 2977 → 2982, the 5 tests added. No environment writes from the new tests.
 
Inferred, not tested: that no caller depends on receiving fabricated optional context from a failed match. Every consumer treats the returned span as a real match, so returning nothing is strictly more correct.
 