### PR TITLE
feat(mlx): Make adamw_8bit actually use 8-bit optimizer state

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -105,8 +105,8 @@ jobs:
         # tensor-vs-list labels contract for response masking (stub tokenizer,
         # no weights). test_mlx_quantized_optimizer_routing pins which optim
         # names reach the 8-bit path; it runs under the torch shim so it
-        # EXECUTES here rather than skipping (the numeric half needs real MLX
-        # and runs on the Apple Silicon job).
+        # EXECUTES here rather than skipping (the numerics need real MLX and run
+        # in the mlx-cpu job below and on the Apple Silicon job).
         #
         # The seven base-model-source files are here for the same reason. They pin
         # that an unreachable Hub is never reported as a missing or unquantized
@@ -146,6 +146,50 @@ jobs:
             tests/test_zoo_history_regressions.py \
             tests/test_pypi_version_sync.py \
             -v
+
+  # Real MLX numerics on Linux. mlx-cpu publishes a manylinux x86-64 wheel and
+  # mx.quantize/dequantize/compile all run on it, so the 8-bit optimizer state
+  # is gated on every PR instead of only on the opt-in Apple Silicon job.
+  # Separate job: tests/mlx_simulation/ must never be in sys.modules here.
+  mlx-cpu-numerics:
+    name: MLX numerics (Linux CPU)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install torch CPU + zoo + mlx-cpu
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://download.pytorch.org/whl/cpu \
+            "torch>=2.4.0,<2.11.0"
+          pip install -e .[core]
+          pip install --no-deps "unsloth @ git+https://github.com/unslothai/unsloth@main" || true
+          pip install pytest==9.0.3 "mlx>=0.22.0" mlx-cpu
+
+      - name: pytest tests/test_mlx_quantized_optimizer_state.py (HARD GATE)
+        # -rs surfaces skips; the next step fails the job if the file skipped,
+        # because a skipped numeric suite is not a gate.
+        run: python -m pytest tests/test_mlx_quantized_optimizer_state.py -v -rs
+
+      - name: Fail if the numeric tests skipped
+        run: |
+          python -m pytest tests/test_mlx_quantized_optimizer_state.py -q -rs | tee out.txt
+          if grep -qiE '[0-9]+ skipped' out.txt; then
+            echo "real mlx is installed but the numeric tests skipped"; exit 1
+          fi
 
   # Core (HF/TRL/peft) drift matrix. Three cells: HF=4.57.6+TRL<1, HF=latest+TRL=latest,
   # and pyproject defaults. fail-fast=false; drift in one cell shouldn't cancel others.

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -103,7 +103,11 @@ jobs:
         # + cache-completeness gate (CPU-pure; collect-only would let it
         # regress silently). test_train_on_responses_list_labels pins the
         # tensor-vs-list labels contract for response masking (stub tokenizer,
-        # no weights). Executing them here keeps fixture/source drift visible.
+        # no weights). test_mlx_quantized_optimizer_routing pins which optim
+        # names reach the 8-bit path; it runs under the torch shim so it
+        # EXECUTES here rather than skipping (the numeric half needs real MLX
+        # and runs on the Apple Silicon job). Executing them here keeps
+        # fixture/source drift visible.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
@@ -112,6 +116,7 @@ jobs:
             tests/test_hf_xet_fallback.py \
             tests/test_get_transformers_model_type_empty.py \
             tests/test_train_on_responses_list_labels.py \
+            tests/test_mlx_quantized_optimizer_routing.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -115,3 +115,8 @@ jobs:
         # Deep behavior checks: resume determinism, completion-only training,
         # epoch step counts, SGD coupled decay, real Qwen2-VL LoRA training.
         run: python -m pytest tests/test_mlx_pr684_full_validation_metal.py -v -rs
+
+      - name: tests/test_mlx_quantized_optimizer_state.py
+        # 8-bit first-moment numerics on Metal: the affine quantizer rounds
+        # differently per backend, so the mlx-cpu job is not a substitute.
+        run: python -m pytest tests/test_mlx_quantized_optimizer_state.py -v -rs

--- a/tests/test_mlx_quantized_optimizer_routing.py
+++ b/tests/test_mlx_quantized_optimizer_routing.py
@@ -2,16 +2,16 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """Which optimizer names route to the 8-bit path, and what the user is told.

--- a/tests/test_mlx_quantized_optimizer_routing.py
+++ b/tests/test_mlx_quantized_optimizer_routing.py
@@ -16,11 +16,9 @@
 
 """Which optimizer names route to the 8-bit path, and what the user is told.
 
-Pure name/string logic, so it runs under the torch shim on Linux CI rather than
-skipping. The numeric behaviour of the quantized moment lives in
-test_mlx_quantized_optimizer_state.py, which needs real MLX and therefore only
-executes on Apple Silicon -- keeping the routing contract here means the gate
-still has something that actually runs.
+Pure name logic, so this runs under the torch shim on Linux CI instead of skipping.
+The numerics live in test_mlx_quantized_optimizer_state.py (real MLX only), so
+keeping the routing contract here means the gate still executes something.
 """
 
 import pytest
@@ -39,8 +37,7 @@ def _normalize(name):
 
 @pytest.mark.parametrize("name", ["adamw_8bit", "adam_8bit"])
 def test_8bit_names_reach_the_quantized_path(name):
-    """The regression: these were rewritten to plain fp32 adamw with no message,
-    so asking for an 8-bit optimizer silently got full-precision state."""
+    """These were rewritten to fp32 adamw with no message."""
     assert _normalize(name) == name, (
         f"{name} was collapsed to {_normalize(name)!r}; the 8-bit request is being "
         "silently downgraded to full-precision optimizer state"
@@ -55,9 +52,7 @@ def test_8bit_names_reach_the_quantized_path(name):
     "adamw_hf",
 ])
 def test_paged_and_bnb_names_still_collapse(name):
-    """Deliberate limit: "paged" promises CPU offload and "bnb" names a library
-    MLX does not use, so routing them here would swap one wrong answer for
-    another. They keep their existing behaviour."""
+    """Deliberate limit: "paged" promises CPU offload, "bnb" a library MLX lacks."""
     assert _normalize(name) == "adamw"
 
 
@@ -78,8 +73,7 @@ def test_8bit_names_are_advertised_as_supported():
 
 
 def test_description_states_what_is_and_is_not_quantized():
-    """The old behaviour was a silent rewrite; a quieter surprise is no better,
-    so the message must name the actual shape of the saving."""
+    """The message must name the actual shape of the saving."""
     from unsloth_zoo.mlx.optimizers_quantized import describe_quantized_optimizer
     message = describe_quantized_optimizer("adamw_8bit")
 

--- a/tests/test_mlx_quantized_optimizer_routing.py
+++ b/tests/test_mlx_quantized_optimizer_routing.py
@@ -1,0 +1,90 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Which optimizer names route to the 8-bit path, and what the user is told.
+
+Pure name/string logic, so it runs under the torch shim on Linux CI rather than
+skipping. The numeric behaviour of the quantized moment lives in
+test_mlx_quantized_optimizer_state.py, which needs real MLX and therefore only
+executes on Apple Silicon -- keeping the routing contract here means the gate
+still has something that actually runs.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def _normalize(name):
+    from unsloth_zoo.mlx.trainer import _normalize_mlx_optimizer_name
+    return _normalize_mlx_optimizer_name(name)
+
+
+@pytest.mark.parametrize("name", ["adamw_8bit", "adam_8bit"])
+def test_8bit_names_reach_the_quantized_path(name):
+    """The regression: these were rewritten to plain fp32 adamw with no message,
+    so asking for an 8-bit optimizer silently got full-precision state."""
+    assert _normalize(name) == name, (
+        f"{name} was collapsed to {_normalize(name)!r}; the 8-bit request is being "
+        "silently downgraded to full-precision optimizer state"
+    )
+
+
+@pytest.mark.parametrize("name", [
+    "paged_adamw_8bit",
+    "adamw_bnb_8bit",
+    "paged_adamw_32bit",
+    "adamw_torch",
+    "adamw_hf",
+])
+def test_paged_and_bnb_names_still_collapse(name):
+    """Deliberate limit: "paged" promises CPU offload and "bnb" names a library
+    MLX does not use, so routing them here would swap one wrong answer for
+    another. They keep their existing behaviour."""
+    assert _normalize(name) == "adamw"
+
+
+@pytest.mark.parametrize("name,expected", [("adamw", "adamw"), ("adam", "adam"), ("sgd", "sgd")])
+def test_plain_names_unchanged(name, expected):
+    assert _normalize(name) == expected
+
+
+def test_unsupported_name_still_raises():
+    with pytest.raises(ValueError, match="Unsupported MLX optimizer"):
+        _normalize("definitely_not_an_optimizer")
+
+
+def test_8bit_names_are_advertised_as_supported():
+    from unsloth_zoo.mlx.trainer import SUPPORTED_MLX_OPTIMIZERS
+    assert "adamw_8bit" in SUPPORTED_MLX_OPTIMIZERS
+    assert "adam_8bit" in SUPPORTED_MLX_OPTIMIZERS
+
+
+def test_description_states_what_is_and_is_not_quantized():
+    """The old behaviour was a silent rewrite; a quieter surprise is no better,
+    so the message must name the actual shape of the saving."""
+    from unsloth_zoo.mlx.optimizers_quantized import describe_quantized_optimizer
+    message = describe_quantized_optimizer("adamw_8bit")
+
+    assert "adamw_8bit" in message
+    assert "FIRST moment" in message
+    assert "group_size=64" in message
+    assert "second moment stays float32" in message
+    assert "multiple of 64" in message

--- a/tests/test_mlx_quantized_optimizer_routing.py
+++ b/tests/test_mlx_quantized_optimizer_routing.py
@@ -80,5 +80,7 @@ def test_description_states_what_is_and_is_not_quantized():
     assert "adamw_8bit" in message
     assert "FIRST moment" in message
     assert "group_size=64" in message
-    assert "second moment stays float32" in message
+    assert "second moment is not quantized" in message
     assert "multiple of 64" in message
+    # The saving depends on the state dtype, so the banner must not imply one number.
+    assert "bfloat16" in message and "peak memory" in message

--- a/tests/test_mlx_quantized_optimizer_state.py
+++ b/tests/test_mlx_quantized_optimizer_state.py
@@ -16,12 +16,9 @@
 
 """8-bit first-moment optimizer state for MLX.
 
