### PR TITLE
Feat(mlx): GGUF multi-quant

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -112,11 +112,18 @@ jobs:
         # CPU-pure and monkeypatch every Hub entry point, so they cost under two
         # seconds. Left out of a gate they would have been collected but never
         # run: `pytest tests/ --collect-only` above proves only that they import.
+        #
+        # test_mlx_save_export_edge_cases pins the MLX GGUF export contract:
+        # which quant targets are produced, that the expensive merge/convert
+        # runs once per export, and when the intermediate is scratch versus a
+        # requested artifact. It fakes llama.cpp end to end (no binary, no
+        # weights) and the whole file runs in well under a second.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
             tests/test_mlx_finetune_last_n_layers.py \
             tests/test_mlx_double_quant_reject.py \
+            tests/test_mlx_save_export_edge_cases.py \
             tests/test_hf_xet_fallback.py \
             tests/test_get_transformers_model_type_empty.py \
             tests/test_train_on_responses_list_labels.py \

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -1362,6 +1362,71 @@ def test_gguf_scalar_full_precision_keeps_its_pre_pr_behaviour(monkeypatch, tmp_
     assert (out / "EdgeModel.BF16.gguf").exists()
 
 
+# --- Group 11e: intermediate must not down-convert an f32 request -----------
+
+
+def test_gguf_f32_request_converts_directly_to_f32(monkeypatch, tmp_path):
+    """bf16 and f16 both embed exactly in f32, so an f32 intermediate is never a
+    precision regression for the other targets -- but a bf16 intermediate makes
+    the requested F32.gguf f32-shaped bf16 data."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["f32", "f16"])
+
+    assert calls["convert_kwargs"]["quantization_type"] == "f32"
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["f16"]
+    assert (out / "EdgeModel.F32.gguf").exists()
+    assert (out / "EdgeModel.F16.gguf").exists()
+
+
+def test_gguf_f32_request_alongside_a_kquant_still_converts_to_f32(
+    monkeypatch, tmp_path
+):
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["f32", "q4_k_m"])
+
+    assert calls["convert_kwargs"]["quantization_type"] == "f32"
+    assert {c["input_gguf"] for c in calls["quantize_calls"]} == {
+        str(out / "EdgeModel.F32.gguf")
+    }
+    assert (out / "EdgeModel.F32.gguf").exists()
+    assert (out / "EdgeModel.Q4_K_M.gguf").exists()
+
+
+def test_gguf_without_f32_the_intermediate_stays_bf16(monkeypatch, tmp_path):
+    """Deliberate non-change. f16 and bf16 are not orderable -- bf16 has the
+    wider exponent, f16 the longer mantissa -- so promoting a requested f16 to
+    the intermediate would CLIP the range of a bf16 checkpoint. Only f32, which
+    represents all three exactly, is a safe promotion."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["f16", "q4_k_m"])
+    assert calls["convert_kwargs"]["quantization_type"] == "bf16"
+
+
+def test_gguf_two_full_precision_no_f32_keeps_bf16_intermediate(
+    monkeypatch, tmp_path
+):
+    """Companion to the above for the all-full-precision set."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["bf16", "f16"])
+    assert calls["convert_kwargs"]["quantization_type"] == "bf16"
+
+
+def test_gguf_explicit_first_conversion_beats_the_f32_promotion(
+    monkeypatch, tmp_path
+):
+    """An explicit `first_conversion` is always honoured; the derivation only
+    runs when it is None (unslothai/unsloth unsloth/save.py:1953)."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["f32", "q4_k_m"], first_conversion="bf16")
+    assert calls["convert_kwargs"]["quantization_type"] == "bf16"
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["f32", "q4_k_m"]
+
+
 def test_mlx_model_method_forwards_a_quant_list(monkeypatch, tmp_path):
     """The user-facing hop: model.save_pretrained_gguf(...) in loader.py."""
     import unsloth_zoo.mlx.loader as loader

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -1331,6 +1331,37 @@ def test_gguf_rejects_non_string_first_conversion_before_the_merge(
     assert "convert_count" not in calls
 
 
+# --- Group 11d: singleton list is a list, not a scalar ----------------------
+
+
+def test_gguf_singleton_list_full_precision_is_still_emitted(monkeypatch, tmp_path):
+    """Upstream runs a llama-quantize pass for every requested method that is not
+    the intermediate, with no full-precision exemption
+    (unslothai/unsloth unsloth/save.py:2067-2070). The scalar carve-out here is a
+    pre-PR MLX behaviour; a singleton LIST is the new list contract and must
+    emit what was asked for."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["f16"], first_conversion="bf16")
+
+    assert calls["convert_kwargs"]["quantization_type"] == "bf16"
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["f16"]
+    assert (out / "EdgeModel.F16.gguf").exists()
+    # bf16 was never requested, so the intermediate is scratch.
+    assert not (out / "EdgeModel.BF16.gguf").exists()
+
+
+def test_gguf_scalar_full_precision_keeps_its_pre_pr_behaviour(monkeypatch, tmp_path):
+    """The scalar form must NOT change: pre-PR a lone full-precision string ran
+    no quantize pass whatever `first_conversion` said."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, "f16", first_conversion="bf16")
+
+    assert "quantize_calls" not in calls
+    assert (out / "EdgeModel.BF16.gguf").exists()
+
+
 def test_mlx_model_method_forwards_a_quant_list(monkeypatch, tmp_path):
     """The user-facing hop: model.save_pretrained_gguf(...) in loader.py."""
     import unsloth_zoo.mlx.loader as loader

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -1256,6 +1256,81 @@ def test_gguf_keeps_intermediate_when_nothing_was_quantized(monkeypatch, tmp_pat
     assert (out / "EdgeModel.F16.gguf").exists()
 
 
+# --- Group 11c: quant-spec normalization ------------------------------------
+#
+# Output filenames are derived as `{base}.{quant.upper()}.gguf`, so two spellings
+# of one type name are the SAME artifact on disk. Every downstream decision
+# (which intermediate to convert to, which targets still need a llama-quantize
+# pass, whether the intermediate is scratch) compares quant names as strings, so
+# they must all see one canonical spelling. llama.cpp's own side already works
+# this way: unsloth_zoo/llama_cpp.py:2174 `check_quantization_type` lowercases
+# before validating.
+
+
+def test_gguf_case_variant_target_is_the_same_artifact(monkeypatch, tmp_path):
+    """`["BF16", "q4_k_m"]` is the llama.cpp spelling of `["bf16", "q4_k_m"]`.
+
+    Un-normalized it produced an in-place `llama-quantize BF16.gguf BF16.gguf`
+    pass and then deleted the requested BF16 artifact as if it were scratch.
+    """
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["BF16", "q4_k_m"])
+
+    assert calls["convert_kwargs"]["quantization_type"] == "bf16"
+    # BF16 IS the intermediate: it must not be re-quantized onto its own path.
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["q4_k_m"]
+    for c in calls["quantize_calls"]:
+        assert c["input_gguf"] != c["output_gguf"]
+    assert (out / "EdgeModel.BF16.gguf").exists()
+    assert (out / "EdgeModel.Q4_K_M.gguf").exists()
+
+
+def test_gguf_case_variant_first_conversion_matches_requested_target(
+    monkeypatch, tmp_path
+):
+    """`first_conversion` is the other half of the same spec and needs the same
+    normalization: spelled `"BF16"` against a requested `"bf16"` it both ran an
+    in-place quantize pass and deleted the requested artifact."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["bf16", "q4_k_m"], first_conversion="BF16")
+
+    assert calls["convert_kwargs"]["quantization_type"] == "bf16"
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["q4_k_m"]
+    for c in calls["quantize_calls"]:
+        assert c["input_gguf"] != c["output_gguf"]
+    assert (out / "EdgeModel.BF16.gguf").exists()
+
+
+def test_gguf_dedup_is_case_insensitive_and_strips(monkeypatch, tmp_path):
+    """Dedup exists because repeats re-run llama-quantize onto an identical
+    output path -- which is exactly what case/whitespace variants also do."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["Q4_K_M", "q4_k_m", " q4_k_m ", "Q8_0"])
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["q4_k_m", "q8_0"]
+
+
+def test_gguf_case_variant_alias_resolves(monkeypatch, tmp_path):
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["Fast_Quantized"])
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["q8_0"]
+
+
+def test_gguf_rejects_non_string_first_conversion_before_the_merge(
+    monkeypatch, tmp_path
+):
+    """Same "reject before the expensive merge" contract the quant list has."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    with pytest.raises(TypeError, match="first_conversion"):
+        _export(mutils, out, ["q4_k_m"], first_conversion=["bf16"])
+    assert "merge_count" not in calls
+    assert "convert_count" not in calls
+
+
 def test_mlx_model_method_forwards_a_quant_list(monkeypatch, tmp_path):
     """The user-facing hop: model.save_pretrained_gguf(...) in loader.py."""
     import unsloth_zoo.mlx.loader as loader

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -1037,6 +1037,7 @@ def _gguf_export_scaffold(monkeypatch, tmp_path):
     calls = {}
 
     def fake_save_merged_model(model, tokenizer, path, dequantize=False):
+        calls["merge_count"] = calls.get("merge_count", 0) + 1
         Path(path).mkdir(parents=True, exist_ok=True)
 
     def fake_download():
@@ -1046,13 +1047,17 @@ def _gguf_export_scaffold(monkeypatch, tmp_path):
 
     def fake_convert_to_gguf(**kwargs):
         calls["convert_kwargs"] = kwargs
+        calls["convert_count"] = calls.get("convert_count", 0) + 1
         output = Path(
             f"{kwargs['model_name']}.{kwargs['quantization_type'].upper()}.gguf"
         )
         output.write_bytes(b"GGUF-intermediate")
 
     def fake_quantize_gguf(**kwargs):
+        # "quantize_kwargs" keeps the last call (pre-existing single-quant
+        # assertions); "quantize_calls" accumulates for multi-quant exports.
         calls["quantize_kwargs"] = kwargs
+        calls.setdefault("quantize_calls", []).append(kwargs)
         Path(kwargs["output_gguf"]).write_bytes(b"GGUF-final")
 
     monkeypatch.setattr(mutils, "save_merged_model", fake_save_merged_model)
@@ -1110,6 +1115,201 @@ def test_gguf_default_first_conversion_not_quantized_skips_quantizer(
     )
     assert calls["convert_kwargs"]["quantization_type"] == "bf16"
     assert (out / "EdgeModel.BF16.gguf").exists()
+
+
+# --- Group 11b: multi-quant export (CUDA parity, unsloth/save.py:1323) ---
+
+
+def _export(mutils, out, quantization_method, **kwargs):
+    return mutils.save_pretrained_gguf(
+        types.SimpleNamespace(_hf_repo="org/EdgeModel"),
+        tokenizer=object(),
+        save_directory=out,
+        quantization_method=quantization_method,
+        **kwargs,
+    )
+
+
+def test_gguf_list_produces_every_quant_from_one_conversion(monkeypatch, tmp_path):
+    """A list is the documented CUDA contract; before this it raised
+    TypeError: unhashable type: 'list' inside the alias lookup."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["q4_k_m", "q8_0", "q5_k_m"])
+
+    # The expensive steps run once; each extra quant only costs its own pass.
+    assert calls["merge_count"] == 1
+    assert calls["convert_count"] == 1
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == [
+        "q4_k_m", "q8_0", "q5_k_m",
+    ]
+    for name in ("Q4_K_M", "Q8_0", "Q5_K_M"):
+        assert (out / f"EdgeModel.{name}.gguf").exists()
+    # Every quant is produced from the shared intermediate, which is scratch.
+    assert {c["input_gguf"] for c in calls["quantize_calls"]} == {
+        str(out / "EdgeModel.BF16.gguf")
+    }
+    assert not (out / "EdgeModel.BF16.gguf").exists()
+
+
+def test_gguf_tuple_accepted_and_aliases_resolve_per_element(monkeypatch, tmp_path):
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ("fast_quantized", "quantized"))
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["q8_0", "q4_k_m"]
+
+
+def test_gguf_list_keeps_intermediate_when_it_is_also_requested(monkeypatch, tmp_path):
+    """bf16 alongside a k-quant is a requested artifact, not scratch -- the
+    single-quant path deleted the intermediate unconditionally."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["bf16", "q4_k_m"])
+
+    assert calls["convert_kwargs"]["quantization_type"] == "bf16"
+    # bf16 comes straight from convert_hf_to_gguf; only q4_k_m is quantized.
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["q4_k_m"]
+    assert (out / "EdgeModel.BF16.gguf").exists()
+    assert (out / "EdgeModel.Q4_K_M.gguf").exists()
+
+
+def test_gguf_list_deduplicates_preserving_order(monkeypatch, tmp_path):
+    """Repeats would re-run llama-quantize onto an identical output path."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["q4_k_m", "q8_0", "q4_k_m", "quantized"])
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["q4_k_m", "q8_0"]
+
+
+def test_gguf_rejects_bad_type_before_the_expensive_merge(monkeypatch, tmp_path):
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    with pytest.raises(TypeError, match="must be a string"):
+        _export(mutils, out, 4)
+    with pytest.raises(TypeError, match="every quantization_method entry"):
+        _export(mutils, out, ["q4_k_m", 4])
+    with pytest.raises(ValueError, match="empty list"):
+        _export(mutils, out, [])
+    # Argument errors must not cost a LoRA merge or a GGUF conversion.
+    assert "merge_count" not in calls
+    assert "convert_count" not in calls
+
+
+def test_gguf_single_string_behaviour_is_unchanged(monkeypatch, tmp_path):
+    """Regression guard: the scalar path must keep its exact old semantics."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, "q4_k_m")
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["q4_k_m"]
+    assert (out / "EdgeModel.Q4_K_M.gguf").exists()
+    assert not (out / "EdgeModel.BF16.gguf").exists()
+
+
+def test_gguf_explicit_first_conversion_still_honored_for_a_list(monkeypatch, tmp_path):
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["q4_k_m", "q8_0"], first_conversion="f32")
+    assert calls["convert_kwargs"]["quantization_type"] == "f32"
+    assert {c["input_gguf"] for c in calls["quantize_calls"]} == {
+        str(out / "EdgeModel.F32.gguf")
+    }
+    assert not (out / "EdgeModel.F32.gguf").exists()
+
+
+def test_gguf_list_produces_full_precision_targets_that_are_not_the_intermediate(
+    monkeypatch, tmp_path
+):
+    """f16 alongside a k-quant must still be emitted. llama-quantize produces
+    f16/bf16/f32 too, so a full-precision target is only free when it IS the
+    intermediate -- exempting all of them silently drops the request."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["f16", "q4_k_m"])
+
+    assert calls["convert_kwargs"]["quantization_type"] == "bf16"
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["f16", "q4_k_m"]
+    assert (out / "EdgeModel.F16.gguf").exists()
+    assert (out / "EdgeModel.Q4_K_M.gguf").exists()
+    # bf16 was only scratch here - it was never requested.
+    assert not (out / "EdgeModel.BF16.gguf").exists()
+
+
+def test_gguf_two_full_precision_targets_both_land(monkeypatch, tmp_path):
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, ["bf16", "f16"])
+
+    # bf16 is the intermediate and is requested, so only f16 needs a pass.
+    assert [c["quant_type"] for c in calls["quantize_calls"]] == ["f16"]
+    assert (out / "EdgeModel.BF16.gguf").exists()
+    assert (out / "EdgeModel.F16.gguf").exists()
+
+
+def test_gguf_keeps_intermediate_when_nothing_was_quantized(monkeypatch, tmp_path):
+    """A full-precision target reached via an explicit first_conversion runs no
+    quantize pass, so the converted file IS the export and must survive."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    out = tmp_path / "out"
+    _export(mutils, out, "not_quantized", first_conversion="f16")
+
+    assert "quantize_calls" not in calls
+    assert (out / "EdgeModel.F16.gguf").exists()
+
+
+def test_mlx_model_method_forwards_a_quant_list(monkeypatch, tmp_path):
+    """The user-facing hop: model.save_pretrained_gguf(...) in loader.py."""
+    import unsloth_zoo.mlx.loader as loader
+    import unsloth_zoo.mlx.utils as mutils
+
+    seen = {}
+    monkeypatch.setattr(
+        mutils, "save_pretrained_gguf",
+        lambda model, tokenizer, save_directory, **kw: seen.update(kw),
+    )
+    model = types.SimpleNamespace(_tokenizer=object())
+    loader._mlx_save_pretrained_gguf(
+        model, tmp_path / "out", quantization_method=["q4_k_m", "q8_0"],
+    )
+    assert seen["quantization_method"] == ["q4_k_m", "q8_0"]
+
+
+def test_push_to_hub_gguf_forwards_a_quant_list(monkeypatch, tmp_path):
+    mutils, _ = _gguf_export_scaffold(monkeypatch, tmp_path)
+    seen = {}
+    monkeypatch.setattr(
+        mutils, "save_pretrained_gguf",
+        lambda model, tokenizer, save_directory, **kw: seen.update(kw),
+    )
+    monkeypatch.setattr(
+        mutils, "HfApi", None, raising=False,
+    )
+    uploaded = {}
+
+    class _FakeApi:
+        def __init__(self, token=None):
+            pass
+
+        def create_repo(self, *a, **k):
+            pass
+
+        def upload_folder(self, **k):
+            uploaded.update(k)
+
+        def upload_large_folder(self, **k):
+            uploaded.update(k)
+
+    monkeypatch.setitem(
+        sys.modules, "huggingface_hub",
+        types.SimpleNamespace(HfApi=_FakeApi),
+    )
+    mutils.push_to_hub_gguf(
+        types.SimpleNamespace(_hf_repo="org/EdgeModel"),
+        tokenizer=object(),
+        save_directory=tmp_path / "out",
+        repo_id="org/EdgeModel",
+        quantization_method=["q4_k_m", "q8_0"],
+    )
+    assert seen["quantization_method"] == ["q4_k_m", "q8_0"]
 
 
 # --- Group 12: concurrency over the patcher env mutation ---

--- a/tests/test_mlx_save_export_edge_cases.py
+++ b/tests/test_mlx_save_export_edge_cases.py
@@ -1427,6 +1427,69 @@ def test_gguf_explicit_first_conversion_beats_the_f32_promotion(
     assert [c["quant_type"] for c in calls["quantize_calls"]] == ["f32", "q4_k_m"]
 
 
+def _shard_the_intermediate(monkeypatch, calls, n_shards=3, return_files=True):
+    """convert_hf_to_gguf writes SHARD_NAME_FORMAT files instead of the plain
+    name once the intermediate crosses --split-max-size."""
+    import unsloth_zoo.llama_cpp as llama_cpp
+
+    def fake_convert_to_gguf(**kwargs):
+        calls["convert_kwargs"] = kwargs
+        calls["convert_count"] = calls.get("convert_count", 0) + 1
+        stem = f"{kwargs['model_name']}.{kwargs['quantization_type'].upper()}"
+        files = []
+        for index in range(1, n_shards + 1):
+            path = Path(f"{stem}-{index:05d}-of-{n_shards:05d}.gguf")
+            path.write_bytes(b"GGUF-shard")
+            files.append(str(path))
+        return (files, False) if return_files else None
+
+    monkeypatch.setattr(llama_cpp, "convert_to_gguf", fake_convert_to_gguf)
+
+
+def test_gguf_quantizes_from_a_sharded_intermediate(monkeypatch, tmp_path):
+    """A sharded intermediate never creates `{base}.F32.gguf`, so passing that
+    name to llama-quantize fed it a path that does not exist."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    _shard_the_intermediate(monkeypatch, calls)
+    out = tmp_path / "out"
+    _export(mutils, out, ["f32", "q4_k_m"])
+
+    assert calls["convert_kwargs"]["quantization_type"] == "f32"
+    assert [c["input_gguf"] for c in calls["quantize_calls"]] == [
+        str(out / "EdgeModel.F32-00001-of-00003.gguf")
+    ]
+    assert (out / "EdgeModel.Q4_K_M.gguf").exists()
+    # f32 was requested, so its shards are the export and must survive.
+    assert len(list(out.glob("EdgeModel.F32-*.gguf"))) == 3
+
+
+def test_gguf_sharded_scratch_intermediate_is_removed_whole(monkeypatch, tmp_path):
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    _shard_the_intermediate(monkeypatch, calls, n_shards=2)
+    out = tmp_path / "out"
+    _export(mutils, out, ["q4_k_m", "q8_0"])
+
+    assert [c["input_gguf"] for c in calls["quantize_calls"]] == [
+        str(out / "EdgeModel.BF16-00001-of-00002.gguf")
+    ] * 2
+    assert list(out.glob("EdgeModel.BF16*.gguf")) == []
+    assert (out / "EdgeModel.Q4_K_M.gguf").exists()
+    assert (out / "EdgeModel.Q8_0.gguf").exists()
+
+
+def test_gguf_shards_resolved_from_disk_without_a_return_value(monkeypatch, tmp_path):
+    """The pre-existing contract is the files on disk, not the return value."""
+    mutils, calls = _gguf_export_scaffold(monkeypatch, tmp_path)
+    _shard_the_intermediate(monkeypatch, calls, n_shards=2, return_files=False)
+    out = tmp_path / "out"
+    _export(mutils, out, "q4_k_m")
+
+    assert [c["input_gguf"] for c in calls["quantize_calls"]] == [
+        str(out / "EdgeModel.BF16-00001-of-00002.gguf")
+    ]
+    assert list(out.glob("EdgeModel.BF16*.gguf")) == []
+
+
 def test_mlx_model_method_forwards_a_quant_list(monkeypatch, tmp_path):
     """The user-facing hop: model.save_pretrained_gguf(...) in loader.py."""
     import unsloth_zoo.mlx.loader as loader

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14560,8 +14560,16 @@ def _normalize_gguf_quantization_methods(quantization_method):
     merge+convert can produce several GGUFs. Deduplicates while preserving
     order: repeats would otherwise re-run llama-quantize onto an identical
     output path, since filenames are derived from the quant type alone.
