### PR TITLE
Bound compiled signatures for streaming MLX training

### DIFF
--- a/tests/test_mlx_batching_and_decay.py
+++ b/tests/test_mlx_batching_and_decay.py
@@ -2574,7 +2574,7 @@ def test_stream_grid_widens_vlm_batches_at_the_consumer_width_seam():
     from unsloth_zoo.mlx.utils import _build_response_masked_vlm_batch
 
     class _ExpandingProcessor(_ContentProcessor):
-        # A post-expansion batch: wider than max_seq_length.
+        # Post-expansion width, past max_seq_length, with a grid for its image.
         def __call__(self, text, **_kwargs):  # noqa: D401
             width = 40 + 7 * max(int(item) for item in text)
             rows = [[int(item), 200] + [2] * (width - 2) for item in text]
@@ -2583,10 +2583,13 @@ def test_stream_grid_widens_vlm_batches_at_the_consumer_width_seam():
                 "attention_mask": np.array(
                     [[1] * width for _ in rows], dtype=np.int32,
                 ),
+                "image_grid_thw": np.array([[1, 2, 2]] * len(text), np.int32),
             }
 
     grid = StreamShapeGrid()
-    config, items = {"image_size": 16, "image_token_id": 200}, [{"text": "5"}]
+    config = {"model_type": "qwen3_5", "image_size": 16, "image_token_id": 200,
+              "video_token_id": 201, "vision_config": {"spatial_merge_size": 2}}
+    items = [{"text": "5"}]
     plain = _build_response_masked_vlm_batch(
         items, _ExpandingProcessor(), config, 8, 16,
     )
@@ -2600,9 +2603,12 @@ def test_stream_grid_widens_vlm_batches_at_the_consumer_width_seam():
     assert raw_width > 8
     guarded_width = int(guarded["input_ids"].shape[1])
     assert guarded_width == grid.endpoint_for(raw_width)
-    # Content preserved, pad tail masked out.
+    # Content preserved, pad tail masked, positions rebuilt at the padded width.
     assert guarded["input_ids"][:, :raw_width].tolist() == plain["input_ids"].tolist()
     assert guarded["attention_mask"][:, raw_width:].sum().item() == 0
+    assert int(guarded["position_ids"].shape[-1]) == guarded_width
+    assert (guarded["position_ids"][..., :raw_width].tolist()
+            == plain["position_ids"].tolist())
 
     # Unmaterializable widening keeps the exact width instead of aborting.
     from unsloth_zoo.mlx.utils import _resolve_stream_vlm_target

