### PR TITLE
feat(mlx): quantization-aware training for LoRA on Apple Silicon

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -99,3 +99,18 @@ jobs:
         # Deep behavior checks: resume determinism, completion-only training,
         # epoch step counts, SGD coupled decay, real Qwen2-VL LoRA training.
         run: python -m pytest tests/test_mlx_pr684_full_validation_metal.py -v -rs
+
+      - name: tests/test_mlx_qat.py
+        # QAT parity against the real fuse(dequantize=False) that merged_4bit
+        # writes, straight-through gradients, and the rejection guards.
+        run: python -m pytest tests/test_mlx_qat.py -v -rs
+
+      - name: tests/test_mlx_qat_metal.py
+        # QAT efficacy: trains with and without QAT from one seed, fuses both,
+        # and asserts the saved model is actually better.
+        run: python -m pytest tests/test_mlx_qat_metal.py -v -rs
+
+      - name: tests/test_mlx_qat_integration_metal.py
+        # QAT against the real product paths: merged_4bit save/reload, adapter
+        # export, MLXTrainer (compile + shape guard), VLM gate, CPT exclusion.
+        run: python -m pytest tests/test_mlx_qat_integration_metal.py -v -rs

--- a/tests/test_mlx_qat.py
+++ b/tests/test_mlx_qat.py
@@ -276,9 +276,13 @@ def test_lora_dropout_is_rejected():
 
 
 def test_model_without_lora_is_rejected():
-    holder = _Holder(nn.Linear(DIMS, DIMS))
+    # Quantized, so only the "no adapters" condition is violated -- otherwise
+    # the earlier unquantized-base preflight fires and this path is never hit.
+    quantized = nn.QuantizedLinear.from_linear(
+        nn.Linear(DIMS, DIMS, bias=False),
+        group_size=GROUP_SIZE, bits=BITS, mode="affine")
     with pytest.raises(ValueError, match="no LoRA layers"):
-        apply_mlx_qat(holder, "auto")
+        apply_mlx_qat(_Holder(quantized), "auto")
 
 
 def test_mixed_quantization_grids_are_rejected():

--- a/tests/test_mlx_qat.py
+++ b/tests/test_mlx_qat.py
@@ -1,0 +1,320 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""QAT for MLX LoRA: parity with fuse(), straight-through gradients, guards.
+
+The load-bearing test is `test_qat_forward_matches_fused_module`: QAT is only
+meaningful if the quantizer it simulates is the one `merged_4bit` actually
+writes, so expectations are taken from calling the real `fuse()` rather than
+from re-deriving the merge arithmetic here. A test that recomputed the merge
+would share any bug with the implementation and pass while proving nothing.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+
+def _real_mlx_runtime():
+    """True only on the genuine mlx stack.
+
+    Sibling test files install the mlx_simulation stub process-wide with no
+    teardown, so a bare `import mlx` can succeed against the shim.
+    """
+    try:
+        lora = importlib.import_module("mlx_lm.tuner.lora")
+    except Exception:
+        return False
+    if not isinstance(getattr(lora, "LoRALinear", None), type):
+        return False
+    origin = getattr(sys.modules.get("mlx.core"), "__file__", "") or ""
+    return "mlx_simulation" not in origin
+
+
+if not _real_mlx_runtime():
+    pytest.skip("needs the real mlx runtime", allow_module_level=True)
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.tuner.lora import LoRALinear
+
+from unsloth_zoo.mlx.qat import (
+    apply_mlx_qat,
+    mlx_qat_module_count,
+    remove_mlx_qat,
+)
+
+DIMS = 128
+GROUP_SIZE = 64
+BITS = 4
+
+
+class _Holder(nn.Module):
+    """Minimal container exposing named_modules() over one LoRA layer."""
+
+    def __init__(self, layer):
+        super().__init__()
+        self.layer = layer
+
+
+def _make_lora(bias=False, bits=BITS, dropout=0.0, quantized=True, seed=0):
+    mx.random.seed(seed)
+    base = nn.Linear(DIMS, DIMS, bias=bias)
+    if quantized:
+        base = nn.QuantizedLinear.from_linear(
+            base, group_size=GROUP_SIZE, bits=bits, mode="affine",
+        )
+    layer = LoRALinear.from_base(base, r=8, scale=2.0, dropout=dropout)
+    # lora_b initialises to zeros; a zero delta would make the merge trivial.
+    layer.lora_b = mx.random.normal(layer.lora_b.shape) * 0.05
+    mx.eval(layer.lora_b, layer.lora_a)
+    return layer
+
+
+# --------------------------------------------------------------------------
+# Parity with the artifact that actually ships
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bias", [False, True])
+def test_qat_forward_matches_fused_module(bias):
+    """QAT's forward must equal the module `merged_4bit` writes to disk.
+
+    Expectations come from the real `fuse(dequantize=False)`, not from
+    re-deriving `quantize(dequantize(W) + BA)` in the test.
+    """
+    layer = _make_lora(bias=bias)
+    fused = layer.fuse(dequantize=False)
+
+    apply_mlx_qat(_Holder(layer), "auto")
+
+    x = mx.random.normal((4, DIMS), dtype=mx.float32)
+    qat_out, fused_out = layer(x), fused(x)
+    mx.eval(qat_out, fused_out)
+
+    # Residual is the dense-dequantised matmul vs quantized_matmul difference.
+    max_delta = float(mx.abs(qat_out - fused_out).max())
+    scale = float(mx.abs(fused_out).max())
+    assert max_delta <= 1e-4 * max(scale, 1.0), (
+        f"QAT forward diverges from fuse(): max|d|={max_delta}"
+    )
+
+
+def test_qat_forward_includes_base_bias():
+    """A dropped bias term still 'runs' — it must be caught explicitly.
+
+    Regression guard: Qwen2/2.5 carry biases on q/k/v projections, and omitting
+    them shifts the loss without raising.
+    """
+    layer = _make_lora(bias=True)
+    base_bias = mx.array(layer.linear.bias)
+    assert float(mx.abs(base_bias).max()) > 0.0
+
+    apply_mlx_qat(_Holder(layer), "auto")
+    x = mx.zeros((1, DIMS), dtype=mx.float32)
+    out = layer(x)
+    mx.eval(out)
+    # With a zero input the output is exactly the bias.
+    assert float(mx.abs(out[0] - base_bias).max()) <= 1e-5
+
+
+def test_qat_perturbs_the_forward():
+    """Sanity: QAT must actually change the forward, else parity is vacuous."""
+    layer = _make_lora()
+    x = mx.random.normal((4, DIMS), dtype=mx.float32)
+    before = layer(x)
+    mx.eval(before)
+
+    apply_mlx_qat(_Holder(layer), "auto")
+    after = layer(x)
+    mx.eval(after)
+    assert float(mx.abs(before - after).max()) > 1e-4
+
+
+# --------------------------------------------------------------------------
+# Straight-through estimator
+# --------------------------------------------------------------------------
+
+def test_straight_through_jacobian_is_identity():
+    """The fake-quant must be transparent to the backward pass.
+
+    The guarantee is on the *Jacobian* of the STE expression: d/dw of
+    `w + stop_gradient(quant(w) - w)` is 1. Note this is not the same as the
+    downstream loss gradient matching an unquantized run — that one is
+    evaluated at the fake-quantized value and legitimately differs by the
+    quantization error, which is exactly the signal QAT trains against.
+    """
+    weight = mx.random.normal((DIMS, DIMS))
+
+    def ste_sum(w):
+        packed, scales, biases = mx.quantize(
+            w, group_size=GROUP_SIZE, bits=BITS, mode="affine")
+        fake = mx.dequantize(
+            packed, scales, biases,
+            group_size=GROUP_SIZE, bits=BITS, mode="affine")
+        return (w + mx.stop_gradient(fake - w)).sum()
+
+    grad = mx.grad(ste_sum)(weight)
+    mx.eval(grad)
+    assert float(mx.abs(grad - mx.ones_like(grad)).max()) <= 1e-6
+
+    # And the forward really is the quantized value, not a pass-through.
+    packed, scales, biases = mx.quantize(
+        weight, group_size=GROUP_SIZE, bits=BITS, mode="affine")
+    fake = mx.dequantize(
+        packed, scales, biases,
+        group_size=GROUP_SIZE, bits=BITS, mode="affine")
+    mx.eval(fake)
+    assert float(mx.abs(fake - weight).max()) > 0.0
+
+
+def test_gradients_reach_lora_parameters_under_qat():
+    layer = _make_lora()
+    apply_mlx_qat(_Holder(layer), "auto")
+    x = mx.random.normal((4, DIMS), dtype=mx.float32)
+
+    def loss(a, b):
+        layer.lora_a, layer.lora_b = a, b
+        return (layer(x) ** 2).sum()
+
+    ga, gb = mx.grad(loss, argnums=(0, 1))(layer.lora_a, layer.lora_b)
+    mx.eval(ga, gb)
+    assert float(mx.abs(ga).max()) > 0.0
+    assert float(mx.abs(gb).max()) > 0.0
+
+
+# --------------------------------------------------------------------------
+# Apply / remove lifecycle
+# --------------------------------------------------------------------------
+
+def test_apply_is_idempotent_and_removable():
+    layer = _make_lora()
+    holder = _Holder(layer)
+    x = mx.random.normal((4, DIMS), dtype=mx.float32)
+    stock = layer(x)
+    mx.eval(stock)
+
+    assert apply_mlx_qat(holder, "auto") == 1
+    assert apply_mlx_qat(holder, "auto") == 0      # already patched
+    assert mlx_qat_module_count(holder) == 1
+
+    assert remove_mlx_qat(holder) == 1
+    assert mlx_qat_module_count(holder) == 0
+    restored = layer(x)
+    mx.eval(restored)
+    assert float(mx.abs(stock - restored).max()) == 0.0
+
+
+def test_qat_preserves_class_name():
+    """The save path keys on type(module).__name__; the stand-in must match."""
+    layer = _make_lora()
+    original_name = type(layer).__name__
+    apply_mlx_qat(_Holder(layer), "auto")
+    assert type(layer).__name__ == original_name
+    assert isinstance(layer, LoRALinear)
+
+
+# --------------------------------------------------------------------------
+# Guards
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "scheme", ["int8-int4", "fp8-int4", "fp8-fp8", "cactus"])
+def test_torchao_only_schemes_are_rejected(scheme):
+    layer = _make_lora()
+    with pytest.raises(NotImplementedError, match="torchao"):
+        apply_mlx_qat(_Holder(layer), scheme)
+
+
+def test_unknown_scheme_is_rejected():
+    layer = _make_lora()
+    with pytest.raises(ValueError, match="unsupported qat_scheme"):
+        apply_mlx_qat(_Holder(layer), "int3")
+
+
+def test_non_string_scheme_is_rejected():
+    layer = _make_lora()
+    with pytest.raises(TypeError):
+        apply_mlx_qat(_Holder(layer), 4)
+
+
+def test_scheme_bits_must_match_the_base_quantization():
+    """int8 QAT on a 4-bit base would simulate a grid fuse() never writes."""
+    layer = _make_lora(bits=4)
+    with pytest.raises(ValueError, match="8-bit"):
+        apply_mlx_qat(_Holder(layer), "int8")
+
+
+def test_matching_scheme_bits_are_accepted():
+    layer = _make_lora(bits=4)
+    assert apply_mlx_qat(_Holder(layer), "int4") == 1
+
+
+def test_unquantized_base_is_rejected():
+    layer = _make_lora(quantized=False)
+    with pytest.raises(ValueError, match="requires a quantized base"):
+        apply_mlx_qat(_Holder(layer), "auto")
+
+
+def test_lora_dropout_is_rejected():
+    layer = _make_lora(dropout=0.1)
+    with pytest.raises(NotImplementedError, match="lora_dropout=0"):
+        apply_mlx_qat(_Holder(layer), "auto")
+
+
+def test_model_without_lora_is_rejected():
+    holder = _Holder(nn.Linear(DIMS, DIMS))
+    with pytest.raises(ValueError, match="no LoRA layers"):
+        apply_mlx_qat(holder, "auto")
+
+
+def test_mixed_quantization_grids_are_rejected():
+    class _Two(nn.Module):
+        def __init__(self, a, b):
+            super().__init__()
+            self.a, self.b = a, b
+
+    holder = _Two(_make_lora(bits=4, seed=0), _make_lora(bits=8, seed=1))
+    with pytest.raises(ValueError, match="single quantization grid"):
+        apply_mlx_qat(holder, "auto")
+
+
+def test_full_finetuning_is_rejected():
+    holder = _Holder(_make_lora())
+    holder._unsloth_full_finetuning = True
+    with pytest.raises(NotImplementedError, match="full_finetuning"):
+        apply_mlx_qat(holder, "auto")
+
+
+def test_dora_is_rejected():
+    dora = pytest.importorskip("mlx_lm.tuner.dora")
+    base = nn.QuantizedLinear.from_linear(
+        nn.Linear(DIMS, DIMS, bias=False),
+        group_size=GROUP_SIZE, bits=BITS, mode="affine")
+    layer = dora.DoRALinear.from_base(base, r=8, scale=2.0)
+    with pytest.raises(NotImplementedError, match="DoRA"):
+        apply_mlx_qat(_Holder(layer), "auto")
+
+
+def test_switch_linear_moe_is_rejected():
+    switch_layers = pytest.importorskip("mlx_lm.models.switch_layers")
+    from mlx_lm.tuner.lora import LoRASwitchLinear
+
+    base = switch_layers.SwitchLinear(DIMS, DIMS, num_experts=2, bias=False)
+    base = base.to_quantized(group_size=GROUP_SIZE, bits=BITS, mode="affine")
+    layer = LoRASwitchLinear.from_base(base, r=8, scale=2.0)
+    with pytest.raises(NotImplementedError, match="MoE|SwitchLinear"):
+        apply_mlx_qat(_Holder(layer), "auto")

