### PR TITLE
Quantize MLX adamw_8bit moments over a flattened view

### DIFF
--- a/tests/test_mlx_quantized_optimizer_routing.py
+++ b/tests/test_mlx_quantized_optimizer_routing.py
@@ -81,6 +81,8 @@ def test_description_states_what_is_and_is_not_quantized():
     assert "FIRST moment" in message
     assert "group_size=64" in message
     assert "second moment is not quantized" in message
-    assert "multiple of 64" in message
+    # Eligibility counts elements, not axes: the banner must not claim a 2-D rule.
+    assert "4096 elements" in message and "groups of 64" in message
+    assert "2-D" not in message
     # The saving depends on the state dtype, so the banner must not imply one number.
     assert "bfloat16" in message and "peak memory" in message

--- a/tests/test_mlx_quantized_optimizer_state.py
+++ b/tests/test_mlx_quantized_optimizer_state.py
@@ -41,6 +41,7 @@ from mlx.utils import tree_flatten, tree_unflatten
 from unsloth_zoo.mlx.optimizers_quantized import (
     DEFAULT_BITS,
     DEFAULT_GROUP_SIZE,
+    MIN_QUANTIZE_SIZE,
     SUPPORTED_GROUP_SIZES,
     QuantizedMomentAdam,
     QuantizedMomentAdamW,
@@ -71,9 +72,11 @@ def _build_model(width=256):
 
 
 def _build_ineligible_model():
-    """Nothing here is quantization-eligible: 100 is not a multiple of 64."""
+    """Nothing here is quantization-eligible. Eligibility counts elements, not
+    axes, so this needs weights that are both small (under MIN_QUANTIZE_SIZE) and
+    not a whole number of groups: 30*50 = 1500, and 1500 % 64 != 0."""
     mx.random.seed(0)
-    model = nn.Sequential(nn.Linear(96, 100), nn.ReLU(), nn.Linear(100, 100))
+    model = nn.Sequential(nn.Linear(50, 30), nn.ReLU(), nn.Linear(30, 50))
     mx.eval(model.parameters())
     return model
 
@@ -268,8 +271,8 @@ def test_model_with_no_quantizable_parameters_still_trains():
         assert not opt.is_quantizable(param), f"fixture is wrong: {param.shape} is eligible"
 
     mx.random.seed(1)
-    x = mx.random.normal((32, 96))
-    y = mx.random.normal((32, 100))
+    x = mx.random.normal((32, 50))
+    y = mx.random.normal((32, 50))
     losses = _train(opt, model, x, y)
 
     assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), (
@@ -463,3 +466,82 @@ def test_adamw_variant_also_quantizes():
     assert isinstance(_moment(opt, "m"), (tuple, list))
     assert _moment(opt, "v").dtype == mx.float32
     assert (DEFAULT_GROUP_SIZE, DEFAULT_BITS) == (opt.group_size, opt.bits)
+
+
+# 12 -----------------------------------------------------------------------
+# Eligibility counts elements, not axes. The earlier rule was 2-D with a
+# divisible last axis, which excluded the shapes below while packing their
+# partner matrices, so a LoRA run saved half of what it reported.
+@pytest.mark.parametrize(
+    "shape, eligible, why",
+    [
+        ((2048, 16), True, "LoRA_B at rank 16: last axis 16, but 32768 elements"),
+        ((2048, 32), True, "LoRA_B at rank 32"),
+        ((8, 512, 512), True, "3-D MoE expert stack"),
+        ((4096,), True, "1-D, a whole number of groups"),
+        ((100, 100), False, "10000 % 64 != 0"),
+        ((32, 32), False, "1024 elements, under MIN_QUANTIZE_SIZE"),
+    ],
+)
+def test_eligibility_counts_elements_not_axes(shape, eligible, why):
+    opt = QuantizedMomentAdam(1e-3)
+    assert opt.is_quantizable(mx.zeros(shape)) is eligible, why
+
+
+def test_flat_packing_round_trips_every_eligible_shape():
+    """Pack/unpack must return the parameter's own shape, not the flat view."""
+    opt = QuantizedMomentAdam(1e-3)
+    for shape in [(2048, 16), (8, 512, 512), (4096,), (256, 256)]:
+        mx.random.seed(0)
+        moment = mx.random.normal(shape)
+        restored = opt._unpack(opt._pack(moment), shape)
+        assert restored.shape == moment.shape, f"{shape} came back as {restored.shape}"
+        error = float(mx.linalg.norm(restored - moment) / mx.linalg.norm(moment))
+        assert error < 0.02, f"{shape} round-tripped at {error:.4f} relative error"
+
+
+def test_small_parameters_keep_full_width_moments():
+    """Norms and biases sit under the threshold and must not be packed."""
+    opt = QuantizedMomentAdam(1e-3)
+    assert not opt.is_quantizable(mx.zeros((MIN_QUANTIZE_SIZE - 64,)))
+    assert opt.is_quantizable(mx.zeros((MIN_QUANTIZE_SIZE,)))
+
+
+def test_lora_b_at_rank_16_trains_and_is_packed():
+    """The regression this change exists for: previously ineligible, so its
+    moment stayed full width while lora_a next to it was packed."""
+    mx.random.seed(0)
+    model = nn.Sequential(nn.Linear(512, 16, bias=False), nn.Linear(16, 512, bias=False))
+    mx.eval(model.parameters())
+    # (16,512) passed the old rule, (512,16) did not, though both are 8192 elements.
+    shapes = [model.layers[i].weight.shape for i in (0, 1)]
+    assert shapes == [(16, 512), (512, 16)], shapes
+
+    opt = QuantizedMomentAdam(1e-3, bias_correction=True)
+    mx.random.seed(1)
+    x = mx.random.normal((32, 512))
+    y = mx.random.normal((32, 512))
+    losses = _train(opt, model, x, y)
+
+    assert all(losses[i] > losses[i + 1] for i in range(len(losses) - 1)), losses
+    moments = [opt.state["layers"][i]["weight"]["m"] for i in (0, 1)]
+    packed = [m for m in moments if isinstance(m, (tuple, list))]
+    assert len(packed) == 2, (
+        f"both adapter matrices should pack, got {len(packed)} of {len(moments)}"
+    )
+
+
+def test_reads_a_checkpoint_written_in_the_old_per_row_layout():
+    """mx.dequantize is self-describing, so a moment packed per row (the previous
+    layout) still loads: only the packed triple's own shape changes."""
+    mx.random.seed(0)
+    parameter = mx.random.normal((256, 256))
+    moment = mx.random.normal((256, 256)) * 0.01
+
+    old = mx.quantize(moment, group_size=DEFAULT_GROUP_SIZE, bits=DEFAULT_BITS)
+    opt = QuantizedMomentAdam(1e-3)
+    restored = opt._unpack(old, parameter.shape)
+
+    assert restored.shape == parameter.shape
+    error = float(mx.linalg.norm(restored - moment) / mx.linalg.norm(moment))
+    assert error < 0.02, f"old-layout checkpoint dequantized at {error:.4f} error"

--- a/tests/test_mlx_quantized_optimizer_state.py
+++ b/tests/test_mlx_quantized_optimizer_state.py
@@ -320,11 +320,17 @@ def test_zero_gradient_coordinates_never_move():
     denominator is eps alone and any dequantization residue is amplified ~1e8x.
     Plain Adam moves it by exactly nothing and so must this."""
     steps, lr = 500, 1e-3
-    grad = mx.array([[1.0] + [0.0] * (DEFAULT_GROUP_SIZE - 1)])
+    # MIN_QUANTIZE_SIZE elements, so the moment really is packed: a smaller
+    # parameter is ineligible and the test would never reach the residue at all.
+    width = MIN_QUANTIZE_SIZE
+    grad = mx.array([[1.0] + [0.0] * (width - 1)])
 
     def drive(opt):
-        param = mx.zeros((1, DEFAULT_GROUP_SIZE))
+        param = mx.zeros((1, width))
         opt.init({"w": param})
+        assert isinstance(opt.state["w"]["m"], (tuple, list)), (
+            "fixture is not exercising the quantized path"
+        )
         for _ in range(steps):
             param = opt.apply_gradients({"w": grad}, {"w": param})["w"]
             mx.eval(param, opt.state)
@@ -386,11 +392,15 @@ def test_unpacking_does_not_carry_the_zero_residue_out():
     to a plain optimizer would divide it by eps while v == 0, reintroducing the
     blow-up on the far side of the switch."""
     steps, lr = 200, 1e-3
-    grad = mx.array([[1.0] + [0.0] * (DEFAULT_GROUP_SIZE - 1)])
+    width = MIN_QUANTIZE_SIZE
+    grad = mx.array([[1.0] + [0.0] * (width - 1)])
 
     packed = QuantizedMomentAdam(lr, bias_correction=True)
-    param = mx.zeros((1, DEFAULT_GROUP_SIZE))
+    param = mx.zeros((1, width))
     packed.init({"w": param})
+    assert isinstance(packed.state["w"]["m"], (tuple, list)), (
+        "fixture is not exercising the quantized path"
+    )
     for _ in range(steps):
         param = packed.apply_gradients({"w": grad}, {"w": param})["w"]
         mx.eval(param, packed.state)
@@ -401,13 +411,13 @@ def test_unpacking_does_not_carry_the_zero_residue_out():
     assert residue == 0.0, f"unpacked moment kept a {residue:.3e} residue where v == 0"
 
     plain = optim.Adam(learning_rate=lr, bias_correction=True)
-    resumed = mx.zeros((1, DEFAULT_GROUP_SIZE))
+    resumed = mx.zeros((1, width))
     plain.init({"w": resumed})
     plain.state = unpacked
     for _ in range(steps):
         resumed = plain.apply_gradients({"w": grad}, {"w": resumed})["w"]
         mx.eval(resumed, plain.state)
-    drift = max(abs(float(resumed[0, i])) for i in range(1, DEFAULT_GROUP_SIZE))
+    drift = float(mx.abs(resumed[0, 1:]).max())
     assert drift == 0.0, f"zero-gradient coordinates drifted {drift:.3e} after unpacking"
 
 

--- a/unsloth_zoo/mlx/optimizers_quantized.py
+++ b/unsloth_zoo/mlx/optimizers_quantized.py
@@ -21,8 +21,8 @@ Packing ``m`` to 8 bits cuts that by ``1 - (f*(1/b + 2/G) + (1-f) + 1)/2`` for a
 dtype of ``b`` bytes, group size ``G`` and an eligible byte fraction ``f``.
 Measured end to end on SmolLM2-135M, group_size=64:
 
-    full fine-tune, float32 state   35.9%     LoRA r=64        35.9%
-    full fine-tune, bfloat16 state  23.4%     LoRA r=16/r=32   35.9%
+    full fine-tune, float32 state   35.9%     LoRA r=32/r=64   35.9%
+    full fine-tune, bfloat16 state  23.4%     LoRA r=16        34.6%
 
 Only the first two are the "8-bit vs 32-bit" figure. MLX creates moments with
 ``mx.zeros_like(parameter)``, so a bfloat16 model has bfloat16 moments and the
@@ -35,6 +35,11 @@ silently excluded LoRA_B below rank 64 and held r=16/r=32 to 18.3%. Anything und
 ``MIN_QUANTIZE_SIZE`` elements keeps a full-width moment: those are the norms and
 biases, worth no bytes and the least tolerant of the error. bitsandbytes draws the
 same line at the same threshold (``min_8bit_size``).
+
+That floor is why r=16 lands at 34.6% rather than 35.9%: under grouped-query
+attention the k/v projections are narrow, so their LoRA_B is ``(kv_dim, r)`` and at
+r=16 that is 3072 elements on a 135M model. The figure is therefore model-shape
+dependent below r=32; a square fixture will report the full 35.9% and overstate it.
 
 This shrinks PERSISTENT state, not peak allocation: ``apply_single`` materialises
 a full-width ``m`` per parameter per step, and peak rose 11.7% on Metal and 29.9%

--- a/unsloth_zoo/mlx/optimizers_quantized.py
+++ b/unsloth_zoo/mlx/optimizers_quantized.py
@@ -22,13 +22,16 @@ dtype of ``b`` bytes, group size ``G`` and an eligible byte fraction ``f``.
 Measured end to end on SmolLM2-135M, group_size=64:
 
     full fine-tune, float32 state   35.9%     LoRA r=64        35.9%
-    full fine-tune, bfloat16 state  23.4%     LoRA r=16/r=32   18.3%
+    full fine-tune, bfloat16 state  23.4%     LoRA r=16/r=32   35.9%
 
 Only the first two are the "8-bit vs 32-bit" figure. MLX creates moments with
 ``mx.zeros_like(parameter)``, so a bfloat16 model has bfloat16 moments and the
-packed moment is being compared against 2 bytes, not 4. Under LoRA only one of
-each adapter pair is eligible unless the group size divides the rank, so r=32
-reaches 34.4% at ``group_size=32`` but only 18.3% at 64.
+packed moment is being compared against 2 bytes, not 4.
+
+Eligibility is measured in elements, not shape: moments are quantized over a
+flattened view, so a rank-16 LoRA_B and a 3-D MoE expert stack pack as readily as
+a square matrix. An earlier rule required 2-D with a divisible last axis, which
+silently excluded LoRA_B below rank 64 and held r=16/r=32 to 18.3%.
 
 This shrinks PERSISTENT state, not peak allocation: ``apply_single`` materialises
 a full-width ``m`` per parameter per step, and peak rose 11.7% on Metal and 29.9%
@@ -77,6 +80,7 @@ __all__ = [
     "DEFAULT_GROUP_SIZE",
     "DEFAULT_BITS",
     "SUPPORTED_GROUP_SIZES",
+    "MIN_QUANTIZE_SIZE",
     "unpack_quantized_moments",
     "state_has_quantized_moments",
 ]
@@ -85,6 +89,9 @@ DEFAULT_GROUP_SIZE = 64
 DEFAULT_BITS = 8
 # mx.quantize's supported group sizes; all three are exercised by the test suite.
 SUPPORTED_GROUP_SIZES = (32, 64, 128)
+# Below this, packing a moment saves bytes that do not matter on parameters that
+# do not tolerate the error well. Matches bitsandbytes' min_8bit_size default.
+MIN_QUANTIZE_SIZE = 4096
 
 
 def _as_int(value, name):
@@ -120,24 +127,44 @@ class _QuantizedFirstMomentMixin:
         self.bits = bits
 
     def is_quantizable(self, parameter):
-        """``mx.quantize`` needs 2-D with last dim divisible by group_size.
-        Everything else keeps a full-width moment and still trains, saving nothing."""
-        return parameter.ndim == 2 and parameter.shape[-1] % self.group_size == 0
+        """``mx.quantize`` constrains the LAST axis only, so a flattened view makes
+        eligibility a question of element count rather than shape. That admits 3-D
+        MoE expert stacks and LoRA_B at rank 16/32, which the previous 2-D rule
+        rejected while their partner matrices were packed.
+
+        Tensors under ``MIN_QUANTIZE_SIZE`` stay full width: they are a rounding
+        error in the state budget but include the norm and bias parameters, which
+        are the ones least worth adding quantization error to. bitsandbytes draws
+        the same line at the same threshold (``min_8bit_size``)."""
+        return (
+            parameter.size >= MIN_QUANTIZE_SIZE
+            and parameter.size % self.group_size == 0
+        )
+
+    def _pack(self, moment):
+        """Quantize over a flat view; the parameter's shape is restored on unpack."""
+        return mx.quantize(
+            moment.reshape(1, -1), group_size=self.group_size, bits=self.bits,
+        )
+
+    def _unpack(self, packed, shape):
+        """``mx.dequantize`` is self-describing, so this also reads checkpoints
+        written by the earlier per-row layout, whose triple carries its own shape."""
+        moment = mx.dequantize(
+            *packed, group_size=self.group_size, bits=self.bits,
+        )
+        return moment.reshape(shape)
 
     def init_single(self, parameter, state):
         super().init_single(parameter, state)
         if self.is_quantizable(parameter):
-            state["m"] = mx.quantize(
-                state["m"], group_size=self.group_size, bits=self.bits,
-            )
+            state["m"] = self._pack(state["m"])
 
     def apply_single(self, gradient, parameter, state):
         packed = state["m"]
         # tuple OR list: mx.quantize and tree_unflatten both give a list.
         if isinstance(packed, (tuple, list)):
-            moment = mx.dequantize(
-                *packed, group_size=self.group_size, bits=self.bits,
-            )
+            moment = self._unpack(packed, parameter.shape)
             # Affine dequantization does not land exactly on zero, and v == 0
             # means this coordinate has only seen zero gradients, so its true
             # moment is zero. Without this the residue is divided by eps alone.
@@ -146,9 +173,7 @@ class _QuantizedFirstMomentMixin:
         # Re-pack from eligibility, not from what was loaded: a checkpoint
         # written by plain AdamW arrives unpacked and must not stay that way.
         if self.is_quantizable(parameter):
-            state["m"] = mx.quantize(
-                state["m"], group_size=self.group_size, bits=self.bits,
-            )
+            state["m"] = self._pack(state["m"])
         return updated
 
 
@@ -228,7 +253,10 @@ def unpack_quantized_moments(state, group_size = DEFAULT_GROUP_SIZE, bits = DEFA
             if key == "m" and isinstance(value, (tuple, list)) and len(value) == 3:
                 moment = mx.dequantize(*value, group_size = group_size, bits = bits)
                 second = state.get("v")
-                if isinstance(second, mx.array) and second.shape == moment.shape:
+                # ``v`` is the only full-width leaf here, so it carries the shape a
+                # flat-packed moment has to be restored to before the mask lines up.
+                if isinstance(second, mx.array) and second.size == moment.size:
+                    moment = moment.reshape(second.shape)
                     moment = mx.where(second == 0, mx.zeros_like(moment), moment)
                 out[key] = moment
             else:

--- a/unsloth_zoo/mlx/optimizers_quantized.py
+++ b/unsloth_zoo/mlx/optimizers_quantized.py
@@ -227,9 +227,10 @@ def describe_quantized_optimizer(optimizer_name, group_size = DEFAULT_GROUP_SIZE
     return (
         f"Unsloth: {optimizer_name} on MLX quantizes the optimizer's FIRST moment "
         f"to 8-bit (group_size={group_size}); the second moment is not quantized "
-        "(affine 8-bit quantization of the second moment diverges). Only 2-D "
-        f"parameters whose last dimension is a multiple of {group_size} are "
-        "quantized; all others keep unquantized moments. Moments follow the "
+        "(affine 8-bit quantization of the second moment diverges). Parameters of "
+        f"at least {MIN_QUANTIZE_SIZE} elements, in a whole number of groups of "
+        f"{group_size}, are quantized; all others keep unquantized moments. "
+        "Moments follow the "
         "parameter dtype, so this saves about 36% of optimizer state in float32 "
         "and about 23% in bfloat16, and it does not lower peak memory."
     )


### PR DESCRIPTION
Follow-up to #962. That PR only packs a moment when the parameter is 2-D with a last axis divisible by `group_size`. `mx.quantize` constrains the last axis only, so quantizing a flattened view turns eligibility into a question of element count instead of shape.

The gap showed up under LoRA. `lora_a` is `(rank, in_features)` and `lora_b` is `(out_features, rank)`, so below rank 64 only one matrix of each pair qualified. The adapter saved 18.3% while taking the packed code path, which is half of what the optimizer name implies.

### Measured, float32 state, group_size 64

| setup | before | after |
| --- | --- | --- |
| LoRA r=16 | 18.3% | 34.6% |
| LoRA r=32 | 18.3% | 35.9% |
| LoRA r=64 | 35.9% | 35.9% |
| full fine-tune | 35.9% | 35.9% |

r=16 lands slightly under the rest because of the minimum size below. Round-trip error is unchanged at 0.0053 relative, the same figure the 2-D layout produces, so spanning group boundaries across rows costs nothing measurable. Verified on a real model: SmolLM2-135M, wikitext-2, LoRA r=16, 50 steps, same seed and data order, this PR tracks full-precision Adam at 0.043% MAPE against 0.047% for the previous rule, so accuracy is if anything slightly better.

3-D MoE expert stacks and 1-D parameters become eligible for the same reason.

### Minimum size

Parameters under 4096 elements keep full-width moments. They contribute almost nothing to the state budget and are mostly norm and bias parameters, which are the ones least worth adding quantization error to. bitsandbytes draws this line at the same threshold via `min_8bit_size`.

This is also why r=16 reaches 34.6% rather than 35.9%: under grouped-query attention the k/v projections are narrow, so their `lora_b` is `(kv_dim, r)`, and at r=16 that is 3072 elements on a 135M model. The figure is model-shape dependent below r=32.

### Checkpoints

`mx.dequantize` reads its shape from the packed triple, so a checkpoint written in the previous per-row layout still loads correctly and is re-packed flat on the next step. Verified in both directions, into both the quantized optimizer and a plain `optim.Adam`, and under `mx.compile(inputs=state, outputs=state)` with bit-identical losses.

A checkpoint whose parameter is now below the minimum size loads, dequantizes, trains, and stays full width for the rest of the run, which is the correct outcome.

### Tests

`tests/test_mlx_quantized_optimizer_state.py` goes from 29 to 39. New coverage: eligibility across six shapes, flat pack/unpack shape restoration, the minimum-size boundary, a rank-16 adapter packing both matrices, and the old-layout checkpoint read.

Two existing fixtures changed. The ineligible-model fixture, because `(100, 96)` is eligible under the new rule. And both zero-residue regressions, which used a 64-element parameter that the minimum size makes ineligible: they were passing without reaching dequantization at all, confirmed by deleting the `v == 0` mask and watching them still pass. They now drive a 4096-element parameter and assert the moment is packed first, and with the mask removed they fail again at the same 1.968774 displacement the mask was added to prevent.

Full run: 39 passed in the state suite, 15 routing, 223 trainer internals. Verified on real Apple Silicon via staging CI, where the state suite is gated to fail if it skips.