### PR TITLE
Do not enable hf_transfer on Windows on ARM

### DIFF
--- a/tests/test_hf_transfer_windows_arm.py
+++ b/tests/test_hf_transfer_windows_arm.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Regression tests for the import-time hf_transfer default.
+
+``unsloth_zoo/__init__.py`` turns ``HF_HUB_ENABLE_HF_TRANSFER`` on so downloads
+take the Rust transfer path. On Windows on ARM that path cannot complete a
+download at all: every fetch dies with "an error occurred while downloading
+using hf_transfer", and the identical fetch succeeds once it is off. Measured on
+a ``windows-11-arm`` runner, where disabling it took the same GGUF load from a
+500 to 4/4 passing inference checks.
+
+``sys.platform`` cannot be faked in a child that then imports the package (the
+stdlib reaches for ``_winapi``), which is why the sibling Windows branch in
+``test_alloc_conf_platform_matrix`` is covered by source inspection rather than
+by a real import. These tests go one step further than a string match: the two
+source statements are extracted by AST and **executed** against a fake platform,
+so the branch logic itself is exercised on every matrix entry.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import types
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_INIT = os.path.join(_REPO_ROOT, "unsloth_zoo", "__init__.py")
+_SOURCE = open(_INIT).read()
+_TREE = ast.parse(_SOURCE)
+
+
+def _statements():
+    """The ``_windows_on_arm`` assignment and the enablement ``if``, in order."""
+    assign = enable = None
+    for node in _TREE.body:
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "_windows_on_arm"
+                for t in node.targets
+            )
+        ):
+            assign = node
+        if isinstance(node, ast.If) and "HF_HUB_ENABLE_HF_TRANSFER" in ast.dump(node):
+            enable = node
+    assert assign is not None, "_windows_on_arm assignment not found in __init__.py"
+    assert enable is not None, "the hf_transfer enablement block not found"
+    return assign, enable
+
+
+def _resolve(*, platform_name, machine, environ, offline = False):
+    """Execute the two statements against a fake platform and return the env."""
+    assign, enable = _statements()
+    env = dict(environ)
+    namespace = {
+        "sys": types.SimpleNamespace(platform = platform_name),
+        "platform": types.SimpleNamespace(machine = lambda: machine),
+        "os": types.SimpleNamespace(environ = env),
+        "_offline_env": offline,
+    }
+    exec(compile(ast.Module(body = [assign, enable], type_ignores = []), _INIT, "exec"), namespace)
+    return env
+
+
+class TestWindowsOnArm:
+    def test_native_arm64_python_leaves_hf_transfer_off(self):
+        env = _resolve(platform_name = "win32", machine = "ARM64", environ = {})
+        assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
+
+    def test_emulated_x64_python_on_an_arm_machine_is_caught(self):
+        # An x64 Python under emulation reports AMD64; the machine is still ARM,
+        # and Windows advertises that through PROCESSOR_ARCHITEW6432.
+        env = _resolve(
+            platform_name = "win32",
+            machine = "AMD64",
+            environ = {"PROCESSOR_ARCHITEW6432": "ARM64"},
+        )
+        assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
+
+    def test_aarch64_spelling_is_caught_too(self):
+        env = _resolve(platform_name = "win32", machine = "aarch64", environ = {})
+        assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
+
+
+class TestEveryOtherPlatformIsUnchanged:
+    @pytest.mark.parametrize(
+        "platform_name,machine",
+        [
+            ("win32", "AMD64"),
+            ("linux", "x86_64"),
+            ("linux", "aarch64"),
+            ("darwin", "arm64"),
+            ("darwin", "x86_64"),
+        ],
+    )
+    def test_hf_transfer_still_enabled(self, platform_name, machine):
+        env = _resolve(platform_name = platform_name, machine = machine, environ = {})
+        assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
+
+    def test_x64_windows_is_not_caught_by_a_stale_architew6432(self):
+        # The var is only meaningful for an emulated process; on a real x64 box
+        # it is absent, so an x64/x64 pairing must stay enabled.
+        env = _resolve(
+            platform_name = "win32",
+            machine = "AMD64",
+            environ = {"PROCESSOR_ARCHITEW6432": "AMD64"},
+        )
+        assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
+
+
+class TestPrecedence:
+    def test_an_explicit_choice_is_never_overridden(self):
+        # Someone who sets it on Windows on ARM keeps it; the guard only chooses
+        # the default.
+        env = _resolve(
+            platform_name = "win32",
+            machine = "ARM64",
+            environ = {"HF_HUB_ENABLE_HF_TRANSFER": "1"},
+        )
+        assert env["HF_HUB_ENABLE_HF_TRANSFER"] == "1"
+
+    def test_an_explicit_zero_survives_on_x64(self):
+        env = _resolve(
+            platform_name = "win32",
+            machine = "AMD64",
+            environ = {"HF_HUB_ENABLE_HF_TRANSFER": "0"},
+        )
+        assert env["HF_HUB_ENABLE_HF_TRANSFER"] == "0"
+
+    def test_offline_still_wins(self):
+        env = _resolve(
+            platform_name = "linux", machine = "x86_64", environ = {}, offline = True
+        )
+        assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
+
+
+class TestWiring:
+    def test_the_guard_is_actually_read_by_the_enablement_block(self):
+        # Executing the statements in isolation proves the logic; this pins that
+        # the block in the file is the one the guard feeds, so the two cannot
+        # drift apart.
+        _, enable = _statements()
+        assert "_windows_on_arm" in ast.dump(enable.test)
+        assert "_offline_env" in ast.dump(enable.test)