--- a/tests/test_mlx_qat.py
+++ b/tests/test_mlx_qat.py
@@ -299,6 +299,24 @@ def test_full_finetuning_is_rejected():
         apply_mlx_qat(holder, "auto")
 
 
+def test_non_affine_quantized_base_is_rejected():
+    """mxfp4/nvfp4/mxfp8 bases must be refused, not crash inside the forward.
+
+    ``mx.quantize`` returns only ``(packed, scales)`` for those modes -- no
+    biases -- so the affine three-value unpack in the QAT forward would raise
+    a bare unpacking error partway through training.
+    """
+    base = nn.Linear(DIMS, DIMS, bias=False)
+    quantized = nn.QuantizedLinear.from_linear(
+        base, group_size=32, bits=4, mode="mxfp4")
+    assert quantized.mode == "mxfp4"
+    assert quantized.biases is None, "mxfp4 unexpectedly produced biases"
+
+    layer = LoRALinear.from_base(quantized, r=8, scale=2.0)
+    with pytest.raises(NotImplementedError, match="mxfp4"):
+        apply_mlx_qat(_Holder(layer), "auto")
+
+
 def test_dora_is_rejected():
     dora = pytest.importorskip("mlx_lm.tuner.dora")
     base = nn.QuantizedLinear.from_linear(

--- a/tests/test_mlx_qat_integration_metal.py
+++ b/tests/test_mlx_qat_integration_metal.py
@@ -200,21 +200,57 @@ def test_full_finetuning_request_is_not_silently_dropped():
     assert mlx_qat_module_count(model) == 0
 
 
-def test_rejected_request_leaves_the_model_unmutated():
-    """A refused QAT request must not install LoRA first and raise after."""
+def _lora_layers_installed(model):
     from mlx_lm.tuner.lora import LoRALinear
+    return sum(
+        1 for _, module in model.named_modules()
+        if isinstance(module, LoRALinear)
+    )
 
+
+def test_dropout_refusal_leaves_the_model_unmutated():
+    """A refused QAT request must not install LoRA first and raise after."""
     model, _ = FastMLXModel.from_pretrained(MODEL, max_seq_length=64)
     with pytest.raises(NotImplementedError, match="lora_dropout=0"):
         FastMLXModel.get_peft_model(
             model, r=8, lora_alpha=16, lora_dropout=0.1,
             qat_scheme="auto", use_gradient_checkpointing=False,
         )
-    installed = sum(
-        1 for _, module in model.named_modules()
-        if isinstance(module, LoRALinear)
-    )
+    installed = _lora_layers_installed(model)
     assert installed == 0, f"{installed} LoRA layers left behind after refusal"
+
+
+def test_unquantized_base_refusal_leaves_the_model_unmutated():
+    """Same guarantee for the unquantized-base refusal.
+
+    Whether the base is quantized is knowable before any adapter exists, so
+    refusing after installing and freezing 100+ LoRA layers would leave a
+    caller who catches the error with a mutated model.
+    """
+    from mlx.utils import tree_flatten
+
+    model, _ = FastMLXModel.from_pretrained(
+        "Qwen/Qwen2.5-0.5B-Instruct", max_seq_length=64,
+        load_in_16bit=True, load_in_4bit=False,
+    )
+
+    def trainable_size():
+        return sum(v.size for _, v in tree_flatten(model.trainable_parameters()))
+
+    # A freshly loaded model has everything trainable; get_peft_model is what
+    # freezes. So "unmutated" means unchanged, not zero.
+    before = trainable_size()
+    with pytest.raises(ValueError, match="requires a quantized base"):
+        FastMLXModel.get_peft_model(
+            model, r=8, lora_alpha=16, lora_dropout=0,
+            qat_scheme="auto", use_gradient_checkpointing=False,
+        )
+    installed = _lora_layers_installed(model)
+    assert installed == 0, f"{installed} LoRA layers left behind after refusal"
+    assert trainable_size() == before, (
+        f"trainability changed by the failed call: {before:,} -> "
+        f"{trainable_size():,}"
+    )
 
 
 def test_vlm_is_gated_off():

--- a/tests/test_mlx_qat_integration_metal.py
+++ b/tests/test_mlx_qat_integration_metal.py
@@ -182,6 +182,41 @@ def test_qat_runs_through_mlx_trainer():
     assert mlx_qat_module_count(model) == patched
 
 
+def test_full_finetuning_request_is_not_silently_dropped():
+    """Every guard must be reachable through the public entry point.
+
+    get_peft_model returns at its full_finetuning branch before the QAT hook,
+    so a guard that only lived inside apply_mlx_qat was unreachable here and
+    the request was silently ignored -- the model trained with no QAT at all
+    and nothing said so.
+    """
+    from unsloth_zoo.mlx.qat import mlx_qat_module_count
+
+    model, _ = FastMLXModel.from_pretrained(
+        "Qwen/Qwen2.5-0.5B-Instruct", max_seq_length=64, full_finetuning=True)
+    with pytest.raises(NotImplementedError, match="full_finetuning"):
+        FastMLXModel.get_peft_model(
+            model, r=8, lora_alpha=16, qat_scheme="auto")
+    assert mlx_qat_module_count(model) == 0
+
+
+def test_rejected_request_leaves_the_model_unmutated():
+    """A refused QAT request must not install LoRA first and raise after."""
+    from mlx_lm.tuner.lora import LoRALinear
+
+    model, _ = FastMLXModel.from_pretrained(MODEL, max_seq_length=64)
+    with pytest.raises(NotImplementedError, match="lora_dropout=0"):
+        FastMLXModel.get_peft_model(
+            model, r=8, lora_alpha=16, lora_dropout=0.1,
+            qat_scheme="auto", use_gradient_checkpointing=False,
+        )
+    installed = sum(
+        1 for _, module in model.named_modules()
+        if isinstance(module, LoRALinear)
+    )
+    assert installed == 0, f"{installed} LoRA layers left behind after refusal"
+
+
 def test_vlm_is_gated_off():
     """VLMs are refused for now: the merge path is unvalidated, not broken.
 

--- a/tests/test_mlx_qat_integration_metal.py
+++ b/tests/test_mlx_qat_integration_metal.py
@@ -1,0 +1,251 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""QAT against the real product paths: merged_4bit save/reload, MLXTrainer, CPT.
+
+tests/test_mlx_qat.py proves the QAT forward matches ``LoRALinear.fuse()``.
+That is necessary but not sufficient: the shipped path is
+``save_pretrained_merged(save_method='merged_4bit')`` -> ``_fuse_mlx_module``
+-> ``save_model`` + config metadata -> reload. If anything in that chain
+differed, the fuse-level tests would still pass while the feature did nothing.
+These tests run the chain end to end on real Metal.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+
+from unsloth_zoo.mlx.loader import FastMLXModel
+from unsloth_zoo.mlx.qat import mlx_qat_module_count
+
+MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
+
+
+@pytest.fixture(autouse=True)
+def _require_real_metal():
+    import mlx.core as _mx
+    if not (getattr(_mx, "metal", None) and _mx.metal.is_available()
+            and _mx.default_device() == _mx.gpu):
+        pytest.skip("real Metal required; shim active or no GPU")
+
+
+def _ids():
+    return mx.array([[3, 11, 19, 27, 35, 43, 51, 59] * 4])
+
+
+def _loss(model, ids):
+    logits = model(ids).astype(mx.float32)
+    return nn.losses.cross_entropy(
+        logits[:, :-1].reshape(-1, logits.shape[-1]),
+        ids[:, 1:].reshape(-1),
+    ).mean()
+
+
+def _train_then_save_and_reload(qat, steps=15, save_method="merged_4bit"):
+    """Train briefly, save through the product path, reload, report losses."""
+    ids = _ids()
+    model, tokenizer = FastMLXModel.from_pretrained(MODEL, max_seq_length=64)
+    kwargs = {"qat_scheme": "auto"} if qat else {}
+    model = FastMLXModel.get_peft_model(
+        model, r=8, lora_alpha=16, lora_dropout=0,
+        use_gradient_checkpointing=False, **kwargs,
+    )
+    if qat:
+        assert mlx_qat_module_count(model) > 0, "qat_scheme did not patch anything"
+
+    optimizer = optim.Adam(learning_rate=1e-4)
+    step = nn.value_and_grad(model, lambda m: _loss(m, ids))
+    for _ in range(steps):
+        _, grads = step(model)
+        optimizer.update(model, grads)
+        mx.eval(model.parameters(), optimizer.state)
+
+    before = float(_loss(model, ids))
+    with tempfile.TemporaryDirectory() as directory:
+        model.save_pretrained_merged(directory, tokenizer, save_method=save_method)
+        reloaded, _ = FastMLXModel.from_pretrained(directory, max_seq_length=64)
+        after = float(_loss(reloaded, ids))
+    return before, after
+
+
+def test_qat_survives_the_merged_4bit_save_round_trip():
+    """The QAT forward must predict the reloaded model, not just fuse()."""
+    before, after = _train_then_save_and_reload(qat=True)
+    assert after == pytest.approx(before, abs=5e-3), (
+        f"QAT loss {before:.6f} did not survive merged_4bit save/reload "
+        f"({after:.6f}); QAT is simulating a different quantizer than the "
+        "one save_pretrained_merged writes"
+    )
+
+
+def test_qat_saved_model_beats_the_non_qat_saved_model():
+    """The comparison that ships: both saved and reloaded, QAT wins."""
+    base_before, base_after = _train_then_save_and_reload(qat=False)
+    qat_before, qat_after = _train_then_save_and_reload(qat=True)
+
+    # The non-QAT run must actually lose something, else there is nothing to fix.
+    assert base_after - base_before > 10 * (qat_after - qat_before), (
+        f"expected merged_4bit to degrade the non-QAT run "
+        f"({base_before:.6f} -> {base_after:.6f}) far more than the QAT run "
+        f"({qat_before:.6f} -> {qat_after:.6f})"
+    )
+    assert qat_after < base_after, (
+        f"QAT saved model ({qat_after:.6f}) should beat the non-QAT saved "
+        f"model ({base_after:.6f})"
+    )
+
+
+def test_save_method_lora_still_exports_adapters_under_qat():
+    """Adapter-only export must not be confused by the QAT subclass.
+
+    ``collect_mlx_lora_adapter_tensors`` keys on ``type(module).__name__``, so
+    the stand-in class has to keep the original name.
+    """
+    from unsloth_zoo.mlx.utils import collect_mlx_lora_adapter_tensors
+
+    model, tokenizer = FastMLXModel.from_pretrained(MODEL, max_seq_length=64)
+    model = FastMLXModel.get_peft_model(
+        model, r=8, lora_alpha=16, lora_dropout=0,
+        qat_scheme="auto", use_gradient_checkpointing=False,
+    )
+    tensors = collect_mlx_lora_adapter_tensors(model)
+    assert tensors, "no adapter tensors collected while QAT was active"
+    assert any("lora_a" in k for k in tensors)
+    assert any("lora_b" in k for k in tensors)
+
+    with tempfile.TemporaryDirectory() as directory:
+        model.save_pretrained_merged(directory, tokenizer, save_method="lora")
+        import os
+        assert any(f.endswith(".safetensors") for f in os.listdir(directory))
+
+
+def test_qat_runs_through_mlx_trainer():
+    """The trainer adds mx.compile and the shape guard on top of the forward."""
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    model, tokenizer = FastMLXModel.from_pretrained(MODEL, max_seq_length=128)
+    model = FastMLXModel.get_peft_model(
+        model, r=8, lora_alpha=16, lora_dropout=0, qat_scheme="auto",
+    )
+    patched = mlx_qat_module_count(model)
+    assert patched > 0
+
+    with tempfile.TemporaryDirectory() as directory:
+        trainer = MLXTrainer(
+            model=model,
+            tokenizer=tokenizer,
+            train_dataset=[
+                {"text": f"### Question: what is {i} plus {i}?\n### Answer: {2 * i}."}
+                for i in range(16)
+            ],
+            args=MLXTrainingConfig(
+                per_device_train_batch_size=2,
+                gradient_accumulation_steps=1,
+                max_steps=6,
+                learning_rate=5e-4,
+                logging_steps=1,
+                output_dir=directory,
+                seed=3407,
+                report_to="none",
+            ),
+        )
+        trainer.train()
+
+    history = trainer._train_loss_history
+    assert len(history) >= 4, f"only {len(history)} logged losses"
+    assert all(loss == loss and abs(loss) != float("inf") for loss in history), (
+        f"non-finite losses under QAT: {history}"
+    )
+    # QAT must still be installed after training: a compile path that rebuilt
+    # the modules would silently drop the fake-quant.
+    assert mlx_qat_module_count(model) == patched
+
+
+def test_vlm_is_gated_off():
+    """VLMs are refused for now: the merge path is unvalidated, not broken.
+
+    All VLM LoRA layers (196 language + 64 vision tower with train_vision=True
+    on Qwen2-VL-2B) are the same LoRALinear-over-QuantizedLinear that QAT
+    handles, so this is a coverage gate. It exists so nobody gets an unverified
+    numeric claim; lifting it needs a VLM train -> merged_4bit -> reload check.
+    """
+    VLM = "mlx-community/Qwen2-VL-2B-Instruct-4bit"
+    model, _ = FastMLXModel.from_pretrained(VLM, max_seq_length=64)
+    with pytest.raises(NotImplementedError, match="VLM"):
+        FastMLXModel.get_peft_model(
+            model, r=8, lora_alpha=16, lora_dropout=0,
+            qat_scheme="auto", use_gradient_checkpointing=False,
+        )
+
+
+def test_qat_and_cpt_full_modules_are_mutually_exclusive():
+    """QAT + continued-pretraining full modules cannot co-occur, by construction.
+
+    CPT trains embed_tokens / lm_head as whole modules, which unsloth already
+    rejects on a quantized base (the CCE backward zeroes the grad of a
+    quantized weight). QAT in turn requires a quantized base -- there is
+    nothing to fake-quantize otherwise. So the combination is impossible from
+    both directions, and the user must get a clear error rather than a model
+    that silently trains nothing.
+    """
+    # Direction 1: quantized base -> CPT rejects (pre-existing guard, fires
+    # before QAT is reached).
+    model, _ = FastMLXModel.from_pretrained(MODEL, max_seq_length=64)
+    with pytest.raises(ValueError, match="quantized"):
+        FastMLXModel.get_peft_model(
+            model,
+            target_modules=["all-linear", "embed_tokens", "lm_head"],
+            r=8, lora_alpha=16, lora_dropout=0,
+            modules_to_save=["embed_tokens", "lm_head"],
+            qat_scheme="auto", use_gradient_checkpointing=False,
+        )
+
+    # Direction 2: an unquantized base is what CPT wants, and there QAT itself
+    # refuses, because merged_4bit would not requantize anything.
+    from unsloth_zoo.mlx.qat import apply_mlx_qat
+    plain, _ = FastMLXModel.from_pretrained(MODEL, max_seq_length=64)
+    plain = FastMLXModel.get_peft_model(
+        plain, r=8, lora_alpha=16, lora_dropout=0,
+        use_gradient_checkpointing=False,
+    )
+    # Strip the quantization from the LoRA bases, then confirm QAT declines
+    # rather than silently doing nothing.
+    import mlx.nn as _nn
+    from mlx_lm.tuner.lora import LoRALinear
+    for _, module in plain.named_modules():
+        if isinstance(module, LoRALinear) and isinstance(
+                module.linear, _nn.QuantizedLinear):
+            dq = _nn.Linear(
+                module.linear.weight.shape[1] * 32 // module.linear.bits,
+                module.linear.weight.shape[0],
+                bias="bias" in module.linear,
+            )
+            dq.weight = mx.dequantize(
+                module.linear.weight, module.linear.scales, module.linear.biases,
+                group_size=module.linear.group_size, bits=module.linear.bits,
+                mode=module.linear.mode,
+            )
+            module.linear = dq
+    with pytest.raises(ValueError, match="requires a quantized base"):
+        apply_mlx_qat(plain, "auto")

--- a/tests/test_mlx_qat_integration_metal.py
+++ b/tests/test_mlx_qat_integration_metal.py
@@ -40,6 +40,8 @@ from unsloth_zoo.mlx.loader import FastMLXModel
 from unsloth_zoo.mlx.qat import mlx_qat_module_count
 
 MODEL = "mlx-community/SmolLM-135M-Instruct-4bit"
+# Unquantized source, for the rejection cases that need one.
+FP_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
 
 
 @pytest.fixture(autouse=True)
@@ -62,9 +64,16 @@ def _loss(model, ids):
     ).mean()
 
 
-def _train_then_save_and_reload(qat, steps=15, save_method="merged_4bit"):
-    """Train briefly, save through the product path, reload, report losses."""
+def _train_then_save_and_reload(qat, steps=15, save_method="merged_4bit", seed=0):
+    """Train briefly, save through the product path, reload, report losses.
+
+    Seeds before loading so the QAT and non-QAT arms start from identical LoRA
+    initialisations. Without this the two calls run sequentially in one
+    process, inheriting whatever RNG state earlier tests left behind, and
+    "QAT's saved model is better" would be a claim about random init.
+    """
     ids = _ids()
+    mx.random.seed(seed)
     model, tokenizer = FastMLXModel.from_pretrained(MODEL, max_seq_length=64)
     kwargs = {"qat_scheme": "auto"} if qat else {}
     model = FastMLXModel.get_peft_model(
@@ -100,9 +109,12 @@ def test_qat_survives_the_merged_4bit_save_round_trip():
 
 
 def test_qat_saved_model_beats_the_non_qat_saved_model():
-    """The comparison that ships: both saved and reloaded, QAT wins."""
-    base_before, base_after = _train_then_save_and_reload(qat=False)
-    qat_before, qat_after = _train_then_save_and_reload(qat=True)
+    """The comparison that ships: both saved and reloaded, QAT wins.
+
+    Both arms are seeded identically so the only difference is QAT itself.
+    """
+    base_before, base_after = _train_then_save_and_reload(qat=False, seed=0)
+    qat_before, qat_after = _train_then_save_and_reload(qat=True, seed=0)
 
     # The non-QAT run must actually lose something, else there is nothing to fix.
     assert base_after - base_before > 10 * (qat_after - qat_before), (
@@ -208,49 +220,50 @@ def _lora_layers_installed(model):
     )
 
 
-def test_dropout_refusal_leaves_the_model_unmutated():
-    """A refused QAT request must not install LoRA first and raise after."""
-    model, _ = FastMLXModel.from_pretrained(MODEL, max_seq_length=64)
-    with pytest.raises(NotImplementedError, match="lora_dropout=0"):
-        FastMLXModel.get_peft_model(
-            model, r=8, lora_alpha=16, lora_dropout=0.1,
-            qat_scheme="auto", use_gradient_checkpointing=False,
-        )
-    installed = _lora_layers_installed(model)
-    assert installed == 0, f"{installed} LoRA layers left behind after refusal"
+# Every way a QAT request can be refused. The property under test is
+# structural: validation of the would-be LoRA targets happens before any of
+# them are replaced, so no rejection can leave adapters attached or
+# trainability changed. Parametrized rather than written out per case so a new
+# rejection added later without a preflight fails here.
+_REFUSAL_CASES = [
+    ("bit-width mismatch", MODEL, {}, {"lora_dropout": 0, "qat_scheme": "int8"}, ValueError),
+    ("lora_dropout > 0", MODEL, {}, {"lora_dropout": 0.1, "qat_scheme": "auto"}, NotImplementedError),
+    ("unquantized base", FP_MODEL, {"load_in_16bit": True, "load_in_4bit": False},
+     {"lora_dropout": 0, "qat_scheme": "auto"}, ValueError),
+    ("full_finetuning", FP_MODEL, {"full_finetuning": True}, {"qat_scheme": "auto"}, NotImplementedError),
+    ("torchao-only scheme", MODEL, {}, {"lora_dropout": 0, "qat_scheme": "fp8-fp8"}, NotImplementedError),
+    ("unknown scheme", MODEL, {}, {"lora_dropout": 0, "qat_scheme": "int3"}, ValueError),
+    ("non-string scheme", MODEL, {}, {"lora_dropout": 0, "qat_scheme": 4}, TypeError),
+]
 
 
-def test_unquantized_base_refusal_leaves_the_model_unmutated():
-    """Same guarantee for the unquantized-base refusal.
-
-    Whether the base is quantized is knowable before any adapter exists, so
-    refusing after installing and freezing 100+ LoRA layers would leave a
-    caller who catches the error with a mutated model.
-    """
+@pytest.mark.parametrize(
+    "label,model_name,load_kwargs,peft_kwargs,expected",
+    _REFUSAL_CASES,
+    ids=[case[0] for case in _REFUSAL_CASES],
+)
+def test_refused_requests_leave_the_model_unmutated(
+    label, model_name, load_kwargs, peft_kwargs, expected,
+):
     from mlx.utils import tree_flatten
 
     model, _ = FastMLXModel.from_pretrained(
-        "Qwen/Qwen2.5-0.5B-Instruct", max_seq_length=64,
-        load_in_16bit=True, load_in_4bit=False,
-    )
+        model_name, max_seq_length=64, **load_kwargs)
 
     def trainable_size():
         return sum(v.size for _, v in tree_flatten(model.trainable_parameters()))
 
-    # A freshly loaded model has everything trainable; get_peft_model is what
-    # freezes. So "unmutated" means unchanged, not zero.
+    # A freshly loaded model has everything trainable until get_peft_model
+    # freezes, so "unmutated" is unchanged-from-before, not zero.
     before = trainable_size()
-    with pytest.raises(ValueError, match="requires a quantized base"):
+    with pytest.raises(expected):
         FastMLXModel.get_peft_model(
-            model, r=8, lora_alpha=16, lora_dropout=0,
-            qat_scheme="auto", use_gradient_checkpointing=False,
+            model, r=8, lora_alpha=16,
+            use_gradient_checkpointing=False, **peft_kwargs,
         )
     installed = _lora_layers_installed(model)
-    assert installed == 0, f"{installed} LoRA layers left behind after refusal"
-    assert trainable_size() == before, (
-        f"trainability changed by the failed call: {before:,} -> "
-        f"{trainable_size():,}"
-    )
+    assert installed == 0, f"{label}: {installed} LoRA layers left behind"
+    assert trainable_size() == before, f"{label}: trainability changed"
 
 
 def test_vlm_is_gated_off():
@@ -318,5 +331,8 @@ def test_qat_and_cpt_full_modules_are_mutually_exclusive():
                 mode=module.linear.mode,
             )
             module.linear = dq
-    with pytest.raises(ValueError, match="requires a quantized base"):
+    # The model still holds quantized modules the LoRA targets do not cover
+    # (a quantized embedding), so the model-level backstop passes and the
+    # target-level check is what refuses -- naming the unquantized targets.
+    with pytest.raises(ValueError, match="quantized LoRA targets"):
         apply_mlx_qat(plain, "auto")

--- a/tests/test_mlx_qat_metal.py
+++ b/tests/test_mlx_qat_metal.py
@@ -1,0 +1,165 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""QAT efficacy on real Metal: does it actually improve the saved artifact?
+
+Everything else about QAT can pass while the feature does nothing useful. This
+trains the same model twice from one seed -- with and without QAT -- then runs
+the real `fuse(dequantize=False)` that `save_method='merged_4bit'` uses, and
+compares the losses of the two *saved* models.
+
+Measured on Qwen2.5-0.5B-Instruct-4bit / wikitext-2 (300 steps): the non-QAT
+run retained only 36% of its training gains through the save, while QAT
+retained ~100% and shipped a 0.13 nats better model. This test reproduces the
+mechanism on a synthetic stack small enough for CI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+
+def _real_mlx_runtime():
+    try:
+        lora = importlib.import_module("mlx_lm.tuner.lora")
+    except Exception:
+        return False
+    if not isinstance(getattr(lora, "LoRALinear", None), type):
+        return False
+    origin = getattr(sys.modules.get("mlx.core"), "__file__", "") or ""
+    return "mlx_simulation" not in origin
+
+
+if not _real_mlx_runtime():
+    pytest.skip("needs the real mlx runtime", allow_module_level=True)
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+from mlx_lm.tuner.lora import LoRALinear
+
+from unsloth_zoo.mlx.qat import apply_mlx_qat
+
+DIMS = 256
+GROUP_SIZE = 64
+BITS = 4
+N_LAYERS = 3
+# QAT's advantage widens with training (it trades a worse free-floating loss
+# for a lossless save), so a short run is genuinely marginal: at 120 steps the
+# saved-model margin was -0.00003 on one of four seeds. Measured minimum margin
+# across seeds 0-3: 120 steps -0.000030, 400 steps +0.001303, 900 +0.002600.
+STEPS = 400
+
+
+@pytest.fixture(autouse=True)
+def _require_real_metal():
+    import mlx.core as _mx
+    if not (getattr(_mx, "metal", None) and _mx.metal.is_available()
+            and _mx.default_device() == _mx.gpu):
+        pytest.skip("real Metal required; shim active or no GPU")
+
+
+class _Stack(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = [
+            LoRALinear.from_base(
+                nn.QuantizedLinear.from_linear(
+                    nn.Linear(DIMS, DIMS, bias=False),
+                    group_size=GROUP_SIZE, bits=BITS, mode="affine",
+                ),
+                r=16, scale=2.0,
+            )
+            for _ in range(N_LAYERS)
+        ]
+
+    def __call__(self, x):
+        for layer in self.layers:
+            x = mx.tanh(layer(x))
+        return x
+
+
+def _fuse_in_place(model):
+    from mlx.utils import tree_unflatten
+    fused = [
+        (name, module.fuse(dequantize=False))
+        for name, module in model.named_modules()
+        if hasattr(module, "fuse")
+    ]
+    model.update_modules(tree_unflatten(fused))
+    return model
+
+
+def _run(use_qat, seed=0):
+    mx.random.seed(seed)
+    model = _Stack()
+    mx.random.seed(1234)
+    xs = mx.random.normal((32, DIMS))
+    target = mx.tanh(mx.random.normal((32, DIMS)) * 0.5)
+    mx.eval(xs, target)
+
+    if use_qat:
+        apply_mlx_qat(model, "auto")
+
+    model.freeze()
+    model.unfreeze(keys=["lora_a", "lora_b"], strict=False)
+
+    def loss_fn(m):
+        return ((m(xs) - target) ** 2).mean()
+
+    opt = optim.Adam(learning_rate=3e-3)
+    step = nn.value_and_grad(model, loss_fn)
+    for _ in range(STEPS):
+        _, grads = step(model)
+        opt.update(model, grads)
+        mx.eval(model.parameters(), opt.state)
+
+    pre = float(loss_fn(model))
+    _fuse_in_place(model)
+    post = float(((model(xs) - target) ** 2).mean())
+    return pre, post
+
+
+@pytest.mark.parametrize("seed", [0, 1])
+def test_qat_removes_post_fuse_degradation_and_improves_the_saved_model(seed):
+    base_pre, base_post = _run(use_qat=False, seed=seed)
+    qat_pre, qat_post = _run(use_qat=True, seed=seed)
+
+    base_degradation = base_post - base_pre
+    qat_degradation = qat_post - qat_pre
+
+    # 1. There is a problem to solve: fusing hurts the non-QAT run.
+    assert base_degradation > 0, (
+        "expected merged_4bit fusing to degrade a non-QAT run; got "
+        f"{base_degradation:+.6f}"
+    )
+
+    # 2. QAT closes the train/deploy gap -- its own fuse is near lossless.
+    assert abs(qat_degradation) < base_degradation / 10, (
+        f"QAT degradation {qat_degradation:+.6f} should be far below the "
+        f"baseline's {base_degradation:+.6f}"
+    )
+
+    # 3. The only comparison that ships: QAT's saved model is better.
+    assert qat_post < base_post, (
+        f"QAT post-fuse loss {qat_post:.6f} should beat baseline "
+        f"{base_post:.6f}"
+    )

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -7530,10 +7530,6 @@ class FastMLXModel:
                 "Unsloth: loftq_config is not supported for MLX LoRA yet."
             )
         qat_scheme = kwargs.pop("qat_scheme", None)
-        if qat_scheme is not None:
-            raise NotImplementedError(
-                "Unsloth: qat_scheme is not supported for MLX LoRA yet."
-            )
         if bias not in (None, False, "none"):
             print(
                 "Unsloth: bias is not supported for MLX LoRA yet - "
@@ -7812,6 +7808,14 @@ class FastMLXModel:
             _unfreeze_full_modules(_cpt_full_specs)
 
         _apply_mlx_lora_initialization(model, init_lora_weights)
+
+        # QAT after the adapters exist, matching the CUDA ordering (QAT is
+        # applied after _get_peft_model there too). It fake-quantizes the
+        # merged weight so training sees the grid that merged_4bit's fuse()
+        # will write.
+        if qat_scheme is not None and qat_scheme is not False:
+            from .qat import apply_mlx_qat
+            apply_mlx_qat(model, qat_scheme)
 
         # Gradient checkpointing: "mlx"/True -> apply; False/"none" -> skip.
         if isinstance(use_gradient_checkpointing, str):

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -7530,6 +7530,16 @@ class FastMLXModel:
                 "Unsloth: loftq_config is not supported for MLX LoRA yet."
             )
         qat_scheme = kwargs.pop("qat_scheme", None)
+        if qat_scheme is not None and qat_scheme is not False:
+            # Validate before the full_finetuning early return below and before
+            # any LoRA is installed. full_finetuning returns from this function
+            # without ever reaching the apply hook, so a guard that only lived
+            # there would let the request be dropped silently; the other
+            # rejections would raise only after the model had been mutated.
+            from .qat import validate_mlx_qat_request
+            validate_mlx_qat_request(
+                model, qat_scheme, lora_dropout=lora_dropout,
+            )
         if bias not in (None, False, "none"):
             print(
                 "Unsloth: bias is not supported for MLX LoRA yet - "

--- a/unsloth_zoo/mlx/loader.py
+++ b/unsloth_zoo/mlx/loader.py
@@ -298,43 +298,49 @@ def _mlx_language_layers(model):
     return model.model.layers
 
 
+def mlx_lora_target_groups(model, num_layers, keys):
+    """``[(container, [(name, module), ...])]`` that LoRA would wrap.
+
+    Single source of truth for target selection. ``linear_to_lora_layers``
+    replaces exactly these modules, and the QAT preflight validates exactly
+    these modules before any of them are replaced, so the two cannot drift
+    apart and let a rejection fire only after the model has been mutated.
+    """
+    layers = _mlx_language_layers(model)
+    keys = set(keys or ())
+    limit = max(int(num_layers), 0)
+
+    groups = []
+    for layer in layers[max(len(layers) - limit, 0):]:
+        picked = [(name, module) for name, module in layer.named_modules()
+                  if name in keys]
+        if picked:
+            groups.append((layer, picked))
+
+    # Root-module pass: a head named in `keys` sits beside the layers, so the
+    # layer walk above never reaches it.
+    root = [(name, module) for name, module in model.named_modules()
+            if name in keys]
+    if root:
+        groups.append((model, root))
+    return groups
+
+
 def linear_to_lora_layers(model, num_layers, config):
     """Attach namespace-compatible LoRA wrappers to selected language layers."""
     from mlx.utils import tree_unflatten
 
-    layers = _mlx_language_layers(model)
     type_specs = _mlx_lora_type_specs()
-    keys = set(config.get("keys") or ())
-
-    limit = max(int(num_layers), 0)
     attached = 0
-    for layer in layers[max(len(layers) - limit, 0):]:
-        replacements = []
-        for name, module in layer.named_modules():
-            if name not in keys:
-                continue
-            replacements.append((
-                name,
-                _mlx_lora_from_base(
-                    module,
-                    config,
-                    specs=type_specs,
-                ),
-            ))
-        if replacements:
-            layer.update_modules(tree_unflatten(replacements))
-            attached += len(replacements)
-
-    # Root-module pass: a head named in `keys` sits beside the layers, so the
-    # layer walk above never reaches it.
-    root_replacements = [
-        (name, _mlx_lora_from_base(module, config, specs=type_specs))
-        for name, module in model.named_modules()
-        if name in keys
-    ]
-    if root_replacements:
-        model.update_modules(tree_unflatten(root_replacements))
-        attached += len(root_replacements)
+    for container, picked in mlx_lora_target_groups(
+        model, num_layers, config.get("keys"),
+    ):
+        replacements = [
+            (name, _mlx_lora_from_base(module, config, specs=type_specs))
+            for name, module in picked
+        ]
+        container.update_modules(tree_unflatten(replacements))
+        attached += len(replacements)
 
     return attached
 
@@ -7789,6 +7795,23 @@ class FastMLXModel:
                     language_lora_keys is None or len(language_lora_keys) > 0
                 )
             if _apply_layer_lora:
+                if qat_scheme is not None and qat_scheme is not False:
+                    # Validate the exact modules LoRA is about to wrap, while
+                    # the model is still untouched. Every QAT rejection that
+                    # depends on the targets (unquantized base, mixed grids,
+                    # non-affine mode, bit-width mismatch) therefore fires
+                    # before any adapter is installed or anything is frozen.
+                    from .qat import validate_mlx_qat_target_modules
+                    validate_mlx_qat_target_modules(
+                        [
+                            (name, module)
+                            for _container, picked in mlx_lora_target_groups(
+                                model, num_layers, language_lora_keys,
+                            )
+                            for name, module in picked
+                        ],
+                        qat_scheme,
+                    )
                 # Compat patch (older mlx-lm rejects scale=/dropout= on
                 # from_base); before the seed since monkey-patching doesn't
                 # advance mx.random.

--- a/unsloth_zoo/mlx/qat.py
+++ b/unsloth_zoo/mlx/qat.py
@@ -46,6 +46,7 @@ __all__ = (
     "SUPPORTED_MLX_QAT_SCHEMES",
     "TORCHAO_ONLY_QAT_SCHEMES",
     "validate_mlx_qat_request",
+    "validate_mlx_qat_target_modules",
     "apply_mlx_qat",
     "remove_mlx_qat",
     "mlx_qat_module_count",
@@ -103,6 +104,90 @@ def _model_has_quantized_module(model):
     return any(
         isinstance(module, quantized_types)
         for _, module in model.named_modules()
+    )
+
+
+def _quantization_grid(module):
+    """``(group_size, bits, mode)`` for a quantized base module.
+
+    ``mode`` is defaulted rather than read directly: published mlx-community
+    configs omit the key, and older quantized layers predate the attribute.
+    """
+    return (
+        module.group_size,
+        module.bits,
+        getattr(module, "mode", None) or "affine",
+    )
+
+
+def _validate_qat_base_modules(named_bases, requested_bits):
+    """Grid rules for the modules QAT will fake-quantize.
+
+    Single source of truth, called both by the preflight (against the modules
+    LoRA is *about* to wrap) and by the post-LoRA pass (against the modules it
+    actually wrapped), so the two cannot disagree about what is acceptable.
+
+    Returns the agreed ``(group_size, bits, mode)``.
+    """
+    import mlx.nn as nn
+
+    if not named_bases:
+        raise ValueError(
+            "Unsloth: qat_scheme was requested but no LoRA targets were "
+            "resolved, so there is nothing for QAT to fake-quantize. Check "
+            "target_modules / finetune_language_layers."
+        )
+
+    unquantized = [name for name, module in named_bases
+                   if not isinstance(module, nn.QuantizedLinear)]
+    if unquantized:
+        raise ValueError(
+            "Unsloth: qat_scheme requires quantized LoRA targets — "
+            f"{len(unquantized)} target(s) are unquantized "
+            f"({_preview(unquantized)}), so save_method='merged_4bit' would "
+            "not requantize them and there is no quantization for QAT to "
+            "simulate. Load with load_in_4bit=True (or a pre-quantized "
+            "-4bit/-8bit repo) to use QAT."
+        )
+
+    grids = {_quantization_grid(module) for _, module in named_bases}
+    if len(grids) != 1:
+        raise ValueError(
+            "Unsloth: qat_scheme requires a single quantization grid across "
+            f"all LoRA targets, found {sorted(grids)}."
+        )
+    group_size, bits, mode = next(iter(grids))
+
+    # Only the affine grid round-trips through the three-value
+    # quantize/dequantize the QAT forward uses: mx.quantize returns just
+    # (packed, scales) for mxfp4/nvfp4/mxfp8, and those grids need different
+    # fake-quant maths anyway.
+    if mode != "affine":
+        raise NotImplementedError(
+            f"Unsloth: qat_scheme is not supported for {mode!r}-quantized "
+            "bases on MLX yet — only the affine grid is implemented. Load the "
+            "model with load_in_4bit=True (affine) to use QAT."
+        )
+
+    if requested_bits is not None and requested_bits != bits:
+        raise ValueError(
+            f"Unsloth: qat_scheme requests {requested_bits}-bit weights but "
+            f"the LoRA targets are quantized to {bits}-bit. QAT must simulate "
+            "the grid that save_method='merged_4bit' will actually write. Use "
+            "qat_scheme='auto' to inherit the base quantization."
+        )
+    return group_size, bits, mode
+
+
+def validate_mlx_qat_target_modules(named_bases, qat_scheme="auto"):
+    """Validate the base modules LoRA is about to wrap, before it wraps them.
+
+    ``named_bases`` must be the exact ``(name, module)`` set that
+    ``linear_to_lora_layers`` will replace, so that every rejection happens
+    while the model is still untouched.
+    """
+    return _validate_qat_base_modules(
+        list(named_bases), _resolve_qat_bits(qat_scheme),
     )
 
 
@@ -200,12 +285,17 @@ def _resolve_qat_bits(qat_scheme):
 
 
 def _qat_targets(model):
-    """Split LoRA modules into (patchable, dora, switch, unquantized)."""
+    """Split LoRA modules into ``(patchable, dora, switch, lora_wrapped)``.
+
+    ``lora_wrapped`` is every plain LoRA layer regardless of whether its base
+    is quantized, so the shared grid validator can name the unquantized ones;
+    ``patchable`` is the quantized subset actually eligible for patching.
+    """
     import mlx.nn as nn
 
     lora_linear_type, dora_types, switch_types = _lora_layer_types()
 
-    patchable, dora, switch, unquantized = [], [], [], []
+    patchable, dora, switch, lora_wrapped = [], [], [], []
     for name, module in model.named_modules():
         if dora_types and isinstance(module, dora_types):
             dora.append(name)
@@ -215,12 +305,10 @@ def _qat_targets(model):
             continue
         if not isinstance(module, lora_linear_type):
             continue
-        base = getattr(module, "linear", None)
-        if isinstance(base, nn.QuantizedLinear):
+        lora_wrapped.append((name, module))
+        if isinstance(getattr(module, "linear", None), nn.QuantizedLinear):
             patchable.append((name, module))
-        else:
-            unquantized.append(name)
-    return patchable, dora, switch, unquantized
+    return patchable, dora, switch, lora_wrapped
 
 
 def _preview(names, limit=3):
@@ -272,9 +360,10 @@ def validate_mlx_qat_request(model, qat_scheme="auto", *, lora_dropout=None):
             f"LoRA activation path for dropout to act on (got {lora_dropout})."
         )
 
-    # Checkable before adapters exist, so it belongs here rather than in the
-    # post-LoRA pass: otherwise get_peft_model installs and freezes 100+ LoRA
-    # layers and only then refuses, leaving a mutated model behind.
+    # Cheap model-level backstop. The authoritative check is
+    # validate_mlx_qat_target_modules, run against the exact modules LoRA is
+    # about to wrap; this only catches the "nothing here is quantized at all"
+    # case for callers that never reach that path.
     if not _model_has_quantized_module(model):
         raise ValueError(
             "Unsloth: qat_scheme requires a quantized base model — nothing in "
@@ -303,7 +392,7 @@ def apply_mlx_qat(model, qat_scheme="auto"):
     # directly, not only through get_peft_model.
     requested_bits = validate_mlx_qat_request(model, qat_scheme)
 
-    patchable, dora, switch, unquantized = _qat_targets(model)
+    patchable, dora, switch, lora_wrapped = _qat_targets(model)
 
     if dora:
         raise NotImplementedError(
@@ -318,50 +407,18 @@ def apply_mlx_qat(model, qat_scheme="auto"):
             "experts on MLX yet — their fuse() merges a 3-D per-expert weight "
             f"with a different delta layout. Affected: {_preview(switch)}."
         )
-    if not patchable:
-        if unquantized:
-            raise ValueError(
-                "Unsloth: qat_scheme requires a quantized base model. The LoRA "
-                f"layers wrap unquantized modules ({_preview(unquantized)}), so "
-                "save_method='merged_4bit' would not requantize and there is no "
-                "quantization for QAT to simulate. Load with q_bits=4 (or a "
-                "pre-quantized -4bit/-8bit repo) to use QAT."
-            )
+    if not patchable and not lora_wrapped:
         raise ValueError(
             "Unsloth: qat_scheme was requested but the model has no LoRA "
             "layers. Call get_peft_model(...) with LoRA targets first."
         )
 
-    # Every layer must share one grid: the saved config records a single
-    # global quantization, and a mixed set cannot be expressed there.
-    grids = {
-        (m.linear.group_size, m.linear.bits, m.linear.mode) for _, m in patchable
-    }
-    if len(grids) != 1:
-        raise ValueError(
-            "Unsloth: qat_scheme requires a single quantization grid across all "
-            f"LoRA layers, found {sorted(grids)}."
-        )
-    group_size, bits, mode = next(iter(grids))
-
-    # Only the affine grid round-trips through the three-value
-    # quantize/dequantize used below: mx.quantize returns just (packed, scales)
-    # for mxfp4/nvfp4/mxfp8, and those grids need different fake-quant maths
-    # anyway. Reject explicitly rather than unpack-crash inside the forward.
-    if mode not in (None, "affine"):
-        raise NotImplementedError(
-            f"Unsloth: qat_scheme is not supported for {mode!r}-quantized "
-            "bases on MLX yet — only the affine grid is implemented. Load the "
-            "model with load_in_4bit=True (affine) to use QAT."
-        )
-
-    if requested_bits is not None and requested_bits != bits:
-        raise ValueError(
-            f"Unsloth: qat_scheme={qat_scheme!r} requests {requested_bits}-bit "
-            f"weights but the base model is quantized to {bits}-bit. QAT must "
-            "simulate the grid that save_method='merged_4bit' will actually "
-            "write. Use qat_scheme='auto' to inherit the base quantization."
-        )
+    # Same rules the preflight applied to the would-be targets, now applied to
+    # what LoRA actually wrapped. Shared so the two cannot diverge.
+    group_size, bits, mode = _validate_qat_base_modules(
+        [(name, module.linear) for name, module in lora_wrapped],
+        requested_bits,
+    )
 
     dropout_layers = [n for n, m in patchable if _dropout_probability(m) > 0.0]
     if dropout_layers:

--- a/unsloth_zoo/mlx/qat.py
+++ b/unsloth_zoo/mlx/qat.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 __all__ = (
     "SUPPORTED_MLX_QAT_SCHEMES",
     "TORCHAO_ONLY_QAT_SCHEMES",
+    "validate_mlx_qat_request",
     "apply_mlx_qat",
     "remove_mlx_qat",
     "mlx_qat_module_count",
@@ -207,17 +208,16 @@ def _preview(names, limit=3):
     return shown
 
 
-def apply_mlx_qat(model, qat_scheme="auto"):
-    """Fake-quantize the merged LoRA weight during training.
+def validate_mlx_qat_request(model, qat_scheme="auto", *, lora_dropout=None):
+    """Reject an unsupportable QAT request *before* anything is mutated.
 
-    Args:
-        model: an MLX model that already has LoRA layers attached.
-        qat_scheme: ``"auto"``/``True`` to inherit the base model's own
-            quantization, or ``"int4"`` / ``"int8"`` to additionally assert the
-            base was quantized to that width.
+    Everything checkable without adapters lives here so ``get_peft_model`` can
+    call it up front: otherwise a rejected request either raises after LoRA has
+    already been installed and trainability changed, or -- for
+    ``full_finetuning=True``, which returns before adapters are ever created --
+    is silently ignored.
 
-    Returns:
-        The number of LoRA modules placed under QAT.
+    Returns the requested bit width (``None`` means "inherit the base").
     """
     requested_bits = _resolve_qat_bits(qat_scheme)
 
@@ -242,6 +242,32 @@ def apply_mlx_qat(model, qat_scheme="auto"):
             "against save_method='merged_4bit'. Use a text-only model, or "
             "train the VLM without qat_scheme."
         )