+
+    Returns ``(quant_types, requested_as_sequence)``. The flag is the ONLY
+    record of how the caller spelled the request once the value is a list, and
+    Step 6 needs it: the scalar form carries a pre-PR full-precision exemption
+    that the list form must not inherit. Deriving it here keeps the "was this a
+    sequence" predicate in one place instead of re-testing the raw argument at
+    the use site, where it would drift from this branch.
     """
-    if isinstance(quantization_method, (list, tuple)):
+    requested_as_sequence = isinstance(quantization_method, (list, tuple))
+    if requested_as_sequence:
         methods = list(quantization_method)
     elif isinstance(quantization_method, str) or quantization_method is None:
         methods = [quantization_method]
@@ -14600,7 +14608,7 @@ def _normalize_gguf_quantization_methods(quantization_method):
 
     # Dedup now also collapses case/whitespace variants, which name the same
     # output path and would otherwise re-run llama-quantize onto it.
-    return list(dict.fromkeys(resolved))
+    return list(dict.fromkeys(resolved)), requested_as_sequence
 
 
 def save_pretrained_gguf(
@@ -14648,7 +14656,9 @@ def save_pretrained_gguf(
     save_directory = Path(save_directory)
     save_directory.mkdir(parents=True, exist_ok=True)
 
-    quant_types = _normalize_gguf_quantization_methods(quantization_method)
+    quant_types, requested_as_sequence = _normalize_gguf_quantization_methods(
+        quantization_method
+    )
 
     # first_conversion is the other half of the same quant spec: it is compared
     # against quant_types and .upper()-ed into the intermediate's path, so it
@@ -14833,12 +14843,22 @@ def save_pretrained_gguf(
         # The merge and convert above are the expensive steps and already ran
         # once, so extra targets only cost their own llama-quantize pass.
         base_gguf = f"{output_base}.{first_conversion.upper()}.gguf"
-        # Pre-existing single-target contract: a lone full-precision request is
+        # Pre-existing SCALAR-ONLY contract: a lone full-precision string is
         # satisfied by whatever convert_hf_to_gguf emitted, with no llama-quantize
         # pass, even when an explicit first_conversion names a different dtype.
-        # Kept as-is; only the list form follows the CUDA rule below.
+        # Kept for the string form so pre-PR callers see no change.
+        #
+        # A singleton LIST is not that form. Upstream has no full-precision
+        # exemption at all - it quantizes every requested method that is not the
+        # intermediate (unslothai/unsloth unsloth/save.py:2067-2070,
+        # `[m for m in dict.fromkeys(quantization_method) if m != first_conversion]`)
+        # - so ["f16"] with first_conversion="bf16" must emit F16.gguf. Letting
+        # the list form inherit the scalar exemption left only Model.BF16.gguf
+        # and silently dropped the one target that was asked for.
         legacy_single_full_precision = (
-            len(quant_types) == 1 and quant_types[0] in _GGUF_FULL_PRECISION_TYPES
+            not requested_as_sequence
+            and len(quant_types) == 1
+            and quant_types[0] in _GGUF_FULL_PRECISION_TYPES
         )
         quantized_any = False
         for quant_type in quant_types:

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14611,6 +14611,44 @@ def _normalize_gguf_quantization_methods(quantization_method):
     return list(dict.fromkeys(resolved)), requested_as_sequence
 
 
+# llama.cpp SHARD_NAME_FORMAT = "{:s}-{:05d}-of-{:05d}.gguf".
+_GGUF_SHARD_SUFFIX = r"-\d{5}-of-\d{5}\.gguf$"
+
+
+def _resolve_gguf_intermediate(produced_files, base_gguf):
+    """Files convert_hf_to_gguf actually wrote for the intermediate ``base_gguf``.
+
+    ``{output_base}.{DTYPE}.gguf`` is only one of the two shapes it emits: an
+    intermediate over ``--split-max-size`` (50GB by default) is written as
+    ``...-00001-of-000NN.gguf`` shards and that plain name is never created
+    (``convert_to_gguf``, ``unsloth_zoo/llama_cpp.py``). Assuming the unsplit
+    name handed llama-quantize a path that does not exist.
+
+    Prefers the paths ``convert_to_gguf`` returned, since those are where the
+    files really landed; falls back to scanning the output directory. Returns
+    the shards in index order, a single-element list, or ``[]``.
+    """
+    import re
+
+    name = os.path.basename(base_gguf)
+    shard_pattern = re.compile(re.escape(name[: -len(".gguf")]) + _GGUF_SHARD_SUFFIX)
+
+    paths = []
+    if isinstance(produced_files, (list, tuple)):
+        paths = [str(f) for f in produced_files]
+    if not paths:
+        directory = os.path.dirname(base_gguf) or "."
+        try:
+            paths = [os.path.join(directory, f) for f in os.listdir(directory)]
+        except OSError:
+            paths = []
+
+    exact = [p for p in paths if os.path.basename(p) == name]
+    if exact:
+        return exact[:1]
+    return sorted(p for p in paths if shard_pattern.search(os.path.basename(p)))
+
+
 def save_pretrained_gguf(
     model,
     tokenizer,
@@ -14851,7 +14889,7 @@ def save_pretrained_gguf(
                 else gguf_py_dir + os.pathsep + original_pythonpath
             )
         try:
-            convert_to_gguf(**kwargs)
+            converted = convert_to_gguf(**kwargs)
         finally:
             if has_local_gguf:
                 if original_pythonpath is None:
@@ -14863,6 +14901,19 @@ def save_pretrained_gguf(
         # The merge and convert above are the expensive steps and already ran
         # once, so extra targets only cost their own llama-quantize pass.
         base_gguf = f"{output_base}.{first_conversion.upper()}.gguf"
+        # convert_to_gguf returns (output_files, is_vlm) and shards anything over
+        # --split-max-size, so base_gguf is not always the file that was written.
+        # The f32 promotion above makes that reachable at ~13B, where a bf16
+        # intermediate would have stayed under the 50GB default.
+        intermediate_files = _resolve_gguf_intermediate(
+            converted[0] if isinstance(converted, tuple) else converted,
+            base_gguf,
+        )
+        # The first shard is enough: llama-quantize's loader reads split.count
+        # off it and pulls the rest in itself (llama.cpp
+        # src/llama-model-loader.cpp, llama_get_list_splits), and its output is
+        # unsplit because --keep-split is not passed.
+        quantize_input = intermediate_files[0] if intermediate_files else base_gguf
         # Pre-existing SCALAR-ONLY contract: a lone full-precision string is
         # satisfied by whatever convert_hf_to_gguf emitted, with no llama-quantize
         # pass, even when an explicit first_conversion names a different dtype.
@@ -14894,7 +14945,7 @@ def save_pretrained_gguf(
 
             print(f"Unsloth: Quantizing to {quant_type}...")
             quantize_gguf(
-                input_gguf=base_gguf,
+                input_gguf=quantize_input,
                 output_gguf=final_gguf,
                 quant_type=quant_type,
                 quantizer_location=quantizer,
@@ -14907,9 +14958,16 @@ def save_pretrained_gguf(
         # nothing was quantized it IS the export, so it always stays - including
         # a full-precision target reached through an explicit first_conversion.
         if quantized_any and first_conversion not in quant_types:
-            if os.path.exists(base_gguf):
-                os.remove(base_gguf)
-                print(f"Unsloth: Removed intermediate {Path(base_gguf).name}")
+            removed = []
+            for path in intermediate_files or [base_gguf]:
+                if os.path.exists(path):
+                    os.remove(path)
+                    removed.append(Path(path).name)
+            if removed:
+                print(
+                    f"Unsloth: Removed intermediate {removed[0]}"
+                    + (f" (+{len(removed) - 1} shards)" if len(removed) > 1 else "")
+                )
 
     # List produced files
     gguf_files = sorted(save_directory.glob("*.gguf"))

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -12435,6 +12435,59 @@ def _install_llama_cpp_macos(llama_cpp_folder="llama.cpp"):
     print("Unsloth: llama.cpp installed successfully.")
 
 
+# GGUF types convert_hf_to_gguf emits directly; everything else is reached by
+# running llama-quantize over one of these as the intermediate.
+_GGUF_FULL_PRECISION_TYPES = ("bf16", "f16", "f32")
+
+# Friendly aliases accepted for CUDA parity (unsloth/save.py). "not_quantized"
+# is bf16 here rather than the CUDA model_dtype switch: Apple Silicon always
+# supports bf16, which is why model_dtype is hardcoded below.
+_GGUF_QUANT_ALIASES = {
+    "not_quantized": "bf16",
+    "fast_quantized": "q8_0",
+    "quantized": "q4_k_m",
+    None: "q8_0",
+}
+
+
+def _normalize_gguf_quantization_methods(quantization_method):
+    """Resolve ``quantization_method`` to an ordered list of llama.cpp types.
+
+    Mirrors the CUDA path (``unsloth/save.py``), which accepts a list so one
+    merge+convert can produce several GGUFs. Deduplicates while preserving
+    order: repeats would otherwise re-run llama-quantize onto an identical
+    output path, since filenames are derived from the quant type alone.
+    """
+    if isinstance(quantization_method, (list, tuple)):
+        methods = list(quantization_method)
+    elif isinstance(quantization_method, str) or quantization_method is None:
+        methods = [quantization_method]
+    else:
+        raise TypeError(
+            "Unsloth: quantization_method must be a string, or a list/tuple "
+            f"of strings - got {type(quantization_method).__name__}."
+        )
+
+    if not methods:
+        raise ValueError(
+            "Unsloth: quantization_method was an empty list; pass at least "
+            "one quantization type."
+        )
+
+    resolved = []
+    for method in methods:
+        if not (isinstance(method, str) or method is None):
+            raise TypeError(
+                "Unsloth: every quantization_method entry must be a string - "
+                f"got {type(method).__name__}."
+            )
+        # Alias lookup is exact (matching CUDA); unknown names pass through to
+        # llama-quantize, which reports the supported ftypes on failure.
+        resolved.append(_GGUF_QUANT_ALIASES.get(method, method))
+
+    return list(dict.fromkeys(resolved))
+
+
 def save_pretrained_gguf(
     model,
     tokenizer,
@@ -12461,6 +12514,8 @@ def save_pretrained_gguf(
             "quantized" - q4_k_m (small, fast inference)
             Or any llama.cpp quant type: q2_k, q3_k_m, q4_k_m, q5_k_m,
             q6_k, q8_0, f16, bf16, f32, etc.
+            May also be a list/tuple to emit several GGUFs from a single
+            merge+convert, e.g. ``["q4_k_m", "q8_0"]`` (CUDA parity).
         first_conversion: Optional override for the intermediate GGUF
             dtype produced by convert_hf_to_gguf before llama-quantize
             compresses it to ``quantization_method``. Pass ``"f32"`` /
@@ -12478,22 +12533,18 @@ def save_pretrained_gguf(
     save_directory = Path(save_directory)
     save_directory.mkdir(parents=True, exist_ok=True)
 
-    # Map friendly names to llama.cpp quant types
-    quant_map = {
-        "not_quantized": "bf16",
-        "fast_quantized": "q8_0",
-        "quantized": "q4_k_m",
-        None: "q8_0",
-    }
-    quant_type = quant_map.get(quantization_method, quantization_method)
+    quant_types = _normalize_gguf_quantization_methods(quantization_method)
 
     # Apple Silicon always supports bf16
     model_dtype = "bf16"
 
-    # Determine first_conversion (intermediate GGUF format before quantizing)
+    # Determine first_conversion (the single intermediate every requested quant
+    # is produced from). Only a lone full-precision target can be emitted by
+    # convert_hf_to_gguf directly; any k-quant/q8_0 in the set - even alongside
+    # a full-precision one - needs a bf16 intermediate for llama-quantize.
     if first_conversion is None:
-        if quant_type in ("bf16", "f16", "f32"):
-            first_conversion = quant_type
+        if len(quant_types) == 1 and quant_types[0] in _GGUF_FULL_PRECISION_TYPES:
+            first_conversion = quant_types[0]
         else:
             # k-quants and q8_0 go through a bf16 intermediate, then llama-quantize
             first_conversion = "bf16"
@@ -12644,10 +12695,27 @@ def save_pretrained_gguf(
                 else:
                     os.environ["PYTHONPATH"] = original_pythonpath
 
-        # Step 6: Quantize if the target quant differs from first_conversion
-        if quant_type not in ("bf16", "f16", "f32") and first_conversion != quant_type:
+        # Step 6: Quantize every requested target off the shared intermediate.
+        # The merge and convert above are the expensive steps and already ran
+        # once, so extra targets only cost their own llama-quantize pass.
+        base_gguf = f"{output_base}.{first_conversion.upper()}.gguf"
+        # Pre-existing single-target contract: a lone full-precision request is
+        # satisfied by whatever convert_hf_to_gguf emitted, with no llama-quantize
+        # pass, even when an explicit first_conversion names a different dtype.
+        # Kept as-is; only the list form follows the CUDA rule below.
+        legacy_single_full_precision = (
+            len(quant_types) == 1 and quant_types[0] in _GGUF_FULL_PRECISION_TYPES
+        )
+        quantized_any = False
+        for quant_type in quant_types:
+            # CUDA rule (unsloth/save.py:1528): everything that is not the
+            # intermediate itself gets a llama-quantize pass. Full-precision
+            # targets are NOT exempt - llama-quantize emits f16/bf16/f32 too, and
+            # skipping them would silently drop e.g. the f16 in ["f16","q4_k_m"].
+            if quant_type == first_conversion or legacy_single_full_precision:
+                # Already produced by convert_hf_to_gguf as the intermediate.
+                continue
             quantizer = quantizer_location
-            base_gguf = f"{output_base}.{first_conversion.upper()}.gguf"
             final_gguf = f"{output_base}.{quant_type.upper()}.gguf"
 
             print(f"Unsloth: Quantizing to {quant_type}...")
@@ -12658,8 +12726,14 @@ def save_pretrained_gguf(
                 quantizer_location=quantizer,
                 print_output=True,
             )
-            # Remove intermediate bf16 gguf to save space
-            if os.path.exists(base_gguf) and base_gguf != final_gguf:
+            quantized_any = True
+
+        # The intermediate is scratch only once something was quantized off it
+        # and it is not itself a requested type (e.g. ["bf16", "q4_k_m"]). When
+        # nothing was quantized it IS the export, so it always stays - including
+        # a full-precision target reached through an explicit first_conversion.
+        if quantized_any and first_conversion not in quant_types:
+            if os.path.exists(base_gguf):
                 os.remove(base_gguf)
                 print(f"Unsloth: Removed intermediate {Path(base_gguf).name}")
 
@@ -12833,7 +12907,9 @@ def push_to_hub_gguf(
         tokenizer: Tokenizer.
         save_directory: Local path for GGUF output.
         repo_id: HuggingFace repo ID.
-        quantization_method: GGUF quantization type.
+        quantization_method: GGUF quantization type, or a list/tuple of types
+            to upload several GGUFs from one merge+convert. Every produced
+            *.gguf in save_directory is uploaded.
         token: HuggingFace token.
         private: Whether repo should be private.
         first_conversion: Optional intermediate GGUF dtype passed through to

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14532,6 +14532,27 @@ _GGUF_QUANT_ALIASES = {
 }
 
 
+def _normalize_gguf_quant_name(name):
+    """Fold one quant/dtype name to the single spelling the rest of the export
+    compares against.
+
+    GGUF output paths are ``{base}.{name.upper()}.gguf``, so ``"BF16"``,
+    ``" bf16 "`` and ``"bf16"`` all name the *same file on disk*. Every decision
+    downstream - which intermediate to convert to, which targets still need a
+    llama-quantize pass, whether the intermediate is scratch or a requested
+    artifact - compares these names as plain strings, so they must all see one
+    spelling or they disagree about which file is which. Left un-folded,
+    ``["BF16", "q4_k_m"]`` ran ``llama-quantize`` with input and output both
+    pointing at ``*.BF16.gguf`` and then deleted that requested artifact.
+
+    llama.cpp's own entry point already normalizes this way:
+    ``check_quantization_type`` (``unsloth_zoo/llama_cpp.py:2174``) lowercases
+    before validating, which is why the converter accepts ``"BF16"`` while this
+    module's string comparisons did not.
+    """
+    return name.strip().lower()
+
+
 def _normalize_gguf_quantization_methods(quantization_method):
     """Resolve ``quantization_method`` to an ordered list of llama.cpp types.
 
