### PR TITLE
Feat(mlx): Honor adam_epsilon in MLXTrainer

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -112,11 +112,17 @@ jobs:
         # CPU-pure and monkeypatch every Hub entry point, so they cost under two
         # seconds. Left out of a gate they would have been collected but never
         # run: `pytest tests/ --collect-only` above proves only that they import.
+        #
+        # test_mlx_adam_epsilon pins that HF's adam_epsilon reaches Adam/AdamW
+        # and reaches nothing else, plus the appended-field ordering the config's
+        # positional binding depends on. CPU-pure via the MLX simulation shim,
+        # no weights, and the whole file runs in about a tenth of a second.
         run: |
           python -m pytest \
             tests/test_training_utils_use_cache.py \
             tests/test_mlx_finetune_last_n_layers.py \
             tests/test_mlx_double_quant_reject.py \
+            tests/test_mlx_adam_epsilon.py \
             tests/test_hf_xet_fallback.py \
             tests/test_get_transformers_model_type_empty.py \
             tests/test_train_on_responses_list_labels.py \

--- a/tests/test_mlx_adam_epsilon.py
+++ b/tests/test_mlx_adam_epsilon.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""adam_epsilon on the MLX trainer (HF TrainingArguments parity).
+
+HF exposes ``adam_epsilon`` and the CUDA path forwards it to the optimizer
+(``unsloth/trainer.py:350``, alongside the betas). MLX carried ``adam_beta1`` /
+``adam_beta2`` but not the epsilon, and because ``MLXTrainingConfig`` rejects
+unknown kwargs, passing it raised ``TypeError`` before training began rather
+than being quietly ignored.
+
+CPU-pure: builds optimizers through the MLX simulation shim, no weights and no
+Metal. ``optimizer._kw`` is the shim's record of the kwargs MLX was called with.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch  # noqa: F401  (the simulation shim runs MLX ops on torch)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _install_shim():
+    """Install-only, matching tests/test_mlx_double_quant_reject.py. Deliberately
+    no teardown: popping mlx / unsloth_zoo.mlx modules on the way out breaks
+    later files that hold references to them (this file sorts before
+    test_mlx_generate.py, which does)."""
+    from mlx_simulation import simulate_mlx_on_torch
+
+    simulate_mlx_on_torch()
+
+
+def _trainer(**config_kwargs):
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    class DummyModel:
+        def trainable_parameters(self):
+            return {}
+
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model = DummyModel()
+    trainer.args = MLXTrainingConfig(**config_kwargs)
+    return trainer
+
+
+def test_config_accepts_adam_epsilon():
+    """The regression itself: MLXTrainingConfig validates its kwargs, so
+    adam_epsilon=... used to raise TypeError before a step ever ran."""
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
+
+    assert MLXTrainingConfig(adam_epsilon=1e-6).adam_epsilon == pytest.approx(1e-6)
+    assert MLXTrainingConfig().adam_epsilon is None
+
+
+@pytest.mark.parametrize("optim_name", ["adamw", "adam"])
+def test_adam_epsilon_reaches_the_optimizer(optim_name):
+    optimizer = _trainer(optim=optim_name, adam_epsilon=1e-6)._build_optimizer(
+        total_steps=4
+    )
+    assert optimizer._kw["eps"] == pytest.approx(1e-6)
+
+
+@pytest.mark.parametrize("optim_name", ["adamw", "adam"])
+def test_unset_epsilon_leaves_the_mlx_default_untouched(optim_name):
+    """None means "not requested": nothing is forwarded, so MLX's own default
+    (1e-8, matching HF) stands and the unset path is bitwise unchanged."""
+    optimizer = _trainer(optim=optim_name)._build_optimizer(total_steps=4)
+    assert "eps" not in optimizer._kw
+
+
+def test_epsilon_composes_with_betas():
+    optimizer = _trainer(
+        optim="adamw", adam_beta1=0.85, adam_beta2=0.95, adam_epsilon=1e-7,
+    )._build_optimizer(total_steps=4)
+    assert optimizer._kw["eps"] == pytest.approx(1e-7)
+    assert optimizer._kw["betas"] == (pytest.approx(0.85), pytest.approx(0.95))
+
+
+@pytest.mark.parametrize("optim_name", ["sgd", "muon", "lion"])
+def test_epsilon_is_not_forwarded_to_epsilon_free_optimizers(optim_name):
+    """SGD/Muon/Lion accept no epsilon, so forwarding one would be a TypeError.
+    HF ignores adam_epsilon for these too, so setting it stays harmless."""
+    optimizer = _trainer(
+        optim=optim_name, adam_epsilon=1e-6,
+    )._build_optimizer(total_steps=4)
+    assert "eps" not in getattr(optimizer, "_kw", {})
+
+
+def test_adafactor_does_not_receive_the_scalar_epsilon():
+    """MLX's Adafactor eps is a 2-tuple with different meaning from HF's scalar,
+    so adam_epsilon must not leak into it. The CUDA path scopes it the same way."""
+    optimizer = _trainer(
+        optim="adafactor", adam_epsilon=1e-6,
+    )._build_optimizer(total_steps=4)
+    assert "eps" not in getattr(optimizer, "_kw", {})
+
+
+def test_appended_field_stays_an_exact_suffix():
+    """MLXTrainingConfig binds positional args by field order, so a new field
+    must be appended last and keep _MLX_CONFIG_OPTIONAL_COPY_FIELDS a suffix of
+    the field list; inserting mid-list would shift every later field's slot."""
+    from dataclasses import fields as dataclass_fields
+    from unsloth_zoo.mlx.trainer import (
+        MLXTrainingConfig,
+        _MLX_CONFIG_OPTIONAL_COPY_FIELDS,
+    )
+
+    names = [f.name for f in dataclass_fields(MLXTrainingConfig) if f.init]
+    assert "adam_epsilon" in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+    # Deliberately not `names[-1] == "adam_epsilon"`: the convention is that
+    # each new field is appended and registered here, so pinning this field as
+    # the permanent last one would fire on the next unrelated addition. The
+    # suffix property below is the invariant that actually has to hold.
+    tail = tuple(names[-len(_MLX_CONFIG_OPTIONAL_COPY_FIELDS):])
+    assert tail == _MLX_CONFIG_OPTIONAL_COPY_FIELDS