+
+    if lora_dropout is not None and float(lora_dropout) > 0.0:
+        raise NotImplementedError(
+            "Unsloth: qat_scheme requires lora_dropout=0 on MLX. QAT folds the "
+            "adapter into the weight to match fuse(), which leaves no separate "
+            f"LoRA activation path for dropout to act on (got {lora_dropout})."
+        )
+
+    return requested_bits
+
+
+def apply_mlx_qat(model, qat_scheme="auto"):
+    """Fake-quantize the merged LoRA weight during training.
+
+    Args:
+        model: an MLX model that already has LoRA layers attached.
+        qat_scheme: ``"auto"``/``True`` to inherit the base model's own
+            quantization, or ``"int4"`` / ``"int8"`` to additionally assert the
+            base was quantized to that width.
+
+    Returns:
+        The number of LoRA modules placed under QAT.
+    """
+    # Re-run the pre-mutation checks: apply_mlx_qat is public and may be called
+    # directly, not only through get_peft_model.
+    requested_bits = validate_mlx_qat_request(model, qat_scheme)
 
     patchable, dora, switch, unquantized = _qat_targets(model)
 
@@ -283,6 +309,17 @@ def apply_mlx_qat(model, qat_scheme="auto"):
             f"LoRA layers, found {sorted(grids)}."
         )
     group_size, bits, mode = next(iter(grids))