-These assert BEHAVIOUR over steps, not construction: a quantized moment that is
-built correctly but trains wrongly is the failure mode that matters.
-
-CPU/Metal, synthetic models only -- no weights, no network, no ``Dataset.map``
-(so the spawn-vs-fork start-method matrix that applies to dataset code is not
-relevant here; nothing in this path is handed to a worker process).
+Behaviour over steps, not construction. Real MLX required, so this skips on Linux;
+the routing half runs under the torch shim. No ``Dataset.map`` here, so the
+spawn-vs-fork matrix does not apply.
 """
 
 import tempfile
@@ -48,7 +45,6 @@ STEPS = 8
 
 
 def _build_model(width=256):
-    """Deterministic 2-layer MLP whose weights ARE quantization-eligible."""
     mx.random.seed(0)
     model = nn.Sequential(nn.Linear(width, width), nn.ReLU(), nn.Linear(width, width))
     mx.eval(model.parameters())
@@ -56,12 +52,7 @@ def _build_model(width=256):
 
 
 def _build_ineligible_model():
-    """Every trainable parameter is ineligible for mx.quantize.
-
-    Linear(96, 100) has last dim 100, which is not a multiple of 64; biases are
-    1-D. Nothing here can be quantized, so the optimizer must fall back to fp32
-    moments throughout and still train.
-    """
+    """Nothing here is quantization-eligible: 100 is not a multiple of 64."""
     mx.random.seed(0)
     model = nn.Sequential(nn.Linear(96, 100), nn.ReLU(), nn.Linear(100, 100))
     mx.eval(model.parameters())
@@ -98,13 +89,8 @@ def _train(optimizer, model, x, y, steps=STEPS, compiled=False):
 
 
 def _state_bytes(state):
-    """Sum every array in the state tree.
-
-    Default traversal only: a quantized moment is a tuple/list of arrays, which
-    tree_flatten descends into as ``<param>.m.0/.1/.2`` -- the same flattening
-    save_optimizer_state relies on. Marking tuple/list as a leaf here would stop
-    the walk at the top-level ``layers`` list and count almost nothing.
-    """
+    """Sum every array in the state tree. Default traversal only: marking
+    tuple/list as a leaf would stop at the top-level ``layers`` list."""
     return sum(v.nbytes for _, v in tree_flatten(state) if isinstance(v, mx.array))
 
 
@@ -187,7 +173,7 @@ def test_quantized_state_saves_reloads_and_resumes_identically():
 
 # 5 ------------------------------------------------------------------------
 def test_second_moment_is_never_quantized():
-    """Guard: quantizing v diverges to NaN, so it must not be silently enabled."""
+    """Quantizing v diverges to NaN; it must not be silently enabled."""
     x, y = _batch()
     opt = QuantizedMomentAdam(1e-3, bias_correction=True)
     _train(opt, _build_model(), x, y, steps=2)
@@ -219,7 +205,7 @@ def test_compiled_and_uncompiled_agree():
 
 # 7 ------------------------------------------------------------------------
 def test_model_with_no_quantizable_parameters_still_trains():
-    """Most likely real-world break: nothing is eligible, so every moment is fp32."""
+    """Nothing eligible -> every moment fp32, must still train."""
     model = _build_ineligible_model()
     opt = QuantizedMomentAdam(1e-3, bias_correction=True)
 
@@ -242,12 +228,7 @@ def test_model_with_no_quantizable_parameters_still_trains():
 # 8 ------------------------------------------------------------------------
 @pytest.mark.parametrize("bits", [2, 4, 16, 32])
 def test_bit_widths_other_than_8_are_rejected(bits):
-    """Don't ship an unexercised knob: narrower widths are refused, not offered.
-
-    Optimizer moments are demonstrably quantization-sensitive -- affine 8-bit
-    quantization of the SECOND moment already diverges to NaN -- so a width with
-    no convergence evidence must not be silently accepted.
-    """
+    """Narrower widths are refused, not offered untested."""
     with pytest.raises(ValueError, match=r"supports bits=8 only"):
         QuantizedMomentAdam(1e-3, bits=bits)
     with pytest.raises(ValueError, match=r"supports bits=8 only"):
@@ -257,7 +238,7 @@ def test_bit_widths_other_than_8_are_rejected(bits):
 # 9 ------------------------------------------------------------------------
 @pytest.mark.parametrize("group_size", SUPPORTED_GROUP_SIZES)
 def test_every_supported_group_size_trains(group_size):
-    """Each advertised group size is exercised, not just the default."""
+
     x, y = _batch()
     opt = QuantizedMomentAdam(1e-3, bias_correction=True, group_size=group_size)
     losses = _train(opt, _build_model(), x, y)
@@ -276,7 +257,7 @@ def test_unsupported_group_size_is_rejected(group_size):
 
 # 10 -----------------------------------------------------------------------
 def test_adamw_variant_also_quantizes():
-    """The AdamW subclass inherits decoupled decay from the stock implementation."""
+
     x, y = _batch()
     opt = QuantizedMomentAdamW(1e-3, weight_decay=0.0, bias_correction=True)
     losses = _train(opt, _build_model(), x, y)

--- a/tests/test_mlx_quantized_optimizer_state.py
+++ b/tests/test_mlx_quantized_optimizer_state.py
@@ -2,16 +2,16 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """8-bit first-moment optimizer state for MLX.
@@ -44,6 +44,7 @@ from unsloth_zoo.mlx.optimizers_quantized import (
     SUPPORTED_GROUP_SIZES,
     QuantizedMomentAdam,
     QuantizedMomentAdamW,
+    unpack_quantized_moments,
 )
 from unsloth_zoo.mlx.utils import load_optimizer_state, save_optimizer_state
 
@@ -374,6 +375,37 @@ def test_packed_checkpoint_loads_into_plain_optimizer():
     load_optimizer_state(plain, checkpoint)
     assert isinstance(_moment(plain, "m"), mx.array), "packed moment was not unpacked"
     _train(plain, plain_model, x, y, steps=1)
+
+
+# 13b ----------------------------------------------------------------------
+def test_unpacking_does_not_carry_the_zero_residue_out():
+    """Dequantization leaves a residue where the true moment is zero. Handing that
+    to a plain optimizer would divide it by eps while v == 0, reintroducing the
+    blow-up on the far side of the switch."""
+    steps, lr = 200, 1e-3
+    grad = mx.array([[1.0] + [0.0] * (DEFAULT_GROUP_SIZE - 1)])
+
+    packed = QuantizedMomentAdam(lr, bias_correction=True)
+    param = mx.zeros((1, DEFAULT_GROUP_SIZE))
+    packed.init({"w": param})
+    for _ in range(steps):
+        param = packed.apply_gradients({"w": grad}, {"w": param})["w"]
+        mx.eval(param, packed.state)
+
+    unpacked = unpack_quantized_moments(packed.state, packed.group_size, packed.bits)
+    m, v = unpacked["w"]["m"], unpacked["w"]["v"]
+    residue = float(mx.max(mx.abs(mx.where(v == 0, m, mx.zeros_like(m)))))
+    assert residue == 0.0, f"unpacked moment kept a {residue:.3e} residue where v == 0"
+
+    plain = optim.Adam(learning_rate=lr, bias_correction=True)
+    resumed = mx.zeros((1, DEFAULT_GROUP_SIZE))
+    plain.init({"w": resumed})
+    plain.state = unpacked
+    for _ in range(steps):
+        resumed = plain.apply_gradients({"w": grad}, {"w": resumed})["w"]
+        mx.eval(resumed, plain.state)
+    drift = max(abs(float(resumed[0, i])) for i in range(1, DEFAULT_GROUP_SIZE))
+    assert drift == 0.0, f"zero-gradient coordinates drifted {drift:.3e} after unpacking"
 
 
 # 14 -----------------------------------------------------------------------

