### PR TITLE
Print the MLX 8-bit optimizer routing line once, on one line

### DIFF
--- a/tests/test_mlx_quantized_optimizer_routing.py
+++ b/tests/test_mlx_quantized_optimizer_routing.py
@@ -72,15 +72,38 @@ def test_8bit_names_are_advertised_as_supported():
     assert "adam_8bit" in SUPPORTED_MLX_OPTIMIZERS
 
 
-def test_description_states_what_is_and_is_not_quantized():
-    """The message must name the actual shape of the saving."""
+def test_description_names_the_one_thing_the_name_does_not():
+    """bitsandbytes' adamw_8bit quantizes both moments; this quantizes one. That
+    is the whole reason to print anything, so it must fit on one line."""
     from unsloth_zoo.mlx.optimizers_quantized import describe_quantized_optimizer
     message = describe_quantized_optimizer("adamw_8bit")
 
     assert "adamw_8bit" in message
-    assert "FIRST moment" in message
+    assert "first moment" in message
     assert "group_size=64" in message
-    assert "second moment is not quantized" in message
-    assert "multiple of 64" in message
-    # The saving depends on the state dtype, so the banner must not imply one number.
-    assert "bfloat16" in message and "peak memory" in message
+    assert "second moment is unquantized" in message
+    assert "\n" not in message
+    assert len(message) <= 120, f"routing line grew to {len(message)} chars: {message}"
+
+
+def test_the_routing_line_is_printed_once_per_process(capsys):
+    """_build_optimizer runs per training run and per rank."""
+    from unsloth_zoo.mlx import optimizers_quantized as oq
+
+    oq._ANNOUNCED.discard("adamw_8bit")
+    assert oq.announce_quantized_optimizer("adamw_8bit") is True
+    first = capsys.readouterr().out
+    assert first.count("Unsloth:") == 1
+
+    for _ in range(3):
+        assert oq.announce_quantized_optimizer("adamw_8bit") is False
+    assert capsys.readouterr().out == ""
+
+
+def test_non_main_processes_stay_quiet(capsys):
+    from unsloth_zoo.mlx import optimizers_quantized as oq
+
+    oq._ANNOUNCED.discard("adam_8bit")
+    assert oq.announce_quantized_optimizer("adam_8bit", enabled=False) is False
+    assert capsys.readouterr().out == ""
+    assert "adam_8bit" not in oq._ANNOUNCED, "a silenced rank must not consume the slot"

--- a/unsloth_zoo/mlx/optimizers_quantized.py
+++ b/unsloth_zoo/mlx/optimizers_quantized.py
@@ -79,12 +79,15 @@ __all__ = [
     "SUPPORTED_GROUP_SIZES",
     "unpack_quantized_moments",
     "state_has_quantized_moments",
+    "announce_quantized_optimizer",
 ]
 
 DEFAULT_GROUP_SIZE = 64
 DEFAULT_BITS = 8
 # mx.quantize's supported group sizes; all three are exercised by the test suite.
 SUPPORTED_GROUP_SIZES = (32, 64, 128)
+# Names already announced in this process; see announce_quantized_optimizer.
+_ANNOUNCED = set()
 
 
 def _as_int(value, name):
@@ -197,17 +200,30 @@ class QuantizedMomentAdamW(_QuantizedFirstMomentMixin, optim.AdamW):
 
 
 def describe_quantized_optimizer(optimizer_name, group_size = DEFAULT_GROUP_SIZE):
-    """What an 8-bit request actually gets. The old behaviour rewrote
-    ``adamw_8bit`` to ``adamw`` silently; a quieter surprise would be no better."""
+    """One line. The only thing a user cannot infer from the name is that this
+    quantizes ONE moment, where bitsandbytes' ``adamw_8bit`` quantizes both.
+    Eligibility, dtype and memory behaviour live in this module's docstring; they
+    are reference material and do not belong in stdout on every run."""
     return (
-        f"Unsloth: {optimizer_name} on MLX quantizes the optimizer's FIRST moment "
-        f"to 8-bit (group_size={group_size}); the second moment is not quantized "
-        "(affine 8-bit quantization of the second moment diverges). Only 2-D "
-        f"parameters whose last dimension is a multiple of {group_size} are "
-        "quantized; all others keep unquantized moments. Moments follow the "
-        "parameter dtype, so this saves about 36% of optimizer state in float32 "
-        "and about 23% in bfloat16, and it does not lower peak memory."
+        f"Unsloth: {optimizer_name} on MLX quantizes Adam's first moment to 8-bit "
+        f"(group_size={group_size}); the second moment is unquantized."
     )