--- a/tests/test_mlx_adam_epsilon.py
+++ b/tests/test_mlx_adam_epsilon.py
@@ -36,7 +36,7 @@ def _install_shim():
     simulate_mlx_on_torch()
 
 
-def _trainer(**config_kwargs):
+def _trainer(model=None, **config_kwargs):
     from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
 
     class DummyModel:
@@ -44,7 +44,7 @@ def _trainer(**config_kwargs):
             return {}
 
     trainer = MLXTrainer.__new__(MLXTrainer)
-    trainer.model = DummyModel()
+    trainer.model = DummyModel() if model is None else model
     trainer.args = MLXTrainingConfig(**config_kwargs)
     # is_main_process is a property over this attribute; the 8-bit branch reads
     # it to decide whether to print its one-line banner.
@@ -68,7 +68,7 @@ _OPTIMIZER_CONSTRUCTORS = {
 }
 
 
-def _forwarded(monkeypatch, optim_name, **config_kwargs):
+def _forwarded(monkeypatch, optim_name, model=None, **config_kwargs):
     """Return ``(constructor_name, kwargs)`` for the optimizer the trainer builds.
 
     Records instead of constructing, so the assertions hold identically under
@@ -95,7 +95,9 @@ def _forwarded(monkeypatch, optim_name, **config_kwargs):
         for constructor in constructors:
             monkeypatch.setattr(target, constructor, _recorder(constructor))
 
-    _trainer(optim=optim_name, **config_kwargs)._build_optimizer(total_steps=4)
+    _trainer(
+        model=model, optim=optim_name, **config_kwargs,
+    )._build_optimizer(total_steps=4)
     assert len(recorded) == 1, f"expected one optimizer, recorded {recorded}"
     name, args, kwargs = recorded[0]
     assert not args, f"{name} was given positional arguments: {args}"
@@ -210,6 +212,47 @@ def test_adafactor_does_not_receive_the_scalar_epsilon(monkeypatch):
     default (1e-30, 1e-3)) with different meaning from HF's scalar, so
     adam_epsilon must not leak into it. The CUDA path scopes it the same way."""
     _name, kwargs = _forwarded(monkeypatch, "adafactor", adam_epsilon=1e-6)
+    assert "eps" not in kwargs
+
+
+def _rank3_model():
+    """A model whose only trainable parameter demotes Adafactor to AdamW."""
+    import types
+
+    parameter = types.SimpleNamespace(ndim=3, shape=(2, 2, 2))
+    return types.SimpleNamespace(
+        trainable_parameters=lambda: {"vision.patch_embed.weight": parameter}
+    )
+
+
+def test_the_adafactor_fallback_carries_the_epsilon(monkeypatch):
+    """rank>2 trainable parameters demote Adafactor to AdamW inside
+    _build_optimizer, and that demoted branch does take adam_kwargs. So the
+    epsilon has to be resolved after the fallback, not before it."""
+    name, kwargs = _forwarded(
+        monkeypatch, "adafactor", model=_rank3_model(), adam_epsilon=1e-6,
+    )
+    assert name == "AdamW"
+    assert kwargs["eps"] == pytest.approx(1e-6)
+
+
+def test_the_adafactor_fallback_rejects_a_bad_epsilon():
+    with pytest.raises(ValueError, match="adam_epsilon"):
+        _trainer(
+            model=_rank3_model(), optim="adafactor", adam_epsilon=-1.0,
+        )._build_optimizer(total_steps=4)
+
+
+@pytest.mark.parametrize("optim_name", ["sgd", "muon", "lion", "adafactor"])
+@pytest.mark.parametrize("bad", [-1.0, float("nan"), "not-a-number"])
+def test_epsilon_free_optimizers_ignore_an_invalid_epsilon(
+    monkeypatch, optim_name, bad,
+):
+    """The guard is scoped to the branches that consume the epsilon. HF never
+    hands adam_epsilon to these, so `optim="sgd", adam_epsilon=-1.0` trains
+    fine on CUDA; rejecting it here would block a config that is valid
+    everywhere else, and the value it complains about is never used."""
+    _name, kwargs = _forwarded(monkeypatch, optim_name, adam_epsilon=bad)
     assert "eps" not in kwargs
 
 

--- a/tests/test_mlx_adam_epsilon.py
+++ b/tests/test_mlx_adam_epsilon.py
@@ -281,6 +281,30 @@ def test_appended_field_stays_an_exact_suffix():
         assert tail == _MLX_CONFIG_OPTIONAL_COPY_FIELDS, config_class.__name__
 
 