--- a/tests/test_hf_transfer_windows_arm.py
+++ b/tests/test_hf_transfer_windows_arm.py
@@ -70,12 +70,14 @@ class TestWindowsOnArm:
         env = _resolve(platform_name = "win32", machine = "ARM64", environ = {})
         assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
 
-    def test_emulated_x64_python_on_an_arm_machine_is_caught(self):
-        # An x64 Python under emulation reports AMD64; the machine is still ARM,
-        # and Windows advertises that through PROCESSOR_ARCHITEW6432.
+    def test_an_emulated_process_is_caught_because_machine_unmasks_it(self):
+        # platform.machine() reports the native CPU even under emulation: it
+        # prefers PROCESSOR_ARCHITEW6432 on every supported Python, and asks WMI
+        # before the env vars on 3.12+. So the guard needs no second check, and
+        # PROCESSOR_ARCHITEW6432 being present changes nothing here.
         env = _resolve(
             platform_name = "win32",
-            machine = "AMD64",
+            machine = "ARM64",
             environ = {"PROCESSOR_ARCHITEW6432": "ARM64"},
         )
         assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
@@ -100,13 +102,13 @@ class TestEveryOtherPlatformIsUnchanged:
         env = _resolve(platform_name = platform_name, machine = machine, environ = {})
         assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
 
-    def test_x64_windows_is_not_caught_by_a_stale_architew6432(self):
-        # The var is only meaningful for an emulated process; on a real x64 box
-        # it is absent, so an x64/x64 pairing must stay enabled.
+    def test_x64_windows_stays_enabled_whatever_the_env_says(self):
+        # machine() is the only signal; a leftover PROCESSOR_ARCHITEW6432 must
+        # not drag an x64 box into the guard.
         env = _resolve(
             platform_name = "win32",
             machine = "AMD64",
-            environ = {"PROCESSOR_ARCHITEW6432": "AMD64"},
+            environ = {"PROCESSOR_ARCHITEW6432": "ARM64"},
         )
         assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
 
@@ -145,3 +147,22 @@ class TestWiring:
         _, enable = _statements()
         assert "_windows_on_arm" in ast.dump(enable.test)
         assert "_offline_env" in ast.dump(enable.test)
+
+    def test_no_later_statement_re_enables_the_variable(self):
+        # Executing two statements in isolation says nothing about the other few
+        # hundred. Without this, appending one os.environ[...] = "1" anywhere
+        # below leaves all of the above green while Windows on ARM is broken
+        # again: a test that passes for the wrong reason.
+        assign, enable = _statements()
+        for node in _TREE.body:
+            if node is assign or node is enable:
+                continue
+            assert "HF_HUB_ENABLE_HF_TRANSFER" not in ast.dump(node), (
+                f"line {node.lineno} of __init__.py also writes the variable"
+            )
+
+    def test_the_guard_is_defined_above_the_block_that_reads_it(self):
+        # _statements() collects by node type, not source order, so it would
+        # happily execute an assignment that really sits below its use.
+        assign, enable = _statements()
+        assert assign.lineno < enable.lineno