@@ -14558,15 +14579,27 @@ def _normalize_gguf_quantization_methods(quantization_method):
 
     resolved = []
     for method in methods:
-        if not (isinstance(method, str) or method is None):
+        if method is None:
+            resolved.append(_GGUF_QUANT_ALIASES[None])
+            continue
+        if not isinstance(method, str):
             raise TypeError(
                 "Unsloth: every quantization_method entry must be a string - "
                 f"got {type(method).__name__}."
             )
-        # Alias lookup is exact (matching CUDA); unknown names pass through to
-        # llama-quantize, which reports the supported ftypes on failure.
+        method = _normalize_gguf_quant_name(method)
+        if not method:
+            raise ValueError(
+                "Unsloth: quantization_method contained an empty quantization "
+                "type; pass a llama.cpp quant name such as 'q4_k_m'."
+            )
+        # Aliases are matched on the folded name, so "Not_Quantized" resolves
+        # like "not_quantized". Unknown names pass through to llama-quantize,
+        # which reports the supported ftypes on failure.
         resolved.append(_GGUF_QUANT_ALIASES.get(method, method))
 
+    # Dedup now also collapses case/whitespace variants, which name the same
+    # output path and would otherwise re-run llama-quantize onto it.
     return list(dict.fromkeys(resolved))
 
 