+def test_the_preference_trainers_share_the_one_entry_point():
+    """_build_optimizer is the only optimizer construction site in
+    unsloth_zoo/mlx, and MLXORPOTrainer / MLXDPOTrainer inherit it rather than
+    building their own. That is what makes "one guard covers every objective"
+    true; a subclass that grows its own optimizer has to revisit the epsilon."""
+    from unsloth_zoo.mlx.trainer import (
+        MLXDPOConfig,
+        MLXDPOTrainer,
+        MLXORPOConfig,
+        MLXORPOTrainer,
+        MLXTrainer,
+    )
+
+    for trainer_class in (MLXORPOTrainer, MLXDPOTrainer):
+        assert (
+            trainer_class._build_optimizer is MLXTrainer._build_optimizer
+        ), trainer_class.__name__
+    # And the preference configs carry the field, so the knob is reachable from
+    # every objective the trainer supports.
+    for config_class in (MLXORPOConfig, MLXDPOConfig):
+        assert config_class(adam_epsilon=1e-6).adam_epsilon == pytest.approx(1e-6)
+        assert config_class().adam_epsilon is None
+
+
 def test_a_pre_pr_positional_config_copy_still_maps(monkeypatch):
     """An old config dump has no adam_epsilon. Copying it positionally must land
     every value in the same slot it came from and leave the epsilon unset."""

--- a/tests/test_mlx_adam_epsilon.py
+++ b/tests/test_mlx_adam_epsilon.py
@@ -213,6 +213,44 @@ def test_adafactor_does_not_receive_the_scalar_epsilon(monkeypatch):
     assert "eps" not in kwargs
 
 
+@pytest.mark.parametrize("bad", [-1e-8, -1.0, float("nan"), "not-a-number"])
+def test_epsilon_values_pytorch_rejects_are_rejected_here(bad):
+    """MLX validates nothing and adds eps straight into the denominator, so a
+    negative epsilon can flip an update's sign and a NaN one poisons every
+    parameter -- silently, where the identical CUDA config stops with an error.
+    The accepted set is torch's: `not 0.0 <= eps` (torch/optim/adam.py:60-61),
+    which rejects NaN because every NaN comparison is False."""
+    with pytest.raises(ValueError, match="adam_epsilon"):
+        _trainer(optim="adamw", adam_epsilon=bad)._build_optimizer(total_steps=4)
+
+
+@pytest.mark.parametrize("good", [0.0, 1e-8, 1e-30, float("inf"), "1e-6"])
+def test_epsilon_values_pytorch_accepts_are_accepted_here(monkeypatch, good):
+    """Zero and inf both satisfy torch's `0.0 <= eps`, so neither may be
+    rejected here. Numeric strings survive a JSON round trip of the config."""
+    _name, kwargs = _forwarded(monkeypatch, "adamw", adam_epsilon=good)
+    assert kwargs["eps"] == pytest.approx(float(good))
+
+
+def test_the_epsilon_guard_covers_non_mlx_config_objects():
+    """_build_optimizer reads adam_epsilon off self.args with getattr, so the
+    check has to live there rather than in MLXTrainingConfig.__init__: an HF
+    TrainingArguments or a bare namespace reaches the same line."""
+    import types
+
+    from unsloth_zoo.mlx.trainer import MLXTrainer, MLXTrainingConfig
+
+    trainer = MLXTrainer.__new__(MLXTrainer)
+    trainer.model = types.SimpleNamespace(trainable_parameters=lambda: {})
+    trainer._distributed_is_main_process = True
+    defaults = MLXTrainingConfig()
+    trainer.args = types.SimpleNamespace(
+        **{**vars(defaults), "optim": "adamw", "adam_epsilon": -1.0}
+    )
+    with pytest.raises(ValueError, match="adam_epsilon"):
+        trainer._build_optimizer(total_steps=4)
+
+
 def test_appended_field_stays_an_exact_suffix():
     """MLXTrainingConfig binds positional args by field order, so a new field
     must be appended last and keep _MLX_CONFIG_OPTIONAL_COPY_FIELDS a suffix of

--- a/tests/test_mlx_adam_epsilon.py
+++ b/tests/test_mlx_adam_epsilon.py
@@ -2,14 +2,21 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 """adam_epsilon on the MLX trainer (HF TrainingArguments parity).
 
-HF exposes ``adam_epsilon`` and the CUDA path forwards it to the optimizer
-(``unsloth/trainer.py:350``, alongside the betas). MLX carried ``adam_beta1`` /
+HF exposes ``adam_epsilon`` (transformers/training_args.py:919, default 1e-8)
+and forwards it to the optimizer as ``eps`` alongside the betas
+(transformers/trainer.py:1397-1400). MLX carried ``adam_beta1`` /
 ``adam_beta2`` but not the epsilon, and because ``MLXTrainingConfig`` rejects
 unknown kwargs, passing it raised ``TypeError`` before training began rather
 than being quietly ignored.
 