--- a/tests/test_mlx_quantized_optimizer_state.py
+++ b/tests/test_mlx_quantized_optimizer_state.py
@@ -1,0 +1,287 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""8-bit first-moment optimizer state for MLX.
+
+These assert BEHAVIOUR over steps, not construction: a quantized moment that is
+built correctly but trains wrongly is the failure mode that matters.
+
+CPU/Metal, synthetic models only -- no weights, no network, no ``Dataset.map``
+(so the spawn-vs-fork start-method matrix that applies to dataset code is not
+relevant here; nothing in this path is handed to a worker process).
+"""
+
+import tempfile
+
+import pytest
+
+mx = pytest.importorskip("mlx.core", reason="MLX is only available on Apple Silicon")
+nn = pytest.importorskip("mlx.nn", reason="MLX is only available on Apple Silicon")
+optim = pytest.importorskip("mlx.optimizers", reason="MLX is only available on Apple Silicon")
+
+from mlx.utils import tree_flatten, tree_unflatten
+
+from unsloth_zoo.mlx.optimizers_quantized import (
+    DEFAULT_BITS,
+    DEFAULT_GROUP_SIZE,
+    SUPPORTED_GROUP_SIZES,
+    QuantizedMomentAdam,
+    QuantizedMomentAdamW,
+)
+from unsloth_zoo.mlx.utils import load_optimizer_state, save_optimizer_state
+
+
+STEPS = 8
+
+
+def _build_model(width=256):
+    """Deterministic 2-layer MLP whose weights ARE quantization-eligible."""
+    mx.random.seed(0)
+    model = nn.Sequential(nn.Linear(width, width), nn.ReLU(), nn.Linear(width, width))
+    mx.eval(model.parameters())
+    return model
+
+
+def _build_ineligible_model():
+    """Every trainable parameter is ineligible for mx.quantize.
+
+    Linear(96, 100) has last dim 100, which is not a multiple of 64; biases are
+    1-D. Nothing here can be quantized, so the optimizer must fall back to fp32
+    moments throughout and still train.
+    """
+    mx.random.seed(0)
+    model = nn.Sequential(nn.Linear(96, 100), nn.ReLU(), nn.Linear(100, 100))
+    mx.eval(model.parameters())
+    return model
+
+
+def _batch(width=256, rows=32):
+    mx.random.seed(1)
+    return mx.random.normal((rows, width)), mx.random.normal((rows, width))
+
+
+def _mse(model, x, y):
+    return ((model(x) - y) ** 2).mean()
+
+
+def _train(optimizer, model, x, y, steps=STEPS, compiled=False):
+    grad_fn = nn.value_and_grad(model, _mse)
+    # Mirrors MLXTrainer: state = [model.state, optimizer.state, mx.random.state]
+    state = [model.state, optimizer.state, mx.random.state]
+
+    def step_fn(x, y):
+        loss, grads = grad_fn(model, x, y)
+        optimizer.update(model, grads)
+        return loss
+
+    if compiled:
+        step_fn = mx.compile(step_fn, inputs=state, outputs=state)
+    losses = []
+    for _ in range(steps):
+        loss = step_fn(x, y)
+        mx.eval(state)
+        losses.append(float(loss))
+    return losses
+
+
+def _state_bytes(state):
+    """Sum every array in the state tree.
+
+    Default traversal only: a quantized moment is a tuple/list of arrays, which
+    tree_flatten descends into as ``<param>.m.0/.1/.2`` -- the same flattening
+    save_optimizer_state relies on. Marking tuple/list as a leaf here would stop
+    the walk at the top-level ``layers`` list and count almost nothing.
+    """
+    return sum(v.nbytes for _, v in tree_flatten(state) if isinstance(v, mx.array))
+
+
+def _moment(optimizer, key="m"):
+    return optimizer.state["layers"][0]["weight"][key]
+
+
+# 1 ------------------------------------------------------------------------
+def test_loss_decreases_with_quantized_first_moment():
+    x, y = _batch()
+    losses = _train(QuantizedMomentAdam(1e-3, bias_correction=True), _build_model(), x, y)
+
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), (
+        f"loss did not decrease monotonically over {STEPS} steps: {losses}"
+    )
+    assert losses[-1] < losses[0]
+
+
+# 2 ------------------------------------------------------------------------
+def test_final_loss_matches_fp32_baseline():
+    x, y = _batch()
+    fp32 = _train(optim.Adam(learning_rate=1e-3, bias_correction=True), _build_model(), x, y)
+    int8 = _train(QuantizedMomentAdam(1e-3, bias_correction=True), _build_model(), x, y)
+
+    delta = abs(fp32[-1] - int8[-1])
+    assert delta < 1e-4, (
+        f"quantized first moment changed the final loss by {delta:.3e} "
+        f"(fp32 {fp32[-1]:.6f} vs int8 {int8[-1]:.6f})"
+    )
+
+
+# 3 ------------------------------------------------------------------------
+def test_optimizer_state_is_measurably_smaller():
+    x, y = _batch()
+    fp32_opt = optim.Adam(learning_rate=1e-3, bias_correction=True)
+    int8_opt = QuantizedMomentAdam(1e-3, bias_correction=True)
+    _train(fp32_opt, _build_model(), x, y, steps=1)
+    _train(int8_opt, _build_model(), x, y, steps=1)
+
+    fp32_bytes = _state_bytes(fp32_opt.state)
+    int8_bytes = _state_bytes(int8_opt.state)
+    reduction = 1.0 - (int8_bytes / fp32_bytes)
+
+    assert fp32_bytes > 0 and int8_bytes > 0
+    assert reduction >= 0.30, (
+        f"expected >=30% optimizer-state reduction, got {reduction:.1%} "
+        f"({fp32_bytes:,} -> {int8_bytes:,} bytes)"
+    )
+
+
+# 4 ------------------------------------------------------------------------
+def test_quantized_state_saves_reloads_and_resumes_identically():
+    x, y = _batch()
+    model = _build_model()
+    opt = QuantizedMomentAdam(1e-3, bias_correction=True)
+    _train(opt, model, x, y, steps=4)
+
+    checkpoint = tempfile.mkdtemp()
+    save_optimizer_state(opt, checkpoint)
+    weights = dict(tree_flatten(model.parameters()))
+
+    continuous = _train(opt, model, x, y, steps=1)[0]
+
+    resumed_model = _build_model()
+    resumed_model.update(tree_unflatten(list(weights.items())))
+    resumed_opt = QuantizedMomentAdam(1e-3, bias_correction=True)
+    # Materialise the state tree, then overwrite both weights and state so only
+    # the checkpoint contributes to the next step.
+    _train(resumed_opt, resumed_model, x, y, steps=1)
+    resumed_model.update(tree_unflatten(list(weights.items())))
+    load_optimizer_state(resumed_opt, checkpoint)
+    mx.eval(resumed_model.parameters(), resumed_opt.state)
+
+    resumed = _train(resumed_opt, resumed_model, x, y, steps=1)[0]
+
+    assert resumed == continuous, (
+        f"resume diverged: continuous {continuous:.8f} vs resumed {resumed:.8f}"
+    )
+
+
+# 5 ------------------------------------------------------------------------
+def test_second_moment_is_never_quantized():
+    """Guard: quantizing v diverges to NaN, so it must not be silently enabled."""
+    x, y = _batch()
+    opt = QuantizedMomentAdam(1e-3, bias_correction=True)
+    _train(opt, _build_model(), x, y, steps=2)
+
+    second = _moment(opt, "v")
+    assert isinstance(second, mx.array), (
+        f"second moment must stay a single fp32 array, got {type(second).__name__} "
+        "(a tuple/list means it was quantized)"
+    )
+    assert second.dtype == mx.float32, f"second moment dtype is {second.dtype}, expected float32"
+
+    first = _moment(opt, "m")
+    assert isinstance(first, (tuple, list)), (
+        "first moment should be a packed triple for an eligible parameter"
+    )
+
+
+# 6 ------------------------------------------------------------------------
+def test_compiled_and_uncompiled_agree():
+    x, y = _batch()
+    plain = _train(QuantizedMomentAdam(1e-3, bias_correction=True), _build_model(), x, y)
+    compiled = _train(
+        QuantizedMomentAdam(1e-3, bias_correction=True), _build_model(), x, y, compiled=True,
+    )
+
+    worst = max(abs(a - b) for a, b in zip(plain, compiled))
+    assert worst == 0.0, f"mx.compile changed the loss trajectory by {worst:.3e}: {plain} vs {compiled}"
+
+
+# 7 ------------------------------------------------------------------------
+def test_model_with_no_quantizable_parameters_still_trains():
+    """Most likely real-world break: nothing is eligible, so every moment is fp32."""
+    model = _build_ineligible_model()
+    opt = QuantizedMomentAdam(1e-3, bias_correction=True)
+
+    for _, param in tree_flatten(model.parameters()):
+        assert not opt.is_quantizable(param), f"fixture is wrong: {param.shape} is eligible"
+
+    mx.random.seed(1)
+    x = mx.random.normal((32, 96))
+    y = mx.random.normal((32, 100))
+    losses = _train(opt, model, x, y)
+
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), (
+        f"ineligible-parameter model failed to train: {losses}"
+    )
+    assert isinstance(_moment(opt, "m"), mx.array), (
+        "an ineligible parameter must keep a plain fp32 first moment"
+    )
+
+
+# 8 ------------------------------------------------------------------------
+@pytest.mark.parametrize("bits", [2, 4, 16, 32])
+def test_bit_widths_other_than_8_are_rejected(bits):
+    """Don't ship an unexercised knob: narrower widths are refused, not offered.
+
+    Optimizer moments are demonstrably quantization-sensitive -- affine 8-bit
+    quantization of the SECOND moment already diverges to NaN -- so a width with
+    no convergence evidence must not be silently accepted.
+    """
+    with pytest.raises(ValueError, match=r"supports bits=8 only"):
+        QuantizedMomentAdam(1e-3, bits=bits)
+    with pytest.raises(ValueError, match=r"supports bits=8 only"):
+        QuantizedMomentAdamW(1e-3, bits=bits)
+
+
+# 9 ------------------------------------------------------------------------
+@pytest.mark.parametrize("group_size", SUPPORTED_GROUP_SIZES)
+def test_every_supported_group_size_trains(group_size):
+    """Each advertised group size is exercised, not just the default."""
+    x, y = _batch()
+    opt = QuantizedMomentAdam(1e-3, bias_correction=True, group_size=group_size)
+    losses = _train(opt, _build_model(), x, y)
+
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), (
+        f"group_size={group_size} failed to train: {losses}"
+    )
+    assert isinstance(_moment(opt, "m"), (tuple, list))
+
+
+@pytest.mark.parametrize("group_size", [1, 48, 100, 256])
+def test_unsupported_group_size_is_rejected(group_size):
+    with pytest.raises(ValueError, match=r"supports group_size in"):
+        QuantizedMomentAdam(1e-3, group_size=group_size)
+
+
+# 10 -----------------------------------------------------------------------
+def test_adamw_variant_also_quantizes():
+    """The AdamW subclass inherits decoupled decay from the stock implementation."""
+    x, y = _batch()
+    opt = QuantizedMomentAdamW(1e-3, weight_decay=0.0, bias_correction=True)
+    losses = _train(opt, _build_model(), x, y)
+
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), losses
+    assert isinstance(_moment(opt, "m"), (tuple, list))
+    assert _moment(opt, "v").dtype == mx.float32
+    assert (DEFAULT_GROUP_SIZE, DEFAULT_BITS) == (opt.group_size, opt.bits)

--- a/tests/test_mlx_quantized_optimizer_state.py
+++ b/tests/test_mlx_quantized_optimizer_state.py
@@ -16,18 +16,25 @@
 
 """8-bit first-moment optimizer state for MLX.
 
