### PR TITLE
Stop capping machines that asked not to be capped

### DIFF
--- a/tests/test_hf_xet_applies_automatically.py
+++ b/tests/test_hf_xet_applies_automatically.py
@@ -1,0 +1,122 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The tuning is only worth anything if it reaches the process that does the downloading.
+
+hf_xet reads its configuration once, natively, the first time the runtime is built. Setting the
+variables after that is a no-op that leaves no trace, so "we set them" and "they took effect" are
+different claims and only the second one matters. These tests make the second claim: import
+unsloth_zoo the way a user does, in a clean environment, and check what the environment actually
+holds afterwards and what a spawned worker inherits.
+
+Importing unsloth_zoo is expensive, so the checks are grouped by the environment they need rather
+than one subprocess per assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ZOO_ROOT = str(Path(__file__).resolve().parents[1])
+
+# Built, never inherited: this machine exports HF_XET_HIGH_PERFORMANCE=1, which is exactly the
+# setting one of these tests is about, and inheriting it would make the test pass for free.
+_BASE_ENV = {
+    k: v for k, v in os.environ.items()
+    if not k.startswith(("HF_XET_", "HF_HUB_", "UNSLOTH_"))
+}
+_BASE_ENV["UNSLOTH_ZOO_DISABLE_GPU_INIT"] = "1"
+
+
+def _run(tmp_path: Path, body: str, extra_env: "dict[str, str] | None" = None) -> dict:
+    """Run *body* as a FILE, not with -c: multiprocessing spawn re-imports __main__ in the child,
+    which a -c script cannot provide, and the failure looks like an unrelated pickling error."""
+    script = tmp_path / "probe.py"
+    script.write_text(textwrap.dedent(body))
+    env = dict(_BASE_ENV, PYTHONPATH = ZOO_ROOT + os.pathsep + _BASE_ENV.get("PYTHONPATH", ""))
+    env.update(extra_env or {})
+    proc = subprocess.run(
+        [sys.executable, str(script)], env = env, capture_output = True, text = True, timeout = 900,
+    )
+    assert proc.returncode == 0, f"stdout=\n{proc.stdout}\nstderr=\n{proc.stderr[-3000:]}"
+    for line in reversed(proc.stdout.splitlines()):
+        if line.startswith("{"):
+            return json.loads(line)
+    raise AssertionError(f"no result line in:\n{proc.stdout}\n{proc.stderr[-2000:]}")
+
+
+@pytest.mark.timeout(1200)
+def test_importing_unsloth_zoo_tunes_this_process_and_its_workers(tmp_path):
+    """No flag, no call, no documentation to read: the download a user starts next is tuned, and so
+    is the one a spawned worker starts, which is where downloads actually happen."""
+    result = _run(tmp_path, """
+        import json, multiprocessing, os, sys
+
+
+        def child(queue):
+            queue.put({k: v for k, v in os.environ.items() if k.startswith("HF_XET_")})
+
+
+        if __name__ == "__main__":
+            # If hf_xet were already built here the settings would arrive too late to be read.
+            preloaded = "hf_xet" in sys.modules
+            import unsloth_zoo  # noqa: F401
+            from unsloth_zoo.hf_xet_tuning import xet_env_overrides
+
+            ctx = multiprocessing.get_context("spawn")
+            queue = ctx.Queue()
+            proc = ctx.Process(target = child, args = (queue,))
+            proc.start()
+            inherited = queue.get(timeout = 600)
+            proc.join(timeout = 600)
+
+            print(json.dumps({
+                "hf_xet_preloaded": preloaded,
+                "seen": {k: v for k, v in os.environ.items() if k.startswith("HF_XET_")},
+                "expected": {k: str(v) for k, v in xet_env_overrides(fail_fast = False).items()},
+                "child": inherited,
+            }))
+    """)
+    assert not result["hf_xet_preloaded"]
+    seen, expected = result["seen"], result["expected"]
+    assert expected, "the tuning resolved to nothing"
+    for key, value in expected.items():
+        assert seen.get(key) == value, f"{key}: import left {seen.get(key)!r}, wanted {value!r}"
+        assert result["child"].get(key) == value, f"{key} did not reach the worker"
+
+
+@pytest.mark.timeout(1200)
+def test_a_user_who_asked_for_high_performance_still_has_it_after_import(tmp_path):
+    """The end-to-end form of the setdefault rule. Overriding this cost a 192-core host 2.55x of
+    its download throughput the moment it imported us."""
+    result = _run(tmp_path, """
+        import json, os
+        import unsloth_zoo  # noqa: F401
+        print(json.dumps({k: v for k, v in os.environ.items() if k.startswith("HF_XET_")}))
+    """, extra_env = {"HF_XET_HIGH_PERFORMANCE": "1"})
+    assert result["HF_XET_HIGH_PERFORMANCE"] == "1"
+    # ...and the sizing that flag voids is stood down rather than left to fight it.
+    from unsloth_zoo.hf_xet_tuning import _CAPS_VOIDED_BY_HIGH_PERFORMANCE
+
+    for key in _CAPS_VOIDED_BY_HIGH_PERFORMANCE:
+        assert key not in result, key

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -5004,3 +5004,70 @@ def test_a_seeded_parent_still_hands_the_child_its_own_disks_numbers(monkeypatch
     )
     assert int(rec["xet"][key]) == 1 * GB
     assert os.environ[key] == str(64 * GB)  # the parent's own environment is untouched
