### PR TITLE
feat(mlx): off-policy knowledge distillation (GKD)

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -103,7 +103,11 @@ jobs:
         # + cache-completeness gate (CPU-pure; collect-only would let it
         # regress silently). test_train_on_responses_list_labels pins the
         # tensor-vs-list labels contract for response masking (stub tokenizer,
-        # no weights). Executing them here keeps fixture/source drift visible.
+        # no weights). test_mlx_gkd_guards pins the tokenizer-compatibility,
+        # config and memory-preflight contracts for distillation; it runs under
+        # the torch shim so it EXECUTES here rather than skipping (the numeric
+        # half needs real MLX and runs on the Apple Silicon job). Executing them
+        # here keeps fixture/source drift visible.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
@@ -112,6 +116,7 @@ jobs:
             tests/test_hf_xet_fallback.py \
             tests/test_get_transformers_model_type_empty.py \
             tests/test_train_on_responses_list_labels.py \
+            tests/test_mlx_gkd_guards.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/tests/test_mlx_gkd_guards.py
+++ b/tests/test_mlx_gkd_guards.py
@@ -16,15 +16,10 @@
 
 """GKD guards: tokenizer compatibility, config validation, memory preflight.
 
-Pure logic and arithmetic, so this runs under the torch shim on Linux CI instead
-of skipping. The numeric behaviour of the divergence lives in
-test_mlx_gkd_loss.py, which needs real MLX and runs on Apple Silicon.
-
-The preflight numbers below are the measured ones from a Qwen2.5-0.5B LoRA
-student with a Qwen2.5-3B teacher (vocab 151936, 2.881 GB resident) on a 16 GB
-machine. They matter because an oversized step does not raise a catchable OOM --
-it aborts with "[METAL] Command buffer execution failed: Impacting
-Interactivity" and wedges the GPU context.
+Pure logic, so this runs under the torch shim on Linux CI instead of skipping.
+The preflight numbers are measured on a Qwen2.5-0.5B student + Qwen2.5-3B teacher
+(vocab 151936, 2.881 GB resident) on a 16 GB machine: an oversized step aborts
+with "[METAL] Command buffer execution failed" and wedges the GPU context.
 """
 
 import pytest
@@ -47,7 +42,6 @@ def _distill():
 
 
 class FakeTokenizer:
-    """Encodes by a per-instance rule so probe agreement can be controlled."""
 
     def __init__(self, offset=0):
         self.offset = offset
@@ -69,11 +63,7 @@ def test_width_mismatch_is_rejected():
 
 
 def test_width_matches_but_ids_differ_is_rejected():
-    """The silent-misalignment case: same vocab size, different encodings.
-
-    A width-only check would let this through and train the student against
-    targets that do not correspond to its own tokens, with no error.
-    """
+    """Same vocab size, different encodings: a width-only check misses this."""
     d = _distill()
     with pytest.raises(ValueError, match="encode text differently"):
         d.assert_tokenizers_compatible(FakeTokenizer(0), FakeTokenizer(1), VOCAB, VOCAB)
@@ -105,28 +95,27 @@ def test_non_positive_temperature_rejected(temperature):
 
 
 def test_on_policy_lmbda_rejected_with_reason():
-    """Off-policy only: on-policy needs generation in the training loop, which
-    the MLX trainer does not have."""
+    """On-policy needs generation in the loop, which the MLX trainer lacks."""
     with pytest.raises(ValueError, match="generation inside the training loop"):
         _distill().validate_gkd_config(0.5, 1.0, 0.5)
 
 
 # --- memory preflight --------------------------------------------------------
 def test_preflight_allows_batch2_seq512():
