### PR TITLE
Fix Qwen3.5 fp16 training dtype mismatches under UNSLOTH_FORCE_FLOAT32

### DIFF
--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -29,6 +29,7 @@ import transformers.models.qwen3_5.modeling_qwen3_5 as qwen  # noqa: E402
 
 from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES  # noqa: E402
 from unsloth_zoo.temporary_patches.qwen3_5_float32 import (  # noqa: E402
+    _unsloth_fused_loss_kwargs,
     _unsloth_is_default_causal_lm_loss,
 )
 
@@ -185,3 +186,17 @@ def test_custom_loss_rejected():
     """Custom losses must fall back to the logits + loss_function branch."""
     fake_loss = type("_FakeLoss", (), {"__name__": "CustomFocalLoss"})()
     assert _unsloth_is_default_causal_lm_loss(fake_loss) is False
+
+
+def test_fused_loss_kwargs_filter():
+    """Model-only kwargs must not leak into the fused CE kernel."""
+    kwargs = {
+        "num_items_in_batch": 8,
+        "shift_labels": False,
+        "output_attentions": True,
+        "output_hidden_states": True,
+        "return_dict": True,
+        "use_cache": True,
+    }
+    filtered = _unsloth_fused_loss_kwargs(kwargs)
+    assert filtered == {"num_items_in_batch": 8, "shift_labels": False}

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -193,10 +193,17 @@ def test_fused_loss_kwargs_filter():
     kwargs = {
         "num_items_in_batch": 8,
         "shift_labels": False,
+        "ignore_index": -100,
+        "label_smoothing": 0.1,
         "output_attentions": True,
         "output_hidden_states": True,
         "return_dict": True,
         "use_cache": True,
     }
     filtered = _unsloth_fused_loss_kwargs(kwargs)
-    assert filtered == {"num_items_in_batch": 8, "shift_labels": False}
+    assert filtered == {
+        "num_items_in_batch": 8,
+        "shift_labels": False,
+        "ignore_index": -100,
+        "label_smoothing": 0.1,
+    }

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -28,6 +28,9 @@ from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig 
 import transformers.models.qwen3_5.modeling_qwen3_5 as qwen  # noqa: E402
 
 from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES  # noqa: E402
+from unsloth_zoo.temporary_patches.qwen3_5_float32 import (  # noqa: E402
+    _unsloth_is_default_causal_lm_loss,
+)
 
 
 def _apply_temporary_patches():
@@ -124,3 +127,16 @@ def test_qwen3_5_for_causal_lm_respects_output_hidden_states_config(monkeypatch)
     outputs = model(input_ids, use_cache=False)
     assert outputs.logits.shape == (2, 4, config.vocab_size)
     assert outputs.hidden_states is not None
+
+
+@pytest.mark.parametrize("name", ["ForCausalLMLoss", "UnslothForCausalLMLoss"])
+def test_default_causal_lm_loss_accepted(name):
+    """The default (and Unsloth-patched) loss names must take the fused path."""
+    fake_loss = type("_FakeLoss", (), {"__name__": name})()
+    assert _unsloth_is_default_causal_lm_loss(fake_loss) is True
+
+
+def test_custom_loss_rejected():
+    """Custom losses must fall back to the logits + loss_function branch."""
+    fake_loss = type("_FakeLoss", (), {"__name__": "CustomFocalLoss"})()
+    assert _unsloth_is_default_causal_lm_loss(fake_loss) is False

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -29,8 +29,8 @@ import transformers.models.qwen3_5.modeling_qwen3_5 as qwen  # noqa: E402
 
 from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES  # noqa: E402
 from unsloth_zoo.temporary_patches.qwen3_5_float32 import (  # noqa: E402
-    _unsloth_fused_loss_kwargs,
-    _unsloth_is_default_causal_lm_loss,
+    _unsloth_cast_position_embeddings,
+    _unsloth_weight_dtype,
 )
 
 
@@ -97,113 +97,41 @@ def test_qwen3_5_attention_dtype_mismatch_fixed(monkeypatch):
     assert out.dtype == hidden.dtype
 
 
-def test_qwen3_5_for_causal_lm_dtype_mismatch_fixed(monkeypatch):
-    """``Qwen3_5ForCausalLM`` must complete forward passes with fp16 weights."""
+def test_qwen3_5_gated_delta_net_dtype_mismatch_fixed(monkeypatch):
+    """``Qwen3_5GatedDeltaNet`` must accept bf16 activations when weights are fp16."""
     monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
     _apply_temporary_patches()
 
-    config = _tiny_text_config(layer_types=("full_attention", "full_attention"))
-    model = qwen.Qwen3_5ForCausalLM(config).to(torch.float16)
-    input_ids = torch.randint(0, config.vocab_size, (2, 4))
+    config = _tiny_text_config(layer_types=("linear_attention",))
+    block = qwen.Qwen3_5GatedDeltaNet(config, layer_idx=0).to(torch.float16)
+    x = torch.randn(2, 4, config.hidden_size, dtype=torch.bfloat16)
 
-    outputs = model(input_ids, use_cache=False)
-    assert outputs.logits.shape == (2, 4, config.vocab_size)
-
-    # The wrapper must preserve the standard Transformers tuple-output contract.
-    tuple_outputs = model(input_ids, use_cache=False, return_dict=False)
-    assert isinstance(tuple_outputs, tuple)
-    assert tuple_outputs[0].shape == (2, 4, config.vocab_size)
+    out = block(x)
+    assert out.shape == x.shape
+    assert out.dtype == x.dtype
 
 
-def test_qwen3_5_for_causal_lm_respects_output_hidden_states_config(monkeypatch):
-    """`config.output_hidden_states=True` must propagate even without the kwarg."""
-    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
-    _apply_temporary_patches()
+def test_unsloth_weight_dtype_skips_quantized_and_missing():
+    """`_unsloth_weight_dtype` must refuse quantized or absent weights."""
+    assert _unsloth_weight_dtype(None) is None
 
-    config = _tiny_text_config(layer_types=("full_attention", "full_attention"))
-    config.output_hidden_states = True
-    model = qwen.Qwen3_5ForCausalLM(config).to(torch.float16)
-    input_ids = torch.randint(0, config.vocab_size, (2, 4))
+    linear = torch.nn.Linear(4, 4)
+    linear.weight = torch.nn.Parameter(torch.randn(4, 4, dtype=torch.float32))
+    assert _unsloth_weight_dtype(linear) is torch.float32
 
-    outputs = model(input_ids, use_cache=False)
-    assert outputs.logits.shape == (2, 4, config.vocab_size)
-    assert outputs.hidden_states is not None
-
-
-def test_qwen3_5_for_causal_lm_custom_loss_does_not_receive_return_dict(monkeypatch):
-    """A custom loss must not see the wrapper's synthetic return_dict kwarg."""
-    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
-    _apply_temporary_patches()
-
-    config = _tiny_text_config(layer_types=("full_attention", "full_attention"))
-    model = qwen.Qwen3_5ForCausalLM(config).to(torch.float16)
-    received_kwargs = {}
-
-    def custom_loss(*, logits, labels, vocab_size, **kwargs):
-        received_kwargs.update(kwargs)
-        return torch.tensor(0.0, dtype=logits.dtype)
-
-    model.loss_function = custom_loss
-
-    input_ids = torch.randint(0, config.vocab_size, (2, 4))
-    labels = input_ids.clone()
-    out = model(input_ids, labels=labels, use_cache=False)
-    assert out.loss is not None
-    assert "return_dict" not in received_kwargs
+    # Fake quantized weight
+    param = torch.nn.Parameter(torch.randn(4, 4, dtype=torch.float16))
+    param.quant_state = object()
+    linear.weight = param
+    assert _unsloth_weight_dtype(linear) is None
 
 
-def test_qwen3_5_for_causal_lm_honors_accepts_loss_kwargs(monkeypatch):
-    """Respect accepts_loss_kwargs=False by not passing extra kwargs to loss."""
-    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
-    _apply_temporary_patches()
+def test_unsloth_cast_position_embeddings():
+    """`_unsloth_cast_position_embeddings` casts cos/sin to the target dtype."""
+    cos = torch.randn(1, 8, 16, dtype=torch.float32)
+    sin = torch.randn(1, 8, 16, dtype=torch.float32)
+    out = _unsloth_cast_position_embeddings((cos, sin), torch.float16)
+    assert out[0].dtype is torch.float16
+    assert out[1].dtype is torch.float16
 