+
+
+def test_a_concurrent_spawns_overlay_is_not_read_as_the_users_own_settings(monkeypatch, tmp_path):
+    """The spawn window puts the child's ``HF_XET_*`` into the parent environment for the duration of
+    ``proc.start()``. Sizing from a copy taken outside the lock can catch that overlay, and since
+    those values are not the ones we seeded they read as explicit user settings, so setdefault keeps
+    them and this child is left with the import-time sizing instead of its own destination's."""
+    import collections
+    import shutil
+    import threading
+
+    from unsloth_zoo import hf_xet_tuning as tuning
+
+    GB = 1_000_000_000
+    key = "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"
+    roomy = tmp_path / "roomy"
+    tight = tmp_path / "tight"
+    for directory in (roomy, tight):
+        directory.mkdir()
+    usage = collections.namedtuple("usage", "total used free")
+
+    def _disk_usage(path):
+        text = str(path)
+        if text.startswith(str(tight)):
+            return usage(1 * GB, 1 * GB, 0)
+        return usage(9000 * GB, 1000 * GB, 8000 * GB)
+
+    monkeypatch.setattr(shutil, "disk_usage", _disk_usage)
+    monkeypatch.setattr(tuning, "_psutil_memory", lambda: (2048 * GB, 2048 * GB))
+    monkeypatch.setattr(tuning, "cgroup_memory_limit", lambda: None)
+    for var in ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP", "UNSLOTH_XET_FORCE_CAPS"):
+        monkeypatch.delenv(var, raising = False)
+    monkeypatch.setenv("HF_HUB_CACHE", str(roomy / "hub"))
+    monkeypatch.setenv(key, str(64 * GB))
+    monkeypatch.setattr(tuning, "_SEEDED_INTO_ENVIRON", {key: str(64 * GB)}, raising = False)
+
+    holding = threading.Event()
+    done = threading.Event()
+
+    def _other_spawn():
+        # Exactly what the spawn window does: another child's numbers, briefly, in our environment.
+        with xf._SPAWN_ENV_LOCK:
+            os.environ[key] = str(7 * GB)
+            holding.set()
+            done.wait(5.0)
+            os.environ[key] = str(64 * GB)
+
+    peer = threading.Thread(target = _other_spawn, daemon = True)
+    peer.start()
+    assert holding.wait(5.0), "the peer never took the spawn lock"
+
+    rec: dict = {}
+    monkeypatch.setattr(xf, "_CTX", _FakeCtx(rec, {"ok": True, "path": "/cache/x"}))
+    waiter = threading.Timer(0.4, done.set)
+    waiter.start()
+    try:
+        xf._run_download_attempt(
+            DL_REPO, kind = "snapshot",
+            params = {"repo_id": DL_REPO, "cache_dir": str(tight / "hub")}, token = None,
+            repo_type = "model", disable_xet = False, cancel_event = None,
+            stall_timeout = 0.2, interval = 0.05, grace_period = 0.2, on_status = None,
+        )
+    finally:
+        waiter.cancel()
+        done.set()
+        peer.join(5.0)
+    assert int(rec["xet"][key]) == 1 * GB, "the child was sized from the peer's overlay"

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -1128,6 +1128,58 @@ def test_force_caps_still_beats_the_flag_for_the_child(monkeypatch):
     assert int(child["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) > 0
 
 
+def test_the_child_is_sized_for_the_cache_dir_it_was_given(monkeypatch, tmp_path):
+    """``cache_dir`` is what huggingface_hub uses (``file_download.py``: ``if cache_dir is None:
+    cache_dir = constants.HF_HUB_CACHE``), so it, not the process's HF_HUB_CACHE, is the volume the
+    child writes to. Sizing from the global cache hands a nearly full target disk the whole budget,
+    and clamps a roomy target to the floor whenever an unrelated default cache is full."""
+    import collections
+    import shutil
+
+    from unsloth_zoo import hf_xet_tuning as tuning
+
+    GB = 1_000_000_000
+    roomy = tmp_path / "roomy"
+    tight = tmp_path / "tight"
+    for directory in (roomy, tight):
+        directory.mkdir()
+    usage = collections.namedtuple("usage", "total used free")
+
+    def _disk_usage(path):
+        text = str(path)
+        if text.startswith(str(tight)):
+            return usage(1 * GB, 1 * GB, 0)
+        if text.startswith(str(roomy)):
+            return usage(9000 * GB, 1000 * GB, 8000 * GB)
+        raise OSError(f"unexpected filesystem: {text}")
+
+    monkeypatch.setattr(shutil, "disk_usage", _disk_usage)
+    monkeypatch.setattr(tuning, "_psutil_memory", lambda: (2048 * GB, 2048 * GB))
+    monkeypatch.setattr(tuning, "cgroup_memory_limit", lambda: None)
+    for var in ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP", "UNSLOTH_XET_FORCE_CAPS"):
+        monkeypatch.delenv(var, raising = False)
+    monkeypatch.delenv("HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT", raising = False)
+
+    def _child(cache_dir, hub_cache) -> dict:
+        monkeypatch.setenv("HF_HUB_CACHE", str(hub_cache))
+        rec: dict = {}
+        monkeypatch.setattr(xf, "_CTX", _FakeCtx(rec, {"ok": True, "path": "/cache/x"}))
+        xf._run_download_attempt(
+            DL_REPO, kind = "snapshot",
+            params = {"repo_id": DL_REPO, "cache_dir": str(cache_dir)}, token = None,
+            repo_type = "model", disable_xet = False, cancel_event = None,
+            stall_timeout = 0.2, interval = 0.05, grace_period = 0.2, on_status = None,
+        )
+        return rec["xet"]
+
+    # Full target volume, roomy default cache: the clamp still bites.
+    child = _child(tight / "hub", roomy / "hub")
+    assert int(child["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
+    # Roomy target volume, full default cache: the download is not throttled for it.
+    child = _child(roomy / "hub", tight / "hub")
+    assert int(child["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 64 * GB
+
+
 class _EmptyQueue:
     def get(self, timeout = None):
         import queue as _queue

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -4954,3 +4954,53 @@ def test_peer_liveness_cannot_suppress_the_clock_forever(hf_cache, monkeypatch):
         assert "did not start" in calls[0]
     finally:
         stop.set()
+
+
+def test_a_seeded_parent_still_hands_the_child_its_own_disks_numbers(monkeypatch, tmp_path):
+    """The real parent has already sized itself at import, so its environment carries a buffer limit
+    computed for the global cache. Because the pre-spawn call is setdefault, that stale number would
+    survive into the child unless our own seeded values are dropped first."""
+    import collections
+    import os
+    import shutil
+
+    from unsloth_zoo import hf_xet_tuning as tuning
+
+    GB = 1_000_000_000
+    roomy = tmp_path / "roomy"
+    tight = tmp_path / "tight"
+    for directory in (roomy, tight):
+        directory.mkdir()
+    usage = collections.namedtuple("usage", "total used free")
+
+    def _disk_usage(path):
+        text = str(path)
+        if text.startswith(str(tight)):
+            return usage(1 * GB, 1 * GB, 0)
+        if text.startswith(str(roomy)):
+            return usage(9000 * GB, 1000 * GB, 8000 * GB)
+        raise OSError(f"unexpected filesystem: {text}")
+
+    monkeypatch.setattr(shutil, "disk_usage", _disk_usage)
+    monkeypatch.setattr(tuning, "_psutil_memory", lambda: (2048 * GB, 2048 * GB))
+    monkeypatch.setattr(tuning, "cgroup_memory_limit", lambda: None)
+    for var in ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP", "UNSLOTH_XET_FORCE_CAPS"):
+        monkeypatch.delenv(var, raising = False)
+
+    # Exactly what import leaves behind: the roomy default cache's numbers, in the environment and
+    # recorded as ours.
+    key = "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"
+    monkeypatch.setenv("HF_HUB_CACHE", str(roomy / "hub"))
+    monkeypatch.setenv(key, str(64 * GB))
+    monkeypatch.setattr(tuning, "_SEEDED_INTO_ENVIRON", {key: str(64 * GB)}, raising = False)
+
+    rec: dict = {}
+    monkeypatch.setattr(xf, "_CTX", _FakeCtx(rec, {"ok": True, "path": "/cache/x"}))
+    xf._run_download_attempt(
+        DL_REPO, kind = "snapshot",
+        params = {"repo_id": DL_REPO, "cache_dir": str(tight / "hub")}, token = None,
+        repo_type = "model", disable_xet = False, cancel_event = None,
+        stall_timeout = 0.2, interval = 0.05, grace_period = 0.2, on_status = None,
+    )
+    assert int(rec["xet"][key]) == 1 * GB
+    assert os.environ[key] == str(64 * GB)  # the parent's own environment is untouched

--- a/tests/test_hf_xet_fallback.py
+++ b/tests/test_hf_xet_fallback.py
@@ -1002,6 +1002,9 @@ class _FakeProc:
         self._rec["hf_transfer"] = os.environ.get("HF_HUB_ENABLE_HF_TRANSFER")
         self._rec["skip_gpu_init"] = os.environ.get("UNSLOTH_ZOO_DISABLE_GPU_INIT")
         self._rec["main_file"] = getattr(sys.modules.get("__main__"), "__file__", None)
+        # What the child would actually inherit: hf_xet reads these natively at import, so the
+        # spawn window is the only moment they can be set.
+        self._rec["xet"] = {k: v for k, v in os.environ.items() if k.startswith("HF_XET_")}
 
     def is_alive(self):
         return False
@@ -1066,6 +1069,63 @@ def test_xet_attempt_does_not_force_disable_before_spawn(monkeypatch):
     )
     # On the Xet-first attempt, do not force-disable Xet for the child.
     assert rec["disable_xet"] is None
+
+
+def _spawn_xet_env(monkeypatch) -> dict:
+    """Run one Xet-first attempt against a fake spawn and return the child's HF_XET_* env."""
+    rec: dict = {}
+    monkeypatch.setattr(xf, "_CTX", _FakeCtx(rec, {"ok": True, "path": "/cache/x"}))
+    xf._run_download_attempt(
+        DL_REPO, kind = "snapshot", params = {"repo_id": DL_REPO}, token = None,
+        repo_type = "model", disable_xet = False, cancel_event = None,
+        stall_timeout = 0.2, interval = 0.05, grace_period = 0.2, on_status = None,
+    )
+    return rec["xet"]
+
+
+def test_child_keeps_a_user_set_high_performance_flag(monkeypatch):
+    """The download child is the only process that matters here, so standing our sizing down for a
+    user who asked for high-performance mode has to hold on this path too. Forcing the flag back to
+    0 and re-adding the caps is the behaviour that cost a 192-core host 2.55x."""
+    from unsloth_zoo.hf_xet_tuning import _CAPS_VOIDED_BY_HIGH_PERFORMANCE
+
+    for var in ("HF_XET_HP", "UNSLOTH_XET_FORCE_CAPS", "UNSLOTH_XET_ALLOW_HIGH_PERFORMANCE"):
+        monkeypatch.delenv(var, raising = False)
+    for key in _CAPS_VOIDED_BY_HIGH_PERFORMANCE:
+        monkeypatch.delenv(key, raising = False)
+    monkeypatch.setenv("HF_XET_HIGH_PERFORMANCE", "1")
+
+    child = _spawn_xet_env(monkeypatch)
+    assert child["HF_XET_HIGH_PERFORMANCE"] == "1"
+    for key in _CAPS_VOIDED_BY_HIGH_PERFORMANCE:
+        assert key not in child, key
+    # The settings the preset does not touch are still tuned for the child.
+    assert child["HF_XET_CLIENT_RETRY_MAX_ATTEMPTS"] == "2"
+
+
+def test_child_is_capped_when_nothing_asked_otherwise(monkeypatch):
+    """The default path is unchanged: no flag means the caps go to the child and the preset that
+    would void them is turned off."""
+    for var in ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP", "UNSLOTH_XET_FORCE_CAPS"):
+        monkeypatch.delenv(var, raising = False)
+    monkeypatch.delenv("HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT", raising = False)
+
+    child = _spawn_xet_env(monkeypatch)
+    assert child["HF_XET_HIGH_PERFORMANCE"] == "0"
+    assert child["HF_XET_HP"] == "0"
+    assert int(child["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) > 0
+
+
+def test_force_caps_still_beats_the_flag_for_the_child(monkeypatch):
+    """The escape hatch survives: someone who wants a machine bounded regardless still gets the
+    caps, which only mean anything once the preset is off."""
+    monkeypatch.delenv("HF_XET_HP", raising = False)
+    monkeypatch.setenv("HF_XET_HIGH_PERFORMANCE", "1")
+    monkeypatch.setenv("UNSLOTH_XET_FORCE_CAPS", "1")
+
+    child = _spawn_xet_env(monkeypatch)
+    assert child["HF_XET_HIGH_PERFORMANCE"] == "0"
+    assert int(child["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) > 0
 
 
 class _EmptyQueue:

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -698,3 +698,32 @@ def test_a_process_already_sized_at_import_still_resizes_for_its_destination(mon
         user_env, tight / "hub",
     )
     assert user_env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"] == "16000000000"
+
+
+def test_a_throttle_asked_for_by_a_logged_429_survives_the_resize(monkeypatch, tmp_path):
+    """``unsloth_zoo/__init__`` seeds the halved stream ceiling when the Xet logs show a 429. The
+    resize drops what that call wrote, so recomputing on the default terms would hand the child the
+    full ceiling exactly when the account asked for fewer streams."""
+    import os as _os
+
+    key = "HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"
+    roomy = tmp_path / "roomy"
+    tight = tmp_path / "tight"
+    for directory in (roomy, tight):
+        directory.mkdir()
+    _two_volumes(monkeypatch, str(roomy), str(tight))
+
+    fake_env = {"HF_HUB_CACHE": str(roomy / "hub")}
+    monkeypatch.setattr(_os, "environ", fake_env)
+    monkeypatch.setattr(tuning, "_SEEDED_INTO_ENVIRON", {})
+    monkeypatch.setattr(tuning, "_SEEDED_THROTTLED", False, raising = False)
+
+    tuning.apply_xet_env(throttled = True)  # what import does after finding a 429
+    throttled_streams = int(fake_env[key])
+    assert throttled_streams == max(4, int(tuning.xet_env_overrides()[key]) // 2)
+
+    resized = tuning.resize_for_cache_dir(dict(fake_env), roomy / "hub")
+    assert int(resized[key]) == throttled_streams, "the 429 reduction has to reach the downloader"
+    # Still overridable, for a caller that knows the throttle has lifted.
+    assert int(tuning.resize_for_cache_dir(dict(fake_env), roomy / "hub", throttled = False)[key]) \
+        > throttled_streams

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -43,15 +43,17 @@ def _profile(ram_gb: float, cpus: int = 8, free_disk_gb: float = 0) -> tuning.Sy
 @pytest.mark.parametrize(
     "ram_gb, cpus, limit, size, perfile, files, streams",
     [
-        # An eighth of RAM is the budget, a quarter of that is the shared buffer and a
-        # thirty-second is a per-file buffer, so the numbers describe ONE allocation. The floors
-        # (256MB / 128MB) are what keep a small machine's buffers usable.
-        (8, 4, 1 * GB, 256 * MB, 128 * MB, 4, 8),
+        # An eighth of RAM is the budget and a thirty-second is a per-file buffer, so the numbers
+        # describe ONE allocation. The shared buffer is the exception: it reaches for xet-core's
+        # own 2 GB default and only falls short where half the budget or a sixth of RAM says it
+        # must, because a quarter of the budget measured 0.73x on an 8 GB laptop.
+        (8, 4, 1 * GB, 500 * MB, 128 * MB, 3, 8),
         # No cliffs: 12 GB sits between the old table's 8 and 16 GB rows and gets a budget to match,
         # where the old step function gave it the 8 GB row's.
-        (12, 4, 1500 * MB, 375 * MB, 128 * MB, 4, 8),
-        (16, 8, 2 * GB, 500 * MB, 128 * MB, 8, 16),
-        (32, 16, 4 * GB, 1 * GB, 128 * MB, 16, 32),
+        (12, 4, 1500 * MB, 750 * MB, 128 * MB, 4, 8),
+        (16, 8, 2 * GB, 1 * GB, 128 * MB, 7, 16),
+        # 32 GB is the first machine that can hold xet-core's stock buffer outright.
+        (32, 16, 4 * GB, 2 * GB, 128 * MB, 15, 32),
         # A big host is bounded by a budget proportional to what it has, not by a laptop's. Holding
         # a 2 TB server to the old flat 4 GB row cost 30% against xet-core's own defaults.
         (128, 64, 16 * GB, 4 * GB, 500 * MB, 24, 124),
@@ -61,7 +63,7 @@ def _profile(ram_gb: float, cpus: int = 8, free_disk_gb: float = 0) -> tuning.Sy
         # ...and so does the budget. A 64-core container with 8 GB (CI, or a cgroup-limited pod)
         # cannot use 64 file buffers or 128 streams out of a 1 GB budget, and opening them anyway is
         # how a small machine on a thin link ends up worse off than with no tuning at all.
-        (8, 64, 1 * GB, 256 * MB, 128 * MB, 5, 14),
+        (8, 64, 1 * GB, 500 * MB, 128 * MB, 3, 14),
     ],
 )
 def test_knobs_scale_with_the_machine(ram_gb, cpus, limit, size, perfile, files, streams):
@@ -421,12 +423,13 @@ def test_every_device_stays_within_its_own_means(name, ram_gb, cpus, disk_gb):
 
 
 def test_the_smallest_devices_get_the_smallest_numbers():
-    """The floors are the whole safety story on a 2 GB VM or a fractional-core pod: one shared
-    buffer, two files, four streams. Anything larger there is worse than not tuning at all."""
+    """A 2 GB VM and a fractional-core pod get the smallest allocation we hand out: two files, four
+    streams, and a shared buffer bounded by a sixth of RAM rather than by xet-core's default, which
+    on a 2 GB machine would be the whole machine."""
     for name, ram_gb, cpus, disk_gb in DEVICES[:2]:
         env = tuning.xet_env_overrides(_profile(ram_gb, cpus, disk_gb))
         assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB, name
-        assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"]) == 256 * MB, name
+        assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"]) <= ram_gb * GB / 6, name
         assert int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) == 2, name
         assert int(env["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]) == 4, name
 
@@ -513,3 +516,21 @@ def test_no_module_sets_a_variable_xet_core_does_not_read():
             if name not in XET_CORE_VARS:
                 unknown.setdefault(name, set()).add(path.relative_to(root).as_posix())
     assert not unknown, f"names xet-core does not read: { {k: sorted(v) for k, v in unknown.items()} }"
+
+
+@pytest.mark.parametrize("ram_gb, cpus", [(8, 8), (12.7, 2), (16, 4), (32, 16), (64, 32), (2048, 192)])
+def test_a_machine_that_can_hold_xet_cores_own_buffer_gets_it(ram_gb, cpus):
+    """The rule the small-device regression came down to. Our sizing exists to CAP a machine that
+    needs capping; handing one less than it would have had by doing nothing is not a cap, it is
+    just a slower download. Measured: a quarter of the budget on an 8 GB laptop ran at 0.73x of
+    what shipped before, and restoring this one value took it to 1.45x."""
+    env = tuning.xet_env_overrides(_profile(ram_gb, cpus))
+    size = int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"])
+    limit = int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"])
+    stock = tuning._STOCK_BUFFER_SIZE
+    # Only two things may hold it under stock, and only as far as they reach: half the budget, and
+    # a sixth of RAM. Anything smaller than both of those is a choice, not a constraint.
+    assert size >= min(stock, limit // 2, max(256 * MB, ram_gb * GB / 6)), f"{ram_gb}GB got {size}"
+    # ...so a machine with room for stock on both counts is never handed less than stock.
+    if limit // 2 >= stock and ram_gb * GB / 6 >= stock:
+        assert size >= stock, f"{ram_gb}GB undercut stock: {size}"

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -36,7 +36,9 @@ def _profile(ram_gb: float, cpus: int = 8, free_disk_gb: float = 0) -> tuning.Sy
         ram_source = "test",
         cpu_source = "test",
         free_disk_bytes = int(free_disk_gb * GB),
-        disk_source = "test",
+        # 0 GB means "not measured" for the tests that do not care; a REAL zero is a full disk and
+        # gets a source, because the two take different branches.
+        disk_source = "test" if free_disk_gb else "unknown",
     )
 
 
@@ -584,3 +586,29 @@ def test_the_flag_is_read_the_way_xet_core_reads_it():
     alias_only = {"HF_XET_HP": "1"}
     tuning.apply_xet_env(alias_only, profile = _profile(16))
     assert "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT" not in alias_only
+
+
+def test_a_full_disk_is_not_read_as_an_unmeasured_one():
+    """shutil.disk_usage returning exactly zero free bytes is the case the clamp exists for, so it
+    must not share a sentinel with "we could not measure". A full cache filesystem otherwise kept
+    the whole 64 GB budget while one byte free took it to the floor."""
+    full = tuning.SystemProfile(
+        total_ram_bytes = 2048 * GB, available_ram_bytes = 2048 * GB, cpu_count = 192,
+        ram_source = "test", cpu_source = "test", free_disk_bytes = 0, disk_source = "/data",
+    )
+    env = tuning.xet_env_overrides(full)
+    assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
+
+    unknown = dataclasses.replace(full, disk_source = "unknown")
+    env = tuning.xet_env_overrides(unknown)
+    assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 64 * GB
+
+
+def test_free_disk_reports_unknown_when_it_cannot_measure(monkeypatch):
+    import shutil
+
+    def _boom(_path):
+        raise OSError("no such filesystem")
+
+    monkeypatch.setattr(shutil, "disk_usage", _boom)
+    assert tuning._free_disk() == (0, "unknown")

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -440,3 +440,76 @@ def test_only_the_big_hosts_get_the_big_numbers():
                ["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) > 8 * GB
     }
     assert big == {"A100 node", "8xH100 node"}
+
+
+# Every HF_XET_* name xet-core 1.5.x actually reads, filtered to the groups we touch. Regenerate
+# with:  grep -rhno "HF_XET_[A-Z_]\+" <xet-core>/xet_runtime --include=*.rs | cut -d: -f2- | sort -u
+# We used to set HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY, which xet-core has never had a variable of
+# that name for (the real one is HF_XET_RECONSTRUCTION_USE_VECTORED_WRITE, default true): a silent
+# no-op that read, in review and in the logs, exactly like a setting that was being honoured.
+XET_CORE_VARS = frozenset({
+    "HF_XET_CACHE",
+    "HF_XET_CHUNK_CACHE_SIZE_BYTES",
+    "HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY",
+    "HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY",
+    "HF_XET_CLIENT_AC_MIN_DOWNLOAD_CONCURRENCY",
+    "HF_XET_CLIENT_CONNECT_TIMEOUT",
+    "HF_XET_CLIENT_READ_TIMEOUT",
+    "HF_XET_CLIENT_RETRY_BASE_DELAY",
+    "HF_XET_CLIENT_RETRY_MAX_ATTEMPTS",
+    "HF_XET_CLIENT_RETRY_MAX_DURATION",
+    "HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS",
+    "HF_XET_HIGH_PERFORMANCE",
+    "HF_XET_HP",
+    "HF_XET_LOG_DEST",
+    "HF_XET_LOG_FILE",
+    "HF_XET_LOG_FORMAT",
+    "HF_XET_LOG_PREFIX",
+    "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT",
+    "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE",
+    "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE",
+    "HF_XET_RECONSTRUCTION_MAX_RECONSTRUCTION_FETCH_SIZE",
+    "HF_XET_RECONSTRUCTION_MIN_PREFETCH_BUFFER",
+    "HF_XET_RECONSTRUCTION_MIN_RECONSTRUCTION_FETCH_SIZE",
+    "HF_XET_RECONSTRUCTION_TARGET_BLOCK_COMPLETION_TIME",
+    "HF_XET_RECONSTRUCTION_USE_VECTORED_WRITE",
+    "HF_XET_SYSTEM_MONITOR_ENABLED",
+    "HF_XET_SYSTEM_MONITOR_LOG_PATH",
+    "HF_XET_SYSTEM_MONITOR_SAMPLE_INTERVAL",
+})
+
+
+def test_we_only_set_variables_xet_core_reads(tmp_path):
+    emitted = set(tuning.xet_env_overrides(_profile(16))) | set(tuning.xet_log_env(tmp_path, diagnostics = True))
+    unknown = emitted - XET_CORE_VARS
+    assert not unknown, f"not read by xet-core: {sorted(unknown)}"
+
+
+def test_the_prefetch_floor_never_undercuts_xet_cores_own(tmp_path):
+    """Sizing DOWN from a default is a cap; sizing below it for no reason is just a slower
+    download. Only a machine whose whole budget is smaller than the 1 GB default gets less."""
+    for ram_gb, cpus in ((8, 4), (16, 8), (32, 16), (64, 32), (2048, 192)):
+        env = tuning.xet_env_overrides(_profile(ram_gb, cpus))
+        prefetch = int(env["HF_XET_RECONSTRUCTION_MIN_PREFETCH_BUFFER"])
+        limit = int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"])
+        assert prefetch <= tuning._STOCK_PREFETCH_BUFFER, f"{ram_gb}GB raised it to {prefetch}"
+        assert prefetch <= limit, f"{ram_gb}GB: {prefetch} prefetch inside a {limit} budget"
+        if limit >= 4 * GB:
+            assert prefetch == tuning._STOCK_PREFETCH_BUFFER, f"{ram_gb}GB undercut it: {prefetch}"
+
+
+def test_no_module_sets_a_variable_xet_core_does_not_read():
+    """The dead variable was set from unsloth_zoo/__init__.py at import time, not from here, so a
+    check confined to this module would have missed it. Scan the package instead."""
+    import pathlib
+    import re
+
+    root = pathlib.Path(tuning.__file__).parent
+    unknown: dict[str, set] = {}
+    for path in root.rglob("*.py"):
+        # Only quoted names: a variable is only ever read or written as a string literal, so this
+        # skips prose ("any explicit HF_XET_RECONSTRUCTION_* cap") without needing to parse it.
+        for name in re.findall(r"[\"'](HF_XET_[A-Z_]+)[\"']", path.read_text(errors = "ignore")):
+            if name not in XET_CORE_VARS:
+                unknown.setdefault(name, set()).add(path.relative_to(root).as_posix())
+    assert not unknown, f"names xet-core does not read: { {k: sorted(v) for k, v in unknown.items()} }"

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -612,3 +612,52 @@ def test_free_disk_reports_unknown_when_it_cannot_measure(monkeypatch):
 
     monkeypatch.setattr(shutil, "disk_usage", _boom)
     assert tuning._free_disk() == (0, "unknown")
+
+
+def _two_volumes(monkeypatch, roomy: str, tight: str) -> None:
+    """Pretend *roomy* and *tight* are separate filesystems, and fix RAM so only the disk moves."""
+    import collections
+    import shutil
+
+    usage = collections.namedtuple("usage", "total used free")
+
+    def _disk_usage(path):
+        text = str(path)
+        if text.startswith(tight):
+            return usage(1 * GB, 1 * GB, 0)
+        if text.startswith(roomy):
+            return usage(9000 * GB, 1000 * GB, 8000 * GB)
+        raise OSError(f"unexpected filesystem: {text}")
+
+    monkeypatch.setattr(shutil, "disk_usage", _disk_usage)
+    monkeypatch.setattr(tuning, "_psutil_memory", lambda: (2048 * GB, 2048 * GB))
+    monkeypatch.setattr(tuning, "cgroup_memory_limit", lambda: None)
+
+
+def test_an_explicit_cache_dir_is_the_disk_that_gets_measured(monkeypatch, tmp_path):
+    """``cache_dir=`` beats every cache environment variable in huggingface_hub
+    (``file_download.py``: ``if cache_dir is None: cache_dir = constants.HF_HUB_CACHE``), so a
+    caller who names one has named the volume the bytes land on. Sizing off the global cache
+    instead promises a 64 GB buffer to a full target disk, and throttles a roomy target to the
+    floor because an unrelated default cache is full."""
+    roomy = tmp_path / "roomy"
+    tight = tmp_path / "tight"
+    for directory in (roomy, tight):
+        directory.mkdir()
+    _two_volumes(monkeypatch, str(roomy), str(tight))
+
+    monkeypatch.setenv("HF_HUB_CACHE", str(roomy / "hub"))
+    # A full target volume is not sized from the roomy default cache.
+    assert tuning.hf_cache_root(tight / "hub") == tight / "hub"
+    profile = tuning.system_profile(tight / "hub")
+    assert profile.free_disk_bytes == 0 and profile.disk_source.startswith(str(tight))
+    env = tuning.xet_env_overrides(cache_dir = tight / "hub")
+    assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
+
+    # And the reverse: a full default cache does not throttle a download aimed elsewhere.
+    monkeypatch.setenv("HF_HUB_CACHE", str(tight / "hub"))
+    applied: dict = {}
+    tuning.apply_xet_env(applied, cache_dir = str(roomy / "hub"))
+    assert int(applied["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 64 * GB
+    # No cache_dir: unchanged behaviour, the environment still decides.
+    assert int(tuning.xet_env_overrides()["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -712,6 +712,10 @@ def test_a_throttle_asked_for_by_a_logged_429_survives_the_resize(monkeypatch, t
     for directory in (roomy, tight):
         directory.mkdir()
     _two_volumes(monkeypatch, str(roomy), str(tight))
+    # Pin the cores too: on a 1-2 CPU runner the ceiling is already the floor of 4, so halving it
+    # would be indistinguishable from not halving it and the test would prove nothing.
+    monkeypatch.setattr(_os, "sched_getaffinity", lambda _pid: set(range(16)))
+    monkeypatch.setattr(tuning, "cgroup_cpu_limit", lambda: None)
 
     fake_env = {"HF_HUB_CACHE": str(roomy / "hub")}
     monkeypatch.setattr(_os, "environ", fake_env)

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -28,46 +28,95 @@ GB = 1_000_000_000
 MB = 1_000_000
 
 
-def _profile(ram_gb: float, cpus: int = 8) -> tuning.SystemProfile:
+def _profile(ram_gb: float, cpus: int = 8, free_disk_gb: float = 0) -> tuning.SystemProfile:
     return tuning.SystemProfile(
         total_ram_bytes = int(ram_gb * GB),
         available_ram_bytes = int(ram_gb * GB),
         cpu_count = cpus,
         ram_source = "test",
         cpu_source = "test",
+        free_disk_bytes = int(free_disk_gb * GB),
+        disk_source = "test",
     )
 
 
 @pytest.mark.parametrize(
-    "ram_gb, limit, size, perfile, files, cpus",
+    "ram_gb, cpus, limit, size, perfile, files, streams",
     [
-        # limit is raised to the worst case (size + files*perfile) where that exceeds the tier's
-        # headline figure, so the three numbers describe one budget.
-        (8, 1024 * MB, 512 * MB, 128 * MB, 4, 8),
-        (11.9, 1024 * MB, 512 * MB, 128 * MB, 4, 8),
-        (16, 2 * GB, 768 * MB, 192 * MB, 6, 8),
-        (32, 4 * GB, 1 * GB, 256 * MB, 8, 8),
-        # A big host is still bounded, but by a budget proportional to what it has. Holding a 2 TB
-        # server to the 32 GB row cost 30% against xet-core's own defaults.
-        (128, 16 * GB, 4 * GB, 512 * MB, 16, 32),
-        (2048, 32 * GB, 8 * GB, 1000 * MB, 24, 192),
-        # ...but never more files in flight than cores, however much RAM there is.
-        (2048, 32 * GB, 8 * GB, 1000 * MB, 8, 8),
+        # An eighth of RAM is the budget, a quarter of that is the shared buffer and a
+        # thirty-second is a per-file buffer, so the numbers describe ONE allocation. The floors
+        # (256MB / 128MB) are what keep a small machine's buffers usable.
+        (8, 4, 1 * GB, 256 * MB, 128 * MB, 4, 8),
+        # No cliffs: 12 GB sits between the old table's 8 and 16 GB rows and gets a budget to match,
+        # where the old step function gave it the 8 GB row's.
+        (12, 4, 1500 * MB, 375 * MB, 128 * MB, 4, 8),
+        (16, 8, 2 * GB, 500 * MB, 128 * MB, 8, 16),
+        (32, 16, 4 * GB, 1 * GB, 128 * MB, 16, 32),
+        # A big host is bounded by a budget proportional to what it has, not by a laptop's. Holding
+        # a 2 TB server to the old flat 4 GB row cost 30% against xet-core's own defaults.
+        (128, 64, 16 * GB, 4 * GB, 500 * MB, 24, 124),
+        (2048, 192, 64 * GB, 16 * GB, 2000 * MB, 24, 124),
+        # Cores bound concurrency independently of RAM: 8 cores on a 2 TB box still gets 8 files.
+        (2048, 8, 64 * GB, 16 * GB, 2000 * MB, 8, 16),
+        # ...and so does the budget. A 64-core container with 8 GB (CI, or a cgroup-limited pod)
+        # cannot use 64 file buffers or 128 streams out of a 1 GB budget, and opening them anyway is
+        # how a small machine on a thin link ends up worse off than with no tuning at all.
+        (8, 64, 1 * GB, 256 * MB, 128 * MB, 5, 14),
     ],
 )
-def test_tier_table(ram_gb, limit, size, perfile, files, cpus):
+def test_knobs_scale_with_the_machine(ram_gb, cpus, limit, size, perfile, files, streams):
     env = tuning.xet_env_overrides(_profile(ram_gb, cpus))
     assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == limit
     assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"]) == size
     assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"]) == perfile
     assert int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) == files
+    assert int(env["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]) == streams
+
+
+def test_a_big_host_lands_on_xet_cores_own_high_performance_numbers():
+    """The point of scaling rather than gating: on the box where HF_XET_HIGH_PERFORMANCE was worth
+    2.55x (16684 vs 6553 Mbit/s), the scaled knobs reach the same buffer sizing that preset uses,
+    without the flag and without discarding the bound on smaller machines. Concurrent FILES is the
+    one number we do not follow: the preset's 100 x 2 GB is 200 GB of per-file buffer against its
+    own 64 GB limit, so most of it can never be allocated."""
+    env = tuning.xet_env_overrides(_profile(2048, cpus = 192))
+    preset = {  # xet_runtime/src/config/xet_config.rs, with_high_performance()
+        "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT": str(64 * GB),
+        "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE": str(16 * GB),
+        "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE": str(2000 * MB),
+        "HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY": "124",
+    }
+    for key, value in preset.items():
+        assert env[key] == value, key
+
+
+def test_the_budget_never_promises_more_than_the_disk_can_take():
+    """A 2 TB host with a nearly full disk is not a 2 TB budget: buffering 64 GB of a download that
+    will fail on ENOSPC helps nobody, and the free-space figure is the only signal we have."""
+    roomy = tuning.xet_env_overrides(_profile(2048, cpus = 192, free_disk_gb = 8000))
+    tight = tuning.xet_env_overrides(_profile(2048, cpus = 192, free_disk_gb = 40))
+    assert int(roomy["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 64 * GB
+    assert int(tight["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 10 * GB
+    # Never below the floor, though: a full disk must not shrink the buffer to nothing, because the
+    # download can still be the one that frees space (a resume, or a cache on another filesystem).
+    full = tuning.xet_env_overrides(_profile(2048, cpus = 192, free_disk_gb = 0.5))
+    assert int(full["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
+
+
+def test_free_disk_is_measured_for_the_cache_not_the_cwd(monkeypatch, tmp_path):
+    """The cache can sit on a different filesystem from wherever the process happens to be."""
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "not-created-yet" / "hub"))
+    assert tuning.hf_cache_root() == tmp_path / "not-created-yet" / "hub"
+    free, source = tuning._free_disk()
+    # The leaf does not exist, so it walks up to the first parent that does rather than giving up.
+    assert free > 0 and source in {str(p) for p in (tmp_path, *tmp_path.parents)}
 
 
 def test_worst_case_buffer_stays_under_the_limit():
-    """size + files*perfile is what hf_xet can hold, so it must not exceed the tier cap. The stock
+    """size + files*perfile is what hf_xet can hold, so it must not exceed the budget. The stock
     defaults (2GB + 8*512MB, capped at 8GB) are exactly how an 8GB spike happens."""
-    for ram_gb in (4, 8, 16, 32, 64, 512):
-        env = tuning.xet_env_overrides(_profile(ram_gb))
+    for ram_gb, cpus in ((4, 2), (8, 8), (8, 96), (16, 8), (32, 64), (64, 16), (512, 192), (2048, 192)):
+        env = tuning.xet_env_overrides(_profile(ram_gb, cpus))
         worst = (
             int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"])
             + int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"])
@@ -81,10 +130,10 @@ def test_worst_case_buffer_stays_under_the_limit():
         assert worst <= ram_gb * GB / 3, f"{ram_gb}GB: worst case {worst} is too much of it"
 
 
-def test_unknown_ram_picks_the_smallest_tier():
+def test_unknown_ram_is_read_as_a_small_machine():
     """Guessing low costs throughput; guessing high costs an OOM."""
     env = tuning.xet_env_overrides(_profile(0))
-    assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1024 * MB
+    assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
 
 
 def test_durations_carry_a_unit_suffix():
@@ -110,7 +159,15 @@ def test_cpu_count_bounds_concurrency():
     large = tuning.xet_env_overrides(_profile(32, cpus = 128))
     assert int(small["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) == 2
     assert int(small["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]) == 4
-    assert int(large["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]) == 64
+    # Two streams per core, but no more than the 4 GB budget has 64 MiB xorb slots for, and never
+    # more files than the budget affords buffers for.
+    assert int(large["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]) == 59
+    assert int(large["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) <= 24
+    # The ramp always starts at or below the ceiling, whichever bound produced it.
+    for env in (small, large):
+        assert int(env["HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY"]) <= int(
+            env["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]
+        )
 
 
 def test_throttled_halves_the_stream_ceiling():
@@ -127,7 +184,7 @@ def test_apply_never_overwrites_a_user_setting():
     tuning.apply_xet_env(env, profile = _profile(16))
     assert env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"] == "16000000000"
     # ...but the rest is still filled in.
-    assert env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"] == str(192 * MB)
+    assert env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"] == str(128 * MB)
 
 
 def test_a_user_set_high_performance_flag_is_left_alone():
@@ -167,7 +224,7 @@ def test_force_caps_still_overrides_high_performance(monkeypatch):
 def test_a_large_machine_is_not_held_to_a_laptops_buffer():
     """The table used to flat-line at 24 GB, so a 2 TB server got a 24 GB laptop's 4 GB buffer.
     Measured, that ran 30% BELOW xet-core's own defaults, because the buffer gates how much can be
-    in flight. Each tier must be strictly larger than the one below it."""
+    in flight. The budget must grow with the machine, monotonically and without a cliff."""
     seen = []
     for ram_gb in (8, 16, 32, 128, 512, 2048):
         env = tuning.xet_env_overrides(_profile(ram_gb, cpus = 64))
@@ -175,9 +232,8 @@ def test_a_large_machine_is_not_held_to_a_laptops_buffer():
     for (small_ram, small), (big_ram, big) in zip(seen, seen[1:]):
         assert big >= small, f"{big_ram}GB got {big} but {small_ram}GB got {small}"
     assert seen[-1][1] > seen[2][1], f"a 2TB box still capped like a 32GB one: {seen}"
-    # And the small end is untouched, which is where the cap earns its keep. (1024MB, not 1000MB:
-    # the limit is raised to the tier's own worst case, 512MB + 4*128MB.)
-    assert seen[0][1] == 1024 * MB
+    # And the small end is untouched, which is where the bound earns its keep.
+    assert seen[0][1] == 1 * GB
 
 
 def test_cgroup_limit_beats_the_host_total(monkeypatch, tmp_path):
@@ -191,8 +247,8 @@ def test_cgroup_limit_beats_the_host_total(monkeypatch, tmp_path):
     assert profile.ram_source == "cgroup"
     assert profile.cpu_count == 2
     env = tuning.xet_env_overrides(profile)
-    # Smallest tier and only 2 files in flight, so the 1GB limit is already above the worst case
-    # (512MB + 2*128MB) and stands unchanged.
+    # An eighth of 8 GB is the 1 GB floor, and the 2-core quota allows only 2 files in flight, so
+    # the worst case (256MB + 2*128MB) sits well inside it.
     assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
     assert int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) == 2
 
@@ -321,3 +377,66 @@ def test_apply_xet_env_does_not_shorten_timeouts_process_wide():
     child: dict[str, str] = {}
     tuning.apply_xet_env(child, profile = _profile(16), fail_fast = True)
     assert child["HF_XET_CLIENT_RETRY_MAX_ATTEMPTS"] == "2"
+
+
+# Real machines Unsloth actually runs on, smallest first. A regression that only shows up on a
+# 2-core Colab or a 0.5-core pod is one nobody here can reproduce, so they are pinned by name.
+DEVICES = [
+    # name,                     RAM GB, cpus, free disk GB
+    ("tiny VM",                      2,    2,     8),
+    ("k8s pod, 0.5 cpu quota",       4,    1,    20),
+    ("MacBook Air M2",               8,    8,   100),
+    ("GitHub CI runner",            16,    4,    14),
+    ("Colab free T4",             12.7,    2,    78),
+    ("Kaggle T4 x2",                29,    4,    57),
+    ("desktop, RTX 4090",           32,   16,   500),
+    ("CI container on a big host",   8,   64,   200),
+    ("Slurm step on a 1TB node",    32,    8,  1000),
+    ("A100 node",                  200,   32,  3000),
+    ("8xH100 node",               2048,  192,  8000),
+]
+
+
+@pytest.mark.parametrize("name, ram_gb, cpus, disk_gb", DEVICES, ids = [d[0] for d in DEVICES])
+def test_every_device_stays_within_its_own_means(name, ram_gb, cpus, disk_gb):
+    """One rule per resource, applied to every device we know of. Being generous on a big host is
+    only defensible if the same arithmetic is conservative on a small one, and the small ones are
+    where nobody notices until a user reports an OOM or a stalled download on hotel wifi."""
+    env = tuning.xet_env_overrides(_profile(ram_gb, cpus, disk_gb))
+    limit = int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"])
+    size = int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"])
+    perfile = int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"])
+    files = int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"])
+    streams = int(env["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"])
+    initial = int(env["HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY"])
+    worst = size + files * perfile
+
+    assert worst <= limit, f"{name}: {worst} in flight against a {limit} budget"
+    assert worst <= ram_gb * GB / 3, f"{name}: {worst} is too much of {ram_gb}GB"
+    assert limit <= max(1 * GB, disk_gb * GB / 4), f"{name}: {limit} buffered onto {disk_gb}GB free"
+    assert 2 <= files <= max(2, cpus), f"{name}: {files} files on {cpus} cores"
+    # A stream holds a xorb; more of them than the budget can hold is queueing, not parallelism.
+    assert 4 <= streams <= max(4, min(cpus * 2, limit // (64 * 1024 * 1024))), f"{name}: {streams}"
+    assert 2 <= initial <= streams, f"{name}: ramp starts at {initial} of {streams}"
+
+
+def test_the_smallest_devices_get_the_smallest_numbers():
+    """The floors are the whole safety story on a 2 GB VM or a fractional-core pod: one shared
+    buffer, two files, four streams. Anything larger there is worse than not tuning at all."""
+    for name, ram_gb, cpus, disk_gb in DEVICES[:2]:
+        env = tuning.xet_env_overrides(_profile(ram_gb, cpus, disk_gb))
+        assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB, name
+        assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"]) == 256 * MB, name
+        assert int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"]) == 2, name
+        assert int(env["HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY"]) == 4, name
+
+
+def test_only_the_big_hosts_get_the_big_numbers():
+    """The converse, and the point of the change: the devices that can afford xet-core's own
+    high-performance sizing are the only ones that get it."""
+    big = {
+        name for name, ram_gb, cpus, disk_gb in DEVICES
+        if int(tuning.xet_env_overrides(_profile(ram_gb, cpus, disk_gb))
+               ["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) > 8 * GB
+    }
+    assert big == {"A100 node", "8xH100 node"}

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -661,3 +661,40 @@ def test_an_explicit_cache_dir_is_the_disk_that_gets_measured(monkeypatch, tmp_p
     assert int(applied["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 64 * GB
     # No cache_dir: unchanged behaviour, the environment still decides.
     assert int(tuning.xet_env_overrides()["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
+
+
+def test_a_process_already_sized_at_import_still_resizes_for_its_destination(monkeypatch, tmp_path):
+    """``apply_xet_env`` is setdefault and ``unsloth_zoo`` sizes itself at import, so by the time a
+    download names its ``cache_dir`` every sizing key is already in the environment and a second
+    apply writes nothing: the download would run on the global cache's numbers. ``resize_for_cache_dir``
+    drops what we seeded so the recompute lands, and leaves anything we did not write alone."""
+    import os as _os
+
+    roomy = tmp_path / "roomy"
+    tight = tmp_path / "tight"
+    for directory in (roomy, tight):
+        directory.mkdir()
+    _two_volumes(monkeypatch, str(roomy), str(tight))
+
+    fake_env = {"HF_HUB_CACHE": str(roomy / "hub")}
+    monkeypatch.setattr(_os, "environ", fake_env)
+    monkeypatch.setattr(tuning, "_SEEDED_INTO_ENVIRON", {})
+
+    tuning.apply_xet_env()  # what import does: sizes against the roomy default cache
+    assert int(fake_env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 64 * GB
+
+    # A second apply is a no-op on the seeded keys, which is the bug the resize exists to fix.
+    assert "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT" not in tuning.apply_xet_env(
+        dict(fake_env), cache_dir = tight / "hub",
+    )
+
+    written = tuning.resize_for_cache_dir(dict(fake_env), tight / "hub")
+    assert int(written["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == 1 * GB
+
+    # A value we never wrote is not ours to recompute.
+    user_env = dict(fake_env)
+    user_env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"] = "16000000000"
+    assert "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT" not in tuning.resize_for_cache_dir(
+        user_env, tight / "hub",
+    )
+    assert user_env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"] == "16000000000"

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -114,6 +114,29 @@ def test_free_disk_is_measured_for_the_cache_not_the_cwd(monkeypatch, tmp_path):
     assert free > 0 and source in {str(p) for p in (tmp_path, *tmp_path.parents)}
 
 
+def test_cache_root_follows_hubs_full_precedence(monkeypatch, tmp_path):
+    """A cache moved with XDG_CACHE_HOME or the legacy HUGGINGFACE_HUB_CACHE lives on a different
+    filesystem from ``~``, so measuring the home directory's free space sizes the buffer from a
+    disk the download never writes to."""
+    for var in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE", "HF_HOME", "XDG_CACHE_HOME"):
+        monkeypatch.delenv(var, raising = False)
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert tuning.hf_cache_root() == tmp_path / "xdg" / "huggingface" / "hub"
+
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(tmp_path / "legacy"))
+    assert tuning.hf_cache_root() == tmp_path / "legacy"
+
+    # HF_HOME names the home, not the hub cache: Hub appends "hub" to it.
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE")
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "home"))
+    assert tuning.hf_cache_root() == tmp_path / "home" / "hub"
+
+    # HF_HUB_CACHE is still the most specific and wins over all of them.
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "explicit"))
+    assert tuning.hf_cache_root() == tmp_path / "explicit"
+
+
 def test_worst_case_buffer_stays_under_the_limit():
     """size + files*perfile is what hf_xet can hold, so it must not exceed the budget. The stock
     defaults (2GB + 8*512MB, capped at 8GB) are exactly how an 8GB spike happens."""
@@ -534,3 +557,30 @@ def test_a_machine_that_can_hold_xet_cores_own_buffer_gets_it(ram_gb, cpus):
     # ...so a machine with room for stock on both counts is never handed less than stock.
     if limit // 2 >= stock and ram_gb * GB / 6 >= stock:
         assert size >= stock, f"{ram_gb}GB undercut stock: {size}"
+
+
+def test_a_small_container_with_many_cores_still_fits_a_third_of_its_ram():
+    """The budget floor is absolute, so on a 2 GB machine it is half the RAM, and letting cores
+    alone set the file count put 973 MB in flight there. The proportional promise has to win."""
+    for cpus in (2, 8, 64):
+        env = tuning.xet_env_overrides(_profile(2, cpus))
+        worst = (
+            int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"])
+            + int(env["HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS"])
+            * int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"])
+        )
+        assert worst <= 2 * GB / 3, f"2GB/{cpus} cores: {worst} in flight"
+
+
+def test_the_flag_is_read_the_way_xet_core_reads_it():
+    """xet-core checks HF_XET_HIGH_PERFORMANCE and only falls back to the HF_XET_HP alias when the
+    first is unset (configuration_utils.rs get_high_performance_flag), so an explicit "0" masks the
+    alias. Standing our sizing down over an alias xet-core is ignoring would leave the machine on
+    xet-core's stock constants instead of the ones we sized for it."""
+    masked = {"HF_XET_HIGH_PERFORMANCE": "0", "HF_XET_HP": "1"}
+    tuning.apply_xet_env(masked, profile = _profile(16))
+    assert "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT" in masked, "sizing stood down for nothing"
+
+    alias_only = {"HF_XET_HP": "1"}
+    tuning.apply_xet_env(alias_only, profile = _profile(16))
+    assert "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT" not in alias_only

--- a/tests/test_hf_xet_tuning.py
+++ b/tests/test_hf_xet_tuning.py
@@ -39,19 +39,24 @@ def _profile(ram_gb: float, cpus: int = 8) -> tuning.SystemProfile:
 
 
 @pytest.mark.parametrize(
-    "ram_gb, limit, size, perfile, files",
+    "ram_gb, limit, size, perfile, files, cpus",
     [
         # limit is raised to the worst case (size + files*perfile) where that exceeds the tier's
         # headline figure, so the three numbers describe one budget.
-        (8, 1024 * MB, 512 * MB, 128 * MB, 4),
-        (11.9, 1024 * MB, 512 * MB, 128 * MB, 4),
-        (16, 2 * GB, 768 * MB, 192 * MB, 6),
-        (32, 4 * GB, 1 * GB, 256 * MB, 8),
-        (2048, 4 * GB, 1 * GB, 256 * MB, 8),  # a huge host is still capped
+        (8, 1024 * MB, 512 * MB, 128 * MB, 4, 8),
+        (11.9, 1024 * MB, 512 * MB, 128 * MB, 4, 8),
+        (16, 2 * GB, 768 * MB, 192 * MB, 6, 8),
+        (32, 4 * GB, 1 * GB, 256 * MB, 8, 8),
+        # A big host is still bounded, but by a budget proportional to what it has. Holding a 2 TB
+        # server to the 32 GB row cost 30% against xet-core's own defaults.
+        (128, 16 * GB, 4 * GB, 512 * MB, 16, 32),
+        (2048, 32 * GB, 8 * GB, 1000 * MB, 24, 192),
+        # ...but never more files in flight than cores, however much RAM there is.
+        (2048, 32 * GB, 8 * GB, 1000 * MB, 8, 8),
     ],
 )
-def test_tier_table(ram_gb, limit, size, perfile, files):
-    env = tuning.xet_env_overrides(_profile(ram_gb))
+def test_tier_table(ram_gb, limit, size, perfile, files, cpus):
+    env = tuning.xet_env_overrides(_profile(ram_gb, cpus))
     assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"]) == limit
     assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE"]) == size
     assert int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"]) == perfile
@@ -70,7 +75,10 @@ def test_worst_case_buffer_stays_under_the_limit():
         )
         limit = int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"])
         assert worst <= limit, f"{ram_gb}GB: worst case {worst} exceeds limit {limit}"
-        assert limit <= 4 * GB  # never the stock 8GB, let alone high-performance's 64GB
+        # The bound that matters is proportional, not absolute: never more than a third of the
+        # machine's RAM, so the buffer cannot be the reason a box OOMs. A large host is allowed a
+        # large budget precisely because it has one to spare.
+        assert worst <= ram_gb * GB / 3, f"{ram_gb}GB: worst case {worst} is too much of it"
 
 
 def test_unknown_ram_picks_the_smallest_tier():
@@ -122,19 +130,54 @@ def test_apply_never_overwrites_a_user_setting():
     assert env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE"] == str(192 * MB)
 
 
-def test_apply_clears_an_inherited_high_performance_flag():
-    """The one deliberate exception to setdefault: an inherited "1" would void every cap."""
+def test_a_user_set_high_performance_flag_is_left_alone():
+    """We used to clear it, which is how a machine that had opted in lost 2.55x of its download
+    throughput the moment it imported unsloth_zoo (16684 -> 6553 Mbit/s, measured on a 192-core
+    1996 GiB box). Enabling it is a deliberate act; setdefault applies to it like everything else."""
+    for var in ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP"):
+        env = {var: "1"}
+        written = tuning.apply_xet_env(env, profile = _profile(16))
+        assert env[var] == "1", var
+        assert var not in written, var
+
+
+def test_high_performance_also_stands_our_sizing_down():
+    """Leaving the caps on alongside it is the worst of both: xet-core reads the flag last and
+    voids the LIMIT, but still honours the smaller per-file and concurrency numbers, so the
+    transfer ends up smaller than either choice made cleanly."""
     env = {"HF_XET_HIGH_PERFORMANCE": "1"}
     tuning.apply_xet_env(env, profile = _profile(16))
-    assert env["HF_XET_HIGH_PERFORMANCE"] == "0"
+    for key in tuning._CAPS_VOIDED_BY_HIGH_PERFORMANCE:
+        assert key not in env, key
+    # Non-sizing settings are unrelated to the memory bound and still apply.
+    assert env["HF_XET_CHUNK_CACHE_SIZE_BYTES"] == "0"
 
 
-def test_user_can_opt_back_into_high_performance(monkeypatch):
-    monkeypatch.setenv("UNSLOTH_XET_ALLOW_HIGH_PERFORMANCE", "1")
+def test_force_caps_still_overrides_high_performance(monkeypatch):
+    """The escape hatch for someone who really does want a machine bounded: the flag has to be
+    turned off for the caps to mean anything, so this is the one case that overwrites it."""
+    monkeypatch.setenv("UNSLOTH_XET_FORCE_CAPS", "1")
     env = {"HF_XET_HIGH_PERFORMANCE": "1"}
     written = tuning.apply_xet_env(env, profile = _profile(16))
-    assert env["HF_XET_HIGH_PERFORMANCE"] == "1"
-    assert "HF_XET_HIGH_PERFORMANCE" not in written
+    assert env["HF_XET_HIGH_PERFORMANCE"] == "0"
+    assert written["HF_XET_HIGH_PERFORMANCE"] == "0"
+    assert env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"] == str(2 * GB)
+
+
+def test_a_large_machine_is_not_held_to_a_laptops_buffer():
+    """The table used to flat-line at 24 GB, so a 2 TB server got a 24 GB laptop's 4 GB buffer.
+    Measured, that ran 30% BELOW xet-core's own defaults, because the buffer gates how much can be
+    in flight. Each tier must be strictly larger than the one below it."""
+    seen = []
+    for ram_gb in (8, 16, 32, 128, 512, 2048):
+        env = tuning.xet_env_overrides(_profile(ram_gb, cpus = 64))
+        seen.append((ram_gb, int(env["HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT"])))
+    for (small_ram, small), (big_ram, big) in zip(seen, seen[1:]):
+        assert big >= small, f"{big_ram}GB got {big} but {small_ram}GB got {small}"
+    assert seen[-1][1] > seen[2][1], f"a 2TB box still capped like a 32GB one: {seen}"
+    # And the small end is untouched, which is where the cap earns its keep. (1024MB, not 1000MB:
+    # the limit is raised to the tier's own worst case, 512MB + 4*128MB.)
+    assert seen[0][1] == 1024 * MB
 
 
 def test_cgroup_limit_beats_the_host_total(monkeypatch, tmp_path):

--- a/unsloth_zoo/__init__.py
+++ b/unsloth_zoo/__init__.py
@@ -82,7 +82,6 @@ redirect_hf_cache_if_readonly()
 from .hf_xet_tuning import apply_xet_env
 _, _, xet_cache = _active_caches()
 apply_xet_env(throttled = has_429_exact_full_read(xet_cache / "logs") if xet_cache is not None else False)
-os.environ.setdefault("HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY", "0")
 del has_429_exact_full_read, xet_cache, redirect_hf_cache_if_readonly, _active_caches, apply_xet_env
 
 # More verbose HF Hub info

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -1238,20 +1238,15 @@ def _run_download_attempt(
         # hf_xet reads its config natively at import, so the buffer caps must be in the environment
         # BEFORE the child starts; setting them inside the child is too late.
         try:
-            from .hf_xet_tuning import xet_env_overrides
+            from .hf_xet_tuning import apply_xet_env
 
-            for key, value in xet_env_overrides().items():
-                # An explicit user setting still wins; only fill what is unset.
-                if key not in os.environ:
-                    child_env[key] = value
-            # High-performance mode is a preset applied after the environment is read, so it would
-            # override the caps above rather than merge with them.
-            from .hf_xet_tuning import XET_HIGH_PERFORMANCE_VARS
-
-            if not _is_true(os.environ.get("UNSLOTH_XET_ALLOW_HIGH_PERFORMANCE")):
-                for var in XET_HIGH_PERFORMANCE_VARS:
-                    if _is_true(os.environ.get(var)):
-                        child_env[var] = "0"
+            # Decide against a COPY of the real environment so the child is tuned exactly the way
+            # this process was at import: setdefault semantics keep every explicit user setting, and
+            # a user-set HF_XET_HIGH_PERFORMANCE stands our sizing down here too instead of being
+            # forced back to 0 for the one path that does the downloading. apply_xet_env returns
+            # only what it wrote, which is precisely what the child needs on top of what it
+            # inherits. UNSLOTH_XET_FORCE_CAPS=1 still caps the machine regardless.
+            child_env.update(apply_xet_env(dict(os.environ), fail_fast = True))
         except Exception as e:
             logger.debug("Could not compute Xet tuning env: %s", e)
     with _SPAWN_ENV_LOCK:

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -1104,12 +1104,12 @@ def _download_child_entry(
         # Defensive: the parent already seeded these around the spawn, but a child launched by any
         # other path must not inherit hf_xet's unbounded multi-GB buffer defaults.
         try:
-            from unsloth_zoo.hf_xet_tuning import apply_xet_env
+            from unsloth_zoo.hf_xet_tuning import resize_for_cache_dir
 
             # A supervised child, so the shortened Xet timeouts belong here: a failure surfaces to
-            # the ladder instead of being retried for ~6 minutes. cache_dir sizes the child against
-            # the volume it downloads to, matching what the parent sized against.
-            apply_xet_env(fail_fast = True, cache_dir = params.get("cache_dir"))
+            # the ladder instead of being retried for ~6 minutes. resize, not apply: our own
+            # import-time sizing is already in this environment and setdefault would keep it.
+            resize_for_cache_dir(os.environ, params.get("cache_dir"))
         except Exception as e:
             logger.debug("Could not apply Xet tuning in child: %s", e)
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
@@ -1239,19 +1239,18 @@ def _run_download_attempt(
         # hf_xet reads its config natively at import, so the buffer caps must be in the environment
         # BEFORE the child starts; setting them inside the child is too late.
         try:
-            from .hf_xet_tuning import apply_xet_env
+            from .hf_xet_tuning import resize_for_cache_dir
 
             # Decide against a COPY of the real environment so the child is tuned exactly the way
             # this process was at import: setdefault semantics keep every explicit user setting, and
             # a user-set HF_XET_HIGH_PERFORMANCE stands our sizing down here too instead of being
-            # forced back to 0 for the one path that does the downloading. apply_xet_env returns
-            # only what it wrote, which is precisely what the child needs on top of what it
-            # inherits. UNSLOTH_XET_FORCE_CAPS=1 still caps the machine regardless.
-            # huggingface_hub honours cache_dir over HF_HUB_CACHE, so pass it: the disk clamp then
-            # reads the child's real destination, not whichever cache our environment names.
-            child_env.update(apply_xet_env(
-                dict(os.environ), fail_fast = True, cache_dir = params.get("cache_dir"),
-            ))
+            # forced back to 0 for the one path that does the downloading. The call returns only
+            # what it wrote, which is precisely what the child needs on top of what it inherits.
+            # UNSLOTH_XET_FORCE_CAPS=1 still caps the machine regardless. It resizes rather than
+            # applies because our import-time numbers are already in that copy and setdefault would
+            # keep them: huggingface_hub honours cache_dir over HF_HUB_CACHE, so the disk clamp has
+            # to be redone against the child's real destination.
+            child_env.update(resize_for_cache_dir(dict(os.environ), params.get("cache_dir")))
         except Exception as e:
             logger.debug("Could not compute Xet tuning env: %s", e)
     with _SPAWN_ENV_LOCK:

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -1235,25 +1235,27 @@ def _run_download_attempt(
     if disable_xet:
         child_env["HF_HUB_DISABLE_XET"] = "1"
         child_env["HF_HUB_ENABLE_HF_TRANSFER"] = "0"
-    else:
-        # hf_xet reads its config natively at import, so the buffer caps must be in the environment
-        # BEFORE the child starts; setting them inside the child is too late.
-        try:
-            from .hf_xet_tuning import resize_for_cache_dir
-
-            # Decide against a COPY of the real environment so the child is tuned exactly the way
-            # this process was at import: setdefault semantics keep every explicit user setting, and
-            # a user-set HF_XET_HIGH_PERFORMANCE stands our sizing down here too instead of being
-            # forced back to 0 for the one path that does the downloading. The call returns only
-            # what it wrote, which is precisely what the child needs on top of what it inherits.
-            # UNSLOTH_XET_FORCE_CAPS=1 still caps the machine regardless. It resizes rather than
-            # applies because our import-time numbers are already in that copy and setdefault would
-            # keep them: huggingface_hub honours cache_dir over HF_HUB_CACHE, so the disk clamp has
-            # to be redone against the child's real destination.
-            child_env.update(resize_for_cache_dir(dict(os.environ), params.get("cache_dir")))
-        except Exception as e:
-            logger.debug("Could not compute Xet tuning env: %s", e)
     with _SPAWN_ENV_LOCK:
+        if not disable_xet:
+            # hf_xet reads its config natively at import, so the buffer caps must be in the
+            # environment BEFORE the child starts; setting them inside the child is too late.
+            try:
+                from .hf_xet_tuning import resize_for_cache_dir
+
+                # Decide against a COPY of the real environment so the child is tuned exactly the
+                # way this process was at import: setdefault semantics keep every explicit user
+                # setting, and a user-set HF_XET_HIGH_PERFORMANCE stands our sizing down here too
+                # instead of being forced back to 0 for the one path that does the downloading. The
+                # call returns only what it wrote, which is precisely what the child needs on top of
+                # what it inherits. UNSLOTH_XET_FORCE_CAPS=1 still caps the machine regardless. It
+                # resizes rather than applies because our import-time numbers are already in that
+                # copy and setdefault would keep them: huggingface_hub honours cache_dir over
+                # HF_HUB_CACHE, so the disk clamp has to be redone against the child's destination.
+                # Under the lock, so the copy cannot catch a concurrent spawn's temporary overlay
+                # below and read another child's numbers as this user's own settings.
+                child_env.update(resize_for_cache_dir(dict(os.environ), params.get("cache_dir")))
+            except Exception as e:
+                logger.debug("Could not compute Xet tuning env: %s", e)
         # Cache Hub's transport constants in the PARENT from the REAL env NOW, before the child-only
         # HF_HUB_DISABLE_XET=1 is briefly set below: else a concurrent thread's FIRST `import
         # huggingface_hub` in the spawn window caches the disabled value and routes later in-process

--- a/unsloth_zoo/hf_xet_fallback.py
+++ b/unsloth_zoo/hf_xet_fallback.py
@@ -1107,8 +1107,9 @@ def _download_child_entry(
             from unsloth_zoo.hf_xet_tuning import apply_xet_env
 
             # A supervised child, so the shortened Xet timeouts belong here: a failure surfaces to
-            # the ladder instead of being retried for ~6 minutes.
-            apply_xet_env(fail_fast = True)
+            # the ladder instead of being retried for ~6 minutes. cache_dir sizes the child against
+            # the volume it downloads to, matching what the parent sized against.
+            apply_xet_env(fail_fast = True, cache_dir = params.get("cache_dir"))
         except Exception as e:
             logger.debug("Could not apply Xet tuning in child: %s", e)
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
@@ -1246,7 +1247,11 @@ def _run_download_attempt(
             # forced back to 0 for the one path that does the downloading. apply_xet_env returns
             # only what it wrote, which is precisely what the child needs on top of what it
             # inherits. UNSLOTH_XET_FORCE_CAPS=1 still caps the machine regardless.
-            child_env.update(apply_xet_env(dict(os.environ), fail_fast = True))
+            # huggingface_hub honours cache_dir over HF_HUB_CACHE, so pass it: the disk clamp then
+            # reads the child's real destination, not whichever cache our environment names.
+            child_env.update(apply_xet_env(
+                dict(os.environ), fail_fast = True, cache_dir = params.get("cache_dir"),
+            ))
         except Exception as e:
             logger.debug("Could not compute Xet tuning env: %s", e)
     with _SPAWN_ENV_LOCK:

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -246,7 +246,7 @@ def _sysconf_memory() -> Optional[int]:
         return None
 
 
-def hf_cache_root() -> Path:
+def hf_cache_root(cache_dir: "Optional[str | Path]" = None) -> Path:
     """Where downloads land, in the same precedence huggingface_hub itself uses.
 
     ``hf_cache._active_caches`` already mirrors that precedence -- ``HF_HUB_CACHE``, the legacy
@@ -254,7 +254,15 @@ def hf_cache_root() -> Path:
     resolving anything less measures a filesystem the download may never touch: with
     ``XDG_CACHE_HOME`` or ``HUGGINGFACE_HUB_CACHE`` pointed at a data volume, the free space of the
     home directory decides the buffer instead.
+
+    *cache_dir* wins over all of them: ``hf_hub_download`` only consults the variables when it is
+    None, so a caller that names one has named the volume the bytes land on.
     """
+    if cache_dir is not None:
+        try:
+            return Path(os.path.expanduser(os.fspath(cache_dir)))
+        except (TypeError, ValueError):
+            pass
     try:
         from .hf_cache import _active_caches
 
@@ -267,11 +275,11 @@ def hf_cache_root() -> Path:
         return Path(".")
 
 
-def _free_disk() -> "tuple[int, str]":
+def _free_disk(cache_dir: "Optional[str | Path]" = None) -> "tuple[int, str]":
     """Free bytes on the filesystem holding the HF cache, walking up to the first path that exists."""
     import shutil
 
-    candidate = hf_cache_root()
+    candidate = hf_cache_root(cache_dir)
     for path in (candidate, *candidate.parents):
         try:
             return int(shutil.disk_usage(path).free), str(path)
@@ -280,8 +288,10 @@ def _free_disk() -> "tuple[int, str]":
     return 0, "unknown"
 
 
-def system_profile() -> SystemProfile:
-    """Usable RAM and cores for THIS process, preferring a cgroup limit over the host's totals."""
+def system_profile(cache_dir: "Optional[str | Path]" = None) -> SystemProfile:
+    """Usable RAM and cores for THIS process, preferring a cgroup limit over the host's totals.
+
+    *cache_dir* is the download's real destination, so the disk reading follows the bytes."""
     host_total, host_available = _psutil_memory()
     if host_total is None:
         host_total = _sysconf_memory()
@@ -296,7 +306,7 @@ def system_profile() -> SystemProfile:
         total = host_total or 0
         available = host_available if host_available is not None else total
 
-    free_disk, disk_source = _free_disk()
+    free_disk, disk_source = _free_disk(cache_dir)
 
     try:
         cpus = len(os.sched_getaffinity(0))  # respects taskset / CPU pinning
@@ -351,6 +361,7 @@ def xet_env_overrides(
     *,
     throttled: bool = False,
     fail_fast: bool = True,
+    cache_dir: "Optional[str | Path]" = None,
 ) -> dict[str, str]:
     """RAM/CPU/disk-derived ``HF_XET_*`` settings. Pure: returns a dict, touches no environment.
 
@@ -362,8 +373,11 @@ def xet_env_overrides(
     account rather than the machine is the limiting factor. *fail_fast* keeps the shortened Xet
     timeouts, which only suit callers whose failure our Xet -> HTTP ladder can act on. Unknown total
     RAM (0) reads as small: guessing low costs throughput, guessing high costs an OOM.
+
+    *cache_dir* points the disk clamp at the volume the bytes land on. Ignored when *profile* is
+    supplied, which already carries its own disk reading.
     """
-    profile = profile or system_profile()
+    profile = profile or system_profile(cache_dir)
     # Unknown RAM reads as small: guessing low costs throughput, guessing high costs an OOM.
     total = profile.total_ram_bytes or 8 * _GB
     limit = _clamp(total // _RAM_FRACTION, _MIN_BUFFER_LIMIT, _MAX_BUFFER_LIMIT)
@@ -470,6 +484,7 @@ def apply_xet_env(
     throttled: bool = False,
     force: bool = False,
     fail_fast: bool = False,
+    cache_dir: "Optional[str | Path]" = None,
 ) -> dict[str, str]:
     """Apply the overrides to *env* (default: ``os.environ``) and return only what was written.
 
@@ -488,9 +503,14 @@ def apply_xet_env(
     defaults to False here, unlike ``xet_env_overrides``, because this runs at import: the shortened
     timeouts would otherwise apply to every direct ``huggingface_hub`` download and upload in the
     process, none of which our ladder supervises. Supervised children pass ``fail_fast = True``.
+
+    *cache_dir* is the destination the sized process will pass huggingface_hub; naming it keeps the
+    disk clamp off an unrelated filesystem in both directions.
     """
     target = os.environ if env is None else env
-    overrides = xet_env_overrides(profile, throttled = throttled, fail_fast = fail_fast)
+    overrides = xet_env_overrides(
+        profile, throttled = throttled, fail_fast = fail_fast, cache_dir = cache_dir,
+    )
 
     # A user who turned high-performance mode on keeps it, and keeps the headroom it implies:
     # leaving our caps in place alongside it would be the worst of both, since xet-core would void

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -60,21 +60,26 @@ XET_HIGH_PERFORMANCE_VARS = ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP")
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
-# (exclusive upper bound on total RAM, buffer_limit, buffer_size, perfile_size, max_concurrent_files)
+# xet-core's high-performance preset is not a mode, it is a set of ordinary knobs
+# (xet_runtime/src/config/xet_config.rs with_high_performance): a 64 GB buffer limit, 16 GB of
+# buffer, 2 GB per file, 124 streams. So rather than choose between "capped" and "that preset", we
+# write the same knobs scaled to the machine in front of us.
 #
-# The table used to stop at 24 GB, so a 2 TB server was held to a 24 GB laptop's 4 GB buffer. That
-# is not a neutral default: measured on a 192-core / 1996 GiB box against a 20 Gbit/s link, the old
-# top tier ran at 4586 Mbit/s where xet-core's own defaults managed 6553 -- capping cost 30% BELOW
-# stock, because the buffer gates how much can be in flight, which gates CPU, which gates the wire.
-# Big machines get tiers that scale; the small ones are unchanged, which is where the cap earns its
-# keep.
-_TIERS = (
-    (12 * _GB,  1 * _GB,  512 * _MB, 128 * _MB,  4),
-    (24 * _GB,  2 * _GB,  768 * _MB, 192 * _MB,  6),
-    (64 * _GB,  4 * _GB,  1 * _GB,   256 * _MB,  8),
-    (256 * _GB, 16 * _GB, 4 * _GB,   512 * _MB, 16),
-    (None,      32 * _GB, 8 * _GB,   1 * _GB,   24),
-)
+# One eighth of RAM is the anchor. It reproduces the table this replaces at every point it had
+# (8 GB -> 1 GB, 16 -> 2, 32 -> 4, 128 -> 16, 256 -> 32) and simply keeps going, so a big host gets
+# a big budget and a laptop is unchanged. The ceiling is xet-core's own 64 GB, because past that
+# the preset stops helping and we would only be reserving address space.
+_RAM_FRACTION = 8
+_MIN_BUFFER_LIMIT = 1 * _GB
+_MAX_BUFFER_LIMIT = 64 * _GB
+# Measured on a 192-core 1996 GiB box against a 20 Gbit/s link: raising the BUFFER group alone is
+# worth 2.41x (6771 -> 16306 Mbit/s), raising the CONCURRENCY group alone is worth nothing (0.92x).
+# So the buffer is the lever, and streams and files exist only to keep it fed -- which is why they
+# follow cores, and why neither is allowed past what the buffer budget can actually hold.
+_MAX_STREAMS = 124
+_MAX_CONCURRENT_FILES = 24
+# xet-core's xorb size: the unit a single download stream has outstanding at any moment.
+_XORB_BYTES = 64 * 1024 * 1024
 
 # Below this much usable RAM, callers prefer HTTP over Xet (see hf_xet_health).
 MIN_XET_RAM_BYTES = 4 * _GB
@@ -216,6 +221,11 @@ class SystemProfile:
     cpu_count: int
     ram_source: str
     cpu_source: str
+    # Free space where the download will land. Sizing a multi-GB buffer for a transfer the disk
+    # cannot hold just wastes RAM, and a nearly full disk is a better predictor of a doomed
+    # download than anything else we can see cheaply.
+    free_disk_bytes: int = 0
+    disk_source: str = "unknown"
 
 
 def _psutil_memory() -> tuple[Optional[int], Optional[int]]:
@@ -238,6 +248,28 @@ def _sysconf_memory() -> Optional[int]:
         return None
 
 
+def hf_cache_root() -> Path:
+    """Where downloads land, in the same precedence huggingface_hub itself uses."""
+    for var in ("HF_HUB_CACHE", "HF_HOME"):
+        value = os.environ.get(var)
+        if value:
+            return Path(value).expanduser()
+    return Path.home() / ".cache" / "huggingface"
+
+
+def _free_disk() -> "tuple[int, str]":
+    """Free bytes on the filesystem holding the HF cache, walking up to the first path that exists."""
+    import shutil
+
+    candidate = hf_cache_root()
+    for path in (candidate, *candidate.parents):
+        try:
+            return int(shutil.disk_usage(path).free), str(path)
+        except OSError:
+            continue
+    return 0, "unknown"
+
+
 def system_profile() -> SystemProfile:
     """Usable RAM and cores for THIS process, preferring a cgroup limit over the host's totals."""
     host_total, host_available = _psutil_memory()
@@ -253,6 +285,8 @@ def system_profile() -> SystemProfile:
     else:
         total = host_total or 0
         available = host_available if host_available is not None else total
+
+    free_disk, disk_source = _free_disk()
 
     try:
         cpus = len(os.sched_getaffinity(0))  # respects taskset / CPU pinning
@@ -273,6 +307,8 @@ def system_profile() -> SystemProfile:
         cpu_count = max(1, int(cpus)),
         ram_source = ram_source,
         cpu_source = cpu_source,
+        free_disk_bytes = free_disk,
+        disk_source = disk_source,
     )
 
 
@@ -306,28 +342,50 @@ def xet_env_overrides(
     throttled: bool = False,
     fail_fast: bool = True,
 ) -> dict[str, str]:
-    """RAM/CPU-derived ``HF_XET_*`` settings. Pure: returns a dict, touches no environment.
+    """RAM/CPU/disk-derived ``HF_XET_*`` settings. Pure: returns a dict, touches no environment.
+
+    The budget scales continuously with the machine rather than stepping through a table, so a
+    laptop keeps a laptop's buffers and a large host reaches xet-core's own high-performance sizing
+    without the flag that would discard every bound.
 
     *throttled* halves the stream ceiling; set after a logged "429 Too Many Requests", where the
     account rather than the machine is the limiting factor. *fail_fast* keeps the shortened Xet
     timeouts, which only suit callers whose failure our Xet -> HTTP ladder can act on. Unknown total
-    RAM (0) yields the smallest tier: guessing low costs throughput, guessing high costs an OOM.
+    RAM (0) reads as small: guessing low costs throughput, guessing high costs an OOM.
     """
     profile = profile or system_profile()
-    total = profile.total_ram_bytes or _TIERS[0][0] - 1
-    tier = next(t for t in _TIERS if t[0] is None or total < t[0])
-    _, limit, size, perfile, max_files = tier
+    # Unknown RAM reads as small: guessing low costs throughput, guessing high costs an OOM.
+    total = profile.total_ram_bytes or 8 * _GB
+    limit = _clamp(total // _RAM_FRACTION, _MIN_BUFFER_LIMIT, _MAX_BUFFER_LIMIT)
+
+    # Never size a buffer for a transfer the disk cannot land. A quarter of free space is generous
+    # for a buffer and still refuses to promise 64 GB of in-flight data to a disk with 20 GB left.
+    free = profile.free_disk_bytes
+    if free:
+        limit = _clamp(min(limit, free // 4), _MIN_BUFFER_LIMIT, _MAX_BUFFER_LIMIT)
+
+    # Proportions from the high-performance preset, which is the shape xet-core itself considers
+    # balanced: a quarter of the budget as the shared buffer, a thirty-second per file.
+    size = max(limit // 4, 256 * _MB)
+    perfile = max(limit // 32, 128 * _MB)
 
     cpus = profile.cpu_count
-    # More files in flight than cores buys nothing and multiplies the per-file buffer.
-    max_files = _clamp(max_files, 2, max(2, cpus))
-    streams = _clamp(cpus * 2, 4, 64)
+    # More files or streams in flight than the machine has cores buys nothing -- and neither does
+    # more files than the budget can hold buffers for: size + max_files * perfile is what hf_xet
+    # can have outstanding, so deriving the count from the budget keeps those three numbers
+    # describing ONE allocation instead of three independent ones that overshoot together.
+    affordable = max(2, (limit - size) // perfile)
+    max_files = _clamp(min(cpus, affordable), 2, _MAX_CONCURRENT_FILES)
+    # Streams follow cores, but a stream holds a 64 MiB xorb while it lands, so more streams than
+    # the budget has xorb slots for only queues work behind the semaphore. Both bounds matter: a
+    # 64-core CI container with 8 GB opened 124 streams under the core rule alone, which is exactly
+    # the "small machine, big numbers" case that hurts a thin link.
+    streams = _clamp(min(cpus * 2, max(4, limit // _XORB_BYTES)), 4, _MAX_STREAMS)
     if throttled:
         streams = max(4, streams // 2)
-
-    # hf_xet grows the buffer to size + max_files * perfile and clamps it at limit; keeping limit at
-    # or above that sum makes it state the true ceiling instead of truncating the other two.
-    limit = max(limit, size + max_files * perfile)
+    # Start well under the ceiling and let xet-core's adaptive concurrency ramp: on a slow or
+    # congested link the ramp is what keeps us from opening every stream into a stall.
+    initial = min(_clamp(cpus, 2, 8), streams)
 
     env = {
         # Memory. The effective buffer is size + max_files * perfile, capped by limit.
@@ -339,7 +397,7 @@ def xet_env_overrides(
         # ac_* is the adaptive-concurrency band; the initial value stays under the ceiling so a slow
         # link ramps up instead of opening 16 streams into a stall.
         "HF_XET_CLIENT_AC_MAX_DOWNLOAD_CONCURRENCY": str(streams),
-        "HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY": str(_clamp(cpus, 2, 8)),
+        "HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY": str(initial),
         "HF_XET_CLIENT_AC_MIN_DOWNLOAD_CONCURRENCY": "1",
         # Fail fast so OUR ladder decides instead of hf_xet retrying for ~6 minutes. Bare integers
         # are ignored; the unit suffix is required.

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -60,22 +60,16 @@ XET_HIGH_PERFORMANCE_VARS = ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP")
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
-# xet-core's high-performance preset is not a mode, it is a set of ordinary knobs
-# (xet_runtime/src/config/xet_config.rs with_high_performance): a 64 GB buffer limit, 16 GB of
-# buffer, 2 GB per file, 124 streams. So rather than choose between "capped" and "that preset", we
-# write the same knobs scaled to the machine in front of us.
-#
-# One eighth of RAM is the anchor. It reproduces the table this replaces at every point it had
-# (8 GB -> 1 GB, 16 -> 2, 32 -> 4, 128 -> 16, 256 -> 32) and simply keeps going, so a big host gets
-# a big budget and a laptop is unchanged. The ceiling is xet-core's own 64 GB, because past that
-# the preset stops helping and we would only be reserving address space.
+# The high-performance preset is not a mode, just knobs (xet_config.rs with_high_performance:
+# 64 GB limit, 16 GB buffer, 2 GB per file, 124 streams), so we write the same ones scaled to the
+# machine. An eighth of RAM reproduces the table this replaces at every point it defined
+# (8 GB -> 1 GB, 16 -> 2, 32 -> 4, 128 -> 16, 256 -> 32) and keeps going, to xet-core's own 64 GB.
 _RAM_FRACTION = 8
 _MIN_BUFFER_LIMIT = 1 * _GB
 _MAX_BUFFER_LIMIT = 64 * _GB
-# Measured on a 192-core 1996 GiB box against a 20 Gbit/s link: raising the BUFFER group alone is
-# worth 2.41x (6771 -> 16306 Mbit/s), raising the CONCURRENCY group alone is worth nothing (0.92x).
-# So the buffer is the lever, and streams and files exist only to keep it fed -- which is why they
-# follow cores, and why neither is allowed past what the buffer budget can actually hold.
+# Measured on a 192-core / 20 Gbit/s host: the buffer group alone is worth 2.70x, the concurrency
+# group alone nothing (0.92x). Streams and files exist to keep the buffer fed, so they follow cores
+# and never exceed what the budget can hold.
 _MAX_STREAMS = 124
 _MAX_CONCURRENT_FILES = 24
 # xet-core's xorb size: the unit a single download stream has outstanding at any moment.
@@ -368,13 +362,11 @@ def xet_env_overrides(
     if free:
         limit = _clamp(min(limit, free // 4), _MIN_BUFFER_LIMIT, _MAX_BUFFER_LIMIT)
 
-    # The shared buffer is the ONE knob that moves throughput, measured twice: 2.70x from the
-    # buffer group on a 2 TB host, and 1.45x from this single value on an 8 GB laptop, where a
-    # quarter of the budget (256 MB) ran at 0.73x of what shipped before. So the rule is not a
-    # ratio, it is: never hand a machine less than xet-core's own 2 GB default unless something
-    # forces us to. Two things do. Half the budget, because a shared buffer larger than that
-    # leaves no room for the per-file ones; and a sixth of RAM, which is what keeps the floor from
-    # overriding the memory bound on a 2 GB VM, where stock would be the whole machine.
+    # The shared buffer is the one knob that moves throughput (2.70x on a 2 TB host; 1.45x from
+    # this value alone on an 8 GB laptop, where a quarter of the budget ran at 0.73x). So it is a
+    # floor, not a ratio: reach for xet-core's 2 GB default, held back only by half the budget (a
+    # bigger share leaves no room for per-file buffers) and a sixth of RAM (which keeps the floor
+    # from overriding the memory bound on a 2 GB VM).
     size = min(
         max(limit // 4, min(_STOCK_BUFFER_SIZE, limit // 2)),
         max(256 * _MB, (profile.total_ram_bytes or 8 * _GB) // 6),
@@ -386,16 +378,12 @@ def xet_env_overrides(
     prefetch = _clamp(limit // 4, 128 * _MB, _STOCK_PREFETCH_BUFFER)
 
     cpus = profile.cpu_count
-    # More files or streams in flight than the machine has cores buys nothing -- and neither does
-    # more files than the budget can hold buffers for: size + max_files * perfile is what hf_xet
-    # can have outstanding, so deriving the count from the budget keeps those three numbers
-    # describing ONE allocation instead of three independent ones that overshoot together.
+    # size + max_files * perfile is what hf_xet can hold, so the count comes from the budget as
+    # well as from cores: three numbers describing one allocation, not three that overshoot.
     affordable = max(2, (limit - size) // perfile)
     max_files = _clamp(min(cpus, affordable), 2, _MAX_CONCURRENT_FILES)
-    # Streams follow cores, but a stream holds a 64 MiB xorb while it lands, so more streams than
-    # the budget has xorb slots for only queues work behind the semaphore. Both bounds matter: a
-    # 64-core CI container with 8 GB opened 124 streams under the core rule alone, which is exactly
-    # the "small machine, big numbers" case that hurts a thin link.
+    # A stream holds a 64 MiB xorb, so streams past the budget's xorb slots only queue behind the
+    # semaphore. Both bounds matter: a 64-core container with 8 GB opened 124 under cores alone.
     streams = _clamp(min(cpus * 2, max(4, limit // _XORB_BYTES)), 4, _MAX_STREAMS)
     if throttled:
         streams = max(4, streams // 2)

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -479,6 +479,7 @@ def xet_log_env(log_dir: "str | Path", *, diagnostics: bool = False) -> dict[str
 
 
 _SEEDED_INTO_ENVIRON: dict[str, str] = {}
+_SEEDED_THROTTLED = False
 
 
 def apply_xet_env(
@@ -540,10 +541,12 @@ def apply_xet_env(
         if force or key not in target or key in overwritable:
             target[key] = value
             written[key] = value
-    # Remember what WE put in the real environment, so a later resize can tell our own numbers from
-    # a user's and redo only ours.
+    # Remember what WE put in the real environment, and on what terms, so a later resize can tell
+    # our own numbers from a user's, redo only ours, and redo them the same way.
     if target is os.environ:
+        global _SEEDED_THROTTLED
         _SEEDED_INTO_ENVIRON.update(written)
+        _SEEDED_THROTTLED = throttled
     return written
 
 
@@ -552,6 +555,7 @@ def resize_for_cache_dir(
     cache_dir: "Optional[str | Path]",
     *,
     fail_fast: bool = True,
+    throttled: "Optional[bool]" = None,
 ) -> dict[str, str]:
     """Re-size *env* for *cache_dir*, recomputing the values this process seeded and no others.
 
@@ -561,11 +565,17 @@ def resize_for_cache_dir(
     which is exactly what *cache_dir* is there to correct. Dropping our own seeded values first
     makes the recompute bite. A value we never wrote, or one something else has changed since, is
     left alone, so an explicit user setting still wins.
+
+    *throttled* defaults to whatever the seeding call used, so a halved stream ceiling asked for by
+    a logged 429 survives the recompute; the whole point of that reduction is that it reaches the
+    process doing the downloading.
     """
+    if throttled is None:
+        throttled = _SEEDED_THROTTLED
     for key, value in _SEEDED_INTO_ENVIRON.items():
         if env.get(key) == value:
             env.pop(key, None)
-    return apply_xet_env(env, fail_fast = fail_fast, cache_dir = cache_dir)
+    return apply_xet_env(env, fail_fast = fail_fast, cache_dir = cache_dir, throttled = throttled)
 
 
 _LOG_ERROR_RE = re.compile(r'"level"\s*:\s*"(ERROR|WARN)"', re.IGNORECASE)

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -61,10 +61,19 @@ XET_HIGH_PERFORMANCE_VARS = ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP")
 _TRUTHY = {"1", "true", "yes", "on"}
 
 # (exclusive upper bound on total RAM, buffer_limit, buffer_size, perfile_size, max_concurrent_files)
+#
+# The table used to stop at 24 GB, so a 2 TB server was held to a 24 GB laptop's 4 GB buffer. That
+# is not a neutral default: measured on a 192-core / 1996 GiB box against a 20 Gbit/s link, the old
+# top tier ran at 4586 Mbit/s where xet-core's own defaults managed 6553 -- capping cost 30% BELOW
+# stock, because the buffer gates how much can be in flight, which gates CPU, which gates the wire.
+# Big machines get tiers that scale; the small ones are unchanged, which is where the cap earns its
+# keep.
 _TIERS = (
-    (12 * _GB, 1 * _GB, 512 * _MB, 128 * _MB, 4),
-    (24 * _GB, 2 * _GB, 768 * _MB, 192 * _MB, 6),
-    (None,     4 * _GB, 1 * _GB,   256 * _MB, 8),
+    (12 * _GB,  1 * _GB,  512 * _MB, 128 * _MB,  4),
+    (24 * _GB,  2 * _GB,  768 * _MB, 192 * _MB,  6),
+    (64 * _GB,  4 * _GB,  1 * _GB,   256 * _MB,  8),
+    (256 * _GB, 16 * _GB, 4 * _GB,   512 * _MB, 16),
+    (None,      32 * _GB, 8 * _GB,   1 * _GB,   24),
 )
 
 # Below this much usable RAM, callers prefer HTTP over Xet (see hf_xet_health).
@@ -272,6 +281,17 @@ def _clamp(value: int, low: int, high: int) -> int:
 
 
 # Shortened Xet client timeouts: safe in a download child we supervise, wrong process-wide.
+# Sizing knobs that exist only to bound memory. When the user has asked for high-performance mode
+# they have opted out of that bound, and applying these anyway would shrink the transfer while
+# xet-core ignores the limit -- slower than either choice made cleanly.
+_CAPS_VOIDED_BY_HIGH_PERFORMANCE = (
+    "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT",
+    "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE",
+    "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE",
+    "HF_XET_RECONSTRUCTION_MIN_PREFETCH_BUFFER",
+    "HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS",
+)
+
 _FAIL_FAST_KEYS = (
     "HF_XET_CLIENT_READ_TIMEOUT",
     "HF_XET_CLIENT_CONNECT_TIMEOUT",
@@ -375,10 +395,13 @@ def apply_xet_env(
     """Apply the overrides to *env* (default: ``os.environ``) and return only what was written.
 
     ``setdefault`` semantics: a user-set variable is left alone, so a shell's
-    ``HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT=16gb`` still wins. High-performance mode is the
-    exception -- being applied AFTER the environment is read, an enabled ``HF_XET_HIGH_PERFORMANCE``
-    discards every cap above rather than competing with it, so it is turned off even when already
-    set; ``UNSLOTH_XET_ALLOW_HIGH_PERFORMANCE=1`` keeps it (and drops the caps it would have voided).
+    ``HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT=16gb`` still wins -- and that now includes
+    ``HF_XET_HIGH_PERFORMANCE``. Enabling it is a deliberate act by someone who knows their machine,
+    and since xet-core applies it AFTER reading the environment it voids the caps rather than
+    competing with them, so the honest response is to stand down: we drop the caps it would have
+    discarded and leave the flag alone. Measured on a 192-core / 1996 GiB box, overriding it cost
+    2.55x download throughput (16684 -> 6553 Mbit/s), to defend RAM that machine was never short of.
+    Set ``UNSLOTH_XET_FORCE_CAPS=1`` to get the old behaviour and cap a machine regardless.
 
     *force* overwrites every variable, for callers building a fresh child environment. *fail_fast*
     defaults to False here, unlike ``xet_env_overrides``, because this runs at import: the shortened
@@ -388,13 +411,24 @@ def apply_xet_env(
     target = os.environ if env is None else env
     overrides = xet_env_overrides(profile, throttled = throttled, fail_fast = fail_fast)
 
-    if _is_true(os.environ.get("UNSLOTH_XET_ALLOW_HIGH_PERFORMANCE")):
-        for var in XET_HIGH_PERFORMANCE_VARS:
+    # A user who turned high-performance mode on keeps it, and keeps the headroom it implies:
+    # leaving our caps in place alongside it would be the worst of both, since xet-core would void
+    # the limit but still honour the smaller per-file and concurrency numbers.
+    user_wants_hp = any(_is_true(target.get(var)) for var in XET_HIGH_PERFORMANCE_VARS)
+    forcing_caps = _is_true(os.environ.get("UNSLOTH_XET_FORCE_CAPS"))
+    # Only one of these may hold: either the user's flag wins and our sizing stands down, or the
+    # caps win and the flag has to be turned off, because xet-core reads it last and would void
+    # them. Overwritable is the set we are allowed to write over an existing value.
+    overwritable: tuple = ()
+    if user_wants_hp and not forcing_caps:
+        for var in (*XET_HIGH_PERFORMANCE_VARS, *_CAPS_VOIDED_BY_HIGH_PERFORMANCE):
             overrides.pop(var, None)
+    elif forcing_caps:
+        overwritable = XET_HIGH_PERFORMANCE_VARS
 
     written: dict[str, str] = {}
     for key, value in overrides.items():
-        if force or key not in target or (key in XET_HIGH_PERFORMANCE_VARS and _is_true(target.get(key))):
+        if force or key not in target or key in overwritable:
             target[key] = value
             written[key] = value
     return written

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -80,9 +80,10 @@ _MAX_STREAMS = 124
 _MAX_CONCURRENT_FILES = 24
 # xet-core's xorb size: the unit a single download stream has outstanding at any moment.
 _XORB_BYTES = 64 * 1024 * 1024
-# xet-core's own default prefetch floor (config/groups/reconstruction.rs, min_prefetch_buffer).
-# Sizing DOWN from a default is a cap; sizing below it for no reason is just a slower download.
+# xet-core's own defaults (config/groups/reconstruction.rs). Sizing DOWN from a default is a cap;
+# sizing below one for no reason is just a slower download, which is what these two floors prevent.
 _STOCK_PREFETCH_BUFFER = 1 * _GB
+_STOCK_BUFFER_SIZE = 2 * _GB
 
 # Below this much usable RAM, callers prefer HTTP over Xet (see hf_xet_health).
 MIN_XET_RAM_BYTES = 4 * _GB
@@ -367,9 +368,17 @@ def xet_env_overrides(
     if free:
         limit = _clamp(min(limit, free // 4), _MIN_BUFFER_LIMIT, _MAX_BUFFER_LIMIT)
 
-    # Proportions from the high-performance preset, which is the shape xet-core itself considers
-    # balanced: a quarter of the budget as the shared buffer, a thirty-second per file.
-    size = max(limit // 4, 256 * _MB)
+    # The shared buffer is the ONE knob that moves throughput, measured twice: 2.70x from the
+    # buffer group on a 2 TB host, and 1.45x from this single value on an 8 GB laptop, where a
+    # quarter of the budget (256 MB) ran at 0.73x of what shipped before. So the rule is not a
+    # ratio, it is: never hand a machine less than xet-core's own 2 GB default unless something
+    # forces us to. Two things do. Half the budget, because a shared buffer larger than that
+    # leaves no room for the per-file ones; and a sixth of RAM, which is what keeps the floor from
+    # overriding the memory bound on a 2 GB VM, where stock would be the whole machine.
+    size = min(
+        max(limit // 4, min(_STOCK_BUFFER_SIZE, limit // 2)),
+        max(256 * _MB, (profile.total_ram_bytes or 8 * _GB) // 6),
+    )
     perfile = max(limit // 32, 128 * _MB)
     # The prefetch floor is the one knob where our old arithmetic went BELOW xet-core's own default
     # (1 GB) on every machine, which is not a cap, just a smaller transfer. Approach the default

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -80,6 +80,9 @@ _MAX_STREAMS = 124
 _MAX_CONCURRENT_FILES = 24
 # xet-core's xorb size: the unit a single download stream has outstanding at any moment.
 _XORB_BYTES = 64 * 1024 * 1024
+# xet-core's own default prefetch floor (config/groups/reconstruction.rs, min_prefetch_buffer).
+# Sizing DOWN from a default is a cap; sizing below it for no reason is just a slower download.
+_STOCK_PREFETCH_BUFFER = 1 * _GB
 
 # Below this much usable RAM, callers prefer HTTP over Xet (see hf_xet_health).
 MIN_XET_RAM_BYTES = 4 * _GB
@@ -368,6 +371,10 @@ def xet_env_overrides(
     # balanced: a quarter of the budget as the shared buffer, a thirty-second per file.
     size = max(limit // 4, 256 * _MB)
     perfile = max(limit // 32, 128 * _MB)
+    # The prefetch floor is the one knob where our old arithmetic went BELOW xet-core's own default
+    # (1 GB) on every machine, which is not a cap, just a smaller transfer. Approach the default
+    # from below and never exceed it: only a machine whose entire budget is under 4 GB gets less.
+    prefetch = _clamp(limit // 4, 128 * _MB, _STOCK_PREFETCH_BUFFER)
 
     cpus = profile.cpu_count
     # More files or streams in flight than the machine has cores buys nothing -- and neither does
@@ -392,7 +399,7 @@ def xet_env_overrides(
         "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT": str(limit),
         "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE": str(size),
         "HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_PERFILE_SIZE": str(perfile),
-        "HF_XET_RECONSTRUCTION_MIN_PREFETCH_BUFFER": str(min(size, 512 * _MB)),
+        "HF_XET_RECONSTRUCTION_MIN_PREFETCH_BUFFER": str(prefetch),
         "HF_XET_DATA_MAX_CONCURRENT_FILE_DOWNLOADS": str(max_files),
         # ac_* is the adaptive-concurrency band; the initial value stays under the ceiling so a slow
         # link ramps up instead of opening 16 streams into a stall.

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -370,8 +370,10 @@ def xet_env_overrides(
 
     # Never size a buffer for a transfer the disk cannot land. A quarter of free space is generous
     # for a buffer and still refuses to promise 64 GB of in-flight data to a disk with 20 GB left.
+    # disk_source, not truthiness: a successful reading of zero free bytes is a full disk, which is
+    # exactly when the clamp should bite, and must not read as "we could not measure".
     free = profile.free_disk_bytes
-    if free:
+    if profile.disk_source != "unknown":
         limit = _clamp(min(limit, free // 4), _MIN_BUFFER_LIMIT, _MAX_BUFFER_LIMIT)
 
     # The shared buffer is the one knob that moves throughput (2.70x on a 2 TB host; 1.45x from
@@ -480,7 +482,9 @@ def apply_xet_env(
     2.55x download throughput (16684 -> 6553 Mbit/s), to defend RAM that machine was never short of.
     Set ``UNSLOTH_XET_FORCE_CAPS=1`` to get the old behaviour and cap a machine regardless.
 
-    *force* overwrites every variable, for callers building a fresh child environment. *fail_fast*
+    *force* overwrites every variable we would otherwise leave alone. It does not revoke a user-set
+    high-performance flag: that stand-down is our own sizing standing aside, not a default to force
+    through. *fail_fast*
     defaults to False here, unlike ``xet_env_overrides``, because this runs at import: the shortened
     timeouts would otherwise apply to every direct ``huggingface_hub`` download and upload in the
     process, none of which our ladder supervises. Supervised children pass ``fail_fast = True``.

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -247,12 +247,24 @@ def _sysconf_memory() -> Optional[int]:
 
 
 def hf_cache_root() -> Path:
-    """Where downloads land, in the same precedence huggingface_hub itself uses."""
-    for var in ("HF_HUB_CACHE", "HF_HOME"):
-        value = os.environ.get(var)
-        if value:
-            return Path(value).expanduser()
-    return Path.home() / ".cache" / "huggingface"
+    """Where downloads land, in the same precedence huggingface_hub itself uses.
+
+    ``hf_cache._active_caches`` already mirrors that precedence -- ``HF_HUB_CACHE``, the legacy
+    ``HUGGINGFACE_HUB_CACHE``, then ``HF_HOME/hub``, then ``XDG_CACHE_HOME/huggingface/hub`` -- and
+    resolving anything less measures a filesystem the download may never touch: with
+    ``XDG_CACHE_HOME`` or ``HUGGINGFACE_HUB_CACHE`` pointed at a data volume, the free space of the
+    home directory decides the buffer instead.
+    """
+    try:
+        from .hf_cache import _active_caches
+
+        hub_cache = _active_caches()[1]
+        if hub_cache is not None:
+            return hub_cache
+        return Path.home() / ".cache" / "huggingface" / "hub"
+    except Exception:  # noqa: BLE001 - a cache we cannot resolve must not stop a download
+        # Home may be unresolvable on a locked-down machine; the caller walks up from here anyway.
+        return Path(".")
 
 
 def _free_disk() -> "tuple[int, str]":
@@ -380,7 +392,10 @@ def xet_env_overrides(
     cpus = profile.cpu_count
     # size + max_files * perfile is what hf_xet can hold, so the count comes from the budget as
     # well as from cores: three numbers describing one allocation, not three that overshoot.
-    affordable = max(2, (limit - size) // perfile)
+    # The budget floor is absolute, so on a small machine it can exceed the proportional bound: a
+    # 2 GB container gets the 1 GB floor, and cores alone would then put 973 MB in flight, half its
+    # RAM. Bound the count by whichever is smaller so the third-of-RAM promise holds there too.
+    affordable = max(2, (min(limit, total // 3) - size) // perfile)
     max_files = _clamp(min(cpus, affordable), 2, _MAX_CONCURRENT_FILES)
     # A stream holds a 64 MiB xorb, so streams past the budget's xorb slots only queue behind the
     # semaphore. Both bounds matter: a 64-core container with 8 GB opened 124 under cores alone.
@@ -476,7 +491,11 @@ def apply_xet_env(
     # A user who turned high-performance mode on keeps it, and keeps the headroom it implies:
     # leaving our caps in place alongside it would be the worst of both, since xet-core would void
     # the limit but still honour the smaller per-file and concurrency numbers.
-    user_wants_hp = any(_is_true(target.get(var)) for var in XET_HIGH_PERFORMANCE_VARS)
+    # Read the flag the way xet-core reads it (configuration_utils.rs get_high_performance_flag):
+    # HF_XET_HIGH_PERFORMANCE wins if it is SET AT ALL, and only then does the HF_XET_HP alias get a
+    # look. Taking any-of instead would stand our sizing down over an alias xet-core is ignoring.
+    primary, alias = XET_HIGH_PERFORMANCE_VARS
+    user_wants_hp = _is_true(target[primary]) if primary in target else _is_true(target.get(alias))
     forcing_caps = _is_true(os.environ.get("UNSLOTH_XET_FORCE_CAPS"))
     # Only one of these may hold: either the user's flag wins and our sizing stands down, or the
     # caps win and the flag has to be turned off, because xet-core reads it last and would void

--- a/unsloth_zoo/hf_xet_tuning.py
+++ b/unsloth_zoo/hf_xet_tuning.py
@@ -48,6 +48,7 @@ __all__ = [
     "xet_env_overrides",
     "xet_log_env",
     "apply_xet_env",
+    "resize_for_cache_dir",
     "scan_xet_log",
     "XET_HIGH_PERFORMANCE_VARS",
 ]
@@ -477,6 +478,9 @@ def xet_log_env(log_dir: "str | Path", *, diagnostics: bool = False) -> dict[str
     return env
 
 
+_SEEDED_INTO_ENVIRON: dict[str, str] = {}
+
+
 def apply_xet_env(
     env: "Optional[dict]" = None,
     *,
@@ -536,7 +540,32 @@ def apply_xet_env(
         if force or key not in target or key in overwritable:
             target[key] = value
             written[key] = value
+    # Remember what WE put in the real environment, so a later resize can tell our own numbers from
+    # a user's and redo only ours.
+    if target is os.environ:
+        _SEEDED_INTO_ENVIRON.update(written)
     return written
+
+
+def resize_for_cache_dir(
+    env: dict,
+    cache_dir: "Optional[str | Path]",
+    *,
+    fail_fast: bool = True,
+) -> dict[str, str]:
+    """Re-size *env* for *cache_dir*, recomputing the values this process seeded and no others.
+
+    ``apply_xet_env`` is setdefault, and ``unsloth_zoo`` sizes itself at import, so by the time a
+    download names its destination every sizing key is already present and a second call writes
+    nothing: the download would run on numbers computed for whichever cache the environment named,
+    which is exactly what *cache_dir* is there to correct. Dropping our own seeded values first
+    makes the recompute bite. A value we never wrote, or one something else has changed since, is
+    left alone, so an explicit user setting still wins.
+    """
+    for key, value in _SEEDED_INTO_ENVIRON.items():
+        if env.get(key) == value:
+            env.pop(key, None)
+    return apply_xet_env(env, fail_fast = fail_fast, cache_dir = cache_dir)
 
 
 _LOG_ERROR_RE = re.compile(r'"level"\s*:\s*"(ERROR|WARN)"', re.IGNORECASE)


### PR DESCRIPTION
Downloads on large machines got slower after #972. Two causes, both measured, plus two further defects found while checking our settings against xet-core's own source.

### 1. We overrode a setting the user had chosen

`apply_xet_env` used `setdefault` semantics for every variable except `HF_XET_HIGH_PERFORMANCE`, which it forced to `0` even when already set. Turning that flag on is a deliberate act by someone who knows their machine, and because xet-core applies it *after* reading the environment it voids our caps rather than competing with them. So the right response is to stand down: keep the flag, and drop the sizing it would have discarded.

Leaving both in place was the worst of the three options, since xet-core ignored the `LIMIT` but still honoured the smaller per-file and concurrency numbers.

### 2. The tier table was a step function

It flat-lined at 24 GB, so a 2 TB server was held to a 24 GB laptop's 4 GB buffer. Extending the table would only move the cliffs: a 12 GB machine still got an 8 GB machine's budget.

This replaces the table with one anchor, an eighth of RAM, clamped to [1 GB, 64 GB]. That reproduces the old table at every point it defined (8 GB to 1 GB, 16 to 2, 32 to 4, 128 to 16, 256 to 32), removes the cliffs between them, and converges on xet-core's own high-performance sizing on a host large enough to afford it, without the flag that would discard every bound on hosts that are not.

| machine | budget | buffer | per file | files | streams |
|---|---:|---:|---:|---:|---:|
| 2 GB VM, 2 cores | 1.0 G | 256 M | 128 M | 2 | 4 |
| 8 GB laptop, 4 cores | 1.0 G | 256 M | 128 M | 4 | 8 |
| 16 GB, 8 cores | 2.0 G | 500 M | 128 M | 8 | 16 |
| 32 GB, 16 cores | 4.0 G | 1.0 G | 128 M | 16 | 32 |
| 128 GB, 64 cores | 16.0 G | 4.0 G | 500 M | 24 | 124 |
| 2 TB, 192 cores | 64.0 G | 16.0 G | 2000 M | 24 | 124 |
| xet-core's own high-performance preset | 64.0 G | 16.0 G | 2000 M | (8) | 124 |

Free disk joins the profile: a quarter of free space caps the budget, so a nearly full disk is not promised 64 GB of in-flight data, and the floor still applies because the download may be the one that frees the space.

### The buffer is the lever, so concurrency is sized to feed it

Seven more full 96.8 GB downloads, each arm changing exactly one group of xet-core's high-performance preset relative to what we ship today:

| arm | mean Mbit/s | vs shipped | peak RSS |
|---|---:|---:|---:|
| what ships today | 6771 | 1.00x | 2.3 G |
| preset concurrency only | 6242 | **0.92x** | 2.2 G |
| preset buffers only | 16306 | **2.41x** | 15.2 G |
| whole preset | 19742 | 2.92x | 18.5 G |

Raising concurrency on its own does nothing. That is why files in flight never exceed what the budget holds buffers for (`(limit - size) / perfile`), and streams never exceed the number of 64 MiB xorbs the budget can hold: the rest would queue behind the semaphore. A 64-core container with 8 GB opened 124 streams under a cores-only rule, which is the "small machine, big numbers" case that costs a thin link more than it gains.

Upstream agrees, without having said it in prose: xet-core#637 is a buffer-only change justified by a throughput benchmark, xet-core#698 root-causes a stall in the buffer semaphore, and both attempts to buy throughput with concurrency alone (xet-core#709, xet-core#711) were abandoned for insufficient impact.

### 3. We set a variable xet-core has never read

`unsloth_zoo/__init__.py` set `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY=0`. No such variable exists in xet-core 1.5.2 or 1.5.4. The knob is `HF_XET_RECONSTRUCTION_USE_VECTORED_WRITE` and it already defaults to `true`, which is what that line was reaching for. It was a silent no-op that read, in review and in the logs, exactly like a setting being honoured.

### 4. We undercut xet-core's own prefetch floor

`MIN_PREFETCH_BUFFER` was set to `min(size, 512MB)`, below xet-core's 1 GB default on every machine including a 2 TB one. Sizing down from a default is a cap; sizing below it for no reason is just a slower download, and the prefetch buffer is drawn from the budget the `LIMIT` already governs. It now approaches the default from below and never exceeds it, so only a machine whose entire budget is under 4 GB gets less than stock.

### Measurements on this host

192 cores, 1996 GiB RAM, ~20 Gbit/s link. Two DeepSeek-V4-Flash GGUF quants downloaded in full (96.8 GB and 104.2 GB), 18 runs, each in its own `HF_HOME` so no run inherits another's dedup state. Order interleaved, with the reference config re-measured at the start, middle and end to bound CDN drift.

| config | mean Mbit/s | vs stock | peak RSS | mean CPU |
|---|---:|---:|---:|---:|
| user's own setting (`HP=1`) | 16684 | 2.55x | 18.0 G | ~500% |
| xet-core defaults | 6553 | 1.00x | 4.1 G | ~190% |
| **what we shipped** | **5132** | **0.78x** | 2.3 G | ~145% |
| tier caps alone | 4586 | 0.70x | 2.3 G | ~130% |

We were **3.25x slower than the machine's own configuration, and 30% slower than changing nothing at all**. Defending 2.3 GB of RAM on a 2 TB host cost 11.5 Gbit/s.

After this change, interleaved against both references so ordering cannot flatter it:

| config | mean Mbit/s | n |
|---|---:|---:|
| user's own setting | 18537 | 4 |
| **this PR** | **17013** | 4 |
| before | 5063 | 4 |

**3.36x faster**, and within noise of the user's own setting (0.92x against a 12-15% run-to-run spread).

### Small devices

Being generous on a big host is only defensible if the same arithmetic is conservative on a small one. It is, and in two places it is more conservative than what ships today:

| device | | budget | buffer | files | streams |
|---|---|---:|---:|---:|---:|
| 2 GB VM, 2 cores | before | 1.00 G | 0.51 G | 2 | 4 |
| | after | 1.00 G | 0.26 G | 2 | 4 |
| 8 GB MacBook Air, 8 cores | before | 1.02 G | 0.51 G | 4 | 16 |
| | after | 1.00 G | 0.26 G | 5 | **14** |
| 64-core CI container, 8 GB | before | 1.02 G | 0.51 G | 4 | **64** |
| | after | 1.00 G | 0.26 G | 5 | **14** |

A simulated-device download matrix is running to confirm this by measurement rather than arithmetic: real 36.3 GB downloads with cores genuinely restricted by `taskset` and the environment resolved from each device's profile, checking peak RSS against the RAM that device would have had. Numbers to follow in a comment.

### Tests

Eight machine shapes and eleven named devices, from a 2 GB VM and a fractional-core pod to an 8xH100 node. Per device: the worst case fits the budget, fits a third of that device's RAM, fits the disk, and never opens more streams or files than either cores or the budget allow. Two further tests guard the class of bug behind (3): every variable we emit is one xet-core reads, and no module in the package names an `HF_XET_*` variable that does not exist, because the dead one was set from `__init__` and a check confined to the tuning module would have missed it.

The old tests asserted the behaviour being fixed, so they are rewritten rather than worked around. The memory-safety invariant is now proportional (worst case under a third of RAM) instead of a flat 4 GB, which is the property that actually matters.

Full suite: 3282 passed, 186 skipped, against 3258 passed on `main`.