+
+
+def announce_quantized_optimizer(
+    optimizer_name, group_size = DEFAULT_GROUP_SIZE, enabled = True,
+):
+    """Print the routing line at most once per process. Returns whether it printed.
+
+    ``_build_optimizer`` runs per training run and per rank, so an unguarded print
+    put five wrapped lines on screen for every rank and every re-run of a notebook
+    cell, for what is the default optimizer in every Unsloth example.
+    """
+    if not enabled or optimizer_name in _ANNOUNCED:
+        return False
+    _ANNOUNCED.add(optimizer_name)
+    print(describe_quantized_optimizer(optimizer_name, group_size))
+    return True
 
 
 def unpack_quantized_moments(state, group_size = DEFAULT_GROUP_SIZE, bits = DEFAULT_BITS):

--- a/unsloth_zoo/mlx/trainer.py
+++ b/unsloth_zoo/mlx/trainer.py
@@ -3452,13 +3452,14 @@ class MLXTrainer:
                 **adam_kwargs,
             )
         elif opt_name in ("adamw_8bit", "adam_8bit"):
-            # Print rather than route silently: the old path was a quiet rewrite.
+            # One line, once per process, main process only: _build_optimizer runs
+            # per run and per rank, and this is the default optim in every example.
             from .optimizers_quantized import (
                 QuantizedMomentAdam,
                 QuantizedMomentAdamW,
-                describe_quantized_optimizer,
+                announce_quantized_optimizer,
             )
-            print(describe_quantized_optimizer(opt_name))
+            announce_quantized_optimizer(opt_name, enabled=self.is_main_process)
             if opt_name == "adamw_8bit":
                 self._manual_weight_decay = float(wd or 0.0)
                 optimizer = QuantizedMomentAdamW(


### PR DESCRIPTION
Follow-up to #962. Trims the routing line that PR prints when `optim="adamw_8bit"` or `"adam_8bit"` resolves on MLX.

## Why

`_build_optimizer` runs once per training run and once per rank, and `adamw_8bit` is the default in every Unsloth README and notebook example. So the banner was not an unusual-configuration notice, it was a paragraph everyone saw on every run. Captured from `MLXTrainer._build_optimizer` on `dca7439d`:

<img width="980" alt="the routing banner before this change: five wrapped lines per occurrence, twenty across four calls" src="https://raw.githubusercontent.com/danielhanchen/unsloth-zoo-staging/pr962-assets/pr962/pr962_banner.png" />

Five wrapped lines at a 100 column terminal per occurrence. The second panel is four `_build_optimizer` calls, which is a four rank job or a re-run notebook cell: twenty lines before training starts.

Most of that length was mine. I appended the dtype and peak-memory caveats during the #962 review so the 35.8% figure would not travel alone, which was the right correction in the wrong place. Those belong in the module docstring, and they are already there.

## What is left

The banner existed because the old path rewrote `adamw_8bit` to `adamw` silently. That is now handled by the routing being correct. The one thing a user still cannot infer from the name is that this quantizes a single moment, where bitsandbytes' `adamw_8bit` quantizes both. That is worth one line:

```
Unsloth: adamw_8bit on MLX quantizes Adam's first moment to 8-bit (group_size=64); the second moment is unquantized.
```

116 characters, one line, printed at most once per process and only on the main process. `announce_quantized_optimizer` owns that; `describe_quantized_optimizer` still returns the string so it stays unit testable.

This matches the narrower convention `_build_optimizer` already follows a few lines up, where the Adafactor fallback prints only when behaviour deviates from what was asked for.

## Verified

Four `_build_optimizer` calls through the real trainer now emit one line instead of twenty:

```
optimizer: QuantizedMomentAdamW
lines printed across 4 _build_optimizer calls: 1
Unsloth: adamw_8bit on MLX quantizes Adam's first moment to 8-bit (group_size=64); the second moment is unquantized.
```

Tests: `test_mlx_quantized_optimizer_routing.py` 15 passed (the banner assertions now pin the one-line contract, plus print-once and rank-silence cases), `test_mlx_quantized_optimizer_state.py` 29 passed on `mlx-cpu`, and `test_mlx_trainer_internals.py` + `test_mlx_module_exports.py` + `test_mlx_double_quant_reject.py` + `test_mlx_finetune_last_n_layers.py` 260 passed.

No behaviour change to the optimizer itself.