-    config = _tiny_text_config(layer_types=("full_attention", "full_attention"))
-    model = qwen.Qwen3_5ForCausalLM(config).to(torch.float16)
-    received_kwargs = {}
-
-    def custom_loss(*, logits, labels, vocab_size, **kwargs):
-        received_kwargs.update(kwargs)
-        return torch.tensor(0.0, dtype=logits.dtype)
-
-    model.loss_function = custom_loss
-    model.accepts_loss_kwargs = False
-
-    input_ids = torch.randint(0, config.vocab_size, (2, 4))
-    labels = input_ids.clone()
-    out = model(input_ids, labels=labels, use_cache=False, num_items_in_batch=8)
-    assert out.loss is not None
-    assert "num_items_in_batch" not in received_kwargs
-
-
-@pytest.mark.parametrize("name", ["ForCausalLMLoss", "UnslothForCausalLMLoss"])
-def test_default_causal_lm_loss_accepted(name):
-    """The default (and Unsloth-patched) loss names must take the fused path."""
-    fake_loss = type("_FakeLoss", (), {"__name__": name})()
-    assert _unsloth_is_default_causal_lm_loss(fake_loss) is True
-
-
-def test_custom_loss_rejected():
-    """Custom losses must fall back to the logits + loss_function branch."""
-    fake_loss = type("_FakeLoss", (), {"__name__": "CustomFocalLoss"})()
-    assert _unsloth_is_default_causal_lm_loss(fake_loss) is False
-
-
-def test_fused_loss_kwargs_filter():
-    """Model-only kwargs must not leak into the fused CE kernel."""
-    kwargs = {
-        "num_items_in_batch": 8,
-        "shift_labels": False,
-        "ignore_index": -100,
-        "label_smoothing": 0.1,
-        "output_attentions": True,
-        "output_hidden_states": True,
-        "return_dict": True,
-        "use_cache": True,
-    }
-    filtered = _unsloth_fused_loss_kwargs(kwargs)
-    assert filtered == {
-        "num_items_in_batch": 8,
-        "shift_labels": False,
-        "ignore_index": -100,
-        "label_smoothing": 0.1,
-    }
+    assert _unsloth_cast_position_embeddings(None, torch.float16) is None

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -129,6 +129,28 @@ def test_qwen3_5_for_causal_lm_respects_output_hidden_states_config(monkeypatch)
     assert outputs.hidden_states is not None
 
 
+def test_qwen3_5_for_causal_lm_custom_loss_does_not_receive_return_dict(monkeypatch):
+    """A custom loss must not see the wrapper's synthetic return_dict kwarg."""
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    _apply_temporary_patches()
+
+    config = _tiny_text_config(layer_types=("full_attention", "full_attention"))
+    model = qwen.Qwen3_5ForCausalLM(config).to(torch.float16)
+    received_kwargs = {}
+
+    def custom_loss(*, logits, labels, vocab_size, **kwargs):
+        received_kwargs.update(kwargs)
+        return torch.tensor(0.0, dtype=logits.dtype)
+
+    model.loss_function = custom_loss
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 4))
+    labels = input_ids.clone()
+    out = model(input_ids, labels=labels, use_cache=False)
+    assert out.loss is not None
+    assert "return_dict" not in received_kwargs
+
+
 @pytest.mark.parametrize("name", ["ForCausalLMLoss", "UnslothForCausalLMLoss"])
 def test_default_causal_lm_loss_accepted(name):
     """The default (and Unsloth-patched) loss names must take the fused path."""

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -3,8 +3,8 @@
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or (at
-# your option) any later version.
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 
 """Regression tests for ``temporary_patches/qwen3_5_float32.py``.
 
@@ -36,12 +36,12 @@ def _apply_temporary_patches():
         patch_fn()
 
 
-def _tiny_text_config():
+def _tiny_text_config(layer_types=("linear_attention", "full_attention")):
     return Qwen3_5TextConfig(
         vocab_size=128,
         hidden_size=64,
         intermediate_size=128,
-        num_hidden_layers=2,
+        num_hidden_layers=len(layer_types),
         num_attention_heads=4,
         num_key_value_heads=2,
         hidden_act="silu",
@@ -50,7 +50,7 @@ def _tiny_text_config():
         head_dim=16,
         attention_dropout=0.0,
         rms_norm_eps=1e-06,
-        layer_types=["linear_attention", "full_attention"],
+        layer_types=list(layer_types),
         tie_word_embeddings=False,
         partial_rotary_factor=0.25,
     )
@@ -91,3 +91,21 @@ def test_qwen3_5_attention_dtype_mismatch_fixed(monkeypatch):
     )
     assert out.shape == hidden.shape
     assert out.dtype == hidden.dtype
+
+
+def test_qwen3_5_for_causal_lm_dtype_mismatch_fixed(monkeypatch):
+    """``Qwen3_5ForCausalLM`` must complete forward passes with fp16 weights."""
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    _apply_temporary_patches()
+
+    config = _tiny_text_config(layer_types=("full_attention", "full_attention"))
+    model = qwen.Qwen3_5ForCausalLM(config).to(torch.float16)
+    input_ids = torch.randint(0, config.vocab_size, (2, 4))
+
+    outputs = model(input_ids, use_cache=False)
+    assert outputs.logits.shape == (2, 4, config.vocab_size)
+
+    # The wrapper must preserve the standard Transformers tuple-output contract.
+    tuple_outputs = model(input_ids, use_cache=False, return_dict=False)
+    assert isinstance(tuple_outputs, tuple)
+    assert tuple_outputs[0].shape == (2, 4, config.vocab_size)

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import pytest
 
 pytest.importorskip("transformers")
+pytest.importorskip("transformers.models.qwen3_5.configuration_qwen3_5")
+pytest.importorskip("transformers.models.qwen3_5.modeling_qwen3_5")
 
 import torch  # noqa: E402
 from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig  # noqa: E402

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -1,0 +1,91 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+
+"""Regression tests for ``temporary_patches/qwen3_5_float32.py``.
+
+The dtype mismatch reported in unsloth#7506 (``BFloat16 != Half``
+RuntimeError inside Qwen3.5 linear layers) is reproduced on CPU by
+keeping fp16 weights but feeding them bf16 activations. The temporary
+patch normalizes activations to the actual weight dtype under
+``UNSLOTH_FORCE_FLOAT32=1``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("transformers")
+
+import torch  # noqa: E402
+from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig  # noqa: E402
+import transformers.models.qwen3_5.modeling_qwen3_5 as qwen  # noqa: E402
+
+from unsloth_zoo.temporary_patches.common import TEMPORARY_PATCHES  # noqa: E402
+
+
+def _apply_temporary_patches():
+    """Apply all registered temporary patches (they gate on environment vars)."""
+    for patch_fn in TEMPORARY_PATCHES:
+        patch_fn()
+
+
+def _tiny_text_config():
+    return Qwen3_5TextConfig(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+        head_dim=16,
+        attention_dropout=0.0,
+        rms_norm_eps=1e-06,
+        layer_types=["linear_attention", "full_attention"],
+        tie_word_embeddings=False,
+        partial_rotary_factor=0.25,
+    )
+
+
+def test_qwen3_5_mlp_dtype_mismatch_fixed(monkeypatch):
+    """``Qwen3_5MLP`` must accept bf16 activations when weights are fp16."""
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    _apply_temporary_patches()
+
+    config = _tiny_text_config()
+    mlp = qwen.Qwen3_5MLP(config, config.intermediate_size).to(torch.float16)
+    x = torch.randn(2, 4, config.hidden_size, dtype=torch.bfloat16)
+
+    out = mlp(x)
+    assert out.shape == x.shape
+    assert out.dtype == x.dtype
+
+
+def test_qwen3_5_attention_dtype_mismatch_fixed(monkeypatch):
+    """``Qwen3_5Attention`` must accept bf16 hidden states and RoPE when weights are fp16."""
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    _apply_temporary_patches()
+
+    config = _tiny_text_config()
+    attn = qwen.Qwen3_5Attention(config, layer_idx=0).to(torch.float16)
+    rotary = qwen.Qwen3_5TextRotaryEmbedding(config)
+
+    hidden = torch.randn(2, 4, config.hidden_size, dtype=torch.bfloat16)
+    position_ids = torch.arange(4).unsqueeze(0).expand(2, -1)
+    cos, sin = rotary(hidden, position_ids)
+
+    out, _ = attn(
+        hidden,
+        position_embeddings=(cos, sin),
+        position_ids=position_ids,
+        use_cache=False,
+    )
+    assert out.shape == hidden.shape
+    assert out.dtype == hidden.dtype

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -151,6 +151,29 @@ def test_qwen3_5_for_causal_lm_custom_loss_does_not_receive_return_dict(monkeypa
     assert "return_dict" not in received_kwargs
 
 
+def test_qwen3_5_for_causal_lm_honors_accepts_loss_kwargs(monkeypatch):
+    """Respect accepts_loss_kwargs=False by not passing extra kwargs to loss."""
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    _apply_temporary_patches()
+
+    config = _tiny_text_config(layer_types=("full_attention", "full_attention"))
+    model = qwen.Qwen3_5ForCausalLM(config).to(torch.float16)
+    received_kwargs = {}
+
+    def custom_loss(*, logits, labels, vocab_size, **kwargs):
+        received_kwargs.update(kwargs)
+        return torch.tensor(0.0, dtype=logits.dtype)
+
+    model.loss_function = custom_loss
+    model.accepts_loss_kwargs = False
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 4))
+    labels = input_ids.clone()
+    out = model(input_ids, labels=labels, use_cache=False, num_items_in_batch=8)
+    assert out.loss is not None
+    assert "num_items_in_batch" not in received_kwargs
+
+
 @pytest.mark.parametrize("name", ["ForCausalLMLoss", "UnslothForCausalLMLoss"])
 def test_default_causal_lm_loss_accepted(name):
     """The default (and Unsloth-patched) loss names must take the fused path."""

--- a/tests/test_qwen3_5_float32.py
+++ b/tests/test_qwen3_5_float32.py
@@ -109,3 +109,18 @@ def test_qwen3_5_for_causal_lm_dtype_mismatch_fixed(monkeypatch):
     tuple_outputs = model(input_ids, use_cache=False, return_dict=False)
     assert isinstance(tuple_outputs, tuple)
     assert tuple_outputs[0].shape == (2, 4, config.vocab_size)
