### PR TITLE
Fix MLX VLM training attention masking, shared K/V, embedding scale and Gemma 3n batching

### DIFF
--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1995,3 +1995,106 @@ def test_paligemma_token_types_do_not_cross_between_concurrent_callers():
     for name, mark in marks.items():
         assert _Model.seen[name] is mark, f"{name} saw another caller's batch"
     assert _paligemma_pending_token_types() is None
+
+
+# --- gemma3n: AltUp correction at batch sizes above one ---------------------
+
+
+def _broken_altup(mx_, hidden=4, inputs=3):
+    """A stand-in shaped like the AltUp whose correction assumes a batch of one."""
+    from types import SimpleNamespace
+
+    class _Coefs:  # callable like the real nn.Linear, with a weight to clip
+        weight = mx_.zeros((inputs, hidden), dtype=mx_.float32)
+
+        def __call__(self, modalities):
+            return mx_.zeros((*modalities.shape[:-1], inputs), dtype=mx_.float32)
+
+    class _Altup:
+        config = SimpleNamespace(hidden_size=hidden, altup_num_inputs=inputs,
+                                 altup_coef_clip=None, altup_active_idx=0)
+        correction_coefs = _Coefs()
+
+        def compute_router_modalities(self, x):
+            return x
+
+        def correct(self, predictions, activated):
+            all_coefs = mx_.ones((*activated.shape[:-1], inputs), dtype=mx_.float32)
+            innovation = activated - predictions[self.config.altup_active_idx]
+            # The batch axis is treated as though it were last.
+            all_coefs = all_coefs.transpose(2, 1, 0)
+            corrected = innovation[None] * all_coefs[:, None]
+            corrected += predictions
+            return corrected.astype(activated.dtype)
+
+    return _Altup
+
+
+def test_gemma3n_altup_correction_survives_a_batch_larger_than_one():
+    """Upstream transposes its coefficients as though the batch axis were last,
+    which only broadcasts when the batch is one."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import (
+        _VLM_MODEL_FIXUPS, _altup_correct_handles_batch, _fix_gemma3n_altup_batch,
+    )
+
+    assert _fix_gemma3n_altup_batch in _VLM_MODEL_FIXUPS
+
+    mx_ = _utils_mx()
+    # Distinct batch and sequence, or transposing the two would look the same.
+    hidden, inputs, seq, rows = 4, 3, 5, 2
+    cls = _broken_altup(mx_, hidden, inputs)
+    altup = cls()
+    assert not _altup_correct_handles_batch(altup), "fixture should start broken"
+
+    upstream_correct = cls.correct
+    model = SimpleNamespace(language_model=SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(altup=altup)])))
+    assert _fix_gemma3n_altup_batch(model)
+    assert _altup_correct_handles_batch(altup)
+
+    # Rows are independent, so a batch must equal the rows corrected separately.
+    rng = np.random.default_rng(0)
+    activated = mx_.array(
+        rng.normal(size=(rows, seq, hidden)).astype(np.float32))
+    # Non-zero, or subtracting the active prediction would not be observable.
+    predictions = mx_.array(
+        rng.normal(size=(inputs, rows, seq, hidden)).astype(np.float32))
+    both = np.asarray(altup.correct(predictions, activated))
+    assert both.shape == (inputs, rows, seq, hidden)
+    for row in range(rows):
+        one = np.asarray(altup.correct(
+            predictions[:, row:row + 1], activated[row:row + 1]))
+        assert np.allclose(both[:, row:row + 1], one, atol=1e-5), \
+            f"row {row} differs when corrected in a batch"
+
+    # The formula stays upstream's. At a batch of one, where upstream is
+    # already right, the replacement has to reproduce it exactly.
+    one_act, one_pred = activated[:1], predictions[:, :1]
+    assert np.allclose(np.asarray(altup.correct(one_pred, one_act)),
+                       np.asarray(upstream_correct(altup, one_pred, one_act)),
+                       atol=1e-6), "the replacement changed the correction itself"
+
+
+def test_gemma3n_altup_patch_declines_a_release_that_is_already_correct():
+    """Upstream repaired this in 0.5.0, so the backport must leave it alone."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import (
+        _altup_correct_handles_batch, _fix_gemma3n_altup_batch,
+    )
+
+    mx_ = _utils_mx()
+    cls = _broken_altup(mx_)
+
+    def fixed(self, predictions, activated):
+        all_coefs = (self.correction_coefs(activated) + 1.0)
+        all_coefs = all_coefs.transpose(2, 0, 1)[..., None]
+        return (activated - predictions[0])[None] * all_coefs + predictions
+
+    cls.correct = fixed
+    altup = cls()
+    assert _altup_correct_handles_batch(altup)
+    model = SimpleNamespace(language_model=SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(altup=altup)])))
+    assert not _fix_gemma3n_altup_batch(model)
+    assert cls.correct is fixed, "an already-correct release must be left alone"

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1720,3 +1720,24 @@ def test_collation_does_not_require_a_pad_id(honours_side):
     assert mask[:, 0].tolist() == [1, 1] and (ids[mask == 0] == 0).all()
 
 
+# --- KV-shared layers borrow their K/V through the cache --------------------
+
+
+def test_baseline_loss_fn_forwards_real_shared_kv_slots():
+    # Slots, not placeholders, and one per producer: a list of Nones forwards
+    # the same shape while every shared layer rebuilds K/V from its own
+    # projections, and one slot repeated leaves them all reading the last.
+    from unsloth_zoo.mlx.utils import _SharedKVSlot
+
+    seen, _batch = _run_loss("gemma4", kv_shared=20)
+    caches = seen["cache"]
+    assert caches is not None and len(caches) == 15
+    assert all(isinstance(c, _SharedKVSlot) for c in caches)
+    assert len({id(c) for c in caches}) == 15
+    keys, values = object(), object()
+    # The producer stores through `update_and_fetch`, shared layers read `state`.
+    assert caches[0].offset == 0 and caches[0].borrow() is None
+    assert caches[0].update_and_fetch(keys, values) == (keys, values)
+    assert caches[0].state == (keys, values)
+
+

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1741,3 +1741,41 @@ def test_baseline_loss_fn_forwards_real_shared_kv_slots():
     assert caches[0].state == (keys, values)
 
 