+
+    # Only the affine grid round-trips through the three-value
+    # quantize/dequantize used below: mx.quantize returns just (packed, scales)
+    # for mxfp4/nvfp4/mxfp8, and those grids need different fake-quant maths
+    # anyway. Reject explicitly rather than unpack-crash inside the forward.
+    if mode not in (None, "affine"):
+        raise NotImplementedError(
+            f"Unsloth: qat_scheme is not supported for {mode!r}-quantized "
+            "bases on MLX yet — only the affine grid is implemented. Load the "
+            "model with load_in_4bit=True (affine) to use QAT."
+        )
 
     if requested_bits is not None and requested_bits != bits:
         raise ValueError(

--- a/unsloth_zoo/mlx/qat.py
+++ b/unsloth_zoo/mlx/qat.py
@@ -84,6 +84,28 @@ def _dropout_probability(module):
     return 1.0 - float(p_1)
 
 
+def _model_has_quantized_module(model):
+    """True when anything in the tree carries MLX quantized weights.
+
+    Works before adapters exist (bare ``nn.QuantizedLinear``) and after
+    (``named_modules`` still walks into ``LoRALinear.linear``), so the same
+    check serves the pre-mutation preflight and the post-LoRA pass.
+    """
+    import mlx.nn as nn
+
+    quantized_types = [nn.QuantizedLinear, nn.QuantizedEmbedding]
+    try:
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+        quantized_types.append(QuantizedSwitchLinear)
+    except Exception:
+        pass
+    quantized_types = tuple(t for t in quantized_types if isinstance(t, type))
+    return any(
+        isinstance(module, quantized_types)
+        for _, module in model.named_modules()
+    )
+
+
 def _lora_layer_types():
     """(LoRALinear, DoRA types, switch/MoE LoRA types) for the installed stack."""
     from mlx_lm.tuner.lora import LoRALinear, LoRASwitchLinear
@@ -248,6 +270,18 @@ def validate_mlx_qat_request(model, qat_scheme="auto", *, lora_dropout=None):
             "Unsloth: qat_scheme requires lora_dropout=0 on MLX. QAT folds the "
             "adapter into the weight to match fuse(), which leaves no separate "
             f"LoRA activation path for dropout to act on (got {lora_dropout})."
+        )
+
+    # Checkable before adapters exist, so it belongs here rather than in the
+    # post-LoRA pass: otherwise get_peft_model installs and freezes 100+ LoRA
+    # layers and only then refuses, leaving a mutated model behind.
+    if not _model_has_quantized_module(model):
+        raise ValueError(
+            "Unsloth: qat_scheme requires a quantized base model — nothing in "
+            "this model is quantized, so save_method='merged_4bit' would not "
+            "requantize and there is no quantization for QAT to simulate. "
+            "Load with load_in_4bit=True (or a pre-quantized -4bit/-8bit repo) "
+            "to use QAT."
         )
 
     return requested_bits