+
+
+def test_qwen3_5_for_causal_lm_respects_output_hidden_states_config(monkeypatch):
+    """`config.output_hidden_states=True` must propagate even without the kwarg."""
+    monkeypatch.setenv("UNSLOTH_FORCE_FLOAT32", "1")
+    _apply_temporary_patches()
+
+    config = _tiny_text_config(layer_types=("full_attention", "full_attention"))
+    config.output_hidden_states = True
+    model = qwen.Qwen3_5ForCausalLM(config).to(torch.float16)
+    input_ids = torch.randint(0, config.vocab_size, (2, 4))
+
+    outputs = model(input_ids, use_cache=False)
+    assert outputs.logits.shape == (2, 4, config.vocab_size)
+    assert outputs.hidden_states is not None

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -60,6 +60,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.mxfp4",
     "unsloth_zoo.temporary_patches.pixtral",
     "unsloth_zoo.temporary_patches.qwen3_5_moe",
+    "unsloth_zoo.temporary_patches.qwen3_5_float32",
     "unsloth_zoo.temporary_patches.qwen3_moe",
     "unsloth_zoo.temporary_patches.qwen3_moe_float32",
     "unsloth_zoo.temporary_patches.qwen3_next_moe",

--- a/tests/test_temporary_patches_imports.py
+++ b/tests/test_temporary_patches_imports.py
@@ -62,6 +62,7 @@ TEMPORARY_PATCHES_SUBMODULES = [
     "unsloth_zoo.temporary_patches.mxfp4",
     "unsloth_zoo.temporary_patches.pixtral",
     "unsloth_zoo.temporary_patches.qwen3_5_moe",
+    "unsloth_zoo.temporary_patches.qwen3_5_float32",
     "unsloth_zoo.temporary_patches.qwen3_moe",
     "unsloth_zoo.temporary_patches.qwen3_moe_float32",
     "unsloth_zoo.temporary_patches.qwen3_next_moe",

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -31,6 +31,7 @@ from .qwen3_moe_float32 import *
 from .qwen3_vl_moe import *
 from .qwen3_next_moe import *
 from .qwen3_5_moe import *
+from .qwen3_5_float32 import *
 from .glm4_moe import *
 from .deepseek_v3_moe import *
 from .gemma4_moe import *

--- a/unsloth_zoo/temporary_patches/__init__.py
+++ b/unsloth_zoo/temporary_patches/__init__.py
@@ -30,6 +30,7 @@ from .qwen3_moe_float32 import *
 from .qwen3_vl_moe import *
 from .qwen3_next_moe import *
 from .qwen3_5_moe import *
+from .qwen3_5_float32 import *
 from .glm4_moe import *
 from .deepseek_v3_moe import *
 from .gemma4_moe import *

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -49,7 +49,7 @@ from .utils import patch_function, raise_error
 
 def _unsloth_get_linear_weight_dtype(module):
     """Return a representative fp Linear weight dtype, or None if absent."""
-    for attr in ("q_proj", "in_proj_qkv", "gate_proj", "up_proj", "fc1", "lm_head"):
+    for attr in ("q_proj", "qkv", "in_proj_qkv", "gate_proj", "linear_fc1", "up_proj", "fc1", "lm_head"):
         linear = getattr(module, attr, None)
         if linear is None:
             continue
@@ -109,9 +109,7 @@ def patch_Qwen3_5GatedDeltaNet_dtype():
         if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
             output = output.to(input_dtype)
         return output
-    pass
     patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-pass
 TEMPORARY_PATCHES.append(patch_Qwen3_5GatedDeltaNet_dtype)
 
 
@@ -158,9 +156,7 @@ def patch_Qwen3_5Attention_dtype():
         elif isinstance(output, torch.Tensor) and output.dtype != input_dtype:
             output = output.to(input_dtype)
         return output
-    pass
     patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-pass
 TEMPORARY_PATCHES.append(patch_Qwen3_5Attention_dtype)
 
 
@@ -187,19 +183,110 @@ def patch_Qwen3_5MLP_dtype():
         if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
             output = output.to(input_dtype)
         return output
-    pass
     patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-pass
 TEMPORARY_PATCHES.append(patch_Qwen3_5MLP_dtype)
+
+
+def patch_Qwen3_5VisionAttention_dtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return
+    try:
+        import transformers.models.qwen3_5.modeling_qwen3_5
+        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5VisionAttention
+        cls.forward  # ensure attribute exists
+    except Exception as e:
+        return raise_error("Qwen3_5VisionAttention.forward", e)
+
+    original_forward = cls.forward
+
+    def forward(self, hidden_states, cu_seqlens, rotary_pos_emb=None, position_embeddings=None, **kwargs):
+        input_dtype = hidden_states.dtype
+        target_dtype = _unsloth_get_linear_weight_dtype(self)
+        if target_dtype is not None and hidden_states.dtype != target_dtype:
+            hidden_states = hidden_states.to(target_dtype)
+        position_embeddings = _unsloth_cast_position_embeddings(position_embeddings, target_dtype or input_dtype)
+
+        output = original_forward(
+            self,
+            hidden_states,
+            cu_seqlens,
+            rotary_pos_emb=rotary_pos_emb,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+
+        if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
+            output = output.to(input_dtype)
+        return output
+    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
+TEMPORARY_PATCHES.append(patch_Qwen3_5VisionAttention_dtype)
+
+
+def patch_Qwen3_5VisionMLP_dtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return
+    try:
+        import transformers.models.qwen3_5.modeling_qwen3_5
+        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5VisionMLP
+        cls.forward  # ensure attribute exists
+    except Exception as e:
+        return raise_error("Qwen3_5VisionMLP.forward", e)
+
+    original_forward = cls.forward
+
+    def forward(self, hidden_state):
+        input_dtype = hidden_state.dtype
+        target_dtype = _unsloth_get_linear_weight_dtype(self)
+        if target_dtype is not None and hidden_state.dtype != target_dtype:
+            hidden_state = hidden_state.to(target_dtype)
+
+        output = original_forward(self, hidden_state)
+
+        if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
+            output = output.to(input_dtype)
+        return output
+    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
+TEMPORARY_PATCHES.append(patch_Qwen3_5VisionMLP_dtype)
+
+
+def patch_Qwen3_5VisionPatchMerger_dtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return
+    try:
+        import transformers.models.qwen3_5.modeling_qwen3_5
+        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5VisionPatchMerger
+        cls.forward  # ensure attribute exists
+    except Exception as e:
+        return raise_error("Qwen3_5VisionPatchMerger.forward", e)
+
+    original_forward = cls.forward
+
+    def forward(self, x):
+        input_dtype = x.dtype
+        target_dtype = _unsloth_get_linear_weight_dtype(self)
+        if target_dtype is not None and x.dtype != target_dtype:
+            x = x.to(target_dtype)
+
+        output = original_forward(self, x)
+
+        if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
+            output = output.to(input_dtype)
+        return output
+    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
+TEMPORARY_PATCHES.append(patch_Qwen3_5VisionPatchMerger_dtype)
 
 
 def patch_Qwen3_5ForCausalLM_dtype():
     if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
         return
     try:
-        import transformers.models.qwen3_5.modeling_qwen3_5
-        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5ForCausalLM
-        CausalLMOutputWithPast = transformers.models.qwen3_5.modeling_qwen3_5.CausalLMOutputWithPast
+        import transformers.models.qwen3_5.modeling_qwen3_5 as qwen
+        from transformers.utils.generic import can_return_tuple
+        import unsloth_zoo.fused_losses.forward_adapter as fa
+        cls = qwen.Qwen3_5ForCausalLM
+        CausalLMOutputWithPast = qwen.CausalLMOutputWithPast
+        fused_loss = getattr(fa, "unsloth_fused_lm_head_loss", None)
+        EMPTY_LOGITS = getattr(fa, "EMPTY_LOGITS", None)
     except Exception as e:
         return raise_error("Qwen3_5ForCausalLM.forward", e)
 
@@ -215,9 +302,6 @@ def patch_Qwen3_5ForCausalLM_dtype():
         logits_to_keep=0,
         **kwargs,
     ):
-        # Force return_dict so the wrapper can always read ModelOutput attrs;
-        # the public return type is still governed by the original contract.
-        kwargs.pop("return_dict", None)
         output_attentions = kwargs.pop("output_attentions", None)
         output_hidden_states = kwargs.pop("output_hidden_states", None)
 
@@ -238,15 +322,24 @@ def patch_Qwen3_5ForCausalLM_dtype():
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
         lm_input = hidden_states[:, slice_indices, :]
 
-        target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", lm_input.dtype)
-        if getattr(target_dtype, "is_floating_point", False) and lm_input.dtype != target_dtype:
-            lm_input = lm_input.to(target_dtype)
+        target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", None)
 
-        logits = self.lm_head(lm_input)
+        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None:
+            # Training path: keep the fused lm-head / cross-entropy path and
+            # only inject the dtype alignment at the hidden-state boundary.
+            if target_dtype is not None and lm_input.dtype != target_dtype:
+                lm_input = lm_input.to(target_dtype)
+            loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.vocab_size, **kwargs)
+            logits = EMPTY_LOGITS
+        else:
+            # Inference path: materialise logits, but align them first.
+            if target_dtype is not None and lm_input.dtype != target_dtype:
+                lm_input = lm_input.to(target_dtype)
+            logits = self.lm_head(lm_input)
 