+# --- gemma3n: the ids-path embedding scale a merge leaves off ---------------
+
+
+def _scale_probe(model_type, hidden_size=16):
+    """Middle position carries a merged feature; the others are plain tokens."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx import utils
+
+    mx_ = _utils_mx()
+    # Every position shares one token id, so an id-based mask cannot tell the
+    # feature-carrying position from the plain ones -- only a difference can.
+    ids = mx_.array([[7, 7, 7]], dtype=mx_.int32)
+    raw = mx_.ones((1, 3, hidden_size), dtype=mx_.float32)
+
+    class _Backbone:
+        config = SimpleNamespace(model_type=model_type, hidden_size=hidden_size)
+        def embed_tokens(self, _ids): return raw
+
+    merged = mx_.concatenate(
+        [raw[:, :1], mx_.full((1, 1, hidden_size), 9.0), raw[:, 2:]], axis=1)
+    out = utils._apply_vlm_embed_scale(
+        SimpleNamespace(language_model=SimpleNamespace(model=_Backbone())),
+        ids, merged)
+    return np.asarray(out)[0], hidden_size ** 0.5
+
+
+@pytest.mark.parametrize("model_type,scaled", [
+    ("gemma3n_text", True),
+    # gemma3_text is compensated for in `_run_hidden_stack`, the route it takes,
+    # so scaling it here would apply the factor twice.
+    ("qwen2_vl", False), ("gemma3_text", False), ("gemma4_text", False),
+])
+def test_embed_scale_lifts_only_gemma3n_plain_tokens(model_type, scaled):
+    out, scale = _scale_probe(model_type)
+    assert out[0][0] == pytest.approx(scale if scaled else 1.0)
+    assert out[2][0] == pytest.approx(scale if scaled else 1.0)
+    # Merged features already carry the scaled magnitude; rescaling inflates.
+    assert out[1][0] == pytest.approx(9.0)

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1538,3 +1538,185 @@ def test_gemma3n_token_type_ownership_survives_module_relocation():
     assert _vlm_processor_requests_mm_token_type_ids(
         processor("transformers.models.gemma3.processing_gemma3", "Gemma3Processor")
     ) is True
+
+
+# --- causality: a padding mask must never become the attention mask ---------
+
+
+def _utils_mx():
+    """The mlx the module under test is bound to (a sibling test may shim it)."""
+    from unsloth_zoo.mlx import utils
+    return utils.mx
+
+
+def _run_loss(model_type, kv_shared=0):
+    """Run the baseline loss and report what the model was handed."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.utils import make_vlm_baseline_loss_fn
+
+    mx_ = _utils_mx()
+    seen = {}
+    ids = mx_.array([[1, 2, 3, 4]], dtype=mx_.int32)
+    batch = {"input_ids": ids, "labels": ids,
+             "attention_mask": mx_.ones(ids.shape, dtype=mx_.int32)}
+
+    class _Model:
+        config = SimpleNamespace(model_type=model_type)
+
+        # Declared and never read, exactly as molmo_point declares it.
+        def get_input_embeddings(self, input_ids=None, pixel_values=None, mask=None):
+            return None
+
+        # Keyword-only and required, as thirteen families declare it: omitting
+        # it is a TypeError, so every case below also proves it is always sent.
+        def __call__(self, inputs, pixel_values=None, *, mask, cache=None, **kw):
+            seen["mask"], seen["cache"] = mask, cache
+            return SimpleNamespace(
+                logits=mx_.zeros((*inputs.shape, 16), dtype=mx_.float32))
+
+    model = _Model()
+    if kv_shared:
+        model.language_model = SimpleNamespace(model=SimpleNamespace(
+            first_kv_shared_layer_idx=15,
+            config=SimpleNamespace(num_kv_shared_layers=kv_shared)))
+    make_vlm_baseline_loss_fn(model=None, ignore_token_ids=[])(model, batch)
+    return seen, batch
+
+
+# mlx-vlm model_type values, not module names: FastVLM reports either.
+_MASK_KEEPING_FAMILIES = (
+    "gemma3", "paligemma", "llava_qwen2", "fastvlm",
+    "falcon_ocr", "falcon_perception", "falcon-perception",
+)
+
+
+@pytest.mark.parametrize("model_type,keeps", [
+    *[(family, True) for family in _MASK_KEEPING_FAMILIES],
+    # mlx-vlm resolves the module case-insensitively, the config keeps its own.
+    ("Gemma3", True), ("FALCON-PERCEPTION", True),
+    ("qwen2_vl", False),
+    ("molmo_point", False),
+])
+def test_baseline_loss_fn_sends_the_padding_mask_only_where_it_is_read(
+        model_type, keeps):
+    # Elsewhere it reaches the layers verbatim and replaces causality, letting
+    # every supervised position read the token it is scored on.
+    seen, batch = _run_loss(model_type)
+    assert seen["mask"] is (batch["attention_mask"] if keeps else None)
+
+
+def test_mask_keeping_allowlist_is_exactly_these_families_and_all_their_aliases():
+    from unsloth_zoo.mlx.utils import _VLM_FAMILIES_KEEPING_FORWARDED_MASK as listed
+    assert set(listed) == set(_MASK_KEEPING_FAMILIES)
+    # A config keeps its model_type through mlx-vlm's remap, so an alias onto a
+    # listed module has to be listed under its own spelling too.
+    remap = pytest.importorskip("mlx_vlm.utils").MODEL_REMAPPING
+    assert not {a for a, t in remap.items() if t in listed and a not in listed}
+
+
+class _NoPadIdTokenizer(_FakeTokenizer):
+    pad_token_id = None
+
+
+class _LayoutProcessor(_FakeProcessor):
+    """Emits one fixed layout, honouring `padding_side` only when told to.
+
+    Instruct checkpoints ship `padding_side: left`; deepseek_vl_v2 and the
+    falcon pair left-pad multimodal rows whichever side they are asked for.
+    """
+
+    def __init__(self, rows, masks, honours_side=False, tokenizer=None, **extras):
+        self.rows, self.masks, self.extras = rows, masks, extras
+        self.honours_side = honours_side
+        self.tokenizer = tokenizer or _FakeTokenizer()
+
+    def __call__(self, text, padding_side=None, **_kwargs):
+        flush = self.honours_side and padding_side == "right"
+        ids, mask = [], []
+        for row, keep in zip(self.rows, self.masks):
+            body = [t for t, k in zip(row, keep) if k]
+            pad = [0] * (len(row) - len(body))
+            ids.append(body + pad if flush else list(row))
+            mask.append([1] * len(body) + pad if flush else list(keep))
+        out = {"input_ids": np.array(ids, dtype=np.int32),
+               "attention_mask": np.array(mask, dtype=np.int32)}
+        out.update({key: np.asarray(value) for key, value in self.extras.items()})
+        return out
+
+
+# One row already flush, one left-padded, so a repair has something to move.
+_RAGGED = ([[101, 10, 200, 11], [0, 0, 101, 200]],
+           [[1, 1, 1, 1], [0, 0, 1, 1]])
+_MARKS = np.array([[0, 0, 1, 0], [0, 0, 0, 1]], dtype=np.int32)
+
+
+@pytest.mark.parametrize("honours_side", [True, False])
+def test_collation_delivers_content_then_padding(honours_side):
+    # Causality is all that excludes the pads once the mask is withheld, and it
+    # excludes a trailing pad, not a leading one.
+    batch = _finalized_collate(
+        [{"text": "a"}] * 2, _LayoutProcessor(*_RAGGED, honours_side=honours_side),
+        8, None)
+    ids, mask = np.asarray(batch["input_ids"]), np.asarray(batch["attention_mask"])
+    assert mask.tolist() == [[1, 1, 1, 1], [1, 1, 0, 0]]
+    assert ids[1][:2].tolist() == [101, 200]
+
+
+@pytest.mark.parametrize("key", ["mm_token_type_ids", "images_seq_mask"])
+def test_collation_moves_token_aligned_sidecars_with_their_tokens(key):
+    # gemma4 builds its bidirectional multimodal blocks from
+    # `mm_token_type_ids`, the deepseek pair place image embeddings at
+    # `images_seq_mask` indices; left behind, row 1's mark sits on a pad.
+    batch = _finalized_collate(
+        [{"text": "a"}] * 2,
+        _LayoutProcessor(*_RAGGED, mm_token_type_ids=_MARKS,
+                         images_seq_mask=_MARKS.astype(bool)), 8, None)
+    ids, marked = np.asarray(batch["input_ids"]), np.asarray(batch[key]).astype(bool)
+    assert marked.sum() == 2 and (ids[marked] == 200).all()
+    assert marked[1].tolist() == [False, True, False, False]
+
+
+@pytest.mark.parametrize("key", ["image_grid_hw", "some_unlisted_field"])
+def test_collation_leaves_an_unlisted_field_alone(key):
+    # Three images of two columns, in a batch of three rows two tokens wide:
+    # per-image metadata shaped exactly like a per-token array. Recognising
+    # sidecars by shape would compact row 1's to [5, 0], losing its height.
+    grid = np.array([[2, 3], [4, 5], [6, 7]], dtype=np.int32)
+    batch = _finalized_collate(
+        [{"text": "a"}] * 3,
+        _LayoutProcessor([[101, 200], [0, 200], [101, 200]],
+                         [[1, 1], [0, 1], [1, 1]],
+                         image_grid_hw=grid, some_unlisted_field=grid + 10),
+        8, None)
+    assert np.asarray(batch["input_ids"])[1].tolist() == [200, 0]
+    assert np.asarray(batch[key]).tolist() == (grid if key == "image_grid_hw"
+                                               else grid + 10).tolist()
+
+
+@pytest.mark.parametrize("key", ["position_ids", "rope_deltas"])
+def test_collation_refuses_a_processor_authored_layout_coordinate(key, monkeypatch):
+    # Sidecars label tokens and travel with them; these are coordinates of the
+    # layout the repair replaces. `rope_deltas` is injected into the pipeline's
+    # own collection, so naming "position_ids" inline would fail this.
+    from unsloth_zoo.mlx import utils
+
+    monkeypatch.setattr(utils, "_VLM_WIDTH_GENERATED_KEYS",
+                        tuple(utils._VLM_WIDTH_GENERATED_KEYS) + ("rope_deltas",))
+    coords = np.tile(np.arange(4), (2, 1))
+    with pytest.raises(ValueError, match=key):
+        _finalized_collate([{"text": "a"}] * 2,
+                           _LayoutProcessor(*_RAGGED, **{key: coords}), 8, None)
+
+
+@pytest.mark.parametrize("honours_side", [True, False])
+def test_collation_does_not_require_a_pad_id(honours_side):
+    # falcon_ocr and falcon_perception ship no pad id and pad with 0, so
+    # demanding one would refuse batches they collate fine, repair or not.
+    batch = _finalized_collate(
+        [{"text": "a"}] * 2,
+        _LayoutProcessor(*_RAGGED, honours_side=honours_side,
+                         tokenizer=_NoPadIdTokenizer()), 8, None)
+    ids, mask = np.asarray(batch["input_ids"]), np.asarray(batch["attention_mask"])
+    assert mask[:, 0].tolist() == [1, 1] and (ids[mask == 0] == 0).all()
+
+

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1779,3 +1779,219 @@ def test_embed_scale_lifts_only_gemma3n_plain_tokens(model_type, scaled):
     assert out[2][0] == pytest.approx(scale if scaled else 1.0)
     # Merged features already carry the scaled magnitude; rescaling inflates.
     assert out[1][0] == pytest.approx(9.0)