-CPU-pure: builds optimizers through the MLX simulation shim, no weights and no
-Metal. ``optimizer._kw`` is the shim's record of the kwargs MLX was called with.
+CPU-pure: no weights, no Metal, no optimizer step. The assertions are made
+against the kwargs ``_build_optimizer`` hands the optimizer constructor, which
+is the contract this feature owns, rather than against any private attribute of
+whichever MLX implementation happens to be importable. That matters: a host with
+real MLX installed (every Apple Silicon dev machine, and the Linux mlx-cpu CI
+jobs) imports ``unsloth_zoo.mlx`` -- and therefore binds the real
+``mlx.optimizers`` into ``unsloth_zoo.mlx.trainer`` -- during conftest's package
+preload, long before a module fixture could install the simulation shim.
 """
 
 from __future__ import annotations
@@ -23,7 +30,7 @@ def _install_shim():
     """Install-only, matching tests/test_mlx_double_quant_reject.py. Deliberately
     no teardown: popping mlx / unsloth_zoo.mlx modules on the way out breaks
     later files that hold references to them (this file sorts before
-    test_mlx_generate.py, which does)."""
+    test_mlx_generate.py, which does). A no-op where real MLX already won."""
     from mlx_simulation import simulate_mlx_on_torch
 
     simulate_mlx_on_torch()
@@ -39,7 +46,77 @@ def _trainer(**config_kwargs):
     trainer = MLXTrainer.__new__(MLXTrainer)
     trainer.model = DummyModel()
     trainer.args = MLXTrainingConfig(**config_kwargs)
+    # is_main_process is a property over this attribute; the 8-bit branch reads
+    # it to decide whether to print its one-line banner.
+    trainer._distributed_is_main_process = True
     return trainer
+
+
+# Every constructor _build_optimizer can reach, and the module each is looked up
+# on at call time. Keeping the list explicit is the point: a new optimizer branch
+# that this file does not name shows up as a KeyError in _forwarded rather than
+# silently escaping the "reaches nothing else" assertions.
+_OPTIMIZER_CONSTRUCTORS = {
+    "unsloth_zoo.mlx.trainer": (
+        "optim",
+        ("Adafactor", "AdamW", "Adam", "SGD", "Muon", "Lion"),
+    ),
+    "unsloth_zoo.mlx.optimizers_quantized": (
+        None,
+        ("QuantizedMomentAdam", "QuantizedMomentAdamW"),
+    ),
+}
+
+
+def _forwarded(monkeypatch, optim_name, **config_kwargs):
+    """Return ``(constructor_name, kwargs)`` for the optimizer the trainer builds.
+
+    Records instead of constructing, so the assertions hold identically under
+    real MLX and under the torch simulation shim.
+    """
+    import importlib
+
+    recorded = []
+
+    def _recorder(name):
+        def _record(*args, **kwargs):
+            recorded.append((name, args, kwargs))
+            return object()
+        return _record
+
+    # Import every target BEFORE patching any of them: optimizers_quantized
+    # subclasses optim.Adam at module scope, so importing it after optim.Adam has
+    # been replaced by a recorder function is a metaclass conflict, not a test.
+    targets = []
+    for module_path, (attribute, constructors) in _OPTIMIZER_CONSTRUCTORS.items():
+        module = importlib.import_module(module_path)
+        targets.append((getattr(module, attribute) if attribute else module, constructors))
+    for target, constructors in targets:
+        for constructor in constructors:
+            monkeypatch.setattr(target, constructor, _recorder(constructor))
+
+    _trainer(optim=optim_name, **config_kwargs)._build_optimizer(total_steps=4)
+    assert len(recorded) == 1, f"expected one optimizer, recorded {recorded}"
+    name, args, kwargs = recorded[0]
+    assert not args, f"{name} was given positional arguments: {args}"
+    return name, kwargs
+
+
+# adamw_8bit / adam_8bit route to the quantized Adam family, which takes the same
+# scalar eps and hands it straight to the stock MLX parent
+# (unsloth_zoo/mlx/optimizers_quantized.py:194-210, :215-232).
+_EPSILON_TAKING_OPTIMIZERS = ["adamw", "adam", "adamw_8bit", "adam_8bit"]
+# _normalize_mlx_optimizer_name collapses these HF spellings onto "adamw", so a
+# user who copies a CUDA config verbatim must still get the epsilon they asked
+# for. Six entry points, one guard: this is the class, not one instance of it.
+_ADAMW_ALIASES = [
+    "adamw_torch",
+    "adamw_torch_fused",
+    "paged_adamw_32bit",
+    "adamw_hf",
+    "adamw_bnb_8bit",
+    "paged_adamw_8bit",
+]
 
 
 def test_config_accepts_adam_epsilon():
@@ -51,64 +128,141 @@ def test_config_accepts_adam_epsilon():
     assert MLXTrainingConfig().adam_epsilon is None
 
 