-Behaviour over steps, not construction. Real MLX required, so this skips on Linux;
-the routing half runs under the torch shim. No ``Dataset.map`` here, so the
-spawn-vs-fork matrix does not apply.
+Behaviour over steps, not construction. Needs a real mlx runtime: Apple Silicon
+Metal, or Linux via ``mlx-cpu`` (both are wired up in CI). The routing half runs
+under the torch shim, which cannot implement ``mx.quantize``. No ``Dataset.map``
+here, so the spawn-vs-fork matrix does not apply.
 """
 
 import tempfile
 
 import pytest
 
-mx = pytest.importorskip("mlx.core", reason="MLX is only available on Apple Silicon")
-nn = pytest.importorskip("mlx.nn", reason="MLX is only available on Apple Silicon")
-optim = pytest.importorskip("mlx.optimizers", reason="MLX is only available on Apple Silicon")
+_SKIP = "Requires a real mlx runtime (Apple Silicon Metal, or Linux mlx-cpu)"
+
+mx = pytest.importorskip("mlx.core", reason=_SKIP)
+nn = pytest.importorskip("mlx.nn", reason=_SKIP)
+optim = pytest.importorskip("mlx.optimizers", reason=_SKIP)
+# importorskip alone is not enough: another test module may have installed the
+# mlx-on-torch shim into sys.modules first, and the shim raises on mx.quantize.
+if "mlx_simulation" in (getattr(mx, "__file__", "") or ""):
+    pytest.skip(_SKIP, allow_module_level=True)
 
 from mlx.utils import tree_flatten, tree_unflatten
 
@@ -39,6 +46,17 @@ from unsloth_zoo.mlx.optimizers_quantized import (
     QuantizedMomentAdamW,
 )
 from unsloth_zoo.mlx.utils import load_optimizer_state, save_optimizer_state
+
+
+@pytest.fixture(autouse=True)
+def _reject_shimmed_session():
+    """The shim is installed by other modules at test time, after this one was
+    imported, and it then owns mx.quantize for whichever unsloth_zoo module
+    imported mlx later. CI runs this file in its own pytest invocation (and fails
+    the job if it skips), so skipping here only affects mixed local runs."""
+    import sys
+    if "mlx_simulation" in sys.modules:
+        pytest.skip("the mlx-on-torch shim is active in this process")
 
 
 STEPS = 8
@@ -60,6 +78,21 @@ def _build_ineligible_model():
 
 
 def _batch(width=256, rows=32):
+    mx.random.seed(1)
+    return mx.random.normal((rows, width)), mx.random.normal((rows, width))
+
+
+def _build_bottleneck_model(width=256, hidden=64):
+    """Both weights stay quantization-eligible, but the model has far fewer
+    parameters than _underdetermined_batch has targets, so the loss floors above
+    zero instead of collapsing to ~1e-9."""
+    mx.random.seed(0)
+    model = nn.Sequential(nn.Linear(width, hidden), nn.ReLU(), nn.Linear(hidden, width))
+    mx.eval(model.parameters())
+    return model
+
+
+def _underdetermined_batch(width=256, rows=512):
     mx.random.seed(1)
     return mx.random.normal((rows, width)), mx.random.normal((rows, width))
 
@@ -110,16 +143,24 @@ def test_loss_decreases_with_quantized_first_moment():
 
 
 # 2 ------------------------------------------------------------------------
-def test_final_loss_matches_fp32_baseline():
-    x, y = _batch()
-    fp32 = _train(optim.Adam(learning_rate=1e-3, bias_correction=True), _build_model(), x, y)
-    int8 = _train(QuantizedMomentAdam(1e-3, bias_correction=True), _build_model(), x, y)
+def test_loss_trajectory_tracks_fp32_baseline():
+    """Compare the whole trajectory over a target the model CANNOT fit. On the
+    overparameterised fixture the loss reaches ~1e-9, where a relative comparison
+    measures nothing but float noise."""
+    x, y = _underdetermined_batch()
+    steps = 200
+    fp32 = _train(optim.Adam(learning_rate=1e-3, bias_correction=True),
+                  _build_bottleneck_model(), x, y, steps=steps)
+    int8 = _train(QuantizedMomentAdam(1e-3, bias_correction=True),
+                  _build_bottleneck_model(), x, y, steps=steps)
 
-    delta = abs(fp32[-1] - int8[-1])
-    assert delta < 1e-4, (
-        f"quantized first moment changed the final loss by {delta:.3e} "
-        f"(fp32 {fp32[-1]:.6f} vs int8 {int8[-1]:.6f})"
+    tail = slice(steps // 2, None)
+    mape = sum(abs(a - b) / abs(b) for a, b in zip(int8[tail], fp32[tail])) / (steps - steps // 2)
+    assert mape < 0.05, (
+        f"quantized first moment moved the loss trajectory by {mape:.2%} MAPE over the "
+        f"last {steps - steps // 2} steps (fp32 {fp32[-1]:.6e} vs int8 {int8[-1]:.6e})"
     )
+    assert all(l == l for l in int8), "quantized run produced a NaN"
 
 
 # 3 ------------------------------------------------------------------------
@@ -143,6 +184,9 @@ def test_optimizer_state_is_measurably_smaller():
 
 # 4 ------------------------------------------------------------------------
 def test_quantized_state_saves_reloads_and_resumes_identically():
+    """Compares POST-update parameters and every state leaf. ``_train`` returns the
+    loss computed before the update, so comparing that would pass even with
+    load_optimizer_state removed entirely."""
     x, y = _batch()
     model = _build_model()
     opt = QuantizedMomentAdam(1e-3, bias_correction=True)
@@ -152,7 +196,9 @@ def test_quantized_state_saves_reloads_and_resumes_identically():
     save_optimizer_state(opt, checkpoint)
     weights = dict(tree_flatten(model.parameters()))
 
-    continuous = _train(opt, model, x, y, steps=1)[0]
+    _train(opt, model, x, y, steps=1)
+    continuous = dict(tree_flatten(model.parameters()))
+    continuous_state = dict(tree_flatten(opt.state))
 
     resumed_model = _build_model()
     resumed_model.update(tree_unflatten(list(weights.items())))
@@ -164,11 +210,18 @@ def test_quantized_state_saves_reloads_and_resumes_identically():
     load_optimizer_state(resumed_opt, checkpoint)
     mx.eval(resumed_model.parameters(), resumed_opt.state)
 
-    resumed = _train(resumed_opt, resumed_model, x, y, steps=1)[0]
+    _train(resumed_opt, resumed_model, x, y, steps=1)
+    resumed = dict(tree_flatten(resumed_model.parameters()))
+    resumed_state = dict(tree_flatten(resumed_opt.state))
 
-    assert resumed == continuous, (
-        f"resume diverged: continuous {continuous:.8f} vs resumed {resumed:.8f}"
-    )
+    for name, expected in continuous.items():
+        delta = float(mx.abs(resumed[name] - expected).max())
+        assert delta == 0.0, f"resumed parameter {name} differs by {delta:.3e}"
+    assert resumed_state.keys() == continuous_state.keys(), "state tree shape changed"
+    for name, expected in continuous_state.items():
+        delta = float(mx.abs(resumed_state[name].astype(mx.float32)
+                             - expected.astype(mx.float32)).max())
+        assert delta == 0.0, f"resumed state leaf {name} differs by {delta:.3e}"
 
 
 # 5 ------------------------------------------------------------------------
@@ -180,9 +233,10 @@ def test_second_moment_is_never_quantized():
 
     second = _moment(opt, "v")
     assert isinstance(second, mx.array), (
-        f"second moment must stay a single fp32 array, got {type(second).__name__} "
+        f"second moment must stay a single unquantized array, got {type(second).__name__} "
         "(a tuple/list means it was quantized)"
     )
+    # This fixture is fp32; dtype tracking in general is test_moments_follow_the_parameter_dtype.
     assert second.dtype == mx.float32, f"second moment dtype is {second.dtype}, expected float32"
 
     first = _moment(opt, "m")
@@ -256,6 +310,117 @@ def test_unsupported_group_size_is_rejected(group_size):
 
 
 # 10 -----------------------------------------------------------------------
+# 11 -----------------------------------------------------------------------
+def test_zero_gradient_coordinates_never_move():
+    """A coordinate whose gradient is identically zero keeps v == 0, so the Adam
+    denominator is eps alone and any dequantization residue is amplified ~1e8x.
+    Plain Adam moves it by exactly nothing and so must this."""
+    steps, lr = 500, 1e-3
+    grad = mx.array([[1.0] + [0.0] * (DEFAULT_GROUP_SIZE - 1)])
+
+    def drive(opt):
+        param = mx.zeros((1, DEFAULT_GROUP_SIZE))
+        opt.init({"w": param})
+        for _ in range(steps):
+            param = opt.apply_gradients({"w": grad}, {"w": param})["w"]
+            mx.eval(param, opt.state)
+        return param
+
+    got = drive(QuantizedMomentAdam(lr, bias_correction=True))
+    moved = float(mx.abs(got[0, 1:]).max())
+    assert moved == 0.0, (
+        f"a zero-gradient coordinate moved {moved:.6f} ({moved / (lr * steps):.1f}x the "
+        "lr*steps budget); plain Adam leaves it at exactly 0"
+    )
+    assert float(got[0, 0]) != 0.0, "the live coordinate should still train"
+
+
+# 12 -----------------------------------------------------------------------
+def test_plain_checkpoint_migrates_to_packed_on_resume():
+    """Before this optimizer existed, adamw_8bit produced plain AdamW state. Such a
+    checkpoint must not leave the moment full width for the rest of the run."""
+    x, y = _batch()
+    model = _build_model()
+    plain = optim.Adam(learning_rate=1e-3, bias_correction=True)
+    _train(plain, model, x, y, steps=4)
+    checkpoint = tempfile.mkdtemp()
+    save_optimizer_state(plain, checkpoint)
+
+    resumed = QuantizedMomentAdam(1e-3, bias_correction=True)
+    resumed_model = _build_model()
+    _train(resumed, resumed_model, x, y, steps=1)
+    load_optimizer_state(resumed, checkpoint)
+    assert isinstance(_moment(resumed, "m"), mx.array), "fixture is wrong: not a plain array"
+
+    _train(resumed, resumed_model, x, y, steps=1)
+    assert isinstance(_moment(resumed, "m"), (tuple, list)), (
+        "an eligible moment loaded from a pre-quantization checkpoint stayed full width"
+    )
+
+
+# 13 -----------------------------------------------------------------------
+def test_packed_checkpoint_loads_into_plain_optimizer():
+    """Switching back to optim="adamw" must not hand a list to mlx's b1 * m."""
+    x, y = _batch()
+    model = _build_model()
+    packed = QuantizedMomentAdam(1e-3, bias_correction=True)
+    _train(packed, model, x, y, steps=4)
+    checkpoint = tempfile.mkdtemp()
+    save_optimizer_state(packed, checkpoint)
+
+    plain = optim.Adam(learning_rate=1e-3, bias_correction=True)
+    plain_model = _build_model()
+    _train(plain, plain_model, x, y, steps=1)
+    load_optimizer_state(plain, checkpoint)
+    assert isinstance(_moment(plain, "m"), mx.array), "packed moment was not unpacked"
+    _train(plain, plain_model, x, y, steps=1)
+
+
+# 14 -----------------------------------------------------------------------
+@pytest.mark.parametrize("saved,resumed", [(32, 128), (128, 32)])
+def test_group_size_is_read_back_from_the_checkpoint(saved, resumed):
+    """group_size is an instance attribute, so it rides in safetensors metadata."""
+    x, y = _batch()
+    opt = QuantizedMomentAdam(1e-3, bias_correction=True, group_size=saved)
+    _train(opt, _build_model(), x, y, steps=2)
+    checkpoint = tempfile.mkdtemp()
+    save_optimizer_state(opt, checkpoint)
+
+    other = QuantizedMomentAdam(1e-3, bias_correction=True, group_size=resumed)
+    other_model = _build_model()
+    _train(other, other_model, x, y, steps=1)
+    load_optimizer_state(other, checkpoint)
+    assert other.group_size == saved
+    _train(other, other_model, x, y, steps=1)
+
+
+# 15 -----------------------------------------------------------------------
+@pytest.mark.parametrize("kwargs", [{"bits": 8.9}, {"group_size": 64.9}, {"bits": True}])
+def test_non_integral_settings_are_rejected(kwargs):
+    """int() truncates, so bits=8.9 would silently pass the bits == 8 check."""
+    with pytest.raises(ValueError, match="must be an integer"):
+        QuantizedMomentAdam(1e-3, **kwargs)
+
+
+# 16 -----------------------------------------------------------------------
+def test_moments_follow_the_parameter_dtype():
+    """The saving is 8-bit against the parameter dtype, not against float32."""
+    mx.random.seed(0)
+    model = nn.Sequential(nn.Linear(256, 256), nn.ReLU(), nn.Linear(256, 256))
+    model.set_dtype(mx.bfloat16)
+    mx.eval(model.parameters())
+    mx.random.seed(1)
+    x = mx.random.normal((32, 256)).astype(mx.bfloat16)
+    y = mx.random.normal((32, 256)).astype(mx.bfloat16)
+
+    opt = QuantizedMomentAdam(1e-3, bias_correction=True)
+    _train(opt, model, x, y, steps=2)
+    assert _moment(opt, "v").dtype == mx.bfloat16, (
+        "v follows the parameter dtype; it is unquantized, not float32"
+    )
+    assert isinstance(_moment(opt, "m"), (tuple, list))
+
+
 def test_adamw_variant_also_quantizes():
 
     x, y = _batch()