-        loss = None
-        if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = None
+            if labels is not None:
+                loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
 
         return CausalLMOutputWithPast(
             loss=loss,
@@ -255,9 +348,9 @@ def patch_Qwen3_5ForCausalLM_dtype():
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
-    pass
+
+    forward = can_return_tuple(forward)
     patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-pass
 TEMPORARY_PATCHES.append(patch_Qwen3_5ForCausalLM_dtype)
 
 
@@ -265,9 +358,13 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
     if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
         return
     try:
-        import transformers.models.qwen3_5.modeling_qwen3_5
-        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5ForConditionalGeneration
-        CausalLMOutputWithPast = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5CausalLMOutputWithPast
+        import transformers.models.qwen3_5.modeling_qwen3_5 as qwen
+        from transformers.utils.generic import can_return_tuple
+        import unsloth_zoo.fused_losses.forward_adapter as fa
+        cls = qwen.Qwen3_5ForConditionalGeneration
+        CausalLMOutputWithPast = qwen.Qwen3_5CausalLMOutputWithPast
+        fused_loss = getattr(fa, "unsloth_fused_lm_head_loss", None)
+        EMPTY_LOGITS = getattr(fa, "EMPTY_LOGITS", None)
     except Exception as e:
         return raise_error("Qwen3_5ForConditionalGeneration.forward", e)
 
@@ -287,6 +384,9 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
         logits_to_keep=0,
         **kwargs,
     ):
+        output_attentions = kwargs.pop("output_attentions", None)
+        output_hidden_states = kwargs.pop("output_hidden_states", None)
+
         outputs = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -298,37 +398,46 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
             image_grid_thw=image_grid_thw,
             video_grid_thw=video_grid_thw,
             mm_token_type_ids=mm_token_type_ids,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
             **kwargs,
         )
 
-        hidden_states = outputs[0]
+        hidden_states = outputs.last_hidden_state
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
         lm_input = hidden_states[:, slice_indices, :]
 
-        target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", lm_input.dtype)
-        if getattr(target_dtype, "is_floating_point", False) and lm_input.dtype != target_dtype:
-            lm_input = lm_input.to(target_dtype)
+        target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", None)
 
-        logits = self.lm_head(lm_input)
+        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None:
+            if target_dtype is not None and lm_input.dtype != target_dtype:
+                lm_input = lm_input.to(target_dtype)
+            loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.text_config.vocab_size, **kwargs)
+            logits = EMPTY_LOGITS
+        else:
+            if target_dtype is not None and lm_input.dtype != target_dtype:
+                lm_input = lm_input.to(target_dtype)
+            logits = self.lm_head(lm_input)
 
-        loss = None
-        if labels is not None:
-            loss = self.loss_function(
-                logits=logits,
-                labels=labels,
-                vocab_size=self.config.text_config.vocab_size,
-                **kwargs,
-            )
+            loss = None
+            if labels is not None:
+                loss = self.loss_function(
+                    logits=logits,
+                    labels=labels,
+                    vocab_size=self.config.text_config.vocab_size,
+                    **kwargs,
+                )
 
         return CausalLMOutputWithPast(
             loss=loss,
             logits=logits,
-            past_key_values=getattr(outputs, "past_key_values", None),
-            hidden_states=getattr(outputs, "hidden_states", None),
-            attentions=getattr(outputs, "attentions", None),
-            rope_deltas=getattr(outputs, "rope_deltas", None),
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            rope_deltas=outputs.rope_deltas,
         )