-    """Measured 10.16 GB on a 16 GB machine -- must not be rejected."""
+    """Measured 10.16 GB on 16 GB: must not be rejected."""
     d = _distill()
     estimate = d.preflight_memory(2, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
     assert estimate < SYSTEM_16GB * d.MEMORY_SAFETY_FRACTION
 
 
 def test_preflight_rejects_batch4_seq512():
-    """Measured 17.16 GB -- over a 16 GB machine, wedges Metal if allowed."""
+    """Measured 17.16 GB: wedges Metal if allowed."""
     with pytest.raises(ValueError, match="does not fit in memory"):
         _distill().preflight_memory(4, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
 
 
 def test_preflight_rejects_batch2_seq1024_unchunked():
-    """Measured 17.39 GB unchunked -- the config that actually crashed."""
+    """Measured 17.39 GB unchunked: the config that crashed."""
     with pytest.raises(ValueError, match="does not fit in memory"):
         _distill().preflight_memory(2, 1024, VOCAB, RESIDENT, SYSTEM_16GB, chunked=False)
 
@@ -153,7 +142,7 @@ def test_chunked_is_cheaper_than_unchunked_in_the_estimate():
 
 
 def test_largest_tokens_that_fit_is_consistent_with_preflight():
-    """Whatever the message advertises as fitting must actually pass preflight."""
+    """What the message advertises as fitting must pass preflight."""
     d = _distill()
     budget = int(SYSTEM_16GB * d.MEMORY_SAFETY_FRACTION)
     max_tokens = d.largest_tokens_that_fit(VOCAB, RESIDENT, budget, chunked=True)
@@ -164,11 +153,7 @@ def test_largest_tokens_that_fit_is_consistent_with_preflight():
 
 
 def test_skip_override_bypasses_the_raise_and_warns():
-    """Refusing by default is right; refusing with no recourse is not.
-
-    The estimator reads total system memory and is deliberately conservative, so
-    a user who knows their configuration fits must be able to proceed -- loudly.
-    """
+    """The estimator is conservative, so an override must exist -- loudly."""
     d = _distill()
     with pytest.warns(UserWarning) as record:
         estimate = d.preflight_memory(
@@ -184,7 +169,7 @@ def test_skip_override_bypasses_the_raise_and_warns():
 
 
 def test_skip_override_does_not_warn_when_it_already_fits():
-    """No warning noise for a configuration that was never going to be refused."""
+    """No warning for a config that was never going to be refused."""
     import warnings
     d = _distill()
     with warnings.catch_warnings():

--- a/tests/test_mlx_gkd_guards.py
+++ b/tests/test_mlx_gkd_guards.py
@@ -1,0 +1,223 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""GKD guards: tokenizer compatibility, config validation, memory preflight.
+
+Pure logic and arithmetic, so this runs under the torch shim on Linux CI instead
+of skipping. The numeric behaviour of the divergence lives in
+test_mlx_gkd_loss.py, which needs real MLX and runs on Apple Silicon.
+
+The preflight numbers below are the measured ones from a Qwen2.5-0.5B LoRA
+student with a Qwen2.5-3B teacher (vocab 151936, 2.881 GB resident) on a 16 GB
+machine. They matter because an oversized step does not raise a catchable OOM --
+it aborts with "[METAL] Command buffer execution failed: Impacting
+Interactivity" and wedges the GPU context.
+"""
+
+import pytest
+
+GB = 1024 ** 3
+VOCAB = 151936
+RESIDENT = int(2.881 * GB)
+SYSTEM_16GB = 16 * GB
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def _distill():
+    import unsloth_zoo.mlx.distill as distill
+    return distill
+
+
+class FakeTokenizer:
+    """Encodes by a per-instance rule so probe agreement can be controlled."""
+
+    def __init__(self, offset=0):
+        self.offset = offset
+
+    def encode(self, text):
+        return [ord(c) + self.offset for c in text]
+
+
+# --- tokenizer compatibility -------------------------------------------------
+def test_identical_tokenizers_pass():
+    d = _distill()
+    assert d.assert_tokenizers_compatible(FakeTokenizer(), FakeTokenizer(), VOCAB, VOCAB)
+
+
+def test_width_mismatch_is_rejected():
+    d = _distill()
+    with pytest.raises(ValueError, match="logit widths differ"):
+        d.assert_tokenizers_compatible(FakeTokenizer(), FakeTokenizer(), 128256, 151936)
+
+
+def test_width_matches_but_ids_differ_is_rejected():
+    """The silent-misalignment case: same vocab size, different encodings.
+
+    A width-only check would let this through and train the student against
+    targets that do not correspond to its own tokens, with no error.
+    """
+    d = _distill()
+    with pytest.raises(ValueError, match="encode text differently"):
+        d.assert_tokenizers_compatible(FakeTokenizer(0), FakeTokenizer(1), VOCAB, VOCAB)
+
+
+def test_probe_set_covers_more_than_plain_ascii():
+    d = _distill()
+    joined = "".join(d.TOKENIZER_PROBES)
+    assert len(d.TOKENIZER_PROBES) >= 4
+    assert "\n" in joined and "#" in joined
+
+
+# --- config validation -------------------------------------------------------
+@pytest.mark.parametrize("beta", [0.0, 0.5, 1.0])
+def test_valid_beta_accepted(beta):
+    assert _distill().validate_gkd_config(beta, 1.0, 0.0)
+
+
+@pytest.mark.parametrize("beta", [-0.1, 1.1, 2.0])
+def test_out_of_range_beta_rejected(beta):
+    with pytest.raises(ValueError, match=r"gkd_beta must be in \[0, 1\]"):
+        _distill().validate_gkd_config(beta, 1.0, 0.0)
+
+
+@pytest.mark.parametrize("temperature", [0.0, -1.0])
+def test_non_positive_temperature_rejected(temperature):
+    with pytest.raises(ValueError, match="gkd_temperature must be > 0"):
+        _distill().validate_gkd_config(0.5, temperature, 0.0)
+
+
+def test_on_policy_lmbda_rejected_with_reason():
+    """Off-policy only: on-policy needs generation in the training loop, which
+    the MLX trainer does not have."""
+    with pytest.raises(ValueError, match="generation inside the training loop"):
+        _distill().validate_gkd_config(0.5, 1.0, 0.5)
+
+
+# --- memory preflight --------------------------------------------------------
+def test_preflight_allows_batch2_seq512():
+    """Measured 10.16 GB on a 16 GB machine -- must not be rejected."""
+    d = _distill()
+    estimate = d.preflight_memory(2, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
+    assert estimate < SYSTEM_16GB * d.MEMORY_SAFETY_FRACTION
+
+
+def test_preflight_rejects_batch4_seq512():
+    """Measured 17.16 GB -- over a 16 GB machine, wedges Metal if allowed."""
+    with pytest.raises(ValueError, match="does not fit in memory"):
+        _distill().preflight_memory(4, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
+
+
+def test_preflight_rejects_batch2_seq1024_unchunked():
+    """Measured 17.39 GB unchunked -- the config that actually crashed."""
+    with pytest.raises(ValueError, match="does not fit in memory"):
+        _distill().preflight_memory(2, 1024, VOCAB, RESIDENT, SYSTEM_16GB, chunked=False)
+
+
+def test_preflight_message_names_everything_needed_to_act():
+    d = _distill()
+    with pytest.raises(ValueError) as excinfo:
+        d.preflight_memory(4, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
+    message = str(excinfo.value)
+    assert "batch_size=4" in message and "seq_len=512" in message
+    assert "2048 tokens" in message              # requested B*L
+    assert "estimated peak" in message
+    assert "16.00 GB" in message                 # detected system memory
+    assert f"vocab {VOCAB}" in message           # largest that fits, at this width
+    assert "tokens (e.g. batch_size=1" in message
+
+
+def test_chunked_is_cheaper_than_unchunked_in_the_estimate():
+    d = _distill()
+    chunked = d.estimate_distillation_peak_bytes(2, 1024, VOCAB, RESIDENT, chunked=True)
+    naive = d.estimate_distillation_peak_bytes(2, 1024, VOCAB, RESIDENT, chunked=False)
+    assert chunked < naive
+    assert d.CHUNKED_ACTIVATION_MULTIPLIER < d.NAIVE_ACTIVATION_MULTIPLIER
+
+
+def test_largest_tokens_that_fit_is_consistent_with_preflight():
+    """Whatever the message advertises as fitting must actually pass preflight."""
+    d = _distill()
+    budget = int(SYSTEM_16GB * d.MEMORY_SAFETY_FRACTION)
+    max_tokens = d.largest_tokens_that_fit(VOCAB, RESIDENT, budget, chunked=True)
+    assert max_tokens > 0
+    d.preflight_memory(1, max_tokens, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
+    with pytest.raises(ValueError):
+        d.preflight_memory(1, int(max_tokens * 1.5), VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
+
+
+def test_skip_override_bypasses_the_raise_and_warns():
+    """Refusing by default is right; refusing with no recourse is not.
+
+    The estimator reads total system memory and is deliberately conservative, so
+    a user who knows their configuration fits must be able to proceed -- loudly.
+    """
+    d = _distill()
+    with pytest.warns(UserWarning) as record:
+        estimate = d.preflight_memory(
+            4, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True, skip=True,
+        )
+    assert estimate > SYSTEM_16GB * d.MEMORY_SAFETY_FRACTION, (
+        "override should return the same over-budget estimate, not a fudged one"
+    )
+    message = str(record[0].message)
+    assert "gkd_skip_memory_preflight=True" in message
+    assert "Command buffer execution failed" in message   # names the wedge risk
+    assert "estimated at" in message                       # names the estimate
+
+
+def test_skip_override_does_not_warn_when_it_already_fits():
+    """No warning noise for a configuration that was never going to be refused."""
+    import warnings
+    d = _distill()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        d.preflight_memory(2, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True, skip=True)
+
+
+def test_skip_defaults_to_false_so_the_guard_is_on():
+    d = _distill()
+    with pytest.raises(ValueError, match="does not fit in memory"):
+        d.preflight_memory(4, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
+
+
+def test_larger_system_memory_allows_more():
+    d = _distill()
+    with pytest.raises(ValueError):
+        d.preflight_memory(4, 512, VOCAB, RESIDENT, SYSTEM_16GB, chunked=True)
+    assert d.preflight_memory(4, 512, VOCAB, RESIDENT, 64 * GB, chunked=True)
+
+
+def test_config_fields_exist_and_are_inert_by_default():
+    import dataclasses
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig, _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+    names = [f.name for f in dataclasses.fields(MLXTrainingConfig)]
+    for field in ("teacher_model_name_or_path", "gkd_beta", "gkd_temperature",
+                  "gkd_lmbda", "gkd_chunk_size", "gkd_skip_memory_preflight"):
+        assert field in names
+        assert field in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+    config = MLXTrainingConfig()
+    assert config.teacher_model_name_or_path is None   # inert unless set
+    assert config.gkd_lmbda == 0.0                     # off-policy default
+    assert config.gkd_chunk_size > 0                   # chunked by DEFAULT
+    assert config.gkd_skip_memory_preflight is False   # preflight ON by default
+    # The GKD fields must remain an exact suffix: the initializer binds
+    # positional args by field order.
+    assert names[-6:] == list(_MLX_CONFIG_OPTIONAL_COPY_FIELDS)[-6:]

--- a/tests/test_mlx_gkd_loss.py
+++ b/tests/test_mlx_gkd_loss.py
@@ -1,0 +1,212 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Numerics for the GKD divergence: does the student actually move to the teacher?
+
+Behaviour over steps, not construction. Every training assertion also reports a
+divergence-to-teacher number, because a loss can fall while the student drifts
+away from the target (reverse KL does exactly that to forward KL).
+
+Real MLX required, so this skips on Linux; the guard/config/preflight half runs
+under the torch shim in test_mlx_gkd_guards.py. Synthetic tensors only -- no
+weights, no network, no Dataset.map.
+"""
+
+import pytest
+
+mx = pytest.importorskip("mlx.core", reason="MLX is only available on Apple Silicon")
+nn = pytest.importorskip("mlx.nn", reason="MLX is only available on Apple Silicon")
+optim = pytest.importorskip("mlx.optimizers", reason="MLX is only available on Apple Silicon")
+
+from unsloth_zoo.mlx.distill import (
+    DEFAULT_CHUNK_SIZE,
+    generalized_jsd_loss,
+)
+
+
+VOCAB, BATCH, SEQ, HIDDEN = 512, 4, 24, 64
+STEPS = 8
+
+
+def _fixture():
+    mx.random.seed(0)
+    teacher_logits = mx.random.normal((BATCH, SEQ, VOCAB)) * 2.0
+    labels = mx.concatenate(
+        [mx.full((BATCH, SEQ // 2), -100), mx.zeros((BATCH, SEQ - SEQ // 2))], axis=1,
+    ).astype(mx.int32)
+    ids = mx.random.randint(0, VOCAB, (BATCH, SEQ))
+    return teacher_logits, labels, ids
+
+
+class _Student(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = nn.Embedding(VOCAB, HIDDEN)
+        self.head = nn.Linear(HIDDEN, VOCAB)
+
+    def __call__(self, ids):
+        return self.head(self.emb(ids))
+
+
+def _new_student():
+    mx.random.seed(0)
+    student = _Student()
+    mx.eval(student.parameters())
+    return student
+
+
+def _masked_divergence(student_logits, teacher_logits, labels, direction):
+    """KL to the teacher on supervised positions only."""
+    student_lp = nn.log_softmax(student_logits, axis=-1)
+    teacher_lp = nn.log_softmax(teacher_logits, axis=-1)
+    if direction == "forward":       # KL(teacher || student)
+        per = mx.exp(teacher_lp) * (teacher_lp - student_lp)
+    else:                            # KL(student || teacher)
+        per = mx.exp(student_lp) * (student_lp - teacher_lp)
+    per = per.sum(axis=-1)
+    mask = (labels != -100)
+    return float((per * mask).sum() / mx.maximum(mask.sum(), 1))
+
+
+def _train(student, teacher_logits, ids, labels, beta, steps=STEPS, chunk_size=DEFAULT_CHUNK_SIZE):
+    grad_fn = nn.value_and_grad(
+        student,
+        lambda m, i, t, l: generalized_jsd_loss(m(i), t, l, beta=beta, chunk_size=chunk_size),
+    )
+    opt = optim.Adam(learning_rate=5e-3)
+    losses = []
+    for _ in range(steps):
+        loss, grads = grad_fn(student, ids, teacher_logits, labels)
+        opt.update(student, grads)
+        mx.eval(student.parameters(), opt.state)
+        losses.append(float(loss))
+    return losses
+
+
+@pytest.mark.parametrize("beta,direction", [(0.0, "forward"), (0.5, "forward"), (1.0, "reverse")])
+def test_student_moves_toward_teacher(beta, direction):
+    """Loss falls AND the corresponding divergence to the teacher falls."""
+    teacher_logits, labels, ids = _fixture()
+    student = _new_student()
+    before = _masked_divergence(student(ids), teacher_logits, labels, direction)
+
+    losses = _train(student, teacher_logits, ids, labels, beta)
+
+    after = _masked_divergence(student(ids), teacher_logits, labels, direction)
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), (
+        f"beta={beta} loss not strictly decreasing: {losses}"
+    )
+    assert after < before, (
+        f"beta={beta}: loss fell but {direction} KL to teacher rose "
+        f"({before:.5f} -> {after:.5f})"
+    )
+
+
+def test_chunked_matches_unchunked_numerically():
+    """Chunking is the default, so it must be exactly the naive computation."""
+    teacher_logits, labels, ids = _fixture()
+    student = _new_student()
+    logits = student(ids)
+
+    naive = generalized_jsd_loss(logits, teacher_logits, labels, beta=0.5, chunk_size=0)
+    for chunk in (1, 4, 8, SEQ - 1, SEQ, SEQ + 5):
+        chunked = generalized_jsd_loss(logits, teacher_logits, labels, beta=0.5, chunk_size=chunk)
+        assert abs(float(naive) - float(chunked)) < 1e-5, (
+            f"chunk_size={chunk} disagreed with the unchunked loss: "
+            f"{float(chunked):.8f} vs {float(naive):.8f}"
+        )
+
+
+def test_chunked_and_unchunked_train_identically():
+    """Equal values are not enough -- the gradients must agree too."""
+    teacher_logits, labels, ids = _fixture()
+    naive = _train(_new_student(), teacher_logits, ids, labels, 0.5, chunk_size=0)
+    chunked = _train(_new_student(), teacher_logits, ids, labels, 0.5, chunk_size=8)
+    worst = max(abs(a - b) for a, b in zip(naive, chunked))
+    assert worst < 1e-5, f"chunked training diverged from naive by {worst:.3e}"
+
+
+def test_labels_mask_is_honoured():
+    teacher_logits, labels, ids = _fixture()
+    student = _new_student()
+    logits = student(ids)
+
+    all_masked = mx.full((BATCH, SEQ), -100).astype(mx.int32)
+    masked_loss = generalized_jsd_loss(logits, teacher_logits, all_masked, beta=0.5)
+    assert float(masked_loss) == 0.0
+    assert bool(mx.isfinite(masked_loss).item()), "denominator guard missing: 0/0"
+
+    unmasked = generalized_jsd_loss(logits, teacher_logits, None, beta=0.5)
+    half = generalized_jsd_loss(logits, teacher_logits, labels, beta=0.5)
+    assert abs(float(half) - float(unmasked)) > 1e-6, (
+        "masking half the positions changed nothing; the mask is being ignored"
+    )
+
+
+def test_identical_distributions_give_zero_loss():
+    teacher_logits, labels, _ = _fixture()
+    for beta in (0.0, 0.5, 1.0):
+        loss = generalized_jsd_loss(teacher_logits, teacher_logits, labels, beta=beta)
+        assert abs(float(loss)) < 1e-5, f"beta={beta}: self-distillation loss {float(loss)}"
+
+
+def test_temperature_is_wired():
+    teacher_logits, labels, ids = _fixture()
+    logits = _new_student()(ids)
+    at_one = float(generalized_jsd_loss(logits, teacher_logits, labels, beta=0.5, temperature=1.0))
+    at_two = float(generalized_jsd_loss(logits, teacher_logits, labels, beta=0.5, temperature=2.0))
+    assert at_one != at_two
+    assert at_two < at_one, "softening both distributions should reduce the divergence"
+
+
+def test_beta_endpoints_are_asymmetric():
+    """beta=0 and beta=1 are different divergences, not the same number."""
+    teacher_logits, labels, ids = _fixture()
+    logits = _new_student()(ids)
+    forward = float(generalized_jsd_loss(logits, teacher_logits, labels, beta=0.0))
+    reverse = float(generalized_jsd_loss(logits, teacher_logits, labels, beta=1.0))
+    assert abs(forward - reverse) > 1e-4
+
+
+def test_loss_survives_mx_compile():
+    """MLXTrainer compiles the step with inputs=state, outputs=state."""
+    teacher_logits, labels, ids = _fixture()
+
+    def run(compiled):
+        student = _new_student()
+        opt = optim.Adam(learning_rate=5e-3)
+        grad_fn = nn.value_and_grad(
+            student, lambda m, i, t, l: generalized_jsd_loss(m(i), t, l, beta=0.5),
+        )
+        state = [student.state, opt.state, mx.random.state]
+
+        def step(i, t, l):
+            loss, grads = grad_fn(student, i, t, l)
+            opt.update(student, grads)
+            return loss
+
+        if compiled:
+            step = mx.compile(step, inputs=state, outputs=state)
+        out = []
+        for _ in range(STEPS):
+            loss = step(ids, teacher_logits, labels)
+            mx.eval(state)
+            out.append(float(loss))
+        return out
+
+    plain, compiled = run(False), run(True)
+    worst = max(abs(a - b) for a, b in zip(plain, compiled))
+    assert worst == 0.0, f"mx.compile changed the trajectory by {worst:.3e}"

--- a/tests/test_mlx_gkd_loss.py
+++ b/tests/test_mlx_gkd_loss.py
@@ -16,13 +16,9 @@
 
 """Numerics for the GKD divergence: does the student actually move to the teacher?
 
-Behaviour over steps, not construction. Every training assertion also reports a
-divergence-to-teacher number, because a loss can fall while the student drifts
-away from the target (reverse KL does exactly that to forward KL).
-
-Real MLX required, so this skips on Linux; the guard/config/preflight half runs
-under the torch shim in test_mlx_gkd_guards.py. Synthetic tensors only -- no
-weights, no network, no Dataset.map.
+Every training assertion also reports a divergence-to-teacher number, because a
+loss can fall while the student drifts away from the target (reverse KL does
+exactly that to forward KL). Real MLX required, so this skips on Linux.
 """
 
 import pytest
@@ -69,7 +65,6 @@ def _new_student():
 
 
 def _masked_divergence(student_logits, teacher_logits, labels, direction):
-    """KL to the teacher on supervised positions only."""
     student_lp = nn.log_softmax(student_logits, axis=-1)
     teacher_lp = nn.log_softmax(teacher_logits, axis=-1)
     if direction == "forward":       # KL(teacher || student)
@@ -98,7 +93,7 @@ def _train(student, teacher_logits, ids, labels, beta, steps=STEPS, chunk_size=D
 
 @pytest.mark.parametrize("beta,direction", [(0.0, "forward"), (0.5, "forward"), (1.0, "reverse")])
 def test_student_moves_toward_teacher(beta, direction):
-    """Loss falls AND the corresponding divergence to the teacher falls."""
+    """Loss falls AND the divergence to the teacher falls."""
     teacher_logits, labels, ids = _fixture()
     student = _new_student()
     before = _masked_divergence(student(ids), teacher_logits, labels, direction)
@@ -116,7 +111,7 @@ def test_student_moves_toward_teacher(beta, direction):
 
 
 def test_chunked_matches_unchunked_numerically():
-    """Chunking is the default, so it must be exactly the naive computation."""
+    """Chunking is the default, so it must match the naive computation."""
     teacher_logits, labels, ids = _fixture()
     student = _new_student()
     logits = student(ids)
@@ -131,7 +126,7 @@ def test_chunked_matches_unchunked_numerically():
 
 
 def test_chunked_and_unchunked_train_identically():
-    """Equal values are not enough -- the gradients must agree too."""
+    """Gradients must agree too, not just values."""
     teacher_logits, labels, ids = _fixture()
     naive = _train(_new_student(), teacher_logits, ids, labels, 0.5, chunk_size=0)
     chunked = _train(_new_student(), teacher_logits, ids, labels, 0.5, chunk_size=8)
@@ -182,7 +177,6 @@ def test_beta_endpoints_are_asymmetric():
 
 
 def test_loss_survives_mx_compile():
-    """MLXTrainer compiles the step with inputs=state, outputs=state."""
     teacher_logits, labels, ids = _fixture()
 
     def run(compiled):

--- a/unsloth_zoo/mlx/distill.py
+++ b/unsloth_zoo/mlx/distill.py
@@ -1,0 +1,405 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Off-policy knowledge distillation (GKD) for the MLX trainer.
+
+A frozen teacher scores the student's own batch; the student is trained against
+the teacher's distribution with TRL's generalized Jensen-Shannon divergence.
+
+Three things here are load-bearing and were established by measurement, not
+assumption. Read before changing any of them.
+
+1. TEACHER AND STUDENT MUST SHARE A TOKENIZER. Matching ``vocab_size`` alone is
+   NOT sufficient: two checkpoints can report the same width while encoding text
+   differently, which trains the student against misaligned targets and produces
+   no error at all. ``assert_tokenizers_compatible`` therefore compares encoded
+   ids on probe strings as well as the logit width. Verified working pairs
+   include Qwen2.5-0.5B <- Qwen2.5-3B, Llama-3.2-1B <- Llama-3.2-3B, and
+   Qwen3-0.6B <- Qwen2.5-3B (tokenizers agree across generations). Llama <-> Qwen
+   in either direction fails the width check.
+
+2. THE LOSS IS CHUNKED BY DEFAULT. The divergence materializes several
+   [batch, seq, vocab] float32 tensors, and vocab is ~152k for Qwen. Chunking
+   over sequence positions took a measured batch=2/seq=1024 step from 17.39 GB
+   (over a 16 GB machine, crashes) to 15.29 GB (fits). The unchunked path is kept
+   only so a test can assert the two agree numerically.
+
+3. OVERSIZED BATCHES DO NOT RAISE A CATCHABLE OOM. On Apple Silicon they abort
+   the process with
+
+       [METAL] Command buffer execution failed: Impacting Interactivity
+
+   and leave the GPU context wedged for subsequent runs. ``preflight_memory``
+   therefore estimates peak up front and raises a normal Python error instead.
+   Its estimator is a pure function so it is testable without MLX installed.
+"""
+
+# Bind MLX at import, NOT inside each function. Deferred `import mlx.core` calls
+# resolve against sys.modules at call time, so anything that swaps in a stub
+# afterwards (tests/mlx_simulation does exactly this) would silently hand this
+# module the stub instead of real MLX. Binding here captures whichever MLX was
+# present when this module was first imported and keeps it.
+import mlx.core as mx
+import mlx.nn as nn
+
+__all__ = [
+    "generalized_jsd_loss",
+    "assert_tokenizers_compatible",
+    "estimate_distillation_peak_bytes",
+    "largest_tokens_that_fit",
+    "preflight_memory",
+    "validate_gkd_config",
+    "TOKENIZER_PROBES",
+    "DEFAULT_CHUNK_SIZE",
+    "NAIVE_ACTIVATION_MULTIPLIER",
+    "CHUNKED_ACTIVATION_MULTIPLIER",
+    "MEMORY_SAFETY_FRACTION",
+]
+
+# Sequence positions per chunk. 128 was measured; larger trades memory for fewer
+# kernel launches.
+DEFAULT_CHUNK_SIZE = 128
+
+# Peak activation cost expressed as a multiple of one teacher-logit buffer
+# (batch * seq * vocab * 4 bytes). Fitted from measured training steps on a
+# Qwen2.5-0.5B LoRA student with a Qwen2.5-3B teacher (vocab 151936):
+#   unchunked  batch/seq  1/512 -> 7.47 GB, 2/512 -> 12.05 GB, 2/1024 -> 17.39 GB
+#   chunked    batch/seq  2/512 -> 10.46 GB, 2/1024 -> 15.29 GB
+# Rounded UP: a preflight that under-estimates lets the process wedge Metal.
+NAIVE_ACTIVATION_MULTIPLIER = 16.0
+CHUNKED_ACTIVATION_MULTIPLIER = 13.0
+
+# Never plan to fill RAM. Unified memory is shared with the OS and display.
+MEMORY_SAFETY_FRACTION = 0.85
+
+# Short, deliberately varied strings: plain text, chat control tokens, code with
+# runs of whitespace, and non-ASCII. Two tokenizers that agree on all of these
+# and on logit width are treated as interchangeable for distillation.
+TOKENIZER_PROBES = (
+    "The capital of France is Paris.",
+    "user\nhi\nassistant\n",
+    "def f(x):\n    return x**2  # comment",
+    "emoji and accents: cafe, naive, jalapeno",
+    "1234567890 !@#$%^&*()",
+)
+
+
+def _kl_divergence_log_target(input_log_probs, target_log_probs):
+    """Elementwise ``F.kl_div(input, target, log_target=True)``.
+
+    That is ``exp(target) * (target - input)``, matching PyTorch so the port of
+    TRL's loss stays comparable term by term.
+    """
+    return mx.exp(target_log_probs) * (target_log_probs - input_log_probs)
+
+
+def _jsd_per_position(student_logits, teacher_logits, beta, temperature):
+    """Divergence summed over the vocab axis, one value per (batch, position)."""
+    student_log_probs = nn.log_softmax(student_logits / temperature, axis=-1)
+    teacher_log_probs = nn.log_softmax(teacher_logits / temperature, axis=-1)
+
+    if beta == 0.0:
+        # Forward KL: classic KD, teacher as the target distribution.
+        per_token = _kl_divergence_log_target(student_log_probs, teacher_log_probs)
+    elif beta == 1.0:
+        # Reverse KL: mode-seeking. Note it does NOT minimise forward KL.
+        per_token = _kl_divergence_log_target(teacher_log_probs, student_log_probs)
+    else:
+        beta_array = mx.array(beta, dtype=student_log_probs.dtype)
+        mixture_log_probs = mx.logaddexp(
+            student_log_probs + mx.log(1 - beta_array),
+            teacher_log_probs + mx.log(beta_array),
+        )
+        per_token = (
+            beta * _kl_divergence_log_target(mixture_log_probs, teacher_log_probs)
+            + (1 - beta) * _kl_divergence_log_target(mixture_log_probs, student_log_probs)
+        )
+    return per_token.sum(axis=-1)
+
+
+def generalized_jsd_loss(
+    student_logits,
+    teacher_logits,
+    labels = None,
+    beta = 0.5,
+    temperature = 1.0,
+    chunk_size = DEFAULT_CHUNK_SIZE,
+):
+    """TRL's ``GKDTrainer.generalized_jsd_loss`` ported to MLX.
+
+    ``beta=0`` is forward KL (classic KD), ``beta=1`` reverse KL, and values in
+    between interpolate against the log-space mixture. Positions where ``labels``
+    is -100 are excluded; the mean is over supervised positions only.
+
+    ``chunk_size`` splits the sequence axis so only ``[batch, chunk, vocab]``
+    intermediates are alive at once. Pass ``chunk_size=0`` for the unchunked
+    path, which exists so tests can assert the two agree numerically -- it is not
+    the default because it costs ~2 GB more at batch=2/seq=1024.
+    """
+    if labels is None:
+        mask = mx.ones(student_logits.shape[:2])
+    else:
+        mask = (labels != -100)
+    denominator = mx.maximum(mask.sum(), 1)
+
+    sequence_length = student_logits.shape[1]
+    if chunk_size is None or chunk_size <= 0 or chunk_size >= sequence_length:
+        per_position = _jsd_per_position(student_logits, teacher_logits, beta, temperature)
+        return (per_position * mask).sum() / denominator
+
+    total = mx.zeros(())
+    for start in range(0, sequence_length, chunk_size):
+        end = min(start + chunk_size, sequence_length)
+        per_position = _jsd_per_position(
+            student_logits[:, start:end, :],
+            teacher_logits[:, start:end, :],
+            beta,
+            temperature,
+        )
+        total = total + (per_position * mask[:, start:end]).sum()
+    return total / denominator
+
+
+def assert_tokenizers_compatible(student_tokenizer, teacher_tokenizer,
+                                 student_vocab_size = None, teacher_vocab_size = None):
+    """Raise unless the two tokenizers are interchangeable for distillation.
+
+    Width equality is checked first because a mismatch is what MLX would report
+    as an opaque ``broadcast_shapes`` failure deep in the loss. Probe-id equality
+    is checked second because width equality ALONE is not sufficient: two
+    checkpoints can share a vocab size and still encode text differently, which
+    would silently train the student against misaligned targets.
+    """
+    if (student_vocab_size is not None and teacher_vocab_size is not None
+            and student_vocab_size != teacher_vocab_size):
+        raise ValueError(
+            "Unsloth: GKD needs the teacher and student to share a tokenizer, but "
+            f"their logit widths differ (student {student_vocab_size}, teacher "
+            f"{teacher_vocab_size}). Cross-family distillation would need token "
+            "remapping, which is not implemented. Pick a teacher from the "
+            "student's family (e.g. Qwen2.5-3B for a Qwen2.5/Qwen3 student)."
+        )
+
+    for probe in TOKENIZER_PROBES:
+        student_ids = student_tokenizer.encode(probe)
+        teacher_ids = teacher_tokenizer.encode(probe)
+        if list(student_ids) != list(teacher_ids):
+            raise ValueError(
+                "Unsloth: GKD needs the teacher and student to share a tokenizer. "
+                "Their logit widths match but they encode text differently, so the "
+                "teacher's distribution would not line up with the student's "
+                f"tokens. First disagreement on {probe!r}: student produced "
+                f"{len(student_ids)} ids, teacher produced {len(teacher_ids)}. "
+                "Training would silently optimise against misaligned targets."
+            )
+    return True
+
+
+def estimate_distillation_peak_bytes(batch_size, sequence_length, vocab_size,
+                                     resident_bytes, chunked = True,
+                                     bytes_per_element = 4):
+    """Estimated peak bytes for one distillation training step.
+
+    Pure arithmetic with no MLX import, so it is testable anywhere. Peak is
+    modelled as the already-resident weights plus a multiple of one teacher-logit
+    buffer; the multiplier was fitted from measured steps and rounded up, because
+    under-estimating here lets the process wedge the GPU rather than raise.
+    """
+    logit_buffer = batch_size * sequence_length * vocab_size * bytes_per_element
+    multiplier = CHUNKED_ACTIVATION_MULTIPLIER if chunked else NAIVE_ACTIVATION_MULTIPLIER
+    return int(resident_bytes + multiplier * logit_buffer)
+
+
+def largest_tokens_that_fit(vocab_size, resident_bytes, budget_bytes,
+                            chunked = True, bytes_per_element = 4):
+    """Largest batch*sequence token count that fits in ``budget_bytes``."""
+    multiplier = CHUNKED_ACTIVATION_MULTIPLIER if chunked else NAIVE_ACTIVATION_MULTIPLIER
+    headroom = budget_bytes - resident_bytes
+    if headroom <= 0:
+        return 0
+    return int(headroom / (multiplier * vocab_size * bytes_per_element))
+
+
+def preflight_memory(batch_size, sequence_length, vocab_size, resident_bytes,
+                     system_bytes, chunked = True, bytes_per_element = 4,
+                     skip = False):
+    """Raise before the first step if this configuration cannot fit.
+
+    An oversized distillation step does not raise a catchable OOM on Apple
+    Silicon; it aborts with ``[METAL] Command buffer execution failed: Impacting
+    Interactivity`` and leaves the GPU context wedged for later runs. Failing
+    here with a normal Python error is the whole point.
+
+    ``skip=True`` downgrades the refusal to a warning and proceeds. The estimator
+    is deliberately conservative and reads total system memory, so it can reject a
+    configuration that would actually have fit; refusing by default is right, but
+    refusing with no recourse is not.
+    """
+    budget = int(system_bytes * MEMORY_SAFETY_FRACTION)
+    estimate = estimate_distillation_peak_bytes(
+        batch_size, sequence_length, vocab_size, resident_bytes,
+        chunked = chunked, bytes_per_element = bytes_per_element,
+    )
+    if estimate <= budget:
+        return estimate
+
+    gb = 1024 ** 3
+    if skip:
+        import warnings
+        warnings.warn(
+            "Unsloth: gkd_skip_memory_preflight=True, proceeding with a GKD "
+            f"configuration estimated at {estimate / gb:.2f} GB against a "
+            f"{budget / gb:.2f} GB usable budget "
+            f"({system_bytes / gb:.2f} GB system). If this does not fit, the "
+            "process will NOT raise a recoverable error -- it aborts with "
+            "'[METAL] Command buffer execution failed: Impacting Interactivity' "
+            "and leaves the GPU context wedged for subsequent runs.",
+            UserWarning,
+            stacklevel = 2,
+        )
+        return estimate
+
+    max_tokens = largest_tokens_that_fit(
+        vocab_size, resident_bytes, budget,
+        chunked = chunked, bytes_per_element = bytes_per_element,
+    )
+    raise ValueError(
+        "Unsloth: this GKD configuration does not fit in memory.\n"
+        f"  requested      : batch_size={batch_size} x seq_len={sequence_length} "
+        f"= {batch_size * sequence_length} tokens\n"
+        f"  estimated peak : {estimate / gb:.2f} GB"
+        f"{'' if chunked else ' (unchunked loss)'}\n"
+        f"  system memory  : {system_bytes / gb:.2f} GB "
+        f"(usable budget {budget / gb:.2f} GB at "
+        f"{int(MEMORY_SAFETY_FRACTION * 100)}%)\n"
+        f"  largest that fits at vocab {vocab_size}: "
+        f"{max_tokens} tokens (e.g. batch_size=1 x seq_len={max_tokens})\n"
+        "Reduce per_device_train_batch_size or max_seq_length, or use a smaller "
+        "teacher. Proceeding would abort the process with a Metal command-buffer "
+        "failure rather than a recoverable error."
+    )
+
+
+def validate_gkd_config(gkd_beta, gkd_temperature, gkd_lmbda):
+    """Config gate for the GKD knobs. Pure, so the Linux gate can execute it."""
+    if not (0.0 <= gkd_beta <= 1.0):
+        raise ValueError(
+            f"Unsloth: gkd_beta must be in [0, 1], got {gkd_beta}. 0 is forward KL "
+            "(classic KD), 1 is reverse KL, 0.5 is symmetric JSD."
+        )
+    if gkd_temperature <= 0.0:
+        raise ValueError(
+            f"Unsloth: gkd_temperature must be > 0, got {gkd_temperature}."
+        )
+    if gkd_lmbda:
+        raise ValueError(
+            f"Unsloth: gkd_lmbda={gkd_lmbda} selects on-policy distillation, where "
+            "the student generates and the teacher scores its samples. That needs "
+            "generation inside the training loop, which the MLX trainer does not "
+            "have. Only off-policy KD (gkd_lmbda=0, teacher scores your dataset) "
+            "is supported."
+        )
+    return True
+
+
+def load_teacher(model_name_or_path):
+    """Load a teacher, freeze it, and assert it contributes no trainable state.
+
+    Frozen once here rather than per step: the teacher must stay out of
+    ``trainable_parameters()``, out of the optimizer state, and out of the state
+    tuple handed to ``mx.compile``.
+    """
+    from mlx.utils import tree_flatten
+    from mlx_lm import load
+
+    teacher, teacher_tokenizer = load(model_name_or_path)
+    teacher.freeze()
+    trainable = tree_flatten(teacher.trainable_parameters())
+    if trainable:
+        raise RuntimeError(
+            f"Unsloth: teacher {model_name_or_path} still reports "
+            f"{len(trainable)} trainable tensors after freeze(); it would be "
+            "pulled into the optimizer state."
+        )
+    return teacher, teacher_tokenizer
+
+
+def build_gkd_loss_fn(student_model, teacher_model, args, is_vlm,
+                      vocab_size, resident_bytes, system_bytes):
+    """Return a loss function matching the trainer's ``(model, batch, lengths,
+    labels=None) -> (loss, ntoks)`` contract.
+
+    The teacher forward runs under ``stop_gradient``: it is evaluated inside the
+    traced step (the contract gives us no way to hand logits in) but contributes
+    no gradient and no optimizer state.
+    """
+    beta = float(getattr(args, "gkd_beta", 0.5))
+    temperature = float(getattr(args, "gkd_temperature", 1.0))
+    chunk_size = int(getattr(args, "gkd_chunk_size", DEFAULT_CHUNK_SIZE))
+    validate_gkd_config(beta, temperature, getattr(args, "gkd_lmbda", 0.0))
+
+    if is_vlm:
+        raise ValueError(
+            "Unsloth: GKD distillation is text-only on MLX. The teacher would "
+            "need the student's exact image preprocessing for its logits to line "
+            "up, which is not implemented."
+        )
+
+    preflight_memory(
+        batch_size = int(getattr(args, "per_device_train_batch_size", 1)),
+        sequence_length = int(getattr(args, "max_seq_length", 512)),
+        vocab_size = vocab_size,
+        resident_bytes = resident_bytes,
+        system_bytes = system_bytes,
+        chunked = chunk_size > 0,
+        skip = bool(getattr(args, "gkd_skip_memory_preflight", False)),
+    )
+
+    def loss_fn(model, batch, lengths, labels=None):
+        inputs = batch[:, :-1]
+        if labels is None:
+            steps = mx.arange(1, inputs.shape[1] + 1)
+            mask = mx.logical_and(steps >= lengths[:, 0:1], steps < lengths[:, 1:])
+            shifted_labels = mx.where(mask, mx.zeros_like(inputs), mx.full(inputs.shape, -100))
+        else:
+            shifted_labels = labels[:, 1:]
+            mask = (shifted_labels != -100)
+        student_logits = model(inputs)
+        teacher_logits = mx.stop_gradient(teacher_model(inputs))
+        loss = generalized_jsd_loss(
+            student_logits, teacher_logits, shifted_labels,
+            beta = beta, temperature = temperature, chunk_size = chunk_size,
+        )
+        return loss, mask.sum()
+
+    loss_fn._unsloth_gkd = True
+    return loss_fn
+
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/unsloth_zoo/mlx/distill.py
+++ b/unsloth_zoo/mlx/distill.py
@@ -16,42 +16,31 @@
 
 """Off-policy knowledge distillation (GKD) for the MLX trainer.
 
-A frozen teacher scores the student's own batch; the student is trained against
-the teacher's distribution with TRL's generalized Jensen-Shannon divergence.
+A frozen teacher scores the student's own batch; the student trains against its
+distribution with TRL's generalized Jensen-Shannon divergence.
 
-Three things here are load-bearing and were established by measurement, not
-assumption. Read before changing any of them.
+Three things were established by measurement. Read before changing them.
 
-1. TEACHER AND STUDENT MUST SHARE A TOKENIZER. Matching ``vocab_size`` alone is
-   NOT sufficient: two checkpoints can report the same width while encoding text
-   differently, which trains the student against misaligned targets and produces
-   no error at all. ``assert_tokenizers_compatible`` therefore compares encoded
-   ids on probe strings as well as the logit width. Verified working pairs
-   include Qwen2.5-0.5B <- Qwen2.5-3B, Llama-3.2-1B <- Llama-3.2-3B, and
-   Qwen3-0.6B <- Qwen2.5-3B (tokenizers agree across generations). Llama <-> Qwen
-   in either direction fails the width check.
+1. TEACHER AND STUDENT MUST SHARE A TOKENIZER. Matching ``vocab_size`` is NOT
+   enough: two checkpoints can share a width while encoding text differently,
+   which trains against misaligned targets with no error at all. So probe-encoded
+   ids are compared too. Verified: Qwen2.5-0.5B <- Qwen2.5-3B, Llama-3.2-1B <-
+   Llama-3.2-3B, Qwen3-0.6B <- Qwen2.5-3B (agree across generations). Llama <->
+   Qwen fails the width check.
 
-2. THE LOSS IS CHUNKED BY DEFAULT. The divergence materializes several
-   [batch, seq, vocab] float32 tensors, and vocab is ~152k for Qwen. Chunking
-   over sequence positions took a measured batch=2/seq=1024 step from 17.39 GB
-   (over a 16 GB machine, crashes) to 15.29 GB (fits). The unchunked path is kept
-   only so a test can assert the two agree numerically.
+2. THE LOSS IS CHUNKED BY DEFAULT. It materializes several [batch, seq, vocab]
+   float32 tensors and vocab is ~152k for Qwen. Chunking took a measured
+   batch=2/seq=1024 step from 17.39 GB (crashes on 16 GB) to 15.29 GB. The
+   unchunked path exists only so a test can assert the two agree.
 
-3. OVERSIZED BATCHES DO NOT RAISE A CATCHABLE OOM. On Apple Silicon they abort
-   the process with
-
-       [METAL] Command buffer execution failed: Impacting Interactivity
-
-   and leave the GPU context wedged for subsequent runs. ``preflight_memory``
-   therefore estimates peak up front and raises a normal Python error instead.
-   Its estimator is a pure function so it is testable without MLX installed.
+3. OVERSIZED BATCHES DO NOT RAISE A CATCHABLE OOM. They abort with
+   ``[METAL] Command buffer execution failed: Impacting Interactivity`` and wedge
+   the GPU context for later runs, so ``preflight_memory`` estimates up front
+   instead. Its estimator is pure, hence testable without MLX.
 """
 
-# Bind MLX at import, NOT inside each function. Deferred `import mlx.core` calls
-# resolve against sys.modules at call time, so anything that swaps in a stub
-# afterwards (tests/mlx_simulation does exactly this) would silently hand this
-# module the stub instead of real MLX. Binding here captures whichever MLX was
-# present when this module was first imported and keeps it.
+# Bind MLX at import, NOT inside functions: a deferred `import mlx.core` resolves
+# against sys.modules at call time, so tests/mlx_simulation's stub would win.
 import mlx.core as mx
 import mlx.nn as nn
 
@@ -69,25 +58,21 @@ __all__ = [
     "MEMORY_SAFETY_FRACTION",
 ]
 
-# Sequence positions per chunk. 128 was measured; larger trades memory for fewer
-# kernel launches.
+# Sequence positions per chunk; larger trades memory for fewer kernel launches.
 DEFAULT_CHUNK_SIZE = 128
 
-# Peak activation cost expressed as a multiple of one teacher-logit buffer
-# (batch * seq * vocab * 4 bytes). Fitted from measured training steps on a
-# Qwen2.5-0.5B LoRA student with a Qwen2.5-3B teacher (vocab 151936):
-#   unchunked  batch/seq  1/512 -> 7.47 GB, 2/512 -> 12.05 GB, 2/1024 -> 17.39 GB
-#   chunked    batch/seq  2/512 -> 10.46 GB, 2/1024 -> 15.29 GB
-# Rounded UP: a preflight that under-estimates lets the process wedge Metal.
+# Peak as a multiple of one teacher-logit buffer (batch*seq*vocab*4). Fitted on a
+# Qwen2.5-0.5B student + Qwen2.5-3B teacher (vocab 151936):
+#   unchunked 1/512 -> 7.47 GB, 2/512 -> 12.05 GB, 2/1024 -> 17.39 GB
+#   chunked   2/512 -> 10.46 GB, 2/1024 -> 15.29 GB
+# Rounded UP: under-estimating lets the process wedge Metal.
 NAIVE_ACTIVATION_MULTIPLIER = 16.0
 CHUNKED_ACTIVATION_MULTIPLIER = 13.0
 
 # Never plan to fill RAM. Unified memory is shared with the OS and display.
 MEMORY_SAFETY_FRACTION = 0.85
 
-# Short, deliberately varied strings: plain text, chat control tokens, code with
-# runs of whitespace, and non-ASCII. Two tokenizers that agree on all of these
-# and on logit width are treated as interchangeable for distillation.
+# Varied probes: plain text, control tokens, whitespace-heavy code, non-ASCII.
 TOKENIZER_PROBES = (
     "The capital of France is Paris.",
     "user\nhi\nassistant\n",
@@ -98,11 +83,7 @@ TOKENIZER_PROBES = (
 
 
 def _kl_divergence_log_target(input_log_probs, target_log_probs):
-    """Elementwise ``F.kl_div(input, target, log_target=True)``.
-
-    That is ``exp(target) * (target - input)``, matching PyTorch so the port of
-    TRL's loss stays comparable term by term.
-    """
+    """Elementwise ``F.kl_div(input, target, log_target=True)``."""
     return mx.exp(target_log_probs) * (target_log_probs - input_log_probs)
 
 
@@ -112,10 +93,10 @@ def _jsd_per_position(student_logits, teacher_logits, beta, temperature):
     teacher_log_probs = nn.log_softmax(teacher_logits / temperature, axis=-1)
 
     if beta == 0.0:
-        # Forward KL: classic KD, teacher as the target distribution.
+        # Forward KL: classic KD.
         per_token = _kl_divergence_log_target(student_log_probs, teacher_log_probs)
     elif beta == 1.0:
-        # Reverse KL: mode-seeking. Note it does NOT minimise forward KL.
+        # Reverse KL: mode-seeking; does NOT minimise forward KL.
         per_token = _kl_divergence_log_target(teacher_log_probs, student_log_probs)
     else:
         beta_array = mx.array(beta, dtype=student_log_probs.dtype)
@@ -140,15 +121,10 @@ def generalized_jsd_loss(
 ):
     """TRL's ``GKDTrainer.generalized_jsd_loss`` ported to MLX.
 
-    ``beta=0`` is forward KL (classic KD), ``beta=1`` reverse KL, and values in
-    between interpolate against the log-space mixture. Positions where ``labels``
-    is -100 are excluded; the mean is over supervised positions only.
-
-    ``chunk_size`` splits the sequence axis so only ``[batch, chunk, vocab]``
-    intermediates are alive at once. Pass ``chunk_size=0`` for the unchunked
-    path, which exists so tests can assert the two agree numerically -- it is not
-    the default because it costs ~2 GB more at batch=2/seq=1024.
-    """
+    ``beta`` 0 is forward KL, 1 reverse KL, between interpolates via the log-space
+    mixture. -100 labels are excluded. ``chunk_size`` splits the sequence axis so
+    only ``[batch, chunk, vocab]`` is alive at once; 0 (unchunked) exists for the
+    equivalence test and costs ~2 GB more at batch=2/seq=1024."""
     if labels is None:
         mask = mx.ones(student_logits.shape[:2])
     else:
@@ -175,14 +151,10 @@ def generalized_jsd_loss(
 
 def assert_tokenizers_compatible(student_tokenizer, teacher_tokenizer,
                                  student_vocab_size = None, teacher_vocab_size = None):
-    """Raise unless the two tokenizers are interchangeable for distillation.
+    """Raise unless the tokenizers are interchangeable.
 
-    Width equality is checked first because a mismatch is what MLX would report
-    as an opaque ``broadcast_shapes`` failure deep in the loss. Probe-id equality
-    is checked second because width equality ALONE is not sufficient: two
-    checkpoints can share a vocab size and still encode text differently, which
-    would silently train the student against misaligned targets.
-    """
+    Width first (a mismatch surfaces as an opaque broadcast_shapes failure), then
+    probe ids, because equal widths alone still permit misaligned targets."""
     if (student_vocab_size is not None and teacher_vocab_size is not None
             and student_vocab_size != teacher_vocab_size):
         raise ValueError(
@@ -211,13 +183,8 @@ def assert_tokenizers_compatible(student_tokenizer, teacher_tokenizer,
 def estimate_distillation_peak_bytes(batch_size, sequence_length, vocab_size,
                                      resident_bytes, chunked = True,
                                      bytes_per_element = 4):
-    """Estimated peak bytes for one distillation training step.
-
-    Pure arithmetic with no MLX import, so it is testable anywhere. Peak is
-    modelled as the already-resident weights plus a multiple of one teacher-logit
-    buffer; the multiplier was fitted from measured steps and rounded up, because
-    under-estimating here lets the process wedge the GPU rather than raise.
-    """
+    """Estimated peak bytes for one step: resident weights plus a multiple of one
+    teacher-logit buffer. Pure arithmetic, so testable without MLX."""
     logit_buffer = batch_size * sequence_length * vocab_size * bytes_per_element
     multiplier = CHUNKED_ACTIVATION_MULTIPLIER if chunked else NAIVE_ACTIVATION_MULTIPLIER
     return int(resident_bytes + multiplier * logit_buffer)
@@ -238,16 +205,10 @@ def preflight_memory(batch_size, sequence_length, vocab_size, resident_bytes,
                      skip = False):
     """Raise before the first step if this configuration cannot fit.
 
-    An oversized distillation step does not raise a catchable OOM on Apple
-    Silicon; it aborts with ``[METAL] Command buffer execution failed: Impacting
-    Interactivity`` and leaves the GPU context wedged for later runs. Failing
-    here with a normal Python error is the whole point.
-
-    ``skip=True`` downgrades the refusal to a warning and proceeds. The estimator
-    is deliberately conservative and reads total system memory, so it can reject a
-    configuration that would actually have fit; refusing by default is right, but
-    refusing with no recourse is not.
-    """
+    An oversized step does not raise a catchable OOM; it aborts with
+    ``[METAL] Command buffer execution failed`` and wedges the GPU context.
+    ``skip=True`` downgrades the refusal to a warning: the estimator is
+    conservative, so refusing with no recourse would be wrong."""
     budget = int(system_bytes * MEMORY_SAFETY_FRACTION)
     estimate = estimate_distillation_peak_bytes(
         batch_size, sequence_length, vocab_size, resident_bytes,
@@ -294,7 +255,7 @@ def preflight_memory(batch_size, sequence_length, vocab_size, resident_bytes,
 
 
 def validate_gkd_config(gkd_beta, gkd_temperature, gkd_lmbda):
-    """Config gate for the GKD knobs. Pure, so the Linux gate can execute it."""
+    """Config gate. Pure, so the Linux gate can execute it."""
     if not (0.0 <= gkd_beta <= 1.0):
         raise ValueError(
             f"Unsloth: gkd_beta must be in [0, 1], got {gkd_beta}. 0 is forward KL "
@@ -316,12 +277,8 @@ def validate_gkd_config(gkd_beta, gkd_temperature, gkd_lmbda):
 
 
 def load_teacher(model_name_or_path):
-    """Load a teacher, freeze it, and assert it contributes no trainable state.
-
-    Frozen once here rather than per step: the teacher must stay out of
-    ``trainable_parameters()``, out of the optimizer state, and out of the state
-    tuple handed to ``mx.compile``.
-    """
+    """Load and freeze a teacher, asserting it contributes no trainable state:
+    it must stay out of trainable_parameters, optimizer state and mx.compile."""
     from mlx.utils import tree_flatten
     from mlx_lm import load
 
@@ -339,13 +296,8 @@ def load_teacher(model_name_or_path):
 
 def build_gkd_loss_fn(student_model, teacher_model, args, is_vlm,
                       vocab_size, resident_bytes, system_bytes):
-    """Return a loss function matching the trainer's ``(model, batch, lengths,
-    labels=None) -> (loss, ntoks)`` contract.
-
-    The teacher forward runs under ``stop_gradient``: it is evaluated inside the
-    traced step (the contract gives us no way to hand logits in) but contributes
-    no gradient and no optimizer state.
-    """
+    """Loss fn matching the trainer's ``(model, batch, lengths, labels=None) ->
+    (loss, ntoks)`` contract. The teacher runs under ``stop_gradient``."""
     beta = float(getattr(args, "gkd_beta", 0.5))
     temperature = float(getattr(args, "gkd_temperature", 1.0))
     chunk_size = int(getattr(args, "gkd_chunk_size", DEFAULT_CHUNK_SIZE))

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1152,18 +1152,14 @@ class MLXTrainingConfig:
     logging_dir: str | None = None
     run_name: str | None = None
 
-    # Off-policy knowledge distillation (GKD). Setting teacher_model_name_or_path
-    # is what switches the loss; everything else is inert while it is None.
-    # Appended LAST for the same positional-index reason as the fields above, and
-    # listed in _MLX_CONFIG_OPTIONAL_COPY_FIELDS so they stay an exact suffix.
+    # GKD. teacher_model_name_or_path switches the loss; inert while None.
+    # Appended LAST for the positional-index reason as the fields above.
     teacher_model_name_or_path: str | None = None
     gkd_beta: float = 0.5          # 0 = forward KL (classic KD), 1 = reverse KL
     gkd_temperature: float = 1.0
     gkd_lmbda: float = 0.0         # non-zero selects on-policy KD: not supported
     gkd_chunk_size: int = 128      # sequence positions per loss chunk; 0 = unchunked
-    # Downgrade the memory preflight from a refusal to a warning. The estimator
-    # reads total system memory and is deliberately conservative, so it can
-    # reject a config that would have fit; this is the escape hatch.
+    # Escape hatch: the preflight is conservative and can reject a config that fits.
     gkd_skip_memory_preflight: bool = False
 
     def __init__(self, *args, **kwargs):
@@ -4529,9 +4525,7 @@ class MLXTrainer:
         _vlm_ignore_token_ids = None
 
         if getattr(args, "teacher_model_name_or_path", None):
-            # Off-policy KD replaces the loss entirely, so branch before the
-            # CCE/baseline selection below. Implementation lives in distill.py;
-            # this hook stays one branch so it rebases cleanly.
+            # KD replaces the loss, so branch before the CCE/baseline selection.
             import psutil as _psutil
             from .distill import build_gkd_loss_fn, load_teacher, assert_tokenizers_compatible
             _teacher, _teacher_tok = load_teacher(args.teacher_model_name_or_path)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1016,6 +1016,13 @@ _MLX_CONFIG_OPTIONAL_COPY_FIELDS = (
     "streaming_prefetch_batches",
     "logging_dir",
     "run_name",
+    # Off-policy knowledge distillation (GKD); see unsloth_zoo/mlx/distill.py.
+    "teacher_model_name_or_path",
+    "gkd_beta",
+    "gkd_temperature",
+    "gkd_lmbda",
+    "gkd_chunk_size",
+    "gkd_skip_memory_preflight",
 )
 
 
@@ -1144,6 +1151,20 @@ class MLXTrainingConfig:
     # _MLX_CONFIG_OPTIONAL_COPY_FIELDS so they stay an exact suffix of it.
     logging_dir: str | None = None
     run_name: str | None = None
+
+    # Off-policy knowledge distillation (GKD). Setting teacher_model_name_or_path
+    # is what switches the loss; everything else is inert while it is None.
+    # Appended LAST for the same positional-index reason as the fields above, and
+    # listed in _MLX_CONFIG_OPTIONAL_COPY_FIELDS so they stay an exact suffix.
+    teacher_model_name_or_path: str | None = None
+    gkd_beta: float = 0.5          # 0 = forward KL (classic KD), 1 = reverse KL
+    gkd_temperature: float = 1.0
+    gkd_lmbda: float = 0.0         # non-zero selects on-policy KD: not supported
+    gkd_chunk_size: int = 128      # sequence positions per loss chunk; 0 = unchunked
+    # Downgrade the memory preflight from a refusal to a warning. The estimator
+    # reads total system memory and is deliberately conservative, so it can
+    # reject a config that would have fit; this is the escape hatch.
+    gkd_skip_memory_preflight: bool = False
 
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
@@ -4507,7 +4528,34 @@ class MLXTrainer:
         )
         _vlm_ignore_token_ids = None
 
-        if is_vlm:
+        if getattr(args, "teacher_model_name_or_path", None):
+            # Off-policy KD replaces the loss entirely, so branch before the
+            # CCE/baseline selection below. Implementation lives in distill.py;
+            # this hook stays one branch so it rebases cleanly.
+            import psutil as _psutil
+            from .distill import build_gkd_loss_fn, load_teacher, assert_tokenizers_compatible
+            _teacher, _teacher_tok = load_teacher(args.teacher_model_name_or_path)
+            _student_tok = getattr(self, "processing_class", None) or getattr(self, "tokenizer", None)
+            _probe = mx.zeros((1, 8), dtype=mx.int32)
+            _student_vocab = model(_probe).shape[-1]
+            _teacher_vocab = _teacher(_probe).shape[-1]
+            if _student_tok is not None:
+                assert_tokenizers_compatible(
+                    _student_tok, _teacher_tok, _student_vocab, _teacher_vocab,
+                )
+            loss_fn = build_gkd_loss_fn(
+                model, _teacher, args, is_vlm,
+                vocab_size = _teacher_vocab,
+                resident_bytes = mx.get_active_memory(),
+                system_bytes = _psutil.virtual_memory().total,
+            )
+            self._gkd_teacher = _teacher
+            _main_print(
+                f"Unsloth: GKD off-policy distillation from "
+                f"{args.teacher_model_name_or_path} "
+                f"(beta={args.gkd_beta}, temperature={args.gkd_temperature})."
+            )
+        elif is_vlm:
             processor = self._resolve_vlm_processor()
             # Backstop only; VLM collation already owns label masking.
             _vlm_ignore_token_ids = _get_vlm_ignore_token_ids(


### PR DESCRIPTION
A frozen teacher scores the student's own batch, and the student trains against the teacher's distribution via TRL's generalized JSD. TRL has `GKDTrainer`, but MLX stubs every non-SFT TRL trainer at `unsloth/__init__.py:1402-1410`, so distillation was unreachable on Apple Silicon. Requested in unslothai/unsloth#3008 and #1941.
 
New `unsloth_zoo/mlx/distill.py`, one branch at `trainer.py`'s loss-selection site, and five config fields appended last. With `teacher_model_name_or_path = None` everything stays inert.
 
## Verified pairs
 
Teacher and student must share a tokenizer:
 
| student ← teacher | widths | tokenizers agree |
|---|---|---|
| Qwen2.5-0.5B ← Qwen2.5-3B | 151936 | yes |
| Llama-3.2-1B ← Llama-3.2-3B | 128256 | yes |
| Qwen3-0.6B ← Qwen2.5-3B | 151936 | yes — spans generations |
| Llama-3.2-1B ← Qwen2.5-3B | mismatch | no |
 
Width equality alone is **not** sufficient: two checkpoints can share a vocab size and still encode differently, which would silently train against misaligned targets. The guard compares probe-encoded ids as well as width, and raises naming both vocab sizes. Cross-family distillation needs token remapping, which is not implemented here.
 
## The envelope, stated plainly
 
With a 3B teacher on 16 GB, roughly **B×L ≤ 1024 tokens** — one sequence of 1024, or two of 512.
 
| B | L | tokens | teacher logit buffer | chunked peak | unchunked peak |
|---|---|---|---|---|---|
| 1 | 512 | 512 | 0.29 GB | 6.59 GB | 7.47 GB |
| 2 | 512 | 1024 | 0.58 GB | 10.01 GB | 12.05 GB |
| 1 | 1024 | 1024 | 0.58 GB | — | 12.17 GB |
| 2 | 1024 | 2048 | 1.16 GB | 15.29 GB | 17.39 GB — crashes |
| 4 | 512 | 2048 | 1.16 GB | — | 17.16 GB — crashes |
 
These are peaks under a real LoRA training step, including optimizer state and `mx.compile`. They supersede earlier forward+backward-only figures.
 
## Why the preflight is mandatory
 
An oversized batch does not raise a catchable OOM. It aborts with `[METAL] Command buffer execution failed: Impacting Interactivity` and wedges the GPU context for subsequent runs.
 
So a preflight estimates peak from batch × sequence × vocab width up front and raises an ordinary error naming the requested B×L, the estimated peak, the detected system memory, and the largest B×L that fits. Calibration against the integrated path is conservative in the safe direction: predicted 6.65 vs measured 6.59 GB, predicted 10.42 vs measured 10.01 GB.
 
`gkd_skip_memory_preflight = True` bypasses it, emitting a warning that names the estimate, the budget, and the wedge risk — for users with more headroom than the estimator assumes.
 
The loss is chunked by default (B=2/L=1024: 17.39 → 15.29 GB). Unchunked is reachable only for the equivalence test.
 
## Off-policy only
 
`gkd_lmbda != 0` is rejected with a message: on-policy GKD needs generation inside the training loop, and `trainer.py` has no such path (`generate` appears zero times in it; all generation lives in `loader.py` as inference shims).
 
## Tested — 34 tests
 
Loss falls over 8 steps and KL to the teacher measurably falls, at β ∈ {0, 0.5, 1}; chunked equals unchunked in both value and gradients; self-distillation ≈ 0; label masking honoured (fully-masked → exactly 0.0); `mx.compile` bit-identical; preflight fires at the thresholds above and the override bypasses it; the teacher has 0 trainable params, 0 gradients, 0 optimizer-state entries, and is absent from compile-traced state.
 
Full zoo suite run twice per side: 2979 → 3013, delta 34 = the tests added. No regressions, no environment writes.
 
Two test files on purpose: the numeric tests need real `mx.quantize`/MLX, so a single file would skip entirely on Linux CI and be a gate no-op (#669/#739). The guard, config and preflight tests run under the existing torch shim and execute in the behavioral-gates step.
 
**Note for future MLX tests in this repo:** the numeric tests bind `mlx.core` at module import, not inside functions. The repo's `mlx_simulation` shim replaces `sys.modules["mlx.core"]` session-wide, so a function-level `import mlx.core` silently resolves against the stub — tests then pass against a stub while looking clean standalone. This was caught only by a full-suite run.