### PR TITLE
feat(mlx): pooling and contrastive-loss primitives for embedding training

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -103,7 +103,11 @@ jobs:
         # + cache-completeness gate (CPU-pure; collect-only would let it
         # regress silently). test_train_on_responses_list_labels pins the
         # tensor-vs-list labels contract for response masking (stub tokenizer,
-        # no weights). Executing them here keeps fixture/source drift visible.
+        # no weights). test_mlx_embedding_guards pins the sentence-transformers
+        # layout shim and pooling-mode map; it runs under the torch shim so it
+        # EXECUTES here rather than skipping (the numeric half needs real MLX and
+        # runs on the Apple Silicon job). Executing them here keeps fixture/source
+        # drift visible.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
@@ -112,6 +116,7 @@ jobs:
             tests/test_hf_xet_fallback.py \
             tests/test_get_transformers_model_type_empty.py \
             tests/test_train_on_responses_list_labels.py \
+            tests/test_mlx_embedding_guards.py \
             -v
 
       - name: pytest tests/test_mlx_module_exports + zoo-specific CPU tests

--- a/tests/test_mlx_embedding_guards.py
+++ b/tests/test_mlx_embedding_guards.py
@@ -16,14 +16,10 @@
 
 """Sentence-transformers layout shim, pooling-mode detection, batch advisory.
 
-Pure dict/string/arithmetic logic, so this runs under the torch shim on Linux CI
-rather than skipping. The numeric behaviour lives in
-test_mlx_embedding_pooling.py, which needs real MLX.
-
-The layout shim matters because Qwen/Qwen3-Embedding-0.6B -- the obvious model for
-this feature -- does not load without it: sentence-transformers stores the inner
-transformer at the repo root, so all 310 keys arrive without the ``model.`` prefix
-mlx_lm expects and loading fails with "Received 310 parameters not in model".
+Pure logic, so this runs under the torch shim on Linux CI rather than skipping.
+The shim matters because Qwen3-Embedding-0.6B does not load without it: all 310
+keys arrive without the ``model.`` prefix and loading fails with
+"Received 310 parameters not in model".
 """
 
 import pytest
@@ -42,8 +38,7 @@ def _embedding():
 
 # --- pooling-mode detection --------------------------------------------------
 def test_pooling_map_matches_cuda_exactly():