--- a/unsloth_zoo/mlx/optimizers_quantized.py
+++ b/unsloth_zoo/mlx/optimizers_quantized.py
@@ -16,9 +16,24 @@
 
 """8-bit optimizer state for MLX: quantized Adam/AdamW FIRST moment.
 
-Adam holds two fp32 buffers per parameter, so state is 2x the trainable bytes.
-Packing ``m`` to 8 bits cuts that at no measurable cost: final loss 0.08318 vs an
-fp32 baseline of 0.08317 on the same seed.
+Adam holds two moment buffers per parameter, so state is 2x the trainable bytes.
+Packing ``m`` to 8 bits cuts that by ``1 - (f*(1/b + 2/G) + (1-f) + 1)/2`` for a
+dtype of ``b`` bytes, group size ``G`` and an eligible byte fraction ``f``.
+Measured end to end on SmolLM2-135M, group_size=64:
+
+    full fine-tune, float32 state   35.9%     LoRA r=64        35.9%
+    full fine-tune, bfloat16 state  23.4%     LoRA r=16/r=32   18.3%
+
+Only the first two are the "8-bit vs 32-bit" figure. MLX creates moments with
+``mx.zeros_like(parameter)``, so a bfloat16 model has bfloat16 moments and the
+packed moment is being compared against 2 bytes, not 4. Under LoRA only one of
+each adapter pair is eligible unless the group size divides the rank, so r=32
+reaches 34.4% at ``group_size=32`` but only 18.3% at 64.
+
+This shrinks PERSISTENT state, not peak allocation: ``apply_single`` materialises
+a full-width ``m`` per parameter per step, and peak rose 11.7% on Metal and 29.9%
+on the CPU backend in a 135M full fine-tune. Loss impact over 200 steps is 0.44%
+MAPE full fine-tune and 0.76% LoRA against the same seed and data order.
 
 ``v`` is deliberately NOT quantized. It is a running mean of squared gradients, so
 it spans orders of magnitude and sits near zero early; MLX's affine ``mx.quantize``
@@ -28,22 +43,29 @@ explodes - measured, for both int8 m+v and fp32 m + int8 v:
     1.0590 -> 0.8627 -> 19.3755 -> 10.2466 -> nan
 
 That needs bitsandbytes-style dynamic quantization, which MLX does not expose.
+``v`` keeps whatever dtype the parameter has; it is unquantized, not float32.
 
-Two constraints are load-bearing; do not "simplify" them away:
+Three constraints are load-bearing; do not "simplify" them away:
 
 1. Optimizer state must hold ONLY ``mx.array`` leaves - it is walked by
    ``tree_flatten`` (checkpointing) and ``mx.compile``. A Python ``bool`` beside
    the moments raises ``TypeError: object of type 'bool' has no len()``, so
-   whether a moment is quantized is inferred from its value, never a stored flag.
+   group_size/bits live on the instance and are checkpointed as safetensors
+   metadata by ``save_optimizer_state``.
 
-2. ``tree_map`` and ``tree_unflatten`` rebuild the quantized 3-tuple as a LIST, so
-   ``isinstance(m, tuple)`` alone misses the reloaded case and fails with
+2. ``mx.quantize`` returns a LIST on mlx 0.32, and ``tree_unflatten`` rebuilds the
+   triple as a list too, so ``isinstance(m, tuple)`` alone fails with
    ``TypeError: can't multiply sequence by non-int of type 'float'``. Test
    ``(tuple, list)``.
 
-Compiled and uncompiled runs are bit-identical under ``inputs=state,
-outputs=state``. The triple flattens to ``<param>.m.0/.1/.2``, so
-save/load_optimizer_state round-trip it and a resumed step reproduces exactly.
+3. Whether to re-pack is decided from ``is_quantizable(parameter)``, never from
+   the current type of ``state["m"]``. A checkpoint written by plain AdamW loads
+   an unpacked array, and inferring from it would leave that moment full width
+   for the rest of the run while the banner claims otherwise.
+
+Compiled and uncompiled runs agree under ``inputs=state, outputs=state``. The
+triple flattens to ``<param>.m.0/.1/.2``, so save/load_optimizer_state round-trip
+it and a resumed step reproduces the next parameters and state exactly.
 """
 
 import mlx.core as mx
@@ -55,6 +77,8 @@ __all__ = [
     "DEFAULT_GROUP_SIZE",
     "DEFAULT_BITS",
     "SUPPORTED_GROUP_SIZES",
+    "unpack_quantized_moments",
+    "state_has_quantized_moments",
 ]
 
 DEFAULT_GROUP_SIZE = 64
@@ -63,13 +87,20 @@ DEFAULT_BITS = 8
 SUPPORTED_GROUP_SIZES = (32, 64, 128)
 
 
+def _as_int(value, name):
+    """``int()`` truncates, so ``bits=8.9`` would pass as 8. Reject instead."""
+    if isinstance(value, bool) or int(value) != value:
+        raise ValueError(f"Unsloth: {name} must be an integer, got {value!r}.")
+    return int(value)
+
+
 class _QuantizedFirstMomentMixin:
     """Store ``state["m"]`` 8-bit packed; delegate the update math to the parent,
     so bias correction and AdamW's decoupled decay stay the stock implementation."""
 
     def _init_quantization(self, group_size, bits):
         # Instance attributes, NOT optimizer state (which holds arrays only).
-        bits = int(bits)
+        bits = _as_int(bits, "bits")
         if bits != DEFAULT_BITS:
             # Rejected rather than offered untested: this state is demonstrably
             # quantization-sensitive (see the second-moment NaN trace above).
@@ -79,7 +110,7 @@ class _QuantizedFirstMomentMixin:
                 "sensitive (affine 8-bit quantization of the second moment already "
                 "diverges to NaN), so narrower widths are rejected until measured."
             )