--- a/unsloth_zoo/mlx/qat.py
+++ b/unsloth_zoo/mlx/qat.py
@@ -1,0 +1,353 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Quantization-aware training (QAT) for LoRA on Apple Silicon.
+
+MLX's ``merged_4bit`` save path does not keep the base quantization untouched:
+``mlx_lm.tuner.lora.LoRALinear.fuse(dequantize=False)`` dequantizes the base,
+adds the LoRA delta, and then **requantizes** the merged result. So the weight
+that actually ships is ``quantize(dequantize(W_q) + B @ A)`` -- a grid the model
+never sees while training, because during training the LoRA delta is applied in
+full precision on top of the quantized base.
+
+This module closes that gap: it fake-quantizes the *merged* weight in the
+forward pass, at the base layer's own ``group_size`` / ``bits`` / ``mode``, so
+gradients reach the LoRA through the same quantizer that ``fuse()`` will apply
+at save time. A straight-through estimator carries the gradient.
+
+Note this differs deliberately from the CUDA/torchao ``qat_scheme`` path, which
+fake-quantizes the *frozen base* and leaves the adapter in high precision. That
+is correct for bitsandbytes, where the base stays quantized and the adapter is
+merged differently. It is the wrong target for MLX: simulating ``quantize(W)``
+while ``fuse()`` computes ``quantize(W + BA)`` would train against a quantizer
+that never runs.
+
+Expect the training loss to look *worse* with QAT enabled. That is the feature
+working, not failing -- the pre-fuse loss of a non-QAT run describes a model
+configuration that only exists in memory and is destroyed by the save. Measured
+on Qwen2.5-0.5B-Instruct-4bit / wikitext-2 over 300 steps: the non-QAT run
+improved 0.306 nats while training but kept only 0.111 of it after
+``merged_4bit``; the QAT run improved 0.241 and kept 0.241.
+
+Scope: LoRA over ``nn.QuantizedLinear`` on text models. DoRA, MoE/SwitchLinear
+experts, VLMs, unquantized bases, ``lora_dropout > 0`` and the torchao-only
+schemes are refused rather than approximated -- each merges differently, and a
+fake-quant that does not match ``fuse()`` is worse than none.
+"""
+
+from __future__ import annotations
+
+__all__ = (
+    "SUPPORTED_MLX_QAT_SCHEMES",
+    "TORCHAO_ONLY_QAT_SCHEMES",
+    "apply_mlx_qat",
+    "remove_mlx_qat",
+    "mlx_qat_module_count",
+)
+
+# Schemes MLX's affine quantizer can actually express, mapped to weight bits.
+# ``None`` means "inherit whatever the base layer was quantized to".
+SUPPORTED_MLX_QAT_SCHEMES = {
+    "auto": None,
+    "int4": 4,
+    "int8": 8,
+}
+
+# Accepted by the CUDA path via torchao, but not expressible with mx.quantize:
+# they quantize activations and/or use fp8 grids. Rejected explicitly rather
+# than silently approximated with the nearest affine weight-only scheme.
+TORCHAO_ONLY_QAT_SCHEMES = (
+    "int8-int4",
+    "fp8-int4",
+    "fp8-fp8",
+    "cactus",
+)
+
+_QAT_FLAG = "_unsloth_mlx_qat_active"
+_QAT_ORIGINAL_CLASS = "_unsloth_mlx_qat_original_class"
+
+
+def _dropout_probability(module):
+    """Recover ``p`` from an ``mlx.nn.Dropout`` (it stores ``_p_1 = 1 - p``)."""
+    dropout = getattr(module, "dropout", None)
+    if dropout is None:
+        return 0.0
+    p_1 = getattr(dropout, "_p_1", None)
+    if p_1 is None:
+        return 0.0
+    return 1.0 - float(p_1)
+
+
+def _lora_layer_types():
+    """(LoRALinear, DoRA types, switch/MoE LoRA types) for the installed stack."""
+    from mlx_lm.tuner.lora import LoRALinear, LoRASwitchLinear
+
+    dora_types = []
+    try:
+        from mlx_lm.tuner.dora import DoRALinear
+        dora_types.append(DoRALinear)
+    except Exception:
+        pass
+    try:
+        from mlx_lm.tuner.dora import DoRAEmbedding
+        dora_types.append(DoRAEmbedding)
+    except Exception:
+        pass
+
+    switch_types = [LoRASwitchLinear]
+    import sys
+    vlm_lora = sys.modules.get("mlx_vlm.trainer.lora_layers")
+    if vlm_lora is not None:
+        vlm_switch = getattr(vlm_lora, "LoRASwitchLinear", None)
+        if isinstance(vlm_switch, type):
+            switch_types.append(vlm_switch)
+
+    return LoRALinear, tuple(dora_types), tuple(switch_types)
+
+
+def _qat_call(self, x):
+    """Forward using a fake-quantized *merged* weight.
+
+    Mirrors ``LoRALinear.fuse(dequantize=False)`` exactly: dequantize the base,
+    add the LoRA delta, requantize. The straight-through estimator keeps the
+    gradient flowing to ``lora_a`` / ``lora_b`` as if the quantizer were the
+    identity.
+    """
+    import mlx.core as mx
+
+    base = self.linear
+    weight = mx.dequantize(
+        base.weight,
+        base.scales,
+        base.biases,
+        group_size=base.group_size,
+        bits=base.bits,
+        mode=base.mode,
+    )
+    delta = ((self.scale * self.lora_b.T) @ self.lora_a.T).astype(weight.dtype)
+    merged = weight + delta
+
+    packed, scales, biases = mx.quantize(
+        merged, group_size=base.group_size, bits=base.bits, mode=base.mode,
+    )
+    fake = mx.dequantize(
+        packed, scales, biases,
+        group_size=base.group_size, bits=base.bits, mode=base.mode,
+    )
+    # Straight-through: forward uses `fake`, backward behaves like identity.
+    straight_through = merged + mx.stop_gradient(fake - merged)
+
+    y = x @ straight_through.T
+    # `fuse()` carries the base bias through untouched; dropping it silently
+    # corrupts every arch with biased projections (e.g. Qwen2/2.5 q/k/v).
+    if "bias" in base:
+        y = y + base.bias
+    return y
+
+
+def _resolve_qat_bits(qat_scheme):
+    """Validate ``qat_scheme`` and return the requested bit width (or None)."""
+    if qat_scheme is True:
+        return None
+    if not isinstance(qat_scheme, str):
+        raise TypeError(
+            f"Unsloth: qat_scheme must be a string or True, got "
+            f"{type(qat_scheme).__name__}."
+        )
+    scheme = qat_scheme.strip().lower()
+    if scheme in TORCHAO_ONLY_QAT_SCHEMES:
+        raise NotImplementedError(
+            f"Unsloth: qat_scheme={qat_scheme!r} is a torchao scheme and is not "
+            "expressible with MLX's quantizer, which is weight-only and affine "
+            "(group_size/bits/mode). Use 'int4', 'int8', or 'auto' to inherit "
+            "the base model's quantization."
+        )
+    if scheme not in SUPPORTED_MLX_QAT_SCHEMES:
+        supported = ", ".join(sorted(SUPPORTED_MLX_QAT_SCHEMES))
+        raise ValueError(
+            f"Unsloth: unsupported qat_scheme={qat_scheme!r} for MLX. "
+            f"Supported: {supported}."
+        )
+    return SUPPORTED_MLX_QAT_SCHEMES[scheme]
+
+
+def _qat_targets(model):
+    """Split LoRA modules into (patchable, dora, switch, unquantized)."""
+    import mlx.nn as nn
+
+    lora_linear_type, dora_types, switch_types = _lora_layer_types()
+
+    patchable, dora, switch, unquantized = [], [], [], []
+    for name, module in model.named_modules():
+        if dora_types and isinstance(module, dora_types):
+            dora.append(name)
+            continue
+        if switch_types and isinstance(module, switch_types):
+            switch.append(name)
+            continue
+        if not isinstance(module, lora_linear_type):
+            continue
+        base = getattr(module, "linear", None)
+        if isinstance(base, nn.QuantizedLinear):
+            patchable.append((name, module))
+        else:
+            unquantized.append(name)
+    return patchable, dora, switch, unquantized
+
+
+def _preview(names, limit=3):
+    shown = ", ".join(names[:limit])
+    if len(names) > limit:
+        shown += f", +{len(names) - limit} more"
+    return shown
+
+
+def apply_mlx_qat(model, qat_scheme="auto"):
+    """Fake-quantize the merged LoRA weight during training.
+
+    Args:
+        model: an MLX model that already has LoRA layers attached.
+        qat_scheme: ``"auto"``/``True`` to inherit the base model's own
+            quantization, or ``"int4"`` / ``"int8"`` to additionally assert the
+            base was quantized to that width.
+
+    Returns:
+        The number of LoRA modules placed under QAT.
+    """
+    requested_bits = _resolve_qat_bits(qat_scheme)
+
+    if getattr(model, "_unsloth_full_finetuning", False):
+        raise NotImplementedError(
+            "Unsloth: qat_scheme is not supported with full_finetuning=True on "
+            "MLX yet — QAT currently simulates the LoRA merge performed by "
+            "save_method='merged_4bit', which only requantizes when the base "
+            "is quantized."
+        )
+
+    from .utils import _is_vlm_model
+    if _is_vlm_model(model):
+        # The LoRA layers are the same LoRALinear-over-QuantizedLinear, and all
+        # of them (language model and vision tower) do get discovered here, so
+        # this is a coverage gate rather than a known incompatibility: the VLM
+        # train -> merged_4bit -> reload path has not been validated end to end
+        # for QAT. Refuse rather than ship an unverified numeric claim.
+        raise NotImplementedError(
+            "Unsloth: qat_scheme is not supported for VLMs on MLX yet — the "
+            "vision-tower and projector merge paths have not been validated "
+            "against save_method='merged_4bit'. Use a text-only model, or "
+            "train the VLM without qat_scheme."
+        )
+
+    patchable, dora, switch, unquantized = _qat_targets(model)
+
+    if dora:
+        raise NotImplementedError(
+            "Unsloth: qat_scheme is not supported for DoRA on MLX yet. DoRA's "
+            "fuse() rescales the merged weight by m / ||W + BA|| before "
+            "quantizing, so a LoRA-shaped fake-quant would not match the saved "
+            f"weights. Affected: {_preview(dora)}."
+        )
+    if switch:
+        raise NotImplementedError(
+            "Unsloth: qat_scheme is not supported for MoE / SwitchLinear "
+            "experts on MLX yet — their fuse() merges a 3-D per-expert weight "
+            f"with a different delta layout. Affected: {_preview(switch)}."
+        )
+    if not patchable:
+        if unquantized:
+            raise ValueError(
+                "Unsloth: qat_scheme requires a quantized base model. The LoRA "
+                f"layers wrap unquantized modules ({_preview(unquantized)}), so "
+                "save_method='merged_4bit' would not requantize and there is no "
+                "quantization for QAT to simulate. Load with q_bits=4 (or a "
+                "pre-quantized -4bit/-8bit repo) to use QAT."
+            )
+        raise ValueError(
+            "Unsloth: qat_scheme was requested but the model has no LoRA "
+            "layers. Call get_peft_model(...) with LoRA targets first."
+        )
+
+    # Every layer must share one grid: the saved config records a single
+    # global quantization, and a mixed set cannot be expressed there.
+    grids = {
+        (m.linear.group_size, m.linear.bits, m.linear.mode) for _, m in patchable
+    }
+    if len(grids) != 1:
+        raise ValueError(
+            "Unsloth: qat_scheme requires a single quantization grid across all "
+            f"LoRA layers, found {sorted(grids)}."
+        )
+    group_size, bits, mode = next(iter(grids))
+
+    if requested_bits is not None and requested_bits != bits:
+        raise ValueError(
+            f"Unsloth: qat_scheme={qat_scheme!r} requests {requested_bits}-bit "
+            f"weights but the base model is quantized to {bits}-bit. QAT must "
+            "simulate the grid that save_method='merged_4bit' will actually "
+            "write. Use qat_scheme='auto' to inherit the base quantization."
+        )
+
+    dropout_layers = [n for n, m in patchable if _dropout_probability(m) > 0.0]
+    if dropout_layers:
+        raise NotImplementedError(
+            "Unsloth: qat_scheme requires lora_dropout=0 on MLX. QAT folds the "
+            "adapter into the weight to match fuse(), which leaves no separate "
+            "LoRA activation path for dropout to act on. Affected: "
+            f"{_preview(dropout_layers)}."
+        )
+
+    patched = 0
+    for _, module in patchable:
+        if getattr(module, _QAT_FLAG, False):
+            continue
+        original = type(module)
+        # Subclass rather than swap the module: the save path's DoRA detection
+        # keys on type(module).__name__ and the quantization-map scan keys on
+        # isinstance, so the stand-in has to keep both the name and the MRO.
+        qat_class = type(
+            original.__name__,
+            (original,),
+            {
+                "__call__": _qat_call,
+                "__module__": original.__module__,
+                "__qualname__": getattr(original, "__qualname__", original.__name__),
+                _QAT_FLAG: True,
+                _QAT_ORIGINAL_CLASS: original,
+            },
+        )
+        module.__class__ = qat_class
+        patched += 1
+
+    if patched:
+        print(
+            f"Unsloth: QAT enabled on {patched} LoRA layer(s) — simulating "
+            f"{bits}-bit / group_size={group_size} / mode={mode!r} quantization.\n"
+            "Training loss will read higher than a non-QAT run; the comparable "
+            "number is the loss after save_method='merged_4bit'."
+        )
+    return patched
+
+
+def remove_mlx_qat(model):
+    """Restore the stock LoRA forward. Returns the number of layers restored."""
+    restored = 0
+    for _, module in model.named_modules():
+        original = getattr(type(module), _QAT_ORIGINAL_CLASS, None)
+        if original is None or not getattr(module, _QAT_FLAG, False):
+            continue
+        module.__class__ = original
+        restored += 1
+    return restored
+
+
+def mlx_qat_module_count(model):
+    """Number of LoRA modules currently under QAT."""
+    return sum(
+        1 for _, module in model.named_modules()
+        if getattr(module, _QAT_FLAG, False)
+    )


### PR DESCRIPTION
Implements `qat_scheme` for the MLX backend, replacing the `NotImplementedError`
  stub in `get_peft_model` (`unsloth_zoo/mlx/loader.py:7534`).

  ## The problem

  MLX's `merged_4bit` save does **not** leave the base quantization untouched.
  `mlx_lm.tuner.lora.LoRALinear.fuse(dequantize=False)` dequantizes the base, adds the
  LoRA delta, and then **requantizes**:

  ```python
  weight = mx.dequantize(weight, linear.scales, linear.biases, ...)   # 1. dequantize
  fused_linear.weight = weight + delta                                 # 2. add BA
  if is_quantized and not dequantize:
      fused_linear = nn.QuantizedLinear.from_linear(...)               # 3. REQUANTIZE
  ```

  So the weight that actually ships is `quantize(dequantize(W_q) + B @ A)`. But during
  normal QLoRA training the adapter is applied in **full precision** on top of the
  quantized base, so that final requantization is error the model never sees while
  training.

  It is not a rounding detail. Requantization is not idempotent even with a zero LoRA
  delta — `max |W_dq - fq| = 0.0037` on a 4-bit/group-64 base.

  ## Evidence

  Qwen2.5-0.5B-Instruct-4bit, wikitext-2, standard LoRA (r=16, all 24 layers),
  measured pre-fuse vs post-fuse:

  | steps | baseline degradation | QAT degradation |
  |---|---|---|
  | 0 | +0.0112 | −0.0002 |
  | 50 | +0.1133 | +0.0001 |
  | 150 | +0.1657 | +0.0000 |
  | 300 | +0.2063 | −0.0000 |

  The headline number is retention, not degradation. Over 300 steps:

  - **baseline** gains 0.306 nats while training, keeps **0.111** after the save →
  **36%**
  - **QAT** gains 0.241, keeps **0.241** → **~100%**

  64% of what LoRA learns never reaches the saved model. QAT ships a model **0.130 
  nats better** (perplexity 23.19 vs 26.42). The advantage widens with training: 0.058
  → 0.092 → 0.130 at 50/150/300 steps.

  Through the real `save_pretrained_merged(save_method="merged_4bit")` → reload path
  (Qwen2.5-0.5B, short overfit run, so the magnitude is exaggerated but the mechanism
  is the product path):

  | | before save | after reload |
  |---|---|---|
  | no QAT | 0.000087 | **0.930841** |
  | QAT | 0.004248 | **0.004422** |

  **Memory is free.** Peak with gradient checkpointing: baseline 1412 MB, QAT 1404 MB
  (24 LoRA layers, seq 512, 16GB M2). Checkpointing fully absorbs the ~1.6x transient
  overhead. Forward cost is ~2x.

  ## Design — and why this diverges from CUDA

  CUDA/torchao fake-quantizes the **frozen base** and leaves the adapter in high
  precision. I verified this by running `QATConfig(step="prepare")` on a LoRA'd
  `nn.Linear`: `base_layer` becomes `FakeQuantizedLinear`, the base weight gets no
  gradient, and the adapter trains through the quantizer.

  That is correct for bitsandbytes. It is the **wrong target for MLX**: simulating
  `quantize(W)` while `fuse()` computes `quantize(W + BA)` would train against a
  quantizer that never runs. So this fake-quantizes the **merged** weight, at the base
  layer's own `group_size` / `bits` / `mode`, with a straight-through estimator
  carrying the gradient.

  The load-bearing test derives its expectation by calling the real `fuse()` rather
  than re-deriving the merge arithmetic, so a bug in the implementation cannot be
  mirrored into the test.

  Implementation notes:
  
  - Applied **after** the adapters exist, matching the CUDA ordering (`llama.py:3464`,
  `vision.py:2043`)
  - Uses `__class__` reassignment preserving `__name__`/`__qualname__`, following the
  NEFTune precedent at `trainer.py:3899` — the save path's DoRA detection keys on
  `type(module).__name__` and `collect_mlx_lora_adapter_tensors` relies on it
  - `qat_scheme="auto"` inherits the base quantization; `"int4"`/`"int8"` additionally
  assert the base matches

  ## Scope

  Covers **LoRA over `nn.QuantizedLinear` on text models**. Everything else is refused
  rather than approximated, because each merges differently and a fake-quant that
  doesn't match `fuse()` is worse than none:

  | rejected | reason |
  |---|---|
  | DoRA | `fuse()` rescales by `m / ‖W + BA‖` **before** quantizing |
  | MoE / SwitchLinear | 3-D per-expert weight, different delta layout |
  | VLMs | merge path not yet validated end to end (coverage gate, not a known
  incompatibility) |
  | unquantized base | `fuse()` only requantizes when the base is quantized — nothing
  to simulate |
  | `lora_dropout > 0` | folding the adapter into the weight leaves no separate
  activation path |
  | `int8-int4`, `fp8-int4`, `fp8-fp8`, `cactus` | torchao schemes; quantize
  activations and/or use fp8 grids, not expressible with `mx.quantize` |
  | `full_finetuning=True` | needs a quantize-at-save path that does not exist yet |

  QAT + CPT `modules_to_save` is structurally impossible and asserted as such: CPT
  full modules require an unquantized base, QAT requires a quantized one.

  ## Tests

  31 new tests, registered in `mlx-ci.yml`.

  - `tests/test_mlx_qat.py` (23) — fuse parity with and without bias, STE Jacobian,
  apply/remove lifecycle, class-name preservation, and every rejection above
  - `tests/test_mlx_qat_metal.py` (2) — efficacy: trains with and without QAT from one
  seed, fuses both, asserts the saved model is better. Parametrized over seeds; 400
  steps because the margin is genuinely marginal at 120 (measured minimum across seeds
  0–3: 120 steps −0.000030, 400 +0.001303, 900 +0.002600)
  - `tests/test_mlx_qat_integration_metal.py` (6) — the real product paths:
  `merged_4bit` save/reload round trip, QAT vs non-QAT through that path, adapter-only
  export, `MLXTrainer` (verifying QAT survives `mx.compile`), the VLM gate, and the
  CPT exclusion

  No regressions in the existing MLX suite (`trainer_internals` 223, `switch_lora` 23,
  `save_export_regressions` 49, `adapter_metadata_persistence` 31, others green).
  Three suites have pre-existing failures (`module_exports` 2,
  `save_export_edge_cases` 7, `save_lora_adapters_filter` 12) — confirmed identical
  counts against a pristine checkout of `main`; they are the shim-dependent tests that
  fail standalone on real Metal.

  ## Note for reviewers

  **The training loss reads higher with QAT enabled, and that is the feature
  working.** A non-QAT run's pre-fuse loss describes a model configuration that only
  exists in memory and is destroyed by the save. The comparable number is the loss
  *after* `merged_4bit`. The banner printed on activation says this, but it will still
  look wrong on a loss curve.

  Two things worth deciding before you open it: whether to mention that lifting the
  VLM gate is likely test-only work (all 260 layers on Qwen2-VL-2B are already
  discovered correctly), and whether to flag the follow-up sequence — fp16→quantized
  save, then DoRA/MoE QAT — so reviewers know the scope is intentionally staged rather
  than incomplete.