-    """Same map as unsloth/models/sentence_transformer.py:587-599, so a checkpoint
-    resolves to the same mode on both backends."""
+    """Same map as sentence_transformer.py:587-599."""
     expected = {
         "pooling_mode_cls_token": "cls",
         "pooling_mode_mean_tokens": "mean",
@@ -56,7 +51,7 @@ def test_pooling_map_matches_cuda_exactly():
 
 
 def test_qwen3_embedding_resolves_to_lasttoken():
-    """Its real 1_Pooling/config.json. Defaulting to mean would pool the wrong thing."""
+    """Its real 1_Pooling/config.json; defaulting to mean would be wrong."""
     config = {
         "word_embedding_dimension": 1024,
         "pooling_mode_cls_token": False,
@@ -114,7 +109,6 @@ def test_remap_restores_the_model_prefix():
 
 
 def test_remap_preserves_values_identically():
-    """Values must pass through untouched -- only keys change."""
     e = _embedding()
     original = {k: f"tensor-{i}" for i, k in enumerate(ST_KEYS)}
     remapped = e.remap_sentence_transformer_weights(original)
@@ -147,7 +141,7 @@ def test_remap_does_not_double_prefix():
 
 # --- batch-size advisory -----------------------------------------------------
 def test_estimate_reproduces_the_measured_points():
-    """Fitted on measured Qwen3-0.6B steps: 4->4.76, 8->7.92, 16->14.24 GB."""
+    """Measured: 4->4.76, 8->7.92, 16->14.24 GB."""
     e = _embedding()
     for batch, measured in ((4, 4.76), (8, 7.92), (16, 14.24)):
         assert abs(e.estimate_peak_gb(batch) - measured) < 0.6, (
@@ -156,7 +150,7 @@ def test_estimate_reproduces_the_measured_points():
 
 
 def test_estimate_extrapolates_to_the_measured_batch32_point():
-    """Measured once at 26.46 GB (via swap) on a 16 GB machine."""
+    """Measured once at 26.46 GB via swap."""
     assert abs(_embedding().estimate_peak_gb(32) - 26.46) < 1.0
 
 
@@ -176,8 +170,7 @@ def test_recommendation_grows_with_ram_and_shrinks_with_seq_len():
 
 
 def test_small_machines_get_a_warning_not_an_exception():
-    """Advisory only: oversubscription here degrades into swap, not breakage, so a
-    hard refusal would be wrong."""
+    """Advisory: oversubscription degrades into swap, not breakage."""
     e = _embedding()
     batch, warning = e.recommend_batch_size(8)
     assert batch >= 1

--- a/tests/test_mlx_embedding_guards.py
+++ b/tests/test_mlx_embedding_guards.py
@@ -1,0 +1,191 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Sentence-transformers layout shim, pooling-mode detection, batch advisory.
+
+Pure dict/string/arithmetic logic, so this runs under the torch shim on Linux CI
+rather than skipping. The numeric behaviour lives in
+test_mlx_embedding_pooling.py, which needs real MLX.
+
+The layout shim matters because Qwen/Qwen3-Embedding-0.6B -- the obvious model for
+this feature -- does not load without it: sentence-transformers stores the inner
+transformer at the repo root, so all 310 keys arrive without the ``model.`` prefix
+mlx_lm expects and loading fails with "Received 310 parameters not in model".
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_shim():
+    from mlx_simulation import simulate_mlx_on_torch
+    simulate_mlx_on_torch()
+
+
+def _embedding():
+    import unsloth_zoo.mlx.embedding as embedding
+    return embedding
+
+
+# --- pooling-mode detection --------------------------------------------------
+def test_pooling_map_matches_cuda_exactly():
+    """Same map as unsloth/models/sentence_transformer.py:587-599, so a checkpoint
+    resolves to the same mode on both backends."""
+    expected = {
+        "pooling_mode_cls_token": "cls",
+        "pooling_mode_mean_tokens": "mean",
+        "pooling_mode_max_tokens": "max",
+        "pooling_mode_mean_sqrt_len_tokens": "mean_sqrt_len",
+        "pooling_mode_weightedmean_tokens": "weightedmean",
+        "pooling_mode_lasttoken": "lasttoken",
+    }
+    assert _embedding().SENTENCE_TRANSFORMERS_POOLING_MAP == expected
+
+
+def test_qwen3_embedding_resolves_to_lasttoken():
+    """Its real 1_Pooling/config.json. Defaulting to mean would pool the wrong thing."""
+    config = {
+        "word_embedding_dimension": 1024,
+        "pooling_mode_cls_token": False,
+        "pooling_mode_mean_tokens": False,
+        "pooling_mode_max_tokens": False,
+        "pooling_mode_mean_sqrt_len_tokens": False,
+        "pooling_mode_weightedmean_tokens": False,
+        "pooling_mode_lasttoken": True,
+        "include_prompt": True,
+    }
+    assert _embedding().read_pooling_mode(config) == "lasttoken"
+
+
+@pytest.mark.parametrize("key,mode", [
+    ("pooling_mode_cls_token", "cls"),
+    ("pooling_mode_mean_tokens", "mean"),
+    ("pooling_mode_max_tokens", "max"),
+    ("pooling_mode_mean_sqrt_len_tokens", "mean_sqrt_len"),
+    ("pooling_mode_weightedmean_tokens", "weightedmean"),
+    ("pooling_mode_lasttoken", "lasttoken"),
+])
+def test_every_mode_is_detectable(key, mode):
+    assert _embedding().read_pooling_mode({key: True}) == mode
+
+
+def test_missing_or_empty_config_falls_back_to_mean():
+    e = _embedding()
+    assert e.read_pooling_mode(None) == "mean"
+    assert e.read_pooling_mode({}) == "mean"
+    assert e.read_pooling_mode({"pooling_mode_mean_tokens": False}) == "mean"
+
+
+# --- layout shim -------------------------------------------------------------
+ST_KEYS = [
+    "embed_tokens.weight",
+    "layers.0.input_layernorm.weight",
+    "layers.0.self_attn.q_proj.weight",
+    "layers.0.mlp.down_proj.weight",
+    "norm.weight",
+]
+HF_KEYS = ["model." + k for k in ST_KEYS]
+
+
+def test_sentence_transformers_layout_is_detected():
+    e = _embedding()
+    assert e.is_sentence_transformers_layout(ST_KEYS) is True
+    assert e.is_sentence_transformers_layout(HF_KEYS) is False
+    assert e.is_sentence_transformers_layout([]) is False
+
+
+def test_remap_restores_the_model_prefix():
+    e = _embedding()
+    remapped = e.remap_sentence_transformer_weights({k: object() for k in ST_KEYS})
+    assert sorted(remapped) == sorted(HF_KEYS)
+
+
+def test_remap_preserves_values_identically():
+    """Values must pass through untouched -- only keys change."""
+    e = _embedding()
+    original = {k: f"tensor-{i}" for i, k in enumerate(ST_KEYS)}
+    remapped = e.remap_sentence_transformer_weights(original)
+    for key, value in original.items():
+        assert remapped["model." + key] is value
+
+
+def test_remap_is_a_noop_on_plain_hf_layout():
+    e = _embedding()
+    original = {k: object() for k in HF_KEYS}
+    assert e.remap_sentence_transformer_weights(original) == original
+
+
+def test_remap_leaves_lm_head_at_top_level():
+    e = _embedding()
+    remapped = e.remap_sentence_transformer_weights(
+        {"layers.0.mlp.down_proj.weight": 1, "lm_head.weight": 2}
+    )
+    assert "model.layers.0.mlp.down_proj.weight" in remapped
+    assert "lm_head.weight" in remapped
+    assert "model.lm_head.weight" not in remapped
+
+
+def test_remap_does_not_double_prefix():
+    e = _embedding()
+    mixed = {"model.norm.weight": 1, "layers.0.mlp.down_proj.weight": 2}
+    remapped = e.remap_sentence_transformer_weights(mixed)
+    assert not any(k.startswith("model.model.") for k in remapped)
+
+
+# --- batch-size advisory -----------------------------------------------------
+def test_estimate_reproduces_the_measured_points():
+    """Fitted on measured Qwen3-0.6B steps: 4->4.76, 8->7.92, 16->14.24 GB."""
+    e = _embedding()
+    for batch, measured in ((4, 4.76), (8, 7.92), (16, 14.24)):
+        assert abs(e.estimate_peak_gb(batch) - measured) < 0.6, (
+            f"batch={batch}: estimate {e.estimate_peak_gb(batch):.2f} GB vs measured {measured}"
+        )
+
+
+def test_estimate_extrapolates_to_the_measured_batch32_point():
+    """Measured once at 26.46 GB (via swap) on a 16 GB machine."""
+    assert abs(_embedding().estimate_peak_gb(32) - 26.46) < 1.0
+
+
+def test_recommendation_fits_within_the_safety_budget():
+    e = _embedding()
+    for ram in (16, 32, 64, 128):
+        batch, _ = e.recommend_batch_size(ram)
+        assert batch >= 1
+        assert e.estimate_peak_gb(batch) <= ram * e.MEMORY_SAFETY_FRACTION
+
+
+def test_recommendation_grows_with_ram_and_shrinks_with_seq_len():
+    e = _embedding()
+    assert e.recommend_batch_size(64)[0] > e.recommend_batch_size(16)[0]
+    assert e.recommend_batch_size(16, seq_len=1024)[0] < e.recommend_batch_size(16, seq_len=512)[0]
+    assert e.recommend_batch_size(16, hidden=2048)[0] < e.recommend_batch_size(16, hidden=1024)[0]
+
+
+def test_small_machines_get_a_warning_not_an_exception():
+    """Advisory only: oversubscription here degrades into swap, not breakage, so a
+    hard refusal would be wrong."""
+    e = _embedding()
+    batch, warning = e.recommend_batch_size(8)
+    assert batch >= 1
+    assert warning and "batch_size" in warning
+    tiny_batch, tiny_warning = e.recommend_batch_size(1)
+    assert tiny_batch == 1 and tiny_warning
+
+
+def test_comfortable_machine_gets_no_warning():
+    _, warning = _embedding().recommend_batch_size(64)
+    assert warning == ""

--- a/tests/test_mlx_embedding_pooling.py
+++ b/tests/test_mlx_embedding_pooling.py
@@ -16,21 +16,13 @@
 
 """Pooling correctness and contrastive-loss behaviour on MLX.
 
-Two things are asserted that a weaker suite would miss.
+The padding fixture pads with junk at 100x so a mask-ignoring mean differs by ~26;
+that difference is asserted directly, so the invariance tests cannot pass against a
+broken implementation.
 
-Padding invariance: a pool that averages over padding produces no error, only
-worse embeddings. The fixture pads with junk at 100x scale so a mask-ignoring
-mean differs by ~26 -- that difference is asserted directly, so the test cannot
-pass against a broken implementation.
-
-Separation, not loss: a falling loss does not show the objective is doing what it
-claims. Each loss also asserts that positive/negative similarity SEPARATION rises.
-Note the synthetic encoder starts collapsed (all pairs ~0.995 cosine), so
-"positive similarity rises" is unreachable from that ceiling and would be the
-wrong assertion; separation is the metric that discriminates.
-
-Real MLX required, so this skips on Linux; the shim-runnable half is in
-test_mlx_embedding_guards.py. Synthetic tensors only -- no weights, no network.
+Each loss asserts that positive/negative SEPARATION rises, not just that the loss
+falls. The synthetic encoder starts collapsed (all pairs ~0.995 cosine), so
+"positive similarity rises" would be unreachable and the wrong assertion.
 """
 
 import pytest
@@ -62,7 +54,6 @@ STEPS = 8
 
 # --- pooling ---------------------------------------------------------------
 def _padded_fixture():
-    """Same content twice: once unpadded, once padded with extreme junk."""
     mx.random.seed(0)
     rows, length, width, pad = 3, 8, 5, 4
     hidden = mx.random.normal((rows, length, width))
@@ -90,10 +81,10 @@ def test_pooling_is_invariant_to_padding(mode):
 
 
 def test_mask_ignoring_mean_is_measurably_wrong():
-    """Discriminating counterexample: the fixture must be able to fail."""
+    """The fixture must be able to fail."""
     _, _, hidden_padded, mask_padded = _padded_fixture()
 
-    naive = hidden_padded.mean(axis=1)                       # ignores the mask
+    naive = hidden_padded.mean(axis=1)  # ignores the mask
     correct = pool(hidden_padded, mask_padded, "mean")
     difference = float(mx.abs(naive - correct).max())
 
@@ -110,13 +101,13 @@ def test_ragged_batch_mean_matches_hand_computation():
     mask = (mx.arange(8)[None, :] < lengths[:, None]).astype(mx.float32)
 
     pooled = pool(hidden, mask, "mean")
-    manual = hidden[1, :5, :].mean(axis=0)                   # row 1 has 5 real tokens
+    manual = hidden[1, :5, :].mean(axis=0)  # row 1 has 5 real tokens
 
     assert float(mx.abs(pooled[1] - manual).max()) < 1e-5
 
 
 def test_ragged_batch_lasttoken_uses_last_real_token():
-    """Row 1 has 5 real tokens, so lasttoken must return position 4, not 7."""
+    """Row 1 has 5 real tokens: position 4, not 7."""
     mx.random.seed(0)
     hidden = mx.random.normal((3, 8, 5))
     lengths = mx.array([8, 5, 2])
@@ -211,7 +202,7 @@ def _cosent_groups(encoder):
 
 
 def test_cosent_raises_similar_and_lowers_dissimilar():
-    """The cleanest evidence available: the two labelled groups move apart."""
+    """The two labelled groups move apart."""
     encoder = _new_encoder()
     similar_before, dissimilar_before = _cosent_groups(encoder)
 
@@ -250,7 +241,7 @@ def test_triplet_separates_positive_from_explicit_negative():
 
 
 def test_identical_inputs_give_no_separation():
-    """Sanity floor: anchors distilled against themselves cannot separate."""
+    """Self-similarity is 1."""
     encoder = _new_encoder()
     anchors, _, _, mask = _loss_fixture()
     embedded = l2_normalize(encoder(anchors, mask))
@@ -263,7 +254,7 @@ ST_REPO = "Qwen/Qwen3-Embedding-0.6B"
 
 
 def _cached_st_checkpoint():
-    """Resolve the cached repo WITHOUT downloading. Skips if it is not present."""
+    """Resolve the cached repo WITHOUT downloading."""
     huggingface_hub = pytest.importorskip("huggingface_hub")
     try:
         path = huggingface_hub.snapshot_download(ST_REPO, local_files_only=True)
@@ -277,8 +268,7 @@ def _cached_st_checkpoint():
 
 
 def test_real_st_checkpoint_needs_the_remap_and_loads_after_it():
-    """End to end on Qwen3-Embedding-0.6B: without the shim mlx_lm reports
-    'Received 310 parameters not in model'; with it the weights load and match."""
+    """Without the shim mlx_lm reports 'Received 310 parameters not in model'."""
     import json
     import os
 
@@ -291,14 +281,13 @@ def test_real_st_checkpoint_needs_the_remap_and_loads_after_it():
     path, weights_path = _cached_st_checkpoint()
     weights = mx.load(weights_path)
 
-    # The checkpoint really is in sentence-transformers layout.
     assert is_sentence_transformers_layout(weights.keys())
     assert not any(k.startswith("model.") for k in weights)
 
     config = json.load(open(os.path.join(path, "config.json")))
     model = qwen3.Model(qwen3.ModelArgs.from_dict(config))
     expected = {name for name, _ in tree_flatten(model.parameters())}
-    # Same count, zero overlap: exactly the prefix problem, not a real mismatch.
+    # same count, zero overlap: the prefix problem, not a real mismatch
     assert len(weights) == len(expected)
     assert not (set(weights) & expected)
 
@@ -318,7 +307,7 @@ def test_real_st_checkpoint_needs_the_remap_and_loads_after_it():
 
 
 def test_real_st_checkpoint_declares_lasttoken_pooling():
-    """Reading 1_Pooling is not optional: this model is not mean-pooled."""
+    """This model is not mean-pooled."""
     import json
     import os
 

--- a/tests/test_mlx_embedding_pooling.py
+++ b/tests/test_mlx_embedding_pooling.py
@@ -1,0 +1,332 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Pooling correctness and contrastive-loss behaviour on MLX.
+
+Two things are asserted that a weaker suite would miss.
+
+Padding invariance: a pool that averages over padding produces no error, only
+worse embeddings. The fixture pads with junk at 100x scale so a mask-ignoring
+mean differs by ~26 -- that difference is asserted directly, so the test cannot
+pass against a broken implementation.
+
+Separation, not loss: a falling loss does not show the objective is doing what it
+claims. Each loss also asserts that positive/negative similarity SEPARATION rises.
+Note the synthetic encoder starts collapsed (all pairs ~0.995 cosine), so
+"positive similarity rises" is unreachable from that ceiling and would be the
+wrong assertion; separation is the metric that discriminates.
+
+Real MLX required, so this skips on Linux; the shim-runnable half is in
+test_mlx_embedding_guards.py. Synthetic tensors only -- no weights, no network.
+"""
+
+import pytest
+
+mx = pytest.importorskip("mlx.core", reason="MLX is only available on Apple Silicon")
+nn = pytest.importorskip("mlx.nn", reason="MLX is only available on Apple Silicon")
+optim = pytest.importorskip("mlx.optimizers", reason="MLX is only available on Apple Silicon")
+
+# Hoisted to module level on purpose. Inside a test body these resolve against
+# sys.modules at CALL time, and tests/mlx_simulation replaces mlx.* session-wide,
+# so a deferred import silently yields the stub instead of real MLX.
+from mlx.utils import tree_flatten
+_mlx_lm = pytest.importorskip("mlx_lm", reason="MLX is only available on Apple Silicon")
+from mlx_lm.models import qwen3 as _qwen3
+
+from unsloth_zoo.mlx.embedding import (
+    POOLING_MODES,
+    cosent_loss,
+    l2_normalize,
+    multiple_negatives_ranking_loss,
+    pool,
+    triplet_loss,
+)
+
+
+BATCH, SEQ, HIDDEN, VOCAB = 8, 12, 32, 256
+STEPS = 8
+
+
+# --- pooling ---------------------------------------------------------------
+def _padded_fixture():
+    """Same content twice: once unpadded, once padded with extreme junk."""
+    mx.random.seed(0)
+    rows, length, width, pad = 3, 8, 5, 4
+    hidden = mx.random.normal((rows, length, width))
+    mask = mx.ones((rows, length))
+    junk = mx.random.normal((rows, pad, width)) * 100.0
+    hidden_padded = mx.concatenate([hidden, junk], axis=1)
+    mask_padded = mx.concatenate([mx.ones((rows, length)), mx.zeros((rows, pad))], axis=1)
+    return hidden, mask, hidden_padded, mask_padded
+
+
+@pytest.mark.parametrize("mode", POOLING_MODES)
+def test_pooling_is_invariant_to_padding(mode):
+    hidden, mask, hidden_padded, mask_padded = _padded_fixture()
+
+    unpadded = pool(hidden, mask, mode)
+    padded = pool(hidden_padded, mask_padded, mode)
+    mx.eval(unpadded, padded)
+
+    assert unpadded.shape == padded.shape == (3, 5)
+    worst = float(mx.abs(unpadded - padded).max())
+    assert worst < 1e-4, (
+        f"{mode} pooling changed by {worst:.3e} when trailing padding was added; "
+        "the attention mask is being ignored"
+    )
+
+
+def test_mask_ignoring_mean_is_measurably_wrong():
+    """Discriminating counterexample: the fixture must be able to fail."""
+    _, _, hidden_padded, mask_padded = _padded_fixture()
+
+    naive = hidden_padded.mean(axis=1)                       # ignores the mask
+    correct = pool(hidden_padded, mask_padded, "mean")
+    difference = float(mx.abs(naive - correct).max())
+
+    assert difference > 1.0, (
+        f"fixture no longer discriminates: a mask-ignoring mean differs by only "
+        f"{difference:.3e}, so the invariance tests above would pass while broken"
+    )
+
+
+def test_ragged_batch_mean_matches_hand_computation():
+    mx.random.seed(0)
+    hidden = mx.random.normal((3, 8, 5))
+    lengths = mx.array([8, 5, 2])
+    mask = (mx.arange(8)[None, :] < lengths[:, None]).astype(mx.float32)
+
+    pooled = pool(hidden, mask, "mean")
+    manual = hidden[1, :5, :].mean(axis=0)                   # row 1 has 5 real tokens
+
+    assert float(mx.abs(pooled[1] - manual).max()) < 1e-5
+
+
+def test_ragged_batch_lasttoken_uses_last_real_token():
+    """Row 1 has 5 real tokens, so lasttoken must return position 4, not 7."""
+    mx.random.seed(0)
+    hidden = mx.random.normal((3, 8, 5))
+    lengths = mx.array([8, 5, 2])
+    mask = (mx.arange(8)[None, :] < lengths[:, None]).astype(mx.float32)
+
+    pooled = pool(hidden, mask, "lasttoken")
+
+    assert float(mx.abs(pooled[1] - hidden[1, 4, :]).max()) < 1e-6
+    assert float(mx.abs(pooled[1] - hidden[1, 7, :]).max()) > 1e-3, (
+        "lasttoken returned the final SLOT rather than the final real token"
+    )
+    assert float(mx.abs(pooled[2] - hidden[2, 1, :]).max()) < 1e-6
+
+
+def test_unknown_pooling_mode_is_rejected():
+    hidden, mask, _, _ = _padded_fixture()
+    with pytest.raises(ValueError, match="unknown pooling mode"):
+        pool(hidden, mask, "definitely_not_a_mode")
+
+
+# --- losses ----------------------------------------------------------------
+class _Encoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = nn.Embedding(VOCAB, HIDDEN)
+        self.first = nn.Linear(HIDDEN, HIDDEN)
+        self.second = nn.Linear(HIDDEN, HIDDEN)
+
+    def __call__(self, ids, mask):
+        hidden = self.second(nn.gelu(self.first(self.emb(ids))))
+        return pool(hidden, mask, "mean")
+
+
+def _loss_fixture():
+    mx.random.seed(0)
+    anchors = mx.random.randint(0, VOCAB, (BATCH, SEQ))
+    positives = mx.random.randint(0, VOCAB, (BATCH, SEQ))
+    negatives = mx.random.randint(0, VOCAB, (BATCH, SEQ))
+    return anchors, positives, negatives, mx.ones((BATCH, SEQ))
+
+
+def _new_encoder():
+    mx.random.seed(0)
+    encoder = _Encoder()
+    mx.eval(encoder.parameters())
+    return encoder
+
+
+def _train(encoder, loss_fn, steps=STEPS, lr=1e-3):
+    anchors, positives, negatives, mask = _loss_fixture()
+    grad_fn = nn.value_and_grad(encoder, loss_fn)
+    opt = optim.Adam(learning_rate=lr)
+    losses = []
+    for _ in range(steps):
+        loss, grads = grad_fn(encoder, anchors, positives, negatives, mask)
+        opt.update(encoder, grads)
+        mx.eval(encoder.parameters(), opt.state)
+        losses.append(float(loss))
+    return losses
+
+
+def _inbatch_separation(encoder):
+    anchors, positives, _, mask = _loss_fixture()
+    a, p = l2_normalize(encoder(anchors, mask)), l2_normalize(encoder(positives, mask))
+    scores = a @ p.T
+    positive = float(mx.diag(scores).mean())
+    negative = float((scores.sum() - mx.diag(scores).sum()) / (BATCH * BATCH - BATCH))
+    return positive - negative
+
+
+def test_multiple_negatives_ranking_separates_pairs():
+    encoder = _new_encoder()
+    before = _inbatch_separation(encoder)
+
+    losses = _train(encoder, lambda m, a, p, n, k: multiple_negatives_ranking_loss(m(a, k), m(p, k)))
+
+    after = _inbatch_separation(encoder)
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), losses
+    assert after > before, f"separation did not rise: {before:+.4f} -> {after:+.4f}"
+    assert after > 0.15, f"separation only reached {after:+.4f} after {STEPS} steps"
+
+
+COSENT_LABELS = mx.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0])
+
+
+def _cosent_groups(encoder):
+    anchors, positives, _, mask = _loss_fixture()
+    cosine = (l2_normalize(encoder(anchors, mask)) * l2_normalize(encoder(positives, mask))).sum(-1)
+    similar = float((cosine * COSENT_LABELS).sum() / COSENT_LABELS.sum())
+    dissimilar = float((cosine * (1 - COSENT_LABELS)).sum() / (1 - COSENT_LABELS).sum())
+    return similar, dissimilar
+
+
+def test_cosent_raises_similar_and_lowers_dissimilar():
+    """The cleanest evidence available: the two labelled groups move apart."""
+    encoder = _new_encoder()
+    similar_before, dissimilar_before = _cosent_groups(encoder)
+
+    losses = _train(encoder, lambda m, a, p, n, k: cosent_loss(m(a, k), m(p, k), COSENT_LABELS))
+
+    similar_after, dissimilar_after = _cosent_groups(encoder)
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), losses
+    assert similar_after > similar_before, (
+        f"labelled-similar cosine fell: {similar_before:+.4f} -> {similar_after:+.4f}"
+    )
+    assert dissimilar_after < dissimilar_before, (
+        f"labelled-dissimilar cosine rose: {dissimilar_before:+.4f} -> {dissimilar_after:+.4f}"
+    )
+    separation = (similar_after - dissimilar_after) - (similar_before - dissimilar_before)
+    assert separation > 0.3, f"separation only improved by {separation:+.4f}"
+
+
+def _triplet_separation(encoder):
+    anchors, positives, negatives, mask = _loss_fixture()
+    a = l2_normalize(encoder(anchors, mask))
+    p = l2_normalize(encoder(positives, mask))
+    n = l2_normalize(encoder(negatives, mask))
+    return float((a * p).sum(-1).mean()) - float((a * n).sum(-1).mean())
+
+
+def test_triplet_separates_positive_from_explicit_negative():
+    encoder = _new_encoder()
+    before = _triplet_separation(encoder)
+
+    losses = _train(encoder, lambda m, a, p, n, k: triplet_loss(m(a, k), m(p, k), m(n, k)))
+
+    after = _triplet_separation(encoder)
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), losses
+    assert after > before, f"separation did not rise: {before:+.4f} -> {after:+.4f}"
+    assert after > 0.2, f"separation only reached {after:+.4f}"
+
+
+def test_identical_inputs_give_no_separation():
+    """Sanity floor: anchors distilled against themselves cannot separate."""
+    encoder = _new_encoder()
+    anchors, _, _, mask = _loss_fixture()
+    embedded = l2_normalize(encoder(anchors, mask))
+    scores = embedded @ embedded.T
+    assert abs(float(mx.diag(scores).mean()) - 1.0) < 1e-4
+
+
+# --- sentence-transformers layout, against a real checkpoint ----------------
+ST_REPO = "Qwen/Qwen3-Embedding-0.6B"
+
+
+def _cached_st_checkpoint():
+    """Resolve the cached repo WITHOUT downloading. Skips if it is not present."""
+    huggingface_hub = pytest.importorskip("huggingface_hub")
+    try:
+        path = huggingface_hub.snapshot_download(ST_REPO, local_files_only=True)
+    except Exception as exception:                # not cached on this machine
+        pytest.skip(f"{ST_REPO} is not in the local HF cache: {type(exception).__name__}")
+    import os
+    weights_path = os.path.join(path, "model.safetensors")
+    if not os.path.exists(weights_path):
+        pytest.skip(f"{ST_REPO} cache has no model.safetensors")
+    return path, weights_path
+
+
+def test_real_st_checkpoint_needs_the_remap_and_loads_after_it():
+    """End to end on Qwen3-Embedding-0.6B: without the shim mlx_lm reports
+    'Received 310 parameters not in model'; with it the weights load and match."""
+    import json
+    import os
+
+    from unsloth_zoo.mlx.embedding import (
+        is_sentence_transformers_layout,
+        remap_sentence_transformer_weights,
+    )
+    qwen3 = _qwen3
+
+    path, weights_path = _cached_st_checkpoint()
+    weights = mx.load(weights_path)
+
+    # The checkpoint really is in sentence-transformers layout.
+    assert is_sentence_transformers_layout(weights.keys())
+    assert not any(k.startswith("model.") for k in weights)
+
+    config = json.load(open(os.path.join(path, "config.json")))
+    model = qwen3.Model(qwen3.ModelArgs.from_dict(config))
+    expected = {name for name, _ in tree_flatten(model.parameters())}
+    # Same count, zero overlap: exactly the prefix problem, not a real mismatch.
+    assert len(weights) == len(expected)
+    assert not (set(weights) & expected)
+
+    remapped = remap_sentence_transformer_weights(weights)
+    model.load_weights(list(remapped.items()), strict=False)
+    mx.eval(model.parameters())
+
+    loaded = dict(tree_flatten(model.parameters()))
+    probe = "model.layers.0.self_attn.q_proj.weight"
+    assert bool(mx.array_equal(loaded[probe], weights["layers.0.self_attn.q_proj.weight"]).item()), (
+        "remapped weights loaded but do not match the checkpoint tensor"
+    )
+
+    hidden = model.model(mx.random.randint(0, 500, (1, 8)))
+    mx.eval(hidden)
+    assert hidden.shape == (1, 8, config["hidden_size"])
+
+
+def test_real_st_checkpoint_declares_lasttoken_pooling():
+    """Reading 1_Pooling is not optional: this model is not mean-pooled."""
+    import json
+    import os
+
+    from unsloth_zoo.mlx.embedding import read_pooling_mode
+
+    path, _ = _cached_st_checkpoint()
+    pooling_config_path = os.path.join(path, "1_Pooling", "config.json")
+    if not os.path.exists(pooling_config_path):
+        pytest.skip("cached snapshot has no 1_Pooling/config.json")
+
+    assert read_pooling_mode(json.load(open(pooling_config_path))) == "lasttoken"

--- a/unsloth_zoo/mlx/embedding.py
+++ b/unsloth_zoo/mlx/embedding.py
@@ -1,0 +1,298 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Pooling and contrastive-loss primitives for embedding training on MLX.
+
+This is the LIBRARY half only: pooling, losses, and a sentence-transformers
+layout shim. It deliberately does not integrate with MLXTrainer. The trainer's
+loss contract is ``loss_fn(model, batch, lengths, labels=None)`` -- one token
+sequence per row -- and contrastive training needs two or three aligned sequences
+per row (anchor / positive / negative). Carrying a pair through that signature is
+not possible without a separate entry point and data-path work, so integration is
+a separate change.
+
+Scope, stated plainly because the feature name over-promises: only decoder-only
+backbones that ``mlx_lm`` already implements are reachable. BERT, RoBERTa, MiniLM
+and mpnet fail with ``ValueError: Model type bert not supported`` -- there is no
+BERT in mlx_lm at all -- and those are the families most sentence-transformers
+checkpoints actually use.
+
+Two layouts are handled:
+
+* Plain HF layout (e.g. Alibaba-NLP/gte-Qwen2-1.5B-instruct) loads unmodified.
+* sentence-transformers layout (e.g. Qwen/Qwen3-Embedding-0.6B) stores the inner
+  transformer at the repo root, so its keys are ``layers.0.self_attn.q_proj.weight``
+  while mlx_lm expects ``model.layers.0...``. Loading it raw fails with
+  ``ValueError: Received 310 parameters not in model``. ``remap_sentence_transformer_weights``
+  restores the prefix; the pooling mode then comes from ``1_Pooling/config.json``,
+  mirroring the map in unsloth/models/sentence_transformer.py:587-599.
+
+Mask handling is the correctness risk here. A mean-pool that averages over padding
+is silently wrong rather than loud: on a padded batch it differs from the correct
+answer by ~26 in the test fixture, with no error anywhere. Every mode below takes
+the attention mask.
+"""
+
+# Bind MLX at import, NOT inside functions. A deferred `import mlx.core` resolves
+# against sys.modules at call time, so anything that swaps in a stub afterwards
+# (tests/mlx_simulation does exactly that, session-wide) would silently hand this
+# module the stub. Binding here captures whichever MLX was present at first import.
+import mlx.core as mx
+import mlx.nn as nn
+
+__all__ = [
+    "POOLING_MODES",
+    "SENTENCE_TRANSFORMERS_POOLING_MAP",
+    "pool",
+    "l2_normalize",
+    "multiple_negatives_ranking_loss",
+    "cosent_loss",
+    "triplet_loss",
+    "read_pooling_mode",
+    "remap_sentence_transformer_weights",
+    "recommend_batch_size",
+    "PEAK_GB_RESIDENT_DEFAULT",
+    "PEAK_GB_PER_SAMPLE_AT_REFERENCE",
+    "REFERENCE_SEQ_LEN",
+    "REFERENCE_HIDDEN",
+    "MEMORY_SAFETY_FRACTION",
+]
+
+POOLING_MODES = ("cls", "mean", "max", "mean_sqrt_len", "weightedmean", "lasttoken")
+
+# Verbatim from unsloth/models/sentence_transformer.py:587-599, which reads these
+# keys out of 1_Pooling/config.json. Kept identical so a checkpoint resolves to the
+# same mode on MLX as it does on CUDA.
+SENTENCE_TRANSFORMERS_POOLING_MAP = {
+    "pooling_mode_cls_token": "cls",
+    "pooling_mode_mean_tokens": "mean",
+    "pooling_mode_max_tokens": "max",
+    "pooling_mode_mean_sqrt_len_tokens": "mean_sqrt_len",
+    "pooling_mode_weightedmean_tokens": "weightedmean",
+    "pooling_mode_lasttoken": "lasttoken",
+}
+
+
+def l2_normalize(x, eps = 1e-12):
+    """Unit-norm along the last axis, guarded against a zero vector."""
+    return x / mx.maximum(mx.linalg.norm(x, axis = -1, keepdims = True), eps)
+
+
+def pool(hidden_states, attention_mask, mode = "mean"):
+    """Reduce ``[batch, seq, hidden]`` to ``[batch, hidden]``, honouring the mask.
+
+    ``attention_mask`` is ``[batch, seq]`` with 1 for real tokens and 0 for
+    padding. Every mode must be invariant to trailing padding: pooling a padded
+    batch has to equal pooling the unpadded one, whatever junk sits in the pad
+    slots. Getting this wrong produces no error, only worse embeddings.
+    """
+    if mode not in POOLING_MODES:
+        raise ValueError(
+            f"Unsloth: unknown pooling mode {mode!r}. Supported: {', '.join(POOLING_MODES)}."
+        )
+    weights = attention_mask.astype(hidden_states.dtype)[..., None]
+
+    if mode == "cls":
+        # Position 0 is the CLS token and is never padding.
+        return hidden_states[:, 0, :]
+
+    if mode == "mean":
+        return (hidden_states * weights).sum(1) / mx.maximum(weights.sum(1), 1e-9)
+
+    if mode == "max":
+        # -inf in the pad slots so they can never win the max.
+        masked = mx.where(
+            weights > 0, hidden_states,
+            mx.full(hidden_states.shape, -mx.inf).astype(hidden_states.dtype),
+        )
+        return masked.max(axis = 1)
+
+    if mode == "mean_sqrt_len":
+        lengths = mx.maximum(weights.sum(1), 1e-9)
+        return (hidden_states * weights).sum(1) / mx.sqrt(lengths)
+
+    if mode == "weightedmean":
+        # Position weights 1..n over REAL tokens only, so padding cannot shift the
+        # weighting of the tokens that precede it.
+        positions = mx.cumsum(weights.squeeze(-1), axis = 1)[..., None] * weights
+        return (hidden_states * positions).sum(1) / mx.maximum(positions.sum(1), 1e-9)
+
+    # lasttoken: the final REAL token, not the final slot.
+    last_index = mx.maximum(attention_mask.astype(mx.int32).sum(1) - 1, 0)
+    gathered = mx.take_along_axis(
+        hidden_states, last_index[:, None, None].astype(mx.int32), axis = 1,
+    )
+    return gathered.squeeze(1)
+
+
+def multiple_negatives_ranking_loss(anchors, positives, scale = 20.0):
+    """In-batch negatives: row i's positive is column i, every other column is a
+    negative. Cross-entropy over the scaled cosine-similarity matrix.
+
+    Effective difficulty grows with batch size, since the number of negatives is
+    ``batch - 1``. See ``recommend_batch_size`` before pushing it up.
+    """
+    anchors = l2_normalize(anchors)
+    positives = l2_normalize(positives)
+    scores = (anchors @ positives.T) * scale
+    labels = mx.arange(anchors.shape[0])
+    return nn.losses.cross_entropy(scores, labels, reduction = "mean")
+
+
+def cosent_loss(anchors, positives, labels, scale = 20.0):
+    """CoSENT: pairwise ranking over cosine scores.
+
+    ``labels`` is ``[batch]`` with a higher value meaning a more similar pair
+    (1/0 for the binary case). Every ordered pair where i should outrank j
+    contributes; pairs that should not are masked to -inf so they drop out of the
+    logsumexp.
+    """
+    cosine = (l2_normalize(anchors) * l2_normalize(positives)).sum(-1) * scale
+    differences = cosine[None, :] - cosine[:, None]
+    should_rank = (labels[:, None] > labels[None, :])
+    differences = mx.where(
+        should_rank, differences, mx.full(differences.shape, -mx.inf),
+    )
+    return mx.logaddexp(mx.zeros(()), mx.logsumexp(differences.reshape(-1)))
+
+
+def triplet_loss(anchors, positives, negatives, margin = 0.5):
+    """Explicit negatives with a margin, on squared L2 over normalized vectors."""
+    anchors = l2_normalize(anchors)
+    positives = l2_normalize(positives)
+    negatives = l2_normalize(negatives)
+    positive_distance = mx.sum((anchors - positives) ** 2, axis = -1)
+    negative_distance = mx.sum((anchors - negatives) ** 2, axis = -1)
+    return mx.maximum(positive_distance - negative_distance + margin, 0.0).mean()
+
+
+def read_pooling_mode(pooling_config, default = "mean"):
+    """Resolve a sentence-transformers ``1_Pooling/config.json`` dict to a mode.
+
+    Mirrors unsloth/models/sentence_transformer.py:536-599 including its map and
+    its fall-back to "mean" when nothing is set. Qwen3-Embedding-0.6B sets
+    ``pooling_mode_lasttoken``, not mean, so defaulting blindly would pool the
+    wrong thing.
+    """
+    if not pooling_config:
+        return default
+    for config_key, mode in SENTENCE_TRANSFORMERS_POOLING_MAP.items():
+        if pooling_config.get(config_key):
+            return mode
+    return default
+
+
+def is_sentence_transformers_layout(weight_keys):
+    """True when the checkpoint stores the transformer at the repo root.
+
+    sentence-transformers writes the inner Transformer module with ``path: ""``,
+    stripping the ``model.`` prefix mlx_lm's decoder classes expect.
+    """
+    keys = list(weight_keys)
+    if not keys:
+        return False
+    return not any(key.startswith("model.") for key in keys)
+
+
+def remap_sentence_transformer_weights(weights, prefix = "model."):
+    """Restore the ``model.`` prefix on a sentence-transformers-layout checkpoint.
+
+    Loading Qwen/Qwen3-Embedding-0.6B without this fails with
+    ``ValueError: Received 310 parameters not in model`` -- 310 checkpoint keys,
+    310 expected keys, none of them matching because every one is missing the
+    prefix. Keys already prefixed, and top-level heads like ``lm_head``, are left
+    alone. A no-op on plain HF layout.
+    """
+    if not is_sentence_transformers_layout(weights.keys()):
+        return dict(weights)
+    return {
+        key if key.startswith((prefix, "lm_head")) else f"{prefix}{key}": value
+        for key, value in weights.items()
+    }
+
+
+# Peak memory for a contrastive step, fitted on measured runs of a Qwen3-0.6B
+# backbone with LoRA r8 on 8 layers, seq_len 512, hidden 1024:
+#     batch  4 -> 4.76 GB, batch 8 -> 7.92 GB, batch 16 -> 14.24 GB
+# giving peak_GB ~= 1.12 + 0.79 * batch. Reproduces those three to ~0.15 GB and
+# predicted 26.4 GB at batch 32 against 26.46 GB measured.
+PEAK_GB_RESIDENT_DEFAULT = 1.12
+PEAK_GB_PER_SAMPLE_AT_REFERENCE = 0.79
+REFERENCE_SEQ_LEN = 512
+REFERENCE_HIDDEN = 1024
+MEMORY_SAFETY_FRACTION = 0.85
+
+
+def recommend_batch_size(ram_gb, seq_len = REFERENCE_SEQ_LEN, hidden = REFERENCE_HIDDEN,
+                         resident_gb = PEAK_GB_RESIDENT_DEFAULT):
+    """Advisory batch size for in-batch-negative training. Never raises.
+
+    Returns ``(batch_size, warning)`` where ``warning`` is "" when the estimate is
+    comfortable. Advisory rather than enforcing because oversubscription here
+    degrades into swap rather than failing: a measured batch of 32 on a 16 GB
+    machine completed at 26.5 GB peak but took 5x as long. (Only much further out
+    does the process get killed outright.) A hard refusal would be wrong for a
+    cost that is slowness, not breakage.
+    """
+    per_sample = (
+        PEAK_GB_PER_SAMPLE_AT_REFERENCE
+        * (seq_len / REFERENCE_SEQ_LEN)
+        * (hidden / REFERENCE_HIDDEN)
+    )
+    budget = ram_gb * MEMORY_SAFETY_FRACTION
+    usable = budget - resident_gb
+    if usable <= 0 or per_sample <= 0:
+        return 1, (
+            f"Unsloth: {ram_gb:.0f} GB leaves no headroom after a {resident_gb:.2f} GB "
+            "resident model; batch_size=1 is the most that can be recommended."
+        )
+    batch_size = max(1, int(usable / per_sample))
+    warning = ""
+    if batch_size < 8:
+        warning = (
+            f"Unsloth: only batch_size={batch_size} fits in {ram_gb:.0f} GB at "
+            f"seq_len={seq_len}. In-batch-negative losses get their difficulty from "
+            "batch size, so small batches train weaker embeddings; consider a shorter "
+            "seq_len or a smaller backbone."
+        )
+    return batch_size, warning
+
+
+def estimate_peak_gb(batch_size, seq_len = REFERENCE_SEQ_LEN, hidden = REFERENCE_HIDDEN,
+                     resident_gb = PEAK_GB_RESIDENT_DEFAULT):
+    """Estimated peak GB for one contrastive step. Inverse of recommend_batch_size."""
+    per_sample = (
+        PEAK_GB_PER_SAMPLE_AT_REFERENCE
+        * (seq_len / REFERENCE_SEQ_LEN)
+        * (hidden / REFERENCE_HIDDEN)
+    )
+    return resident_gb + per_sample * batch_size
+
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/unsloth_zoo/mlx/embedding.py
+++ b/unsloth_zoo/mlx/embedding.py
@@ -16,40 +16,28 @@
 
 """Pooling and contrastive-loss primitives for embedding training on MLX.
 
-This is the LIBRARY half only: pooling, losses, and a sentence-transformers
-layout shim. It deliberately does not integrate with MLXTrainer. The trainer's
-loss contract is ``loss_fn(model, batch, lengths, labels=None)`` -- one token
-sequence per row -- and contrastive training needs two or three aligned sequences
-per row (anchor / positive / negative). Carrying a pair through that signature is
-not possible without a separate entry point and data-path work, so integration is
-a separate change.
+LIBRARY only: pooling, losses, and a sentence-transformers layout shim. No
+MLXTrainer integration -- the trainer's loss contract is
+``loss_fn(model, batch, lengths, labels=None)``, one sequence per row, and
+contrastive training needs two or three aligned sequences per row.
 
-Scope, stated plainly because the feature name over-promises: only decoder-only
-backbones that ``mlx_lm`` already implements are reachable. BERT, RoBERTa, MiniLM
-and mpnet fail with ``ValueError: Model type bert not supported`` -- there is no
-BERT in mlx_lm at all -- and those are the families most sentence-transformers
-checkpoints actually use.
+Only decoder-only backbones that mlx_lm implements are reachable. BERT, RoBERTa,
+MiniLM and mpnet fail with ``Model type bert not supported`` -- the families most
+sentence-transformers checkpoints use.
 
-Two layouts are handled:
+Plain HF layout (gte-Qwen2-1.5B-instruct) loads unmodified. sentence-transformers
+layout (Qwen3-Embedding-0.6B) stores the transformer at the repo root, so keys are
+``layers.0...`` while mlx_lm expects ``model.layers.0...`` and loading raw fails
+with ``Received 310 parameters not in model``;
+``remap_sentence_transformer_weights`` restores the prefix and the mode then comes
+from ``1_Pooling/config.json``, mirroring sentence_transformer.py:587-599.
 
-* Plain HF layout (e.g. Alibaba-NLP/gte-Qwen2-1.5B-instruct) loads unmodified.
-* sentence-transformers layout (e.g. Qwen/Qwen3-Embedding-0.6B) stores the inner
-  transformer at the repo root, so its keys are ``layers.0.self_attn.q_proj.weight``
-  while mlx_lm expects ``model.layers.0...``. Loading it raw fails with
-  ``ValueError: Received 310 parameters not in model``. ``remap_sentence_transformer_weights``
-  restores the prefix; the pooling mode then comes from ``1_Pooling/config.json``,
-  mirroring the map in unsloth/models/sentence_transformer.py:587-599.
-
-Mask handling is the correctness risk here. A mean-pool that averages over padding
-is silently wrong rather than loud: on a padded batch it differs from the correct
-answer by ~26 in the test fixture, with no error anywhere. Every mode below takes
-the attention mask.
+Mask handling is the correctness risk: a mean-pool over padding is silently wrong,
+differing by ~26 on the test fixture with no error. Every mode takes the mask.
 """
 
-# Bind MLX at import, NOT inside functions. A deferred `import mlx.core` resolves
-# against sys.modules at call time, so anything that swaps in a stub afterwards
-# (tests/mlx_simulation does exactly that, session-wide) would silently hand this
-# module the stub. Binding here captures whichever MLX was present at first import.
+# Bind MLX at import, NOT inside functions: a deferred `import mlx.core` resolves
+# against sys.modules at call time, so tests/mlx_simulation's stub would win.
 import mlx.core as mx
 import mlx.nn as nn
 
@@ -73,9 +61,8 @@ __all__ = [
 
 POOLING_MODES = ("cls", "mean", "max", "mean_sqrt_len", "weightedmean", "lasttoken")
 
-# Verbatim from unsloth/models/sentence_transformer.py:587-599, which reads these
-# keys out of 1_Pooling/config.json. Kept identical so a checkpoint resolves to the
-# same mode on MLX as it does on CUDA.
+# Verbatim from sentence_transformer.py:587-599, so a checkpoint resolves to the
+# same mode on MLX as on CUDA.
 SENTENCE_TRANSFORMERS_POOLING_MAP = {
     "pooling_mode_cls_token": "cls",
     "pooling_mode_mean_tokens": "mean",
@@ -87,18 +74,15 @@ SENTENCE_TRANSFORMERS_POOLING_MAP = {
 
 
 def l2_normalize(x, eps = 1e-12):
-    """Unit-norm along the last axis, guarded against a zero vector."""
+    """Unit-norm along the last axis."""
     return x / mx.maximum(mx.linalg.norm(x, axis = -1, keepdims = True), eps)
 
 
 def pool(hidden_states, attention_mask, mode = "mean"):
     """Reduce ``[batch, seq, hidden]`` to ``[batch, hidden]``, honouring the mask.
 
-    ``attention_mask`` is ``[batch, seq]`` with 1 for real tokens and 0 for
-    padding. Every mode must be invariant to trailing padding: pooling a padded
-    batch has to equal pooling the unpadded one, whatever junk sits in the pad
-    slots. Getting this wrong produces no error, only worse embeddings.
-    """
+    Every mode must be invariant to trailing padding -- getting this wrong
+    produces no error, only worse embeddings."""
     if mode not in POOLING_MODES:
         raise ValueError(
             f"Unsloth: unknown pooling mode {mode!r}. Supported: {', '.join(POOLING_MODES)}."
@@ -106,14 +90,13 @@ def pool(hidden_states, attention_mask, mode = "mean"):
     weights = attention_mask.astype(hidden_states.dtype)[..., None]
 
     if mode == "cls":
-        # Position 0 is the CLS token and is never padding.
         return hidden_states[:, 0, :]
 
     if mode == "mean":
         return (hidden_states * weights).sum(1) / mx.maximum(weights.sum(1), 1e-9)
 
     if mode == "max":
-        # -inf in the pad slots so they can never win the max.
+        # -inf in pad slots so they cannot win the max
         masked = mx.where(
             weights > 0, hidden_states,
             mx.full(hidden_states.shape, -mx.inf).astype(hidden_states.dtype),
@@ -125,12 +108,11 @@ def pool(hidden_states, attention_mask, mode = "mean"):
         return (hidden_states * weights).sum(1) / mx.sqrt(lengths)
 
     if mode == "weightedmean":
-        # Position weights 1..n over REAL tokens only, so padding cannot shift the
-        # weighting of the tokens that precede it.
+        # weights 1..n over REAL tokens only
         positions = mx.cumsum(weights.squeeze(-1), axis = 1)[..., None] * weights
         return (hidden_states * positions).sum(1) / mx.maximum(positions.sum(1), 1e-9)
 
-    # lasttoken: the final REAL token, not the final slot.
+    # final REAL token, not the final slot
     last_index = mx.maximum(attention_mask.astype(mx.int32).sum(1) - 1, 0)
     gathered = mx.take_along_axis(
         hidden_states, last_index[:, None, None].astype(mx.int32), axis = 1,
@@ -139,12 +121,8 @@ def pool(hidden_states, attention_mask, mode = "mean"):
 
 
 def multiple_negatives_ranking_loss(anchors, positives, scale = 20.0):
-    """In-batch negatives: row i's positive is column i, every other column is a
-    negative. Cross-entropy over the scaled cosine-similarity matrix.
-
-    Effective difficulty grows with batch size, since the number of negatives is
-    ``batch - 1``. See ``recommend_batch_size`` before pushing it up.
-    """
+    """In-batch negatives: cross-entropy over the scaled cosine-similarity matrix.
+    Difficulty grows with batch size; see ``recommend_batch_size``."""
     anchors = l2_normalize(anchors)
     positives = l2_normalize(positives)
     scores = (anchors @ positives.T) * scale
@@ -153,13 +131,8 @@ def multiple_negatives_ranking_loss(anchors, positives, scale = 20.0):
 
 
 def cosent_loss(anchors, positives, labels, scale = 20.0):
-    """CoSENT: pairwise ranking over cosine scores.
-
-    ``labels`` is ``[batch]`` with a higher value meaning a more similar pair
-    (1/0 for the binary case). Every ordered pair where i should outrank j
-    contributes; pairs that should not are masked to -inf so they drop out of the
-    logsumexp.
-    """
+    """CoSENT: pairwise ranking over cosine scores. Higher ``labels`` means a more
+    similar pair; pairs that should not rank are masked to -inf."""
     cosine = (l2_normalize(anchors) * l2_normalize(positives)).sum(-1) * scale
     differences = cosine[None, :] - cosine[:, None]
     should_rank = (labels[:, None] > labels[None, :])
@@ -180,13 +153,8 @@ def triplet_loss(anchors, positives, negatives, margin = 0.5):
 
 
 def read_pooling_mode(pooling_config, default = "mean"):
-    """Resolve a sentence-transformers ``1_Pooling/config.json`` dict to a mode.
-
-    Mirrors unsloth/models/sentence_transformer.py:536-599 including its map and
-    its fall-back to "mean" when nothing is set. Qwen3-Embedding-0.6B sets
-    ``pooling_mode_lasttoken``, not mean, so defaulting blindly would pool the
-    wrong thing.
-    """
+    """Resolve ``1_Pooling/config.json`` to a mode, mirroring
+    sentence_transformer.py:536-599. Qwen3-Embedding sets lasttoken, not mean."""
     if not pooling_config:
         return default
     for config_key, mode in SENTENCE_TRANSFORMERS_POOLING_MAP.items():
@@ -196,11 +164,8 @@ def read_pooling_mode(pooling_config, default = "mean"):
 
 
 def is_sentence_transformers_layout(weight_keys):
-    """True when the checkpoint stores the transformer at the repo root.
-
-    sentence-transformers writes the inner Transformer module with ``path: ""``,
-    stripping the ``model.`` prefix mlx_lm's decoder classes expect.
-    """
+    """True when the checkpoint stores the transformer at the repo root, without
+    the ``model.`` prefix mlx_lm expects."""
     keys = list(weight_keys)
     if not keys:
         return False
@@ -208,14 +173,8 @@ def is_sentence_transformers_layout(weight_keys):
 
 
 def remap_sentence_transformer_weights(weights, prefix = "model."):
-    """Restore the ``model.`` prefix on a sentence-transformers-layout checkpoint.
-
-    Loading Qwen/Qwen3-Embedding-0.6B without this fails with
-    ``ValueError: Received 310 parameters not in model`` -- 310 checkpoint keys,
-    310 expected keys, none of them matching because every one is missing the
-    prefix. Keys already prefixed, and top-level heads like ``lm_head``, are left
-    alone. A no-op on plain HF layout.
-    """
+    """Restore the ``model.`` prefix. Without it Qwen3-Embedding-0.6B fails with
+    ``Received 310 parameters not in model``. No-op on plain HF layout."""
     if not is_sentence_transformers_layout(weights.keys()):
         return dict(weights)
     return {
@@ -224,11 +183,9 @@ def remap_sentence_transformer_weights(weights, prefix = "model."):
     }
 
 
-# Peak memory for a contrastive step, fitted on measured runs of a Qwen3-0.6B
-# backbone with LoRA r8 on 8 layers, seq_len 512, hidden 1024:
-#     batch  4 -> 4.76 GB, batch 8 -> 7.92 GB, batch 16 -> 14.24 GB
-# giving peak_GB ~= 1.12 + 0.79 * batch. Reproduces those three to ~0.15 GB and
-# predicted 26.4 GB at batch 32 against 26.46 GB measured.
+# Fitted on a Qwen3-0.6B + LoRA r8 backbone, seq_len 512, hidden 1024:
+#     batch 4 -> 4.76 GB, 8 -> 7.92 GB, 16 -> 14.24 GB, i.e. 1.12 + 0.79 * batch
+# (predicted 26.4 GB at batch 32 against 26.46 measured).
 PEAK_GB_RESIDENT_DEFAULT = 1.12
 PEAK_GB_PER_SAMPLE_AT_REFERENCE = 0.79
 REFERENCE_SEQ_LEN = 512
@@ -238,15 +195,10 @@ MEMORY_SAFETY_FRACTION = 0.85
 
 def recommend_batch_size(ram_gb, seq_len = REFERENCE_SEQ_LEN, hidden = REFERENCE_HIDDEN,
                          resident_gb = PEAK_GB_RESIDENT_DEFAULT):
-    """Advisory batch size for in-batch-negative training. Never raises.
+    """Advisory ``(batch_size, warning)``; never raises.
 
-    Returns ``(batch_size, warning)`` where ``warning`` is "" when the estimate is
-    comfortable. Advisory rather than enforcing because oversubscription here
-    degrades into swap rather than failing: a measured batch of 32 on a 16 GB
-    machine completed at 26.5 GB peak but took 5x as long. (Only much further out
-    does the process get killed outright.) A hard refusal would be wrong for a
-    cost that is slowness, not breakage.
-    """
+    Advisory because oversubscription degrades into swap, not failure: batch 32 on
+    a 16 GB machine completed at 26.5 GB peak but took 5x as long."""
     per_sample = (
         PEAK_GB_PER_SAMPLE_AT_REFERENCE
         * (seq_len / REFERENCE_SEQ_LEN)
@@ -273,7 +225,7 @@ def recommend_batch_size(ram_gb, seq_len = REFERENCE_SEQ_LEN, hidden = REFERENCE
 
 def estimate_peak_gb(batch_size, seq_len = REFERENCE_SEQ_LEN, hidden = REFERENCE_HIDDEN,
                      resident_gb = PEAK_GB_RESIDENT_DEFAULT):
-    """Estimated peak GB for one contrastive step. Inverse of recommend_batch_size."""
+    """Estimated peak GB for one contrastive step."""
     per_sample = (
         PEAK_GB_PER_SAMPLE_AT_REFERENCE
         * (seq_len / REFERENCE_SEQ_LEN)


### PR DESCRIPTION
This adds the **library pieces only** — pooling, three contrastive losses, and a sentence-transformers layout shim. It does **not** integrate with `MLXTrainer`, and it covers decoder-only backbones only.
 
Integration is deliberately deferred: the trainer's loss contract is `loss_fn(model, batch, lengths, labels=None)` — one token sequence per row — and contrastive training needs two or three aligned sequences per row. Carrying a pair through that signature needs a separate entry point plus data-path work, which is its own change.
 
## Coverage, stated up front
 
BERT, RoBERTa, MiniLM and mpnet fail with `ValueError: Model type bert not supported` — there is no BERT implementation in `mlx_lm` at all — so the families most sentence-transformers checkpoints actually use are out of reach.
 
| model | result |
|---|---|
| `Alibaba-NLP/gte-Qwen2-1.5B-instruct` | loads unmodified |
| `Qwen/Qwen3-Embedding-0.6B` | loads via the layout shim |
| BERT / RoBERTa / MiniLM / mpnet | not supported by `mlx_lm` |
 
The shim exists because sentence-transformers stores the inner transformer at repo root, so all 310 keys arrive without the `model.` prefix and loading raw fails with `Received 310 parameters not in model`. A test asserts the remapped weights load and that `mx.array_equal` matches the checkpoint tensor.
 
## Pooling
 
All six modes from `sentence_transformer.py:587-599` — `cls`, `mean`, `max`, `mean_sqrt_len`, `weightedmean`, `lasttoken` — all mask-aware. CUDA only detects the mode and delegates to sentence-transformers; MLX has to implement them.
 
Padding invariance is the correctness risk: a mask-ignoring mean is silently wrong rather than loud. The fixture pads with junk at 100× scale so the naive mean differs by **26.361**, asserted directly so the test can actually fail. All six modes match the unpadded result to `0.000e+00`.
 
Reading `1_Pooling/config.json` matters too — Qwen3-Embedding declares `lasttoken`, not `mean`.
 
## Losses
 
Each verified over 8 steps with **separation** asserted, not just a falling loss:
 
| loss | loss | separation |
|---|---|---|
| MultipleNegativesRanking | 2.077 → 0.675 | +0.0001 → +0.2426 |
| CoSENT | 2.838 → 0.107 | −0.0002 → +0.4911 |
| triplet | 0.500 → 0.190 | −0.0002 → +0.2846 |
 
CoSENT's two groups move apart independently: labelled-similar 0.9951 → 0.9977, labelled-dissimilar 0.9954 → 0.5066. The synthetic encoder starts collapsed at ~0.995 cosine, so "positive-pair cosine rises" would have been the wrong assertion — separation is the metric that tests the objective.
 
## Batch-size advisory
 
`recommend_batch_size` derives from `peak_GB ≈ 1.12 + 0.79 × batch`, fitted on measured peaks at batch 4 / 8 / 16 → 4.76 / 7.92 / 14.24 GB (0.6B backbone, L=512).
 
It is deliberately one notch conservative against an 85% memory budget — it returns 15 on a 16 GB machine where batch 16 measured 14.24 GB — and it raises nothing, so a user who knows their own headroom can ignore it.
 
## Tests
 
37 tests, split so the Linux gate executes the shim-runnable half.
 
The numeric tests bind `mlx.core`, `mlx_lm` and `mlx.utils` at **module** import, not inside test bodies. The repo's `mlx_simulation` shim replaces `sys.modules` entries session-wide, so a function-level import silently resolves against the stub — the test then passes against a stub while looking clean standalone. This was caught only by a full-suite run, and it is worth knowing for any future MLX test in this repo.
 
Full zoo suite run twice per side: collected totals 2979 → 3016, delta 37 = the tests added. No regressions, no environment writes. `trainer.py` is untouched.
 