### PR TITLE
train_on_responses_only: accept plain-list labels under datasets.map(batched=True)

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -101,7 +101,9 @@ jobs:
         # use_cache disable/restore contract for gradient checkpointing
         # (#715). test_hf_xet_fallback exercises the Xet->HTTP stall fallback
         # + cache-completeness gate (CPU-pure; collect-only would let it
-        # regress silently). Executing them here keeps fixture/source drift visible.
+        # regress silently). test_train_on_responses_list_labels pins the
+        # tensor-vs-list labels contract for response masking (stub tokenizer,
+        # no weights). Executing them here keeps fixture/source drift visible.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
@@ -109,6 +111,7 @@ jobs:
             tests/test_mlx_double_quant_reject.py \
             tests/test_hf_xet_fallback.py \
             tests/test_get_transformers_model_type_empty.py \
+            tests/test_train_on_responses_list_labels.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/tests/test_train_on_responses_list_labels.py
+++ b/tests/test_train_on_responses_list_labels.py
@@ -1,0 +1,138 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""``train_on_responses_only`` over a dataset that already has a ``labels`` column.
+
+The masking function type-checks ``input_ids`` for tensor-vs-list:
+
+    if type(input_ids_) is torch_Tensor:
+        use_tensors = True
+        input_ids_ = input_ids_.tolist()
+
+but called ``.tolist()`` on ``labels`` unconditionally. Under
+``datasets.map(batched = True)`` a ``labels`` column arrives as a plain list of
+lists, which has no ``.tolist()``, so any dataset already carrying labels raised
+``AttributeError: 'list' object has no attribute 'tolist'``.
+
+CPU-pure and offline: the tokenizer is a local stub, no weights are loaded.
+"""
+
+import pytest
+import torch
+from datasets import Dataset
+
+from unsloth_zoo.dataset_utils import train_on_responses_only
+
+
+INSTRUCTION_PART = "<|user|>"
+RESPONSE_PART = "<|assistant|>"
+
+# Token ids: 1 = <|user|>, 2 = <|assistant|>, everything else is content.
+USER_ID, ASSISTANT_ID = 1, 2
+ROW = [USER_ID, 10, 11, ASSISTANT_ID, 20, 21]
+
+
+class StubTokenizer:
+    """Maps the two markers to single ids; any other text to per-character ordinals."""
+
+    def __call__(self, text, add_special_tokens=False):
+        class _Result:
+            pass
+
+        result = _Result()
+        if text == INSTRUCTION_PART:
+            result.input_ids = [USER_ID]
+        elif text == RESPONSE_PART:
+            result.input_ids = [ASSISTANT_ID]
+        else:
+            result.input_ids = [ord(c) for c in text]
+        return result
+
+
+def _masker():
+    return train_on_responses_only(
+        None,
+        INSTRUCTION_PART,
+        RESPONSE_PART,
+        tokenizer=StubTokenizer(),
+        return_function=True,
+    )
+
+
+def test_plain_list_labels_do_not_raise():
+    """The regression: a labels column of plain lists must be accepted."""
+    masker = _masker()
+
+    try:
+        out = masker({"input_ids": [list(ROW), list(ROW)], "labels": [list(ROW), list(ROW)]})
+    except AttributeError as exception:  # pragma: no cover - the bug being fixed
+        pytest.fail(f"plain-list labels raised AttributeError: {exception}")
+
+    assert len(out["labels"]) == 2
+
+
+def test_datasets_map_with_existing_labels_column():
+    """End to end through datasets.map(batched=True), which is how the column
+    actually reaches the masking function."""
+    dataset = Dataset.from_dict(
+        {"input_ids": [list(ROW), list(ROW)], "labels": [list(ROW), list(ROW)]}
+    )
+    masker = _masker()
+
+    mapped = dataset.map(masker, batched=True)
+
+    assert len(mapped) == 2
+    for labels in mapped["labels"]:
+        assert any(label != -100 for label in labels), "every label was masked away"
+
+
+def test_tensor_labels_still_supported():
+    """Guard the pre-existing path: tensor labels must keep working."""
+    masker = _masker()
+
+    out = masker(
+        {"input_ids": torch.tensor([ROW, ROW]), "labels": torch.tensor([ROW, ROW])}
+    )
+
+    assert type(out["labels"]) is torch.Tensor
+    assert out["labels"].shape == (2, len(ROW))
+
+
+def test_existing_labels_are_the_source_of_truth():
+    """When labels are supplied, unmasked positions must be copied from them, not
+    re-read from input_ids."""
+    sentinel_row = [900, 901, 902, 903, 904, 905]
+    masker = _masker()
+
+    out = masker({"input_ids": [list(ROW)], "labels": [list(sentinel_row)]})
+
+    kept = [label for label in out["labels"][0] if label != -100]
+    assert kept, "expected at least one unmasked position"
+    assert all(label in sentinel_row for label in kept), (
+        f"unmasked labels {kept} came from input_ids instead of the labels column"
+    )
+
+
+def test_no_labels_column_still_masks_from_input_ids():
+    """Guard the other branch: with no labels column the function builds labels from
+    input_ids as before."""
+    masker = _masker()
+
+    out = masker({"input_ids": [list(ROW)]})
+
+    labels = out["labels"][0]
+    assert len(labels) == len(ROW)
+    assert any(label != -100 for label in labels)

--- a/unsloth_zoo/dataset_utils.py
+++ b/unsloth_zoo/dataset_utils.py
@@ -414,7 +414,12 @@ def train_on_responses_only(
             use_tensors = True
             input_ids_ = input_ids_.tolist()
         if "labels" in examples:
-            labels_ = examples["labels"].tolist()
+            # Type-check labels the same way input_ids is above: under
+            # datasets.map(batched = True) a "labels" column arrives as a plain
+            # list of lists, which has no .tolist() and raised AttributeError.
+            labels_ = examples["labels"]
+            if type(labels_) is torch_Tensor:
+                labels_ = labels_.tolist()
             assert(len(labels_) == len(input_ids_))
         else:
             labels_ = [None]*len(input_ids_)


### PR DESCRIPTION
## Impact
 
Calling `train_on_responses_only` on a dataset that already carries a `labels` column raised `AttributeError: 'list' object has no attribute 'tolist'`, and masking never ran. That covers any dataset labelled before masking — a prior tokenization pass, a collator that emitted labels, or a second `train_on_responses_only` call.
 
## Mechanism
 
The masking function already type-checks `input_ids`:
 
```python
if type(input_ids_) is torch_Tensor:
    use_tensors = True
    input_ids_ = input_ids_.tolist()
```
 
The labels branch immediately below called `.tolist()` unconditionally. Under `datasets.map(batched = True)` — which is how `train_on_responses_only` invokes it on every non-iterable dataset — a `labels` column arrives as a plain list of lists, which has no `.tolist()`. Only a torch-tensor labels column worked, so the failure depended on the dataset's format rather than on anything the caller chose.
 
## Change
 
Type-check labels the same way `input_ids` is checked: convert only when it is a tensor, otherwise use the value as-is. The length assertion below and the tensor return path are unchanged.
 
## Reachability
 
Reached on the ordinary dataset path, not an explicit-argument corner. Reproduced two ways: by calling the returned function directly, and through a real `Dataset.map(batched = True)`. Independent of `force_match` and of whether the markers were auto-detected.
 
## Tested
 
New `tests/test_train_on_responses_list_labels.py` — 5 tests, stub tokenizer, no weights, no network. 3 fail on unpatched source and all 5 pass after. Guards cover the tensor path, the no-labels path, and that supplied labels stay the source of truth for unmasked positions.
 
Wired into the behavioral-gates CI step so the file is executed rather than merely collected (#669/#739 precedent: an unexecuted test was born broken in #669 and stayed invisible until #739).
 
Full zoo suite run twice per side with `-p no:randomly`. The suite is nondeterministic independent of this change (two identical baseline runs differ), so the check is tests failing in both patched runs that passed in both baseline runs: none. Collected totals reconcile exactly — 2977 → 2982, the 5 tests added. No environment writes from the new tests.