--- a/tests/test_mlx_batching_and_decay.py
+++ b/tests/test_mlx_batching_and_decay.py
@@ -2531,3 +2531,66 @@ def test_vlm_plan_reports_an_image_file_rewritten_after_the_plan_was_built(tmp_p
     Image.fromarray(np.full((8, 8, 3), 99, dtype=np.uint8)).save(paths[2])
     with pytest.raises(ValueError, match="file backing a dataset image changed"):
         plan.materialize_all()
+
+
+def test_stream_grid_widens_vlm_batches_at_the_consumer_width_seam():
+    """The consumer width seam works on whatever width finalization produced —
+    for VLM that is the post-expansion width, which may exceed max_seq_length,
+    so the grid is anchor-free. Widening that could not materialize (no pad id,
+    or an endpoint an untouched array occupies) is refused or bumped rather
+    than attempted. The processor here emits the wide batch directly; the
+    expansion step itself is covered by the finite-plan VLM tests."""
+    _skip_if_mlx_core_was_replaced()
+    from unsloth_zoo.mlx.shape_guard import StreamShapeGrid
+    from unsloth_zoo.mlx.utils import _build_response_masked_vlm_batch
+
+    class _ExpandingProcessor(_ContentProcessor):
+        # A post-expansion batch: wider than max_seq_length.
+        def __call__(self, text, **_kwargs):  # noqa: D401
+            width = 40 + 7 * max(int(item) for item in text)
+            rows = [[int(item), 200] + [2] * (width - 2) for item in text]
+            return {
+                "input_ids": np.array(rows, dtype=np.int32),
+                "attention_mask": np.array(
+                    [[1] * width for _ in rows], dtype=np.int32,
+                ),
+            }
+
+    grid = StreamShapeGrid()
+    config, items = {"image_size": 16, "image_token_id": 200}, [{"text": "5"}]
+    plain = _build_response_masked_vlm_batch(
+        items, _ExpandingProcessor(), config, 8, 16,
+    )
+    guarded = _build_response_masked_vlm_batch(
+        items, _ExpandingProcessor(), config, 8, 16,
+        width_policy=grid.endpoint_for,
+    )
+
+    raw_width = int(plain["input_ids"].shape[1])
+    # Guarded lands on a grid endpoint at or above the expanded width.
+    assert raw_width > 8
+    guarded_width = int(guarded["input_ids"].shape[1])
+    assert guarded_width == grid.endpoint_for(raw_width)
+    # Content preserved, pad tail masked out.
+    assert guarded["input_ids"][:, :raw_width].tolist() == plain["input_ids"].tolist()
+    assert guarded["attention_mask"][:, raw_width:].sum().item() == 0
+
+    # Unmaterializable widening keeps the exact width instead of aborting.
+    from unsloth_zoo.mlx.utils import _resolve_stream_vlm_target
+
+    class _NoPadTokenizer(_TinyTokenizer):
+        pad_token_id = None
+
+    class _NoPadProcessor(_ExpandingProcessor):
+        tokenizer = _NoPadTokenizer()
+
+    assert _resolve_stream_vlm_target(
+        plain, config, _NoPadProcessor(), grid.endpoint_for,
+    ) is None
+    # An occupied endpoint is bumped past, never handed to the finalizer.
+    bumped = dict(plain)
+    bumped["media_extent"] = mx.zeros((1, guarded_width), dtype=mx.int32)
+    target = _resolve_stream_vlm_target(
+        bumped, config, _ExpandingProcessor(), grid.endpoint_for,
+    )
+    assert target is not None and target > guarded_width

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -23,6 +23,7 @@ from unsloth_zoo.mlx.shape_guard import (
     resolve_compile_max_variants,
     select_text_shape_padding_budget,
     stream_exact_ceiling,
+    stream_phase_count,
 )
 
 
@@ -509,7 +510,32 @@ def test_stream_grid_anchor_and_report_contract():
     wide = StreamShapeGrid(anchor=4096)
     assert [stream_exact_ceiling(g, c) for g, c in (
         (wide, 128), (wide, 64), (StreamShapeGrid(), 64), (wide, 60),
-    )] == [SMALL_EXACT_SIGNATURE_THRESHOLD, 4, 16, None]
+    )] == [SMALL_EXACT_SIGNATURE_THRESHOLD, 3, 16, None]
+    # The allowance must leave room for the grid it precedes. Two ways to get
+    # this wrong: ignoring that accumulation makes one endpoint cost a
+    # signature per phase, and forgetting that an allowance of N admits N + 1
+    # signatures because it holds while the count is at or below N.
+    # Pin the helper across the range, or one returning 2 for every
+    # accumulation above one would satisfy every other assertion here.
+    assert [stream_phase_count(FULL_STEP_SCOPE, n) for n in (1, 2, 3, 4, 8)] == [
+        1, 2, 3, 3, 3,
+    ]
+    for cap in (64, 128, 256):
+        for anchor in (2048, 4096, 16384):
+            grid = StreamShapeGrid(anchor=anchor)
+            for phases in (1, 2, 3):
+                for in_flight in (0, 2):
+                    ceiling = stream_exact_ceiling(grid, cap, phases, in_flight)
+                    if ceiling is None:
+                        continue
+                    admitted = ceiling + 1 + in_flight
+                    assert admitted + grid.endpoint_count * phases <= cap, (
+                        cap, anchor, phases, in_flight, ceiling,
+                    )
+    # Returning None everywhere would satisfy that invariant vacuously, so pin
+    # that the allowance survives where there is genuinely room for it.
+    assert stream_exact_ceiling(wide, 128, 2) > 0
+    assert stream_exact_ceiling(wide, 128, 1, 4) == SMALL_EXACT_SIGNATURE_THRESHOLD
     assert "at most 32 signatures" in describe_stream_shape_grid(wide, 128, 32)
     assert "stay exact" not in describe_stream_shape_grid(wide, 128, None)
 

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -8,8 +8,12 @@ from unsloth_zoo.mlx.shape_guard import (
     AUTOMATIC_TEXT_COMPILE_CEILING,
     DDP_LOCAL_GRAD_SCOPE,
     FULL_STEP_SCOPE,
+    STREAM_GRID_FLOOR_WIDTH,
+    StreamShapeGrid,
+    StreamShapeGuardReport,
     TextShapeEvent,
     build_text_shape_frontier,
+    describe_stream_shape_grid,
     materialize_text_shape_frontier,
     phase_for_microstep,
     plan_text_shape_buckets,
@@ -189,7 +193,7 @@ def test_padding_budget_exact_threshold_boundary_and_domain():
 
     assert (exact.action, exact.planned_signatures, exact.raw_signatures) == ("exact", 128, 128)
     assert (bucketed.action, bucketed.raw_signatures) == ("bucket", 129)
-    # No bounded points exist below the default; the ceiling caps above.
+    # No bounded points below the default; the ceiling caps above.
     for invalid in (31, AUTOMATIC_TEXT_COMPILE_CEILING + 1):
         with pytest.raises(ValueError):
             select_text_shape_padding_budget(
@@ -423,3 +427,63 @@ def test_shared_cap_materialization_preserves_both_padding_budgets():
     assert shared.report.padding_work_fraction <= 0.05
     assert shared.report.max_width_stretch <= 1.5
     assert shared.report.budget_satisfied is True
+
+
+def test_stream_grid_endpoints_are_idempotent_and_bounded_by_the_budget():
+    grid = StreamShapeGrid()
+    endpoints = grid.endpoints_through(20_000)
+
+    # Endpoints map to themselves; ranks agree without exchanging any.
+    assert all(grid.endpoint_for(point) == point for point in endpoints)
+    assert all(b > a for a, b in zip(endpoints, endpoints[1:]))
+    assert endpoints[0] == STREAM_GRID_FLOOR_WIDTH
+    assert grid.endpoint_for(1) == grid.endpoint_for(2) == STREAM_GRID_FLOOR_WIDTH
+    assert StreamShapeGrid().endpoints_through(20_000) == endpoints
+    linear = [point for point in endpoints if 2 < point <= 641]
+    assert linear == list(range(33, 642, 32))
+    assert all(grid.endpoint_for(point - 1) == point for point in linear[1:])
+    # Inside the quadratic budget the ratio was solved against.
+    overheads = {
+        w: (grid.endpoint_for(w) ** 2 - w * w) / (w * w)
+        for w in range(641, 20_000)
+    }
+    assert max(overheads.values()) < 0.13
+    mass = sum(1 / w for w in overheads)
+    log_uniform_mean = sum(v / w for w, v in overheads.items()) / mass
+    assert log_uniform_mean < 0.06
+
+
+def test_stream_grid_anchor_and_report_contract():
+    anchored = StreamShapeGrid(anchor=100)
+
+    # The anchor is the final endpoint; nothing widens past it.
+    assert anchored.endpoints_through(500) == (2, 33, 65, 97, 100)
+    assert anchored.endpoint_count == 5
+    assert anchored.endpoint_for(98) == anchored.endpoint_for(4096) == 100
+    assert StreamShapeGrid(anchor=STREAM_GRID_FLOOR_WIDTH).endpoint_count == 1
+    with pytest.raises(ValueError):
+        StreamShapeGrid(anchor=STREAM_GRID_FLOOR_WIDTH - 1)
+
+    # VLM has no anchor: expansion can exceed max_seq_length.
+    unbounded = StreamShapeGrid()
+    assert unbounded.endpoint_count is None
+    assert unbounded.endpoint_for(1_000_000) >= 1_000_000
+
+    report = StreamShapeGuardReport(
+        action="stream_grid", reason="streaming", cap=128,
+        compile_scope=FULL_STEP_SCOPE, grid_ratio="21/20", grid_floor=2,
+        grid_anchor=4096, grid_endpoints=60, observed_signatures=7,
+    )
+
+    payload = report.to_dict()
+    assert set(payload) == {
+        "action", "reason", "cap", "compile_scope", "grid_ratio", "grid_floor",
+        "grid_anchor", "grid_endpoints", "observed_signatures", "tripped",
+        "trip_reason", "exact_width_only",
+    }
+    assert payload["action"] == "stream_grid"
+    assert (payload["observed_signatures"], payload["tripped"]) == (7, False)
+    assert (payload["grid_endpoints"], payload["grid_anchor"]) == (60, 4096)
+    # Reports the grid it was handed, not the default ratio.
+    assert "1.05" in describe_stream_shape_grid(StreamShapeGrid(anchor=4096), 128)
+    assert "2.00" in describe_stream_shape_grid(StreamShapeGrid(ratio=2), 128)

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -8,6 +8,7 @@ from unsloth_zoo.mlx.shape_guard import (
     AUTOMATIC_TEXT_COMPILE_CEILING,
     DDP_LOCAL_GRAD_SCOPE,
     FULL_STEP_SCOPE,
+    SMALL_EXACT_SIGNATURE_THRESHOLD,
     STREAM_GRID_FLOOR_WIDTH,
     StreamShapeGrid,
     StreamShapeGuardReport,
@@ -20,6 +21,7 @@ from unsloth_zoo.mlx.shape_guard import (
     plan_text_shape_padding_budget,
     resolve_compile_max_variants,
     select_text_shape_padding_budget,
+    stream_exact_ceiling,
 )
 
 
@@ -473,17 +475,27 @@ def test_stream_grid_anchor_and_report_contract():
         action="stream_grid", reason="streaming", cap=128,
         compile_scope=FULL_STEP_SCOPE, grid_ratio="21/20", grid_floor=2,
         grid_anchor=4096, grid_endpoints=60, observed_signatures=7,
+        gate_released=True,
     )
 
     payload = report.to_dict()
     assert set(payload) == {
         "action", "reason", "cap", "compile_scope", "grid_ratio", "grid_floor",
         "grid_anchor", "grid_endpoints", "observed_signatures", "tripped",
-        "trip_reason", "exact_width_only",
+        "trip_reason", "exact_width_only", "exact_ceiling", "gate_released",
     }
-    assert payload["action"] == "stream_grid"
+    assert (payload["action"], payload["gate_released"]) == ("stream_grid", True)
     assert (payload["observed_signatures"], payload["tripped"]) == (7, False)
     assert (payload["grid_endpoints"], payload["grid_anchor"]) == (60, 4096)
     # Reports the grid it was handed, not the default ratio.
     assert "1.05" in describe_stream_shape_grid(StreamShapeGrid(anchor=4096), 128)
     assert "2.00" in describe_stream_shape_grid(StreamShapeGrid(ratio=2), 128)
+
+    # Tightest clamp wins, and the allowance vanishes once endpoints or the
+    # cap leave nothing to spend. 60 endpoints here, so cap 64 leaves only 4.
+    wide = StreamShapeGrid(anchor=4096)
+    assert [stream_exact_ceiling(g, c) for g, c in (
+        (wide, 128), (wide, 64), (StreamShapeGrid(), 64), (wide, 60),
+    )] == [SMALL_EXACT_SIGNATURE_THRESHOLD, 4, 16, None]
+    assert "at most 32 signatures" in describe_stream_shape_grid(wide, 128, 32)
+    assert "stay exact" not in describe_stream_shape_grid(wide, 128, None)

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -8186,6 +8186,10 @@ def test_stream_width_policy_and_registry_contracts():
         "stream_exact", False, 2)
     # One signature past the allowance the same object widens.
     assert gated(55) == 65 and gated.gate_released
+    # A permanent eager fallback disarms it; nothing compiled consumes a grid
+    # width again, so the tail must not keep padding onto one.
+    gated.armed = False
+    assert gated(55) is None
     assert rep().action == "stream_grid"
 
     registry = _StreamSignatureRegistry(1)

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -8125,3 +8125,132 @@ def test_qwen3_prompt_rows_defer_to_the_native_deepstack_path():
     mask_only = {"inputs_embeds": mx.zeros((1, 4, 1)), "visual_pos_masks": masks}
     filled = mc._pad_qwen3_prompt_rows([mask_only, compact_row])[0]
     assert not filled[mc._QWEN3_VISUAL_STATE_KEY].any().item()
+
+
+def test_stream_width_policy_and_registry_contracts():
+    """A disarmed policy leaves both staging rules untouched, and the registry
+    separates every axis a compiled call keys on."""
+    import numpy as np
+
+    from unsloth_zoo.mlx.shape_guard import StreamShapeGrid
+    from unsloth_zoo.mlx.trainer import (
+        _StreamSignatureRegistry, _StreamWidthPolicy, _stream_batch_signature,
+    )
+    from unsloth_zoo.mlx.utils import (
+        _stage_text_batch_from_items, _stage_tokenized_text_batch,
+    )
+
+    class _Tok:
+        pad_token_id = 0
+
+    policy = _StreamWidthPolicy(StreamShapeGrid(anchor=512))
+    # Labeled, so label bytes are compared and not just their absence.
+    rows = [([1] * 40, [2] * 40), ([1] * 55, [3] * 55)]
+    raw = [[1] * 40, [1] * 55]
+    plain = _stage_tokenized_text_batch(rows, 512, pad_id=0)
+    plain_raw = _stage_text_batch_from_items(raw, _Tok(), 512)
+    assert policy(55) is None
+    # Disarmed: both paths stage byte-identically.
+    for staged, reference in (
+        (_stage_tokenized_text_batch(rows, 512, pad_id=0, width_policy=policy), plain),
+        (_stage_text_batch_from_items(raw, _Tok(), 512, width_policy=policy), plain_raw),
+    ):
+        assert np.array_equal(np.asarray(staged.ids), np.asarray(reference.ids))
+        assert np.array_equal(
+            np.asarray(staged.lengths_info), np.asarray(reference.lengths_info),
+        )
+        assert np.array_equal(
+            np.asarray(staged.labels), np.asarray(reference.labels),
+        )
+
+    policy.armed = True
+    guarded = _stage_tokenized_text_batch(
+        rows, 512, pad_id=0, width_policy=policy,
+    )
+    # Widened, with true lengths kept so masking never sees the tail.
+    assert guarded.ids.shape == (2, 65)
+    assert np.array_equal(guarded.lengths_info, plain.lengths_info)
+
+    registry = _StreamSignatureRegistry(1)
+
+    def _key(width, rows=2, phase="single", execution=("gpu", "s0")):
+        batch = (np.zeros((rows, width), dtype=np.int32), None, None)
+        return _stream_batch_signature(batch, phase, execution)
+
+    registry.record(_key(33))
+    # A repeat never trips; every keyed axis is distinct.
+    assert not registry.would_trip(_key(33))
+    assert all(registry.would_trip(other) for other in (
+        _key(65), _key(33, rows=4), _key(33, phase="tree_update"),
+        _key(33, execution=("gpu", "s1")),
+    ))
+
+
+
+
+def test_streaming_guard_admission_protocol_is_one_collective_per_fetch():
+    """One reduction per fetch, failure outranking a trip, a peer-only trip
+    switching this rank, and non-compiled microsteps still participating."""
+    import numpy as np
+
+    from unsloth_zoo.mlx.shape_guard import FULL_STEP_SCOPE
+    from unsloth_zoo.mlx.trainer import (
+        MLXTrainer, _StreamSignatureRegistry, _stream_batch_signature,
+        _stream_execution_key,
+    )
+
+    trainer = object.__new__(MLXTrainer)
+    trainer._distributed_initialized = True
+    trainer._distributed_rank = 0
+    trainer.stop_requested = False
+    reductions = []
+    peer_signal = 0
+
+    def _fake_max_int(value):
+        reductions.append(value)
+        return max(value, peer_signal)
+
+    trainer._distributed_max_int = _fake_max_int
+    registry = _StreamSignatureRegistry(1)
+    batch = (np.zeros((2, 33), dtype=np.int32), None, None)
+
+    def _admit(world=2, data=batch):
+        return trainer._admit_stream_batch(
+            registry, data, FULL_STEP_SCOPE, 1, 0, world,
+        )
+
+    # Admitted and recorded; one reduction, contributing 0.
+    assert _admit() is False
+    assert reductions == [0] and len(registry.observed) == 1
+
+    # A second distinct shape exceeds the cap.
+    wide = (np.zeros((2, 65), dtype=np.int32), None, None)
+    assert _admit(data=wide) is True
+    assert reductions[-1] == 1
+
+    peer_signal = 1
+    assert _admit() is True
+    peer_signal = 0
+
+    # A microstep with no compiled call still participates.
+    before = len(reductions)
+    assert _admit(data=None) is False
+    assert len(reductions) == before + 1 and reductions[-1] == 0
+
+    # A peer failure outranks everything.
+    peer_signal = 2
+    with pytest.raises(RuntimeError, match="peer rank failed"):
+        _admit()
+    # One reduction per admission, never two.
+    assert len(reductions) == 5
+
+    # Single-process runs add no collective at all.
+    solo = _StreamSignatureRegistry(1)
+    before = len(reductions)
+    assert trainer._admit_stream_batch(
+        solo, batch, FULL_STEP_SCOPE, 1, 0, 1,
+    ) is False
+    assert len(reductions) == before
+    assert _stream_batch_signature(
+        batch, "single", _stream_execution_key(),
+    ) in solo.observed

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -8244,6 +8244,16 @@ def test_streaming_guard_admission_protocol_is_one_collective_per_fetch():
     # One reduction per admission, never two.
     assert len(reductions) == 5
 
+    # An uncertifiable family may span several real cache keys: one eager
+    # batch each time, never spending capacity.
+    uncertifiable = {"input_ids": np.zeros((1, 33), dtype=np.int32), "m": object()}
+    for _ in range(3):
+        assert trainer._admit_stream_batch(
+            registry, uncertifiable, FULL_STEP_SCOPE, 1, 0, 1,
+        ) == "eager_batch"
+    assert registry.uncertified == 3 and registry.uncertified_family
+    assert len(registry.observed) == 1
+
     # Single-process runs add no collective at all.
     solo = _StreamSignatureRegistry(1)
     before = len(reductions)

--- a/tests/test_mlx_trainer_internals.py
+++ b/tests/test_mlx_trainer_internals.py
@@ -8135,6 +8135,7 @@ def test_stream_width_policy_and_registry_contracts():
     from unsloth_zoo.mlx.shape_guard import StreamShapeGrid
     from unsloth_zoo.mlx.trainer import (
         _StreamSignatureRegistry, _StreamWidthPolicy, _stream_batch_signature,
+        _stream_guard_report,
     )
     from unsloth_zoo.mlx.utils import (
         _stage_text_batch_from_items, _stage_tokenized_text_batch,
@@ -8170,6 +8171,22 @@ def test_stream_width_policy_and_registry_contracts():
     # Widened, with true lengths kept so masking never sees the tail.
     assert guarded.ids.shape == (2, 65)
     assert np.array_equal(guarded.lengths_info, plain.lengths_info)
+
+    # Armed through the production path, which derives the allowance itself.
+    gated, counted = _StreamWidthPolicy(StreamShapeGrid(anchor=512)), _StreamSignatureRegistry(128)
+    gated.arm(counted)
+    assert (gated.armed, gated.exact_ceiling) == (True, 32)
+    assert gated.observed is counted.observed
+    gated.exact_ceiling = 2
+    rep = lambda: _stream_guard_report(gated, counted, "full_step")
+    for index in range(3):
+        assert gated(55) is None, index
+        counted.record(("k", index))
+    assert (rep().action, rep().gate_released, rep().exact_ceiling) == (
+        "stream_exact", False, 2)
+    # One signature past the allowance the same object widens.
+    assert gated(55) == 65 and gated.gate_released
+    assert rep().action == "stream_grid"
 
     registry = _StreamSignatureRegistry(1)
 

--- a/unsloth_zoo/mlx/shape_guard.py
+++ b/unsloth_zoo/mlx/shape_guard.py
@@ -138,6 +138,8 @@ class StreamShapeGuardReport:
     tripped: bool = False
     trip_reason: str = ""
     exact_width_only: bool = False
+    exact_ceiling: int | None = None
+    gate_released: bool = False
 
     def to_dict(self):
         return asdict(self)
@@ -235,15 +237,48 @@ class StreamShapeGrid:
         return len(self._endpoints)
 
 
-def describe_stream_shape_grid(grid, cap):
-    """One-line summary of the endpoint policy a streaming run will use."""
+def stream_exact_ceiling(grid, cap):
+    """Signatures a stream may compile before widths widen onto the grid.
+
+    Staging precedes admission, so the batch introducing the signature past
+    this count is itself staged exact and a synchronous run compiles one more
+    than the ceiling. A text prefetch producer consults this while staging and
+    can queue further exact batches ahead of the consumer; the VLM prefetch
+    path decides after dequeue, so it adds none.
+
+    Below this a width grid cannot pay for itself, the same judgement the
+    finite path makes with ``SMALL_EXACT_SIGNATURE_THRESHOLD``. Exact
+    signatures are sunk in the compile cache, so the allowance is also held
+    to a quarter of the cap and, for an anchored grid, to whatever the
+    endpoints leave unclaimed. ``None`` disables it: widen from the first
+    batch, which is the behaviour of a run with no headroom to spend.
+    """
+    cap = int(cap)
+    ceiling = min(SMALL_EXACT_SIGNATURE_THRESHOLD, cap // 4)
+    endpoints = grid.endpoint_count
+    if endpoints is not None:
+        ceiling = min(ceiling, cap - endpoints)
+    return ceiling if ceiling > 0 else None
+
+
+def describe_stream_shape_grid(grid, cap, exact_ceiling=None):
+    """One-line summary of the endpoint policy a streaming run will use.
+
+    States configuration, not outcome: at startup a run that stays exact and
+    one that later widens are indistinguishable.
+    """
 
     count = grid.endpoint_count
     reach = "unbounded" if count is None else f"{count} endpoints"
+    allowance = (
+        "" if exact_ceiling is None else
+        f" widths stay exact while at most {exact_ceiling} signatures have "
+        f"been compiled, after which"
+    )
     return (
-        f"Unsloth: streaming compile shapes are bounded to {cap} signatures "
-        f"over a {reach} width grid (ratio {float(grid.ratio):.2f}, floor "
-        f"{STREAM_GRID_FLOOR_WIDTH})."
+        f"Unsloth: streaming compile shapes are bounded to {cap} signatures;"
+        f"{allowance} widths widen over a {reach} grid (ratio "
+        f"{float(grid.ratio):.2f}, floor {STREAM_GRID_FLOOR_WIDTH})."
     )
 
 
@@ -953,6 +988,7 @@ __all__ = (
     "StreamShapeGrid",
     "StreamShapeGuardReport",
     "describe_stream_shape_grid",
+    "stream_exact_ceiling",
     "TextShapeEvent",
     "TextShapeFrontier",
     "TextShapeGuardReport",

--- a/unsloth_zoo/mlx/shape_guard.py
+++ b/unsloth_zoo/mlx/shape_guard.py
@@ -6,7 +6,13 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-"""Pure planning for bounded finite-text ``mx.compile`` signatures.
+"""Pure planning for bounded ``mx.compile`` signatures.
+
+Two regimes share this module. A finite dataset, text or VLM, is planned whole
+from the widths its schedule already fixes. An unsized stream has no schedule to
+plan from and is instead held to an endpoint grid — anchored to
+``max_seq_length`` for text, anchor-free for VLM, whose compile-visible width is
+only known after image-token expansion.
 
 The cap here counts application-visible callable signatures. It is not an MLX
 compiler-cache count and is not an estimate of Metal resources.

--- a/unsloth_zoo/mlx/shape_guard.py
+++ b/unsloth_zoo/mlx/shape_guard.py
@@ -250,8 +250,18 @@ def stream_exact_ceiling(grid, cap):
     finite path makes with ``SMALL_EXACT_SIGNATURE_THRESHOLD``. Exact
     signatures are sunk in the compile cache, so the allowance is also held
     to a quarter of the cap and, for an anchored grid, to whatever the
-    endpoints leave unclaimed. ``None`` disables it: widen from the first
-    batch, which is the behaviour of a run with no headroom to spend.
+    endpoints leave unclaimed.
+
+    ``None`` disables the allowance and widens from the first batch. An
+    anchored grid's endpoint count grows with ``max_seq_length``, so a long
+    enough context, or a cap at or below the endpoint count, leaves nothing to
+    reserve. Widening immediately is the safe answer there, not a free one: an
+    allowance spent first would sink signatures the endpoints still need, so a
+    diverse stream would reach the cap and fall back to eager. A stream narrow
+    enough to have stayed under the cap regardless pays padding it never needed,
+    which is the price of not being able to tell the two apart in advance.
+    The corollary is that a stream is only guaranteed to stage exactly what an
+    unguarded run would when this returns a positive allowance.
     """
     cap = int(cap)
     ceiling = min(SMALL_EXACT_SIGNATURE_THRESHOLD, cap // 4)

--- a/unsloth_zoo/mlx/shape_guard.py
+++ b/unsloth_zoo/mlx/shape_guard.py
@@ -32,6 +32,16 @@ MAX_COMPILE_VARIANTS = 256
 FULL_STEP_SCOPE = "full_step"
 DDP_LOCAL_GRAD_SCOPE = "ddp_local_grad"
 
+# An unsized source cannot be surveyed, so endpoints are fixed up front:
+# widths widen onto this grid, confining compiled signatures to grid points.
+STREAM_GRID_FLOOR_WIDTH = 2
+STREAM_GRID_LINEAR_STEP = 32
+STREAM_GRID_ALIGNMENT = 8
+# Solved against MAX_PADDING_WORK_PERCENT under the planner's quadratic work
+# measure: log-uniform mean overhead (r^2 - 1) / (2 ln r) - 1 is 5.04% at 21/20.
+# Exact rationals keep the sequence identical across processes and ranks.
+STREAM_GRID_RATIO = Fraction(21, 20)
+
 
 @dataclass(frozen=True)
 class TextShapeEvent:
@@ -105,6 +115,136 @@ class TextShapeGuardReport:
         }
         result["padding_fraction"] = self.padding_fraction
         return result
+
+
+@dataclass(frozen=True)
+class StreamShapeGuardReport:
+    """Outcome of guarding an unsized streaming schedule.
+
+    Separate from ``TextShapeGuardReport``: a stream has no surveyed catalog,
+    so the meaningful numbers are what the run compiled and whether it hit the
+    cap. Emitted at training end, when those counts are final.
+    """
+
+    action: str
+    reason: str
+    cap: int
+    compile_scope: str
+    grid_ratio: str
+    grid_floor: int
+    grid_anchor: int | None = None
+    grid_endpoints: int | None = None
+    observed_signatures: int = 0
+    tripped: bool = False
+    trip_reason: str = ""
+    exact_width_only: bool = False
+
+    def to_dict(self):
+        return asdict(self)
+
+
+class StreamShapeGrid:
+    """Fixed endpoint grid a streamed batch's width is widened onto.
+
+    One recurrence carries an exact value: ``x0 = floor``, ``x1 = step``, then
+    ``x -> max(x + step, x * ratio)``, so the additive branch spans short
+    widths and the geometric one long widths without a hand-placed crossover.
+    Terms after ``x0`` publish ``1 + alignment * ceil(x / alignment)``. The
+    sequence is materialized lazily, so lookups bisect and every endpoint maps
+    to itself. An ``anchor`` (text's ``max_seq_length``) terminates the grid;
+    without one it extends on demand, which VLM needs because image-token
+    expansion produces widths above ``max_seq_length`` and an endpoint below a
+    batch's own width could never materialize.
+    """
+
+    __slots__ = ("_anchor", "_ratio", "_carried", "_endpoints", "_closed")
+
+    def __init__(self, *, anchor=None, ratio=STREAM_GRID_RATIO):
+        if ratio <= 1:
+            raise ValueError("stream grid ratio must exceed 1")
+        if anchor is not None:
+            anchor = operator.index(anchor)
+            if anchor < STREAM_GRID_FLOOR_WIDTH:
+                raise ValueError(
+                    "stream grid anchor must be at least "
+                    f"{STREAM_GRID_FLOOR_WIDTH}, got {anchor}"
+                )
+        self._anchor = anchor
+        self._ratio = Fraction(ratio)
+        self._carried = Fraction(STREAM_GRID_LINEAR_STEP)
+        self._endpoints = []
+        self._closed = False
+        self._publish(STREAM_GRID_FLOOR_WIDTH)
+
+    def _publish(self, endpoint):
+        if self._anchor is not None and endpoint >= self._anchor:
+            endpoint = self._anchor
+            self._closed = True
+        if not self._endpoints or endpoint > self._endpoints[-1]:
+            self._endpoints.append(endpoint)
+
+    def _grow(self):
+        """False once the grid is closed."""
+        if self._closed:
+            return False
+        carried = self._carried
+        self._carried = max(
+            carried + STREAM_GRID_LINEAR_STEP, carried * self._ratio,
+        )
+        aligned = -(-carried // STREAM_GRID_ALIGNMENT)
+        self._publish(1 + STREAM_GRID_ALIGNMENT * int(aligned))
+        return True
+
+    def endpoint_for(self, width):
+        """Smallest endpoint at or above ``width`` (the anchor caps it)."""
+        width = operator.index(width)
+        while self._endpoints[-1] < width and self._grow():
+            pass
+        endpoints = self._endpoints
+        low, high = 0, len(endpoints)
+        while low < high:
+            middle = (low + high) // 2
+            if endpoints[middle] < width:
+                low = middle + 1
+            else:
+                high = middle
+        return endpoints[low] if low < len(endpoints) else endpoints[-1]
+
+    def endpoints_through(self, width):
+        """Materialized endpoints up to ``width``."""
+        self.endpoint_for(width)
+        return tuple(
+            endpoint for endpoint in self._endpoints if endpoint <= width
+        )
+
+    @property
+    def ratio(self):
+        return self._ratio
+
+    @property
+    def anchor(self):
+        return self._anchor
+
+    @property
+    def endpoint_count(self):
+        """Total endpoints, or None while the grid can still grow."""
+        if self._anchor is None:
+            return None
+        while self._grow():
+            pass
+        return len(self._endpoints)
+
+
+def describe_stream_shape_grid(grid, cap):
+    """One-line summary of the endpoint policy a streaming run will use."""
+
+    count = grid.endpoint_count
+    reach = "unbounded" if count is None else f"{count} endpoints"
+    return (
+        f"Unsloth: streaming compile shapes are bounded to {cap} signatures "
+        f"over a {reach} width grid (ratio {float(grid.ratio):.2f}, floor "
+        f"{STREAM_GRID_FLOOR_WIDTH})."
+    )
 
 
 @dataclass(frozen=True)
@@ -806,6 +946,13 @@ __all__ = (
     "MAX_COMPILE_VARIANTS",
     "FULL_STEP_SCOPE",
     "DDP_LOCAL_GRAD_SCOPE",
+    "STREAM_GRID_FLOOR_WIDTH",
+    "STREAM_GRID_LINEAR_STEP",
+    "STREAM_GRID_ALIGNMENT",
+    "STREAM_GRID_RATIO",
+    "StreamShapeGrid",
+    "StreamShapeGuardReport",
+    "describe_stream_shape_grid",
     "TextShapeEvent",
     "TextShapeFrontier",
     "TextShapeGuardReport",

--- a/unsloth_zoo/mlx/shape_guard.py
+++ b/unsloth_zoo/mlx/shape_guard.py
@@ -237,7 +237,20 @@ class StreamShapeGrid:
         return len(self._endpoints)
 
 
-def stream_exact_ceiling(grid, cap):
+def stream_phase_count(compile_scope, gradient_accumulation_steps):
+    """Distinct compiled argument structures one width can produce.
+
+    The signature carries the accumulation micro-step's phase, so a single
+    endpoint backs this many cache entries rather than one.
+    """
+    steps = operator.index(gradient_accumulation_steps)
+    return len({
+        phase_for_microstep(compile_scope, steps, index)
+        for index in range(max(1, steps))
+    })
+
+
+def stream_exact_ceiling(grid, cap, phases_per_endpoint=1, in_flight=0):
     """Signatures a stream may compile before widths widen onto the grid.
 
     Staging precedes admission, so the batch introducing the signature past
@@ -264,10 +277,18 @@ def stream_exact_ceiling(grid, cap):
     unguarded run would when this returns a positive allowance.
     """
     cap = int(cap)
+    phases = max(1, operator.index(phases_per_endpoint))
     ceiling = min(SMALL_EXACT_SIGNATURE_THRESHOLD, cap // 4)
     endpoints = grid.endpoint_count
     if endpoints is not None:
-        ceiling = min(ceiling, cap - endpoints)
+        # Every endpoint costs one signature per phase, so reserving one slot
+        # each would let the allowance push a grid that fits over the cap. Two
+        # slots go beyond the allowance's own value: the crossing batch, since
+        # the allowance holds while the count is at or below it, and whatever a
+        # prefetch producer already staged before the consumer saw the release.
+        ceiling = min(
+        ceiling, cap - endpoints * phases - 1 - max(0, operator.index(in_flight)),
+    )
     return ceiling if ceiling > 0 else None
 
 
@@ -999,6 +1020,7 @@ __all__ = (
     "StreamShapeGuardReport",
     "describe_stream_shape_grid",
     "stream_exact_ceiling",
+    "stream_phase_count",
     "TextShapeEvent",
     "TextShapeFrontier",
     "TextShapeGuardReport",

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -552,9 +552,14 @@ from .shape_guard import (
     AUTOMATIC_TEXT_COMPILE_CEILING,
     DDP_LOCAL_GRAD_SCOPE,
     FULL_STEP_SCOPE,
+    STREAM_GRID_FLOOR_WIDTH,
+    STREAM_GRID_RATIO,
+    StreamShapeGrid,
+    StreamShapeGuardReport,
     TextShapeEvent,
     TextShapeGuardReport,
     build_text_shape_frontier,
+    describe_stream_shape_grid,
     materialize_text_shape_frontier,
     phase_for_microstep,
     plan_text_shape_buckets,
@@ -1382,6 +1387,101 @@ def _effective_compile_mode(compile_policy, compile_decision):
     """
     mode = getattr(compile_decision, "policy_mode", None)
     return mode if mode else compile_policy.mode
+
+
+class _StreamWidthPolicy:
+    """Grid width policy a streaming producer consults for every batch.
+
+    Handed over disarmed (returns None, so staging keeps its own rule) because
+    staging is wired before the compile decision resolves; the trainer arms
+    this same object later, which also reaches a running prefetch thread.
+    """
+
+    __slots__ = ("grid", "armed")
+
+    def __init__(self, grid):
+        self.grid = grid
+        self.armed = False
+
+    def __call__(self, width):
+        return self.grid.endpoint_for(width) if self.armed else None
+
+
+def _stream_execution_key():
+    """The default device/stream pair the next compiled call will key on.
+
+    A runtime not exposing these has no compile cache to bound, so an
+    unreadable pair collapses to one constant rather than failing the step.
+    """
+    try:
+        device = mx.default_device()
+        return (str(device), str(mx.default_stream(device)))
+    except (AttributeError, NotImplementedError):
+        return ("default", "default")
+
+
+def _stream_batch_signature(batch_data, phase, execution_key):
+    """Conservative key for one compiled call on a streamed batch.
+
+    Covers each argument leaf's shape and dtype, the accumulation phase, and
+    the default device/stream pair, which a step callback may legally change
+    mid-run. Finer than the true key is safe: the guard can only degrade
+    early, never late.
+    """
+    leaves = []
+    values = batch_data if isinstance(batch_data, (tuple, list)) else (batch_data,)
+    for value in values:
+        shape = getattr(value, "shape", None)
+        if shape is None:
+            leaves.append(repr(type(value)))
+        else:
+            leaves.append((tuple(int(extent) for extent in shape), str(value.dtype)))
+    return (phase, tuple(leaves), execution_key)
+
+
+class _StreamSignatureRegistry:
+    """Compiled signatures one streaming run has already paid for.
+
+    An unsized stream has no plan to cap, so the cap binds on what was
+    actually compiled. Scoped to one compiled callable, like the cache it
+    stands in for.
+    """
+
+    __slots__ = ("cap", "observed", "tripped", "trip_reason")
+
+    def __init__(self, cap):
+        self.cap = int(cap)
+        self.observed = set()
+        self.tripped = False
+        self.trip_reason = ""
+
+    def would_trip(self, key):
+        return key not in self.observed and len(self.observed) >= self.cap
+
+    def record(self, key):
+        self.observed.add(key)
+
+    def trip(self, reason):
+        self.tripped = True
+        self.trip_reason = reason
+
+
+def _stream_guard_report(policy, registry, compile_scope):
+    """Final streaming-guard telemetry, built once the counts are settled."""
+    grid = policy.grid
+    return StreamShapeGuardReport(
+        action="stream_grid",
+        reason="streaming",
+        cap=registry.cap,
+        compile_scope=compile_scope,
+        grid_ratio=str(STREAM_GRID_RATIO),
+        grid_floor=STREAM_GRID_FLOOR_WIDTH,
+        grid_anchor=grid.anchor,
+        grid_endpoints=grid.endpoint_count,
+        observed_signatures=len(registry.observed),
+        tripped=registry.tripped,
+        trip_reason=registry.trip_reason,
+    )
 
 
 def _plan_single_process_vlm_shapes(
@@ -2384,6 +2484,49 @@ class MLXTrainer:
             context,
             exc,
         )
+
+    def _admit_stream_batch(self, registry, batch_data, compile_scope,
+                            grad_accum, microstep, world_size):
+        """Decide whether one streamed batch may take the compiled path.
+
+        ``batch_data`` is None for a microstep not reaching a compiled call; it
+        still participates so the collective schedule stays fixed. Returns True
+        to hand the run over to the eager step, ``"eager_batch"`` for this
+        batch alone.
+
+        Exactly one reduction per fetch: an all-max where 2 (a rank failed)
+        dominates 1 (would trip) dominates 0. Consensus before acting keeps the
+        world uniform — a rank tripping alone would leave peers compiled, and
+        the runtime-fallback protocol reruns a step on every rank, which an
+        already-eager rank cannot repeat without drawing again from its RNG.
+        """
+        key = None
+        error = None
+        try:
+            if batch_data is not None:
+                key = _stream_batch_signature(
+                    batch_data,
+                    phase_for_microstep(compile_scope, grad_accum, microstep),
+                    _stream_execution_key(),
+                )
+        except BaseException as exc:
+            error = exc
+        signal = 2 if error is not None else (
+            1 if key is not None and registry.would_trip(key) else 0
+        )
+        if world_size > 1:
+            signal = self._distributed_max_int(signal)
+            if signal >= 2:
+                self._raise_distributed_failure_from_any(
+                    True, "admitting a streaming batch shape", error,
+                )
+        elif error is not None:
+            raise error
+        if signal == 1:
+            return True
+        if key is not None:
+            registry.record(key)
+        return False
 
     def _distributed_sum_gradient_tree(self, grad):
         """All-sum a gradient tree while preserving MLX's grouped all-reduce."""
@@ -5217,6 +5360,51 @@ class MLXTrainer:
             f"shape_guard:{_compile_shape_guard_report.reason}"
             if _shape_guard_eager else None
         )
+        _stream_policy = getattr(self, "_mlx_stream_width_policy", None)
+        _stream_registry = None
+        _stream_scope = "none"
+        _stream_capture_stable = True
+        if (
+            _stream_policy is not None
+            and batch_iter is not None
+            and _use_compile
+            and not _ddp_compile_local_grad
+        ):
+            # The full-step callable captures optimizer.state, and MLX
+            # optimizers build per-parameter state lazily at the first update —
+            # two cache entries for one signature. Initialize before compile
+            # setup consumes this list, then refresh the captured entry, which
+            # an initializer may have replaced rather than filled.
+            try:
+                optimizer.init(model.trainable_parameters())
+                state[1] = optimizer.state
+            except Exception as _init_error:
+                # Refresh here too: the initializer may have replaced the
+                # container before raising, and the eager steps below must not
+                # read the pre-initialization object.
+                state[1] = optimizer.state
+                # Captured state that changes later makes one batch signature
+                # several cache entries, and nothing bounds how often an
+                # unknown optimizer reshapes it — so no signature count can
+                # bound the cache. Compilation stops instead: an eager stream
+                # compiles nothing, closing the failure outright.
+                _stream_capture_stable = False
+                if _effective_compile_mode(
+                    compile_policy, _compile_decision,
+                ) == "strict":
+                    raise RuntimeError(
+                        "Unsloth: strict mx.compile cannot bound compiled "
+                        "shapes for a streaming source with this optimizer, "
+                        "because its captured state cannot be initialized "
+                        f"before the first compiled step ({_init_error})."
+                    ) from _init_error
+                _main_print(
+                    "Unsloth: compiling disabled for this streaming run — "
+                    "this optimizer's captured state cannot be initialized "
+                    "up front, so compiled shapes could not be bounded."
+                )
+                _use_compile = False
+                _compile_fallback_reason = "stream_capture_unstable"
         _compile_state = state
         class _DDPCompiledLocalGradError(RuntimeError):
             """Marks failures from the compiled DDP local-gradient graph."""
@@ -6346,6 +6534,26 @@ class MLXTrainer:
             _run_callback_epoch_begin(
                 float(microstep // epoch_event_microbatches)
             )
+        if (
+            _stream_policy is not None
+            and batch_iter is not None
+            and _use_compile
+            and _stream_capture_stable
+            and _compile_scope in (FULL_STEP_SCOPE, DDP_LOCAL_GRAD_SCOPE)
+        ):
+            # Armed only now: compile setup can still fall back to eager, and
+            # arming earlier would grid-pad that run, add a collective it does
+            # not need, and report a plan that never existed.
+            _stream_policy.armed = True
+            _stream_registry = _StreamSignatureRegistry(
+                resolve_compile_max_variants(args.compile_max_variants),
+            )
+            # A later fallback rewrites _compile_scope, which would make the
+            # report describe a callable that compiled none of these.
+            _stream_scope = _compile_scope
+            _main_print(describe_stream_shape_grid(
+                _stream_policy.grid, _stream_registry.cap,
+            ))
         while self._global_step < total_steps:
             it = microstep + 1
             if self._distributed_should_stop() or self._early_stopped:
@@ -6415,6 +6623,52 @@ class MLXTrainer:
                 )
             elif batch_error is not None:
                 raise batch_error
+
+            if _stream_registry is not None:
+                _stream_trip = self._admit_stream_batch(
+                    _stream_registry,
+                    batch_data if _use_compile and _compile_scope in (
+                        FULL_STEP_SCOPE, DDP_LOCAL_GRAD_SCOPE,
+                    ) else None,
+                    _compile_scope,
+                    grad_accum,
+                    it - 1,
+                    distributed_world_size,
+                )
+                if _stream_trip:
+                    if _effective_compile_mode(
+                        compile_policy, _compile_decision,
+                    ) == "strict":
+                        # Every rank saw the same reduced signal, so all ranks
+                        # raise together here.
+                        raise RuntimeError(
+                            "Unsloth: strict mx.compile exceeded the "
+                            f"{_stream_registry.cap}-signature cap on a "
+                            "streaming source "
+                            f"({len(_stream_registry.observed)} compiled). "
+                            "Raise compile_max_variants or use a source with "
+                            "fewer distinct batch shapes."
+                        )
+                    _main_print(
+                        "Unsloth: streaming compile shapes reached the "
+                        f"{_stream_registry.cap}-signature cap "
+                        f"({len(_stream_registry.observed)} compiled); "
+                        "continuing eagerly. Raise or lower "
+                        "compile_max_variants to change this bound."
+                    )
+                    _stream_registry.trip("signature_cap")
+                    # The runtime compile fallback's handover, so DDP
+                    # local-grad restores its own eager step. The batch in hand
+                    # is reused: re-fetching would consume the source.
+                    if _ddp_compile_local_grad:
+                        step_fn = _ddp_eager_local_step_fn
+                        _ddp_compile_local_grad = False
+                    else:
+                        step_fn = _uncompiled_step_fn
+                    _use_compile = False
+                    _compile_scope = "fallback_eager"
+                    _compile_fallback_reason = "stream_signature_cap"
+                    state = [model.state, optimizer.state, mx.random.state]
 
             do_update = (accum_progress + 1 >= grad_accum)
             # HF forces a sync step on an epoch's last micro-batch, so the epoch is
@@ -6979,7 +7233,13 @@ class MLXTrainer:
                 _compile_decision.policy_mode if _compile_decision is not None else compile_policy.mode
             ),
             "compile_scope": _compile_scope,
-            "compile_shape_guard": _compile_shape_guard_report.to_dict(),
+            "compile_shape_guard": (
+                _stream_guard_report(
+                    _stream_policy, _stream_registry, _stream_scope,
+                ).to_dict()
+                if _stream_registry is not None
+                else _compile_shape_guard_report.to_dict()
+            ),
             "patch_mode": getattr(self.args, "patch_mode", "patched"),
             "compile_trace": (
                 asdict(self._compile_trace)
@@ -7293,6 +7553,20 @@ class MLXTrainer:
                     int(getattr(self, "_mlx_resume_step_for_prefetch", 0))
                     * args.gradient_accumulation_steps
                 )
+                # Disarmed: whether this run compiles is unresolved, and the
+                # grid must not touch widths unless the guard takes effect.
+                self._mlx_stream_width_policy = (
+                    _StreamWidthPolicy(
+                        StreamShapeGrid(anchor=int(args.max_seq_length)),
+                    )
+                    if (
+                        # Only the unsized-source branch consults the policy; a
+                        # map-style run keeps its own widths.
+                        _is_mlx_lazy_text_source(train_dataset)
+                        and int(args.max_seq_length) >= STREAM_GRID_FLOOR_WIDTH
+                    )
+                    else None
+                )
                 return None, iterate_training_batches(
                     dataset=train_dataset,
                     tokenizer=self.tokenizer,
@@ -7317,6 +7591,7 @@ class MLXTrainer:
                             args, "streaming_text_length_window_batches", 8,
                         )
                     ),
+                    width_policy=self._mlx_stream_width_policy,
                     prefetch_batches=prefetch_depth,
                     prefetch_skip_batches=resume_skip if prefetch_depth else 0,
                     prefetch_control=self._mlx_prefetch_control,

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -602,6 +602,7 @@ from .shape_guard import (
     build_text_shape_frontier,
     describe_stream_shape_grid,
     stream_exact_ceiling,
+    stream_phase_count,
     materialize_text_shape_frontier,
     phase_for_microstep,
     plan_text_shape_buckets,
@@ -1457,11 +1458,19 @@ class _StreamWidthPolicy:
         self.observed = None
         self.gate_released = False
 
-    def arm(self, registry):
+    def arm(self, registry, phases_per_endpoint=1, in_flight=0):
         """Arm against the set the cap binds on, so the exact allowance and
-        the bound it protects are counted in the same units."""
+        the bound it protects are counted in the same units.
+
+        ``phases_per_endpoint`` is how many compiled signatures one width
+        costs, which gradient accumulation raises above one. ``in_flight`` is
+        how many batches a prefetch producer may have staged exact before the
+        consumer reaches the release.
+        """
         self.observed = registry.observed
-        self.exact_ceiling = stream_exact_ceiling(self.grid, registry.cap)
+        self.exact_ceiling = stream_exact_ceiling(
+            self.grid, registry.cap, phases_per_endpoint, in_flight,
+        )
         self.armed = True
 
     @property
@@ -6804,7 +6813,16 @@ class MLXTrainer:
             _stream_registry = _StreamSignatureRegistry(
                 resolve_compile_max_variants(args.compile_max_variants),
             )
-            _stream_policy.arm(_stream_registry)
+            _stream_policy.arm(
+                _stream_registry,
+                stream_phase_count(_compile_scope, grad_accum),
+                # Effective, not configured: DDP and non-lazy sources turn
+                # prefetch off, and reserving for a producer that will never
+                # run costs the allowance for nothing.
+                getattr(args, "streaming_prefetch_batches", 0)
+                if (getattr(self, "_mlx_prefetch_control", None)
+                    and self._mlx_prefetch_control.get("eligible")) else 0,
+            )
             # A later fallback rewrites _compile_scope, which would make the
             # report describe a callable that compiled none of these.
             _stream_scope = _compile_scope

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1441,9 +1441,11 @@ class _StreamWidthPolicy:
 
     An armed policy still declines while the run has compiled no more than
     ``exact_ceiling`` signatures, so a stream whose diversity never justifies
-    a grid pays no padding. Declining is per batch rather than a disarm
-    because the prefetch seams pick their finalizer once from ``armed``: a
-    policy armed later than that would never widen at all.
+    a grid pays no padding. Declining is per batch rather than a disarm so
+    that nothing has to be re-decided when it changes: every seam reads this
+    object when it stages, including the prefetch finalizers, which select on
+    the policy's presence rather than on ``armed`` precisely because their
+    generator body runs before arming.
     """
 
     __slots__ = ("grid", "armed", "exact_ceiling", "observed", "gate_released")

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -561,6 +561,7 @@ from .shape_guard import (
     TextShapeGuardReport,
     build_text_shape_frontier,
     describe_stream_shape_grid,
+    stream_exact_ceiling,
     materialize_text_shape_frontier,
     phase_for_microstep,
     plan_text_shape_buckets,
@@ -1396,16 +1397,46 @@ class _StreamWidthPolicy:
     Handed over disarmed (returns None, so staging keeps its own rule) because
     staging is wired before the compile decision resolves; the trainer arms
     this same object later, which also reaches a running prefetch thread.
+
+    An armed policy still declines while the run has compiled no more than
+    ``exact_ceiling`` signatures, so a stream whose diversity never justifies
+    a grid pays no padding. Declining is per batch rather than a disarm
+    because the prefetch seams pick their finalizer once from ``armed``: a
+    policy armed later than that would never widen at all.
     """
 
-    __slots__ = ("grid", "armed")
+    __slots__ = ("grid", "armed", "exact_ceiling", "observed", "gate_released")
 
     def __init__(self, grid):
         self.grid = grid
         self.armed = False
+        self.exact_ceiling = None
+        self.observed = None
+        self.gate_released = False
+
+    def arm(self, registry):
+        """Arm against the set the cap binds on, so the exact allowance and
+        the bound it protects are counted in the same units."""
+        self.observed = registry.observed
+        self.exact_ceiling = stream_exact_ceiling(self.grid, registry.cap)
+        self.armed = True
+
+    @property
+    def holding(self):
+        """True while the exact allowance still applies. Lets a caller skip
+        work whose only purpose is choosing an endpoint."""
+        return (
+            self.armed
+            and self.exact_ceiling is not None
+            and self.observed is not None
+            and len(self.observed) <= self.exact_ceiling
+        )
 
     def __call__(self, width):
-        return self.grid.endpoint_for(width) if self.armed else None
+        if not self.armed or self.holding:
+            return None
+        self.gate_released = True
+        return self.grid.endpoint_for(width)
 
 
 def _stream_execution_key():
@@ -1486,7 +1517,11 @@ def _stream_guard_report(policy, registry, compile_scope):
     """Final streaming-guard telemetry, built once the counts are settled."""
     grid = policy.grid
     return StreamShapeGuardReport(
-        action="stream_grid",
+        # A run whose policy never released its exact allowance must not
+        # report a grid action. Tracks the policy's own transition, not
+        # per-batch outcomes: a released policy may still hand back an
+        # endpoint equal to the width it was given.
+        action="stream_grid" if policy.gate_released else "stream_exact",
         reason="streaming",
         cap=registry.cap,
         compile_scope=compile_scope,
@@ -1497,6 +1532,8 @@ def _stream_guard_report(policy, registry, compile_scope):
         observed_signatures=len(registry.observed),
         tripped=registry.tripped,
         trip_reason=registry.trip_reason,
+        exact_ceiling=policy.exact_ceiling,
+        gate_released=policy.gate_released,
     )
 
 
@@ -6570,15 +6607,16 @@ class MLXTrainer:
             # Armed only now: compile setup can still fall back to eager, and
             # arming earlier would grid-pad that run, add a collective it does
             # not need, and report a plan that never existed.
-            _stream_policy.armed = True
             _stream_registry = _StreamSignatureRegistry(
                 resolve_compile_max_variants(args.compile_max_variants),
             )
+            _stream_policy.arm(_stream_registry)
             # A later fallback rewrites _compile_scope, which would make the
             # report describe a callable that compiled none of these.
             _stream_scope = _compile_scope
             _main_print(describe_stream_shape_grid(
                 _stream_policy.grid, _stream_registry.cap,
+                _stream_policy.exact_ceiling,
             ))
         while self._global_step < total_steps:
             it = microstep + 1

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -6469,6 +6469,8 @@ class MLXTrainer:
                 _compile_scope = "fallback_eager"
                 _compile_fallback_reason = "runtime_error"
                 _ddp_compile_local_grad = False
+                if _stream_policy is not None:
+                    _stream_policy.armed = False
                 if isinstance(batches, _EAGER_REFETCHABLE_PLAN_TYPES):
                     batch_data = batches[scheduled_index]
                 state = [model.state, optimizer.state, mx.random.state]
@@ -6749,6 +6751,9 @@ class MLXTrainer:
                     _use_compile = False
                     _compile_scope = "fallback_eager"
                     _compile_fallback_reason = "stream_signature_cap"
+                    # Nothing compiled will consume a grid width again, so the
+                    # eager tail should not keep paying to pad onto one.
+                    _stream_policy.armed = False
                     state = [model.state, optimizer.state, mx.random.state]
 
             _step_fn_for_batch = step_fn
@@ -6836,6 +6841,8 @@ class MLXTrainer:
                         _use_compile = False
                         _compile_scope = "fallback_eager"
                         _compile_fallback_reason = "runtime_error"
+                        if _stream_policy is not None:
+                            _stream_policy.armed = False
                         if isinstance(batches, _EAGER_REFETCHABLE_PLAN_TYPES):
                             batch_data = batches[scheduled_index]
                         if rng_state_before is not None:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -5627,7 +5627,9 @@ class MLXTrainer:
             # optimizers build per-parameter state lazily at the first update —
             # two cache entries for one signature. Initialize before compile
             # setup consumes this list, then refresh the captured entry, which
-            # an initializer may have replaced rather than filled.
+            # an initializer may have replaced rather than filled. Safe over a
+            # resumed checkpoint: MLX initializes only per-parameter state that
+            # is still empty, so restored moments and step count survive.
             try:
                 optimizer.init(model.trainable_parameters())
                 state[1] = optimizer.state

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -509,6 +509,7 @@ from .utils import (
     create_vlm_batches,
     _create_vlm_batch_plan,
     _finite_text_pad_width,
+    _vlm_batch_family,
     _vlm_family_is_plannable,
     FiniteVLMBatchPlan,
     _preserved_preprocessing_rng,
@@ -1428,6 +1429,16 @@ def _stream_batch_signature(batch_data, phase, execution_key):
     mid-run. Finer than the true key is safe: the guard can only degrade
     early, never late.
     """
+    if isinstance(batch_data, dict):
+        # A family the serializer cannot certify may span several real cache
+        # keys, so it is reported rather than recorded: counting it as one
+        # would understate the cache and make the cap unsound.
+        family = _vlm_batch_family(batch_data)
+        if not _vlm_family_is_plannable(family):
+            # None means uncertifiable; the family rides along so a strict
+            # refusal can name what it refused.
+            return None, family
+        return (phase, family, execution_key)
     leaves = []
     values = batch_data if isinstance(batch_data, (tuple, list)) else (batch_data,)
     for value in values:
@@ -1447,13 +1458,18 @@ class _StreamSignatureRegistry:
     stands in for.
     """
 
-    __slots__ = ("cap", "observed", "tripped", "trip_reason")
+    __slots__ = (
+        "cap", "observed", "tripped", "trip_reason", "uncertified",
+        "uncertified_family",
+    )
 
     def __init__(self, cap):
         self.cap = int(cap)
         self.observed = set()
         self.tripped = False
         self.trip_reason = ""
+        self.uncertified = 0
+        self.uncertified_family = ""
 
     def would_trip(self, key):
         return key not in self.observed and len(self.observed) >= self.cap
@@ -2501,6 +2517,7 @@ class MLXTrainer:
         already-eager rank cannot repeat without drawing again from its RNG.
         """
         key = None
+        uncertifiable = False
         error = None
         try:
             if batch_data is not None:
@@ -2509,6 +2526,10 @@ class MLXTrainer:
                     phase_for_microstep(compile_scope, grad_accum, microstep),
                     _stream_execution_key(),
                 )
+                if isinstance(key, tuple) and key and key[0] is None:
+                    registry.uncertified_family = repr(key[1])
+                    key = None
+                uncertifiable = key is None
         except BaseException as exc:
             error = exc
         signal = 2 if error is not None else (
@@ -2526,6 +2547,11 @@ class MLXTrainer:
             return True
         if key is not None:
             registry.record(key)
+        elif uncertifiable:
+            # Neither compiled nor counted, so an uncertifiable family
+            # cannot spend capacity certified ones need.
+            registry.uncertified += 1
+            return "eager_batch"
         return False
 
     def _distributed_sum_gradient_tree(self, grad):
@@ -6580,6 +6606,7 @@ class MLXTrainer:
             # Get next batch
             batch_error = None
             batch_data = None
+            _stream_eager_batch = False
             try:
                 if batch_iter is not None:
                     batch_data = next(batch_iter)
@@ -6635,6 +6662,22 @@ class MLXTrainer:
                     it - 1,
                     distributed_world_size,
                 )
+                if _stream_trip == "eager_batch":
+                    # Uncertifiable family: eager for this batch, compiled
+                    # again next fetch.
+                    if _effective_compile_mode(
+                        compile_policy, _compile_decision,
+                    ) == "strict":
+                        raise RuntimeError(
+                            "Unsloth: strict mx.compile cannot certify a "
+                            "streamed batch's compile-key family, so its "
+                            "compiled shapes could not be bounded: "
+                            f"{_stream_registry.uncertified_family}"
+                        )
+                    _stream_eager_batch = True
+                    _stream_trip = False
+                else:
+                    _stream_eager_batch = False
                 if _stream_trip:
                     if _effective_compile_mode(
                         compile_policy, _compile_decision,
@@ -6669,6 +6712,15 @@ class MLXTrainer:
                     _compile_scope = "fallback_eager"
                     _compile_fallback_reason = "stream_signature_cap"
                     state = [model.state, optimizer.state, mx.random.state]
+
+            _step_fn_for_batch = step_fn
+            if _stream_eager_batch:
+                # Only a VLM mapping is uncertifiable and unsized VLM streams
+                # are refused under DDP, so this is single-process today.
+                _step_fn_for_batch = (
+                    _ddp_eager_local_step_fn if _ddp_compile_local_grad
+                    else _uncompiled_step_fn
+                )
 
             do_update = (accum_progress + 1 >= grad_accum)
             # HF forces a sync step on an epoch's last micro-batch, so the epoch is
@@ -6722,12 +6774,16 @@ class MLXTrainer:
                         _rng_state[0].tolist(), dtype=mx.uint32,
                     )
                 try:
-                    lvalue, toks, grad_accum_state, grad_norm = step_fn(
+                    lvalue, toks, grad_accum_state, grad_norm = _step_fn_for_batch(
                         batch_data, grad_accum_state, do_update,
                     )
                 except (ValueError, RuntimeError, TypeError) as e:
                     _is_compile_failure = (
                         _use_compile
+                        # Bypassed the compiled callable, so this is not a
+                        # compile failure: classifying it as one would rerun
+                        # the batch and degrade the whole run.
+                        and not _stream_eager_batch
                         and not _ddp_compile_local_grad
                         and _is_compile_exception(e)
                     )
@@ -7410,6 +7466,12 @@ class MLXTrainer:
                     int(getattr(self, "_mlx_resume_step_for_prefetch", 0))
                     * args.gradient_accumulation_steps
                 )
+                # Anchor-free: expansion decides the compile-visible width and
+                # exceeds max_seq_length, so an endpoint below a batch's own
+                # width could never materialize.
+                self._mlx_stream_width_policy = (
+                    _StreamWidthPolicy(StreamShapeGrid()) if vlm_lazy else None
+                )
                 return None, iterate_vlm_training_batches(
                     dataset=train_dataset,
                     processor=processor,
@@ -7431,6 +7493,7 @@ class MLXTrainer:
                         if vlm_prefetch_depth and vlm_lazy else 0
                     ),
                     prefetch_control=self._mlx_prefetch_control,
+                    width_policy=self._mlx_stream_width_policy,
                 )
             else:
                 self._prepared_batches_include_epochs = vlm_num_epochs is not None

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -10189,11 +10189,15 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                 skip_batches=prefetch_skip_batches,
                 # The prefetch path's terminal width point. Safe to widen
                 # here: response-masked streams are rejected at iterator entry,
-                # so no mask can follow.
+                # so no mask can follow. Chosen on the policy's presence and
+                # never on ``armed``: this generator body runs at the first
+                # advance, which the audio peek performs before the policy is
+                # armed, so latching on ``armed`` would pin the plain finalizer
+                # and the stream would never widen. Widening is identity while
+                # the policy declines, so deciding per call is safe.
                 finalize=(
                     _finalize_vlm_batch
                     if width_policy is None
-                    or not getattr(width_policy, "armed", True)
                     else lambda staged, policy=width_policy: (
                         _widen_finalized_vlm_batch(
                             _finalize_vlm_batch(staged, phase="content"),

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6079,6 +6079,7 @@ def _build_response_masked_vlm_batch(
     yield_host_staged=False,
     reject_mlx_valued=False,
     target_width=None,
+    width_policy=None,
 ):
     """Collate VLM rows and apply the CUDA response-mask closure.
 
@@ -6091,6 +6092,10 @@ def _build_response_masked_vlm_batch(
     at the width seam: the finalizer stops after its content phase, the pad lands
     after expansion and response masking so padded tails stay inert, and the
     position phase then runs at the final width.
+
+    ``width_policy`` is the streaming form: a stream has no surveyed endpoint,
+    and expansion decides the compile-visible width, so the endpoint is chosen
+    from that width here. Returning None leaves the batch unpadded.
     """
     staged, is_prompt_completion = _collate_vlm_batch(
         items, processor, max_seq_length, image_size,
@@ -6103,15 +6108,29 @@ def _build_response_masked_vlm_batch(
     staged.config = config
     # Unplanned batches keep the historical single-pass order, including its
     # failure ordering (a broken batch raises before the response-mask callback).
-    phase = None if target_width is None else "content"
+    # Splitting finalization defers the positions phase to the width seam, so
+    # a policy not in force must not split it.
+    widening = target_width is not None or (
+        width_policy is not None and getattr(width_policy, "armed", True)
+    )
+    phase = "content" if widening else None
 
     def _seal(batch_dict):
-        """Width seam: pad to the planned endpoint, then record positions."""
-        if target_width is None:
-            return batch_dict
+        """Width seam: pad to the chosen endpoint, then record positions."""
+        target = target_width
+        if target is None and widening and width_policy is not None:
+            # The compile-visible width exists only now, after expansion.
+            target = _resolve_stream_vlm_target(
+                batch_dict, config, processor, width_policy,
+            )
+        if target is None:
+            # Exact width is still a compiled signature.
+            return _prepare_vlm_batch_for_compile(
+                batch_dict, config, phase="positions",
+            ) if widening else batch_dict
         tokenizer = getattr(processor, "tokenizer", processor)
         batch_dict = _finalize_vlm_batch_width(
-            batch_dict, target_width,
+            batch_dict, target,
             getattr(tokenizer, "pad_token_id", None),
             disposable_keys=_vlm_pipeline_disposable_keys(config),
         )
@@ -7609,13 +7628,71 @@ def _vlm_has_sized_index_space(dataset):
     return True
 
 
+def _resolve_stream_vlm_target(batch_dict, config, processor, width_policy):
+    """Endpoint for a streamed VLM batch, or None to keep its exact width.
+
+    Widening is refused rather than attempted when it could not materialize:
+    no pad id to fill with, a batch the survey cannot prove right-paddable, or
+    an endpoint an untouched array already occupies. Such a batch still
+    compiles at its own width, which keeps it inside the cap.
+    """
+    ids = batch_dict.get("input_ids")
+    shape = getattr(ids, "shape", None)
+    if shape is None or len(shape) < 2:
+        return None
+    tokenizer = getattr(processor, "tokenizer", processor)
+    if getattr(tokenizer, "pad_token_id", None) is None:
+        return None
+    width, _axes, padable, forbidden = _vlm_width_survey(
+        batch_dict, disposable_keys=_vlm_pipeline_disposable_keys(config),
+    )
+    if not padable or width is None:
+        return None
+    target = width_policy(int(width))
+    # Bump past extents an untouched array occupies; the grid is strictly
+    # increasing, so this terminates on that batch's finite set.
+    seen = 0
+    while target is not None and target in forbidden and seen <= len(forbidden):
+        target = width_policy(int(target) + 1)
+        seen += 1
+    if target is None or target in forbidden:
+        return None
+    return None if int(target) <= int(width) else int(target)
+
+
+def _widen_finalized_vlm_batch(batch_dict, config, processor, width_policy):
+    """Widen a finalized VLM batch onto the grid, then set positions.
+
+    The prefetch path's terminal width point; the synchronous path reaches the
+    same policy through the builder's width seam, after response masking.
+    Producer-staged streams have no mask to order against — they are rejected
+    at iterator entry.
+    """
+    target = _resolve_stream_vlm_target(
+        batch_dict, config, processor, width_policy,
+    )
+    if target is None:
+        return _prepare_vlm_batch_for_compile(
+            batch_dict, config, phase="positions",
+        )
+    tokenizer = getattr(processor, "tokenizer", processor)
+    batch_dict = _finalize_vlm_batch_width(
+        batch_dict, target,
+        getattr(tokenizer, "pad_token_id", None),
+        disposable_keys=_vlm_pipeline_disposable_keys(config),
+    )
+    return _prepare_vlm_batch_for_compile(
+        batch_dict, config, phase="positions",
+    )
+
+
 def _iterate_lazy_vlm_training_batches(
     dataset, processor, config, batch_size, max_seq_length, *,
     response_mask_fn=None, formatting_func=None, dataset_order="default",
     completion_only_loss=None, image_size=None, comm_group=None,
     require_replayable=False, expected_rows_per_pass=None,
     ignore_token_ids=None, yield_host_staged=False, reject_mlx_valued=False,
-    should_stop=None,
+    should_stop=None, width_policy=None,
 ):
     """Unsized VLM batches under the lazy text-stream lifecycle contracts.
 
@@ -7656,6 +7733,9 @@ def _iterate_lazy_vlm_training_batches(
             completion_only_loss=completion_only_loss,
             yield_host_staged=yield_host_staged,
             reject_mlx_valued=reject_mlx_valued,
+            # The synchronous path widens here, after expansion and masking;
+            # producer-staged batches widen in the prefetcher's finalize.
+            width_policy=None if yield_host_staged else width_policy,
         )
 
     def _filter_stream_item(item):
@@ -7849,7 +7929,8 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                                   expected_rows_per_pass=None,
                                   prefetch_batches=0,
                                   prefetch_skip_batches=0,
-                                  prefetch_control=None):
+                                  prefetch_control=None,
+                                  width_policy=None):
     """Streaming VLM batch generator using processor directly. Yields batch
     dicts with input_ids, pixel_values, attention_mask, and optionally labels."""
     import numpy as np
@@ -7964,7 +8045,20 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
                 None,
                 prefetch_depth,
                 skip_batches=prefetch_skip_batches,
-                finalize=_finalize_vlm_batch,
+                # The prefetch path's terminal width point. Safe to widen
+                # here: response-masked streams are rejected at iterator entry,
+                # so no mask can follow.
+                finalize=(
+                    _finalize_vlm_batch
+                    if width_policy is None
+                    or not getattr(width_policy, "armed", True)
+                    else lambda staged, policy=width_policy: (
+                        _widen_finalized_vlm_batch(
+                            _finalize_vlm_batch(staged, phase="content"),
+                            staged.config, processor, policy,
+                        )
+                    )
+                ),
             )
             prefetcher._make_iterator = (
                 lambda pf=prefetcher: _iterate_lazy_vlm_training_batches(
@@ -8001,6 +8095,7 @@ def iterate_vlm_training_batches(dataset, processor, config, batch_size,
             require_replayable=require_replayable,
             expected_rows_per_pass=expected_rows_per_pass,
             ignore_token_ids=ignore_token_ids,
+            width_policy=width_policy,
         )
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -7643,6 +7643,10 @@ def _resolve_stream_vlm_target(batch_dict, config, processor, width_policy):
     tokenizer = getattr(processor, "tokenizer", processor)
     if getattr(tokenizer, "pad_token_id", None) is None:
         return None
+    # The survey exists only to pick an endpoint; skip it while the policy is
+    # not choosing one.
+    if getattr(width_policy, "holding", False):
+        return None
     width, _axes, padable, forbidden = _vlm_width_survey(
         batch_dict, disposable_keys=_vlm_pipeline_disposable_keys(config),
     )

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -4631,8 +4631,12 @@ def _stage_tokenized_text_batch(
     pad_id=0,
     labels_expected=None,
     host_valued=None,
+    width_policy=None,
 ):
     """Host staging of one pretokenized text batch (no MLX work).
+
+    ``width_policy`` maps this batch's width to the width it is staged at;
+    ``None`` keeps the exact batch maximum, as unguarded runs do.
 
     ``host_valued=None`` computes the flag from the items; the lazy pipeline
     instead passes the stream-level flag recorded at row normalization, where
@@ -4646,6 +4650,13 @@ def _stage_tokenized_text_batch(
     max_length = max(lengths)
     if max_length == 0:
         max_length = min(2, max_seq_length)
+    if width_policy is not None:
+        # Widen onto the grid so compiled signatures live only at grid
+        # points; true lengths stay in lengths_info, so masking is unaffected.
+        # A policy returning None is not in force.
+        endpoint = width_policy(max_length)
+        if endpoint is not None:
+            max_length = endpoint
     batch_ids = np.full((len(batch_items), max_length), int(pad_id), dtype=np.int32)
     has_labels = (
         valid_items[0][1] is not None
@@ -8332,8 +8343,13 @@ def _make_text_batch_from_items(batch_items, tokenizer, max_seq_length):
     )
 
 
-def _stage_text_batch_from_items(batch_items, tokenizer, max_seq_length, host_valued=True):
-    """Build a text training batch from tokenized items."""
+def _stage_text_batch_from_items(batch_items, tokenizer, max_seq_length,
+                                 host_valued=True, width_policy=None):
+    """Build a text training batch from tokenized items.
+
+    ``width_policy`` replaces the mlx-lm rounding rule; ``None`` keeps it, as
+    unguarded runs do.
+    """
     valid_items = [item for item in batch_items if item is not None]
     with_offsets = bool(
         valid_items
@@ -8365,12 +8381,16 @@ def _stage_text_batch_from_items(batch_items, tokenizer, max_seq_length, host_va
         )
     pad_id = getattr(tokenizer, "pad_token_id", None)
     pad_id = 0 if pad_id is None else int(pad_id)
-    max_length = _finite_text_pad_width(
-        max(lengths),
-        pad_to_multiple=32,
-        minimum_width=2,
-        max_seq_length=max_seq_length,
-    )
+    # The grid replaces the rounding rule (it caps at max_seq_length and
+    # carries its own floor); a policy returning None is not in force.
+    max_length = None if width_policy is None else width_policy(max(lengths))
+    if max_length is None:
+        max_length = _finite_text_pad_width(
+            max(lengths),
+            pad_to_multiple=32,
+            minimum_width=2,
+            max_seq_length=max_seq_length,
+        )
     batch_ids = []
     truncated_lengths = []
     for ids, length in zip(batch, lengths):
@@ -9501,6 +9521,7 @@ def _iterate_lazy_text_training_batches(
     yield_host_staged=False,
     reject_mlx_valued=False,
     should_stop=None,
+    width_policy=None,
 ):
     """Yield text batches without materializing an unsized source.
 
@@ -9578,6 +9599,7 @@ def _iterate_lazy_text_training_batches(
                     tokenizer,
                     max_seq_length,
                     host_valued=state.get("host_valued", True),
+                    width_policy=width_policy,
                 )
             return _stage_tokenized_text_batch(
                 local_items,
@@ -9585,6 +9607,7 @@ def _iterate_lazy_text_training_batches(
                 pad_id=_mlx_text_pad_id(tokenizer),
                 labels_expected=state.get("label_state"),
                 host_valued=state.get("host_valued", True),
+                width_policy=width_policy,
             )
 
         def _yield_value(local_items):
@@ -10202,7 +10225,8 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
                              length_window_batches=1,
                              prefetch_batches=0,
                              prefetch_skip_batches=0,
-                             prefetch_control=None):
+                             prefetch_control=None,
+                             width_policy=None):
     """Streaming batch generator for MLX training.
 
     Map-style datasets retain the existing mlx-lm batching behavior. Unsized
@@ -10238,6 +10262,7 @@ def iterate_training_batches(dataset, tokenizer, batch_size, max_seq_length,
             expected_rows_per_pass=expected_rows_per_pass,
             length_window_batches=length_window_batches,
             window_seed=seed,
+            width_policy=width_policy,
         )
         prefetch_depth = _validate_streaming_prefetch(prefetch_batches)
         if prefetch_depth and _distributed_rank_size(comm_group)[1] == 1:


### PR DESCRIPTION
## Summary

Follow-up to #918 and #940, which bounded compiled `mx.compile` signatures for **finite** text and vision-language training. This PR closes the remaining hole: **unsized streaming sources**, which those PRs deferred because both depended on #927 landing first.

A finite dataset can be surveyed, so its planner knows every shape before compiling anything. A stream cannot. Staging therefore padded each batch to its own width, every novel width became a fresh compiled signature, and nothing bounded the total — the same growth that breaks the Metal 499,000-resource limit and aborts training (unslothai/unsloth#6990), except a stream has no end to grow toward.

Measured on a real model at the shipping default cap: an unguarded streaming run presenting 96 distinct shapes reached **29.5% of the Metal resource limit in 96 steps** (VLM) and 28.5% (text). Those numbers keep climbing for as long as the stream runs.

## What changed

- **A fixed endpoint grid, computed rather than surveyed.** One recurrence carries an exact rational: `x₀ = 2`, `x₁ = 32`, then `x → max(x + 32, x · 21/20)`, publishing `1 + 8·⌈x/8⌉`. The additive branch spans short widths and the geometric one long widths with no hand-placed crossover, and the ratio is solved against the existing 5% padding-work budget. Exact rationals mean every process and every rank derives an identical sequence with zero coordination — which is what makes this usable on a source no one can survey.
- **Text anchors the grid to `max_seq_length`; VLM does not.** Image-token expansion produces widths above `max_seq_length`, so an anchored grid could offer no endpoint at or above a batch's own width. The VLM grid extends on demand instead.
- **The cap binds on what was actually compiled.** With no plan to bound, a registry counts observed signatures and trips at `compile_max_variants`, handing the run to eager (or raising, under strict). One all-max reduction per fetch carries a three-valued signal so DDP ranks trip together without a second collective.
- **Low-diversity streams stay exact.** A stream whose shapes never justify a grid should not pay for one. The width policy declines to name an endpoint while the run has compiled no more than `min(32, cap // 4)` signatures — further clamped by whatever an anchored grid's endpoints leave unclaimed, and disabled when that leaves nothing to spend. `32` is the same threshold the finite path uses for the same reason.

The policy stays armed and only its per-batch answer varies. Disarming instead would be silently ignored: the prefetch seams select their finalizer from `armed` once at construction, so a policy armed later would never widen at all.

## Performance

Apple M3 Max, MLX 0.32.0 / mlx-vlm 0.4.4, 4-bit QLoRA rank 4, CCE, gradient checkpointing, batch 1, `max_seq_length=4096`, default cap, one fresh process per cell. Each distinct shape is presented exactly once, so the baseline traces on every step and amortizes nothing — an upper bound on the throughput benefit, not a typical-workload estimate.

| case | distinct shapes | signatures | peak Metal resources | wall |
|---|---:|---:|---:|---:|
| VLM (Qwen3.5-0.8B) | 24 | 24 → 24 | 41,900 → 39,887 (8.4% → 8.0% of limit) | −5.3% |
| VLM (Qwen3.5-0.8B) | 96 | **96 → 81** | **147,321 → 118,242** (29.5% → 23.7%) | −13.9% |
| text (gemma-4-E2B) | 24 | 24 → 24 | 45,618 → 42,760 (9.1% → 8.6%) | −2.9% |
| text (gemma-4-E2B) | 96 | **96 → 55** | **142,336 → 88,368** (28.5% → 17.7%) | −17.1% |

Trained tokens were identical in every pair; loss differences 0.000–0.045% relative.

Both 24-shape cells report `stream_exact` and never widen — their staged width sequences are **byte-identical** to an unguarded run, so the guard is provably inert where it is not needed. Peak resources at that step count are within run-to-run noise (three repeats of the 24-shape VLM cell spread −4.8% to +20.1%); the 96-shape cells are the load-bearing measurement.

Runtime is one unpaired observation per cell. Repeat runs of identical work on this host differ by ~5–6% systematically and up to 29–55% across positions in a counterbalanced ordering, so treat wall deltas as direction; the signature counts are deterministic.

## Correctness and validation

Compile-miss counts, distinct widths, trained tokens, padding work and max stretch are identical across every repeat. Peak resources track compile **misses**, not distinct widths — a VLM compile key carries image tensor shapes alongside the text width, so quoting the width collapse (96 → 23) as a signature reduction would overstate the effect roughly threefold. The reported figures use misses.

Beyond the repository suite, seam-level validation covers: byte-identity to an unguarded run through both text staging seams while the policy declines, with per-seam controls proving each seam widens once released; the allowance boundary and non-reversion; the disabled-ceiling case; signature multiplicity under gradient accumulation; and the response-masked VLM width seam against a real processor, config and masked batch, where a declining policy holds its width with every entry byte-identical and a released control widens the same batch.

## Notes and follow-ups

- **Padding overhead is regime-dependent.** The grid's 5.04% figure is a property of its geometric branch. Below width ~640 the additive branch reproduces `1 + 32·⌈w/32⌉`, which is exactly what raw-text staging already does — so the grid cannot consolidate raw-text signatures there at all, and short-sequence VLM (widths 91–905 here) measures 6.9–7.2% instead. Max stretch stays ≤1.25x throughout.
- **The grid bounds one axis of a VLM compile key.** Image-geometry variation is bounded by the cap but not compressed by the grid, so VLM consolidates less than text (30% vs 47% of signatures) — the same asymmetry #940 measured on the finite path.
- **DDP gate timing.** Only rank 0 invokes the width policy while every rank keeps its own registry, so a peer can pass its allowance while rank 0 has not and the gate releases late. In best-effort mode that degrades to eager; under strict the cap raises first. Closing it needs an added collective, left as follow-up.
- Prefetch-thread transitions are not covered by an automated case; both producers stage off-thread and the two paths decide at different points (text producer-side, VLM consumer-side after dequeue).

Closes unslothai/unsloth#6990 for streaming sources.