-        group_size = int(group_size)
+        group_size = _as_int(group_size, "group_size")
         if group_size not in SUPPORTED_GROUP_SIZES:
             raise ValueError(
                 f"Unsloth: quantized optimizer state supports group_size in "
@@ -90,7 +121,7 @@ class _QuantizedFirstMomentMixin:
 
     def is_quantizable(self, parameter):
         """``mx.quantize`` needs 2-D with last dim divisible by group_size.
-        Everything else keeps an fp32 moment and still trains, saving nothing."""
+        Everything else keeps a full-width moment and still trains, saving nothing."""
         return parameter.ndim == 2 and parameter.shape[-1] % self.group_size == 0
 
     def init_single(self, parameter, state):
@@ -102,14 +133,19 @@ class _QuantizedFirstMomentMixin:
 
     def apply_single(self, gradient, parameter, state):
         packed = state["m"]
-        # tuple OR list: tree_map/tree_unflatten rebuild the triple as a list.
-        quantized = isinstance(packed, (tuple, list))
-        if quantized:
-            state["m"] = mx.dequantize(
+        # tuple OR list: mx.quantize and tree_unflatten both give a list.
+        if isinstance(packed, (tuple, list)):
+            moment = mx.dequantize(
                 *packed, group_size=self.group_size, bits=self.bits,
             )
+            # Affine dequantization does not land exactly on zero, and v == 0
+            # means this coordinate has only seen zero gradients, so its true
+            # moment is zero. Without this the residue is divided by eps alone.
+            state["m"] = mx.where(state["v"] == 0, mx.zeros_like(moment), moment)
         updated = super().apply_single(gradient, parameter, state)
-        if quantized:
+        # Re-pack from eligibility, not from what was loaded: a checkpoint
+        # written by plain AdamW arrives unpacked and must not stay that way.
+        if self.is_quantizable(parameter):
             state["m"] = mx.quantize(
                 state["m"], group_size=self.group_size, bits=self.bits,
             )
@@ -117,7 +153,7 @@ class _QuantizedFirstMomentMixin:
 
 
 class QuantizedMomentAdam(_QuantizedFirstMomentMixin, optim.Adam):
-    """Adam with an 8-bit first moment. Second moment stays fp32."""
+    """Adam with an 8-bit first moment. Second moment is left unquantized."""
 
     def __init__(
         self,
@@ -138,7 +174,7 @@ class QuantizedMomentAdam(_QuantizedFirstMomentMixin, optim.Adam):
 
 
 class QuantizedMomentAdamW(_QuantizedFirstMomentMixin, optim.AdamW):
-    """AdamW with an 8-bit first moment. Second moment stays fp32."""
+    """AdamW with an 8-bit first moment. Second moment is left unquantized."""
 
     def __init__(
         self,
@@ -165,11 +201,47 @@ def describe_quantized_optimizer(optimizer_name, group_size = DEFAULT_GROUP_SIZE
     ``adamw_8bit`` to ``adamw`` silently; a quieter surprise would be no better."""
     return (
         f"Unsloth: {optimizer_name} on MLX quantizes the optimizer's FIRST moment "
-        f"to 8-bit (group_size={group_size}); the second moment stays float32 "
+        f"to 8-bit (group_size={group_size}); the second moment is not quantized "
         "(affine 8-bit quantization of the second moment diverges). Only 2-D "
         f"parameters whose last dimension is a multiple of {group_size} are "
-        "quantized; all others keep float32 moments."
+        "quantized; all others keep unquantized moments. Moments follow the "
+        "parameter dtype, so this saves about 36% of optimizer state in float32 "
+        "and about 23% in bfloat16, and it does not lower peak memory."
     )
+
+
+def unpack_quantized_moments(state, group_size = DEFAULT_GROUP_SIZE, bits = DEFAULT_BITS):
+    """Dequantize every packed first moment in a loaded state tree.
+
+    Lets a checkpoint written by a quantized optimizer load into a plain
+    ``optim.Adam``/``AdamW``, which would otherwise reach ``b1 * m`` on a list and
+    raise ``TypeError: can't multiply sequence by non-int of type 'float'`` from
+    inside mlx with no mention of quantization.
+    """
+    if isinstance(state, dict):
+        out = {}
+        for key, value in state.items():
+            if key == "m" and isinstance(value, (tuple, list)) and len(value) == 3:
+                out[key] = mx.dequantize(*value, group_size = group_size, bits = bits)
+            else:
+                out[key] = unpack_quantized_moments(value, group_size, bits)
+        return out
+    if isinstance(state, list):
+        return [unpack_quantized_moments(v, group_size, bits) for v in state]
+    return state
+
+
+def state_has_quantized_moments(state):
+    """True if any ``m`` leaf in the tree is a packed triple."""
+    if isinstance(state, dict):
+        return any(
+            (key == "m" and isinstance(value, (tuple, list)) and len(value) == 3)
+            or state_has_quantized_moments(value)
+            for key, value in state.items()
+        )
+    if isinstance(state, list):
+        return any(state_has_quantized_moments(v) for v in state)
+    return False
 
 # Unsloth Zoo - Utilities for Unsloth
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.

--- a/unsloth_zoo/mlx/optimizers_quantized.py
+++ b/unsloth_zoo/mlx/optimizers_quantized.py
@@ -16,46 +16,34 @@
 
 """8-bit optimizer state for MLX: quantized Adam/AdamW FIRST moment.
 
-Adam keeps two fp32 buffers per parameter (``m``, ``v``), so optimizer state is
-2x the trainable-parameter bytes. Storing ``m`` as 8-bit packed arrays cuts that
-materially at no measurable cost to the loss curve.
+Adam holds two fp32 buffers per parameter, so state is 2x the trainable bytes.
+Packing ``m`` to 8 bits cuts that at no measurable cost: final loss 0.08318 vs an
+fp32 baseline of 0.08317 on the same seed.
 
-ONLY the first moment is quantized. The second moment stays fp32, deliberately:
-``v`` is a running mean of SQUARED gradients, so its values span many orders of
-magnitude and sit near zero early in training. MLX's ``mx.quantize`` is an affine
-per-group scheme, and the reconstruction error near zero is large relative to the
-value; ``sqrt(v)`` then lands in the update denominator and the step explodes.
-Measured on a 2-layer MLP, quantizing ``v`` diverges within three steps:
+``v`` is deliberately NOT quantized. It is a running mean of squared gradients, so
+it spans orders of magnitude and sits near zero early; MLX's affine ``mx.quantize``
+reconstructs poorly there, ``sqrt(v)`` lands in the denominator, and the step
+explodes - measured, for both int8 m+v and fp32 m + int8 v:
 
     1.0590 -> 0.8627 -> 19.3755 -> 10.2466 -> nan
 
-both for int8 m + int8 v and for fp32 m + int8 v. Quantizing ``m`` alone is
-stable: final loss 0.08318 against an fp32 baseline of 0.08317 on the same seed.
-Making ``v`` quantizable needs a dynamic/exponential mapping with stochastic
-rounding (what bitsandbytes implements); MLX exposes no such primitive, so this
-module does not pretend to offer it.
+That needs bitsandbytes-style dynamic quantization, which MLX does not expose.
 
-Two MLX-specific constraints are load-bearing here. Do not "simplify" them away:
+Two constraints are load-bearing; do not "simplify" them away:
 
-1. Optimizer state must contain ONLY ``mx.array`` leaves. ``Optimizer.state`` is
-   walked by ``tree_flatten`` (for checkpointing) and by ``mx.compile``'s
-   inputs/outputs. A plain Python ``bool`` stored alongside the moments raises
-   ``TypeError: object of type 'bool' has no len()``. Whether a moment is
-   quantized is therefore inferred from its VALUE, never from a stored flag.
+1. Optimizer state must hold ONLY ``mx.array`` leaves - it is walked by
+   ``tree_flatten`` (checkpointing) and ``mx.compile``. A Python ``bool`` beside
+   the moments raises ``TypeError: object of type 'bool' has no len()``, so
+   whether a moment is quantized is inferred from its value, never a stored flag.
 
-2. A quantized moment is the 3-tuple ``mx.quantize`` returns, but
-   ``mlx.utils.tree_map`` (used by ``Optimizer.apply_gradients``) and
-   ``tree_unflatten`` (used when reloading a checkpoint) rebuild containers, so
-   the triple comes back as a LIST. Checking ``isinstance(m, tuple)`` alone
-   silently misses the reloaded case and fails with
-   ``TypeError: can't multiply sequence by non-int of type 'float'``. Always test
+2. ``tree_map`` and ``tree_unflatten`` rebuild the quantized 3-tuple as a LIST, so
+   ``isinstance(m, tuple)`` alone misses the reloaded case and fails with
+   ``TypeError: can't multiply sequence by non-int of type 'float'``. Test
    ``(tuple, list)``.
 
-Verified against ``mx.compile`` with ``inputs=state, outputs=state`` (how
-MLXTrainer compiles its step): compiled and uncompiled runs are bit-identical.
-The quantized triple flattens to ``<param>.m.0/.1/.2``, all arrays, so
-``save_optimizer_state`` / ``load_optimizer_state`` round-trip it unchanged and a
-resumed step reproduces the continuous one exactly.
+Compiled and uncompiled runs are bit-identical under ``inputs=state,
+outputs=state``. The triple flattens to ``<param>.m.0/.1/.2``, so
+save/load_optimizer_state round-trip it and a resumed step reproduces exactly.
 """
 
 import mlx.core as mx
@@ -76,23 +64,15 @@ SUPPORTED_GROUP_SIZES = (32, 64, 128)
 
 
 class _QuantizedFirstMomentMixin:
-    """Store ``state["m"]`` 8-bit packed; delegate the update math to the parent.
-
-    ``apply_single`` dequantizes into the state, calls the parent (so bias
-    correction and AdamW's decoupled decay stay byte-for-byte the stock
-    implementation), then requantizes what the parent wrote back.
-    """
+    """Store ``state["m"]`` 8-bit packed; delegate the update math to the parent,
+    so bias correction and AdamW's decoupled decay stay the stock implementation."""
 
     def _init_quantization(self, group_size, bits):
-        # Plain instance attributes, NOT optimizer state: state holds arrays only
-        # (see the module docstring). self.betas / self.eps are stored the same way.
+        # Instance attributes, NOT optimizer state (which holds arrays only).
         bits = int(bits)
         if bits != DEFAULT_BITS:
-            # Rejected rather than offered untested. Optimizer state here is
-            # demonstrably quantization-sensitive, not theoretically so: affine
-            # 8-bit quantization of the SECOND moment already diverges to NaN
-            # (1.0590 -> 0.8627 -> 19.3755 -> nan). A narrower width for the first
-            # moment needs its own convergence evidence before it ships.
+            # Rejected rather than offered untested: this state is demonstrably
+            # quantization-sensitive (see the second-moment NaN trace above).
             raise ValueError(
                 f"Unsloth: quantized optimizer state supports bits={DEFAULT_BITS} "
                 f"only, got bits={bits}. Optimizer moments are quantization-"
@@ -109,12 +89,8 @@ class _QuantizedFirstMomentMixin:
         self.bits = bits
 
     def is_quantizable(self, parameter):
-        """``mx.quantize`` needs a 2-D array whose last dim divides group_size.
-
-        Everything else (biases, norms, embeddings with an odd width) keeps an
-        fp32 moment, so a model with no eligible parameter still trains -- it
-        just saves nothing.
-        """
+        """``mx.quantize`` needs 2-D with last dim divisible by group_size.
+        Everything else keeps an fp32 moment and still trains, saving nothing."""
         return parameter.ndim == 2 and parameter.shape[-1] % self.group_size == 0
 
     def init_single(self, parameter, state):
@@ -185,13 +161,8 @@ class QuantizedMomentAdamW(_QuantizedFirstMomentMixin, optim.AdamW):
 
 
 def describe_quantized_optimizer(optimizer_name, group_size = DEFAULT_GROUP_SIZE):
-    """One-line description of what an 8-bit optimizer request actually gets.
-
-    The historical behaviour was to rewrite ``adamw_8bit`` to plain ``adamw``
-    with no message, so users asking for 8-bit silently got fp32 state. Replacing
-    that with a quieter surprise would be no better, so state the shape of the
-    saving explicitly.
-    """
+    """What an 8-bit request actually gets. The old behaviour rewrote
+    ``adamw_8bit`` to ``adamw`` silently; a quieter surprise would be no better."""
     return (
         f"Unsloth: {optimizer_name} on MLX quantizes the optimizer's FIRST moment "
         f"to 8-bit (group_size={group_size}); the second moment stays float32 "

--- a/unsloth_zoo/mlx/optimizers_quantized.py
+++ b/unsloth_zoo/mlx/optimizers_quantized.py
@@ -2,16 +2,16 @@
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public License
+# You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """8-bit optimizer state for MLX: quantized Adam/AdamW FIRST moment.
@@ -217,12 +217,20 @@ def unpack_quantized_moments(state, group_size = DEFAULT_GROUP_SIZE, bits = DEFA
     ``optim.Adam``/``AdamW``, which would otherwise reach ``b1 * m`` on a list and
     raise ``TypeError: can't multiply sequence by non-int of type 'float'`` from
     inside mlx with no mention of quantization.
+
+    Applies the same ``v == 0`` mask ``apply_single`` does. Carrying the residue out
+    to a plain optimizer would reintroduce the blow-up there: measured 5.96e-08 of
+    residue moving inactive coordinates by 5.4e-02 over 200 zero-gradient steps.
     """
     if isinstance(state, dict):
         out = {}
         for key, value in state.items():
             if key == "m" and isinstance(value, (tuple, list)) and len(value) == 3:
-                out[key] = mx.dequantize(*value, group_size = group_size, bits = bits)
+                moment = mx.dequantize(*value, group_size = group_size, bits = bits)
+                second = state.get("v")
+                if isinstance(second, mx.array) and second.shape == moment.shape:
+                    moment = mx.where(second == 0, mx.zeros_like(moment), moment)
+                out[key] = moment
             else:
                 out[key] = unpack_quantized_moments(value, group_size, bits)
         return out
@@ -242,19 +250,3 @@ def state_has_quantized_moments(state):
     if isinstance(state, list):
         return any(state_has_quantized_moments(v) for v in state)
     return False
-
-# Unsloth Zoo - Utilities for Unsloth
-# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/unsloth_zoo/mlx/optimizers_quantized.py
+++ b/unsloth_zoo/mlx/optimizers_quantized.py
@@ -1,0 +1,217 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""8-bit optimizer state for MLX: quantized Adam/AdamW FIRST moment.
+
+Adam keeps two fp32 buffers per parameter (``m``, ``v``), so optimizer state is
+2x the trainable-parameter bytes. Storing ``m`` as 8-bit packed arrays cuts that
+materially at no measurable cost to the loss curve.
+
+ONLY the first moment is quantized. The second moment stays fp32, deliberately:
+``v`` is a running mean of SQUARED gradients, so its values span many orders of
+magnitude and sit near zero early in training. MLX's ``mx.quantize`` is an affine
+per-group scheme, and the reconstruction error near zero is large relative to the
+value; ``sqrt(v)`` then lands in the update denominator and the step explodes.
+Measured on a 2-layer MLP, quantizing ``v`` diverges within three steps:
+
+    1.0590 -> 0.8627 -> 19.3755 -> 10.2466 -> nan
+
+both for int8 m + int8 v and for fp32 m + int8 v. Quantizing ``m`` alone is
+stable: final loss 0.08318 against an fp32 baseline of 0.08317 on the same seed.
+Making ``v`` quantizable needs a dynamic/exponential mapping with stochastic
+rounding (what bitsandbytes implements); MLX exposes no such primitive, so this
+module does not pretend to offer it.
+
+Two MLX-specific constraints are load-bearing here. Do not "simplify" them away:
+
+1. Optimizer state must contain ONLY ``mx.array`` leaves. ``Optimizer.state`` is
+   walked by ``tree_flatten`` (for checkpointing) and by ``mx.compile``'s
+   inputs/outputs. A plain Python ``bool`` stored alongside the moments raises
+   ``TypeError: object of type 'bool' has no len()``. Whether a moment is
+   quantized is therefore inferred from its VALUE, never from a stored flag.
+
+2. A quantized moment is the 3-tuple ``mx.quantize`` returns, but
+   ``mlx.utils.tree_map`` (used by ``Optimizer.apply_gradients``) and
+   ``tree_unflatten`` (used when reloading a checkpoint) rebuild containers, so
+   the triple comes back as a LIST. Checking ``isinstance(m, tuple)`` alone
+   silently misses the reloaded case and fails with
+   ``TypeError: can't multiply sequence by non-int of type 'float'``. Always test
+   ``(tuple, list)``.
+
+Verified against ``mx.compile`` with ``inputs=state, outputs=state`` (how
+MLXTrainer compiles its step): compiled and uncompiled runs are bit-identical.
+The quantized triple flattens to ``<param>.m.0/.1/.2``, all arrays, so
+``save_optimizer_state`` / ``load_optimizer_state`` round-trip it unchanged and a
+resumed step reproduces the continuous one exactly.
+"""
+
+import mlx.core as mx
+import mlx.optimizers as optim
+
+__all__ = [
+    "QuantizedMomentAdam",
+    "QuantizedMomentAdamW",
+    "DEFAULT_GROUP_SIZE",
+    "DEFAULT_BITS",
+    "SUPPORTED_GROUP_SIZES",
+]
+
+DEFAULT_GROUP_SIZE = 64
+DEFAULT_BITS = 8
+# mx.quantize's supported group sizes; all three are exercised by the test suite.
+SUPPORTED_GROUP_SIZES = (32, 64, 128)
+
+
+class _QuantizedFirstMomentMixin:
+    """Store ``state["m"]`` 8-bit packed; delegate the update math to the parent.
+
+    ``apply_single`` dequantizes into the state, calls the parent (so bias
+    correction and AdamW's decoupled decay stay byte-for-byte the stock
+    implementation), then requantizes what the parent wrote back.
+    """
+
+    def _init_quantization(self, group_size, bits):
+        # Plain instance attributes, NOT optimizer state: state holds arrays only
+        # (see the module docstring). self.betas / self.eps are stored the same way.
+        bits = int(bits)
+        if bits != DEFAULT_BITS:
+            # Rejected rather than offered untested. Optimizer state here is
+            # demonstrably quantization-sensitive, not theoretically so: affine
+            # 8-bit quantization of the SECOND moment already diverges to NaN
+            # (1.0590 -> 0.8627 -> 19.3755 -> nan). A narrower width for the first
+            # moment needs its own convergence evidence before it ships.
+            raise ValueError(
+                f"Unsloth: quantized optimizer state supports bits={DEFAULT_BITS} "
+                f"only, got bits={bits}. Optimizer moments are quantization-"
+                "sensitive (affine 8-bit quantization of the second moment already "
+                "diverges to NaN), so narrower widths are rejected until measured."
+            )
+        group_size = int(group_size)
+        if group_size not in SUPPORTED_GROUP_SIZES:
+            raise ValueError(
+                f"Unsloth: quantized optimizer state supports group_size in "
+                f"{SUPPORTED_GROUP_SIZES}, got group_size={group_size}."
+            )
+        self.group_size = group_size
+        self.bits = bits
+
+    def is_quantizable(self, parameter):
+        """``mx.quantize`` needs a 2-D array whose last dim divides group_size.
+
+        Everything else (biases, norms, embeddings with an odd width) keeps an
+        fp32 moment, so a model with no eligible parameter still trains -- it
+        just saves nothing.
+        """
+        return parameter.ndim == 2 and parameter.shape[-1] % self.group_size == 0
+
+    def init_single(self, parameter, state):
+        super().init_single(parameter, state)
+        if self.is_quantizable(parameter):
+            state["m"] = mx.quantize(
+                state["m"], group_size=self.group_size, bits=self.bits,
+            )
+
+    def apply_single(self, gradient, parameter, state):
+        packed = state["m"]
+        # tuple OR list: tree_map/tree_unflatten rebuild the triple as a list.
+        quantized = isinstance(packed, (tuple, list))
+        if quantized:
+            state["m"] = mx.dequantize(
+                *packed, group_size=self.group_size, bits=self.bits,
+            )
+        updated = super().apply_single(gradient, parameter, state)
+        if quantized:
+            state["m"] = mx.quantize(
+                state["m"], group_size=self.group_size, bits=self.bits,
+            )
+        return updated
+
+
+class QuantizedMomentAdam(_QuantizedFirstMomentMixin, optim.Adam):
+    """Adam with an 8-bit first moment. Second moment stays fp32."""
+
+    def __init__(
+        self,
+        learning_rate,
+        betas = [0.9, 0.999],
+        eps = 1e-8,
+        bias_correction = False,
+        group_size = DEFAULT_GROUP_SIZE,
+        bits = DEFAULT_BITS,
+    ):
+        super().__init__(
+            learning_rate = learning_rate,
+            betas = betas,
+            eps = eps,
+            bias_correction = bias_correction,
+        )
+        self._init_quantization(group_size, bits)
+
+
+class QuantizedMomentAdamW(_QuantizedFirstMomentMixin, optim.AdamW):
+    """AdamW with an 8-bit first moment. Second moment stays fp32."""
+
+    def __init__(
+        self,
+        learning_rate,
+        betas = [0.9, 0.999],
+        eps = 1e-8,
+        weight_decay = 0.01,
+        bias_correction = False,
+        group_size = DEFAULT_GROUP_SIZE,
+        bits = DEFAULT_BITS,
+    ):
+        super().__init__(
+            learning_rate = learning_rate,
+            betas = betas,
+            eps = eps,
+            weight_decay = weight_decay,
+            bias_correction = bias_correction,
+        )
+        self._init_quantization(group_size, bits)
+
+
+def describe_quantized_optimizer(optimizer_name, group_size = DEFAULT_GROUP_SIZE):
+    """One-line description of what an 8-bit optimizer request actually gets.
+
+    The historical behaviour was to rewrite ``adamw_8bit`` to plain ``adamw``
+    with no message, so users asking for 8-bit silently got fp32 state. Replacing
+    that with a quieter surprise would be no better, so state the shape of the
+    saving explicitly.
+    """
+    return (
+        f"Unsloth: {optimizer_name} on MLX quantizes the optimizer's FIRST moment "
+        f"to 8-bit (group_size={group_size}); the second moment stays float32 "
+        "(affine 8-bit quantization of the second moment diverges). Only 2-D "
+        f"parameters whose last dimension is a multiple of {group_size} are "
+        "quantized; all others keep float32 moments."
+    )
+
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -53,7 +53,12 @@ import mlx.optimizers as optim
 from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
 
 _PAD_MULTIPLE = 32
-SUPPORTED_MLX_OPTIMIZERS = ("adafactor", "adamw", "adam", "sgd", "muon", "lion")
+SUPPORTED_MLX_OPTIMIZERS = (
+    "adafactor", "adamw", "adam", "sgd", "muon", "lion",
+    # 8-bit variants quantize the optimizer's FIRST moment only; see
+    # unsloth_zoo/mlx/optimizers_quantized.py for why the second moment cannot be.
+    "adamw_8bit", "adam_8bit",
+)
 SUPPORTED_MLX_LR_SCHEDULERS = ("linear", "cosine", "constant")
 
 
@@ -742,8 +747,12 @@ def _normalize_mlx_optimizer_name(name):
         name = name.value
     opt_name = str(name or "adamw").strip().lower()
     opt_name = opt_name.rsplit(".", 1)[-1].replace("-", "_")
+    # "adamw_8bit" / "adam_8bit" are NOT collapsed: they route to a real 8-bit
+    # first-moment optimizer. "paged_*" and "*_bnb_*" stay collapsed on purpose --
+    # "paged" promises CPU offload and "bnb" names a library MLX does not use, so
+    # routing them to this implementation would substitute a different wrong
+    # answer for the current one.
     if opt_name in (
-        "adamw_8bit",
         "paged_adamw_8bit",
         "adamw_bnb_8bit",
         "paged_adamw_32bit",
@@ -3339,6 +3348,30 @@ class MLXTrainer:
                 bias_correction=True,
                 **adam_kwargs,
             )
+        elif opt_name in ("adamw_8bit", "adam_8bit"):
+            # 8-bit FIRST moment only. Print rather than route silently: the old
+            # behaviour rewrote adamw_8bit to fp32 adamw with no message, and a
+            # quieter surprise would be no improvement.
+            from .optimizers_quantized import (
+                QuantizedMomentAdam,
+                QuantizedMomentAdamW,
+                describe_quantized_optimizer,
+            )
+            print(describe_quantized_optimizer(opt_name))
+            if opt_name == "adamw_8bit":
+                self._manual_weight_decay = float(wd or 0.0)
+                optimizer = QuantizedMomentAdamW(
+                    learning_rate=initial_lr,
+                    weight_decay=0.0,
+                    bias_correction=True,
+                    **adam_kwargs,
+                )
+            else:
+                optimizer = QuantizedMomentAdam(
+                    learning_rate=initial_lr,
+                    bias_correction=True,
+                    **adam_kwargs,
+                )
         elif opt_name == "sgd":
             # HF/PyTorch SGD couples weight decay into the gradient (and thus
             # momentum/Nesterov), unlike AdamW's decoupled shrink. Apply our

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -55,8 +55,7 @@ from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
 _PAD_MULTIPLE = 32
 SUPPORTED_MLX_OPTIMIZERS = (
     "adafactor", "adamw", "adam", "sgd", "muon", "lion",
-    # 8-bit variants quantize the optimizer's FIRST moment only; see
-    # unsloth_zoo/mlx/optimizers_quantized.py for why the second moment cannot be.
+    # First moment only; see unsloth_zoo/mlx/optimizers_quantized.py.
     "adamw_8bit", "adam_8bit",
 )
 SUPPORTED_MLX_LR_SCHEDULERS = ("linear", "cosine", "constant")
@@ -747,11 +746,8 @@ def _normalize_mlx_optimizer_name(name):
         name = name.value
     opt_name = str(name or "adamw").strip().lower()
     opt_name = opt_name.rsplit(".", 1)[-1].replace("-", "_")
-    # "adamw_8bit" / "adam_8bit" are NOT collapsed: they route to a real 8-bit
-    # first-moment optimizer. "paged_*" and "*_bnb_*" stay collapsed on purpose --
-    # "paged" promises CPU offload and "bnb" names a library MLX does not use, so
-    # routing them to this implementation would substitute a different wrong
-    # answer for the current one.
+    # "*_8bit" route to a real 8-bit optimizer. "paged_*" / "*_bnb_*" stay
+    # collapsed: they promise CPU offload / a library MLX does not use.
     if opt_name in (
         "paged_adamw_8bit",
         "adamw_bnb_8bit",
@@ -3349,9 +3345,7 @@ class MLXTrainer:
                 **adam_kwargs,
             )
         elif opt_name in ("adamw_8bit", "adam_8bit"):
-            # 8-bit FIRST moment only. Print rather than route silently: the old
-            # behaviour rewrote adamw_8bit to fp32 adamw with no message, and a
-            # quieter surprise would be no improvement.
+            # Print rather than route silently: the old path was a quiet rewrite.
             from .optimizers_quantized import (
                 QuantizedMomentAdam,
                 QuantizedMomentAdamW,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -10798,16 +10798,30 @@ def save_optimizer_state(optimizer, path):
     to ``<path>/optimizer_state.safetensors`` so training can resume from a
     checkpoint with identical optimizer dynamics.
 
-    The optimizer's ``.state`` is a nested dict whose leaves are ``mx.array``.
-    ``tree_flatten`` produces dotted-name string keys (e.g.
-    ``"layers.0.lora_a.weight.m"``), all values are arrays, so the whole tree
-    serializes cleanly with ``mx.save_safetensors``. Round-trip preserves
-    bytes exactly for the optimizer's ``.state`` dict.
+    The optimizer's ``.state`` is a nested dict whose leaves are ``mx.array``,
+    except that a quantized first moment is a 3-element list that ``tree_flatten``
+    decomposes into ``<param>.m.0/.1/.2``. Either way the flattened values are all
+    arrays, so the whole tree serializes cleanly with ``mx.save_safetensors``.
+
+    ``group_size``/``bits`` live on the optimizer instance rather than in the state
+    tree, so they are written as safetensors metadata; without them a resume cannot
+    tell how the packed moments were laid out.
     """
     import os
     os.makedirs(path, exist_ok=True)
     flat = dict(mlx.utils.tree_flatten(optimizer.state))
-    mx.save_safetensors(f"{path}/optimizer_state.safetensors", flat)
+    target = f"{path}/optimizer_state.safetensors"
+    if hasattr(optimizer, "group_size") and hasattr(optimizer, "bits"):
+        metadata = {
+            "quantized_moment_group_size" : str(optimizer.group_size),
+            "quantized_moment_bits"       : str(optimizer.bits),
+        }
+        try:
+            mx.save_safetensors(target, flat, metadata = metadata)
+            return
+        except TypeError:
+            pass  # backend without metadata support; fall through
+    mx.save_safetensors(target, flat)
 
 
 def load_optimizer_state(optimizer, path):
@@ -10818,10 +10832,48 @@ def load_optimizer_state(optimizer, path):
     Raises FileNotFoundError if the file is missing -- a resume request with
     no optimizer state is a hard error, not silent fall-back, because resuming
     with a fresh optimizer would silently restart Adam's moment estimates.
+
+    Reconciles a quantized first moment with the optimizer being resumed into.
+    Loading packed moments into a plain Adam/AdamW would otherwise reach
+    ``b1 * m`` on a list and raise a bare ``TypeError`` from inside mlx, and a
+    group_size mismatch would only surface as a dequantize shape error.
     """
+    from .optimizers_quantized import (
+        state_has_quantized_moments,
+        unpack_quantized_moments,
+    )
+
     state_path = f"{path}/optimizer_state.safetensors"
-    flat = mx.load(state_path)
-    optimizer.state = mlx.utils.tree_unflatten(list(flat.items()))
+    flat, metadata = mx.load(state_path), {}
+    try:
+        # Backends that do not support the flag (the torch shim) still return a
+        # bare dict, so check the shape of what came back rather than trusting it.
+        loaded = mx.load(state_path, return_metadata=True)
+        if isinstance(loaded, tuple) and len(loaded) == 2:
+            flat, metadata = loaded
+    except TypeError:
+        pass
+    state = mlx.utils.tree_unflatten(list(flat.items()))
+
+    if state_has_quantized_moments(state):
+        saved_group = int((metadata or {}).get(
+            "quantized_moment_group_size", getattr(optimizer, "group_size", 64),
+        ))
+        saved_bits = int((metadata or {}).get(
+            "quantized_moment_bits", getattr(optimizer, "bits", 8),
+        ))
+        if not hasattr(optimizer, "group_size"):
+            # Resuming an 8-bit checkpoint into a plain optimizer.
+            state = unpack_quantized_moments(state, saved_group, saved_bits)
+        elif (optimizer.group_size, optimizer.bits) != (saved_group, saved_bits):
+            print(
+                f"Unsloth: optimizer checkpoint packs its first moment with "
+                f"group_size={saved_group}, bits={saved_bits}; adopting those over "
+                f"group_size={optimizer.group_size}, bits={optimizer.bits}."
+            )
+            optimizer.group_size, optimizer.bits = saved_group, saved_bits
+
+    optimizer.state = state
 
 
 def save_trainer_state(trainer_state, path):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -10844,15 +10844,19 @@ def load_optimizer_state(optimizer, path):
     )
 
     state_path = f"{path}/optimizer_state.safetensors"
-    flat, metadata = mx.load(state_path), {}
+    # Metadata form first: loading twice would keep two full copies of a
+    # multi-GB optimizer checkpoint live at once. Backends without the flag (the
+    # torch shim) still return a bare dict, so check the shape of what came back
+    # rather than trusting the kwarg to have been honoured.
+    metadata = {}
     try:
-        # Backends that do not support the flag (the torch shim) still return a
-        # bare dict, so check the shape of what came back rather than trusting it.
         loaded = mx.load(state_path, return_metadata=True)
-        if isinstance(loaded, tuple) and len(loaded) == 2:
-            flat, metadata = loaded
     except TypeError:
-        pass
+        loaded = mx.load(state_path)
+    if isinstance(loaded, tuple) and len(loaded) == 2:
+        flat, metadata = loaded
+    else:
+        flat = loaded
     state = mlx.utils.tree_unflatten(list(flat.items()))
 
     if state_has_quantized_moments(state):


### PR DESCRIPTION
## The silent ignore
 
`trainer.py:745-758` accepts `adamw_8bit` and rewrites it to plain `adamw` with no message, so a user asking for an 8-bit optimizer on MLX silently gets full fp32 optimizer state. `adam_8bit` was not accepted at all.
 
## Delivered
 
Both names now route to `QuantizedMomentAdamW` / `QuantizedMomentAdam` in a new `unsloth_zoo/mlx/optimizers_quantized.py`, holding Adam's **first** moment as 8-bit packed arrays.
 
Optimizer state 1,052,684 → 675,852 B — 35.8% measured on the test model, 35.9% on a wider one. Final loss 0.08318 against an fp32 baseline of 0.08317 on the same seed.
 
Both classes wrap the stock MLX update, so bias correction and AdamW's decoupled decay are unchanged. Routing prints once, naming what you get: first moment 8-bit (`group_size=64`), second moment float32, and only 2-D parameters whose last dim is a multiple of the group size.
 
## Documented limitation: the second moment is not quantized
 
`v` is a running mean of squared gradients, so it spans orders of magnitude and sits near zero early. MLX's affine `mx.quantize` reconstructs poorly there, `sqrt(v)` lands in the update denominator, and the step explodes. Measured, both for int8 m+v and for fp32 m + int8 v:
 
```
1.0590 -> 0.8627 -> 19.3755 -> 10.2466 -> nan
```
 
Fixing this needs a dynamic/exponential mapping with stochastic rounding — what bitsandbytes implements and MLX does not expose. A guard test asserts `v` stays a single float32 array so this cannot be silently switched on.
 
`bits` is constrained to 8 with a `ValueError` rather than shipped untested. `group_size` accepts 32 / 64 / 128, all three exercised (finals 0.75205 / 0.75203 / 0.75202, all monotonic).
 
## Deliberate exclusions
 
`paged_adamw_8bit` and `adamw_bnb_8bit` keep collapsing to `adamw`. "paged" promises CPU offload and "bnb" names a library MLX does not use, so routing them here would swap one wrong answer for another.
 
## Two test files, on purpose
 
The numeric tests need real `mx.quantize`, so a single file would skip entirely on Linux CI and be a gate no-op — the #669/#739 pattern the behavioral-gates step exists to prevent.
 
- `tests/test_mlx_quantized_optimizer_routing.py` runs under the existing torch shim and executes in the gate.
- `tests/test_mlx_quantized_optimizer_state.py` holds the behaviour tests and runs on Apple Silicon.
## Tested
 
32 tests. Loss decreases over 8 steps; final loss within 1e-4 of fp32 on the same seed; asserted byte reduction; save → reload → resume reproduces the next step exactly; compiled and uncompiled bit-identical under `mx.compile(inputs=state, outputs=state)`; a model with no quantization-eligible parameter still trains; `bits != 8` and invalid `group_size` rejected.
 
Three of the routing tests fail against unpatched `trainer.py` — `adamw_8bit` resolving to `adamw`, `adam_8bit` raising `Unsupported MLX optimizer`, and `adamw_8bit` absent from the advertised list.
 
Full zoo suite run twice per side: totals 2979 → 3011, delta 32 = the tests added. No environment writes. No `Dataset.map` path is involved, so the forced-`fork` matrix does not apply here.
 
One caveat on the suite comparison: `tests/test_unsloth_zoo_lora_merge.py` and `tests/test_moe_fused_narrow_expert_merge.py` are nondeterministic independent of this change — the same file run twice on unmodified `main` gave 14 then 12 failures. Four of their tests appeared to regress on a two-run-per-side comparison and cleared on two additional baseline passes; neither file references MLX or the new module. Two runs per side is not always enough to separate signal from that file's noise.
 
## Overlap
 
Textual overlap with #819 on `trainer.py:56` and the `_build_optimizer` chain — same author, semantically disjoint (the optimizers #819 adds hold no first moment). Whichever merges second rebases.