### PR TITLE
feat(mlx): audio-input training for VLM SFT, behind a per-family gate

### DIFF
--- a/tests/test_mlx_batching_and_decay.py
+++ b/tests/test_mlx_batching_and_decay.py
@@ -577,6 +577,35 @@ def test_vlm_family_invariant_against_live_mx_compile_traces():
     assert family({"t": Point(1, 2)}) != family({"t": (1, 2)})
 
 
+def test_per_row_audio_spans_stay_plannable():
+    """Spans are carried one array per row, since rows hold different clip
+    counts and stacking them raises. Leaving them as host arrays would describe
+    every batch of the family as opaque, sending it to eager and making a
+    strict run raise -- text-only batches of that family included."""
+    _skip_if_mlx_core_was_replaced()
+    from unsloth_zoo.mlx.utils import (
+        _to_mx_vlm_batch,
+        _vlm_batch_family as family,
+        _vlm_family_is_plannable as plannable,
+    )
+
+    cases = [
+        ([np.zeros((0, 2), np.int32)] * 2, [[], []]),         # a text-only batch
+        ([np.array([[1, 3]]), np.array([[1, 3], [4, 7]])],
+         [[[1, 3]], [[1, 3], [4, 7]]]),
+    ]
+    for spans, expected in cases:
+        batch = _to_mx_vlm_batch({
+            "input_ids": np.zeros((2, 8), dtype=np.int32),
+            "audio_bounds": spans,
+        })
+        # Both halves matter here: the generic conversion also yields something
+        # plannable, by stacking equal rows and keeping only the first of ragged
+        # ones, so plannability alone would not show the rows survived.
+        assert [np.asarray(row).tolist() for row in batch["audio_bounds"]] == expected
+        assert plannable(family(batch))
+
+
 class _VarWidthProcessor(_CountingProcessor):
     """Batch width AND structure follow content: different scheduled
     batches produce genuinely distinct families even after the text axis

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -564,3 +564,32 @@ def test_streaming_audio_is_detected_without_consuming_the_stream():
     assert peek(None) == (False, None)
     carries, stream = peek(iter(()))
     assert carries is False and list(stream) == []
+
+
+def test_a_streamed_batch_that_turns_out_to_carry_audio_leaves_the_compiled_path():
+    """The peek sees one batch, so a text-first stream plans as compilable.
+    Every later batch is therefore asked directly: without this the audio batch
+    reaches the compiled step, and a strict run aborts only after earlier
+    optimizer updates rather than up front."""
+    import numpy as np
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+    from unsloth_zoo.mlx.utils import FiniteVLMBatchPlan
+
+    leaves = MLXTrainer._streamed_audio_leaves_the_compiled_path
+    audio_batch = {"input_features": np.zeros((1, 8, 4), np.float32)}
+    plain_batch = {"pixel_values": np.zeros((1, 3, 4, 4), np.float32)}
+
+    assert leaves(audio_batch, None) is True
+    assert leaves(plain_batch, None) is False
+    # Loaders that yield (batch, extras): audio lives in the first element.
+    assert leaves((audio_batch, {"step": 3}), None) is True
+
+    # An empty payload is how some processors report "no audio here"; reading
+    # it as audio would drop every text batch on that checkpoint to eager.
+    assert leaves({"input_features": np.zeros((0, 8, 0), np.float32)}, None) is False
+
+    # A finite plan was surveyed whole and routed by `carries_audio_in`, so
+    # re-deciding per batch here would fight that routing.
+    plan = FiniteVLMBatchPlan.__new__(FiniteVLMBatchPlan)
+    assert leaves(audio_batch, plan) is False

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -453,6 +453,15 @@ def _audio_plan_stub():
             assert self.surveyed, "routing must survey before asking"
             return True
 
+        # Routing asks only about the batches the schedule executes, so the
+        # stub has to answer for a visit as well as for the whole plan.
+        def batch_index_for_visit(self, absolute_visit):
+            return 0
+
+        def carries_audio_in(self, indices):
+            assert self.surveyed, "routing must survey before asking"
+            return 0 in set(indices)
+
     return _Stub()
 
 
@@ -483,6 +492,59 @@ def test_audio_runs_route_eager_before_every_other_exit():
 
     with pytest.raises(RuntimeError, match="cannot plan audio training"):
         _plan(_audio_plan_stub(), mode="strict")
+
+
+def test_carries_audio_in_answers_only_for_the_batches_named():
+    from unsloth_zoo.mlx.utils import FiniteVLMBatchPlan
+
+    plan = FiniteVLMBatchPlan.__new__(FiniteVLMBatchPlan)
+    plan._audio_flags = (False, False, True)     # audio only in the trailing batch
+    assert plan.carries_audio() is True
+    assert plan.carries_audio_in([0, 1]) is False
+    assert plan.carries_audio_in([0, 1, 2]) is True
+    assert plan.carries_audio_in([]) is False
+    assert plan.carries_audio_in([7]) is False   # out of range, not an IndexError
+
+    plan._audio_flags = None
+    with pytest.raises(RuntimeError, match="have not been surveyed"):
+        plan.carries_audio_in([0])
+
+
+def test_audio_routing_asks_only_about_executed_batches():
+    """A ragged epoch drops its trailing micro-batches. Audio only in that tail
+    reaches no compiled call, so it must not degrade the run to eager or abort
+    strict mode -- the same rule the family admission below it already follows."""
+    from unsloth_zoo.mlx.utils import FiniteVLMBatchPlan
+
+    class _StopPlanning(Exception):
+        """Stops the planner right after the routing decision, so this test
+        depends on the decision alone and not on the rest of the stub."""
+
+    class _Spy(FiniteVLMBatchPlan):
+        def __init__(self):
+            self.asked_about = None
+
+        def __len__(self):
+            return 2
+
+        def ensure_descriptors(self):
+            pass
+
+        def carries_audio(self):               # whole-plan: batch 1 has audio
+            raise AssertionError("routing must not ask the whole plan")
+
+        def batch_index_for_visit(self, absolute_visit):
+            return 0                           # the schedule only visits batch 0
+
+        def carries_audio_in(self, indices):
+            self.asked_about = sorted(indices)
+            raise _StopPlanning
+
+    for mode in ("best_effort", "strict"):
+        spy = _Spy()
+        with pytest.raises(_StopPlanning):
+            _plan(spy, mode=mode)
+        assert spy.asked_about == [0], mode
 
 
 def test_streaming_audio_is_detected_without_consuming_the_stream():

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -20,6 +20,18 @@ from unsloth_zoo.mlx.shape_guard import (
 )
 
 
+def _requires_mlx():
+    """Skip a test that reaches `unsloth_zoo.mlx.{utils,trainer}`.
+
+    Both import `mlx.core` at module scope. The rest of this file is pure
+    shape planning against `unsloth_zoo.mlx.shape_guard`, which has no such
+    dependency, so the module keeps running where mlx is not installed --
+    every Linux and Windows CI environment. Without the guard those tests
+    turn a passing module into failures rather than skips.
+    """
+    pytest.importorskip("mlx.core")
+
+
 def _event(family, width, phase="p", frequency=1, batch_size=1):
     return TextShapeEvent(family, width, phase, frequency, batch_size)
 
@@ -428,6 +440,7 @@ def test_shared_cap_materialization_preserves_both_padding_budgets():
 
 def test_audio_feature_batches_are_detected_for_eager_routing():
     """Audio feature extents follow clip duration, so they cannot be planned."""
+    _requires_mlx()
     from unsloth_zoo.mlx.utils import _vlm_batch_carries_audio
 
     for batch in ({"input_features": object()}, {"input_audio_embeds": object()}):
@@ -482,6 +495,7 @@ def _plan(batches, mode="best_effort", batch_iter=None, carries_audio=None):
 
 
 def test_audio_runs_route_eager_before_every_other_exit():
+    _requires_mlx()
 
     _, report, compile_allowed, _ = _plan(_audio_plan_stub())
     assert compile_allowed is False and report.reason == "vlm_audio_inputs"
@@ -495,6 +509,7 @@ def test_audio_runs_route_eager_before_every_other_exit():
 
 
 def test_carries_audio_in_answers_only_for_the_batches_named():
+    _requires_mlx()
     from unsloth_zoo.mlx.utils import FiniteVLMBatchPlan
 
     plan = FiniteVLMBatchPlan.__new__(FiniteVLMBatchPlan)
@@ -514,6 +529,7 @@ def test_audio_routing_asks_only_about_executed_batches():
     """A ragged epoch drops its trailing micro-batches. Audio only in that tail
     reaches no compiled call, so it must not degrade the run to eager or abort
     strict mode -- the same rule the family admission below it already follows."""
+    _requires_mlx()
     from unsloth_zoo.mlx.utils import FiniteVLMBatchPlan
 
     class _StopPlanning(Exception):
@@ -548,6 +564,7 @@ def test_audio_routing_asks_only_about_executed_batches():
 
 
 def test_streaming_audio_is_detected_without_consuming_the_stream():
+    _requires_mlx()
     from unsloth_zoo.mlx.trainer import MLXTrainer
 
     peek = MLXTrainer._peek_stream_carries_audio
@@ -571,6 +588,7 @@ def test_a_streamed_batch_that_turns_out_to_carry_audio_leaves_the_compiled_path
     Every later batch is therefore asked directly: without this the audio batch
     reaches the compiled step, and a strict run aborts only after earlier
     optimizer updates rather than up front."""
+    _requires_mlx()
     import numpy as np
 
     from unsloth_zoo.mlx.trainer import MLXTrainer

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -437,7 +437,6 @@ def test_audio_feature_batches_are_detected_for_eager_routing():
 
 
 def _audio_plan_stub():
-    """Finite plan reporting audio once surveyed."""
     from unsloth_zoo.mlx.utils import FiniteVLMBatchPlan
 
     class _Stub(FiniteVLMBatchPlan):
@@ -474,7 +473,6 @@ def _plan(batches, mode="best_effort", batch_iter=None, carries_audio=None):
 
 
 def test_audio_runs_route_eager_before_every_other_exit():
-    """Audio decides routing ahead of streaming and clip-eligibility exits."""
 
     _, report, compile_allowed, _ = _plan(_audio_plan_stub())
     assert compile_allowed is False and report.reason == "vlm_audio_inputs"
@@ -488,7 +486,6 @@ def test_audio_runs_route_eager_before_every_other_exit():
 
 
 def test_streaming_audio_is_detected_without_consuming_the_stream():
-    """Routing peeks one batch and chains it back, so nothing is lost."""
     from unsloth_zoo.mlx.trainer import MLXTrainer
 
     peek = MLXTrainer._peek_stream_carries_audio

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -583,6 +583,42 @@ def test_streaming_audio_is_detected_without_consuming_the_stream():
     assert carries is False and list(stream) == []
 
 
+def test_the_peeked_stream_still_closes_the_producer_behind_it():
+    """The peek hands the run a wrapper, and the run's cleanup closes what it
+    was handed. A wrapper with no close of its own therefore ends the run with
+    the producer -- and the files, workers and buffers it holds -- still open."""
+    _requires_mlx()
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    def producer(batches):
+        try:
+            for batch in batches:
+                yield batch
+        finally:
+            closed.append(True)
+
+    for consumed in (0, 1, 3):
+        closed = []
+        _, stream = MLXTrainer._peek_stream_carries_audio(
+            producer([{"pixel_values": index} for index in range(3)])
+        )
+        for _, _batch in zip(range(consumed), stream):
+            pass
+
+        trainer = object.__new__(MLXTrainer)
+        trainer._active_batch_iter = stream
+        trainer._close_active_batch_iterator()
+        assert closed, f"the producer outlived the run ({consumed} consumed)"
+
+    # An exhausted source is still the run's to close, and a stream nobody
+    # peeked -- there is none -- is still reported as nothing to close.
+    closed = []
+    _, stream = MLXTrainer._peek_stream_carries_audio(producer([]))
+    stream.close()
+    assert closed
+    assert MLXTrainer._peek_stream_carries_audio(None) == (False, None)
+
+
 def test_a_streamed_batch_that_turns_out_to_carry_audio_leaves_the_compiled_path():
     """The peek sees one batch, so a text-first stream plans as compilable.
     Every later batch is therefore asked directly: without this the audio batch

--- a/tests/test_mlx_shape_guard.py
+++ b/tests/test_mlx_shape_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import random
+import types
 
 import pytest
 
@@ -423,3 +424,84 @@ def test_shared_cap_materialization_preserves_both_padding_budgets():
     assert shared.report.padding_work_fraction <= 0.05
     assert shared.report.max_width_stretch <= 1.5
     assert shared.report.budget_satisfied is True
+
+
+def test_audio_feature_batches_are_detected_for_eager_routing():
+    """Audio feature extents follow clip duration, so they cannot be planned."""
+    from unsloth_zoo.mlx.utils import _vlm_batch_carries_audio
+
+    for batch in ({"input_features": object()}, {"input_audio_embeds": object()}):
+        assert _vlm_batch_carries_audio(batch) is True
+    for batch in ({"pixel_values": object()}, {"input_features": None}, None):
+        assert _vlm_batch_carries_audio(batch) is False
+
+
+def _audio_plan_stub():
+    """Finite plan reporting audio once surveyed."""
+    from unsloth_zoo.mlx.utils import FiniteVLMBatchPlan
+
+    class _Stub(FiniteVLMBatchPlan):
+        def __init__(self):
+            self.surveyed = False
+
+        def __len__(self):
+            return 1
+
+        def ensure_descriptors(self):
+            self.surveyed = True
+
+        def carries_audio(self):
+            assert self.surveyed, "routing must survey before asking"
+            return True
+
+    return _Stub()
+
+
+def _plan(batches, mode="best_effort", batch_iter=None, carries_audio=None):
+    from unsloth_zoo.mlx import trainer as T
+
+    ns = types.SimpleNamespace
+    return T._plan_single_process_vlm_shapes(
+        batches, batch_iter,
+        args=ns(compile_max_variants=None, gradient_accumulation_steps=1,
+                max_grad_norm=0.0, max_grad_value=None),
+        total_steps=1, distributed_world_size=1,
+        compile_policy=ns(mode=mode),
+        compile_decision=ns(enabled=True, policy_mode=mode, should_raise=False,
+                            arch="gemma3n", reason="qualified"),
+        install_plan=False, carries_audio=carries_audio,
+    )
+
+
+def test_audio_runs_route_eager_before_every_other_exit():
+    """Audio decides routing ahead of streaming and clip-eligibility exits."""
+
+    _, report, compile_allowed, _ = _plan(_audio_plan_stub())
+    assert compile_allowed is False and report.reason == "vlm_audio_inputs"
+    # Streaming: the caller's flag must win over the streaming exit.
+    _, report, compile_allowed, _ = _plan(None, batch_iter=iter(()),
+                                          carries_audio=True)
+    assert compile_allowed is False and report.reason == "vlm_audio_inputs"
+
+    with pytest.raises(RuntimeError, match="cannot plan audio training"):
+        _plan(_audio_plan_stub(), mode="strict")
+
+
+def test_streaming_audio_is_detected_without_consuming_the_stream():
+    """Routing peeks one batch and chains it back, so nothing is lost."""
+    from unsloth_zoo.mlx.trainer import MLXTrainer
+
+    peek = MLXTrainer._peek_stream_carries_audio
+    audio_batch = {"input_features": object()}
+    plain_batch = {"pixel_values": object()}
+
+    carries, stream = peek(iter([audio_batch, plain_batch]))
+    assert carries is True and list(stream) == [audio_batch, plain_batch]
+
+    # Only the first batch is observable ahead of the run.
+    carries, stream = peek(iter([plain_batch, audio_batch]))
+    assert carries is False and list(stream) == [plain_batch, audio_batch]
+
+    assert peek(None) == (False, None)
+    carries, stream = peek(iter(()))
+    assert carries is False and list(stream) == []

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2297,6 +2297,42 @@ def test_fixed_budget_families_reject_shortened_runs(monkeypatch):
         _finalized_collate([_audio_row(_CLIP)], processor, 4, None)
 
 
+def test_processors_taking_audio_pairs_are_accommodated(monkeypatch):
+    """Some processors want (samples, rate) pairs and reject add_special_tokens."""
+    class _PairsOnly(_FakeGemmaAudioProcessor):
+        """Takes (samples, rate) pairs and no add_special_tokens, like phi4mm.
+
+        It also exposes no sampling rate of its own, so the only source for the
+        pair's rate is the one extraction verified on the clip.
+        """
+        feature_extractor = None
+        seen = {}
+
+        def __call__(self, text, audio=None, padding=True, return_tensors="np",
+                     truncation=False, max_length=None):
+            # Accepts neither add_special_tokens nor padding_side, like phi4mm.
+            self.seen["pairs"] = [isinstance(c, tuple) for c in (audio or [])]
+            if audio and not all(self.seen["pairs"]):
+                raise ValueError("too many values to unpack (expected 2)")
+            self.seen["rates"] = [r for _, r in (audio or [])]
+            return _FakeGemmaAudioProcessor.__call__(
+                self, text, [s for s, _ in (audio or [])], max_length)
+
+    processor = _PairsOnly()
+    _qualify(monkeypatch, processor=processor)
+    batch = _finalized_collate([_audio_row(_CLIP)], processor, 16, None)
+    assert "input_features" in batch
+    # The paired form is retried with the rate extraction verified.
+    assert processor.seen["pairs"] == [True] and processor.seen["rates"] == [16000]
+    # Prompt/completion also sends padding_side: one-at-a-time recovery fails.
+    pc_row = {"prompt": _audio_row(_CLIP)["messages"][:1],
+              "completion": [{"role": "assistant", "content": "ok"}]}
+    batch, is_pc = _finalized_collate([pc_row], processor, 16, None,
+                                      return_prompt_completion=True)
+    assert is_pc and "input_features" in batch
+
+
+
 def test_placeholders_without_features_are_rejected(monkeypatch):
     _qualify(monkeypatch)
     # Pre-rendered text can keep the placeholder after the clip is gone.

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2165,18 +2165,17 @@ def _qualify(monkeypatch, processor=None, version=None):
         {version or mlx_utils._installed_mlx_vlm_version()})})
 
 
-@pytest.mark.parametrize("setup,message", [
-    (None, "not enabled for any model family"),
-    ("other_family", "is not supported for"),
-    ("other_version", "only been verified"),
+@pytest.mark.parametrize("gate,message", [
+    ({}, "not enabled for any model family"),
+    ({"otherfam": frozenset({"9.9.9"})}, "is not supported for"),
+    (None, "only been verified"),
 ])
-def test_audio_gate_refuses_unverified_family_or_version(monkeypatch, setup, message):
-    if setup == "other_family":
-        from unsloth_zoo.mlx import utils as mlx_utils
-        monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES",
-                            {"otherfam": frozenset({"9.9.9"})})
-    elif setup:
+def test_audio_gate_refuses_unverified_family_or_version(monkeypatch, gate, message):
+    from unsloth_zoo.mlx import utils as mlx_utils
+    if gate is None:  # this family, but a version nothing was probed on
         _qualify(monkeypatch, version="0.0.1-never")
+    else:
+        monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES", gate)
     with pytest.raises(NotImplementedError, match=message):
         _finalized_collate([_audio_row(_CLIP)], _FakeGemmaAudioProcessor(), 16, None)
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1995,3 +1995,106 @@ def test_paligemma_token_types_do_not_cross_between_concurrent_callers():
     for name, mark in marks.items():
         assert _Model.seen[name] is mark, f"{name} saw another caller's batch"
     assert _paligemma_pending_token_types() is None
+
+
+# --- gemma3n: AltUp correction at batch sizes above one ---------------------
+
+
+def _broken_altup(mx_, hidden=4, inputs=3):
+    """A stand-in shaped like the AltUp whose correction assumes a batch of one."""
+    from types import SimpleNamespace
+
+    class _Coefs:  # callable like the real nn.Linear, with a weight to clip
+        weight = mx_.zeros((inputs, hidden), dtype=mx_.float32)
+
+        def __call__(self, modalities):
+            return mx_.zeros((*modalities.shape[:-1], inputs), dtype=mx_.float32)
+
+    class _Altup:
+        config = SimpleNamespace(hidden_size=hidden, altup_num_inputs=inputs,
+                                 altup_coef_clip=None, altup_active_idx=0)
+        correction_coefs = _Coefs()
+
+        def compute_router_modalities(self, x):
+            return x
+
+        def correct(self, predictions, activated):
+            all_coefs = mx_.ones((*activated.shape[:-1], inputs), dtype=mx_.float32)
+            innovation = activated - predictions[self.config.altup_active_idx]
+            # The batch axis is treated as though it were last.
+            all_coefs = all_coefs.transpose(2, 1, 0)
+            corrected = innovation[None] * all_coefs[:, None]
+            corrected += predictions
+            return corrected.astype(activated.dtype)
+
+    return _Altup
+
+
+def test_gemma3n_altup_correction_survives_a_batch_larger_than_one():
+    """Upstream transposes its coefficients as though the batch axis were last,
+    which only broadcasts when the batch is one."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import (
+        _VLM_MODEL_FIXUPS, _altup_correct_handles_batch, _fix_gemma3n_altup_batch,
+    )
+
+    assert _fix_gemma3n_altup_batch in _VLM_MODEL_FIXUPS
+
+    mx_ = _utils_mx()
+    # Distinct batch and sequence, or transposing the two would look the same.
+    hidden, inputs, seq, rows = 4, 3, 5, 2
+    cls = _broken_altup(mx_, hidden, inputs)
+    altup = cls()
+    assert not _altup_correct_handles_batch(altup), "fixture should start broken"
+
+    upstream_correct = cls.correct
+    model = SimpleNamespace(language_model=SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(altup=altup)])))
+    assert _fix_gemma3n_altup_batch(model)
+    assert _altup_correct_handles_batch(altup)
+
+    # Rows are independent, so a batch must equal the rows corrected separately.
+    rng = np.random.default_rng(0)
+    activated = mx_.array(
+        rng.normal(size=(rows, seq, hidden)).astype(np.float32))
+    # Non-zero, or subtracting the active prediction would not be observable.
+    predictions = mx_.array(
+        rng.normal(size=(inputs, rows, seq, hidden)).astype(np.float32))
+    both = np.asarray(altup.correct(predictions, activated))
+    assert both.shape == (inputs, rows, seq, hidden)
+    for row in range(rows):
+        one = np.asarray(altup.correct(
+            predictions[:, row:row + 1], activated[row:row + 1]))
+        assert np.allclose(both[:, row:row + 1], one, atol=1e-5), \
+            f"row {row} differs when corrected in a batch"
+
+    # The formula stays upstream's. At a batch of one, where upstream is
+    # already right, the replacement has to reproduce it exactly.
+    one_act, one_pred = activated[:1], predictions[:, :1]
+    assert np.allclose(np.asarray(altup.correct(one_pred, one_act)),
+                       np.asarray(upstream_correct(altup, one_pred, one_act)),
+                       atol=1e-6), "the replacement changed the correction itself"
+
+
+def test_gemma3n_altup_patch_declines_a_release_that_is_already_correct():
+    """Upstream repaired this in 0.5.0, so the backport must leave it alone."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import (
+        _altup_correct_handles_batch, _fix_gemma3n_altup_batch,
+    )
+
+    mx_ = _utils_mx()
+    cls = _broken_altup(mx_)
+
+    def fixed(self, predictions, activated):
+        all_coefs = (self.correction_coefs(activated) + 1.0)
+        all_coefs = all_coefs.transpose(2, 0, 1)[..., None]
+        return (activated - predictions[0])[None] * all_coefs + predictions
+
+    cls.correct = fixed
+    altup = cls()
+    assert _altup_correct_handles_batch(altup)
+    model = SimpleNamespace(language_model=SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(altup=altup)])))
+    assert not _fix_gemma3n_altup_batch(model)
+    assert cls.correct is fixed, "an already-correct release must be left alone"

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1743,6 +1743,40 @@ def test_baseline_loss_fn_forwards_real_shared_kv_slots():
     assert caches[0].state == (keys, values)
 
 
+def test_a_natively_shared_backbone_gets_no_legacy_slots():
+    """mlx-vlm 0.5.0+ threads shared K/V itself, so `_fix_gemma4_kv_sharing`
+    leaves those backbones alone and they keep the ordinary per-layer cache
+    contract. The legacy slot list is shorter than the layer count by
+    construction -- `first_kv_shared_layer_idx` is
+    `num_hidden_layers - num_kv_shared_layers` -- so forwarding it as `cache`
+    truncates the zip over layers and silently drops the shared tail."""
+    from types import SimpleNamespace
+
+    from unsloth_zoo.mlx.utils import _build_shared_kv_caches
+
+    def _model(layers, shared, native):
+        backbone = SimpleNamespace(
+            layers=[object() for _ in range(layers)],
+            config=SimpleNamespace(num_kv_shared_layers=shared,
+                                   model_type="gemma4_text"),
+            first_kv_shared_layer_idx=layers - shared,
+        )
+        if native:                       # the marker mlx-vlm 0.5.0+ exposes
+            backbone.previous_kvs = [None] * layers
+        return SimpleNamespace(language_model=SimpleNamespace(model=backbone))
+
+    # Native: no slots at all, so `cache` stays unset and every layer runs.
+    assert _build_shared_kv_caches(_model(4, 2, native=True)) is None
+
+    # Legacy backbones still get exactly one slot per producer layer.
+    legacy = _build_shared_kv_caches(_model(4, 2, native=False))
+    assert legacy is not None and len(legacy) == 2
+
+    # And a stack that shares nothing is unaffected either way.
+    assert _build_shared_kv_caches(_model(4, 0, native=False)) is None
+    assert _build_shared_kv_caches(_model(4, 0, native=True)) is None
+
+
 # --- gemma3n: the ids-path embedding scale a merge leaves off ---------------
 
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1720,3 +1720,24 @@ def test_collation_does_not_require_a_pad_id(honours_side):
     assert mask[:, 0].tolist() == [1, 1] and (ids[mask == 0] == 0).all()
 
 
+# --- KV-shared layers borrow their K/V through the cache --------------------
+
+
+def test_baseline_loss_fn_forwards_real_shared_kv_slots():
+    # Slots, not placeholders, and one per producer: a list of Nones forwards
+    # the same shape while every shared layer rebuilds K/V from its own
+    # projections, and one slot repeated leaves them all reading the last.
+    from unsloth_zoo.mlx.utils import _SharedKVSlot
+
+    seen, _batch = _run_loss("gemma4", kv_shared=20)
+    caches = seen["cache"]
+    assert caches is not None and len(caches) == 15
+    assert all(isinstance(c, _SharedKVSlot) for c in caches)
+    assert len({id(c) for c in caches}) == 15
+    keys, values = object(), object()
+    # The producer stores through `update_and_fetch`, shared layers read `state`.
+    assert caches[0].offset == 0 and caches[0].borrow() is None
+    assert caches[0].update_and_fetch(keys, values) == (keys, values)
+    assert caches[0].state == (keys, values)
+
+

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1741,3 +1741,41 @@ def test_baseline_loss_fn_forwards_real_shared_kv_slots():
     assert caches[0].state == (keys, values)
 
 
+# --- gemma3n: the ids-path embedding scale a merge leaves off ---------------
+
+
+def _scale_probe(model_type, hidden_size=16):
+    """Middle position carries a merged feature; the others are plain tokens."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx import utils
+
+    mx_ = _utils_mx()
+    # Every position shares one token id, so an id-based mask cannot tell the
+    # feature-carrying position from the plain ones -- only a difference can.
+    ids = mx_.array([[7, 7, 7]], dtype=mx_.int32)
+    raw = mx_.ones((1, 3, hidden_size), dtype=mx_.float32)
+
+    class _Backbone:
+        config = SimpleNamespace(model_type=model_type, hidden_size=hidden_size)
+        def embed_tokens(self, _ids): return raw
+
+    merged = mx_.concatenate(
+        [raw[:, :1], mx_.full((1, 1, hidden_size), 9.0), raw[:, 2:]], axis=1)
+    out = utils._apply_vlm_embed_scale(
+        SimpleNamespace(language_model=SimpleNamespace(model=_Backbone())),
+        ids, merged)
+    return np.asarray(out)[0], hidden_size ** 0.5
+
+
+@pytest.mark.parametrize("model_type,scaled", [
+    ("gemma3n_text", True),
+    # gemma3_text is compensated for in `_run_hidden_stack`, the route it takes,
+    # so scaling it here would apply the factor twice.
+    ("qwen2_vl", False), ("gemma3_text", False), ("gemma4_text", False),
+])
+def test_embed_scale_lifts_only_gemma3n_plain_tokens(model_type, scaled):
+    out, scale = _scale_probe(model_type)
+    assert out[0][0] == pytest.approx(scale if scaled else 1.0)
+    assert out[2][0] == pytest.approx(scale if scaled else 1.0)
+    # Merged features already carry the scaled magnitude; rescaling inflates.
+    assert out[1][0] == pytest.approx(9.0)

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2405,3 +2405,114 @@ def test_deferred_prompt_completion_staging_rechecks_audio_runs(monkeypatch):
     # Truncation drops the run; the deferred check must catch it.
     with pytest.raises(ValueError, match="0 placeholder run"):
         _finalize_vlm_batch(staged)
+
+
+def test_audio_merge_compacts_valid_features_per_row():
+    """Padded rows must not spill their tails into the next row's placeholders."""
+    import mlx.core as mx_
+    from unsloth_zoo.mlx.utils import _compact_audio_features
+
+    embeds = mx_.array([[[1.0], [2.0], [9.0]], [[3.0], [4.0], [5.0]]])
+    padded = mx_.array([[False, False, True], [False, False, False]])
+    # Row 0 keeps 2 of 3 positions, row 1 keeps 3: the compacted source is the
+    # valid ones in row order, so the merge's running count lines up again.
+    out = _compact_audio_features(embeds, padded, [2, 3])
+    assert out.flatten().tolist() == [1.0, 2.0, 3.0, 4.0, 5.0]
+    # Each row must come out exact: [2, 3] clips against [3, 2] rows sums to
+    # five either way while everything after the first position is mispaired.
+    with pytest.raises(ValueError, match="cannot be paired for this row"):
+        _compact_audio_features(embeds, padded, [3, 2])
+    with pytest.raises(ValueError, match="cannot be paired for this row"):
+        _compact_audio_features(embeds, padded, [2, 4])
+
+
+def test_qualified_families_carry_their_probed_requirements():
+    """The shipped gate names the families whose probes actually ran."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    gate = mlx_utils._AUDIO_QUALIFIED_FAMILIES
+    # Exact versions: a stray one would enable code no probe ran against.
+    assert gate == {
+        "gemma3n": frozenset({"0.4.4"}),
+        "gemma4": frozenset({"0.4.4"}),
+        "phi4mm": frozenset({"0.4.4"}),
+    }
+    # Gemma 4 was probed only on a newer transformers; this env pins an older.
+    gemma4_like = type("Proc", (), {})
+    gemma4_like.__module__ = "mlx_vlm.models.gemma4.processing_gemma4"
+    assert mlx_utils._audio_family_from_processor(gemma4_like()) == "gemma4"
+    with pytest.raises(NotImplementedError, match="transformers"):
+        mlx_utils._check_audio_family_gate(gemma4_like())
+    mlx_utils._check_audio_transformers_floor("gemma3n")  # no floor recorded
+
+
+def test_audio_merge_patch_is_held_and_restored_exactly():
+    """Overlapping runs share the correction; the last one puts it back."""
+    from unsloth_zoo.mlx.utils import (
+        install_audio_merge_patch, remove_audio_merge_patch,
+    )
+
+    class _Model:
+        def get_input_embeddings(self, *a, **k):
+            return "class method"
+
+    model = _Model()
+    original = model.get_input_embeddings
+    # Every caller taking a hold is told so, and releases exactly one.
+    assert install_audio_merge_patch(model, 1) is True
+    assert install_audio_merge_patch(model, 1) is True    # second holder
+    assert remove_audio_merge_patch(model) is False       # first release
+    assert model.get_input_embeddings.__name__ == "patched"
+    assert remove_audio_merge_patch(model) is True        # last release
+    assert model.get_input_embeddings() == original()
+    assert remove_audio_merge_patch(model) is False
+
+    # Someone else's instance-level wrapper must survive.
+    model.get_input_embeddings = lambda *a, **k: "instance wrapper"
+    install_audio_merge_patch(model, 1)
+    remove_audio_merge_patch(model)
+    assert model.get_input_embeddings() == "instance wrapper"
+
+
+
+def test_patched_audio_merge_places_each_row_own_features():
+    """The correction must actually re-pair features, not just wrap the call."""
+    import mlx.core as current_mx
+    if current_mx is not mx:
+        pytest.skip("requires real MLX runtime without mlx_simulation monkeypatch")
+    mx_ = mx
+    from unsloth_zoo.mlx.utils import (
+        install_audio_merge_patch, remove_audio_merge_patch,
+    )
+
+    embed_dim, token = 1, 7
+
+    class _Tower:
+        def __call__(self, features, padding):
+            # Row 0 has one valid frame, row 1 two; the tail is what leaks.
+            return features, mx_.array([[False, True], [False, False]])
+
+    class _Model:
+        audio_tower = _Tower()
+        embed_audio = staticmethod(lambda x: x)
+
+        def get_input_embeddings(self, input_ids=None, pixel_values=None, **kw):
+            # Text embeddings carry the model dtype; audio arrives wider.
+            return mx_.zeros((*input_ids.shape, embed_dim), dtype=mx_.bfloat16)
+
+    model = _Model()
+    install_audio_merge_patch(model, token)
+    try:
+        # Row 0 wants 1 placeholder, row 1 wants 2.
+        features = mx_.array([[[1.0], [99.0]], [[2.0], [3.0]]], dtype=mx_.float32)
+        ids = mx_.array([[token, 0], [token, token]])
+        out = model.get_input_embeddings(
+            input_ids=ids, input_features=features,
+            input_features_mask=mx_.array([[True, False], [True, True]]),
+        )
+        # 99.0 is padding: it must not appear; row 1 keeps its own values.
+        assert out.flatten().tolist() == [1.0, 0.0, 2.0, 3.0]
+        # Merging must not widen the LM input dtype.
+        assert out.dtype == mx_.bfloat16
+    finally:
+        remove_audio_merge_patch(model)

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1823,8 +1823,14 @@ def _baseline_scale_model(model_type, hidden_size=16):
     `Model.__call__` sends ids through `get_input_embeddings`, which embeds
     without the sqrt(hidden_size) factor the language stack applies on the ids
     path; the stack then takes the `inputs_embeds` branch and never applies it.
-    Recording what the forward receives is the only way to see which route the
-    loss backend took.
+    Recording what the language model receives is the only way to see which
+    route the loss backend took.
+
+    The outer `__call__` here is mlx-vlm 0.4.4's -- the floor this package
+    declares -- which re-embeds from ids and discards a supplied
+    `inputs_embeds`. 0.5.0 onwards forwards it straight to the language model
+    instead. Modelling the older one is what makes the rescale observable:
+    routed through this outer call the factor is silently dropped.
     """
     from types import SimpleNamespace
 
@@ -1836,8 +1842,18 @@ def _baseline_scale_model(model_type, hidden_size=16):
         def embed_tokens(self, ids):
             return mx_.ones((*ids.shape, hidden_size), dtype=mx_.float32)
 
+    class _LanguageModel:
+        model = _Backbone()
+
+        def __call__(self, inputs=None, inputs_embeds=None, **kwargs):
+            seen["forwarded"] = inputs_embeds
+            seen["kwargs"] = kwargs
+            width = (inputs_embeds if inputs_embeds is not None else inputs).shape[1]
+            return SimpleNamespace(
+                logits=mx_.zeros((1, width, 8), dtype=mx_.float32))
+
     class _Model:
-        language_model = SimpleNamespace(model=_Backbone())
+        language_model = _LanguageModel()
         config = SimpleNamespace(model_type=model_type)
 
         def get_input_embeddings(self, inputs, pixel_values=None, **_kwargs):
@@ -1846,9 +1862,13 @@ def _baseline_scale_model(model_type, hidden_size=16):
                 inputs_embeds=_Backbone().embed_tokens(inputs))
 
         def __call__(self, inputs, pixel_values=None, **kwargs):
-            seen["kwargs"] = kwargs
-            width = inputs.shape[1]
-            return mx_.zeros((inputs.shape[0], width, 8), dtype=mx_.float32)
+            seen["outer"] = kwargs
+            # 0.4.4: whatever it was handed, it embeds again from the ids.
+            # Embedded here rather than via `get_input_embeddings` so `merged`
+            # stays a marker of the loss backend's own merge.
+            return self.language_model(
+                inputs, inputs_embeds=_Backbone().embed_tokens(inputs),
+            )
 
     return _Model(), seen, hidden_size ** 0.5
 
@@ -1875,13 +1895,25 @@ def test_the_baseline_loss_backend_restores_the_gemma3n_embed_scale(
         "labels": ids,
     })
 
-    embeds = seen.get("kwargs", {}).get("inputs_embeds")
     if not rescaled:
-        # Every other family keeps the untouched ids path.
-        assert embeds is None and "merged" not in seen
+        # Every other family keeps the untouched ids path: the outer model is
+        # entered, and it is the one that embeds.
+        assert "outer" in seen and "merged" not in seen
+        assert seen["forwarded"] is not None
+        assert np.asarray(seen["forwarded"])[0][0][0] == pytest.approx(1.0)
         return
-    assert embeds is not None, "the forward still received bare ids"
+
+    assert seen.get("merged"), "the loss backend never merged"
+    embeds = seen.get("forwarded")
+    assert embeds is not None, "the language model still received bare ids"
+    # The scale has to survive all the way to the language model. Routed
+    # through `Model.__call__` on mlx-vlm 0.4.4 it does not: that call embeds
+    # again from the ids and the factor arrives as a plain 1.0.
     assert np.asarray(embeds)[0][0][0] == pytest.approx(scale)
+    assert "outer" not in seen, (
+        "the rescaled embeddings went through Model.__call__, which drops them "
+        "on every mlx-vlm up to the declared floor"
+    )
 
 
 # --- paligemma: a prefix-LM mask, not a padding outer product ---------------
@@ -3310,6 +3342,45 @@ def test_a_bare_message_list_row_is_scanned_for_audio(monkeypatch):
         {"role": "assistant", "content": "ok"}]}
     with pytest.raises(NotImplementedError):
         _format_vlm_row_gating_audio(messages, strip_audio, _FakeGemmaAudioProcessor())
+
+
+def test_a_row_that_is_one_message_dict_is_scanned_for_audio(monkeypatch):
+    """The single-message form of the row above, and the same hazard.
+
+    `_normalize_mlx_messages` wraps a `role`/`content` dict as one message, so
+    it is a supported row. The scan reached it through
+    `_select_vlm_messages_or_raw`, which hands such a row straight back, where
+    the `candidate is item` guard dropped it unscanned -- leaving the gate
+    uncalled and a formatter free to discard the user's clip in silence.
+    """
+    from unsloth_zoo.mlx.utils import (
+        _format_vlm_row_gating_audio, _normalize_vlm_messages,
+        _raw_row_has_audio,
+    )
+
+    clip = {"array": np.zeros(16, np.float32), "sampling_rate": 16000}
+    row = {"role": "user", "content": [{"type": "audio", "audio": clip},
+                                       {"type": "text", "text": "transcribe"}]}
+
+    # Supported: collation turns this row into exactly one message.
+    assert len(_normalize_vlm_messages(row)) == 1
+    assert _raw_row_has_audio(row) is True
+
+    # A message dict carrying no audio must not be gated.
+    assert _raw_row_has_audio(
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+    ) is False
+
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    monkeypatch.setattr(
+        mlx_utils, "_AUDIO_QUALIFIED_FAMILIES", {"other": frozenset({"0.0.0"})},
+    )
+    strip_audio = lambda _row: {"messages": [
+        {"role": "user", "content": [{"type": "text", "text": "transcribe"}]}]}
+    with pytest.raises(NotImplementedError):
+        _format_vlm_row_gating_audio(
+            row, strip_audio, _FakeGemmaAudioProcessor())
 
 
 def test_gemma4_audio_delimiters_are_not_targets():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pytest
 from pathlib import Path
@@ -2382,6 +2384,38 @@ def test_prompt_completion_audio_rides_the_prompt_half(monkeypatch):
                                return_prompt_completion=True)
 
 
+def test_prompt_completion_refuses_audio_stated_as_spans(monkeypatch):
+    """A span is an absolute coordinate into the half it was measured on, and
+    the combine joins the halves before flushing and truncating the result.
+    Letting it through would place the clip's audio on whatever landed there."""
+    class _Spans(_FakeGemmaAudioProcessor):
+        def __call__(self, text, audio=None, max_length=None, **kwargs):
+            out = super().__call__(text, audio, max_length, **kwargs)
+            out["audio_bounds"] = [
+                np.array([[1, 4]] * v.count("<audio>"), np.int32) for v in text
+            ]
+            return out
+
+    processor = _Spans()
+    _qualify(monkeypatch, processor=processor)
+    with pytest.raises(NotImplementedError,
+                       match="spans, which prompt/completion collation can move"):
+        _finalized_collate([_PC_AUDIO_ROW], processor, 16, None,
+                           return_prompt_completion=True)
+    # Only audio rows are refused; the format itself still works for this family.
+    text_only = {"prompt": [{"role": "user", "content": "q"}],
+                 "completion": [{"role": "assistant", "content": "a"}]}
+    _finalized_collate([text_only], processor, 16, None,
+                       return_prompt_completion=True)
+    _finalized_collate([text_only, text_only], processor, 16, None,
+                       return_prompt_completion=True)
+    # The audio is on the later row: a first-row check would let this through.
+    with pytest.raises(NotImplementedError,
+                       match="spans, which prompt/completion collation can move"):
+        _finalized_collate([text_only, _PC_AUDIO_ROW], processor, 16, None,
+                           return_prompt_completion=True)
+
+
 def test_deferred_prompt_completion_staging_rechecks_audio_runs(monkeypatch):
     """Production must build the pc_audio carrier and honor it at finalize."""
     import mlx.core as current_mx
@@ -2436,6 +2470,7 @@ def test_qualified_families_carry_their_probed_requirements():
         "gemma3n": frozenset({"0.4.4"}),
         "gemma4": frozenset({"0.4.4"}),
         "phi4mm": frozenset({"0.4.4"}),
+        "minicpmo": frozenset({"0.4.4"}),
     }
     # Gemma 4 was probed only on a newer transformers; this env pins an older.
     gemma4_like = type("Proc", (), {})
@@ -2812,20 +2847,549 @@ def test_phi4mm_token_ids_fall_back_to_the_mlx_vlm_defaults():
     assert _phi4mm_token_ids(
         {"image_token_index": -7, "audio_token_index": 11}
     ) == (-7, 11)
-    # One present, one absent: only the missing side falls back.
+    # One present, one absent: only the missing side falls back, either way
+    # round, so neither explicit value can be overwritten by the other's gap.
     assert _phi4mm_token_ids({"image_token_index": -7}) == (-7, expected[1])
+    assert _phi4mm_token_ids({"audio_token_index": 11}) == (expected[0], 11)
 
 
-def test_compile_preparation_survives_a_phi4mm_config_without_token_indices():
+def test_compile_preparation_finds_phi4mm_positions_without_token_indices():
     """The regression this guards is in the compile-preparation branch, not the
     helper: training threads the checkpoint mapping, which declares neither
-    index, and `int(None)` raised there before the first step."""
+    index, and `int(None)` raised there before the first step. Surviving the
+    call is not enough -- the positions have to come out where the real marker
+    ids sit, so resolving the wrong ids or swapping them is caught too."""
     from unsloth_zoo.mlx.utils import _prepare_vlm_batch_for_compile
 
-    pytest.importorskip("mlx_vlm.models.phi4mm.config")
-    batch = {
-        "input_ids": mx.array([[1, 2, 3]], dtype=mx.int32),
-        "attention_mask": mx.array([[1, 1, 1]], dtype=mx.int32),
-    }
+    config_cls = pytest.importorskip("mlx_vlm.models.phi4mm.config").ModelConfig
+    fields = config_cls.__dataclass_fields__
+    image_id = int(fields["image_token_index"].default)
+    audio_id = int(fields["audio_token_index"].default)
+
+    def _prepared(config, ids):
+        return _prepare_vlm_batch_for_compile({
+            "input_ids": mx.array([ids], dtype=mx.int32),
+            "attention_mask": mx.array([[1] * len(ids)], dtype=mx.int32),
+        }, config)
+
     # The real checkpoint's config.json shape: model_type only.
-    _prepare_vlm_batch_for_compile(batch, {"model_type": "phi4mm"})
+    prepared = _prepared({"model_type": "phi4mm"}, [7, image_id, 8, audio_id, 9])
+    assert prepared["image_token_positions"] == ((1,),)
+    assert prepared["audio_token_spans"] == (((3, 4),),)
+    # The markers are also resolved a second time, to rewrite the ids: a pair
+    # corrupted only there would leave the metadata above intact.
+    assert np.asarray(prepared["input_ids"]).tolist() == [
+        [7, image_id, 8, audio_id, 9]
+    ]
+    # An explicit config wins at the call site too, not only in the helper, and
+    # at both resolutions: the rewrite ignoring it would restore the defaults.
+    declared = _prepared({"model_type": "phi4mm", "image_token_index": 7,
+                          "audio_token_index": 9}, [7, image_id, 8, audio_id, 9])
+    assert declared["image_token_positions"] == ((0,),)
+    assert declared["audio_token_spans"] == (((4, 5),),)
+    assert np.asarray(declared["input_ids"]).tolist() == [
+        [7, image_id, 8, audio_id, 9]
+    ]
+
+# --- audio alignment from stated spans, for families whose run carries no id ---
+
+
+def _bounds_inputs(bounds, width=8, rows=1, features=1):
+    """A processor output shaped like MiniCPM-o's: spans, not identifiable runs.
+
+    The ids are one repeated token, which is what a placeholder run looks like;
+    tests that need a span landing on ordinary text overwrite them.
+    """
+    return {
+        "input_ids": np.zeros((rows, width), dtype=np.int32),
+        "attention_mask": np.ones((rows, width), dtype=np.int32),
+        "audio_bounds": bounds,
+        "audio_features": np.zeros((features, 80, 4), dtype=np.float32),
+    }
+
+
+def test_the_delimiters_around_an_audio_run_are_not_targets():
+    """A stated span covers the run's interior only, so the delimiters the
+    processor generated around it would otherwise stay supervised -- and they
+    are generated the same way the run is."""
+    from unsloth_zoo.mlx.utils import _get_vlm_ignore_token_ids
+
+    class _Delimited(_FakeProcessor):
+        tokenizer = type("_Tok", (_FakeTokenizer,), {
+            "audio_start_id": 151697, "audio_end_id": 151699})()
+
+    assert {151697, 151699} <= set(_get_vlm_ignore_token_ids(processor=_Delimited()))
+
+
+def test_audio_bounds_are_read_per_row():
+    from unsloth_zoo.mlx.utils import _audio_bounds_per_row
+
+    assert _audio_bounds_per_row({"input_ids": np.zeros((1, 4))}) is None
+    assert _audio_bounds_per_row(_bounds_inputs([[[1, 5]], [[2, 3], [4, 6]]])) == [
+        [(1, 5)], [(2, 3), (4, 6)]
+    ]
+
+
+@pytest.mark.parametrize("bounds, counts, message", [
+    ([[[1, 5]]], [2], "none may be dropped by truncation"),   # a clip lost its run
+    ([[[1, 3], [4, 6]]], [1], "no extra may be added"),       # one clip, two spans
+    ([[[3, 3]]], [1], "does not run forwards"),          # a run with no positions
+    ([[[5, 3]]], [1], "does not run forwards"),          # ends before it starts
+    ([[[1, 99]]], [1], "outside its 8 position"),        # truncation cut the run
+    # A negative start slices empty, which reads as "every position attended".
+    ([[[-1, 3]]], [1], "outside its 8 position"),
+    # The mismatch is on row 1: a check reading only the first row misses it.
+    ([[[1, 3]], [[1, 3]]], [1, 2], "row 1 carries 2 audio clip"),
+])
+def test_audio_bounds_reject_a_batch_that_cannot_be_aligned(bounds, counts, message):
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact
+
+    with pytest.raises(ValueError, match=message):
+        _assert_audio_runs_intact(
+            _bounds_inputs(bounds, rows=len(counts), features=sum(counts)),
+            counts, _FakeProcessor(), 8,
+        )
+
+
+def test_the_projection_after_the_audio_tower_is_frozen_too():
+    """Freezing the encoder alone leaves the layer that projects its output into
+    the language model trainable, which a full fine-tune would pull into the
+    optimizer. Families name that layer differently."""
+    from unsloth_zoo.mlx.utils import freeze_audio_modules
+
+    class _Module:
+        def __init__(self):
+            self.frozen = False
+
+        def freeze(self, recurse=False):
+            self.frozen = True
+
+    class _MiniCPMOish:
+        def __init__(self):
+            self.audio_tower = _Module()
+            self.audio_projection_layer = _Module()
+
+    model = _MiniCPMOish()
+    assert set(freeze_audio_modules(model)) == {
+        "audio_tower", "audio_projection_layer",
+    }
+    assert model.audio_tower.frozen and model.audio_projection_layer.frozen
+
+
+def test_stated_spans_refuse_the_left_padding_repair():
+    """The repair moves each row's tokens forward but re-derives nothing, so a
+    stated span would keep naming its pre-repair position and land the clip's
+    audio on whatever moved there. Both ends of a stale span can still be
+    attended, so no later check would catch it."""
+    from unsloth_zoo.mlx.utils import _right_pad_vlm_rows
+
+    left_padded = _bounds_inputs([[[4, 6]]], width=8)
+    left_padded["attention_mask"] = np.array([[0, 0, 1, 1, 1, 1, 1, 1]], np.int32)
+    with pytest.raises(ValueError, match=r"row\(s\) \[0\] content-first"):
+        _right_pad_vlm_rows(left_padded, _FakeProcessor())
+
+    # Interior padding moves tokens just as leading padding does, so the refusal
+    # covers it and must not describe the layout as merely left-padded.
+    interior = _bounds_inputs([[[5, 7]]], width=8)
+    interior["attention_mask"] = np.array([[1, 1, 0, 0, 1, 1, 1, 1]], np.int32)
+    with pytest.raises(ValueError, match=r"row\(s\) \[0\] content-first"):
+        _right_pad_vlm_rows(interior, _FakeProcessor())
+
+    # Already content-first: the repair is a no-op and must not refuse.
+    right_padded = _bounds_inputs([[[1, 3]]], width=8)
+    right_padded["attention_mask"] = np.array([[1, 1, 1, 1, 1, 1, 0, 0]], np.int32)
+    _right_pad_vlm_rows(right_padded, _FakeProcessor())
+
+    # These processors report the field on every batch, empty when there is no
+    # audio, so keying the refusal on the field would strand text-only rows.
+    no_audio = _bounds_inputs([[], []], width=8, rows=2, features=0)
+    no_audio["attention_mask"] = np.array([[0, 0, 1, 1, 1, 1, 1, 1],
+                                           [0, 1, 1, 1, 1, 1, 1, 1]], np.int32)
+    repaired = _right_pad_vlm_rows(no_audio, _FakeProcessor())
+    assert np.asarray(repaired["attention_mask"])[:, 0].tolist() == [1, 1]
+
+    # Only the text-only row moves. The audio row keeps its layout, so its spans
+    # keep naming the same tokens and the batch is repairable.
+    neighbour_moves = _bounds_inputs([[[1, 3]], []], width=8, rows=2)
+    neighbour_moves["attention_mask"] = np.array([[1, 1, 1, 1, 1, 1, 0, 0],
+                                                  [0, 0, 1, 1, 1, 1, 1, 1]], np.int32)
+    repaired = _right_pad_vlm_rows(neighbour_moves, _FakeProcessor())
+    assert np.asarray(repaired["attention_mask"])[:, 0].tolist() == [1, 1]
+
+    # The moving span-bearing row is not row 0, so checking only the first row's
+    # spans would repair this batch and strand row 1's coordinates.
+    later_row = _bounds_inputs([[[1, 3]], [[4, 6]]], width=8, rows=2, features=2)
+    later_row["attention_mask"] = np.array([[1, 1, 1, 1, 1, 1, 0, 0],
+                                            [0, 0, 1, 1, 1, 1, 1, 1]], np.int32)
+    with pytest.raises(ValueError, match=r"row\(s\) \[1\] content-first"):
+        _right_pad_vlm_rows(later_row, _FakeProcessor())
+
+
+def test_spans_that_do_not_name_a_placeholder_run_are_refused():
+    """These processors pair the n-th opening delimiter with the n-th closing
+    one, so a delimiter the rendered text carries itself shifts every later pair
+    onto ordinary tokens. The shifted span still counts, fits and attends: only
+    the tokens it names show it is wrong."""
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact
+
+    shifted = _bounds_inputs([[[1, 4]]], width=8)
+    # start delimiter, prefix, start delimiter, placeholder, end delimiter, ...
+    shifted["input_ids"] = np.array([[9, 5, 9, 0, 8, 6, 6, 6]], dtype=np.int32)
+    with pytest.raises(ValueError, match="does not name a placeholder run"):
+        _assert_audio_runs_intact(shifted, [1], _FakeProcessor(), 8)
+
+    # Two rows whose runs disagree: one of them is not the placeholder token.
+    mixed = _bounds_inputs([[[1, 3]], [[1, 3]]], width=8, rows=2, features=2)
+    mixed["input_ids"] = np.array([[9, 0, 0, 8, 6, 6, 6, 6],
+                                   [9, 4, 4, 8, 6, 6, 6, 6]], dtype=np.int32)
+    with pytest.raises(ValueError, match="does not name a placeholder run"):
+        _assert_audio_runs_intact(mixed, [1, 1], _FakeProcessor(), 8)
+
+    # Two spans in one row, the second naming a different repeated token: a
+    # check comparing only each row's first span would accept this.
+    within_row = _bounds_inputs([[[1, 3], [4, 6]]], width=8, features=2)
+    within_row["input_ids"] = np.array([[9, 0, 0, 9, 4, 4, 8, 6]], dtype=np.int32)
+    with pytest.raises(ValueError, match="does not name a placeholder run"):
+        _assert_audio_runs_intact(within_row, [2], _FakeProcessor(), 8)
+
+    # And the batch this is all protecting: two rows, two clips, one marker.
+    valid = _bounds_inputs([[[1, 3]], [[1, 3], [4, 6]]], width=8, rows=2,
+                           features=3)
+    valid["input_ids"] = np.array([[9, 0, 0, 8, 6, 6, 6, 6],
+                                   [9, 0, 0, 9, 0, 0, 8, 6]], dtype=np.int32)
+    _assert_audio_runs_intact(valid, [1, 2], _FakeProcessor(), 8)
+
+
+def test_clips_the_extractor_would_truncate_are_refused():
+    """A clip past the extractor's window asks for positions whose audio the
+    model never receives. Sizing the run from the waveform also leaves it a
+    position or two above the embeddings on ordinary clips, which is upstream's
+    own rounding with the whole clip present -- that must still be accepted, or
+    every real batch is refused."""
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact
+
+    class _Windowed(_FakeProcessor):
+        audio_processor = type("_Ex", (), {"n_samples": 16, "sampling_rate": 16})()
+
+    inputs = _bounds_inputs([[], [[1, 3]]], width=8, rows=2)
+    with pytest.raises(ValueError, match="row 1 carries a 17-sample audio clip"):
+        _assert_audio_runs_intact(inputs, [0, 1], _Windowed(), 8,
+                                  clips=[[], [np.zeros(17, np.float32)]])
+
+    # The second clip is the long one: checking only the first would miss it.
+    two_clips = _bounds_inputs([[], [[1, 3], [4, 6]]], width=8, rows=2, features=2)
+    with pytest.raises(ValueError, match="row 1 carries a 17-sample audio clip"):
+        _assert_audio_runs_intact(
+            two_clips, [0, 2], _Windowed(), 8,
+            clips=[[], [np.zeros(16, np.float32), np.zeros(17, np.float32)]],
+        )
+
+    _assert_audio_runs_intact(inputs, [0, 1], _Windowed(), 8,
+                              clips=[[], [np.zeros(16, np.float32)]])
+
+
+def test_text_carrying_the_audio_delimiters_itself_is_refused(monkeypatch):
+    """The processor pairs opening delimiters with closing ones across the whole
+    row, so one the text brought itself shifts the pairing, and truncation can
+    drop the generated span and leave the foreign one standing in for it at any
+    length -- including exactly the right one. Nothing downstream separates
+    them, so the text is refused before the processor expands it."""
+    class _Delimited(_FakeGemmaAudioProcessor):
+        tokenizer = type("_Tok", (_FakeGemmaAudioProcessor.tokenizer.__class__,), {
+            "audio_start_id": 301, "audio_end_id": 302,
+            "convert_ids_to_tokens": staticmethod(
+                lambda i: {301: "<|audio_start|>", 302: "<|audio_end|>"}.get(i)),
+        })()
+
+    processor = _Delimited()
+    _qualify(monkeypatch, processor=processor)
+    # Either delimiter alone is enough to shift the pairing, so each is refused
+    # on its own, not only a well-formed pair.
+    for text, named in (("<|audio_start|>x<|audio_end|> hi", "<|audio_start|>"),
+                        ("<|audio_start|> hi", "<|audio_start|>"),
+                        ("<|audio_end|> hi", "<|audio_end|>")):
+        row = _audio_row(_CLIP)
+        row["messages"][0]["content"][1]["text"] = text
+        with pytest.raises(ValueError, match=f"already contains {re.escape(named)}"):
+            _finalized_collate([row], processor, 16, None)
+
+    # The delimiter is on the second audio row: a check reading only the first
+    # would let it through and shift that row's spans.
+    later = _audio_row(_CLIP)
+    later["messages"][0]["content"][1]["text"] = "<|audio_start|> hi"
+    with pytest.raises(ValueError, match="row 1 already contains"):
+        _finalized_collate([_audio_row(_CLIP), later], processor, 16, None)
+
+    # The pairing is per row, so a row with no clip has none to disturb: a
+    # text-only sibling may say whatever it likes beside an audio row.
+    sibling = _audio_row(None, text="<|audio_start|> plain")
+    _finalized_collate([_audio_row(_CLIP), sibling], processor, 16, None)
+
+
+def test_ragged_image_metadata_survives_an_audio_batch():
+    """An audio row may carry images too, and those rows were refused before
+    this family was qualified. Their per-row image coordinates are ragged for
+    the same reason the audio spans are, and the model indexes both by row."""
+    from unsloth_zoo.mlx.utils import _to_mx_vlm_batch
+
+    batch = _to_mx_vlm_batch({
+        "input_ids": np.zeros((2, 8), dtype=np.int32),
+        "audio_bounds": [np.zeros((0, 2), np.int32), np.array([[1, 3]])],
+        "image_bound": [np.array([[1, 3], [4, 6]]), np.array([[2, 5]])],
+        "tgt_sizes": [np.array([[4, 4], [4, 4]]), np.array([[8, 8]])],
+    })
+    assert [np.asarray(r).tolist() for r in batch["image_bound"]] == [
+        [[1, 3], [4, 6]], [[2, 5]]
+    ]
+    assert [np.asarray(r).tolist() for r in batch["tgt_sizes"]] == [
+        [[4, 4], [4, 4]], [[8, 8]]
+    ]
+
+
+def test_collation_hands_the_clip_lengths_to_the_window_check(monkeypatch):
+    """The check can only see clips the collation passes it, so dropping that
+    wiring would leave it live but blind."""
+    class _Spans(_FakeGemmaAudioProcessor):
+        audio_processor = type("_Ex", (), {"n_samples": 4, "sampling_rate": 16})()
+
+        def __call__(self, text, audio=None, max_length=None, **kwargs):
+            out = super().__call__(text, audio, max_length, **kwargs)
+            out["audio_bounds"] = [
+                np.array([[2, 5]] * v.count("<audio>"), np.int32) for v in text
+            ]
+            return out
+
+    processor = _Spans()
+    _qualify(monkeypatch, processor=processor)
+    with pytest.raises(ValueError, match="audio clip"):
+        _finalized_collate([_audio_row(_CLIP)], processor, 16, None)
+
+
+def test_ids_the_run_path_rejects_are_rejected_on_the_bounds_path_too():
+    """Reading rows and width off shape[0] and shape[1] would take a 3-D batch
+    for an 8-wide one and pass it on with its extra axis intact."""
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact
+
+    inputs = _bounds_inputs([[[1, 3]]], width=8)
+    inputs["input_ids"] = np.zeros((1, 8, 1), dtype=np.int32)
+    inputs.pop("attention_mask")
+    with pytest.raises(ValueError, match="cannot verify audio alignment"):
+        _assert_audio_runs_intact(inputs, [1], _FakeProcessor(), 8)
+
+
+def test_audio_clips_are_grouped_per_row_when_the_processor_assigns_them():
+    """A flat list leaves the row assignment to a marker count over the rendered
+    text, which a chat template need not emit; every clip then lands on row 0.
+    Grouping per row states the assignment instead of leaving it inferable."""
+    from unsloth_zoo.mlx.utils import _format_vlm_audio_for_processor
+
+    class _MiniCPMOProcessor(_FakeProcessor):  # matched by class name, as images are
+        pass
+
+    # A row with two clips: keeping only the first would drop one, and the span
+    # count would then disagree with what the row carries.
+    clips = [[], ["one", "two"]]
+    assert _format_vlm_audio_for_processor(clips, _MiniCPMOProcessor()) == [
+        [], ["one", "two"]
+    ]
+    assert _format_vlm_audio_for_processor(clips, _FakeProcessor()) == ["one", "two"]
+    assert _format_vlm_audio_for_processor([[], []], _MiniCPMOProcessor()) is None
+
+
+def test_collation_hands_the_processor_the_grouping_it_assigns_by(monkeypatch):
+    """Whatever the helper decides is worth nothing if collation calls it without
+    the processor: the payload silently reverts to flat and rows are guessed."""
+    seen = {}
+
+    class _MiniCPMOish(_FakeGemmaAudioProcessor):
+        def __call__(self, text, audio=None, max_length=None, **kwargs):
+            seen["audio"] = audio
+            flat = [clip for row in audio for clip in row] if audio else audio
+            return super().__call__(text, flat, max_length, **kwargs)
+
+    processor = _MiniCPMOish()
+    _qualify(monkeypatch, processor=processor)
+    audio_row = dict(_audio_row(None, placeholder_only=True), audio=_CLIP)
+    _finalized_collate([_audio_row(None, text="plain"), audio_row], processor, 16, None)
+    assert [len(row) for row in seen["audio"]] == [0, 1]
+
+
+def test_stated_spans_are_checked_instead_of_soft_token_runs():
+    """The run interior need not be an audio-specific token, so counting runs
+    would find none. A batch whose spans line up must still pass, and one whose
+    spans have no payload behind them must not: the placeholders would occupy
+    the sequence with nothing to merge into them."""
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact
+
+    _assert_audio_runs_intact(_bounds_inputs([[[1, 5]]]), [1], _FakeProcessor(), 8)
+
+    without_payload = _bounds_inputs([[[1, 5]]])
+    without_payload.pop("audio_features")
+    with pytest.raises(ValueError, match="audio"):
+        _assert_audio_runs_intact(without_payload, [1], _FakeProcessor(), 8)
+
+    # Present is not enough: the payload has to carry one entry per span, no
+    # more and no fewer, or a clip's placeholders would be filled from another
+    # clip's features.
+    for features in (1, 3):
+        with pytest.raises(ValueError, match="audio"):
+            _assert_audio_runs_intact(
+                _bounds_inputs([[[1, 3], [4, 6]]], features=features), [2],
+                _FakeProcessor(), 8,
+            )
+    _assert_audio_runs_intact(
+        _bounds_inputs([[[1, 3], [4, 6]]], features=2), [2], _FakeProcessor(), 8,
+    )
+
+
+def test_audio_span_positions_are_excluded_from_the_loss():
+    """Placeholder positions are inputs, never text to predict, and they cannot
+    be masked by token id when the marker is the unknown token. Each row is
+    masked by its own spans: reusing row 0's would silently supervise one row's
+    audio while masking another's text."""
+    from unsloth_zoo.mlx.utils import _stage_vlm_label_mask_np
+
+    inputs = _bounds_inputs([[[2, 5]], [], [[0, 1], [6, 8]]], width=8, rows=3)
+    mask = _stage_vlm_label_mask_np(inputs)
+    assert mask[0].tolist() == [0, 0, 1, 1, 1, 0, 0, 0]
+    assert mask[1].tolist() == [0] * 8
+    assert mask[2].tolist() == [1, 0, 0, 0, 0, 0, 1, 1]
+
+
+@pytest.mark.parametrize("bounds, expected", [
+    # Rows holding different clip counts: stacking raises, and keeping only the
+    # first row would tell every later row it has no audio while its
+    # placeholders still occupy the sequence.
+    ([np.array([[1, 3]]), np.array([[1, 3], [4, 7]])], [[[1, 3]], [[1, 3], [4, 7]]]),
+    # A row without audio beside one with it: the empty row must stay empty and
+    # stay a row, or the audio row's index moves.
+    ([np.zeros((0, 2), np.int32), np.array([[1, 3]])], [[], [[1, 3]]]),
+])
+def test_ragged_audio_bounds_survive_conversion_to_mlx(bounds, expected):
+    from unsloth_zoo.mlx.utils import _to_mx_vlm_batch
+
+    batch = _to_mx_vlm_batch({
+        "input_ids": np.zeros((2, 8), dtype=np.int32),
+        "audio_bounds": bounds,
+        # Nested ints, the shape MiniCPM-o reports: no array to stack, so this
+        # rides the ordinary passthrough and needs no per-row handling.
+        "audio_feature_lens": [[9], [9, 4]],
+    })
+    assert [np.asarray(r).tolist() for r in batch["audio_bounds"]] == expected
+    assert batch["audio_feature_lens"] == [[9], [9, 4]]
+
+
+def test_audio_spans_are_masked_on_the_deferred_label_path_too():
+    """Processor output the host staging cannot claim decides its labels at
+    finalize instead, and that decision has to exclude the spans as well. The
+    response-mask path arrives here with labels already chosen, so masking only
+    while deriving them would supervise audio under train_on_responses_only."""
+    import mlx.core as current_mx
+    if current_mx is not mx:
+        pytest.skip("requires real MLX runtime without mlx_simulation monkeypatch")
+    from unsloth_zoo.mlx.utils import _apply_vlm_label_masks
+
+    batch = {
+        "input_ids": mx.array([[5, 6, 7, 8, 9, 10]], dtype=mx.int32),
+        "attention_mask": mx.array([[1, 1, 1, 1, 1, 1]], dtype=mx.int32),
+        "audio_bounds": [mx.array([[2, 5]], dtype=mx.int32)],
+    }
+    derived = np.asarray(_apply_vlm_label_masks(batch)).tolist()
+    assert derived == [[5, 6, -100, -100, -100, 10]]
+
+    supplied = mx.array([[-100, -100, 7, 8, 9, 10]], dtype=mx.int32)
+    responses_only = np.asarray(_apply_vlm_label_masks(batch, supplied)).tolist()
+    assert responses_only == [[-100, -100, -100, -100, -100, 10]]
+
+    # Each row by its own spans: broadcasting row 0's would supervise row 1's
+    # audio positions and mask text it should be learning.
+    rows = {
+        "input_ids": mx.array([[5, 6, 7, 8, 9, 10]] * 2, dtype=mx.int32),
+        "attention_mask": mx.array([[1] * 6] * 2, dtype=mx.int32),
+        "audio_bounds": [mx.array([[0, 2]], dtype=mx.int32),
+                         mx.array([[4, 6]], dtype=mx.int32)],
+    }
+    assert np.asarray(_apply_vlm_label_masks(rows)).tolist() == [
+        [-100, -100, 7, 8, 9, 10], [5, 6, 7, 8, -100, -100],
+    ]
+
+
+def test_an_empty_audio_payload_is_not_audio():
+    """MiniCPM-o hands a text-only batch audio_features shaped (0, 80, 0).
+    Calling that audio would route the run eagerly and abort a strict one."""
+    from unsloth_zoo.mlx.utils import _vlm_batch_carries_audio
+
+    assert not _vlm_batch_carries_audio({"audio_features": np.zeros((0, 80, 0), np.float32)})
+    assert _vlm_batch_carries_audio({"audio_features": np.zeros((1, 80, 4), np.float32)})
+    # A payload can arrive as a plain sequence too, and an empty one is no more
+    # audio than an empty array is.
+    assert not _vlm_batch_carries_audio({"input_audio_embeds": []})
+    assert _vlm_batch_carries_audio({"input_audio_embeds": [object()]})
+
+
+def test_audio_spans_are_checked_against_attended_positions():
+    """A span covering padding is not placed on the tokens the model attends.
+    Rows reach here content-first, so the check is per row over the positions
+    the span names."""
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact
+
+    # Row 1's span starts on content and runs off the end of it. Row 0 attends
+    # everything, so a check reading row 0's mask sees nothing wrong, and one
+    # reading only the span's first position sees nothing wrong either.
+    straddling = _bounds_inputs([[[1, 3]], [[3, 6]]], width=8, rows=2, features=2)
+    straddling["attention_mask"] = np.array([[1, 1, 1, 1, 1, 1, 1, 1],
+                                             [1, 1, 1, 1, 0, 0, 0, 0]], np.int32)
+    with pytest.raises(ValueError, match="row 1 .* covering padding"):
+        _assert_audio_runs_intact(straddling, [1, 1], _FakeProcessor(), 8)
+
+
+def test_audio_bounds_require_a_row_per_tokenized_row():
+    """Bounds are indexed per row by the model, so a count that disagrees with
+    the tokenized rows would silently leave a row's audio unplaced. All three
+    counts have to agree, in both directions."""
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact
+
+    # Dataset rows and tokenized rows agree; only the bounds disagree, so a
+    # check comparing just those two would pass this batch.
+    inputs = _bounds_inputs([[[1, 3]]], width=8, rows=2, features=2)
+    with pytest.raises(ValueError, match="tokenized row"):
+        _assert_audio_runs_intact(inputs, [1, 1], _FakeProcessor(), 8)
+
+    # Bounds and dataset rows agree; the tokenized rows do not.
+    fewer_ids = _bounds_inputs([[[1, 3]], [[1, 3]]], width=8, rows=1, features=2)
+    with pytest.raises(ValueError, match="tokenized row"):
+        _assert_audio_runs_intact(fewer_ids, [1, 1], _FakeProcessor(), 8)
+
+    # And the other direction: more bounds rows than the batch has.
+    extra_bounds = _bounds_inputs([[[1, 3]], [[1, 3]], [[1, 3]]], width=8,
+                                  rows=2, features=2)
+    with pytest.raises(ValueError, match="tokenized row"):
+        _assert_audio_runs_intact(extra_bounds, [1, 1], _FakeProcessor(), 8)
+
+    # Bounds and tokenized rows agree; only the dataset rows do not, so a check
+    # comparing just those two would accept this.
+    extra_counts = _bounds_inputs([[[1, 3]], [[1, 3]]], width=8, rows=2, features=2)
+    with pytest.raises(ValueError, match="dataset row"):
+        _assert_audio_runs_intact(extra_counts, [1, 1, 1], _FakeProcessor(), 8)
+
+
+def test_overlong_rows_are_refused_by_what_the_model_attends():
+    """The run path caps each row's attended tokens. Capping the padded width
+    instead would refuse a batch it accepts, since padding is not the row's own
+    length."""
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact
+
+    padded = _bounds_inputs([[[1, 3]]], width=12)
+    padded["attention_mask"] = np.array([[1] * 6 + [0] * 6], dtype=np.int32)
+    _assert_audio_runs_intact(padded, [1], _FakeProcessor(), 8)
+
+    with pytest.raises(ValueError, match="row 0 is 12 tokens"):
+        _assert_audio_runs_intact(_bounds_inputs([[[1, 3]]], width=12), [1],
+                                  _FakeProcessor(), 8)
+
+    # Row 1 is the one over the cap: reading row 0's mask every time would
+    # accept it, since row 0 stays under.
+    later_row = _bounds_inputs([[[1, 3]], [[1, 3]]], width=12, rows=2, features=2)
+    later_row["attention_mask"] = np.array([[1] * 6 + [0] * 6, [1] * 12], np.int32)
+    with pytest.raises(ValueError, match="row 1 is 12 tokens"):
+        _assert_audio_runs_intact(later_row, [1, 1], _FakeProcessor(), 8)

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3015,6 +3015,70 @@ def test_the_delimiters_around_an_audio_run_are_not_targets():
     assert {151697, 151699} <= set(_get_vlm_ignore_token_ids(processor=_Delimited()))
 
 
+def test_an_untyped_audio_part_is_typed_whichever_alias_it_uses(monkeypatch):
+    """An untyped part is typed from its key, and a part the inference misses
+    reaches neither the family gate nor the extractor."""
+    from unsloth_zoo.mlx.utils import (
+        _extract_vlm_audio, _normalize_vlm_messages, _raw_row_has_audio,
+    )
+
+    processor = _FakeGemmaAudioProcessor()
+    _qualify(monkeypatch, processor=processor)
+    # A ramp rather than the shared constant clip, so a clip substituted for
+    # the caller's cannot coincide with it.
+    ramp = {"array": np.linspace(-0.5, 0.5, 16, dtype=np.float32),
+            "sampling_rate": 16000}
+    for alias in ("audio", "audio_url", "input_audio"):
+        row = {"messages": [{"role": "user", "content": [
+            {alias: ramp}, {"type": "text", "text": "hi"}]}]}
+        messages = _normalize_vlm_messages(row["messages"])
+        part = messages[0]["content"][0]
+        # "audio", not the alias: Gemma's templates render a placeholder for
+        # that spelling alone.
+        assert part["type"] == "audio", alias
+        assert _raw_row_has_audio(row) is True, alias
+        # ...and the caller's own clip reaches the extractor, which reads the
+        # payload from the key the caller used.
+        clips = _extract_vlm_audio(row, messages, processor)
+        assert len(clips) == 1, alias
+        assert np.array_equal(np.asarray(clips[0]), ramp["array"]), alias
+
+
+def test_a_fixed_budget_row_cannot_hide_a_short_run_behind_a_long_one():
+    """Runs of the wrong lengths still total correctly and still start once per
+    clip, so the total cannot stand in for the individual runs: a clip then
+    spills into the next run and pairs audio with the wrong positions."""
+    from unsloth_zoo.mlx.utils import _assert_audio_runs_intact_ids
+
+    # Budget 3, three clips: runs of 3, 2 and 4 total 9 and begin three times,
+    # which the total check and the run-count check both accept. The aligned
+    # row comes first, so a check that reads only row 0 cannot pass.
+    ids = np.array([[1, 7, 7, 7, 1, 7, 7, 7, 1, 7, 7, 7, 1],
+                    [1, 7, 7, 7, 1, 7, 7, 1, 7, 7, 7, 7, 1]])
+    with pytest.raises(ValueError,
+                       match=r"row 1 .*run\(s\) of length \[3, 2, 4\]"):
+        _assert_audio_runs_intact_ids(
+            ids, np.ones_like(ids), [3, 3], [7], None, budget=3)
+
+    # One wrong run in each position in turn, so an implementation that skips
+    # any single position accepts the row whose only bad run sits there. The
+    # fourth case keeps both bad runs past a three-run prefix, which a check
+    # reading only the first few runs would clear, and the last is uniformly
+    # wrong, which a check comparing the runs to each other would clear.
+    for lengths in ([2, 3, 3], [3, 2, 3], [3, 3, 2], [3, 3, 3, 2, 4], [4, 4]):
+        row = [1]
+        for length in lengths:
+            row += [7] * length + [1]
+        row = np.array([row])
+        with pytest.raises(ValueError,
+                           match=re.escape(f"length {lengths}")):
+            _assert_audio_runs_intact_ids(
+                row, np.ones_like(row), [len(lengths)], [7], None, budget=3)
+
+    assert _assert_audio_runs_intact_ids(
+        ids[:1], np.ones_like(ids[:1]), [3], [7], None, budget=3) == 3
+
+
 def test_audio_bounds_are_read_per_row():
     from unsloth_zoo.mlx.utils import _audio_bounds_per_row
 

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1538,3 +1538,185 @@ def test_gemma3n_token_type_ownership_survives_module_relocation():
     assert _vlm_processor_requests_mm_token_type_ids(
         processor("transformers.models.gemma3.processing_gemma3", "Gemma3Processor")
     ) is True
+
+
+# --- causality: a padding mask must never become the attention mask ---------
+
+
+def _utils_mx():
+    """The mlx the module under test is bound to (a sibling test may shim it)."""
+    from unsloth_zoo.mlx import utils
+    return utils.mx
+
+
+def _run_loss(model_type, kv_shared=0):
+    """Run the baseline loss and report what the model was handed."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.utils import make_vlm_baseline_loss_fn
+
+    mx_ = _utils_mx()
+    seen = {}
+    ids = mx_.array([[1, 2, 3, 4]], dtype=mx_.int32)
+    batch = {"input_ids": ids, "labels": ids,
+             "attention_mask": mx_.ones(ids.shape, dtype=mx_.int32)}
+
+    class _Model:
+        config = SimpleNamespace(model_type=model_type)
+
+        # Declared and never read, exactly as molmo_point declares it.
+        def get_input_embeddings(self, input_ids=None, pixel_values=None, mask=None):
+            return None
+
+        # Keyword-only and required, as thirteen families declare it: omitting
+        # it is a TypeError, so every case below also proves it is always sent.
+        def __call__(self, inputs, pixel_values=None, *, mask, cache=None, **kw):
+            seen["mask"], seen["cache"] = mask, cache
+            return SimpleNamespace(
+                logits=mx_.zeros((*inputs.shape, 16), dtype=mx_.float32))
+
+    model = _Model()
+    if kv_shared:
+        model.language_model = SimpleNamespace(model=SimpleNamespace(
+            first_kv_shared_layer_idx=15,
+            config=SimpleNamespace(num_kv_shared_layers=kv_shared)))
+    make_vlm_baseline_loss_fn(model=None, ignore_token_ids=[])(model, batch)
+    return seen, batch
+
+
+# mlx-vlm model_type values, not module names: FastVLM reports either.
+_MASK_KEEPING_FAMILIES = (
+    "gemma3", "paligemma", "llava_qwen2", "fastvlm",
+    "falcon_ocr", "falcon_perception", "falcon-perception",
+)
+
+
+@pytest.mark.parametrize("model_type,keeps", [
+    *[(family, True) for family in _MASK_KEEPING_FAMILIES],
+    # mlx-vlm resolves the module case-insensitively, the config keeps its own.
+    ("Gemma3", True), ("FALCON-PERCEPTION", True),
+    ("qwen2_vl", False),
+    ("molmo_point", False),
+])
+def test_baseline_loss_fn_sends_the_padding_mask_only_where_it_is_read(
+        model_type, keeps):
+    # Elsewhere it reaches the layers verbatim and replaces causality, letting
+    # every supervised position read the token it is scored on.
+    seen, batch = _run_loss(model_type)
+    assert seen["mask"] is (batch["attention_mask"] if keeps else None)
+
+
+def test_mask_keeping_allowlist_is_exactly_these_families_and_all_their_aliases():
+    from unsloth_zoo.mlx.utils import _VLM_FAMILIES_KEEPING_FORWARDED_MASK as listed
+    assert set(listed) == set(_MASK_KEEPING_FAMILIES)
+    # A config keeps its model_type through mlx-vlm's remap, so an alias onto a
+    # listed module has to be listed under its own spelling too.
+    remap = pytest.importorskip("mlx_vlm.utils").MODEL_REMAPPING
+    assert not {a for a, t in remap.items() if t in listed and a not in listed}
+
+
+class _NoPadIdTokenizer(_FakeTokenizer):
+    pad_token_id = None
+
+
+class _LayoutProcessor(_FakeProcessor):
+    """Emits one fixed layout, honouring `padding_side` only when told to.
+
+    Instruct checkpoints ship `padding_side: left`; deepseek_vl_v2 and the
+    falcon pair left-pad multimodal rows whichever side they are asked for.
+    """
+
+    def __init__(self, rows, masks, honours_side=False, tokenizer=None, **extras):
+        self.rows, self.masks, self.extras = rows, masks, extras
+        self.honours_side = honours_side
+        self.tokenizer = tokenizer or _FakeTokenizer()
+
+    def __call__(self, text, padding_side=None, **_kwargs):
+        flush = self.honours_side and padding_side == "right"
+        ids, mask = [], []
+        for row, keep in zip(self.rows, self.masks):
+            body = [t for t, k in zip(row, keep) if k]
+            pad = [0] * (len(row) - len(body))
+            ids.append(body + pad if flush else list(row))
+            mask.append([1] * len(body) + pad if flush else list(keep))
+        out = {"input_ids": np.array(ids, dtype=np.int32),
+               "attention_mask": np.array(mask, dtype=np.int32)}
+        out.update({key: np.asarray(value) for key, value in self.extras.items()})
+        return out
+
+
+# One row already flush, one left-padded, so a repair has something to move.
+_RAGGED = ([[101, 10, 200, 11], [0, 0, 101, 200]],
+           [[1, 1, 1, 1], [0, 0, 1, 1]])
+_MARKS = np.array([[0, 0, 1, 0], [0, 0, 0, 1]], dtype=np.int32)
+
+
+@pytest.mark.parametrize("honours_side", [True, False])
+def test_collation_delivers_content_then_padding(honours_side):
+    # Causality is all that excludes the pads once the mask is withheld, and it
+    # excludes a trailing pad, not a leading one.
+    batch = _finalized_collate(
+        [{"text": "a"}] * 2, _LayoutProcessor(*_RAGGED, honours_side=honours_side),
+        8, None)
+    ids, mask = np.asarray(batch["input_ids"]), np.asarray(batch["attention_mask"])
+    assert mask.tolist() == [[1, 1, 1, 1], [1, 1, 0, 0]]
+    assert ids[1][:2].tolist() == [101, 200]
+
+
+@pytest.mark.parametrize("key", ["mm_token_type_ids", "images_seq_mask"])
+def test_collation_moves_token_aligned_sidecars_with_their_tokens(key):
+    # gemma4 builds its bidirectional multimodal blocks from
+    # `mm_token_type_ids`, the deepseek pair place image embeddings at
+    # `images_seq_mask` indices; left behind, row 1's mark sits on a pad.
+    batch = _finalized_collate(
+        [{"text": "a"}] * 2,
+        _LayoutProcessor(*_RAGGED, mm_token_type_ids=_MARKS,
+                         images_seq_mask=_MARKS.astype(bool)), 8, None)
+    ids, marked = np.asarray(batch["input_ids"]), np.asarray(batch[key]).astype(bool)
+    assert marked.sum() == 2 and (ids[marked] == 200).all()
+    assert marked[1].tolist() == [False, True, False, False]
+
+
+@pytest.mark.parametrize("key", ["image_grid_hw", "some_unlisted_field"])
+def test_collation_leaves_an_unlisted_field_alone(key):
+    # Three images of two columns, in a batch of three rows two tokens wide:
+    # per-image metadata shaped exactly like a per-token array. Recognising
+    # sidecars by shape would compact row 1's to [5, 0], losing its height.
+    grid = np.array([[2, 3], [4, 5], [6, 7]], dtype=np.int32)
+    batch = _finalized_collate(
+        [{"text": "a"}] * 3,
+        _LayoutProcessor([[101, 200], [0, 200], [101, 200]],
+                         [[1, 1], [0, 1], [1, 1]],
+                         image_grid_hw=grid, some_unlisted_field=grid + 10),
+        8, None)
+    assert np.asarray(batch["input_ids"])[1].tolist() == [200, 0]
+    assert np.asarray(batch[key]).tolist() == (grid if key == "image_grid_hw"
+                                               else grid + 10).tolist()
+
+
+@pytest.mark.parametrize("key", ["position_ids", "rope_deltas"])
+def test_collation_refuses_a_processor_authored_layout_coordinate(key, monkeypatch):
+    # Sidecars label tokens and travel with them; these are coordinates of the
+    # layout the repair replaces. `rope_deltas` is injected into the pipeline's
+    # own collection, so naming "position_ids" inline would fail this.
+    from unsloth_zoo.mlx import utils
+
+    monkeypatch.setattr(utils, "_VLM_WIDTH_GENERATED_KEYS",
+                        tuple(utils._VLM_WIDTH_GENERATED_KEYS) + ("rope_deltas",))
+    coords = np.tile(np.arange(4), (2, 1))
+    with pytest.raises(ValueError, match=key):
+        _finalized_collate([{"text": "a"}] * 2,
+                           _LayoutProcessor(*_RAGGED, **{key: coords}), 8, None)
+
+
+@pytest.mark.parametrize("honours_side", [True, False])
+def test_collation_does_not_require_a_pad_id(honours_side):
+    # falcon_ocr and falcon_perception ship no pad id and pad with 0, so
+    # demanding one would refuse batches they collate fine, repair or not.
+    batch = _finalized_collate(
+        [{"text": "a"}] * 2,
+        _LayoutProcessor(*_RAGGED, honours_side=honours_side,
+                         tokenizer=_NoPadIdTokenizer()), 8, None)
+    ids, mask = np.asarray(batch["input_ids"]), np.asarray(batch["attention_mask"])
+    assert mask[:, 0].tolist() == [1, 1] and (ids[mask == 0] == 0).all()
+
+

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1779,3 +1779,219 @@ def test_embed_scale_lifts_only_gemma3n_plain_tokens(model_type, scaled):
     assert out[2][0] == pytest.approx(scale if scaled else 1.0)
     # Merged features already carry the scaled magnitude; rescaling inflates.
     assert out[1][0] == pytest.approx(9.0)
+
+
+# --- paligemma: a prefix-LM mask, not a padding outer product ---------------
+
+
+def test_paligemma_mask_is_bidirectional_on_the_prefix_and_causal_on_the_suffix():
+    """PaliGemma's own mask is an outer product of the padding mask, so with
+    nothing padded the suffix being trained on reads the tokens after it."""
+    from unsloth_zoo.mlx.loader import (
+        _VLM_MODEL_FIXUPS, _fix_paligemma_multimodal_causal_mask,
+        _paligemma_prefix_lm_mask,
+    )
+
+    # Loading a VLM has to apply the correction, not just define it.
+    assert _fix_paligemma_multimodal_causal_mask in _VLM_MODEL_FIXUPS
+
+    mx_ = _utils_mx()
+    seq = 8
+    # 0 marks the prefix, 1 the suffix: the reverse of Gemma3's convention.
+    token_type_ids = mx_.array([[0, 0, 0, 0, 1, 1, 0, 0]], dtype=mx_.int32)
+    padding = mx_.array([[1, 1, 1, 1, 1, 1, 0, 0]], dtype=mx_.int32)
+    m = np.asarray(
+        _paligemma_prefix_lm_mask(token_type_ids, padding)
+    ).reshape(-1, seq, seq)[0].astype(bool)
+
+    q_idx, kv_idx = np.indices(m.shape)
+    real = np.asarray(padding)[0] == 1
+    prefix = (np.asarray(token_type_ids)[0] == 0) & real
+    both_real = real[q_idx] & real[kv_idx]
+    both_prefix = prefix[q_idx] & prefix[kv_idx]
+    ahead = q_idx < kv_idx
+    # The suffix is causal: outside the prefix nothing reads ahead. Left as an
+    # outer product every one of these is visible.
+    assert not m[ahead & ~both_prefix & both_real].any()
+    # The prefix stays bidirectional, which is what PaliGemma is trained for.
+    assert m[both_prefix].all()
+    # The past is always visible, so this is a mask and not all-zeros.
+    assert m[(q_idx >= kv_idx) & both_real].all()
+    # And the pads are excluded, which the outer product did do and this must too.
+    assert not m[~both_real].any()
+
+
+def test_paligemma_mask_is_left_alone_without_token_types():
+    """`Model.__call__` forwards no extra kwargs, so on the plain loss path the
+    token types never arrive and there is no prefix boundary to derive."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import (
+        _paligemma_causal_mask_wrapper, _paligemma_replace_mask,
+    )
+
+    mx_ = _utils_mx()
+    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+    padding = mx_.ones((1, 4), dtype=mx_.int32)
+
+    untouched = _paligemma_replace_mask(
+        SimpleNamespace(attention_mask_4d=outer_product), None, padding)
+    assert untouched.attention_mask_4d is outer_product
+    # Nor when upstream built no mask at all, e.g. a text-only batch.
+    assert _paligemma_replace_mask(
+        SimpleNamespace(attention_mask_4d=None),
+        mx_.zeros((1, 4), dtype=mx_.int32), padding).attention_mask_4d is None
+    # But it is replaced once the token types are there.
+    replaced = _paligemma_replace_mask(
+        SimpleNamespace(attention_mask_4d=outer_product),
+        mx_.array([[0, 0, 1, 1]], dtype=mx_.int32), padding)
+    assert replaced.attention_mask_4d is not outer_product
+    assert not np.asarray(replaced.attention_mask_4d).reshape(4, 4)[2, 3]
+
+
+def test_paligemma_embedder_wrapper_replaces_the_mask_it_wrapped():
+    """The wrapper is what actually reaches a loaded model, so it has to hand the
+    token types on rather than return upstream's mask untouched."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import _paligemma_causal_mask_wrapper
+
+    mx_ = _utils_mx()
+    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+    seen = {}
+
+    def original(_self, input_ids=None, pixel_values=None, mask=None, **kwargs):
+        seen["kwargs"] = kwargs
+        return SimpleNamespace(attention_mask_4d=outer_product)
+
+    wrapped = _paligemma_causal_mask_wrapper(original)
+    got = wrapped(object(), mx_.zeros((1, 4), dtype=mx_.int32), None,
+                  mx_.ones((1, 4), dtype=mx_.int32),
+                  token_type_ids=mx_.array([[0, 0, 1, 1]], dtype=mx_.int32))
+    # Upstream still runs and still sees its kwargs.
+    assert "token_type_ids" in seen["kwargs"]
+    # And its all-visible mask does not survive: the suffix cannot read ahead.
+    assert got.attention_mask_4d is not outer_product
+    assert not np.asarray(got.attention_mask_4d).reshape(4, 4)[2, 3]
+
+
+def test_paligemma_plain_loss_path_also_gets_the_causal_suffix():
+    """Upstream's call embeds with a fixed three arguments, dropping the token
+    types, so without threading them the `use_cce=False` path keeps leaking."""
+    from types import SimpleNamespace
+    from unsloth_zoo.mlx.loader import (
+        _paligemma_call_wrapper, _paligemma_causal_mask_wrapper,
+        _paligemma_pending_token_types,
+    )
+
+    mx_ = _utils_mx()
+    outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+    padding = mx_.ones((1, 4), dtype=mx_.int32)
+    seen = {}
+
+    def upstream_embed(_self, input_ids=None, pixel_values=None, mask=None, **kw):
+        return SimpleNamespace(attention_mask_4d=outer_product)
+
+    class _Model:
+        get_input_embeddings = _paligemma_causal_mask_wrapper(upstream_embed)
+
+        def __call__(self, input_ids, pixel_values=None, mask=None, **kwargs):
+            # Upstream drops kwargs here, exactly as PaliGemma does.
+            seen["mask"] = self.get_input_embeddings(
+                input_ids, pixel_values, mask).attention_mask_4d
+            return seen["mask"]
+
+    _Model.__call__ = _paligemma_call_wrapper(_Model.__call__)
+    model = _Model()
+    model(mx_.zeros((1, 4), dtype=mx_.int32), None, padding,
+          token_type_ids=mx_.array([[0, 0, 1, 1]], dtype=mx_.int32))
+
+    assert seen["mask"] is not outer_product
+    assert not np.asarray(seen["mask"]).reshape(4, 4)[2, 3]
+    # And nothing is left pending once the call returns.
+    assert _paligemma_pending_token_types() is None
+
+
+class _FakePaligemma:
+    """Upstream's shape: `__call__` embeds with a fixed three arguments, so the
+    token types it was given never reach the embedder on their own."""
+
+    outer_product = None          # set per test, so identity can be compared
+    seen = None
+
+    def get_input_embeddings(self, input_ids=None, pixel_values=None, mask=None,
+                             **kwargs):
+        from types import SimpleNamespace
+        return SimpleNamespace(attention_mask_4d=self.outer_product)
+
+    def __call__(self, input_ids, pixel_values=None, mask=None, **kwargs):
+        import threading
+        from unsloth_zoo.mlx.loader import _paligemma_pending_token_types
+        if self.seen is not None:
+            self.seen[threading.current_thread().name] = \
+                _paligemma_pending_token_types()
+        return self.get_input_embeddings(input_ids, pixel_values, mask)
+
+
+def test_paligemma_install_puts_both_wrappers_on_the_class():
+    """Removing either assignment leaves the matching production loss path
+    unfixed, so the install itself has to be checked, not just the wrappers."""
+    from unsloth_zoo.mlx.loader import _install_paligemma_causal_mask
+
+    mx_ = _utils_mx()
+    padding = mx_.ones((1, 4), dtype=mx_.int32)
+    token_type_ids = mx_.array([[0, 0, 1, 1]], dtype=mx_.int32)
+
+    class _Model(_FakePaligemma):
+        outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+        seen = {}
+
+    assert _install_paligemma_causal_mask(_Model)
+    model, ids = _Model(), mx_.zeros((1, 4), dtype=mx_.int32)
+
+    # The plain path: the call wrapper has to carry the token types across.
+    plain = model(ids, None, padding, token_type_ids=token_type_ids)
+    assert not np.asarray(plain.attention_mask_4d).reshape(4, 4)[2, 3]
+    # The cross-entropy path: the embedder wrapper receives them itself.
+    direct = model.get_input_embeddings(
+        ids, None, padding, token_type_ids=token_type_ids).attention_mask_4d
+    assert not np.asarray(direct).reshape(4, 4)[2, 3]
+
+
+def test_paligemma_token_types_do_not_cross_between_concurrent_callers():
+    """One model can serve several callers at once; an attribute on the model
+    would let one read another's batch."""
+    import threading
+    from unsloth_zoo.mlx.loader import (
+        _install_paligemma_causal_mask, _paligemma_pending_token_types,
+    )
+
+    mx_ = _utils_mx()
+    padding = mx_.ones((1, 4), dtype=mx_.int32)
+    entered = threading.Barrier(2)
+
+    class _Model(_FakePaligemma):
+        outer_product = mx_.ones((1, 1, 4, 4), dtype=mx_.bool_)
+        seen = {}
+
+        def __call__(self, *args, **kwargs):
+            entered.wait(timeout=5)      # both callers inside their own call
+            return _FakePaligemma.__call__(self, *args, **kwargs)
+
+    assert _install_paligemma_causal_mask(_Model)
+    model = _Model()
+    marks = {"a": mx_.array([[0, 0, 1, 1]], dtype=mx_.int32),
+             "b": mx_.array([[0, 1, 1, 1]], dtype=mx_.int32)}
+    threads = [
+        threading.Thread(name=name, target=model,
+                         args=(mx_.zeros((1, 4), dtype=mx_.int32), None, padding),
+                         kwargs={"token_type_ids": mark})
+        for name, mark in marks.items()
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    # Each caller saw its own token types, not the other's.
+    for name, mark in marks.items():
+        assert _Model.seen[name] is mark, f"{name} saw another caller's batch"
+    assert _paligemma_pending_token_types() is None

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2446,6 +2446,280 @@ def test_qualified_families_carry_their_probed_requirements():
     mlx_utils._check_audio_transformers_floor("gemma3n")  # no floor recorded
 
 
+class _Gemma4Extractor:
+    """Gemma 4's mel framing and masking, in the two shapes mlx-vlm has shipped.
+
+    Both releases pad waveforms to the longest in the batch and on to a multiple
+    of 128 samples before framing. 0.5.0 added the reference's semicausal
+    left-pad and its mask rule -- a frame is valid only when its whole analysis
+    window is real audio -- where 0.4.4 subsamples a sample-level mask, which
+    keeps frames a padded batch filled with silence.
+
+    Frame counts and mask sums match the shipped extractors at every length
+    asserted below. Mel values, dithering, normalisation and the 480,000-sample
+    truncation are not reproduced; nothing here depends on them.
+    """
+    sampling_rate = 16000
+    frame_length, hop_length, pad_multiple = 320, 160, 128
+
+    def __init__(self, semicausal_pad, emit_mask=True):
+        self.semicausal_pad = semicausal_pad
+        self.emit_mask = emit_mask
+
+    def __call__(self, waveforms, sampling_rate=None, return_attention_mask=True):
+        lengths = [len(w) for w in waveforms]
+        target = max(lengths)
+        if target % self.pad_multiple:
+            target = (target // self.pad_multiple + 1) * self.pad_multiple
+        left = self.frame_length // 2 if self.semicausal_pad else 0
+        frames = (target + left - (self.frame_length + 1)) // self.hop_length + 1
+        out = {"input_features": np.zeros(
+            (len(waveforms), max(frames, 0), 128), np.float32)}
+        if self.emit_mask:
+            offsets = np.arange(max(frames, 0)) * self.hop_length
+            out["input_features_mask"] = np.stack([
+                (offsets + self.frame_length < length + left) if left
+                else (offsets < length)
+                for length in lengths
+            ])
+        return out
+
+
+class Gemma4Processor:  # named as mlx-vlm's, so the family resolves to gemma4
+    tokenizer = type("_AudioTok", (_FakeTokenizer,), {
+        "audio_token": "<|audio|>",
+        "_vocab": dict(_FakeTokenizer._vocab, **{"<|audio|>": 300})})()
+
+    def __init__(self, extractor):
+        self.feature_extractor = extractor
+
+    def _compute_audio_num_tokens(self, waveform, sampling_rate):
+        raise AssertionError("the shipped duration rule must not be reached")
+
+    def __call__(self, text=None, audio=None, **_kwargs):
+        extracted = self.feature_extractor(audio, sampling_rate=16000)
+        runs = [[101] + [300] * self._compute_audio_num_tokens(clip, 16000) + [11]
+                for clip in audio]
+        width = max(len(run) for run in runs)
+        return {
+            "input_ids": np.array(
+                [run + [0] * (width - len(run)) for run in runs], np.int32),
+            "attention_mask": np.array(
+                [[1] * len(run) + [0] * (width - len(run)) for run in runs],
+                np.int32),
+            "input_features": extracted["input_features"],
+            "input_features_mask": extracted["input_features_mask"],
+        }
+
+
+class _ForwardsTheHook(Gemma4Processor):
+    """Keeps its own attributes, but writes that one hook through to another.
+
+    The narrowest sharing there is: a probe watching any other attribute name
+    sees an independent copy.
+    """
+    def __setattr__(self, name, value):
+        origin = self.__dict__.get("_origin")
+        if origin is not None and name == "_compute_audio_num_tokens":
+            return setattr(origin, name, value)
+        return object.__setattr__(self, name, value)
+
+    def __delattr__(self, name):
+        origin = self.__dict__.get("_origin")
+        if origin is not None and name == "_compute_audio_num_tokens":
+            return delattr(origin, name)
+        return object.__delattr__(self, name)
+
+    def __copy__(self):
+        twin = type(self)(self.feature_extractor)
+        object.__setattr__(twin, "_origin", self)
+        return twin
+
+
+@pytest.mark.parametrize("samples,reference,floor_044,mask_blind", [
+    # 5.855 s: ceil(duration / 40 ms) says 147 and the reference agrees, but
+    # 0.4.4's extractor emits one frame fewer -- copying the reference formula
+    # would keep predicting a frame that extractor never produces.
+    (93680, 147, 146, 147),
+    # 2.245 s: both extractors emit 56; only the duration rule is over, at 57.
+    (35920, 56, 56, 56),
+    # Short enough that the reference's trailing frames are all padding, so a
+    # count taken from the frame total instead of the mask says two.
+    (769, 1, 1, 2),
+])
+def test_gemma4_audio_placeholders_track_the_installed_extractor(
+        samples, reference, floor_044, mask_blind):
+    """Counts must equal the positions the audio tower emits, per version."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    clip = np.zeros(samples, dtype=np.float32)
+    counts = []
+    for semicausal_pad in (True, False):
+        processor = Gemma4Processor(_Gemma4Extractor(semicausal_pad))
+        mlx_utils._repair_gemma4_audio_processor(processor)
+        counts.append(processor._compute_audio_num_tokens(clip, 16000))
+    assert counts == [reference, floor_044]
+
+    # What a count that ignored the mask would produce, so the cases above that
+    # differ from it show the mask is load-bearing.
+    frames = _Gemma4Extractor(True)([clip])["input_features"].shape[1]
+    assert mlx_utils._gemma4_audio_encoder_positions(
+        np.ones(frames, dtype=bool)) == mask_blind
+    # An extractor reporting no mask leaves the encoder without one too, so
+    # every frame counts -- the same number.
+    maskless = Gemma4Processor(_Gemma4Extractor(True, emit_mask=False))
+    mlx_utils._repair_gemma4_audio_processor(maskless)
+    assert maskless._compute_audio_num_tokens(clip, 16000) == mask_blind
+
+
+@pytest.mark.parametrize("order", [(93680, 35920), (35920, 93680)])
+@pytest.mark.parametrize("emit_mask", [True, False])
+def test_padded_audio_batch_masks_each_clip_to_its_own_audio(order, emit_mask):
+    """Batch padding must not hand a short clip frames that are silence."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    # The 0.4.4 mask rule this corrects, and an extractor reporting no mask at
+    # all: padding looks like real audio either way once a batch is padded.
+    extractor = _Gemma4Extractor(False, emit_mask=emit_mask)
+    processor = Gemma4Processor(extractor)
+    clips = [np.zeros(samples, np.float32) for samples in order]
+    solo = [223 if samples == 35920 else 584 for samples in order]
+
+    batched = dict(extractor(clips))
+    as_collated = batched.get("input_features_mask")
+    features = batched["input_features"]
+    if emit_mask:
+        # The short clip keeps two frames of pure padding, and how many it
+        # keeps depends on what it was batched against.
+        assert sorted(int(m.sum()) for m in as_collated) == [225, 584]
+
+    corrected = mlx_utils._audio_repaired_processor(processor)
+    repaired = mlx_utils._repair_audio_batch(batched, clips, corrected)
+    counts = [corrected._compute_audio_num_tokens(clip, 16000) for clip in clips]
+    mask = repaired["input_features_mask"]
+    # Exact, not just the count: the frames kept must be that clip's own, at
+    # its own offsets, or the encoder reads silence for real audio.
+    assert mask.shape == (2, 584) and mask.dtype == np.dtype(bool)
+    for row, keep in enumerate(solo):
+        assert mask[row][:keep].all() and not mask[row][keep:].any()
+    # Every row's surviving positions now match the run written for that clip,
+    # and the features those positions index are still there.
+    assert [mlx_utils._gemma4_audio_encoder_positions(row)
+            for row in mask] == counts
+    assert repaired["input_features"] is features
+
+    # Half a contract: on a processor whose count was left alone, so is the
+    # mask. A clip list that does not pair with the feature rows -- in either
+    # direction -- is left alone too, so the collation check reports that
+    # instead of a plausible-looking mask hiding it.
+    three = [*clips, np.zeros(74000, np.float32)]
+    left_alone = [
+        mlx_utils._repair_audio_batch(dict(extractor(clips)), clips, processor),
+        mlx_utils._repair_audio_batch(dict(extractor(clips)), three, corrected),
+        mlx_utils._repair_audio_batch(dict(extractor(three)), clips, corrected),
+    ]
+    for untouched, source in zip(left_alone, (clips, clips, three)):
+        expected = extractor(source).get("input_features_mask")
+        assert (untouched.get("input_features_mask") is None if not emit_mask
+                else untouched["input_features_mask"].tolist()
+                == expected.tolist())
+
+    # A mask that does not cover its features is not left to broadcast: no
+    # other check compares the two.
+    if emit_mask:
+        for batch_clips in (clips, clips[:1]):
+            ragged = dict(extractor(batch_clips))
+            ragged["input_features_mask"] = (
+                ragged["input_features_mask"][:, :1])
+            with pytest.raises(ValueError, match="paired with their clips"):
+                mlx_utils._repair_audio_batch(ragged, batch_clips, corrected)
+
+
+def test_collation_repairs_the_audio_batch_before_the_model_sees_it():
+    import pickle
+
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    processor = Gemma4Processor(_Gemma4Extractor(False))
+    clips = [np.zeros(93680, np.float32), np.zeros(35920, np.float32)]
+    inputs = mlx_utils._processor_vlm_inputs(
+        processor, ["<|audio|>", "<|audio|>"], [[], []], 1024,
+        all_audio=[[clips[0]], [clips[1]]],
+    )
+    assert [int(m.sum()) for m in inputs["input_features_mask"]] == [584, 223]
+    assert inputs["input_features"].shape[:2] == (2, 584)
+    # The shared processor is never touched: a corrected count on it would meet
+    # an uncorrected mask in anything else using it, concurrently or after.
+    assert "_compute_audio_num_tokens" not in vars(processor)
+    assert not mlx_utils._audio_count_corrected(processor)
+    pickle.loads(pickle.dumps(processor))
+
+
+def test_the_corrected_count_rides_a_copy_and_only_for_its_family(monkeypatch):
+    """The correction must not be observable through the shared processor."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    monkeypatch.setattr(mlx_utils, "_AUDIO_MIN_TRANSFORMERS", {})
+    monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES", {
+        "gemma4": frozenset({mlx_utils._installed_mlx_vlm_version()}),
+        "fakegemmaaudio": frozenset({mlx_utils._installed_mlx_vlm_version()}),
+    })
+    processor = Gemma4Processor(_Gemma4Extractor(True))
+    assert mlx_utils._check_audio_family_gate(processor) == "gemma4"
+
+    corrected = mlx_utils._audio_repaired_processor(processor)
+    assert corrected is not processor and type(corrected) is type(processor)
+    assert corrected.feature_extractor is processor.feature_extractor
+    assert corrected._compute_audio_num_tokens(
+        np.zeros(35920, dtype=np.float32), 16000) == 56
+    # Built on the copy, not installed on the original and moved across.
+    assert corrected._compute_audio_num_tokens.args[0] is corrected
+
+    # Same family name, so the repair is reached, but not independently
+    # copyable -- correcting either would correct the caller's own processor.
+    # A copy that is the original, and one that keeps its own attributes but
+    # writes just that hook through -- the narrowest sharing there is.
+    for cls in (type("Gemma4Processor", (Gemma4Processor,),
+                     {"__copy__": lambda self: self}),
+                type("Gemma4Processor", (_ForwardsTheHook,), {})):
+        for own in (lambda clip, rate: 7, None):
+            shared = cls(_Gemma4Extractor(True))
+            if own is not None:
+                shared._compute_audio_num_tokens = own
+            with pytest.raises(NotImplementedError, match="independent object"):
+                mlx_utils._audio_repaired_processor(shared)
+            assert not mlx_utils._audio_count_corrected(shared)
+            # Refusing must leave the processor exactly as it was: whatever it
+            # had of its own, and nothing where it had been inheriting.
+            if own is not None:
+                assert shared._compute_audio_num_tokens is own
+            else:
+                assert "_compute_audio_num_tokens" not in vars(shared)
+    # The gate only decides support; nothing about the original changes, so a
+    # concurrent user of it cannot pick up half the correction.
+    assert "_compute_audio_num_tokens" not in vars(processor)
+    assert not mlx_utils._audio_count_corrected(processor)
+
+    other = _FakeGemmaAudioProcessor()
+    assert mlx_utils._check_audio_family_gate(other) == "fakegemmaaudio"
+    assert mlx_utils._audio_repaired_processor(other) is other
+
+
+def test_gemma4_repair_refuses_a_processor_it_cannot_correct():
+    """A renamed hook would silently restore the defect the gate says is fixed."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    renamed = type("_Renamed", (), {})()
+    renamed.feature_extractor = _Gemma4Extractor(True)
+    with pytest.raises(NotImplementedError, match="_compute_audio_num_tokens"):
+        mlx_utils._repair_gemma4_audio_processor(renamed)
+
+    no_extractor = Gemma4Processor(None)
+    mlx_utils._repair_gemma4_audio_processor(no_extractor)
+    with pytest.raises(NotImplementedError, match="audio feature extractor"):
+        no_extractor._compute_audio_num_tokens(np.zeros(16000, np.float32), 16000)
+
+
 def test_audio_merge_patch_is_held_and_restored_exactly():
     """Overlapping runs share the correction; the last one puts it back."""
     from unsloth_zoo.mlx.utils import (

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2098,3 +2098,262 @@ def test_gemma3n_altup_patch_declines_a_release_that_is_already_correct():
         model=SimpleNamespace(layers=[SimpleNamespace(altup=altup)])))
     assert not _fix_gemma3n_altup_batch(model)
     assert cls.correct is fixed, "an already-correct release must be left alone"
+# --- Audio input collation -------------------------------------------------
+
+
+class _FakeGemmaAudioProcessor(_ConversationalPromptCompletionProcessor):
+    """Gemma-style: one delimited soft-token run per clip."""
+    tokenizer = type("_AudioTok", (_FakeTokenizer,), {
+        "audio_token": "<audio_soft_token>",
+        "_vocab": dict(_FakeTokenizer._vocab, **{"<audio_soft_token>": 300})})()
+    feature_extractor = type("_Extractor", (), {"sampling_rate": 16000})()
+    soft_tokens = 3
+    def __init__(self, truncates=False):
+        super().__init__()
+        self.truncates = truncates
+    def apply_chat_template(self, messages, tokenize=False,
+                            add_generation_prompt=False):
+        # Real templates emit a placeholder per audio part.
+        marked = [dict(m, content=[
+            {"type": "text", "text": "<audio>"} if p.get("type") == "audio" else p
+            for p in m.get("content", [])
+        ] if isinstance(m.get("content"), list) else m.get("content", ""))
+            for m in messages]
+        return super().apply_chat_template(marked, tokenize=tokenize,
+                                           add_generation_prompt=add_generation_prompt)
+    def __call__(self, text, audio=None, max_length=None, **_kwargs):
+        # Delimited (301/302) as real templates do, so runs stay separable.
+        rows = [[101] + sum(([301] + [300] * self.soft_tokens + [302]
+                             for _ in range(v.count("<audio>"))), []) + [11]
+                for v in text]
+        width = max(len(r) for r in rows)
+        cut = max_length if self.truncates else width
+        pad = lambda r, v: r + [v] * (width - len(r))
+        out = {
+            "input_ids": np.array([pad(r, 0) for r in rows], np.int32)[:, :cut],
+            "attention_mask": np.array(
+                [pad([1] * len(r), 0) for r in rows], np.int32)[:, :cut],
+        }
+        if audio:  # equal-length clips; ragged batches are qualification work
+            feats = np.stack([np.asarray(c) for c in audio]).astype(np.float32)
+            out["input_features"] = feats
+            out["input_features_mask"] = np.ones(feats.shape, dtype=bool)
+        return out
+
+
+class _FakeAudioDecoder:  # datasets 4.x: output rate fixed at construction
+    def __init__(self, data, sample_rate=16000):
+        self._s = type("_D", (), {"data": data, "sample_rate": sample_rate})()
+    def get_all_samples(self):
+        return self._s
+
+
+def _audio_row(clip, text="hi", placeholder_only=False):
+    part = {"type": "audio"} if placeholder_only else {"type": "audio", "audio": clip}
+    content = [part] if placeholder_only or clip is not None else []
+    return {"messages": [
+        {"role": "user", "content": content + [{"type": "text", "text": text}]},
+        {"role": "assistant", "content": "ok"}]}
+
+
+def _qualify(monkeypatch, processor=None, version=None):
+    """Open the family allow-gate for one test."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+    family = mlx_utils._audio_family_from_processor(
+        processor or _FakeGemmaAudioProcessor())
+    monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES", {family: frozenset(
+        {version or mlx_utils._installed_mlx_vlm_version()})})
+
+
+@pytest.mark.parametrize("setup,message", [
+    (None, "not enabled for any model family"),
+    ("other_family", "is not supported for"),
+    ("other_version", "only been verified"),
+])
+def test_audio_gate_refuses_unverified_family_or_version(monkeypatch, setup, message):
+    if setup == "other_family":
+        from unsloth_zoo.mlx import utils as mlx_utils
+        monkeypatch.setattr(mlx_utils, "_AUDIO_QUALIFIED_FAMILIES",
+                            {"otherfam": frozenset({"9.9.9"})})
+    elif setup:
+        _qualify(monkeypatch, version="0.0.1-never")
+    with pytest.raises(NotImplementedError, match=message):
+        _finalized_collate([_audio_row(_CLIP)], _FakeGemmaAudioProcessor(), 16, None)
+
+
+_MONO = np.full(10, 0.5, dtype=np.float32)
+_STEREO = np.stack([np.zeros(10, np.float32), np.ones(10, np.float32)])
+_CLIP = {"array": _MONO, "sampling_rate": 16000}
+
+
+def _audio_hiding_plan_kwargs(**extra):
+    dataset = [
+        {"audio": [{"array": np.zeros(1600, dtype=np.float32),
+                    "sampling_rate": 16000}],
+         "text": "a"},
+    ]
+    return dict(
+        dataset=dataset,
+        processor=_FakeProcessor(),
+        config={"image_size": 16, "image_token_id": 200},
+        batch_size=1,
+        max_seq_length=8,
+        formatting_func=lambda row: {"text": row["text"]},
+        **extra,
+    )
+
+
+def test_batch_plan_gates_audio_a_formatter_hides_under_response_masking():
+    """With a response mask the plan filters rows first, formatting there and
+    collating with no formatter, so it needs the same gate."""
+    from unsloth_zoo.mlx.utils import _create_vlm_batch_plan
+
+    with pytest.raises((NotImplementedError, ValueError), match="audio"):
+        _create_vlm_batch_plan(**_audio_hiding_plan_kwargs(
+            response_mask_fn=lambda b: {"labels": b["input_ids"]},
+        ))
+
+
+def test_batch_plan_gates_audio_that_a_formatter_would_hide():
+    """The plan formats at construction and collates with no formatter, so the
+    collation gate never sees the audio the user actually supplied."""
+    from unsloth_zoo.mlx.utils import _create_vlm_batch_plan
+
+    dataset = [
+        {"audio": [{"array": np.zeros(1600, dtype=np.float32),
+                    "sampling_rate": 16000}],
+         "text": "a"},
+    ]
+    with pytest.raises((NotImplementedError, ValueError), match="audio"):
+        _create_vlm_batch_plan(
+            dataset=dataset,
+            processor=_FakeProcessor(),
+            config={"image_size": 16, "image_token_id": 200},
+            batch_size=1,
+            max_seq_length=8,
+            formatting_func=lambda row: {"text": row["text"]},
+        )
+
+
+# Channel-first stereo must average to the same mono waveform, never flatten
+# into a 20-sample concatenation of both channels.
+@pytest.mark.parametrize("clip", [_CLIP, _FakeAudioDecoder(_MONO),
+                                  _FakeAudioDecoder(_STEREO)],
+                         ids=["datasets3_mapping", "datasets4_decoder", "stereo"])
+def test_audio_source_forms_reach_the_processor_as_mono(monkeypatch, clip):
+    _qualify(monkeypatch)
+    row = _audio_row(clip)
+    feats = np.asarray(_finalized_collate([row], _FakeGemmaAudioProcessor(),
+                                          16, None)["input_features"])
+    assert feats.shape == (1, 10) and np.allclose(feats[0], 0.5)  # mono, averaged
+    # A bare message list must reach extraction; a single dict rendering
+    # without a placeholder must be refused, not trained on.
+    bare = _finalized_collate([row["messages"]], _FakeGemmaAudioProcessor(), 16, None)
+    assert np.asarray(bare["input_features"]).shape[0] == 1
+    with pytest.raises(ValueError, match="0 placeholder run"):
+        _finalized_collate([dict(row["messages"][0], text="hi")],
+                           _FakeGemmaAudioProcessor(), 16, None)
+
+
+def test_multiple_clips_keep_their_order_and_untyped_parts_count(monkeypatch):
+    _qualify(monkeypatch)
+    quiet = {"array": np.full(10, 0.25, np.float32), "sampling_rate": 16000}
+    loud = {"array": np.full(10, 0.75, np.float32), "sampling_rate": 16000}
+    row = {"messages": [{"role": "user", "content": [
+        {"type": "audio", "audio": quiet},
+        {"audio": loud},  # untyped part must still be inferred as audio
+        {"type": "text", "text": "hi"}]}, {"role": "assistant", "content": "ok"}]}
+    feats = np.asarray(_finalized_collate([row], _FakeGemmaAudioProcessor(),
+                                          32, None)["input_features"])
+    # Clip order must survive extraction, or features pair with the wrong runs.
+    assert np.allclose(feats[0], 0.25) and np.allclose(feats[1], 0.75)
+
+
+# over_cap models a processor diverting truncation to its audio extractor.
+@pytest.mark.parametrize("clip,message,max_len", [
+    ({"path": "a.wav", "bytes": b""}, "datasets.Audio", 16),
+    (_MONO, "must carry their sampling rate", 16),  # no rate: untrustworthy
+    ({"array": _MONO, "sampling_rate": 8000}, "8000 Hz", 16),
+    (None, "no audio data", 16),
+    (_CLIP, "did not apply truncation", 3),
+], ids=["undecoded", "no_rate", "rate_mismatch", "no_data", "over_cap"])
+def test_unusable_audio_rows_are_rejected(monkeypatch, clip, message, max_len):
+    processor = _FakeGemmaAudioProcessor()
+    _qualify(monkeypatch, processor=processor)
+    row = _audio_row(clip, placeholder_only=clip is None)
+    with pytest.raises(ValueError, match=message):
+        _finalized_collate([row], processor, max_len, None)
+
+
+def test_placeholders_without_features_are_rejected(monkeypatch):
+    _qualify(monkeypatch)
+    # Pre-rendered text can keep the placeholder after the clip is gone.
+    with pytest.raises(ValueError, match="returned no audio features"):
+        _finalized_collate([{"raw": "x"}], _FakeGemmaAudioProcessor(), 16, None,
+                           formatting_func=lambda _: {"text": "<audio>hi"})
+
+
+def test_audio_placeholders_masked_and_mixed_batches_collate(monkeypatch):
+    from unsloth_zoo.mlx.utils import _get_vlm_ignore_token_ids
+    _qualify(monkeypatch)
+    processor = _FakeGemmaAudioProcessor()
+    audio_row = dict(_audio_row(None, placeholder_only=True), audio=_CLIP)
+    batch = _finalized_collate(
+        [audio_row, _audio_row(None, text="plain")], processor, 16, None,
+        ignore_token_ids=_get_vlm_ignore_token_ids(processor=processor))
+    ids, labels = np.asarray(batch["input_ids"]), np.asarray(batch["labels"])
+    # The column feeds only the row carrying the placeholder.
+    assert ids.shape[0] == 2 and np.asarray(batch["input_features"]).shape[0] == 1
+    assert (ids[1] != 300).all() and (labels[ids == 300] == -100).all()
+
+
+_PC_AUDIO_ROW = {
+    "prompt": [{"role": "user", "content": [
+        {"type": "audio", "audio": _CLIP},
+        {"type": "text", "text": "transcribe"}]}],
+    "completion": [{"role": "assistant", "content": "done"}],
+}
+
+
+def test_prompt_completion_audio_rides_the_prompt_half(monkeypatch):
+    _qualify(monkeypatch)
+    batch, is_pc = _finalized_collate([_PC_AUDIO_ROW], _FakeGemmaAudioProcessor(),
+                                      16, None, return_prompt_completion=True)
+    assert is_pc and "input_features" in batch
+    # The host combine re-verifies after truncating: here the run is dropped.
+    with pytest.raises(ValueError, match="0 placeholder run"):
+        _finalized_collate([_PC_AUDIO_ROW], _FakeGemmaAudioProcessor(truncates=True),
+                           2, None, return_prompt_completion=True)
+    # Audio may not sit in the completion half, payload or not.
+    for part in ({"type": "audio", "audio": _CLIP}, {"type": "audio"}):
+        moved = {"prompt": [{"role": "user",
+                             "content": [{"type": "text", "text": "q"}]}],
+                 "completion": [{"role": "assistant", "content": [part]}]}
+        with pytest.raises(ValueError, match="audio in the completion half"):
+            _finalized_collate([moved], _FakeGemmaAudioProcessor(), 16, None,
+                               return_prompt_completion=True)
+
+
+def test_deferred_prompt_completion_staging_rechecks_audio_runs(monkeypatch):
+    """Production must build the pc_audio carrier and honor it at finalize."""
+    import mlx.core as current_mx
+    if current_mx is not mx:
+        pytest.skip("requires real MLX runtime without mlx_simulation monkeypatch")
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch, _finalize_vlm_batch
+
+    class _MLXValued(_FakeGemmaAudioProcessor):  # forces the deferred path
+        def __call__(self, text, audio=None, max_length=None, **_kw):
+            return {k: mx.array(v)
+                    for k, v in super().__call__(text, audio, max_length).items()}
+
+    processor = _MLXValued()
+    _qualify(monkeypatch, processor=processor)
+    staged, _ = _collate_vlm_batch([_PC_AUDIO_ROW], processor, 2, None,
+                                   reject_mlx_valued=True,
+                                   return_prompt_completion=True)
+    # MLX-valued halves defer the combine, so the counts must ride pc_audio for
+    # the post-combine check to be possible on the consumer thread.
+    assert staged.pc_opaque is not None and staged.pc_audio == ([1], [300])
+    # Truncation drops the run; the deferred check must catch it.
+    with pytest.raises(ValueError, match="0 placeholder run"):
+        _finalize_vlm_batch(staged)

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2790,3 +2790,42 @@ def test_patched_audio_merge_places_each_row_own_features():
         assert out.dtype == mx_.bfloat16
     finally:
         remove_audio_merge_patch(model)
+
+
+def test_phi4mm_token_ids_fall_back_to_the_mlx_vlm_defaults():
+    """Phi-4-multimodal's config.json declares neither token index.
+
+    Training threads the checkpoint mapping rather than the model's config
+    object, so both arrive absent and the compile preparation cannot read them
+    directly. mlx-vlm carries them as dataclass defaults.
+    """
+    from unsloth_zoo.mlx.utils import _phi4mm_token_ids
+
+    config_cls = pytest.importorskip("mlx_vlm.models.phi4mm.config").ModelConfig
+    fields = config_cls.__dataclass_fields__
+    expected = (int(fields["image_token_index"].default),
+                int(fields["audio_token_index"].default))
+
+    # The real checkpoint's shape: model_type present, neither index declared.
+    assert _phi4mm_token_ids({"model_type": "phi4mm"}) == expected
+    # A config that does declare them wins over the defaults.
+    assert _phi4mm_token_ids(
+        {"image_token_index": -7, "audio_token_index": 11}
+    ) == (-7, 11)
+    # One present, one absent: only the missing side falls back.
+    assert _phi4mm_token_ids({"image_token_index": -7}) == (-7, expected[1])
+
+
+def test_compile_preparation_survives_a_phi4mm_config_without_token_indices():
+    """The regression this guards is in the compile-preparation branch, not the
+    helper: training threads the checkpoint mapping, which declares neither
+    index, and `int(None)` raised there before the first step."""
+    from unsloth_zoo.mlx.utils import _prepare_vlm_batch_for_compile
+
+    pytest.importorskip("mlx_vlm.models.phi4mm.config")
+    batch = {
+        "input_ids": mx.array([[1, 2, 3]], dtype=mx.int32),
+        "attention_mask": mx.array([[1, 1, 1]], dtype=mx.int32),
+    }
+    # The real checkpoint's config.json shape: model_type only.
+    _prepare_vlm_batch_for_compile(batch, {"model_type": "phi4mm"})

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3015,9 +3015,11 @@ def test_the_delimiters_around_an_audio_run_are_not_targets():
     assert {151697, 151699} <= set(_get_vlm_ignore_token_ids(processor=_Delimited()))
 
 
-def test_an_untyped_audio_part_is_typed_whichever_alias_it_uses(monkeypatch):
-    """An untyped part is typed from its key, and a part the inference misses
-    reaches neither the family gate nor the extractor."""
+def test_an_audio_part_canonicalizes_whichever_alias_it_uses(monkeypatch):
+    """Every audio spelling ends up typed "audio", whether the caller wrote the
+    type out or left it off. An untyped alias otherwise reaches neither the
+    family gate nor the extractor, and one left under an explicit alias reaches
+    both but renders no placeholder."""
     from unsloth_zoo.mlx.utils import (
         _extract_vlm_audio, _normalize_vlm_messages, _raw_row_has_audio,
     )
@@ -3028,20 +3030,59 @@ def test_an_untyped_audio_part_is_typed_whichever_alias_it_uses(monkeypatch):
     # the caller's cannot coincide with it.
     ramp = {"array": np.linspace(-0.5, 0.5, 16, dtype=np.float32),
             "sampling_rate": 16000}
+    text = {"type": "text", "text": "hi"}
     for alias in ("audio", "audio_url", "input_audio"):
-        row = {"messages": [{"role": "user", "content": [
-            {alias: ramp}, {"type": "text", "text": "hi"}]}]}
-        messages = _normalize_vlm_messages(row["messages"])
-        part = messages[0]["content"][0]
-        # "audio", not the alias: Gemma's templates render a placeholder for
-        # that spelling alone.
-        assert part["type"] == "audio", alias
-        assert _raw_row_has_audio(row) is True, alias
-        # ...and the caller's own clip reaches the extractor, which reads the
-        # payload from the key the caller used.
-        clips = _extract_vlm_audio(row, messages, processor)
-        assert len(clips) == 1, alias
-        assert np.array_equal(np.asarray(clips[0]), ramp["array"]), alias
+        for part in ({alias: ramp}, {"type": alias, alias: ramp}):
+            # The clip takes the first, an interior and the last position on
+            # both axes -- content entry within a message, and message within
+            # the conversation -- past index 1 on each, and one layout carries
+            # two clips, once across messages and once within one. An
+            # implementation that reaches only some positions, ties the two
+            # indices together, or stops after the first clip in a message or
+            # in the row, fails one of these.
+            for content in ([[dict(part), text]],
+                            [[text, dict(part)]],
+                            [[text, dict(part), text]],
+                            [[text, text, dict(part)]],
+                            [[dict(part), text], [text]],
+                            [[text], [text, dict(part)]],
+                            [[text], [dict(part), text], [text]],
+                            [[text], [text], [text, dict(part)]],
+                            [[dict(part), text], [text, dict(part)]],
+                            [[dict(part), text, dict(part)]]):
+                row = {"messages": [{"role": "user", "content": entries}
+                                    for entries in content]}
+                messages = _normalize_vlm_messages(row["messages"])
+                # Normalization retypes in place: the conversation keeps its
+                # shape and every clip keeps the coordinates it was given, so
+                # a pass that relocated or dropped one would not survive here.
+                at = [(index, position)
+                      for index, entries in enumerate(content)
+                      for position, entry in enumerate(entries) if alias in entry]
+                assert [len(message["content"]) for message in messages] == \
+                    [len(entries) for entries in content], (part, content)
+                assert [(index, position)
+                        for index, message in enumerate(messages)
+                        for position, entry in enumerate(message["content"])
+                        if alias in entry] == at, (part, content)
+                for index, position in at:
+                    # "audio", not the alias: Gemma 3n's template renders a
+                    # placeholder for that spelling alone.
+                    assert messages[index]["content"][position]["type"] == \
+                        "audio", (part, content)
+                assert _raw_row_has_audio(row) is True, (part, content)
+                # ...and the caller's own clips reach the extractor, which
+                # reads the payload from the key the caller used.
+                clips = _extract_vlm_audio(row, messages, processor)
+                assert len(clips) == len(at), (part, content)
+                for clip in clips:
+                    assert np.array_equal(
+                        np.asarray(clip), ramp["array"]), (part, content)
+
+    # A type outside the audio spellings is never rewritten.
+    kept = _normalize_vlm_messages(
+        [{"role": "user", "content": [{"type": "video", "video": "v.mp4"}]}])
+    assert kept[0]["content"][0]["type"] == "video"
 
 
 def test_a_fixed_budget_row_cannot_hide_a_short_run_behind_a_long_one():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2284,6 +2284,19 @@ def test_unusable_audio_rows_are_rejected(monkeypatch, clip, message, max_len):
         _finalized_collate([row], processor, max_len, None)
 
 
+def test_fixed_budget_families_reject_shortened_runs(monkeypatch):
+    """A fixed per-clip budget detects a run that was clipped, not dropped."""
+    class _Budgeted(_FakeGemmaAudioProcessor):
+        audio_seq_length = 3  # exactly 3 positions per clip
+
+    processor = _Budgeted(truncates=True)
+    _qualify(monkeypatch, processor=processor)
+    # Truncation leaves 2 of 3 placeholders: one run survives, so only the
+    # budget can tell the row was clipped.
+    with pytest.raises(ValueError, match="merges 3 per clip"):
+        _finalized_collate([_audio_row(_CLIP)], processor, 4, None)
+
+
 def test_placeholders_without_features_are_rejected(monkeypatch):
     _qualify(monkeypatch)
     # Pre-rendered text can keep the placeholder after the clip is gone.

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2755,6 +2755,24 @@ def test_gemma4_repair_refuses_a_processor_it_cannot_correct():
         no_extractor._compute_audio_num_tokens(np.zeros(16000, np.float32), 16000)
 
 
+def test_the_merge_correction_follows_the_family_not_its_spelling():
+    """mlx-vlm lowercases model_type before selecting the module, so a
+    differently spelled checkpoint loads the same family and passes the audio
+    gate. Matching it exactly here would skip the correction for a model whose
+    merge needs it, and the misalignment that follows is silent."""
+    from unsloth_zoo.mlx.utils import audio_merge_patch_needed
+
+    # Every casing, not a sample of them: a listed few can be satisfied by
+    # matching those strings, which is the defect this guards against.
+    import itertools
+    for chars in itertools.product(*({c.lower(), c.upper()} for c in "gemma4")):
+        spelling = "".join(chars)
+        assert audio_merge_patch_needed({"model_type": spelling}), spelling
+    # Families whose merge is already per row must still be left alone.
+    for other in ("gemma3n", "phi4mm", "minicpmo", None):
+        assert not audio_merge_patch_needed({"model_type": other}), other
+
+
 def test_audio_merge_patch_is_held_and_restored_exactly():
     """Overlapping runs share the correction; the last one puts it back."""
     from unsloth_zoo.mlx.utils import (

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3624,6 +3624,59 @@ class _AudioModel:
         return [(name, None) for name in self._names]
 
 
+def test_a_pair_taking_processor_is_not_reported_unusable():
+    """Some processors take ``(samples, rate)`` pairs and reject a bare
+    waveform by failing to unpack it. Reading that first refusal as the answer
+    reports a working checkpoint as unusable, which is what Phi-4's
+    remote-code processor did."""
+    from unsloth_zoo.mlx.utils import (
+        _AUDIO_PROBE_RATE, _AUDIO_PROBE_TONES, _audio_payload_as_pairs,
+        _audio_probe_tone, audio_input_capability,
+    )
+
+    class _PairsOnly(_ProbeProcessor):
+        def __init__(self):
+            super().__init__()
+            self.seen = []
+
+        def __call__(self, text, audio=None, **kwargs):
+            for entry in audio or ():
+                samples, rate = entry  # a bare waveform raises here
+                self.seen.append((len(samples), rate))
+            return super().__call__(text, audio=audio, **kwargs)
+
+    processor = _PairsOnly()
+    verdict = audio_input_capability(_AudioModel(), processor)
+    assert verdict.capable is True and verdict.processor_ok is True
+    # The whole waveform arrives, with the rate it was built at alongside it.
+    whole = len(_audio_probe_tone(_AUDIO_PROBE_RATE, _AUDIO_PROBE_TONES[0]))
+    assert processor.seen and set(processor.seen) == {(whole, _AUDIO_PROBE_RATE)}
+
+    # An unrelated refusal is not a payload-shape complaint, so it is reported
+    # rather than retried in another shape.
+    class _Broken(_ProbeProcessor):
+        def __init__(self):
+            super().__init__()
+            self.saw_pairs = False
+
+        def __call__(self, text, audio=None, **kwargs):
+            self.saw_pairs |= any(isinstance(entry, tuple) for entry in audio or ())
+            raise ValueError("this processor is broken")
+
+    broken = _Broken()
+    assert audio_input_capability(_AudioModel(), broken).capable is False
+    assert broken.saw_pairs is False
+
+    # A clip that carries no rate of its own -- what a dataset column yields --
+    # takes the rate the processor's extractor expects, which Phi-4 keeps on a
+    # separately named audio extractor rather than on the processor itself.
+    rated = type("_Rated", (_ProbeProcessor,), {
+        "audio_processor": type("_Extractor", (), {"sampling_rate": 22050})(),
+    })()
+    bare = np.zeros(4, dtype=np.float32)
+    assert _audio_payload_as_pairs([bare], rated)[0][1] == 22050
+
+
 def test_a_checkpoint_that_drops_its_audio_is_not_capable():
     """The motivating defect: the export omits the audio half of its
     preprocessor configuration, so the processor takes the argument and skips

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3035,6 +3035,33 @@ def test_the_delimiters_around_an_audio_run_are_not_targets():
     assert {151697, 151699} <= set(_get_vlm_ignore_token_ids(processor=_Delimited()))
 
 
+def test_gemma4_audio_delimiters_are_not_targets():
+    """Gemma 4 spells them boa/eoa rather than audio_start/audio_end, and wraps
+    every clip in them: processing_gemma4 renders boa_token + placeholders +
+    eoa_token per clip, and gemma4/config.py declares boa_token_id/eoa_token_id.
+    The image pair boi/eoi was already resolved; without the audio pair the two
+    delimiters stayed supervised on every audio row."""
+    from unsloth_zoo.mlx.utils import _get_vlm_ignore_token_ids
+
+    class _Gemma4(_FakeProcessor):
+        tokenizer = type("_Tok", (_FakeTokenizer,), {
+            "boa_token": "<|begin_of_audio|>",
+            "eoa_token": "<|end_of_audio|>",
+            "_vocab": dict(_FakeTokenizer._vocab, **{
+                "<|begin_of_audio|>": 256000, "<|end_of_audio|>": 258883}),
+        })()
+
+    by_token = set(_get_vlm_ignore_token_ids(processor=_Gemma4()))
+    assert {256000, 258883} <= by_token, "resolved from the tokenizer attributes"
+
+    # And from the checkpoint config, which is where gemma4 actually declares them.
+    by_config = set(_get_vlm_ignore_token_ids(
+        processor=_FakeProcessor(),
+        config={"boa_token_id": 256000, "eoa_token_id": 258883},
+    ))
+    assert {256000, 258883} <= by_config
+
+
 def test_an_audio_part_canonicalizes_whichever_alias_it_uses(monkeypatch):
     """Every audio spelling ends up typed "audio", whether the caller wrote the
     type out or left it off. An untyped alias otherwise reaches neither the

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3729,6 +3729,67 @@ def test_ragged_image_metadata_survives_an_audio_batch():
     ]
 
 
+def test_clips_of_unequal_duration_all_reach_the_model():
+    """Audio features are one array per clip and clips run different lengths,
+    so they do not stack. Keeping only the first left a batch whose ids,
+    placeholder runs and labels still described every clip -- the pairing
+    `_assert_audio_features_present` verifies a step earlier, undone here, and
+    silently: the run trains against features belonging to another clip."""
+    from unsloth_zoo.mlx.utils import (
+        _assert_audio_features_present, _to_mx_vlm_batch,
+        _vlm_batch_carries_audio,
+    )
+
+    inputs = {
+        "input_ids": np.zeros((1, 8), dtype=np.int32),
+        "input_features": [np.zeros((80, 300), np.float32),
+                           np.zeros((80, 137), np.float32)],
+    }
+    # The count the collation established, before the conversion touches it.
+    _assert_audio_features_present(inputs, 2, _FakeProcessor())
+
+    features = _to_mx_vlm_batch(inputs)["input_features"]
+    assert len(features) == 2, "a clip was dropped by the conversion"
+    assert [tuple(f.shape) for f in features] == [(80, 300), (80, 137)]
+    # And the batch still reports itself as audio, so it is routed eagerly
+    # rather than into a compiled signature it has no fixed shape for.
+    assert _vlm_batch_carries_audio({"input_features": features}) is True
+
+    # Equal-length clips stack as before -- the fallback is not the usual path.
+    stacked = _to_mx_vlm_batch({
+        "input_features": [np.zeros((80, 300), np.float32)] * 2,
+    })["input_features"]
+    assert tuple(stacked.shape) == (2, 80, 300)
+
+
+def test_nested_audio_rows_are_paired_clip_by_clip():
+    """A processor that wants ``(samples, rate)`` pairs may also want its audio
+    nested per row (MiniCPM-o). Pairing the payload as though its entries were
+    clips fused each row into one 2-D 'clip' carrying no rate -- or, when the
+    row's clips ran different lengths, raised out of numpy, reporting a payload
+    the processor was never offered."""
+    from unsloth_zoo.mlx.utils import (
+        _AudioClip, _audio_payload_as_pairs, _format_vlm_audio_for_processor,
+    )
+
+    nesting = type("_MiniCPMOProcessor", (), {})
+    nesting.__module__ = "transformers.models.minicpmo.processing_minicpmo"
+
+    rows = [[_AudioClip(np.zeros(1600, np.float32), 16000),
+             _AudioClip(np.zeros(800, np.float32), 22050)],
+            [_AudioClip(np.zeros(1600, np.float32), 16000)]]
+    payload = _format_vlm_audio_for_processor(rows, processor=nesting())
+    paired = _audio_payload_as_pairs(payload, nesting())
+
+    assert [len(row) for row in paired] == [2, 1], "the row layout was lost"
+    assert [[rate for _, rate in row] for row in paired] == [
+        [16000, 22050], [16000]
+    ], "clips took a neighbour's rate"
+    assert [[tuple(s.shape) for s, _ in row] for row in paired] == [
+        [(1600,), (800,)], [(1600,)]
+    ]
+
+
 def test_collation_hands_the_clip_lengths_to_the_window_check(monkeypatch):
     """The check can only see clips the collation passes it, so dropping that
     wiring would leave it live but blind."""

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2159,7 +2159,6 @@ def _audio_row(clip, text="hi", placeholder_only=False):
 
 
 def _qualify(monkeypatch, processor=None, version=None):
-    """Open the family allow-gate for one test."""
     from unsloth_zoo.mlx import utils as mlx_utils
     family = mlx_utils._audio_family_from_processor(
         processor or _FakeGemmaAudioProcessor())
@@ -2246,7 +2245,7 @@ def test_audio_source_forms_reach_the_processor_as_mono(monkeypatch, clip):
     row = _audio_row(clip)
     feats = np.asarray(_finalized_collate([row], _FakeGemmaAudioProcessor(),
                                           16, None)["input_features"])
-    assert feats.shape == (1, 10) and np.allclose(feats[0], 0.5)  # mono, averaged
+    assert feats.shape == (1, 10) and np.allclose(feats[0], 0.5)
     # A bare message list must reach extraction; a single dict rendering
     # without a placeholder must be refused, not trained on.
     bare = _finalized_collate([row["messages"]], _FakeGemmaAudioProcessor(), 16, None)
@@ -2262,7 +2261,7 @@ def test_multiple_clips_keep_their_order_and_untyped_parts_count(monkeypatch):
     loud = {"array": np.full(10, 0.75, np.float32), "sampling_rate": 16000}
     row = {"messages": [{"role": "user", "content": [
         {"type": "audio", "audio": quiet},
-        {"audio": loud},  # untyped part must still be inferred as audio
+        {"audio": loud},
         {"type": "text", "text": "hi"}]}, {"role": "assistant", "content": "ok"}]}
     feats = np.asarray(_finalized_collate([row], _FakeGemmaAudioProcessor(),
                                           32, None)["input_features"])
@@ -2287,9 +2286,8 @@ def test_unusable_audio_rows_are_rejected(monkeypatch, clip, message, max_len):
 
 
 def test_fixed_budget_families_reject_shortened_runs(monkeypatch):
-    """A fixed per-clip budget detects a run that was clipped, not dropped."""
     class _Budgeted(_FakeGemmaAudioProcessor):
-        audio_seq_length = 3  # exactly 3 positions per clip
+        audio_seq_length = 3
 
     processor = _Budgeted(truncates=True)
     _qualify(monkeypatch, processor=processor)
@@ -2297,6 +2295,22 @@ def test_fixed_budget_families_reject_shortened_runs(monkeypatch):
     # budget can tell the row was clipped.
     with pytest.raises(ValueError, match="merges 3 per clip"):
         _finalized_collate([_audio_row(_CLIP)], processor, 4, None)
+
+
+def test_a_prompt_completion_combine_cannot_clip_a_fixed_budget_run(monkeypatch):
+    """The combine truncates after the halves are checked, so it is its own
+    chance to cut a run short. One run per clip still survives that, which is
+    why the budget has to reach the post-combine check too."""
+    class _Budgeted(_FakeGemmaAudioProcessor):
+        audio_seq_length = 3
+
+    processor = _Budgeted()
+    _qualify(monkeypatch, processor=processor)
+    # The halves are checked untruncated and pass; the combine then cuts the
+    # run to 2 of 3, which still leaves one run for the count check to accept.
+    with pytest.raises(ValueError, match="merges 3 per clip"):
+        _finalized_collate([_PC_AUDIO_ROW], processor, 4, None,
+                           return_prompt_completion=True)
 
 
 def test_processors_taking_audio_pairs_are_accommodated(monkeypatch):
@@ -2451,6 +2465,33 @@ def test_prompt_completion_refuses_audio_stated_as_spans(monkeypatch):
                            return_prompt_completion=True)
 
 
+def test_the_deferred_combine_carries_the_fixed_budget_too(monkeypatch):
+    """MLX-valued halves defer the combine to the consumer thread, so the
+    budget has to survive the carrier as well -- a run the combine cuts short
+    still leaves one run per clip, and the count check alone accepts it."""
+    import mlx.core as current_mx
+    if current_mx is not mx:
+        pytest.skip("requires real MLX runtime without mlx_simulation monkeypatch")
+    from unsloth_zoo.mlx.utils import _collate_vlm_batch, _finalize_vlm_batch
+
+    class _BudgetedMLXValued(_FakeGemmaAudioProcessor):
+        audio_seq_length = 3
+
+        def __call__(self, text, audio=None, max_length=None, **_kw):
+            return {k: mx.array(v)
+                    for k, v in super().__call__(text, audio, max_length).items()}
+
+    processor = _BudgetedMLXValued()
+    _qualify(monkeypatch, processor=processor)
+    staged, _ = _collate_vlm_batch([_PC_AUDIO_ROW], processor, 4, None,
+                                   reject_mlx_valued=True,
+                                   return_prompt_completion=True)
+    assert staged.pc_audio == ([1], [300], 3)
+    # The combine truncates to 4, cutting the run to 2 of 3.
+    with pytest.raises(ValueError, match="merges 3 per clip"):
+        _finalize_vlm_batch(staged)
+
+
 def test_deferred_prompt_completion_staging_rechecks_audio_runs(monkeypatch):
     """Production must build the pc_audio carrier and honor it at finalize."""
     import mlx.core as current_mx
@@ -2458,7 +2499,7 @@ def test_deferred_prompt_completion_staging_rechecks_audio_runs(monkeypatch):
         pytest.skip("requires real MLX runtime without mlx_simulation monkeypatch")
     from unsloth_zoo.mlx.utils import _collate_vlm_batch, _finalize_vlm_batch
 
-    class _MLXValued(_FakeGemmaAudioProcessor):  # forces the deferred path
+    class _MLXValued(_FakeGemmaAudioProcessor):
         def __call__(self, text, audio=None, max_length=None, **_kw):
             return {k: mx.array(v)
                     for k, v in super().__call__(text, audio, max_length).items()}
@@ -2469,8 +2510,10 @@ def test_deferred_prompt_completion_staging_rechecks_audio_runs(monkeypatch):
                                    reject_mlx_valued=True,
                                    return_prompt_completion=True)
     # MLX-valued halves defer the combine, so the counts must ride pc_audio for
-    # the post-combine check to be possible on the consumer thread.
-    assert staged.pc_opaque is not None and staged.pc_audio == ([1], [300])
+    # the post-combine check to be possible on the consumer thread. This family
+    # has no fixed budget, hence the third slot is empty.
+    assert staged.pc_opaque is not None
+    assert staged.pc_audio == ([1], [300], None)
     # Truncation drops the run; the deferred check must catch it.
     with pytest.raises(ValueError, match="0 placeholder run"):
         _finalize_vlm_batch(staged)
@@ -2496,7 +2539,6 @@ def test_audio_merge_compacts_valid_features_per_row():
 
 
 def test_qualified_families_carry_their_probed_requirements():
-    """The shipped gate names the families whose probes actually ran."""
     from unsloth_zoo.mlx import utils as mlx_utils
 
     gate = mlx_utils._AUDIO_QUALIFIED_FAMILIES
@@ -2619,7 +2661,6 @@ class _ForwardsTheHook(Gemma4Processor):
 ])
 def test_gemma4_audio_placeholders_track_the_installed_extractor(
         samples, reference, floor_044, mask_blind):
-    """Counts must equal the positions the audio tower emits, per version."""
     from unsloth_zoo.mlx import utils as mlx_utils
 
     clip = np.zeros(samples, dtype=np.float32)
@@ -3452,7 +3493,6 @@ def test_overlong_rows_are_refused_by_what_the_model_attends():
 
 
 class _ProbeProcessor:
-    """A processor that reads its audio, as a capable checkpoint's does."""
 
     def __init__(self, needs_text=None):
         self.needs_text = needs_text
@@ -3677,3 +3717,28 @@ def test_even_a_base_exception_cannot_escape_the_capability_check():
 
     verdict = audio_input_capability(_Interrupts(), _ProbeProcessor())
     assert verdict.capable is False and "could not run" in verdict.reason
+
+
+def test_the_repeated_audio_placeholder_is_never_a_target(monkeypatch):
+    """Phi-4 spells its placeholder `<|endoftext11|>` and declares it in neither
+    the tokenizer attributes nor its checkpoint config, so the names the loss
+    mask collects from do not reach it and every audio position was supervised.
+    It is resolved the same way run counting resolves it."""
+    from unsloth_zoo.mlx.utils import (
+        _get_vlm_audio_soft_token_ids, _get_vlm_ignore_token_ids,
+    )
+
+    class _UndeclaredPlaceholder(_FakeProcessor):
+        # Phi-4's shape: the placeholder is in the vocabulary and nowhere else.
+        # No `audio_token` attribute, no config index -- only the spelling.
+        tokenizer = type("_Tok", (_FakeTokenizer,), {
+            "_vocab": dict(_FakeTokenizer._vocab, **{"<|endoftext11|>": 200011}),
+        })()
+
+    processor = _UndeclaredPlaceholder()
+    assert not hasattr(processor.tokenizer, "audio_token")
+    soft = _get_vlm_audio_soft_token_ids(processor)
+    assert soft, "this fixture must have a resolvable placeholder"
+    ignored = _get_vlm_ignore_token_ids(processor=processor) or []
+    for token_id in soft:
+        assert token_id in ignored, token_id

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3053,6 +3053,61 @@ def test_the_hold_count_is_only_touched_under_the_lock(monkeypatch):
     assert model.get_input_embeddings() == "original"
 
 
+def test_the_wrapper_swap_happens_inside_the_critical_section(monkeypatch):
+    """Counting acquisitions is not enough: the capture, the install and the
+    restoration have to be *inside* the lock, not merely preceded by it. If the
+    lock is released after the count and before the swap, an installer arriving
+    while the last holder restores can capture the outgoing wrapper as its own
+    original, and the remover then overwrites the freshly installed one.
+
+    Observed by recording what `get_input_embeddings` is at lock entry and
+    exit: a swap that happened inside shows a difference across that span.
+    """
+    import threading
+
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    spans = []
+
+    class _ObservingLock:
+        def __init__(self):
+            self._lock = threading.Lock()
+            self._model = None
+
+        def watch(self, model):
+            self._model = model
+
+        def __enter__(self):
+            self._entry = getattr(self._model, "get_input_embeddings", None)
+            return self._lock.__enter__()
+
+        def __exit__(self, *exc):
+            spans.append((
+                getattr(self._entry, "__name__", None),
+                getattr(getattr(self._model, "get_input_embeddings", None),
+                        "__name__", None),
+            ))
+            return self._lock.__exit__(*exc)
+
+    lock = _ObservingLock()
+    monkeypatch.setattr(mlx_utils, "_AUDIO_MERGE_LOCK", lock)
+
+    class _Model:
+        def get_input_embeddings(self, *a, **k):
+            return "original"
+
+    model = _Model()
+    lock.watch(model)
+
+    mlx_utils.install_audio_merge_patch(model, 1)
+    assert spans[-1] == ("get_input_embeddings", "patched"), (
+        "the wrapper was installed outside the lock: " + repr(spans[-1]))
+
+    mlx_utils.remove_audio_merge_patch(model)
+    assert spans[-1] == ("patched", "get_input_embeddings"), (
+        "the wrapper was restored outside the lock: " + repr(spans[-1]))
+
+
 def test_patched_audio_merge_places_each_row_own_features():
     """The correction must actually re-pair features, not just wrap the call."""
     import mlx.core as current_mx

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2965,6 +2965,54 @@ def test_audio_merge_patch_is_held_and_restored_exactly():
 
 
 
+def test_concurrent_installs_take_one_wrapper_and_one_hold_each():
+    """The hold count is read, decided on and written back, which is not atomic
+    under the GIL. Two trainers starting close together -- the case this
+    function documents as supported -- could otherwise both read zero, both
+    install a wrapper, and both leave the count at one, so the first to finish
+    would restore the original embedder while the other was still training.
+
+    The barrier lines the threads up on the read, which is where they would
+    interleave; without the lock the count lands on 1 instead of the number of
+    holders."""
+    import threading
+
+    from unsloth_zoo.mlx.utils import (
+        _AUDIO_MERGE_HOLDERS, install_audio_merge_patch, remove_audio_merge_patch,
+    )
+
+    class _Model:
+        def get_input_embeddings(self, *a, **k):
+            return "original"
+
+    workers = 8
+    model = _Model()
+    original = model.get_input_embeddings
+    barrier = threading.Barrier(workers)
+    granted = []
+
+    def _install():
+        barrier.wait()
+        granted.append(install_audio_merge_patch(model, 1))
+
+    threads = [threading.Thread(target=_install) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert granted == [True] * workers, "every caller must be told it holds"
+    assert getattr(model, _AUDIO_MERGE_HOLDERS) == workers
+    assert model.get_input_embeddings.__name__ == "patched", "exactly one wrapper"
+
+    # And the correction survives until the last release, not the first.
+    for _ in range(workers - 1):
+        assert remove_audio_merge_patch(model) is False
+        assert model.get_input_embeddings.__name__ == "patched"
+    assert remove_audio_merge_patch(model) is True
+    assert model.get_input_embeddings() == original()
+
+
 def test_patched_audio_merge_places_each_row_own_features():
     """The correction must actually re-pair features, not just wrap the call."""
     import mlx.core as current_mx

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3004,6 +3004,10 @@ def test_concurrent_installs_take_one_wrapper_and_one_hold_each():
     assert granted == [True] * workers, "every caller must be told it holds"
     assert getattr(model, _AUDIO_MERGE_HOLDERS) == workers
     assert model.get_input_embeddings.__name__ == "patched", "exactly one wrapper"
+    # Note this alone does not prove serialization: the read and the write are
+    # adjacent, so the GIL rarely switches between them and the assertions
+    # above hold by luck even unlocked. The regression guard is the test below,
+    # which asserts the critical section is actually entered under the lock.
 
     # And the correction survives until the last release, not the first.
     for _ in range(workers - 1):
@@ -3011,6 +3015,42 @@ def test_concurrent_installs_take_one_wrapper_and_one_hold_each():
         assert model.get_input_embeddings.__name__ == "patched"
     assert remove_audio_merge_patch(model) is True
     assert model.get_input_embeddings() == original()
+
+
+def test_the_hold_count_is_only_touched_under_the_lock(monkeypatch):
+    """The guard the threaded test above cannot be: assert the read/decide/write
+    really runs inside the lock, by counting acquisitions. Drop the `with` and
+    the count goes to zero, whatever the scheduler happens to do."""
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    acquired = []
+
+    class _RecordingLock:
+        def __init__(self):
+            self._lock = __import__("threading").Lock()
+
+        def __enter__(self):
+            acquired.append("in")
+            return self._lock.__enter__()
+
+        def __exit__(self, *exc):
+            return self._lock.__exit__(*exc)
+
+    monkeypatch.setattr(mlx_utils, "_AUDIO_MERGE_LOCK", _RecordingLock())
+
+    class _Model:
+        def get_input_embeddings(self, *a, **k):
+            return "original"
+
+    model = _Model()
+    mlx_utils.install_audio_merge_patch(model, 1)
+    assert len(acquired) == 1, "install did not serialize the hold count"
+    mlx_utils.install_audio_merge_patch(model, 1)
+    assert len(acquired) == 2, "the second hold bypassed the lock"
+    mlx_utils.remove_audio_merge_patch(model)
+    mlx_utils.remove_audio_merge_patch(model)
+    assert len(acquired) == 4, "release did not serialize the hold count"
+    assert model.get_input_embeddings() == "original"
 
 
 def test_patched_audio_merge_places_each_row_own_features():

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3035,6 +3035,39 @@ def test_the_delimiters_around_an_audio_run_are_not_targets():
     assert {151697, 151699} <= set(_get_vlm_ignore_token_ids(processor=_Delimited()))
 
 
+def test_a_bare_message_list_row_is_scanned_for_audio(monkeypatch):
+    """A row that is itself a list of messages is a supported shape, which
+    _collate_vlm_batch normalizes. The pre-formatter scan has to see it too:
+    a formatting_func that drops the clips otherwise leaves the family gate
+    nothing to refuse, and the row trains as text with its audio discarded."""
+    from unsloth_zoo.mlx.utils import (
+        _format_vlm_row_gating_audio, _raw_row_has_audio,
+    )
+
+    clip = {"array": np.zeros(16, np.float32), "sampling_rate": 16000}
+    messages = [
+        {"role": "user", "content": [{"type": "audio", "audio": clip},
+                                     {"type": "text", "text": "transcribe"}]},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+    assert _raw_row_has_audio({"messages": messages}) is True
+    assert _raw_row_has_audio(messages) is True, "the same row, unwrapped"
+
+    # An unqualified family must still be refused when the formatter hides the
+    # clips, which is the whole point of scanning before formatting.
+    from unsloth_zoo.mlx import utils as mlx_utils
+
+    monkeypatch.setattr(
+        mlx_utils, "_AUDIO_QUALIFIED_FAMILIES", {"other": frozenset({"0.0.0"})},
+    )
+    strip_audio = lambda row: {"messages": [
+        {"role": "user", "content": [{"type": "text", "text": "transcribe"}]},
+        {"role": "assistant", "content": "ok"}]}
+    with pytest.raises(NotImplementedError):
+        _format_vlm_row_gating_audio(messages, strip_audio, _FakeGemmaAudioProcessor())
+
+
 def test_gemma4_audio_delimiters_are_not_targets():
     """Gemma 4 spells them boa/eoa rather than audio_start/audio_end, and wraps
     every clip in them: processing_gemma4 renders boa_token + placeholders +

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2285,6 +2285,26 @@ def test_unusable_audio_rows_are_rejected(monkeypatch, clip, message, max_len):
         _finalized_collate([row], processor, max_len, None)
 
 
+def test_an_audio_free_row_over_the_cap_still_collates(monkeypatch):
+    """The over_cap refusal above is for rows that carry audio. An omni
+    checkpoint resolves its soft token whether or not the run uses audio, so
+    without a clip-count guard the same cap refuses ordinary text and image
+    training -- and a rendered row wider than max_seq_length is normal, which
+    is why the shape planner plans for it rather than rejecting it."""
+    processor = _FakeGemmaAudioProcessor()
+    _qualify(monkeypatch, processor=processor)
+    row = {"messages": [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {"role": "assistant", "content": "ok"}]}
+
+    batch = _finalized_collate([row], processor, 1, None)
+    ids = np.asarray(batch["input_ids"])
+    assert ids.shape[0] == 1
+    assert int(np.asarray(batch["attention_mask"]).sum()) > 1, (
+        "the row is deliberately wider than the cap it was collated under"
+    )
+
+
 def test_fixed_budget_families_reject_shortened_runs(monkeypatch):
     class _Budgeted(_FakeGemmaAudioProcessor):
         audio_seq_length = 3

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -2338,9 +2338,44 @@ def test_processors_taking_audio_pairs_are_accommodated(monkeypatch):
 def test_placeholders_without_features_are_rejected(monkeypatch):
     _qualify(monkeypatch)
     # Pre-rendered text can keep the placeholder after the clip is gone.
-    with pytest.raises(ValueError, match="returned no audio features"):
+    with pytest.raises(ValueError) as caught:
         _finalized_collate([{"raw": "x"}], _FakeGemmaAudioProcessor(), 16, None,
                            formatting_func=lambda _: {"text": "<audio>hi"})
+    message = str(caught.value)
+    assert "returned no audio features" in message
+    # This processor is fine and never saw a clip, so the message has to reach
+    # that cause and introduce the checkpoint as an example. Prose cannot be
+    # checked for every way of blaming it; what is pinned is that the hedge
+    # still introduces the checkpoint clause.
+    assert "never received" in message
+    assert "for instance the checkpoint" in message
+
+
+def test_a_checkpoint_that_drops_its_audio_is_named_as_the_cause(monkeypatch):
+    """An export whose preprocessor configuration omits its audio half accepts
+    the audio argument and skips the audio, so this is where the user learns
+    their checkpoint is the problem rather than their dataset."""
+    class _Drops(_FakeGemmaAudioProcessor):
+        def __call__(self, text, audio=None, max_length=None, **kwargs):
+            out = super().__call__(text, audio, max_length, **kwargs)
+            out.pop("input_features", None)
+            out.pop("input_features_mask", None)
+            return out
+
+    processor = _Drops()
+    _qualify(monkeypatch, processor=processor)
+    audio_row = dict(_audio_row(None, placeholder_only=True), audio=_CLIP)
+    with pytest.raises(ValueError) as caught:
+        _finalized_collate([audio_row], processor, 16, None)
+    message = str(caught.value)
+    assert "preprocessor configuration" in message
+    assert "audio feature extractor" in message
+    # Actionable, not just diagnostic.
+    assert "train on the text and image parts" in message
+    # One message serves both callers, and the other one has a healthy
+    # processor, so the checkpoint stays introduced as an example.
+    assert "for instance the checkpoint" in message
+    assert "never received" in message
 
 
 def test_audio_placeholders_masked_and_mixed_batches_collate(monkeypatch):
@@ -3411,3 +3446,234 @@ def test_overlong_rows_are_refused_by_what_the_model_attends():
     later_row["attention_mask"] = np.array([[1] * 6 + [0] * 6, [1] * 12], np.int32)
     with pytest.raises(ValueError, match="row 1 is 12 tokens"):
         _assert_audio_runs_intact(later_row, [1, 1], _FakeProcessor(), 8)
+
+
+# --- can this checkpoint take audio at all: behaviour, not configuration ---
+
+
+class _ProbeProcessor:
+    """A processor that reads its audio, as a capable checkpoint's does."""
+
+    def __init__(self, needs_text=None):
+        self.needs_text = needs_text
+        self.calls = 0
+
+    @staticmethod
+    def _samples(audio):
+        clip = audio[0][0] if isinstance(audio[0], (list, tuple)) else audio[0]
+        return np.asarray(clip, dtype=np.float32)
+
+    def __call__(self, text, audio=None, **kwargs):
+        self.calls += 1
+        if self.needs_text is not None and text[0] != self.needs_text:
+            raise ValueError("this processor wants its own marker")
+        return {"input_ids": np.zeros((1, 8), np.int32),
+                "audio_features": self._samples(audio)[:16].copy()}
+
+
+class _AudioModel:
+    def __init__(self, names=("language_model", "audio_tower")):
+        self._names = names
+
+    def named_modules(self):
+        return [(name, None) for name in self._names]
+
+
+def test_a_checkpoint_that_drops_its_audio_is_not_capable():
+    """The motivating defect: the export omits the audio half of its
+    preprocessor configuration, so the processor takes the argument and skips
+    the audio. Nothing raises and every field is well formed, so only the
+    content differential separates it from a working checkpoint."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _Drops(_ProbeProcessor):
+        def __call__(self, text, audio=None, **kwargs):
+            self.calls += 1
+            return {"input_ids": np.zeros((1, 8), np.int32)}
+
+    verdict = audio_input_capability(_AudioModel(), _Drops())
+    assert verdict.capable is False and verdict.processor_ok is False
+    assert "no audio-dependent output" in verdict.reason
+    # The model half is not what refused it; the audio modules are present.
+    assert verdict.model_ok is True
+
+
+def test_output_that_follows_only_the_clip_length_is_not_capable():
+    """Both tones are the same duration, so a processor sizing its output from
+    the length alone produces identical outputs and cannot be told from one
+    that ignored the audio."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _LengthOnly(_ProbeProcessor):
+        def __call__(self, text, audio=None, **kwargs):
+            self.calls += 1
+            return {"input_ids": np.zeros((1, len(self._samples(audio))), np.int32)}
+
+    assert audio_input_capability(_AudioModel(), _LengthOnly()).capable is False
+
+
+def test_a_processor_that_cannot_repeat_itself_is_not_capable():
+    """The same tone twice must agree. A processor alternating between outputs
+    would otherwise show a difference that says nothing about the audio."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _Alternates(_ProbeProcessor):
+        def __call__(self, text, audio=None, **kwargs):
+            self.calls += 1
+            # A period that also makes the two tones' outputs differ, so only
+            # the same-tone agreement check can refuse this.
+            return {"input_ids": np.full((1, 8), self.calls % 3, np.int32)}
+
+    assert audio_input_capability(_AudioModel(), _Alternates()).capable is False
+
+
+def test_keying_on_the_buffer_instead_of_its_samples_is_not_capable():
+    """Every call gets a freshly built buffer, so a processor keying on object
+    identity sees four distinct clips -- the discarded warm-up and the three
+    measured calls -- and cannot repeat itself. Reusing one buffer per tone in
+    the probe would let this shape pass."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _KeysOnIdentity(_ProbeProcessor):
+        def __init__(self):
+            super().__init__()
+            self.seen = {}
+
+        def __call__(self, text, audio=None, **kwargs):
+            self.calls += 1
+            clip = audio[0][0] if isinstance(audio[0], (list, tuple)) else audio[0]
+            index = self.seen.setdefault(id(clip), len(self.seen))
+            return {"input_ids": np.full((1, 8), index, np.int32)}
+
+    assert audio_input_capability(_AudioModel(), _KeysOnIdentity()).capable is False
+
+
+def test_a_processor_that_warms_up_on_its_first_call_is_still_capable():
+    """One discarded call absorbs one-time state, so a real processor that
+    differs only on its first call is not mistaken for an unrepeatable one."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _Warms(_ProbeProcessor):
+        def __call__(self, text, audio=None, **kwargs):
+            if self.calls == 0:
+                self.calls += 1
+                return {"input_ids": np.full((1, 8), 99, np.int32)}
+            return super().__call__(text, audio, **kwargs)
+
+    assert audio_input_capability(_AudioModel(), _Warms()).capable is True
+
+
+def test_a_caller_supplied_text_answers_for_a_processor_that_needs_a_marker():
+    """Which marker a processor needs is prompt-rendering knowledge, so the
+    caller supplies candidates. A lone string is one candidate, not a sequence
+    of characters -- the form the Studio consumer passes."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    processor = _ProbeProcessor(needs_text="<|audio|> transcribe")
+    assert audio_input_capability(_AudioModel(), processor).capable is False
+    verdict = audio_input_capability(
+        _AudioModel(), _ProbeProcessor(needs_text="<|audio|> transcribe"),
+        texts="<|audio|> transcribe",
+    )
+    assert verdict.capable is True
+
+
+def test_a_processor_that_raises_answers_not_capable_without_escaping():
+    """Totality: this runs at model-load time and may never fail a load."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _Raises(_ProbeProcessor):
+        def __call__(self, text, audio=None, **kwargs):
+            raise RuntimeError("no audio machinery here")
+
+    verdict = audio_input_capability(_AudioModel(), _Raises())
+    assert verdict.capable is False and "raised" in verdict.reason
+
+    # A model that raises escapes the probe's own guards, so only the outer
+    # one keeps this total.
+    class _BrokenModel:
+        def named_modules(self):
+            raise RuntimeError("this model cannot be walked")
+
+    broken = audio_input_capability(_BrokenModel(), _ProbeProcessor())
+    assert broken.capable is False and "could not run" in broken.reason
+
+
+def test_audio_modules_are_found_wherever_the_family_nests_them():
+    """The families spell it five ways, so the walk keys on the name. The
+    nested path is a layout a fixed attribute list would miss -- not a claim
+    about where any one family puts it; Phi-4's pair sits at the top level."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    for names in (("audio_tower", "embed_audio"),
+                  ("audio_tower", "audio_projection_layer"),
+                  ("embed_tokens_extend.audio_embed.audio_encoder",)):
+        verdict = audio_input_capability(_AudioModel(names), _ProbeProcessor())
+        assert verdict.model_ok is True and verdict.capable is True, names
+    absent = audio_input_capability(
+        _AudioModel(("language_model", "vision_tower")), _ProbeProcessor())
+    assert absent.model_ok is False and absent.capable is False
+
+
+def test_without_a_model_the_check_can_refute_but_never_affirm():
+    """A processor-only call still answers for an unloadable export, and says
+    plainly that it did not look at a model."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    verdict = audio_input_capability(None, _ProbeProcessor())
+    assert verdict.capable is False
+    assert verdict.processor_ok is True and verdict.model_ok is None
+
+
+def test_mlx_array_outputs_are_fingerprinted_by_their_own_values():
+    """Real processors return MLX arrays, and exact integer outputs must not be
+    collapsed by a lossy cast on the way to comparison."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _MXOut(_ProbeProcessor):
+        def __call__(self, text, audio=None, **kwargs):
+            self.calls += 1
+            # Two values a float32 round-trip cannot tell apart.
+            value = 16777216 + int(abs(self._samples(audio)[1]) > 0.05)
+            return {"input_ids": mx.array([[value]], dtype=mx.int32)}
+
+    assert audio_input_capability(_AudioModel(), _MXOut()).capable is True
+
+
+def test_a_later_candidate_text_still_answers():
+    """The contract takes a sequence, so a processor whose marker appears only
+    in a later candidate must still be found capable."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    processor = _ProbeProcessor(needs_text="second <|audio|>")
+    verdict = audio_input_capability(
+        _AudioModel(), processor, texts=["first", "second <|audio|>"],
+    )
+    assert verdict.capable is True
+
+
+def test_a_processor_taking_only_audios_is_called_with_that_keyword():
+    """Families disagree on the keyword; resolving it wrongly would refuse a
+    capable checkpoint for a reason that has nothing to do with its audio."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _AudiosOnly(_ProbeProcessor):
+        def __call__(self, text, audios=None, **kwargs):
+            self.calls += 1
+            return {"input_ids": np.zeros((1, 8), np.int32),
+                    "audio_features": self._samples(audios)[:16].copy()}
+
+    assert audio_input_capability(_AudioModel(), _AudiosOnly()).capable is True
+
+
+def test_even_a_base_exception_cannot_escape_the_capability_check():
+    """It runs at model-load time, so nothing it touches may abort a load --
+    including the interrupt-shaped exceptions a narrower guard would let past."""
+    from unsloth_zoo.mlx.utils import audio_input_capability
+
+    class _Interrupts:
+        def named_modules(self):
+            raise KeyboardInterrupt("interrupted mid-walk")
+
+    verdict = audio_input_capability(_Interrupts(), _ProbeProcessor())
+    assert verdict.capable is False and "could not run" in verdict.reason

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -3624,6 +3624,125 @@ class _AudioModel:
         return [(name, None) for name in self._names]
 
 
+def test_the_mlx_vlm_boundary_reshapes_audio_a_processor_cannot_unpack():
+    """Inference reaches the processor through mlx-vlm, which decodes audio to
+    bare waveforms and refuses tuples, so a processor wanting (samples, rate)
+    pairs is unreachable from the caller and has to be met at this boundary."""
+    from unsloth_zoo.mlx.utils import _mlx_vlm_process_inputs_adapter
+
+    class _Processor:
+        # A rate mlx-vlm never consults, to catch a pairing that resolves the
+        # rate for itself instead of using the one the samples are actually at.
+        sampling_rate = 22050
+
+    def pairs_only(processor, prompts, images=None, audio=None, **kwargs):
+        calls.append(audio)
+        if any(not isinstance(entry, tuple) for entry in audio or ()):
+            raise ValueError("too many values to unpack (expected 2)")
+        return {"input_audio_embeds": audio}
+
+    calls = []
+    patched = _mlx_vlm_process_inputs_adapter(pairs_only)
+    clip = np.zeros(4, dtype=np.float32)
+    out = patched(_Processor(), ["hi"], audio=[clip])
+    # mlx-vlm resamples a decoded file to feature_extractor.sampling_rate and
+    # falls back to 16 kHz, so that is the rate it assumes these are at.
+    assert [(int(np.asarray(s).size), r)
+            for s, r in out["input_audio_embeds"]] == [(4, 16000)]
+    assert len(calls) == 2, "the pair shape is a retry, not the first guess"
+
+    # ...and when mlx-vlm has a rate of its own, that one is used.
+    class _Resampled(_Processor):
+        feature_extractor = type("_FE", (), {"sampling_rate": 24000})()
+
+    calls = []
+    out = _mlx_vlm_process_inputs_adapter(pairs_only)(
+        _Resampled(), ["hi"], audio=[clip])
+    assert [r for _s, r in out["input_audio_embeds"]] == [24000]
+
+    # A request carrying no audio must not reach for audio attributes at all:
+    # processors expose some of them through properties that warn or raise.
+    class _Hostile:
+        @property
+        def feature_extractor(self):
+            raise AssertionError("a non-audio request asked for the audio rate")
+
+    def text_only(processor, prompts, images=None, audio=None, **kwargs):
+        return {"input_ids": prompts}
+
+    assert _mlx_vlm_process_inputs_adapter(text_only)(
+        _Hostile(), ["hi"])["input_ids"] == ["hi"]
+
+    # Only a ValueError is a payload-shape refusal: another type carrying the
+    # same word is the processor's own failure and is raised on the first call.
+    seen = []
+
+    def wrong_type(processor, prompts, images=None, audio=None, **kwargs):
+        seen.append(audio)
+        raise RuntimeError("cannot unpack, but not as a ValueError")
+
+    with pytest.raises(RuntimeError, match="not as a ValueError"):
+        _mlx_vlm_process_inputs_adapter(wrong_type)(
+            _Processor(), ["hi"], audio=[clip])
+    assert len(seen) == 1
+
+    # Neither guard may be dropped: a refusal that is not about unpacking, and
+    # an unpacking refusal with no audio to reshape, are both raised on the
+    # first call rather than provoking a second in another shape.
+    for label, message, audio in (("not an unpacking refusal", "some other complaint", [clip]),
+                                  ("nothing to reshape", "too many values to unpack", [])):
+        seen = []
+
+        def refuses(processor, prompts, images=None, audio=None,
+                    _message=message, _seen=seen, **kwargs):
+            _seen.append(audio)
+            raise ValueError(_message)
+
+        with pytest.raises(ValueError, match=re.escape(message)):
+            _mlx_vlm_process_inputs_adapter(refuses)(
+                _Processor(), ["hi"], audio=audio)
+        assert len(seen) == 1, label
+
+    # Only the retried call is answered with the first refusal. A failure
+    # while building the pairs says nothing about what the processor wanted,
+    # so it is raised as itself.
+    from unsloth_zoo.mlx.utils import _call_pairing_audio_on_refusal
+
+    def always_refuses(call_kwargs):
+        raise ValueError("too many values to unpack (expected 2)")
+
+    def cannot_pair(_clips):
+        raise RuntimeError("building the pairs failed on its own terms")
+
+    with pytest.raises(RuntimeError, match="on its own terms"):
+        _call_pairing_audio_on_refusal(
+            always_refuses, {"audio": [clip]}, "audio", cannot_pair)
+
+    # Everything else the caller passed survives the retry, or a mixed
+    # image-and-audio request would silently lose its image.
+    retries = []
+
+    def records(processor, prompts, images=None, audio=None, **kwargs):
+        retries.append({"images": images, "prompts": prompts, **kwargs})
+        if any(not isinstance(entry, tuple) for entry in audio or ()):
+            raise ValueError("too many values to unpack (expected 2)")
+        return {"ok": True}
+
+    _mlx_vlm_process_inputs_adapter(records)(
+        _Processor(), ["hi"], images=["an image"], audio=[clip],
+        padding_side="right")
+    assert len(retries) == 2 and retries[0] == retries[1], retries
+
+    def still_broken(processor, prompts, images=None, audio=None, **kwargs):
+        if any(isinstance(entry, tuple) for entry in audio or ()):
+            raise RuntimeError("the retry's error, which must not surface")
+        raise ValueError("too many values to unpack (expected 2)")
+
+    with pytest.raises(ValueError, match="too many values"):
+        _mlx_vlm_process_inputs_adapter(still_broken)(
+            _Processor(), ["hi"], audio=[clip])
+
+
 def test_a_pair_taking_processor_is_not_reported_unusable():
     """Some processors take ``(samples, rate)`` pairs and reject a bare
     waveform by failing to unpack it. Reading that first refusal as the answer
@@ -3651,21 +3770,6 @@ def test_a_pair_taking_processor_is_not_reported_unusable():
     # The whole waveform arrives, with the rate it was built at alongside it.
     whole = len(_audio_probe_tone(_AUDIO_PROBE_RATE, _AUDIO_PROBE_TONES[0]))
     assert processor.seen and set(processor.seen) == {(whole, _AUDIO_PROBE_RATE)}
-
-    # An unrelated refusal is not a payload-shape complaint, so it is reported
-    # rather than retried in another shape.
-    class _Broken(_ProbeProcessor):
-        def __init__(self):
-            super().__init__()
-            self.saw_pairs = False
-
-        def __call__(self, text, audio=None, **kwargs):
-            self.saw_pairs |= any(isinstance(entry, tuple) for entry in audio or ())
-            raise ValueError("this processor is broken")
-
-    broken = _Broken()
-    assert audio_input_capability(_AudioModel(), broken).capable is False
-    assert broken.saw_pairs is False
 
     # A clip that carries no rate of its own -- what a dataset column yields --
     # takes the rate the processor's extractor expects, which Phi-4 keeps on a

--- a/tests/test_mlx_vlm_label_masks.py
+++ b/tests/test_mlx_vlm_label_masks.py
@@ -1783,6 +1783,73 @@ def test_embed_scale_lifts_only_gemma3n_plain_tokens(model_type, scaled):
     assert out[1][0] == pytest.approx(9.0)
 
 
+def _baseline_scale_model(model_type, hidden_size=16):
+    """A VLM whose merge leaves the ids-path scale off, as mlx-vlm's does.
+
+    `Model.__call__` sends ids through `get_input_embeddings`, which embeds
+    without the sqrt(hidden_size) factor the language stack applies on the ids
+    path; the stack then takes the `inputs_embeds` branch and never applies it.
+    Recording what the forward receives is the only way to see which route the
+    loss backend took.
+    """
+    from types import SimpleNamespace
+
+    mx_ = _utils_mx()
+    seen = {}
+
+    class _Backbone:
+        config = SimpleNamespace(model_type=model_type, hidden_size=hidden_size)
+        def embed_tokens(self, ids):
+            return mx_.ones((*ids.shape, hidden_size), dtype=mx_.float32)
+
+    class _Model:
+        language_model = SimpleNamespace(model=_Backbone())
+        config = SimpleNamespace(model_type=model_type)
+
+        def get_input_embeddings(self, inputs, pixel_values=None, **_kwargs):
+            seen["merged"] = True
+            return SimpleNamespace(
+                inputs_embeds=_Backbone().embed_tokens(inputs))
+
+        def __call__(self, inputs, pixel_values=None, **kwargs):
+            seen["kwargs"] = kwargs
+            width = inputs.shape[1]
+            return mx_.zeros((inputs.shape[0], width, 8), dtype=mx_.float32)
+
+    return _Model(), seen, hidden_size ** 0.5
+
+
+@pytest.mark.parametrize("model_type,rescaled", [
+    ("gemma3n_text", True),
+    ("qwen2_vl", False),
+])
+def test_the_baseline_loss_backend_restores_the_gemma3n_embed_scale(
+        model_type, rescaled):
+    """use_cce={True,False} have to agree. `_vlm_cce_forward` merges and
+    rescales itself; handing the model ids on the baseline path skipped the
+    factor, training text embeddings ~sqrt(hidden_size) times too small beside
+    merged audio or image features."""
+    from unsloth_zoo.mlx.utils import make_vlm_baseline_loss_fn
+
+    mx_ = _utils_mx()
+    model, seen, scale = _baseline_scale_model(model_type)
+    ids = mx_.array([[3, 4, 5]], dtype=mx_.int32)
+    loss_fn = make_vlm_baseline_loss_fn(model, ignore_token_ids=[])
+    loss_fn(model, {
+        "input_ids": ids,
+        "attention_mask": mx_.ones((1, 3), dtype=mx_.int32),
+        "labels": ids,
+    })
+
+    embeds = seen.get("kwargs", {}).get("inputs_embeds")
+    if not rescaled:
+        # Every other family keeps the untouched ids path.
+        assert embeds is None and "merged" not in seen
+        return
+    assert embeds is not None, "the forward still received bare ids"
+    assert np.asarray(embeds)[0][0][0] == pytest.approx(scale)
+
+
 # --- paligemma: a prefix-LM mask, not a padding outer product ---------------
 
 
@@ -3302,6 +3369,66 @@ def test_stated_spans_refuse_the_left_padding_repair():
                                             [0, 0, 1, 1, 1, 1, 1, 1]], np.int32)
     with pytest.raises(ValueError, match=r"row\(s\) \[1\] content-first"):
         _right_pad_vlm_rows(later_row, _FakeProcessor())
+
+
+def _image_bound_inputs(bounds, mask):
+    """A MiniCPM-shaped batch: per-row (images, 2) columns into the ids."""
+    mask = np.array(mask, np.int32)
+    return {
+        "input_ids": np.arange(1, mask.size + 1, dtype=np.int32).reshape(mask.shape),
+        "attention_mask": mask,
+        "image_bound": [
+            np.array(row, np.int32).reshape(-1, 2) if row else np.zeros((0, 2), np.int32)
+            for row in bounds
+        ],
+    }
+
+
+def test_stated_image_bounds_refuse_the_left_padding_repair():
+    """`image_bound` is the same kind of thing as `audio_bounds`: absolute
+    columns into the layout the processor padded, which MiniCPM-V offsets by
+    each row's leading pad count. It is neither width-generated nor token
+    aligned -- an (images, 2) grid is not the ids shape -- so the sidecar
+    relocation leaves it behind, and the model would scatter each image's
+    features onto whatever tokens moved into those columns. The stale columns
+    stay attended, so nothing downstream objects."""
+    from unsloth_zoo.mlx.utils import _right_pad_vlm_rows
+
+    moved = _image_bound_inputs([[[2, 4]]], [[0, 0, 1, 1, 1]])
+    with pytest.raises(ValueError, match=r"row\(s\) \[0\] content-first"):
+        _right_pad_vlm_rows(moved, _FakeProcessor())
+    with pytest.raises(ValueError, match="image positions as spans"):
+        _right_pad_vlm_rows(
+            _image_bound_inputs([[[2, 4]]], [[0, 0, 1, 1, 1]]), _FakeProcessor())
+
+    # Interior padding moves tokens exactly as leading padding does.
+    with pytest.raises(ValueError, match=r"row\(s\) \[0\] content-first"):
+        _right_pad_vlm_rows(
+            _image_bound_inputs([[[3, 4]]], [[1, 0, 0, 1, 1]]), _FakeProcessor())
+
+    # Already content-first: the repair is a no-op and must not refuse.
+    _right_pad_vlm_rows(
+        _image_bound_inputs([[[0, 2]]], [[1, 1, 1, 0, 0]]), _FakeProcessor())
+
+    # Reported on every batch, empty when the row has no image: keying the
+    # refusal on the field would strand text-only rows.
+    repaired = _right_pad_vlm_rows(
+        _image_bound_inputs([[], []], [[0, 0, 1, 1, 1], [0, 1, 1, 1, 1]]),
+        _FakeProcessor())
+    assert np.asarray(repaired["attention_mask"])[:, 0].tolist() == [1, 1]
+
+    # Only the bound-free row moves, so the batch is still repairable.
+    repaired = _right_pad_vlm_rows(
+        _image_bound_inputs([[[0, 2]], []], [[1, 1, 1, 0, 0], [0, 0, 1, 1, 1]]),
+        _FakeProcessor())
+    assert np.asarray(repaired["attention_mask"])[:, 0].tolist() == [1, 1]
+
+    # The moving bound-bearing row is not row 0.
+    with pytest.raises(ValueError, match=r"row\(s\) \[1\] content-first"):
+        _right_pad_vlm_rows(
+            _image_bound_inputs([[[0, 2]], [[2, 4]]],
+                                [[1, 1, 1, 0, 0], [0, 0, 1, 1, 1]]),
+            _FakeProcessor())
 
 
 def test_spans_that_do_not_name_a_placeholder_run_are_refused():

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2349,11 +2349,13 @@ def _fix_gemma3_multimodal_image_feature_scale(model=None):
             final_embedding, image_mask_expanded, scaled_image_features,
         )
 
-        attention_mask_expanded_1 = mx.expand_dims(attention_mask, 1)
-        attention_mask_expanded_2 = mx.expand_dims(attention_mask, 2)
-        final_attention_mask_4d = mx.expand_dims(
-            attention_mask_expanded_1 * attention_mask_expanded_2,
-            1,
+        # Gemma3's layers use this verbatim, so it has to carry causality; an
+        # outer product of the padding mask does not. Same builder as the CCE
+        # path: causal, bidirectional inside each image block.
+        from .utils import _build_gemma_image_attention_mask
+        token_type_ids = (input_ids == image_token_index).astype(mx.int32)
+        final_attention_mask_4d = _build_gemma_image_attention_mask(
+            token_type_ids, attention_mask=attention_mask,
         )
         return final_embedding.astype(inputs_embeds.dtype), final_attention_mask_4d
 

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2369,6 +2369,134 @@ def _fix_gemma3_multimodal_image_feature_scale(model=None):
     if model is not None:
         model._unsloth_gemma3_image_feature_scale = "text_embed_dim"
     return True
+def _paligemma_prefix_lm_mask(token_type_ids, attention_mask):
+    """PaliGemma's prefix is bidirectional and only its suffix is causal.
+
+    Its processor marks the suffix with 1, the reverse of the convention the
+    builder reads, so the polarity is inverted before the group is formed.
+    """
+    from .utils import _build_gemma_image_attention_mask
+    prefix = (token_type_ids == 0).astype(token_type_ids.dtype)
+    return _build_gemma_image_attention_mask(prefix, attention_mask=attention_mask)
+
+
+def _paligemma_replace_mask(features, token_type_ids, attention_mask):
+    """Swap the outer-product mask for the prefix-LM one where the split is known.
+
+    Without token types there is no prefix boundary to derive, so upstream's mask
+    is left as it is rather than guessed at.
+    """
+    if token_type_ids is None or features.attention_mask_4d is None:
+        return features
+    features.attention_mask_4d = _paligemma_prefix_lm_mask(
+        token_type_ids, attention_mask,
+    )
+    return features
+
+
+# Where the call wrapper leaves the token types for the embedder wrapper. A
+# per-thread stack, not an attribute on the model: one model can serve several
+# callers at once, and an attribute would let them read each other's batch.
+_PALIGEMMA_TOKEN_TYPES = threading.local()
+
+
+def _paligemma_pending_token_types():
+    stack = getattr(_PALIGEMMA_TOKEN_TYPES, "stack", None)
+    return stack[-1] if stack else None
+
+
+def _paligemma_call_wrapper(original_call):
+    """Thread the token types through to the embedder.
+
+    Upstream's call embeds with a fixed three arguments, so the token types that
+    carry the prefix boundary never reach the mask on the plain loss path.
+    """
+
+    def __call__(self, *args, **kwargs):
+        stack = getattr(_PALIGEMMA_TOKEN_TYPES, "stack", None)
+        if stack is None:
+            stack = _PALIGEMMA_TOKEN_TYPES.stack = []
+        stack.append(kwargs.get("token_type_ids"))
+        try:
+            return original_call(self, *args, **kwargs)
+        finally:
+            stack.pop()
+
+    return __call__
+
+
+def _paligemma_causal_mask_wrapper(original):
+    """Wrap PaliGemma's embedder so its 4-D mask carries a causal suffix."""
+
+    def get_input_embeddings(self, input_ids=None, pixel_values=None, mask=None,
+                             **kwargs):
+        features = original(self, input_ids, pixel_values, mask, **kwargs)
+        token_type_ids = kwargs.get("token_type_ids")
+        if token_type_ids is None:
+            token_type_ids = _paligemma_pending_token_types()
+        return _paligemma_replace_mask(features, token_type_ids, mask)
+
+    return get_input_embeddings
+
+
+def _install_paligemma_causal_mask(model_cls):
+    """Put both wrappers on a PaliGemma model class, or report why not."""
+    original_embed = getattr(model_cls, "get_input_embeddings", None)
+    original_call = getattr(model_cls, "__call__", None)
+    if not callable(original_embed) or not callable(original_call):
+        return False
+    model_cls.get_input_embeddings = _paligemma_causal_mask_wrapper(original_embed)
+    model_cls.__call__ = _paligemma_call_wrapper(original_call)
+    model_cls._unsloth_causal_mask_patched = True
+    return True
+
+
+def _fix_paligemma_multimodal_causal_mask(model=None):
+    """Give PaliGemma's prefix-LM mask a causal suffix.
+
+    Its 4-D mask is an outer product of the padding mask, so with nothing padded
+    every position sees every other and the suffix being trained on can read the
+    answer tokens after it. PaliGemma wants its prefix -- image plus prompt --
+    bidirectional and its suffix causal, which is what the reference builds from
+    `token_type_ids`, marking the suffix with 1 where Gemma3 marks the
+    bidirectional side.
+
+    Both loss paths are corrected: the cross-entropy path embeds directly and
+    already carries the token types, and the plain path goes through
+    `Model.__call__`, which the companion wrapper makes them survive.
+    """
+    try:
+        import mlx.core as mx
+        paligemma_module = importlib.import_module("mlx_vlm.models.paligemma.paligemma")
+    except Exception:
+        return False
+
+    model_cls = getattr(paligemma_module, "Model", None)
+    # A real class, not the simulation shim's stand-in object.
+    if not isinstance(model_cls, type):
+        return False
+    if getattr(model_cls, "_unsloth_causal_mask_patched", False):
+        return True
+    try:
+        return _install_paligemma_causal_mask(model_cls)
+    except Exception:
+        return False
+
+
+# Upstream corrections applied to every VLM as it loads, in order.
+_VLM_MODEL_FIXUPS = (
+    _fix_gemma4_kv_sharing,
+    _fix_gemma3_vision_post_layernorm_eps,
+    _fix_gemma3_vision_attention_fp32_sdpa,
+    _fix_gemma3_vision_encoder_fp32_layernorm,
+    _fix_gemma3_vision_post_layernorm_fp32,
+    _fix_gemma3_vision_mlp_fp32_activation,
+    _fix_gemma3_language_mlp_fp32_activation,
+    _fix_gemma3_multimodal_image_feature_scale,
+    _fix_paligemma_multimodal_causal_mask,
+)
+
+
 def _disable_fused_mrope(model):
     """Flip fused_apply off so MRoPE training uses the differentiable
     cos/sin fallback; the fused Metal kernel has no VJP."""
@@ -7320,16 +7448,7 @@ class FastMLXModel:
                 model._unsloth_text_only_vlm = True
             model._is_vlm_model = True
             model._processor = processor
-            for fixup in (
-                _fix_gemma4_kv_sharing,
-                _fix_gemma3_vision_post_layernorm_eps,
-                _fix_gemma3_vision_attention_fp32_sdpa,
-                _fix_gemma3_vision_encoder_fp32_layernorm,
-                _fix_gemma3_vision_post_layernorm_fp32,
-                _fix_gemma3_vision_mlp_fp32_activation,
-                _fix_gemma3_language_mlp_fp32_activation,
-                _fix_gemma3_multimodal_image_feature_scale,
-            ):
+            for fixup in _VLM_MODEL_FIXUPS:
                 _run_with_vlm_config_view(fixup, model)
 
             model._config = getattr(model, "_config", config_data)

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -2369,6 +2369,69 @@ def _fix_gemma3_multimodal_image_feature_scale(model=None):
     if model is not None:
         model._unsloth_gemma3_image_feature_scale = "text_embed_dim"
     return True
+def _altup_correct_handles_batch(altup):
+    """True when this AltUp already corrects a batch larger than one."""
+    import mlx.core as mx
+    hidden = getattr(getattr(altup, "config", None), "hidden_size", None)
+    inputs = getattr(getattr(altup, "config", None), "altup_num_inputs", None)
+    if not hidden or not inputs:
+        return True  # cannot tell, so leave it alone
+    activated = mx.zeros((2, 1, int(hidden)), dtype=mx.float32)
+    predictions = mx.zeros((int(inputs), 2, 1, int(hidden)), dtype=mx.float32)
+    try:
+        mx.eval(altup.correct(predictions, activated))
+    except Exception:
+        return False
+    return True
+
+
+def _fix_gemma3n_altup_batch(model=None):
+    """Correct Gemma 3n's AltUp coefficients for batches larger than one.
+
+    The correction transposes its coefficients as though the batch axis were
+    last, which only broadcasts when the batch is one; anything larger fails
+    outright. Upstream repaired this in mlx-vlm 0.5.0, so this only ever runs
+    against older releases, whose source no longer changes.
+    """
+    layers = getattr(getattr(getattr(model, "language_model", None), "model", None),
+                     "layers", None)
+    altup = getattr(layers[0], "altup", None) if layers else None
+    if altup is None:
+        return False
+    model_cls = type(altup)
+    if getattr(model_cls, "_unsloth_altup_batch_patched", False):
+        return True
+    if _altup_correct_handles_batch(altup):
+        return False
+
+    import mlx.core as mx
+
+    def correct(self, predictions, activated):
+        modalities = self.compute_router_modalities(activated)
+        self.correction_coefs.weight = self.correction_coefs.weight.astype(mx.float32)
+        if self.config.altup_coef_clip is not None:
+            self.correction_coefs.weight = mx.clip(
+                self.correction_coefs.weight,
+                -self.config.altup_coef_clip,
+                self.config.altup_coef_clip,
+            )
+        all_coefs = self.correction_coefs(modalities) + 1.0
+        innovation = activated - predictions[self.config.altup_active_idx]
+        # Coefficients are (batch, sequence, input); the correction needs them
+        # as (input, batch, sequence, 1) so they broadcast over the hidden axis.
+        all_coefs = all_coefs.transpose(2, 0, 1)[..., None]
+        corrected = innovation[None] * all_coefs
+        corrected += predictions
+        return corrected.astype(activated.dtype)
+
+    try:
+        model_cls.correct = correct
+        model_cls._unsloth_altup_batch_patched = True
+    except Exception:
+        return False
+    return True
+
+
 def _paligemma_prefix_lm_mask(token_type_ids, attention_mask):
     """PaliGemma's prefix is bidirectional and only its suffix is causal.
 
@@ -2494,6 +2557,7 @@ _VLM_MODEL_FIXUPS = (
     _fix_gemma3_language_mlp_fp32_activation,
     _fix_gemma3_multimodal_image_feature_scale,
     _fix_paligemma_multimodal_causal_mask,
+    _fix_gemma3n_altup_batch,
 )
 
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -3206,6 +3206,20 @@ class MLXTrainer:
         )
 
     @staticmethod
+    def _streamed_audio_leaves_the_compiled_path(batch_data, batches):
+        """Whether this streamed batch has to drop the run to eager.
+
+        The stream counterpart to the plan's ``carries_audio_in``: a finite
+        plan is surveyed whole and already routed, but a stream only ever
+        offered the one batch ``_peek_stream_carries_audio`` looked at, so
+        audio appearing later has to be noticed here.
+        """
+        if isinstance(batches, FiniteVLMBatchPlan):
+            return False
+        payload = batch_data[0] if isinstance(batch_data, tuple) else batch_data
+        return _vlm_batch_carries_audio(payload)
+
+    @staticmethod
     def _ensure_lora_frozen(model):
         """Freeze accidentally trainable norm params when LoRA is active.
 
@@ -6508,6 +6522,40 @@ class MLXTrainer:
                 )
             elif batch_error is not None:
                 raise batch_error
+
+            # A stream cannot be surveyed, so the plan's only audio evidence is
+            # the one batch peeked before training. Audio that first appears
+            # later would otherwise reach the compiled step: strict would abort
+            # after earlier optimizer updates, and best-effort would pay a
+            # runtime compile failure to discover it. Ask each streamed batch
+            # instead, so the switch is deterministic rather than resting on
+            # whether the compiled call happens to raise. Finite plans are
+            # already routed by the survey, and only compiled runs can care.
+            if (
+                _use_compile
+                and self._is_vlm
+                and self._streamed_audio_leaves_the_compiled_path(
+                    batch_data, batches,
+                )
+            ):
+                if not _compile_fallback_allowed():
+                    raise RuntimeError(
+                        "Unsloth: strict mx.compile cannot plan audio training: "
+                        "audio feature shapes follow clip duration, so every "
+                        "distinct clip length would need its own compiled "
+                        "signature. This stream's first batch carried no audio, "
+                        "so the shape guard could not see it up front. Train "
+                        "audio with compile disabled."
+                    )
+                _main_print(
+                    "Unsloth: audio inputs appeared later in the stream; "
+                    "training continues eagerly because audio feature shapes "
+                    "cannot be compiled into fixed signatures."
+                )
+                step_fn = _uncompiled_step_fn
+                _use_compile = False
+                _compile_scope = "fallback_eager"
+                _compile_fallback_reason = "audio_inputs"
 
             do_update = (accum_progress + 1 >= grad_accum)
             # HF forces a sync step on an epoch's last micro-batch, so the epoch is

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -39,7 +39,6 @@ Usage mirrors TRL notebooks:
 from dataclasses import MISSING, asdict, dataclass, field, fields, is_dataclass, replace
 import concurrent.futures
 import hashlib
-import itertools
 import json
 import math
 import os
@@ -368,6 +367,35 @@ class _MLXTokenizedDatasetView:
         item["input_ids"] = encoded
         item["attention_mask"] = [1] * len(encoded)
         return item
+
+
+class _PeekedBatchStream:
+    """A peeked batch put back in front of its source, cleanup intact.
+
+    ``itertools.chain`` would do the putting back, but it owns no ``close`` and
+    the run's cleanup only closes what it is handed -- so the producer behind a
+    peeked stream, and whatever it holds open, would survive the run that made
+    it. Close is forwarded to the source instead, at whatever point the run
+    ends, including before the first batch is drawn.
+    """
+
+    def __init__(self, source, pending = ()):
+        self._pending = list(pending)
+        self._source = source
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._pending:
+            return self._pending.pop(0)
+        return next(self._source)
+
+    def close(self):
+        self._pending.clear()
+        close = getattr(self._source, "close", None)
+        if callable(close):
+            close()
 
 
 def _mlx_stream_declares_infinite(dataset):
@@ -3199,11 +3227,13 @@ class MLXTrainer:
         try:
             first = next(batch_iter)
         except StopIteration:
-            return False, iter(())
+            # Exhausted, but still the run's to close: the source may hold a
+            # file or a worker open past its last batch.
+            return False, _PeekedBatchStream(batch_iter)
         payload = first[0] if isinstance(first, tuple) else first
         return (
             _vlm_batch_carries_audio(payload),
-            itertools.chain((first,), batch_iter),
+            _PeekedBatchStream(batch_iter, (first,)),
         )
 
     @staticmethod

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4331,25 +4331,14 @@ class MLXTrainer:
                 if deferred_check is not None:
                     # Global counts, so an all-masked dataset raises symmetrically.
                     deferred_check()
-                # Strict asks for a guarantee that an unsurveyable source
-                # cannot give: one peeked batch says nothing about the rest, so
-                # on a checkpoint that could produce audio at all, strict has to
-                # refuse here -- before any optimizer update, callback or
-                # checkpoint. The per-batch check in the training loop is a
-                # safety net for best-effort runs, which degrade to eager; it
-                # cannot keep this promise, because by the time audio appears
-                # the run is already partially applied.
-                #
-                # `batch_iter is not None` is the planner's own test for an
-                # unsurveyable source, matched here so the two cannot drift: a
-                # finite plan is surveyed batch by batch below and admitted or
-                # routed on the evidence, and must not be refused.
-                #
-                # The remaining operands are rank-invariant (the mode is
-                # configured, the checkpoint is the same everywhere), so every
-                # rank refuses together without needing a collective.
-                # Deliberately not keyed on the peek, which is per-rank and
-                # would abort asymmetrically.
+                # Strict asks for a guarantee an unsurveyable source cannot
+                # give, so refuse before anything is applied: the per-batch
+                # check in the loop only degrades best-effort runs to eager,
+                # and by the time audio appears the run is partly done.
+                # `batch_iter is not None` is the planner's own test for
+                # unsurveyable, matched so the two cannot drift. Every operand
+                # is rank-invariant, so ranks refuse together with no
+                # collective -- not keyed on the peek, which is per-rank.
                 if (
                     batch_iter is not None
                     and _effective_compile_mode(
@@ -6558,40 +6547,16 @@ class MLXTrainer:
             elif batch_error is not None:
                 raise batch_error
 
-            # A stream cannot be surveyed, so the plan's only audio evidence is
-            # the one batch peeked before training. Audio that first appears
-            # later would otherwise reach the compiled step and best-effort
-            # would pay a runtime compile failure to discover it. Ask each
-            # streamed batch instead, so the switch to eager is deterministic
-            # rather than resting on whether the compiled call happens to
-            # raise. Finite plans are already routed by the survey, and only
-            # compiled runs can care.
+            # A stream is surveyed only by the one batch the peek looked at, so
+            # audio appearing later must be caught here rather than at the
+            # compiled call, which may or may not raise. Under DDP each rank
+            # shards its own stream, so the verdict is agreed before anyone acts
+            # on it: one rank's audio takes every rank off the compiled path.
             #
-            # This does not rescue a strict run: by the time audio appears the
-            # run is partially applied, which is why strict refuses an
-            # audio-capable stream up front instead. The strict branch below
-            # remains for a checkpoint that carries no audio modules yet still
-            # produces audio features -- it should not happen, and if it does,
-            # stopping beats compiling shapes nothing planned for.
-            #
-            # Under DDP the answer has to be rank-wide before anyone acts on it:
-            # each rank shards its own stream, so one rank alone seeing audio
-            # must still take every rank off the compiled path together, and a
-            # rank that decided locally would abort into a collective its peers
-            # still expect to reach. `_distributed_any_flag` is the same
-            # primitive the per-batch failure consensus already uses, and the
-            # collective is confined to compiled streaming runs -- a surveyed
-            # plan short-circuits before it, and once audio has appeared
-            # `_use_compile` is False and the question stops being asked.
-            #
-            # Every operand of the guard below has to stay rank-invariant, or
-            # one rank enters this collective alone and hangs its peers. It
-            # holds today: `_is_vlm` and the plan type come from the same model
-            # and dataset everywhere, and every `_use_compile = False` that a
-            # DDP run can reach is itself driven by a collective -- the
-            # coordinated shape guard, the `_distributed_status_mask` setup
-            # consensus, and the DDP runtime fallback. Do not add a rank-local
-            # term here.
+            # Every operand below must stay rank-invariant, or one rank enters
+            # the collective alone and hangs its peers. It holds today: every
+            # `_use_compile = False` a DDP run reaches is itself driven by a
+            # collective. Do not add a rank-local term here.
             if _use_compile and self._is_vlm and not isinstance(
                 batches, FiniteVLMBatchPlan,
             ):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -39,6 +39,7 @@ Usage mirrors TRL notebooks:
 from dataclasses import MISSING, asdict, dataclass, field, fields, is_dataclass, replace
 import concurrent.futures
 import hashlib
+import itertools
 import json
 import math
 import os
@@ -490,6 +491,8 @@ def _mlx_declared_iterable_length(dataset):
 
 
 from .utils import (
+    _vlm_batch_carries_audio,
+    freeze_audio_modules,
     make_cce_loss_fn,
     make_baseline_loss_fn,
     make_vlm_cce_loss_fn,
@@ -1394,6 +1397,7 @@ def _plan_single_process_vlm_shapes(
     compile_policy,
     compile_decision,
     install_plan=True,
+    carries_audio=None,
 ):
     """Plan finite VLM shapes for the single-process compiled path.
 
@@ -1420,6 +1424,21 @@ def _plan_single_process_vlm_shapes(
             f"cannot be enabled "
             f"({getattr(compile_decision, 'reason', 'unqualified')})."
         )
+    if carries_audio:
+        if _effective_compile_mode(compile_policy, compile_decision) == "strict":
+            raise RuntimeError(
+                "Unsloth: strict mx.compile cannot plan audio training: audio "
+                "feature shapes follow clip duration, so every distinct clip "
+                "length would need its own compiled signature. Train audio "
+                "with compile disabled."
+            )
+        print(
+            "Unsloth: audio inputs detected; training runs eagerly because "
+            "audio feature shapes cannot be compiled into fixed signatures."
+        )
+        return None, _shape_guard_report(
+            "eager", "vlm_audio_inputs", cap, lazy_batches=lazy,
+        ), False, None
     if batch_iter is not None:
         return None, _shape_guard_report(
             "not_applicable", "streaming", cap, lazy_batches=False,
@@ -1467,6 +1486,22 @@ def _plan_single_process_vlm_shapes(
         return None, report, False, None
 
     batches.ensure_descriptors()
+    if batches.carries_audio():
+        if effective_mode == "strict":
+            raise RuntimeError(
+                "Unsloth: strict mx.compile cannot plan audio training: audio "
+                "feature shapes follow clip duration, so every distinct clip "
+                "length would need its own compiled signature. Train audio "
+                "with compile disabled."
+            )
+        print(
+            "Unsloth: audio inputs detected; training runs eagerly because "
+            "audio feature shapes cannot be compiled into fixed signatures."
+        )
+        return None, _shape_guard_report(
+            "eager", "vlm_audio_inputs", cap, compile_scope,
+            cap_selection="not_applicable",
+        ), False, None
     # Admit only the batches the loop actually visits. The gradient-accumulation
     # floor drops the schedule's trailing micro-batches, and an unplannable
     # family confined to that tail would otherwise degrade the whole run to
@@ -3144,6 +3179,25 @@ class MLXTrainer:
         return applied
 
     @staticmethod
+    def _peek_stream_carries_audio(batch_iter):
+        """Peek one batch for audio and chain it back, consuming nothing.
+
+        Returns ``(carries_audio, batch_iter)``; streaming plans cannot be
+        surveyed and batches are the only place audio is observable.
+        """
+        if batch_iter is None:
+            return False, batch_iter
+        try:
+            first = next(batch_iter)
+        except StopIteration:
+            return False, iter(())
+        payload = first[0] if isinstance(first, tuple) else first
+        return (
+            _vlm_batch_carries_audio(payload),
+            itertools.chain((first,), batch_iter),
+        )
+
+    @staticmethod
     def _ensure_lora_frozen(model):
         """Freeze accidentally trainable norm params when LoRA is active.
 
@@ -4254,6 +4308,10 @@ class MLXTrainer:
                 if deferred_check is not None:
                     # Global counts, so an all-masked dataset raises symmetrically.
                     deferred_check()
+                # No plan to survey: peek one batch, chained back.
+                stream_carries_audio, batch_iter = (
+                    self._peek_stream_carries_audio(batch_iter)
+                )
                 local_plan_error = None
                 shape_plan = None
                 frontier = None
@@ -4272,6 +4330,7 @@ class MLXTrainer:
                         compile_policy=compile_policy,
                         compile_decision=self._compile_decision,
                         install_plan=False,
+                        carries_audio=stream_carries_audio,
                     )
                 except Exception as exc:
                     local_plan_error = exc
@@ -4713,6 +4772,19 @@ class MLXTrainer:
             ),
         )
         self._compile_shape_guard_report = _compile_shape_guard_report
+
+        # Audio towers are never trained here (their encoders are poor training
+        # subjects and the merge assumes their output is a fixed function of the
+        # clip). LoRA runs already freeze everything, but a full fine-tune would
+        # pull the encoder and its projection into the optimizer, so freeze them
+        # before it is built.
+        if self._is_vlm:
+            frozen_audio = freeze_audio_modules(self.model)
+            if frozen_audio:
+                print(
+                    "Unsloth: audio modules kept frozen during training "
+                    f"({', '.join(frozen_audio)})."
+                )
 
         # Build optimizer with LR schedule
         optimizer = self._build_optimizer(total_steps)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -492,6 +492,7 @@ def _mlx_declared_iterable_length(dataset):
 
 from .utils import (
     _config_get,
+    _model_carries_audio_modules,
     _vlm_batch_carries_audio,
     audio_merge_patch_needed,
     freeze_audio_modules,
@@ -4330,6 +4331,33 @@ class MLXTrainer:
                 if deferred_check is not None:
                     # Global counts, so an all-masked dataset raises symmetrically.
                     deferred_check()
+                # Strict asks for a guarantee that an unsurveyable source
+                # cannot give: one peeked batch says nothing about the rest, so
+                # on a checkpoint that could produce audio at all, strict has to
+                # refuse here -- before any optimizer update, callback or
+                # checkpoint. The per-batch check in the training loop is a
+                # safety net for best-effort runs, which degrade to eager; it
+                # cannot keep this promise, because by the time audio appears
+                # the run is already partially applied.
+                #
+                # Both operands are rank-invariant (the mode is configured, the
+                # checkpoint is the same everywhere), so every rank refuses
+                # together without needing a collective. Deliberately not keyed
+                # on the peek, which is per-rank and would abort asymmetrically.
+                if (
+                    _effective_compile_mode(
+                        compile_policy, self._compile_decision,
+                    ) == "strict"
+                    and _model_carries_audio_modules(self.model)
+                ):
+                    raise RuntimeError(
+                        "Unsloth: strict mx.compile cannot be honored for a "
+                        "streaming dataset on an audio-capable checkpoint: the "
+                        "source cannot be surveyed, so audio may appear in any "
+                        "later batch and audio feature shapes have no fixed "
+                        "compiled signature. Use a finite dataset, or train "
+                        "with compile disabled or in best-effort mode."
+                    )
                 # No plan to survey: peek one batch, chained back.
                 stream_carries_audio, batch_iter = (
                     self._peek_stream_carries_audio(batch_iter)
@@ -6525,12 +6553,19 @@ class MLXTrainer:
 
             # A stream cannot be surveyed, so the plan's only audio evidence is
             # the one batch peeked before training. Audio that first appears
-            # later would otherwise reach the compiled step: strict would abort
-            # after earlier optimizer updates, and best-effort would pay a
-            # runtime compile failure to discover it. Ask each streamed batch
-            # instead, so the switch is deterministic rather than resting on
-            # whether the compiled call happens to raise. Finite plans are
-            # already routed by the survey, and only compiled runs can care.
+            # later would otherwise reach the compiled step and best-effort
+            # would pay a runtime compile failure to discover it. Ask each
+            # streamed batch instead, so the switch to eager is deterministic
+            # rather than resting on whether the compiled call happens to
+            # raise. Finite plans are already routed by the survey, and only
+            # compiled runs can care.
+            #
+            # This does not rescue a strict run: by the time audio appears the
+            # run is partially applied, which is why strict refuses an
+            # audio-capable stream up front instead. The strict branch below
+            # remains for a checkpoint that carries no audio modules yet still
+            # produces audio features -- it should not happen, and if it does,
+            # stopping beats compiling shapes nothing planned for.
             #
             # Under DDP the answer has to be rank-wide before anyone acts on it:
             # each rank shards its own stream, so one rank alone seeing audio

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -6531,9 +6531,18 @@ class MLXTrainer:
             # instead, so the switch is deterministic rather than resting on
             # whether the compiled call happens to raise. Finite plans are
             # already routed by the survey, and only compiled runs can care.
+            #
+            # Single-process only, for the two reasons the runtime fallback
+            # below is: the DDP path runs its own local-grad step_fn with a
+            # different signature, and each rank shards its own stream, so a
+            # rank that alone saw audio would abort into a collective its peers
+            # still expect to reach. The planner scopes its streaming strict
+            # abort the same way.
             if (
                 _use_compile
                 and self._is_vlm
+                and distributed_world_size <= 1
+                and not _ddp_compile_local_grad
                 and self._streamed_audio_leaves_the_compiled_path(
                     batch_data, batches,
                 )

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1490,22 +1490,6 @@ def _plan_single_process_vlm_shapes(
         return None, report, False, None
 
     batches.ensure_descriptors()
-    if batches.carries_audio():
-        if effective_mode == "strict":
-            raise RuntimeError(
-                "Unsloth: strict mx.compile cannot plan audio training: audio "
-                "feature shapes follow clip duration, so every distinct clip "
-                "length would need its own compiled signature. Train audio "
-                "with compile disabled."
-            )
-        print(
-            "Unsloth: audio inputs detected; training runs eagerly because "
-            "audio feature shapes cannot be compiled into fixed signatures."
-        )
-        return None, _shape_guard_report(
-            "eager", "vlm_audio_inputs", cap, compile_scope,
-            cap_selection="not_applicable",
-        ), False, None
     # Admit only the batches the loop actually visits. The gradient-accumulation
     # floor drops the schedule's trailing micro-batches, and an unplannable
     # family confined to that tail would otherwise degrade the whole run to
@@ -1530,6 +1514,26 @@ def _plan_single_process_vlm_shapes(
         batches.batch_index_for_visit(microstep)
         for microstep in range(total_microsteps)
     })
+    # Scoped to `executed` for the same reason the family admission below is:
+    # a ragged epoch drops its trailing micro-batches, and audio confined to
+    # that tail must not route the whole run eagerly or abort strict mode over
+    # a batch no compiled call reaches.
+    if batches.carries_audio_in(executed):
+        if effective_mode == "strict":
+            raise RuntimeError(
+                "Unsloth: strict mx.compile cannot plan audio training: audio "
+                "feature shapes follow clip duration, so every distinct clip "
+                "length would need its own compiled signature. Train audio "
+                "with compile disabled."
+            )
+        print(
+            "Unsloth: audio inputs detected; training runs eagerly because "
+            "audio feature shapes cannot be compiled into fixed signatures."
+        )
+        return None, _shape_guard_report(
+            "eager", "vlm_audio_inputs", cap, compile_scope,
+            cap_selection="not_applicable",
+        ), False, None
     unplannable = [
         index
         for index in executed

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -4340,12 +4340,19 @@ class MLXTrainer:
                 # cannot keep this promise, because by the time audio appears
                 # the run is already partially applied.
                 #
-                # Both operands are rank-invariant (the mode is configured, the
-                # checkpoint is the same everywhere), so every rank refuses
-                # together without needing a collective. Deliberately not keyed
-                # on the peek, which is per-rank and would abort asymmetrically.
+                # `batch_iter is not None` is the planner's own test for an
+                # unsurveyable source, matched here so the two cannot drift: a
+                # finite plan is surveyed batch by batch below and admitted or
+                # routed on the evidence, and must not be refused.
+                #
+                # The remaining operands are rank-invariant (the mode is
+                # configured, the checkpoint is the same everywhere), so every
+                # rank refuses together without needing a collective.
+                # Deliberately not keyed on the peek, which is per-rank and
+                # would abort asymmetrically.
                 if (
-                    _effective_compile_mode(
+                    batch_iter is not None
+                    and _effective_compile_mode(
                         compile_policy, self._compile_decision,
                     ) == "strict"
                     and _model_carries_audio_modules(self.model)

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -491,8 +491,12 @@ def _mlx_declared_iterable_length(dataset):
 
 
 from .utils import (
+    _config_get,
     _vlm_batch_carries_audio,
+    audio_merge_patch_needed,
     freeze_audio_modules,
+    install_audio_merge_patch,
+    remove_audio_merge_patch,
     make_cce_loss_fn,
     make_baseline_loss_fn,
     make_vlm_cce_loss_fn,
@@ -4312,6 +4316,7 @@ class MLXTrainer:
                 stream_carries_audio, batch_iter = (
                     self._peek_stream_carries_audio(batch_iter)
                 )
+                self._stream_carries_audio = stream_carries_audio
                 local_plan_error = None
                 shape_plan = None
                 frontier = None
@@ -4503,6 +4508,10 @@ class MLXTrainer:
                 self._setup_report_to_callbacks()
             return self._train_inner()
         finally:
+            # The correction belongs to this run only.
+            if getattr(self, "_audio_merge_patched", False):
+                remove_audio_merge_patch(self.model)
+                self._audio_merge_patched = False
             self._close_active_batch_iterator()
             _handles = getattr(self, "_report_to_handles", (None, None))
             _wb, _tb = _handles
@@ -4773,11 +4782,19 @@ class MLXTrainer:
         )
         self._compile_shape_guard_report = _compile_shape_guard_report
 
-        # Audio towers are never trained here (their encoders are poor training
-        # subjects and the merge assumes their output is a fixed function of the
-        # clip). LoRA runs already freeze everything, but a full fine-tune would
-        # pull the encoder and its projection into the optimizer, so freeze them
-        # before it is built.
+        # Whole run, not just when audio is spotted up front: audio-free
+        # batches pass straight through, and audio may start in a later row.
+        config = getattr(self.model, "config", None)
+        if self._is_vlm and audio_merge_patch_needed(config):
+            token_id = _config_get(config, "audio_token_id")
+            if token_id is not None and install_audio_merge_patch(
+                self.model, int(token_id),
+            ):
+                self._audio_merge_patched = True
+                print(
+                    "Unsloth: corrected this model's audio merge for training "
+                    "(its own merge misplaces padded rows)."
+                )
         if self._is_vlm:
             frozen_audio = freeze_audio_modules(self.model)
             if frozen_audio:

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -6583,6 +6583,15 @@ class MLXTrainer:
             # collective is confined to compiled streaming runs -- a surveyed
             # plan short-circuits before it, and once audio has appeared
             # `_use_compile` is False and the question stops being asked.
+            #
+            # Every operand of the guard below has to stay rank-invariant, or
+            # one rank enters this collective alone and hangs its peers. It
+            # holds today: `_is_vlm` and the plan type come from the same model
+            # and dataset everywhere, and every `_use_compile = False` that a
+            # DDP run can reach is itself driven by a collective -- the
+            # coordinated shape guard, the `_distributed_status_mask` setup
+            # consensus, and the DDP runtime fallback. Do not add a rank-local
+            # term here.
             if _use_compile and self._is_vlm and not isinstance(
                 batches, FiniteVLMBatchPlan,
             ):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -6532,22 +6532,29 @@ class MLXTrainer:
             # whether the compiled call happens to raise. Finite plans are
             # already routed by the survey, and only compiled runs can care.
             #
-            # Single-process only, for the two reasons the runtime fallback
-            # below is: the DDP path runs its own local-grad step_fn with a
-            # different signature, and each rank shards its own stream, so a
-            # rank that alone saw audio would abort into a collective its peers
-            # still expect to reach. The planner scopes its streaming strict
-            # abort the same way.
-            if (
-                _use_compile
-                and self._is_vlm
-                and distributed_world_size <= 1
-                and not _ddp_compile_local_grad
-                and self._streamed_audio_leaves_the_compiled_path(
+            # Under DDP the answer has to be rank-wide before anyone acts on it:
+            # each rank shards its own stream, so one rank alone seeing audio
+            # must still take every rank off the compiled path together, and a
+            # rank that decided locally would abort into a collective its peers
+            # still expect to reach. `_distributed_any_flag` is the same
+            # primitive the per-batch failure consensus already uses, and the
+            # collective is confined to compiled streaming runs -- a surveyed
+            # plan short-circuits before it, and once audio has appeared
+            # `_use_compile` is False and the question stops being asked.
+            if _use_compile and self._is_vlm and not isinstance(
+                batches, FiniteVLMBatchPlan,
+            ):
+                _late_audio = self._streamed_audio_leaves_the_compiled_path(
                     batch_data, batches,
                 )
-            ):
+                if distributed_world_size > 1:
+                    _late_audio = self._distributed_any_flag(_late_audio)
+            else:
+                _late_audio = False
+            if _late_audio:
                 if not _compile_fallback_allowed():
+                    # Every rank reached the same verdict above, so this raises
+                    # on all of them together rather than stranding peers.
                     raise RuntimeError(
                         "Unsloth: strict mx.compile cannot plan audio training: "
                         "audio feature shapes follow clip duration, so every "
@@ -6561,7 +6568,13 @@ class MLXTrainer:
                     "training continues eagerly because audio feature shapes "
                     "cannot be compiled into fixed signatures."
                 )
-                step_fn = _uncompiled_step_fn
+                if _ddp_compile_local_grad:
+                    # The DDP local-grad path has its own eager step_fn with a
+                    # different signature; mirror its runtime fallback exactly.
+                    step_fn = _ddp_eager_local_step_fn
+                    _ddp_compile_local_grad = False
+                else:
+                    step_fn = _uncompiled_step_fn
                 _use_compile = False
                 _compile_scope = "fallback_eager"
                 _compile_fallback_reason = "audio_inputs"

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -51,7 +51,7 @@ import weakref
 import zlib
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from functools import lru_cache, wraps
+from functools import lru_cache, partial, wraps
 from pathlib import Path
 
 
@@ -5553,6 +5553,196 @@ def _check_audio_transformers_floor(family):
         )
 
 
+# Gemma 4's audio encoder subsamples time through two stride-2, kernel-3 conv
+# blocks (SubSampleConvProjection), each padding one frame on either side.
+_GEMMA4_AUDIO_SUBSAMPLE_BLOCKS = 2
+
+
+def _gemma4_audio_frame_mask(extractor, waveform, sampling_rate):
+    """The mel frames one clip fills, extracted on its own.
+
+    Alone is the only way to ask: mlx-vlm pads waveforms to the longest in the
+    batch before framing, and 0.4.4 derives the mask by subsampling a
+    sample-level one, so a shorter clip's valid count moves with whatever else
+    it is batched against.
+    """
+    features = extractor(
+        [np.asarray(waveform, dtype=np.float32)],
+        sampling_rate=sampling_rate,
+        return_attention_mask=True,
+    )
+    if "input_features_mask" in features:
+        return np.asarray(features["input_features_mask"])[0].astype(bool)
+    # An extractor that reports no mask leaves the encoder without one too, and
+    # Gemma 4 then treats every frame as real audio.
+    return np.ones(
+        int(np.asarray(features["input_features"]).shape[-2]), dtype=bool,
+    )
+
+
+def _gemma4_audio_encoder_positions(frames):
+    for _ in range(_GEMMA4_AUDIO_SUBSAMPLE_BLOCKS):
+        kept = (len(frames) + 2 - 3) // 2 + 1
+        frames = frames[::2][:kept]
+    return int(frames.sum())
+
+
+def _gemma4_audio_placeholder_count(processor, waveform, sampling_rate):
+    """How many audio placeholders one Gemma 4 clip needs.
+
+    Must equal the number of positions the audio tower emits, or the merge has
+    nothing to put behind the surplus placeholder. mlx-vlm's processor instead
+    counts ``ceil(duration / 40 ms)``: 40 ms is only the nominal frame period,
+    so the count runs one over whenever a duration lands near a frame boundary
+    (3 of 10 real LibriSpeech utterances).
+
+    The frames are read off the installed extractor rather than recomputed from
+    a copy of its framing arithmetic, because that arithmetic changed inside the
+    supported span -- mlx-vlm added the reference's semicausal left-pad in
+    0.5.0, and a formula assuming it predicts a frame 0.4.4 never produces. The
+    extractor's own truncation applies for the same reason: the count has to
+    follow the audio the tower is actually given.
+    """
+    extractor = getattr(processor, "feature_extractor", None)
+    if extractor is None:
+        raise NotImplementedError(
+            f"Unsloth MLX: {type(processor).__name__} has no audio feature "
+            f"extractor, so the number of audio placeholders a clip needs "
+            f"cannot be determined."
+        )
+    return _gemma4_audio_encoder_positions(
+        _gemma4_audio_frame_mask(extractor, waveform, sampling_rate),
+    )
+
+
+def _trim_gemma4_audio_batch_mask(inputs, clips, processor):
+    """Mask each clip to the frames its own audio fills.
+
+    Batch padding otherwise leaves a shorter clip holding frames that are
+    entirely silence, which the encoder reports as valid positions and the model
+    trains on as speech. Restoring each clip's own mask also puts the valid
+    count back in step with the placeholder run written for it.
+    """
+    extractor = getattr(processor, "feature_extractor", None)
+    features = inputs.get("input_features")
+    if extractor is None or features is None:
+        return inputs
+    mask = inputs.get("input_features_mask")
+    # An extractor that reports no mask leaves every padded frame looking real,
+    # so the batch needs one written for it rather than left out.
+    shape = np.asarray(features).shape[:2]
+    if mask is not None and np.asarray(mask).shape != shape:
+        # Nothing downstream compares these two, and a mask short of its
+        # features broadcasts over the rows it does not cover.
+        raise ValueError(
+            f"Unsloth MLX: {type(processor).__name__} returned an audio mask "
+            f"of shape {tuple(np.asarray(mask).shape)} for features of shape "
+            f"{tuple(np.asarray(features).shape)}, so audio positions cannot "
+            f"be paired with their clips."
+        )
+    if shape[0] != len(clips):
+        # The feature-count check reports this; repairing part of the batch
+        # would hide it behind a plausible-looking mask.
+        return inputs
+    if len(clips) < 2:
+        # One clip is extracted the way it will be used, so nothing was padded
+        # against a neighbour and its mask already covers only its own audio.
+        return inputs
+    trimmed = np.zeros(shape, dtype=bool)
+    default_rate = _audio_extractor_sampling_rate(processor)
+    for row, clip in enumerate(clips[:shape[0]]):
+        waveform, rate = clip if isinstance(clip, tuple) else (clip, None)
+        solo = _gemma4_audio_frame_mask(
+            extractor, waveform,
+            rate or getattr(clip, "sampling_rate", None) or default_rate,
+        )
+        keep = min(len(solo), shape[1])
+        trimmed[row, :keep] = solo[:keep]
+    inputs["input_features_mask"] = (
+        trimmed if mask is None else trimmed.astype(np.asarray(mask).dtype)
+    )
+    return inputs
+
+
+def _repair_gemma4_audio_processor(processor):
+    if not callable(getattr(processor, "_compute_audio_num_tokens", None)):
+        raise NotImplementedError(
+            f"Unsloth MLX: {type(processor).__name__} does not expose "
+            f"_compute_audio_num_tokens, so its audio placeholder count cannot "
+            f"be matched to the model's audio encoder. This mlx-vlm release is "
+            f"not usable for Gemma 4 audio training."
+        )
+    # Bound on the instance, not the class: a class-level patch would follow the
+    # processor type into every other use of it in this process. Unlike
+    # __call__, this one is reached through the instance dict.
+    processor._compute_audio_num_tokens = partial(
+        _gemma4_audio_placeholder_count, processor,
+    )
+
+
+_AUDIO_PROCESSOR_REPAIRS = {"gemma4": _repair_gemma4_audio_processor}
+
+_AUDIO_BATCH_MASK_REPAIRS = {"gemma4": _trim_gemma4_audio_batch_mask}
+
+_AUDIO_NO_OWN_HOOK = object()
+
+
+def _audio_count_corrected(processor):
+    """Whether this processor is carrying the corrected placeholder count."""
+    hook = getattr(processor, "_compute_audio_num_tokens", None)
+    return (isinstance(hook, partial)
+            and hook.func is _gemma4_audio_placeholder_count)
+
+
+def _audio_repaired_processor(processor):
+    """A processor counting audio placeholders the way its encoder does.
+
+    A copy, because the correction has a second half -- the batch mask -- that
+    can only be applied where the collated batch is held. Correcting the shared
+    processor in place would hand the count alone to anything else using it,
+    including a concurrent collation's own model call, and a corrected count
+    meeting an uncorrected mask misaligns a batch that lined up before.
+    Components are shared by reference, so the copy costs a dict.
+    """
+    repair = _AUDIO_PROCESSOR_REPAIRS.get(
+        _audio_family_from_processor(processor),
+    )
+    if repair is None:
+        return processor
+    corrected = copy.copy(processor)
+    # Only an instance-level hook is ours to put back; pinning an inherited one
+    # would leave a copy of it shadowing the class's own.
+    state = getattr(processor, "__dict__", None) or {}
+    own_hook = state.get("_compute_audio_num_tokens", _AUDIO_NO_OWN_HOOK)
+    repair(corrected)
+    if _audio_count_corrected(processor):
+        # The copy shares state with the processor this run was handed, so the
+        # correction reached it too. Half of it -- the batch mask -- can only
+        # be applied to a batch collated here, and the count alone misaligns a
+        # batch that lined up before, so put back what was there and refuse.
+        if own_hook is _AUDIO_NO_OWN_HOOK:
+            del corrected._compute_audio_num_tokens
+        else:
+            corrected._compute_audio_num_tokens = own_hook
+        raise NotImplementedError(
+            f"Unsloth MLX: copying {type(processor).__name__} does not give an "
+            f"independent object, so its audio placeholder count cannot be "
+            f"corrected without changing the processor this run was handed."
+        )
+    return corrected
+
+
+def _repair_audio_batch(inputs, clips, processor):
+    repair = _AUDIO_BATCH_MASK_REPAIRS.get(
+        _audio_family_from_processor(processor),
+    )
+    # Only on the processor whose count was corrected: the two describe one
+    # contract, so applying either alone puts them back out of step.
+    if not clips or repair is None or not _audio_count_corrected(processor):
+        return inputs
+    return repair(inputs, clips, processor)
+
+
 def _check_audio_family_gate(processor):
     """Refuse audio rows for families/versions without a verified contract."""
     family = _audio_family_from_processor(processor)
@@ -6307,6 +6497,9 @@ def _processor_vlm_inputs(
     if audio is not None:
         audio_kwarg = _vlm_processor_audio_kwarg(processor)
         base_kwargs[audio_kwarg] = audio
+        # Everything below this line collates through the corrected copy; the
+        # caller's processor stays as mlx-vlm made it.
+        processor = _audio_repaired_processor(processor)
     if truncation:
         base_kwargs["truncation"] = True
         if max_seq_length is not None:
@@ -6379,8 +6572,14 @@ def _processor_vlm_inputs(
 
     if audio_kwarg is None:
         return _run_layouts()
+
+    def _run_audio_layouts():
+        return _repair_audio_batch(
+            _run_layouts(), base_kwargs[audio_kwarg], processor,
+        )
+
     try:
-        return _run_layouts()
+        return _run_audio_layouts()
     except ValueError as exc:
         if "unpack" not in str(exc):
             raise
@@ -6392,7 +6591,7 @@ def _processor_vlm_inputs(
             for clip in audio
         ]
         try:
-            return _run_layouts()
+            return _run_audio_layouts()
         except Exception:
             # Guess was wrong: report what the processor first said.
             raise exc from None

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -51,7 +51,7 @@ import weakref
 import zlib
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from functools import wraps
+from functools import lru_cache, wraps
 from pathlib import Path
 
 
@@ -1659,6 +1659,31 @@ def _get_image_token_ids(model):
     return _get_vlm_ignore_token_ids(model=model)
 
 
+def _get_vlm_audio_soft_token_ids(processor=None, config=None):
+    """Resolve the repeated audio placeholder ("soft") token IDs.
+
+    Narrower than the loss-masking set in two ways: image placeholders are
+    excluded, and so are the begin/end audio delimiters, which appear once per
+    clip and would corrupt run counting. Families that identify their
+    placeholder only by a config index resolve through a config when one is
+    reachable; when nothing resolves, the caller refuses the row rather than
+    training on an unverifiable audio/text alignment.
+    """
+    ids = []
+    tokenizer = _get_processor_tokenizer(processor)
+    if tokenizer is not None:
+        for tok_str in _AUDIO_SOFT_TOKEN_STRINGS:
+            _append_unique_int(ids, _convert_token_to_id(tokenizer, tok_str))
+        token = getattr(tokenizer, "audio_token", None)
+        if token is not None:
+            _append_unique_int(ids, _convert_token_to_id(tokenizer, token))
+        _append_unique_int(ids, getattr(tokenizer, "audio_token_id", None))
+    for source in (config, getattr(processor, "config", None)):
+        for key in ("audio_token_index", "audio_token_id"):
+            _append_unique_int(ids, _config_get(source, key, None))
+    return ids
+
+
 def _normalize_cce_label_dtype(labels):
     """Widen unsigned label dtypes to int64 so masking can inject -100.
 
@@ -1800,11 +1825,12 @@ class _HostStagedVLMBatch:
     """
 
     __slots__ = ("inputs", "label_mask", "widen_labels_int64", "host_valued",
-                 "ignore_token_ids", "config", "prefinalized", "pc_opaque")
+                 "ignore_token_ids", "config", "prefinalized", "pc_opaque",
+                 "pc_audio")
 
     def __init__(self, inputs, label_mask, host_valued=True,
                  ignore_token_ids=None, config=None, prefinalized=None,
-                 widen_labels_int64=False, pc_opaque=None):
+                 widen_labels_int64=False, pc_opaque=None, pc_audio=None):
         self.inputs = inputs
         self.label_mask = label_mask
         self.host_valued = host_valued
@@ -1813,6 +1839,8 @@ class _HostStagedVLMBatch:
         self.prefinalized = prefinalized
         self.widen_labels_int64 = widen_labels_int64
         self.pc_opaque = pc_opaque
+        # Checked after the deferred combine: the ids only exist once it runs.
+        self.pc_audio = pc_audio
 
 
 def _finalize_vlm_batch(staged, keep_raw_carrier=False, phase=None):
@@ -1834,11 +1862,13 @@ def _finalize_vlm_batch(staged, keep_raw_carrier=False, phase=None):
     if staged.pc_opaque is not None:
         (prompt_inputs, completion_inputs, flush_side, pad_id, max_seq_length,
          completion_only_loss) = staged.pc_opaque
+        audio_counts, audio_soft_ids = staged.pc_audio or (None, None)
         inner = _combine_vlm_prompt_completion_inputs(
             prompt_inputs, completion_inputs, flush_side, pad_id,
             max_seq_length,
             ignore_token_ids=staged.ignore_token_ids,
             completion_only_loss=completion_only_loss,
+            audio_counts=audio_counts, audio_soft_ids=audio_soft_ids,
         )
         inner.config = staged.config
         return _finalize_vlm_batch(
@@ -3721,6 +3751,8 @@ def _normalize_mlx_messages(messages, *, is_vlm=False):
                                 clean["type"] = "text"
                             elif "image" in clean:
                                 clean["type"] = "image"
+                            elif "audio" in clean:
+                                clean["type"] = "audio"
                         parts.append(clean)
                 msg["content"] = parts
             else:
@@ -5426,6 +5458,481 @@ def _extract_vlm_pc_images(item, prompt_messages, completion_messages, image_siz
     return []
 
 
+_AUDIO_PART_TYPES = ("audio", "audio_url", "input_audio")
+
+# Repeated placeholders only: begin/end delimiters would corrupt run counting.
+_AUDIO_SOFT_TOKEN_STRINGS = (
+    "<audio_soft_token>",   # Gemma 3n
+    "<|audio|>",            # Gemma 4
+    "<|AUDIO|>",            # Qwen2.5-Omni
+    "<so_embedding>",       # Nemotron Nano Omni
+    # Phi-4-multimodal reuses a spare special token, exposed nowhere else.
+    "<|endoftext11|>",
+)
+
+# Model families whose audio training contract has been verified, mapped to the
+# exact mlx-vlm versions whose probe suite passed. Audio rows for a family or an
+# installed version outside this table are refused rather than trained on: the
+# per-family merge contracts differ (variable-length token budgets versus a fixed
+# budget with learned padding embeddings), and mlx-vlm has changed audio
+# preprocessing within its supported span, so an unprobed combination cannot be
+# assumed correct. Entries are added only alongside verified merge contracts.
+_AUDIO_QUALIFIED_FAMILIES: "dict[str, frozenset]" = {}
+
+_AUDIO_CAST_HINT = (
+    "Cast the dataset column with "
+    "datasets.Audio(sampling_rate=<processor rate>) so rows decode to samples "
+    "at the rate the model's feature extractor expects."
+)
+
+
+def _audio_family_from_processor(processor):
+    """Identify the audio model family behind a processor.
+
+    Returns a lowercase family key drawn from the processor's defining module
+    (mlx-vlm processors live in ``mlx_vlm.models.<family>.processing_<family>``)
+    with a class-name fallback for wrappers.
+    """
+    module = getattr(type(processor), "__module__", "") or ""
+    for part in module.lower().split("."):
+        if part.startswith("processing_"):
+            return part[len("processing_"):]
+    parts = module.lower().split(".")
+    if "models" in parts:
+        index = parts.index("models")
+        if index + 1 < len(parts):
+            return parts[index + 1]
+    name = getattr(type(processor), "__name__", "") or ""
+    return name.lower().replace("processor", "").strip("_")
+
+
+@lru_cache(maxsize=1)
+def _installed_mlx_vlm_version():
+    try:
+        from importlib.metadata import version
+
+        return str(version("mlx-vlm"))
+    except Exception:
+        try:
+            import mlx_vlm
+
+            return str(getattr(mlx_vlm, "__version__", "") or "")
+        except Exception:
+            return ""
+
+
+def _check_audio_family_gate(processor):
+    """Refuse audio rows for families/versions without a verified contract."""
+    family = _audio_family_from_processor(processor)
+    probed = _AUDIO_QUALIFIED_FAMILIES.get(family)
+    installed = _installed_mlx_vlm_version()
+    if probed and installed in probed:
+        return family
+    if not _AUDIO_QUALIFIED_FAMILIES:
+        raise NotImplementedError(
+            f"Unsloth MLX: audio inputs were found in this dataset, but audio "
+            f"training is not enabled for any model family yet (this row uses "
+            f"'{family}'). Remove the audio content to train on the text and "
+            f"image parts of this dataset."
+        )
+    supported = ", ".join(
+        f"{name} (mlx-vlm {', '.join(sorted(versions))})"
+        for name, versions in sorted(_AUDIO_QUALIFIED_FAMILIES.items())
+    )
+    if probed:
+        raise NotImplementedError(
+            f"Unsloth MLX: audio training for '{family}' has only been verified "
+            f"on mlx-vlm {', '.join(sorted(probed))}, but mlx-vlm "
+            f"{installed or 'unknown'} is installed. Pin a verified version to "
+            f"train on audio. Verified: {supported}."
+        )
+    raise NotImplementedError(
+        f"Unsloth MLX: audio training is not supported for '{family}'. "
+        f"Verified families: {supported}."
+    )
+
+
+def _audio_extractor_sampling_rate(processor):
+    """The sampling rate this processor's audio feature extractor expects."""
+    for holder in (getattr(processor, "feature_extractor", None), processor):
+        rate = getattr(holder, "sampling_rate", None)
+        if rate:
+            try:
+                return int(rate)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _audio_samples_to_mono(samples, *, channel_first):
+    """Reduce decoded samples to a 1-D mono waveform.
+
+    ``channel_first`` records the source's documented layout rather than
+    guessing from extents: torchcodec returns ``(channels, samples)``, and a
+    short clip can legitimately have more channels than samples.
+    """
+    array = np.asarray(samples)
+    if array.ndim == 1:
+        return array
+    if array.ndim == 2 and channel_first:
+        # Mirrors the datasets mono accessor.
+        return array.mean(axis=0)
+    raise ValueError(
+        f"Unsloth MLX: expected a mono waveform, got an array of shape "
+        f"{array.shape}. Provide single-channel audio, or let "
+        f"datasets.Audio decode the column so channels are handled for you."
+    )
+
+
+def _normalize_audio_clip(clip, expected_rate):
+    """Coerce one dataset audio value into a mono waveform at ``expected_rate``.
+
+    Accepts decoded ``{"array", "sampling_rate"}`` mappings (datasets 3.x) and
+    decoder objects exposing ``get_all_samples()`` (datasets 4.x). Every form
+    must carry its own sampling rate: without one the waveform's duration is
+    unknowable, and feeding it to an extractor expecting another rate silently
+    changes the features (and, for families whose placeholder budget follows
+    clip duration, the number of placeholders too).
+    Undecoded values -- ``{"path", "bytes"}`` mappings and bare paths or URLs --
+    are refused, since decoding them needs an audio backend this package does
+    not depend on and casting the column solves it at the dataset layer.
+    """
+    if isinstance(clip, (str, os.PathLike)):
+        raise ValueError(
+            f"Unsloth MLX: audio file paths are not decoded during training. "
+            f"{_AUDIO_CAST_HINT}"
+        )
+    if hasattr(clip, "get_all_samples"):
+        # datasets 4.x: rate is fixed at construction, so read once and verify.
+        decoded = clip.get_all_samples()
+        samples = _audio_samples_to_mono(
+            getattr(decoded, "data", decoded), channel_first=True,
+        )
+        rate = getattr(decoded, "sample_rate", None)
+    elif isinstance(clip, dict):
+        if clip.get("array") is not None:
+            samples = _audio_samples_to_mono(clip["array"], channel_first=False)
+            rate = clip.get("sampling_rate")
+        elif "path" in clip or "bytes" in clip:
+            raise ValueError(
+                f"Unsloth MLX: this audio column is undecoded (it carries "
+                f"'path'/'bytes'). {_AUDIO_CAST_HINT}"
+            )
+        else:
+            raise ValueError(
+                f"Unsloth MLX: unrecognized audio value; expected decoded "
+                f"samples with a sampling rate. {_AUDIO_CAST_HINT}"
+            )
+    else:
+        raise ValueError(
+            f"Unsloth MLX: audio values must carry their sampling rate, so a "
+            f"bare {type(clip).__name__} cannot be used. {_AUDIO_CAST_HINT}"
+        )
+
+    if rate is None:
+        raise ValueError(
+            f"Unsloth MLX: this audio value has no sampling rate. "
+            f"{_AUDIO_CAST_HINT}"
+        )
+    if expected_rate is not None and int(rate) != expected_rate:
+        raise ValueError(
+            f"Unsloth MLX: audio is sampled at {int(rate)} Hz but this model's "
+            f"feature extractor expects {expected_rate} Hz, and resampling is "
+            f"not performed during training. {_AUDIO_CAST_HINT}"
+        )
+    return np.asarray(samples, dtype=np.float32)
+
+
+def _vlm_audio_part_state(messages):
+    """Whether messages carry audio placeholders and/or embedded audio."""
+    bare_placeholders = False
+    payloads = []
+    if not isinstance(messages, list):
+        return bare_placeholders, payloads
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content", "")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") not in _AUDIO_PART_TYPES:
+                continue
+            payload = None
+            for key in _AUDIO_PART_TYPES:
+                if part.get(key) is not None:
+                    payload = part[key]
+                    break
+            if payload is None:
+                bare_placeholders = True
+            else:
+                payloads.append(payload)
+    return bare_placeholders, payloads
+
+
+def _raw_row_has_audio(item):
+    """Best-effort audio detection on an unvalidated row.
+
+    Runs before a formatting function rewrites the row, so the family gate sees
+    the data the user actually supplied. Shapes it cannot parse are reported as
+    audio-free and left to the normal collation errors.
+    """
+    if not isinstance(item, dict):
+        return False
+    for key in ("audio", "audios"):
+        value = item.get(key)
+        if value is not None and (not isinstance(value, list) or value):
+            return True
+    try:
+        for candidate in (item.get("prompt"), item.get("completion"),
+                          _select_vlm_messages_or_raw(item)):
+            if candidate is item or not isinstance(candidate, (list, dict)):
+                continue
+            messages = candidate if isinstance(candidate, list) else [candidate]
+            if any(_vlm_audio_part_state(_normalize_vlm_messages(messages))):
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def _format_vlm_row_gating_audio(row, formatting_func, processor):
+    """Format one row, gating audio a formatter would otherwise hide.
+
+    Callers that format here go on to collate with no formatter, so the
+    collation gate would have nothing left to refuse.
+    """
+    if formatting_func is None:
+        return row
+    if _raw_row_has_audio(row):
+        _check_audio_family_gate(processor)
+    return formatting_func(row)
+
+
+def _extract_vlm_audio(item, messages, processor):
+    """Collect this row's audio clips as mono waveforms at the model's rate.
+
+    Sources, in order: embedded message audio parts, then top-level ``audio`` /
+    ``audios`` columns. Rows carrying audio are gated to verified families
+    before any decoding work happens.
+    """
+    bare_placeholders, payloads = _vlm_audio_part_state(messages)
+    column = []
+    if isinstance(item, dict):
+        for key in ("audio", "audios"):
+            value = item.get(key)
+            if value is None:
+                continue
+            candidate = value if isinstance(value, list) else [value]
+            if candidate:
+                # An empty column must not shadow a populated alias.
+                column = candidate
+                break
+    if payloads and column:
+        raise ValueError(
+            "Unsloth MLX: this row carries audio both inside its messages and "
+            "in an 'audio'/'audios' column. Keep one source so clips pair with "
+            "their placeholders unambiguously."
+        )
+    if payloads and bare_placeholders:
+        raise ValueError(
+            "Unsloth MLX: this row mixes audio placeholders that carry a clip "
+            "with placeholders that do not. Give every audio placeholder its "
+            "own clip so features pair with the right positions."
+        )
+    clips = list(payloads) or column
+
+    if not clips:
+        if bare_placeholders:
+            raise ValueError(
+                "Unsloth MLX: this row has an audio placeholder but no audio "
+                "data. Provide the clip in the message part or an 'audio' column."
+            )
+        return []
+
+    _check_audio_family_gate(processor)
+    expected_rate = _audio_extractor_sampling_rate(processor)
+    return [_normalize_audio_clip(clip, expected_rate) for clip in clips]
+
+
+# Payload keys only: masks and size vectors can survive a dropped payload.
+_AUDIO_FEATURE_PAYLOAD_KEYS = ("input_features", "input_audio_embeds")
+
+
+def _assert_audio_features_present(inputs, expected, processor):
+    """Fail when a row carried clips but the processor returned no audio tensors.
+
+    A processor that accepts ``audio=`` and silently discards it would otherwise
+    stage a placeholder run with nothing behind it, which trains the model on
+    text while the placeholders resolve to whatever the merge invents. Masks and
+    size vectors do not count: only the feature payload itself does, and it must
+    carry one entry per clip so features and placeholder runs stay paired.
+    """
+    if not expected or not isinstance(inputs, Mapping):
+        return
+    for key in _AUDIO_FEATURE_PAYLOAD_KEYS:
+        value = inputs.get(key)
+        if value is None:
+            continue
+        shape = getattr(value, "shape", None)
+        if shape is not None and all(int(dim) for dim in shape):
+            found = int(shape[0])
+        elif isinstance(value, (list, tuple)) and value:
+            found = len(value)
+        else:
+            continue
+        if found != expected:
+            raise ValueError(
+                f"Unsloth MLX: {type(processor).__name__} returned {found} "
+                f"audio feature entr(ies) for {expected} clip(s), so features "
+                f"and placeholder runs cannot be paired."
+            )
+        return
+    raise ValueError(
+        f"Unsloth MLX: {type(processor).__name__} returned no audio features "
+        f"for a batch containing audio, so the placeholders would have nothing "
+        f"behind them. Check that this processor has an audio feature extractor."
+    )
+
+
+def _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
+                              truncated=True):
+    """Reject rows whose audio placeholder runs did not survive tokenization.
+
+    The processor expands each clip into a run of soft tokens whose length the
+    model matches against its encoder output, so a run that vanished misaligns
+    audio features against text positions. Two conditions are enforced per row:
+    one surviving placeholder run per clip, and a length within
+    ``max_seq_length`` (some processors divert the truncation arguments to their
+    audio feature extractor and leave the text over the cap).
+
+    A run that was *shortened* rather than dropped cannot be detected here: that
+    needs the family's post-subsampling token budget, which only the model-side
+    merge knows, so the merge is where the exact count is checked.
+    """
+    ids = inputs.get("input_ids") if isinstance(inputs, Mapping) else None
+    if ids is None:
+        if not any(audio_counts):
+            return
+        raise ValueError(
+            "Unsloth MLX: the processor returned no input_ids for a batch "
+            "containing audio, so audio/text alignment cannot be verified."
+        )
+    soft_ids = _get_vlm_audio_soft_token_ids(processor)
+    if not soft_ids:
+        if not any(audio_counts):
+            return
+        # An unverifiable run is what this check exists to prevent.
+        raise ValueError(
+            f"Unsloth MLX: could not resolve the audio placeholder token for "
+            f"{type(processor).__name__}, so audio/text alignment cannot be "
+            f"verified. This model family is not usable for audio training."
+        )
+    total_runs = _assert_audio_runs_intact_ids(
+        ids, inputs.get("attention_mask"), audio_counts, soft_ids,
+        max_seq_length if truncated else None,
+    )
+    # Placeholders with nothing behind them misalign the sequence however they
+    # got there -- e.g. a formatter that kept the text but dropped the clip.
+    _assert_audio_features_present(inputs, total_runs, processor)
+
+
+def _assert_audio_runs_intact_ids(ids, attention_mask, audio_counts, soft_ids,
+                                  max_seq_length):
+    """Run-integrity check over materialized ids (see the caller's contract).
+
+    Returns the total number of surviving placeholder runs in the batch.
+    """
+    if not soft_ids:
+        return 0
+    total_runs = 0
+    rows = np.asarray(ids)
+    attention_mask = (
+        np.asarray(attention_mask) if attention_mask is not None else None
+    )
+    if rows.ndim == 1:
+        # Some processors emit a single unbatched row; verify it as one.
+        rows = rows[None, :]
+    if attention_mask is not None and attention_mask.ndim == 1:
+        attention_mask = attention_mask[None, :]
+    if rows.ndim != 2:
+        raise ValueError(
+            f"Unsloth MLX: cannot verify audio alignment against input_ids of "
+            f"shape {rows.shape}."
+        )
+    if rows.shape[0] != len(audio_counts):
+        raise ValueError(
+            f"Unsloth MLX: the processor returned {rows.shape[0]} row(s) for "
+            f"{len(audio_counts)} dataset row(s), so audio clips cannot be "
+            f"matched to their rows."
+        )
+    soft_array = np.array(sorted(soft_ids), dtype=rows.dtype)
+    attention = attention_mask
+    for index, expected_clips in enumerate(audio_counts):
+        if index >= rows.shape[0]:
+            continue
+        row = rows[index]
+        valid = (
+            attention[index] > 0 if attention is not None
+            else np.ones(row.shape, dtype=bool)
+        )
+        is_soft = np.isin(row, soft_array) & valid
+        # Count maximal runs: a rising edge starts a new placeholder run.
+        starts = int(np.sum(is_soft & ~np.concatenate(([False], is_soft[:-1]))))
+        total_runs += starts
+        if expected_clips and starts != expected_clips:
+            raise ValueError(
+                f"Unsloth MLX: row {index} carries {expected_clips} audio "
+                f"clip(s) but {starts} placeholder run(s) survived "
+                f"tokenization. Every clip needs its own placeholder in the "
+                f"rendered text, and none may be dropped by truncation."
+            )
+        if max_seq_length is None:
+            continue
+        if int(valid.sum()) > int(max_seq_length):
+            # Some processors divert the truncation kwargs to their audio
+            # extractor, leaving the text over the cap.
+            raise ValueError(
+                f"Unsloth MLX: row {index} is {int(valid.sum())} tokens but "
+                f"max_seq_length={max_seq_length}; this processor did not apply "
+                f"truncation, so an audio placeholder run could be cut later "
+                f"without being detected. Use a shorter clip or raise "
+                f"max_seq_length."
+            )
+    return total_runs
+
+
+def _format_vlm_audio_for_processor(all_audio):
+    """Flatten per-row clips into the flat list processors expect."""
+    if not all_audio:
+        return None
+    flattened = []
+    for clips in all_audio:
+        if clips:
+            flattened.extend(clips)
+    return flattened or None
+
+
+def _vlm_processor_audio_kwarg(processor):
+    """The audio keyword this processor accepts ('audio' or 'audios')."""
+    try:
+        parameters = inspect.signature(processor.__call__).parameters
+    except (TypeError, ValueError):
+        return "audio"
+    if "audio" in parameters:
+        return "audio"
+    if "audios" in parameters:
+        return "audios"
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
+        return "audio"
+    raise ValueError(
+        f"Unsloth MLX: {type(processor).__name__} does not accept audio inputs, "
+        f"but this dataset carries audio."
+    )
+
+
 def _flatten_vlm_images(all_images):
     flattened = []
     for images in all_images:
@@ -5693,6 +6200,7 @@ def _processor_vlm_inputs(
     suffixes=None,
     truncation=True,
     padding_side=None,
+    all_audio=None,
 ):
     base_kwargs = dict(
         text=texts,
@@ -5700,6 +6208,9 @@ def _processor_vlm_inputs(
         return_tensors="np",
         add_special_tokens=False,
     )
+    audio = _format_vlm_audio_for_processor(all_audio)
+    if audio is not None:
+        base_kwargs[_vlm_processor_audio_kwarg(processor)] = audio
     if truncation:
         base_kwargs["truncation"] = True
         if max_seq_length is not None:
@@ -5957,6 +6468,7 @@ def _collate_vlm_prompt_completion_batch(
     prompt_texts = []
     completion_texts = []
     all_images = []
+    all_audio = []
 
     for item in items:
         prompt_raw = item.get("prompt", "")
@@ -5998,6 +6510,16 @@ def _collate_vlm_prompt_completion_batch(
         prompt_texts.append(prompt_text)
         completion_texts.append(completion_text)
         all_images.append(images)
+        # Audio conditions the response, so it belongs to the prompt half;
+        # scanning the completion keeps a misplaced clip from passing the gate.
+        if any(_vlm_audio_part_state(completion_messages or [])):
+            raise ValueError(
+                "Unsloth MLX: audio in the completion half is not supported; "
+                "put the audio in the prompt so it conditions the response."
+            )
+        all_audio.append(
+            _extract_vlm_audio(item, prompt_messages or [], processor)
+        )
 
     prompt_inputs = _processor_vlm_inputs(
         processor,
@@ -6006,6 +6528,15 @@ def _collate_vlm_prompt_completion_batch(
         max_seq_length,
         truncation=False,
         padding_side="left",
+        all_audio=all_audio,
+    )
+    # Untruncated halves: only run presence is checkable until the combine.
+    audio_counts = [len(clips) for clips in all_audio]
+    _assert_audio_runs_intact(
+        prompt_inputs, audio_counts, processor, None, truncated=False,
+    )
+    audio_soft_ids = (
+        _get_vlm_audio_soft_token_ids(processor) if any(audio_counts) else None
     )
     completion_inputs = _processor_vlm_inputs(
         processor,
@@ -6033,12 +6564,14 @@ def _collate_vlm_prompt_completion_batch(
             ignore_token_ids=ignore_token_ids,
             pc_opaque=(prompt_inputs, completion_inputs, flush_side, pad_id,
                        max_seq_length, completion_only_loss),
+            pc_audio=(audio_counts, audio_soft_ids),
         )
     return _combine_vlm_prompt_completion_inputs(
         prompt_inputs, completion_inputs, flush_side, pad_id, max_seq_length,
         ignore_token_ids=ignore_token_ids,
         completion_only_loss=completion_only_loss,
         reject_mlx_valued=reject_mlx_valued,
+        audio_counts=audio_counts, audio_soft_ids=audio_soft_ids,
     )
 
 
@@ -6051,6 +6584,8 @@ def _combine_vlm_prompt_completion_inputs(
     ignore_token_ids=None,
     completion_only_loss=None,
     reject_mlx_valued=False,
+    audio_counts=None,
+    audio_soft_ids=None,
 ):
     """Concatenate prompt/completion processor outputs into one staged batch.
 
@@ -6087,6 +6622,12 @@ def _combine_vlm_prompt_completion_inputs(
     input_ids, attention_mask, extras = _flush_vlm_arrays_to_side(
         input_ids, attention_mask, "right", pad_id, extras,
     )
+    if audio_counts and any(audio_counts):
+        # Flush + truncate is where a prompt-side run can actually be cut.
+        _assert_audio_runs_intact_ids(
+            input_ids, attention_mask, audio_counts, audio_soft_ids,
+            max_seq_length,
+        )
 
     combined_inputs = dict(prompt_inputs)
     combined_inputs["input_ids"] = input_ids
@@ -6141,13 +6682,20 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
     if reject_mlx_valued and any(_contains_mlx_values(item) for item in items):
         # Reject before formatting or the processor touches them off-thread.
         _reject_mlx_valued_vlm("the dataset row")
+    if formatting_func is not None:
+        # Gate the rows as supplied: a formatter must not hide audio.
+        for item in items:
+            if _raw_row_has_audio(item):
+                _check_audio_family_gate(processor)
+                break
     formatted_items = []
     for item in items:
         if formatting_func is not None:
-            item = formatting_func(item)
-            if reject_mlx_valued and _contains_mlx_values(item):
+            formatted = formatting_func(item)
+            if reject_mlx_valued and _contains_mlx_values(formatted):
                 # Formatters can introduce MLX values after the row scan.
                 _reject_mlx_valued_vlm("the formatting function")
+            item = formatted
         formatted_items.append(item)
 
     if (
@@ -6166,13 +6714,18 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
 
     all_texts = []
     all_images = []
+    all_audio = []
     all_suffixes = []
 
     for item in formatted_items:
         raw = _select_vlm_messages_or_raw(item)
         if raw is item:
             text = render_mlx_chat_example(processor, item, is_vlm=True)
-            messages = []
+            # A bare message list still carries media parts.
+            messages = (
+                _normalize_vlm_messages(item if isinstance(item, list) else [item])
+                if isinstance(item, (list, dict)) else []
+            )
         else:
             messages = _normalize_vlm_messages(raw)
             text = _render_vlm_messages(processor, messages)
@@ -6182,8 +6735,10 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
                 "Provide messages/conversations, a text field, or a formatting_func."
             )
         images = _extract_vlm_images(item, messages, image_size)
+        audio = _extract_vlm_audio(item, messages, processor)
         all_texts.append(text)
         all_images.append(images)
+        all_audio.append(audio)
         all_suffixes.append(item.get("suffix") if isinstance(item, dict) else None)
 
     inputs = _right_pad_vlm_rows(
@@ -6191,9 +6746,12 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
             processor, all_texts, all_images, max_seq_length,
             suffixes=all_suffixes,
             padding_side="right",
+            all_audio=all_audio,
         ),
         processor,
     )
+    audio_counts = [len(clips) for clips in all_audio]
+    _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length)
     if _vlm_inputs_host_valued(inputs) and _vlm_ids_integer_host(inputs):
         label_mask = _stage_vlm_label_mask_np(
             inputs, ignore_token_ids=ignore_token_ids,
@@ -6401,9 +6959,9 @@ def _filter_trainable_vlm_indices(
     # read after them and carry the same reuse-buffer exposure as the planner.
     media_pins = []
     for idx in indices:
-        item = dataset[idx]
-        if formatting_func is not None:
-            item = formatting_func(item)
+        item = _format_vlm_row_gating_audio(
+            dataset[idx], formatting_func, processor,
+        )
         batch_dict, is_prompt_completion = _build_response_masked_vlm_batch(
             [item],
             processor,
@@ -7721,8 +8279,9 @@ def _create_vlm_batch_plan(dataset, processor, config, batch_size, max_seq_lengt
             # dataset that rewrites one shared path per row.
             _pinned_finite_vlm_row(
                 _release_vlm_row_image_handles(
-                    dataset[idx] if formatting_func is None
-                    else formatting_func(dataset[idx])
+                    _format_vlm_row_gating_audio(
+                        dataset[idx], formatting_func, processor,
+                    )
                 ),
                 True if _supervision is None else _supervision[idx],
                 _all_pins=media_pins,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5908,18 +5908,13 @@ def _audio_probe_once(processor, text, kwarg, rate, hertz, held):
     # Held for the probe's lifetime so no later buffer can reuse its address.
     held.append(clip)
     payload = _format_vlm_audio_for_processor([[clip]], processor=processor)
-    try:
-        return processor(text=[text], **{kwarg: payload})
-    except ValueError as exc:
-        if "unpack" not in str(exc):
-            raise
-        # Same contract collation handles: a processor that wants
-        # (samples, rate) pairs rejects a bare waveform by failing to unpack
-        # it. Answering "not capable" here would report a working checkpoint
-        # as unusable.
-        return processor(
-            text=[text],
-            **{kwarg: _audio_payload_as_pairs([clip], processor)})
+    # Answering "not capable" from a payload-shape refusal would report a
+    # working checkpoint as unusable.
+    return _call_pairing_audio_on_refusal(
+        lambda call_kwargs: processor(**call_kwargs),
+        {"text": [text], kwarg: payload}, kwarg,
+        lambda clips: _audio_payload_as_pairs([clip], processor),
+    )
 
 
 def _audio_probe_processor(processor, texts):
@@ -6664,6 +6659,44 @@ def _vlm_processor_prefers_nested_audio(processor):
     return any(name in marker for name in ("minicpmo",))
 
 
+def _call_pairing_audio_on_refusal(invoke, kwargs, audio_kwarg, to_pairs):
+    """Call a processor, retrying once as ``(samples, rate)`` pairs.
+
+    Some processors take their audio as pairs and refuse a bare waveform by
+    failing to unpack it. The shape is not discoverable in advance, so it is
+    corrected from the refusal. A processor that refuses the corrected payload
+    too reports its own first refusal rather than the second one; a failure
+    while building the pairs is raised as itself, since it says nothing about
+    what the processor wanted.
+    """
+    try:
+        return invoke(kwargs)
+    except ValueError as error:
+        clips = kwargs.get(audio_kwarg)
+        if not clips or "unpack" not in str(error):
+            raise
+        retried = dict(kwargs)
+        retried[audio_kwarg] = to_pairs(clips)
+        try:
+            return invoke(retried)
+        except Exception:
+            raise error from None
+
+
+def _mlx_vlm_audio_rate(processor):
+    """The rate mlx-vlm assumes this processor's audio is at.
+
+    It resamples a decoded file to ``feature_extractor.sampling_rate`` and
+    falls back to 16 kHz; an array it forwards untouched, so this is the rate
+    the samples are expected to be at rather than one it enforced. Reading the
+    rate from anywhere else risks labelling them with a rate the rest of
+    mlx-vlm never assumed. An extractor that states ``None`` takes the same
+    fallback, since a pair has to carry a number.
+    """
+    extractor = getattr(processor, "feature_extractor", None)
+    return getattr(extractor, "sampling_rate", None) or 16000
+
+
 def _audio_payload_as_pairs(clips, processor):
     """The ``(samples, rate)`` form processors that reject bare waveforms want.
 
@@ -6944,7 +6977,8 @@ def _vlm_processor_requests_mm_token_type_ids(processor):
 
 
 def _mlx_vlm_process_inputs_adapter(original):
-    """Apply the exact PyTorch-only retry to mlx-vlm's processor boundary."""
+    """Negotiate mlx-vlm's processor boundary: the Transformers PyTorch-only
+    output contract, and processors that take audio as (samples, rate) pairs."""
 
     if getattr(original, "_unsloth_pytorch_processor_output", False):
         return original
@@ -6970,7 +7004,18 @@ def _mlx_vlm_process_inputs_adapter(original):
             return_tensors=return_tensors,
             **kwargs,
         )
-        return _call_vlm_processor(original, (processor, prompts), call_kwargs)
+        # mlx-vlm sends bare waveforms and refuses tuples, so a processor
+        # wanting pairs cannot be reached from the caller at all. The rate it
+        # assumes is read only when reshaping, since reaching for it on every
+        # request would touch attributes a non-audio processor need not have.
+        def _as_pairs(clips):
+            rate = _mlx_vlm_audio_rate(processor)
+            return [(np.asarray(clip), rate) for clip in clips]
+
+        return _call_pairing_audio_on_refusal(
+            lambda kw: _call_vlm_processor(original, (processor, prompts), kw),
+            call_kwargs, "audio", _as_pairs,
+        )
 
     patched._unsloth_pytorch_processor_output = True
     return patched
@@ -7098,19 +7143,14 @@ def _processor_vlm_inputs(
             _run_layouts(), base_kwargs[audio_kwarg], processor,
         )
 
-    try:
+    def _invoke(kwargs):
+        base_kwargs[audio_kwarg] = kwargs[audio_kwarg]
         return _run_audio_layouts()
-    except ValueError as exc:
-        if "unpack" not in str(exc):
-            raise
-        # Some take (samples, rate) pairs, which surfaces as an unpacking
-        # error.
-        base_kwargs[audio_kwarg] = _audio_payload_as_pairs(audio, processor)
-        try:
-            return _run_audio_layouts()
-        except Exception:
-            # Guess was wrong: report what the processor first said.
-            raise exc from None
+
+    return _call_pairing_audio_on_refusal(
+        _invoke, {audio_kwarg: audio}, audio_kwarg,
+        lambda clips: _audio_payload_as_pairs(clips, processor),
+    )
 
 
 def _as_numpy_vlm_field(inputs, key):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -7300,6 +7300,46 @@ def _vlm_family_encode_key(key):
     return ("unstable_key", _vlm_family_type_tag(key_type))
 
 
+
+_AUDIO_TOWER_ATTRS = (
+    "audio_tower", "embed_audio", "audio_encoder", "audio_projection",
+)
+
+
+def freeze_audio_modules(model):
+    """Freeze the audio tower and its projection.
+
+    Audio towers are inference-only here: their encoders carry fp32 promotions,
+    long cumulative reductions and host-synchronizing guards that make them
+    poor training subjects, and the model-side merge assumes their output is a
+    fixed function of the clip. LoRA runs freeze everything by default, but a
+    full fine-tune would otherwise pull these parameters into the optimizer.
+
+    Returns the names of the modules that were frozen.
+    """
+    frozen = []
+    for attr in _AUDIO_TOWER_ATTRS:
+        for owner in (model, getattr(model, "language_model", None)):
+            module = getattr(owner, attr, None) if owner is not None else None
+            if module is None or not hasattr(module, "freeze"):
+                continue
+            module.freeze(recurse=True)
+            frozen.append(attr)
+            break
+    return frozen
+
+
+def _vlm_batch_carries_audio(batch):
+    """Whether a prepared VLM batch carries audio feature tensors.
+
+    Audio feature extents vary per clip and belong to no padable axis, so a
+    batch carrying them cannot participate in compiled-signature planning.
+    """
+    if not isinstance(batch, Mapping):
+        return False
+    return any(batch.get(key) is not None for key in _AUDIO_FEATURE_PAYLOAD_KEYS)
+
+
 def _vlm_batch_family(batch, symbolic_axes=None):
     """Process-stable compile-key family of a prepared VLM batch pytree.
 
@@ -7739,6 +7779,7 @@ class FiniteVLMBatchPlan(_FiniteVisitMixin):
         "_visit_epoch_cache",
         "_mru",
         "_descriptors",
+        "_audio_flags",
         "_widths",
         "_padable",
         "_forbidden",
@@ -7789,6 +7830,7 @@ class FiniteVLMBatchPlan(_FiniteVisitMixin):
         self._visit_epoch_cache = None
         self._mru = None
         self._descriptors = None
+        self._audio_flags = None
         self._widths = None
         self._padable = None
         self._forbidden = None
@@ -8014,6 +8056,7 @@ class FiniteVLMBatchPlan(_FiniteVisitMixin):
         widths = []
         padable_flags = []
         forbidden_sets = []
+        audio_flags = []
         with _preserved_preprocessing_rng():
             for index in range(len(self._schedule)):
                 batch = self._build_batch(index)
@@ -8026,12 +8069,15 @@ class FiniteVLMBatchPlan(_FiniteVisitMixin):
                 family = _vlm_batch_family(
                     batch, symbolic_axes=axes if padable else None,
                 )
+                carries_audio = _vlm_batch_carries_audio(batch)
                 del batch
+                audio_flags.append(carries_audio)
                 families.append(family)
                 widths.append(width)
                 padable_flags.append(bool(padable))
                 forbidden_sets.append(forbidden)
         self._descriptors = tuple(families)
+        self._audio_flags = tuple(audio_flags)
         self._widths = tuple(widths)
         self._padable = tuple(padable_flags)
         self._forbidden = tuple(forbidden_sets)
@@ -8044,6 +8090,15 @@ class FiniteVLMBatchPlan(_FiniteVisitMixin):
         eager before surveying anything."""
         tokenizer = getattr(self._processor, "tokenizer", self._processor)
         return getattr(tokenizer, "pad_token_id", None)
+
+    def carries_audio(self):
+        """Whether any surveyed batch carries audio feature tensors."""
+        if self._audio_flags is None:
+            raise RuntimeError(
+                "Unsloth MLX: VLM batch families have not been surveyed; "
+                "call ensure_descriptors() first."
+            )
+        return any(self._audio_flags)
 
     def batch_family(self, index):
         """Surveyed compile-key family for one scheduled batch."""

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5477,7 +5477,13 @@ _AUDIO_SOFT_TOKEN_STRINGS = (
 # budget with learned padding embeddings), and mlx-vlm has changed audio
 # preprocessing within its supported span, so an unprobed combination cannot be
 # assumed correct. Entries are added only alongside verified merge contracts.
-_AUDIO_QUALIFIED_FAMILIES: "dict[str, frozenset]" = {}
+#
+# gemma3n merges a fixed 188 positions per clip, which lets collation verify the
+# placeholder budget outright; its probes (forward, audio conditioning, ragged
+# collation, LoRA training smoke) pass on mlx-vlm 0.4.4.
+_AUDIO_QUALIFIED_FAMILIES: "dict[str, frozenset]" = {
+    "gemma3n": frozenset({"0.4.4"}),
+}
 
 _AUDIO_CAST_HINT = (
     "Cast the dataset column with "
@@ -5833,6 +5839,7 @@ def _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
     total_runs = _assert_audio_runs_intact_ids(
         ids, inputs.get("attention_mask"), audio_counts, soft_ids,
         max_seq_length if truncated else None,
+        budget=_audio_fixed_budget(processor),
     )
     # Placeholders with nothing behind them misalign the sequence however they
     # got there -- e.g. a formatter that kept the text but dropped the clip.
@@ -5840,7 +5847,7 @@ def _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
 
 
 def _assert_audio_runs_intact_ids(ids, attention_mask, audio_counts, soft_ids,
-                                  max_seq_length):
+                                  max_seq_length, budget=None):
     """Run-integrity check over materialized ids (see the caller's contract).
 
     Returns the total number of surviving placeholder runs in the batch.
@@ -5882,6 +5889,18 @@ def _assert_audio_runs_intact_ids(ids, attention_mask, audio_counts, soft_ids,
         # Count maximal runs: a rising edge starts a new placeholder run.
         starts = int(np.sum(is_soft & ~np.concatenate(([False], is_soft[:-1]))))
         total_runs += starts
+        if expected_clips and budget:
+            # Fixed-budget families merge exactly `budget` per clip, so this is
+            # what catches a run shortened rather than dropped.
+            placeholders = int(is_soft.sum())
+            if placeholders != budget * expected_clips:
+                raise ValueError(
+                    f"Unsloth MLX: row {index} has {placeholders} audio "
+                    f"placeholder tokens but this model merges {budget} per "
+                    f"clip and the row carries {expected_clips} clip(s). The "
+                    f"row cannot be aligned; shorten it or raise "
+                    f"max_seq_length."
+                )
         if expected_clips and starts != expected_clips:
             raise ValueError(
                 f"Unsloth MLX: row {index} carries {expected_clips} audio "
@@ -7299,6 +7318,32 @@ def _vlm_family_encode_key(key):
         return ("seq",) + tuple(_vlm_family_encode_key(item) for item in key)
     return ("unstable_key", _vlm_family_type_tag(key_type))
 
+
+
+def _audio_fixed_budget(processor, config=None):
+    """Placeholders a family emits per clip, when that count is fixed.
+
+    Gemma 3n always merges the same number of positions per clip, padding short
+    clips with learned padding embeddings, so the count is known before the
+    model runs and a row's placeholders can be checked against it.
+
+    A processor that converts clip duration into a token count has no such
+    constant: its ``audio_soft_tokens_per_image`` is an upper bound rather than
+    the per-clip budget (Gemma 4 reports 750 while emitting 25 placeholders for
+    a one-second clip), so the presence of a per-token duration is what rules
+    the check out. Those families are verified against the encoder's own output
+    instead.
+    """
+    if getattr(processor, "audio_ms_per_token", None):
+        return None
+    for source in (config, getattr(processor, "config", None)):
+        value = _config_get(source, "audio_soft_tokens_per_image", None)
+        if value:
+            return int(value)
+    length = getattr(processor, "audio_seq_length", None)
+    if length:
+        return int(length)
+    return None
 
 
 _AUDIO_TOWER_ATTRS = (

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3791,18 +3791,19 @@ def _normalize_mlx_messages(messages, *, is_vlm=False):
                         parts.append({"type": "text", "text": part})
                     elif isinstance(part, dict):
                         clean = _clean_vlm_none_keys(part)
+                        # Gemma 3n's template renders a placeholder for
+                        # "audio" alone, so a part left under an alias carries
+                        # a clip with nothing behind it, and an untyped one
+                        # reaches neither the family gate nor the extractor.
                         if "type" not in clean:
                             if "text" in clean:
                                 clean["type"] = "text"
                             elif "image" in clean:
                                 clean["type"] = "image"
                             elif any(alias in clean for alias in _AUDIO_PART_TYPES):
-                                # Every spelling an audio part accepts, typed
-                                # as "audio": an untyped alias otherwise
-                                # reaches neither the family gate nor the
-                                # extractor, and Gemma's templates render a
-                                # placeholder for "audio" alone.
                                 clean["type"] = "audio"
+                        elif clean["type"] in _AUDIO_PART_TYPES:
+                            clean["type"] = "audio"
                         parts.append(clean)
                 msg["content"] = parts
             else:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5560,7 +5560,12 @@ def _check_audio_family_gate(processor):
 
 def _audio_extractor_sampling_rate(processor):
     """The sampling rate this processor's audio feature extractor expects."""
-    for holder in (getattr(processor, "feature_extractor", None), processor):
+    for holder in (
+        getattr(processor, "feature_extractor", None),
+        # Some name their audio extractor separately, and only it knows the rate.
+        getattr(processor, "audio_processor", None),
+        processor,
+    ):
         rate = getattr(holder, "sampling_rate", None)
         if rate:
             try:
@@ -5568,6 +5573,29 @@ def _audio_extractor_sampling_rate(processor):
             except (TypeError, ValueError):
                 continue
     return None
+
+
+class _AudioClip(np.ndarray):
+    """A mono waveform that remembers the rate it was decoded at.
+
+    Processors normally take bare waveforms, but some want
+    ``(samples, sampling_rate)`` pairs and do not expose a rate of their own, so
+    the value verified during extraction has to travel with the samples.
+
+    The rate survives views, slicing and copies, which is all collation does to
+    a clip. It does not survive concatenation, stacking, ``np.asarray`` or
+    pickling; anything that grows such a step must pass the rate explicitly
+    rather than expect it to ride along.
+    """
+
+    def __new__(cls, samples, sampling_rate):
+        obj = np.asarray(samples, dtype=np.float32).view(cls)
+        obj.sampling_rate = int(sampling_rate)
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is not None:
+            self.sampling_rate = getattr(obj, "sampling_rate", None)
 
 
 def _audio_samples_to_mono(samples, *, channel_first):
@@ -5646,7 +5674,7 @@ def _normalize_audio_clip(clip, expected_rate):
             f"feature extractor expects {expected_rate} Hz, and resampling is "
             f"not performed during training. {_AUDIO_CAST_HINT}"
         )
-    return np.asarray(samples, dtype=np.float32)
+    return _AudioClip(np.asarray(samples, dtype=np.float32), int(rate))
 
 
 def _vlm_audio_part_state(messages):
@@ -6211,6 +6239,25 @@ def _mlx_vlm_process_inputs_adapter(original):
     return patched
 
 
+def _drop_unsupported_processor_kwargs(processor, kwargs):
+    """Remove keyword arguments this processor's ``__call__`` does not take.
+
+    Processors disagree on which collation keywords they accept, and discovering
+    that by exception does not compose: a processor rejecting two of them raises
+    again inside the first retry. Filtering up front handles any number of them,
+    and a processor whose signature absorbs ``**kwargs`` keeps everything (the
+    per-keyword retries below still cover a signature that promises more than it
+    honours).
+    """
+    try:
+        params = inspect.signature(processor.__call__).parameters
+    except (TypeError, ValueError):
+        return kwargs
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return kwargs
+    return {k: v for k, v in kwargs.items() if k in params}
+
+
 def _processor_vlm_inputs(
     processor,
     texts,
@@ -6227,9 +6274,12 @@ def _processor_vlm_inputs(
         return_tensors="np",
         add_special_tokens=False,
     )
+    base_kwargs = _drop_unsupported_processor_kwargs(processor, base_kwargs)
     audio = _format_vlm_audio_for_processor(all_audio)
+    audio_kwarg = None
     if audio is not None:
-        base_kwargs[_vlm_processor_audio_kwarg(processor)] = audio
+        audio_kwarg = _vlm_processor_audio_kwarg(processor)
+        base_kwargs[audio_kwarg] = audio
     if truncation:
         base_kwargs["truncation"] = True
         if max_seq_length is not None:
@@ -6250,52 +6300,75 @@ def _processor_vlm_inputs(
     if _vlm_processor_requests_mm_token_type_ids(processor):
         base_kwargs["return_mm_token_type_ids"] = True
 
-    first_error = None
-    for image_layout in image_layouts:
-        proc_kwargs = dict(base_kwargs)
-        if image_layout is not None:
-            proc_kwargs["images"] = _format_vlm_images_for_processor(
-                all_images,
-                processor=processor,
-                image_layout=image_layout,
-            )
+    def _run_layouts():
+        first_error = None
+        for image_layout in image_layouts:
+            proc_kwargs = dict(base_kwargs)
+            if image_layout is not None:
+                proc_kwargs["images"] = _format_vlm_images_for_processor(
+                    all_images,
+                    processor=processor,
+                    image_layout=image_layout,
+                )
+            try:
+                return _call_vlm_processor(processor, (), proc_kwargs)
+            except TypeError as exc:
+                if (
+                    "add_special_tokens" in str(exc)
+                    # Bound twice, or not accepted: both mean drop and retry.
+                    and ("multiple values" in str(exc)
+                         or "unexpected keyword argument" in str(exc))
+                    and "add_special_tokens" in proc_kwargs
+                ):
+                    proc_kwargs.pop("add_special_tokens", None)
+                    try:
+                        return _call_vlm_processor(processor, (), proc_kwargs)
+                    except Exception as retry_exc:
+                        if first_error is None:
+                            first_error = retry_exc
+                        if len(image_layouts) == 1:
+                            raise
+                        continue
+                if "padding_side" in str(exc) and "padding_side" in proc_kwargs:
+                    proc_kwargs.pop("padding_side", None)
+                    try:
+                        return _call_vlm_processor(processor, (), proc_kwargs)
+                    except Exception as retry_exc:
+                        if first_error is None:
+                            first_error = retry_exc
+                        if len(image_layouts) == 1:
+                            raise
+                        continue
+                if first_error is None:
+                    first_error = exc
+                if len(image_layouts) == 1:
+                    raise
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+                if len(image_layouts) == 1:
+                    raise
+        raise first_error
+
+    if audio_kwarg is None:
+        return _run_layouts()
+    try:
+        return _run_layouts()
+    except ValueError as exc:
+        if "unpack" not in str(exc):
+            raise
+        # Some take (samples, rate) pairs, which surfaces as an unpacking
+        # error. The rate rides on the clip: such processors expose none.
+        default_rate = _audio_extractor_sampling_rate(processor)
+        base_kwargs[audio_kwarg] = [
+            (np.asarray(clip), getattr(clip, "sampling_rate", None) or default_rate)
+            for clip in audio
+        ]
         try:
-            return _call_vlm_processor(processor, (), proc_kwargs)
-        except TypeError as exc:
-            if (
-                "add_special_tokens" in str(exc)
-                and "multiple values" in str(exc)
-                and "add_special_tokens" in proc_kwargs
-            ):
-                proc_kwargs.pop("add_special_tokens", None)
-                try:
-                    return _call_vlm_processor(processor, (), proc_kwargs)
-                except Exception as retry_exc:
-                    if first_error is None:
-                        first_error = retry_exc
-                    if len(image_layouts) == 1:
-                        raise
-                    continue
-            if "padding_side" in str(exc) and "padding_side" in proc_kwargs:
-                proc_kwargs.pop("padding_side", None)
-                try:
-                    return _call_vlm_processor(processor, (), proc_kwargs)
-                except Exception as retry_exc:
-                    if first_error is None:
-                        first_error = retry_exc
-                    if len(image_layouts) == 1:
-                        raise
-                    continue
-            if first_error is None:
-                first_error = exc
-            if len(image_layouts) == 1:
-                raise
-        except Exception as exc:
-            if first_error is None:
-                first_error = exc
-            if len(image_layouts) == 1:
-                raise
-    raise first_error
+            return _run_layouts()
+        except Exception:
+            # Guess was wrong: report what the processor first said.
+            raise exc from None
 
 
 def _as_numpy_vlm_field(inputs, key):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -534,6 +534,26 @@ def _build_gemma_image_attention_mask(token_type_ids, attention_mask=None,
     return mx.expand_dims(mask, axis=1)
 
 
+# Families that read the padding mask, or whose layers fall back on a stored
+# `_full_attn_mask` without one -- falcon_perception never clears it, so a text
+# batch can inherit the previous image batch's. Elsewhere a supplied mask
+# reaches the layers, where it REPLACES causality. Listed rather than probed
+# from the signature, since molmo_point declares `mask` and never reads it, and
+# keyed on `model_type`, so aliases need their own entry.
+_VLM_FAMILIES_KEEPING_FORWARDED_MASK = frozenset({
+    "gemma3", "paligemma",
+    "llava_qwen2", "fastvlm",                    # FastVLM answers to both
+    "falcon_ocr", "falcon_perception", "falcon-perception",
+})
+
+
+def _keeps_forwarded_mask(model):
+    model_type = _config_get(getattr(model, "config", None), "model_type")
+    # mlx-vlm lower-cases model_type to resolve the module but leaves the
+    # config's own spelling alone, so match the way it resolves.
+    return str(model_type).lower() in _VLM_FAMILIES_KEEPING_FORWARDED_MASK
+
+
 def _run_hidden_stack(stack, inputs, inputs_embeds=None, **kwargs):
     """Execute a language stack up to pre-lm_head hidden states."""
     from mlx_vlm.models.base import create_attention_mask
@@ -552,8 +572,8 @@ def _run_hidden_stack(stack, inputs, inputs_embeds=None, **kwargs):
     mask = kwargs.get("mask")
     if mask is None:
         mask = kwargs.get("attention_mask_4d")
-    if mask is None:
-        mask = kwargs.get("attention_mask")
+    # No fallback to the 2-D `attention_mask`: layers use what they are handed
+    # verbatim, so it would replace causality.
     token_type_ids = kwargs.get("token_type_ids")
     token_type_mask = None
     if token_type_ids is not None:
@@ -1854,12 +1874,9 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
         # Forward full sequence then shift (Qwen3-VL mRoPE/deepstack need it);
         # mirrors `_vlm_cce_forward` so use_cce={True,False} stay in parity.
         inputs = input_ids
-        fwd_mask = attention_mask
 
-        # Model owns the causal mask. Pass through extras (e.g. image_grid_thw
-        # for Qwen). Strip every private `_unsloth_*` carrier (raw-ids plus the
-        # _unsloth_collated_position_ids marker) so model(...) never sees a kwarg
-        # it would reject, matching _vlm_cce_forward's filter.
+        # Pass through extras (e.g. image_grid_thw); strip the private
+        # `_unsloth_*` carriers, matching _vlm_cce_forward's filter.
         fwd_kwargs = {
             k: v for k, v in batch_dict.items()
             if k not in ("input_ids", "pixel_values", "attention_mask", "labels")
@@ -1867,7 +1884,12 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
             and v is not None
         }
         fwd_kwargs = _trim_sequence_aligned_vlm_kwargs(fwd_kwargs, inputs.shape[1])
-        output = model(inputs, pixel_values=pixel_values, mask=fwd_mask, **fwd_kwargs)
+        # Always sent: 13 families declare `mask` without a default. None lets
+        # them build the mask they would use for generation.
+        fwd_kwargs["mask"] = (
+            attention_mask if _keeps_forwarded_mask(model) else None
+        )
+        output = model(inputs, pixel_values=pixel_values, **fwd_kwargs)
         logits = output.logits if hasattr(output, "logits") else output
         logits = logits.astype(mx.float32)
         # Drop the final position so logits predict the next token.
@@ -5626,6 +5648,77 @@ def _as_numpy_vlm_field(inputs, key):
     return arr
 
 
+# Text-width-aligned arrays a processor authors for itself, beyond the ones the
+# pipeline owns in `_VLM_WIDTH_PADDABLE_KEYS`. The deepseek pair place image
+# embeddings at these indices.
+_VLM_PROCESSOR_TOKEN_ALIGNED_KEYS = ("images_seq_mask",)
+
+# Of those, the ones the compaction may move: inert at zero, which is what the
+# gather writes into a vacated slot. That drops the label carriers, which the
+# pipeline rebuilds from the repaired ids anyway; ids and mask move on their own.
+_VLM_RELOCATABLE_SIDECAR_KEYS = tuple(
+    key for key, inert in _VLM_WIDTH_PADDABLE_KEYS.items()
+    if inert == 0 and key != "attention_mask"
+) + _VLM_PROCESSOR_TOKEN_ALIGNED_KEYS
+
+
+def _vlm_token_aligned_sidecars(inputs, ids_shape):
+    """Return the processor fields whose columns are the token positions.
+
+    Left at the pre-repair columns these mark the wrong tokens: gemma4 builds
+    its bidirectional multimodal blocks from `mm_token_type_ids`, the deepseek
+    pair place image embeddings at `images_seq_mask` indices. Named, not
+    recognised by shape, since a shape does not say what indexes it -- an
+    (images, 2) grid matches a two-token batch -- so an unlisted sidecar is left
+    alone, as `_vlm_width_survey` also declines to guess.
+    """
+    sidecars = {}
+    for key in _VLM_RELOCATABLE_SIDECAR_KEYS:
+        if inputs.get(key) is None:
+            continue
+        values = _as_numpy_vlm_field(inputs, key)
+        if values.shape == ids_shape:
+            sidecars[key] = values
+    return sidecars
+
+
+def _right_pad_vlm_rows(inputs, processor):
+    """Compact each row's real tokens to the front.
+
+    Causality is all that excludes the pads once the mask is withheld, and it
+    excludes a trailing pad, not a leading one. deepseek_vl_v2 and the falcon
+    pair left-pad multimodal rows whatever side they are asked for, so the
+    layout is repaired rather than demanded.
+    """
+    value = inputs.get("attention_mask") if hasattr(inputs, "get") else None
+    if value is None:
+        return inputs
+    mask = _as_numpy_vlm_field(inputs, "attention_mask")
+    # Content-then-padding, so an interior pad counts as much as a leading one.
+    if not mask.size or bool(np.all(mask[:, :-1] >= mask[:, 1:])):
+        return inputs
+    generated = [
+        key for key in _VLM_WIDTH_GENERATED_KEYS if inputs.get(key) is not None
+    ]
+    if generated:
+        # Coordinates of the layout the repair replaces, not labels that travel.
+        raise ValueError(
+            f"Unsloth MLX: {type(processor).__name__} left-padded this batch "
+            f"and supplied its own {', '.join(generated)}, which cannot be "
+            f"re-derived for the repaired row order."
+        )
+    ids = _as_numpy_vlm_field(inputs, "input_ids")
+    extras = _vlm_token_aligned_sidecars(inputs, ids.shape)
+    ids, mask, extras = _flush_vlm_arrays_to_side(
+        ids, mask, "right", _vlm_pad_token_id(processor, default=0), extras,
+    )
+    inputs["input_ids"] = ids
+    inputs["attention_mask"] = mask
+    for key, values in extras.items():
+        inputs[key] = values
+    return inputs
+
+
 def _common_text_prefix(left, right):
     """Return CUDA's shared rendered prompt prefix for VLM PC rows."""
     end = 0
@@ -5643,11 +5736,13 @@ def _vlm_tokenizer_padding_side(processor):
     return "left" if side == "left" else "right"
 
 
-def _vlm_pad_token_id(processor):
-    """Return the processor tokenizer pad id required for PC collation."""
+def _vlm_pad_token_id(processor, default=None):
+    """Return the processor tokenizer pad id, or ``default`` when it has none."""
     tokenizer = _get_processor_tokenizer(processor)
     pad_id = getattr(tokenizer, "pad_token_id", None)
     if pad_id is None:
+        if default is not None:
+            return default
         raise ValueError(
             "Tokenizer must define `pad_token_id` for prompt-completion collation."
         )
@@ -5859,6 +5954,10 @@ def _combine_vlm_prompt_completion_inputs(
     input_ids, attention_mask, extras = _truncate_vlm_arrays_by_side(
         input_ids, attention_mask, flush_side, max_seq_length, extras,
     )
+    # Truncation keeps CUDA's side; the rows still have to arrive right-padded.
+    input_ids, attention_mask, extras = _flush_vlm_arrays_to_side(
+        input_ids, attention_mask, "right", pad_id, extras,
+    )
 
     combined_inputs = dict(prompt_inputs)
     combined_inputs["input_ids"] = input_ids
@@ -5958,9 +6057,13 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         all_images.append(images)
         all_suffixes.append(item.get("suffix") if isinstance(item, dict) else None)
 
-    inputs = _processor_vlm_inputs(
-        processor, all_texts, all_images, max_seq_length,
-        suffixes=all_suffixes,
+    inputs = _right_pad_vlm_rows(
+        _processor_vlm_inputs(
+            processor, all_texts, all_images, max_seq_length,
+            suffixes=all_suffixes,
+            padding_side="right",
+        ),
+        processor,
     )
     if _vlm_inputs_host_valued(inputs) and _vlm_ids_integer_host(inputs):
         label_mask = _stage_vlm_label_mask_np(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -8336,14 +8336,10 @@ _AUDIO_TOWER_ATTRS = (
 _AUDIO_MERGE_SENTINEL = "_unsloth_audio_merge_patched"
 _AUDIO_MERGE_HOLDERS = "_unsloth_audio_merge_holders"
 _AUDIO_MERGE_ORIGINAL = "_unsloth_audio_merge_original"
-# The hold count is read, decided on and written back, which is three
-# statements and therefore not atomic under the GIL. Two trainers starting
-# close together -- the case install_audio_merge_patch documents as supported
-# -- could both read zero, both install a wrapper, and both leave the count at
-# one; the first to finish would then restore the original embedder while the
-# other was still training, silently reinstating the merge bug. Module-level
-# rather than per-model: it is taken twice per run, so contention is
-# irrelevant, and a per-model lock would need this same guard to create.
+# The hold count is read, decided on and written back, which the GIL does not
+# make atomic, so two trainers starting close together could both install a
+# wrapper and the first to finish would restore the original mid-training.
+# Module-level: it is taken twice per run, so contention is irrelevant.
 _AUDIO_MERGE_LOCK = threading.Lock()
 
 # Families whose merge walks a flattened feature block with a running
@@ -8421,13 +8417,9 @@ def install_audio_merge_patch(model, audio_token_id):
     until the last of them releases it. Returns True when a hold was taken, so
     every caller that gets True must release exactly once.
     """
-    # The whole sequence is under the lock, not just the count: capturing the
-    # current embedder, installing the wrapper and recording what to restore
-    # are one transition. Split across the lock boundary, an installer arriving
-    # while the last holder is restoring can capture the outgoing wrapper as
-    # its "original", and the remover can then overwrite the freshly installed
-    # one -- leaving the live run unpatched. Building the closure is pure
-    # Python with no I/O, so holding the lock across it costs nothing.
+    # Capture, install and record are one transition, so all of it is under the
+    # lock: split, an installer arriving mid-restore captures the outgoing
+    # wrapper as its "original" and the remover overwrites the new one.
     with _AUDIO_MERGE_LOCK:
         holders = getattr(model, _AUDIO_MERGE_HOLDERS, 0)
         if holders:
@@ -8482,10 +8474,8 @@ def remove_audio_merge_patch(model):
         if holders > 1:
             setattr(model, _AUDIO_MERGE_HOLDERS, holders - 1)
             return False
-        # Last holder. The restoration stays inside the lock with the count
-        # drop: released early, an installer could take the slot and capture
-        # the outgoing wrapper as its own "original", and this restore would
-        # then overwrite the wrapper that installer had just put in place.
+        # Last holder: restore inside the lock with the count drop, for the
+        # reason install gives.
         previous = getattr(model, _AUDIO_MERGE_ORIGINAL, None)
         if previous is not None:
             model.get_input_embeddings = previous

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -8421,6 +8421,13 @@ def install_audio_merge_patch(model, audio_token_id):
     until the last of them releases it. Returns True when a hold was taken, so
     every caller that gets True must release exactly once.
     """
+    # The whole sequence is under the lock, not just the count: capturing the
+    # current embedder, installing the wrapper and recording what to restore
+    # are one transition. Split across the lock boundary, an installer arriving
+    # while the last holder is restoring can capture the outgoing wrapper as
+    # its "original", and the remover can then overwrite the freshly installed
+    # one -- leaving the live run unpatched. Building the closure is pure
+    # Python with no I/O, so holding the lock across it costs nothing.
     with _AUDIO_MERGE_LOCK:
         holders = getattr(model, _AUDIO_MERGE_HOLDERS, 0)
         if holders:
@@ -8428,44 +8435,42 @@ def install_audio_merge_patch(model, audio_token_id):
             # finishes first.
             setattr(model, _AUDIO_MERGE_HOLDERS, holders + 1)
             return True
-        # Claim the slot before building the wrapper, so a second caller
-        # arriving mid-build takes a hold instead of installing its own.
+        original = model.get_input_embeddings
+        had_instance_attr = "get_input_embeddings" in vars(model)
+        audio_keys = ("input_features", "input_features_mask",
+                      "audio_features", "audio_mask")
+
+        def patched(input_ids=None, pixel_values=None, **kwargs):
+            features = kwargs.get("input_features", kwargs.get("audio_features"))
+            valid = kwargs.get("input_features_mask")
+            if features is None or valid is None:
+                return original(input_ids=input_ids, pixel_values=pixel_values, **kwargs)
+            # Model builds text and vision embeddings; audio is merged here.
+            rest = {k: v for k, v in kwargs.items() if k not in audio_keys}
+            result = original(input_ids=input_ids, pixel_values=pixel_values, **rest)
+            embeds = getattr(result, "inputs_embeds", result)
+            encoded, padding = model.audio_tower(features, ~valid)
+            audio_embeds = model.embed_audio(encoded)
+            placeholders = np.asarray(input_ids == audio_token_id).sum(axis=1)
+            source = _compact_audio_features(audio_embeds, padding, placeholders)
+            # Without this cast the merge widens the whole LM input to float32.
+            source = source.astype(embeds.dtype)
+            mask = mx.broadcast_to(
+                mx.expand_dims(input_ids == audio_token_id, -1), embeds.shape,
+            )
+            merged = _masked_scatter_rowwise(embeds, mask, source)
+            if hasattr(result, "inputs_embeds"):
+                result.inputs_embeds = merged
+                return result
+            return merged
+
+        model.get_input_embeddings = patched
+        setattr(model, _AUDIO_MERGE_SENTINEL, True)
         setattr(model, _AUDIO_MERGE_HOLDERS, 1)
-    original = model.get_input_embeddings
-    had_instance_attr = "get_input_embeddings" in vars(model)
-    audio_keys = ("input_features", "input_features_mask",
-                  "audio_features", "audio_mask")
-
-    def patched(input_ids=None, pixel_values=None, **kwargs):
-        features = kwargs.get("input_features", kwargs.get("audio_features"))
-        valid = kwargs.get("input_features_mask")
-        if features is None or valid is None:
-            return original(input_ids=input_ids, pixel_values=pixel_values, **kwargs)
-        # Model builds text and vision embeddings; audio is merged here.
-        rest = {k: v for k, v in kwargs.items() if k not in audio_keys}
-        result = original(input_ids=input_ids, pixel_values=pixel_values, **rest)
-        embeds = getattr(result, "inputs_embeds", result)
-        encoded, padding = model.audio_tower(features, ~valid)
-        audio_embeds = model.embed_audio(encoded)
-        placeholders = np.asarray(input_ids == audio_token_id).sum(axis=1)
-        source = _compact_audio_features(audio_embeds, padding, placeholders)
-        # Without this cast the merge widens the whole LM input to float32.
-        source = source.astype(embeds.dtype)
-        mask = mx.broadcast_to(
-            mx.expand_dims(input_ids == audio_token_id, -1), embeds.shape,
-        )
-        merged = _masked_scatter_rowwise(embeds, mask, source)
-        if hasattr(result, "inputs_embeds"):
-            result.inputs_embeds = merged
-            return result
-        return merged
-
-    model.get_input_embeddings = patched
-    setattr(model, _AUDIO_MERGE_SENTINEL, True)
-    # Put back exactly what was there: deleting would discard someone else's
-    # instance-level wrapper.
-    setattr(model, _AUDIO_MERGE_ORIGINAL, original if had_instance_attr else None)
-    return True
+        # Put back exactly what was there: deleting would discard someone else's
+        # instance-level wrapper.
+        setattr(model, _AUDIO_MERGE_ORIGINAL, original if had_instance_attr else None)
+        return True
 
 
 def remove_audio_merge_patch(model):
@@ -8477,20 +8482,22 @@ def remove_audio_merge_patch(model):
         if holders > 1:
             setattr(model, _AUDIO_MERGE_HOLDERS, holders - 1)
             return False
-        # Last holder: drop the count inside the lock so a caller arriving now
-        # installs afresh rather than taking a hold on a patch being removed.
+        # Last holder. The restoration stays inside the lock with the count
+        # drop: released early, an installer could take the slot and capture
+        # the outgoing wrapper as its own "original", and this restore would
+        # then overwrite the wrapper that installer had just put in place.
+        previous = getattr(model, _AUDIO_MERGE_ORIGINAL, None)
+        if previous is not None:
+            model.get_input_embeddings = previous
+        else:
+            try:
+                del model.get_input_embeddings
+            except AttributeError:
+                pass
+        setattr(model, _AUDIO_MERGE_SENTINEL, False)
+        setattr(model, _AUDIO_MERGE_ORIGINAL, None)
         setattr(model, _AUDIO_MERGE_HOLDERS, 0)
-    previous = getattr(model, _AUDIO_MERGE_ORIGINAL, None)
-    if previous is not None:
-        model.get_input_embeddings = previous
-    else:
-        try:
-            del model.get_input_embeddings
-        except AttributeError:
-            pass
-    setattr(model, _AUDIO_MERGE_SENTINEL, False)
-    setattr(model, _AUDIO_MERGE_ORIGINAL, None)
-    return True
+        return True
 
 
 def _masked_scatter_rowwise(embeds, mask, source):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6362,7 +6362,9 @@ def _assert_audio_bounds_intact(rows, ids, attention_mask, audio_counts,
             width if mask_np is None
             else int(mask_np[index].astype(bool).sum())
         )
-        if max_seq_length and attended > int(max_seq_length):
+        # Audio-bearing rows only, as in the run path: a stated-span family
+        # reports bounds for every row, so an audio-free one would be capped too.
+        if expected and max_seq_length and attended > int(max_seq_length):
             # Padding is not the row's own length, so this counts what the model
             # attends -- the same quantity the run check caps.
             raise ValueError(
@@ -6635,7 +6637,12 @@ def _assert_audio_runs_intact_ids(ids, attention_mask, audio_counts, soft_ids,
                 f"tokenization. Every clip needs its own placeholder in the "
                 f"rendered text, and none may be dropped by truncation."
             )
-        if max_seq_length is None:
+        # Only rows that carry audio, as the two checks above are: the cap is
+        # here so a placeholder run is not cut unnoticed, and an audio-free row
+        # has none to cut. An omni checkpoint resolves soft ids whether or not
+        # the run uses audio, so without this a plain text or image batch wider
+        # than the cap is refused -- which the shape planner states is normal.
+        if max_seq_length is None or not expected_clips:
             continue
         if int(valid.sum()) > int(max_seq_length):
             # Some processors divert the truncation kwargs to their audio

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6779,11 +6779,22 @@ def _audio_payload_as_pairs(clips, processor):
 
     A clip carries the rate it was decoded at; the processor's own extractor
     rate stands in for anything that does not.
+
+    The nested payload a processor like MiniCPM-o is handed keeps its shape: a
+    row is a list of clips, not a clip, so pairing it whole would fuse a row
+    into one 2-D "clip" carrying no rate -- or raise out of numpy when the
+    row's clips differ in length, which reports a payload the processor never
+    saw. Rows are paired clip by clip instead.
     """
     default_rate = audio_extractor_sampling_rate(processor)
-    return [(np.asarray(clip),
-             getattr(clip, "sampling_rate", None) or default_rate)
-            for clip in clips]
+
+    def _pair(clip):
+        return (np.asarray(clip),
+                getattr(clip, "sampling_rate", None) or default_rate)
+
+    return [[_pair(clip) for clip in row] if isinstance(row, (list, tuple))
+            else _pair(row)
+            for row in clips]
 
 
 def _format_vlm_audio_for_processor(all_audio, processor=None):
@@ -6903,7 +6914,19 @@ def _to_mx_vlm_batch(inputs):
                     for x in value
                 ])
             except Exception:
-                batch[key] = mx.array(value[0]) if not isinstance(value[0], mx.array) else value[0]
+                if key in _AUDIO_FEATURE_PAYLOAD_KEYS and len(value) > 1:
+                    # Clips of unequal duration do not stack, and dropping to
+                    # value[0] would leave one clip behind ids, placeholder runs
+                    # and labels for all of them -- the pairing
+                    # `_assert_audio_features_present` just verified. Kept entry
+                    # by entry so the count survives; ragged audio never reaches
+                    # the compiled path, so there is no signature to hold.
+                    batch[key] = [
+                        x if isinstance(x, mx.array) else mx.array(np.asarray(x))
+                        for x in value
+                    ]
+                else:
+                    batch[key] = mx.array(value[0]) if not isinstance(value[0], mx.array) else value[0]
         else:
             batch[key] = value
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -8000,8 +8000,15 @@ _AUDIO_MERGE_PATCH_FAMILIES = frozenset({"gemma4"})
 
 
 def audio_merge_patch_needed(config):
-    """Whether this model family's audio merge must be corrected for training."""
-    return _config_get(config, "model_type") in _AUDIO_MERGE_PATCH_FAMILIES
+    """Whether this model family's audio merge must be corrected for training.
+
+    Matched case-insensitively because mlx-vlm lowercases ``model_type`` before
+    selecting the module: a checkpoint spelling it differently loads the same
+    family and passes the audio gate, so an exact match here would skip the
+    correction for a model that needs it.
+    """
+    model_type = _config_get(config, "model_type")
+    return str(model_type).lower() in _AUDIO_MERGE_PATCH_FAMILIES
 
 
 def _compact_audio_features(embeddings, padding_mask, placeholders_per_row):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -667,6 +667,16 @@ def _shared_kv_slot_count(model):
     config = getattr(backbone, "config", None)
     if not (_config_get(config, "num_kv_shared_layers") or 0):
         return 0
+    # mlx-vlm 0.5.0+ threads shared K/V itself, so `_fix_gemma4_kv_sharing`
+    # leaves those backbones alone and they keep the ordinary per-layer cache
+    # contract. These slots are shorter than the layer count by construction
+    # (`first_kv_shared_layer_idx == num_hidden_layers - num_kv_shared_layers`),
+    # so handing them over as `cache` would truncate the zip over layers and
+    # silently drop the shared tail of the stack. Imported here rather than at
+    # module scope: loader imports nothing from this module and vice versa.
+    from .loader import _gemma4_has_native_shared_kv
+    if _gemma4_has_native_shared_kv(backbone):
+        return 0
     return getattr(backbone, "first_kv_shared_layer_idx", 0) or 0
 
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -434,10 +434,26 @@ def _patch_layer_class_for_gc(layer_cls):
     fn = layer_cls.__call__
 
     def checkpointed_fn(self, *args, **kwargs):
-        def inner_fn(params, *args, **kwargs):
+        slot = next((a for a in args if isinstance(a, _SharedKVSlot)), None)
+        if slot is None:
+            def inner_fn(params, *args, **kwargs):
+                self.update(params)
+                return fn(self, *args, **kwargs)
+            return mx.checkpoint(inner_fn)(
+                self.trainable_parameters(), *args, **kwargs)
+
+        # Shared K/V crosses the checkpoint boundary as a traced argument and a
+        # traced result; read off the slot and the VJP drops the gradient.
+        def inner_fn(params, borrowed, *args, **kwargs):
             self.update(params)
-            return fn(self, *args, **kwargs)
-        return mx.checkpoint(inner_fn)(self.trainable_parameters(), *args, **kwargs)
+            slot.install(borrowed)
+            out = fn(self, *args, **kwargs)
+            return out, slot.recorded()
+
+        out, recorded = mx.checkpoint(inner_fn)(
+            self.trainable_parameters(), slot.borrow(), *args, **kwargs)
+        slot.install(recorded)
+        return out
 
     layer_cls.__call__ = checkpointed_fn
 
@@ -552,6 +568,74 @@ def _keeps_forwarded_mask(model):
     # mlx-vlm lower-cases model_type to resolve the module but leaves the
     # config's own spelling alone, so match the way it resolves.
     return str(model_type).lower() in _VLM_FAMILIES_KEEPING_FORWARDED_MASK
+
+
+class _SharedKVSlot:
+    """A cache with training semantics, so KV-shared layers borrow rather than
+    rebuild K/V that the reference implementation never recomputes.
+
+    Position stays 0 and nothing is ever trimmed; a prompt cache would forget
+    past its sliding window and re-rope queries at an advancing offset. No
+    version gate: gemma4 from mlx-vlm 0.5.0 reads shared K/V from its layer
+    results instead; the slots still travel with the batch, but stop being where
+    the sharing is read and leave the training result unchanged.
+
+    `borrow`/`install`/`recorded` exist because gradient checkpointing cannot
+    see an attribute read -- the recomputed VJP drops the gradient while the
+    forward stays correct -- so the wrapper passes K/V in as an argument and
+    takes it back as a result.
+    """
+
+    __slots__ = ("keys", "values")
+
+    def __init__(self):
+        self.keys = None
+        self.values = None
+
+    @property
+    def offset(self):
+        return 0
+
+    @property
+    def state(self):
+        return self.keys, self.values
+
+    def update_and_fetch(self, keys, values):
+        self.keys, self.values = keys, values
+        return keys, values
+
+    def borrow(self):
+        """K/V to pass into the next layer's traced region, if any."""
+        return None if self.keys is None else (self.keys, self.values)
+
+    def install(self, borrowed):
+        if borrowed is not None:
+            self.keys, self.values = borrowed
+
+    def recorded(self):
+        return self.keys, self.values
+
+
+def _shared_kv_slot_count(model):
+    """How many cache slots this stack needs, or 0 when it shares no K/V.
+
+    Not `first_kv_shared_layer_idx > 0`: upstream derives that as
+    `num_hidden_layers - num_kv_shared_layers`, so it is positive with zero
+    sharing too, as gemma4 12B/26B declare.
+    """
+    backbone = getattr(_get_text_model(model), "model", None)
+    if backbone is None:
+        return 0
+    config = getattr(backbone, "config", None)
+    if not (_config_get(config, "num_kv_shared_layers") or 0):
+        return 0
+    return getattr(backbone, "first_kv_shared_layer_idx", 0) or 0
+
+
+def _build_shared_kv_caches(model):
+    """Fresh per-forward slots for a stack that shares K/V, else None."""
+    slots = _shared_kv_slot_count(model)
+    return [_SharedKVSlot() for _ in range(slots)] if slots else None
 
 
 def _run_hidden_stack(stack, inputs, inputs_embeds=None, **kwargs):
@@ -1889,6 +1973,9 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
         fwd_kwargs["mask"] = (
             attention_mask if _keeps_forwarded_mask(model) else None
         )
+        shared_kv = _build_shared_kv_caches(model)
+        if shared_kv is not None:
+            fwd_kwargs["cache"] = shared_kv
         output = model(inputs, pixel_values=pixel_values, **fwd_kwargs)
         logits = output.logits if hasattr(output, "logits") else output
         logits = logits.astype(mx.float32)
@@ -2084,6 +2171,10 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
         backbone_kwargs["token_type_ids"] = extra_kwargs["token_type_ids"]
         if attention_mask is not None:
             backbone_kwargs["attention_mask"] = attention_mask
+
+    shared_kv = _build_shared_kv_caches(model)
+    if shared_kv is not None:
+        backbone_kwargs["cache"] = shared_kv
 
     hidden = _forward_text_hidden_states(
         model,

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -8336,6 +8336,15 @@ _AUDIO_TOWER_ATTRS = (
 _AUDIO_MERGE_SENTINEL = "_unsloth_audio_merge_patched"
 _AUDIO_MERGE_HOLDERS = "_unsloth_audio_merge_holders"
 _AUDIO_MERGE_ORIGINAL = "_unsloth_audio_merge_original"
+# The hold count is read, decided on and written back, which is three
+# statements and therefore not atomic under the GIL. Two trainers starting
+# close together -- the case install_audio_merge_patch documents as supported
+# -- could both read zero, both install a wrapper, and both leave the count at
+# one; the first to finish would then restore the original embedder while the
+# other was still training, silently reinstating the merge bug. Module-level
+# rather than per-model: it is taken twice per run, so contention is
+# irrelevant, and a per-model lock would need this same guard to create.
+_AUDIO_MERGE_LOCK = threading.Lock()
 
 # Families whose merge walks a flattened feature block with a running
 # placeholder count, so a padded row's tail is consumed by the next row. Gemma 3n
@@ -8412,11 +8421,16 @@ def install_audio_merge_patch(model, audio_token_id):
     until the last of them releases it. Returns True when a hold was taken, so
     every caller that gets True must release exactly once.
     """
-    holders = getattr(model, _AUDIO_MERGE_HOLDERS, 0)
-    if holders:
-        # Another run holds it: take a hold so it outlives whoever finishes first.
-        setattr(model, _AUDIO_MERGE_HOLDERS, holders + 1)
-        return True
+    with _AUDIO_MERGE_LOCK:
+        holders = getattr(model, _AUDIO_MERGE_HOLDERS, 0)
+        if holders:
+            # Another run holds it: take a hold so it outlives whoever
+            # finishes first.
+            setattr(model, _AUDIO_MERGE_HOLDERS, holders + 1)
+            return True
+        # Claim the slot before building the wrapper, so a second caller
+        # arriving mid-build takes a hold instead of installing its own.
+        setattr(model, _AUDIO_MERGE_HOLDERS, 1)
     original = model.get_input_embeddings
     had_instance_attr = "get_input_embeddings" in vars(model)
     audio_keys = ("input_features", "input_features_mask",
@@ -8448,7 +8462,6 @@ def install_audio_merge_patch(model, audio_token_id):
 
     model.get_input_embeddings = patched
     setattr(model, _AUDIO_MERGE_SENTINEL, True)
-    setattr(model, _AUDIO_MERGE_HOLDERS, 1)
     # Put back exactly what was there: deleting would discard someone else's
     # instance-level wrapper.
     setattr(model, _AUDIO_MERGE_ORIGINAL, original if had_instance_attr else None)
@@ -8457,12 +8470,16 @@ def install_audio_merge_patch(model, audio_token_id):
 
 def remove_audio_merge_patch(model):
     """Release one hold on the corrected merge, restoring it at the last."""
-    holders = getattr(model, _AUDIO_MERGE_HOLDERS, 0)
-    if holders <= 0:
-        return False
-    if holders > 1:
-        setattr(model, _AUDIO_MERGE_HOLDERS, holders - 1)
-        return False
+    with _AUDIO_MERGE_LOCK:
+        holders = getattr(model, _AUDIO_MERGE_HOLDERS, 0)
+        if holders <= 0:
+            return False
+        if holders > 1:
+            setattr(model, _AUDIO_MERGE_HOLDERS, holders - 1)
+            return False
+        # Last holder: drop the count inside the lock so a caller arriving now
+        # installs afresh rather than taking a hold on a patch being removed.
+        setattr(model, _AUDIO_MERGE_HOLDERS, 0)
     previous = getattr(model, _AUDIO_MERGE_ORIGINAL, None)
     if previous is not None:
         model.get_input_embeddings = previous
@@ -8472,7 +8489,6 @@ def remove_audio_merge_patch(model):
         except AttributeError:
             pass
     setattr(model, _AUDIO_MERGE_SENTINEL, False)
-    setattr(model, _AUDIO_MERGE_HOLDERS, 0)
     setattr(model, _AUDIO_MERGE_ORIGINAL, None)
     return True
 

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2079,6 +2079,28 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
         shared_kv = _build_shared_kv_caches(model)
         if shared_kv is not None:
             fwd_kwargs["cache"] = shared_kv
+        # gemma3n scales token embeddings by sqrt(hidden_size) on the ids path
+        # only, and `Model.__call__` sends ids through `get_input_embeddings`,
+        # which does not scale. Handing the model ids therefore trains on text
+        # embeddings ~45x too small beside merged features. `_vlm_cce_forward`
+        # already merges and rescales itself; do the same here so
+        # use_cce={True,False} stay in parity instead of differing by that.
+        if _vlm_embed_scale(model) is not None:
+            embed_result = model.get_input_embeddings(
+                inputs,
+                pixel_values,
+                mask=fwd_kwargs.get("mask"),
+                **{k: v for k, v in fwd_kwargs.items()
+                   if k not in ("mask", "cache")},
+            )
+            merged_embeds, embed_kwargs = _unpack_embed_result(embed_result, model)
+            fwd_kwargs["inputs_embeds"] = _apply_vlm_embed_scale(
+                model, inputs, merged_embeds,
+            )
+            # per_layer_inputs and friends: the merge produced them, and
+            # recomputing from ids inside the stack would redo the work.
+            for key, value in embed_kwargs.items():
+                fwd_kwargs.setdefault(key, value)
         output = model(inputs, pixel_values=pixel_values, **fwd_kwargs)
         logits = output.logits if hasattr(output, "logits") else output
         logits = logits.astype(mx.float32)
@@ -6305,6 +6327,24 @@ def _assert_audio_features_present(inputs, expected, processor):
     )
 
 
+def _image_bounds_per_row(inputs):
+    """Per-row image placeholder spans, when the processor states them.
+
+    MiniCPM-V and MiniCPM-o report ``image_bound`` as absolute columns into the
+    layout they padded, offsetting it by each row's leading pad count. The
+    values are coordinates like ``audio_bounds``, not labels that travel with a
+    row, so a repair that moves the tokens invalidates them the same way.
+    """
+    bounds = inputs.get("image_bound") if isinstance(inputs, Mapping) else None
+    if bounds is None:
+        return None
+    rows = []
+    for row in bounds:
+        spans = np.asarray(row).reshape(-1, 2) if np.size(row) else np.empty((0, 2))
+        rows.append([(int(start), int(end)) for start, end in spans])
+    return rows
+
+
 def _audio_bounds_per_row(inputs):
     """Per-row ``(start, end)`` audio spans, when the processor states them.
 
@@ -7267,6 +7307,22 @@ def _right_pad_vlm_rows(inputs, processor):
             f"{stale} content-first despite being asked for right-padded rows, "
             f"and reports their audio positions as spans, which name the layout "
             f"the repair replaces."
+        )
+    # Same argument for image spans. `image_bound` is neither width-generated
+    # nor token-aligned -- an (images, 2) grid is not the ids shape -- so the
+    # sidecar relocation leaves it naming pre-repair columns, and the model
+    # would scatter each image's features onto whatever tokens moved there.
+    # Silent: the stale columns stay attended, so nothing downstream objects.
+    image_stale = [
+        index for index, spans in enumerate(_image_bounds_per_row(inputs) or ())
+        if spans and index < moved.shape[0] and bool(moved[index])
+    ]
+    if image_stale:
+        raise ValueError(
+            f"Unsloth MLX: {type(processor).__name__} did not put row(s) "
+            f"{image_stale} content-first despite being asked for right-padded "
+            f"rows, and reports their image positions as spans, which name the "
+            f"layout the repair replaces."
         )
     ids = _as_numpy_vlm_field(inputs, "input_ids")
     extras = _vlm_token_aligned_sidecars(inputs, ids.shape)

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -5908,7 +5908,18 @@ def _audio_probe_once(processor, text, kwarg, rate, hertz, held):
     # Held for the probe's lifetime so no later buffer can reuse its address.
     held.append(clip)
     payload = _format_vlm_audio_for_processor([[clip]], processor=processor)
-    return processor(text=[text], **{kwarg: payload})
+    try:
+        return processor(text=[text], **{kwarg: payload})
+    except ValueError as exc:
+        if "unpack" not in str(exc):
+            raise
+        # Same contract collation handles: a processor that wants
+        # (samples, rate) pairs rejects a bare waveform by failing to unpack
+        # it. Answering "not capable" here would report a working checkpoint
+        # as unusable.
+        return processor(
+            text=[text],
+            **{kwarg: _audio_payload_as_pairs([clip], processor)})
 
 
 def _audio_probe_processor(processor, texts):
@@ -6653,6 +6664,18 @@ def _vlm_processor_prefers_nested_audio(processor):
     return any(name in marker for name in ("minicpmo",))
 
 
+def _audio_payload_as_pairs(clips, processor):
+    """The ``(samples, rate)`` form processors that reject bare waveforms want.
+
+    A clip carries the rate it was decoded at; the processor's own extractor
+    rate stands in for anything that does not.
+    """
+    default_rate = audio_extractor_sampling_rate(processor)
+    return [(np.asarray(clip),
+             getattr(clip, "sampling_rate", None) or default_rate)
+            for clip in clips]
+
+
 def _format_vlm_audio_for_processor(all_audio, processor=None):
     """Group per-row clips the way this processor assigns them to rows."""
     if not all_audio or not any(all_audio):
@@ -7081,12 +7104,8 @@ def _processor_vlm_inputs(
         if "unpack" not in str(exc):
             raise
         # Some take (samples, rate) pairs, which surfaces as an unpacking
-        # error. The rate rides on the clip: such processors expose none.
-        default_rate = audio_extractor_sampling_rate(processor)
-        base_kwargs[audio_kwarg] = [
-            (np.asarray(clip), getattr(clip, "sampling_rate", None) or default_rate)
-            for clip in audio
-        ]
+        # error.
+        base_kwargs[audio_kwarg] = _audio_payload_as_pairs(audio, processor)
         try:
             return _run_audio_layouts()
         except Exception:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1654,6 +1654,13 @@ def _get_vlm_ignore_token_ids(processor=None, config=None, model=None):
     ):
         _append_unique_int(ids, _config_get(config, key, None))
 
+    # The repeated audio placeholder, which the names above do not always reach:
+    # Phi-4 spells it `<|endoftext11|>` and declares it in neither the tokenizer
+    # attributes nor its checkpoint config, so every audio position was a
+    # supervised target. Resolved the same way run counting resolves it.
+    for token_id in _get_vlm_audio_soft_token_ids(processor, config) or ():
+        _append_unique_int(ids, token_id)
+
     if not ids:
         return None
     return ids  # plain Python list; avoids mx.eval in the hot path
@@ -1870,13 +1877,16 @@ def _finalize_vlm_batch(staged, keep_raw_carrier=False, phase=None):
     if staged.pc_opaque is not None:
         (prompt_inputs, completion_inputs, flush_side, pad_id, max_seq_length,
          completion_only_loss) = staged.pc_opaque
-        audio_counts, audio_soft_ids = staged.pc_audio or (None, None)
+        audio_counts, audio_soft_ids, audio_budget = (
+            staged.pc_audio or (None, None, None)
+        )
         inner = _combine_vlm_prompt_completion_inputs(
             prompt_inputs, completion_inputs, flush_side, pad_id,
             max_seq_length,
             ignore_token_ids=staged.ignore_token_ids,
             completion_only_loss=completion_only_loss,
             audio_counts=audio_counts, audio_soft_ids=audio_soft_ids,
+            audio_budget=audio_budget,
         )
         inner.config = staged.config
         return _finalize_vlm_batch(
@@ -5722,7 +5732,6 @@ _AUDIO_NO_OWN_HOOK = object()
 
 
 def _audio_count_corrected(processor):
-    """Whether this processor is carrying the corrected placeholder count."""
     hook = getattr(processor, "_compute_audio_num_tokens", None)
     return (isinstance(hook, partial)
             and hook.func is _gemma4_audio_placeholder_count)
@@ -5889,7 +5898,6 @@ def _audio_probe_fingerprint(value):
 
 
 def _audio_probe_once(processor, text, kwarg, rate, hertz, held):
-    """One real processor call on a freshly built tone."""
     clip = _AudioClip(_audio_probe_tone(rate, hertz), rate)
     # Held for the probe's lifetime so no later buffer can reuse its address.
     held.append(clip)
@@ -6107,7 +6115,6 @@ def _normalize_audio_clip(clip, expected_rate):
 
 
 def _vlm_audio_part_state(messages):
-    """Whether messages carry audio placeholders and/or embedded audio."""
     bare_placeholders = False
     payloads = []
     if not isinstance(messages, list):
@@ -6536,7 +6543,6 @@ def _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
     if not soft_ids:
         if not any(audio_counts):
             return
-        # An unverifiable run is what this check exists to prevent.
         raise ValueError(
             f"Unsloth MLX: could not resolve the audio placeholder token for "
             f"{type(processor).__name__}, so audio/text alignment cannot be "
@@ -6592,7 +6598,6 @@ def _assert_audio_runs_intact_ids(ids, attention_mask, audio_counts, soft_ids,
             else np.ones(row.shape, dtype=bool)
         )
         is_soft = np.isin(row, soft_array) & valid
-        # Count maximal runs: a rising edge starts a new placeholder run.
         starts = int(np.sum(is_soft & ~np.concatenate(([False], is_soft[:-1]))))
         total_runs += starts
         if expected_clips and budget:
@@ -6652,7 +6657,6 @@ def _format_vlm_audio_for_processor(all_audio, processor=None):
 
 
 def _vlm_processor_audio_kwarg(processor):
-    """The audio keyword this processor accepts ('audio' or 'audios')."""
     try:
         parameters = inspect.signature(processor.__call__).parameters
     except (TypeError, ValueError):
@@ -7371,6 +7375,7 @@ def _collate_vlm_prompt_completion_batch(
     _assert_audio_runs_intact(
         prompt_inputs, audio_counts, processor, None, truncated=False,
     )
+    audio_budget = _audio_fixed_budget(processor)
     audio_soft_ids = (
         _get_vlm_audio_soft_token_ids(processor) if any(audio_counts) else None
     )
@@ -7400,7 +7405,7 @@ def _collate_vlm_prompt_completion_batch(
             ignore_token_ids=ignore_token_ids,
             pc_opaque=(prompt_inputs, completion_inputs, flush_side, pad_id,
                        max_seq_length, completion_only_loss),
-            pc_audio=(audio_counts, audio_soft_ids),
+            pc_audio=(audio_counts, audio_soft_ids, audio_budget),
         )
     return _combine_vlm_prompt_completion_inputs(
         prompt_inputs, completion_inputs, flush_side, pad_id, max_seq_length,
@@ -7408,6 +7413,7 @@ def _collate_vlm_prompt_completion_batch(
         completion_only_loss=completion_only_loss,
         reject_mlx_valued=reject_mlx_valued,
         audio_counts=audio_counts, audio_soft_ids=audio_soft_ids,
+        audio_budget=audio_budget,
     )
 
 
@@ -7422,6 +7428,7 @@ def _combine_vlm_prompt_completion_inputs(
     reject_mlx_valued=False,
     audio_counts=None,
     audio_soft_ids=None,
+    audio_budget=None,
 ):
     """Concatenate prompt/completion processor outputs into one staged batch.
 
@@ -7460,9 +7467,11 @@ def _combine_vlm_prompt_completion_inputs(
     )
     if audio_counts and any(audio_counts):
         # Flush + truncate is where a prompt-side run can actually be cut.
+        # With the family's fixed budget, since a run cut short still leaves one
+        # run per clip and only its length gives it away.
         _assert_audio_runs_intact_ids(
             input_ids, attention_mask, audio_counts, audio_soft_ids,
-            max_seq_length,
+            max_seq_length, budget=audio_budget,
         )
 
     combined_inputs = dict(prompt_inputs)
@@ -8317,7 +8326,6 @@ def remove_audio_merge_patch(model):
 
 
 def _masked_scatter_rowwise(embeds, mask, source):
-    """Place ``source`` rows at the masked positions, in order."""
     flat_mask = mask.flatten().astype(mx.int32)
     indices = mx.cumsum(flat_mask) - 1
     flat_source = source.flatten()

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -53,6 +53,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from functools import lru_cache, partial, wraps
 from pathlib import Path
+from typing import NamedTuple
 
 
 from .cce import _get_runtime_cce
@@ -5682,7 +5683,7 @@ def _trim_gemma4_audio_batch_mask(inputs, clips, processor):
         # against a neighbour and its mask already covers only its own audio.
         return inputs
     trimmed = np.zeros(shape, dtype=bool)
-    default_rate = _audio_extractor_sampling_rate(processor)
+    default_rate = audio_extractor_sampling_rate(processor)
     for row, clip in enumerate(clips[:shape[0]]):
         waveform, rate = clip if isinstance(clip, tuple) else (clip, None)
         solo = _gemma4_audio_frame_mask(
@@ -5808,7 +5809,7 @@ def _check_audio_family_gate(processor):
     )
 
 
-def _audio_extractor_sampling_rate(processor):
+def audio_extractor_sampling_rate(processor):
     """The sampling rate this processor's audio feature extractor expects."""
     for holder in (
         getattr(processor, "feature_extractor", None),
@@ -5823,6 +5824,184 @@ def _audio_extractor_sampling_rate(processor):
             except (TypeError, ValueError):
                 continue
     return None
+
+
+class AudioInputCapability(NamedTuple):
+    """Whether a loaded checkpoint can take audio input.
+
+    ``processor_ok`` and ``model_ok`` are the two halves, each ``True``,
+    ``False``, or ``None`` when it was not evaluated. ``capable`` requires both
+    to be ``True``, so a call without a model can refute a checkpoint but never
+    affirm one. ``reason`` names what was observed.
+    """
+
+    capable: bool
+    reason: str
+    processor_ok: "bool | None"
+    model_ok: "bool | None"
+
+
+# Two pitches two octaves apart, long enough for any pinned extractor's
+# framing and short enough that four calls cost a moment.
+_AUDIO_PROBE_TONES = (440.0, 1760.0)
+_AUDIO_PROBE_SECONDS = 0.2
+_AUDIO_PROBE_RATE = 16000
+# Marker-free by contract: which marker a processor needs is prompt-rendering
+# knowledge, so callers supply their own candidates through `texts`.
+_AUDIO_PROBE_TEXT = "Describe the audio."
+
+
+def _audio_probe_tone(rate, hertz):
+    """A fresh mono tone. Fresh matters: a processor keying on buffer identity
+    rather than sample values must not see the same object twice."""
+    count = max(int(rate * _AUDIO_PROBE_SECONDS), 1)
+    time = np.arange(count, dtype=np.float32) / float(rate)
+    return (0.25 * np.sin(2.0 * np.pi * hertz * time)).astype(np.float32)
+
+
+def _audio_probe_fingerprint(value):
+    """A content fingerprint of a processor's output.
+
+    Arrays enter by their bytes, so a field that echoes the call rather than the
+    audio compares equal and cannot be mistaken for evidence.
+    """
+    if isinstance(value, Mapping):
+        return tuple(
+            (str(key), _audio_probe_fingerprint(value[key]))
+            for key in sorted(value, key=str)
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_audio_probe_fingerprint(item) for item in value)
+    if type(value) is _MX_ARRAY_TYPE:
+        try:
+            value = np.asarray(value)
+        except Exception:
+            # Only the dtypes numpy has no equivalent for, where float32 is
+            # lossless. Casting everything would collapse large exact integers.
+            value = np.asarray(value.astype(mx.float32))
+    if isinstance(value, np.ndarray):
+        if value.dtype == object:
+            return ("object_array", value.shape, repr(value.tolist()))
+        return ("array", value.shape, str(value.dtype), value.tobytes())
+    if hasattr(value, "detach") and hasattr(value, "cpu"):
+        return _audio_probe_fingerprint(np.asarray(value.detach().cpu()))
+    return ("scalar", repr(value))
+
+
+def _audio_probe_once(processor, text, kwarg, rate, hertz, held):
+    """One real processor call on a freshly built tone."""
+    clip = _AudioClip(_audio_probe_tone(rate, hertz), rate)
+    # Held for the probe's lifetime so no later buffer can reuse its address.
+    held.append(clip)
+    payload = _format_vlm_audio_for_processor([[clip]], processor=processor)
+    return processor(text=[text], **{kwarg: payload})
+
+
+def _audio_probe_processor(processor, texts):
+    """Whether audio content demonstrably reaches this processor's output.
+
+    Per candidate text: a discarded warm-up call absorbs one-time state, then
+    the same tone twice -- which must agree, or the processor cannot repeat
+    itself and its outputs carry no evidence -- then a second tone, which must
+    differ. Both tones share duration, dtype and construction, so sample values
+    are the only input property that separates them: a processor that sizes its
+    output from the clip length, echoes the call, or drops the audio entirely
+    produces identical outputs and is refused.
+    """
+    try:
+        kwarg = _vlm_processor_audio_kwarg(processor)
+    except Exception:
+        return False, "the processor accepts no audio argument"
+    rate = audio_extractor_sampling_rate(processor) or _AUDIO_PROBE_RATE
+    held = []
+    raised = None
+    for text in texts:
+        try:
+            _audio_probe_once(processor, text, kwarg, rate,
+                              _AUDIO_PROBE_TONES[0], held)
+        except Exception:
+            pass  # a warm-up is discarded on any outcome, by design
+        try:
+            first = _audio_probe_fingerprint(
+                _audio_probe_once(processor, text, kwarg, rate,
+                                  _AUDIO_PROBE_TONES[0], held))
+            again = _audio_probe_fingerprint(
+                _audio_probe_once(processor, text, kwarg, rate,
+                                  _AUDIO_PROBE_TONES[0], held))
+            other = _audio_probe_fingerprint(
+                _audio_probe_once(processor, text, kwarg, rate,
+                                  _AUDIO_PROBE_TONES[1], held))
+        except Exception as exc:
+            raised = exc
+            continue
+        if first != again:
+            raised = None
+            continue  # not repeatable: its outputs prove nothing either way
+        if first != other:
+            return True, "audio content changed the processor output"
+    if raised is not None:
+        return False, f"the processor raised on audio ({type(raised).__name__})"
+    return False, (
+        "the processor accepted audio and produced no audio-dependent output"
+    )
+
+
+def _model_carries_audio_modules(model):
+    """Whether the loaded model has audio machinery, by name.
+
+    A name walk rather than a fixed attribute list: the pinned families spell it
+    ``audio_tower``, ``embed_audio``, ``audio_projection_layer``,
+    ``audio_encoder`` and ``audio_projection``, and Phi-4 nests its pair under
+    an intermediate submodule.
+    """
+    walk = getattr(model, "named_modules", None)
+    if walk is None:
+        return False
+    for entry in walk():
+        name = entry[0] if isinstance(entry, tuple) else entry
+        if "audio" in str(name).lower():
+            return True
+    return False
+
+
+def audio_input_capability(model, processor, texts=None):
+    """Whether this loaded checkpoint can take audio input.
+
+    Answered from observed behaviour, per checkpoint: audio content has to
+    change what the processor returns, and the model has to carry audio
+    modules. Two exports of one family can therefore disagree -- a processor
+    whose checkpoint omits the audio half of its preprocessor configuration
+    accepts the argument, drops the audio, and is refused here.
+
+    ``texts`` supplies candidate prompts, as one string or a sequence; a
+    processor that needs a marker only its own template emits will not answer
+    positively without one, and which marker that is belongs to whoever renders
+    prompts, not here. The built-in candidate carries none.
+
+    Never raises: anything unevaluable answers not capable, so this cannot fail
+    a model load. A positive says audio reaches the processor's output and the
+    model has somewhere to put it -- not that features merge correctly, which
+    the per-batch checks continue to guard.
+    """
+    processor_ok = model_ok = None
+    try:
+        if isinstance(texts, str):
+            texts = [texts]
+        candidates = [*(texts or ()), _AUDIO_PROBE_TEXT]
+        processor_ok, reason = _audio_probe_processor(processor, candidates)
+        if model is None:
+            return AudioInputCapability(False, reason, processor_ok, None)
+        model_ok = _model_carries_audio_modules(model)
+        if not model_ok:
+            reason = "the model carries no audio modules"
+        return AudioInputCapability(
+            bool(processor_ok and model_ok), reason, processor_ok, model_ok,
+        )
+    except BaseException as exc:  # totality: a load must never fail on this
+        return AudioInputCapability(
+            False, f"the capability check could not run ({type(exc).__name__})",
+            processor_ok, model_ok,
+        )
 
 
 class _AudioClip(np.ndarray):
@@ -6037,7 +6216,7 @@ def _extract_vlm_audio(item, messages, processor):
         return []
 
     _check_audio_family_gate(processor)
-    expected_rate = _audio_extractor_sampling_rate(processor)
+    expected_rate = audio_extractor_sampling_rate(processor)
     return [_normalize_audio_clip(clip, expected_rate) for clip in clips]
 
 
@@ -6078,8 +6257,12 @@ def _assert_audio_features_present(inputs, expected, processor):
         return
     raise ValueError(
         f"Unsloth MLX: {type(processor).__name__} returned no audio features "
-        f"for a batch containing audio, so the placeholders would have nothing "
-        f"behind them. Check that this processor has an audio feature extractor."
+        f"for a batch whose text carries audio placeholders, so those "
+        f"placeholders have nothing behind them. The cause is upstream of this "
+        f"check -- for instance the checkpoint ships no audio feature extractor "
+        f"(look for an audio section in its preprocessor configuration), or a "
+        f"placeholder was rendered for a clip the processor never received. "
+        f"Otherwise train on the text and image parts of this dataset."
     )
 
 
@@ -6294,7 +6477,7 @@ def _assert_audio_clips_fit_the_extractor(clips, processor):
     window = _extractor_window_samples(processor)
     if not window or not clips:
         return
-    rate = _audio_extractor_sampling_rate(processor)
+    rate = audio_extractor_sampling_rate(processor)
     for index, row in enumerate(clips):
         for clip in row or ():
             length = int(np.asarray(clip).shape[0])
@@ -6885,7 +7068,7 @@ def _processor_vlm_inputs(
             raise
         # Some take (samples, rate) pairs, which surfaces as an unpacking
         # error. The rate rides on the clip: such processors expose none.
-        default_rate = _audio_extractor_sampling_rate(processor)
+        default_rate = audio_extractor_sampling_rate(processor)
         base_kwargs[audio_kwarg] = [
             (np.asarray(clip), getattr(clip, "sampling_rate", None) or default_rate)
             for clip in audio

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3035,7 +3035,9 @@ def _prepare_vlm_batch_for_compile(batch_dict, config, phase=None):
     if images_spatial_crop is not None:
         batch_dict["images_spatial_crop"] = images_spatial_crop
     if audio_embed_sizes is not None:
-        batch_dict["audio_embed_sizes"] = audio_embed_sizes
+        # The model calls .item() on each entry, so hand over an array; the
+        # tuple above is only for this function's span arithmetic.
+        batch_dict["audio_embed_sizes"] = mx.array(list(audio_embed_sizes))
 
     if model_type == "multi_modality":
         input_ids = batch_dict.get("input_ids")
@@ -5470,20 +5472,19 @@ _AUDIO_SOFT_TOKEN_STRINGS = (
     "<|endoftext11|>",
 )
 
-# Model families whose audio training contract has been verified, mapped to the
-# exact mlx-vlm versions whose probe suite passed. Audio rows for a family or an
-# installed version outside this table are refused rather than trained on: the
-# per-family merge contracts differ (variable-length token budgets versus a fixed
-# budget with learned padding embeddings), and mlx-vlm has changed audio
-# preprocessing within its supported span, so an unprobed combination cannot be
-# assumed correct. Entries are added only alongside verified merge contracts.
-#
-# gemma3n merges a fixed 188 positions per clip, which lets collation verify the
-# placeholder budget outright; its probes (forward, audio conditioning, ragged
-# collation, LoRA training smoke) pass on mlx-vlm 0.4.4.
+# Families and the exact mlx-vlm versions their audio path was validated on.
+# Anything else is refused: merge contracts differ per family and mlx-vlm has
+# changed audio preprocessing within its supported span.
 _AUDIO_QUALIFIED_FAMILIES: "dict[str, frozenset]" = {
     "gemma3n": frozenset({"0.4.4"}),
+    "gemma4": frozenset({"0.4.4"}),
+    "phi4mm": frozenset({"0.4.4"}),
 }
+
+# Families probed only on a newer transformers than this package pins, at the
+# version the probes ran on. Older releases expand their audio tokens
+# differently, so they are refused rather than assumed compatible.
+_AUDIO_MIN_TRANSFORMERS = {"gemma4": (5, 5)}
 
 _AUDIO_CAST_HINT = (
     "Cast the dataset column with "
@@ -5527,12 +5528,38 @@ def _installed_mlx_vlm_version():
             return ""
 
 
+def _check_audio_transformers_floor(family):
+    """Refuse a family probed only on a newer transformers than is installed."""
+    floor = _AUDIO_MIN_TRANSFORMERS.get(family)
+    if not floor:
+        return
+    try:
+        import transformers
+
+        version = transformers.__version__
+        parts = tuple(int(x) for x in version.split(".")[:2])
+    except Exception:
+        raise NotImplementedError(
+            f"Unsloth MLX: audio training for '{family}' requires transformers "
+            f"{floor[0]}.{floor[1]} or newer, and the installed version could "
+            f"not be determined."
+        ) from None
+    if parts < floor:
+        raise NotImplementedError(
+            f"Unsloth MLX: audio training for '{family}' was verified on "
+            f"transformers {floor[0]}.{floor[1]}, but {version} is installed; "
+            f"older releases handle its audio token expansion differently. "
+            f"Upgrade transformers to train on audio with this model."
+        )
+
+
 def _check_audio_family_gate(processor):
     """Refuse audio rows for families/versions without a verified contract."""
     family = _audio_family_from_processor(processor)
     probed = _AUDIO_QUALIFIED_FAMILIES.get(family)
     installed = _installed_mlx_vlm_version()
     if probed and installed in probed:
+        _check_audio_transformers_floor(family)
         return family
     if not _AUDIO_QUALIFIED_FAMILIES:
         raise NotImplementedError(
@@ -7424,6 +7451,152 @@ _AUDIO_TOWER_ATTRS = (
 )
 
 
+_AUDIO_MERGE_SENTINEL = "_unsloth_audio_merge_patched"
+_AUDIO_MERGE_HOLDERS = "_unsloth_audio_merge_holders"
+_AUDIO_MERGE_ORIGINAL = "_unsloth_audio_merge_original"
+
+# Families whose merge walks a flattened feature block with a running
+# placeholder count, so a padded row's tail is consumed by the next row. Gemma 3n
+# (fixed budget, merges its own padding) and Phi-4 (row by row) must not get it.
+_AUDIO_MERGE_PATCH_FAMILIES = frozenset({"gemma4"})
+
+
+def audio_merge_patch_needed(config):
+    """Whether this model family's audio merge must be corrected for training."""
+    return _config_get(config, "model_type") in _AUDIO_MERGE_PATCH_FAMILIES
+
+
+def _compact_audio_features(embeddings, padding_mask, placeholders_per_row):
+    """Concatenate every clip's valid audio embeddings, in clip order.
+
+    The upstream merge flattens the whole padded feature block and walks it with
+    a running count of placeholder positions, so a short clip's padding is
+    consumed by the placeholders that follow it. Feeding that walk only the
+    valid embeddings, in the order the clips appear, makes the count line up
+    again -- collation emits clips row by row, so clip order is row order.
+
+    The encoder yields one entry per clip while placeholders are counted per
+    text row, and a row may hold several clips or none. Clips are therefore
+    assigned to rows in order and each row must be satisfied exactly: a batch
+    whose totals happen to agree while individual rows do not is still
+    mispaired, and is rejected here rather than trained on.
+
+    ``padding_mask`` marks padded frames (the encoder's own polarity), so valid
+    positions are its complement.
+    """
+    selected = []
+    counts = []
+    for index in range(embeddings.shape[0]):
+        keep = ~np.asarray(padding_mask[index]).astype(bool)
+        counts.append(int(keep.sum()))
+        if counts[-1]:
+            selected.append(embeddings[index][mx.array(np.nonzero(keep)[0])])
+
+    clip = 0
+    for row, wanted in enumerate(int(n) for n in placeholders_per_row):
+        filled = 0
+        while filled < wanted and clip < len(counts):
+            filled += counts[clip]
+            clip += 1
+        if filled != wanted:
+            raise ValueError(
+                f"Unsloth MLX: row {row} has {wanted} audio placeholder(s) but "
+                f"its clips produced {filled} valid audio position(s). Audio "
+                f"and text cannot be paired for this row."
+            )
+    if clip != len(counts):
+        raise ValueError(
+            f"Unsloth MLX: this batch carries {len(counts)} audio clip(s) but "
+            f"only {clip} could be matched to placeholder runs."
+        )
+    if not selected:
+        return embeddings[:0].reshape(0, embeddings.shape[-1])
+    return mx.concatenate(selected, axis=0)
+
+
+def install_audio_merge_patch(model, audio_token_id):
+    """Correct a model's audio merge for the duration of training.
+
+    Bound on the instance rather than the class, so a patch cannot leak into
+    inference on other models of the same type. Installs are counted: two
+    trainers sharing one model both hold a reference, and the correction stays
+    until the last of them releases it. Returns True when a hold was taken, so
+    every caller that gets True must release exactly once.
+    """
+    holders = getattr(model, _AUDIO_MERGE_HOLDERS, 0)
+    if holders:
+        # Another run holds it: take a hold so it outlives whoever finishes first.
+        setattr(model, _AUDIO_MERGE_HOLDERS, holders + 1)
+        return True
+    original = model.get_input_embeddings
+    had_instance_attr = "get_input_embeddings" in vars(model)
+    audio_keys = ("input_features", "input_features_mask",
+                  "audio_features", "audio_mask")
+
+    def patched(input_ids=None, pixel_values=None, **kwargs):
+        features = kwargs.get("input_features", kwargs.get("audio_features"))
+        valid = kwargs.get("input_features_mask")
+        if features is None or valid is None:
+            return original(input_ids=input_ids, pixel_values=pixel_values, **kwargs)
+        # Model builds text and vision embeddings; audio is merged here.
+        rest = {k: v for k, v in kwargs.items() if k not in audio_keys}
+        result = original(input_ids=input_ids, pixel_values=pixel_values, **rest)
+        embeds = getattr(result, "inputs_embeds", result)
+        encoded, padding = model.audio_tower(features, ~valid)
+        audio_embeds = model.embed_audio(encoded)
+        placeholders = np.asarray(input_ids == audio_token_id).sum(axis=1)
+        source = _compact_audio_features(audio_embeds, padding, placeholders)
+        # Without this cast the merge widens the whole LM input to float32.
+        source = source.astype(embeds.dtype)
+        mask = mx.broadcast_to(
+            mx.expand_dims(input_ids == audio_token_id, -1), embeds.shape,
+        )
+        merged = _masked_scatter_rowwise(embeds, mask, source)
+        if hasattr(result, "inputs_embeds"):
+            result.inputs_embeds = merged
+            return result
+        return merged
+
+    model.get_input_embeddings = patched
+    setattr(model, _AUDIO_MERGE_SENTINEL, True)
+    setattr(model, _AUDIO_MERGE_HOLDERS, 1)
+    # Put back exactly what was there: deleting would discard someone else's
+    # instance-level wrapper.
+    setattr(model, _AUDIO_MERGE_ORIGINAL, original if had_instance_attr else None)
+    return True
+
+
+def remove_audio_merge_patch(model):
+    """Release one hold on the corrected merge, restoring it at the last."""
+    holders = getattr(model, _AUDIO_MERGE_HOLDERS, 0)
+    if holders <= 0:
+        return False
+    if holders > 1:
+        setattr(model, _AUDIO_MERGE_HOLDERS, holders - 1)
+        return False
+    previous = getattr(model, _AUDIO_MERGE_ORIGINAL, None)
+    if previous is not None:
+        model.get_input_embeddings = previous
+    else:
+        try:
+            del model.get_input_embeddings
+        except AttributeError:
+            pass
+    setattr(model, _AUDIO_MERGE_SENTINEL, False)
+    setattr(model, _AUDIO_MERGE_HOLDERS, 0)
+    setattr(model, _AUDIO_MERGE_ORIGINAL, None)
+    return True
+
+
+def _masked_scatter_rowwise(embeds, mask, source):
+    """Place ``source`` rows at the masked positions, in order."""
+    flat_mask = mask.flatten().astype(mx.int32)
+    indices = mx.cumsum(flat_mask) - 1
+    flat_source = source.flatten()
+    aligned = flat_source[mx.clip(indices, 0, flat_source.size - 1)]
+    return mx.where(flat_mask, aligned, embeds.flatten()).reshape(embeds.shape)
+
+
 def freeze_audio_modules(model):
     """Freeze the audio tower and its projection.
 
@@ -8208,6 +8381,23 @@ class FiniteVLMBatchPlan(_FiniteVisitMixin):
         eager before surveying anything."""
         tokenizer = getattr(self._processor, "tokenizer", self._processor)
         return getattr(tokenizer, "pad_token_id", None)
+
+    def carries_audio_hint(self):
+        """Whether this plan carries audio, without forcing a full survey.
+
+        Uses the survey when one has run, else builds a single batch. Callers
+        that must materialize nothing should survey and ask ``carries_audio``.
+        """
+        if self._audio_flags is not None:
+            return any(self._audio_flags)
+        if not len(self._schedule):
+            return False
+        with _preserved_preprocessing_rng():
+            batch = self._build_batch(0)
+        try:
+            return _vlm_batch_carries_audio(batch)
+        finally:
+            del batch
 
     def carries_audio(self):
         """Whether any surveyed batch carries audio feature tensors."""

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1624,6 +1624,11 @@ def _get_vlm_ignore_token_ids(processor=None, config=None, model=None):
             "audio_token",
             "boi_token",
             "eoi_token",
+            # Gemma 4 wraps every audio run in these, the way boi/eoi wrap an
+            # image run: processing_gemma4.py builds boa_token + placeholders +
+            # eoa_token per clip.
+            "boa_token",
+            "eoa_token",
         ):
             token = getattr(tokenizer, attr, None)
             if token is not None:
@@ -1637,6 +1642,8 @@ def _get_vlm_ignore_token_ids(processor=None, config=None, model=None):
             # is, so they are no more a target than the run itself.
             "audio_start_id",
             "audio_end_id",
+            "boa_token_id",
+            "eoa_token_id",
         ):
             _append_unique_int(ids, getattr(tokenizer, attr, None))
 
@@ -1651,6 +1658,11 @@ def _get_vlm_ignore_token_ids(processor=None, config=None, model=None):
         "boi_token_id",
         "eoi_token_index",
         "eoi_token_id",
+        # Gemma 4 declares its audio delimiters here (gemma4/config.py).
+        "boa_token_index",
+        "boa_token_id",
+        "eoa_token_index",
+        "eoa_token_id",
     ):
         _append_unique_int(ids, _config_get(config, key, None))
 
@@ -9224,6 +9236,22 @@ class FiniteVLMBatchPlan(_FiniteVisitMixin):
             return _vlm_batch_carries_audio(batch)
         finally:
             del batch
+
+    def carries_audio_in(self, indices):
+        """Whether any of the named surveyed batches carries audio.
+
+        The whole-plan answer counts batches the schedule drops, and audio
+        confined to that tail would route a run eagerly, or abort strict mode,
+        over a batch no compiled call reaches -- the same reason family
+        admission is restricted to the executed set.
+        """
+        flags = self._audio_flags
+        if flags is None:
+            raise RuntimeError(
+                "Unsloth MLX: VLM batch families have not been surveyed; "
+                "call ensure_descriptors() first."
+            )
+        return any(flags[index] for index in indices if 0 <= index < len(flags))
 
     def carries_audio(self):
         """Whether any surveyed batch carries audio feature tensors."""

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -6173,6 +6173,14 @@ def _raw_row_has_audio(item):
     the data the user actually supplied. Shapes it cannot parse are reported as
     audio-free and left to the normal collation errors.
     """
+    if isinstance(item, list):
+        # A bare message list is a supported row shape -- _collate_vlm_batch
+        # normalizes one -- so it has to be scanned here too, or a formatter
+        # that drops its clips leaves the gate nothing to refuse.
+        try:
+            return any(_vlm_audio_part_state(_normalize_vlm_messages(item)))
+        except Exception:
+            return False
     if not isinstance(item, dict):
         return False
     for key in ("audio", "audios"):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -3796,7 +3796,12 @@ def _normalize_mlx_messages(messages, *, is_vlm=False):
                                 clean["type"] = "text"
                             elif "image" in clean:
                                 clean["type"] = "image"
-                            elif "audio" in clean:
+                            elif any(alias in clean for alias in _AUDIO_PART_TYPES):
+                                # Every spelling an audio part accepts, typed
+                                # as "audio": an untyped alias otherwise
+                                # reaches neither the family gate nor the
+                                # extractor, and Gemma's templates render a
+                                # placeholder for "audio" alone.
                                 clean["type"] = "audio"
                         parts.append(clean)
                 msg["content"] = parts
@@ -6510,9 +6515,9 @@ def _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
     ``max_seq_length`` (some processors divert the truncation arguments to their
     audio feature extractor and leave the text over the cap).
 
-    A run that was *shortened* rather than dropped cannot be detected here: that
-    needs the family's post-subsampling token budget, which only the model-side
-    merge knows, so the merge is where the exact count is checked.
+    A run that was *shortened* rather than dropped needs the family's
+    post-subsampling token budget. Families that state a fixed count per clip
+    before the model runs have each of their runs checked against it here.
 
     Processors that state their spans take a different route, since their run
     carries no identifying token. Those rows are held to the conditions in
@@ -6598,19 +6603,23 @@ def _assert_audio_runs_intact_ids(ids, attention_mask, audio_counts, soft_ids,
             else np.ones(row.shape, dtype=bool)
         )
         is_soft = np.isin(row, soft_array) & valid
-        starts = int(np.sum(is_soft & ~np.concatenate(([False], is_soft[:-1]))))
+        begins = is_soft & ~np.concatenate(([False], is_soft[:-1]))
+        starts = int(begins.sum())
         total_runs += starts
         if expected_clips and budget:
-            # Fixed-budget families merge exactly `budget` per clip, so this is
-            # what catches a run shortened rather than dropped.
-            placeholders = int(is_soft.sum())
-            if placeholders != budget * expected_clips:
+            # Fixed-budget families merge exactly `budget` per clip, so every
+            # run must be that long. Checking the total instead lets a short
+            # run hide behind a long one and pairs a clip with the wrong
+            # positions.
+            ends = is_soft & ~np.concatenate((is_soft[1:], [False]))
+            lengths = (np.flatnonzero(ends) - np.flatnonzero(begins) + 1).tolist()
+            if any(int(length) != budget for length in lengths):
                 raise ValueError(
-                    f"Unsloth MLX: row {index} has {placeholders} audio "
-                    f"placeholder tokens but this model merges {budget} per "
-                    f"clip and the row carries {expected_clips} clip(s). The "
-                    f"row cannot be aligned; shorten it or raise "
-                    f"max_seq_length."
+                    f"Unsloth MLX: row {index} has audio placeholder run(s) of "
+                    f"length {[int(length) for length in lengths]} but this "
+                    f"model merges {budget} per clip, so its audio cannot be "
+                    f"aligned. Check whether the row was truncated, or whether "
+                    f"its rendered text carries placeholder tokens of its own."
                 )
         if expected_clips and starts != expected_clips:
             raise ValueError(

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2318,6 +2318,27 @@ def _config_to_mapping(config):
     }
 
 
+def _phi4mm_token_ids(config):
+    """Phi-4-multimodal's image and audio token ids.
+
+    Its checkpoint config.json declares neither; mlx-vlm supplies both as
+    dataclass defaults. Training threads the checkpoint mapping rather than the
+    model's config object, so read the defaults off the dataclass instead of
+    restating them here.
+    """
+    image_id = _config_get(config, "image_token_index")
+    audio_id = _config_get(config, "audio_token_index")
+    if image_id is None or audio_id is None:
+        from mlx_vlm.models.phi4mm.config import ModelConfig as _Phi4MMConfig
+
+        fields = _Phi4MMConfig.__dataclass_fields__
+        if image_id is None:
+            image_id = fields["image_token_index"].default
+        if audio_id is None:
+            audio_id = fields["audio_token_index"].default
+    return int(image_id), int(audio_id)
+
+
 def _normalize_grid_thw(grid_thw):
     if grid_thw is None:
         return None
@@ -3116,8 +3137,7 @@ def _prepare_vlm_batch_for_compile(batch_dict, config, phase=None):
         pixel_attention_mask = batch_dict.get("pixel_attention_mask")
         if input_ids is not None:
             input_ids_np = np.asarray(input_ids)
-            image_token_id = int(_config_get(config, "image_token_index"))
-            audio_token_id = int(_config_get(config, "audio_token_index"))
+            image_token_id, audio_token_id = _phi4mm_token_ids(config)
             batch_dict["image_token_positions"] = tuple(
                 tuple(
                     int(pos)
@@ -3153,8 +3173,7 @@ def _prepare_vlm_batch_for_compile(batch_dict, config, phase=None):
             replacements = []
             image_idx = 0
             audio_idx = 0
-            image_token_id = int(_config_get(config, "image_token_index"))
-            audio_token_id = int(_config_get(config, "audio_token_index"))
+            image_token_id, audio_token_id = _phi4mm_token_ids(config)
             for batch_idx, row in enumerate(input_ids_np):
                 batch_replacements = []
                 for pos in image_positions[batch_idx]:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -616,6 +616,43 @@ class _SharedKVSlot:
         return self.keys, self.values
 
 
+# Language models that scale token embeddings by sqrt(hidden_size) on the ids
+# path only, so every multimodal forward loses it. gemma3 is absent because
+# `_run_hidden_stack`, the route it takes, already compensates.
+_VLM_EMBED_SCALE_FAMILIES = frozenset({"gemma3n_text"})
+
+
+def _vlm_embed_scale(model):
+    """The embedding scale this family's LM applies only on the ids path."""
+    config = getattr(getattr(_get_text_model(model), "model", None), "config", None)
+    if _config_get(config, "model_type") not in _VLM_EMBED_SCALE_FAMILIES:
+        return None
+    hidden_size = _config_get(config, "hidden_size")
+    return float(hidden_size) ** 0.5 if hidden_size else None
+
+
+def _apply_vlm_embed_scale(model, input_ids, merged_embeds):
+    """Scale the token embeddings a multimodal merge left unscaled.
+
+    Only positions still holding a plain token embedding: merged features
+    already carry the scaled magnitude. Found by difference, not by token id --
+    gemma3n's closing audio delimiter carries a feature without being the audio
+    token, and an id-based mask would rescale it.
+    """
+    scale = _vlm_embed_scale(model)
+    if scale is None or input_ids is None:
+        return merged_embeds
+    backbone = getattr(_get_text_model(model), "model", None)
+    embed_tokens = getattr(backbone, "embed_tokens", None)
+    if embed_tokens is None:
+        return merged_embeds
+    raw = embed_tokens(input_ids).astype(merged_embeds.dtype)
+    untouched = mx.all(merged_embeds == raw, axis=-1, keepdims=True)
+    # In the embedding dtype, as the ids path does: an fp32 product rounded back
+    # lands on different bf16 values.
+    return mx.where(untouched, merged_embeds * scale, merged_embeds)
+
+
 def _shared_kv_slot_count(model):
     """How many cache slots this stack needs, or 0 when it shares no K/V.
 
@@ -2162,6 +2199,7 @@ def _vlm_cce_forward(model, batch_dict, image_token_ids=None,
         **extra_kwargs,
     )
     merged_embeds, backbone_kwargs = _unpack_embed_result(embed_result, model)
+    merged_embeds = _apply_vlm_embed_scale(model, inputs, merged_embeds)
     # Prefer collator-built mRoPE IDs when present. Qwen/GLM collators build
     # CUDA-parity full-sequence positions; recomputing inside the embedder moved
     # Qwen3-VL first-step loss from ~6.45 to ~6.90 on the real-cat fixture.

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -2095,6 +2095,7 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
         # embeddings ~45x too small beside merged features. `_vlm_cce_forward`
         # already merges and rescales itself; do the same here so
         # use_cce={True,False} stay in parity instead of differing by that.
+        scaled_embeds = None
         if _vlm_embed_scale(model) is not None:
             embed_result = model.get_input_embeddings(
                 inputs,
@@ -2104,14 +2105,23 @@ def make_vlm_baseline_loss_fn(model=None, assistant_token_id=0,
                    if k not in ("mask", "cache")},
             )
             merged_embeds, embed_kwargs = _unpack_embed_result(embed_result, model)
-            fwd_kwargs["inputs_embeds"] = _apply_vlm_embed_scale(
-                model, inputs, merged_embeds,
-            )
+            scaled_embeds = _apply_vlm_embed_scale(model, inputs, merged_embeds)
             # per_layer_inputs and friends: the merge produced them, and
             # recomputing from ids inside the stack would redo the work.
             for key, value in embed_kwargs.items():
                 fwd_kwargs.setdefault(key, value)
-        output = model(inputs, pixel_values=pixel_values, **fwd_kwargs)
+        if scaled_embeds is not None:
+            # Not `model(...)`: mlx-vlm up to 0.4.4 -- the floor this package
+            # declares -- re-embeds from ids inside `Model.__call__` and drops
+            # a supplied `inputs_embeds`, so the rescale above would be thrown
+            # away on exactly the versions that need it. 0.5.0 onwards honors
+            # it by forwarding straight to the language model; do that here on
+            # every version, which is what `_vlm_cce_forward` already does.
+            output = _get_text_model(model)(
+                inputs, inputs_embeds=scaled_embeds, **fwd_kwargs
+            )
+        else:
+            output = model(inputs, pixel_values=pixel_values, **fwd_kwargs)
         logits = output.logits if hasattr(output, "logits") else output
         logits = logits.astype(mx.float32)
         # Drop the final position so logits predict the next token.
@@ -6215,6 +6225,16 @@ def _raw_row_has_audio(item):
             return False
     if not isinstance(item, dict):
         return False
+    if "role" in item and "content" in item:
+        # A single message is a supported row shape too -- `_normalize_mlx_
+        # messages` wraps one as `[item]`. Scanned here because the lookups
+        # below read a row, and `_select_vlm_messages_or_raw` hands such a row
+        # straight back, where the identity guard drops it unscanned.
+        try:
+            if any(_vlm_audio_part_state(_normalize_vlm_messages(item))):
+                return True
+        except Exception:
+            return False
     for key in ("audio", "audios"):
         value = item.get(key)
         if value is not None and (not isinstance(value, list) or value):

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -1632,6 +1632,10 @@ def _get_vlm_ignore_token_ids(processor=None, config=None, model=None):
             "image_token_id",
             "video_token_id",
             "audio_token_id",
+            # Delimiters around a media run are generated the same way the run
+            # is, so they are no more a target than the run itself.
+            "audio_start_id",
+            "audio_end_id",
         ):
             _append_unique_int(ids, getattr(tokenizer, attr, None))
 
@@ -1751,6 +1755,9 @@ def _stage_vlm_label_mask_np(inputs, ignore_token_ids=None, labels=None):
         if np.issubdtype(values.dtype, np.floating):
             compare = compare.astype(values.dtype)  # mirror mx scalar narrowing
         mask = mask | np.isin(values, compare)
+    spans = _audio_span_positions_np(inputs, mask.shape)
+    if spans is not None:
+        mask = mask | spans
     attention = inputs.get("attention_mask")
     if attention is not None:
         attention_np = (
@@ -1932,6 +1939,12 @@ def _apply_vlm_label_masks(batch_dict, labels=None, ignore_token_ids=None,
         labels = batch_dict.get(_RAW_INPUT_IDS_FOR_LABELS, batch_dict["input_ids"])
     labels = _normalize_cce_label_dtype(labels)
     labels = _mask_label_token_ids(labels, ignore_token_ids, ignore_index)
+    spans = _audio_span_positions_np(batch_dict, labels.shape)
+    if spans is not None:
+        # This path decides labels for processor output the host staging could
+        # not claim, so it owns the span masking too.
+        labels = mx.where(mx.array(spans),
+                          mx.array(ignore_index, dtype=labels.dtype), labels)
     attention_mask = batch_dict.get("attention_mask")
     if attention_mask is not None:
         ignore = mx.array(ignore_index, dtype=labels.dtype)
@@ -5498,6 +5511,7 @@ _AUDIO_QUALIFIED_FAMILIES: "dict[str, frozenset]" = {
     "gemma3n": frozenset({"0.4.4"}),
     "gemma4": frozenset({"0.4.4"}),
     "phi4mm": frozenset({"0.4.4"}),
+    "minicpmo": frozenset({"0.4.4"}),
 }
 
 # Families probed only on a newer transformers than this package pins, at the
@@ -6028,7 +6042,9 @@ def _extract_vlm_audio(item, messages, processor):
 
 
 # Payload keys only: masks and size vectors can survive a dropped payload.
-_AUDIO_FEATURE_PAYLOAD_KEYS = ("input_features", "input_audio_embeds")
+_AUDIO_FEATURE_PAYLOAD_KEYS = (
+    "input_features", "input_audio_embeds", "audio_features",
+)
 
 
 def _assert_audio_features_present(inputs, expected, processor):
@@ -6067,8 +6083,234 @@ def _assert_audio_features_present(inputs, expected, processor):
     )
 
 
+def _audio_bounds_per_row(inputs):
+    """Per-row ``(start, end)`` audio spans, when the processor states them.
+
+    Counting runs of a soft token only verifies alignment when that token means
+    "audio". MiniCPM-o repeats ``<unk>`` between its delimiters, which a real
+    unknown word in the transcript is indistinguishable from, so its runs carry
+    no alignment evidence at all. Processors in that shape report the spans
+    themselves, which is a better starting point than counting runs, though not
+    a trustworthy one: see ``_assert_audio_bounds_intact`` for how a reported
+    span can still be wrong.
+    """
+    bounds = inputs.get("audio_bounds") if isinstance(inputs, Mapping) else None
+    if bounds is None:
+        return None
+    rows = []
+    for row in bounds:
+        spans = np.asarray(row).reshape(-1, 2) if np.size(row) else np.empty((0, 2))
+        rows.append([(int(start), int(end)) for start, end in spans])
+    return rows
+
+
+def _audio_span_positions_np(inputs, shape):
+    """Positions covered by stated audio spans, or None when there are none.
+
+    These hold placeholder tokens, never text to predict, and they cannot be
+    found by token id: the marker is not always an audio-specific token --
+    MiniCPM-o repeats ``<unk>`` -- so an id-based rule either misses the run or
+    masks real unknown words along with it.
+    """
+    bounds = _audio_bounds_per_row(inputs)
+    if not bounds or len(shape) != 2:
+        return None
+    rows, width = int(shape[0]), int(shape[1])
+    positions = np.zeros((rows, width), dtype=bool)
+    # Every caller runs after the collation check, which has already refused
+    # spans that fall outside their row.
+    for row, spans in enumerate(bounds[:rows]):
+        for start, end in spans:
+            positions[row, int(start):int(end)] = True
+    return positions if positions.any() else None
+
+
+def _assert_audio_bounds_intact(rows, ids, attention_mask, audio_counts,
+                                max_seq_length, processor):
+    """Reject rows whose stated audio spans cannot be trusted.
+
+    Read off the processor's own spans: one span per clip, each covering at
+    least one position inside the row's real content so truncation cannot have
+    clipped it, and each naming a placeholder run rather than ordinary text --
+    one token repeated, the same token in every span of the batch.
+    """
+    ids_np = np.asarray(ids)
+    if ids_np.ndim == 1:
+        ids_np = ids_np.reshape(1, -1)
+    if ids_np.ndim != 2:
+        raise ValueError(
+            f"Unsloth MLX: cannot verify audio alignment against input_ids of "
+            f"shape {ids_np.shape}."
+        )
+    mask_np = None if attention_mask is None else np.asarray(attention_mask)
+    if mask_np is not None and mask_np.ndim == 1:
+        mask_np = mask_np.reshape(1, -1)
+    width = int(ids_np.shape[1])
+    if not (len(rows) == len(audio_counts) == int(ids_np.shape[0])):
+        raise ValueError(
+            f"Unsloth MLX: {type(processor).__name__} reported audio spans for "
+            f"{len(rows)} row(s) against {len(audio_counts)} dataset row(s) and "
+            f"{ids_np.shape[0]} tokenized row(s), so audio clips cannot be "
+            f"paired with their rows."
+        )
+    total = 0
+    marker = None
+    for index, (spans, expected) in enumerate(zip(rows, audio_counts)):
+        attended = (
+            width if mask_np is None
+            else int(mask_np[index].astype(bool).sum())
+        )
+        if max_seq_length and attended > int(max_seq_length):
+            # Padding is not the row's own length, so this counts what the model
+            # attends -- the same quantity the run check caps.
+            raise ValueError(
+                f"Unsloth MLX: row {index} is {attended} tokens but "
+                f"max_seq_length={max_seq_length}; this processor did not apply "
+                f"the truncation it was given, and some divert it to their audio "
+                f"feature extractor instead."
+            )
+        if len(spans) != expected:
+            raise ValueError(
+                f"Unsloth MLX: row {index} carries {expected} audio clip(s) but "
+                f"the processor reported {len(spans)} audio span(s). Every clip "
+                f"needs exactly one placeholder in the rendered text, none may "
+                f"be dropped by truncation, and no extra may be added."
+            )
+        for start, end in spans:
+            if end <= start:
+                raise ValueError(
+                    f"Unsloth MLX: row {index} has an audio span ({start}, "
+                    f"{end}) that does not run forwards, so its clip has no "
+                    f"positions to occupy."
+                )
+            if start < 0 or end > width:
+                raise ValueError(
+                    f"Unsloth MLX: row {index} has an audio span ({start}, "
+                    f"{end}) outside its {width} position(s), so the span names "
+                    f"tokens the row does not have."
+                )
+            # Attended positions, not their count: a left-padded row holds its
+            # content at the top of the range, so comparing against a total
+            # rejects spans that are perfectly placed.
+            if mask_np is not None and not mask_np[index][start:end].astype(bool).all():
+                raise ValueError(
+                    f"Unsloth MLX: row {index} has an audio span ({start}, "
+                    f"{end}) covering padding, so its clip is not aligned with "
+                    f"the tokens the model attends."
+                )
+            # These processors report spans by pairing the n-th opening
+            # delimiter with the n-th closing one, so a delimiter that the
+            # rendered text carries of its own shifts every later pair onto
+            # ordinary tokens. The span still counts, fits and attends, and only
+            # the run it names gives it away: a placeholder run is one token
+            # repeated, and the same token in every span.
+            run = np.unique(ids_np[index][start:end])
+            if run.size != 1 or (marker is not None and run[0] != marker):
+                raise ValueError(
+                    f"Unsloth MLX: row {index} has an audio span ({start}, "
+                    f"{end}) that does not name a placeholder run. The rendered "
+                    f"text most likely carries an audio delimiter of its own, "
+                    f"which shifts the positions the processor reports."
+                )
+            marker = run[0]
+        total += len(spans)
+    return total
+
+
+def _extractor_window_samples(processor):
+    extractor = getattr(processor, "audio_processor", None) or getattr(
+        processor, "feature_extractor", None
+    )
+    samples = getattr(extractor, "n_samples", None)
+    try:
+        return int(samples) if samples is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _audio_delimiter_strings(processor):
+    tokenizer = _get_processor_tokenizer(processor)
+    convert = getattr(tokenizer, "convert_ids_to_tokens", None)
+    if convert is None:
+        return ()
+    found = []
+    for attr in ("audio_start_id", "audio_end_id"):
+        token_id = getattr(tokenizer, attr, None)
+        if token_id is None:
+            continue
+        try:
+            token = convert(int(token_id))
+        except Exception:
+            continue
+        if isinstance(token, str) and token:
+            found.append(token)
+    return tuple(found)
+
+
+def _assert_text_carries_no_audio_delimiters(texts, clips, processor):
+    """Reject audio rows whose text already contains the run's delimiters.
+
+    A processor that reports spans finds them by pairing the n-th opening
+    delimiter with the n-th closing one, within a row. A delimiter the text
+    brought itself is indistinguishable from a generated one, so it shifts the
+    pairing onto ordinary tokens, and truncation can drop the generated span and
+    leave the foreign one standing in for it. Nothing downstream can tell the
+    two apart -- the foreign span attends, sits inside the content, holds a
+    repeated marker, and can be any length, including exactly the right one --
+    so the text is refused before the processor ever expands it. The pairing is
+    per row, so a row carrying no clip has no pairing to disturb.
+    """
+    delimiters = _audio_delimiter_strings(processor)
+    if not delimiters:
+        return
+    for index, (text, row) in enumerate(zip(texts or (), clips or ())):
+        if not row or not isinstance(text, str):
+            continue
+        for delimiter in delimiters:
+            if delimiter in text:
+                raise ValueError(
+                    f"Unsloth MLX: row {index} already contains {delimiter}, "
+                    f"which {type(processor).__name__} generates around the "
+                    f"audio it inserts and locates its clips by. Remove it and "
+                    f"mark the audio the way the model's template does."
+                )
+
+
+def _assert_audio_clips_fit_the_extractor(clips, processor):
+    """Reject clips the audio feature extractor would truncate.
+
+    These processors size the placeholder run from the whole waveform while
+    their extractor keeps a fixed window, so a longer clip asks for positions
+    whose audio the model never receives: the merge stops at the shorter side
+    and the tail keeps ordinary text embeddings, which no count, range or run
+    check can see.
+
+    Sizing the run from the waveform also leaves the count one or two above the
+    embeddings on ordinary clips, because the two round their framing
+    differently. That is upstream's own arithmetic, it happens with the whole
+    clip present, and inference merges the same way, so it is not what this
+    rejects -- only a clip whose audio is actually cut.
+    """
+    window = _extractor_window_samples(processor)
+    if not window or not clips:
+        return
+    rate = _audio_extractor_sampling_rate(processor)
+    for index, row in enumerate(clips):
+        for clip in row or ():
+            length = int(np.asarray(clip).shape[0])
+            if length <= window:
+                continue
+            seconds = f", {window / rate:.0f}s" if rate else ""
+            raise ValueError(
+                f"Unsloth MLX: row {index} carries a {length}-sample audio clip "
+                f"but {type(processor).__name__} keeps only the first {window} "
+                f"samples of one clip ({window}{seconds}), so the row asks for "
+                f"more audio positions than the model can fill. Split the clip."
+            )
+
+
 def _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
-                              truncated=True):
+                              truncated=True, clips=None):
     """Reject rows whose audio placeholder runs did not survive tokenization.
 
     The processor expands each clip into a run of soft tokens whose length the
@@ -6081,6 +6323,12 @@ def _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
     A run that was *shortened* rather than dropped cannot be detected here: that
     needs the family's post-subsampling token budget, which only the model-side
     merge knows, so the merge is where the exact count is checked.
+
+    Processors that state their spans take a different route, since their run
+    carries no identifying token. Those rows are held to the conditions in
+    ``_assert_audio_bounds_intact`` instead of the two above, and additionally
+    to one the run path has no equivalent of: a clip may not be longer than the
+    window its feature extractor keeps.
     """
     ids = inputs.get("input_ids") if isinstance(inputs, Mapping) else None
     if ids is None:
@@ -6090,6 +6338,17 @@ def _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
             "Unsloth MLX: the processor returned no input_ids for a batch "
             "containing audio, so audio/text alignment cannot be verified."
         )
+    bounds = _audio_bounds_per_row(inputs)
+    if bounds is not None:
+        # Stated spans beat inferred ones, so they are checked instead of the
+        # runs rather than alongside them.
+        total_runs = _assert_audio_bounds_intact(
+            bounds, ids, inputs.get("attention_mask"), audio_counts,
+            max_seq_length if truncated else None, processor,
+        )
+        _assert_audio_features_present(inputs, total_runs, processor)
+        _assert_audio_clips_fit_the_extractor(clips, processor)
+        return
     soft_ids = _get_vlm_audio_soft_token_ids(processor)
     if not soft_ids:
         if not any(audio_counts):
@@ -6187,10 +6446,21 @@ def _assert_audio_runs_intact_ids(ids, attention_mask, audio_counts, soft_ids,
     return total_runs
 
 
-def _format_vlm_audio_for_processor(all_audio):
-    """Flatten per-row clips into the flat list processors expect."""
-    if not all_audio:
+def _vlm_processor_prefers_nested_audio(processor):
+    cls = processor.__class__
+    marker = f"{getattr(cls, '__module__', '')}.{getattr(cls, '__name__', '')}".lower()
+    # A flat list leaves these processors to guess which row owns which clip:
+    # they count audio markers in the rendered text, which a chat template need
+    # not emit, and hand every clip to row 0 when the count comes up short.
+    return any(name in marker for name in ("minicpmo",))
+
+
+def _format_vlm_audio_for_processor(all_audio, processor=None):
+    """Group per-row clips the way this processor assigns them to rows."""
+    if not all_audio or not any(all_audio):
         return None
+    if processor is not None and _vlm_processor_prefers_nested_audio(processor):
+        return [list(clips) if clips else [] for clips in all_audio]
     flattened = []
     for clips in all_audio:
         if clips:
@@ -6278,9 +6548,20 @@ def _format_vlm_images_for_processor(all_images, processor=None, image_layout=No
 # model forward kwargs so the backbone never sees it.
 
 
+# One array per row, and rows hold different clip and image counts. Stacking
+# them raises, and the generic fallback below then keeps only the first row --
+# which the model indexes per row, so every later row reads row 0's coordinates
+# instead of its own. Converted row by row instead, so the ragged shape survives
+# and the batch still describes itself to the planner.
+_VLM_PER_ROW_MEDIA_KEYS = ("audio_bounds", "image_bound", "tgt_sizes")
+
+
 def _to_mx_vlm_batch(inputs):
     batch = {}
     for key, value in inputs.items():
+        if key in _VLM_PER_ROW_MEDIA_KEYS and isinstance(value, (list, tuple)):
+            batch[key] = [mx.array(np.asarray(row)) for row in value]
+            continue
         if isinstance(value, mx.array):
             batch[key] = value
         elif hasattr(value, "shape"):
@@ -6511,7 +6792,7 @@ def _processor_vlm_inputs(
         add_special_tokens=False,
     )
     base_kwargs = _drop_unsupported_processor_kwargs(processor, base_kwargs)
-    audio = _format_vlm_audio_for_processor(all_audio)
+    audio = _format_vlm_audio_for_processor(all_audio, processor=processor)
     audio_kwarg = None
     if audio is not None:
         audio_kwarg = _vlm_processor_audio_kwarg(processor)
@@ -6672,7 +6953,8 @@ def _right_pad_vlm_rows(inputs, processor):
         return inputs
     mask = _as_numpy_vlm_field(inputs, "attention_mask")
     # Content-then-padding, so an interior pad counts as much as a leading one.
-    if not mask.size or bool(np.all(mask[:, :-1] >= mask[:, 1:])):
+    moved = np.any(mask[:, :-1] < mask[:, 1:], axis=1)
+    if not moved.any():
         return inputs
     generated = [
         key for key in _VLM_WIDTH_GENERATED_KEYS if inputs.get(key) is not None
@@ -6683,6 +6965,25 @@ def _right_pad_vlm_rows(inputs, processor):
             f"Unsloth MLX: {type(processor).__name__} left-padded this batch "
             f"and supplied its own {', '.join(generated)}, which cannot be "
             f"re-derived for the repaired row order."
+        )
+    bounds = _audio_bounds_per_row(inputs) or ()
+    # Only the rows the repair actually moves lose their coordinates, so a row
+    # that is already content-first keeps valid spans however its neighbours are
+    # padded. Rows with no spans have nothing to invalidate.
+    stale = [
+        index for index, spans in enumerate(bounds)
+        if spans and index < moved.shape[0] and bool(moved[index])
+    ]
+    if stale:
+        # Stated spans are coordinates into the layout the repair replaces, and
+        # nothing re-derives them: they would keep naming pre-repair positions
+        # and put each clip's audio on whatever tokens moved there. Both ends of
+        # a stale span can still be attended, so no later check would catch it.
+        raise ValueError(
+            f"Unsloth MLX: {type(processor).__name__} did not put row(s) "
+            f"{stale} content-first despite being asked for right-padded rows, "
+            f"and reports their audio positions as spans, which name the layout "
+            f"the repair replaces."
         )
     ids = _as_numpy_vlm_field(inputs, "input_ids")
     extras = _vlm_token_aligned_sidecars(inputs, ids.shape)
@@ -6869,6 +7170,21 @@ def _collate_vlm_prompt_completion_batch(
     )
     # Untruncated halves: only run presence is checkable until the combine.
     audio_counts = [len(clips) for clips in all_audio]
+    if any(audio_counts) and _audio_bounds_per_row(prompt_inputs) is not None:
+        # A stated span is an absolute coordinate into the half it was measured
+        # on. The combine concatenates the halves and then flushes and truncates
+        # the joined rows, either of which can carry the prompt's tokens away
+        # from the positions its spans name and put the clip's audio on whatever
+        # lands there. Refused for the whole format rather than relocated, and
+        # for every row rather than the ones that would move: nothing here has
+        # verified a relocation, and this is not the format the family was
+        # qualified on.
+        raise NotImplementedError(
+            f"Unsloth MLX: {type(processor).__name__} reports audio positions as "
+            f"spans, which prompt/completion collation can move the tokens out "
+            f"from under. Use a single `text`/messages column for audio rows "
+            f"with this model."
+        )
     _assert_audio_runs_intact(
         prompt_inputs, audio_counts, processor, None, truncated=False,
     )
@@ -7078,6 +7394,8 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         all_audio.append(audio)
         all_suffixes.append(item.get("suffix") if isinstance(item, dict) else None)
 
+    if any(all_audio):
+        _assert_text_carries_no_audio_delimiters(all_texts, all_audio, processor)
     inputs = _right_pad_vlm_rows(
         _processor_vlm_inputs(
             processor, all_texts, all_images, max_seq_length,
@@ -7088,7 +7406,8 @@ def _collate_vlm_batch(items, processor, max_seq_length, image_size,
         processor,
     )
     audio_counts = [len(clips) for clips in all_audio]
-    _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length)
+    _assert_audio_runs_intact(inputs, audio_counts, processor, max_seq_length,
+                              clips=all_audio)
     if _vlm_inputs_host_valued(inputs) and _vlm_ids_integer_host(inputs):
         label_mask = _stage_vlm_label_mask_np(
             inputs, ignore_token_ids=ignore_token_ids,
@@ -7666,6 +7985,7 @@ def _audio_fixed_budget(processor, config=None):
 
 _AUDIO_TOWER_ATTRS = (
     "audio_tower", "embed_audio", "audio_encoder", "audio_projection",
+    "audio_projection_layer",
 )
 
 
@@ -7846,7 +8166,21 @@ def _vlm_batch_carries_audio(batch):
     """
     if not isinstance(batch, Mapping):
         return False
-    return any(batch.get(key) is not None for key in _AUDIO_FEATURE_PAYLOAD_KEYS)
+    for key in _AUDIO_FEATURE_PAYLOAD_KEYS:
+        value = batch.get(key)
+        if value is None:
+            continue
+        # An empty payload is how some processors report "no audio here":
+        # MiniCPM-o returns audio_features shaped (0, 80, 0) for a text-only
+        # batch, which must not route the run eagerly or abort a strict one.
+        shape = getattr(value, "shape", None)
+        if shape is not None:
+            if all(int(dim) for dim in shape):
+                return True
+            continue
+        if not hasattr(value, "__len__") or len(value):
+            return True
+    return False
 
 
 def _vlm_batch_family(batch, symbolic_axes=None):


### PR DESCRIPTION
Adds audio-input support to MLX VLM SFT, behind a per-family allow gate, and qualifies four families: Gemma 3n, Gemma 4, Phi-4-multimodal and MiniCPM-o. Before this, an audio column either crashed collation or trained against misaligned features; audio rows are now either collated correctly or refused with a message that names what is wrong.

## Stacked on #963

**This is stacked on #963 ("fix(mlx): VLM training correctness"), which is not merged yet.** GitHub's diff is against `main`, so it shows that PR's commits too. The reviewable change here is the 8 commits on top of #963's tip `40b3f5b8`:

```bash
git diff 40b3f5b8..HEAD          # 5 files, 3589 insertions, 62 deletions
```

| | vs #963 tip (this PR) | vs `main` (what GitHub shows) |
|---|---|---|
| files | 5 | 6 |
| insertions | **3589** | 4596 |
| deletions | 62 | 92 |

Please review against `40b3f5b8`. I will retarget this once #963 lands.

## What changed

- **Collation.** Audio clips are extracted from dataset rows, grouped the way each processor assigns them to rows, and passed to the processor with the truncation arguments it actually honours. Rows whose audio and text cannot be paired are refused rather than trained.
- **Alignment is verified, not assumed.** Families whose placeholder run carries an identifying token are checked by counting runs. Families that state spans instead (MiniCPM-o reports `audio_bounds`, and its run interior is `<unk>`, which a genuine unknown word is indistinguishable from) are checked against those spans: one span per clip, inside the row's attended content, and naming a real placeholder run rather than ordinary text.
- **Loss masking.** Audio placeholder positions and the delimiters around them are excluded from the loss. For a stated-span family this cannot be done by token id, so the spans themselves drive the mask; without it every audio position was a supervised target.
- **Model-side merge.** Gemma 4's merge walks a flattened feature block with a running placeholder count, so a padded row's tail is consumed by the next row. It is patched per row. Gemma 4's placeholder count is also derived from the installed feature extractor rather than `ceil(duration / 40 ms)`, which runs one over whenever a duration lands near a frame boundary — 3 of 10 real LibriSpeech utterances.
- **Audio towers stay frozen**, including the projection that follows them, so a full fine-tune cannot pull them into the optimizer.
- **The gate.** `_AUDIO_QUALIFIED_FAMILIES` admits a family only at the exact mlx-vlm version it was probed on; Gemma 4 additionally requires transformers 5.5, since older releases expand its audio tokens differently. An unqualified family is refused with the versions that were verified.

## Public API

`unsloth_zoo.mlx.utils` gains two public names, recorded here because a consumer branch adopts them:

- `audio_input_capability(model, processor, texts=None) -> AudioInputCapability` — whether a loaded checkpoint can take audio, answered from behaviour rather than configuration. Audio content has to change what the processor returns (the same tone twice must agree, a second tone must differ, both share duration and construction, every call gets a fresh buffer) and the model has to carry audio modules, found by walking the module tree for the name. Result carries `capable`, `reason`, `processor_ok`, `model_ok`. Never raises, so it cannot fail a model load; anything unevaluable answers negative. Candidate prompts are the caller's, via `texts` — which marker a processor needs is prompt-rendering knowledge and the built-in candidate carries none.
- `audio_extractor_sampling_rate(processor)` — the promoted former private helper.

Nothing in training consults it. An empty audio payload already fails the per-batch pairing check on the same batch in the same call, so that message now points upstream instead, naming a checkpoint without an audio feature extractor as one example rather than as a diagnosis the check cannot make.

Measured against every audio-capable checkpoint in the local cache — gemma-3n-E2B, gemma-4-E4B (through its transformers 5.5 routing), MiniCPM-o-4.5 and Phi-4-multimodal answer capable; Qwen3-0.6B, Qwen2.5-VL-3B and the Ferox Phi-4 export answer not-capable. Every verdict matches expectation.

## Validation

Each family: 30 steps of LoRA on real LibriSpeech utterances, gradient checkpointing and CCE enabled, `dataset_order="torch_randperm"`. All four run to completion with finite losses and gradients.

| family | transformers | LoRA | step 1 | step 30 | mean loss |
|---|---|---|---|---|---|
| gemma4 | 5.5.0 | 35 × `q_proj` | 3.1281 | 1.0487 | 2.5040 |
| gemma3n | 4.57.6 | 30 × `q_proj` | 4.2405 | 1.9014 | 3.4067 |
| phi4mm | 4.57.6 | 32 × `qkv_proj` | 11.2239 | 5.0805 | 7.8304 |
| minicpmo | 4.57.6 | 36 × `q_proj` | 4.9293 | 2.2900 | 3.7666 |

Phi-4-multimodal's absolute loss is high because chance is 12.21 nats for its ~200k vocabulary; 28 of its 30 steps are below that.

**Gemma 4 against CUDA.** Same checkpoint on both machines, verified by digest rather than downloaded twice, and the same fixture and row order. The CUDA side runs unsloth's own stack (`FastVisionModel` + `get_peft_model` + `use_gradient_checkpointing="unsloth"`) on an RTX 4070 SUPER, both sides in bf16, neither side's adapters pinned.

| | MLX | CUDA | |
|---|---|---|---|
| mean loss (30) | 2.4388 | 2.4394 | −0.02% |
| mean grad norm (30) | 2.1523 | 2.2211 | −3.10% |
| step-1 loss | 3.1366 | 3.0965 | +1.30% |

<img width="1999" height="734" alt="图片" src="https://github.com/user-attachments/assets/6c30cda0-87d7-4196-ab37-ce0391e83116" />


Both sides produce identical sequence lengths and identical supervised-token counts step for step, so the losses are computed over the same positions.

**One open question, stated plainly.** Step 1 is the only directly comparable point — `lora_B` starts at zero in both implementations, so the adapters contribute nothing and it is a pure forward-pass comparison of the same weights on the same tokens. The two differ by 1.30% (0.0401 nats), which is larger than bf16 accumulation-order differences alone produce. Quantization is not the cause (running MLX 4-bit instead moves it to +1.02%, the wrong direction), nor are differing supervised positions. The training trajectories agree closely, so this does not block the feature, but it is not yet explained. A text-only run of the same comparison would localise it to the audio path or to Gemma 4's forward generally.

## Known limits

- Prompt/completion collation is refused for stated-span families: the combine moves tokens the spans name, and nothing here has verified a relocation.
- With no literal audio marker in the rendered text, MiniCPM-o's processor places the run after the last user tag rather than where the audio part sat in the message. Row ownership is correct; intra-turn placement is not addressed.
- Clips longer than the feature extractor's window are refused rather than silently truncated.

## Test coverage

Tests are in `tests/test_mlx_vlm_label_masks.py`. Every added test was mutation-checked: reverting or weakening the production change it covers makes exactly that test fail. Test share of this PR's diff is 46%, which is above the usual bar; the audio path fails silently rather than loudly when alignment is wrong, so the coverage is deliberate.