-@pytest.mark.parametrize("optim_name", ["adamw", "adam"])
-def test_adam_epsilon_reaches_the_optimizer(optim_name):
-    optimizer = _trainer(optim=optim_name, adam_epsilon=1e-6)._build_optimizer(
-        total_steps=4
-    )
-    assert optimizer._kw["eps"] == pytest.approx(1e-6)
+@pytest.mark.parametrize("optim_name", _EPSILON_TAKING_OPTIMIZERS)
+def test_adam_epsilon_reaches_the_optimizer(monkeypatch, optim_name):
+    _name, kwargs = _forwarded(monkeypatch, optim_name, adam_epsilon=1e-6)
+    assert kwargs["eps"] == pytest.approx(1e-6)
 
 
-@pytest.mark.parametrize("optim_name", ["adamw", "adam"])
-def test_unset_epsilon_leaves_the_mlx_default_untouched(optim_name):
-    """None means "not requested": nothing is forwarded, so MLX's own default
-    (1e-8, matching HF) stands and the unset path is bitwise unchanged."""
-    optimizer = _trainer(optim=optim_name)._build_optimizer(total_steps=4)
-    assert "eps" not in optimizer._kw
+@pytest.mark.parametrize("optim_name", _ADAMW_ALIASES)
+def test_hf_optimizer_aliases_still_receive_the_epsilon(monkeypatch, optim_name):
+    name, kwargs = _forwarded(monkeypatch, optim_name, adam_epsilon=1e-6)
+    assert kwargs["eps"] == pytest.approx(1e-6), name
 
 
-def test_epsilon_composes_with_betas():
-    optimizer = _trainer(
-        optim="adamw", adam_beta1=0.85, adam_beta2=0.95, adam_epsilon=1e-7,
-    )._build_optimizer(total_steps=4)
-    assert optimizer._kw["eps"] == pytest.approx(1e-7)
-    assert optimizer._kw["betas"] == (pytest.approx(0.85), pytest.approx(0.95))
-
-
-@pytest.mark.parametrize("optim_name", ["sgd", "muon", "lion"])
-def test_epsilon_is_not_forwarded_to_epsilon_free_optimizers(optim_name):
-    """SGD/Muon/Lion accept no epsilon, so forwarding one would be a TypeError.
-    HF ignores adam_epsilon for these too, so setting it stays harmless."""
+@pytest.mark.parametrize("optim_name", _EPSILON_TAKING_OPTIMIZERS)
+def test_the_optimizer_accepts_the_epsilon_it_is_given(optim_name):
+    """The recorder above proves what is passed, not that MLX takes it. Build the
+    real thing once per branch so a kwarg MLX does not accept is a failure here
+    and not a TypeError in front of a user."""
     optimizer = _trainer(
         optim=optim_name, adam_epsilon=1e-6,
     )._build_optimizer(total_steps=4)