+
+
+# --- paligemma: a prefix-LM mask, not a padding outer product ---------------
+
+
+def test_paligemma_mask_is_bidirectional_on_the_prefix_and_causal_on_the_suffix():
+    """PaliGemma's own mask is an outer product of the padding mask, so with
+    nothing padded the suffix being trained on reads the tokens after it."""
+    from unsloth_zoo.mlx.loader import (
+        _VLM_MODEL_FIXUPS, _fix_paligemma_multimodal_causal_mask,
+        _paligemma_prefix_lm_mask,
+    )
+
+    # Loading a VLM has to apply the correction, not just define it.
+    assert _fix_paligemma_multimodal_causal_mask in _VLM_MODEL_FIXUPS
+
+    mx_ = _utils_mx()
+    seq = 8
+    # 0 marks the prefix, 1 the suffix: the reverse of Gemma3's convention.
+    token_type_ids = mx_.array([[0, 0, 0, 0, 1, 1, 0, 0]], dtype=mx_.int32)
+    padding = mx_.array([[1, 1, 1, 1, 1, 1, 0, 0]], dtype=mx_.int32)
+    m = np.asarray(
+        _paligemma_prefix_lm_mask(token_type_ids, padding)
+    ).reshape(-1, seq, seq)[0].astype(bool)
+
+    q_idx, kv_idx = np.indices(m.shape)
+    real = np.asarray(padding)[0] == 1
+    prefix = (np.asarray(token_type_ids)[0] == 0) & real
+    both_real = real[q_idx] & real[kv_idx]
+    both_prefix = prefix[q_idx] & prefix[kv_idx]
+    ahead = q_idx < kv_idx
+    # The suffix is causal: outside the prefix nothing reads ahead. Left as an
+    # outer product every one of these is visible.
+    assert not m[ahead & ~both_prefix & both_real].any()
+    # The prefix stays bidirectional, which is what PaliGemma is trained for.
+    assert m[both_prefix].all()
+    # The past is always visible, so this is a mask and not all-zeros.
+    assert m[(q_idx >= kv_idx) & both_real].all()
+    # And the pads are excluded, which the outer product did do and this must too.
+    assert not m[~both_real].any()
+
+
+def test_paligemma_mask_is_left_alone_without_token_types():
+    """`Model.__call__` forwards no extra kwargs, so on the plain loss path the
+    token types never arrive and there is no prefix boundary to derive."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import (
+        _paligemma_causal_mask_wrapper, _paligemma_replace_mask,
+    )
+
+    mx_ = _utils_mx()
+    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+    padding = mx_.ones((1, 4), dtype=mx_.int32)
+
+    untouched = _paligemma_replace_mask(
+        SimpleNamespace(attention_mask_4d=outer_product), None, padding)
+    assert untouched.attention_mask_4d is outer_product
+    # Nor when upstream built no mask at all, e.g. a text-only batch.
+    assert _paligemma_replace_mask(
+        SimpleNamespace(attention_mask_4d=None),
+        mx_.zeros((1, 4), dtype=mx_.int32), padding).attention_mask_4d is None
+    # But it is replaced once the token types are there.
+    replaced = _paligemma_replace_mask(
+        SimpleNamespace(attention_mask_4d=outer_product),
+        mx_.array([[0, 0, 1, 1]], dtype=mx_.int32), padding)
+    assert replaced.attention_mask_4d is not outer_product
+    assert not np.asarray(replaced.attention_mask_4d).reshape(4, 4)[2, 3]
+
+
+def test_paligemma_embedder_wrapper_replaces_the_mask_it_wrapped():
+    """The wrapper is what actually reaches a loaded model, so it has to hand the
+    token types on rather than return upstream's mask untouched."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import _paligemma_causal_mask_wrapper
+
+    mx_ = _utils_mx()
+    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+    seen = {}
+
+    def original(_self, input_ids=None, pixel_values=None, mask=None, **kwargs):
+        seen["kwargs"] = kwargs
+        return SimpleNamespace(attention_mask_4d=outer_product)
+
+    wrapped = _paligemma_causal_mask_wrapper(original)
+    got = wrapped(object(), mx_.zeros((1, 4), dtype=mx_.int32), None,
+                  mx_.ones((1, 4), dtype=mx_.int32),
+                  token_type_ids=mx_.array([[0, 0, 1, 1]], dtype=mx_.int32))
+    # Upstream still runs and still sees its kwargs.
+    assert "token_type_ids" in seen["kwargs"]
+    # And its all-visible mask does not survive: the suffix cannot read ahead.
+    assert got.attention_mask_4d is not outer_product
+    assert not np.asarray(got.attention_mask_4d).reshape(4, 4)[2, 3]
+
+
+def test_paligemma_plain_loss_path_also_gets_the_causal_suffix():
+    """Upstream's call embeds with a fixed three arguments, dropping the token
+    types, so without threading them the `use_cce=False` path keeps leaking."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import (
+        _paligemma_call_wrapper, _paligemma_causal_mask_wrapper,
+        _paligemma_pending_token_types,
+    )
+
+    mx_ = _utils_mx()
+    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+    padding = mx_.ones((1, 4), dtype=mx_.int32)
+    seen = {}
+
+    def upstream_embed(_self, input_ids=None, pixel_values=None, mask=None, **kw):
+        return SimpleNamespace(attention_mask_4d=outer_product)
+
+    class _Model:
+        get_input_embeddings = _paligemma_causal_mask_wrapper(upstream_embed)
+
+        def __call__(self, input_ids, pixel_values=None, mask=None, **kwargs):
+            # Upstream drops kwargs here, exactly as PaliGemma does.
+            seen["mask"] = self.get_input_embeddings(
+                input_ids, pixel_values, mask).attention_mask_4d
+            return seen["mask"]
+
+    _Model.__call__ = _paligemma_call_wrapper(_Model.__call__)
+    model = _Model()
+    model(mx_.zeros((1, 4), dtype=mx_.int32), None, padding,
+          token_type_ids=mx_.array([[0, 0, 1, 1]], dtype=mx_.int32))
+
+    assert seen["mask"] is not outer_product
+    assert not np.asarray(seen["mask"]).reshape(4, 4)[2, 3]
+    # And nothing is left pending once the call returns.
+    assert _paligemma_pending_token_types() is None
+
+
+class _FakePaligemma:
+    """Upstream's shape: `__call__` embeds with a fixed three arguments, so the
+    token types it was given never reach the embedder on their own."""
+
+    outer_product = None          # set per test, so identity can be compared
+    seen = None
+
+    def get_input_embeddings(self, input_ids=None, pixel_values=None, mask=None,
+                             **kwargs):
+        from types import SimpleNamespace
+        return SimpleNamespace(attention_mask_4d=self.outer_product)
+
+    def __call__(self, input_ids, pixel_values=None, mask=None, **kwargs):
+        import threading
+        from unsloth_zoo.mlx.loader import _paligemma_pending_token_types
+        if self.seen is not None:
+            self.seen[threading.current_thread().name] = \
+                _paligemma_pending_token_types()
+        return self.get_input_embeddings(input_ids, pixel_values, mask)
+
+
+def test_paligemma_install_puts_both_wrappers_on_the_class():
+    """Removing either assignment leaves the matching production loss path
+    unfixed, so the install itself has to be checked, not just the wrappers."""
+    from unsloth_zoo.mlx.loader import _install_paligemma_causal_mask
+
+    mx_ = _utils_mx()
+    padding = mx_.ones((1, 4), dtype=mx_.int32)
+    token_type_ids = mx_.array([[0, 0, 1, 1]], dtype=mx_.int32)
+
+    class _Model(_FakePaligemma):
+        outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+        seen = {}
+
+    assert _install_paligemma_causal_mask(_Model)
+    model, ids = _Model(), mx_.zeros((1, 4), dtype=mx_.int32)
+
+    # The plain path: the call wrapper has to carry the token types across.
+    plain = model(ids, None, padding, token_type_ids=token_type_ids)
+    assert not np.asarray(plain.attention_mask_4d).reshape(4, 4)[2, 3]
+    # The cross-entropy path: the embedder wrapper receives them itself.
+    direct = model.get_input_embeddings(
+        ids, None, padding, token_type_ids=token_type_ids).attention_mask_4d
+    assert not np.asarray(direct).reshape(4, 4)[2, 3]
+
+
+def test_paligemma_token_types_do_not_cross_between_concurrent_callers():
+    """One model can serve several callers at once; an attribute on the model
+    would let one read another's batch."""
+    import threading
+    from unsloth_zoo.mlx.loader import (
+        _install_paligemma_causal_mask, _paligemma_pending_token_types,
+    )
+
+    mx_ = _utils_mx()
+    padding = mx_.ones((1, 4), dtype=mx_.int32)
+    entered = threading.Barrier(2)
+
+    class _Model(_FakePaligemma):
+        outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+        seen = {}
+
+        def __call__(self, *args, **kwargs):
+            entered.wait(timeout=5)      # both callers inside their own call
+            return _FakePaligemma.__call__(self, *args, **kwargs)
+
+    assert _install_paligemma_causal_mask(_Model)
+    model = _Model()
+    marks = {"a": mx_.array([[0, 0, 1, 1]], dtype=mx_.int32),
+             "b": mx_.array([[0, 1, 1, 1]], dtype=mx_.int32)}
+    threads = [
+        threading.Thread(name=name, target=model,
+                         args=(mx_.zeros((1, 4), dtype=mx_.int32), None, padding),
+                         kwargs={"token_type_ids": mark})
+        for name, mark in marks.items()
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    # Each caller saw its own token types, not the other's.
+    for name, mark in marks.items():
+        assert _Model.seen[name] is mark, f"{name} saw another caller's batch"
+    assert _paligemma_pending_token_types() is None

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2349,11 +2349,13 @@ def _fix_gemma3_multimodal_image_feature_scale(model=None):
             final_embedding, image_mask_expanded, scaled_image_features,
         )
 