-    pass
+
+    forward = can_return_tuple(forward)
     patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-pass
 TEMPORARY_PATCHES.append(patch_Qwen3_5ForConditionalGeneration_dtype)

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -124,6 +124,8 @@ _FUSED_LOSS_KWARG_KEYS = frozenset({
     "num_items_in_batch",
     "n_items",
     "shift_labels",
+    "ignore_index",
+    "label_smoothing",
     "logit_scale_multiply",
     "logit_scale_divide",
     "logit_softcapping",

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -92,13 +92,14 @@ def _unsloth_weight_dtype(linear):
 
 
 def _unsloth_is_default_causal_lm_loss(loss_function):
-    """True when the configured loss is the standard HF causal-LM objective.
+    """True when the configured loss is the standard HF/Unsloth causal-LM objective.
 
-    Custom loss functions should fall back to the logits + loss_function path
-    rather than being silently replaced by the fused CE kernel.
+    Unsloth renames the default loss to ``UnslothForCausalLMLoss``; keep the
+    same suffix rule used by the compiler rewrite so the default fused path is
+    still taken while custom losses fall back to logits + loss_function.
     """
     name = getattr(loss_function, "__name__", "")
-    return name in ("ForCausalLMLoss",)
+    return name.endswith("ForCausalLMLoss")
 
 
 def _unsloth_cast_position_embeddings(position_embeddings, dtype):

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -60,24 +60,9 @@ def _unsloth_get_linear_weight_dtype(module):
     """Return a representative fp Linear weight dtype, or None if absent."""
     for attr in ("q_proj", "qkv", "in_proj_qkv", "gate_proj", "linear_fc1", "up_proj", "fc1", "lm_head"):
         linear = getattr(module, attr, None)
-        if linear is None:
-            continue
-        linear = _unsloth_base_linear(linear)
-        if linear is None:
-            continue
-        weight = getattr(linear, "weight", None)
-        if weight is None:
-            continue
-        quant_state = getattr(weight, "quant_state", None)
-        if quant_state is not None:
-            continue
-        dtype = getattr(weight, "dtype", None)
-        if dtype is None or not getattr(dtype, "is_floating_point", False):
-            continue
-        # Skip sub-2-byte floats (fp8) where casting would destroy values.
-        if getattr(dtype, "itemsize", 2) < 2:
-            continue
-        return dtype
+        dtype = _unsloth_weight_dtype(linear)
+        if dtype is not None:
+            return dtype
     return None
 
 
@@ -196,7 +181,7 @@ def patch_Qwen3_5Attention_dtype():
     def forward(
         self,
         hidden_states,
-        position_embeddings=None,
+        position_embeddings,
         attention_mask=None,
         past_key_values=None,
         **kwargs,

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -102,6 +102,24 @@ def _unsloth_is_default_causal_lm_loss(loss_function):
     return name.endswith("ForCausalLMLoss")
 
 
+# Kwargs allowed through to the fused CE kernel. Model-only keys such as
+# output_attentions / output_hidden_states / return_dict must not be forwarded
+# because unsloth_fused_ce_loss passes them into an autograd Function.
+_FUSED_LOSS_KWARG_KEYS = frozenset({
+    "num_items_in_batch",
+    "n_items",
+    "shift_labels",
+    "logit_scale_multiply",
+    "logit_scale_divide",
+    "logit_softcapping",
+})
+
+
+def _unsloth_fused_loss_kwargs(kwargs):
+    """Return only the kwargs the fused loss kernel understands."""
+    return {k: v for k, v in kwargs.items() if k in _FUSED_LOSS_KWARG_KEYS}
+
+
 def _unsloth_cast_position_embeddings(position_embeddings, dtype):
     """Cast a (cos, sin) tuple to dtype when necessary."""
     if position_embeddings is None:
@@ -232,7 +250,7 @@ def patch_Qwen3_5VisionAttention_dtype():
 
     original_forward = cls.forward
 
-    def forward(self, hidden_states, cu_seqlens, rotary_pos_emb=None, position_embeddings=None, **kwargs):
+    def forward(self, hidden_states, cu_seqlens, position_embeddings=None, max_seqlen=None, **kwargs):
         input_dtype = hidden_states.dtype
         target_dtype = _unsloth_get_linear_weight_dtype(self)
         if target_dtype is not None and hidden_states.dtype != target_dtype:
@@ -243,8 +261,8 @@ def patch_Qwen3_5VisionAttention_dtype():
             self,
             hidden_states,
             cu_seqlens,
-            rotary_pos_emb=rotary_pos_emb,
             position_embeddings=position_embeddings,
+            max_seqlen=max_seqlen,
             **kwargs,
         )
 
@@ -338,6 +356,10 @@ def patch_Qwen3_5ForCausalLM_dtype():
         RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
         RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
 
+        # can_return_tuple normally pops return_dict, but be defensive so a
+        # caller-supplied return_dict never reaches the loss function either.
+        kwargs.pop("return_dict", None)
+
         # Always work with ModelOutput internally; @can_return_tuple preserves
         # the public tuple/return_dict contract. Use a separate dict so the
         # synthetic return_dict never reaches the loss function.
@@ -381,7 +403,11 @@ def patch_Qwen3_5ForCausalLM_dtype():
             # only inject the dtype alignment at the hidden-state boundary.
             if target_dtype is not None and lm_input.dtype != target_dtype:
                 lm_input = lm_input.to(target_dtype)
-            loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.vocab_size, **loss_kwargs)
+            loss = fused_loss(
+                lm_input, self.lm_head, labels,
+                vocab_size=self.config.vocab_size,
+                **_unsloth_fused_loss_kwargs(loss_kwargs),
+            )
             logits = EMPTY_LOGITS
         else:
             # Inference path (or explicit logits opt-in / custom loss):
@@ -392,7 +418,11 @@ def patch_Qwen3_5ForCausalLM_dtype():
 
             loss = None
             if labels is not None:
-                loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **loss_kwargs)
+                loss = self.loss_function(
+                    logits=logits, labels=labels,
+                    vocab_size=self.config.vocab_size,
+                    **loss_kwargs,
+                )
 
         return CausalLMOutputWithPast(
             loss=loss,
@@ -440,6 +470,10 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
         RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
         RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
 
+        # can_return_tuple normally pops return_dict, but be defensive so a
+        # caller-supplied return_dict never reaches the loss function either.
+        kwargs.pop("return_dict", None)
+
         # Keep the synthetic return_dict away from the loss function.
         model_kwargs = dict(kwargs)
         model_kwargs["return_dict"] = True
@@ -481,7 +515,11 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
                 and _unsloth_is_default_causal_lm_loss(self.loss_function):
             if target_dtype is not None and lm_input.dtype != target_dtype:
                 lm_input = lm_input.to(target_dtype)
-            loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.text_config.vocab_size, **loss_kwargs)
+            loss = fused_loss(
+                lm_input, self.lm_head, labels,
+                vocab_size=self.config.text_config.vocab_size,
+                **_unsloth_fused_loss_kwargs(loss_kwargs),
+            )
             logits = EMPTY_LOGITS
         else:
             if target_dtype is not None and lm_input.dtype != target_dtype:

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -339,8 +339,10 @@ def patch_Qwen3_5ForCausalLM_dtype():
         RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
 
         # Always work with ModelOutput internally; @can_return_tuple preserves
-        # the public tuple/return_dict contract.
-        kwargs["return_dict"] = True
+        # the public tuple/return_dict contract. Use a separate dict so the
+        # synthetic return_dict never reaches the loss function.
+        model_kwargs = dict(kwargs)
+        model_kwargs["return_dict"] = True
         outputs = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -348,7 +350,7 @@ def patch_Qwen3_5ForCausalLM_dtype():
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
             use_cache=use_cache,
-            **kwargs,
+            **model_kwargs,
         )
 
         hidden_states = outputs.last_hidden_state
@@ -432,7 +434,9 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
         RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
         RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
 
-        kwargs["return_dict"] = True
+        # Keep the synthetic return_dict away from the loss function.
+        model_kwargs = dict(kwargs)
+        model_kwargs["return_dict"] = True
         outputs = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -444,7 +448,7 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
             image_grid_thw=image_grid_thw,
             video_grid_thw=video_grid_thw,
             mm_token_type_ids=mm_token_type_ids,
-            **kwargs,
+            **model_kwargs,
         )
 
         hidden_states = outputs.last_hidden_state

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -369,13 +369,19 @@ def patch_Qwen3_5ForCausalLM_dtype():
 
         target_dtype = _unsloth_weight_dtype(self.lm_head)
 
+        # Some model classes (notably Qwen3_5ForConditionalGeneration) set
+        # accepts_loss_kwargs=False to avoid scaling the loss by
+        # num_items_in_batch during gradient accumulation. Mirror that contract
+        # instead of blindly forwarding all kwargs to the loss.
+        loss_kwargs = kwargs if getattr(self, "accepts_loss_kwargs", True) else {}
+
         if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS \
                 and _unsloth_is_default_causal_lm_loss(self.loss_function):
             # Training path: keep the fused lm-head / cross-entropy path and
             # only inject the dtype alignment at the hidden-state boundary.
             if target_dtype is not None and lm_input.dtype != target_dtype:
                 lm_input = lm_input.to(target_dtype)
-            loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.vocab_size, **loss_kwargs)
             logits = EMPTY_LOGITS
         else:
             # Inference path (or explicit logits opt-in / custom loss):
@@ -386,7 +392,7 @@ def patch_Qwen3_5ForCausalLM_dtype():
 
             loss = None
             if labels is not None:
-                loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+                loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **loss_kwargs)
 
         return CausalLMOutputWithPast(
             loss=loss,
@@ -467,11 +473,15 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
 
         target_dtype = _unsloth_weight_dtype(self.lm_head)
 
+        # Honor accepts_loss_kwargs (upstream Qwen3_5ForConditionalGeneration
+        # sets this to False so num_items_in_batch is not applied to the loss).
+        loss_kwargs = kwargs if getattr(self, "accepts_loss_kwargs", True) else {}
+
         if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS \
                 and _unsloth_is_default_causal_lm_loss(self.loss_function):
             if target_dtype is not None and lm_input.dtype != target_dtype:
                 lm_input = lm_input.to(target_dtype)
-            loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.text_config.vocab_size, **kwargs)
+            loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.text_config.vocab_size, **loss_kwargs)
             logits = EMPTY_LOGITS
         else:
             if target_dtype is not None and lm_input.dtype != target_dtype:
@@ -484,7 +494,7 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
                     logits=logits,
                     labels=labels,
                     vocab_size=self.config.text_config.vocab_size,
-                    **kwargs,
+                    **loss_kwargs,
                 )
 
         return CausalLMOutputWithPast(
@@ -499,3 +509,4 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
     forward = can_return_tuple(forward)
     patch_function(cls, "forward", forward, force=True, match_level="relaxed")
 TEMPORARY_PATCHES.append(patch_Qwen3_5ForConditionalGeneration_dtype)
+

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -215,6 +215,12 @@ def patch_Qwen3_5ForCausalLM_dtype():
         logits_to_keep=0,
         **kwargs,
     ):
+        # Force return_dict so the wrapper can always read ModelOutput attrs;
+        # the public return type is still governed by the original contract.
+        kwargs.pop("return_dict", None)
+        output_attentions = kwargs.pop("output_attentions", None)
+        output_hidden_states = kwargs.pop("output_hidden_states", None)
+
         outputs = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -222,6 +228,9 @@ def patch_Qwen3_5ForCausalLM_dtype():
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
             use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
             **kwargs,
         )
 
@@ -250,3 +259,76 @@ def patch_Qwen3_5ForCausalLM_dtype():
     patch_function(cls, "forward", forward, force=True, match_level="relaxed")
 pass
 TEMPORARY_PATCHES.append(patch_Qwen3_5ForCausalLM_dtype)
+
+
+def patch_Qwen3_5ForConditionalGeneration_dtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return
+    try:
+        import transformers.models.qwen3_5.modeling_qwen3_5
+        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5ForConditionalGeneration
+        CausalLMOutputWithPast = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5CausalLMOutputWithPast
+    except Exception as e:
+        return raise_error("Qwen3_5ForConditionalGeneration.forward", e)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        labels=None,
+        pixel_values=None,
+        pixel_values_videos=None,
+        image_grid_thw=None,
+        video_grid_thw=None,
+        mm_token_type_ids=None,
+        logits_to_keep=0,
+        **kwargs,
+    ):
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            mm_token_type_ids=mm_token_type_ids,
+            **kwargs,
+        )
+
+        hidden_states = outputs[0]
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        lm_input = hidden_states[:, slice_indices, :]
+
+        target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", lm_input.dtype)
+        if getattr(target_dtype, "is_floating_point", False) and lm_input.dtype != target_dtype:
+            lm_input = lm_input.to(target_dtype)
+
+        logits = self.lm_head(lm_input)
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.text_config.vocab_size,
+                **kwargs,
+            )
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=getattr(outputs, "past_key_values", None),
+            hidden_states=getattr(outputs, "hidden_states", None),
+            attentions=getattr(outputs, "attentions", None),
+            rope_deltas=getattr(outputs, "rope_deltas", None),
+        )
+    pass
+    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
+pass
+TEMPORARY_PATCHES.append(patch_Qwen3_5ForConditionalGeneration_dtype)

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -69,6 +69,38 @@ def _unsloth_get_linear_weight_dtype(module):
     return None
 
 
+def _unsloth_weight_dtype(linear):
+    """Return a safe compute dtype for a single Linear's weight, or None.
+
+    Mirrors the guard in ``_unsloth_get_linear_weight_dtype`` so we do not
+    cast activations to a packed quantized storage dtype or to fp8.
+    """
+    if linear is None:
+        return None
+    weight = getattr(linear, "weight", None)
+    if weight is None:
+        return None
+    quant_state = getattr(weight, "quant_state", None)
+    if quant_state is not None:
+        return None
+    dtype = getattr(weight, "dtype", None)
+    if dtype is None or not getattr(dtype, "is_floating_point", False):
+        return None
+    if getattr(dtype, "itemsize", 2) < 2:
+        return None
+    return dtype
+
+
+def _unsloth_is_default_causal_lm_loss(loss_function):
+    """True when the configured loss is the standard HF causal-LM objective.
+
+    Custom loss functions should fall back to the logits + loss_function path
+    rather than being silently replaced by the fused CE kernel.
+    """
+    name = getattr(loss_function, "__name__", "")
+    return name in ("ForCausalLMLoss",)
+
+
 def _unsloth_cast_position_embeddings(position_embeddings, dtype):
     """Cast a (cos, sin) tuple to dtype when necessary."""
     if position_embeddings is None:
@@ -332,9 +364,10 @@ def patch_Qwen3_5ForCausalLM_dtype():
                 attentions=outputs.attentions,
             )
 
-        target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", None)
+        target_dtype = _unsloth_weight_dtype(self.lm_head)
 
-        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS:
+        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS \
+                and _unsloth_is_default_causal_lm_loss(self.loss_function):
             # Training path: keep the fused lm-head / cross-entropy path and
             # only inject the dtype alignment at the hidden-state boundary.
             if target_dtype is not None and lm_input.dtype != target_dtype:
@@ -342,8 +375,8 @@ def patch_Qwen3_5ForCausalLM_dtype():
             loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.vocab_size, **kwargs)
             logits = EMPTY_LOGITS
         else:
-            # Inference path (or explicit logits opt-in): materialise logits,
-            # but align them first.
+            # Inference path (or explicit logits opt-in / custom loss):
+            # materialise logits, but align them first.
             if target_dtype is not None and lm_input.dtype != target_dtype:
                 lm_input = lm_input.to(target_dtype)
             logits = self.lm_head(lm_input)
@@ -427,9 +460,10 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
                 rope_deltas=outputs.rope_deltas,
             )
 
-        target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", None)
+        target_dtype = _unsloth_weight_dtype(self.lm_head)
 
-        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS:
+        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS \
+                and _unsloth_is_default_causal_lm_loss(self.loss_function):
             if target_dtype is not None and lm_input.dtype != target_dtype:
                 lm_input = lm_input.to(target_dtype)
             loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.text_config.vocab_size, **kwargs)

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -1,0 +1,252 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ============================================================================
+# Qwen3.5 targeted dtype-consistency patches for fp16 (UNSLOTH_FORCE_FLOAT32)
+# training.
+#
+# Qwen3.5 is in unsloth_zoo.model_lists.FORCE_FLOAT32 because its GatedDeltaNet
+# layers NaN/Inf in float16 training. When a user requests fp16 on a GPU that
+# does not support bf16, unsloth loads in bf16 and patch_model_and_tokenizer
+# down-casts the weights to fp16. The SFTTrainer may still autocast activations
+# to bf16 (or keep the pre-quant fp32 residual stream), so hidden_states can end
+# up with a different dtype than the down-casted linear weights. The first
+# affected linear call then raises:
+#
+#   RuntimeError: expected mat1 and mat2 to have the same dtype,
+#   but got: c10::BFloat16 != c10::Half
+#
+# These boundary patches are a targeted analog of gemma4_float32.py's
+# _unsloth_gemma4_ple_cast_input helper: they align each projection's input
+# (and Rotary position embeddings, for attention) with the actual weight dtype
+# of the submodule, then cast the output back to the caller's dtype. This keeps
+# the residual highway's dtype unchanged while guaranteeing that the fp16 matmuls
+# never see a mismatched activation.
+#
+# All patches gate on UNSLOTH_FORCE_FLOAT32 == "1", so bf16 / fp32 training and
+# fp16 training on architectures that do not need the FORCE_FLOAT32 fallback
+# are untouched.
+# ============================================================================
+
+import os
+import torch
+from .common import TEMPORARY_PATCHES
+from .utils import patch_function, raise_error
+
+
+def _unsloth_get_linear_weight_dtype(module):
+    """Return a representative fp Linear weight dtype, or None if absent."""
+    for attr in ("q_proj", "in_proj_qkv", "gate_proj", "up_proj", "fc1", "lm_head"):
+        linear = getattr(module, attr, None)
+        if linear is None:
+            continue
+        weight = getattr(linear, "weight", None)
+        if weight is None:
+            continue
+        quant_state = getattr(weight, "quant_state", None)
+        if quant_state is not None:
+            continue
+        dtype = getattr(weight, "dtype", None)
+        if dtype is None or not getattr(dtype, "is_floating_point", False):
+            continue
+        # Skip sub-2-byte floats (fp8) where casting would destroy values.
+        if getattr(dtype, "itemsize", 2) < 2:
+            continue
+        return dtype
+    return None
+
+
+def _unsloth_cast_position_embeddings(position_embeddings, dtype):
+    """Cast a (cos, sin) tuple to dtype when necessary."""
+    if position_embeddings is None:
+        return None
+    cos, sin = position_embeddings
+    if cos.dtype != dtype:
+        cos = cos.to(dtype)
+    if sin.dtype != dtype:
+        sin = sin.to(dtype)
+    return (cos, sin)
+
+
+def patch_Qwen3_5GatedDeltaNet_dtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return
+    try:
+        import transformers.models.qwen3_5.modeling_qwen3_5
+        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5GatedDeltaNet
+        cls.forward  # ensure attribute exists
+    except Exception as e:
+        return raise_error("Qwen3_5GatedDeltaNet.forward", e)
+
+    original_forward = cls.forward
+
+    def forward(self, hidden_states, cache_params=None, attention_mask=None, **kwargs):
+        input_dtype = hidden_states.dtype
+        target_dtype = _unsloth_get_linear_weight_dtype(self)
+        if target_dtype is not None and hidden_states.dtype != target_dtype:
+            hidden_states = hidden_states.to(target_dtype)
+
+        output = original_forward(
+            self, hidden_states,
+            cache_params=cache_params,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+
+        if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
+            output = output.to(input_dtype)
+        return output
+    pass
+    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
+pass
+TEMPORARY_PATCHES.append(patch_Qwen3_5GatedDeltaNet_dtype)
+
+
+def patch_Qwen3_5Attention_dtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return
+    try:
+        import transformers.models.qwen3_5.modeling_qwen3_5
+        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5Attention
+        cls.forward  # ensure attribute exists
+    except Exception as e:
+        return raise_error("Qwen3_5Attention.forward", e)
+
+    original_forward = cls.forward
+
+    def forward(
+        self,
+        hidden_states,
+        position_embeddings=None,
+        attention_mask=None,
+        past_key_values=None,
+        **kwargs,
+    ):
+        input_dtype = hidden_states.dtype
+        target_dtype = _unsloth_get_linear_weight_dtype(self)
+        if target_dtype is not None and hidden_states.dtype != target_dtype:
+            hidden_states = hidden_states.to(target_dtype)
+        position_embeddings = _unsloth_cast_position_embeddings(position_embeddings, target_dtype or input_dtype)
+
+        output = original_forward(
+            self,
+            hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            **kwargs,
+        )
+
+        if isinstance(output, tuple):
+            first = output[0]
+            if first.dtype != input_dtype:
+                first = first.to(input_dtype)
+            return (first,) + output[1:]
+        elif isinstance(output, torch.Tensor) and output.dtype != input_dtype:
+            output = output.to(input_dtype)
+        return output
+    pass
+    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
+pass
+TEMPORARY_PATCHES.append(patch_Qwen3_5Attention_dtype)
+
+
+def patch_Qwen3_5MLP_dtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return
+    try:
+        import transformers.models.qwen3_5.modeling_qwen3_5
+        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5MLP
+        cls.forward  # ensure attribute exists
+    except Exception as e:
+        return raise_error("Qwen3_5MLP.forward", e)
+
+    original_forward = cls.forward
+
+    def forward(self, x):
+        input_dtype = x.dtype
+        target_dtype = _unsloth_get_linear_weight_dtype(self)
+        if target_dtype is not None and x.dtype != target_dtype:
+            x = x.to(target_dtype)
+
+        output = original_forward(self, x)
+
+        if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
+            output = output.to(input_dtype)
+        return output
+    pass
+    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
+pass
+TEMPORARY_PATCHES.append(patch_Qwen3_5MLP_dtype)
+
+
+def patch_Qwen3_5ForCausalLM_dtype():
+    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
+        return
+    try:
+        import transformers.models.qwen3_5.modeling_qwen3_5
+        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5ForCausalLM
+        CausalLMOutputWithPast = transformers.models.qwen3_5.modeling_qwen3_5.CausalLMOutputWithPast
+    except Exception as e:
+        return raise_error("Qwen3_5ForCausalLM.forward", e)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        labels=None,
+        use_cache=None,
+        logits_to_keep=0,
+        **kwargs,
+    ):
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        lm_input = hidden_states[:, slice_indices, :]
+
+        target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", lm_input.dtype)
+        if getattr(target_dtype, "is_floating_point", False) and lm_input.dtype != target_dtype:
+            lm_input = lm_input.to(target_dtype)
+
+        logits = self.lm_head(lm_input)
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+    pass
+    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
+pass
+TEMPORARY_PATCHES.append(patch_Qwen3_5ForCausalLM_dtype)

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 # ============================================================================
-# Qwen3.5 targeted dtype-consistency patches for fp16 (UNSLOTH_FORCE_FLOAT32)
+# Qwen3.5 targeted dtype-normalization patches for fp16 (UNSLOTH_FORCE_FLOAT32)
 # training.
 #
 # Qwen3.5 is in unsloth_zoo.model_lists.FORCE_FLOAT32 because its GatedDeltaNet
@@ -30,11 +30,13 @@
 #   but got: c10::BFloat16 != c10::Half
 #
 # These boundary patches are a targeted analog of gemma4_float32.py's
-# _unsloth_gemma4_ple_cast_input helper: they align each projection's input
-# (and Rotary position embeddings, for attention) with the actual weight dtype
-# of the submodule, then cast the output back to the caller's dtype. This keeps
-# the residual highway's dtype unchanged while guaranteeing that the fp16 matmuls
-# never see a mismatched activation.
+# _unsloth_gemma4_ple_cast_input helper and of the per-component shape used in
+# qwen3_moe_float32.py: they align each projection's input (and Rotary position
+# embeddings, for attention) with the actual weight dtype of the submodule,
+# then cast the output back to the caller's dtype. This keeps the residual
+# highway's dtype unchanged while guaranteeing that the fp16 matmuls never see
+# a mismatched activation. The causal-LM / conditional-generation loss paths
+# are intentionally left untouched.
 #
 # All patches gate on UNSLOTH_FORCE_FLOAT32 == "1", so bf16 / fp32 training and
 # fp16 training on architectures that do not need the FORCE_FLOAT32 fallback
@@ -54,16 +56,6 @@ def _unsloth_base_linear(linear):
     if hasattr(linear, "get_base_layer"):
         return linear.get_base_layer()
     return getattr(linear, "base_layer", linear)
-
-
-def _unsloth_get_linear_weight_dtype(module):
-    """Return a representative fp Linear weight dtype, or None if absent."""
-    for attr in ("q_proj", "qkv", "in_proj_qkv", "gate_proj", "linear_fc1", "up_proj", "fc1", "lm_head"):
-        linear = getattr(module, attr, None)
-        dtype = _unsloth_weight_dtype(linear)
-        if dtype is not None:
-            return dtype
-    return None
 
 
 def _unsloth_weight_dtype(linear):
@@ -91,35 +83,14 @@ def _unsloth_weight_dtype(linear):
     return dtype
 
 
-def _unsloth_is_default_causal_lm_loss(loss_function):
-    """True when the configured loss is the standard HF/Unsloth causal-LM objective.
-
-    Unsloth renames the default loss to ``UnslothForCausalLMLoss``; keep the
-    same suffix rule used by the compiler rewrite so the default fused path is
-    still taken while custom losses fall back to logits + loss_function.
-    """
-    name = getattr(loss_function, "__name__", "")
-    return name.endswith("ForCausalLMLoss")
-
-
-# Kwargs allowed through to the fused CE kernel. Model-only keys such as
-# output_attentions / output_hidden_states / return_dict must not be forwarded
-# because unsloth_fused_ce_loss passes them into an autograd Function.
-_FUSED_LOSS_KWARG_KEYS = frozenset({
-    "num_items_in_batch",
-    "n_items",
-    "shift_labels",
-    "ignore_index",
-    "label_smoothing",
-    "logit_scale_multiply",
-    "logit_scale_divide",
-    "logit_softcapping",
-})
-
-
-def _unsloth_fused_loss_kwargs(kwargs):
-    """Return only the kwargs the fused loss kernel understands."""
-    return {k: v for k, v in kwargs.items() if k in _FUSED_LOSS_KWARG_KEYS}
+def _unsloth_get_linear_weight_dtype(module):
+    """Return a representative fp Linear weight dtype, or None if absent."""
+    for attr in ("q_proj", "qkv", "in_proj_qkv", "gate_proj", "linear_fc1", "up_proj", "fc1", "lm_head"):
+        linear = getattr(module, attr, None)
+        dtype = _unsloth_weight_dtype(linear)
+        if dtype is not None:
+            return dtype
+    return None
 
 
 def _unsloth_cast_position_embeddings(position_embeddings, dtype):
@@ -238,315 +209,3 @@ def patch_Qwen3_5MLP_dtype():
         return output
     patch_function(cls, "forward", forward, force=True, match_level="relaxed")
 TEMPORARY_PATCHES.append(patch_Qwen3_5MLP_dtype)
-
-
-def patch_Qwen3_5VisionAttention_dtype():
-    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
-        return
-    try:
-        import transformers.models.qwen3_5.modeling_qwen3_5
-        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5VisionAttention
-        cls.forward  # ensure attribute exists
-    except Exception as e:
-        return raise_error("Qwen3_5VisionAttention.forward", e)
-
-    original_forward = cls.forward
-
-    def forward(self, hidden_states, cu_seqlens, position_embeddings=None, max_seqlen=None, **kwargs):
-        input_dtype = hidden_states.dtype
-        target_dtype = _unsloth_get_linear_weight_dtype(self)
-        if target_dtype is not None and hidden_states.dtype != target_dtype:
-            hidden_states = hidden_states.to(target_dtype)
-        position_embeddings = _unsloth_cast_position_embeddings(position_embeddings, target_dtype or input_dtype)
-
-        output = original_forward(
-            self,
-            hidden_states,
-            cu_seqlens,
-            position_embeddings=position_embeddings,
-            max_seqlen=max_seqlen,
-            **kwargs,
-        )
-
-        if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
-            output = output.to(input_dtype)
-        return output
-    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-TEMPORARY_PATCHES.append(patch_Qwen3_5VisionAttention_dtype)
-
-
-def patch_Qwen3_5VisionMLP_dtype():
-    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
-        return
-    try:
-        import transformers.models.qwen3_5.modeling_qwen3_5
-        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5VisionMLP
-        cls.forward  # ensure attribute exists
-    except Exception as e:
-        return raise_error("Qwen3_5VisionMLP.forward", e)
-
-    original_forward = cls.forward
-
-    def forward(self, hidden_state):
-        input_dtype = hidden_state.dtype
-        target_dtype = _unsloth_get_linear_weight_dtype(self)
-        if target_dtype is not None and hidden_state.dtype != target_dtype:
-            hidden_state = hidden_state.to(target_dtype)
-
-        output = original_forward(self, hidden_state)
-
-        if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
-            output = output.to(input_dtype)
-        return output
-    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-TEMPORARY_PATCHES.append(patch_Qwen3_5VisionMLP_dtype)
-
-
-def patch_Qwen3_5VisionPatchMerger_dtype():
-    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
-        return
-    try:
-        import transformers.models.qwen3_5.modeling_qwen3_5
-        cls = transformers.models.qwen3_5.modeling_qwen3_5.Qwen3_5VisionPatchMerger
-        cls.forward  # ensure attribute exists
-    except Exception as e:
-        return raise_error("Qwen3_5VisionPatchMerger.forward", e)
-
-    original_forward = cls.forward
-
-    def forward(self, x):
-        input_dtype = x.dtype
-        target_dtype = _unsloth_get_linear_weight_dtype(self)
-        if target_dtype is not None and x.dtype != target_dtype:
-            x = x.to(target_dtype)
-
-        output = original_forward(self, x)
-
-        if isinstance(output, torch.Tensor) and output.dtype != input_dtype:
-            output = output.to(input_dtype)
-        return output
-    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-TEMPORARY_PATCHES.append(patch_Qwen3_5VisionPatchMerger_dtype)
-
-
-def patch_Qwen3_5ForCausalLM_dtype():
-    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
-        return
-    try:
-        import transformers.models.qwen3_5.modeling_qwen3_5 as qwen
-        from transformers.utils.generic import can_return_tuple
-        import unsloth_zoo.fused_losses.forward_adapter as fa
-        cls = qwen.Qwen3_5ForCausalLM
-        CausalLMOutputWithPast = qwen.CausalLMOutputWithPast
-        fused_loss = getattr(fa, "unsloth_fused_lm_head_loss", None)
-        EMPTY_LOGITS = getattr(fa, "EMPTY_LOGITS", None)
-    except Exception as e:
-        return raise_error("Qwen3_5ForCausalLM.forward", e)
-
-    def forward(
-        self,
-        input_ids=None,
-        attention_mask=None,
-        position_ids=None,
-        past_key_values=None,
-        inputs_embeds=None,
-        labels=None,
-        use_cache=None,
-        logits_to_keep=0,
-        **kwargs,
-    ):
-        RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
-        RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
-
-        # can_return_tuple normally pops return_dict, but be defensive so a
-        # caller-supplied return_dict never reaches the loss function either.
-        kwargs.pop("return_dict", None)
-
-        # Always work with ModelOutput internally; @can_return_tuple preserves
-        # the public tuple/return_dict contract. Use a separate dict so the
-        # synthetic return_dict never reaches the loss function.
-        model_kwargs = dict(kwargs)
-        model_kwargs["return_dict"] = True
-        outputs = self.model(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            inputs_embeds=inputs_embeds,
-            use_cache=use_cache,
-            **model_kwargs,
-        )
-
-        hidden_states = outputs.last_hidden_state
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-        lm_input = hidden_states[:, slice_indices, :]
-
-        if RETURN_HIDDEN_STATES:
-            # GRPO path: downstream rl_replacements applies lm_head selectively.
-            return CausalLMOutputWithPast(
-                loss=None,
-                logits=lm_input,
-                past_key_values=outputs.past_key_values,
-                hidden_states=outputs.hidden_states,
-                attentions=outputs.attentions,
-            )
-
-        target_dtype = _unsloth_weight_dtype(self.lm_head)
-
-        # Some model classes (notably Qwen3_5ForConditionalGeneration) set
-        # accepts_loss_kwargs=False to avoid scaling the loss by
-        # num_items_in_batch during gradient accumulation. Mirror that contract
-        # instead of blindly forwarding all kwargs to the loss.
-        loss_kwargs = kwargs if getattr(self, "accepts_loss_kwargs", True) else {}
-
-        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS \
-                and _unsloth_is_default_causal_lm_loss(self.loss_function):
-            # Training path: keep the fused lm-head / cross-entropy path and
-            # only inject the dtype alignment at the hidden-state boundary.
-            if target_dtype is not None and lm_input.dtype != target_dtype:
-                lm_input = lm_input.to(target_dtype)
-            loss = fused_loss(
-                lm_input, self.lm_head, labels,
-                vocab_size=self.config.vocab_size,
-                **_unsloth_fused_loss_kwargs(loss_kwargs),
-            )
-            logits = EMPTY_LOGITS
-        else:
-            # Inference path (or explicit logits opt-in / custom loss):
-            # materialise logits, but align them first.
-            if target_dtype is not None and lm_input.dtype != target_dtype:
-                lm_input = lm_input.to(target_dtype)
-            logits = self.lm_head(lm_input)
-
-            loss = None
-            if labels is not None:
-                loss = self.loss_function(
-                    logits=logits, labels=labels,
-                    vocab_size=self.config.vocab_size,
-                    **loss_kwargs,
-                )
-
-        return CausalLMOutputWithPast(
-            loss=loss,
-            logits=logits,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
-        )
-
-    forward = can_return_tuple(forward)
-    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-TEMPORARY_PATCHES.append(patch_Qwen3_5ForCausalLM_dtype)
-
-
-def patch_Qwen3_5ForConditionalGeneration_dtype():
-    if os.environ.get("UNSLOTH_FORCE_FLOAT32", "0") != "1":
-        return
-    try:
-        import transformers.models.qwen3_5.modeling_qwen3_5 as qwen
-        from transformers.utils.generic import can_return_tuple
-        import unsloth_zoo.fused_losses.forward_adapter as fa
-        cls = qwen.Qwen3_5ForConditionalGeneration
-        CausalLMOutputWithPast = qwen.Qwen3_5CausalLMOutputWithPast
-        fused_loss = getattr(fa, "unsloth_fused_lm_head_loss", None)
-        EMPTY_LOGITS = getattr(fa, "EMPTY_LOGITS", None)
-    except Exception as e:
-        return raise_error("Qwen3_5ForConditionalGeneration.forward", e)
-
-    def forward(
-        self,
-        input_ids=None,
-        attention_mask=None,
-        position_ids=None,
-        past_key_values=None,
-        inputs_embeds=None,
-        labels=None,
-        pixel_values=None,
-        pixel_values_videos=None,
-        image_grid_thw=None,
-        video_grid_thw=None,
-        mm_token_type_ids=None,
-        logits_to_keep=0,
-        **kwargs,
-    ):
-        RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
-        RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
-
-        # can_return_tuple normally pops return_dict, but be defensive so a
-        # caller-supplied return_dict never reaches the loss function either.
-        kwargs.pop("return_dict", None)
-
-        # Keep the synthetic return_dict away from the loss function.
-        model_kwargs = dict(kwargs)
-        model_kwargs["return_dict"] = True
-        outputs = self.model(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            inputs_embeds=inputs_embeds,
-            pixel_values=pixel_values,
-            pixel_values_videos=pixel_values_videos,
-            image_grid_thw=image_grid_thw,
-            video_grid_thw=video_grid_thw,
-            mm_token_type_ids=mm_token_type_ids,
-            **model_kwargs,
-        )
-
-        hidden_states = outputs.last_hidden_state
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-        lm_input = hidden_states[:, slice_indices, :]
-
-        if RETURN_HIDDEN_STATES:
-            return CausalLMOutputWithPast(
-                loss=None,
-                logits=lm_input,
-                past_key_values=outputs.past_key_values,
-                hidden_states=outputs.hidden_states,
-                attentions=outputs.attentions,
-                rope_deltas=outputs.rope_deltas,
-            )
-
-        target_dtype = _unsloth_weight_dtype(self.lm_head)
-
-        # Honor accepts_loss_kwargs (upstream Qwen3_5ForConditionalGeneration
-        # sets this to False so num_items_in_batch is not applied to the loss).
-        loss_kwargs = kwargs if getattr(self, "accepts_loss_kwargs", True) else {}
-
-        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS \
-                and _unsloth_is_default_causal_lm_loss(self.loss_function):
-            if target_dtype is not None and lm_input.dtype != target_dtype:
-                lm_input = lm_input.to(target_dtype)
-            loss = fused_loss(
-                lm_input, self.lm_head, labels,
-                vocab_size=self.config.text_config.vocab_size,
-                **_unsloth_fused_loss_kwargs(loss_kwargs),
-            )
-            logits = EMPTY_LOGITS
-        else:
-            if target_dtype is not None and lm_input.dtype != target_dtype:
-                lm_input = lm_input.to(target_dtype)
-            logits = self.lm_head(lm_input)
-
-            loss = None
-            if labels is not None:
-                loss = self.loss_function(
-                    logits=logits,
-                    labels=labels,
-                    vocab_size=self.config.text_config.vocab_size,
-                    **loss_kwargs,
-                )
-
-        return CausalLMOutputWithPast(
-            loss=loss,
-            logits=logits,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
-            rope_deltas=outputs.rope_deltas,
-        )
-
-    forward = can_return_tuple(forward)
-    patch_function(cls, "forward", forward, force=True, match_level="relaxed")
-TEMPORARY_PATCHES.append(patch_Qwen3_5ForConditionalGeneration_dtype)
-

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -302,9 +302,12 @@ def patch_Qwen3_5ForCausalLM_dtype():
         logits_to_keep=0,
         **kwargs,
     ):
-        output_attentions = kwargs.pop("output_attentions", None)
-        output_hidden_states = kwargs.pop("output_hidden_states", None)
+        RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
+        RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
 
+        # Always work with ModelOutput internally; @can_return_tuple preserves
+        # the public tuple/return_dict contract.
+        kwargs["return_dict"] = True
         outputs = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -312,9 +315,6 @@ def patch_Qwen3_5ForCausalLM_dtype():
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
             use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=True,
             **kwargs,
         )
 
@@ -322,9 +322,19 @@ def patch_Qwen3_5ForCausalLM_dtype():
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
         lm_input = hidden_states[:, slice_indices, :]
 
+        if RETURN_HIDDEN_STATES:
+            # GRPO path: downstream rl_replacements applies lm_head selectively.
+            return CausalLMOutputWithPast(
+                loss=None,
+                logits=lm_input,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
+            )
+
         target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", None)
 
-        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None:
+        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS:
             # Training path: keep the fused lm-head / cross-entropy path and
             # only inject the dtype alignment at the hidden-state boundary.
             if target_dtype is not None and lm_input.dtype != target_dtype:
@@ -332,7 +342,8 @@ def patch_Qwen3_5ForCausalLM_dtype():
             loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.vocab_size, **kwargs)
             logits = EMPTY_LOGITS
         else:
-            # Inference path: materialise logits, but align them first.
+            # Inference path (or explicit logits opt-in): materialise logits,
+            # but align them first.
             if target_dtype is not None and lm_input.dtype != target_dtype:
                 lm_input = lm_input.to(target_dtype)
             logits = self.lm_head(lm_input)
@@ -384,9 +395,10 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
         logits_to_keep=0,
         **kwargs,
     ):
-        output_attentions = kwargs.pop("output_attentions", None)
-        output_hidden_states = kwargs.pop("output_hidden_states", None)
+        RETURN_HIDDEN_STATES = os.environ.get("UNSLOTH_RETURN_HIDDEN_STATES", "0") == "1"
+        RETURN_LOGITS = os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
 
+        kwargs["return_dict"] = True
         outputs = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,
@@ -398,9 +410,6 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
             image_grid_thw=image_grid_thw,
             video_grid_thw=video_grid_thw,
             mm_token_type_ids=mm_token_type_ids,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=True,
             **kwargs,
         )
 
@@ -408,9 +417,19 @@ def patch_Qwen3_5ForConditionalGeneration_dtype():
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
         lm_input = hidden_states[:, slice_indices, :]
 
+        if RETURN_HIDDEN_STATES:
+            return CausalLMOutputWithPast(
+                loss=None,
+                logits=lm_input,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
+                rope_deltas=outputs.rope_deltas,
+            )
+
         target_dtype = getattr(getattr(self.lm_head, "weight", None), "dtype", None)
 
-        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None:
+        if labels is not None and fused_loss is not None and EMPTY_LOGITS is not None and not RETURN_LOGITS:
             if target_dtype is not None and lm_input.dtype != target_dtype:
                 lm_input = lm_input.to(target_dtype)
             loss = fused_loss(lm_input, self.lm_head, labels, vocab_size=self.config.text_config.vocab_size, **kwargs)

--- a/unsloth_zoo/temporary_patches/qwen3_5_float32.py
+++ b/unsloth_zoo/temporary_patches/qwen3_5_float32.py
@@ -47,10 +47,22 @@ from .common import TEMPORARY_PATCHES
 from .utils import patch_function, raise_error
 
 
+def _unsloth_base_linear(linear):
+    """Return the underlying Linear if `linear` is a PEFT/LoRA adapter wrapper."""
+    if linear is None:
+        return None
+    if hasattr(linear, "get_base_layer"):
+        return linear.get_base_layer()
+    return getattr(linear, "base_layer", linear)
+
+
 def _unsloth_get_linear_weight_dtype(module):
     """Return a representative fp Linear weight dtype, or None if absent."""
     for attr in ("q_proj", "qkv", "in_proj_qkv", "gate_proj", "linear_fc1", "up_proj", "fc1", "lm_head"):
         linear = getattr(module, attr, None)
+        if linear is None:
+            continue
+        linear = _unsloth_base_linear(linear)
         if linear is None:
             continue
         weight = getattr(linear, "weight", None)
@@ -75,6 +87,9 @@ def _unsloth_weight_dtype(linear):
     Mirrors the guard in ``_unsloth_get_linear_weight_dtype`` so we do not
     cast activations to a packed quantized storage dtype or to fp8.
     """
+    if linear is None:
+        return None
+    linear = _unsloth_base_linear(linear)
     if linear is None:
         return None
     weight = getattr(linear, "weight", None)


### PR DESCRIPTION
Adds targeted dtype-normalization patches for Qwen3.5 when UNSLOTH_FORCE_FLOAT32=1.

Problem
- unsloth#7506 reports fp16 fine-tuning of Qwen3.5 failing with RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::BFloat16 != c10::Half.
- On non-bf16 GPUs, unsloth loads Qwen3.5 in bf16 and then down-casts weights to fp16, but the trainer/autocast path may still present bf16 activations to those fp16 weights.

Fix
- Boundary-style wrappers for Qwen3_5GatedDeltaNet, Qwen3_5Attention, Qwen3_5MLP, and Qwen3_5ForCausalLM.
- Each wrapper casts inputs (and RoPE position embeddings for attention) to the actual submodule weight dtype before calling the original forward, then restores the caller dtype for the residual stream.
- Patches are gated on UNSLOTH_FORCE_FLOAT32 == "1", so bf16 / fp32 training and systems that do not need the fallback are untouched.

Validation
- Added tests/test_qwen3_5_float32.py with tiny Qwen3.5 models; it reproduces the mismatch on CPU (fp16 weights + bf16 activations) and verifies the patched forwards succeed.
- tests/test_temporary_patches_imports.py updated so the new submodule is covered by the import smoke suite.
- pytest tests/test_temporary_patches_imports.py tests/test_temporary_patches_exhaustive.py tests/test_qwen3_5_float32.py passes locally (143 passed, 12 skipped).