@@ -14616,6 +14649,25 @@ def save_pretrained_gguf(
     save_directory.mkdir(parents=True, exist_ok=True)
 
     quant_types = _normalize_gguf_quantization_methods(quantization_method)
+
+    # first_conversion is the other half of the same quant spec: it is compared
+    # against quant_types and .upper()-ed into the intermediate's path, so it
+    # has to be folded identically or the two halves disagree about which file
+    # the intermediate is. Validated here, before the LoRA merge, so a bad
+    # argument does not cost a merge + convert (it used to surface as
+    # `AttributeError: 'list' object has no attribute 'upper'` after both).
+    if first_conversion is not None:
+        if not isinstance(first_conversion, str):
+            raise TypeError(
+                "Unsloth: first_conversion must be a string naming a GGUF dtype "
+                f"- got {type(first_conversion).__name__}."
+            )
+        first_conversion = _normalize_gguf_quant_name(first_conversion)
+        if not first_conversion:
+            raise ValueError(
+                "Unsloth: first_conversion was empty; pass 'f32', 'f16' or "
+                "'bf16', or leave it as None to derive it."
+            )
 
     # Apple Silicon always supports bf16
     model_dtype = "bf16"

--- a/unsloth_zoo/mlx/utils.py
+++ b/unsloth_zoo/mlx/utils.py
@@ -14642,7 +14642,11 @@ def save_pretrained_gguf(
         first_conversion: Optional override for the intermediate GGUF
             dtype produced by convert_hf_to_gguf before llama-quantize
             compresses it to ``quantization_method``. Pass ``"f32"`` /
-            ``"f16"`` / ``"bf16"`` to force a specific intermediate
+            ``"f16"`` / ``"bf16"`` to force a specific intermediate.
+            When left as ``None`` it is derived: a lone full-precision
+            target is converted to directly, a set containing ``"f32"``
+            converts through f32 so no target is built from rounded
+            weights, and anything else uses a bf16 intermediate.
     """
     from ..llama_cpp import (
         convert_to_gguf,
@@ -14682,13 +14686,29 @@ def save_pretrained_gguf(
     # Apple Silicon always supports bf16
     model_dtype = "bf16"
 
-    # Determine first_conversion (the single intermediate every requested quant
-    # is produced from). Only a lone full-precision target can be emitted by
-    # convert_hf_to_gguf directly; any k-quant/q8_0 in the set - even alongside
-    # a full-precision one - needs a bf16 intermediate for llama-quantize.
+    # Determine first_conversion: the single intermediate every requested quant
+    # is produced from. Only honoured when the caller did not pin one
+    # (unslothai/unsloth unsloth/save.py:1953 derives it under the same
+    # `first_conversion is None` guard).
     if first_conversion is None:
         if len(quant_types) == 1 and quant_types[0] in _GGUF_FULL_PRECISION_TYPES:
+            # A lone full-precision target is emitted by convert_hf_to_gguf
+            # directly - no intermediate, no llama-quantize pass.
             first_conversion = quant_types[0]
+        elif "f32" in quant_types:
+            # Everything the intermediate can be (bf16, f16, f32) is exactly
+            # representable in f32 - bf16 is literally the high 16 bits of an
+            # IEEE f32 - so an f32 intermediate can never round the weights that
+            # the other targets are quantized from. Converting to bf16 first
+            # instead built the requested *.F32.gguf out of bf16-rounded data:
+            # f32-shaped, but only 8 mantissa bits of real signal.
+            #
+            # Only f32 is a safe promotion. f16 and bf16 are NOT orderable
+            # against each other - bf16 has the wider exponent, f16 the longer
+            # mantissa - so promoting a requested f16 to the intermediate would
+            # clip the range of a bf16 checkpoint, which is why a requested f16
+            # alone still goes through bf16 below.
+            first_conversion = "f32"
         else:
             # k-quants and q8_0 go through a bf16 intermediate, then llama-quantize
             first_conversion = "bf16"


### PR DESCRIPTION

  `save_pretrained_gguf` crashes on the list form of `quantization_method` that the CUDA path
  documents, so an MLX user cannot produce more than one GGUF per export.

  ## The bug
  
  CUDA states the contract in the signature itself (`unsloth/save.py:1323`):

  ```python
  quantization_method = "fast_quantized",  # Can be a list of options! ["q4_k_m", "q8_0", "q5_k_m"]
  ```

  and normalizes it to a list at `save.py:1342-1352`. On MLX the argument reached a dict lookup keyed
  by the whole value:

  ```python
  quant_type = quant_map.get(quantization_method, quantization_method)
  ```

  A list is unhashable, so this raises:

  ```
  TypeError: unhashable type: 'list'
    unsloth_zoo/mlx/utils.py:12488
  ```

  It is reachable from the user-facing API, not just the internal helper: `model.save_pretrained_gguf`
  is bound in `loader.py` and forwards `quantization_method` untouched.

  Beyond the crash, the single-target restriction is wasteful. The LoRA merge and the
  `convert_hf_to_gguf` pass are the expensive steps, and both are independent of the target quant —
  producing q4_k_m and q8_0 meant running the whole pipeline twice.

  ## What changed

  `quantization_method` resolves to an ordered list of llama.cpp types, and each target is quantized
  off the single shared intermediate. Extra targets now cost only their own `llama-quantize` pass.

  ```python
  model.save_pretrained_gguf(out, tokenizer, quantization_method=["q4_k_m", "q8_0", "q5_k_m"])
  # one merge, one convert, three GGUFs
  ```

  Scalar strings keep their exact previous semantics. `push_to_hub_gguf` inherits the behaviour and
  already uploads every `*.gguf` it finds.

  ### Deliberate decisions

  - **Targets follow the CUDA rule** (`save.py:1528`): everything that is not the intermediate itself
  gets a `llama-quantize` pass. Full-precision targets are *not* exempt — `llama-quantize` emits
  f16/bf16/f32 too, so exempting them would silently drop the `f16` in `["f16", "q4_k_m"]`.
  - **The pre-existing single-target contract is unchanged.** A lone full-precision request is
  satisfied by whatever `convert_hf_to_gguf` emitted, with no quantize pass, even when
  `first_conversion` names a different dtype. Only the list form is new behaviour.
  - **Intermediate cleanup is now conditional**, matching CUDA's `quants_created` /
  `want_full_precision` pair. It is removed only once something was quantized off it *and* it is not
  itself a requested type, so `["bf16", "q4_k_m"]` keeps the bf16 file. When no quantize pass runs the
  converted file *is* the export and always stays. The previous code deleted unconditionally whenever a
  quantize ran, which a naive loop would have turned into deleting a requested artifact.
  - **Duplicates are deduplicated, preserving order.** Output filenames derive from the quant type
  alone, so a repeated entry would re-run `llama-quantize` onto a path it just wrote. CUDA does not
  deduplicate; this is a small intentional divergence.
  - **Quant names are still passed through unvalidated**, exactly as before. An upfront allowlist would
  mean duplicating `ALLOWED_QUANTS` from the `unsloth` repo into this one, where the two copies would
  drift. Left as a follow-up rather than smuggled into this PR. Argument-shape errors (non-string
  entries, empty list) are still rejected before the expensive merge.

  ## Tests
  
  Twelve cases in `tests/test_mlx_save_export_edge_cases.py`, covering: the list form producing every
  quant from one merge and one convert; tuple input; per-element alias resolution; deduplication;
  full-precision targets that are not the intermediate (`["f16","q4_k_m"]` and `["bf16","f16"]`);
  intermediate retained when also requested; intermediate retained when nothing was quantized; explicit
  `first_conversion` with a list; scalar-string regression; and forwarding through both
  `model.save_pretrained_gguf` and `push_to_hub_gguf`.

  The bug was reproduced on the parent commit before fixing — the new list test fails there with
  `TypeError: unhashable type: 'list'` at `utils.py:12488`.
  
  Across the 789-test MLX + GGUF suite the failing set is byte-identical to the base commit; the only
  delta is the twelve added tests. The existing GGUF assertions are untouched — the shared scaffold
  gained an accumulating `quantize_calls` list alongside the pre-existing single-call
  `quantize_kwargs`.

  ## CI

  Second commit adds the file to the behavioral-gate job. It was previously only collected, and as that
  step's own comment says, `pytest tests/ --collect-only` proves only that a file imports — the same
  gap that let `test_mlx_finetune_last_n_layers` stay broken from #669 until #739. The file is
  deterministic, CPU-pure, fakes llama.cpp end to end (no binary, no network, no weights) and runs in
  well under a second.

  I fixed one stale number while pulling this up — the Tests section said "ten added tests" from before
  the CUDA-rule fix added two more.