-        attention_mask_expanded_1 = mx.expand_dims(attention_mask, 1)
-        attention_mask_expanded_2 = mx.expand_dims(attention_mask, 2)
-        final_attention_mask_4d = mx.expand_dims(
-            attention_mask_expanded_1 * attention_mask_expanded_2,
-            1,
+        # Gemma3's layers use this verbatim, so it has to carry causality; an
+        # outer product of the padding mask does not. Same builder as the CCE
+        # path: causal, bidirectional inside each image block.
+        from .utils import _build_gemma_image_attention_mask
+        token_type_ids = (input_ids == image_token_index).astype(mx.int32)
+        final_attention_mask_4d = _build_gemma_image_attention_mask(
+            token_type_ids, attention_mask=attention_mask,
         )
         return final_embedding.astype(inputs_embeds.dtype), final_attention_mask_4d
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2369,6 +2369,134 @@ def _fix_gemma3_multimodal_image_feature_scale(model=None):
     if model is not None:
         model._unsloth_gemma3_image_feature_scale = "text_embed_dim"
     return True
+def _paligemma_prefix_lm_mask(token_type_ids, attention_mask):
+    """PaliGemma's prefix is bidirectional and only its suffix is causal.
+
+    Its processor marks the suffix with 1, the reverse of the convention the
+    builder reads, so the polarity is inverted before the group is formed.
+    """
+    from .utils import _build_gemma_image_attention_mask
+    prefix = (token_type_ids == 0).astype(token_type_ids.dtype)
+    return _build_gemma_image_attention_mask(prefix, attention_mask=attention_mask)
+
+
+def _paligemma_replace_mask(features, token_type_ids, attention_mask):
+    """Swap the outer-product mask for the prefix-LM one where the split is known.
+
+    Without token types there is no prefix boundary to derive, so upstream's mask
+    is left as it is rather than guessed at.
+    """
+    if token_type_ids is None or features.attention_mask_4d is None:
+        return features
+    features.attention_mask_4d = _paligemma_prefix_lm_mask(
+        token_type_ids, attention_mask,
+    )
+    return features
+
+
+# Where the call wrapper leaves the token types for the embedder wrapper. A
+# per-thread stack, not an attribute on the model: one model can serve several
+# callers at once, and an attribute would let them read each other's batch.
+_PALIGEMMA_TOKEN_TYPES = threading.local()
+
+
+def _paligemma_pending_token_types():
+    stack = getattr(_PALIGEMMA_TOKEN_TYPES, "stack", None)
+    return stack[-1] if stack else None
+
+
+def _paligemma_call_wrapper(original_call):
+    """Thread the token types through to the embedder.
+
+    Upstream's call embeds with a fixed three arguments, so the token types that
+    carry the prefix boundary never reach the mask on the plain loss path.
+    """
+
+    def __call__(self, *args, **kwargs):
+        stack = getattr(_PALIGEMMA_TOKEN_TYPES, "stack", None)
+        if stack is None:
+            stack = _PALIGEMMA_TOKEN_TYPES.stack = []
+        stack.append(kwargs.get("token_type_ids"))
+        try:
+            return original_call(self, *args, **kwargs)
+        finally:
+            stack.pop()
+
+    return __call__
+
+
+def _paligemma_causal_mask_wrapper(original):
+    """Wrap PaliGemma's embedder so its 4-D mask carries a causal suffix."""
+
+    def get_input_embeddings(self, input_ids=None, pixel_values=None, mask=None,
+                             **kwargs):
+        features = original(self, input_ids, pixel_values, mask, **kwargs)
+        token_type_ids = kwargs.get("token_type_ids")
+        if token_type_ids is None:
+            token_type_ids = _paligemma_pending_token_types()
+        return _paligemma_replace_mask(features, token_type_ids, mask)
+
+    return get_input_embeddings
+
+
+def _install_paligemma_causal_mask(model_cls):
+    """Put both wrappers on a PaliGemma model class, or report why not."""
+    original_embed = getattr(model_cls, "get_input_embeddings", None)
+    original_call = getattr(model_cls, "__call__", None)
+    if not callable(original_embed) or not callable(original_call):
+        return False
+    model_cls.get_input_embeddings = _paligemma_causal_mask_wrapper(original_embed)
+    model_cls.__call__ = _paligemma_call_wrapper(original_call)
+    model_cls._unsloth_causal_mask_patched = True
+    return True
+
+
+def _fix_paligemma_multimodal_causal_mask(model=None):
+    """Give PaliGemma's prefix-LM mask a causal suffix.
+
+    Its 4-D mask is an outer product of the padding mask, so with nothing padded
+    every position sees every other and the suffix being trained on can read the
+    answer tokens after it. PaliGemma wants its prefix -- image plus prompt --
+    bidirectional and its suffix causal, which is what the reference builds from
+    `token_type_ids`, marking the suffix with 1 where Gemma3 marks the
+    bidirectional side.
+
+    Both loss paths are corrected: the cross-entropy path embeds directly and
+    already carries the token types, and the plain path goes through
+    `Model.__call__`, which the companion wrapper makes them survive.
+    """
+    try:
+        import mlx.core as mx
+        paligemma_module = importlib.import_module("mlx_vlm.models.paligemma.paligemma")
+    except Exception:
+        return False
+
+    model_cls = getattr(paligemma_module, "Model", None)
+    # A real class, not the simulation shim's stand-in object.
+    if not isinstance(model_cls, type):
+        return False
+    if getattr(model_cls, "_unsloth_causal_mask_patched", False):
+        return True
+    try:
+        return _install_paligemma_causal_mask(model_cls)
+    except Exception:
+        return False
+
+
+# Upstream corrections applied to every VLM as it loads, in order.
+_VLM_MODEL_FIXUPS = (
+    _fix_gemma4_kv_sharing,
+    _fix_gemma3_vision_post_layernorm_eps,
+    _fix_gemma3_vision_attention_fp32_sdpa,
+    _fix_gemma3_vision_encoder_fp32_layernorm,
+    _fix_gemma3_vision_post_layernorm_fp32,
+    _fix_gemma3_vision_mlp_fp32_activation,
+    _fix_gemma3_language_mlp_fp32_activation,
+    _fix_gemma3_multimodal_image_feature_scale,
+    _fix_paligemma_multimodal_causal_mask,
+)
+
+
 def _disable_fused_mrope(model):
     """Flip fused_apply off so MRoPE training uses the differentiable
     cos/sin fallback; the fused Metal kernel has no VJP."""
@@ -7320,16 +7448,7 @@ class FastMLXModel:
                 model._unsloth_text_only_vlm = True
             model._is_vlm_model = True
             model._processor = processor
-            for fixup in (
-                _fix_gemma4_kv_sharing,
-                _fix_gemma3_vision_post_layernorm_eps,
-                _fix_gemma3_vision_attention_fp32_sdpa,
-                _fix_gemma3_vision_encoder_fp32_layernorm,
-                _fix_gemma3_vision_post_layernorm_fp32,
-                _fix_gemma3_vision_mlp_fp32_activation,
-                _fix_gemma3_language_mlp_fp32_activation,
-                _fix_gemma3_multimodal_image_feature_scale,
-            ):
+            for fixup in _VLM_MODEL_FIXUPS:
                 _run_with_vlm_config_view(fixup, model)
 
             model._config = getattr(model, "_config", config_data)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2369,6 +2369,69 @@ def _fix_gemma3_multimodal_image_feature_scale(model=None):
     if model is not None:
         model._unsloth_gemma3_image_feature_scale = "text_embed_dim"
     return True
+def _altup_correct_handles_batch(altup):
+    """True when this AltUp already corrects a batch larger than one."""
+    import mlx.core as mx
+    hidden = getattr(getattr(altup, "config", None), "hidden_size", None)
+    inputs = getattr(getattr(altup, "config", None), "altup_num_inputs", None)
+    if not hidden or not inputs:
+        return True  # cannot tell, so leave it alone
+    activated = mx.zeros((2, 1, int(hidden)), dtype=mx.float32)
+    predictions = mx.zeros((int(inputs), 2, 1, int(hidden)), dtype=mx.float32)
+    try:
+        mx.eval(altup.correct(predictions, activated))
+    except Exception:
+        return False
+    return True
+
+
+def _fix_gemma3n_altup_batch(model=None):
+    """Correct Gemma 3n's AltUp coefficients for batches larger than one.
+
+    The correction transposes its coefficients as though the batch axis were
+    last, which only broadcasts when the batch is one; anything larger fails
+    outright. Upstream repaired this in mlx-vlm 0.5.0, so this only ever runs
+    against older releases, whose source no longer changes.
+    """
+    layers = getattr(getattr(getattr(model, "language_model", None), "model", None),
+                     "layers", None)
+    altup = getattr(layers[0], "altup", None) if layers else None
+    if altup is None:
+        return False
+    model_cls = type(altup)
+    if getattr(model_cls, "_unsloth_altup_batch_patched", False):
+        return True
+    if _altup_correct_handles_batch(altup):
+        return False
+
+    import mlx.core as mx
+
+    def correct(self, predictions, activated):
+        modalities = self.compute_router_modalities(activated)
+        self.correction_coefs.weight = self.correction_coefs.weight.astype(mx.float32)
+        if self.config.altup_coef_clip is not None:
+            self.correction_coefs.weight = mx.clip(
+                self.correction_coefs.weight,
+                -self.config.altup_coef_clip,
+                self.config.altup_coef_clip,
+            )
+        all_coefs = self.correction_coefs(modalities) + 1.0
+        innovation = activated - predictions[self.config.altup_active_idx]
+        # Coefficients are (batch, sequence, input); the correction needs them
+        # as (input, batch, sequence, 1) so they broadcast over the hidden axis.
+        all_coefs = all_coefs.transpose(2, 0, 1)[..., None]
+        corrected = innovation[None] * all_coefs
+        corrected += predictions
+        return corrected.astype(activated.dtype)
+
+    try:
+        model_cls.correct = correct
+        model_cls._unsloth_altup_batch_patched = True
+    except Exception:
+        return False
+    return True
+
+
 def _paligemma_prefix_lm_mask(token_type_ids, attention_mask):
     """PaliGemma's prefix is bidirectional and only its suffix is causal.
 
@@ -2494,6 +2557,7 @@ _VLM_MODEL_FIXUPS = (
     _fix_gemma3_language_mlp_fp32_activation,
     _fix_gemma3_multimodal_image_feature_scale,
     _fix_paligemma_multimodal_causal_mask,
+    _fix_gemma3n_altup_batch,
 )
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -534,6 +534,26 @@ def _build_gemma_image_attention_mask(token_type_ids, attention_mask=None,
     return mx.expand_dims(mask, axis=1)
 
 
+# Families that read the padding mask, or whose layers fall back on a stored
+# `_full_attn_mask` without one -- falcon_perception never clears it, so a text
+# batch can inherit the previous image batch's. Elsewhere a supplied mask
+# reaches the layers, where it REPLACES causality. Listed rather than probed
+# from the signature, since molmo_point declares `mask` and never reads it, and
+# keyed on `model_type`, so aliases need their own entry.
+_VLM_FAMILIES_KEEPING_FORWARDED_MASK = frozenset({
+    "gemma3", "paligemma",
+    "llava_qwen2", "fastvlm",                    # FastVLM answers to both
+    "falcon_ocr", "falcon_perception", "falcon-perception",
+})
+
+
+def _keeps_forwarded_mask(model):
+    model_type = _config_get(getattr(model, "config", None), "model_type")
+    # mlx-vlm lower-cases model_type to resolve the module but leaves the
+    # config's own spelling alone, so match the way it resolves.
+    return str(model_type).lower() in _VLM_FAMILIES_KEEPING_FORWARDED_MASK
+
+
 def _run_hidden_stack(stack, inputs, inputs_embeds=None, **kwargs):
     """Execute a language stack up to pre-lm_head hidden states."""
     from mlx_vlm.models.base import create_attention_mask
@@ -552,8 +572,8 @@ def _run_hidden_stack(stack, inputs, inputs_embeds=None, **kwargs):
     mask = kwargs.get("mask")
     if mask is None:
         mask = kwargs.get("attention_mask_4d")
-    if mask is None:
-        mask = kwargs.get("attention_mask")
+    # No fallback to the 2-D `attention_mask`: layers use what they are handed
+    # verbatim, so it would replace causality.
     token_type_ids = kwargs.get("token_type_ids")
     token_type_mask = None
     if token_type_ids is not None:
@@ -1854,12 +1874,9 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
         # Forward full sequence then shift (Qwen3-VL mRoPE/deepstack need it);
         # mirrors `_vlm_cce_forward` so use_cce={True,False} stay in parity.
         inputs = input_ids
-        fwd_mask = attention_mask
 
-        # Model owns the causal mask. Pass through extras (e.g. image_grid_thw
-        # for Qwen). Strip every private `_unsloth_*` carrier (raw-ids plus the
-        # _unsloth_collated_position_ids marker) so model(...) never sees a kwarg
-        # it would reject, matching _vlm_cce_forward's filter.
+        # Pass through extras (e.g. image_grid_thw); strip the private
+        # `_unsloth_*` carriers, matching _vlm_cce_forward's filter.
         fwd_kwargs = {
             k: v for k, v in batch_dict.items()
             if k not in ("input_ids", "pixel_values", "attention_mask", "labels")
@@ -1867,7 +1884,12 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
             and v is not None
         }
         fwd_kwargs = _trim_sequence_aligned_vlm_kwargs(fwd_kwargs, inputs.shape[1])
-        output = model(inputs, pixel_values=pixel_values, mask=fwd_mask, **fwd_kwargs)
+        # Always sent: 13 families declare `mask` without a default. None lets
+        # them build the mask they would use for generation.
+        fwd_kwargs["mask"] = (
+            attention_mask if _keeps_forwarded_mask(model) else None
+        )
+        output = model(inputs, pixel_values=pixel_values, **fwd_kwargs)
         logits = output.logits if hasattr(output, "logits") else output
         logits = logits.astype(mx.float32)
         # Drop the final position so logits predict the next token.
@@ -5626,6 +5648,77 @@ def _as_numpy_vlm_field(inputs, key):
     return arr
 
 
+# Text-width-aligned arrays a processor authors for itself, beyond the ones the
+# pipeline owns in `_VLM_WIDTH_PADDABLE_KEYS`. The deepseek pair place image
+# embeddings at these indices.
+_VLM_PROCESSOR_TOKEN_ALIGNED_KEYS = ("images_seq_mask",)
+
+# Of those, the ones the compaction may move: inert at zero, which is what the
+# gather writes into a vacated slot. That drops the label carriers, which the
+# pipeline rebuilds from the repaired ids anyway; ids and mask move on their own.
+_VLM_RELOCATABLE_SIDECAR_KEYS = tuple(
+    key for key, inert in _VLM_WIDTH_PADDABLE_KEYS.items()
+    if inert == 0 and key != "attention_mask"
+) + _VLM_PROCESSOR_TOKEN_ALIGNED_KEYS
+
+
+def _vlm_token_aligned_sidecars(inputs, ids_shape):
+    """Return the processor fields whose columns are the token positions.
+
+    Left at the pre-repair columns these mark the wrong tokens: gemma4 builds
+    its bidirectional multimodal blocks from `mm_token_type_ids`, the deepseek
+    pair place image embeddings at `images_seq_mask` indices. Named, not
+    recognised by shape, since a shape does not say what indexes it -- an
+    (images, 2) grid matches a two-token batch -- so an unlisted sidecar is left
+    alone, as `_vlm_width_survey` also declines to guess.
+    """
+    sidecars = {}
+    for key in _VLM_RELOCATABLE_SIDECAR_KEYS:
+        if inputs.get(key) is None:
+            continue
+        values = _as_numpy_vlm_field(inputs, key)
+        if values.shape == ids_shape:
+            sidecars[key] = values
+    return sidecars
+
+
+def _right_pad_vlm_rows(inputs, processor):
+    """Compact each row's real tokens to the front.
+
+    Causality is all that excludes the pads once the mask is withheld, and it
+    excludes a trailing pad, not a leading one. deepseek_vl_v2 and the falcon
+    pair left-pad multimodal rows whatever side they are asked for, so the
+    layout is repaired rather than demanded.
+    """
+    value = inputs.get("attention_mask") if hasattr(inputs, "get") else None
+    if value is None:
+        return inputs
+    mask = _as_numpy_vlm_field(inputs, "attention_mask")
+    # Content-then-padding, so an interior pad counts as much as a leading one.
+    if not mask.size or bool(np.all(mask[:, :-1] >= mask[:, 1:])):
+        return inputs
+    generated = [
+        key for key in _VLM_WIDTH_GENERATED_KEYS if inputs.get(key) is not None
+    ]
+    if generated:
+        # Coordinates of the layout the repair replaces, not labels that travel.
+        raise ValueError(
+            f"Unsloth MLX: {type(processor).__name__} left-padded this batch "
+            f"and supplied its own {', '.join(generated)}, which cannot be "
+            f"re-derived for the repaired row order."
+        )
+    ids = _as_numpy_vlm_field(inputs, "input_ids")
+    extras = _vlm_token_aligned_sidecars(inputs, ids.shape)
+    ids, mask, extras = _flush_vlm_arrays_to_side(
+        ids, mask, "right", _vlm_pad_token_id(processor, default=0), extras,
+    )
+    inputs["input_ids"] = ids
+    inputs["attention_mask"] = mask
+    for key, values in extras.items():
+        inputs[key] = values
+    return inputs
+
+
 def _common_text_prefix(left, right):
     """Return CUDA's shared rendered prompt prefix for VLM PC rows."""
     end = 0
@@ -5643,11 +5736,13 @@ def _vlm_tokenizer_padding_side(processor):
     return "left" if side == "left" else "right"
 
 
-def _vlm_pad_token_id(processor):
-    """Return the processor tokenizer pad id required for PC collation."""
+def _vlm_pad_token_id(processor, default=None):
+    """Return the processor tokenizer pad id, or ``default`` when it has none."""
     tokenizer = _get_processor_tokenizer(processor)
     pad_id = getattr(tokenizer, "pad_token_id", None)
     if pad_id is None:
+        if default is not None:
+            return default
         raise ValueError(
             "Tokenizer must define `pad_token_id` for prompt-completion collation."
         )
@@ -5859,6 +5954,10 @@ def _combine_vlm_prompt_completion_inputs(
     input_ids, attention_mask, extras = _truncate_vlm_arrays_by_side(
         input_ids, attention_mask, flush_side, max_seq_length, extras,
     )
+    # Truncation keeps CUDA's side; the rows still have to arrive right-padded.
+    input_ids, attention_mask, extras = _flush_vlm_arrays_to_side(
+        input_ids, attention_mask, "right", pad_id, extras,
+    )
 
     combined_inputs = dict(prompt_inputs)
     combined_inputs["input_ids"] = input_ids
@@ -5958,9 +6057,13 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         all_images.append(images)
         all_suffixes.append(item.get("suffix") if isinstance(item, dict) else None)
 
-    inputs = _processor_vlm_inputs(
-        processor, all_texts, all_images, max_seq_length,
-        suffixes=all_suffixes,
+    inputs = _right_pad_vlm_rows(
+        _processor_vlm_inputs(
+            processor, all_texts, all_images, max_seq_length,
+            suffixes=all_suffixes,
+            padding_side="right",
+        ),
+        processor,
     )
     if _vlm_inputs_host_valued(inputs) and _vlm_ids_integer_host(inputs):
         label_mask = _stage_vlm_label_mask_np(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -434,10 +434,26 @@ def _patch_layer_class_for_gc(layer_cls):
     fn = layer_cls.__call__
 
     def checkpointed_fn(self, *args, **kwargs):
-        def inner_fn(params, *args, **kwargs):
+        slot = next((a for a in args if isinstance(a, _SharedKVSlot)), None)
+        if slot is None:
+            def inner_fn(params, *args, **kwargs):
+                self.update(params)
+                return fn(self, *args, **kwargs)
+            return mx.checkpoint(inner_fn)(
+                self.trainable_parameters(), *args, **kwargs)
+
+        # Shared K/V crosses the checkpoint boundary as a traced argument and a
+        # traced result; read off the slot and the VJP drops the gradient.
+        def inner_fn(params, borrowed, *args, **kwargs):
             self.update(params)
-            return fn(self, *args, **kwargs)
-        return mx.checkpoint(inner_fn)(self.trainable_parameters(), *args, **kwargs)
+            slot.install(borrowed)
+            out = fn(self, *args, **kwargs)
+            return out, slot.recorded()
+
+        out, recorded = mx.checkpoint(inner_fn)(
+            self.trainable_parameters(), slot.borrow(), *args, **kwargs)
+        slot.install(recorded)
+        return out
 
     layer_cls.__call__ = checkpointed_fn
 
@@ -552,6 +568,74 @@ def _keeps_forwarded_mask(model):
     # mlx-vlm lower-cases model_type to resolve the module but leaves the
     # config's own spelling alone, so match the way it resolves.
     return str(model_type).lower() in _VLM_FAMILIES_KEEPING_FORWARDED_MASK
+
+
+class _SharedKVSlot:
+    """A cache with training semantics, so KV-shared layers borrow rather than
+    rebuild K/V that the reference implementation never recomputes.
+
+    Position stays 0 and nothing is ever trimmed; a prompt cache would forget
+    past its sliding window and re-rope queries at an advancing offset. No
+    version gate: gemma4 from mlx-vlm 0.5.0 reads shared K/V from its layer
+    results instead; the slots still travel with the batch, but stop being where
+    the sharing is read and leave the training result unchanged.
+
+    `borrow`/`install`/`recorded` exist because gradient checkpointing cannot
+    see an attribute read -- the recomputed VJP drops the gradient while the
+    forward stays correct -- so the wrapper passes K/V in as an argument and
+    takes it back as a result.
+    """
+
+    __slots__ = ("keys", "values")
+
+    def __init__(self):
+        self.keys = None
+        self.values = None
+
+    @property
+    def offset(self):
+        return 0
+
+    @property
+    def state(self):
+        return self.keys, self.values
+
+    def update_and_fetch(self, keys, values):
+        self.keys, self.values = keys, values
+        return keys, values
+
+    def borrow(self):
+        """K/V to pass into the next layer's traced region, if any."""
+        return None if self.keys is None else (self.keys, self.values)
+
+    def install(self, borrowed):
+        if borrowed is not None:
+            self.keys, self.values = borrowed
+
+    def recorded(self):
+        return self.keys, self.values
+
+
+def _shared_kv_slot_count(model):
+    """How many cache slots this stack needs, or 0 when it shares no K/V.
+
+    Not `first_kv_shared_layer_idx > 0`: upstream derives that as
+    `num_hidden_layers - num_kv_shared_layers`, so it is positive with zero
+    sharing too, as gemma4 12B/26B declare.
+    """
+    backbone = getattr(_get_text_model(model), "model", None)
+    if backbone is None:
+        return 0
+    config = getattr(backbone, "config", None)
+    if not (_config_get(config, "num_kv_shared_layers") or 0):
+        return 0
+    return getattr(backbone, "first_kv_shared_layer_idx", 0) or 0
+
+
+def _build_shared_kv_caches(model):
+    """Fresh per-forward slots for a stack that shares K/V, else None."""
+    slots = _shared_kv_slot_count(model)
+    return [_SharedKVSlot() for _ in range(slots)] if slots else None
 
 
 def _run_hidden_stack(stack, inputs, inputs_embeds=None, **kwargs):
@@ -1889,6 +1973,9 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
         fwd_kwargs["mask"] = (
             attention_mask if _keeps_forwarded_mask(model) else None
         )
+        shared_kv = _build_shared_kv_caches(model)
+        if shared_kv is not None:
+            fwd_kwargs["cache"] = shared_kv
         output = model(inputs, pixel_values=pixel_values, **fwd_kwargs)
         logits = output.logits if hasattr(output, "logits") else output
         logits = logits.astype(mx.float32)
@@ -2084,6 +2171,10 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
         backbone_kwargs["token_type_ids"] = extra_kwargs["token_type_ids"]
         if attention_mask is not None:
             backbone_kwargs["attention_mask"] = attention_mask
+
+    shared_kv = _build_shared_kv_caches(model)
+    if shared_kv is not None:
+        backbone_kwargs["cache"] = shared_kv
 
     hidden = _forward_text_hidden_states(
         model,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -616,6 +616,43 @@ class _SharedKVSlot:
         return self.keys, self.values
 
 
+# Language models that scale token embeddings by sqrt(hidden_size) on the ids
+# path only, so every multimodal forward loses it. gemma3 is absent because
+# `_run_hidden_stack`, the route it takes, already compensates.
+_VLM_EMBED_SCALE_FAMILIES = frozenset({"gemma3n_text"})
+
+
+def _vlm_embed_scale(model):
+    """The embedding scale this family's LM applies only on the ids path."""
+    config = getattr(getattr(_get_text_model(model), "model", None), "config", None)
+    if _config_get(config, "model_type") not in _VLM_EMBED_SCALE_FAMILIES:
+        return None
+    hidden_size = _config_get(config, "hidden_size")
+    return float(hidden_size) ** 0.5 if hidden_size else None
+
+
+def _apply_vlm_embed_scale(model, input_ids, merged_embeds):
+    """Scale the token embeddings a multimodal merge left unscaled.
+
+    Only positions still holding a plain token embedding: merged features
+    already carry the scaled magnitude. Found by difference, not by token id --
+    gemma3n's closing audio delimiter carries a feature without being the audio
+    token, and an id-based mask would rescale it.
+    """
+    scale = _vlm_embed_scale(model)
+    if scale is None or input_ids is None:
+        return merged_embeds
+    backbone = getattr(_get_text_model(model), "model", None)
+    embed_tokens = getattr(backbone, "embed_tokens", None)
+    if embed_tokens is None:
+        return merged_embeds
+    raw = embed_tokens(input_ids).astype(merged_embeds.dtype)
+    untouched = mx.all(merged_embeds == raw, axis=-1, keepdims=True)
+    # In the embedding dtype, as the ids path does: an fp32 product rounded back
+    # lands on different bf16 values.
+    return mx.where(untouched, merged_embeds * scale, merged_embeds)
+
+
 def _shared_kv_slot_count(model):
     """How many cache slots this stack needs, or 0 when it shares no K/V.
 
@@ -2162,6 +2199,7 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
         **extra_kwargs,
     )
     merged_embeds, backbone_kwargs = _unpack_embed_result(embed_result, model)
+    merged_embeds = _apply_vlm_embed_scale(model, inputs, merged_embeds)
     # Prefer collator-built mRoPE IDs when present. Qwen/GLM collators build
     # CUDA-parity full-sequence positions; recomputing inside the embedder moved
     # Qwen3-VL first-step loss from ~6.45 to ~6.90 on the real-cat fixture.


### PR DESCRIPTION
Six independent correctness bugs in MLX VLM training, each of which silently produced a wrong loss rather than an error. Four were found while building audio-input training and are extracted here so they can land on their own; the last two were found by sweeping the other families once the pattern was clear.

## The bugs

**A forwarded padding mask replaced causality.** mlx-vlm treats a supplied `mask` as the complete attention mask for every layer and only builds causal or sliding masks when it is `None`. The baseline VLM loss forwarded the collated 2-D padding mask, so causality was replaced outright and every supervised position could attend to the token it was being scored on. On `gemma-4-E2B` the loss came out at **3.9322 against a transformers reference of 7.4854** — below the reference, which is the tell: the model was reading the answer. Withholding the mask matches at 7.3659.

The fix sends `mask=None` except to the families that genuinely consume it. That is a checked list rather than a signature probe, because `molmo_point` declares `mask` and never reads it; the keyword is still always sent, because thirteen families declare it with no default; and it is matched case-insensitively on `model_type`, because a config keeps its own spelling through mlx-vlm's alias remap.

Withholding the mask leaves causality as the only thing excluding pads, and causality excludes a trailing pad, not a leading one. Collation therefore has to guarantee the layout rather than assume it. This is not a corner case: instruct checkpoints commonly ship `padding_side: left`, and five of the eleven locally exercisable families — Gemma 3, Gemma 3n, GLM-OCR, Qwen2-VL and Qwen3-VL — were producing left-padded batches before this change.

**KV-shared layers rebuilt K/V they were meant to borrow.** Gemma 3n and Gemma 4 reuse one layer's K/V in later layers, and mlx-vlm reaches that shared state only through the cache. Training forwards pass no cache, so every KV-shared layer rebuilt K/V from projections the reference implementation never uses, and the tail of the model attended to the wrong keys. `gemma-4-E2B` scored **14.3929 where transformers gives 7.4854**; supplying the shared state reaches 7.3659, matching mlx-vlm's own later implementation exactly. Gemma 3n moves from 22.1412 to 17.9880 against an 18.0012 reference and has no fixed upstream release at all.

For Gemma 4 this is a backport rather than a new fix: mlx-vlm shipped this correctly in 0.4.3, regressed it in `Fix Gemma 4 chunked prefill for KV-shared models and thinking` (#901) which first released in **0.4.4**, and repaired it in `Add KV cache quantization for continuous batching` (#1030) which first released in **0.5.0**. The affected window is exactly one release — and it is the release this package declares as its floor, so anyone on `mlx-vlm>=0.4.4` who has not upgraded is training on it. Gemma 3n is not a backport: its shared branch still reads `if self.is_kv_shared_layer and cache is not None` at 0.6.8, with no `shared_kv` threading anywhere in its language model, so there is no upstream release to move to.

No version gate is needed. On 0.5.0 and later Gemma 4 reads shared K/V from its own layer results, so the slots supplied here stop being where the sharing is read and leave the result unchanged — measured identical with and without them.

The borrowed K/V is carried as a value in the call graph rather than as an attribute on the cache. Under gradient checkpointing — on by default — an attribute is invisible to the recomputed backward pass, which silently drops the gradient while leaving the forward correct: the same model measured a gradient norm of 19.172302 against 21.723606 without checkpointing.

**Gemma 3 image training had no causality.** The multimodal path built its 4-D mask as an outer product of the padding mask, which is all-ones whenever nothing is padded. On `gemma-3-4b-it` with a 274-token image batch, **all 37,401 above-diagonal entries were visible** and the loss came out at 5.6532 against 19.0356 for the same batch through the cross-entropy path. Both paths now agree exactly, and the remaining above-diagonal visibility is 32,640 entries, which is the interior of the single 256-token image block and nothing else.

**Gemma 3n lost its embedding scale on every multimodal forward.** Its language model multiplies token embeddings by `sqrt(hidden_size)` only when given input ids; every multimodal forward hands it merged embeddings instead. The cross-entropy path scored **12.1275 where transformers gives 18.0012**, and now reaches 17.9937. Only positions still holding a plain token embedding are scaled — merged features already arrive at the scaled magnitude — and those positions are found by comparing against the token embeddings rather than by token id, because Gemma 3n's closing audio delimiter carries a feature while not being the audio token.

**PaliGemma's suffix was not causal.** Same construction as the Gemma 3 bug, in a separate implementation that the Gemma 3 fix does not reach, and still present upstream at 0.6.8 — this one has nowhere to upgrade to either. PaliGemma is a prefix-LM: its image and prompt are meant to attend bidirectionally and only the suffix is causal. Its 4-D mask was an outer product of the padding mask, so on an eight-position batch with a four-token prefix all 28 above-diagonal entries were visible and **22 of them were a completion token reading its own future**. After the fix the same batch keeps 6, exactly the prefix block's interior, with the prefix still fully bidirectional.

Both loss paths are corrected. The cross-entropy path embeds directly and already carries the token types that mark the prefix boundary; the plain path goes through `Model.__call__`, which embeds with a fixed three arguments and drops them, so a companion wrapper carries them across on a per-thread stack — not on the model, since one model can serve several callers at once and an attribute would let one read another's batch.

**Gemma 3n could not train above a batch of one.** Its AltUp correction transposes its coefficients as though the batch axis were last, giving `(inputs, sequence, batch)` against an innovation of `(batch, sequence, hidden)`. At a batch of one the trailing axis is 1 and broadcasts by accident; anything larger raises `[broadcast_shapes] Shapes (1,3,24,2048) and (4,1,24,3) cannot be broadcast`. Transposing to `(inputs, batch, sequence)` with an explicit trailing axis makes the coefficients broadcast over hidden instead of colliding with it. A ragged batch of three now trains where it previously raised, and a batch of one is bit-identical before and after.

This is the second backport of mlx-vlm #1030 — the same upstream commit that repaired Gemma 4's KV sharing, for the same reason. The replacement installs only after the loaded implementation is observed to fail a two-row correction, so a release that already handles it is left untouched and no version is hard-coded.

## Validation

Every number above is measured, not estimated. Beyond that:

**Ragged batches larger than one.** Every earlier validation of these fixes ran at batch size 1, where there is no padding at all and therefore no way to see a padding-layout defect. Collation was re-checked on real processors at ragged batch 3 across every locally available family, asserting content-then-padding on every row and that each token-aligned sidecar still marks the same tokens after a repair. The sidecar check has to compare positionally: an image block is a run of one repeated soft token, so a shift inside it leaves the multiset of marked ids identical while every mark points at the wrong column.

**No regression on other families.** Losses are bit-identical between this branch and `main` where no change is intended — `idefics3` at 6.443582 on both mlx-vlm 0.4.4 and 0.6.8, `gemma3` at 4.000300. Qwen2-VL's loss changes, and only because its layout is corrected: both sides supervise the same 88 positions and neither supervises a pad. A behavioural causality probe that perturbs a future token and checks whether an earlier logit moves reports zero drift for every family on both sides, so withholding the mask cannot make a family less causal than it was.

**A reference check on the padding argument.** Under causal-only attention a right-padded batch should reproduce the loss you get when the padding mask is supplied, and a left-padded batch should not. On the reference implementation with no MLX involved:

```text
right-padded   with padding mask 3.664971 | causal-only 3.662987 | drift 0.001984
left-padded    with padding mask 3.937409 | causal-only 3.412554 | drift 0.524856
```

Right-padded agrees to 0.002 nats; left-padded is 0.52 out and lower, the same "better than the reference" signature as the original defect.

**Suite.** No test fails on this branch that does not also fail on `main`. Note that `tests/test_moe_fused_narrow_expert_merge.py::test_fused_narrow_expert_merge_applies_delta` is nondeterministic on `main` itself — five full-suite runs there gave 167, 167, 166, 167 and 168 failures — so the comparison was made over unions of failing node ids across several runs per side rather than single runs.

## Relationship to upstream

Two of these have upstream fixes, both in mlx-vlm #1030, first released in 0.5.0: Gemma 4's shared K/V and Gemma 3n's AltUp batching. Those two parts are backports so the declared `mlx-vlm>=0.4.4` floor is correct, and both become inert once a user is on 0.5.0 or later — the AltUp one detects that for itself. Everything else is still live at 0.6.8: Gemma 3n's shared layers remain cache-tied, and the padding-outer-product mask remains in both `gemma3.py` and `paligemma.py`. The remaining two — the forwarded padding mask and the lost embedding scale — are in this package's own call sites, not upstream's.

## Risks and limits

- The Gemma 3n embedding scale is restored on the cross-entropy path, which is the trainer default, and not on the `use_cce=False` path, which calls the model's own forward and embeds internally where this cannot reach.
- The PaliGemma correction needs the processor's token types, which is where the prefix boundary lives. transformers 5.x returns those unconditionally; 4.x returns them only for a row carrying a suffix, so on 4.x a chat-style row keeps upstream's mask. The boundary is not recoverable at the embedder — only the supervised positions identify the suffix, and labels do not reach it — and guessing would be worse than leaving it, since a plain causal mask would also make the image block causal, which PaliGemma is not trained for. Where token types are absent the mask is left exactly as upstream built it, so this is a strict improvement rather than a change of behaviour.
- Sidecar relocation is driven by a named key set rather than inferred from array shapes. Shape does not identify what an array is indexed by — per-image metadata can carry the same extents as a per-token array — so an unlisted sidecar is deliberately left alone rather than guessed at, which is the same stance the width survey already takes on the same ambiguity.
- The collation repair is a safety net, not a normal path: every family checked honours `padding_side="right"`, so it only runs for processors that ignore the request, which `deepseek_vl_v2` and the Falcon pair do.
- `lfm2_vl` fails to train on mlx-vlm 0.4.4. That is an upstream issue, it reproduces identically on `main`, and it is not addressed here.