-    assert "eps" not in getattr(optimizer, "_kw", {})
+    # Real MLX publishes it (mlx/optimizers/optimizers.py:504); the simulation
+    # shim keeps constructor kwargs in _kw.
+    stored = getattr(optimizer, "eps", None)
+    if stored is None:
+        stored = optimizer._kw["eps"]
+    assert stored == pytest.approx(1e-6)
 
 
-def test_adafactor_does_not_receive_the_scalar_epsilon():
-    """MLX's Adafactor eps is a 2-tuple with different meaning from HF's scalar,
-    so adam_epsilon must not leak into it. The CUDA path scopes it the same way."""
-    optimizer = _trainer(
-        optim="adafactor", adam_epsilon=1e-6,
-    )._build_optimizer(total_steps=4)
-    assert "eps" not in getattr(optimizer, "_kw", {})
+@pytest.mark.parametrize("optim_name", _EPSILON_TAKING_OPTIMIZERS)
+def test_unset_epsilon_forwards_no_eps_kwarg(monkeypatch, optim_name):
+    """None means "not requested": nothing is forwarded, so MLX's own default
+    stands and the unset path is bitwise unchanged."""
+    _name, kwargs = _forwarded(monkeypatch, optim_name)
+    assert "eps" not in kwargs
+
+
+def test_the_mlx_default_epsilon_is_the_hf_default():
+    """What "leave the default alone" is worth depends on the two defaults
+    agreeing. Read both, do not assume either."""
+    import inspect
+
+    from transformers import TrainingArguments
+
+    # The module the trainer actually calls, not sys.modules["mlx.optimizers"]:
+    # the shim can be installed in sys.modules while the trainer still holds the
+    # real module it bound at import time.
+    from unsloth_zoo.mlx.trainer import optim
+
+    hf_default = TrainingArguments.__dataclass_fields__["adam_epsilon"].default
+    checked = 0
+    for constructor in (optim.Adam, optim.AdamW):
+        parameter = inspect.signature(constructor).parameters.get("eps")
+        if parameter is None:
+            # The simulation shim takes **kw and models no defaults.
+            continue
+        assert parameter.default == pytest.approx(hf_default), constructor
+        checked += 1
+    if not checked:
+        pytest.skip("the simulation shim does not model MLX's default eps")
+
+
+def test_epsilon_composes_with_betas(monkeypatch):
+    _name, kwargs = _forwarded(
+        monkeypatch, "adamw", adam_beta1=0.85, adam_beta2=0.95, adam_epsilon=1e-7,
+    )
+    assert kwargs["eps"] == pytest.approx(1e-7)
+    assert kwargs["betas"] == (pytest.approx(0.85), pytest.approx(0.95))
+
+
+@pytest.mark.parametrize("optim_name", ["sgd", "muon", "lion"])
+def test_epsilon_is_not_forwarded_to_epsilon_free_optimizers(monkeypatch, optim_name):
+    """SGD/Muon/Lion accept no epsilon, so forwarding one would be a TypeError.
+    HF ignores adam_epsilon for these too, so setting it stays harmless."""
+    _name, kwargs = _forwarded(monkeypatch, optim_name, adam_epsilon=1e-6)
+    assert "eps" not in kwargs
+
+
+def test_adafactor_does_not_receive_the_scalar_epsilon(monkeypatch):
+    """MLX's Adafactor eps is a 2-tuple (mlx/optimizers/optimizers.py:744,
+    default (1e-30, 1e-3)) with different meaning from HF's scalar, so
+    adam_epsilon must not leak into it. The CUDA path scopes it the same way."""
+    _name, kwargs = _forwarded(monkeypatch, "adafactor", adam_epsilon=1e-6)
+    assert "eps" not in kwargs
 
 
 def test_appended_field_stays_an_exact_suffix():
     """MLXTrainingConfig binds positional args by field order, so a new field
     must be appended last and keep _MLX_CONFIG_OPTIONAL_COPY_FIELDS a suffix of
-    the field list; inserting mid-list would shift every later field's slot."""
+    the POSITIONAL field list; inserting mid-list would shift every later field's
+    slot. The preference configs add kw_only fields after adam_epsilon, and
+    __init__ filters those out before zipping, so the invariant is over
+    `not field.kw_only` and has to hold for the subclasses too."""
     from dataclasses import fields as dataclass_fields
     from unsloth_zoo.mlx.trainer import (
+        MLXDPOConfig,
+        MLXORPOConfig,
         MLXTrainingConfig,
         _MLX_CONFIG_OPTIONAL_COPY_FIELDS,
     )
 
-    names = [f.name for f in dataclass_fields(MLXTrainingConfig) if f.init]
     assert "adam_epsilon" in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
-    # Deliberately not `names[-1] == "adam_epsilon"`: the convention is that
-    # each new field is appended and registered here, so pinning this field as
-    # the permanent last one would fire on the next unrelated addition. The
-    # suffix property below is the invariant that actually has to hold.
-    tail = tuple(names[-len(_MLX_CONFIG_OPTIONAL_COPY_FIELDS):])
-    assert tail == _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+    for config_class in (MLXTrainingConfig, MLXORPOConfig, MLXDPOConfig):
+        names = [
+            f.name
+            for f in dataclass_fields(config_class)
+            if f.init and not f.kw_only
+        ]
+        # Deliberately not `names[-1] == "adam_epsilon"`: the convention is that
+        # each new field is appended and registered here, so pinning this field
+        # as the permanent last one would fire on the next unrelated addition.
+        # The suffix property below is the invariant that actually has to hold.
+        tail = tuple(names[-len(_MLX_CONFIG_OPTIONAL_COPY_FIELDS):])
+        assert tail == _MLX_CONFIG_OPTIONAL_COPY_FIELDS, config_class.__name__
+
+
+def test_a_pre_pr_positional_config_copy_still_maps(monkeypatch):
+    """An old config dump has no adam_epsilon. Copying it positionally must land
+    every value in the same slot it came from and leave the epsilon unset."""
+    from dataclasses import fields as dataclass_fields
+    from unsloth_zoo.mlx.trainer import MLXTrainingConfig
+
+    names = [
+        f.name
+        for f in dataclass_fields(MLXTrainingConfig)
+        if f.init and not f.kw_only
+    ]
+    original = MLXTrainingConfig(optim="adam", learning_rate=1.5e-4, run_name="old")
+    # Everything the pre-PR surface had: the full positional list minus the
+    # field this PR appended.
+    pre_pr = [getattr(original, name) for name in names if name != "adam_epsilon"]
+    copied = MLXTrainingConfig(*pre_pr)
+
+    assert copied.optim == "adam"
+    assert copied.learning_rate == pytest.approx(1.5e-4)
+    assert copied.run_name == "old"
+    assert copied.adam_epsilon is None
+    _name, kwargs = _forwarded(monkeypatch, "adam")
+    assert "eps" not in kwargs

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1197,13 +1197,17 @@ class MLXTrainingConfig:
     logging_dir: str | None = None
     run_name: str | None = None
 
-    # HF TrainingArguments.adam_epsilon. Declared LAST for the same positional
-    # reason as the fields above, and listed in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
-    # so those stay an exact suffix. None means "not requested" and leaves the
-    # MLX optimizer default (1e-8, which is also the HF default) untouched, so
-    # this is a no-op unless it is set. Applies to adam/adamw only, matching the
-    # CUDA path; SGD/Muon/Lion take no epsilon and MLX's Adafactor eps is a
-    # 2-tuple with different meaning, so HF's scalar does not belong there.
+    # HF TrainingArguments.adam_epsilon (transformers/training_args.py:919,
+    # default 1e-8). Declared LAST for the same positional reason as the fields
+    # above, and listed in _MLX_CONFIG_OPTIONAL_COPY_FIELDS so those stay an
+    # exact suffix of the positional fields. None means "not requested" and
+    # leaves the MLX optimizer default (1e-8, mlx/optimizers/optimizers.py:497
+    # and :568 -- the same value HF defaults to) untouched, so this is a no-op
+    # unless it is set. Applies to the Adam family only, matching the CUDA path:
+    # adam / adamw and their 8-bit quantized counterparts, which take the same
+    # scalar eps and hand it to the stock MLX parent. SGD/Muon/Lion take no
+    # epsilon at all, and MLX's Adafactor eps is a 2-tuple with different
+    # meaning (optimizers.py:744), so HF's scalar does not belong there.
     adam_epsilon: float | None = None
 
     def __init__(self, *args, **kwargs):
@@ -3473,8 +3477,11 @@ class MLXTrainer:
                 float(0.999 if adam_beta2 is None else adam_beta2),
             )
         # Only forwarded when explicitly set, so the MLX default stays in force
-        # otherwise. adam_kwargs reaches Adam/AdamW alone (see below), which is
-        # the same scope as the CUDA path (unsloth/trainer.py:350).
+        # otherwise. adam_kwargs reaches the Adam family alone (see below):
+        # Adam/AdamW and the 8-bit QuantizedMomentAdam{,W}, which forward eps
+        # unchanged to those same parents. That is the CUDA scope too -- HF
+        # builds one adam_kwargs holding betas + eps and applies it only to the
+        # Adam-family branches (transformers/trainer.py:1397-1400).
         if adam_epsilon is not None:
             adam_kwargs["eps"] = float(adam_epsilon)
 

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -59,6 +59,8 @@ SUPPORTED_MLX_OPTIMIZERS = (
     # First moment only; see unsloth_zoo/mlx/optimizers_quantized.py.
     "adamw_8bit", "adam_8bit",
 )
+# The branches _build_optimizer forwards betas/eps to.
+_MLX_ADAM_FAMILY_OPTIMIZERS = ("adamw", "adam", "adamw_8bit", "adam_8bit")
 SUPPORTED_MLX_LR_SCHEDULERS = ("linear", "cosine", "constant")
 
 
@@ -3497,24 +3499,6 @@ class MLXTrainer:
         wd = self.args.weight_decay
         self._manual_weight_decay = 0.0
         self._coupled_weight_decay = 0.0
-        adam_beta1 = getattr(self.args, "adam_beta1", None)
-        adam_beta2 = getattr(self.args, "adam_beta2", None)
-        adam_epsilon = getattr(self.args, "adam_epsilon", None)
-        adam_kwargs = {}
-        if adam_beta1 is not None or adam_beta2 is not None:
-            adam_kwargs["betas"] = (
-                float(0.9 if adam_beta1 is None else adam_beta1),
-                float(0.999 if adam_beta2 is None else adam_beta2),
-            )
-        # Only forwarded when explicitly set, so the MLX default stays in force
-        # otherwise. adam_kwargs reaches the Adam family alone (see below):
-        # Adam/AdamW and the 8-bit QuantizedMomentAdam{,W}, which forward eps
-        # unchanged to those same parents. That is the CUDA scope too -- HF
-        # builds one adam_kwargs holding betas + eps and applies it only to the
-        # Adam-family branches (transformers/trainer.py:1397-1400).
-        if adam_epsilon is not None:
-            adam_kwargs["eps"] = _resolve_adam_epsilon(adam_epsilon)
-
         opt_name = _normalize_mlx_optimizer_name(self.args.optim)
         if opt_name == "adafactor":
             unsupported = self._adafactor_unsupported_parameters(self.model)
@@ -3530,6 +3514,28 @@ class MLXTrainer:
                     f"({preview})."
                 )
                 opt_name = "adamw"
+
+        # Built after the Adafactor fallback above, since that fallback lands on
+        # AdamW and has to carry the betas and epsilon with it. Scoped to the
+        # Adam family -- Adam/AdamW and the 8-bit QuantizedMomentAdam{,W}, which
+        # forward eps unchanged to those same parents -- so an epsilon set
+        # alongside optim="sgd" is ignored rather than validated, matching CUDA:
+        # HF builds one adam_kwargs holding betas + eps and applies it only to
+        # the Adam-family branches (transformers/trainer.py:1397-1400).
+        adam_kwargs = {}
+        if opt_name in _MLX_ADAM_FAMILY_OPTIMIZERS:
+            adam_beta1 = getattr(self.args, "adam_beta1", None)
+            adam_beta2 = getattr(self.args, "adam_beta2", None)
+            adam_epsilon = getattr(self.args, "adam_epsilon", None)
+            if adam_beta1 is not None or adam_beta2 is not None:
+                adam_kwargs["betas"] = (
+                    float(0.9 if adam_beta1 is None else adam_beta1),
+                    float(0.999 if adam_beta2 is None else adam_beta2),
+                )
+            # Only forwarded when explicitly set, so MLX's default stays in
+            # force otherwise.
+            if adam_epsilon is not None:
+                adam_kwargs["eps"] = _resolve_adam_epsilon(adam_epsilon)
 
         if opt_name == "adafactor":
             optimizer = optim.Adafactor(

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -816,6 +816,36 @@ def _normalize_mlx_optimizer_name(name):
     return opt_name
 
 
+def _resolve_adam_epsilon(value):
+    """HF's ``adam_epsilon`` as a float, rejecting what PyTorch rejects.
+
+    ``torch/optim/adam.py:60-61`` refuses ``not 0.0 <= eps`` (which also catches
+    NaN, since every comparison with NaN is False), so on CUDA a negative or NaN
+    epsilon stops the run with a clear error. MLX validates nothing --
+    ``mlx/optimizers/optimizers.py:493-504`` stores ``eps`` and adds it straight
+    into the update denominator -- so without this the same config trains to
+    garbage on Metal instead: a negative epsilon can cancel ``sqrt(v)`` and flip
+    the update's sign, and a NaN one poisons every parameter on the first step.
+
+    Numeric strings are accepted because configs round-trip through JSON in
+    Unsloth Studio; anything float() cannot read is named rather than surfacing
+    as a bare "could not convert string to float".
+    """
+    try:
+        epsilon = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Unsloth: adam_epsilon must be a number, got {value!r}."
+        ) from None
+    if not 0.0 <= epsilon:
+        raise ValueError(
+            f"Unsloth: adam_epsilon must be >= 0, got {value!r}. "
+            "PyTorch rejects the same values (torch/optim/adam.py:60), but MLX "
+            "would accept it and produce NaN or sign-flipped updates."
+        )
+    return epsilon
+
+
 _part_is_norm = _mlx_norm_path_part_is_norm
 _iter_norm_output_cast_classes = iter_mlx_norm_output_cast_classes
 _set_norm_output_cast_to_input_dtype = set_mlx_norm_output_cast_to_input_dtype
@@ -3483,7 +3513,7 @@ class MLXTrainer:
         # builds one adam_kwargs holding betas + eps and applies it only to the
         # Adam-family branches (transformers/trainer.py:1397-1400).
         if adam_epsilon is not None:
-            adam_kwargs["eps"] = float(adam_epsilon)
+            adam_kwargs["eps"] = _resolve_adam_epsilon(adam_epsilon)
 
         opt_name = _normalize_mlx_optimizer_name(self.args.optim)
         if opt_name == "adafactor":

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -1052,6 +1052,7 @@ _MLX_CONFIG_OPTIONAL_COPY_FIELDS = (
     "streaming_prefetch_batches",
     "logging_dir",
     "run_name",
+    "adam_epsilon",
 )
 
 
@@ -1180,6 +1181,15 @@ class MLXTrainingConfig:
     # _MLX_CONFIG_OPTIONAL_COPY_FIELDS so they stay an exact suffix of it.
     logging_dir: str | None = None
     run_name: str | None = None
+
+    # HF TrainingArguments.adam_epsilon. Declared LAST for the same positional
+    # reason as the fields above, and listed in _MLX_CONFIG_OPTIONAL_COPY_FIELDS
+    # so those stay an exact suffix. None means "not requested" and leaves the
+    # MLX optimizer default (1e-8, which is also the HF default) untouched, so
+    # this is a no-op unless it is set. Applies to adam/adamw only, matching the
+    # CUDA path; SGD/Muon/Lion take no epsilon and MLX's Adafactor eps is a
+    # 2-tuple with different meaning, so HF's scalar does not belong there.
+    adam_epsilon: float | None = None
 
     def __init__(self, *args, **kwargs):
         config_fields = [field for field in fields(type(self)) if field.init]
@@ -3401,12 +3411,18 @@ class MLXTrainer:
         self._coupled_weight_decay = 0.0
         adam_beta1 = getattr(self.args, "adam_beta1", None)
         adam_beta2 = getattr(self.args, "adam_beta2", None)
+        adam_epsilon = getattr(self.args, "adam_epsilon", None)
         adam_kwargs = {}
         if adam_beta1 is not None or adam_beta2 is not None:
             adam_kwargs["betas"] = (
                 float(0.9 if adam_beta1 is None else adam_beta1),
                 float(0.999 if adam_beta2 is None else adam_beta2),
             )
+        # Only forwarded when explicitly set, so the MLX default stays in force
+        # otherwise. adam_kwargs reaches Adam/AdamW alone (see below), which is
+        # the same scope as the CUDA path (unsloth/trainer.py:350).
+        if adam_epsilon is not None:
+            adam_kwargs["eps"] = float(adam_epsilon)
 
         opt_name = _normalize_mlx_optimizer_name(self.args.optim)
         if opt_name == "adafactor":


### PR DESCRIPTION
 `MLXTrainingConfig` mirrors SFTConfig / TrainingArguments field names and already carried
  `adam_beta1` / `adam_beta2` — but not `adam_epsilon`, which did not exist anywhere under
  `unsloth_zoo/mlx`.

  ## The bug
  
  The CUDA path forwards it alongside the betas (`unsloth/trainer.py:349-350`):

  ```python
  betas = (self.args.adam_beta1, self.args.adam_beta2),
  eps   = self.args.adam_epsilon,
  ```

  Because the MLX config validates its kwargs and rejects unknown ones, this was a hard failure
  rather than a silent drop:

  ```
  TypeError: MLXTrainingConfig got unexpected arguments: adam_epsilon
  ```

  So a script ported from CUDA died before the first step, rather than training with the wrong
  epsilon.

  ## What changed
  
  Add the field and forward it, scoped to `adam` / `adamw` exactly as CUDA scopes it. SGD, Muon
  and Lion accept no epsilon, and MLX's Adafactor `eps` is a 2-tuple whose meaning differs from
  HF's scalar, so it is deliberately not routed there.

  `None` means "not requested" and forwards nothing, leaving MLX's own default (1e-8, which is
  also the HF default) in force. The unset path is therefore bitwise unchanged, and only callers
  who set an explicit epsilon see any difference.

  The field is appended last and registered in `_MLX_CONFIG_OPTIONAL_COPY_FIELDS`, keeping those
  an exact suffix of the field list: the config binds positional arguments by field order, so
  inserting mid-list would shift every later field's slot.

  Consistent with HF and with the sibling betas, the value is not range-validated.

  ## Tests

  Eleven cases in a new `tests/test_mlx_adam_epsilon.py` (CPU-pure via the MLX simulation shim,
  no weights, ~0.1s for the module):

  - the config accepts `adam_epsilon` at all — the regression itself
  - the value reaches Adam and AdamW
  - unset forwards nothing, so the optimizer default stands
  - it composes with explicit betas
  - it is **not** forwarded to SGD / Muon / Lion, where it would be a `TypeError`
  - it is not forwarded to Adafactor, whose `eps` is a different shape
  - `_MLX_CONFIG_OPTIONAL_COPY_FIELDS` remains an exact suffix of the field list

  The bug was reproduced on the parent commit before fixing. Across the MLX suite the failing
  set is byte-identical to a clean checkout of `main`; the only delta is the eleven added tests.

  ## CI

  Second commit adds the new file to the behavioral-gate job. Outside those gate jobs `tests/`
  is collect-only, and as that step's own comment notes, collection proves solely that a file
  imports — a new test file left out of the gate would never actually run.