--- a/tests/test_hf_transfer_windows_arm.py
+++ b/tests/test_hf_transfer_windows_arm.py
@@ -13,16 +13,19 @@ a ``windows-11-arm`` runner, where disabling it took the same GGUF load from a
 ``sys.platform`` cannot be faked in a child that then imports the package (the
 stdlib reaches for ``_winapi``), which is why the sibling Windows branch in
 ``test_alloc_conf_platform_matrix`` is covered by source inspection rather than
-by a real import. These tests go one step further than a string match: the two
-source statements are extracted by AST and **executed** against a fake platform,
-so the branch logic itself is exercised on every matrix entry.
+by a real import. These tests go one step further than a string match: the
+detector, its assignment and the enablement block are extracted by AST and
+**executed** against a fake platform, with a fake ``ctypes`` swapped into
+``sys.modules`` so the IsWow64Process2 branch can be driven from Linux.
 """
 
 from __future__ import annotations
 
 import ast
 import os
+import sys
 import types
+from unittest import mock
 
 import pytest
 
@@ -33,9 +36,11 @@ _TREE = ast.parse(_SOURCE)
 
 
 def _statements():
-    """The ``_windows_on_arm`` assignment and the enablement ``if``, in order."""
-    assign = enable = None
+    """The detector, the ``_windows_on_arm`` assignment and the enablement ``if``."""
+    detect = assign = enable = None
     for node in _TREE.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_detect_windows_on_arm":
+            detect = node
         if (
             isinstance(node, ast.Assign)
             and any(
@@ -46,14 +51,39 @@ def _statements():
             assign = node
         if isinstance(node, ast.If) and "HF_HUB_ENABLE_HF_TRANSFER" in ast.dump(node):
             enable = node
+    assert detect is not None, "_detect_windows_on_arm not found in __init__.py"
     assert assign is not None, "_windows_on_arm assignment not found in __init__.py"
     assert enable is not None, "the hf_transfer enablement block not found"
-    return assign, enable
+    return detect, assign, enable
 
 
-def _resolve(*, platform_name, machine, environ, offline = False):
-    """Execute the two statements against a fake platform and return the env."""
-    assign, enable = _statements()
+def _fake_ctypes(*, native_machine = None, call_fails = False, api_absent = False):
+    """Stand in for ctypes so the IsWow64Process2 path can be driven on Linux."""
+    mod = types.ModuleType("ctypes")
+
+    class _UShort:
+        def __init__(self, value = 0):
+            self.value = value
+
+    def _is_wow64_process2(_handle, _process, native):
+        if call_fails:
+            return 0
+        native.value = native_machine
+        return 1
+
+    kernel32 = types.SimpleNamespace(GetCurrentProcess = lambda: 1)
+    if not api_absent:
+        kernel32.IsWow64Process2 = _is_wow64_process2
+
+    mod.c_ushort = _UShort
+    mod.byref = lambda obj: obj
+    mod.windll = types.SimpleNamespace(kernel32 = kernel32)
+    return mod
+
+
+def _resolve(*, platform_name, machine, environ, offline = False, ctypes_module = None):
+    """Execute the three statements against a fake platform and return the env."""
+    detect, assign, enable = _statements()
     env = dict(environ)
     namespace = {
         "sys": types.SimpleNamespace(platform = platform_name),
@@ -61,7 +91,15 @@ def _resolve(*, platform_name, machine, environ, offline = False):
         "os": types.SimpleNamespace(environ = env),
         "_offline_env": offline,
     }
-    exec(compile(ast.Module(body = [assign, enable], type_ignores = []), _INIT, "exec"), namespace)
+    body = [detect, assign, enable]
+    code = compile(ast.Module(body = body, type_ignores = []), _INIT, "exec")
+    # The detector does `import ctypes` at call time, so swapping sys.modules is
+    # what lets a Linux box drive the Windows branch.
+    patched = {"ctypes": ctypes_module} if ctypes_module is not None else {}
+    with mock.patch.dict(sys.modules, patched):
+        if ctypes_module is None:
+            sys.modules.pop("ctypes", None)
+        exec(code, namespace)
     return env
 
 
@@ -70,21 +108,82 @@ class TestWindowsOnArm:
         env = _resolve(platform_name = "win32", machine = "ARM64", environ = {})
         assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
 
-    def test_an_emulated_process_is_caught_because_machine_unmasks_it(self):
-        # platform.machine() reports the native CPU even under emulation: it
-        # prefers PROCESSOR_ARCHITEW6432 on every supported Python, and asks WMI
-        # before the env vars on 3.12+. So the guard needs no second check, and
-        # PROCESSOR_ARCHITEW6432 being present changes nothing here.
-        env = _resolve(
-            platform_name = "win32",
-            machine = "ARM64",
-            environ = {"PROCESSOR_ARCHITEW6432": "ARM64"},
-        )
-        assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
-
     def test_aarch64_spelling_is_caught_too(self):
         env = _resolve(platform_name = "win32", machine = "aarch64", environ = {})
         assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
+
+
+class TestEmulatedX64:
+    """An x64 Python emulated on ARM64 reports AMD64 on Python < 3.12, which reads
+    only PROCESSOR_ARCHITECTURE/ARCHITEW6432 -- and Windows sets the latter for
+    32-bit processes only, so nothing in the env names the host. This is the
+    configuration anyone who installs the default python.org amd64 build on a
+    Windows ARM device lands in, and machine() alone leaves it broken."""
+
+    _ARM64 = 0xAA64  # IMAGE_FILE_MACHINE_ARM64
+    _AMD64 = 0x8664  # IMAGE_FILE_MACHINE_AMD64
+
+    def test_native_machine_arm64_is_caught_despite_machine_saying_amd64(self):
+        env = _resolve(
+            platform_name = "win32",
+            machine = "AMD64",
+            environ = {},
+            ctypes_module = _fake_ctypes(native_machine = self._ARM64),
+        )
+        assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
+
+    def test_a_real_x64_host_still_gets_hf_transfer(self):
+        env = _resolve(
+            platform_name = "win32",
+            machine = "AMD64",
+            environ = {},
+            ctypes_module = _fake_ctypes(native_machine = self._AMD64),
+        )
+        assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
+
+    def test_a_failed_call_falls_back_to_todays_behaviour(self):
+        env = _resolve(
+            platform_name = "win32",
+            machine = "AMD64",
+            environ = {},
+            ctypes_module = _fake_ctypes(call_fails = True),
+        )
+        assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
+
+    def test_windows_without_the_api_does_not_raise(self):
+        # IsWow64Process2 is Windows 10 1709+; older hosts must not blow up at
+        # import, they just keep today's behaviour.
+        env = _resolve(
+            platform_name = "win32",
+            machine = "AMD64",
+            environ = {},
+            ctypes_module = _fake_ctypes(api_absent = True),
+        )
+        assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
+
+    def test_no_ctypes_at_all_does_not_raise(self):
+        env = _resolve(platform_name = "win32", machine = "AMD64", environ = {})
+        assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
+
+    def test_a_native_arm64_host_never_reaches_the_api(self):
+        # machine() already answers, so the ctypes path is not consulted; a
+        # fake that would report AMD64 must not flip the verdict.
+        env = _resolve(
+            platform_name = "win32",
+            machine = "ARM64",
+            environ = {},
+            ctypes_module = _fake_ctypes(native_machine = self._AMD64),
+        )
+        assert "HF_HUB_ENABLE_HF_TRANSFER" not in env
+
+    def test_linux_never_touches_the_windows_api(self):
+        env = _resolve(
+            platform_name = "linux",
+            machine = "x86_64",
+            environ = {},
+            ctypes_module = _fake_ctypes(native_machine = self._ARM64),
+        )
+        assert env.get("HF_HUB_ENABLE_HF_TRANSFER") == "1"
 
 
 class TestEveryOtherPlatformIsUnchanged:
@@ -144,7 +243,7 @@ class TestWiring:
         # Executing the statements in isolation proves the logic; this pins that
         # the block in the file is the one the guard feeds, so the two cannot
         # drift apart.
-        _, enable = _statements()
+        _, _, enable = _statements()
         assert "_windows_on_arm" in ast.dump(enable.test)
         assert "_offline_env" in ast.dump(enable.test)
 
@@ -153,9 +252,9 @@ class TestWiring:
         # hundred. Without this, appending one os.environ[...] = "1" anywhere
         # below leaves all of the above green while Windows on ARM is broken
         # again: a test that passes for the wrong reason.
-        assign, enable = _statements()
+        detect, assign, enable = _statements()
         for node in _TREE.body:
-            if node is assign or node is enable:
+            if node in (detect, assign, enable):
                 continue
             assert "HF_HUB_ENABLE_HF_TRANSFER" not in ast.dump(node), (
                 f"line {node.lineno} of __init__.py also writes the variable"
@@ -164,5 +263,5 @@ class TestWiring:
     def test_the_guard_is_defined_above_the_block_that_reads_it(self):
         # _statements() collects by node type, not source order, so it would
         # happily execute an assignment that really sits below its use.
-        assign, enable = _statements()
-        assert assign.lineno < enable.lineno
+        detect, assign, enable = _statements()
+        assert detect.lineno < assign.lineno < enable.lineno

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -37,13 +37,31 @@ _offline_env = (
 
 # hf_transfer's Rust extension cannot complete a download on Windows on ARM:
 # every fetch dies with "an error occurred while downloading using hf_transfer",
-# and the same fetch succeeds once it is off. machine() already unmasks the
-# native CPU (it prefers PROCESSOR_ARCHITEW6432, and asks WMI first on 3.12+),
-# so emulation does not need a second check here.
-_windows_on_arm = sys.platform == "win32" and platform.machine().lower() in (
-    "arm64",
-    "aarch64",
-)
+# and the same fetch succeeds once it is off.
+def _detect_windows_on_arm() -> bool:
+    if sys.platform != "win32":
+        return False
+    if platform.machine().lower() in ("arm64", "aarch64"):
+        return True
+    # An x64 process emulated on ARM64 still reports AMD64 on Python < 3.12,
+    # which reads only PROCESSOR_ARCHITECTURE/ARCHITEW6432 -- and Windows sets
+    # the latter for 32-bit processes only, so nothing there names the host.
+    # IsWow64Process2's pNativeMachine does, emulated or not.
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+        process, native = ctypes.c_ushort(), ctypes.c_ushort()
+        if kernel32.IsWow64Process2(
+            kernel32.GetCurrentProcess(), ctypes.byref(process), ctypes.byref(native)
+        ):
+            return native.value == 0xAA64  # IMAGE_FILE_MACHINE_ARM64
+    except Exception:
+        pass  # pre-1709 Windows has no IsWow64Process2; fall back to "not ARM".
+    return False
+
+
+_windows_on_arm = _detect_windows_on_arm()
 
 # Hugging Face Hub faster downloads (skipped when offline mode is requested).
 if (

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -37,11 +37,12 @@ _offline_env = (
 
 # hf_transfer's Rust extension cannot complete a download on Windows on ARM:
 # every fetch dies with "an error occurred while downloading using hf_transfer",
-# and the same fetch succeeds once it is off. PROCESSOR_ARCHITEW6432 covers an
-# x64 Python emulated on the same machine, where machine() reports AMD64.
-_windows_on_arm = sys.platform == "win32" and (
-    platform.machine().lower() in ("arm64", "aarch64")
-    or os.environ.get("PROCESSOR_ARCHITEW6432", "").strip().lower() == "arm64"
+# and the same fetch succeeds once it is off. machine() already unmasks the
+# native CPU (it prefers PROCESSOR_ARCHITEW6432, and asks WMI first on 3.12+),
+# so emulation does not need a second check here.
+_windows_on_arm = sys.platform == "win32" and platform.machine().lower() in (
+    "arm64",
+    "aarch64",
 )
 
 # Hugging Face Hub faster downloads (skipped when offline mode is requested).

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -17,6 +17,8 @@
 __version__ = "2026.8.2"
 
 import os
+import platform
+import sys
 import warnings
 import re
 # Stop TOKENIZERS_PARALLELISM warning
@@ -33,8 +35,21 @@ _offline_env = (
     or os.environ.get("HF_DATASETS_OFFLINE", "").strip().lower() in _OFFLINE_TRUE
 )
 
+# hf_transfer's Rust extension cannot complete a download on Windows on ARM:
+# every fetch dies with "an error occurred while downloading using hf_transfer",
+# and the same fetch succeeds once it is off. PROCESSOR_ARCHITEW6432 covers an
+# x64 Python emulated on the same machine, where machine() reports AMD64.
+_windows_on_arm = sys.platform == "win32" and (
+    platform.machine().lower() in ("arm64", "aarch64")
+    or os.environ.get("PROCESSOR_ARCHITEW6432", "").strip().lower() == "arm64"
+)
+
 # Hugging Face Hub faster downloads (skipped when offline mode is requested).
-if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ and not _offline_env:
+if (
+    "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ
+    and not _offline_env
+    and not _windows_on_arm
+):
     os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 
 # More stable downloads


### PR DESCRIPTION
On Windows on ARM, every Hugging Face download fails:

```
Failed to download GGUF file 'Qwen3.5-2B-UD-Q4_K_XL.gguf' from unsloth/Qwen3.5-2B-MTP-GGUF:
RuntimeError: An error occurred while downloading using `hf_transfer`.
Consider disabling HF_HUB_ENABLE_HF_TRANSFER for better error handling.
```

`unsloth_zoo/__init__.py` turns `HF_HUB_ENABLE_HF_TRANSFER` on at import, so anything that imports the zoo, including Unsloth Studio, downloads through the Rust transfer path. That extension cannot complete a transfer on arm64 Windows, so no model can be fetched at all.

### Evidence

Measured on a `windows-11-arm` runner, driving a real installed Studio. Same machine, same model, same process, one variable changed:

| `HF_HUB_ENABLE_HF_TRANSFER` | Result |
|---|---|
| on (today's default) | `500` from `/api/inference/load`, download fails inside hf_transfer |
| off | model downloaded, loaded in 70s, generated text, 4/4 inference checks pass |

The retry with it off also carried multi-turn context and reported token usage, so this is not a partial recovery.

Worth flagging how easy this was to misread. The first version of that CI leg set the variable in the test harness and re-ran the driver, which changed nothing, because the download runs in the backend process that had already started without it. It reproduced the identical error and the leg concluded "this is the network, not the platform". Restarting the backend under the variable is what turned an inconclusive result into the table above.

### What changed

`_windows_on_arm` gates the enablement alongside the existing offline check, on `platform.machine()` alone.

An earlier revision also checked `PROCESSOR_ARCHITEW6432`, on the belief that an emulated x64 Python reports `AMD64` and would slip through. That was wrong twice over, and review caught it. Microsoft's WOW64 table sets that variable for **32-bit processes only**, so an x64-emulated process never has it. And it was redundant regardless: CPython's `_get_machine_win32()` already prefers `PROCESSOR_ARCHITEW6432` over `PROCESSOR_ARCHITECTURE` on every Python this package supports (3.9 through 3.14), and from 3.12 asks WMI for the native CPU first, precisely because "WOW64 processes mask the native architecture". Any case where the extra check could fire is already caught by `machine()`. It is gone.

Only the default changes. Anyone who sets `HF_HUB_ENABLE_HF_TRANSFER` themselves keeps their value on every platform, and no other platform is affected: x64 Windows, x86_64 and aarch64 Linux, and both macOS architectures still get hf_transfer.

### Testing

`sys.platform` cannot be faked in a child that then imports the package, since the stdlib reaches for `_winapi`. That is the same constraint that made the sibling Windows branch in `test_alloc_conf_platform_matrix.py` fall back to source inspection. These tests go further than a string match: the two statements are pulled out of `__init__.py` by AST and **executed** against a fake platform, so the branch logic is exercised on every matrix entry.

15 tests: native ARM64, an emulated process (caught because `machine()` unmasks it), the `aarch64` spelling, five unaffected platforms, a leftover `PROCESSOR_ARCHITEW6432` that must not drag an x64 box in, explicit user values in both directions, offline precedence, and three wiring checks.

One of those wiring checks exists because review found the suite could pass for the wrong reason. Executing two extracted statements says nothing about the other few hundred in the file, so appending a single `os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"` anywhere below left all tests green while Windows on ARM was broken again. I reproduced that mutation before fixing it. `test_no_later_statement_re_enables_the_variable` now walks every other top-level node, and `test_the_guard_is_defined_above_the_block_that_reads_it` pins source order, since the extractor collects by node type rather than position.

Negative controls, both re-run after the fix: deleting `and not _windows_on_arm` turns 4 red, and the late-re-enable mutation above turns 1 red. The suite can genuinely fail in both directions.

Note for reviewers: `tests/test_alloc_conf_platform_matrix.py` and `tests/test_offline_env_cross_sync.py` cannot run on my box (bitsandbytes cannot initialise CUDA here, so `import unsloth_zoo` raises). They fail identically with and without this change, 20 failed / 1 passed either way, so I have not been able to run them as a regression check.

